### PR TITLE
fix: preserve empty skill path (follow-up #383)

### DIFF
--- a/internal/workspace/image_preference.go
+++ b/internal/workspace/image_preference.go
@@ -138,7 +138,11 @@ func workspaceSkillDiscoveryRootsFromMetadata(metadata map[string]any) ([]string
 		return []string{}, true
 	}
 
-	return normalizeWorkspaceSkillDiscoveryRoots(roots), true
+	normalized := normalizeWorkspaceSkillDiscoveryRoots(roots)
+	if normalized == nil {
+		return []string{}, true
+	}
+	return normalized, true
 }
 
 func withWorkspaceImagePreference(metadata map[string]any, image string) map[string]any {

--- a/internal/workspace/image_preference_test.go
+++ b/internal/workspace/image_preference_test.go
@@ -163,6 +163,9 @@ func TestWorkspaceSkillDiscoveryRootsExplicitDisableRemainsPresent(t *testing.T)
 	if !ok {
 		t.Fatal("expected skill discovery roots key to remain present")
 	}
+	if roots == nil {
+		t.Fatal("expected explicit disable to return a non-nil empty slice")
+	}
 	if len(roots) != 0 {
 		t.Fatalf("expected explicit disable with no roots, got %#v", roots)
 	}


### PR DESCRIPTION
Follow up fixing https://github.com/memohai/Memoh/pull/383#discussion_r3098702957

When `workspace.skill_discovery_roots` is saved as `[]`, it should disable external skill discovery instead of falling back to the default paths.