### PR TITLE
fix(installer): avoid root shell install by default

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -3,10 +3,11 @@
 ## One-Click Install
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh
+curl -fsSL https://memoh.sh | sh
 ```
 
 The script prompts for configuration, generates `config.toml`, and starts all services.
+Run it as your normal user. The script will use `sudo docker` internally only when Docker requires it.
 
 ## Manual Install
 
@@ -24,13 +25,13 @@ nano config.toml   # Change passwords and JWT secret
 ### Standard startup (with Qdrant + Browser)
 
 ```bash
-sudo docker compose --profile qdrant --profile browser up -d
+docker compose --profile qdrant --profile browser up -d
 ```
 
 ### Minimal startup (core only)
 
 ```bash
-sudo docker compose up -d
+docker compose up -d
 ```
 
 Access:
@@ -69,7 +70,7 @@ For Mem0 or OpenViking SaaS, no profile is needed. Configure the provider direct
 Uncomment `registry = "memoh.cn"` in `config.toml` under `[workspace]`, then add the CN overlay:
 
 ```bash
-sudo docker compose -f docker-compose.yml -f docker/docker-compose.cn.yml \
+docker compose -f docker-compose.yml -f docker/docker-compose.cn.yml \
   --profile qdrant --profile browser up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Memoh is an always-on, containerized AI agent system. Create multiple AI bots, e
 One-click install (**requires [Docker](https://www.docker.com/get-started/)**):
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh
+curl -fsSL https://memoh.sh | sh
 ```
 
-*Silent install with all defaults: `curl -fsSL ... | sudo sh -s -- -y`*
+*Silent install with all defaults: `curl -fsSL ... | sh -s -- -y`*
 
 Or manually:
 
@@ -45,20 +45,22 @@ git clone --depth 1 https://github.com/memohai/Memoh.git
 cd Memoh
 cp conf/app.docker.toml config.toml
 # Edit config.toml
-sudo docker compose up -d
+docker compose up -d
 ```
 
 > **Install a specific version:**
 > ```bash
-> curl -fsSL https://memoh.sh | sudo MEMOH_VERSION=v0.6.0 sh
+> curl -fsSL https://memoh.sh | MEMOH_VERSION=v0.6.0 sh
 > ```
 >
 > **Use CN mirror for slow image pulls:**
 > ```bash
-> curl -fsSL https://memoh.sh | sudo USE_CN_MIRROR=true sh
+> curl -fsSL https://memoh.sh | USE_CN_MIRROR=true sh
 > ```
 >
-> On macOS or if your user is in the `docker` group, `sudo` is not required.
+> Do not run the whole installer with `sudo`. The installer will use `sudo docker`
+> internally if Docker requires it. On macOS or if your user is in the `docker`
+> group, `sudo` is not required for Docker either.
 
 Visit <http://localhost:8082> after startup. Default login: `admin` / `admin123`
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -33,10 +33,10 @@ Memoh 是一个常驻运行的容器化 AI Agent 系统。你可以创建多个 
 一键安装（**需先安装 [Docker](https://www.docker.com/get-started/)**）：
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh
+curl -fsSL https://memoh.sh | sh
 ```
 
-*静默安装（全部默认）：`curl -fsSL ... | sudo sh -s -- -y`*
+*静默安装（全部默认）：`curl -fsSL ... | sh -s -- -y`*
 
 或手动部署：
 
@@ -45,20 +45,22 @@ git clone --depth 1 https://github.com/memohai/Memoh.git
 cd Memoh
 cp conf/app.docker.toml config.toml
 # 编辑 config.toml
-sudo docker compose up -d
+docker compose up -d
 ```
 
 > **安装指定版本：**
 > ```bash
-> curl -fsSL https://memoh.sh | sudo MEMOH_VERSION=v0.6.0 sh
+> curl -fsSL https://memoh.sh | MEMOH_VERSION=v0.6.0 sh
 > ```
 >
 > **使用中国大陆镜像加速：**
 > ```bash
-> curl -fsSL https://memoh.sh | sudo USE_CN_MIRROR=true sh
+> curl -fsSL https://memoh.sh | USE_CN_MIRROR=true sh
 > ```
 >
-> macOS 或用户已在 `docker` 用户组中时，无需 `sudo`。
+> 不要用 `sudo` 运行整个安装脚本。脚本会在 Docker 需要时只对
+> `docker` 命令使用 `sudo`。macOS 或用户已在 `docker` 用户组中时，
+> Docker 命令通常也无需 `sudo`。
 
 启动后访问 <http://localhost:8082>。默认登录：`admin` / `admin123`
 

--- a/docs/docs/installation/docker.md
+++ b/docs/docs/installation/docker.md
@@ -52,8 +52,13 @@ For more details on memory modes, see [Built-in Memory Provider](/memory-provide
 Run the official install script (requires Docker and Docker Compose):
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh
+curl -fsSL https://memoh.sh | sh
 ```
+
+Run the installer as your normal user. Do not wrap the whole script in `sudo`;
+the script will use `sudo docker` internally only if Docker requires it. If you
+intentionally need to run the whole installer as root, set
+`MEMOH_ALLOW_ROOT_INSTALL=true` explicitly.
 
 The script will:
 
@@ -71,7 +76,7 @@ The script will:
 **Silent install** (use all defaults, no prompts):
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh -s -- -y
+curl -fsSL https://memoh.sh | sh -s -- -y
 ```
 
 Defaults when running silently:
@@ -87,34 +92,34 @@ If the script detects an existing Memoh installation in silent mode, it defaults
 **Force a clean reinstall** (removes Memoh Docker data before starting again):
 
 ```bash
-curl -fsSL https://memoh.sh | sudo MEMOH_INSTALL_MODE=reinstall sh
+curl -fsSL https://memoh.sh | MEMOH_INSTALL_MODE=reinstall sh
 ```
 
 You can also pass the install mode as an argument:
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh -s -- --install-mode reinstall
+curl -fsSL https://memoh.sh | sh -s -- --install-mode reinstall
 ```
 
 **Install a specific version:**
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh -s -- --version v0.6.0
+curl -fsSL https://memoh.sh | sh -s -- --version v0.6.0
 ```
 
 Or using the environment variable:
 
 ```bash
-curl -fsSL https://memoh.sh | sudo MEMOH_VERSION=v0.6.0 sh
+curl -fsSL https://memoh.sh | MEMOH_VERSION=v0.6.0 sh
 ```
 
 **Use China mainland mirror** (for slow image pulls):
 
 ```bash
-curl -fsSL https://memoh.sh | sudo USE_CN_MIRROR=true sh
+curl -fsSL https://memoh.sh | USE_CN_MIRROR=true sh
 ```
 
-> Environment variables can be combined, e.g. `curl -fsSL https://memoh.sh | sudo MEMOH_VERSION=v0.6.0 USE_CN_MIRROR=true sh`
+> Environment variables can be combined, e.g. `curl -fsSL https://memoh.sh | MEMOH_VERSION=v0.6.0 USE_CN_MIRROR=true sh`
 
 ## Manual Install
 
@@ -133,13 +138,13 @@ Edit `config.toml` — at minimum change:
 Then start (recommended — with Qdrant, Browser, and Sparse):
 
 ```bash
-sudo POSTGRES_PASSWORD=your-db-password docker compose --profile qdrant --profile browser --profile sparse up -d
+POSTGRES_PASSWORD=your-db-password docker compose --profile qdrant --profile browser --profile sparse up -d
 ```
 
 Or start core services only (no vector DB or browser automation):
 
 ```bash
-sudo POSTGRES_PASSWORD=your-db-password docker compose up -d
+POSTGRES_PASSWORD=your-db-password docker compose up -d
 ```
 
 > On macOS or if your user is in the `docker` group, `sudo` is not required.
@@ -158,7 +163,7 @@ registry = "memoh.cn"
 And add the China mirror compose overlay:
 
 ```bash
-sudo docker compose -f docker-compose.yml -f docker/docker-compose.cn.yml \
+docker compose -f docker-compose.yml -f docker/docker-compose.cn.yml \
   --profile qdrant --profile browser up -d
 ```
 
@@ -219,6 +224,7 @@ docker compose pull && docker compose up -d  # Update to latest images
 | `MEMOH_CONFIG`     | `./config.toml`    | Path to the configuration file               |
 | `MEMOH_VERSION`    | *(latest release)* | Git tag to install (e.g. `v0.6.0`). Also pins Docker image versions. |
 | `MEMOH_INSTALL_MODE` | `auto`           | Install mode: `auto`, `fresh`, `upgrade`, or `reinstall` |
+| `MEMOH_ALLOW_ROOT_INSTALL` | `false` | Allow running the installer shell itself as root. Prefer leaving this unset and running the installer as a normal user. |
 | `USE_CN_MIRROR`    | `false`            | Set to `true` to use China mainland image mirrors |
 | `BROWSER_CORES`    | `chromium,firefox`  | Browser engines to include in the browser image |
 | `BROWSER_TAG`      | `latest`           | Docker tag for the browser image |

--- a/docs/docs/zh/installation/docker.md
+++ b/docs/docs/zh/installation/docker.md
@@ -52,15 +52,19 @@ docker compose --profile qdrant --profile sparse --profile browser up -d
 官方脚本（本机已装好 Docker 与 Compose）：
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh
+curl -fsSL https://memoh.sh | sh
 ```
+
+请用普通用户运行安装脚本，不要给整个脚本套 `sudo`。如果 Docker
+需要提权，脚本会只对 `docker` 命令使用 `sudo`。如果确实要以 root
+运行整个安装脚本，需要显式设置 `MEMOH_ALLOW_ROOT_INSTALL=true`。
 
 脚本会：检查 Docker/Compose；交互问配置（工作区、数据目录、管理员、JWT、Postgres 密码、是否开 sparse、浏览器核等）；从 GitHub 取最新发布并克隆；按 Docker 模板生成 `config.toml`；钉死镜像版本；按选的核编浏览器镜像并拉齐服务。
 
 **静默安装**（全默认、无提问）：
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh -s -- -y
+curl -fsSL https://memoh.sh | sh -s -- -y
 ```
 
 静默时默认大概：工作区 `~/memoh`；数据 `~/memoh/data`；管理员 `admin` / `admin123`；JWT 随机；Postgres 密码 `memoh123`。
@@ -68,19 +72,19 @@ curl -fsSL https://memoh.sh | sudo sh -s -- -y
 **指定版本：**
 
 ```bash
-curl -fsSL https://memoh.sh | sudo sh -s -- --version v0.6.0
+curl -fsSL https://memoh.sh | sh -s -- --version v0.6.0
 ```
 
 或：
 
 ```bash
-curl -fsSL https://memoh.sh | sudo MEMOH_VERSION=v0.6.0 sh
+curl -fsSL https://memoh.sh | MEMOH_VERSION=v0.6.0 sh
 ```
 
 **大陆镜像**（拉镜像慢时）：
 
 ```bash
-curl -fsSL https://memoh.sh | sudo USE_CN_MIRROR=true sh
+curl -fsSL https://memoh.sh | USE_CN_MIRROR=true sh
 ```
 
 > 环境变量可组合，例如 `MEMOH_VERSION=v0.6.0 USE_CN_MIRROR=true`。
@@ -102,13 +106,13 @@ cp conf/app.docker.toml config.toml
 然后（推荐开 Qdrant、浏览器、sparse）：
 
 ```bash
-sudo POSTGRES_PASSWORD=你的库密码 docker compose --profile qdrant --profile browser --profile sparse up -d
+POSTGRES_PASSWORD=你的库密码 docker compose --profile qdrant --profile browser --profile sparse up -d
 ```
 
 只跑核心（无向量、无浏览器）：
 
 ```bash
-sudo POSTGRES_PASSWORD=你的库密码 docker compose up -d
+POSTGRES_PASSWORD=你的库密码 docker compose up -d
 ```
 
 > macOS 或用户已在 `docker` 组里，一般不必 `sudo`。
@@ -127,7 +131,7 @@ registry = "memoh.cn"
 并叠加国内 overlay：
 
 ```bash
-sudo docker compose -f docker-compose.yml -f docker/docker-compose.cn.yml \
+docker compose -f docker-compose.yml -f docker/docker-compose.cn.yml \
   --profile qdrant --profile browser up -d
 ```
 
@@ -184,6 +188,7 @@ docker compose pull && docker compose up -d  # 更新镜像再起
 | `POSTGRES_PASSWORD` | `memoh123` | 须与 `config.toml` 里 `postgres.password` 一致 |
 | `MEMOH_CONFIG` | `./config.toml` | 配置文件路径 |
 | `MEMOH_VERSION` | 最新发版 | 要装的 git 标签，也用于钉死镜像 |
+| `MEMOH_ALLOW_ROOT_INSTALL` | `false` | 允许以 root 运行安装脚本本身。建议保持未设置，用普通用户运行安装脚本。 |
 | `USE_CN_MIRROR` | `false` | 是否用大陆镜像 |
 | `BROWSER_CORES` | `chromium,firefox` | 浏览器镜像里包含的引擎 |
 | `BROWSER_TAG` | `latest` | 浏览器镜像 tag |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,13 +80,13 @@ fi
 echo "${PURPLE}Memoh One-Click Install${NC}"
 
 if [ "$(id -u 2>/dev/null || printf '1')" = "0" ] && [ "${MEMOH_ALLOW_ROOT_INSTALL:-false}" != "true" ]; then
-    echo "${RED}Error: Do not run this installer as root.${NC}"
-    echo "Run it as your normal user instead:"
-    echo "  curl -fsSL https://memoh.sh | sh"
-    echo ""
-    echo "The installer will use sudo for Docker commands only when Docker requires it."
-    echo "To override this guard, set MEMOH_ALLOW_ROOT_INSTALL=true."
-    exit 1
+  echo "${RED}Error: Do not run this installer as root.${NC}"
+  echo "Run it as your normal user instead:"
+  echo "  curl -fsSL https://memoh.sh | sh"
+  echo ""
+  echo "The installer will use sudo for Docker commands only when Docker requires it."
+  echo "To override this guard, set MEMOH_ALLOW_ROOT_INSTALL=true."
+  exit 1
 fi
 
 read_env_file_value() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,6 +79,16 @@ fi
 
 echo "${PURPLE}Memoh One-Click Install${NC}"
 
+if [ "$(id -u 2>/dev/null || printf '1')" = "0" ] && [ "${MEMOH_ALLOW_ROOT_INSTALL:-false}" != "true" ]; then
+    echo "${RED}Error: Do not run this installer as root.${NC}"
+    echo "Run it as your normal user instead:"
+    echo "  curl -fsSL https://memoh.sh | sh"
+    echo ""
+    echo "The installer will use sudo for Docker commands only when Docker requires it."
+    echo "To override this guard, set MEMOH_ALLOW_ROOT_INSTALL=true."
+    exit 1
+fi
+
 read_env_file_value() {
   file="$1"
   key="$2"

--- a/scripts/test-install-root-guard.sh
+++ b/scripts/test-install-root-guard.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+FAKEBIN="$TMPDIR/bin"
+mkdir -p "$FAKEBIN"
+
+cat > "$FAKEBIN/id" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-u" ]; then
+  printf '0\n'
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$FAKEBIN/id"
+
+cat > "$FAKEBIN/docker" <<'EOF'
+#!/bin/sh
+[ -n "${DOCKER_MARKER:-}" ] && echo invoked >> "$DOCKER_MARKER"
+exit 42
+EOF
+chmod +x "$FAKEBIN/docker"
+
+OUTPUT="$TMPDIR/output.txt"
+DOCKER_MARKER="$TMPDIR/docker-marker.txt"
+set +e
+PATH="$FAKEBIN:/usr/bin:/bin" HOME="$TMPDIR/home" DOCKER_MARKER="$DOCKER_MARKER" sh "$ROOT/scripts/install.sh" --yes >"$OUTPUT" 2>&1
+STATUS=$?
+set -e
+
+if [ "$STATUS" -eq 0 ]; then
+  echo "expected root installer invocation to fail" >&2
+  cat "$OUTPUT" >&2
+  exit 1
+fi
+
+if [ -f "$DOCKER_MARKER" ]; then
+  echo "installer reached Docker before rejecting root execution" >&2
+  cat "$OUTPUT" >&2
+  exit 1
+fi
+
+if ! grep -q "Do not run this installer as root" "$OUTPUT"; then
+  echo "expected root execution warning was not printed" >&2
+  cat "$OUTPUT" >&2
+  exit 1
+fi
+
+OPT_IN_OUTPUT="$TMPDIR/opt-in-output.txt"
+set +e
+PATH="$FAKEBIN:/usr/bin:/bin" HOME="$TMPDIR/home" DOCKER_MARKER="$DOCKER_MARKER" MEMOH_ALLOW_ROOT_INSTALL=true sh "$ROOT/scripts/install.sh" --yes >"$OPT_IN_OUTPUT" 2>&1
+OPT_IN_STATUS=$?
+set -e
+
+if [ "$OPT_IN_STATUS" -eq 0 ]; then
+  echo "expected opt-in root invocation to stop at fake Docker" >&2
+  cat "$OPT_IN_OUTPUT" >&2
+  exit 1
+fi
+
+if [ ! -f "$DOCKER_MARKER" ]; then
+  echo "explicit root opt-in did not continue to Docker checks" >&2
+  cat "$OPT_IN_OUTPUT" >&2
+  exit 1
+fi

--- a/scripts/test-install-root-guard.sh
+++ b/scripts/test-install-root-guard.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -eu
 
-ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-TMPDIR=$(mktemp -d)
+ROOT=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/test-install-root-guard.XXXXXX" 2>/dev/null || mktemp -d -t test-install-root-guard)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 FAKEBIN="$TMPDIR/bin"
@@ -24,6 +24,12 @@ cat > "$FAKEBIN/docker" <<'EOF'
 exit 42
 EOF
 chmod +x "$FAKEBIN/docker"
+
+cat > "$FAKEBIN/sudo" <<'EOF'
+#!/bin/sh
+exec "$@"
+EOF
+chmod +x "$FAKEBIN/sudo"
 
 OUTPUT="$TMPDIR/output.txt"
 DOCKER_MARKER="$TMPDIR/docker-marker.txt"


### PR DESCRIPTION
Closes #406 

## Summary

- Avoid recommending `curl | sudo sh` for the one-click installer.
- Add an installer guard that rejects root shell execution unless explicitly opted in with
`MEMOH_ALLOW_ROOT_INSTALL=true`.
- Update docs to separate installer privileges from Docker privileges.