### PR TITLE
fix(command): allow QQ and WeChat slash write commands

### DIFF
--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -595,6 +595,50 @@ func TestChannelInboundProcessorACLReceivesThreadScope(t *testing.T) {
 	}
 }
 
+func TestChannelInboundProcessorQQAndWeixinWriteCommandsBypassChatACL(t *testing.T) {
+	for _, channelType := range []channel.ChannelType{channel.ChannelType("qq"), channel.ChannelType("weixin")} {
+		t.Run(channelType.String(), func(t *testing.T) {
+			channelIdentitySvc := &fakeChannelIdentityService{channelIdentity: identities.ChannelIdentity{ID: "channelIdentity-im-command"}}
+			policySvc := &fakePolicyService{}
+			chatSvc := &fakeChatService{resolveResult: route.ResolveConversationResult{ChatID: "chat-im-command", RouteID: "route-im-command"}}
+			gateway := &fakeChatGateway{}
+			processor := NewChannelInboundProcessor(slog.Default(), nil, chatSvc, chatSvc, gateway, channelIdentitySvc, policySvc, "", 0)
+			aclSvc := &fakeChatACL{allowed: false}
+			processor.SetACLService(aclSvc)
+			processor.SetCommandHandler(command.NewHandler(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil))
+			sender := &fakeReplySender{}
+
+			msg := channel.InboundMessage{
+				BotID:       "bot-1",
+				Channel:     channelType,
+				Message:     channel.Message{Text: "/model set"},
+				ReplyTarget: "target-id",
+				Sender:      channel.Identity{SubjectID: "im-user-1"},
+				Conversation: channel.Conversation{
+					ID:   "im-user-1",
+					Type: channel.ConversationTypePrivate,
+				},
+			}
+
+			if err := processor.HandleInbound(context.Background(), channel.ChannelConfig{ID: "cfg-1", BotID: "bot-1", ChannelType: channelType}, msg, sender); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if aclSvc.calls != 0 {
+				t.Fatalf("slash command should be handled before chat ACL, got %d ACL calls", aclSvc.calls)
+			}
+			if gateway.gotReq.Query != "" {
+				t.Fatalf("slash command should not trigger chat call, got query %q", gateway.gotReq.Query)
+			}
+			if len(sender.sent) != 1 {
+				t.Fatalf("expected one command reply, got %d", len(sender.sent))
+			}
+			if !strings.Contains(sender.sent[0].Message.Text, "Usage: /model set") {
+				t.Fatalf("expected command usage reply, got %q", sender.sent[0].Message.Text)
+			}
+		})
+	}
+}
+
 func TestChannelInboundProcessorIgnoreEmpty(t *testing.T) {
 	channelIdentitySvc := &fakeChannelIdentityService{channelIdentity: identities.ChannelIdentity{ID: "channelIdentity-3"}}
 	policySvc := &fakePolicyService{}

--- a/internal/command/access.go
+++ b/internal/command/access.go
@@ -15,7 +15,7 @@ func (h *Handler) buildAccessGroup() *CommandGroup {
 		Usage: "show - Show current identity, write access, and chat ACL context",
 		Handler: func(cc CommandContext) (string, error) {
 			writeAccess := "no"
-			if cc.Role == "owner" {
+			if cc.WriteAccess {
 				writeAccess = "yes"
 			}
 

--- a/internal/command/handler.go
+++ b/internal/command/handler.go
@@ -201,11 +201,13 @@ func (h *Handler) ExecuteWithInput(ctx context.Context, input ExecuteInput) (str
 			role = r
 		}
 	}
+	writeAccess := role == "owner" || allowsUnboundWriteCommands(input)
 
 	cc := CommandContext{
 		Ctx:               ctx,
 		BotID:             input.BotID,
 		Role:              role,
+		WriteAccess:       writeAccess,
 		Args:              parsed.Args,
 		ChannelIdentityID: strings.TrimSpace(input.ChannelIdentityID),
 		UserID:            strings.TrimSpace(input.UserID),
@@ -253,7 +255,7 @@ func (h *Handler) ExecuteWithInput(ctx context.Context, input ExecuteInput) (str
 		return fmt.Sprintf("Unknown action \"%s\" for /%s.\n\n%s", parsed.Action, parsed.Resource, group.Usage()), nil
 	}
 
-	if sub.IsWrite && role != "owner" {
+	if sub.IsWrite && !writeAccess {
 		return "Permission denied: only the bot owner can execute this command.", nil
 	}
 
@@ -262,6 +264,23 @@ func (h *Handler) ExecuteWithInput(ctx context.Context, input ExecuteInput) (str
 		return fmt.Sprintf("Error: %s", handlerErr.Error()), nil
 	}
 	return result, nil
+}
+
+func allowsUnboundWriteCommands(input ExecuteInput) bool {
+	if strings.TrimSpace(input.UserID) != "" {
+		return false
+	}
+	if strings.TrimSpace(input.ChannelIdentityID) == "" {
+		return false
+	}
+	// QQ and personal WeChat no longer have a channel-identity bind flow, so
+	// channel-scoped slash commands must not depend on a linked Web user.
+	switch strings.ToLower(strings.TrimSpace(input.ChannelType)) {
+	case "qq", "weixin":
+		return true
+	default:
+		return false
+	}
 }
 
 // safeExecute runs a sub-command handler and recovers from panics.

--- a/internal/command/handler_test.go
+++ b/internal/command/handler_test.go
@@ -242,6 +242,48 @@ func TestExecute_WritePermissionAllowedForOwner(t *testing.T) {
 	}
 }
 
+func TestExecute_WritePermissionAllowedForQQAndWeixinWithoutLinkedUser(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(&fakeRoleResolver{role: ""})
+	for _, channelType := range []string{"qq", "weixin"} {
+		t.Run(channelType, func(t *testing.T) {
+			t.Parallel()
+			result, err := h.ExecuteWithInput(context.Background(), ExecuteInput{
+				BotID:             "bot-1",
+				ChannelIdentityID: "channel-id-1",
+				Text:              "/model set",
+				ChannelType:       channelType,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if strings.Contains(result, "Permission denied") {
+				t.Fatalf("%s write command should not require linked owner user, got: %s", channelType, result)
+			}
+			if !strings.Contains(result, "Usage: /model set") {
+				t.Fatalf("expected command to reach handler usage, got: %s", result)
+			}
+		})
+	}
+}
+
+func TestExecute_WritePermissionStillDeniedForOtherUnlinkedChannels(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(&fakeRoleResolver{role: ""})
+	result, err := h.ExecuteWithInput(context.Background(), ExecuteInput{
+		BotID:             "bot-1",
+		ChannelIdentityID: "channel-id-1",
+		Text:              "/model set",
+		ChannelType:       "discord",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Permission denied") {
+		t.Fatalf("unlinked discord write command should still be denied, got: %s", result)
+	}
+}
+
 func TestExecute_SettingsDefaultAction(t *testing.T) {
 	t.Parallel()
 	h := newTestHandler(&fakeRoleResolver{role: ""})

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -11,6 +11,7 @@ type CommandContext struct {
 	Ctx               context.Context
 	BotID             string
 	Role              string // "owner", "admin", "member", or "" (guest)
+	WriteAccess       bool
 	Args              []string
 	ChannelIdentityID string
 	UserID            string


### PR DESCRIPTION
## Summary
- Allow QQ and personal WeChat channel identities without linked Web users to run slash write commands.
- Keep owner-only write-command checks for other unlinked channels.
- Surface actual write-command access in `/access`.

## Validation
- `go test ./internal/command ./internal/channel/inbound`
- `go test ./internal/channel/... ./internal/command`
- Commit hook Go checks passed during commit.

Closes #453