### PR TITLE
fix: wait for bot workspace setup before redirect

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -935,6 +935,9 @@
     "createBot": "New Bot",
     "createBotWaitHint": "First-time creation may pull base images and take a moment.",
     "createBotSuccess": "Bot created successfully.",
+    "createBotSettingUp": "Setting up...",
+    "createBotSetupTitle": "Setting up bot",
+    "createBotSetupDesc": "Creating the bot and workspace container. The page will open it automatically when it is ready.",
     "steps": {
       "basicInfo": "Basic Info",
       "basicInfoDesc": "Name and avatar",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -931,6 +931,9 @@
     "createBot": "新建 Bot",
     "createBotWaitHint": "首次创建可能需要拉取基础镜像，请耐心等待。",
     "createBotSuccess": "Bot 创建成功。",
+    "createBotSettingUp": "正在准备...",
+    "createBotSetupTitle": "正在准备 Bot",
+    "createBotSetupDesc": "正在创建 Bot 和工作区容器。准备完成后会自动打开这个 Bot。",
     "steps": {
       "basicInfo": "基本信息",
       "basicInfoDesc": "名称和头像",

--- a/apps/web/src/pages/bots/new.vue
+++ b/apps/web/src/pages/bots/new.vue
@@ -1,6 +1,10 @@
 <template>
-  <section class="px-4 pt-2 pb-10 lg:px-6 md:pt-4 md:pb-12 max-w-2xl">
-    <form @submit.prevent="handleSubmit">
+  <section class="relative px-4 pt-2 pb-10 lg:px-6 md:pt-4 md:pb-12 max-w-2xl">
+    <form
+      :aria-busy="isCreateFlowBlocked"
+      :class="{ 'pointer-events-none select-none opacity-60': isCreateFlowBlocked }"
+      @submit.prevent="handleSubmit"
+    >
       <!-- Basic Info -->
       <div>
         <h3 class="text-sm font-medium mb-4">
@@ -224,19 +228,39 @@
         <Button
           type="button"
           variant="outline"
+          :disabled="isCreateFlowBlocked"
           @click="router.back()"
         >
           {{ $t('common.cancel') }}
         </Button>
         <Button
           type="submit"
-          :disabled="!canSubmit || submitLoading"
+          :disabled="!canSubmit || isCreateFlowBlocked"
         >
-          <Spinner v-if="submitLoading" />
-          {{ $t('bots.createBot') }}
+          <Spinner v-if="isCreateFlowBlocked" />
+          {{ isCreateFlowBlocked ? $t('bots.createBotSettingUp') : $t('bots.createBot') }}
         </Button>
       </div>
     </form>
+
+    <div
+      v-if="isCreateFlowBlocked"
+      class="absolute inset-0 z-10 flex items-start justify-center bg-background/70 pt-20 backdrop-blur-[1px]"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="flex max-w-md items-start gap-3 rounded-md border bg-background px-4 py-3 shadow-sm">
+        <Spinner class="mt-0.5 shrink-0" />
+        <div class="min-w-0">
+          <p class="text-sm font-medium">
+            {{ $t('bots.createBotSetupTitle') }}
+          </p>
+          <p class="mt-1 text-xs leading-relaxed text-muted-foreground">
+            {{ $t('bots.createBotSetupDesc') }}
+          </p>
+        </div>
+      </div>
+    </div>
 
     <AvatarEditDialog
       v-model:open="avatarDialogOpen"
@@ -392,8 +416,10 @@ const { mutateAsync: createBot, isLoading: submitLoading } = useMutation({
   onSettled: () => queryCache.invalidateQueries({ key: getBotsQueryKey() }),
 })
 
+const isCreateFlowBlocked = computed(() => submitLoading.value)
+
 async function handleSubmit() {
-  if (!canSubmit.value || submitLoading.value) return
+  if (!canSubmit.value || isCreateFlowBlocked.value) return
 
   const metadata = localWorkspaceEnabled.value && form.workspace_backend === 'local'
     ? {
@@ -415,6 +441,7 @@ async function handleSubmit() {
         is_active: true,
         acl_preset: form.acl_preset,
         metadata,
+        wait_for_ready: true,
       },
     })
 

--- a/internal/bots/service.go
+++ b/internal/bots/service.go
@@ -155,6 +155,13 @@ func (s *Service) Create(ctx context.Context, ownerUserID string, req CreateBotR
 	if err := s.attachCheckSummary(ctx, &bot, asSQLCBot(row)); err != nil {
 		return Bot{}, err
 	}
+	if req.WaitForReady {
+		waitCtx := context.WithoutCancel(ctx)
+		if err := s.runCreateLifecycle(waitCtx, bot.ID); err != nil {
+			return Bot{}, err
+		}
+		return s.Get(waitCtx, bot.ID)
+	}
 	s.enqueueCreateLifecycle(ctx, bot.ID)
 	return bot, nil
 }
@@ -358,25 +365,36 @@ func (s *Service) ListChecks(ctx context.Context, botID string) ([]BotCheck, err
 
 func (s *Service) enqueueCreateLifecycle(ctx context.Context, botID string) {
 	go func() {
-		lifecycleCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), botLifecycleOperationTimeout)
-		defer cancel()
-
-		if s.containerLifecycle != nil {
-			if err := s.containerLifecycle.SetupBotContainer(lifecycleCtx, botID); err != nil {
-				s.logger.Error("bot container setup failed",
-					slog.String("bot_id", botID),
-					slog.Any("error", err),
-				)
-			}
-		}
-
-		if err := s.updateStatus(lifecycleCtx, botID, BotStatusReady); err != nil {
-			s.logger.Error("failed to update bot status to ready after create",
+		if err := s.runCreateLifecycle(context.WithoutCancel(ctx), botID); err != nil {
+			s.logger.Error("bot create lifecycle failed",
 				slog.String("bot_id", botID),
 				slog.Any("error", err),
 			)
 		}
 	}()
+}
+
+func (s *Service) runCreateLifecycle(ctx context.Context, botID string) error {
+	lifecycleCtx, cancel := context.WithTimeout(ctx, botLifecycleOperationTimeout)
+	defer cancel()
+
+	if s.containerLifecycle != nil {
+		if err := s.containerLifecycle.SetupBotContainer(lifecycleCtx, botID); err != nil {
+			s.logger.Error("bot container setup failed",
+				slog.String("bot_id", botID),
+				slog.Any("error", err),
+			)
+		}
+	}
+
+	if err := s.updateStatus(lifecycleCtx, botID, BotStatusReady); err != nil {
+		s.logger.Error("failed to update bot status to ready after create",
+			slog.String("bot_id", botID),
+			slog.Any("error", err),
+		)
+		return err
+	}
+	return nil
 }
 
 func (s *Service) enqueueDeleteLifecycle(ctx context.Context, botID string) {

--- a/internal/bots/service_test.go
+++ b/internal/bots/service_test.go
@@ -27,9 +27,13 @@ func (r *fakeRow) Scan(dest ...any) error {
 // fakeDBTX implements sqlc.DBTX for unit testing.
 type fakeDBTX struct {
 	queryRowFunc func(ctx context.Context, sql string, args ...any) pgx.Row
+	execFunc     func(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
 }
 
-func (*fakeDBTX) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
+func (d *fakeDBTX) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
+	if d.execFunc != nil {
+		return d.execFunc(ctx, sql, args...)
+	}
 	return pgconn.CommandTag{}, nil
 }
 
@@ -89,6 +93,24 @@ func mustParseUUID(s string) pgtype.UUID {
 	var u pgtype.UUID
 	_ = u.Scan(s)
 	return u
+}
+
+type fakeContainerLifecycle struct {
+	onSetup    func()
+	setupBotID string
+	setupErr   error
+}
+
+func (f *fakeContainerLifecycle) SetupBotContainer(_ context.Context, botID string) error {
+	if f.onSetup != nil {
+		f.onSetup()
+	}
+	f.setupBotID = botID
+	return f.setupErr
+}
+
+func (*fakeContainerLifecycle) CleanupBotContainer(context.Context, string, bool) error {
+	return nil
 }
 
 func TestAuthorizeAccess(t *testing.T) {
@@ -178,5 +200,43 @@ func TestCreateRejectsUnknownACLPreset(t *testing.T) {
 	}
 	if createCalled {
 		t.Fatal("bot row should not be created when acl preset is invalid")
+	}
+}
+
+func TestRunCreateLifecycleSetsUpContainerBeforeReady(t *testing.T) {
+	botUUID := mustParseUUID("00000000-0000-0000-0000-000000000002")
+	botID := botUUID.String()
+	events := make([]string, 0, 2)
+
+	db := &fakeDBTX{
+		execFunc: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "UPDATE bots") && strings.Contains(sql, "SET status = $2") {
+				events = append(events, "status")
+				if got := args[0].(pgtype.UUID); got != botUUID {
+					t.Fatalf("expected status update for %s, got %s", botUUID, got)
+				}
+				if got := args[1].(string); got != BotStatusReady {
+					t.Fatalf("expected status %q, got %q", BotStatusReady, got)
+				}
+			}
+			return pgconn.CommandTag{}, nil
+		},
+	}
+	lifecycle := &fakeContainerLifecycle{
+		onSetup: func() {
+			events = append(events, "setup")
+		},
+	}
+	svc := NewService(nil, postgresstore.NewQueries(sqlc.New(db)))
+	svc.SetContainerLifecycle(lifecycle)
+
+	if err := svc.runCreateLifecycle(context.Background(), botID); err != nil {
+		t.Fatalf("run create lifecycle: %v", err)
+	}
+	if lifecycle.setupBotID != botID {
+		t.Fatalf("expected setup for bot %s, got %s", botID, lifecycle.setupBotID)
+	}
+	if len(events) != 2 || events[0] != "setup" || events[1] != "status" {
+		t.Fatalf("expected setup before ready status update, got events %v", events)
 	}
 }

--- a/internal/bots/types.go
+++ b/internal/bots/types.go
@@ -35,12 +35,13 @@ type BotCheck struct {
 
 // CreateBotRequest is the input for creating a bot.
 type CreateBotRequest struct {
-	DisplayName string         `json:"display_name,omitempty"`
-	AvatarURL   string         `json:"avatar_url,omitempty"`
-	Timezone    *string        `json:"timezone,omitempty"`
-	IsActive    *bool          `json:"is_active,omitempty"`
-	AclPreset   string         `json:"acl_preset,omitempty"`
-	Metadata    map[string]any `json:"metadata,omitempty"`
+	DisplayName  string         `json:"display_name,omitempty"`
+	AvatarURL    string         `json:"avatar_url,omitempty"`
+	Timezone     *string        `json:"timezone,omitempty"`
+	IsActive     *bool          `json:"is_active,omitempty"`
+	AclPreset    string         `json:"acl_preset,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
+	WaitForReady bool           `json:"wait_for_ready,omitempty"`
 }
 
 // UpdateBotRequest is the input for updating a bot.

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -469,6 +469,7 @@ export type BotsCreateBotRequest = {
         [key: string]: unknown;
     };
     timezone?: string;
+    wait_for_ready?: boolean;
 };
 
 export type BotsListBotsResponse = {

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -10668,6 +10668,9 @@ const docTemplate = `{
                 },
                 "timezone": {
                     "type": "string"
+                },
+                "wait_for_ready": {
+                    "type": "boolean"
                 }
             }
         },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -10659,6 +10659,9 @@
                 },
                 "timezone": {
                     "type": "string"
+                },
+                "wait_for_ready": {
+                    "type": "boolean"
                 }
             }
         },

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -750,6 +750,8 @@ definitions:
         type: object
       timezone:
         type: string
+      wait_for_ready:
+        type: boolean
     type: object
   bots.ListBotsResponse:
     properties:


### PR DESCRIPTION
## Summary

- Add an optional `wait_for_ready` flag to bot creation so selected callers can block until the bot create lifecycle completes.
- Reuse the backend create lifecycle for both async and blocking create flows.
- Update the new bot page to block the form while the backend prepares the bot workspace and redirect only after the create response returns.
- Expose the new request field through OpenAPI and the generated TypeScript SDK.

## Why

Newly-created bots could navigate to the detail page while the workspace container was still being prepared, leaving users on a page that looked unready and showed misleading health state. The backend owns the lifecycle timing, so the new bot flow now opts into backend-side waiting instead of frontend polling.

## Validation

- `go test ./internal/bots`
- `pnpm --filter @memohai/web exec vue-tsc --noEmit`
- `pnpm exec eslint apps/web/src/pages/bots/new.vue`
- `pnpm --filter @memohai/web build`
- `git diff --check`
- JSON parse check for i18n files and `spec/swagger.json`
- Commit hook Go test and staged ESLint checks
