### PR TITLE
feat(web): markdown/html preview toggle in workspace file viewer

### DIFF
--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, watch, computed, onMounted, onBeforeUnmount, defineAsyncComponent, h } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { File, Download, Save } from 'lucide-vue-next'
@@ -12,10 +12,32 @@ import {
 import type { HandlersFsFileInfo } from '@memohai/sdk'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import MonacoEditor from '@/components/monaco-editor/index.vue'
+import PreviewModeToggle, { type PreviewMode } from '@/components/preview-mode-toggle/index.vue'
 import { sdkApiUrl, sdkAuthQuery } from '@/lib/api-client'
-import { isTextFile, isImageFile } from './utils'
+import { isTextFile, isImageFile, isMarkdownFile, isHtmlFile } from './utils'
 import { useChatStore } from '@/store/chat-list'
 import { storeToRefs } from 'pinia'
+
+const AsyncLoading = {
+  render: () =>
+    h(
+      'div',
+      { class: 'flex h-full items-center justify-center text-muted-foreground' },
+      [h(Spinner, { class: 'mr-2' })],
+    ),
+}
+
+const MarkdownPreview = defineAsyncComponent({
+  loader: () => import('@/components/markdown-preview/index.vue'),
+  loadingComponent: AsyncLoading,
+  delay: 120,
+})
+
+const HtmlPreview = defineAsyncComponent({
+  loader: () => import('@/components/html-preview/index.vue'),
+  loadingComponent: AsyncLoading,
+  delay: 120,
+})
 
 const props = defineProps<{
   botId: string
@@ -39,7 +61,12 @@ const filename = computed(() => props.file.name ?? '')
 const filePath = computed(() => props.file.path ?? '')
 const isText = computed(() => isTextFile(filename.value))
 const isImage = computed(() => isImageFile(filename.value))
+const isMd = computed(() => isMarkdownFile(filename.value))
+const isHtml = computed(() => isHtmlFile(filename.value))
+const hasPreviewToggle = computed(() => isText.value && (isMd.value || isHtml.value))
 const isDirty = computed(() => content.value !== originalContent.value)
+
+const mode = ref<PreviewMode>('raw')
 
 watch(isDirty, (dirty) => {
   emit('update:dirty', dirty)
@@ -122,6 +149,9 @@ watch(() => props.file.path, () => {
   cleanupImageUrl()
   content.value = ''
   originalContent.value = ''
+  // Default mode: rich preview for markdown, raw source for HTML/other text.
+  if (isMd.value) mode.value = 'preview'
+  else mode.value = 'raw'
   if (isText.value) {
     void loadTextContent()
   } else if (isImage.value) {
@@ -165,22 +195,31 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="relative flex h-full flex-col overflow-hidden">
-    <Button
-      v-if="isText"
-      type="button"
-      size="sm"
-      class="absolute top-2 right-2 z-10 gap-1.5 bg-primary text-primary-foreground shadow-md hover:bg-brand-hover disabled:bg-primary/40 disabled:text-primary-foreground/80"
-      :disabled="!isDirty || saving"
-      :title="t('bots.files.save')"
-      @click="handleSave"
+    <div
+      v-if="hasPreviewToggle || isText"
+      class="absolute top-2 right-2 z-10 flex items-center gap-2"
     >
-      <Spinner v-if="saving" />
-      <Save
-        v-else
-        class="size-3.5"
+      <PreviewModeToggle
+        v-if="hasPreviewToggle"
+        v-model="mode"
       />
-      {{ t('bots.files.save') }}
-    </Button>
+      <Button
+        v-if="isText && (!hasPreviewToggle || mode === 'raw')"
+        type="button"
+        size="sm"
+        class="gap-1.5 bg-primary text-primary-foreground shadow-md hover:bg-brand-hover disabled:bg-primary/40 disabled:text-primary-foreground/80"
+        :disabled="!isDirty || saving"
+        :title="t('bots.files.save')"
+        @click="handleSave"
+      >
+        <Spinner v-if="saving" />
+        <Save
+          v-else
+          class="size-3.5"
+        />
+        {{ t('bots.files.save') }}
+      </Button>
+    </div>
 
     <div class="flex-1 min-h-0 overflow-hidden">
       <div
@@ -190,6 +229,18 @@ onBeforeUnmount(() => {
         <Spinner class="mr-2" />
         {{ t('common.loading') }}
       </div>
+
+      <MarkdownPreview
+        v-else-if="isText && isMd && mode === 'preview'"
+        :content="content"
+        class="h-full"
+      />
+
+      <HtmlPreview
+        v-else-if="isText && isHtml && mode === 'preview'"
+        :content="content"
+        class="h-full"
+      />
 
       <MonacoEditor
         v-else-if="isText"

--- a/apps/web/src/components/file-manager/utils.ts
+++ b/apps/web/src/components/file-manager/utils.ts
@@ -117,6 +117,16 @@ export function isImageFile(filename: string): boolean {
   return IMAGE_EXTENSIONS.has(ext)
 }
 
+export function isMarkdownFile(filename: string): boolean {
+  const ext = getExtension(filename)
+  return ext === 'md' || ext === 'markdown'
+}
+
+export function isHtmlFile(filename: string): boolean {
+  const ext = getExtension(filename)
+  return ext === 'html' || ext === 'htm'
+}
+
 export function isArchiveFile(filename: string | undefined): boolean {
   const lower = (filename ?? '').toLowerCase()
   return lower.endsWith('.zip') || lower.endsWith('.tar.gz') || lower.endsWith('.tgz')

--- a/apps/web/src/components/html-preview/index.vue
+++ b/apps/web/src/components/html-preview/index.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed, onMounted, nextTick, ref, watch } from 'vue'
+import { useSettingsStore } from '@/store/settings'
+
+const props = withDefaults(defineProps<{
+  content: string
+  class?: string
+}>(), {
+  class: undefined,
+})
+
+const settings = useSettingsStore()
+const themeStyle = ref('')
+
+// Resolve the current themed defaults at runtime so the iframe's blank canvas
+// inherits the app theme (foreground/background) and gets the correct
+// `color-scheme` for native scrollbars / form controls.
+// User-authored CSS inside the HTML still wins because it appears later in
+// the document source order (equal specificity → later rule applies).
+function refreshThemeStyle() {
+  if (typeof document === 'undefined') return
+  const cs = getComputedStyle(document.documentElement)
+  const fg = cs.getPropertyValue('--color-foreground').trim()
+  const bg = cs.getPropertyValue('--color-background').trim()
+  const muted = cs.getPropertyValue('--color-muted-foreground').trim()
+  const border = cs.getPropertyValue('--color-border').trim()
+  const accent = cs.getPropertyValue('--color-accent').trim()
+  const isDark = settings.theme === 'dark'
+
+  themeStyle.value = `<style>
+:root { color-scheme: ${isDark ? 'dark' : 'light'}; }
+html, body {
+  color: ${fg || 'inherit'};
+  background-color: ${bg || 'transparent'};
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+}
+body { margin: 16px; }
+a { color: ${fg || 'inherit'}; }
+hr { border-color: ${border || 'currentColor'}; }
+code, pre { background-color: ${accent || 'transparent'}; color: ${fg || 'inherit'}; }
+blockquote { color: ${muted || 'inherit'}; border-left: 3px solid ${border || 'currentColor'}; padding-left: 12px; margin-left: 0; }
+::selection { background-color: ${accent || 'rgba(127,127,127,0.3)'}; }
+</style>`
+}
+
+onMounted(() => refreshThemeStyle())
+
+watch(() => settings.theme, async () => {
+  await nextTick()
+  refreshThemeStyle()
+})
+
+const srcdoc = computed(() => themeStyle.value + (props.content ?? ''))
+</script>
+
+<template>
+  <div :class="['flex h-full w-full min-h-0 bg-background', props.class]">
+    <iframe
+      :srcdoc="srcdoc"
+      sandbox="allow-same-origin"
+      class="h-full w-full border-0"
+      title="HTML preview"
+      referrerpolicy="no-referrer"
+    />
+  </div>
+</template>

--- a/apps/web/src/components/markdown-preview/index.vue
+++ b/apps/web/src/components/markdown-preview/index.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import MarkdownRender, { enableKatex, enableMermaid } from 'markstream-vue'
+import { useSettingsStore } from '@/store/settings'
+
+const props = withDefaults(defineProps<{
+  content: string
+  class?: string
+}>(), {
+  class: undefined,
+})
+
+enableKatex()
+enableMermaid()
+
+const settings = useSettingsStore()
+const isDark = computed(() => settings.theme === 'dark')
+</script>
+
+<template>
+  <div :class="['h-full w-full min-h-0 overflow-auto bg-card', props.class]">
+    <div class="prose prose-sm dark:prose-invert max-w-none px-6 py-4 *:first:mt-0">
+      <MarkdownRender
+        :content="props.content"
+        :is-dark="isDark"
+        :typewriter="false"
+        custom-id="file-preview-md"
+      />
+    </div>
+  </div>
+</template>

--- a/apps/web/src/components/preview-mode-toggle/index.vue
+++ b/apps/web/src/components/preview-mode-toggle/index.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Eye, Code } from 'lucide-vue-next'
+import { Tabs, TabsList, TabsTrigger } from '@memohai/ui'
+
+export type PreviewMode = 'preview' | 'raw'
+
+const props = withDefaults(defineProps<{
+  modelValue: PreviewMode
+  previewLabel?: string
+  rawLabel?: string
+  class?: string
+}>(), {
+  previewLabel: undefined,
+  rawLabel: undefined,
+  class: undefined,
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: PreviewMode]
+}>()
+
+const { t } = useI18n()
+
+const previewText = computed(() => props.previewLabel ?? t('common.preview'))
+const rawText = computed(() => props.rawLabel ?? t('common.raw'))
+
+const current = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value as PreviewMode),
+})
+</script>
+
+<template>
+  <Tabs
+    v-model="current"
+    :class="['inline-flex', props.class]"
+  >
+    <TabsList class="h-7 p-0.5 gap-0.5">
+      <TabsTrigger
+        value="preview"
+        class="h-6 gap-1 px-2 text-[11px]"
+        :aria-label="previewText"
+      >
+        <Eye class="size-3.5" />
+        {{ previewText }}
+      </TabsTrigger>
+      <TabsTrigger
+        value="raw"
+        class="h-6 gap-1 px-2 text-[11px]"
+        :aria-label="rawText"
+      >
+        <Code class="size-3.5" />
+        {{ rawText }}
+      </TabsTrigger>
+    </TabsList>
+  </Tabs>
+</template>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -71,7 +71,9 @@
     "categories": "Categories",
     "unsaved": "Unsaved",
     "editJson": "Edit JSON",
-    "actionRequired": "Action Required"
+    "actionRequired": "Action Required",
+    "preview": "Preview",
+    "raw": "Source"
   },
   "auth": {
     "welcome": "Welcome Back",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -71,7 +71,9 @@
     "categories": "搜索类别",
     "unsaved": "未保存",
     "editJson": "编辑 JSON",
-    "actionRequired": "需要操作"
+    "actionRequired": "需要操作",
+    "preview": "预览",
+    "raw": "源码"
   },
   "auth": {
     "welcome": "欢迎回来",


### PR DESCRIPTION
## Summary
- Add a unified Preview/Raw toggle for `.md` and `.html` files in the workspace file viewer.
- Markdown preview reuses the existing `MarkdownRender` (`markstream-vue`) with the typewriter fade-in disabled, so it inherits chat's design tokens and dark-mode styles.
- HTML preview renders inside a sandboxed iframe (no scripts) and runtime-injects theme-aware default CSS (foreground/background, `color-scheme`, link/code/blockquote/border) so a bare HTML document matches the current light/dark theme without overriding user-authored styles.
- Save button now only shows in Raw mode; preview-eligible files default to Preview (markdown) or Raw (HTML, to preserve current editing behavior).
- Preview components are lazy-loaded via `defineAsyncComponent`.

## Changes
- New components: `apps/web/src/components/preview-mode-toggle/`, `markdown-preview/`, `html-preview/`.
- `file-manager/file-viewer.vue`: wire up mode toggle, lazy previews, conditional Save button.
- `file-manager/utils.ts`: add `isMarkdownFile` / `isHtmlFile` helpers.
- `i18n/locales/{en,zh}.json`: add `common.preview` / `common.raw`.

## Test plan
- [ ] Open a `.md` file in a bot workspace → defaults to Preview, renders with chat markdown styles, Save button hidden.
- [ ] Switch to Raw → Monaco editor appears, Save button visible, edits round-trip.
- [ ] Toggle dark/light → markdown preview restyles correctly.
- [ ] Open a `.html` file → defaults to Raw (editor), switch to Preview → iframe renders with theme-matched defaults.
- [ ] Confirm HTML preview blocks scripts (sandbox without `allow-scripts`).
- [ ] Non-md/non-html text files behave as before (no toggle, Save visible).