### PR TITLE
fix: route websocket streams by stream id

### DIFF
--- a/apps/web/src/composables/api/useChat.types.ts
+++ b/apps/web/src/composables/api/useChat.types.ts
@@ -224,19 +224,27 @@ export type UITurn = UIUserTurn | UIAssistantTurn | UISystemTurn
 
 export interface UIStreamStartEvent {
   type: 'start'
+  stream_id?: string
+  session_id?: string
 }
 
 export interface UIStreamMessageEvent {
   type: 'message'
+  stream_id?: string
+  session_id?: string
   data: UIMessage
 }
 
 export interface UIStreamEndEvent {
   type: 'end'
+  stream_id?: string
+  session_id?: string
 }
 
 export interface UIStreamErrorEvent {
   type: 'error'
+  stream_id?: string
+  session_id?: string
   message: string
 }
 

--- a/apps/web/src/composables/api/useChat.ws.test.ts
+++ b/apps/web/src/composables/api/useChat.ws.test.ts
@@ -16,8 +16,10 @@ class MockWebSocket {
   onclose: (() => void) | null = null
   onerror: (() => void) | null = null
   onmessage: ((event: { data: string }) => void) | null = null
+  readonly url: string
 
-  constructor(public readonly url: string) {
+  constructor(url: string) {
+    this.url = url
     MockWebSocket.instances.push(this)
   }
 
@@ -56,10 +58,10 @@ describe('useChat.ws', () => {
   it('queues outbound messages until socket opens', () => {
     const onStreamEvent = vi.fn()
     const ws = connectWebSocket('bot-1', onStreamEvent)
-    const socket = MockWebSocket.instances[0]
+    const socket = MockWebSocket.instances[0]!
 
     expect(socket).toBeDefined()
-    ws.send({ type: 'message', text: 'hello', session_id: 'session-1' })
+    ws.send({ type: 'message', stream_id: 'stream-1', text: 'hello', session_id: 'session-1' })
     expect(socket.sent).toEqual([])
 
     socket.open()
@@ -67,8 +69,22 @@ describe('useChat.ws', () => {
     expect(socket.sent).toHaveLength(1)
     expect(JSON.parse(socket.sent[0]!)).toEqual({
       type: 'message',
+      stream_id: 'stream-1',
       text: 'hello',
       session_id: 'session-1',
+    })
+  })
+
+  it('sends targeted abort messages', () => {
+    const ws = connectWebSocket('bot-1', vi.fn())
+    const socket = MockWebSocket.instances[0]!
+    socket.open()
+
+    ws.abort('stream-1')
+
+    expect(JSON.parse(socket.sent[0]!)).toEqual({
+      type: 'abort',
+      stream_id: 'stream-1',
     })
   })
 

--- a/apps/web/src/composables/api/useChat.ws.ts
+++ b/apps/web/src/composables/api/useChat.ws.ts
@@ -3,6 +3,7 @@ import type { ChatAttachment, UIStreamEvent, UIStreamEventHandler } from './useC
 
 export interface WSClientMessage {
   type: 'message' | 'abort' | 'tool_approval_response'
+  stream_id?: string
   text?: string
   session_id?: string
   attachments?: ChatAttachment[]
@@ -17,7 +18,7 @@ export interface WSClientMessage {
 
 export interface ChatWebSocket {
   send: (msg: WSClientMessage) => void
-  abort: () => void
+  abort: (streamId: string) => void
   close: () => void
   readonly connected: boolean
   onOpen: (() => void) | null
@@ -58,9 +59,11 @@ export function connectWebSocket(
       }
       sendQueue.push(payload)
     },
-    abort() {
+    abort(streamId: string) {
+      const id = streamId.trim()
+      if (!id) return
       if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'abort' }))
+        ws.send(JSON.stringify({ type: 'abort', stream_id: id }))
       }
     },
     close() {

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -24,10 +24,14 @@ function flushPromises() {
 describe('chat-list store', () => {
   let streamHandler: UIStreamEventHandler | null
   let sendEvents: UIStreamEvent[]
+  let lastStreamId = ''
+  let lastSessionId = ''
 
   beforeEach(() => {
     setActivePinia(createPinia())
     streamHandler = null
+    lastStreamId = ''
+    lastSessionId = ''
     sendEvents = [
       { type: 'start' } as UIStreamEvent,
       { type: 'error', message: 'model failed' } as UIStreamEvent,
@@ -54,9 +58,15 @@ describe('chat-list store', () => {
         get connected() {
           return true
         },
-        send: vi.fn(() => {
+        send: vi.fn((message: { stream_id?: string; session_id?: string }) => {
+          lastStreamId = message.stream_id ?? ''
+          lastSessionId = message.session_id ?? ''
           for (const event of sendEvents) {
-            onStreamEvent(event)
+            onStreamEvent({
+              ...event,
+              stream_id: lastStreamId,
+              session_id: lastSessionId,
+            } as UIStreamEvent)
           }
         }),
         abort: vi.fn(),
@@ -136,7 +146,7 @@ describe('chat-list store', () => {
       text: 'hello',
       timestamp: '2026-05-17T08:00:00.000Z',
     }])
-    streamHandler?.({ type: 'end' } as UIStreamEvent)
+    streamHandler?.({ type: 'end', stream_id: lastStreamId, session_id: lastSessionId } as UIStreamEvent)
     await flushPromises()
 
     expect(store.messages).toHaveLength(2)
@@ -146,5 +156,81 @@ describe('chat-list store', () => {
       messages: [{ type: 'error', content: 'model failed' }],
       streaming: false,
     })
+  })
+
+  it('routes interleaved websocket events by stream id', async () => {
+    sendEvents = []
+    api.fetchSessions.mockResolvedValueOnce([
+      { id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' },
+      { id: 'session-b', bot_id: 'bot-1', title: 'B', type: 'chat' },
+    ])
+    api.fetchMessagesUI.mockResolvedValue([])
+
+    const sent: Array<{ stream_id?: string; session_id?: string }> = []
+    api.connectWebSocket.mockImplementation((_botId: string, onStreamEvent: UIStreamEventHandler) => {
+      streamHandler = onStreamEvent
+      return {
+        get connected() {
+          return true
+        },
+        send: vi.fn((message: { stream_id?: string; session_id?: string }) => {
+          sent.push(message)
+        }),
+        abort: vi.fn(),
+        close: vi.fn(),
+        onOpen: null,
+        onClose: null,
+      }
+    })
+
+    const store = useChatStore()
+
+    await store.selectBot('bot-1')
+    const first = store.sendMessage('first')
+    await flushPromises()
+
+    await store.selectSession('session-b')
+    const second = store.sendMessage('second')
+    await flushPromises()
+
+    const streamA = sent.find(item => item.session_id === 'session-a')?.stream_id
+    const streamB = sent.find(item => item.session_id === 'session-b')?.stream_id
+    expect(streamA).toBeTruthy()
+    expect(streamB).toBeTruthy()
+    expect(store.isSessionStreaming('session-a')).toBe(true)
+    expect(store.isSessionStreaming('session-b')).toBe(true)
+
+    streamHandler?.({
+      type: 'message',
+      stream_id: streamA,
+      session_id: 'session-a',
+      data: { id: 0, type: 'text', content: 'answer A' },
+    } as UIStreamEvent)
+    streamHandler?.({
+      type: 'message',
+      stream_id: streamB,
+      session_id: 'session-b',
+      data: { id: 0, type: 'text', content: 'answer B' },
+    } as UIStreamEvent)
+    expect(store.sessionId).toBe('session-b')
+    expect(store.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        messages: [expect.objectContaining({ type: 'text', content: 'answer B' })],
+      }),
+    ]))
+
+    await store.selectSession('session-a')
+    expect(store.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: 'assistant',
+        messages: [expect.objectContaining({ type: 'text', content: 'answer A' })],
+      }),
+    ]))
+
+    streamHandler?.({ type: 'end', stream_id: streamA, session_id: 'session-a' } as UIStreamEvent)
+    streamHandler?.({ type: 'end', stream_id: streamB, session_id: 'session-b' } as UIStreamEvent)
+    await first
+    await second
   })
 })

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -110,13 +110,18 @@ export interface ChatSystemTurn {
 export type ChatMessage = ChatUserTurn | ChatAssistantTurn | ChatSystemTurn
 
 interface PendingAssistantStream {
+  streamId: string
   assistantTurn: ChatAssistantTurn
   botId: string
   sessionId: string
   done: boolean
   resolve: () => void
   reject: (err: Error) => void
-  streamError?: StreamFailureError
+}
+
+interface StreamIdentity {
+  stream_id?: string
+  session_id?: string
 }
 
 export type SendMessageStage = 'startup' | 'stream'
@@ -164,8 +169,15 @@ export const useChatStore = defineStore('chat', () => {
   const { currentBotId, sessionId } = storeToRefs(selectionStore)
 
   const messages = reactive<ChatMessage[]>([])
-  const streamingSessionId = ref<string | null>(null)
-  const streaming = computed(() => streamingSessionId.value !== null && streamingSessionId.value === sessionId.value)
+  const pendingAssistantStreams = reactive(new Map<string, PendingAssistantStream>())
+  const pendingStreams = () => [...pendingAssistantStreams.values()].filter(stream => !stream.done)
+  const streamingSessionId = computed(() => {
+    const activeSid = (sessionId.value ?? '').trim()
+    const activeSessionIds = pendingStreams().map(stream => stream.sessionId)
+    if (activeSid && activeSessionIds.includes(activeSid)) return activeSid
+    return activeSessionIds[0] ?? null
+  })
+  const streaming = computed(() => isSessionStreaming(sessionId.value))
   const sessions = ref<SessionSummary[]>([])
   const loading = ref(false)
   const loadingChats = ref(false)
@@ -190,13 +202,10 @@ export const useChatStore = defineStore('chat', () => {
     fsChangedAt.value = Date.now()
   }
 
-  let abortFn: (() => void) | null = null
   let messageEventsSince = ''
-  let pendingAssistantStream: PendingAssistantStream | null = null
   let activeWs: ChatWebSocket | null = null
   let refreshTimer: ReturnType<typeof setTimeout> | null = null
   let refreshPromise: { key: string; promise: Promise<void> } | null = null
-  let suppressNextStartPlaceholder = false
   const pendingBackgroundEvents = new Map<string, BackgroundTask[]>()
   const latestBackgroundTasks = new Map<string, BackgroundTask>()
   // Open chat tabs share this store, so keep a small per-session view cache.
@@ -225,8 +234,8 @@ export const useChatStore = defineStore('chat', () => {
       void initialize()
     } else {
       stopMessageEvents()
+      abortAllAssistantStreams()
       stopWebSocket()
-      rejectPendingAssistantStream(new Error('Bot stream stopped'))
       messageEventsSince = ''
       sessions.value = []
       sessionId.value = null
@@ -359,7 +368,7 @@ export const useChatStore = defineStore('chat', () => {
 
   function mergeBackgroundTask(existing: BackgroundTask | undefined, incoming: BackgroundTask): BackgroundTask {
     const merged: BackgroundTask = existing ? { ...existing } : { taskId: incoming.taskId, status: incoming.status }
-    const writable = merged as Record<string, unknown>
+    const writable = merged as unknown as Record<string, unknown>
     for (const [key, value] of Object.entries(incoming)) {
       if (value === undefined || value === '') continue
       writable[key] = value
@@ -589,11 +598,12 @@ export const useChatStore = defineStore('chat', () => {
     return target
   }
 
-  function findUserTurnBeforeAssistant(assistantTurn: ChatAssistantTurn): ChatUserTurn | null {
-    const index = messages.indexOf(assistantTurn)
+  function findUserTurnBeforeAssistant(assistantTurn: ChatAssistantTurn, botId = currentBotId.value ?? '', targetSessionId = sessionId.value ?? ''): ChatUserTurn | null {
+    const items = collectionForTurn(botId, targetSessionId, assistantTurn)
+    const index = items.indexOf(assistantTurn)
     if (index < 0) return null
     for (let i = index - 1; i >= 0; i -= 1) {
-      const item = messages[i]
+      const item = items[i]
       if (item?.role === 'user') return item
     }
     return null
@@ -749,17 +759,122 @@ export const useChatStore = defineStore('chat', () => {
     if (key) sessionMessageStates.delete(key)
   }
 
-  function createCompletionForAssistantTurn(assistantTurn: ChatAssistantTurn): Promise<void> {
+  function createStreamId(): string {
+    const randomUUID = globalThis.crypto?.randomUUID
+    if (typeof randomUUID === 'function') return randomUUID.call(globalThis.crypto)
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  }
+
+  function fallbackStreamId(targetSessionId?: string | null): string {
+    const sid = (targetSessionId ?? sessionId.value ?? '').trim()
+    return sid ? `session:${sid}:agent-stream` : 'legacy-stream'
+  }
+
+  function activeStreamIdsForSession(targetSessionId?: string | null): string[] {
+    const sid = (targetSessionId ?? '').trim()
+    if (!sid) return []
+    return pendingStreams()
+      .filter(stream => stream.sessionId === sid)
+      .map(stream => stream.streamId)
+  }
+
+  function isSessionStreaming(targetSessionId?: string | null): boolean {
+    return activeStreamIdsForSession(targetSessionId).length > 0
+  }
+
+  function streamIdForEvent(event: StreamIdentity, targetSessionId?: string): string {
+    const explicit = (event.stream_id ?? '').trim()
+    if (explicit) return explicit
+    const sid = (event.session_id ?? targetSessionId ?? '').trim()
+    const activeIds = activeStreamIdsForSession(sid)
+    return activeIds.length === 1 ? activeIds[0]! : fallbackStreamId(sid)
+  }
+
+  function trackAssistantStream(streamId: string, assistantTurn: ChatAssistantTurn, botId: string, targetSessionId: string): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      pendingAssistantStream = {
+      const id = streamId.trim()
+      if (!id) {
+        reject(new Error('stream_id is required'))
+        return
+      }
+      if (pendingAssistantStreams.has(id)) {
+        reject(new Error(`stream_id ${id} is already active`))
+        return
+      }
+      pendingAssistantStreams.set(id, {
+        streamId: id,
         assistantTurn,
-        botId: currentBotId.value ?? '',
-        sessionId: streamingSessionId.value ?? sessionId.value ?? '',
+        botId,
+        sessionId: targetSessionId.trim(),
         done: false,
         resolve,
         reject,
-      }
+      })
     })
+  }
+
+  function getAssistantStream(streamId: string): PendingAssistantStream | undefined {
+    return pendingAssistantStreams.get(streamId.trim())
+  }
+
+  function finishAssistantStream(streamId: string): PendingAssistantStream | undefined {
+    const stream = getAssistantStream(streamId)
+    if (!stream || stream.done) return undefined
+    stream.assistantTurn.streaming = false
+    stream.done = true
+    pendingAssistantStreams.delete(stream.streamId)
+    return stream
+  }
+
+  function resolveAssistantStream(streamId: string) {
+    finishAssistantStream(streamId)?.resolve()
+  }
+
+  function rejectAssistantStream(streamId: string, err: Error) {
+    finishAssistantStream(streamId)?.reject(err)
+  }
+
+  function forgetAssistantStream(streamId: string) {
+    pendingAssistantStreams.delete(streamId.trim())
+  }
+
+  function appendTurnToSession(botId: string, targetSessionId: string, turn: ChatMessage) {
+    const bid = botId.trim()
+    const sid = targetSessionId.trim()
+    if (!bid || !sid) return
+    if (currentBotId.value === bid && sessionId.value === sid) {
+      messages.push(turn)
+      return
+    }
+    const key = sessionMessageKey(bid, sid)
+    if (!key) return
+    const cached = sessionMessageStates.get(key)
+    if (cached) {
+      cached.items.push(turn)
+    } else {
+      sessionMessageStates.set(key, {
+        items: [turn],
+        hasMoreOlder: true,
+      })
+    }
+  }
+
+  function removeTurnFromSession(botId: string, targetSessionId: string, turn: ChatMessage) {
+    const idx = messages.indexOf(turn)
+    if (idx >= 0) messages.splice(idx, 1)
+    const key = sessionMessageKey(botId, targetSessionId)
+    const cached = key ? sessionMessageStates.get(key) : undefined
+    if (!cached) return
+    const cachedIdx = cached.items.indexOf(turn)
+    if (cachedIdx >= 0) cached.items.splice(cachedIdx, 1)
+  }
+
+  function collectionForTurn(botId: string, targetSessionId: string, turn: ChatMessage): ChatMessage[] {
+    if (messages.includes(turn)) return messages
+    const key = sessionMessageKey(botId, targetSessionId)
+    const cached = key ? sessionMessageStates.get(key) : undefined
+    if (cached?.items.includes(turn)) return cached.items
+    return messages
   }
 
   function createOptimisticAssistantTurn(): ChatAssistantTurn {
@@ -789,36 +904,20 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  function resolvePendingAssistantStream() {
-    if (!pendingAssistantStream || pendingAssistantStream.done) return
-    const session = pendingAssistantStream
-    session.assistantTurn.streaming = false
-    session.done = true
-    pendingAssistantStream = null
-    if (session.streamError) {
-      session.reject(session.streamError)
-      return
+  function ensureDiscussStream(streamId: string, targetSessionId?: string): PendingAssistantStream {
+    const id = streamIdForEvent({ stream_id: streamId, session_id: targetSessionId }, targetSessionId)
+    const existing = getAssistantStream(id)
+    if (existing && !existing.done) {
+      return existing
     }
-    session.resolve()
-  }
-
-  function rejectPendingAssistantStream(err: Error) {
-    if (!pendingAssistantStream || pendingAssistantStream.done) return
-    const session = pendingAssistantStream
-    session.assistantTurn.streaming = false
-    session.done = true
-    pendingAssistantStream = null
-    session.reject(err)
-  }
-
-  function ensureDiscussStream(): PendingAssistantStream {
-    if (pendingAssistantStream && !pendingAssistantStream.done) {
-      return pendingAssistantStream
-    }
-    messages.push(createOptimisticAssistantTurn())
-    const assistantTurn = messages[messages.length - 1] as ChatAssistantTurn
-    void createCompletionForAssistantTurn(assistantTurn).catch(() => {})
-    return pendingAssistantStream!
+    const sid = (targetSessionId ?? sessionId.value ?? '').trim()
+    const bid = (currentBotId.value ?? '').trim()
+    const assistantTurn = createOptimisticAssistantTurn()
+    appendTurnToSession(bid, sid, assistantTurn)
+    void trackAssistantStream(id, assistantTurn, bid, sid).catch((error: Error) => {
+      finalizeStreamFailure(assistantTurn, bid, sid, error)
+    })
+    return getAssistantStream(id)!
   }
 
   function upsertAssistantUIMessage(turn: ChatAssistantTurn, message: UIMessage) {
@@ -835,13 +934,13 @@ export const useChatStore = defineStore('chat', () => {
     return turn.messages.some(block => block.type !== 'error')
   }
 
-  function rememberAssistantError(errorMessage: string, assistantTurn: ChatAssistantTurn) {
-    const sid = (streamingSessionId.value ?? sessionId.value ?? '').trim()
+  function rememberAssistantError(errorMessage: string, botId: string, targetSessionId: string, assistantTurn: ChatAssistantTurn) {
+    const sid = targetSessionId.trim()
     const text = errorMessage.trim()
     if (!sid || !text) return
     const current = ephemeralAssistantErrors.get(sid) ?? []
     if (current.some(item => item.content === text)) return
-    const anchorUser = findUserTurnBeforeAssistant(assistantTurn)
+    const anchorUser = findUserTurnBeforeAssistant(assistantTurn, botId, sid)
     ephemeralAssistantErrors.set(sid, [...current, {
       content: text,
       timestamp: new Date().toISOString(),
@@ -849,16 +948,26 @@ export const useChatStore = defineStore('chat', () => {
     }].slice(-5))
   }
 
-  function appendAssistantError(session: PendingAssistantStream, errorMessage: string) {
+  function appendAssistantError(assistantTurn: ChatAssistantTurn, botId: string, targetSessionId: string, errorMessage: string) {
     const text = errorMessage.trim()
     if (!text) return
 
-    rememberAssistantError(text, session.assistantTurn)
-    session.assistantTurn.messages.push({
-      id: nextAssistantMessageId(session.assistantTurn),
+    rememberAssistantError(text, botId, targetSessionId, assistantTurn)
+    assistantTurn.messages.push({
+      id: nextAssistantMessageId(assistantTurn),
       type: 'error',
       content: text,
     })
+  }
+
+  function finalizeStreamFailure(assistantTurn: ChatAssistantTurn, botId: string, targetSessionId: string, error: Error) {
+    if (!hasVisibleAssistantBlocks(assistantTurn)) {
+      removeTurnFromSession(botId, targetSessionId, assistantTurn)
+      return
+    }
+    if (error.name === 'AbortError') return
+    if (assistantTurn.messages.some(block => block.type === 'error')) return
+    appendAssistantError(assistantTurn, botId, targetSessionId, error.message)
   }
 
   function rememberStartupSendFailure(failure: Omit<StartupSendFailure, 'id'>) {
@@ -875,50 +984,40 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  function pruneEmptyAssistantTurnIfPending() {
-    if (!pendingAssistantStream) return
-    const turn = pendingAssistantStream.assistantTurn
+  function pruneEmptyAssistantTurnIfPending(streamId: string) {
+    const session = getAssistantStream(streamId)
+    if (!session) return
+    const turn = session.assistantTurn
     if (turn.messages.length > 0) return
-    const idx = messages.indexOf(turn)
-    if (idx >= 0) messages.splice(idx, 1)
+    removeTurnFromSession(session.botId, session.sessionId, turn)
   }
 
   function handleWSStreamEvent(event: UIStreamEvent, targetSessionId?: string) {
+    const sid = (event.session_id ?? targetSessionId ?? sessionId.value ?? '').trim()
+    const streamId = streamIdForEvent(event, sid)
+
     switch (event.type) {
       case 'start':
-        if (suppressNextStartPlaceholder) {
-          suppressNextStartPlaceholder = false
-        } else {
-          ensureDiscussStream()
-        }
+        ensureDiscussStream(streamId, sid)
         break
       case 'message':
-        upsertAssistantUIMessage(ensureDiscussStream().assistantTurn, event.data)
+        upsertAssistantUIMessage(ensureDiscussStream(streamId, sid).assistantTurn, event.data)
         break
       case 'end':
-        const endedBotId = pendingAssistantStream?.botId
-        const endedSessionId = targetSessionId || pendingAssistantStream?.sessionId
-        pruneEmptyAssistantTurnIfPending()
-        resolvePendingAssistantStream()
-        streamingSessionId.value = null
-        loading.value = false
-        abortFn = null
+        const endedSession = getAssistantStream(streamId)
+        const endedBotId = endedSession?.botId ?? currentBotId.value ?? ''
+        const endedSessionId = sid || endedSession?.sessionId
+        pruneEmptyAssistantTurnIfPending(streamId)
+        resolveAssistantStream(streamId)
+        loading.value = isSessionStreaming(sessionId.value)
         void refreshCurrentSession(endedBotId, endedSessionId)
         break
       case 'error': {
-        const session = ensureDiscussStream()
+        const session = getAssistantStream(streamId) ?? ensureDiscussStream(streamId, sid)
         const message = event.message || 'stream error'
         const stage: SendMessageStage = hasVisibleAssistantBlocks(session.assistantTurn) ? 'stream' : 'startup'
-        if (stage === 'stream') {
-          appendAssistantError(session, message)
-        } else {
-          const idx = messages.indexOf(session.assistantTurn)
-          if (idx >= 0) messages.splice(idx, 1)
-        }
-        rejectPendingAssistantStream(new StreamFailureError(message, stage))
-        loading.value = false
-        streamingSessionId.value = null
-        abortFn = null
+        rejectAssistantStream(streamId, new StreamFailureError(message, stage))
+        loading.value = isSessionStreaming(sessionId.value)
         break
       }
     }
@@ -977,14 +1076,6 @@ export const useChatStore = defineStore('chat', () => {
         cacheFetchedMessages(bid, sid, normalized, moreOlder)
       }
       touchSession(sid)
-      const streamStillActive = streamingSessionId.value === sid && pendingAssistantStream && !pendingAssistantStream.done
-      if (!streamStillActive && pendingAssistantStream) {
-        pendingAssistantStream.assistantTurn.streaming = false
-        pendingAssistantStream = null
-      }
-      if (!streamStillActive) {
-        streamingSessionId.value = null
-      }
     })().finally(() => {
       if (refreshPromise?.promise === promise) {
         refreshPromise = null
@@ -1004,7 +1095,7 @@ export const useChatStore = defineStore('chat', () => {
     refreshTimer = setTimeout(() => {
       refreshTimer = null
       const sidNow = (sessionId.value ?? '').trim()
-      const streamActive = streamingSessionId.value === sidNow && pendingAssistantStream && !pendingAssistantStream.done
+      const streamActive = isSessionStreaming(sidNow)
       if (streamActive) return
       void refreshCurrentSession()
     }, delay)
@@ -1076,14 +1167,12 @@ export const useChatStore = defineStore('chat', () => {
     const sid = (event.session_id ?? '').trim()
     const activeSid = (sessionId.value ?? '').trim()
     if (sid && activeSid && sid !== activeSid) {
-      const isKnownBackgroundStream = streamingSessionId.value === sid && pendingAssistantStream && !pendingAssistantStream.done
+      const isKnownBackgroundStream = !!stream.stream_id && pendingAssistantStreams.has(stream.stream_id)
       if (!isKnownBackgroundStream) return
     }
 
     if (stream.type === 'start' || stream.type === 'message') {
-      if (sid) streamingSessionId.value = sid
       loading.value = true
-      suppressNextStartPlaceholder = false
     }
 
     handleWSStreamEvent(stream, sid || undefined)
@@ -1143,17 +1232,24 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   function abort() {
-    if (activeWs?.connected) {
-      activeWs.abort()
+    const activeIds = activeStreamIdsForSession(sessionId.value)
+    const abortError = new Error('aborted')
+    abortError.name = 'AbortError'
+    for (const streamId of activeIds) {
+      if (activeWs?.connected) activeWs.abort(streamId)
+      rejectAssistantStream(streamId, abortError)
     }
-    abortFn?.()
-    abortFn = null
-    for (const message of messages) {
-      if (message.role === 'assistant' && message.streaming) {
-        message.streaming = false
-      }
+    loading.value = isSessionStreaming(sessionId.value)
+  }
+
+  function abortAllAssistantStreams() {
+    const abortError = new Error('aborted')
+    abortError.name = 'AbortError'
+    for (const stream of pendingStreams()) {
+      if (activeWs?.connected) activeWs.abort(stream.streamId)
+      rejectAssistantStream(stream.streamId, abortError)
     }
-    streamingSessionId.value = null
+    loading.value = false
   }
 
   async function ensureBot(): Promise<string | null> {
@@ -1352,6 +1448,7 @@ export const useChatStore = defineStore('chat', () => {
   async function selectBot(targetBotId: string) {
     if (currentBotId.value === targetBotId) return
     abort()
+    abortAllAssistantStreams()
     currentBotId.value = targetBotId
     sessionId.value = null
     await initialize()
@@ -1431,6 +1528,7 @@ export const useChatStore = defineStore('chat', () => {
     let userTurn: ChatUserTurn | null = null
     let sendBotId = ''
     let sendSessionId = ''
+    let sendStreamId = ''
 
     try {
       await ensureActiveSession()
@@ -1439,7 +1537,7 @@ export const useChatStore = defineStore('chat', () => {
       const sid = sessionId.value!
       sendBotId = bid
       sendSessionId = sid
-      streamingSessionId.value = sid
+      sendStreamId = createStreamId()
 
       userTurn = createOptimisticUserTurn(trimmed, attachments)
       messages.push(userTurn)
@@ -1455,15 +1553,10 @@ export const useChatStore = defineStore('chat', () => {
         if (!ws.connected) {
           throw new StreamFailureError('WebSocket is not connected', 'startup')
         }
-        const completion = createCompletionForAssistantTurn(assistantTurn)
-        abortFn = () => {
-          const abortError = new Error('aborted')
-          abortError.name = 'AbortError'
-          ws.abort()
-          rejectPendingAssistantStream(abortError)
-        }
+        const completion = trackAssistantStream(sendStreamId, assistantTurn, bid, sid)
         ws.send({
           type: 'message',
+          stream_id: sendStreamId,
           text: trimmed,
           session_id: sid,
           attachments,
@@ -1473,71 +1566,36 @@ export const useChatStore = defineStore('chat', () => {
         await completion
         await refreshCurrentSession(bid, sid)
       } else {
-        void createCompletionForAssistantTurn(assistantTurn).catch(() => {})
         await sendLocalChannelMessage(bid, trimmed, attachments, { modelId, reasoningEffort })
         await refreshCurrentSession(bid, sid)
       }
 
       assistantTurn.streaming = false
-      streamingSessionId.value = null
       loading.value = false
-      abortFn = null
       touchSession(sid)
       return { ok: true }
     } catch (error) {
-      const isAbort = error instanceof Error && error.name === 'AbortError'
-      const reason = error instanceof Error ? error.message : 'Unknown error'
-      const stage: SendMessageStage = error instanceof StreamFailureError
-        ? error.stage
+      const err = error instanceof Error ? error : new Error('Unknown error')
+      const isAbort = err.name === 'AbortError'
+      const reason = err.message
+      const stage: SendMessageStage = err instanceof StreamFailureError
+        ? err.stage
         : (assistantTurn && hasVisibleAssistantBlocks(assistantTurn) ? 'stream' : 'startup')
+      const bid = sendBotId || currentBotId.value || ''
+      const sid = sendSessionId || sessionId.value || ''
 
-      if (!isAbort && stage === 'startup') {
-        if (assistantTurn) {
-          const idx = messages.indexOf(assistantTurn)
-          if (idx >= 0) messages.splice(idx, 1)
-        }
-        if (userTurn) {
-          const idx = messages.indexOf(userTurn)
-          if (idx >= 0) messages.splice(idx, 1)
-        }
-      } else if (!isAbort && assistantTurn && stage === 'stream') {
-        if (!assistantTurn.messages.some(block => block.type === 'error')) {
-          appendAssistantError({ assistantTurn, done: false, resolve: () => {}, reject: () => {} }, reason)
-        }
-        assistantTurn.streaming = false
-      } else if (!isAbort) {
-        messages.push({
-          id: nextId(),
-          role: 'assistant',
-          messages: [{
-            id: 0,
-            type: 'error',
-            content: reason,
-          }],
-          timestamp: new Date().toISOString(),
-          streaming: false,
-        })
+      if (assistantTurn) finalizeStreamFailure(assistantTurn, bid, sid, err)
+      if (!isAbort && stage === 'startup' && userTurn) {
+        removeTurnFromSession(bid, sid, userTurn)
       }
-      pendingAssistantStream = null
-      streamingSessionId.value = null
+
+      if (sendStreamId) forgetAssistantStream(sendStreamId)
       loading.value = false
-      abortFn = null
+
       if (isAbort) return { ok: false, stage: 'stream', error: reason }
       if (stage === 'startup') {
-        rememberStartupSendFailure({
-          botId: sendBotId || currentBotId.value || '',
-          sessionId: sendSessionId || sessionId.value || '',
-          error: reason,
-          restoreInput: text,
-          restoreAttachments: attachments,
-        })
-        return {
-          ok: false,
-          stage,
-          error: reason,
-          restoreInput: text,
-          restoreAttachments: attachments,
-        }
+        rememberStartupSendFailure({ botId: bid, sessionId: sid, error: reason, restoreInput: text, restoreAttachments: attachments })
+        return { ok: false, stage, error: reason, restoreInput: text, restoreAttachments: attachments }
       }
       return { ok: false, stage, error: reason }
     }
@@ -1548,9 +1606,13 @@ export const useChatStore = defineStore('chat', () => {
     const sid = sessionId.value ?? ''
     if (!bid || !sid || !approval.approval_id || streaming.value) return
     const ws = ensureWebSocket(bid)
-    streamingSessionId.value = sid
+    const streamId = createStreamId()
+    const assistantTurn = createOptimisticAssistantTurn()
+    messages.push(assistantTurn)
+    void trackAssistantStream(streamId, assistantTurn, bid, sid).catch((error: Error) => {
+      finalizeStreamFailure(assistantTurn, bid, sid, error)
+    })
     loading.value = true
-    suppressNextStartPlaceholder = true
     // Optimistically update the approved/rejected tool block before the
     // server snapshot arrives so the buttons disappear immediately.
     for (const message of messages) {
@@ -1565,17 +1627,9 @@ export const useChatStore = defineStore('chat', () => {
         }
       }
     }
-    abortFn = () => {
-      const abortError = new Error('aborted')
-      abortError.name = 'AbortError'
-      ws?.abort()
-      rejectPendingAssistantStream(abortError)
-      streamingSessionId.value = null
-      loading.value = false
-      abortFn = null
-    }
     ws?.send({
       type: 'tool_approval_response',
+      stream_id: streamId,
       session_id: sid,
       approval_id: approval.approval_id,
       short_id: approval.short_id,
@@ -1605,6 +1659,7 @@ export const useChatStore = defineStore('chat', () => {
     bots,
     activeSession,
     activeChatReadOnly,
+    isSessionStreaming,
     loading,
     loadingChats,
     loadingOlder,

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -325,7 +325,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   function isTabBusy(tab: WorkspaceTab, dirty: Record<string, boolean>): boolean {
     switch (tab.type) {
       case 'chat':
-        return chatStore.streamingSessionId === tab.sessionId
+        return chatStore.isSessionStreaming(tab.sessionId)
       case 'file':
         return dirty[tab.id] === true
       case 'terminal':

--- a/internal/handlers/local_channel.go
+++ b/internal/handlers/local_channel.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -259,6 +260,7 @@ var wsUpgrader = websocket.Upgrader{
 
 type wsClientMessage struct {
 	Type            string            `json:"type"`
+	StreamID        string            `json:"stream_id,omitempty"`
 	Text            string            `json:"text,omitempty"`
 	SessionID       string            `json:"session_id,omitempty"`
 	Attachments     []json.RawMessage `json:"attachments,omitempty"`
@@ -269,6 +271,81 @@ type wsClientMessage struct {
 	ToolCallID      string            `json:"tool_call_id,omitempty"`
 	Decision        string            `json:"decision,omitempty"`
 	Reason          string            `json:"reason,omitempty"`
+}
+
+type wsOutboundEvent struct {
+	Type      string `json:"type"`
+	StreamID  string `json:"stream_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Data      any    `json:"data,omitempty"`
+	Message   string `json:"message,omitempty"`
+}
+
+type activeWSStream struct {
+	streamID string
+	cancel   context.CancelFunc
+	abortCh  chan struct{}
+}
+
+type wsStreamRegistry struct {
+	mu   sync.Mutex
+	byID map[string]*activeWSStream
+}
+
+func newWSStreamRegistry() *wsStreamRegistry {
+	return &wsStreamRegistry{
+		byID: make(map[string]*activeWSStream),
+	}
+}
+
+func (r *wsStreamRegistry) register(stream *activeWSStream) error {
+	streamID := strings.TrimSpace(stream.streamID)
+	if streamID == "" {
+		return errors.New("stream_id is required")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.byID[streamID]; exists {
+		return fmt.Errorf("stream_id %q is already active", streamID)
+	}
+	stream.streamID = streamID
+	r.byID[streamID] = stream
+	return nil
+}
+
+func (r *wsStreamRegistry) finish(streamID string) {
+	streamID = strings.TrimSpace(streamID)
+	if streamID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	stream := r.byID[streamID]
+	if stream == nil {
+		return
+	}
+	delete(r.byID, streamID)
+}
+
+func (r *wsStreamRegistry) abort(streamID string) bool {
+	streamID = strings.TrimSpace(streamID)
+	if streamID == "" {
+		return false
+	}
+
+	r.mu.Lock()
+	stream := r.byID[streamID]
+	r.mu.Unlock()
+	if stream == nil {
+		return false
+	}
+	select {
+	case stream.abortCh <- struct{}{}:
+	default:
+	}
+	stream.cancel()
+	return true
 }
 
 // wsWriter serialises all WebSocket writes through a single goroutine to
@@ -349,6 +426,110 @@ func extractRawBearerToken(c echo.Context) string {
 	return strings.TrimSpace(c.QueryParam("token"))
 }
 
+func sendWSError(writer *wsWriter, streamID, sessionID, message string) {
+	writer.SendJSON(wsOutboundEvent{
+		Type:      "error",
+		StreamID:  strings.TrimSpace(streamID),
+		SessionID: strings.TrimSpace(sessionID),
+		Message:   message,
+	})
+}
+
+func (h *LocalChannelHandler) forwardWSStreamEvents(ctx, assetCtx context.Context, writer *wsWriter, botID, sessionID, streamID string, eventCh <-chan flow.WSStreamEvent) {
+	converter := conversation.NewUIMessageStreamConverter()
+	outboundAssetRefs := make([]messagepkg.AssetRef, 0)
+	for event := range eventCh {
+		processed := h.processWSEvent(ctx, botID, event)
+		for _, p := range processed {
+			if refs := extractAssetRefsFromProcessedEvent(p); len(refs) > 0 {
+				outboundAssetRefs = append(outboundAssetRefs, refs...)
+			}
+
+			var streamEvent agentpkg.StreamEvent
+			if err := json.Unmarshal(p, &streamEvent); err != nil {
+				continue
+			}
+
+			switch streamEvent.Type {
+			case agentpkg.EventAgentStart:
+				writer.SendJSON(wsOutboundEvent{
+					Type:      "start",
+					StreamID:  streamID,
+					SessionID: sessionID,
+				})
+				continue
+			case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort:
+				for _, uiMessage := range conversation.ConvertRawModelMessagesToUIAssistantMessages(streamEvent.Messages) {
+					writer.SendJSON(wsOutboundEvent{
+						Type:      "message",
+						StreamID:  streamID,
+						SessionID: sessionID,
+						Data:      uiMessage,
+					})
+				}
+				writer.SendJSON(wsOutboundEvent{
+					Type:      "end",
+					StreamID:  streamID,
+					SessionID: sessionID,
+				})
+				continue
+			case agentpkg.EventError:
+				message := strings.TrimSpace(streamEvent.Error)
+				if message == "" {
+					message = "stream error"
+				}
+				sendWSError(writer, streamID, sessionID, message)
+				continue
+			}
+
+			uiEvents := converter.HandleEvent(uiStreamEventFromAgentEvent(streamEvent))
+			for _, uiMessage := range uiEvents {
+				writer.SendJSON(wsOutboundEvent{
+					Type:      "message",
+					StreamID:  streamID,
+					SessionID: sessionID,
+					Data:      uiMessage,
+				})
+			}
+		}
+	}
+	if len(outboundAssetRefs) > 0 {
+		h.resolver.LinkOutboundAssets(assetCtx, botID, sessionID, outboundAssetRefs)
+	}
+}
+
+type wsStreamRunner func(ctx context.Context, eventCh chan<- flow.WSStreamEvent, abortCh <-chan struct{}) error
+
+func (h *LocalChannelHandler) startWSStream(baseCtx, connCtx context.Context, activeStreams *wsStreamRegistry, writer *wsWriter, botID, sessionID, streamID, logLabel string, runner wsStreamRunner) {
+	streamCtx, streamCancel := context.WithCancel(baseCtx)
+	abortCh := make(chan struct{}, 1)
+	if err := activeStreams.register(&activeWSStream{
+		streamID: streamID,
+		cancel:   streamCancel,
+		abortCh:  abortCh,
+	}); err != nil {
+		streamCancel()
+		sendWSError(writer, streamID, sessionID, err.Error())
+		return
+	}
+
+	eventCh := make(chan flow.WSStreamEvent, 64)
+	go func() {
+		defer streamCancel()
+		err := func() error {
+			defer activeStreams.finish(streamID)
+			defer close(eventCh)
+			return runner(streamCtx, eventCh, abortCh)
+		}()
+		if err != nil && connCtx.Err() == nil {
+			h.logger.Error("ws stream error", slog.String("operation", logLabel), slog.Any("error", err), slog.String("bot_id", botID), slog.String("session_id", sessionID))
+			sendWSError(writer, streamID, sessionID, err.Error())
+		}
+	}()
+
+	go h.forwardWSStreamEvents(streamCtx, baseCtx, writer, botID, sessionID, streamID, eventCh)
+}
+
 // HandleWebSocket godoc
 // @Summary WebSocket chat endpoint
 // @Description Upgrade to WebSocket for bidirectional chat streaming with abort support.
@@ -394,8 +575,7 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 	defer connCancel()
 	streamBaseCtx := context.WithoutCancel(c.Request().Context())
 
-	abortCh := make(chan struct{}, 1)
-	var activeCancel context.CancelFunc
+	activeStreams := newWSStreamRegistry()
 
 	for {
 		_, raw, readErr := conn.ReadMessage()
@@ -419,217 +599,89 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 
 		switch msg.Type {
 		case "abort":
-			select {
-			case abortCh <- struct{}{}:
-			default:
+			streamID := strings.TrimSpace(msg.StreamID)
+			if streamID == "" {
+				sendWSError(writer, "", strings.TrimSpace(msg.SessionID), "stream_id is required")
+				continue
 			}
+			activeStreams.abort(streamID)
 
 		case "tool_approval_response":
 			sessionID := strings.TrimSpace(msg.SessionID)
 			if sessionID == "" {
-				writer.SendJSON(map[string]string{"type": "error", "message": "session_id is required"})
+				sendWSError(writer, strings.TrimSpace(msg.StreamID), "", "session_id is required")
+				continue
+			}
+			streamID := strings.TrimSpace(msg.StreamID)
+			if streamID == "" {
+				sendWSError(writer, "", sessionID, "stream_id is required")
 				continue
 			}
 			explicitID := strings.TrimSpace(msg.ApprovalID)
 			if explicitID == "" && msg.ShortID > 0 {
 				explicitID = strconv.Itoa(msg.ShortID)
 			}
-			streamCtx, streamCancel := context.WithCancel(streamBaseCtx)
-			activeCancel = streamCancel
-			eventCh := make(chan flow.WSStreamEvent, 64)
 
-			var (
-				outboundAssetMu   sync.Mutex
-				outboundAssetRefs []messagepkg.AssetRef
+			h.startWSStream(streamBaseCtx, connCtx, activeStreams, writer, botID, sessionID, streamID, "ws approval stream error",
+				func(ctx context.Context, eventCh chan<- flow.WSStreamEvent, _ <-chan struct{}) error {
+					return h.resolver.RespondToolApproval(ctx, flow.ToolApprovalResponseInput{
+						BotID:                  botID,
+						SessionID:              sessionID,
+						ActorChannelIdentityID: channelIdentityID,
+						ApprovalID:             strings.TrimSpace(msg.ApprovalID),
+						ExplicitID:             explicitID,
+						Decision:               strings.TrimSpace(msg.Decision),
+						Reason:                 strings.TrimSpace(msg.Reason),
+						ChatToken:              bearerToken,
+					}, eventCh)
+				},
 			)
-
-			go func() {
-				defer streamCancel()
-				defer close(eventCh)
-				if err := h.resolver.RespondToolApproval(streamCtx, flow.ToolApprovalResponseInput{
-					BotID:                  botID,
-					SessionID:              sessionID,
-					ActorChannelIdentityID: channelIdentityID,
-					ApprovalID:             strings.TrimSpace(msg.ApprovalID),
-					ExplicitID:             explicitID,
-					Decision:               strings.TrimSpace(msg.Decision),
-					Reason:                 strings.TrimSpace(msg.Reason),
-					ChatToken:              bearerToken,
-				}, eventCh); err != nil {
-					if connCtx.Err() == nil {
-						h.logger.Error("ws approval stream error", slog.Any("error", err), slog.String("bot_id", botID), slog.String("session_id", sessionID))
-						writer.SendJSON(map[string]string{"type": "error", "message": err.Error()})
-					}
-				}
-			}()
-
-			go func() {
-				converter := conversation.NewUIMessageStreamConverter()
-				for event := range eventCh {
-					processed := h.processWSEvent(streamCtx, botID, event)
-					for _, p := range processed {
-						if refs := extractAssetRefsFromProcessedEvent(p); len(refs) > 0 {
-							outboundAssetMu.Lock()
-							outboundAssetRefs = append(outboundAssetRefs, refs...)
-							outboundAssetMu.Unlock()
-						}
-
-						var streamEvent agentpkg.StreamEvent
-						if err := json.Unmarshal(p, &streamEvent); err != nil {
-							continue
-						}
-
-						switch streamEvent.Type {
-						case agentpkg.EventAgentStart:
-							writer.SendJSON(map[string]string{"type": "start"})
-							continue
-						case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort:
-							for _, uiMessage := range conversation.ConvertRawModelMessagesToUIAssistantMessages(streamEvent.Messages) {
-								writer.SendJSON(map[string]any{
-									"type": "message",
-									"data": uiMessage,
-								})
-							}
-							writer.SendJSON(map[string]string{"type": "end"})
-							continue
-						case agentpkg.EventError:
-							message := strings.TrimSpace(streamEvent.Error)
-							if message == "" {
-								message = "stream error"
-							}
-							writer.SendJSON(map[string]string{"type": "error", "message": message})
-							continue
-						}
-
-						uiEvents := converter.HandleEvent(uiStreamEventFromAgentEvent(streamEvent))
-						for _, uiMessage := range uiEvents {
-							writer.SendJSON(map[string]any{
-								"type": "message",
-								"data": uiMessage,
-							})
-						}
-					}
-				}
-				outboundAssetMu.Lock()
-				refs := outboundAssetRefs
-				outboundAssetMu.Unlock()
-				if len(refs) > 0 {
-					h.resolver.LinkOutboundAssets(streamBaseCtx, botID, sessionID, refs)
-				}
-			}()
 
 		case "message":
 			text := strings.TrimSpace(msg.Text)
 			sessionID := strings.TrimSpace(msg.SessionID)
+			streamID := strings.TrimSpace(msg.StreamID)
 
 			chatAttachments := parseWSClientAttachments(msg.Attachments)
 
+			if streamID == "" {
+				sendWSError(writer, "", sessionID, "stream_id is required")
+				continue
+			}
+			if sessionID == "" {
+				sendWSError(writer, streamID, "", "session_id is required")
+				continue
+			}
 			if text == "" && len(chatAttachments) == 0 {
-				writer.SendJSON(map[string]string{"type": "error", "message": "message text or attachments required"})
+				sendWSError(writer, streamID, sessionID, "message text or attachments required")
 				continue
 			}
 
-			// Drain any previous abort signal.
-			select {
-			case <-abortCh:
-			default:
-			}
-
-			streamCtx, streamCancel := context.WithCancel(streamBaseCtx)
-			activeCancel = streamCancel
-			eventCh := make(chan flow.WSStreamEvent, 64)
-
-			var (
-				outboundAssetMu   sync.Mutex
-				outboundAssetRefs []messagepkg.AssetRef
+			h.startWSStream(streamBaseCtx, connCtx, activeStreams, writer, botID, sessionID, streamID, "ws stream error",
+				func(ctx context.Context, eventCh chan<- flow.WSStreamEvent, abortCh <-chan struct{}) error {
+					req := conversation.ChatRequest{
+						BotID:                   botID,
+						ChatID:                  botID,
+						SessionID:               sessionID,
+						Token:                   bearerToken,
+						UserID:                  channelIdentityID,
+						SourceChannelIdentityID: channelIdentityID,
+						ConversationType:        channel.ConversationTypePrivate,
+						Query:                   text,
+						CurrentChannel:          h.channelType.String(),
+						Channels:                []string{h.channelType.String()},
+						Attachments:             chatAttachments,
+						Model:                   strings.TrimSpace(msg.ModelID),
+						ReasoningEffort:         strings.TrimSpace(msg.ReasoningEffort),
+					}
+					return h.resolver.StreamChatWS(ctx, req, eventCh, abortCh)
+				},
 			)
 
-			go func() {
-				defer streamCancel()
-				defer close(eventCh)
-				req := conversation.ChatRequest{
-					BotID:                   botID,
-					ChatID:                  botID,
-					SessionID:               sessionID,
-					Token:                   bearerToken,
-					UserID:                  channelIdentityID,
-					SourceChannelIdentityID: channelIdentityID,
-					ConversationType:        channel.ConversationTypePrivate,
-					Query:                   text,
-					CurrentChannel:          h.channelType.String(),
-					Channels:                []string{h.channelType.String()},
-					Attachments:             chatAttachments,
-					Model:                   strings.TrimSpace(msg.ModelID),
-					ReasoningEffort:         strings.TrimSpace(msg.ReasoningEffort),
-				}
-				if streamErr := h.resolver.StreamChatWS(streamCtx, req, eventCh, abortCh); streamErr != nil {
-					if connCtx.Err() == nil {
-						h.logger.Error("ws stream error", slog.Any("error", streamErr), slog.String("bot_id", botID), slog.String("session_id", sessionID))
-						writer.SendJSON(map[string]string{"type": "error", "message": streamErr.Error()})
-					}
-				}
-			}()
-
-			go func() {
-				converter := conversation.NewUIMessageStreamConverter()
-				for event := range eventCh {
-					processed := h.processWSEvent(streamCtx, botID, event)
-					for _, p := range processed {
-						if refs := extractAssetRefsFromProcessedEvent(p); len(refs) > 0 {
-							outboundAssetMu.Lock()
-							outboundAssetRefs = append(outboundAssetRefs, refs...)
-							outboundAssetMu.Unlock()
-						}
-
-						var streamEvent agentpkg.StreamEvent
-						if err := json.Unmarshal(p, &streamEvent); err != nil {
-							continue
-						}
-
-						switch streamEvent.Type {
-						case agentpkg.EventAgentStart:
-							writer.SendJSON(map[string]string{"type": "start"})
-							continue
-						case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort:
-							for _, uiMessage := range conversation.ConvertRawModelMessagesToUIAssistantMessages(streamEvent.Messages) {
-								writer.SendJSON(map[string]any{
-									"type": "message",
-									"data": uiMessage,
-								})
-							}
-							writer.SendJSON(map[string]string{"type": "end"})
-							continue
-						case agentpkg.EventError:
-							message := strings.TrimSpace(streamEvent.Error)
-							if message == "" {
-								message = "stream error"
-							}
-							writer.SendJSON(map[string]string{"type": "error", "message": message})
-							continue
-						}
-
-						uiEvents := converter.HandleEvent(uiStreamEventFromAgentEvent(streamEvent))
-						for _, uiMessage := range uiEvents {
-							writer.SendJSON(map[string]any{
-								"type": "message",
-								"data": uiMessage,
-							})
-						}
-					}
-				}
-				outboundAssetMu.Lock()
-				refs := outboundAssetRefs
-				outboundAssetMu.Unlock()
-				if len(refs) > 0 {
-					h.resolver.LinkOutboundAssets(streamBaseCtx, botID, sessionID, refs)
-				}
-			}()
-
 		default:
-			writer.SendJSON(map[string]string{"type": "error", "message": "unknown message type: " + msg.Type})
+			sendWSError(writer, strings.TrimSpace(msg.StreamID), strings.TrimSpace(msg.SessionID), "unknown message type: "+msg.Type)
 		}
 	}
-	_ = activeCancel
 	return nil
 }
 

--- a/internal/handlers/local_channel_test.go
+++ b/internal/handlers/local_channel_test.go
@@ -135,6 +135,67 @@ func TestWSWriterIgnoresLateSendsAfterClose(t *testing.T) {
 	}
 }
 
+func TestWSStreamRegistry_AbortsOnlyTargetStream(t *testing.T) {
+	t.Parallel()
+
+	registry := newWSStreamRegistry()
+	ctxA, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+	abortA := make(chan struct{}, 1)
+	abortB := make(chan struct{}, 1)
+
+	if err := registry.register(&activeWSStream{streamID: "stream-a", cancel: cancelA, abortCh: abortA}); err != nil {
+		t.Fatalf("register stream-a: %v", err)
+	}
+	if err := registry.register(&activeWSStream{streamID: "stream-b", cancel: cancelB, abortCh: abortB}); err != nil {
+		t.Fatalf("register stream-b: %v", err)
+	}
+
+	if !registry.abort("stream-a") {
+		t.Fatal("expected stream-a abort to succeed")
+	}
+
+	select {
+	case <-abortA:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream-a abort signal")
+	}
+	select {
+	case <-ctxA.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream-a context cancellation")
+	}
+	select {
+	case <-abortB:
+		t.Fatal("stream-b received abort signal")
+	default:
+	}
+	select {
+	case <-ctxB.Done():
+		t.Fatal("stream-b context was cancelled")
+	default:
+	}
+}
+
+func TestWSStreamRegistry_RejectsDuplicateStreamID(t *testing.T) {
+	t.Parallel()
+
+	registry := newWSStreamRegistry()
+	_, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	_, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+
+	if err := registry.register(&activeWSStream{streamID: "stream-a", cancel: cancelA, abortCh: make(chan struct{}, 1)}); err != nil {
+		t.Fatalf("register stream-a: %v", err)
+	}
+	if err := registry.register(&activeWSStream{streamID: "stream-a", cancel: cancelB, abortCh: make(chan struct{}, 1)}); err == nil {
+		t.Fatal("expected duplicate stream id registration to fail")
+	}
+}
+
 func TestWSIngestAttachments_RewritesContainerPathToAssetRef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/api.go
+++ b/internal/tui/api.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
+	"github.com/google/uuid"
 
 	"github.com/memohai/memoh/internal/bots"
 	"github.com/memohai/memoh/internal/conversation"
@@ -181,6 +182,7 @@ func (c *Client) StreamChat(ctx context.Context, req ChatRequest, onEvent func(C
 
 	payload := map[string]string{
 		"type":       "message",
+		"stream_id":  uuid.NewString(),
 		"text":       req.Text,
 		"session_id": req.SessionID,
 	}


### PR DESCRIPTION
## Summary

- add client-generated `stream_id` to WebSocket message and tool approval requests
- echo `stream_id` on WebSocket stream lifecycle events and route frontend pending streams by it
- make WebSocket abort target a specific stream instead of shared active state
- update TUI WebSocket requests to include `stream_id`
- add focused tests for interleaved stream routing and targeted abort

Fixes #517

## Verification

- `go test ./internal/handlers ./internal/tui ./internal/conversation/flow`
- `pnpm --filter @memohai/web exec vitest run src/store/chat-list.test.ts src/composables/api/useChat.ws.test.ts`
- pre-commit hook: Go tests and staged frontend eslint passed
