### PR TITLE
feat(agent): emit tool_call_input_start for immediate tool block render

### DIFF
--- a/apps/web/src/pages/home/components/tool-call-detail-edit.vue
+++ b/apps/web/src/pages/home/components/tool-call-detail-edit.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, watch } from 'vue'
 import { LoaderCircle } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import type { ToolCallBlock } from '@/store/chat-list'
@@ -50,11 +50,18 @@ const newText = computed(() => {
 
 const hasChanges = computed(() => Boolean(oldText.value || newText.value))
 
-onMounted(() => {
-  if (hasChanges.value) {
-    void shiki.highlightDiff(oldText.value, newText.value, extractFilename(filePath.value))
-  }
-})
+// Re-highlight whenever the diff arrives. Input now streams in after the tool
+// block first renders (tool_call_input_start), so an onMounted-only highlight
+// would miss content that lands later.
+watch(
+  [oldText, newText, filePath],
+  ([oldT, newT, path]) => {
+    if (oldT || newT) {
+      void shiki.highlightDiff(oldT, newT, extractFilename(path))
+    }
+  },
+  { immediate: true },
+)
 </script>
 
 <style>

--- a/apps/web/src/pages/home/components/tool-call-detail-write.vue
+++ b/apps/web/src/pages/home/components/tool-call-detail-write.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, watch } from 'vue'
 import { LoaderCircle } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import type { ToolCallBlock } from '@/store/chat-list'
@@ -43,9 +43,16 @@ const content = computed(() => {
   return (input?.content as string) ?? ''
 })
 
-onMounted(() => {
-  if (content.value) {
-    void shiki.highlight(content.value, extractFilename(filePath.value))
-  }
-})
+// Re-highlight whenever content arrives. Input now streams in after the tool
+// block first renders (tool_call_input_start), so an onMounted-only highlight
+// would miss the content that lands later.
+watch(
+  [content, filePath],
+  ([text, path]) => {
+    if (text) {
+      void shiki.highlight(text, extractFilename(path))
+    }
+  },
+  { immediate: true },
+)
 </script>

--- a/apps/web/src/pages/home/components/tool-call-inline.vue
+++ b/apps/web/src/pages/home/components/tool-call-inline.vue
@@ -15,10 +15,10 @@
         class="size-3.5 shrink-0"
       />
       <span
-        v-if="!display.hideAction"
+        v-if="showActionLabel"
         class="shrink-0"
         :class="actionClass"
-      >{{ actionLabel }}</span>
+      >{{ renderedActionLabel }}</span>
       <button
         v-if="display.target && canOpenInFiles"
         class="font-mono truncate hover:underline cursor-pointer"
@@ -70,10 +70,10 @@
         class="size-3.5 shrink-0"
       />
       <span
-        v-if="!display.hideAction"
+        v-if="showActionLabel"
         class="shrink-0"
         :class="actionClass"
-      >{{ actionLabel }}</span>
+      >{{ renderedActionLabel }}</span>
       <button
         v-if="display.target && canOpenInFiles"
         class="font-mono truncate hover:underline cursor-pointer"
@@ -108,7 +108,7 @@
     </div>
 
     <div
-      v-if="expandable && open"
+      v-if="expandable && open && !isPending"
       class="mt-1 ml-5 py-1 space-y-1.5"
     >
       <component
@@ -179,6 +179,40 @@ const actionLabel = computed(() => {
   return t(key, display.value.actionParams ?? {})
 })
 
+// A tool is "pending" while it is running and its input arguments have not
+// streamed in yet (tool_call_input_start fires before the full call). In that
+// window tools like write/edit hide their action label and have no target, so
+// only a bare icon would show. We surface a placeholder label instead.
+const isPending = computed(() => {
+  if (props.block.done) return false
+  const input = props.block.input
+  return !(
+    input
+    && typeof input === 'object'
+    && Object.keys(input as Record<string, unknown>).length > 0
+  )
+})
+
+const showsBareIconWhenPending = computed(
+  () => display.value.hideAction === true && !display.value.target,
+)
+
+const showPendingLabel = computed(
+  () => isPending.value && showsBareIconWhenPending.value,
+)
+
+const pendingLabel = computed(
+  () => t(`chat.tools.pending.${display.value.actionKey}`, t('chat.tools.pending.generic')),
+)
+
+const showActionLabel = computed(
+  () => showPendingLabel.value || !display.value.hideAction,
+)
+
+const renderedActionLabel = computed(
+  () => (showPendingLabel.value ? pendingLabel.value : actionLabel.value),
+)
+
 const rowClass = computed(() => {
   if (!expandable.value) {
     return display.value.isError ? 'text-destructive' : 'text-muted-foreground'
@@ -226,6 +260,7 @@ const targetClass = computed(() => {
 })
 
 const actionClass = computed(() => {
+  if (showPendingLabel.value) return 'tool-shimmer-text'
   if (showRunning.value && !display.value.target) return 'tool-shimmer-text'
   return ''
 })

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -337,12 +337,21 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 
 		case *sdk.ToolInputStartPart:
 			// ToolInputStartPart fires before tool input args have streamed.
-			// We suppress it here because downstream consumers (IM adapters and
-			// Web UI) only care about the fully-assembled call announced by
-			// StreamToolCallPart below. Emitting a start event twice for the
-			// same CallID would produce duplicate "running" messages in IMs.
+			// We emit a lightweight tool_call_input_start (name + call ID, no
+			// input) so the Web UI can render the tool block immediately while
+			// arguments are still streaming. StreamToolCallPart below backfills
+			// the fully-assembled Input under the same call ID. IM/Discuss
+			// adapters do not map tool_call_input_start, so they keep their
+			// single-start behavior and avoid duplicate "running" messages.
 			if textLoopProbeBuffer != nil {
 				textLoopProbeBuffer.Flush()
+			}
+			if !sendEvent(ctx, ch, StreamEvent{
+				Type:       EventToolCallInputStart,
+				ToolName:   p.ToolName,
+				ToolCallID: p.ID,
+			}) {
+				aborted = true
 			}
 
 		case *sdk.StreamToolCallPart:
@@ -1120,11 +1129,18 @@ func (a *Agent) runMidStreamRetry(
 					aborted = true
 				}
 			case *sdk.ToolInputStartPart:
-				// See ToolInputStartPart note above: suppress the early start
-				// and rely on StreamToolCallPart (which carries the fully
-				// assembled Input) as the single source of truth.
+				// See ToolInputStartPart note above: emit a lightweight
+				// tool_call_input_start so the Web UI shows the tool block while
+				// arguments stream; StreamToolCallPart backfills the Input.
 				if textLoopProbeBuffer != nil {
 					textLoopProbeBuffer.Flush()
+				}
+				if !sendEvent(sendCtx, ch, StreamEvent{
+					Type:       EventToolCallInputStart,
+					ToolName:   rp.ToolName,
+					ToolCallID: rp.ID,
+				}) {
+					aborted = true
 				}
 			case *sdk.StreamToolCallPart:
 				if textLoopProbeBuffer != nil {

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -13,6 +13,7 @@ const (
 	EventReasoningStart      StreamEventType = "reasoning_start"
 	EventReasoningDelta      StreamEventType = "reasoning_delta"
 	EventReasoningEnd        StreamEventType = "reasoning_end"
+	EventToolCallInputStart  StreamEventType = "tool_call_input_start"
 	EventToolCallStart       StreamEventType = "tool_call_start"
 	EventToolCallProgress    StreamEventType = "tool_call_progress"
 	EventToolCallEnd         StreamEventType = "tool_call_end"

--- a/internal/agent/stream_test.go
+++ b/internal/agent/stream_test.go
@@ -46,12 +46,14 @@ func (*agentToolPlaceholderProvider) DoStream(_ context.Context, _ sdk.GenerateP
 	return &sdk.StreamResult{Stream: ch}, nil
 }
 
-// TestAgentStreamEmitsToolCallStartOnceWithInput asserts that each tool call
-// produces exactly one EventToolCallStart with the fully-assembled Input, even
-// though the underlying SDK emits a preliminary ToolInputStartPart (no input)
-// followed by a StreamToolCallPart (with input). Emitting two start events per
-// call caused duplicate "running" messages in IM adapters.
-func TestAgentStreamEmitsToolCallStartOnceWithInput(t *testing.T) {
+// TestAgentStreamEmitsToolCallInputStartThenStart asserts that a tool call
+// produces a lightweight EventToolCallInputStart (name + call ID, no input)
+// when the SDK emits ToolInputStartPart, followed by a EventToolCallStart
+// carrying the fully-assembled Input when StreamToolCallPart arrives. The
+// early input-start lets the Web UI render the tool block while arguments are
+// still streaming, while IM adapters (which do not map input-start) keep their
+// single-start behavior and avoid duplicate "running" messages.
+func TestAgentStreamEmitsToolCallInputStartThenStart(t *testing.T) {
 	t.Parallel()
 
 	a := New(Deps{})
@@ -69,20 +71,26 @@ func TestAgentStreamEmitsToolCallStartOnceWithInput(t *testing.T) {
 		events = append(events, event)
 	}
 
-	if len(events) != 3 {
-		t.Fatalf("expected 3 events, got %d: %#v", len(events), events)
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d: %#v", len(events), events)
 	}
 	if events[0].Type != EventAgentStart {
 		t.Fatalf("expected first event %q, got %#v", EventAgentStart, events[0])
 	}
-	if events[1].Type != EventToolCallStart || events[1].ToolCallID != "call-1" || events[1].ToolName != "write" {
-		t.Fatalf("unexpected tool call start event: %#v", events[1])
+	if events[1].Type != EventToolCallInputStart || events[1].ToolCallID != "call-1" || events[1].ToolName != "write" {
+		t.Fatalf("unexpected tool call input start event: %#v", events[1])
+	}
+	if events[1].Input != nil {
+		t.Fatalf("expected tool call input start to carry no input, got %#v", events[1].Input)
+	}
+	if events[2].Type != EventToolCallStart || events[2].ToolCallID != "call-1" || events[2].ToolName != "write" {
+		t.Fatalf("unexpected tool call start event: %#v", events[2])
 	}
 	expectedInput := map[string]any{"path": "/tmp/long.txt"}
-	if !reflect.DeepEqual(events[1].Input, expectedInput) {
-		t.Fatalf("expected tool call start input %#v, got %#v", expectedInput, events[1].Input)
+	if !reflect.DeepEqual(events[2].Input, expectedInput) {
+		t.Fatalf("expected tool call start input %#v, got %#v", expectedInput, events[2].Input)
 	}
-	if events[2].Type != EventAgentEnd {
-		t.Fatalf("expected terminal event %q, got %#v", EventAgentEnd, events[2])
+	if events[3].Type != EventAgentEnd {
+		t.Fatalf("expected terminal event %q, got %#v", EventAgentEnd, events[3])
 	}
 }

--- a/internal/conversation/flow/resolver_stream.go
+++ b/internal/conversation/flow/resolver_stream.go
@@ -34,6 +34,7 @@ func isVisibleAgentStreamEvent(event agentpkg.StreamEvent) bool {
 		agentpkg.EventReasoningStart,
 		agentpkg.EventReasoningDelta,
 		agentpkg.EventReasoningEnd,
+		agentpkg.EventToolCallInputStart,
 		agentpkg.EventToolCallStart,
 		agentpkg.EventToolCallProgress,
 		agentpkg.EventToolCallEnd,

--- a/internal/conversation/uimessage_stream.go
+++ b/internal/conversation/uimessage_stream.go
@@ -67,7 +67,7 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 		c.reasoning = nil
 		return nil
 
-	case "tool_call_start":
+	case "tool_call_start", "tool_call_input_start":
 		state := c.findToolState(event.ToolCallID, event.ToolName)
 		if state == nil {
 			state = &uiToolStreamState{

--- a/internal/conversation/uimessage_test.go
+++ b/internal/conversation/uimessage_test.go
@@ -468,6 +468,63 @@ func TestUIMessageStreamConverterMergesRepeatedToolCallStart(t *testing.T) {
 	}
 }
 
+func TestUIMessageStreamConverterToolCallInputStartThenStartBackfillsInput(t *testing.T) {
+	t.Parallel()
+
+	converter := NewUIMessageStreamConverter()
+
+	inputStart := converter.HandleEvent(UIMessageStreamEvent{
+		Type:       "tool_call_input_start",
+		ToolName:   "write",
+		ToolCallID: "call-1",
+	})
+	if len(inputStart) != 1 || inputStart[0].Type != UIMessageTool {
+		t.Fatalf("unexpected initial tool placeholder: %#v", inputStart)
+	}
+	if inputStart[0].Input != nil {
+		t.Fatalf("expected input-start placeholder to have nil input, got %#v", inputStart[0].Input)
+	}
+	if inputStart[0].Running == nil || !*inputStart[0].Running {
+		t.Fatalf("expected input-start placeholder to be running, got %#v", inputStart[0])
+	}
+
+	fullInput := map[string]any{"path": "/tmp/long.txt"}
+	start := converter.HandleEvent(UIMessageStreamEvent{
+		Type:       "tool_call_start",
+		ToolName:   "write",
+		ToolCallID: "call-1",
+		Input:      fullInput,
+	})
+	if len(start) != 1 {
+		t.Fatalf("expected one updated tool snapshot, got %#v", start)
+	}
+	if start[0].ID != inputStart[0].ID {
+		t.Fatalf("expected tool start to reuse message id, got input-start=%d start=%d", inputStart[0].ID, start[0].ID)
+	}
+	if !reflect.DeepEqual(start[0].Input, fullInput) {
+		t.Fatalf("expected tool start to backfill input, got %#v", start[0].Input)
+	}
+	if start[0].Running == nil || !*start[0].Running {
+		t.Fatalf("expected merged tool message to stay running, got %#v", start[0])
+	}
+
+	end := converter.HandleEvent(UIMessageStreamEvent{
+		Type:       "tool_call_end",
+		ToolName:   "write",
+		ToolCallID: "call-1",
+		Output:     map[string]any{"ok": true},
+	})
+	if len(end) != 1 || end[0].ID != inputStart[0].ID {
+		t.Fatalf("expected tool end to reuse merged message id, got %#v", end)
+	}
+	if !reflect.DeepEqual(end[0].Input, fullInput) {
+		t.Fatalf("expected tool end to preserve merged input, got %#v", end[0].Input)
+	}
+	if end[0].Running == nil || *end[0].Running {
+		t.Fatalf("expected tool end to mark message complete, got %#v", end[0])
+	}
+}
+
 func TestUIMessageStreamConverterKeepsParallelSameNameToolCallsSeparate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- 在模型开始流式输出工具入参时，发出轻量的 `tool_call_input_start` 事件（仅工具名 + call ID，无 input），让 Web UI 能立即渲染工具块，而无需等待完整入参。
- `StreamToolCallPart` 仍会在同一 call ID 下回填完整的 `Input`。
- IM/Discuss 适配器保持原有的单次 start 行为，避免重复的 "running" 消息。
- Web UI 侧（`tool-call-inline` / `tool-call-detail-edit` / `tool-call-detail-write`）增加 pending 工具块渲染。

## Changes
- 后端：`internal/agent/agent.go`、`stream.go`、`internal/conversation/flow/resolver_stream.go`、`uimessage_stream.go`（+ 对应测试）
- 前端：`apps/web/src/pages/home/components/tool-call-*.vue`

## Test plan
- [ ] `go test ./internal/agent/... ./internal/conversation/...`
- [ ] 手动验证：触发一次工具调用，观察 Web UI 在入参流式期间即显示工具块，完成后正常回填
- [ ] 确认 IM/Discuss 渠道无重复 "running" 消息