### PR TITLE
fix(web): use transcription providers in model select

### DIFF
--- a/apps/web/src/pages/bots/components/bot-settings.vue
+++ b/apps/web/src/pages/bots/components/bot-settings.vue
@@ -108,6 +108,7 @@
         :tts-models="ttsModels"
         :tts-providers="ttsProviders"
         :transcription-models="transcriptionModels"
+        :transcription-providers="transcriptionProviders"
         :image-capable-models="imageCapableModels"
         :providers="providers"
       />

--- a/apps/web/src/pages/bots/components/settings-multimedia-card.vue
+++ b/apps/web/src/pages/bots/components/settings-multimedia-card.vue
@@ -29,7 +29,7 @@
         <TtsModelSelect
           v-model="form.transcription_model_id"
           :models="transcriptionModels"
-          :providers="ttsProviders"
+          :providers="transcriptionProviders"
           :placeholder="$t('bots.settings.transcriptionModelPlaceholder')"
           show-icons
         />
@@ -63,6 +63,7 @@ import type {
   AudioSpeechModelResponse, 
   AudioSpeechProviderResponse, 
   AudioTranscriptionModelResponse,
+  AudioTranscriptionProviderResponse,
   ModelsGetResponse,
   ProvidersGetResponse
 } from '@memohai/sdk'
@@ -72,6 +73,7 @@ defineProps<{
   ttsModels: AudioSpeechModelResponse[]
   ttsProviders: AudioSpeechProviderResponse[]
   transcriptionModels: AudioTranscriptionModelResponse[]
+  transcriptionProviders: AudioTranscriptionProviderResponse[]
   imageCapableModels: ModelsGetResponse[]
   providers: ProvidersGetResponse[]
 }>()


### PR DESCRIPTION
## Summary
- Pass transcription providers into the bot multimedia settings card.
- Use transcription provider metadata for the transcription model select instead of TTS providers.

## Root cause
The transcription model select received `ttsProviders` while rendering transcription models. When a transcription model provider was not present in the TTS provider list, the select fell back to the provider UUID as the group label.

## Validation
- `pnpm --filter @memohai/web build`
- `pnpm exec lint-staged`

Notes: the build still prints the existing lightningcss warnings for `.about-markdown-container :deep(...)` and chunk size warnings; they are outside this change.