### PR TITLE
feat(botbackup): export/import long-term memory

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -22,6 +22,7 @@
     "viewAll": "View All",
     "import": "Import",
     "export": "Export",
+    "done": "Done",
     "copy": "Copy",
     "copied": "Copied to clipboard",
     "tabAddSingle": "Add single",
@@ -1231,6 +1232,7 @@
         "email": "Email bindings",
         "history": "Chat history",
         "assets": "Attachments",
+        "memory": "Long-term memory",
         "workspace": "Workspace files"
       },
       "previewSchema": "Backup schema version: {version}",
@@ -1238,7 +1240,34 @@
       "exportFailed": "Failed to export bot backup",
       "previewFailed": "Failed to preview backup",
       "importSuccess": "Bot backup imported",
-      "importFailed": "Failed to import bot backup"
+      "importFailed": "Failed to import bot backup",
+      "memoryRebuild": {
+        "title": "Rebuild memory index",
+        "loading": "Checking memory status…",
+        "variant": {
+          "dense": "Imported memory is stored, but its dense vector index needs to be rebuilt before it becomes searchable.",
+          "sparse": "Imported memory is stored, but its sparse index needs to be rebuilt before it becomes searchable.",
+          "mem0": "Imported memory files need to be synced to Mem0 before they become searchable.",
+          "generic": "Imported memory needs to be rebuilt before it becomes searchable."
+        },
+        "selectModel": "Embedding model",
+        "selectModelHint": "Dense memory needs an embedding model to build its vector index.",
+        "selectModelPlaceholder": "Select an embedding model",
+        "selectModelRequired": "Choose an embedding model to enable the rebuild.",
+        "sourceInfo": "{count} memory item(s) ready to index.",
+        "action": {
+          "dense": "Save & rebuild",
+          "sparse": "Rebuild index",
+          "mem0": "Sync to Mem0",
+          "generic": "Rebuild index"
+        },
+        "skip": "Skip for now",
+        "statusFailed": "Failed to load memory status",
+        "success": "Memory rebuilt — {count} item(s) indexed",
+        "failed": "Failed to rebuild memory index",
+        "resultTitle": "Memory index rebuilt",
+        "resultDetail": "{restored} of {total} item(s) indexed."
+      }
     },
     "checks": {
       "lastSync": "Last synced",
@@ -1579,6 +1608,7 @@
       "mem0StatusHint": "Markdown files are the source of truth. Syncing rebuilds Mem0 memories from /data/memory.",
       "indexedMemoryStatusPendingSave": "Save the selected memory provider before viewing indexed memory status or running a sync.",
       "memorySyncAction": "Manual Sync",
+      "memoryIndexStale": "Memory index is behind its source ({source} entries vs {indexed} indexed). Rebuild to make it searchable.",
       "memorySyncSuccess": "Sync completed: {fsCount} source entries, {restoredCount} restored, {storageCount} indexed.",
       "memorySyncFailed": "Manual sync failed",
       "memorySourceDir": "Memory Directory",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -22,6 +22,7 @@
     "viewAll": "查看全部",
     "import": "导入",
     "export": "导出",
+    "done": "完成",
     "copy": "复制",
     "copied": "已复制到剪贴板",
     "tabAddSingle": "添加单个",
@@ -1227,6 +1228,7 @@
         "email": "邮箱绑定",
         "history": "聊天历史",
         "assets": "附件",
+        "memory": "长期记忆",
         "workspace": "工作区文件"
       },
       "previewSchema": "备份格式版本：{version}",
@@ -1234,7 +1236,34 @@
       "exportFailed": "导出 Bot 备份失败",
       "previewFailed": "预览备份失败",
       "importSuccess": "Bot 备份已导入",
-      "importFailed": "导入 Bot 备份失败"
+      "importFailed": "导入 Bot 备份失败",
+      "memoryRebuild": {
+        "title": "重建记忆索引",
+        "loading": "正在检查记忆状态…",
+        "variant": {
+          "dense": "记忆内容已导入，但其稠密向量索引需要重建后才能被检索。",
+          "sparse": "记忆内容已导入，但其稀疏索引需要重建后才能被检索。",
+          "mem0": "导入的记忆文件需要同步到 Mem0 后才能被检索。",
+          "generic": "导入的记忆需要重建后才能被检索。"
+        },
+        "selectModel": "嵌入模型",
+        "selectModelHint": "稠密记忆需要一个嵌入模型来构建向量索引。",
+        "selectModelPlaceholder": "选择嵌入模型",
+        "selectModelRequired": "请选择嵌入模型后再重建。",
+        "sourceInfo": "共有 {count} 条记忆待建立索引。",
+        "action": {
+          "dense": "保存并重建",
+          "sparse": "重建索引",
+          "mem0": "同步到 Mem0",
+          "generic": "重建索引"
+        },
+        "skip": "暂时跳过",
+        "statusFailed": "加载记忆状态失败",
+        "success": "记忆已重建 —— 已索引 {count} 条",
+        "failed": "重建记忆索引失败",
+        "resultTitle": "记忆索引已重建",
+        "resultDetail": "已索引 {restored} / {total} 条。"
+      }
     },
     "checks": {
       "lastSync": "上次同步",
@@ -1575,6 +1604,7 @@
       "mem0StatusHint": "Markdown 文件是唯一可信源；手动同步将把 /data/memory 中的条目重新同步至 Mem0。",
       "indexedMemoryStatusPendingSave": "请在查看索引状态或执行同步前，先保存所选的记忆提供方。",
       "memorySyncAction": "手动同步",
+      "memoryIndexStale": "记忆索引落后于来源（来源 {source} 条，已索引 {indexed} 条）。请重建后才能检索。",
       "memorySyncSuccess": "同步完成：源条目 {fsCount} 条，修复 {restoredCount} 条，索引现有 {storageCount} 条。",
       "memorySyncFailed": "手动同步失败",
       "memorySourceDir": "记忆目录",

--- a/apps/web/src/pages/bots/components/backup-section-cards.vue
+++ b/apps/web/src/pages/bots/components/backup-section-cards.vue
@@ -15,6 +15,7 @@ import {
   MessageCircle,
   Paperclip,
   HardDrive,
+  Brain,
   type LucideIcon,
 } from 'lucide-vue-next'
 
@@ -61,6 +62,7 @@ const iconMap: Record<string, LucideIcon> = {
   email: Mail,
   history: MessageCircle,
   assets: Paperclip,
+  memory: Brain,
   workspace: HardDrive,
 }
 

--- a/apps/web/src/pages/bots/components/bot-backup-actions.vue
+++ b/apps/web/src/pages/bots/components/bot-backup-actions.vue
@@ -44,7 +44,7 @@ const summary = ref<BotbackupSummaryResult | null>(null)
 const exportPassphrase = ref('')
 
 const EXPORT_SECTIONS = [
-  'settings', 'models', 'acl', 'channels', 'mcp', 'schedules', 'email', 'history', 'assets', 'workspace',
+  'settings', 'models', 'acl', 'channels', 'mcp', 'schedules', 'email', 'history', 'assets', 'memory', 'workspace',
 ] as const
 
 const exportSections = reactive<Record<string, 'skip' | 'merge' | 'replace'>>({})

--- a/apps/web/src/pages/bots/components/bot-import-panel.vue
+++ b/apps/web/src/pages/bots/components/bot-import-panel.vue
@@ -23,6 +23,7 @@ import { resolveApiErrorMessage } from '@/utils/api-error'
 import { formatFileSize } from '@/components/file-manager/utils'
 import { uploadWithProgress } from '@/lib/upload-with-progress'
 import BackupSectionCards from './backup-section-cards.vue'
+import MemoryRebuildStep from './memory-rebuild-step.vue'
 
 type SectionState = 'skip' | 'merge' | 'replace'
 
@@ -48,6 +49,9 @@ const preview = ref<BotbackupPreviewResult | null>(null)
 const previewError = ref('')
 const passphrase = ref('')
 const uploadPercent = ref(0)
+// When an import leaves a stale memory index, we hold the new bot id here and
+// show the rebuild step instead of finishing immediately.
+const finalizeBotId = ref<string | null>(null)
 
 const allowOverwrite = computed(() => !!props.targetBotId)
 const importMode = ref<'create' | 'overwrite'>('create')
@@ -61,7 +65,7 @@ const isOverwrite = computed(() => allowOverwrite.value && importMode.value === 
 // Canonical section order. Every section is always shown; those absent from the
 // backup (or empty) are rendered disabled so users see the full picture.
 const ALL_SECTIONS = [
-  'settings', 'models', 'acl', 'channels', 'mcp', 'schedules', 'email', 'history', 'assets', 'workspace',
+  'settings', 'models', 'acl', 'channels', 'mcp', 'schedules', 'email', 'history', 'assets', 'memory', 'workspace',
 ] as const
 
 const sectionItems = computed(() => {
@@ -204,6 +208,12 @@ async function handleImport() {
     if (data.warnings?.length) {
       toast.warning(t('bots.backup.importWarnings', { count: data.warnings.length }))
     }
+    // A restored file-backed memory index is stale: keep the panel open on a
+    // rebuild step instead of navigating away, so the user can finish the job.
+    if (data.bot_id && data.memory_needs_rebuild) {
+      finalizeBotId.value = data.bot_id
+      return
+    }
     clearFile()
     if (data.bot_id) emit('imported', data.bot_id)
   } catch (error) {
@@ -212,10 +222,25 @@ async function handleImport() {
     importing.value = false
   }
 }
+
+function handleFinalizeDone() {
+  const botId = finalizeBotId.value
+  finalizeBotId.value = null
+  clearFile()
+  if (botId) emit('imported', botId)
+}
 </script>
 
 <template>
-  <div class="flex min-h-0 flex-1 flex-col gap-3">
+  <MemoryRebuildStep
+    v-if="finalizeBotId"
+    :bot-id="finalizeBotId"
+    @done="handleFinalizeDone"
+  />
+  <div
+    v-else
+    class="flex min-h-0 flex-1 flex-col gap-3"
+  >
     <input
       ref="fileInput"
       type="file"

--- a/apps/web/src/pages/bots/components/memory-rebuild-step.vue
+++ b/apps/web/src/pages/bots/components/memory-rebuild-step.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { toast } from 'vue-sonner'
+import { Button, Label, Spinner } from '@memohai/ui'
+import { Brain, Check } from 'lucide-vue-next'
+import {
+  getBotsByBotIdMemoryStatus,
+  getBotsByBotIdSettings,
+  getMemoryProvidersById,
+  getModels,
+  getProviders,
+  postBotsByBotIdMemoryRebuild,
+  putMemoryProvidersById,
+  type AdaptersMemoryStatusResponse,
+  type AdaptersRebuildResult,
+  type ModelsGetResponse,
+  type ProvidersGetResponse,
+} from '@memohai/sdk'
+import { resolveApiErrorMessage } from '@/utils/api-error'
+import ModelSelect from './model-select.vue'
+
+// Post-import finalize step: a restored bot's file-backed memory (built-in
+// sparse/dense Qdrant, or Mem0 SaaS) arrives as files but its derived index is
+// stale. This guides the user to rebuild it, and — for dense memory missing a
+// usable embedding model — lets them pick one before rebuilding.
+const props = defineProps<{ botId: string }>()
+const emit = defineEmits<{ done: [] }>()
+const { t } = useI18n()
+
+const loading = ref(true)
+const status = ref<AdaptersMemoryStatusResponse | null>(null)
+const memoryProviderId = ref('')
+const providerConfig = ref<Record<string, unknown>>({})
+const embeddingModelId = ref('')
+const models = ref<ModelsGetResponse[]>([])
+const providers = ref<ProvidersGetResponse[]>([])
+const rebuilding = ref(false)
+const savingModel = ref(false)
+const result = ref<AdaptersRebuildResult | null>(null)
+
+const providerType = computed(() => status.value?.provider_type ?? '')
+const memoryMode = computed(() => status.value?.memory_mode ?? '')
+const sourceCount = computed(() => status.value?.source_count ?? 0)
+const needsEmbedding = computed(() => providerType.value === 'builtin' && memoryMode.value === 'dense')
+
+const variantKey = computed<'dense' | 'sparse' | 'mem0' | 'generic'>(() => {
+  if (providerType.value === 'mem0') return 'mem0'
+  if (providerType.value === 'builtin' && memoryMode.value === 'dense') return 'dense'
+  if (providerType.value === 'builtin' && memoryMode.value === 'sparse') return 'sparse'
+  return 'generic'
+})
+
+const canRebuild = computed(() => {
+  if (rebuilding.value || savingModel.value || loading.value) return false
+  if (needsEmbedding.value) return !!embeddingModelId.value.trim()
+  return true
+})
+
+onMounted(load)
+
+async function load() {
+  loading.value = true
+  try {
+    const [{ data: st }, { data: settings }] = await Promise.all([
+      getBotsByBotIdMemoryStatus({ path: { bot_id: props.botId }, throwOnError: true }),
+      getBotsByBotIdSettings({ path: { bot_id: props.botId }, throwOnError: true }),
+    ])
+    status.value = st ?? null
+    memoryProviderId.value = settings?.memory_provider_id ?? ''
+    if (needsEmbedding.value) await loadEmbeddingOptions()
+  } catch (error) {
+    toast.error(resolveApiErrorMessage(error, t('bots.backup.memoryRebuild.statusFailed')))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadEmbeddingOptions() {
+  const tasks: Promise<unknown>[] = [
+    getModels({ throwOnError: true }).then(({ data }) => { models.value = data ?? [] }),
+    getProviders({ throwOnError: true }).then(({ data }) => { providers.value = data ?? [] }),
+  ]
+  if (memoryProviderId.value) {
+    tasks.push(
+      getMemoryProvidersById({ path: { id: memoryProviderId.value }, throwOnError: true }).then(({ data }) => {
+        providerConfig.value = (data?.config as Record<string, unknown>) ?? {}
+        const current = providerConfig.value.embedding_model_id
+        embeddingModelId.value = typeof current === 'string' ? current : ''
+      }),
+    )
+  }
+  await Promise.all(tasks)
+}
+
+async function handleRebuild() {
+  if (!canRebuild.value) return
+  try {
+    // A changed embedding model is persisted on the shared memory provider
+    // before the rebuild so the dense encoder can come up.
+    if (needsEmbedding.value && memoryProviderId.value) {
+      const current = typeof providerConfig.value.embedding_model_id === 'string' ? providerConfig.value.embedding_model_id : ''
+      if (embeddingModelId.value && embeddingModelId.value !== current) {
+        savingModel.value = true
+        await putMemoryProvidersById({
+          path: { id: memoryProviderId.value },
+          body: { config: { ...providerConfig.value, memory_mode: 'dense', embedding_model_id: embeddingModelId.value } },
+          throwOnError: true,
+        })
+        providerConfig.value = { ...providerConfig.value, embedding_model_id: embeddingModelId.value }
+        savingModel.value = false
+      }
+    }
+    rebuilding.value = true
+    const { data } = await postBotsByBotIdMemoryRebuild({ path: { bot_id: props.botId }, throwOnError: true })
+    result.value = data ?? null
+    toast.success(t('bots.backup.memoryRebuild.success', { count: data?.restored_count ?? 0 }))
+  } catch (error) {
+    toast.error(resolveApiErrorMessage(error, t('bots.backup.memoryRebuild.failed')))
+  } finally {
+    rebuilding.value = false
+    savingModel.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="flex min-h-0 flex-1 flex-col gap-3">
+    <div class="flex-1 space-y-3 overflow-y-auto px-0.5">
+      <div class="flex items-start gap-3 rounded-md border border-border/60 bg-background p-3">
+        <div class="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <Brain class="size-4" />
+        </div>
+        <div class="min-w-0 flex-1 space-y-0.5">
+          <p class="text-xs font-medium">
+            {{ t('bots.backup.memoryRebuild.title') }}
+          </p>
+          <p class="text-[11px] text-muted-foreground">
+            {{ t(`bots.backup.memoryRebuild.variant.${variantKey}`) }}
+          </p>
+        </div>
+      </div>
+
+      <div
+        v-if="loading"
+        class="flex items-center gap-2 rounded-md border border-border/60 bg-background p-3 text-xs text-muted-foreground"
+      >
+        <Spinner />
+        {{ t('bots.backup.memoryRebuild.loading') }}
+      </div>
+
+      <!-- Rebuild result -->
+      <div
+        v-else-if="result"
+        class="space-y-1 rounded-md border border-success-border bg-success-soft p-3 text-xs text-success-foreground"
+      >
+        <div class="flex items-center gap-1.5 font-medium">
+          <Check class="size-3.5" />
+          {{ t('bots.backup.memoryRebuild.resultTitle') }}
+        </div>
+        <p class="text-[11px]">
+          {{ t('bots.backup.memoryRebuild.resultDetail', { restored: result.restored_count ?? 0, total: result.fs_count ?? 0 }) }}
+        </p>
+      </div>
+
+      <template v-else>
+        <!-- Dense: embedding model picker -->
+        <div
+          v-if="needsEmbedding"
+          class="space-y-2 rounded-md border border-border/60 bg-background p-3"
+        >
+          <Label class="text-xs">{{ t('bots.backup.memoryRebuild.selectModel') }}</Label>
+          <p class="text-[11px] text-muted-foreground">
+            {{ t('bots.backup.memoryRebuild.selectModelHint') }}
+          </p>
+          <ModelSelect
+            v-model="embeddingModelId"
+            :models="models"
+            :providers="providers"
+            model-type="embedding"
+            :placeholder="t('bots.backup.memoryRebuild.selectModelPlaceholder')"
+          />
+          <p
+            v-if="!embeddingModelId"
+            class="text-[11px] text-warning-foreground"
+          >
+            {{ t('bots.backup.memoryRebuild.selectModelRequired') }}
+          </p>
+        </div>
+
+        <p
+          v-if="sourceCount > 0"
+          class="px-0.5 text-[11px] text-muted-foreground"
+        >
+          {{ t('bots.backup.memoryRebuild.sourceInfo', { count: sourceCount }) }}
+        </p>
+      </template>
+    </div>
+
+    <!-- Actions -->
+    <div class="shrink-0 space-y-2 border-t pt-3">
+      <div class="flex justify-end gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          :disabled="rebuilding || savingModel"
+          @click="emit('done')"
+        >
+          {{ result ? t('common.done') : t('bots.backup.memoryRebuild.skip') }}
+        </Button>
+        <Button
+          v-if="!result"
+          size="sm"
+          :disabled="!canRebuild"
+          @click="handleRebuild"
+        >
+          <Spinner
+            v-if="rebuilding || savingModel"
+            class="mr-1.5"
+          />
+          {{ t(`bots.backup.memoryRebuild.action.${variantKey}`) }}
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/web/src/pages/bots/components/settings-context-card.vue
+++ b/apps/web/src/pages/bots/components/settings-context-card.vue
@@ -73,7 +73,32 @@
               </Button>
             </div>
           </div>
-          
+
+          <div
+            v-if="memoryIndexStale"
+            class="flex items-center justify-between gap-2 rounded-md border border-warning-border bg-warning-soft px-3 py-2"
+          >
+            <div class="flex min-w-0 items-center gap-2">
+              <TriangleAlert class="size-3.5 shrink-0 text-warning-foreground" />
+              <p class="truncate text-[11px] text-warning-foreground">
+                {{ $t('bots.settings.memoryIndexStale', { source: statusCardData?.source_count ?? 0, indexed: statusCardData?.indexed_count ?? 0 }) }}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              :disabled="isRebuilding"
+              class="h-7 shrink-0 bg-background px-3 text-xs shadow-none"
+              @click="$emit('sync-memory')"
+            >
+              <Spinner
+                v-if="isRebuilding"
+                class="mr-1.5 size-3"
+              />
+              {{ $t('bots.settings.memorySyncAction') }}
+            </Button>
+          </div>
+
           <div
             v-if="showDetails && isSelectedMemoryProviderPersisted"
             class="grid gap-2 sm:grid-cols-3"
@@ -196,7 +221,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { Label, Button, Spinner } from '@memohai/ui'
-import { ChevronDown } from 'lucide-vue-next'
+import { ChevronDown, TriangleAlert } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import SearchProviderSelect from './search-provider-select.vue'
 import MemoryProviderSelect from './memory-provider-select.vue'
@@ -258,6 +283,13 @@ const indexedMemoryStatusTitle = computed(() =>
 )
 
 const statusCardData = computed(() => props.memoryStatus)
+// The derived index lags the source files (e.g. after a backup import that
+// restored memory files but never rebuilt). Prompt a rebuild.
+const memoryIndexStale = computed(() => {
+  const s = props.memoryStatus
+  if (!s || !isSelectedMemoryProviderPersisted.value || !s.can_manual_sync) return false
+  return (s.source_count ?? 0) > (s.indexed_count ?? 0)
+})
 const showQdrantDetails = computed(() =>
   selectedBuiltinMemoryMode.value === 'sparse' || selectedBuiltinMemoryMode.value === 'dense',
 )

--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -569,7 +569,7 @@ func provideContainerdHandler(log *slog.Logger, manager *workspace.Manager, cfg 
 	return handlers.NewContainerdHandler(log, manager, cfg.Workspace, rc.ContainerBackend, botService, accountService, policyService)
 }
 
-func provideBotBackupService(log *slog.Logger, conn *pgxpool.Pool, queries dbstore.Queries, botService *bots.Service, settingsService *settings.Service, aclService *acl.Service, channelStore *channel.Store, mcpService *mcp.ConnectionService, scheduleService *schedule.Service, emailService *emailpkg.Service, providerService *providers.Service, modelsService *models.Service, searchProviderService *searchproviders.Service, memoryProviderService *memprovider.Service, manager *workspace.Manager) *botbackup.Service {
+func provideBotBackupService(log *slog.Logger, conn *pgxpool.Pool, queries dbstore.Queries, botService *bots.Service, settingsService *settings.Service, aclService *acl.Service, channelStore *channel.Store, mcpService *mcp.ConnectionService, scheduleService *schedule.Service, emailService *emailpkg.Service, providerService *providers.Service, modelsService *models.Service, searchProviderService *searchproviders.Service, memoryProviderService *memprovider.Service, memoryRegistry *memprovider.Registry, manager *workspace.Manager) *botbackup.Service {
 	return botbackup.New(botbackup.Params{
 		Logger:          log,
 		DB:              conn,
@@ -585,6 +585,7 @@ func provideBotBackupService(log *slog.Logger, conn *pgxpool.Pool, queries dbsto
 		Models:          modelsService,
 		SearchProviders: searchProviderService,
 		MemoryProviders: memoryProviderService,
+		MemoryRegistry:  memoryRegistry,
 		Workspace:       manager,
 	})
 }

--- a/internal/botbackup/backup_flow_test.go
+++ b/internal/botbackup/backup_flow_test.go
@@ -41,6 +41,7 @@ func buildSampleBundle(t *testing.T) []byte {
 	write("history/sessions.json", "history", []map[string]any{{"title": "chat 1", "type": "conversation"}})
 	write("history/messages.json", "history", []map[string]any{{"id": "1"}, {"id": "2"}, {"id": "3"}})
 	write("assets/message_assets.json", "assets", []map[string]any{{"name": "image.png"}})
+	write(memoryEntriesPath, "memory_entries", []map[string]any{{"id": "m1", "memory": "likes coffee"}, {"id": "m2", "memory": "based in NYC"}})
 
 	if err := w.writeStream(workspaceArchivePath, bytes.NewReader(sampleTarGz(t)), 0o640, time.Time{}, zip.Store); err != nil {
 		t.Fatalf("writeStream(workspace) error = %v", err)
@@ -104,6 +105,9 @@ func TestPreviewPlainBundleRoundTrip(t *testing.T) {
 	}
 	if got := sectionCount(preview.Sections, SectionWorkspace); got != 1 {
 		t.Fatalf("workspace count = %d, want 1", got)
+	}
+	if got := sectionCount(preview.Sections, SectionMemory); got != 2 {
+		t.Fatalf("memory count = %d, want 2", got)
 	}
 	if preview.RestorePlan.Mode != ImportModeCreate {
 		t.Fatalf("restore mode = %q, want create", preview.RestorePlan.Mode)
@@ -247,5 +251,50 @@ func TestMCPRequestFromConnection(t *testing.T) {
 	}
 	if sse.Headers["Authorization"] != "Bearer x" {
 		t.Fatalf("sse headers = %v", sse.Headers)
+	}
+}
+
+func TestIsFileBackedMemoryType(t *testing.T) {
+	// Built-in and Mem0 keep memory as files under /data (workspace section);
+	// an unset type defaults to built-in. Only external services are not.
+	for _, tt := range []struct {
+		providerType string
+		want         bool
+	}{
+		{"builtin", true},
+		{"mem0", true},
+		{"", true},
+		{"openviking", false},
+		{"unknown", false},
+	} {
+		if got := isFileBackedMemoryType(tt.providerType); got != tt.want {
+			t.Fatalf("isFileBackedMemoryType(%q) = %v, want %v", tt.providerType, got, tt.want)
+		}
+	}
+}
+
+func TestRemapEmbeddingModel(t *testing.T) {
+	models := map[string]string{"src-embed": "dst-embed"}
+
+	// A known source id is remapped to its imported counterpart.
+	cfg := map[string]any{"memory_mode": "dense", "embedding_model_id": "src-embed"}
+	remapEmbeddingModel(cfg, models)
+	if cfg["embedding_model_id"] != "dst-embed" {
+		t.Fatalf("embedding_model_id = %v, want dst-embed", cfg["embedding_model_id"])
+	}
+
+	// An unknown id (e.g. a bare model_id string) is left untouched.
+	cfg = map[string]any{"embedding_model_id": "text-embedding-3-small"}
+	remapEmbeddingModel(cfg, models)
+	if cfg["embedding_model_id"] != "text-embedding-3-small" {
+		t.Fatalf("embedding_model_id = %v, want unchanged", cfg["embedding_model_id"])
+	}
+
+	// Nil config and missing key are no-ops.
+	remapEmbeddingModel(nil, models)
+	cfg = map[string]any{"memory_mode": "sparse"}
+	remapEmbeddingModel(cfg, models)
+	if _, ok := cfg["embedding_model_id"]; ok {
+		t.Fatal("remapEmbeddingModel should not add embedding_model_id when absent")
 	}
 }

--- a/internal/botbackup/import.go
+++ b/internal/botbackup/import.go
@@ -178,6 +178,7 @@ func (s *Service) targetSectionCounts(ctx context.Context, botID string) map[Sec
 			out[SectionHistory] = len(msgs)
 		}
 	}
+	out[SectionMemory] = s.targetMemoryCount(ctx, botID)
 	return out
 }
 
@@ -287,6 +288,8 @@ func summarizeSections(entries map[string]backupZipEntry) []SectionSummary {
 		jsonArrayLabels(entries["history/sessions.json"].data, sectionItemLimit, "title", "type"))
 	add(SectionAssets, "assets/message_assets.json", countArrayEntry(entries, "assets/message_assets.json"),
 		jsonArrayLabels(entries["assets/message_assets.json"].data, sectionItemLimit, "name"))
+	add(SectionMemory, memoryEntriesPath, countArrayEntry(entries, memoryEntriesPath),
+		jsonArrayLabels(entries[memoryEntriesPath].data, sectionItemLimit, "memory"))
 	if hasWorkspaceEntries(entries) {
 		out = append(out, SectionSummary{
 			Key:   SectionWorkspace,
@@ -504,7 +507,13 @@ func (s *Service) Import(ctx context.Context, actorUserID string, raw []byte, op
 	}
 
 	committed = true
-	return ImportResult{BotID: targetBotID, Created: created, Warnings: state.warnings, Imported: state.counts}, nil
+	return ImportResult{
+		BotID:              targetBotID,
+		Created:            created,
+		Warnings:           state.warnings,
+		Imported:           state.counts,
+		MemoryNeedsRebuild: s.memoryNeedsRebuild(ctx, targetBotID, state),
+	}, nil
 }
 
 // applyRestore runs every selected section in order. A returned error is fatal
@@ -574,6 +583,11 @@ func (s *Service) applyRestore(ctx context.Context, actorUserID, targetBotID str
 		if err := restore("history import failed", func() error {
 			return s.restoreHistory(ctx, targetBotID, state, opts.wants(SectionAssets), replace)
 		}); err != nil {
+			return err
+		}
+	}
+	if opts.wants(SectionMemory) {
+		if err := restore("memory import failed", func() error { return s.restoreMemory(ctx, targetBotID, state) }); err != nil {
 			return err
 		}
 	}
@@ -687,7 +701,7 @@ func (s *Service) importDependencies(ctx context.Context, state *importState) (d
 	}
 	memoryProviders, _ := readEntry[[]memprovider.ProviderGetResponse](state, "dependencies/memory_providers.json")
 	for _, item := range memoryProviders {
-		id, err := s.ensureMemoryProvider(ctx, item)
+		id, err := s.ensureMemoryProvider(ctx, item, deps)
 		if err != nil {
 			state.warnings = append(state.warnings, "memory provider dependency skipped: "+err.Error())
 			continue
@@ -1174,10 +1188,15 @@ func (s *Service) ensureSearchProvider(ctx context.Context, item searchpkg.GetRe
 	return created.ID, nil
 }
 
-func (s *Service) ensureMemoryProvider(ctx context.Context, item memprovider.ProviderGetResponse) (string, error) {
+func (s *Service) ensureMemoryProvider(ctx context.Context, item memprovider.ProviderGetResponse, deps dependencyMap) (string, error) {
 	if s.memoryProviders == nil {
 		return item.ID, errors.New("memory provider service not configured")
 	}
+	// A dense built-in provider references an embedding model by id inside its
+	// config. Remap that reference through the imported models so the restored
+	// provider points at the target's freshly-imported model rather than the
+	// source's id (which would be dangling on the target and break dense memory).
+	remapEmbeddingModel(item.Config, deps.models)
 	list, _ := s.memoryProviders.List(ctx)
 	for _, existing := range list {
 		if existing.Name == item.Name {
@@ -1193,6 +1212,23 @@ func (s *Service) ensureMemoryProvider(ctx context.Context, item memprovider.Pro
 		return "", err
 	}
 	return created.ID, nil
+}
+
+// remapEmbeddingModel rewrites a memory provider config's embedding_model_id
+// from a source model id to its imported counterpart, when one exists. A value
+// that is not a known source id (e.g. a bare model_id string, or already valid
+// on the target) is left untouched.
+func remapEmbeddingModel(config map[string]any, models map[string]string) {
+	if config == nil {
+		return
+	}
+	raw, ok := config["embedding_model_id"].(string)
+	if !ok {
+		return
+	}
+	if mapped := strings.TrimSpace(models[strings.TrimSpace(raw)]); mapped != "" {
+		config["embedding_model_id"] = mapped
+	}
 }
 
 func (s *Service) ensureEmailProvider(ctx context.Context, item emailpkg.ProviderResponse) (string, error) {

--- a/internal/botbackup/memory.go
+++ b/internal/botbackup/memory.go
@@ -1,0 +1,209 @@
+package botbackup
+
+import (
+	"context"
+	"strings"
+
+	memprovider "github.com/memohai/memoh/internal/memory/adapters"
+)
+
+// memoryProviderRef captures the resolved memory backend for a bot: its DB id,
+// provider type, and (for built-in) the memory_mode. It lets the backup decide
+// whether memory is file-backed (rides the workspace /data tree) or external
+// (must be exported/imported through the provider's own API).
+type memoryProviderRef struct {
+	id           string
+	providerType string
+	mode         string
+}
+
+// isFileBackedMemoryType reports whether a provider keeps its canonical memory
+// as files under the workspace /data tree. Those backends (built-in, Mem0) are
+// captured by the workspace section and rebuilt from files after import, so the
+// dedicated memory section is reserved for external services (e.g. OpenViking).
+func isFileBackedMemoryType(providerType string) bool {
+	switch memprovider.ProviderType(strings.TrimSpace(providerType)) {
+	case memprovider.ProviderBuiltin, memprovider.ProviderMem0, "":
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveMemoryProvider returns the memory backend a bot currently uses. An
+// unset provider falls back to the built-in default (file-backed, off mode).
+func (s *Service) resolveMemoryProvider(ctx context.Context, botID string) memoryProviderRef {
+	ref := memoryProviderRef{providerType: string(memprovider.ProviderBuiltin)}
+	if s.settings == nil {
+		return ref
+	}
+	cfg, err := s.settings.GetBot(ctx, botID)
+	if err != nil {
+		return ref
+	}
+	providerID := strings.TrimSpace(cfg.MemoryProviderID)
+	if providerID == "" || s.memoryProviders == nil {
+		return ref
+	}
+	resp, err := s.memoryProviders.Get(ctx, providerID)
+	if err != nil {
+		return ref
+	}
+	ref.id = providerID
+	ref.providerType = resp.Provider
+	ref.mode = strings.TrimSpace(memprovider.StringFromConfig(resp.Config, "memory_mode"))
+	return ref
+}
+
+// readExternalMemory pulls every memory entry for a bot from an external
+// provider via its GetAll API. File-backed providers return no entries here.
+func (s *Service) readExternalMemory(ctx context.Context, botID string, ref memoryProviderRef) ([]memprovider.MemoryItem, error) {
+	if s.memoryRegistry == nil || ref.id == "" {
+		return nil, nil
+	}
+	p, err := s.memoryRegistry.Get(ref.id)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.GetAll(ctx, memprovider.GetAllRequest{BotID: botID, NoStats: true})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Results, nil
+}
+
+// writeMemory exports long-term memory for external providers as a
+// backend-agnostic entries.json. Built-in/Mem0 memory is intentionally skipped:
+// it lives as files under /data and is captured by the workspace section.
+func (s *Service) writeMemory(ctx context.Context, botID string, writer *zipBackupWriter, opts ExportOptions) error {
+	ref := s.resolveMemoryProvider(ctx, botID)
+	if isFileBackedMemoryType(ref.providerType) {
+		return nil
+	}
+	items, err := s.readExternalMemory(ctx, botID, ref)
+	if err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	return writer.writeJSON(memoryEntriesPath, "memory_entries", items, opts)
+}
+
+// summarizeMemory reports the exportable memory entry count for the export
+// dialog. File-backed memory reports 0 because it ships inside the workspace
+// section rather than as standalone entries.
+func (s *Service) summarizeMemory(ctx context.Context, botID string) SectionSummary {
+	out := SectionSummary{Key: SectionMemory}
+	ref := s.resolveMemoryProvider(ctx, botID)
+	if isFileBackedMemoryType(ref.providerType) {
+		return out
+	}
+	items, err := s.readExternalMemory(ctx, botID, ref)
+	if err != nil {
+		return out
+	}
+	out.Count = len(items)
+	out.Items = memoryEntryLabels(items, sectionItemLimit)
+	return out
+}
+
+// targetMemoryCount returns how many memory entries the target bot already has,
+// for overwrite-mode conflict detection. Best-effort: 0 when unknown.
+func (s *Service) targetMemoryCount(ctx context.Context, botID string) int {
+	ref := s.resolveMemoryProvider(ctx, botID)
+	if isFileBackedMemoryType(ref.providerType) {
+		return 0
+	}
+	items, err := s.readExternalMemory(ctx, botID, ref)
+	if err != nil {
+		return 0
+	}
+	return len(items)
+}
+
+// restoreMemory re-ingests external memory entries into the target bot's
+// provider. It only applies to external backends; if the target bot resolves to
+// a file-backed provider (or none), the entries are skipped with a warning since
+// they cannot be meaningfully reinserted there.
+func (s *Service) restoreMemory(ctx context.Context, targetBotID string, state *importState) error {
+	entry, ok := state.entries[memoryEntriesPath]
+	if !ok || len(entry.data) == 0 {
+		return nil
+	}
+	var items []memprovider.MemoryItem
+	if err := unmarshalJSON(entry.data, &items); err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	ref := s.resolveMemoryProvider(ctx, targetBotID)
+	if s.memoryRegistry == nil || ref.id == "" || isFileBackedMemoryType(ref.providerType) {
+		state.warnings = append(state.warnings, "memory entries skipped: target bot has no external memory provider")
+		return nil
+	}
+	p, err := s.memoryRegistry.Get(ref.id)
+	if err != nil {
+		state.warnings = append(state.warnings, "memory entries skipped: "+err.Error())
+		return nil
+	}
+	infer := false
+	restored := 0
+	for _, item := range items {
+		text := strings.TrimSpace(item.Memory)
+		if text == "" {
+			continue
+		}
+		if _, addErr := p.Add(ctx, memprovider.AddRequest{
+			Message: text,
+			BotID:   targetBotID,
+			Infer:   &infer,
+		}); addErr != nil {
+			if err := state.itemErr("memory entry", addErr); err != nil {
+				return err
+			}
+			continue
+		}
+		restored++
+	}
+	state.counts[SectionMemory] = restored
+	return nil
+}
+
+// memoryNeedsRebuild reports whether the imported memory left a derived index
+// (built-in sparse/dense Qdrant or Mem0 SaaS) stale. That happens when the
+// file-backed memory arrived via the workspace section but its index has not
+// been rebuilt yet. External providers persist on write and never need this;
+// built-in "off" mode keeps no index at all.
+func (s *Service) memoryNeedsRebuild(ctx context.Context, botID string, state *importState) bool {
+	if state.counts[SectionWorkspace] <= 0 {
+		return false
+	}
+	ref := s.resolveMemoryProvider(ctx, botID)
+	if !isFileBackedMemoryType(ref.providerType) {
+		return false
+	}
+	if memprovider.ProviderType(ref.providerType) == memprovider.ProviderBuiltin {
+		mode := strings.ToLower(ref.mode)
+		if mode == "" || mode == "off" {
+			return false
+		}
+	}
+	return true
+}
+
+func memoryEntryLabels(items []memprovider.MemoryItem, limit int) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		text := strings.TrimSpace(item.Memory)
+		if text == "" {
+			continue
+		}
+		out = append(out, text)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}

--- a/internal/botbackup/service.go
+++ b/internal/botbackup/service.go
@@ -58,6 +58,7 @@ type Service struct {
 	models          *modelpkg.Service
 	searchProviders *searchpkg.Service
 	memoryProviders *memprovider.Service
+	memoryRegistry  *memprovider.Registry
 	workspace       WorkspaceData
 }
 
@@ -76,6 +77,7 @@ type Params struct {
 	Models          *modelpkg.Service
 	SearchProviders *searchpkg.Service
 	MemoryProviders *memprovider.Service
+	MemoryRegistry  *memprovider.Registry
 	Workspace       WorkspaceData
 }
 
@@ -99,6 +101,7 @@ func New(params Params) *Service {
 		models:          params.Models,
 		searchProviders: params.SearchProviders,
 		memoryProviders: params.MemoryProviders,
+		memoryRegistry:  params.MemoryRegistry,
 		workspace:       params.Workspace,
 	}
 }
@@ -197,6 +200,11 @@ func (s *Service) Export(ctx context.Context, botID string, opts ExportOptions, 
 	if opts.wants(SectionAssets) {
 		if err := writer.writeJSON("assets/message_assets.json", "bot_message_assets", data.History.Assets, opts); err != nil {
 			return err
+		}
+	}
+	if opts.wants(SectionMemory) {
+		if err := s.writeMemory(ctx, botID, writer, opts); err != nil {
+			manifest.Warnings = append(manifest.Warnings, "memory export failed: "+err.Error())
 		}
 	}
 	if opts.wants(SectionWorkspace) && s.workspace != nil {

--- a/internal/botbackup/summary.go
+++ b/internal/botbackup/summary.go
@@ -65,6 +65,7 @@ func (s *Service) Summary(ctx context.Context, botID string) (SummaryResult, err
 	add(SectionEmail, data.EmailBindings, "email_address")
 	res.Sections = append(res.Sections, s.summarizeHistory(ctx, botID))
 	res.Sections = append(res.Sections, s.summarizeAssets(ctx, botID))
+	res.Sections = append(res.Sections, s.summarizeMemory(ctx, botID))
 	res.Sections = append(res.Sections, s.summarizeWorkspace(ctx, botID))
 	return res, nil
 }

--- a/internal/botbackup/types.go
+++ b/internal/botbackup/types.go
@@ -10,6 +10,11 @@ const (
 	// workspaceArchivePath is the single zip entry holding the container's
 	// /data tar.gz verbatim (no re-packing on export/import).
 	workspaceArchivePath = "workspace/data.tar.gz"
+	// memoryEntriesPath holds long-term memory entries as a backend-agnostic
+	// JSON array. It is only written for providers whose canonical data lives
+	// outside the workspace /data tree (e.g. external services like OpenViking);
+	// built-in/Mem0 memory rides the workspace section as files under /data.
+	memoryEntriesPath = "memory/entries.json"
 )
 
 // Section identifies a selectable group of data within a backup. On import,
@@ -28,6 +33,7 @@ const (
 	SectionEmail     Section = "email"
 	SectionHistory   Section = "history"
 	SectionAssets    Section = "assets"
+	SectionMemory    Section = "memory"
 	SectionWorkspace Section = "workspace"
 )
 
@@ -35,7 +41,7 @@ const (
 // profile is always exported (it identifies the bot) and is not user-toggleable.
 var AllExportSections = []Section{
 	SectionSettings, SectionModels, SectionACL, SectionChannels, SectionMCP,
-	SectionSchedules, SectionEmail, SectionHistory, SectionAssets, SectionWorkspace,
+	SectionSchedules, SectionEmail, SectionHistory, SectionAssets, SectionMemory, SectionWorkspace,
 }
 
 // isSensitiveSection reports whether a section may carry API keys or other
@@ -203,6 +209,12 @@ type ImportResult struct {
 	// Imported reports how many items were restored per section, powering the
 	// post-import summary in the UI.
 	Imported map[Section]int `json:"imported,omitempty"`
+	// MemoryNeedsRebuild signals that the restored memory has a derived index
+	// (built-in sparse/dense Qdrant, or Mem0 SaaS) that is now stale and should
+	// be rebuilt before it becomes searchable. The UI uses this to guide the
+	// user to the rebuild step. External providers (e.g. OpenViking) persist on
+	// write and never need a rebuild, so this stays false for them.
+	MemoryNeedsRebuild bool `json:"memory_needs_rebuild,omitempty"`
 }
 
 type backupData struct {

--- a/packages/sdk/src/@pinia/colada.gen.ts
+++ b/packages/sdk/src/@pinia/colada.gen.ts
@@ -2969,7 +2969,7 @@ export const putProvidersByIdMutation = (options?: Partial<Options<PutProvidersB
 /**
  * Import models from provider
  *
- * Fetch models from provider's /v1/models endpoint and import them
+ * Fetch models from provider and import them
  */
 export const postProvidersByIdImportModelsMutation = (options?: Partial<Options<PostProvidersByIdImportModelsData>>): UseMutationOptions<PostProvidersByIdImportModelsResponse, Options<PostProvidersByIdImportModelsData>, PostProvidersByIdImportModelsError> => ({
     mutation: async (vars) => {

--- a/packages/sdk/src/sdk.gen.ts
+++ b/packages/sdk/src/sdk.gen.ts
@@ -1624,7 +1624,7 @@ export const putProvidersById = <ThrowOnError extends boolean = false>(options: 
 /**
  * Import models from provider
  *
- * Fetch models from provider's /v1/models endpoint and import them
+ * Fetch models from provider and import them
  */
 export const postProvidersByIdImportModels = <ThrowOnError extends boolean = false>(options: Options<PostProvidersByIdImportModelsData, ThrowOnError>) => (options.client ?? client).post<PostProvidersByIdImportModelsResponses, PostProvidersByIdImportModelsErrors, ThrowOnError>({ url: '/providers/{id}/import-models', ...options });
 

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -499,6 +499,14 @@ export type BotbackupImportResult = {
     imported?: {
         [key: string]: number;
     };
+    /**
+     * MemoryNeedsRebuild signals that the restored memory has a derived index
+     * (built-in sparse/dense Qdrant, or Mem0 SaaS) that is now stale and should
+     * be rebuilt before it becomes searchable. The UI uses this to guide the
+     * user to the rebuild step. External providers (e.g. OpenViking) persist on
+     * write and never need a rebuild, so this stays false for them.
+     */
+    memory_needs_rebuild?: boolean;
     warnings?: Array<string>;
 };
 
@@ -560,7 +568,7 @@ export type BotbackupRestorePlan = {
     will_restore_workspace?: boolean;
 };
 
-export type BotbackupSection = 'profile' | 'settings' | 'models' | 'acl' | 'channels' | 'mcp' | 'schedules' | 'email' | 'history' | 'assets' | 'workspace';
+export type BotbackupSection = 'profile' | 'settings' | 'models' | 'acl' | 'channels' | 'mcp' | 'schedules' | 'email' | 'history' | 'assets' | 'memory' | 'workspace';
 
 export type BotbackupSectionSummary = {
     conflict?: boolean;

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -8252,7 +8252,7 @@ const docTemplate = `{
         },
         "/providers/{id}/import-models": {
             "post": {
-                "description": "Fetch models from provider's /v1/models endpoint and import them",
+                "description": "Fetch models from provider and import them",
                 "consumes": [
                     "application/json"
                 ],
@@ -11464,6 +11464,10 @@ const docTemplate = `{
                         "type": "integer"
                     }
                 },
+                "memory_needs_rebuild": {
+                    "description": "MemoryNeedsRebuild signals that the restored memory has a derived index\n(built-in sparse/dense Qdrant, or Mem0 SaaS) that is now stale and should\nbe rebuilt before it becomes searchable. The UI uses this to guide the\nuser to the rebuild step. External providers (e.g. OpenViking) persist on\nwrite and never need a rebuild, so this stays false for them.",
+                    "type": "boolean"
+                },
                 "warnings": {
                     "type": "array",
                     "items": {
@@ -11633,6 +11637,7 @@ const docTemplate = `{
                 "email",
                 "history",
                 "assets",
+                "memory",
                 "workspace"
             ],
             "x-enum-varnames": [
@@ -11646,6 +11651,7 @@ const docTemplate = `{
                 "SectionEmail",
                 "SectionHistory",
                 "SectionAssets",
+                "SectionMemory",
                 "SectionWorkspace"
             ]
         },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -8243,7 +8243,7 @@
         },
         "/providers/{id}/import-models": {
             "post": {
-                "description": "Fetch models from provider's /v1/models endpoint and import them",
+                "description": "Fetch models from provider and import them",
                 "consumes": [
                     "application/json"
                 ],
@@ -11455,6 +11455,10 @@
                         "type": "integer"
                     }
                 },
+                "memory_needs_rebuild": {
+                    "description": "MemoryNeedsRebuild signals that the restored memory has a derived index\n(built-in sparse/dense Qdrant, or Mem0 SaaS) that is now stale and should\nbe rebuilt before it becomes searchable. The UI uses this to guide the\nuser to the rebuild step. External providers (e.g. OpenViking) persist on\nwrite and never need a rebuild, so this stays false for them.",
+                    "type": "boolean"
+                },
                 "warnings": {
                     "type": "array",
                     "items": {
@@ -11624,6 +11628,7 @@
                 "email",
                 "history",
                 "assets",
+                "memory",
                 "workspace"
             ],
             "x-enum-varnames": [
@@ -11637,6 +11642,7 @@
                 "SectionEmail",
                 "SectionHistory",
                 "SectionAssets",
+                "SectionMemory",
                 "SectionWorkspace"
             ]
         },

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -807,6 +807,14 @@ definitions:
           Imported reports how many items were restored per section, powering the
           post-import summary in the UI.
         type: object
+      memory_needs_rebuild:
+        description: |-
+          MemoryNeedsRebuild signals that the restored memory has a derived index
+          (built-in sparse/dense Qdrant, or Mem0 SaaS) that is now stale and should
+          be rebuilt before it becomes searchable. The UI uses this to guide the
+          user to the rebuild step. External providers (e.g. OpenViking) persist on
+          write and never need a rebuild, so this stays false for them.
+        type: boolean
       warnings:
         items:
           type: string
@@ -925,6 +933,7 @@ definitions:
     - email
     - history
     - assets
+    - memory
     - workspace
     type: string
     x-enum-varnames:
@@ -938,6 +947,7 @@ definitions:
     - SectionEmail
     - SectionHistory
     - SectionAssets
+    - SectionMemory
     - SectionWorkspace
   botbackup.SectionSummary:
     properties:
@@ -8919,7 +8929,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Fetch models from provider's /v1/models endpoint and import them
+      description: Fetch models from provider and import them
       parameters:
       - description: Provider ID (UUID)
         in: path


### PR DESCRIPTION
## Summary

Adds long-term **memory** to bot backup/restore, plus post-import guidance to rebuild a file-backed memory index.

- **External providers (e.g. OpenViking)** — a new `memory` section exports entries via `GetAll` and re-imports them via `Add`, since their data lives outside the workspace `/data` tree.
- **Built-in / Mem0 (file-backed)** — memory keeps riding the existing **Workspace** `/data` section as files. The backup deliberately never reads memory over the bridge: `ExportData` stops the container during export, so a live bridge read would be fragile and backend-inconsistent.
- **Fix `embedding_model_id` remap** — `ensureMemoryProvider` now remaps a dense provider's `embedding_model_id` through the imported models, so restored dense memory points at a valid model instead of a dangling source id.
- **Rebuild guidance** — `ImportResult.memory_needs_rebuild` flags a stale derived index after a workspace import. The import dialog then shows an adaptive rebuild step:
  - dense → embedding-model picker (saves the shared provider config, then rebuilds)
  - sparse → local rebuild · Mem0 → sync · or **skip**
  - The memory settings card also shows an "index behind source" banner (`source_count > indexed_count`).

## Files

- Backend: `internal/botbackup/{types,service,import,summary}.go`, new `internal/botbackup/memory.go`, `cmd/agent/app.go` (inject `*memprovider.Registry`)
- Frontend: new `memory-rebuild-step.vue`, `bot-import-panel.vue`, `settings-context-card.vue`, `backup-section-cards.vue`, `bot-backup-actions.vue`, i18n (en/zh)
- Generated: swagger + SDK

## Test plan

- [x] `go build ./...`, `go test ./internal/botbackup/...`, full pre-commit Go test suite, `golangci-lint`
- [x] `pnpm --filter @memohai/web build`, ESLint on changed files
- [ ] **Manual E2E not yet done** (reason this PR is a draft):
  - [ ] Export/import a bot using OpenViking memory → entries round-trip
  - [ ] Import a built-in **sparse** bot with workspace → rebuild step appears → index becomes searchable
  - [ ] Import a built-in **dense** bot with a missing/invalid embedding model → picker required → save + rebuild works
  - [ ] Import a **Mem0** bot → "sync to Mem0" path
  - [ ] "Index behind source" banner shows on the memory settings card and clears after rebuild
  - [ ] Built-in memory with no workspace selected → no false rebuild prompt