### PR TITLE
fix: smooth background exec handoff UX

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -61,7 +61,7 @@
               </div>
 
               <div
-                v-for="(msg, msgIndex) in messages"
+                v-for="(msg, msgIndex) in visibleMessages"
                 :key="msg.id"
                 :data-message-id="msg.id"
                 :data-scroll-segment-id="messageSegmentDomId(msg, msgIndex)"
@@ -243,7 +243,7 @@
                     class="h-auto min-h-8 w-full justify-start whitespace-normal rounded-md px-2.5 py-1.5 text-left text-xs"
                     :class="selectedPendingUserInputOptionId === option.id ? 'bg-muted text-foreground' : 'text-foreground hover:bg-accent'"
                     :title="option.description || option.label"
-                    :disabled="streaming"
+                    :disabled="busy"
                     :aria-pressed="selectedPendingUserInputOptionId === option.id"
                     @click="selectPendingUserInputOption(option)"
                   >
@@ -265,7 +265,7 @@
                     v-model="pendingUserInputAnswer"
                     class="h-8 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     :placeholder="pendingUserInputOptionPlaceholder"
-                    :disabled="streaming"
+                    :disabled="busy"
                     @keydown.enter.prevent="handlePendingUserInputSubmit"
                   >
                 </div>
@@ -275,7 +275,7 @@
                     size="sm"
                     variant="ghost"
                     class="text-xs text-muted-foreground hover:text-foreground"
-                    :disabled="streaming"
+                    :disabled="busy"
                     @click="handlePendingUserInputCancel"
                   >
                     {{ $t('chat.tools.cancelUserInput') }}
@@ -284,7 +284,7 @@
                     type="button"
                     size="sm"
                     class="text-xs"
-                    :disabled="streaming || !canSubmitPendingUserInput"
+                    :disabled="busy || !canSubmitPendingUserInput"
                     @click="handlePendingUserInputSubmit"
                   >
                     {{ $t('chat.tools.submitUserInput') }}
@@ -549,7 +549,7 @@
                   type="button"
                   size="sm"
                   variant="ghost"
-                  :disabled="!currentBotId || activeChatReadOnly || streaming"
+                  :disabled="!currentBotId || activeChatReadOnly || busy"
                   aria-label="Attach files"
                   @click="fileInput?.click()"
                 >
@@ -567,7 +567,7 @@
                 />
 
                 <Button
-                  v-if="!streaming"
+                  v-if="!busy"
                   type="button"
                   size="icon"
                   :disabled="(!inputText.trim() && !pendingFiles.length) || !currentBotId || activeChatReadOnly"
@@ -583,8 +583,9 @@
                   size="icon"
                   variant="destructive"
                   class="size-7 rounded-full"
-                  aria-label="Stop generating response"
-                  @click="chatStore.abort()"
+                  :aria-label="streaming ? 'Stop generating response' : 'Waiting for background task'"
+                  :aria-disabled="!streaming"
+                  @click="streaming && chatStore.abort()"
                 >
                   <LoaderCircle class="size-3.5 animate-spin" />
                 </Button>
@@ -666,6 +667,8 @@ const inputDrafts = useStorage<Record<string, string>>('chat-input-drafts', {})
 const {
   messages,
   streaming,
+  busy,
+  backgroundHandoff,
   currentBotId,
   bots,
   activeSession,
@@ -811,7 +814,23 @@ const activeACPProjectLabel = computed(() => {
   const parts = path.split('/').filter(Boolean)
   return path ? parts[parts.length - 1] ?? path : t('chat.noProject')
 })
-const canChangeAgent = computed(() => !streaming.value && messages.value.length === 0)
+const canChangeAgent = computed(() => !busy.value && messages.value.length === 0)
+const backgroundHandoffMessage = computed<ChatMessage | null>(() => {
+  if (!backgroundHandoff.value || streaming.value) return null
+  const sid = chatStore.sessionId?.trim() || activeSessionId.value || 'current'
+  const latestAssistant = [...messages.value].reverse().find(message => message.role === 'assistant')
+  return {
+    id: `background-handoff-${sid}`,
+    role: 'assistant',
+    messages: [],
+    timestamp: latestAssistant?.timestamp ?? new Date().toISOString(),
+    streaming: true,
+  }
+})
+const visibleMessages = computed<ChatMessage[]>(() => {
+  const handoff = backgroundHandoffMessage.value
+  return handoff ? [...messages.value, handoff] : messages.value
+})
 const activeSessionId = computed(() => activeSession.value?.id ?? '')
 const {
   runtime: acpRuntime,
@@ -1675,7 +1694,7 @@ async function handleSend() {
   // isAutoScroll.value = true
   const text = inputText.value.trim()
   const files = [...pendingFiles.value]
-  if ((!text && !files.length) || streaming.value || activeChatReadOnly.value) return
+  if ((!text && !files.length) || busy.value || activeChatReadOnly.value) return
   if (activeIsACP.value && files.length) {
     composerError.value = t('chat.acpAttachmentsUnsupported')
     return

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -64,23 +64,9 @@
         {{ message.senderDisplayName || senderFallbackName }}
       </p> -->
 
-      <!-- Background task status -->
-      <div
-        v-if="message.role === 'system' && message.kind === 'background_task'"
-        class="space-y-1"
-      >
-        <BackgroundTaskBlock :task="message.backgroundTask" />
-        <p
-          class="text-xs text-muted-foreground/80 mt-1"
-          :title="fullTimestamp"
-        >
-          {{ relativeTimestamp }}
-        </p>
-      </div>
-
       <!-- Heartbeat trigger (replaces user message) -->
       <div
-        v-else-if="message.role === 'user' && sessionType === 'heartbeat'"
+        v-if="message.role === 'user' && sessionType === 'heartbeat'"
         class="space-y-2"
       >
         <HeartbeatTriggerBlock
@@ -295,7 +281,7 @@
 
         <!-- Streaming indicator -->
         <div
-          v-if="message.streaming && !hasVisibleAssistantBlocks"
+          v-if="showThinkingIndicator"
           class="flex items-center gap-2 text-xs text-muted-foreground h-6"
         >
           <LoaderCircle class="size-3.5 animate-spin" />
@@ -322,7 +308,6 @@ import { useSettingsStore } from '@/store/settings'
 import ThinkingBlock from './thinking-block.vue'
 import ToolCallBlock from './tool-call-block.vue'
 import AttachmentBlock from './attachment-block.vue'
-import BackgroundTaskBlock from './background-task-block.vue'
 import HeartbeatTriggerBlock from './heartbeat-trigger-block.vue'
 import ScheduleTriggerBlock from './schedule-trigger-block.vue'
 import ChannelBadge from '@/components/chat-list/channel-badge/index.vue'
@@ -362,6 +347,7 @@ const props = defineProps<{
   onOpenMedia?: (src: string) => void
   onReplyClick?: (messageId: string) => void
   isScrolling: boolean
+  handoffThinking?: boolean
 }>()
 
 const isVisible = useElementVisibility(messageEl, {
@@ -477,8 +463,52 @@ const hasVisibleAssistantBlocks = computed(() =>
   && props.message.messages.some(isVisibleAssistantBlock),
 )
 
+const hasActiveBackgroundTool = computed(() =>
+  props.message.role === 'assistant'
+  && props.message.messages.some((block) => {
+    if (block.type !== 'tool') return false
+    const status = (block.backgroundTask?.status ?? '').trim().toLowerCase()
+    return status === 'running' || status === 'stalled'
+  }),
+)
+
+function isTerminalBackgroundTool(block: ContentBlock | null): boolean {
+  if (!block || block.type !== 'tool') return false
+  const task = block.backgroundTask
+  if (!task?.taskId) return false
+  const status = (task.status ?? '').trim().toLowerCase()
+  return status === 'completed' || status === 'failed' || status === 'killed'
+}
+
+const lastVisibleAssistantBlock = computed(() => {
+  if (props.message.role !== 'assistant') return null
+  for (let i = props.message.messages.length - 1; i >= 0; i -= 1) {
+    const block = props.message.messages[i]
+    if (block && isVisibleAssistantBlock(block)) return block
+  }
+  return null
+})
+
+const showThinkingIndicator = computed(() =>
+  props.message.role === 'assistant'
+  && (
+    (props.message.streaming && !hasVisibleAssistantBlocks.value)
+    || hasActiveBackgroundTool.value
+    || props.handoffThinking === true
+    || (props.message.streaming && isTerminalBackgroundTool(lastVisibleAssistantBlock.value))
+  ),
+)
+
 const shouldRenderMessage = computed(() =>
-  props.message.role !== 'assistant' || hasVisibleAssistantBlocks.value || props.message.streaming,
+  props.message.role === 'system'
+    ? props.message.kind !== 'background_task'
+    : (
+        props.message.role !== 'assistant'
+        || hasVisibleAssistantBlocks.value
+        || props.message.streaming
+        || hasActiveBackgroundTool.value
+        || props.handoffThinking === true
+      ),
 )
 
 function isVisibleAssistantBlock(block: ContentBlock): boolean {

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1040,4 +1040,404 @@ describe('chat-list store', () => {
     await first
     await second
   })
+
+  it('keeps a session busy while a background exec task is running', async () => {
+    api.fetchSessions.mockResolvedValueOnce([
+      { id: 'session-bg', bot_id: 'bot-1', title: 'Background task', type: 'chat' },
+    ])
+    api.fetchMessagesUI.mockResolvedValueOnce([
+      {
+        role: 'assistant',
+        id: 'turn-bg',
+        timestamp: '2026-06-05T08:00:00.000Z',
+        messages: [
+          {
+            id: 1,
+            type: 'tool',
+            name: 'exec',
+            tool_call_id: 'call-bg',
+            input: { command: 'npm install' },
+            output: {
+              structuredContent: {
+                status: 'background_started',
+                task_id: 'bg_task_1',
+                output_file: '/tmp/memoh-bg/bg_task_1.log',
+              },
+            },
+            background_task: {
+              task_id: 'bg_task_1',
+              status: 'running',
+              command: 'npm install',
+              output_file: '/tmp/memoh-bg/bg_task_1.log',
+            },
+            running: true,
+          },
+        ],
+      },
+    ])
+
+    const store = useChatStore()
+
+    await store.selectBot('bot-1')
+
+    expect(store.streaming).toBe(false)
+    expect(store.busy).toBe(true)
+    expect(store.isSessionBusy('session-bg')).toBe(true)
+
+    const blocked = await store.sendMessage('second request')
+    expect(blocked).toMatchObject({ ok: false, stage: 'startup' })
+    expect(sentWSMessages).toHaveLength(0)
+
+    messageEventsHandler?.({
+      type: 'background_task',
+      bot_id: 'bot-1',
+      event: 'completed',
+      task: {
+        task_id: 'bg_task_1',
+        session_id: 'session-bg',
+        status: 'completed',
+        command: 'npm install',
+        output_file: '/tmp/memoh-bg/bg_task_1.log',
+      },
+    } as MessageStreamEvent)
+
+    expect(store.busy).toBe(true)
+    expect(store.backgroundHandoff).toBe(true)
+    expect(store.isSessionBusy('session-bg')).toBe(true)
+
+    const stillBlocked = await store.sendMessage('third request')
+    expect(stillBlocked).toMatchObject({ ok: false, stage: 'startup' })
+    expect(sentWSMessages).toHaveLength(0)
+
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'start',
+        stream_id: 'stream-after-bg',
+        session_id: 'session-bg',
+      },
+    } as MessageStreamEvent)
+    expect(store.backgroundHandoff).toBe(false)
+    expect(store.busy).toBe(true)
+
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'message',
+        stream_id: 'stream-after-bg',
+        session_id: 'session-bg',
+        data: { id: 1, type: 'text', content: 'done' },
+      },
+    } as MessageStreamEvent)
+
+    expect(store.messages).toHaveLength(1)
+    expect(store.messages[0]).toMatchObject({
+      role: 'assistant',
+      messages: [
+        expect.objectContaining({ type: 'tool', toolCallId: 'call-bg' }),
+        expect.objectContaining({ type: 'text', content: 'done' }),
+      ],
+    })
+
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'end',
+        stream_id: 'stream-after-bg',
+        session_id: 'session-bg',
+      },
+    } as MessageStreamEvent)
+    await flushPromises()
+
+    expect(store.busy).toBe(false)
+    expect(store.isSessionBusy('session-bg')).toBe(false)
+  })
+
+  it('keeps a session busy when a message refresh marks a background exec task completed', async () => {
+    api.fetchSessions.mockResolvedValueOnce([
+      { id: 'session-bg-refresh', bot_id: 'bot-1', title: 'Background task refresh', type: 'chat' },
+    ])
+    api.fetchMessagesUI.mockResolvedValueOnce([
+      {
+        role: 'assistant',
+        id: 'turn-bg-refresh',
+        timestamp: '2026-06-05T08:00:00.000Z',
+        messages: [
+          {
+            id: 1,
+            type: 'tool',
+            name: 'exec',
+            tool_call_id: 'call-bg-refresh',
+            input: { command: 'pnpm install' },
+            output: {
+              structuredContent: {
+                status: 'background_started',
+                task_id: 'bg_task_refresh',
+                output_file: '/tmp/memoh-bg/bg_task_refresh.log',
+              },
+            },
+            background_task: {
+              task_id: 'bg_task_refresh',
+              status: 'running',
+              session_id: 'session-bg-refresh',
+              command: 'pnpm install',
+              output_file: '/tmp/memoh-bg/bg_task_refresh.log',
+            },
+            running: true,
+          },
+        ],
+      },
+    ])
+
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+
+    expect(store.busy).toBe(true)
+
+    vi.useFakeTimers()
+    try {
+      api.fetchMessagesUI.mockResolvedValueOnce([
+        {
+          role: 'assistant',
+          id: 'turn-bg-refresh',
+          timestamp: '2026-06-05T08:00:00.000Z',
+          messages: [
+            {
+              id: 1,
+              type: 'tool',
+              name: 'exec',
+              tool_call_id: 'call-bg-refresh',
+              input: { command: 'pnpm install' },
+              output: {
+                structuredContent: {
+                  status: 'completed',
+                  task_id: 'bg_task_refresh',
+                  output_file: '/tmp/memoh-bg/bg_task_refresh.log',
+                },
+              },
+              background_task: {
+                task_id: 'bg_task_refresh',
+                status: 'completed',
+                session_id: 'session-bg-refresh',
+                command: 'pnpm install',
+                output_file: '/tmp/memoh-bg/bg_task_refresh.log',
+              },
+              running: false,
+            },
+          ],
+        },
+      ])
+
+      messageEventsHandler?.({
+        type: 'message_created',
+        bot_id: 'bot-1',
+        message: {
+          id: 'message-bg-refresh',
+          bot_id: 'bot-1',
+          session_id: 'session-bg-refresh',
+          role: 'assistant',
+          created_at: '2026-06-05T08:00:10.000Z',
+        },
+      })
+
+      await vi.advanceTimersByTimeAsync(100)
+      await Promise.resolve()
+
+      expect(store.busy).toBe(true)
+      expect(store.backgroundHandoff).toBe(true)
+      expect(store.isSessionBusy('session-bg-refresh')).toBe(true)
+      expect(store.messages).toHaveLength(1)
+      expect(store.messages[0]).toMatchObject({
+        role: 'assistant',
+        messages: [
+          expect.objectContaining({
+            type: 'tool',
+            toolCallId: 'call-bg-refresh',
+            running: false,
+            done: true,
+            backgroundTask: expect.objectContaining({ status: 'completed' }),
+          }),
+        ],
+      })
+
+      const stillBlocked = await store.sendMessage('third request')
+      expect(stillBlocked).toMatchObject({ ok: false, stage: 'startup' })
+      expect(sentWSMessages).toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps thinking after a live exec tool starts a background task without a background_task field', async () => {
+    api.fetchSessions.mockResolvedValueOnce([
+      { id: 'session-live-bg', bot_id: 'bot-1', title: 'Live background task', type: 'chat' },
+    ])
+    api.fetchMessagesUI.mockResolvedValueOnce([])
+
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'start',
+        stream_id: 'stream-live-bg',
+        session_id: 'session-live-bg',
+      },
+    } as MessageStreamEvent)
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'message',
+        stream_id: 'stream-live-bg',
+        session_id: 'session-live-bg',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'exec',
+          tool_call_id: 'call-live-bg',
+          input: { command: 'sleep 10 && echo done' },
+          output: {
+            structuredContent: {
+              status: 'background_started',
+              task_id: 'bg_live_1',
+              output_file: '/tmp/memoh-bg/bg_live_1.log',
+            },
+          },
+          running: false,
+        },
+      },
+    } as MessageStreamEvent)
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'end',
+        stream_id: 'stream-live-bg',
+        session_id: 'session-live-bg',
+      },
+    } as MessageStreamEvent)
+
+    const assistant = store.messages.find(message => message.role === 'assistant')
+    const tool = assistant?.role === 'assistant' ? assistant.messages[0] : undefined
+
+    expect(store.streaming).toBe(false)
+    expect(store.busy).toBe(true)
+    expect(store.isSessionBusy('session-live-bg')).toBe(true)
+    expect(api.fetchMessagesUI).toHaveBeenCalledTimes(1)
+    expect(assistant).toMatchObject({ streaming: false })
+    expect(tool).toMatchObject({
+      type: 'tool',
+      toolCallId: 'call-live-bg',
+      running: true,
+      done: false,
+      backgroundTask: {
+        taskId: 'bg_live_1',
+        status: 'running',
+        command: 'sleep 10 && echo done',
+      },
+    })
+  })
+
+  it('keeps the handoff active when a refreshed system task notification completes a live background exec', async () => {
+    api.fetchSessions.mockResolvedValueOnce([
+      { id: 'session-live-refresh', bot_id: 'bot-1', title: 'Live background refresh', type: 'chat' },
+    ])
+    api.fetchMessagesUI.mockResolvedValueOnce([])
+
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'start',
+        stream_id: 'stream-live-refresh',
+        session_id: 'session-live-refresh',
+      },
+    } as MessageStreamEvent)
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'message',
+        stream_id: 'stream-live-refresh',
+        session_id: 'session-live-refresh',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'exec',
+          tool_call_id: 'call-live-refresh',
+          input: { command: 'sleep 10 && echo done' },
+          output: {
+            structuredContent: {
+              status: 'background_started',
+              task_id: 'bg_live_refresh',
+              output_file: '/tmp/memoh-bg/bg_live_refresh.log',
+            },
+          },
+          running: false,
+        },
+      },
+    } as MessageStreamEvent)
+    messageEventsHandler?.({
+      type: 'agent_stream',
+      bot_id: 'bot-1',
+      stream: {
+        type: 'end',
+        stream_id: 'stream-live-refresh',
+        session_id: 'session-live-refresh',
+      },
+    } as MessageStreamEvent)
+
+    expect(store.busy).toBe(true)
+    store.messages.splice(0, store.messages.length)
+    expect(store.isSessionBusy('session-live-refresh')).toBe(true)
+
+    vi.useFakeTimers()
+    try {
+      api.fetchMessagesUI.mockResolvedValueOnce([
+        {
+          role: 'system',
+          kind: 'background_task',
+          id: 'notification-live-refresh',
+          timestamp: '2026-06-05T08:00:10.000Z',
+          background_task: {
+            task_id: 'bg_live_refresh',
+            status: 'completed',
+            session_id: 'session-live-refresh',
+            command: 'sleep 10 && echo done',
+            output_file: '/tmp/memoh-bg/bg_live_refresh.log',
+          },
+        },
+      ])
+
+      messageEventsHandler?.({
+        type: 'message_created',
+        bot_id: 'bot-1',
+        message: {
+          id: 'notification-live-refresh',
+          bot_id: 'bot-1',
+          session_id: 'session-live-refresh',
+          role: 'user',
+          created_at: '2026-06-05T08:00:10.000Z',
+        },
+      })
+
+      await vi.advanceTimersByTimeAsync(100)
+      await Promise.resolve()
+
+      expect(store.backgroundHandoff).toBe(true)
+      expect(store.busy).toBe(true)
+      expect(store.isSessionBusy('session-live-refresh')).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -130,6 +130,7 @@ interface PendingAssistantStream {
   assistantTurn: ChatAssistantTurn
   botId: string
   sessionId: string
+  messageIdOffset: number
   done: boolean
   resolve: () => void
   reject: (err: Error) => void
@@ -138,6 +139,14 @@ interface PendingAssistantStream {
 interface StreamIdentity {
   stream_id?: string
   session_id?: string
+}
+
+interface RememberBackgroundTaskOptions {
+  batchStartedTaskIds?: Set<string>
+}
+
+interface RefreshCurrentSessionOptions {
+  deferApplyWhileBusy?: boolean
 }
 
 export type SendMessageStage = 'startup' | 'stream'
@@ -213,6 +222,7 @@ export const useChatStore = defineStore('chat', () => {
     return activeSessionIds[0] ?? null
   })
   const streaming = computed(() => isSessionStreaming(sessionId.value))
+  const busy = computed(() => isSessionBusy(sessionId.value))
   const sessions = ref<SessionSummary[]>([])
   const loading = ref(false)
   const loadingChats = ref(false)
@@ -229,6 +239,7 @@ export const useChatStore = defineStore('chat', () => {
   // and any open file viewers without polling.
   const fsChangedAt = ref(0)
   const FS_MUTATING_TOOLS = new Set(['write', 'edit', 'exec'])
+  const BACKGROUND_HANDOFF_HOLD_MS = 30000
 
   function bumpFsChangedAtIfFsMutation(message: UIMessage) {
     if (message.type !== 'tool') return
@@ -240,10 +251,12 @@ export const useChatStore = defineStore('chat', () => {
   let messageEventsSince = ''
   let activeWs: ChatWebSocket | null = null
   let refreshTimer: ReturnType<typeof setTimeout> | null = null
-  let refreshPromise: { key: string; promise: Promise<void> } | null = null
+  let refreshPromise: { key: string; promise: Promise<boolean> } | null = null
   let sessionListRefreshPromise: { botId: string; promise: Promise<void> } | null = null
   const pendingBackgroundEvents = new Map<string, BackgroundTask[]>()
-  const latestBackgroundTasks = new Map<string, BackgroundTask>()
+  const latestBackgroundTasks = reactive(new Map<string, BackgroundTask>())
+  const backgroundHandoffExpires = reactive(new Map<string, number>())
+  const backgroundHandoffTimers = new Map<string, ReturnType<typeof setTimeout>>()
   // Open chat tabs share this store, so keep a small per-session view cache.
   // Switching tabs saves/restores from here; the active session remains the
   // only live `messages` array rendered by ChatPane.
@@ -450,6 +463,7 @@ export const useChatStore = defineStore('chat', () => {
 
   function mergeBackgroundTask(existing: BackgroundTask | undefined, incoming: BackgroundTask): BackgroundTask {
     const merged: BackgroundTask = existing ? { ...existing } : { taskId: incoming.taskId, status: incoming.status }
+    const preserveTerminalStatus = !!existing && !isBackgroundTaskActive(existing) && isBackgroundTaskActive(incoming)
     const writable = merged as unknown as Record<string, unknown>
     for (const [key, value] of Object.entries(incoming)) {
       if (value === undefined || value === '') continue
@@ -458,14 +472,28 @@ export const useChatStore = defineStore('chat', () => {
     if (!incoming.outputTail && incoming.chunk) {
       merged.outputTail = `${existing?.outputTail ?? ''}${incoming.chunk}`.slice(-4096)
     }
+    if (preserveTerminalStatus) {
+      merged.status = existing.status
+    }
     merged.status = normalizeBackgroundStatus(merged.status, merged.event) || merged.status || 'running'
     merged.stalled = merged.stalled === true || merged.status === 'stalled'
     return merged
   }
 
-  function rememberBackgroundTask(task: BackgroundTask): BackgroundTask {
-    const latest = mergeBackgroundTask(latestBackgroundTasks.get(task.taskId), task)
+  function rememberBackgroundTask(task: BackgroundTask, options: RememberBackgroundTaskOptions = {}): BackgroundTask {
+    const previous = latestBackgroundTasks.get(task.taskId)
+    const latest = mergeBackgroundTask(previous, task)
     latestBackgroundTasks.set(task.taskId, latest)
+    if (!previous && isBackgroundTaskActive(latest)) {
+      options.batchStartedTaskIds?.add(latest.taskId)
+    }
+    if (
+      isBackgroundTaskActive(previous)
+      && !isBackgroundTaskActive(latest)
+      && !options.batchStartedTaskIds?.has(latest.taskId)
+    ) {
+      startBackgroundHandoff(latest.sessionId || previous?.sessionId || sessionId.value)
+    }
     return latest
   }
 
@@ -480,6 +508,27 @@ export const useChatStore = defineStore('chat', () => {
     const structured = structuredToolResult(block.result)
     const result = asRecord(block.result)
     return pickString(structured, 'task_id', 'taskId') || pickString(result, 'task_id', 'taskId')
+  }
+
+  function backgroundTaskFromExecToolOutput(msg: UIToolMessage): BackgroundTask | null {
+    if (msg.name !== 'exec' || !msg.output) return null
+    const structured = structuredToolResult(msg.output)
+    const taskId = pickString(structured, 'task_id', 'taskId')
+    if (!taskId) return null
+    const input = asRecord(msg.input)
+    return normalizeBackgroundTask({
+      task_id: taskId,
+      status: pickString(structured, 'status'),
+      event: pickString(structured, 'event'),
+      bot_id: pickString(structured, 'bot_id', 'botId'),
+      session_id: pickString(structured, 'session_id', 'sessionId'),
+      command: pickString(structured, 'command') || pickString(input, 'command'),
+      output_file: pickString(structured, 'output_file', 'outputFile'),
+      output_tail: pickString(structured, 'output_tail', 'outputTail', 'tail'),
+      exit_code: structured.exit_code ?? structured.exitCode,
+      duration: pickString(structured, 'duration'),
+      stalled: structured.stalled === true,
+    })
   }
 
   function mergeBackgroundTaskIntoToolBlock(block: ToolCallBlock, task: BackgroundTask) {
@@ -520,10 +569,20 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  function normalizeUIMessage(msg: UIMessage): ContentBlock {
+  function normalizeUIMessage(
+    msg: UIMessage,
+    targetSessionId?: string | null,
+    batchStartedTaskIds?: Set<string>,
+  ): ContentBlock {
     switch (msg.type) {
       case 'tool': {
-        const backgroundTask = normalizeBackgroundTask(msg.background_task)
+        const rawBackgroundTask = normalizeBackgroundTask(msg.background_task) ?? backgroundTaskFromExecToolOutput(msg)
+        const backgroundTask = rawBackgroundTask
+          ? rememberBackgroundTask({
+              ...rawBackgroundTask,
+              sessionId: rawBackgroundTask.sessionId || (targetSessionId ?? sessionId.value ?? '').trim() || undefined,
+            }, { batchStartedTaskIds })
+          : null
         const block: ToolCallBlock = {
           ...msg,
           toolCallId: msg.tool_call_id,
@@ -551,7 +610,7 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  function normalizeTurn(turn: UITurn): ChatMessage {
+  function normalizeTurn(turn: UITurn, targetSessionId?: string | null, batchStartedTaskIds?: Set<string>): ChatMessage {
     if (turn.role === 'user') {
       return {
         id: String(turn.id ?? nextId()),
@@ -576,7 +635,7 @@ export const useChatStore = defineStore('chat', () => {
         taskId: String(turn.id ?? nextId()),
         status: 'completed',
       }
-      const latest = rememberBackgroundTask(task)
+      const latest = rememberBackgroundTask(task, { batchStartedTaskIds })
       return {
         id: String(turn.id ?? `system-${latest.taskId}`),
         role: 'system',
@@ -591,7 +650,7 @@ export const useChatStore = defineStore('chat', () => {
     return {
       id: String(turn.id ?? nextId()),
       role: 'assistant',
-      messages: (turn.messages ?? []).map(normalizeUIMessage),
+      messages: (turn.messages ?? []).map(message => normalizeUIMessage(message, targetSessionId, batchStartedTaskIds)),
       timestamp: normalizeTimestamp(turn.timestamp),
       platform: (turn.platform ?? '').trim() || undefined,
       externalMessageId: (turn.external_message_id ?? '').trim() || undefined,
@@ -764,7 +823,8 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   function normalizeTurns(items: UITurn[], targetSessionId?: string): ChatMessage[] {
-    const normalized = items.map(normalizeTurn)
+    const batchStartedTaskIds = new Set<string>()
+    const normalized = items.map(turn => normalizeTurn(turn, targetSessionId, batchStartedTaskIds))
     reconcileBackgroundTasksInMessages(normalized)
     appendEphemeralErrors(normalized, targetSessionId)
     return normalized
@@ -776,7 +836,9 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   function replaceMessages(items: UITurn[], targetSessionId?: string) {
-    setMessages(normalizeTurns(items, targetSessionId))
+    const normalized = normalizeTurns(items, targetSessionId)
+    startBackgroundHandoffForTerminalTransitions(messages, normalized, targetSessionId)
+    setMessages(normalized)
   }
 
   function sortChatMessages(items: ChatMessage[]): ChatMessage[] {
@@ -789,6 +851,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   function mergeMessages(items: UITurn[], targetSessionId?: string) {
+    const previous = [...messages]
     const merged = new Map<string, ChatMessage>()
     for (const item of messages) {
       merged.set(item.id, item)
@@ -796,7 +859,9 @@ export const useChatStore = defineStore('chat', () => {
     for (const item of normalizeTurns(items, targetSessionId)) {
       merged.set(item.id, item)
     }
-    setMessages(sortChatMessages([...merged.values()]))
+    const normalized = sortChatMessages([...merged.values()])
+    startBackgroundHandoffForTerminalTransitions(previous, normalized, targetSessionId)
+    setMessages(normalized)
   }
 
   function sessionMessageKey(botId?: string | null, sid?: string | null): string {
@@ -827,6 +892,8 @@ export const useChatStore = defineStore('chat', () => {
   function cacheFetchedMessages(botId: string, sid: string, items: ChatMessage[], moreOlder: boolean) {
     const key = sessionMessageKey(botId, sid)
     if (!key) return
+    const previous = sessionMessageStates.get(key)?.items ?? []
+    startBackgroundHandoffForTerminalTransitions(previous, items, sid)
     sessionMessageStates.set(key, {
       items: [...items],
       hasMoreOlder: moreOlder,
@@ -865,6 +932,118 @@ export const useChatStore = defineStore('chat', () => {
     return activeStreamIdsForSession(targetSessionId).length > 0
   }
 
+  function clearBackgroundHandoff(targetSessionId?: string | null) {
+    const sid = (targetSessionId ?? '').trim()
+    if (!sid) return
+    const timer = backgroundHandoffTimers.get(sid)
+    if (timer) clearTimeout(timer)
+    backgroundHandoffTimers.delete(sid)
+    backgroundHandoffExpires.delete(sid)
+  }
+
+  function startBackgroundHandoff(targetSessionId?: string | null) {
+    const sid = (targetSessionId ?? '').trim()
+    if (!sid) return
+    clearBackgroundHandoff(sid)
+    backgroundHandoffExpires.set(sid, Date.now() + BACKGROUND_HANDOFF_HOLD_MS)
+    backgroundHandoffTimers.set(sid, setTimeout(() => {
+      clearBackgroundHandoff(sid)
+    }, BACKGROUND_HANDOFF_HOLD_MS))
+  }
+
+  function isSessionBackgroundHandoff(targetSessionId?: string | null): boolean {
+    const sid = (targetSessionId ?? '').trim()
+    if (!sid) return false
+    const expiresAt = backgroundHandoffExpires.get(sid)
+    return typeof expiresAt === 'number' && expiresAt > Date.now()
+  }
+
+  function backgroundTasksInItems(items: ChatMessage[]): Map<string, BackgroundTask> {
+    const tasks = new Map<string, BackgroundTask>()
+    for (const item of items) {
+      if (item.role === 'system' && item.kind === 'background_task') {
+        if (item.backgroundTask.taskId) tasks.set(item.backgroundTask.taskId, item.backgroundTask)
+        continue
+      }
+      if (item.role !== 'assistant') continue
+      for (const block of item.messages) {
+        if (block.type !== 'tool') continue
+        const task = block.backgroundTask
+        if (task?.taskId) tasks.set(task.taskId, task)
+      }
+    }
+    return tasks
+  }
+
+  function startBackgroundHandoffForTerminalTransitions(
+    previousItems: ChatMessage[],
+    nextItems: ChatMessage[],
+    targetSessionId?: string | null,
+  ) {
+    const previousTasks = backgroundTasksInItems(previousItems)
+    if (previousTasks.size === 0) return
+
+    const nextTasks = backgroundTasksInItems(nextItems)
+    const fallbackSessionId = (targetSessionId ?? sessionId.value ?? '').trim()
+    for (const [taskId, previousTask] of previousTasks) {
+      if (!isBackgroundTaskActive(previousTask)) continue
+      const nextTask = nextTasks.get(taskId)
+      if (!nextTask || isBackgroundTaskActive(nextTask)) continue
+      startBackgroundHandoff(nextTask.sessionId || previousTask.sessionId || fallbackSessionId)
+    }
+  }
+
+  function applyBackgroundTasksFromItemsToCurrentMessages(items: ChatMessage[]) {
+    const tasks = backgroundTasksInItems(items)
+    for (const task of tasks.values()) {
+      const block = findBackgroundToolBlock(task.taskId)
+      if (!block) continue
+      mergeBackgroundTaskIntoToolBlock(block, task)
+      if (!isBackgroundTaskActive(block.backgroundTask)) {
+        fsChangedAt.value = Date.now()
+      }
+    }
+  }
+
+  function hasActiveBackgroundTaskInItems(items: ChatMessage[]): boolean {
+    for (const item of items) {
+      if (item.role === 'system' && item.kind === 'background_task') {
+        if (isBackgroundTaskActive(item.backgroundTask)) return true
+        continue
+      }
+      if (item.role !== 'assistant') continue
+      for (const block of item.messages) {
+        if (block.type === 'tool' && isBackgroundTaskActive(block.backgroundTask)) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  function hasActiveBackgroundTaskForSession(targetSessionId?: string | null): boolean {
+    const sid = (targetSessionId ?? '').trim()
+    if (!sid) return false
+    if (sid === (sessionId.value ?? '').trim()) {
+      if (hasActiveBackgroundTaskInItems(messages)) return true
+    } else {
+      const key = sessionMessageKey(currentBotId.value, sid)
+      const cached = key ? sessionMessageStates.get(key) : undefined
+      if (cached && hasActiveBackgroundTaskInItems(cached.items)) return true
+    }
+
+    for (const task of latestBackgroundTasks.values()) {
+      if (task.sessionId === sid && isBackgroundTaskActive(task)) return true
+    }
+    return false
+  }
+
+  function isSessionBusy(targetSessionId?: string | null): boolean {
+    return isSessionStreaming(targetSessionId)
+      || hasActiveBackgroundTaskForSession(targetSessionId)
+      || isSessionBackgroundHandoff(targetSessionId)
+  }
+
   function streamIdForEvent(event: StreamIdentity, targetSessionId?: string): string {
     const explicit = (event.stream_id ?? '').trim()
     if (explicit) return explicit
@@ -873,7 +1052,7 @@ export const useChatStore = defineStore('chat', () => {
     return activeIds.length === 1 ? activeIds[0]! : fallbackStreamId(sid)
   }
 
-  function trackAssistantStream(streamId: string, assistantTurn: ChatAssistantTurn, botId: string, targetSessionId: string): Promise<void> {
+  function trackAssistantStream(streamId: string, assistantTurn: ChatAssistantTurn, botId: string, targetSessionId: string, messageIdOffset = 0): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const id = streamId.trim()
       if (!id) {
@@ -889,6 +1068,7 @@ export const useChatStore = defineStore('chat', () => {
         assistantTurn,
         botId,
         sessionId: targetSessionId.trim(),
+        messageIdOffset,
         done: false,
         resolve,
         reject,
@@ -987,6 +1167,17 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
+  function backgroundHandoffAssistantTurn(targetSessionId: string): ChatAssistantTurn | null {
+    const sid = targetSessionId.trim()
+    if (!sid || sid !== (sessionId.value ?? '').trim()) return null
+    if (!isSessionBackgroundHandoff(sid)) return null
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      const item = messages[i]
+      if (item?.role === 'assistant') return item
+    }
+    return null
+  }
+
   function ensureDiscussStream(streamId: string, targetSessionId?: string): PendingAssistantStream {
     const id = streamIdForEvent({ stream_id: streamId, session_id: targetSessionId }, targetSessionId)
     const existing = getAssistantStream(id)
@@ -995,18 +1186,25 @@ export const useChatStore = defineStore('chat', () => {
     }
     const sid = (targetSessionId ?? sessionId.value ?? '').trim()
     const bid = (currentBotId.value ?? '').trim()
-    const assistantTurn = createOptimisticAssistantTurn()
-    appendTurnToSession(bid, sid, assistantTurn)
-    void trackAssistantStream(id, assistantTurn, bid, sid).catch((error: Error) => {
+    const handoffTurn = backgroundHandoffAssistantTurn(sid)
+    const assistantTurn = handoffTurn ?? createOptimisticAssistantTurn()
+    const messageIdOffset = handoffTurn ? nextAssistantMessageId(handoffTurn) : 0
+    assistantTurn.streaming = true
+    if (!handoffTurn) appendTurnToSession(bid, sid, assistantTurn)
+    clearBackgroundHandoff(sid)
+    void trackAssistantStream(id, assistantTurn, bid, sid, messageIdOffset).catch((error: Error) => {
       finalizeStreamFailure(assistantTurn, bid, sid, error)
     })
     return getAssistantStream(id)!
   }
 
-  function upsertAssistantUIMessage(turn: ChatAssistantTurn, message: UIMessage) {
-    const normalized = normalizeUIMessage(message)
+  function upsertAssistantUIMessage(turn: ChatAssistantTurn, message: UIMessage, messageIdOffset = 0, targetSessionId?: string | null) {
+    const shifted = messageIdOffset > 0
+      ? { ...message, id: message.id + messageIdOffset }
+      : message
+    const normalized = normalizeUIMessage(shifted, targetSessionId)
     turn.messages = upsertById(turn.messages, normalized)
-    bumpFsChangedAtIfFsMutation(message)
+    bumpFsChangedAtIfFsMutation(shifted)
   }
 
   function nextAssistantMessageId(turn: ChatAssistantTurn): number {
@@ -1116,23 +1314,25 @@ export const useChatStore = defineStore('chat', () => {
         ensureDiscussStream(streamId, sid)
         break
       case 'message':
-        upsertAssistantUIMessage(ensureDiscussStream(streamId, sid).assistantTurn, event.data)
+        const activeStream = ensureDiscussStream(streamId, sid)
+        upsertAssistantUIMessage(activeStream.assistantTurn, event.data, activeStream.messageIdOffset, activeStream.sessionId || sid)
         break
       case 'end':
         const endedSession = getAssistantStream(streamId)
-        const endedBotId = endedSession?.botId ?? currentBotId.value ?? ''
         const endedSessionId = sid || endedSession?.sessionId
         pruneEmptyAssistantTurnIfPending(streamId)
         resolveAssistantStream(streamId)
-        loading.value = isSessionStreaming(sessionId.value)
-        void refreshCurrentSession(endedBotId, endedSessionId)
+        loading.value = isSessionBusy(sessionId.value)
+        if (!isSessionBusy(endedSessionId)) {
+          scheduleRefreshCurrentSession(endedSessionId, 0)
+        }
         break
       case 'error': {
         const session = getAssistantStream(streamId) ?? ensureDiscussStream(streamId, sid)
         const message = event.message || 'stream error'
         const stage: SendMessageStage = hasVisibleAssistantBlocks(session.assistantTurn) ? 'stream' : 'startup'
         rejectAssistantStream(streamId, new StreamFailureError(message, stage))
-        loading.value = isSessionStreaming(sessionId.value)
+        loading.value = isSessionBusy(sessionId.value)
         break
       }
     }
@@ -1183,6 +1383,9 @@ export const useChatStore = defineStore('chat', () => {
     pendingAssistantStreams.clear()
     pendingBackgroundEvents.clear()
     latestBackgroundTasks.clear()
+    for (const timer of backgroundHandoffTimers.values()) clearTimeout(timer)
+    backgroundHandoffTimers.clear()
+    backgroundHandoffExpires.clear()
     sessionMessageStates.clear()
     ephemeralAssistantErrors.clear()
   }
@@ -1203,16 +1406,19 @@ export const useChatStore = defineStore('chat', () => {
     return activeWs
   }
 
-  async function refreshCurrentSession(targetBotId?: string, targetSessionId?: string) {
+  async function refreshCurrentSession(
+    targetBotId?: string,
+    targetSessionId?: string,
+    options: RefreshCurrentSessionOptions = {},
+  ): Promise<boolean> {
     const bid = (targetBotId ?? currentBotId.value ?? '').trim()
     const sid = (targetSessionId ?? sessionId.value ?? '').trim()
-    if (!bid || !sid) return
+    if (!bid || !sid) return false
     const key = sessionMessageKey(bid, sid)
 
     if (refreshPromise) {
       if (refreshPromise.key === key) {
-        await refreshPromise.promise
-        return
+        return refreshPromise.promise
       }
       await refreshPromise.promise
     }
@@ -1222,6 +1428,13 @@ export const useChatStore = defineStore('chat', () => {
       const normalized = normalizeTurns(turns, sid)
       const moreOlder = turns.length > 0
       if (currentBotId.value === bid && sessionId.value === sid) {
+        if (options.deferApplyWhileBusy && isSessionBusy(sid)) {
+          applyBackgroundTasksFromItemsToCurrentMessages(normalized)
+          cacheFetchedMessages(bid, sid, normalized, moreOlder)
+          touchSession(sid)
+          return false
+        }
+        startBackgroundHandoffForTerminalTransitions(messages, normalized, sid)
         setMessages(normalized)
         hasMoreOlder.value = moreOlder
         cacheCurrentMessages()
@@ -1229,6 +1442,7 @@ export const useChatStore = defineStore('chat', () => {
         cacheFetchedMessages(bid, sid, normalized, moreOlder)
       }
       touchSession(sid)
+      return true
     })().finally(() => {
       if (refreshPromise?.promise === promise) {
         refreshPromise = null
@@ -1271,9 +1485,10 @@ export const useChatStore = defineStore('chat', () => {
     refreshTimer = setTimeout(() => {
       refreshTimer = null
       const sidNow = (sessionId.value ?? '').trim()
-      const streamActive = isSessionStreaming(sidNow)
-      if (streamActive) return
-      void refreshCurrentSession()
+      void refreshCurrentSession(undefined, sidNow, { deferApplyWhileBusy: true })
+        .then((applied) => {
+          if (!applied) scheduleRefreshCurrentSession(sidNow, Math.max(delay, 500))
+        })
     }, delay)
   }
 
@@ -1315,6 +1530,9 @@ export const useChatStore = defineStore('chat', () => {
     const sid = (sessionId.value ?? '').trim()
 
     const task = rememberBackgroundTask(incoming)
+    const taskActive = isBackgroundTaskActive(task)
+    const taskSessionId = task.sessionId || sid
+    if (!taskActive) startBackgroundHandoff(taskSessionId)
 
     if (incoming.sessionId && sid && incoming.sessionId !== sid) {
       applyBackgroundTaskToCachedMessages(targetBotId, task)
@@ -1331,7 +1549,7 @@ export const useChatStore = defineStore('chat', () => {
       queuePendingBackgroundEvent(task)
     }
 
-    if (!isBackgroundTaskActive(task) || task.status === 'stalled') {
+    if (!taskActive || task.status === 'stalled') {
       scheduleRefreshCurrentSession(task.sessionId, 250)
     }
   }
@@ -1423,7 +1641,7 @@ export const useChatStore = defineStore('chat', () => {
       if (activeWs?.connected) activeWs.abort(streamId)
       rejectAssistantStream(streamId, abortError)
     }
-    loading.value = isSessionStreaming(sessionId.value)
+    loading.value = isSessionBusy(sessionId.value)
   }
 
   function abortAllAssistantStreams() {
@@ -2080,7 +2298,7 @@ export const useChatStore = defineStore('chat', () => {
 
   async function sendMessage(text: string, attachments?: ChatAttachment[]): Promise<SendMessageResult> {
     const trimmed = text.trim()
-    if ((!trimmed && !attachments?.length) || streaming.value || !currentBotId.value) return { ok: false, stage: 'startup' }
+    if ((!trimmed && !attachments?.length) || busy.value || !currentBotId.value) return { ok: false, stage: 'startup' }
 
     loading.value = true
     let assistantTurn: ChatAssistantTurn | null = null
@@ -2163,7 +2381,7 @@ export const useChatStore = defineStore('chat', () => {
   async function respondToolApproval(approval: UIToolApproval, decision: 'approve' | 'reject') {
     const bid = currentBotId.value ?? ''
     const sid = sessionId.value ?? ''
-    if (!bid || !sid || !approval.approval_id || streaming.value) return
+    if (!bid || !sid || !approval.approval_id || busy.value) return
     const ws = ensureWebSocket(bid)
     const streamId = createStreamId()
     const assistantTurn = createOptimisticAssistantTurn()
@@ -2202,7 +2420,7 @@ export const useChatStore = defineStore('chat', () => {
   ) {
     const bid = currentBotId.value ?? ''
     const sid = sessionId.value ?? ''
-    if (!bid || !sid || !userInput.user_input_id || streaming.value) return
+    if (!bid || !sid || !userInput.user_input_id || busy.value) return
     const ws = ensureWebSocket(bid)
     const streamId = createStreamId()
     const previousUserInputStates = snapshotUserInputStates(userInput.user_input_id)
@@ -2256,6 +2474,8 @@ export const useChatStore = defineStore('chat', () => {
   return {
     messages,
     streaming,
+    busy,
+    backgroundHandoff: computed(() => isSessionBackgroundHandoff(sessionId.value)),
     streamingSessionId,
     sessions,
     acpRuntimeStatuses,
@@ -2274,6 +2494,8 @@ export const useChatStore = defineStore('chat', () => {
     activeSession,
     activeChatReadOnly,
     isSessionStreaming,
+    isSessionBusy,
+    isSessionBackgroundHandoff,
     loading,
     loadingChats,
     loadingOlder,


### PR DESCRIPTION
## Summary
- keep chat busy/thinking state active across background exec handoff
- reuse the previous assistant turn after background wakeups while offsetting stream block IDs to avoid replacing the existing ExecToolCard
- infer running background exec state from realtime exec tool structured output
- hide the separate background task status system message after completion

## Validation
- `pnpm --dir apps/web exec eslint src/store/chat-list.ts src/store/chat-list.test.ts src/pages/home/components/chat-pane.vue src/pages/home/components/message-item.vue`
- `pnpm --dir apps/web exec vitest run src/store/chat-list.test.ts`
- `pnpm --dir apps/web exec vue-tsc --noEmit`
- `git diff --check`
- pre-commit hook during commit