### PR TITLE
feat: bot create progress stream

### DIFF
--- a/apps/web/src/composables/api/botCreateTerminal.test.ts
+++ b/apps/web/src/composables/api/botCreateTerminal.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendBotCreateTerminalLine,
+  finalizeBotCreateTerminalLines,
+  pushBotCreateTerminalLine,
+  type BotCreateTerminalLine,
+} from './botCreateTerminal'
+import type { BotCreateStreamEvent } from './useBotCreateStream'
+
+describe('botCreateTerminal', () => {
+  it('pushes a running pulling line carrying the image', () => {
+    const lines = appendBotCreateTerminalLine([], { type: 'pulling', image: 'ghcr.io/memoh:latest' })
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({ kind: 'pulling', status: 'running', image: 'ghcr.io/memoh:latest' })
+  })
+
+  it('updates the trailing pulling line percent in place on pull_progress', () => {
+    let lines = appendBotCreateTerminalLine([], { type: 'pulling', image: 'img' })
+    lines = appendBotCreateTerminalLine(lines, {
+      type: 'pull_progress',
+      layers: [{ ref: 'a', offset: 50, total: 100 }],
+    })
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({ kind: 'pulling', status: 'running', percent: 50 })
+  })
+
+  it('finalizes the pulling line and pushes a running creating line', () => {
+    let lines = appendBotCreateTerminalLine([], { type: 'pulling', image: 'img' })
+    lines = appendBotCreateTerminalLine(lines, { type: 'creating' })
+
+    expect(lines.map(l => ({ kind: l.kind, status: l.status }))).toEqual([
+      { kind: 'pulling', status: 'done' },
+      { kind: 'creating', status: 'running' },
+    ])
+  })
+
+  it('marks the trailing running line as error and appends an error line', () => {
+    let lines = appendBotCreateTerminalLine([], { type: 'creating' })
+    lines = appendBotCreateTerminalLine(lines, { type: 'error', message: 'boom' })
+
+    expect(lines.map(l => ({ kind: l.kind, status: l.status }))).toEqual([
+      { kind: 'creating', status: 'error' },
+      { kind: 'error', status: 'error' },
+    ])
+    expect(lines[1].message).toBe('boom')
+  })
+
+  it('derives the full happy-path log', () => {
+    let lines: BotCreateTerminalLine[] = []
+    const events: BotCreateStreamEvent[] = [
+      { type: 'bot_created', bot: { id: 'b1' } },
+      { type: 'pulling', image: 'img' },
+      { type: 'pull_progress', layers: [{ ref: 'a', offset: 100, total: 100 }] },
+      { type: 'creating' },
+      { type: 'restoring' },
+      { type: 'ready', bot: { id: 'b1' } },
+    ]
+    for (const event of events) {
+      lines = appendBotCreateTerminalLine(lines, event)
+    }
+
+    expect(lines.map(l => ({ kind: l.kind, status: l.status }))).toEqual([
+      { kind: 'bot-created', status: 'done' },
+      { kind: 'pulling', status: 'done' },
+      { kind: 'creating', status: 'done' },
+      { kind: 'restoring', status: 'done' },
+      { kind: 'ready', status: 'done' },
+    ])
+  })
+
+  it('pushBotCreateTerminalLine finalizes the prior running line to done', () => {
+    let lines = appendBotCreateTerminalLine([], { type: 'creating' })
+    lines = pushBotCreateTerminalLine(lines, { kind: 'applying-settings', status: 'running' })
+
+    expect(lines.map(l => ({ kind: l.kind, status: l.status }))).toEqual([
+      { kind: 'creating', status: 'done' },
+      { kind: 'applying-settings', status: 'running' },
+    ])
+  })
+
+  it('finalizeBotCreateTerminalLines marks the trailing running line done', () => {
+    let lines = pushBotCreateTerminalLine([], { kind: 'applying-settings', status: 'running' })
+    lines = finalizeBotCreateTerminalLines(lines)
+
+    expect(lines[0]).toMatchObject({ kind: 'applying-settings', status: 'done' })
+  })
+})

--- a/apps/web/src/composables/api/botCreateTerminal.ts
+++ b/apps/web/src/composables/api/botCreateTerminal.ts
@@ -1,0 +1,85 @@
+import { botCreateProgressPercent, type BotCreateStreamEvent } from './useBotCreateStream'
+
+// codesync(bot-create-stream): line kinds mirror the SSE event phases emitted by
+// internal/handlers/users.go, rendered as a pseudo-terminal log on the client.
+export type BotCreateTerminalLineStatus = 'running' | 'done' | 'error' | 'info'
+
+export type BotCreateTerminalLineKind =
+  | 'command'
+  | 'bot-created'
+  | 'pulling'
+  | 'creating'
+  | 'restoring'
+  | 'ready'
+  | 'applying-settings'
+  | 'error'
+
+export type BotCreateTerminalLine = {
+  id: string
+  kind: BotCreateTerminalLineKind
+  status: BotCreateTerminalLineStatus
+  image?: string
+  percent?: number
+  message?: string
+}
+
+type NewBotCreateTerminalLine = Omit<BotCreateTerminalLine, 'id'>
+
+function withId(line: NewBotCreateTerminalLine, index: number): BotCreateTerminalLine {
+  return { ...line, id: `${line.kind}-${index}` }
+}
+
+// Close out the trailing line if it is still running; other lines are untouched.
+export function finalizeBotCreateTerminalLines(
+  lines: BotCreateTerminalLine[],
+  status: 'done' | 'error' = 'done',
+): BotCreateTerminalLine[] {
+  if (lines.length === 0) return lines
+  const last = lines[lines.length - 1]
+  if (last.status !== 'running') return lines
+  return [...lines.slice(0, -1), { ...last, status }]
+}
+
+// Append a fresh line, first finalizing any trailing running line to done so the
+// log reads as a sequence of completed steps with a single active one.
+export function pushBotCreateTerminalLine(
+  lines: BotCreateTerminalLine[],
+  line: NewBotCreateTerminalLine,
+): BotCreateTerminalLine[] {
+  const finalized = finalizeBotCreateTerminalLines(lines)
+  return [...finalized, withId(line, finalized.length)]
+}
+
+export function appendBotCreateTerminalLine(
+  lines: BotCreateTerminalLine[],
+  event: BotCreateStreamEvent,
+): BotCreateTerminalLine[] {
+  switch (event.type) {
+    case 'bot_created':
+      return pushBotCreateTerminalLine(lines, { kind: 'bot-created', status: 'done' })
+    case 'pulling':
+      return pushBotCreateTerminalLine(lines, { kind: 'pulling', status: 'running', image: event.image })
+    case 'pull_progress': {
+      const percent = botCreateProgressPercent({ phase: 'pulling', layers: event.layers })
+      const last = lines[lines.length - 1]
+      if (last && last.kind === 'pulling' && last.status === 'running') {
+        return [...lines.slice(0, -1), { ...last, percent }]
+      }
+      return pushBotCreateTerminalLine(lines, { kind: 'pulling', status: 'running', percent })
+    }
+	case 'pull_skipped':
+	case 'pull_delegated':
+		// Image already present or pulled elsewhere, so close out the pull line.
+		return finalizeBotCreateTerminalLines(lines)
+    case 'creating':
+      return pushBotCreateTerminalLine(lines, { kind: 'creating', status: 'running' })
+    case 'restoring':
+      return pushBotCreateTerminalLine(lines, { kind: 'restoring', status: 'running' })
+    case 'ready':
+      return pushBotCreateTerminalLine(lines, { kind: 'ready', status: 'done' })
+    case 'error': {
+      const errored = finalizeBotCreateTerminalLines(lines, 'error')
+      return [...errored, withId({ kind: 'error', status: 'error', message: event.message }, errored.length)]
+    }
+  }
+}

--- a/apps/web/src/composables/api/botCreateTerminal.ts
+++ b/apps/web/src/composables/api/botCreateTerminal.ts
@@ -67,10 +67,10 @@ export function appendBotCreateTerminalLine(
       }
       return pushBotCreateTerminalLine(lines, { kind: 'pulling', status: 'running', percent })
     }
-	case 'pull_skipped':
-	case 'pull_delegated':
-		// Image already present or pulled elsewhere, so close out the pull line.
-		return finalizeBotCreateTerminalLines(lines)
+    case 'pull_skipped':
+    case 'pull_delegated':
+      // Image already present or pulled elsewhere, so close out the pull line.
+      return finalizeBotCreateTerminalLines(lines)
     case 'creating':
       return pushBotCreateTerminalLine(lines, { kind: 'creating', status: 'running' })
     case 'restoring':

--- a/apps/web/src/composables/api/sseClient.test.ts
+++ b/apps/web/src/composables/api/sseClient.test.ts
@@ -48,4 +48,54 @@ describe('SDK SSE client', () => {
     expect(onSseError.mock.calls[0]?.[0]).toBeInstanceOf(Error)
     expect((onSseError.mock.calls[0]?.[0] as Error).message).toBe('SSE failed: 401 Unauthorized')
   })
+
+  it('threads transformed errors through SSE error interceptors', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 500, statusText: 'Internal Server Error' }))
+    const onSseError = vi.fn()
+    const transformed = new Error('transformed')
+    const firstInterceptor = vi.fn(() => transformed)
+    const secondInterceptor = vi.fn(() => undefined)
+
+    client.setConfig({
+      baseUrl: 'http://example.test',
+      fetch: fetchMock as unknown as typeof fetch,
+    })
+    client.interceptors.error.use(error => firstInterceptor(error))
+    client.interceptors.error.use(error => secondInterceptor(error))
+
+    const result = await client.sse.get({
+      url: '/events',
+      onSseError,
+      sseMaxRetryAttempts: 1,
+    })
+
+    await drain(result.stream)
+
+    expect(secondInterceptor).toHaveBeenCalledWith(transformed)
+    expect(onSseError).toHaveBeenCalledWith(transformed)
+  })
+
+  it('still reports the original SSE error when an error interceptor throws', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 401, statusText: 'Unauthorized' }))
+    const onSseError = vi.fn()
+
+    client.setConfig({
+      baseUrl: 'http://example.test',
+      fetch: fetchMock as unknown as typeof fetch,
+    })
+    client.interceptors.error.use(() => {
+      throw new Error('interceptor failed')
+    })
+
+    const result = await client.sse.get({
+      url: '/events',
+      onSseError,
+      sseMaxRetryAttempts: 1,
+    })
+
+    await expect(drain(result.stream)).resolves.toBeUndefined()
+    expect(onSseError).toHaveBeenCalledTimes(1)
+    expect(onSseError.mock.calls[0]?.[0]).toBeInstanceOf(Error)
+    expect((onSseError.mock.calls[0]?.[0] as Error).message).toBe('SSE failed: 401 Unauthorized')
+  })
 })

--- a/apps/web/src/composables/api/sseClient.test.ts
+++ b/apps/web/src/composables/api/sseClient.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { client } from '@memohai/sdk/client'
+
+async function drain<T>(stream: AsyncGenerator<T, unknown, unknown>) {
+  for await (const _event of stream) {
+    // drain
+  }
+}
+
+describe('SDK SSE client', () => {
+  beforeEach(() => {
+    client.interceptors.error.clear()
+    client.interceptors.request.clear()
+    client.interceptors.response.clear()
+  })
+
+  afterEach(() => {
+    client.interceptors.error.clear()
+    client.interceptors.request.clear()
+    client.interceptors.response.clear()
+  })
+
+  it('runs response and error interceptors before reporting failed SSE responses', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 401, statusText: 'Unauthorized' }))
+    const onSseError = vi.fn()
+    const responseInterceptor = vi.fn((response: Response) => response)
+    const errorInterceptor = vi.fn((error: unknown) => error)
+
+    client.setConfig({
+      baseUrl: 'http://example.test',
+      fetch: fetchMock as unknown as typeof fetch,
+    })
+    client.interceptors.response.use((response) => responseInterceptor(response))
+    client.interceptors.error.use((error) => errorInterceptor(error))
+
+    const result = await client.sse.get({
+      url: '/events',
+      onSseError,
+      sseMaxRetryAttempts: 1,
+    })
+
+    await drain(result.stream)
+
+    expect(responseInterceptor).toHaveBeenCalledTimes(1)
+    expect(responseInterceptor.mock.calls[0]?.[0].status).toBe(401)
+    expect(errorInterceptor).toHaveBeenCalledTimes(1)
+    expect(onSseError).toHaveBeenCalledTimes(1)
+    expect(onSseError.mock.calls[0]?.[0]).toBeInstanceOf(Error)
+    expect((onSseError.mock.calls[0]?.[0] as Error).message).toBe('SSE failed: 401 Unauthorized')
+  })
+})

--- a/apps/web/src/composables/api/useBotCreateStream.test.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { BotsBot } from '@memohai/sdk'
-import { reduceBotCreateProgressEvent } from './useBotCreateStream'
+import {
+  collectBotCreateProgressStream,
+  reduceBotCreateProgressEvent,
+  type BotCreateStreamEvent,
+} from './useBotCreateStream'
 
 describe('useBotCreateStream', () => {
   it('keeps the created bot when container setup reports an error', () => {
@@ -21,5 +25,39 @@ describe('useBotCreateStream', () => {
       phase: 'error',
       error: 'container setup failed',
     })
+  })
+
+  it('keeps the created bot when the stream fails after bot_created', async () => {
+    const bot: BotsBot = { id: 'bot-1', name: 'stream-bot' }
+
+    async function* stream(): AsyncGenerator<BotCreateStreamEvent, void, unknown> {
+      yield { type: 'bot_created', bot }
+      throw new Error('connection reset')
+    }
+
+    const result = await collectBotCreateProgressStream(stream())
+
+    expect(result.bot).toEqual(bot)
+    expect(result.setupError).toBe('connection reset')
+    expect(result.progress).toEqual({
+      phase: 'error',
+      error: 'connection reset',
+    })
+  })
+
+  it('ignores stream failures after ready', async () => {
+    const bot: BotsBot = { id: 'bot-1', name: 'stream-bot' }
+
+    async function* stream(): AsyncGenerator<BotCreateStreamEvent, void, unknown> {
+      yield { type: 'bot_created', bot }
+      yield { type: 'ready', bot }
+      throw new Error('late connection reset')
+    }
+
+    const result = await collectBotCreateProgressStream(stream())
+
+    expect(result.bot).toEqual(bot)
+    expect(result.setupError).toBeUndefined()
+    expect(result.progress).toBeUndefined()
   })
 })

--- a/apps/web/src/composables/api/useBotCreateStream.test.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { BotsBot } from '@memohai/sdk'
+import { client } from '@memohai/sdk/client'
 import {
   collectBotCreateProgressStream,
+  postBotsStream,
   reduceBotCreateProgressEvent,
   type BotCreateStreamEvent,
 } from './useBotCreateStream'
 
 describe('useBotCreateStream', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('keeps the created bot when container setup reports an error', () => {
     const bot: BotsBot = { id: 'bot-1', name: 'stream-bot' }
 
@@ -76,5 +82,28 @@ describe('useBotCreateStream', () => {
     expect(result.bot).toEqual(bot)
     expect(result.setupError).toBeUndefined()
     expect(result.progress).toBeUndefined()
+  })
+
+  it('does not throw a stale SSE error after a later successful event', async () => {
+    const bot: BotsBot = { id: 'bot-1', name: 'stream-bot' }
+
+    vi.spyOn(client.sse, 'post').mockImplementation(async (options: Parameters<typeof client.sse.post>[0]) => {
+      options.onSseError?.(new Error('transient reset'))
+      return {
+        stream: (async function* (): AsyncGenerator<BotCreateStreamEvent, void, unknown> {
+          yield { type: 'ready', bot }
+        })(),
+      }
+    })
+
+    const result = await postBotsStream({
+      body: { name: 'stream-bot', display_name: 'Stream Bot' },
+    })
+    const events: BotCreateStreamEvent[] = []
+    for await (const event of result.stream) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([{ type: 'ready', bot }])
   })
 })

--- a/apps/web/src/composables/api/useBotCreateStream.test.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.test.ts
@@ -45,6 +45,23 @@ describe('useBotCreateStream', () => {
     })
   })
 
+  it('calls onEvent for each event in order', async () => {
+    const bot: BotsBot = { id: 'bot-1', name: 'stream-bot' }
+
+    async function* stream(): AsyncGenerator<BotCreateStreamEvent, void, unknown> {
+      yield { type: 'bot_created', bot }
+      yield { type: 'creating' }
+      yield { type: 'ready', bot }
+    }
+
+    const seen: string[] = []
+    await collectBotCreateProgressStream(stream(), {
+      onEvent: event => seen.push(event.type),
+    })
+
+    expect(seen).toEqual(['bot_created', 'creating', 'ready'])
+  })
+
   it('ignores stream failures after ready', async () => {
     const bot: BotsBot = { id: 'bot-1', name: 'stream-bot' }
 

--- a/apps/web/src/composables/api/useBotCreateStream.test.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import type { BotsBot } from '@memohai/sdk'
+import { reduceBotCreateProgressEvent } from './useBotCreateStream'
+
+describe('useBotCreateStream', () => {
+  it('keeps the created bot when container setup reports an error', () => {
+    const bot: BotsBot = { id: 'bot-1', name: 'stream-bot' }
+
+    const created = reduceBotCreateProgressEvent({}, {
+      type: 'bot_created',
+      bot,
+    })
+    const failed = reduceBotCreateProgressEvent(created, {
+      type: 'error',
+      message: 'container setup failed',
+    })
+
+    expect(failed.bot).toEqual(bot)
+    expect(failed.setupError).toBe('container setup failed')
+    expect(failed.progress).toEqual({
+      phase: 'error',
+      error: 'container setup failed',
+    })
+  })
+})

--- a/apps/web/src/composables/api/useBotCreateStream.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.ts
@@ -86,6 +86,48 @@ export function reduceBotCreateProgressEvent(
   }
 }
 
+export type CollectBotCreateProgressStreamOptions = {
+  initialState?: BotCreateProgressState
+  onState?: (state: BotCreateProgressState) => void
+}
+
+export async function collectBotCreateProgressStream(
+  stream: AsyncGenerator<BotCreateStreamEvent, void, unknown>,
+  options: CollectBotCreateProgressStreamOptions = {},
+): Promise<BotCreateProgressState> {
+  let state = options.initialState ?? {}
+  let ready = false
+
+  const update = (next: BotCreateProgressState) => {
+    state = next
+    options.onState?.(state)
+  }
+
+  try {
+    for await (const event of stream) {
+      if (event.type === 'ready') {
+        ready = true
+      }
+      update(reduceBotCreateProgressEvent(state, event))
+    }
+  } catch (error) {
+    if (!state.bot) {
+      throw error
+    }
+    if (ready) {
+      return state
+    }
+    const message = toError(error).message
+    update({
+      ...state,
+      setupError: message,
+      progress: { phase: 'error', error: message },
+    })
+  }
+
+  return state
+}
+
 function isLayerStatus(value: unknown): value is ContainerCreateLayerStatus {
   return !!value
     && typeof value === 'object'

--- a/apps/web/src/composables/api/useBotCreateStream.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.ts
@@ -89,6 +89,7 @@ export function reduceBotCreateProgressEvent(
 export type CollectBotCreateProgressStreamOptions = {
   initialState?: BotCreateProgressState
   onState?: (state: BotCreateProgressState) => void
+  onEvent?: (event: BotCreateStreamEvent) => void
 }
 
 export async function collectBotCreateProgressStream(
@@ -105,6 +106,7 @@ export async function collectBotCreateProgressStream(
 
   try {
     for await (const event of stream) {
+      options.onEvent?.(event)
       if (event.type === 'ready') {
         ready = true
       }

--- a/apps/web/src/composables/api/useBotCreateStream.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.ts
@@ -20,6 +20,72 @@ export type BotCreateStreamResult = {
   stream: AsyncGenerator<BotCreateStreamEvent, void, unknown>
 }
 
+export type BotCreateProgress = {
+  phase: 'preserving' | 'pulling' | 'creating' | 'restoring' | 'complete' | 'error'
+  layers?: ContainerCreateLayerStatus[]
+  image?: string
+  error?: string
+}
+
+export type BotCreateProgressState = {
+  bot?: BotsBot
+  progress?: BotCreateProgress
+  setupError?: string
+}
+
+export function botCreateProgressPercent(progress: BotCreateProgress | null | undefined): number {
+  const layers = progress?.layers
+  if (!layers || layers.length === 0) return 0
+  let totalOffset = 0
+  let totalSize = 0
+  for (const layer of layers) {
+    totalOffset += layer.offset
+    totalSize += layer.total
+  }
+  return totalSize > 0 ? Math.round((totalOffset / totalSize) * 100) : 0
+}
+
+export function reduceBotCreateProgressEvent(
+  state: BotCreateProgressState,
+  event: BotCreateStreamEvent,
+): BotCreateProgressState {
+  switch (event.type) {
+    case 'bot_created':
+      return { ...state, bot: event.bot }
+    case 'pulling':
+      return { ...state, progress: { phase: 'pulling', image: event.image } }
+    case 'pull_progress':
+      return {
+        ...state,
+        progress: {
+          phase: 'pulling',
+          image: state.progress?.image,
+          layers: event.layers,
+        },
+      }
+    case 'pull_skipped':
+    case 'pull_delegated':
+      return {
+        ...state,
+        progress: event.image === 'local'
+          ? { phase: 'creating' }
+          : { phase: 'pulling', image: event.image },
+      }
+    case 'creating':
+      return { ...state, progress: { phase: 'creating' } }
+    case 'restoring':
+      return { ...state, progress: { phase: 'restoring' } }
+    case 'ready':
+      return { ...state, bot: event.bot }
+    case 'error':
+      return {
+        ...state,
+        setupError: event.message,
+        progress: { phase: 'error', error: event.message },
+      }
+  }
+}
+
 function isLayerStatus(value: unknown): value is ContainerCreateLayerStatus {
   return !!value
     && typeof value === 'object'

--- a/apps/web/src/composables/api/useBotCreateStream.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.ts
@@ -1,0 +1,106 @@
+import { client } from '@memohai/sdk/client'
+import type { Options } from '@memohai/sdk'
+import type { BotsBot, PostBotsData } from '@memohai/sdk'
+import type { ContainerCreateLayerStatus } from './useContainerStream'
+
+// codesync(bot-create-stream): keep these manual SSE payload types in sync
+// with internal/handlers/users.go.
+export type BotCreateStreamEvent =
+  | { type: 'bot_created'; bot: BotsBot }
+  | { type: 'pulling'; image: string }
+  | { type: 'pull_progress'; layers: ContainerCreateLayerStatus[] }
+  | { type: 'pull_skipped'; image: string; message?: string }
+  | { type: 'pull_delegated'; image: string; message?: string }
+  | { type: 'creating' }
+  | { type: 'restoring' }
+  | { type: 'ready'; bot: BotsBot }
+  | { type: 'error'; message: string }
+
+export type BotCreateStreamResult = {
+  stream: AsyncGenerator<BotCreateStreamEvent, void, unknown>
+}
+
+function isLayerStatus(value: unknown): value is ContainerCreateLayerStatus {
+  return !!value
+    && typeof value === 'object'
+    && typeof (value as { ref?: unknown }).ref === 'string'
+    && typeof (value as { offset?: unknown }).offset === 'number'
+    && typeof (value as { total?: unknown }).total === 'number'
+}
+
+function isBot(value: unknown): value is BotsBot {
+  return !!value && typeof value === 'object'
+}
+
+function isBotCreateStreamEvent(value: unknown): value is BotCreateStreamEvent {
+  if (!value || typeof value !== 'object') return false
+
+  const event = value as Record<string, unknown>
+  switch (event.type) {
+    case 'bot_created':
+    case 'ready':
+      return isBot(event.bot)
+    case 'pulling':
+      return typeof event.image === 'string'
+    case 'pull_progress':
+      return Array.isArray(event.layers) && event.layers.every(isLayerStatus)
+    case 'pull_skipped':
+    case 'pull_delegated':
+      return typeof event.image === 'string'
+        && (event.message === undefined || typeof event.message === 'string')
+    case 'creating':
+    case 'restoring':
+      return true
+    case 'error':
+      return typeof event.message === 'string'
+    default:
+      return false
+  }
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) return error
+  if (typeof error === 'string' && error.trim()) return new Error(error)
+  return new Error('Bot create stream failed')
+}
+
+export async function postBotsStream(
+  options: Options<PostBotsData>,
+): Promise<BotCreateStreamResult> {
+  let streamError: unknown
+
+  const { throwOnError: _throwOnError, ...rest } = options
+  const result = await client.sse.post<BotCreateStreamEvent>({
+    url: '/bots',
+    ...rest,
+    headers: {
+      ...options.headers as Record<string, string>,
+      Accept: 'text/event-stream',
+      'Content-Type': 'application/json',
+    },
+    onSseError: (error) => {
+      streamError = error
+    },
+    responseValidator: async (data) => {
+      if (!isBotCreateStreamEvent(data)) {
+        throw new Error('Invalid bot create stream event')
+      }
+    },
+    sseMaxRetryAttempts: 1,
+  })
+
+  return {
+    stream: (async function* () {
+      for await (const event of result.stream as AsyncGenerator<unknown, void, unknown>) {
+        if (!isBotCreateStreamEvent(event)) {
+          throw new Error('Invalid bot create stream event')
+        }
+        yield event
+      }
+
+      if (streamError) {
+        throw toError(streamError)
+      }
+    })(),
+  }
+}

--- a/apps/web/src/composables/api/useBotCreateStream.ts
+++ b/apps/web/src/composables/api/useBotCreateStream.ts
@@ -205,6 +205,7 @@ export async function postBotsStream(
         if (!isBotCreateStreamEvent(event)) {
           throw new Error('Invalid bot create stream event')
         }
+        streamError = undefined
         yield event
       }
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1117,6 +1117,23 @@
       "settingsDesc": "Timezone and more"
     },
     "createBotLocalHint": "Local bots use a folder on this computer and are not sandboxed.",
+    "create": {
+      "terminalTitle": "Setting up {name}",
+      "terminalSubtitle": "Provisioning the workspace container. You'll be taken to your bot automatically when it's ready.",
+      "failedSubtitle": "Something went wrong while setting up the workspace.",
+      "failedTitle": "Setup failed",
+      "retry": "Retry",
+      "back": "Back to form",
+      "line": {
+        "command": "Creating bot \"{name}\"",
+        "botCreated": "Bot record created",
+        "pulling": "Pulling base image",
+        "creating": "Creating container",
+        "restoring": "Restoring memory & data",
+        "ready": "Bot is ready",
+        "applyingSettings": "Applying model & memory settings"
+      }
+    },
     "workspaceBackend": "Workspace",
     "workspaceBackendHint": "Container workspaces are isolated. Local workspaces run directly on this computer.",
     "workspaceBackends": {

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1113,6 +1113,23 @@
       "settingsDesc": "时区等"
     },
     "createBotLocalHint": "Local Bot 会使用这台电脑上的文件夹，且不提供沙箱隔离。",
+    "create": {
+      "terminalTitle": "正在准备 {name}",
+      "terminalSubtitle": "正在创建工作区容器。准备完成后会自动打开这个 Bot。",
+      "failedSubtitle": "准备工作区时出现问题。",
+      "failedTitle": "准备失败",
+      "retry": "重试",
+      "back": "返回表单",
+      "line": {
+        "command": "正在创建 Bot「{name}」",
+        "botCreated": "已创建 Bot 记录",
+        "pulling": "正在拉取基础镜像",
+        "creating": "正在创建容器",
+        "restoring": "正在恢复记忆与数据",
+        "ready": "Bot 已就绪",
+        "applyingSettings": "正在应用模型与记忆设置"
+      }
+    },
     "workspaceBackend": "工作区",
     "workspaceBackendHint": "容器工作区提供隔离；本地文件夹会直接在宿主机上运行。",
     "workspaceBackends": {

--- a/apps/web/src/pages/bots/components/bot-create-terminal.vue
+++ b/apps/web/src/pages/bots/components/bot-create-terminal.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { Spinner } from '@memohai/ui'
+import { Check, X, ChevronRight } from 'lucide-vue-next'
+import { computed, nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { BotCreateTerminalLine, BotCreateTerminalLineKind } from '@/composables/api/botCreateTerminal'
+
+const props = defineProps<{
+  lines: BotCreateTerminalLine[]
+}>()
+
+const { t } = useI18n()
+
+const lineLabelKey: Partial<Record<BotCreateTerminalLineKind, string>> = {
+  command: 'bots.create.line.command',
+  'bot-created': 'bots.create.line.botCreated',
+  pulling: 'bots.create.line.pulling',
+  creating: 'bots.create.line.creating',
+  restoring: 'bots.create.line.restoring',
+  ready: 'bots.create.line.ready',
+  'applying-settings': 'bots.create.line.applyingSettings',
+}
+
+function labelFor(line: BotCreateTerminalLine): string {
+  if (line.kind === 'error') return line.message ?? t('bots.create.failedTitle')
+  const key = lineLabelKey[line.kind]
+  if (!key) return ''
+  return t(key, { name: line.message ?? '' })
+}
+
+const scroller = ref<HTMLElement | null>(null)
+
+watch(
+  () => props.lines.length,
+  async () => {
+    await nextTick()
+    const el = scroller.value
+    if (el) el.scrollTop = el.scrollHeight
+  },
+)
+
+const hasLines = computed(() => props.lines.length > 0)
+</script>
+
+<template>
+  <div
+    ref="scroller"
+    class="max-h-72 overflow-y-auto rounded-lg border border-zinc-800 bg-zinc-950 p-4 font-mono text-xs leading-relaxed text-zinc-100"
+    role="log"
+    aria-live="polite"
+  >
+    <p
+      v-if="!hasLines"
+      class="text-zinc-500"
+    >
+      &nbsp;
+    </p>
+    <div
+      v-for="line in lines"
+      :key="line.id"
+      class="flex items-start gap-2 py-0.5"
+      :class="{ 'text-zinc-500': line.kind === 'command' }"
+    >
+      <span class="mt-0.5 flex size-3.5 shrink-0 items-center justify-center">
+        <Spinner
+          v-if="line.status === 'running'"
+          class="size-3.5 text-zinc-300"
+        />
+        <Check
+          v-else-if="line.status === 'done'"
+          class="size-3.5 text-emerald-400"
+        />
+        <X
+          v-else-if="line.status === 'error'"
+          class="size-3.5 text-red-400"
+        />
+        <ChevronRight
+          v-else
+          class="size-3.5 text-zinc-500"
+        />
+      </span>
+      <span
+        class="min-w-0 flex-1 break-words"
+        :class="{ 'text-red-400': line.status === 'error' }"
+      >
+        {{ labelFor(line) }}
+        <span
+          v-if="line.image && line.kind === 'pulling'"
+          class="text-zinc-500"
+        >· {{ line.image }}</span>
+        <span
+          v-if="line.kind === 'pulling' && typeof line.percent === 'number' && line.percent > 0"
+          class="text-zinc-400 tabular-nums"
+        >· {{ line.percent }}%</span>
+      </span>
+    </div>
+  </div>
+</template>

--- a/apps/web/src/pages/bots/new-progress.test.ts
+++ b/apps/web/src/pages/bots/new-progress.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { createApp, h, KeepAlive, nextTick, ref } from 'vue'
+import type { Slots } from 'vue'
+import { useBotCreateProgressStore } from '@/store/bot-create-progress'
+
+const routerReplace = vi.fn()
+const invalidateQueries = vi.fn()
+
+function translate(key: string, params?: Record<string, string>) {
+  return params?.name ? `${key}:${params.name}` : key
+}
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    replace: routerReplace,
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: translate,
+  }),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useQueryCache: () => ({
+    invalidateQueries,
+  }),
+}))
+
+vi.mock('@memohai/sdk/colada', () => ({
+  getBotsQueryKey: () => ['bots'],
+}))
+
+vi.mock('@memohai/ui', async () => {
+  const { h } = await import('vue')
+  const Passthrough = (_props: Record<string, unknown>, { slots }: { slots: Slots }) => {
+    return h('div', slots.default?.())
+  }
+  const Button = Object.assign((
+    _props: Record<string, unknown>,
+    { emit, slots }: { emit: (event: 'click') => void, slots: Slots },
+  ) => {
+    return h('button', { onClick: () => emit('click') }, slots.default?.())
+  }, {
+    emits: ['click'],
+  })
+  return {
+    Avatar: Passthrough,
+    AvatarFallback: Passthrough,
+    AvatarImage: Passthrough,
+    Button,
+    Spinner: Passthrough,
+  }
+})
+
+function setupStore() {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const store = useBotCreateProgressStore()
+  store.status = 'creating'
+  store.display = { display_name: 'Prog', name: 'prog' }
+  store.bot = { id: 'bot-1', name: 'prog' }
+  return { pinia, store }
+}
+
+async function mountKeptProgress() {
+  const { pinia, store } = setupStore()
+  const ProgressPage = (await import('./new-progress.vue')).default
+  const show = ref(true)
+  const app = createApp({
+    name: 'ProgressRouteTestHost',
+    setup() {
+      return () => h(KeepAlive, null, () => show.value ? h(ProgressPage) : h('div'))
+    },
+  })
+  const root = document.createElement('div')
+  document.body.append(root)
+  app.use(pinia)
+  app.config.globalProperties.$t = translate
+  app.mount(root)
+  await nextTick()
+
+  return {
+    app,
+    root,
+    show,
+    store,
+    async deactivate() {
+      show.value = false
+      await nextTick()
+    },
+    async activate() {
+      show.value = true
+      await nextTick()
+    },
+  }
+}
+
+describe('bot create progress route', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    routerReplace.mockReset()
+    invalidateQueries.mockReset()
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not navigate after the ready redirect delay when deactivated', async () => {
+    const mounted = await mountKeptProgress()
+
+    mounted.store.status = 'ready'
+    await nextTick()
+    await mounted.deactivate()
+    await vi.advanceTimersByTimeAsync(700)
+
+    expect(routerReplace).not.toHaveBeenCalled()
+    expect(invalidateQueries).not.toHaveBeenCalled()
+
+    mounted.app.unmount()
+    mounted.root.remove()
+  })
+
+  it('redirects back to the create form when reactivated without an in-memory stream', async () => {
+    const mounted = await mountKeptProgress()
+
+    await mounted.deactivate()
+    mounted.store.reset()
+    routerReplace.mockClear()
+
+    await mounted.activate()
+
+    expect(routerReplace).toHaveBeenCalledWith({ name: 'bot-new' })
+
+    mounted.app.unmount()
+    mounted.root.remove()
+  })
+})

--- a/apps/web/src/pages/bots/new-progress.test.ts
+++ b/apps/web/src/pages/bots/new-progress.test.ts
@@ -110,6 +110,8 @@ describe('bot create progress route', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     routerReplace.mockReset()
+    // Real vue-router returns a Promise that resolves when navigation commits.
+    routerReplace.mockResolvedValue(undefined)
     invalidateQueries.mockReset()
     document.body.innerHTML = ''
   })
@@ -128,6 +130,38 @@ describe('bot create progress route', () => {
 
     expect(routerReplace).not.toHaveBeenCalled()
     expect(invalidateQueries).not.toHaveBeenCalled()
+
+    mounted.app.unmount()
+    mounted.root.remove()
+  })
+
+  it('keeps the terminal intact until navigation commits, then resets', async () => {
+    let resolveReplace: (() => void) | undefined
+    routerReplace.mockImplementation(() => new Promise<void>((resolve) => {
+      resolveReplace = resolve
+    }))
+
+    const mounted = await mountKeptProgress()
+    mounted.store.status = 'ready'
+    mounted.store.lines = [{ id: 'ready', kind: 'ready', status: 'done' }]
+    await nextTick()
+
+    // Fire the 700ms ready redirect: goToBot() -> router.replace() (still pending).
+    await vi.advanceTimersByTimeAsync(700)
+
+    expect(routerReplace).toHaveBeenCalledWith({ name: 'bot-detail', params: { botName: 'prog' } })
+    // Navigation has not committed yet, so the store must stay intact — otherwise
+    // the still-visible terminal flashes empty before the view swaps.
+    expect(mounted.store.status).toBe('ready')
+    expect(mounted.store.lines).toHaveLength(1)
+
+    // Commit the navigation; only now should the store reset.
+    resolveReplace?.()
+    await nextTick()
+    await nextTick()
+
+    expect(mounted.store.status).toBe('idle')
+    expect(mounted.store.lines).toEqual([])
 
     mounted.app.unmount()
     mounted.root.remove()

--- a/apps/web/src/pages/bots/new-progress.vue
+++ b/apps/web/src/pages/bots/new-progress.vue
@@ -48,7 +48,7 @@
 
 <script setup lang="ts">
 import { Avatar, AvatarImage, AvatarFallback, Button } from '@memohai/ui'
-import { computed, onMounted, watch } from 'vue'
+import { computed, onActivated, onBeforeUnmount, onDeactivated, onMounted, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
@@ -69,9 +69,29 @@ const displayName = computed(() => display.value?.display_name || '')
 const avatarFallback = useAvatarInitials(() => displayName.value)
 
 let navigated = false
+let readyRedirectTimer: ReturnType<typeof window.setTimeout> | null = null
+let resetTimer: ReturnType<typeof window.setTimeout> | null = null
+
+function clearReadyRedirectTimer() {
+  if (readyRedirectTimer === null) return
+  window.clearTimeout(readyRedirectTimer)
+  readyRedirectTimer = null
+}
+
+function clearResetTimer() {
+  if (resetTimer === null) return
+  window.clearTimeout(resetTimer)
+  resetTimer = null
+}
+
+function clearTimers() {
+  clearReadyRedirectTimer()
+  clearResetTimer()
+}
 
 function goToBot() {
   if (navigated) return
+  clearReadyRedirectTimer()
   navigated = true
   const target = bot.value?.name ?? bot.value?.id
   if (setupError.value) {
@@ -86,15 +106,38 @@ function goToBot() {
     router.replace({ name: 'bots' })
   }
   // Clear once the navigation is committed so a fresh create starts clean.
-  window.setTimeout(() => store.reset(), 0)
+  resetTimer = window.setTimeout(() => {
+    resetTimer = null
+    store.reset()
+  }, 0)
+}
+
+function scheduleReadyRedirect() {
+  clearReadyRedirectTimer()
+  // Brief pause so the final "ready" line is visible before redirecting.
+  readyRedirectTimer = window.setTimeout(() => {
+    readyRedirectTimer = null
+    goToBot()
+  }, 700)
+}
+
+function guardLiveProgress() {
+  if (status.value === 'idle') {
+    router.replace({ name: 'bot-new' })
+    return
+  }
+  if (status.value === 'ready' && !navigated) {
+    scheduleReadyRedirect()
+  }
 }
 
 watch(
   status,
   (value) => {
     if (value === 'ready') {
-      // Brief pause so the final "ready" line is visible before redirecting.
-      window.setTimeout(goToBot, 700)
+      scheduleReadyRedirect()
+    } else {
+      clearReadyRedirectTimer()
     }
   },
   { immediate: true },
@@ -103,10 +146,12 @@ watch(
 onMounted(() => {
   // Direct navigation or a refresh drops the in-memory stream, so send the user
   // back to the form rather than showing an empty terminal.
-  if (status.value === 'idle') {
-    router.replace({ name: 'bot-new' })
-  }
+  guardLiveProgress()
 })
+
+onActivated(guardLiveProgress)
+onDeactivated(clearTimers)
+onBeforeUnmount(clearTimers)
 
 function handleRetry() {
   navigated = false

--- a/apps/web/src/pages/bots/new-progress.vue
+++ b/apps/web/src/pages/bots/new-progress.vue
@@ -70,7 +70,6 @@ const avatarFallback = useAvatarInitials(() => displayName.value)
 
 let navigated = false
 let readyRedirectTimer: ReturnType<typeof window.setTimeout> | null = null
-let resetTimer: ReturnType<typeof window.setTimeout> | null = null
 
 function clearReadyRedirectTimer() {
   if (readyRedirectTimer === null) return
@@ -78,18 +77,11 @@ function clearReadyRedirectTimer() {
   readyRedirectTimer = null
 }
 
-function clearResetTimer() {
-  if (resetTimer === null) return
-  window.clearTimeout(resetTimer)
-  resetTimer = null
-}
-
 function clearTimers() {
   clearReadyRedirectTimer()
-  clearResetTimer()
 }
 
-function goToBot() {
+async function goToBot() {
   if (navigated) return
   clearReadyRedirectTimer()
   navigated = true
@@ -100,16 +92,17 @@ function goToBot() {
     toast.success(t('bots.createBotSuccess'))
   }
   void queryCache.invalidateQueries({ key: getBotsQueryKey() })
-  if (target) {
-    router.replace({ name: 'bot-detail', params: { botName: target } })
-  } else {
-    router.replace({ name: 'bots' })
+  try {
+    await (target
+      ? router.replace({ name: 'bot-detail', params: { botName: target } })
+      : router.replace({ name: 'bots' }))
+  } catch {
+    // Navigation aborted/failed — keep the page as-is rather than blanking it.
+    return
   }
-  // Clear once the navigation is committed so a fresh create starts clean.
-  resetTimer = window.setTimeout(() => {
-    resetTimer = null
-    store.reset()
-  }, 0)
+  // Reset only after navigation has committed, so the still-mounted terminal
+  // never flashes empty before the view swaps.
+  store.reset()
 }
 
 function scheduleReadyRedirect() {
@@ -117,7 +110,7 @@ function scheduleReadyRedirect() {
   // Brief pause so the final "ready" line is visible before redirecting.
   readyRedirectTimer = window.setTimeout(() => {
     readyRedirectTimer = null
-    goToBot()
+    void goToBot()
   }, 700)
 }
 

--- a/apps/web/src/pages/bots/new-progress.vue
+++ b/apps/web/src/pages/bots/new-progress.vue
@@ -1,0 +1,120 @@
+<template>
+  <section class="relative mx-auto flex min-h-[60vh] max-w-2xl flex-col justify-center px-4 py-10 lg:px-6">
+    <div class="flex items-center gap-4">
+      <Avatar class="size-12 rounded-full">
+        <AvatarImage
+          v-if="display?.avatar_url?.trim()"
+          :src="display.avatar_url.trim()"
+          :alt="displayName"
+        />
+        <AvatarFallback class="text-base">
+          {{ avatarFallback }}
+        </AvatarFallback>
+      </Avatar>
+      <div class="min-w-0">
+        <h1 class="truncate text-lg font-semibold">
+          {{ $t('bots.create.terminalTitle', { name: displayName }) }}
+        </h1>
+        <p class="mt-0.5 text-xs text-muted-foreground">
+          {{ status === 'error' ? $t('bots.create.failedSubtitle') : $t('bots.create.terminalSubtitle') }}
+        </p>
+      </div>
+    </div>
+
+    <BotCreateTerminal
+      :lines="lines"
+      class="mt-6"
+    />
+
+    <div
+      v-if="status === 'error'"
+      class="mt-6 flex justify-end gap-3"
+    >
+      <Button
+        variant="outline"
+        @click="handleBack"
+      >
+        {{ $t('bots.create.back') }}
+      </Button>
+      <Button
+        :disabled="status !== 'error'"
+        @click="handleRetry"
+      >
+        {{ $t('bots.create.retry') }}
+      </Button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { Avatar, AvatarImage, AvatarFallback, Button } from '@memohai/ui'
+import { computed, onMounted, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useRouter } from 'vue-router'
+import { toast } from 'vue-sonner'
+import { useI18n } from 'vue-i18n'
+import { useQueryCache } from '@pinia/colada'
+import { getBotsQueryKey } from '@memohai/sdk/colada'
+import { useAvatarInitials } from '@/composables/useAvatarInitials'
+import { useBotCreateProgressStore } from '@/store/bot-create-progress'
+import BotCreateTerminal from './components/bot-create-terminal.vue'
+
+const router = useRouter()
+const { t } = useI18n()
+const queryCache = useQueryCache()
+const store = useBotCreateProgressStore()
+const { status, lines, display, bot, setupError } = storeToRefs(store)
+
+const displayName = computed(() => display.value?.display_name || '')
+const avatarFallback = useAvatarInitials(() => displayName.value)
+
+let navigated = false
+
+function goToBot() {
+  if (navigated) return
+  navigated = true
+  const target = bot.value?.name ?? bot.value?.id
+  if (setupError.value) {
+    toast.error(setupError.value)
+  } else {
+    toast.success(t('bots.createBotSuccess'))
+  }
+  void queryCache.invalidateQueries({ key: getBotsQueryKey() })
+  if (target) {
+    router.replace({ name: 'bot-detail', params: { botName: target } })
+  } else {
+    router.replace({ name: 'bots' })
+  }
+  // Clear once the navigation is committed so a fresh create starts clean.
+  window.setTimeout(() => store.reset(), 0)
+}
+
+watch(
+  status,
+  (value) => {
+    if (value === 'ready') {
+      // Brief pause so the final "ready" line is visible before redirecting.
+      window.setTimeout(goToBot, 700)
+    }
+  },
+  { immediate: true },
+)
+
+onMounted(() => {
+  // Direct navigation or a refresh drops the in-memory stream, so send the user
+  // back to the form rather than showing an empty terminal.
+  if (status.value === 'idle') {
+    router.replace({ name: 'bot-new' })
+  }
+})
+
+function handleRetry() {
+  navigated = false
+  void store.retry()
+}
+
+function handleBack() {
+  store.reset()
+  router.replace({ name: 'bot-new' })
+}
+</script>

--- a/apps/web/src/pages/bots/new.test.ts
+++ b/apps/web/src/pages/bots/new.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import type { Slots } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  getBotsNameAvailability: vi.fn(),
+  loadCapabilities: vi.fn(),
+  routerBack: vi.fn(),
+  routerPush: vi.fn(),
+  startBotCreate: vi.fn(),
+}))
+
+function translate(key: string) {
+  return key
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({
+    back: mocks.routerBack,
+    push: mocks.routerPush,
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: translate,
+  }),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('@vueuse/core', () => ({
+  useDebounceFn: (fn: (...args: unknown[]) => unknown) => fn,
+}))
+
+vi.mock('@pinia/colada', async () => {
+  const { ref } = await import('vue')
+  return {
+    useQuery: () => ({ data: ref([]) }),
+    useQueryCache: () => ({ invalidateQueries: vi.fn() }),
+  }
+})
+
+vi.mock('@memohai/sdk', () => ({
+  getBotsNameAvailability: (...args: unknown[]) => mocks.getBotsNameAvailability(...args),
+  getMemoryProviders: vi.fn(async () => ({ data: [] })),
+  getModels: vi.fn(async () => ({ data: [] })),
+  getProviders: vi.fn(async () => ({ data: [] })),
+}))
+
+vi.mock('@memohai/sdk/colada', () => ({
+  getBotsQueryKey: () => ['bots'],
+}))
+
+vi.mock('@/store/capabilities', () => ({
+  useCapabilitiesStore: () => ({
+    load: mocks.loadCapabilities,
+    localWorkspaceEnabled: false,
+  }),
+}))
+
+vi.mock('@/store/bot-create-progress', () => ({
+  useBotCreateProgressStore: () => ({
+    bot: null,
+    setupError: null,
+    start: mocks.startBotCreate,
+    status: 'idle',
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables/useAvatarInitials', () => ({
+  useAvatarInitials: () => 'P',
+}))
+
+vi.mock('@memohai/ui', async () => {
+  const { h } = await import('vue')
+  const Passthrough = (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.())
+  const Button = (props: Record<string, unknown>, { attrs, slots }: { attrs: Record<string, unknown>, slots: Slots }) =>
+    h('button', { ...attrs, disabled: props.disabled, type: props.type ?? 'button' }, slots.default?.())
+  const Input = Object.assign((
+    props: { modelValue?: string },
+    { attrs, emit }: { attrs: Record<string, unknown>, emit: (event: 'update:modelValue', value: string) => void },
+  ) =>
+    h('input', {
+      ...attrs,
+      value: props.modelValue ?? '',
+      onInput: (event: Event) => emit('update:modelValue', (event.target as HTMLInputElement).value),
+    }), {
+    emits: ['update:modelValue'],
+  })
+  return {
+    Avatar: Passthrough,
+    AvatarFallback: Passthrough,
+    AvatarImage: Passthrough,
+    Button,
+    Input,
+    Label: Passthrough,
+    Select: Passthrough,
+    SelectContent: Passthrough,
+    SelectItem: Passthrough,
+    SelectTrigger: Passthrough,
+    SelectValue: Passthrough,
+    Separator: Passthrough,
+    Spinner: Passthrough,
+    Tabs: Passthrough,
+    TabsList: Passthrough,
+    TabsTrigger: Passthrough,
+    Tooltip: Passthrough,
+    TooltipContent: Passthrough,
+    TooltipTrigger: Passthrough,
+  }
+})
+
+vi.mock('lucide-vue-next', async () => {
+  const { h } = await import('vue')
+  const Icon = () => h('span')
+  return {
+    Check: Icon,
+    CircleHelp: Icon,
+    LoaderCircle: Icon,
+    SquarePen: Icon,
+    X: Icon,
+  }
+})
+
+vi.mock('@/components/timezone-select/index.vue', () => ({ default: (_props: Record<string, unknown>) => h('select') }))
+vi.mock('./components/avatar-edit-dialog.vue', () => ({ default: () => h('div') }))
+vi.mock('./components/bot-import-panel.vue', () => ({ default: () => h('div') }))
+vi.mock('./components/memory-provider-select.vue', () => ({ default: () => h('select') }))
+vi.mock('./components/model-select.vue', () => ({ default: () => h('select') }))
+
+describe('bot create page', () => {
+  beforeEach(() => {
+    mocks.getBotsNameAvailability.mockResolvedValue({ data: { available: true } })
+    mocks.loadCapabilities.mockReset()
+    mocks.routerBack.mockReset()
+    mocks.routerPush.mockReset()
+    mocks.startBotCreate.mockReset()
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('clears submit loading after handing container creation to the progress route', async () => {
+    const Page = (await import('./new.vue')).default
+    const root = document.createElement('div')
+    document.body.append(root)
+    const app = createApp(Page)
+    app.config.globalProperties.$t = translate
+    app.mount(root)
+    await flushPromises()
+
+    const [displayInput] = Array.from(root.querySelectorAll('input'))
+    displayInput!.value = 'Prog'
+    displayInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const form = root.querySelector('form')!
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.startBotCreate).toHaveBeenCalledTimes(1)
+    expect(mocks.routerPush).toHaveBeenCalledWith({ name: 'bot-create-progress' })
+    expect(form.getAttribute('aria-busy')).toBe('false')
+
+    app.unmount()
+    root.remove()
+  })
+})

--- a/apps/web/src/pages/bots/new.vue
+++ b/apps/web/src/pages/bots/new.vue
@@ -380,7 +380,7 @@ import { toast } from 'vue-sonner'
 import { useI18n } from 'vue-i18n'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { getModels, getProviders, getMemoryProviders, getBotsNameAvailability, putBotsByBotIdSettings } from '@memohai/sdk'
-import type { BotsBot, BotsCreateBotRequest } from '@memohai/sdk'
+import type { BotsCreateBotRequest } from '@memohai/sdk'
 import { getBotsQueryKey } from '@memohai/sdk/colada'
 import { useCapabilitiesStore } from '@/store/capabilities'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
@@ -388,8 +388,12 @@ import { resolveApiErrorMessage } from '@/utils/api-error'
 import { aclPresetOptions, defaultAclPreset } from '@/constants/acl-presets'
 import { emptyTimezoneValue } from '@/utils/timezones'
 import TimezoneSelect from '@/components/timezone-select/index.vue'
-import { postBotsStream, type BotCreateStreamEvent } from '@/composables/api/useBotCreateStream'
-import type { ContainerCreateLayerStatus } from '@/composables/api/useContainerStream'
+import {
+  botCreateProgressPercent,
+  postBotsStream,
+  reduceBotCreateProgressEvent,
+  type BotCreateProgressState,
+} from '@/composables/api/useBotCreateStream'
 import ModelSelect from './components/model-select.vue'
 import MemoryProviderSelect from './components/memory-provider-select.vue'
 import AvatarEditDialog from './components/avatar-edit-dialog.vue'
@@ -573,29 +577,12 @@ const canSubmit = computed(() => {
   return true
 })
 
-// Submit
-type CreateProgress = {
-  phase: 'preserving' | 'pulling' | 'creating' | 'restoring' | 'complete' | 'error'
-  layers?: ContainerCreateLayerStatus[]
-  image?: string
-  error?: string
-}
-
 const submitLoading = ref(false)
-const createProgress = ref<CreateProgress | null>(null)
+const createState = ref<BotCreateProgressState>({})
+const createProgress = computed(() => createState.value.progress ?? null)
 const isCreateFlowBlocked = computed(() => submitLoading.value)
 
-const createProgressPercent = computed(() => {
-  const layers = createProgress.value?.layers
-  if (!layers || layers.length === 0) return 0
-  let totalOffset = 0
-  let totalSize = 0
-  for (const layer of layers) {
-    totalOffset += layer.offset
-    totalSize += layer.total
-  }
-  return totalSize > 0 ? Math.round((totalOffset / totalSize) * 100) : 0
-})
+const createProgressPercent = computed(() => botCreateProgressPercent(createProgress.value))
 
 // Detect a name-uniqueness conflict (HTTP 409) from the create request, used as
 // a fallback when the realtime check raced with submission.
@@ -614,57 +601,22 @@ function handleImported(botId: string) {
   }
 }
 
-function applyCreateBotEvent(event: BotCreateStreamEvent): BotsBot | undefined {
-  switch (event.type) {
-    case 'bot_created':
-      return event.bot
-    case 'pulling':
-      createProgress.value = { phase: 'pulling', image: event.image }
-      return undefined
-    case 'pull_progress':
-      createProgress.value = {
-        phase: 'pulling',
-        image: createProgress.value?.image,
-        layers: event.layers,
-      }
-      return undefined
-    case 'pull_skipped':
-    case 'pull_delegated':
-      createProgress.value = event.image === 'local'
-        ? { phase: 'creating' }
-        : { phase: 'pulling', image: event.image }
-      return undefined
-    case 'creating':
-      createProgress.value = { phase: 'creating' }
-      return undefined
-    case 'restoring':
-      createProgress.value = { phase: 'restoring' }
-      return undefined
-    case 'ready':
-      return event.bot
-    case 'error':
-      createProgress.value = { phase: 'error', error: event.message }
-      throw new Error(event.message || 'Unknown error')
-  }
-}
-
-async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotsBot | undefined> {
+async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotCreateProgressState> {
   const { stream } = await postBotsStream({
     body,
     throwOnError: true,
   })
 
-  let bot: BotsBot | undefined
   for await (const event of stream) {
-    bot = applyCreateBotEvent(event) ?? bot
+    createState.value = reduceBotCreateProgressEvent(createState.value, event)
   }
-  return bot
+  return createState.value
 }
 
 async function handleSubmit() {
   if (!canSubmit.value || isCreateFlowBlocked.value) return
   submitLoading.value = true
-  createProgress.value = form.workspace_backend === 'local' ? null : { phase: 'pulling' }
+  createState.value = form.workspace_backend === 'local' ? {} : { progress: { phase: 'pulling' } }
 
   const metadata = localWorkspaceEnabled.value && form.workspace_backend === 'local'
     ? {
@@ -678,7 +630,7 @@ async function handleSubmit() {
   const tz = form.timezone === emptyTimezoneValue ? undefined : form.timezone || undefined
 
   try {
-    const bot = await createBotWithProgress({
+    const result = await createBotWithProgress({
       name: form.name.trim(),
       display_name: form.display_name.trim(),
       avatar_url: form.avatar_url.trim() || undefined,
@@ -689,8 +641,12 @@ async function handleSubmit() {
       wait_for_ready: true,
     })
 
+    const bot = result.bot
     const botId = bot?.id
     const botName = bot?.name ?? botId
+    if (!botId) {
+      throw new Error(t('common.saveFailed'))
+    }
     if (botId && (form.chat_model_id || form.memory_provider_id)) {
       try {
         await putBotsByBotIdSettings({
@@ -706,7 +662,11 @@ async function handleSubmit() {
       }
     }
 
-    toast.success(t('bots.createBotSuccess'))
+    if (result.setupError) {
+      toast.error(result.setupError)
+    } else {
+      toast.success(t('bots.createBotSuccess'))
+    }
     if (botName) {
       router.push({ name: 'bot-detail', params: { botName } })
     } else {
@@ -721,7 +681,7 @@ async function handleSubmit() {
     toast.error(resolveApiErrorMessage(error, t('common.saveFailed')))
   } finally {
     submitLoading.value = false
-    createProgress.value = null
+    createState.value = {}
     void queryCache.invalidateQueries({ key: getBotsQueryKey() })
   }
 }

--- a/apps/web/src/pages/bots/new.vue
+++ b/apps/web/src/pages/bots/new.vue
@@ -328,6 +328,16 @@
           <p class="mt-1 text-xs leading-relaxed text-muted-foreground">
             {{ $t('bots.createBotSetupDesc') }}
           </p>
+          <div
+            v-if="createProgress && form.workspace_backend !== 'local'"
+            class="mt-3 w-full"
+          >
+            <ContainerCreateProgress
+              :phase="createProgress.phase"
+              :percent="createProgressPercent"
+              :error="createProgress.error"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -368,19 +378,23 @@ import { useDebounceFn } from '@vueuse/core'
 import { useRouter, useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import { useI18n } from 'vue-i18n'
-import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { getModels, getProviders, getMemoryProviders, getBotsNameAvailability, putBotsByBotIdSettings } from '@memohai/sdk'
-import { postBotsMutation, getBotsQueryKey } from '@memohai/sdk/colada'
+import type { BotsBot, BotsCreateBotRequest } from '@memohai/sdk'
+import { getBotsQueryKey } from '@memohai/sdk/colada'
 import { useCapabilitiesStore } from '@/store/capabilities'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import { aclPresetOptions, defaultAclPreset } from '@/constants/acl-presets'
 import { emptyTimezoneValue } from '@/utils/timezones'
 import TimezoneSelect from '@/components/timezone-select/index.vue'
+import { postBotsStream, type BotCreateStreamEvent } from '@/composables/api/useBotCreateStream'
+import type { ContainerCreateLayerStatus } from '@/composables/api/useContainerStream'
 import ModelSelect from './components/model-select.vue'
 import MemoryProviderSelect from './components/memory-provider-select.vue'
 import AvatarEditDialog from './components/avatar-edit-dialog.vue'
 import BotImportPanel from './components/bot-import-panel.vue'
+import ContainerCreateProgress from './components/container-create-progress.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -560,12 +574,28 @@ const canSubmit = computed(() => {
 })
 
 // Submit
-const { mutateAsync: createBot, isLoading: submitLoading } = useMutation({
-  ...postBotsMutation(),
-  onSettled: () => queryCache.invalidateQueries({ key: getBotsQueryKey() }),
-})
+type CreateProgress = {
+  phase: 'preserving' | 'pulling' | 'creating' | 'restoring' | 'complete' | 'error'
+  layers?: ContainerCreateLayerStatus[]
+  image?: string
+  error?: string
+}
 
+const submitLoading = ref(false)
+const createProgress = ref<CreateProgress | null>(null)
 const isCreateFlowBlocked = computed(() => submitLoading.value)
+
+const createProgressPercent = computed(() => {
+  const layers = createProgress.value?.layers
+  if (!layers || layers.length === 0) return 0
+  let totalOffset = 0
+  let totalSize = 0
+  for (const layer of layers) {
+    totalOffset += layer.offset
+    totalSize += layer.total
+  }
+  return totalSize > 0 ? Math.round((totalOffset / totalSize) * 100) : 0
+})
 
 // Detect a name-uniqueness conflict (HTTP 409) from the create request, used as
 // a fallback when the realtime check raced with submission.
@@ -584,8 +614,57 @@ function handleImported(botId: string) {
   }
 }
 
+function applyCreateBotEvent(event: BotCreateStreamEvent): BotsBot | undefined {
+  switch (event.type) {
+    case 'bot_created':
+      return event.bot
+    case 'pulling':
+      createProgress.value = { phase: 'pulling', image: event.image }
+      return undefined
+    case 'pull_progress':
+      createProgress.value = {
+        phase: 'pulling',
+        image: createProgress.value?.image,
+        layers: event.layers,
+      }
+      return undefined
+    case 'pull_skipped':
+    case 'pull_delegated':
+      createProgress.value = event.image === 'local'
+        ? { phase: 'creating' }
+        : { phase: 'pulling', image: event.image }
+      return undefined
+    case 'creating':
+      createProgress.value = { phase: 'creating' }
+      return undefined
+    case 'restoring':
+      createProgress.value = { phase: 'restoring' }
+      return undefined
+    case 'ready':
+      return event.bot
+    case 'error':
+      createProgress.value = { phase: 'error', error: event.message }
+      throw new Error(event.message || 'Unknown error')
+  }
+}
+
+async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotsBot | undefined> {
+  const { stream } = await postBotsStream({
+    body,
+    throwOnError: true,
+  })
+
+  let bot: BotsBot | undefined
+  for await (const event of stream) {
+    bot = applyCreateBotEvent(event) ?? bot
+  }
+  return bot
+}
+
 async function handleSubmit() {
   if (!canSubmit.value || isCreateFlowBlocked.value) return
+  submitLoading.value = true
+  createProgress.value = form.workspace_backend === 'local' ? null : { phase: 'pulling' }
 
   const metadata = localWorkspaceEnabled.value && form.workspace_backend === 'local'
     ? {
@@ -599,17 +678,15 @@ async function handleSubmit() {
   const tz = form.timezone === emptyTimezoneValue ? undefined : form.timezone || undefined
 
   try {
-    const bot = await createBot({
-      body: {
-        name: form.name.trim(),
-        display_name: form.display_name.trim(),
-        avatar_url: form.avatar_url.trim() || undefined,
-        timezone: tz,
-        is_active: true,
-        acl_preset: form.acl_preset,
-        metadata,
-        wait_for_ready: true,
-      },
+    const bot = await createBotWithProgress({
+      name: form.name.trim(),
+      display_name: form.display_name.trim(),
+      avatar_url: form.avatar_url.trim() || undefined,
+      timezone: tz,
+      is_active: true,
+      acl_preset: form.acl_preset,
+      metadata,
+      wait_for_ready: true,
     })
 
     const botId = bot?.id
@@ -642,6 +719,10 @@ async function handleSubmit() {
       return
     }
     toast.error(resolveApiErrorMessage(error, t('common.saveFailed')))
+  } finally {
+    submitLoading.value = false
+    createProgress.value = null
+    void queryCache.invalidateQueries({ key: getBotsQueryKey() })
   }
 }
 </script>

--- a/apps/web/src/pages/bots/new.vue
+++ b/apps/web/src/pages/bots/new.vue
@@ -609,7 +609,11 @@ async function handleSubmit() {
 
   // Container backend: hand the live stream off to the dedicated progress route.
   void store.start(payload, options)
-  router.push({ name: 'bot-create-progress' })
+  try {
+    await router.push({ name: 'bot-create-progress' })
+  } finally {
+    submitLoading.value = false
+  }
 }
 
 function finishLocalCreate() {

--- a/apps/web/src/pages/bots/new.vue
+++ b/apps/web/src/pages/bots/new.vue
@@ -390,8 +390,8 @@ import { emptyTimezoneValue } from '@/utils/timezones'
 import TimezoneSelect from '@/components/timezone-select/index.vue'
 import {
   botCreateProgressPercent,
+  collectBotCreateProgressStream,
   postBotsStream,
-  reduceBotCreateProgressEvent,
   type BotCreateProgressState,
 } from '@/composables/api/useBotCreateStream'
 import ModelSelect from './components/model-select.vue'
@@ -607,10 +607,12 @@ async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotCre
     throwOnError: true,
   })
 
-  for await (const event of stream) {
-    createState.value = reduceBotCreateProgressEvent(createState.value, event)
-  }
-  return createState.value
+  return collectBotCreateProgressStream(stream, {
+    initialState: createState.value,
+    onState: (state) => {
+      createState.value = state
+    },
+  })
 }
 
 async function handleSubmit() {

--- a/apps/web/src/pages/bots/new.vue
+++ b/apps/web/src/pages/bots/new.vue
@@ -313,35 +313,6 @@
       </div>
     </form>
 
-    <div
-      v-if="isCreateFlowBlocked"
-      class="absolute inset-0 z-10 flex items-start justify-center bg-background/70 pt-20 backdrop-blur-[1px]"
-      role="status"
-      aria-live="polite"
-    >
-      <div class="flex max-w-md items-start gap-3 rounded-md border bg-background px-4 py-3 shadow-sm">
-        <Spinner class="mt-0.5 shrink-0" />
-        <div class="min-w-0">
-          <p class="text-sm font-medium">
-            {{ $t('bots.createBotSetupTitle') }}
-          </p>
-          <p class="mt-1 text-xs leading-relaxed text-muted-foreground">
-            {{ $t('bots.createBotSetupDesc') }}
-          </p>
-          <div
-            v-if="createProgress && form.workspace_backend !== 'local'"
-            class="mt-3 w-full"
-          >
-            <ContainerCreateProgress
-              :phase="createProgress.phase"
-              :percent="createProgressPercent"
-              :error="createProgress.error"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-
     <AvatarEditDialog
       v-model:open="avatarDialogOpen"
       v-model:avatar-url="form.avatar_url"
@@ -379,26 +350,19 @@ import { useRouter, useRoute } from 'vue-router'
 import { toast } from 'vue-sonner'
 import { useI18n } from 'vue-i18n'
 import { useQuery, useQueryCache } from '@pinia/colada'
-import { getModels, getProviders, getMemoryProviders, getBotsNameAvailability, putBotsByBotIdSettings } from '@memohai/sdk'
+import { getModels, getProviders, getMemoryProviders, getBotsNameAvailability } from '@memohai/sdk'
 import type { BotsCreateBotRequest } from '@memohai/sdk'
 import { getBotsQueryKey } from '@memohai/sdk/colada'
 import { useCapabilitiesStore } from '@/store/capabilities'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
-import { resolveApiErrorMessage } from '@/utils/api-error'
 import { aclPresetOptions, defaultAclPreset } from '@/constants/acl-presets'
 import { emptyTimezoneValue } from '@/utils/timezones'
 import TimezoneSelect from '@/components/timezone-select/index.vue'
-import {
-  botCreateProgressPercent,
-  collectBotCreateProgressStream,
-  postBotsStream,
-  type BotCreateProgressState,
-} from '@/composables/api/useBotCreateStream'
+import { useBotCreateProgressStore } from '@/store/bot-create-progress'
 import ModelSelect from './components/model-select.vue'
 import MemoryProviderSelect from './components/memory-provider-select.vue'
 import AvatarEditDialog from './components/avatar-edit-dialog.vue'
 import BotImportPanel from './components/bot-import-panel.vue'
-import ContainerCreateProgress from './components/container-create-progress.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -577,20 +541,9 @@ const canSubmit = computed(() => {
   return true
 })
 
+const store = useBotCreateProgressStore()
 const submitLoading = ref(false)
-const createState = ref<BotCreateProgressState>({})
-const createProgress = computed(() => createState.value.progress ?? null)
 const isCreateFlowBlocked = computed(() => submitLoading.value)
-
-const createProgressPercent = computed(() => botCreateProgressPercent(createProgress.value))
-
-// Detect a name-uniqueness conflict (HTTP 409) from the create request, used as
-// a fallback when the realtime check raced with submission.
-function isNameConflict(error: unknown): boolean {
-  const e = error as { status?: number, response?: { status?: number } } | null
-  if (e?.status === 409 || e?.response?.status === 409) return true
-  return resolveApiErrorMessage(error, '').toLowerCase().includes('already taken')
-}
 
 // Import from backup
 function handleImported(botId: string) {
@@ -601,25 +554,7 @@ function handleImported(botId: string) {
   }
 }
 
-async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotCreateProgressState> {
-  const { stream } = await postBotsStream({
-    body,
-    throwOnError: true,
-  })
-
-  return collectBotCreateProgressStream(stream, {
-    initialState: createState.value,
-    onState: (state) => {
-      createState.value = state
-    },
-  })
-}
-
-async function handleSubmit() {
-  if (!canSubmit.value || isCreateFlowBlocked.value) return
-  submitLoading.value = true
-  createState.value = form.workspace_backend === 'local' ? {} : { progress: { phase: 'pulling' } }
-
+function buildCreatePayload(): BotsCreateBotRequest {
   const metadata = localWorkspaceEnabled.value && form.workspace_backend === 'local'
     ? {
         workspace: {
@@ -628,63 +563,80 @@ async function handleSubmit() {
         },
       }
     : undefined
-
   const tz = form.timezone === emptyTimezoneValue ? undefined : form.timezone || undefined
 
-  try {
-    const result = await createBotWithProgress({
-      name: form.name.trim(),
+  return {
+    name: form.name.trim(),
+    display_name: form.display_name.trim(),
+    avatar_url: form.avatar_url.trim() || undefined,
+    timezone: tz,
+    is_active: true,
+    acl_preset: form.acl_preset,
+    metadata,
+    wait_for_ready: true,
+  }
+}
+
+function createStartOptions() {
+  return {
+    display: {
       display_name: form.display_name.trim(),
+      name: form.name.trim(),
       avatar_url: form.avatar_url.trim() || undefined,
-      timezone: tz,
-      is_active: true,
-      acl_preset: form.acl_preset,
-      metadata,
-      wait_for_ready: true,
-    })
+    },
+    settings: {
+      chat_model_id: form.chat_model_id || undefined,
+      memory_provider_id: form.memory_provider_id || undefined,
+    },
+  }
+}
 
-    const bot = result.bot
-    const botId = bot?.id
-    const botName = bot?.name ?? botId
-    if (!botId) {
-      throw new Error(t('common.saveFailed'))
-    }
-    if (botId && (form.chat_model_id || form.memory_provider_id)) {
-      try {
-        await putBotsByBotIdSettings({
-          path: { bot_id: botId },
-          body: {
-            ...(form.chat_model_id ? { chat_model_id: form.chat_model_id } : {}),
-            ...(form.memory_provider_id ? { memory_provider_id: form.memory_provider_id } : {}),
-          },
-          throwOnError: true,
-        })
-      } catch {
-        // Bot created successfully, settings save failed — non-fatal
-      }
-    }
+async function handleSubmit() {
+  if (!canSubmit.value || isCreateFlowBlocked.value) return
+  submitLoading.value = true
 
-    if (result.setupError) {
-      toast.error(result.setupError)
-    } else {
-      toast.success(t('bots.createBotSuccess'))
-    }
-    if (botName) {
-      router.push({ name: 'bot-detail', params: { botName } })
-    } else {
-      router.push({ name: 'bots' })
-    }
-  } catch (error) {
-    if (isNameConflict(error)) {
+  const payload = buildCreatePayload()
+  const options = createStartOptions()
+
+  // Local workspaces are near-instant and not sandboxed; skip the dedicated
+  // progress route and finish inline.
+  if (form.workspace_backend === 'local') {
+    await store.start(payload, options)
+    submitLoading.value = false
+    finishLocalCreate()
+    return
+  }
+
+  // Container backend: hand the live stream off to the dedicated progress route.
+  void store.start(payload, options)
+  router.push({ name: 'bot-create-progress' })
+}
+
+function finishLocalCreate() {
+  if (store.status === 'error') {
+    const message = store.setupError ?? ''
+    if (message.toLowerCase().includes('already taken')) {
       nameStatus.value = 'taken'
       toast.error(t('bots.nameStatus.taken'))
-      return
+    } else {
+      toast.error(message || t('common.saveFailed'))
     }
-    toast.error(resolveApiErrorMessage(error, t('common.saveFailed')))
-  } finally {
-    submitLoading.value = false
-    createState.value = {}
-    void queryCache.invalidateQueries({ key: getBotsQueryKey() })
+    store.reset()
+    return
+  }
+
+  if (store.setupError) {
+    toast.error(store.setupError)
+  } else {
+    toast.success(t('bots.createBotSuccess'))
+  }
+  const botName = store.bot?.name ?? store.bot?.id
+  void queryCache.invalidateQueries({ key: getBotsQueryKey() })
+  store.reset()
+  if (botName) {
+    router.push({ name: 'bot-detail', params: { botName } })
+  } else {
+    router.push({ name: 'bots' })
   }
 }
 </script>

--- a/apps/web/src/pages/onboarding/steps/Step4Bot.vue
+++ b/apps/web/src/pages/onboarding/steps/Step4Bot.vue
@@ -23,22 +23,17 @@ import { ref, reactive, computed, watch, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { useI18n } from 'vue-i18n'
 import { useQuery, useQueryCache } from '@pinia/colada'
-import { getModels, getProviders, getMemoryProviders, putBotsByBotIdSettings } from '@memohai/sdk'
+import { getModels, getProviders, getMemoryProviders } from '@memohai/sdk'
 import type { BotsCreateBotRequest } from '@memohai/sdk'
 import { getBotsQueryKey } from '@memohai/sdk/colada'
+import { storeToRefs } from 'pinia'
 import { useOnboarding } from '@/composables/useOnboarding'
 import { useCapabilitiesStore } from '@/store/capabilities'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
-import { resolveApiErrorMessage } from '@/utils/api-error'
 import { defaultAclPreset } from '@/constants/acl-presets'
-import {
-  botCreateProgressPercent,
-  collectBotCreateProgressStream,
-  postBotsStream,
-  type BotCreateProgressState,
-} from '@/composables/api/useBotCreateStream'
+import { useBotCreateProgressStore } from '@/store/bot-create-progress'
 import AvatarEditDialog from '@/pages/bots/components/avatar-edit-dialog.vue'
-import ContainerCreateProgress from '@/pages/bots/components/container-create-progress.vue'
+import BotCreateTerminal from '@/pages/bots/components/bot-create-terminal.vue'
 import ModelSelect from '@/pages/bots/components/model-select.vue'
 import { useStepTransition, nextFrame } from '../useStepTransition'
 import { ONBOARDING_KEYS } from '../constants'
@@ -52,9 +47,8 @@ const { visible, exiting, leave } = useStepTransition()
 const workspaceVisible = ref(false)
 const submitting = ref(false)
 
-const createState = ref<BotCreateProgressState>({})
-const createProgress = computed(() => createState.value.progress ?? null)
-const createProgressPercent = computed(() => botCreateProgressPercent(createProgress.value))
+const store = useBotCreateProgressStore()
+const { lines: terminalLines, status: createStatus } = storeToRefs(store)
 
 onMounted(() => {
   void capabilities.load()
@@ -133,24 +127,9 @@ const ctaLabel = computed(() => {
   return t('onboarding.next')
 })
 
-async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotCreateProgressState> {
-  const { stream } = await postBotsStream({
-    body,
-    throwOnError: true,
-  })
-
-  return collectBotCreateProgressStream(stream, {
-    initialState: createState.value,
-    onState: (state) => {
-      createState.value = state
-    },
-  })
-}
-
 async function handleSubmit() {
   if (!canSubmit.value || submitting.value) return
   submitting.value = true
-  createState.value = form.workspace_backend === 'local' ? {} : { progress: { phase: 'pulling' } }
 
   const metadata = localWorkspaceEnabled.value && form.workspace_backend === 'local'
     ? {
@@ -160,53 +139,45 @@ async function handleSubmit() {
       }
     : undefined
 
-  const tz = undefined
+  const payload: BotsCreateBotRequest = {
+    display_name: form.display_name.trim(),
+    avatar_url: form.avatar_url.trim() || undefined,
+    timezone: undefined,
+    is_active: true,
+    acl_preset: defaultAclPreset,
+    metadata,
+    wait_for_ready: true,
+  }
 
-  try {
-    const result = await createBotWithProgress({
+  // The store drives the inline terminal reactively while we await completion.
+  await store.start(payload, {
+    display: {
       display_name: form.display_name.trim(),
       avatar_url: form.avatar_url.trim() || undefined,
-      timezone: tz,
-      is_active: true,
-      acl_preset: defaultAclPreset,
-      metadata,
-      wait_for_ready: true,
-    })
+    },
+    settings: {
+      chat_model_id: form.chat_model_id || undefined,
+      memory_provider_id: form.memory_provider_id || undefined,
+    },
+  })
+  submitting.value = false
 
-    const bot = result.bot
-    const botId = bot?.id
-    if (!botId) {
-      throw new Error(t('common.saveFailed'))
-    }
-    if (botId) {
-      sessionStorage.setItem(ONBOARDING_KEYS.createdBotId, botId)
-    }
-    if (botId && (form.chat_model_id || form.memory_provider_id)) {
-      try {
-        await putBotsByBotIdSettings({
-          path: { bot_id: botId },
-          body: {
-            ...(form.chat_model_id ? { chat_model_id: form.chat_model_id } : {}),
-            ...(form.memory_provider_id ? { memory_provider_id: form.memory_provider_id } : {}),
-          },
-          throwOnError: true,
-        })
-      } catch {
-        // Bot created successfully, settings save failed — non-fatal
-      }
-    }
-
-    if (result.setupError) {
-      toast.error(result.setupError)
-    }
-    leave(nextStep)
-  } catch (error) {
-    toast.error(resolveApiErrorMessage(error, t('common.saveFailed')))
-  } finally {
-    submitting.value = false
-    createState.value = {}
-    void queryCache.invalidateQueries({ key: getBotsQueryKey() })
+  if (store.status === 'error') {
+    toast.error(store.setupError ?? t('common.saveFailed'))
+    store.reset()
+    return
   }
+
+  const botId = store.bot?.id
+  if (botId) {
+    sessionStorage.setItem(ONBOARDING_KEYS.createdBotId, botId)
+  }
+  if (store.setupError) {
+    toast.error(store.setupError)
+  }
+  void queryCache.invalidateQueries({ key: getBotsQueryKey() })
+  leave(nextStep)
+  store.reset()
 }
 </script>
 
@@ -373,15 +344,11 @@ async function handleSubmit() {
               {{ $t('bots.createBotWaitHint') }}
             </div>
             <div
-              v-if="createProgress && form.workspace_backend !== 'local'"
+              v-if="form.workspace_backend !== 'local' && (createStatus === 'creating' || createStatus === 'error') && terminalLines.length"
               class="mt-3 transition-all duration-[350ms] ease-out delay-[220ms]"
               :class="visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
             >
-              <ContainerCreateProgress
-                :phase="createProgress.phase"
-                :percent="createProgressPercent"
-                :error="createProgress.error"
-              />
+              <BotCreateTerminal :lines="terminalLines" />
             </div>
           </form>
         </div>

--- a/apps/web/src/pages/onboarding/steps/Step4Bot.vue
+++ b/apps/web/src/pages/onboarding/steps/Step4Bot.vue
@@ -33,8 +33,8 @@ import { resolveApiErrorMessage } from '@/utils/api-error'
 import { defaultAclPreset } from '@/constants/acl-presets'
 import {
   botCreateProgressPercent,
+  collectBotCreateProgressStream,
   postBotsStream,
-  reduceBotCreateProgressEvent,
   type BotCreateProgressState,
 } from '@/composables/api/useBotCreateStream'
 import AvatarEditDialog from '@/pages/bots/components/avatar-edit-dialog.vue'
@@ -139,10 +139,12 @@ async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotCre
     throwOnError: true,
   })
 
-  for await (const event of stream) {
-    createState.value = reduceBotCreateProgressEvent(createState.value, event)
-  }
-  return createState.value
+  return collectBotCreateProgressStream(stream, {
+    initialState: createState.value,
+    onState: (state) => {
+      createState.value = state
+    },
+  })
 }
 
 async function handleSubmit() {

--- a/apps/web/src/pages/onboarding/steps/Step4Bot.vue
+++ b/apps/web/src/pages/onboarding/steps/Step4Bot.vue
@@ -24,15 +24,19 @@ import { toast } from 'vue-sonner'
 import { useI18n } from 'vue-i18n'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { getModels, getProviders, getMemoryProviders, putBotsByBotIdSettings } from '@memohai/sdk'
-import type { BotsBot, BotsCreateBotRequest } from '@memohai/sdk'
+import type { BotsCreateBotRequest } from '@memohai/sdk'
 import { getBotsQueryKey } from '@memohai/sdk/colada'
 import { useOnboarding } from '@/composables/useOnboarding'
 import { useCapabilitiesStore } from '@/store/capabilities'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import { defaultAclPreset } from '@/constants/acl-presets'
-import { postBotsStream, type BotCreateStreamEvent } from '@/composables/api/useBotCreateStream'
-import type { ContainerCreateLayerStatus } from '@/composables/api/useContainerStream'
+import {
+  botCreateProgressPercent,
+  postBotsStream,
+  reduceBotCreateProgressEvent,
+  type BotCreateProgressState,
+} from '@/composables/api/useBotCreateStream'
 import AvatarEditDialog from '@/pages/bots/components/avatar-edit-dialog.vue'
 import ContainerCreateProgress from '@/pages/bots/components/container-create-progress.vue'
 import ModelSelect from '@/pages/bots/components/model-select.vue'
@@ -48,26 +52,9 @@ const { visible, exiting, leave } = useStepTransition()
 const workspaceVisible = ref(false)
 const submitting = ref(false)
 
-type CreateProgress = {
-  phase: 'preserving' | 'pulling' | 'creating' | 'restoring' | 'complete' | 'error'
-  layers?: ContainerCreateLayerStatus[]
-  image?: string
-  error?: string
-}
-
-const createProgress = ref<CreateProgress | null>(null)
-
-const createProgressPercent = computed(() => {
-  const layers = createProgress.value?.layers
-  if (!layers || layers.length === 0) return 0
-  let totalOffset = 0
-  let totalSize = 0
-  for (const layer of layers) {
-    totalOffset += layer.offset
-    totalSize += layer.total
-  }
-  return totalSize > 0 ? Math.round((totalOffset / totalSize) * 100) : 0
-})
+const createState = ref<BotCreateProgressState>({})
+const createProgress = computed(() => createState.value.progress ?? null)
+const createProgressPercent = computed(() => botCreateProgressPercent(createProgress.value))
 
 onMounted(() => {
   void capabilities.load()
@@ -146,57 +133,22 @@ const ctaLabel = computed(() => {
   return t('onboarding.next')
 })
 
-function applyCreateBotEvent(event: BotCreateStreamEvent): BotsBot | undefined {
-  switch (event.type) {
-    case 'bot_created':
-      return event.bot
-    case 'pulling':
-      createProgress.value = { phase: 'pulling', image: event.image }
-      return undefined
-    case 'pull_progress':
-      createProgress.value = {
-        phase: 'pulling',
-        image: createProgress.value?.image,
-        layers: event.layers,
-      }
-      return undefined
-    case 'pull_skipped':
-    case 'pull_delegated':
-      createProgress.value = event.image === 'local'
-        ? { phase: 'creating' }
-        : { phase: 'pulling', image: event.image }
-      return undefined
-    case 'creating':
-      createProgress.value = { phase: 'creating' }
-      return undefined
-    case 'restoring':
-      createProgress.value = { phase: 'restoring' }
-      return undefined
-    case 'ready':
-      return event.bot
-    case 'error':
-      createProgress.value = { phase: 'error', error: event.message }
-      throw new Error(event.message || 'Unknown error')
-  }
-}
-
-async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotsBot | undefined> {
+async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotCreateProgressState> {
   const { stream } = await postBotsStream({
     body,
     throwOnError: true,
   })
 
-  let bot: BotsBot | undefined
   for await (const event of stream) {
-    bot = applyCreateBotEvent(event) ?? bot
+    createState.value = reduceBotCreateProgressEvent(createState.value, event)
   }
-  return bot
+  return createState.value
 }
 
 async function handleSubmit() {
   if (!canSubmit.value || submitting.value) return
   submitting.value = true
-  createProgress.value = form.workspace_backend === 'local' ? null : { phase: 'pulling' }
+  createState.value = form.workspace_backend === 'local' ? {} : { progress: { phase: 'pulling' } }
 
   const metadata = localWorkspaceEnabled.value && form.workspace_backend === 'local'
     ? {
@@ -209,7 +161,7 @@ async function handleSubmit() {
   const tz = undefined
 
   try {
-    const bot = await createBotWithProgress({
+    const result = await createBotWithProgress({
       display_name: form.display_name.trim(),
       avatar_url: form.avatar_url.trim() || undefined,
       timezone: tz,
@@ -219,7 +171,11 @@ async function handleSubmit() {
       wait_for_ready: true,
     })
 
+    const bot = result.bot
     const botId = bot?.id
+    if (!botId) {
+      throw new Error(t('common.saveFailed'))
+    }
     if (botId) {
       sessionStorage.setItem(ONBOARDING_KEYS.createdBotId, botId)
     }
@@ -238,12 +194,15 @@ async function handleSubmit() {
       }
     }
 
+    if (result.setupError) {
+      toast.error(result.setupError)
+    }
     leave(nextStep)
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('common.saveFailed')))
   } finally {
     submitting.value = false
-    createProgress.value = null
+    createState.value = {}
     void queryCache.invalidateQueries({ key: getBotsQueryKey() })
   }
 }

--- a/apps/web/src/pages/onboarding/steps/Step4Bot.vue
+++ b/apps/web/src/pages/onboarding/steps/Step4Bot.vue
@@ -22,15 +22,19 @@ import { SquarePen, CircleHelp, Bot } from 'lucide-vue-next'
 import { ref, reactive, computed, watch, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
 import { useI18n } from 'vue-i18n'
-import { useQuery, useMutation, useQueryCache } from '@pinia/colada'
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { getModels, getProviders, getMemoryProviders, putBotsByBotIdSettings } from '@memohai/sdk'
-import { postBotsMutation, getBotsQueryKey } from '@memohai/sdk/colada'
+import type { BotsBot, BotsCreateBotRequest } from '@memohai/sdk'
+import { getBotsQueryKey } from '@memohai/sdk/colada'
 import { useOnboarding } from '@/composables/useOnboarding'
 import { useCapabilitiesStore } from '@/store/capabilities'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import { defaultAclPreset } from '@/constants/acl-presets'
+import { postBotsStream, type BotCreateStreamEvent } from '@/composables/api/useBotCreateStream'
+import type { ContainerCreateLayerStatus } from '@/composables/api/useContainerStream'
 import AvatarEditDialog from '@/pages/bots/components/avatar-edit-dialog.vue'
+import ContainerCreateProgress from '@/pages/bots/components/container-create-progress.vue'
 import ModelSelect from '@/pages/bots/components/model-select.vue'
 import { useStepTransition, nextFrame } from '../useStepTransition'
 import { ONBOARDING_KEYS } from '../constants'
@@ -43,6 +47,27 @@ const { visible, exiting, leave } = useStepTransition()
 
 const workspaceVisible = ref(false)
 const submitting = ref(false)
+
+type CreateProgress = {
+  phase: 'preserving' | 'pulling' | 'creating' | 'restoring' | 'complete' | 'error'
+  layers?: ContainerCreateLayerStatus[]
+  image?: string
+  error?: string
+}
+
+const createProgress = ref<CreateProgress | null>(null)
+
+const createProgressPercent = computed(() => {
+  const layers = createProgress.value?.layers
+  if (!layers || layers.length === 0) return 0
+  let totalOffset = 0
+  let totalSize = 0
+  for (const layer of layers) {
+    totalOffset += layer.offset
+    totalSize += layer.total
+  }
+  return totalSize > 0 ? Math.round((totalOffset / totalSize) * 100) : 0
+})
 
 onMounted(() => {
   void capabilities.load()
@@ -121,14 +146,57 @@ const ctaLabel = computed(() => {
   return t('onboarding.next')
 })
 
-const { mutateAsync: createBot } = useMutation({
-  ...postBotsMutation(),
-  onSettled: () => queryCache.invalidateQueries({ key: getBotsQueryKey() }),
-})
+function applyCreateBotEvent(event: BotCreateStreamEvent): BotsBot | undefined {
+  switch (event.type) {
+    case 'bot_created':
+      return event.bot
+    case 'pulling':
+      createProgress.value = { phase: 'pulling', image: event.image }
+      return undefined
+    case 'pull_progress':
+      createProgress.value = {
+        phase: 'pulling',
+        image: createProgress.value?.image,
+        layers: event.layers,
+      }
+      return undefined
+    case 'pull_skipped':
+    case 'pull_delegated':
+      createProgress.value = event.image === 'local'
+        ? { phase: 'creating' }
+        : { phase: 'pulling', image: event.image }
+      return undefined
+    case 'creating':
+      createProgress.value = { phase: 'creating' }
+      return undefined
+    case 'restoring':
+      createProgress.value = { phase: 'restoring' }
+      return undefined
+    case 'ready':
+      return event.bot
+    case 'error':
+      createProgress.value = { phase: 'error', error: event.message }
+      throw new Error(event.message || 'Unknown error')
+  }
+}
+
+async function createBotWithProgress(body: BotsCreateBotRequest): Promise<BotsBot | undefined> {
+  const { stream } = await postBotsStream({
+    body,
+    throwOnError: true,
+  })
+
+  let bot: BotsBot | undefined
+  for await (const event of stream) {
+    bot = applyCreateBotEvent(event) ?? bot
+  }
+  return bot
+}
 
 async function handleSubmit() {
   if (!canSubmit.value || submitting.value) return
   submitting.value = true
+  createProgress.value = form.workspace_backend === 'local' ? null : { phase: 'pulling' }
 
   const metadata = localWorkspaceEnabled.value && form.workspace_backend === 'local'
     ? {
@@ -141,16 +209,14 @@ async function handleSubmit() {
   const tz = undefined
 
   try {
-    const bot = await createBot({
-      body: {
-        display_name: form.display_name.trim(),
-        avatar_url: form.avatar_url.trim() || undefined,
-        timezone: tz,
-        is_active: true,
-        acl_preset: defaultAclPreset,
-        metadata,
-        wait_for_ready: true,
-      },
+    const bot = await createBotWithProgress({
+      display_name: form.display_name.trim(),
+      avatar_url: form.avatar_url.trim() || undefined,
+      timezone: tz,
+      is_active: true,
+      acl_preset: defaultAclPreset,
+      metadata,
+      wait_for_ready: true,
     })
 
     const botId = bot?.id
@@ -177,6 +243,8 @@ async function handleSubmit() {
     toast.error(resolveApiErrorMessage(error, t('common.saveFailed')))
   } finally {
     submitting.value = false
+    createProgress.value = null
+    void queryCache.invalidateQueries({ key: getBotsQueryKey() })
   }
 }
 </script>
@@ -342,6 +410,17 @@ async function handleSubmit() {
               :class="visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
             >
               {{ $t('bots.createBotWaitHint') }}
+            </div>
+            <div
+              v-if="createProgress && form.workspace_backend !== 'local'"
+              class="mt-3 transition-all duration-[350ms] ease-out delay-[220ms]"
+              :class="visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
+            >
+              <ContainerCreateProgress
+                :phase="createProgress.phase"
+                :percent="createProgressPercent"
+                :error="createProgress.error"
+              />
             </div>
           </form>
         </div>

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -73,6 +73,14 @@ const routes = [
             },
           },
           {
+            name: 'bot-create-progress',
+            path: 'new/progress',
+            component: () => import('@/pages/bots/new-progress.vue'),
+            meta: {
+              breadcrumb: i18nRef('bots.createBot'),
+            },
+          },
+          {
             name: 'bot-detail',
             path: ':botName',
             component: () => import('@/pages/bots/detail.vue'),

--- a/apps/web/src/store/bot-create-progress.test.ts
+++ b/apps/web/src/store/bot-create-progress.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type { BotCreateStreamEvent } from '@/composables/api/useBotCreateStream'
+
+const postBotsStream = vi.fn()
+const putBotsByBotIdSettings = vi.fn()
+
+vi.mock('@/composables/api/useBotCreateStream', async (importActual) => {
+  const actual = await importActual<typeof import('@/composables/api/useBotCreateStream')>()
+  return { ...actual, postBotsStream: (...args: unknown[]) => postBotsStream(...args) }
+})
+
+vi.mock('@memohai/sdk', () => ({
+  putBotsByBotIdSettings: (...args: unknown[]) => putBotsByBotIdSettings(...args),
+}))
+
+const { useBotCreateProgressStore } = await import('./bot-create-progress')
+
+function streamOf(events: BotCreateStreamEvent[]) {
+  return {
+    stream: (async function* () {
+      for (const event of events) yield event
+    })(),
+  }
+}
+
+describe('useBotCreateProgressStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    postBotsStream.mockReset()
+    putBotsByBotIdSettings.mockReset()
+    putBotsByBotIdSettings.mockResolvedValue({ data: {} })
+  })
+
+  it('streams the happy path to a ready state with a terminal log', async () => {
+    const bot = { id: 'bot-1', name: 'ada' }
+    postBotsStream.mockResolvedValue(streamOf([
+      { type: 'bot_created', bot },
+      { type: 'pulling', image: 'img' },
+      { type: 'pull_progress', layers: [{ ref: 'a', offset: 100, total: 100 }] },
+      { type: 'creating' },
+      { type: 'ready', bot },
+    ]))
+
+    const store = useBotCreateProgressStore()
+    await store.start({ name: 'ada', display_name: 'Ada' })
+
+    expect(store.status).toBe('ready')
+    expect(store.bot).toEqual(bot)
+    expect(store.lines.map(l => l.kind)).toEqual(['command', 'bot-created', 'pulling', 'creating', 'ready'])
+    expect(store.lines.at(-1)).toMatchObject({ kind: 'ready', status: 'done' })
+  })
+
+  it('treats a hard failure with no bot as an error status', async () => {
+    postBotsStream.mockResolvedValue(streamOf([
+      { type: 'pulling', image: 'img' },
+      { type: 'error', message: 'image pull failed' },
+    ]))
+
+    const store = useBotCreateProgressStore()
+    await store.start({ name: 'ada', display_name: 'Ada' })
+
+    expect(store.status).toBe('error')
+    expect(store.bot).toBeNull()
+    expect(store.setupError).toBe('image pull failed')
+    expect(store.lines.at(-1)).toMatchObject({ kind: 'error', status: 'error', message: 'image pull failed' })
+  })
+
+  it('treats a setup failure after the bot exists as a ready-with-warning state', async () => {
+    const bot = { id: 'bot-1', name: 'ada' }
+    postBotsStream.mockResolvedValue(streamOf([
+      { type: 'bot_created', bot },
+      { type: 'creating' },
+      { type: 'error', message: 'container setup failed' },
+    ]))
+
+    const store = useBotCreateProgressStore()
+    await store.start({ name: 'ada', display_name: 'Ada' })
+
+    expect(store.status).toBe('ready')
+    expect(store.bot).toEqual(bot)
+    expect(store.setupError).toBe('container setup failed')
+  })
+
+  it('rethrows-as-error when the stream fails before any bot is created', async () => {
+    postBotsStream.mockResolvedValue({
+      stream: (async function* (): AsyncGenerator<BotCreateStreamEvent, void, unknown> {
+        throw new Error('connection reset')
+      })(),
+    })
+
+    const store = useBotCreateProgressStore()
+    await store.start({ name: 'ada', display_name: 'Ada' })
+
+    expect(store.status).toBe('error')
+    expect(store.bot).toBeNull()
+    expect(store.setupError).toBe('connection reset')
+    expect(store.lines.at(-1)).toMatchObject({ kind: 'error', status: 'error' })
+  })
+
+  it('applies model and memory settings after the bot is ready', async () => {
+    const bot = { id: 'bot-1', name: 'ada' }
+    postBotsStream.mockResolvedValue(streamOf([
+      { type: 'bot_created', bot },
+      { type: 'ready', bot },
+    ]))
+
+    const store = useBotCreateProgressStore()
+    await store.start(
+      { name: 'ada', display_name: 'Ada' },
+      { settings: { chat_model_id: 'm1', memory_provider_id: 'p1' } },
+    )
+
+    expect(putBotsByBotIdSettings).toHaveBeenCalledWith(expect.objectContaining({
+      path: { bot_id: 'bot-1' },
+      body: { chat_model_id: 'm1', memory_provider_id: 'p1' },
+    }))
+    expect(store.status).toBe('ready')
+    expect(store.lines.some(l => l.kind === 'applying-settings' && l.status === 'done')).toBe(true)
+  })
+
+  it('keeps the bot ready when settings application fails', async () => {
+    const bot = { id: 'bot-1', name: 'ada' }
+    postBotsStream.mockResolvedValue(streamOf([
+      { type: 'bot_created', bot },
+      { type: 'ready', bot },
+    ]))
+    putBotsByBotIdSettings.mockRejectedValue(new Error('settings boom'))
+
+    const store = useBotCreateProgressStore()
+    await store.start(
+      { name: 'ada', display_name: 'Ada' },
+      { settings: { chat_model_id: 'm1' } },
+    )
+
+    expect(store.status).toBe('ready')
+    expect(store.bot).toEqual(bot)
+  })
+
+  it('reset returns the store to idle', async () => {
+    const bot = { id: 'bot-1', name: 'ada' }
+    postBotsStream.mockResolvedValue(streamOf([{ type: 'ready', bot }]))
+
+    const store = useBotCreateProgressStore()
+    await store.start({ name: 'ada', display_name: 'Ada' })
+    store.reset()
+
+    expect(store.status).toBe('idle')
+    expect(store.lines).toEqual([])
+    expect(store.bot).toBeNull()
+    expect(store.setupError).toBeNull()
+  })
+})

--- a/apps/web/src/store/bot-create-progress.ts
+++ b/apps/web/src/store/bot-create-progress.ts
@@ -1,0 +1,178 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { putBotsByBotIdSettings } from '@memohai/sdk'
+import type { BotsBot, BotsCreateBotRequest } from '@memohai/sdk'
+import {
+  botCreateProgressPercent,
+  collectBotCreateProgressStream,
+  postBotsStream,
+  type BotCreateProgress,
+} from '@/composables/api/useBotCreateStream'
+import {
+  appendBotCreateTerminalLine,
+  finalizeBotCreateTerminalLines,
+  pushBotCreateTerminalLine,
+  type BotCreateTerminalLine,
+} from '@/composables/api/botCreateTerminal'
+
+// status reflects the bot-create lifecycle:
+//   idle     - nothing in flight (also the guard for the progress route)
+//   creating - the SSE stream is running
+//   ready    - a bot exists (possibly with a non-fatal setupError warning)
+//   error    - a hard failure where no bot was created
+export type BotCreateStatus = 'idle' | 'creating' | 'ready' | 'error'
+
+export type BotCreateDisplay = {
+  display_name: string
+  name?: string
+  avatar_url?: string
+}
+
+export type BotCreateSettings = {
+  chat_model_id?: string
+  memory_provider_id?: string
+}
+
+export type StartBotCreateOptions = {
+  display?: BotCreateDisplay
+  settings?: BotCreateSettings
+}
+
+function hasSettings(settings?: BotCreateSettings): boolean {
+  return !!(settings && (settings.chat_model_id || settings.memory_provider_id))
+}
+
+function settingsBody(settings: BotCreateSettings) {
+  return {
+    ...(settings.chat_model_id ? { chat_model_id: settings.chat_model_id } : {}),
+    ...(settings.memory_provider_id ? { memory_provider_id: settings.memory_provider_id } : {}),
+  }
+}
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string' && error.trim()) return error
+  return 'Bot create failed'
+}
+
+// Owns the bot-create SSE stream and derived state so it survives navigation
+// from the create form to the dedicated progress route. Views read this store
+// and own navigation/onboarding side effects.
+export const useBotCreateProgressStore = defineStore('bot-create-progress', () => {
+  const status = ref<BotCreateStatus>('idle')
+  const display = ref<BotCreateDisplay | null>(null)
+  const progress = ref<BotCreateProgress | null>(null)
+  const lines = ref<BotCreateTerminalLine[]>([])
+  const bot = ref<BotsBot | null>(null)
+  const setupError = ref<string | null>(null)
+
+  let lastPayload: BotsCreateBotRequest | null = null
+  let lastOptions: StartBotCreateOptions = {}
+
+  const percent = computed(() => botCreateProgressPercent(progress.value))
+  const isActive = computed(() => status.value === 'creating')
+
+  function reset() {
+    status.value = 'idle'
+    display.value = null
+    progress.value = null
+    lines.value = []
+    bot.value = null
+    setupError.value = null
+  }
+
+  function ensureErrorLine(message: string) {
+    if (lines.value.at(-1)?.kind === 'error') return
+    lines.value = appendBotCreateTerminalLine(lines.value, { type: 'error', message })
+  }
+
+  async function start(payload: BotsCreateBotRequest, options: StartBotCreateOptions = {}) {
+    if (status.value === 'creating') return
+    lastPayload = payload
+    lastOptions = options
+
+    status.value = 'creating'
+    bot.value = null
+    setupError.value = null
+    progress.value = { phase: 'pulling' }
+    display.value = options.display ?? {
+      display_name: payload.display_name ?? payload.name ?? '',
+      avatar_url: payload.avatar_url,
+    }
+    lines.value = pushBotCreateTerminalLine([], {
+      kind: 'command',
+      status: 'info',
+      message: display.value.display_name,
+    })
+
+    try {
+      const { stream } = await postBotsStream({ body: payload, throwOnError: true })
+      const result = await collectBotCreateProgressStream(stream, {
+        onState: (state) => {
+          progress.value = state.progress ?? progress.value
+        },
+        onEvent: (event) => {
+          // The final "ready" line is emitted after settings are applied so the
+          // log reads naturally: creating, applying settings, ready.
+          if (event.type === 'ready') return
+          lines.value = appendBotCreateTerminalLine(lines.value, event)
+        },
+      })
+
+      const createdBot = result.bot ?? null
+      bot.value = createdBot
+      setupError.value = result.setupError ?? null
+
+      if (!createdBot) {
+        ensureErrorLine(result.setupError ?? toMessage(undefined))
+        status.value = 'error'
+        return
+      }
+
+      const botId = createdBot.id
+      if (botId && hasSettings(options.settings)) {
+        lines.value = pushBotCreateTerminalLine(lines.value, { kind: 'applying-settings', status: 'running' })
+        try {
+          await putBotsByBotIdSettings({
+            path: { bot_id: botId },
+            body: settingsBody(options.settings!),
+            throwOnError: true,
+          })
+        } catch {
+          // Bot created successfully, settings save failed; this is non-fatal.
+        }
+        lines.value = finalizeBotCreateTerminalLines(lines.value)
+      }
+
+      if (!result.setupError) {
+        lines.value = pushBotCreateTerminalLine(lines.value, { kind: 'ready', status: 'done' })
+      }
+      status.value = 'ready'
+    } catch (error) {
+      const message = toMessage(error)
+      setupError.value = message
+      progress.value = { phase: 'error', error: message }
+      ensureErrorLine(message)
+      status.value = 'error'
+    }
+  }
+
+  async function retry() {
+    if (!lastPayload) return
+    await start(lastPayload, lastOptions)
+  }
+
+  return {
+    status,
+    display,
+    progress,
+    lines,
+    bot,
+    setupError,
+    percent,
+    isActive,
+    start,
+    retry,
+    reset,
+  }
+})

--- a/internal/bots/service.go
+++ b/internal/bots/service.go
@@ -581,7 +581,7 @@ func (s *Service) ensureUserExists(ctx context.Context, userID pgtype.UUID) erro
 	}
 	_, err := s.queries.GetUserByID(ctx, userID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) || errors.Is(err, db.ErrNotFound) {
 			return ErrOwnerUserNotFound
 		}
 		return err

--- a/internal/bots/service.go
+++ b/internal/bots/service.go
@@ -167,6 +167,9 @@ func (s *Service) Create(ctx context.Context, ownerUserID string, req CreateBotR
 	if err := s.attachCheckSummary(ctx, &bot, asSQLCBot(row)); err != nil {
 		return Bot{}, err
 	}
+	if req.SkipLifecycle {
+		return bot, nil
+	}
 	if req.WaitForReady {
 		waitCtx := context.WithoutCancel(ctx)
 		if err := s.runCreateLifecycle(waitCtx, bot.ID); err != nil {
@@ -176,6 +179,14 @@ func (s *Service) Create(ctx context.Context, ownerUserID string, req CreateBotR
 	}
 	s.enqueueCreateLifecycle(ctx, bot.ID)
 	return bot, nil
+}
+
+// MarkReady marks a bot lifecycle transition as complete and returns the fresh row.
+func (s *Service) MarkReady(ctx context.Context, botID string) (Bot, error) {
+	if err := s.updateStatus(ctx, botID, BotStatusReady); err != nil {
+		return Bot{}, err
+	}
+	return s.Get(ctx, botID)
 }
 
 // Get returns a bot by its identifier, which may be either a UUID or a name slug.

--- a/internal/bots/service_test.go
+++ b/internal/bots/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/memohai/memoh/internal/acl"
+	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
 )
@@ -201,6 +202,37 @@ func TestCreateRejectsUnknownACLPreset(t *testing.T) {
 	}
 	if createCalled {
 		t.Fatal("bot row should not be created when acl preset is invalid")
+	}
+}
+
+func TestCreateTreatsStoreNotFoundAsMissingOwner(t *testing.T) {
+	ownerUUID := mustParseUUID("00000000-0000-0000-0000-000000000001")
+	createCalled := false
+
+	dbtx := &fakeDBTX{
+		queryRowFunc: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "FROM users") && strings.Contains(sql, "WHERE id = $1"):
+				return &fakeRow{scanFunc: func(_ ...any) error { return db.ErrNotFound }}
+			case strings.Contains(sql, "INSERT INTO bots"):
+				createCalled = true
+				return &fakeRow{scanFunc: func(_ ...any) error { return nil }}
+			default:
+				return &fakeRow{scanFunc: func(_ ...any) error { return pgx.ErrNoRows }}
+			}
+		},
+	}
+
+	svc := NewService(nil, postgresstore.NewQueries(sqlc.New(dbtx)))
+	_, err := svc.Create(context.Background(), ownerUUID.String(), CreateBotRequest{
+		DisplayName: "test-bot",
+		AclPreset:   "allow_all",
+	})
+	if !errors.Is(err, ErrOwnerUserNotFound) {
+		t.Fatalf("expected ErrOwnerUserNotFound, got %v", err)
+	}
+	if createCalled {
+		t.Fatal("bot row should not be created when owner is missing")
 	}
 }
 

--- a/internal/bots/types.go
+++ b/internal/bots/types.go
@@ -40,14 +40,15 @@ type BotCheck struct {
 
 // CreateBotRequest is the input for creating a bot.
 type CreateBotRequest struct {
-	Name         string         `json:"name,omitempty"`
-	DisplayName  string         `json:"display_name,omitempty"`
-	AvatarURL    string         `json:"avatar_url,omitempty"`
-	Timezone     *string        `json:"timezone,omitempty"`
-	IsActive     *bool          `json:"is_active,omitempty"`
-	AclPreset    string         `json:"acl_preset,omitempty"`
-	Metadata     map[string]any `json:"metadata,omitempty"`
-	WaitForReady bool           `json:"wait_for_ready,omitempty"`
+	Name          string         `json:"name,omitempty"`
+	DisplayName   string         `json:"display_name,omitempty"`
+	AvatarURL     string         `json:"avatar_url,omitempty"`
+	Timezone      *string        `json:"timezone,omitempty"`
+	IsActive      *bool          `json:"is_active,omitempty"`
+	AclPreset     string         `json:"acl_preset,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+	WaitForReady  bool           `json:"wait_for_ready,omitempty"`
+	SkipLifecycle bool           `json:"-"`
 }
 
 // UpdateBotRequest is the input for updating a bot.

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -108,6 +108,7 @@ func (h *UsersHandler) Register(e *echo.Echo) {
 // @Tags users
 // @Success 200 {object} accounts.Account
 // @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /users/me [get].
 func (h *UsersHandler) GetMe(c echo.Context) error {
@@ -117,6 +118,9 @@ func (h *UsersHandler) GetMe(c echo.Context) error {
 	}
 	resp, err := h.service.Get(c.Request().Context(), channelIdentityID)
 	if err != nil {
+		if accountNotFound(err) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "current user not found, please login again")
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	return c.JSON(http.StatusOK, resp)
@@ -450,7 +454,7 @@ func (h *UsersHandler) CreateBot(c echo.Context) error {
 	}
 	if ownerFromToken {
 		if _, err := h.service.Get(c.Request().Context(), ownerID); err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if accountNotFound(err) {
 				return echo.NewHTTPError(http.StatusUnauthorized, "owner user not found, please login again")
 			} else {
 				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -469,6 +473,10 @@ func (h *UsersHandler) CreateBot(c echo.Context) error {
 
 func acceptsEventStream(c echo.Context) bool {
 	return strings.Contains(strings.ToLower(c.Request().Header.Get(echo.HeaderAccept)), "text/event-stream")
+}
+
+func accountNotFound(err error) bool {
+	return errors.Is(err, pgx.ErrNoRows) || errors.Is(err, db.ErrNotFound)
 }
 
 func createBotHTTPError(err error, ownerFromToken bool) error {

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
@@ -20,12 +23,23 @@ import (
 	"github.com/memohai/memoh/internal/channel/route"
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/identity"
+	"github.com/memohai/memoh/internal/workspace"
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
 type acpWorkspaceConfigProvider interface {
 	bridge.Provider
 	WorkspaceInfo(ctx context.Context, botID string) (bridge.WorkspaceInfo, error)
+}
+
+type botCreateProgressWorkspace interface {
+	acpWorkspaceConfigProvider
+	SetupBotContainerWithProgress(ctx context.Context, botID string, progress workspace.ContainerSetupProgress) error
+}
+
+type createBotStreamBotEvent struct {
+	Type string   `json:"type"`
+	Bot  bots.Bot `json:"bot"`
 }
 
 // UsersHandler manages user/account CRUD and bot operations via REST API.
@@ -443,26 +457,124 @@ func (h *UsersHandler) CreateBot(c echo.Context) error {
 			}
 		}
 	}
+	if acceptsEventStream(c) {
+		return h.createBotStream(c, ownerID, ownerFromToken, req)
+	}
 	resp, err := h.botService.Create(c.Request().Context(), ownerID, req)
 	if err != nil {
-		if errors.Is(err, bots.ErrOwnerUserNotFound) {
-			if ownerFromToken {
-				return echo.NewHTTPError(http.StatusUnauthorized, "owner user not found, please login again")
-			}
-			return echo.NewHTTPError(http.StatusBadRequest, "owner user not found")
-		}
-		if errors.Is(err, acl.ErrUnknownPreset) {
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-		}
-		if errors.Is(err, bots.ErrBotNameTaken) {
-			return echo.NewHTTPError(http.StatusConflict, err.Error())
-		}
-		if errors.Is(err, bots.ErrBotNameInvalid) || errors.Is(err, bots.ErrBotNameReserved) {
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-		}
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return createBotHTTPError(err, ownerFromToken)
 	}
 	return c.JSON(http.StatusCreated, scrubBotForResponse(resp))
+}
+
+func acceptsEventStream(c echo.Context) bool {
+	return strings.Contains(strings.ToLower(c.Request().Header.Get(echo.HeaderAccept)), "text/event-stream")
+}
+
+func createBotHTTPError(err error, ownerFromToken bool) error {
+	if errors.Is(err, bots.ErrOwnerUserNotFound) {
+		if ownerFromToken {
+			return echo.NewHTTPError(http.StatusUnauthorized, "owner user not found, please login again")
+		}
+		return echo.NewHTTPError(http.StatusBadRequest, "owner user not found")
+	}
+	if errors.Is(err, acl.ErrUnknownPreset) {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if errors.Is(err, bots.ErrBotNameTaken) {
+		return echo.NewHTTPError(http.StatusConflict, err.Error())
+	}
+	if errors.Is(err, bots.ErrBotNameInvalid) || errors.Is(err, bots.ErrBotNameReserved) {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+}
+
+func (h *UsersHandler) createBotStream(c echo.Context, ownerID string, ownerFromToken bool, req bots.CreateBotRequest) error {
+	flusher, ok := c.Response().Writer.(http.Flusher)
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, "streaming not supported")
+	}
+
+	req.WaitForReady = false
+	req.SkipLifecycle = true
+	bot, err := h.botService.Create(c.Request().Context(), ownerID, req)
+	if err != nil {
+		return createBotHTTPError(err, ownerFromToken)
+	}
+
+	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-cache")
+	c.Response().Header().Set(echo.HeaderConnection, "keep-alive")
+	c.Response().WriteHeader(http.StatusOK)
+	writer := bufio.NewWriter(c.Response().Writer)
+
+	var mu sync.Mutex
+	var writeErr error
+	send := func(payload any) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		if writeErr != nil {
+			return false
+		}
+		if err := writeSSEJSON(writer, flusher, payload); err != nil {
+			writeErr = err
+			return false
+		}
+		return true
+	}
+	sendError := func(message string) {
+		_ = send(createContainerErrorEvent{Type: "error", Message: message})
+	}
+
+	send(createBotStreamBotEvent{Type: "bot_created", Bot: scrubBotForResponse(bot)})
+
+	lifecycleCtx, cancel := context.WithTimeout(context.WithoutCancel(c.Request().Context()), 5*time.Minute)
+	defer cancel()
+
+	if workspaceWithProgress, ok := h.acpWorkspace.(botCreateProgressWorkspace); ok {
+		if err := workspaceWithProgress.SetupBotContainerWithProgress(lifecycleCtx, bot.ID, func(event workspace.ContainerSetupEvent) {
+			switch event.Type {
+			case "pulling":
+				send(createContainerPullingEvent{Type: "pulling", Image: event.Image})
+			case "pull_progress":
+				send(createContainerPullProgressEvent{Type: "pull_progress", Layers: event.Layers})
+			case "pull_skipped", "pull_delegated":
+				send(createContainerPullStatusEvent{Type: event.Type, Image: event.Image, Message: event.Message})
+			case "creating":
+				send(createContainerCreatingEvent{Type: "creating"})
+			case "restoring":
+				send(createContainerRestoringEvent{Type: "restoring"})
+			}
+		}); err != nil {
+			h.logger.Error("bot container setup failed",
+				slog.String("bot_id", bot.ID),
+				slog.Any("error", err),
+			)
+			if _, readyErr := h.botService.MarkReady(lifecycleCtx, bot.ID); readyErr != nil {
+				h.logger.Error("failed to update bot status to ready after stream create failure",
+					slog.String("bot_id", bot.ID),
+					slog.Any("error", readyErr),
+				)
+				sendError("container setup failed: " + err.Error() + "; ready status update failed: " + readyErr.Error())
+				return nil
+			}
+			sendError("container setup failed: " + err.Error())
+			return nil
+		}
+	}
+
+	readyBot, err := h.botService.MarkReady(lifecycleCtx, bot.ID)
+	if err != nil {
+		h.logger.Error("failed to update bot status to ready after stream create",
+			slog.String("bot_id", bot.ID),
+			slog.Any("error", err),
+		)
+		sendError("ready status update failed: " + err.Error())
+		return nil
+	}
+	send(createBotStreamBotEvent{Type: "ready", Bot: scrubBotForResponse(readyBot)})
+	return nil
 }
 
 // CheckBotName godoc

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -32,7 +32,7 @@ type acpWorkspaceConfigProvider interface {
 	WorkspaceInfo(ctx context.Context, botID string) (bridge.WorkspaceInfo, error)
 }
 
-type botCreateProgressWorkspace interface {
+type botCreateWorkspace interface {
 	acpWorkspaceConfigProvider
 	SetupBotContainerWithProgress(ctx context.Context, botID string, progress workspace.ContainerSetupProgress) error
 }
@@ -51,12 +51,12 @@ type UsersHandler struct {
 	channelLifecycle *channel.Lifecycle
 	channelManager   *channel.Manager
 	registry         *channel.Registry
-	acpWorkspace     acpWorkspaceConfigProvider
+	acpWorkspace     botCreateWorkspace
 	logger           *slog.Logger
 }
 
 // NewUsersHandler creates a UsersHandler with channel identity support.
-func NewUsersHandler(log *slog.Logger, service *accounts.Service, botService *bots.Service, routeService route.Service, channelStore *channel.Store, channelLifecycle *channel.Lifecycle, channelManager *channel.Manager, registry *channel.Registry, acpWorkspace acpWorkspaceConfigProvider) *UsersHandler {
+func NewUsersHandler(log *slog.Logger, service *accounts.Service, botService *bots.Service, routeService route.Service, channelStore *channel.Store, channelLifecycle *channel.Lifecycle, channelManager *channel.Manager, registry *channel.Registry, acpWorkspace botCreateWorkspace) *UsersHandler {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -495,6 +495,9 @@ func (h *UsersHandler) createBotStream(c echo.Context, ownerID string, ownerFrom
 	if !ok {
 		return echo.NewHTTPError(http.StatusInternalServerError, "streaming not supported")
 	}
+	if h.acpWorkspace == nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "workspace lifecycle not configured")
+	}
 
 	req.WaitForReady = false
 	req.SkipLifecycle = true
@@ -532,36 +535,34 @@ func (h *UsersHandler) createBotStream(c echo.Context, ownerID string, ownerFrom
 	lifecycleCtx, cancel := context.WithTimeout(context.WithoutCancel(c.Request().Context()), 5*time.Minute)
 	defer cancel()
 
-	if workspaceWithProgress, ok := h.acpWorkspace.(botCreateProgressWorkspace); ok {
-		if err := workspaceWithProgress.SetupBotContainerWithProgress(lifecycleCtx, bot.ID, func(event workspace.ContainerSetupEvent) {
-			switch event.Type {
-			case "pulling":
-				send(createContainerPullingEvent{Type: "pulling", Image: event.Image})
-			case "pull_progress":
-				send(createContainerPullProgressEvent{Type: "pull_progress", Layers: event.Layers})
-			case "pull_skipped", "pull_delegated":
-				send(createContainerPullStatusEvent{Type: event.Type, Image: event.Image, Message: event.Message})
-			case "creating":
-				send(createContainerCreatingEvent{Type: "creating"})
-			case "restoring":
-				send(createContainerRestoringEvent{Type: "restoring"})
-			}
-		}); err != nil {
-			h.logger.Error("bot container setup failed",
+	if err := h.acpWorkspace.SetupBotContainerWithProgress(lifecycleCtx, bot.ID, func(event workspace.ContainerSetupEvent) {
+		switch event.Type {
+		case "pulling":
+			send(createContainerPullingEvent{Type: "pulling", Image: event.Image})
+		case "pull_progress":
+			send(createContainerPullProgressEvent{Type: "pull_progress", Layers: event.Layers})
+		case "pull_skipped", "pull_delegated":
+			send(createContainerPullStatusEvent{Type: event.Type, Image: event.Image, Message: event.Message})
+		case "creating":
+			send(createContainerCreatingEvent{Type: "creating"})
+		case "restoring":
+			send(createContainerRestoringEvent{Type: "restoring"})
+		}
+	}); err != nil {
+		h.logger.Error("bot container setup failed",
+			slog.String("bot_id", bot.ID),
+			slog.Any("error", err),
+		)
+		if _, readyErr := h.botService.MarkReady(lifecycleCtx, bot.ID); readyErr != nil {
+			h.logger.Error("failed to update bot status to ready after stream create failure",
 				slog.String("bot_id", bot.ID),
-				slog.Any("error", err),
+				slog.Any("error", readyErr),
 			)
-			if _, readyErr := h.botService.MarkReady(lifecycleCtx, bot.ID); readyErr != nil {
-				h.logger.Error("failed to update bot status to ready after stream create failure",
-					slog.String("bot_id", bot.ID),
-					slog.Any("error", readyErr),
-				)
-				sendError("container setup failed: " + err.Error() + "; ready status update failed: " + readyErr.Error())
-				return nil
-			}
-			sendError("container setup failed: " + err.Error())
+			sendError("container setup failed: " + err.Error() + "; ready status update failed: " + readyErr.Error())
 			return nil
 		}
+		sendError("container setup failed: " + err.Error())
+		return nil
 	}
 
 	readyBot, err := h.botService.MarkReady(lifecycleCtx, bot.ID)

--- a/internal/handlers/users_acp_config_test.go
+++ b/internal/handlers/users_acp_config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/memohai/memoh/internal/acpclient"
 	"github.com/memohai/memoh/internal/acpprofile"
 	"github.com/memohai/memoh/internal/bots"
+	"github.com/memohai/memoh/internal/workspace"
 	"github.com/memohai/memoh/internal/workspace/bridge"
 	pb "github.com/memohai/memoh/internal/workspace/bridgepb"
 )
@@ -158,6 +159,10 @@ func (w *usersACPConfigWorkspace) WorkspaceInfo(context.Context, string) (bridge
 
 func (w *usersACPConfigWorkspace) MCPClient(context.Context, string) (*bridge.Client, error) {
 	return w.client, nil
+}
+
+func (*usersACPConfigWorkspace) SetupBotContainerWithProgress(context.Context, string, workspace.ContainerSetupProgress) error {
+	return nil
 }
 
 type usersACPConfigWrite struct {

--- a/internal/handlers/users_create_bot_stream_test.go
+++ b/internal/handlers/users_create_bot_stream_test.go
@@ -1,0 +1,277 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/labstack/echo/v4"
+
+	"github.com/memohai/memoh/internal/accounts"
+	"github.com/memohai/memoh/internal/bots"
+	ctr "github.com/memohai/memoh/internal/container"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/workspace"
+	"github.com/memohai/memoh/internal/workspace/bridge"
+)
+
+func TestCreateBotStreamsLifecycleWhenSSERequested(t *testing.T) {
+	ownerID := "00000000-0000-0000-0000-000000000101"
+	botID := "00000000-0000-0000-0000-000000000201"
+	botUUID := testUUID(botID)
+
+	handler := &UsersHandler{
+		service: newTestCreateBotAccountService(ownerID),
+		botService: bots.NewService(nil, postgresstore.NewQueries(sqlc.New(&createBotStreamDB{
+			ownerID: ownerID,
+			botID:   botID,
+		}))),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/bots", strings.NewReader(`{
+		"name": "stream-bot",
+		"display_name": "Stream Bot",
+		"acl_preset": "allow_all",
+		"wait_for_ready": true
+	}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set(echo.HeaderAccept, "text/event-stream")
+	rec := httptest.NewRecorder()
+	ctx := testAuthContext(echo.New(), req, rec, ownerID)
+
+	if err := handler.CreateBot(ctx); err != nil {
+		t.Fatalf("CreateBot() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := rec.Header().Get(echo.HeaderContentType); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("content type = %q, want text/event-stream", got)
+	}
+
+	events := decodeSSEEvents(t, rec.Body.String())
+	if len(events) < 2 {
+		t.Fatalf("events len = %d, want at least bot_created and ready: %#v", len(events), events)
+	}
+	if events[0]["type"] != "bot_created" {
+		t.Fatalf("first event type = %#v, want bot_created; events=%#v", events[0]["type"], events)
+	}
+	if got := eventBotID(events[0]); got != botID {
+		t.Fatalf("created bot id = %q, want %q", got, botID)
+	}
+	last := events[len(events)-1]
+	if last["type"] != "ready" {
+		t.Fatalf("last event type = %#v, want ready; events=%#v", last["type"], events)
+	}
+	if got := eventBotID(last); got != botID {
+		t.Fatalf("ready bot id = %q, want %q", got, botID)
+	}
+	if handler.botService == nil {
+		t.Fatal("bot service should be configured")
+	}
+	if botUUID.Valid != true {
+		t.Fatal("bot UUID helper sanity check failed")
+	}
+}
+
+func TestCreateBotStreamsContainerProgressEvents(t *testing.T) {
+	ownerID := "00000000-0000-0000-0000-000000000102"
+	botID := "00000000-0000-0000-0000-000000000202"
+
+	handler := &UsersHandler{
+		service: newTestCreateBotAccountService(ownerID),
+		botService: bots.NewService(nil, postgresstore.NewQueries(sqlc.New(&createBotStreamDB{
+			ownerID: ownerID,
+			botID:   botID,
+		}))),
+		acpWorkspace: &createBotStreamWorkspace{events: []workspace.ContainerSetupEvent{
+			{Type: "pulling", Image: "debian:bookworm-slim"},
+			{Type: "pull_progress", Layers: []ctr.LayerStatus{{Ref: "layer-1", Offset: 10, Total: 100}}},
+			{Type: "creating"},
+		}},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/bots", strings.NewReader(`{
+		"name": "progress-bot",
+		"display_name": "Progress Bot",
+		"acl_preset": "allow_all",
+		"wait_for_ready": true
+	}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set(echo.HeaderAccept, "text/event-stream")
+	rec := httptest.NewRecorder()
+	ctx := testAuthContext(echo.New(), req, rec, ownerID)
+
+	if err := handler.CreateBot(ctx); err != nil {
+		t.Fatalf("CreateBot() error = %v", err)
+	}
+
+	events := decodeSSEEvents(t, rec.Body.String())
+	for _, eventType := range []string{"bot_created", "pulling", "pull_progress", "creating", "ready"} {
+		if !hasEventType(events, eventType) {
+			t.Fatalf("missing %q event: %#v", eventType, events)
+		}
+	}
+}
+
+func decodeSSEEvents(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	events := make([]map[string]any, 0)
+	for _, block := range strings.Split(raw, "\n\n") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		for _, line := range strings.Split(block, "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			var event map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event); err != nil {
+				t.Fatalf("decode event %q: %v", line, err)
+			}
+			events = append(events, event)
+		}
+	}
+	return events
+}
+
+func eventBotID(event map[string]any) string {
+	bot, ok := event["bot"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := bot["id"].(string)
+	return id
+}
+
+func hasEventType(events []map[string]any, eventType string) bool {
+	for _, event := range events {
+		if event["type"] == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestCreateBotAccountService(userID string) *accounts.Service {
+	return accounts.NewService(nil, createBotAccountStore{userID: userID})
+}
+
+type createBotStreamWorkspace struct {
+	events []workspace.ContainerSetupEvent
+}
+
+func (w *createBotStreamWorkspace) MCPClient(context.Context, string) (*bridge.Client, error) {
+	return nil, nil
+}
+
+func (w *createBotStreamWorkspace) WorkspaceInfo(context.Context, string) (bridge.WorkspaceInfo, error) {
+	return bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer}, nil
+}
+
+func (w *createBotStreamWorkspace) SetupBotContainerWithProgress(_ context.Context, _ string, progress workspace.ContainerSetupProgress) error {
+	for _, event := range w.events {
+		progress(event)
+	}
+	return nil
+}
+
+type createBotAccountStore struct {
+	dbstore.AccountStore
+	userID string
+}
+
+func (s createBotAccountStore) GetByUserID(_ context.Context, userID string) (dbstore.AccountRecord, error) {
+	if userID != s.userID {
+		return dbstore.AccountRecord{}, pgx.ErrNoRows
+	}
+	return dbstore.AccountRecord{ID: userID, Role: "member", IsActive: true}, nil
+}
+
+type createBotStreamDB struct {
+	ownerID string
+	botID   string
+}
+
+func (d *createBotStreamDB) Exec(_ context.Context, _ string, _ ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (*createBotStreamDB) Query(context.Context, string, ...interface{}) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (d *createBotStreamDB) QueryRow(_ context.Context, query string, args ...any) pgx.Row {
+	switch {
+	case strings.Contains(query, "FROM users") && strings.Contains(query, "WHERE id = $1"):
+		return &createBotStreamRow{scanFunc: func(_ ...any) error { return nil }}
+	case strings.Contains(query, "INSERT INTO bots"):
+		return d.botRow(bots.BotStatusCreating)
+	case strings.Contains(query, "FROM bots") && strings.Contains(query, "WHERE id = $1"):
+		return d.botRow(bots.BotStatusReady)
+	case strings.Contains(query, "FROM bots") && strings.Contains(query, "WHERE name = $1"):
+		return &createBotStreamRow{scanFunc: func(_ ...any) error { return pgx.ErrNoRows }}
+	default:
+		_ = args
+		return &createBotStreamRow{scanFunc: func(_ ...any) error { return pgx.ErrNoRows }}
+	}
+}
+
+func (d *createBotStreamDB) botRow(status string) pgx.Row {
+	botID := testUUID(d.botID)
+	ownerID := testUUID(d.ownerID)
+	return &createBotStreamRow{scanFunc: func(dest ...any) error {
+		if len(dest) < 20 {
+			return pgx.ErrNoRows
+		}
+		*dest[0].(*pgtype.UUID) = botID
+		*dest[1].(*pgtype.UUID) = ownerID
+		*dest[2].(*string) = "stream-bot"
+		*dest[3].(*pgtype.Text) = pgtype.Text{String: "Stream Bot", Valid: true}
+		*dest[4].(*pgtype.Text) = pgtype.Text{}
+		*dest[5].(*pgtype.Text) = pgtype.Text{}
+		*dest[6].(*bool) = true
+		*dest[7].(*string) = status
+		*dest[8].(*string) = "en"
+		*dest[9].(*bool) = false
+		*dest[10].(*string) = "medium"
+		*dest[11].(*pgtype.UUID) = pgtype.UUID{}
+		*dest[12].(*pgtype.UUID) = pgtype.UUID{}
+		*dest[13].(*pgtype.UUID) = pgtype.UUID{}
+		*dest[14].(*bool) = false
+		*dest[15].(*int32) = 30
+		*dest[16].(*string) = ""
+		if len(dest) == 20 {
+			*dest[17].(*[]byte) = []byte(`{}`)
+			*dest[18].(*pgtype.Timestamptz) = pgtype.Timestamptz{Valid: false}
+			*dest[19].(*pgtype.Timestamptz) = pgtype.Timestamptz{Valid: false}
+			return nil
+		}
+		*dest[17].(*bool) = false
+		*dest[18].(*int32) = 200
+		*dest[19].(*int32) = 50
+		*dest[20].(*pgtype.UUID) = pgtype.UUID{}
+		*dest[21].(*[]byte) = []byte(`{}`)
+		*dest[22].(*pgtype.Timestamptz) = pgtype.Timestamptz{Valid: false}
+		*dest[23].(*pgtype.Timestamptz) = pgtype.Timestamptz{Valid: false}
+		return nil
+	}}
+}
+
+type createBotStreamRow struct {
+	scanFunc func(dest ...any) error
+}
+
+func (r *createBotStreamRow) Scan(dest ...any) error {
+	return r.scanFunc(dest...)
+}

--- a/internal/handlers/users_create_bot_stream_test.go
+++ b/internal/handlers/users_create_bot_stream_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/memohai/memoh/internal/accounts"
 	"github.com/memohai/memoh/internal/bots"
 	ctr "github.com/memohai/memoh/internal/container"
+	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -209,6 +210,62 @@ func TestCreateBotStreamReportsSetupErrorAfterCreatedBot(t *testing.T) {
 	}
 }
 
+func TestGetMeReturnsUnauthorizedWhenTokenUserIsMissing(t *testing.T) {
+	ownerID := "00000000-0000-0000-0000-000000000105"
+
+	handler := &UsersHandler{
+		service: accounts.NewService(nil, createBotMissingAccountStore{}),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/users/me", nil)
+	rec := httptest.NewRecorder()
+	ctx := testAuthContext(echo.New(), req, rec, ownerID)
+
+	err := handler.GetMe(ctx)
+	if err == nil {
+		t.Fatal("GetMe() error = nil, want unauthorized")
+	}
+	httpErr, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("GetMe() error type = %T, want *echo.HTTPError", err)
+	}
+	if httpErr.Code != http.StatusUnauthorized {
+		t.Fatalf("GetMe() status = %d, want %d", httpErr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestCreateBotStreamReturnsUnauthorizedWhenTokenUserIsMissing(t *testing.T) {
+	ownerID := "00000000-0000-0000-0000-000000000105"
+
+	handler := &UsersHandler{
+		service:    accounts.NewService(nil, createBotMissingAccountStore{}),
+		botService: bots.NewService(nil, nil),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/bots", strings.NewReader(`{
+		"name": "stale-token-bot",
+		"display_name": "Stale Token Bot",
+		"acl_preset": "allow_all",
+		"wait_for_ready": true
+	}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set(echo.HeaderAccept, "text/event-stream")
+	rec := httptest.NewRecorder()
+	ctx := testAuthContext(echo.New(), req, rec, ownerID)
+
+	err := handler.CreateBot(ctx)
+	if err == nil {
+		t.Fatal("CreateBot() error = nil, want unauthorized")
+	}
+	httpErr, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("CreateBot() error type = %T, want *echo.HTTPError", err)
+	}
+	if httpErr.Code != http.StatusUnauthorized {
+		t.Fatalf("CreateBot() status = %d, want %d", httpErr.Code, http.StatusUnauthorized)
+	}
+}
+
 func decodeSSEEvents(t *testing.T, raw string) []map[string]any {
 	t.Helper()
 	events := make([]map[string]any, 0)
@@ -284,6 +341,14 @@ func (s createBotAccountStore) GetByUserID(_ context.Context, userID string) (db
 		return dbstore.AccountRecord{}, pgx.ErrNoRows
 	}
 	return dbstore.AccountRecord{ID: userID, Role: "member", IsActive: true}, nil
+}
+
+type createBotMissingAccountStore struct {
+	dbstore.AccountStore
+}
+
+func (createBotMissingAccountStore) GetByUserID(context.Context, string) (dbstore.AccountRecord, error) {
+	return dbstore.AccountRecord{}, db.ErrNotFound
 }
 
 type createBotStreamDB struct {

--- a/internal/handlers/users_create_bot_stream_test.go
+++ b/internal/handlers/users_create_bot_stream_test.go
@@ -112,10 +112,7 @@ func TestCreateBotStreamRequiresWorkspaceLifecycle(t *testing.T) {
 	if err == nil {
 		t.Fatal("CreateBot() error = nil, want workspace lifecycle configuration error")
 	}
-	httpErr, ok := err.(*echo.HTTPError)
-	if !ok {
-		t.Fatalf("CreateBot() error type = %T, want *echo.HTTPError", err)
-	}
+	httpErr := requireHTTPError(t, err)
 	if httpErr.Code != http.StatusInternalServerError {
 		t.Fatalf("CreateBot() status = %d, want %d", httpErr.Code, http.StatusInternalServerError)
 	}
@@ -225,10 +222,7 @@ func TestGetMeReturnsUnauthorizedWhenTokenUserIsMissing(t *testing.T) {
 	if err == nil {
 		t.Fatal("GetMe() error = nil, want unauthorized")
 	}
-	httpErr, ok := err.(*echo.HTTPError)
-	if !ok {
-		t.Fatalf("GetMe() error type = %T, want *echo.HTTPError", err)
-	}
+	httpErr := requireHTTPError(t, err)
 	if httpErr.Code != http.StatusUnauthorized {
 		t.Fatalf("GetMe() status = %d, want %d", httpErr.Code, http.StatusUnauthorized)
 	}
@@ -257,13 +251,19 @@ func TestCreateBotStreamReturnsUnauthorizedWhenTokenUserIsMissing(t *testing.T) 
 	if err == nil {
 		t.Fatal("CreateBot() error = nil, want unauthorized")
 	}
-	httpErr, ok := err.(*echo.HTTPError)
-	if !ok {
-		t.Fatalf("CreateBot() error type = %T, want *echo.HTTPError", err)
-	}
+	httpErr := requireHTTPError(t, err)
 	if httpErr.Code != http.StatusUnauthorized {
 		t.Fatalf("CreateBot() status = %d, want %d", httpErr.Code, http.StatusUnauthorized)
 	}
+}
+
+func requireHTTPError(t *testing.T, err error) *echo.HTTPError {
+	t.Helper()
+	var httpErr *echo.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error type = %T, want *echo.HTTPError", err)
+	}
+	return httpErr
 }
 
 func decodeSSEEvents(t *testing.T, raw string) []map[string]any {
@@ -316,11 +316,11 @@ type createBotStreamWorkspace struct {
 	err    error
 }
 
-func (w *createBotStreamWorkspace) MCPClient(context.Context, string) (*bridge.Client, error) {
+func (*createBotStreamWorkspace) MCPClient(context.Context, string) (*bridge.Client, error) {
 	return nil, nil
 }
 
-func (w *createBotStreamWorkspace) WorkspaceInfo(context.Context, string) (bridge.WorkspaceInfo, error) {
+func (*createBotStreamWorkspace) WorkspaceInfo(context.Context, string) (bridge.WorkspaceInfo, error) {
 	return bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer}, nil
 }
 
@@ -356,7 +356,7 @@ type createBotStreamDB struct {
 	botID   string
 }
 
-func (d *createBotStreamDB) Exec(_ context.Context, _ string, _ ...interface{}) (pgconn.CommandTag, error) {
+func (*createBotStreamDB) Exec(_ context.Context, _ string, _ ...interface{}) (pgconn.CommandTag, error) {
 	return pgconn.CommandTag{}, nil
 }
 

--- a/internal/handlers/users_create_bot_stream_test.go
+++ b/internal/handlers/users_create_bot_stream_test.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -34,6 +36,7 @@ func TestCreateBotStreamsLifecycleWhenSSERequested(t *testing.T) {
 			ownerID: ownerID,
 			botID:   botID,
 		}))),
+		acpWorkspace: &createBotStreamWorkspace{},
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/bots", strings.NewReader(`{
@@ -82,6 +85,41 @@ func TestCreateBotStreamsLifecycleWhenSSERequested(t *testing.T) {
 	}
 }
 
+func TestCreateBotStreamRequiresWorkspaceLifecycle(t *testing.T) {
+	ownerID := "00000000-0000-0000-0000-000000000103"
+
+	handler := &UsersHandler{
+		service: newTestCreateBotAccountService(ownerID),
+		botService: bots.NewService(nil, postgresstore.NewQueries(sqlc.New(&createBotStreamDB{
+			ownerID: ownerID,
+			botID:   "00000000-0000-0000-0000-000000000203",
+		}))),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/bots", strings.NewReader(`{
+		"name": "misconfigured-bot",
+		"display_name": "Misconfigured Bot",
+		"acl_preset": "allow_all",
+		"wait_for_ready": true
+	}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set(echo.HeaderAccept, "text/event-stream")
+	rec := httptest.NewRecorder()
+	ctx := testAuthContext(echo.New(), req, rec, ownerID)
+
+	err := handler.CreateBot(ctx)
+	if err == nil {
+		t.Fatal("CreateBot() error = nil, want workspace lifecycle configuration error")
+	}
+	httpErr, ok := err.(*echo.HTTPError)
+	if !ok {
+		t.Fatalf("CreateBot() error type = %T, want *echo.HTTPError", err)
+	}
+	if httpErr.Code != http.StatusInternalServerError {
+		t.Fatalf("CreateBot() status = %d, want %d", httpErr.Code, http.StatusInternalServerError)
+	}
+}
+
 func TestCreateBotStreamsContainerProgressEvents(t *testing.T) {
 	ownerID := "00000000-0000-0000-0000-000000000102"
 	botID := "00000000-0000-0000-0000-000000000202"
@@ -119,6 +157,55 @@ func TestCreateBotStreamsContainerProgressEvents(t *testing.T) {
 		if !hasEventType(events, eventType) {
 			t.Fatalf("missing %q event: %#v", eventType, events)
 		}
+	}
+}
+
+func TestCreateBotStreamReportsSetupErrorAfterCreatedBot(t *testing.T) {
+	ownerID := "00000000-0000-0000-0000-000000000104"
+	botID := "00000000-0000-0000-0000-000000000204"
+
+	handler := &UsersHandler{
+		logger:  slog.Default(),
+		service: newTestCreateBotAccountService(ownerID),
+		botService: bots.NewService(nil, postgresstore.NewQueries(sqlc.New(&createBotStreamDB{
+			ownerID: ownerID,
+			botID:   botID,
+		}))),
+		acpWorkspace: &createBotStreamWorkspace{err: errors.New("image pull failed")},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/bots", strings.NewReader(`{
+		"name": "setup-failed-bot",
+		"display_name": "Setup Failed Bot",
+		"acl_preset": "allow_all",
+		"wait_for_ready": true
+	}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set(echo.HeaderAccept, "text/event-stream")
+	rec := httptest.NewRecorder()
+	ctx := testAuthContext(echo.New(), req, rec, ownerID)
+
+	if err := handler.CreateBot(ctx); err != nil {
+		t.Fatalf("CreateBot() error = %v", err)
+	}
+
+	events := decodeSSEEvents(t, rec.Body.String())
+	if len(events) < 2 {
+		t.Fatalf("events len = %d, want bot_created and error: %#v", len(events), events)
+	}
+	if events[0]["type"] != "bot_created" {
+		t.Fatalf("first event type = %#v, want bot_created; events=%#v", events[0]["type"], events)
+	}
+	if got := eventBotID(events[0]); got != botID {
+		t.Fatalf("created bot id = %q, want %q", got, botID)
+	}
+	last := events[len(events)-1]
+	if last["type"] != "error" {
+		t.Fatalf("last event type = %#v, want error; events=%#v", last["type"], events)
+	}
+	message, _ := last["message"].(string)
+	if !strings.Contains(message, "container setup failed: image pull failed") {
+		t.Fatalf("error message = %q, want setup failure details", message)
 	}
 }
 
@@ -169,6 +256,7 @@ func newTestCreateBotAccountService(userID string) *accounts.Service {
 
 type createBotStreamWorkspace struct {
 	events []workspace.ContainerSetupEvent
+	err    error
 }
 
 func (w *createBotStreamWorkspace) MCPClient(context.Context, string) (*bridge.Client, error) {
@@ -183,7 +271,7 @@ func (w *createBotStreamWorkspace) SetupBotContainerWithProgress(_ context.Conte
 	for _, event := range w.events {
 		progress(event)
 	}
-	return nil
+	return w.err
 }
 
 type createBotAccountStore struct {

--- a/internal/workspace/manager_lifecycle.go
+++ b/internal/workspace/manager_lifecycle.go
@@ -326,8 +326,31 @@ func (m *Manager) GetContainerInfo(ctx context.Context, botID string) (*Containe
 // Container lifecycle (bots.ContainerLifecycle interface)
 // ---------------------------------------------------------------------------
 
+type ContainerSetupEvent struct {
+	Type    string
+	Image   string
+	Message string
+	Layers  []ctr.LayerStatus
+}
+
+type ContainerSetupProgress func(ContainerSetupEvent)
+
 // SetupBotContainer creates/starts the container and upserts the DB record.
 func (m *Manager) SetupBotContainer(ctx context.Context, botID string) error {
+	return m.setupBotContainer(ctx, botID, nil)
+}
+
+func (m *Manager) SetupBotContainerWithProgress(ctx context.Context, botID string, progress ContainerSetupProgress) error {
+	return m.setupBotContainer(ctx, botID, progress)
+}
+
+func (m *Manager) setupBotContainer(ctx context.Context, botID string, progress ContainerSetupProgress) error {
+	emit := func(event ContainerSetupEvent) {
+		if progress != nil {
+			progress(event)
+		}
+	}
+
 	workspaceCfg, err := m.botWorkspaceStartPreference(ctx, botID)
 	if err != nil {
 		m.logger.Error("setup bot container: resolve workspace backend failed",
@@ -343,9 +366,13 @@ func (m *Manager) SetupBotContainer(ctx context.Context, botID string) error {
 		return err
 	}
 	if workspaceCfg.Backend != bridge.WorkspaceBackendLocal {
+		emit(ContainerSetupEvent{Type: "pulling", Image: image})
 		result, err := m.PrepareImageForCreate(ctx, image, &ctr.PullImageOptions{
 			Unpack:        true,
 			StorageDriver: m.cfg.Snapshotter,
+			OnProgress: func(p ctr.PullProgress) {
+				emit(ContainerSetupEvent{Type: "pull_progress", Layers: p.Layers})
+			},
 		})
 		if err != nil {
 			m.logger.Error("setup bot container: prepare image failed",
@@ -357,12 +384,24 @@ func (m *Manager) SetupBotContainer(ctx context.Context, botID string) error {
 		if strings.TrimSpace(result.ImageRef) != "" {
 			image = result.ImageRef
 		}
+		switch result.Mode {
+		case ImagePrepareSkipped:
+			emit(ContainerSetupEvent{Type: "pull_skipped", Image: image, Message: result.Message})
+		case ImagePrepareDelegated:
+			emit(ContainerSetupEvent{Type: "pull_delegated", Image: image, Message: result.Message})
+		}
 	} else {
 		image = "local"
+		emit(ContainerSetupEvent{Type: "pull_skipped", Image: image, Message: "local workspace does not use container images"})
 	}
 	gpu, err := m.resolveWorkspaceGPU(ctx, botID)
 	if err != nil {
 		return err
+	}
+
+	emit(ContainerSetupEvent{Type: "creating"})
+	if m.HasPreservedData(botID) {
+		emit(ContainerSetupEvent{Type: "restoring"})
 	}
 
 	if err := m.StartWithWorkspaceConfig(ctx, botID, image, gpu, workspaceCfg); err != nil {

--- a/packages/sdk/src/client/client.gen.ts
+++ b/packages/sdk/src/client/client.gen.ts
@@ -248,10 +248,13 @@ export const createClient = (config: Config = {}): Client => {
         let finalError = error;
         for (const fn of interceptors.error.fns) {
           if (fn) {
-            finalError = await fn(error, response as any, request as any, opts);
+            const nextError = await fn(finalError, response as any, request as any, opts);
+            if (nextError !== undefined && nextError !== null) {
+              finalError = nextError;
+            }
           }
         }
-        return finalError || ({} as unknown);
+        return finalError;
       },
       onRequest: async (url, init) => {
         let request = new Request(url, init);

--- a/packages/sdk/src/client/client.gen.ts
+++ b/packages/sdk/src/client/client.gen.ts
@@ -244,6 +244,15 @@ export const createClient = (config: Config = {}): Client => {
       body: opts.body as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
+      onError: async (error, response, request) => {
+        let finalError = error;
+        for (const fn of interceptors.error.fns) {
+          if (fn) {
+            finalError = await fn(error, response as any, request as any, opts);
+          }
+        }
+        return finalError || ({} as unknown);
+      },
       onRequest: async (url, init) => {
         let request = new Request(url, init);
         for (const fn of interceptors.request.fns) {
@@ -252,6 +261,14 @@ export const createClient = (config: Config = {}): Client => {
           }
         }
         return request;
+      },
+      onResponse: async (response, request) => {
+        for (const fn of interceptors.response.fns) {
+          if (fn) {
+            response = await fn(response, request, opts);
+          }
+        }
+        return response;
       },
       serializedBody: getValidRequestBody(opts) as BodyInit | null | undefined,
       url,

--- a/packages/sdk/src/core/serverSentEvents.gen.ts
+++ b/packages/sdk/src/core/serverSentEvents.gen.ts
@@ -16,6 +16,14 @@ export type ServerSentEventsOptions<TData = unknown> = Omit<RequestInit, 'method
      */
     onRequest?: (url: string, init: RequestInit) => Promise<Request>;
     /**
+     * Implementing clients can call response interceptors inside this hook.
+     */
+    onResponse?: (response: Response, request: Request) => Promise<Response>;
+    /**
+     * Implementing clients can call error interceptors inside this hook.
+     */
+    onError?: (error: unknown, response?: Response, request?: Request) => Promise<unknown>;
+    /**
      * Callback invoked when a network or parsing error occurs during streaming.
      *
      * This option applies only if the endpoint returns a stream of events.
@@ -80,7 +88,9 @@ export type ServerSentEventsResult<TData = unknown, TReturn = void, TNext = unkn
 };
 
 export const createSseClient = <TData = unknown>({
+  onError,
   onRequest,
+  onResponse,
   onSseError,
   onSseEvent,
   responseTransformer,
@@ -115,6 +125,9 @@ export const createSseClient = <TData = unknown>({
         headers.set('Last-Event-ID', lastEventId);
       }
 
+      let request: Request | undefined;
+      let response: Response | undefined;
+
       try {
         const requestInit: RequestInit = {
           redirect: 'follow',
@@ -123,14 +136,18 @@ export const createSseClient = <TData = unknown>({
           headers,
           signal,
         };
-        let request = new Request(url, requestInit);
+        request = new Request(url, requestInit);
         if (onRequest) {
           request = await onRequest(url, requestInit);
         }
         // fetch must be assigned here, otherwise it would throw the error:
         // TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
         const _fetch = options.fetch ?? globalThis.fetch;
-        const response = await _fetch(request);
+        response = await _fetch(request);
+
+        if (onResponse) {
+          response = await onResponse(response, request);
+        }
 
         if (!response.ok) throw new Error(`SSE failed: ${response.status} ${response.statusText}`);
 
@@ -224,7 +241,8 @@ export const createSseClient = <TData = unknown>({
         break; // exit loop on normal completion
       } catch (error) {
         // connection failed or aborted; retry after delay
-        onSseError?.(error);
+        const finalError = onError ? await onError(error, response, request) : error;
+        onSseError?.(finalError);
 
         if (sseMaxRetryAttempts !== undefined && attempt >= sseMaxRetryAttempts) {
           break; // stop after firing error

--- a/packages/sdk/src/core/serverSentEvents.gen.ts
+++ b/packages/sdk/src/core/serverSentEvents.gen.ts
@@ -241,7 +241,17 @@ export const createSseClient = <TData = unknown>({
         break; // exit loop on normal completion
       } catch (error) {
         // connection failed or aborted; retry after delay
-        const finalError = onError ? await onError(error, response, request) : error;
+        let finalError = error;
+        if (onError) {
+          try {
+            const nextError = await onError(error, response, request);
+            if (nextError !== undefined && nextError !== null) {
+              finalError = nextError;
+            }
+          } catch {
+            finalError = error;
+          }
+        }
         onSseError?.(finalError);
 
         if (sseMaxRetryAttempts !== undefined && attempt >= sseMaxRetryAttempts) {


### PR DESCRIPTION
## Summary

- Add SSE-based Bot creation progress for container setup.
- Keep creation progress alive across navigation via a shared Pinia store and dedicated progress route.
- Preserve created Bot state when post-create container/setup steps fail, surfacing setup errors as warnings instead of losing the Bot.
- Route SSE non-2xx responses through the shared SDK response/error interceptor path.
- Harden progress route lifecycle cleanup for delayed redirects under KeepAlive.

## Verification

- `go test -count=1 ./internal/bots ./internal/handlers`
- `vitest run --config vitest.config.ts --project web src/composables/api/sseClient.test.ts src/pages/bots/new-progress.test.ts src/composables/api/useBotCreateStream.test.ts src/store/bot-create-progress.test.ts`
- targeted ESLint passed
- `git diff --check`
