### PR TITLE
fix: provider OAuth and ACP OAuth timeout

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -671,6 +671,7 @@
       "authorize": "Authorize",
       "deviceAuthorize": "Start Device Authorization",
       "authorizeFailed": "Failed to start authorization",
+      "authorizeTimedOut": "Authorization timed out. Try again.",
       "authorizeSuccess": "Authorization successful",
       "revoke": "Revoke",
       "revokeFailed": "Failed to revoke authorization",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -667,6 +667,7 @@
       "authorize": "授权",
       "deviceAuthorize": "启动设备授权",
       "authorizeFailed": "启动授权失败",
+      "authorizeTimedOut": "授权超时，请重试。",
       "authorizeSuccess": "授权成功",
       "revoke": "撤销授权",
       "revokeFailed": "撤销授权失败",

--- a/apps/web/src/pages/bots/components/settings-acp-card.vue
+++ b/apps/web/src/pages/bots/components/settings-acp-card.vue
@@ -459,7 +459,9 @@ function cancelCodexOAuthAuthorization() {
 async function handleAuthorize(profile: AcpprofilePublicProfile) {
   try {
     if (!props.botId) return
-    codexOAuthFlow.value?.cancel()
+    // Supersede any in-flight popup silently: dispose() (not cancel()) so the
+    // previous flow's onAborted doesn't fight the new attempt's loading state.
+    codexOAuthFlow.value?.dispose()
     agentForm(profile).setup_mode = 'oauth'
     authorizingCodexOAuth.value = true
     const { data } = await client.get<{ 200: ACPCodexOAuthAuthorizeResponse }, unknown, true>({
@@ -473,6 +475,7 @@ async function handleAuthorize(profile: AcpprofilePublicProfile) {
     codexOAuthFlow.value = startOAuthPopupFlow<ACPCodexOAuthStatus>({
       popup,
       target: window,
+      expectedSource: popup,
       messageType: 'memoh-acp-codex-oauth-success',
       messageMatches: event => event.data?.botId === props.botId,
       pollIntervalMs: codexOAuthPollIntervalMs,

--- a/apps/web/src/pages/bots/components/settings-acp-card.vue
+++ b/apps/web/src/pages/bots/components/settings-acp-card.vue
@@ -86,37 +86,39 @@
               v-if="isCodexProfile(profile) && agentForm(profile).setup_mode === 'oauth'"
               class="space-y-2 rounded-md border border-border/70 bg-muted/20 p-3"
             >
-              <div class="flex items-center justify-between gap-3">
+              <div class="flex items-center gap-3">
                 <div
-                  class="min-w-0 text-[10px]"
+                  class="min-w-0 flex-1 text-[10px]"
                   :class="codexOAuthStatus?.has_token ? 'text-muted-foreground' : 'text-destructive'"
                 >
                   {{ codexOAuthStatusText() }}
                 </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  class="h-7 shrink-0 text-xs shadow-none"
-                  :disabled="authorizingCodexOAuth"
-                  @click="handleAuthorize(profile)"
-                >
-                  <LoaderCircle
-                    v-if="authorizingCodexOAuth"
-                    class="size-3 animate-spin"
-                  />
-                  {{ $t('bots.settings.acpOAuthAuthorizeCodex') }}
-                </Button>
-                <Button
-                  v-if="codexOAuthFlow"
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  class="h-7 shrink-0 text-xs shadow-none"
-                  @click="cancelCodexOAuthAuthorization"
-                >
-                  {{ $t('common.cancel') }}
-                </Button>
+                <div class="flex shrink-0 items-center gap-2">
+                  <Button
+                    v-if="codexOAuthFlow"
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    class="h-7 shrink-0 text-xs shadow-none"
+                    @click="cancelCodexOAuthAuthorization"
+                  >
+                    {{ $t('common.cancel') }}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    class="h-7 shrink-0 text-xs shadow-none"
+                    :disabled="authorizingCodexOAuth"
+                    @click="handleAuthorize(profile)"
+                  >
+                    <LoaderCircle
+                      v-if="authorizingCodexOAuth"
+                      class="size-3 animate-spin"
+                    />
+                    {{ $t('bots.settings.acpOAuthAuthorizeCodex') }}
+                  </Button>
+                </div>
               </div>
             </div>
 
@@ -124,27 +126,29 @@
               v-if="isClaudeCodeProfile(profile) && agentForm(profile).setup_mode === 'oauth'"
               class="space-y-2 rounded-md border border-border/70 bg-muted/20 p-3"
             >
-              <div class="flex items-center justify-between gap-3">
+              <div class="flex items-center gap-3">
                 <div
-                  class="min-w-0 text-[10px]"
+                  class="min-w-0 flex-1 text-[10px]"
                   :class="claudeOAuthStatus?.has_token ? 'text-muted-foreground' : 'text-destructive'"
                 >
                   {{ claudeOAuthStatusText() }}
                 </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  class="h-7 shrink-0 text-xs shadow-none"
-                  :disabled="authorizingClaudeOAuth"
-                  @click="handleAuthorizeClaude(profile)"
-                >
-                  <LoaderCircle
-                    v-if="authorizingClaudeOAuth"
-                    class="size-3 animate-spin"
-                  />
-                  {{ $t('bots.settings.acpOAuthAuthorizeClaudeCode') }}
-                </Button>
+                <div class="flex shrink-0 items-center gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    class="h-7 shrink-0 text-xs shadow-none"
+                    :disabled="authorizingClaudeOAuth"
+                    @click="handleAuthorizeClaude(profile)"
+                  >
+                    <LoaderCircle
+                      v-if="authorizingClaudeOAuth"
+                      class="size-3 animate-spin"
+                    />
+                    {{ $t('bots.settings.acpOAuthAuthorizeClaudeCode') }}
+                  </Button>
+                </div>
               </div>
 
               <div
@@ -232,6 +236,7 @@ import {
 } from '@memohai/sdk'
 import { acpAgentIcon, ensureACPAgentForm, normalizeACPAgentID, type ACPAgentForm, type ACPForm } from '@/utils/acp'
 import { startOAuthPopupFlow, type OAuthPopupFlowController } from '@/utils/oauth/popup-flow'
+import { oauthStatusTextKey } from '@/utils/oauth/status-text'
 
 const props = defineProps<{
   botId: string
@@ -274,6 +279,10 @@ interface ACPClaudeCodeOAuthStatus {
 interface ACPClaudeCodeOAuthAuthorizeResponse {
   auth_url: string
   session_id: string
+}
+
+interface OAuthStatusLoadOptions {
+  silent?: boolean
 }
 
 function agentForm(profile: AcpprofilePublicProfile): ACPAgentForm {
@@ -365,6 +374,12 @@ const claudeOAuthActive = computed(() => {
   return !!form.enabled && form.setup_mode === 'oauth'
 })
 
+const codexOAuthPending = computed(() => authorizingCodexOAuth.value || Boolean(codexOAuthFlow.value))
+const claudeOAuthPending = computed(() => {
+  if (authorizingClaudeOAuth.value || exchangingClaudeOAuth.value) return true
+  return Boolean(claudeOAuthSessionId.value && !claudeOAuthStatus.value?.has_token)
+})
+
 watch([() => props.botId, codexOAuthActive], () => {
   if (codexOAuthActive.value) void loadOAuthStatus()
 }, { immediate: true })
@@ -378,23 +393,26 @@ onBeforeUnmount(() => {
 })
 
 function codexOAuthStatusText(): string {
-  return oauthStatusText(codexOAuthStatusLoading.value, codexOAuthStatus.value, 'bots.settings.acpOAuthUnavailable')
+  return t(oauthStatusTextKey({
+    loading: codexOAuthStatusLoading.value,
+    authorizing: codexOAuthPending.value,
+    status: codexOAuthStatus.value,
+    unavailableKey: 'bots.settings.acpOAuthUnavailable',
+  }))
 }
 
 function claudeOAuthStatusText(): string {
-  return oauthStatusText(claudeOAuthStatusLoading.value, claudeOAuthStatus.value, 'bots.settings.acpClaudeOAuthUnavailable')
+  return t(oauthStatusTextKey({
+    loading: claudeOAuthStatusLoading.value,
+    authorizing: claudeOAuthPending.value,
+    status: claudeOAuthStatus.value,
+    unavailableKey: 'bots.settings.acpClaudeOAuthUnavailable',
+  }))
 }
 
-function oauthStatusText(loading: boolean, status: { configured: boolean, has_token: boolean } | null, unavailableKey: string): string {
-  if (loading) return t('provider.oauth.status.checking')
-  if (!status?.configured) return t(unavailableKey)
-  if (status.has_token) return t('provider.oauth.status.authorized')
-  return t('provider.oauth.status.missing')
-}
-
-async function loadOAuthStatus(): Promise<ACPCodexOAuthStatus | null> {
+async function loadOAuthStatus(options: OAuthStatusLoadOptions = {}): Promise<ACPCodexOAuthStatus | null> {
   if (!props.botId) return null
-  codexOAuthStatusLoading.value = true
+  if (!options.silent) codexOAuthStatusLoading.value = true
   try {
     const { data } = await client.get<{ 200: ACPCodexOAuthStatus }, unknown, true>({
       url: '/bots/{bot_id}/acp/codex/oauth/status',
@@ -404,10 +422,10 @@ async function loadOAuthStatus(): Promise<ACPCodexOAuthStatus | null> {
     codexOAuthStatus.value = data ?? null
     return codexOAuthStatus.value
   } catch {
-    codexOAuthStatus.value = null
+    if (!options.silent) codexOAuthStatus.value = null
     return null
   } finally {
-    codexOAuthStatusLoading.value = false
+    if (!options.silent) codexOAuthStatusLoading.value = false
   }
 }
 
@@ -441,6 +459,7 @@ function cancelCodexOAuthAuthorization() {
 async function handleAuthorize(profile: AcpprofilePublicProfile) {
   try {
     if (!props.botId) return
+    codexOAuthFlow.value?.cancel()
     agentForm(profile).setup_mode = 'oauth'
     authorizingCodexOAuth.value = true
     const { data } = await client.get<{ 200: ACPCodexOAuthAuthorizeResponse }, unknown, true>({
@@ -451,7 +470,6 @@ async function handleAuthorize(profile: AcpprofilePublicProfile) {
     if (!data?.auth_url) throw new Error(t('provider.oauth.authorizeFailed'))
     const popup = window.open(data.auth_url, 'acp-codex-oauth', 'width=600,height=720')
     if (!popup) throw new Error(t('provider.oauth.authorizeFailed'))
-    codexOAuthFlow.value?.cancel()
     codexOAuthFlow.value = startOAuthPopupFlow<ACPCodexOAuthStatus>({
       popup,
       target: window,
@@ -459,11 +477,11 @@ async function handleAuthorize(profile: AcpprofilePublicProfile) {
       messageMatches: event => event.data?.botId === props.botId,
       pollIntervalMs: codexOAuthPollIntervalMs,
       timeoutMs: codexOAuthPollTimeoutMs,
-      pollStatus: loadOAuthStatus,
+      pollStatus: () => loadOAuthStatus({ silent: true }),
       isAuthorized: status => Boolean(status?.has_token),
       onAuthorized: async () => {
         codexOAuthFlow.value = null
-        await loadOAuthStatus()
+        await loadOAuthStatus({ silent: true })
         toast.success(t('provider.oauth.authorizeSuccess'))
         authorizingCodexOAuth.value = false
       },

--- a/apps/web/src/pages/bots/components/settings-acp-card.vue
+++ b/apps/web/src/pages/bots/components/settings-acp-card.vue
@@ -107,6 +107,16 @@
                   />
                   {{ $t('bots.settings.acpOAuthAuthorizeCodex') }}
                 </Button>
+                <Button
+                  v-if="codexOAuthFlow"
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  class="h-7 shrink-0 text-xs shadow-none"
+                  @click="cancelCodexOAuthAuthorization"
+                >
+                  {{ $t('common.cancel') }}
+                </Button>
               </div>
             </div>
 
@@ -209,7 +219,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { useQueryCache } from '@pinia/colada'
@@ -221,6 +231,7 @@ import {
   type AcpprofilePublicProfile,
 } from '@memohai/sdk'
 import { acpAgentIcon, ensureACPAgentForm, normalizeACPAgentID, type ACPAgentForm, type ACPForm } from '@/utils/acp'
+import { startOAuthPopupFlow, type OAuthPopupFlowController } from '@/utils/oauth/popup-flow'
 
 const props = defineProps<{
   botId: string
@@ -234,12 +245,15 @@ const queryCache = useQueryCache()
 const codexOAuthStatus = ref<ACPCodexOAuthStatus | null>(null)
 const codexOAuthStatusLoading = ref(false)
 const authorizingCodexOAuth = ref(false)
+const codexOAuthFlow = ref<OAuthPopupFlowController | null>(null)
 const claudeOAuthStatus = ref<ACPClaudeCodeOAuthStatus | null>(null)
 const claudeOAuthStatusLoading = ref(false)
 const authorizingClaudeOAuth = ref(false)
 const exchangingClaudeOAuth = ref(false)
 const claudeOAuthSessionId = ref('')
 const claudeOAuthCode = ref('')
+const codexOAuthPollIntervalMs = 1500
+const codexOAuthPollTimeoutMs = 5 * 60 * 1000
 
 interface ACPCodexOAuthStatus {
   configured: boolean
@@ -359,6 +373,10 @@ watch([() => props.botId, claudeOAuthActive], () => {
   if (claudeOAuthActive.value) void loadClaudeOAuthStatus()
 }, { immediate: true })
 
+onBeforeUnmount(() => {
+  cancelCodexOAuthAuthorization()
+})
+
 function codexOAuthStatusText(): string {
   return oauthStatusText(codexOAuthStatusLoading.value, codexOAuthStatus.value, 'bots.settings.acpOAuthUnavailable')
 }
@@ -416,8 +434,13 @@ async function loadClaudeOAuthStatus(): Promise<ACPClaudeCodeOAuthStatus | null>
   }
 }
 
+function cancelCodexOAuthAuthorization() {
+  codexOAuthFlow.value?.cancel()
+}
+
 async function handleAuthorize(profile: AcpprofilePublicProfile) {
   try {
+    if (!props.botId) return
     agentForm(profile).setup_mode = 'oauth'
     authorizingCodexOAuth.value = true
     const { data } = await client.get<{ 200: ACPCodexOAuthAuthorizeResponse }, unknown, true>({
@@ -427,38 +450,33 @@ async function handleAuthorize(profile: AcpprofilePublicProfile) {
     })
     if (!data?.auth_url) throw new Error(t('provider.oauth.authorizeFailed'))
     const popup = window.open(data.auth_url, 'acp-codex-oauth', 'width=600,height=720')
-    const startedAt = Date.now()
-    let completed = false
-    const finish = async () => {
-      if (completed) return
-      completed = true
-      window.removeEventListener('message', listener)
-      popup?.close()
-      await loadOAuthStatus()
-      toast.success(t('provider.oauth.authorizeSuccess'))
-      authorizingCodexOAuth.value = false
-    }
-    const poll = () => {
-      window.setTimeout(() => {
-        void (async () => {
-          const status = await loadOAuthStatus()
-          if (status?.has_token) {
-            await finish()
-            return
-          }
-          if (Date.now() - startedAt < 120_000 && !completed) poll()
-          else authorizingCodexOAuth.value = false
-        })()
-      }, 1_500)
-    }
-    const listener = (event: MessageEvent) => {
-      if (event.data?.type === 'memoh-acp-codex-oauth-success' && event.data?.botId === props.botId) {
-        void finish()
-      }
-    }
-    window.addEventListener('message', listener)
-    poll()
+    if (!popup) throw new Error(t('provider.oauth.authorizeFailed'))
+    codexOAuthFlow.value?.cancel()
+    codexOAuthFlow.value = startOAuthPopupFlow<ACPCodexOAuthStatus>({
+      popup,
+      target: window,
+      messageType: 'memoh-acp-codex-oauth-success',
+      messageMatches: event => event.data?.botId === props.botId,
+      pollIntervalMs: codexOAuthPollIntervalMs,
+      timeoutMs: codexOAuthPollTimeoutMs,
+      pollStatus: loadOAuthStatus,
+      isAuthorized: status => Boolean(status?.has_token),
+      onAuthorized: async () => {
+        codexOAuthFlow.value = null
+        await loadOAuthStatus()
+        toast.success(t('provider.oauth.authorizeSuccess'))
+        authorizingCodexOAuth.value = false
+      },
+      onAborted: (reason) => {
+        codexOAuthFlow.value = null
+        authorizingCodexOAuth.value = false
+        if (reason === 'timeout') {
+          toast.error(t('provider.oauth.authorizeTimedOut'))
+        }
+      },
+    })
   } catch (error) {
+    cancelCodexOAuthAuthorization()
     authorizingCodexOAuth.value = false
     toast.error(error instanceof Error ? error.message : t('provider.oauth.authorizeFailed'))
   }

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -679,10 +679,14 @@ async function handleAuthorize() {
     if (!result.auth_url) throw new Error(t('provider.oauth.authorizeFailed'))
     const popup = window.open(result.auth_url, 'provider-oauth', 'width=600,height=720')
     if (!popup) throw new Error(t('provider.oauth.authorizeFailed'))
-    webOAuthFlow.value?.cancel()
+    // Supersede any in-flight popup silently: dispose() (not cancel()) so the
+    // previous flow's onAborted doesn't clear this attempt's loading state or
+    // close the window we just reused.
+    webOAuthFlow.value?.dispose()
     webOAuthFlow.value = startOAuthPopupFlow<ProvidersOAuthStatus>({
       popup,
       target: window,
+      expectedSource: popup,
       messageType: 'memoh-provider-oauth-success',
       pollIntervalMs: webOAuthPollIntervalMs,
       timeoutMs: webOAuthPollTimeoutMs,

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -54,7 +54,7 @@
       </FormField>
 
       <FormField
-        v-if="!['openai-codex', 'github-copilot'].includes(form.values.client_type)"
+        v-if="!isProviderOAuthClientType(form.values.client_type)"
         v-slot="{ componentField }"
         name="api_key"
       >
@@ -108,7 +108,7 @@
       </FormField>
 
       <section
-        v-if="['openai-codex', 'github-copilot'].includes(form.values.client_type)"
+        v-if="isProviderOAuthClientType(form.values.client_type)"
         class="md:col-span-2 rounded-lg border p-4 space-y-3 text-xs"
       >
         <div class="space-y-1">
@@ -213,7 +213,7 @@
         <div class="flex gap-2">
           <LoadingButton
             v-if="props.provider?.id
-              && ['openai-codex', 'github-copilot'].includes(form.values.client_type)
+              && isProviderOAuthClientType(form.values.client_type)
               && !(
                 form.values.client_type === 'github-copilot'
                 && oauthStatus?.device?.pending
@@ -224,13 +224,21 @@
               && (!oauthStatus?.has_token || oauthExpired)"
             type="button"
             variant="outline"
-            :disabled="!props.provider?.id || !['openai-codex', 'github-copilot'].includes(form.values.client_type) || oauthStatusLoading"
+            :disabled="!props.provider?.id || !isProviderOAuthClientType(form.values.client_type) || oauthStatusLoading"
             :loading="authorizeLoading"
             @click="handleAuthorize"
           >
             <KeyRound />
             {{ $t(form.values.client_type === 'github-copilot' ? 'provider.oauth.deviceAuthorize' : 'provider.oauth.authorize') }}
           </LoadingButton>
+          <Button
+            v-if="webOAuthFlow"
+            type="button"
+            variant="ghost"
+            @click="cancelWebOAuthAuthorization"
+          >
+            {{ $t('common.cancel') }}
+          </Button>
           <LoadingButton
             v-if="oauthStatus?.has_token"
             type="button"
@@ -361,6 +369,7 @@ import type {
 } from '@memohai/sdk'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
+import { startOAuthPopupFlow, type OAuthPopupFlowController } from '@/utils/oauth/popup-flow'
 
 const { t } = useI18n()
 const { copyText } = useClipboard()
@@ -387,6 +396,10 @@ function supportsPromptCache(clientType: string | undefined): boolean {
   return !!clientType && PROMPT_CACHE_CLIENT_TYPES.has(clientType)
 }
 
+function isProviderOAuthClientType(clientType: string | undefined): boolean {
+  return clientType === 'openai-codex' || clientType === 'github-copilot'
+}
+
 const props = defineProps<{
   provider: ProviderWithAuth | undefined
   editLoading: boolean
@@ -406,7 +419,7 @@ const oauthStatusLoading = ref(false)
 const authorizeLoading = ref(false)
 const revokeLoading = ref(false)
 const devicePollTimer = ref<number | null>(null)
-const webPollTimer = ref<number | null>(null)
+const webOAuthFlow = ref<OAuthPopupFlowController | null>(null)
 const webOAuthPollIntervalMs = 2000
 const webOAuthPollTimeoutMs = 5 * 60 * 1000
 
@@ -488,7 +501,7 @@ watch(() => props.provider, (newVal) => {
 }, { immediate: true })
 
 watch(() => form.values.client_type, (clientType) => {
-  if (!['openai-codex', 'github-copilot'].includes(clientType)) {
+  if (!isProviderOAuthClientType(clientType)) {
     oauthStatus.value = null
   }
   if (clientType === 'openai-codex' && !form.values.base_url) {
@@ -570,10 +583,8 @@ function clearDevicePollTimer() {
 }
 
 function clearWebPollTimer() {
-  if (webPollTimer.value !== null) {
-    window.clearTimeout(webPollTimer.value)
-    webPollTimer.value = null
-  }
+  webOAuthFlow.value?.cancel()
+  webOAuthFlow.value = null
 }
 
 function clearPollTimers() {
@@ -639,22 +650,8 @@ onBeforeUnmount(() => {
   clearPollTimers()
 })
 
-function scheduleWebOAuthStatusPoll(startedAt: number, onAuthorized: () => Promise<void>) {
-  clearWebPollTimer()
-  webPollTimer.value = window.setTimeout(() => {
-    void (async () => {
-      const status = await fetchOAuthStatus()
-      if (status?.has_token && !status.expired) {
-        await onAuthorized()
-        return
-      }
-      if (Date.now() - startedAt >= webOAuthPollTimeoutMs) {
-        authorizeLoading.value = false
-        return
-      }
-      scheduleWebOAuthStatusPoll(startedAt, onAuthorized)
-    })()
-  }, webOAuthPollIntervalMs)
+function cancelWebOAuthAuthorization() {
+  webOAuthFlow.value?.cancel()
 }
 
 async function handleAuthorize() {
@@ -681,23 +678,30 @@ async function handleAuthorize() {
     }
     if (!result.auth_url) throw new Error(t('provider.oauth.authorizeFailed'))
     const popup = window.open(result.auth_url, 'provider-oauth', 'width=600,height=720')
-    let completed = false
-    const completeAuthorization = async () => {
-      if (completed) return
-      completed = true
-      clearWebPollTimer()
-      window.removeEventListener('message', listener)
-      popup?.close()
-      toast.success(t('provider.oauth.authorizeSuccess'))
-      await fetchOAuthStatus()
-      authorizeLoading.value = false
-    }
-    const listener = async (event: MessageEvent) => {
-      if (event.data?.type !== 'memoh-provider-oauth-success') return
-      await completeAuthorization()
-    }
-    window.addEventListener('message', listener)
-    scheduleWebOAuthStatusPoll(Date.now(), completeAuthorization)
+    if (!popup) throw new Error(t('provider.oauth.authorizeFailed'))
+    webOAuthFlow.value?.cancel()
+    webOAuthFlow.value = startOAuthPopupFlow<ProvidersOAuthStatus>({
+      popup,
+      target: window,
+      messageType: 'memoh-provider-oauth-success',
+      pollIntervalMs: webOAuthPollIntervalMs,
+      timeoutMs: webOAuthPollTimeoutMs,
+      pollStatus: fetchOAuthStatus,
+      isAuthorized: status => Boolean(status?.has_token && !status.expired),
+      onAuthorized: async () => {
+        webOAuthFlow.value = null
+        toast.success(t('provider.oauth.authorizeSuccess'))
+        await fetchOAuthStatus()
+        authorizeLoading.value = false
+      },
+      onAborted: (reason) => {
+        webOAuthFlow.value = null
+        authorizeLoading.value = false
+        if (reason === 'timeout') {
+          toast.error(t('provider.oauth.authorizeTimedOut'))
+        }
+      },
+    })
   } catch (error) {
     clearWebPollTimer()
     toast.error(error instanceof Error ? error.message : t('provider.oauth.authorizeFailed'))

--- a/apps/web/src/utils/oauth/popup-flow.test.ts
+++ b/apps/web/src/utils/oauth/popup-flow.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { startOAuthPopupFlow } from './popup-flow'
 
-function messageEvent(data: unknown): MessageEvent {
+function messageEvent(data: unknown, source?: MessageEventSource | null): MessageEvent {
   const event = new Event('message') as MessageEvent
   Object.defineProperty(event, 'data', { value: data })
+  if (source !== undefined) Object.defineProperty(event, 'source', { value: source })
   return event
 }
 
@@ -52,7 +53,7 @@ describe('startOAuthPopupFlow', () => {
     expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function))
   })
 
-  it('treats a closed popup as cancellation and stops polling', async () => {
+  it('polls once more before treating a closed popup as cancellation', async () => {
     const onAborted = vi.fn()
     const pollStatus = vi.fn(async () => null)
 
@@ -70,12 +71,41 @@ describe('startOAuthPopupFlow', () => {
     popup.closed = true
 
     await vi.advanceTimersByTimeAsync(1_000)
-    await vi.advanceTimersByTimeAsync(4_000)
 
+    // The callback page closes the popup right after posting success, so a closed
+    // popup must be confirmed via one final poll before concluding cancellation.
+    expect(pollStatus).toHaveBeenCalledTimes(1)
     expect(onAborted).toHaveBeenCalledWith('cancelled')
-    expect(pollStatus).not.toHaveBeenCalled()
     expect(closePopup).not.toHaveBeenCalled()
+
+    // ...and once cancelled it stops polling.
+    await vi.advanceTimersByTimeAsync(4_000)
+    expect(pollStatus).toHaveBeenCalledTimes(1)
     expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function))
+  })
+
+  it('completes authorization when a closed popup already stored a token', async () => {
+    const onAuthorized = vi.fn(async () => {})
+    const onAborted = vi.fn()
+    const pollStatus = vi.fn(async () => ({ has_token: true }))
+
+    startOAuthPopupFlow({
+      popup,
+      target,
+      messageType: 'memoh-oauth-success',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      pollStatus,
+      isAuthorized: status => Boolean(status?.has_token),
+      onAuthorized,
+      onAborted,
+    })
+    popup.closed = true
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(onAuthorized).toHaveBeenCalledTimes(1)
+    expect(onAborted).not.toHaveBeenCalled()
   })
 
   it('allows explicit cancellation before timeout', () => {
@@ -152,5 +182,85 @@ describe('startOAuthPopupFlow', () => {
     expect(onAborted).not.toHaveBeenCalled()
     expect(closePopup).toHaveBeenCalledTimes(1)
     expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function))
+  })
+
+  it('ignores success messages from an unexpected source', async () => {
+    const onAuthorized = vi.fn(async () => {})
+    const expectedSource = popup as unknown as MessageEventSource
+
+    startOAuthPopupFlow({
+      popup,
+      target,
+      expectedSource,
+      messageType: 'memoh-oauth-success',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      pollStatus: vi.fn(async () => null),
+      isAuthorized: () => false,
+      onAuthorized,
+      onAborted: vi.fn(),
+    })
+
+    target.dispatchEvent(messageEvent({ type: 'memoh-oauth-success' }, {} as MessageEventSource))
+    expect(onAuthorized).not.toHaveBeenCalled()
+
+    target.dispatchEvent(messageEvent({ type: 'memoh-oauth-success' }, expectedSource))
+    await vi.runAllTimersAsync()
+    expect(onAuthorized).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a failing status poll via onError and keeps polling', async () => {
+    const onError = vi.fn()
+    const onAuthorized = vi.fn(async () => {})
+    const pollStatus = vi.fn<() => Promise<{ has_token: boolean } | null>>()
+    pollStatus.mockRejectedValueOnce(new Error('poll failed'))
+    pollStatus.mockResolvedValue({ has_token: true })
+
+    startOAuthPopupFlow({
+      popup,
+      target,
+      messageType: 'memoh-oauth-success',
+      pollIntervalMs: 1_000,
+      timeoutMs: 60_000,
+      pollStatus,
+      isAuthorized: status => Boolean(status?.has_token),
+      onAuthorized,
+      onAborted: vi.fn(),
+      onError,
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onAuthorized).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(pollStatus).toHaveBeenCalledTimes(2)
+    expect(onAuthorized).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes onAuthorized failures to onError', async () => {
+    const onError = vi.fn()
+    const onAuthorized = vi.fn(async () => {
+      throw new Error('save failed')
+    })
+
+    startOAuthPopupFlow({
+      popup,
+      target,
+      messageType: 'memoh-oauth-success',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      pollStatus: vi.fn(async () => null),
+      isAuthorized: () => false,
+      onAuthorized,
+      onAborted: vi.fn(),
+      onError,
+    })
+
+    target.dispatchEvent(messageEvent({ type: 'memoh-oauth-success' }))
+    await vi.runAllTimersAsync()
+
+    expect(onAuthorized).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/utils/oauth/popup-flow.test.ts
+++ b/apps/web/src/utils/oauth/popup-flow.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startOAuthPopupFlow } from './popup-flow'
+
+function messageEvent(data: unknown): MessageEvent {
+  const event = new Event('message') as MessageEvent
+  Object.defineProperty(event, 'data', { value: data })
+  return event
+}
+
+describe('startOAuthPopupFlow', () => {
+  let target: EventTarget
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>
+  let popup: { closed: boolean, close: () => void }
+  let closePopup: ReturnType<typeof vi.fn<() => void>>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    target = new EventTarget()
+    removeEventListenerSpy = vi.spyOn(target, 'removeEventListener')
+    closePopup = vi.fn<() => void>(() => {
+      popup.closed = true
+    })
+    popup = { closed: false, close: closePopup }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('times out independently of a hanging status poll and cleans up the popup flow', async () => {
+    const onAuthorized = vi.fn()
+    const onAborted = vi.fn()
+
+    startOAuthPopupFlow({
+      popup,
+      target,
+      messageType: 'memoh-oauth-success',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      pollStatus: () => new Promise<null>(() => {}),
+      isAuthorized: () => false,
+      onAuthorized,
+      onAborted,
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(onAuthorized).not.toHaveBeenCalled()
+    expect(onAborted).toHaveBeenCalledWith('timeout')
+    expect(closePopup).toHaveBeenCalledTimes(1)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function))
+  })
+
+  it('treats a closed popup as cancellation and stops polling', async () => {
+    const onAborted = vi.fn()
+    const pollStatus = vi.fn(async () => null)
+
+    startOAuthPopupFlow({
+      popup,
+      target,
+      messageType: 'memoh-oauth-success',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      pollStatus,
+      isAuthorized: () => false,
+      onAuthorized: vi.fn(),
+      onAborted,
+    })
+    popup.closed = true
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.advanceTimersByTimeAsync(4_000)
+
+    expect(onAborted).toHaveBeenCalledWith('cancelled')
+    expect(pollStatus).not.toHaveBeenCalled()
+    expect(closePopup).not.toHaveBeenCalled()
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function))
+  })
+
+  it('allows explicit cancellation before timeout', () => {
+    const onAborted = vi.fn()
+
+    const flow = startOAuthPopupFlow({
+      popup,
+      target,
+      messageType: 'memoh-oauth-success',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      pollStatus: vi.fn(async () => null),
+      isAuthorized: () => false,
+      onAuthorized: vi.fn(),
+      onAborted,
+    })
+    flow.cancel()
+
+    expect(onAborted).toHaveBeenCalledWith('cancelled')
+    expect(closePopup).toHaveBeenCalledTimes(1)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function))
+  })
+
+  it('disposes silently and ignores a pending status poll', async () => {
+    const onAborted = vi.fn()
+    const pollStatus = vi.fn(() => new Promise<null>(resolve => setTimeout(() => resolve(null), 2_000)))
+
+    const flow = startOAuthPopupFlow({
+      popup,
+      target,
+      messageType: 'memoh-oauth-success',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      pollStatus,
+      isAuthorized: () => false,
+      onAuthorized: vi.fn(),
+      onAborted,
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    flow.dispose()
+    await vi.advanceTimersByTimeAsync(4_000)
+
+    expect(onAborted).not.toHaveBeenCalled()
+    expect(closePopup).not.toHaveBeenCalled()
+    expect(pollStatus).toHaveBeenCalledTimes(1)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function))
+  })
+
+  it('completes once when a matching success message arrives', async () => {
+    const onAuthorized = vi.fn(async () => {})
+    const onAborted = vi.fn()
+
+    startOAuthPopupFlow({
+      popup,
+      target,
+      messageType: 'memoh-oauth-success',
+      messageMatches: event => event.data?.providerId === 'provider-1',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      pollStatus: vi.fn(async () => null),
+      isAuthorized: () => false,
+      onAuthorized,
+      onAborted,
+    })
+
+    target.dispatchEvent(messageEvent({ type: 'other' }))
+    target.dispatchEvent(messageEvent({ type: 'memoh-oauth-success', providerId: 'provider-2' }))
+    target.dispatchEvent(messageEvent({ type: 'memoh-oauth-success', providerId: 'provider-1' }))
+    target.dispatchEvent(messageEvent({ type: 'memoh-oauth-success', providerId: 'provider-1' }))
+    await vi.runAllTimersAsync()
+
+    expect(onAuthorized).toHaveBeenCalledTimes(1)
+    expect(onAborted).not.toHaveBeenCalled()
+    expect(closePopup).toHaveBeenCalledTimes(1)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function))
+  })
+})

--- a/apps/web/src/utils/oauth/popup-flow.ts
+++ b/apps/web/src/utils/oauth/popup-flow.ts
@@ -1,0 +1,120 @@
+export type OAuthPopupFlowAbortReason = 'timeout' | 'cancelled'
+
+export interface OAuthPopupFlowController {
+  cancel: () => void
+  dispose: () => void
+}
+
+interface OAuthPopupLike {
+  readonly closed?: boolean
+  close?: () => void
+}
+
+interface OAuthPopupFlowOptions<TStatus> {
+  popup: OAuthPopupLike
+  target: Pick<EventTarget, 'addEventListener' | 'removeEventListener'>
+  messageType: string
+  messageMatches?: (event: MessageEvent) => boolean
+  pollIntervalMs: number
+  timeoutMs: number
+  pollStatus: () => Promise<TStatus | null>
+  isAuthorized: (status: TStatus | null) => boolean
+  onAuthorized: () => Promise<void> | void
+  onAborted?: (reason: OAuthPopupFlowAbortReason) => void
+  onError?: (error: unknown) => void
+}
+
+export function startOAuthPopupFlow<TStatus>(options: OAuthPopupFlowOptions<TStatus>): OAuthPopupFlowController {
+  let completed = false
+  let pollTimer: ReturnType<typeof globalThis.setTimeout> | null = null
+  let timeoutTimer: ReturnType<typeof globalThis.setTimeout> | null = null
+
+  const clearPollTimer = () => {
+    if (pollTimer === null) return
+    globalThis.clearTimeout(pollTimer)
+    pollTimer = null
+  }
+
+  const clearTimeoutTimer = () => {
+    if (timeoutTimer === null) return
+    globalThis.clearTimeout(timeoutTimer)
+    timeoutTimer = null
+  }
+
+  const closePopup = () => {
+    if (options.popup.closed) return
+    options.popup.close?.()
+  }
+
+  const cleanup = () => {
+    clearPollTimer()
+    clearTimeoutTimer()
+    options.target.removeEventListener('message', onMessage)
+  }
+
+  const finishAuthorized = () => {
+    if (completed) return
+    completed = true
+    cleanup()
+    closePopup()
+    void Promise.resolve(options.onAuthorized()).catch((error: unknown) => {
+      options.onError?.(error)
+    })
+  }
+
+  const finishAborted = (reason: OAuthPopupFlowAbortReason) => {
+    if (completed) return
+    completed = true
+    cleanup()
+    closePopup()
+    options.onAborted?.(reason)
+  }
+
+  const schedulePoll = () => {
+    if (completed) return
+    pollTimer = globalThis.setTimeout(() => {
+      pollTimer = null
+      if (completed) return
+      if (options.popup.closed) {
+        finishAborted('cancelled')
+        return
+      }
+      void options.pollStatus()
+        .then((status) => {
+          if (completed) return
+          if (options.isAuthorized(status)) {
+            finishAuthorized()
+            return
+          }
+          schedulePoll()
+        })
+        .catch((error: unknown) => {
+          if (completed) return
+          options.onError?.(error)
+          schedulePoll()
+        })
+    }, options.pollIntervalMs)
+  }
+
+  function onMessage(event: Event) {
+    const message = event as MessageEvent
+    if (message.data?.type !== options.messageType) return
+    if (options.messageMatches && !options.messageMatches(message)) return
+    finishAuthorized()
+  }
+
+  options.target.addEventListener('message', onMessage)
+  timeoutTimer = globalThis.setTimeout(() => {
+    finishAborted('timeout')
+  }, options.timeoutMs)
+  schedulePoll()
+
+  return {
+    cancel: () => finishAborted('cancelled'),
+    dispose: () => {
+      if (completed) return
+      completed = true
+      cleanup()
+    },
+  }
+}

--- a/apps/web/src/utils/oauth/popup-flow.ts
+++ b/apps/web/src/utils/oauth/popup-flow.ts
@@ -15,6 +15,12 @@ interface OAuthPopupFlowOptions<TStatus> {
   target: Pick<EventTarget, 'addEventListener' | 'removeEventListener'>
   messageType: string
   messageMatches?: (event: MessageEvent) => boolean
+  // When set, success messages must originate from this window (the popup we
+  // opened). Guards against unrelated tabs/scripts spoofing the success message.
+  expectedSource?: MessageEventSource | null
+  // Optional origin allow-check. Left unset by default because the OAuth callback
+  // page may be served from a different origin than the SPA (e.g. in dev).
+  originMatches?: (event: MessageEvent) => boolean
   pollIntervalMs: number
   timeoutMs: number
   pollStatus: () => Promise<TStatus | null>
@@ -75,10 +81,11 @@ export function startOAuthPopupFlow<TStatus>(options: OAuthPopupFlowOptions<TSta
     pollTimer = globalThis.setTimeout(() => {
       pollTimer = null
       if (completed) return
-      if (options.popup.closed) {
-        finishAborted('cancelled')
-        return
-      }
+      // The callback page posts its success message and immediately calls
+      // window.close(), so a closed popup does NOT necessarily mean the user
+      // cancelled — the token may already be stored. Poll one final time before
+      // concluding, and only abort as cancelled if it is still unauthorized.
+      const popupClosed = options.popup.closed === true
       void options.pollStatus()
         .then((status) => {
           if (completed) return
@@ -86,11 +93,19 @@ export function startOAuthPopupFlow<TStatus>(options: OAuthPopupFlowOptions<TSta
             finishAuthorized()
             return
           }
+          if (popupClosed) {
+            finishAborted('cancelled')
+            return
+          }
           schedulePoll()
         })
         .catch((error: unknown) => {
           if (completed) return
           options.onError?.(error)
+          if (popupClosed) {
+            finishAborted('cancelled')
+            return
+          }
           schedulePoll()
         })
     }, options.pollIntervalMs)
@@ -99,6 +114,8 @@ export function startOAuthPopupFlow<TStatus>(options: OAuthPopupFlowOptions<TSta
   function onMessage(event: Event) {
     const message = event as MessageEvent
     if (message.data?.type !== options.messageType) return
+    if (options.expectedSource !== undefined && message.source !== options.expectedSource) return
+    if (options.originMatches && !options.originMatches(message)) return
     if (options.messageMatches && !options.messageMatches(message)) return
     finishAuthorized()
   }

--- a/apps/web/src/utils/oauth/status-text.test.ts
+++ b/apps/web/src/utils/oauth/status-text.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { oauthStatusTextKey } from './status-text'
+
+describe('oauthStatusTextKey', () => {
+  it('keeps the text stable while authorization is pending', () => {
+    expect(oauthStatusTextKey({
+      loading: true,
+      authorizing: true,
+      status: { configured: true, has_token: false },
+      unavailableKey: 'unavailable',
+    })).toBe('provider.oauth.status.oauthing')
+
+    expect(oauthStatusTextKey({
+      loading: false,
+      authorizing: true,
+      status: { configured: true, has_token: false },
+      unavailableKey: 'unavailable',
+    })).toBe('provider.oauth.status.oauthing')
+  })
+
+  it('does not hide authorized or unavailable states behind pending text', () => {
+    expect(oauthStatusTextKey({
+      loading: true,
+      authorizing: true,
+      status: { configured: true, has_token: true },
+      unavailableKey: 'unavailable',
+    })).toBe('provider.oauth.status.authorized')
+
+    expect(oauthStatusTextKey({
+      loading: true,
+      authorizing: true,
+      status: { configured: false, has_token: false },
+      unavailableKey: 'unavailable',
+    })).toBe('unavailable')
+  })
+
+  it('keeps the existing idle status order outside authorization', () => {
+    expect(oauthStatusTextKey({
+      loading: true,
+      status: null,
+      unavailableKey: 'unavailable',
+    })).toBe('provider.oauth.status.checking')
+
+    expect(oauthStatusTextKey({
+      loading: false,
+      status: { configured: true, has_token: false },
+      unavailableKey: 'unavailable',
+    })).toBe('provider.oauth.status.missing')
+  })
+})

--- a/apps/web/src/utils/oauth/status-text.ts
+++ b/apps/web/src/utils/oauth/status-text.ts
@@ -1,0 +1,20 @@
+interface OAuthStatusTextStatus {
+  configured: boolean
+  has_token: boolean
+}
+
+interface OAuthStatusTextOptions {
+  loading: boolean
+  authorizing?: boolean
+  status: OAuthStatusTextStatus | null
+  unavailableKey: string
+}
+
+export function oauthStatusTextKey(options: OAuthStatusTextOptions): string {
+  if (options.status?.has_token) return 'provider.oauth.status.authorized'
+  if (options.status && !options.status.configured) return options.unavailableKey
+  if (options.authorizing) return 'provider.oauth.status.oauthing'
+  if (options.loading) return 'provider.oauth.status.checking'
+  if (!options.status?.configured) return options.unavailableKey
+  return 'provider.oauth.status.missing'
+}

--- a/apps/web/src/utils/oauth/status-text.ts
+++ b/apps/web/src/utils/oauth/status-text.ts
@@ -1,4 +1,4 @@
-interface OAuthStatusTextStatus {
+interface OAuthStatusSummary {
   configured: boolean
   has_token: boolean
 }
@@ -6,7 +6,7 @@ interface OAuthStatusTextStatus {
 interface OAuthStatusTextOptions {
   loading: boolean
   authorizing?: boolean
-  status: OAuthStatusTextStatus | null
+  status: OAuthStatusSummary | null
   unavailableKey: string
 }
 


### PR DESCRIPTION
Fixed GPT/Codex OAuth authorization had no timeout and no cancel on failure (popup closed, popup blocked, or hanging status poll) the UI spun forever.

Extracts a reusable `startOAuthPopupFlow` controller and wires it into both OAuth entry points, so every flow now terminates deterministically.

## Summary
- **New `utils/oauth/popup-flow.ts`** controller with an independent timeout timer (fires regardless of a hanging status poll), explicit `cancel()`, popup-closed detection, unmount-safe `dispose()`, and an idempotent `completed` guard against double-completion.
- **New `utils/oauth/status-text.ts`** shared OAuth status-text resolver (adds an `oauthing` in-progress state).
- **`settings-acp-card.vue`** (Codex / "GPT" ACP OAuth) and **`provider-form.vue`** (codex / github-copilot): use the controller, add a **Cancel** button, guard blocked popups (`if (!popup) throw`), 5-min timeout with a toast, and `onBeforeUnmount` cleanup.
- i18n: `provider.oauth.authorizeTimedOut` + `status.oauthing` (en + zh).
