### PR TITLE
feat(keyboard): unify app shortcut commands

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,6 +35,8 @@ import {
   writeCliPrefs,
   type CliStatus,
 } from './cli-integration'
+import { acceleratorForCommand, appKeyboardCommands } from '../shared/keyboard-commands'
+import { dispatchFocusedWindowCommand } from './window-commands'
 
 type DesktopRuntimeMode = 'local' | 'remote'
 
@@ -788,6 +790,22 @@ function dispatchSettingsNavigate(window: BrowserWindow, target: string): void {
   window.webContents.send('settings:navigate', target)
 }
 
+// Derive the native Close accelerator from the shared binding table. The
+// focused window decides whether the command closes an app tab or the window.
+function closeWindowMenuItem(): MenuItemConstructorOptions {
+  return {
+    label: 'Close',
+    accelerator: acceleratorForCommand(appKeyboardCommands.closeCurrentWorkspaceTab),
+    click: () => {
+      dispatchFocusedWindowCommand(
+        chatWindow,
+        BrowserWindow.getFocusedWindow(),
+        appKeyboardCommands.closeCurrentWorkspaceTab,
+      )
+    },
+  }
+}
+
 // CLI install / menu helpers — kept above the whenReady block so the
 // Promise chain can call them without forward-declaration noise.
 
@@ -913,7 +931,7 @@ async function rebuildAppMenu(): Promise<void> {
         label: 'Window',
         submenu: [
           { role: 'minimize' },
-          { role: 'close' },
+          closeWindowMenuItem(),
         ],
       },
     )
@@ -1016,7 +1034,7 @@ async function rebuildAppMenu(): Promise<void> {
       label: 'Window',
       submenu: [
         { role: 'minimize' },
-        { role: 'close' },
+        closeWindowMenuItem(),
       ],
     },
   )

--- a/apps/desktop/src/main/window-commands.test.ts
+++ b/apps/desktop/src/main/window-commands.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DESKTOP_KEYBOARD_COMMAND_CHANNEL, appKeyboardCommands } from '../shared/keyboard-commands'
+import { dispatchFocusedWindowCommand } from './window-commands'
+
+function createWindow(options: { loading?: boolean } = {}) {
+  return {
+    close: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    webContents: {
+      isLoading: vi.fn(() => options.loading ?? false),
+      send: vi.fn(),
+    },
+  }
+}
+
+describe('dispatchFocusedWindowCommand', () => {
+  it('dispatches keyboard commands to the chat renderer', () => {
+    const chatWindow = createWindow()
+
+    const handled = dispatchFocusedWindowCommand(
+      chatWindow,
+      chatWindow,
+      appKeyboardCommands.closeCurrentWorkspaceTab,
+    )
+
+    expect(handled).toBe(true)
+    expect(chatWindow.webContents.send).toHaveBeenCalledWith(
+      DESKTOP_KEYBOARD_COMMAND_CHANNEL,
+      appKeyboardCommands.closeCurrentWorkspaceTab,
+    )
+    expect(chatWindow.close).not.toHaveBeenCalled()
+  })
+
+  it('keeps the close-tab command mapped to native close for non-chat windows', () => {
+    const chatWindow = createWindow()
+    const settingsWindow = createWindow()
+
+    const handled = dispatchFocusedWindowCommand(
+      chatWindow,
+      settingsWindow,
+      appKeyboardCommands.closeCurrentWorkspaceTab,
+    )
+
+    expect(handled).toBe(true)
+    expect(settingsWindow.close).toHaveBeenCalledOnce()
+    expect(settingsWindow.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('falls back to native close when the chat renderer cannot receive commands yet', () => {
+    const chatWindow = createWindow({ loading: true })
+
+    const handled = dispatchFocusedWindowCommand(
+      chatWindow,
+      chatWindow,
+      appKeyboardCommands.closeCurrentWorkspaceTab,
+    )
+
+    expect(handled).toBe(true)
+    expect(chatWindow.close).toHaveBeenCalledOnce()
+    expect(chatWindow.webContents.send).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/window-commands.ts
+++ b/apps/desktop/src/main/window-commands.ts
@@ -1,0 +1,40 @@
+import {
+  DESKTOP_KEYBOARD_COMMAND_CHANNEL,
+  appKeyboardCommands,
+  type AppKeyboardCommand,
+} from '../shared/keyboard-commands'
+
+interface CommandWindow {
+  close(): void
+  isDestroyed(): boolean
+  webContents: {
+    isLoading?(): boolean
+    send(channel: string, command: AppKeyboardCommand): void
+  }
+}
+
+function canSendRendererCommand(window: CommandWindow): boolean {
+  return !window.webContents.isLoading?.()
+}
+
+export function dispatchFocusedWindowCommand(
+  chatWindow: CommandWindow | null,
+  focusedWindow: CommandWindow | null,
+  command: AppKeyboardCommand,
+): boolean {
+  if (!focusedWindow || focusedWindow.isDestroyed()) return false
+
+  if (chatWindow && !chatWindow.isDestroyed() && focusedWindow === chatWindow) {
+    if (canSendRendererCommand(focusedWindow)) {
+      focusedWindow.webContents.send(DESKTOP_KEYBOARD_COMMAND_CHANNEL, command)
+      return true
+    }
+  }
+
+  if (command === appKeyboardCommands.closeCurrentWorkspaceTab) {
+    focusedWindow.close()
+    return true
+  }
+
+  return false
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,10 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import {
+  DESKTOP_KEYBOARD_COMMAND_CHANNEL,
+  isAppKeyboardCommand,
+  type AppKeyboardCommand,
+} from '../shared/keyboard-commands'
 
 // Cross-window query-cache invalidation payload. Mirrors the subset of
 // Pinia Colada's `UseQueryEntryFilter` that survives structured-clone
@@ -87,6 +92,15 @@ const api = {
       ipcRenderer.on('chat:navigate', (_event: IpcRendererEvent, target: string) => {
         cb(target)
       })
+    },
+    onKeyboardCommand: (cb: (command: AppKeyboardCommand) => void): (() => void) => {
+      const listener = (_event: IpcRendererEvent, command: unknown) => {
+        if (isAppKeyboardCommand(command)) cb(command)
+      }
+      ipcRenderer.on(DESKTOP_KEYBOARD_COMMAND_CHANNEL, listener)
+      return () => {
+        ipcRenderer.removeListener(DESKTOP_KEYBOARD_COMMAND_CHANNEL, listener)
+      }
     },
   },
 }

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -9,6 +9,12 @@ import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 
 import i18n from '@memohai/web/i18n'
 import { setupApiClient } from '@memohai/web/api-client'
+import { appKeyboardCommands, createKeyboardCommandRegistry, type AppKeyboardCommand } from '@memohai/web/lib/keyboard-commands'
+import { connectBrowserKeyboardShortcuts } from '@memohai/web/lib/browser-keyboard-shortcuts'
+import { keyboardBindings, selectDesktopKeydownBindings } from '@memohai/web/lib/keyboard-bindings'
+import { KEYBOARD_REGISTRY } from '@memohai/web/composables/useKeyboardCommand'
+import { registerWorkspaceTabCommands } from '@memohai/web/pages/home/commands/workspace-tab-commands'
+import { useWorkspaceTabsStore } from '@memohai/web/store/workspace-tabs'
 
 import 'markstream-vue/index.css'
 import '@memohai/web/style.css'
@@ -19,6 +25,16 @@ import 'katex/dist/katex.min.css'
 import App from './chat/App.vue'
 import router from './chat/router'
 import { setupCrossWindowCacheSync } from './cross-window-cache-sync'
+
+// Window-management fallback, intentionally kept separate from the close-tab app
+// command. Cmd/Ctrl+W closes the active workspace tab; when the registry reports
+// no tab claimed the command, the same key closes the window. The
+// tab-close binding lives in the shared table; this window decision is an explicit
+// desktop product rule, not something derived from that binding.
+function closeWindowWhenNoTab(command: AppKeyboardCommand): void {
+  if (command !== appKeyboardCommands.closeCurrentWorkspaceTab) return
+  void window.api.window.closeSelf()
+}
 
 async function bootstrap() {
   const status = await window.api.desktop.getServerStatus()
@@ -36,11 +52,22 @@ async function bootstrap() {
     void router.push(target)
   })
 
+  const pinia = createPinia().use(piniaPluginPersistedstate)
+  const keyboardCommands = createKeyboardCommandRegistry()
+  registerWorkspaceTabCommands(keyboardCommands, useWorkspaceTabsStore(pinia))
+  // Menu-delivered commands arrive over IPC; closing the window when no tab
+  // remains is a distinct window-management concern (see closeWindowWhenNoTab).
+  keyboardCommands.connect(window.api.window, closeWindowWhenNoTab)
+  // keydown-delivered commands (e.g. save) share the exact web matcher; menu
+  // commands are excluded here so they never double-fire with the accelerator.
+  connectBrowserKeyboardShortcuts(keyboardCommands, selectDesktopKeydownBindings(keyboardBindings))
+
   const app = createApp(App)
-    .use(createPinia().use(piniaPluginPersistedstate))
+    .use(pinia)
     .use(PiniaColada)
     .use(router)
     .use(i18n)
+    .provide(KEYBOARD_REGISTRY, keyboardCommands)
 
   // Bridge query-cache invalidations between chat and settings windows.
   // Must run after `PiniaColada` is installed so the store is registered.

--- a/apps/desktop/src/renderer/types/web-stubs.d.ts
+++ b/apps/desktop/src/renderer/types/web-stubs.d.ts
@@ -1,11 +1,11 @@
 // Type stubs for @memohai/web subpath imports consumed by the renderer.
 // We route typechecking through these stubs (via tsconfig `paths`) so vue-tsc
-// does not recursively typecheck @memohai/web's source tree — @memohai/web
+// does not recursively typecheck @memohai/web's source tree. @memohai/web
 // owns its own types/CI. Vite ignores `paths` and resolves the real `exports`
 // entries at bundle time, so runtime behavior is unchanged.
 
 // Marker to make this file a module (not an ambient script). Required so
-// that paths-mapped dynamic `import('@memohai/web/...')` calls succeed —
+// that paths-mapped dynamic `import('@memohai/web/...')` calls succeed.
 // TS otherwise complains that the resolved file "is not a module".
 export {}
 
@@ -43,10 +43,114 @@ declare module '@memohai/web/api-client' {
   export function setupApiClient(options?: SetupApiClientOptions): void
 }
 
+declare module '@memohai/web/lib/keyboard-commands' {
+  export const appKeyboardCommands: {
+    readonly closeCurrentWorkspaceTab: 'close-current-workspace-tab'
+    readonly saveActiveFile: 'save-active-file'
+  }
+  export type AppKeyboardCommand =
+    typeof appKeyboardCommands[keyof typeof appKeyboardCommands]
+  export type KeyboardCommandHandler = () => boolean | void
+  export type UnhandledKeyboardCommandCallback = (command: AppKeyboardCommand) => void
+  export interface KeyboardCommandApi {
+    onKeyboardCommand(cb: (command: AppKeyboardCommand) => void): (() => void) | void
+  }
+  export interface KeyboardCommandRegistry {
+    register(command: AppKeyboardCommand, handler: KeyboardCommandHandler): () => void
+    dispatch(command: AppKeyboardCommand): boolean
+    connect(api: KeyboardCommandApi, onUnhandled?: UnhandledKeyboardCommandCallback): () => void
+  }
+  export function isAppKeyboardCommand(value: unknown): value is AppKeyboardCommand
+  export function createKeyboardCommandRegistry(): KeyboardCommandRegistry
+}
+
+declare module '@memohai/web/lib/keyboard-bindings' {
+  import type { AppKeyboardCommand } from '@memohai/web/lib/keyboard-commands'
+  export type DesktopDelivery = 'menu' | 'keydown'
+  export type BrowserBehavior = 'intercept' | 'passthrough'
+  export interface KeyboardBinding {
+    command: AppKeyboardCommand
+    key: string
+    mod?: boolean
+    alt?: boolean
+    shift?: boolean
+    desktop: DesktopDelivery
+    browser: BrowserBehavior
+  }
+  export const keyboardBindings: KeyboardBinding[]
+  export const RESERVED_BROWSER_COMBOS: Set<string>
+  export function toElectronAccelerator(binding: KeyboardBinding): string
+  export function acceleratorForCommand(command: AppKeyboardCommand): string | undefined
+  export function selectWebBindings(bindings: KeyboardBinding[]): KeyboardBinding[]
+  export function selectDesktopKeydownBindings(bindings: KeyboardBinding[]): KeyboardBinding[]
+}
+
+declare module '@memohai/web/lib/browser-keyboard-shortcuts' {
+  import type { AppKeyboardCommand, KeyboardCommandRegistry } from '@memohai/web/lib/keyboard-commands'
+  export interface BrowserKeyboardShortcutBinding {
+    command: AppKeyboardCommand
+    key: string
+    mod?: boolean
+    alt?: boolean
+    shift?: boolean
+  }
+  export function handleBrowserKeyboardShortcut(
+    event: {
+      key: string
+      metaKey: boolean
+      ctrlKey: boolean
+      altKey: boolean
+      shiftKey: boolean
+      preventDefault(): void
+    },
+    registry: Pick<KeyboardCommandRegistry, 'dispatch'>,
+    bindings: BrowserKeyboardShortcutBinding[],
+  ): boolean
+  export function connectBrowserKeyboardShortcuts(
+    registry: Pick<KeyboardCommandRegistry, 'dispatch'>,
+    bindings: BrowserKeyboardShortcutBinding[],
+    target?: unknown,
+  ): () => void
+}
+
+declare module '@memohai/web/composables/useKeyboardCommand' {
+  import type { InjectionKey } from 'vue'
+  import type {
+    AppKeyboardCommand,
+    KeyboardCommandHandler,
+    KeyboardCommandRegistry,
+  } from '@memohai/web/lib/keyboard-commands'
+  export const KEYBOARD_REGISTRY: InjectionKey<KeyboardCommandRegistry>
+  export function useKeyboardCommand(command: AppKeyboardCommand, handler: KeyboardCommandHandler): void
+}
+
+declare module '@memohai/web/pages/home/commands/workspace-tab-commands' {
+  import type { AppKeyboardCommand, KeyboardCommandRegistry } from '@memohai/web/lib/keyboard-commands'
+  export interface WorkspaceTabCommandStore {
+    activeId: string | null
+    closeTab(id: string): void
+  }
+  export function handleWorkspaceKeyboardCommand(
+    command: AppKeyboardCommand,
+    store: WorkspaceTabCommandStore,
+  ): boolean
+  export function registerWorkspaceTabCommands(
+    registry: Pick<KeyboardCommandRegistry, 'register'>,
+    store: WorkspaceTabCommandStore,
+  ): () => void
+}
+
 declare module '@memohai/web/store/settings' {
-  // We don't need the concrete Pinia store type here — desktop just calls the
+  // We don't need the concrete Pinia store type here. Desktop just calls the
   // composable for its registration side-effect.
   export function useSettingsStore(): unknown
+}
+
+declare module '@memohai/web/store/workspace-tabs' {
+  export function useWorkspaceTabsStore(pinia?: unknown): {
+    activeId: string | null
+    closeTab: (id: string) => void
+  }
 }
 
 declare module '@memohai/web/store/user' {

--- a/apps/desktop/src/shared/keyboard-commands.test.ts
+++ b/apps/desktop/src/shared/keyboard-commands.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DESKTOP_KEYBOARD_COMMAND_CHANNEL,
+  appKeyboardCommands,
+  isAppKeyboardCommand,
+} from './keyboard-commands'
+
+describe('desktop keyboard command transport', () => {
+  it('defines a stable desktop IPC channel and reuses app command validation', () => {
+    expect(DESKTOP_KEYBOARD_COMMAND_CHANNEL).toBe('desktop:keyboard-command')
+    expect(isAppKeyboardCommand(appKeyboardCommands.closeCurrentWorkspaceTab)).toBe(true)
+    expect(isAppKeyboardCommand('workspace-tab:close-current')).toBe(false)
+    expect(isAppKeyboardCommand(null)).toBe(false)
+  })
+})

--- a/apps/desktop/src/shared/keyboard-commands.ts
+++ b/apps/desktop/src/shared/keyboard-commands.ts
@@ -1,0 +1,11 @@
+import {
+  appKeyboardCommands,
+  isAppKeyboardCommand,
+  type AppKeyboardCommand,
+} from '../../../web/src/lib/keyboard-commands'
+import { acceleratorForCommand } from '../../../web/src/lib/keyboard-bindings'
+
+export const DESKTOP_KEYBOARD_COMMAND_CHANNEL = 'desktop:keyboard-command'
+
+export { appKeyboardCommands, isAppKeyboardCommand, acceleratorForCommand }
+export type { AppKeyboardCommand }

--- a/apps/web/src/components/file-manager/file-save-command.test.ts
+++ b/apps/web/src/components/file-manager/file-save-command.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { isFileSaveEligible } from './file-save-command'
+
+const editableDirty = { readonly: false, isText: true, isDirty: true, saving: false }
+
+describe('isFileSaveEligible', () => {
+  it('is eligible for an editable, dirty text file that is not currently saving', () => {
+    expect(isFileSaveEligible(editableDirty)).toBe(true)
+  })
+
+  it('is not eligible when the file is readonly', () => {
+    expect(isFileSaveEligible({ ...editableDirty, readonly: true })).toBe(false)
+  })
+
+  it('is not eligible for non-text files', () => {
+    expect(isFileSaveEligible({ ...editableDirty, isText: false })).toBe(false)
+  })
+
+  it('is not eligible when there are no unsaved changes', () => {
+    expect(isFileSaveEligible({ ...editableDirty, isDirty: false })).toBe(false)
+  })
+
+  it('is not eligible while a save is already in flight', () => {
+    expect(isFileSaveEligible({ ...editableDirty, saving: true })).toBe(false)
+  })
+})

--- a/apps/web/src/components/file-manager/file-save-command.ts
+++ b/apps/web/src/components/file-manager/file-save-command.ts
@@ -1,0 +1,16 @@
+export interface FileSaveState {
+  readonly: boolean
+  isText: boolean
+  isDirty: boolean
+  saving: boolean
+}
+
+/**
+ * Whether the file viewer should claim the save-active-file command. When it
+ * returns false the command falls through. In the browser that means the native
+ * "save page" behavior is left intact, matching the viewer's pre-unification
+ * behavior of only intercepting Cmd/Ctrl+S for editable, dirty text files.
+ */
+export function isFileSaveEligible(state: FileSaveState): boolean {
+  return !state.readonly && state.isText && state.isDirty && !state.saving
+}

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { ref, watch, computed, onMounted, onBeforeUnmount, defineAsyncComponent, h } from 'vue'
+import { ref, watch, computed, onBeforeUnmount, defineAsyncComponent, h } from 'vue'
+import { appKeyboardCommands } from '@/lib/keyboard-commands'
+import { useKeyboardCommand } from '@/composables/useKeyboardCommand'
+import { isFileSaveEligible } from './file-save-command'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { File, Download, Save } from 'lucide-vue-next'
@@ -177,21 +180,24 @@ watch(fsChangedAt, () => {
   }
 })
 
-function handleKeydown(e: KeyboardEvent) {
-  const isSave = (e.metaKey || e.ctrlKey) && (e.key === 's' || e.key === 'S')
-  if (!isSave) return
-  if (props.readonly) return
-  if (!isText.value || !isDirty.value || saving.value) return
-  e.preventDefault()
+// Save on Cmd/Ctrl+S via the shared keyboard layer. The handler is scoped to this
+// component's lifetime: it returns true only for an editable, dirty text file, so
+// the browser keeps its native save behavior in every other state. The
+// cross-platform mod key is handled by the binding table.
+useKeyboardCommand(appKeyboardCommands.saveActiveFile, () => {
+  if (!isFileSaveEligible({
+    readonly: props.readonly ?? false,
+    isText: isText.value,
+    isDirty: isDirty.value,
+    saving: saving.value,
+  })) {
+    return false
+  }
   void handleSave()
-}
-
-onMounted(() => {
-  window.addEventListener('keydown', handleKeydown)
+  return true
 })
 
 onBeforeUnmount(() => {
-  window.removeEventListener('keydown', handleKeydown)
   cleanupImageUrl()
 })
 </script>

--- a/apps/web/src/composables/useKeyboardCommand.test.ts
+++ b/apps/web/src/composables/useKeyboardCommand.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, effectScope, type App } from 'vue'
+import { appKeyboardCommands, createKeyboardCommandRegistry, type KeyboardCommandRegistry } from '@/lib/keyboard-commands'
+import { KEYBOARD_REGISTRY, useKeyboardCommand } from './useKeyboardCommand'
+
+// Run a composable inside both an app injection context and an effect scope, the
+// same two contexts a component setup provides, so inject() and onScopeDispose()
+// both work. Returns the scope so the test can dispose it (simulating unmount).
+function runInScope(fn: () => void, registry?: KeyboardCommandRegistry) {
+  const app: App = createApp({})
+  if (registry) app.provide(KEYBOARD_REGISTRY, registry)
+  const scope = effectScope()
+  app.runWithContext(() => {
+    scope.run(() => fn())
+  })
+  return scope
+}
+
+describe('useKeyboardCommand', () => {
+  it('registers the handler so the command dispatches while mounted', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+
+    runInScope(() => useKeyboardCommand(appKeyboardCommands.saveActiveFile, handler), registry)
+
+    expect(registry.dispatch(appKeyboardCommands.saveActiveFile)).toBe(true)
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('unregisters the handler when the scope is disposed (unmount)', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+
+    const scope = runInScope(() => useKeyboardCommand(appKeyboardCommands.saveActiveFile, handler), registry)
+    scope.stop()
+
+    expect(registry.dispatch(appKeyboardCommands.saveActiveFile)).toBe(false)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when no registry has been provided', () => {
+    const handler = vi.fn(() => true)
+    expect(() =>
+      runInScope(() => useKeyboardCommand(appKeyboardCommands.saveActiveFile, handler)),
+    ).not.toThrow()
+  })
+})

--- a/apps/web/src/composables/useKeyboardCommand.ts
+++ b/apps/web/src/composables/useKeyboardCommand.ts
@@ -1,0 +1,50 @@
+import {
+  getCurrentInstance,
+  inject,
+  onActivated,
+  onDeactivated,
+  onScopeDispose,
+  type InjectionKey,
+} from 'vue'
+import {
+  createScopedKeyboardBinding,
+  type AppKeyboardCommand,
+  type KeyboardCommandHandler,
+  type KeyboardCommandRegistry,
+} from '@/lib/keyboard-commands'
+
+/** Provided once at app bootstrap so any component can register scoped shortcuts. */
+export const KEYBOARD_REGISTRY: InjectionKey<KeyboardCommandRegistry> = Symbol('keyboard-registry')
+
+/**
+ * Register a keyboard command handler that is live only while the calling
+ * component is mounted AND active. A handler that returns `false` declines the
+ * command, letting it fall through (in the browser, to native behavior).
+ *
+ * KeepAlive matters here: a cached-but-deactivated component stays *mounted*, so
+ * relying on unmount alone would leave its handler claiming the command from
+ * other tabs. We bind on setup, rebind on `onActivated`, and unbind on both
+   * `onDeactivated` and scope disposal, so an inactive file viewer can't swallow
+ * Cmd/Ctrl+S meant for whatever tab is actually focused.
+ *
+ * No-ops when no registry is provided, so components stay safe to mount in
+ * isolation (tests, storybook, non-app contexts).
+ */
+export function useKeyboardCommand(
+  command: AppKeyboardCommand,
+  handler: KeyboardCommandHandler,
+): void {
+  const registry = inject(KEYBOARD_REGISTRY, null)
+  if (!registry) return
+
+  const binding = createScopedKeyboardBinding(registry, command, handler)
+  binding.bind()
+  onScopeDispose(binding.unbind)
+
+  // Activate/deactivate only fire for components inside <KeepAlive>; guard on an
+  // instance so the composable stays usable (and warning-free) outside one.
+  if (getCurrentInstance()) {
+    onActivated(binding.bind)
+    onDeactivated(binding.unbind)
+  }
+}

--- a/apps/web/src/lib/browser-keyboard-shortcuts.test.ts
+++ b/apps/web/src/lib/browser-keyboard-shortcuts.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest'
+import { appKeyboardCommands, type KeyboardCommandRegistry } from './keyboard-commands'
+import { handleBrowserKeyboardShortcut, type BrowserKeyboardShortcutBinding } from './browser-keyboard-shortcuts'
+
+function createKeyboardEventLike(options: {
+  key: string
+  metaKey?: boolean
+  ctrlKey?: boolean
+  altKey?: boolean
+  shiftKey?: boolean
+}) {
+  return {
+    key: options.key,
+    metaKey: options.metaKey ?? false,
+    ctrlKey: options.ctrlKey ?? false,
+    altKey: options.altKey ?? false,
+    shiftKey: options.shiftKey ?? false,
+    preventDefault: vi.fn(),
+  }
+}
+
+function createRegistry(handled = true): Pick<KeyboardCommandRegistry, 'dispatch'> {
+  return {
+    dispatch: vi.fn(() => handled),
+  }
+}
+
+const saveBinding: BrowserKeyboardShortcutBinding = {
+  command: appKeyboardCommands.saveActiveFile,
+  key: 's',
+  mod: true,
+}
+
+describe('browser keyboard shortcuts matcher', () => {
+  it('matches a mod binding via Cmd on macOS', () => {
+    const registry = createRegistry(true)
+    const event = createKeyboardEventLike({ key: 's', metaKey: true })
+
+    expect(handleBrowserKeyboardShortcut(event, registry, [saveBinding], 'mac')).toBe(true)
+    expect(registry.dispatch).toHaveBeenCalledWith(appKeyboardCommands.saveActiveFile)
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('matches a mod binding via Ctrl on Windows/Linux', () => {
+    const registry = createRegistry(true)
+    const winEvent = createKeyboardEventLike({ key: 's', ctrlKey: true })
+    const linuxEvent = createKeyboardEventLike({ key: 's', ctrlKey: true })
+
+    expect(handleBrowserKeyboardShortcut(winEvent, registry, [saveBinding], 'win')).toBe(true)
+    expect(handleBrowserKeyboardShortcut(linuxEvent, registry, [saveBinding], 'linux')).toBe(true)
+  })
+
+  it('on macOS, Ctrl does NOT satisfy a mod binding (mod is Cmd, not "meta or ctrl")', () => {
+    const registry = createRegistry()
+    const event = createKeyboardEventLike({ key: 's', ctrlKey: true })
+
+    expect(handleBrowserKeyboardShortcut(event, registry, [saveBinding], 'mac')).toBe(false)
+    expect(registry.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('on Windows/Linux, Meta does NOT satisfy a mod binding', () => {
+    const registry = createRegistry()
+    const event = createKeyboardEventLike({ key: 's', metaKey: true })
+
+    expect(handleBrowserKeyboardShortcut(event, registry, [saveBinding], 'linux')).toBe(false)
+    expect(registry.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('requires the opposite platform key absent (Cmd+Ctrl+S is not Cmd+S)', () => {
+    const registry = createRegistry()
+    const event = createKeyboardEventLike({ key: 's', metaKey: true, ctrlKey: true })
+
+    expect(handleBrowserKeyboardShortcut(event, registry, [saveBinding], 'mac')).toBe(false)
+    expect(registry.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('leaves browser defaults alone when the matched command is unhandled', () => {
+    const registry = createRegistry(false)
+    const event = createKeyboardEventLike({ key: 's', metaKey: true })
+
+    expect(handleBrowserKeyboardShortcut(event, registry, [saveBinding], 'mac')).toBe(false)
+    expect(registry.dispatch).toHaveBeenCalledWith(appKeyboardCommands.saveActiveFile)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when given no bindings (passthrough exclusion happens at selection)', () => {
+    const registry = createRegistry()
+    const event = createKeyboardEventLike({ key: 'w', metaKey: true })
+
+    expect(handleBrowserKeyboardShortcut(event, registry, [], 'mac')).toBe(false)
+    expect(registry.dispatch).not.toHaveBeenCalled()
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('has no internal reserved-key list: a mod+w binding passed in is dispatched', () => {
+    const registry = createRegistry(true)
+    const event = createKeyboardEventLike({ key: 'w', metaKey: true })
+
+    expect(handleBrowserKeyboardShortcut(event, registry, [{
+      command: appKeyboardCommands.closeCurrentWorkspaceTab,
+      key: 'w',
+      mod: true,
+    }], 'mac')).toBe(true)
+    expect(registry.dispatch).toHaveBeenCalledWith(appKeyboardCommands.closeCurrentWorkspaceTab)
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+  })
+
+  it('does not match when a required modifier is absent', () => {
+    const registry = createRegistry()
+    const event = createKeyboardEventLike({ key: 's' })
+
+    expect(handleBrowserKeyboardShortcut(event, registry, [saveBinding], 'mac')).toBe(false)
+    expect(registry.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('matches the per-platform key override for the active platform', () => {
+    const registry = createRegistry(true)
+    const binding: BrowserKeyboardShortcutBinding = {
+      command: appKeyboardCommands.closeCurrentWorkspaceTab,
+      key: 'w',
+      win: 'F4',
+      mod: true,
+    }
+    const f4 = createKeyboardEventLike({ key: 'F4', ctrlKey: true })
+    const w = createKeyboardEventLike({ key: 'w', ctrlKey: true })
+
+    expect(handleBrowserKeyboardShortcut(f4, registry, [binding], 'win')).toBe(true)
+    // On Windows the base 'w' no longer matches because the override took effect.
+    expect(handleBrowserKeyboardShortcut(w, createRegistry(), [binding], 'win')).toBe(false)
+  })
+})

--- a/apps/web/src/lib/browser-keyboard-shortcuts.ts
+++ b/apps/web/src/lib/browser-keyboard-shortcuts.ts
@@ -1,0 +1,96 @@
+import type { AppKeyboardCommand, KeyboardCommandRegistry } from './keyboard-commands'
+import { detectPlatform, resolveBindingKey, type KeyboardPlatform } from './keyboard-bindings'
+
+export interface BrowserKeyboardShortcutEvent {
+  key: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  preventDefault(): void
+}
+
+/** Matching-relevant subset of a KeyboardBinding. */
+export interface BrowserKeyboardShortcutBinding {
+  command: AppKeyboardCommand
+  key: string
+  mac?: string
+  win?: string
+  linux?: string
+  mod?: boolean
+  alt?: boolean
+  shift?: boolean
+}
+
+interface BrowserKeyboardShortcutTarget {
+  addEventListener(type: 'keydown', listener: (event: KeyboardEvent) => void): void
+  removeEventListener(type: 'keydown', listener: (event: KeyboardEvent) => void): void
+}
+
+function normalizeKey(key: string): string {
+  return key.length === 1 ? key.toLowerCase() : key
+}
+
+function modifierMatches(actual: boolean, expected = false): boolean {
+  return actual === expected
+}
+
+// `mod` is the platform command key: Command on macOS, Ctrl on Windows/Linux.
+// It is not "meta or ctrl". On macOS Ctrl must be absent for a mod binding
+// and vice versa, so Cmd+Ctrl+S does not satisfy a Cmd+S binding.
+function modMatches(event: BrowserKeyboardShortcutEvent, wantsMod: boolean | undefined, isMac: boolean): boolean {
+  if (!wantsMod) return !event.metaKey && !event.ctrlKey
+  return isMac
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey
+}
+
+function bindingMatchesEvent(
+  binding: BrowserKeyboardShortcutBinding,
+  event: BrowserKeyboardShortcutEvent,
+  platform: KeyboardPlatform,
+): boolean {
+  return normalizeKey(event.key) === normalizeKey(resolveBindingKey(binding, platform))
+    && modMatches(event, binding.mod, platform === 'mac')
+    && modifierMatches(event.altKey, binding.alt)
+    && modifierMatches(event.shiftKey, binding.shift)
+}
+
+/**
+ * Match a keydown against the given bindings and dispatch the first hit. The
+   * matcher acts on exactly the bindings it is handed. Deciding which combos are
+ * browser-owned (passthrough) is the caller's job, done via selectWebBindings.
+ * preventDefault is only called when a handler actually claimed the command, so
+ * unhandled keys fall through to the browser/OS.
+ */
+export function handleBrowserKeyboardShortcut(
+  event: BrowserKeyboardShortcutEvent,
+  registry: Pick<KeyboardCommandRegistry, 'dispatch'>,
+  bindings: BrowserKeyboardShortcutBinding[],
+  platform: KeyboardPlatform = detectPlatform(),
+): boolean {
+  for (const binding of bindings) {
+    if (!bindingMatchesEvent(binding, event, platform)) continue
+    const handled = registry.dispatch(binding.command)
+    if (!handled) return false
+    event.preventDefault()
+    return true
+  }
+  return false
+}
+
+export function connectBrowserKeyboardShortcuts(
+  registry: Pick<KeyboardCommandRegistry, 'dispatch'>,
+  bindings: BrowserKeyboardShortcutBinding[],
+  target: BrowserKeyboardShortcutTarget | undefined = typeof window === 'undefined' ? undefined : window,
+): () => void {
+  if (!target || bindings.length === 0) return () => {}
+  const platform = detectPlatform()
+  const listener = (event: KeyboardEvent) => {
+    handleBrowserKeyboardShortcut(event, registry, bindings, platform)
+  }
+  target.addEventListener('keydown', listener)
+  return () => {
+    target.removeEventListener('keydown', listener)
+  }
+}

--- a/apps/web/src/lib/keyboard-bindings.test.ts
+++ b/apps/web/src/lib/keyboard-bindings.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { appKeyboardCommands } from './keyboard-commands'
+import {
+  keyboardBindings,
+  toElectronAccelerator,
+  acceleratorForCommand,
+  selectWebBindings,
+  selectDesktopKeydownBindings,
+  resolveBindingKey,
+  detectPlatform,
+  RESERVED_BROWSER_COMBOS,
+  type KeyboardBinding,
+} from './keyboard-bindings'
+
+describe('keyboard bindings table', () => {
+  it('declares the close-tab and save bindings as the single source of truth', () => {
+    const close = keyboardBindings.find(b => b.command === appKeyboardCommands.closeCurrentWorkspaceTab)
+    const save = keyboardBindings.find(b => b.command === appKeyboardCommands.saveActiveFile)
+
+    expect(close).toMatchObject({ key: 'w', mod: true, desktop: 'menu', browser: 'passthrough' })
+    expect(save).toMatchObject({ key: 's', mod: true, desktop: 'keydown', browser: 'intercept' })
+  })
+})
+
+describe('toElectronAccelerator', () => {
+  it('maps mod to CmdOrCtrl so one string aligns across platforms', () => {
+    expect(toElectronAccelerator({ command: appKeyboardCommands.closeCurrentWorkspaceTab, key: 'w', mod: true, desktop: 'menu', browser: 'passthrough' })).toBe('CmdOrCtrl+W')
+  })
+
+  it('orders modifiers CmdOrCtrl, Alt, Shift and uppercases single-char keys', () => {
+    const binding: KeyboardBinding = { command: appKeyboardCommands.saveActiveFile, key: 'k', mod: true, alt: true, shift: true, desktop: 'keydown', browser: 'intercept' }
+    expect(toElectronAccelerator(binding)).toBe('CmdOrCtrl+Alt+Shift+K')
+  })
+})
+
+describe('acceleratorForCommand', () => {
+  it('returns the derived accelerator for a known command', () => {
+    expect(acceleratorForCommand(appKeyboardCommands.closeCurrentWorkspaceTab)).toBe('CmdOrCtrl+W')
+  })
+
+  it('returns undefined for a command without a binding', () => {
+    expect(acceleratorForCommand('no-such-command' as never)).toBeUndefined()
+  })
+})
+
+describe('selectWebBindings', () => {
+  it('keeps intercept bindings and drops passthrough ones (browser keeps native behavior)', () => {
+    const commands = selectWebBindings(keyboardBindings).map(b => b.command)
+    expect(commands).toContain(appKeyboardCommands.saveActiveFile)
+    expect(commands).not.toContain(appKeyboardCommands.closeCurrentWorkspaceTab)
+  })
+})
+
+describe('selectDesktopKeydownBindings', () => {
+  it('keeps keydown bindings and drops menu ones (avoids double-firing with menu accelerators)', () => {
+    const commands = selectDesktopKeydownBindings(keyboardBindings).map(b => b.command)
+    expect(commands).toContain(appKeyboardCommands.saveActiveFile)
+    expect(commands).not.toContain(appKeyboardCommands.closeCurrentWorkspaceTab)
+  })
+})
+
+describe('resolveBindingKey', () => {
+  const base = { command: appKeyboardCommands.saveActiveFile, key: 's' }
+
+  it('returns the base key when no per-platform override is declared', () => {
+    expect(resolveBindingKey(base, 'mac')).toBe('s')
+    expect(resolveBindingKey(base, 'win')).toBe('s')
+    expect(resolveBindingKey(base, 'linux')).toBe('s')
+  })
+
+  it('returns the platform-specific override when declared', () => {
+    const binding = { key: 'w', mac: 'w', win: 'F4', linux: 'w' }
+    expect(resolveBindingKey(binding, 'mac')).toBe('w')
+    expect(resolveBindingKey(binding, 'win')).toBe('F4')
+    expect(resolveBindingKey(binding, 'linux')).toBe('w')
+  })
+
+  it('falls back to the base key when only some platforms are overridden', () => {
+    const binding = { key: 'k', win: 'j' }
+    expect(resolveBindingKey(binding, 'mac')).toBe('k')
+    expect(resolveBindingKey(binding, 'win')).toBe('j')
+  })
+})
+
+describe('detectPlatform', () => {
+  it('detects mac, windows and linux from a navigator-like object', () => {
+    expect(detectPlatform({ platform: 'MacIntel' })).toBe('mac')
+    expect(detectPlatform({ platform: 'Win32' })).toBe('win')
+    expect(detectPlatform({ platform: 'Linux x86_64' })).toBe('linux')
+  })
+
+  it('falls back to userAgent when platform is unavailable', () => {
+    expect(detectPlatform({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X)' })).toBe('mac')
+    expect(detectPlatform({ userAgent: 'Mozilla/5.0 (Windows NT 10.0)' })).toBe('win')
+  })
+
+  it('defaults to linux for unknown environments', () => {
+    expect(detectPlatform({})).toBe('linux')
+    expect(detectPlatform(undefined)).toBe('linux')
+  })
+})
+
+describe('menu bindings do not use per-platform key overrides', () => {
+  // toElectronAccelerator emits CmdOrCtrl+<base key>; Electron maps the mod per
+  // platform natively. A menu binding with divergent per-platform keys would not
+  // be reflected in that single accelerator, so it is disallowed (flagged here
+  // rather than silently producing a wrong menu accelerator).
+  it('every desktop:menu binding leaves mac/win/linux keys unset', () => {
+    const offenders = keyboardBindings.filter(
+      b => b.desktop === 'menu' && (b.mac !== undefined || b.win !== undefined || b.linux !== undefined),
+    )
+    expect(offenders).toEqual([])
+  })
+})
+
+describe('reserved browser combos invariant', () => {
+  it('never marks an OS/browser-reserved combo as browser:intercept', () => {
+    const offenders = keyboardBindings.filter(
+      b => b.mod === true && b.browser === 'intercept' && RESERVED_BROWSER_COMBOS.has(b.key.toLowerCase()),
+    )
+    expect(offenders).toEqual([])
+  })
+})

--- a/apps/web/src/lib/keyboard-bindings.ts
+++ b/apps/web/src/lib/keyboard-bindings.ts
@@ -1,0 +1,122 @@
+import { appKeyboardCommands, type AppKeyboardCommand } from './keyboard-commands'
+
+/**
+ * Where a binding is delivered inside the Electron desktop app:
+ * - `menu`    - owned by a native menu item with an accelerator (routed via IPC).
+ *               Excluded from the renderer keydown listener to avoid double-firing.
+ * - `keydown` - handled by the shared renderer keydown listener, exactly like web.
+ */
+export type DesktopDelivery = 'menu' | 'keydown'
+
+/**
+ * How a binding behaves in a plain browser:
+ * - `intercept`   - we match it, dispatch the command, and call preventDefault.
+ * - `passthrough` - we never touch it; the browser/OS keeps its native behavior
+ *                   (e.g. Cmd/Ctrl+W closes the browser tab).
+ */
+export type BrowserBehavior = 'intercept' | 'passthrough'
+
+export type KeyboardPlatform = 'mac' | 'win' | 'linux'
+
+export interface KeyboardBinding {
+  command: AppKeyboardCommand
+  /**
+   * Default key. `mod`-based bindings that use the same key on every platform
+   * only need this. Use per-platform overrides only when a shortcut genuinely
+   * diverges.
+   */
+  key: string
+  mac?: string
+  win?: string
+  linux?: string
+  /** Command on macOS, Ctrl on Windows/Linux. Resolved per platform, not "meta or ctrl". */
+  mod?: boolean
+  alt?: boolean
+  shift?: boolean
+  desktop: DesktopDelivery
+  browser: BrowserBehavior
+}
+
+/**
+ * Single source of truth. Adding a shortcut is one row here; the Electron menu,
+ * the Electron renderer keydown listener, and the web keydown listener all derive
+ * their behavior from this table.
+ */
+export const keyboardBindings: KeyboardBinding[] = [
+  {
+    command: appKeyboardCommands.closeCurrentWorkspaceTab,
+    key: 'w',
+    mod: true,
+    desktop: 'menu',
+    browser: 'passthrough',
+  },
+  {
+    command: appKeyboardCommands.saveActiveFile,
+    key: 's',
+    mod: true,
+    desktop: 'keydown',
+    browser: 'intercept',
+  },
+]
+
+/**
+ * Combos that the OS / browser owns when pressed with the platform mod key. A
+ * binding must never claim `browser: 'intercept'` on one of these. Browsers do
+ * not reliably let JS preventDefault them. Enforced by test, not at runtime, so
+ * the invariant is visible at authoring time.
+ */
+export const RESERVED_BROWSER_COMBOS = new Set<string>(['w', 'q', 't', 'n'])
+
+/** The effective key for a platform: a per-platform override, else the base key. */
+export function resolveBindingKey(
+  binding: { key: string; mac?: string; win?: string; linux?: string },
+  platform: KeyboardPlatform,
+): string {
+  return binding[platform] ?? binding.key
+}
+
+/**
+ * Best-effort platform detection for the keydown listener. Accepts a
+ * navigator-like object for testability; defaults to the global navigator.
+ * Only the mac vs non-mac distinction affects `mod`; win vs linux matters only
+ * for bindings that declare divergent per-platform keys.
+ */
+export function detectPlatform(
+  navigatorLike: { platform?: string; userAgent?: string } | undefined =
+    typeof navigator === 'undefined' ? undefined : navigator,
+): KeyboardPlatform {
+  const haystack = `${navigatorLike?.platform ?? ''} ${navigatorLike?.userAgent ?? ''}`
+  if (/mac/i.test(haystack)) return 'mac'
+  if (/win/i.test(haystack)) return 'win'
+  return 'linux'
+}
+
+function normalizeAcceleratorKey(key: string): string {
+  return key.length === 1 ? key.toUpperCase() : key
+}
+
+/** Derive an Electron accelerator string, e.g. `{ key: 'w', mod: true }` becomes `CmdOrCtrl+W`. */
+export function toElectronAccelerator(binding: KeyboardBinding): string {
+  const parts: string[] = []
+  if (binding.mod) parts.push('CmdOrCtrl')
+  if (binding.alt) parts.push('Alt')
+  if (binding.shift) parts.push('Shift')
+  parts.push(normalizeAcceleratorKey(binding.key))
+  return parts.join('+')
+}
+
+/** Accelerator for a command, or undefined if no binding declares it. */
+export function acceleratorForCommand(command: AppKeyboardCommand): string | undefined {
+  const binding = keyboardBindings.find(b => b.command === command)
+  return binding ? toElectronAccelerator(binding) : undefined
+}
+
+/** Bindings the web keydown listener should act on (browser-owned combos excluded). */
+export function selectWebBindings(bindings: KeyboardBinding[]): KeyboardBinding[] {
+  return bindings.filter(b => b.browser === 'intercept')
+}
+
+/** Bindings the Electron renderer keydown listener should act on (menu-owned excluded). */
+export function selectDesktopKeydownBindings(bindings: KeyboardBinding[]): KeyboardBinding[] {
+  return bindings.filter(b => b.desktop === 'keydown')
+}

--- a/apps/web/src/lib/keyboard-commands.test.ts
+++ b/apps/web/src/lib/keyboard-commands.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  appKeyboardCommands,
+  createKeyboardCommandRegistry,
+  createScopedKeyboardBinding,
+  isAppKeyboardCommand,
+  type AppKeyboardCommand,
+} from './keyboard-commands'
+
+describe('keyboard command registry', () => {
+  it('defines stable app commands and validates command ids', () => {
+    expect(isAppKeyboardCommand(appKeyboardCommands.closeCurrentWorkspaceTab)).toBe(true)
+    expect(isAppKeyboardCommand(appKeyboardCommands.saveActiveFile)).toBe(true)
+    expect(isAppKeyboardCommand('workspace-tab:close-current')).toBe(false)
+    expect(isAppKeyboardCommand(null)).toBe(false)
+  })
+
+  it('dispatches registered command handlers', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+
+    registry.register(appKeyboardCommands.closeCurrentWorkspaceTab, handler)
+
+    expect(registry.dispatch(appKeyboardCommands.closeCurrentWorkspaceTab)).toBe(true)
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  it('unregisters command handlers', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+
+    const unregister = registry.register(appKeyboardCommands.closeCurrentWorkspaceTab, handler)
+    unregister()
+
+    expect(registry.dispatch(appKeyboardCommands.closeCurrentWorkspaceTab)).toBe(false)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('connects command sources to the registry', () => {
+    const listeners: Array<(command: string) => void> = []
+    const unsubscribe = vi.fn()
+    const api = {
+      onKeyboardCommand: vi.fn((cb: (command: string) => void) => {
+        listeners.push(cb)
+        return unsubscribe
+      }),
+    }
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+
+    registry.register(appKeyboardCommands.closeCurrentWorkspaceTab, handler)
+    const disconnect = registry.connect(api)
+    const listener = listeners[0]
+    if (!listener) throw new Error('keyboard command listener was not registered')
+    listener(appKeyboardCommands.closeCurrentWorkspaceTab)
+    disconnect()
+
+    expect(api.onKeyboardCommand).toHaveBeenCalledOnce()
+    expect(handler).toHaveBeenCalledOnce()
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('invokes onUnhandled when a connected command has no handler (or none claim it)', () => {
+    const listeners: Array<(command: AppKeyboardCommand) => void> = []
+    const api = {
+      onKeyboardCommand: (cb: (command: AppKeyboardCommand) => void) => {
+        listeners.push(cb)
+        return () => {}
+      },
+    }
+    const registry = createKeyboardCommandRegistry()
+    const onUnhandled = vi.fn()
+
+    registry.connect(api, onUnhandled)
+    const listener = listeners[0]
+    if (!listener) throw new Error('keyboard command listener was not registered')
+    listener(appKeyboardCommands.closeCurrentWorkspaceTab)
+
+    expect(onUnhandled).toHaveBeenCalledWith(appKeyboardCommands.closeCurrentWorkspaceTab)
+  })
+
+  it('scoped binding: bind registers, unbind removes (so a deactivated handler stops firing)', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+    const binding = createScopedKeyboardBinding(registry, appKeyboardCommands.saveActiveFile, handler)
+
+    binding.bind()
+    expect(registry.dispatch(appKeyboardCommands.saveActiveFile)).toBe(true)
+    expect(handler).toHaveBeenCalledOnce()
+
+    handler.mockClear()
+    binding.unbind()
+    expect(registry.dispatch(appKeyboardCommands.saveActiveFile)).toBe(false)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('scoped binding: bind is idempotent (mounted + activated fire both)', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+    const binding = createScopedKeyboardBinding(registry, appKeyboardCommands.saveActiveFile, handler)
+
+    binding.bind()
+    binding.bind()
+    registry.dispatch(appKeyboardCommands.saveActiveFile)
+    expect(handler).toHaveBeenCalledOnce()
+
+    // A single unbind fully detaches despite the double bind.
+    binding.unbind()
+    expect(registry.dispatch(appKeyboardCommands.saveActiveFile)).toBe(false)
+  })
+
+  it('scoped binding: can re-bind after unbind (KeepAlive re-activate)', () => {
+    const registry = createKeyboardCommandRegistry()
+    const handler = vi.fn(() => true)
+    const binding = createScopedKeyboardBinding(registry, appKeyboardCommands.saveActiveFile, handler)
+
+    binding.bind()
+    binding.unbind()
+    binding.bind()
+    expect(registry.dispatch(appKeyboardCommands.saveActiveFile)).toBe(true)
+  })
+
+  it('does not invoke onUnhandled when a handler claims the command', () => {
+    const listeners: Array<(command: AppKeyboardCommand) => void> = []
+    const api = {
+      onKeyboardCommand: (cb: (command: AppKeyboardCommand) => void) => {
+        listeners.push(cb)
+        return () => {}
+      },
+    }
+    const registry = createKeyboardCommandRegistry()
+    const onUnhandled = vi.fn()
+    registry.register(appKeyboardCommands.closeCurrentWorkspaceTab, () => true)
+
+    registry.connect(api, onUnhandled)
+    listeners[0]?.(appKeyboardCommands.closeCurrentWorkspaceTab)
+
+    expect(onUnhandled).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/keyboard-commands.ts
+++ b/apps/web/src/lib/keyboard-commands.ts
@@ -1,0 +1,96 @@
+export const appKeyboardCommands = {
+  closeCurrentWorkspaceTab: 'close-current-workspace-tab',
+  saveActiveFile: 'save-active-file',
+} as const
+
+export type AppKeyboardCommand =
+  typeof appKeyboardCommands[keyof typeof appKeyboardCommands]
+
+const appKeyboardCommandValues = new Set<string>(Object.values(appKeyboardCommands))
+
+export function isAppKeyboardCommand(value: unknown): value is AppKeyboardCommand {
+  return typeof value === 'string' && appKeyboardCommandValues.has(value)
+}
+
+export type KeyboardCommandHandler = () => boolean | void
+
+export interface KeyboardCommandApi {
+  onKeyboardCommand(cb: (command: AppKeyboardCommand) => void): (() => void) | void
+}
+
+export type UnhandledKeyboardCommandCallback = (command: AppKeyboardCommand) => void
+
+export interface KeyboardCommandRegistry {
+  register(command: AppKeyboardCommand, handler: KeyboardCommandHandler): () => void
+  dispatch(command: AppKeyboardCommand): boolean
+  /**
+   * Bridge an external command source (e.g. Electron IPC) into the registry.
+   * `onUnhandled` fires for commands no registered handler claimed. Desktop uses
+   * it to fall back to closing the window when there is no workspace tab to close.
+   */
+  connect(api: KeyboardCommandApi, onUnhandled?: UnhandledKeyboardCommandCallback): () => void
+}
+
+export interface ScopedKeyboardBinding {
+  bind(): void
+  unbind(): void
+}
+
+/**
+ * An idempotent register/unregister pair for one command handler. Lets a caller
+ * attach and detach the same handler repeatedly. Used by useKeyboardCommand to
+ * keep a component's shortcut live only while it is mounted AND active, so a
+ * KeepAlive-cached-but-deactivated component does not keep claiming the command.
+ */
+export function createScopedKeyboardBinding(
+  registry: Pick<KeyboardCommandRegistry, 'register'>,
+  command: AppKeyboardCommand,
+  handler: KeyboardCommandHandler,
+): ScopedKeyboardBinding {
+  let unregister: (() => void) | null = null
+  return {
+    bind() {
+      if (unregister) return
+      unregister = registry.register(command, handler)
+    },
+    unbind() {
+      if (!unregister) return
+      unregister()
+      unregister = null
+    },
+  }
+}
+
+export function createKeyboardCommandRegistry(): KeyboardCommandRegistry {
+  const handlers = new Map<AppKeyboardCommand, Set<KeyboardCommandHandler>>()
+
+  return {
+    register(command, handler) {
+      const commandHandlers = handlers.get(command) ?? new Set<KeyboardCommandHandler>()
+      commandHandlers.add(handler)
+      handlers.set(command, commandHandlers)
+      return () => {
+        commandHandlers.delete(handler)
+        if (commandHandlers.size === 0) handlers.delete(command)
+      }
+    },
+
+    dispatch(command) {
+      const commandHandlers = handlers.get(command)
+      if (!commandHandlers) return false
+      let handled = false
+      for (const handler of commandHandlers) {
+        handled = handler() === true || handled
+      }
+      return handled
+    },
+
+    connect(api, onUnhandled) {
+      const unsubscribe = api.onKeyboardCommand((command) => {
+        const handled = this.dispatch(command)
+        if (!handled) onUnhandled?.(command)
+      })
+      return typeof unsubscribe === 'function' ? unsubscribe : () => {}
+    },
+  }
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -3,7 +3,13 @@ import 'markstream-vue/index.css'
 import './style.css'
 import App from './App.vue'
 import router from './router'
+import { createKeyboardCommandRegistry } from './lib/keyboard-commands'
+import { connectBrowserKeyboardShortcuts } from './lib/browser-keyboard-shortcuts'
+import { keyboardBindings, selectWebBindings } from './lib/keyboard-bindings'
+import { KEYBOARD_REGISTRY } from './composables/useKeyboardCommand'
 import { setupApiClient } from './lib/api-client'
+import { registerWorkspaceTabCommands } from './pages/home/commands/workspace-tab-commands'
+import { useWorkspaceTabsStore } from './store/workspace-tabs'
 import 'animate.css'
 import { createPinia } from 'pinia'
 import i18n from './i18n'
@@ -15,9 +21,17 @@ setupApiClient({
   onUnauthorized: () => router.replace({ name: 'Login' }),
 })
 
+const pinia = createPinia().use(piniaPluginPersistedstate)
+const keyboardCommands = createKeyboardCommandRegistry()
+registerWorkspaceTabCommands(keyboardCommands, useWorkspaceTabsStore(pinia))
+// Browser-owned combos (e.g. Cmd/Ctrl+W) are excluded by selectWebBindings, so
+// they keep their native behavior — we don't intercept them in the browser.
+connectBrowserKeyboardShortcuts(keyboardCommands, selectWebBindings(keyboardBindings))
+
 createApp(App)
-  .use(createPinia().use(piniaPluginPersistedstate))
+  .use(pinia)
   .use(PiniaColada)
   .use(router)
   .use(i18n)
+  .provide(KEYBOARD_REGISTRY, keyboardCommands)
   .mount('#app')

--- a/apps/web/src/pages/home/commands/workspace-tab-commands.test.ts
+++ b/apps/web/src/pages/home/commands/workspace-tab-commands.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import { appKeyboardCommands } from '@/lib/keyboard-commands'
+import { handleWorkspaceKeyboardCommand, registerWorkspaceTabCommands } from './workspace-tab-commands'
+
+describe('workspace tab commands', () => {
+  it('closes the active workspace tab', () => {
+    const store = {
+      activeId: 'terminal:1',
+      closeTab: vi.fn(),
+    }
+
+    expect(handleWorkspaceKeyboardCommand(appKeyboardCommands.closeCurrentWorkspaceTab, store)).toBe(true)
+    expect(store.closeTab).toHaveBeenCalledWith('terminal:1')
+  })
+
+  it('leaves the workspace unchanged when there is no active tab', () => {
+    const store = {
+      activeId: null,
+      closeTab: vi.fn(),
+    }
+
+    expect(handleWorkspaceKeyboardCommand(appKeyboardCommands.closeCurrentWorkspaceTab, store)).toBe(false)
+    expect(store.closeTab).not.toHaveBeenCalled()
+  })
+
+  it('registers the close-tab command with a keyboard registry', () => {
+    const handlers = new Map<string, () => boolean>()
+    const unregister = vi.fn()
+    const registry = {
+      register: vi.fn((command: string, handler: () => boolean) => {
+        handlers.set(command, handler)
+        return unregister
+      }),
+    }
+    const store = {
+      activeId: 'browser:1',
+      closeTab: vi.fn(),
+    }
+
+    const cleanup = registerWorkspaceTabCommands(registry, store)
+    const handler = handlers.get(appKeyboardCommands.closeCurrentWorkspaceTab)
+    if (!handler) throw new Error('close-tab handler was not registered')
+
+    expect(registry.register).toHaveBeenCalledWith(appKeyboardCommands.closeCurrentWorkspaceTab, expect.any(Function))
+    expect(handler()).toBe(true)
+    expect(store.closeTab).toHaveBeenCalledWith('browser:1')
+    cleanup()
+    expect(unregister).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/pages/home/commands/workspace-tab-commands.ts
+++ b/apps/web/src/pages/home/commands/workspace-tab-commands.ts
@@ -1,0 +1,30 @@
+import {
+  appKeyboardCommands,
+  type AppKeyboardCommand,
+  type KeyboardCommandRegistry,
+} from '@/lib/keyboard-commands'
+
+export interface WorkspaceTabCommandStore {
+  activeId: string | null
+  closeTab(id: string): void
+}
+
+export function handleWorkspaceKeyboardCommand(
+  command: AppKeyboardCommand,
+  store: WorkspaceTabCommandStore,
+): boolean {
+  if (command !== appKeyboardCommands.closeCurrentWorkspaceTab) return false
+  const activeId = store.activeId
+  if (!activeId) return false
+  store.closeTab(activeId)
+  return true
+}
+
+export function registerWorkspaceTabCommands(
+  registry: Pick<KeyboardCommandRegistry, 'register'>,
+  store: WorkspaceTabCommandStore,
+): () => void {
+  return registry.register(appKeyboardCommands.closeCurrentWorkspaceTab, () =>
+    handleWorkspaceKeyboardCommand(appKeyboardCommands.closeCurrentWorkspaceTab, store),
+  )
+}


### PR DESCRIPTION
## Summary

- Add a shared keyboard command registry and binding table for web and desktop.
- Route desktop `Cmd/Ctrl+W` through the shared close-tab command while preserving native window close fallback.
- Keep browser `Cmd/Ctrl+W` passthrough so the browser tab-close default is not intercepted.
- Move file save shortcut handling (`Cmd/Ctrl+S`) onto the shared keyboard layer with scoped component handlers.

Supersedes #580.

## Notes

This keeps command semantics in `@memohai/web` while letting each surface own delivery:

- Electron menu accelerator for desktop-owned shortcuts.
- Web keydown listener only for browser-safe shortcuts.
- Component-scoped handlers for active/KeepAlive-aware command ownership.
