### PR TITLE
feat(command): add /start welcome command

### DIFF
--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -367,8 +367,11 @@ func (p *ChannelInboundProcessor) HandleInbound(ctx context.Context, cfg channel
 	// (via @mention or reply) to avoid all bots responding to the same command.
 	cmdText := rawTextForCommand(msg, text)
 
-	// /new and /stop require route context, so they are handled separately
-	// from the general command handler (which runs before route resolution).
+	// /start, /new, /stop, and /status require channel-layer handling outside
+	// the generic command handler (which runs before route resolution).
+	if isStartCommand(cmdText) && isDirectedAtBot(msg) {
+		return p.handleStartCommand(ctx, msg, sender, identity)
+	}
 	if isNewSessionCommand(cmdText) && isDirectedAtBot(msg) {
 		return p.handleNewSessionCommand(ctx, cfg, msg, sender, identity)
 	}
@@ -2864,6 +2867,37 @@ func (p *ChannelInboundProcessor) handleStopCommand(
 		)
 	}
 	return nil
+}
+
+// isStartCommand returns true when the command text is "/start".
+func isStartCommand(cmdText string) bool {
+	parsed, err := command.Parse(command.ExtractCommandText(cmdText))
+	if err != nil {
+		return false
+	}
+	return parsed.Resource == "start" && parsed.Action == "" && len(parsed.Args) == 0
+}
+
+// handleStartCommand replies with a lightweight welcome. Unlike /new it does not
+// reset the active session or show configuration — it only opens the door.
+func (p *ChannelInboundProcessor) handleStartCommand(
+	ctx context.Context,
+	msg channel.InboundMessage,
+	sender channel.StreamReplySender,
+	identity InboundIdentity,
+) error {
+	target := strings.TrimSpace(msg.ReplyTarget)
+	if target == "" {
+		return errors.New("reply target missing for /start command")
+	}
+	loc := p.localizer(ctx, identity.BotID)
+	caps := p.channelCaps(msg.Channel)
+
+	out := applyMessageFormat(channel.Message{Text: formatStartWelcomeMessage(loc)}, caps)
+	if mid := strings.TrimSpace(msg.Message.ID); mid != "" {
+		out.Reply = &channel.ReplyRef{MessageID: mid}
+	}
+	return sender.Send(ctx, channel.OutboundMessage{Target: target, Message: out})
 }
 
 // isNewSessionCommand returns true when the command text is "/new" (with

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -2869,13 +2869,20 @@ func (p *ChannelInboundProcessor) handleStopCommand(
 	return nil
 }
 
-// isStartCommand returns true when the command text is "/start".
+// isStartCommand returns true when the command text is "/start" (with optional
+// Telegram-style @botname suffix and a deep-link payload). Telegram deep links
+// deliver "/start <payload>" (and "/start@bot <payload>" in groups), which Parse
+// reads as an Action/Args; the payload is ignored — any /start opens the welcome.
 func isStartCommand(cmdText string) bool {
-	parsed, err := command.Parse(command.ExtractCommandText(cmdText))
+	extracted := command.ExtractCommandText(cmdText)
+	if extracted == "" {
+		return false
+	}
+	parsed, err := command.Parse(extracted)
 	if err != nil {
 		return false
 	}
-	return parsed.Resource == "start" && parsed.Action == "" && len(parsed.Args) == 0
+	return parsed.Resource == "start"
 }
 
 // handleStartCommand replies with a lightweight welcome. Unlike /new it does not

--- a/internal/channel/inbound/dispatcher_test.go
+++ b/internal/channel/inbound/dispatcher_test.go
@@ -42,6 +42,31 @@ func TestDetectMode(t *testing.T) {
 	}
 }
 
+func TestIsStartCommand(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"/start", true},
+		{"/start@MemohBot", true},
+		// Telegram deep links: /start <payload> (and /start@bot <payload>).
+		{"/start abc123", true},
+		{"/start@MemohBot abc123", true},
+		{"/start deep_link_payload", true},
+		{"/new", false},
+		{"/started", false},
+		{"start", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isStartCommand(tt.input); got != tt.want {
+				t.Errorf("isStartCommand(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsModeCommand(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/channel/inbound/result_render.go
+++ b/internal/channel/inbound/result_render.go
@@ -30,6 +30,45 @@ func friendlyOps(t *i18n.Localizer, verbKey string) string {
 	return t.T("ops.template", map[string]any{"verb": t.T(verbKey)})
 }
 
+func reasoningLabel(t *i18n.Localizer, cc command.CurrentContext) string {
+	if !cc.ReasoningEnabled {
+		return t.T("cmd.common.off")
+	}
+	reasoning := strings.TrimSpace(cc.ReasoningEffort)
+	if reasoning == "" {
+		return t.T("cmd.common.on")
+	}
+	return reasoning
+}
+
+// appendCurrentContextLines adds the model/heartbeat/reasoning/context summary
+// shown after /new resets a session.
+func appendCurrentContextLines(b *strings.Builder, t *i18n.Localizer, cc command.CurrentContext) {
+	fmt.Fprintf(b, "\n\n- %s: %s", t.T("newSession.labelModel"), cc.ChatModel)
+	if hb := strings.TrimSpace(cc.HeartbeatModel); hb != "" && hb != t.T("cmd.common.none") {
+		fmt.Fprintf(b, "\n- %s: %s", t.T("newSession.labelHeartbeat"), hb)
+	}
+	fmt.Fprintf(b, "\n- %s: %s", t.T("newSession.labelReasoning"), reasoningLabel(t, cc))
+	if cw := strings.TrimSpace(cc.ContextWindow); cw != "" {
+		fmt.Fprintf(b, "\n- %s: %s %s", t.T("newSession.labelContext"), cw, t.T("newSession.contextUnit"))
+	}
+}
+
+// formatStartWelcomeMessage builds the /start doorway greeting. It welcomes the
+// user and invites the first message — it does not reset history or dump bot
+// configuration (that is /new's job after a fresh session is created).
+func formatStartWelcomeMessage(t *i18n.Localizer) string {
+	var b strings.Builder
+	b.WriteString(command.MdBold(t.T("startWelcome.title")))
+	b.WriteString("\n\n")
+	b.WriteString(t.T("startWelcome.intro"))
+	fmt.Fprintf(&b, "\n\n%s", t.T("startWelcome.tip", map[string]any{
+		"new":  command.CmdRef("new"),
+		"help": command.CmdRef("help"),
+	}))
+	return b.String()
+}
+
 // formatNewSessionMessage builds the /new confirmation card. A fresh start is an
 // orientation moment, so it confirms the full setup the user is departing with —
 // which model (and its provider) will answer, whether reasoning is on, and how
@@ -38,25 +77,9 @@ func friendlyOps(t *i18n.Localizer, verbKey string) string {
 // and stripped later for non-markdown channels. modeKey is an i18n key under
 // "newSession.*" naming the session mode (e.g. newSession.modeChat).
 func formatNewSessionMessage(t *i18n.Localizer, modeKey string, cc command.CurrentContext) string {
-	reasoning := t.T("cmd.common.off")
-	if cc.ReasoningEnabled {
-		reasoning = strings.TrimSpace(cc.ReasoningEffort)
-		if reasoning == "" {
-			reasoning = t.T("cmd.common.on")
-		}
-	}
 	var b strings.Builder
 	b.WriteString(command.MdBold(t.T("newSession.title", map[string]any{"mode": t.T(modeKey)})))
-	// Display names / enums read better as plain text than monospace.
-	fmt.Fprintf(&b, "\n\n- %s: %s", t.T("newSession.labelModel"), cc.ChatModel)
-	if hb := strings.TrimSpace(cc.HeartbeatModel); hb != "" && hb != t.T("cmd.common.none") {
-		fmt.Fprintf(&b, "\n- %s: %s", t.T("newSession.labelHeartbeat"), hb)
-	}
-	fmt.Fprintf(&b, "\n- %s: %s", t.T("newSession.labelReasoning"), reasoning)
-	if cw := strings.TrimSpace(cc.ContextWindow); cw != "" {
-		fmt.Fprintf(&b, "\n- %s: %s %s", t.T("newSession.labelContext"), cw, t.T("newSession.contextUnit"))
-	}
-	// One guiding line: how to change the setup they're departing with.
+	appendCurrentContextLines(&b, t, cc)
 	fmt.Fprintf(&b, "\n\n%s", t.T("newSession.tip", map[string]any{
 		"model":     command.CmdRef("model"),
 		"reasoning": command.CmdRef("reasoning"),

--- a/internal/channel/inbound/result_render_test.go
+++ b/internal/channel/inbound/result_render_test.go
@@ -266,6 +266,25 @@ func TestRenderModelPickerProviderGrid(t *testing.T) {
 	}
 }
 
+func TestFormatStartWelcomeMessage(t *testing.T) {
+	got := formatStartWelcomeMessage(i18n.New("en"))
+	for _, want := range []string{
+		"**👋 Hi there!**",
+		"Just send me a message",
+		"`/help` shows what I can do.",
+		"`/new` starts a clean slate anytime.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("message missing %q:\n%s", want, got)
+		}
+	}
+	for _, omit := range []string{"Model:", "Reasoning:", "Context:", "New chat started"} {
+		if strings.Contains(got, omit) {
+			t.Errorf("/start welcome should not include %q:\n%s", omit, got)
+		}
+	}
+}
+
 func TestFormatNewSessionMessage(t *testing.T) {
 	got := formatNewSessionMessage(i18n.New("en"), "newSession.modeChat", command.CurrentContext{
 		ChatModel: "Claude Opus 4.7 (Anthropic)", HeartbeatModel: "DeepSeek V4 (DeepSeek)",

--- a/internal/command/handler.go
+++ b/internal/command/handler.go
@@ -157,14 +157,15 @@ func (h *Handler) CurrentContext(ctx context.Context, botID string) (CurrentCont
 // topLevelCommands are standalone commands (no sub-actions) that IsCommand
 // recognises and that are handled outside the regular resource-group dispatch
 // (the channel inbound processor has the routing context they need). Only
-// /help, /new, /stop are advertised in /help output — /approve and /reject are
-// internal tool-approval protocol verbs that users discover via the inline
-// approval prompt, not via the help listing.
+// /help, /start, /new, /stop are advertised in /help output — /approve and
+// /reject are internal tool-approval protocol verbs that users discover via the
+// inline approval prompt, not via the help listing.
 //
 // The map carries no per-key data — membership is the only fact callers need.
 // Localized descriptions for the advertised entries live under `cmd.help.top.*`
 // in the i18n catalog.
 var topLevelCommands = map[string]struct{}{
+	"start":   {},
 	"new":     {},
 	"stop":    {},
 	"approve": {},

--- a/internal/command/menu.go
+++ b/internal/command/menu.go
@@ -19,6 +19,7 @@ type MenuCommand struct {
 // adapters that register the menu without per-bot locale context currently pass.
 func MenuCommands(t *i18n.Localizer) []MenuCommand {
 	return []MenuCommand{
+		{"start", t.T("menu.start")},
 		{"help", t.T("menu.help")},
 		{"new", t.T("menu.new")},
 		{"stop", t.T("menu.stop")},

--- a/internal/command/reasoning_test.go
+++ b/internal/command/reasoning_test.go
@@ -107,7 +107,7 @@ func TestUnknownCommandHandling(t *testing.T) {
 		}
 	}
 	// Known commands and aliases are recognized (so they aren't treated as unknown).
-	for _, c := range []string{"/help", "/commands", "/setting", "/think", "/effort", "/reason", "/model", "/models"} {
+	for _, c := range []string{"/help", "/commands", "/start", "/setting", "/think", "/effort", "/reason", "/model", "/models"} {
 		if !h.IsCommand(c) {
 			t.Errorf("%s should be a known command", c)
 		}

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -136,6 +136,7 @@ func (r *Registry) GlobalHelp(localizers ...*i18n.Localizer) string {
 	var b strings.Builder
 	b.WriteString(MdBold(t.T("cmd.help.availableCommands")) + "\n\n")
 	b.WriteString("- /help — " + t.T("cmd.help.top.help") + "\n")
+	b.WriteString("- /start — " + t.T("cmd.help.top.start") + "\n")
 	b.WriteString("- /new — " + t.T("cmd.help.top.new") + "\n")
 	b.WriteString("- /stop — " + t.T("cmd.help.top.stop") + "\n")
 	for _, name := range r.order {

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -15,6 +15,11 @@
     "models": "models",
     "rangeAll": "All"
   },
+  "startWelcome": {
+    "title": "👋 Hi there!",
+    "intro": "Just send me a message and we'll get going.",
+    "tip": "New here? {help} shows what I can do. {new} starts a clean slate anytime."
+  },
   "newSession": {
     "title": "✨ New {mode} started.",
     "modeChat": "chat",
@@ -141,6 +146,7 @@
       "availableCommands": "Available commands",
       "top": {
         "help": "show this help",
+        "start": "show the welcome message",
         "new": "start a new conversation",
         "stop": "stop the current reply",
         "approve": "approve the latest or specified pending tool call",
@@ -446,6 +452,7 @@
     }
   },
   "menu": {
+    "start": "Show the welcome message",
     "help": "Show available commands",
     "new": "Start a new conversation",
     "stop": "Stop the current reply",

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -15,6 +15,11 @@
     "models": "模型",
     "rangeAll": "全部"
   },
+  "startWelcome": {
+    "title": "👋 你好呀！",
+    "intro": "直接发消息给我，我们就能开始聊。",
+    "tip": "第一次来？用 {help} 看看我能做什么；想从头开始，随时用 {new}。"
+  },
   "newSession": {
     "title": "✨ 已开启新{mode}。",
     "modeChat": "对话",
@@ -141,6 +146,7 @@
       "availableCommands": "可用命令",
       "top": {
         "help": "显示帮助",
+        "start": "显示欢迎信息",
         "new": "开始新对话",
         "stop": "停止当前回复",
         "approve": "批准待执行的工具调用",
@@ -446,6 +452,7 @@
     }
   },
   "menu": {
+    "start": "显示欢迎信息",
     "help": "查看可用命令",
     "new": "开始新对话",
     "stop": "停止当前回复",


### PR DESCRIPTION
## Summary

- Registers `/start` as a top-level command so it is no longer caught by the "unknown command" guidance introduced in the command UX revamp (#553). Before this, sending `/start` (a very common Telegram entry point) replied with *"Unknown command /start…"* instead of doing anything useful.
- On Telegram (and any channel) `/start` now replies with a lightweight welcome that invites the first message, points to `/help`, and mentions `/new`.
- `/start` is published in the native command menu (`setMyCommands`) and listed in `/help`.

## Behavior & design

`/start` is intentionally **not** a clone of `/new`:

| | `/start` | `/new` |
|---|----------|--------|
| Resets session / clears history | No | Yes |
| Telegram confirm gate | No | Yes |
| Content | Short welcome + how to begin | Config snapshot (model / reasoning / context) |

`/start` is a doorway greeting; `/new` is the "start a fresh session" action. The welcome copy is written in the bot's voice (first person) rather than as a system card, and is localized for English and Simplified Chinese.

## Changes

- `internal/command/handler.go` — register `start` in `topLevelCommands`
- `internal/command/menu.go` — add `/start` to the native command menu (first entry)
- `internal/command/registry.go` — list `/start` in `/help`
- `internal/channel/inbound/channel.go` — `handleStartCommand` (intercepts `/start`, replies with welcome, no session reset)
- `internal/channel/inbound/result_render.go` — `formatStartWelcomeMessage` + shared current-context helper reused by `/new`
- `internal/i18n/locales/{en,zh}.json` — `startWelcome.*`, `menu.start`, `cmd.help.top.start`
- tests: `result_render_test.go`, `reasoning_test.go`

## Test plan

- [x] `go test ./internal/command/... ./internal/channel/inbound/...`
- [x] `/start` is recognized as a known command (not "unknown command")
- [x] `/start` welcome omits the `/new` config snapshot and does not claim a new session started