### PR TITLE
fix: publish npm packages from workspace root

### DIFF
--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 import { execFileSync, spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
 
 const CANDIDATE_DIRS = [
   'apps/desktop',
@@ -36,8 +39,8 @@ function prereleaseTag(version) {
   return /^[a-z][a-z0-9._-]*$/i.test(identifier) ? identifier : 'next'
 }
 
-function publishArgs(version) {
-  const args = ['publish', '--access', 'public', '--no-git-checks']
+function publishOptions(version) {
+  const args = ['--access', 'public', '--no-git-checks']
   const tag = prereleaseTag(version)
   if (tag) {
     args.push('--tag', tag)
@@ -58,7 +61,7 @@ function isVersionPublished(name, version) {
 }
 
 function publish(dir, version) {
-  const args = publishArgs(version)
+  const args = ['publish', dir, ...publishOptions(version)]
   if (dryRun) {
     log.info(`[dry-run] ${dir}: pnpm ${args.join(' ')}`)
     return true
@@ -67,7 +70,7 @@ function publish(dir, version) {
   const result = spawnSync(
     'pnpm',
     args,
-    { cwd: dir, stdio: 'inherit' },
+    { cwd: ROOT_DIR, stdio: 'inherit' },
   )
   return result.status === 0
 }
@@ -79,7 +82,7 @@ let failed = 0
 for (const dir of CANDIDATE_DIRS) {
   let pkg
   try {
-    pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+    pkg = JSON.parse(readFileSync(join(ROOT_DIR, dir, 'package.json'), 'utf8'))
   } catch {
     log.skip(`${dir} (no package.json)`)
     skipped++


### PR DESCRIPTION
## What changed

- Publish each npm package from the workspace root with an explicit package directory.
- Keep the existing skip logic for private packages, already-published versions, and prerelease npm tags.

## Why

The release workflow writes npm auth config at the workspace root via `actions/setup-node`. Publishing from each package subdirectory can miss that auth config, causing npm to return E404 for packages the token cannot publish.

## Validation

- `node scripts/publish-packages.mjs --dry-run`
- `git diff --check`
- Pre-commit checks during commit, including Go tests and lint-staged