### PR TITLE
feat: customize workspace desktop theme

### DIFF
--- a/cmd/bridge/display.go
+++ b/cmd/bridge/display.go
@@ -13,9 +13,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/memohai/memoh/internal/logger"
+	scriptassets "github.com/memohai/memoh/scripts"
 )
 
 const (
@@ -36,9 +38,12 @@ const (
 	defaultXvncGeometry   = "1280x960"
 	xvncSocketPath        = x11SocketDir + "/X99"
 	xvncLockPath          = "/tmp/.X99-lock"
+	desktopStylePath      = "/tmp/memoh-desktop-style.sh"
 	defaultRFBTCPAddr     = "127.0.0.1:5999"
 	displayReadyTimeout   = 30 * time.Second
 )
+
+var desktopSessionMonitorOnce sync.Once
 
 func startDisplaySupervisor(ctx context.Context) {
 	if !isTruthy(os.Getenv(displayEnabledEnv)) {
@@ -326,9 +331,14 @@ func startDisplaySession(ctx context.Context) {
 		return
 	}
 	if xsetroot := resolveDisplayCommand(toolkitXsetrootPath, "/usr/bin/xsetroot", "/usr/local/bin/xsetroot", "xsetroot"); xsetroot != "" {
-		runDisplayCommand(ctx, xsetroot, "-solid", "#315f7d")
+		runDisplayCommand(ctx, xsetroot, "-solid", desktopBackgroundColor())
+		runDisplayCommand(ctx, xsetroot, "-cursor_name", "left_ptr")
 	}
 	startDesktopSession(ctx)
+	desktopSessionMonitorOnce.Do(func() {
+		go superviseDesktopSession(ctx)
+	})
+	startDesktopStyle(ctx)
 	startDisplayTerminal(ctx)
 	startDisplayBrowser(ctx)
 }
@@ -380,19 +390,29 @@ func runDisplayCommand(ctx context.Context, path string, args ...string) {
 }
 
 func startDesktopSession(ctx context.Context) {
-	if displayProcessRunning(ctx, "xfce4-session", "xfwm4", "twm") {
+	if xfceSessionAvailable() {
+		if xfceSessionRunning(ctx) {
+			ensureXfceWindowManager(ctx)
+			return
+		}
+		if desktop := resolveDisplayCommand("startxfce4"); desktop != "" {
+			stopFallbackWindowManagers(ctx)
+			startDisplayCommand(ctx, "desktop", desktop)
+			return
+		}
+		if desktop := resolveDisplayCommand("xfce4-session"); desktop != "" {
+			stopFallbackWindowManagers(ctx)
+			startDisplayCommand(ctx, "desktop", desktop)
+			return
+		}
+	}
+	if xfceWindowManagerRunning(ctx) {
 		return
 	}
-	if desktop := resolveDisplayCommand("startxfce4"); desktop != "" {
-		startDisplayCommand(ctx, "desktop", desktop)
+	if ensureXfceWindowManager(ctx) {
 		return
 	}
-	if desktop := resolveDisplayCommand("xfce4-session"); desktop != "" {
-		startDisplayCommand(ctx, "desktop", desktop)
-		return
-	}
-	if windowManager := resolveDisplayCommand("xfwm4"); windowManager != "" {
-		startDisplayCommand(ctx, "window manager", windowManager)
+	if displayProcessRunning(ctx, "twm") {
 		return
 	}
 	if windowManager := resolveDisplayCommand(toolkitTwmPath); windowManager != "" {
@@ -400,6 +420,76 @@ func startDesktopSession(ctx context.Context) {
 		return
 	}
 	logger.FromContext(ctx).Warn("display desktop session unavailable")
+}
+
+func superviseDesktopSession(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	lastRestart := time.Time{}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if !displayTCPReady(ctx, displayRFBTCPAddr()) {
+				continue
+			}
+			if desktopSessionHealthy(ctx) {
+				continue
+			}
+			if !lastRestart.IsZero() && time.Since(lastRestart) < 10*time.Second {
+				continue
+			}
+			lastRestart = time.Now()
+			logger.FromContext(ctx).Warn("display desktop session is not running; restarting")
+			startDesktopSession(ctx)
+			startDesktopStyle(ctx)
+		}
+	}
+}
+
+func desktopSessionHealthy(ctx context.Context) bool {
+	if xfceSessionAvailable() {
+		return xfceSessionRunning(ctx) && (!xfceWindowManagerAvailable() || xfceWindowManagerRunning(ctx))
+	}
+	if xfceWindowManagerAvailable() {
+		return xfceWindowManagerRunning(ctx)
+	}
+	return displayProcessRunning(ctx, "twm")
+}
+
+func xfceSessionAvailable() bool {
+	return resolveDisplayCommand("startxfce4") != "" ||
+		resolveDisplayCommand("xfce4-session") != ""
+}
+
+func xfceSessionRunning(ctx context.Context) bool {
+	return displayProcessRunning(ctx, "startxfce4", "xfce4-session", "xfdesktop")
+}
+
+func xfceWindowManagerAvailable() bool {
+	return resolveDisplayCommand("xfwm4") != ""
+}
+
+func xfceWindowManagerRunning(ctx context.Context) bool {
+	return displayProcessRunning(ctx, "xfwm4")
+}
+
+func ensureXfceWindowManager(ctx context.Context) bool {
+	windowManager := resolveDisplayCommand("xfwm4")
+	if windowManager == "" {
+		return false
+	}
+	if xfceWindowManagerRunning(ctx) {
+		return true
+	}
+	stopFallbackWindowManagers(ctx)
+	startDisplayCommand(ctx, "window manager", windowManager, "--replace")
+	return true
+}
+
+func stopFallbackWindowManagers(ctx context.Context) {
+	stopDisplayProcesses(ctx, "twm")
 }
 
 func startDisplayTerminal(ctx context.Context) {
@@ -447,18 +537,89 @@ func startDisplayBrowser(ctx context.Context) {
 	)
 }
 
-func displayProcessRunning(ctx context.Context, patterns ...string) bool {
-	pgrep := resolveDisplayCommand("pgrep")
-	if pgrep == "" {
-		return false
+func startDesktopStyle(ctx context.Context) {
+	script := strings.TrimSpace(desktopStyleScript())
+	if script == "" {
+		return
 	}
-	for _, pattern := range patterns {
-		cmd := exec.CommandContext(ctx, pgrep, "-f", pattern) //nolint:gosec // patterns are controlled by this package.
-		if cmd.Run() == nil {
-			return true
+	if err := os.WriteFile(desktopStylePath, []byte(script+"\n"), 0o755); err != nil { //nolint:gosec // G306: executable script is intentionally written for this container session.
+		logger.FromContext(ctx).Warn("failed to write display desktop style script", slog.String("path", desktopStylePath), slog.Any("error", err))
+		return
+	}
+	startDisplayCommand(ctx, "desktop style", "/bin/sh", desktopStylePath)
+}
+
+func desktopBackgroundColor() string {
+	color := strings.TrimSpace(os.Getenv("MEMOH_DISPLAY_DESKTOP_COLOR"))
+	if color == "" {
+		return "#1f2329"
+	}
+	return color
+}
+
+func desktopStyleScript() string {
+	if data, err := os.ReadFile("scripts/desktop-style.sh"); err == nil {
+		return string(data)
+	}
+	return scriptassets.DesktopStyle
+}
+
+func displayProcessRunning(_ context.Context, patterns ...string) bool {
+	return len(displayProcessIDsByName(patterns...)) > 0
+}
+
+func displayProcessIDsByName(names ...string) []int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	wanted := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			wanted[name] = struct{}{}
 		}
 	}
-	return false
+	if len(wanted) == 0 {
+		return nil
+	}
+	var pids []int
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == "" || name[0] < '0' || name[0] > '9' {
+			continue
+		}
+		cmdline, err := os.ReadFile(filepath.Join("/proc", name, "cmdline")) //nolint:gosec // /proc entries are kernel-provided.
+		if err != nil || len(cmdline) == 0 {
+			continue
+		}
+		pid, err := strconv.Atoi(name)
+		if err != nil {
+			continue
+		}
+		parts := strings.Split(strings.TrimRight(string(cmdline), "\x00"), "\x00")
+		for _, arg := range parts {
+			if _, ok := wanted[filepath.Base(strings.TrimSpace(arg))]; ok {
+				pids = append(pids, pid)
+				break
+			}
+		}
+	}
+	return pids
+}
+
+func stopDisplayProcesses(ctx context.Context, names ...string) {
+	pids := displayProcessIDsByName(names...)
+	for _, pid := range pids {
+		process, err := os.FindProcess(pid)
+		if err == nil {
+			_ = process.Kill()
+		}
+	}
+	if len(pids) == 0 {
+		return
+	}
+	_ = sleepWithContext(ctx, 300*time.Millisecond)
 }
 
 func xvncProcessRunning() bool {

--- a/internal/handlers/display.go
+++ b/internal/handlers/display.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -163,6 +164,8 @@ func (h *ContainerdHandler) HandleDisplayWebRTCOffer(c echo.Context) error {
 		}
 		return echo.NewHTTPError(status, err.Error())
 	}
+
+	h.applyDisplayStyleAsync(c.Request().Context(), botID)
 
 	return c.JSON(http.StatusOK, displayWebRTCOfferResponse{
 		Type:      answer.Type,
@@ -412,6 +415,10 @@ func displayPrepareCommand() string {
 ` + strings.TrimRight(displayPrepareInstallScript(), "\n") + `
 MEMOH_DESKTOP_INSTALL
 chmod 0755 /tmp/memoh-desktop-install.sh
+cat >/tmp/memoh-desktop-style.sh <<'MEMOH_DESKTOP_STYLE'
+` + strings.TrimRight(displayPrepareStyleScript(), "\n") + `
+MEMOH_DESKTOP_STYLE
+chmod 0755 /tmp/memoh-desktop-style.sh
 ` + displayPrepareMainCommand
 }
 
@@ -420,6 +427,96 @@ func displayPrepareInstallScript() string {
 		return string(data)
 	}
 	return scriptassets.DesktopInstall
+}
+
+func displayPrepareStyleScript() string {
+	if data, err := os.ReadFile("scripts/desktop-style.sh"); err == nil {
+		return string(data)
+	}
+	return scriptassets.DesktopStyle
+}
+
+func displayApplyStyleCommand() string {
+	return `cat >/tmp/memoh-desktop-install.sh <<'MEMOH_DESKTOP_INSTALL'
+` + strings.TrimRight(displayPrepareInstallScript(), "\n") + `
+MEMOH_DESKTOP_INSTALL
+chmod 0755 /tmp/memoh-desktop-install.sh
+cat >/tmp/memoh-desktop-style.sh <<'MEMOH_DESKTOP_STYLE'
+` + strings.TrimRight(displayPrepareStyleScript(), "\n") + `
+MEMOH_DESKTOP_STYLE
+chmod 0755 /tmp/memoh-desktop-style.sh
+cat >/tmp/memoh-desktop-apply-style.sh <<'MEMOH_DESKTOP_APPLY_STYLE'
+#!/bin/sh
+
+progress() { :; }
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+os_like() {
+  if [ -r /etc/os-release ]; then
+    . /etc/os-release
+    printf '%s %s\n' "${ID:-}" "${ID_LIKE:-}"
+    return
+  fi
+  printf unknown
+}
+is_debian_like() {
+  case " $(os_like) " in
+    *" debian "*|*" ubuntu "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+is_alpine() {
+  case " $(os_like) " in
+    *" alpine "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+. /tmp/memoh-desktop-install.sh
+
+style_lock=/tmp/memoh-desktop-style.lock
+if mkdir "$style_lock" 2>/dev/null; then
+  trap 'rmdir "$style_lock" 2>/dev/null || true' EXIT INT TERM
+else
+  exit 0
+fi
+
+install_style_extras_for_current_os
+/bin/sh /tmp/memoh-desktop-style.sh
+MEMOH_DESKTOP_APPLY_STYLE
+chmod 0755 /tmp/memoh-desktop-apply-style.sh
+/bin/sh /tmp/memoh-desktop-apply-style.sh`
+}
+
+func (h *ContainerdHandler) applyDisplayStyleAsync(ctx context.Context, botID string) {
+	if h == nil || h.manager == nil {
+		return
+	}
+	go func() {
+		runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
+		defer cancel()
+		client, err := h.manager.MCPClient(runCtx, botID)
+		if err != nil || client == nil {
+			if err != nil && h.logger != nil {
+				h.logger.Warn("display desktop style skipped", slog.String("bot_id", botID), slog.Any("error", err))
+			}
+			return
+		}
+		result, err := client.Exec(runCtx, displayApplyStyleCommand(), "/", 540)
+		if err != nil {
+			if h.logger != nil {
+				h.logger.Warn("display desktop style failed", slog.String("bot_id", botID), slog.Any("error", err))
+			}
+			return
+		}
+		if result != nil && result.ExitCode != 0 && h.logger != nil {
+			h.logger.Warn(
+				"display desktop style exited non-zero",
+				slog.String("bot_id", botID),
+				slog.Int("exit_code", int(result.ExitCode)),
+				slog.String("stderr", strings.TrimSpace(result.Stderr)),
+			)
+		}
+	}()
 }
 
 const displayPrepareMainCommand = `cat >/tmp/memoh-display-prepare.sh <<'MEMOH_DISPLAY_PREPARE'
@@ -565,6 +662,77 @@ stop_browsers() {
     kill -9 "$pid" 2>/dev/null || true
   done
 }
+process_pids_by_name() {
+  for proc_dir in /proc/[0-9]*; do
+    [ -d "$proc_dir" ] || continue
+    pid="${proc_dir#/proc/}"
+    cmdline="$(tr '\000' '\n' <"$proc_dir/cmdline" 2>/dev/null || true)"
+    found=0
+    old_ifs="$IFS"
+    IFS='
+'
+    for arg in $cmdline; do
+      base="${arg##*/}"
+      for target in "$@"; do
+        [ "$base" = "$target" ] && found=1
+      done
+    done
+    IFS="$old_ifs"
+    [ "$found" = 1 ] && printf '%s\n' "$pid"
+  done
+  return 0
+}
+xfce_session_pids() {
+  process_pids_by_name startxfce4 xfce4-session xfdesktop
+}
+xfwm4_pids() {
+  process_pids_by_name xfwm4
+}
+fallback_wm_pids() {
+  process_pids_by_name twm
+}
+stop_fallback_wm() {
+  pids="$(fallback_wm_pids)"
+  [ -n "$pids" ] || return 0
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null || true
+  done
+  sleep 1
+  pids="$(fallback_wm_pids)"
+  for pid in $pids; do
+    kill -9 "$pid" 2>/dev/null || true
+  done
+}
+start_xfwm4() {
+  has_cmd xfwm4 || return 1
+  [ -n "$(xfwm4_pids)" ] && return 0
+  stop_fallback_wm
+  nohup xfwm4 --replace >/tmp/memoh-xfwm4.log 2>&1 &
+  return 0
+}
+start_desktop_session() {
+  if has_cmd startxfce4; then
+    if [ -n "$(xfce_session_pids)" ]; then
+      start_xfwm4
+      return 0
+    fi
+    stop_fallback_wm
+    nohup startxfce4 >/tmp/memoh-xfce.log 2>&1 &
+  elif has_cmd xfce4-session; then
+    if [ -n "$(xfce_session_pids)" ]; then
+      start_xfwm4
+      return 0
+    fi
+    stop_fallback_wm
+    nohup xfce4-session >/tmp/memoh-xfce.log 2>&1 &
+  elif has_cmd xfwm4; then
+    start_xfwm4
+  elif [ -n "$(fallback_wm_pids)" ]; then
+    return 0
+  elif [ -x /opt/memoh/toolkit/display/bin/twm ]; then
+    nohup /opt/memoh/toolkit/display/bin/twm >/tmp/memoh-twm.log 2>&1 &
+  fi
+}
 display_socket_ready() {
   xvnc_running && [ -S "$X_SOCKET" ] && awk -v port="$(printf '%04X' "$RFB_PORT")" 'toupper($2) ~ ":" port "$" && $4 == "0A" { found = 1 } END { exit found ? 0 : 1 }' /proc/net/tcp /proc/net/tcp6 2>/dev/null
 }
@@ -613,6 +781,7 @@ else
     exit 1
   fi
 fi
+install_style_extras_for_current_os
 
 XVNC="$(find_xvnc || true)"
 BROWSER="$(find_browser || true)"
@@ -672,22 +841,15 @@ if command -v fc-cache >/dev/null 2>&1; then
 fi
 if [ -S "$X_SOCKET" ]; then
   if command -v xsetroot >/dev/null 2>&1; then
-    run_quick xsetroot -solid '#315f7d'
+    run_quick xsetroot -solid "${MEMOH_DISPLAY_DESKTOP_COLOR:-#1f2329}"
+    run_quick xsetroot -cursor_name left_ptr
   elif [ -x /opt/memoh/toolkit/display/bin/xsetroot ]; then
-    run_quick /opt/memoh/toolkit/display/bin/xsetroot -solid '#315f7d'
+    run_quick /opt/memoh/toolkit/display/bin/xsetroot -solid "${MEMOH_DISPLAY_DESKTOP_COLOR:-#1f2329}"
+    run_quick /opt/memoh/toolkit/display/bin/xsetroot -cursor_name left_ptr
   fi
 fi
-if ! ps -ef 2>/dev/null | grep -E 'xfce4-session|xfwm4|twm' | grep -v grep >/dev/null 2>&1; then
-  if has_cmd startxfce4; then
-    nohup startxfce4 >/tmp/memoh-xfce.log 2>&1 &
-  elif has_cmd xfce4-session; then
-    nohup xfce4-session >/tmp/memoh-xfce.log 2>&1 &
-  elif has_cmd xfwm4; then
-    nohup xfwm4 >/tmp/memoh-xfwm4.log 2>&1 &
-  elif [ -x /opt/memoh/toolkit/display/bin/twm ]; then
-    nohup /opt/memoh/toolkit/display/bin/twm >/tmp/memoh-twm.log 2>&1 &
-  fi
-fi
+start_desktop_session
+nohup /bin/sh /tmp/memoh-desktop-style.sh >/tmp/memoh-desktop-style.log 2>&1 &
 
 progress 94 browser "Launching browser"
 if ! browser_cdp_running; then

--- a/internal/handlers/display_test.go
+++ b/internal/handlers/display_test.go
@@ -48,11 +48,50 @@ func TestDisplayPrepareCommandInjectsInstallScript(t *testing.T) {
 	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-install.sh") {
 		t.Fatal("display prepare command must inject the install script")
 	}
+	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-style.sh") {
+		t.Fatal("display prepare command must inject the desktop style script")
+	}
 	if !strings.Contains(cmd, ". /tmp/memoh-desktop-install.sh") {
 		t.Fatal("display prepare command must source the injected install script")
 	}
 	if !strings.Contains(cmd, "install_debian()") || !strings.Contains(cmd, "install_alpine()") {
 		t.Fatal("injected install script must define Debian and Alpine installers")
+	}
+	if !strings.Contains(cmd, "configure_plank()") || !strings.Contains(cmd, "WhiteSur-Dark") {
+		t.Fatal("injected style script must define macOS-like desktop styling")
+	}
+	if !strings.Contains(cmd, "configure_topbar()") || !strings.Contains(cmd, "windowck-plugin") || !strings.Contains(cmd, "appmenu") {
+		t.Fatal("injected style script must define macOS-like topbar styling")
+	}
+	if !strings.Contains(cmd, "memoh-logo-white") || strings.Contains(cmd, "memoh-apple-symbol") {
+		t.Fatal("injected style script must use the white Memoh logo for the topbar menu icon")
+	}
+	if !strings.Contains(cmd, "xfconf_replace_int_array xfce4-panel /panels 1") || !strings.Contains(cmd, "restart_xfce_panel()") {
+		t.Fatal("injected style script must remove the default Xfce bottom panel")
+	}
+	if !strings.Contains(cmd, "xsetroot -cursor_name left_ptr") || !strings.Contains(cmd, "nohup xfwm4 --replace") {
+		t.Fatal("injected style script must restore the Xfce window manager and pointer cursor")
+	}
+	if !strings.Contains(cmd, "plugin-ids 101 102 103 104 105 106 107 108") ||
+		!strings.Contains(cmd, "xfconf_reset xfce4-panel /plugins/plugin-109") ||
+		strings.Contains(cmd, "plugin-109 string actions") {
+		t.Fatal("injected style script must omit the Xfce actions menu with logout and power options")
+	}
+	if !strings.Contains(cmd, `write_chromium_wrapper "$browser"`) ||
+		!strings.Contains(cmd, `write_desktop_file "$file" "Chromium" "chromium" "$wrapper"`) ||
+		!strings.Contains(cmd, `--user-data-dir="\$profile"`) ||
+		!strings.Contains(cmd, `rm -f "\$profile"/SingletonLock`) ||
+		strings.Contains(cmd, `write_desktop_file "$file" "Browser" "web-browser"`) {
+		t.Fatal("injected style script must pin the dock browser launcher to a Chromium wrapper with an isolated profile")
+	}
+	if !strings.Contains(cmd, "install_style_extras_for_current_os") {
+		t.Fatal("display prepare must install styling assets even when core display packages already exist")
+	}
+	if !strings.Contains(cmd, "SUDO_USER") || !strings.Contains(cmd, "sudo git unzip bash") {
+		t.Fatal("display prepare must support WhiteSur's installer in non-login root containers")
+	}
+	if !strings.Contains(cmd, "xfce4-appmenu-plugin") || !strings.Contains(cmd, "xfce4-windowck-plugin") || !strings.Contains(cmd, "appmenu-gtk3-module") {
+		t.Fatal("display prepare must install macOS-like topbar plugins when available")
 	}
 	if strings.Contains(displayPrepareMainCommand, "apt-get install") || strings.Contains(displayPrepareMainCommand, "apk add") {
 		t.Fatal("package installation details should stay in scripts/desktop-install.sh")
@@ -69,6 +108,19 @@ func TestDisplayPrepareCommandInjectsInstallScript(t *testing.T) {
 	if !strings.Contains(displayPrepareMainCommand, "grep -Eq '^--type=' && continue") {
 		t.Fatal("CDP readiness detection must ignore Chromium child processes")
 	}
+	if !strings.Contains(displayPrepareMainCommand, "start_desktop_session()") ||
+		!strings.Contains(displayPrepareMainCommand, "stop_fallback_wm") ||
+		!strings.Contains(displayPrepareMainCommand, "start_xfwm4()") ||
+		!strings.Contains(displayPrepareMainCommand, "process_pids_by_name startxfce4 xfce4-session xfdesktop") ||
+		!strings.Contains(displayPrepareMainCommand, "process_pids_by_name xfwm4") {
+		t.Fatal("display prepare must prefer Xfce over the fallback window manager")
+	}
+	if strings.Contains(displayPrepareMainCommand, "grep -E 'xfce4-session|xfwm4|twm'") {
+		t.Fatal("display prepare must not treat twm as a healthy Xfce desktop session")
+	}
+	if !strings.Contains(displayPrepareMainCommand, "xsetroot -cursor_name left_ptr") {
+		t.Fatal("display prepare must replace the default X root cursor")
+	}
 	if !strings.Contains(displayPrepareMainCommand, "SingletonLock") {
 		t.Fatal("display prepare must clean stale Chromium profile locks before starting the browser")
 	}
@@ -83,5 +135,50 @@ func TestDisplayPrepareCommandInjectsInstallScript(t *testing.T) {
 	}
 	if !strings.Contains(displayPrepareMainCommand, `-geometry "$XVNC_GEOMETRY"`) {
 		t.Fatal("display prepare must pass the configured geometry to Xvnc")
+	}
+}
+
+func TestDisplayApplyStyleCommandInjectsStyleScript(t *testing.T) {
+	t.Parallel()
+
+	cmd := displayApplyStyleCommand()
+	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-install.sh") {
+		t.Fatal("display style command must inject the install script for existing desktops")
+	}
+	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-style.sh") {
+		t.Fatal("display style command must inject the desktop style script")
+	}
+	if !strings.Contains(cmd, "install_style_extras_for_current_os") {
+		t.Fatal("display style command must install missing macOS styling assets")
+	}
+	if !strings.Contains(cmd, "/bin/sh /tmp/memoh-desktop-style.sh") {
+		t.Fatal("display style command must run the desktop style script")
+	}
+	if !strings.Contains(cmd, "configure_plank()") || !strings.Contains(cmd, "WhiteSur-Dark") {
+		t.Fatal("display style command must include macOS-like desktop styling")
+	}
+	if !strings.Contains(cmd, "configure_topbar()") || !strings.Contains(cmd, "windowck-plugin") || !strings.Contains(cmd, "appmenu") {
+		t.Fatal("display style command must include macOS-like topbar styling")
+	}
+	if !strings.Contains(cmd, "memoh-logo-white") || strings.Contains(cmd, "memoh-apple-symbol") {
+		t.Fatal("display style command must use the white Memoh logo for the topbar menu icon")
+	}
+	if !strings.Contains(cmd, "xfconf_replace_int_array xfce4-panel /panels 1") || !strings.Contains(cmd, "restart_xfce_panel()") {
+		t.Fatal("display style command must remove the default Xfce bottom panel")
+	}
+	if !strings.Contains(cmd, "xsetroot -cursor_name left_ptr") || !strings.Contains(cmd, "nohup xfwm4 --replace") {
+		t.Fatal("display style command must restore the Xfce window manager and pointer cursor")
+	}
+	if !strings.Contains(cmd, "plugin-ids 101 102 103 104 105 106 107 108") ||
+		!strings.Contains(cmd, "xfconf_reset xfce4-panel /plugins/plugin-109") ||
+		strings.Contains(cmd, "plugin-109 string actions") {
+		t.Fatal("display style command must omit the Xfce actions menu with logout and power options")
+	}
+	if !strings.Contains(cmd, `write_chromium_wrapper "$browser"`) ||
+		!strings.Contains(cmd, `write_desktop_file "$file" "Chromium" "chromium" "$wrapper"`) ||
+		!strings.Contains(cmd, `--user-data-dir="\$profile"`) ||
+		!strings.Contains(cmd, `rm -f "\$profile"/SingletonLock`) ||
+		strings.Contains(cmd, `write_desktop_file "$file" "Browser" "web-browser"`) {
+		t.Fatal("display style command must pin the dock browser launcher to a Chromium wrapper with an isolated profile")
 	}
 }

--- a/scripts/desktop-install.sh
+++ b/scripts/desktop-install.sh
@@ -1,19 +1,180 @@
 #!/bin/sh
 
+apt_get() {
+  timeout_seconds="${MEMOH_APT_COMMAND_TIMEOUT:-300}"
+  if has_cmd timeout; then
+    timeout "$timeout_seconds" apt-get \
+      -o "Acquire::Retries=${MEMOH_APT_RETRIES:-2}" \
+      -o "Acquire::Connect::Timeout=${MEMOH_APT_CONNECT_TIMEOUT:-20}" \
+      -o "Acquire::http::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
+      -o "Acquire::https::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
+      "$@"
+    return $?
+  fi
+  apt-get \
+    -o "Acquire::Retries=${MEMOH_APT_RETRIES:-2}" \
+    -o "Acquire::Connect::Timeout=${MEMOH_APT_CONNECT_TIMEOUT:-20}" \
+    -o "Acquire::http::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
+    -o "Acquire::https::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
+    "$@"
+}
+
+run_limited() {
+  timeout_seconds="${1:-180}"
+  shift
+  if has_cmd timeout; then
+    timeout "$timeout_seconds" "$@"
+    return $?
+  fi
+  "$@"
+}
+
+install_debian_optional() {
+  optional_packages=""
+  for package in "$@"; do
+    if apt-cache show "$package" >/dev/null 2>&1; then
+      optional_packages="$optional_packages $package"
+    fi
+  done
+  [ -n "$optional_packages" ] || return 0
+  # Optional styling packages should never block display setup.
+  apt_get install -y --no-install-recommends $optional_packages || true
+}
+
+install_alpine_optional() {
+  for package in "$@"; do
+    apk add --no-cache "$package" >/dev/null 2>&1 || true
+  done
+}
+
+display_style_enabled() {
+  style="${MEMOH_DISPLAY_DESKTOP_STYLE:-macos}"
+  case "$style" in
+    ""|0|false|False|FALSE|off|Off|OFF|none|None|NONE) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+has_macos_theme_assets() {
+  { [ -d "$HOME/.themes/WhiteSur-Dark-alt" ] || [ -d "$HOME/.themes/WhiteSur-Dark" ] || [ -d "$HOME/.themes/WhiteSur-Dark-solid" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark-alt" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark-solid" ]; } &&
+    { [ -d "$HOME/.local/share/icons/WhiteSur" ] || [ -d "$HOME/.icons/WhiteSur" ] || [ -d "$HOME/.local/share/icons/WhiteSur-dark" ] || [ -d "$HOME/.icons/WhiteSur-dark" ]; } &&
+    { [ -d "$HOME/.local/share/plank/themes/macOS Dark" ] || [ -d "$HOME/.local/share/plank/themes/Big Sur Dark" ]; } &&
+    find "$HOME/.local/share/backgrounds/WhiteSur" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null | grep -q .
+}
+
+clone_or_update_theme_repo() {
+  url="$1"
+  dest="$2"
+  [ -n "$url" ] && [ -n "$dest" ] || return 1
+  if [ -d "$dest/.git" ]; then
+    run_limited "${MEMOH_THEME_FETCH_TIMEOUT:-180}" git -C "$dest" fetch --depth=1 origin >/dev/null 2>&1 || return 1
+    run_limited "${MEMOH_THEME_FETCH_TIMEOUT:-180}" git -C "$dest" reset --hard origin/HEAD >/dev/null 2>&1 || return 1
+    return 0
+  fi
+  rm -rf "$dest"
+  run_limited "${MEMOH_THEME_FETCH_TIMEOUT:-180}" git clone --depth=1 "$url" "$dest" >/dev/null 2>&1
+}
+
+install_macos_theme_assets() {
+  display_style_enabled || return 0
+  has_macos_theme_assets && return 0
+  has_cmd git || return 0
+  has_cmd bash || return 0
+
+  theme_cache="${XDG_CACHE_HOME:-$HOME/.cache}/memoh-display-themes"
+  mkdir -p "$theme_cache" "$HOME/.themes" "$HOME/.icons" "$HOME/.local/share/icons" "$HOME/.local/share/plank/themes" "$HOME/.local/share/backgrounds/WhiteSur"
+
+  progress 58 desktop "Installing macOS desktop theme"
+
+  if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-gtk-theme.git "$theme_cache/WhiteSur-gtk-theme"; then
+    (
+      cd "$theme_cache/WhiteSur-gtk-theme"
+      export SUDO_USER="${SUDO_USER:-root}"
+      run_limited "${MEMOH_THEME_INSTALL_TIMEOUT:-240}" ./install.sh \
+        -d "$HOME/.themes" \
+        -n WhiteSur \
+        -c dark \
+        -o normal \
+        -t default \
+        -a alt \
+        -m \
+        --silent-mode
+    ) || true
+  fi
+
+  if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-icon-theme.git "$theme_cache/WhiteSur-icon-theme"; then
+    (
+      cd "$theme_cache/WhiteSur-icon-theme"
+      run_limited "${MEMOH_THEME_INSTALL_TIMEOUT:-180}" ./install.sh \
+        -d "$HOME/.local/share/icons" \
+        -n WhiteSur \
+        -t default \
+        -a
+    ) || true
+  fi
+
+  if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-cursors.git "$theme_cache/WhiteSur-cursors"; then
+    (
+      cd "$theme_cache/WhiteSur-cursors"
+      run_limited "${MEMOH_THEME_INSTALL_TIMEOUT:-120}" ./install.sh
+    ) || true
+  fi
+
+  if clone_or_update_theme_repo https://github.com/x64Bits/plank-themes.git "$theme_cache/plank-themes"; then
+    find "$theme_cache/plank-themes" -mindepth 1 -maxdepth 1 -type d ! -name .git -exec cp -a {} "$HOME/.local/share/plank/themes/" \; 2>/dev/null || true
+  fi
+
+  if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-wallpapers.git "$theme_cache/WhiteSur-wallpapers"; then
+    find "$theme_cache/WhiteSur-wallpapers" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) -exec cp -a {} "$HOME/.local/share/backgrounds/WhiteSur/" \; 2>/dev/null || true
+  fi
+}
+
+install_debian_style_extras() {
+  display_style_enabled || return 0
+  if [ "${MEMOH_APT_INDEX_UPDATED:-0}" != "1" ]; then
+    apt_get update && MEMOH_APT_INDEX_UPDATED=1 || true
+  fi
+  has_macos_theme_assets && return 0
+  progress 54 desktop "Installing macOS desktop theme dependencies"
+  install_debian_optional sudo git unzip bash sassc libglib2.0-bin libglib2.0-dev-bin libglib2.0-dev libxml2-utils gtk2-engines-murrine gtk2-engines-pixbuf plank papirus-icon-theme arc-theme fonts-inter gnome-themes-extra bibata-cursor-theme xfce4-appmenu-plugin xfce4-windowck-plugin appmenu-gtk2-module appmenu-gtk3-module appmenu-registrar
+  install_macos_theme_assets
+}
+
+install_alpine_style_extras() {
+  display_style_enabled || return 0
+  has_macos_theme_assets && return 0
+  install_alpine_optional sudo git unzip bash sassc glib-dev libxml2-utils plank papirus-icon-theme arc-theme font-inter
+  install_macos_theme_assets
+}
+
+install_style_extras_for_current_os() {
+  display_style_enabled || return 0
+  if is_debian_like; then
+    install_debian_style_extras
+  elif is_alpine; then
+    install_alpine_style_extras
+  else
+    install_macos_theme_assets
+  fi
+}
+
 install_debian() {
   has_cmd apt-get || { echo "This image looks Debian-like but apt-get is unavailable. Install the Memoh workspace toolkit or use a Debian/Alpine image." >&2; exit 1; }
   export DEBIAN_FRONTEND=noninteractive
+  export APT_LISTCHANGES_FRONTEND=none
   progress 18 system "Detected Debian workspace"
   progress 24 installing "Updating package index"
-  apt-get update
+  apt_get update
+  MEMOH_APT_INDEX_UPDATED=1
   if ! has_cmd apt-extracttemplates; then
-    apt-get install -y --no-install-recommends apt-utils
+    apt_get install -y --no-install-recommends apt-utils
   fi
   progress 42 installing "Installing VNC, desktop, accessibility, and CJK fonts"
-  apt-get install -y --no-install-recommends ca-certificates curl gnupg dbus-x11 x11-xserver-utils xterm xfce4 tigervnc-standalone-server fontconfig fonts-dejavu fonts-noto-cjk fonts-noto-color-emoji procps at-spi2-core
+  apt_get install -y --no-install-recommends ca-certificates curl gnupg dbus-x11 x11-xserver-utils xterm xfce4 tigervnc-standalone-server fontconfig fonts-dejavu fonts-noto-cjk fonts-noto-color-emoji procps at-spi2-core
+  install_debian_style_extras
   if ! find_browser >/dev/null 2>&1; then
     progress 66 browser "Installing browser"
-    if apt-get install -y --no-install-recommends chromium || apt-get install -y --no-install-recommends chromium-browser; then
+    if apt_get install -y --no-install-recommends chromium || apt_get install -y --no-install-recommends chromium-browser; then
       return 0
     fi
     arch="$(dpkg --print-architecture)"
@@ -22,8 +183,8 @@ install_debian() {
     rm -f /etc/apt/keyrings/google-chrome.gpg
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --batch --yes --dearmor -o /etc/apt/keyrings/google-chrome.gpg
     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >/etc/apt/sources.list.d/google-chrome.list
-    apt-get update
-    apt-get install -y --no-install-recommends google-chrome-stable
+    apt_get update
+    apt_get install -y --no-install-recommends google-chrome-stable
   fi
 }
 
@@ -32,4 +193,5 @@ install_alpine() {
   progress 18 system "Detected Alpine workspace"
   progress 42 installing "Installing VNC, desktop, browser, accessibility, and CJK fonts"
   apk add --no-cache tigervnc xkeyboard-config xfce4 xfce4-terminal dbus-x11 xterm chromium fontconfig ttf-dejavu font-noto-cjk font-noto-emoji at-spi2-core
+  install_alpine_style_extras
 }

--- a/scripts/desktop-style.sh
+++ b/scripts/desktop-style.sh
@@ -1,0 +1,597 @@
+#!/bin/sh
+
+style="${MEMOH_DISPLAY_DESKTOP_STYLE:-macos}"
+case "$style" in
+  ""|0|false|False|FALSE|off|Off|OFF|none|None|NONE)
+    exit 0
+    ;;
+esac
+
+DISPLAY="${DISPLAY:-:99}"
+GTK_A11Y="${GTK_A11Y:-1}"
+export DISPLAY GTK_A11Y
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+theme_path() {
+  name="$1"
+  for dir in "$HOME/.themes" "$HOME/.local/share/themes" /usr/local/share/themes /usr/share/themes; do
+    [ -d "$dir/$name" ] || continue
+    printf '%s\n' "$dir/$name"
+    return 0
+  done
+  return 1
+}
+
+icon_theme_path() {
+  name="$1"
+  for dir in "$HOME/.icons" "$HOME/.local/share/icons" /usr/local/share/icons /usr/share/icons; do
+    [ -d "$dir/$name" ] || continue
+    printf '%s\n' "$dir/$name"
+    return 0
+  done
+  return 1
+}
+
+first_theme() {
+  for name in "$@"; do
+    theme_path "$name" >/dev/null 2>&1 || continue
+    printf '%s\n' "$name"
+    return 0
+  done
+  return 1
+}
+
+first_xfwm_theme() {
+  for name in "$@"; do
+    path="$(theme_path "$name" 2>/dev/null || true)"
+    [ -n "$path" ] && [ -d "$path/xfwm4" ] || continue
+    printf '%s\n' "$name"
+    return 0
+  done
+  return 1
+}
+
+first_icon_theme() {
+  for name in "$@"; do
+    icon_theme_path "$name" >/dev/null 2>&1 || continue
+    printf '%s\n' "$name"
+    return 0
+  done
+  return 1
+}
+
+first_plank_theme() {
+  for name in "$@"; do
+    for dir in "$HOME/.local/share/plank/themes" "$HOME/.config/plank/themes" /usr/local/share/plank/themes /usr/share/plank/themes; do
+      [ -d "$dir/$name" ] || continue
+      printf '%s\n' "$name"
+      return 0
+    done
+  done
+  return 1
+}
+
+font_available() {
+  has_cmd fc-match || return 1
+  fc-match "$1" 2>/dev/null | grep -qi "$1"
+}
+
+first_font() {
+  for name in "$@"; do
+    if font_available "$name"; then
+      printf '%s 10\n' "$name"
+      return 0
+    fi
+  done
+  printf 'Sans 10\n'
+}
+
+run_xsetroot() {
+  color="${MEMOH_DISPLAY_DESKTOP_COLOR:-#1f2329}"
+  if has_cmd xsetroot; then
+    xsetroot -solid "$color" >/dev/null 2>&1 || true
+    xsetroot -cursor_name left_ptr >/dev/null 2>&1 || true
+  elif [ -x /opt/memoh/toolkit/display/bin/xsetroot ]; then
+    /opt/memoh/toolkit/display/bin/xsetroot -solid "$color" >/dev/null 2>&1 || true
+    /opt/memoh/toolkit/display/bin/xsetroot -cursor_name left_ptr >/dev/null 2>&1 || true
+  fi
+}
+
+wait_for_xfconf() {
+  has_cmd xfconf-query || return 1
+  i=0
+  while [ "$i" -lt 24 ]; do
+    xfconf-query -c xsettings -l >/dev/null 2>&1 && return 0
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+xfconf_set() {
+  channel="$1"
+  property="$2"
+  value_type="$3"
+  value="$4"
+  xfconf-query -c "$channel" -p "$property" -s "$value" >/dev/null 2>&1 && return 0
+  xfconf-query -c "$channel" -p "$property" -n -t "$value_type" -s "$value" >/dev/null 2>&1 || true
+}
+
+xfconf_reset() {
+  channel="$1"
+  property="$2"
+  xfconf-query -c "$channel" -p "$property" -r -R >/dev/null 2>&1 || true
+}
+
+xfconf_set_int_array() {
+  channel="$1"
+  property="$2"
+  shift 2
+  xfconf_reset "$channel" "$property"
+  command="xfconf-query -c \"$channel\" -p \"$property\" -n -a"
+  for value in "$@"; do
+    command="$command -t int -s \"$value\""
+  done
+  eval "$command" >/dev/null 2>&1 || true
+}
+
+xfconf_replace_int_array() {
+  channel="$1"
+  property="$2"
+  shift 2
+  command="xfconf-query -c \"$channel\" -p \"$property\" -a"
+  for value in "$@"; do
+    command="$command -t int -s \"$value\""
+  done
+  eval "$command" >/dev/null 2>&1 && return 0
+  xfconf_set_int_array "$channel" "$property" "$@"
+}
+
+panel_plugin_available() {
+  [ -f "/usr/share/xfce4/panel/plugins/$1.desktop" ]
+}
+
+start_appmenu_registrar() {
+  registrar="$(command -v appmenu-registrar 2>/dev/null || true)"
+  [ -n "$registrar" ] || registrar="/usr/libexec/vala-panel/appmenu-registrar"
+  [ -x "$registrar" ] || return 0
+  ps -ef 2>/dev/null | grep -E '[ /]appmenu-registrar($| )' | grep -v grep >/dev/null 2>&1 && return 0
+  nohup "$registrar" >/tmp/memoh-appmenu-registrar.log 2>&1 &
+}
+
+install_topbar_menu_icon() {
+  icon_dir="$HOME/.local/share/icons/hicolor/scalable/apps"
+  mkdir -p "$icon_dir"
+  cat >"$icon_dir/memoh-logo-white.svg" <<'EOF'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 454.08 399.96">
+  <path fill="#f5f5f7" d="M249.55,307.07c-63.11,20.61-155.69,25.5-182.38,6.68-34.57-24.37-19.05-137.12,7.42-173.36,32.66-44.71,114.75-54.31,152.82-55.97,44.88-1.96,50.44-30.49,50.44-30.49-15.46,14.29-17.33,16.35-64.32,18.23-33.97,1.36-87.49,3.88-130.26,27.67l-2.72-56.39c-.4-8.24-7.4-14.59-15.63-14.2-8.24.4-14.59,7.4-14.2,15.63l3.68,76.38c-4.98,4.93-9.62,10.35-13.82,16.35C3.89,189.99-1.8,249.58.42,297.41c.81,17.44,2.49,31.96,6.82,44.21,0,0,0,.01.01.03.6,1.19,22.35,43.42,104.6,34.64,83.45-8.9,172.88-57.76,208.36-119.64-13.8,23.41-35.2,38.86-70.67,50.43Z"/>
+  <path fill="#f5f5f7" d="M429.45,110.2c-23.96-30.8-56.39-44.77-79.74-51.1l13.35-39.38c2.65-7.81-1.54-16.29-9.35-18.93h0c-7.81-2.65-16.29,1.54-18.93,9.35l-14.85,43.78c-8.49,25.06-53.64,36.67-53.64,36.67,0,0,11.72-1.65,40.22,7.62,28.5,9.29,34.21,37.45,31.07,93.85-1.36,24.71-6.6,46.33-17.36,64.57-35.48,61.88-124.9,110.75-208.36,119.64-82.26,8.78-104-33.45-104.6-34.64,2.24,6.32,5.18,12.03,9.07,17.2,13.1,17.4,32.05,24.78,47.08,28.94,81.61,22.55,233.81,7.12,244.66,5.97,24.35-2.57,51.97-5.92,79.03-25.32,5.4-3.87,22.47-18.21,39.94-46.21,25.47-40.82,44.25-158.22,2.42-212.01Z"/>
+  <path fill="#f5f5f7" d="M163.41,238.79c.37.09,2.75.63,6.52,1.04,11.65,1.27,36.5,1.31,55.49-17.2,3.11-3.04,3.18-8.02.14-11.13-3.04-3.11-8.02-3.18-11.13-.14-18.85,18.38-47.15,12.17-47.44,12.11-4.23-.99-8.45,1.64-9.44,5.86-1,4.23,1.63,8.47,5.86,9.47Z"/>
+  <path fill="#f5f5f7" d="M118.67,218.27c12.32-.73,22.48-9.91,24.45-22.09l2-12.31c1.56-9.59-6.18-18.15-15.87-17.57h0c-12.32.73-22.48,9.91-24.45,22.09l-2,12.31c-1.56,9.59,6.18,18.15,15.87,17.57Z"/>
+  <path fill="#f5f5f7" d="M249.71,207.88h0c12.32-.73,22.48-9.91,24.45-22.09l2-12.31c1.56-9.59-6.18-18.15-15.87-17.57h0c-12.32.73-22.48,9.91-24.45,22.09l-2,12.31c-1.56,9.59,6.18,18.15,15.87,17.57Z"/>
+</svg>
+EOF
+  if has_cmd gtk-update-icon-cache; then
+    gtk-update-icon-cache -q "$HOME/.local/share/icons/hicolor" >/dev/null 2>&1 || true
+  fi
+}
+
+write_panel_css() {
+  mkdir -p "$HOME/.config/gtk-3.0"
+  cat >"$HOME/.config/gtk-3.0/gtk.css" <<'EOF'
+#XfcePanelWindow,
+#XfcePanelWindow.background,
+.xfce4-panel {
+  background-color: rgba(28, 31, 36, 0.92);
+  color: #f5f5f7;
+  font-weight: 600;
+}
+
+#XfcePanelWindow button,
+#XfcePanelWindow .flat,
+#XfcePanelWindow menuitem {
+  min-height: 22px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #f5f5f7;
+  box-shadow: none;
+}
+
+#XfcePanelWindow button:hover {
+  background-color: rgba(255, 255, 255, 0.14);
+}
+EOF
+}
+
+write_gtk_settings() {
+  theme="$1"
+  icons="$2"
+  cursor="$3"
+  font="$4"
+
+  mkdir -p "$HOME/.config/gtk-3.0" "$HOME/.config/gtk-4.0"
+  cat >"$HOME/.config/gtk-3.0/settings.ini" <<EOF
+[Settings]
+gtk-theme-name=${theme}
+gtk-icon-theme-name=${icons}
+gtk-cursor-theme-name=${cursor}
+gtk-font-name=${font}
+gtk-application-prefer-dark-theme=1
+gtk-toolbar-style=GTK_TOOLBAR_ICONS
+gtk-button-images=1
+gtk-menu-images=1
+EOF
+  cp "$HOME/.config/gtk-3.0/settings.ini" "$HOME/.config/gtk-4.0/settings.ini" 2>/dev/null || true
+}
+
+configure_topbar() {
+  wait_for_xfconf || return 0
+
+  appmenu_plugin="separator"
+  panel_title_plugin="separator"
+  if panel_plugin_available appmenu; then
+    appmenu_plugin="appmenu"
+    xfconf_set xsettings /Gtk/ShellShowsMenubar bool true
+    xfconf_set xsettings /Gtk/ShellShowsAppmenu bool true
+    xfconf_set xsettings /Gtk/Modules string "appmenu-gtk-module"
+    start_appmenu_registrar
+  fi
+  if panel_plugin_available windowck-plugin; then
+    panel_title_plugin="windowck-plugin"
+  elif panel_plugin_available windowmenu; then
+    panel_title_plugin="windowmenu"
+  fi
+
+  xfconf_replace_int_array xfce4-panel /panels 1
+  xfconf_reset xfce4-panel /panels/panel-2
+  xfconf_set_int_array xfce4-panel /panels/panel-1/plugin-ids 101 102 103 104 105 106 107 108
+  xfconf_reset xfce4-panel /plugins
+  xfconf_reset xfce4-panel /plugins/plugin-109
+
+  xfconf_set xfce4-panel /plugins/plugin-101 string applicationsmenu
+  install_topbar_menu_icon
+  xfconf_set xfce4-panel /plugins/plugin-101/show-button-title bool false
+  xfconf_set xfce4-panel /plugins/plugin-101/button-icon string "memoh-logo-white"
+  xfconf_set xfce4-panel /plugins/plugin-101/show-menu-icons bool true
+  xfconf_set xfce4-panel /plugins/plugin-101/show-generic-names bool false
+  xfconf_set xfce4-panel /plugins/plugin-101/small bool true
+
+  xfconf_set xfce4-panel /plugins/plugin-102 string "$panel_title_plugin"
+  xfconf_set xfce4-panel /plugins/plugin-102/active_window bool true
+  xfconf_set xfce4-panel /plugins/plugin-102/only_maximized bool false
+  xfconf_set xfce4-panel /plugins/plugin-102/show_on_desktop bool true
+  xfconf_set xfce4-panel /plugins/plugin-102/sync_wm_font bool true
+  xfconf_set xfce4-panel /plugins/plugin-102/full_name bool false
+  xfconf_set xfce4-panel /plugins/plugin-102/title_padding int 6
+  xfconf_set xfce4-panel /plugins/plugin-102/title_size int 28
+  xfconf_set xfce4-panel /plugins/plugin-102/title_alignment int 0
+
+  xfconf_set xfce4-panel /plugins/plugin-103 string "$appmenu_plugin"
+  xfconf_set xfce4-panel /plugins/plugin-103/compact-mode bool false
+  xfconf_set xfce4-panel /plugins/plugin-103/bold-application-name bool true
+
+  xfconf_set xfce4-panel /plugins/plugin-104 string separator
+  xfconf_set xfce4-panel /plugins/plugin-104/expand bool true
+  xfconf_set xfce4-panel /plugins/plugin-104/style int 0
+
+  xfconf_set xfce4-panel /plugins/plugin-105 string systray
+  xfconf_set xfce4-panel /plugins/plugin-105/square-icons bool true
+
+  xfconf_set xfce4-panel /plugins/plugin-106 string pulseaudio
+  xfconf_set xfce4-panel /plugins/plugin-106/enable-keyboard-shortcuts bool true
+  xfconf_set xfce4-panel /plugins/plugin-106/show-notifications bool false
+
+  xfconf_set xfce4-panel /plugins/plugin-107 string notification-plugin
+
+  xfconf_set xfce4-panel /plugins/plugin-108 string clock
+  xfconf_set xfce4-panel /plugins/plugin-108/mode int 2
+  xfconf_set xfce4-panel /plugins/plugin-108/digital-layout int 3
+  xfconf_set xfce4-panel /plugins/plugin-108/digital-time-format string "%a %b %-d  %H:%M"
+  xfconf_set xfce4-panel /plugins/plugin-108/tooltip-format string "%A, %B %-d, %Y"
+}
+
+first_wallpaper() {
+  for file in \
+    "$HOME/.local/share/backgrounds/WhiteSur/WhiteSur-dark.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/WhiteSur.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/Monterey-dark.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/Ventura-dark.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/Sonoma-dark.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/WhiteSur-light.jpg" \
+    "$HOME/.local/share/backgrounds/WhiteSur/Monterey.jpg"; do
+    [ -f "$file" ] || continue
+    printf '%s\n' "$file"
+    return 0
+  done
+
+  for dir in \
+    "$HOME/.local/share/backgrounds/WhiteSur" \
+    "$HOME/.local/share/backgrounds/whitesur" \
+    "$HOME/.local/share/backgrounds" \
+    /usr/local/share/backgrounds \
+    /usr/share/backgrounds; do
+    [ -d "$dir" ] || continue
+    found="$(find "$dir" -maxdepth 2 -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null | grep -Ei 'WhiteSur|Big[ -]?Sur|Monterey|Ventura|macOS|Mojave' | sort | head -n 1 || true)"
+    [ -n "$found" ] && { printf '%s\n' "$found"; return 0; }
+  done
+  return 1
+}
+
+configure_wallpaper() {
+  wallpaper="$(first_wallpaper 2>/dev/null || true)"
+  [ -n "$wallpaper" ] || return 0
+  wait_for_xfconf || return 0
+
+  props="$(xfconf-query -c xfce4-desktop -l 2>/dev/null | grep '/last-image$' || true)"
+  if [ -z "$props" ]; then
+    props="/backdrop/screen0/monitor0/workspace0/last-image
+/backdrop/screen0/monitorVNC-0/workspace0/last-image
+/backdrop/screen0/monitorVirtual1/workspace0/last-image
+/backdrop/screen0/monitordefault/workspace0/last-image"
+  fi
+
+  printf '%s\n' "$props" | while IFS= read -r prop; do
+    [ -n "$prop" ] || continue
+    base="${prop%/last-image}"
+    xfconf_set xfce4-desktop "$prop" string "$wallpaper"
+    xfconf_set xfce4-desktop "$base/image-style" int 5
+    xfconf_set xfce4-desktop "$base/color-style" int 0
+  done
+}
+
+configure_xfce() {
+  wait_for_xfconf || return 0
+
+  gtk_theme="${MEMOH_DISPLAY_GTK_THEME:-$(first_theme WhiteSur-Dark-solid-alt WhiteSur-Dark-alt WhiteSur-Dark-solid WhiteSur-Dark WhiteSur-dark-solid-alt WhiteSur-dark-alt WhiteSur-dark-solid WhiteSur-dark WhiteSur-Light-solid-alt WhiteSur-Light-alt WhiteSur-Light-solid WhiteSur-Light WhiteSur Arc-Dark Arc Adwaita-dark Adwaita 2>/dev/null || true)}"
+  xfwm_theme="${MEMOH_DISPLAY_XFWM_THEME:-$(first_xfwm_theme "$gtk_theme" WhiteSur-Dark-solid-alt WhiteSur-Dark-alt WhiteSur-Dark-solid WhiteSur-Dark WhiteSur-dark-solid-alt WhiteSur-dark-alt WhiteSur-dark-solid WhiteSur-dark WhiteSur-Light-solid-alt WhiteSur-Light-alt WhiteSur-Light-solid WhiteSur-Light WhiteSur Arc-Dark Arc Adwaita-dark Adwaita 2>/dev/null || true)}"
+  icons="${MEMOH_DISPLAY_ICON_THEME:-$(first_icon_theme WhiteSur-dark WhiteSur-Dark WhiteSur WhiteSur-light WhiteSur-Light Cupertino McMojave-circle-dark McMojave-circle Papirus-Dark Papirus Adwaita 2>/dev/null || true)}"
+  cursor="${MEMOH_DISPLAY_CURSOR_THEME:-$(first_icon_theme WhiteSur-cursors WhiteSur Bibata-Modern-Classic Bibata-Modern-Ice Adwaita 2>/dev/null || true)}"
+  font="$(first_font Inter 'SF Pro Display' 'Noto Sans' Cantarell Sans)"
+
+  [ -n "$gtk_theme" ] && xfconf_set xsettings /Net/ThemeName string "$gtk_theme"
+  [ -n "$xfwm_theme" ] && xfconf_set xfwm4 /general/theme string "$xfwm_theme"
+  [ -n "$icons" ] && xfconf_set xsettings /Net/IconThemeName string "$icons"
+  [ -n "$cursor" ] && xfconf_set xsettings /Gtk/CursorThemeName string "$cursor"
+
+  xfconf_set xsettings /Gtk/FontName string "$font"
+  xfconf_set xsettings /Gtk/MonospaceFontName string "Monospace 10"
+  xfconf_set xsettings /Gtk/ToolbarStyle string "icons"
+  xfconf_set xsettings /Gtk/MenuImages bool true
+  xfconf_set xsettings /Gtk/ButtonImages bool true
+  [ -n "$gtk_theme" ] && [ -n "$icons" ] && [ -n "$cursor" ] && write_gtk_settings "$gtk_theme" "$icons" "$cursor" "$font"
+  write_panel_css
+
+  # macOS order: close, minimize, maximize on the left; the WhiteSur xfwm4
+  # assets render these as traffic-light buttons.
+  xfconf_set xfwm4 /general/button_layout string "CHM|"
+  xfconf_set xfwm4 /general/title_alignment string "center"
+  xfconf_set xfwm4 /general/workspace_count int 1
+  xfconf_set xfwm4 /general/use_compositing bool true
+  xfconf_set xfwm4 /general/frame_opacity int 100
+  xfconf_set xfwm4 /general/inactive_opacity int 94
+  xfconf_set xfwm4 /general/title_font string "$font"
+
+  xfconf_set xfce4-desktop /desktop-icons/style int 0
+
+  xfconf_set xfce4-panel /panels/panel-1/mode int 0
+  xfconf_set xfce4-panel /panels/panel-1/position string "p=6;x=0;y=0"
+  xfconf_set xfce4-panel /panels/panel-1/position-locked bool true
+  xfconf_set xfce4-panel /panels/panel-1/size int 26
+  xfconf_set xfce4-panel /panels/panel-1/length int 100
+  xfconf_set xfce4-panel /panels/panel-1/length-adjust bool false
+  xfconf_set xfce4-panel /panels/panel-1/autohide-behavior int 0
+  configure_topbar
+}
+
+write_desktop_file() {
+  file="$1"
+  name="$2"
+  icon="$3"
+  exec_cmd="$4"
+  [ -n "$exec_cmd" ] || return 1
+  mkdir -p "$(dirname "$file")"
+  cat >"$file" <<EOF
+[Desktop Entry]
+Type=Application
+Name=${name}
+Icon=${icon}
+Exec=${exec_cmd}
+Terminal=false
+Categories=Utility;
+EOF
+}
+
+first_existing_file() {
+  for file in "$@"; do
+    [ -f "$file" ] || continue
+    printf '%s\n' "$file"
+    return 0
+  done
+  return 1
+}
+
+write_chromium_wrapper() {
+  browser="$1"
+  [ -n "$browser" ] || return 1
+
+  wrapper="$HOME/.local/bin/memoh-chromium"
+  mkdir -p "$(dirname "$wrapper")"
+  cat >"$wrapper" <<EOF
+#!/bin/sh
+browser="${browser}"
+profile="\${MEMOH_DISPLAY_CHROMIUM_PROFILE:-/tmp/memoh-display-browser}"
+
+if [ "\$#" -eq 0 ]; then
+  set -- about:blank
+fi
+
+mkdir -p "\$profile"
+if ! ps -ef 2>/dev/null | grep -F -- "--user-data-dir=\$profile" | grep -v grep >/dev/null 2>&1; then
+  rm -f "\$profile"/SingletonLock "\$profile"/SingletonSocket "\$profile"/SingletonCookie
+fi
+
+exec "\$browser" \\
+  --no-sandbox \\
+  --disable-dev-shm-usage \\
+  --disable-gpu \\
+  --no-first-run \\
+  --no-default-browser-check \\
+  --force-renderer-accessibility \\
+  --remote-debugging-address=127.0.0.1 \\
+  --remote-debugging-port=9222 \\
+  --remote-allow-origins='*' \\
+  --user-data-dir="\$profile" \\
+  "\$@"
+EOF
+  chmod 0755 "$wrapper" 2>/dev/null || true
+  printf '%s\n' "$wrapper"
+}
+
+browser_desktop_file() {
+  browser="$(command -v chromium 2>/dev/null || command -v chromium-browser 2>/dev/null || true)"
+  if [ -n "$browser" ]; then
+    wrapper="$(write_chromium_wrapper "$browser" 2>/dev/null || true)"
+    [ -n "$wrapper" ] || wrapper="$browser"
+    file="$HOME/.local/share/applications/memoh-chromium.desktop"
+    write_desktop_file "$file" "Chromium" "chromium" "$wrapper"
+    printf '%s\n' "$file"
+    return 0
+  fi
+
+  first_existing_file \
+    /usr/share/applications/chromium.desktop \
+    /usr/share/applications/chromium-browser.desktop \
+    /usr/local/share/applications/chromium.desktop \
+    /usr/local/share/applications/chromium-browser.desktop
+}
+
+terminal_desktop_file() {
+  first_existing_file \
+    /usr/share/applications/xfce4-terminal.desktop \
+    /usr/share/applications/org.xfce.terminal.desktop \
+    /usr/share/applications/debian-xterm.desktop \
+    /usr/local/share/applications/xfce4-terminal.desktop && return 0
+
+  terminal="$(command -v xfce4-terminal 2>/dev/null || command -v xterm 2>/dev/null || true)"
+  [ -n "$terminal" ] || return 1
+  file="$HOME/.local/share/applications/memoh-terminal.desktop"
+  write_desktop_file "$file" "Terminal" "utilities-terminal" "$terminal"
+  printf '%s\n' "$file"
+}
+
+files_desktop_file() {
+  first_existing_file \
+    /usr/share/applications/thunar.desktop \
+    /usr/share/applications/org.xfce.Thunar.desktop \
+    /usr/local/share/applications/thunar.desktop && return 0
+  return 1
+}
+
+write_dockitem() {
+  name="$1"
+  launcher="$2"
+  [ -n "$launcher" ] && [ -f "$launcher" ] || return 0
+  mkdir -p "$HOME/.config/plank/dock1/launchers"
+  cat >"$HOME/.config/plank/dock1/launchers/$name.dockitem" <<EOF
+[PlankDockItemPreferences]
+Launcher=file://${launcher}
+EOF
+}
+
+gsettings_set_plank() {
+  has_cmd gsettings || return 0
+  key="$1"
+  shift
+  gsettings set net.launchpad.plank.dock.settings:/net/launchpad/plank/docks/dock1/ "$key" "$@" >/dev/null 2>&1 || true
+}
+
+configure_plank() {
+  has_cmd plank || return 0
+
+  dock_theme="${MEMOH_DISPLAY_DOCK_THEME:-$(first_plank_theme 'macOS Dark' 'Big Sur Dark' 'Mojave Dark' 'macOS Night Owl' 'macOS Light' 'Big Sur Light' Default 2>/dev/null || true)}"
+  [ -n "$dock_theme" ] || dock_theme="Default"
+
+  browser_file="$(browser_desktop_file 2>/dev/null || true)"
+  terminal_file="$(terminal_desktop_file 2>/dev/null || true)"
+  files_file="$(files_desktop_file 2>/dev/null || true)"
+
+  rm -rf "$HOME/.config/plank/dock1/launchers"
+  write_dockitem 01-browser "$browser_file"
+  write_dockitem 02-terminal "$terminal_file"
+  write_dockitem 03-files "$files_file"
+
+  mkdir -p "$HOME/.config/plank/dock1"
+  cat >"$HOME/.config/plank/dock1/settings" <<EOF
+[PlankDockPreferences]
+CurrentWorkspaceOnly=false
+IconSize=56
+HideMode=1
+UnhideDelay=0
+Monitor=
+DockItems=01-browser.dockitem;02-terminal.dockitem;03-files.dockitem;
+Position=3
+Offset=0
+Theme=${dock_theme}
+Alignment=3
+ItemsAlignment=3
+LockItems=false
+PressureReveal=false
+PinnedOnly=false
+ZoomEnabled=true
+ZoomPercent=150
+EOF
+
+  gsettings_set_plank theme "$dock_theme"
+  gsettings_set_plank icon-size 56
+  gsettings_set_plank position "'bottom'"
+  gsettings_set_plank alignment "'center'"
+  gsettings_set_plank items-alignment "'center'"
+  gsettings_set_plank hide-mode "'intelligent'"
+  gsettings_set_plank zoom-enabled true
+  gsettings_set_plank zoom-percent 150
+}
+
+restart_plank() {
+  has_cmd plank || return 0
+  pids="$(ps -ef 2>/dev/null | grep -E '[ /]plank($| )' | grep -v grep | awk '{print $2}' || true)"
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null || true
+  done
+  [ -n "$pids" ] && sleep 1
+  nohup plank >/tmp/memoh-plank.log 2>&1 &
+}
+
+restart_xfce_panel() {
+  has_cmd xfce4-panel || return 0
+  pids="$(ps -ef 2>/dev/null | grep -E '[ /]xfce4-panel($| )' | grep -v grep | awk '{print $2}' || true)"
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null || true
+  done
+  [ -n "$pids" ] && sleep 1
+  pids="$(ps -ef 2>/dev/null | grep -E '[ /]xfce4-panel($| )' | grep -v grep | awk '{print $2}' || true)"
+  for pid in $pids; do
+    kill -9 "$pid" 2>/dev/null || true
+  done
+  nohup xfce4-panel >/tmp/memoh-xfce-panel.log 2>&1 &
+}
+
+reload_xfce_components() {
+  if has_cmd xfwm4; then
+    nohup xfwm4 --replace >/tmp/memoh-xfwm4-replace.log 2>&1 &
+  fi
+  restart_xfce_panel
+}
+
+run_xsetroot
+configure_xfce
+configure_wallpaper
+configure_plank
+restart_plank
+reload_xfce_components
+
+exit 0

--- a/scripts/embed.go
+++ b/scripts/embed.go
@@ -6,3 +6,8 @@ import _ "embed"
 //
 //go:embed desktop-install.sh
 var DesktopInstall string
+
+// DesktopStyle is the fallback desktop styling script bundled into the binary.
+//
+//go:embed desktop-style.sh
+var DesktopStyle string


### PR DESCRIPTION
## Summary

- add a bundled desktop styling script for macOS-like XFCE workspaces
- install and apply WhiteSur theme assets, icon theme, wallpaper, top bar plugins, and Plank dock styling when available
- pin the dock browser launcher to Chromium with an isolated profile wrapper
- improve XFCE session startup/recovery so workspaces do not stay in the fallback window manager after session loss

## Validation

- `sh -n scripts/desktop-install.sh && sh -n scripts/desktop-style.sh`
- `go test ./cmd/bridge ./internal/handlers`
- pre-commit hook: full Go test and Go lint passed during commit
