### PR TITLE
chore: use workspace image in dev config

### DIFF
--- a/devenv/app.dev.toml
+++ b/devenv/app.dev.toml
@@ -29,7 +29,7 @@ driver = "postgres"
 # production Docker Compose image.
 backend = "containerd"
 # registry = "memoh.cn"  # Uncomment for China mainland mirror
-default_image = "debian:bookworm-slim"
+default_image = "memohai/workspace:debian"
 image_pull_policy = "if_not_present"
 # containerd snapshotter and CNI settings for bot workspace containers.
 snapshotter = "overlayfs"

--- a/docker/Dockerfile.workspace
+++ b/docker/Dockerfile.workspace
@@ -2,7 +2,9 @@
 
 FROM debian:bookworm-slim
 
+ARG MEMOH_APT_COMMAND_TIMEOUT=1200
 ENV DEBIAN_FRONTEND=noninteractive
+ENV MEMOH_APT_COMMAND_TIMEOUT=${MEMOH_APT_COMMAND_TIMEOUT}
 WORKDIR /data
 
 COPY scripts/desktop-install.sh /tmp/memoh-desktop-install.sh


### PR DESCRIPTION
## Summary
- Point the PostgreSQL dev profile at `memohai/workspace:debian` so new dev workspaces use the prebuilt desktop/browser image.
- Add a default `MEMOH_APT_COMMAND_TIMEOUT=1200` build setting to the workspace Dockerfile so large Debian package downloads can finish on slower networks.

## Validation
- Built `memohai/workspace:debian` locally with `mise run docker:workspace:build`.
- Verified the image with `docker image inspect memohai/workspace:debian`.
- Pre-commit Go tests passed during commit.