### PR TITLE
fix(docker): add toolkit-acp-bridge-live stage for ACP container live tests

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -77,6 +77,32 @@ COPY cmd/bridge/template /assembly/templates
 COPY docker/toolkit/bin /assembly/toolkit/bin
 RUN chmod +x /assembly/toolkit/bin/*
 
+# ---- Optional Stage: standalone toolkit + bridge over TCP (live ACP tests) ----
+# A glibc image (claude-agent-acp requires glibc; the wrapper refuses musl)
+# with the toolkit at the canonical /opt/memoh/toolkit and the bridge served
+# over TCP, so integration tests can drive the REAL container backend (agent
+# runs inside the container with a managed HOME) without the full
+# containerd/server stack. Built via `--target toolkit-acp-bridge-live`.
+FROM debian:bookworm-slim AS toolkit-acp-bridge-live
+# procps provides `ps`, which the live credential-redaction smoke test
+# (TestACPContainerAPIKeyCredentialNotInPSEF) needs to assert managed API keys
+# never surface in the container's process listing.
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates procps \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=toolkit-assembly /assembly/toolkit /opt/memoh/toolkit
+COPY --from=toolkit-assembly /assembly/bridge /usr/local/bin/bridge
+# Templates let the bridge seed /data with AGENTS.md on first boot, matching
+# real workspace containers - agents read AGENTS.md, so the live environment
+# must show them the same files production does.
+COPY --from=toolkit-assembly /assembly/templates /opt/memoh/templates
+RUN mkdir -p /data
+ENV BRIDGE_TCP_ADDR=":1455" \
+    PATH="/opt/memoh/toolkit/bin:/usr/local/bin:/usr/bin:/bin"
+WORKDIR /data
+EXPOSE 1455
+ENTRYPOINT ["/usr/local/bin/bridge"]
+
 # ---- Optional Stage 5a: glibc runtime for containerd/Kata deployments ----
 # Host-installed Kata shims are commonly glibc-linked. Keep this as an explicit
 # build target so the default server image remains the Alpine runtime below.


### PR DESCRIPTION
## 问题

容器 live 测试（`internal/acpclient/codex_container_live_test.go`）需要构建 `--target toolkit-acp-bridge-live`，但这个构建阶段从未合入主干——测试文件随 #605 进了 main，配套的 Dockerfile 阶段被遗漏。现在设置 `MEMOH_LIVE_CODEX_ACP_CONTAINER=1` 运行测试，会在 docker build 一步直接失败：

```
ERROR: target stage "toolkit-acp-bridge-live" could not be found
```

由于该测试被环境变量门控，CI 默认跳过，所以一直没有暴露。

## 修复

补上该构建阶段（+26 行，仅 Dockerfile，无生产代码改动）：

- **glibc 基底**（debian:bookworm-slim）——claude-agent-acp 的启动器拒绝 musl，不能用项目默认的 Alpine
- **toolkit 置于生产容器标准路径** `/opt/memoh/toolkit`（内含按版本钉死的 codex-acp），并加入 PATH
- **bridge 以 TCP（:1455）作为入口进程**，测试从宿主机直连，无需完整 containerd/服务端栈
- **procps** 供凭据泄露冒烟（`TestACPContainerAPIKeyCredentialNotInPSEF` 需要 `ps -ef`）
- **复制 bridge 模板**到 `/opt/memoh/templates`——容器首次启动时 bridge 会把 AGENTS.md 等出厂文件种入 /data，与真实 workspace 容器行为一致（Memoh 的上下文构建每个 turn 都会读取这些文件，agent 的测试环境应与生产看到相同的文件）

## 验证

在隔离 worktree（上游 main + 仅本文件改动）中：

- ✅ 镜像构建成功
- ✅ bridge 启动后 2 秒内将全部 4 个模板（AGENTS.md / HEARTBEAT.md / MEMORY.md / PROFILES.md）种入 /data
- ✅ 容器 api_key 冒烟测试对真实 codex-acp 通过（约 5s）