### PR TITLE
fix(db): renumber reasoning effort migrations

### DIFF
--- a/db/postgres/migrations/0094_relax_reasoning_effort.down.sql
+++ b/db/postgres/migrations/0094_relax_reasoning_effort.down.sql
@@ -1,4 +1,4 @@
--- 0093_relax_reasoning_effort (down)
+-- 0094_relax_reasoning_effort (down)
 -- Restore the previous fixed reasoning effort ladder. Rows with newer effort
 -- tiers (minimal/max/custom) are reconciled into the old ladder first, otherwise
 -- re-adding the CHECK constraint would fail on any row using a relaxed value.

--- a/db/postgres/migrations/0094_relax_reasoning_effort.up.sql
+++ b/db/postgres/migrations/0094_relax_reasoning_effort.up.sql
@@ -1,4 +1,4 @@
--- 0093_relax_reasoning_effort
+-- 0094_relax_reasoning_effort
 -- Reasoning effort is now a free-form tier string (minimal/low/medium/high/xhigh/max/none),
 -- driven by per-model capability discovery rather than a fixed enum. Drop the
 -- old CHECK constraint that only permitted low/medium/high.

--- a/db/sqlite/migrations/0019_relax_reasoning_effort.down.sql
+++ b/db/sqlite/migrations/0019_relax_reasoning_effort.down.sql
@@ -1,15 +1,24 @@
--- 0018_relax_reasoning_effort
--- Reasoning effort is now a free-form tier string (minimal/low/medium/high/xhigh/max/none),
--- driven by per-model capability discovery. SQLite cannot drop a CHECK
--- constraint in place, so rebuild the bots table without bots_reasoning_effort_check.
--- NOTE: this rebuild must preserve all columns added by earlier migrations,
--- including command_ui_language, and keep heartbeat_interval DEFAULT 1440.
+-- 0019_relax_reasoning_effort (down)
+-- Restore the previous fixed reasoning effort ladder by rebuilding the table.
+-- Rows with newer effort tiers must be reconciled before rolling back.
+-- Preserves columns added by earlier migrations, including command_ui_language,
+-- and keeps heartbeat_interval DEFAULT 1440.
 -- Use the bots_new/copy/drop/rename pattern (as in 0013) rather than renaming
 -- bots to bots_old: on SQLite 3.26+, ALTER TABLE ... RENAME rewrites dependent
 -- child-table foreign keys to the new name even with foreign_keys=OFF, so
 -- renaming the parent first would leave child FKs pointing at the dropped table.
 
 PRAGMA foreign_keys = OFF;
+
+-- Map relaxed tiers back into the old enum before copying into the constrained
+-- table, otherwise the INSERT into bots_new would violate bots_reasoning_effort_check:
+--   minimal -> low, max -> xhigh, anything else out of range -> medium (default).
+UPDATE bots SET reasoning_effort = CASE
+  WHEN reasoning_effort = 'minimal' THEN 'low'
+  WHEN reasoning_effort = 'max' THEN 'xhigh'
+  ELSE 'medium'
+END
+WHERE reasoning_effort NOT IN ('none', 'low', 'medium', 'high', 'xhigh');
 
 CREATE TABLE bots_new (
   id TEXT PRIMARY KEY,
@@ -55,6 +64,7 @@ CREATE TABLE bots_new (
   CONSTRAINT bots_type_check CHECK (type IN ('personal', 'public')),
   CONSTRAINT bots_status_check CHECK (status IN ('creating', 'ready', 'deleting')),
   CONSTRAINT bots_acl_default_effect_check CHECK (acl_default_effect IN ('allow', 'deny')),
+  CONSTRAINT bots_reasoning_effort_check CHECK (reasoning_effort IN ('none', 'low', 'medium', 'high', 'xhigh')),
   CONSTRAINT bots_name_format_check CHECK (
     name GLOB '[a-z0-9]*'
     AND name NOT GLOB '*[^a-z0-9-]*'

--- a/db/sqlite/migrations/0019_relax_reasoning_effort.down.sql
+++ b/db/sqlite/migrations/0019_relax_reasoning_effort.down.sql
@@ -1,8 +1,8 @@
 -- 0019_relax_reasoning_effort (down)
 -- Restore the previous fixed reasoning effort ladder by rebuilding the table.
 -- Rows with newer effort tiers must be reconciled before rolling back.
--- Preserves columns added by earlier migrations, including command_ui_language,
--- and keeps heartbeat_interval DEFAULT 1440.
+-- Preserves columns added by earlier migrations, including command_ui_language
+-- and fetch_provider_id, and keeps heartbeat_interval DEFAULT 1440.
 -- Use the bots_new/copy/drop/rename pattern (as in 0013) rather than renaming
 -- bots to bots_old: on SQLite 3.26+, ALTER TABLE ... RENAME rewrites dependent
 -- child-table foreign keys to the new name even with foreign_keys=OFF, so
@@ -37,6 +37,7 @@ CREATE TABLE bots_new (
   reasoning_effort TEXT NOT NULL DEFAULT 'medium',
   chat_model_id TEXT REFERENCES models(id) ON DELETE SET NULL,
   search_provider_id TEXT REFERENCES search_providers(id) ON DELETE SET NULL,
+  fetch_provider_id TEXT REFERENCES fetch_providers(id) ON DELETE SET NULL,
   memory_provider_id TEXT REFERENCES memory_providers(id) ON DELETE SET NULL,
   heartbeat_enabled INTEGER NOT NULL DEFAULT 0,
   heartbeat_interval INTEGER NOT NULL DEFAULT 1440,
@@ -75,7 +76,7 @@ CREATE TABLE bots_new (
 INSERT INTO bots_new (
   id, owner_user_id, type, name, display_name, avatar_url, timezone, is_active, status,
   acl_default_effect, language, command_ui_language, reasoning_enabled, reasoning_effort,
-  chat_model_id, search_provider_id, memory_provider_id,
+  chat_model_id, search_provider_id, fetch_provider_id, memory_provider_id,
   heartbeat_enabled, heartbeat_interval, heartbeat_prompt, heartbeat_model_id,
   compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id,
   title_model_id, image_model_id, discuss_probe_model_id, tts_model_id,
@@ -86,7 +87,7 @@ INSERT INTO bots_new (
 SELECT
   id, owner_user_id, type, name, display_name, avatar_url, timezone, is_active, status,
   acl_default_effect, language, command_ui_language, reasoning_enabled, reasoning_effort,
-  chat_model_id, search_provider_id, memory_provider_id,
+  chat_model_id, search_provider_id, fetch_provider_id, memory_provider_id,
   heartbeat_enabled, heartbeat_interval, heartbeat_prompt, heartbeat_model_id,
   compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id,
   title_model_id, image_model_id, discuss_probe_model_id, tts_model_id,

--- a/db/sqlite/migrations/0019_relax_reasoning_effort.up.sql
+++ b/db/sqlite/migrations/0019_relax_reasoning_effort.up.sql
@@ -1,24 +1,15 @@
--- 0018_relax_reasoning_effort (down)
--- Restore the previous fixed reasoning effort ladder by rebuilding the table.
--- Rows with newer effort tiers must be reconciled before rolling back.
--- Preserves columns added by earlier migrations, including command_ui_language,
--- and keeps heartbeat_interval DEFAULT 1440.
+-- 0019_relax_reasoning_effort
+-- Reasoning effort is now a free-form tier string (minimal/low/medium/high/xhigh/max/none),
+-- driven by per-model capability discovery. SQLite cannot drop a CHECK
+-- constraint in place, so rebuild the bots table without bots_reasoning_effort_check.
+-- NOTE: this rebuild must preserve all columns added by earlier migrations,
+-- including command_ui_language, and keep heartbeat_interval DEFAULT 1440.
 -- Use the bots_new/copy/drop/rename pattern (as in 0013) rather than renaming
 -- bots to bots_old: on SQLite 3.26+, ALTER TABLE ... RENAME rewrites dependent
 -- child-table foreign keys to the new name even with foreign_keys=OFF, so
 -- renaming the parent first would leave child FKs pointing at the dropped table.
 
 PRAGMA foreign_keys = OFF;
-
--- Map relaxed tiers back into the old enum before copying into the constrained
--- table, otherwise the INSERT into bots_new would violate bots_reasoning_effort_check:
---   minimal -> low, max -> xhigh, anything else out of range -> medium (default).
-UPDATE bots SET reasoning_effort = CASE
-  WHEN reasoning_effort = 'minimal' THEN 'low'
-  WHEN reasoning_effort = 'max' THEN 'xhigh'
-  ELSE 'medium'
-END
-WHERE reasoning_effort NOT IN ('none', 'low', 'medium', 'high', 'xhigh');
 
 CREATE TABLE bots_new (
   id TEXT PRIMARY KEY,
@@ -64,7 +55,6 @@ CREATE TABLE bots_new (
   CONSTRAINT bots_type_check CHECK (type IN ('personal', 'public')),
   CONSTRAINT bots_status_check CHECK (status IN ('creating', 'ready', 'deleting')),
   CONSTRAINT bots_acl_default_effect_check CHECK (acl_default_effect IN ('allow', 'deny')),
-  CONSTRAINT bots_reasoning_effort_check CHECK (reasoning_effort IN ('none', 'low', 'medium', 'high', 'xhigh')),
   CONSTRAINT bots_name_format_check CHECK (
     name GLOB '[a-z0-9]*'
     AND name NOT GLOB '*[^a-z0-9-]*'

--- a/db/sqlite/migrations/0019_relax_reasoning_effort.up.sql
+++ b/db/sqlite/migrations/0019_relax_reasoning_effort.up.sql
@@ -3,7 +3,7 @@
 -- driven by per-model capability discovery. SQLite cannot drop a CHECK
 -- constraint in place, so rebuild the bots table without bots_reasoning_effort_check.
 -- NOTE: this rebuild must preserve all columns added by earlier migrations,
--- including command_ui_language, and keep heartbeat_interval DEFAULT 1440.
+-- including command_ui_language and fetch_provider_id, and keep heartbeat_interval DEFAULT 1440.
 -- Use the bots_new/copy/drop/rename pattern (as in 0013) rather than renaming
 -- bots to bots_old: on SQLite 3.26+, ALTER TABLE ... RENAME rewrites dependent
 -- child-table foreign keys to the new name even with foreign_keys=OFF, so
@@ -28,6 +28,7 @@ CREATE TABLE bots_new (
   reasoning_effort TEXT NOT NULL DEFAULT 'medium',
   chat_model_id TEXT REFERENCES models(id) ON DELETE SET NULL,
   search_provider_id TEXT REFERENCES search_providers(id) ON DELETE SET NULL,
+  fetch_provider_id TEXT REFERENCES fetch_providers(id) ON DELETE SET NULL,
   memory_provider_id TEXT REFERENCES memory_providers(id) ON DELETE SET NULL,
   heartbeat_enabled INTEGER NOT NULL DEFAULT 0,
   heartbeat_interval INTEGER NOT NULL DEFAULT 1440,
@@ -65,7 +66,7 @@ CREATE TABLE bots_new (
 INSERT INTO bots_new (
   id, owner_user_id, type, name, display_name, avatar_url, timezone, is_active, status,
   acl_default_effect, language, command_ui_language, reasoning_enabled, reasoning_effort,
-  chat_model_id, search_provider_id, memory_provider_id,
+  chat_model_id, search_provider_id, fetch_provider_id, memory_provider_id,
   heartbeat_enabled, heartbeat_interval, heartbeat_prompt, heartbeat_model_id,
   compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id,
   title_model_id, image_model_id, discuss_probe_model_id, tts_model_id,
@@ -76,7 +77,7 @@ INSERT INTO bots_new (
 SELECT
   id, owner_user_id, type, name, display_name, avatar_url, timezone, is_active, status,
   acl_default_effect, language, command_ui_language, reasoning_enabled, reasoning_effort,
-  chat_model_id, search_provider_id, memory_provider_id,
+  chat_model_id, search_provider_id, fetch_provider_id, memory_provider_id,
   heartbeat_enabled, heartbeat_interval, heartbeat_prompt, heartbeat_model_id,
   compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id,
   title_model_id, image_model_id, discuss_probe_model_id, tts_model_id,

--- a/internal/db/acp_migration_test.go
+++ b/internal/db/acp_migration_test.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"io/fs"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	embeddeddb "github.com/memohai/memoh/db"
 	"github.com/memohai/memoh/internal/config"
@@ -104,6 +106,37 @@ func sqliteMigrationsFS(t *testing.T) fs.FS {
 		t.Fatalf("sqlite migrations fs: %v", err)
 	}
 	return migrations
+}
+
+func sqliteMigrationsFSUpTo(t *testing.T, maxVersion int) fs.FS {
+	t.Helper()
+	migrations := sqliteMigrationsFS(t)
+	entries, err := fs.ReadDir(migrations, ".")
+	if err != nil {
+		t.Fatalf("read sqlite migrations: %v", err)
+	}
+
+	out := fstest.MapFS{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		sep := strings.IndexByte(name, '_')
+		if sep <= 0 {
+			continue
+		}
+		version, err := strconv.Atoi(name[:sep])
+		if err != nil || version > maxVersion {
+			continue
+		}
+		data, err := fs.ReadFile(migrations, name)
+		if err != nil {
+			t.Fatalf("read sqlite migration %s: %v", name, err)
+		}
+		out[name] = &fstest.MapFile{Data: data}
+	}
+	return out
 }
 
 func tempSQLiteMigrationDSN(t *testing.T) string {

--- a/internal/db/command_ui_language_migration_test.go
+++ b/internal/db/command_ui_language_migration_test.go
@@ -84,3 +84,43 @@ func TestSQLiteFreshReplayReasoningEffortLadder(t *testing.T) {
 		}
 	}
 }
+
+func TestSQLiteRelaxReasoningPreservesFetchProviderID(t *testing.T) {
+	dsn := tempSQLiteMigrationDSN(t)
+
+	if err := RunMigrateTarget(nil, MigrationTarget{Driver: DriverSQLite, DSN: dsn}, sqliteMigrationsFSUpTo(t, 18), "up", nil); err != nil {
+		t.Fatalf("migrate through 0018_fetch_providers: %v", err)
+	}
+
+	db := openMigrationSQLite(t, dsn)
+	if _, err := db.ExecContext(context.Background(), `INSERT INTO users(id,email,role) VALUES('00000000-0000-0000-0000-0000000000c1','fetch@example.com','member')`); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `INSERT INTO fetch_providers(id,name,provider) VALUES('fetch-provider-preserve','Fetch Preserve','generic')`); err != nil {
+		t.Fatalf("insert fetch provider: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `INSERT INTO bots(id,owner_user_id,type,name,display_name,fetch_provider_id) VALUES('00000000-0000-0000-0000-0000000000c2','00000000-0000-0000-0000-0000000000c1','personal','fetch-bot','Fetch Bot','fetch-provider-preserve')`); err != nil {
+		t.Fatalf("insert bot with fetch_provider_id: %v", err)
+	}
+	closeMigrationSQLite(t, db)
+
+	if err := RunMigrateTarget(nil, MigrationTarget{Driver: DriverSQLite, DSN: dsn}, sqliteMigrationsFS(t), "up", nil); err != nil {
+		t.Fatalf("migrate through 0019_relax_reasoning_effort: %v", err)
+	}
+
+	db = openMigrationSQLite(t, dsn)
+	defer closeMigrationSQLite(t, db)
+
+	schema := sqliteTableSQL(t, db, "bots")
+	if n := strings.Count(schema, "fetch_provider_id"); n != 1 {
+		t.Fatalf("fetch_provider_id appears %d times after 0019 rebuild, want exactly 1:\n%s", n, schema)
+	}
+
+	var providerID string
+	if err := db.QueryRowContext(context.Background(), `SELECT fetch_provider_id FROM bots WHERE id='00000000-0000-0000-0000-0000000000c2'`).Scan(&providerID); err != nil {
+		t.Fatalf("select fetch_provider_id after 0019 rebuild: %v", err)
+	}
+	if providerID != "fetch-provider-preserve" {
+		t.Fatalf("fetch_provider_id after 0019 rebuild = %q, want %q", providerID, "fetch-provider-preserve")
+	}
+}


### PR DESCRIPTION
## Summary

Renumber the reasoning effort migrations that were merged with the same versions as the fetch providers migrations.

- PostgreSQL: move `0093_relax_reasoning_effort` to `0094_relax_reasoning_effort`
- SQLite: move `0018_relax_reasoning_effort` to `0019_relax_reasoning_effort`

## Root Cause

PR #563 was squash-merged after `origin/main` already had `0093_fetch_providers` and `0018_fetch_providers`, leaving duplicate migration versions in both migration directories. `golang-migrate` rejects duplicate version/direction pairs during source initialization.

## Validation

- `go test -count=1 ./internal/db`
- `git diff --check`
- checked migration filenames for duplicate version/direction pairs