### PR TITLE
fix: stabilize workspace display styling

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -610,6 +610,7 @@
         "browser": "Installing Chrome and CJK fonts",
         "starting": "Starting VNC display",
         "desktop": "Starting desktop session",
+        "styling": "Applying desktop style",
         "complete": "Desktop is ready",
         "default": "Preparing desktop",
         "failed": "Failed to prepare desktop",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -606,6 +606,7 @@
         "browser": "正在安装 Chrome 和 CJK 字体",
         "starting": "正在启动 VNC 显示器",
         "desktop": "正在启动桌面环境",
+        "styling": "正在应用桌面样式",
         "complete": "桌面已就绪",
         "default": "正在准备桌面",
         "failed": "桌面准备失败",

--- a/apps/web/src/pages/home/components/display-pane.timeout.test.ts
+++ b/apps/web/src/pages/home/components/display-pane.timeout.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'display-pane.vue'), 'utf8')
+
+function connectSource() {
+  const start = source.indexOf('async function connect()')
+  const end = source.indexOf('function handleVisibilityChange()')
+  if (start < 0 || end < 0) {
+    throw new Error('display-pane.vue connect() source not found')
+  }
+  return source.slice(start, end)
+}
+
+describe('display pane connection timeout', () => {
+  it('starts the 15s WebRTC timeout only after display preparation finishes', () => {
+    const connect = connectSource()
+    const timeoutIndex = connect.indexOf('startConnectTimeout(attempt)')
+    const prepareIndex = connect.indexOf('if (canPrepareDisplay(info))')
+    const peerIndex = connect.indexOf('const next = new RTCPeerConnection()')
+
+    expect(prepareIndex).toBeGreaterThan(-1)
+    expect(timeoutIndex).toBeGreaterThan(prepareIndex)
+    expect(timeoutIndex).toBeLessThan(peerIndex)
+    expect(connect.slice(0, timeoutIndex)).not.toContain('startConnectTimeout(attempt)')
+  })
+})

--- a/apps/web/src/pages/home/components/display-pane.vue
+++ b/apps/web/src/pages/home/components/display-pane.vue
@@ -400,7 +400,7 @@ const statusLabel = computed(() => {
 
 const preparePercent = computed(() => Math.max(0, Math.min(100, Math.round(prepareProgress.value?.percent ?? 0))))
 
-const prepareStageOrder = ['checking', 'system', 'installing', 'browser', 'starting', 'desktop', 'complete']
+const prepareStageOrder = ['checking', 'system', 'installing', 'browser', 'starting', 'desktop', 'styling', 'complete']
 
 const prepareStages = computed<PrepareStage[]>(() => {
   const current = prepareProgress.value?.step ?? 'checking'
@@ -1091,6 +1091,7 @@ function prepareEventMessage(event: DisplayPrepareStreamEvent): string {
     case 'browser': return t('chat.display.prepare.browser')
     case 'starting': return t('chat.display.prepare.starting')
     case 'desktop': return t('chat.display.prepare.desktop')
+    case 'styling': return t('chat.display.prepare.styling')
     case 'complete': return t('chat.display.prepare.complete')
     default: return event.message || t('chat.display.prepare.default')
   }
@@ -1138,7 +1139,6 @@ async function connect() {
   status.value = 'connecting'
   unavailableReason.value = ''
   prepareProgress.value = null
-  startConnectTimeout(attempt)
 
   try {
     let info = await loadDisplayInfo()
@@ -1177,6 +1177,7 @@ async function connect() {
     return
   }
 
+  startConnectTimeout(attempt)
   const next = new RTCPeerConnection()
   peer = next
   inputChannel = next.createDataChannel('display-input', { ordered: true })

--- a/docker/Dockerfile.workspace
+++ b/docker/Dockerfile.workspace
@@ -22,7 +22,9 @@ RUN set -eux; \
       return 1; \
     }; \
     . /tmp/memoh-desktop-install.sh; \
+    export MEMOH_DISPLAY_INSTALL_ASSETS_GLOBAL=1; \
     install_debian; \
+    unset MEMOH_DISPLAY_INSTALL_ASSETS_GLOBAL; \
     rm -rf /var/lib/apt/lists/* /tmp/memoh-desktop-install.sh; \
     mkdir -p /data /tmp/.X11-unix; \
     chmod 0755 /data; \

--- a/internal/handlers/display.go
+++ b/internal/handlers/display.go
@@ -217,7 +217,10 @@ func (h *ContainerdHandler) CloseDisplaySession(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-const displayPrepareProgressPrefix = "__MEMOH_DISPLAY_PROGRESS__"
+const (
+	displayPrepareProgressPrefix = "__MEMOH_DISPLAY_PROGRESS__"
+	displayDesktopStyleVersion   = "2026-06-14.10"
+)
 
 type displayPrepareStreamEvent struct {
 	Type    string `json:"type"`
@@ -411,6 +414,12 @@ func appendLimitedLine(builder *strings.Builder, line string) {
 }
 
 func displayPrepareCommand() string {
+	return displayDesktopScriptPreamble() + `
+` + displayApplyStyleScript() + `
+` + displayPrepareMainCommand
+}
+
+func displayDesktopScriptPreamble() string {
 	return `cat >/tmp/memoh-desktop-install.sh <<'MEMOH_DESKTOP_INSTALL'
 ` + strings.TrimRight(displayPrepareInstallScript(), "\n") + `
 MEMOH_DESKTOP_INSTALL
@@ -419,7 +428,7 @@ cat >/tmp/memoh-desktop-style.sh <<'MEMOH_DESKTOP_STYLE'
 ` + strings.TrimRight(displayPrepareStyleScript(), "\n") + `
 MEMOH_DESKTOP_STYLE
 chmod 0755 /tmp/memoh-desktop-style.sh
-` + displayPrepareMainCommand
+`
 }
 
 func displayPrepareInstallScript() string {
@@ -437,16 +446,79 @@ func displayPrepareStyleScript() string {
 }
 
 func displayApplyStyleCommand() string {
-	return `cat >/tmp/memoh-desktop-install.sh <<'MEMOH_DESKTOP_INSTALL'
-` + strings.TrimRight(displayPrepareInstallScript(), "\n") + `
-MEMOH_DESKTOP_INSTALL
-chmod 0755 /tmp/memoh-desktop-install.sh
-cat >/tmp/memoh-desktop-style.sh <<'MEMOH_DESKTOP_STYLE'
-` + strings.TrimRight(displayPrepareStyleScript(), "\n") + `
-MEMOH_DESKTOP_STYLE
-chmod 0755 /tmp/memoh-desktop-style.sh
-cat >/tmp/memoh-desktop-apply-style.sh <<'MEMOH_DESKTOP_APPLY_STYLE'
+	return displayDesktopScriptPreamble() + `
+` + displayApplyStyleScript() + `
+/bin/sh /tmp/memoh-desktop-apply-style.sh --if-needed`
+}
+
+func displayApplyStyleScript() string {
+	return `cat >/tmp/memoh-desktop-apply-style.sh <<'MEMOH_DESKTOP_APPLY_STYLE'
 #!/bin/sh
+
+style_version='` + displayDesktopStyleVersion + `'
+style_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/memoh"
+style_marker="$style_config_dir/display-style.version"
+style_lock=/tmp/memoh-desktop-style.lock
+style_log=/tmp/memoh-desktop-style.log
+
+style_enabled() {
+  style="${MEMOH_DISPLAY_DESKTOP_STYLE:-macos}"
+  case "$style" in
+    ""|0|false|False|FALSE|off|Off|OFF|none|None|NONE) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+style_is_current() {
+  [ -r "$style_marker" ] && [ "$(cat "$style_marker" 2>/dev/null || true)" = "$style_version" ]
+}
+
+if [ "${1:-}" = "--check" ]; then
+  style_enabled || exit 0
+  style_is_current
+  exit $?
+fi
+
+mode="${1:---if-needed}"
+style_enabled || exit 0
+if { [ "$mode" = "--if-needed" ] || [ "$mode" = "--ensure" ]; } && style_is_current; then
+  exit 0
+fi
+
+acquire_style_lock() {
+  wait_seconds="$1"
+  if mkdir "$style_lock" 2>/dev/null; then
+    return 0
+  fi
+  i=0
+  while [ "$i" -lt "$wait_seconds" ]; do
+    if [ "$mode" = "--if-needed" ] && style_is_current; then
+      exit 0
+    fi
+    [ -d "$style_lock" ] || break
+    sleep 1
+    i=$((i + 1))
+  done
+  mkdir "$style_lock" 2>/dev/null
+}
+
+wait_seconds=30
+case "$mode" in
+  --ensure|--force) wait_seconds=120 ;;
+esac
+if ! acquire_style_lock "$wait_seconds"; then
+  if [ "$mode" = "--if-needed" ]; then
+    echo "Another desktop style apply is running; skipping retry." >&2
+    exit 0
+  fi
+  echo "Another desktop style apply is still running." >&2
+  exit 1
+fi
+trap 'rmdir "$style_lock" 2>/dev/null || true' EXIT INT TERM
+
+if { [ "$mode" = "--if-needed" ] || [ "$mode" = "--ensure" ]; } && style_is_current; then
+  exit 0
+fi
 
 progress() { :; }
 has_cmd() { command -v "$1" >/dev/null 2>&1; }
@@ -473,18 +545,88 @@ is_alpine() {
 
 . /tmp/memoh-desktop-install.sh
 
-style_lock=/tmp/memoh-desktop-style.lock
-if mkdir "$style_lock" 2>/dev/null; then
-  trap 'rmdir "$style_lock" 2>/dev/null || true' EXIT INT TERM
-else
+install_style_extras_for_current_os
+rm -f "$style_log"
+if /bin/sh /tmp/memoh-desktop-style.sh >"$style_log" 2>&1; then
+  mkdir -p "$style_config_dir"
+  printf '%s\n' "$style_version" >"$style_marker"
   exit 0
 fi
 
-install_style_extras_for_current_os
-/bin/sh /tmp/memoh-desktop-style.sh
+status=$?
+echo "Desktop style apply failed with exit code $status. Log tail:" >&2
+tail -n 80 "$style_log" >&2 2>/dev/null || true
+exit "$status"
 MEMOH_DESKTOP_APPLY_STYLE
-chmod 0755 /tmp/memoh-desktop-apply-style.sh
-/bin/sh /tmp/memoh-desktop-apply-style.sh`
+chmod 0755 /tmp/memoh-desktop-apply-style.sh`
+}
+
+func displayStyleStatusCommand() string {
+	return `style_version='` + displayDesktopStyleVersion + `'
+style="${MEMOH_DISPLAY_DESKTOP_STYLE:-macos}"
+case "$style" in
+  ""|0|false|False|FALSE|off|Off|OFF|none|None|NONE) exit 0 ;;
+esac
+style_marker="${XDG_CONFIG_HOME:-$HOME/.config}/memoh/display-style.version"
+[ -r "$style_marker" ] && [ "$(cat "$style_marker" 2>/dev/null || true)" = "$style_version" ]`
+}
+
+func displayStyleLogTailCommand() string {
+	return `tail -n 80 /tmp/memoh-desktop-style.log 2>/dev/null || true`
+}
+
+func trimDisplayLog(text string) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= 6000 {
+		return text
+	}
+	return text[len(text)-6000:]
+}
+
+func displayStyleApplyNeedsRun(ctx context.Context, client *bridge.Client) bool {
+	if client == nil {
+		return false
+	}
+	result, err := client.Exec(ctx, displayStyleStatusCommand(), "/", 15)
+	return err != nil || result == nil || result.ExitCode != 0
+}
+
+func displayStyleLogTail(ctx context.Context, client *bridge.Client) string {
+	if client == nil {
+		return ""
+	}
+	result, err := client.Exec(ctx, displayStyleLogTailCommand(), "/", 15)
+	if err != nil || result == nil {
+		return ""
+	}
+	return result.Stdout + result.Stderr
+}
+
+func displayStyleLogArgs(ctx context.Context, client *bridge.Client, botID string, result *bridge.ExecResult) []any {
+	exitCode := -1
+	stdout := ""
+	stderr := ""
+	if result != nil {
+		exitCode = int(result.ExitCode)
+		stdout = trimDisplayLog(result.Stdout)
+		stderr = trimDisplayLog(result.Stderr)
+	}
+	args := []any{
+		slog.String("bot_id", botID),
+		slog.Int("exit_code", exitCode),
+	}
+	if stderr != "" {
+		args = append(args, slog.String("stderr", stderr))
+	}
+	if stdout != "" {
+		args = append(args, slog.String("stdout", stdout))
+	}
+	if stdout == "" && stderr == "" {
+		if tail := trimDisplayLog(displayStyleLogTail(ctx, client)); tail != "" {
+			args = append(args, slog.String("style_log_tail", tail))
+		}
+	}
+	return args
 }
 
 func (h *ContainerdHandler) applyDisplayStyleAsync(ctx context.Context, botID string) {
@@ -501,6 +643,9 @@ func (h *ContainerdHandler) applyDisplayStyleAsync(ctx context.Context, botID st
 			}
 			return
 		}
+		if !displayStyleApplyNeedsRun(runCtx, client) {
+			return
+		}
 		result, err := client.Exec(runCtx, displayApplyStyleCommand(), "/", 540)
 		if err != nil {
 			if h.logger != nil {
@@ -508,13 +653,8 @@ func (h *ContainerdHandler) applyDisplayStyleAsync(ctx context.Context, botID st
 			}
 			return
 		}
-		if result != nil && result.ExitCode != 0 && h.logger != nil {
-			h.logger.Warn(
-				"display desktop style exited non-zero",
-				slog.String("bot_id", botID),
-				slog.Int("exit_code", int(result.ExitCode)),
-				slog.String("stderr", strings.TrimSpace(result.Stderr)),
-			)
+		if (result == nil || result.ExitCode != 0) && h.logger != nil {
+			h.logger.Warn("display desktop style exited non-zero", displayStyleLogArgs(runCtx, client, botID, result)...)
 		}
 	}()
 }
@@ -736,8 +876,11 @@ start_desktop_session() {
 display_socket_ready() {
   xvnc_running && [ -S "$X_SOCKET" ] && awk -v port="$(printf '%04X' "$RFB_PORT")" 'toupper($2) ~ ":" port "$" && $4 == "0A" { found = 1 } END { exit found ? 0 : 1 }' /proc/net/tcp /proc/net/tcp6 2>/dev/null
 }
+desktop_style_current() {
+  /bin/sh /tmp/memoh-desktop-apply-style.sh --check >/dev/null 2>&1
+}
 display_ready() {
-  display_socket_ready && find_browser >/dev/null 2>&1 && has_desktop
+  display_socket_ready && find_browser >/dev/null 2>&1 && has_desktop && desktop_style_current
 }
 
 . /tmp/memoh-desktop-install.sh
@@ -781,7 +924,6 @@ else
     exit 1
   fi
 fi
-install_style_extras_for_current_os
 
 XVNC="$(find_xvnc || true)"
 BROWSER="$(find_browser || true)"
@@ -849,7 +991,9 @@ if [ -S "$X_SOCKET" ]; then
   fi
 fi
 start_desktop_session
-nohup /bin/sh /tmp/memoh-desktop-style.sh >/tmp/memoh-desktop-style.log 2>&1 &
+
+progress 90 styling "Applying desktop style"
+/bin/sh /tmp/memoh-desktop-apply-style.sh --ensure
 
 progress 94 browser "Launching browser"
 if ! browser_cdp_running; then

--- a/internal/handlers/display.go
+++ b/internal/handlers/display.go
@@ -459,6 +459,7 @@ style_version='` + displayDesktopStyleVersion + `'
 style_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/memoh"
 style_marker="$style_config_dir/display-style.version"
 style_lock=/tmp/memoh-desktop-style.lock
+style_lock_stale_seconds=60
 style_log=/tmp/memoh-desktop-style.log
 
 style_enabled() {
@@ -485,9 +486,68 @@ if { [ "$mode" = "--if-needed" ] || [ "$mode" = "--ensure" ]; } && style_is_curr
   exit 0
 fi
 
+now_seconds() {
+  date +%s 2>/dev/null || printf '0\n'
+}
+
+lock_file_mtime_seconds() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || printf '0\n'
+}
+
+write_style_lock_owner() {
+  printf '%s\n' "$$" >"$style_lock/pid" 2>/dev/null || true
+  now_seconds >"$style_lock/created_at" 2>/dev/null || true
+}
+
+try_acquire_style_lock() {
+  if mkdir "$style_lock" 2>/dev/null; then
+    write_style_lock_owner
+    return 0
+  fi
+  return 1
+}
+
+read_style_lock_owner_pid() {
+  cat "$style_lock/pid" 2>/dev/null || true
+}
+
+style_lock_age_seconds() {
+  now="$(now_seconds)"
+  created="$(cat "$style_lock/created_at" 2>/dev/null || true)"
+  case "$created" in
+    ""|*[!0-9]*) created="$(lock_file_mtime_seconds "$style_lock")" ;;
+  esac
+  case "$now:$created" in
+    *[!0-9:]*|0:*|*:0) printf '0\n' ;;
+    *) printf '%s\n' "$((now - created))" ;;
+  esac
+}
+
+cleanup_stale_style_lock() {
+  [ -d "$style_lock" ] || return 1
+  owner_pid="$(read_style_lock_owner_pid)"
+  stale_reason=
+  case "$owner_pid" in
+    ""|*[!0-9]*)
+      age="$(style_lock_age_seconds)"
+      if [ "$age" -ge "$style_lock_stale_seconds" ]; then
+        stale_reason="missing owner metadata for ${age}s"
+      fi
+      ;;
+    *)
+      if ! kill -0 "$owner_pid" 2>/dev/null && ! ps -p "$owner_pid" >/dev/null 2>&1; then
+        stale_reason="owner pid $owner_pid is not running"
+      fi
+      ;;
+  esac
+  [ -n "$stale_reason" ] || return 1
+  echo "Removing stale desktop style lock: $stale_reason." >&2
+  rm -rf "$style_lock" 2>/dev/null || true
+}
+
 acquire_style_lock() {
   wait_seconds="$1"
-  if mkdir "$style_lock" 2>/dev/null; then
+  if try_acquire_style_lock; then
     return 0
   fi
   i=0
@@ -495,11 +555,24 @@ acquire_style_lock() {
     if [ "$mode" = "--if-needed" ] && style_is_current; then
       exit 0
     fi
-    [ -d "$style_lock" ] || break
+    cleanup_stale_style_lock || true
+    if try_acquire_style_lock; then
+      return 0
+    fi
     sleep 1
     i=$((i + 1))
   done
-  mkdir "$style_lock" 2>/dev/null
+  cleanup_stale_style_lock || true
+  try_acquire_style_lock
+}
+
+release_style_lock() {
+  owner_pid="$(read_style_lock_owner_pid)"
+  if [ "$owner_pid" = "$$" ]; then
+    rm -rf "$style_lock" 2>/dev/null || true
+  else
+    rmdir "$style_lock" 2>/dev/null || true
+  fi
 }
 
 wait_seconds=30
@@ -514,7 +587,7 @@ if ! acquire_style_lock "$wait_seconds"; then
   echo "Another desktop style apply is still running." >&2
   exit 1
 fi
-trap 'rmdir "$style_lock" 2>/dev/null || true' EXIT INT TERM
+trap 'release_style_lock' EXIT INT TERM
 
 if { [ "$mode" = "--if-needed" ] || [ "$mode" = "--ensure" ]; } && style_is_current; then
   exit 0

--- a/internal/handlers/display_test.go
+++ b/internal/handlers/display_test.go
@@ -231,6 +231,17 @@ func TestDisplayApplyStyleCommandInjectsStyleScript(t *testing.T) {
 		!strings.Contains(cmd, "acquire_style_lock") {
 		t.Fatal("display style command must serialize style application with a lock")
 	}
+	if !strings.Contains(cmd, "style_lock_stale_seconds=60") ||
+		!strings.Contains(cmd, `printf '%s\n' "$$" >"$style_lock/pid"`) ||
+		!strings.Contains(cmd, `now_seconds >"$style_lock/created_at"`) ||
+		!strings.Contains(cmd, "cleanup_stale_style_lock") ||
+		!strings.Contains(cmd, `kill -0 "$owner_pid"`) ||
+		!strings.Contains(cmd, `ps -p "$owner_pid"`) ||
+		!strings.Contains(cmd, `Removing stale desktop style lock`) ||
+		!strings.Contains(cmd, `rm -rf "$style_lock"`) ||
+		!strings.Contains(cmd, `trap 'release_style_lock' EXIT INT TERM`) {
+		t.Fatal("display style command must recover stale locks left behind by killed apply helpers")
+	}
 	if !strings.Contains(cmd, `tail -n 80 "$style_log"`) ||
 		!strings.Contains(cmd, `printf '%s\n' "$style_version" >"$style_marker"`) {
 		t.Fatal("display style command must persist success and print log tail on failure")

--- a/internal/handlers/display_test.go
+++ b/internal/handlers/display_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -66,6 +67,12 @@ func TestDisplayPrepareCommandInjectsInstallScript(t *testing.T) {
 	if !strings.Contains(cmd, "memoh-logo-white") || strings.Contains(cmd, "memoh-apple-symbol") {
 		t.Fatal("injected style script must use the white Memoh logo for the topbar menu icon")
 	}
+	if !strings.Contains(cmd, "memoh_logo_png_base64()") ||
+		!strings.Contains(cmd, "memoh-logo-white.png") ||
+		!strings.Contains(cmd, "/usr/share/icons/hicolor/48x48/apps") ||
+		!strings.Contains(cmd, "base64 -d") {
+		t.Fatal("injected style script must install a PNG Memoh logo fallback for panels without SVG icon loading")
+	}
 	if !strings.Contains(cmd, "xfconf_replace_int_array xfce4-panel /panels 1") || !strings.Contains(cmd, "restart_xfce_panel()") {
 		t.Fatal("injected style script must remove the default Xfce bottom panel")
 	}
@@ -84,14 +91,75 @@ func TestDisplayPrepareCommandInjectsInstallScript(t *testing.T) {
 		strings.Contains(cmd, `write_desktop_file "$file" "Browser" "web-browser"`) {
 		t.Fatal("injected style script must pin the dock browser launcher to a Chromium wrapper with an isolated profile")
 	}
+	terminalIndex := strings.Index(cmd, `terminal="$(command -v xfce4-terminal`)
+	terminalLauncherIndex := strings.Index(cmd, `write_desktop_file "$file" "Terminal" "utilities-terminal" "$terminal"`)
+	xtermFallbackIndex := strings.Index(cmd, `/usr/share/applications/debian-xterm.desktop`)
+	if terminalIndex < 0 || terminalLauncherIndex < terminalIndex || xtermFallbackIndex < terminalLauncherIndex ||
+		strings.Contains(cmd, `write_desktop_file "$file" "XTerm" "xterm" "$terminal"`) {
+		t.Fatal("injected style script must prefer a custom terminal launcher with the themed terminal icon over Debian's mini.xterm desktop file")
+	}
+	filesIndex := strings.Index(cmd, `files_desktop_file()`)
+	filesLauncherIndex := strings.Index(cmd, `write_desktop_file "$file" "Files" "$icon"`)
+	thunarFallbackIndex := strings.Index(cmd, `/usr/share/applications/thunar.desktop`)
+	if filesIndex < 0 || filesLauncherIndex < filesIndex || thunarFallbackIndex < filesLauncherIndex ||
+		!strings.Contains(cmd, "Memoh-WhiteSur-dark") ||
+		!strings.Contains(cmd, "global_theme_dir") ||
+		!strings.Contains(cmd, "install_file_manager_icon_aliases") ||
+		!strings.Contains(cmd, "file_manager_icon_path()") ||
+		!strings.Contains(cmd, "folder-blue.svg") ||
+		!strings.Contains(cmd, "org.xfce.filemanager") ||
+		!strings.Contains(cmd, "org.xfce.thunar") ||
+		!strings.Contains(cmd, "inode-directory") ||
+		!strings.Contains(cmd, "text-x-generic.svg") ||
+		!strings.Contains(cmd, `require_xfconf_value xsettings /Net/IconThemeName Memoh-WhiteSur-dark`) ||
+		!strings.Contains(cmd, "restart_file_manager()") ||
+		strings.Contains(cmd, "memoh_files_icon_png_base64") ||
+		strings.Contains(cmd, "write_memoh_files_icon_png") {
+		t.Fatal("injected style script must use a custom Files launcher and a WhiteSur-backed icon theme overlay")
+	}
 	if !strings.Contains(cmd, "install_style_extras_for_current_os") {
 		t.Fatal("display prepare must install styling assets even when core display packages already exist")
+	}
+	if !strings.Contains(cmd, "cat >/tmp/memoh-desktop-apply-style.sh") {
+		t.Fatal("display prepare command must inject the shared desktop style apply helper")
+	}
+	if !strings.Contains(displayPrepareMainCommand, `desktop_style_current()`) ||
+		!strings.Contains(displayPrepareMainCommand, `/bin/sh /tmp/memoh-desktop-apply-style.sh --check`) {
+		t.Fatal("display prepare readiness must include the desktop style marker")
+	}
+	if strings.Contains(displayPrepareMainCommand, `nohup /bin/sh /tmp/memoh-desktop-style.sh`) {
+		t.Fatal("display prepare must not apply desktop style asynchronously")
+	}
+	styleIndex := strings.Index(displayPrepareMainCommand, `progress 90 styling "Applying desktop style"`)
+	browserIndex := strings.Index(displayPrepareMainCommand, `progress 94 browser "Launching browser"`)
+	completeIndex := strings.LastIndex(displayPrepareMainCommand, "\ncomplete\nexit 0")
+	if styleIndex < 0 || browserIndex < 0 || styleIndex > browserIndex || browserIndex > completeIndex {
+		t.Fatal("display prepare must apply desktop style synchronously before browser launch and completion")
+	}
+	if !strings.Contains(displayPrepareMainCommand, `/bin/sh /tmp/memoh-desktop-apply-style.sh --ensure`) {
+		t.Fatal("display prepare must ensure the current style version before reporting ready")
 	}
 	if !strings.Contains(cmd, "SUDO_USER") || !strings.Contains(cmd, "sudo git unzip bash") {
 		t.Fatal("display prepare must support WhiteSur's installer in non-login root containers")
 	}
+	if !strings.Contains(cmd, "MEMOH_DISPLAY_INSTALL_ASSETS_GLOBAL") ||
+		!strings.Contains(cmd, "/usr/local/share/themes") ||
+		!strings.Contains(cmd, "/usr/local/share/icons") ||
+		!strings.Contains(cmd, "/usr/local/share/backgrounds/WhiteSur") ||
+		!strings.Contains(cmd, "/usr/local/share/plank/themes") {
+		t.Fatal("display prepare must support image-baked desktop style assets in global paths")
+	}
+	if !strings.Contains(cmd, "librsvg2-common") {
+		t.Fatal("display prepare must install SVG icon loading support for themed icon assets")
+	}
 	if !strings.Contains(cmd, "xfce4-appmenu-plugin") || !strings.Contains(cmd, "xfce4-windowck-plugin") || !strings.Contains(cmd, "appmenu-gtk3-module") {
 		t.Fatal("display prepare must install macOS-like topbar plugins when available")
+	}
+	if topbarIndex := strings.Index(cmd, "configure_topbar\n  xfconf_set xfce4-panel /panels/panel-1/mode"); topbarIndex < 0 {
+		t.Fatal("injected style script must set panel geometry after rebuilding the topbar panel")
+	}
+	if !strings.Contains(cmd, "if verify_style; then\n  exit 0\nfi\nexit 1") {
+		t.Fatal("injected style script must return non-zero when style verification fails")
 	}
 	if strings.Contains(displayPrepareMainCommand, "apt-get install") || strings.Contains(displayPrepareMainCommand, "apk add") {
 		t.Fatal("package installation details should stay in scripts/desktop-install.sh")
@@ -154,14 +222,43 @@ func TestDisplayApplyStyleCommandInjectsStyleScript(t *testing.T) {
 	if !strings.Contains(cmd, "/bin/sh /tmp/memoh-desktop-style.sh") {
 		t.Fatal("display style command must run the desktop style script")
 	}
+	if !strings.Contains(cmd, "style_marker=\"$style_config_dir/display-style.version\"") ||
+		!strings.Contains(cmd, "style_version='"+displayDesktopStyleVersion+"'") ||
+		!strings.Contains(cmd, "style_is_current") {
+		t.Fatal("display style command must gate retries with a versioned marker")
+	}
+	if !strings.Contains(cmd, "style_lock=/tmp/memoh-desktop-style.lock") ||
+		!strings.Contains(cmd, "acquire_style_lock") {
+		t.Fatal("display style command must serialize style application with a lock")
+	}
+	if !strings.Contains(cmd, `tail -n 80 "$style_log"`) ||
+		!strings.Contains(cmd, `printf '%s\n' "$style_version" >"$style_marker"`) {
+		t.Fatal("display style command must persist success and print log tail on failure")
+	}
+	if !strings.Contains(cmd, `/bin/sh /tmp/memoh-desktop-apply-style.sh --if-needed`) {
+		t.Fatal("display style command must only apply style when the marker is missing or stale")
+	}
 	if !strings.Contains(cmd, "configure_plank()") || !strings.Contains(cmd, "WhiteSur-Dark") {
 		t.Fatal("display style command must include macOS-like desktop styling")
 	}
 	if !strings.Contains(cmd, "configure_topbar()") || !strings.Contains(cmd, "windowck-plugin") || !strings.Contains(cmd, "appmenu") {
 		t.Fatal("display style command must include macOS-like topbar styling")
 	}
+	if !strings.Contains(cmd, "MEMOH_DISPLAY_INSTALL_ASSETS_GLOBAL") ||
+		!strings.Contains(cmd, "/usr/local/share/themes") ||
+		!strings.Contains(cmd, "/usr/local/share/icons") ||
+		!strings.Contains(cmd, "/usr/local/share/backgrounds/WhiteSur") ||
+		!strings.Contains(cmd, "/usr/local/share/plank/themes") {
+		t.Fatal("display style command must reuse image-baked desktop style assets in global paths")
+	}
 	if !strings.Contains(cmd, "memoh-logo-white") || strings.Contains(cmd, "memoh-apple-symbol") {
 		t.Fatal("display style command must use the white Memoh logo for the topbar menu icon")
+	}
+	if !strings.Contains(cmd, "memoh_logo_png_base64()") ||
+		!strings.Contains(cmd, "memoh-logo-white.png") ||
+		!strings.Contains(cmd, "/usr/share/icons/hicolor/48x48/apps") ||
+		!strings.Contains(cmd, "base64 -d") {
+		t.Fatal("display style command must install a PNG Memoh logo fallback for panels without SVG icon loading")
 	}
 	if !strings.Contains(cmd, "xfconf_replace_int_array xfce4-panel /panels 1") || !strings.Contains(cmd, "restart_xfce_panel()") {
 		t.Fatal("display style command must remove the default Xfce bottom panel")
@@ -180,5 +277,52 @@ func TestDisplayApplyStyleCommandInjectsStyleScript(t *testing.T) {
 		!strings.Contains(cmd, `rm -f "\$profile"/SingletonLock`) ||
 		strings.Contains(cmd, `write_desktop_file "$file" "Browser" "web-browser"`) {
 		t.Fatal("display style command must pin the dock browser launcher to a Chromium wrapper with an isolated profile")
+	}
+	if !strings.Contains(cmd, `write_desktop_file "$file" "Files" "$icon"`) ||
+		!strings.Contains(cmd, "Memoh-WhiteSur-dark") ||
+		!strings.Contains(cmd, "global_theme_dir") ||
+		!strings.Contains(cmd, "install_file_manager_icon_aliases") ||
+		!strings.Contains(cmd, "file_manager_icon_path()") ||
+		!strings.Contains(cmd, "folder-blue.svg") ||
+		!strings.Contains(cmd, "org.xfce.filemanager") ||
+		!strings.Contains(cmd, "org.xfce.thunar") ||
+		!strings.Contains(cmd, "inode-directory") ||
+		!strings.Contains(cmd, "text-x-generic.svg") ||
+		!strings.Contains(cmd, "verify_file_manager_style()") ||
+		!strings.Contains(cmd, "restart_file_manager()") ||
+		strings.Contains(cmd, "memoh_files_icon_png_base64") ||
+		strings.Contains(cmd, "write_memoh_files_icon_png") {
+		t.Fatal("display style command must configure the Files launcher and file-manager icon theme")
+	}
+}
+
+func TestDisplayStyleStatusCommandChecksVersionMarker(t *testing.T) {
+	t.Parallel()
+
+	cmd := displayStyleStatusCommand()
+	if !strings.Contains(cmd, "display-style.version") {
+		t.Fatal("style status command must check the desktop style marker")
+	}
+	if !strings.Contains(cmd, "style_version='"+displayDesktopStyleVersion+"'") {
+		t.Fatal("style status command must check the current style version")
+	}
+	if !strings.Contains(cmd, "MEMOH_DISPLAY_DESKTOP_STYLE") {
+		t.Fatal("style status command must treat disabled desktop styling as current")
+	}
+}
+
+func TestWorkspaceDockerfileInstallsDisplayAssetsGlobally(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../docker/Dockerfile.workspace")
+	if err != nil {
+		t.Fatalf("read workspace Dockerfile: %v", err)
+	}
+	dockerfile := string(data)
+	if !strings.Contains(dockerfile, "COPY scripts/desktop-install.sh /tmp/memoh-desktop-install.sh") {
+		t.Fatal("workspace Dockerfile must install display assets through the shared install script")
+	}
+	if !strings.Contains(dockerfile, "MEMOH_DISPLAY_INSTALL_ASSETS_GLOBAL=1") {
+		t.Fatal("workspace Dockerfile must bake static display style assets into global image paths")
 	}
 }

--- a/scripts/desktop-install.sh
+++ b/scripts/desktop-install.sh
@@ -56,10 +56,58 @@ display_style_enabled() {
 }
 
 has_macos_theme_assets() {
-  { [ -d "$HOME/.themes/WhiteSur-Dark-alt" ] || [ -d "$HOME/.themes/WhiteSur-Dark" ] || [ -d "$HOME/.themes/WhiteSur-Dark-solid" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark-alt" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark" ] || [ -d "$HOME/.local/share/themes/WhiteSur-Dark-solid" ]; } &&
-    { [ -d "$HOME/.local/share/icons/WhiteSur" ] || [ -d "$HOME/.icons/WhiteSur" ] || [ -d "$HOME/.local/share/icons/WhiteSur-dark" ] || [ -d "$HOME/.icons/WhiteSur-dark" ]; } &&
-    { [ -d "$HOME/.local/share/plank/themes/macOS Dark" ] || [ -d "$HOME/.local/share/plank/themes/Big Sur Dark" ]; } &&
-    find "$HOME/.local/share/backgrounds/WhiteSur" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null | grep -q .
+  has_one_dir \
+    "$HOME/.themes/WhiteSur-Dark-alt" \
+    "$HOME/.themes/WhiteSur-Dark" \
+    "$HOME/.themes/WhiteSur-Dark-solid" \
+    "$HOME/.local/share/themes/WhiteSur-Dark-alt" \
+    "$HOME/.local/share/themes/WhiteSur-Dark" \
+    "$HOME/.local/share/themes/WhiteSur-Dark-solid" \
+    /usr/local/share/themes/WhiteSur-Dark-alt \
+    /usr/local/share/themes/WhiteSur-Dark \
+    /usr/local/share/themes/WhiteSur-Dark-solid \
+    /usr/share/themes/WhiteSur-Dark-alt \
+    /usr/share/themes/WhiteSur-Dark \
+    /usr/share/themes/WhiteSur-Dark-solid &&
+    has_one_dir \
+      "$HOME/.local/share/icons/WhiteSur" \
+      "$HOME/.icons/WhiteSur" \
+      "$HOME/.local/share/icons/WhiteSur-dark" \
+      "$HOME/.icons/WhiteSur-dark" \
+      /usr/local/share/icons/WhiteSur \
+      /usr/local/share/icons/WhiteSur-dark \
+      /usr/share/icons/WhiteSur \
+      /usr/share/icons/WhiteSur-dark &&
+    has_one_dir \
+      "$HOME/.local/share/plank/themes/macOS Dark" \
+      "$HOME/.local/share/plank/themes/Big Sur Dark" \
+      "/usr/local/share/plank/themes/macOS Dark" \
+      "/usr/local/share/plank/themes/Big Sur Dark" \
+      "/usr/share/plank/themes/macOS Dark" \
+      "/usr/share/plank/themes/Big Sur Dark" &&
+    has_macos_wallpaper_assets
+}
+
+has_one_dir() {
+  for dir in "$@"; do
+    [ -d "$dir" ] && return 0
+  done
+  return 1
+}
+
+has_macos_wallpaper_assets() {
+  for dir in "$HOME/.local/share/backgrounds/WhiteSur" /usr/local/share/backgrounds/WhiteSur /usr/share/backgrounds/WhiteSur; do
+    [ -d "$dir" ] || continue
+    find "$dir" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) 2>/dev/null | grep -q . && return 0
+  done
+  return 1
+}
+
+install_macos_assets_globally() {
+  case "${MEMOH_DISPLAY_INSTALL_ASSETS_GLOBAL:-}" in
+    1|true|True|TRUE|yes|Yes|YES|on|On|ON) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 clone_or_update_theme_repo() {
@@ -82,7 +130,18 @@ install_macos_theme_assets() {
   has_cmd bash || return 0
 
   theme_cache="${XDG_CACHE_HOME:-$HOME/.cache}/memoh-display-themes"
-  mkdir -p "$theme_cache" "$HOME/.themes" "$HOME/.icons" "$HOME/.local/share/icons" "$HOME/.local/share/plank/themes" "$HOME/.local/share/backgrounds/WhiteSur"
+  if install_macos_assets_globally; then
+    theme_dest=/usr/local/share/themes
+    icon_dest=/usr/local/share/icons
+    plank_dest=/usr/local/share/plank/themes
+    wallpaper_dest=/usr/local/share/backgrounds/WhiteSur
+  else
+    theme_dest="$HOME/.themes"
+    icon_dest="$HOME/.local/share/icons"
+    plank_dest="$HOME/.local/share/plank/themes"
+    wallpaper_dest="$HOME/.local/share/backgrounds/WhiteSur"
+  fi
+  mkdir -p "$theme_cache" "$theme_dest" "$icon_dest" "$plank_dest" "$wallpaper_dest"
 
   progress 58 desktop "Installing macOS desktop theme"
 
@@ -91,7 +150,7 @@ install_macos_theme_assets() {
       cd "$theme_cache/WhiteSur-gtk-theme"
       export SUDO_USER="${SUDO_USER:-root}"
       run_limited "${MEMOH_THEME_INSTALL_TIMEOUT:-240}" ./install.sh \
-        -d "$HOME/.themes" \
+        -d "$theme_dest" \
         -n WhiteSur \
         -c dark \
         -o normal \
@@ -106,7 +165,7 @@ install_macos_theme_assets() {
     (
       cd "$theme_cache/WhiteSur-icon-theme"
       run_limited "${MEMOH_THEME_INSTALL_TIMEOUT:-180}" ./install.sh \
-        -d "$HOME/.local/share/icons" \
+        -d "$icon_dest" \
         -n WhiteSur \
         -t default \
         -a
@@ -121,29 +180,30 @@ install_macos_theme_assets() {
   fi
 
   if clone_or_update_theme_repo https://github.com/x64Bits/plank-themes.git "$theme_cache/plank-themes"; then
-    find "$theme_cache/plank-themes" -mindepth 1 -maxdepth 1 -type d ! -name .git -exec cp -a {} "$HOME/.local/share/plank/themes/" \; 2>/dev/null || true
+    find "$theme_cache/plank-themes" -mindepth 1 -maxdepth 1 -type d ! -name .git -exec cp -a {} "$plank_dest/" \; 2>/dev/null || true
   fi
 
   if clone_or_update_theme_repo https://github.com/vinceliuice/WhiteSur-wallpapers.git "$theme_cache/WhiteSur-wallpapers"; then
-    find "$theme_cache/WhiteSur-wallpapers" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) -exec cp -a {} "$HOME/.local/share/backgrounds/WhiteSur/" \; 2>/dev/null || true
+    find "$theme_cache/WhiteSur-wallpapers" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \) -exec cp -a {} "$wallpaper_dest/" \; 2>/dev/null || true
   fi
 }
 
 install_debian_style_extras() {
   display_style_enabled || return 0
+  has_macos_theme_assets && return 0
   if [ "${MEMOH_APT_INDEX_UPDATED:-0}" != "1" ]; then
     apt_get update && MEMOH_APT_INDEX_UPDATED=1 || true
   fi
-  has_macos_theme_assets && return 0
   progress 54 desktop "Installing macOS desktop theme dependencies"
-  install_debian_optional sudo git unzip bash sassc libglib2.0-bin libglib2.0-dev-bin libglib2.0-dev libxml2-utils gtk2-engines-murrine gtk2-engines-pixbuf plank papirus-icon-theme arc-theme fonts-inter gnome-themes-extra bibata-cursor-theme xfce4-appmenu-plugin xfce4-windowck-plugin appmenu-gtk2-module appmenu-gtk3-module appmenu-registrar
+  install_debian_optional sudo git unzip bash sassc libglib2.0-bin libglib2.0-dev-bin libglib2.0-dev libxml2-utils librsvg2-common gtk2-engines-murrine gtk2-engines-pixbuf plank papirus-icon-theme arc-theme fonts-inter gnome-themes-extra bibata-cursor-theme xfce4-appmenu-plugin xfce4-windowck-plugin appmenu-gtk2-module appmenu-gtk3-module appmenu-registrar
+  has_macos_theme_assets && return 0
   install_macos_theme_assets
 }
 
 install_alpine_style_extras() {
   display_style_enabled || return 0
   has_macos_theme_assets && return 0
-  install_alpine_optional sudo git unzip bash sassc glib-dev libxml2-utils plank papirus-icon-theme arc-theme font-inter
+  install_alpine_optional sudo git unzip bash sassc glib-dev libxml2-utils librsvg plank papirus-icon-theme arc-theme font-inter
   install_macos_theme_assets
 }
 

--- a/scripts/desktop-style.sh
+++ b/scripts/desktop-style.sh
@@ -162,10 +162,35 @@ start_appmenu_registrar() {
   nohup "$registrar" >/tmp/memoh-appmenu-registrar.log 2>&1 &
 }
 
+memoh_logo_png_base64() {
+  cat <<'EOF'
+iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAADGvAAAyCACUCpAZAAAFaklEQVR4nO2ZeYxdUxzHf0VrLKMtqqbVGqVii2omlmRS6z+W2KOJSK2xRDSxRlAMTZAQYgmNCk1FUCSNLQhasf2jKQ2tEWos1VqnaItixvfTc27nvOPed+99b+aZJr7JJ+8u59z7+9177u/8fucN6e3ttU1ZW/zXBtSr/x3oZx0lHhQ/iKnii7wOg82BDjHBc4q4K69DmgNDRG/w2yhNFAcG+0uKdEpzAKMni9linThTdNVpXBEdL7b025+Kt4p0yhpC00Wb3z5H3FiXacV0arD9nPijSKcsB/4OtkfWalGGGJrN4pfg2F7WN3y499yiF8tyILz4NmWsy9FYcZ54JLrHtWKo32YIXy6eFK9azpvIcmBNsL1tjlFNYgexo/8dIbYz95TpO1yMFq1+f4b4yvcdJu4U0yKbpnmWiXvFQ+LPMg78WsWBFnGIaDf3se8pxojNonYEgLXmHgbx/GVzT/5bMcrcR3ul2DvDBvPn7jf31vgu3y3qQPgGhvlf4vJZ4jBzTzXRN+JFsUh8ZC5ifWduiPwm1oueoP1Yfx0mqj2qGB+KgLJAXCpmlXVgX/G+mBQc+1A84w1ne11BQ9AKcYtnnDhCXCYOyOlHiH3A3Ii4IzlY5CNu8aA3xO3iJauMVLWKb4GI84SYL44p0If7fynmsVM0legWV5gbwwMhhtnF4gNzASBP94k3xco0B3YStwb7n4sTzA2VgVSXeF2cVKAtQYBQe1WaA3PEPn6bJ98I4xO9Y8UcQGeImbEDF1rlOOywxhmPukq05btsDx1gEuqILja7bpP6xBObIl4TT2W0+bnkNaeEDjBR7BzsP2Yujsc6WBwtllYxJBYh8xq/fYG5VLkzpV3qbFtFkxIH+PLPD04w8cxP6XCaOceSvIUYvjDnJqQR04N9krmtMtpunnOtWOMSB/hQxwQnltu/CwpufIP1GY9GFbgJqUaYjvxo2aViU4HrhRqeODA1OvGeudgcihRgt+hY2jDIM4osszujbXOB64UagQNkke3RiUUpjXmKYWpNyMuLUPQhtjPxHCReETOrtB+dc71YTThADrJ9dOLjlMYcI/U9USw2l7/0pLRDPJR7zEWd/a3yG6imiQXbJVqNA23RQQqKrzM6kE5QfIRFxnhzAeAncyk1BuMkGevjVplX5WlyibZoDQ7sFx0kdGaNURRXSMzaM6JjDMG7xaMljNnVnPNltOENtEYHMTAt/meJzJSalvHLkKI+WF7SEHSylS9fVyQfcageyx7bWeq0YhEpS8wLl9TQ7xMciEvGoVYZ6xshhuDuNfRbggNx/s1rpDBfWa9VBcXsfnUN/Rgli3Fg6+gE0zlrk8vqNKyIqI1nWfkUAn0mOnGAFYh48epw8UJdplXXLuJmc6t+tYoJcj0OUMDHDpBa3GSVxX1/iDB5tqfeFb+NNXGakUxOzKTn1nkTJjNWNY4Ux5pLJ2oZLrGonVlm2eDA95a+uMTr5YnNMZf3MDszq4brPBjDcgcfPk+UjHaCN5plGCa5Fut/UV/0Jg4Qvw/NaNhmfalGt4fVNgoP0oZh3vhmTyPCL3XKvGQHBxZaZTGTpZHW/yvVZcU60kXhARxgdW2VVZaTg1Gs/p1ubm11o3Bgtbje+reA72+Rm2H82/GJpCJj+bpVXNc4mwqLhTVWpxeknQxXJchHCE/E/2pL3o0S9cXD4jZzdXSq4oUtlkmeF8eZS2/5H2B8SruBEOGZ/IvFBL7LZ82l5lWVZhjj7WkPaS6FPCsLlHut5mI9KThJIHkU80ASTingWbUm1P4u/vKGcU0+QiZNFq94uvyZzf8Iq7zhK7zBa8t4nfdkufFSz6DUYPunvrQ2eQf+AYv3BU4h7cP0AAAAAElFTkSuQmCC
+EOF
+}
+
+write_memoh_logo_png() {
+  file="$1"
+  has_cmd base64 || return 0
+  mkdir -p "$(dirname "$file")"
+  memoh_logo_png_base64 | base64 -d >"$file" 2>/dev/null ||
+    memoh_logo_png_base64 | base64 --decode >"$file" 2>/dev/null ||
+    rm -f "$file"
+}
+
 install_topbar_menu_icon() {
-  icon_dir="$HOME/.local/share/icons/hicolor/scalable/apps"
-  mkdir -p "$icon_dir"
-  cat >"$icon_dir/memoh-logo-white.svg" <<'EOF'
+  for icon_dir in \
+    "$HOME/.local/share/icons/hicolor/48x48/apps" \
+    /usr/local/share/icons/hicolor/48x48/apps \
+    /usr/share/icons/hicolor/48x48/apps; do
+    write_memoh_logo_png "$icon_dir/memoh-logo-white.png"
+  done
+
+  for icon_dir in \
+    "$HOME/.local/share/icons/hicolor/scalable/apps" \
+    /usr/local/share/icons/hicolor/scalable/apps \
+    /usr/share/icons/hicolor/scalable/apps; do
+    mkdir -p "$icon_dir"
+    cat >"$icon_dir/memoh-logo-white.svg" <<'EOF'
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 454.08 399.96">
   <path fill="#f5f5f7" d="M249.55,307.07c-63.11,20.61-155.69,25.5-182.38,6.68-34.57-24.37-19.05-137.12,7.42-173.36,32.66-44.71,114.75-54.31,152.82-55.97,44.88-1.96,50.44-30.49,50.44-30.49-15.46,14.29-17.33,16.35-64.32,18.23-33.97,1.36-87.49,3.88-130.26,27.67l-2.72-56.39c-.4-8.24-7.4-14.59-15.63-14.2-8.24.4-14.59,7.4-14.2,15.63l3.68,76.38c-4.98,4.93-9.62,10.35-13.82,16.35C3.89,189.99-1.8,249.58.42,297.41c.81,17.44,2.49,31.96,6.82,44.21,0,0,0,.01.01.03.6,1.19,22.35,43.42,104.6,34.64,83.45-8.9,172.88-57.76,208.36-119.64-13.8,23.41-35.2,38.86-70.67,50.43Z"/>
   <path fill="#f5f5f7" d="M429.45,110.2c-23.96-30.8-56.39-44.77-79.74-51.1l13.35-39.38c2.65-7.81-1.54-16.29-9.35-18.93h0c-7.81-2.65-16.29,1.54-18.93,9.35l-14.85,43.78c-8.49,25.06-53.64,36.67-53.64,36.67,0,0,11.72-1.65,40.22,7.62,28.5,9.29,34.21,37.45,31.07,93.85-1.36,24.71-6.6,46.33-17.36,64.57-35.48,61.88-124.9,110.75-208.36,119.64-82.26,8.78-104-33.45-104.6-34.64,2.24,6.32,5.18,12.03,9.07,17.2,13.1,17.4,32.05,24.78,47.08,28.94,81.61,22.55,233.81,7.12,244.66,5.97,24.35-2.57,51.97-5.92,79.03-25.32,5.4-3.87,22.47-18.21,39.94-46.21,25.47-40.82,44.25-158.22,2.42-212.01Z"/>
@@ -174,8 +199,268 @@ install_topbar_menu_icon() {
   <path fill="#f5f5f7" d="M249.71,207.88h0c12.32-.73,22.48-9.91,24.45-22.09l2-12.31c1.56-9.59-6.18-18.15-15.87-17.57h0c-12.32.73-22.48,9.91-24.45,22.09l-2,12.31c-1.56,9.59,6.18,18.15,15.87,17.57Z"/>
 </svg>
 EOF
+  done
+
   if has_cmd gtk-update-icon-cache; then
-    gtk-update-icon-cache -q "$HOME/.local/share/icons/hicolor" >/dev/null 2>&1 || true
+    for theme_root in "$HOME/.local/share/icons/hicolor" /usr/local/share/icons/hicolor /usr/share/icons/hicolor; do
+      [ -d "$theme_root" ] || continue
+      gtk-update-icon-cache -q "$theme_root" >/dev/null 2>&1 || true
+    done
+  fi
+}
+
+link_or_copy_icon() {
+  dest="$1"
+  shift
+  mkdir -p "$(dirname "$dest")"
+  for src in "$@"; do
+    [ -f "$src" ] || continue
+    ln -sf "$src" "$dest" 2>/dev/null || cp -f "$src" "$dest" 2>/dev/null || true
+    [ -f "$dest" ] || [ -L "$dest" ] && return 0
+  done
+  return 1
+}
+
+file_manager_icon_path() {
+  first_existing_file \
+    /usr/local/share/icons/WhiteSur-dark/places/scalable/folder-blue.svg \
+    /usr/local/share/icons/WhiteSur-dark/places/24/folder-blue.svg \
+    /usr/local/share/icons/WhiteSur-dark/places/22/folder-blue.svg \
+    /usr/local/share/icons/WhiteSur/places/scalable/folder-blue.svg \
+    /usr/local/share/icons/WhiteSur/places/24/folder-blue.svg \
+    /usr/local/share/icons/WhiteSur/places/22/folder-blue.svg \
+    /usr/share/icons/Papirus/64x64/places/folder-blue.svg \
+    /usr/share/icons/Papirus/48x48/places/folder-blue.svg \
+    /usr/share/icons/Papirus/24x24/places/folder-blue.svg
+}
+
+install_file_manager_icon_aliases() {
+  icon="$(file_manager_icon_path 2>/dev/null || true)"
+  [ -n "$icon" ] || return 0
+
+  for root in "$HOME/.local/share/icons/hicolor" /usr/local/share/icons/hicolor /usr/share/icons/hicolor; do
+    for size in 16 22 24 32 48 64 128 scalable; do
+      dir="$root/${size}x${size}/apps"
+      [ "$size" = "scalable" ] && dir="$root/scalable/apps"
+      mkdir -p "$dir"
+      for name in memoh-files system-file-manager org.xfce.filemanager org.xfce.thunar file-manager user-file-manager Thunar thunar thunar-filemanager; do
+        rm -f "$dir/$name.png" "$dir/$name.svg"
+        link_or_copy_icon "$dir/$name.svg" "$icon" >/dev/null 2>&1 || true
+      done
+    done
+  done
+
+  if has_cmd gtk-update-icon-cache; then
+    for theme_root in "$HOME/.local/share/icons/hicolor" /usr/local/share/icons/hicolor /usr/share/icons/hicolor; do
+      [ -d "$theme_root" ] || continue
+      gtk-update-icon-cache -q "$theme_root" >/dev/null 2>&1 || true
+    done
+  fi
+}
+
+install_memoh_icon_theme() {
+  icon_theme_path WhiteSur-dark >/dev/null 2>&1 || return 0
+  install_file_manager_icon_aliases
+
+  theme_dir="$HOME/.local/share/icons/Memoh-WhiteSur-dark"
+  mkdir -p \
+    "$theme_dir/apps/22" "$theme_dir/apps/scalable" \
+    "$theme_dir/places/16" "$theme_dir/places/22" "$theme_dir/places/24" "$theme_dir/places/32" "$theme_dir/places/48" "$theme_dir/places/64" "$theme_dir/places/scalable" \
+    "$theme_dir/mimes/16" "$theme_dir/mimes/22" "$theme_dir/mimes/24" "$theme_dir/mimes/32" "$theme_dir/mimes/48" "$theme_dir/mimes/64" "$theme_dir/mimes/scalable" "$theme_dir/mimes/symbolic"
+
+  cat >"$theme_dir/index.theme" <<'EOF'
+[Icon Theme]
+Name=Memoh-WhiteSur-dark
+Comment=Memoh desktop icon theme overlay for WhiteSur-dark.
+Inherits=WhiteSur-dark,WhiteSur,Papirus-Dark,Papirus,hicolor
+Directories=apps/22,apps/scalable,places/16,places/22,places/24,places/32,places/48,places/64,places/scalable,mimes/16,mimes/22,mimes/24,mimes/32,mimes/48,mimes/64,mimes/scalable,mimes/symbolic
+
+[apps/22]
+Size=22
+Context=Applications
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[apps/scalable]
+Size=256
+Context=Applications
+Type=Scalable
+MinSize=16
+MaxSize=512
+
+[places/16]
+Size=16
+Context=Places
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[places/22]
+Size=22
+Context=Places
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[places/24]
+Size=24
+Context=Places
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[places/32]
+Size=32
+Context=Places
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[places/48]
+Size=48
+Context=Places
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[places/64]
+Size=64
+Context=Places
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[places/scalable]
+Size=256
+Context=Places
+Type=Scalable
+MinSize=16
+MaxSize=512
+
+[mimes/16]
+Size=16
+Context=MimeTypes
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[mimes/22]
+Size=22
+Context=MimeTypes
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[mimes/24]
+Size=24
+Context=MimeTypes
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[mimes/32]
+Size=32
+Context=MimeTypes
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[mimes/48]
+Size=48
+Context=MimeTypes
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[mimes/64]
+Size=64
+Context=MimeTypes
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+[mimes/scalable]
+Size=256
+Context=MimeTypes
+Type=Scalable
+MinSize=16
+MaxSize=512
+
+[mimes/symbolic]
+Size=16
+Context=MimeTypes
+Type=Scalable
+MinSize=16
+MaxSize=512
+EOF
+
+  for size in 22 scalable; do
+    for name in memoh-files system-file-manager org.xfce.filemanager org.xfce.thunar file-manager user-file-manager Thunar thunar thunar-filemanager; do
+      link_or_copy_icon "$theme_dir/apps/$size/$name.svg" \
+        "/usr/local/share/icons/WhiteSur-dark/places/$size/folder-blue.svg" \
+        "/usr/local/share/icons/WhiteSur/places/$size/folder-blue.svg" \
+        "/usr/local/share/icons/WhiteSur-dark/places/$size/folder.svg" \
+        "/usr/local/share/icons/WhiteSur/places/$size/folder.svg" \
+        /usr/share/icons/Papirus/64x64/apps/system-file-manager.svg \
+        /usr/share/icons/Papirus/48x48/apps/system-file-manager.svg \
+        /usr/share/icons/Papirus/24x24/apps/system-file-manager.svg >/dev/null 2>&1 || true
+    done
+  done
+
+  for global_theme_dir in /usr/local/share/icons/WhiteSur-dark /usr/local/share/icons/WhiteSur; do
+    [ -d "$global_theme_dir" ] || continue
+    for size in 22 scalable; do
+      for name in memoh-files system-file-manager org.xfce.filemanager org.xfce.thunar file-manager user-file-manager Thunar thunar thunar-filemanager; do
+        link_or_copy_icon "$global_theme_dir/apps/$size/$name.svg" \
+          "$global_theme_dir/places/$size/folder-blue.svg" \
+          "$global_theme_dir/places/scalable/folder-blue.svg" \
+          "$global_theme_dir/places/$size/folder.svg" \
+          "$global_theme_dir/places/scalable/folder.svg" >/dev/null 2>&1 || true
+      done
+    done
+  done
+
+  for size in 16 22 24 32 48 64 scalable; do
+    link_or_copy_icon "$theme_dir/places/$size/folder.svg" \
+      "/usr/local/share/icons/WhiteSur-dark/places/$size/folder.svg" \
+      "/usr/local/share/icons/WhiteSur/places/$size/folder.svg" \
+      /usr/share/icons/Papirus/64x64/places/folder.svg \
+      /usr/share/icons/Papirus/48x48/places/folder.svg \
+      /usr/share/icons/Papirus/24x24/places/folder.svg >/dev/null 2>&1 || true
+    link_or_copy_icon "$theme_dir/mimes/$size/inode-directory.svg" \
+      "$theme_dir/places/$size/folder.svg" \
+      "/usr/local/share/icons/WhiteSur-dark/places/$size/folder.svg" \
+      "/usr/local/share/icons/WhiteSur/places/$size/folder.svg" >/dev/null 2>&1 || true
+  done
+  link_or_copy_icon "$theme_dir/mimes/symbolic/inode-directory-symbolic.svg" \
+    /usr/local/share/icons/WhiteSur-dark/places/symbolic/folder-symbolic.svg \
+    /usr/local/share/icons/WhiteSur/places/symbolic/folder-symbolic.svg >/dev/null 2>&1 || true
+
+  for name in \
+    text-x-generic text-x-script text-x-python text-x-javascript text-markdown text-css text-html text-rust text-x-go text-x-csrc text-x-c++src text-x-cpp \
+    application-json application-xml application-x-shellscript application-x-executable application-octet-stream application-x-zerosize application-pdf application-zip application-x-archive application-x-compressed-tar \
+    image-x-generic audio-x-generic media-video x-office-document x-office-spreadsheet x-office-presentation package-x-generic; do
+    for size in 16 22 24 32 48 64 scalable; do
+      link_or_copy_icon "$theme_dir/mimes/$size/$name.svg" \
+        "/usr/local/share/icons/WhiteSur/mimes/$size/$name.svg" \
+        "/usr/local/share/icons/WhiteSur/mimes/scalable/$name.svg" \
+        "/usr/local/share/icons/WhiteSur-dark/mimes/symbolic/$name-symbolic.svg" \
+        "/usr/local/share/icons/WhiteSur/mimes/symbolic/$name-symbolic.svg" \
+        "/usr/share/icons/Papirus/64x64/mimetypes/$name.svg" \
+        "/usr/share/icons/Papirus/48x48/mimetypes/$name.svg" \
+        "/usr/share/icons/Papirus/24x24/mimetypes/$name.svg" >/dev/null 2>&1 || true
+    done
+    link_or_copy_icon "$theme_dir/mimes/symbolic/$name-symbolic.svg" \
+      "/usr/local/share/icons/WhiteSur-dark/mimes/symbolic/$name-symbolic.svg" \
+      "/usr/local/share/icons/WhiteSur/mimes/symbolic/$name-symbolic.svg" \
+      "/usr/local/share/icons/WhiteSur/mimes/scalable/$name.svg" >/dev/null 2>&1 || true
+  done
+
+  if has_cmd gtk-update-icon-cache; then
+    gtk-update-icon-cache -q "$theme_dir" >/dev/null 2>&1 || true
+    gtk-update-icon-cache -q /usr/local/share/icons/WhiteSur-dark >/dev/null 2>&1 || true
+    gtk-update-icon-cache -q /usr/local/share/icons/WhiteSur >/dev/null 2>&1 || true
   fi
 }
 
@@ -347,9 +632,11 @@ configure_wallpaper() {
 configure_xfce() {
   wait_for_xfconf || return 0
 
+  install_memoh_icon_theme
+
   gtk_theme="${MEMOH_DISPLAY_GTK_THEME:-$(first_theme WhiteSur-Dark-solid-alt WhiteSur-Dark-alt WhiteSur-Dark-solid WhiteSur-Dark WhiteSur-dark-solid-alt WhiteSur-dark-alt WhiteSur-dark-solid WhiteSur-dark WhiteSur-Light-solid-alt WhiteSur-Light-alt WhiteSur-Light-solid WhiteSur-Light WhiteSur Arc-Dark Arc Adwaita-dark Adwaita 2>/dev/null || true)}"
   xfwm_theme="${MEMOH_DISPLAY_XFWM_THEME:-$(first_xfwm_theme "$gtk_theme" WhiteSur-Dark-solid-alt WhiteSur-Dark-alt WhiteSur-Dark-solid WhiteSur-Dark WhiteSur-dark-solid-alt WhiteSur-dark-alt WhiteSur-dark-solid WhiteSur-dark WhiteSur-Light-solid-alt WhiteSur-Light-alt WhiteSur-Light-solid WhiteSur-Light WhiteSur Arc-Dark Arc Adwaita-dark Adwaita 2>/dev/null || true)}"
-  icons="${MEMOH_DISPLAY_ICON_THEME:-$(first_icon_theme WhiteSur-dark WhiteSur-Dark WhiteSur WhiteSur-light WhiteSur-Light Cupertino McMojave-circle-dark McMojave-circle Papirus-Dark Papirus Adwaita 2>/dev/null || true)}"
+  icons="${MEMOH_DISPLAY_ICON_THEME:-$(first_icon_theme Memoh-WhiteSur-dark WhiteSur-dark WhiteSur-Dark WhiteSur WhiteSur-light WhiteSur-Light Cupertino McMojave-circle-dark McMojave-circle Papirus-Dark Papirus Adwaita 2>/dev/null || true)}"
   cursor="${MEMOH_DISPLAY_CURSOR_THEME:-$(first_icon_theme WhiteSur-cursors WhiteSur Bibata-Modern-Classic Bibata-Modern-Ice Adwaita 2>/dev/null || true)}"
   font="$(first_font Inter 'SF Pro Display' 'Noto Sans' Cantarell Sans)"
 
@@ -378,6 +665,7 @@ configure_xfce() {
 
   xfconf_set xfce4-desktop /desktop-icons/style int 0
 
+  configure_topbar
   xfconf_set xfce4-panel /panels/panel-1/mode int 0
   xfconf_set xfce4-panel /panels/panel-1/position string "p=6;x=0;y=0"
   xfconf_set xfce4-panel /panels/panel-1/position-locked bool true
@@ -385,7 +673,6 @@ configure_xfce() {
   xfconf_set xfce4-panel /panels/panel-1/length int 100
   xfconf_set xfce4-panel /panels/panel-1/length-adjust bool false
   xfconf_set xfce4-panel /panels/panel-1/autohide-behavior int 0
-  configure_topbar
 }
 
 write_desktop_file() {
@@ -393,6 +680,7 @@ write_desktop_file() {
   name="$2"
   icon="$3"
   exec_cmd="$4"
+  categories="${5:-Utility;}"
   [ -n "$exec_cmd" ] || return 1
   mkdir -p "$(dirname "$file")"
   cat >"$file" <<EOF
@@ -402,7 +690,7 @@ Name=${name}
 Icon=${icon}
 Exec=${exec_cmd}
 Terminal=false
-Categories=Utility;
+Categories=${categories}
 EOF
 }
 
@@ -471,20 +759,36 @@ browser_desktop_file() {
 }
 
 terminal_desktop_file() {
+  terminal="$(command -v xfce4-terminal 2>/dev/null || command -v xterm 2>/dev/null || true)"
+  if [ -n "$terminal" ]; then
+    file="$HOME/.local/share/applications/memoh-terminal.desktop"
+    write_desktop_file "$file" "Terminal" "utilities-terminal" "$terminal"
+    printf '%s\n' "$file"
+    return 0
+  fi
+
   first_existing_file \
     /usr/share/applications/xfce4-terminal.desktop \
     /usr/share/applications/org.xfce.terminal.desktop \
     /usr/share/applications/debian-xterm.desktop \
     /usr/local/share/applications/xfce4-terminal.desktop && return 0
-
-  terminal="$(command -v xfce4-terminal 2>/dev/null || command -v xterm 2>/dev/null || true)"
-  [ -n "$terminal" ] || return 1
-  file="$HOME/.local/share/applications/memoh-terminal.desktop"
-  write_desktop_file "$file" "Terminal" "utilities-terminal" "$terminal"
-  printf '%s\n' "$file"
 }
 
 files_desktop_file() {
+  manager="$(command -v thunar 2>/dev/null || true)"
+  if [ -n "$manager" ]; then
+    file="$HOME/.local/share/applications/memoh-files.desktop"
+    icon="$(file_manager_icon_path 2>/dev/null || true)"
+    [ -n "$icon" ] || icon="system-file-manager"
+    write_desktop_file "$file" "Files" "$icon" "$manager ${HOME:-/data}" "System;FileManager;"
+    cat >>"$file" <<'EOF'
+StartupNotify=true
+MimeType=inode/directory;
+EOF
+    printf '%s\n' "$file"
+    return 0
+  fi
+
   first_existing_file \
     /usr/share/applications/thunar.desktop \
     /usr/share/applications/org.xfce.Thunar.desktop \
@@ -566,6 +870,11 @@ restart_plank() {
   nohup plank >/tmp/memoh-plank.log 2>&1 &
 }
 
+restart_file_manager() {
+  has_cmd thunar || return 0
+  thunar -q >/dev/null 2>&1 || thunar --quit >/dev/null 2>&1 || true
+}
+
 restart_xfce_panel() {
   has_cmd xfce4-panel || return 0
   pids="$(ps -ef 2>/dev/null | grep -E '[ /]xfce4-panel($| )' | grep -v grep | awk '{print $2}' || true)"
@@ -581,10 +890,96 @@ restart_xfce_panel() {
 }
 
 reload_xfce_components() {
+  restart_file_manager
   if has_cmd xfwm4; then
     nohup xfwm4 --replace >/tmp/memoh-xfwm4-replace.log 2>&1 &
   fi
   restart_xfce_panel
+}
+
+xfconf_value() {
+  channel="$1"
+  property="$2"
+  xfconf-query -c "$channel" -p "$property" 2>/dev/null || true
+}
+
+require_xfconf_value() {
+  channel="$1"
+  property="$2"
+  expected="$3"
+  actual="$(xfconf_value "$channel" "$property")"
+  [ "$actual" = "$expected" ] && return 0
+  echo "Expected $channel $property to be '$expected', got '${actual:-<empty>}'." >&2
+  return 1
+}
+
+verify_xfce_style() {
+  has_cmd xfconf-query || return 0
+  if ! wait_for_xfconf; then
+    echo "xfconf is not ready; desktop style could not be verified." >&2
+    return 1
+  fi
+
+  failed=0
+  require_xfconf_value xsettings /Gtk/ToolbarStyle icons || failed=1
+  if [ -z "${MEMOH_DISPLAY_ICON_THEME:-}" ] && icon_theme_path Memoh-WhiteSur-dark >/dev/null 2>&1; then
+    require_xfconf_value xsettings /Net/IconThemeName Memoh-WhiteSur-dark || failed=1
+  fi
+  require_xfconf_value xfwm4 /general/button_layout 'CHM|' || failed=1
+  require_xfconf_value xfce4-panel /panels/panel-1/position 'p=6;x=0;y=0' || failed=1
+  require_xfconf_value xfce4-panel /plugins/plugin-101 applicationsmenu || failed=1
+  return "$failed"
+}
+
+verify_file_manager_style() {
+  has_cmd thunar || return 0
+  launcher="$HOME/.local/share/applications/memoh-files.desktop"
+  [ -f "$launcher" ] || { echo "Files launcher was not written." >&2; return 1; }
+  grep -q '^Name=Files$' "$launcher" || { echo "Files launcher name is not set." >&2; return 1; }
+  if file_manager_icon_path >/dev/null 2>&1; then
+    grep -q '^Icon=.*/folder-blue.svg$' "$launcher" || { echo "Files launcher icon is not themed." >&2; return 1; }
+  else
+    grep -q '^Icon=system-file-manager$' "$launcher" || { echo "Files launcher icon is not themed." >&2; return 1; }
+  fi
+
+  theme_dir="$HOME/.local/share/icons/Memoh-WhiteSur-dark"
+  [ -d "$theme_dir" ] || return 0
+  [ -f "$theme_dir/apps/22/system-file-manager.svg" ] || [ -L "$theme_dir/apps/22/system-file-manager.svg" ] || {
+    echo "Files icon alias was not installed." >&2
+    return 1
+  }
+  [ -f "$HOME/.local/share/icons/hicolor/64x64/apps/system-file-manager.svg" ] || [ -L "$HOME/.local/share/icons/hicolor/64x64/apps/system-file-manager.svg" ] || {
+    echo "Files hicolor icon was not installed." >&2
+    return 1
+  }
+  [ -f "$theme_dir/places/24/folder.svg" ] || [ -L "$theme_dir/places/24/folder.svg" ] || {
+    echo "Folder icon alias was not installed." >&2
+    return 1
+  }
+  [ -f "$theme_dir/mimes/24/text-x-generic.svg" ] || [ -L "$theme_dir/mimes/24/text-x-generic.svg" ] || {
+    echo "MIME icon aliases were not installed." >&2
+    return 1
+  }
+}
+
+verify_plank_style() {
+  has_cmd plank || return 0
+  settings="$HOME/.config/plank/dock1/settings"
+  [ -f "$settings" ] || { echo "Plank settings were not written." >&2; return 1; }
+  grep -q '^DockItems=01-browser.dockitem;02-terminal.dockitem;03-files.dockitem;' "$settings" || {
+    echo "Plank dock items were not configured." >&2
+    return 1
+  }
+}
+
+verify_style() {
+  verify_xfce_style
+  xfce_status=$?
+  verify_file_manager_style
+  files_status=$?
+  verify_plank_style
+  plank_status=$?
+  [ "$xfce_status" -eq 0 ] && [ "$files_status" -eq 0 ] && [ "$plank_status" -eq 0 ]
 }
 
 run_xsetroot
@@ -593,5 +988,7 @@ configure_wallpaper
 configure_plank
 restart_plank
 reload_xfce_components
-
-exit 0
+if verify_style; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary
- Make display preparation apply the desktop style synchronously before reporting ready.
- Add a versioned desktop style marker and lock so reconnects only retry when the style is missing or stale.
- Improve style failure diagnostics with `/tmp/memoh-desktop-style.log` tail output and add lightweight XFCE/Plank verification.
- Move the frontend 15s connection timeout so it only covers WebRTC negotiation after prepare completes.

## Validation
- `go test ./internal/handlers ./internal/workspace/bridge ./internal/workspace/bridgesvc`
- `sh -n scripts/desktop-style.sh`
- `pnpm test apps/web/src/pages/home/components/display-pane.timeout.test.ts --run`
- `pnpm --filter @memohai/web build`
- `go test ./...` via pre-commit hook

## Notes
- `pnpm test -- --run` still has existing failures outside this change: `keyboard-bindings.test.ts`, `workspace-tabs.test.ts`, and `provider-presets.test.ts`. The new Display timeout test passes in that run.