### PR TITLE
fix(sqlite): normalize message timestamp cursors

### DIFF
--- a/db/sqlite/queries/messages.sql
+++ b/db/sqlite/queries/messages.sql
@@ -79,7 +79,7 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.bot_id = sqlc.arg(bot_id)
-  AND m.created_at >= sqlc.arg(created_at)
+  AND m.created_at >= strftime('%Y-%m-%d %H:%M:%S', sqlc.arg(created_at))
 ORDER BY m.created_at ASC;
 
 -- name: ListMessagesSinceBySession :many
@@ -96,7 +96,7 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.session_id = sqlc.arg(session_id)
-  AND m.created_at >= sqlc.arg(created_at)
+  AND m.created_at >= strftime('%Y-%m-%d %H:%M:%S', sqlc.arg(created_at))
 ORDER BY m.created_at ASC;
 
 -- name: ListActiveMessagesSince :many
@@ -113,7 +113,7 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.bot_id = sqlc.arg(bot_id)
-  AND m.created_at >= sqlc.arg(created_at)
+  AND m.created_at >= strftime('%Y-%m-%d %H:%M:%S', sqlc.arg(created_at))
   AND (json_extract(m.metadata, '$.trigger_mode') IS NULL OR json_extract(m.metadata, '$.trigger_mode') != 'passive_sync')
 ORDER BY m.created_at ASC;
 
@@ -131,7 +131,7 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.session_id = sqlc.arg(session_id)
-  AND m.created_at >= sqlc.arg(created_at)
+  AND m.created_at >= strftime('%Y-%m-%d %H:%M:%S', sqlc.arg(created_at))
   AND (json_extract(m.metadata, '$.trigger_mode') IS NULL OR json_extract(m.metadata, '$.trigger_mode') != 'passive_sync')
 ORDER BY m.created_at ASC;
 
@@ -149,7 +149,7 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.bot_id = sqlc.arg(bot_id)
-  AND m.created_at < sqlc.arg(created_at)
+  AND m.created_at < strftime('%Y-%m-%d %H:%M:%S', sqlc.arg(created_at))
 ORDER BY m.created_at DESC
 LIMIT sqlc.arg(max_count);
 
@@ -167,7 +167,7 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.session_id = sqlc.arg(session_id)
-  AND m.created_at < sqlc.arg(created_at)
+  AND m.created_at < strftime('%Y-%m-%d %H:%M:%S', sqlc.arg(created_at))
 ORDER BY m.created_at DESC
 LIMIT sqlc.arg(max_count);
 
@@ -237,7 +237,7 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.session_id = sqlc.arg(session_id)
-  AND m.created_at > sqlc.arg(created_at)
+  AND m.created_at > strftime('%Y-%m-%d %H:%M:%S', sqlc.arg(created_at))
 ORDER BY m.created_at ASC
 LIMIT sqlc.arg(max_count);
 
@@ -332,8 +332,8 @@ LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.bot_id = sqlc.arg(bot_id)
   AND (sqlc.narg(session_id) IS NULL OR m.session_id = sqlc.narg(session_id))
   AND (sqlc.narg(contact_id) IS NULL OR m.sender_channel_identity_id = sqlc.narg(contact_id))
-  AND (sqlc.narg(start_time) IS NULL OR m.created_at >= sqlc.narg(start_time))
-  AND (sqlc.narg(end_time) IS NULL OR m.created_at <= sqlc.narg(end_time))
+  AND (sqlc.narg(start_time) IS NULL OR m.created_at >= strftime('%Y-%m-%d %H:%M:%S', sqlc.narg(start_time)))
+  AND (sqlc.narg(end_time) IS NULL OR m.created_at <= strftime('%Y-%m-%d %H:%M:%S', sqlc.narg(end_time)))
   AND (sqlc.narg(role) IS NULL OR m.role = sqlc.narg(role))
   AND (sqlc.narg(keyword) IS NULL OR (
     CASE

--- a/internal/db/sqlite/sqlc/messages.sql.go
+++ b/internal/db/sqlite/sqlc/messages.sql.go
@@ -229,14 +229,14 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.bot_id = ?1
-  AND m.created_at >= ?2
+  AND m.created_at >= strftime('%Y-%m-%d %H:%M:%S', ?2)
   AND (json_extract(m.metadata, '$.trigger_mode') IS NULL OR json_extract(m.metadata, '$.trigger_mode') != 'passive_sync')
 ORDER BY m.created_at ASC
 `
 
 type ListActiveMessagesSinceParams struct {
-	BotID     string `json:"bot_id"`
-	CreatedAt string `json:"created_at"`
+	BotID     string      `json:"bot_id"`
+	CreatedAt interface{} `json:"created_at"`
 }
 
 type ListActiveMessagesSinceRow struct {
@@ -316,14 +316,14 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.session_id = ?1
-  AND m.created_at >= ?2
+  AND m.created_at >= strftime('%Y-%m-%d %H:%M:%S', ?2)
   AND (json_extract(m.metadata, '$.trigger_mode') IS NULL OR json_extract(m.metadata, '$.trigger_mode') != 'passive_sync')
 ORDER BY m.created_at ASC
 `
 
 type ListActiveMessagesSinceBySessionParams struct {
 	SessionID sql.NullString `json:"session_id"`
-	CreatedAt string         `json:"created_at"`
+	CreatedAt interface{}    `json:"created_at"`
 }
 
 type ListActiveMessagesSinceBySessionRow struct {
@@ -482,14 +482,14 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.session_id = ?1
-  AND m.created_at > ?2
+  AND m.created_at > strftime('%Y-%m-%d %H:%M:%S', ?2)
 ORDER BY m.created_at ASC
 LIMIT ?3
 `
 
 type ListMessagesAfterBySessionParams struct {
 	SessionID sql.NullString `json:"session_id"`
-	CreatedAt string         `json:"created_at"`
+	CreatedAt interface{}    `json:"created_at"`
 	MaxCount  int64          `json:"max_count"`
 }
 
@@ -568,15 +568,15 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.bot_id = ?1
-  AND m.created_at < ?2
+  AND m.created_at < strftime('%Y-%m-%d %H:%M:%S', ?2)
 ORDER BY m.created_at DESC
 LIMIT ?3
 `
 
 type ListMessagesBeforeParams struct {
-	BotID     string `json:"bot_id"`
-	CreatedAt string `json:"created_at"`
-	MaxCount  int64  `json:"max_count"`
+	BotID     string      `json:"bot_id"`
+	CreatedAt interface{} `json:"created_at"`
+	MaxCount  int64       `json:"max_count"`
 }
 
 type ListMessagesBeforeRow struct {
@@ -654,14 +654,14 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.session_id = ?1
-  AND m.created_at < ?2
+  AND m.created_at < strftime('%Y-%m-%d %H:%M:%S', ?2)
 ORDER BY m.created_at DESC
 LIMIT ?3
 `
 
 type ListMessagesBeforeBySessionParams struct {
 	SessionID sql.NullString `json:"session_id"`
-	CreatedAt string         `json:"created_at"`
+	CreatedAt interface{}    `json:"created_at"`
 	MaxCount  int64          `json:"max_count"`
 }
 
@@ -987,13 +987,13 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.bot_id = ?1
-  AND m.created_at >= ?2
+  AND m.created_at >= strftime('%Y-%m-%d %H:%M:%S', ?2)
 ORDER BY m.created_at ASC
 `
 
 type ListMessagesSinceParams struct {
-	BotID     string `json:"bot_id"`
-	CreatedAt string `json:"created_at"`
+	BotID     string      `json:"bot_id"`
+	CreatedAt interface{} `json:"created_at"`
 }
 
 type ListMessagesSinceRow struct {
@@ -1071,13 +1071,13 @@ FROM bot_history_messages m
 LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.session_id = ?1
-  AND m.created_at >= ?2
+  AND m.created_at >= strftime('%Y-%m-%d %H:%M:%S', ?2)
 ORDER BY m.created_at ASC
 `
 
 type ListMessagesSinceBySessionParams struct {
 	SessionID sql.NullString `json:"session_id"`
-	CreatedAt string         `json:"created_at"`
+	CreatedAt interface{}    `json:"created_at"`
 }
 
 type ListMessagesSinceBySessionRow struct {
@@ -1398,8 +1398,8 @@ LEFT JOIN bot_sessions s ON s.id = m.session_id
 WHERE m.bot_id = ?1
   AND (?2 IS NULL OR m.session_id = ?2)
   AND (?3 IS NULL OR m.sender_channel_identity_id = ?3)
-  AND (?4 IS NULL OR m.created_at >= ?4)
-  AND (?5 IS NULL OR m.created_at <= ?5)
+  AND (?4 IS NULL OR m.created_at >= strftime('%Y-%m-%d %H:%M:%S', ?4))
+  AND (?5 IS NULL OR m.created_at <= strftime('%Y-%m-%d %H:%M:%S', ?5))
   AND (?6 IS NULL OR m.role = ?6)
   AND (?7 IS NULL OR (
     CASE

--- a/internal/db/sqlite/store/messages_time_test.go
+++ b/internal/db/sqlite/store/messages_time_test.go
@@ -1,0 +1,99 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/config"
+	"github.com/memohai/memoh/internal/db"
+	pgsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+func TestSQLiteListMessagesBeforeBySessionUsesSQLiteTimestampFormat(t *testing.T) {
+	ctx := context.Background()
+	conn, err := db.OpenSQLite(ctx, config.SQLiteConfig{DSN: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	execAll(t, conn, `
+CREATE TABLE channel_identities (
+  id TEXT PRIMARY KEY,
+  display_name TEXT,
+  avatar_url TEXT
+);
+CREATE TABLE bot_sessions (
+  id TEXT PRIMARY KEY,
+  channel_type TEXT
+);
+CREATE TABLE bot_history_messages (
+  id TEXT PRIMARY KEY,
+  bot_id TEXT NOT NULL,
+  session_id TEXT,
+  sender_channel_identity_id TEXT,
+  sender_account_user_id TEXT,
+  source_message_id TEXT,
+  source_reply_to_message_id TEXT,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL DEFAULT '{}',
+  metadata TEXT NOT NULL DEFAULT '{}',
+  usage TEXT,
+  event_id TEXT,
+  display_text TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`)
+
+	botID := "00000000-0000-0000-0000-000000002001"
+	sessionID := "00000000-0000-0000-0000-000000002002"
+	if _, err := conn.ExecContext(ctx, `INSERT INTO bot_sessions (id, channel_type) VALUES (?, ?)`, sessionID, "local"); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	for _, item := range []struct {
+		id      string
+		role    string
+		content string
+	}{
+		{"00000000-0000-0000-0000-000000002003", "user", `{"role":"user","content":"hello"}`},
+		{"00000000-0000-0000-0000-000000002004", "assistant", `{"role":"assistant","content":"hi"}`},
+	} {
+		_, err := conn.ExecContext(ctx, `
+INSERT INTO bot_history_messages (id, bot_id, session_id, role, content, created_at)
+VALUES (?, ?, ?, ?, ?, ?)`,
+			item.id,
+			botID,
+			sessionID,
+			item.role,
+			item.content,
+			"2026-06-13 19:53:50",
+		)
+		if err != nil {
+			t.Fatalf("insert message %s: %v", item.id, err)
+		}
+	}
+
+	store, err := New(conn)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	q := NewQueries(store)
+
+	rows, err := q.ListMessagesBeforeBySession(ctx, pgsqlc.ListMessagesBeforeBySessionParams{
+		SessionID: mustUUID(t, sessionID),
+		CreatedAt: pgtype.Timestamptz{
+			Time:  time.Date(2026, 6, 13, 19, 53, 50, 0, time.UTC),
+			Valid: true,
+		},
+		MaxCount: 30,
+	})
+	if err != nil {
+		t.Fatalf("list messages before: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("same-second messages must not be returned by before cursor, got %d", len(rows))
+	}
+}


### PR DESCRIPTION
## 背景

Desktop/local 模式使用 SQLite。消息历史分页和定位接口会接收时间 cursor。Web UI 的 older pagination 使用 `UITurn.timestamp` 作为 `before` cursor；该字段来自 Go `time.Time` 的 JSON 序列化，并会在前端通过 `toISOString()` 归一化，因此实际请求值是 RFC3339/ISO 格式，例如：

`2026-06-13T19:53:50Z`

但 SQLite 里的 `created_at` 默认由 `CURRENT_TIMESTAMP` 生成，格式是：

`2026-06-13 19:53:50`

SQLite 查询里直接用文本比较：

`m.created_at < sqlc.arg(created_at)`

会导致同一秒的当前消息被错误判断为“更早消息”。在聊天 UI 切换会话回来并触发 older pagination 时，后端会把当前页再次返回，前端 prepend 后表现为消息重复，例如 `1-2 1-2`。

## 修改

- 只调整 SQLite message 查询里的时间 cursor 比较。
- 将传入参数通过 `strftime('%Y-%m-%d %H:%M:%S', ...)` 归一化到 SQLite `CURRENT_TIMESTAMP` 的文本格式。
- 覆盖 message 的 `since / before / after / search start/end` 时间过滤。
- 重新生成 SQLite sqlc 代码。
- 新增 SQLite 回归测试，验证 RFC3339 cursor 不会把同一秒消息查成 older page。

## 说明

这个 PR 不修改前端逻辑。重复渲染的根因是 SQLite 分页接口错误返回当前页；后端修复后，前端不会再收到重复的 older page。

## 测试

```bash
mise run sqlc-generate
go test ./internal/db/sqlite/store ./internal/message ./internal/handlers
```
