### PR TITLE
feat: add apply_patch tool

### DIFF
--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -134,7 +134,7 @@ watch(() => props.file.path, () => {
   }
 }, { immediate: true })
 
-// Reload the file when the chat agent runs a fs-mutating tool (write/edit/exec)
+// Reload the file when the chat agent runs a fs-mutating tool (write/edit/apply_patch/exec)
 // against the same bot. Skip if the user has unsaved changes — we don't want to
 // silently overwrite their edits.
 const chatStore = useChatStore()

--- a/apps/web/src/components/sidebar/files-pane.vue
+++ b/apps/web/src/components/sidebar/files-pane.vue
@@ -921,7 +921,7 @@ watch(() => props.botId, () => {
   reload()
 }, { immediate: true })
 
-// Auto-refresh listing when the chat agent runs a fs-mutating tool (write/edit/exec).
+// Auto-refresh listing when the chat agent runs a fs-mutating tool (write/edit/apply_patch/exec).
 const chatStore = useChatStore()
 const { fsChangedAt } = storeToRefs(chatStore)
 watch(fsChangedAt, () => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -338,6 +338,7 @@
       "read": "Read",
       "write": "Write",
       "edit": "Edit",
+      "apply_patch": "Patch",
       "list": "List",
       "exec": "Run",
       "bg_status": "Background",
@@ -445,7 +446,8 @@
       "pending": {
         "generic": "Working…",
         "write": "Writing file…",
-        "edit": "Editing…"
+        "edit": "Editing…",
+        "apply_patch": "Applying patch…"
       },
       "detail": {
         "openInFiles": "Open in files",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -334,6 +334,7 @@
       "read": "读取",
       "write": "写入",
       "edit": "编辑",
+      "apply_patch": "应用补丁",
       "list": "列出",
       "exec": "执行",
       "bg_status": "后台任务",
@@ -441,7 +442,8 @@
       "pending": {
         "generic": "处理中…",
         "write": "正在写入文件…",
-        "edit": "正在编辑…"
+        "edit": "正在编辑…",
+        "apply_patch": "正在应用补丁…"
       },
       "detail": {
         "openInFiles": "在文件中打开",

--- a/apps/web/src/pages/home/components/tool-call-detail-apply-patch.vue
+++ b/apps/web/src/pages/home/components/tool-call-detail-apply-patch.vue
@@ -1,0 +1,193 @@
+<template>
+  <div class="space-y-2 text-xs leading-relaxed">
+    <div
+      v-if="summary"
+      class="rounded-sm border border-border bg-muted/30 px-2 py-1 font-mono whitespace-pre-wrap break-all text-muted-foreground"
+    >
+      {{ summary }}
+    </div>
+
+    <div
+      v-if="files.length"
+      class="space-y-1"
+    >
+      <div
+        v-for="file in files"
+        :key="`${file.operation}:${file.path}`"
+        class="flex items-center gap-2 font-mono"
+      >
+        <span
+          class="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-sm border px-1 text-[10px] font-semibold leading-none"
+          :class="operationClass(file.operation)"
+        >
+          {{ operationLabel(file.operation) }}
+        </span>
+        <span
+          class="min-w-0 truncate text-foreground"
+          :title="file.path"
+        >{{ file.path }}</span>
+      </div>
+    </div>
+
+    <div
+      v-if="errorText"
+      class="font-mono whitespace-pre-wrap break-all text-destructive"
+    >
+      {{ errorText }}
+    </div>
+
+    <div
+      v-if="patchText && shiki.loading.value"
+      class="flex items-center gap-1.5 text-xs text-muted-foreground"
+    >
+      <LoaderCircle class="size-3 animate-spin" />
+    </div>
+    <!-- eslint-disable vue/no-v-html -->
+    <div
+      v-else-if="patchText"
+      class="shiki-patch-container max-h-96 overflow-x-auto overflow-y-auto rounded-sm text-xs [&_pre]:m-0 [&_pre]:bg-transparent! [&_pre]:p-2 [&_code]:text-xs"
+      v-html="shiki.html.value"
+    />
+    <!-- eslint-enable vue/no-v-html -->
+
+    <p
+      v-if="!summary && !files.length && !patchText && !errorText"
+      class="text-muted-foreground italic"
+    >
+      {{ t('chat.tools.detail.noData') }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { LoaderCircle } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+import type { ToolCallBlock } from '@/store/chat-list'
+import { useShikiHighlighter } from '@/composables/useShikiHighlighter'
+
+type PatchOperation = 'add' | 'modify' | 'delete'
+
+interface PatchFile {
+  operation: PatchOperation
+  path: string
+}
+
+const props = defineProps<{ block: ToolCallBlock }>()
+const { t } = useI18n()
+const shiki = useShikiHighlighter()
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+function resultObject(): Record<string, unknown> {
+  const result = asObject(props.block.result)
+  const sc = asObject(result.structuredContent)
+  return Object.keys(sc).length > 0 ? sc : result
+}
+
+const patchText = computed(() => {
+  const input = asObject(props.block.input)
+  return typeof input.patch === 'string' ? input.patch : ''
+})
+
+const summary = computed(() => {
+  const r = resultObject()
+  return typeof r.summary === 'string' ? r.summary : ''
+})
+
+const errorText = computed(() => {
+  const result = asObject(props.block.result)
+  if (result.isError !== true) return ''
+  const content = result.content
+  if (!Array.isArray(content)) return ''
+  return (content as Array<Record<string, unknown>>)
+    .filter(item => item.type === 'text')
+    .map(item => item.text)
+    .filter((text): text is string => typeof text === 'string' && text.length > 0)
+    .join('\n')
+})
+
+const files = computed<PatchFile[]>(() => {
+  const fromResult = filesFromResult(resultObject())
+  if (fromResult.length > 0) return fromResult
+  return filesFromPatch(patchText.value)
+})
+
+function filesFromResult(result: Record<string, unknown>): PatchFile[] {
+  const rawFiles = result.files
+  if (Array.isArray(rawFiles)) {
+    return rawFiles
+      .map((item) => {
+        const obj = asObject(item)
+        const path = typeof obj.path === 'string' ? obj.path : ''
+        const operation = normalizeOperation(obj.operation)
+        return path && operation ? { operation, path } : null
+      })
+      .filter((item): item is PatchFile => Boolean(item))
+  }
+
+  const out: PatchFile[] = []
+  for (const [key, operation] of [
+    ['added', 'add'],
+    ['modified', 'modify'],
+    ['deleted', 'delete'],
+  ] as const) {
+    const paths = result[key]
+    if (!Array.isArray(paths)) continue
+    for (const path of paths) {
+      if (typeof path === 'string' && path) out.push({ operation, path })
+    }
+  }
+  return out
+}
+
+function filesFromPatch(patch: string): PatchFile[] {
+  if (!patch) return []
+  const out: PatchFile[] = []
+  for (const rawLine of patch.split('\n')) {
+    const line = rawLine.trim()
+    if (line.startsWith('*** Add File: ')) {
+      const path = line.slice('*** Add File: '.length).trim()
+      if (path) out.push({ operation: 'add', path })
+    }
+    else if (line.startsWith('*** Delete File: ')) {
+      const path = line.slice('*** Delete File: '.length).trim()
+      if (path) out.push({ operation: 'delete', path })
+    }
+    else if (line.startsWith('*** Update File: ')) {
+      const path = line.slice('*** Update File: '.length).trim()
+      if (path) out.push({ operation: 'modify', path })
+    }
+  }
+  return out
+}
+
+function normalizeOperation(value: unknown): PatchOperation | '' {
+  if (value === 'add' || value === 'added') return 'add'
+  if (value === 'modify' || value === 'modified' || value === 'update') return 'modify'
+  if (value === 'delete' || value === 'deleted') return 'delete'
+  return ''
+}
+
+function operationLabel(operation: PatchOperation): string {
+  if (operation === 'add') return 'A'
+  if (operation === 'delete') return 'D'
+  return 'M'
+}
+
+function operationClass(operation: PatchOperation): string {
+  if (operation === 'add') return 'border-success/30 bg-success/10 text-success-foreground'
+  if (operation === 'delete') return 'border-destructive/30 bg-destructive/10 text-destructive'
+  return 'border-warning/30 bg-warning/10 text-warning-foreground'
+}
+
+watch(
+  patchText,
+  (patch) => {
+    if (patch) void shiki.highlightLang(patch, 'diff')
+  },
+  { immediate: true },
+)
+</script>

--- a/apps/web/src/pages/home/components/tool-call-registry.ts
+++ b/apps/web/src/pages/home/components/tool-call-registry.ts
@@ -61,6 +61,7 @@ import {
 } from 'lucide-vue-next'
 import type { ToolCallBlock } from '@/store/chat-list'
 import ToolCallDetailBrowser from './tool-call-detail-browser.vue'
+import ToolCallDetailApplyPatch from './tool-call-detail-apply-patch.vue'
 import ToolCallDetailComputer from './tool-call-detail-computer.vue'
 import ToolCallDetailContacts from './tool-call-detail-contacts.vue'
 import ToolCallDetailEdit from './tool-call-detail-edit.vue'
@@ -174,6 +175,84 @@ function lineCount(s: string): number {
   return s.split('\n').length
 }
 
+function resultObject(block: ToolCallBlock): Record<string, unknown> {
+  const result = asObject(block.result)
+  const sc = asObject(result.structuredContent)
+  return Object.keys(sc).length > 0 ? sc : result
+}
+
+interface PatchFileTarget {
+  operation: 'add' | 'modify' | 'delete'
+  path: string
+}
+
+function normalizePatchOperation(value: unknown): PatchFileTarget['operation'] | '' {
+  if (value === 'add' || value === 'added') return 'add'
+  if (value === 'modify' || value === 'modified' || value === 'update') return 'modify'
+  if (value === 'delete' || value === 'deleted') return 'delete'
+  return ''
+}
+
+function patchFilesFromResult(block: ToolCallBlock): PatchFileTarget[] {
+  const result = resultObject(block)
+  const rawFiles = result.files
+  if (Array.isArray(rawFiles)) {
+    return rawFiles
+      .map((item) => {
+        const obj = asObject(item)
+        const path = pickString(obj, 'path')
+        const operation = normalizePatchOperation(obj.operation)
+        return path && operation ? { operation, path } : null
+      })
+      .filter((item): item is PatchFileTarget => Boolean(item))
+  }
+
+  const out: PatchFileTarget[] = []
+  for (const [key, operation] of [
+    ['added', 'add'],
+    ['modified', 'modify'],
+    ['deleted', 'delete'],
+  ] as const) {
+    const paths = result[key]
+    if (!Array.isArray(paths)) continue
+    for (const path of paths) {
+      if (typeof path === 'string' && path) out.push({ operation, path })
+    }
+  }
+  return out
+}
+
+function patchFilesFromInput(patch: string): PatchFileTarget[] {
+  if (!patch) return []
+  const out: PatchFileTarget[] = []
+  for (const rawLine of patch.split('\n')) {
+    const line = rawLine.trim()
+    if (line.startsWith('*** Add File: ')) {
+      const path = line.slice('*** Add File: '.length).trim()
+      if (path) out.push({ operation: 'add', path })
+    }
+    else if (line.startsWith('*** Delete File: ')) {
+      const path = line.slice('*** Delete File: '.length).trim()
+      if (path) out.push({ operation: 'delete', path })
+    }
+    else if (line.startsWith('*** Update File: ')) {
+      const path = line.slice('*** Update File: '.length).trim()
+      if (path) out.push({ operation: 'modify', path })
+    }
+  }
+  return out
+}
+
+function patchLineCounts(patch: string): { add: number; remove: number } {
+  let add = 0
+  let remove = 0
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('+')) add++
+    else if (line.startsWith('-') && !line.startsWith('***')) remove++
+  }
+  return { add, remove }
+}
+
 function hostnameOrUrl(url: string): string {
   if (!url) return ''
   try {
@@ -279,7 +358,7 @@ function resolveGuiAction(
 
 export function getToolDisplay(block: ToolCallBlock): ToolDisplay {
   const input = asObject(block.input)
-  
+
   switch (block.toolName) {
     case 'ask_user': {
       // pickString covers pre-v2 history where input was { question: "..." }.
@@ -324,6 +403,30 @@ export function getToolDisplay(block: ToolCallBlock): ToolDisplay {
         detail: ToolCallDetailEdit,
         diffAdd: lineCount(newText),
         diffRemove: lineCount(oldText),
+      }
+    }
+    case 'apply_patch': {
+      const patch = pickString(input, 'patch')
+      const files = patchFilesFromResult(block)
+      const fileTargets = files.length > 0 ? files : patchFilesFromInput(patch)
+      const target = fileTargets.length === 1
+        ? basename(fileTargets[0]!.path)
+        : fileTargets.length > 1
+          ? `${fileTargets.length} files`
+          : ''
+      const fullTarget = fileTargets
+        .map(file => `${file.operation} ${file.path}`)
+        .join('\n')
+      const counts = patchLineCounts(patch)
+      return {
+        icon: FilePen,
+        actionKey: 'apply_patch',
+        target,
+        fullTarget,
+        detail: ToolCallDetailApplyPatch,
+        defaultOpen: true,
+        diffAdd: counts.add,
+        diffRemove: counts.remove,
       }
     }
     case 'list': {

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -252,11 +252,11 @@ export const useChatStore = defineStore('chat', () => {
   const overrideReasoningEffort = ref<string>('')
   const startupSendFailure = ref<StartupSendFailure | null>(null)
 
-  // Bumps every time a fs-mutating tool call (write/edit/exec) finishes for the
+  // Bumps every time a fs-mutating tool call (write/edit/apply_patch/exec) finishes for the
   // current bot. File-manager components watch this to refresh their listings
   // and any open file viewers without polling.
   const fsChangedAt = ref(0)
-  const FS_MUTATING_TOOLS = new Set(['write', 'edit', 'exec'])
+  const FS_MUTATING_TOOLS = new Set(['write', 'edit', 'apply_patch', 'exec'])
 
   function bumpFsChangedAtIfFsMutation(message: UIMessage) {
     if (message.type !== 'tool') return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -793,7 +793,7 @@ func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.
 func markApprovalTools(tools []sdk.Tool) []sdk.Tool {
 	for i := range tools {
 		switch tools[i].Name {
-		case "write", "edit", "exec":
+		case "write", "edit", "apply_patch", "exec":
 			tools[i].RequireApproval = true
 		}
 	}

--- a/internal/agent/tools/apply_patch.go
+++ b/internal/agent/tools/apply_patch.go
@@ -268,23 +268,27 @@ func parseApplyPatch(patch string) ([]applyPatchHunk, error) {
 		lineNo := i + 1
 		trimmed := strings.TrimSpace(line)
 
-		if header, ok, err := parseApplyPatchHeader(trimmed, lineNo, mode, currentUpdateLine, hunks); ok || err != nil {
-			if err != nil {
-				return nil, err
+		updateContentLine := mode == "update" && (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-"))
+		if !updateContentLine {
+			header, ok, err := parseApplyPatchHeader(trimmed, lineNo, mode, currentUpdateLine, hunks)
+			if ok || err != nil {
+				if err != nil {
+					return nil, err
+				}
+				switch header.kind {
+				case applyPatchHunkAdd:
+					hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkAdd, path: header.path})
+					mode = "add"
+				case applyPatchHunkDelete:
+					hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkDelete, path: header.path})
+					mode = "delete"
+				case applyPatchHunkUpdate:
+					hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkUpdate, path: header.path})
+					mode = "update"
+					currentUpdateLine = lineNo
+				}
+				continue
 			}
-			switch header.kind {
-			case applyPatchHunkAdd:
-				hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkAdd, path: header.path})
-				mode = "add"
-			case applyPatchHunkDelete:
-				hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkDelete, path: header.path})
-				mode = "delete"
-			case applyPatchHunkUpdate:
-				hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkUpdate, path: header.path})
-				mode = "update"
-				currentUpdateLine = lineNo
-			}
-			continue
 		}
 
 		switch mode {
@@ -642,7 +646,7 @@ func computeApplyPatchReplacements(originalLines []string, path string, chunks [
 				insertionIdx = lineIndex
 			}
 			replacements = append(replacements, applyPatchReplacement{start: insertionIdx, newLines: append([]string(nil), chunk.newLines...)})
-			lineIndex = insertionIdx + len(chunk.newLines)
+			lineIndex = insertionIdx
 			continue
 		}
 

--- a/internal/agent/tools/apply_patch.go
+++ b/internal/agent/tools/apply_patch.go
@@ -1,0 +1,726 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/memohai/memoh/internal/workspace/bridge"
+)
+
+const (
+	applyPatchBeginMarker  = "*** Begin Patch"
+	applyPatchEndMarker    = "*** End Patch"
+	applyPatchAddMarker    = "*** Add File: "
+	applyPatchDeleteMarker = "*** Delete File: "
+	applyPatchUpdateMarker = "*** Update File: "
+	applyPatchMoveMarker   = "*** Move to: "
+	applyPatchEOFMarker    = "*** End of File"
+)
+
+type applyPatchHunkKind string
+
+const (
+	applyPatchHunkAdd    applyPatchHunkKind = "add"
+	applyPatchHunkDelete applyPatchHunkKind = "delete"
+	applyPatchHunkUpdate applyPatchHunkKind = "update"
+)
+
+type applyPatchHunk struct {
+	kind     applyPatchHunkKind
+	path     string
+	movePath string
+	contents string
+	chunks   []applyPatchChunk
+}
+
+type applyPatchChunk struct {
+	changeContext *string
+	oldLines      []string
+	newLines      []string
+	endOfFile     bool
+}
+
+type applyPatchParseError struct {
+	line    int
+	message string
+}
+
+func (e *applyPatchParseError) Error() string {
+	if e.line > 0 {
+		return fmt.Sprintf("invalid patch hunk on line %d: %s", e.line, e.message)
+	}
+	return "invalid patch: " + e.message
+}
+
+type applyPatchOperationKind string
+
+const (
+	applyPatchOperationWrite  applyPatchOperationKind = "write"
+	applyPatchOperationDelete applyPatchOperationKind = "delete"
+)
+
+type applyPatchOperation struct {
+	kind    applyPatchOperationKind
+	path    string
+	content string
+}
+
+type applyPatchPlan struct {
+	operations []applyPatchOperation
+	added      []string
+	modified   []string
+	deleted    []string
+}
+
+func (p applyPatchPlan) files() []map[string]any {
+	files := make([]map[string]any, 0, len(p.added)+len(p.modified)+len(p.deleted))
+	for _, path := range p.added {
+		files = append(files, map[string]any{"operation": "add", "path": path})
+	}
+	for _, path := range p.modified {
+		files = append(files, map[string]any{"operation": "modify", "path": path})
+	}
+	for _, path := range p.deleted {
+		files = append(files, map[string]any{"operation": "delete", "path": path})
+	}
+	return files
+}
+
+func (p applyPatchPlan) summary() string {
+	var b strings.Builder
+	b.WriteString("Success. Updated the following files:")
+	for _, path := range p.added {
+		b.WriteString("\nA ")
+		b.WriteString(path)
+	}
+	for _, path := range p.modified {
+		b.WriteString("\nM ")
+		b.WriteString(path)
+	}
+	for _, path := range p.deleted {
+		b.WriteString("\nD ")
+		b.WriteString(path)
+	}
+	return b.String()
+}
+
+type applyPatchFileInfo struct {
+	exists bool
+	isDir  bool
+}
+
+type applyPatchReadFS interface {
+	Stat(ctx context.Context, path string) (applyPatchFileInfo, error)
+	ReadText(ctx context.Context, path string) (string, error)
+}
+
+type bridgeApplyPatchFS struct {
+	client *bridge.Client
+}
+
+func (fs bridgeApplyPatchFS) Stat(ctx context.Context, path string) (applyPatchFileInfo, error) {
+	entry, err := fs.client.Stat(ctx, path)
+	if err != nil {
+		if errors.Is(err, bridge.ErrNotFound) {
+			return applyPatchFileInfo{exists: false}, nil
+		}
+		return applyPatchFileInfo{}, err
+	}
+	return applyPatchFileInfo{exists: true, isDir: entry.GetIsDir()}, nil
+}
+
+func (fs bridgeApplyPatchFS) ReadText(ctx context.Context, path string) (string, error) {
+	reader, err := fs.client.ReadRaw(ctx, path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = reader.Close() }()
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+	if strings.IndexByte(string(raw), 0) >= 0 {
+		return "", fmt.Errorf("file appears to be binary: %s", path)
+	}
+	return string(raw), nil
+}
+
+type applyPatchVirtualFile struct {
+	exists        bool
+	isDir         bool
+	content       string
+	contentLoaded bool
+}
+
+func execApplyPatchInput(input any) (string, error) {
+	if text, ok := input.(string); ok {
+		if strings.TrimSpace(text) == "" {
+			return "", errors.New("patch is required")
+		}
+		return text, nil
+	}
+	args := inputAsMap(input)
+	raw, ok := args["patch"]
+	if !ok || raw == nil {
+		return "", errors.New("patch is required")
+	}
+	text, ok := raw.(string)
+	if !ok {
+		return "", errors.New("patch must be a string")
+	}
+	if strings.TrimSpace(text) == "" {
+		return "", errors.New("patch is required")
+	}
+	return text, nil
+}
+
+func (p *ContainerProvider) execApplyPatch(ctx context.Context, session SessionContext, input any) (any, error) {
+	patch, err := execApplyPatchInput(input)
+	if err != nil {
+		return nil, err
+	}
+
+	opCtx, opCancel := context.WithTimeout(ctx, containerOpTimeout)
+	defer opCancel()
+
+	client, err := p.getClient(opCtx, session.BotID)
+	if err != nil {
+		return nil, err
+	}
+	hunks, err := parseApplyPatch(patch)
+	if err != nil {
+		return nil, err
+	}
+	if len(hunks) == 0 {
+		return nil, errors.New("no files were modified")
+	}
+
+	workspace := p.resolveToolWorkspace(ctx, session)
+	plan, err := buildApplyPatchPlan(opCtx, bridgeApplyPatchFS{client: client}, workspace.defaultWorkDir, hunks)
+	if err != nil {
+		return nil, err
+	}
+	if err := commitApplyPatchPlan(opCtx, client, plan); err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"ok":       true,
+		"summary":  plan.summary(),
+		"added":    plan.added,
+		"modified": plan.modified,
+		"deleted":  plan.deleted,
+		"files":    plan.files(),
+	}, nil
+}
+
+func commitApplyPatchPlan(ctx context.Context, client *bridge.Client, plan *applyPatchPlan) error {
+	for _, op := range plan.operations {
+		switch op.kind {
+		case applyPatchOperationWrite:
+			data := []byte(op.content)
+			if len(data) > largeFileThreshold {
+				if _, err := client.WriteRaw(ctx, op.path, strings.NewReader(op.content)); err != nil {
+					return fmt.Errorf("write %s: %w", op.path, err)
+				}
+				continue
+			}
+			if err := client.WriteFile(ctx, op.path, data); err != nil {
+				return fmt.Errorf("write %s: %w", op.path, err)
+			}
+		case applyPatchOperationDelete:
+			if err := client.DeleteFile(ctx, op.path, false); err != nil {
+				return fmt.Errorf("delete %s: %w", op.path, err)
+			}
+		default:
+			return fmt.Errorf("unknown apply_patch operation %q", op.kind)
+		}
+	}
+	return nil
+}
+
+func parseApplyPatch(patch string) ([]applyPatchHunk, error) {
+	lines := splitPatchLines(patch)
+	lines, err := stripLenientHeredoc(lines)
+	if err != nil {
+		return nil, err
+	}
+	if len(lines) < 2 {
+		return nil, &applyPatchParseError{message: "The first line of the patch must be '*** Begin Patch'"}
+	}
+	if strings.TrimSpace(lines[0]) != applyPatchBeginMarker {
+		return nil, &applyPatchParseError{message: "The first line of the patch must be '*** Begin Patch'"}
+	}
+	if strings.TrimSpace(lines[len(lines)-1]) != applyPatchEndMarker {
+		return nil, &applyPatchParseError{message: "The last line of the patch must be '*** End Patch'"}
+	}
+
+	var hunks []applyPatchHunk
+	mode := ""
+	currentUpdateLine := 0
+	for i := 1; i < len(lines)-1; i++ {
+		line := strings.TrimSuffix(lines[i], "\r")
+		lineNo := i + 1
+		trimmed := strings.TrimSpace(line)
+
+		if header, ok, err := parseApplyPatchHeader(trimmed, lineNo, mode, currentUpdateLine, hunks); ok || err != nil {
+			if err != nil {
+				return nil, err
+			}
+			switch header.kind {
+			case applyPatchHunkAdd:
+				hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkAdd, path: header.path})
+				mode = "add"
+			case applyPatchHunkDelete:
+				hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkDelete, path: header.path})
+				mode = "delete"
+			case applyPatchHunkUpdate:
+				hunks = append(hunks, applyPatchHunk{kind: applyPatchHunkUpdate, path: header.path})
+				mode = "update"
+				currentUpdateLine = lineNo
+			}
+			continue
+		}
+
+		switch mode {
+		case "":
+			return nil, &applyPatchParseError{line: lineNo, message: fmt.Sprintf("'%s' is not a valid hunk header", trimmed)}
+		case "add":
+			if content, ok := strings.CutPrefix(line, "+"); ok {
+				hunks[len(hunks)-1].contents += content + "\n"
+				continue
+			}
+			return nil, &applyPatchParseError{line: lineNo, message: fmt.Sprintf("'%s' is not a valid hunk header", trimmed)}
+		case "delete":
+			return nil, &applyPatchParseError{line: lineNo, message: fmt.Sprintf("'%s' is not a valid hunk header", trimmed)}
+		case "update":
+			if err := parseApplyPatchUpdateLine(&hunks[len(hunks)-1], line, strings.TrimRight(line, " \t"), lineNo); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := ensureApplyPatchUpdateHunkComplete(mode, currentUpdateLine, len(lines), hunks); err != nil {
+		return nil, err
+	}
+	return hunks, nil
+}
+
+func splitPatchLines(patch string) []string {
+	patch = strings.TrimSpace(patch)
+	if patch == "" {
+		return nil
+	}
+	return strings.Split(patch, "\n")
+}
+
+func stripLenientHeredoc(lines []string) ([]string, error) {
+	if len(lines) == 0 {
+		return lines, nil
+	}
+	if strings.TrimSpace(lines[0]) == applyPatchBeginMarker {
+		return lines, nil
+	}
+	if len(lines) < 4 {
+		return lines, nil
+	}
+	first := strings.TrimSpace(lines[0])
+	last := strings.TrimSpace(lines[len(lines)-1])
+	if (first == "<<EOF" || first == "<<'EOF'" || first == "<<\"EOF\"") && strings.HasSuffix(last, "EOF") {
+		return lines[1 : len(lines)-1], nil
+	}
+	return lines, nil
+}
+
+func parseApplyPatchHeader(trimmed string, lineNo int, mode string, hunkLine int, hunks []applyPatchHunk) (applyPatchHunk, bool, error) {
+	var kind applyPatchHunkKind
+	var path string
+	switch {
+	case strings.HasPrefix(trimmed, applyPatchAddMarker):
+		kind = applyPatchHunkAdd
+		path = strings.TrimSpace(strings.TrimPrefix(trimmed, applyPatchAddMarker))
+	case strings.HasPrefix(trimmed, applyPatchDeleteMarker):
+		kind = applyPatchHunkDelete
+		path = strings.TrimSpace(strings.TrimPrefix(trimmed, applyPatchDeleteMarker))
+	case strings.HasPrefix(trimmed, applyPatchUpdateMarker):
+		kind = applyPatchHunkUpdate
+		path = strings.TrimSpace(strings.TrimPrefix(trimmed, applyPatchUpdateMarker))
+	default:
+		return applyPatchHunk{}, false, nil
+	}
+	if path == "" {
+		return applyPatchHunk{}, true, &applyPatchParseError{line: lineNo, message: "hunk path is required"}
+	}
+	if err := ensureApplyPatchUpdateHunkComplete(mode, hunkLine, lineNo, hunks); err != nil {
+		return applyPatchHunk{}, true, err
+	}
+	return applyPatchHunk{kind: kind, path: path}, true, nil
+}
+
+func ensureApplyPatchUpdateHunkComplete(mode string, hunkLine, lineNo int, hunks []applyPatchHunk) error {
+	if mode != "update" || len(hunks) == 0 {
+		return nil
+	}
+	last := hunks[len(hunks)-1]
+	if len(last.chunks) == 0 {
+		return &applyPatchParseError{line: hunkLine, message: fmt.Sprintf("Update file hunk for path '%s' is empty", last.path)}
+	}
+	chunk := last.chunks[len(last.chunks)-1]
+	if len(chunk.oldLines) == 0 && len(chunk.newLines) == 0 {
+		return &applyPatchParseError{line: lineNo, message: "Update hunk does not contain any lines"}
+	}
+	return nil
+}
+
+func parseApplyPatchUpdateLine(hunk *applyPatchHunk, line, updateLine string, lineNo int) error {
+	if len(hunk.chunks) > 0 && hunk.chunks[len(hunk.chunks)-1].endOfFile {
+		if updateLine == "" {
+			return nil
+		}
+		if updateLine != "@@" && !strings.HasPrefix(updateLine, "@@ ") {
+			return &applyPatchParseError{line: lineNo, message: fmt.Sprintf("Expected update hunk to start with a @@ context marker, got: '%s'", line)}
+		}
+	}
+
+	if updateLine == applyPatchMoveMarker || strings.HasPrefix(updateLine, applyPatchMoveMarker) {
+		if len(hunk.chunks) > 0 || hunk.movePath != "" {
+			return &applyPatchParseError{line: lineNo, message: "move marker must appear before update lines"}
+		}
+		movePath := strings.TrimSpace(strings.TrimPrefix(updateLine, applyPatchMoveMarker))
+		if movePath == "" {
+			return &applyPatchParseError{line: lineNo, message: "move path is required"}
+		}
+		hunk.movePath = movePath
+		return nil
+	}
+
+	if updateLine == "@@" || strings.HasPrefix(updateLine, "@@ ") {
+		if len(hunk.chunks) > 0 {
+			prev := hunk.chunks[len(hunk.chunks)-1]
+			if len(prev.oldLines) == 0 && len(prev.newLines) == 0 {
+				return &applyPatchParseError{line: lineNo, message: fmt.Sprintf("Unexpected line found in update hunk: '%s'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)", line)}
+			}
+		}
+		var ctx *string
+		if strings.HasPrefix(updateLine, "@@ ") {
+			value := strings.TrimPrefix(updateLine, "@@ ")
+			ctx = &value
+		}
+		hunk.chunks = append(hunk.chunks, applyPatchChunk{changeContext: ctx})
+		return nil
+	}
+
+	if updateLine == applyPatchEOFMarker {
+		if len(hunk.chunks) == 0 {
+			return &applyPatchParseError{line: lineNo, message: "Update hunk does not contain any lines"}
+		}
+		chunk := &hunk.chunks[len(hunk.chunks)-1]
+		if len(chunk.oldLines) == 0 && len(chunk.newLines) == 0 {
+			return &applyPatchParseError{line: lineNo, message: "Update hunk does not contain any lines"}
+		}
+		chunk.endOfFile = true
+		return nil
+	}
+
+	if len(hunk.chunks) == 0 {
+		hunk.chunks = append(hunk.chunks, applyPatchChunk{})
+	}
+	chunk := &hunk.chunks[len(hunk.chunks)-1]
+	switch {
+	case line == "":
+		chunk.oldLines = append(chunk.oldLines, "")
+		chunk.newLines = append(chunk.newLines, "")
+	case strings.HasPrefix(line, " "):
+		value := strings.TrimPrefix(line, " ")
+		chunk.oldLines = append(chunk.oldLines, value)
+		chunk.newLines = append(chunk.newLines, value)
+	case strings.HasPrefix(line, "+"):
+		chunk.newLines = append(chunk.newLines, strings.TrimPrefix(line, "+"))
+	case strings.HasPrefix(line, "-"):
+		chunk.oldLines = append(chunk.oldLines, strings.TrimPrefix(line, "-"))
+	default:
+		if len(chunk.oldLines) > 0 || len(chunk.newLines) > 0 {
+			return &applyPatchParseError{line: lineNo, message: fmt.Sprintf("Expected update hunk to start with a @@ context marker, got: '%s'", line)}
+		}
+		return &applyPatchParseError{line: lineNo, message: fmt.Sprintf("Unexpected line found in update hunk: '%s'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)", line)}
+	}
+	return nil
+}
+
+func buildApplyPatchPlan(ctx context.Context, fs applyPatchReadFS, defaultWorkDir string, hunks []applyPatchHunk) (*applyPatchPlan, error) {
+	files := make(map[string]applyPatchVirtualFile)
+	plan := &applyPatchPlan{}
+
+	for _, hunk := range hunks {
+		path, err := normalizeApplyPatchPath(hunk.path, defaultWorkDir)
+		if err != nil {
+			return nil, err
+		}
+		switch hunk.kind {
+		case applyPatchHunkAdd:
+			info, err := statApplyPatchVirtualFile(ctx, fs, files, path)
+			if err != nil {
+				return nil, err
+			}
+			if info.exists && info.isDir {
+				return nil, fmt.Errorf("cannot add file over directory: %s", path)
+			}
+			files[path] = applyPatchVirtualFile{exists: true, content: hunk.contents, contentLoaded: true}
+			plan.operations = append(plan.operations, applyPatchOperation{kind: applyPatchOperationWrite, path: path, content: hunk.contents})
+			plan.added = append(plan.added, path)
+		case applyPatchHunkDelete:
+			info, err := statApplyPatchVirtualFile(ctx, fs, files, path)
+			if err != nil {
+				return nil, err
+			}
+			if !info.exists {
+				return nil, fmt.Errorf("cannot delete missing file: %s", path)
+			}
+			if info.isDir {
+				return nil, fmt.Errorf("cannot delete directory with apply_patch: %s", path)
+			}
+			files[path] = applyPatchVirtualFile{exists: false, contentLoaded: true}
+			plan.operations = append(plan.operations, applyPatchOperation{kind: applyPatchOperationDelete, path: path})
+			plan.deleted = append(plan.deleted, path)
+		case applyPatchHunkUpdate:
+			original, err := readApplyPatchVirtualFile(ctx, fs, files, path)
+			if err != nil {
+				return nil, err
+			}
+			newContent, err := deriveApplyPatchContent(path, original, hunk.chunks)
+			if err != nil {
+				return nil, err
+			}
+			if hunk.movePath != "" {
+				movePath, err := normalizeApplyPatchPath(hunk.movePath, defaultWorkDir)
+				if err != nil {
+					return nil, err
+				}
+				if movePath == path {
+					files[path] = applyPatchVirtualFile{exists: true, content: newContent, contentLoaded: true}
+					plan.operations = append(plan.operations, applyPatchOperation{kind: applyPatchOperationWrite, path: path, content: newContent})
+				} else {
+					info, err := statApplyPatchVirtualFile(ctx, fs, files, movePath)
+					if err != nil {
+						return nil, err
+					}
+					if info.exists && info.isDir {
+						return nil, fmt.Errorf("cannot move file over directory: %s", movePath)
+					}
+					files[path] = applyPatchVirtualFile{exists: false, contentLoaded: true}
+					files[movePath] = applyPatchVirtualFile{exists: true, content: newContent, contentLoaded: true}
+					plan.operations = append(plan.operations,
+						applyPatchOperation{kind: applyPatchOperationWrite, path: movePath, content: newContent},
+						applyPatchOperation{kind: applyPatchOperationDelete, path: path},
+					)
+				}
+			} else {
+				files[path] = applyPatchVirtualFile{exists: true, content: newContent, contentLoaded: true}
+				plan.operations = append(plan.operations, applyPatchOperation{kind: applyPatchOperationWrite, path: path, content: newContent})
+			}
+			plan.modified = append(plan.modified, path)
+		default:
+			return nil, fmt.Errorf("unknown apply_patch hunk kind %q", hunk.kind)
+		}
+	}
+
+	return plan, nil
+}
+
+func normalizeApplyPatchPath(rawPath, defaultWorkDir string) (string, error) {
+	path := strings.TrimSpace(rawPath)
+	if path == "" {
+		return "", errors.New("patch path is required")
+	}
+	if strings.Contains(path, "\x00") {
+		return "", fmt.Errorf("patch path contains null byte: %q", rawPath)
+	}
+	workDir := strings.TrimRight(strings.TrimSpace(defaultWorkDir), "/")
+	if workDir == "" {
+		workDir = defaultContainerExecWorkDir
+	}
+	if path == workDir {
+		return "", fmt.Errorf("patch path must refer to a file: %s", rawPath)
+	}
+	if strings.HasPrefix(path, workDir+"/") {
+		path = strings.TrimLeft(strings.TrimPrefix(path, workDir+"/"), "/")
+	}
+	clean := filepath.Clean(path)
+	if clean == "." || clean == string(filepath.Separator) {
+		return "", fmt.Errorf("patch path must refer to a file: %s", rawPath)
+	}
+	if !filepath.IsAbs(clean) && (clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator))) {
+		return "", fmt.Errorf("patch path escapes workspace: %s", rawPath)
+	}
+	return clean, nil
+}
+
+func statApplyPatchVirtualFile(ctx context.Context, fs applyPatchReadFS, files map[string]applyPatchVirtualFile, path string) (applyPatchVirtualFile, error) {
+	if file, ok := files[path]; ok {
+		return file, nil
+	}
+	info, err := fs.Stat(ctx, path)
+	if err != nil {
+		return applyPatchVirtualFile{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+	file := applyPatchVirtualFile{exists: info.exists, isDir: info.isDir}
+	files[path] = file
+	return file, nil
+}
+
+func readApplyPatchVirtualFile(ctx context.Context, fs applyPatchReadFS, files map[string]applyPatchVirtualFile, path string) (string, error) {
+	file, err := statApplyPatchVirtualFile(ctx, fs, files, path)
+	if err != nil {
+		return "", err
+	}
+	if !file.exists {
+		return "", fmt.Errorf("cannot update missing file: %s", path)
+	}
+	if file.isDir {
+		return "", fmt.Errorf("cannot update directory with apply_patch: %s", path)
+	}
+	if file.contentLoaded {
+		return file.content, nil
+	}
+	content, err := fs.ReadText(ctx, path)
+	if err != nil {
+		if errors.Is(err, bridge.ErrNotFound) {
+			return "", fmt.Errorf("cannot update missing file: %s", path)
+		}
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	file.content = content
+	file.contentLoaded = true
+	files[path] = file
+	return content, nil
+}
+
+func deriveApplyPatchContent(path, original string, chunks []applyPatchChunk) (string, error) {
+	originalLines := strings.Split(original, "\n")
+	if len(originalLines) > 0 && originalLines[len(originalLines)-1] == "" {
+		originalLines = originalLines[:len(originalLines)-1]
+	}
+	replacements, err := computeApplyPatchReplacements(originalLines, path, chunks)
+	if err != nil {
+		return "", err
+	}
+	updatedLines := applyPatchReplacements(originalLines, replacements)
+	if len(updatedLines) == 0 || updatedLines[len(updatedLines)-1] != "" {
+		updatedLines = append(updatedLines, "")
+	}
+	return strings.Join(updatedLines, "\n"), nil
+}
+
+type applyPatchReplacement struct {
+	start    int
+	oldLen   int
+	newLines []string
+}
+
+func computeApplyPatchReplacements(originalLines []string, path string, chunks []applyPatchChunk) ([]applyPatchReplacement, error) {
+	replacements := make([]applyPatchReplacement, 0, len(chunks))
+	lineIndex := 0
+	for _, chunk := range chunks {
+		if chunk.changeContext != nil {
+			idx, ok := seekApplyPatchSequence(originalLines, []string{*chunk.changeContext}, lineIndex, false)
+			if !ok {
+				return nil, fmt.Errorf("failed to find context %q in %s", *chunk.changeContext, path)
+			}
+			lineIndex = idx + 1
+		}
+		if len(chunk.oldLines) == 0 {
+			insertionIdx := len(originalLines)
+			if len(originalLines) > 0 && originalLines[len(originalLines)-1] == "" {
+				insertionIdx = len(originalLines) - 1
+			}
+			replacements = append(replacements, applyPatchReplacement{start: insertionIdx, newLines: append([]string(nil), chunk.newLines...)})
+			continue
+		}
+
+		pattern := chunk.oldLines
+		newLines := chunk.newLines
+		start, ok := seekApplyPatchSequence(originalLines, pattern, lineIndex, chunk.endOfFile)
+		if !ok && len(pattern) > 0 && pattern[len(pattern)-1] == "" {
+			pattern = pattern[:len(pattern)-1]
+			if len(newLines) > 0 && newLines[len(newLines)-1] == "" {
+				newLines = newLines[:len(newLines)-1]
+			}
+			start, ok = seekApplyPatchSequence(originalLines, pattern, lineIndex, chunk.endOfFile)
+		}
+		if !ok {
+			return nil, fmt.Errorf("failed to find expected lines in %s:\n%s", path, strings.Join(chunk.oldLines, "\n"))
+		}
+		replacements = append(replacements, applyPatchReplacement{
+			start:    start,
+			oldLen:   len(pattern),
+			newLines: append([]string(nil), newLines...),
+		})
+		lineIndex = start + len(pattern)
+	}
+	sort.SliceStable(replacements, func(i, j int) bool {
+		return replacements[i].start < replacements[j].start
+	})
+	return replacements, nil
+}
+
+func applyPatchReplacements(lines []string, replacements []applyPatchReplacement) []string {
+	out := append([]string(nil), lines...)
+	for i := len(replacements) - 1; i >= 0; i-- {
+		repl := replacements[i]
+		if repl.start > len(out) {
+			continue
+		}
+		end := repl.start + repl.oldLen
+		if end > len(out) {
+			end = len(out)
+		}
+		next := make([]string, 0, len(out)-(end-repl.start)+len(repl.newLines))
+		next = append(next, out[:repl.start]...)
+		next = append(next, repl.newLines...)
+		next = append(next, out[end:]...)
+		out = next
+	}
+	return out
+}
+
+func seekApplyPatchSequence(lines, pattern []string, start int, eof bool) (int, bool) {
+	if len(pattern) == 0 {
+		return start, true
+	}
+	if len(pattern) > len(lines) {
+		return 0, false
+	}
+	searchStart := start
+	if eof && len(lines) >= len(pattern) {
+		searchStart = len(lines) - len(pattern)
+	}
+	if searchStart < 0 {
+		searchStart = 0
+	}
+	if searchStart > len(lines)-len(pattern) {
+		return 0, false
+	}
+	for _, match := range []func(string, string) bool{
+		func(a, b string) bool { return a == b },
+		func(a, b string) bool { return strings.TrimRight(a, " \t") == strings.TrimRight(b, " \t") },
+		func(a, b string) bool { return strings.TrimSpace(a) == strings.TrimSpace(b) },
+	} {
+		for i := searchStart; i <= len(lines)-len(pattern); i++ {
+			ok := true
+			for j := range pattern {
+				if !match(lines[i+j], pattern[j]) {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}

--- a/internal/agent/tools/apply_patch.go
+++ b/internal/agent/tools/apply_patch.go
@@ -466,8 +466,11 @@ func buildApplyPatchPlan(ctx context.Context, fs applyPatchReadFS, defaultWorkDi
 			if err != nil {
 				return nil, err
 			}
-			if info.exists && info.isDir {
-				return nil, fmt.Errorf("cannot add file over directory: %s", path)
+			if info.exists {
+				if info.isDir {
+					return nil, fmt.Errorf("cannot add file over directory: %s", path)
+				}
+				return nil, fmt.Errorf("cannot add existing file: %s", path)
 			}
 			files[path] = applyPatchVirtualFile{exists: true, content: hunk.contents, contentLoaded: true}
 			plan.operations = append(plan.operations, applyPatchOperation{kind: applyPatchOperationWrite, path: path, content: hunk.contents})
@@ -625,6 +628,7 @@ func computeApplyPatchReplacements(originalLines []string, path string, chunks [
 	replacements := make([]applyPatchReplacement, 0, len(chunks))
 	lineIndex := 0
 	for _, chunk := range chunks {
+		hasChangeContext := chunk.changeContext != nil
 		if chunk.changeContext != nil {
 			idx, ok := seekApplyPatchSequence(originalLines, []string{*chunk.changeContext}, lineIndex, false)
 			if !ok {
@@ -634,10 +638,11 @@ func computeApplyPatchReplacements(originalLines []string, path string, chunks [
 		}
 		if len(chunk.oldLines) == 0 {
 			insertionIdx := len(originalLines)
-			if len(originalLines) > 0 && originalLines[len(originalLines)-1] == "" {
-				insertionIdx = len(originalLines) - 1
+			if hasChangeContext {
+				insertionIdx = lineIndex
 			}
 			replacements = append(replacements, applyPatchReplacement{start: insertionIdx, newLines: append([]string(nil), chunk.newLines...)})
+			lineIndex = insertionIdx + len(chunk.newLines)
 			continue
 		}
 

--- a/internal/agent/tools/apply_patch_test.go
+++ b/internal/agent/tools/apply_patch_test.go
@@ -147,6 +147,52 @@ func TestBuildApplyPatchPlanRejectsMissingContextBeforeCommitPlan(t *testing.T) 
 	}
 }
 
+func TestBuildApplyPatchPlanRejectsAddOverExistingFile(t *testing.T) {
+	patch := `*** Begin Patch
+*** Add File: existing.txt
++new
+*** End Patch`
+	hunks, err := parseApplyPatch(patch)
+	if err != nil {
+		t.Fatalf("parseApplyPatch() error = %v", err)
+	}
+
+	_, err = buildApplyPatchPlan(context.Background(), applyPatchFakeFS{
+		files: map[string]string{"existing.txt": "old\n"},
+	}, "/data", hunks)
+	if err == nil {
+		t.Fatal("expected existing-file add error")
+	}
+	if !strings.Contains(err.Error(), "cannot add existing file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildApplyPatchPlanInsertionOnlyUsesContext(t *testing.T) {
+	patch := `*** Begin Patch
+*** Update File: notes.txt
+@@ heading
++inserted
+*** End Patch`
+	hunks, err := parseApplyPatch(patch)
+	if err != nil {
+		t.Fatalf("parseApplyPatch() error = %v", err)
+	}
+
+	plan, err := buildApplyPatchPlan(context.Background(), applyPatchFakeFS{
+		files: map[string]string{"notes.txt": "intro\nheading\noutro\n"},
+	}, "/data", hunks)
+	if err != nil {
+		t.Fatalf("buildApplyPatchPlan() error = %v", err)
+	}
+	if len(plan.operations) != 1 {
+		t.Fatalf("expected 1 operation, got %d", len(plan.operations))
+	}
+	if got, want := plan.operations[0].content, "intro\nheading\ninserted\noutro\n"; got != want {
+		t.Fatalf("patched content = %q, want %q", got, want)
+	}
+}
+
 func TestNormalizeApplyPatchPathRejectsRelativeTraversal(t *testing.T) {
 	if _, err := normalizeApplyPatchPath("../outside.txt", "/data"); err == nil {
 		t.Fatal("expected traversal path to be rejected")

--- a/internal/agent/tools/apply_patch_test.go
+++ b/internal/agent/tools/apply_patch_test.go
@@ -193,6 +193,55 @@ func TestBuildApplyPatchPlanInsertionOnlyUsesContext(t *testing.T) {
 	}
 }
 
+func TestBuildApplyPatchPlanMultipleInsertionOnlyChunksUseOriginalPositions(t *testing.T) {
+	patch := `*** Begin Patch
+*** Update File: notes.txt
+@@ a
++after-a
+@@ b
++after-b
+*** End Patch`
+	hunks, err := parseApplyPatch(patch)
+	if err != nil {
+		t.Fatalf("parseApplyPatch() error = %v", err)
+	}
+
+	plan, err := buildApplyPatchPlan(context.Background(), applyPatchFakeFS{
+		files: map[string]string{"notes.txt": "a\nb\nc\n"},
+	}, "/data", hunks)
+	if err != nil {
+		t.Fatalf("buildApplyPatchPlan() error = %v", err)
+	}
+	if len(plan.operations) != 1 {
+		t.Fatalf("expected 1 operation, got %d", len(plan.operations))
+	}
+	if got, want := plan.operations[0].content, "a\nafter-a\nb\nafter-b\nc\n"; got != want {
+		t.Fatalf("patched content = %q, want %q", got, want)
+	}
+}
+
+func TestParseApplyPatchAllowsLiteralMarkerContextLines(t *testing.T) {
+	patch := `*** Begin Patch
+*** Update File: docs.txt
+@@
+ *** Update File: example
++literal marker follows
+*** End Patch`
+	hunks, err := parseApplyPatch(patch)
+	if err != nil {
+		t.Fatalf("parseApplyPatch() error = %v", err)
+	}
+	if len(hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(hunks))
+	}
+	if len(hunks[0].chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(hunks[0].chunks))
+	}
+	if got, want := hunks[0].chunks[0].oldLines, []string{"*** Update File: example"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("oldLines = %#v, want %#v", got, want)
+	}
+}
+
 func TestNormalizeApplyPatchPathRejectsRelativeTraversal(t *testing.T) {
 	if _, err := normalizeApplyPatchPath("../outside.txt", "/data"); err == nil {
 		t.Fatal("expected traversal path to be rejected")

--- a/internal/agent/tools/apply_patch_test.go
+++ b/internal/agent/tools/apply_patch_test.go
@@ -1,0 +1,161 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type applyPatchFakeFS struct {
+	files map[string]string
+	dirs  map[string]bool
+}
+
+func (fs applyPatchFakeFS) Stat(_ context.Context, path string) (applyPatchFileInfo, error) {
+	if fs.dirs[path] {
+		return applyPatchFileInfo{exists: true, isDir: true}, nil
+	}
+	if _, ok := fs.files[path]; ok {
+		return applyPatchFileInfo{exists: true}, nil
+	}
+	return applyPatchFileInfo{exists: false}, nil
+}
+
+func (fs applyPatchFakeFS) ReadText(_ context.Context, path string) (string, error) {
+	if content, ok := fs.files[path]; ok {
+		return content, nil
+	}
+	return "", errors.New("not found")
+}
+
+func TestParseApplyPatchMultipleOperations(t *testing.T) {
+	patch := `*** Begin Patch
+*** Add File: nested/new.txt
++hello
++world
+*** Delete File: obsolete.txt
+*** Update File: old/name.txt
+*** Move to: renamed/name.txt
+@@
+-old
++new
+*** End Patch`
+
+	hunks, err := parseApplyPatch(patch)
+	if err != nil {
+		t.Fatalf("parseApplyPatch() error = %v", err)
+	}
+	if len(hunks) != 3 {
+		t.Fatalf("expected 3 hunks, got %d", len(hunks))
+	}
+	if hunks[0].kind != applyPatchHunkAdd || hunks[0].path != "nested/new.txt" || hunks[0].contents != "hello\nworld\n" {
+		t.Fatalf("unexpected add hunk: %+v", hunks[0])
+	}
+	if hunks[1].kind != applyPatchHunkDelete || hunks[1].path != "obsolete.txt" {
+		t.Fatalf("unexpected delete hunk: %+v", hunks[1])
+	}
+	if hunks[2].kind != applyPatchHunkUpdate || hunks[2].movePath != "renamed/name.txt" {
+		t.Fatalf("unexpected update hunk: %+v", hunks[2])
+	}
+	if got := hunks[2].chunks[0].oldLines; !reflect.DeepEqual(got, []string{"old"}) {
+		t.Fatalf("unexpected old lines: %#v", got)
+	}
+	if got := hunks[2].chunks[0].newLines; !reflect.DeepEqual(got, []string{"new"}) {
+		t.Fatalf("unexpected new lines: %#v", got)
+	}
+}
+
+func TestBuildApplyPatchPlanMultipleOperations(t *testing.T) {
+	patch := `*** Begin Patch
+*** Add File: nested/new.txt
++created
+*** Update File: modify.txt
+@@
+ foo
+-bar
++baz
+*** Delete File: obsolete.txt
+*** Update File: old/name.txt
+*** Move to: renamed/name.txt
+@@
+-old
++new
+*** End Patch`
+	hunks, err := parseApplyPatch(patch)
+	if err != nil {
+		t.Fatalf("parseApplyPatch() error = %v", err)
+	}
+
+	plan, err := buildApplyPatchPlan(context.Background(), applyPatchFakeFS{
+		files: map[string]string{
+			"modify.txt":   "foo\nbar\n",
+			"obsolete.txt": "gone\n",
+			"old/name.txt": "old\n",
+		},
+	}, "/data", hunks)
+	if err != nil {
+		t.Fatalf("buildApplyPatchPlan() error = %v", err)
+	}
+
+	if got, want := plan.added, []string{"nested/new.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("added = %#v, want %#v", got, want)
+	}
+	if got, want := plan.modified, []string{"modify.txt", "old/name.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("modified = %#v, want %#v", got, want)
+	}
+	if got, want := plan.deleted, []string{"obsolete.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("deleted = %#v, want %#v", got, want)
+	}
+	if len(plan.operations) != 5 {
+		t.Fatalf("expected 5 operations, got %d: %#v", len(plan.operations), plan.operations)
+	}
+	if op := plan.operations[1]; op.kind != applyPatchOperationWrite || op.path != "modify.txt" || op.content != "foo\nbaz\n" {
+		t.Fatalf("unexpected modify operation: %#v", op)
+	}
+	if op := plan.operations[3]; op.kind != applyPatchOperationWrite || op.path != "renamed/name.txt" || op.content != "new\n" {
+		t.Fatalf("unexpected move write operation: %#v", op)
+	}
+	if op := plan.operations[4]; op.kind != applyPatchOperationDelete || op.path != "old/name.txt" {
+		t.Fatalf("unexpected move delete operation: %#v", op)
+	}
+}
+
+func TestBuildApplyPatchPlanRejectsMissingContextBeforeCommitPlan(t *testing.T) {
+	patch := `*** Begin Patch
+*** Add File: created.txt
++created
+*** Update File: modify.txt
+@@
+-missing
++new
+*** End Patch`
+	hunks, err := parseApplyPatch(patch)
+	if err != nil {
+		t.Fatalf("parseApplyPatch() error = %v", err)
+	}
+
+	_, err = buildApplyPatchPlan(context.Background(), applyPatchFakeFS{
+		files: map[string]string{"modify.txt": "original\n"},
+	}, "/data", hunks)
+	if err == nil {
+		t.Fatal("expected missing context error")
+	}
+	if !strings.Contains(err.Error(), "failed to find expected lines") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNormalizeApplyPatchPathRejectsRelativeTraversal(t *testing.T) {
+	if _, err := normalizeApplyPatchPath("../outside.txt", "/data"); err == nil {
+		t.Fatal("expected traversal path to be rejected")
+	}
+	path, err := normalizeApplyPatchPath("/data/src/main.go", "/data")
+	if err != nil {
+		t.Fatalf("normalizeApplyPatchPath() error = %v", err)
+	}
+	if path != "src/main.go" {
+		t.Fatalf("normalized path = %q, want src/main.go", path)
+	}
+}

--- a/internal/agent/tools/container.go
+++ b/internal/agent/tools/container.go
@@ -130,6 +130,33 @@ func (p *ContainerProvider) Tools(ctx context.Context, session SessionContext) (
 			},
 		},
 		{
+			Name: "apply_patch",
+			Description: fmt.Sprintf(`Apply a structured patch %s. Supports adding, deleting, updating, and moving files.
+
+Patch format:
+*** Begin Patch
+*** Add File: path
++new line
+*** Update File: path
+@@
+-old line
++new line
+*** Delete File: path
+*** End Patch
+
+Use apply_patch for multi-file or structured edits. Use edit for a single exact text replacement and write for full-file overwrite.`, workspace.locationDescription),
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"patch": map[string]any{"type": "string", "description": "Patch body using the apply_patch format. Paths are relative to the workspace by default, or absolute paths supported by the workspace backend."},
+				},
+				"required": []string{"patch"},
+			},
+			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				return p.execApplyPatch(ctx.Context, sess, input)
+			},
+		},
+		{
 			Name: "exec",
 			Description: fmt.Sprintf(`Execute a shell command %s. Runs in %s by default.
 

--- a/internal/agent/tools/container.go
+++ b/internal/agent/tools/container.go
@@ -131,20 +131,50 @@ func (p *ContainerProvider) Tools(ctx context.Context, session SessionContext) (
 		},
 		{
 			Name: "apply_patch",
-			Description: fmt.Sprintf(`Apply a structured patch %s. Supports adding, deleting, updating, and moving files.
+			Description: fmt.Sprintf(`Apply a structured patch %s. This is a Memoh/Codex-style patch format, not a standard unified diff or git patch.
 
-Patch format:
+Use this tool for multi-file edits, structured code changes, file creation, file deletion, or file moves. Use edit for one exact text replacement and write for full-file overwrite.
+
+Patch grammar:
+- The patch must start with "*** Begin Patch" and end with "*** End Patch".
+- Add a file with "*** Add File: path". Every following content line for that file must start with "+".
+- Delete a file with "*** Delete File: path".
+- Update a file with "*** Update File: path".
+- Move or rename a file by putting "*** Move to: new/path" immediately after an update header, before any changed lines.
+- Inside update hunks, use "@@" or "@@ context line" before changed lines. The optional context line helps locate the block in the file.
+- Changed lines use a one-character prefix: " " for unchanged context, "-" for removed lines, and "+" for added lines.
+- Use "*** End of File" inside an update hunk when the hunk should match the end of the file.
+- Paths are relative to the workspace by default. Absolute paths are accepted only when the workspace backend allows them.
+
+Examples:
+
+Add a file:
 *** Begin Patch
-*** Add File: path
+*** Add File: docs/notes.md
 +new line
+*** End Patch
+
+Update a file:
+*** Begin Patch
 *** Update File: path
 @@
 -old line
 +new line
-*** Delete File: path
 *** End Patch
 
-Use apply_patch for multi-file or structured edits. Use edit for a single exact text replacement and write for full-file overwrite.`, workspace.locationDescription),
+Move a file:
+*** Begin Patch
+*** Update File: old/path.txt
+*** Move to: new/path.txt
+@@
+ old content
+*** End Patch
+
+Delete a file:
+*** Begin Patch
+*** Delete File: obsolete.txt
+*** End Patch
+`, workspace.locationDescription),
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/internal/toolapproval/policy.go
+++ b/internal/toolapproval/policy.go
@@ -41,6 +41,15 @@ func needsApproval(cfg settings.ToolApprovalConfig, toolName string, input any) 
 			return false
 		}
 		return true
+	case "apply_patch":
+		// apply_patch can add, edit, delete, and move multiple files from a
+		// freeform patch body. Without a single path to compare against bypass
+		// globs, require approval whenever file mutations are configured for
+		// review or force-review rules exist.
+		return cfg.Write.RequireApproval ||
+			cfg.Edit.RequireApproval ||
+			len(cfg.Write.ForceReviewGlobs) > 0 ||
+			len(cfg.Edit.ForceReviewGlobs) > 0
 	case "exec":
 		exe, ok := simpleExecutable(readString(args, "command"))
 		if !ok {

--- a/internal/toolapproval/policy_test.go
+++ b/internal/toolapproval/policy_test.go
@@ -34,6 +34,26 @@ func TestNeedsApprovalForceReviewOverridesBypass(t *testing.T) {
 	}
 }
 
+func TestNeedsApprovalApplyPatchUsesFileApproval(t *testing.T) {
+	cfg := settings.DefaultToolApprovalConfig()
+	cfg.Enabled = true
+
+	if !needsApproval(cfg, "apply_patch", map[string]any{"patch": "*** Begin Patch\n*** End Patch"}) {
+		t.Fatal("expected apply_patch to require approval when file approvals are enabled")
+	}
+
+	cfg.Write.RequireApproval = false
+	cfg.Edit.RequireApproval = false
+	if needsApproval(cfg, "apply_patch", map[string]any{"patch": "*** Begin Patch\n*** End Patch"}) {
+		t.Fatal("expected apply_patch to skip approval when file approvals are disabled")
+	}
+
+	cfg.Write.ForceReviewGlobs = []string{"/data/secret/**"}
+	if !needsApproval(cfg, "apply_patch", map[string]any{"patch": "*** Begin Patch\n*** End Patch"}) {
+		t.Fatal("expected apply_patch to require approval when force-review file globs exist")
+	}
+}
+
 func TestNeedsApprovalExecDefaultsToAllowed(t *testing.T) {
 	cfg := settings.DefaultToolApprovalConfig()
 	cfg.Enabled = true


### PR DESCRIPTION
## Summary
- Add a Memoh-native `apply_patch` agent tool for structured file edits.
- Support add, delete, update, move, EOF markers, lenient heredoc wrapping, and fuzzy line matching inspired by Codex.
- Expand the tool schema description with the non-standard apply_patch grammar and examples.
- Add web UI handling for `apply_patch`, including patch summary/details rendering, file badges, diff counts, i18n labels, and file-pane refresh after patch mutations.

## Validation
- `go test ./internal/agent/tools ./internal/agent`
- `pnpm --filter @memohai/web exec vue-tsc --noEmit`
- `pnpm exec eslint apps/web/src/pages/home/components/tool-call-detail-apply-patch.vue apps/web/src/pages/home/components/tool-call-registry.ts apps/web/src/store/chat-list.ts apps/web/src/components/sidebar/files-pane.vue apps/web/src/components/file-manager/file-viewer.vue`
- Pre-commit full Go test hook was attempted but failed in `internal/handlers` at `TestChatCompactDevFlowCompactsAndArchivesFileMemory` with `listen unix .../bridge.sock: bind: invalid argument`, which appears environment/path related and outside this change.

## Notes
- The current Twilight tool schema uses an object parameter, so the tool accepts `{ "patch": "..." }` rather than a raw freeform payload.