### PR TITLE
feat: add list skill tool

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -366,6 +366,7 @@
       "spawn": "Spawn {count} subagents",
       "clustered": "{count} tool calls",
       "use_skill": "Use skill",
+      "list_skills": "List skills",
       "browser_action": "Browser {action}",
       "browser_observe": "Observe browser {action}",
       "computer_observe": "Observe desktop {action}",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -362,6 +362,7 @@
       "spawn": "派遣 {count} 个子代理",
       "clustered": "{count} 次工具调用",
       "use_skill": "使用技能",
+      "list_skills": "列出技能",
       "browser_action": "浏览器 {action}",
       "browser_observe": "观察浏览器 {action}",
       "computer_observe": "观察桌面 {action}",

--- a/apps/web/src/pages/home/components/tool-call-group.vue
+++ b/apps/web/src/pages/home/components/tool-call-group.vue
@@ -128,7 +128,7 @@ function labelFor(tool: ToolCallBlockType): string {
 const BROWSE_TOOLS = new Set([
   'read', 'list', 'web_search', 'web_fetch', 'search_memory', 'search_messages',
   'get_contacts', 'list_sessions', 'list_email', 'read_email', 'list_email_accounts',
-  'list_schedule', 'get_schedule',
+  'list_schedule', 'get_schedule', 'list_skills',
 ])
 const RUN_TOOLS = new Set(['exec'])
 const EDIT_TOOLS = new Set(['write', 'edit'])

--- a/apps/web/src/pages/home/components/tool-call-registry.ts
+++ b/apps/web/src/pages/home/components/tool-call-registry.ts
@@ -115,7 +115,7 @@ export function isDirPathTool(toolName: string): boolean {
 const READONLY_TOOLS = new Set([
   'read', 'list', 'web_search', 'web_fetch', 'search_memory', 'search_messages',
   'get_contacts', 'list_sessions', 'list_email', 'read_email', 'list_email_accounts',
-  'list_schedule', 'get_schedule', 'bg_status', 'browser_observe', 'computer_observe',
+  'list_schedule', 'get_schedule', 'list_skills', 'bg_status', 'browser_observe', 'computer_observe',
 ])
 
 export function isReadOnlyTool(toolName: string): boolean {
@@ -520,6 +520,12 @@ export function getToolDisplay(block: ToolCallBlock): ToolDisplay {
         icon: Sparkles,
         actionKey: 'use_skill',
         target: pickString(input, 'skillName'),
+      }
+    case 'list_skills':
+      return {
+        icon: Sparkles,
+        actionKey: 'list_skills',
+        target: '',
       }
     case 'browser_action': {
       const resolved = resolveGuiAction(BROWSER_ACTION_ICONS, 'browserAction', MousePointerClick, 'browser_action', pickString(input, 'action'))

--- a/internal/agent/tools/skill.go
+++ b/internal/agent/tools/skill.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 )
@@ -26,6 +27,36 @@ func (*SkillProvider) Tools(_ context.Context, session SessionContext) ([]sdk.To
 	}
 	skills := session.Skills
 	return []sdk.Tool{
+		{
+			Name:        "list_skills",
+			Description: "List the skills available in the current session. Use this to inspect skill names and descriptions before activating one with use_skill.",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+			Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
+				names := make([]string, 0, len(skills))
+				for name := range skills {
+					names = append(names, name)
+				}
+				sort.Strings(names)
+
+				items := make([]map[string]any, 0, len(names))
+				for _, name := range names {
+					skill := skills[name]
+					items = append(items, map[string]any{
+						"name":        name,
+						"description": skill.Description,
+						"path":        skill.Path,
+					})
+				}
+				return map[string]any{
+					"success": true,
+					"count":   len(items),
+					"skills":  items,
+				}, nil
+			},
+		},
 		{
 			Name:        "use_skill",
 			Description: "Activate a skill to get its full instructions. Call this when you think a skill is relevant to the current task.",

--- a/internal/agent/tools/skill_test.go
+++ b/internal/agent/tools/skill_test.go
@@ -5,6 +5,60 @@ import (
 	"testing"
 )
 
+func TestListSkillReturnsSortedSummaries(t *testing.T) {
+	provider := NewSkillProvider(nil)
+
+	toolset, err := provider.Tools(context.Background(), SessionContext{
+		Skills: map[string]SkillDetail{
+			"zeta": {
+				Description: "Zeta instructions",
+				Content:     "Do not include this full content.",
+				Path:        "/data/skills/zeta",
+			},
+			"alpha": {
+				Description: "Alpha instructions",
+				Content:     "Do not include this full content either.",
+				Path:        "/data/skills/alpha",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Tools returned error: %v", err)
+	}
+	if len(toolset) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(toolset))
+	}
+	if got := toolset[0].Name; got != "list_skills" {
+		t.Fatalf("first tool = %q, want list_skills", got)
+	}
+
+	result, err := toolset[0].Execute(nil, nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	payload, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", result)
+	}
+	if got := payload["count"]; got != 2 {
+		t.Fatalf("count = %#v, want 2", got)
+	}
+	items, ok := payload["skills"].([]map[string]any)
+	if !ok {
+		t.Fatalf("skills type = %T, want []map[string]any", payload["skills"])
+	}
+	if got := items[0]["name"]; got != "alpha" {
+		t.Fatalf("first skill name = %#v, want alpha", got)
+	}
+	if got := items[1]["name"]; got != "zeta" {
+		t.Fatalf("second skill name = %#v, want zeta", got)
+	}
+	if _, ok := items[0]["content"]; ok {
+		t.Fatalf("list_skills should not return full skill content")
+	}
+}
+
 func TestUseSkillReturnsPath(t *testing.T) {
 	provider := NewSkillProvider(nil)
 
@@ -20,11 +74,11 @@ func TestUseSkillReturnsPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Tools returned error: %v", err)
 	}
-	if len(toolset) != 1 {
-		t.Fatalf("expected 1 tool, got %d", len(toolset))
+	if len(toolset) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(toolset))
 	}
 
-	result, err := toolset[0].Execute(nil, map[string]any{
+	result, err := toolset[1].Execute(nil, map[string]any{
 		"skillName": "pdf",
 		"reason":    "Need to process a PDF attachment",
 	})


### PR DESCRIPTION
## Summary

- Add a `list_skills` native agent tool that lists available session skills by name, description, and path.
- Keep full skill instructions behind `use_skill` so listing skills does not return every skill body.
- Render `list_skills` as a first-class read-only tool in the chat UI, including grouped process summaries and English/Chinese labels.
- Cover sorted summary output and the existing `use_skill` path behavior with focused tests.

## Validation

- `go test ./internal/agent/tools`
- `pnpm exec eslint apps/web/src/pages/home/components/tool-call-registry.ts apps/web/src/pages/home/components/tool-call-group.vue`
- `node -e "JSON.parse(require('fs').readFileSync('apps/web/src/i18n/locales/en.json','utf8')); JSON.parse(require('fs').readFileSync('apps/web/src/i18n/locales/zh.json','utf8')); console.log('i18n json ok')"`
- `git diff --check`

Note: the local pre-commit hook ran broader Go tests and failed in `internal/handlers` on `TestChatCompactDevFlowCompactsAndArchivesFileMemory` with `listen unix .../bridge.sock: bind: invalid argument`, which appears unrelated to this tool change.