### PR TITLE
feat(agent): add get_messages tool

### DIFF
--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -661,7 +661,7 @@ func provideBackgroundManager(log *slog.Logger) *background.Manager {
 	return background.New(log)
 }
 
-func provideToolProviders(log *slog.Logger, channelManager *channel.Manager, registry *channel.Registry, routeService *route.DBService, scheduleService *schedule.Service, settingsService *settings.Service, searchProviderService *searchproviders.Service, fetchProviderService *fetchproviders.Service, manager *workspace.Manager, mediaService *media.Service, memoryRegistry *memprovider.Registry, emailService *emailpkg.Service, emailManager *emailpkg.Manager, fedGateway *handlers.MCPFederationGateway, mcpConnService *mcp.ConnectionService, modelsService *models.Service, queries dbstore.Queries, audioService *audiopkg.Service, sessionService *sessionpkg.Service, bgManager *background.Manager) []agenttools.ToolProvider {
+func provideToolProviders(log *slog.Logger, channelManager *channel.Manager, registry *channel.Registry, routeService *route.DBService, scheduleService *schedule.Service, settingsService *settings.Service, searchProviderService *searchproviders.Service, fetchProviderService *fetchproviders.Service, manager *workspace.Manager, mediaService *media.Service, memoryRegistry *memprovider.Registry, emailService *emailpkg.Service, emailManager *emailpkg.Manager, fedGateway *handlers.MCPFederationGateway, mcpConnService *mcp.ConnectionService, modelsService *models.Service, queries dbstore.Queries, audioService *audiopkg.Service, sessionService *sessionpkg.Service, messageService *message.DBService, bgManager *background.Manager) []agenttools.ToolProvider {
 	var assetResolver messaging.AssetResolver
 	if mediaService != nil {
 		assetResolver = &mediaAssetResolverAdapter{media: mediaService}
@@ -684,7 +684,7 @@ func provideToolProviders(log *slog.Logger, channelManager *channel.Manager, reg
 		agenttools.NewTranscriptionProvider(log, settingsService, audioService, mediaService),
 		agenttools.NewImageGenProvider(log, settingsService, modelsService, queries, manager, config.DefaultDataMount),
 		agenttools.NewFederationProvider(log, fedSource),
-		agenttools.NewHistoryProvider(log, sessionService, queries),
+		agenttools.NewHistoryProvider(log, sessionService, messageService, queries),
 	}
 }
 

--- a/internal/agent/tools/history.go
+++ b/internal/agent/tools/history.go
@@ -15,6 +15,7 @@ import (
 	dbpkg "github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
+	messagepkg "github.com/memohai/memoh/internal/message"
 	"github.com/memohai/memoh/internal/session"
 )
 
@@ -25,19 +26,29 @@ type SessionLister interface {
 	ListByBot(ctx context.Context, botID string) ([]session.Session, error)
 }
 
-// HistoryProvider exposes list_sessions and search_messages tools.
+// HistoryMessageReader is the minimal interface for reading persisted messages.
+type HistoryMessageReader interface {
+	ListLatest(ctx context.Context, botID string, limit int32) ([]messagepkg.Message, error)
+	ListBefore(ctx context.Context, botID string, before time.Time, limit int32) ([]messagepkg.Message, error)
+	ListLatestBySession(ctx context.Context, sessionID string, limit int32) ([]messagepkg.Message, error)
+	ListBeforeBySession(ctx context.Context, sessionID string, before time.Time, limit int32) ([]messagepkg.Message, error)
+}
+
+// HistoryProvider exposes list_sessions, get_messages, and search_messages tools.
 type HistoryProvider struct {
 	sessions SessionLister
+	messages HistoryMessageReader
 	queries  dbstore.Queries
 	logger   *slog.Logger
 }
 
-func NewHistoryProvider(log *slog.Logger, sessions SessionLister, queries dbstore.Queries) *HistoryProvider {
+func NewHistoryProvider(log *slog.Logger, sessions SessionLister, messages HistoryMessageReader, queries dbstore.Queries) *HistoryProvider {
 	if log == nil {
 		log = slog.Default()
 	}
 	return &HistoryProvider{
 		sessions: sessions,
+		messages: messages,
 		queries:  queries,
 		logger:   log.With(slog.String("tool", "history")),
 	}
@@ -75,6 +86,35 @@ func (p *HistoryProvider) Tools(_ context.Context, sess SessionContext) ([]sdk.T
 			},
 			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
 				return p.execListSessions(ctx.Context, s, inputAsMap(input))
+			},
+		})
+	}
+
+	if p.messages != nil {
+		s := sess
+		tools = append(tools, sdk.Tool{
+			Name:        "get_messages",
+			Description: "Get recent messages from a chat session. Defaults to the current session. Use list_sessions to find other session IDs. Results are returned oldest-first.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"session_id": map[string]any{
+						"type":        "string",
+						"description": "Session ID to read. Defaults to the current session when omitted.",
+					},
+					"before": map[string]any{
+						"type":        "string",
+						"description": "ISO 8601 timestamp cursor. When provided, returns messages created before this time.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Maximum number of messages to return. Default 30, max 100.",
+					},
+				},
+				"required": []string{},
+			},
+			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				return p.execGetMessages(ctx.Context, s, inputAsMap(input))
 			},
 		})
 	}
@@ -198,6 +238,98 @@ func (p *HistoryProvider) execListSessions(ctx context.Context, sess SessionCont
 }
 
 // ---------------------------------------------------------------------------
+// get_messages
+// ---------------------------------------------------------------------------
+
+func (p *HistoryProvider) execGetMessages(ctx context.Context, sess SessionContext, args map[string]any) (any, error) {
+	botID := strings.TrimSpace(sess.BotID)
+	if botID == "" {
+		return nil, errors.New("bot_id is required")
+	}
+
+	limit := int32(30)
+	if v, ok, err := IntArg(args, "limit"); err != nil {
+		return nil, err
+	} else if ok && v > 0 {
+		if v > 100 {
+			v = 100
+		}
+		limit = int32(v) //nolint:gosec // upper-bounded above
+	}
+
+	sessionID := strings.TrimSpace(StringArg(args, "session_id"))
+	if sessionID == "" {
+		sessionID = strings.TrimSpace(sess.SessionID)
+	}
+	if sessionID != "" && sessionID != strings.TrimSpace(sess.SessionID) {
+		if err := p.ensureSessionBelongsToBot(ctx, botID, sessionID); err != nil {
+			return nil, err
+		}
+	}
+
+	var (
+		messages []messagepkg.Message
+		err      error
+		before   time.Time
+	)
+	if rawBefore := StringArg(args, "before"); rawBefore != "" {
+		before, err = parseFlexibleTime(rawBefore)
+		if err != nil {
+			return nil, err
+		}
+		if sessionID != "" {
+			messages, err = p.messages.ListBeforeBySession(ctx, sessionID, before, limit)
+		} else {
+			messages, err = p.messages.ListBefore(ctx, botID, before, limit)
+		}
+	} else if sessionID != "" {
+		messages, err = p.messages.ListLatestBySession(ctx, sessionID, limit)
+		reverseHistoryMessages(messages)
+	} else {
+		messages, err = p.messages.ListLatest(ctx, botID, limit)
+		reverseHistoryMessages(messages)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]map[string]any, 0, len(messages))
+	for _, msg := range messages {
+		results = append(results, formatHistoryMessage(sess, msg))
+	}
+
+	out := map[string]any{
+		"ok":       true,
+		"bot_id":   botID,
+		"count":    len(results),
+		"messages": results,
+	}
+	if sessionID != "" {
+		out["session_id"] = sessionID
+	}
+	if !before.IsZero() {
+		out["before"] = sess.FormatTime(before)
+	}
+	return out, nil
+}
+
+func (p *HistoryProvider) ensureSessionBelongsToBot(ctx context.Context, botID, sessionID string) error {
+	if p.sessions == nil {
+		return errors.New("session lookup is not configured")
+	}
+	sessions, err := p.sessions.ListByBot(ctx, botID)
+	if err != nil {
+		return err
+	}
+	for _, item := range sessions {
+		if item.ID == sessionID {
+			return nil
+		}
+	}
+	return errors.New("session_id does not belong to the current bot")
+}
+
+// ---------------------------------------------------------------------------
 // search_messages
 // ---------------------------------------------------------------------------
 
@@ -283,6 +415,55 @@ func (p *HistoryProvider) execSearchMessages(ctx context.Context, sess SessionCo
 		"count":    len(messages),
 		"messages": messages,
 	}, nil
+}
+
+func formatHistoryMessage(sess SessionContext, msg messagepkg.Message) map[string]any {
+	entry := map[string]any{
+		"id":         msg.ID,
+		"session_id": msg.SessionID,
+		"role":       msg.Role,
+		"text":       extractTextContent(msg.Content),
+		"created_at": sess.FormatTime(msg.CreatedAt),
+	}
+	if strings.TrimSpace(msg.Platform) != "" {
+		entry["platform"] = msg.Platform
+	}
+	if strings.TrimSpace(msg.SenderDisplayName) != "" {
+		entry["sender"] = msg.SenderDisplayName
+	}
+	if strings.TrimSpace(msg.SenderChannelIdentityID) != "" {
+		entry["contact_id"] = msg.SenderChannelIdentityID
+	}
+	if strings.TrimSpace(msg.ExternalMessageID) != "" {
+		entry["external_message_id"] = msg.ExternalMessageID
+	}
+	if strings.TrimSpace(msg.SourceReplyToMessageID) != "" {
+		entry["source_reply_to_message_id"] = msg.SourceReplyToMessageID
+	}
+	if len(msg.Assets) > 0 {
+		assets := make([]map[string]any, 0, len(msg.Assets))
+		for _, asset := range msg.Assets {
+			item := map[string]any{
+				"content_hash": asset.ContentHash,
+				"role":         asset.Role,
+				"ordinal":      asset.Ordinal,
+				"mime":         asset.Mime,
+				"name":         asset.Name,
+			}
+			if asset.SizeBytes > 0 {
+				item["size_bytes"] = asset.SizeBytes
+			}
+			assets = append(assets, item)
+		}
+		entry["assets"] = assets
+	}
+	return entry
+}
+
+func reverseHistoryMessages(messages []messagepkg.Message) {
+	for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+		messages[i], messages[j] = messages[j], messages[i]
+	}
 }
 
 // extractTextContent deserialises the JSONB content column (a ModelMessage)
@@ -459,6 +640,7 @@ func dedupeHistoryNames(names []string) []string {
 }
 
 var timeFormats = []string{
+	time.RFC3339Nano,
 	time.RFC3339,
 	"2006-01-02T15:04:05",
 	"2006-01-02 15:04:05",

--- a/internal/agent/tools/history_test.go
+++ b/internal/agent/tools/history_test.go
@@ -1,11 +1,141 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/memohai/memoh/internal/conversation"
+	messagepkg "github.com/memohai/memoh/internal/message"
+	"github.com/memohai/memoh/internal/session"
 )
+
+type fakeHistorySessionLister struct {
+	sessions []session.Session
+}
+
+func (f fakeHistorySessionLister) ListByBot(_ context.Context, _ string) ([]session.Session, error) {
+	return f.sessions, nil
+}
+
+type fakeHistoryMessageReader struct {
+	latestSessionID string
+	beforeSessionID string
+	before          time.Time
+	latestMessages  []messagepkg.Message
+	beforeMessages  []messagepkg.Message
+}
+
+func (f *fakeHistoryMessageReader) ListLatest(_ context.Context, _ string, _ int32) ([]messagepkg.Message, error) {
+	return f.latestMessages, nil
+}
+
+func (f *fakeHistoryMessageReader) ListBefore(_ context.Context, _ string, before time.Time, _ int32) ([]messagepkg.Message, error) {
+	f.before = before
+	return f.beforeMessages, nil
+}
+
+func (f *fakeHistoryMessageReader) ListLatestBySession(_ context.Context, sessionID string, _ int32) ([]messagepkg.Message, error) {
+	f.latestSessionID = sessionID
+	return f.latestMessages, nil
+}
+
+func (f *fakeHistoryMessageReader) ListBeforeBySession(_ context.Context, sessionID string, before time.Time, _ int32) ([]messagepkg.Message, error) {
+	f.beforeSessionID = sessionID
+	f.before = before
+	return f.beforeMessages, nil
+}
+
+func TestHistoryProviderGetMessagesDefaultsToCurrentSession(t *testing.T) {
+	t.Parallel()
+
+	older := historyTestMessage(t, "msg-1", "session-current", "user", "hello", time.Date(2026, 6, 14, 9, 0, 0, 0, time.UTC))
+	newer := historyTestMessage(t, "msg-2", "session-current", "assistant", "hi there", time.Date(2026, 6, 14, 9, 1, 0, 0, time.UTC))
+	reader := &fakeHistoryMessageReader{latestMessages: []messagepkg.Message{newer, older}}
+	provider := NewHistoryProvider(nil, nil, reader, nil)
+
+	got, err := provider.execGetMessages(context.Background(), SessionContext{
+		BotID:     "bot-1",
+		SessionID: "session-current",
+	}, map[string]any{"limit": 2})
+	if err != nil {
+		t.Fatalf("execGetMessages() error = %v", err)
+	}
+	if reader.latestSessionID != "session-current" {
+		t.Fatalf("latest session id = %q, want session-current", reader.latestSessionID)
+	}
+
+	out := got.(map[string]any)
+	messages := out["messages"].([]map[string]any)
+	if len(messages) != 2 {
+		t.Fatalf("message count = %d, want 2", len(messages))
+	}
+	if messages[0]["id"] != "msg-1" || messages[0]["text"] != "hello" {
+		t.Fatalf("first message = %#v, want oldest message text", messages[0])
+	}
+	if messages[1]["id"] != "msg-2" || messages[1]["text"] != "hi there" {
+		t.Fatalf("second message = %#v, want newest message text", messages[1])
+	}
+}
+
+func TestHistoryProviderGetMessagesBeforeUsesRequestedSession(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeHistoryMessageReader{
+		beforeMessages: []messagepkg.Message{
+			historyTestMessage(t, "msg-1", "session-other", "user", "before cursor", time.Date(2026, 6, 14, 8, 0, 0, 0, time.UTC)),
+		},
+	}
+	provider := NewHistoryProvider(nil, fakeHistorySessionLister{
+		sessions: []session.Session{{ID: "session-other", BotID: "bot-1"}},
+	}, reader, nil)
+
+	got, err := provider.execGetMessages(context.Background(), SessionContext{
+		BotID:     "bot-1",
+		SessionID: "session-current",
+	}, map[string]any{
+		"session_id": "session-other",
+		"before":     "2026-06-14T09:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("execGetMessages() error = %v", err)
+	}
+	if reader.beforeSessionID != "session-other" {
+		t.Fatalf("before session id = %q, want session-other", reader.beforeSessionID)
+	}
+	if reader.before.IsZero() {
+		t.Fatal("before cursor was not parsed")
+	}
+
+	out := got.(map[string]any)
+	if out["session_id"] != "session-other" {
+		t.Fatalf("session_id = %v, want session-other", out["session_id"])
+	}
+	messages := out["messages"].([]map[string]any)
+	if messages[0]["text"] != "before cursor" {
+		t.Fatalf("message text = %v, want before cursor", messages[0]["text"])
+	}
+}
+
+func TestHistoryProviderGetMessagesRejectsSessionOutsideBot(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeHistoryMessageReader{}
+	provider := NewHistoryProvider(nil, fakeHistorySessionLister{
+		sessions: []session.Session{{ID: "session-current", BotID: "bot-1"}},
+	}, reader, nil)
+
+	_, err := provider.execGetMessages(context.Background(), SessionContext{
+		BotID:     "bot-1",
+		SessionID: "session-current",
+	}, map[string]any{
+		"session_id": "session-other",
+	})
+	if err == nil {
+		t.Fatal("execGetMessages() error = nil, want session ownership error")
+	}
+}
 
 func TestExtractTextContentSummarizesAssistantToolCalls(t *testing.T) {
 	t.Parallel()
@@ -31,6 +161,30 @@ func TestExtractTextContentSummarizesAssistantToolCalls(t *testing.T) {
 	want := "[tool_call: read, edit]"
 	if got != want {
 		t.Fatalf("extractTextContent() = %q, want %q", got, want)
+	}
+}
+
+func historyTestMessage(t *testing.T, id, sessionID, role, text string, createdAt time.Time) messagepkg.Message {
+	t.Helper()
+
+	rawText, err := json.Marshal(text)
+	if err != nil {
+		t.Fatalf("marshal text: %v", err)
+	}
+	content, err := json.Marshal(conversation.ModelMessage{
+		Role:    role,
+		Content: rawText,
+	})
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+	return messagepkg.Message{
+		ID:        id,
+		BotID:     "bot-1",
+		SessionID: sessionID,
+		Role:      role,
+		Content:   content,
+		CreatedAt: createdAt,
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a `get_messages` native history tool for agent sessions
- default reads to the current session, with optional `session_id`, `before`, and `limit`
- validate non-current session IDs against the current bot before reading messages

## Validation
- `go test ./internal/agent/tools ./cmd/agent`
- `TMPDIR=/tmp go test ./internal/handlers -run TestChatCompactDevFlowCompactsAndArchivesFileMemory -count=1`
- pre-commit hook with `TMPDIR=/tmp` (`go test ./...`)
