### PR TITLE
style: align sidebar settings action

### DIFF
--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -121,20 +121,14 @@
       <div class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-sidebar to-transparent" />
     </div>
 
-    <!-- Settings, pinned to the bottom. Shares the icon column with New Chat /
-         session rows: container px-2 + button px-[11px] → the hover pill sits 8px
-         off the left AND right walls, matching every list row above. Bottom pad is
-         pb-2 (8px) too, so the pill clears all three outer walls by the same 8px
-         (it was pb-1.5/6px, which read as the button crowding the bottom edge).
-         Top stays pt-1.5 — the list above fades into it, so it isn't a hard wall.
-         Hover uses the stronger ACTIVE fill (sidebar-accent) so it registers
-         against the non-white sidebar background. No top border — the list above
-         fades into it instead. -->
+    <!-- Settings, pinned to the bottom. Uses the same row metrics as Quick
+         Actions so the icon column, label x-position, text size and tone stay
+         aligned with the actions above. -->
     <div class="shrink-0 px-2 pt-1.5 pb-2">
       <Button
         variant="ghost"
         block
-        class="h-9 justify-start gap-2 rounded-[9px] px-[11px] text-control text-muted-foreground [--btn-ghost-hover:var(--sidebar-accent)] hover:text-foreground"
+        class="h-9 justify-start gap-[9px] px-[11px] text-control font-medium text-foreground/92 dark:text-[color:oklch(0.86_0_0)]"
         :class="isSettingsActive && 'bg-sidebar-accent text-foreground!'"
         :aria-label="t('sidebar.settings')"
         @click="router.push('/settings')"


### PR DESCRIPTION
## What changed
- Align the bottom Settings action with the Quick Actions row metrics.
- Simplify the Settings action comment to describe the shared row styling.

## Impact
- Keeps the sidebar action row spacing, text sizing, and tone consistent with the actions above it.

## Validation
- `pnpm exec eslint --concurrency=auto apps/web/src/components/sidebar/index.vue apps/web/src/components/sidebar/panel-sessions.vue apps/web/src/i18n/locales/en.json apps/web/src/i18n/locales/zh.json apps/web/src/pages/home/components/thinking-block.vue apps/web/src/pages/home/components/tool-call-detail-exec.vue apps/web/src/pages/home/components/tool-call-detail-output.vue apps/web/src/pages/home/components/tool-call-group.vue apps/web/src/pages/home/components/tool-call-inline.vue` passed for Vue files; locale JSON files were ignored by ESLint config with warnings.
- Pre-commit full Go tests were attempted and failed in unrelated `internal/handlers` Unix socket setup: `listen unix .../bridge.sock: bind: invalid argument`.
