### PR TITLE
feat: add manage bot quick action

### DIFF
--- a/apps/web/src/components/sidebar/panel-sessions.vue
+++ b/apps/web/src/components/sidebar/panel-sessions.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col h-full min-w-0">
     <!-- Quick Actions: a named cluster of "things you can start" (New Chat,
-         Scheduled Jobs), mirroring the Recents block below (actions you take vs
+         Manage Bot), mirroring the Recents block below (actions you take vs
          history you return to). The label does double duty: it names the group
          AND its top padding is what separates this cluster from the nav above —
          without it New Chat butts against the nav, and since the active Chat pill
@@ -34,13 +34,13 @@
         block
         class="h-9 justify-start gap-[9px] px-[11px] text-control font-medium text-foreground/92 dark:text-[color:oklch(0.86_0_0)]"
         :disabled="!currentBotId"
-        @click="handleScheduledJobs"
+        @click="handleManageBot"
       >
-        <Clock
+        <Settings
           :stroke-width="1.75"
           class="size-[18px]"
         />
-        {{ t('chat.scheduledJobs') }}
+        {{ t('chat.manageBot') }}
       </Button>
     </div>
     <Recents class="flex-1 min-h-0" />
@@ -52,7 +52,7 @@ import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { Button } from '@memohai/ui'
-import { SquarePen, Clock } from 'lucide-vue-next'
+import { SquarePen, Settings } from 'lucide-vue-next'
 import { useChatStore } from '@/store/chat-list'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import Recents from './recents.vue'
@@ -69,13 +69,9 @@ function handleNewSession() {
   workspaceTabs.openChat(t('chat.newSession'))
 }
 
-// Scheduled jobs live on the bot's settings page as a tab. The bot-detail route
-// accepts an id in its botName slot (same shortcut schedule-trigger-block uses),
-// so we can deep-link straight to the current bot's schedule tab without
-// resolving a name first.
-function handleScheduledJobs() {
+function handleManageBot() {
   const botId = currentBotId.value
   if (!botId) return
-  void router.push({ name: 'bot-detail', params: { botName: botId }, query: { tab: 'schedule' } })
+  void router.push({ name: 'bot-detail', params: { botName: botId } })
 }
 </script>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -536,6 +536,7 @@
     "noSessions": "No sessions yet",
     "recents": "Recents",
     "quickActions": "Quick Actions",
+    "manageBot": "Manage Bot",
     "scheduledJobs": "Scheduled Jobs",
     "sessionTypeHeartbeat": "Heartbeat",
     "sessionTypeSchedule": "Scheduled Task",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -532,6 +532,7 @@
     "noSessions": "暂无会话",
     "recents": "最近",
     "quickActions": "快捷操作",
+    "manageBot": "管理智能体",
     "scheduledJobs": "定时任务",
     "sessionTypeHeartbeat": "心跳",
     "sessionTypeSchedule": "定时任务",


### PR DESCRIPTION
## What changed
- Replace the Scheduled Jobs quick action with a Manage Bot quick action.
- Route the action to the current bot detail page.
- Add English and Chinese `chat.manageBot` translations.

## Impact
- Gives users a direct sidebar shortcut from chat to the selected bot management page.

## Validation
- `pnpm exec eslint --concurrency=auto apps/web/src/components/sidebar/index.vue apps/web/src/components/sidebar/panel-sessions.vue apps/web/src/i18n/locales/en.json apps/web/src/i18n/locales/zh.json apps/web/src/pages/home/components/thinking-block.vue apps/web/src/pages/home/components/tool-call-detail-exec.vue apps/web/src/pages/home/components/tool-call-detail-output.vue apps/web/src/pages/home/components/tool-call-group.vue apps/web/src/pages/home/components/tool-call-inline.vue` passed for Vue files; locale JSON files were ignored by ESLint config with warnings.
- Pre-commit full Go tests were attempted and failed in unrelated `internal/handlers` Unix socket setup: `listen unix .../bridge.sock: bind: invalid argument`.
