### PR TITLE
style: use rem font units in chat tool blocks

### DIFF
--- a/apps/web/src/pages/home/components/thinking-block.vue
+++ b/apps/web/src/pages/home/components/thinking-block.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-[13px] leading-[18px] font-[400]">
+  <div class="text-[0.8125rem] leading-[1.125rem] font-[400]">
     <button
       class="group/h flex items-center gap-1.5 w-full text-left transition-colors duration-75 cursor-pointer py-px text-muted-foreground hover:text-foreground select-none"
       @click="toggleOpen"

--- a/apps/web/src/pages/home/components/tool-call-detail-exec.vue
+++ b/apps/web/src/pages/home/components/tool-call-detail-exec.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="space-y-1.5 font-mono text-[12px] leading-relaxed">
+  <div class="space-y-1.5 font-mono text-[0.75rem] leading-relaxed">
     <div
       v-if="command"
       class="text-muted-foreground whitespace-pre-wrap break-all"
@@ -8,7 +8,7 @@
     </div>
     <div
       v-if="backgroundMeta.length"
-      class="flex flex-wrap gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground"
+      class="flex flex-wrap gap-x-2 gap-y-0.5 text-[0.6875rem] text-muted-foreground"
     >
       <span
         v-for="item in backgroundMeta"

--- a/apps/web/src/pages/home/components/tool-call-detail-output.vue
+++ b/apps/web/src/pages/home/components/tool-call-detail-output.vue
@@ -3,7 +3,7 @@
     v-if="text"
     :code="text"
     :filename="highlightFilename"
-    class="text-[12px] leading-relaxed whitespace-pre overflow-x-auto max-h-72 overflow-y-auto"
+    class="text-[0.75rem] leading-relaxed whitespace-pre overflow-x-auto max-h-72 overflow-y-auto"
   />
   <p
     v-else

--- a/apps/web/src/pages/home/components/tool-call-group.vue
+++ b/apps/web/src/pages/home/components/tool-call-group.vue
@@ -13,7 +13,7 @@
   <!-- Multiple items collapse into one process block. -->
   <div
     v-else
-    class="text-[13px] leading-[18px] font-[400]"
+    class="text-[0.8125rem] leading-[1.125rem] font-[400]"
   >
     <button
       class="group/h flex items-center gap-1.5 w-full text-left transition-colors duration-75 cursor-pointer py-px text-muted-foreground hover:text-foreground select-none"

--- a/apps/web/src/pages/home/components/tool-call-inline.vue
+++ b/apps/web/src/pages/home/components/tool-call-inline.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-[13px] leading-[18px] font-[400]">
+  <div class="text-[0.8125rem] leading-[1.125rem] font-[400]">
     <div
       v-if="expandable"
       role="button"


### PR DESCRIPTION
## What changed
- Convert chat thinking/tool-call arbitrary font sizes and line heights from px values to equivalent rem values.

## Impact
- Preserves the rendered sizes while making the font sizing relative to the root font size.

## Validation
- `pnpm exec eslint --concurrency=auto apps/web/src/components/sidebar/index.vue apps/web/src/components/sidebar/panel-sessions.vue apps/web/src/i18n/locales/en.json apps/web/src/i18n/locales/zh.json apps/web/src/pages/home/components/thinking-block.vue apps/web/src/pages/home/components/tool-call-detail-exec.vue apps/web/src/pages/home/components/tool-call-detail-output.vue apps/web/src/pages/home/components/tool-call-group.vue apps/web/src/pages/home/components/tool-call-inline.vue` passed for Vue files; locale JSON files were ignored by ESLint config with warnings.
- Pre-commit full Go tests were attempted and failed in unrelated `internal/handlers` Unix socket setup: `listen unix .../bridge.sock: bind: invalid argument`.
