### PR TITLE
fix(web): add dark mode overrides for markstream-vue code/table surface tokens

### DIFF
--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -346,6 +346,14 @@
   background-color: var(--color-card);
 }
 
+/* Dark mode: flip hardcoded light-surface values to dark equivalents */
+.dark .markstream-vue {
+  --code-bg: oklch(0.24 0 0);
+  --code-border: oklch(0.30 0 0);
+  --table-header-bg: oklch(0.22 0 0);
+  --inline-code-bg: oklch(0.24 0 0);
+}
+
 /* Full grid (Excel feel): both vertical + horizontal cell lines, but a finer/
  * lighter hairline than the outer frame so the grid is calm, not heavy. */
 .markstream-vue .table-node th,


### PR DESCRIPTION
## Summary

- `--code-bg`, `--code-border`, `--table-header-bg`, `--inline-code-bg` are set to hardcoded light-surface OKLCH values inside `.markstream-vue {}` (light mode only)
- In dark mode, these remain as light gray backgrounds, making code blocks and table headers look broken
- Add `.dark .markstream-vue {}` block to flip each token to a matching dark-surface equivalent

## Changes

`apps/web/src/style.css` — 8 lines added, no other files touched