### PR TITLE
feat(channel): inbound rich Parts across IMs

### DIFF
--- a/internal/channel/adapters/feishu/inbound.go
+++ b/internal/channel/adapters/feishu/inbound.go
@@ -51,6 +51,10 @@ func extractFeishuInbound(event *larkim.P2MessageReceiveV1, botOpenID string, lo
 			if postText != "" {
 				msg.Text = postText
 			}
+			if postParts := extractFeishuPostParts(contentMap); len(postParts) > 0 {
+				msg.Parts = postParts
+				msg.Format = channel.MessageFormatRich
+			}
 			postAtts := extractFeishuPostAttachments(contentMap, msg.ID)
 			msg.Attachments = append(msg.Attachments, postAtts...)
 			if len(postAtts) > 0 || postText != "" {

--- a/internal/channel/adapters/feishu/inbound_post.go
+++ b/internal/channel/adapters/feishu/inbound_post.go
@@ -227,7 +227,16 @@ func feishuPostPartToMessagePart(part map[string]any) (channel.MessagePart, bool
 			Language: strings.TrimSpace(stringValue(part["language"])),
 		}, true, true
 	default:
-		return channel.MessagePart{}, false, false
+		// Forward-compatible: any future tag carrying a `text` field should
+		// still surface its body so users don't lose content when a styled
+		// element promotes the post to rich (and adaptBody picks Parts over
+		// Text). rich=false keeps this from falsely promoting a plain-only
+		// post on its own.
+		text := stringValue(part["text"])
+		if text == "" {
+			return channel.MessagePart{}, false, false
+		}
+		return channel.MessagePart{Type: channel.MessagePartText, Text: text}, false, true
 	}
 }
 

--- a/internal/channel/adapters/feishu/inbound_post.go
+++ b/internal/channel/adapters/feishu/inbound_post.go
@@ -128,3 +128,124 @@ func stringValue(raw any) string {
 	}
 	return fmt.Sprint(raw)
 }
+
+func extractFeishuPostParts(contentMap map[string]any) []channel.MessagePart {
+	linesRaw := getFeishuPostContentLines(contentMap)
+	if linesRaw == nil {
+		return nil
+	}
+	var parts []channel.MessagePart
+	hasRich := false
+	for li, rawLine := range linesRaw {
+		line, ok := rawLine.([]any)
+		if !ok {
+			continue
+		}
+		if li > 0 && len(parts) > 0 {
+			parts = append(parts, channel.MessagePart{Type: channel.MessagePartText, Text: "\n"})
+			hasRich = true
+		}
+		for _, rawPart := range line {
+			part, ok := rawPart.(map[string]any)
+			if !ok {
+				continue
+			}
+			mp, rich, ok := feishuPostPartToMessagePart(part)
+			if !ok {
+				continue
+			}
+			if rich {
+				hasRich = true
+			}
+			parts = append(parts, mp)
+		}
+	}
+	if !hasRich {
+		return nil
+	}
+	return parts
+}
+
+func feishuPostPartToMessagePart(part map[string]any) (channel.MessagePart, bool, bool) {
+	tag := strings.ToLower(strings.TrimSpace(stringValue(part["tag"])))
+	switch tag {
+	case "text":
+		text := stringValue(part["text"])
+		if text == "" {
+			return channel.MessagePart{}, false, false
+		}
+		styles := feishuPostStyles(part["style"])
+		return channel.MessagePart{
+			Type:   channel.MessagePartText,
+			Text:   text,
+			Styles: styles,
+		}, len(styles) > 0, true
+	case "a":
+		text := stringValue(part["text"])
+		href := strings.TrimSpace(stringValue(part["href"]))
+		if text == "" && href == "" {
+			return channel.MessagePart{}, false, false
+		}
+		if text == "" {
+			text = href
+		}
+		return channel.MessagePart{
+			Type: channel.MessagePartLink,
+			Text: text,
+			URL:  href,
+		}, true, true
+	case "at":
+		uid := strings.TrimSpace(stringValue(part["user_id"]))
+		display := strings.TrimSpace(stringValue(part["text"]))
+		if display == "" {
+			display = strings.TrimSpace(stringValue(part["name"]))
+		}
+		if display == "" {
+			display = strings.TrimSpace(stringValue(part["user_name"]))
+		}
+		if display == "" {
+			if uid == "" {
+				return channel.MessagePart{}, false, false
+			}
+			display = "@" + uid
+		} else if !strings.HasPrefix(display, "@") {
+			display = "@" + display
+		}
+		return channel.MessagePart{
+			Type:              channel.MessagePartMention,
+			Text:              display,
+			ChannelIdentityID: uid,
+		}, true, true
+	case "code_block":
+		text := stringValue(part["text"])
+		if text == "" {
+			return channel.MessagePart{}, false, false
+		}
+		return channel.MessagePart{
+			Type:     channel.MessagePartCodeBlock,
+			Text:     text,
+			Language: strings.TrimSpace(stringValue(part["language"])),
+		}, true, true
+	default:
+		return channel.MessagePart{}, false, false
+	}
+}
+
+func feishuPostStyles(raw any) []channel.MessageTextStyle {
+	arr, ok := raw.([]any)
+	if !ok || len(arr) == 0 {
+		return nil
+	}
+	var styles []channel.MessageTextStyle
+	for _, item := range arr {
+		switch strings.ToLower(strings.TrimSpace(stringValue(item))) {
+		case "bold":
+			styles = append(styles, channel.MessageStyleBold)
+		case "italic":
+			styles = append(styles, channel.MessageStyleItalic)
+		case "linethrough", "strike", "strikethrough":
+			styles = append(styles, channel.MessageStyleStrikethrough)
+		}
+	}
+	return styles
+}

--- a/internal/channel/adapters/feishu/inbound_post_parts_test.go
+++ b/internal/channel/adapters/feishu/inbound_post_parts_test.go
@@ -1,0 +1,164 @@
+package feishu
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/channel"
+)
+
+func TestExtractFeishuPostParts_StyleArrayIsRespected(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "text", "text": "shout", "style": []any{"bold", "italic"}},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if len(parts) != 1 {
+		t.Fatalf("got %+v", parts)
+	}
+	styles := parts[0].Styles
+	if len(styles) != 2 || styles[0] != channel.MessageStyleBold || styles[1] != channel.MessageStyleItalic {
+		t.Fatalf("expected bold+italic styles, got %+v", styles)
+	}
+}
+
+func TestExtractFeishuPostParts_LineThroughMapsToStrike(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "text", "text": "gone", "style": []any{"lineThrough"}},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if len(parts) != 1 || len(parts[0].Styles) != 1 || parts[0].Styles[0] != channel.MessageStyleStrikethrough {
+		t.Fatalf("expected strikethrough, got %+v", parts)
+	}
+}
+
+func TestExtractFeishuPostParts_LinkTag(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "a", "text": "Memoh", "href": "https://example.com"},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if len(parts) != 1 || parts[0].Type != channel.MessagePartLink {
+		t.Fatalf("expected link part, got %+v", parts)
+	}
+	if parts[0].URL != "https://example.com" || parts[0].Text != "Memoh" {
+		t.Fatalf("link content wrong: %+v", parts[0])
+	}
+}
+
+func TestExtractFeishuPostParts_AtTag(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "at", "user_id": "ou_xyz", "text": "@Alice"},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if len(parts) != 1 || parts[0].Type != channel.MessagePartMention {
+		t.Fatalf("expected mention, got %+v", parts)
+	}
+	if parts[0].ChannelIdentityID != "ou_xyz" || parts[0].Text != "@Alice" {
+		t.Fatalf("mention content wrong: %+v", parts[0])
+	}
+}
+
+func TestExtractFeishuPostParts_CodeBlock(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "code_block", "text": "fn main(){}", "language": "rust"},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if len(parts) != 1 || parts[0].Type != channel.MessagePartCodeBlock {
+		t.Fatalf("expected code_block, got %+v", parts)
+	}
+	if parts[0].Language != "rust" || parts[0].Text != "fn main(){}" {
+		t.Fatalf("code_block content wrong: %+v", parts[0])
+	}
+}
+
+func TestExtractFeishuPostParts_MixedLineBreaksWithNewline(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "text", "text": "line1"},
+			},
+			[]any{
+				map[string]any{"tag": "text", "text": "line2"},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts (text, newline, text), got %+v", parts)
+	}
+	if parts[0].Text != "line1" {
+		t.Fatalf("part 0 wrong: %+v", parts[0])
+	}
+	if parts[1].Type != channel.MessagePartText || parts[1].Text != "\n" {
+		t.Fatalf("expected newline separator, got %+v", parts[1])
+	}
+	if parts[2].Text != "line2" {
+		t.Fatalf("part 2 wrong: %+v", parts[2])
+	}
+}
+
+func TestExtractFeishuPostParts_ImagesAndFilesSkipped(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "text", "text": "see", "style": []any{"bold"}},
+				map[string]any{"tag": "img", "image_key": "img_x"},
+				map[string]any{"tag": "file", "file_key": "f_y"},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if len(parts) != 1 || parts[0].Text != "see" || parts[0].Type != channel.MessagePartText {
+		t.Fatalf("img/file tags should be skipped (extracted as attachments elsewhere), got %+v", parts)
+	}
+}
+
+func TestExtractFeishuPostParts_NoContentReturnsNil(t *testing.T) {
+	t.Parallel()
+	if got := extractFeishuPostParts(nil); got != nil {
+		t.Fatalf("expected nil for nil content, got %+v", got)
+	}
+	if got := extractFeishuPostParts(map[string]any{}); got != nil {
+		t.Fatalf("expected nil for empty content, got %+v", got)
+	}
+}
+
+func TestExtractFeishuPostParts_PlainOnlyReturnsNil(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "text", "text": "just text"},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if parts != nil {
+		t.Fatalf("expected nil when only unstyled plain text (caller falls back to Text), got %+v", parts)
+	}
+}

--- a/internal/channel/adapters/feishu/inbound_post_parts_test.go
+++ b/internal/channel/adapters/feishu/inbound_post_parts_test.go
@@ -121,6 +121,28 @@ func TestExtractFeishuPostParts_MixedLineBreaksWithNewline(t *testing.T) {
 	}
 }
 
+func TestExtractFeishuPostParts_KeepsTextFromUnknownTag(t *testing.T) {
+	t.Parallel()
+	// When a styled element promotes the post to "rich", adaptBody picks Parts
+	// over Text. Any text-bearing unknown tag must still surface its body or
+	// the LLM loses that content entirely.
+	content := map[string]any{
+		"content": []any{
+			[]any{
+				map[string]any{"tag": "text", "text": "intro", "style": []any{"bold"}},
+				map[string]any{"tag": "unknown_future_tag", "text": "important detail"},
+			},
+		},
+	}
+	parts := extractFeishuPostParts(content)
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts (bold + unknown's text), got %+v", parts)
+	}
+	if parts[1].Type != channel.MessagePartText || parts[1].Text != "important detail" {
+		t.Fatalf("expected unknown tag's text preserved, got %+v", parts[1])
+	}
+}
+
 func TestExtractFeishuPostParts_ImagesAndFilesSkipped(t *testing.T) {
 	t.Parallel()
 	content := map[string]any{

--- a/internal/channel/adapters/telegram/parts.go
+++ b/internal/channel/adapters/telegram/parts.go
@@ -67,13 +67,17 @@ func extractTelegramMessageParts(msg *tgbotapi.Message) []channel.MessagePart {
 			if i == j {
 				continue
 			}
+			// Only style/format entities can host a structural child; two
+			// coextensive structurals (e.g. two text_links on the same span)
+			// would otherwise pick each other as parent and both get marked
+			// as nested, dropping both.
+			if telegramEntityIsStructural(candidate.Type) {
+				continue
+			}
 			if candidate.Offset > ent.Offset {
 				continue
 			}
 			if candidate.Offset+candidate.Length < ent.Offset+ent.Length {
-				continue
-			}
-			if candidate.Offset == ent.Offset && candidate.Length == ent.Length {
 				continue
 			}
 			if parent == -1 || candidate.Length < parentSize {

--- a/internal/channel/adapters/telegram/parts.go
+++ b/internal/channel/adapters/telegram/parts.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf16"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 
@@ -36,8 +37,12 @@ func extractTelegramMessageParts(msg *tgbotapi.Message) []channel.MessagePart {
 		return sorted[i].Length > sorted[j].Length
 	})
 
-	runes := []rune(text)
-	n := len(runes)
+	// Telegram entity offsets and lengths are documented as UTF-16 code units,
+	// so slice the text through utf16 indices rather than runes — supplementary
+	// plane characters (e.g. most emoji) take 2 code units each and would
+	// otherwise drift rune-based offsets.
+	units := utf16.Encode([]rune(text))
+	n := len(units)
 	var parts []channel.MessagePart
 	appendPlain := func(s string) {
 		if s == "" {
@@ -55,9 +60,9 @@ func extractTelegramMessageParts(msg *tgbotapi.Message) []channel.MessagePart {
 			continue
 		}
 		if ent.Offset > cursor {
-			appendPlain(string(runes[cursor:ent.Offset]))
+			appendPlain(string(utf16.Decode(units[cursor:ent.Offset])))
 		}
-		slice := string(runes[ent.Offset : ent.Offset+ent.Length])
+		slice := string(utf16.Decode(units[ent.Offset : ent.Offset+ent.Length]))
 		if part, ok := telegramEntityToPart(ent, slice); ok {
 			parts = append(parts, part)
 		} else {
@@ -66,7 +71,7 @@ func extractTelegramMessageParts(msg *tgbotapi.Message) []channel.MessagePart {
 		cursor = ent.Offset + ent.Length
 	}
 	if cursor < n {
-		appendPlain(string(runes[cursor:]))
+		appendPlain(string(utf16.Decode(units[cursor:])))
 	}
 
 	if onlyPlainText(parts) {

--- a/internal/channel/adapters/telegram/parts.go
+++ b/internal/channel/adapters/telegram/parts.go
@@ -51,9 +51,56 @@ func extractTelegramMessageParts(msg *tgbotapi.Message) []channel.MessagePart {
 		parts = append(parts, channel.MessagePart{Type: channel.MessagePartText, Text: s})
 	}
 
+	// Pre-pass: identify nested structural entities (link/mention/text_mention)
+	// so the outer span can be split around them. The flat MessagePart schema
+	// can't simultaneously style + link the same range, but splitting lets us
+	// keep both the styled context and the link/identity signal.
+	childrenOf := make([][]int, len(sorted))
+	isNestedChild := make([]bool, len(sorted))
+	for i, ent := range sorted {
+		if !telegramEntityIsStructural(ent.Type) {
+			continue
+		}
+		parent := -1
+		parentSize := 0
+		for j, candidate := range sorted {
+			if i == j {
+				continue
+			}
+			if candidate.Offset > ent.Offset {
+				continue
+			}
+			if candidate.Offset+candidate.Length < ent.Offset+ent.Length {
+				continue
+			}
+			if candidate.Offset == ent.Offset && candidate.Length == ent.Length {
+				continue
+			}
+			if parent == -1 || candidate.Length < parentSize {
+				parent = j
+				parentSize = candidate.Length
+			}
+		}
+		if parent != -1 {
+			childrenOf[parent] = append(childrenOf[parent], i)
+			isNestedChild[i] = true
+		}
+	}
+
+	emitFromEntity := func(ent tgbotapi.MessageEntity, slice string) {
+		if part, ok := telegramEntityToPart(ent, slice); ok {
+			parts = append(parts, part)
+		} else {
+			appendPlain(slice)
+		}
+	}
+
 	cursor := 0
-	for _, ent := range sorted {
+	for i, ent := range sorted {
 		if ent.Offset < 0 || ent.Length <= 0 || ent.Offset+ent.Length > n {
+			continue
+		}
+		if isNestedChild[i] {
 			continue
 		}
 		if ent.Offset < cursor {
@@ -62,11 +109,25 @@ func extractTelegramMessageParts(msg *tgbotapi.Message) []channel.MessagePart {
 		if ent.Offset > cursor {
 			appendPlain(string(utf16.Decode(units[cursor:ent.Offset])))
 		}
-		slice := string(utf16.Decode(units[ent.Offset : ent.Offset+ent.Length]))
-		if part, ok := telegramEntityToPart(ent, slice); ok {
-			parts = append(parts, part)
+		if kids := childrenOf[i]; len(kids) > 0 {
+			ordered := append([]int{}, kids...)
+			sort.SliceStable(ordered, func(a, b int) bool {
+				return sorted[ordered[a]].Offset < sorted[ordered[b]].Offset
+			})
+			innerCursor := ent.Offset
+			for _, ki := range ordered {
+				child := sorted[ki]
+				if child.Offset > innerCursor {
+					emitFromEntity(ent, string(utf16.Decode(units[innerCursor:child.Offset])))
+				}
+				emitFromEntity(child, string(utf16.Decode(units[child.Offset:child.Offset+child.Length])))
+				innerCursor = child.Offset + child.Length
+			}
+			if innerCursor < ent.Offset+ent.Length {
+				emitFromEntity(ent, string(utf16.Decode(units[innerCursor:ent.Offset+ent.Length])))
+			}
 		} else {
-			appendPlain(slice)
+			emitFromEntity(ent, string(utf16.Decode(units[ent.Offset:ent.Offset+ent.Length])))
 		}
 		cursor = ent.Offset + ent.Length
 	}
@@ -136,6 +197,14 @@ func telegramEntityToPart(ent tgbotapi.MessageEntity, slice string) (channel.Mes
 	default:
 		return channel.MessagePart{}, false
 	}
+}
+
+func telegramEntityIsStructural(t string) bool {
+	switch t {
+	case "mention", "text_mention", "text_link", "url":
+		return true
+	}
+	return false
 }
 
 func styledText(text string, style channel.MessageTextStyle) channel.MessagePart {

--- a/internal/channel/adapters/telegram/parts.go
+++ b/internal/channel/adapters/telegram/parts.go
@@ -1,0 +1,147 @@
+package telegram
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
+	"github.com/memohai/memoh/internal/channel"
+)
+
+// extractTelegramMessageParts converts Telegram entities into channel.MessagePart
+// slices, interleaving styled spans with the surrounding plain text. Returns nil
+// when the resulting slice would carry no rich information (so callers can fall
+// back to the plain Text field).
+func extractTelegramMessageParts(msg *tgbotapi.Message) []channel.MessagePart {
+	if msg == nil {
+		return nil
+	}
+	text := msg.Text
+	entities := msg.Entities
+	if text == "" {
+		text = msg.Caption
+		entities = msg.CaptionEntities
+	}
+	if text == "" || len(entities) == 0 {
+		return nil
+	}
+
+	sorted := append([]tgbotapi.MessageEntity{}, entities...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Offset != sorted[j].Offset {
+			return sorted[i].Offset < sorted[j].Offset
+		}
+		return sorted[i].Length > sorted[j].Length
+	})
+
+	runes := []rune(text)
+	n := len(runes)
+	var parts []channel.MessagePart
+	appendPlain := func(s string) {
+		if s == "" {
+			return
+		}
+		parts = append(parts, channel.MessagePart{Type: channel.MessagePartText, Text: s})
+	}
+
+	cursor := 0
+	for _, ent := range sorted {
+		if ent.Offset < 0 || ent.Length <= 0 || ent.Offset+ent.Length > n {
+			continue
+		}
+		if ent.Offset < cursor {
+			continue
+		}
+		if ent.Offset > cursor {
+			appendPlain(string(runes[cursor:ent.Offset]))
+		}
+		slice := string(runes[ent.Offset : ent.Offset+ent.Length])
+		if part, ok := telegramEntityToPart(ent, slice); ok {
+			parts = append(parts, part)
+		} else {
+			appendPlain(slice)
+		}
+		cursor = ent.Offset + ent.Length
+	}
+	if cursor < n {
+		appendPlain(string(runes[cursor:]))
+	}
+
+	if onlyPlainText(parts) {
+		return nil
+	}
+	return parts
+}
+
+func telegramEntityToPart(ent tgbotapi.MessageEntity, slice string) (channel.MessagePart, bool) {
+	switch ent.Type {
+	case "bold":
+		return styledText(slice, channel.MessageStyleBold), true
+	case "italic":
+		return styledText(slice, channel.MessageStyleItalic), true
+	case "strikethrough":
+		return styledText(slice, channel.MessageStyleStrikethrough), true
+	case "code":
+		return styledText(slice, channel.MessageStyleCode), true
+	case "pre":
+		return channel.MessagePart{
+			Type:     channel.MessagePartCodeBlock,
+			Text:     slice,
+			Language: strings.TrimSpace(ent.Language),
+		}, true
+	case "text_link":
+		return channel.MessagePart{
+			Type: channel.MessagePartLink,
+			Text: slice,
+			URL:  strings.TrimSpace(ent.URL),
+		}, true
+	case "url":
+		return channel.MessagePart{
+			Type: channel.MessagePartLink,
+			Text: slice,
+			URL:  slice,
+		}, true
+	case "mention":
+		return channel.MessagePart{Type: channel.MessagePartMention, Text: slice}, true
+	case "text_mention":
+		if ent.User == nil {
+			return channel.MessagePart{}, false
+		}
+		name := strings.TrimSpace(ent.User.FirstName + " " + ent.User.LastName)
+		if name == "" {
+			name = ent.User.UserName
+		}
+		meta := map[string]any{
+			"user_id": strconv.FormatInt(ent.User.ID, 10),
+		}
+		if ent.User.UserName != "" {
+			meta["username"] = ent.User.UserName
+		}
+		return channel.MessagePart{
+			Type:     channel.MessagePartMention,
+			Text:     "@" + name,
+			Metadata: meta,
+		}, true
+	default:
+		return channel.MessagePart{}, false
+	}
+}
+
+func styledText(text string, style channel.MessageTextStyle) channel.MessagePart {
+	return channel.MessagePart{
+		Type:   channel.MessagePartText,
+		Text:   text,
+		Styles: []channel.MessageTextStyle{style},
+	}
+}
+
+func onlyPlainText(parts []channel.MessagePart) bool {
+	for _, p := range parts {
+		if p.Type != channel.MessagePartText || len(p.Styles) > 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/channel/adapters/telegram/parts.go
+++ b/internal/channel/adapters/telegram/parts.go
@@ -114,20 +114,24 @@ func telegramEntityToPart(ent tgbotapi.MessageEntity, slice string) (channel.Mes
 		if ent.User == nil {
 			return channel.MessagePart{}, false
 		}
-		name := strings.TrimSpace(ent.User.FirstName + " " + ent.User.LastName)
-		if name == "" {
-			name = ent.User.UserName
-		}
+		uid := strconv.FormatInt(ent.User.ID, 10)
 		meta := map[string]any{
-			"user_id": strconv.FormatInt(ent.User.ID, 10),
+			"user_id": uid,
 		}
 		if ent.User.UserName != "" {
 			meta["username"] = ent.User.UserName
 		}
+		if name := strings.TrimSpace(ent.User.FirstName + " " + ent.User.LastName); name != "" {
+			meta["display_name"] = name
+		}
+		// Preserve the sender-typed label as the display text; identity flows
+		// through ChannelIdentityID + Metadata so the LLM still sees who was
+		// anchored without overwriting what the user actually wrote.
 		return channel.MessagePart{
-			Type:     channel.MessagePartMention,
-			Text:     "@" + name,
-			Metadata: meta,
+			Type:              channel.MessagePartMention,
+			Text:              slice,
+			ChannelIdentityID: uid,
+			Metadata:          meta,
 		}, true
 	default:
 		return channel.MessagePart{}, false

--- a/internal/channel/adapters/telegram/parts_test.go
+++ b/internal/channel/adapters/telegram/parts_test.go
@@ -314,6 +314,55 @@ func TestExtractTelegramMessageParts_HandlesSupplementaryPlaneEmoji(t *testing.T
 	}
 }
 
+func TestExtractTelegramMessageParts_NestedLinkInsideBold(t *testing.T) {
+	t.Parallel()
+	// Telegram sends overlapping entities natively: the bold span covers the
+	// whole rendered text and the text_link entity points at a sub-range.
+	// Splitting the outer around the inner keeps the URL discoverable; the
+	// flat MessagePart schema can't carry both bold and link at the same
+	// position, so the link span itself appears without the bold style.
+	msg := &tgbotapi.Message{
+		Text: "Check this out",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "bold", Offset: 0, Length: 14},
+			{Type: "text_link", Offset: 6, Length: 4, URL: "https://example.com"},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts (lead-bold + link + tail-bold), got %+v", parts)
+	}
+	if parts[0].Type != channel.MessagePartText || parts[0].Text != "Check " || len(parts[0].Styles) != 1 || parts[0].Styles[0] != channel.MessageStyleBold {
+		t.Fatalf("part 0 wrong: %+v", parts[0])
+	}
+	if parts[1].Type != channel.MessagePartLink || parts[1].URL != "https://example.com" || parts[1].Text != "this" {
+		t.Fatalf("part 1 wrong: %+v", parts[1])
+	}
+	if parts[2].Type != channel.MessagePartText || parts[2].Text != " out" || len(parts[2].Styles) != 1 || parts[2].Styles[0] != channel.MessageStyleBold {
+		t.Fatalf("part 2 wrong: %+v", parts[2])
+	}
+}
+
+func TestExtractTelegramMessageParts_NestedMentionInsideStyle(t *testing.T) {
+	t.Parallel()
+	// Same shape but with a text_mention nested in italic; identity must
+	// reach the LLM even though the italic span covers the mention.
+	msg := &tgbotapi.Message{
+		Text: "hi Alice ok",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "italic", Offset: 0, Length: 11},
+			{Type: "text_mention", Offset: 3, Length: 5, User: &tgbotapi.User{ID: 7, FirstName: "Alice"}},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts, got %+v", parts)
+	}
+	if parts[1].Type != channel.MessagePartMention || parts[1].Text != "Alice" || parts[1].ChannelIdentityID != "7" {
+		t.Fatalf("nested mention wrong: %+v", parts[1])
+	}
+}
+
 func TestExtractTelegramMessageParts_NilMessage(t *testing.T) {
 	t.Parallel()
 	if got := extractTelegramMessageParts(nil); got != nil {

--- a/internal/channel/adapters/telegram/parts_test.go
+++ b/internal/channel/adapters/telegram/parts_test.go
@@ -343,6 +343,35 @@ func TestExtractTelegramMessageParts_NestedLinkInsideBold(t *testing.T) {
 	}
 }
 
+func TestExtractTelegramMessageParts_LinkCoextensiveWithStyle(t *testing.T) {
+	t.Parallel()
+	// A fully bold link sends two entities covering the exact same range.
+	// The equality exclusion in the parent-search pre-pass treated those as
+	// "not nested", so the structural entity (text_link) was dropped by the
+	// main loop's cursor guard and the URL never reached the LLM.
+	msg := &tgbotapi.Message{
+		Text: "click here",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "bold", Offset: 0, Length: 10},
+			{Type: "text_link", Offset: 0, Length: 10, URL: "https://example.com"},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	var link *channel.MessagePart
+	for i := range parts {
+		if parts[i].Type == channel.MessagePartLink {
+			link = &parts[i]
+			break
+		}
+	}
+	if link == nil {
+		t.Fatalf("expected link part for coextensive bold+link, got %+v", parts)
+	}
+	if link.URL != "https://example.com" || link.Text != "click here" {
+		t.Fatalf("link content wrong: %+v", link)
+	}
+}
+
 func TestExtractTelegramMessageParts_NestedMentionInsideStyle(t *testing.T) {
 	t.Parallel()
 	// Same shape but with a text_mention nested in italic; identity must

--- a/internal/channel/adapters/telegram/parts_test.go
+++ b/internal/channel/adapters/telegram/parts_test.go
@@ -161,14 +161,55 @@ func TestExtractTelegramMessageParts_TextMentionCarriesUserMetadata(t *testing.T
 	if mention.Type != channel.MessagePartMention {
 		t.Fatalf("expected mention, got %+v", mention)
 	}
-	if mention.Text != "@Alice" {
-		t.Fatalf("expected @Alice display, got %q", mention.Text)
+	// The visible text the sender wrote (the entity slice) is preserved; the
+	// user identity is surfaced through Metadata + ChannelIdentityID rather
+	// than overwriting the displayed label.
+	if mention.Text != "Alice" {
+		t.Fatalf("expected slice 'Alice' preserved, got %q", mention.Text)
+	}
+	if mention.ChannelIdentityID != "7" {
+		t.Fatalf("expected channel_identity_id=7, got %q", mention.ChannelIdentityID)
 	}
 	if got := mention.Metadata["user_id"]; got != "7" {
 		t.Fatalf("expected user_id=7, got %v", got)
 	}
 	if got := mention.Metadata["username"]; got != "ali" {
 		t.Fatalf("expected username=ali, got %v", got)
+	}
+}
+
+func TestExtractTelegramMessageParts_TextMentionPreservesSenderLabel(t *testing.T) {
+	t.Parallel()
+	// A text_mention can anchor a profile link onto an arbitrary label such as
+	// "the reviewer". The displayed slice is what the LLM should see, not the
+	// linked profile's first name.
+	msg := &tgbotapi.Message{
+		Text: "ask the reviewer please",
+		Entities: []tgbotapi.MessageEntity{
+			{
+				Type:   "text_mention",
+				Offset: 4,
+				Length: 12,
+				User:   &tgbotapi.User{ID: 42, FirstName: "Alice", UserName: "ali"},
+			},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	var mention *channel.MessagePart
+	for i := range parts {
+		if parts[i].Type == channel.MessagePartMention {
+			mention = &parts[i]
+			break
+		}
+	}
+	if mention == nil {
+		t.Fatalf("expected mention, got %+v", parts)
+	}
+	if mention.Text != "the reviewer" {
+		t.Fatalf("expected sender-typed label preserved, got %q", mention.Text)
+	}
+	if got := mention.Metadata["user_id"]; got != "42" {
+		t.Fatalf("expected user_id=42, got %v", got)
 	}
 }
 

--- a/internal/channel/adapters/telegram/parts_test.go
+++ b/internal/channel/adapters/telegram/parts_test.go
@@ -221,8 +221,11 @@ func TestExtractTelegramMessageParts_UsesCaptionAndCaptionEntities(t *testing.T)
 	}
 }
 
-func TestExtractTelegramMessageParts_HonorsRuneOffsets(t *testing.T) {
+func TestExtractTelegramMessageParts_HonorsUTF16OffsetsForBMP(t *testing.T) {
 	t.Parallel()
+	// CJK characters live in the BMP, so one UTF-16 code unit equals one rune;
+	// the offsets line up under either indexing strategy. The supplementary-plane
+	// case is covered separately below.
 	msg := &tgbotapi.Message{
 		Text: "你好 world",
 		Entities: []tgbotapi.MessageEntity{
@@ -238,6 +241,35 @@ func TestExtractTelegramMessageParts_HonorsRuneOffsets(t *testing.T) {
 	}
 	if parts[1].Text != "world" || len(parts[1].Styles) != 1 {
 		t.Fatalf("expected bold 'world', got %+v", parts[1])
+	}
+}
+
+func TestExtractTelegramMessageParts_HandlesSupplementaryPlaneEmoji(t *testing.T) {
+	t.Parallel()
+	// 🎉 (U+1F389) is encoded as a UTF-16 surrogate pair (2 code units) but is a
+	// single rune in Go. Telegram entity offsets are documented as UTF-16 code
+	// units; rune-based slicing would drift by 1 after each supplementary-plane
+	// character.
+	msg := &tgbotapi.Message{
+		Text: "see 🎉 bold here",
+		Entities: []tgbotapi.MessageEntity{
+			// "bold" begins at UTF-16 index 7: "see "(0-3) + 🎉(4-5) + " "(6) + "bold"(7-10).
+			{Type: "bold", Offset: 7, Length: 4},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	var bold *channel.MessagePart
+	for i := range parts {
+		if len(parts[i].Styles) == 1 && parts[i].Styles[0] == channel.MessageStyleBold {
+			bold = &parts[i]
+			break
+		}
+	}
+	if bold == nil {
+		t.Fatalf("expected a bold part, got %+v", parts)
+	}
+	if bold.Text != "bold" {
+		t.Fatalf("expected bold text 'bold' under UTF-16 offsets, got %q (offsets interpreted as runes drift past the surrogate pair)", bold.Text)
 	}
 }
 

--- a/internal/channel/adapters/telegram/parts_test.go
+++ b/internal/channel/adapters/telegram/parts_test.go
@@ -1,0 +1,249 @@
+package telegram
+
+import (
+	"testing"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
+	"github.com/memohai/memoh/internal/channel"
+)
+
+func TestExtractTelegramMessageParts_PlainTextNoEntities(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{Text: "hello world"}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 0 {
+		t.Fatalf("expected no parts for plain text, got %+v", parts)
+	}
+}
+
+func TestExtractTelegramMessageParts_BoldSpanInMiddle(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "hi shout bye",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "bold", Offset: 3, Length: 5},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts (text, bold, text), got %d: %+v", len(parts), parts)
+	}
+	if parts[0].Type != channel.MessagePartText || parts[0].Text != "hi " {
+		t.Fatalf("part 0 wrong: %+v", parts[0])
+	}
+	if parts[1].Type != channel.MessagePartText || parts[1].Text != "shout" || len(parts[1].Styles) != 1 || parts[1].Styles[0] != channel.MessageStyleBold {
+		t.Fatalf("part 1 wrong: %+v", parts[1])
+	}
+	if parts[2].Type != channel.MessagePartText || parts[2].Text != " bye" {
+		t.Fatalf("part 2 wrong: %+v", parts[2])
+	}
+}
+
+func TestExtractTelegramMessageParts_ItalicStrikeCode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		entity string
+		style  channel.MessageTextStyle
+	}{
+		{"italic", "italic", channel.MessageStyleItalic},
+		{"strikethrough", "strikethrough", channel.MessageStyleStrikethrough},
+		{"inline_code", "code", channel.MessageStyleCode},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msg := &tgbotapi.Message{
+				Text: "xx",
+				Entities: []tgbotapi.MessageEntity{
+					{Type: tc.entity, Offset: 0, Length: 2},
+				},
+			}
+			parts := extractTelegramMessageParts(msg)
+			if len(parts) != 1 || parts[0].Type != channel.MessagePartText {
+				t.Fatalf("expected single text part, got %+v", parts)
+			}
+			if len(parts[0].Styles) != 1 || parts[0].Styles[0] != tc.style {
+				t.Fatalf("expected style %q, got %+v", tc.style, parts[0].Styles)
+			}
+		})
+	}
+}
+
+func TestExtractTelegramMessageParts_CodeBlockWithLanguage(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "fn main(){}",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "pre", Offset: 0, Length: 11, Language: "rust"},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part, got %+v", parts)
+	}
+	if parts[0].Type != channel.MessagePartCodeBlock || parts[0].Language != "rust" || parts[0].Text != "fn main(){}" {
+		t.Fatalf("expected pre with language=rust, got %+v", parts[0])
+	}
+}
+
+func TestExtractTelegramMessageParts_TextLinkWithURL(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "see Memoh now",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "text_link", Offset: 4, Length: 5, URL: "https://example.com"},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts, got %+v", parts)
+	}
+	if parts[1].Type != channel.MessagePartLink || parts[1].URL != "https://example.com" || parts[1].Text != "Memoh" {
+		t.Fatalf("link part wrong: %+v", parts[1])
+	}
+}
+
+func TestExtractTelegramMessageParts_BareURLEntity(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "go https://example.com",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "url", Offset: 3, Length: 19},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %+v", parts)
+	}
+	if parts[1].Type != channel.MessagePartLink || parts[1].URL != "https://example.com" || parts[1].Text != "https://example.com" {
+		t.Fatalf("url part wrong: %+v", parts[1])
+	}
+}
+
+func TestExtractTelegramMessageParts_MentionPreserved(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "hi @bot ok",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "mention", Offset: 3, Length: 4},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 parts, got %+v", parts)
+	}
+	if parts[1].Type != channel.MessagePartMention || parts[1].Text != "@bot" {
+		t.Fatalf("mention part wrong: %+v", parts[1])
+	}
+}
+
+func TestExtractTelegramMessageParts_TextMentionCarriesUserMetadata(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "hi Alice",
+		Entities: []tgbotapi.MessageEntity{
+			{
+				Type:   "text_mention",
+				Offset: 3,
+				Length: 5,
+				User:   &tgbotapi.User{ID: 7, FirstName: "Alice", UserName: "ali"},
+			},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) < 2 {
+		t.Fatalf("expected at least 2 parts, got %+v", parts)
+	}
+	mention := parts[len(parts)-1]
+	if mention.Type != channel.MessagePartMention {
+		t.Fatalf("expected mention, got %+v", mention)
+	}
+	if mention.Text != "@Alice" {
+		t.Fatalf("expected @Alice display, got %q", mention.Text)
+	}
+	if got := mention.Metadata["user_id"]; got != "7" {
+		t.Fatalf("expected user_id=7, got %v", got)
+	}
+	if got := mention.Metadata["username"]; got != "ali" {
+		t.Fatalf("expected username=ali, got %v", got)
+	}
+}
+
+func TestExtractTelegramMessageParts_UnsupportedEntityKeepsTextAsPlain(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "see #news today",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "hashtag", Offset: 4, Length: 5},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 0 {
+		t.Fatalf("expected no parts when only hashtag entity (whole text plain), got %+v", parts)
+	}
+}
+
+func TestExtractTelegramMessageParts_OverlappingEntityDropped(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "bold italic",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "bold", Offset: 0, Length: 11},
+			{Type: "italic", Offset: 5, Length: 6},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 part (outer bold), got %+v", parts)
+	}
+	if parts[0].Type != channel.MessagePartText || parts[0].Text != "bold italic" || len(parts[0].Styles) != 1 || parts[0].Styles[0] != channel.MessageStyleBold {
+		t.Fatalf("expected single bold-styled text, got %+v", parts[0])
+	}
+}
+
+func TestExtractTelegramMessageParts_UsesCaptionAndCaptionEntities(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Caption: "x y",
+		CaptionEntities: []tgbotapi.MessageEntity{
+			{Type: "bold", Offset: 0, Length: 1},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts from caption, got %+v", parts)
+	}
+	if parts[0].Type != channel.MessagePartText || parts[0].Text != "x" || len(parts[0].Styles) != 1 {
+		t.Fatalf("part 0 wrong: %+v", parts[0])
+	}
+}
+
+func TestExtractTelegramMessageParts_HonorsRuneOffsets(t *testing.T) {
+	t.Parallel()
+	msg := &tgbotapi.Message{
+		Text: "你好 world",
+		Entities: []tgbotapi.MessageEntity{
+			{Type: "bold", Offset: 3, Length: 5},
+		},
+	}
+	parts := extractTelegramMessageParts(msg)
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %+v", parts)
+	}
+	if parts[0].Text != "你好 " {
+		t.Fatalf("expected leading CJK text, got %q", parts[0].Text)
+	}
+	if parts[1].Text != "world" || len(parts[1].Styles) != 1 {
+		t.Fatalf("expected bold 'world', got %+v", parts[1])
+	}
+}
+
+func TestExtractTelegramMessageParts_NilMessage(t *testing.T) {
+	t.Parallel()
+	if got := extractTelegramMessageParts(nil); got != nil {
+		t.Fatalf("expected nil for nil msg, got %+v", got)
+	}
+}

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -760,15 +760,19 @@ func (a *TelegramAdapter) toInboundTelegramMessage(
 	for key, value := range metadata {
 		meta[key] = value
 	}
-	mentionParts := extractTelegramMessageParts(raw)
+	richParts := extractTelegramMessageParts(raw)
+	format := channel.MessageFormatPlain
+	if len(richParts) > 0 {
+		format = channel.MessageFormatRich
+	}
 
 	return channel.InboundMessage{
 		Channel: Type,
 		Message: channel.Message{
 			ID:          strconv.Itoa(raw.MessageID),
-			Format:      channel.MessageFormatPlain,
+			Format:      format,
 			Text:        text,
-			Parts:       mentionParts,
+			Parts:       richParts,
 			Attachments: attachments,
 			Reply:       replyRef,
 			Forward:     forwardRef,

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -760,7 +760,7 @@ func (a *TelegramAdapter) toInboundTelegramMessage(
 	for key, value := range metadata {
 		meta[key] = value
 	}
-	mentionParts := extractTelegramMentionParts(raw)
+	mentionParts := extractTelegramMessageParts(raw)
 
 	return channel.InboundMessage{
 		Channel: Type,
@@ -1564,55 +1564,6 @@ func buildTelegramAnimation(target string, file tgbotapi.RequestFileData) (tgbot
 	animation := tgbotapi.NewAnimation(chatID, file)
 	animation.ChannelUsername = channelUsername
 	return animation, nil
-}
-
-// extractTelegramMentionParts extracts structured mention parts from Telegram message entities.
-func extractTelegramMentionParts(msg *tgbotapi.Message) []channel.MessagePart {
-	if msg == nil {
-		return nil
-	}
-	text := msg.Text
-	if text == "" {
-		text = msg.Caption
-	}
-	entities := make([]tgbotapi.MessageEntity, 0, len(msg.Entities)+len(msg.CaptionEntities))
-	entities = append(entities, msg.Entities...)
-	entities = append(entities, msg.CaptionEntities...)
-
-	var parts []channel.MessagePart
-	for _, entity := range entities {
-		switch entity.Type {
-		case "mention":
-			if text != "" && entity.Offset >= 0 && entity.Offset+entity.Length <= len([]rune(text)) {
-				runes := []rune(text)
-				mentionText := string(runes[entity.Offset : entity.Offset+entity.Length])
-				parts = append(parts, channel.MessagePart{
-					Type: channel.MessagePartMention,
-					Text: mentionText,
-				})
-			}
-		case "text_mention":
-			if entity.User != nil {
-				name := strings.TrimSpace(entity.User.FirstName + " " + entity.User.LastName)
-				if name == "" {
-					name = entity.User.UserName
-				}
-				displayText := "@" + name
-				meta := map[string]any{
-					"user_id": strconv.FormatInt(entity.User.ID, 10),
-				}
-				if entity.User.UserName != "" {
-					meta["username"] = entity.User.UserName
-				}
-				parts = append(parts, channel.MessagePart{
-					Type:     channel.MessagePartMention,
-					Text:     displayText,
-					Metadata: meta,
-				})
-			}
-		}
-	}
-	return parts
 }
 
 func isTelegramBotMentioned(msg *tgbotapi.Message, botUsername string) bool {

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -330,6 +330,61 @@ func TestBuildTelegramInboundMessageIncludesUpdateIDMetadata(t *testing.T) {
 	}
 }
 
+func TestBuildTelegramInboundMessage_PlainFormatWhenNoEntities(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewTelegramAdapter(nil)
+	bot := &tgbotapi.BotAPI{Token: "test", Self: tgbotapi.User{ID: 1, UserName: "memohbot"}}
+	update := tgbotapi.Update{
+		UpdateID: 1,
+		Message: &tgbotapi.Message{
+			MessageID: 1,
+			Text:      "plain text only",
+			Chat:      &tgbotapi.Chat{ID: 1, Type: "private"},
+			From:      &tgbotapi.User{ID: 1, UserName: "alice"},
+		},
+	}
+	inbound, ok := adapter.buildTelegramInboundMessage(bot, channel.ChannelConfig{}, update)
+	if !ok {
+		t.Fatal("expected inbound message")
+	}
+	if inbound.Message.Format != channel.MessageFormatPlain {
+		t.Fatalf("expected plain format when no entities, got %q", inbound.Message.Format)
+	}
+	if len(inbound.Message.Parts) != 0 {
+		t.Fatalf("expected no Parts, got %+v", inbound.Message.Parts)
+	}
+}
+
+func TestBuildTelegramInboundMessage_RichFormatWhenEntitiesPopulateParts(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewTelegramAdapter(nil)
+	bot := &tgbotapi.BotAPI{Token: "test", Self: tgbotapi.User{ID: 1, UserName: "memohbot"}}
+	update := tgbotapi.Update{
+		UpdateID: 1,
+		Message: &tgbotapi.Message{
+			MessageID: 1,
+			Text:      "hi shout bye",
+			Chat:      &tgbotapi.Chat{ID: 1, Type: "private"},
+			From:      &tgbotapi.User{ID: 1, UserName: "alice"},
+			Entities: []tgbotapi.MessageEntity{
+				{Type: "bold", Offset: 3, Length: 5},
+			},
+		},
+	}
+	inbound, ok := adapter.buildTelegramInboundMessage(bot, channel.ChannelConfig{}, update)
+	if !ok {
+		t.Fatal("expected inbound message")
+	}
+	if len(inbound.Message.Parts) == 0 {
+		t.Fatalf("expected Parts populated from bold entity, got empty")
+	}
+	if inbound.Message.Format != channel.MessageFormatRich {
+		t.Fatalf("expected rich format when Parts populate, got %q", inbound.Message.Format)
+	}
+}
+
 func TestSeenTelegramUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/adapt.go
+++ b/internal/pipeline/adapt.go
@@ -39,7 +39,7 @@ func adaptMessage(msg channel.InboundMessage, sessionID, channelIdentityID, disp
 		}
 	}
 
-	content := adaptContent(msg.Message.Text)
+	content := adaptBody(msg.Message)
 	attachments := adaptAttachments(msg.Message.Attachments)
 	forwardInfo := adaptForward(msg.Message.Forward)
 
@@ -83,6 +83,125 @@ func adaptContent(text string) []ContentNode {
 		return nil
 	}
 	return []ContentNode{{Type: "text", Text: text}}
+}
+
+func adaptBody(m channel.Message) []ContentNode {
+	if nodes := adaptParts(m.Parts); len(nodes) > 0 {
+		return nodes
+	}
+	return adaptContent(m.Text)
+}
+
+func adaptParts(parts []channel.MessagePart) []ContentNode {
+	if len(parts) == 0 {
+		return nil
+	}
+	nodes := make([]ContentNode, 0, len(parts))
+	for _, p := range parts {
+		node, ok := partToNode(p)
+		if !ok {
+			continue
+		}
+		nodes = append(nodes, node)
+	}
+	if len(nodes) == 0 {
+		return nil
+	}
+	return nodes
+}
+
+func partToNode(p channel.MessagePart) (ContentNode, bool) {
+	switch p.Type {
+	case channel.MessagePartCodeBlock:
+		if strings.TrimSpace(p.Text) == "" {
+			return ContentNode{}, false
+		}
+		return ContentNode{Type: "pre", Language: strings.TrimSpace(p.Language), Text: p.Text}, true
+	case channel.MessagePartLink:
+		display := p.Text
+		if strings.TrimSpace(display) == "" {
+			display = p.URL
+		}
+		if strings.TrimSpace(display) == "" {
+			return ContentNode{}, false
+		}
+		return ContentNode{
+			Type:     "link",
+			URL:      strings.TrimSpace(p.URL),
+			Children: []ContentNode{{Type: "text", Text: display}},
+		}, true
+	case channel.MessagePartMention:
+		display := strings.TrimSpace(p.Text)
+		uid := strings.TrimSpace(p.ChannelIdentityID)
+		if display == "" {
+			if uid == "" {
+				return ContentNode{}, false
+			}
+			display = "@" + uid
+		}
+		return ContentNode{
+			Type:     "mention",
+			UserID:   uid,
+			Children: []ContentNode{{Type: "text", Text: display}},
+		}, true
+	case channel.MessagePartEmoji:
+		text := strings.TrimSpace(p.Emoji)
+		if text == "" {
+			text = strings.TrimSpace(p.Text)
+		}
+		if text == "" {
+			return ContentNode{}, false
+		}
+		return ContentNode{Type: "text", Text: text}, true
+	case channel.MessagePartText:
+		return textPartToNode(p)
+	default:
+		return ContentNode{}, false
+	}
+}
+
+func textPartToNode(p channel.MessagePart) (ContentNode, bool) {
+	if strings.TrimSpace(p.Text) == "" {
+		return ContentNode{}, false
+	}
+
+	hasInlineCode := false
+	wrappers := make([]channel.MessageTextStyle, 0, len(p.Styles))
+	for _, s := range p.Styles {
+		if s == channel.MessageStyleCode {
+			hasInlineCode = true
+			continue
+		}
+		wrappers = append(wrappers, s)
+	}
+
+	var node ContentNode
+	if hasInlineCode {
+		node = ContentNode{Type: "code", Text: p.Text}
+	} else {
+		node = ContentNode{Type: "text", Text: p.Text}
+	}
+	for i := len(wrappers) - 1; i >= 0; i-- {
+		kind := styleToNodeType(wrappers[i])
+		if kind == "" {
+			continue
+		}
+		node = ContentNode{Type: kind, Children: []ContentNode{node}}
+	}
+	return node, true
+}
+
+func styleToNodeType(s channel.MessageTextStyle) string {
+	switch s {
+	case channel.MessageStyleBold:
+		return "bold"
+	case channel.MessageStyleItalic:
+		return "italic"
+	case channel.MessageStyleStrikethrough:
+		return "strikethrough"
+	default:
+		return ""
+	}
 }
 
 func adaptAttachments(atts []channel.Attachment) []Attachment {
@@ -159,7 +278,7 @@ func adaptEdit(msg channel.InboundMessage, sessionID, channelIdentityID, display
 		ReceivedAtMs: now.UnixMilli(),
 		TimestampSec: now.Unix(),
 		UTCOffsetMin: offset / 60,
-		Content:      adaptContent(msg.Message.Text),
+		Content:      adaptBody(msg.Message),
 		Attachments:  adaptAttachments(msg.Message.Attachments),
 	}
 }

--- a/internal/pipeline/adapt.go
+++ b/internal/pipeline/adapt.go
@@ -161,7 +161,7 @@ func partToNode(p channel.MessagePart) (ContentNode, bool) {
 }
 
 func textPartToNode(p channel.MessagePart) (ContentNode, bool) {
-	if strings.TrimSpace(p.Text) == "" {
+	if p.Text == "" {
 		return ContentNode{}, false
 	}
 

--- a/internal/pipeline/adapt_test.go
+++ b/internal/pipeline/adapt_test.go
@@ -1,0 +1,251 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/memohai/memoh/internal/channel"
+)
+
+func TestAdaptInbound_FallsBackToText_WhenPartsEmpty(t *testing.T) {
+	msg := channel.InboundMessage{
+		Channel:    channel.ChannelTypeTelegram,
+		Message:    channel.Message{ID: "m1", Text: "plain hello"},
+		ReceivedAt: time.Unix(1700000000, 0).UTC(),
+	}
+	ev := AdaptInbound(msg, "sess", "ci", "Alice")
+	me, ok := ev.(MessageEvent)
+	if !ok {
+		t.Fatalf("expected MessageEvent, got %T", ev)
+	}
+	if len(me.Content) != 1 || me.Content[0].Type != "text" || me.Content[0].Text != "plain hello" {
+		t.Fatalf("expected single text node, got %+v", me.Content)
+	}
+}
+
+func TestAdaptInbound_PreservesMention_FromParts(t *testing.T) {
+	msg := channel.InboundMessage{
+		Channel: channel.ChannelTypeTelegram,
+		Message: channel.Message{
+			ID:     "m1",
+			Format: channel.MessageFormatRich,
+			Text:   "hello @bot",
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartText, Text: "hello "},
+				{Type: channel.MessagePartMention, Text: "@bot", ChannelIdentityID: "ci-bot"},
+			},
+		},
+		ReceivedAt: time.Unix(1700000000, 0).UTC(),
+	}
+	me := AdaptInbound(msg, "sess", "ci", "Alice").(MessageEvent)
+	if len(me.Content) != 2 {
+		t.Fatalf("expected 2 nodes, got %d: %+v", len(me.Content), me.Content)
+	}
+	if me.Content[0].Type != "text" || me.Content[0].Text != "hello " {
+		t.Fatalf("expected leading text node, got %+v", me.Content[0])
+	}
+	mention := me.Content[1]
+	if mention.Type != "mention" || mention.UserID != "ci-bot" {
+		t.Fatalf("expected mention with UserID=ci-bot, got %+v", mention)
+	}
+	if len(mention.Children) != 1 || mention.Children[0].Type != "text" || mention.Children[0].Text != "@bot" {
+		t.Fatalf("expected mention to wrap text child '@bot', got %+v", mention.Children)
+	}
+}
+
+func TestAdaptInbound_PreservesLink_FromParts(t *testing.T) {
+	msg := channel.InboundMessage{
+		Message: channel.Message{
+			ID: "m1",
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartLink, Text: "Memoh", URL: "https://example.com"},
+			},
+		},
+	}
+	me := AdaptInbound(msg, "sess", "", "").(MessageEvent)
+	if len(me.Content) != 1 || me.Content[0].Type != "link" {
+		t.Fatalf("expected single link node, got %+v", me.Content)
+	}
+	if me.Content[0].URL != "https://example.com" {
+		t.Fatalf("expected URL preserved, got %+v", me.Content[0])
+	}
+	kids := me.Content[0].Children
+	if len(kids) != 1 || kids[0].Type != "text" || kids[0].Text != "Memoh" {
+		t.Fatalf("expected link to wrap text 'Memoh', got %+v", kids)
+	}
+}
+
+func TestAdaptInbound_CodeBlockIsLeafWithLanguage(t *testing.T) {
+	msg := channel.InboundMessage{
+		Message: channel.Message{
+			ID: "m1",
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartCodeBlock, Text: "fn main(){}", Language: "rust"},
+			},
+		},
+	}
+	me := AdaptInbound(msg, "sess", "", "").(MessageEvent)
+	if len(me.Content) != 1 {
+		t.Fatalf("got %+v", me.Content)
+	}
+	got := me.Content[0]
+	if got.Type != "pre" || got.Language != "rust" || got.Text != "fn main(){}" {
+		t.Fatalf("expected leaf pre node with language=rust, got %+v", got)
+	}
+	if len(got.Children) != 0 {
+		t.Fatalf("pre should be a leaf, got children %+v", got.Children)
+	}
+}
+
+func TestAdaptInbound_InlineCodeStyleIsLeaf(t *testing.T) {
+	msg := channel.InboundMessage{
+		Message: channel.Message{
+			ID: "m1",
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartText, Text: "x", Styles: []channel.MessageTextStyle{channel.MessageStyleCode}},
+			},
+		},
+	}
+	me := AdaptInbound(msg, "sess", "", "").(MessageEvent)
+	if len(me.Content) != 1 || me.Content[0].Type != "code" || me.Content[0].Text != "x" {
+		t.Fatalf("expected leaf code node, got %+v", me.Content)
+	}
+	if len(me.Content[0].Children) != 0 {
+		t.Fatalf("inline code should be a leaf, got children %+v", me.Content[0].Children)
+	}
+}
+
+func TestAdaptInbound_NestsCompoundStyles(t *testing.T) {
+	msg := channel.InboundMessage{
+		Message: channel.Message{
+			ID: "m1",
+			Parts: []channel.MessagePart{
+				{
+					Type:   channel.MessagePartText,
+					Text:   "shout",
+					Styles: []channel.MessageTextStyle{channel.MessageStyleBold, channel.MessageStyleItalic},
+				},
+			},
+		},
+	}
+	me := AdaptInbound(msg, "sess", "", "").(MessageEvent)
+	if len(me.Content) != 1 || me.Content[0].Type != "bold" {
+		t.Fatalf("expected outer bold, got %+v", me.Content)
+	}
+	inner := me.Content[0].Children
+	if len(inner) != 1 || inner[0].Type != "italic" {
+		t.Fatalf("expected inner italic, got %+v", inner)
+	}
+	leaf := inner[0].Children
+	if len(leaf) != 1 || leaf[0].Type != "text" || leaf[0].Text != "shout" {
+		t.Fatalf("expected leaf text 'shout', got %+v", leaf)
+	}
+}
+
+func TestAdaptInbound_StrikethroughStyleWraps(t *testing.T) {
+	msg := channel.InboundMessage{
+		Message: channel.Message{
+			ID: "m1",
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartText, Text: "gone", Styles: []channel.MessageTextStyle{channel.MessageStyleStrikethrough}},
+			},
+		},
+	}
+	me := AdaptInbound(msg, "sess", "", "").(MessageEvent)
+	if len(me.Content) != 1 || me.Content[0].Type != "strikethrough" {
+		t.Fatalf("expected strikethrough wrapper, got %+v", me.Content)
+	}
+	kids := me.Content[0].Children
+	if len(kids) != 1 || kids[0].Type != "text" || kids[0].Text != "gone" {
+		t.Fatalf("expected text child 'gone', got %+v", kids)
+	}
+}
+
+func TestAdaptInbound_EmojiBecomesText(t *testing.T) {
+	msg := channel.InboundMessage{
+		Message: channel.Message{
+			ID: "m1",
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartEmoji, Emoji: "👍"},
+			},
+		},
+	}
+	me := AdaptInbound(msg, "sess", "", "").(MessageEvent)
+	if len(me.Content) != 1 || me.Content[0].Type != "text" || me.Content[0].Text != "👍" {
+		t.Fatalf("expected emoji rendered as text node, got %+v", me.Content)
+	}
+}
+
+func TestAdaptInbound_SkipsEmptyTextParts(t *testing.T) {
+	msg := channel.InboundMessage{
+		Message: channel.Message{
+			ID: "m1",
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartText, Text: ""},
+				{Type: channel.MessagePartText, Text: "kept"},
+				{Type: channel.MessagePartText, Text: "   "},
+			},
+		},
+	}
+	me := AdaptInbound(msg, "sess", "", "").(MessageEvent)
+	if len(me.Content) != 1 || me.Content[0].Text != "kept" {
+		t.Fatalf("expected only the non-empty text node, got %+v", me.Content)
+	}
+}
+
+func TestAdaptInbound_EditEvent_PreservesParts(t *testing.T) {
+	msg := channel.InboundMessage{
+		Message: channel.Message{
+			ID:   "m1",
+			Text: "fallback",
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartMention, Text: "@bot", ChannelIdentityID: "ci-bot"},
+			},
+		},
+		Metadata:   map[string]any{"event_type": "edit"},
+		ReceivedAt: time.Unix(1700000000, 0).UTC(),
+	}
+	e := AdaptInbound(msg, "sess", "ci", "Alice").(EditEvent)
+	if len(e.Content) != 1 || e.Content[0].Type != "mention" || e.Content[0].UserID != "ci-bot" {
+		t.Fatalf("expected edit event to preserve mention, got %+v", e.Content)
+	}
+}
+
+func TestAdaptInbound_RoundTripsThroughRenderer(t *testing.T) {
+	msg := channel.InboundMessage{
+		Channel: channel.ChannelTypeTelegram,
+		Message: channel.Message{
+			ID:     "m1",
+			Format: channel.MessageFormatRich,
+			Parts: []channel.MessagePart{
+				{Type: channel.MessagePartText, Text: "hi "},
+				{Type: channel.MessagePartMention, Text: "@bot", ChannelIdentityID: "ci-bot"},
+				{Type: channel.MessagePartText, Text: " see "},
+				{Type: channel.MessagePartLink, Text: "Memoh", URL: "https://example.com"},
+			},
+		},
+		ReceivedAt: time.Unix(1700000000, 0).UTC(),
+	}
+	me := AdaptInbound(msg, "sess", "ci-sender", "Alice").(MessageEvent)
+	icMsg := &ICMessage{
+		MessageID:    me.MessageID,
+		Sender:       me.Sender,
+		ReceivedAtMs: me.ReceivedAtMs,
+		TimestampSec: me.TimestampSec,
+		UTCOffsetMin: me.UTCOffsetMin,
+		Content:      me.Content,
+		Conversation: me.Conversation,
+	}
+	seg := renderMessage(icMsg, RenderParams{})
+	if len(seg.Content) == 0 {
+		t.Fatalf("expected rendered content")
+	}
+	xml := seg.Content[0].Text
+	if !strings.Contains(xml, `<mention uid="ci-bot">@bot</mention>`) {
+		t.Fatalf("expected rendered mention tag, got: %s", xml)
+	}
+	if !strings.Contains(xml, `<a href="https://example.com">Memoh</a>`) {
+		t.Fatalf("expected rendered link tag, got: %s", xml)
+	}
+}

--- a/internal/pipeline/adapt_test.go
+++ b/internal/pipeline/adapt_test.go
@@ -177,20 +177,33 @@ func TestAdaptInbound_EmojiBecomesText(t *testing.T) {
 	}
 }
 
-func TestAdaptInbound_SkipsEmptyTextParts(t *testing.T) {
+func TestAdaptInbound_SkipsLiterallyEmptyTextParts(t *testing.T) {
+	// Only truly empty text parts are dropped; whitespace-only spans (newline
+	// separators emitted by structured-post adapters like Feishu) must survive
+	// so that line breaks between rich spans are preserved end-to-end.
 	msg := channel.InboundMessage{
 		Message: channel.Message{
 			ID: "m1",
 			Parts: []channel.MessagePart{
 				{Type: channel.MessagePartText, Text: ""},
 				{Type: channel.MessagePartText, Text: "kept"},
-				{Type: channel.MessagePartText, Text: "   "},
+				{Type: channel.MessagePartText, Text: "\n"},
+				{Type: channel.MessagePartText, Text: "next"},
 			},
 		},
 	}
 	me := AdaptInbound(msg, "sess", "", "").(MessageEvent)
-	if len(me.Content) != 1 || me.Content[0].Text != "kept" {
-		t.Fatalf("expected only the non-empty text node, got %+v", me.Content)
+	if len(me.Content) != 3 {
+		t.Fatalf("expected 3 nodes (kept, newline separator, next), got %+v", me.Content)
+	}
+	if me.Content[0].Text != "kept" {
+		t.Fatalf("part 0 wrong: %+v", me.Content[0])
+	}
+	if me.Content[1].Type != "text" || me.Content[1].Text != "\n" {
+		t.Fatalf("expected newline separator preserved, got %+v", me.Content[1])
+	}
+	if me.Content[2].Text != "next" {
+		t.Fatalf("part 2 wrong: %+v", me.Content[2])
 	}
 }
 


### PR DESCRIPTION
## Summary
adapter 把平台原生富文本翻译成 canonical MessagePart → pipeline adaptBody 自动消费 → renderer 输出 `<b>/<i>/<mention uid>/<a href>/<pre lang>` XML 进 LLM 上下文。

## Boundary
|  | Telegram | Feishu | Matrix | Discord | Slack |
|------|----------|---------|--------|---------|-------|
| 入站 Parts | ✅ 全 entity | ✅ post 全结构 | ⚪ plain | ✅ markdown | ✅ mrkdwn |
| 入站 Edit | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
| 入站 Delete | ⚪ Bot API 不暴露 | ⚪ 同 | ⚪ 同 | ⚪ | ⚪ |

- 完全不收 reactions: 要另外考虑 reactions 传给 LLM context 的组织方式，相较于消息的信息过低且杂乱
- 未引入 `InboundCapabilities` 矩阵

## Follow-up
- 交互回调统一(Discord components / Slack block_actions / Feishu card_action 回传 LLM)。
- Adapter → pipeline → rendered XML 的 round-trip 集成测试 harness。