### PR TITLE
fix(plugins): open OAuth externally and show plugin skills

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -47,6 +47,7 @@ const LEGACY_REMOTE_PRODUCT_NAME = 'Memoh Online'
 const LEGACY_LOCAL_PRODUCT_NAME = 'Memoh'
 const DESKTOP_PRODUCT_NAME = DESKTOP_RUNTIME_MODE === 'remote' ? ONLINE_PRODUCT_NAME : LOCAL_PRODUCT_NAME
 const DEFAULT_REMOTE_BASE_URL = is.dev ? 'http://localhost:18080' : 'http://localhost:8080'
+const guardedExternalLinkWebContents = new WeakSet<Electron.WebContents>()
 
 interface RemoteProfile {
   baseUrl?: string
@@ -380,10 +381,57 @@ app.on('will-quit', () => {
 })
 
 function applyExternalLinkHandler(window: BrowserWindow): void {
-  window.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url)
+  attachExternalLinkGuards(window.webContents)
+}
+
+function normalizeExternalUrl(rawURL: unknown): { url: string, protocol: string, supported: boolean } {
+  const url = typeof rawURL === 'string' ? rawURL.trim() : ''
+  let protocol = ''
+  try {
+    protocol = new URL(url).protocol
+  } catch {
+    protocol = ''
+  }
+  return {
+    url,
+    protocol,
+    supported: ['http:', 'https:', 'mailto:'].includes(protocol),
+  }
+}
+
+function attachExternalLinkGuards(webContents: Electron.WebContents): void {
+  if (guardedExternalLinkWebContents.has(webContents)) return
+  guardedExternalLinkWebContents.add(webContents)
+
+  webContents.setWindowOpenHandler(({ url }) => {
+    const external = normalizeExternalUrl(url)
+    if (!external.supported) {
+      console.warn('blocked unsupported window.open URL', external.url || url)
+      return { action: 'deny' }
+    }
+    void shell.openExternal(external.url).catch((error) => {
+      console.error('failed to open external URL', external.url, error)
+    })
     return { action: 'deny' }
   })
+
+  webContents.on('will-navigate', (event, url) => {
+    const external = normalizeExternalUrl(url)
+    if (external.protocol === 'about:' || (!external.supported && external.protocol !== 'file:')) {
+      console.warn('blocked unsupported navigation URL', external.url || url)
+      event.preventDefault()
+    }
+  })
+}
+
+async function openExternalUrl(rawURL: unknown): Promise<void> {
+  const external = normalizeExternalUrl(rawURL)
+  if (!external.supported) {
+    const blockedURL = external.url || String(rawURL ?? '')
+    console.warn('blocked unsupported external URL', blockedURL)
+    throw new Error(`Unsupported external URL: ${blockedURL || 'empty URL'}`)
+  }
+  await shell.openExternal(external.url)
 }
 
 function loadRendererEntry(window: BrowserWindow, entry: 'index'): void {
@@ -936,6 +984,7 @@ app.whenReady().then(async () => {
 
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window)
+    attachExternalLinkGuards(window.webContents)
   })
 
   createAppTray()
@@ -991,6 +1040,7 @@ app.whenReady().then(async () => {
     }
     await rebuildAppMenu()
   })
+  ipcMain.handle('desktop:open-external-url', (_event, rawURL: unknown) => openExternalUrl(rawURL))
 
   // Cross-window Pinia Colada query-cache invalidation. Each renderer owns
   // an independent in-memory cache (separate Vue/Pinia instances per

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -61,6 +61,7 @@ const api = {
     // items with the user's bindings instead of the static table defaults.
     setMenuAccelerators: (overrides: Record<string, string>): Promise<void> =>
       ipcRenderer.invoke('desktop:set-menu-accelerators', overrides),
+    openExternalUrl: (url: string): Promise<void> => ipcRenderer.invoke('desktop:open-external-url', url),
     // Tell the main process to fan a query-cache invalidation out to every
     // other BrowserWindow. Used by `setupCrossWindowCacheSync` to mirror
     // mutations performed in one renderer onto siblings.

--- a/apps/web/src/pages/bots/components/mcp-server-detail.vue
+++ b/apps/web/src/pages/bots/components/mcp-server-detail.vue
@@ -762,7 +762,7 @@ async function handleOAuthFlow() {
     })
     if (!data?.authorization_url) throw new Error(t('mcp.oauth.flowInitFailed'))
 
-    const popup = window.open(data.authorization_url, 'mcp-oauth', 'width=600,height=700')
+    const popup = await openOAuthURL(data.authorization_url)
     let completed = false
     let pollTimer: ReturnType<typeof setInterval> | undefined
     const finishOAuth = async (result: 'success' | 'error', error?: string) => {
@@ -814,6 +814,15 @@ async function handleOAuthFlow() {
     toast.error(resolveApiErrorMessage(error, t('mcp.oauth.flowInitFailed')))
     oauthAuthorizing.value = false
   }
+}
+
+async function openOAuthURL(url: string): Promise<Window | null> {
+  const desktopOpenExternal = window.api?.desktop?.openExternalUrl
+  if (desktopOpenExternal) {
+    await desktopOpenExternal(url)
+    return null
+  }
+  return window.open(url, 'mcp-oauth', 'width=600,height=700')
 }
 
 async function handleOAuthRevoke() {

--- a/apps/web/src/pages/supermarket/components/install-plugin-dialog.vue
+++ b/apps/web/src/pages/supermarket/components/install-plugin-dialog.vue
@@ -20,8 +20,11 @@
           v-if="plugin"
           class="rounded-md border border-border p-3 space-y-1"
         >
-          <div class="flex items-center gap-2">
-            <p class="text-xs font-medium">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <p
+              class="min-w-0 truncate text-xs font-medium"
+              :title="plugin.name"
+            >
               {{ plugin.name }}
             </p>
             <Badge
@@ -31,10 +34,43 @@
             >
               {{ plugin.mcps.length }} MCPs
             </Badge>
+            <Badge
+              v-if="pluginSkills.length"
+              variant="outline"
+              size="sm"
+            >
+              {{ pluginSkills.length }} Skills
+            </Badge>
           </div>
           <p class="text-[11px] text-muted-foreground line-clamp-3">
             {{ plugin.description }}
           </p>
+          <div
+            v-if="pluginSkills.length"
+            class="mt-3 grid gap-1.5"
+          >
+            <div
+              v-for="skill in pluginSkills"
+              :key="skillKey(skill)"
+              class="flex min-w-0 items-start gap-2 rounded border border-border/60 bg-muted/20 px-2 py-1.5"
+            >
+              <Boxes class="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+              <div class="min-w-0 flex-1">
+                <p
+                  class="truncate text-[11px] font-medium"
+                  :title="skillName(skill)"
+                >
+                  {{ skillName(skill) }}
+                </p>
+                <p
+                  class="truncate text-[10px] text-muted-foreground"
+                  :title="skillDescription(skill)"
+                >
+                  {{ skillDescription(skill) }}
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div
@@ -90,6 +126,7 @@
 import { computed, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
+import { Boxes } from 'lucide-vue-next'
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose,
   Button, Spinner, Badge, Input, toast,
@@ -101,6 +138,8 @@ import {
   type PluginsConfigVar,
   type PluginsInstallation,
   type PluginsManifest,
+  type PluginsSkillEntry,
+  type PluginsSkillResource,
 } from '@memohai/sdk'
 import { client } from '@memohai/sdk/client'
 import { resolveApiErrorMessage } from '@/utils/api-error'
@@ -125,6 +164,13 @@ const installing = ref(false)
 const variableValues = reactive<Record<string, string>>({})
 
 const variables = computed<PluginsConfigVar[]>(() => props.plugin?.variables ?? [])
+type PluginSkill = PluginsSkillEntry | PluginsSkillResource
+
+const pluginSkills = computed<PluginSkill[]>(() => [
+  ...(props.plugin?.bundled_skills ?? []),
+  ...(props.plugin?.skills ?? []),
+])
+
 const requiresManagedOAuth = computed(() => {
   return (props.plugin?.auth_requirements ?? []).some(item => item.type === 'managed_oauth')
 })
@@ -132,6 +178,25 @@ const canInstall = computed(() => {
   if (!selectedBotId.value || !props.plugin?.id) return false
   return variables.value.every(item => !item.required || !!variableValues[item.key || '']?.trim())
 })
+
+function skillKey(skill: PluginSkill): string {
+  if ('id' in skill && skill.id) return skill.id
+  if ('key' in skill && skill.key) return skill.key
+  return skillName(skill)
+}
+
+function skillName(skill: PluginSkill): string {
+  if ('name' in skill && skill.name) return skill.name
+  if ('id' in skill && skill.id) return skill.id
+  if ('key' in skill && skill.key) return skill.key
+  return t('supermarket.unnamedSkill')
+}
+
+function skillDescription(skill: PluginSkill): string {
+  if ('description' in skill && skill.description) return skill.description
+  if ('path' in skill && skill.path) return skill.path
+  return t('supermarket.noDescription')
+}
 
 watch(() => props.open, (open) => {
   if (!open) {
@@ -148,7 +213,9 @@ watch(() => props.open, (open) => {
 async function handleInstall() {
   if (!selectedBotId.value || !props.plugin?.id) return
   const botId = selectedBotId.value
-  const oauthPopup = requiresManagedOAuth.value ? window.open('', 'mcp-oauth', 'width=600,height=700') : null
+  const oauthPopup = requiresManagedOAuth.value && !canOpenOAuthExternally()
+    ? window.open('', 'mcp-oauth', 'width=600,height=700')
+    : null
   installing.value = true
   try {
     const { data } = await postBotsByBotIdSupermarketInstallPlugin({
@@ -205,7 +272,7 @@ async function startOAuthAfterInstall(botId: string, installation: PluginsInstal
     if (popup && !popup.closed) {
       popup.location.href = data.authorization_url
     } else {
-      popup = window.open(data.authorization_url, 'mcp-oauth', 'width=600,height=700')
+      popup = await openOAuthURL(data.authorization_url)
     }
 
     await waitForMCPOAuth(botId, installation.id!, popup)
@@ -225,6 +292,19 @@ async function startOAuthAfterInstall(botId: string, installation: PluginsInstal
     popup?.close()
     toast.error(resolveApiErrorMessage(error, t('mcp.oauth.flowInitFailed')))
   }
+}
+
+function canOpenOAuthExternally(): boolean {
+  return Boolean(window.api?.desktop?.openExternalUrl)
+}
+
+async function openOAuthURL(url: string): Promise<Window | null> {
+  const desktopOpenExternal = window.api?.desktop?.openExternalUrl
+  if (desktopOpenExternal) {
+    await desktopOpenExternal(url)
+    return null
+  }
+  return window.open(url, 'mcp-oauth', 'width=600,height=700')
 }
 
 function waitForMCPOAuth(botId: string, installationId: string, popup: Window | null): Promise<void> {
@@ -261,11 +341,11 @@ function waitForMCPOAuth(botId: string, installationId: string, popup: Window | 
           finish('success')
           return
         }
-        if (popup?.closed || Date.now() - startedAt > 120_000) {
+        if ((popup && popup.closed) || Date.now() - startedAt > 120_000) {
           finish('error')
         }
       }).catch(() => {
-        if (!completed && (popup?.closed || Date.now() - startedAt > 120_000)) {
+        if (!completed && ((popup && popup.closed) || Date.now() - startedAt > 120_000)) {
           finish('error')
         }
       })

--- a/apps/web/src/pages/supermarket/plugin-detail.vue
+++ b/apps/web/src/pages/supermarket/plugin-detail.vue
@@ -97,14 +97,17 @@
           <div
             v-for="mcp in plugin.mcps"
             :key="mcp.key || mcp.name"
-            class="flex items-center gap-3 py-4"
+            class="flex min-w-0 items-center gap-3 py-4"
           >
             <div class="flex size-10 shrink-0 items-center justify-center rounded-md border bg-background">
               <Plug class="size-5 text-muted-foreground" />
             </div>
             <div class="min-w-0 flex-1">
               <div class="flex flex-wrap items-center gap-2">
-                <p class="font-medium">
+                <p
+                  class="min-w-0 truncate font-medium"
+                  :title="mcp.display_name || mcp.name || mcp.key"
+                >
                   {{ mcp.display_name || mcp.name || mcp.key }}
                 </p>
                 <Badge
@@ -135,16 +138,22 @@
           <div
             v-for="skill in pluginSkills"
             :key="skillKey(skill)"
-            class="flex items-center gap-3 py-4"
+            class="flex min-w-0 items-center gap-3 py-4"
           >
             <div class="flex size-10 shrink-0 items-center justify-center rounded-md border bg-background">
               <Boxes class="size-5 text-muted-foreground" />
             </div>
             <div class="min-w-0 flex-1">
-              <p class="font-medium">
+              <p
+                class="min-w-0 truncate font-medium"
+                :title="skillName(skill)"
+              >
                 {{ skillName(skill) }}
               </p>
-              <p class="mt-1 text-sm text-muted-foreground">
+              <p
+                class="mt-1 line-clamp-2 break-words text-sm text-muted-foreground"
+                :title="skillDescription(skill)"
+              >
                 {{ skillDescription(skill) }}
               </p>
             </div>

--- a/apps/web/type.d.ts
+++ b/apps/web/type.d.ts
@@ -1,1 +1,9 @@
 declare module '@jamescoyle/vue-icon'
+
+interface Window {
+  api?: {
+    desktop?: {
+      openExternalUrl?: (url: string) => Promise<void>
+    }
+  }
+}

--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -242,6 +242,10 @@ func provideBridgeProvider(manage *workspace.Manager) bridge.Provider {
 	return manage
 }
 
+func providePluginBridgeProvider(provider bridge.Provider) pluginspkg.BridgeProvider {
+	return pluginspkg.BridgeProvider{Provider: provider}
+}
+
 func provideHooksService(log *slog.Logger, provider bridge.Provider, pluginService *pluginspkg.Service) *hookspkg.Service {
 	service := hookspkg.NewService(log, provider)
 	service.SetPluginService(pluginService)

--- a/cmd/agent/module.go
+++ b/cmd/agent/module.go
@@ -57,6 +57,7 @@ func options() fx.Option {
 			provideAccountStore,
 			provideWorkspaceManager,
 			provideBridgeProvider,
+			providePluginBridgeProvider,
 			provideMemoryLLM,
 			memprovider.NewService,
 			provideMemoryProviderRegistry,

--- a/conf/app.local.toml
+++ b/conf/app.local.toml
@@ -78,7 +78,7 @@ base_url = "http://127.0.0.1:8085"
 providers_dir = "conf/providers"
 
 [supermarket]
-base_url = "https://supermarket.memoh.ai"
+base_url = "http://127.0.0.1:5174"
 
 [oauth_clients]
 config_path = "conf/oauth-clients.toml"

--- a/internal/mcp/oauth.go
+++ b/internal/mcp/oauth.go
@@ -449,12 +449,48 @@ type tokenResponse struct {
 	ErrorDescription string `json:"error_description,omitempty"`
 }
 
+type mcpOAuthProbeRequest struct {
+	JSONRPC string                  `json:"jsonrpc"`
+	ID      string                  `json:"id"`
+	Method  string                  `json:"method"`
+	Params  mcpOAuthProbeParameters `json:"params"`
+}
+
+type mcpOAuthProbeParameters struct {
+	ProtocolVersion string                  `json:"protocolVersion"`
+	Capabilities    map[string]any          `json:"capabilities"`
+	ClientInfo      mcpOAuthProbeClientInfo `json:"clientInfo"`
+}
+
+type mcpOAuthProbeClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
 func (s *OAuthService) probeForAuth(ctx context.Context, serverURL string) (resourceMetaURL, scope string, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL, nil)
+	payload, err := json.Marshal(mcpOAuthProbeRequest{
+		JSONRPC: "2.0",
+		ID:      "oauth-probe",
+		Method:  "initialize",
+		Params: mcpOAuthProbeParameters{
+			ProtocolVersion: "2025-06-18",
+			Capabilities:    map[string]any{},
+			ClientInfo: mcpOAuthProbeClientInfo{
+				Name:    "Memoh",
+				Version: "dev",
+			},
+		},
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL, strings.NewReader(string(payload)))
 	if err != nil {
 		return "", "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
 
 	resp, err := s.httpClient.Do(req) //nolint:gosec // G704: URL is from OAuth server discovery metadata or operator config, not user input
 	if err != nil {

--- a/internal/mcp/oauth_test.go
+++ b/internal/mcp/oauth_test.go
@@ -1,0 +1,53 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProbeForAuthUsesMCPInitializeRequest(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod string
+	var gotAccept string
+	var gotRequest struct {
+		JSONRPC string `json:"jsonrpc"`
+		Method  string `json:"method"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAccept = r.Header.Get("Accept")
+		if err := json.NewDecoder(r.Body).Decode(&gotRequest); err != nil {
+			t.Fatalf("decode probe request: %v", err)
+		}
+		w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="https://example.test/.well-known/oauth-protected-resource",scope="mcp:connect"`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	svc := NewOAuthService(nil, nil, "")
+	resourceMetaURL, scope, err := svc.probeForAuth(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("probeForAuth() error = %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	if gotRequest.JSONRPC != "2.0" || gotRequest.Method != "initialize" {
+		t.Fatalf("request = %#v, want JSON-RPC initialize", gotRequest)
+	}
+	if gotAccept != "application/json, text/event-stream" {
+		t.Fatalf("Accept = %q", gotAccept)
+	}
+	if resourceMetaURL != "https://example.test/.well-known/oauth-protected-resource" {
+		t.Fatalf("resourceMetaURL = %q", resourceMetaURL)
+	}
+	if scope != "mcp:connect" {
+		t.Fatalf("scope = %q", scope)
+	}
+}

--- a/internal/plugins/service.go
+++ b/internal/plugins/service.go
@@ -5,29 +5,39 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"path"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"gopkg.in/yaml.v3"
 
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/mcp"
+	skillset "github.com/memohai/memoh/internal/skills"
+	"github.com/memohai/memoh/internal/workspace/bridge"
 )
+
+type BridgeProvider struct {
+	Provider bridge.Provider
+}
 
 type Service struct {
 	queries      dbstore.Queries
 	mcpService   *mcp.ConnectionService
 	oauthService *mcp.OAuthService
 	oauthClients *OAuthClientRegistry
+	bridges      bridge.Provider
 	logger       *slog.Logger
 }
 
-func NewService(log *slog.Logger, queries dbstore.Queries, mcpService *mcp.ConnectionService, oauthService *mcp.OAuthService, oauthClients *OAuthClientRegistry) *Service {
+func NewService(log *slog.Logger, queries dbstore.Queries, mcpService *mcp.ConnectionService, oauthService *mcp.OAuthService, oauthClients *OAuthClientRegistry, bridges BridgeProvider) *Service {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -36,6 +46,7 @@ func NewService(log *slog.Logger, queries dbstore.Queries, mcpService *mcp.Conne
 		mcpService:   mcpService,
 		oauthService: oauthService,
 		oauthClients: oauthClients,
+		bridges:      bridges.Provider,
 		logger:       log.With(slog.String("service", "plugins")),
 	}
 }
@@ -162,6 +173,29 @@ func (s *Service) Install(ctx context.Context, botID string, req InstallRequest)
 			return Installation{}, err
 		}
 	}
+	for _, skill := range manifest.BundledSkills {
+		name := strings.TrimSpace(skill.Name)
+		if name == "" {
+			name = strings.TrimSpace(skill.ID)
+		}
+		key := sanitizeID(name)
+		if key == "" {
+			continue
+		}
+		if _, err := s.queries.UpsertBotPluginResource(ctx, sqlc.UpsertBotPluginResourceParams{
+			InstallationID: row.ID,
+			ResourceType:   "skill",
+			ResourceKey:    key,
+			ResourceID:     path.Join(skillset.ManagedDir(), name, "SKILL.md"),
+			Status:         "bundled",
+			Metadata:       mustJSON(map[string]any{"name": name, "skill_id": skill.ID}),
+		}); err != nil {
+			return Installation{}, err
+		}
+	}
+	if err := s.installBundledSkills(ctx, botID, row, manifest); err != nil {
+		return Installation{}, err
+	}
 
 	return s.normalizeInstallation(ctx, row)
 }
@@ -221,6 +255,9 @@ func (s *Service) Uninstall(ctx context.Context, botID, installationID string) (
 	if err := s.mcpService.DeleteByPlugin(ctx, botID, installationID); err != nil {
 		return Installation{}, err
 	}
+	if err := s.uninstallBundledSkills(ctx, botID, row); err != nil {
+		return Installation{}, err
+	}
 	if err := s.queries.DeleteBotPluginResources(ctx, row.ID); err != nil {
 		return Installation{}, err
 	}
@@ -237,6 +274,9 @@ func (s *Service) Purge(ctx context.Context, botID, installationID string) error
 		return err
 	}
 	if err := s.mcpService.DeleteByPlugin(ctx, botID, installationID); err != nil {
+		return err
+	}
+	if err := s.uninstallBundledSkills(ctx, botID, row); err != nil {
 		return err
 	}
 	if err := s.queries.DeleteBotPluginResources(ctx, row.ID); err != nil {
@@ -418,6 +458,145 @@ func (s *Service) normalizeInstallation(ctx context.Context, row sqlc.BotPluginI
 	}, nil
 }
 
+func (s *Service) installBundledSkills(ctx context.Context, botID string, row sqlc.BotPluginInstallation, manifest Manifest) error {
+	if s.bridges == nil || len(manifest.BundledSkills) == 0 {
+		return nil
+	}
+	client, err := s.bridges.MCPClient(ctx, botID)
+	if err != nil {
+		return fmt.Errorf("install plugin skills: container not reachable: %w", err)
+	}
+	for _, skill := range manifest.BundledSkills {
+		name := strings.TrimSpace(skill.Name)
+		if name == "" {
+			name = strings.TrimSpace(skill.ID)
+		}
+		if !skillset.IsValidName(name) {
+			return fmt.Errorf("plugin skill %q has an invalid name", name)
+		}
+		raw := pluginSkillRaw(skill, name, row)
+		parsed := skillset.ParseFile(raw, name)
+		dirPath, err := skillset.ManagedSkillDirForName(parsed.Name)
+		if err != nil {
+			return fmt.Errorf("plugin skill %q has an invalid name", parsed.Name)
+		}
+		if err := client.Mkdir(ctx, dirPath); err != nil {
+			return fmt.Errorf("create plugin skill %q directory: %w", parsed.Name, err)
+		}
+		if err := client.WriteFile(ctx, path.Join(dirPath, "SKILL.md"), []byte(raw)); err != nil {
+			return fmt.Errorf("write plugin skill %q: %w", parsed.Name, err)
+		}
+		owner, err := encodeJSON(pluginSkillOwner(row, manifest, skill, parsed.Name))
+		if err != nil {
+			return err
+		}
+		if err := client.WriteFile(ctx, path.Join(dirPath, ".memoh-plugin-owner.json"), owner); err != nil {
+			return fmt.Errorf("write plugin skill %q owner marker: %w", parsed.Name, err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) uninstallBundledSkills(ctx context.Context, botID string, row sqlc.BotPluginInstallation) error {
+	if s.bridges == nil {
+		return nil
+	}
+	manifest, err := decodeManifest(row.Manifest)
+	if err != nil {
+		return err
+	}
+	if len(manifest.BundledSkills) == 0 {
+		return nil
+	}
+	client, err := s.bridges.MCPClient(ctx, botID)
+	if err != nil {
+		return fmt.Errorf("uninstall plugin skills: container not reachable: %w", err)
+	}
+	for _, skill := range manifest.BundledSkills {
+		name := strings.TrimSpace(skill.Name)
+		if name == "" {
+			name = strings.TrimSpace(skill.ID)
+		}
+		if !skillset.IsValidName(name) {
+			continue
+		}
+		dirPath, err := skillset.ManagedSkillDirForName(name)
+		if err != nil {
+			continue
+		}
+		if !canDeletePluginSkill(ctx, client, dirPath, row.ID.String()) {
+			continue
+		}
+		if err := client.DeleteFile(ctx, dirPath, true); err != nil {
+			return fmt.Errorf("delete plugin skill %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+type skillFileClient interface {
+	ReadRaw(ctx context.Context, path string) (io.ReadCloser, error)
+}
+
+func canDeletePluginSkill(ctx context.Context, client skillFileClient, dirPath, installationID string) bool {
+	rc, err := client.ReadRaw(ctx, path.Join(dirPath, ".memoh-plugin-owner.json"))
+	if err != nil {
+		return false
+	}
+	defer func() { _ = rc.Close() }()
+	var owner struct {
+		InstallationID string `json:"installation_id"`
+	}
+	if err := json.NewDecoder(rc).Decode(&owner); err != nil {
+		return false
+	}
+	return strings.TrimSpace(owner.InstallationID) == installationID
+}
+
+func pluginSkillRaw(skill SkillEntry, name string, row sqlc.BotPluginInstallation) string {
+	metadata := normalizeMetadataMap(skill.Metadata)
+	metadata["managed_by_plugin"] = map[string]any{
+		"installation_id": row.ID.String(),
+		"plugin_id":       row.PluginID,
+		"plugin_name":     row.PluginName,
+	}
+	frontmatter := map[string]any{
+		"name":        name,
+		"description": strings.TrimSpace(skill.Description),
+		"metadata":    metadata,
+	}
+	payload, _ := encodeYAML(frontmatter)
+	body := strings.TrimSpace(skill.Content)
+	if body == "" {
+		body = "# " + name
+	}
+	return "---\n" + strings.TrimSpace(string(payload)) + "\n---\n\n" + body + "\n"
+}
+
+func pluginSkillOwner(row sqlc.BotPluginInstallation, manifest Manifest, skill SkillEntry, name string) map[string]any {
+	return map[string]any{
+		"installation_id": row.ID.String(),
+		"plugin_id":       manifest.ID,
+		"skill_id":        skill.ID,
+		"skill_name":      name,
+	}
+}
+
+func normalizeMetadataMap(value map[string]any) map[string]any {
+	if value == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(value))
+	for key, item := range value {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = item
+	}
+	return out
+}
+
 func (s *Service) evaluateInitialStatus(manifest Manifest, variables map[string]string) string {
 	status := StatusReady
 	for _, resource := range manifest.MCPs {
@@ -497,10 +676,6 @@ func normalizeResource(row sqlc.BotPluginResource) (Resource, error) {
 	}, nil
 }
 
-func NormalizeManifest(manifest Manifest) Manifest {
-	return normalizeManifest(manifest)
-}
-
 func normalizeManifest(manifest Manifest) Manifest {
 	manifest.ID = sanitizeID(manifest.ID)
 	manifest.Name = strings.TrimSpace(manifest.Name)
@@ -528,6 +703,10 @@ func normalizeManifest(manifest Manifest) Manifest {
 		}
 	}
 	return manifest
+}
+
+func NormalizeManifest(manifest Manifest) Manifest {
+	return normalizeManifest(manifest)
 }
 
 func normalizeInstallCommands(commands []string) InstallCommands {
@@ -762,6 +941,13 @@ func encodeJSON(value any) ([]byte, error) {
 		value = map[string]any{}
 	}
 	return json.Marshal(value)
+}
+
+func encodeYAML(value any) ([]byte, error) {
+	if value == nil {
+		value = map[string]any{}
+	}
+	return yaml.Marshal(value)
 }
 
 func mustJSON(value any) []byte {

--- a/internal/plugins/service_test.go
+++ b/internal/plugins/service_test.go
@@ -1,68 +1,18 @@
 package plugins
 
 import (
-	"encoding/json"
-	"reflect"
+	"context"
+	"io"
+	"path"
+	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	"github.com/memohai/memoh/internal/mcp"
+	skillset "github.com/memohai/memoh/internal/skills"
 )
-
-func TestManifestInstallCommandsAcceptStringOrList(t *testing.T) {
-	tests := []struct {
-		name string
-		raw  string
-		want []string
-	}{
-		{
-			name: "string",
-			raw:  `{"id":"plugin","name":"Plugin","author":{"name":"Memoh"},"install":" sh scripts/install.sh "}`,
-			want: []string{"sh scripts/install.sh"},
-		},
-		{
-			name: "list",
-			raw:  `{"id":"plugin","name":"Plugin","author":{"name":"Memoh"},"install":[" sh scripts/a.sh ","","python3 scripts/b.py"]}`,
-			want: []string{"sh scripts/a.sh", "python3 scripts/b.py"},
-		},
-		{
-			name: "null",
-			raw:  `{"id":"plugin","name":"Plugin","author":{"name":"Memoh"},"install":null}`,
-			want: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var manifest Manifest
-			if err := json.Unmarshal([]byte(tt.raw), &manifest); err != nil {
-				t.Fatalf("json.Unmarshal: %v", err)
-			}
-			if !reflect.DeepEqual([]string(manifest.Install), tt.want) {
-				t.Fatalf("install = %#v, want %#v", []string(manifest.Install), tt.want)
-			}
-		})
-	}
-}
-
-func TestManifestInstallCommandsRejectInvalidShape(t *testing.T) {
-	var manifest Manifest
-	if err := json.Unmarshal([]byte(`{"id":"plugin","install":7}`), &manifest); err == nil {
-		t.Fatal("expected invalid install shape to fail")
-	}
-}
-
-func TestNormalizeManifestTrimsInstallCommands(t *testing.T) {
-	manifest := NormalizeManifest(Manifest{
-		ID:      "Plugin.ID",
-		Name:    " Plugin ",
-		Install: InstallCommands{" sh scripts/install.sh ", "", "python3 scripts/setup.py"},
-	})
-
-	want := []string{"sh scripts/install.sh", "python3 scripts/setup.py"}
-	if !reflect.DeepEqual([]string(manifest.Install), want) {
-		t.Fatalf("install = %#v, want %#v", []string(manifest.Install), want)
-	}
-}
 
 func TestMissingRequiredVariablesTreatsSelfTemplateDefaultAsMissing(t *testing.T) {
 	manifest := Manifest{
@@ -140,4 +90,61 @@ func TestManifestScopesOverrideDiscoveredScopes(t *testing.T) {
 	if len(result.ScopesSupported) != 2 || result.ScopesSupported[0] != "repo" || result.ScopesSupported[1] != "read:org" {
 		t.Fatalf("scopes = %#v, want manifest scopes", result.ScopesSupported)
 	}
+}
+
+func TestPluginSkillRawAddsFrontmatterAndOwnership(t *testing.T) {
+	row := sqlc.BotPluginInstallation{
+		ID:         pgtype.UUID{Bytes: [16]byte{15: 1}, Valid: true},
+		PluginID:   "github",
+		PluginName: "GitHub",
+	}
+	raw := pluginSkillRaw(SkillEntry{
+		ID:          "github",
+		Name:        "github",
+		Description: "Use GitHub.",
+		Content:     "# GitHub\n\nUse the connected app.",
+	}, "github", row)
+
+	parsed := skillset.ParseFile(raw, "")
+	if parsed.Name != "github" {
+		t.Fatalf("parsed name = %q, want github", parsed.Name)
+	}
+	if parsed.Description != "Use GitHub." {
+		t.Fatalf("parsed description = %q", parsed.Description)
+	}
+	owner, ok := parsed.Metadata["managed_by_plugin"].(map[string]any)
+	if !ok {
+		t.Fatalf("managed_by_plugin metadata missing: %#v", parsed.Metadata)
+	}
+	if owner["plugin_id"] != "github" {
+		t.Fatalf("plugin_id = %#v, want github", owner["plugin_id"])
+	}
+}
+
+func TestCanDeletePluginSkillRequiresMatchingOwnerMarker(t *testing.T) {
+	dir := path.Join(skillset.ManagedDir(), "github")
+	client := &pluginSkillFileClient{
+		files: map[string]string{
+			path.Join(dir, ".memoh-plugin-owner.json"): `{"installation_id":"install-1"}`,
+		},
+	}
+
+	if !canDeletePluginSkill(context.Background(), client, dir, "install-1") {
+		t.Fatal("expected matching owner marker to allow deletion")
+	}
+	if canDeletePluginSkill(context.Background(), client, dir, "install-2") {
+		t.Fatal("expected mismatched owner marker to block deletion")
+	}
+}
+
+type pluginSkillFileClient struct {
+	files map[string]string
+}
+
+func (c *pluginSkillFileClient) ReadRaw(_ context.Context, filePath string) (io.ReadCloser, error) {
+	raw, ok := c.files[filePath]
+	if !ok {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return io.NopCloser(strings.NewReader(raw)), nil
 }


### PR DESCRIPTION
## Summary

- Open MCP/plugin OAuth URLs through the desktop main process so macOS receives the real OAuth URL instead of `about:blank`.
- Add desktop-side guards for unsupported external URLs.
- Show plugin bundled skills in the Supermarket install dialog.
- Keep long MCP/skill names and skill descriptions constrained on the plugin detail page.

## Testing

- `git diff --check`
- `mise exec -- pnpm --dir apps/desktop run typecheck:node`
- `mise exec -- pnpm --dir apps/web exec vue-tsc --noEmit`