### PR TITLE
fix(security): harden TCP workspace bridge with strict mTLS

### DIFF
--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -240,7 +240,7 @@ func provideBridgeProvider(manage *workspace.Manager) bridge.Provider {
 	return manage
 }
 
-func provideWorkspaceManager(lc fx.Lifecycle, log *slog.Logger, service ctr.Service, networkController netctl.Controller, cfg config.Config, conn *pgxpool.Pool, queries dbstore.Queries) *workspace.Manager {
+func provideWorkspaceManager(lc fx.Lifecycle, log *slog.Logger, service ctr.Service, networkController netctl.Controller, cfg config.Config, conn *pgxpool.Pool, queries dbstore.Queries) (*workspace.Manager, error) {
 	localSvc := workspace.NewLocalService(log, cfg.Local, cfg.Workspace.DataRoot)
 	lc.Append(fx.Hook{
 		OnStop: func(context.Context) error {
@@ -249,7 +249,15 @@ func provideWorkspaceManager(lc fx.Lifecycle, log *slog.Logger, service ctr.Serv
 		},
 	})
 	runtimeSvc := workspace.NewRuntimeRouter(service, localSvc)
-	return workspace.NewManager(log, runtimeSvc, networkController, cfg.Workspace, cfg.Containerd.Namespace, conn, queries)
+	mgr := workspace.NewManager(log, runtimeSvc, networkController, cfg.Workspace, cfg.Containerd.Namespace, conn, queries)
+	tlsOpts, err := workspace.BridgeTLSRuntimeOptionsFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if tlsOpts != nil {
+		mgr.SetBridgeTLS(tlsOpts)
+	}
+	return mgr, nil
 }
 
 func provideMemoryLLM(modelsService *models.Service, settingsService *settings.Service, queries dbstore.Queries, log *slog.Logger) memprovider.LLM {

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -142,9 +142,9 @@ func main() {
 		return
 	}
 
-	srv := grpc.NewServer(
-		grpc.MaxRecvMsgSize(16*1024*1024),
-		grpc.MaxSendMsgSize(16*1024*1024),
+	serverOpts := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(16 * 1024 * 1024),
+		grpc.MaxSendMsgSize(16 * 1024 * 1024),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle:     5 * time.Minute,
 			MaxConnectionAge:      30 * time.Minute,
@@ -156,7 +156,21 @@ func main() {
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
 		}),
-	)
+	}
+	// strict mTLS 只约束 TCP 通道；UDS 走文件系统 socket 权限的本地信任模型。
+	// strict 下材料缺失/损坏直接拒绝启动，不回退明文（设计 §10）。
+	if network == "tcp" {
+		creds, err := bridgeServerCredentials()
+		if err != nil {
+			logger.Error("bridge TLS configuration invalid", slog.Any("error", err))
+			return
+		}
+		if creds != nil {
+			serverOpts = append(serverOpts, grpc.Creds(creds))
+			logger.Info("bridge TCP gRPC requires mTLS", slog.String("mode", bridgeTLSModeStrict))
+		}
+	}
+	srv := grpc.NewServer(serverOpts...)
 	pb.RegisterContainerServiceServer(srv, bridgesvc.New(bridgesvc.Options{
 		DefaultWorkDir:    bridgesvc.DefaultWorkDir,
 		DataMount:         bridgesvc.DefaultWorkDir,

--- a/cmd/bridge/tls.go
+++ b/cmd/bridge/tls.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// bridge TCP 通道的 strict mTLS（设计 memoh-saas-bridge-mtls-design.md §8.1）。
+// 材料由 memoh-bridge-mtls Secret 挂载，env 只传路径与模式，私钥不进 env。
+const (
+	bridgeTLSModeEnv              = "BRIDGE_TLS_MODE"
+	bridgeTLSCertFileEnv          = "BRIDGE_TLS_CERT_FILE"
+	bridgeTLSKeyFileEnv           = "BRIDGE_TLS_KEY_FILE"
+	bridgeTLSClientCAFileEnv      = "BRIDGE_TLS_CLIENT_CA_FILE"
+	bridgeTLSExpectedClientURIEnv = "BRIDGE_TLS_EXPECTED_CLIENT_URI"
+
+	bridgeTLSModeDisabled = "disabled"
+	bridgeTLSModeStrict   = "strict"
+)
+
+// bridgeServerCredentials 按 BRIDGE_TLS_MODE 构建 gRPC server credentials。
+// disabled/空 → (nil, nil) 维持现状；strict → 必须 mTLS，材料缺失即错误，
+// 绝不静默回退明文（设计 §10）。仅对 TCP listener 调用；UDS 走文件系统权限。
+func bridgeServerCredentials() (credentials.TransportCredentials, error) {
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv(bridgeTLSModeEnv)))
+	switch mode {
+	case "", bridgeTLSModeDisabled:
+		return nil, nil
+	case bridgeTLSModeStrict:
+	default:
+		return nil, fmt.Errorf("unknown %s %q (want %s|%s)", bridgeTLSModeEnv, mode, bridgeTLSModeDisabled, bridgeTLSModeStrict)
+	}
+
+	certFile := strings.TrimSpace(os.Getenv(bridgeTLSCertFileEnv))
+	keyFile := strings.TrimSpace(os.Getenv(bridgeTLSKeyFileEnv))
+	caFile := strings.TrimSpace(os.Getenv(bridgeTLSClientCAFileEnv))
+	expectedURI := strings.TrimSpace(os.Getenv(bridgeTLSExpectedClientURIEnv))
+	if certFile == "" || keyFile == "" || caFile == "" || expectedURI == "" {
+		return nil, fmt.Errorf("strict bridge TLS requires %s, %s, %s and %s", bridgeTLSCertFileEnv, bridgeTLSKeyFileEnv, bridgeTLSClientCAFileEnv, bridgeTLSExpectedClientURIEnv)
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load bridge server keypair: %w", err)
+	}
+	caPEM, err := os.ReadFile(caFile) //nolint:gosec // G304: path comes from operator-controlled env, not end-user input
+	if err != nil {
+		return nil, fmt.Errorf("read server client CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("no certificates parsed from %s", caFile)
+	}
+
+	cfg := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		// RequireAndVerifyClientCert 已验链（含 ClientAuth EKU）；这里把调用方
+		// 钉死到本 instance 的 Memoh Server SPIFFE 身份。被攻破的 bot 只持有
+		// shared bridge server cert（ServerAuth、bridge URI），过不了这一关。
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			return verifyMemohServerClientIdentity(cs, expectedURI)
+		},
+	}
+	return credentials.NewTLS(cfg), nil
+}
+
+func verifyMemohServerClientIdentity(cs tls.ConnectionState, expectedURI string) error {
+	if len(cs.PeerCertificates) == 0 {
+		return errors.New("client certificate required")
+	}
+	leaf := cs.PeerCertificates[0]
+	if !slices.Contains(leaf.ExtKeyUsage, x509.ExtKeyUsageClientAuth) {
+		return errors.New("client certificate lacks ClientAuth EKU")
+	}
+	for _, uri := range leaf.URIs {
+		if uri.String() == expectedURI {
+			return nil
+		}
+	}
+	return fmt.Errorf("client certificate URI SAN mismatch (want %s)", expectedURI)
+}

--- a/cmd/bridge/tls_test.go
+++ b/cmd/bridge/tls_test.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+
+	"github.com/memohai/memoh/internal/workspace/bridge"
+)
+
+const (
+	testInstanceID  = "11111111-1111-1111-1111-111111111111"
+	testServerName  = "memoh-bridge." + testInstanceID + ".bridge.memoh.internal"
+	testServerURI   = "spiffe://memoh/instance/" + testInstanceID + "/server"
+	testBridgeURI   = "spiffe://memoh/instance/" + testInstanceID + "/bridge"
+	wrongInstanceID = "22222222-2222-2222-2222-222222222222"
+)
+
+type testCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+	pem  []byte
+}
+
+func newTestCA(t *testing.T, cn string) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &testCA{cert: cert, key: key, pem: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})}
+}
+
+func (ca *testCA) issue(t *testing.T, cn string, eku x509.ExtKeyUsage, dnsNames []string, uriSAN string) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{eku},
+		DNSNames:     dnsNames,
+	}
+	if uriSAN != "" {
+		parsed, err := url.Parse(uriSAN)
+		if err != nil {
+			t.Fatal(err)
+		}
+		template.URIs = []*url.URL{parsed}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+}
+
+func writeTempFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// testMTLSMaterial 在临时目录铺出 instance 级全套材料（镜像 bytenet provisioning 的产物）。
+type testMTLSMaterial struct {
+	dir            string
+	clientCA       *testCA
+	bridgeCA       *testCA
+	bridgeCertFile string
+	bridgeKeyFile  string
+	clientCAFile   string
+	clientCertFile string
+	clientKeyFile  string
+	bridgeCAFile   string
+}
+
+func newTestMTLSMaterial(t *testing.T) *testMTLSMaterial {
+	t.Helper()
+	dir := t.TempDir()
+	clientCA := newTestCA(t, "server-client CA")
+	bridgeCA := newTestCA(t, "bridge-server CA")
+	bridgeCert, bridgeKey := bridgeCA.issue(t, "bridge", x509.ExtKeyUsageServerAuth, []string{testServerName}, testBridgeURI)
+	clientCert, clientKey := clientCA.issue(t, "server", x509.ExtKeyUsageClientAuth, nil, testServerURI)
+	return &testMTLSMaterial{
+		dir:            dir,
+		clientCA:       clientCA,
+		bridgeCA:       bridgeCA,
+		bridgeCertFile: writeTempFile(t, dir, "bridge-server.crt", bridgeCert),
+		bridgeKeyFile:  writeTempFile(t, dir, "bridge-server.key", bridgeKey),
+		clientCAFile:   writeTempFile(t, dir, "server-client-ca.crt", clientCA.pem),
+		clientCertFile: writeTempFile(t, dir, "server-client.crt", clientCert),
+		clientKeyFile:  writeTempFile(t, dir, "server-client.key", clientKey),
+		bridgeCAFile:   writeTempFile(t, dir, "bridge-server-ca.crt", bridgeCA.pem),
+	}
+}
+
+func (m *testMTLSMaterial) setStrictEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(bridgeTLSModeEnv, bridgeTLSModeStrict)
+	t.Setenv(bridgeTLSCertFileEnv, m.bridgeCertFile)
+	t.Setenv(bridgeTLSKeyFileEnv, m.bridgeKeyFile)
+	t.Setenv(bridgeTLSClientCAFileEnv, m.clientCAFile)
+	t.Setenv(bridgeTLSExpectedClientURIEnv, testServerURI)
+}
+
+func (m *testMTLSMaterial) clientOptions() *bridge.TLSOptions {
+	return &bridge.TLSOptions{
+		ServerName:        testServerName,
+		ExpectedServerURI: testBridgeURI,
+		ClientCertFile:    m.clientCertFile,
+		ClientKeyFile:     m.clientKeyFile,
+		ServerCAFile:      m.bridgeCAFile,
+	}
+}
+
+// startStrictServer 用 bridgeServerCredentials() 起一个真实 TLS gRPC listener。
+// 不注册任何 service：握手成功 → RPC 报 Unimplemented；握手/身份校验失败 → Unavailable。
+func startStrictServer(t *testing.T) string {
+	t.Helper()
+	creds, err := bridgeServerCredentials()
+	if err != nil {
+		t.Fatalf("bridgeServerCredentials: %v", err)
+	}
+	if creds == nil {
+		t.Fatal("expected strict credentials, got nil")
+	}
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer(grpc.Creds(creds))
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return lis.Addr().String()
+}
+
+// rpcErr 经 DialTLS 发起一次 RPC 并返回 bridge 客户端映射后的错误：
+// 握手成功 → "grpc Unimplemented"（测试服务器未注册任何 service）；
+// 握手/身份校验失败 → bridge.ErrUnavailable。
+func rpcErr(t *testing.T, addr string, opts *bridge.TLSOptions) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c, err := bridge.DialTLS(ctx, addr, opts)
+	if err != nil {
+		t.Fatalf("DialTLS: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+	_, err = c.ReadFile(ctx, "/etc/hostname", 0, 0)
+	return err
+}
+
+func assertHandshakeOK(t *testing.T, err error) {
+	t.Helper()
+	if err == nil || errors.Is(err, bridge.ErrUnavailable) || !strings.Contains(err.Error(), "Unimplemented") {
+		t.Fatalf("want Unimplemented (handshake ok), got %v", err)
+	}
+}
+
+func assertHandshakeRejected(t *testing.T, err error) {
+	t.Helper()
+	if !errors.Is(err, bridge.ErrUnavailable) {
+		t.Fatalf("want ErrUnavailable (handshake rejected), got %v", err)
+	}
+}
+
+func TestStrictMTLSAcceptsMemohServerIdentity(t *testing.T) {
+	material := newTestMTLSMaterial(t)
+	material.setStrictEnv(t)
+	addr := startStrictServer(t)
+
+	// 合法 server client cert：握手通过，错误是 Unimplemented（无注册服务），
+	// 证明 TLS 通道建立成功。
+	assertHandshakeOK(t, rpcErr(t, addr, material.clientOptions()))
+}
+
+func TestStrictMTLSRejectsBridgeCertAsClientCert(t *testing.T) {
+	material := newTestMTLSMaterial(t)
+	material.setStrictEnv(t)
+	addr := startStrictServer(t)
+
+	// 核心威胁模型：被攻破的 bot 拿 pod 内仅有的 shared bridge server cert 当
+	// client cert 横向调用其他 bridge——证书由 bridge CA 签发且无 ClientAuth EKU，
+	// 必须被拒。
+	opts := material.clientOptions()
+	opts.ClientCertFile = material.bridgeCertFile
+	opts.ClientKeyFile = material.bridgeKeyFile
+	assertHandshakeRejected(t, rpcErr(t, addr, opts))
+}
+
+func TestStrictMTLSRejectsClientWithoutCert(t *testing.T) {
+	material := newTestMTLSMaterial(t)
+	material.setStrictEnv(t)
+	addr := startStrictServer(t)
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(material.bridgeCA.pem)
+	creds := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12, ServerName: testServerName, RootCAs: pool})
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds), grpc.WithAuthority(testServerName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := conn.Invoke(ctx, "/bridge.v1.ContainerService/ReadFile", nil, nil); status.Code(err) != codes.Unavailable {
+		t.Fatalf("certless client got %v, want Unavailable", status.Code(err))
+	}
+}
+
+func TestStrictMTLSRejectsWrongCAClientCert(t *testing.T) {
+	material := newTestMTLSMaterial(t)
+	material.setStrictEnv(t)
+	addr := startStrictServer(t)
+
+	rogueCA := newTestCA(t, "rogue CA")
+	rogueCert, rogueKey := rogueCA.issue(t, "rogue", x509.ExtKeyUsageClientAuth, nil, testServerURI)
+	opts := material.clientOptions()
+	opts.ClientCertFile = writeTempFile(t, material.dir, "rogue.crt", rogueCert)
+	opts.ClientKeyFile = writeTempFile(t, material.dir, "rogue.key", rogueKey)
+	assertHandshakeRejected(t, rpcErr(t, addr, opts))
+}
+
+func TestStrictMTLSRejectsWrongInstanceURI(t *testing.T) {
+	material := newTestMTLSMaterial(t)
+	material.setStrictEnv(t)
+	addr := startStrictServer(t)
+
+	// CA 正确、EKU 正确、但 instance 不匹配 → VerifyConnection 拒绝。
+	wrongURI := "spiffe://memoh/instance/" + wrongInstanceID + "/server"
+	cert, key := material.clientCA.issue(t, "other-instance server", x509.ExtKeyUsageClientAuth, nil, wrongURI)
+	opts := material.clientOptions()
+	opts.ClientCertFile = writeTempFile(t, material.dir, "other.crt", cert)
+	opts.ClientKeyFile = writeTempFile(t, material.dir, "other.key", key)
+	assertHandshakeRejected(t, rpcErr(t, addr, opts))
+}
+
+func TestClientRejectsWrongBridgeURI(t *testing.T) {
+	material := newTestMTLSMaterial(t)
+	material.setStrictEnv(t)
+	addr := startStrictServer(t)
+
+	// 客户端把对端钉到本 instance 的 bridge URI；server cert instance 不符必须拒连。
+	opts := material.clientOptions()
+	opts.ExpectedServerURI = "spiffe://memoh/instance/" + wrongInstanceID + "/bridge"
+	assertHandshakeRejected(t, rpcErr(t, addr, opts))
+}
+
+func TestBridgeServerCredentialsModeValidation(t *testing.T) {
+	t.Setenv(bridgeTLSModeEnv, "")
+	if creds, err := bridgeServerCredentials(); err != nil || creds != nil {
+		t.Fatalf("empty mode = (%v, %v), want (nil, nil)", creds, err)
+	}
+	t.Setenv(bridgeTLSModeEnv, bridgeTLSModeDisabled)
+	if creds, err := bridgeServerCredentials(); err != nil || creds != nil {
+		t.Fatalf("disabled mode = (%v, %v), want (nil, nil)", creds, err)
+	}
+	t.Setenv(bridgeTLSModeEnv, "permissive")
+	if _, err := bridgeServerCredentials(); err == nil {
+		t.Fatal("unknown mode must error")
+	}
+	// strict 缺材料：必须报错，不允许静默回退明文。
+	t.Setenv(bridgeTLSModeEnv, bridgeTLSModeStrict)
+	t.Setenv(bridgeTLSCertFileEnv, "")
+	t.Setenv(bridgeTLSKeyFileEnv, "")
+	t.Setenv(bridgeTLSClientCAFileEnv, "")
+	t.Setenv(bridgeTLSExpectedClientURIEnv, "")
+	if _, err := bridgeServerCredentials(); err == nil {
+		t.Fatal("strict without material must error")
+	}
+}

--- a/cmd/gen-bridge-mtls/main.go
+++ b/cmd/gen-bridge-mtls/main.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math/big"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/memohai/memoh/internal/config"
+)
+
+const (
+	serverClientCertFile = "server-client.crt"
+	serverClientKeyFile  = "server-client.key"
+	bridgeServerCAFile   = "bridge-server-ca.crt"
+
+	bridgeServerCertFile   = "bridge-server.crt"
+	bridgeServerKeyFile    = "bridge-server.key"
+	serverClientCACertFile = "server-client-ca.crt"
+
+	defaultLeafDays = 365
+	defaultCADays   = 2 * defaultLeafDays
+)
+
+type commandOptions struct {
+	instanceID string
+	outDir     string
+	serverName string
+	force      bool
+	leafDays   int
+	caDays     int
+}
+
+type fileMaterial struct {
+	name string
+	data []byte
+}
+
+type bridgeMTLSMaterial struct {
+	server []fileMaterial
+	bridge []fileMaterial
+}
+
+type materialLayout struct {
+	rootDir   string
+	serverDir string
+	bridgeDir string
+}
+
+type leafSpec struct {
+	commonName  string
+	extKeyUsage x509.ExtKeyUsage
+	dnsNames    []string
+	uris        []*url.URL
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout io.Writer) error {
+	opts, err := parseOptions(args, stdout)
+	if err != nil {
+		return err
+	}
+	instanceID, err := canonicalInstanceID(opts.instanceID)
+	if err != nil {
+		return err
+	}
+	serverName := strings.TrimSpace(opts.serverName)
+	if serverName == "" {
+		serverName = config.BridgeServerName(instanceID)
+	}
+	if opts.leafDays <= 0 {
+		return errors.New("leaf-days must be positive")
+	}
+	if opts.caDays <= 0 {
+		return errors.New("ca-days must be positive")
+	}
+	if opts.caDays < opts.leafDays {
+		return errors.New("ca-days must be greater than or equal to leaf-days")
+	}
+
+	material, err := generateBridgeMTLS(instanceID, serverName, days(opts.leafDays), days(opts.caDays))
+	if err != nil {
+		return err
+	}
+	layout, err := writeBridgeMTLSMaterial(opts.outDir, material, opts.force)
+	if err != nil {
+		return err
+	}
+	return printSummary(stdout, instanceID, serverName, layout)
+}
+
+func parseOptions(args []string, output io.Writer) (commandOptions, error) {
+	opts := commandOptions{
+		outDir:   "data/bridge-mtls",
+		leafDays: defaultLeafDays,
+		caDays:   defaultCADays,
+	}
+	fs := flag.NewFlagSet("gen-bridge-mtls", flag.ContinueOnError)
+	fs.SetOutput(output)
+	fs.StringVar(&opts.instanceID, "instance-id", "", "Memoh instance UUID used in SPIFFE URI SANs")
+	fs.StringVar(&opts.outDir, "out", opts.outDir, "output directory that will receive server/ and bridge/")
+	fs.StringVar(&opts.serverName, "server-name", "", "optional synthetic bridge DNS SAN; defaults from instance-id")
+	fs.BoolVar(&opts.force, "force", false, "replace existing server/ and bridge/ material directories")
+	fs.IntVar(&opts.leafDays, "leaf-days", opts.leafDays, "leaf certificate validity in days")
+	fs.IntVar(&opts.caDays, "ca-days", opts.caDays, "CA certificate validity in days")
+	if err := fs.Parse(args); err != nil {
+		return opts, err
+	}
+	if fs.NArg() != 0 {
+		return opts, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if strings.TrimSpace(opts.instanceID) == "" {
+		return opts, errors.New("instance-id is required")
+	}
+	if strings.TrimSpace(opts.outDir) == "" {
+		return opts, errors.New("out is required")
+	}
+	return opts, nil
+}
+
+func canonicalInstanceID(raw string) (string, error) {
+	id, err := uuid.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("instance-id must be a UUID: %w", err)
+	}
+	if id == uuid.Nil {
+		return "", errors.New("instance-id must not be the nil UUID")
+	}
+	return id.String(), nil
+}
+
+func days(value int) time.Duration {
+	return time.Duration(value) * 24 * time.Hour
+}
+
+func generateBridgeMTLS(instanceID, serverName string, leafTTL, caTTL time.Duration) (bridgeMTLSMaterial, error) {
+	clientCACert, clientCAKey, clientCAPEM, err := newMTLSCA(fmt.Sprintf("memoh instance %s server-client CA", instanceID), caTTL)
+	if err != nil {
+		return bridgeMTLSMaterial{}, err
+	}
+	bridgeCACert, bridgeCAKey, bridgeCAPEM, err := newMTLSCA(fmt.Sprintf("memoh instance %s bridge-server CA", instanceID), caTTL)
+	if err != nil {
+		return bridgeMTLSMaterial{}, err
+	}
+
+	clientURI, err := url.Parse(config.ServerClientSPIFFE(instanceID))
+	if err != nil {
+		return bridgeMTLSMaterial{}, err
+	}
+	clientCertPEM, clientKeyPEM, err := newMTLSLeaf(clientCACert, clientCAKey, leafSpec{
+		commonName:  fmt.Sprintf("memoh instance %s server", instanceID),
+		extKeyUsage: x509.ExtKeyUsageClientAuth,
+		uris:        []*url.URL{clientURI},
+	}, leafTTL)
+	if err != nil {
+		return bridgeMTLSMaterial{}, err
+	}
+
+	bridgeURI, err := url.Parse(config.BridgeServerSPIFFE(instanceID))
+	if err != nil {
+		return bridgeMTLSMaterial{}, err
+	}
+	bridgeCertPEM, bridgeKeyPEM, err := newMTLSLeaf(bridgeCACert, bridgeCAKey, leafSpec{
+		commonName:  fmt.Sprintf("memoh instance %s bridge", instanceID),
+		extKeyUsage: x509.ExtKeyUsageServerAuth,
+		dnsNames:    []string{serverName},
+		uris:        []*url.URL{bridgeURI},
+	}, leafTTL)
+	if err != nil {
+		return bridgeMTLSMaterial{}, err
+	}
+
+	return bridgeMTLSMaterial{
+		server: []fileMaterial{
+			{name: serverClientCertFile, data: clientCertPEM},
+			{name: serverClientKeyFile, data: clientKeyPEM},
+			{name: bridgeServerCAFile, data: bridgeCAPEM},
+		},
+		bridge: []fileMaterial{
+			{name: bridgeServerCertFile, data: bridgeCertPEM},
+			{name: bridgeServerKeyFile, data: bridgeKeyPEM},
+			{name: serverClientCACertFile, data: clientCAPEM},
+		},
+	}, nil
+}
+
+func newMTLSCA(commonName string, ttl time.Duration) (*x509.Certificate, *ecdsa.PrivateKey, []byte, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	serial, err := randomCertSerial()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: commonName, Organization: []string{"memoh"}},
+		NotBefore:             now.Add(-5 * time.Minute),
+		NotAfter:              now.Add(ttl),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return cert, key, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
+}
+
+func newMTLSLeaf(ca *x509.Certificate, caKey *ecdsa.PrivateKey, spec leafSpec, ttl time.Duration) (certPEM, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	serial, err := randomCertSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: spec.commonName, Organization: []string{"memoh"}},
+		NotBefore:    now.Add(-5 * time.Minute),
+		NotAfter:     now.Add(ttl),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{spec.extKeyUsage},
+		DNSNames:     spec.dnsNames,
+		URIs:         spec.uris,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}
+
+func randomCertSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	return rand.Int(rand.Reader, limit)
+}
+
+func writeBridgeMTLSMaterial(root string, material bridgeMTLSMaterial, force bool) (materialLayout, error) {
+	rootDir, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return materialLayout{}, err
+	}
+	if rootDir == string(filepath.Separator) {
+		return materialLayout{}, errors.New("refusing to write bridge mTLS material to filesystem root")
+	}
+	layout := materialLayout{
+		rootDir:   rootDir,
+		serverDir: filepath.Join(rootDir, "server"),
+		bridgeDir: filepath.Join(rootDir, "bridge"),
+	}
+	if err := prepareMaterialDir(layout.serverDir, force); err != nil {
+		return materialLayout{}, fmt.Errorf("prepare server material dir: %w", err)
+	}
+	if err := prepareMaterialDir(layout.bridgeDir, force); err != nil {
+		return materialLayout{}, fmt.Errorf("prepare bridge material dir: %w", err)
+	}
+	if err := writeMaterialFiles(layout.serverDir, material.server); err != nil {
+		return materialLayout{}, err
+	}
+	if err := writeMaterialFiles(layout.bridgeDir, material.bridge); err != nil {
+		return materialLayout{}, err
+	}
+	return layout, nil
+}
+
+func prepareMaterialDir(dir string, force bool) error {
+	if force {
+		if err := os.RemoveAll(dir); err != nil {
+			return err
+		}
+		return os.MkdirAll(dir, 0o700)
+	}
+	entries, err := os.ReadDir(dir)
+	if err == nil {
+		if len(entries) != 0 {
+			return fmt.Errorf("%s already exists and is not empty; use -force to replace it", dir)
+		}
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return err
+	}
+	return os.MkdirAll(dir, 0o700)
+}
+
+func writeMaterialFiles(dir string, files []fileMaterial) error {
+	for _, file := range files {
+		path := filepath.Join(dir, file.name)
+		// #nosec G304,G703 -- The output directory is operator-provided and this tool intentionally writes there.
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+		_, writeErr := f.Write(file.data)
+		closeErr := f.Close()
+		if writeErr != nil {
+			return fmt.Errorf("write %s: %w", path, writeErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close %s: %w", path, closeErr)
+		}
+	}
+	return nil
+}
+
+func printSummary(w io.Writer, instanceID, serverName string, layout materialLayout) error {
+	serverNameValue := "\"\""
+	if serverName != config.BridgeServerName(instanceID) {
+		serverNameValue = fmt.Sprintf("%q", serverName)
+	}
+	summary := fmt.Sprintf(`generated bridge mTLS material under %s
+
+config.toml:
+instance_id = %q
+
+[bridge_tls]
+mode = %q
+server_dir = %q
+bridge_dir = %q
+server_name = %s
+`, layout.rootDir, instanceID, config.BridgeTLSModeStrict, layout.serverDir, layout.bridgeDir, serverNameValue)
+	// #nosec G705 -- This is CLI stdout, not HTML or a web response.
+	_, err := io.WriteString(w, summary)
+	return err
+}

--- a/cmd/gen-bridge-mtls/main_test.go
+++ b/cmd/gen-bridge-mtls/main_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/memohai/memoh/internal/config"
+)
+
+const testInstanceID = "11111111-1111-1111-1111-111111111111"
+
+func TestGenerateBridgeMTLS(t *testing.T) {
+	serverName := config.BridgeServerName(testInstanceID)
+	material, err := generateBridgeMTLS(testInstanceID, serverName, 365*24*time.Hour, 2*365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("generateBridgeMTLS: %v", err)
+	}
+
+	serverFiles := materialMap(material.server)
+	bridgeFiles := materialMap(material.bridge)
+	for _, name := range []string{serverClientCertFile, serverClientKeyFile, bridgeServerCAFile} {
+		if len(serverFiles[name]) == 0 {
+			t.Fatalf("server material missing %s", name)
+		}
+	}
+	for _, name := range []string{bridgeServerCertFile, bridgeServerKeyFile, serverClientCACertFile} {
+		if len(bridgeFiles[name]) == 0 {
+			t.Fatalf("bridge material missing %s", name)
+		}
+	}
+	for _, forbidden := range []string{serverClientCertFile, serverClientKeyFile, bridgeServerCAFile} {
+		if _, ok := bridgeFiles[forbidden]; ok {
+			t.Fatalf("bridge material must not contain %s", forbidden)
+		}
+	}
+	for _, data := range [][]byte{serverFiles[bridgeServerCAFile], bridgeFiles[serverClientCACertFile]} {
+		if strings.Contains(string(data), "PRIVATE KEY") {
+			t.Fatal("CA bundle must not contain private key material")
+		}
+	}
+
+	serverClientCA := mustParseCertPEM(t, bridgeFiles[serverClientCACertFile])
+	bridgeServerCA := mustParseCertPEM(t, serverFiles[bridgeServerCAFile])
+	serverClientCert := mustParseCertPEM(t, serverFiles[serverClientCertFile])
+	bridgeServerCert := mustParseCertPEM(t, bridgeFiles[bridgeServerCertFile])
+
+	serverClientPool := x509.NewCertPool()
+	serverClientPool.AddCert(serverClientCA)
+	bridgeServerPool := x509.NewCertPool()
+	bridgeServerPool.AddCert(bridgeServerCA)
+
+	if _, err := serverClientCert.Verify(x509.VerifyOptions{
+		Roots:     serverClientPool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Fatalf("server client cert does not verify against server-client CA: %v", err)
+	}
+	if got := serverClientCert.URIs; len(got) != 1 || got[0].String() != config.ServerClientSPIFFE(testInstanceID) {
+		t.Fatalf("server client cert URI SAN = %v", got)
+	}
+	if got := serverClientCert.ExtKeyUsage; len(got) != 1 || got[0] != x509.ExtKeyUsageClientAuth {
+		t.Fatalf("server client cert EKU = %v, want ClientAuth only", got)
+	}
+
+	if _, err := bridgeServerCert.Verify(x509.VerifyOptions{
+		Roots:     bridgeServerPool,
+		DNSName:   serverName,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("bridge server cert does not verify against bridge-server CA: %v", err)
+	}
+	if got := bridgeServerCert.URIs; len(got) != 1 || got[0].String() != config.BridgeServerSPIFFE(testInstanceID) {
+		t.Fatalf("bridge server cert URI SAN = %v", got)
+	}
+	if got := bridgeServerCert.ExtKeyUsage; len(got) != 1 || got[0] != x509.ExtKeyUsageServerAuth {
+		t.Fatalf("bridge server cert EKU = %v, want ServerAuth only", got)
+	}
+
+	if _, err := bridgeServerCert.Verify(x509.VerifyOptions{
+		Roots:     serverClientPool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err == nil {
+		t.Fatal("bridge server cert must not verify against server-client CA")
+	}
+	if _, err := serverClientCert.Verify(x509.VerifyOptions{
+		Roots:     bridgeServerPool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err == nil {
+		t.Fatal("server client cert must not verify against bridge-server CA")
+	}
+}
+
+func TestRunWritesExpectedLayout(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "bridge-mtls")
+	var stdout bytes.Buffer
+	if err := run([]string{"-instance-id", testInstanceID, "-out", outDir}, &stdout); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(outDir, "server", serverClientCertFile),
+		filepath.Join(outDir, "server", serverClientKeyFile),
+		filepath.Join(outDir, "server", bridgeServerCAFile),
+		filepath.Join(outDir, "bridge", bridgeServerCertFile),
+		filepath.Join(outDir, "bridge", bridgeServerKeyFile),
+		filepath.Join(outDir, "bridge", serverClientCACertFile),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("stat generated file %s: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "bridge", serverClientKeyFile)); !os.IsNotExist(err) {
+		t.Fatalf("bridge dir must not contain %s: %v", serverClientKeyFile, err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, `mode = "strict"`) ||
+		!strings.Contains(output, `instance_id = "`+testInstanceID+`"`) {
+		t.Fatalf("summary missing config snippet:\n%s", output)
+	}
+}
+
+func TestRunRejectsInvalidInstanceID(t *testing.T) {
+	var stdout bytes.Buffer
+	if err := run([]string{"-instance-id", "not-a-uuid", "-out", t.TempDir()}, &stdout); err == nil || !strings.Contains(err.Error(), "must be a UUID") {
+		t.Fatalf("invalid instance id err = %v", err)
+	}
+}
+
+func TestRunRejectsExistingMaterialWithoutForce(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "bridge-mtls")
+	var stdout bytes.Buffer
+	if err := run([]string{"-instance-id", testInstanceID, "-out", outDir}, &stdout); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if err := run([]string{"-instance-id", testInstanceID, "-out", outDir}, &stdout); err == nil || !strings.Contains(err.Error(), "use -force") {
+		t.Fatalf("second run err = %v", err)
+	}
+}
+
+func materialMap(files []fileMaterial) map[string][]byte {
+	out := make(map[string][]byte, len(files))
+	for _, file := range files {
+		out[file.name] = file.data
+	}
+	return out
+}
+
+func mustParseCertPEM(t *testing.T, data []byte) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		t.Fatalf("expected CERTIFICATE PEM block, got %v", block)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	return cert
+}

--- a/conf/app.example.toml
+++ b/conf/app.example.toml
@@ -20,6 +20,10 @@ jwt_expires_in = "168h"
 
 timezone = "UTC"
 
+# Instance identity used by bridge mTLS strict mode.
+# Leave empty unless [bridge_tls].mode = "strict".
+instance_id = ""
+
 [database]
 # Supported values: "postgres" or "sqlite".
 # PostgreSQL is recommended for shared and production deployments; SQLite is
@@ -60,6 +64,25 @@ runtime_type = "io.containerd.runc.v2"
 # Leave empty to use Docker's standard environment discovery (DOCKER_HOST,
 # DOCKER_TLS_VERIFY, DOCKER_CERT_PATH, or the platform default socket).
 host = ""
+
+[bridge_tls]
+# disabled: default for local/open-source deployments.
+# strict: TCP workspace bridge requires mTLS. UDS/local workspace bridges keep
+# using their local trust model. Shared Kata/CNI deployments should use strict.
+# Generate material with:
+#   scripts/gen-bridge-mtls.sh -instance-id <uuid> -out /opt/memoh/bridge-mtls
+mode = "disabled"
+# Directory readable by the Memoh server process. It must contain:
+# server-client.crt, server-client.key, bridge-server-ca.crt.
+server_dir = ""
+# Directory mounted read-only into workspace containers. It must contain only
+# bridge-server.crt, bridge-server.key, server-client-ca.crt. Strict mode
+# rejects unexpected files here. Do not point this at server_dir, because
+# server_dir contains the Memoh server client key.
+bridge_dir = ""
+# Optional synthetic TLS ServerName. Empty derives
+# memoh-bridge.<instance_id>.bridge.memoh.internal.
+server_name = ""
 
 [apple]
 # Used when [container].backend = "apple". Leave empty to use socktainer defaults.

--- a/docs/kata-containerd.md
+++ b/docs/kata-containerd.md
@@ -28,6 +28,74 @@ guest VM. Memoh routes Kata bridge traffic to the workspace CNI IP and disables
 HTTP proxy use for bridge gRPC dials so proxy settings on the server container
 do not intercept private workspace addresses.
 
+For shared deployments, enable `[bridge_tls].mode = "strict"`. The default
+`disabled` mode keeps local installs simple, but it does not protect a shared
+Kata/CNI network from workspace-to-workspace bridge traffic. In a multi-tenant
+Kata deployment, strict bridge mTLS is the required isolation layer unless your
+networking stack independently blocks workspace-to-workspace TCP access.
+
+## Bridge mTLS Material
+
+Generate strict bridge mTLS material with the repository tool instead of
+hand-writing OpenSSL commands:
+
+```bash
+INSTANCE_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+scripts/gen-bridge-mtls.sh \
+  -instance-id "$INSTANCE_ID" \
+  -out /opt/memoh/bridge-mtls
+```
+
+The `mise` equivalent is:
+
+```bash
+mise run bridge:mtls:gen -- \
+  -instance-id "$INSTANCE_ID" \
+  -out /opt/memoh/bridge-mtls
+```
+
+The generator creates two independent CAs, signs one `ClientAuth` certificate
+for the Memoh server, signs one `ServerAuth` certificate for the workspace
+bridge, writes only the required leaf keys and CA bundles, and discards both CA
+private keys. It prints a config snippet like this:
+
+```toml
+instance_id = "11111111-1111-1111-1111-111111111111"
+
+[bridge_tls]
+mode = "strict"
+server_dir = "/opt/memoh/bridge-mtls/server"
+bridge_dir = "/opt/memoh/bridge-mtls/bridge"
+server_name = ""
+```
+
+`server_dir` is read only by the Memoh server and contains:
+
+```text
+server-client.crt
+server-client.key
+bridge-server-ca.crt
+```
+
+`bridge_dir` is mounted read-only into workspace containers and must contain
+only:
+
+```text
+bridge-server.crt
+bridge-server.key
+server-client-ca.crt
+```
+
+Do not reuse `server_dir` for `bridge_dir`, and do not copy
+`server-client.crt` or `server-client.key` into `bridge_dir`. Strict mode
+rejects a shared directory, symlinked shared directory, missing material, or
+unexpected files in `bridge_dir` before mounting anything into a workspace.
+
+If you enable strict bridge mTLS on an existing deployment, recreate or restart
+all existing workspace containers. Old containers do not have the TLS material
+mount or `BRIDGE_TLS_*` environment variables and will fail closed once the
+server requires mTLS.
+
 ## Host Requirements
 
 - Linux host with KVM available at `/dev/kvm`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,6 +62,46 @@ type Config struct {
 	Registry     RegistryConfig     `toml:"registry"`
 	Supermarket  SupermarketConfig  `toml:"supermarket"`
 	OAuthClients OAuthClientsConfig `toml:"oauth_clients"`
+	InstanceID   string             `toml:"instance_id"`
+	BridgeTLS    BridgeTLSConfig    `toml:"bridge_tls"`
+}
+
+const (
+	BridgeTLSModeDisabled = "disabled"
+	BridgeTLSModeStrict   = "strict"
+)
+
+// BridgeTLSConfig controls mTLS for Memoh server -> workspace bridge TCP gRPC.
+// Strict mode never falls back to plaintext. UDS/local targets are unaffected.
+type BridgeTLSConfig struct {
+	Mode       string `toml:"mode"`
+	ServerDir  string `toml:"server_dir"`
+	BridgeDir  string `toml:"bridge_dir"`
+	ServerName string `toml:"server_name"`
+}
+
+func (c BridgeTLSConfig) EffectiveMode() string {
+	mode := strings.TrimSpace(strings.ToLower(c.Mode))
+	if mode == "" {
+		return BridgeTLSModeDisabled
+	}
+	return mode
+}
+
+func (c BridgeTLSConfig) Strict() bool {
+	return c.EffectiveMode() == BridgeTLSModeStrict
+}
+
+func BridgeServerName(instanceID string) string {
+	return fmt.Sprintf("memoh-bridge.%s.bridge.memoh.internal", instanceID)
+}
+
+func BridgeServerSPIFFE(instanceID string) string {
+	return fmt.Sprintf("spiffe://memoh/instance/%s/bridge", instanceID)
+}
+
+func ServerClientSPIFFE(instanceID string) string {
+	return fmt.Sprintf("spiffe://memoh/instance/%s/server", instanceID)
 }
 
 type LogConfig struct {
@@ -390,6 +431,7 @@ func Load(path string) (Config, error) {
 
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
+			cfg.applyBridgeTLSEnvOverrides()
 			cfg.resolvePaths()
 			return cfg, nil
 		}
@@ -428,9 +470,28 @@ func Load(path string) (Config, error) {
 	} else {
 		cfg.Workspace = cfg.Container.WorkspaceConfig
 	}
+	cfg.applyBridgeTLSEnvOverrides()
 	cfg.resolvePaths()
 
 	return cfg, nil
+}
+
+func (cfg *Config) applyBridgeTLSEnvOverrides() {
+	if value := strings.TrimSpace(os.Getenv("MEMOH_INSTANCE_ID")); value != "" {
+		cfg.InstanceID = value
+	}
+	if value := strings.TrimSpace(os.Getenv("MEMOH_BRIDGE_TLS_MODE")); value != "" {
+		cfg.BridgeTLS.Mode = value
+	}
+	if value := strings.TrimSpace(os.Getenv("MEMOH_BRIDGE_TLS_SERVER_DIR")); value != "" {
+		cfg.BridgeTLS.ServerDir = value
+	}
+	if value := strings.TrimSpace(os.Getenv("MEMOH_BRIDGE_TLS_BRIDGE_DIR")); value != "" {
+		cfg.BridgeTLS.BridgeDir = value
+	}
+	if value := strings.TrimSpace(os.Getenv("MEMOH_BRIDGE_TLS_SERVER_NAME")); value != "" {
+		cfg.BridgeTLS.ServerName = value
+	}
 }
 
 func (cfg *Config) resolvePaths() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -156,6 +156,28 @@ binary_path = "/opt/homebrew/bin/socktainer"
 	}
 }
 
+func TestLoadAppliesBridgeTLSEnvOverrides(t *testing.T) {
+	t.Setenv("MEMOH_INSTANCE_ID", "instance-1")
+	t.Setenv("MEMOH_BRIDGE_TLS_MODE", BridgeTLSModeStrict)
+	t.Setenv("MEMOH_BRIDGE_TLS_SERVER_DIR", "/server")
+	t.Setenv("MEMOH_BRIDGE_TLS_BRIDGE_DIR", "/bridge")
+	t.Setenv("MEMOH_BRIDGE_TLS_SERVER_NAME", "bridge.internal")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "missing.toml"))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.InstanceID != "instance-1" {
+		t.Fatalf("instance id = %q", cfg.InstanceID)
+	}
+	if cfg.BridgeTLS.Mode != BridgeTLSModeStrict ||
+		cfg.BridgeTLS.ServerDir != "/server" ||
+		cfg.BridgeTLS.BridgeDir != "/bridge" ||
+		cfg.BridgeTLS.ServerName != "bridge.internal" {
+		t.Fatalf("bridge tls config = %#v", cfg.BridgeTLS)
+	}
+}
+
 func TestLoadDefaultsContainerdRuntimeType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/bridge/client.go
+++ b/internal/workspace/bridge/client.go
@@ -44,9 +44,15 @@ func NewClientFromConn(conn *grpc.ClientConn) *Client {
 
 // Dial creates a new Client connected to the given gRPC target.
 // For UDS use "unix:///path/to/sock", for TCP use "host:port".
-func Dial(_ context.Context, target string) (*Client, error) {
-	conn, err := grpc.NewClient(target,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+func Dial(ctx context.Context, target string) (*Client, error) {
+	return DialTLS(ctx, target, nil)
+}
+
+// DialTLS dials with optional mTLS. A nil TLS config or UDS target uses the
+// local trust model; TCP targets use strict mTLS when configured.
+func DialTLS(_ context.Context, target string, tlsOpts *TLSOptions) (*Client, error) {
+	creds := insecure.NewCredentials()
+	opts := []grpc.DialOption{
 		grpc.WithNoProxy(),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                30 * time.Second, // ping every 30s if idle
@@ -57,7 +63,19 @@ func Dial(_ context.Context, target string) (*Client, error) {
 			grpc.MaxCallRecvMsgSize(16*1024*1024),
 			grpc.MaxCallSendMsgSize(16*1024*1024),
 		),
-	)
+	}
+	if tlsOpts.appliesTo(target) {
+		tlsCreds, err := tlsOpts.transportCredentials()
+		if err != nil {
+			return nil, err
+		}
+		creds = tlsCreds
+		// The dial target can be an IP or port-forward address, so authority
+		// must be pinned to the synthetic DNS name used in the certificate SAN.
+		opts = append(opts, grpc.WithAuthority(tlsOpts.ServerName))
+	}
+	opts = append(opts, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.NewClient(target, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("grpc dial %s: %w", target, err)
 	}
@@ -587,6 +605,7 @@ type Pool struct {
 	mu             sync.RWMutex
 	clients        map[string]*Client
 	dialTargetFunc func(botID string) string
+	tlsOpts        *TLSOptions
 }
 
 // NewPool creates a client pool. dialTargetFunc maps bot ID to a gRPC target
@@ -596,6 +615,20 @@ func NewPool(dialTargetFunc func(string) string) *Pool {
 		clients:        make(map[string]*Client),
 		dialTargetFunc: dialTargetFunc,
 	}
+}
+
+// SetTLSOptions enables strict mTLS for subsequent TCP dials (UDS targets are
+// exempt). Call once during startup, before the pool serves traffic.
+func (p *Pool) SetTLSOptions(opts *TLSOptions) {
+	p.mu.Lock()
+	p.tlsOpts = opts
+	p.mu.Unlock()
+}
+
+func (p *Pool) tlsOptions() *TLSOptions {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.tlsOpts
 }
 
 // MCPClient implements Provider. Alias for Get.
@@ -626,7 +659,7 @@ func (p *Pool) Get(ctx context.Context, botID string) (*Client, error) {
 		return nil, fmt.Errorf("no dial target for bot %s", botID)
 	}
 
-	c, err := Dial(ctx, target)
+	c, err := DialTLS(ctx, target, p.tlsOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workspace/bridge/tls.go
+++ b/internal/workspace/bridge/tls.go
@@ -1,0 +1,105 @@
+package bridge
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// TLSOptions 配置 Memoh Server → bridge 的 TCP gRPC mTLS（设计 §8.2）。
+// nil 表示 disabled（开源/本地默认）。strict 下握手或身份校验失败一律拒绝，
+// 不回退明文；UDS target 不论 mode 始终走本地信任模型（insecure）。
+type TLSOptions struct {
+	// ServerName 是 synthetic TLS ServerName（memoh-bridge.<instance-id>.bridge.memoh.internal）。
+	// 连接目标是 PodIP（或 port-forward 的 localhost），证书校验必须用稳定名字
+	// 而不是关闭 hostname verification。
+	ServerName string
+	// ExpectedServerURI 是 bridge server cert 必须携带的 URI SAN
+	// （spiffe://memoh/instance/<instance-id>/bridge）。
+	ExpectedServerURI string
+	ClientCertFile    string
+	ClientKeyFile     string
+	// ServerCAFile 是 bridge-server CA bundle（bridge-server-ca.crt）。
+	ServerCAFile string
+}
+
+func (o *TLSOptions) validate() error {
+	if strings.TrimSpace(o.ServerName) == "" {
+		return errors.New("bridge tls: server name is required")
+	}
+	if strings.TrimSpace(o.ExpectedServerURI) == "" {
+		return errors.New("bridge tls: expected server URI is required")
+	}
+	if strings.TrimSpace(o.ClientCertFile) == "" || strings.TrimSpace(o.ClientKeyFile) == "" {
+		return errors.New("bridge tls: client cert/key files are required")
+	}
+	if strings.TrimSpace(o.ServerCAFile) == "" {
+		return errors.New("bridge tls: bridge server CA file is required")
+	}
+	return nil
+}
+
+// transportCredentials 构建 strict mTLS 的 gRPC transport credentials。
+// 每次 dial 重新读文件，证书轮换（Secret 更新 + pod 滚动）后新连接自动用新材料。
+func (o *TLSOptions) transportCredentials() (credentials.TransportCredentials, error) {
+	if err := o.validate(); err != nil {
+		return nil, err
+	}
+	cert, err := tls.LoadX509KeyPair(o.ClientCertFile, o.ClientKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("bridge tls: load client keypair: %w", err)
+	}
+	caPEM, err := os.ReadFile(o.ServerCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("bridge tls: read bridge server CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("bridge tls: no certificates parsed from %s", o.ServerCAFile)
+	}
+	expectedURI := o.ExpectedServerURI
+	cfg := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		ServerName:   o.ServerName,
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		// 标准握手已验:链由 bridge-server CA 签发、DNS SAN 匹配 ServerName、
+		// EKU 含 ServerAuth。这里补 URI SAN 强校验,把对端钉死到本 instance 的
+		// bridge 身份(防同 CA 误签/跨用途证书)。
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			return verifyBridgeServerIdentity(cs, expectedURI)
+		},
+	}
+	return credentials.NewTLS(cfg), nil
+}
+
+func verifyBridgeServerIdentity(cs tls.ConnectionState, expectedURI string) error {
+	if len(cs.PeerCertificates) == 0 {
+		return errors.New("bridge tls: server presented no certificate")
+	}
+	leaf := cs.PeerCertificates[0]
+	if !slices.Contains(leaf.ExtKeyUsage, x509.ExtKeyUsageServerAuth) {
+		return errors.New("bridge tls: server certificate lacks ServerAuth EKU")
+	}
+	for _, uri := range leaf.URIs {
+		if uri.String() == expectedURI {
+			return nil
+		}
+	}
+	return fmt.Errorf("bridge tls: server certificate URI SAN mismatch (want %s)", expectedURI)
+}
+
+// appliesTo 判断 target 是否需要 mTLS：UDS 走文件系统权限的本地信任模型，
+// 始终豁免；其余（PodIP:port、port-forward 的 localhost:port）一律 strict。
+func (o *TLSOptions) appliesTo(target string) bool {
+	if o == nil {
+		return false
+	}
+	return !strings.HasPrefix(target, "unix://") && !strings.HasPrefix(target, "unix:")
+}

--- a/internal/workspace/bridge_tls.go
+++ b/internal/workspace/bridge_tls.go
@@ -1,0 +1,172 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/memohai/memoh/internal/config"
+	"github.com/memohai/memoh/internal/workspace/bridge"
+)
+
+// memoh-server-mtls Secret 在 server pod 内的文件布局（设计 §6.1，由 bytenet 挂载）。
+const (
+	serverClientCertFile = "server-client.crt"
+	serverClientKeyFile  = "server-client.key"
+	bridgeServerCAFile   = "bridge-server-ca.crt"
+
+	bridgeMTLSMountPath    = "/run/memoh/mtls/bridge"
+	bridgeServerCertFile   = "bridge-server.crt"
+	bridgeServerKeyFile    = "bridge-server.key"
+	serverClientCACertFile = "server-client-ca.crt"
+)
+
+type BridgeTLSRuntimeOptions struct {
+	Client            *bridge.TLSOptions
+	BridgeMaterialDir string
+	ExpectedClientURI string
+}
+
+// BridgeTLSOptionsFromConfig 把 server 配置翻译成 bridge dial 的 mTLS options。
+// disabled → (nil, nil)。strict 但材料/instance-id 不全 → error：strict 不允许
+// 静默回退明文，配置残缺必须在启动期暴露。
+func BridgeTLSOptionsFromConfig(cfg config.Config) (*bridge.TLSOptions, error) {
+	switch cfg.BridgeTLS.EffectiveMode() {
+	case config.BridgeTLSModeDisabled:
+		return nil, nil
+	case config.BridgeTLSModeStrict:
+	default:
+		return nil, fmt.Errorf("bridge tls: unknown mode %q (want %s|%s)", cfg.BridgeTLS.Mode, config.BridgeTLSModeDisabled, config.BridgeTLSModeStrict)
+	}
+	instanceID := strings.TrimSpace(cfg.InstanceID)
+	if instanceID == "" {
+		return nil, errors.New("bridge tls: strict mode requires instance id (MEMOH_INSTANCE_ID)")
+	}
+	dir := strings.TrimSpace(cfg.BridgeTLS.ServerDir)
+	if dir == "" {
+		return nil, errors.New("bridge tls: strict mode requires server material dir (MEMOH_BRIDGE_TLS_SERVER_DIR)")
+	}
+	dir, err := normalizeMaterialDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("bridge tls: normalize server material dir: %w", err)
+	}
+	serverName := strings.TrimSpace(cfg.BridgeTLS.ServerName)
+	if serverName == "" {
+		serverName = config.BridgeServerName(instanceID)
+	}
+	opts := &bridge.TLSOptions{
+		ServerName:        serverName,
+		ExpectedServerURI: config.BridgeServerSPIFFE(instanceID),
+		ClientCertFile:    filepath.Join(dir, serverClientCertFile),
+		ClientKeyFile:     filepath.Join(dir, serverClientKeyFile),
+		ServerCAFile:      filepath.Join(dir, bridgeServerCAFile),
+	}
+	if err := validateReadableMaterialFiles(opts.ClientCertFile, opts.ClientKeyFile, opts.ServerCAFile); err != nil {
+		return nil, err
+	}
+	return opts, nil
+}
+
+func BridgeTLSRuntimeOptionsFromConfig(cfg config.Config) (*BridgeTLSRuntimeOptions, error) {
+	clientOpts, err := BridgeTLSOptionsFromConfig(cfg)
+	if err != nil || clientOpts == nil {
+		return nil, err
+	}
+	bridgeDir := strings.TrimSpace(cfg.BridgeTLS.BridgeDir)
+	if bridgeDir == "" {
+		return nil, errors.New("bridge tls: strict mode requires bridge material dir (MEMOH_BRIDGE_TLS_BRIDGE_DIR)")
+	}
+	bridgeDir, err = normalizeMaterialDir(bridgeDir)
+	if err != nil {
+		return nil, fmt.Errorf("bridge tls: normalize bridge material dir: %w", err)
+	}
+	serverDir := filepath.Dir(clientOpts.ClientCertFile)
+	sameDir, err := sameMaterialDir(bridgeDir, serverDir)
+	if err != nil {
+		return nil, err
+	}
+	if sameDir {
+		return nil, errors.New("bridge tls: server material dir and bridge material dir must be different")
+	}
+	if err := validateReadableMaterialFiles(
+		filepath.Join(bridgeDir, bridgeServerCertFile),
+		filepath.Join(bridgeDir, bridgeServerKeyFile),
+		filepath.Join(bridgeDir, serverClientCACertFile),
+	); err != nil {
+		return nil, err
+	}
+	if err := validateBridgeMaterialDirContents(bridgeDir); err != nil {
+		return nil, err
+	}
+	instanceID := strings.TrimSpace(cfg.InstanceID)
+	return &BridgeTLSRuntimeOptions{
+		Client:            clientOpts,
+		BridgeMaterialDir: bridgeDir,
+		ExpectedClientURI: config.ServerClientSPIFFE(instanceID),
+	}, nil
+}
+
+func normalizeMaterialDir(dir string) (string, error) {
+	return filepath.Abs(filepath.Clean(dir))
+}
+
+func validateReadableMaterialFiles(paths ...string) error {
+	for _, path := range paths {
+		// #nosec G304 -- Bridge TLS material paths are operator-configured and must be opened to fail fast.
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("bridge tls: read material file %q: %w", path, err)
+		}
+		info, statErr := file.Stat()
+		closeErr := file.Close()
+		if statErr != nil {
+			return fmt.Errorf("bridge tls: stat material file %q: %w", path, statErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("bridge tls: close material file %q: %w", path, closeErr)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("bridge tls: material path %q is a directory", path)
+		}
+	}
+	return nil
+}
+
+func validateBridgeMaterialDirContents(dir string) error {
+	allowed := map[string]struct{}{
+		bridgeServerCertFile:   {},
+		bridgeServerKeyFile:    {},
+		serverClientCACertFile: {},
+	}
+	// #nosec G304 -- Bridge TLS material dirs are operator-configured and must be inspected before mounting.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("bridge tls: read bridge material dir %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if _, ok := allowed[entry.Name()]; !ok {
+			return fmt.Errorf("bridge tls: bridge material dir %q contains unexpected file %q", dir, entry.Name())
+		}
+	}
+	return nil
+}
+
+func sameMaterialDir(left, right string) (bool, error) {
+	leftInfo, err := os.Stat(left)
+	if err != nil {
+		return false, fmt.Errorf("bridge tls: stat material dir %q: %w", left, err)
+	}
+	if !leftInfo.IsDir() {
+		return false, fmt.Errorf("bridge tls: material dir %q is not a directory", left)
+	}
+	rightInfo, err := os.Stat(right)
+	if err != nil {
+		return false, fmt.Errorf("bridge tls: stat material dir %q: %w", right, err)
+	}
+	if !rightInfo.IsDir() {
+		return false, fmt.Errorf("bridge tls: material dir %q is not a directory", right)
+	}
+	return os.SameFile(leftInfo, rightInfo), nil
+}

--- a/internal/workspace/bridge_tls_test.go
+++ b/internal/workspace/bridge_tls_test.go
@@ -1,0 +1,168 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/config"
+)
+
+func TestBridgeTLSOptionsFromConfigDisabled(t *testing.T) {
+	opts, err := BridgeTLSOptionsFromConfig(config.Config{})
+	if err != nil || opts != nil {
+		t.Fatalf("disabled mode = (%v, %v), want (nil, nil)", opts, err)
+	}
+}
+
+func TestBridgeTLSOptionsFromConfigStrict(t *testing.T) {
+	cfg := newBridgeTLSConfig(t)
+	opts, err := BridgeTLSOptionsFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("strict mode: %v", err)
+	}
+	if opts.ServerName != "memoh-bridge."+cfg.InstanceID+".bridge.memoh.internal" {
+		t.Fatalf("derived ServerName = %q", opts.ServerName)
+	}
+	if opts.ExpectedServerURI != "spiffe://memoh/instance/"+cfg.InstanceID+"/bridge" {
+		t.Fatalf("ExpectedServerURI = %q", opts.ExpectedServerURI)
+	}
+	if opts.ClientCertFile != filepath.Join(cfg.BridgeTLS.ServerDir, serverClientCertFile) ||
+		opts.ClientKeyFile != filepath.Join(cfg.BridgeTLS.ServerDir, serverClientKeyFile) ||
+		opts.ServerCAFile != filepath.Join(cfg.BridgeTLS.ServerDir, bridgeServerCAFile) {
+		t.Fatalf("file paths = %q %q %q", opts.ClientCertFile, opts.ClientKeyFile, opts.ServerCAFile)
+	}
+
+	cfg.BridgeTLS.ServerName = "custom.name.internal"
+	opts, err = BridgeTLSOptionsFromConfig(cfg)
+	if err != nil || opts.ServerName != "custom.name.internal" {
+		t.Fatalf("explicit ServerName = (%q, %v)", opts.ServerName, err)
+	}
+}
+
+func TestBridgeTLSRuntimeOptionsFromConfigStrict(t *testing.T) {
+	cfg := newBridgeTLSConfig(t)
+	opts, err := BridgeTLSRuntimeOptionsFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("strict runtime options: %v", err)
+	}
+	if opts.Client == nil {
+		t.Fatal("runtime options missing client TLS config")
+	}
+	if opts.BridgeMaterialDir != cfg.BridgeTLS.BridgeDir {
+		t.Fatalf("BridgeMaterialDir = %q", opts.BridgeMaterialDir)
+	}
+	if opts.ExpectedClientURI != "spiffe://memoh/instance/"+cfg.InstanceID+"/server" {
+		t.Fatalf("ExpectedClientURI = %q", opts.ExpectedClientURI)
+	}
+}
+
+func TestBridgeTLSOptionsFromConfigStrictRequiresMaterial(t *testing.T) {
+	// strict 不许静默回退明文：instance id 或材料目录缺失必须在启动期报错。
+	if _, err := BridgeTLSOptionsFromConfig(config.Config{
+		BridgeTLS: config.BridgeTLSConfig{Mode: config.BridgeTLSModeStrict, ServerDir: "/x"},
+	}); err == nil || !strings.Contains(err.Error(), "instance id") {
+		t.Fatalf("missing instance id: err = %v", err)
+	}
+	if _, err := BridgeTLSOptionsFromConfig(config.Config{
+		InstanceID: "i-1",
+		BridgeTLS:  config.BridgeTLSConfig{Mode: config.BridgeTLSModeStrict},
+	}); err == nil || !strings.Contains(err.Error(), "server material dir") {
+		t.Fatalf("missing dir: err = %v", err)
+	}
+	if _, err := BridgeTLSOptionsFromConfig(config.Config{
+		BridgeTLS: config.BridgeTLSConfig{Mode: "permissive"},
+	}); err == nil || !strings.Contains(err.Error(), "unknown mode") {
+		t.Fatalf("unknown mode: err = %v", err)
+	}
+	cfg := newBridgeTLSConfig(t)
+	cfg.BridgeTLS.BridgeDir = ""
+	if _, err := BridgeTLSRuntimeOptionsFromConfig(cfg); err == nil || !strings.Contains(err.Error(), "bridge material dir") {
+		t.Fatalf("missing bridge dir: err = %v", err)
+	}
+}
+
+func TestBridgeTLSOptionsFromConfigStrictRequiresReadableServerMaterial(t *testing.T) {
+	cfg := newBridgeTLSConfig(t)
+	if err := os.Remove(filepath.Join(cfg.BridgeTLS.ServerDir, serverClientKeyFile)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := BridgeTLSOptionsFromConfig(cfg); err == nil || !strings.Contains(err.Error(), serverClientKeyFile) {
+		t.Fatalf("missing server material: err = %v", err)
+	}
+}
+
+func TestBridgeTLSRuntimeOptionsFromConfigRejectsSharedMaterialDir(t *testing.T) {
+	cfg := newBridgeTLSConfig(t)
+	cfg.BridgeTLS.BridgeDir = cfg.BridgeTLS.ServerDir
+
+	if _, err := BridgeTLSRuntimeOptionsFromConfig(cfg); err == nil || !strings.Contains(err.Error(), "must be different") {
+		t.Fatalf("shared material dir: err = %v", err)
+	}
+}
+
+func TestBridgeTLSRuntimeOptionsFromConfigRejectsSymlinkedSharedMaterialDir(t *testing.T) {
+	cfg := newBridgeTLSConfig(t)
+	bridgeLink := filepath.Join(t.TempDir(), "bridge-link")
+	if err := os.Symlink(cfg.BridgeTLS.ServerDir, bridgeLink); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	cfg.BridgeTLS.BridgeDir = bridgeLink
+
+	if _, err := BridgeTLSRuntimeOptionsFromConfig(cfg); err == nil || !strings.Contains(err.Error(), "must be different") {
+		t.Fatalf("symlinked shared material dir: err = %v", err)
+	}
+}
+
+func TestBridgeTLSRuntimeOptionsFromConfigRequiresReadableBridgeMaterial(t *testing.T) {
+	cfg := newBridgeTLSConfig(t)
+	if err := os.Remove(filepath.Join(cfg.BridgeTLS.BridgeDir, bridgeServerKeyFile)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := BridgeTLSRuntimeOptionsFromConfig(cfg); err == nil || !strings.Contains(err.Error(), bridgeServerKeyFile) {
+		t.Fatalf("missing bridge material: err = %v", err)
+	}
+}
+
+func TestBridgeTLSRuntimeOptionsFromConfigRejectsUnexpectedBridgeMaterial(t *testing.T) {
+	cfg := newBridgeTLSConfig(t)
+	if err := os.WriteFile(filepath.Join(cfg.BridgeTLS.BridgeDir, serverClientKeyFile), []byte("must not leak\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := BridgeTLSRuntimeOptionsFromConfig(cfg); err == nil || !strings.Contains(err.Error(), "unexpected file") {
+		t.Fatalf("unexpected bridge material: err = %v", err)
+	}
+}
+
+func newBridgeTLSConfig(t *testing.T) config.Config {
+	t.Helper()
+	root := t.TempDir()
+	serverDir := filepath.Join(root, "server")
+	bridgeDir := filepath.Join(root, "bridge")
+	writeMaterialFiles(t, serverDir, serverClientCertFile, serverClientKeyFile, bridgeServerCAFile)
+	writeMaterialFiles(t, bridgeDir, bridgeServerCertFile, bridgeServerKeyFile, serverClientCACertFile)
+	return config.Config{
+		InstanceID: "11111111-1111-1111-1111-111111111111",
+		BridgeTLS: config.BridgeTLSConfig{
+			Mode:      config.BridgeTLSModeStrict,
+			ServerDir: serverDir,
+			BridgeDir: bridgeDir,
+		},
+	}
+}
+
+func writeMaterialFiles(t *testing.T, dir string, names ...string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range names {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("test material\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -93,6 +93,7 @@ type Manager struct {
 	containerLockMu   sync.Mutex
 	containerLocks    map[string]*sync.Mutex
 	grpcPool          *bridge.Pool
+	bridgeTLS         *BridgeTLSRuntimeOptions
 	legacyMu          sync.RWMutex
 	legacyIPs         map[string]string // botID → IP for pre-bridge containers
 }
@@ -127,7 +128,20 @@ func NewManager(log *slog.Logger, service runtimeService, networkController netc
 	return m
 }
 
-// resolveContainerID resolves the actual containerd container ID for a bot.
+// SetBridgeTLS enables strict mTLS on TCP bridge dials and injects bridge-side
+// TLS material into new workspace containers. UDS bridge targets keep using the
+// local filesystem trust model.
+func (m *Manager) SetBridgeTLS(opts *BridgeTLSRuntimeOptions) {
+	if opts == nil {
+		m.bridgeTLS = nil
+		m.grpcPool.SetTLSOptions(nil)
+		return
+	}
+	m.bridgeTLS = opts
+	m.grpcPool.SetTLSOptions(opts.Client)
+}
+
+// resolveContainerID resolves the actual workspace container ID for a bot.
 // This is the SINGLE point of container ID resolution for all lookup operations.
 // It delegates to ContainerID (DB → label → scan) and falls back to the
 // new-style prefix if no container exists yet.
@@ -371,6 +385,18 @@ func (m *Manager) buildWorkspaceContainerSpec(ctx context.Context, botID string,
 	}
 	tzMounts, tzEnv := ctr.TimezoneSpec()
 	mounts = append(mounts, tzMounts...)
+	if m.bridgeTLS != nil {
+		bridgeDir := strings.TrimSpace(m.bridgeTLS.BridgeMaterialDir)
+		if bridgeDir == "" || strings.TrimSpace(m.bridgeTLS.ExpectedClientURI) == "" {
+			return ctr.ContainerSpec{}, fmt.Errorf("%w: bridge TLS strict mode requires bridge material dir and expected client URI", ctr.ErrInvalidArgument)
+		}
+		mounts = append(mounts, ctr.MountSpec{
+			Destination: bridgeMTLSMountPath,
+			Type:        "bind",
+			Source:      bridgeDir,
+			Options:     []string{"rbind", "ro"},
+		})
+	}
 
 	skillRoots, err := m.ResolveWorkspaceSkillDiscoveryRoots(ctx, botID)
 	if err != nil {
@@ -384,6 +410,7 @@ func (m *Manager) buildWorkspaceContainerSpec(ctx context.Context, botID string,
 	} else {
 		env = append(env, "BRIDGE_SOCKET_PATH=/run/memoh/bridge.sock")
 	}
+	env = m.appendBridgeTLSEnv(env)
 	if m.botDisplayEnabled(ctx, botID) {
 		env = append(env,
 			"MEMOH_DISPLAY_ENABLED=true",
@@ -399,6 +426,19 @@ func (m *Manager) buildWorkspaceContainerSpec(ctx context.Context, botID string,
 		Env:        env,
 		CDIDevices: normalizeWorkspaceGPUDevices(gpu.Devices),
 	}, nil
+}
+
+func (m *Manager) appendBridgeTLSEnv(env []string) []string {
+	if m.bridgeTLS == nil {
+		return env
+	}
+	return append(env,
+		"BRIDGE_TLS_MODE="+config.BridgeTLSModeStrict,
+		"BRIDGE_TLS_CERT_FILE="+bridgeMTLSMountPath+"/"+bridgeServerCertFile,
+		"BRIDGE_TLS_KEY_FILE="+bridgeMTLSMountPath+"/"+bridgeServerKeyFile,
+		"BRIDGE_TLS_CLIENT_CA_FILE="+bridgeMTLSMountPath+"/"+serverClientCACertFile,
+		"BRIDGE_TLS_EXPECTED_CLIENT_URI="+m.bridgeTLS.ExpectedClientURI,
+	)
 }
 
 func (m *Manager) botDisplayEnabled(ctx context.Context, botID string) bool {

--- a/internal/workspace/manager_legacy_test.go
+++ b/internal/workspace/manager_legacy_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -16,9 +17,10 @@ import (
 )
 
 type legacyRouteTestService struct {
-	container ctr.ContainerInfo
-	created   bool
-	byLabel   []ctr.ContainerInfo
+	container  ctr.ContainerInfo
+	created    bool
+	byLabel    []ctr.ContainerInfo
+	createdReq ctr.CreateContainerRequest
 
 	createCalls int
 	startCalls  int
@@ -92,6 +94,7 @@ func (*legacyRouteTestService) ResolveRemoteDigest(context.Context, string) (str
 func (s *legacyRouteTestService) CreateContainer(_ context.Context, req ctr.CreateContainerRequest) (ctr.ContainerInfo, error) {
 	s.createCalls++
 	s.created = true
+	s.createdReq = req
 	s.container = ctr.ContainerInfo{
 		ID:         req.ID,
 		Image:      req.ImageRef,
@@ -213,6 +216,68 @@ func newLegacyRouteTestManager(t *testing.T, svc runtimeService, cfg config.Work
 	}
 	m.grpcPool = bridge.NewPool(m.dialTarget)
 	return m
+}
+
+func TestBuildWorkspaceContainerSpecInjectsBridgeTLSMaterial(t *testing.T) {
+	dataRoot := t.TempDir()
+	runtimeDir := t.TempDir()
+	bridgeDir := t.TempDir()
+	expectedClientURI := config.ServerClientSPIFFE("instance-1")
+	m := newLegacyRouteTestManager(t, &legacyRouteTestService{}, config.WorkspaceConfig{
+		DataRoot:   dataRoot,
+		RuntimeDir: runtimeDir,
+	})
+	m.SetBridgeTLS(&BridgeTLSRuntimeOptions{
+		Client:            &bridge.TLSOptions{},
+		BridgeMaterialDir: bridgeDir,
+		ExpectedClientURI: expectedClientURI,
+	})
+
+	spec, err := m.buildWorkspaceContainerSpec(context.Background(), "00000000-0000-0000-0000-000000000001", WorkspaceGPUConfig{})
+	if err != nil {
+		t.Fatalf("build spec: %v", err)
+	}
+
+	var foundMount bool
+	for _, mount := range spec.Mounts {
+		if mount.Destination == bridgeMTLSMountPath {
+			foundMount = true
+			if mount.Source != bridgeDir {
+				t.Fatalf("bridge TLS mount source = %q, want %q", mount.Source, bridgeDir)
+			}
+			if strings.Join(mount.Options, ",") != "rbind,ro" {
+				t.Fatalf("bridge TLS mount options = %v", mount.Options)
+			}
+		}
+	}
+	if !foundMount {
+		t.Fatalf("missing bridge TLS mount at %s", bridgeMTLSMountPath)
+	}
+
+	env := envMap(spec.Env)
+	wantEnv := map[string]string{
+		"BRIDGE_TLS_MODE":                config.BridgeTLSModeStrict,
+		"BRIDGE_TLS_CERT_FILE":           bridgeMTLSMountPath + "/" + bridgeServerCertFile,
+		"BRIDGE_TLS_KEY_FILE":            bridgeMTLSMountPath + "/" + bridgeServerKeyFile,
+		"BRIDGE_TLS_CLIENT_CA_FILE":      bridgeMTLSMountPath + "/" + serverClientCACertFile,
+		"BRIDGE_TLS_EXPECTED_CLIENT_URI": expectedClientURI,
+	}
+	for key, want := range wantEnv {
+		if got := env[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func envMap(items []string) map[string]string {
+	out := make(map[string]string, len(items))
+	for _, item := range items {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			out[key] = value
+		}
+	}
+	return out
 }
 
 func TestStartWithImageClearsLegacyRouteForBridgeContainer(t *testing.T) {

--- a/mise.toml
+++ b/mise.toml
@@ -226,6 +226,10 @@ docker compose -f devenv/docker-compose.yml -f devenv/docker-compose.selinux.yml
   sh -c 'cd /workspace && sh devenv/bridge-build.sh'
 """
 
+[tasks."bridge:mtls:gen"]
+description = "Generate strict bridge mTLS material (usage: mise run bridge:mtls:gen -- -instance-id <uuid> -out data/bridge-mtls)"
+run = "scripts/gen-bridge-mtls.sh"
+
 [tasks."kata:runner"]
 description = "Check that the current Linux/KVM host is ready to run Kata E2E"
 run = "scripts/check-kata-runner-ready.sh"

--- a/scripts/gen-bridge-mtls.sh
+++ b/scripts/gen-bridge-mtls.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+go run ./cmd/gen-bridge-mtls "$@"


### PR DESCRIPTION
## Summary
- port the audited bridge mTLS hardening into the open-source workspace bridge path
- add strict server/client SPIFFE and EKU validation for TCP bridge gRPC while keeping UDS/local bridge paths unchanged
- add a bridge mTLS material generator plus docs for shared Kata deployments
- fail fast on missing TLS material and reject bridge material directories that would leak server-side client credentials

## Testing
- go test ./cmd/gen-bridge-mtls ./internal/workspace ./internal/config ./cmd/bridge ./internal/workspace/bridge
- TMPDIR=/tmp go test ./...
- pre-commit Go test, Go lint, and lint-staged passed during amend
