### PR TITLE
feat: run plugin install scripts

### DIFF
--- a/internal/handlers/supermarket.go
+++ b/internal/handlers/supermarket.go
@@ -29,17 +29,25 @@ import (
 type SupermarketHandler struct {
 	baseURL        string
 	httpClient     *http.Client
-	pluginService  *pluginspkg.Service
+	pluginService  pluginInstaller
 	containers     bridge.Provider
 	botService     *bots.Service
 	accountService *accounts.Service
 	logger         *slog.Logger
 }
 
+type pluginInstaller interface {
+	Install(ctx context.Context, botID string, req pluginspkg.InstallRequest) (pluginspkg.Installation, error)
+}
+
 type pluginBundleWriter interface {
 	DeleteFile(ctx context.Context, path string, recursive bool) error
 	Mkdir(ctx context.Context, path string) error
 	WriteFile(ctx context.Context, path string, content []byte) error
+}
+
+type pluginInstallScriptExecutor interface {
+	ExecWithEnv(ctx context.Context, command, workDir string, timeout int32, env []string) (*bridge.ExecResult, error)
 }
 
 type pluginAssetInstallResult struct {
@@ -53,6 +61,26 @@ type pluginBundleInstallResult struct {
 	Hooks   pluginAssetInstallResult
 	Scripts pluginAssetInstallResult
 }
+
+type pluginInstallScriptsResult struct {
+	OK          bool                         `json:"ok"`
+	CommandsRun int                          `json:"commands_run"`
+	Results     []pluginInstallCommandResult `json:"results,omitempty"`
+	Error       string                       `json:"error,omitempty"`
+}
+
+type pluginInstallCommandResult struct {
+	Command  string `json:"command"`
+	ExitCode int32  `json:"exit_code"`
+	Stdout   string `json:"stdout,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+const (
+	pluginInstallScriptTimeoutSeconds int32 = 10 * 60
+	pluginInstallScriptOutputLimit          = 64 * 1024
+)
 
 func NewSupermarketHandler(
 	log *slog.Logger,
@@ -229,16 +257,30 @@ func (h *SupermarketHandler) InstallPlugin(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	manifest = pluginspkg.NormalizeManifest(manifest)
+	if manifest.ID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "plugin id is required")
+	}
 
-	installation, err := h.pluginService.Install(c.Request().Context(), botID, pluginspkg.InstallRequest{
+	ctx := c.Request().Context()
+	bundleResult, err := h.installPluginBundle(ctx, botID, req.PluginID, manifest.ID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+	}
+	scriptsResult, err := h.runPluginInstallScripts(ctx, botID, manifest.ID, manifest.Install)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+	}
+
+	installation, err := h.pluginService.Install(ctx, botID, pluginspkg.InstallRequest{
 		Manifest:  manifest,
 		Variables: req.Variables,
 	})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	result, installBundleErr := h.installPluginBundle(c.Request().Context(), botID, req.PluginID, installation.PluginID)
-	installation = withPluginBundleInstallMetadata(installation, result, installBundleErr)
+	installation = withPluginBundleInstallMetadata(installation, bundleResult, nil)
+	installation = withPluginInstallScriptsMetadata(installation, scriptsResult, nil)
 	return c.JSON(http.StatusOK, installation)
 }
 
@@ -463,6 +505,67 @@ func (h *SupermarketHandler) installPluginBundle(ctx context.Context, botID, dow
 	return result, nil
 }
 
+func (h *SupermarketHandler) runPluginInstallScripts(ctx context.Context, botID, pluginID string, commands pluginspkg.InstallCommands) (pluginInstallScriptsResult, error) {
+	result := newPluginInstallScriptsResult()
+	if len(commands) == 0 {
+		return result, nil
+	}
+	if h.containers == nil {
+		return result, errors.New("container provider is not configured")
+	}
+	client, err := h.containers.MCPClient(ctx, botID)
+	if err != nil {
+		return result, fmt.Errorf("container not reachable: %w", err)
+	}
+	return runPluginInstallCommands(ctx, client, botID, pluginID, []string(commands))
+}
+
+func runPluginInstallCommands(ctx context.Context, executor pluginInstallScriptExecutor, botID, pluginID string, commands []string) (pluginInstallScriptsResult, error) {
+	result := newPluginInstallScriptsResult()
+	if executor == nil {
+		return result, errors.New("plugin install script executor is not configured")
+	}
+	pluginRoot, err := skillset.PluginDirForID(pluginID)
+	if err != nil {
+		return result, err
+	}
+	env := []string{
+		"MEMOH_PLUGIN_ID=" + pluginID,
+		"MEMOH_PLUGIN_DIR=" + pluginRoot,
+		"MEMOH_BOT_ID=" + botID,
+	}
+	for _, command := range commands {
+		command = strings.TrimSpace(command)
+		if command == "" {
+			continue
+		}
+		commandResult := pluginInstallCommandResult{Command: command}
+		execResult, execErr := executor.ExecWithEnv(ctx, command, pluginRoot, pluginInstallScriptTimeoutSeconds, env)
+		result.CommandsRun++
+		if execResult != nil {
+			commandResult.ExitCode = execResult.ExitCode
+			commandResult.Stdout = truncatePluginInstallOutput(execResult.Stdout)
+			commandResult.Stderr = truncatePluginInstallOutput(execResult.Stderr)
+		}
+		if execErr != nil {
+			commandResult.Error = execErr.Error()
+			result.Results = append(result.Results, commandResult)
+			result.OK = false
+			result.Error = execErr.Error()
+			return result, fmt.Errorf("plugin install command %q failed: %w", command, execErr)
+		}
+		if execResult != nil && execResult.ExitCode != 0 {
+			commandResult.Error = fmt.Sprintf("command exited with code %d", execResult.ExitCode)
+			result.Results = append(result.Results, commandResult)
+			result.OK = false
+			result.Error = commandResult.Error
+			return result, fmt.Errorf("plugin install command %q exited with code %d", command, execResult.ExitCode)
+		}
+		result.Results = append(result.Results, commandResult)
+	}
+	return result, nil
+}
+
 const (
 	pluginArchiveKindSkills  = "skills"
 	pluginArchiveKindHooks   = "hooks"
@@ -604,6 +707,10 @@ func newPluginBundleInstallResult() pluginBundleInstallResult {
 	}
 }
 
+func newPluginInstallScriptsResult() pluginInstallScriptsResult {
+	return pluginInstallScriptsResult{OK: true}
+}
+
 func withPluginBundleInstallMetadata(installation pluginspkg.Installation, result pluginBundleInstallResult, err error) pluginspkg.Installation {
 	metadata := maps.Clone(installation.Metadata)
 	if metadata == nil {
@@ -618,4 +725,25 @@ func withPluginBundleInstallMetadata(installation pluginspkg.Installation, resul
 	metadata["scripts_install"] = result.Scripts
 	installation.Metadata = metadata
 	return installation
+}
+
+func withPluginInstallScriptsMetadata(installation pluginspkg.Installation, result pluginInstallScriptsResult, err error) pluginspkg.Installation {
+	metadata := maps.Clone(installation.Metadata)
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	if err != nil {
+		result.OK = false
+		result.Error = err.Error()
+	}
+	metadata["install_scripts"] = result
+	installation.Metadata = metadata
+	return installation
+}
+
+func truncatePluginInstallOutput(output string) string {
+	if len(output) <= pluginInstallScriptOutputLimit {
+		return output
+	}
+	return output[:pluginInstallScriptOutputLimit]
 }

--- a/internal/handlers/supermarket_test.go
+++ b/internal/handlers/supermarket_test.go
@@ -4,10 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	skillset "github.com/memohai/memoh/internal/skills"
+	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
 func TestPluginBundleArchiveEntryAllowsTrustedBundleFiles(t *testing.T) {
@@ -161,6 +163,101 @@ func TestExtractPluginBundleArchiveSeparatesArchiveAndTargetPluginIDs(t *testing
 	}
 }
 
+func TestRunPluginInstallCommandsUsesPluginRootAndMemohEnv(t *testing.T) {
+	pluginRoot, err := skillset.PluginDirForID("github")
+	if err != nil {
+		t.Fatalf("plugin root: %v", err)
+	}
+	longOutput := strings.Repeat("x", pluginInstallScriptOutputLimit+8)
+	executor := &pluginInstallScriptTestExecutor{
+		results: []*bridge.ExecResult{
+			{Stdout: longOutput, ExitCode: 0},
+			{Stderr: "setup ok\n", ExitCode: 0},
+		},
+	}
+
+	result, err := runPluginInstallCommands(context.Background(), executor, "bot-1", "github", []string{
+		" sh scripts/install.sh ",
+		"",
+		"python3 scripts/setup.py",
+	})
+	if err != nil {
+		t.Fatalf("runPluginInstallCommands returned error: %v", err)
+	}
+	if !result.OK || result.CommandsRun != 2 || len(result.Results) != 2 {
+		t.Fatalf("result = %+v, want two successful commands", result)
+	}
+	if len(result.Results[0].Stdout) != pluginInstallScriptOutputLimit {
+		t.Fatalf("stdout was not truncated to limit: %d", len(result.Results[0].Stdout))
+	}
+
+	wantCommands := []string{"sh scripts/install.sh", "python3 scripts/setup.py"}
+	if len(executor.calls) != len(wantCommands) {
+		t.Fatalf("calls = %+v, want %d calls", executor.calls, len(wantCommands))
+	}
+	for i, call := range executor.calls {
+		if call.command != wantCommands[i] {
+			t.Fatalf("call %d command = %q, want %q", i, call.command, wantCommands[i])
+		}
+		if call.workDir != pluginRoot {
+			t.Fatalf("call %d work dir = %q, want %q", i, call.workDir, pluginRoot)
+		}
+		if call.timeout != pluginInstallScriptTimeoutSeconds {
+			t.Fatalf("call %d timeout = %d, want %d", i, call.timeout, pluginInstallScriptTimeoutSeconds)
+		}
+		wantEnv := []string{
+			"MEMOH_PLUGIN_ID=github",
+			"MEMOH_PLUGIN_DIR=" + pluginRoot,
+			"MEMOH_BOT_ID=bot-1",
+		}
+		if strings.Join(call.env, "\n") != strings.Join(wantEnv, "\n") {
+			t.Fatalf("call %d env = %#v, want %#v", i, call.env, wantEnv)
+		}
+	}
+}
+
+func TestRunPluginInstallCommandsStopsOnNonZeroExit(t *testing.T) {
+	executor := &pluginInstallScriptTestExecutor{
+		results: []*bridge.ExecResult{
+			{Stdout: "ok\n", ExitCode: 0},
+			{Stderr: "boom\n", ExitCode: 7},
+			{Stdout: "should not run\n", ExitCode: 0},
+		},
+	}
+
+	result, err := runPluginInstallCommands(context.Background(), executor, "bot-1", "github", []string{
+		"sh scripts/one.sh",
+		"sh scripts/two.sh",
+		"sh scripts/three.sh",
+	})
+	if err == nil {
+		t.Fatal("expected non-zero exit to fail")
+	}
+	if result.OK || result.CommandsRun != 2 || len(result.Results) != 2 {
+		t.Fatalf("result = %+v, want failure after second command", result)
+	}
+	if result.Results[1].ExitCode != 7 || result.Results[1].Stderr != "boom\n" || result.Results[1].Error == "" {
+		t.Fatalf("failed command result = %+v, want exit code, stderr, and error", result.Results[1])
+	}
+	if len(executor.calls) != 2 {
+		t.Fatalf("commands run = %d, want 2", len(executor.calls))
+	}
+}
+
+func TestRunPluginInstallCommandsReportsExecError(t *testing.T) {
+	executor := &pluginInstallScriptTestExecutor{
+		errors: []error{errors.New("bridge unavailable")},
+	}
+
+	result, err := runPluginInstallCommands(context.Background(), executor, "bot-1", "github", []string{"sh scripts/install.sh"})
+	if err == nil {
+		t.Fatal("expected exec error")
+	}
+	if result.OK || result.CommandsRun != 1 || len(result.Results) != 1 || result.Results[0].Error != "bridge unavailable" {
+		t.Fatalf("result = %+v, want exec error metadata", result)
+	}
+}
+
 func tarArchive(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -216,4 +313,39 @@ func (w *pluginBundleTestWriter) Mkdir(_ context.Context, path string) error {
 func (w *pluginBundleTestWriter) WriteFile(_ context.Context, path string, content []byte) error {
 	w.files[path] = string(content)
 	return nil
+}
+
+type pluginInstallScriptTestExecutor struct {
+	calls   []pluginInstallScriptTestCall
+	results []*bridge.ExecResult
+	errors  []error
+}
+
+type pluginInstallScriptTestCall struct {
+	command string
+	workDir string
+	timeout int32
+	env     []string
+}
+
+func (e *pluginInstallScriptTestExecutor) ExecWithEnv(_ context.Context, command, workDir string, timeout int32, env []string) (*bridge.ExecResult, error) {
+	callIndex := len(e.calls)
+	e.calls = append(e.calls, pluginInstallScriptTestCall{
+		command: command,
+		workDir: workDir,
+		timeout: timeout,
+		env:     append([]string(nil), env...),
+	})
+	var result *bridge.ExecResult
+	if callIndex < len(e.results) {
+		result = e.results[callIndex]
+	}
+	if result == nil {
+		result = &bridge.ExecResult{ExitCode: 0}
+	}
+	var err error
+	if callIndex < len(e.errors) {
+		err = e.errors[callIndex]
+	}
+	return result, err
 }

--- a/internal/plugins/service.go
+++ b/internal/plugins/service.go
@@ -497,6 +497,10 @@ func normalizeResource(row sqlc.BotPluginResource) (Resource, error) {
 	}, nil
 }
 
+func NormalizeManifest(manifest Manifest) Manifest {
+	return normalizeManifest(manifest)
+}
+
 func normalizeManifest(manifest Manifest) Manifest {
 	manifest.ID = sanitizeID(manifest.ID)
 	manifest.Name = strings.TrimSpace(manifest.Name)
@@ -507,6 +511,7 @@ func normalizeManifest(manifest Manifest) Manifest {
 	if manifest.SchemaVersion == "" {
 		manifest.SchemaVersion = "1"
 	}
+	manifest.Install = normalizeInstallCommands(manifest.Install)
 	for i := range manifest.MCPs {
 		manifest.MCPs[i].Key = sanitizeID(manifest.MCPs[i].Key)
 		if manifest.MCPs[i].Key == "" {
@@ -523,6 +528,18 @@ func normalizeManifest(manifest Manifest) Manifest {
 		}
 	}
 	return manifest
+}
+
+func normalizeInstallCommands(commands []string) InstallCommands {
+	out := make([]string, 0, len(commands))
+	for _, command := range commands {
+		command = strings.TrimSpace(command)
+		if command == "" {
+			continue
+		}
+		out = append(out, command)
+	}
+	return InstallCommands(out)
 }
 
 func manifestAuthForResource(manifest Manifest, resource MCPResource) AuthRequirement {

--- a/internal/plugins/service_test.go
+++ b/internal/plugins/service_test.go
@@ -1,10 +1,68 @@
 package plugins
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/memohai/memoh/internal/mcp"
 )
+
+func TestManifestInstallCommandsAcceptStringOrList(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "string",
+			raw:  `{"id":"plugin","name":"Plugin","author":{"name":"Memoh"},"install":" sh scripts/install.sh "}`,
+			want: []string{"sh scripts/install.sh"},
+		},
+		{
+			name: "list",
+			raw:  `{"id":"plugin","name":"Plugin","author":{"name":"Memoh"},"install":[" sh scripts/a.sh ","","python3 scripts/b.py"]}`,
+			want: []string{"sh scripts/a.sh", "python3 scripts/b.py"},
+		},
+		{
+			name: "null",
+			raw:  `{"id":"plugin","name":"Plugin","author":{"name":"Memoh"},"install":null}`,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var manifest Manifest
+			if err := json.Unmarshal([]byte(tt.raw), &manifest); err != nil {
+				t.Fatalf("json.Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual([]string(manifest.Install), tt.want) {
+				t.Fatalf("install = %#v, want %#v", []string(manifest.Install), tt.want)
+			}
+		})
+	}
+}
+
+func TestManifestInstallCommandsRejectInvalidShape(t *testing.T) {
+	var manifest Manifest
+	if err := json.Unmarshal([]byte(`{"id":"plugin","install":7}`), &manifest); err == nil {
+		t.Fatal("expected invalid install shape to fail")
+	}
+}
+
+func TestNormalizeManifestTrimsInstallCommands(t *testing.T) {
+	manifest := NormalizeManifest(Manifest{
+		ID:      "Plugin.ID",
+		Name:    " Plugin ",
+		Install: InstallCommands{" sh scripts/install.sh ", "", "python3 scripts/setup.py"},
+	})
+
+	want := []string{"sh scripts/install.sh", "python3 scripts/setup.py"}
+	if !reflect.DeepEqual([]string(manifest.Install), want) {
+		t.Fatalf("install = %#v, want %#v", []string(manifest.Install), want)
+	}
+}
 
 func TestMissingRequiredVariablesTreatsSelfTemplateDefaultAsMissing(t *testing.T) {
 	manifest := Manifest{

--- a/internal/plugins/types.go
+++ b/internal/plugins/types.go
@@ -1,6 +1,11 @@
 package plugins
 
-import "time"
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
 
 const (
 	StatusReady         = "ready"
@@ -70,6 +75,37 @@ type SkillEntry struct {
 	Files       []string       `json:"files,omitempty"`
 }
 
+type InstallCommands []string
+
+func (c *InstallCommands) UnmarshalJSON(data []byte) error {
+	raw := strings.TrimSpace(string(data))
+	if raw == "" || raw == "null" {
+		*c = nil
+		return nil
+	}
+	if strings.HasPrefix(raw, "[") {
+		var items []string
+		if err := json.Unmarshal(data, &items); err != nil {
+			return err
+		}
+		*c = normalizeInstallCommands(items)
+		return nil
+	}
+	if strings.HasPrefix(raw, "\"") {
+		var item string
+		if err := json.Unmarshal(data, &item); err != nil {
+			return err
+		}
+		*c = normalizeInstallCommands([]string{item})
+		return nil
+	}
+	return errors.New("install must be a string or string array")
+}
+
+func (c InstallCommands) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]string(c))
+}
+
 type Manifest struct {
 	SchemaVersion    string            `json:"schema_version,omitempty"`
 	ID               string            `json:"id"`
@@ -81,6 +117,7 @@ type Manifest struct {
 	Homepage         string            `json:"homepage,omitempty"`
 	Tags             []string          `json:"tags,omitempty"`
 	Capabilities     []string          `json:"capabilities,omitempty"`
+	Install          InstallCommands   `json:"install,omitempty"`
 	Variables        []ConfigVar       `json:"variables,omitempty"`
 	AuthRequirements []AuthRequirement `json:"auth_requirements,omitempty"`
 	MCPs             []MCPResource     `json:"mcps,omitempty"`

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -2162,6 +2162,7 @@ export type PluginsManifest = {
     homepage?: string;
     icon?: PluginsIcon;
     id?: string;
+    install?: Array<string>;
     mcps?: Array<PluginsMcpResource>;
     name?: string;
     schema_version?: string;

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -17307,6 +17307,12 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "install": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "mcps": {
                     "type": "array",
                     "items": {

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -17298,6 +17298,12 @@
                 "id": {
                     "type": "string"
                 },
+                "install": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "mcps": {
                     "type": "array",
                     "items": {

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -3598,6 +3598,10 @@ definitions:
         $ref: '#/definitions/plugins.Icon'
       id:
         type: string
+      install:
+        items:
+          type: string
+        type: array
       mcps:
         items:
           $ref: '#/definitions/plugins.MCPResource'


### PR DESCRIPTION
## Summary
- Add the plugin manifest `install` field with string/list parsing and normalized SDK/OpenAPI output.
- Change Supermarket plugin install order to fetch trusted manifest, extract the bundle, run install commands from `/data/.memoh/plugins/<plugin_id>`, then create DB/MCP installation records.
- Inject only `MEMOH_PLUGIN_ID`, `MEMOH_PLUGIN_DIR`, and `MEMOH_BOT_ID`; command failure now fails the API before DB/MCP plugin creation.
- Return `install_scripts` metadata on successful installs with command count, exit code, and truncated stdout/stderr.

## Validation
- `mise run sdk-generate`
- `TMPDIR=/tmp go test ./internal/plugins ./internal/handlers ./internal/skills ./internal/hooks ./cmd/agent`
- `pnpm --filter @memohai/web build`
- `TMPDIR=/tmp git commit -m "feat: run plugin install scripts"` (pre-commit Go lint/tests)

Related: memohai/supermarket#14