### PR TITLE
fix(web): restore sidebar workspace actions

### DIFF
--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -125,22 +125,16 @@
       <div class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-sidebar to-transparent" />
     </div>
 
-    <!-- Settings, pinned to the bottom. Shares the icon column with New Chat /
-         session rows: container px-2 + button px-[11px] → the hover pill sits 8px
-         off the left AND right walls, matching every list row above. The button is
-         the SHORTER h-8: it's a single standing footer action, not a list row, so
-         a full control-height pill made the footer block read as heavy and ate the
-         space the list above needs to fade into. Bottom keeps pb-2 (8px) so the
-         pill clears the bottom edge by the same 8px as the side walls; the top is
-         tightened to pt-1 since the list fades into it (it isn't a hard wall).
-         Hover uses the stronger ACTIVE fill (sidebar-accent) so it registers
-         against the non-white sidebar background. No top border — the list above
-         fades into it instead. -->
+    <!-- Settings, pinned to the bottom. Shares the same action-row geometry as
+         New Session / Bot Settings above: container px-2 + button px-[11px]
+         aligns the icon column, while h-9 + gap-[9px] keeps the footer action
+         from reading like a separate control family. No top border — the list
+         above fades into it instead. -->
     <div class="shrink-0 px-2 pt-1 pb-2">
       <Button
         variant="ghost"
         block
-        class="h-8 justify-start gap-2 rounded-[9px] px-[11px] text-control text-muted-foreground [--btn-ghost-hover:var(--sidebar-accent)] hover:text-foreground"
+        class="h-9 justify-start gap-[9px] px-[11px] text-control font-medium text-foreground/92 dark:text-[color:oklch(0.86_0_0)]"
         :class="isSettingsActive && 'bg-sidebar-accent text-foreground!'"
         :aria-label="t('sidebar.settings')"
         @click="router.push('/settings')"

--- a/apps/web/src/components/sidebar/panel-sessions.vue
+++ b/apps/web/src/components/sidebar/panel-sessions.vue
@@ -82,6 +82,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
@@ -95,7 +96,11 @@ const { t } = useI18n()
 const router = useRouter()
 const chatStore = useChatStore()
 const workspaceTabs = useWorkspaceTabsStore()
-const { currentBotId } = storeToRefs(chatStore)
+const { currentBotId, bots } = storeToRefs(chatStore)
+
+const currentBot = computed(() =>
+  bots.value.find(bot => bot.id === currentBotId.value) ?? null,
+)
 
 function handleNewSession() {
   if (!currentBotId.value) return
@@ -107,6 +112,6 @@ function handleNewSession() {
 function handleBotSettings() {
   const botId = currentBotId.value
   if (!botId) return
-  void router.push({ name: 'bot-detail', params: { botName: botId } })
+  void router.push({ name: 'bot-detail', params: { botName: currentBot.value?.name ?? botId } })
 }
 </script>

--- a/apps/web/src/pages/home/components/dockview/header-add-actions.vue
+++ b/apps/web/src/pages/home/components/dockview/header-add-actions.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { Columns2, Globe, Monitor, Plus, Rows2, Terminal } from 'lucide-vue-next'
@@ -78,7 +78,7 @@ import {
 } from '@memohai/ui'
 import type { DockviewApi, DockviewGroupPanelApi, IDockviewGroupPanel } from 'dockview-vue'
 import { useChatStore } from '@/store/chat-list'
-import { CHAT_PANEL_ID, useWorkspaceTabsStore } from '@/store/workspace-tabs'
+import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { isLocalWorkspaceBot } from '@/utils/bot-workspace'
 import { hasBotPermission } from '@/utils/bot-permissions'
 
@@ -108,19 +108,21 @@ const isTerminalGroup = computed(() => {
   return panels.length > 0 && panels.every(p => p.id.startsWith('terminal:'))
 })
 
+const activePanelId = ref<string | null>(props.params.group.activePanel?.id ?? null)
+const activePanelSub = props.params.api.onDidActivePanelChange(() => {
+  activePanelId.value = props.params.group.activePanel?.id ?? null
+})
+
+onBeforeUnmount(() => activePanelSub.dispose())
+
 // Browser / desktop are container-only and need manage permission; a local
 // (trusted-host) workspace exposes neither, so its menu is terminal + split only.
 const canSplitExtras = computed(() => canManage.value && !isLocalWorkspace.value)
 
-// Splitting duplicates the active tab into a second pane. The chat conversation
-// is a singleton panel (one fixed id), so it can't be duplicated — offering
-// "split" while chat is the active tab just no-ops. Hide it then, and show it
-// only for panels that can actually open a second view (file/terminal/…).
-// store.activeId re-fires this whenever the active tab changes.
+// Splitting duplicates the active tab into a second pane. Chat keeps its stable
+// primary id for routing/title sync, but split copies use generated ids.
 const canSplit = computed(() => {
-  void store.activeId
-  const active = props.params.group.activePanel?.id
-  return !!active && active !== CHAT_PANEL_ID
+  return !!activePanelId.value
 })
 
 const hasAnyAction = computed(() =>

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -212,6 +212,23 @@ describe('workspace layout store', () => {
     expect(dock.getPanel('chat')?.title).toBe('Renamed')
   })
 
+  it('splits the chat panel into a duplicate chat pane', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+
+    store.openChat('Session')
+    store.splitGroup('group-1', 'right')
+
+    expect(dock.getPanel('chat')).toBeTruthy()
+    expect(dock.getPanel('chat~2')).toBeTruthy()
+    expect(dock.getPanel('chat~2')?.component).toBe('chat')
+
+    store.setChatTitle('Renamed')
+    expect(dock.getPanel('chat')?.title).toBe('Renamed')
+    expect(dock.getPanel('chat~2')?.title).toBe('Renamed')
+  })
+
   it('opens multiple schedule panels and focuses an existing schedule', () => {
     const store = useWorkspaceTabsStore()
     const dock = createFakeDock()

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -59,6 +59,7 @@ function fileBaseName(filePath: string): string {
 
 function panelComponentOf(id: string): WorkspacePanelComponent | null {
   if (id === CHAT_PANEL_ID) return 'chat'
+  if (id.startsWith(`${CHAT_PANEL_ID}~`)) return 'chat'
   if (id.startsWith('file:')) return 'file'
   if (id.startsWith('preview:')) return 'preview'
   if (id.startsWith('asset:')) return 'asset'
@@ -542,9 +543,13 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   }
 
   function setChatTitle(title: string) {
-    const panel = api.value?.getPanel(CHAT_PANEL_ID)
-    if (panel && panel.api.title !== title) {
-      panel.api.setTitle(title)
+    const dock = api.value
+    if (!dock) return
+    for (const panel of dock.panels) {
+      if (panel.id !== CHAT_PANEL_ID && !panel.id.startsWith(`${CHAT_PANEL_ID}~`)) continue
+      if (panel.api.title !== title) {
+        panel.api.setTitle(title)
+      }
     }
   }
 
@@ -792,10 +797,13 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
         break
       }
       case 'chat':
-        // The chat conversation is a singleton (one fixed panel id), so it can't
-        // be duplicated into a split. The "+" menu hides split while chat is the
-        // active tab; this stays a defensive no-op (re-adding CHAT_PANEL_ID would
-        // collide with the existing panel).
+        dock.addPanel({
+          id: uniqueSplitPanelId(source.id),
+          component: 'chat',
+          title,
+          renderer: 'always',
+          position,
+        })
         break
     }
   }


### PR DESCRIPTION
## Summary

- allow the workspace split menu to duplicate the active chat/session pane instead of hiding split actions there
- keep duplicated chat panes titled with the active session title
- align the sidebar Settings action with Quick Actions styling
- route Quick Actions Bot Settings through the bot URL name when available

## Root cause

The workspace add menu treated the chat panel as an unsplittable singleton, so split actions were hidden and `splitGroup()` no-oped while the session pane was active. The Bot Settings quick action also passed `currentBotId` directly as the route param instead of using the bot slug/name like other bot entry points.

## Validation

- `pnpm --filter @memohai/web exec vue-tsc --noEmit`
- `pnpm --filter @memohai/web exec vitest run src/store/workspace-tabs.test.ts`
- `pnpm --filter @memohai/web exec eslint src/pages/home/components/dockview/header-add-actions.vue src/components/sidebar/index.vue src/store/workspace-tabs.ts src/store/workspace-tabs.test.ts`
- `pnpm --filter @memohai/web exec eslint src/components/sidebar/panel-sessions.vue`
- commit hook: staged eslint and Go tests
