### PR TITLE
fix: navigate after plugin install

### DIFF
--- a/apps/web/src/pages/bots/components/bot-plugins.vue
+++ b/apps/web/src/pages/bots/components/bot-plugins.vue
@@ -126,7 +126,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { ExternalLink, PackageOpen, Store } from 'lucide-vue-next'
@@ -143,6 +143,7 @@ import {
 import { client } from '@memohai/sdk/client'
 import PageShell from '@/components/page-shell/index.vue'
 import { resolveApiErrorMessage } from '@/utils/api-error'
+import { BOT_PLUGINS_UPDATED_EVENT, isBotPluginsUpdatedEvent } from '@/utils/bot-plugin-events'
 import SettingsSection from '@/components/settings/section.vue'
 import ProviderIcon from '@/components/provider-icon/index.vue'
 
@@ -158,11 +159,22 @@ const pendingKey = ref('')
 
 onMounted(() => {
   void loadPlugins()
+  window.addEventListener(BOT_PLUGINS_UPDATED_EVENT, handleBotPluginsUpdated)
+})
+
+onUnmounted(() => {
+  window.removeEventListener(BOT_PLUGINS_UPDATED_EVENT, handleBotPluginsUpdated)
 })
 
 watch(() => props.botId, () => {
   void loadPlugins()
 })
+
+function handleBotPluginsUpdated(event: Event) {
+  if (!isBotPluginsUpdatedEvent(event)) return
+  if (event.detail.botId !== props.botId) return
+  void loadPlugins()
+}
 
 async function loadPlugins() {
   if (!props.botId) return

--- a/apps/web/src/pages/supermarket/components/install-plugin-dialog.vue
+++ b/apps/web/src/pages/supermarket/components/install-plugin-dialog.vue
@@ -89,6 +89,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose,
   Button, Spinner, Badge, Input, toast,
@@ -103,6 +104,7 @@ import {
 } from '@memohai/sdk'
 import { client } from '@memohai/sdk/client'
 import { resolveApiErrorMessage } from '@/utils/api-error'
+import { emitBotPluginsUpdated } from '@/utils/bot-plugin-events'
 import BotSelect from '@/components/bot-select/index.vue'
 
 const props = defineProps<{
@@ -116,6 +118,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const router = useRouter()
 
 const selectedBotId = ref('')
 const installing = ref(false)
@@ -159,8 +162,14 @@ async function handleInstall() {
       throwOnError: true,
     })
     toast.success(t('supermarket.installSuccess'))
+    emitBotPluginsUpdated(botId)
     emit('update:open', false)
     emit('installed')
+    void router.push({
+      name: 'bot-detail',
+      params: { botName: botId },
+      query: { tab: 'plugins' },
+    }).catch(() => {})
     if (data.status === 'needs_auth' && data.id) {
       await startOAuthAfterInstall(botId, data, oauthPopup)
     } else {
@@ -202,10 +211,12 @@ async function startOAuthAfterInstall(botId: string, installation: PluginsInstal
     await waitForMCPOAuth(botId, installation.id!, popup)
     const synced = await syncOAuthStatus(botId, installation.id!)
     if (synced.status !== 'ready' && !synced.enabled) throw new Error(t('mcp.oauth.authFailed'))
+    emitBotPluginsUpdated(botId)
     toast.success(t('mcp.oauth.authSuccess'))
     emit('installed')
   } catch (error) {
     const synced = await syncOAuthStatus(botId, installation.id!).catch(() => null)
+    if (synced) emitBotPluginsUpdated(botId)
     if (synced?.status === 'ready' || synced?.enabled) {
       toast.success(t('mcp.oauth.authSuccess'))
       emit('installed')

--- a/apps/web/src/utils/bot-plugin-events.ts
+++ b/apps/web/src/utils/bot-plugin-events.ts
@@ -1,0 +1,17 @@
+export const BOT_PLUGINS_UPDATED_EVENT = 'memoh:bot-plugins-updated'
+
+export type BotPluginsUpdatedDetail = {
+  botId: string
+}
+
+export function emitBotPluginsUpdated(botId: string): void {
+  const normalizedBotId = botId.trim()
+  if (!normalizedBotId || typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent<BotPluginsUpdatedDetail>(BOT_PLUGINS_UPDATED_EVENT, {
+    detail: { botId: normalizedBotId },
+  }))
+}
+
+export function isBotPluginsUpdatedEvent(event: Event): event is CustomEvent<BotPluginsUpdatedDetail> {
+  return event.type === BOT_PLUGINS_UPDATED_EVENT
+}


### PR DESCRIPTION
## Summary
- Navigate to the selected bot detail Plugins tab after a Supermarket plugin install succeeds.
- Add a small browser-local plugin update event so the Bot Plugins tab refreshes after install and managed OAuth status syncs.
- Preserve the existing OAuth popup flow while the user is already on the installed plugin list.

## Validation
- `pnpm exec eslint apps/web/src/pages/supermarket/components/install-plugin-dialog.vue apps/web/src/pages/bots/components/bot-plugins.vue apps/web/src/utils/bot-plugin-events.ts`
- `pnpm --filter @memohai/web build`
- pre-commit hooks: Go lint/tests and staged eslint
