### PR TITLE
fix(config): default to packaged workspace image

### DIFF
--- a/conf/app.docker.toml
+++ b/conf/app.docker.toml
@@ -31,7 +31,7 @@ driver = "postgres"
 # runtime bind mounts and Docker socket access.
 backend = "containerd"
 # registry = "memoh.cn"  # Uncomment for China mainland mirror
-default_image = "debian:bookworm-slim"
+default_image = "memohai/workspace:debian"
 image_pull_policy = "if_not_present"
 # containerd snapshotter and CNI settings for bot workspace containers.
 snapshotter = "overlayfs"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,8 +31,8 @@ const (
 	DefaultQdrantURL             = "http://127.0.0.1:6334"
 	DefaultQdrantCollection      = "memory"
 	DefaultRuntimeDir            = "/opt/memoh/runtime"
-	DefaultBaseImage             = "debian:bookworm-slim"
 	DefaultWorkspaceImage        = "memohai/workspace:debian"
+	DefaultBaseImage             = DefaultWorkspaceImage
 	DefaultWorkspaceMirrorImage  = "memoh.cn/memohai/workspace:debian"
 	DefaultTimezone              = "UTC"
 	DefaultContainerdRuntimeType = "io.containerd.runc.v2"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -346,6 +346,14 @@ func TestWorkspaceImagePullPolicyDefaultsAndNormalizes(t *testing.T) {
 	}
 }
 
+func TestWorkspaceImageRefDefaultsToPackagedWorkspace(t *testing.T) {
+	got := (WorkspaceConfig{}).ImageRef()
+	want := "docker.io/memohai/workspace:debian"
+	if got != want {
+		t.Fatalf("default image ref = %q, want %q", got, want)
+	}
+}
+
 func TestWorkspaceImagePullCandidatesAddsWorkspaceMirror(t *testing.T) {
 	got := WorkspaceImagePullCandidates("memohai/workspace:debian")
 	want := []string{"docker.io/memohai/workspace:debian", "memoh.cn/memohai/workspace:debian"}


### PR DESCRIPTION
## Summary

- Update the Docker Compose install template to use `memohai/workspace:debian` for new installs.
- Make the server-side empty-config fallback resolve to the packaged workspace image instead of official Debian.
- Add a config test that locks the default image ref to `docker.io/memohai/workspace:debian`.

## Root Cause

The one-click install path copies `conf/app.docker.toml` into `config.toml` for fresh installs, and that template still pointed at `debian:bookworm-slim`. The code fallback for missing `default_image` also still used official Debian, so underconfigured instances could drift back to the wrong base image.

## Validation

- `TMPDIR=/tmp go test ./internal/config`
- Commit hook Go test suite passed during commit creation.