### PR TITLE
fix(web): keep chat draft tab available

### DIFF
--- a/apps/web/src/pages/home/index.vue
+++ b/apps/web/src/pages/home/index.vue
@@ -113,7 +113,13 @@ async function maybeStartACPSession() {
 
 async function syncStoreFromUrl(rawName: string) {
   const urlName = rawName.trim()
-  if (!urlName) return
+  if (!urlName) {
+    if (!currentBotId.value) {
+      await chatStore.initialize()
+    }
+    await maybeStartACPSession()
+    return
+  }
   const resolvedId = await resolveBotIdFromName(urlName)
   if (!resolvedId) return
   if (resolvedId !== (currentBotId.value ?? '').trim()) {
@@ -134,7 +140,14 @@ async function syncStoreFromUrl(rawName: string) {
   }
 }
 
-void syncStoreFromUrl((route.params.botName as string) ?? '')
+watch(
+  () => [route.name, route.params.botName] as const,
+  ([routeName, paramBotName]) => {
+    if (!CHAT_ROUTE_NAMES.has(routeName as string)) return
+    void syncStoreFromUrl((paramBotName as string) ?? '')
+  },
+  { immediate: true },
+)
 
 watch(currentBotId, async (newBotId) => {
   if (suppressUrlSync) return
@@ -157,13 +170,4 @@ watch(currentBotId, async (newBotId) => {
   })
 })
 
-watch(
-  () => route.params.botName,
-  (paramBotName) => {
-    // Only sync on a chat route. The settings route shares the :botName param;
-    // reacting to its changes would bounce the user back to chat (see above).
-    if (!isChatRoute()) return
-    void syncStoreFromUrl((paramBotName as string) ?? '')
-  },
-)
 </script>

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -28,6 +28,10 @@ const toast = vi.hoisted(() => ({
 
 vi.mock('@/composables/api/useChat', () => api)
 vi.mock('vue-sonner', () => ({ toast }))
+vi.mock('@memohai/ui', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@memohai/ui')>()
+  return { ...original, toast }
+})
 
 function flushPromises() {
   return new Promise(resolve => setTimeout(resolve, 0))
@@ -183,6 +187,20 @@ describe('chat-list store', () => {
         onClose: null,
       }
     })
+  })
+
+  it('selects the first ready bot during initialization when none is selected', async () => {
+    api.fetchBots.mockResolvedValueOnce([
+      { id: 'bot-creating', status: 'creating', name: 'Creating' },
+      { id: 'bot-ready', status: 'active', name: 'Ready' },
+    ])
+
+    const store = useChatStore()
+
+    await store.initialize()
+
+    expect(store.currentBotId).toBe('bot-ready')
+    expect(api.fetchSessions).toHaveBeenCalledWith('bot-ready')
   })
 
   it('returns startup stream errors to the composer when no assistant output exists', async () => {

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -1,7 +1,12 @@
+import { nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { useChatSelectionStore } from './chat-selection'
 import { useWorkspaceTabsStore } from './workspace-tabs'
+
+const chatStoreMock = vi.hoisted(() => ({
+  createNewSession: vi.fn(async () => {}),
+}))
 
 vi.mock('@/store/chat-list', () => ({
   useChatStore: () => ({
@@ -14,6 +19,7 @@ vi.mock('@/store/chat-list', () => ({
       },
     ],
     isSessionStreaming: vi.fn(() => false),
+    createNewSession: chatStoreMock.createNewSession,
   }),
 }))
 
@@ -39,8 +45,18 @@ interface FakePanel {
 
 function createFakeDock() {
   const panels: FakePanel[] = []
+  const removeListeners: Array<(panel: FakePanel) => void> = []
   let activePanel: FakePanel | null = null
   const noopDisposable = () => ({ dispose: () => {} })
+  const removeDisposable = (listener: (panel: FakePanel) => void) => {
+    removeListeners.push(listener)
+    return {
+      dispose: () => {
+        const idx = removeListeners.indexOf(listener)
+        if (idx >= 0) removeListeners.splice(idx, 1)
+      },
+    }
+  }
   const groupElement = {
     classList: {
       toggle: vi.fn(),
@@ -69,7 +85,7 @@ function createFakeDock() {
     },
     onDidActivePanelChange: noopDisposable,
     onDidLayoutChange: noopDisposable,
-    onDidRemovePanel: noopDisposable,
+    onDidRemovePanel: removeDisposable,
     onDidAddPanel: noopDisposable,
     onDidMovePanel: noopDisposable,
     onWillShowOverlay: noopDisposable,
@@ -102,6 +118,7 @@ function createFakeDock() {
             const idx = panels.indexOf(panel)
             if (idx >= 0) panels.splice(idx, 1)
             if (activePanel === panel) activePanel = panels[0] ?? null
+            removeListeners.forEach(listener => listener(panel))
           },
           setTitle: (title: string) => {
             panel.title = title
@@ -147,6 +164,7 @@ describe('workspace layout store', () => {
       removeItem: (key: string) => storage.delete(key),
       clear: () => storage.clear(),
     })
+    chatStoreMock.createNewSession.mockClear()
     setActivePinia(createPinia())
     useChatSelectionStore().setBot('bot-1')
   })
@@ -210,6 +228,35 @@ describe('workspace layout store', () => {
 
     store.setChatTitle('Renamed')
     expect(dock.getPanel('chat')?.title).toBe('Renamed')
+  })
+
+  it('keeps the final draft chat tab open when it is closed', async () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+
+    store.openChat('Existing')
+    store.closeTab('chat')
+
+    expect(dock.panels).toHaveLength(1)
+    expect(dock.getPanel('chat')?.component).toBe('chat')
+    expect(chatStoreMock.createNewSession).not.toHaveBeenCalled()
+  })
+
+  it('opens a draft chat when a non-chat tab leaves the dock empty', async () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+
+    store.openTerminal()
+    store.closeTab('terminal:1')
+
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(chatStoreMock.createNewSession).toHaveBeenCalledOnce()
+    expect(dock.panels).toHaveLength(1)
+    expect(dock.getPanel('chat')?.component).toBe('chat')
   })
 
   it('splits the chat panel into a duplicate chat pane', () => {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -92,7 +92,7 @@ function syncAllTerminalGroupChrome(dock: DockviewApi) {
 
 export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   const selection = useChatSelectionStore()
-  const { currentBotId } = storeToRefs(selection)
+  const { currentBotId, sessionId } = storeToRefs(selection)
   const chatStore = useChatStore()
   const currentBot = computed(() =>
     chatStore.bots.find(bot => bot.id === currentBotId.value) ?? null,
@@ -140,6 +140,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   // into the bottom panel; terminal drags leave them open so terminals can be
   // reordered or stacked. Reset on drag end.
   let dragSourceTerminal = false
+  let draftChatQueued = false
   // The most recent NON-terminal group to hold focus. A terminal group is
   // exclusive — opening a file/browser/etc. while it is the active group must
   // land in an editor group, not contaminate the terminals — so we remember the
@@ -237,6 +238,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   function restoreLayout(botId: string) {
     const dock = api.value
     if (!dock) return
+    let restoredEmptyLayout = false
     suppressPersist = true
     try {
       const stored = storage.value[botId]?.layout ?? null
@@ -254,9 +256,11 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       prunePanels()
       activePanelId.value = dock.activePanel?.id ?? null
       syncAllTerminalGroupChrome(dock)
+      restoredEmptyLayout = !!stored && dock.panels.length === 0
     } finally {
       suppressPersist = false
     }
+    if (restoredEmptyLayout) ensureDraftChatPanel()
   }
 
   function domListener<K extends keyof DocumentEventMap>(
@@ -334,6 +338,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
           void nextTick(() => deleteTerminalSnapshot(terminalCacheKey(bid, panel.id)))
         }
         syncAllTerminalGroupChrome(dock)
+        ensureDraftChatPanel()
       }),
       dock.onDidAddPanel(() => {
         syncAllTerminalGroupChrome(dock)
@@ -396,6 +401,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     loadedBotId = null
     panelDragging.value = false
     dragSourceTerminal = false
+    draftChatQueued = false
   }
 
   // ---- panel operations ----------------------------------------------------
@@ -551,6 +557,32 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
         panel.api.setTitle(title)
       }
     }
+  }
+
+  function ensureDraftChatPanel() {
+    const dock = api.value
+    if (!dock || suppressPersist || draftChatQueued) return
+    if (dock.panels.length > 0) return
+    if (!(currentBotId.value ?? '').trim()) return
+
+    draftChatQueued = true
+    void nextTick(async () => {
+      draftChatQueued = false
+      const latestDock = api.value
+      if (!latestDock || suppressPersist || latestDock.panels.length > 0) return
+      if (!(currentBotId.value ?? '').trim()) return
+
+      try {
+        await chatStore.createNewSession()
+      } catch {
+        // A draft reset should not leave the dock blank if the active bot is still usable.
+      }
+
+      const settledDock = api.value
+      if (!settledDock || suppressPersist || settledDock.panels.length > 0) return
+      if (!(currentBotId.value ?? '').trim()) return
+      openChat('')
+    })
   }
 
   function openFile(filePath: string) {
@@ -836,7 +868,15 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     })
   }
 
+  function shouldKeepLastDraftChat(id: string) {
+    const dock = api.value
+    if (!dock || dock.panels.length !== 1) return false
+    if ((sessionId.value ?? '').trim()) return false
+    return !!dock.getPanel(id) && panelComponentOf(id) === 'chat'
+  }
+
   function closeTab(id: string) {
+    if (shouldKeepLastDraftChat(id)) return
     const panel = api.value?.getPanel(id)
     panel?.api.close()
   }


### PR DESCRIPTION
## Summary
- Select the first available bot when entering the chat route with empty local storage and no bot in the URL.
- Keep a draft `New Chat` tab available for each selected bot, including brand-new bots with no sessions.
- Prevent the final draft chat tab from closing, while still falling back to a draft chat if other panel types leave the dock empty.
- Add focused store coverage for default bot initialization and persistent draft chat behavior.

## Validation
- `pnpm --filter @memohai/web exec vitest run src/store/workspace-tabs.test.ts src/store/chat-list.test.ts`
- `pnpm --filter @memohai/web exec eslint src/pages/home/index.vue src/store/workspace-tabs.ts src/store/workspace-tabs.test.ts src/store/chat-list.test.ts`
- `pnpm --filter @memohai/web exec vue-tsc --noEmit`
- `git diff --check`
- pre-commit Go tests and lint-staged checks