### PR TITLE
fix(web): center new bot page

### DIFF
--- a/apps/web/src/pages/bots/new.vue
+++ b/apps/web/src/pages/bots/new.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="relative px-4 pt-2 pb-10 lg:px-6 md:pt-4 md:pb-12 max-w-2xl">
+  <section class="relative mx-auto w-full max-w-2xl px-4 pt-2 pb-10 md:pt-4 md:pb-12 lg:px-6">
     <Tabs
       v-model="mode"
       class="mb-6"


### PR DESCRIPTION
## Summary

- Center the New Bot page container while preserving its existing max width.
- Apply the alignment to both create and import modes through the shared root section.

## Impact

The New Bot page now matches the centered settings-page rhythm instead of sitting left-aligned in the available pane.

## Validation

- `pnpm --dir apps/web exec eslint src/pages/bots/new.vue`
- Commit hook: staged ESLint and Go tests