### PR TITLE
chore(desktop): add remote dev scripts

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -23,12 +23,16 @@ belongs in this `main.ts`, not in `@memohai/web`.
 ```bash
 # from repo root
 pnpm --filter @memohai/desktop dev
+pnpm --filter @memohai/desktop dev:remote
 # or via mise
 mise run desktop:dev
+mise run desktop:dev:remote
 ```
 
 `MEMOH_WEB_PROXY_TARGET` overrides the backend that the renderer's `/api` proxy points
 at (defaults to whatever `config.toml` / `conf/app.docker.toml` declares).
+Remote desktop dev defaults to `http://localhost:18080`; override it with
+`MEMOH_DESKTOP_REMOTE_BASE_URL`.
 
 ## Build
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "pnpm run prepare:qdrant && pnpm run prepare:gstreamer && electron-vite dev",
+    "dev:remote": "node scripts/dev-remote.mjs",
     "start": "electron-vite preview",
     "prepare:qdrant": "node scripts/prepare-qdrant.mjs --targets=current",
     "prepare:qdrant:release-platform": "node scripts/prepare-qdrant.mjs --targets=release-platform",

--- a/apps/desktop/scripts/dev-remote.mjs
+++ b/apps/desktop/scripts/dev-remote.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+
+const env = {
+  ...process.env,
+  MEMOH_DESKTOP_RUNTIME_MODE: 'remote',
+}
+
+if (!env.MEMOH_DESKTOP_REMOTE_BASE_URL?.trim()) {
+  env.MEMOH_DESKTOP_REMOTE_BASE_URL = 'http://localhost:18080'
+}
+
+console.log(`desktop remote dev api=${env.MEMOH_DESKTOP_REMOTE_BASE_URL}`)
+
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const result = spawnSync(pnpm, ['exec', 'electron-vite', 'dev'], {
+  stdio: 'inherit',
+  env,
+})
+
+if (result.error) {
+  console.error(result.error.message)
+  process.exit(1)
+}
+
+process.exit(result.status ?? 1)

--- a/mise.toml
+++ b/mise.toml
@@ -426,6 +426,16 @@ fi
 pnpm dev
 """
 
+[tasks."desktop:dev:remote"]
+description = "Start Electron desktop app in remote dev mode"
+dir = "{{config_root}}/apps/desktop"
+run = """
+#!/bin/bash
+set -euo pipefail
+
+pnpm dev:remote
+"""
+
 [tasks."desktop:qdrant:prepare"]
 description = "Download the Qdrant binary used by the Electron desktop app"
 dir = "{{config_root}}/apps/desktop"


### PR DESCRIPTION
## Summary
- add a cross-platform `pnpm dev:remote` launcher for the desktop app
- add `mise run desktop:dev:remote` as the repo-level shortcut
- document the remote desktop dev commands and default API URL

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('apps/desktop/package.json','utf8')); console.log('desktop package.json ok')"`
- `node --check apps/desktop/scripts/dev-remote.mjs`
- `mise tasks | rg "desktop:dev(:remote)?"`
- commit hook: lint-staged, Go lint, Go tests