### PR TITLE
fix(pipeline): preserve tool-call provider metadata

### DIFF
--- a/internal/pipeline/turn_response.go
+++ b/internal/pipeline/turn_response.go
@@ -49,13 +49,14 @@ func DecodeTurnResponseEntry(msg messagepkg.Message) (TurnResponseEntry, bool) {
 // purposefully uses json.RawMessage for tool input/output to avoid losing
 // structure while keeping the type declaration local to this package.
 type turnResponsePart struct {
-	Type       string          `json:"type"`
-	Text       string          `json:"text,omitempty"`
-	ToolCallID string          `json:"toolCallId,omitempty"`
-	ToolName   string          `json:"toolName,omitempty"`
-	Input      json.RawMessage `json:"input,omitempty"`
-	Output     json.RawMessage `json:"output,omitempty"`
-	Result     json.RawMessage `json:"result,omitempty"`
+	Type             string          `json:"type"`
+	Text             string          `json:"text,omitempty"`
+	ToolCallID       string          `json:"toolCallId,omitempty"`
+	ToolName         string          `json:"toolName,omitempty"`
+	Input            json.RawMessage `json:"input,omitempty"`
+	Output           json.RawMessage `json:"output,omitempty"`
+	Result           json.RawMessage `json:"result,omitempty"`
+	ProviderMetadata json.RawMessage `json:"providerMetadata,omitempty"`
 }
 
 func nativeAssistantContent(msg conversation.ModelMessage) json.RawMessage {
@@ -96,7 +97,7 @@ func nativeAssistantContent(msg conversation.ModelMessage) json.RawMessage {
 			// leak back into subsequent prompts verbatim.
 			continue
 		case "tool-call":
-			out = append(out, nativeToolCallPart(p.ToolCallID, p.ToolName, p.Input))
+			out = append(out, nativeToolCallPart(p.ToolCallID, p.ToolName, p.Input, p.ProviderMetadata))
 		case "tool-result":
 			payload := p.Output
 			if len(payload) == 0 {
@@ -122,7 +123,7 @@ func nativeAssistantContent(msg conversation.ModelMessage) json.RawMessage {
 				input = encoded
 			}
 		}
-		out = append(out, nativeToolCallPart(id, name, input))
+		out = append(out, nativeToolCallPart(id, name, input, nil))
 	}
 
 	return marshalParts(out)
@@ -159,7 +160,7 @@ func nativeToolRoleContent(msg conversation.ModelMessage) json.RawMessage {
 	return marshalParts(out)
 }
 
-func nativeToolCallPart(id, name string, input json.RawMessage) map[string]any {
+func nativeToolCallPart(id, name string, input, providerMetadata json.RawMessage) map[string]any {
 	part := map[string]any{
 		"type":       "tool-call",
 		"toolCallId": strings.TrimSpace(id),
@@ -169,6 +170,9 @@ func nativeToolCallPart(id, name string, input json.RawMessage) map[string]any {
 		part["input"] = input
 	} else {
 		part["input"] = map[string]any{}
+	}
+	if len(providerMetadata) > 0 && strings.TrimSpace(string(providerMetadata)) != "" {
+		part["providerMetadata"] = providerMetadata
 	}
 	return part
 }

--- a/internal/pipeline/turn_response_test.go
+++ b/internal/pipeline/turn_response_test.go
@@ -89,6 +89,51 @@ func TestDecodeTurnResponseEntryPreservesToolCallOnlyPayload(t *testing.T) {
 	}
 }
 
+func TestDecodeTurnResponseEntryPreservesToolCallProviderMetadata(t *testing.T) {
+	t.Parallel()
+
+	content, err := json.Marshal([]map[string]any{
+		{
+			"type":       "tool-call",
+			"toolName":   "read",
+			"toolCallId": "call-1",
+			"input":      map[string]any{"path": "/tmp/a.txt"},
+			"providerMetadata": map[string]any{
+				"google": map[string]any{"thoughtSignature": "sig-1"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal content: %v", err)
+	}
+
+	modelMessage, err := json.Marshal(conversation.ModelMessage{
+		Role:    "assistant",
+		Content: content,
+	})
+	if err != nil {
+		t.Fatalf("marshal model message: %v", err)
+	}
+
+	entry, ok := DecodeTurnResponseEntry(messagepkg.Message{
+		Role:      "assistant",
+		Content:   modelMessage,
+		CreatedAt: time.Unix(1710000000, 0).UTC(),
+	})
+	if !ok {
+		t.Fatal("expected turn response entry")
+	}
+	part := assertRawPart(t, entry.RawContent, "tool-call", "read", "call-1")
+	meta, ok := part["providerMetadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("providerMetadata = %#v, want map", part["providerMetadata"])
+	}
+	google, ok := meta["google"].(map[string]any)
+	if !ok || google["thoughtSignature"] != "sig-1" {
+		t.Fatalf("google metadata = %#v, want thought signature", meta["google"])
+	}
+}
+
 func TestDecodeTurnResponseEntryRendersTextAndToolCall(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 概述

修复 persisted turn response 解码时丢失 tool-call provider metadata 的问题。

部分 provider 会在 tool-call 中写入 provider metadata，例如 Gemini 的 thoughtSignature。历史消息重新进入上下文时，如果该字段被丢弃，后续多轮调用可能缺少 provider 需要的上下文信息。

## 改动

- 在 turn response tool-call part 中保留 `providerMetadata`
- 重建 native assistant content 时透传该字段
- 补充回归测试，覆盖 Gemini `thoughtSignature` 这类 metadata

## 验证

- `go test ./internal/pipeline`
