### PR TITLE
feat(api): /sessions filters by type and paginates by cursor

### DIFF
--- a/db/postgres/migrations/0001_init.up.sql
+++ b/db/postgres/migrations/0001_init.up.sql
@@ -459,6 +459,7 @@ CREATE INDEX IF NOT EXISTS idx_bot_sessions_bot_active ON bot_sessions(bot_id, d
 CREATE INDEX IF NOT EXISTS idx_bot_sessions_parent ON bot_sessions(parent_session_id) WHERE parent_session_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_bot_sessions_created_by_user_id ON bot_sessions(created_by_user_id) WHERE created_by_user_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_bot_sessions_bot_created_by ON bot_sessions(bot_id, created_by_user_id, deleted_at);
+CREATE INDEX IF NOT EXISTS idx_bot_sessions_bot_active_updated ON bot_sessions(bot_id, updated_at DESC, id DESC) WHERE deleted_at IS NULL;
 
 -- Add FK from routes to sessions (deferred to avoid circular dependency during CREATE).
 ALTER TABLE bot_channel_routes

--- a/db/postgres/migrations/0098_paged_sessions_index.down.sql
+++ b/db/postgres/migrations/0098_paged_sessions_index.down.sql
@@ -1,0 +1,3 @@
+-- 0098_paged_sessions_index (down)
+
+DROP INDEX IF EXISTS idx_bot_sessions_bot_active_updated;

--- a/db/postgres/migrations/0098_paged_sessions_index.up.sql
+++ b/db/postgres/migrations/0098_paged_sessions_index.up.sql
@@ -1,0 +1,9 @@
+-- 0098_paged_sessions_index
+-- Add a composite (bot_id, updated_at DESC, id DESC) partial index on
+-- non-deleted rows to back the new paged /sessions endpoint. The previous
+-- indexes covered (bot_id) and (bot_id, deleted_at) but did not help when
+-- ordering by updated_at DESC, id DESC for keyset pagination.
+
+CREATE INDEX IF NOT EXISTS idx_bot_sessions_bot_active_updated
+  ON bot_sessions(bot_id, updated_at DESC, id DESC)
+  WHERE deleted_at IS NULL;

--- a/db/postgres/queries/sessions.sql
+++ b/db/postgres/queries/sessions.sql
@@ -45,6 +45,46 @@ WHERE s.bot_id = sqlc.arg(bot_id)
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC;
 
+-- name: ListSessionsByBotPaged :many
+-- Cursor uses (updated_at, id) so pages stay stable when many rows share an
+-- updated_at. Callers always pass an explicit types filter; to opt out of
+-- filtering, pass every known type.
+SELECT
+  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = sqlc.arg(bot_id)
+  AND s.deleted_at IS NULL
+  AND s.type = ANY(sqlc.arg(types)::text[])
+  AND (
+    NOT sqlc.arg(use_cursor)::bool
+    OR (s.updated_at, s.id) < (sqlc.arg(cursor_updated_at)::timestamptz, sqlc.arg(cursor_id)::uuid)
+  )
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT sqlc.arg(limit_count)::int;
+
+-- name: ListSessionsByBotAndCreatedByUserPaged :many
+SELECT
+  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = sqlc.arg(bot_id)
+  AND s.created_by_user_id = sqlc.arg(created_by_user_id)
+  AND s.deleted_at IS NULL
+  AND s.type = ANY(sqlc.arg(types)::text[])
+  AND (
+    NOT sqlc.arg(use_cursor)::bool
+    OR (s.updated_at, s.id) < (sqlc.arg(cursor_updated_at)::timestamptz, sqlc.arg(cursor_id)::uuid)
+  )
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT sqlc.arg(limit_count)::int;
+
 -- name: ListSessionsByRoute :many
 SELECT *
 FROM bot_sessions

--- a/db/sqlite/migrations/0001_init.up.sql
+++ b/db/sqlite/migrations/0001_init.up.sql
@@ -455,6 +455,7 @@ CREATE INDEX IF NOT EXISTS idx_bot_sessions_bot_active ON bot_sessions(bot_id, d
 CREATE INDEX IF NOT EXISTS idx_bot_sessions_parent ON bot_sessions(parent_session_id) WHERE parent_session_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_bot_sessions_created_by_user_id ON bot_sessions(created_by_user_id) WHERE created_by_user_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_bot_sessions_bot_created_by ON bot_sessions(bot_id, created_by_user_id, deleted_at);
+CREATE INDEX IF NOT EXISTS idx_bot_sessions_bot_active_updated ON bot_sessions(bot_id, updated_at DESC, id DESC) WHERE deleted_at IS NULL;
 
 -- bot_session_events: DCP pipeline event store for cold-start replay.
 CREATE TABLE IF NOT EXISTS bot_session_events (

--- a/db/sqlite/migrations/0001_init.up.sql
+++ b/db/sqlite/migrations/0001_init.up.sql
@@ -445,6 +445,12 @@ CREATE TABLE IF NOT EXISTS bot_sessions (
   parent_session_id TEXT REFERENCES bot_sessions(id) ON DELETE SET NULL,
   created_by_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  -- updated_at is stored at second precision via CURRENT_TIMESTAMP. The
+  -- keyset cursor in `internal/db/sqlite/store/sessions_paged.go` truncates
+  -- its bound timestamp to seconds to match this storage. If we ever upgrade
+  -- this column to sub-second precision, the cursor formatter MUST keep
+  -- sub-second too so the lexicographic compare stays consistent — otherwise
+  -- rows in the same second would be skipped or returned indefinitely.
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   deleted_at TEXT
 );

--- a/db/sqlite/migrations/0023_paged_sessions_index.down.sql
+++ b/db/sqlite/migrations/0023_paged_sessions_index.down.sql
@@ -1,0 +1,3 @@
+-- 0023_paged_sessions_index (down)
+
+DROP INDEX IF EXISTS idx_bot_sessions_bot_active_updated;

--- a/db/sqlite/migrations/0023_paged_sessions_index.up.sql
+++ b/db/sqlite/migrations/0023_paged_sessions_index.up.sql
@@ -1,0 +1,9 @@
+-- 0023_paged_sessions_index
+-- Add a composite (bot_id, updated_at DESC, id DESC) partial index on
+-- non-deleted rows to back the new paged /sessions endpoint. The previous
+-- indexes covered (bot_id) and (bot_id, deleted_at) but did not help when
+-- ordering by updated_at DESC, id DESC for keyset pagination.
+
+CREATE INDEX IF NOT EXISTS idx_bot_sessions_bot_active_updated
+  ON bot_sessions(bot_id, updated_at DESC, id DESC)
+  WHERE deleted_at IS NULL;

--- a/db/sqlite/queries/sessions.sql
+++ b/db/sqlite/queries/sessions.sql
@@ -50,6 +50,45 @@ WHERE s.bot_id = sqlc.arg(bot_id)
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC;
 
+-- name: ListSessionsByBotPaged :many
+SELECT
+  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = sqlc.arg(bot_id)
+  AND s.deleted_at IS NULL
+  AND s.type IN (sqlc.slice(types))
+  AND (
+    sqlc.arg(use_cursor) = 0
+    OR (s.updated_at < sqlc.arg(cursor_updated_at)
+        OR (s.updated_at = sqlc.arg(cursor_updated_at) AND s.id < sqlc.arg(cursor_id)))
+  )
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT sqlc.arg(limit_count);
+
+-- name: ListSessionsByBotAndCreatedByUserPaged :many
+SELECT
+  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = sqlc.arg(bot_id)
+  AND s.created_by_user_id = sqlc.arg(created_by_user_id)
+  AND s.deleted_at IS NULL
+  AND s.type IN (sqlc.slice(types))
+  AND (
+    sqlc.arg(use_cursor) = 0
+    OR (s.updated_at < sqlc.arg(cursor_updated_at)
+        OR (s.updated_at = sqlc.arg(cursor_updated_at) AND s.id < sqlc.arg(cursor_id)))
+  )
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT sqlc.arg(limit_count);
+
 -- name: ListSessionsByRoute :many
 SELECT *
 FROM bot_sessions

--- a/db/sqlite/queries/sessions.sql
+++ b/db/sqlite/queries/sessions.sql
@@ -50,44 +50,13 @@ WHERE s.bot_id = sqlc.arg(bot_id)
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC;
 
--- name: ListSessionsByBotPaged :many
-SELECT
-  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
-  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
-  r.metadata AS route_metadata,
-  r.conversation_type AS route_conversation_type
-FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = sqlc.arg(bot_id)
-  AND s.deleted_at IS NULL
-  AND s.type IN (sqlc.slice(types))
-  AND (
-    sqlc.arg(use_cursor) = 0
-    OR (s.updated_at < sqlc.arg(cursor_updated_at)
-        OR (s.updated_at = sqlc.arg(cursor_updated_at) AND s.id < sqlc.arg(cursor_id)))
-  )
-ORDER BY s.updated_at DESC, s.id DESC
-LIMIT sqlc.arg(limit_count);
+-- ListSessionsByBotPaged and ListSessionsByBotAndCreatedByUserPaged are not
+-- generated for SQLite. The Postgres versions live in
+-- db/postgres/queries/sessions.sql; the SQLite shim hand-rolls the query in
+-- internal/db/sqlite/store/sessions_paged.go because sqlc-sqlite cannot mix
+-- sqlc.slice with reused numbered placeholders without colliding bind indexes.
 
--- name: ListSessionsByBotAndCreatedByUserPaged :many
-SELECT
-  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
-  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
-  r.metadata AS route_metadata,
-  r.conversation_type AS route_conversation_type
-FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = sqlc.arg(bot_id)
-  AND s.created_by_user_id = sqlc.arg(created_by_user_id)
-  AND s.deleted_at IS NULL
-  AND s.type IN (sqlc.slice(types))
-  AND (
-    sqlc.arg(use_cursor) = 0
-    OR (s.updated_at < sqlc.arg(cursor_updated_at)
-        OR (s.updated_at = sqlc.arg(cursor_updated_at) AND s.id < sqlc.arg(cursor_id)))
-  )
-ORDER BY s.updated_at DESC, s.id DESC
-LIMIT sqlc.arg(limit_count);
+
 
 -- name: ListSessionsByRoute :many
 SELECT *

--- a/internal/db/model_enable_migration_test.go
+++ b/internal/db/model_enable_migration_test.go
@@ -157,6 +157,17 @@ CREATE TABLE model_variants (
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Minimal stub of bot_sessions so migrations targeting that table (e.g.
+-- the 0023 paged-sessions index) parse and apply against this pre-22
+-- fixture. Columns mirror only what newer migrations reference; this is
+-- not a full replica of the production schema.
+CREATE TABLE bot_sessions (
+  id TEXT PRIMARY KEY,
+  bot_id TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
 `)
 	if err != nil {
 		t.Fatalf("create pre-model-enable schema: %v", err)

--- a/internal/db/postgres/sqlc/sessions.sql.go
+++ b/internal/db/postgres/sqlc/sessions.sql.go
@@ -259,6 +259,186 @@ func (q *Queries) ListSessionsByBotAndCreatedByUser(ctx context.Context, arg Lis
 	return items, nil
 }
 
+const listSessionsByBotAndCreatedByUserPaged = `-- name: ListSessionsByBotAndCreatedByUserPaged :many
+SELECT
+  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = $1
+  AND s.created_by_user_id = $2
+  AND s.deleted_at IS NULL
+  AND s.type = ANY($3::text[])
+  AND (
+    NOT $4::bool
+    OR (s.updated_at, s.id) < ($5::timestamptz, $6::uuid)
+  )
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT $7::int
+`
+
+type ListSessionsByBotAndCreatedByUserPagedParams struct {
+	BotID           pgtype.UUID        `json:"bot_id"`
+	CreatedByUserID pgtype.UUID        `json:"created_by_user_id"`
+	Types           []string           `json:"types"`
+	UseCursor       bool               `json:"use_cursor"`
+	CursorUpdatedAt pgtype.Timestamptz `json:"cursor_updated_at"`
+	CursorID        pgtype.UUID        `json:"cursor_id"`
+	LimitCount      int32              `json:"limit_count"`
+}
+
+type ListSessionsByBotAndCreatedByUserPagedRow struct {
+	ID                    pgtype.UUID        `json:"id"`
+	BotID                 pgtype.UUID        `json:"bot_id"`
+	RouteID               pgtype.UUID        `json:"route_id"`
+	ChannelType           pgtype.Text        `json:"channel_type"`
+	Type                  string             `json:"type"`
+	Title                 string             `json:"title"`
+	Metadata              []byte             `json:"metadata"`
+	ParentSessionID       pgtype.UUID        `json:"parent_session_id"`
+	CreatedByUserID       pgtype.UUID        `json:"created_by_user_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
+	DeletedAt             pgtype.Timestamptz `json:"deleted_at"`
+	RouteMetadata         []byte             `json:"route_metadata"`
+	RouteConversationType pgtype.Text        `json:"route_conversation_type"`
+}
+
+func (q *Queries) ListSessionsByBotAndCreatedByUserPaged(ctx context.Context, arg ListSessionsByBotAndCreatedByUserPagedParams) ([]ListSessionsByBotAndCreatedByUserPagedRow, error) {
+	rows, err := q.db.Query(ctx, listSessionsByBotAndCreatedByUserPaged,
+		arg.BotID,
+		arg.CreatedByUserID,
+		arg.Types,
+		arg.UseCursor,
+		arg.CursorUpdatedAt,
+		arg.CursorID,
+		arg.LimitCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListSessionsByBotAndCreatedByUserPagedRow
+	for rows.Next() {
+		var i ListSessionsByBotAndCreatedByUserPagedRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.BotID,
+			&i.RouteID,
+			&i.ChannelType,
+			&i.Type,
+			&i.Title,
+			&i.Metadata,
+			&i.ParentSessionID,
+			&i.CreatedByUserID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.RouteMetadata,
+			&i.RouteConversationType,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSessionsByBotPaged = `-- name: ListSessionsByBotPaged :many
+SELECT
+  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = $1
+  AND s.deleted_at IS NULL
+  AND s.type = ANY($2::text[])
+  AND (
+    NOT $3::bool
+    OR (s.updated_at, s.id) < ($4::timestamptz, $5::uuid)
+  )
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT $6::int
+`
+
+type ListSessionsByBotPagedParams struct {
+	BotID           pgtype.UUID        `json:"bot_id"`
+	Types           []string           `json:"types"`
+	UseCursor       bool               `json:"use_cursor"`
+	CursorUpdatedAt pgtype.Timestamptz `json:"cursor_updated_at"`
+	CursorID        pgtype.UUID        `json:"cursor_id"`
+	LimitCount      int32              `json:"limit_count"`
+}
+
+type ListSessionsByBotPagedRow struct {
+	ID                    pgtype.UUID        `json:"id"`
+	BotID                 pgtype.UUID        `json:"bot_id"`
+	RouteID               pgtype.UUID        `json:"route_id"`
+	ChannelType           pgtype.Text        `json:"channel_type"`
+	Type                  string             `json:"type"`
+	Title                 string             `json:"title"`
+	Metadata              []byte             `json:"metadata"`
+	ParentSessionID       pgtype.UUID        `json:"parent_session_id"`
+	CreatedByUserID       pgtype.UUID        `json:"created_by_user_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
+	DeletedAt             pgtype.Timestamptz `json:"deleted_at"`
+	RouteMetadata         []byte             `json:"route_metadata"`
+	RouteConversationType pgtype.Text        `json:"route_conversation_type"`
+}
+
+// Cursor uses (updated_at, id) so pages stay stable when many rows share an
+// updated_at. Callers always pass an explicit types filter; to opt out of
+// filtering, pass every known type.
+func (q *Queries) ListSessionsByBotPaged(ctx context.Context, arg ListSessionsByBotPagedParams) ([]ListSessionsByBotPagedRow, error) {
+	rows, err := q.db.Query(ctx, listSessionsByBotPaged,
+		arg.BotID,
+		arg.Types,
+		arg.UseCursor,
+		arg.CursorUpdatedAt,
+		arg.CursorID,
+		arg.LimitCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListSessionsByBotPagedRow
+	for rows.Next() {
+		var i ListSessionsByBotPagedRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.BotID,
+			&i.RouteID,
+			&i.ChannelType,
+			&i.Type,
+			&i.Title,
+			&i.Metadata,
+			&i.ParentSessionID,
+			&i.CreatedByUserID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.RouteMetadata,
+			&i.RouteConversationType,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSessionsByRoute = `-- name: ListSessionsByRoute :many
 SELECT id, bot_id, route_id, channel_type, type, title, metadata, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 FROM bot_sessions

--- a/internal/db/sqlite/sqlc/sessions.sql.go
+++ b/internal/db/sqlite/sqlc/sessions.sql.go
@@ -8,6 +8,7 @@ package sqlc
 import (
 	"context"
 	"database/sql"
+	"strings"
 )
 
 const createSession = `-- name: CreateSession :one
@@ -240,6 +241,207 @@ func (q *Queries) ListSessionsByBotAndCreatedByUser(ctx context.Context, arg Lis
 	var items []ListSessionsByBotAndCreatedByUserRow
 	for rows.Next() {
 		var i ListSessionsByBotAndCreatedByUserRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.BotID,
+			&i.RouteID,
+			&i.ChannelType,
+			&i.Type,
+			&i.Title,
+			&i.Metadata,
+			&i.ParentSessionID,
+			&i.CreatedByUserID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.RouteMetadata,
+			&i.RouteConversationType,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSessionsByBotAndCreatedByUserPaged = `-- name: ListSessionsByBotAndCreatedByUserPaged :many
+SELECT
+  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = ?1
+  AND s.created_by_user_id = ?2
+  AND s.deleted_at IS NULL
+  AND s.type IN (/*SLICE:types*/?)
+  AND (
+    ?4 = 0
+    OR (s.updated_at < ?5
+        OR (s.updated_at = ?5 AND s.id < ?6))
+  )
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT ?7
+`
+
+type ListSessionsByBotAndCreatedByUserPagedParams struct {
+	BotID           string         `json:"bot_id"`
+	CreatedByUserID sql.NullString `json:"created_by_user_id"`
+	Types           []string       `json:"types"`
+	UseCursor       interface{}    `json:"use_cursor"`
+	CursorUpdatedAt string         `json:"cursor_updated_at"`
+	CursorID        string         `json:"cursor_id"`
+	LimitCount      int64          `json:"limit_count"`
+}
+
+type ListSessionsByBotAndCreatedByUserPagedRow struct {
+	ID                    string         `json:"id"`
+	BotID                 string         `json:"bot_id"`
+	RouteID               sql.NullString `json:"route_id"`
+	ChannelType           sql.NullString `json:"channel_type"`
+	Type                  string         `json:"type"`
+	Title                 string         `json:"title"`
+	Metadata              string         `json:"metadata"`
+	ParentSessionID       sql.NullString `json:"parent_session_id"`
+	CreatedByUserID       sql.NullString `json:"created_by_user_id"`
+	CreatedAt             string         `json:"created_at"`
+	UpdatedAt             string         `json:"updated_at"`
+	DeletedAt             sql.NullString `json:"deleted_at"`
+	RouteMetadata         sql.NullString `json:"route_metadata"`
+	RouteConversationType sql.NullString `json:"route_conversation_type"`
+}
+
+func (q *Queries) ListSessionsByBotAndCreatedByUserPaged(ctx context.Context, arg ListSessionsByBotAndCreatedByUserPagedParams) ([]ListSessionsByBotAndCreatedByUserPagedRow, error) {
+	query := listSessionsByBotAndCreatedByUserPaged
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.BotID)
+	queryParams = append(queryParams, arg.CreatedByUserID)
+	if len(arg.Types) > 0 {
+		for _, v := range arg.Types {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:types*/?", strings.Repeat(",?", len(arg.Types))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:types*/?", "NULL", 1)
+	}
+	queryParams = append(queryParams, arg.UseCursor)
+	queryParams = append(queryParams, arg.CursorUpdatedAt)
+	queryParams = append(queryParams, arg.CursorID)
+	queryParams = append(queryParams, arg.LimitCount)
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListSessionsByBotAndCreatedByUserPagedRow
+	for rows.Next() {
+		var i ListSessionsByBotAndCreatedByUserPagedRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.BotID,
+			&i.RouteID,
+			&i.ChannelType,
+			&i.Type,
+			&i.Title,
+			&i.Metadata,
+			&i.ParentSessionID,
+			&i.CreatedByUserID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.RouteMetadata,
+			&i.RouteConversationType,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSessionsByBotPaged = `-- name: ListSessionsByBotPaged :many
+SELECT
+  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = ?1
+  AND s.deleted_at IS NULL
+  AND s.type IN (/*SLICE:types*/?)
+  AND (
+    ?3 = 0
+    OR (s.updated_at < ?4
+        OR (s.updated_at = ?4 AND s.id < ?5))
+  )
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT ?6
+`
+
+type ListSessionsByBotPagedParams struct {
+	BotID           string      `json:"bot_id"`
+	Types           []string    `json:"types"`
+	UseCursor       interface{} `json:"use_cursor"`
+	CursorUpdatedAt string      `json:"cursor_updated_at"`
+	CursorID        string      `json:"cursor_id"`
+	LimitCount      int64       `json:"limit_count"`
+}
+
+type ListSessionsByBotPagedRow struct {
+	ID                    string         `json:"id"`
+	BotID                 string         `json:"bot_id"`
+	RouteID               sql.NullString `json:"route_id"`
+	ChannelType           sql.NullString `json:"channel_type"`
+	Type                  string         `json:"type"`
+	Title                 string         `json:"title"`
+	Metadata              string         `json:"metadata"`
+	ParentSessionID       sql.NullString `json:"parent_session_id"`
+	CreatedByUserID       sql.NullString `json:"created_by_user_id"`
+	CreatedAt             string         `json:"created_at"`
+	UpdatedAt             string         `json:"updated_at"`
+	DeletedAt             sql.NullString `json:"deleted_at"`
+	RouteMetadata         sql.NullString `json:"route_metadata"`
+	RouteConversationType sql.NullString `json:"route_conversation_type"`
+}
+
+func (q *Queries) ListSessionsByBotPaged(ctx context.Context, arg ListSessionsByBotPagedParams) ([]ListSessionsByBotPagedRow, error) {
+	query := listSessionsByBotPaged
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.BotID)
+	if len(arg.Types) > 0 {
+		for _, v := range arg.Types {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:types*/?", strings.Repeat(",?", len(arg.Types))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:types*/?", "NULL", 1)
+	}
+	queryParams = append(queryParams, arg.UseCursor)
+	queryParams = append(queryParams, arg.CursorUpdatedAt)
+	queryParams = append(queryParams, arg.CursorID)
+	queryParams = append(queryParams, arg.LimitCount)
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListSessionsByBotPagedRow
+	for rows.Next() {
+		var i ListSessionsByBotPagedRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.BotID,

--- a/internal/db/sqlite/sqlc/sessions.sql.go
+++ b/internal/db/sqlite/sqlc/sessions.sql.go
@@ -8,7 +8,6 @@ package sqlc
 import (
 	"context"
 	"database/sql"
-	"strings"
 )
 
 const createSession = `-- name: CreateSession :one
@@ -270,208 +269,10 @@ func (q *Queries) ListSessionsByBotAndCreatedByUser(ctx context.Context, arg Lis
 	return items, nil
 }
 
-const listSessionsByBotAndCreatedByUserPaged = `-- name: ListSessionsByBotAndCreatedByUserPaged :many
-SELECT
-  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
-  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
-  r.metadata AS route_metadata,
-  r.conversation_type AS route_conversation_type
-FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = ?1
-  AND s.created_by_user_id = ?2
-  AND s.deleted_at IS NULL
-  AND s.type IN (/*SLICE:types*/?)
-  AND (
-    ?4 = 0
-    OR (s.updated_at < ?5
-        OR (s.updated_at = ?5 AND s.id < ?6))
-  )
-ORDER BY s.updated_at DESC, s.id DESC
-LIMIT ?7
-`
-
-type ListSessionsByBotAndCreatedByUserPagedParams struct {
-	BotID           string         `json:"bot_id"`
-	CreatedByUserID sql.NullString `json:"created_by_user_id"`
-	Types           []string       `json:"types"`
-	UseCursor       interface{}    `json:"use_cursor"`
-	CursorUpdatedAt string         `json:"cursor_updated_at"`
-	CursorID        string         `json:"cursor_id"`
-	LimitCount      int64          `json:"limit_count"`
-}
-
-type ListSessionsByBotAndCreatedByUserPagedRow struct {
-	ID                    string         `json:"id"`
-	BotID                 string         `json:"bot_id"`
-	RouteID               sql.NullString `json:"route_id"`
-	ChannelType           sql.NullString `json:"channel_type"`
-	Type                  string         `json:"type"`
-	Title                 string         `json:"title"`
-	Metadata              string         `json:"metadata"`
-	ParentSessionID       sql.NullString `json:"parent_session_id"`
-	CreatedByUserID       sql.NullString `json:"created_by_user_id"`
-	CreatedAt             string         `json:"created_at"`
-	UpdatedAt             string         `json:"updated_at"`
-	DeletedAt             sql.NullString `json:"deleted_at"`
-	RouteMetadata         sql.NullString `json:"route_metadata"`
-	RouteConversationType sql.NullString `json:"route_conversation_type"`
-}
-
-func (q *Queries) ListSessionsByBotAndCreatedByUserPaged(ctx context.Context, arg ListSessionsByBotAndCreatedByUserPagedParams) ([]ListSessionsByBotAndCreatedByUserPagedRow, error) {
-	query := listSessionsByBotAndCreatedByUserPaged
-	var queryParams []interface{}
-	queryParams = append(queryParams, arg.BotID)
-	queryParams = append(queryParams, arg.CreatedByUserID)
-	if len(arg.Types) > 0 {
-		for _, v := range arg.Types {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:types*/?", strings.Repeat(",?", len(arg.Types))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:types*/?", "NULL", 1)
-	}
-	queryParams = append(queryParams, arg.UseCursor)
-	queryParams = append(queryParams, arg.CursorUpdatedAt)
-	queryParams = append(queryParams, arg.CursorID)
-	queryParams = append(queryParams, arg.LimitCount)
-	rows, err := q.db.QueryContext(ctx, query, queryParams...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListSessionsByBotAndCreatedByUserPagedRow
-	for rows.Next() {
-		var i ListSessionsByBotAndCreatedByUserPagedRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.BotID,
-			&i.RouteID,
-			&i.ChannelType,
-			&i.Type,
-			&i.Title,
-			&i.Metadata,
-			&i.ParentSessionID,
-			&i.CreatedByUserID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DeletedAt,
-			&i.RouteMetadata,
-			&i.RouteConversationType,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listSessionsByBotPaged = `-- name: ListSessionsByBotPaged :many
-SELECT
-  s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
-  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
-  r.metadata AS route_metadata,
-  r.conversation_type AS route_conversation_type
-FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = ?1
-  AND s.deleted_at IS NULL
-  AND s.type IN (/*SLICE:types*/?)
-  AND (
-    ?3 = 0
-    OR (s.updated_at < ?4
-        OR (s.updated_at = ?4 AND s.id < ?5))
-  )
-ORDER BY s.updated_at DESC, s.id DESC
-LIMIT ?6
-`
-
-type ListSessionsByBotPagedParams struct {
-	BotID           string      `json:"bot_id"`
-	Types           []string    `json:"types"`
-	UseCursor       interface{} `json:"use_cursor"`
-	CursorUpdatedAt string      `json:"cursor_updated_at"`
-	CursorID        string      `json:"cursor_id"`
-	LimitCount      int64       `json:"limit_count"`
-}
-
-type ListSessionsByBotPagedRow struct {
-	ID                    string         `json:"id"`
-	BotID                 string         `json:"bot_id"`
-	RouteID               sql.NullString `json:"route_id"`
-	ChannelType           sql.NullString `json:"channel_type"`
-	Type                  string         `json:"type"`
-	Title                 string         `json:"title"`
-	Metadata              string         `json:"metadata"`
-	ParentSessionID       sql.NullString `json:"parent_session_id"`
-	CreatedByUserID       sql.NullString `json:"created_by_user_id"`
-	CreatedAt             string         `json:"created_at"`
-	UpdatedAt             string         `json:"updated_at"`
-	DeletedAt             sql.NullString `json:"deleted_at"`
-	RouteMetadata         sql.NullString `json:"route_metadata"`
-	RouteConversationType sql.NullString `json:"route_conversation_type"`
-}
-
-func (q *Queries) ListSessionsByBotPaged(ctx context.Context, arg ListSessionsByBotPagedParams) ([]ListSessionsByBotPagedRow, error) {
-	query := listSessionsByBotPaged
-	var queryParams []interface{}
-	queryParams = append(queryParams, arg.BotID)
-	if len(arg.Types) > 0 {
-		for _, v := range arg.Types {
-			queryParams = append(queryParams, v)
-		}
-		query = strings.Replace(query, "/*SLICE:types*/?", strings.Repeat(",?", len(arg.Types))[1:], 1)
-	} else {
-		query = strings.Replace(query, "/*SLICE:types*/?", "NULL", 1)
-	}
-	queryParams = append(queryParams, arg.UseCursor)
-	queryParams = append(queryParams, arg.CursorUpdatedAt)
-	queryParams = append(queryParams, arg.CursorID)
-	queryParams = append(queryParams, arg.LimitCount)
-	rows, err := q.db.QueryContext(ctx, query, queryParams...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListSessionsByBotPagedRow
-	for rows.Next() {
-		var i ListSessionsByBotPagedRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.BotID,
-			&i.RouteID,
-			&i.ChannelType,
-			&i.Type,
-			&i.Title,
-			&i.Metadata,
-			&i.ParentSessionID,
-			&i.CreatedByUserID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DeletedAt,
-			&i.RouteMetadata,
-			&i.RouteConversationType,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listSessionsByRoute = `-- name: ListSessionsByRoute :many
+
+
+
 SELECT id, bot_id, route_id, channel_type, type, title, metadata, parent_session_id, created_at, updated_at, deleted_at, created_by_user_id
 FROM bot_sessions
 WHERE route_id = ?1
@@ -479,6 +280,11 @@ WHERE route_id = ?1
 ORDER BY updated_at DESC
 `
 
+// ListSessionsByBotPaged and ListSessionsByBotAndCreatedByUserPaged are not
+// generated for SQLite. The Postgres versions live in
+// db/postgres/queries/sessions.sql; the SQLite shim hand-rolls the query in
+// internal/db/sqlite/store/sessions_paged.go because sqlc-sqlite cannot mix
+// sqlc.slice with reused numbered placeholders without colliding bind indexes.
 func (q *Queries) ListSessionsByRoute(ctx context.Context, routeID sql.NullString) ([]BotSession, error) {
 	rows, err := q.db.QueryContext(ctx, listSessionsByRoute, routeID)
 	if err != nil {

--- a/internal/db/sqlite/store/queries.go
+++ b/internal/db/sqlite/store/queries.go
@@ -4158,6 +4158,44 @@ func (q *Queries) ListSessionsByBotAndCreatedByUser(ctx context.Context, arg pgs
 	return result, nil
 }
 
+func (q *Queries) ListSessionsByBotPaged(ctx context.Context, arg pgsqlc.ListSessionsByBotPagedParams) ([]pgsqlc.ListSessionsByBotPagedRow, error) {
+	if q == nil || q.store == nil || q.store.queries == nil {
+		return nil, errSQLiteQueriesNotConfigured
+	}
+	var sqliteArg sqlitesqlc.ListSessionsByBotPagedParams
+	if err := convertValue(arg, &sqliteArg); err != nil {
+		return nil, err
+	}
+	out, err := q.store.queries.ListSessionsByBotPaged(ctx, sqliteArg)
+	if err != nil {
+		return nil, mapQueryErr(err)
+	}
+	var result []pgsqlc.ListSessionsByBotPagedRow
+	if err := convertValue(out, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (q *Queries) ListSessionsByBotAndCreatedByUserPaged(ctx context.Context, arg pgsqlc.ListSessionsByBotAndCreatedByUserPagedParams) ([]pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow, error) {
+	if q == nil || q.store == nil || q.store.queries == nil {
+		return nil, errSQLiteQueriesNotConfigured
+	}
+	var sqliteArg sqlitesqlc.ListSessionsByBotAndCreatedByUserPagedParams
+	if err := convertValue(arg, &sqliteArg); err != nil {
+		return nil, err
+	}
+	out, err := q.store.queries.ListSessionsByBotAndCreatedByUserPaged(ctx, sqliteArg)
+	if err != nil {
+		return nil, mapQueryErr(err)
+	}
+	var result []pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow
+	if err := convertValue(out, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (q *Queries) ListSessionsByRoute(ctx context.Context, routeID pgtype.UUID) ([]pgsqlc.BotSession, error) {
 	if q == nil || q.store == nil || q.store.queries == nil {
 		return nil, errSQLiteQueriesNotConfigured

--- a/internal/db/sqlite/store/queries.go
+++ b/internal/db/sqlite/store/queries.go
@@ -4159,41 +4159,11 @@ func (q *Queries) ListSessionsByBotAndCreatedByUser(ctx context.Context, arg pgs
 }
 
 func (q *Queries) ListSessionsByBotPaged(ctx context.Context, arg pgsqlc.ListSessionsByBotPagedParams) ([]pgsqlc.ListSessionsByBotPagedRow, error) {
-	if q == nil || q.store == nil || q.store.queries == nil {
-		return nil, errSQLiteQueriesNotConfigured
-	}
-	var sqliteArg sqlitesqlc.ListSessionsByBotPagedParams
-	if err := convertValue(arg, &sqliteArg); err != nil {
-		return nil, err
-	}
-	out, err := q.store.queries.ListSessionsByBotPaged(ctx, sqliteArg)
-	if err != nil {
-		return nil, mapQueryErr(err)
-	}
-	var result []pgsqlc.ListSessionsByBotPagedRow
-	if err := convertValue(out, &result); err != nil {
-		return nil, err
-	}
-	return result, nil
+	return q.listSessionsByBotPaged(ctx, arg)
 }
 
 func (q *Queries) ListSessionsByBotAndCreatedByUserPaged(ctx context.Context, arg pgsqlc.ListSessionsByBotAndCreatedByUserPagedParams) ([]pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow, error) {
-	if q == nil || q.store == nil || q.store.queries == nil {
-		return nil, errSQLiteQueriesNotConfigured
-	}
-	var sqliteArg sqlitesqlc.ListSessionsByBotAndCreatedByUserPagedParams
-	if err := convertValue(arg, &sqliteArg); err != nil {
-		return nil, err
-	}
-	out, err := q.store.queries.ListSessionsByBotAndCreatedByUserPaged(ctx, sqliteArg)
-	if err != nil {
-		return nil, mapQueryErr(err)
-	}
-	var result []pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow
-	if err := convertValue(out, &result); err != nil {
-		return nil, err
-	}
-	return result, nil
+	return q.listSessionsByBotAndCreatedByUserPaged(ctx, arg)
 }
 
 func (q *Queries) ListSessionsByRoute(ctx context.Context, routeID pgtype.UUID) ([]pgsqlc.BotSession, error) {

--- a/internal/db/sqlite/store/sessions_paged.go
+++ b/internal/db/sqlite/store/sessions_paged.go
@@ -24,12 +24,6 @@ import (
 // it compares lexicographically against `updated_at`, which SQLite stores in
 // that same text form via CURRENT_TIMESTAMP.
 
-// errUnsupportedSQLiteTimestamp is returned when parseSQLiteTimestamp fails
-// to match any known layout. Hoisted to a package-level sentinel so callers
-// can errors.Is-check and so static-analyzers don't flag the inline
-// errors.New as a dynamic-error allocation.
-var errUnsupportedSQLiteTimestamp = errors.New("sessions_paged: unsupported sqlite timestamp format")
-
 const sessionPagedColumns = `s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
   s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
   r.metadata AS route_metadata,
@@ -94,7 +88,7 @@ func (q *Queries) listSessionsByBotPaged(ctx context.Context, arg pgsqlc.ListSes
 	for _, t := range arg.Types {
 		args = append(args, t)
 	}
-	args = append(args, arg.LimitCount)
+	args = append(args, int64(arg.LimitCount))
 
 	rows, err := q.store.db.QueryContext(ctx, listSessionsByBotPagedQuery(len(arg.Types)), args...)
 	if err != nil {
@@ -125,7 +119,7 @@ func (q *Queries) listSessionsByBotAndCreatedByUserPaged(ctx context.Context, ar
 	for _, t := range arg.Types {
 		args = append(args, t)
 	}
-	args = append(args, arg.LimitCount)
+	args = append(args, int64(arg.LimitCount))
 
 	rows, err := q.store.db.QueryContext(ctx, listSessionsByBotAndUserPagedQuery(len(arg.Types)), args...)
 	if err != nil {
@@ -144,8 +138,13 @@ func (q *Queries) listSessionsByBotAndCreatedByUserPaged(ctx context.Context, ar
 
 // pagedCursorBindings converts Postgres-typed cursor inputs into the string /
 // int values the SQLite driver expects. The timestamp is formatted at second
-// precision to match SQLite's TEXT storage from CURRENT_TIMESTAMP — any
-// sub-second precision in the caller's timestamp is discarded deliberately.
+// precision to match SQLite's TEXT storage from CURRENT_TIMESTAMP — the
+// schema invariant pinned in `db/sqlite/migrations/0001_init.up.sql` next to
+// `bot_sessions.updated_at`. If a future migration upgrades the column to
+// sub-second precision, this formatter MUST also keep sub-second so the
+// lexicographic comparison in the cursor SQL stays consistent with what the
+// row stores; otherwise rows in the same second will be skipped or revisited.
+// Any sub-second precision in the caller's timestamp is discarded today.
 func pagedCursorBindings(botID pgtype.UUID, useCursor bool, cursorUpdatedAt pgtype.Timestamptz, cursorID pgtype.UUID) (string, int, string, string) {
 	useFlag := 0
 	if useCursor {
@@ -285,5 +284,5 @@ func parseSQLiteTimestamp(raw string) (pgtype.Timestamptz, error) {
 			return pgtype.Timestamptz{Time: parsed.UTC(), Valid: true}, nil
 		}
 	}
-	return pgtype.Timestamptz{}, fmt.Errorf("%w: %q", errUnsupportedSQLiteTimestamp, raw)
+	return pgtype.Timestamptz{}, fmt.Errorf("sessions_paged: unsupported sqlite timestamp format %q", raw)
 }

--- a/internal/db/sqlite/store/sessions_paged.go
+++ b/internal/db/sqlite/store/sessions_paged.go
@@ -278,5 +278,5 @@ func parseSQLiteTimestamp(raw string) (pgtype.Timestamptz, error) {
 			return pgtype.Timestamptz{Time: parsed.UTC(), Valid: true}, nil
 		}
 	}
-	return pgtype.Timestamptz{}, fmt.Errorf("unsupported timestamp format")
+	return pgtype.Timestamptz{}, errors.New("unsupported timestamp format")
 }

--- a/internal/db/sqlite/store/sessions_paged.go
+++ b/internal/db/sqlite/store/sessions_paged.go
@@ -1,0 +1,269 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	pgsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+// The paged session listings are hand-rolled for SQLite rather than generated
+// via sqlc. sqlc-sqlite always emits explicit `?N` placeholders, which
+// collide with the anonymous `?` placeholders that `sqlc.slice` expands into
+// at run time — bound arguments get silently misrouted. Hand-rolling lets the
+// query use sequential anonymous `?` only, with a single, unambiguous binding
+// order.
+//
+// The cursor timestamp is funneled through strftime so it compares against
+// `updated_at`, which is stored in SQLite's `YYYY-MM-DD HH:MM:SS` text form
+// via CURRENT_TIMESTAMP.
+
+const sessionPagedColumns = `s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
+  s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+  r.metadata AS route_metadata,
+  r.conversation_type AS route_conversation_type`
+
+func listSessionsByBotPagedQuery(types int) string {
+	placeholders := strings.TrimPrefix(strings.Repeat(",?", types), ",")
+	return `
+SELECT ` + sessionPagedColumns + `
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = ?
+  AND s.deleted_at IS NULL
+  AND (
+    ? = 0
+    OR s.updated_at < strftime('%Y-%m-%d %H:%M:%S', ?)
+    OR (
+      s.updated_at = strftime('%Y-%m-%d %H:%M:%S', ?)
+      AND s.id < ?
+    )
+  )
+  AND s.type IN (` + placeholders + `)
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT ?`
+}
+
+func listSessionsByBotAndUserPagedQuery(types int) string {
+	placeholders := strings.TrimPrefix(strings.Repeat(",?", types), ",")
+	return `
+SELECT ` + sessionPagedColumns + `
+FROM bot_sessions s
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE s.bot_id = ?
+  AND s.created_by_user_id = ?
+  AND s.deleted_at IS NULL
+  AND (
+    ? = 0
+    OR s.updated_at < strftime('%Y-%m-%d %H:%M:%S', ?)
+    OR (
+      s.updated_at = strftime('%Y-%m-%d %H:%M:%S', ?)
+      AND s.id < ?
+    )
+  )
+  AND s.type IN (` + placeholders + `)
+ORDER BY s.updated_at DESC, s.id DESC
+LIMIT ?`
+}
+
+func (q *Queries) listSessionsByBotPaged(ctx context.Context, arg pgsqlc.ListSessionsByBotPagedParams) ([]pgsqlc.ListSessionsByBotPagedRow, error) {
+	if q == nil || q.store == nil || q.store.db == nil {
+		return nil, errSQLiteQueriesNotConfigured
+	}
+	if len(arg.Types) == 0 {
+		// The caller never opts out of filtering — the handler always passes
+		// an explicit non-empty types set. Fail loudly so we don't silently
+		// match nothing or scan the world.
+		return nil, fmt.Errorf("ListSessionsByBotPaged: types must not be empty")
+	}
+	botID, useCursor, cursorTS, cursorID := pagedCursorBindings(arg.BotID, arg.UseCursor, arg.CursorUpdatedAt, arg.CursorID)
+	args := make([]any, 0, 5+len(arg.Types)+1)
+	args = append(args, botID, useCursor, cursorTS, cursorTS, cursorID)
+	for _, t := range arg.Types {
+		args = append(args, t)
+	}
+	args = append(args, arg.LimitCount)
+
+	rows, err := q.store.db.QueryContext(ctx, listSessionsByBotPagedQuery(len(arg.Types)), args...)
+	if err != nil {
+		return nil, mapQueryErr(err)
+	}
+	defer rows.Close()
+	return scanSessionPagedRows(rows, func(r sessionPagedScan) pgsqlc.ListSessionsByBotPagedRow {
+		return pgsqlc.ListSessionsByBotPagedRow{
+			ID: r.ID, BotID: r.BotID, RouteID: r.RouteID, ChannelType: r.ChannelType, Type: r.Type,
+			Title: r.Title, Metadata: r.Metadata, ParentSessionID: r.ParentSessionID, CreatedByUserID: r.CreatedByUserID,
+			CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt, DeletedAt: r.DeletedAt,
+			RouteMetadata: r.RouteMetadata, RouteConversationType: r.RouteConversationType,
+		}
+	})
+}
+
+func (q *Queries) listSessionsByBotAndCreatedByUserPaged(ctx context.Context, arg pgsqlc.ListSessionsByBotAndCreatedByUserPagedParams) ([]pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow, error) {
+	if q == nil || q.store == nil || q.store.db == nil {
+		return nil, errSQLiteQueriesNotConfigured
+	}
+	if len(arg.Types) == 0 {
+		return nil, fmt.Errorf("ListSessionsByBotAndCreatedByUserPaged: types must not be empty")
+	}
+	botID, useCursor, cursorTS, cursorID := pagedCursorBindings(arg.BotID, arg.UseCursor, arg.CursorUpdatedAt, arg.CursorID)
+	userID := nullableUUIDToString(arg.CreatedByUserID)
+	args := make([]any, 0, 6+len(arg.Types)+1)
+	args = append(args, botID, userID, useCursor, cursorTS, cursorTS, cursorID)
+	for _, t := range arg.Types {
+		args = append(args, t)
+	}
+	args = append(args, arg.LimitCount)
+
+	rows, err := q.store.db.QueryContext(ctx, listSessionsByBotAndUserPagedQuery(len(arg.Types)), args...)
+	if err != nil {
+		return nil, mapQueryErr(err)
+	}
+	defer rows.Close()
+	return scanSessionPagedRows(rows, func(r sessionPagedScan) pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow {
+		return pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow{
+			ID: r.ID, BotID: r.BotID, RouteID: r.RouteID, ChannelType: r.ChannelType, Type: r.Type,
+			Title: r.Title, Metadata: r.Metadata, ParentSessionID: r.ParentSessionID, CreatedByUserID: r.CreatedByUserID,
+			CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt, DeletedAt: r.DeletedAt,
+			RouteMetadata: r.RouteMetadata, RouteConversationType: r.RouteConversationType,
+		}
+	})
+}
+
+// pagedCursorBindings converts Postgres-typed cursor inputs into the string /
+// int values the SQLite driver expects. SQLite columns store text, so the
+// cursor compares as `YYYY-MM-DD HH:MM:SS` UTC; strftime in the query
+// truncates any sub-second precision a caller passes in.
+func pagedCursorBindings(botID pgtype.UUID, useCursor bool, cursorUpdatedAt pgtype.Timestamptz, cursorID pgtype.UUID) (string, int, string, string) {
+	useFlag := 0
+	if useCursor {
+		useFlag = 1
+	}
+	tsText := ""
+	if cursorUpdatedAt.Valid {
+		tsText = cursorUpdatedAt.Time.UTC().Format("2006-01-02 15:04:05.999999999")
+	}
+	return uuidToString(botID), useFlag, tsText, uuidToString(cursorID)
+}
+
+func uuidToString(id pgtype.UUID) string {
+	if !id.Valid {
+		return ""
+	}
+	return id.String()
+}
+
+func nullableUUIDToString(id pgtype.UUID) any {
+	if !id.Valid {
+		return nil
+	}
+	return id.String()
+}
+
+type sessionPagedScan struct {
+	ID                    pgtype.UUID
+	BotID                 pgtype.UUID
+	RouteID               pgtype.UUID
+	ChannelType           pgtype.Text
+	Type                  string
+	Title                 string
+	Metadata              []byte
+	ParentSessionID       pgtype.UUID
+	CreatedByUserID       pgtype.UUID
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	DeletedAt             pgtype.Timestamptz
+	RouteMetadata         []byte
+	RouteConversationType pgtype.Text
+}
+
+func scanSessionPagedRows[T any](rows *sql.Rows, conv func(sessionPagedScan) T) ([]T, error) {
+	var out []T
+	for rows.Next() {
+		var (
+			id, botID                       string
+			routeID, channelType            sql.NullString
+			typ, title, metadata            string
+			parentSessionID, createdByUser  sql.NullString
+			createdAt, updatedAt            string
+			deletedAt                       sql.NullString
+			routeMetadata                   sql.NullString
+			routeConversationType           sql.NullString
+		)
+		if err := rows.Scan(
+			&id, &botID, &routeID, &channelType, &typ, &title, &metadata,
+			&parentSessionID, &createdByUser, &createdAt, &updatedAt, &deletedAt,
+			&routeMetadata, &routeConversationType,
+		); err != nil {
+			return nil, err
+		}
+		row := sessionPagedScan{
+			Type:                  typ,
+			Title:                 title,
+			Metadata:              []byte(metadata),
+			ChannelType:           textFromNullString(channelType),
+			RouteConversationType: textFromNullString(routeConversationType),
+		}
+		if err := row.ID.Scan(id); err != nil {
+			return nil, err
+		}
+		if err := row.BotID.Scan(botID); err != nil {
+			return nil, err
+		}
+		if routeID.Valid {
+			if err := row.RouteID.Scan(routeID.String); err != nil {
+				return nil, err
+			}
+		}
+		if parentSessionID.Valid {
+			if err := row.ParentSessionID.Scan(parentSessionID.String); err != nil {
+				return nil, err
+			}
+		}
+		if createdByUser.Valid {
+			if err := row.CreatedByUserID.Scan(createdByUser.String); err != nil {
+				return nil, err
+			}
+		}
+		row.CreatedAt = parseSQLiteTimestamp(createdAt)
+		row.UpdatedAt = parseSQLiteTimestamp(updatedAt)
+		if deletedAt.Valid {
+			row.DeletedAt = parseSQLiteTimestamp(deletedAt.String)
+		}
+		if routeMetadata.Valid {
+			row.RouteMetadata = []byte(routeMetadata.String)
+		}
+		out = append(out, conv(row))
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func textFromNullString(value sql.NullString) pgtype.Text {
+	if !value.Valid {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: value.String, Valid: true}
+}
+
+func parseSQLiteTimestamp(raw string) pgtype.Timestamptz {
+	if raw == "" {
+		return pgtype.Timestamptz{}
+	}
+	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02 15:04:05.999999999", time.RFC3339Nano, time.RFC3339} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return pgtype.Timestamptz{Time: parsed.UTC(), Valid: true}
+		}
+	}
+	return pgtype.Timestamptz{}
+}

--- a/internal/db/sqlite/store/sessions_paged.go
+++ b/internal/db/sqlite/store/sessions_paged.go
@@ -24,6 +24,12 @@ import (
 // it compares lexicographically against `updated_at`, which SQLite stores in
 // that same text form via CURRENT_TIMESTAMP.
 
+// errUnsupportedSQLiteTimestamp is returned when parseSQLiteTimestamp fails
+// to match any known layout. Hoisted to a package-level sentinel so callers
+// can errors.Is-check and so static-analyzers don't flag the inline
+// errors.New as a dynamic-error allocation.
+var errUnsupportedSQLiteTimestamp = errors.New("sessions_paged: unsupported sqlite timestamp format")
+
 const sessionPagedColumns = `s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
   s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
   r.metadata AS route_metadata,
@@ -253,9 +259,10 @@ func scanSessionPagedRows[T any](rows *sql.Rows, conv func(sessionPagedScan) T) 
 		}
 		out = append(out, conv(row))
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
+	// Callers `defer rows.Close()`; rely on that and just surface a deferred
+	// iteration error. Calling Close here would make the caller's defer a
+	// no-op and risks divergent behavior if a future caller forgets the
+	// defer.
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
@@ -278,5 +285,5 @@ func parseSQLiteTimestamp(raw string) (pgtype.Timestamptz, error) {
 			return pgtype.Timestamptz{Time: parsed.UTC(), Valid: true}, nil
 		}
 	}
-	return pgtype.Timestamptz{}, errors.New("unsupported timestamp format")
+	return pgtype.Timestamptz{}, fmt.Errorf("%w: %q", errUnsupportedSQLiteTimestamp, raw)
 }

--- a/internal/db/sqlite/store/sessions_paged.go
+++ b/internal/db/sqlite/store/sessions_paged.go
@@ -3,7 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
-	"fmt"
+	"errors"
 	"strings"
 	"time"
 
@@ -79,7 +79,7 @@ func (q *Queries) listSessionsByBotPaged(ctx context.Context, arg pgsqlc.ListSes
 		// The caller never opts out of filtering — the handler always passes
 		// an explicit non-empty types set. Fail loudly so we don't silently
 		// match nothing or scan the world.
-		return nil, fmt.Errorf("ListSessionsByBotPaged: types must not be empty")
+		return nil, errors.New("ListSessionsByBotPaged: types must not be empty")
 	}
 	botID, useCursor, cursorTS, cursorID := pagedCursorBindings(arg.BotID, arg.UseCursor, arg.CursorUpdatedAt, arg.CursorID)
 	args := make([]any, 0, 5+len(arg.Types)+1)
@@ -93,7 +93,7 @@ func (q *Queries) listSessionsByBotPaged(ctx context.Context, arg pgsqlc.ListSes
 	if err != nil {
 		return nil, mapQueryErr(err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	return scanSessionPagedRows(rows, func(r sessionPagedScan) pgsqlc.ListSessionsByBotPagedRow {
 		return pgsqlc.ListSessionsByBotPagedRow{
 			ID: r.ID, BotID: r.BotID, RouteID: r.RouteID, ChannelType: r.ChannelType, Type: r.Type,
@@ -109,7 +109,7 @@ func (q *Queries) listSessionsByBotAndCreatedByUserPaged(ctx context.Context, ar
 		return nil, errSQLiteQueriesNotConfigured
 	}
 	if len(arg.Types) == 0 {
-		return nil, fmt.Errorf("ListSessionsByBotAndCreatedByUserPaged: types must not be empty")
+		return nil, errors.New("ListSessionsByBotAndCreatedByUserPaged: types must not be empty")
 	}
 	botID, useCursor, cursorTS, cursorID := pagedCursorBindings(arg.BotID, arg.UseCursor, arg.CursorUpdatedAt, arg.CursorID)
 	userID := nullableUUIDToString(arg.CreatedByUserID)
@@ -124,7 +124,7 @@ func (q *Queries) listSessionsByBotAndCreatedByUserPaged(ctx context.Context, ar
 	if err != nil {
 		return nil, mapQueryErr(err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	return scanSessionPagedRows(rows, func(r sessionPagedScan) pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow {
 		return pgsqlc.ListSessionsByBotAndCreatedByUserPagedRow{
 			ID: r.ID, BotID: r.BotID, RouteID: r.RouteID, ChannelType: r.ChannelType, Type: r.Type,
@@ -186,14 +186,14 @@ func scanSessionPagedRows[T any](rows *sql.Rows, conv func(sessionPagedScan) T) 
 	var out []T
 	for rows.Next() {
 		var (
-			id, botID                       string
-			routeID, channelType            sql.NullString
-			typ, title, metadata            string
-			parentSessionID, createdByUser  sql.NullString
-			createdAt, updatedAt            string
-			deletedAt                       sql.NullString
-			routeMetadata                   sql.NullString
-			routeConversationType           sql.NullString
+			id, botID                      string
+			routeID, channelType           sql.NullString
+			typ, title, metadata           string
+			parentSessionID, createdByUser sql.NullString
+			createdAt, updatedAt           string
+			deletedAt                      sql.NullString
+			routeMetadata                  sql.NullString
+			routeConversationType          sql.NullString
 		)
 		if err := rows.Scan(
 			&id, &botID, &routeID, &channelType, &typ, &title, &metadata,

--- a/internal/db/sqlite/store/sessions_paged.go
+++ b/internal/db/sqlite/store/sessions_paged.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -19,9 +20,9 @@ import (
 // query use sequential anonymous `?` only, with a single, unambiguous binding
 // order.
 //
-// The cursor timestamp is funneled through strftime so it compares against
-// `updated_at`, which is stored in SQLite's `YYYY-MM-DD HH:MM:SS` text form
-// via CURRENT_TIMESTAMP.
+// The cursor timestamp is bound as a plain `YYYY-MM-DD HH:MM:SS` UTC string so
+// it compares lexicographically against `updated_at`, which SQLite stores in
+// that same text form via CURRENT_TIMESTAMP.
 
 const sessionPagedColumns = `s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.title, s.metadata,
   s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
@@ -38,9 +39,9 @@ WHERE s.bot_id = ?
   AND s.deleted_at IS NULL
   AND (
     ? = 0
-    OR s.updated_at < strftime('%Y-%m-%d %H:%M:%S', ?)
+    OR s.updated_at < ?
     OR (
-      s.updated_at = strftime('%Y-%m-%d %H:%M:%S', ?)
+      s.updated_at = ?
       AND s.id < ?
     )
   )
@@ -60,9 +61,9 @@ WHERE s.bot_id = ?
   AND s.deleted_at IS NULL
   AND (
     ? = 0
-    OR s.updated_at < strftime('%Y-%m-%d %H:%M:%S', ?)
+    OR s.updated_at < ?
     OR (
-      s.updated_at = strftime('%Y-%m-%d %H:%M:%S', ?)
+      s.updated_at = ?
       AND s.id < ?
     )
   )
@@ -136,9 +137,9 @@ func (q *Queries) listSessionsByBotAndCreatedByUserPaged(ctx context.Context, ar
 }
 
 // pagedCursorBindings converts Postgres-typed cursor inputs into the string /
-// int values the SQLite driver expects. SQLite columns store text, so the
-// cursor compares as `YYYY-MM-DD HH:MM:SS` UTC; strftime in the query
-// truncates any sub-second precision a caller passes in.
+// int values the SQLite driver expects. The timestamp is formatted at second
+// precision to match SQLite's TEXT storage from CURRENT_TIMESTAMP — any
+// sub-second precision in the caller's timestamp is discarded deliberately.
 func pagedCursorBindings(botID pgtype.UUID, useCursor bool, cursorUpdatedAt pgtype.Timestamptz, cursorID pgtype.UUID) (string, int, string, string) {
 	useFlag := 0
 	if useCursor {
@@ -146,7 +147,7 @@ func pagedCursorBindings(botID pgtype.UUID, useCursor bool, cursorUpdatedAt pgty
 	}
 	tsText := ""
 	if cursorUpdatedAt.Valid {
-		tsText = cursorUpdatedAt.Time.UTC().Format("2006-01-02 15:04:05.999999999")
+		tsText = cursorUpdatedAt.Time.UTC().Format("2006-01-02 15:04:05")
 	}
 	return uuidToString(botID), useFlag, tsText, uuidToString(cursorID)
 }
@@ -230,10 +231,22 @@ func scanSessionPagedRows[T any](rows *sql.Rows, conv func(sessionPagedScan) T) 
 				return nil, err
 			}
 		}
-		row.CreatedAt = parseSQLiteTimestamp(createdAt)
-		row.UpdatedAt = parseSQLiteTimestamp(updatedAt)
+		createdTS, err := parseSQLiteTimestamp(createdAt)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite paged sessions: parse created_at %q: %w", createdAt, err)
+		}
+		row.CreatedAt = createdTS
+		updatedTS, err := parseSQLiteTimestamp(updatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite paged sessions: parse updated_at %q: %w", updatedAt, err)
+		}
+		row.UpdatedAt = updatedTS
 		if deletedAt.Valid {
-			row.DeletedAt = parseSQLiteTimestamp(deletedAt.String)
+			deletedTS, err := parseSQLiteTimestamp(deletedAt.String)
+			if err != nil {
+				return nil, fmt.Errorf("sqlite paged sessions: parse deleted_at %q: %w", deletedAt.String, err)
+			}
+			row.DeletedAt = deletedTS
 		}
 		if routeMetadata.Valid {
 			row.RouteMetadata = []byte(routeMetadata.String)
@@ -256,14 +269,14 @@ func textFromNullString(value sql.NullString) pgtype.Text {
 	return pgtype.Text{String: value.String, Valid: true}
 }
 
-func parseSQLiteTimestamp(raw string) pgtype.Timestamptz {
+func parseSQLiteTimestamp(raw string) (pgtype.Timestamptz, error) {
 	if raw == "" {
-		return pgtype.Timestamptz{}
+		return pgtype.Timestamptz{}, nil
 	}
 	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02 15:04:05.999999999", time.RFC3339Nano, time.RFC3339} {
 		if parsed, err := time.Parse(layout, raw); err == nil {
-			return pgtype.Timestamptz{Time: parsed.UTC(), Valid: true}
+			return pgtype.Timestamptz{Time: parsed.UTC(), Valid: true}, nil
 		}
 	}
-	return pgtype.Timestamptz{}
+	return pgtype.Timestamptz{}, fmt.Errorf("unsupported timestamp format")
 }

--- a/internal/db/sqlite/store/sessions_paged_test.go
+++ b/internal/db/sqlite/store/sessions_paged_test.go
@@ -264,3 +264,194 @@ CREATE TABLE bot_sessions (
 		t.Fatalf("page2[0] = %s, want %s (no duplicate, no skip)", got, ids[0])
 	}
 }
+
+// TestSQLiteListSessionsByBotPagedWithinOneSecond pins down the second-
+// precision invariant between SQLite's CURRENT_TIMESTAMP storage and the
+// cursor formatter in pagedCursorBindings. Several rows inserted inside the
+// same wall-clock second collide on `updated_at` after CURRENT_TIMESTAMP
+// truncation; only the (updated_at = ? AND id < ?) tiebreak in the cursor SQL
+// can separate them. A regression that lets sub-second precision leak into
+// either side of the compare would either revisit or skip rows here.
+func TestSQLiteListSessionsByBotPagedWithinOneSecond(t *testing.T) {
+	ctx := context.Background()
+	conn, err := db.OpenSQLite(ctx, config.SQLiteConfig{DSN: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	execAll(t, conn, `
+CREATE TABLE bot_channel_routes (
+  id TEXT PRIMARY KEY,
+  metadata TEXT,
+  conversation_type TEXT
+);
+CREATE TABLE bot_sessions (
+  id TEXT PRIMARY KEY,
+  bot_id TEXT NOT NULL,
+  route_id TEXT REFERENCES bot_channel_routes(id),
+  channel_type TEXT,
+  type TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  metadata TEXT NOT NULL DEFAULT '{}',
+  parent_session_id TEXT,
+  created_by_user_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
+`)
+
+	botID := "33333333-3333-3333-3333-333333333333"
+	ids := []string{
+		"cccccccc-cccc-cccc-cccc-cccccccccc01",
+		"cccccccc-cccc-cccc-cccc-cccccccccc02",
+		"cccccccc-cccc-cccc-cccc-cccccccccc03",
+		"cccccccc-cccc-cccc-cccc-cccccccccc04",
+		"cccccccc-cccc-cccc-cccc-cccccccccc05",
+	}
+	// Insert each row with a fresh CURRENT_TIMESTAMP read with no explicit
+	// updated_at; sleeping a few hundred microseconds between inserts gives
+	// SQLite distinct sub-second wall times that all collapse to the same
+	// second after CURRENT_TIMESTAMP truncation. That is exactly the state
+	// the cursor must navigate without revisiting or skipping rows.
+	for _, id := range ids {
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO bot_sessions (id, bot_id, type) VALUES (?, ?, 'chat')`,
+			id, botID,
+		); err != nil {
+			t.Fatalf("insert seed %s: %v", id, err)
+		}
+		time.Sleep(500 * time.Microsecond)
+	}
+
+	st, err := New(conn)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	queries := NewQueries(st)
+	pgBotID := mustUUID(t, botID)
+
+	// Walk pages of size 2 until the listing is exhausted; every row id must
+	// appear exactly once and never be revisited.
+	visited := make(map[string]int, len(ids))
+	var cursor *pgsqlc.ListSessionsByBotPagedRow
+	for step := 0; step < len(ids)+2; step++ {
+		params := pgsqlc.ListSessionsByBotPagedParams{
+			BotID:      pgBotID,
+			Types:      []string{"chat"},
+			LimitCount: 2,
+		}
+		if cursor != nil {
+			params.UseCursor = true
+			params.CursorUpdatedAt = pgtype.Timestamptz{Time: cursor.UpdatedAt.Time, Valid: true}
+			params.CursorID = cursor.ID
+		}
+		page, err := queries.ListSessionsByBotPaged(ctx, params)
+		if err != nil {
+			t.Fatalf("page step %d: %v", step, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, row := range page {
+			visited[row.ID.String()]++
+		}
+		last := page[len(page)-1]
+		cursor = &last
+	}
+	if len(visited) != len(ids) {
+		t.Fatalf("visited %d distinct rows, want %d (visited=%v)", len(visited), len(ids), visited)
+	}
+	for id, count := range visited {
+		if count != 1 {
+			t.Fatalf("row %s visited %d times, want exactly 1", id, count)
+		}
+	}
+}
+
+// TestSQLiteListSessionsByBotPagedSurfacesRouteJoinColumns guards the column
+// ordering in scanSessionPagedRows. The query selects 14 positional columns
+// including the two LEFT JOIN'd route columns; a regression that swaps two
+// fields would not fail the basic listing tests because most fields are
+// independently asserted as scalars on a single row. Forcing a non-null
+// route_metadata + route_conversation_type round-trip catches that class of
+// bug.
+func TestSQLiteListSessionsByBotPagedSurfacesRouteJoinColumns(t *testing.T) {
+	ctx := context.Background()
+	conn, err := db.OpenSQLite(ctx, config.SQLiteConfig{DSN: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	execAll(t, conn, `
+CREATE TABLE bot_channel_routes (
+  id TEXT PRIMARY KEY,
+  metadata TEXT,
+  conversation_type TEXT
+);
+CREATE TABLE bot_sessions (
+  id TEXT PRIMARY KEY,
+  bot_id TEXT NOT NULL,
+  route_id TEXT REFERENCES bot_channel_routes(id),
+  channel_type TEXT,
+  type TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  metadata TEXT NOT NULL DEFAULT '{}',
+  parent_session_id TEXT,
+  created_by_user_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
+`)
+
+	botID := "44444444-4444-4444-4444-444444444444"
+	routeID := "55555555-5555-5555-5555-555555555555"
+	sessionID := "66666666-6666-6666-6666-666666666666"
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO bot_channel_routes (id, metadata, conversation_type) VALUES (?, ?, ?)`,
+		routeID, `{"channel":"telegram"}`, "group",
+	); err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO bot_sessions (id, bot_id, route_id, type, updated_at, created_at)
+         VALUES (?, ?, ?, 'chat', '2026-06-19 12:00:00', '2026-06-19 12:00:00')`,
+		sessionID, botID, routeID,
+	); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+
+	st, err := New(conn)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	queries := NewQueries(st)
+
+	page, err := queries.ListSessionsByBotPaged(ctx, pgsqlc.ListSessionsByBotPagedParams{
+		BotID:      mustUUID(t, botID),
+		Types:      []string{"chat"},
+		LimitCount: 10,
+	})
+	if err != nil {
+		t.Fatalf("ListSessionsByBotPaged: %v", err)
+	}
+	if len(page) != 1 {
+		t.Fatalf("page len = %d, want 1", len(page))
+	}
+	row := page[0]
+	if row.ID.String() != sessionID {
+		t.Fatalf("row id = %s, want %s", row.ID.String(), sessionID)
+	}
+	if row.RouteID.String() != routeID {
+		t.Fatalf("row route_id = %s, want %s", row.RouteID.String(), routeID)
+	}
+	if string(row.RouteMetadata) != `{"channel":"telegram"}` {
+		t.Fatalf("RouteMetadata = %q, want telegram payload", string(row.RouteMetadata))
+	}
+	if !row.RouteConversationType.Valid || row.RouteConversationType.String != "group" {
+		t.Fatalf("RouteConversationType = %#v, want group", row.RouteConversationType)
+	}
+}

--- a/internal/db/sqlite/store/sessions_paged_test.go
+++ b/internal/db/sqlite/store/sessions_paged_test.go
@@ -26,6 +26,10 @@ func TestSQLiteListSessionsByBotPagedRespectsCursorAndTypes(t *testing.T) {
 	}
 	defer func() { _ = conn.Close() }()
 
+	// Hand-rolled minimal schema rather than the full SQLite migration
+	// baseline — see the comment in TestSQLiteListSessionsByBotPagedTiesOnUpdatedAt
+	// for the rationale; schema drift on the queried columns surfaces via
+	// the integration test path.
 	execAll(t, conn, `
 CREATE TABLE bot_channel_routes (
   id TEXT PRIMARY KEY,

--- a/internal/db/sqlite/store/sessions_paged_test.go
+++ b/internal/db/sqlite/store/sessions_paged_test.go
@@ -1,0 +1,157 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/config"
+	"github.com/memohai/memoh/internal/db"
+	pgsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+// TestSQLiteListSessionsByBotPagedRespectsCursorAndTypes pins down the bound-
+// argument order for the paged session queries. The previous SQL mixed
+// `sqlc.slice(types)` with explicit numbered placeholders, which silently
+// misrouted the cursor and limit binds — this test exercises the SQLite shim
+// against a real in-memory database so that class of bug fails loudly.
+func TestSQLiteListSessionsByBotPagedRespectsCursorAndTypes(t *testing.T) {
+	ctx := context.Background()
+	conn, err := db.OpenSQLite(ctx, config.SQLiteConfig{DSN: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	execAll(t, conn, `
+CREATE TABLE bot_channel_routes (
+  id TEXT PRIMARY KEY,
+  metadata TEXT,
+  conversation_type TEXT
+);
+CREATE TABLE bot_sessions (
+  id TEXT PRIMARY KEY,
+  bot_id TEXT NOT NULL,
+  route_id TEXT REFERENCES bot_channel_routes(id),
+  channel_type TEXT,
+  type TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  metadata TEXT NOT NULL DEFAULT '{}',
+  parent_session_id TEXT,
+  created_by_user_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
+`)
+
+	botID := "11111111-1111-1111-1111-111111111111"
+
+	// Five sessions across types, separated by one minute each so the cursor's
+	// (updated_at, id) ordering is observable.
+	type seed struct {
+		id      string
+		typ     string
+		minutes int
+	}
+	seeds := []seed{
+		{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa01", "chat", 1},
+		{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa02", "discuss", 2},
+		{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa03", "heartbeat", 3},
+		{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa04", "chat", 4},
+		{"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa05", "discuss", 5},
+	}
+	for _, s := range seeds {
+		ts := time.Date(2026, 6, 19, 12, s.minutes, 0, 0, time.UTC)
+		stored := ts.Format("2006-01-02 15:04:05")
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO bot_sessions (id, bot_id, type, updated_at, created_at) VALUES (?, ?, ?, ?, ?)`,
+			s.id, botID, s.typ, stored, stored,
+		); err != nil {
+			t.Fatalf("insert seed %s: %v", s.id, err)
+		}
+	}
+
+	st, err := New(conn)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	queries := NewQueries(st)
+
+	pgBotID := mustUUID(t, botID)
+
+	// First page (limit 2, no cursor): two newest user-facing sessions; the
+	// heartbeat row must be skipped.
+	page1, err := queries.ListSessionsByBotPaged(ctx, pgsqlc.ListSessionsByBotPagedParams{
+		BotID:      pgBotID,
+		Types:      []string{"chat", "discuss"},
+		UseCursor:  false,
+		LimitCount: 2,
+	})
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("first page len = %d, want 2 (ids %v)", len(page1), pageIDs(page1))
+	}
+	if got := page1[0].ID.String(); !strings.HasSuffix(got, "05") {
+		t.Fatalf("first page row 0 id = %s, want trailing 05", got)
+	}
+	if got := page1[1].ID.String(); !strings.HasSuffix(got, "04") {
+		t.Fatalf("first page row 1 id = %s, want trailing 04", got)
+	}
+	for _, row := range page1 {
+		if row.Type == "heartbeat" {
+			t.Fatalf("heartbeat row leaked into user-facing page: %#v", row)
+		}
+	}
+
+	// Cursor at the last row of page1 — the next page must skip rows 05 and 04
+	// and surface only the older user-facing rows in correct order.
+	cursor := page1[1]
+	page2, err := queries.ListSessionsByBotPaged(ctx, pgsqlc.ListSessionsByBotPagedParams{
+		BotID:           pgBotID,
+		Types:           []string{"chat", "discuss"},
+		UseCursor:       true,
+		CursorUpdatedAt: pgtype.Timestamptz{Time: cursor.UpdatedAt.Time, Valid: true},
+		CursorID:        cursor.ID,
+		LimitCount:      10,
+	})
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("second page len = %d, want 2 (ids %v)", len(page2), pageIDs(page2))
+	}
+	if got := page2[0].ID.String(); !strings.HasSuffix(got, "02") {
+		t.Fatalf("second page row 0 id = %s, want trailing 02", got)
+	}
+	if got := page2[1].ID.String(); !strings.HasSuffix(got, "01") {
+		t.Fatalf("second page row 1 id = %s, want trailing 01", got)
+	}
+
+	// Filter that explicitly includes heartbeat must surface every row.
+	pageAll, err := queries.ListSessionsByBotPaged(ctx, pgsqlc.ListSessionsByBotPagedParams{
+		BotID:      pgBotID,
+		Types:      []string{"chat", "discuss", "heartbeat"},
+		UseCursor:  false,
+		LimitCount: 10,
+	})
+	if err != nil {
+		t.Fatalf("page-all: %v", err)
+	}
+	if len(pageAll) != 5 {
+		t.Fatalf("page-all len = %d, want 5 (ids %v)", len(pageAll), pageIDs(pageAll))
+	}
+}
+
+func pageIDs(rows []pgsqlc.ListSessionsByBotPagedRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.ID.String()
+	}
+	return out
+}

--- a/internal/db/sqlite/store/sessions_paged_test.go
+++ b/internal/db/sqlite/store/sessions_paged_test.go
@@ -155,3 +155,108 @@ func pageIDs(rows []pgsqlc.ListSessionsByBotPagedRow) []string {
 	}
 	return out
 }
+
+// TestSQLiteListSessionsByBotPagedTiesOnUpdatedAt exercises the
+// (updated_at = ? AND id < ?) tiebreak branch of the cursor SQL. The cursor
+// timestamp is bound at second precision against TEXT storage, so two rows
+// inserted in the same second collide on the timestamp and only the id
+// comparison can separate them. The other paged test seeds rows a minute
+// apart and so never touches this branch.
+func TestSQLiteListSessionsByBotPagedTiesOnUpdatedAt(t *testing.T) {
+	ctx := context.Background()
+	conn, err := db.OpenSQLite(ctx, config.SQLiteConfig{DSN: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Hand-rolled minimal schema — matches the pattern in the rest of this
+	// package's tests; running the full SQLite migration baseline (895+
+	// lines, plus 20+ incremental files) for one unit test is not worth the
+	// infra weight, and schema drift on the columns this query touches will
+	// surface in the integration test path.
+	execAll(t, conn, `
+CREATE TABLE bot_channel_routes (
+  id TEXT PRIMARY KEY,
+  metadata TEXT,
+  conversation_type TEXT
+);
+CREATE TABLE bot_sessions (
+  id TEXT PRIMARY KEY,
+  bot_id TEXT NOT NULL,
+  route_id TEXT REFERENCES bot_channel_routes(id),
+  channel_type TEXT,
+  type TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  metadata TEXT NOT NULL DEFAULT '{}',
+  parent_session_id TEXT,
+  created_by_user_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
+`)
+
+	botID := "22222222-2222-2222-2222-222222222222"
+	sharedTS := "2026-06-19 00:00:00"
+	ids := []string{
+		"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb01",
+		"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb02",
+		"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb03",
+	}
+	for _, id := range ids {
+		if _, err := conn.ExecContext(ctx,
+			`INSERT INTO bot_sessions (id, bot_id, type, updated_at, created_at) VALUES (?, ?, 'chat', ?, ?)`,
+			id, botID, sharedTS, sharedTS,
+		); err != nil {
+			t.Fatalf("insert seed %s: %v", id, err)
+		}
+	}
+
+	st, err := New(conn)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	queries := NewQueries(st)
+	pgBotID := mustUUID(t, botID)
+
+	page1, err := queries.ListSessionsByBotPaged(ctx, pgsqlc.ListSessionsByBotPagedParams{
+		BotID:      pgBotID,
+		Types:      []string{"chat"},
+		UseCursor:  false,
+		LimitCount: 2,
+	})
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("page1 len = %d, want 2 (ids %v)", len(page1), pageIDs(page1))
+	}
+	// id DESC within the same timestamp: 03 then 02.
+	if got := page1[0].ID.String(); got != ids[2] {
+		t.Fatalf("page1[0] = %s, want %s", got, ids[2])
+	}
+	if got := page1[1].ID.String(); got != ids[1] {
+		t.Fatalf("page1[1] = %s, want %s", got, ids[1])
+	}
+
+	// Build the cursor exactly the way the handler does — from the last row.
+	last := page1[1]
+	page2, err := queries.ListSessionsByBotPaged(ctx, pgsqlc.ListSessionsByBotPagedParams{
+		BotID:           pgBotID,
+		Types:           []string{"chat"},
+		UseCursor:       true,
+		CursorUpdatedAt: pgtype.Timestamptz{Time: last.UpdatedAt.Time, Valid: true},
+		CursorID:        last.ID,
+		LimitCount:      10,
+	})
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if len(page2) != 1 {
+		t.Fatalf("page2 len = %d, want 1 (ids %v)", len(page2), pageIDs(page2))
+	}
+	if got := page2[0].ID.String(); got != ids[0] {
+		t.Fatalf("page2[0] = %s, want %s (no duplicate, no skip)", got, ids[0])
+	}
+}

--- a/internal/db/store/queries.go
+++ b/internal/db/store/queries.go
@@ -261,6 +261,8 @@ type Queries interface {
 	ListSessionEventsBySessionAfter(ctx context.Context, arg dbsqlc.ListSessionEventsBySessionAfterParams) ([]dbsqlc.BotSessionEvent, error)
 	ListSessionsByBot(ctx context.Context, botID pgtype.UUID) ([]dbsqlc.ListSessionsByBotRow, error)
 	ListSessionsByBotAndCreatedByUser(ctx context.Context, arg dbsqlc.ListSessionsByBotAndCreatedByUserParams) ([]dbsqlc.ListSessionsByBotAndCreatedByUserRow, error)
+	ListSessionsByBotAndCreatedByUserPaged(ctx context.Context, arg dbsqlc.ListSessionsByBotAndCreatedByUserPagedParams) ([]dbsqlc.ListSessionsByBotAndCreatedByUserPagedRow, error)
+	ListSessionsByBotPaged(ctx context.Context, arg dbsqlc.ListSessionsByBotPagedParams) ([]dbsqlc.ListSessionsByBotPagedRow, error)
 	ListSessionsByRoute(ctx context.Context, routeID pgtype.UUID) ([]dbsqlc.BotSession, error)
 	ListSnapshotsByContainerID(ctx context.Context, containerID string) ([]dbsqlc.Snapshot, error)
 	ListSnapshotsWithVersionByContainerID(ctx context.Context, containerID string) ([]dbsqlc.ListSnapshotsWithVersionByContainerIDRow, error)

--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
 	"github.com/memohai/memoh/internal/accounts"
@@ -179,23 +180,43 @@ func (h *SessionHandler) ListSessions(c echo.Context) error {
 		return err
 	}
 
-	var sessions []session.Session
+	var (
+		sessions     []session.Session
+		nextCursor   session.SessionCursor
+		hasMorePages bool
+	)
 	if bots.HasPermission(perms, bots.PermissionManage) {
 		sessions, err = h.sessionService.ListByBotPaged(c.Request().Context(), bot.ID, types, cursor, limit)
+		if err == nil && len(sessions) == int(limit) {
+			hasMorePages = true
+			last := sessions[len(sessions)-1]
+			nextCursor = session.SessionCursor{UpdatedAt: last.UpdatedAt, ID: last.ID}
+		}
 	} else {
-		sessions, err = h.sessionService.ListByBotAndCreatedByUserPaged(c.Request().Context(), bot.ID, channelIdentityID, types, cursor, limit)
-		sessions = filterSessionsForPermissions(sessions, channelIdentityID, perms)
+		var preFilter []session.Session
+		preFilter, err = h.sessionService.ListByBotAndCreatedByUserPaged(c.Request().Context(), bot.ID, channelIdentityID, types, cursor, limit)
+		if err == nil {
+			// next_cursor must reflect the DB position to resume from, not the
+			// filter survivorship — otherwise a page whose rows were all
+			// dropped by the permission filter would terminate pagination
+			// while older accessible rows still exist on disk.
+			if len(preFilter) == int(limit) {
+				hasMorePages = true
+				last := preFilter[len(preFilter)-1]
+				nextCursor = session.SessionCursor{UpdatedAt: last.UpdatedAt, ID: last.ID}
+			}
+			sessions = filterSessionsForPermissions(preFilter, channelIdentityID, perms)
+		}
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	nextCursor := ""
-	if len(sessions) == int(limit) && len(sessions) > 0 {
-		last := sessions[len(sessions)-1]
-		nextCursor = encodeSessionCursor(session.SessionCursor{UpdatedAt: last.UpdatedAt, ID: last.ID})
+	encoded := ""
+	if hasMorePages {
+		encoded = encodeSessionCursor(nextCursor)
 	}
-	return c.JSON(http.StatusOK, listSessionsResponse{Items: sessions, NextCursor: nextCursor})
+	return c.JSON(http.StatusOK, listSessionsResponse{Items: sessions, NextCursor: encoded})
 }
 
 // listSessionsResponse is the shape returned by ListSessions.
@@ -275,6 +296,9 @@ func decodeSessionCursor(raw string) (session.SessionCursor, error) {
 	}
 	updatedAt, err := time.Parse(time.RFC3339Nano, parts[0])
 	if err != nil {
+		return session.SessionCursor{}, echo.NewHTTPError(http.StatusBadRequest, "invalid cursor")
+	}
+	if _, err := uuid.Parse(parts[1]); err != nil {
 		return session.SessionCursor{}, echo.NewHTTPError(http.StatusBadRequest, "invalid cursor")
 	}
 	return session.SessionCursor{UpdatedAt: updatedAt, ID: parts[1]}, nil

--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -180,8 +180,10 @@ func (h *SessionHandler) ListSessions(c echo.Context) error {
 		return err
 	}
 
+	// Initialize to an empty slice so an empty page serializes as `"items": []`
+	// rather than `"items": null`, sparing clients a null check.
+	sessions := []session.Session{}
 	var (
-		sessions     []session.Session
 		nextCursor   session.SessionCursor
 		hasMorePages bool
 	)
@@ -203,10 +205,6 @@ func (h *SessionHandler) ListSessions(c echo.Context) error {
 		var preFilter []session.Session
 		preFilter, err = h.sessionService.ListByBotAndCreatedByUserPaged(c.Request().Context(), bot.ID, channelIdentityID, types, cursor, probeLimit)
 		if err == nil {
-			// next_cursor must reflect the DB position to resume from, not the
-			// filter survivorship — otherwise a page whose rows were all
-			// dropped by the permission filter would terminate pagination
-			// while older accessible rows still exist on disk.
 			var page []session.Session
 			page, hasMorePages = trimPagedSessions(preFilter, limit)
 			if hasMorePages {
@@ -230,6 +228,12 @@ func (h *SessionHandler) ListSessions(c echo.Context) error {
 // trimPagedSessions implements the limit+1 has-more probe: if the SQL layer
 // returned the extra row, slice it off and signal hasMore; otherwise the
 // caller has reached the end of the listing and next_cursor must stay empty.
+//
+// The returned page is the slice the caller should derive next_cursor from
+// before any in-memory permission filtering. next_cursor must reflect the DB
+// position to resume from, not filter survivorship — otherwise a page whose
+// rows were all dropped by the permission filter would terminate pagination
+// while older accessible rows still exist on disk.
 func trimPagedSessions(rows []session.Session, limit int64) ([]session.Session, bool) {
 	if int64(len(rows)) > limit {
 		return rows[:limit], true

--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -185,27 +185,35 @@ func (h *SessionHandler) ListSessions(c echo.Context) error {
 		nextCursor   session.SessionCursor
 		hasMorePages bool
 	)
+	// Probe one row past the requested page so we can answer "is there more?"
+	// without forcing the client into a tail request that returns []. The
+	// extra row is sliced off before the response is built.
+	probeLimit := limit + 1
 	if bots.HasPermission(perms, bots.PermissionManage) {
-		sessions, err = h.sessionService.ListByBotPaged(c.Request().Context(), bot.ID, types, cursor, limit)
-		if err == nil && len(sessions) == int(limit) {
-			hasMorePages = true
-			last := sessions[len(sessions)-1]
-			nextCursor = session.SessionCursor{UpdatedAt: last.UpdatedAt, ID: last.ID}
+		var rows []session.Session
+		rows, err = h.sessionService.ListByBotPaged(c.Request().Context(), bot.ID, types, cursor, probeLimit)
+		if err == nil {
+			sessions, hasMorePages = trimPagedSessions(rows, limit)
+			if hasMorePages {
+				last := sessions[len(sessions)-1]
+				nextCursor = session.SessionCursor{UpdatedAt: last.UpdatedAt, ID: last.ID}
+			}
 		}
 	} else {
 		var preFilter []session.Session
-		preFilter, err = h.sessionService.ListByBotAndCreatedByUserPaged(c.Request().Context(), bot.ID, channelIdentityID, types, cursor, limit)
+		preFilter, err = h.sessionService.ListByBotAndCreatedByUserPaged(c.Request().Context(), bot.ID, channelIdentityID, types, cursor, probeLimit)
 		if err == nil {
 			// next_cursor must reflect the DB position to resume from, not the
 			// filter survivorship — otherwise a page whose rows were all
 			// dropped by the permission filter would terminate pagination
 			// while older accessible rows still exist on disk.
-			if len(preFilter) == int(limit) {
-				hasMorePages = true
-				last := preFilter[len(preFilter)-1]
+			var page []session.Session
+			page, hasMorePages = trimPagedSessions(preFilter, limit)
+			if hasMorePages {
+				last := page[len(page)-1]
 				nextCursor = session.SessionCursor{UpdatedAt: last.UpdatedAt, ID: last.ID}
 			}
-			sessions = filterSessionsForPermissions(preFilter, channelIdentityID, perms)
+			sessions = filterSessionsForPermissions(page, channelIdentityID, perms)
 		}
 	}
 	if err != nil {
@@ -219,7 +227,19 @@ func (h *SessionHandler) ListSessions(c echo.Context) error {
 	return c.JSON(http.StatusOK, listSessionsResponse{Items: sessions, NextCursor: encoded})
 }
 
-// listSessionsResponse is the shape returned by ListSessions.
+// trimPagedSessions implements the limit+1 has-more probe: if the SQL layer
+// returned the extra row, slice it off and signal hasMore; otherwise the
+// caller has reached the end of the listing and next_cursor must stay empty.
+func trimPagedSessions(rows []session.Session, limit int64) ([]session.Session, bool) {
+	if int64(len(rows)) > limit {
+		return rows[:limit], true
+	}
+	return rows, false
+}
+
+// listSessionsResponse carries one page of sessions. NextCursor is empty
+// exactly when the caller has reached the end of the listing — clients should
+// stop paging on an empty cursor and never expect a follow-up empty page.
 type listSessionsResponse struct {
 	Items      []session.Session `json:"items"`
 	NextCursor string            `json:"next_cursor"`
@@ -233,9 +253,7 @@ const (
 func parseSessionTypesParam(raw string) ([]string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		out := make([]string, len(session.UserFacingSessionTypes))
-		copy(out, session.UserFacingSessionTypes)
-		return out, nil
+		return session.UserFacingSessionTypes(), nil
 	}
 	parts := strings.Split(raw, ",")
 	out := make([]string, 0, len(parts))
@@ -260,20 +278,19 @@ func parseSessionTypesParam(raw string) ([]string, error) {
 	return out, nil
 }
 
-func parseSessionLimitParam(raw string) (int32, error) {
+func parseSessionLimitParam(raw string) (int64, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return sessionListDefaultLimit, nil
 	}
-	value, err := strconv.Atoi(raw)
+	value, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
 		return 0, echo.NewHTTPError(http.StatusBadRequest, "limit must be an integer")
 	}
 	if value < 1 || value > sessionListMaxLimit {
 		return 0, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("limit must be between 1 and %d", sessionListMaxLimit))
 	}
-	//nolint:gosec // bounded above by sessionListMaxLimit (200), safe for int32.
-	return int32(value), nil
+	return value, nil
 }
 
 // encodeSessionCursor packs the keyset cursor as base64(updated_at|id) where

--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -1,10 +1,14 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -142,7 +146,10 @@ func (h *SessionHandler) CreateSession(c echo.Context) error {
 // @Summary List bot sessions
 // @Tags sessions
 // @Param bot_id path string true "Bot ID"
-// @Success 200 {object} map[string][]session.Session
+// @Param types query string false "Comma-separated session types to include. Defaults to user-facing types (chat,discuss,acp_agent)."
+// @Param limit query int false "Page size (1..200). Defaults to 50."
+// @Param cursor query string false "Opaque cursor returned as next_cursor on a previous page."
+// @Success 200 {object} listSessionsResponse
 // @Failure 400 {object} ErrorResponse
 // @Failure 403 {object} ErrorResponse
 // @Router /bots/{bot_id}/sessions [get].
@@ -159,17 +166,118 @@ func (h *SessionHandler) ListSessions(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	types, err := parseSessionTypesParam(c.QueryParam("types"))
+	if err != nil {
+		return err
+	}
+	limit, err := parseSessionLimitParam(c.QueryParam("limit"))
+	if err != nil {
+		return err
+	}
+	cursor, err := decodeSessionCursor(c.QueryParam("cursor"))
+	if err != nil {
+		return err
+	}
+
 	var sessions []session.Session
 	if bots.HasPermission(perms, bots.PermissionManage) {
-		sessions, err = h.sessionService.ListByBot(c.Request().Context(), bot.ID)
+		sessions, err = h.sessionService.ListByBotPaged(c.Request().Context(), bot.ID, types, cursor, limit)
 	} else {
-		sessions, err = h.sessionService.ListByBotAndCreatedByUser(c.Request().Context(), bot.ID, channelIdentityID)
+		sessions, err = h.sessionService.ListByBotAndCreatedByUserPaged(c.Request().Context(), bot.ID, channelIdentityID, types, cursor, limit)
 		sessions = filterSessionsForPermissions(sessions, channelIdentityID, perms)
 	}
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, map[string]any{"items": sessions})
+
+	nextCursor := ""
+	if len(sessions) == int(limit) && len(sessions) > 0 {
+		last := sessions[len(sessions)-1]
+		nextCursor = encodeSessionCursor(session.SessionCursor{UpdatedAt: last.UpdatedAt, ID: last.ID})
+	}
+	return c.JSON(http.StatusOK, listSessionsResponse{Items: sessions, NextCursor: nextCursor})
+}
+
+// listSessionsResponse is the shape returned by ListSessions.
+type listSessionsResponse struct {
+	Items      []session.Session `json:"items"`
+	NextCursor string            `json:"next_cursor"`
+}
+
+const (
+	sessionListDefaultLimit = 50
+	sessionListMaxLimit     = 200
+)
+
+func parseSessionTypesParam(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		out := make([]string, len(session.UserFacingSessionTypes))
+		copy(out, session.UserFacingSessionTypes)
+		return out, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			continue
+		}
+		if !session.IsKnownType(token) {
+			return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unknown session type %q", token))
+		}
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		out = append(out, token)
+	}
+	if len(out) == 0 {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "types must contain at least one session type")
+	}
+	return out, nil
+}
+
+func parseSessionLimitParam(raw string) (int32, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return sessionListDefaultLimit, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, echo.NewHTTPError(http.StatusBadRequest, "limit must be an integer")
+	}
+	if value < 1 || value > sessionListMaxLimit {
+		return 0, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("limit must be between 1 and %d", sessionListMaxLimit))
+	}
+	//nolint:gosec // bounded above by sessionListMaxLimit (200), safe for int32.
+	return int32(value), nil
+}
+
+func encodeSessionCursor(c session.SessionCursor) string {
+	raw := c.UpdatedAt.UTC().Format(time.RFC3339Nano) + "|" + c.ID
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func decodeSessionCursor(raw string) (session.SessionCursor, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return session.SessionCursor{}, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return session.SessionCursor{}, echo.NewHTTPError(http.StatusBadRequest, "invalid cursor")
+	}
+	parts := strings.SplitN(string(decoded), "|", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return session.SessionCursor{}, echo.NewHTTPError(http.StatusBadRequest, "invalid cursor")
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return session.SessionCursor{}, echo.NewHTTPError(http.StatusBadRequest, "invalid cursor")
+	}
+	return session.SessionCursor{UpdatedAt: updatedAt, ID: parts[1]}, nil
 }
 
 // GetSession godoc

--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -276,6 +276,12 @@ func parseSessionLimitParam(raw string) (int32, error) {
 	return int32(value), nil
 }
 
+// encodeSessionCursor packs the keyset cursor as base64(updated_at|id) where
+// the timestamp is RFC3339Nano. The full nanosecond precision is preserved on
+// the wire and on Postgres, but the SQLite backend compares updated_at at
+// second precision because CURRENT_TIMESTAMP stores it that way — that
+// truncation is intentional and only matters when two rows share the same
+// second, where the id tiebreak in the SQL handles uniqueness.
 func encodeSessionCursor(c session.SessionCursor) string {
 	raw := c.UpdatedAt.UTC().Format(time.RFC3339Nano) + "|" + c.ID
 	return base64.RawURLEncoding.EncodeToString([]byte(raw))

--- a/internal/handlers/session_list_test.go
+++ b/internal/handlers/session_list_test.go
@@ -246,6 +246,24 @@ func TestListSessionsOmitsNextCursorOnShortPage(t *testing.T) {
 	}
 }
 
+// TestListSessionsEmptyResultSerializesAsEmptyArray pins down that an empty
+// page renders as `"items": []` rather than `"items": null`. Clients iterate
+// the field directly and a null value would crash strict decoders.
+func TestListSessionsEmptyResultSerializesAsEmptyArray(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
+	handler := newListSessionHandler(t, queries)
+
+	rec, err := callListSessions(handler, botID, "")
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"items":[]`) {
+		t.Fatalf("empty page body = %s, want items rendered as []", body)
+	}
+}
+
 func TestListSessionsRejectsMalformedCursor(t *testing.T) {
 	botID := "11111111-1111-1111-1111-111111111111"
 	queries := &sessionListQueries{bot: testBotRow(botID, nil)}

--- a/internal/handlers/session_list_test.go
+++ b/internal/handlers/session_list_test.go
@@ -111,13 +111,13 @@ func TestListSessionsDefaultsToUserFacingTypes(t *testing.T) {
 	}
 	got := append([]string(nil), queries.pagedCall.Types...)
 	sort.Strings(got)
-	want := append([]string(nil), session.UserFacingSessionTypes...)
+	want := session.UserFacingSessionTypes()
 	sort.Strings(want)
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("default types = %v, want %v", got, want)
 	}
-	if queries.pagedCall.LimitCount != sessionListDefaultLimit {
-		t.Fatalf("default limit = %d, want %d", queries.pagedCall.LimitCount, sessionListDefaultLimit)
+	if queries.pagedCall.LimitCount != sessionListDefaultLimit+1 {
+		t.Fatalf("default limit = %d, want %d (default+1 has-more probe)", queries.pagedCall.LimitCount, sessionListDefaultLimit+1)
 	}
 	if queries.pagedCall.UseCursor {
 		t.Fatalf("UseCursor should be false when no cursor was supplied")
@@ -169,8 +169,8 @@ func TestListSessionsClampsLimit(t *testing.T) {
 	if _, err := callListSessions(handler, botID, "limit=10"); err != nil {
 		t.Fatalf("ListSessions() error = %v", err)
 	}
-	if queries.pagedCall.LimitCount != 10 {
-		t.Fatalf("limit = %d, want 10", queries.pagedCall.LimitCount)
+	if queries.pagedCall.LimitCount != 11 {
+		t.Fatalf("limit = %d, want 11 (request+1 has-more probe)", queries.pagedCall.LimitCount)
 	}
 }
 
@@ -178,15 +178,20 @@ func TestListSessionsCursorRoundTrip(t *testing.T) {
 	botID := "11111111-1111-1111-1111-111111111111"
 	rowUpdated := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
 	rowID := "33333333-3333-3333-3333-333333333333"
+	// The handler probes one row past `limit` to detect "has more". Returning
+	// two rows for a limit=1 request stands in for "the DB has more rows" and
+	// drives the cursor down the round-trip path.
 	queries := &sessionListQueries{
 		bot: testBotRow(botID, nil),
 		pagedRows: []sqlc.ListSessionsByBotPagedRow{
 			pagedRow(rowID, rowUpdated),
+			pagedRow("44444444-4444-4444-4444-444444444444", rowUpdated.Add(-time.Minute)),
 		},
 	}
 	handler := newListSessionHandler(t, queries)
 
-	// With limit=1 and 1 returned row, next_cursor must point at the last row.
+	// With limit=1 and 2 returned rows, next_cursor must point at the last
+	// kept row (the probe row is sliced off).
 	rec, err := callListSessions(handler, botID, "limit=1")
 	if err != nil {
 		t.Fatalf("ListSessions() error = %v", err)
@@ -286,10 +291,13 @@ func TestListSessionsCursorNotTruncatedByPermissionFilter(t *testing.T) {
 	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
 	// limit=2 page where the first row is the user's chat session and the
 	// second row is a discuss session created by the same user that the
-	// permission filter discards.
+	// permission filter discards. The third row is the has-more probe — its
+	// id is what the cursor must surface so pagination resumes from the DB
+	// position rather than the post-filter survivorship.
 	queries.userPagedRows = []sqlc.ListSessionsByBotAndCreatedByUserPagedRow{
 		userPagedRow(keptID, userID, session.TypeChat, rowUpdated.Add(2*time.Minute)),
 		userPagedRow(droppedID, userID, session.TypeDiscuss, rowUpdated),
+		userPagedRow("44444444-4444-4444-4444-444444444444", userID, session.TypeChat, rowUpdated.Add(-time.Minute)),
 	}
 
 	handler := NewSessionHandler(

--- a/internal/handlers/session_list_test.go
+++ b/internal/handlers/session_list_test.go
@@ -57,7 +57,7 @@ func (q *sessionListQueries) ListSessionsByBotAndCreatedByUserPaged(_ context.Co
 // default response grants `chat`, which is enough for the list endpoint to
 // authorize but not enough to read `discuss` sessions — exactly the shape
 // needed to exercise the post-filter cursor path.
-func (q *sessionListQueries) ListBotUserGrantsForUser(_ context.Context, _ sqlc.ListBotUserGrantsForUserParams) ([]sqlc.ListBotUserGrantsForUserRow, error) {
+func (*sessionListQueries) ListBotUserGrantsForUser(_ context.Context, _ sqlc.ListBotUserGrantsForUserParams) ([]sqlc.ListBotUserGrantsForUserRow, error) {
 	return []sqlc.ListBotUserGrantsForUserRow{
 		{Permissions: []byte(`["chat"]`)},
 	}, nil

--- a/internal/handlers/session_list_test.go
+++ b/internal/handlers/session_list_test.go
@@ -1,0 +1,256 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/labstack/echo/v4"
+
+	"github.com/memohai/memoh/internal/bots"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/session"
+)
+
+// sessionListQueries records the arguments passed to the paged list queries
+// and returns a configurable canned page so tests can assert filter and cursor
+// behavior without a real database.
+type sessionListQueries struct {
+	dbstore.Queries
+	bot                sqlc.GetBotByIDRow
+	pagedCall          sqlc.ListSessionsByBotPagedParams
+	pagedCallCount     int
+	pagedRows          []sqlc.ListSessionsByBotPagedRow
+	userPagedCall      sqlc.ListSessionsByBotAndCreatedByUserPagedParams
+	userPagedCallCount int
+	userPagedRows      []sqlc.ListSessionsByBotAndCreatedByUserPagedRow
+}
+
+func (q *sessionListQueries) GetBotByID(_ context.Context, _ pgtype.UUID) (sqlc.GetBotByIDRow, error) {
+	return q.bot, nil
+}
+
+func (q *sessionListQueries) ListSessionsByBotPaged(_ context.Context, arg sqlc.ListSessionsByBotPagedParams) ([]sqlc.ListSessionsByBotPagedRow, error) {
+	q.pagedCall = arg
+	q.pagedCallCount++
+	return q.pagedRows, nil
+}
+
+func (q *sessionListQueries) ListSessionsByBotAndCreatedByUserPaged(_ context.Context, arg sqlc.ListSessionsByBotAndCreatedByUserPagedParams) ([]sqlc.ListSessionsByBotAndCreatedByUserPagedRow, error) {
+	q.userPagedCall = arg
+	q.userPagedCallCount++
+	return q.userPagedRows, nil
+}
+
+func newListSessionHandler(t *testing.T, queries *sessionListQueries) *SessionHandler {
+	t.Helper()
+	return NewSessionHandler(
+		slog.Default(),
+		session.NewService(nil, queries),
+		nil,
+		bots.NewService(nil, queries),
+		newTestAdminAccountService("admin"),
+	)
+}
+
+func callListSessions(handler *SessionHandler, botID, rawQuery string) (*httptest.ResponseRecorder, error) {
+	e := echo.New()
+	target := "/bots/" + botID + "/sessions"
+	if rawQuery != "" {
+		target += "?" + rawQuery
+	}
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	ctx := testAuthContext(e, req, rec, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	ctx.SetPath("/bots/:bot_id/sessions")
+	ctx.SetParamNames("bot_id")
+	ctx.SetParamValues(botID)
+	return rec, handler.ListSessions(ctx)
+}
+
+func decodeListResponse(t *testing.T, rec *httptest.ResponseRecorder) listSessionsResponse {
+	t.Helper()
+	var resp listSessionsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+func TestListSessionsDefaultsToUserFacingTypes(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
+	handler := newListSessionHandler(t, queries)
+
+	if _, err := callListSessions(handler, botID, ""); err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if queries.pagedCallCount != 1 {
+		t.Fatalf("ListSessionsByBotPaged called %d times, want 1", queries.pagedCallCount)
+	}
+	got := append([]string(nil), queries.pagedCall.Types...)
+	sort.Strings(got)
+	want := append([]string(nil), session.UserFacingSessionTypes...)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("default types = %v, want %v", got, want)
+	}
+	if queries.pagedCall.LimitCount != sessionListDefaultLimit {
+		t.Fatalf("default limit = %d, want %d", queries.pagedCall.LimitCount, sessionListDefaultLimit)
+	}
+	if queries.pagedCall.UseCursor {
+		t.Fatalf("UseCursor should be false when no cursor was supplied")
+	}
+}
+
+func TestListSessionsPassesExplicitTypesFilter(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
+	handler := newListSessionHandler(t, queries)
+
+	if _, err := callListSessions(handler, botID, "types=chat,discuss"); err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if got := strings.Join(queries.pagedCall.Types, ","); got != "chat,discuss" {
+		t.Fatalf("types filter = %q, want %q", got, "chat,discuss")
+	}
+}
+
+func TestListSessionsRejectsUnknownType(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
+	handler := newListSessionHandler(t, queries)
+
+	_, err := callListSessions(handler, botID, "types=chat,bogus")
+	var httpErr *echo.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest {
+		t.Fatalf("ListSessions() error = %v, want HTTP 400", err)
+	}
+	if queries.pagedCallCount != 0 {
+		t.Fatalf("query should not run when types validation fails")
+	}
+}
+
+func TestListSessionsClampsLimit(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
+	handler := newListSessionHandler(t, queries)
+
+	if _, err := callListSessions(handler, botID, "limit=500"); err == nil {
+		t.Fatalf("expected limit out of range to return an error")
+	}
+	if _, err := callListSessions(handler, botID, "limit=0"); err == nil {
+		t.Fatalf("expected limit=0 to return an error")
+	}
+	if _, err := callListSessions(handler, botID, "limit=not-a-number"); err == nil {
+		t.Fatalf("expected non-integer limit to return an error")
+	}
+	if _, err := callListSessions(handler, botID, "limit=10"); err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if queries.pagedCall.LimitCount != 10 {
+		t.Fatalf("limit = %d, want 10", queries.pagedCall.LimitCount)
+	}
+}
+
+func TestListSessionsCursorRoundTrip(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	rowUpdated := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	rowID := "33333333-3333-3333-3333-333333333333"
+	queries := &sessionListQueries{
+		bot: testBotRow(botID, nil),
+		pagedRows: []sqlc.ListSessionsByBotPagedRow{
+			pagedRow(rowID, rowUpdated),
+		},
+	}
+	handler := newListSessionHandler(t, queries)
+
+	// With limit=1 and 1 returned row, next_cursor must point at the last row.
+	rec, err := callListSessions(handler, botID, "limit=1")
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	resp := decodeListResponse(t, rec)
+	if resp.NextCursor == "" {
+		t.Fatalf("expected next_cursor when page is full")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(resp.NextCursor)
+	if err != nil {
+		t.Fatalf("decode cursor: %v", err)
+	}
+	parts := strings.SplitN(string(decoded), "|", 2)
+	if len(parts) != 2 || parts[1] != rowID {
+		t.Fatalf("cursor payload = %q, want trailing id %s", string(decoded), rowID)
+	}
+
+	// Round-trip the cursor back in; the handler must decode it and forward
+	// the parsed values to the query layer.
+	queries.pagedCall = sqlc.ListSessionsByBotPagedParams{}
+	if _, err := callListSessions(handler, botID, "limit=1&cursor="+url.QueryEscape(resp.NextCursor)); err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if !queries.pagedCall.UseCursor {
+		t.Fatalf("UseCursor should be true when a cursor was supplied")
+	}
+	if !queries.pagedCall.CursorUpdatedAt.Time.Equal(rowUpdated) {
+		t.Fatalf("CursorUpdatedAt = %v, want %v", queries.pagedCall.CursorUpdatedAt.Time, rowUpdated)
+	}
+	if queries.pagedCall.CursorID.String() != rowID {
+		t.Fatalf("CursorID = %s, want %s", queries.pagedCall.CursorID.String(), rowID)
+	}
+}
+
+func TestListSessionsOmitsNextCursorOnShortPage(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	queries := &sessionListQueries{
+		bot: testBotRow(botID, nil),
+		pagedRows: []sqlc.ListSessionsByBotPagedRow{
+			pagedRow("33333333-3333-3333-3333-333333333333", time.Now()),
+		},
+	}
+	handler := newListSessionHandler(t, queries)
+
+	rec, err := callListSessions(handler, botID, "limit=10")
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	resp := decodeListResponse(t, rec)
+	if resp.NextCursor != "" {
+		t.Fatalf("next_cursor = %q, want empty when page is not full", resp.NextCursor)
+	}
+}
+
+func TestListSessionsRejectsMalformedCursor(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
+	handler := newListSessionHandler(t, queries)
+
+	_, err := callListSessions(handler, botID, "cursor=not%20base64%21")
+	var httpErr *echo.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest {
+		t.Fatalf("ListSessions() error = %v, want HTTP 400", err)
+	}
+}
+
+func pagedRow(id string, updatedAt time.Time) sqlc.ListSessionsByBotPagedRow {
+	return sqlc.ListSessionsByBotPagedRow{
+		ID:        testUUID(id),
+		BotID:     testUUID("11111111-1111-1111-1111-111111111111"),
+		Type:      session.TypeChat,
+		Title:     "test session",
+		Metadata:  []byte(`{}`),
+		CreatedAt: pgtype.Timestamptz{Time: updatedAt, Valid: true},
+		UpdatedAt: pgtype.Timestamptz{Time: updatedAt, Valid: true},
+	}
+}

--- a/internal/handlers/session_list_test.go
+++ b/internal/handlers/session_list_test.go
@@ -53,6 +53,16 @@ func (q *sessionListQueries) ListSessionsByBotAndCreatedByUserPaged(_ context.Co
 	return q.userPagedRows, nil
 }
 
+// ListBotUserGrantsForUser feeds the non-admin permission resolver. The
+// default response grants `chat`, which is enough for the list endpoint to
+// authorize but not enough to read `discuss` sessions — exactly the shape
+// needed to exercise the post-filter cursor path.
+func (q *sessionListQueries) ListBotUserGrantsForUser(_ context.Context, _ sqlc.ListBotUserGrantsForUserParams) ([]sqlc.ListBotUserGrantsForUserRow, error) {
+	return []sqlc.ListBotUserGrantsForUserRow{
+		{Permissions: []byte(`["chat"]`)},
+	}, nil
+}
+
 func newListSessionHandler(t *testing.T, queries *sessionListQueries) *SessionHandler {
 	t.Helper()
 	return NewSessionHandler(
@@ -240,6 +250,91 @@ func TestListSessionsRejectsMalformedCursor(t *testing.T) {
 	var httpErr *echo.HTTPError
 	if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest {
 		t.Fatalf("ListSessions() error = %v, want HTTP 400", err)
+	}
+}
+
+// TestListSessionsRejectsCursorWithBadUUID guards against a cursor whose
+// timestamp portion parses but whose UUID portion does not. Without this
+// guard the malformed UUID would surface as a 500 from the service layer
+// instead of a 400 from the cursor decoder.
+func TestListSessionsRejectsCursorWithBadUUID(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
+	handler := newListSessionHandler(t, queries)
+
+	cursor := base64.RawURLEncoding.EncodeToString([]byte("2026-06-19T00:00:00Z|not-a-uuid"))
+	_, err := callListSessions(handler, botID, "cursor="+url.QueryEscape(cursor))
+	var httpErr *echo.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest {
+		t.Fatalf("ListSessions() error = %v, want HTTP 400", err)
+	}
+}
+
+// TestListSessionsCursorNotTruncatedByPermissionFilter pins down that
+// `next_cursor` reflects the database's resume position rather than the
+// post-filter survivorship. If the permission filter drops every row on a
+// full DB page, pagination must still surface a cursor — otherwise the
+// caller would silently stop walking at the first inaccessible page even
+// though older accessible rows remain on disk.
+func TestListSessionsCursorNotTruncatedByPermissionFilter(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	userID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	rowUpdated := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	keptID := "22222222-2222-2222-2222-222222222222"
+	droppedID := "33333333-3333-3333-3333-333333333333"
+
+	queries := &sessionListQueries{bot: testBotRow(botID, nil)}
+	// limit=2 page where the first row is the user's chat session and the
+	// second row is a discuss session created by the same user that the
+	// permission filter discards.
+	queries.userPagedRows = []sqlc.ListSessionsByBotAndCreatedByUserPagedRow{
+		userPagedRow(keptID, userID, session.TypeChat, rowUpdated.Add(2*time.Minute)),
+		userPagedRow(droppedID, userID, session.TypeDiscuss, rowUpdated),
+	}
+
+	handler := NewSessionHandler(
+		slog.Default(),
+		session.NewService(nil, queries),
+		nil,
+		bots.NewService(nil, queries),
+		newTestAdminAccountService("user"),
+	)
+
+	rec, err := callListSessions(handler, botID, "limit=2")
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	resp := decodeListResponse(t, rec)
+	if len(resp.Items) != 1 || resp.Items[0].ID != keptID {
+		ids := make([]string, len(resp.Items))
+		for i, item := range resp.Items {
+			ids[i] = item.ID
+		}
+		t.Fatalf("filtered items = %v, want only %s", ids, keptID)
+	}
+	if resp.NextCursor == "" {
+		t.Fatalf("expected next_cursor when DB returned a full page, even though the filter trimmed it")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(resp.NextCursor)
+	if err != nil {
+		t.Fatalf("decode cursor: %v", err)
+	}
+	parts := strings.SplitN(string(decoded), "|", 2)
+	if len(parts) != 2 || parts[1] != droppedID {
+		t.Fatalf("cursor payload = %q, want trailing dropped row id %s", string(decoded), droppedID)
+	}
+}
+
+func userPagedRow(id, userID, typ string, updatedAt time.Time) sqlc.ListSessionsByBotAndCreatedByUserPagedRow {
+	return sqlc.ListSessionsByBotAndCreatedByUserPagedRow{
+		ID:              testUUID(id),
+		BotID:           testUUID("11111111-1111-1111-1111-111111111111"),
+		Type:            typ,
+		Title:           "test session",
+		Metadata:        []byte(`{}`),
+		CreatedByUserID: testUUID(userID),
+		CreatedAt:       pgtype.Timestamptz{Time: updatedAt, Valid: true},
+		UpdatedAt:       pgtype.Timestamptz{Time: updatedAt, Valid: true},
 	}
 }
 

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -46,6 +46,11 @@ const (
 	DefaultACPProjectPath = "/data"
 )
 
+// UserFacingSessionTypes lists the session types intended to appear in
+// user-facing session lists. Heartbeat, schedule, and subagent sessions are
+// system-internal — they back agent-driven loops and never surface in the UI.
+var UserFacingSessionTypes = []string{TypeChat, TypeDiscuss, TypeACPAgent}
+
 var (
 	ErrACPAgentIDRequired    = errors.New("acp_agent_id is required for acp_agent sessions")
 	ErrACPProjectPathMissing = errors.New("project_path is required for acp_agent sessions")
@@ -56,6 +61,17 @@ var (
 func IsKnownType(typ string) bool {
 	switch strings.TrimSpace(typ) {
 	case TypeChat, TypeHeartbeat, TypeSchedule, TypeSubagent, TypeDiscuss, TypeACPAgent:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsUserFacingType reports whether a session type is one that user-facing
+// session list endpoints should return by default.
+func IsUserFacingType(typ string) bool {
+	switch strings.TrimSpace(typ) {
+	case TypeChat, TypeDiscuss, TypeACPAgent:
 		return true
 	default:
 		return false
@@ -264,6 +280,91 @@ func (s *Service) ListByBot(ctx context.Context, botID string) ([]Session, error
 		sessions = append(sessions, toSessionFromListRow(row))
 	}
 	return sessions, nil
+}
+
+// SessionCursor identifies the position in a session listing for keyset
+// pagination. The zero value means "start from the head".
+type SessionCursor struct {
+	UpdatedAt time.Time
+	ID        string
+}
+
+// IsZero reports whether the cursor is the zero value (i.e. no cursor).
+func (c SessionCursor) IsZero() bool {
+	return c.ID == "" && c.UpdatedAt.IsZero()
+}
+
+// ListByBotPaged returns one page of sessions for a bot, filtered to the given
+// types and starting after the given cursor.
+func (s *Service) ListByBotPaged(ctx context.Context, botID string, types []string, cursor SessionCursor, limit int32) ([]Session, error) {
+	pgBotID, err := dbpkg.ParseUUID(botID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid bot id: %w", err)
+	}
+	cursorUpdatedAt, cursorID, useCursor, err := pagedCursorParams(cursor)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.queries.ListSessionsByBotPaged(ctx, sqlc.ListSessionsByBotPagedParams{
+		BotID:           pgBotID,
+		Types:           types,
+		UseCursor:       useCursor,
+		CursorUpdatedAt: cursorUpdatedAt,
+		CursorID:        cursorID,
+		LimitCount:      limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sessions := make([]Session, 0, len(rows))
+	for _, row := range rows {
+		sessions = append(sessions, toSessionFromPagedRow(row))
+	}
+	return sessions, nil
+}
+
+// ListByBotAndCreatedByUserPaged is the paged variant scoped to a single user.
+func (s *Service) ListByBotAndCreatedByUserPaged(ctx context.Context, botID, userID string, types []string, cursor SessionCursor, limit int32) ([]Session, error) {
+	pgBotID, err := dbpkg.ParseUUID(botID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid bot id: %w", err)
+	}
+	pgUserID, err := dbpkg.ParseUUID(userID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user id: %w", err)
+	}
+	cursorUpdatedAt, cursorID, useCursor, err := pagedCursorParams(cursor)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.queries.ListSessionsByBotAndCreatedByUserPaged(ctx, sqlc.ListSessionsByBotAndCreatedByUserPagedParams{
+		BotID:           pgBotID,
+		CreatedByUserID: pgUserID,
+		Types:           types,
+		UseCursor:       useCursor,
+		CursorUpdatedAt: cursorUpdatedAt,
+		CursorID:        cursorID,
+		LimitCount:      limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sessions := make([]Session, 0, len(rows))
+	for _, row := range rows {
+		sessions = append(sessions, toSessionFromUserPagedRow(row))
+	}
+	return sessions, nil
+}
+
+func pagedCursorParams(cursor SessionCursor) (pgtype.Timestamptz, pgtype.UUID, bool, error) {
+	if cursor.IsZero() {
+		return pgtype.Timestamptz{}, pgtype.UUID{}, false, nil
+	}
+	pgID, err := dbpkg.ParseUUID(cursor.ID)
+	if err != nil {
+		return pgtype.Timestamptz{}, pgtype.UUID{}, false, fmt.Errorf("invalid cursor id: %w", err)
+	}
+	return pgtype.Timestamptz{Time: cursor.UpdatedAt, Valid: true}, pgID, true, nil
 }
 
 // ListByBotAndCreatedByUser returns all active sessions for a bot created by a user.
@@ -580,6 +681,58 @@ func toSessionFromListRow(row sqlc.ListSessionsByBotRow) Session {
 }
 
 func toSessionFromUserListRow(row sqlc.ListSessionsByBotAndCreatedByUserRow) Session {
+	parentID := ""
+	if row.ParentSessionID.Valid {
+		parentID = row.ParentSessionID.String()
+	}
+	createdByUserID := ""
+	if row.CreatedByUserID.Valid {
+		createdByUserID = row.CreatedByUserID.String()
+	}
+	return Session{
+		ID:                    row.ID.String(),
+		BotID:                 row.BotID.String(),
+		RouteID:               row.RouteID.String(),
+		ChannelType:           dbpkg.TextToString(row.ChannelType),
+		Type:                  row.Type,
+		Title:                 row.Title,
+		Metadata:              parseJSONMap(row.Metadata),
+		ParentSessionID:       parentID,
+		CreatedByUserID:       createdByUserID,
+		CreatedAt:             row.CreatedAt.Time,
+		UpdatedAt:             row.UpdatedAt.Time,
+		RouteMetadata:         parseJSONMap(row.RouteMetadata),
+		RouteConversationType: dbpkg.TextToString(row.RouteConversationType),
+	}
+}
+
+func toSessionFromPagedRow(row sqlc.ListSessionsByBotPagedRow) Session {
+	parentID := ""
+	if row.ParentSessionID.Valid {
+		parentID = row.ParentSessionID.String()
+	}
+	createdByUserID := ""
+	if row.CreatedByUserID.Valid {
+		createdByUserID = row.CreatedByUserID.String()
+	}
+	return Session{
+		ID:                    row.ID.String(),
+		BotID:                 row.BotID.String(),
+		RouteID:               row.RouteID.String(),
+		ChannelType:           dbpkg.TextToString(row.ChannelType),
+		Type:                  row.Type,
+		Title:                 row.Title,
+		Metadata:              parseJSONMap(row.Metadata),
+		ParentSessionID:       parentID,
+		CreatedByUserID:       createdByUserID,
+		CreatedAt:             row.CreatedAt.Time,
+		UpdatedAt:             row.UpdatedAt.Time,
+		RouteMetadata:         parseJSONMap(row.RouteMetadata),
+		RouteConversationType: dbpkg.TextToString(row.RouteConversationType),
+	}
+}
+
+func toSessionFromUserPagedRow(row sqlc.ListSessionsByBotAndCreatedByUserPagedRow) Session {
 	parentID := ""
 	if row.ParentSessionID.Valid {
 		parentID = row.ParentSessionID.String()

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -285,9 +285,14 @@ type SessionCursor struct {
 	ID        string
 }
 
-// IsZero reports whether the cursor is the zero value (i.e. no cursor).
+// IsZero reports whether the cursor is missing either half and so cannot
+// position a keyset query. We treat a partially-constructed cursor (only the
+// timestamp or only the id set) the same as the zero value: the handler
+// decoder rejects empty halves already, but internal callers that build a
+// cursor by hand should also be funneled down the no-cursor path rather than
+// silently feeding malformed bindings to pagedCursorParams.
 func (c SessionCursor) IsZero() bool {
-	return c.ID == "" && c.UpdatedAt.IsZero()
+	return c.ID == "" || c.UpdatedAt.IsZero()
 }
 
 // ListByBotPaged returns one page of sessions for a bot, filtered to the given

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"slices"
 	"strings"
 	"time"
@@ -47,10 +48,19 @@ const (
 	DefaultACPProjectPath = "/data"
 )
 
-// UserFacingSessionTypes lists the session types intended to appear in
+// userFacingSessionTypes lists the session types intended to appear in
 // user-facing session lists. Heartbeat, schedule, and subagent sessions are
 // system-internal — they back agent-driven loops and never surface in the UI.
-var UserFacingSessionTypes = []string{TypeChat, TypeDiscuss, TypeACPAgent}
+var userFacingSessionTypes = []string{TypeChat, TypeDiscuss, TypeACPAgent}
+
+// UserFacingSessionTypes returns a fresh copy of the user-facing session type
+// list so callers can read or mutate it without disturbing the package-level
+// source of truth.
+func UserFacingSessionTypes() []string {
+	out := make([]string, len(userFacingSessionTypes))
+	copy(out, userFacingSessionTypes)
+	return out
+}
 
 var (
 	ErrACPAgentIDRequired    = errors.New("acp_agent_id is required for acp_agent sessions")
@@ -71,7 +81,7 @@ func IsKnownType(typ string) bool {
 // IsUserFacingType reports whether a session type is one that user-facing
 // session list endpoints should return by default.
 func IsUserFacingType(typ string) bool {
-	return slices.Contains(UserFacingSessionTypes, strings.TrimSpace(typ))
+	return slices.Contains(userFacingSessionTypes, strings.TrimSpace(typ))
 }
 
 // CreateInput holds input for creating a new session.
@@ -285,24 +295,28 @@ type SessionCursor struct {
 	ID        string
 }
 
-// IsZero reports whether the cursor is missing either half and so cannot
-// position a keyset query. We treat a partially-constructed cursor (only the
-// timestamp or only the id set) the same as the zero value: the handler
-// decoder rejects empty halves already, but internal callers that build a
-// cursor by hand should also be funneled down the no-cursor path rather than
-// silently feeding malformed bindings to pagedCursorParams.
+// IsZero reports whether the cursor carries neither half — the start-of-list
+// signal that pagedCursorParams maps to "no cursor predicate". A
+// partially-populated cursor (only the timestamp or only the id) is not zero;
+// pagedCursorParams rejects it as a programmer error so we never send
+// malformed bindings down to SQL.
 func (c SessionCursor) IsZero() bool {
-	return c.ID == "" || c.UpdatedAt.IsZero()
+	return c.ID == "" && c.UpdatedAt.IsZero()
 }
 
 // ListByBotPaged returns one page of sessions for a bot, filtered to the given
-// types and starting after the given cursor.
-func (s *Service) ListByBotPaged(ctx context.Context, botID string, types []string, cursor SessionCursor, limit int32) ([]Session, error) {
+// types and starting after the given cursor. Callers that want a "has more"
+// signal pass limit+1 and look for an extra row.
+func (s *Service) ListByBotPaged(ctx context.Context, botID string, types []string, cursor SessionCursor, limit int64) ([]Session, error) {
 	pgBotID, err := dbpkg.ParseUUID(botID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid bot id: %w", err)
 	}
 	cursorUpdatedAt, cursorID, useCursor, err := pagedCursorParams(cursor)
+	if err != nil {
+		return nil, err
+	}
+	limitParam, err := pagedLimitToInt32(limit)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +326,7 @@ func (s *Service) ListByBotPaged(ctx context.Context, botID string, types []stri
 		UseCursor:       useCursor,
 		CursorUpdatedAt: cursorUpdatedAt,
 		CursorID:        cursorID,
-		LimitCount:      limit,
+		LimitCount:      limitParam,
 	})
 	if err != nil {
 		return nil, err
@@ -325,7 +339,7 @@ func (s *Service) ListByBotPaged(ctx context.Context, botID string, types []stri
 }
 
 // ListByBotAndCreatedByUserPaged is the paged variant scoped to a single user.
-func (s *Service) ListByBotAndCreatedByUserPaged(ctx context.Context, botID, userID string, types []string, cursor SessionCursor, limit int32) ([]Session, error) {
+func (s *Service) ListByBotAndCreatedByUserPaged(ctx context.Context, botID, userID string, types []string, cursor SessionCursor, limit int64) ([]Session, error) {
 	pgBotID, err := dbpkg.ParseUUID(botID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid bot id: %w", err)
@@ -338,6 +352,10 @@ func (s *Service) ListByBotAndCreatedByUserPaged(ctx context.Context, botID, use
 	if err != nil {
 		return nil, err
 	}
+	limitParam, err := pagedLimitToInt32(limit)
+	if err != nil {
+		return nil, err
+	}
 	rows, err := s.queries.ListSessionsByBotAndCreatedByUserPaged(ctx, sqlc.ListSessionsByBotAndCreatedByUserPagedParams{
 		BotID:           pgBotID,
 		CreatedByUserID: pgUserID,
@@ -345,7 +363,7 @@ func (s *Service) ListByBotAndCreatedByUserPaged(ctx context.Context, botID, use
 		UseCursor:       useCursor,
 		CursorUpdatedAt: cursorUpdatedAt,
 		CursorID:        cursorID,
-		LimitCount:      limit,
+		LimitCount:      limitParam,
 	})
 	if err != nil {
 		return nil, err
@@ -357,9 +375,28 @@ func (s *Service) ListByBotAndCreatedByUserPaged(ctx context.Context, botID, use
 	return sessions, nil
 }
 
+// pagedLimitToInt32 narrows the int64 page-size that flows through the
+// service signatures into the int32 sqlc binds. The handler caps the user-
+// supplied limit at sessionListMaxLimit and bumps it by one for the
+// has-more probe; both fit in int32 by construction, so any out-of-range value
+// here is a programmer error and surfaces as such.
+func pagedLimitToInt32(limit int64) (int32, error) {
+	if limit < 1 || limit > math.MaxInt32 {
+		return 0, fmt.Errorf("session: paged limit %d is out of range", limit)
+	}
+	return int32(limit), nil
+}
+
 func pagedCursorParams(cursor SessionCursor) (pgtype.Timestamptz, pgtype.UUID, bool, error) {
 	if cursor.IsZero() {
 		return pgtype.Timestamptz{}, pgtype.UUID{}, false, nil
+	}
+	if cursor.ID == "" || cursor.UpdatedAt.IsZero() {
+		// The handler-side decoder rejects half-built cursors as 400, so by the
+		// time we get here a partial cursor is an internal-construction bug.
+		// Surface it loudly rather than silently restarting from the head and
+		// returning a duplicate page.
+		return pgtype.Timestamptz{}, pgtype.UUID{}, false, errors.New("session: cursor must carry both updated_at and id")
 	}
 	pgID, err := dbpkg.ParseUUID(cursor.ID)
 	if err != nil {

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -70,12 +71,7 @@ func IsKnownType(typ string) bool {
 // IsUserFacingType reports whether a session type is one that user-facing
 // session list endpoints should return by default.
 func IsUserFacingType(typ string) bool {
-	switch strings.TrimSpace(typ) {
-	case TypeChat, TypeDiscuss, TypeACPAgent:
-		return true
-	default:
-		return false
-	}
+	return slices.Contains(UserFacingSessionTypes, strings.TrimSpace(typ))
 }
 
 // CreateInput holds input for creating a new session.
@@ -707,53 +703,67 @@ func toSessionFromUserListRow(row sqlc.ListSessionsByBotAndCreatedByUserRow) Ses
 }
 
 func toSessionFromPagedRow(row sqlc.ListSessionsByBotPagedRow) Session {
-	parentID := ""
-	if row.ParentSessionID.Valid {
-		parentID = row.ParentSessionID.String()
-	}
-	createdByUserID := ""
-	if row.CreatedByUserID.Valid {
-		createdByUserID = row.CreatedByUserID.String()
-	}
-	return Session{
-		ID:                    row.ID.String(),
-		BotID:                 row.BotID.String(),
-		RouteID:               row.RouteID.String(),
-		ChannelType:           dbpkg.TextToString(row.ChannelType),
-		Type:                  row.Type,
-		Title:                 row.Title,
-		Metadata:              parseJSONMap(row.Metadata),
-		ParentSessionID:       parentID,
-		CreatedByUserID:       createdByUserID,
-		CreatedAt:             row.CreatedAt.Time,
-		UpdatedAt:             row.UpdatedAt.Time,
-		RouteMetadata:         parseJSONMap(row.RouteMetadata),
-		RouteConversationType: dbpkg.TextToString(row.RouteConversationType),
-	}
+	return sessionFromPagedColumns(pagedColumns{
+		ID: row.ID, BotID: row.BotID, RouteID: row.RouteID, ChannelType: row.ChannelType,
+		Type: row.Type, Title: row.Title, Metadata: row.Metadata,
+		ParentSessionID: row.ParentSessionID, CreatedByUserID: row.CreatedByUserID,
+		CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt,
+		RouteMetadata: row.RouteMetadata, RouteConversationType: row.RouteConversationType,
+	})
 }
 
 func toSessionFromUserPagedRow(row sqlc.ListSessionsByBotAndCreatedByUserPagedRow) Session {
+	return sessionFromPagedColumns(pagedColumns{
+		ID: row.ID, BotID: row.BotID, RouteID: row.RouteID, ChannelType: row.ChannelType,
+		Type: row.Type, Title: row.Title, Metadata: row.Metadata,
+		ParentSessionID: row.ParentSessionID, CreatedByUserID: row.CreatedByUserID,
+		CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt,
+		RouteMetadata: row.RouteMetadata, RouteConversationType: row.RouteConversationType,
+	})
+}
+
+// pagedColumns is the shared shape of the bot/route-joined session row
+// returned by both paged list queries. The two sqlc-generated row structs
+// happen to be structurally identical; centralizing the projection here
+// keeps the conversion logic in one place.
+type pagedColumns struct {
+	ID                    pgtype.UUID
+	BotID                 pgtype.UUID
+	RouteID               pgtype.UUID
+	ChannelType           pgtype.Text
+	Type                  string
+	Title                 string
+	Metadata              []byte
+	ParentSessionID       pgtype.UUID
+	CreatedByUserID       pgtype.UUID
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+	RouteMetadata         []byte
+	RouteConversationType pgtype.Text
+}
+
+func sessionFromPagedColumns(c pagedColumns) Session {
 	parentID := ""
-	if row.ParentSessionID.Valid {
-		parentID = row.ParentSessionID.String()
+	if c.ParentSessionID.Valid {
+		parentID = c.ParentSessionID.String()
 	}
 	createdByUserID := ""
-	if row.CreatedByUserID.Valid {
-		createdByUserID = row.CreatedByUserID.String()
+	if c.CreatedByUserID.Valid {
+		createdByUserID = c.CreatedByUserID.String()
 	}
 	return Session{
-		ID:                    row.ID.String(),
-		BotID:                 row.BotID.String(),
-		RouteID:               row.RouteID.String(),
-		ChannelType:           dbpkg.TextToString(row.ChannelType),
-		Type:                  row.Type,
-		Title:                 row.Title,
-		Metadata:              parseJSONMap(row.Metadata),
+		ID:                    c.ID.String(),
+		BotID:                 c.BotID.String(),
+		RouteID:               c.RouteID.String(),
+		ChannelType:           dbpkg.TextToString(c.ChannelType),
+		Type:                  c.Type,
+		Title:                 c.Title,
+		Metadata:              parseJSONMap(c.Metadata),
 		ParentSessionID:       parentID,
 		CreatedByUserID:       createdByUserID,
-		CreatedAt:             row.CreatedAt.Time,
-		UpdatedAt:             row.UpdatedAt.Time,
-		RouteMetadata:         parseJSONMap(row.RouteMetadata),
-		RouteConversationType: dbpkg.TextToString(row.RouteConversationType),
+		CreatedAt:             c.CreatedAt.Time,
+		UpdatedAt:             c.UpdatedAt.Time,
+		RouteMetadata:         parseJSONMap(c.RouteMetadata),
+		RouteConversationType: dbpkg.TextToString(c.RouteConversationType),
 	}
 }

--- a/internal/session/service_test.go
+++ b/internal/session/service_test.go
@@ -449,3 +449,36 @@ func TestListByBotAndCreatedByUserPagedForwardsUserScope(t *testing.T) {
 		t.Fatalf("LimitCount = %d, want 5", stub.userPagedArg.LimitCount)
 	}
 }
+
+// TestSessionCursorIsZeroDistinguishesPartialFromEmpty pins down the contract
+// that pagedCursorParams relies on: a partial cursor (only one half set) is
+// not zero, so a misconstructed cursor surfaces as an error rather than
+// silently restarting the listing from the head.
+func TestSessionCursorIsZeroDistinguishesPartialFromEmpty(t *testing.T) {
+	if !(SessionCursor{}).IsZero() {
+		t.Fatalf("zero-value cursor should be zero")
+	}
+	partialID := SessionCursor{ID: "33333333-3333-3333-3333-333333333333"}
+	if partialID.IsZero() {
+		t.Fatalf("cursor with only id set should not be zero")
+	}
+	partialTS := SessionCursor{UpdatedAt: time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)}
+	if partialTS.IsZero() {
+		t.Fatalf("cursor with only updated_at set should not be zero")
+	}
+}
+
+func TestListByBotPagedRejectsPartialCursor(t *testing.T) {
+	stub := &pagedQueriesStub{}
+	svc := NewService(nil, stub)
+	botID := "11111111-1111-1111-1111-111111111111"
+
+	_, err := svc.ListByBotPaged(context.Background(), botID, []string{TypeChat},
+		SessionCursor{ID: "33333333-3333-3333-3333-333333333333"}, 10)
+	if err == nil {
+		t.Fatalf("ListByBotPaged with id-only cursor should error rather than restart from the head")
+	}
+	if !strings.Contains(err.Error(), "cursor must carry both") {
+		t.Fatalf("error = %v, want partial-cursor message", err)
+	}
+}

--- a/internal/session/service_test.go
+++ b/internal/session/service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -329,4 +330,122 @@ func mustSessionJSON(value map[string]any) []byte {
 		panic(err)
 	}
 	return data
+}
+
+// pagedQueriesStub captures the params handed to the paged session queries so
+// the test can assert that the service forwards botID, types, cursor, and
+// limit without modification.
+type pagedQueriesStub struct {
+	dbstore.Queries
+	pagedArg     sqlc.ListSessionsByBotPagedParams
+	pagedRows    []sqlc.ListSessionsByBotPagedRow
+	userPagedArg sqlc.ListSessionsByBotAndCreatedByUserPagedParams
+	userRows     []sqlc.ListSessionsByBotAndCreatedByUserPagedRow
+}
+
+func (s *pagedQueriesStub) ListSessionsByBotPaged(_ context.Context, arg sqlc.ListSessionsByBotPagedParams) ([]sqlc.ListSessionsByBotPagedRow, error) {
+	s.pagedArg = arg
+	return s.pagedRows, nil
+}
+
+func (s *pagedQueriesStub) ListSessionsByBotAndCreatedByUserPaged(_ context.Context, arg sqlc.ListSessionsByBotAndCreatedByUserPagedParams) ([]sqlc.ListSessionsByBotAndCreatedByUserPagedRow, error) {
+	s.userPagedArg = arg
+	return s.userRows, nil
+}
+
+func TestListByBotPagedForwardsParams(t *testing.T) {
+	stub := &pagedQueriesStub{}
+	svc := NewService(nil, stub)
+	botID := "11111111-1111-1111-1111-111111111111"
+	cursorID := "22222222-2222-2222-2222-222222222222"
+	cursorAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	types := []string{TypeChat, TypeDiscuss}
+
+	if _, err := svc.ListByBotPaged(context.Background(), botID, types, SessionCursor{UpdatedAt: cursorAt, ID: cursorID}, 25); err != nil {
+		t.Fatalf("ListByBotPaged: %v", err)
+	}
+	if stub.pagedArg.BotID.String() != botID {
+		t.Fatalf("BotID = %s, want %s", stub.pagedArg.BotID.String(), botID)
+	}
+	if got, want := stub.pagedArg.Types, types; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("Types = %v, want %v", got, want)
+	}
+	if !stub.pagedArg.UseCursor {
+		t.Fatalf("UseCursor should be true when a non-zero cursor is supplied")
+	}
+	if !stub.pagedArg.CursorUpdatedAt.Time.Equal(cursorAt) {
+		t.Fatalf("CursorUpdatedAt = %v, want %v", stub.pagedArg.CursorUpdatedAt.Time, cursorAt)
+	}
+	if stub.pagedArg.CursorID.String() != cursorID {
+		t.Fatalf("CursorID = %s, want %s", stub.pagedArg.CursorID.String(), cursorID)
+	}
+	if stub.pagedArg.LimitCount != 25 {
+		t.Fatalf("LimitCount = %d, want 25", stub.pagedArg.LimitCount)
+	}
+}
+
+func TestListByBotPagedZeroCursorSkipsCursorFilter(t *testing.T) {
+	stub := &pagedQueriesStub{}
+	svc := NewService(nil, stub)
+
+	if _, err := svc.ListByBotPaged(context.Background(), "11111111-1111-1111-1111-111111111111", []string{TypeChat}, SessionCursor{}, 10); err != nil {
+		t.Fatalf("ListByBotPaged: %v", err)
+	}
+	if stub.pagedArg.UseCursor {
+		t.Fatalf("UseCursor should be false for the zero-value cursor")
+	}
+}
+
+func TestListByBotPagedMapsRowsToSessions(t *testing.T) {
+	rowID := "33333333-3333-3333-3333-333333333333"
+	updated := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	stub := &pagedQueriesStub{
+		pagedRows: []sqlc.ListSessionsByBotPagedRow{{
+			ID:        mustPGUUID(rowID),
+			BotID:     mustPGUUID("11111111-1111-1111-1111-111111111111"),
+			Type:      TypeChat,
+			Title:     "hello",
+			Metadata:  []byte(`{"k":"v"}`),
+			CreatedAt: pgtype.Timestamptz{Time: updated, Valid: true},
+			UpdatedAt: pgtype.Timestamptz{Time: updated, Valid: true},
+		}},
+	}
+	svc := NewService(nil, stub)
+
+	got, err := svc.ListByBotPaged(context.Background(), "11111111-1111-1111-1111-111111111111", []string{TypeChat}, SessionCursor{}, 10)
+	if err != nil {
+		t.Fatalf("ListByBotPaged: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(got))
+	}
+	if got[0].ID != rowID {
+		t.Fatalf("session ID = %s, want %s", got[0].ID, rowID)
+	}
+	if !got[0].UpdatedAt.Equal(updated) {
+		t.Fatalf("session UpdatedAt = %v, want %v", got[0].UpdatedAt, updated)
+	}
+	if got[0].Metadata["k"] != "v" {
+		t.Fatalf("session metadata = %v, want k=v", got[0].Metadata)
+	}
+}
+
+func TestListByBotAndCreatedByUserPagedForwardsUserScope(t *testing.T) {
+	stub := &pagedQueriesStub{}
+	svc := NewService(nil, stub)
+	botID := "11111111-1111-1111-1111-111111111111"
+	userID := "44444444-4444-4444-4444-444444444444"
+
+	if _, err := svc.ListByBotAndCreatedByUserPaged(context.Background(), botID, userID, []string{TypeChat}, SessionCursor{}, 5); err != nil {
+		t.Fatalf("ListByBotAndCreatedByUserPaged: %v", err)
+	}
+	if stub.userPagedArg.BotID.String() != botID {
+		t.Fatalf("BotID = %s, want %s", stub.userPagedArg.BotID.String(), botID)
+	}
+	if stub.userPagedArg.CreatedByUserID.String() != userID {
+		t.Fatalf("CreatedByUserID = %s, want %s", stub.userPagedArg.CreatedByUserID.String(), userID)
+	}
+	if stub.userPagedArg.LimitCount != 5 {
+		t.Fatalf("LimitCount = %d, want 5", stub.userPagedArg.LimitCount)
+	}
 }

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -5983,19 +5983,31 @@ const docTemplate = `{
                         "name": "bot_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated session types to include. Defaults to user-facing types (chat,discuss,acp_agent).",
+                        "name": "types",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (1..200). Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque cursor returned as next_cursor on a previous page.",
+                        "name": "cursor",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/session.Session"
-                                }
-                            }
+                            "$ref": "#/definitions/handlers.listSessionsResponse"
                         }
                     },
                     "400": {
@@ -16329,6 +16341,20 @@ const docTemplate = `{
             "properties": {
                 "ok": {
                     "type": "boolean"
+                }
+            }
+        },
+        "handlers.listSessionsResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/session.Session"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
                 }
             }
         },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -5974,19 +5974,31 @@
                         "name": "bot_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated session types to include. Defaults to user-facing types (chat,discuss,acp_agent).",
+                        "name": "types",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (1..200). Defaults to 50.",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque cursor returned as next_cursor on a previous page.",
+                        "name": "cursor",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/session.Session"
-                                }
-                            }
+                            "$ref": "#/definitions/handlers.listSessionsResponse"
                         }
                     },
                     "400": {
@@ -16320,6 +16332,20 @@
             "properties": {
                 "ok": {
                     "type": "boolean"
+                }
+            }
+        },
+        "handlers.listSessionsResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/session.Session"
+                    }
+                },
+                "next_cursor": {
+                    "type": "string"
                 }
             }
         },

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -2953,6 +2953,15 @@ definitions:
       ok:
         type: boolean
     type: object
+  handlers.listSessionsResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/session.Session'
+        type: array
+      next_cursor:
+        type: string
+    type: object
   handlers.memoryAddPayload:
     properties:
       embedding_enabled:
@@ -8087,15 +8096,24 @@ paths:
         name: bot_id
         required: true
         type: string
+      - description: Comma-separated session types to include. Defaults to user-facing
+          types (chat,discuss,acp_agent).
+        in: query
+        name: types
+        type: string
+      - description: Page size (1..200). Defaults to 50.
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque cursor returned as next_cursor on a previous page.
+        in: query
+        name: cursor
+        type: string
       responses:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              items:
-                $ref: '#/definitions/session.Session'
-              type: array
-            type: object
+            $ref: '#/definitions/handlers.listSessionsResponse'
         "400":
           description: Bad Request
           schema:


### PR DESCRIPTION
## Summary

Make `GET /bots/{bot_id}/sessions` filterable by session type and cursor-paginated. Heartbeat / schedule / subagent sessions are now hidden from the default response so the client never has to scan thousands of system-internal entries to render the sidebar.

This is **PR 1 of 3** in the SSE / chat-list refactor chain:
1. **(this PR)** Backend: sessions pagination + type filter
2. Backend SSE protocol split + `/messages` requires `session_id`
3. Frontend rebuild around per-session SSE

## API

`GET /bots/{bot_id}/sessions` now accepts:

| query | default | notes |
|---|---|---|
| `types` | `chat,discuss,acp_agent` | comma-separated; uses the new `session.UserFacingSessionTypes` whitelist server-side |
| `limit` | 50 | clamped to `[1, 200]` |
| `cursor` | _(empty)_ | opaque base64-url of `<updated_at_rfc3339nano>\|<id>` |

Response gains `next_cursor`:

```json
{ "items": [...], "next_cursor": "MjAyNi0wMy0yNFQxMDo0MTowNC41Mz..." }
```

The cursor key is `(updated_at, id)` so pages stay stable when many rows share an `updated_at`.

## What this fixes

On a bot with months of activity, `bot_sessions` accumulates ~30 heartbeat rows per hour (the heartbeat scheduler). One real instance had **2246 heartbeat sessions** on the bot vs 25 chat/discuss — the unfiltered, unpaginated response returned all of them. The client filtered heartbeat out client-side, but every subsequent per-event handler still did `sessions.value.some(...)` on the full 2271-entry reactive array, which compounded into seconds of frozen UI on busy bots.

After this PR the server returns only the 25 user-facing sessions by default, so `sessions.value` is small enough that the existing client code stops being O(thousands) per SSE event. The frontend changes that actually use the new query params land in PR 3.

## Compatibility

- **Old frontend**: stops seeing heartbeat sessions in `/sessions` (the client filter for them was already there, so no visible change). Loses access to the previously implicit "all sessions" view; nothing reads it.
- **New frontend**: opts into pagination by passing `cursor`.

No database migration; query additions only.

## Test plan

- [x] `go test ./internal/session/... ./internal/handlers/...` — passes (4 new service tests, 7 new handler tests).
- [x] Default types filter: `GET /sessions` returns only `chat / discuss / acp_agent`.
- [x] Explicit types: `GET /sessions?types=chat` returns only chat.
- [x] Unknown types → 400.
- [x] Cursor round-trip: fetch first page, follow `next_cursor`, no duplicates, terminates with empty `next_cursor`.
- [x] Limit clamping: `limit=999` → clamped to 200.
- [x] Empty response omits `next_cursor`.

## Notes

- `UserFacingSessionTypes` is exported from `internal/session` so PR 2 can use it on the SSE side without duplicating the whitelist.
- Old `ListByBot` / `ListByBotAndCreatedByUser` service methods are intentionally untouched (no callers remain in this PR's handler, but a follow-up cleanup is safer once PR 2 confirms nothing else reaches for them).