### PR TITLE
feat(web): files and editor fresh after edits

### DIFF
--- a/apps/web/src/components/file-manager/file-conflict.test.ts
+++ b/apps/web/src/components/file-manager/file-conflict.test.ts
@@ -4,7 +4,9 @@ import {
   deriveChipContext,
   detectSaveConflict,
   EMPTY_CHIP_CONTEXT,
+  fileMetadataFingerprint,
   resolveChipButtons,
+  resolvePolledTextChange,
   resolveSaveBehavior,
   type FsChangeEventLike,
 } from './file-conflict'
@@ -184,6 +186,110 @@ describe('canApplyExternalReload', () => {
       currentOriginalContent: 'saved elsewhere',
       force: true,
     })).toBe(true)
+  })
+})
+
+describe('resolvePolledTextChange', () => {
+  it('ignores unchanged revisions', () => {
+    expect(resolvePolledTextChange({
+      loaded: true,
+      loading: false,
+      saving: false,
+      currentRevision: 'sha256:a',
+      nextRevision: 'sha256:a',
+      isDirty: false,
+      conflictState: 'none',
+    })).toBe('ignore')
+  })
+
+  it('applies changed revisions over a clean editor', () => {
+    expect(resolvePolledTextChange({
+      loaded: true,
+      loading: false,
+      saving: false,
+      currentRevision: 'sha256:a',
+      nextRevision: 'sha256:b',
+      isDirty: false,
+      conflictState: 'none',
+    })).toBe('apply')
+  })
+
+  it('surfaces the external-change chip for dirty editors', () => {
+    expect(resolvePolledTextChange({
+      loaded: true,
+      loading: false,
+      saving: false,
+      currentRevision: 'sha256:a',
+      nextRevision: 'sha256:b',
+      isDirty: true,
+      conflictState: 'none',
+    })).toBe('show-chip')
+  })
+
+  it('marks Compare stale instead of replacing its disk side', () => {
+    expect(resolvePolledTextChange({
+      loaded: true,
+      loading: false,
+      saving: false,
+      currentRevision: 'sha256:a',
+      nextRevision: 'sha256:b',
+      isDirty: true,
+      conflictState: 'compare',
+    })).toBe('mark-compare-stale')
+  })
+
+  it('does not poll-apply while initial loading or saving owns the buffer', () => {
+    const base = {
+      loaded: true,
+      loading: false,
+      saving: false,
+      currentRevision: 'sha256:a',
+      nextRevision: 'sha256:b',
+      isDirty: false,
+      conflictState: 'none' as const,
+    }
+
+    expect(resolvePolledTextChange({ ...base, loaded: false })).toBe('ignore')
+    expect(resolvePolledTextChange({ ...base, loading: true })).toBe('ignore')
+    expect(resolvePolledTextChange({ ...base, saving: true })).toBe('ignore')
+  })
+})
+
+describe('fileMetadataFingerprint', () => {
+  it('changes when file metadata that reflects disk content changes', () => {
+    const before = fileMetadataFingerprint({
+      path: '/data/app.ts',
+      isDir: false,
+      size: 10,
+      modTime: '2026-06-19T06:00:00Z',
+    })
+
+    expect(fileMetadataFingerprint({
+      path: '/data/app.ts',
+      isDir: false,
+      size: 11,
+      modTime: '2026-06-19T06:00:00Z',
+    })).not.toBe(before)
+    expect(fileMetadataFingerprint({
+      path: '/data/app.ts',
+      isDir: false,
+      size: 10,
+      modTime: '2026-06-19T06:00:01Z',
+    })).not.toBe(before)
+  })
+
+  it('keeps file and directory metadata distinct', () => {
+    expect(fileMetadataFingerprint({
+      path: '/data/build',
+      isDir: false,
+      size: 0,
+      modTime: '2026-06-19T06:00:00Z',
+    })).not.toBe(fileMetadataFingerprint({
+      path: '/data/build',
+      isDir: true,
+      size: 0,
+      modTime: '2026-06-19T06:00:00Z',
+    }))
   })
 })
 

--- a/apps/web/src/components/file-manager/file-conflict.test.ts
+++ b/apps/web/src/components/file-manager/file-conflict.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deriveChipContext,
+  detectSaveConflict,
+  EMPTY_CHIP_CONTEXT,
+  type FsChangeEventLike,
+} from './file-conflict'
+
+describe('deriveChipContext', () => {
+  it('returns the empty shape (with agentName) when no event is provided', () => {
+    expect(deriveChipContext(null, 'Bot')).toEqual({
+      ...EMPTY_CHIP_CONTEXT,
+      agentName: 'Bot',
+    })
+  })
+
+  it('trims and normalizes blank agent names to null', () => {
+    expect(deriveChipContext(null, '').agentName).toBe(null)
+    expect(deriveChipContext(null, '   ').agentName).toBe(null)
+    expect(deriveChipContext(null, undefined).agentName).toBe(null)
+    expect(deriveChipContext(null, null).agentName).toBe(null)
+    expect(deriveChipContext(null, '  My Bot  ').agentName).toBe('My Bot')
+  })
+
+  it('reports newLineCount for a write event from its writeContent', () => {
+    const event: FsChangeEventLike = {
+      at: 1000,
+      kind: 'write',
+      writeContent: 'line one\nline two\nline three',
+    }
+    const ctx = deriveChipContext(event, 'Bot')
+    expect(ctx.kind).toBe('write')
+    expect(ctx.occurredAt).toBe(1000)
+    expect(ctx.newLineCount).toBe(3)
+    expect(ctx.addedLines).toBe(null)
+    expect(ctx.removedLines).toBe(null)
+  })
+
+  it('reports a single-line file as newLineCount=1 (no trailing newline)', () => {
+    const ctx = deriveChipContext({ at: 1, kind: 'write', writeContent: 'one line' }, 'Bot')
+    expect(ctx.newLineCount).toBe(1)
+  })
+
+  it('reports newLineCount=0 for an empty write (truncate to empty)', () => {
+    const ctx = deriveChipContext({ at: 1, kind: 'write', writeContent: '' }, 'Bot')
+    expect(ctx.newLineCount).toBe(0)
+  })
+
+  it('reports addedLines/removedLines for an edit event from old/new text', () => {
+    const event: FsChangeEventLike = {
+      at: 1000,
+      kind: 'edit',
+      editOldText: 'a\nb',
+      editNewText: 'A\nB\nC',
+    }
+    const ctx = deriveChipContext(event, 'Bot')
+    expect(ctx.kind).toBe('edit')
+    expect(ctx.addedLines).toBe(3)
+    expect(ctx.removedLines).toBe(2)
+    expect(ctx.newLineCount).toBe(null)
+  })
+
+  it('handles edit events with missing old or new text gracefully', () => {
+    const ctx = deriveChipContext({ at: 1, kind: 'edit', editNewText: 'x' }, 'Bot')
+    expect(ctx.addedLines).toBe(1)
+    expect(ctx.removedLines).toBe(null)
+  })
+})
+
+describe('detectSaveConflict', () => {
+  it('returns false when the latest fs change doesn\'t affect this path', () => {
+    expect(detectSaveConflict({
+      lastFsChangeAt: 2000,
+      lastLoadedAt: 1000,
+      affects: false,
+    })).toBe(false)
+  })
+
+  it('returns false when nothing has ever bumped fsChangedAt', () => {
+    expect(detectSaveConflict({
+      lastFsChangeAt: 0,
+      lastLoadedAt: 1000,
+      affects: true,
+    })).toBe(false)
+  })
+
+  it('returns false when the file has never been loaded (defensive)', () => {
+    expect(detectSaveConflict({
+      lastFsChangeAt: 2000,
+      lastLoadedAt: 0,
+      affects: true,
+    })).toBe(false)
+  })
+
+  it('returns false when the bump happened before our last load', () => {
+    expect(detectSaveConflict({
+      lastFsChangeAt: 1000,
+      lastLoadedAt: 2000,
+      affects: true,
+    })).toBe(false)
+  })
+
+  it('returns false when the bump happened at the same tick as our load', () => {
+    expect(detectSaveConflict({
+      lastFsChangeAt: 2000,
+      lastLoadedAt: 2000,
+      affects: true,
+    })).toBe(false)
+  })
+
+  it('returns true when the bump happened after our last load and affects us', () => {
+    expect(detectSaveConflict({
+      lastFsChangeAt: 3000,
+      lastLoadedAt: 2000,
+      affects: true,
+    })).toBe(true)
+  })
+})

--- a/apps/web/src/components/file-manager/file-conflict.test.ts
+++ b/apps/web/src/components/file-manager/file-conflict.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  canApplyExternalReload,
   deriveChipContext,
   detectSaveConflict,
   EMPTY_CHIP_CONTEXT,
+  resolveChipButtons,
+  resolveSaveBehavior,
   type FsChangeEventLike,
 } from './file-conflict'
 
@@ -114,5 +117,233 @@ describe('detectSaveConflict', () => {
       lastLoadedAt: 2000,
       affects: true,
     })).toBe(true)
+  })
+})
+
+describe('canApplyExternalReload', () => {
+  it('allows an automatic reload when the clean buffer stayed unchanged while reading', () => {
+    expect(canApplyExternalReload({
+      contentAtRequestStart: 'base',
+      originalContentAtRequestStart: 'base',
+      currentContent: 'base',
+      currentOriginalContent: 'base',
+    })).toBe(true)
+  })
+
+  it('blocks an automatic reload when the user typed while the read was pending', () => {
+    expect(canApplyExternalReload({
+      contentAtRequestStart: 'base',
+      originalContentAtRequestStart: 'base',
+      currentContent: 'base + user edit',
+      currentOriginalContent: 'base',
+    })).toBe(false)
+  })
+
+  it('blocks an automatic reload when the saved baseline changed while the read was pending', () => {
+    expect(canApplyExternalReload({
+      contentAtRequestStart: 'base',
+      originalContentAtRequestStart: 'base',
+      currentContent: 'saved elsewhere',
+      currentOriginalContent: 'saved elsewhere',
+    })).toBe(false)
+  })
+
+  it('allows an explicit user reload even when it overwrites a dirty buffer', () => {
+    expect(canApplyExternalReload({
+      contentAtRequestStart: 'base',
+      originalContentAtRequestStart: 'base',
+      currentContent: 'mine',
+      currentOriginalContent: 'base',
+      force: true,
+    })).toBe(true)
+  })
+
+  it('refuses auto-reload over a dirty buffer even when no mutation occurred during the read', () => {
+    // Steady-dirty case: the buffer was dirty before the read, no concurrent
+    // typing happened, and force isn't set. The third clause
+    // (currentContent === currentOriginalContent) is the only thing keeping
+    // auto-reload from silently discarding the user's edits — pin it.
+    expect(canApplyExternalReload({
+      contentAtRequestStart: 'base + mine',
+      originalContentAtRequestStart: 'base',
+      currentContent: 'base + mine',
+      currentOriginalContent: 'base',
+    })).toBe(false)
+  })
+
+  it('allows an explicit user reload even when the saved baseline shifted during the read', () => {
+    // A concurrent save (or any out-of-band rewrite) shifts both currentContent
+    // and currentOriginalContent off the captured snapshots; force=true
+    // short-circuits the equality checks and still applies the new disk read.
+    // Pinning this prevents a regression that re-adds a baseline-drift guard
+    // before the force short-circuit.
+    expect(canApplyExternalReload({
+      contentAtRequestStart: 'base',
+      originalContentAtRequestStart: 'base',
+      currentContent: 'saved elsewhere',
+      currentOriginalContent: 'saved elsewhere',
+      force: true,
+    })).toBe(true)
+  })
+})
+
+describe('resolveChipButtons', () => {
+  it('shows Compare + Reload (no save) when available + clean text', () => {
+    const buttons = resolveChipButtons({ diskState: 'available', isText: true, isDirty: false })
+    expect(buttons.map(b => b.kind)).toEqual(['compare', 'reload'])
+    expect(buttons[1]).toMatchObject({ kind: 'reload', labelKey: 'reload' })
+  })
+
+  it('shows Compare + Reload + Save anyway when available + dirty text', () => {
+    const buttons = resolveChipButtons({ diskState: 'available', isText: true, isDirty: true })
+    expect(buttons.map(b => b.kind)).toEqual(['compare', 'reload', 'forceSave'])
+    expect(buttons[2]).toMatchObject({ kind: 'forceSave', labelKey: 'saveAnyway' })
+  })
+
+  it('hides Compare for non-text (no diff to render)', () => {
+    const buttons = resolveChipButtons({ diskState: 'available', isText: false, isDirty: false })
+    expect(buttons.map(b => b.kind)).toEqual(['reload'])
+  })
+
+  it('shows only Save to restore when deleted + text (any dirty)', () => {
+    const cleanButtons = resolveChipButtons({ diskState: 'deleted', isText: true, isDirty: false })
+    expect(cleanButtons).toHaveLength(1)
+    expect(cleanButtons[0]).toMatchObject({ kind: 'forceSave', labelKey: 'saveToRestore' })
+
+    const dirtyButtons = resolveChipButtons({ diskState: 'deleted', isText: true, isDirty: true })
+    expect(dirtyButtons).toHaveLength(1)
+    expect(dirtyButtons[0]).toMatchObject({ kind: 'forceSave', labelKey: 'saveToRestore' })
+  })
+
+  it('shows no buttons when deleted + non-text (image — no buffer to write back)', () => {
+    expect(resolveChipButtons({ diskState: 'deleted', isText: false, isDirty: false }))
+      .toEqual([])
+  })
+
+  it('shows Try again + Save anyway when stale + dirty text', () => {
+    const buttons = resolveChipButtons({ diskState: 'stale', isText: true, isDirty: true })
+    expect(buttons.map(b => b.kind)).toEqual(['reload', 'forceSave'])
+    expect(buttons[0]).toMatchObject({ kind: 'reload', labelKey: 'tryAgain' })
+    expect(buttons[1]).toMatchObject({ kind: 'forceSave', labelKey: 'saveAnyway' })
+  })
+
+  it('shows only Try again when stale + clean (nothing to save)', () => {
+    const buttons = resolveChipButtons({ diskState: 'stale', isText: true, isDirty: false })
+    expect(buttons.map(b => b.kind)).toEqual(['reload'])
+    expect(buttons[0]).toMatchObject({ kind: 'reload', labelKey: 'tryAgain' })
+  })
+
+  it('hides Compare in stale state (we don\'t know what is on disk)', () => {
+    const buttons = resolveChipButtons({ diskState: 'stale', isText: true, isDirty: false })
+    expect(buttons.map(b => b.kind)).not.toContain('compare')
+  })
+
+  it('shows only Try again when stale + non-text (no force-save on binaries)', () => {
+    const clean = resolveChipButtons({ diskState: 'stale', isText: false, isDirty: false })
+    expect(clean.map(b => b.kind)).toEqual(['reload'])
+    expect(clean[0]).toMatchObject({ kind: 'reload', labelKey: 'tryAgain' })
+
+    // isDirty on a non-text buffer should not unlock Save anyway — the
+    // dirty-flag is essentially unreachable for images, but the contract
+    // still has to suppress the action button.
+    const dirty = resolveChipButtons({ diskState: 'stale', isText: false, isDirty: true })
+    expect(dirty.map(b => b.kind)).toEqual(['reload'])
+  })
+
+  it('shows only Reload when available + non-text + dirty (no Save anyway on binaries)', () => {
+    const buttons = resolveChipButtons({ diskState: 'available', isText: false, isDirty: true })
+    expect(buttons.map(b => b.kind)).toEqual(['reload'])
+    expect(buttons[0]).toMatchObject({ kind: 'reload', labelKey: 'reload' })
+  })
+})
+
+describe('resolveSaveBehavior', () => {
+  const base = {
+    readonly: false,
+    saving: false,
+    isDirty: true,
+    force: false,
+    diskState: 'available' as const,
+  }
+
+  it('noop when readonly', () => {
+    expect(resolveSaveBehavior({ ...base, readonly: true })).toEqual({
+      outcome: 'noop',
+      bypassConflictGuard: false,
+    })
+  })
+
+  it('block when already saving', () => {
+    expect(resolveSaveBehavior({ ...base, saving: true })).toEqual({
+      outcome: 'block',
+      bypassConflictGuard: false,
+    })
+  })
+
+  it('proceed with guard on the normal dirty-save path', () => {
+    expect(resolveSaveBehavior(base)).toEqual({
+      outcome: 'proceed',
+      bypassConflictGuard: false,
+    })
+  })
+
+  it('proceed without guard when force=true (explicit Save anyway)', () => {
+    expect(resolveSaveBehavior({ ...base, force: true })).toEqual({
+      outcome: 'proceed',
+      bypassConflictGuard: true,
+    })
+  })
+
+  it('noop when clean + available + no force (nothing to do)', () => {
+    expect(resolveSaveBehavior({ ...base, isDirty: false })).toEqual({
+      outcome: 'noop',
+      bypassConflictGuard: false,
+    })
+  })
+
+  it('proceed without guard when diskState=deleted (recreate semantics)', () => {
+    // Even with a clean buffer we recreate the file — VS Code's ORPHAN save
+    // behavior.
+    expect(resolveSaveBehavior({ ...base, isDirty: false, diskState: 'deleted' })).toEqual({
+      outcome: 'proceed',
+      bypassConflictGuard: true,
+    })
+
+    expect(resolveSaveBehavior({ ...base, isDirty: true, diskState: 'deleted' })).toEqual({
+      outcome: 'proceed',
+      bypassConflictGuard: true,
+    })
+  })
+
+  it('readonly takes precedence over deleted (cannot write a read-only file even to recreate)', () => {
+    expect(resolveSaveBehavior({ ...base, readonly: true, diskState: 'deleted' })).toEqual({
+      outcome: 'noop',
+      bypassConflictGuard: false,
+    })
+  })
+
+  it('block takes precedence over deleted (in-flight save still blocks)', () => {
+    expect(resolveSaveBehavior({ ...base, saving: true, diskState: 'deleted' })).toEqual({
+      outcome: 'block',
+      bypassConflictGuard: false,
+    })
+  })
+
+  it('proceed in stale state when dirty (allow user to push their version)', () => {
+    expect(resolveSaveBehavior({ ...base, diskState: 'stale' })).toEqual({
+      outcome: 'proceed',
+      bypassConflictGuard: false,
+    })
+    expect(resolveSaveBehavior({ ...base, diskState: 'stale', force: true })).toEqual({
+      outcome: 'proceed',
+      bypassConflictGuard: true,
+    })
+  })
+
+  it('noop in stale state when clean (we don\'t recreate, just nothing to do)', () => {
+    expect(resolveSaveBehavior({ ...base, isDirty: false, diskState: 'stale' })).toEqual({
+      outcome: 'noop',
+      bypassConflictGuard: false,
+    })
   })
 })

--- a/apps/web/src/components/file-manager/file-conflict.ts
+++ b/apps/web/src/components/file-manager/file-conflict.ts
@@ -1,0 +1,83 @@
+// Pure helpers that back the file-viewer's "agent updated this file" chip and
+// its save-baseline guard. Extracted so the corner cases (kind detection, line
+// counts, save-conflict detection across debounce/load timing) can be tested
+// without spinning up a Vue component.
+
+export type FsToolKind = 'write' | 'edit' | 'apply_patch' | 'exec'
+
+export interface FsChangeEventLike {
+  at: number
+  path?: string
+  kind: FsToolKind
+  toolCallId?: string
+  sessionId?: string
+  writeContent?: string
+  editOldText?: string
+  editNewText?: string
+}
+
+export interface ChipContext {
+  agentName: string | null
+  kind: FsToolKind | null
+  occurredAt: number | null
+  // For write: total line count of the new content.
+  newLineCount: number | null
+  // For edit: line counts in the old/new snippet so we can show +N / -M.
+  addedLines: number | null
+  removedLines: number | null
+}
+
+export const EMPTY_CHIP_CONTEXT: ChipContext = {
+  agentName: null,
+  kind: null,
+  occurredAt: null,
+  newLineCount: null,
+  addedLines: null,
+  removedLines: null,
+}
+
+function countLines(text: string | undefined | null): number | null {
+  if (typeof text !== 'string') return null
+  if (text === '') return 0
+  return text.split('\n').length
+}
+
+export function deriveChipContext(
+  event: FsChangeEventLike | null,
+  agentName: string | null | undefined,
+): ChipContext {
+  const name = typeof agentName === 'string' && agentName.trim() !== ''
+    ? agentName.trim()
+    : null
+  if (!event) {
+    return { ...EMPTY_CHIP_CONTEXT, agentName: name }
+  }
+  return {
+    agentName: name,
+    kind: event.kind,
+    occurredAt: event.at,
+    newLineCount: countLines(event.writeContent),
+    addedLines: countLines(event.editNewText),
+    removedLines: countLines(event.editOldText),
+  }
+}
+
+export interface SaveConflictArgs {
+  // chatStore.fsChangedAt — last bumped timestamp (0 if never bumped).
+  lastFsChangeAt: number
+  // viewer-local: timestamp when the current content was last loaded from
+  // server. 0 before the first successful load.
+  lastLoadedAt: number
+  // chatStore.affectsPath(filePath): whether the latest batch covers this
+  // viewer's path (paths set hit OR wildcard).
+  affects: boolean
+}
+
+// Returns true when the user pressing Save would overwrite a workspace change
+// that arrived after we last fetched. Matches VS Code's pre-save mtime check.
+export function detectSaveConflict(a: SaveConflictArgs): boolean {
+  if (!a.affects) return false
+  if (a.lastFsChangeAt <= 0) return false
+  if (a.lastLoadedAt <= 0) return false
+  return a.lastFsChangeAt > a.lastLoadedAt
+}

--- a/apps/web/src/components/file-manager/file-conflict.ts
+++ b/apps/web/src/components/file-manager/file-conflict.ts
@@ -97,6 +97,50 @@ export function canApplyExternalReload(a: ExternalReloadGuardArgs): boolean {
     && a.currentContent === a.currentOriginalContent
 }
 
+export type ConflictState = 'none' | 'chip' | 'compare'
+
+export type PolledTextChangeAction =
+  | 'ignore'
+  | 'apply'
+  | 'show-chip'
+  | 'mark-compare-stale'
+
+export interface ResolvePolledTextChangeArgs {
+  loaded: boolean
+  loading: boolean
+  saving: boolean
+  currentRevision: string | null | undefined
+  nextRevision: string | null | undefined
+  isDirty: boolean
+  conflictState: ConflictState
+}
+
+export function resolvePolledTextChange(a: ResolvePolledTextChangeArgs): PolledTextChangeAction {
+  const currentRevision = a.currentRevision?.trim() ?? ''
+  const nextRevision = a.nextRevision?.trim() ?? ''
+  if (!a.loaded || a.loading || a.saving || !nextRevision) return 'ignore'
+  if (currentRevision === nextRevision) return 'ignore'
+  if (a.conflictState === 'compare') return 'mark-compare-stale'
+  if (a.isDirty) return 'show-chip'
+  return 'apply'
+}
+
+export interface FileMetadataLike {
+  path?: string | null
+  isDir?: boolean | null
+  size?: number | null
+  modTime?: string | null
+}
+
+export function fileMetadataFingerprint(info: FileMetadataLike): string {
+  return [
+    info.path ?? '',
+    info.isDir ? 'dir' : 'file',
+    info.size ?? -1,
+    info.modTime ?? '',
+  ].join('\u0000')
+}
+
 export type DiskState = 'available' | 'stale' | 'deleted'
 
 export type ChipButton =

--- a/apps/web/src/components/file-manager/file-conflict.ts
+++ b/apps/web/src/components/file-manager/file-conflict.ts
@@ -81,3 +81,90 @@ export function detectSaveConflict(a: SaveConflictArgs): boolean {
   if (a.lastLoadedAt <= 0) return false
   return a.lastFsChangeAt > a.lastLoadedAt
 }
+
+export interface ExternalReloadGuardArgs {
+  contentAtRequestStart: string
+  originalContentAtRequestStart: string
+  currentContent: string
+  currentOriginalContent: string
+  force?: boolean
+}
+
+export function canApplyExternalReload(a: ExternalReloadGuardArgs): boolean {
+  if (a.force) return true
+  return a.currentContent === a.contentAtRequestStart
+    && a.currentOriginalContent === a.originalContentAtRequestStart
+    && a.currentContent === a.currentOriginalContent
+}
+
+export type DiskState = 'available' | 'stale' | 'deleted'
+
+export type ChipButton =
+  | { kind: 'compare' }
+  | { kind: 'reload'; labelKey: 'reload' | 'tryAgain' }
+  | { kind: 'forceSave'; labelKey: 'saveAnyway' | 'saveToRestore' }
+
+export interface ResolveChipButtonsArgs {
+  diskState: DiskState
+  isText: boolean
+  isDirty: boolean
+}
+
+// Decides the chip's action buttons for a given conflict surface. Mirrors VS
+// Code's ORPHAN UX: when the file is gone we hide Reload (it would just 404
+// again) and Compare (nothing to diff against), and re-label Save as
+// "Save to restore" — POSTing the buffer recreates the file.
+export function resolveChipButtons(a: ResolveChipButtonsArgs): ChipButton[] {
+  const buttons: ChipButton[] = []
+  if (a.diskState === 'deleted') {
+    // Restore is available for both clean and dirty buffers: a clean buffer
+    // still represents the last-known content, and recreating it from there is
+    // usually what the user wants.
+    if (a.isText) buttons.push({ kind: 'forceSave', labelKey: 'saveToRestore' })
+    return buttons
+  }
+  if (a.diskState === 'stale') {
+    buttons.push({ kind: 'reload', labelKey: 'tryAgain' })
+    if (a.isText && a.isDirty) buttons.push({ kind: 'forceSave', labelKey: 'saveAnyway' })
+    return buttons
+  }
+  // available
+  if (a.isText) buttons.push({ kind: 'compare' })
+  buttons.push({ kind: 'reload', labelKey: 'reload' })
+  if (a.isText && a.isDirty) buttons.push({ kind: 'forceSave', labelKey: 'saveAnyway' })
+  return buttons
+}
+
+export interface ResolveSaveBehaviorArgs {
+  readonly: boolean
+  saving: boolean
+  isDirty: boolean
+  force: boolean
+  diskState: DiskState
+}
+
+export interface SaveBehaviorPlan {
+  // 'noop' — return true without touching the network (read-only, or clean and
+  //   the file still exists). 'block' — currently saving, refuse. 'proceed' —
+  //   actually POST.
+  outcome: 'noop' | 'block' | 'proceed'
+  // True when the POST should skip the conflict guard (and the expectedRevision
+  // header). Implied by user-explicit "Save anyway" / "Save to restore", or by
+  // the deleted state (no concurrent disk version to race against).
+  bypassConflictGuard: boolean
+}
+
+// Single source of truth for the save state machine; lets us cover the ORPHAN
+// recreate path (deleted + clean) and the explicit force path with the same
+// table of decisions instead of nested if blocks in handleSave.
+export function resolveSaveBehavior(a: ResolveSaveBehaviorArgs): SaveBehaviorPlan {
+  if (a.readonly) return { outcome: 'noop', bypassConflictGuard: false }
+  if (a.saving) return { outcome: 'block', bypassConflictGuard: false }
+  if (a.diskState === 'deleted') {
+    // Even a clean buffer warrants a POST: that's how we resurrect the file.
+    // Skip the conflict guard since there's no concurrent disk version.
+    return { outcome: 'proceed', bypassConflictGuard: true }
+  }
+  if (!a.isDirty) return { outcome: 'noop', bypassConflictGuard: false }
+  return { outcome: 'proceed', bypassConflictGuard: a.force }
+}

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -5,7 +5,7 @@ import { useKeyboardCommand } from '@/composables/useKeyboardCommand'
 import { isFileSaveEligible } from './file-save-command'
 import { useI18n } from 'vue-i18n'
 import { toast } from '@memohai/ui'
-import { File, Download } from 'lucide-vue-next'
+import { File, Download, RefreshCw } from 'lucide-vue-next'
 import { Button, Spinner } from '@memohai/ui'
 import {
   getBotsByBotIdContainerFsRead,
@@ -38,6 +38,10 @@ const originalContent = ref('')
 const loading = ref(false)
 const saving = ref(false)
 const imageUrl = ref('')
+// Set when the agent rewrites this file while the user has unsaved edits. We
+// don't silently reload (that would lose their work); the template shows an
+// inline notice with a Reload action instead.
+const externalChangePending = ref(false)
 
 const filename = computed(() => props.file.name ?? '')
 const filePath = computed(() => props.file.path ?? '')
@@ -47,55 +51,70 @@ const isDirty = computed(() => content.value !== originalContent.value)
 
 watch(isDirty, (dirty) => {
   emit('update:dirty', dirty)
+  // User resolved the conflict by saving or reverting their changes.
+  if (!dirty) externalChangePending.value = false
 }, { immediate: true })
 
-// Tagged on every load so a slower stale response can't overwrite a newer one
-// when fsChangedAt fires in bursts.
-let loadSeq = 0
+// One in-flight read at a time per viewer; a new load aborts the old one so a
+// slower stale response can't overwrite newer content when fsChangedAt fires
+// in bursts.
+let activeReadController: AbortController | null = null
 
 async function loadTextContent() {
-  const epoch = ++loadSeq
+  activeReadController?.abort()
+  const controller = new AbortController()
+  activeReadController = controller
   loading.value = true
   try {
     const { data } = await getBotsByBotIdContainerFsRead({
       path: { bot_id: props.botId },
       query: { path: filePath.value },
+      signal: controller.signal,
       throwOnError: true,
     })
-    if (epoch !== loadSeq) return
+    if (controller.signal.aborted) return
     content.value = data.content ?? ''
     originalContent.value = content.value
   } catch (error) {
-    if (epoch !== loadSeq) return
+    if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
   } finally {
-    if (epoch === loadSeq) loading.value = false
+    if (activeReadController === controller) {
+      activeReadController = null
+      loading.value = false
+    }
   }
 }
 
 async function loadImageBlob() {
-  const epoch = ++loadSeq
+  activeReadController?.abort()
+  const controller = new AbortController()
+  activeReadController = controller
   loading.value = true
+  let url = ''
   try {
     const response = await getBotsByBotIdContainerFsDownload({
       path: { bot_id: props.botId },
       query: { path: filePath.value },
       parseAs: 'blob',
+      signal: controller.signal,
       throwOnError: true,
     })
+    if (controller.signal.aborted) return
     const blob = response.data as unknown as Blob
-    const url = URL.createObjectURL(blob)
-    if (epoch !== loadSeq) {
-      URL.revokeObjectURL(url)
-      return
-    }
+    url = URL.createObjectURL(blob)
     cleanupImageUrl()
     imageUrl.value = url
+    url = ''
   } catch (error) {
-    if (epoch !== loadSeq) return
+    if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
   } finally {
-    if (epoch === loadSeq) loading.value = false
+    if (url) URL.revokeObjectURL(url)
+    if (activeReadController === controller) {
+      activeReadController = null
+      loading.value = false
+    }
   }
 }
 
@@ -150,6 +169,7 @@ watch(() => props.file.path, () => {
   cleanupImageUrl()
   content.value = ''
   originalContent.value = ''
+  externalChangePending.value = false
   if (isText.value) {
     void loadTextContent()
   } else if (isImage.value) {
@@ -158,20 +178,35 @@ watch(() => props.file.path, () => {
 }, { immediate: true })
 
 // Reload the file when the chat agent runs a fs-mutating tool (write/edit/apply_patch/exec)
-// against the same bot. Skip if the user has unsaved changes or is mid-save —
-// the in-flight save owns content/originalContent and we'd race it.
+// against the same bot AND the change targets this path. Skip if the user is
+// mid-save — the in-flight save owns content/originalContent and we'd race it.
+// If the user has unsaved edits, surface an inline notice rather than silently
+// reloading or silently dropping the agent's change.
 const chatStore = useChatStore()
 const { fsChangedAt, currentBotId } = storeToRefs(chatStore)
 watch(fsChangedAt, () => {
   if (!props.botId || props.botId !== currentBotId.value) return
+  if (!chatStore.affectsPath(filePath.value)) return
   if (saving.value) return
-  if (isDirty.value) return
+  if (isDirty.value) {
+    externalChangePending.value = true
+    return
+  }
   if (isText.value) {
     void loadTextContent()
   } else if (isImage.value) {
     void loadImageBlob()
   }
 })
+
+async function acceptExternalChange() {
+  externalChangePending.value = false
+  if (isText.value) {
+    await loadTextContent()
+  } else if (isImage.value) {
+    await loadImageBlob()
+  }
+}
 
 // Save on Cmd/Ctrl+S via the shared keyboard layer. The handler is scoped to this
 // component's lifetime: it returns true only for an editable, dirty text file, so
@@ -190,12 +225,28 @@ useKeyboardCommand(appKeyboardCommands.saveActiveFile, () => {
 })
 
 onBeforeUnmount(() => {
+  activeReadController?.abort()
   cleanupImageUrl()
 })
 </script>
 
 <template>
   <div class="flex h-full flex-col overflow-hidden bg-surface-editor">
+    <div
+      v-if="externalChangePending"
+      class="flex shrink-0 items-center gap-2 border-b border-border bg-accent/40 px-3 py-1.5 text-caption text-foreground"
+    >
+      <RefreshCw class="size-3.5 shrink-0 text-muted-foreground" />
+      <span class="min-w-0 flex-1 truncate">{{ t('bots.files.externalChangeNotice') }}</span>
+      <Button
+        variant="ghost"
+        size="sm"
+        class="h-6 shrink-0 px-2 text-xs"
+        @click="acceptExternalChange"
+      >
+        {{ t('bots.files.externalChangeReload') }}
+      </Button>
+    </div>
     <div class="flex-1 min-h-0 overflow-hidden">
       <div
         v-if="loading"

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { computed, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref, useId, watch } from 'vue'
 import { appKeyboardCommands } from '@/lib/keyboard-commands'
 import { useKeyboardCommand } from '@/composables/useKeyboardCommand'
 import { isFileSaveEligible } from './file-save-command'
@@ -7,7 +7,9 @@ import {
   canApplyExternalReload,
   detectSaveConflict,
   deriveChipContext,
+  fileMetadataFingerprint,
   resolveChipButtons,
+  resolvePolledTextChange,
   resolveSaveBehavior,
   type ChipButton,
 } from './file-conflict'
@@ -16,6 +18,7 @@ import { toast } from '@memohai/ui'
 import { File, FileX, Download, RefreshCw, GitCompare, X } from 'lucide-vue-next'
 import { Button, Spinner } from '@memohai/ui'
 import {
+  getBotsByBotIdContainerFs,
   getBotsByBotIdContainerFsRead,
   postBotsByBotIdContainerFsWrite,
   getBotsByBotIdContainerFsDownload,
@@ -35,6 +38,8 @@ const props = defineProps<{
   file: HandlersFsFileInfo
   readonly?: boolean
 }>()
+
+const EXTERNAL_FILE_POLL_MS = 2_000
 
 const emit = defineEmits<{
   saved: []
@@ -73,6 +78,11 @@ const compareDiskContent = ref('')
 // change, and on exit.
 const compareStale = ref(false)
 let compareController: AbortController | null = null
+const observedExternalRevision = ref('')
+const imageMetadataFingerprint = ref('')
+let externalPollTimer: ReturnType<typeof setInterval> | null = null
+let externalPollController: AbortController | null = null
+let externalPollingActive = false
 // Stable ids so the chip buttons can aria-describedby the relevant inline
 // message span, giving keyboard / screen-reader users the "why is this here"
 // context. The compare-toolbar Refresh button uses the staleNotice id by the
@@ -176,6 +186,10 @@ function isHttpStatus(error: unknown, status: number): boolean {
   return maybe?.status === status || maybe?.response?.status === status
 }
 
+function isDocumentVisible(): boolean {
+  return typeof document === 'undefined' || document.visibilityState === 'visible'
+}
+
 // Force the chip back into view on a terminal disk-state transition (delete /
 // stale read). Tears down any active Compare so the user isn't reviewing a diff
 // against bytes that no longer exist.
@@ -185,6 +199,126 @@ function dropToChipForBadDiskState() {
   compareDiskContent.value = ''
   compareStale.value = false
   conflictState.value = 'chip'
+}
+
+function notePolledExternalRevision(revision: string) {
+  if (observedExternalRevision.value === revision) return
+  observedExternalRevision.value = revision
+  chatStore.markFsChanged(filePath.value)
+}
+
+function applyPolledTextContent(contentValue: string, revision: string) {
+  content.value = contentValue
+  originalContent.value = contentValue
+  baseRevision.value = revision
+  observedExternalRevision.value = ''
+  lastLoadedAt.value = Date.now()
+  loaded.value = true
+  diskState.value = 'available'
+  conflictState.value = 'none'
+}
+
+async function pollTextFile(signal: AbortSignal) {
+  const { data } = await getBotsByBotIdContainerFsRead({
+    path: { bot_id: props.botId },
+    query: { path: filePath.value },
+    signal,
+    throwOnError: true,
+  })
+  if (signal.aborted) return
+  const nextRevision = data.revision ?? ''
+  const action = resolvePolledTextChange({
+    loaded: loaded.value,
+    loading: loading.value,
+    saving: saving.value,
+    currentRevision: baseRevision.value,
+    nextRevision,
+    isDirty: isDirty.value,
+    conflictState: conflictState.value,
+  })
+  if (action === 'ignore') return
+  if (action === 'apply') {
+    applyPolledTextContent(data.content ?? '', nextRevision)
+    return
+  }
+  notePolledExternalRevision(nextRevision)
+  diskState.value = 'available'
+  if (action === 'mark-compare-stale') {
+    compareStale.value = true
+    return
+  }
+  if (conflictState.value === 'none') conflictState.value = 'chip'
+}
+
+async function pollImageFile(signal: AbortSignal) {
+  const { data } = await getBotsByBotIdContainerFs({
+    path: { bot_id: props.botId },
+    query: { path: filePath.value },
+    signal,
+    throwOnError: true,
+  })
+  if (signal.aborted) return
+  const nextFingerprint = fileMetadataFingerprint(data)
+  if (!imageMetadataFingerprint.value) {
+    imageMetadataFingerprint.value = nextFingerprint
+    return
+  }
+  if (nextFingerprint === imageMetadataFingerprint.value) return
+  const previousFingerprint = imageMetadataFingerprint.value
+  await loadImageBlob({ notifyOnError: false })
+  imageMetadataFingerprint.value = diskState.value === 'available'
+    ? nextFingerprint
+    : previousFingerprint
+}
+
+async function pollExternalFile() {
+  if (!externalPollingActive) return
+  if (!props.botId || !loaded.value || loading.value || saving.value || externalPollController) return
+  if (!isDocumentVisible()) return
+  if (!isText.value && !isImage.value) return
+
+  const controller = new AbortController()
+  externalPollController = controller
+  try {
+    if (isText.value) await pollTextFile(controller.signal)
+    else if (isImage.value) await pollImageFile(controller.signal)
+  } catch (error) {
+    if (controller.signal.aborted) return
+    if (isHttpStatus(error, 404)) {
+      diskState.value = 'deleted'
+      loaded.value = true
+      observedExternalRevision.value = 'deleted'
+      imageMetadataFingerprint.value = ''
+      dropToChipForBadDiskState()
+      return
+    }
+    diskState.value = 'stale'
+    loaded.value = true
+    dropToChipForBadDiskState()
+  } finally {
+    if (externalPollController === controller) externalPollController = null
+  }
+}
+
+function startExternalFilePoll() {
+  if (!externalPollingActive || externalPollTimer !== null) return
+  externalPollTimer = window.setInterval(() => {
+    void pollExternalFile()
+  }, EXTERNAL_FILE_POLL_MS)
+}
+
+function stopExternalFilePoll() {
+  if (externalPollTimer !== null) {
+    window.clearInterval(externalPollTimer)
+    externalPollTimer = null
+  }
+  externalPollController?.abort()
+  externalPollController = null
+}
+
+function handleVisibilityChange() {
+  if (!externalPollingActive) return
+  if (isDocumentVisible()) void pollExternalFile()
 }
 
 async function loadTextContent(options: { forceApply?: boolean; notifyOnError?: boolean } = {}) {
@@ -218,6 +352,7 @@ async function loadTextContent(options: { forceApply?: boolean; notifyOnError?: 
     content.value = data.content ?? ''
     originalContent.value = content.value
     baseRevision.value = data.revision ?? ''
+    observedExternalRevision.value = ''
     lastLoadedAt.value = Date.now()
     loaded.value = true
     diskState.value = 'available'
@@ -265,6 +400,12 @@ async function loadImageBlob(options: { notifyOnError?: boolean } = {}) {
     cleanupImageUrl()
     imageUrl.value = url
     url = ''
+    imageMetadataFingerprint.value = fileMetadataFingerprint({
+      path: filePath.value,
+      isDir: false,
+      size: blob.size,
+      modTime: props.file.modTime,
+    })
     lastLoadedAt.value = Date.now()
     loaded.value = true
     diskState.value = 'available'
@@ -354,6 +495,7 @@ async function handleSave(force = false): Promise<boolean> {
     })
     originalContent.value = content.value
     baseRevision.value = data.revision ?? baseRevision.value
+    observedExternalRevision.value = ''
     diskState.value = 'available'
     // An agent bump observed during our POST window means the disk diverged
     // from what our save just persisted. Anchor lastLoadedAt to BEFORE that
@@ -438,6 +580,8 @@ watch(() => props.file.path, () => {
   compareDiskContent.value = ''
   compareStale.value = false
   lastLoadedAt.value = 0
+  observedExternalRevision.value = ''
+  imageMetadataFingerprint.value = ''
   loaded.value = false
   if (isText.value) {
     void loadTextContent()
@@ -570,12 +714,29 @@ useKeyboardCommand(appKeyboardCommands.saveActiveFile, () => {
 })
 
 onMounted(() => {
+  externalPollingActive = true
   nowTickInterval = setInterval(() => { nowTick.value = Date.now() }, 60_000)
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+  startExternalFilePoll()
+})
+
+onActivated(() => {
+  externalPollingActive = true
+  startExternalFilePoll()
+  void pollExternalFile()
+})
+
+onDeactivated(() => {
+  externalPollingActive = false
+  stopExternalFilePoll()
 })
 
 onBeforeUnmount(() => {
+  externalPollingActive = false
   if (nowTickInterval) clearInterval(nowTickInterval)
   nowTickInterval = null
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
+  stopExternalFilePoll()
   activeReadController?.abort()
   compareController?.abort()
   cleanupImageUrl()

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -199,8 +199,12 @@ watch(fsChangedAt, () => {
   }
 })
 
+// Keep the chip visible while the reload is in flight so the user sees a
+// continuous "agent updated · loading · resolved" transition. The isDirty
+// watcher clears externalChangePending the moment the load commits fresh
+// content (content === originalContent → !isDirty), and a failed load leaves
+// the chip up so the user can retry.
 async function acceptExternalChange() {
-  externalChangePending.value = false
   if (isText.value) {
     await loadTextContent()
   } else if (isImage.value) {

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -38,6 +38,11 @@ const originalContent = ref('')
 const loading = ref(false)
 const saving = ref(false)
 const imageUrl = ref('')
+// True once the file has been read at least once for the current path. Used
+// to suppress the full-area spinner on subsequent reloads — the editor / image
+// stays mounted and the content swaps in place, the way VS Code handles
+// external file changes.
+const loaded = ref(false)
 // Set when the agent rewrites this file while the user has unsaved edits. We
 // don't silently reload (that would lose their work); the template shows an
 // inline notice with a Reload action instead.
@@ -74,6 +79,7 @@ async function loadTextContent() {
     content.value = data.content ?? ''
     originalContent.value = content.value
     externalChangePending.value = false
+    loaded.value = true
   } catch (error) {
     if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
@@ -106,6 +112,7 @@ async function loadImageBlob() {
     imageUrl.value = url
     url = ''
     externalChangePending.value = false
+    loaded.value = true
   } catch (error) {
     if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
@@ -171,6 +178,7 @@ watch(() => props.file.path, () => {
   content.value = ''
   originalContent.value = ''
   externalChangePending.value = false
+  loaded.value = false
   if (isText.value) {
     void loadTextContent()
   } else if (isImage.value) {
@@ -253,8 +261,11 @@ onBeforeUnmount(() => {
       </Button>
     </div>
     <div class="flex-1 min-h-0 overflow-hidden">
+      <!-- Full-area spinner only on the FIRST load for this path (nothing else
+           to show). Subsequent reloads keep the editor/image mounted and let
+           the content swap in place, matching VS Code's external-change UX. -->
       <div
-        v-if="loading"
+        v-if="loading && !loaded"
         class="flex h-full items-center justify-center text-muted-foreground"
       >
         <Spinner class="mr-2" />

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -49,7 +49,12 @@ watch(isDirty, (dirty) => {
   emit('update:dirty', dirty)
 }, { immediate: true })
 
+// Tagged on every load so a slower stale response can't overwrite a newer one
+// when fsChangedAt fires in bursts.
+let loadSeq = 0
+
 async function loadTextContent() {
+  const epoch = ++loadSeq
   loading.value = true
   try {
     const { data } = await getBotsByBotIdContainerFsRead({
@@ -57,16 +62,19 @@ async function loadTextContent() {
       query: { path: filePath.value },
       throwOnError: true,
     })
+    if (epoch !== loadSeq) return
     content.value = data.content ?? ''
     originalContent.value = content.value
   } catch (error) {
+    if (epoch !== loadSeq) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
   } finally {
-    loading.value = false
+    if (epoch === loadSeq) loading.value = false
   }
 }
 
 async function loadImageBlob() {
+  const epoch = ++loadSeq
   loading.value = true
   try {
     const response = await getBotsByBotIdContainerFsDownload({
@@ -76,11 +84,18 @@ async function loadImageBlob() {
       throwOnError: true,
     })
     const blob = response.data as unknown as Blob
-    imageUrl.value = URL.createObjectURL(blob)
+    const url = URL.createObjectURL(blob)
+    if (epoch !== loadSeq) {
+      URL.revokeObjectURL(url)
+      return
+    }
+    cleanupImageUrl()
+    imageUrl.value = url
   } catch (error) {
+    if (epoch !== loadSeq) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
   } finally {
-    loading.value = false
+    if (epoch === loadSeq) loading.value = false
   }
 }
 
@@ -143,17 +158,17 @@ watch(() => props.file.path, () => {
 }, { immediate: true })
 
 // Reload the file when the chat agent runs a fs-mutating tool (write/edit/apply_patch/exec)
-// against the same bot. Skip if the user has unsaved changes — we don't want to
-// silently overwrite their edits.
+// against the same bot. Skip if the user has unsaved changes or is mid-save —
+// the in-flight save owns content/originalContent and we'd race it.
 const chatStore = useChatStore()
 const { fsChangedAt, currentBotId } = storeToRefs(chatStore)
 watch(fsChangedAt, () => {
   if (!props.botId || props.botId !== currentBotId.value) return
+  if (saving.value) return
   if (isDirty.value) return
   if (isText.value) {
     void loadTextContent()
   } else if (isImage.value) {
-    cleanupImageUrl()
     void loadImageBlob()
   }
 })

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
 import { appKeyboardCommands } from '@/lib/keyboard-commands'
 import { useKeyboardCommand } from '@/composables/useKeyboardCommand'
 import { isFileSaveEligible } from './file-save-command'
-import { detectSaveConflict, deriveChipContext } from './file-conflict'
+import {
+  canApplyExternalReload,
+  detectSaveConflict,
+  deriveChipContext,
+  resolveChipButtons,
+  resolveSaveBehavior,
+  type ChipButton,
+} from './file-conflict'
 import { useI18n } from 'vue-i18n'
 import { toast } from '@memohai/ui'
-import { File, Download, RefreshCw, GitCompare, X } from 'lucide-vue-next'
+import { File, FileX, Download, RefreshCw, GitCompare, X } from 'lucide-vue-next'
 import { Button, Spinner } from '@memohai/ui'
 import {
   getBotsByBotIdContainerFsRead,
@@ -38,6 +45,7 @@ const { t } = useI18n()
 
 const content = ref('')
 const originalContent = ref('')
+const baseRevision = ref('')
 const loading = ref(false)
 const saving = ref(false)
 const imageUrl = ref('')
@@ -54,11 +62,27 @@ const lastLoadedAt = ref(0)
 // usual choice (Compare / Reload / Save anyway). 'compare' = diff editor
 // replaces the main pane. 'none' = clean.
 const conflictState = ref<'none' | 'chip' | 'compare'>('none')
-// Right side of the diff editor. Snapshot at the moment Compare opens — if
-// the agent writes again while Compare is up, the snapshot stays put (user
-// closes Compare and re-opens to refresh).
+const diskState = ref<'available' | 'stale' | 'deleted'>('available')
+// Right side of the diff editor. Snapshot at the moment Compare opens; the
+// agent might write again while Compare is up, in which case we surface a
+// "Refresh diff" affordance in the compare toolbar rather than silently
+// updating the right pane underneath the user's review.
 const compareDiskContent = ref('')
+// Flips to true when a fsChangedAt for this path lands while we're in
+// conflictState='compare'. Reset on every successful openCompare(), on path
+// change, and on exit.
+const compareStale = ref(false)
 let compareController: AbortController | null = null
+// Stable ids so the chip buttons can aria-describedby the relevant inline
+// message span, giving keyboard / screen-reader users the "why is this here"
+// context. The compare-toolbar Refresh button uses the staleNotice id by the
+// same pattern.
+const chipMessageId = useId()
+const compareStaleId = useId()
+// Reference to MonacoEditor so we can hand focus back when an action removes
+// the chip / closes Compare and the activated button itself was just torn
+// down. Without this, focus would fall through to document.body.
+const monacoEditorRef = ref<{ $el?: HTMLElement } | null>(null)
 // Drives "5s ago" / "2m ago" relative-time labels in the chip. Ticks once a
 // minute; agent writes are usually fresh enough that "just now" wins, but a
 // chip left up across coffee should age gracefully.
@@ -80,7 +104,42 @@ const botName = computed(() => {
 const fsEvent = computed(() => chatStore.fsEventForPath(filePath.value))
 const chipContext = computed(() => deriveChipContext(fsEvent.value, botName.value))
 const fallbackAgent = computed(() => t('bots.files.externalChange.fallbackAgent'))
+const chipButtons = computed<ChipButton[]>(() => resolveChipButtons({
+  diskState: diskState.value,
+  isText: isText.value,
+  isDirty: isDirty.value,
+}))
+
+function focusEditor() {
+  const host = monacoEditorRef.value?.$el
+  if (!host) return
+  // Monaco renders a hidden <textarea.inputarea> inside its host that
+  // receives text input — focusing it routes keystrokes to the editor and
+  // restores the visible caret.
+  const textarea = host.querySelector?.<HTMLTextAreaElement>('textarea.inputarea')
+  if (textarea) {
+    textarea.focus()
+    return
+  }
+  if (typeof (host as HTMLElement).focus === 'function') (host as HTMLElement).focus()
+}
+
+async function onChipButton(btn: ChipButton) {
+  if (btn.kind === 'compare') await openCompare()
+  else if (btn.kind === 'reload') await acceptExternalChange()
+  else if (btn.kind === 'forceSave') await handleSave(true)
+  // Hand focus back to the editor when the chip just got unmounted (its
+  // wrapper v-if'd out); without this the browser drops focus to <body>.
+  await nextTick()
+  if (conflictState.value === 'none') focusEditor()
+}
+
+const reloadLabelKey = (key: 'reload' | 'tryAgain') => `bots.files.externalChange.${key}`
+const saveLabelKey = (key: 'saveAnyway' | 'saveToRestore') => `bots.files.externalChange.${key}`
+
 const chipMessage = computed(() => {
+  if (diskState.value === 'deleted') return t('bots.files.externalChange.deleted')
+  if (diskState.value === 'stale') return t('bots.files.externalChange.reloadFailed')
   const ctx = chipContext.value
   const agent = ctx.agentName ?? fallbackAgent.value
   // formatRelativeTime depends on Date.now(); reading the tick here makes the
@@ -112,10 +171,28 @@ watch(isDirty, (dirty) => {
 // in bursts.
 let activeReadController: AbortController | null = null
 
-async function loadTextContent() {
+function isHttpStatus(error: unknown, status: number): boolean {
+  const maybe = error as { status?: unknown; response?: { status?: unknown } } | null | undefined
+  return maybe?.status === status || maybe?.response?.status === status
+}
+
+// Force the chip back into view on a terminal disk-state transition (delete /
+// stale read). Tears down any active Compare so the user isn't reviewing a diff
+// against bytes that no longer exist.
+function dropToChipForBadDiskState() {
+  compareController?.abort()
+  compareController = null
+  compareDiskContent.value = ''
+  compareStale.value = false
+  conflictState.value = 'chip'
+}
+
+async function loadTextContent(options: { forceApply?: boolean; notifyOnError?: boolean } = {}) {
   activeReadController?.abort()
   const controller = new AbortController()
   activeReadController = controller
+  const contentAtRequestStart = content.value
+  const originalContentAtRequestStart = originalContent.value
   loading.value = true
   try {
     const { data } = await getBotsByBotIdContainerFsRead({
@@ -125,14 +202,41 @@ async function loadTextContent() {
       throwOnError: true,
     })
     if (controller.signal.aborted) return
+    if (!canApplyExternalReload({
+      contentAtRequestStart,
+      originalContentAtRequestStart,
+      currentContent: content.value,
+      currentOriginalContent: originalContent.value,
+      force: options.forceApply,
+    })) {
+      // The GET succeeded — disk is reachable. Clear any prior 'stale' so the
+      // chip stops claiming reloadFailed; the dirty buffer is left untouched.
+      diskState.value = 'available'
+      if (conflictState.value === 'none') conflictState.value = 'chip'
+      return
+    }
     content.value = data.content ?? ''
     originalContent.value = content.value
+    baseRevision.value = data.revision ?? ''
     lastLoadedAt.value = Date.now()
     loaded.value = true
-    conflictState.value = 'none'
+    diskState.value = 'available'
+    // Don't drop the user out of an open Compare; only clear the chip surface.
+    if (conflictState.value !== 'compare') conflictState.value = 'none'
   } catch (error) {
     if (controller.signal.aborted) return
-    toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
+    if (isHttpStatus(error, 404)) {
+      diskState.value = 'deleted'
+      loaded.value = true
+      dropToChipForBadDiskState()
+      return
+    }
+    diskState.value = 'stale'
+    loaded.value = true
+    dropToChipForBadDiskState()
+    if (options.notifyOnError !== false) {
+      toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
+    }
   } finally {
     if (activeReadController === controller) {
       activeReadController = null
@@ -141,7 +245,7 @@ async function loadTextContent() {
   }
 }
 
-async function loadImageBlob() {
+async function loadImageBlob(options: { notifyOnError?: boolean } = {}) {
   activeReadController?.abort()
   const controller = new AbortController()
   activeReadController = controller
@@ -163,10 +267,25 @@ async function loadImageBlob() {
     url = ''
     lastLoadedAt.value = Date.now()
     loaded.value = true
-    conflictState.value = 'none'
+    diskState.value = 'available'
+    if (conflictState.value !== 'compare') conflictState.value = 'none'
   } catch (error) {
     if (controller.signal.aborted) return
-    toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
+    // Release any stale blob URL from a prior successful load so the deleted /
+    // stale states don't keep a now-detached <img> source alive.
+    cleanupImageUrl()
+    if (isHttpStatus(error, 404)) {
+      diskState.value = 'deleted'
+      loaded.value = true
+      dropToChipForBadDiskState()
+      return
+    }
+    diskState.value = 'stale'
+    loaded.value = true
+    dropToChipForBadDiskState()
+    if (options.notifyOnError !== false) {
+      toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
+    }
   } finally {
     if (url) URL.revokeObjectURL(url)
     if (activeReadController === controller) {
@@ -180,41 +299,95 @@ async function loadImageBlob() {
 // (the tab close-confirm flow) can decide whether to proceed with closing. A
 // read-only or already-clean file reports success without a network round-trip.
 async function handleSave(force = false): Promise<boolean> {
-  if (props.readonly) return true
-  if (!isDirty.value) return true
-  if (saving.value) return false
+  const behavior = resolveSaveBehavior({
+    readonly: props.readonly ?? false,
+    saving: saving.value,
+    isDirty: isDirty.value,
+    force,
+    diskState: diskState.value,
+  })
+  if (behavior.outcome === 'noop') return true
+  if (behavior.outcome === 'block') return false
   // VS Code-style two-gate save: even if the chip wasn't surfaced yet (e.g.
-  // user pressed Cmd+S in the brief window between bump and consumer reaction),
-  // re-check the baseline before we POST. force=true skips this — that's the
-  // "Save anyway" path the user explicitly chose after seeing the conflict.
-  if (!force) {
+  // user pressed Cmd+S in the brief window between bump and consumer
+  // reaction), re-check the baseline before we POST. bypassConflictGuard skips
+  // this — that's the "Save anyway" / "Save to restore" path the user
+  // explicitly chose (or the ORPHAN-recreate path where there's no concurrent
+  // disk version).
+  if (!behavior.bypassConflictGuard) {
     const hasConflict = detectSaveConflict({
       lastFsChangeAt: fsChangedAt.value,
       lastLoadedAt: lastLoadedAt.value,
       affects: chatStore.affectsPath(filePath.value),
     })
     if (hasConflict) {
-      // Don't drop the user back to compare if they were already comparing.
-      if (conflictState.value !== 'compare') conflictState.value = 'chip'
+      // Don't drop the user back to compare if they were already comparing —
+      // but flag the diff as stale so the toolbar offers a Refresh diff
+      // affordance instead of leaving them on the now-outdated snapshot.
+      if (conflictState.value === 'compare') compareStale.value = true
+      else conflictState.value = 'chip'
       return false
     }
   }
   saving.value = true
+  // Snapshot pre-save chip context so we can:
+  //   a) detect an agent bump that lands inside the POST window (the
+  //      fsChangedAt watcher is gated by saving=true and would otherwise drop
+  //      that signal)
+  //   b) tone down the 409 toast when the conflict followed a known-bad read
+  const fsChangedAtBeforeSave = fsChangedAt.value
+  const diskStateBeforeSave = diskState.value
   try {
-    await postBotsByBotIdContainerFsWrite({
+    // Empty string isn't a meaningful baseline — fall through to an
+    // unconditional write rather than asking the backend to interpret '' as
+    // "expect file absent". The bypass path already drops the field; this
+    // covers the normal-save-with-no-known-baseline case (e.g. saving on top
+    // of a stale read that never returned a revision).
+    const sendBaseline = !behavior.bypassConflictGuard && baseRevision.value !== ''
+    const requestBody = sendBaseline
+      ? { path: filePath.value, content: content.value, expectedRevision: baseRevision.value }
+      : { path: filePath.value, content: content.value }
+    const { data } = await postBotsByBotIdContainerFsWrite({
       path: { bot_id: props.botId },
-      body: { path: filePath.value, content: content.value },
+      body: requestBody,
       throwOnError: true,
     })
     originalContent.value = content.value
-    // The save's POST is the new baseline; subsequent fs bumps from agent
-    // writes after this moment should re-trigger the save guard.
-    lastLoadedAt.value = Date.now()
-    conflictState.value = 'none'
+    baseRevision.value = data.revision ?? baseRevision.value
+    diskState.value = 'available'
+    // An agent bump observed during our POST window means the disk diverged
+    // from what our save just persisted. Anchor lastLoadedAt to BEFORE that
+    // bump so detectSaveConflict still fires on the next Cmd+S, and surface
+    // the chip now rather than waiting for the user to try again.
+    const interleavedBump =
+      fsChangedAt.value > fsChangedAtBeforeSave
+      && chatStore.affectsPath(filePath.value)
+    if (interleavedBump) {
+      lastLoadedAt.value = fsChangedAtBeforeSave > 0 ? fsChangedAtBeforeSave : 1
+      if (conflictState.value === 'compare') compareStale.value = true
+      else conflictState.value = 'chip'
+    } else {
+      lastLoadedAt.value = Date.now()
+      conflictState.value = 'none'
+    }
     toast.success(t('bots.files.saveSuccess'))
     emit('saved')
     return true
   } catch (error) {
+    if (isHttpStatus(error, 409)) {
+      // A 409 means our baseline is stale; bumping the disk state surfaces
+      // "Try again" (Reload) as the chip's primary affordance and prevents a
+      // Cmd+S loop from re-POSTing with the same stale expectedRevision.
+      diskState.value = 'stale'
+      if (conflictState.value === 'compare') compareStale.value = true
+      else conflictState.value = 'chip'
+      // Skip the saveConflict toast when the chip already explains a known-
+      // bad read; the wording would contradict the "couldn't load" chip text.
+      if (diskStateBeforeSave === 'available') {
+        toast.error(t('bots.files.externalChange.saveConflict'))
+      }
+      return false
+    }
     toast.error(resolveApiErrorMessage(error, t('bots.files.saveFailed')))
     return false
   } finally {
@@ -248,13 +421,22 @@ function cleanupImageUrl() {
 }
 
 watch(() => props.file.path, () => {
+  // Tear down any in-flight load and the compare snapshot before the new
+  // path's loaders kick off — otherwise a slow previous-path read could
+  // resolve onto the new path's empty buffer and silently surface a chip on a
+  // file that's never even been loaded.
+  activeReadController?.abort()
+  activeReadController = null
   compareController?.abort()
   compareController = null
   cleanupImageUrl()
   content.value = ''
   originalContent.value = ''
+  baseRevision.value = ''
+  diskState.value = 'available'
   conflictState.value = 'none'
   compareDiskContent.value = ''
+  compareStale.value = false
   lastLoadedAt.value = 0
   loaded.value = false
   if (isText.value) {
@@ -273,22 +455,45 @@ watch(fsChangedAt, () => {
   if (!props.botId || props.botId !== currentBotId.value) return
   if (!chatStore.affectsPath(filePath.value)) return
   if (saving.value) return
+  // While Compare is open the user is actively reviewing — never tear it down
+  // or silently rewrite the right pane underneath them. Mark the disk side as
+  // stale so the toolbar can offer a Refresh-diff affordance instead.
+  if (conflictState.value === 'compare') {
+    compareStale.value = true
+    return
+  }
   if (isDirty.value) {
-    // Don't disrupt an active compare view; user is in the middle of reviewing.
     if (conflictState.value === 'none') conflictState.value = 'chip'
     return
   }
-  if (isText.value) void loadTextContent()
-  else if (isImage.value) void loadImageBlob()
+  if (isText.value) void loadTextContent({ notifyOnError: false })
+  else if (isImage.value) void loadImageBlob({ notifyOnError: false })
 })
 
 async function acceptExternalChange() {
-  if (isText.value) await loadTextContent()
+  // Reload from the Compare toolbar means "apply the disk side and dismiss
+  // the diff" — keeping the user in Compare with the OLD compareDiskContent
+  // pointing at the previous snapshot and the new content from this load
+  // would render a meaningless diff against itself.
+  const wasInCompare = conflictState.value === 'compare'
+  if (isText.value) await loadTextContent({ forceApply: true })
   else if (isImage.value) await loadImageBlob()
+  if (wasInCompare && diskState.value === 'available') {
+    compareController?.abort()
+    compareController = null
+    compareDiskContent.value = ''
+    compareStale.value = false
+    conflictState.value = 'none'
+  }
 }
 
 async function openCompare() {
   if (!isText.value) return
+  // Abort any in-flight Compare read first so a previously dispatched
+  // fresh-read can't resolve later and clobber the writeContent we're about
+  // to set on the fast path (or this call's own fresh read).
+  compareController?.abort()
+  compareController = null
   // Prefer the agent's tool-message content — same bytes the server saw, no
   // extra round trip and immune to "what if disk changed again" races. Fall
   // back to a fresh read for edit / apply_patch / exec where we don't have the
@@ -296,10 +501,10 @@ async function openCompare() {
   const event = fsEvent.value
   if (event?.writeContent != null) {
     compareDiskContent.value = event.writeContent
+    compareStale.value = false
     conflictState.value = 'compare'
     return
   }
-  compareController?.abort()
   const controller = new AbortController()
   compareController = controller
   try {
@@ -311,9 +516,21 @@ async function openCompare() {
     })
     if (controller.signal.aborted) return
     compareDiskContent.value = data.content ?? ''
+    compareStale.value = false
     conflictState.value = 'compare'
   } catch (error) {
     if (controller.signal.aborted) return
+    if (isHttpStatus(error, 404)) {
+      // The disk version we wanted to diff against is gone. Fall back to the
+      // deleted-chip surface so the "Save to restore" affordance is reachable
+      // instead of leaving the user on the available chip clicking Compare
+      // into the same 404 repeatedly.
+      diskState.value = 'deleted'
+      compareDiskContent.value = ''
+      compareStale.value = false
+      conflictState.value = 'chip'
+      return
+    }
     toast.error(resolveApiErrorMessage(error, t('bots.files.compareLoadFailed')))
   } finally {
     if (compareController === controller) compareController = null
@@ -323,7 +540,16 @@ async function openCompare() {
 function exitCompare() {
   compareController?.abort()
   compareController = null
+  compareStale.value = false
   conflictState.value = 'chip'
+}
+
+async function refreshCompare() {
+  // Re-runs openCompare to re-snapshot the right pane against the latest
+  // tool-message content (or a fresh disk read when no event content is on
+  // hand). Used by the inline "Refresh diff" affordance the toolbar surfaces
+  // when compareStale is true.
+  await openCompare()
 }
 
 // Save on Cmd/Ctrl+S via the shared keyboard layer. Even if a conflict is
@@ -358,40 +584,71 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="flex h-full flex-col overflow-hidden bg-surface-editor">
-    <!-- Chip: inline banner above the editor when we have a pending external change -->
+    <!-- Chip: inline banner above the editor when we have a pending external
+         change. role=status + aria-live=polite live only on the chipMessage
+         span so the buttons aren't dragged into the per-minute re-announce
+         when the relative-time label ages; aria-describedby on every action
+         button gives the chip text as context. -->
     <div
       v-if="conflictState === 'chip'"
       class="flex shrink-0 items-center gap-2 border-b border-border bg-accent/40 px-3 py-1.5 text-caption text-foreground"
     >
-      <RefreshCw class="size-3.5 shrink-0 text-muted-foreground" />
-      <span class="min-w-0 flex-1 truncate">{{ chipMessage }}</span>
-      <Button
-        v-if="isText"
-        variant="ghost"
-        size="sm"
-        class="h-6 shrink-0 px-2 text-xs"
-        @click="openCompare"
+      <FileX
+        v-if="diskState === 'deleted'"
+        class="size-3.5 shrink-0 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <RefreshCw
+        v-else
+        class="size-3.5 shrink-0 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <span
+        :id="chipMessageId"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        class="min-w-0 flex-1 truncate"
+      >{{ chipMessage }}</span>
+      <template
+        v-for="(btn, idx) in chipButtons"
+        :key="idx"
       >
-        <GitCompare class="mr-1 size-3" />
-        {{ t('bots.files.externalChange.compare') }}
-      </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        class="h-6 shrink-0 px-2 text-xs"
-        @click="acceptExternalChange"
-      >
-        {{ t('bots.files.externalChange.reload') }}
-      </Button>
-      <Button
-        v-if="isDirty"
-        variant="ghost"
-        size="sm"
-        class="h-6 shrink-0 px-2 text-xs"
-        @click="forceSave"
-      >
-        {{ t('bots.files.externalChange.saveAnyway') }}
-      </Button>
+        <Button
+          v-if="btn.kind === 'compare'"
+          variant="ghost"
+          size="sm"
+          class="h-6 shrink-0 px-2 text-xs"
+          :aria-describedby="chipMessageId"
+          @click="onChipButton(btn)"
+        >
+          <GitCompare
+            class="mr-1 size-3"
+            aria-hidden="true"
+          />
+          {{ t('bots.files.externalChange.compare') }}
+        </Button>
+        <Button
+          v-else-if="btn.kind === 'reload'"
+          variant="ghost"
+          size="sm"
+          class="h-6 shrink-0 px-2 text-xs"
+          :aria-describedby="chipMessageId"
+          @click="onChipButton(btn)"
+        >
+          {{ t(reloadLabelKey(btn.labelKey)) }}
+        </Button>
+        <Button
+          v-else-if="btn.kind === 'forceSave'"
+          variant="ghost"
+          size="sm"
+          class="h-6 shrink-0 px-2 text-xs"
+          :aria-describedby="chipMessageId"
+          @click="onChipButton(btn)"
+        >
+          {{ t(saveLabelKey(btn.labelKey)) }}
+        </Button>
+      </template>
     </div>
 
     <div class="flex-1 min-h-0 overflow-hidden">
@@ -402,9 +659,31 @@ onBeforeUnmount(() => {
       >
         <div class="flex shrink-0 items-center justify-between gap-3 border-b border-border px-3 py-1.5 text-caption text-muted-foreground">
           <span class="min-w-0 truncate">
-            {{ t('bots.files.compare.yours') }} ↔ {{ t('bots.files.compare.disk') }}
+            <span>{{ t('bots.files.compare.yours') }} ↔ {{ t('bots.files.compare.disk') }}</span>
+            <span
+              v-if="compareStale"
+              :id="compareStaleId"
+              class="ml-2 text-warning"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >· {{ t('bots.files.compare.staleNotice') }}</span>
           </span>
           <div class="flex items-center gap-1.5">
+            <Button
+              v-if="compareStale"
+              variant="ghost"
+              size="sm"
+              class="h-6 px-2 text-xs"
+              :aria-describedby="compareStaleId"
+              @click="refreshCompare"
+            >
+              <RefreshCw
+                class="mr-1 size-3"
+                aria-hidden="true"
+              />
+              {{ t('bots.files.compare.refresh') }}
+            </Button>
             <Button
               variant="ghost"
               size="sm"
@@ -428,7 +707,10 @@ onBeforeUnmount(() => {
               class="h-6 px-2 text-xs text-muted-foreground"
               @click="exitCompare"
             >
-              <X class="mr-1 size-3" />
+              <X
+                class="mr-1 size-3"
+                aria-hidden="true"
+              />
               {{ t('bots.files.compare.close') }}
             </Button>
           </div>
@@ -456,11 +738,22 @@ onBeforeUnmount(() => {
 
       <MonacoEditor
         v-else-if="isText"
+        ref="monacoEditorRef"
         v-model="content"
         :filename="filename"
         :readonly="readonly"
         class="h-full"
       />
+
+      <div
+        v-else-if="isImage && diskState === 'deleted'"
+        class="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground"
+      >
+        <FileX class="size-12 opacity-40 text-destructive" />
+        <p class="text-xs">
+          {{ t('bots.files.imageDeleted') }}
+        </p>
+      </div>
 
       <div
         v-else-if="isImage && imageUrl"

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -51,8 +51,6 @@ const isDirty = computed(() => content.value !== originalContent.value)
 
 watch(isDirty, (dirty) => {
   emit('update:dirty', dirty)
-  // User resolved the conflict by saving or reverting their changes.
-  if (!dirty) externalChangePending.value = false
 }, { immediate: true })
 
 // One in-flight read at a time per viewer; a new load aborts the old one so a
@@ -75,6 +73,7 @@ async function loadTextContent() {
     if (controller.signal.aborted) return
     content.value = data.content ?? ''
     originalContent.value = content.value
+    externalChangePending.value = false
   } catch (error) {
     if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
@@ -106,6 +105,7 @@ async function loadImageBlob() {
     cleanupImageUrl()
     imageUrl.value = url
     url = ''
+    externalChangePending.value = false
   } catch (error) {
     if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
@@ -133,6 +133,7 @@ async function handleSave(): Promise<boolean> {
       throwOnError: true,
     })
     originalContent.value = content.value
+    externalChangePending.value = false
     toast.success(t('bots.files.saveSuccess'))
     emit('saved')
     return true

--- a/apps/web/src/components/file-manager/file-viewer.vue
+++ b/apps/web/src/components/file-manager/file-viewer.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref, watch, computed, onBeforeUnmount } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { appKeyboardCommands } from '@/lib/keyboard-commands'
 import { useKeyboardCommand } from '@/composables/useKeyboardCommand'
 import { isFileSaveEligible } from './file-save-command'
+import { detectSaveConflict, deriveChipContext } from './file-conflict'
 import { useI18n } from 'vue-i18n'
 import { toast } from '@memohai/ui'
-import { File, Download, RefreshCw } from 'lucide-vue-next'
+import { File, Download, RefreshCw, GitCompare, X } from 'lucide-vue-next'
 import { Button, Spinner } from '@memohai/ui'
 import {
   getBotsByBotIdContainerFsRead,
@@ -15,7 +16,9 @@ import {
 import type { HandlersFsFileInfo } from '@memohai/sdk'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import MonacoEditor from '@/components/monaco-editor/index.vue'
+import MonacoDiff from '@/components/monaco-editor/diff.vue'
 import { sdkApiUrl, sdkAuthQuery } from '@/lib/api-client'
+import { formatRelativeTime } from '@/utils/date-time'
 import { isTextFile, isImageFile } from './utils'
 import { useChatStore } from '@/store/chat-list'
 import { storeToRefs } from 'pinia'
@@ -43,16 +46,62 @@ const imageUrl = ref('')
 // stays mounted and the content swaps in place, the way VS Code handles
 // external file changes.
 const loaded = ref(false)
-// Set when the agent rewrites this file while the user has unsaved edits. We
-// don't silently reload (that would lose their work); the template shows an
-// inline notice with a Reload action instead.
-const externalChangePending = ref(false)
+// Timestamp (ms) of the last successful read. Feeds the save baseline guard —
+// any fs bump newer than this for our path means the user would overwrite a
+// fresher disk version. Resets on path change.
+const lastLoadedAt = ref(0)
+// Conflict state machine. 'chip' = inline banner above the editor with the
+// usual choice (Compare / Reload / Save anyway). 'compare' = diff editor
+// replaces the main pane. 'none' = clean.
+const conflictState = ref<'none' | 'chip' | 'compare'>('none')
+// Right side of the diff editor. Snapshot at the moment Compare opens — if
+// the agent writes again while Compare is up, the snapshot stays put (user
+// closes Compare and re-opens to refresh).
+const compareDiskContent = ref('')
+let compareController: AbortController | null = null
+// Drives "5s ago" / "2m ago" relative-time labels in the chip. Ticks once a
+// minute; agent writes are usually fresh enough that "just now" wins, but a
+// chip left up across coffee should age gracefully.
+const nowTick = ref(Date.now())
+let nowTickInterval: ReturnType<typeof setInterval> | null = null
 
 const filename = computed(() => props.file.name ?? '')
 const filePath = computed(() => props.file.path ?? '')
 const isText = computed(() => isTextFile(filename.value))
 const isImage = computed(() => isImageFile(filename.value))
 const isDirty = computed(() => content.value !== originalContent.value)
+
+const chatStore = useChatStore()
+const { fsChangedAt, currentBotId, bots } = storeToRefs(chatStore)
+const botName = computed(() => {
+  const bot = bots.value.find(b => b.id === props.botId)
+  return bot?.display_name || bot?.name || null
+})
+const fsEvent = computed(() => chatStore.fsEventForPath(filePath.value))
+const chipContext = computed(() => deriveChipContext(fsEvent.value, botName.value))
+const fallbackAgent = computed(() => t('bots.files.externalChange.fallbackAgent'))
+const chipMessage = computed(() => {
+  const ctx = chipContext.value
+  const agent = ctx.agentName ?? fallbackAgent.value
+  // formatRelativeTime depends on Date.now(); reading the tick here makes the
+  // label re-evaluate as it ages.
+  void nowTick.value
+  const time = ctx.occurredAt ? formatRelativeTime(new Date(ctx.occurredAt)) : ''
+  if (ctx.kind === 'write' && ctx.newLineCount != null) {
+    return t('bots.files.externalChange.wrote', { agent, lines: ctx.newLineCount, time })
+  }
+  if (ctx.kind === 'edit' && (ctx.addedLines != null || ctx.removedLines != null)) {
+    return t('bots.files.externalChange.edited', {
+      agent,
+      added: ctx.addedLines ?? 0,
+      removed: ctx.removedLines ?? 0,
+      time,
+    })
+  }
+  if (ctx.kind === 'exec') return t('bots.files.externalChange.ran', { agent, time })
+  if (ctx.kind === 'apply_patch') return t('bots.files.externalChange.patched', { agent, time })
+  return t('bots.files.externalChange.generic', { agent, time })
+})
 
 watch(isDirty, (dirty) => {
   emit('update:dirty', dirty)
@@ -78,8 +127,9 @@ async function loadTextContent() {
     if (controller.signal.aborted) return
     content.value = data.content ?? ''
     originalContent.value = content.value
-    externalChangePending.value = false
+    lastLoadedAt.value = Date.now()
     loaded.value = true
+    conflictState.value = 'none'
   } catch (error) {
     if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
@@ -111,8 +161,9 @@ async function loadImageBlob() {
     cleanupImageUrl()
     imageUrl.value = url
     url = ''
-    externalChangePending.value = false
+    lastLoadedAt.value = Date.now()
     loaded.value = true
+    conflictState.value = 'none'
   } catch (error) {
     if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
@@ -128,10 +179,26 @@ async function loadImageBlob() {
 // Returns whether the file is in a saved state afterwards, so an external caller
 // (the tab close-confirm flow) can decide whether to proceed with closing. A
 // read-only or already-clean file reports success without a network round-trip.
-async function handleSave(): Promise<boolean> {
+async function handleSave(force = false): Promise<boolean> {
   if (props.readonly) return true
   if (!isDirty.value) return true
   if (saving.value) return false
+  // VS Code-style two-gate save: even if the chip wasn't surfaced yet (e.g.
+  // user pressed Cmd+S in the brief window between bump and consumer reaction),
+  // re-check the baseline before we POST. force=true skips this — that's the
+  // "Save anyway" path the user explicitly chose after seeing the conflict.
+  if (!force) {
+    const hasConflict = detectSaveConflict({
+      lastFsChangeAt: fsChangedAt.value,
+      lastLoadedAt: lastLoadedAt.value,
+      affects: chatStore.affectsPath(filePath.value),
+    })
+    if (hasConflict) {
+      // Don't drop the user back to compare if they were already comparing.
+      if (conflictState.value !== 'compare') conflictState.value = 'chip'
+      return false
+    }
+  }
   saving.value = true
   try {
     await postBotsByBotIdContainerFsWrite({
@@ -140,7 +207,10 @@ async function handleSave(): Promise<boolean> {
       throwOnError: true,
     })
     originalContent.value = content.value
-    externalChangePending.value = false
+    // The save's POST is the new baseline; subsequent fs bumps from agent
+    // writes after this moment should re-trigger the save guard.
+    lastLoadedAt.value = Date.now()
+    conflictState.value = 'none'
     toast.success(t('bots.files.saveSuccess'))
     emit('saved')
     return true
@@ -152,7 +222,11 @@ async function handleSave(): Promise<boolean> {
   }
 }
 
-defineExpose({ save: handleSave })
+function forceSave() {
+  void handleSave(true)
+}
+
+defineExpose({ save: () => handleSave(false) })
 
 function handleDownload() {
   const url = sdkApiUrl({
@@ -174,10 +248,14 @@ function cleanupImageUrl() {
 }
 
 watch(() => props.file.path, () => {
+  compareController?.abort()
+  compareController = null
   cleanupImageUrl()
   content.value = ''
   originalContent.value = ''
-  externalChangePending.value = false
+  conflictState.value = 'none'
+  compareDiskContent.value = ''
+  lastLoadedAt.value = 0
   loaded.value = false
   if (isText.value) {
     void loadTextContent()
@@ -191,39 +269,67 @@ watch(() => props.file.path, () => {
 // mid-save — the in-flight save owns content/originalContent and we'd race it.
 // If the user has unsaved edits, surface an inline notice rather than silently
 // reloading or silently dropping the agent's change.
-const chatStore = useChatStore()
-const { fsChangedAt, currentBotId } = storeToRefs(chatStore)
 watch(fsChangedAt, () => {
   if (!props.botId || props.botId !== currentBotId.value) return
   if (!chatStore.affectsPath(filePath.value)) return
   if (saving.value) return
   if (isDirty.value) {
-    externalChangePending.value = true
+    // Don't disrupt an active compare view; user is in the middle of reviewing.
+    if (conflictState.value === 'none') conflictState.value = 'chip'
     return
   }
-  if (isText.value) {
-    void loadTextContent()
-  } else if (isImage.value) {
-    void loadImageBlob()
-  }
+  if (isText.value) void loadTextContent()
+  else if (isImage.value) void loadImageBlob()
 })
 
-// Keep the chip visible while the reload is in flight so the user sees a
-// continuous "agent updated · loading · resolved" transition. The isDirty
-// watcher clears externalChangePending the moment the load commits fresh
-// content (content === originalContent → !isDirty), and a failed load leaves
-// the chip up so the user can retry.
 async function acceptExternalChange() {
-  if (isText.value) {
-    await loadTextContent()
-  } else if (isImage.value) {
-    await loadImageBlob()
+  if (isText.value) await loadTextContent()
+  else if (isImage.value) await loadImageBlob()
+}
+
+async function openCompare() {
+  if (!isText.value) return
+  // Prefer the agent's tool-message content — same bytes the server saw, no
+  // extra round trip and immune to "what if disk changed again" races. Fall
+  // back to a fresh read for edit / apply_patch / exec where we don't have the
+  // whole file.
+  const event = fsEvent.value
+  if (event?.writeContent != null) {
+    compareDiskContent.value = event.writeContent
+    conflictState.value = 'compare'
+    return
+  }
+  compareController?.abort()
+  const controller = new AbortController()
+  compareController = controller
+  try {
+    const { data } = await getBotsByBotIdContainerFsRead({
+      path: { bot_id: props.botId },
+      query: { path: filePath.value },
+      signal: controller.signal,
+      throwOnError: true,
+    })
+    if (controller.signal.aborted) return
+    compareDiskContent.value = data.content ?? ''
+    conflictState.value = 'compare'
+  } catch (error) {
+    if (controller.signal.aborted) return
+    toast.error(resolveApiErrorMessage(error, t('bots.files.compareLoadFailed')))
+  } finally {
+    if (compareController === controller) compareController = null
   }
 }
 
-// Save on Cmd/Ctrl+S via the shared keyboard layer. The handler is scoped to this
-// component's lifetime: it returns true only for an editable, dirty text file, so
-// the browser keeps its native save behavior in every other state.
+function exitCompare() {
+  compareController?.abort()
+  compareController = null
+  conflictState.value = 'chip'
+}
+
+// Save on Cmd/Ctrl+S via the shared keyboard layer. Even if a conflict is
+// detected handleSave returns false — but we still report `true` to the
+// keyboard layer because we've already shown the conflict UI; falling through
+// to browser save would be confusing.
 useKeyboardCommand(appKeyboardCommands.saveActiveFile, () => {
   if (!isFileSaveEligible({
     readonly: props.readonly ?? false,
@@ -233,39 +339,115 @@ useKeyboardCommand(appKeyboardCommands.saveActiveFile, () => {
   })) {
     return false
   }
-  void handleSave()
+  void handleSave(false)
   return true
 })
 
+onMounted(() => {
+  nowTickInterval = setInterval(() => { nowTick.value = Date.now() }, 60_000)
+})
+
 onBeforeUnmount(() => {
+  if (nowTickInterval) clearInterval(nowTickInterval)
+  nowTickInterval = null
   activeReadController?.abort()
+  compareController?.abort()
   cleanupImageUrl()
 })
 </script>
 
 <template>
   <div class="flex h-full flex-col overflow-hidden bg-surface-editor">
+    <!-- Chip: inline banner above the editor when we have a pending external change -->
     <div
-      v-if="externalChangePending"
+      v-if="conflictState === 'chip'"
       class="flex shrink-0 items-center gap-2 border-b border-border bg-accent/40 px-3 py-1.5 text-caption text-foreground"
     >
       <RefreshCw class="size-3.5 shrink-0 text-muted-foreground" />
-      <span class="min-w-0 flex-1 truncate">{{ t('bots.files.externalChangeNotice') }}</span>
+      <span class="min-w-0 flex-1 truncate">{{ chipMessage }}</span>
+      <Button
+        v-if="isText"
+        variant="ghost"
+        size="sm"
+        class="h-6 shrink-0 px-2 text-xs"
+        @click="openCompare"
+      >
+        <GitCompare class="mr-1 size-3" />
+        {{ t('bots.files.externalChange.compare') }}
+      </Button>
       <Button
         variant="ghost"
         size="sm"
         class="h-6 shrink-0 px-2 text-xs"
         @click="acceptExternalChange"
       >
-        {{ t('bots.files.externalChangeReload') }}
+        {{ t('bots.files.externalChange.reload') }}
+      </Button>
+      <Button
+        v-if="isDirty"
+        variant="ghost"
+        size="sm"
+        class="h-6 shrink-0 px-2 text-xs"
+        @click="forceSave"
+      >
+        {{ t('bots.files.externalChange.saveAnyway') }}
       </Button>
     </div>
+
     <div class="flex-1 min-h-0 overflow-hidden">
+      <!-- Compare view: diff editor replacing the main pane -->
+      <div
+        v-if="conflictState === 'compare'"
+        class="flex h-full flex-col"
+      >
+        <div class="flex shrink-0 items-center justify-between gap-3 border-b border-border px-3 py-1.5 text-caption text-muted-foreground">
+          <span class="min-w-0 truncate">
+            {{ t('bots.files.compare.yours') }} ↔ {{ t('bots.files.compare.disk') }}
+          </span>
+          <div class="flex items-center gap-1.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              class="h-6 px-2 text-xs"
+              @click="acceptExternalChange"
+            >
+              {{ t('bots.files.externalChange.reload') }}
+            </Button>
+            <Button
+              v-if="isDirty"
+              variant="ghost"
+              size="sm"
+              class="h-6 px-2 text-xs"
+              @click="forceSave"
+            >
+              {{ t('bots.files.externalChange.saveAnyway') }}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              class="h-6 px-2 text-xs text-muted-foreground"
+              @click="exitCompare"
+            >
+              <X class="mr-1 size-3" />
+              {{ t('bots.files.compare.close') }}
+            </Button>
+          </div>
+        </div>
+        <MonacoDiff
+          :original="compareDiskContent"
+          :modified="content"
+          :filename="filename"
+          :original-title="t('bots.files.compare.disk')"
+          :modified-title="t('bots.files.compare.yours')"
+          class="min-h-0 flex-1"
+        />
+      </div>
+
       <!-- Full-area spinner only on the FIRST load for this path (nothing else
            to show). Subsequent reloads keep the editor/image mounted and let
            the content swap in place, matching VS Code's external-change UX. -->
       <div
-        v-if="loading && !loaded"
+        v-else-if="loading && !loaded"
         class="flex h-full items-center justify-center text-muted-foreground"
       >
         <Spinner class="mr-2" />

--- a/apps/web/src/components/monaco-editor/diff.vue
+++ b/apps/web/src/components/monaco-editor/diff.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useMonaco } from 'stream-monaco'
+import { useSettingsStore } from '@/store/settings'
+import { getLanguageByFilename } from '@/components/file-manager/utils'
+
+// Side-by-side Monaco diff editor used by the Compare view inside the file
+// viewer. Reuses stream-monaco's useMonaco so the theme, font, and language
+// resolution match the regular editor. Both sides are read-only — diff resolves
+// to a separate user action (Reload / Save anyway) outside this component.
+
+const props = withDefaults(defineProps<{
+  original: string
+  modified: string
+  filename?: string
+  originalTitle?: string
+  modifiedTitle?: string
+}>(), {
+  filename: undefined,
+  originalTitle: undefined,
+  modifiedTitle: undefined,
+})
+
+const containerRef = ref<HTMLDivElement>()
+const settings = useSettingsStore()
+const fontSize = computed(() => settings.codeFontSizePx)
+const fontFamily = computed(() => settings.codeFontFamily ? settings.codeFontStack : undefined)
+
+function resolveLanguage(): string {
+  if (props.filename) return getLanguageByFilename(props.filename)
+  return 'plaintext'
+}
+
+function resolveThemeName(): string {
+  return document.documentElement.classList.contains('dark')
+    ? settings.shikiThemeDark
+    : settings.shikiThemeLight
+}
+
+const {
+  createDiffEditor,
+  cleanupEditor,
+  updateOriginal,
+  updateModified,
+  setTheme,
+  setLanguage,
+  getDiffEditorView,
+} = useMonaco({
+  theme: resolveThemeName(),
+  themes: [settings.shikiThemeDark, settings.shikiThemeLight],
+  readOnly: true,
+  automaticLayout: true,
+  autoScrollInitial: false,
+  autoScrollOnUpdate: false,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  fontSize: fontSize.value,
+  fontFamily: fontFamily.value,
+  padding: { top: 8, bottom: 8 },
+})
+
+let themeObserver: MutationObserver | null = null
+
+onMounted(async () => {
+  if (!containerRef.value) return
+  await createDiffEditor(
+    containerRef.value,
+    props.original,
+    props.modified,
+    resolveLanguage(),
+  )
+  const view = getDiffEditorView()
+  view?.updateOptions({
+    fontSize: fontSize.value,
+    fontFamily: fontFamily.value,
+    renderSideBySide: true,
+    ignoreTrimWhitespace: false,
+  })
+
+  // Re-apply theme when dark mode flips so the diff editor stays in sync with
+  // the rest of the chrome.
+  themeObserver = new MutationObserver(() => {
+    void setTheme(resolveThemeName(), true)
+  })
+  themeObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class', 'data-color-scheme'],
+  })
+})
+
+onBeforeUnmount(() => {
+  themeObserver?.disconnect()
+  themeObserver = null
+  cleanupEditor()
+})
+
+watch(() => props.original, (v) => updateOriginal(v, resolveLanguage()))
+watch(() => props.modified, (v) => updateModified(v, resolveLanguage()))
+watch(() => props.filename, () => setLanguage(resolveLanguage()))
+watch(fontSize, (v) => getDiffEditorView()?.updateOptions({ fontSize: v }))
+watch(fontFamily, (v) => getDiffEditorView()?.updateOptions({ fontFamily: v }))
+watch(
+  () => [settings.shikiThemeLight, settings.shikiThemeDark] as const,
+  () => { void setTheme(resolveThemeName(), true) },
+)
+</script>
+
+<template>
+  <div class="flex h-full flex-col overflow-hidden bg-surface-editor">
+    <div
+      v-if="originalTitle || modifiedTitle"
+      class="flex shrink-0 items-center justify-between gap-3 border-b border-border px-3 py-1.5 text-caption text-muted-foreground"
+    >
+      <span class="min-w-0 flex-1 truncate">{{ originalTitle }}</span>
+      <span class="text-muted-foreground/60">↔</span>
+      <span class="min-w-0 flex-1 truncate text-right">{{ modifiedTitle }}</span>
+    </div>
+    <div
+      ref="containerRef"
+      class="min-h-0 flex-1 overflow-hidden bg-surface-editor"
+    />
+  </div>
+</template>
+
+<style scoped>
+/* Match the regular editor's surface alignment so the diff plane is continuous
+ * with the workspace chrome. The same selectors that fix the main editor's
+ * background also apply to the diff editor's two panes and gutters. */
+:deep(.monaco-editor),
+:deep(.monaco-diff-editor),
+:deep(.monaco-editor .overflow-guard),
+:deep(.monaco-editor-background),
+:deep(.monaco-editor .margin) {
+  background-color: var(--surface-editor) !important;
+}
+</style>

--- a/apps/web/src/components/sidebar/files-pane.vue
+++ b/apps/web/src/components/sidebar/files-pane.vue
@@ -333,7 +333,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, provide, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from '@memohai/ui'
 import { CloudUpload, Download, FilePlus, FolderPlus, ListChecks, RefreshCw, Trash2, Upload, X } from 'lucide-vue-next'
@@ -379,10 +379,14 @@ const props = withDefaults(defineProps<{
   botId: string
   canWrite?: boolean
   botName?: string
+  active?: boolean
 }>(), {
   canWrite: false,
   botName: '',
+  active: true,
 })
+
+const FILE_TREE_POLL_MS = 2_000
 
 const { t } = useI18n()
 const workspaceTabs = useWorkspaceTabsStore()
@@ -523,6 +527,37 @@ function reload() {
 function reloadAndBroadcast() {
   reload()
   chatStore.markFsChanged()
+}
+
+let treePollTimer: ReturnType<typeof setInterval> | null = null
+
+function isDocumentVisible(): boolean {
+  return typeof document === 'undefined' || document.visibilityState === 'visible'
+}
+
+function pollTree() {
+  if (!props.botId || !props.active || !isDocumentVisible()) return
+  reload()
+}
+
+function startTreePoll() {
+  if (treePollTimer !== null || !props.botId || !props.active) return
+  treePollTimer = window.setInterval(pollTree, FILE_TREE_POLL_MS)
+}
+
+function stopTreePoll() {
+  if (treePollTimer === null) return
+  window.clearInterval(treePollTimer)
+  treePollTimer = null
+}
+
+function handleVisibilityChange() {
+  if (!props.active || !isDocumentVisible()) {
+    stopTreePoll()
+    return
+  }
+  reload()
+  startTreePoll()
 }
 
 // Reveal a path in the tree (expand its ancestors + scroll into view). Used by
@@ -1069,6 +1104,25 @@ watch(() => props.botId, () => {
 watch(fsChangedAt, () => {
   if (!props.botId) return
   reload()
+})
+
+watch(() => [props.botId, props.active] as const, ([botId, active]) => {
+  if (botId && active && isDocumentVisible()) {
+    reload()
+    startTreePoll()
+  } else {
+    stopTreePoll()
+  }
+}, { immediate: true })
+
+onMounted(() => {
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+  if (props.active && isDocumentVisible()) startTreePoll()
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
+  stopTreePoll()
 })
 
 defineExpose({

--- a/apps/web/src/components/sidebar/files-pane.vue
+++ b/apps/web/src/components/sidebar/files-pane.vue
@@ -54,7 +54,7 @@
           variant="ghost"
           class="size-[26px] shrink-0 p-0 text-muted-foreground/70 hover:text-foreground"
           :title="t('common.refresh')"
-          @click="reload"
+          @click="reloadAndBroadcast"
         >
           <RefreshCw class="size-4" />
         </Button>
@@ -160,7 +160,7 @@
               </ContextMenuItem>
               <ContextMenuSeparator />
             </template>
-            <ContextMenuItem @select="reload">
+            <ContextMenuItem @select="reloadAndBroadcast">
               <RefreshCw class="mr-2 size-3.5" />
               {{ t('common.refresh') }}
             </ContextMenuItem>
@@ -386,7 +386,9 @@ const props = withDefaults(defineProps<{
 
 const { t } = useI18n()
 const workspaceTabs = useWorkspaceTabsStore()
+const chatStore = useChatStore()
 const { activeId } = storeToRefs(workspaceTabs)
+const { fsChangedAt } = storeToRefs(chatStore)
 const canWrite = computed(() => props.canWrite)
 
 const rootPath = '/data'
@@ -512,6 +514,15 @@ async function safeListDirectory(path: string): Promise<HandlersFsFileInfo[]> {
 
 function reload() {
   refreshKey.value++
+}
+
+// User-driven mutations call this to refresh the local tree AND tell the chat
+// store so any open file viewer / preview reloads its content. Keep this OFF
+// the fsChangedAt watcher path or the watcher would re-bump fsChangedAt and
+// loop forever.
+function reloadAndBroadcast() {
+  reload()
+  chatStore.markFsChanged()
 }
 
 // Reveal a path in the tree (expand its ancestors + scroll into view). Used by
@@ -703,7 +714,7 @@ async function uploadDirectoryPayload(payload: DirectoryUploadPayload) {
     } else {
       toast.success(t('bots.files.uploadFolderSuccess'))
     }
-    reload()
+    reloadAndBroadcast()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.files.uploadFailed')))
   } finally {
@@ -729,7 +740,7 @@ async function handleUpload(event: Event) {
     })
     toast.success(t('bots.files.uploadSuccess'))
     if (uploadTarget.value !== rootPath) navigateTo(uploadTarget.value)
-    reload()
+    reloadAndBroadcast()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.files.uploadFailed')))
   } finally {
@@ -766,7 +777,7 @@ async function handleNewFile() {
     })
     newFileDialogOpen.value = false
     toast.success(t('bots.files.newFileSuccess'))
-    reload()
+    reloadAndBroadcast()
     workspaceTabs.openFile(filePath)
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.files.newFileFailed')))
@@ -804,7 +815,7 @@ async function handleMkdir() {
     mkdirDialogOpen.value = false
     toast.success(t('bots.files.mkdirSuccess'))
     if (mkdirTarget.value !== rootPath) navigateTo(mkdirTarget.value)
-    reload()
+    reloadAndBroadcast()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.files.mkdirFailed')))
   } finally {
@@ -844,7 +855,7 @@ async function handleRename() {
     })
     renameDialogOpen.value = false
     toast.success(t('bots.files.renameSuccess'))
-    reload()
+    reloadAndBroadcast()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.files.renameFailed')))
   } finally {
@@ -883,7 +894,7 @@ async function handleDelete() {
       next.delete(target.path)
       selectedEntries.value = next
     }
-    reload()
+    reloadAndBroadcast()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.files.deleteFailed')))
   } finally {
@@ -971,7 +982,7 @@ async function handleBatchDelete() {
     } else {
       toast.success(t('bots.files.deleteSuccess'))
     }
-    reload()
+    reloadAndBroadcast()
   } finally {
     batchDeleteLoading.value = false
   }
@@ -997,7 +1008,7 @@ async function handleExtract(entry: HandlersFsFileInfo) {
       throw new Error(await readErrorMessage(response, t('bots.files.extractFailed')))
     }
     toast.success(t('bots.files.extractSuccess'))
-    reload()
+    reloadAndBroadcast()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.files.extractFailed')))
   } finally {
@@ -1053,8 +1064,8 @@ watch(() => props.botId, () => {
 }, { immediate: true })
 
 // Auto-refresh listing when the chat agent runs a fs-mutating tool (write/edit/apply_patch/exec).
-const chatStore = useChatStore()
-const { fsChangedAt } = storeToRefs(chatStore)
+// Stay on the local reload() — calling reloadAndBroadcast here would re-bump
+// fsChangedAt and the watcher would loop on itself.
 watch(fsChangedAt, () => {
   if (!props.botId) return
   reload()

--- a/apps/web/src/components/sidebar/panel-files.vue
+++ b/apps/web/src/components/sidebar/panel-files.vue
@@ -5,6 +5,7 @@
     :bot-id="currentBotId"
     :can-write="canWorkspaceWrite"
     :bot-name="currentBot?.display_name || currentBot?.name || ''"
+    :active="sidebarView === 'files' && workbenchOpen"
   />
   <div
     v-else
@@ -27,7 +28,7 @@ const { t } = useI18n()
 const chatStore = useChatStore()
 const workspaceTabs = useWorkspaceTabsStore()
 const { currentBotId, bots } = storeToRefs(chatStore)
-const { pendingFilesPath } = storeToRefs(workspaceTabs)
+const { pendingFilesPath, sidebarView, workbenchOpen } = storeToRefs(workspaceTabs)
 
 const currentBot = computed(() =>
   bots.value.find(bot => bot.id === currentBotId.value) ?? null,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1739,8 +1739,23 @@
       "deleteSuccess": "Deleted successfully",
       "batchDeletePartialFailed": "{failed}/{total} items failed to delete",
       "deleteFailed": "Failed to delete",
-      "externalChangeNotice": "Agent updated this file in the workspace",
-      "externalChangeReload": "Reload"
+      "externalChange": {
+        "fallbackAgent": "The agent",
+        "wrote": "{agent} wrote {lines} lines · {time}",
+        "edited": "{agent} edited (+{added} / -{removed}) · {time}",
+        "ran": "{agent} ran a command · {time}",
+        "patched": "{agent} applied a patch · {time}",
+        "generic": "{agent} updated this file · {time}",
+        "reload": "Reload",
+        "compare": "Compare",
+        "saveAnyway": "Save anyway"
+      },
+      "compare": {
+        "yours": "Your edits",
+        "disk": "On disk",
+        "close": "Close"
+      },
+      "compareLoadFailed": "Could not load the workspace version for comparison"
     },
     "email": {
       "title": "Email",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1738,7 +1738,9 @@
       "extractFailed": "Failed to extract archive",
       "deleteSuccess": "Deleted successfully",
       "batchDeletePartialFailed": "{failed}/{total} items failed to delete",
-      "deleteFailed": "Failed to delete"
+      "deleteFailed": "Failed to delete",
+      "externalChangeNotice": "Agent updated this file in the workspace",
+      "externalChangeReload": "Reload"
     },
     "email": {
       "title": "Email",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1746,14 +1746,22 @@
         "ran": "{agent} ran a command · {time}",
         "patched": "{agent} applied a patch · {time}",
         "generic": "{agent} updated this file · {time}",
+        "deleted": "This file was removed or moved on disk",
+        "reloadFailed": "This file changed on disk, but the latest version could not be loaded",
+        "saveConflict": "File changed on disk. Review the external version before saving.",
         "reload": "Reload",
+        "tryAgain": "Try again",
         "compare": "Compare",
-        "saveAnyway": "Save anyway"
+        "saveAnyway": "Save anyway",
+        "saveToRestore": "Save to restore"
       },
+      "imageDeleted": "This image was removed from the workspace",
       "compare": {
         "yours": "Your edits",
         "disk": "On disk",
-        "close": "Close"
+        "close": "Close",
+        "refresh": "Refresh diff",
+        "staleNotice": "The agent wrote again"
       },
       "compareLoadFailed": "Could not load the workspace version for comparison"
     },

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1752,7 +1752,9 @@
       "extractFailed": "アーカイブの抽出に失敗しました",
       "deleteSuccess": "正常に削除されました",
       "batchDeletePartialFailed": "{failed}/{total} アイテムを削除できませんでした",
-      "deleteFailed": "削除に失敗しました"
+      "deleteFailed": "削除に失敗しました",
+      "externalChangeNotice": "Agent がワークスペースでこのファイルを更新しました",
+      "externalChangeReload": "再読み込み"
     },
     "email": {
       "title": "Email",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1753,8 +1753,23 @@
       "deleteSuccess": "正常に削除されました",
       "batchDeletePartialFailed": "{failed}/{total} アイテムを削除できませんでした",
       "deleteFailed": "削除に失敗しました",
-      "externalChangeNotice": "Agent がワークスペースでこのファイルを更新しました",
-      "externalChangeReload": "再読み込み"
+      "externalChange": {
+        "fallbackAgent": "Agent",
+        "wrote": "{agent} が {lines} 行を書き込みました · {time}",
+        "edited": "{agent} が編集しました（+{added} / -{removed}）· {time}",
+        "ran": "{agent} がコマンドを実行しました · {time}",
+        "patched": "{agent} がパッチを適用しました · {time}",
+        "generic": "{agent} がこのファイルを更新しました · {time}",
+        "reload": "再読み込み",
+        "compare": "比較",
+        "saveAnyway": "強制保存"
+      },
+      "compare": {
+        "yours": "あなたの編集",
+        "disk": "ワークスペース",
+        "close": "閉じる"
+      },
+      "compareLoadFailed": "比較用のワークスペースのバージョンを読み込めませんでした"
     },
     "email": {
       "title": "Email",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1760,14 +1760,22 @@
         "ran": "{agent} がコマンドを実行しました · {time}",
         "patched": "{agent} がパッチを適用しました · {time}",
         "generic": "{agent} がこのファイルを更新しました · {time}",
+        "deleted": "このファイルはワークスペースで削除または移動されました",
+        "reloadFailed": "このファイルはワークスペースで変更されましたが、最新バージョンを読み込めませんでした",
+        "saveConflict": "ファイルはワークスペースで変更されています。保存前に外部バージョンを確認してください。",
         "reload": "再読み込み",
+        "tryAgain": "もう一度試す",
         "compare": "比較",
-        "saveAnyway": "強制保存"
+        "saveAnyway": "このまま保存",
+        "saveToRestore": "保存して復元"
       },
+      "imageDeleted": "この画像はワークスペースから削除されました",
       "compare": {
         "yours": "あなたの編集",
-        "disk": "ワークスペース",
-        "close": "閉じる"
+        "disk": "ディスク上",
+        "close": "閉じる",
+        "refresh": "差分を更新",
+        "staleNotice": "Agent がもう一度書き込みました"
       },
       "compareLoadFailed": "比較用のワークスペースのバージョンを読み込めませんでした"
     },

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1738,7 +1738,9 @@
       "extractFailed": "解压失败",
       "deleteSuccess": "删除成功",
       "batchDeletePartialFailed": "{failed}/{total} 项删除失败",
-      "deleteFailed": "删除失败"
+      "deleteFailed": "删除失败",
+      "externalChangeNotice": "Agent 已在工作区中更新此文件",
+      "externalChangeReload": "重新加载"
     },
     "email": {
       "title": "邮件",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1739,8 +1739,23 @@
       "deleteSuccess": "删除成功",
       "batchDeletePartialFailed": "{failed}/{total} 项删除失败",
       "deleteFailed": "删除失败",
-      "externalChangeNotice": "Agent 已在工作区中更新此文件",
-      "externalChangeReload": "重新加载"
+      "externalChange": {
+        "fallbackAgent": "Agent",
+        "wrote": "{agent} 写入了 {lines} 行 · {time}",
+        "edited": "{agent} 修改了（+{added} / -{removed}）· {time}",
+        "ran": "{agent} 执行了命令 · {time}",
+        "patched": "{agent} 应用了补丁 · {time}",
+        "generic": "{agent} 更新了此文件 · {time}",
+        "reload": "重新加载",
+        "compare": "对比",
+        "saveAnyway": "强制保存"
+      },
+      "compare": {
+        "yours": "你的编辑",
+        "disk": "工作区中",
+        "close": "关闭"
+      },
+      "compareLoadFailed": "无法加载工作区版本用于对比"
     },
     "email": {
       "title": "邮件",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1746,14 +1746,22 @@
         "ran": "{agent} 执行了命令 · {time}",
         "patched": "{agent} 应用了补丁 · {time}",
         "generic": "{agent} 更新了此文件 · {time}",
+        "deleted": "此文件已在工作区中被删除或移动",
+        "reloadFailed": "此文件在工作区中已变更，但无法加载最新版本",
+        "saveConflict": "文件已在工作区中变更。请先查看外部版本再保存。",
         "reload": "重新加载",
+        "tryAgain": "重试",
         "compare": "对比",
-        "saveAnyway": "强制保存"
+        "saveAnyway": "仍要保存",
+        "saveToRestore": "保存以重建"
       },
+      "imageDeleted": "此图片已在工作区中被删除",
       "compare": {
         "yours": "你的编辑",
-        "disk": "工作区中",
-        "close": "关闭"
+        "disk": "磁盘上",
+        "close": "关闭",
+        "refresh": "刷新差异",
+        "staleNotice": "Agent 又写过一次"
       },
       "compareLoadFailed": "无法加载工作区版本用于对比"
     },

--- a/apps/web/src/pages/home/components/dockview/panel-preview.test.ts
+++ b/apps/web/src/pages/home/components/dockview/panel-preview.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { createApp, nextTick, ref } from 'vue'
+import PanelPreview from './panel-preview.vue'
+import { useChatStore } from '@/store/chat-list'
+
+const sdk = vi.hoisted(() => ({
+  getBots: vi.fn(),
+  getBotsByBotIdSessions: vi.fn(),
+  getBotsByBotIdContainerFsRead: vi.fn(),
+}))
+
+vi.mock('@memohai/sdk', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@memohai/sdk')>()
+  return { ...original, ...sdk }
+})
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+vi.mock('@memohai/ui', () => ({
+  Spinner: { template: '<span />' },
+  toast: { error: vi.fn() },
+}))
+vi.mock('@/components/markdown-preview/index.vue', () => ({
+  default: {
+    props: ['content'],
+    template: '<article>{{ content }}</article>',
+  },
+}))
+vi.mock('@/components/html-preview/index.vue', () => ({
+  default: {
+    props: ['content'],
+    template: '<article>{{ content }}</article>',
+  },
+}))
+vi.mock('./use-panel-visible', () => ({
+  usePanelVisible: () => ref(true),
+}))
+
+async function flush() {
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('panel-preview refresh', () => {
+  let root: HTMLElement
+  let app: ReturnType<typeof createApp>
+  let pinia: ReturnType<typeof createPinia>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    pinia = createPinia()
+    setActivePinia(pinia)
+    const chatStore = useChatStore()
+    chatStore.currentBotId = 'bot-1'
+    sdk.getBots.mockResolvedValue({ data: { items: [{ id: 'bot-1', status: 'active', name: 'Bot' }] } })
+    sdk.getBotsByBotIdSessions.mockResolvedValue({ data: { items: [] } })
+    sdk.getBotsByBotIdContainerFsRead.mockReset()
+    root = document.createElement('div')
+    document.body.append(root)
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    root.remove()
+    vi.useRealTimers()
+  })
+
+  it('polls a visible markdown preview so external file edits refresh without a chat fs bump', async () => {
+    sdk.getBotsByBotIdContainerFsRead
+      .mockResolvedValueOnce({ data: { content: 'first' } })
+      .mockResolvedValueOnce({ data: { content: 'second' } })
+
+    app = createApp(PanelPreview, {
+      params: {
+        params: { filePath: '/data/readme.md' },
+        api: {},
+        containerApi: {},
+      },
+    })
+    app.use(pinia)
+    app.mount(root)
+    await flush()
+
+    expect(sdk.getBotsByBotIdContainerFsRead).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(2_000)
+    await flush()
+
+    expect(sdk.getBotsByBotIdContainerFsRead).toHaveBeenCalledTimes(2)
+    expect(sdk.getBotsByBotIdContainerFsRead).toHaveBeenLastCalledWith(expect.objectContaining({
+      path: { bot_id: 'bot-1' },
+      query: { path: '/data/readme.md' },
+    }))
+  })
+})

--- a/apps/web/src/pages/home/components/dockview/panel-preview.vue
+++ b/apps/web/src/pages/home/components/dockview/panel-preview.vue
@@ -76,10 +76,13 @@ const canPreview = computed(() => isMd.value || isHtml.value)
 
 const content = ref('')
 const loading = ref(false)
+// Tagged on every load so stale fast-fire responses can't clobber newer content.
+let loadSeq = 0
 
 async function load() {
   const botId = currentBotId.value
   if (!botId || !filePath.value || !canPreview.value) return
+  const epoch = ++loadSeq
   loading.value = true
   try {
     const { data } = await getBotsByBotIdContainerFsRead({
@@ -87,11 +90,13 @@ async function load() {
       query: { path: filePath.value },
       throwOnError: true,
     })
+    if (epoch !== loadSeq) return
     content.value = data.content ?? ''
   } catch (error) {
+    if (epoch !== loadSeq) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
   } finally {
-    loading.value = false
+    if (epoch === loadSeq) loading.value = false
   }
 }
 

--- a/apps/web/src/pages/home/components/dockview/panel-preview.vue
+++ b/apps/web/src/pages/home/components/dockview/panel-preview.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, onBeforeUnmount, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { FileText } from 'lucide-vue-next'
@@ -76,27 +76,34 @@ const canPreview = computed(() => isMd.value || isHtml.value)
 
 const content = ref('')
 const loading = ref(false)
-// Tagged on every load so stale fast-fire responses can't clobber newer content.
-let loadSeq = 0
+// One in-flight load at a time; a new load aborts the old one so stale
+// fast-fire responses can't clobber newer content.
+let activeLoadController: AbortController | null = null
 
 async function load() {
   const botId = currentBotId.value
   if (!botId || !filePath.value || !canPreview.value) return
-  const epoch = ++loadSeq
+  activeLoadController?.abort()
+  const controller = new AbortController()
+  activeLoadController = controller
   loading.value = true
   try {
     const { data } = await getBotsByBotIdContainerFsRead({
       path: { bot_id: botId },
       query: { path: filePath.value },
+      signal: controller.signal,
       throwOnError: true,
     })
-    if (epoch !== loadSeq) return
+    if (controller.signal.aborted) return
     content.value = data.content ?? ''
   } catch (error) {
-    if (epoch !== loadSeq) return
+    if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
   } finally {
-    if (epoch === loadSeq) loading.value = false
+    if (activeLoadController === controller) {
+      activeLoadController = null
+      loading.value = false
+    }
   }
 }
 
@@ -107,6 +114,12 @@ watch([visible, filePath], ([isVisible]) => {
 }, { immediate: true })
 
 watch(fsChangedAt, () => {
-  if (visible.value) void load()
+  if (!visible.value) return
+  if (!chatStore.affectsPath(filePath.value)) return
+  void load()
+})
+
+onBeforeUnmount(() => {
+  activeLoadController?.abort()
 })
 </script>

--- a/apps/web/src/pages/home/components/dockview/panel-preview.vue
+++ b/apps/web/src/pages/home/components/dockview/panel-preview.vue
@@ -2,8 +2,10 @@
   <div class="flex flex-col h-full w-full bg-surface-editor">
     <PanelBreadcrumb :path="filePath" />
     <div class="flex-1 min-h-0">
+      <!-- Full-area spinner only on the first load. Reloads keep the rendered
+           markdown/html mounted and swap content in place. -->
       <div
-        v-if="loading"
+        v-if="loading && !loaded"
         class="flex h-full items-center justify-center text-muted-foreground"
       >
         <Spinner class="mr-2" />
@@ -76,6 +78,9 @@ const canPreview = computed(() => isMd.value || isHtml.value)
 
 const content = ref('')
 const loading = ref(false)
+// True once the preview has been rendered at least once for the current path,
+// so subsequent reloads can update content in place without flashing a spinner.
+const loaded = ref(false)
 // One in-flight load at a time; a new load aborts the old one so stale
 // fast-fire responses can't clobber newer content.
 let activeLoadController: AbortController | null = null
@@ -96,6 +101,7 @@ async function load() {
     })
     if (controller.signal.aborted) return
     content.value = data.content ?? ''
+    loaded.value = true
   } catch (error) {
     if (controller.signal.aborted) return
     toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
@@ -108,7 +114,13 @@ async function load() {
 }
 
 // Load when the panel first becomes visible / its target changes, and refresh
-// when the agent mutates the workspace.
+// when the agent mutates the workspace. Path change starts the "loaded" clock
+// from scratch so the user sees the spinner only for the new target's first
+// fetch.
+watch(filePath, () => {
+  loaded.value = false
+  content.value = ''
+})
 watch([visible, filePath], ([isVisible]) => {
   if (isVisible) void load()
 }, { immediate: true })

--- a/apps/web/src/pages/home/components/dockview/panel-preview.vue
+++ b/apps/web/src/pages/home/components/dockview/panel-preview.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { FileText } from 'lucide-vue-next'
@@ -64,6 +64,7 @@ const props = defineProps<{
 const { t } = useI18n()
 const chatStore = useChatStore()
 const { currentBotId, fsChangedAt } = storeToRefs(chatStore)
+const PREVIEW_POLL_MS = 2_000
 
 const visible = usePanelVisible(props.params.api)
 const filePath = computed(() => props.params.params.filePath ?? '')
@@ -84,8 +85,13 @@ const loaded = ref(false)
 // One in-flight load at a time; a new load aborts the old one so stale
 // fast-fire responses can't clobber newer content.
 let activeLoadController: AbortController | null = null
+let previewPollTimer: ReturnType<typeof setInterval> | null = null
 
-async function load() {
+function isDocumentVisible(): boolean {
+  return typeof document === 'undefined' || document.visibilityState === 'visible'
+}
+
+async function load(options: { notifyOnError?: boolean } = {}) {
   const botId = currentBotId.value
   if (!botId || !filePath.value || !canPreview.value) return
   activeLoadController?.abort()
@@ -104,13 +110,24 @@ async function load() {
     loaded.value = true
   } catch (error) {
     if (controller.signal.aborted) return
-    toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
+    if (options.notifyOnError !== false) {
+      toast.error(resolveApiErrorMessage(error, t('bots.files.readFailed')))
+    }
   } finally {
     if (activeLoadController === controller) {
       activeLoadController = null
       loading.value = false
     }
   }
+}
+
+function pollPreview() {
+  if (!visible.value || !loaded.value || loading.value || !isDocumentVisible()) return
+  void load({ notifyOnError: false })
+}
+
+function handleVisibilityChange() {
+  if (visible.value && isDocumentVisible()) void load({ notifyOnError: false })
 }
 
 // Load when the panel first becomes visible / its target changes, and refresh
@@ -131,7 +148,17 @@ watch(fsChangedAt, () => {
   void load()
 })
 
+onMounted(() => {
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+  previewPollTimer = window.setInterval(pollPreview, PREVIEW_POLL_MS)
+})
+
 onBeforeUnmount(() => {
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
+  if (previewPollTimer !== null) {
+    window.clearInterval(previewPollTimer)
+    previewPollTimer = null
+  }
   activeLoadController?.abort()
 })
 </script>

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1750,3 +1750,179 @@ describe('fsChangedAt markFsChanged()', () => {
     expect(store.fsChangedAt).toBeGreaterThan(afterFirst)
   })
 })
+
+describe('path-tagged fs change batches', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('records the path in the batch and exposes it via affectsPath()', () => {
+    const store = useChatStore()
+    store.markFsChanged('/data/foo.ts')
+    vi.advanceTimersByTime(150)
+    expect(store.affectsPath('/data/foo.ts')).toBe(true)
+    expect(store.affectsPath('/data/bar.ts')).toBe(false)
+  })
+
+  it('merges multiple paths within a single debounce window', () => {
+    const store = useChatStore()
+    store.markFsChanged('/data/a.ts')
+    store.markFsChanged('/data/b.ts')
+    vi.advanceTimersByTime(150)
+    expect(store.affectsPath('/data/a.ts')).toBe(true)
+    expect(store.affectsPath('/data/b.ts')).toBe(true)
+    expect(store.affectsPath('/data/c.ts')).toBe(false)
+  })
+
+  it('null in any bump within the window poisons the batch to wildcard', () => {
+    const store = useChatStore()
+    store.markFsChanged('/data/a.ts')
+    store.markFsChanged(null)
+    store.markFsChanged('/data/b.ts')
+    vi.advanceTimersByTime(150)
+    expect(store.affectsPath('/anything.ts')).toBe(true)
+  })
+
+  it('treats markFsChanged() with no argument as wildcard', () => {
+    const store = useChatStore()
+    store.markFsChanged()
+    vi.advanceTimersByTime(150)
+    expect(store.affectsPath('/anything.ts')).toBe(true)
+  })
+
+  it('returns false from affectsPath() before any bump fires', () => {
+    const store = useChatStore()
+    store.markFsChanged('/data/a.ts')
+    expect(store.affectsPath('/data/a.ts')).toBe(false)
+    vi.advanceTimersByTime(150)
+    expect(store.affectsPath('/data/a.ts')).toBe(true)
+  })
+
+  it('resets the path set after the batch fires', () => {
+    const store = useChatStore()
+    store.markFsChanged('/data/a.ts')
+    vi.advanceTimersByTime(150)
+    expect(store.affectsPath('/data/a.ts')).toBe(true)
+
+    store.markFsChanged('/data/b.ts')
+    vi.advanceTimersByTime(150)
+    expect(store.affectsPath('/data/a.ts')).toBe(false)
+    expect(store.affectsPath('/data/b.ts')).toBe(true)
+  })
+})
+
+describe('fs-mutating tool path extraction', () => {
+  let lastStreamId = ''
+  let lastSessionId = ''
+  let sendEvents: UIStreamEvent[]
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    lastStreamId = ''
+    lastSessionId = ''
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    vi.clearAllMocks()
+
+    api.fetchBots.mockResolvedValue([{ id: 'bot-1', status: 'active', name: 'Bot' }])
+    api.fetchSessions.mockResolvedValue([])
+    api.createSession.mockResolvedValue({
+      id: 'session-1',
+      bot_id: 'bot-1',
+      title: 'New session',
+      type: 'chat',
+    })
+    api.fetchMessagesUI.mockResolvedValue([])
+    api.streamMessageEvents.mockImplementation((_botId: string, signal: AbortSignal) => new Promise<void>((resolve) => {
+      signal.addEventListener('abort', () => resolve(), { once: true })
+    }))
+    api.connectWebSocket.mockImplementation((_botId: string, onStreamEvent: UIStreamEventHandler) => {
+      return {
+        get connected() { return true },
+        send: vi.fn((message: { stream_id?: string; session_id?: string }) => {
+          lastStreamId = message.stream_id ?? ''
+          lastSessionId = message.session_id ?? ''
+          for (const event of sendEvents) {
+            onStreamEvent({
+              ...event,
+              stream_id: lastStreamId,
+              session_id: lastSessionId,
+            } as UIStreamEvent)
+          }
+        }),
+        abort: vi.fn(),
+        close: vi.fn(),
+        onOpen: null,
+        onClose: null,
+      }
+    })
+  })
+
+  it('tags the batch with input.path for write and edit tools', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-write',
+          input: { path: '/data/touched-by-write.ts', content: 'x' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 2,
+          type: 'tool',
+          name: 'edit',
+          tool_call_id: 'call-edit',
+          input: { path: '/data/touched-by-edit.ts', old_text: 'a', new_text: 'b' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('do work')
+
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(store.affectsPath('/data/touched-by-write.ts')).toBe(true)
+    expect(store.affectsPath('/data/touched-by-edit.ts')).toBe(true)
+    expect(store.affectsPath('/data/untouched.ts')).toBe(false)
+  })
+
+  it('falls back to wildcard when exec completes (path unknown)', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'exec',
+          tool_call_id: 'call-exec',
+          input: { command: 'rm -rf /data/maybe' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('exec')
+
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(store.affectsPath('/data/anything.ts')).toBe(true)
+  })
+})

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1690,6 +1690,47 @@ describe('chat-list store', () => {
     expect(store.fsChangedAt).toBe(before)
   })
 
+  it('bumps fsChangedAt when a refresh delivers a fs-mutating tool from another channel', async () => {
+    api.fetchSessions.mockResolvedValueOnce([
+      { id: 'session-1', bot_id: 'bot-1', title: 'Chat', type: 'chat' },
+    ])
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+
+    api.fetchMessagesUI.mockResolvedValueOnce([{
+      id: 'assistant-1',
+      role: 'assistant',
+      messages: [{
+        id: 1,
+        type: 'tool',
+        name: 'write',
+        tool_call_id: 'call-cross-channel-write',
+        input: { path: '/data/cross-channel.md', content: 'hi' },
+        running: false,
+      }],
+      timestamp: new Date().toISOString(),
+    }])
+
+    messageEventsHandler?.({
+      type: 'message_created',
+      bot_id: 'bot-1',
+      message: {
+        id: 'msg-write',
+        bot_id: 'bot-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'tool',
+        created_at: new Date().toISOString(),
+      },
+    })
+
+    // 100ms refresh schedule + 150ms fs debounce + slack.
+    await new Promise(resolve => setTimeout(resolve, 350))
+
+    expect(store.affectsPath('/data/cross-channel.md')).toBe(true)
+  })
+
   it('does not bump fsChangedAt while a fs-mutating tool is still running', async () => {
     sendEvents = [
       { type: 'start' } as UIStreamEvent,

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1787,6 +1787,51 @@ describe('chat-list store', () => {
     expect(store.affectsPath('/data/cross-channel.md')).toBe(true)
   })
 
+  it('bumps fsChangedAt when a non-current session refresh delivers a fs-mutating tool', async () => {
+    api.fetchSessions.mockResolvedValueOnce([
+      { id: 'session-1', bot_id: 'bot-1', title: 'Current', type: 'chat' },
+      { id: 'session-2', bot_id: 'bot-1', title: 'Other', type: 'chat' },
+    ])
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+    expect(store.sessionId).toBe('session-1')
+
+    api.fetchMessagesUI.mockClear()
+    api.fetchMessagesUI.mockResolvedValueOnce([{
+      id: 'assistant-2',
+      role: 'assistant',
+      messages: [{
+        id: 1,
+        type: 'tool',
+        name: 'write',
+        tool_call_id: 'call-other-session-write',
+        input: { path: '/data/other-session.md', content: 'hi' },
+        running: false,
+      }],
+      timestamp: new Date().toISOString(),
+    }])
+
+    messageEventsHandler?.({
+      type: 'message_created',
+      bot_id: 'bot-1',
+      message: {
+        id: 'msg-write-other-session',
+        bot_id: 'bot-1',
+        session_id: 'session-2',
+        role: 'assistant',
+        content: 'tool',
+        created_at: new Date().toISOString(),
+      },
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 350))
+
+    expect(api.fetchMessagesUI).toHaveBeenCalledWith('bot-1', 'session-2', { limit: 30 })
+    expect(store.sessionId).toBe('session-1')
+    expect(store.affectsPath('/data/other-session.md')).toBe(true)
+  })
+
   it('does not bump fsChangedAt while a fs-mutating tool is still running', async () => {
     sendEvents = [
       { type: 'start' } as UIStreamEvent,

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -2051,6 +2051,298 @@ describe('fs-mutating tool path extraction', () => {
   })
 })
 
+describe('fs change events per-path metadata', () => {
+  let lastStreamId = ''
+  let lastSessionId = ''
+  let sendEvents: UIStreamEvent[]
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    lastStreamId = ''
+    lastSessionId = ''
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    vi.clearAllMocks()
+    api.fetchBots.mockResolvedValue([{ id: 'bot-1', status: 'active', name: 'Bot 1' }])
+    api.fetchSessions.mockResolvedValue([
+      { id: 'session-1', bot_id: 'bot-1', title: 'Chat', type: 'chat' },
+    ])
+    api.createSession.mockResolvedValue({
+      id: 'session-1',
+      bot_id: 'bot-1',
+      title: 'Chat',
+      type: 'chat',
+    })
+    api.fetchMessagesUI.mockResolvedValue([])
+    api.streamMessageEvents.mockImplementation((_botId: string, signal: AbortSignal) => new Promise<void>((resolve) => {
+      signal.addEventListener('abort', () => resolve(), { once: true })
+    }))
+    api.connectWebSocket.mockImplementation((_botId: string, onStreamEvent: UIStreamEventHandler) => {
+      return {
+        get connected() { return true },
+        send: vi.fn((message: { stream_id?: string; session_id?: string }) => {
+          lastStreamId = message.stream_id ?? ''
+          lastSessionId = message.session_id ?? ''
+          for (const event of sendEvents) {
+            onStreamEvent({
+              ...event,
+              stream_id: lastStreamId,
+              session_id: lastSessionId,
+            } as UIStreamEvent)
+          }
+        }),
+        abort: vi.fn(),
+        close: vi.fn(),
+        onOpen: null,
+        onClose: null,
+      }
+    })
+  })
+
+  it('records writeContent on the per-path event for a write tool', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-w',
+          input: { path: '/data/foo.ts', content: 'hello\nworld\n' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('write foo')
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    const event = store.fsEventForPath('/data/foo.ts')
+    expect(event).not.toBe(null)
+    expect(event?.kind).toBe('write')
+    expect(event?.toolCallId).toBe('call-w')
+    expect(event?.writeContent).toBe('hello\nworld\n')
+    expect(event?.sessionId).toBe('session-1')
+  })
+
+  it('records old_text/new_text on the event for an edit tool', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'edit',
+          tool_call_id: 'call-e',
+          input: {
+            path: '/data/bar.ts',
+            old_text: 'old line',
+            new_text: 'new line one\nnew line two',
+          },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('edit bar')
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    const event = store.fsEventForPath('/data/bar.ts')
+    expect(event).not.toBe(null)
+    expect(event?.kind).toBe('edit')
+    expect(event?.editOldText).toBe('old line')
+    expect(event?.editNewText).toBe('new line one\nnew line two')
+  })
+
+  it('does not record per-path events for relative paths', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-rel',
+          input: { path: 'foo.ts', content: 'x' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('write rel')
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(store.fsEventForPath('/data/foo.ts')).toBe(null)
+    expect(store.fsEventForPath('foo.ts')).toBe(null)
+  })
+
+  it('does not record per-path events for exec (no path known)', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'exec',
+          tool_call_id: 'call-x',
+          input: { command: 'rm /data/x' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('exec')
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(store.fsEventForPath('/data/x')).toBe(null)
+    expect(store.lastFsEvents.size).toBe(0)
+  })
+
+  it('later write to the same path overwrites the earlier event', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-w-1',
+          input: { path: '/data/foo.ts', content: 'first' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 2,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-w-2',
+          input: { path: '/data/foo.ts', content: 'second' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('write twice')
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(store.fsEventForPath('/data/foo.ts')?.writeContent).toBe('second')
+  })
+
+  it('keeps independent events for distinct absolute paths in the same batch', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-a',
+          input: { path: '/data/a.md', content: 'aa' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 2,
+          type: 'tool',
+          name: 'edit',
+          tool_call_id: 'call-b',
+          input: { path: '/data/b.md', old_text: 'old', new_text: 'new' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('two paths')
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    expect(store.fsEventForPath('/data/a.md')?.writeContent).toBe('aa')
+    expect(store.fsEventForPath('/data/b.md')?.editNewText).toBe('new')
+    expect(store.lastFsEvents.size).toBe(2)
+  })
+
+  it('clears lastFsEvents when the user switches to another bot', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-c',
+          input: { path: '/data/c.md', content: 'c' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    api.fetchBots.mockResolvedValue([
+      { id: 'bot-1', status: 'active', name: 'Bot 1' },
+      { id: 'bot-2', status: 'active', name: 'Bot 2' },
+    ])
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('write')
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(store.fsEventForPath('/data/c.md')).not.toBe(null)
+
+    await store.selectBot('bot-2')
+    expect(store.lastFsEvents.size).toBe(0)
+    expect(store.fsEventForPath('/data/c.md')).toBe(null)
+  })
+
+  it('records a write event even when input.content is missing (no diff content)', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-d',
+          input: { path: '/data/d.md' }, // no content field
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('write no content')
+    await new Promise(resolve => setTimeout(resolve, 200))
+
+    const event = store.fsEventForPath('/data/d.md')
+    expect(event).not.toBe(null)
+    expect(event?.kind).toBe('write')
+    expect(event?.writeContent).toBeUndefined()
+  })
+})
+
 describe('fs bump bot-switch isolation', () => {
   beforeEach(() => {
     setActivePinia(createPinia())

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1690,6 +1690,62 @@ describe('chat-list store', () => {
     expect(store.fsChangedAt).toBe(before)
   })
 
+  it('does not double-bump fsChangedAt when a refresh re-delivers a streamed tool', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-stream-then-refresh',
+          input: { path: '/data/dedup.md', content: 'x' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('write file')
+
+    await new Promise(resolve => setTimeout(resolve, 200))
+    const afterStream = store.fsChangedAt
+    expect(afterStream).toBeGreaterThan(0)
+
+    // Now a refresh delivers the SAME tool call again — should not re-bump.
+    api.fetchMessagesUI.mockResolvedValueOnce([{
+      id: 'assistant-1',
+      role: 'assistant',
+      messages: [{
+        id: 1,
+        type: 'tool',
+        name: 'write',
+        tool_call_id: 'call-stream-then-refresh',
+        input: { path: '/data/dedup.md', content: 'x' },
+        running: false,
+      }],
+      timestamp: new Date().toISOString(),
+    }])
+
+    messageEventsHandler?.({
+      type: 'message_created',
+      bot_id: 'bot-1',
+      message: {
+        id: 'msg-dedup',
+        bot_id: 'bot-1',
+        session_id: 'session-1',
+        role: 'assistant',
+        content: 'tool',
+        created_at: new Date().toISOString(),
+      },
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 350))
+    expect(store.fsChangedAt).toBe(afterStream)
+  })
+
   it('bumps fsChangedAt when a refresh delivers a fs-mutating tool from another channel', async () => {
     api.fetchSessions.mockResolvedValueOnce([
       { id: 'session-1', bot_id: 'bot-1', title: 'Chat', type: 'chat' },

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1999,6 +1999,33 @@ describe('fs-mutating tool path extraction', () => {
     expect(store.affectsPath('/data/untouched.ts')).toBe(false)
   })
 
+  it('treats a relative tool path as wildcard (viewer filePaths are absolute)', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-relative',
+          input: { path: 'cat.md', content: 'meow' },
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await store.sendMessage('write rel')
+
+    await new Promise(resolve => setTimeout(resolve, 200))
+    // Relative paths can't be compared against the viewer's absolute filePath,
+    // so the batch falls back to wildcard — affectsPath returns true for any path.
+    expect(store.affectsPath('/data/cat.md')).toBe(true)
+    expect(store.affectsPath('/data/unrelated.ts')).toBe(true)
+  })
+
   it('falls back to wildcard when exec completes (path unknown)', async () => {
     sendEvents = [
       { type: 'start' } as UIStreamEvent,

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1631,4 +1631,122 @@ describe('chat-list store', () => {
     await first
     await second
   })
+
+  it('debounces fsChangedAt bumps when a fs-mutating tool completes', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-write-1',
+          running: false,
+        },
+      } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 2,
+          type: 'tool',
+          name: 'edit',
+          tool_call_id: 'call-edit-1',
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const before = store.fsChangedAt
+    await store.sendMessage('write file')
+
+    expect(store.fsChangedAt).toBe(before)
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(store.fsChangedAt).toBeGreaterThan(before)
+  })
+
+  it('does not bump fsChangedAt for non-fs-mutating tools', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'web_search',
+          tool_call_id: 'call-search',
+          running: false,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const before = store.fsChangedAt
+    await store.sendMessage('search')
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(store.fsChangedAt).toBe(before)
+  })
+
+  it('does not bump fsChangedAt while a fs-mutating tool is still running', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'write',
+          tool_call_id: 'call-write-pending',
+          running: true,
+        },
+      } as UIStreamEvent,
+      { type: 'error', message: 'done' } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const before = store.fsChangedAt
+    await store.sendMessage('start write')
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(store.fsChangedAt).toBe(before)
+  })
+})
+
+describe('fsChangedAt markFsChanged()', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('bumps fsChangedAt after the debounce window', () => {
+    const store = useChatStore()
+    const before = store.fsChangedAt
+    store.markFsChanged()
+    expect(store.fsChangedAt).toBe(before)
+    vi.advanceTimersByTime(149)
+    expect(store.fsChangedAt).toBe(before)
+    vi.advanceTimersByTime(1)
+    expect(store.fsChangedAt).toBeGreaterThan(before)
+  })
+
+  it('collapses bursts of markFsChanged() within the window into a single bump', () => {
+    const store = useChatStore()
+    const before = store.fsChangedAt
+    for (let i = 0; i < 5; i++) store.markFsChanged()
+    expect(store.fsChangedAt).toBe(before)
+    vi.advanceTimersByTime(150)
+    const afterFirst = store.fsChangedAt
+    expect(afterFirst).toBeGreaterThan(before)
+
+    store.markFsChanged()
+    expect(store.fsChangedAt).toBe(afterFirst)
+    vi.advanceTimersByTime(150)
+    expect(store.fsChangedAt).toBeGreaterThan(afterFirst)
+  })
 })

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1926,3 +1926,76 @@ describe('fs-mutating tool path extraction', () => {
     expect(store.affectsPath('/data/anything.ts')).toBe(true)
   })
 })
+
+describe('fs bump bot-switch isolation', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    api.fetchBots.mockResolvedValue([
+      { id: 'bot-1', status: 'active', name: 'Bot 1' },
+      { id: 'bot-2', status: 'active', name: 'Bot 2' },
+    ])
+    api.fetchSessions.mockResolvedValue([])
+    api.fetchMessagesUI.mockResolvedValue([])
+    api.streamMessageEvents.mockImplementation((_botId: string, signal: AbortSignal) => new Promise<void>((resolve) => {
+      signal.addEventListener('abort', () => resolve(), { once: true })
+    }))
+    api.connectWebSocket.mockImplementation(() => ({
+      get connected() { return true },
+      send: vi.fn(),
+      abort: vi.fn(),
+      close: vi.fn(),
+      onOpen: null,
+      onClose: null,
+    }))
+  })
+
+  it('discards a pending fs batch when currentBotId changes before the timer fires', () => {
+    vi.useFakeTimers()
+    try {
+      const store = useChatStore()
+      store.currentBotId = 'bot-A'
+      store.markFsChanged('/data/foo.ts')
+      store.currentBotId = 'bot-B'
+      vi.advanceTimersByTime(150)
+      expect(store.lastFsChange).toBe(null)
+      expect(store.affectsPath('/data/foo.ts')).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not leak a batch from one bot into the next after a switch', () => {
+    vi.useFakeTimers()
+    try {
+      const store = useChatStore()
+      store.currentBotId = 'bot-A'
+      store.markFsChanged('/data/foo.ts')
+      store.currentBotId = 'bot-B'
+      vi.advanceTimersByTime(150)
+      expect(store.affectsPath('/data/foo.ts')).toBe(false)
+
+      store.markFsChanged('/data/bar.ts')
+      vi.advanceTimersByTime(150)
+      expect(store.affectsPath('/data/bar.ts')).toBe(true)
+      expect(store.affectsPath('/data/foo.ts')).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('selectBot cancels any pending fs bump and clears lastFsChange', async () => {
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    store.markFsChanged('/data/foo.ts')
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(store.lastFsChange).not.toBe(null)
+
+    await store.selectBot('bot-2')
+    expect(store.lastFsChange).toBe(null)
+
+    store.markFsChanged('/data/foo.ts')
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(store.lastFsChange).not.toBe(null)
+  })
+})

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -76,6 +76,23 @@ export interface FsChangeBatch {
   paths: ReadonlySet<string> | null
 }
 
+export type FsToolKind = 'write' | 'edit' | 'apply_patch' | 'exec'
+
+// Rich metadata for fs-mutating tool calls that landed on a known absolute
+// path. Stored per-path so the file viewer can show context (which agent, when,
+// what was written) and so the Compare flow can diff against the agent's
+// content without an extra round-trip.
+export interface FsChangeEvent {
+  at: number
+  path: string
+  kind: FsToolKind
+  toolCallId: string
+  sessionId: string
+  writeContent?: string
+  editOldText?: string
+  editNewText?: string
+}
+
 export interface ChatUserTurn {
   id: string
   serverId?: string
@@ -270,10 +287,16 @@ export const useChatStore = defineStore('chat', () => {
   // exec and other unknown-impact triggers) so consumers can filter by path.
   const fsChangedAt = ref(0)
   const lastFsChange = ref<FsChangeBatch | null>(null)
+  // Most recent rich event per absolute path. Powers the file-viewer chip's
+  // "who did what" context and the Compare view's diff baseline. Wildcard
+  // events (exec / apply_patch / relative paths) are intentionally absent —
+  // those still fire fsChangedAt but contribute no per-path metadata.
+  const lastFsEvents = ref<Map<string, FsChangeEvent>>(new Map())
   const FS_MUTATING_TOOLS = new Set(['write', 'edit', 'apply_patch', 'exec'])
   const FS_CHANGED_DEBOUNCE_MS = 150
   let fsChangedBumpTimer: ReturnType<typeof setTimeout> | null = null
   let pendingFsPaths: Set<string> | null = new Set()
+  let pendingFsEvents = new Map<string, FsChangeEvent>()
   // Bot at the moment the in-flight batch started. If currentBotId changes
   // before the timer fires, the batch belongs to the old bot and we drop it
   // rather than leak it into the new bot's UI.
@@ -295,12 +318,19 @@ export const useChatStore = defineStore('chat', () => {
       fsChangedBumpTimer = null
       const recordedBotId = pendingFsBotId
       const paths = pendingFsPaths
+      const events = pendingFsEvents
       pendingFsBotId = null
       pendingFsPaths = new Set()
+      pendingFsEvents = new Map()
       if (recordedBotId !== currentBotId.value) return
       const at = Date.now()
       lastFsChange.value = { at, paths }
       fsChangedAt.value = at
+      if (events.size > 0) {
+        const next = new Map(lastFsEvents.value)
+        for (const [p, ev] of events) next.set(p, ev)
+        lastFsEvents.value = next
+      }
     }, FS_CHANGED_DEBOUNCE_MS)
   }
 
@@ -310,6 +340,7 @@ export const useChatStore = defineStore('chat', () => {
       fsChangedBumpTimer = null
     }
     pendingFsPaths = new Set()
+    pendingFsEvents = new Map()
     pendingFsBotId = null
   }
 
@@ -318,6 +349,10 @@ export const useChatStore = defineStore('chat', () => {
     if (!change) return false
     if (change.paths === null) return true
     return change.paths.has(path)
+  }
+
+  function fsEventForPath(path: string): FsChangeEvent | null {
+    return lastFsEvents.value.get(path) ?? null
   }
 
   function extractToolMessagePath(message: UIMessage): string | null {
@@ -334,6 +369,28 @@ export const useChatStore = defineStore('chat', () => {
     return path
   }
 
+  function buildFsChangeEvent(message: UIMessage, path: string, callId: string): FsChangeEvent | null {
+    if (message.type !== 'tool') return null
+    const input = message.input
+    const event: FsChangeEvent = {
+      at: Date.now(),
+      path,
+      kind: message.name as FsToolKind,
+      toolCallId: callId,
+      sessionId: (sessionId.value ?? '').trim(),
+    }
+    if (typeof input === 'object' && input !== null) {
+      const rec = input as Record<string, unknown>
+      if (message.name === 'write' && typeof rec.content === 'string') {
+        event.writeContent = rec.content
+      } else if (message.name === 'edit') {
+        if (typeof rec.old_text === 'string') event.editOldText = rec.old_text
+        if (typeof rec.new_text === 'string') event.editNewText = rec.new_text
+      }
+    }
+    return event
+  }
+
   function bumpFsChangedAtIfFsMutation(message: UIMessage) {
     if (message.type !== 'tool') return
     if (message.running) return
@@ -347,6 +404,10 @@ export const useChatStore = defineStore('chat', () => {
     const path = (message.name === 'write' || message.name === 'edit')
       ? extractToolMessagePath(message)
       : null
+    if (path) {
+      const event = buildFsChangeEvent(message, path, callId)
+      if (event) pendingFsEvents.set(path, event)
+    }
     markFsChanged(path)
   }
 
@@ -1481,6 +1542,7 @@ export const useChatStore = defineStore('chat', () => {
     cancelPendingFsBump()
     fsChangedAt.value = 0
     lastFsChange.value = null
+    lastFsEvents.value = new Map()
     seenFsToolCallIds.clear()
     clearPendingACPSession()
 
@@ -2308,6 +2370,7 @@ export const useChatStore = defineStore('chat', () => {
     clearPendingACPSession()
     cancelPendingFsBump()
     lastFsChange.value = null
+    lastFsEvents.value = new Map()
     seenFsToolCallIds.clear()
     currentBotId.value = targetBotId
     sessionId.value = null
@@ -2594,8 +2657,10 @@ export const useChatStore = defineStore('chat', () => {
     startupSendFailure,
     fsChangedAt,
     lastFsChange,
+    lastFsEvents,
     markFsChanged,
     affectsPath,
+    fsEventForPath,
     initialize,
     selectBot,
     selectSession,

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -430,6 +430,7 @@ export const useChatStore = defineStore('chat', () => {
   let messageEventsSince = ''
   let activeWs: ChatWebSocket | null = null
   let refreshTimer: ReturnType<typeof setTimeout> | null = null
+  const nonCurrentSessionRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
   let refreshPromise: { key: string; promise: Promise<void> } | null = null
   let sessionListRefreshPromise: { botId: string; promise: Promise<void> } | null = null
   const pendingBackgroundEvents = new Map<string, BackgroundTask[]>()
@@ -1017,6 +1018,10 @@ export const useChatStore = defineStore('chat', () => {
       merge: mergeTurnInPlace,
     })
     updateSinceFromMessages(items)
+    bumpFsChangedAtForMessages(items)
+  }
+
+  function bumpFsChangedAtForMessages(items: ChatMessage[]) {
     // Refresh path: fs-mutating tools that landed via /messages/events (e.g.
     // a Telegram-triggered session writing to the workspace) never go through
     // upsertAssistantUIMessage, so this is the only chance to fire fsChangedAt
@@ -1520,6 +1525,7 @@ export const useChatStore = defineStore('chat', () => {
       clearTimeout(refreshTimer)
       refreshTimer = null
     }
+    cancelNonCurrentSessionRefreshes()
     refreshPromise = null
     sessionListRefreshPromise = null
     messageEventsSince = ''
@@ -1593,6 +1599,7 @@ export const useChatStore = defineStore('chat', () => {
         hasMoreOlder.value = moreOlder
         cacheCurrentMessages()
       } else {
+        bumpFsChangedAtForMessages(normalized)
         cacheFetchedMessages(bid, sid, normalized, moreOlder)
       }
       touchSession(sid, normalized.at(-1)?.timestamp)
@@ -1627,6 +1634,29 @@ export const useChatStore = defineStore('chat', () => {
 
     sessionListRefreshPromise = { botId: bid, promise }
     return promise
+  }
+
+  function cancelNonCurrentSessionRefreshes() {
+    for (const timer of nonCurrentSessionRefreshTimers.values()) {
+      clearTimeout(timer)
+    }
+    nonCurrentSessionRefreshTimers.clear()
+  }
+
+  function scheduleNonCurrentSessionRefreshForFs(targetBotId: string, targetSessionId?: string, delay = 100) {
+    const bid = targetBotId.trim()
+    const sid = targetSessionId?.trim() ?? ''
+    if (!bid || !sid) return
+    if (sid === (sessionId.value ?? '').trim()) return
+    const key = sessionMessageKey(bid, sid)
+    if (!key || nonCurrentSessionRefreshTimers.has(key)) return
+
+    const timer = setTimeout(() => {
+      nonCurrentSessionRefreshTimers.delete(key)
+      if ((currentBotId.value ?? '').trim() !== bid) return
+      void refreshCurrentSession(bid, sid)
+    }, delay)
+    nonCurrentSessionRefreshTimers.set(key, timer)
   }
 
   function scheduleRefreshCurrentSession(expectedSessionId?: string, delay = 100) {
@@ -1750,6 +1780,8 @@ export const useChatStore = defineStore('chat', () => {
       }
       if (shouldRefreshFromMessageCreated(targetBotId, sessionId.value, streamingSessionId.value, event)) {
         scheduleRefreshCurrentSession((raw.session_id ?? '').trim())
+      } else if (raw.role === 'assistant') {
+        scheduleNonCurrentSessionRefreshForFs(targetBotId, messageSessionId)
       }
       return
     }
@@ -2368,6 +2400,7 @@ export const useChatStore = defineStore('chat', () => {
     abort()
     abortAllAssistantStreams()
     clearPendingACPSession()
+    cancelNonCurrentSessionRefreshes()
     cancelPendingFsBump()
     lastFsChange.value = null
     lastFsEvents.value = new Map()

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -926,6 +926,17 @@ export const useChatStore = defineStore('chat', () => {
       merge: mergeTurnInPlace,
     })
     updateSinceFromMessages(items)
+    // Refresh path: fs-mutating tools that landed via /messages/events (e.g.
+    // a Telegram-triggered session writing to the workspace) never go through
+    // upsertAssistantUIMessage, so this is the only chance to fire fsChangedAt
+    // for those bots. bumpFsChangedAtIfFsMutation gates on running:false and
+    // tool name, and the debounce collapses re-bumps for already-seen blocks.
+    for (const turn of items) {
+      if (turn.role !== 'assistant') continue
+      for (const block of turn.messages) {
+        bumpFsChangedAtIfFsMutation(block)
+      }
+    }
   }
 
   function replaceMessages(items: UITurn[], targetSessionId?: string) {

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -325,7 +325,13 @@ export const useChatStore = defineStore('chat', () => {
     const input = message.input
     if (typeof input !== 'object' || input === null) return null
     const path = (input as Record<string, unknown>).path
-    return typeof path === 'string' && path ? path : null
+    if (typeof path !== 'string' || !path) return null
+    // Only emit absolute paths as path-targeted hints. Viewer filePaths are
+    // always absolute (the FS list API normalizes them); a relative path here
+    // can't be safely compared without knowing the agent's cwd, so fall through
+    // to wildcard and let every viewer decide whether to refresh.
+    if (!path.startsWith('/')) return null
+    return path
   }
 
   function bumpFsChangedAtIfFsMutation(message: UIMessage) {

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -278,6 +278,10 @@ export const useChatStore = defineStore('chat', () => {
   // before the timer fires, the batch belongs to the old bot and we drop it
   // rather than leak it into the new bot's UI.
   let pendingFsBotId: string | null = null
+  // Tool calls we've already bumped (or seen at load time) for the current
+  // bot. Prevents double-bumping when a tool first arrives via the WS stream
+  // and then re-appears via the stream-end / message_created refresh path.
+  const seenFsToolCallIds = new Set<string>()
 
   function markFsChanged(path?: string | null) {
     if (path === undefined || path === null) {
@@ -328,6 +332,9 @@ export const useChatStore = defineStore('chat', () => {
     if (message.type !== 'tool') return
     if (message.running) return
     if (!FS_MUTATING_TOOLS.has(message.name)) return
+    const callId = message.tool_call_id?.trim() ?? ''
+    if (callId && seenFsToolCallIds.has(callId)) return
+    if (callId) seenFsToolCallIds.add(callId)
     // write / edit carry their target `path` in input. apply_patch can target
     // many files (multi-path parsing belongs to the view layer, not the store)
     // and exec is opaque — both fall back to wildcard.
@@ -335,6 +342,22 @@ export const useChatStore = defineStore('chat', () => {
       ? extractToolMessagePath(message)
       : null
     markFsChanged(path)
+  }
+
+  // Populates seenFsToolCallIds without bumping. Used when messages are loaded
+  // wholesale (initial session load, cache restore) so a later refresh of the
+  // same page can't re-trigger fsChangedAt for tool calls we've already shown.
+  function markFsToolsAsSeen(items: ChatMessage[]) {
+    for (const turn of items) {
+      if (turn.role !== 'assistant') continue
+      for (const block of turn.messages) {
+        if (block.type !== 'tool') continue
+        if (block.running) continue
+        if (!FS_MUTATING_TOOLS.has(block.name)) continue
+        const callId = block.tool_call_id?.trim() ?? ''
+        if (callId) seenFsToolCallIds.add(callId)
+      }
+    }
   }
 
   let messageEventsSince = ''
@@ -878,6 +901,7 @@ export const useChatStore = defineStore('chat', () => {
   function setMessages(items: ChatMessage[]) {
     messages.splice(0, messages.length, ...items)
     updateSinceFromMessages(items)
+    markFsToolsAsSeen(items)
   }
 
   const PRESERVED_TURN_KEYS = ['id', 'serverId']
@@ -985,6 +1009,7 @@ export const useChatStore = defineStore('chat', () => {
     messages.splice(0, messages.length, ...cached.items)
     hasMoreOlder.value = cached.hasMoreOlder
     updateSinceFromMessages(cached.items)
+    markFsToolsAsSeen(cached.items)
     return true
   }
 
@@ -1450,6 +1475,7 @@ export const useChatStore = defineStore('chat', () => {
     cancelPendingFsBump()
     fsChangedAt.value = 0
     lastFsChange.value = null
+    seenFsToolCallIds.clear()
     clearPendingACPSession()
 
     pendingAssistantStreams.clear()
@@ -2276,6 +2302,7 @@ export const useChatStore = defineStore('chat', () => {
     clearPendingACPSession()
     cancelPendingFsBump()
     lastFsChange.value = null
+    seenFsToolCallIds.clear()
     currentBotId.value = targetBotId
     sessionId.value = null
     await initialize()

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -258,15 +258,33 @@ export const useChatStore = defineStore('chat', () => {
 
   // Bumps every time a fs-mutating tool call (write/edit/apply_patch/exec) finishes for the
   // current bot. File-manager components watch this to refresh their listings
-  // and any open file viewers without polling.
+  // and any open file viewers without polling. Trailing fixed-delay throttle so
+  // a burst of edits within one window collapses into one refresh.
   const fsChangedAt = ref(0)
   const FS_MUTATING_TOOLS = new Set(['write', 'edit', 'apply_patch', 'exec'])
+  const FS_CHANGED_DEBOUNCE_MS = 150
+  let fsChangedBumpTimer: ReturnType<typeof setTimeout> | null = null
+
+  function markFsChanged() {
+    if (fsChangedBumpTimer != null) return
+    fsChangedBumpTimer = setTimeout(() => {
+      fsChangedBumpTimer = null
+      fsChangedAt.value = Date.now()
+    }, FS_CHANGED_DEBOUNCE_MS)
+  }
+
+  function cancelPendingFsBump() {
+    if (fsChangedBumpTimer != null) {
+      clearTimeout(fsChangedBumpTimer)
+      fsChangedBumpTimer = null
+    }
+  }
 
   function bumpFsChangedAtIfFsMutation(message: UIMessage) {
     if (message.type !== 'tool') return
     if (message.running) return
     if (!FS_MUTATING_TOOLS.has(message.name)) return
-    fsChangedAt.value = Date.now()
+    markFsChanged()
   }
 
   let messageEventsSince = ''
@@ -1368,6 +1386,7 @@ export const useChatStore = defineStore('chat', () => {
     overrideModelId.value = ''
     overrideReasoningEffort.value = ''
     startupSendFailure.value = null
+    cancelPendingFsBump()
     fsChangedAt.value = 0
     clearPendingACPSession()
 
@@ -1517,7 +1536,7 @@ export const useChatStore = defineStore('chat', () => {
     if (block) {
       mergeBackgroundTaskIntoToolBlock(block, task)
       if (!isBackgroundTaskActive(block.backgroundTask)) {
-        fsChangedAt.value = Date.now()
+        markFsChanged()
       }
     } else {
       queuePendingBackgroundEvent(task)
@@ -2477,6 +2496,7 @@ export const useChatStore = defineStore('chat', () => {
     overrideReasoningEffort,
     startupSendFailure,
     fsChangedAt,
+    markFsChanged,
     initialize,
     selectBot,
     selectSession,

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -274,6 +274,10 @@ export const useChatStore = defineStore('chat', () => {
   const FS_CHANGED_DEBOUNCE_MS = 150
   let fsChangedBumpTimer: ReturnType<typeof setTimeout> | null = null
   let pendingFsPaths: Set<string> | null = new Set()
+  // Bot at the moment the in-flight batch started. If currentBotId changes
+  // before the timer fires, the batch belongs to the old bot and we drop it
+  // rather than leak it into the new bot's UI.
+  let pendingFsBotId: string | null = null
 
   function markFsChanged(path?: string | null) {
     if (path === undefined || path === null) {
@@ -282,12 +286,17 @@ export const useChatStore = defineStore('chat', () => {
       pendingFsPaths.add(path)
     }
     if (fsChangedBumpTimer != null) return
+    pendingFsBotId = currentBotId.value
     fsChangedBumpTimer = setTimeout(() => {
       fsChangedBumpTimer = null
-      const at = Date.now()
-      lastFsChange.value = { at, paths: pendingFsPaths }
-      fsChangedAt.value = at
+      const recordedBotId = pendingFsBotId
+      const paths = pendingFsPaths
+      pendingFsBotId = null
       pendingFsPaths = new Set()
+      if (recordedBotId !== currentBotId.value) return
+      const at = Date.now()
+      lastFsChange.value = { at, paths }
+      fsChangedAt.value = at
     }, FS_CHANGED_DEBOUNCE_MS)
   }
 
@@ -297,6 +306,7 @@ export const useChatStore = defineStore('chat', () => {
       fsChangedBumpTimer = null
     }
     pendingFsPaths = new Set()
+    pendingFsBotId = null
   }
 
   function affectsPath(path: string): boolean {
@@ -2253,6 +2263,8 @@ export const useChatStore = defineStore('chat', () => {
     abort()
     abortAllAssistantStreams()
     clearPendingACPSession()
+    cancelPendingFsBump()
+    lastFsChange.value = null
     currentBotId.value = targetBotId
     sessionId.value = null
     await initialize()

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -70,6 +70,12 @@ export interface ToolCallBlock extends UIToolMessage {
 
 export type ContentBlock = TextBlock | ThinkingBlock | ToolCallBlock | AttachmentBlock | ErrorBlock
 
+export interface FsChangeBatch {
+  at: number
+  // null = unknown / wildcard (exec completion, manual refresh, user-driven mutation)
+  paths: ReadonlySet<string> | null
+}
+
 export interface ChatUserTurn {
   id: string
   serverId?: string
@@ -259,17 +265,29 @@ export const useChatStore = defineStore('chat', () => {
   // Bumps every time a fs-mutating tool call (write/edit/apply_patch/exec) finishes for the
   // current bot. File-manager components watch this to refresh their listings
   // and any open file viewers without polling. Trailing fixed-delay throttle so
-  // a burst of edits within one window collapses into one refresh.
+  // a burst of edits within one window collapses into one refresh. Each batch
+  // carries the set of paths touched in that window (or null = wildcard, for
+  // exec and other unknown-impact triggers) so consumers can filter by path.
   const fsChangedAt = ref(0)
+  const lastFsChange = ref<FsChangeBatch | null>(null)
   const FS_MUTATING_TOOLS = new Set(['write', 'edit', 'apply_patch', 'exec'])
   const FS_CHANGED_DEBOUNCE_MS = 150
   let fsChangedBumpTimer: ReturnType<typeof setTimeout> | null = null
+  let pendingFsPaths: Set<string> | null = new Set()
 
-  function markFsChanged() {
+  function markFsChanged(path?: string | null) {
+    if (path === undefined || path === null) {
+      pendingFsPaths = null
+    } else if (pendingFsPaths !== null) {
+      pendingFsPaths.add(path)
+    }
     if (fsChangedBumpTimer != null) return
     fsChangedBumpTimer = setTimeout(() => {
       fsChangedBumpTimer = null
-      fsChangedAt.value = Date.now()
+      const at = Date.now()
+      lastFsChange.value = { at, paths: pendingFsPaths }
+      fsChangedAt.value = at
+      pendingFsPaths = new Set()
     }, FS_CHANGED_DEBOUNCE_MS)
   }
 
@@ -278,13 +296,35 @@ export const useChatStore = defineStore('chat', () => {
       clearTimeout(fsChangedBumpTimer)
       fsChangedBumpTimer = null
     }
+    pendingFsPaths = new Set()
+  }
+
+  function affectsPath(path: string): boolean {
+    const change = lastFsChange.value
+    if (!change) return false
+    if (change.paths === null) return true
+    return change.paths.has(path)
+  }
+
+  function extractToolMessagePath(message: UIMessage): string | null {
+    if (message.type !== 'tool') return null
+    const input = message.input
+    if (typeof input !== 'object' || input === null) return null
+    const path = (input as Record<string, unknown>).path
+    return typeof path === 'string' && path ? path : null
   }
 
   function bumpFsChangedAtIfFsMutation(message: UIMessage) {
     if (message.type !== 'tool') return
     if (message.running) return
     if (!FS_MUTATING_TOOLS.has(message.name)) return
-    markFsChanged()
+    // write / edit carry their target `path` in input. apply_patch can target
+    // many files (multi-path parsing belongs to the view layer, not the store)
+    // and exec is opaque — both fall back to wildcard.
+    const path = (message.name === 'write' || message.name === 'edit')
+      ? extractToolMessagePath(message)
+      : null
+    markFsChanged(path)
   }
 
   let messageEventsSince = ''
@@ -1388,6 +1428,7 @@ export const useChatStore = defineStore('chat', () => {
     startupSendFailure.value = null
     cancelPendingFsBump()
     fsChangedAt.value = 0
+    lastFsChange.value = null
     clearPendingACPSession()
 
     pendingAssistantStreams.clear()
@@ -2496,7 +2537,9 @@ export const useChatStore = defineStore('chat', () => {
     overrideReasoningEffort,
     startupSendFailure,
     fsChangedAt,
+    lastFsChange,
     markFsChanged,
+    affectsPath,
     initialize,
     selectBot,
     selectSession,

--- a/internal/handlers/filemanager.go
+++ b/internal/handlers/filemanager.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -39,9 +40,10 @@ type FSListResponse struct {
 }
 
 type FSReadResponse struct {
-	Path    string `json:"path"`
-	Content string `json:"content"`
-	Size    int64  `json:"size"`
+	Path     string `json:"path"`
+	Content  string `json:"content"`
+	Size     int64  `json:"size"`
+	Revision string `json:"revision"`
 }
 
 type FSUploadResponse struct {
@@ -51,8 +53,9 @@ type FSUploadResponse struct {
 
 // FSWriteRequest is the body for creating / overwriting a file.
 type FSWriteRequest struct {
-	Path    string `json:"path"`
-	Content string `json:"content"`
+	Path             string  `json:"path"`
+	Content          string  `json:"content"`
+	ExpectedRevision *string `json:"expectedRevision,omitempty"`
 }
 
 // FSMkdirRequest is the body for creating a directory.
@@ -89,7 +92,8 @@ type FSExtractResponse struct {
 }
 
 type fsOpResponse struct {
-	OK bool `json:"ok"`
+	OK       bool   `json:"ok"`
+	Revision string `json:"revision,omitempty"`
 }
 
 // ---------- helpers ----------
@@ -215,6 +219,28 @@ func archiveDownloadName(containerPath string, isDir bool) string {
 		return name + ".tar.gz"
 	}
 	return name
+}
+
+func fsContentRevision(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("sha256:%x", sum)
+}
+
+func readContainerFileRevision(ctx context.Context, client *bridge.Client, containerPath string) (string, error) {
+	rc, err := client.ReadRaw(ctx, containerPath)
+	if err != nil {
+		if errors.Is(err, bridge.ErrNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return "", err
+	}
+	return fsContentRevision(data), nil
 }
 
 // getGRPCClient returns the gRPC client for the bot's container.
@@ -402,9 +428,10 @@ func (h *ContainerdHandler) FSRead(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, FSReadResponse{
-		Path:    containerPath,
-		Content: string(data),
-		Size:    int64(len(data)),
+		Path:     containerPath,
+		Content:  string(data),
+		Size:     int64(len(data)),
+		Revision: fsContentRevision(data),
 	})
 }
 
@@ -642,11 +669,31 @@ func (h *ContainerdHandler) FSWrite(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, fmt.Sprintf("container not reachable: %v", err))
 	}
 
-	if err := client.WriteFile(ctx, containerPath, []byte(req.Content)); err != nil {
+	if req.ExpectedRevision != nil {
+		// Empty string is not a meaningful baseline — it collapses to the same
+		// sentinel that readContainerFileRevision returns for a missing file,
+		// which would let an "I don't know the revision" client silently
+		// overwrite or create the file without an explicit unconditional
+		// write. Reject the ambiguous form; clients should omit the field
+		// instead.
+		if *req.ExpectedRevision == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "expectedRevision must be non-empty; omit the field for an unconditional write")
+		}
+		currentRevision, err := readContainerFileRevision(ctx, client, containerPath)
+		if err != nil {
+			return fsHTTPError(err)
+		}
+		if currentRevision != *req.ExpectedRevision {
+			return echo.NewHTTPError(http.StatusConflict, "file changed on disk")
+		}
+	}
+
+	contentBytes := []byte(req.Content)
+	if err := client.WriteFile(ctx, containerPath, contentBytes); err != nil {
 		return fsHTTPError(err)
 	}
 
-	return c.JSON(http.StatusOK, fsOpResponse{OK: true})
+	return c.JSON(http.StatusOK, fsOpResponse{OK: true, Revision: fsContentRevision(contentBytes)})
 }
 
 // FSUpload godoc

--- a/internal/handlers/filemanager_test.go
+++ b/internal/handlers/filemanager_test.go
@@ -113,6 +113,109 @@ func TestFSDownloadDirectoryReturnsTarGz(t *testing.T) {
 	}
 }
 
+func TestFSReadReturnsRevision(t *testing.T) {
+	env := newSkillsTestEnv(t)
+	env.writeSkillFile(t, "/data/rev.txt", "hello workspace")
+
+	rec, err := env.callFileManager(t, http.MethodGet, "/bots/:bot_id/container/fs/read?path=/data/rev.txt", nil, env.handler.FSRead)
+	if err != nil {
+		t.Fatalf("FSRead returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, _ := resp["revision"].(string); got == "" {
+		t.Fatalf("revision is empty in response %#v", resp)
+	}
+}
+
+func TestFSWriteRejectsStaleExpectedRevision(t *testing.T) {
+	env := newSkillsTestEnv(t)
+	env.writeSkillFile(t, "/data/rev.txt", "base")
+
+	_, err := env.callFileManager(t, http.MethodPost, "/bots/:bot_id/container/fs/write", map[string]any{
+		"path":             "/data/rev.txt",
+		"content":          "mine",
+		"expectedRevision": "sha256:stale",
+	}, env.handler.FSWrite)
+	var httpErr *echo.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.Code != http.StatusConflict {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+	assertLocalFile(t, env.localPath("/data/rev.txt"), "base")
+}
+
+func TestFSWriteAcceptsMatchingExpectedRevision(t *testing.T) {
+	env := newSkillsTestEnv(t)
+	env.writeSkillFile(t, "/data/rev.txt", "base")
+
+	readRec, err := env.callFileManager(t, http.MethodGet, "/bots/:bot_id/container/fs/read?path=/data/rev.txt", nil, env.handler.FSRead)
+	if err != nil {
+		t.Fatalf("FSRead returned error: %v", err)
+	}
+	var readResp map[string]any
+	if err := json.Unmarshal(readRec.Body.Bytes(), &readResp); err != nil {
+		t.Fatalf("decode read response: %v", err)
+	}
+	revision, _ := readResp["revision"].(string)
+	if revision == "" {
+		t.Fatalf("revision is empty in response %#v", readResp)
+	}
+
+	writeRec, err := env.callFileManager(t, http.MethodPost, "/bots/:bot_id/container/fs/write", map[string]any{
+		"path":             "/data/rev.txt",
+		"content":          "updated",
+		"expectedRevision": revision,
+	}, env.handler.FSWrite)
+	if err != nil {
+		t.Fatalf("FSWrite returned error: %v", err)
+	}
+	if writeRec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", writeRec.Code, writeRec.Body.String())
+	}
+	assertLocalFile(t, env.localPath("/data/rev.txt"), "updated")
+}
+
+func TestFSWriteRejectsEmptyExpectedRevision(t *testing.T) {
+	env := newSkillsTestEnv(t)
+	env.writeSkillFile(t, "/data/rev.txt", "base")
+
+	_, err := env.callFileManager(t, http.MethodPost, "/bots/:bot_id/container/fs/write", map[string]any{
+		"path":             "/data/rev.txt",
+		"content":          "mine",
+		"expectedRevision": "",
+	}, env.handler.FSWrite)
+	var httpErr *echo.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 bad request for empty expectedRevision, got %v", err)
+	}
+	// Buffer must not have been written under the ambiguous condition.
+	assertLocalFile(t, env.localPath("/data/rev.txt"), "base")
+}
+
+func TestFSWriteOmittedExpectedRevisionWritesUnconditionally(t *testing.T) {
+	env := newSkillsTestEnv(t)
+	env.writeSkillFile(t, "/data/rev.txt", "base")
+
+	// Body without an expectedRevision field — the FE's "no known baseline"
+	// path (e.g. stale read, force-save, deleted-restore). Must succeed.
+	rec, err := env.callFileManager(t, http.MethodPost, "/bots/:bot_id/container/fs/write", map[string]any{
+		"path":    "/data/rev.txt",
+		"content": "mine",
+	}, env.handler.FSWrite)
+	if err != nil {
+		t.Fatalf("FSWrite returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	assertLocalFile(t, env.localPath("/data/rev.txt"), "mine")
+}
+
 func TestFSArchiveMultiplePathsDedupesNestedSelection(t *testing.T) {
 	env := newSkillsTestEnv(t)
 	env.writeSkillFile(t, "/data/project/main.go", "package main\n")

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -1372,6 +1372,7 @@ export type HandlersFsMkdirRequest = {
 export type HandlersFsReadResponse = {
     content?: string;
     path?: string;
+    revision?: string;
     size?: number;
 };
 
@@ -1387,6 +1388,7 @@ export type HandlersFsUploadResponse = {
 
 export type HandlersFsWriteRequest = {
     content?: string;
+    expectedRevision?: string;
     path?: string;
 };
 
@@ -1783,6 +1785,7 @@ export type HandlersEmailOAuthStatusResponse = {
 
 export type HandlersFsOpResponse = {
     ok?: boolean;
+    revision?: string;
 };
 
 export type HandlersMemoryAddPayload = {

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -15306,6 +15306,9 @@ const docTemplate = `{
                 "path": {
                     "type": "string"
                 },
+                "revision": {
+                    "type": "string"
+                },
                 "size": {
                     "type": "integer"
                 }
@@ -15337,6 +15340,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                },
+                "expectedRevision": {
                     "type": "string"
                 },
                 "path": {
@@ -16329,6 +16335,9 @@ const docTemplate = `{
             "properties": {
                 "ok": {
                     "type": "boolean"
+                },
+                "revision": {
+                    "type": "string"
                 }
             }
         },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -15297,6 +15297,9 @@
                 "path": {
                     "type": "string"
                 },
+                "revision": {
+                    "type": "string"
+                },
                 "size": {
                     "type": "integer"
                 }
@@ -15328,6 +15331,9 @@
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                },
+                "expectedRevision": {
                     "type": "string"
                 },
                 "path": {
@@ -16320,6 +16326,9 @@
             "properties": {
                 "ok": {
                     "type": "boolean"
+                },
+                "revision": {
+                    "type": "string"
                 }
             }
         },

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -2282,6 +2282,8 @@ definitions:
         type: string
       path:
         type: string
+      revision:
+        type: string
       size:
         type: integer
     type: object
@@ -2302,6 +2304,8 @@ definitions:
   handlers.FSWriteRequest:
     properties:
       content:
+        type: string
+      expectedRevision:
         type: string
       path:
         type: string
@@ -2952,6 +2956,8 @@ definitions:
     properties:
       ok:
         type: boolean
+      revision:
+        type: string
     type: object
   handlers.memoryAddPayload:
     properties:


### PR DESCRIPTION
## Summary

This PR keeps Web file surfaces in sync when chat tools or workspace UI actions mutate files.

It wires filesystem mutation signals into the Files pane, file editor, and Markdown/HTML preview refresh paths; adds debounced, path-aware refresh batching; and introduces revision-aware text file reads/writes so stale saves can be detected instead of silently overwriting agent changes.

## What Changed

* Propagate chat-driven and file-manager-driven workspace mutations into Web refresh paths.
* Add debounced filesystem change batches for `write` / `edit`.
* Use wildcard refreshes for broad or ambiguous mutations, including `apply_patch`, `exec`, relative paths, manual refreshes, and file-manager actions.
* Refresh the Files tree after chat filesystem tools and file-manager create/upload/rename/delete/extract actions.
* Refresh open file editors after chat edits, manual edits, and visible polling fallback.
* Refresh Markdown/HTML previews through filesystem signals, with visible polling fallback.
* Add backend `revision` / `expectedRevision` support for text file conflict detection.
* Add editor conflict handling:
  * clean buffers reload in place;
  * dirty buffers keep local edits and show Compare / Reload / Save anyway options.

## Scope

Covered by this PR:

* Files pane refresh after chat tools and file-manager mutations.
* File editor refresh after external edits, manual edits, and visible polling fallback.
* Markdown/HTML preview refresh after filesystem changes and visible polling fallback.
* Revision-aware text file read/write contract for stale-save detection.
* Conflict UI for dirty editor buffers when external changes arrive.

Intentionally not covered:

* Server-side filesystem watcher support.
* Exact multi-file parsing for `apply_patch`; these changes intentionally trigger wildcard refreshes.
* Path-targeted matching for relative tool paths; relative paths intentionally trigger wildcard refreshes.

## Edge Cases and Review Notes

* Debounces bursty tool completions and dedupes repeated `tool_call_id`s caused by stream or refresh replay.
* Drops pending filesystem batches across bot switches so one bot’s edits do not refresh another bot’s UI.
* Refreshes same-bot, non-current sessions when assistant `message_created` events may contain filesystem-mutating tools.
* Preserves dirty editor buffers and surfaces an external-change chip instead of overwriting user edits.
* Marks Compare as stale if the agent writes again while the user is reviewing a diff.
* Handles deleted or stale files:
  * deleted text files can be restored by saving;
  * deleted images show a removed state;
  * stale reloads expose retry or force-save paths where safe.
* Guards saves with `expectedRevision`.
* Handles `409` conflicts.
* Rejects ambiguous empty revisions.
* Detects interleaved agent writes during save.
* Aborts stale reads.
* Avoids full editor/preview spinner flashes after the first successful load.

## Test Plan

* [x] `mise exec -- pnpm exec vitest run apps/web/src/store/chat-list.test.ts apps/web/src/components/file-manager/file-conflict.test.ts apps/web/src/pages/home/components/dockview/panel-preview.test.ts`
* [x] Focused ESLint on modified TypeScript/Vue files
