### PR TITLE
feat(web): open localhost links from markdown/terminal in the browser tab

### DIFF
--- a/apps/web/src/components/markdown/index.ts
+++ b/apps/web/src/components/markdown/index.ts
@@ -4,6 +4,7 @@ import MdCheckbox from './md-checkbox.vue'
 import MdFootnoteReference from './md-footnote-reference.vue'
 import MdFootnoteAnchor from './md-footnote-anchor.vue'
 import MdText from './md-text.vue'
+import MdLink from './md-link.vue'
 
 // Custom markstream node components shared by every markdown surface (chat +
 // file preview). They replace markstream's built-in glyphs with design-system
@@ -17,6 +18,9 @@ const sharedComponents: Record<string, Component> = {
   footnote_reference: MdFootnoteReference,
   footnote_anchor: MdFootnoteAnchor,
   text: MdText,
+  // Intercept clicks on container-local (localhost) links to open the workspace
+  // browser panel; delegates rendering/external links to markstream's LinkNode.
+  link: MdLink,
 }
 
 const registered = new Set<string>()

--- a/apps/web/src/components/markdown/md-link.vue
+++ b/apps/web/src/components/markdown/md-link.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+import { LinkNode } from 'markstream-vue'
+import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
+import { tryParseLocalhostHref } from '@/utils/localhost-link'
+
+// Custom markstream `link` node. Rendering is delegated wholesale to markstream's
+// own LinkNode (so styling, tooltip and stream animation are untouched); we only
+// hijack the CLICK for links that point at a container-local dev server, opening
+// them in the workspace browser panel instead of the user's OS browser — the
+// container's localhost is not the user's localhost. Everything else (external
+// links, modifier-clicks) keeps default behavior.
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps<{
+  node: {
+    type: 'link'
+    href: string
+    title: string | null
+    text: string
+    children?: unknown[]
+    raw: string
+  }
+}>()
+
+const attrs = useAttrs()
+const tabs = useWorkspaceTabsStore()
+
+const localAddress = computed(() => tryParseLocalhostHref(props.node?.href))
+
+function onClickCapture(event: MouseEvent) {
+  const parsed = localAddress.value
+  if (!parsed) return
+  // Leave modifier/middle clicks to the browser (open externally) for users who
+  // really want an OS tab.
+  if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+  event.preventDefault()
+  // openBrowserAt returns false when the workspace browser is unavailable
+  // (no manage permission / local workspace / no dock) — fall back to the OS tab.
+  if (!tabs.openBrowserAt(parsed.display)) {
+    window.open(props.node.href, '_blank', 'noopener')
+  }
+}
+</script>
+
+<template>
+  <span @click.capture="onClickCapture"><LinkNode
+    :node="node"
+    v-bind="attrs"
+  /></span>
+</template>

--- a/apps/web/src/pages/home/components/terminal-pane.vue
+++ b/apps/web/src/pages/home/components/terminal-pane.vue
@@ -28,7 +28,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { Terminal } from '@xterm/xterm'
+import { Terminal, type ILink } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { SerializeAddon } from '@xterm/addon-serialize'
 import { Button } from '@memohai/ui'
@@ -39,6 +39,8 @@ import {
 } from '@/composables/useTerminalCache'
 import { sdkAuthQuery, sdkWebSocketUrl } from '@/lib/api-client'
 import { useSettingsStore } from '@/store/settings'
+import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
+import { LOCALHOST_URL_REGEX, tryParseLocalhostHref } from '@/utils/localhost-link'
 import '@xterm/xterm/css/xterm.css'
 
 const props = withDefaults(defineProps<{
@@ -51,6 +53,7 @@ const props = withDefaults(defineProps<{
 
 const { t } = useI18n()
 const settingsStore = useSettingsStore()
+const tabsStore = useWorkspaceTabsStore()
 
 function cssVar(name: string): string {
   if (typeof document === 'undefined') return ''
@@ -208,6 +211,43 @@ onMounted(() => {
   term.loadAddon(fa)
   term.loadAddon(sa)
   term.open(containerRef.value)
+
+  // Make container-local URLs in command output clickable: clicking opens the
+  // workspace browser panel (falling back to an OS tab when it is unavailable),
+  // rather than the user's OS browser, since the container's localhost differs.
+  disposables.push(term.registerLinkProvider({
+    provideLinks(bufferLineNumber, callback) {
+      const line = term.buffer.active.getLine(bufferLineNumber - 1)
+      const text = line?.translateToString(true)
+      if (!text) {
+        callback(undefined)
+        return
+      }
+      const links: ILink[] = []
+      const regex = new RegExp(LOCALHOST_URL_REGEX.source, 'gi')
+      let match: RegExpExecArray | null
+      while ((match = regex.exec(text)) !== null) {
+        const raw = match[0]
+        const parsed = tryParseLocalhostHref(raw)
+        if (!parsed) continue
+        const startIndex = match.index
+        links.push({
+          text: raw,
+          range: {
+            start: { x: startIndex + 1, y: bufferLineNumber },
+            end: { x: startIndex + raw.length, y: bufferLineNumber },
+          },
+          activate: () => {
+            if (!tabsStore.openBrowserAt(parsed.display)) {
+              const href = /^https?:\/\//i.test(raw) ? raw : `http://${raw}`
+              window.open(href, '_blank', 'noopener')
+            }
+          },
+        })
+      }
+      callback(links.length ? links : undefined)
+    },
+  }))
 
   terminal = term
   fitAddon = fa

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -213,6 +213,36 @@ describe('workspace layout store', () => {
     expect(panel?.title).toBe('localhost:3000/app')
   })
 
+  it('opens a browser tab at an address and focuses the existing one on the same URL', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+
+    // First click normalizes the address and titles the tab with it.
+    expect(store.openBrowserAt('http://localhost:5173/app')).toBe(true)
+    const first = dock.getPanel('browser:1')
+    expect(first?.params.address).toBe('localhost:5173/app')
+    expect(first?.title).toBe('localhost:5173/app')
+
+    // A different path on the same port opens a second tab.
+    expect(store.openBrowserAt('127.0.0.1:5173/other')).toBe(true)
+    expect(dock.getPanel('browser:2')?.params.address).toBe('localhost:5173/other')
+
+    // The exact same URL (after normalization) focuses the existing tab.
+    expect(store.openBrowserAt('localhost:5173/app')).toBe(true)
+    expect(dock.panels.filter(p => p.component === 'browser')).toHaveLength(2)
+    expect(dock.activePanel?.id).toBe('browser:1')
+  })
+
+  it('refuses to open a browser tab for a non-local address', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+
+    expect(store.openBrowserAt('https://example.com/')).toBe(false)
+    expect(dock.panels.filter(p => p.component === 'browser')).toHaveLength(0)
+  })
+
   it('keeps terminal ids monotonic per bot', () => {
     const store = useWorkspaceTabsStore()
     const dock = createFakeDock()

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -6,6 +6,7 @@ import { useChatStore } from '@/store/chat-list'
 import { useChatSelectionStore } from '@/store/chat-selection'
 import { onAuthSessionCleared } from '@/lib/auth-session'
 import { hasBotPermission, type BotPermission } from '@/utils/bot-permissions'
+import { parseBrowserAddress } from '@/utils/browser-address'
 import {
   clearTerminalSnapshots,
   clearTerminalSnapshotsForBot,
@@ -742,19 +743,62 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
 
   function openBrowser(groupId?: string) {
     if (!hasCurrentPermission('manage')) return
+    addBrowserPanel(DEFAULT_BROWSER_ADDRESS, undefined, groupId)
+  }
+
+  // Create a fresh browser panel at `address`. Shared by the manual "+ New
+  // Browser" entry (always-new, default "Browser N" title) and the link-click
+  // path (after a dedup miss, titled with the address). Returns false when there
+  // is no dock/bot layout.
+  function addBrowserPanel(address: string, title: string | undefined, groupId?: string): boolean {
     const bid = (currentBotId.value ?? '').trim()
     const state = ensureBotLayout(bid)
-    if (!state || !api.value) return
+    if (!state || !api.value) return false
     const next = state.browserCounter + 1
     patchBotLayout(bid, { browserCounter: next })
     focusOrAdd({
       id: `browser:${next}`,
       component: 'browser',
-      title: `Browser ${next}`,
-      params: { address: DEFAULT_BROWSER_ADDRESS },
+      title: title ?? `Browser ${next}`,
+      params: { address },
       groupId,
     })
+    return true
   }
+
+  // Open the workspace browser panel at a specific local address (e.g. from a
+  // clicked localhost link in chat markdown or terminal output). If a browser
+  // tab already shows the exact same normalized URL, focus it instead of opening
+  // a duplicate. Returns true when a tab was opened or focused, false when the
+  // browser is unavailable (no permission / no dock / unparseable address) so
+  // callers can fall back to the OS browser.
+  function openBrowserAt(address: string, groupId?: string): boolean {
+    if (!hasCurrentPermission('manage')) return false
+    const dock = api.value
+    if (!dock) return false
+    let target: string
+    try {
+      target = parseBrowserAddress(address).display
+    } catch {
+      return false
+    }
+    const existing = dock.panels.find((panel) => {
+      if (!panel.id.startsWith('browser:')) return false
+      const current = (panel.params as { address?: string } | undefined)?.address
+      if (!current) return false
+      try {
+        return parseBrowserAddress(current).display === target
+      } catch {
+        return false
+      }
+    })
+    if (existing) {
+      focusPanel(existing)
+      return true
+    }
+    return addBrowserPanel(target, target, groupId)
+  }
+
 
   function openDisplay(groupId?: string) {
     if (!hasCurrentPermission('manage')) return
@@ -1224,6 +1268,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     openTerminal,
     openTerminalInPanel,
     openBrowser,
+    openBrowserAt,
     openDisplay,
     splitGroup,
     openSchedule,

--- a/apps/web/src/utils/localhost-link.ts
+++ b/apps/web/src/utils/localhost-link.ts
@@ -1,0 +1,23 @@
+import { parseBrowserAddress, type BrowserAddress } from '@/utils/browser-address'
+
+// Detect/normalize links that point at a container-local dev server so they can
+// be opened in the workspace `browser` panel instead of the user's OS browser
+// (the container's localhost is NOT the user's localhost). Reuses the strict
+// `parseBrowserAddress` validator, which only admits localhost / 127.0.0.1 / ::1
+// with an explicit port — so a bare `localhost` is intentionally rejected.
+
+export function tryParseLocalhostHref(raw: string | null | undefined): BrowserAddress | null {
+  if (!raw) return null
+  try {
+    return parseBrowserAddress(raw)
+  } catch {
+    return null
+  }
+}
+
+// Scans free-form terminal output for local URLs. A port is required (`:\d+`) so
+// prose words like "localhost" alone never match. Matches accept an optional
+// http(s):// scheme and an optional path. Each hit is re-validated through
+// `tryParseLocalhostHref` before use.
+export const LOCALHOST_URL_REGEX
+  = /(?:https?:\/\/)?(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)(?:\/[^\s)\]]*)?/gi


### PR DESCRIPTION
## What

Make `localhost` / `127.0.0.1` / `::1` URLs (with a port) that appear in **chat markdown** and **terminal output** clickable so they open the workspace **browser** panel — and focus an already-open tab when the exact same URL is clicked again instead of creating a duplicate.

## Why

The workspace already has a `browser` tab that proxies a container-local dev server (iframe over HTTP, restricted to localhost). But:
- localhost links in chat markdown were plain `<a>` that opened in the user's **OS browser** — where the container's `localhost` is meaningless (it's not the user's localhost).
- localhost URLs in terminal output weren't clickable at all (xterm had no link addon).

Now clicking such a link lands the user inside the workspace browser pointed at the right in-container service.

## How

- **`apps/web/src/utils/localhost-link.ts`** (new) — shared detection that reuses the existing strict `parseBrowserAddress` validator (only localhost/127.0.0.1/::1 + explicit port pass; a bare `localhost` is rejected), plus a regex for scanning free-form terminal output.
- **`store/workspace-tabs.ts`** — new `openBrowserAt(address, groupId?)`: normalizes the address, dedups by exact normalized URL (focus existing `browser:*` tab on a hit), otherwise opens a new tab titled with the address. `openBrowser()` keeps its original *always-new* behavior, so the manual **“+ New Browser”** button is unchanged. Returns a boolean so callers can fall back when the browser is unavailable.
- **`components/markdown/md-link.vue`** (new) — custom markstream `link` node. Rendering is delegated wholesale to markstream's `LinkNode` (styling/tooltip/stream animation untouched); only the click is hijacked, and only for local links (capture phase, primary click without modifiers). Registered as `link` in `components/markdown/index.ts`, so it applies to every markdown surface (chat + file preview). Modifier/middle clicks and external links keep default behavior.
- **`pages/home/components/terminal-pane.vue`** — registers an xterm `ILinkProvider` that detects local URLs per line and opens them via `openBrowserAt`; the disposable is cleaned up with the terminal.

## Dedup rule

Exact normalized URL (host:port **and** path). Same port, different path → opens a new tab. (`127.0.0.1` and `localhost` normalize to the same key, so they're treated as one tab.)

## Fallback

When the workspace browser is unavailable (no `manage` permission / local workspace / no dock), `openBrowserAt` returns `false` and the markdown/terminal handler falls back to opening the URL in the OS browser — so a click never silently does nothing.

## Tests

- Added 2 store unit tests (dedup/normalize on the same URL; refuse non-local addresses). Full suite: 19 passing.
- `eslint`, `vue-tsc` (0 errors), and the UI contract guard pass for the changed files.

## Reviewer notes / manual verification

Pre-commit Go + ESLint hooks passed. Manual UI check still recommended: in a **container-workspace** bot, have the bot reply with `http://localhost:5173/` (and a different path on the same port), and `echo` a localhost URL in the terminal — clicking should open/focus browser tabs per the dedup rule; external links (e.g. `https://example.com`) should be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)