### PR TITLE
fix(agent): gate image input on vision capability

### DIFF
--- a/internal/conversation/flow/resolver.go
+++ b/internal/conversation/flow/resolver.go
@@ -657,10 +657,8 @@ func (r *Resolver) canDeliverUserInputWS(eventCh chan<- WSStreamEvent) bool {
 	return r.userInput != nil && eventCh != nil
 }
 
-func supportsImageInputForModel(_ models.GetResponse) bool {
-	// Keep in-process read-media image injection available until model-level
-	// capability metadata is authoritative; ACP keeps this disabled separately.
-	return true
+func supportsImageInputForModel(m models.GetResponse) bool {
+	return m.HasCompatibility(models.CompatVision)
 }
 
 const (

--- a/internal/conversation/flow/resolver_model_selection_test.go
+++ b/internal/conversation/flow/resolver_model_selection_test.go
@@ -119,7 +119,7 @@ func TestBuildModelSelectionRequest_PreservesOverrides(t *testing.T) {
 	}
 }
 
-func TestSupportsImageInputForModelDefaultsToSupported(t *testing.T) {
+func TestSupportsImageInputForModel(t *testing.T) {
 	t.Parallel()
 
 	visionModel := models.GetResponse{
@@ -134,8 +134,8 @@ func TestSupportsImageInputForModelDefaultsToSupported(t *testing.T) {
 	}
 
 	plainModel := models.GetResponse{}
-	if !supportsImageInputForModel(plainModel) {
-		t.Fatal("model image input should default to supported until model capability metadata is available")
+	if supportsImageInputForModel(plainModel) {
+		t.Fatal("model without vision compatibility should not support image input")
 	}
 }
 


### PR DESCRIPTION
## 问题

`supportsImageInputForModel` 当前无条件返回 `true`，忽略了模型的视觉能力标签（`CompatVision`）。这导致所有原生 agent 路径下的模型都会被注入图片，无论模型是否支持多模态输入。

注释中写道"在模型级能力元数据变得权威之前先保留图片注入"——但模型能力元数据（`ModelConfig.Compatibilities` + `HasCompatibility()`）早已存在且被其他能力字段（如 `SupportsToolCall`）正常使用，这个过渡逻辑不应再保留。

## 影响

使用非视觉模型（纯文本模型）+ read_media 工具时，读取的图片会被无条件注入到 user message 中（`image_url` content part），发送给不支持多模态的后端时会返回 400 错误：

```
Failed to deserialize the JSON body into the target type:
messages[33]: unknown variant image_url, expected text
```

ACP 路径不受影响（`resolver_acp.go` 中硬编码 `SupportsImageInput: false`）。

## 修复

还原成按 `CompatVision` 标签判断，与 `SupportsToolCall` 等其他能力字段保持一致：

```go
func supportsImageInputForModel(m models.GetResponse) bool {
    return m.HasCompatibility(models.CompatVision)
}
```

同步更新了测试用例（`TestSupportsImageInputForModel`）：无 `vision` 标签的模型不再期望支持图片输入。

## 验证

- `go test ./internal/conversation/flow/... ./internal/agent/...` 全部通过
- 确认附件路由（`capability_policy.go`）本来就按 `CompatVision` 过滤，修复后语义对齐
- 确认 `SupportsToolCall` 等其他能力字段未受影响，仍由 `HasCompatibility` 驱动

#### Test plan
- [x] `go test ./internal/conversation/flow/` 通过
- [x] `go test ./internal/agent/` 通过
- [x] `go build ./internal/conversation/flow/...` 通过