### PR TITLE
fix(web): improve desktop resize responsiveness

### DIFF
--- a/apps/web/src/pages/home/components/chat-workspace.vue
+++ b/apps/web/src/pages/home/components/chat-workspace.vue
@@ -67,21 +67,56 @@ const { currentBotId, sessionId, activeSession } = storeToRefs(chatStore)
 // dockview's own auto-resize is disabled at construction (:disable-auto-resizing);
 // we drive layout from this ResizeObserver instead. The dock is a flex-1 sibling
 // of the sidebar (push/pull model), so when the sidebar slides out/in this root's
-// width animates frame-by-frame; the observer relays out on each of those frames,
-// keeping panels matched to the container the whole way. The right edge is pinned
-// (viewport edge), so the right-side actions ("+") never move while the width
-// changes — no snap.
+// width changes frame-by-frame; the observer relays layout before paint, keeping
+// panels matched to the latest container size without an extra frame of lag. The
+// right edge is pinned (viewport edge), so the right-side actions ("+") never move
+// while the width changes - no snap.
 // (NOTE: dockview 6.6.1 ignores updateOptions({ disableAutoResizing }) at runtime
 // — a guard checks the wrong key — so toggling the prop reactively does nothing;
 // owning the observer is the reliable route.)
 const rootEl = ref<HTMLElement | null>(null)
 let resizeObserver: ResizeObserver | null = null
+let lastLayoutSize = { width: -1, height: -1 }
+
+function normalizeLayoutSize(width: number, height: number): { width: number, height: number } | null {
+  const normalized = {
+    width: Math.round(width),
+    height: Math.round(height),
+  }
+  if (normalized.width <= 0 || normalized.height <= 0) return null
+  return normalized
+}
+
+function readLayoutSize(): { width: number, height: number } | null {
+  const el = rootEl.value
+  if (!el) return null
+
+  return normalizeLayoutSize(el.clientWidth, el.clientHeight)
+}
+
+function readObservedSize(entry: ResizeObserverEntry): { width: number, height: number } | null {
+  return normalizeLayoutSize(entry.contentRect.width, entry.contentRect.height)
+}
+
+function applyLayoutSize(size: { width: number, height: number }) {
+  const dock = api.value
+  if (!dock) return
+  if (size.width === lastLayoutSize.width && size.height === lastLayoutSize.height) return
+
+  lastLayoutSize = size
+  dock.layout(size.width, size.height)
+}
 
 function applyLayout() {
-  const dock = api.value
-  const el = rootEl.value
-  if (!dock || !el) return
-  dock.layout(el.clientWidth, el.clientHeight)
+  const size = readLayoutSize()
+  if (!size) return
+  applyLayoutSize(size)
+}
+
+function handleResize(entry?: ResizeObserverEntry) {
+  const size = entry ? readObservedSize(entry) : readLayoutSize()
+  if (!size) return
+  applyLayoutSize(size)
 }
 
 // Panel components are looked up by name when panels are added or restored
@@ -147,7 +182,7 @@ const chatPanelTitle = computed(() => {
 
 function onReady(event: DockviewReadyEvent) {
   store.registerApi(event.api)
-  if (rootEl.value) event.api.layout(rootEl.value.clientWidth, rootEl.value.clientHeight)
+  applyLayout()
   ensureChatPanel()
 }
 
@@ -207,7 +242,9 @@ provide(openInFileManagerKey, (path: string, isDir = false) => {
 provide(openAssetPreviewKey, args => store.openAsset(args))
 
 onMounted(() => {
-  resizeObserver = new ResizeObserver(() => applyLayout())
+  resizeObserver = new ResizeObserver(([entry]) => {
+    handleResize(entry)
+  })
   if (rootEl.value) resizeObserver.observe(rootEl.value)
 })
 

--- a/apps/web/src/pages/main-section/index.vue
+++ b/apps/web/src/pages/main-section/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="h-dvh w-screen overflow-hidden transition-all duration-[450ms] ease-out"
+    class="h-dvh w-screen overflow-hidden transition-[opacity,scale] duration-[450ms] ease-out"
     :class="entering ? 'scale-[1.15] opacity-0' : 'scale-100 opacity-100'"
   >
     <!-- PUSH/PULL. The sidebar (a flex sibling) slides out left and the dock,


### PR DESCRIPTION
## Summary

- Replaced the main shell `transition-all` with an entry-only `opacity` and `scale` transition.
- Updated dockview resize handling to use normalized `ResizeObserver` dimensions and skip duplicate layout calls.

## Testing

- `mise exec -- pnpm --filter @memohai/web build`