### PR TITLE
fix(web): isolate sidebar drag regions

### DIFF
--- a/apps/web/src/components/master-detail-sidebar-layout/index.vue
+++ b/apps/web/src/components/master-detail-sidebar-layout/index.vue
@@ -76,9 +76,12 @@
             <SheetDescription>Sidebar navigation</SheetDescription>
           </SheetHeader>
           <div class="flex h-full w-full flex-col">
-            <SidebarHeader>
+            <component
+              :is="flush ? 'div' : SidebarHeader"
+              class="shrink-0"
+            >
               <slot name="sidebar-header" />
-            </SidebarHeader>
+            </component>
             <SidebarContent class="px-2 scrollbar-none">
               <slot name="sidebar-content" />
             </SidebarContent>

--- a/apps/web/src/components/settings-sidebar/index.vue
+++ b/apps/web/src/components/settings-sidebar/index.vue
@@ -12,6 +12,11 @@
       collapsible="none"
       :class="['border-r border-sidebar-border', desktopShell && 'h-dvh']"
     >
+      <div
+        v-if="macTrafficReserve"
+        class="h-12 shrink-0 [-webkit-app-region:drag]"
+        aria-hidden="true"
+      />
       <!-- Traffic-reserve top padding: clears the macOS traffic lights (bottom edge
            ≈28px from top) with a comfortable ~20px gap below them — tighter than the
            old full-width header's 62px (which read as over-reserved) but not cramped
@@ -21,10 +26,9 @@
       <SidebarHeader
         v-if="!hideHeader"
         class="px-[16px] pb-3 border-0"
-        :class="macTrafficReserve ? 'pt-[48px] [-webkit-app-region:drag]' : 'pt-[18px]'"
+        :class="macTrafficReserve ? 'pt-0' : 'pt-[18px]'"
       >
         <NavItem
-          class="[-webkit-app-region:no-drag]"
           @click="router.push(_backToChatRoute).catch(() => {})"
         >
           <ChevronLeft class="size-3.5 shrink-0" />
@@ -182,9 +186,8 @@ import NavItem from './nav-item.vue'
 const props = withDefaults(defineProps<{
   hideHeader?: boolean
   excludeItems?: string[]
-  // When true, the sidebar header reserves space for the macOS traffic lights and
-  // becomes a window drag region — used when this sidebar runs to the very top of
-  // the window (no full-width topbar above it), mirroring the chat SideBar.
+  // When true, the sidebar reserves a draggable macOS traffic-light strip above
+  // its visible controls.
   macTrafficReserve?: boolean
 }>(), {
   hideHeader: false,

--- a/apps/web/src/components/sidebar/bot-switcher.vue
+++ b/apps/web/src/components/sidebar/bot-switcher.vue
@@ -13,7 +13,7 @@
            hover fill. No color transition: the fill snaps on hover/open. -->
       <button
         type="button"
-        class="group flex h-8 items-center text-xs text-foreground outline-none hover:bg-[color:var(--sidebar-hover)] focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[color:var(--sidebar-hover)]"
+        class="group flex h-8 items-center text-xs text-foreground outline-none hover:bg-[color:var(--sidebar-hover)] focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[color:var(--sidebar-hover)] [-webkit-app-region:no-drag]"
         :class="fullWidth
           ? 'w-[calc(100%+3px)] -ml-[3px] gap-1.5 rounded-full pl-2 pr-2.5'
           : 'max-w-full gap-2 rounded-md px-1.5'"

--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -20,7 +20,7 @@
       class="flex h-11 shrink-0 items-center bg-sidebar pr-2 py-1.5 [-webkit-app-region:drag]"
       :class="macTrafficReserve ? 'pl-[76px]' : 'pl-3'"
     >
-      <div class="min-w-0 flex-1 [-webkit-app-region:no-drag]">
+      <div class="min-w-0 flex-1">
         <BotSwitcher :full-width="!macTrafficReserve" />
       </div>
     </header>

--- a/apps/web/src/pages/bots/detail.vue
+++ b/apps/web/src/pages/bots/detail.vue
@@ -26,8 +26,13 @@
                  a floating card, which anchors the header and keeps back from
                  reading as a stray nav row — no hairline needed. -->
             <div
+              v-if="macTrafficReserve"
+              class="h-12 shrink-0 [-webkit-app-region:drag]"
+              aria-hidden="true"
+            />
+            <div
               class="px-4 pb-3 flex flex-col"
-              :class="macTrafficReserve ? 'pt-[48px] [-webkit-app-region:drag]' : 'pt-[18px]'"
+              :class="macTrafficReserve ? undefined : 'pt-[18px]'"
             >
               <NavItem
                 class="[-webkit-app-region:no-drag]"


### PR DESCRIPTION
## Summary

- Put sidebar top drag areas in separate in-flow strips instead of making visible headers draggable.
- Keep sidebar controls outside drag regions, with the BotSwitcher trigger marked as `no-drag`.
- Use a neutral wrapper for flush master-detail sheet headers so bot detail sheet spacing matches the primary sidebar.

## Testing

- `mise exec -- pnpm eslint apps/web/src/components/master-detail-sidebar-layout/index.vue apps/web/src/components/settings-sidebar/index.vue apps/web/src/components/sidebar/bot-switcher.vue apps/web/src/components/sidebar/index.vue apps/web/src/pages/bots/detail.vue`