### PR TITLE
feat(web): auto-close terminal tab when shell exits

### DIFF
--- a/apps/web/src/pages/home/components/terminal-pane.vue
+++ b/apps/web/src/pages/home/components/terminal-pane.vue
@@ -161,7 +161,11 @@ function connectWs() {
     }
   }
 
-  socket.onclose = () => {
+  socket.onclose = (event) => {
+    if (event.code === 1000) {
+      tabsStore.closeTab(props.tabId)
+      return
+    }
     status.value = 'disconnected'
     terminal?.write('\r\n\x1b[31m[Connection closed]\x1b[0m\r\n')
   }

--- a/internal/handlers/containerd_terminal.go
+++ b/internal/handlers/containerd_terminal.go
@@ -145,6 +145,9 @@ func (h *ContainerdHandler) HandleTerminalWS(c echo.Context) error {
 					}
 				}
 			case pb.ExecOutput_EXIT:
+				_ = conn.WriteControl(websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+					time.Now().Add(5*time.Second))
 				return
 			}
 		}


### PR DESCRIPTION
## Summary

Terminal tab 在 shell 退出后（`exit` / Cmd+D）不会自动关闭，用户需要手动点 X 关闭。本 PR 修复了这个问题，行为对齐 VS Code 集成终端。

**问题根因：** 后端在 PTY 进程退出时仅做了原始的 `conn.Close()`（TCP 层），没有发送 WebSocket close
frame，导致前端 `onclose` 事件的 `wasClean` 始终为 `false`，无法区分"shell 正常退出"与"网络断开"。

## Changes
- **后端** (`containerd_terminal.go`)：PTY 退出（`ExecOutput_EXIT`）时发送 `CloseNormalClosure (1000)`
WebSocket close frame
- **前端** (`terminal-pane.vue`)：`onclose` 检查 `event.code === 1000` 时自动关闭 tab；其他 code 保留原有的 "[Connection closed]" + Reconnect 按钮

## Close code
| Code | 场景 | 行为 |
|------|------|------|
| 1000 | Shell 正常退出 | 自动关闭 tab |
| 1001 | 空闲超时（30min） | 显示 Reconnect |
| 1006 | 网络错误 | 显示 Reconnect |