### PR TITLE
chore: add frontend code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Frontend code owners
+# 前端相关 PR 自动将以下 owner 加为 reviewer
+
+apps/web/          @qqqqqf-q
+packages/ui/       @qqqqqf-q

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
-# Frontend code owners
-# 前端相关 PR 自动将以下 owner 加为 reviewer
-
 apps/web/          @qqqqqf-q
 packages/ui/       @qqqqqf-q


### PR DESCRIPTION
加一个前端 code owner 文件,前端相关 PR(`apps/web`、`packages/ui/`)自动将 owner 加为 reviewer,方便前端 review。

不开启 branch protection、不强制 block,只是让前端 owner 在 PR 开的时候能被自动提醒、看到 diff。路径先覆盖前端核心两块,后续按需扩展。