### PR TITLE
fix: recover long-turn chat visibility

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -1105,6 +1105,8 @@ const isWelcome = computed(() =>
   !!currentBotId.value
   && !activeChatReadOnly.value
   && !loadingChats.value
+  && !loadingMessages.value
+  && !streaming.value
   && messages.value.length === 0,
 )
 

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1780,6 +1780,68 @@ describe('chat-list store', () => {
     await second
   })
 
+  it('reattaches an in-flight local turn when switching back before history is persisted', async () => {
+    // Long local tasks persist their bot_history_messages as a terminal
+    // snapshot. Until the stream ends, switching back to the session can
+    // legitimately fetch an empty REST transcript; the pending stream must
+    // still keep the optimistic user prompt and assistant turn visible.
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: { id: 0, type: 'text', content: 'working' },
+      } as UIStreamEvent,
+    ]
+    api.fetchSessions.mockResolvedValueOnce({ items: [
+      { id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' },
+      { id: 'session-b', bot_id: 'bot-1', title: 'B', type: 'chat' },
+    ], nextCursor: null })
+    api.fetchMessagesUI.mockResolvedValue([])
+
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+
+    const sendPromise = store.sendMessage('long job')
+    await flushPromises()
+    expect(store.sessionId).toBe('session-a')
+    expect(store.messages.map(m => m.role)).toEqual(['user', 'assistant'])
+
+    await store.selectSession('session-b')
+    await flushPromises()
+    expect(store.sessionId).toBe('session-b')
+    expect(store.messages).toEqual([])
+
+    await store.selectSession('session-a')
+    await flushPromises()
+    expect(store.sessionId).toBe('session-a')
+    expect(store.messages.map(m => m.role)).toEqual(['user', 'assistant'])
+    expect(store.messages[0]).toMatchObject({ role: 'user', text: 'long job' })
+    expect(store.messages[1]).toMatchObject({
+      role: 'assistant',
+      messages: [expect.objectContaining({ type: 'text', content: 'working' })],
+      streaming: true,
+    })
+
+    api.fetchMessagesUI.mockResolvedValueOnce([
+      {
+        id: 'server-user',
+        role: 'user',
+        text: 'long job',
+        attachments: [],
+        timestamp: '2026-06-24T10:00:00.000Z',
+      },
+      {
+        id: 'server-assistant',
+        role: 'assistant',
+        messages: [{ id: 0, type: 'text', content: 'done' }],
+        timestamp: '2026-06-24T10:00:01.000Z',
+      },
+    ])
+    streamHandler?.({ type: 'end', stream_id: lastStreamId, session_id: lastSessionId } as UIStreamEvent)
+    await sendPromise
+  })
+
   it('hydrates hidden subagent session summaries after selecting them', async () => {
     api.fetchSessions.mockResolvedValueOnce({ items: [
       { id: 'session-parent', bot_id: 'bot-1', title: 'Parent', type: 'chat' },

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -185,6 +185,7 @@ function userInputConnectionLostMessage() {
 
 interface PendingAssistantStream {
   streamId: string
+  userTurn?: ChatUserTurn
   assistantTurn: ChatAssistantTurn
   botId: string
   sessionId: string
@@ -1072,13 +1073,13 @@ export const useChatStore = defineStore('chat', () => {
     return normalized
   }
 
-  // Active-session-only view. There is no per-session message cache: switching
-  // sessions clears `messages` and re-fetches the new session's transcript via
-  // `refreshCurrentSession`. The previous identity-preserving reconciler held
-  // ChatMessage references across sessions in the cache and let
-  // mergeTurnInPlace mutate them, which corrupted the view when navigating
-  // between sessions. Per-session SSE delivers live updates without ever
-  // touching another session's data, so cross-session caching has no purpose.
+  // Active-session-only view. There is no full per-session message cache:
+  // switching sessions clears `messages` and re-fetches the target session's
+  // persisted transcript via `refreshCurrentSession`. The one exception is an
+  // in-flight assistant stream. Long agent tasks are persisted as a terminal
+  // snapshot, so the server can legitimately return an empty transcript while
+  // the task is still running. Keep those optimistic turns in the stream entry
+  // and reattach them when the user switches back to that session.
 
   function replaceMessages(items: UITurn[], targetSessionId?: string) {
     const next = normalizeTurns(items, targetSessionId)
@@ -1184,7 +1185,28 @@ export const useChatStore = defineStore('chat', () => {
     return activeIds.length === 1 ? activeIds[0]! : fallbackStreamId(sid)
   }
 
-  function trackAssistantStream(streamId: string, assistantTurn: ChatAssistantTurn, botId: string, targetSessionId: string): Promise<void> {
+  function hasTurnInView(turn: ChatMessage): boolean {
+    return messages.some(item => item === turn || item.id === turn.id || isSameLogicalTurn(turn, item))
+  }
+
+  function restorePendingStreamTurns(botId: string, targetSessionId: string) {
+    const bid = botId.trim()
+    const sid = targetSessionId.trim()
+    if (!bid || !sid) return
+    if (currentBotId.value !== bid || sessionId.value !== sid) return
+
+    for (const stream of pendingStreams()) {
+      if (stream.botId !== bid || stream.sessionId !== sid) continue
+      if (stream.userTurn && !hasTurnInView(stream.userTurn)) {
+        messages.push(stream.userTurn)
+      }
+      if (!hasTurnInView(stream.assistantTurn)) {
+        messages.push(stream.assistantTurn)
+      }
+    }
+  }
+
+  function trackAssistantStream(streamId: string, assistantTurn: ChatAssistantTurn, botId: string, targetSessionId: string, userTurn?: ChatUserTurn): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const id = streamId.trim()
       if (!id) {
@@ -1197,6 +1219,7 @@ export const useChatStore = defineStore('chat', () => {
       }
       pendingAssistantStreams.set(id, {
         streamId: id,
+        userTurn,
         assistantTurn,
         botId,
         sessionId: targetSessionId.trim(),
@@ -1232,11 +1255,10 @@ export const useChatStore = defineStore('chat', () => {
     pendingAssistantStreams.delete(streamId.trim())
   }
 
-  // Append/remove operate only on the active session's `messages` array.
-  // Optimistic turns belonging to a now-stale session (the user switched away
-  // before the assistant stream finished) are silently dropped from the view;
-  // the server keeps recording the conversation and the next REST refresh on
-  // that session will surface the response.
+  // Append/remove operate only on the active session's `messages` array. If an
+  // optimistic turn belongs to a now-stale session, the pending stream retains
+  // it and `restorePendingStreamTurns` reattaches it when that session becomes
+  // active again.
 
   function appendTurnToSession(botId: string, targetSessionId: string, turn: ChatMessage) {
     const bid = botId.trim()
@@ -1666,6 +1688,7 @@ export const useChatStore = defineStore('chat', () => {
         // empty-server-response handling settles the flag correctly.
         hasMoreOlder.value = true
       }
+      restorePendingStreamTurns(bid, sid)
       const latest = messages[messages.length - 1]?.timestamp
       touchSessionInList(sid, latest)
     })().finally(() => {
@@ -2513,6 +2536,7 @@ export const useChatStore = defineStore('chat', () => {
     hasLoadedOlder.value = false
     const bid = (currentBotId.value ?? '').trim()
     if (!bid || !sid) return
+    restorePendingStreamTurns(bid, sid)
     startSessionMessagesStream(bid, sid)
   }
 
@@ -2656,7 +2680,7 @@ export const useChatStore = defineStore('chat', () => {
         if (!ws.connected) {
           throw new StreamFailureError('WebSocket is not connected', 'startup')
         }
-        const completion = trackAssistantStream(sendStreamId, assistantTurn, bid, sid)
+        const completion = trackAssistantStream(sendStreamId, assistantTurn, bid, sid, userTurn)
         ws.send({
           type: 'message',
           stream_id: sendStreamId,

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -314,6 +314,7 @@ describe('workspace layout store', () => {
 
     expect(dock.panels.filter((p) => p.component === 'chat')).toHaveLength(1)
     expect(dock.activePanel?.component).toBe('chat')
+    expect(chatStoreMock.selectDraft).toHaveBeenCalledTimes(2)
   })
 
   it('opens one chat tab per session and reuses the ephemeral slot', () => {
@@ -334,6 +335,7 @@ describe('workspace layout store', () => {
     expect(chatPanels).toHaveLength(1)
     expect(chatPanels[0]!.id).toBe(firstId)
     expect(chatPanels[0]!.params.sessionId).toBe('s2')
+    expect(chatStoreMock.selectSession).toHaveBeenLastCalledWith('s2')
   })
 
   it('uses remembered hidden session summaries for subagent chat tabs', () => {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -752,6 +752,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     if (existing) {
       existing.api.setTitle(title)
       focusPanel(existing)
+      void chatStore.selectSession(sid)
       return
     }
     // Repoint the target group's existing ephemeral CHAT slot in place (no
@@ -773,13 +774,15 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       void chatStore.selectSession(sid)
       return
     }
-    openEphemeral({
+    if (openEphemeral({
       id: nextChatPanelId(bid),
       component: 'chat',
       title,
       params: { sessionId: sid },
       groupId: opts.groupId,
-    })
+    })) {
+      void chatStore.selectSession(sid)
+    }
   }
 
   /** Open or focus the single draft chat tab (no session yet). */
@@ -793,15 +796,18 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     )
     if (existingDraft) {
       focusPanel(existingDraft)
+      chatStore.selectDraft()
       return
     }
-    openEphemeral({
+    if (openEphemeral({
       id: nextChatPanelId(bid),
       component: 'chat',
       title: opts?.title?.trim() || DEFAULT_CHAT_TITLE,
       params: { sessionId: null },
       groupId: opts?.groupId,
-    })
+    })) {
+      chatStore.selectDraft()
+    }
   }
 
   // Activating a chat tab makes its session the live one (single global messages

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -164,22 +164,7 @@ func (h *MessageHandler) ListMessages(c echo.Context) error {
 	}
 	botID = bot.ID
 
-	var messages []messagepkg.Message
-	if hasBefore {
-		messages, err = h.messageService.ListBeforeBySession(c.Request().Context(), sessionID, before, limit)
-		// ListBeforeBySession returns DESC (newest-first), but the UI turn
-		// converter and the frontend both need oldest-first. The latest-page
-		// branch reverses below; the before-page must match — otherwise older
-		// history renders in reverse and turns fall apart.
-		if err == nil {
-			reverseMessages(messages)
-		}
-	} else {
-		messages, err = h.messageService.ListLatestBySession(c.Request().Context(), sessionID, limit)
-		if err == nil {
-			reverseMessages(messages)
-		}
-	}
+	messages, err := h.listSessionMessageWindow(c.Request().Context(), sessionID, hasBefore, before, limit)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -188,7 +173,7 @@ func (h *MessageHandler) ListMessages(c echo.Context) error {
 	// reply as several turns/action bars. Extend the head back to a real turn
 	// boundary so a turn is never split across pages.
 	if format == "ui" && sessionID != "" && len(messages) > 0 {
-		messages = h.extendToUITurnHead(c.Request().Context(), sessionID, messages)
+		messages = h.ensureUITurnHead(c.Request().Context(), sessionID, messages, hasBefore, before, limit)
 	}
 	h.fillAssetMimeFromStorage(c.Request().Context(), botID, messages)
 	if format == "ui" {
@@ -486,6 +471,57 @@ func reverseMessages(m []messagepkg.Message) {
 	for i, j := 0, len(m)-1; i < j; i, j = i+1, j-1 {
 		m[i], m[j] = m[j], m[i]
 	}
+}
+
+var uiTurnHeadFallbackLimits = []int32{100, 250, 500}
+
+func (h *MessageHandler) listSessionMessageWindow(ctx context.Context, sessionID string, hasBefore bool, before time.Time, limit int32) ([]messagepkg.Message, error) {
+	var messages []messagepkg.Message
+	var err error
+	if hasBefore {
+		messages, err = h.messageService.ListBeforeBySession(ctx, sessionID, before, limit)
+	} else {
+		messages, err = h.messageService.ListLatestBySession(ctx, sessionID, limit)
+	}
+	if err != nil {
+		return nil, err
+	}
+	reverseMessages(messages)
+	return messages, nil
+}
+
+func (h *MessageHandler) ensureUITurnHead(ctx context.Context, sessionID string, messages []messagepkg.Message, hasBefore bool, before time.Time, limit int32) []messagepkg.Message {
+	messages = h.extendToUITurnHead(ctx, sessionID, messages)
+	if len(messages) == 0 || conversation.IsUITurnBoundary(messages[0]) {
+		return messages
+	}
+
+	// Stopgap for long single-turn runs persisted in one SQLite second: the
+	// 30-row default can land inside assistant/tool rows, while the
+	// created_at-only cursor cannot reliably walk through same-second rows to
+	// the user boundary. Keep the normal page size for ordinary turns, but
+	// progressively widen this UI-only page when the head is still not a safe
+	// boundary after the usual backfill.
+	for _, expandedLimit := range uiTurnHeadFallbackLimits {
+		if expandedLimit <= limit {
+			continue
+		}
+		expanded, err := h.listSessionMessageWindow(ctx, sessionID, hasBefore, before, expandedLimit)
+		if err != nil {
+			if h.logger != nil {
+				h.logger.Warn("expand UI message page failed", slog.Int("limit", int(expandedLimit)), slog.Any("error", err))
+			}
+			return messages
+		}
+		if len(expanded) <= len(messages) {
+			continue
+		}
+		messages = h.extendToUITurnHead(ctx, sessionID, expanded)
+		if len(messages) == 0 || conversation.IsUITurnBoundary(messages[0]) {
+			return messages
+		}
+	}
+	return messages
 }
 
 // StreamMessageEvents was removed in favor of two narrower streams: a

--- a/internal/handlers/message_pagination_test.go
+++ b/internal/handlers/message_pagination_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sort"
 	"testing"
@@ -24,7 +25,12 @@ func (s *stubMessageService) latest(sid string, limit int) []messagepkg.Message 
 	all := s.bySession[sid]
 	desc := make([]messagepkg.Message, len(all))
 	copy(desc, all)
-	sort.Slice(desc, func(i, j int) bool { return desc[i].CreatedAt.After(desc[j].CreatedAt) })
+	sort.Slice(desc, func(i, j int) bool {
+		if desc[i].CreatedAt.Equal(desc[j].CreatedAt) {
+			return desc[i].ID > desc[j].ID
+		}
+		return desc[i].CreatedAt.After(desc[j].CreatedAt)
+	})
 	if len(desc) > limit {
 		desc = desc[:limit]
 	}
@@ -63,6 +69,15 @@ func msg(role string, t time.Time) messagepkg.Message {
 // test.
 func userMsg(t time.Time, text string) messagepkg.Message {
 	return messagepkg.Message{Role: "user", CreatedAt: t, Content: []byte(`{}`), DisplayContent: text}
+}
+
+func indexedMsg(id int, role string, t time.Time) messagepkg.Message {
+	return messagepkg.Message{
+		ID:        fmt.Sprintf("%04d", id),
+		Role:      role,
+		CreatedAt: t,
+		Content:   []byte(`{}`),
+	}
 }
 
 // TestExtendToUITurnHead_PreservesMonotonicOrder is the regression test for the
@@ -132,5 +147,83 @@ func TestExtendToUITurnHead_StopsAtBoundary(t *testing.T) {
 	}
 	if got[0].Role != "user" {
 		t.Fatalf("expected head to be the user boundary, got role %q", got[0].Role)
+	}
+}
+
+func TestEnsureUITurnHead_ExpandsSameSecondPage(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 6, 24, 13, 17, 26, 0, time.UTC)
+	const sessionID = "same-second"
+	all := []messagepkg.Message{{
+		ID:             "0001",
+		Role:           "user",
+		CreatedAt:      base,
+		Content:        []byte(`{}`),
+		DisplayContent: "run many commands",
+	}}
+	all = append(all, indexedMsg(2, "assistant", base))
+	for i := 3; i <= 32; i++ {
+		role := "assistant"
+		if i%2 == 1 {
+			role = "tool"
+		}
+		all = append(all, indexedMsg(i, role, base))
+	}
+	svc := &stubMessageService{bySession: map[string][]messagepkg.Message{sessionID: all}}
+	h := &MessageHandler{messageService: svc, logger: slog.Default()}
+
+	latest := svc.latest(sessionID, 30)
+	reverseMessages(latest)
+	if len(latest) != 30 || latest[0].Role == "user" {
+		t.Fatalf("test setup failed: latest 30 should start mid-turn, got len=%d role=%q", len(latest), latest[0].Role)
+	}
+	if extended := h.extendToUITurnHead(context.Background(), sessionID, latest); len(extended) != len(latest) {
+		t.Fatalf("test setup failed: created_at-only backfill unexpectedly changed same-second page")
+	}
+
+	got := h.ensureUITurnHead(context.Background(), sessionID, latest, false, time.Time{}, 30)
+	if len(got) != len(all) {
+		t.Fatalf("expected same-second fallback to expand to full test turn, got %d want %d", len(got), len(all))
+	}
+	if got[0].Role != "user" {
+		t.Fatalf("expected expanded page to start at user boundary, got role %q", got[0].Role)
+	}
+}
+
+func TestEnsureUITurnHead_EscalatesSameSecondPagePastFirstFallback(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 6, 24, 12, 40, 57, 0, time.UTC)
+	const sessionID = "same-second-large"
+	all := []messagepkg.Message{{
+		ID:             "0001",
+		Role:           "user",
+		CreatedAt:      base,
+		Content:        []byte(`{}`),
+		DisplayContent: "run a very long command-heavy task",
+	}}
+	for i := 2; i <= 132; i++ {
+		role := "assistant"
+		if i%2 == 0 {
+			role = "tool"
+		}
+		all = append(all, indexedMsg(i, role, base))
+	}
+	svc := &stubMessageService{bySession: map[string][]messagepkg.Message{sessionID: all}}
+	h := &MessageHandler{messageService: svc, logger: slog.Default()}
+
+	latest := svc.latest(sessionID, 30)
+	reverseMessages(latest)
+	firstFallback := svc.latest(sessionID, 100)
+	reverseMessages(firstFallback)
+	if len(firstFallback) != 100 || firstFallback[0].Role == "user" {
+		t.Fatalf("test setup failed: first fallback should still start mid-turn, got len=%d role=%q", len(firstFallback), firstFallback[0].Role)
+	}
+
+	got := h.ensureUITurnHead(context.Background(), sessionID, latest, false, time.Time{}, 30)
+	if len(got) != len(all) {
+		t.Fatalf("expected second fallback to expand to full test turn, got %d want %d", len(got), len(all))
+	}
+	if got[0].Role != "user" {
+		t.Fatalf("expected expanded page to start at user boundary, got role %q", got[0].Role)
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds release-blocker stopgaps for long single-turn local sessions where a large agent run is persisted as one terminal snapshot.

- Expand `format=ui` message windows when the initial page still starts mid-turn, so same-second long turns can recover the user boundary instead of hiding the user prompt.
- Preserve and reattach in-flight optimistic user/assistant turns when switching back to a session before its terminal history snapshot is persisted.
- Harden workspace chat tab activation by explicitly syncing focused/opened chat tabs to the chat store session/draft state.

## Notes

These are stopgaps, not the final data-model fix. The underlying backend issues still need durable ordering for history pagination and durable active-run state/event replay for reconnect or page reload recovery.

The workspace-tab change is defensive hardening; it reduces the chance that the visible chat tab and global chat store selection drift apart, but it is not claimed as the confirmed root cause for cross-session prompt confusion.

## Test

- `go test ./internal/handlers -run 'TestExtendToUITurnHead|TestEnsureUITurnHead'`
- `pnpm --filter @memohai/web exec vitest run src/store/chat-list.test.ts src/store/workspace-tabs.test.ts`
- `pnpm --filter @memohai/web exec vue-tsc --noEmit`
- pre-commit hook: staged ESLint and Go tests passed
- `git diff --check`

## Known lint status

`mise run lint` currently fails on pre-existing UI contract issues outside this PR's diff:

- `apps/web/src/components/sidebar/index.vue` px baseline violations
- `apps/web/src/pages/video/provider-setting.vue` app-injection violation

Those files are unchanged by this PR.
