### PR TITLE
Upgrade Electron and polish desktop chrome

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -38,6 +38,10 @@ extraResources:
       - ${env.MEMOH_DESKTOP_GSTREAMER_TARGET}/**/*
 mac:
   category: public.app-category.productivity
+  # Electron 42 ships Chromium 148, whose hard floor is macOS 12 (Monterey).
+  # Pinning it stamps LSMinimumSystemVersion so the installer refuses macOS 11
+  # rather than installing an app that can't launch.
+  minimumSystemVersion: '12.0'
   target:
     - dmg
   icon: build/icon.icon

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -63,7 +63,7 @@
     "@vitejs/plugin-vue": "^6.0.5",
     "@vue/tsconfig": "^0.8.1",
     "animate.css": "^4.1.1",
-    "electron": "^34.5.0",
+    "electron": "^42.0.0",
     "electron-builder": "^26.0.12",
     "electron-vite": "^4.0.0",
     "katex": "^0.16.37",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -629,7 +629,10 @@ function macWindowChromeOptions(tabbingIdentifier: string): Partial<Electron.Bro
   if (process.platform !== 'darwin') return {}
   return {
     titleBarStyle: 'hidden',
-    trafficLightPosition: { x: 14, y: 12 },
+    // Electron 42 renders the macOS traffic lights slightly larger than the
+    // previous runtime. y is the lights' top-left; y=13 keeps their visual
+    // center aligned with the 40px chrome strip's midline.
+    trafficLightPosition: { x: 14, y: 13 },
     transparent: true,
     backgroundColor: '#00000000',
     tabbingIdentifier,

--- a/apps/web/src/components/sidebar/bot-switcher.vue
+++ b/apps/web/src/components/sidebar/bot-switcher.vue
@@ -13,7 +13,7 @@
            hover fill. No color transition: the fill snaps on hover/open. -->
       <button
         type="button"
-        class="group flex h-8 items-center text-xs text-foreground outline-none hover:bg-[color:var(--sidebar-hover)] focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[color:var(--sidebar-hover)] [-webkit-app-region:no-drag]"
+        class="group flex h-8 items-center translate-y-[-2px] text-xs text-foreground outline-none hover:bg-[color:var(--sidebar-hover)] focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[color:var(--sidebar-hover)] [-webkit-app-region:no-drag]"
         :class="fullWidth
           ? 'w-[calc(100%+3px)] -ml-[3px] gap-1.5 rounded-full pl-2 pr-2.5'
           : 'max-w-full gap-2 rounded-md px-1.5'"

--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -17,8 +17,8 @@
          web/Windows start at the normal pl-3 indent and the switcher goes
          full-width (right edge aligns with the search row below). -->
     <header
-      class="flex h-11 shrink-0 items-center bg-sidebar pr-2 py-1.5 [-webkit-app-region:drag]"
-      :class="macTrafficReserve ? 'pl-[76px]' : 'pl-3'"
+      class="flex h-11 shrink-0 items-center bg-sidebar pr-2 [-webkit-app-region:drag]"
+      :class="macTrafficReserve ? 'pl-[88px]' : 'pl-3'"
     >
       <!-- ui-allow-px: macOS traffic-light reserve is OS-pixel-precise, cannot be rem -->
       <div class="min-w-0 flex-1">
@@ -71,7 +71,7 @@
             class="size-[18px] shrink-0"
           />
           <!-- Unsaved files live on the Files view, so a count here surfaces them
-               even while the user is in Chat (mirrors VS Code's explorer badge). -->
+               even while the user is in Chat. -->
           <BadgeCount
             v-if="view.id === 'files' && dirtyFileCount > 0"
             :count="dirtyFileCount"

--- a/apps/web/src/pages/home/components/dockview/header-add-actions.vue
+++ b/apps/web/src/pages/home/components/dockview/header-add-actions.vue
@@ -18,7 +18,7 @@
         <Button
           variant="ghost"
           size="icon-sm"
-          class="size-7 shrink-0 translate-y-[0.75px] rounded-full p-0 text-muted-foreground hover:text-foreground data-[state=open]:text-foreground"
+          class="size-7 shrink-0 rounded-full p-0 text-muted-foreground hover:text-foreground data-[state=open]:text-foreground"
           :title="t('chat.tabBarToolkit.openMenu')"
           :aria-label="t('chat.tabBarToolkit.openMenu')"
         >

--- a/apps/web/src/pages/home/components/dockview/header-add-actions.vue
+++ b/apps/web/src/pages/home/components/dockview/header-add-actions.vue
@@ -18,7 +18,7 @@
         <Button
           variant="ghost"
           size="icon-sm"
-          class="size-7 shrink-0 rounded-full p-0 text-muted-foreground hover:text-foreground data-[state=open]:text-foreground"
+          class="size-7 shrink-0 translate-y-[0.75px] rounded-full p-0 text-muted-foreground hover:text-foreground data-[state=open]:text-foreground"
           :title="t('chat.tabBarToolkit.openMenu')"
           :aria-label="t('chat.tabBarToolkit.openMenu')"
         >

--- a/apps/web/src/pages/home/components/dockview/prefix-header-actions.vue
+++ b/apps/web/src/pages/home/components/dockview/prefix-header-actions.vue
@@ -1,12 +1,12 @@
 <template>
   <!-- No vertical seam against the first tab: separation is the gap + the strip's
        own outline (the bottom hairline, plus the active tab's crown/foot stroke),
-       not a divider between the nav cluster and the tabs. pr-2 keeps the buttons
+       not a divider between the nav cluster and the tabs. The right padding keeps the buttons
        off the first tab; the tab's own pl-4 keeps its title off the gap. -->
   <div
     v-if="isFirstGroup"
-    class="flex h-full items-center gap-0.5 pr-2 [-webkit-app-region:drag] transition-[padding] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
-    :class="shouldReserveTrafficLight ? 'pl-[76px]' : 'pl-2'"
+    class="flex h-full items-center gap-0.5 pr-1 [-webkit-app-region:drag] transition-[padding] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+    :class="shouldReserveTrafficLight ? 'pl-[88px]' : 'pl-2'"
   >
     <Button
       variant="ghost"

--- a/apps/web/src/pages/home/components/dockview/prefix-header-actions.vue
+++ b/apps/web/src/pages/home/components/dockview/prefix-header-actions.vue
@@ -5,7 +5,7 @@
        off the first tab; the tab's own pl-4 keeps its title off the gap. -->
   <div
     v-if="isFirstGroup"
-    class="flex h-full items-center gap-0.5 pr-1 [-webkit-app-region:drag] transition-[padding] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+    class="flex h-full items-center gap-0.5 pr-0 [-webkit-app-region:drag] transition-[padding] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
     :class="shouldReserveTrafficLight ? 'pl-[88px]' : 'pl-2'"
   >
     <Button

--- a/apps/web/src/pages/home/components/dockview/workspace-tab.vue
+++ b/apps/web/src/pages/home/components/dockview/workspace-tab.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="rootEl"
-    class="group/tab relative z-[1] flex h-full min-w-0 items-center overflow-visible pr-[1.6875rem] pb-[3.5px] pl-2"
+    class="group/tab relative z-[1] flex h-full min-w-0 items-center overflow-visible pr-[var(--tab-close-reserve)] pb-[var(--tab-inset)] pl-[var(--tab-pad-inline)]"
     @auxclick.middle.prevent="close"
   >
     <svg
@@ -26,9 +26,10 @@
       />
     </svg>
     <!-- Active state is signalled by text colour, fill, and the connected chip
-         shape, not by weight or size. Every tab is the same height. The tab's
-         reserved top border plus this bottom padding parks label and close on
-         the same optical center for active and inactive states. -->
+         shape, not by weight or size. Every tab is the same height. Label and
+         close share the strip's one optical centre (see the geometry contract in
+         dockview-theme.css): the tab's top inset plus this bottom padding give
+         both the same centred box, so neither needs a per-control nudge. -->
     <span
       class="relative z-[1] min-w-0 flex-1 truncate text-label leading-[1.3] tracking-normal transition-colors"
       :class="[
@@ -41,7 +42,7 @@
          it instead of colliding with the glyph. -->
     <div
       v-if="isDirty"
-      class="close-fade pointer-events-none absolute right-[0.1875rem] z-[2] flex items-center pl-6 pr-[0.1875rem] opacity-100 group-hover/tab:opacity-0"
+      class="close-fade pointer-events-none absolute right-[var(--tab-close-edge)] z-[2] flex items-center pl-6 pr-0 opacity-100 group-hover/tab:opacity-0"
     >
       <span class="flex size-5 items-center justify-center">
         <span
@@ -57,7 +58,7 @@
          button. The fade layer is click-through; only the button takes pointer
          events. Keyboard focus reveals it for a11y; middle-click closes without it. -->
     <div
-      class="close-fade pointer-events-none absolute right-[0.1875rem] z-[2] flex items-center pl-6 pr-[0.1875rem] opacity-0 group-hover/tab:opacity-100 focus-within:opacity-100"
+      class="close-fade pointer-events-none absolute right-[var(--tab-close-edge)] z-[2] flex items-center pl-6 pr-0 opacity-0 group-hover/tab:opacity-100 focus-within:opacity-100"
     >
       <!-- No own hover fill: the close affordance is read through the left→right
            fade (which already paints the chip's hover surface) plus the icon
@@ -65,7 +66,7 @@
            double-stacks chrome, so the ghost hover background is suppressed. -->
       <Button
         variant="ghost"
-        class="pointer-events-auto size-5 shrink-0 translate-y-[-0.5px] rounded-sm p-0 text-muted-foreground [--btn-ghost-hover:transparent] hover:text-foreground"
+        class="pointer-events-auto size-5 shrink-0 rounded-sm p-0 text-muted-foreground [--btn-ghost-hover:transparent] hover:text-foreground"
         :aria-label="t('chat.tabMenu.close')"
         @pointerdown.stop
         @mousedown.stop
@@ -102,9 +103,14 @@ const rootEl = ref<HTMLElement | null>(null)
 const panelId = props.params.api.id
 const title = ref(props.params.api.title ?? '')
 const isActive = ref(props.params.api.isActive)
+// First-paint placeholder ONLY — these mirror the CSS contract (200≈12.5rem tab,
+// 35 = 40px strip − 5px inset, 8 = --tab-radius, 1px stroke) just so the active
+// SVG has a sane shape for the one frame before onMounted measures the real DOM.
+// updateActiveTabShape() overwrites all of it; do NOT treat these as a source of
+// truth — the CSS tokens are. They exist because the path can't be empty pre-mount.
 const initialTabShape = buildActiveTabShape({
   width: 200,
-  height: 31,
+  height: 35,
   radius: 8,
   strokeWidth: 1,
 })
@@ -115,7 +121,7 @@ const activeTabShapeStyle = ref<Record<string, string>>({
   left: '-8px',
   top: '0px',
   width: '216px',
-  height: '31px',
+  height: '35px',
 })
 let resizeObserver: ResizeObserver | null = null
 let pendingShapeFrame = 0
@@ -299,37 +305,34 @@ function fmt(value: number) {
   pointer-events: none;
 }
 
-/* The close affordance blots out the title with the chip's own opaque hover colour:
- * transparent on the left so the text dissolves into the chip, fully opaque by the
- * button so NOTHING is legible underneath. --tab-hover-bg is inherited from .dv-tab
- * (the editor surface for the active tab, the hover tint otherwise), so the fade is
- * seamless with whatever the chip is wearing. Absolutely positioned, so painting it
- * never reserves a slot or resizes the chip. */
-/* Two stacked fades so the blot is ALWAYS opaque. --tab-hover-bg is the surface a
- * tab wears (opaque --surface-editor when active; the TRANSLUCENT hover overlay
- * otherwise), so painting it alone left the title legible under the close button on
- * a hovered tab. Layering the opaque --surface-chrome base UNDER that overlay
- * composites to exactly what the tab shows — chrome+overlay on hover, plain editor
- * when active (the opaque top layer hides the base) — but never see-through. */
+/* Close-fade: a left→right blot that paints the chip's own surface so the title
+ * dissolves under the close button and nothing stays legible beneath the glyph.
+ * It is TWO stacked gradients on purpose: --tab-hover-bg is the surface the tab
+ * wears (opaque --surface-editor when active, but the TRANSLUCENT hover overlay
+ * otherwise), so painting it alone left the title readable on a hovered tab.
+ * Layering an opaque --surface-chrome base UNDER it composites to exactly what the
+ * tab shows — chrome+overlay on hover, plain editor when active — but never
+ * see-through. Absolutely positioned, so it never reserves a slot or resizes the
+ * chip. (Geometry — why it's a centred band, not the full box — is on the rule.) */
 .close-fade {
-  /* Span the tab's content box (1px top via the border / 3.5px bottom) so the
-   * close affordance centres on the label. top:0 — the root is already below
-   * the 1px top border. */
-  top: 0;
-  bottom: 3.5px;
+  /* A band centred on the 20px lane — NOT the full tab box. On an active tab this
+   * paints the editor fill, so a full-height band with a straight top edge would
+   * spill editor colour ABOVE the rounded crown onto the chrome strip (the "close
+   * fill overflows" bug). The tab box floats --tab-inset below the strip top but
+   * its bottom meets the pane, so to stay centred on the lane the bottom inset is
+   * the top inset + --tab-inset. top:--tab-inset drops the band clear of the crown
+   * arc while still covering the label; bottom:2×--tab-inset keeps it centred. */
+  top: var(--tab-inset);
+  bottom: calc(var(--tab-inset) * 2);
   /* Instant hide when hover ends — avoids white/grey close-fade lingering on a tab
    * you just switched away from. Fade-in only while the tab group is hovered. */
   transition: none;
   background:
     linear-gradient(to right, transparent, var(--tab-hover-bg, var(--surface-editor)) 1rem),
     linear-gradient(to right, transparent, var(--surface-chrome) 1rem);
-  /* Both right corners follow the hover rectangle's radius so the fade does not
-   * square off the fill. */
-  border-radius:
-    0
-    var(--tab-hover-right-radius, var(--tab-hover-radius, 0.3125rem))
-    var(--tab-hover-right-radius, var(--tab-hover-radius, 0.3125rem))
-    0;
+  /* Right corners follow the hover pill radius so the fade never squares off the
+   * fill on an inactive hovered tab. */
+  border-radius: 0 var(--tab-hover-radius) var(--tab-hover-radius) 0;
 }
 
 .group\/tab:hover .close-fade,

--- a/apps/web/src/pages/home/components/dockview/workspace-tab.vue
+++ b/apps/web/src/pages/home/components/dockview/workspace-tab.vue
@@ -1,14 +1,36 @@
 <template>
   <div
-    class="group/tab relative z-[1] flex h-full min-w-0 items-center pr-[1.6875rem] pb-[3.5px] pl-2"
+    ref="rootEl"
+    class="group/tab relative z-[1] flex h-full min-w-0 items-center overflow-visible pr-[1.6875rem] pb-[3.5px] pl-2"
     @auxclick.middle.prevent="close"
   >
+    <svg
+      v-if="isActive"
+      class="active-tab-shape z-0"
+      :viewBox="activeTabViewBox"
+      :style="activeTabShapeStyle"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        :d="activeTabFillPath"
+        fill="var(--surface-editor)"
+      />
+      <path
+        :d="activeTabStrokePath"
+        fill="none"
+        stroke="var(--dock-stroke)"
+        stroke-width="1"
+        vector-effect="non-scaling-stroke"
+      />
+    </svg>
     <!-- Active state is signalled by text colour, fill, and the connected chip
          shape, not by weight or size. Every tab is the same height. The tab's
          reserved top border plus this bottom padding parks label and close on
          the same optical center for active and inactive states. -->
     <span
-      class="min-w-0 flex-1 truncate text-label leading-[1.3] tracking-normal transition-colors"
+      class="relative z-[1] min-w-0 flex-1 truncate text-label leading-[1.3] tracking-normal transition-colors"
       :class="[
         isActive ? 'text-foreground' : 'text-muted-foreground',
       ]"
@@ -19,7 +41,7 @@
          it instead of colliding with the glyph. -->
     <div
       v-if="isDirty"
-      class="close-fade pointer-events-none absolute right-[0.1875rem] flex items-center pl-6 pr-[0.1875rem] opacity-100 group-hover/tab:opacity-0"
+      class="close-fade pointer-events-none absolute right-[0.1875rem] z-[2] flex items-center pl-6 pr-[0.1875rem] opacity-100 group-hover/tab:opacity-0"
     >
       <span class="flex size-5 items-center justify-center">
         <span
@@ -35,7 +57,7 @@
          button. The fade layer is click-through; only the button takes pointer
          events. Keyboard focus reveals it for a11y; middle-click closes without it. -->
     <div
-      class="close-fade pointer-events-none absolute right-[0.1875rem] flex items-center pl-6 pr-[0.1875rem] opacity-0 group-hover/tab:opacity-100 focus-within:opacity-100"
+      class="close-fade pointer-events-none absolute right-[0.1875rem] z-[2] flex items-center pl-6 pr-[0.1875rem] opacity-0 group-hover/tab:opacity-100 focus-within:opacity-100"
     >
       <!-- No own hover fill: the close affordance is read through the left→right
            fade (which already paints the chip's hover surface) plus the icon
@@ -56,7 +78,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { X } from 'lucide-vue-next'
 import { Button } from '@memohai/ui'
@@ -76,9 +98,27 @@ const props = defineProps<{
 const { t } = useI18n()
 const workspaceTabs = useWorkspaceTabsStore()
 
+const rootEl = ref<HTMLElement | null>(null)
 const panelId = props.params.api.id
 const title = ref(props.params.api.title ?? '')
 const isActive = ref(props.params.api.isActive)
+const initialTabShape = buildActiveTabShape({
+  width: 200,
+  height: 31,
+  radius: 8,
+  strokeWidth: 1,
+})
+const activeTabViewBox = ref(initialTabShape.viewBox)
+const activeTabFillPath = ref(initialTabShape.fillPath)
+const activeTabStrokePath = ref(initialTabShape.strokePath)
+const activeTabShapeStyle = ref<Record<string, string>>({
+  left: '-8px',
+  top: '0px',
+  width: '216px',
+  height: '31px',
+})
+let resizeObserver: ResizeObserver | null = null
+let pendingShapeFrame = 0
 // Unsaved-changes flag for file panels — read from the store's reactive map, so
 // the dot, the sidebar badge and the close dialog never drift apart.
 const isDirty = computed(() => !!workspaceTabs.fileDirty[panelId])
@@ -92,6 +132,10 @@ const disposables = [
   }),
   props.params.api.onDidActiveChange((event) => {
     isActive.value = event.isActive
+    if (event.isActive) scheduleActiveTabShapeUpdate()
+  }),
+  props.params.containerApi.onDidLayoutChange(() => {
+    scheduleActiveTabShapeUpdate()
   }),
 ]
 
@@ -100,6 +144,11 @@ const disposables = [
 onMounted(() => {
   title.value = props.params.api.title ?? title.value
   isActive.value = props.params.api.isActive
+  nextTick(() => {
+    installShapeObserver()
+    window.addEventListener('resize', scheduleActiveTabShapeUpdate)
+    scheduleActiveTabShapeUpdate()
+  })
 })
 
 // Route through the store guard: a dirty file opens the save-confirm dialog
@@ -109,11 +158,147 @@ function close() {
 }
 
 onBeforeUnmount(() => {
+  if (pendingShapeFrame) cancelAnimationFrame(pendingShapeFrame)
+  resizeObserver?.disconnect()
+  window.removeEventListener('resize', scheduleActiveTabShapeUpdate)
   for (const d of disposables) d.dispose()
 })
+
+watch(isActive, (active) => {
+  if (active) nextTick(scheduleActiveTabShapeUpdate)
+})
+
+function installShapeObserver() {
+  const root = rootEl.value
+  if (!root || resizeObserver) return
+
+  resizeObserver = new ResizeObserver(() => scheduleActiveTabShapeUpdate())
+  resizeObserver.observe(root)
+
+  const tab = root.closest<HTMLElement>('.dv-tab')
+  if (tab && tab !== root) resizeObserver.observe(tab)
+}
+
+function scheduleActiveTabShapeUpdate() {
+  if (!isActive.value || pendingShapeFrame) return
+
+  pendingShapeFrame = requestAnimationFrame(() => {
+    pendingShapeFrame = 0
+    updateActiveTabShape()
+  })
+}
+
+function updateActiveTabShape() {
+  const root = rootEl.value
+  const tab = root?.closest<HTMLElement>('.dv-tab')
+  if (!root || !tab) return
+
+  const rootRect = root.getBoundingClientRect()
+  const tabRect = tab.getBoundingClientRect()
+  if (tabRect.width <= 0 || tabRect.height <= 0) return
+
+  const scale = window.devicePixelRatio || 1
+  const alignedLeft = snapToDevicePixel(tabRect.left, scale)
+  const alignedTop = snapToDevicePixel(tabRect.top, scale)
+  const alignedRight = snapToDevicePixel(tabRect.right, scale)
+  const alignedBottom = snapToDevicePixel(tabRect.bottom, scale)
+  const width = alignedRight - alignedLeft
+  const height = alignedBottom - alignedTop
+  const radius = Math.min(
+    snapToDevicePixel(readTabRadius(tab), scale),
+    Math.max(0, width / 2),
+    Math.max(0, height),
+  )
+
+  const shape = buildActiveTabShape({
+    width,
+    height,
+    radius,
+    strokeWidth: 1,
+  })
+
+  activeTabViewBox.value = shape.viewBox
+  activeTabFillPath.value = shape.fillPath
+  activeTabStrokePath.value = shape.strokePath
+  activeTabShapeStyle.value = {
+    left: `${formatPx(alignedLeft - rootRect.left - radius)}`,
+    top: `${formatPx(alignedTop - rootRect.top)}`,
+    width: `${formatPx(width + radius * 2)}`,
+    height: `${formatPx(height)}`,
+  }
+}
+
+function buildActiveTabShape({
+  width,
+  height,
+  radius,
+  strokeWidth,
+}: {
+  width: number
+  height: number
+  radius: number
+  strokeWidth: number
+}) {
+  const strokeAdjustment = strokeWidth * 0.5
+  const extension = radius
+  const left = -extension
+  const right = width + extension
+  const extendedBottom = height
+  const tabLeft = strokeAdjustment
+  const tabRight = width - strokeAdjustment
+  const tabTop = strokeAdjustment
+  const tabBottom = height - strokeAdjustment
+  const topRadius = Math.max(0, radius - strokeAdjustment)
+  const bottomRadius = Math.max(0, radius - strokeAdjustment)
+
+  const outline = [
+    `M ${fmt(left)} ${fmt(extendedBottom)}`,
+    `L ${fmt(left)} ${fmt(tabBottom)}`,
+    `L ${fmt(tabLeft - bottomRadius)} ${fmt(tabBottom)}`,
+    `A ${fmt(bottomRadius)} ${fmt(bottomRadius)} 0 0 0 ${fmt(tabLeft)} ${fmt(tabBottom - bottomRadius)}`,
+    `L ${fmt(tabLeft)} ${fmt(tabTop + topRadius)}`,
+    `A ${fmt(topRadius)} ${fmt(topRadius)} 0 0 1 ${fmt(tabLeft + topRadius)} ${fmt(tabTop)}`,
+    `L ${fmt(tabRight - topRadius)} ${fmt(tabTop)}`,
+    `A ${fmt(topRadius)} ${fmt(topRadius)} 0 0 1 ${fmt(tabRight)} ${fmt(tabTop + topRadius)}`,
+    `L ${fmt(tabRight)} ${fmt(tabBottom - bottomRadius)}`,
+    `A ${fmt(bottomRadius)} ${fmt(bottomRadius)} 0 0 0 ${fmt(tabRight + bottomRadius)} ${fmt(tabBottom)}`,
+    `L ${fmt(right)} ${fmt(tabBottom)}`,
+    `L ${fmt(right)} ${fmt(extendedBottom)}`,
+  ].join(' ')
+
+  return {
+    viewBox: `${fmt(left)} 0 ${fmt(width + extension * 2)} ${fmt(height)}`,
+    fillPath: `${outline} L ${fmt(left)} ${fmt(extendedBottom)} Z`,
+    strokePath: outline,
+  }
+}
+
+function readTabRadius(tab: HTMLElement) {
+  const radius = Number.parseFloat(getComputedStyle(tab).borderTopLeftRadius)
+  return Number.isFinite(radius) && radius > 0 ? radius : 8
+}
+
+function snapToDevicePixel(value: number, scale: number) {
+  return Math.round(value * scale) / scale
+}
+
+function formatPx(value: number) {
+  return `${fmt(value)}px`
+}
+
+function fmt(value: number) {
+  const normalized = Math.abs(value) < 0.0001 ? 0 : value
+  return Number(normalized.toFixed(3)).toString()
+}
 </script>
 
 <style scoped>
+.active-tab-shape {
+  position: absolute;
+  overflow: visible;
+  pointer-events: none;
+}
+
 /* The close affordance blots out the title with the chip's own opaque hover colour:
  * transparent on the left so the text dissolves into the chip, fully opaque by the
  * button so NOTHING is legible underneath. --tab-hover-bg is inherited from .dv-tab

--- a/apps/web/src/pages/home/components/dockview/workspace-tab.vue
+++ b/apps/web/src/pages/home/components/dockview/workspace-tab.vue
@@ -1,32 +1,25 @@
 <template>
   <div
-    class="group/tab relative z-[1] flex h-full min-w-0 items-center pl-4 pr-4"
+    class="group/tab relative z-[1] flex h-full min-w-0 items-center pr-[1.6875rem] pb-[3.5px] pl-2"
     @auxclick.middle.prevent="close"
   >
-    <!-- Active state is signalled by text color (and the CSS top-accent on the
-         tab chip), NOT by weight or size — so selecting a tab never changes the
-         label's metrics or baseline. The chip hugs its title with symmetric
-         padding: no slot is reserved for the close button on ANY tab (selected or
-         not); it overlays the text on hover instead. -->
-    <!-- leading-[1.4], not leading-none: with truncate (overflow:hidden) a line box
-         equal to the font size clips descenders (g/y) and CJK bottoms; a slightly
-         taller line box gives them room without affecting the centered baseline. -->
-    <!-- Sized by its own content (no flex-grow): the tab is natural width (see
-         dockview-theme.css), so a flex-basis:0 grow span made the tab's intrinsic
-         width ambiguous and it jumped on title changes. min-w-0 still lets it shrink
-         + truncate once the tab hits its max-width cap. Centred in the chip (not
-         lifted to the bar centre), so it rides a touch below the top headroom. -->
+    <!-- Active state is signalled by text colour, fill, and the connected chip
+         shape, not by weight or size. Every tab is the same height. The tab's
+         reserved top border plus this bottom padding parks label and close on
+         the same optical center for active and inactive states. -->
     <span
-      class="min-w-0 truncate text-[12.5px] leading-[1.4] transition-colors"
-      :class="isActive ? 'text-foreground' : 'text-muted-foreground'"
+      class="min-w-0 flex-1 truncate text-label leading-[1.3] tracking-normal transition-colors"
+      :class="[
+        isActive ? 'text-foreground' : 'text-muted-foreground',
+      ]"
     >{{ title }}</span>
-    <!-- Unsaved-changes dot: sits in the close slot AT REST so the affordance never
-         shifts; hovering fades it out as the close button fades in (VS Code's tab).
+    <!-- Unsaved-changes dot: sits in the close slot at rest so the affordance never
+         shifts; hovering fades it out as the close button fades in.
          Painted over the same fade as the button so a long title dissolves behind
          it instead of colliding with the glyph. -->
     <div
       v-if="isDirty"
-      class="close-fade pointer-events-none absolute right-0 flex items-center pl-6 pr-2 opacity-100 group-hover/tab:opacity-0"
+      class="close-fade pointer-events-none absolute right-[0.1875rem] flex items-center pl-6 pr-[0.1875rem] opacity-100 group-hover/tab:opacity-0"
     >
       <span class="flex size-5 items-center justify-center">
         <span
@@ -42,7 +35,7 @@
          button. The fade layer is click-through; only the button takes pointer
          events. Keyboard focus reveals it for a11y; middle-click closes without it. -->
     <div
-      class="close-fade pointer-events-none absolute right-0 flex items-center pl-6 pr-2 opacity-0 group-hover/tab:opacity-100 focus-within:opacity-100"
+      class="close-fade pointer-events-none absolute right-[0.1875rem] flex items-center pl-6 pr-[0.1875rem] opacity-0 group-hover/tab:opacity-100 focus-within:opacity-100"
     >
       <!-- No own hover fill: the close affordance is read through the left→right
            fade (which already paints the chip's hover surface) plus the icon
@@ -50,7 +43,7 @@
            double-stacks chrome, so the ghost hover background is suppressed. -->
       <Button
         variant="ghost"
-        class="pointer-events-auto size-5 shrink-0 rounded-full p-0 text-muted-foreground [--btn-ghost-hover:transparent] hover:text-foreground"
+        class="pointer-events-auto size-5 shrink-0 translate-y-[-0.5px] rounded-sm p-0 text-muted-foreground [--btn-ghost-hover:transparent] hover:text-foreground"
         :aria-label="t('chat.tabMenu.close')"
         @pointerdown.stop
         @mousedown.stop
@@ -89,7 +82,7 @@ const isActive = ref(props.params.api.isActive)
 // Unsaved-changes flag for file panels — read from the store's reactive map, so
 // the dot, the sidebar badge and the close dialog never drift apart.
 const isDirty = computed(() => !!workspaceTabs.fileDirty[panelId])
-// Ephemeral (VS Code "preview") tabs still get replaced in place when another
+// Ephemeral preview tabs still get replaced in place when another
 // preview-eligible tab opens into the same group (see workspace-tabs store), but
 // the state is no longer surfaced visually — there is no italic or other marker.
 
@@ -134,16 +127,24 @@ onBeforeUnmount(() => {
  * composites to exactly what the tab shows — chrome+overlay on hover, plain editor
  * when active (the opaque top layer hides the base) — but never see-through. */
 .close-fade {
-  top: var(--tab-hover-fill-top, 0);
-  bottom: 0;
+  /* Span the tab's content box (1px top via the border / 3.5px bottom) so the
+   * close affordance centres on the label. top:0 — the root is already below
+   * the 1px top border. */
+  top: 0;
+  bottom: 3.5px;
   /* Instant hide when hover ends — avoids white/grey close-fade lingering on a tab
    * you just switched away from. Fade-in only while the tab group is hovered. */
   transition: none;
   background:
     linear-gradient(to right, transparent, var(--tab-hover-bg, var(--surface-editor)) 1rem),
     linear-gradient(to right, transparent, var(--surface-chrome) 1rem);
-  /* Full-height. Only the TOP-right corner is rounded, to the crown radius. */
-  border-top-right-radius: var(--radius-sm);
+  /* Both right corners follow the hover rectangle's radius so the fade does not
+   * square off the fill. */
+  border-radius:
+    0
+    var(--tab-hover-right-radius, var(--tab-hover-radius, 0.3125rem))
+    var(--tab-hover-right-radius, var(--tab-hover-radius, 0.3125rem))
+    0;
 }
 
 .group\/tab:hover .close-fade,

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -212,17 +212,13 @@
   display: none;
 }
 
-/* Active tab = the full connected silhouette: editor-surface fill (continuous with the
- * pane below), a --dock-stroke crown/side stroke, and the bottom fillet feet
- * (::before) that curve down into the bar. It ALONE wears the 倒角 — selection is a
- * physical "grafted onto the pane" shape. The crown is rounded; the bottom is left
- * open so the fill bleeds into the pane and the feet carry the stroke down to the bar
- * (outline reads as one line: bar → left foot → up the crown → down the right foot). */
+/* Active tab paint is owned by the tab content's single path shape. The wrapper
+ * keeps the same box metrics as inactive tabs, but it no longer paints its own
+ * fill/border/foot pieces; otherwise separate raster models meet at the lower
+ * turns and produce doubled pixels. */
 .dockview-theme-memoh .dv-tab.dv-active-tab {
-  background-color: var(--surface-editor);
-  border-top-color: var(--dock-stroke);
-  border-left-color: var(--dock-stroke);
-  border-right-color: var(--dock-stroke);
+  background-color: transparent !important;
+  border-color: transparent;
   /* The active tab never takes the hover lift, so its blot-out colour is the
    * editor surface it already wears. */
   --tab-hover-bg: var(--surface-editor);
@@ -235,35 +231,10 @@
   background-color: transparent !important;
 }
 
-/* Bottom flare = a CONCAVE fillet (倒角), not a bump. A single pseudo spans
- * --tab-flare BEYOND each side at the bottom; each side is a solid tile of the pane
- * colour with a quarter-circle CARVED OUT of its OUTER-TOP corner (transparent
- * inside the radius, fill outside). What remains is an inward-curving foot: the
- * tab's vertical edge sweeps down and splays out to meet the bar tangentially —
- * a negative curve that seats the tab on the strip. (Filling the
- * disc instead of carving it would bulge two convex "circles" out of the corners,
- * which is the opposite of a fillet.) dockview leaves ::before unused (it only
- * styles ::after on :focus), so this is a clean slot. ACTIVE-ONLY: a hover is a plain
- * rounded rectangle (above), never these feet. */
+/* The active path layer owns the lower fillets. Keep the wrapper pseudo empty so
+ * the old gradient flare cannot stack under the path stroke. */
 .dockview-theme-memoh .dv-tab.dv-active-tab::before {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: calc(-1 * var(--tab-flare));
-  right: calc(-1 * var(--tab-flare));
-  height: var(--tab-flare);
-  pointer-events: none;
-  /* Three layers, top to bottom:
-   *  1. left foot  — carved concave fill with a 1px --dock-stroke ring ALONG the curve
-   *     (transparent inside the radius → chrome shows; ring at [r-1,r]; fill beyond).
-   *  2. right foot — mirror.
-   *  3. middle fill — a plain fill spanning exactly the tab body's width, painted
-   *     over the bottom strip so the crown's side borders don't leave a stray
-   *     vertical nub in the foot zone (the stroke there is the curve, not a line). */
-  background:
-    radial-gradient(circle at top left, transparent calc(var(--tab-flare) - 1px), var(--dock-stroke) calc(var(--tab-flare) - 1px), var(--dock-stroke) var(--tab-flare), var(--surface-editor) calc(var(--tab-flare) + 0.5px)) left bottom / var(--tab-flare) var(--tab-flare) no-repeat,
-    radial-gradient(circle at top right, transparent calc(var(--tab-flare) - 1px), var(--dock-stroke) calc(var(--tab-flare) - 1px), var(--dock-stroke) var(--tab-flare), var(--surface-editor) calc(var(--tab-flare) + 0.5px)) right bottom / var(--tab-flare) var(--tab-flare) no-repeat,
-    linear-gradient(var(--surface-editor), var(--surface-editor)) center bottom / calc(100% - 2 * var(--tab-flare)) 100% no-repeat;
+  content: none;
 }
 
 .dockview-theme-memoh .dv-right-actions-container,

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -2,7 +2,7 @@
  * tokens from @memohai/ui style.css so the dock chrome follows light/dark
  * and any future palette swap automatically.
  *
- * Two-plane editor model (VS-Code): the active tab and the view it owns both
+ * Two-plane editor model: the active tab and the view it owns both
  * sit on --surface-editor, so the selected tab reads as continuous with its
  * pane. The tab strip and every unselected tab sit on --surface-chrome — the
  * same recessed chrome as the left rail. Because the two planes differ in BOTH
@@ -24,7 +24,7 @@
   --dv-activegroup-hiddenpanel-tab-color: var(--muted-foreground);
 
   /* Inactive group: its selected tab must still read as selected (same editor
-   * surface, just a dimmer label — VS Code's unfocused-active tab). Without this
+   * surface, just a dimmer label). Without this
    * the second pane's current tab looked grey/unselected after a split. */
   --dv-inactivegroup-visiblepanel-tab-background-color: var(--surface-editor);
   --dv-inactivegroup-visiblepanel-tab-color: var(--muted-foreground);
@@ -57,22 +57,24 @@
 
   --dv-floating-border: 1px solid var(--border);
 
-  /* Chrome-tab geometry knobs (tunable). --tab-top-inset lifts every tab off the
-   * top of the strip so the rounded crown floats below the window edge. --tab-gap
-   * is the breathing room between adjacent tabs (no border dividers any more —
-   * separation is space). --tab-flare is the radius of the active tab's bottom
-   * "feet" that splay outward and curve down into the pane; tying it to --tab-gap
-   * makes the flare exactly bridge the gap to the neighbour, so the active tab
-   * reads as connected to the surface below (Chrome). */
-  --tab-top-inset: 0.1875rem;
-  --tab-gap: var(--radius-sm);
-  --tab-flare: var(--tab-gap);
+  /* Tab geometry knobs. --tab-top-inset lifts every tab off the top of the
+   * strip so the rounded crown floats below the window edge. Main editor tabs
+   * touch edge-to-edge; selection is carried by fill, stroke, and the bottom
+   * fillet rather than inter-tab whitespace. --tab-edge-pad gives the first and
+   * last tab just enough room for the connected bottom edge without turning the
+   * prefix-actions-to-first-tab space into a second large gutter. */
+  --tab-top-inset: 0.3125rem;
+  --chrome-center: 20px;
+  --tab-crown-radius: var(--radius-md);
+  --tab-gap: 0rem;
+  --tab-flare: var(--tab-crown-radius);
+  --tab-edge-pad: 0.1875rem;
+  --tab-hover-radius: 0.34375rem;
+  --tab-hover-open-edge-radius: 0.28125rem;
   /* Horizontal breathing room between the last tab's foot and the "+" cluster. */
-  --tab-actions-gap: 6px;
-  /* Shared timing for inactive-tab hover fill + close-fade (workspace-tab.vue). */
+  --tab-actions-gap: 0.015625rem;
+  /* Shared timing for close-fade (workspace-tab.vue). Tab hover fill itself is instant. */
   --tab-hover-duration: 150ms;
-  /* How far the inactive hover colour layer sits below a flush-top fill (subpixel ok). */
-  --tab-hover-fill-offset: 0.5px;
   /* ONE stroke colour for the whole dock outline — the strip's bottom hairline, the
    * active tab's crown/side border, and the fillet-foot ring. It MUST be opaque, yet
    * it must also read as the SAME line as the rest of the app's dividers (the sidebar's
@@ -103,11 +105,10 @@
 }
 
 /* The custom tab content (workspace-tab.vue) owns its padding/ellipsis; .dv-tab
- * carries the chip background (from the --dv-* vars above). Tabs are NATURAL width
- * — a tab is as wide as its title, capped at max-width (then the title truncates,
- * see workspace-tab.vue) — never stretched to fill the row. The row hugs its
- * content so the right-side actions ("+") sit directly after the LAST tab
- * (Chrome/Notion), not pinned to the viewport edge. The close button overlays the
+ * carries the chip background (from the --dv-* vars above). Editor tabs use a
+ * fixed measure so label truncation, hover geometry, and close placement remain
+ * stable. The row hugs its content so the right-side actions ("+") sit directly
+ * after the LAST tab, not pinned to the viewport edge. The close button overlays the
  * title on hover (no reserved slot — see workspace-tab.vue). --tab-hover-bg is the
  * opaque colour a tab wears while hovered; the close affordance paints it to blot
  * out the text beneath the button. */
@@ -115,39 +116,29 @@
   box-sizing: border-box;
   padding: 0;
   /* A tab activates on click but is not a link/button affordance — keep the plain
-   * arrow (VS Code), not a pointer. dockview defaults .dv-tab to cursor:pointer;
+   * arrow. dockview defaults .dv-tab to cursor:pointer;
    * the close button re-enables the pointer on itself only. */
   cursor: default;
-  /* HYBRID width model (Chrome): a tab hugs its title when the strip has room,
-   * and shrinks together with its siblings when it doesn't.
-   *   flex-basis AUTO (not 0): the item is sized to its own title first, so a
-   *     live title change resizes the tab smoothly instead of collapsing toward a
-   *     zero basis (the jumping-width bug that forced flex:0 0 auto before).
-   *   grow:1: only claims free space the strip actually has — when few tabs are
-   *     open there is none (the container hugs their content), so each rests at
-   *     its natural width and "+" sits right after the LAST tab (Chrome/Notion).
-   *   shrink:1: once the tabs out-measure the strip they all give back width
-   *     TOGETHER down to the min-width floor — like #624's flex:1 1 0 row, but
-   *     without that layout's basis-0 ambiguity — and only past the floor does
-   *     the row scroll.
-   * min-width is the RESTING width of a short tab (a one-word tab still reads as
-   * a real tab, with room for the close button), not just a crowded floor. The
-   * title span truncates once a tab hits max-width. */
-  flex: 1 1 auto;
-  min-width: 8rem;
-  max-width: 11rem;
+  /* Fixed editor-tab measure keeps title truncation, close placement, and the
+   * hover fill stable from tab to tab. Overflow scrolls instead of shrinking, so
+   * the tab geometry never changes under pointer movement. */
+  flex: 0 0 12.5rem;
+  width: 12.5rem;
+  min-width: 12.5rem;
+  max-width: 12.5rem;
   /* Rounded crown on EVERY tab, always — radius is state-independent so it can
    * never flash square for a frame while dockview swaps active/hover classes (it
    * only used to live on the active/hover rules). Invisible on a transparent
    * inactive tab; revealed once a fill paints. */
-  border-top-left-radius: var(--radius-sm);
-  border-top-right-radius: var(--radius-sm);
+  border-top-left-radius: var(--tab-crown-radius);
+  border-top-right-radius: var(--tab-crown-radius);
   /* Float the chip below the strip's top edge — the rounded crown needs headroom
-   * (Chrome). Applied to EVERY tab uniformly, so selecting one never shifts it
+   * above the strip. Applied to EVERY tab uniformly, so selecting one never shifts it
    * vertically. The fill still reaches the bottom, so the active tab meets the
    * pane. position:relative anchors the ::before bottom-flare (see active rule). */
   position: relative;
   margin-top: var(--tab-top-inset);
+  height: calc(100% - var(--tab-top-inset));
   /* A transparent 1px border on EVERY tab reserves the active tab's outline width
    * up front, so selecting a tab only RECOLOURS its crown stroke — it never resizes
    * or nudges the chip. Bottom edge stays borderless (the active fill bleeds into
@@ -155,27 +146,23 @@
   border: 1px solid transparent;
   border-bottom: none;
   --tab-hover-bg: var(--surface-chrome-hover);
-  --tab-hover-fill-top: 0;
-}
-
-/* Inactive tabs: the hover COLOUR lives on ::before (see below), not on the tab box.
- * Text stays put; only the fill layer's top edge sits 1px lower to match the active
- * tab's crown stroke optically. --tab-hover-fill-top tells close-fade where that layer
- * starts (workspace-tab.vue). */
-.dockview-theme-memoh .dv-tab:not(.dv-active-tab) {
-  --tab-hover-fill-top: var(--tab-hover-fill-offset);
+  --tab-hover-left-radius: var(--tab-hover-radius);
+  --tab-hover-right-radius: var(--tab-hover-radius);
 }
 
 .dockview-theme-memoh .dv-tab:not(.dv-active-tab)::before {
   content: '';
   position: absolute;
-  top: var(--tab-hover-fill-offset);
-  right: 0;
-  bottom: 0;
-  left: 0;
+  top: 0;
+  right: 2px;
+  bottom: 3.5px;
+  left: 2px;
   z-index: 0;
-  border-top-left-radius: var(--radius-sm);
-  border-top-right-radius: var(--radius-sm);
+  border-radius:
+    var(--tab-hover-left-radius)
+    var(--tab-hover-right-radius)
+    var(--tab-hover-right-radius)
+    var(--tab-hover-left-radius);
   background-color: var(--surface-chrome-hover);
   opacity: 0;
   /* Instant hide when hover ends (e.g. after switching tabs) — only fade IN. */
@@ -183,31 +170,28 @@
   pointer-events: none;
 }
 
+.dockview-theme-memoh .dv-tab.dv-active-tab + .dv-tab:not(.dv-active-tab):hover {
+  --tab-hover-right-radius: var(--tab-hover-open-edge-radius);
+}
+
 .dockview-theme-memoh .dv-tab:not(.dv-active-tab):hover::before {
   opacity: 1;
-  transition: opacity var(--tab-hover-duration) ease-out;
+  transition: none;
 }
 
-/* Space between adjacent tabs — separation is breathing room, not a divider line
- * (the old per-tab border seams are gone). The active tab's bottom flare is sized
- * to exactly bridge this gap, so its feet reach the neighbours.
- *
- * Left/right padding matches --tab-flare so the FIRST and LAST tab feet have room
- * INSIDE the scroll content (dockview's .dv-scrollable is overflow:hidden — without
- * this inset an edge tab's foot, which spills --tab-flare past the chip, gets
- * clipped). Horizontal gap from foot to "+" is --tab-actions-gap on the
- * right-actions container, not extra padding here (avoids double-counting). */
+/* Adjacent editor tabs touch; separation is state and surface, not whitespace.
+ * The small edge padding prevents the first/last connected edge from being clipped
+ * by dockview's scroll container without adding a second large gutter after the
+ * prefix action buttons. Horizontal gap from the last tab to "+" is
+ * --tab-actions-gap on the actions container, not extra padding here. */
 .dockview-theme-memoh .dv-tabs-container {
   gap: var(--tab-gap);
-  padding-inline: var(--tab-flare);
+  padding-inline: var(--tab-edge-pad);
 }
 
-/* The tab row hugs its content (does not grow), so the "+" actions land right
- * after the last tab. It may still SHRINK (flex-shrink:1 + min-width:0): when
- * the tabs out-measure the strip the container gives back width, the tabs'
- * own shrink:1 distributes that loss evenly down to their min-width floor, and
- * only past the floor does the scroll container clip them and scroll — rather
- * than pushing the "+" off-screen. */
+/* The tab row hugs its content, so the "+" actions land right after the last tab.
+ * It may still shrink as a scroll container so overflowing fixed-width tabs clip
+ * and scroll rather than pushing the "+" off-screen. */
 .dockview-theme-memoh .dv-tabs-and-actions-container > .dv-scrollable,
 .dockview-theme-memoh .dv-scrollable > .dv-tabs-container {
   flex: 0 1 auto;
@@ -215,7 +199,7 @@
 }
 
 /* No native/dockview horizontal scrollbar on the tab row (it clashed with the
- * hairline), and no edge shadow either — VS Code shows none. When there are more tabs
+ * hairline), and no edge shadow either. When there are more tabs
  * than fit they've already shrunk to their min-width floor, then scroll via
  * wheel/trackpad. */
 .dockview-theme-memoh .dv-tabs-container {
@@ -228,7 +212,7 @@
   display: none;
 }
 
-/* Active tab = the full Chrome silhouette: editor-surface fill (continuous with the
+/* Active tab = the full connected silhouette: editor-surface fill (continuous with the
  * pane below), a --dock-stroke crown/side stroke, and the bottom fillet feet
  * (::before) that curve down into the bar. It ALONE wears the 倒角 — selection is a
  * physical "grafted onto the pane" shape. The crown is rounded; the bottom is left
@@ -244,8 +228,9 @@
   --tab-hover-bg: var(--surface-editor);
 }
 
-/* Hover on an UNSELECTED tab: tab box stays transparent; the chrome-hover fill is
- * painted by ::before (top: --tab-hover-fill-offset → bottom). Text does not move. */
+/* Hover on an UNSELECTED tab: the tab box stays transparent at rest; the
+ * chrome-hover fill is painted by ::before as a rounded rectangle centred on the
+ * label. Text does not move. */
 .dockview-theme-memoh .dv-tab:not(.dv-active-tab):hover {
   background-color: transparent !important;
 }
@@ -255,7 +240,7 @@
  * colour with a quarter-circle CARVED OUT of its OUTER-TOP corner (transparent
  * inside the radius, fill outside). What remains is an inward-curving foot: the
  * tab's vertical edge sweeps down and splays out to meet the bar tangentially —
- * the same negative curve Chrome uses to seat a tab on its toolbar. (Filling the
+ * a negative curve that seats the tab on the strip. (Filling the
  * disc instead of carving it would bulge two convex "circles" out of the corners,
  * which is the opposite of a fillet.) dockview leaves ::before unused (it only
  * styles ::after on :focus), so this is a clean slot. ACTIVE-ONLY: a hover is a plain
@@ -284,12 +269,8 @@
 .dockview-theme-memoh .dv-right-actions-container,
 .dockview-theme-memoh .dv-left-actions-container {
   align-items: center;
-  /* Match the tab chip band: tabs sit margin-top below the strip crown so they can
-   * graft onto the pane; centering "+" in the full strip height put it above the
-   * close button (workspace-tab.vue). */
   box-sizing: border-box;
-  margin-top: var(--tab-top-inset);
-  height: calc(100% - var(--tab-top-inset));
+  height: 100%;
 }
 
 /* Prefix actions container: renders navigation buttons before the tabs. */
@@ -297,6 +278,7 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
+  height: 100%;
 }
 
 /* The void is dockview's droppable empty-header region — it owns the
@@ -344,10 +326,8 @@
   box-shadow: inset 0 -1px 0 var(--dock-stroke);
 }
 
-/* No vertical inter-tab divider lines: tabs are separated by --tab-gap (see the
- * .dv-tabs-container gap rule above) the way Chrome separates them — space, not a
- * seam. The old per-tab border-left/right dividers and the active-tab frame were
- * removed so selecting a tab changes only its fill + flare, never an edge. */
+/* No vertical inter-tab divider lines: selecting a tab changes only fill, stroke,
+ * and the connected bottom edge, never a divider seam. */
 
 /* Dockview paints its tab "selection" box as a PSEUDO-ELEMENT outline, not as an
  * outline on the tab element itself: it ships `.dv-tab:focus::after` /
@@ -431,7 +411,7 @@
    * scroll) these SHRINK: flex-shrink:1 lets the constrained tabs-container
    * squeeze every chip toward a 5.5rem floor (icon + a few title chars + close;
    * the chip's flex-1 min-w-0 span truncates) before the strip ever scrolls, so
-   * a stack of sessions stays on screen the way VS Code's do. */
+   * a stack of sessions stays on screen without immediately scrolling. */
   flex: 0 1 8.75rem;
   min-width: 5.5rem;
   max-width: 8.75rem;

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -13,7 +13,7 @@
   --dv-group-view-background-color: var(--surface-editor);
 
   --dv-tabs-and-actions-container-background-color: var(--surface-chrome);
-  --dv-tabs-and-actions-container-height: 36px;
+  --dv-tabs-and-actions-container-height: 40px;
   --dv-tabs-and-actions-container-font-size: 12px;
 
   /* Active group: visible tab drops to the editor surface (continuous with the
@@ -31,10 +31,12 @@
   --dv-inactivegroup-hiddenpanel-tab-background-color: transparent;
   --dv-inactivegroup-hiddenpanel-tab-color: var(--muted-foreground);
 
-  /* dockview also paints a per-tab ::before divider from this var; tabs are now
-   * separated by gap (no divider lines at all), so kill the built-in one. We also
-   * reuse ::before on the active tab for its bottom flare — this keeps dockview
-   * from drawing anything there. */
+  /* dockview reads --dv-tab-divider-color for TWO built-ins: the per-tab
+   * `:not(:first-child)::before` vertical divider, and the `:focus::after`
+   * selection outline. We draw our OWN dividers (the ::after seam + the action-bar
+   * lead, below) and own the focus treatment, so both built-ins are silenced by
+   * zeroing this one var — otherwise they'd double up with our lines and sit at the
+   * wrong geometry. */
   --dv-tab-divider-color: transparent;
   --dv-tab-font-size: 12px;
 
@@ -57,22 +59,126 @@
 
   --dv-floating-border: 1px solid var(--border);
 
-  /* Tab geometry knobs. --tab-top-inset lifts every tab off the top of the
-   * strip so the rounded crown floats below the window edge. Main editor tabs
-   * touch edge-to-edge; selection is carried by fill, stroke, and the bottom
-   * fillet rather than inter-tab whitespace. --tab-edge-pad must be at least the
-   * active flare radius; otherwise the first/last active tab's connected corner
-   * is clipped by dockview's scroll container. */
-  --tab-top-inset: 0.3125rem;
+  /* Tab geometry contract — ONE source of truth for the dock header.
+   *
+   * Everything in the 40px header lane (label, close, the "+" cluster, the
+   * prefix nav) centres on ONE optical lane derived from the strip geometry
+   * below — no control nudges itself with its own translate. If something looks
+   * off-centre, fix the lane math here; never add a per-control translate (that
+   * is exactly how the old 0.5px / 0.75px drift crept in).
+   *
+   * VERTICAL — one knob, --tab-inset:
+   *   strip is 40px; the tab floats below the top by --tab-inset so its rounded
+   *   crown has headroom, giving a tab box of y = inset..40 (height =
+   *   100% - inset). The label (flex centre, with a matching bottom pad) sits on
+   *   the 20px lane. The tab carries NO 1px transparent border any more: the
+   *   active outline is the SVG stroke (workspace-tab.vue), so that border was
+   *   dead weight whose only effect was a 0.5px shift on every absolute child.
+   *
+   * RADIUS — two knobs, no per-corner special cases:
+   *   --tab-radius   = the crown (every tab) AND the active SVG crown.
+   *   --tab-hover-radius = the floating hover pill, UNIFORM on all four corners.
+   *   The pill is a self-contained inset chip, so its four corners are always
+   *   equal — there is no "tuck a corner toward the active neighbour" rule (the
+   *   pill is inset enough that it never reaches the neighbour's stroke, so there
+   *   is nothing to tuck away from). Asymmetric corners were that rule's symptom.
+   *
+   * HORIZONTAL — both the label's LEFT edge and the close glyph's RIGHT edge are
+   *   COMPUTED, and they MIRROR each other. Each should breathe off the BACKGROUND
+   *   edge it sits against, but that edge differs by state: the hover pill is inset
+   *   --tab-hover-inset, the active fill's visible stroke sits ~0.5px inside the
+   *   tab box. The DOM x of label and glyph is fixed (must not jump hover↔selected),
+   *   so each is anchored to the more-inset edge (the hover pill) plus ONE shared
+   *   knob, --tab-text-gutter:
+   *     --tab-pad-inline = --tab-hover-inset + --tab-text-gutter
+   *   The label's left edge AND the close glyph's right edge both sit
+   *   --tab-pad-inline from their respective tab edges, so the chip reads
+   *   symmetric. The gap reads as: gutter to the hover pill, gutter+inset to the
+   *   active fill (selected tab a touch more open — intentional). Tune the gutter
+   *   ALONE to move both; never hand-set --tab-pad-inline.
+   *   --tab-close-reserve is the trailing room the label must clear (it follows
+   *   the glyph position), --tab-action-gap is the symmetric gap around the "+"
+   *   lead divider, and --tab-edge-pad is the scroll-container inset, which MUST
+   *   be ≥ the active flare radius or the first/last active tab's connected corner
+   *   is clipped.
+   *
+   * HOVER HEIGHT — the hover pill's TOP (only) drops by the active stroke width.
+   *   The active crown is a 1px STROKE whose solid core sits a stroke-width below
+   *   the chip's top edge; the hover pill is a solid FILL from its top edge up. At
+   *   the same top y the fill therefore reads ~1px taller than the active crown.
+   *   Trimming only the pill's top by --tab-active-stroke makes the two read as
+   *   equal height. Left/right/bottom are untouched (they have no such mismatch),
+   *   so the pill is no longer dead-centred on the lane by half a px — that is the
+   *   deliberate cost of matching the active crown's optical height.
+   *
+   * CROWN vs RECTANGLE — the active tab's top corners are ROUNDED (the SVG crown),
+   *   so anything painting the tab's own fill colour (the close-fade) must stay
+   *   BELOW the crown arc: a straight-topped rectangle reaching the strip top would
+   *   spill editor colour past the rounded corner onto the chrome strip. The
+   *   close-fade is therefore a band centred on the 20px lane, never the full box.
+   *
+   * DIVIDERS — two kinds, ONE stroke (--dock-stroke, --tab-active-stroke wide),
+   *   ONE height (--tab-divider-height = the glyph height, so the bar reads the
+   *   same extent as the X/“+” icons beside it — a taller bar reads as "too high"
+   *   even when centred), both centred on the 20px lane:
+   *   1. Inter-tab seam: each tab paints a divider on ITS OWN LEFT edge (::after),
+   *      i.e. the seam to its left. It belongs to the right-hand tab of the seam,
+   *      so "previous sibling is active" is expressible without :has(). It HIDES
+   *      (--tab-divider:transparent) in exactly three cases — first tab (nothing to
+   *      its left), the active tab itself, and the tab right AFTER the active one
+   *      (the active side-stroke is already that seam's boundary). It does NOT hide
+   *      on hover: the hover pill is inset --tab-hover-inset from the seam, so the
+   *      two never touch — which is why no hover adjacency rule is needed.
+   *   2. Action-bar lead: the "+" cluster is its own action bar. Its divider is
+   *      really "the seam to the right of the LAST tab", so it is treated IDENTICALLY
+   *      to an inter-tab seam — it sits AT that seam (the container margin claws back
+   *      the full --tab-edge-pad), so the last tab's hover pill clears it by
+   *      --tab-hover-inset on both sides, exactly like a middle tab. padding-left
+   *      sets the gap from the seam to the "+". And it hides by the SAME rule: when
+   *      the last tab is active, the active side-stroke is the boundary (via :has(),
+   *      since tabs and "+" sit in sibling containers a sibling selector can't span). */
+  /* VERTICAL lane */
+  --tab-inset: 0.3125rem;
   --chrome-center: 20px;
-  --tab-crown-radius: var(--radius-md);
+  /* The active crown/foot is a 1px stroke; single-sourced here so the hover-top
+   * trim that matches it can never drift from the SVG's stroke-width. */
+  --tab-active-stroke: 1px;
+  /* RADIUS — crown (and active SVG crown) vs the uniform floating hover pill */
+  --tab-radius: var(--radius-md);
+  --tab-hover-radius: var(--radius-sm);
   --tab-gap: 0rem;
-  --tab-flare: var(--tab-crown-radius);
+  --tab-flare: var(--tab-radius);
   --tab-edge-pad: var(--tab-flare);
-  --tab-hover-radius: 0.34375rem;
-  --tab-hover-open-edge-radius: 0.28125rem;
-  /* Horizontal breathing room between the last tab's foot and the "+" cluster. */
-  --tab-actions-gap: 0.015625rem;
+  /* HORIZONTAL rhythm */
+  --tab-hover-inset: var(--tab-inset);
+  /* The ONE knob for label/close breathing room (they mirror each other). Label
+   * left x = hover-inset + this; close glyph right x = the same. So both read as
+   * `gutter` to the hover pill and `gutter + inset` to the active fill. Move both
+   * by tuning this alone. */
+  --tab-text-gutter: 0.5rem;
+  --tab-pad-inline: calc(var(--tab-hover-inset) + var(--tab-text-gutter));
+  /* Close button + glyph sizes MIRROR the size-* in workspace-tab.vue — keep in
+   * sync. The button right-aligns in the close-fade and centres the glyph, so the
+   * glyph's right edge sits (btn − glyph)/2 inside the fade's right edge. To land
+   * that glyph edge at --tab-pad-inline (mirroring the label's left), the fade
+   * backs off by that half-difference. */
+  --tab-close-btn: 1.25rem;
+  --tab-close-glyph: 0.875rem;
+  --tab-close-edge: calc(var(--tab-pad-inline) - (var(--tab-close-btn) - var(--tab-close-glyph)) / 2);
+  /* Trailing room the label must clear: it stops a hair before the glyph's left
+   * edge (glyph right is --tab-pad-inline, glyph is --tab-close-glyph wide). */
+  --tab-close-reserve: calc(var(--tab-pad-inline) + var(--tab-close-glyph) + 0.125rem);
+  /* DIVIDERS — one stroke, one width, one HEIGHT for both the inter-tab seam and
+   * the action-bar lead. Height = the close/“+” glyph height so the bar reads the
+   * same extent as the icons it sits between (NOT taller — a taller bar reads as
+   * "too high" even when centred). Both bars centre on the 20px lane.
+   * --tab-divider is a switch the inter-tab rule flips to transparent next to
+   * first/active. --tab-action-gap is the symmetric breathing each side of the "+"
+   * lead divider. */
+  --tab-divider-width: var(--tab-active-stroke);
+  --tab-divider-height: var(--tab-close-glyph);
+  --tab-divider: var(--dock-stroke);
+  --tab-action-gap: 0.375rem;
   /* Shared timing for close-fade (workspace-tab.vue). Tab hover fill itself is instant. */
   --tab-hover-duration: 150ms;
   /* ONE stroke colour for the whole dock outline — the strip's bottom hairline, the
@@ -130,39 +236,33 @@
    * never flash square for a frame while dockview swaps active/hover classes (it
    * only used to live on the active/hover rules). Invisible on a transparent
    * inactive tab; revealed once a fill paints. */
-  border-top-left-radius: var(--tab-crown-radius);
-  border-top-right-radius: var(--tab-crown-radius);
+  border-top-left-radius: var(--tab-radius);
+  border-top-right-radius: var(--tab-radius);
   /* Float the chip below the strip's top edge — the rounded crown needs headroom
    * above the strip. Applied to EVERY tab uniformly, so selecting one never shifts it
    * vertically. The fill still reaches the bottom, so the active tab meets the
-   * pane. position:relative anchors the ::before bottom-flare (see active rule). */
+   * pane. position:relative anchors the ::before hover pill and the ::after seam
+   * divider (and, on the active tab, the absolutely-positioned SVG shape). */
   position: relative;
-  margin-top: var(--tab-top-inset);
-  height: calc(100% - var(--tab-top-inset));
-  /* A transparent 1px border on EVERY tab reserves the active tab's outline width
-   * up front, so selecting a tab only RECOLOURS its crown stroke — it never resizes
-   * or nudges the chip. Bottom edge stays borderless (the active fill bleeds into
-   * the pane there). */
-  border: 1px solid transparent;
-  border-bottom: none;
+  margin-top: var(--tab-inset);
+  height: calc(100% - var(--tab-inset));
   --tab-hover-bg: var(--surface-chrome-hover);
-  --tab-hover-left-radius: var(--tab-hover-radius);
-  --tab-hover-right-radius: var(--tab-hover-radius);
 }
 
 .dockview-theme-memoh .dv-tab:not(.dv-active-tab)::before {
   content: '';
   position: absolute;
-  top: 0;
-  right: 2px;
-  bottom: 3.5px;
-  left: 2px;
+  /* Box coords: the tab box is already top-offset by margin-top:--tab-inset, so
+   * top sits --tab-inset below the strip top. The TOP (only) is trimmed by the
+   * active stroke width so the solid fill reads at the same optical height as the
+   * active crown's 1px stroke (whose solid core sits a stroke below its top edge).
+   * right/bottom/left keep the equal --tab-inset margin — no such mismatch there. */
+  top: var(--tab-active-stroke);
+  right: var(--tab-hover-inset);
+  bottom: var(--tab-hover-inset);
+  left: var(--tab-hover-inset);
   z-index: 0;
-  border-radius:
-    var(--tab-hover-left-radius)
-    var(--tab-hover-right-radius)
-    var(--tab-hover-right-radius)
-    var(--tab-hover-left-radius);
+  border-radius: var(--tab-hover-radius);
   background-color: var(--surface-chrome-hover);
   opacity: 0;
   /* Instant hide when hover ends (e.g. after switching tabs) — only fade IN. */
@@ -170,20 +270,43 @@
   pointer-events: none;
 }
 
-.dockview-theme-memoh .dv-tab.dv-active-tab + .dv-tab:not(.dv-active-tab):hover {
-  --tab-hover-right-radius: var(--tab-hover-open-edge-radius);
-}
-
 .dockview-theme-memoh .dv-tab:not(.dv-active-tab):hover::before {
   opacity: 1;
   transition: none;
 }
 
-/* Adjacent editor tabs touch; separation is state and surface, not whitespace.
- * Edge padding is geometry protection for the connected active corner, not a
- * visual gutter; the prefix action spacing is tuned outside this scroll area.
- * Horizontal gap from the last tab to "+" is --tab-actions-gap on the actions
- * container, not extra padding here. */
+/* Inter-tab seam divider — a short bar on the tab's OWN LEFT edge (the seam to its
+ * left), centred on the 20px lane (same window as the close-fade band). It belongs
+ * to the right-hand tab so "prev is active" needs no :has(). --tab-divider is the
+ * paint switch; the rules below flip it transparent where a boundary already exists.
+ * No hover rule: the hover pill is inset from the seam, so they never collide. */
+.dockview-theme-memoh .dv-tab::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  /* Centre the bar on the 20px lane, same as the X/“+” glyphs. The tab box floats
+   * --tab-inset below the strip top, so its 50% is half an inset below the lane;
+   * back it up by inset/2, then translate the bar's own height onto that point. */
+  top: calc(50% - var(--tab-inset) / 2);
+  transform: translateY(-50%);
+  height: var(--tab-divider-height);
+  width: var(--tab-divider-width);
+  background-color: var(--tab-divider);
+  z-index: 0;
+  pointer-events: none;
+}
+/* Hide it where a boundary already reads: first tab (nothing to its left), the
+ * active tab itself, and the tab right after the active one (the active side
+ * stroke is that seam). */
+.dockview-theme-memoh .dv-tab:first-child::after,
+.dockview-theme-memoh .dv-tab.dv-active-tab::after,
+.dockview-theme-memoh .dv-tab.dv-active-tab + .dv-tab::after {
+  --tab-divider: transparent;
+}
+
+/* Adjacent editor tabs touch; separation is state, surface, and the seam divider
+ * above — not whitespace. Edge padding is geometry protection for the connected
+ * active corner, not a visual gutter. */
 .dockview-theme-memoh .dv-tabs-container {
   gap: var(--tab-gap);
   padding-inline: var(--tab-edge-pad);
@@ -218,7 +341,6 @@
  * turns and produce doubled pixels. */
 .dockview-theme-memoh .dv-tab.dv-active-tab {
   background-color: transparent !important;
-  border-color: transparent;
   /* The active tab never takes the hover lift, so its blot-out colour is the
    * editor surface it already wears. */
   --tab-hover-bg: var(--surface-editor);
@@ -231,8 +353,11 @@
   background-color: transparent !important;
 }
 
-/* The active path layer owns the lower fillets. Keep the wrapper pseudo empty so
- * the old gradient flare cannot stack under the path stroke. */
+/* Active tab paint is owned by the SVG shape in workspace-tab.vue (fill + 1px
+ * stroke crown/foot). dockview's built-in `:not(:first-child)::before` divider also
+ * targets the active tab as a transparent no-op at z-5; kill it so nothing can sit
+ * over the SVG. (Our hover-pill ::before is `:not(.dv-active-tab)`, so it never
+ * applies here — this only silences dockview's own pseudo.) */
 .dockview-theme-memoh .dv-tab.dv-active-tab::before {
   content: none;
 }
@@ -279,10 +404,35 @@
   flex: 0 0 auto;
 }
 
-/* The "+" cluster (leftActions, header-add-actions.vue) renders right after the
- * tabs; one breathing gap separates it from the last tab's foot. */
+/* The "+" cluster (leftActions, header-add-actions.vue) is its own action bar: it
+ * renders right after the tabs and carries a leading divider so it reads as a
+ * separate zone, not another tab. The divider sits at the LAST TAB'S RIGHT SEAM
+ * (margin claws back the full --tab-edge-pad), exactly like an inter-tab seam — so
+ * the last tab's hover pill clears it by --tab-hover-inset on BOTH sides, same as a
+ * middle tab. padding-left then sets the gap from that seam to the "+" button. */
 .dockview-theme-memoh .dv-left-actions-container {
-  margin-left: var(--tab-actions-gap);
+  position: relative;
+  margin-left: calc(-1 * var(--tab-edge-pad));
+  padding-left: calc(var(--tab-action-gap) + var(--tab-divider-width));
+}
+.dockview-theme-memoh .dv-left-actions-container::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  /* Full-height actions container, so 50% IS the 20px lane (no float to correct). */
+  top: 50%;
+  transform: translateY(-50%);
+  height: var(--tab-divider-height);
+  width: var(--tab-divider-width);
+  background-color: var(--dock-stroke);
+  pointer-events: none;
+}
+/* Same rule as an inter-tab seam: when the LAST tab is active, its side stroke is
+ * the boundary, so the lead divider hides. The padding-left stays, so the "+" does
+ * NOT jump left when you select the last tab. :has() because the tabs and the "+"
+ * sit in sibling containers no sibling selector can bridge. */
+.dockview-theme-memoh .dv-tabs-and-actions-container:has(.dv-tab:last-child.dv-active-tab) .dv-left-actions-container::before {
+  content: none;
 }
 
 /* Continuous bottom hairline for the WHOLE strip, drawn as an inset box-shadow so it
@@ -390,13 +540,13 @@
 
 /* Terminal tabs are flat file-row chips: the chip (.memoh-terminal-tab) paints its
  * OWN fill — hover (--sidebar-hover) and active (--sidebar-accent) — from the Vue
- * class, and is the SOLE surface. The editor-tab chrome above paints its hover/
- * active/flare on the WRAPPER's ::before (NOT on the box background), so killing
- * only the box background left that pseudo alive: a real mouse-over lit BOTH the
- * chip's hover AND the wrapper's ::before hover, stacking two translucent layers
- * (a DevTools forced :hover only flags one element, so it looked single-layer).
- * Strip every wrapper-level paint — box background AND the ::before/::after pseudos
- * — so nothing can stack under the chip. */
+ * class, and is the SOLE surface. The editor-tab chrome above paints its hover pill
+ * on the wrapper's ::before and its seam divider on ::after (NOT on the box
+ * background), so killing only the box background left those pseudos alive: a real
+ * mouse-over lit BOTH the chip's hover AND the wrapper's ::before, stacking two
+ * translucent layers (a DevTools forced :hover only flags one element, so it looked
+ * single-layer). Strip every wrapper-level paint — box background AND the
+ * ::before/::after pseudos — so nothing can stack under the chip. */
 .dockview-theme-memoh .dv-tab:has(.memoh-terminal-tab),
 .dockview-theme-memoh .dv-tab:has(.memoh-terminal-tab):hover,
 .dockview-theme-memoh .dv-tab:has(.memoh-terminal-tab).dv-active-tab {
@@ -418,9 +568,15 @@
 
 /* The "+" sits one inter-tab gap (6px) from the last chip: the tabs-container's
  * 3px end inset already gives half, so the "+" cluster (leftActions) adds the
- * remaining 3px — not the wider editor --tab-actions-gap. */
+ * remaining 3px. Terminal groups are flat file-row chips with no editor-tab
+ * geometry, so they DON'T carry the editor action-bar lead divider or its
+ * edge-pad claw-back — reset margin/padding and kill the ::before. */
 .dockview-theme-memoh .memoh-terminal-group .dv-left-actions-container {
   margin-left: 0.1875rem;
+  padding-left: 0;
+}
+.dockview-theme-memoh .memoh-terminal-group .dv-left-actions-container::before {
+  content: none;
 }
 
 .dockview-theme-memoh .memoh-terminal-group .dv-pre-actions-container {

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -139,7 +139,6 @@
    *      since tabs and "+" sit in sibling containers a sibling selector can't span). */
   /* VERTICAL lane */
   --tab-inset: 0.3125rem;
-  --chrome-center: 20px;
   /* The active crown/foot is a 1px stroke; single-sourced here so the hover-top
    * trim that matches it can never drift from the SVG's stroke-width. */
   --tab-active-stroke: 1px;

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -60,15 +60,15 @@
   /* Tab geometry knobs. --tab-top-inset lifts every tab off the top of the
    * strip so the rounded crown floats below the window edge. Main editor tabs
    * touch edge-to-edge; selection is carried by fill, stroke, and the bottom
-   * fillet rather than inter-tab whitespace. --tab-edge-pad gives the first and
-   * last tab just enough room for the connected bottom edge without turning the
-   * prefix-actions-to-first-tab space into a second large gutter. */
+   * fillet rather than inter-tab whitespace. --tab-edge-pad must be at least the
+   * active flare radius; otherwise the first/last active tab's connected corner
+   * is clipped by dockview's scroll container. */
   --tab-top-inset: 0.3125rem;
   --chrome-center: 20px;
   --tab-crown-radius: var(--radius-md);
   --tab-gap: 0rem;
   --tab-flare: var(--tab-crown-radius);
-  --tab-edge-pad: 0.1875rem;
+  --tab-edge-pad: var(--tab-flare);
   --tab-hover-radius: 0.34375rem;
   --tab-hover-open-edge-radius: 0.28125rem;
   /* Horizontal breathing room between the last tab's foot and the "+" cluster. */
@@ -180,10 +180,10 @@
 }
 
 /* Adjacent editor tabs touch; separation is state and surface, not whitespace.
- * The small edge padding prevents the first/last connected edge from being clipped
- * by dockview's scroll container without adding a second large gutter after the
- * prefix action buttons. Horizontal gap from the last tab to "+" is
- * --tab-actions-gap on the actions container, not extra padding here. */
+ * Edge padding is geometry protection for the connected active corner, not a
+ * visual gutter; the prefix action spacing is tuned outside this scroll area.
+ * Horizontal gap from the last tab to "+" is --tab-actions-gap on the actions
+ * container, not extra padding here. */
 .dockview-theme-memoh .dv-tabs-container {
   gap: var(--tab-gap);
   padding-inline: var(--tab-edge-pad);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,10 +56,10 @@ importers:
     dependencies:
       '@electron-toolkit/preload':
         specifier: ^3.0.1
-        version: 3.0.2(electron@34.5.8)
+        version: 3.0.2(electron@42.5.0)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@34.5.8)
+        version: 4.0.0(electron@42.5.0)
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -104,8 +104,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       electron:
-        specifier: ^34.5.0
-        version: 34.5.8
+        specifier: ^42.0.0
+        version: 42.5.0
       electron-builder:
         specifier: ^26.0.12
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
@@ -684,6 +684,10 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@electron-internal/extract-zip@1.0.4':
+    resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
+    engines: {node: '>=22.12.0'}
+
   '@electron-toolkit/preload@3.0.2':
     resolution: {integrity: sha512-TWWPToXd8qPRfSXwzf5KVhpXMfONaUuRAZJHsKthKgZR/+LqX1dZVSSClQ8OTAEduvLGdecljCsoT2jSshfoUg==}
     peerDependencies:
@@ -708,13 +712,13 @@ packages:
     resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
     hasBin: true
 
-  '@electron/get@2.0.3':
-    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
-    engines: {node: '>=12'}
-
   '@electron/get@3.1.0':
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
+
+  '@electron/get@5.0.0':
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
@@ -2349,9 +2353,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
-
   '@types/node@24.10.4':
     resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
 
@@ -2384,9 +2385,6 @@ packages:
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.52.0':
     resolution: {integrity: sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==}
@@ -2911,9 +2909,6 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -3524,9 +3519,9 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@34.5.8:
-    resolution: {integrity: sha512-vxLD65mabTzYmEVa9KceMHM0+zO+vqgrhcyNVlmTd0IGV5J7XZ8v/qElm0o4YQ4wPeq7olZkUjZkBQQEdr23/g==}
-    engines: {node: '>= 12.20.55'}
+  electron@42.5.0:
+    resolution: {integrity: sha512-cYEKS9XFz+c9fAB4jI0x49yz1FFzB55r3q96wu9YkwwJMv7t9202IE/ltlgy6yitl/J4M7C8JQcmUqdzDvPl/w==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   emoji-regex@10.6.0:
@@ -3557,6 +3552,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -3701,11 +3700,6 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
@@ -3718,9 +3712,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -4667,9 +4658,6 @@ packages:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -5368,15 +5356,16 @@ packages:
   ufo@1.6.2:
     resolution: {integrity: sha512-heMioaxBcG9+Znsda5Q8sQbWnLJSl98AFDXTO80wELWEzX3hordXsTdxrIfMQoO9IY1MEnoGoPjpoKpMj+Yx0Q==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -5869,9 +5858,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -6180,17 +6166,19 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@electron-toolkit/preload@3.0.2(electron@34.5.8)':
+  '@electron-internal/extract-zip@1.0.4': {}
+
+  '@electron-toolkit/preload@3.0.2(electron@42.5.0)':
     dependencies:
-      electron: 34.5.8
+      electron: 42.5.0
 
   '@electron-toolkit/tsconfig@1.0.1(@types/node@24.10.4)':
     dependencies:
       '@types/node': 24.10.4
 
-  '@electron-toolkit/utils@4.0.0(electron@34.5.8)':
+  '@electron-toolkit/utils@4.0.0(electron@42.5.0)':
     dependencies:
-      electron: 34.5.8
+      electron: 42.5.0
 
   '@electron/asar@3.4.1':
     dependencies:
@@ -6204,7 +6192,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@2.0.3':
+  '@electron/get@3.1.0':
     dependencies:
       debug: 4.4.3
       env-paths: 2.2.1
@@ -6218,17 +6206,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@3.1.0':
+  '@electron/get@5.0.0':
     dependencies:
       debug: 4.4.3
-      env-paths: 2.2.1
-      fs-extra: 8.1.0
-      got: 11.8.6
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 6.3.1
+      semver: 7.7.3
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 3.0.0
+      undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7590,10 +7577,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@20.19.39':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@24.10.4':
     dependencies:
       undici-types: 7.16.0
@@ -7631,11 +7614,6 @@ snapshots:
     optional: true
 
   '@types/web-bluetooth@0.0.21': {}
-
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 24.10.4
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.52.0(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -8273,8 +8251,6 @@ snapshots:
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
 
@@ -8978,11 +8954,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@34.5.8:
+  electron@42.5.0:
     dependencies:
-      '@electron/get': 2.0.3
-      '@types/node': 20.19.39
-      extract-zip: 2.0.1
+      '@electron-internal/extract-zip': 1.0.4
+      '@electron/get': 5.0.0
+      '@types/node': 24.10.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9007,6 +8983,8 @@ snapshots:
   entities@7.0.0: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   environment@1.1.0: {}
 
@@ -9227,16 +9205,6 @@ snapshots:
 
   exsolve@1.0.8: {}
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   extsprintf@1.4.1:
     optional: true
 
@@ -9245,10 +9213,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -10224,8 +10188,6 @@ snapshots:
 
   pe-library@0.4.1: {}
 
-  pend@1.2.0: {}
-
   perfect-debounce@1.0.0: {}
 
   perfect-debounce@2.0.0: {}
@@ -10976,11 +10938,12 @@ snapshots:
 
   ufo@1.6.2: {}
 
-  undici-types@6.21.0: {}
-
   undici-types@7.16.0: {}
 
   undici@6.25.0: {}
+
+  undici@7.28.0:
+    optional: true
 
   unist-util-is@6.0.1:
     dependencies:
@@ -11466,11 +11429,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- upgrade the desktop Electron runtime to 42
- retune macOS traffic light placement and desktop sidebar/topbar reserve space
- polish the dockview editor topbar, tab shape, hover fill, close affordance, and add-button alignment
- tighten the prefix-actions-to-first-tab spacing by separating tab edge padding from the active connected edge radius

## Commit structure
- chore(desktop): upgrade Electron to 42
- fix(desktop): retune macOS chrome spacing
- feat(web): polish dockview topbar tabs

## Verification
- pnpm --dir apps/desktop typecheck
- pnpm --filter @memohai/web exec vue-tsc --noEmit
- pnpm exec eslint apps/desktop/src/main/index.ts apps/web/src/components/sidebar/bot-switcher.vue apps/web/src/components/sidebar/index.vue apps/web/src/pages/home/components/dockview/header-add-actions.vue apps/web/src/pages/home/components/dockview/prefix-header-actions.vue apps/web/src/pages/home/components/dockview/workspace-tab.vue
- git diff --check
- pre-commit hooks completed Go tests and staged-file linting for each commit

## Notes
Draft/WIP PR for reviewing the overall desktop chrome direction before final visual tightening.