### PR TITLE
feat(contextfrag): add typed context fragment compile path

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -166,10 +166,12 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 			// Must run before buildGenerateOptions so prompt caching and
 			// background task summaries see the usage-augmented text.
 			cfg.System = appendToolUsageToSystem(cfg.System, toolUsage)
+			cfg.ContextToolUsage = toolUsage
 		}
 	}
 	limit := a.Limits().ToolOutputLimit()
 	sdkTools, readMediaState := decorateReadMediaTools(cfg.Model, sdkTools)
+	cfg = cfg.RefreshContextFragWithDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, true)
 	sdkTools = tools.WrapToolOutputLimits(sdkTools, limit)
 	approvalTools := append([]sdk.Tool(nil), sdkTools...)
 	sdkTools = a.wrapToolsWithHooks(ctx, cfg, sdkTools)
@@ -260,6 +262,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 		sendEvent(ctx, ch, StreamEvent{Type: EventError, Error: turnError})
 		return
 	}
+	cfg = cfg.RefreshContextFragWithDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, true)
 	opts := a.buildGenerateOptions(cfg, sdkTools, approvalTools, prepareStep)
 	modelStepIndex := 0
 	opts = append(opts, sdk.WithOnStep(func(step *sdk.StepResult) *sdk.GenerateParams {
@@ -640,10 +643,12 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 			// Must run before buildGenerateOptions so prompt caching and
 			// background task summaries see the usage-augmented text.
 			cfg.System = appendToolUsageToSystem(cfg.System, toolUsage)
+			cfg.ContextToolUsage = toolUsage
 		}
 	}
 	limit := a.Limits().ToolOutputLimit()
 	sdkTools, readMediaState := decorateReadMediaTools(cfg.Model, sdkTools)
+	cfg = cfg.RefreshContextFragWithDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, false)
 	sdkTools = tools.WrapToolOutputLimits(sdkTools, limit)
 	approvalTools := append([]sdk.Tool(nil), sdkTools...)
 	sdkTools = a.wrapToolsWithHooks(ctx, cfg, sdkTools)
@@ -671,6 +676,7 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 	if err != nil {
 		return nil, err
 	}
+	cfg = cfg.RefreshContextFragWithDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, false)
 	opts := a.buildGenerateOptions(cfg, sdkTools, approvalTools, prepareStep)
 	modelStepIndex := 0
 	opts = append(opts,
@@ -1330,6 +1336,7 @@ func (a *Agent) runMidStreamRetry(
 		// media resolution, and other prepare-step logic — same as initial stream.
 		retryCfgCopy := cfg
 		retryCfgCopy.Messages = prevResult.Messages
+		retryCfgCopy = retryCfgCopy.RefreshContextFrag()
 		retryOpts := a.buildGenerateOptions(retryCfgCopy, sdkTools, approvalTools, prepareStep)
 
 		retryResult, retryErr := a.client.StreamText(streamCtx, retryOpts...)

--- a/internal/agent/context_frag.go
+++ b/internal/agent/context_frag.go
@@ -9,8 +9,10 @@ import (
 // RunConfig fields. The SDK-facing fields remain the source of truth in phase 1.
 func (cfg RunConfig) RefreshContextFrag() RunConfig {
 	query := cfg.Query
+	inlineImages := cfg.InlineImages
 	if cfg.ContextQueryMaterialized {
 		query = ""
+		inlineImages = nil
 	}
 	assembled := contextfrag.Compile(contextfrag.CompileInput{
 		Source:          contextfrag.SourceRunConfig,
@@ -18,7 +20,7 @@ func (cfg RunConfig) RefreshContextFrag() RunConfig {
 		System:          cfg.System,
 		Messages:        cfg.Messages,
 		Query:           query,
-		InlineImages:    cfg.InlineImages,
+		InlineImages:    inlineImages,
 		ToolUsage:       cfg.ContextToolUsage,
 		DynamicMutators: cfg.ContextDynamicMutators,
 		Existing:        cfg.ContextFrags,

--- a/internal/agent/context_frag.go
+++ b/internal/agent/context_frag.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"github.com/memohai/memoh/internal/contextfrag"
+	"github.com/memohai/memoh/internal/models"
+)
+
+// RefreshContextFrag rebuilds the typed context frag view from the legacy
+// RunConfig fields. The SDK-facing fields remain the source of truth in phase 1.
+func (cfg RunConfig) RefreshContextFrag() RunConfig {
+	query := cfg.Query
+	if cfg.ContextQueryMaterialized {
+		query = ""
+	}
+	assembled := contextfrag.Compile(contextfrag.CompileInput{
+		Source:          contextfrag.SourceRunConfig,
+		Scope:           cfg.ContextScope,
+		System:          cfg.System,
+		Messages:        cfg.Messages,
+		Query:           query,
+		InlineImages:    cfg.InlineImages,
+		ToolUsage:       cfg.ContextToolUsage,
+		DynamicMutators: cfg.ContextDynamicMutators,
+		Existing:        cfg.ContextFrags,
+	})
+	cfg.ContextFrags = assembled.Frags
+	cfg.ContextManifest = assembled.Manifest
+	return cfg
+}
+
+func (cfg RunConfig) RefreshContextFragWithDynamicMutators(readMedia bool, beforeModelCallHook bool, injectCh bool) RunConfig {
+	cfg.ContextDynamicMutators = cfg.contextDynamicMutators(readMedia, beforeModelCallHook, injectCh)
+	return cfg.RefreshContextFrag()
+}
+
+func (cfg RunConfig) contextDynamicMutators(readMedia bool, beforeModelCallHook bool, injectCh bool) []contextfrag.DynamicMutator {
+	var mutators []contextfrag.DynamicMutator
+	if cfg.Model != nil &&
+		models.ResolveClientType(cfg.Model) == string(models.ClientTypeAnthropicMessages) &&
+		models.NormalizePromptCacheTTL(cfg.PromptCacheTTL) != models.PromptCacheTTLOff {
+		mutators = append(mutators, contextfrag.DynamicMutatorPromptCache)
+	}
+	if injectCh && cfg.InjectCh != nil {
+		mutators = append(mutators, contextfrag.DynamicMutatorInjectCh)
+	}
+	if readMedia {
+		mutators = append(mutators, contextfrag.DynamicMutatorReadMedia)
+	}
+	if beforeModelCallHook {
+		mutators = append(mutators, contextfrag.DynamicMutatorBeforeModelCallHook)
+	}
+	if cfg.BackgroundManager != nil {
+		mutators = append(mutators, contextfrag.DynamicMutatorBackgroundSummary)
+	}
+	mutators = append(mutators, contextfrag.DynamicMutatorMidTaskPrune)
+	return mutators
+}

--- a/internal/agent/context_frag_test.go
+++ b/internal/agent/context_frag_test.go
@@ -30,6 +30,29 @@ func TestRefreshContextFragOmitsMaterializedQuery(t *testing.T) {
 	}
 }
 
+func TestRefreshContextFragOmitsMaterializedInlineImages(t *testing.T) {
+	t.Parallel()
+
+	image := sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"}
+	cfg := RunConfig{
+		System:                   "base system",
+		Query:                    "current user",
+		Messages:                 []sdk.Message{sdk.UserMessage("current user", image)},
+		InlineImages:             []sdk.ImagePart{image},
+		ContextQueryMaterialized: true,
+	}
+
+	cfg = cfg.RefreshContextFrag()
+
+	if cfg.ContextManifest.Counts.Images != 1 {
+		t.Fatalf("manifest image count = %d, want only materialized message image: %#v", cfg.ContextManifest.Counts.Images, cfg.ContextManifest.Items)
+	}
+	rendered := contextfrag.Render(cfg.ContextFrags)
+	if len(rendered.InlineImages) != 0 {
+		t.Fatalf("rendered inline images = %#v, want images only inside materialized message", rendered.InlineImages)
+	}
+}
+
 func TestRefreshContextFragMarksToolUsageBeforeWorkspaceInstructions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/context_frag_test.go
+++ b/internal/agent/context_frag_test.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	"github.com/memohai/memoh/internal/agent/background"
+	"github.com/memohai/memoh/internal/agent/tools"
+	"github.com/memohai/memoh/internal/contextfrag"
+)
+
+func TestRefreshContextFragOmitsMaterializedQuery(t *testing.T) {
+	t.Parallel()
+
+	cfg := RunConfig{
+		System:                   "base system",
+		Query:                    "current user",
+		Messages:                 []sdk.Message{sdk.UserMessage("current user")},
+		ContextQueryMaterialized: true,
+	}
+
+	cfg = cfg.RefreshContextFrag()
+
+	if manifestHasAgentKind(cfg.ContextManifest, contextfrag.KindCurrentUserMessage) {
+		t.Fatalf("manifest should not include pending current user query after it was materialized: %#v", cfg.ContextManifest.Items)
+	}
+	if cfg.ContextManifest.Counts.Messages != 1 {
+		t.Fatalf("manifest message count = %d, want 1", cfg.ContextManifest.Counts.Messages)
+	}
+}
+
+func TestRefreshContextFragMarksToolUsageBeforeWorkspaceInstructions(t *testing.T) {
+	t.Parallel()
+
+	cfg := RunConfig{
+		System: appendToolUsageToSystem(
+			"base system\n\n## Workspace instruction files\n\nworkspace text",
+			"## Tool usage\n\nusage text",
+		),
+		ContextToolUsage: "## Tool usage\n\nusage text",
+		Messages:         []sdk.Message{sdk.UserMessage("hi")},
+	}
+
+	cfg = cfg.RefreshContextFrag()
+
+	toolIndex := manifestAgentKindIndex(cfg.ContextManifest, contextfrag.KindToolUsage)
+	workspaceIndex := manifestAgentKindIndex(cfg.ContextManifest, contextfrag.KindWorkspaceInstruction)
+	if toolIndex < 0 {
+		t.Fatalf("manifest missing tool usage item: %#v", cfg.ContextManifest.Items)
+	}
+	if workspaceIndex < 0 {
+		t.Fatalf("manifest missing workspace instruction item: %#v", cfg.ContextManifest.Items)
+	}
+	if toolIndex > workspaceIndex {
+		t.Fatalf("tool usage manifest index = %d, workspace index = %d; want tool usage before workspace", toolIndex, workspaceIndex)
+	}
+	rendered := contextfrag.Render(cfg.ContextFrags)
+	if rendered.System != cfg.System {
+		t.Fatalf("rendered system = %q, want %q", rendered.System, cfg.System)
+	}
+}
+
+func TestSpawnRunConfigCarriesContextScopeAndMaterializedQuery(t *testing.T) {
+	t.Parallel()
+
+	rc := runConfigFromSpawnRunConfig(tools.SpawnRunConfig{
+		Query:    "do the task",
+		Messages: []sdk.Message{sdk.UserMessage("history")},
+		Identity: tools.SpawnIdentity{
+			BotID:             "bot-1",
+			ChatID:            "chat-1",
+			SessionID:         "child-1",
+			ChannelIdentityID: "identity-1",
+			CurrentPlatform:   "telegram",
+			IsSubagent:        true,
+		},
+	})
+
+	if !rc.ContextQueryMaterialized {
+		t.Fatal("spawn query should be marked materialized because it is appended to Messages")
+	}
+	rc = rc.RefreshContextFrag()
+	if manifestHasAgentKind(rc.ContextManifest, contextfrag.KindCurrentUserMessage) {
+		t.Fatalf("manifest should not include duplicate pending current user query: %#v", rc.ContextManifest.Items)
+	}
+	if rc.ContextManifest.Counts.Messages != 2 {
+		t.Fatalf("manifest message count = %d, want history + materialized query", rc.ContextManifest.Counts.Messages)
+	}
+	for _, item := range rc.ContextManifest.Items {
+		if item.Scope.BotID != "bot-1" || item.Scope.SessionID != "child-1" || item.Scope.ChannelIdentityID != "identity-1" {
+			t.Fatalf("manifest item lost subagent scope: %#v", item.Scope)
+		}
+	}
+}
+
+func TestRefreshContextFragWithDynamicMutatorsMarksPreProviderBoundary(t *testing.T) {
+	t.Parallel()
+
+	injectCh := make(chan InjectMessage)
+	cfg := RunConfig{
+		System:            "base system",
+		Messages:          []sdk.Message{sdk.UserMessage("hi")},
+		InjectCh:          injectCh,
+		BackgroundManager: background.New(nil),
+	}
+	cfg = cfg.RefreshContextFragWithDynamicMutators(true, true, true)
+
+	if cfg.ContextManifest.View != contextfrag.ViewRunConfigPreProvider {
+		t.Fatalf("manifest view = %q, want %q", cfg.ContextManifest.View, contextfrag.ViewRunConfigPreProvider)
+	}
+	for _, want := range []contextfrag.DynamicMutator{
+		contextfrag.DynamicMutatorInjectCh,
+		contextfrag.DynamicMutatorReadMedia,
+		contextfrag.DynamicMutatorBeforeModelCallHook,
+		contextfrag.DynamicMutatorBackgroundSummary,
+		contextfrag.DynamicMutatorMidTaskPrune,
+	} {
+		if !manifestHasMutator(cfg.ContextManifest, want) {
+			t.Fatalf("manifest dynamic mutators = %#v, want %q", cfg.ContextManifest.DynamicMutators, want)
+		}
+	}
+}
+
+func manifestHasAgentKind(manifest contextfrag.Manifest, kind contextfrag.Kind) bool {
+	return manifestAgentKindIndex(manifest, kind) >= 0
+}
+
+func manifestHasMutator(manifest contextfrag.Manifest, want contextfrag.DynamicMutator) bool {
+	for _, got := range manifest.DynamicMutators {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+func manifestAgentKindIndex(manifest contextfrag.Manifest, kind contextfrag.Kind) int {
+	for i, item := range manifest.Items {
+		if item.Kind == kind {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -206,6 +206,7 @@ func (a *Agent) applyBeforeModelCallHook(ctx context.Context, cfg RunConfig, ste
 	}
 	if strings.TrimSpace(res.AppendContext) != "" {
 		cfg.Messages = append(cfg.Messages, sdk.UserMessage(formatHookContext(hooks.EventBeforeModelCall, res.AppendContext)))
+		cfg = cfg.RefreshContextFrag()
 	}
 	return cfg, nil
 }

--- a/internal/agent/spawn_adapter.go
+++ b/internal/agent/spawn_adapter.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	"github.com/memohai/memoh/internal/agent/tools"
+	"github.com/memohai/memoh/internal/contextfrag"
 	"github.com/memohai/memoh/internal/models"
 )
 
@@ -24,36 +25,7 @@ func NewSpawnAdapter(a *Agent) *SpawnAdapter {
 }
 
 func (s *SpawnAdapter) Generate(ctx context.Context, cfg tools.SpawnRunConfig) (*tools.SpawnResult, error) {
-	messages := cfg.Messages
-	if cfg.Query != "" {
-		messages = append(messages, sdk.Message{
-			Role:    sdk.MessageRoleUser,
-			Content: []sdk.MessagePart{sdk.TextPart{Text: cfg.Query}},
-		})
-	}
-
-	rc := RunConfig{
-		Model:            cfg.Model,
-		System:           cfg.System,
-		Query:            cfg.Query,
-		SessionType:      cfg.SessionType,
-		Messages:         messages,
-		ReasoningEffort:  cfg.ReasoningEffort,
-		PromptCacheTTL:   cfg.PromptCacheTTL,
-		SupportsToolCall: true,
-		Identity: SessionContext{
-			BotID:             cfg.Identity.BotID,
-			ChatID:            cfg.Identity.ChatID,
-			SessionID:         cfg.Identity.SessionID,
-			ChannelIdentityID: cfg.Identity.ChannelIdentityID,
-			CurrentPlatform:   cfg.Identity.CurrentPlatform,
-			SessionToken:      cfg.Identity.SessionToken,
-			IsSubagent:        cfg.Identity.IsSubagent,
-		},
-		LoopDetection: LoopDetectionConfig{
-			Enabled: cfg.LoopDetection.Enabled,
-		},
-	}
+	rc := runConfigFromSpawnRunConfig(cfg)
 
 	result, err := s.agent.Generate(ctx, rc)
 	if err != nil {
@@ -67,11 +39,7 @@ func (s *SpawnAdapter) Generate(ctx context.Context, cfg tools.SpawnRunConfig) (
 	}, nil
 }
 
-// GenerateWithWatchdog runs the agent in streaming mode, touching the
-// provided touchFn on every stream event (token, tool progress, etc.).
-// It collects the full result and returns it in the same shape as Generate.
-// This enables activity-based watchdog monitoring for subagent execution.
-func (s *SpawnAdapter) GenerateWithWatchdog(ctx context.Context, cfg tools.SpawnRunConfig, touchFn func()) (*tools.SpawnResult, error) {
+func runConfigFromSpawnRunConfig(cfg tools.SpawnRunConfig) RunConfig {
 	messages := cfg.Messages
 	if cfg.Query != "" {
 		messages = append(messages, sdk.Message{
@@ -80,28 +48,45 @@ func (s *SpawnAdapter) GenerateWithWatchdog(ctx context.Context, cfg tools.Spawn
 		})
 	}
 
-	rc := RunConfig{
-		Model:            cfg.Model,
-		System:           cfg.System,
-		Query:            cfg.Query,
-		SessionType:      cfg.SessionType,
-		Messages:         messages,
-		ReasoningEffort:  cfg.ReasoningEffort,
-		PromptCacheTTL:   cfg.PromptCacheTTL,
-		SupportsToolCall: true,
-		Identity: SessionContext{
-			BotID:             cfg.Identity.BotID,
-			ChatID:            cfg.Identity.ChatID,
-			SessionID:         cfg.Identity.SessionID,
-			ChannelIdentityID: cfg.Identity.ChannelIdentityID,
-			CurrentPlatform:   cfg.Identity.CurrentPlatform,
-			SessionToken:      cfg.Identity.SessionToken,
-			IsSubagent:        cfg.Identity.IsSubagent,
+	identity := SessionContext{
+		BotID:             cfg.Identity.BotID,
+		ChatID:            cfg.Identity.ChatID,
+		SessionID:         cfg.Identity.SessionID,
+		ChannelIdentityID: cfg.Identity.ChannelIdentityID,
+		CurrentPlatform:   cfg.Identity.CurrentPlatform,
+		SessionToken:      cfg.Identity.SessionToken,
+		IsSubagent:        cfg.Identity.IsSubagent,
+	}
+	return RunConfig{
+		Model:                    cfg.Model,
+		System:                   cfg.System,
+		Query:                    cfg.Query,
+		ContextQueryMaterialized: cfg.Query != "",
+		SessionType:              cfg.SessionType,
+		Messages:                 messages,
+		ReasoningEffort:          cfg.ReasoningEffort,
+		PromptCacheTTL:           cfg.PromptCacheTTL,
+		SupportsToolCall:         true,
+		Identity:                 identity,
+		ContextScope: contextfrag.Scope{
+			BotID:             identity.BotID,
+			ChatID:            identity.ChatID,
+			SessionID:         identity.SessionID,
+			ChannelIdentityID: identity.ChannelIdentityID,
+			Platform:          identity.CurrentPlatform,
 		},
 		LoopDetection: LoopDetectionConfig{
 			Enabled: cfg.LoopDetection.Enabled,
 		},
 	}
+}
+
+// GenerateWithWatchdog runs the agent in streaming mode, touching the
+// provided touchFn on every stream event (token, tool progress, etc.).
+// It collects the full result and returns it in the same shape as Generate.
+// This enables activity-based watchdog monitoring for subagent execution.
+func (s *SpawnAdapter) GenerateWithWatchdog(ctx context.Context, cfg tools.SpawnRunConfig, touchFn func()) (*tools.SpawnResult, error) {
+	rc := runConfigFromSpawnRunConfig(cfg)
 
 	// Use Stream instead of Generate to get per-token/per-tool activity signals.
 	eventCh := s.agent.Stream(ctx, rc)

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/memohai/memoh/internal/agent/background"
 	"github.com/memohai/memoh/internal/agent/event"
+	"github.com/memohai/memoh/internal/contextfrag"
 )
 
 // SessionContext carries request-scoped identity and routing information.
@@ -72,27 +73,33 @@ type InjectMessage struct {
 
 // RunConfig holds everything needed for a single agent invocation.
 type RunConfig struct {
-	Model                 *sdk.Model
-	ReasoningEffort       string
-	ReasoningActive       bool
-	ReasoningDisabled     bool
-	ReasoningAdaptive     bool
-	ReasoningOffEffort    string
-	ChatCompletionsCompat string
-	Messages              []sdk.Message
-	Query                 string
-	System                string
-	SessionType           string
-	LiveToolStream        bool
-	CanRequestUserInput   bool
-	SupportsImageInput    bool
-	SupportsToolCall      bool
-	InlineImages          []sdk.ImagePart
-	Identity              SessionContext
-	Bot                   BotInfo
-	Skills                []SkillEntry
-	LoopDetection         LoopDetectionConfig
-	Retry                 RetryConfig
+	Model                    *sdk.Model
+	ReasoningEffort          string
+	ReasoningActive          bool
+	ReasoningDisabled        bool
+	ReasoningAdaptive        bool
+	ReasoningOffEffort       string
+	ChatCompletionsCompat    string
+	Messages                 []sdk.Message
+	Query                    string
+	System                   string
+	ContextFrags             []contextfrag.ContextFrag
+	ContextManifest          contextfrag.Manifest
+	ContextScope             contextfrag.Scope
+	ContextQueryMaterialized bool
+	ContextToolUsage         string
+	ContextDynamicMutators   []contextfrag.DynamicMutator
+	SessionType              string
+	LiveToolStream           bool
+	CanRequestUserInput      bool
+	SupportsImageInput       bool
+	SupportsToolCall         bool
+	InlineImages             []sdk.ImagePart
+	Identity                 SessionContext
+	Bot                      BotInfo
+	Skills                   []SkillEntry
+	LoopDetection            LoopDetectionConfig
+	Retry                    RetryConfig
 
 	// PromptCacheTTL controls prompt caching for this run. Empty or
 	// unrecognized values default to 5m. Use "1h" for the long-cache tier

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -1030,6 +1030,8 @@ startStream:
 		ReplySender:               inboundReplySender(msg.Message.Reply),
 		ReplyPreview:              inboundReplyPreview(msg.Message.Reply),
 		ReplyAttachments:          replyAttachments,
+		MentionsBot:               metadataBool(msg.Metadata, "is_mentioned"),
+		RepliesToBot:              metadataBool(msg.Metadata, "is_reply_to_bot"),
 		ForwardMessageID:          inboundForwardMessageID(msg.Message.Forward),
 		ForwardFromUserID:         inboundForwardFromUserID(msg.Message.Forward),
 		ForwardFromConversationID: inboundForwardFromConversationID(msg.Message.Forward),

--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -1601,6 +1601,9 @@ func TestChannelInboundProcessorGroupMentionTriggersReply(t *testing.T) {
 	if gateway.gotReq.UserMessagePersisted {
 		t.Fatalf("expected UserMessagePersisted=false: user message persistence is deferred to storeRound")
 	}
+	if !gateway.gotReq.MentionsBot {
+		t.Fatalf("expected is_mentioned metadata to be carried into ChatRequest")
+	}
 }
 
 type failingOpenStreamSender struct {

--- a/internal/contextfrag/compile.go
+++ b/internal/contextfrag/compile.go
@@ -38,11 +38,17 @@ func Compile(input CompileInput) AssembledContext {
 
 	explicit := preserveExplicit(input.Existing)
 	frags := make([]ContextFrag, 0, len(explicit)+len(input.Messages)+4)
+	derivedMessageIDs := make(map[string]struct{}, len(input.Messages))
+	for i := range input.Messages {
+		derivedMessageIDs[fmt.Sprintf("message.%03d", i)] = struct{}{}
+	}
 	messageOverrides := make(map[string]ContextFrag, len(explicit))
 	for _, frag := range explicit {
 		if id := strings.TrimSpace(frag.ID); id != "" && overridesDerivedMessage(frag) {
-			messageOverrides[id] = frag
-			continue
+			if _, ok := derivedMessageIDs[id]; ok {
+				messageOverrides[id] = frag
+				continue
+			}
 		}
 		frags = append(frags, frag)
 	}

--- a/internal/contextfrag/compile.go
+++ b/internal/contextfrag/compile.go
@@ -78,7 +78,7 @@ func Compile(input CompileInput) AssembledContext {
 		}
 	}
 
-	frags, warnings := normalizeContextRefs(frags)
+	frags = normalizeContextRefs(frags)
 	assembled := Render(frags)
 	assembled.Frags = frags
 	assembled.Manifest = BuildManifest(frags)
@@ -87,7 +87,6 @@ func Compile(input CompileInput) AssembledContext {
 		assembled.Manifest.View = ViewRunConfigPreProvider
 	}
 	assembled.Manifest.DynamicMutators = normalizeDynamicMutators(input.DynamicMutators)
-	assembled.Manifest.ValidationWarnings = append(assembled.Manifest.ValidationWarnings, warnings...)
 	return assembled
 }
 
@@ -364,24 +363,16 @@ func normalizeScope(scope Scope) Scope {
 	return scope
 }
 
-func normalizeContextRefs(frags []ContextFrag) ([]ContextFrag, []ValidationWarning) {
+func normalizeContextRefs(frags []ContextFrag) []ContextFrag {
 	if len(frags) == 0 {
-		return nil, nil
+		return nil
 	}
 	out := make([]ContextFrag, 0, len(frags))
-	var warnings []ValidationWarning
 	for _, frag := range frags {
 		normalized := WithContextRef(frag, frag.Ref)
-		if err := ValidateContextRef(normalized.Ref); err != nil {
-			warnings = append(warnings, ValidationWarning{
-				Code:    "invalid_context_ref",
-				Message: err.Error(),
-				Ref:     normalized.Ref,
-			})
-		}
 		out = append(out, normalized)
 	}
-	return out, warnings
+	return out
 }
 
 func normalizeDynamicMutators(mutators []DynamicMutator) []DynamicMutator {

--- a/internal/contextfrag/compile.go
+++ b/internal/contextfrag/compile.go
@@ -36,13 +36,27 @@ func Compile(input CompileInput) AssembledContext {
 	}
 	scope := normalizeScope(input.Scope)
 
-	frags := preserveExplicit(input.Existing)
+	explicit := preserveExplicit(input.Existing)
+	frags := make([]ContextFrag, 0, len(explicit)+len(input.Messages)+4)
+	messageOverrides := make(map[string]ContextFrag, len(explicit))
+	for _, frag := range explicit {
+		if id := strings.TrimSpace(frag.ID); id != "" && overridesDerivedMessage(frag) {
+			messageOverrides[id] = frag
+			continue
+		}
+		frags = append(frags, frag)
+	}
 	if strings.TrimSpace(input.System) != "" {
 		frags = append(frags, systemFrags(input.System, strings.TrimSpace(input.ToolUsage), scope, source)...)
 	}
 	for i, msg := range input.Messages {
+		id := fmt.Sprintf("message.%03d", i)
+		if frag, ok := messageOverrides[id]; ok {
+			frags = append(frags, frag)
+			continue
+		}
 		frags = append(frags, MessageFrag(MessageFragInput{
-			ID:         fmt.Sprintf("message.%03d", i),
+			ID:         id,
 			Message:    msg,
 			Kind:       kindForMessage(msg),
 			Slot:       SlotHistory,
@@ -305,6 +319,18 @@ func preserveExplicit(frags []ContextFrag) []ContextFrag {
 		out = append(out, frag)
 	}
 	return out
+}
+
+func overridesDerivedMessage(frag ContextFrag) bool {
+	if frag.Slot != SlotHistory {
+		return false
+	}
+	for _, part := range frag.Parts {
+		if part.Type == PartSDKMessage && partMessage(part) != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func kindForMessage(msg sdk.Message) Kind {

--- a/internal/contextfrag/compile.go
+++ b/internal/contextfrag/compile.go
@@ -1,0 +1,496 @@
+package contextfrag
+
+import (
+	"fmt"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+const (
+	CollectorRunConfigFields = "run_config_fields"
+	SourceRunConfig          = "run_config"
+	SourceAgentToolUsage     = "agent_tool_usage"
+)
+
+// CompileInput contains the legacy RunConfig fields used as phase-1 sources.
+type CompileInput struct {
+	Source          string
+	Scope           Scope
+	System          string
+	Messages        []sdk.Message
+	Query           string
+	InlineImages    []sdk.ImagePart
+	ToolUsage       string
+	View            ManifestView
+	DynamicMutators []DynamicMutator
+	Existing        []ContextFrag
+}
+
+// Compile builds typed fragments from the current SDK-shaped fields, preserving
+// explicit non-derived fragments such as tool usage.
+func Compile(input CompileInput) AssembledContext {
+	source := strings.TrimSpace(input.Source)
+	if source == "" {
+		source = SourceRunConfig
+	}
+	scope := normalizeScope(input.Scope)
+
+	frags := preserveExplicit(input.Existing)
+	if strings.TrimSpace(input.System) != "" {
+		frags = append(frags, systemFrags(input.System, strings.TrimSpace(input.ToolUsage), scope, source)...)
+	}
+	for i, msg := range input.Messages {
+		frags = append(frags, MessageFrag(MessageFragInput{
+			ID:         fmt.Sprintf("message.%03d", i),
+			Message:    msg,
+			Kind:       kindForMessage(msg),
+			Slot:       SlotHistory,
+			Priority:   priorityForMessage(msg),
+			CacheClass: cacheForMessage(msg),
+			Trust:      trustForMessage(msg),
+			Scope:      scope,
+			Source:     source,
+			Collector:  CollectorRunConfigFields,
+			Index:      i,
+		}))
+	}
+	if strings.TrimSpace(input.Query) != "" {
+		frags = append(frags, TextFrag(TextFragInput{
+			ID:         "current_user.message",
+			Kind:       KindCurrentUserMessage,
+			Role:       sdk.MessageRoleUser,
+			Slot:       SlotCurrentUser,
+			Text:       strings.TrimSpace(input.Query),
+			Priority:   90,
+			CacheClass: CacheNever,
+			Trust:      TrustUser,
+			Scope:      scope,
+			Source:     source,
+			Collector:  CollectorRunConfigFields,
+			Render:     RenderPolicy{Format: RenderSDKMessage},
+		}))
+	}
+	if len(input.InlineImages) > 0 {
+		imageFrag := ImageFrag("current_user.images", input.InlineImages, scope, source)
+		if len(imageFrag.Parts) > 0 {
+			frags = append(frags, imageFrag)
+		}
+	}
+
+	assembled := Render(frags)
+	assembled.Frags = frags
+	assembled.Manifest = BuildManifest(frags)
+	assembled.Manifest.View = input.View
+	if assembled.Manifest.View == "" {
+		assembled.Manifest.View = ViewRunConfigPreProvider
+	}
+	assembled.Manifest.DynamicMutators = normalizeDynamicMutators(input.DynamicMutators)
+	return assembled
+}
+
+func systemFrags(system string, toolUsage string, scope Scope, source string) []ContextFrag {
+	system = strings.TrimSpace(system)
+	if system == "" {
+		return nil
+	}
+	toolStart := -1
+	if toolUsage != "" {
+		toolStart = strings.Index(system, toolUsage)
+	}
+	if toolStart < 0 {
+		return []ContextFrag{systemTextFrag("system.prompt", KindSystemPrompt, system, 20, CacheStable, scope, source, 0)}
+	}
+
+	var frags []ContextFrag
+	if prefix := strings.TrimSpace(system[:toolStart]); prefix != "" {
+		frags = append(frags, systemTextFrag("system.prompt", KindSystemPrompt, prefix, 20, CacheStable, scope, source, 0))
+	}
+
+	rest := strings.TrimSpace(system[toolStart:])
+	toolEnd := len(toolUsage)
+	toolUsageText := strings.TrimSpace(rest[:toolEnd])
+	if toolUsageText != "" {
+		frags = append(frags, systemTextFrag("system.tool_usage", KindToolUsage, toolUsageText, 45, CacheStable, scope, SourceAgentToolUsage, 1))
+	}
+	if suffix := strings.TrimSpace(rest[toolEnd:]); suffix != "" {
+		kind := KindSystemPrompt
+		id := "system.prompt.tail"
+		if strings.HasPrefix(suffix, "## Workspace instruction files") {
+			kind = KindWorkspaceInstruction
+			id = "system.workspace_instructions"
+		}
+		frags = append(frags, systemTextFrag(id, kind, suffix, 50, CacheStable, scope, source, 2))
+	}
+	return frags
+}
+
+func systemTextFrag(id string, kind Kind, text string, priority int, cacheClass CacheClass, scope Scope, source string, index int) ContextFrag {
+	return TextFrag(TextFragInput{
+		ID:         id,
+		Kind:       kind,
+		Role:       sdk.MessageRoleSystem,
+		Slot:       SlotSystem,
+		Text:       text,
+		Priority:   priority,
+		CacheClass: cacheClass,
+		Trust:      TrustSystem,
+		Scope:      scope,
+		Source:     source,
+		Collector:  CollectorRunConfigFields,
+		Index:      index,
+		Render:     RenderPolicy{Format: RenderMarkdown},
+	})
+}
+
+// TextFragInput describes a text fragment to construct.
+type TextFragInput struct {
+	ID         string
+	Kind       Kind
+	Role       sdk.MessageRole
+	Slot       Slot
+	Text       string
+	Priority   int
+	CacheClass CacheClass
+	Trust      TrustLevel
+	Scope      Scope
+	Source     string
+	SourceID   string
+	Collector  string
+	Index      int
+	Render     RenderPolicy
+	Budget     BudgetPolicy
+}
+
+// TextFrag creates a text-backed fragment.
+func TextFrag(input TextFragInput) ContextFrag {
+	return ContextFrag{
+		ID:         strings.TrimSpace(input.ID),
+		Kind:       input.Kind,
+		Role:       input.Role,
+		Slot:       input.Slot,
+		Priority:   input.Priority,
+		CacheClass: input.CacheClass,
+		Trust:      input.Trust,
+		Scope:      normalizeScope(input.Scope),
+		Budget:     input.Budget,
+		Render:     input.Render,
+		Provenance: Provenance{
+			Source:    strings.TrimSpace(input.Source),
+			SourceID:  strings.TrimSpace(input.SourceID),
+			Collector: strings.TrimSpace(input.Collector),
+			Index:     input.Index,
+		},
+		Parts: []Part{{
+			Type: PartText,
+			Text: strings.TrimSpace(input.Text),
+		}},
+	}
+}
+
+// MessageFragInput describes an SDK message fragment.
+type MessageFragInput struct {
+	ID         string
+	Message    sdk.Message
+	Kind       Kind
+	Slot       Slot
+	Priority   int
+	CacheClass CacheClass
+	Trust      TrustLevel
+	Scope      Scope
+	Source     string
+	SourceID   string
+	Collector  string
+	Index      int
+}
+
+// MessageFrag creates a message-backed fragment.
+func MessageFrag(input MessageFragInput) ContextFrag {
+	msg := cloneMessage(input.Message)
+	return ContextFrag{
+		ID:         strings.TrimSpace(input.ID),
+		Kind:       input.Kind,
+		Role:       input.Message.Role,
+		Slot:       input.Slot,
+		Priority:   input.Priority,
+		CacheClass: input.CacheClass,
+		Trust:      input.Trust,
+		Scope:      normalizeScope(input.Scope),
+		Render:     RenderPolicy{Format: RenderSDKMessage},
+		Provenance: Provenance{
+			Source:    strings.TrimSpace(input.Source),
+			SourceID:  strings.TrimSpace(input.SourceID),
+			Collector: strings.TrimSpace(input.Collector),
+			Index:     input.Index,
+		},
+		Parts: []Part{{
+			Type:       PartSDKMessage,
+			SDKMessage: &msg,
+		}},
+	}
+}
+
+// ImageFrag creates one fragment for native image parts.
+func ImageFrag(id string, images []sdk.ImagePart, scope Scope, source string) ContextFrag {
+	parts := make([]Part, 0, len(images))
+	for _, image := range images {
+		if strings.TrimSpace(image.Image) == "" {
+			continue
+		}
+		img := image
+		parts = append(parts, Part{
+			Type: PartImage,
+			Image: ImageRef{
+				MediaType: strings.TrimSpace(image.MediaType),
+				Source:    "inline",
+			},
+			SDKImage: &img,
+		})
+	}
+	return ContextFrag{
+		ID:         strings.TrimSpace(id),
+		Kind:       KindNativeImage,
+		Role:       sdk.MessageRoleUser,
+		Slot:       SlotCurrentUser,
+		Priority:   90,
+		CacheClass: CacheNever,
+		Trust:      TrustUser,
+		Scope:      normalizeScope(scope),
+		Render:     RenderPolicy{Format: RenderNativePart},
+		Provenance: Provenance{
+			Source:    strings.TrimSpace(source),
+			Collector: CollectorRunConfigFields,
+		},
+		Parts: parts,
+	}
+}
+
+// Upsert returns frags with next inserted or replacing an existing fragment
+// with the same ID.
+func Upsert(frags []ContextFrag, next ContextFrag) []ContextFrag {
+	next.ID = strings.TrimSpace(next.ID)
+	if next.ID == "" {
+		return frags
+	}
+	out := make([]ContextFrag, 0, len(frags)+1)
+	replaced := false
+	for _, frag := range frags {
+		if frag.ID == next.ID {
+			if !replaced {
+				out = append(out, next)
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, frag)
+	}
+	if !replaced {
+		out = append(out, next)
+	}
+	return out
+}
+
+// BuildManifest creates a non-sensitive summary from fragments.
+func BuildManifest(frags []ContextFrag) Manifest {
+	manifest := Manifest{Version: 1}
+	manifest.Items = make([]ManifestItem, 0, len(frags))
+	for _, frag := range frags {
+		item := ManifestItem{
+			ID:         frag.ID,
+			Kind:       frag.Kind,
+			Slot:       frag.Slot,
+			Role:       frag.Role,
+			Priority:   frag.Priority,
+			CacheClass: frag.CacheClass,
+			Trust:      frag.Trust,
+			Source:     frag.Provenance.Source,
+			SourceID:   frag.Provenance.SourceID,
+			Collector:  frag.Provenance.Collector,
+			Scope:      frag.Scope,
+		}
+		for _, part := range frag.Parts {
+			item.PartTypes = append(item.PartTypes, part.Type)
+			switch part.Type {
+			case PartText:
+				item.TextBytes += len(part.Text)
+			case PartSDKMessage:
+				item.TextBytes += messageTextBytes(part.SDKMessage)
+				item.ImageCount += messageImageCount(part.SDKMessage)
+				manifest.Counts.Messages++
+			case PartImage:
+				item.ImageCount++
+			}
+		}
+		manifest.Counts.TextBytes += item.TextBytes
+		manifest.Counts.Images += item.ImageCount
+		manifest.Items = append(manifest.Items, item)
+	}
+	manifest.Counts.Fragments = len(frags)
+	return manifest
+}
+
+// Render builds the legacy SDK-shaped view from fragments.
+func Render(frags []ContextFrag) AssembledContext {
+	var out AssembledContext
+	for _, frag := range frags {
+		switch frag.Slot {
+		case SlotSystem:
+			for _, part := range frag.Parts {
+				if part.Type != PartText || strings.TrimSpace(part.Text) == "" {
+					continue
+				}
+				if out.System != "" {
+					out.System += "\n\n"
+				}
+				out.System += strings.TrimSpace(part.Text)
+			}
+		case SlotCurrentUser:
+			for _, part := range frag.Parts {
+				switch part.Type {
+				case PartText:
+					if strings.TrimSpace(part.Text) != "" {
+						out.Query = strings.TrimSpace(part.Text)
+					}
+				case PartImage:
+					if part.SDKImage != nil && strings.TrimSpace(part.SDKImage.Image) != "" {
+						out.InlineImages = append(out.InlineImages, *part.SDKImage)
+					}
+				case PartSDKMessage:
+					if part.SDKMessage != nil {
+						out.Messages = append(out.Messages, cloneMessage(*part.SDKMessage))
+					}
+				}
+			}
+		default:
+			for _, part := range frag.Parts {
+				if part.Type == PartSDKMessage && part.SDKMessage != nil {
+					out.Messages = append(out.Messages, cloneMessage(*part.SDKMessage))
+				}
+			}
+		}
+	}
+	return out
+}
+
+func preserveExplicit(frags []ContextFrag) []ContextFrag {
+	if len(frags) == 0 {
+		return nil
+	}
+	out := make([]ContextFrag, 0, len(frags))
+	for _, frag := range frags {
+		if frag.Provenance.Collector == CollectorRunConfigFields {
+			continue
+		}
+		out = append(out, frag)
+	}
+	return out
+}
+
+func kindForMessage(msg sdk.Message) Kind {
+	switch msg.Role {
+	case sdk.MessageRoleSystem:
+		return KindSystemPolicy
+	case sdk.MessageRoleUser:
+		return KindConversationEvent
+	case sdk.MessageRoleAssistant:
+		return KindConversationEvent
+	case sdk.MessageRoleTool:
+		return KindConversationEvent
+	default:
+		return KindConversationEvent
+	}
+}
+
+func priorityForMessage(msg sdk.Message) int {
+	switch msg.Role {
+	case sdk.MessageRoleSystem:
+		return 30
+	case sdk.MessageRoleTool:
+		return 55
+	default:
+		return 70
+	}
+}
+
+func cacheForMessage(msg sdk.Message) CacheClass {
+	switch msg.Role {
+	case sdk.MessageRoleSystem:
+		return CacheDynamic
+	default:
+		return CacheNever
+	}
+}
+
+func trustForMessage(msg sdk.Message) TrustLevel {
+	switch msg.Role {
+	case sdk.MessageRoleSystem:
+		return TrustSystem
+	case sdk.MessageRoleAssistant, sdk.MessageRoleTool:
+		return TrustWorkspace
+	default:
+		return TrustExternal
+	}
+}
+
+func normalizeScope(scope Scope) Scope {
+	if len(scope.Attention) == 0 {
+		scope.Attention = nil
+	}
+	if len(scope.Metadata) == 0 {
+		scope.Metadata = nil
+	}
+	return scope
+}
+
+func cloneMessage(msg sdk.Message) sdk.Message {
+	out := msg
+	if len(msg.Content) > 0 {
+		out.Content = append([]sdk.MessagePart(nil), msg.Content...)
+	}
+	return out
+}
+
+func messageTextBytes(msg *sdk.Message) int {
+	if msg == nil {
+		return 0
+	}
+	total := 0
+	for _, part := range msg.Content {
+		switch p := part.(type) {
+		case sdk.TextPart:
+			total += len(p.Text)
+		case sdk.ReasoningPart:
+			total += len(p.Text)
+		}
+	}
+	return total
+}
+
+func messageImageCount(msg *sdk.Message) int {
+	if msg == nil {
+		return 0
+	}
+	total := 0
+	for _, part := range msg.Content {
+		if _, ok := part.(sdk.ImagePart); ok {
+			total++
+		}
+	}
+	return total
+}
+
+func normalizeDynamicMutators(mutators []DynamicMutator) []DynamicMutator {
+	if len(mutators) == 0 {
+		return nil
+	}
+	out := make([]DynamicMutator, 0, len(mutators))
+	seen := make(map[DynamicMutator]bool, len(mutators))
+	for _, mutator := range mutators {
+		if mutator == "" || seen[mutator] {
+			continue
+		}
+		seen[mutator] = true
+		out = append(out, mutator)
+	}
+	return out
+}

--- a/internal/contextfrag/compile.go
+++ b/internal/contextfrag/compile.go
@@ -78,6 +78,7 @@ func Compile(input CompileInput) AssembledContext {
 		}
 	}
 
+	frags, warnings := normalizeContextRefs(frags)
 	assembled := Render(frags)
 	assembled.Frags = frags
 	assembled.Manifest = BuildManifest(frags)
@@ -86,6 +87,7 @@ func Compile(input CompileInput) AssembledContext {
 		assembled.Manifest.View = ViewRunConfigPreProvider
 	}
 	assembled.Manifest.DynamicMutators = normalizeDynamicMutators(input.DynamicMutators)
+	assembled.Manifest.ValidationWarnings = append(assembled.Manifest.ValidationWarnings, warnings...)
 	return assembled
 }
 
@@ -225,6 +227,7 @@ func MessageFrag(input MessageFragInput) ContextFrag {
 		},
 		Parts: []Part{{
 			Type:       PartSDKMessage,
+			Message:    &msg,
 			SDKMessage: &msg,
 		}},
 	}
@@ -244,7 +247,8 @@ func ImageFrag(id string, images []sdk.ImagePart, scope Scope, source string) Co
 				MediaType: strings.TrimSpace(image.MediaType),
 				Source:    "inline",
 			},
-			SDKImage: &img,
+			ImagePart: &img,
+			SDKImage:  &img,
 		})
 	}
 	return ContextFrag{
@@ -286,88 +290,6 @@ func Upsert(frags []ContextFrag, next ContextFrag) []ContextFrag {
 	}
 	if !replaced {
 		out = append(out, next)
-	}
-	return out
-}
-
-// BuildManifest creates a non-sensitive summary from fragments.
-func BuildManifest(frags []ContextFrag) Manifest {
-	manifest := Manifest{Version: 1}
-	manifest.Items = make([]ManifestItem, 0, len(frags))
-	for _, frag := range frags {
-		item := ManifestItem{
-			ID:         frag.ID,
-			Kind:       frag.Kind,
-			Slot:       frag.Slot,
-			Role:       frag.Role,
-			Priority:   frag.Priority,
-			CacheClass: frag.CacheClass,
-			Trust:      frag.Trust,
-			Source:     frag.Provenance.Source,
-			SourceID:   frag.Provenance.SourceID,
-			Collector:  frag.Provenance.Collector,
-			Scope:      frag.Scope,
-		}
-		for _, part := range frag.Parts {
-			item.PartTypes = append(item.PartTypes, part.Type)
-			switch part.Type {
-			case PartText:
-				item.TextBytes += len(part.Text)
-			case PartSDKMessage:
-				item.TextBytes += messageTextBytes(part.SDKMessage)
-				item.ImageCount += messageImageCount(part.SDKMessage)
-				manifest.Counts.Messages++
-			case PartImage:
-				item.ImageCount++
-			}
-		}
-		manifest.Counts.TextBytes += item.TextBytes
-		manifest.Counts.Images += item.ImageCount
-		manifest.Items = append(manifest.Items, item)
-	}
-	manifest.Counts.Fragments = len(frags)
-	return manifest
-}
-
-// Render builds the legacy SDK-shaped view from fragments.
-func Render(frags []ContextFrag) AssembledContext {
-	var out AssembledContext
-	for _, frag := range frags {
-		switch frag.Slot {
-		case SlotSystem:
-			for _, part := range frag.Parts {
-				if part.Type != PartText || strings.TrimSpace(part.Text) == "" {
-					continue
-				}
-				if out.System != "" {
-					out.System += "\n\n"
-				}
-				out.System += strings.TrimSpace(part.Text)
-			}
-		case SlotCurrentUser:
-			for _, part := range frag.Parts {
-				switch part.Type {
-				case PartText:
-					if strings.TrimSpace(part.Text) != "" {
-						out.Query = strings.TrimSpace(part.Text)
-					}
-				case PartImage:
-					if part.SDKImage != nil && strings.TrimSpace(part.SDKImage.Image) != "" {
-						out.InlineImages = append(out.InlineImages, *part.SDKImage)
-					}
-				case PartSDKMessage:
-					if part.SDKMessage != nil {
-						out.Messages = append(out.Messages, cloneMessage(*part.SDKMessage))
-					}
-				}
-			}
-		default:
-			for _, part := range frag.Parts {
-				if part.Type == PartSDKMessage && part.SDKMessage != nil {
-					out.Messages = append(out.Messages, cloneMessage(*part.SDKMessage))
-				}
-			}
-		}
 	}
 	return out
 }
@@ -442,41 +364,24 @@ func normalizeScope(scope Scope) Scope {
 	return scope
 }
 
-func cloneMessage(msg sdk.Message) sdk.Message {
-	out := msg
-	if len(msg.Content) > 0 {
-		out.Content = append([]sdk.MessagePart(nil), msg.Content...)
+func normalizeContextRefs(frags []ContextFrag) ([]ContextFrag, []ValidationWarning) {
+	if len(frags) == 0 {
+		return nil, nil
 	}
-	return out
-}
-
-func messageTextBytes(msg *sdk.Message) int {
-	if msg == nil {
-		return 0
-	}
-	total := 0
-	for _, part := range msg.Content {
-		switch p := part.(type) {
-		case sdk.TextPart:
-			total += len(p.Text)
-		case sdk.ReasoningPart:
-			total += len(p.Text)
+	out := make([]ContextFrag, 0, len(frags))
+	var warnings []ValidationWarning
+	for _, frag := range frags {
+		normalized := WithContextRef(frag, frag.Ref)
+		if err := ValidateContextRef(normalized.Ref); err != nil {
+			warnings = append(warnings, ValidationWarning{
+				Code:    "invalid_context_ref",
+				Message: err.Error(),
+				Ref:     normalized.Ref,
+			})
 		}
+		out = append(out, normalized)
 	}
-	return total
-}
-
-func messageImageCount(msg *sdk.Message) int {
-	if msg == nil {
-		return 0
-	}
-	total := 0
-	for _, part := range msg.Content {
-		if _, ok := part.(sdk.ImagePart); ok {
-			total++
-		}
-	}
-	return total
+	return out, warnings
 }
 
 func normalizeDynamicMutators(mutators []DynamicMutator) []DynamicMutator {

--- a/internal/contextfrag/compile_contract_test.go
+++ b/internal/contextfrag/compile_contract_test.go
@@ -257,3 +257,37 @@ func TestCompilePreservesExplicitMessageFragAtSourcePosition(t *testing.T) {
 		t.Fatalf("explicit message ref was not preserved: %#v", assembled.Manifest.Items[1].Ref)
 	}
 }
+
+func TestCompilePreservesUnmatchedExplicitMessageFrag(t *testing.T) {
+	t.Parallel()
+
+	summary := sdk.UserMessage("<summary>\ncondensed\n</summary>")
+	summaryRef := ContextRef{Namespace: "compaction_log", ID: "log-1", Schema: SchemaContextRef, Durability: RefDurable}
+	summaryFrag := MessageFrag(MessageFragInput{
+		ID:      "summary.log-1",
+		Message: summary,
+		Kind:    KindConversationSummary,
+		Slot:    SlotHistory,
+		Source:  "compaction_log",
+	})
+	summaryFrag.Ref = summaryRef
+
+	assembled := Compile(CompileInput{
+		Source:   SourceRunConfig,
+		Messages: []sdk.Message{sdk.UserMessage("after summary")},
+		Existing: []ContextFrag{summaryFrag},
+	})
+
+	if len(assembled.Messages) != 2 {
+		t.Fatalf("messages = %d, want explicit summary plus derived message: %#v", len(assembled.Messages), assembled.Messages)
+	}
+	if len(assembled.Manifest.Items) != 2 {
+		t.Fatalf("manifest items = %d, want explicit summary plus derived message: %#v", len(assembled.Manifest.Items), assembled.Manifest.Items)
+	}
+	if assembled.Manifest.Items[0].Kind != KindConversationSummary {
+		t.Fatalf("first manifest item kind = %q, want %q", assembled.Manifest.Items[0].Kind, KindConversationSummary)
+	}
+	if !assembled.Manifest.Items[0].Ref.EqualIdentity(summaryRef) {
+		t.Fatalf("unmatched explicit message ref was not preserved: %#v", assembled.Manifest.Items[0].Ref)
+	}
+}

--- a/internal/contextfrag/compile_contract_test.go
+++ b/internal/contextfrag/compile_contract_test.go
@@ -1,0 +1,221 @@
+package contextfrag
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestCompileAddsRefsAndManifestTraceWithoutChangingRenderedLegacyView(t *testing.T) {
+	t.Parallel()
+
+	system := "base system"
+	messages := []sdk.Message{sdk.UserMessage("history")}
+	images := []sdk.ImagePart{{Image: "data:image/png;base64,abc", MediaType: "image/png"}}
+
+	got := Compile(CompileInput{
+		Source:       "test",
+		System:       system,
+		Messages:     messages,
+		Query:        "current",
+		InlineImages: images,
+	})
+
+	if got.System != system || got.Query != "current" || len(got.Messages) != 1 || len(got.InlineImages) != 1 {
+		t.Fatalf("rendered legacy view changed: system=%q query=%q messages=%d images=%d", got.System, got.Query, len(got.Messages), len(got.InlineImages))
+	}
+	for _, frag := range got.Frags {
+		if err := ValidateContextRef(frag.Ref); err != nil {
+			t.Fatalf("compiled frag %q has invalid ref %#v: %v", frag.ID, frag.Ref, err)
+		}
+		if frag.Ref.HashScope != HashScopeCanonicalFragment || frag.Ref.ContentHash == "" {
+			t.Fatalf("compiled frag %q missing canonical hash ref: %#v", frag.ID, frag.Ref)
+		}
+	}
+	if len(got.Manifest.RenderedOutputs) == 0 {
+		t.Fatal("manifest should explain rendered output refs")
+	}
+	if !manifestHasWarning(got.Manifest, "non_durable_context_ref") {
+		t.Fatalf("source-less legacy refs should produce synthetic warning: %#v", got.Manifest.ValidationWarnings)
+	}
+}
+
+func TestContextRefEmptyDurabilityMatchesDurableIdentity(t *testing.T) {
+	t.Parallel()
+
+	legacy := ContextRef{Namespace: "history", ID: "row-1", Schema: SchemaContextRef}
+	durable := legacy
+	durable.Durability = RefDurable
+
+	if !legacy.EqualIdentity(durable) {
+		t.Fatalf("empty durability should match durable identity: legacy=%#v durable=%#v", legacy, durable)
+	}
+	if legacy.StableKey() != durable.StableKey() {
+		t.Fatalf("empty durability stable key = %q, durable = %q", legacy.StableKey(), durable.StableKey())
+	}
+	if legacy.StableKey() != "history:row-1#context_ref" {
+		t.Fatalf("durable stable key should preserve legacy shape, got %q", legacy.StableKey())
+	}
+	if !legacy.IsDurable() {
+		t.Fatalf("empty durability should default to durable for compatibility: %#v", legacy)
+	}
+}
+
+func TestBuildManifestWarnsForDirectNonDurableRefs(t *testing.T) {
+	t.Parallel()
+
+	synthetic := TextFrag(TextFragInput{
+		ID:   "history.synthetic",
+		Kind: KindConversationEvent,
+		Slot: SlotHistory,
+		Text: "source-less",
+	})
+	debug := TextFrag(TextFragInput{
+		ID:   "history.debug",
+		Kind: KindConversationEvent,
+		Slot: SlotHistory,
+		Text: "debug",
+	})
+	debug.Ref = ContextRef{
+		Namespace:  "test",
+		ID:         "debug-ref",
+		Schema:     SchemaContextRef,
+		Durability: RefDebug,
+	}
+
+	manifest := BuildManifest([]ContextFrag{synthetic, debug})
+	if countManifestWarnings(manifest, "non_durable_context_ref") != 2 {
+		t.Fatalf("BuildManifest should warn for direct synthetic/debug refs: %#v", manifest.ValidationWarnings)
+	}
+}
+
+func TestCompileUsesStableContentAddressedRefsWhenSourceIDIsMissing(t *testing.T) {
+	t.Parallel()
+
+	first := Compile(CompileInput{
+		Source:   "test",
+		Messages: []sdk.Message{sdk.UserMessage("target")},
+	})
+	second := Compile(CompileInput{
+		Source:   "test",
+		Messages: []sdk.Message{sdk.UserMessage("prefix"), sdk.UserMessage("target")},
+	})
+
+	firstRef, ok := refForRenderedMessageText(first.Frags, "target")
+	if !ok {
+		t.Fatalf("missing target ref in first compile: %#v", first.Manifest.Items)
+	}
+	secondRef, ok := refForRenderedMessageText(second.Frags, "target")
+	if !ok {
+		t.Fatalf("missing target ref in second compile: %#v", second.Manifest.Items)
+	}
+	if firstRef.ID != secondRef.ID {
+		t.Fatalf("source-less legacy message ref drifted with position: first=%#v second=%#v", firstRef, secondRef)
+	}
+	if firstRef.Durability != RefSynthetic || secondRef.Durability != RefSynthetic {
+		t.Fatalf("source-less fallback refs must be marked synthetic: first=%#v second=%#v", firstRef, secondRef)
+	}
+}
+
+func TestCompileMarksDuplicateSourceLessRefsSynthetic(t *testing.T) {
+	t.Parallel()
+
+	got := Compile(CompileInput{
+		Source: "test",
+		Messages: []sdk.Message{
+			sdk.UserMessage("same"),
+			sdk.UserMessage("same"),
+		},
+	})
+
+	var refs []ContextRef
+	for _, frag := range got.Frags {
+		if frag.Slot == SlotHistory {
+			refs = append(refs, frag.Ref)
+		}
+	}
+	if len(refs) != 2 {
+		t.Fatalf("history refs = %d, want 2: %#v", len(refs), got.Manifest.Items)
+	}
+	if refs[0].ID != refs[1].ID {
+		t.Fatalf("duplicate source-less content should share content-addressed ID for trace: %#v", refs)
+	}
+	for _, ref := range refs {
+		if ref.Durability != RefSynthetic || ref.IsDurable() {
+			t.Fatalf("duplicate source-less refs must not be treated as durable: %#v", ref)
+		}
+	}
+	if !manifestHasWarning(got.Manifest, "non_durable_context_ref") {
+		t.Fatalf("manifest missing synthetic warning for duplicate source-less refs: %#v", got.Manifest.ValidationWarnings)
+	}
+	if countManifestWarnings(got.Manifest, "non_durable_context_ref") != 2 {
+		t.Fatalf("manifest should warn for each non-durable ref: %#v", got.Manifest.ValidationWarnings)
+	}
+}
+
+func TestCompileWarnsWhenSourceLessRefsDependOnScope(t *testing.T) {
+	t.Parallel()
+
+	first := Compile(CompileInput{
+		Source:   "test",
+		Scope:    Scope{CurrentMessageID: "msg-1"},
+		Messages: []sdk.Message{sdk.UserMessage("same")},
+	})
+	second := Compile(CompileInput{
+		Source:   "test",
+		Scope:    Scope{CurrentMessageID: "msg-2"},
+		Messages: []sdk.Message{sdk.UserMessage("same")},
+	})
+
+	firstRef, ok := refForRenderedMessageText(first.Frags, "same")
+	if !ok {
+		t.Fatalf("missing first ref: %#v", first.Manifest.Items)
+	}
+	secondRef, ok := refForRenderedMessageText(second.Frags, "same")
+	if !ok {
+		t.Fatalf("missing second ref: %#v", second.Manifest.Items)
+	}
+	if firstRef.ID == secondRef.ID {
+		t.Fatalf("scope-dependent source-less refs should expose drift, got same ID %#v", firstRef)
+	}
+	if firstRef.Durability != RefSynthetic || secondRef.Durability != RefSynthetic {
+		t.Fatalf("scope-dependent source-less refs must be synthetic: first=%#v second=%#v", firstRef, secondRef)
+	}
+	if !manifestHasWarning(first.Manifest, "non_durable_context_ref") || !manifestHasWarning(second.Manifest, "non_durable_context_ref") {
+		t.Fatalf("missing synthetic warnings: first=%#v second=%#v", first.Manifest.ValidationWarnings, second.Manifest.ValidationWarnings)
+	}
+}
+
+func TestManifestRenderedOutputsOnlyIncludeRenderedRefs(t *testing.T) {
+	t.Parallel()
+
+	historyText := WithContextRef(TextFrag(TextFragInput{
+		ID:   "history.text",
+		Kind: KindConversationEvent,
+		Slot: SlotHistory,
+		Text: "not rendered by legacy renderer",
+	}), ContextRef{Namespace: "test", ID: "history.text", Schema: SchemaContextRef})
+	currentA := WithContextRef(TextFrag(TextFragInput{
+		ID:   "current.a",
+		Kind: KindCurrentUserMessage,
+		Slot: SlotCurrentUser,
+		Text: "a",
+	}), ContextRef{Namespace: "test", ID: "current.a", Schema: SchemaContextRef})
+	currentB := WithContextRef(TextFrag(TextFragInput{
+		ID:   "current.b",
+		Kind: KindCurrentUserMessage,
+		Slot: SlotCurrentUser,
+		Text: "b",
+	}), ContextRef{Namespace: "test", ID: "current.b", Schema: SchemaContextRef})
+
+	manifest := BuildManifest([]ContextFrag{historyText, currentA, currentB})
+	if renderedOutputContainsRef(manifest.RenderedOutputs, historyText.Ref) {
+		t.Fatalf("history text ref should not be listed as rendered output: %#v", manifest.RenderedOutputs)
+	}
+	if renderedOutputContainsRef(manifest.RenderedOutputs, currentA.Ref) {
+		t.Fatalf("overwritten current-user text ref should not be listed as rendered output: %#v", manifest.RenderedOutputs)
+	}
+	if !renderedOutputContainsRef(manifest.RenderedOutputs, currentB.Ref) {
+		t.Fatalf("last current-user text ref should be listed as rendered output: %#v", manifest.RenderedOutputs)
+	}
+}

--- a/internal/contextfrag/compile_contract_test.go
+++ b/internal/contextfrag/compile_contract_test.go
@@ -219,3 +219,41 @@ func TestManifestRenderedOutputsOnlyIncludeRenderedRefs(t *testing.T) {
 		t.Fatalf("last current-user text ref should be listed as rendered output: %#v", manifest.RenderedOutputs)
 	}
 }
+
+func TestCompilePreservesExplicitMessageFragAtSourcePosition(t *testing.T) {
+	t.Parallel()
+
+	before := sdk.UserMessage("before")
+	summary := sdk.UserMessage("<summary>\ncondensed\n</summary>")
+	summaryRef := ContextRef{Namespace: "compaction_log", ID: "log-1", Schema: SchemaContextRef, Durability: RefDurable}
+	summaryFrag := MessageFrag(MessageFragInput{
+		ID:      "message.001",
+		Message: summary,
+		Kind:    KindConversationSummary,
+		Slot:    SlotHistory,
+		Source:  "compaction_log",
+	})
+	summaryFrag.Ref = summaryRef
+
+	assembled := Compile(CompileInput{
+		Source:   SourceRunConfig,
+		Messages: []sdk.Message{before, summary},
+		Existing: []ContextFrag{summaryFrag},
+	})
+
+	if len(assembled.Messages) != 2 {
+		t.Fatalf("messages = %d, want explicit message frag to replace derived message only: %#v", len(assembled.Messages), assembled.Messages)
+	}
+	if got := assembled.Messages[0].Content[0].(sdk.TextPart).Text; got != "before" {
+		t.Fatalf("first message = %q, want source order preserved", got)
+	}
+	if len(assembled.Manifest.Items) != 2 {
+		t.Fatalf("manifest items = %d, want 2: %#v", len(assembled.Manifest.Items), assembled.Manifest.Items)
+	}
+	if assembled.Manifest.Items[1].Kind != KindConversationSummary {
+		t.Fatalf("second manifest item kind = %q, want %q", assembled.Manifest.Items[1].Kind, KindConversationSummary)
+	}
+	if !assembled.Manifest.Items[1].Ref.EqualIdentity(summaryRef) {
+		t.Fatalf("explicit message ref was not preserved: %#v", assembled.Manifest.Items[1].Ref)
+	}
+}

--- a/internal/contextfrag/compile_test.go
+++ b/internal/contextfrag/compile_test.go
@@ -1,0 +1,94 @@
+package contextfrag
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestCompileRendersLegacyFieldsAndSplitsToolUsage(t *testing.T) {
+	t.Parallel()
+
+	system := "base system\n\n## Tool usage\n\nuse the right tool\n\n## Workspace instruction files\n\nAGENTS.md"
+	messages := []sdk.Message{
+		sdk.UserMessage("history"),
+		sdk.AssistantMessage("reply"),
+	}
+	images := []sdk.ImagePart{{Image: "data:image/png;base64,abc", MediaType: "image/png"}}
+	scope := Scope{
+		BotID:            "bot-1",
+		ChatID:           "chat-1",
+		SessionID:        "sess-1",
+		CurrentMessageID: "msg-1",
+		EventID:          "evt-1",
+		Attention:        []AttentionReason{AttentionReply},
+	}
+
+	got := Compile(CompileInput{
+		Source:       "test",
+		Scope:        scope,
+		System:       system,
+		Messages:     messages,
+		Query:        "current",
+		InlineImages: images,
+		ToolUsage:    "## Tool usage\n\nuse the right tool",
+		DynamicMutators: []DynamicMutator{
+			DynamicMutatorReadMedia,
+			DynamicMutatorReadMedia,
+			DynamicMutatorBeforeModelCallHook,
+		},
+	})
+
+	if got.Manifest.View != ViewRunConfigPreProvider {
+		t.Fatalf("manifest view = %q, want %q", got.Manifest.View, ViewRunConfigPreProvider)
+	}
+	if len(got.Manifest.DynamicMutators) != 2 ||
+		got.Manifest.DynamicMutators[0] != DynamicMutatorReadMedia ||
+		got.Manifest.DynamicMutators[1] != DynamicMutatorBeforeModelCallHook {
+		t.Fatalf("dynamic mutators = %#v", got.Manifest.DynamicMutators)
+	}
+	if got.System != system {
+		t.Fatalf("rendered system = %q, want %q", got.System, system)
+	}
+	if got.Query != "current" {
+		t.Fatalf("rendered query = %q, want current", got.Query)
+	}
+	if len(got.Messages) != len(messages) {
+		t.Fatalf("rendered messages = %d, want %d", len(got.Messages), len(messages))
+	}
+	if len(got.InlineImages) != 1 || got.InlineImages[0].Image != images[0].Image {
+		t.Fatalf("rendered images = %#v, want %#v", got.InlineImages, images)
+	}
+	if !manifestHasKind(got.Manifest, KindToolUsage) {
+		t.Fatalf("manifest missing tool usage item: %#v", got.Manifest.Items)
+	}
+	if !manifestHasKind(got.Manifest, KindWorkspaceInstruction) {
+		t.Fatalf("manifest missing workspace instruction item: %#v", got.Manifest.Items)
+	}
+	for _, item := range got.Manifest.Items {
+		if item.Scope.EventID != "evt-1" || item.Scope.CurrentMessageID != "msg-1" {
+			t.Fatalf("manifest item lost IM scope: %#v", item.Scope)
+		}
+	}
+}
+
+func TestCompileDoesNotInferToolUsageFromPlainSystemText(t *testing.T) {
+	t.Parallel()
+
+	got := Compile(CompileInput{
+		System: "base system\n\n## Workspace instruction files\n\n## Tool usage\n\ntext from AGENTS.md",
+	})
+
+	if manifestHasKind(got.Manifest, KindToolUsage) {
+		t.Fatalf("manifest should not infer tool usage from arbitrary system text: %#v", got.Manifest.Items)
+	}
+}
+
+func manifestHasKind(manifest Manifest, kind Kind) bool {
+	for _, item := range manifest.Items {
+		if item.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/contextfrag/contract.go
+++ b/internal/contextfrag/contract.go
@@ -158,13 +158,14 @@ func WithContextRef(frag ContextFrag, ref ContextRef) ContextFrag {
 	hasExplicitID := strings.TrimSpace(ref.ID) != ""
 	hasSourceID := strings.TrimSpace(frag.Provenance.SourceID) != ""
 	ref.Namespace = firstNonEmpty(ref.Namespace, frag.Provenance.Source, "context_frag")
-	if hasExplicitID {
+	switch {
+	case hasExplicitID:
 		ref.ID = strings.TrimSpace(ref.ID)
-	} else if hasSourceID {
+	case hasSourceID:
 		ref.ID = strings.TrimSpace(frag.Provenance.SourceID)
-	} else if hashErr == nil && hash.Value != "" {
+	case hashErr == nil && hash.Value != "":
 		ref.ID = hash.Value
-	} else {
+	default:
 		ref.ID = strings.TrimSpace(frag.ID)
 	}
 	ref.Schema = firstNonEmpty(ref.Schema, SchemaContextRef)

--- a/internal/contextfrag/contract.go
+++ b/internal/contextfrag/contract.go
@@ -10,6 +10,7 @@ func (ref ContextRef) StableKey() string {
 	namespace := strings.TrimSpace(ref.Namespace)
 	id := strings.TrimSpace(ref.ID)
 	schema := strings.TrimSpace(ref.Schema)
+	durability := strings.TrimSpace(string(normalizeRefDurability(ref.Durability)))
 	key := namespace + ":" + id
 	if ref.Version != 0 {
 		key += fmt.Sprintf("@v%d", ref.Version)
@@ -19,6 +20,9 @@ func (ref ContextRef) StableKey() string {
 	}
 	if schema != "" {
 		key += "#" + schema
+	}
+	if durability != "" && durability != string(RefDurable) {
+		key += "$" + durability
 	}
 	return key
 }
@@ -36,10 +40,17 @@ func (ref ContextRef) EqualIdentity(other ContextRef) bool {
 	if strings.TrimSpace(ref.Schema) != strings.TrimSpace(other.Schema) {
 		return false
 	}
+	if normalizeRefDurability(ref.Durability) != normalizeRefDurability(other.Durability) {
+		return false
+	}
 	if ref.Range == nil || other.Range == nil {
 		return ref.Range == nil && other.Range == nil
 	}
 	return ref.Range.Start == other.Range.Start && ref.Range.End == other.Range.End
+}
+
+func (ref ContextRef) IsDurable() bool {
+	return normalizeRefDurability(ref.Durability) == RefDurable
 }
 
 func ValidateContextRef(ref ContextRef) error {
@@ -51,6 +62,9 @@ func ValidateContextRef(ref ContextRef) error {
 	}
 	if strings.TrimSpace(ref.Schema) == "" {
 		return errors.New("context ref schema is required")
+	}
+	if ref.Durability != "" && !knownRefDurability(ref.Durability) {
+		return fmt.Errorf("unknown context ref durability %q", ref.Durability)
 	}
 	if err := ValidateSchemaVersions([]SchemaVersion{{Name: ref.Schema, Version: CurrentSchemaVersion}}); err != nil {
 		return err
@@ -141,9 +155,29 @@ func CheckEditPreconditions(edit ContextEdit, stateRefs []ContextRef) []ContextC
 
 func WithContextRef(frag ContextFrag, ref ContextRef) ContextFrag {
 	hash, hashErr := CanonicalFragmentHash(frag)
+	hasExplicitID := strings.TrimSpace(ref.ID) != ""
+	hasSourceID := strings.TrimSpace(frag.Provenance.SourceID) != ""
 	ref.Namespace = firstNonEmpty(ref.Namespace, frag.Provenance.Source, "context_frag")
-	ref.ID = firstNonEmpty(ref.ID, frag.Provenance.SourceID, hash.Value, frag.ID)
+	if hasExplicitID {
+		ref.ID = strings.TrimSpace(ref.ID)
+	} else if hasSourceID {
+		ref.ID = strings.TrimSpace(frag.Provenance.SourceID)
+	} else if hashErr == nil && hash.Value != "" {
+		ref.ID = hash.Value
+	} else {
+		ref.ID = strings.TrimSpace(frag.ID)
+	}
 	ref.Schema = firstNonEmpty(ref.Schema, SchemaContextRef)
+	if ref.Durability == "" {
+		switch {
+		case hasExplicitID || hasSourceID:
+			ref.Durability = RefDurable
+		case hashErr == nil && hash.Value != "":
+			ref.Durability = RefSynthetic
+		default:
+			ref.Durability = RefDebug
+		}
+	}
 	if hashErr == nil {
 		ref.HashAlgo = hash.Algo
 		ref.HashScope = hash.Scope
@@ -151,6 +185,31 @@ func WithContextRef(frag ContextFrag, ref ContextRef) ContextFrag {
 	}
 	frag.Ref = ref
 	return frag
+}
+
+// UsesLockstepSchemaVersions reports the PR0 schema strategy: all context
+// schemas share CurrentSchemaVersion until per-schema migration ranges exist.
+func UsesLockstepSchemaVersions() bool {
+	return true
+}
+
+func ContextRefWarnings(ref ContextRef) []ValidationWarning {
+	var warnings []ValidationWarning
+	if err := ValidateContextRef(ref); err != nil {
+		warnings = append(warnings, ValidationWarning{
+			Code:    "invalid_context_ref",
+			Message: err.Error(),
+			Ref:     ref,
+		})
+	}
+	if !ref.IsDurable() {
+		warnings = append(warnings, ValidationWarning{
+			Code:    "non_durable_context_ref",
+			Message: fmt.Sprintf("context ref durability %q is for phase-1 trace only; durable sources should provide ContextRef IDs", ref.Durability),
+			Ref:     ref,
+		})
+	}
+	return warnings
 }
 
 func DefaultSchemaVersions() []SchemaVersion {
@@ -173,6 +232,22 @@ func DefaultSlotRenderPolicies() []SlotRenderPolicy {
 		{Slot: SlotCurrentUser, Order: "last_text_wins_images_append", DedupeBy: "ref", CoverageAware: true, Target: "query_inline_images"},
 		{Slot: SlotAfterCurrent, Order: "fragment_order", DedupeBy: "ref", CoverageAware: true, Target: "messages"},
 	}
+}
+
+func knownRefDurability(durability RefDurability) bool {
+	switch durability {
+	case RefDurable, RefSynthetic, RefDebug:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeRefDurability(durability RefDurability) RefDurability {
+	if durability == "" {
+		return RefDurable
+	}
+	return durability
 }
 
 func knownSchemaName(name string) bool {

--- a/internal/contextfrag/contract.go
+++ b/internal/contextfrag/contract.go
@@ -1,0 +1,194 @@
+package contextfrag
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func (ref ContextRef) StableKey() string {
+	namespace := strings.TrimSpace(ref.Namespace)
+	id := strings.TrimSpace(ref.ID)
+	schema := strings.TrimSpace(ref.Schema)
+	key := namespace + ":" + id
+	if ref.Version != 0 {
+		key += fmt.Sprintf("@v%d", ref.Version)
+	}
+	if ref.Range != nil {
+		key += fmt.Sprintf("[%d:%d]", ref.Range.Start, ref.Range.End)
+	}
+	if schema != "" {
+		key += "#" + schema
+	}
+	return key
+}
+
+func (ref ContextRef) EqualIdentity(other ContextRef) bool {
+	if strings.TrimSpace(ref.Namespace) != strings.TrimSpace(other.Namespace) {
+		return false
+	}
+	if strings.TrimSpace(ref.ID) != strings.TrimSpace(other.ID) {
+		return false
+	}
+	if ref.Version != other.Version {
+		return false
+	}
+	if strings.TrimSpace(ref.Schema) != strings.TrimSpace(other.Schema) {
+		return false
+	}
+	if ref.Range == nil || other.Range == nil {
+		return ref.Range == nil && other.Range == nil
+	}
+	return ref.Range.Start == other.Range.Start && ref.Range.End == other.Range.End
+}
+
+func ValidateContextRef(ref ContextRef) error {
+	if strings.TrimSpace(ref.Namespace) == "" {
+		return errors.New("context ref namespace is required")
+	}
+	if strings.TrimSpace(ref.ID) == "" {
+		return errors.New("context ref id is required")
+	}
+	if strings.TrimSpace(ref.Schema) == "" {
+		return errors.New("context ref schema is required")
+	}
+	if err := ValidateSchemaVersions([]SchemaVersion{{Name: ref.Schema, Version: CurrentSchemaVersion}}); err != nil {
+		return err
+	}
+	if ref.Range != nil && ref.Range.End < ref.Range.Start {
+		return fmt.Errorf("context ref range end %d before start %d", ref.Range.End, ref.Range.Start)
+	}
+	if strings.TrimSpace(ref.HashAlgo) != "" && ref.HashAlgo != HashAlgoSHA256 {
+		return fmt.Errorf("unsupported context ref hash algo %q", ref.HashAlgo)
+	}
+	if strings.TrimSpace(ref.HashScope) != "" && ref.HashScope != HashScopeCanonicalFragment {
+		return fmt.Errorf("unsupported context ref hash scope %q", ref.HashScope)
+	}
+	if strings.TrimSpace(ref.ContentHash) != "" {
+		if strings.TrimSpace(ref.HashAlgo) == "" {
+			return errors.New("context ref hash algo is required when content hash is set")
+		}
+		if strings.TrimSpace(ref.HashScope) == "" {
+			return errors.New("context ref hash scope is required when content hash is set")
+		}
+	}
+	return nil
+}
+
+func ValidateSchemaVersions(versions []SchemaVersion) error {
+	for _, version := range versions {
+		name := strings.TrimSpace(version.Name)
+		if name == "" {
+			return errors.New("schema version name is required")
+		}
+		if !knownSchemaName(name) {
+			return fmt.Errorf("unknown schema %q", name)
+		}
+		if version.Version != CurrentSchemaVersion {
+			return fmt.Errorf("unsupported schema %q version %d", name, version.Version)
+		}
+	}
+	return nil
+}
+
+func (edit ContextEdit) Targets(ref ContextRef) bool {
+	for _, got := range edit.Refs {
+		if got.EqualIdentity(ref) {
+			return true
+		}
+	}
+	return false
+}
+
+func CheckEditPreconditions(edit ContextEdit, stateRefs []ContextRef) []ContextConflict {
+	var conflicts []ContextConflict
+	if edit.Schema.Name != SchemaContextEdit || edit.Schema.Version != CurrentSchemaVersion {
+		conflicts = append(conflicts, ContextConflict{
+			Kind:     ConflictInvalidSchema,
+			Expected: fmt.Sprintf("%s@%d", SchemaContextEdit, CurrentSchemaVersion),
+			Actual:   fmt.Sprintf("%s@%d", edit.Schema.Name, edit.Schema.Version),
+		})
+	} else if err := ValidateSchemaVersions([]SchemaVersion{edit.Schema}); err != nil {
+		conflicts = append(conflicts, ContextConflict{
+			Kind:     ConflictInvalidSchema,
+			Expected: fmt.Sprintf("%s@%d", SchemaContextEdit, CurrentSchemaVersion),
+			Actual:   fmt.Sprintf("%s@%d", edit.Schema.Name, edit.Schema.Version),
+		})
+	}
+
+	byKey := make(map[string]ContextRef, len(stateRefs))
+	for _, ref := range stateRefs {
+		byKey[ref.StableKey()] = ref
+	}
+
+	for key, expected := range edit.Preconditions.ExpectedHashes {
+		ref, ok := byKey[key]
+		if !ok {
+			conflicts = append(conflicts, ContextConflict{Kind: ConflictMissingRef, Key: key, Expected: expected})
+			continue
+		}
+		if ref.ContentHash != expected {
+			conflicts = append(conflicts, ContextConflict{
+				Kind:     ConflictContentHashMismatch,
+				Key:      key,
+				Expected: expected,
+				Actual:   ref.ContentHash,
+			})
+		}
+	}
+	return conflicts
+}
+
+func WithContextRef(frag ContextFrag, ref ContextRef) ContextFrag {
+	hash, hashErr := CanonicalFragmentHash(frag)
+	ref.Namespace = firstNonEmpty(ref.Namespace, frag.Provenance.Source, "context_frag")
+	ref.ID = firstNonEmpty(ref.ID, frag.Provenance.SourceID, hash.Value, frag.ID)
+	ref.Schema = firstNonEmpty(ref.Schema, SchemaContextRef)
+	if hashErr == nil {
+		ref.HashAlgo = hash.Algo
+		ref.HashScope = hash.Scope
+		ref.ContentHash = hash.Value
+	}
+	frag.Ref = ref
+	return frag
+}
+
+func DefaultSchemaVersions() []SchemaVersion {
+	return []SchemaVersion{
+		{Name: SchemaContextManifest, Version: CurrentSchemaVersion},
+		{Name: SchemaContextFrag, Version: CurrentSchemaVersion},
+		{Name: SchemaContextRef, Version: CurrentSchemaVersion},
+		{Name: SchemaContextEdit, Version: CurrentSchemaVersion},
+		{Name: SchemaSummaryCoverage, Version: CurrentSchemaVersion},
+		{Name: SchemaRenderPolicy, Version: CurrentSchemaVersion},
+	}
+}
+
+func DefaultSlotRenderPolicies() []SlotRenderPolicy {
+	return []SlotRenderPolicy{
+		{Slot: SlotSystem, Order: "fragment_order", DedupeBy: "ref", CoverageAware: true, Target: "system"},
+		{Slot: SlotBeforeHistory, Order: "fragment_order", DedupeBy: "ref", CoverageAware: true, Target: "messages"},
+		{Slot: SlotHistory, Order: "fragment_order", DedupeBy: "ref", CoverageAware: true, Target: "messages"},
+		{Slot: SlotAfterHistoryBeforeCurrent, Order: "fragment_order", DedupeBy: "ref", CoverageAware: true, Target: "messages"},
+		{Slot: SlotCurrentUser, Order: "last_text_wins_images_append", DedupeBy: "ref", CoverageAware: true, Target: "query_inline_images"},
+		{Slot: SlotAfterCurrent, Order: "fragment_order", DedupeBy: "ref", CoverageAware: true, Target: "messages"},
+	}
+}
+
+func knownSchemaName(name string) bool {
+	switch name {
+	case SchemaContextManifest, SchemaContextFrag, SchemaContextRef, SchemaContextEdit, SchemaSummaryCoverage, SchemaRenderPolicy:
+		return true
+	default:
+		return false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/contextfrag/contract_test.go
+++ b/internal/contextfrag/contract_test.go
@@ -20,6 +20,7 @@ func TestContextRefRoundTripPreservesReducerIdentity(t *testing.T) {
 		ContentHash: "abc123",
 		HashScope:   HashScopeCanonicalFragment,
 		Schema:      SchemaContextRef,
+		Durability:  RefDurable,
 	}
 
 	raw, err := json.Marshal(ref)
@@ -252,15 +253,25 @@ func TestSerdeRoundTripsContextFragManifestEditAndCoverage(t *testing.T) {
 	})
 
 	coverage := SummaryCoverage{
-		CoverageID:     "coverage-1",
-		SummaryRef:     ContextRef{Namespace: "summary", ID: "summary-1", Schema: SchemaContextRef},
-		CoveredRefs:    []ContextRef{frag.Ref},
-		CoveredFragIDs: []string{frag.ID},
-		Schema:         SchemaVersion{Name: SchemaSummaryCoverage, Version: CurrentSchemaVersion},
+		CoverageID:   "coverage-1",
+		SummaryRef:   ContextRef{Namespace: "summary", ID: "summary-1", Schema: SchemaContextRef, Durability: RefDurable},
+		CoveredRefs:  []ContextRef{frag.Ref},
+		TraceFragIDs: []string{frag.ID},
+		Schema:       SchemaVersion{Name: SchemaSummaryCoverage, Version: CurrentSchemaVersion},
 	}
 	roundTripJSON(t, coverage, func(got SummaryCoverage) {
 		if len(got.CoveredRefs) != 1 || !got.CoveredRefs[0].EqualIdentity(frag.Ref) {
 			t.Fatalf("coverage refs mismatch after roundtrip: %#v", got.CoveredRefs)
+		}
+		if len(got.TraceFragIDs) != 1 || got.TraceFragIDs[0] != frag.ID {
+			t.Fatalf("coverage trace frag IDs mismatch after roundtrip: %#v", got.TraceFragIDs)
+		}
+		raw, err := json.Marshal(got)
+		if err != nil {
+			t.Fatalf("marshal coverage: %v", err)
+		}
+		if json.Valid(raw) && containsJSONField(raw, "covered_frag_ids") {
+			t.Fatalf("coverage JSON should use trace_frag_ids, got %s", raw)
 		}
 	})
 
@@ -290,6 +301,14 @@ func TestSchemaAndHashValidationRejectsSilentDrift(t *testing.T) {
 	}
 	if err := ValidateSchemaVersions([]SchemaVersion{{Name: "unknown_schema", Version: CurrentSchemaVersion}}); err == nil {
 		t.Fatal("unknown schema name should fail validation")
+	}
+	if !UsesLockstepSchemaVersions() {
+		t.Fatal("PR0 schema strategy should explicitly report lockstep schema versions")
+	}
+	for _, schema := range DefaultSchemaVersions() {
+		if schema.Version != CurrentSchemaVersion {
+			t.Fatalf("lockstep schema %q version = %d, want %d", schema.Name, schema.Version, CurrentSchemaVersion)
+		}
 	}
 	if err := ValidateContextRef(ContextRef{
 		Namespace: "history",
@@ -336,99 +355,6 @@ func TestSchemaAndHashValidationRejectsSilentDrift(t *testing.T) {
 	missing := CheckEditPreconditions(edit, nil)
 	if len(missing) != 1 || missing[0].Kind != ConflictMissingRef {
 		t.Fatalf("expected one missing-ref conflict, got %#v", missing)
-	}
-}
-
-func TestCompileAddsRefsAndManifestTraceWithoutChangingRenderedLegacyView(t *testing.T) {
-	t.Parallel()
-
-	system := "base system"
-	messages := []sdk.Message{sdk.UserMessage("history")}
-	images := []sdk.ImagePart{{Image: "data:image/png;base64,abc", MediaType: "image/png"}}
-
-	got := Compile(CompileInput{
-		Source:       "test",
-		System:       system,
-		Messages:     messages,
-		Query:        "current",
-		InlineImages: images,
-	})
-
-	if got.System != system || got.Query != "current" || len(got.Messages) != 1 || len(got.InlineImages) != 1 {
-		t.Fatalf("rendered legacy view changed: system=%q query=%q messages=%d images=%d", got.System, got.Query, len(got.Messages), len(got.InlineImages))
-	}
-	for _, frag := range got.Frags {
-		if err := ValidateContextRef(frag.Ref); err != nil {
-			t.Fatalf("compiled frag %q has invalid ref %#v: %v", frag.ID, frag.Ref, err)
-		}
-		if frag.Ref.HashScope != HashScopeCanonicalFragment || frag.Ref.ContentHash == "" {
-			t.Fatalf("compiled frag %q missing canonical hash ref: %#v", frag.ID, frag.Ref)
-		}
-	}
-	if len(got.Manifest.RenderedOutputs) == 0 {
-		t.Fatal("manifest should explain rendered output refs")
-	}
-	if len(got.Manifest.ValidationWarnings) != 0 {
-		t.Fatalf("unexpected manifest validation warnings: %#v", got.Manifest.ValidationWarnings)
-	}
-}
-
-func TestCompileUsesStableContentAddressedRefsWhenSourceIDIsMissing(t *testing.T) {
-	t.Parallel()
-
-	first := Compile(CompileInput{
-		Source:   "test",
-		Messages: []sdk.Message{sdk.UserMessage("target")},
-	})
-	second := Compile(CompileInput{
-		Source:   "test",
-		Messages: []sdk.Message{sdk.UserMessage("prefix"), sdk.UserMessage("target")},
-	})
-
-	firstRef, ok := refForRenderedMessageText(first.Frags, "target")
-	if !ok {
-		t.Fatalf("missing target ref in first compile: %#v", first.Manifest.Items)
-	}
-	secondRef, ok := refForRenderedMessageText(second.Frags, "target")
-	if !ok {
-		t.Fatalf("missing target ref in second compile: %#v", second.Manifest.Items)
-	}
-	if firstRef.ID != secondRef.ID {
-		t.Fatalf("source-less legacy message ref drifted with position: first=%#v second=%#v", firstRef, secondRef)
-	}
-}
-
-func TestManifestRenderedOutputsOnlyIncludeRenderedRefs(t *testing.T) {
-	t.Parallel()
-
-	historyText := WithContextRef(TextFrag(TextFragInput{
-		ID:   "history.text",
-		Kind: KindConversationEvent,
-		Slot: SlotHistory,
-		Text: "not rendered by legacy renderer",
-	}), ContextRef{Namespace: "test", ID: "history.text", Schema: SchemaContextRef})
-	currentA := WithContextRef(TextFrag(TextFragInput{
-		ID:   "current.a",
-		Kind: KindCurrentUserMessage,
-		Slot: SlotCurrentUser,
-		Text: "a",
-	}), ContextRef{Namespace: "test", ID: "current.a", Schema: SchemaContextRef})
-	currentB := WithContextRef(TextFrag(TextFragInput{
-		ID:   "current.b",
-		Kind: KindCurrentUserMessage,
-		Slot: SlotCurrentUser,
-		Text: "b",
-	}), ContextRef{Namespace: "test", ID: "current.b", Schema: SchemaContextRef})
-
-	manifest := BuildManifest([]ContextFrag{historyText, currentA, currentB})
-	if renderedOutputContainsRef(manifest.RenderedOutputs, historyText.Ref) {
-		t.Fatalf("history text ref should not be listed as rendered output: %#v", manifest.RenderedOutputs)
-	}
-	if renderedOutputContainsRef(manifest.RenderedOutputs, currentA.Ref) {
-		t.Fatalf("overwritten current-user text ref should not be listed as rendered output: %#v", manifest.RenderedOutputs)
-	}
-	if !renderedOutputContainsRef(manifest.RenderedOutputs, currentB.Ref) {
-		t.Fatalf("last current-user text ref should be listed as rendered output: %#v", manifest.RenderedOutputs)
 	}
 }
 
@@ -482,4 +408,27 @@ func renderedOutputContainsRef(outputs []RenderedOutputRef, ref ContextRef) bool
 		}
 	}
 	return false
+}
+
+func manifestHasWarning(manifest Manifest, code string) bool {
+	return countManifestWarnings(manifest, code) > 0
+}
+
+func countManifestWarnings(manifest Manifest, code string) int {
+	total := 0
+	for _, warning := range manifest.ValidationWarnings {
+		if warning.Code == code {
+			total++
+		}
+	}
+	return total
+}
+
+func containsJSONField(raw []byte, field string) bool {
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false
+	}
+	_, ok := value[field]
+	return ok
 }

--- a/internal/contextfrag/contract_test.go
+++ b/internal/contextfrag/contract_test.go
@@ -1,0 +1,485 @@
+package contextfrag
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestContextRefRoundTripPreservesReducerIdentity(t *testing.T) {
+	t.Parallel()
+
+	ref := ContextRef{
+		Namespace:   "history",
+		ID:          "row-1",
+		Version:     2,
+		Range:       &ContentRange{Start: 10, End: 20},
+		HashAlgo:    HashAlgoSHA256,
+		ContentHash: "abc123",
+		HashScope:   HashScopeCanonicalFragment,
+		Schema:      SchemaContextRef,
+	}
+
+	raw, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("marshal context ref: %v", err)
+	}
+	var got ContextRef
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal context ref: %v", err)
+	}
+
+	if !ref.EqualIdentity(got) {
+		t.Fatalf("roundtrip ref identity mismatch: got %#v want %#v", got, ref)
+	}
+	if got.StableKey() != ref.StableKey() {
+		t.Fatalf("stable key = %q, want %q", got.StableKey(), ref.StableKey())
+	}
+	for _, op := range []ContextEditOp{EditReplace, EditRemove, EditCover} {
+		edit := ContextEdit{Op: op, Slot: SlotHistory, Refs: []ContextRef{got}}
+		if !edit.Targets(ref) {
+			t.Fatalf("%s edit should target round-tripped ref", op)
+		}
+	}
+	if err := ValidateContextRef(ContextRef{Namespace: "history", Schema: SchemaContextRef}); err == nil {
+		t.Fatal("context ref without ID should fail validation")
+	}
+}
+
+func TestCanonicalFragmentHashIsStableAndIgnoresDebugID(t *testing.T) {
+	t.Parallel()
+
+	frag := TextFrag(TextFragInput{
+		ID:         "debug-a",
+		Kind:       KindConversationEvent,
+		Role:       sdk.MessageRoleUser,
+		Slot:       SlotHistory,
+		Text:       "hello",
+		Priority:   70,
+		CacheClass: CacheNever,
+		Trust:      TrustExternal,
+		Source:     "history",
+		SourceID:   "row-1",
+		Collector:  "test",
+	})
+	same := frag
+	same.ID = "debug-b"
+	same.Provenance.Index = 42
+	changed := frag
+	changed.Parts = append([]Part(nil), frag.Parts...)
+	changed.Parts[0].Text = "hello again"
+
+	hash, err := CanonicalFragmentHash(frag)
+	if err != nil {
+		t.Fatalf("canonical hash: %v", err)
+	}
+	sameHash, err := CanonicalFragmentHash(same)
+	if err != nil {
+		t.Fatalf("canonical hash for same content: %v", err)
+	}
+	changedHash, err := CanonicalFragmentHash(changed)
+	if err != nil {
+		t.Fatalf("canonical hash for changed content: %v", err)
+	}
+
+	if hash.Algo != HashAlgoSHA256 || hash.Scope != HashScopeCanonicalFragment {
+		t.Fatalf("hash metadata = %#v", hash)
+	}
+	if hash.Value == "" {
+		t.Fatal("canonical hash should not be empty")
+	}
+	if sameHash.Value != hash.Value {
+		t.Fatalf("canonical hash should ignore debug ID and positional index: got %q want %q", sameHash.Value, hash.Value)
+	}
+	if changedHash.Value == hash.Value {
+		t.Fatalf("canonical hash should change when fragment content changes: %q", hash.Value)
+	}
+}
+
+func TestCanonicalFragmentHashDiscriminatesSDKMessagePartTypes(t *testing.T) {
+	t.Parallel()
+
+	textFrag := MessageFrag(MessageFragInput{
+		ID:      "message.text",
+		Message: sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.TextPart{Text: "same"}}},
+		Kind:    KindConversationEvent,
+		Slot:    SlotHistory,
+	})
+	reasoningFrag := MessageFrag(MessageFragInput{
+		ID:      "message.reasoning",
+		Message: sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.ReasoningPart{Text: "same"}}},
+		Kind:    KindConversationEvent,
+		Slot:    SlotHistory,
+	})
+
+	textHash, err := CanonicalFragmentHash(textFrag)
+	if err != nil {
+		t.Fatalf("text hash: %v", err)
+	}
+	reasoningHash, err := CanonicalFragmentHash(reasoningFrag)
+	if err != nil {
+		t.Fatalf("reasoning hash: %v", err)
+	}
+	if textHash.Value == reasoningHash.Value {
+		t.Fatalf("text and reasoning SDK message parts must not collide: %q", textHash.Value)
+	}
+}
+
+func TestCanonicalFragmentHashIncludesNativeImageSDKPayload(t *testing.T) {
+	t.Parallel()
+
+	base := ImageFrag("image", []sdk.ImagePart{{
+		Image:     "data:image/png;base64,abc",
+		MediaType: "image/png",
+	}}, Scope{}, "test")
+	withCache := ImageFrag("image", []sdk.ImagePart{{
+		Image:        "data:image/png;base64,abc",
+		MediaType:    "image/png",
+		CacheControl: &sdk.CacheControl{Type: "ephemeral"},
+	}}, Scope{}, "test")
+
+	baseHash, err := CanonicalFragmentHash(base)
+	if err != nil {
+		t.Fatalf("base image hash: %v", err)
+	}
+	cacheHash, err := CanonicalFragmentHash(withCache)
+	if err != nil {
+		t.Fatalf("cache-control image hash: %v", err)
+	}
+	if baseHash.Value == cacheHash.Value {
+		t.Fatalf("image fragments with different SDK cache control must not collide: %q", baseHash.Value)
+	}
+}
+
+func TestSerdeRoundTripsContextFragManifestEditAndCoverage(t *testing.T) {
+	t.Parallel()
+
+	frag := TextFrag(TextFragInput{
+		ID:         "history.001",
+		Kind:       KindConversationEvent,
+		Role:       sdk.MessageRoleUser,
+		Slot:       SlotHistory,
+		Text:       "hello",
+		Priority:   70,
+		CacheClass: CacheNever,
+		Trust:      TrustExternal,
+		Source:     "history",
+		SourceID:   "row-1",
+		Collector:  "test",
+	})
+	frag = WithContextRef(frag, ContextRef{
+		Namespace: "history",
+		ID:        "row-1",
+		Version:   1,
+		Schema:    SchemaContextRef,
+	})
+
+	roundTripJSON(t, frag, func(got ContextFrag) {
+		if !frag.Ref.EqualIdentity(got.Ref) {
+			t.Fatalf("frag ref mismatch after roundtrip: got %#v want %#v", got.Ref, frag.Ref)
+		}
+		if got.Ref.ContentHash == "" {
+			t.Fatal("frag ref should carry canonical content hash")
+		}
+	})
+	msgFrag := WithContextRef(MessageFrag(MessageFragInput{
+		ID:         "message.001",
+		Message:    sdk.UserMessage("from sdk", sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"}),
+		Kind:       KindConversationEvent,
+		Slot:       SlotHistory,
+		Priority:   70,
+		CacheClass: CacheNever,
+		Trust:      TrustExternal,
+		Source:     "history",
+		SourceID:   "row-2",
+		Collector:  "test",
+	}), ContextRef{
+		Namespace: "history",
+		ID:        "row-2",
+		Version:   1,
+		Schema:    SchemaContextRef,
+	})
+	roundTripJSON(t, msgFrag, func(got ContextFrag) {
+		rendered := Render([]ContextFrag{got})
+		if len(rendered.Messages) != 1 {
+			t.Fatalf("round-tripped sdk message fragment rendered %d messages, want 1", len(rendered.Messages))
+		}
+		if rendered.Messages[0].Role != sdk.MessageRoleUser {
+			t.Fatalf("round-tripped sdk message role = %q, want user", rendered.Messages[0].Role)
+		}
+		if !reflect.DeepEqual(rendered.Messages[0], *msgFrag.Parts[0].Message) {
+			t.Fatalf("round-tripped sdk message mismatch: got %#v want %#v", rendered.Messages[0], msgFrag.Parts[0].Message)
+		}
+	})
+
+	manifest := BuildManifest([]ContextFrag{frag, msgFrag})
+	roundTripJSON(t, manifest, func(got Manifest) {
+		if !hasSchemaVersion(got.SchemaVersions, SchemaContextManifest, CurrentSchemaVersion) {
+			t.Fatalf("manifest schema versions missing manifest version: %#v", got.SchemaVersions)
+		}
+		if len(got.Items) != 2 || !frag.Ref.EqualIdentity(got.Items[0].Ref) {
+			t.Fatalf("manifest item ref mismatch: %#v", got.Items)
+		}
+		if len(got.SlotPolicies) == 0 {
+			t.Fatal("manifest should include per-slot render policies")
+		}
+		if got.Counts.Images != 1 {
+			t.Fatalf("manifest image count = %d, want 1", got.Counts.Images)
+		}
+	})
+
+	edit := ContextEdit{
+		EditID: "edit-1",
+		Slot:   SlotHistory,
+		Op:     EditReplace,
+		Refs:   []ContextRef{frag.Ref},
+		Payload: []ContextFrag{
+			frag,
+		},
+		Preconditions: EditPreconditions{
+			ExpectedRevision: "rev-1",
+			MaxSequence:      42,
+			ExpectedHashes:   map[string]string{frag.Ref.StableKey(): frag.Ref.ContentHash},
+		},
+		Schema: SchemaVersion{Name: SchemaContextEdit, Version: CurrentSchemaVersion},
+	}
+	roundTripJSON(t, edit, func(got ContextEdit) {
+		if !got.Targets(frag.Ref) {
+			t.Fatalf("round-tripped edit should target payload ref: %#v", got)
+		}
+	})
+
+	coverage := SummaryCoverage{
+		CoverageID:     "coverage-1",
+		SummaryRef:     ContextRef{Namespace: "summary", ID: "summary-1", Schema: SchemaContextRef},
+		CoveredRefs:    []ContextRef{frag.Ref},
+		CoveredFragIDs: []string{frag.ID},
+		Schema:         SchemaVersion{Name: SchemaSummaryCoverage, Version: CurrentSchemaVersion},
+	}
+	roundTripJSON(t, coverage, func(got SummaryCoverage) {
+		if len(got.CoveredRefs) != 1 || !got.CoveredRefs[0].EqualIdentity(frag.Ref) {
+			t.Fatalf("coverage refs mismatch after roundtrip: %#v", got.CoveredRefs)
+		}
+	})
+
+	group := ContinuityGroup{
+		ID:               "tool-call-1",
+		Kind:             "tool_call",
+		Provider:         "openai",
+		ModelFamily:      "responses",
+		Refs:             []ContextRef{frag.Ref},
+		MustKeepTogether: true,
+		MustKeepRaw:      true,
+		MustKeepOrder:    true,
+		MustBeComplete:   true,
+	}
+	roundTripJSON(t, group, func(got ContinuityGroup) {
+		if len(got.Refs) != 1 || !got.Refs[0].EqualIdentity(frag.Ref) || !got.MustKeepTogether || !got.MustBeComplete {
+			t.Fatalf("continuity group mismatch after roundtrip: %#v", got)
+		}
+	})
+}
+
+func TestSchemaAndHashValidationRejectsSilentDrift(t *testing.T) {
+	t.Parallel()
+
+	if err := ValidateSchemaVersions([]SchemaVersion{{Name: SchemaContextFrag, Version: 999}}); err == nil {
+		t.Fatal("unknown context frag schema version should fail validation")
+	}
+	if err := ValidateSchemaVersions([]SchemaVersion{{Name: "unknown_schema", Version: CurrentSchemaVersion}}); err == nil {
+		t.Fatal("unknown schema name should fail validation")
+	}
+	if err := ValidateContextRef(ContextRef{
+		Namespace: "history",
+		ID:        "row-1",
+		HashScope: "rendered_payload",
+		Schema:    SchemaContextRef,
+	}); err == nil {
+		t.Fatal("non-canonical hash scope should fail even when content hash is empty")
+	}
+	wrongSchema := ContextEdit{
+		EditID: "edit-wrong-schema",
+		Slot:   SlotHistory,
+		Op:     EditReplace,
+		Schema: SchemaVersion{Name: SchemaContextRef, Version: CurrentSchemaVersion},
+	}
+	schemaConflicts := CheckEditPreconditions(wrongSchema, nil)
+	if len(schemaConflicts) != 1 || schemaConflicts[0].Kind != ConflictInvalidSchema {
+		t.Fatalf("wrong edit schema should produce invalid-schema conflict, got %#v", schemaConflicts)
+	}
+
+	ref := ContextRef{
+		Namespace:   "history",
+		ID:          "row-1",
+		HashAlgo:    HashAlgoSHA256,
+		HashScope:   HashScopeCanonicalFragment,
+		ContentHash: "good",
+		Schema:      SchemaContextRef,
+	}
+	edit := ContextEdit{
+		EditID: "edit-1",
+		Slot:   SlotHistory,
+		Op:     EditReplace,
+		Refs:   []ContextRef{ref},
+		Preconditions: EditPreconditions{
+			ExpectedHashes: map[string]string{ref.StableKey(): "bad"},
+		},
+		Schema: SchemaVersion{Name: SchemaContextEdit, Version: CurrentSchemaVersion},
+	}
+	conflicts := CheckEditPreconditions(edit, []ContextRef{ref})
+	if len(conflicts) != 1 || conflicts[0].Kind != ConflictContentHashMismatch {
+		t.Fatalf("expected one content-hash conflict, got %#v", conflicts)
+	}
+
+	missing := CheckEditPreconditions(edit, nil)
+	if len(missing) != 1 || missing[0].Kind != ConflictMissingRef {
+		t.Fatalf("expected one missing-ref conflict, got %#v", missing)
+	}
+}
+
+func TestCompileAddsRefsAndManifestTraceWithoutChangingRenderedLegacyView(t *testing.T) {
+	t.Parallel()
+
+	system := "base system"
+	messages := []sdk.Message{sdk.UserMessage("history")}
+	images := []sdk.ImagePart{{Image: "data:image/png;base64,abc", MediaType: "image/png"}}
+
+	got := Compile(CompileInput{
+		Source:       "test",
+		System:       system,
+		Messages:     messages,
+		Query:        "current",
+		InlineImages: images,
+	})
+
+	if got.System != system || got.Query != "current" || len(got.Messages) != 1 || len(got.InlineImages) != 1 {
+		t.Fatalf("rendered legacy view changed: system=%q query=%q messages=%d images=%d", got.System, got.Query, len(got.Messages), len(got.InlineImages))
+	}
+	for _, frag := range got.Frags {
+		if err := ValidateContextRef(frag.Ref); err != nil {
+			t.Fatalf("compiled frag %q has invalid ref %#v: %v", frag.ID, frag.Ref, err)
+		}
+		if frag.Ref.HashScope != HashScopeCanonicalFragment || frag.Ref.ContentHash == "" {
+			t.Fatalf("compiled frag %q missing canonical hash ref: %#v", frag.ID, frag.Ref)
+		}
+	}
+	if len(got.Manifest.RenderedOutputs) == 0 {
+		t.Fatal("manifest should explain rendered output refs")
+	}
+	if len(got.Manifest.ValidationWarnings) != 0 {
+		t.Fatalf("unexpected manifest validation warnings: %#v", got.Manifest.ValidationWarnings)
+	}
+}
+
+func TestCompileUsesStableContentAddressedRefsWhenSourceIDIsMissing(t *testing.T) {
+	t.Parallel()
+
+	first := Compile(CompileInput{
+		Source:   "test",
+		Messages: []sdk.Message{sdk.UserMessage("target")},
+	})
+	second := Compile(CompileInput{
+		Source:   "test",
+		Messages: []sdk.Message{sdk.UserMessage("prefix"), sdk.UserMessage("target")},
+	})
+
+	firstRef, ok := refForRenderedMessageText(first.Frags, "target")
+	if !ok {
+		t.Fatalf("missing target ref in first compile: %#v", first.Manifest.Items)
+	}
+	secondRef, ok := refForRenderedMessageText(second.Frags, "target")
+	if !ok {
+		t.Fatalf("missing target ref in second compile: %#v", second.Manifest.Items)
+	}
+	if firstRef.ID != secondRef.ID {
+		t.Fatalf("source-less legacy message ref drifted with position: first=%#v second=%#v", firstRef, secondRef)
+	}
+}
+
+func TestManifestRenderedOutputsOnlyIncludeRenderedRefs(t *testing.T) {
+	t.Parallel()
+
+	historyText := WithContextRef(TextFrag(TextFragInput{
+		ID:   "history.text",
+		Kind: KindConversationEvent,
+		Slot: SlotHistory,
+		Text: "not rendered by legacy renderer",
+	}), ContextRef{Namespace: "test", ID: "history.text", Schema: SchemaContextRef})
+	currentA := WithContextRef(TextFrag(TextFragInput{
+		ID:   "current.a",
+		Kind: KindCurrentUserMessage,
+		Slot: SlotCurrentUser,
+		Text: "a",
+	}), ContextRef{Namespace: "test", ID: "current.a", Schema: SchemaContextRef})
+	currentB := WithContextRef(TextFrag(TextFragInput{
+		ID:   "current.b",
+		Kind: KindCurrentUserMessage,
+		Slot: SlotCurrentUser,
+		Text: "b",
+	}), ContextRef{Namespace: "test", ID: "current.b", Schema: SchemaContextRef})
+
+	manifest := BuildManifest([]ContextFrag{historyText, currentA, currentB})
+	if renderedOutputContainsRef(manifest.RenderedOutputs, historyText.Ref) {
+		t.Fatalf("history text ref should not be listed as rendered output: %#v", manifest.RenderedOutputs)
+	}
+	if renderedOutputContainsRef(manifest.RenderedOutputs, currentA.Ref) {
+		t.Fatalf("overwritten current-user text ref should not be listed as rendered output: %#v", manifest.RenderedOutputs)
+	}
+	if !renderedOutputContainsRef(manifest.RenderedOutputs, currentB.Ref) {
+		t.Fatalf("last current-user text ref should be listed as rendered output: %#v", manifest.RenderedOutputs)
+	}
+}
+
+func roundTripJSON[T any](t *testing.T, input T, check func(T)) {
+	t.Helper()
+
+	raw, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal %T: %v", input, err)
+	}
+	var got T
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal %T: %v", input, err)
+	}
+	check(got)
+}
+
+func hasSchemaVersion(versions []SchemaVersion, name string, version int) bool {
+	for _, got := range versions {
+		if got.Name == name && got.Version == version {
+			return true
+		}
+	}
+	return false
+}
+
+func refForRenderedMessageText(frags []ContextFrag, text string) (ContextRef, bool) {
+	for _, frag := range frags {
+		for _, part := range frag.Parts {
+			msg := partMessage(part)
+			if msg == nil {
+				continue
+			}
+			for _, content := range msg.Content {
+				textPart, ok := content.(sdk.TextPart)
+				if ok && textPart.Text == text {
+					return frag.Ref, true
+				}
+			}
+		}
+	}
+	return ContextRef{}, false
+}
+
+func renderedOutputContainsRef(outputs []RenderedOutputRef, ref ContextRef) bool {
+	for _, output := range outputs {
+		for _, got := range output.Refs {
+			if got.EqualIdentity(ref) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/contextfrag/hash.go
+++ b/internal/contextfrag/hash.go
@@ -1,0 +1,99 @@
+package contextfrag
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+func CanonicalFragmentHash(frag ContextFrag) (FragmentHash, error) {
+	parts, err := canonicalParts(frag.Parts)
+	if err != nil {
+		return FragmentHash{}, err
+	}
+	canonical := canonicalFragment{
+		Kind:       frag.Kind,
+		Role:       string(frag.Role),
+		Slot:       frag.Slot,
+		Priority:   frag.Priority,
+		CacheClass: frag.CacheClass,
+		Trust:      frag.Trust,
+		Scope:      frag.Scope,
+		Budget:     frag.Budget,
+		Render:     frag.Render,
+		Provenance: canonicalProvenance{
+			Source:    frag.Provenance.Source,
+			SourceID:  frag.Provenance.SourceID,
+			Collector: frag.Provenance.Collector,
+		},
+		Parts: parts,
+	}
+	raw, err := json.Marshal(canonical)
+	if err != nil {
+		return FragmentHash{}, err
+	}
+	sum := sha256.Sum256(raw)
+	return FragmentHash{
+		Algo:  HashAlgoSHA256,
+		Scope: HashScopeCanonicalFragment,
+		Value: hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+type canonicalFragment struct {
+	Kind       Kind                `json:"kind"`
+	Role       string              `json:"role,omitempty"`
+	Slot       Slot                `json:"slot"`
+	Priority   int                 `json:"priority,omitempty"`
+	CacheClass CacheClass          `json:"cache_class,omitempty"`
+	Trust      TrustLevel          `json:"trust,omitempty"`
+	Scope      Scope               `json:"scope,omitempty"`
+	Budget     BudgetPolicy        `json:"budget,omitempty"`
+	Render     RenderPolicy        `json:"render,omitempty"`
+	Provenance canonicalProvenance `json:"provenance,omitempty"`
+	Parts      []canonicalPart     `json:"parts,omitempty"`
+}
+
+type canonicalProvenance struct {
+	Source    string `json:"source,omitempty"`
+	SourceID  string `json:"source_id,omitempty"`
+	Collector string `json:"collector,omitempty"`
+}
+
+type canonicalPart struct {
+	Type      PartType        `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	Image     ImageRef        `json:"image,omitempty"`
+	Message   json.RawMessage `json:"message,omitempty"`
+	ImagePart json.RawMessage `json:"image_part,omitempty"`
+}
+
+func canonicalParts(parts []Part) ([]canonicalPart, error) {
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	out := make([]canonicalPart, 0, len(parts))
+	for _, part := range parts {
+		next := canonicalPart{
+			Type:  part.Type,
+			Text:  part.Text,
+			Image: part.Image,
+		}
+		if msg := partMessage(part); msg != nil {
+			raw, err := json.Marshal(msg)
+			if err != nil {
+				return nil, err
+			}
+			next.Message = raw
+		}
+		if image := partSDKImage(part); image != nil {
+			raw, err := json.Marshal(image)
+			if err != nil {
+				return nil, err
+			}
+			next.ImagePart = raw
+		}
+		out = append(out, next)
+	}
+	return out, nil
+}

--- a/internal/contextfrag/render.go
+++ b/internal/contextfrag/render.go
@@ -18,14 +18,8 @@ func BuildManifest(frags []ContextFrag) Manifest {
 		if err := ValidateContextRef(ref); err != nil {
 			normalized := WithContextRef(frag, ref)
 			ref = normalized.Ref
-			if err := ValidateContextRef(ref); err != nil {
-				manifest.ValidationWarnings = append(manifest.ValidationWarnings, ValidationWarning{
-					Code:    "invalid_context_ref",
-					Message: err.Error(),
-					Ref:     ref,
-				})
-			}
 		}
+		manifest.ValidationWarnings = append(manifest.ValidationWarnings, ContextRefWarnings(ref)...)
 		item := ManifestItem{
 			ID:         frag.ID,
 			Ref:        ref,

--- a/internal/contextfrag/render.go
+++ b/internal/contextfrag/render.go
@@ -1,0 +1,238 @@
+package contextfrag
+
+import (
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// BuildManifest creates a non-sensitive summary from fragments.
+func BuildManifest(frags []ContextFrag) Manifest {
+	manifest := Manifest{
+		SchemaVersions: DefaultSchemaVersions(),
+		SlotPolicies:   DefaultSlotRenderPolicies(),
+	}
+	manifest.Items = make([]ManifestItem, 0, len(frags))
+	for _, frag := range frags {
+		ref := frag.Ref
+		if err := ValidateContextRef(ref); err != nil {
+			normalized := WithContextRef(frag, ref)
+			ref = normalized.Ref
+			if err := ValidateContextRef(ref); err != nil {
+				manifest.ValidationWarnings = append(manifest.ValidationWarnings, ValidationWarning{
+					Code:    "invalid_context_ref",
+					Message: err.Error(),
+					Ref:     ref,
+				})
+			}
+		}
+		item := ManifestItem{
+			ID:         frag.ID,
+			Ref:        ref,
+			Kind:       frag.Kind,
+			Slot:       frag.Slot,
+			Role:       frag.Role,
+			Priority:   frag.Priority,
+			CacheClass: frag.CacheClass,
+			Trust:      frag.Trust,
+			Source:     frag.Provenance.Source,
+			SourceID:   frag.Provenance.SourceID,
+			Collector:  frag.Provenance.Collector,
+			Scope:      frag.Scope,
+		}
+		for _, part := range frag.Parts {
+			item.PartTypes = append(item.PartTypes, part.Type)
+			switch part.Type {
+			case PartText:
+				item.TextBytes += len(part.Text)
+			case PartSDKMessage:
+				item.TextBytes += messageTextBytes(partMessage(part))
+				item.ImageCount += messageImageCount(partMessage(part))
+				manifest.Counts.Messages++
+			case PartImage:
+				item.ImageCount++
+			}
+		}
+		manifest.Counts.TextBytes += item.TextBytes
+		manifest.Counts.Images += item.ImageCount
+		manifest.Items = append(manifest.Items, item)
+	}
+	manifest.Counts.Fragments = len(frags)
+	manifest.RenderedOutputs = renderedOutputRefs(frags)
+	return manifest
+}
+
+// Render builds the legacy SDK-shaped view from fragments.
+func Render(frags []ContextFrag) AssembledContext {
+	var out AssembledContext
+	for _, frag := range frags {
+		switch frag.Slot {
+		case SlotSystem:
+			for _, part := range frag.Parts {
+				if part.Type != PartText || strings.TrimSpace(part.Text) == "" {
+					continue
+				}
+				if out.System != "" {
+					out.System += "\n\n"
+				}
+				out.System += strings.TrimSpace(part.Text)
+			}
+		case SlotCurrentUser:
+			for _, part := range frag.Parts {
+				switch part.Type {
+				case PartText:
+					if strings.TrimSpace(part.Text) != "" {
+						out.Query = strings.TrimSpace(part.Text)
+					}
+				case PartImage:
+					if image := partSDKImage(part); image != nil && strings.TrimSpace(image.Image) != "" {
+						out.InlineImages = append(out.InlineImages, *image)
+					}
+				case PartSDKMessage:
+					if msg := partMessage(part); msg != nil {
+						out.Messages = append(out.Messages, cloneMessage(*msg))
+					}
+				}
+			}
+		default:
+			for _, part := range frag.Parts {
+				if msg := partMessage(part); part.Type == PartSDKMessage && msg != nil {
+					out.Messages = append(out.Messages, cloneMessage(*msg))
+				}
+			}
+		}
+	}
+	return out
+}
+
+func cloneMessage(msg sdk.Message) sdk.Message {
+	out := msg
+	if len(msg.Content) > 0 {
+		out.Content = append([]sdk.MessagePart(nil), msg.Content...)
+	}
+	return out
+}
+
+func partMessage(part Part) *sdk.Message {
+	if part.SDKMessage != nil {
+		return part.SDKMessage
+	}
+	return part.Message
+}
+
+func partSDKImage(part Part) *sdk.ImagePart {
+	if part.SDKImage != nil {
+		return part.SDKImage
+	}
+	return part.ImagePart
+}
+
+func messageTextBytes(msg *sdk.Message) int {
+	if msg == nil {
+		return 0
+	}
+	total := 0
+	for _, part := range msg.Content {
+		switch p := part.(type) {
+		case sdk.TextPart:
+			total += len(p.Text)
+		case sdk.ReasoningPart:
+			total += len(p.Text)
+		}
+	}
+	return total
+}
+
+func messageImageCount(msg *sdk.Message) int {
+	if msg == nil {
+		return 0
+	}
+	total := 0
+	for _, part := range msg.Content {
+		if _, ok := part.(sdk.ImagePart); ok {
+			total++
+		}
+	}
+	return total
+}
+
+func renderTargetForSlot(slot Slot) string {
+	switch slot {
+	case SlotSystem:
+		return "system"
+	case SlotCurrentUser:
+		return "query_inline_images"
+	default:
+		return "messages"
+	}
+}
+
+func renderedOutputRefs(frags []ContextFrag) []RenderedOutputRef {
+	lastCurrentText := lastCurrentUserTextIndex(frags)
+	out := make([]RenderedOutputRef, 0, len(frags))
+	for i, frag := range frags {
+		if !fragContributesToRender(i, frag, lastCurrentText) {
+			continue
+		}
+		ref := frag.Ref
+		if err := ValidateContextRef(ref); err != nil {
+			ref = WithContextRef(frag, ref).Ref
+		}
+		out = append(out, RenderedOutputRef{
+			Target: renderTargetForSlot(frag.Slot),
+			Slot:   frag.Slot,
+			Refs:   []ContextRef{ref},
+		})
+	}
+	return out
+}
+
+func lastCurrentUserTextIndex(frags []ContextFrag) int {
+	last := -1
+	for i, frag := range frags {
+		if frag.Slot != SlotCurrentUser {
+			continue
+		}
+		for _, part := range frag.Parts {
+			if part.Type == PartText && strings.TrimSpace(part.Text) != "" {
+				last = i
+			}
+		}
+	}
+	return last
+}
+
+func fragContributesToRender(index int, frag ContextFrag, lastCurrentText int) bool {
+	switch frag.Slot {
+	case SlotSystem:
+		for _, part := range frag.Parts {
+			if part.Type == PartText && strings.TrimSpace(part.Text) != "" {
+				return true
+			}
+		}
+	case SlotCurrentUser:
+		for _, part := range frag.Parts {
+			switch part.Type {
+			case PartText:
+				if index == lastCurrentText && strings.TrimSpace(part.Text) != "" {
+					return true
+				}
+			case PartImage:
+				if image := partSDKImage(part); image != nil && strings.TrimSpace(image.Image) != "" {
+					return true
+				}
+			case PartSDKMessage:
+				if partMessage(part) != nil {
+					return true
+				}
+			}
+		}
+	default:
+		for _, part := range frag.Parts {
+			if part.Type == PartSDKMessage && partMessage(part) != nil {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/contextfrag/types.go
+++ b/internal/contextfrag/types.go
@@ -1,0 +1,247 @@
+// Package contextfrag defines the typed intermediate representation used to
+// describe context before it is rendered into provider-specific SDK inputs.
+package contextfrag
+
+import sdk "github.com/memohai/twilight-ai/sdk"
+
+// Kind identifies the semantic source and intent of a context fragment.
+type Kind string
+
+const (
+	KindSystemPrompt         Kind = "system_prompt"
+	KindSystemPolicy         Kind = "system_policy"
+	KindBotIdentity          Kind = "bot_identity"
+	KindWorkspaceInstruction Kind = "workspace_instruction"
+	KindPlatformIdentity     Kind = "platform_identity"
+	KindToolUsage            Kind = "tool_usage"
+	KindConversationEvent    Kind = "conversation_event"
+	KindCurrentUserMessage   Kind = "current_user_message"
+	KindAttachmentRef        Kind = "attachment_ref"
+	KindNativeImage          Kind = "native_image"
+	KindHookContext          Kind = "hook_context"
+	KindBackgroundSummary    Kind = "background_summary"
+	KindACPContext           Kind = "acp_context"
+
+	// Reserved for the memory/compaction rewrites. Phase 1 keeps their existing
+	// resolver paths intact while making room for future collectors.
+	KindMemoryRecall        Kind = "memory_recall"
+	KindConversationSummary Kind = "conversation_summary"
+)
+
+// Slot describes where a fragment is rendered in the LLM input layout.
+type Slot string
+
+const (
+	SlotSystem                    Slot = "system"
+	SlotBeforeHistory             Slot = "before_history"
+	SlotHistory                   Slot = "history"
+	SlotAfterHistoryBeforeCurrent Slot = "after_history_before_current"
+	SlotCurrentUser               Slot = "current_user"
+	SlotAfterCurrent              Slot = "after_current"
+)
+
+// CacheClass marks whether a fragment is expected to be prompt-cache friendly.
+type CacheClass string
+
+const (
+	CacheStable  CacheClass = "stable"
+	CacheDynamic CacheClass = "dynamic"
+	CacheNever   CacheClass = "never"
+)
+
+// TrustLevel records whether a fragment comes from Memoh-controlled state or
+// untrusted external conversation content.
+type TrustLevel string
+
+const (
+	TrustSystem    TrustLevel = "system"
+	TrustWorkspace TrustLevel = "workspace"
+	TrustUser      TrustLevel = "user"
+	TrustExternal  TrustLevel = "external"
+)
+
+// OverflowAction is the policy to use when a fragment exceeds budget.
+type OverflowAction string
+
+const (
+	OverflowKeep      OverflowAction = "keep"
+	OverflowTrim      OverflowAction = "trim"
+	OverflowSummarize OverflowAction = "summarize"
+	OverflowDrop      OverflowAction = "drop"
+)
+
+// BudgetPolicy captures the planned budget behavior for a fragment. Phase 1
+// records policy only; enforcement remains in the existing trimming paths.
+type BudgetPolicy struct {
+	MaxTokens int            `json:"max_tokens,omitempty"`
+	MaxChars  int            `json:"max_chars,omitempty"`
+	Overflow  OverflowAction `json:"overflow,omitempty"`
+}
+
+// RenderFormat describes how a fragment should be rendered.
+type RenderFormat string
+
+const (
+	RenderPlainText  RenderFormat = "plain_text"
+	RenderMarkdown   RenderFormat = "markdown"
+	RenderSDKMessage RenderFormat = "sdk_message"
+	RenderNativePart RenderFormat = "native_part"
+)
+
+// RenderPolicy stores rendering hints. Anchor is used for sections such as
+// tool usage that must land before a known heading.
+type RenderPolicy struct {
+	Format RenderFormat `json:"format,omitempty"`
+	Anchor string       `json:"anchor,omitempty"`
+}
+
+// Provenance identifies where a fragment came from.
+type Provenance struct {
+	Source    string `json:"source,omitempty"`
+	SourceID  string `json:"source_id,omitempty"`
+	Collector string `json:"collector,omitempty"`
+	Index     int    `json:"index,omitempty"`
+}
+
+// AttentionReason explains why an IM/group-chat event deserves attention.
+type AttentionReason string
+
+const (
+	AttentionDirect    AttentionReason = "direct"
+	AttentionMention   AttentionReason = "mention"
+	AttentionReply     AttentionReason = "reply"
+	AttentionCommand   AttentionReason = "command"
+	AttentionSchedule  AttentionReason = "schedule"
+	AttentionHeartbeat AttentionReason = "heartbeat"
+	AttentionPassive   AttentionReason = "passive"
+)
+
+// Scope preserves IM/group-chat topology separately from rendered text.
+type Scope struct {
+	BotID                     string            `json:"bot_id,omitempty"`
+	ChatID                    string            `json:"chat_id,omitempty"`
+	SessionID                 string            `json:"session_id,omitempty"`
+	ChannelIdentityID         string            `json:"channel_identity_id,omitempty"`
+	DisplayName               string            `json:"display_name,omitempty"`
+	Platform                  string            `json:"platform,omitempty"`
+	ConversationType          string            `json:"conversation_type,omitempty"`
+	ConversationName          string            `json:"conversation_name,omitempty"`
+	ReplyTarget               string            `json:"reply_target,omitempty"`
+	CurrentMessageID          string            `json:"current_message_id,omitempty"`
+	EventID                   string            `json:"event_id,omitempty"`
+	ReplyToMessageID          string            `json:"reply_to_message_id,omitempty"`
+	ReplySender               string            `json:"reply_sender,omitempty"`
+	MentionsBot               bool              `json:"mentions_bot,omitempty"`
+	RepliesToBot              bool              `json:"replies_to_bot,omitempty"`
+	ForwardMessageID          string            `json:"forward_message_id,omitempty"`
+	ForwardFromUserID         string            `json:"forward_from_user_id,omitempty"`
+	ForwardFromConversationID string            `json:"forward_from_conversation_id,omitempty"`
+	Attention                 []AttentionReason `json:"attention,omitempty"`
+	Metadata                  map[string]string `json:"metadata,omitempty"`
+}
+
+// PartType identifies the payload shape inside a ContextFrag.
+type PartType string
+
+const (
+	PartText       PartType = "text"
+	PartSDKMessage PartType = "sdk_message"
+	PartImage      PartType = "image"
+)
+
+// ImageRef records image metadata without embedding the image payload in the
+// manifest. The actual SDK image part is retained in SDKImage for rendering.
+type ImageRef struct {
+	MediaType string `json:"media_type,omitempty"`
+	Source    string `json:"source,omitempty"`
+}
+
+// Part is one payload item in a context fragment.
+type Part struct {
+	Type       PartType       `json:"type"`
+	Text       string         `json:"text,omitempty"`
+	Image      ImageRef       `json:"image,omitempty"`
+	SDKMessage *sdk.Message   `json:"-"`
+	SDKImage   *sdk.ImagePart `json:"-"`
+}
+
+// ContextFrag is the typed context fragment abstraction.
+type ContextFrag struct {
+	ID         string          `json:"id"`
+	Kind       Kind            `json:"kind"`
+	Role       sdk.MessageRole `json:"role,omitempty"`
+	Slot       Slot            `json:"slot"`
+	Priority   int             `json:"priority,omitempty"`
+	CacheClass CacheClass      `json:"cache_class,omitempty"`
+	Trust      TrustLevel      `json:"trust,omitempty"`
+	Scope      Scope           `json:"scope,omitempty"`
+	Budget     BudgetPolicy    `json:"budget,omitempty"`
+	Render     RenderPolicy    `json:"render,omitempty"`
+	Provenance Provenance      `json:"provenance,omitempty"`
+	Parts      []Part          `json:"parts,omitempty"`
+}
+
+// AssembledContext is the compiled view produced from fragments.
+type AssembledContext struct {
+	Frags        []ContextFrag   `json:"frags,omitempty"`
+	System       string          `json:"system,omitempty"`
+	Messages     []sdk.Message   `json:"-"`
+	Query        string          `json:"query,omitempty"`
+	InlineImages []sdk.ImagePart `json:"-"`
+	Manifest     Manifest        `json:"manifest"`
+}
+
+// Manifest is a content-light accounting view for debugging and review.
+type Manifest struct {
+	Version         int              `json:"version"`
+	View            ManifestView     `json:"view,omitempty"`
+	DynamicMutators []DynamicMutator `json:"dynamic_mutators,omitempty"`
+	Counts          ManifestCounts   `json:"counts"`
+	Items           []ManifestItem   `json:"items,omitempty"`
+}
+
+// ManifestView names the exact view represented by a manifest.
+type ManifestView string
+
+const (
+	ViewRunConfigPreProvider ManifestView = "run_config_pre_provider"
+)
+
+// DynamicMutator names a later runtime transform that can change provider params
+// after the RunConfig-level context frag view has been compiled.
+type DynamicMutator string
+
+const (
+	DynamicMutatorPromptCache         DynamicMutator = "prompt_cache"
+	DynamicMutatorInjectCh            DynamicMutator = "inject_ch"
+	DynamicMutatorReadMedia           DynamicMutator = "read_media"
+	DynamicMutatorBeforeModelCallHook DynamicMutator = "before_model_call_hook"
+	DynamicMutatorBackgroundSummary   DynamicMutator = "background_summary"
+	DynamicMutatorMidTaskPrune        DynamicMutator = "mid_task_prune"
+)
+
+// ManifestCounts summarizes fragment composition.
+type ManifestCounts struct {
+	Fragments int `json:"fragments"`
+	Messages  int `json:"messages"`
+	Images    int `json:"images"`
+	TextBytes int `json:"text_bytes"`
+}
+
+// ManifestItem is one non-sensitive fragment entry.
+type ManifestItem struct {
+	ID         string          `json:"id"`
+	Kind       Kind            `json:"kind"`
+	Slot       Slot            `json:"slot"`
+	Role       sdk.MessageRole `json:"role,omitempty"`
+	Priority   int             `json:"priority,omitempty"`
+	CacheClass CacheClass      `json:"cache_class,omitempty"`
+	Trust      TrustLevel      `json:"trust,omitempty"`
+	Source     string          `json:"source,omitempty"`
+	SourceID   string          `json:"source_id,omitempty"`
+	Collector  string          `json:"collector,omitempty"`
+	PartTypes  []PartType      `json:"part_types,omitempty"`
+	TextBytes  int             `json:"text_bytes,omitempty"`
+	ImageCount int             `json:"image_count,omitempty"`
+	Scope      Scope           `json:"scope,omitempty"`
+}

--- a/internal/contextfrag/types.go
+++ b/internal/contextfrag/types.go
@@ -28,6 +28,8 @@ const (
 	KindConversationSummary Kind = "conversation_summary"
 )
 
+// v1 keeps all context schema versions in lockstep; future migrations can
+// split this into per-schema supported ranges without changing manifest shape.
 const CurrentSchemaVersion = 1
 
 const (
@@ -63,6 +65,7 @@ type ContextRef struct {
 	ContentHash string        `json:"content_hash,omitempty"`
 	HashScope   string        `json:"hash_scope,omitempty"`
 	Schema      string        `json:"schema"`
+	Durability  RefDurability `json:"durability,omitempty"`
 }
 
 type FragmentHash struct {
@@ -70,6 +73,14 @@ type FragmentHash struct {
 	Scope string `json:"scope"`
 	Value string `json:"value"`
 }
+
+type RefDurability string
+
+const (
+	RefDurable   RefDurability = "durable"
+	RefSynthetic RefDurability = "synthetic"
+	RefDebug     RefDurability = "debug"
+)
 
 // Slot describes where a fragment is rendered in the LLM input layout.
 type Slot string
@@ -347,11 +358,12 @@ type ContextEditTrace struct {
 }
 
 type SummaryCoverage struct {
-	CoverageID     string        `json:"coverage_id"`
-	SummaryRef     ContextRef    `json:"summary_ref"`
-	CoveredRefs    []ContextRef  `json:"covered_refs,omitempty"`
-	CoveredFragIDs []string      `json:"covered_frag_ids,omitempty"`
-	Schema         SchemaVersion `json:"schema"`
+	CoverageID  string       `json:"coverage_id"`
+	SummaryRef  ContextRef   `json:"summary_ref"`
+	CoveredRefs []ContextRef `json:"covered_refs,omitempty"`
+	// TraceFragIDs is debug-only and must not be used as durable coverage identity.
+	TraceFragIDs []string      `json:"trace_frag_ids,omitempty"`
+	Schema       SchemaVersion `json:"schema"`
 }
 
 type ContinuityGroup struct {

--- a/internal/contextfrag/types.go
+++ b/internal/contextfrag/types.go
@@ -28,6 +28,49 @@ const (
 	KindConversationSummary Kind = "conversation_summary"
 )
 
+const CurrentSchemaVersion = 1
+
+const (
+	SchemaContextManifest = "context_manifest"
+	SchemaContextFrag     = "context_frag"
+	SchemaContextRef      = "context_ref"
+	SchemaContextEdit     = "context_edit"
+	SchemaSummaryCoverage = "summary_coverage"
+	SchemaRenderPolicy    = "render_policy"
+)
+
+const (
+	HashAlgoSHA256             = "sha256"
+	HashScopeCanonicalFragment = "canonical_fragment"
+)
+
+type SchemaVersion struct {
+	Name    string `json:"name"`
+	Version int    `json:"version"`
+}
+
+type ContentRange struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+type ContextRef struct {
+	Namespace   string        `json:"namespace"`
+	ID          string        `json:"id"`
+	Version     int           `json:"version,omitempty"`
+	Range       *ContentRange `json:"range,omitempty"`
+	HashAlgo    string        `json:"hash_algo,omitempty"`
+	ContentHash string        `json:"content_hash,omitempty"`
+	HashScope   string        `json:"hash_scope,omitempty"`
+	Schema      string        `json:"schema"`
+}
+
+type FragmentHash struct {
+	Algo  string `json:"algo"`
+	Scope string `json:"scope"`
+	Value string `json:"value"`
+}
+
 // Slot describes where a fragment is rendered in the LLM input layout.
 type Slot string
 
@@ -161,6 +204,8 @@ type Part struct {
 	Type       PartType       `json:"type"`
 	Text       string         `json:"text,omitempty"`
 	Image      ImageRef       `json:"image,omitempty"`
+	Message    *sdk.Message   `json:"message,omitempty"`
+	ImagePart  *sdk.ImagePart `json:"image_part,omitempty"`
 	SDKMessage *sdk.Message   `json:"-"`
 	SDKImage   *sdk.ImagePart `json:"-"`
 }
@@ -168,6 +213,7 @@ type Part struct {
 // ContextFrag is the typed context fragment abstraction.
 type ContextFrag struct {
 	ID         string          `json:"id"`
+	Ref        ContextRef      `json:"ref,omitempty"`
 	Kind       Kind            `json:"kind"`
 	Role       sdk.MessageRole `json:"role,omitempty"`
 	Slot       Slot            `json:"slot"`
@@ -193,11 +239,17 @@ type AssembledContext struct {
 
 // Manifest is a content-light accounting view for debugging and review.
 type Manifest struct {
-	Version         int              `json:"version"`
-	View            ManifestView     `json:"view,omitempty"`
-	DynamicMutators []DynamicMutator `json:"dynamic_mutators,omitempty"`
-	Counts          ManifestCounts   `json:"counts"`
-	Items           []ManifestItem   `json:"items,omitempty"`
+	SchemaVersions     []SchemaVersion     `json:"schema_versions,omitempty"`
+	View               ManifestView        `json:"view,omitempty"`
+	DynamicMutators    []DynamicMutator    `json:"dynamic_mutators,omitempty"`
+	SlotPolicies       []SlotRenderPolicy  `json:"slot_policies,omitempty"`
+	RenderedOutputs    []RenderedOutputRef `json:"rendered_outputs,omitempty"`
+	EditTrace          []ContextEditTrace  `json:"edit_trace,omitempty"`
+	CoverageTrace      []SummaryCoverage   `json:"coverage_trace,omitempty"`
+	ContinuityGroups   []ContinuityGroup   `json:"continuity_groups,omitempty"`
+	ValidationWarnings []ValidationWarning `json:"validation_warnings,omitempty"`
+	Counts             ManifestCounts      `json:"counts"`
+	Items              []ManifestItem      `json:"items,omitempty"`
 }
 
 // ManifestView names the exact view represented by a manifest.
@@ -231,6 +283,7 @@ type ManifestCounts struct {
 // ManifestItem is one non-sensitive fragment entry.
 type ManifestItem struct {
 	ID         string          `json:"id"`
+	Ref        ContextRef      `json:"ref,omitempty"`
 	Kind       Kind            `json:"kind"`
 	Slot       Slot            `json:"slot"`
 	Role       sdk.MessageRole `json:"role,omitempty"`
@@ -244,4 +297,92 @@ type ManifestItem struct {
 	TextBytes  int             `json:"text_bytes,omitempty"`
 	ImageCount int             `json:"image_count,omitempty"`
 	Scope      Scope           `json:"scope,omitempty"`
+}
+
+type SlotRenderPolicy struct {
+	Slot          Slot   `json:"slot"`
+	Order         string `json:"order,omitempty"`
+	DedupeBy      string `json:"dedupe_by,omitempty"`
+	CoverageAware bool   `json:"coverage_aware,omitempty"`
+	Target        string `json:"target"`
+}
+
+type RenderedOutputRef struct {
+	Target string       `json:"target"`
+	Slot   Slot         `json:"slot,omitempty"`
+	Refs   []ContextRef `json:"refs,omitempty"`
+}
+
+type ContextEditOp string
+
+const (
+	EditAppend   ContextEditOp = "append"
+	EditReplace  ContextEditOp = "replace"
+	EditRemove   ContextEditOp = "remove"
+	EditCover    ContextEditOp = "cover"
+	EditAnnotate ContextEditOp = "annotate"
+)
+
+type ContextEdit struct {
+	EditID        string            `json:"edit_id"`
+	Slot          Slot              `json:"slot"`
+	Op            ContextEditOp     `json:"op"`
+	Refs          []ContextRef      `json:"refs,omitempty"`
+	Payload       []ContextFrag     `json:"payload,omitempty"`
+	Preconditions EditPreconditions `json:"preconditions,omitempty"`
+	Schema        SchemaVersion     `json:"schema"`
+}
+
+type EditPreconditions struct {
+	ExpectedRevision string            `json:"expected_revision,omitempty"`
+	MaxSequence      int64             `json:"max_sequence,omitempty"`
+	ExpectedHashes   map[string]string `json:"expected_hashes,omitempty"`
+}
+
+type ContextEditTrace struct {
+	EditID string        `json:"edit_id,omitempty"`
+	Op     ContextEditOp `json:"op,omitempty"`
+	Slot   Slot          `json:"slot,omitempty"`
+	Refs   []ContextRef  `json:"refs,omitempty"`
+}
+
+type SummaryCoverage struct {
+	CoverageID     string        `json:"coverage_id"`
+	SummaryRef     ContextRef    `json:"summary_ref"`
+	CoveredRefs    []ContextRef  `json:"covered_refs,omitempty"`
+	CoveredFragIDs []string      `json:"covered_frag_ids,omitempty"`
+	Schema         SchemaVersion `json:"schema"`
+}
+
+type ContinuityGroup struct {
+	ID               string       `json:"id"`
+	Kind             string       `json:"kind"`
+	Provider         string       `json:"provider,omitempty"`
+	ModelFamily      string       `json:"model_family,omitempty"`
+	Refs             []ContextRef `json:"refs,omitempty"`
+	MustKeepTogether bool         `json:"must_keep_together,omitempty"`
+	MustKeepRaw      bool         `json:"must_keep_raw,omitempty"`
+	MustKeepOrder    bool         `json:"must_keep_order,omitempty"`
+	MustBeComplete   bool         `json:"must_be_complete,omitempty"`
+}
+
+type ValidationWarning struct {
+	Code    string     `json:"code"`
+	Message string     `json:"message,omitempty"`
+	Ref     ContextRef `json:"ref,omitempty"`
+}
+
+type ConflictKind string
+
+const (
+	ConflictMissingRef          ConflictKind = "missing_ref"
+	ConflictContentHashMismatch ConflictKind = "content_hash_mismatch"
+	ConflictInvalidSchema       ConflictKind = "invalid_schema"
+)
+
+type ContextConflict struct {
+	Kind     ConflictKind `json:"kind"`
+	Key      string       `json:"key,omitempty"`
+	Expected string       `json:"expected,omitempty"`
+	Actual   string       `json:"actual,omitempty"`
 }

--- a/internal/conversation/flow/context_frag.go
+++ b/internal/conversation/flow/context_frag.go
@@ -1,0 +1,77 @@
+package flow
+
+import (
+	"strings"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
+	"github.com/memohai/memoh/internal/contextfrag"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func buildContextFragScope(req conversation.ChatRequest, displayName string, identity agentpkg.SessionContext) contextfrag.Scope {
+	channelIdentityID := firstNonEmpty(req.SourceChannelIdentityID, identity.ChannelIdentityID)
+	scope := contextfrag.Scope{
+		BotID:                     firstNonEmpty(req.BotID, identity.BotID),
+		ChatID:                    firstNonEmpty(req.ChatID, identity.ChatID),
+		SessionID:                 firstNonEmpty(req.SessionID, identity.SessionID),
+		ChannelIdentityID:         strings.TrimSpace(channelIdentityID),
+		DisplayName:               strings.TrimSpace(displayName),
+		Platform:                  firstNonEmpty(req.CurrentChannel, identity.CurrentPlatform),
+		ConversationType:          firstNonEmpty(req.ConversationType, identity.ConversationType),
+		ConversationName:          strings.TrimSpace(req.ConversationName),
+		ReplyTarget:               firstNonEmpty(req.ReplyTarget, identity.ReplyTarget),
+		CurrentMessageID:          strings.TrimSpace(req.ExternalMessageID),
+		EventID:                   strings.TrimSpace(req.EventID),
+		ReplyToMessageID:          strings.TrimSpace(req.SourceReplyToMessageID),
+		ReplySender:               strings.TrimSpace(req.ReplySender),
+		MentionsBot:               req.MentionsBot,
+		RepliesToBot:              req.RepliesToBot,
+		ForwardMessageID:          strings.TrimSpace(req.ForwardMessageID),
+		ForwardFromUserID:         strings.TrimSpace(req.ForwardFromUserID),
+		ForwardFromConversationID: strings.TrimSpace(req.ForwardFromConversationID),
+	}
+	scope.Attention = contextFragAttentionReasons(req)
+	return scope
+}
+
+func contextFragAttentionReasons(req conversation.ChatRequest) []contextfrag.AttentionReason {
+	var reasons []contextfrag.AttentionReason
+	add := func(reason contextfrag.AttentionReason) {
+		for _, existing := range reasons {
+			if existing == reason {
+				return
+			}
+		}
+		reasons = append(reasons, reason)
+	}
+
+	switch strings.TrimSpace(req.SessionType) {
+	case sessionmode.Schedule:
+		add(contextfrag.AttentionSchedule)
+	case sessionmode.Heartbeat:
+		add(contextfrag.AttentionHeartbeat)
+	}
+	if req.MentionsBot {
+		add(contextfrag.AttentionMention)
+	}
+	if req.RepliesToBot {
+		add(contextfrag.AttentionReply)
+	}
+	query := strings.TrimSpace(firstNonEmpty(req.RawQuery, req.Query))
+	if strings.HasPrefix(query, "/") {
+		add(contextfrag.AttentionCommand)
+	}
+	switch strings.ToLower(strings.TrimSpace(req.ConversationType)) {
+	case conversation.KindDirect, "private", "":
+		add(contextfrag.AttentionDirect)
+	case conversation.KindGroup, conversation.KindThread:
+		if len(reasons) == 0 {
+			add(contextfrag.AttentionPassive)
+		}
+	}
+	if len(reasons) == 0 {
+		add(contextfrag.AttentionPassive)
+	}
+	return reasons
+}

--- a/internal/conversation/flow/context_frag_test.go
+++ b/internal/conversation/flow/context_frag_test.go
@@ -1,0 +1,92 @@
+package flow
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/contextfrag"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func TestBuildContextFragScopePreservesIMTopology(t *testing.T) {
+	t.Parallel()
+
+	scope := buildContextFragScope(conversation.ChatRequest{
+		BotID:                     "bot-1",
+		ChatID:                    "chat-1",
+		SessionID:                 "sess-1",
+		SourceChannelIdentityID:   "identity-1",
+		DisplayName:               "ignored",
+		CurrentChannel:            "telegram",
+		ConversationType:          conversation.KindGroup,
+		ConversationName:          "Research Group",
+		ReplyTarget:               "group-1",
+		ExternalMessageID:         "msg-1",
+		EventID:                   "evt-1",
+		SourceReplyToMessageID:    "msg-0",
+		ReplySender:               "Alice",
+		MentionsBot:               true,
+		RepliesToBot:              true,
+		ForwardMessageID:          "fwd-1",
+		ForwardFromUserID:         "user-2",
+		ForwardFromConversationID: "source-chat",
+		RawQuery:                  "/summarize this",
+	}, "Bob", agent.SessionContext{})
+
+	if scope.BotID != "bot-1" || scope.ChatID != "chat-1" || scope.SessionID != "sess-1" {
+		t.Fatalf("unexpected base scope: %#v", scope)
+	}
+	if scope.Platform != "telegram" || scope.ConversationType != conversation.KindGroup || scope.ConversationName != "Research Group" {
+		t.Fatalf("unexpected conversation scope: %#v", scope)
+	}
+	if scope.CurrentMessageID != "msg-1" || scope.EventID != "evt-1" || scope.ReplyToMessageID != "msg-0" {
+		t.Fatalf("unexpected message topology: %#v", scope)
+	}
+	if !scope.MentionsBot || !scope.RepliesToBot {
+		t.Fatalf("expected structured directed-at-bot flags in scope: %#v", scope)
+	}
+	if scope.ForwardMessageID != "fwd-1" || scope.ForwardFromUserID != "user-2" || scope.ForwardFromConversationID != "source-chat" {
+		t.Fatalf("unexpected forward topology: %#v", scope)
+	}
+	if !hasAttention(scope.Attention, contextfrag.AttentionReply) || !hasAttention(scope.Attention, contextfrag.AttentionCommand) {
+		t.Fatalf("attention reasons = %#v, want reply and command", scope.Attention)
+	}
+	if !hasAttention(scope.Attention, contextfrag.AttentionMention) {
+		t.Fatalf("attention reasons = %#v, want mention", scope.Attention)
+	}
+	if hasAttention(scope.Attention, contextfrag.AttentionPassive) {
+		t.Fatalf("attention reasons should not include passive when reply/command are present: %#v", scope.Attention)
+	}
+}
+
+func TestBuildContextFragScopeDoesNotInferDirectedReplyFromAnyReplyID(t *testing.T) {
+	t.Parallel()
+
+	scope := buildContextFragScope(conversation.ChatRequest{
+		BotID:                  "bot-1",
+		ChatID:                 "chat-1",
+		SessionID:              "sess-1",
+		ConversationType:       conversation.KindGroup,
+		SourceReplyToMessageID: "someone-elses-message",
+		Query:                  "thread side comment",
+	}, "Bob", agent.SessionContext{})
+
+	if scope.ReplyToMessageID != "someone-elses-message" {
+		t.Fatalf("reply topology not preserved: %#v", scope)
+	}
+	if hasAttention(scope.Attention, contextfrag.AttentionReply) || hasAttention(scope.Attention, contextfrag.AttentionMention) {
+		t.Fatalf("attention should not infer directed reply/mention without structured flags: %#v", scope.Attention)
+	}
+	if !hasAttention(scope.Attention, contextfrag.AttentionPassive) {
+		t.Fatalf("group reply without directed flags should be passive attention: %#v", scope.Attention)
+	}
+}
+
+func hasAttention(reasons []contextfrag.AttentionReason, want contextfrag.AttentionReason) bool {
+	for _, reason := range reasons {
+		if reason == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/conversation/flow/context_frag_test.go
+++ b/internal/conversation/flow/context_frag_test.go
@@ -1,7 +1,10 @@
 package flow
 
 import (
+	"context"
 	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
 
 	"github.com/memohai/memoh/internal/agent"
 	"github.com/memohai/memoh/internal/contextfrag"
@@ -82,10 +85,45 @@ func TestBuildContextFragScopeDoesNotInferDirectedReplyFromAnyReplyID(t *testing
 	}
 }
 
+func TestPrepareRunConfigDoesNotDoubleCountPipelineInlineImages(t *testing.T) {
+	t.Parallel()
+
+	image := sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"}
+	resolver := &Resolver{}
+	cfg := agent.RunConfig{
+		Messages:     []sdk.Message{sdk.UserMessage("pipeline current user")},
+		InlineImages: []sdk.ImagePart{image},
+	}
+
+	got := resolver.prepareRunConfig(context.Background(), cfg)
+
+	if got.ContextManifest.Counts.Images != 1 {
+		t.Fatalf("manifest image count = %d, want only image injected into SDK message: %#v", got.ContextManifest.Counts.Images, got.ContextManifest.Items)
+	}
+	rendered := contextfrag.Render(got.ContextFrags)
+	if len(rendered.InlineImages) != 0 {
+		t.Fatalf("rendered inline images = %#v, want images only inside pipeline SDK message", rendered.InlineImages)
+	}
+	if !messagesContainImage(got.Messages) {
+		t.Fatalf("prepared messages do not contain injected image: %#v", got.Messages)
+	}
+}
+
 func hasAttention(reasons []contextfrag.AttentionReason, want contextfrag.AttentionReason) bool {
 	for _, reason := range reasons {
 		if reason == want {
 			return true
+		}
+	}
+	return false
+}
+
+func messagesContainImage(messages []sdk.Message) bool {
+	for _, message := range messages {
+		for _, part := range message.Content {
+			if _, ok := part.(sdk.ImagePart); ok {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/conversation/flow/resolver.go
+++ b/internal/conversation/flow/resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/memohai/memoh/internal/agent/sessionmode"
 	"github.com/memohai/memoh/internal/channel"
 	"github.com/memohai/memoh/internal/compaction"
+	"github.com/memohai/memoh/internal/contextfrag"
 	"github.com/memohai/memoh/internal/conversation"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -443,6 +444,8 @@ func (r *Resolver) resolve(ctx context.Context, req conversation.ChatRequest, ru
 		runCfg.Query = headerifiedQuery
 	}
 	runCfg.InlineImages = extractNativeImageParts(mergedAttachments)
+	runCfg.ContextScope = buildContextFragScope(req, displayName, runCfg.Identity)
+	runCfg = runCfg.RefreshContextFrag()
 
 	var injectedRecords *[]conversation.InjectedMessageRecord
 	if req.InjectCh != nil {
@@ -664,6 +667,15 @@ func (r *Resolver) buildBaseRunConfig(ctx context.Context, p baseRunConfigParams
 		Skills:            agentSkills,
 		LoopDetection:     agentpkg.LoopDetectionConfig{Enabled: loopDetectionEnabled},
 		BackgroundManager: r.bgManager,
+		ContextScope: contextfrag.Scope{
+			BotID:             p.BotID,
+			ChatID:            chatID,
+			SessionID:         p.SessionID,
+			ChannelIdentityID: strings.TrimSpace(p.ChannelIdentityID),
+			Platform:          strings.TrimSpace(p.CurrentPlatform),
+			ConversationType:  strings.TrimSpace(p.ConversationType),
+			ReplyTarget:       strings.TrimSpace(p.ReplyTarget),
+		},
 	}
 	if r.toolApproval != nil || r.userInput != nil {
 		cfg.ToolApprovalHandler = r.buildToolApprovalHandler(p)
@@ -1176,6 +1188,7 @@ func (r *Resolver) prepareRunConfig(ctx context.Context, cfg agentpkg.RunConfig)
 			}
 		}
 		cfg.Messages = append(cfg.Messages, sdk.UserMessage(cfg.Query, extra...))
+		cfg.ContextQueryMaterialized = true
 	} else if len(cfg.InlineImages) > 0 {
 		// Pipeline path: the user query is already embedded in the RC messages,
 		// but image parts are not rendered by the pipeline renderer. Inject the
@@ -1201,7 +1214,7 @@ func (r *Resolver) prepareRunConfig(ctx context.Context, cfg agentpkg.RunConfig)
 		}
 	}
 
-	return cfg
+	return cfg.RefreshContextFrag()
 }
 
 func normalizeGatewaySkill(entry SkillEntry) (agentpkg.SkillEntry, bool) {

--- a/internal/conversation/flow/resolver.go
+++ b/internal/conversation/flow/resolver.go
@@ -1211,6 +1211,7 @@ func (r *Resolver) prepareRunConfig(ctx context.Context, cfg agentpkg.RunConfig)
 			if !injected {
 				cfg.Messages = append(cfg.Messages, sdk.UserMessage("", imageParts...))
 			}
+			cfg.ContextQueryMaterialized = true
 		}
 	}
 

--- a/internal/conversation/flow/resolver_trigger.go
+++ b/internal/conversation/flow/resolver_trigger.go
@@ -43,6 +43,7 @@ func (r *Resolver) TriggerSchedule(ctx context.Context, botID string, payload sc
 	cfg := rc.runConfig
 	cfg.SessionType = sessionmode.Schedule
 	cfg.Identity.ChannelIdentityID = strings.TrimSpace(payload.OwnerUserID)
+	cfg.ContextScope.ChannelIdentityID = strings.TrimSpace(payload.OwnerUserID)
 
 	schedulePrompt := agentpkg.GenerateSchedulePrompt(agentpkg.Schedule{
 		ID:          payload.ID,
@@ -103,6 +104,7 @@ func (r *Resolver) TriggerHeartbeat(ctx context.Context, botID string, payload h
 	cfg := rc.runConfig
 	cfg.SessionType = sessionmode.Heartbeat
 	cfg.Identity.ChannelIdentityID = strings.TrimSpace(payload.OwnerUserID)
+	cfg.ContextScope.ChannelIdentityID = strings.TrimSpace(payload.OwnerUserID)
 
 	var checklist string
 	if r.agent != nil {

--- a/internal/conversation/types.go
+++ b/internal/conversation/types.go
@@ -240,6 +240,8 @@ type ChatRequest struct {
 	ReplySender               string           `json:"-"`
 	ReplyPreview              string           `json:"-"`
 	ReplyAttachments          []ChatAttachment `json:"-"`
+	MentionsBot               bool             `json:"-"`
+	RepliesToBot              bool             `json:"-"`
 	ForwardMessageID          string           `json:"-"`
 	ForwardFromUserID         string           `json:"-"`
 	ForwardFromConversationID string           `json:"-"`

--- a/internal/pipeline/driver.go
+++ b/internal/pipeline/driver.go
@@ -344,6 +344,7 @@ func (d *DiscussDriver) handleReplyWithAgent(ctx context.Context, sess *discussS
 	isMentioned := wasRecentlyMentioned(rc, sess.lastProcessedMs)
 	lateBinding := buildLateBindingPrompt(isMentioned)
 	runConfig.Messages = append(runConfig.Messages, sdk.UserMessage(lateBinding))
+	runConfig = runConfig.RefreshContextFrag()
 
 	eventCh := agent.Stream(ctx, runConfig)
 

--- a/internal/pipeline/driver_test.go
+++ b/internal/pipeline/driver_test.go
@@ -11,6 +11,7 @@ import (
 
 	agentpkg "github.com/memohai/memoh/internal/agent"
 	"github.com/memohai/memoh/internal/channel"
+	"github.com/memohai/memoh/internal/contextfrag"
 	"github.com/memohai/memoh/internal/conversation"
 	sessionpkg "github.com/memohai/memoh/internal/session"
 )
@@ -723,6 +724,43 @@ func TestAgentEventToChannelEventMapsACPDecisionRequests(t *testing.T) {
 	}
 }
 
+func TestHandleReplyWithAgentRefreshesContextFragAfterLateBinding(t *testing.T) {
+	rc := RenderedContext{
+		{
+			ReceivedAtMs: 200,
+			Content:      []RenderedContentPiece{{Type: "text", Text: `<message id="x">hello</message>`}},
+		},
+	}
+	fakeAgent := &fakeDiscussStreamer{}
+	resolver := &fakeRunConfigResolver{
+		resolveResult: ResolveRunConfigResult{
+			RunConfig: agentpkg.RunConfig{System: "base system"},
+			ModelID:   "model-1",
+		},
+	}
+	driver := NewDiscussDriver(DiscussDriverDeps{
+		Pipeline: NewPipeline(RenderParams{}),
+		Resolver: resolver,
+	})
+	sess := &discussSession{
+		config:          DiscussSessionConfig{BotID: "b", SessionID: "s"},
+		lastProcessedMs: 0,
+	}
+
+	driver.handleReplyWithAgent(context.Background(), sess, rc, driver.logger, fakeAgent)
+
+	if fakeAgent.lastConfig == nil {
+		t.Fatal("expected agent to be invoked")
+	}
+	cfg := fakeAgent.lastConfig
+	if cfg.ContextManifest.Counts.Messages != len(cfg.Messages) {
+		t.Fatalf("manifest message count = %d, messages = %d", cfg.ContextManifest.Counts.Messages, len(cfg.Messages))
+	}
+	if !lastMessageFragContains(cfg.ContextFrags, "IMPORTANT: You MUST use the `send` tool") {
+		t.Fatalf("context frags do not include late-binding prompt: %#v", cfg.ContextManifest.Items)
+	}
+}
+
 // --- Test helpers ---
 
 type fakeDiscussStreamer struct {
@@ -798,4 +836,20 @@ func (f *fakeDiscussCursorStore) UpsertDiscussConsumedCursor(_ context.Context, 
 	f.upsertRouteID = routeID
 	f.upsertCursor = cursor
 	return nil
+}
+
+func lastMessageFragContains(frags []contextfrag.ContextFrag, needle string) bool {
+	for i := len(frags) - 1; i >= 0; i-- {
+		frag := frags[i]
+		if frag.Kind != contextfrag.KindConversationEvent || len(frag.Parts) == 0 || frag.Parts[0].SDKMessage == nil {
+			continue
+		}
+		for _, part := range frag.Parts[0].SDKMessage.Content {
+			if text, ok := part.(sdk.TextPart); ok && strings.Contains(text.Text, needle) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }


### PR DESCRIPTION

## Summary
- 引入 typed context fragment 编译路径，为后续 history、summary、budget 等不同来源的上下文提供统一结构。
- 修正显式 message fragment 的保留行为：当调用方明确传入 message fragment 时，编译结果会保留其原始语义和源位置，不再被后续普通文本拼接或 fallback 逻辑覆盖。
- 保持 origin/main 上既有 output-limit wrapping 行为，同时接入新的 context fragment 刷新和 tool usage 路径。

## Boundary
- 显式 message fragment 是调用方已完成语义归类的输入，编译器不能擅自重写 role、位置或内容。
- context fragment 编译只负责把 fragment 转成模型输入，不负责推断更高层的 conversation/history 语义。
- 覆盖了显式 message fragment 在 source position 上被保留的回归测试。