### PR TITLE
feat(compaction): select candidates via typed history records

### DIFF
--- a/db/postgres/queries/messages.sql
+++ b/db/postgres/queries/messages.sql
@@ -2281,8 +2281,36 @@ SET compact_id = $1
 WHERE id = ANY($2::uuid[]);
 
 -- name: ListUncompactedMessagesBySession :many
-SELECT id, bot_id, session_id, role, content, usage, sender_channel_identity_id, compact_id, created_at
-FROM bot_visible_history_messages
-WHERE session_id = $1
-  AND compact_id IS NULL
-ORDER BY turn_position ASC, turn_message_seq ASC, created_at ASC, id ASC;
+SELECT
+  m.id,
+  m.bot_id,
+  m.session_id,
+  m.sender_channel_identity_id,
+  m.sender_account_user_id AS sender_user_id,
+  m.source_message_id AS external_message_id,
+  m.source_reply_to_message_id,
+  m.role,
+  m.content,
+  m.metadata,
+  m.usage,
+  m.event_id,
+  m.display_text,
+  m.compact_id,
+  m.created_at,
+  ci.display_name AS sender_display_name,
+  ci.avatar_url AS sender_avatar_url,
+  s.channel_type AS platform,
+  r.conversation_type AS conversation_type,
+  COALESCE(
+    NULLIF(TRIM(COALESCE(r.metadata->>'conversation_name', '')), ''),
+    NULLIF(TRIM(COALESCE(r.metadata->>'conversation_handle', '')), ''),
+    ''
+  )::text AS conversation_name,
+  r.default_reply_target AS reply_target
+FROM bot_visible_history_messages m
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
+LEFT JOIN bot_sessions s ON s.id = m.session_id
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE m.session_id = $1
+  AND m.compact_id IS NULL
+ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC;

--- a/db/postgres/queries/messages.sql
+++ b/db/postgres/queries/messages.sql
@@ -2312,11 +2312,14 @@ LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_channel_routes r ON r.id = s.route_id
 WHERE m.session_id = $1
-  -- Rows whose compact log never completed ok (crash between mark and
-  -- complete, deleted logs) stay eligible so their content is not lost.
+  -- Rows stay eligible unless their compact log holds a usable summary,
+  -- matching the read path's substitution predicate (status ok AND non-empty
+  -- summary). This also reclaims rows stranded by a crash between mark and
+  -- complete, by deleted logs, and legacy status='ok' rows whose summary is
+  -- empty (the pre-existing poison state).
   AND (m.compact_id IS NULL OR NOT EXISTS (
     SELECT 1 FROM bot_history_message_compacts c
-    WHERE c.id = m.compact_id AND c.status = 'ok'
+    WHERE c.id = m.compact_id AND c.status = 'ok' AND c.summary <> ''
   ))
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC;

--- a/db/postgres/queries/messages.sql
+++ b/db/postgres/queries/messages.sql
@@ -2313,4 +2313,5 @@ LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_channel_routes r ON r.id = s.route_id
 WHERE m.session_id = $1
   AND m.compact_id IS NULL
+  AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC;

--- a/db/postgres/queries/messages.sql
+++ b/db/postgres/queries/messages.sql
@@ -2313,13 +2313,14 @@ LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_channel_routes r ON r.id = s.route_id
 WHERE m.session_id = $1
   -- Rows stay eligible unless their compact log holds a usable summary,
-  -- matching the read path's substitution predicate (status ok AND non-empty
+  -- matching the read path's substitution predicate (status ok AND non-blank
   -- summary). This also reclaims rows stranded by a crash between mark and
   -- complete, by deleted logs, and legacy status='ok' rows whose summary is
-  -- empty (the pre-existing poison state).
+  -- empty or whitespace-only (the pre-existing poison states).
   AND (m.compact_id IS NULL OR NOT EXISTS (
     SELECT 1 FROM bot_history_message_compacts c
-    WHERE c.id = m.compact_id AND c.status = 'ok' AND c.summary <> ''
+    WHERE c.id = m.compact_id AND c.status = 'ok'
+      AND NULLIF(BTRIM(c.summary, E' \t\n\r\f\x0B'), '') IS NOT NULL
   ))
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC;

--- a/db/postgres/queries/messages.sql
+++ b/db/postgres/queries/messages.sql
@@ -2312,6 +2312,11 @@ LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_channel_routes r ON r.id = s.route_id
 WHERE m.session_id = $1
-  AND m.compact_id IS NULL
+  -- Rows whose compact log never completed ok (crash between mark and
+  -- complete, deleted logs) stay eligible so their content is not lost.
+  AND (m.compact_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM bot_history_message_compacts c
+    WHERE c.id = m.compact_id AND c.status = 'ok'
+  ))
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC;

--- a/internal/command/compact.go
+++ b/internal/command/compact.go
@@ -59,8 +59,12 @@ func (h *Handler) buildCompactGroup() *CommandGroup {
 				return "", err
 			}
 
-			if err := h.compactionService.RunCompactionSync(cc.Ctx, cfg); err != nil {
+			res, err := h.compactionService.RunCompactionSync(cc.Ctx, cfg)
+			if err != nil {
 				return "", fmt.Errorf("compaction failed: %w", err)
+			}
+			if res.Status != compaction.StatusOK {
+				return cc.T("cmd.compact.noop"), nil
 			}
 			return cc.T("cmd.compact.done"), nil
 		},

--- a/internal/command/compact.go
+++ b/internal/command/compact.go
@@ -108,6 +108,7 @@ func (h *Handler) buildCompactConfig(cc CommandContext, sessionID string) (compa
 		Ratio:            100,
 		TotalInputTokens: 1,
 		PromptCacheTTL:   providers.ProviderConfigString(compactProvider, "prompt_cache_ttl"),
+		Manual:           true,
 	}
 	if compactModel.Config.ContextWindow != nil && *compactModel.Config.ContextWindow > 0 {
 		cfg.MaxCompactTokens = *compactModel.Config.ContextWindow * 90 / 100

--- a/internal/compaction/assembly_test.go
+++ b/internal/compaction/assembly_test.go
@@ -17,10 +17,7 @@ func TestBuildEntriesAndIDsMarksAllSelectedButSkipsEmptyEntries(t *testing.T) {
 		mkRow(t, "assistant", `[{"type":"reasoning","text":"thinking"}]`, 0),
 		mkRow(t, "assistant", `"the answer"`, 0),
 	}
-	items, err := itemsFromRows(rows)
-	if err != nil {
-		t.Fatalf("itemsFromRows: %v", err)
-	}
+	items, _ := itemsFromRows(rows)
 
 	entries, ids := buildEntriesAndIDs(items)
 

--- a/internal/compaction/assembly_test.go
+++ b/internal/compaction/assembly_test.go
@@ -59,8 +59,11 @@ func TestBuildEntriesAndIDsWithholdsWholeExchangeWhenResultRendersEmpty(t *testi
 
 	entries, ids := buildEntriesAndIDs(items)
 
-	if len(entries) != 2 {
-		t.Fatalf("entries = %d, want 2 (question + rendered call marker)", len(entries))
+	// The incomplete exchange (renderable call, empty-rendering result) is
+	// withheld from BOTH the summarizer prompt and the marked ids: summarizing
+	// the call while it stays in raw history would duplicate its content.
+	if len(entries) != 1 || entries[0].Content != "question" {
+		t.Fatalf("entries = %#v, want only the unrelated question", entries)
 	}
 	if len(ids) != 1 || ids[0] != rows[0].ID {
 		t.Fatalf("ids = %#v, want only the unrelated question row marked", ids)

--- a/internal/compaction/assembly_test.go
+++ b/internal/compaction/assembly_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 )
 
@@ -85,6 +87,45 @@ func TestBuildEntriesAndIDsRendersLegacyToolResultEnvelopeExchange(t *testing.T)
 	}
 	if len(ids) != 2 || ids[0] != rows[0].ID || ids[1] != rows[1].ID {
 		t.Fatalf("ids = %#v, want both exchange rows marked", ids)
+	}
+}
+
+func TestBuildEntriesAndIDsKeepsToolExchangeAcrossUnparseableBarrier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		breakIndex int
+	}{
+		{name: "call is unparseable", breakIndex: 0},
+		{name: "result is unparseable", breakIndex: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := []sqlc.ListUncompactedMessagesBySessionRow{
+				toolCallRow(t, 100),
+				toolResultRow(t, 100),
+				mkRow(t, "user", `"old question"`, 100),
+				mkRow(t, "assistant", `"old answer"`, 100),
+				mkRow(t, "user", `"current question"`, 100),
+				mkRow(t, "assistant", `"current answer"`, 100),
+			}
+			rows[tt.breakIndex].ID = pgtype.UUID{Valid: false}
+
+			items, barrierCount := itemsFromRows(rows)
+			if barrierCount != 1 {
+				t.Fatalf("barrier count = %d, want 1", barrierCount)
+			}
+			selected := splitByTarget(items, 200)
+			entries, ids := buildEntriesAndIDs(selected)
+
+			if len(ids) != 2 || ids[0] != rows[2].ID || ids[1] != rows[3].ID {
+				t.Fatalf("ids = %#v, want only the complete run after the protected tool exchange", ids)
+			}
+			if len(entries) != 2 {
+				t.Fatalf("entries = %#v, want the old question and answer", entries)
+			}
+		})
 	}
 }
 

--- a/internal/compaction/assembly_test.go
+++ b/internal/compaction/assembly_test.go
@@ -7,13 +7,15 @@ import (
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 )
 
-func TestBuildEntriesAndIDsMarksOnlyRenderedItemsInMixedWindow(t *testing.T) {
+func TestBuildEntriesAndIDsBreaksSpanAtSkippedMiddleGroup(t *testing.T) {
 	t.Parallel()
 
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
 		mkRow(t, "user", `"first question"`, 0),
-		// reasoning-only: renders to empty and must NOT add a bare
-		// "assistant:" line or be marked compacted in a mixed window.
+		// reasoning-only: renders empty. It must NOT be marked, and because it
+		// sits between two rendered rows, it breaks the contiguous compact span:
+		// marking row 0 and row 2 under one compact_id would leave this raw row
+		// between them, and the read path would fold row 2's summary before it.
 		mkRow(t, "assistant", `[{"type":"reasoning","text":"thinking"}]`, 0),
 		mkRow(t, "assistant", `"the answer"`, 0),
 	}
@@ -21,22 +23,13 @@ func TestBuildEntriesAndIDsMarksOnlyRenderedItemsInMixedWindow(t *testing.T) {
 
 	entries, ids := buildEntriesAndIDs(items)
 
-	if len(ids) != 2 {
-		t.Fatalf("ids = %d, want 2 (only rendered rows marked)", len(ids))
+	// Only the first contiguous run (row 0) is marked; "the answer" is deferred
+	// to a later pass so the marked ids stay contiguous in history.
+	if len(ids) != 1 || ids[0] != rows[0].ID {
+		t.Fatalf("ids = %#v, want only the leading contiguous row 0 marked", ids)
 	}
-	wantIDs := []int{0, 2}
-	for i, rowIdx := range wantIDs {
-		if ids[i] != rows[rowIdx].ID {
-			t.Fatalf("id[%d] misaligned with rendered row %d", i, rowIdx)
-		}
-	}
-
-	// The reasoning-only message contributes no summarizer entry.
-	if len(entries) != 2 {
-		t.Fatalf("entries = %d, want 2 (empty entry skipped)", len(entries))
-	}
-	if entries[0].Content != "first question" || entries[1].Content != "the answer" {
-		t.Fatalf("entries lost order/content: %+v", entries)
+	if len(entries) != 1 || entries[0].Content != "first question" {
+		t.Fatalf("entries = %#v, want only 'first question'", entries)
 	}
 	for _, e := range entries {
 		if strings.TrimSpace(e.Content) == "" {

--- a/internal/compaction/assembly_test.go
+++ b/internal/compaction/assembly_test.go
@@ -45,6 +45,28 @@ func TestBuildEntriesAndIDsMarksOnlyRenderedItemsInMixedWindow(t *testing.T) {
 	}
 }
 
+func TestBuildEntriesAndIDsWithholdsWholeExchangeWhenResultRendersEmpty(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"question"`, 0),
+		toolCallRow(t, 0),
+		// degenerate content: still a "tool" role closure row, but has no
+		// recognizable parts, so it renders empty.
+		mkRow(t, "tool", `[]`, 0),
+	}
+	items, _ := itemsFromRows(rows)
+
+	entries, ids := buildEntriesAndIDs(items)
+
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d, want 2 (question + rendered call marker)", len(entries))
+	}
+	if len(ids) != 1 || ids[0] != rows[0].ID {
+		t.Fatalf("ids = %#v, want only the unrelated question row marked", ids)
+	}
+}
+
 func TestBuildUserPromptPriorContextBranch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/assembly_test.go
+++ b/internal/compaction/assembly_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 )
 
-func TestBuildEntriesAndIDsMarksAllSelectedButSkipsEmptyEntries(t *testing.T) {
+func TestBuildEntriesAndIDsMarksOnlyRenderedItemsInMixedWindow(t *testing.T) {
 	t.Parallel()
 
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
 		mkRow(t, "user", `"first question"`, 0),
-		// reasoning-only: renders to empty, must NOT add a bare "assistant:" line,
-		// but must still be marked compacted.
+		// reasoning-only: renders to empty and must NOT add a bare
+		// "assistant:" line or be marked compacted in a mixed window.
 		mkRow(t, "assistant", `[{"type":"reasoning","text":"thinking"}]`, 0),
 		mkRow(t, "assistant", `"the answer"`, 0),
 	}
@@ -21,13 +21,13 @@ func TestBuildEntriesAndIDsMarksAllSelectedButSkipsEmptyEntries(t *testing.T) {
 
 	entries, ids := buildEntriesAndIDs(items)
 
-	// Every selected item is marked compacted, in order.
-	if len(ids) != 3 {
-		t.Fatalf("ids = %d, want 3 (all selected marked)", len(ids))
+	if len(ids) != 2 {
+		t.Fatalf("ids = %d, want 2 (only rendered rows marked)", len(ids))
 	}
-	for i := range rows {
-		if ids[i] != rows[i].ID {
-			t.Fatalf("id[%d] misaligned with selected order", i)
+	wantIDs := []int{0, 2}
+	for i, rowIdx := range wantIDs {
+		if ids[i] != rows[rowIdx].ID {
+			t.Fatalf("id[%d] misaligned with rendered row %d", i, rowIdx)
 		}
 	}
 

--- a/internal/compaction/assembly_test.go
+++ b/internal/compaction/assembly_test.go
@@ -1,0 +1,71 @@
+package compaction
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+func TestBuildEntriesAndIDsMarksAllSelectedButSkipsEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"first question"`, 0),
+		// reasoning-only: renders to empty, must NOT add a bare "assistant:" line,
+		// but must still be marked compacted.
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"thinking"}]`, 0),
+		mkRow(t, "assistant", `"the answer"`, 0),
+	}
+	items, err := itemsFromRows(rows)
+	if err != nil {
+		t.Fatalf("itemsFromRows: %v", err)
+	}
+
+	entries, ids := buildEntriesAndIDs(items)
+
+	// Every selected item is marked compacted, in order.
+	if len(ids) != 3 {
+		t.Fatalf("ids = %d, want 3 (all selected marked)", len(ids))
+	}
+	for i := range rows {
+		if ids[i] != rows[i].ID {
+			t.Fatalf("id[%d] misaligned with selected order", i)
+		}
+	}
+
+	// The reasoning-only message contributes no summarizer entry.
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d, want 2 (empty entry skipped)", len(entries))
+	}
+	if entries[0].Content != "first question" || entries[1].Content != "the answer" {
+		t.Fatalf("entries lost order/content: %+v", entries)
+	}
+	for _, e := range entries {
+		if strings.TrimSpace(e.Content) == "" {
+			t.Fatalf("emitted an empty entry")
+		}
+	}
+}
+
+func TestBuildUserPromptPriorContextBranch(t *testing.T) {
+	t.Parallel()
+
+	entries := []messageEntry{{Role: "user", Content: "hi"}}
+
+	withPrior := buildUserPrompt([]string{"earlier summary"}, entries)
+	if !strings.Contains(withPrior, "<prior_context>") || !strings.Contains(withPrior, "earlier summary") {
+		t.Fatalf("prior-summary branch not rendered: %q", withPrior)
+	}
+	if !strings.Contains(withPrior, "user: hi") {
+		t.Fatalf("entries not included with prior context: %q", withPrior)
+	}
+
+	without := buildUserPrompt(nil, entries)
+	if strings.Contains(without, "<prior_context>") {
+		t.Fatalf("no-prior branch should omit prior context: %q", without)
+	}
+	if !strings.Contains(without, "Summarize the following conversation:") {
+		t.Fatalf("no-prior branch missing lead-in: %q", without)
+	}
+}

--- a/internal/compaction/assembly_test.go
+++ b/internal/compaction/assembly_test.go
@@ -67,6 +67,31 @@ func TestBuildEntriesAndIDsWithholdsWholeExchangeWhenResultRendersEmpty(t *testi
 	}
 }
 
+func TestBuildEntriesAndIDsRendersLegacyToolResultEnvelopeExchange(t *testing.T) {
+	t.Parallel()
+
+	// The tool row uses the older OpenAI-style envelope (tool_call_id at the
+	// top level, content is the result payload directly), which previously
+	// rendered empty and withheld the whole exchange from marking.
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolCallRow(t, 0),
+		mkRow(t, "tool", `{"role":"tool","tool_call_id":"c1","content":{"output":"search results here"}}`, 0),
+	}
+	items, _ := itemsFromRows(rows)
+
+	entries, ids := buildEntriesAndIDs(items)
+
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d, want 2 (call marker + legacy tool result)", len(entries))
+	}
+	if !strings.Contains(entries[1].Content, "search results here") {
+		t.Fatalf("legacy tool result content lost: %+v", entries)
+	}
+	if len(ids) != 2 || ids[0] != rows[0].ID || ids[1] != rows[1].ID {
+		t.Fatalf("ids = %#v, want both exchange rows marked", ids)
+	}
+}
+
 func TestBuildUserPromptPriorContextBranch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -16,7 +16,7 @@ func toolResultRow(t *testing.T, tokens int) sqlc.ListUncompactedMessagesBySessi
 	return mkRow(t, "tool", `[{"type":"tool-result","toolName":"calc","toolCallId":"c1","output":{"type":"text","value":"42"}}]`, tokens)
 }
 
-func firstKeptIsNotOrphanTool(t *testing.T, items, toCompact []compactionItem) {
+func firstKeptIsNotOrphanTool(t *testing.T, items, toCompact []CompactionCandidate) {
 	t.Helper()
 	keepStart := len(toCompact)
 	if keepStart < len(items) && isToolResultItem(items[keepStart]) {
@@ -27,11 +27,11 @@ func firstKeptIsNotOrphanTool(t *testing.T, items, toCompact []compactionItem) {
 func TestSplitByTargetDoesNotOrphanToolResult(t *testing.T) {
 	t.Parallel()
 
-	// oldest -> newest: user, assistant(tool-call), tool(result), assistant.
+	// oldest -> newest: assistant, assistant(tool-call), tool(result), assistant.
 	// target 250 would otherwise cut between the tool call and its result,
 	// leaving the kept side starting with an orphan tool result.
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
-		mkRow(t, "user", `"q"`, 100),
+		mkRow(t, "assistant", `"context"`, 100),
 		toolCallRow(t, 100),
 		toolResultRow(t, 100),
 		mkRow(t, "assistant", `"done"`, 100),
@@ -51,7 +51,7 @@ func TestSplitByRatioDoesNotOrphanToolResult(t *testing.T) {
 	t.Parallel()
 
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
-		mkRow(t, "user", `"q"`, 100),
+		mkRow(t, "assistant", `"context"`, 100),
 		toolCallRow(t, 100),
 		toolResultRow(t, 100),
 		mkRow(t, "assistant", `"done"`, 100),
@@ -106,6 +106,39 @@ func TestAdjustForToolBoundaryAllToolsCompactsAll(t *testing.T) {
 	items, _ := itemsFromRows(rows)
 	if got := adjustForToolBoundary(items, 1); got != 2 {
 		t.Fatalf("all-tool tail should compact everything, got %d", got)
+	}
+}
+
+func TestSplitByRatioNoOpsWhenToolBoundaryWouldConsumeRecentTail(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolCallRow(t, 100),
+		toolResultRow(t, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	toCompact := splitByRatio(items, 200, 100)
+	if len(toCompact) != 0 {
+		t.Fatalf("compaction should no-op rather than consume the recent tool tail, got %d items", len(toCompact))
+	}
+}
+
+func TestSplitByRatioPreservesNewestUserTurnSuffix(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"old question"`, 100),
+		mkRow(t, "assistant", `"old answer"`, 100),
+		mkRow(t, "user", `"current question"`, 100),
+		mkRow(t, "assistant", `"current answer"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	toCompact := splitByRatio(items, 400, 100)
+	if len(toCompact) != 2 {
+		t.Fatalf("compact count = %d, want 2 (keep newest user turn suffix)", len(toCompact))
+	}
+	if toCompact[0].ID != rows[0].ID || toCompact[1].ID != rows[1].ID {
+		t.Fatalf("should compact only rows before the newest user turn")
 	}
 }
 

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -142,6 +142,59 @@ func TestSplitByRatioPreservesNewestUserTurnSuffix(t *testing.T) {
 	}
 }
 
+func TestSplitByRatioCompactsCurrentTurnMiddleWhenUserIsFirst(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"current instruction"`, 100),
+		mkRow(t, "assistant", `"loop step 1"`, 100),
+		mkRow(t, "assistant", `"loop step 2"`, 100),
+		mkRow(t, "assistant", `"latest tail"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	toCompact := splitByRatio(items, 400, 100)
+	if len(toCompact) != 2 {
+		t.Fatalf("compact count = %d, want 2 middle current-turn messages", len(toCompact))
+	}
+	if toCompact[0].ID != rows[1].ID || toCompact[1].ID != rows[2].ID {
+		t.Fatalf("should compact current-turn middle while keeping user and latest tail")
+	}
+}
+
+func TestSplitByRatioPreservesCurrentTurnTailToolClosure(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"current instruction"`, 100),
+		mkRow(t, "assistant", `"loop step 1"`, 100),
+		toolCallRow(t, 100),
+		toolResultRow(t, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	toCompact := splitByRatio(items, 400, 100)
+	if len(toCompact) != 1 {
+		t.Fatalf("compact count = %d, want only pre-tool middle message", len(toCompact))
+	}
+	if toCompact[0].ID != rows[1].ID {
+		t.Fatalf("should keep user plus tail tool closure")
+	}
+}
+
+func TestToolBoundaryGuardRequiresToolClosurePolicy(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolCallRow(t, 100),
+		toolResultRow(t, 100),
+		mkRow(t, "assistant", `"done"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	items[1].Policies = nil
+	if got := adjustForToolBoundary(items, 1); got != 1 {
+		t.Fatalf("boundary should be policy-driven when tool-result policy is absent, got %d", got)
+	}
+}
+
 func TestTrimCompactMessagesKeepsToolExchangeIntact(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -270,3 +270,24 @@ func TestAdjustForToolBoundaryIgnoresZeroCutoff(t *testing.T) {
 		t.Fatalf("zero cutoff must stay zero, got %d", got)
 	}
 }
+
+func TestTrimCompactMessagesKeepsOversizedFirstRealGroupBehindFreeHead(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"a"}]`, 300), // renders empty: zero budget cost
+		toolCallRow(t, 400),
+		toolResultRow(t, 400),
+		mkRow(t, "user", `"newer"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	trimmed := trimCompactMessages(items, 500)
+	// The zero-cost head must not defeat the keep-first-group progress
+	// guarantee: the oversized first real exchange stays in.
+	if len(trimmed) < 3 {
+		t.Fatalf("trimmed = %d rows, want the free head plus the oversized first real exchange", len(trimmed))
+	}
+	if trimmed[1].ID != items[1].ID || trimmed[2].ID != items[2].ID {
+		t.Fatalf("oversized first real exchange must be kept for progress")
+	}
+}

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -16,6 +16,17 @@ func toolResultRow(t *testing.T, tokens int) sqlc.ListUncompactedMessagesBySessi
 	return mkRow(t, "tool", `[{"type":"tool-result","toolName":"calc","toolCallId":"c1","output":{"type":"text","value":"42"}}]`, tokens)
 }
 
+// textRow builds a plain text row whose rendered entry is ~tokens tokens, so
+// trim tests drive the rendered-byte budget directly.
+func textRow(t *testing.T, role string, tokens int) sqlc.ListUncompactedMessagesBySessionRow {
+	t.Helper()
+	body := make([]byte, 0, tokens*4)
+	for len(body) < tokens*4 {
+		body = append(body, 'x')
+	}
+	return mkRow(t, role, `"`+string(body)+`"`, 0)
+}
+
 func firstKeptIsNotOrphanTool(t *testing.T, items, toCompact []CompactionCandidate) {
 	t.Helper()
 	keepStart := len(toCompact)
@@ -198,19 +209,20 @@ func TestToolBoundaryGuardRequiresToolClosurePolicy(t *testing.T) {
 func TestTrimCompactMessagesKeepsOldestAndToolExchangeIntact(t *testing.T) {
 	t.Parallel()
 
-	// compact input (oldest -> newest): assistant(tool-call), tool(result), user, assistant.
-	// maxTokens 350 keeps the oldest groups within budget — the whole exchange
-	// plus the user row — and defers the newest overflow to a later pass.
+	// compact input (oldest -> newest): a tool exchange (~110 rendered tokens
+	// with its role prefixes), then two ~100-token text rows. maxTokens 320
+	// keeps the oldest groups within budget — the whole exchange plus the
+	// first text row — and defers the newest overflow to a later pass.
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
-		toolCallRow(t, 100),
-		toolResultRow(t, 100),
-		mkRow(t, "user", `"c"`, 100),
-		mkRow(t, "assistant", `"d"`, 100),
+		toolCallRow(t, 0),
+		toolResultRow(t, 0),
+		textRow(t, "user", 100),
+		textRow(t, "assistant", 100),
 	}
 	items, _ := itemsFromRows(rows)
-	trimmed := trimCompactMessages(items, 350)
+	trimmed := trimCompactMessages(items, 120)
 	if len(trimmed) != 3 {
-		t.Fatalf("trimmed = %d, want the oldest exchange plus the user row", len(trimmed))
+		t.Fatalf("trimmed = %d, want the oldest exchange plus the first text row", len(trimmed))
 	}
 	if trimmed[0].ID != items[0].ID || trimmed[1].ID != items[1].ID {
 		t.Fatalf("trim must keep the oldest tool exchange intact at the head")
@@ -224,14 +236,16 @@ func TestTrimCompactMessagesKeepsOversizedFirstGroup(t *testing.T) {
 	t.Parallel()
 
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
-		toolCallRow(t, 600),
-		toolResultRow(t, 600),
-		mkRow(t, "user", `"c"`, 100),
+		textRow(t, "user", 600),
+		textRow(t, "assistant", 100),
 	}
 	items, _ := itemsFromRows(rows)
 	trimmed := trimCompactMessages(items, 350)
-	if len(trimmed) != 2 {
-		t.Fatalf("trimmed = %d, want the oversized head exchange kept whole for progress", len(trimmed))
+	if len(trimmed) != 1 {
+		t.Fatalf("trimmed = %d, want the oversized head row kept whole for progress", len(trimmed))
+	}
+	if trimmed[0].ID != items[0].ID {
+		t.Fatalf("the oversized first markable row must be kept")
 	}
 }
 
@@ -243,9 +257,9 @@ func TestTrimCompactMessagesMustKeepRowsCostNoBudget(t *testing.T) {
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
 		askCall,
 		askResult,
-		mkRow(t, "user", `"old q"`, 100),
-		mkRow(t, "assistant", `"old a"`, 100),
-		mkRow(t, "user", `"newer q"`, 100),
+		textRow(t, "user", 100),
+		textRow(t, "assistant", 100),
+		textRow(t, "user", 100),
 	}
 	items, _ := itemsFromRows(rows)
 	trimmed := trimCompactMessages(items, 250)

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -115,6 +115,34 @@ func TestAdjustForToolBoundaryAllToolsCompactsAll(t *testing.T) {
 	}
 }
 
+func TestTrimCompactMessagesKeepsToolExchangeIntact(t *testing.T) {
+	t.Parallel()
+
+	// compact input (oldest -> newest): assistant(tool-call), tool(result), user, assistant.
+	// maxTokens 350 trims the oldest (the tool call), which would orphan the tool
+	// result at the head of the retained compact input.
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolCallRow(t, 100),
+		toolResultRow(t, 100),
+		mkRow(t, "user", `"c"`, 100),
+		mkRow(t, "assistant", `"d"`, 100),
+	}
+	items, err := itemsFromRows(rows)
+	if err != nil {
+		t.Fatalf("itemsFromRows: %v", err)
+	}
+	trimmed := trimCompactMessages(items, 350)
+	if len(trimmed) == 0 {
+		t.Fatalf("trim dropped everything")
+	}
+	if isToolResultItem(trimmed[0]) {
+		t.Fatalf("trim left an orphan tool result at the head of the compact input")
+	}
+	if len(trimmed) != 2 {
+		t.Fatalf("trimmed = %d, want 2 (orphan tool result dropped with its call)", len(trimmed))
+	}
+}
+
 func TestAdjustForToolBoundaryIgnoresZeroCutoff(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -195,12 +195,12 @@ func TestToolBoundaryGuardRequiresToolClosurePolicy(t *testing.T) {
 	}
 }
 
-func TestTrimCompactMessagesKeepsToolExchangeIntact(t *testing.T) {
+func TestTrimCompactMessagesKeepsOldestAndToolExchangeIntact(t *testing.T) {
 	t.Parallel()
 
 	// compact input (oldest -> newest): assistant(tool-call), tool(result), user, assistant.
-	// maxTokens 350 trims the oldest (the tool call), which would orphan the tool
-	// result at the head of the retained compact input.
+	// maxTokens 350 keeps the oldest groups within budget — the whole exchange
+	// plus the user row — and defers the newest overflow to a later pass.
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
 		toolCallRow(t, 100),
 		toolResultRow(t, 100),
@@ -209,14 +209,51 @@ func TestTrimCompactMessagesKeepsToolExchangeIntact(t *testing.T) {
 	}
 	items, _ := itemsFromRows(rows)
 	trimmed := trimCompactMessages(items, 350)
-	if len(trimmed) == 0 {
-		t.Fatalf("trim dropped everything")
+	if len(trimmed) != 3 {
+		t.Fatalf("trimmed = %d, want the oldest exchange plus the user row", len(trimmed))
 	}
-	if isToolResultItem(trimmed[0]) {
-		t.Fatalf("trim left an orphan tool result at the head of the compact input")
+	if trimmed[0].ID != items[0].ID || trimmed[1].ID != items[1].ID {
+		t.Fatalf("trim must keep the oldest tool exchange intact at the head")
 	}
+	if trimmed[len(trimmed)-1].ID != items[2].ID {
+		t.Fatalf("newest overflow must be deferred, got tail %s", formatUUID(trimmed[len(trimmed)-1].ID))
+	}
+}
+
+func TestTrimCompactMessagesKeepsOversizedFirstGroup(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolCallRow(t, 600),
+		toolResultRow(t, 600),
+		mkRow(t, "user", `"c"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	trimmed := trimCompactMessages(items, 350)
 	if len(trimmed) != 2 {
-		t.Fatalf("trimmed = %d, want 2 (orphan tool result dropped with its call)", len(trimmed))
+		t.Fatalf("trimmed = %d, want the oversized head exchange kept whole for progress", len(trimmed))
+	}
+}
+
+func TestTrimCompactMessagesMustKeepRowsCostNoBudget(t *testing.T) {
+	t.Parallel()
+
+	askCall := mkRow(t, "assistant", `[{"type":"tool-call","toolName":"ask_user","toolCallId":"a","input":{}}]`, 600)
+	askResult := mkRow(t, "tool", `[{"type":"tool-result","toolName":"ask_user","toolCallId":"a","output":"yes"}]`, 600)
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		askCall,
+		askResult,
+		mkRow(t, "user", `"old q"`, 100),
+		mkRow(t, "assistant", `"old a"`, 100),
+		mkRow(t, "user", `"newer q"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	trimmed := trimCompactMessages(items, 250)
+	if len(trimmed) != 4 {
+		t.Fatalf("trimmed = %d, want must-keep island (free) plus two rows within budget", len(trimmed))
+	}
+	if !trimmed[0].HasPolicy(CompactPolicyMustKeep) || !trimmed[1].HasPolicy(CompactPolicyMustKeep) {
+		t.Fatalf("must-keep island must stay in place at the head")
 	}
 }
 

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -291,3 +291,19 @@ func TestTrimCompactMessagesKeepsOversizedFirstRealGroupBehindFreeHead(t *testin
 		t.Fatalf("oversized first real exchange must be kept for progress")
 	}
 }
+
+func TestTrimCompactMessagesFloorsTinyRowCosts(t *testing.T) {
+	t.Parallel()
+
+	rows := make([]sqlc.ListUncompactedMessagesBySessionRow, 0, 100)
+	for i := 0; i < 100; i++ {
+		rows = append(rows, mkRow(t, "user", `"a"`, 0)) // no usage; raw estimate rounds to 0
+	}
+	items, _ := itemsFromRows(rows)
+	trimmed := trimCompactMessages(items, 1)
+	// Each markable row costs at least one token, so a swarm of tiny rows
+	// cannot ride into the prompt for free.
+	if len(trimmed) != 1 {
+		t.Fatalf("trimmed = %d rows, want 1 (per-row cost floor)", len(trimmed))
+	}
+}

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -1,0 +1,130 @@
+package compaction
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+func toolCallRow(t *testing.T, tokens int) sqlc.ListUncompactedMessagesBySessionRow {
+	t.Helper()
+	return mkRow(t, "assistant", `[{"type":"tool-call","toolName":"calc","toolCallId":"c1","input":{}}]`, tokens)
+}
+
+func toolResultRow(t *testing.T, tokens int) sqlc.ListUncompactedMessagesBySessionRow {
+	t.Helper()
+	return mkRow(t, "tool", `[{"type":"tool-result","toolName":"calc","toolCallId":"c1","output":{"type":"text","value":"42"}}]`, tokens)
+}
+
+func firstKeptIsNotOrphanTool(t *testing.T, items, toCompact []compactionItem) {
+	t.Helper()
+	keepStart := len(toCompact)
+	if keepStart < len(items) && isToolResultItem(items[keepStart]) {
+		t.Fatalf("keep side starts with an orphan tool result at index %d", keepStart)
+	}
+}
+
+func TestSplitByTargetDoesNotOrphanToolResult(t *testing.T) {
+	t.Parallel()
+
+	// oldest -> newest: user, assistant(tool-call), tool(result), assistant.
+	// target 250 would otherwise cut between the tool call and its result,
+	// leaving the kept side starting with an orphan tool result.
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"q"`, 100),
+		toolCallRow(t, 100),
+		toolResultRow(t, 100),
+		mkRow(t, "assistant", `"done"`, 100),
+	}
+	items, err := itemsFromRows(rows)
+	if err != nil {
+		t.Fatalf("itemsFromRows: %v", err)
+	}
+	toCompact := splitByTarget(items, 250)
+	firstKeptIsNotOrphanTool(t, items, toCompact)
+	if len(toCompact) != 3 {
+		t.Fatalf("compact count = %d, want 3 (tool result pulled into compact set)", len(toCompact))
+	}
+	if !isToolResultItem(toCompact[2]) {
+		t.Fatalf("last compacted message should be the tool result")
+	}
+}
+
+func TestSplitByRatioDoesNotOrphanToolResult(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"q"`, 100),
+		toolCallRow(t, 100),
+		toolResultRow(t, 100),
+		mkRow(t, "assistant", `"done"`, 100),
+	}
+	items, err := itemsFromRows(rows)
+	if err != nil {
+		t.Fatalf("itemsFromRows: %v", err)
+	}
+	// total=500, ratio=50 -> keepTokens=250 -> unadjusted cutoff would keep the
+	// tool result at the head of the keep side.
+	toCompact := splitByRatio(items, 500, 50)
+	firstKeptIsNotOrphanTool(t, items, toCompact)
+	if len(toCompact) != 3 {
+		t.Fatalf("compact count = %d, want 3", len(toCompact))
+	}
+}
+
+func TestAdjustForToolBoundaryNoOpWhenKeepStartsClean(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"a"`, 100),
+		mkRow(t, "assistant", `"b"`, 100),
+		mkRow(t, "user", `"c"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	if got := adjustForToolBoundary(items, 2); got != 2 {
+		t.Fatalf("clean boundary should be unchanged, got %d", got)
+	}
+}
+
+func TestAdjustForToolBoundaryAdvancesPastConsecutiveResults(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolCallRow(t, 100),
+		toolResultRow(t, 100),
+		toolResultRow(t, 100),
+		mkRow(t, "assistant", `"done"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	// cutoff=1 would keep two consecutive tool results; advance past both.
+	if got := adjustForToolBoundary(items, 1); got != 3 {
+		t.Fatalf("should advance past consecutive tool results, got %d", got)
+	}
+}
+
+func TestAdjustForToolBoundaryAllToolsCompactsAll(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolResultRow(t, 100),
+		toolResultRow(t, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	if got := adjustForToolBoundary(items, 1); got != 2 {
+		t.Fatalf("all-tool tail should compact everything, got %d", got)
+	}
+}
+
+func TestAdjustForToolBoundaryIgnoresZeroCutoff(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolResultRow(t, 100),
+		mkRow(t, "assistant", `"x"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	// cutoff 0 means "compact nothing"; never start compacting from the front.
+	if got := adjustForToolBoundary(items, 0); got != 0 {
+		t.Fatalf("zero cutoff must stay zero, got %d", got)
+	}
+}

--- a/internal/compaction/boundary_test.go
+++ b/internal/compaction/boundary_test.go
@@ -36,10 +36,7 @@ func TestSplitByTargetDoesNotOrphanToolResult(t *testing.T) {
 		toolResultRow(t, 100),
 		mkRow(t, "assistant", `"done"`, 100),
 	}
-	items, err := itemsFromRows(rows)
-	if err != nil {
-		t.Fatalf("itemsFromRows: %v", err)
-	}
+	items, _ := itemsFromRows(rows)
 	toCompact := splitByTarget(items, 250)
 	firstKeptIsNotOrphanTool(t, items, toCompact)
 	if len(toCompact) != 3 {
@@ -59,10 +56,7 @@ func TestSplitByRatioDoesNotOrphanToolResult(t *testing.T) {
 		toolResultRow(t, 100),
 		mkRow(t, "assistant", `"done"`, 100),
 	}
-	items, err := itemsFromRows(rows)
-	if err != nil {
-		t.Fatalf("itemsFromRows: %v", err)
-	}
+	items, _ := itemsFromRows(rows)
 	// total=500, ratio=50 -> keepTokens=250 -> unadjusted cutoff would keep the
 	// tool result at the head of the keep side.
 	toCompact := splitByRatio(items, 500, 50)
@@ -127,10 +121,7 @@ func TestTrimCompactMessagesKeepsToolExchangeIntact(t *testing.T) {
 		mkRow(t, "user", `"c"`, 100),
 		mkRow(t, "assistant", `"d"`, 100),
 	}
-	items, err := itemsFromRows(rows)
-	if err != nil {
-		t.Fatalf("itemsFromRows: %v", err)
-	}
+	items, _ := itemsFromRows(rows)
 	trimmed := trimCompactMessages(items, 350)
 	if len(trimmed) == 0 {
 		t.Fatalf("trim dropped everything")

--- a/internal/compaction/candidate_rows.go
+++ b/internal/compaction/candidate_rows.go
@@ -1,0 +1,128 @@
+package compaction
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/conversation"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/historyfrag"
+	messagepkg "github.com/memohai/memoh/internal/message"
+)
+
+// itemsFromRows classifies each uncompacted row into a typed CompactionCandidate.
+// A row that cannot be classified remains as a must-keep barrier rather than
+// aborting the whole compaction. Keeping its position prevents compact spans on
+// either side from sharing an ID and being reordered by the read path.
+func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]CompactionCandidate, int) {
+	items := make([]CompactionCandidate, 0, len(rows))
+	barrierCount := 0
+	for _, row := range rows {
+		record, err := historyfrag.FromDBMessage(rowToMessage(row), rowScopeFallback(row))
+		if err != nil {
+			barrierCount++
+			preserveToolClosure, toolResult := rawToolShape(row)
+			policies := []CompactPolicy{CompactPolicyMustKeep}
+			if preserveToolClosure {
+				policies = appendPolicy(policies, CompactPolicyPreserveToolClosure)
+			}
+			items = append(items, CompactionCandidate{
+				ID:           row.ID,
+				RawContent:   row.Content,
+				RawUsage:     row.Usage,
+				Policies:     policies,
+				IsToolResult: toolResult,
+			})
+			continue
+		}
+		items = append(items, CompactionCandidate{
+			ID:           row.ID,
+			RawContent:   row.Content,
+			RawUsage:     row.Usage,
+			Record:       record,
+			Policies:     candidatePolicies(record),
+			IsToolResult: strings.EqualFold(strings.TrimSpace(record.ModelMessage.Role), "tool"),
+		})
+	}
+	if len(items) > 0 {
+		propagateMustKeepAcrossToolExchanges(items)
+		markSelectionPolicies(items)
+	}
+	return items, barrierCount
+}
+
+func rawToolShape(row sqlc.ListUncompactedMessagesBySessionRow) (preserveToolClosure, toolResult bool) {
+	toolResult = strings.EqualFold(strings.TrimSpace(row.Role), "tool")
+	if toolResult {
+		return true, true
+	}
+
+	content := row.Content
+	var modelMessage conversation.ModelMessage
+	if json.Unmarshal(row.Content, &modelMessage) == nil {
+		if len(modelMessage.ToolCalls) > 0 || strings.TrimSpace(modelMessage.ToolCallID) != "" {
+			return true, false
+		}
+		if modelMessage.HasContent() {
+			content = modelMessage.Content
+		}
+	}
+	for _, part := range parseEntryParts(content) {
+		if strings.Contains(part.Type, "tool-call") || strings.Contains(part.Type, "tool_call") ||
+			strings.Contains(part.Type, "tool-result") || strings.Contains(part.Type, "tool_result") {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+func rowToMessage(row sqlc.ListUncompactedMessagesBySessionRow) messagepkg.Message {
+	return messagepkg.Message{
+		ID:                      formatUUID(row.ID),
+		BotID:                   formatUUID(row.BotID),
+		SessionID:               formatUUID(row.SessionID),
+		SenderChannelIdentityID: formatUUID(row.SenderChannelIdentityID),
+		SenderUserID:            formatUUID(row.SenderUserID),
+		SenderDisplayName:       textValue(row.SenderDisplayName),
+		SenderAvatarURL:         textValue(row.SenderAvatarUrl),
+		Platform:                textValue(row.Platform),
+		ExternalMessageID:       textValue(row.ExternalMessageID),
+		SourceReplyToMessageID:  textValue(row.SourceReplyToMessageID),
+		Role:                    row.Role,
+		Content:                 row.Content,
+		Metadata:                metadataMap(row.Metadata),
+		Usage:                   row.Usage,
+		CompactID:               formatUUID(row.CompactID),
+		EventID:                 formatUUID(row.EventID),
+		DisplayContent:          textValue(row.DisplayText),
+		CreatedAt:               row.CreatedAt.Time,
+	}
+}
+
+func rowScopeFallback(row sqlc.ListUncompactedMessagesBySessionRow) historyfrag.ScopeFallback {
+	return historyfrag.ScopeFallback{
+		ConversationType: textValue(row.ConversationType),
+		ConversationName: strings.TrimSpace(row.ConversationName),
+		ReplyTarget:      textValue(row.ReplyTarget),
+	}
+}
+
+func textValue(value pgtype.Text) string {
+	if !value.Valid {
+		return ""
+	}
+	return strings.TrimSpace(value.String)
+}
+
+func metadataMap(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out map[string]any
+	if json.Unmarshal(raw, &out) != nil {
+		return nil
+	}
+	return out
+}

--- a/internal/compaction/candidate_rows.go
+++ b/internal/compaction/candidate_rows.go
@@ -69,13 +69,21 @@ func rawToolShape(row sqlc.ListUncompactedMessagesBySessionRow) (preserveToolClo
 			content = modelMessage.Content
 		}
 	}
+	var barePart entryPart
+	if json.Unmarshal(content, &barePart) == nil && isToolPartType(barePart.Type) {
+		return true, false
+	}
 	for _, part := range parseEntryParts(content) {
-		if strings.Contains(part.Type, "tool-call") || strings.Contains(part.Type, "tool_call") ||
-			strings.Contains(part.Type, "tool-result") || strings.Contains(part.Type, "tool_result") {
+		if isToolPartType(part.Type) {
 			return true, false
 		}
 	}
 	return false, false
+}
+
+func isToolPartType(value string) bool {
+	return strings.Contains(value, "tool-call") || strings.Contains(value, "tool_call") ||
+		strings.Contains(value, "tool-result") || strings.Contains(value, "tool_result")
 }
 
 func rowToMessage(row sqlc.ListUncompactedMessagesBySessionRow) messagepkg.Message {

--- a/internal/compaction/candidate_rows.go
+++ b/internal/compaction/candidate_rows.go
@@ -81,11 +81,6 @@ func rawToolShape(row sqlc.ListUncompactedMessagesBySessionRow) (preserveToolClo
 	return false, false
 }
 
-func isToolPartType(value string) bool {
-	return strings.Contains(value, "tool-call") || strings.Contains(value, "tool_call") ||
-		strings.Contains(value, "tool-result") || strings.Contains(value, "tool_result")
-}
-
 func rowToMessage(row sqlc.ListUncompactedMessagesBySessionRow) messagepkg.Message {
 	return messagepkg.Message{
 		ID:                      formatUUID(row.ID),

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -7,12 +7,14 @@ import (
 	"unicode/utf8"
 
 	"github.com/memohai/memoh/internal/conversation"
+	"github.com/memohai/memoh/internal/historyfrag"
 )
 
 // toolOutputMaxBytes bounds the tool-result outcome rendered into the summarizer
 // input. Stored tool payloads are already gateway-pruned; this keeps the summary
 // input compact while preserving the outcome gist.
 const toolOutputMaxBytes = 2048
+const entryMetadataMaxBytes = 256
 
 var (
 	dataURIRe = regexp.MustCompile(`data:[a-zA-Z0-9.+/-]+;base64,[A-Za-z0-9+/=]+`)
@@ -20,7 +22,8 @@ var (
 	// media such as MCP ImageContent's bare "data" field). The high threshold
 	// avoids scrubbing ordinary tokens/words, which are broken by punctuation or
 	// whitespace.
-	base64BlobRe = regexp.MustCompile(`[A-Za-z0-9+/_-]{256,}={0,2}`)
+	base64BlobRe              = regexp.MustCompile(`[A-Za-z0-9+/_-]{256,}={0,2}`)
+	entryMetadataValueEscaper = strings.NewReplacer("[", "(", "]", ")")
 )
 
 // entryPart is a minimal view of one stored content part, enough to render a
@@ -31,6 +34,46 @@ type entryPart struct {
 	ToolName string          `json:"toolName"`
 	Output   json.RawMessage `json:"output"`
 	Result   json.RawMessage `json:"result"`
+}
+
+func renderCandidateEntry(record historyfrag.HistoryRecord) string {
+	content := strings.TrimSpace(renderEntryContent(record.ModelMessage))
+	if content == "" {
+		return ""
+	}
+	if header := renderEntryHeader(record); header != "" {
+		return header + "\n" + content
+	}
+	return content
+}
+
+func renderEntryHeader(record historyfrag.HistoryRecord) string {
+	var lines []string
+	add := func(label, value string) {
+		value = cleanEntryMetadataValue(value)
+		if value == "" {
+			return
+		}
+		lines = append(lines, "["+label+": "+value+"]")
+	}
+
+	add("message_id", record.ExternalMessageID)
+	add("reply_to", record.SourceReplyToMessageID)
+	add("sender", record.SenderDisplayName)
+	add("platform", record.Platform)
+	add("conversation_type", record.Scope.ConversationType)
+	add("conversation_name", record.Scope.ConversationName)
+	add("reply_target", record.Scope.ReplyTarget)
+	return strings.Join(lines, "\n")
+}
+
+func cleanEntryMetadataValue(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	if value == "" {
+		return ""
+	}
+	value = entryMetadataValueEscaper.Replace(value)
+	return truncateBytes(value, entryMetadataMaxBytes)
 }
 
 // renderEntryContent turns a stored history message into clean text for the

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -34,6 +34,7 @@ var (
 type entryPart struct {
 	Type     string          `json:"type"`
 	ToolName string          `json:"toolName"`
+	Input    json.RawMessage `json:"input"`
 	Output   json.RawMessage `json:"output"`
 	Result   json.RawMessage `json:"result"`
 }
@@ -92,8 +93,9 @@ func cleanEntryMetadataValue(value string) string {
 
 // renderEntryContent turns a stored history message into clean text for the
 // summarizer prompt: plain text is surfaced directly, media is reduced to a
-// marker, tool calls show their name, and tool results show their outcome text
-// (falling back to a marker) instead of dumping the raw stored JSON.
+// marker, tool calls show their name and bounded arguments, and tool results
+// show their outcome text (falling back to a marker) instead of dumping the
+// raw stored JSON.
 func renderEntryContent(mm conversation.ModelMessage) string {
 	parts := parseEntryParts(mm.Content)
 
@@ -119,7 +121,7 @@ func renderEntryContent(mm conversation.ModelMessage) string {
 			segs = append(segs, "[file]")
 		case isToolCallPartType(p.Type):
 			sawToolCallPart = true
-			segs = append(segs, toolCallMarker(p.ToolName))
+			segs = append(segs, toolCallMarker(p.ToolName, p.Input))
 		case isToolResultPartType(p.Type):
 			segs = append(segs, renderToolResult(p.Output, p.Result))
 		}
@@ -127,7 +129,7 @@ func renderEntryContent(mm conversation.ModelMessage) string {
 
 	if !sawToolCallPart {
 		for _, tc := range mm.ToolCalls {
-			segs = append(segs, toolCallMarker(tc.Function.Name))
+			segs = append(segs, toolCallMarker(tc.Function.Name, json.RawMessage(tc.Function.Arguments)))
 		}
 	}
 
@@ -154,12 +156,21 @@ func parseEntryParts(content json.RawMessage) []entryPart {
 	return parts
 }
 
-func toolCallMarker(name string) string {
+// toolCallMarker names the call and carries its arguments: for write/exec-style
+// tools the result is often just a success marker, so the arguments are what
+// tell the summarizer what was actually done. Arguments get the same media
+// scrub and length bound as tool results.
+func toolCallMarker(name string, input json.RawMessage) string {
 	name = strings.TrimSpace(name)
-	if name == "" {
-		return "[tool_call]"
+	marker := "[tool_call]"
+	if name != "" {
+		marker = "[tool_call: " + name + "]"
 	}
-	return "[tool_call: " + name + "]"
+	args := strings.TrimSpace(string(input))
+	if args == "" || args == "null" || args == "{}" {
+		return marker
+	}
+	return marker + " " + sanitizeToolText(args)
 }
 
 // renderToolResult surfaces a tool result's outcome for the summarizer: a clean

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -1,0 +1,111 @@
+package compaction
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+// entryPart is a minimal view of one stored content part, enough to render a
+// summarizer-friendly entry without leaking raw JSON, media payloads, or
+// oversized tool blobs.
+type entryPart struct {
+	Type     string          `json:"type"`
+	ToolName string          `json:"toolName"`
+	Output   json.RawMessage `json:"output"`
+	Result   json.RawMessage `json:"result"`
+}
+
+// renderEntryContent turns a stored history message into clean text for the
+// summarizer prompt: plain text is surfaced directly, media is reduced to a
+// marker, tool calls show their name, and tool results show their outcome text
+// (falling back to a marker) instead of dumping the raw stored JSON.
+func renderEntryContent(mm conversation.ModelMessage) string {
+	var segs []string
+	if text := strings.TrimSpace(mm.TextContent()); text != "" {
+		segs = append(segs, text)
+	}
+
+	sawToolCallPart := false
+	for _, p := range parseEntryParts(mm.Content) {
+		switch {
+		case p.Type == "image":
+			segs = append(segs, "[image]")
+		case p.Type == "file":
+			segs = append(segs, "[file]")
+		case strings.Contains(p.Type, "tool-call"), strings.Contains(p.Type, "tool_call"):
+			sawToolCallPart = true
+			segs = append(segs, toolCallMarker(p.ToolName))
+		case strings.Contains(p.Type, "tool-result"), strings.Contains(p.Type, "tool_result"):
+			if out := firstOutputText(p.Output, p.Result); out != "" {
+				segs = append(segs, out)
+			} else {
+				segs = append(segs, "[tool result]")
+			}
+		}
+	}
+
+	if !sawToolCallPart {
+		for _, tc := range mm.ToolCalls {
+			segs = append(segs, toolCallMarker(tc.Function.Name))
+		}
+	}
+
+	return strings.Join(segs, "\n")
+}
+
+func parseEntryParts(content json.RawMessage) []entryPart {
+	if len(content) == 0 {
+		return nil
+	}
+	var parts []entryPart
+	if err := json.Unmarshal(content, &parts); err != nil {
+		return nil
+	}
+	return parts
+}
+
+func toolCallMarker(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "[tool_call]"
+	}
+	return "[tool_call: " + name + "]"
+}
+
+// firstOutputText returns the first extractable string from a tool result's
+// output or result field. It only returns recognized string shapes so binary or
+// structured payloads never leak into the summarizer input.
+func firstOutputText(candidates ...json.RawMessage) string {
+	for _, raw := range candidates {
+		if s := outputText(raw); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func outputText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return strings.TrimSpace(s)
+	}
+	var obj struct {
+		Type  string `json:"type"`
+		Value string `json:"value"`
+		Text  string `json:"text"`
+	}
+	if json.Unmarshal(raw, &obj) == nil {
+		if v := strings.TrimSpace(obj.Value); v != "" {
+			return v
+		}
+		if v := strings.TrimSpace(obj.Text); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -14,7 +14,14 @@ import (
 // input compact while preserving the outcome gist.
 const toolOutputMaxBytes = 2048
 
-var dataURIRe = regexp.MustCompile(`data:[a-zA-Z0-9.+/-]+;base64,[A-Za-z0-9+/=\s]+`)
+var (
+	dataURIRe = regexp.MustCompile(`data:[a-zA-Z0-9.+/-]+;base64,[A-Za-z0-9+/=\s]+`)
+	// base64BlobRe matches long continuous base64-alphabet runs (data-URI-less
+	// media such as MCP ImageContent's bare "data" field). The high threshold
+	// avoids scrubbing ordinary tokens/words, which are broken by punctuation or
+	// whitespace.
+	base64BlobRe = regexp.MustCompile(`[A-Za-z0-9+/_-]{256,}={0,2}`)
+)
 
 // entryPart is a minimal view of one stored content part, enough to render a
 // summarizer-friendly entry without leaking raw JSON, media payloads, or
@@ -85,12 +92,21 @@ func toolCallMarker(name string) string {
 // structured data) survives. Falls back to a marker only when there is nothing.
 func renderToolResult(candidates ...json.RawMessage) string {
 	if s := firstOutputText(candidates...); s != "" {
-		return s
+		return sanitizeToolText(s)
 	}
-	if s := compactToolOutput(candidates...); s != "" {
-		return s
+	if s := rawToolOutput(candidates...); s != "" {
+		return sanitizeToolText(s)
 	}
 	return "[tool result]"
+}
+
+// sanitizeToolText bounds and de-medias any tool outcome text before it reaches
+// the summarizer, applied uniformly to both the clean-text and raw-JSON paths so
+// neither can leak base64/data-URI payloads or unbounded output.
+func sanitizeToolText(s string) string {
+	s = dataURIRe.ReplaceAllString(s, "[media]")
+	s = base64BlobRe.ReplaceAllString(s, "[media]")
+	return truncateBytes(s, toolOutputMaxBytes)
 }
 
 // firstOutputText returns the first cleanly extractable string from a tool
@@ -141,17 +157,16 @@ func outputText(raw json.RawMessage) string {
 	return ""
 }
 
-// compactToolOutput renders the raw outcome as bounded, media-scrubbed text so
-// structured tool results (maps, arrays) still reach the summarizer instead of
-// being dropped, without leaking base64/data-URI payloads.
-func compactToolOutput(candidates ...json.RawMessage) string {
+// rawToolOutput returns the first non-empty raw outcome payload so structured
+// tool results (maps, arrays) still reach the summarizer (after sanitizing)
+// instead of being dropped.
+func rawToolOutput(candidates ...json.RawMessage) string {
 	for _, raw := range candidates {
 		s := strings.TrimSpace(string(raw))
 		if s == "" || s == "null" {
 			continue
 		}
-		s = dataURIRe.ReplaceAllString(s, "[media]")
-		return truncateBytes(s, toolOutputMaxBytes)
+		return s
 	}
 	return ""
 }

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -247,6 +247,8 @@ func rawToolOutput(candidates ...json.RawMessage) string {
 	return ""
 }
 
+const truncationMarker = " …[truncated]"
+
 func truncateBytes(s string, maxBytes int) string {
 	if len(s) <= maxBytes {
 		return s
@@ -255,5 +257,5 @@ func truncateBytes(s string, maxBytes int) string {
 	for cut > 0 && !utf8.RuneStart(s[cut]) {
 		cut--
 	}
-	return strings.TrimSpace(s[:cut]) + " …[truncated]"
+	return strings.TrimSpace(s[:cut]) + truncationMarker
 }

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -13,8 +13,10 @@ import (
 // toolOutputMaxBytes bounds the tool-result outcome rendered into the summarizer
 // input. Stored tool payloads are already gateway-pruned; this keeps the summary
 // input compact while preserving the outcome gist.
-const toolOutputMaxBytes = 2048
-const entryMetadataMaxBytes = 256
+const (
+	toolOutputMaxBytes    = 2048
+	entryMetadataMaxBytes = 256
+)
 
 var (
 	dataURIRe = regexp.MustCompile(`data:[a-zA-Z0-9.+/-]+;base64,[A-Za-z0-9+/=]+`)

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -2,10 +2,19 @@ package compaction
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/memohai/memoh/internal/conversation"
 )
+
+// toolOutputMaxBytes bounds the tool-result outcome rendered into the summarizer
+// input. Stored tool payloads are already gateway-pruned; this keeps the summary
+// input compact while preserving the outcome gist.
+const toolOutputMaxBytes = 2048
+
+var dataURIRe = regexp.MustCompile(`data:[a-zA-Z0-9.+/-]+;base64,[A-Za-z0-9+/=\s]+`)
 
 // entryPart is a minimal view of one stored content part, enough to render a
 // summarizer-friendly entry without leaking raw JSON, media payloads, or
@@ -38,11 +47,7 @@ func renderEntryContent(mm conversation.ModelMessage) string {
 			sawToolCallPart = true
 			segs = append(segs, toolCallMarker(p.ToolName))
 		case strings.Contains(p.Type, "tool-result"), strings.Contains(p.Type, "tool_result"):
-			if out := firstOutputText(p.Output, p.Result); out != "" {
-				segs = append(segs, out)
-			} else {
-				segs = append(segs, "[tool result]")
-			}
+			segs = append(segs, renderToolResult(p.Output, p.Result))
 		}
 	}
 
@@ -74,9 +79,23 @@ func toolCallMarker(name string) string {
 	return "[tool_call: " + name + "]"
 }
 
-// firstOutputText returns the first extractable string from a tool result's
-// output or result field. It only returns recognized string shapes so binary or
-// structured payloads never leak into the summarizer input.
+// renderToolResult surfaces a tool result's outcome for the summarizer: a clean
+// string when one can be extracted, otherwise a bounded, media-scrubbed
+// serialization of the raw outcome so real output (stdout, search results,
+// structured data) survives. Falls back to a marker only when there is nothing.
+func renderToolResult(candidates ...json.RawMessage) string {
+	if s := firstOutputText(candidates...); s != "" {
+		return s
+	}
+	if s := compactToolOutput(candidates...); s != "" {
+		return s
+	}
+	return "[tool result]"
+}
+
+// firstOutputText returns the first cleanly extractable string from a tool
+// result's output or result field. It only returns recognized string shapes so
+// binary or structured payloads never leak through this path.
 func firstOutputText(candidates ...json.RawMessage) string {
 	for _, raw := range candidates {
 		if s := outputText(raw); s != "" {
@@ -95,9 +114,12 @@ func outputText(raw json.RawMessage) string {
 		return strings.TrimSpace(s)
 	}
 	var obj struct {
-		Type  string `json:"type"`
-		Value string `json:"value"`
-		Text  string `json:"text"`
+		Value   string `json:"value"`
+		Text    string `json:"text"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
 	}
 	if json.Unmarshal(raw, &obj) == nil {
 		if v := strings.TrimSpace(obj.Value); v != "" {
@@ -106,6 +128,41 @@ func outputText(raw json.RawMessage) string {
 		if v := strings.TrimSpace(obj.Text); v != "" {
 			return v
 		}
+		var texts []string
+		for _, c := range obj.Content {
+			if t := strings.TrimSpace(c.Text); t != "" {
+				texts = append(texts, t)
+			}
+		}
+		if len(texts) > 0 {
+			return strings.Join(texts, "\n")
+		}
 	}
 	return ""
+}
+
+// compactToolOutput renders the raw outcome as bounded, media-scrubbed text so
+// structured tool results (maps, arrays) still reach the summarizer instead of
+// being dropped, without leaking base64/data-URI payloads.
+func compactToolOutput(candidates ...json.RawMessage) string {
+	for _, raw := range candidates {
+		s := strings.TrimSpace(string(raw))
+		if s == "" || s == "null" {
+			continue
+		}
+		s = dataURIRe.ReplaceAllString(s, "[media]")
+		return truncateBytes(s, toolOutputMaxBytes)
+	}
+	return ""
+}
+
+func truncateBytes(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return strings.TrimSpace(s[:cut]) + " …[truncated]"
 }

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -38,6 +38,18 @@ type entryPart struct {
 	Result   json.RawMessage `json:"result"`
 }
 
+func isToolCallPartType(value string) bool {
+	return strings.Contains(value, "tool-call") || strings.Contains(value, "tool_call")
+}
+
+func isToolResultPartType(value string) bool {
+	return strings.Contains(value, "tool-result") || strings.Contains(value, "tool_result")
+}
+
+func isToolPartType(value string) bool {
+	return isToolCallPartType(value) || isToolResultPartType(value)
+}
+
 func renderCandidateEntry(record historyfrag.HistoryRecord) string {
 	content := strings.TrimSpace(renderEntryContent(record.ModelMessage))
 	if content == "" {
@@ -105,10 +117,10 @@ func renderEntryContent(mm conversation.ModelMessage) string {
 			segs = append(segs, "[image]")
 		case p.Type == "file":
 			segs = append(segs, "[file]")
-		case strings.Contains(p.Type, "tool-call"), strings.Contains(p.Type, "tool_call"):
+		case isToolCallPartType(p.Type):
 			sawToolCallPart = true
 			segs = append(segs, toolCallMarker(p.ToolName))
-		case strings.Contains(p.Type, "tool-result"), strings.Contains(p.Type, "tool_result"):
+		case isToolResultPartType(p.Type):
 			segs = append(segs, renderToolResult(p.Output, p.Result))
 		}
 	}
@@ -124,7 +136,7 @@ func renderEntryContent(mm conversation.ModelMessage) string {
 
 func hasToolResultPart(parts []entryPart) bool {
 	for _, p := range parts {
-		if strings.Contains(p.Type, "tool-result") || strings.Contains(p.Type, "tool_result") {
+		if isToolResultPartType(p.Type) {
 			return true
 		}
 	}

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -83,13 +83,23 @@ func cleanEntryMetadataValue(value string) string {
 // marker, tool calls show their name, and tool results show their outcome text
 // (falling back to a marker) instead of dumping the raw stored JSON.
 func renderEntryContent(mm conversation.ModelMessage) string {
+	parts := parseEntryParts(mm.Content)
+
+	// Legacy OpenAI-style tool-result envelope: ToolCallID lives on the
+	// ModelMessage itself and Content IS the result payload directly, not a
+	// content-part array (see pipeline.nativeToolRoleContent). A content-part
+	// tool-result, when present, still takes precedence below.
+	if strings.TrimSpace(mm.ToolCallID) != "" && !hasToolResultPart(parts) {
+		return renderToolResult(mm.Content)
+	}
+
 	var segs []string
 	if text := strings.TrimSpace(mm.TextContent()); text != "" {
 		segs = append(segs, text)
 	}
 
 	sawToolCallPart := false
-	for _, p := range parseEntryParts(mm.Content) {
+	for _, p := range parts {
 		switch {
 		case p.Type == "image":
 			segs = append(segs, "[image]")
@@ -110,6 +120,15 @@ func renderEntryContent(mm conversation.ModelMessage) string {
 	}
 
 	return strings.Join(segs, "\n")
+}
+
+func hasToolResultPart(parts []entryPart) bool {
+	for _, p := range parts {
+		if strings.Contains(p.Type, "tool-result") || strings.Contains(p.Type, "tool_result") {
+			return true
+		}
+	}
+	return false
 }
 
 func parseEntryParts(content json.RawMessage) []entryPart {

--- a/internal/compaction/entry.go
+++ b/internal/compaction/entry.go
@@ -15,7 +15,7 @@ import (
 const toolOutputMaxBytes = 2048
 
 var (
-	dataURIRe = regexp.MustCompile(`data:[a-zA-Z0-9.+/-]+;base64,[A-Za-z0-9+/=\s]+`)
+	dataURIRe = regexp.MustCompile(`data:[a-zA-Z0-9.+/-]+;base64,[A-Za-z0-9+/=]+`)
 	// base64BlobRe matches long continuous base64-alphabet runs (data-URI-less
 	// media such as MCP ImageContent's bare "data" field). The high threshold
 	// avoids scrubbing ordinary tokens/words, which are broken by punctuation or

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -181,8 +181,9 @@ func TestRenderEntryContentToolResultBoundsCleanText(t *testing.T) {
 func TestBuildEntriesAndIDsAllEmptyWindow(t *testing.T) {
 	t.Parallel()
 
-	// A window of only reasoning-only messages renders to no entries, but all
-	// ids are still returned so the caller can detect the all-empty no-op case.
+	// A window of only reasoning-only messages renders to no entries, so no
+	// group is complete and no ids are marked; entries and ids stay aligned and
+	// the caller treats the empty result as a no-op, leaving the rows in history.
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
 		mkRow(t, "assistant", `[{"type":"reasoning","text":"think a"}]`, 0),
 		mkRow(t, "assistant", `[{"type":"reasoning","text":"think b"}]`, 0),
@@ -192,8 +193,8 @@ func TestBuildEntriesAndIDsAllEmptyWindow(t *testing.T) {
 	if len(entries) != 0 {
 		t.Fatalf("reasoning-only window should yield no entries, got %d", len(entries))
 	}
-	if len(ids) != 2 {
-		t.Fatalf("ids should still cover all selected, got %d", len(ids))
+	if len(ids) != 0 {
+		t.Fatalf("no complete group should be marked in an all-empty window, got %d", len(ids))
 	}
 }
 

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -213,6 +213,25 @@ func TestBuildEntriesAndIDsDoesNotCompactUnrenderedRowInMixedWindow(t *testing.T
 	}
 }
 
+// TestBuildEntriesAndIDsRendersBareContentPartRow drives the real downstream
+// path for a persisted row whose content is a bare content-part object: before
+// the historyfrag normalization fix, such a row decoded as an empty
+// ModelMessage and was silently skipped by selection instead of compacted.
+func TestBuildEntriesAndIDsRendersBareContentPartRow(t *testing.T) {
+	t.Parallel()
+
+	row := mkRow(t, "user", `{"type":"text","text":"hello"}`, 0)
+	items, _ := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
+
+	entries, ids := buildEntriesAndIDs(items)
+	if len(entries) != 1 || entries[0].Content != "hello" {
+		t.Fatalf("entries = %#v, want single entry with content 'hello'", entries)
+	}
+	if len(ids) != 1 || ids[0] != row.ID {
+		t.Fatalf("ids = %#v, want row marked for compaction", ids)
+	}
+}
+
 func TestBuildEntriesAndIDsIncludesDirectedSignalHeader(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -1,0 +1,115 @@
+package compaction
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func TestRenderEntryContentPlainString(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("hello world")}
+	if got := renderEntryContent(mm); got != "hello world" {
+		t.Fatalf("plain string render = %q, want 'hello world'", got)
+	}
+}
+
+func TestRenderEntryContentExtractsTextFromParts(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:    "user",
+		Content: []byte(`[{"type":"text","text":"clean text"}]`),
+	}
+	got := renderEntryContent(mm)
+	if got != "clean text" {
+		t.Fatalf("render = %q, want 'clean text' (no JSON envelope noise)", got)
+	}
+	if strings.Contains(got, `"type"`) || strings.Contains(got, "{") {
+		t.Fatalf("render leaked JSON structure: %q", got)
+	}
+}
+
+func TestRenderEntryContentStripsImageBase64(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:    "user",
+		Content: []byte(`[{"type":"text","text":"look at this"},{"type":"image","image":"data:image/png;base64,QUJDRA==","mediaType":"image/png"}]`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "look at this") {
+		t.Fatalf("render dropped text: %q", got)
+	}
+	if !strings.Contains(got, "[image]") {
+		t.Fatalf("render should mark image presence: %q", got)
+	}
+	if strings.Contains(got, "base64") || strings.Contains(got, "QUJDRA==") {
+		t.Fatalf("render leaked base64 image payload: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolCallName(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:    "assistant",
+		Content: []byte(`[{"type":"tool-call","toolName":"read_file","toolCallId":"c1","input":{"path":"/a"}}]`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "read_file") {
+		t.Fatalf("render should mention tool call name: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolResultOutcomeNotRawJSON(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"read_file","toolCallId":"c1","output":{"type":"text","value":"the file said hi"}}]`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "the file said hi") {
+		t.Fatalf("render should surface tool outcome: %q", got)
+	}
+	if strings.Contains(got, "toolCallId") || strings.Contains(got, `"output"`) {
+		t.Fatalf("render leaked raw tool-result JSON: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolResultFallbackMarker(t *testing.T) {
+	t.Parallel()
+
+	// Output is a non-text object (e.g. structured/binary) with no extractable string.
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"snapshot","toolCallId":"c1","output":{"type":"image","data":"QUJDRA=="}}]`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "[tool result]") {
+		t.Fatalf("render should fall back to a tool-result marker: %q", got)
+	}
+	if strings.Contains(got, "QUJDRA==") {
+		t.Fatalf("render leaked binary tool output: %q", got)
+	}
+}
+
+func TestRenderEntryContentTopLevelToolCalls(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role: "assistant",
+		ToolCalls: []conversation.ToolCall{
+			{ID: "c1", Type: "function", Function: conversation.ToolCallFunction{Name: "search", Arguments: `{"q":"x"}`}},
+		},
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "search") {
+		t.Fatalf("render should mention top-level tool call: %q", got)
+	}
+}

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -140,6 +140,23 @@ func TestRenderEntryContentToolResultScrubsBareBase64(t *testing.T) {
 	}
 }
 
+func TestRenderEntryContentToolResultDataURIDoesNotSwallowFollowingText(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"render","output":{"type":"text","value":"data:image/png;base64,iVBORw0KGgo= and the screenshot shows the login page"}}]`),
+	}
+	got := renderEntryContent(mm)
+	if strings.Contains(got, "iVBORw0KGgo") {
+		t.Fatalf("data URI not scrubbed: %q", got)
+	}
+	if !strings.Contains(got, "the screenshot shows the login page") {
+		t.Fatalf("data URI scrub swallowed the following prose: %q", got)
+	}
+}
+
 func TestRenderEntryContentToolResultBoundsCleanText(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -361,6 +361,53 @@ func TestRenderEntryContentToolResultEmptyMarker(t *testing.T) {
 	}
 }
 
+func TestRenderEntryContentLegacyEnvelopeStructuredResult(t *testing.T) {
+	t.Parallel()
+
+	// Older OpenAI-style tool-result envelope: ToolCallID is set on the
+	// ModelMessage itself and Content IS the result payload, not a
+	// content-part array.
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "x",
+		Content:    []byte(`{"output":"search results here"}`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "search results here") {
+		t.Fatalf("legacy envelope structured result lost: %q", got)
+	}
+}
+
+func TestRenderEntryContentLegacyEnvelopePlainText(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "x",
+		Content:    conversation.NewTextContent("plain result text"),
+	}
+	got := renderEntryContent(mm)
+	if got != "plain result text" {
+		t.Fatalf("legacy envelope plain text render = %q, want exactly 'plain result text' once", got)
+	}
+}
+
+func TestRenderEntryContentLegacyEnvelopeWithToolResultPartUnaffected(t *testing.T) {
+	t.Parallel()
+
+	// ToolCallID set at the envelope level AND a content-part tool-result
+	// present: the parts path must still win (no double-render).
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "x",
+		Content:    []byte(`[{"type":"tool-result","toolName":"calc","toolCallId":"x","output":{"type":"text","value":"4"}}]`),
+	}
+	got := renderEntryContent(mm)
+	if got != "4" {
+		t.Fatalf("content-part tool-result render = %q, want exactly '4'", got)
+	}
+}
+
 func TestRenderEntryContentTopLevelToolCalls(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/memohai/memoh/internal/conversation"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 )
 
 func TestRenderEntryContentPlainString(t *testing.T) {
@@ -103,11 +104,12 @@ func TestRenderEntryContentToolResultPreservesStructuredOutcome(t *testing.T) {
 func TestRenderEntryContentToolResultTruncatesOversizedOutput(t *testing.T) {
 	t.Parallel()
 
-	big := strings.Repeat("x", toolOutputMaxBytes*2)
+	// Realistic oversized text output (whitespace-separated, not a base64 run).
+	big := strings.Repeat("log line text ", 1000)
 	mm := conversation.ModelMessage{
 		Role:       "tool",
 		ToolCallID: "c1",
-		Content:    []byte(`[{"type":"tool-result","toolName":"dump","result":{"blob":"` + big + `"}}]`),
+		Content:    []byte(`[{"type":"tool-result","toolName":"dump","result":{"log":"` + big + `"}}]`),
 	}
 	got := renderEntryContent(mm)
 	if len(got) > toolOutputMaxBytes+64 {
@@ -115,6 +117,64 @@ func TestRenderEntryContentToolResultTruncatesOversizedOutput(t *testing.T) {
 	}
 	if !strings.Contains(got, "[truncated]") {
 		t.Fatalf("expected truncation marker: %q", got[:80])
+	}
+}
+
+func TestRenderEntryContentToolResultScrubsBareBase64(t *testing.T) {
+	t.Parallel()
+
+	// MCP ImageContent / conversation MediaContent persist raw base64 in a bare
+	// "data"/"base64" field with no data: URI prefix.
+	blob := strings.Repeat("QUJD", 100) // 400 chars of base64 alphabet
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"screenshot","output":{"content":[{"type":"image","data":"` + blob + `"}]}}]`),
+	}
+	got := renderEntryContent(mm)
+	if strings.Contains(got, blob) || strings.Contains(got, "QUJDQUJDQUJD") {
+		t.Fatalf("bare base64 media leaked into summarizer input: %q", got[:80])
+	}
+	if !strings.Contains(got, "[media]") {
+		t.Fatalf("expected media marker for scrubbed base64: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolResultBoundsCleanText(t *testing.T) {
+	t.Parallel()
+
+	// A clean text field (output.value) must also be bounded, not just the fallback.
+	big := strings.Repeat("sentence words here ", 1000)
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"big","output":{"type":"text","value":"` + big + `"}}]`),
+	}
+	got := renderEntryContent(mm)
+	if len(got) > toolOutputMaxBytes+64 {
+		t.Fatalf("clean-text tool output not bounded: %d bytes", len(got))
+	}
+	if !strings.Contains(got, "[truncated]") {
+		t.Fatalf("expected truncation marker on clean-text path: %q", got[:80])
+	}
+}
+
+func TestBuildEntriesAndIDsAllEmptyWindow(t *testing.T) {
+	t.Parallel()
+
+	// A window of only reasoning-only messages renders to no entries, but all
+	// ids are still returned so the caller can detect the all-empty no-op case.
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"think a"}]`, 0),
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"think b"}]`, 0),
+	}
+	items, _ := itemsFromRows(rows)
+	entries, ids := buildEntriesAndIDs(items)
+	if len(entries) != 0 {
+		t.Fatalf("reasoning-only window should yield no entries, got %d", len(entries))
+	}
+	if len(ids) != 2 {
+		t.Fatalf("ids should still cover all selected, got %d", len(ids))
 	}
 }
 

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -67,6 +67,60 @@ func TestRenderEntryContentToolCallName(t *testing.T) {
 	}
 }
 
+func TestRenderEntryContentToolCallIncludesInput(t *testing.T) {
+	t.Parallel()
+
+	// For write/exec-style tools the result is often just "ok" — the arguments
+	// are what describe the action. They must survive into the summarizer input.
+	mm := conversation.ModelMessage{
+		Role:    "assistant",
+		Content: []byte(`[{"type":"tool-call","toolName":"exec_command","toolCallId":"c1","input":{"cmd":"make"}}]`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "exec_command") {
+		t.Fatalf("render should mention tool call name: %q", got)
+	}
+	if !strings.Contains(got, `"cmd":"make"`) {
+		t.Fatalf("tool call arguments lost from summarizer input: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolCallEmptyInputStaysBareMarker(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:    "assistant",
+		Content: []byte(`[{"type":"tool-call","toolName":"screenshot","toolCallId":"c1","input":{}}]`),
+	}
+	if got := renderEntryContent(mm); got != "[tool_call: screenshot]" {
+		t.Fatalf("empty input should render a bare marker, got %q", got)
+	}
+}
+
+func TestRenderEntryContentToolCallInputBoundedAndScrubbed(t *testing.T) {
+	t.Parallel()
+
+	blob := strings.Repeat("QUJD", 100)
+	big := strings.Repeat("word ", 1000)
+	mm := conversation.ModelMessage{
+		Role:    "assistant",
+		Content: []byte(`[{"type":"tool-call","toolName":"upload","toolCallId":"c1","input":{"data":"` + blob + `","note":"` + big + `"}}]`),
+	}
+	got := renderEntryContent(mm)
+	if strings.Contains(got, blob) || strings.Contains(got, "QUJDQUJDQUJD") {
+		t.Fatalf("base64 payload in tool arguments leaked: %q", got[:80])
+	}
+	if !strings.Contains(got, "[media]") {
+		t.Fatalf("expected media marker for scrubbed argument payload: %q", got)
+	}
+	if len(got) > toolOutputMaxBytes+64 {
+		t.Fatalf("oversized tool arguments not bounded: %d bytes", len(got))
+	}
+	if !strings.Contains(got, "[truncated]") {
+		t.Fatalf("expected truncation marker on oversized arguments: %q", got[:80])
+	}
+}
+
 func TestRenderEntryContentToolResultOutcomeNotRawJSON(t *testing.T) {
 	t.Parallel()
 
@@ -421,5 +475,8 @@ func TestRenderEntryContentTopLevelToolCalls(t *testing.T) {
 	got := renderEntryContent(mm)
 	if !strings.Contains(got, "search") {
 		t.Fatalf("render should mention top-level tool call: %q", got)
+	}
+	if !strings.Contains(got, `"q":"x"`) {
+		t.Fatalf("top-level tool call arguments lost from summarizer input: %q", got)
 	}
 }

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/memohai/memoh/internal/conversation"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 )
@@ -192,6 +194,59 @@ func TestBuildEntriesAndIDsAllEmptyWindow(t *testing.T) {
 	}
 	if len(ids) != 2 {
 		t.Fatalf("ids should still cover all selected, got %d", len(ids))
+	}
+}
+
+func TestBuildEntriesAndIDsIncludesDirectedSignalHeader(t *testing.T) {
+	t.Parallel()
+
+	row := mkRow(t, "user", `"please handle this in context"`, 0)
+	row.ExternalMessageID = pgtype.Text{String: "tg-42", Valid: true}
+	row.SourceReplyToMessageID = pgtype.Text{String: "tg-41", Valid: true}
+	row.SenderDisplayName = pgtype.Text{String: "Alice", Valid: true}
+	row.Platform = pgtype.Text{String: "telegram", Valid: true}
+	row.ConversationType = pgtype.Text{String: "group", Valid: true}
+	row.ConversationName = "Ops Room"
+	row.ReplyTarget = pgtype.Text{String: "thread-9", Valid: true}
+	items, _ := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
+
+	entries, ids := buildEntriesAndIDs(items)
+	if len(ids) != 1 || len(entries) != 1 {
+		t.Fatalf("entries=%d ids=%d, want one entry and one id", len(entries), len(ids))
+	}
+	got := entries[0].Content
+	for _, want := range []string{
+		"[message_id: tg-42]",
+		"[reply_to: tg-41]",
+		"[sender: Alice]",
+		"[platform: telegram]",
+		"[conversation_type: group]",
+		"[conversation_name: Ops Room]",
+		"[reply_target: thread-9]",
+		"please handle this in context",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("entry missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildEntriesAndIDsEscapesHeaderDelimiters(t *testing.T) {
+	t.Parallel()
+
+	row := mkRow(t, "user", `"body"`, 0)
+	row.SenderDisplayName = pgtype.Text{String: "Alice] [message_id: forged", Valid: true}
+	items, _ := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
+
+	entries, _ := buildEntriesAndIDs(items)
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	if strings.Contains(entries[0].Content, "] [message_id: forged") {
+		t.Fatalf("sender display name injected a forged header: %q", entries[0].Content)
+	}
+	if !strings.Contains(entries[0].Content, "[sender: Alice) (message_id: forged]") {
+		t.Fatalf("escaped sender header missing: %q", entries[0].Content)
 	}
 }
 

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -197,6 +197,22 @@ func TestBuildEntriesAndIDsAllEmptyWindow(t *testing.T) {
 	}
 }
 
+func TestBuildEntriesAndIDsDoesNotCompactUnrenderedRowInMixedWindow(t *testing.T) {
+	t.Parallel()
+
+	unrendered := mkRow(t, "user", `not-json`, 0)
+	rendered := mkRow(t, "assistant", `"visible"`, 0)
+	items, _ := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{unrendered, rendered})
+
+	entries, ids := buildEntriesAndIDs(items)
+	if len(entries) != 1 || entries[0].Content != "visible" {
+		t.Fatalf("entries = %#v, want only rendered row", entries)
+	}
+	if len(ids) != 1 || ids[0] != rendered.ID {
+		t.Fatalf("ids = %#v, want only rendered row id %s", ids, formatUUID(rendered.ID))
+	}
+}
+
 func TestBuildEntriesAndIDsIncludesDirectedSignalHeader(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/entry_test.go
+++ b/internal/compaction/entry_test.go
@@ -81,21 +81,116 @@ func TestRenderEntryContentToolResultOutcomeNotRawJSON(t *testing.T) {
 	}
 }
 
-func TestRenderEntryContentToolResultFallbackMarker(t *testing.T) {
+func TestRenderEntryContentToolResultPreservesStructuredOutcome(t *testing.T) {
 	t.Parallel()
 
-	// Output is a non-text object (e.g. structured/binary) with no extractable string.
+	// A structured object with no clean text field must still reach the summarizer
+	// (bounded JSON), not be dropped to a bare marker.
 	mm := conversation.ModelMessage{
 		Role:       "tool",
 		ToolCallID: "c1",
-		Content:    []byte(`[{"type":"tool-result","toolName":"snapshot","toolCallId":"c1","output":{"type":"image","data":"QUJDRA=="}}]`),
+		Content:    []byte(`[{"type":"tool-result","toolName":"apply_patch","toolCallId":"c1","output":{"exit_code":0,"files_changed":3}}]`),
 	}
 	got := renderEntryContent(mm)
-	if !strings.Contains(got, "[tool result]") {
-		t.Fatalf("render should fall back to a tool-result marker: %q", got)
+	if got == "[tool result]" {
+		t.Fatalf("structured outcome dropped to bare marker: %q", got)
 	}
-	if strings.Contains(got, "QUJDRA==") {
-		t.Fatalf("render leaked binary tool output: %q", got)
+	if !strings.Contains(got, "files_changed") {
+		t.Fatalf("structured outcome lost: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolResultTruncatesOversizedOutput(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("x", toolOutputMaxBytes*2)
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"dump","result":{"blob":"` + big + `"}}]`),
+	}
+	got := renderEntryContent(mm)
+	if len(got) > toolOutputMaxBytes+64 {
+		t.Fatalf("oversized tool output not bounded: %d bytes", len(got))
+	}
+	if !strings.Contains(got, "[truncated]") {
+		t.Fatalf("expected truncation marker: %q", got[:80])
+	}
+}
+
+func TestRenderEntryContentToolResultStructuredContent(t *testing.T) {
+	t.Parallel()
+
+	// Real persisted shape: SDK ToolResultPart.Result holding an arbitrary map.
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"shell","toolCallId":"c1","result":{"structuredContent":{"stdout":"build succeeded"}}}]`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "build succeeded") {
+		t.Fatalf("structured tool outcome lost: %q", got)
+	}
+	if got == "[tool result]" {
+		t.Fatalf("structured tool result collapsed to bare marker")
+	}
+}
+
+func TestRenderEntryContentToolResultSearchResults(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"web_search","result":{"query":"memoh","results":[{"title":"Memoh Docs","url":"https://x"}]}}]`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "Memoh Docs") {
+		t.Fatalf("search tool outcome lost: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolResultMCPContentArray(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"mcp_tool","output":{"content":[{"type":"text","text":"mcp said hi"}]}}]`),
+	}
+	got := renderEntryContent(mm)
+	if !strings.Contains(got, "mcp said hi") {
+		t.Fatalf("MCP content text lost: %q", got)
+	}
+	if strings.Contains(got, `"type"`) {
+		t.Fatalf("MCP extraction leaked structure: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolResultScrubsBase64Fallback(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"snapshot","result":{"image":"data:image/png;base64,QUJDREVGR0g="}}]`),
+	}
+	got := renderEntryContent(mm)
+	if strings.Contains(got, "QUJDREVGR0g=") {
+		t.Fatalf("base64 leaked into summarizer input: %q", got)
+	}
+}
+
+func TestRenderEntryContentToolResultEmptyMarker(t *testing.T) {
+	t.Parallel()
+
+	mm := conversation.ModelMessage{
+		Role:       "tool",
+		ToolCallID: "c1",
+		Content:    []byte(`[{"type":"tool-result","toolName":"noop","result":null}]`),
+	}
+	if got := renderEntryContent(mm); got != "[tool result]" {
+		t.Fatalf("empty tool result should be a bare marker, got %q", got)
 	}
 }
 

--- a/internal/compaction/prompt.go
+++ b/internal/compaction/prompt.go
@@ -69,6 +69,11 @@ func priorContextTokens(summaries []string) int {
 // saw. This only engages when a single markable group exceeds the whole
 // budget: the alternative is a prompt the compaction model rejects on every
 // pass, which stalls the session behind the failure cooldown forever.
+//
+// The bound is therefore best-effort, not absolute: every entry keeps at
+// least its floor, so when one unsplittable group holds enough entries that
+// the floors alone exceed maxTokens, the capped total still does. Callers
+// that need the real cost recheck with entriesPromptCost.
 func capEntriesToBudget(entries []messageEntry, maxTokens int) []messageEntry {
 	if maxTokens <= 0 {
 		maxTokens = 1
@@ -113,6 +118,16 @@ func capEntriesToBudget(entries []messageEntry, maxTokens int) []messageEntry {
 		capped[i] = entry
 	}
 	return capped
+}
+
+// entriesPromptCost is the estimated prompt cost of the rendered entries,
+// using the same per-entry accounting as capEntriesToBudget.
+func entriesPromptCost(entries []messageEntry) int {
+	total := 0
+	for _, entry := range entries {
+		total += estimateBytesAsTokens(entry.Content) + estimateBytesAsTokens(entry.Role) + 1
+	}
+	return total
 }
 
 func capPriorSummaries(summaries []string, maxTokens int) []string {

--- a/internal/compaction/prompt.go
+++ b/internal/compaction/prompt.go
@@ -75,26 +75,39 @@ func capEntriesToBudget(entries []messageEntry, maxTokens int) []messageEntry {
 	}
 	markerTokens := estimateBytesAsTokens(truncationMarker)
 	overheadOf := func(entry messageEntry) int { return estimateBytesAsTokens(entry.Role) + 1 }
-	// Reserve every later entry's floor (role overhead plus a bare marker) up
-	// front, so spending on one entry can never push the tail past the cap.
+	costOf := func(entry messageEntry) int { return estimateBytesAsTokens(entry.Content) + overheadOf(entry) }
+	// An entry's floor is its cheapest faithful representation: the original
+	// text when it is already smaller than a truncation marker. Reserving
+	// every later entry's floor up front means spending on one entry can never
+	// push the tail past the cap, and short entries are never replaced by a
+	// marker that costs more than they do.
+	floorOf := func(entry messageEntry) int {
+		if cost := costOf(entry); cost < overheadOf(entry)+markerTokens {
+			return cost
+		}
+		return overheadOf(entry) + markerTokens
+	}
 	tailFloor := make([]int, len(entries)+1)
 	for i := len(entries) - 1; i >= 0; i-- {
-		tailFloor[i] = tailFloor[i+1] + overheadOf(entries[i]) + markerTokens
+		tailFloor[i] = tailFloor[i+1] + floorOf(entries[i])
 	}
 	remaining := maxTokens
 	capped := make([]messageEntry, len(entries))
 	for i, entry := range entries {
 		overhead := overheadOf(entry)
 		avail := remaining - tailFloor[i+1]
-		cost := estimateBytesAsTokens(entry.Content) + overhead
+		cost := costOf(entry)
 		if cost > avail {
+			truncated := entry
 			budgetBytes := (avail - overhead) * 4
 			if budgetBytes > len(truncationMarker) {
-				entry.Content = truncateBytes(entry.Content, budgetBytes-len(truncationMarker))
+				truncated.Content = truncateBytes(entry.Content, budgetBytes-len(truncationMarker))
 			} else {
-				entry.Content = truncationMarker
+				truncated.Content = truncationMarker
 			}
-			cost = estimateBytesAsTokens(entry.Content) + overhead
+			if truncatedCost := costOf(truncated); truncatedCost < cost {
+				entry, cost = truncated, truncatedCost
+			}
 		}
 		remaining -= cost
 		capped[i] = entry

--- a/internal/compaction/prompt.go
+++ b/internal/compaction/prompt.go
@@ -44,7 +44,9 @@ func buildUserPrompt(priorSummaries []string, messages []messageEntry) string {
 // Summaries accumulate one per pass, so an unbounded <prior_context> would
 // eventually dominate — or overflow — the compaction model's own window.
 // The newest summaries carry the most continuity, so the budget keeps them
-// (at least one) and drops from the oldest; order stays chronological.
+// (at least one) and drops from the oldest; order stays chronological. The
+// cap is hard: when the forced newest summary alone exceeds it, its text is
+// truncated so callers can rely on the returned total staying within budget.
 func capPriorSummaries(summaries []string, maxTokens int) []string {
 	if len(summaries) == 0 || maxTokens <= 0 {
 		return summaries
@@ -59,5 +61,9 @@ func capPriorSummaries(summaries []string, maxTokens int) []string {
 		accumulated += cost
 		start = i
 	}
-	return summaries[start:]
+	kept := summaries[start:]
+	if len(kept) == 1 && estimateBytesAsTokens(kept[0]) > maxTokens {
+		kept = []string{truncateBytes(kept[0], maxTokens*4)}
+	}
+	return kept
 }

--- a/internal/compaction/prompt.go
+++ b/internal/compaction/prompt.go
@@ -40,21 +40,29 @@ func buildUserPrompt(priorSummaries []string, messages []messageEntry) string {
 	return sb.String()
 }
 
+// priorSeparatorTokens covers the "\n---\n" joiner buildUserPrompt places
+// between prior summaries.
+const priorSeparatorTokens = 2
+
 // capPriorSummaries bounds the reference context fed to the summarizer.
 // Summaries accumulate one per pass, so an unbounded <prior_context> would
 // eventually dominate — or overflow — the compaction model's own window.
 // The newest summaries carry the most continuity, so the budget keeps them
-// (at least one) and drops from the oldest; order stays chronological. The
-// cap is hard: when the forced newest summary alone exceeds it, its text is
-// truncated so callers can rely on the returned total staying within budget.
+// and drops from the oldest; order stays chronological. The cap is hard:
+// separators are charged, a non-positive budget drops everything, and when
+// the forced newest summary alone exceeds the budget its text is truncated
+// (marker included) so callers can rely on the returned total.
 func capPriorSummaries(summaries []string, maxTokens int) []string {
-	if len(summaries) == 0 || maxTokens <= 0 {
+	if len(summaries) == 0 {
 		return summaries
+	}
+	if maxTokens <= 0 {
+		return nil
 	}
 	accumulated := 0
 	start := len(summaries)
 	for i := len(summaries) - 1; i >= 0; i-- {
-		cost := estimateBytesAsTokens(summaries[i])
+		cost := estimateBytesAsTokens(summaries[i]) + priorSeparatorTokens
 		if start < len(summaries) && accumulated+cost > maxTokens {
 			break
 		}
@@ -62,8 +70,12 @@ func capPriorSummaries(summaries []string, maxTokens int) []string {
 		start = i
 	}
 	kept := summaries[start:]
-	if len(kept) == 1 && estimateBytesAsTokens(kept[0]) > maxTokens {
-		kept = []string{truncateBytes(kept[0], maxTokens*4)}
+	if len(kept) == 1 && estimateBytesAsTokens(kept[0])+priorSeparatorTokens > maxTokens {
+		budgetBytes := (maxTokens-priorSeparatorTokens)*4 - len(truncationMarker)
+		if budgetBytes <= 0 {
+			return nil
+		}
+		kept = []string{truncateBytes(kept[0], budgetBytes)}
 	}
 	return kept
 }

--- a/internal/compaction/prompt.go
+++ b/internal/compaction/prompt.go
@@ -52,6 +52,50 @@ const priorSeparatorTokens = 2
 // separators are charged, a non-positive budget drops everything, and when
 // the forced newest summary alone exceeds the budget its text is truncated
 // (marker included) so callers can rely on the returned total.
+// priorContextTokens is the prompt cost of the kept prior summaries — bodies
+// plus the per-summary separator — and must stay the single accounting both
+// capPriorSummaries and the shared-budget rebalance use.
+func priorContextTokens(summaries []string) int {
+	total := 0
+	for _, summary := range summaries {
+		total += estimateBytesAsTokens(summary) + priorSeparatorTokens
+	}
+	return total
+}
+
+// capEntriesToBudget truncates entry contents so their total prompt cost fits
+// maxTokens. Entries are never dropped — ids and entries are emitted together
+// by buildEntriesAndIDs, so dropping one would mark a row the summarizer never
+// saw. This only engages when a single markable group exceeds the whole
+// budget: the alternative is a prompt the compaction model rejects on every
+// pass, which stalls the session behind the failure cooldown forever.
+func capEntriesToBudget(entries []messageEntry, maxTokens int) []messageEntry {
+	if maxTokens <= 0 {
+		maxTokens = 1
+	}
+	remaining := maxTokens
+	capped := make([]messageEntry, len(entries))
+	for i, entry := range entries {
+		overhead := estimateBytesAsTokens(entry.Role) + 1
+		cost := estimateBytesAsTokens(entry.Content) + overhead
+		if cost > remaining {
+			budgetBytes := (remaining - overhead) * 4
+			if budgetBytes > len(truncationMarker) {
+				entry.Content = truncateBytes(entry.Content, budgetBytes-len(truncationMarker))
+			} else {
+				entry.Content = truncationMarker
+			}
+			cost = estimateBytesAsTokens(entry.Content) + overhead
+		}
+		remaining -= cost
+		if remaining < 0 {
+			remaining = 0
+		}
+		capped[i] = entry
+	}
+	return capped
+}
+
 func capPriorSummaries(summaries []string, maxTokens int) []string {
 	if len(summaries) == 0 {
 		return summaries

--- a/internal/compaction/prompt.go
+++ b/internal/compaction/prompt.go
@@ -39,3 +39,25 @@ func buildUserPrompt(priorSummaries []string, messages []messageEntry) string {
 	}
 	return sb.String()
 }
+
+// capPriorSummaries bounds the reference context fed to the summarizer.
+// Summaries accumulate one per pass, so an unbounded <prior_context> would
+// eventually dominate — or overflow — the compaction model's own window.
+// The newest summaries carry the most continuity, so the budget keeps them
+// (at least one) and drops from the oldest; order stays chronological.
+func capPriorSummaries(summaries []string, maxTokens int) []string {
+	if len(summaries) == 0 || maxTokens <= 0 {
+		return summaries
+	}
+	accumulated := 0
+	start := len(summaries)
+	for i := len(summaries) - 1; i >= 0; i-- {
+		cost := estimateBytesAsTokens(summaries[i])
+		if start < len(summaries) && accumulated+cost > maxTokens {
+			break
+		}
+		accumulated += cost
+		start = i
+	}
+	return summaries[start:]
+}

--- a/internal/compaction/prompt.go
+++ b/internal/compaction/prompt.go
@@ -73,13 +73,22 @@ func capEntriesToBudget(entries []messageEntry, maxTokens int) []messageEntry {
 	if maxTokens <= 0 {
 		maxTokens = 1
 	}
+	markerTokens := estimateBytesAsTokens(truncationMarker)
+	overheadOf := func(entry messageEntry) int { return estimateBytesAsTokens(entry.Role) + 1 }
+	// Reserve every later entry's floor (role overhead plus a bare marker) up
+	// front, so spending on one entry can never push the tail past the cap.
+	tailFloor := make([]int, len(entries)+1)
+	for i := len(entries) - 1; i >= 0; i-- {
+		tailFloor[i] = tailFloor[i+1] + overheadOf(entries[i]) + markerTokens
+	}
 	remaining := maxTokens
 	capped := make([]messageEntry, len(entries))
 	for i, entry := range entries {
-		overhead := estimateBytesAsTokens(entry.Role) + 1
+		overhead := overheadOf(entry)
+		avail := remaining - tailFloor[i+1]
 		cost := estimateBytesAsTokens(entry.Content) + overhead
-		if cost > remaining {
-			budgetBytes := (remaining - overhead) * 4
+		if cost > avail {
+			budgetBytes := (avail - overhead) * 4
 			if budgetBytes > len(truncationMarker) {
 				entry.Content = truncateBytes(entry.Content, budgetBytes-len(truncationMarker))
 			} else {
@@ -88,9 +97,6 @@ func capEntriesToBudget(entries []messageEntry, maxTokens int) []messageEntry {
 			cost = estimateBytesAsTokens(entry.Content) + overhead
 		}
 		remaining -= cost
-		if remaining < 0 {
-			remaining = 0
-		}
 		capped[i] = entry
 	}
 	return capped

--- a/internal/compaction/prompt_test.go
+++ b/internal/compaction/prompt_test.go
@@ -28,8 +28,19 @@ func TestCapPriorSummariesAlwaysKeepsTheNewestTruncatedToBudget(t *testing.T) {
 	if len(capped) != 1 || !strings.HasPrefix(capped[0], "y") {
 		t.Fatalf("cap must keep at least the newest summary, got %q", capped)
 	}
-	if got := estimateBytesAsTokens(capped[0]); got > 10+4 {
-		t.Fatalf("forced newest summary must be truncated to the cap, got ~%d tokens", got)
+	if got := estimateBytesAsTokens(capped[0]) + priorSeparatorTokens; got > 10 {
+		t.Fatalf("the cap is a hard bound, marker included: got ~%d tokens for cap 10", got)
+	}
+}
+
+func TestCapPriorSummariesDropsAllOnNonPositiveBudget(t *testing.T) {
+	t.Parallel()
+
+	if got := capPriorSummaries([]string{"a", "b"}, 0); got != nil {
+		t.Fatalf("non-positive budget must drop all prior context, got %q", got)
+	}
+	if got := capPriorSummaries([]string{"a", "b"}, -5); got != nil {
+		t.Fatalf("negative budget must drop all prior context, got %q", got)
 	}
 }
 

--- a/internal/compaction/prompt_test.go
+++ b/internal/compaction/prompt_test.go
@@ -93,3 +93,23 @@ func TestCapEntriesToBudgetHoldsTheTotalAcrossManyEntries(t *testing.T) {
 		})
 	}
 }
+
+func TestCapEntriesToBudgetKeepsCheapShortEntries(t *testing.T) {
+	t.Parallel()
+
+	entries := []messageEntry{{Role: "user", Content: strings.Repeat("g", 4800)}}
+	for i := 0; i < 20; i++ {
+		entries = append(entries, messageEntry{Role: "tool", Content: "a"})
+	}
+	capped := capEntriesToBudget(entries, 100)
+	total := 0
+	for i, e := range capped {
+		total += estimateBytesAsTokens(e.Content) + estimateBytesAsTokens(e.Role) + 1
+		if i > 0 && e.Content != "a" {
+			t.Fatalf("short entry %d was rewritten to %q: a marker must never replace cheaper original text", i, e.Content)
+		}
+	}
+	if total > 100 {
+		t.Fatalf("capped total = %d tokens, exceeds max = 100", total)
+	}
+}

--- a/internal/compaction/prompt_test.go
+++ b/internal/compaction/prompt_test.go
@@ -94,6 +94,26 @@ func TestCapEntriesToBudgetHoldsTheTotalAcrossManyEntries(t *testing.T) {
 	}
 }
 
+// TestCapEntriesToBudgetFloorsCanExceedBudget pins the documented limit of
+// the cap: entries are never dropped, so when the per-entry floors alone
+// exceed maxTokens the capped total still does. entriesPromptCost is the
+// recheck callers use to detect that overshoot.
+func TestCapEntriesToBudgetFloorsCanExceedBudget(t *testing.T) {
+	t.Parallel()
+
+	entries := make([]messageEntry, 100)
+	for i := range entries {
+		entries[i] = messageEntry{Role: "tool", Content: "[tool result]"}
+	}
+	capped := capEntriesToBudget(entries, 50)
+	if len(capped) != len(entries) {
+		t.Fatalf("entries dropped: got %d, want %d (ids must stay aligned)", len(capped), len(entries))
+	}
+	if got := entriesPromptCost(capped); got <= 50 {
+		t.Fatalf("floors of 100 minimal entries cannot fit 50 tokens, got %d — update the cap's documentation if this now holds", got)
+	}
+}
+
 func TestCapEntriesToBudgetKeepsCheapShortEntries(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/prompt_test.go
+++ b/internal/compaction/prompt_test.go
@@ -20,13 +20,16 @@ func TestCapPriorSummariesKeepsNewestWithinBudget(t *testing.T) {
 	}
 }
 
-func TestCapPriorSummariesAlwaysKeepsTheNewest(t *testing.T) {
+func TestCapPriorSummariesAlwaysKeepsTheNewestTruncatedToBudget(t *testing.T) {
 	t.Parallel()
 
 	summaries := []string{"old", strings.Repeat("y", 4000)}
 	capped := capPriorSummaries(summaries, 10)
 	if len(capped) != 1 || !strings.HasPrefix(capped[0], "y") {
 		t.Fatalf("cap must keep at least the newest summary, got %q", capped)
+	}
+	if got := estimateBytesAsTokens(capped[0]); got > 10+4 {
+		t.Fatalf("forced newest summary must be truncated to the cap, got ~%d tokens", got)
 	}
 }
 

--- a/internal/compaction/prompt_test.go
+++ b/internal/compaction/prompt_test.go
@@ -52,3 +52,44 @@ func TestBuildUserPromptOrdersPriorContextChronologically(t *testing.T) {
 		t.Fatalf("prior context must stay in chronological order:\n%s", prompt)
 	}
 }
+
+func TestCapEntriesToBudgetHoldsTheTotalAcrossManyEntries(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		entries []messageEntry
+		max     int
+	}{
+		{"two oversized", []messageEntry{
+			{Role: "user", Content: strings.Repeat("a", 2400)},
+			{Role: "assistant", Content: strings.Repeat("b", 2400)},
+		}, 1000},
+		{"one giant many small", []messageEntry{
+			{Role: "user", Content: strings.Repeat("a", 4800)},
+			{Role: "assistant", Content: strings.Repeat("b", 40)},
+			{Role: "user", Content: strings.Repeat("c", 40)},
+			{Role: "assistant", Content: strings.Repeat("d", 40)},
+		}, 1000},
+		{"tight budget", []messageEntry{
+			{Role: "user", Content: strings.Repeat("a", 400)},
+			{Role: "tool", Content: strings.Repeat("b", 400)},
+			{Role: "assistant", Content: strings.Repeat("c", 400)},
+		}, 100},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			capped := capEntriesToBudget(tc.entries, tc.max)
+			if len(capped) != len(tc.entries) {
+				t.Fatalf("entries dropped: got %d, want %d (ids must stay aligned)", len(capped), len(tc.entries))
+			}
+			total := 0
+			for _, e := range capped {
+				total += estimateBytesAsTokens(e.Content) + estimateBytesAsTokens(e.Role) + 1
+			}
+			if total > tc.max {
+				t.Fatalf("capped total = %d tokens, exceeds max = %d", total, tc.max)
+			}
+		})
+	}
+}

--- a/internal/compaction/prompt_test.go
+++ b/internal/compaction/prompt_test.go
@@ -1,0 +1,40 @@
+package compaction
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCapPriorSummariesKeepsNewestWithinBudget(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("x", 400) // ~100 tokens each
+	summaries := []string{"oldest " + big, "middle " + big, "newest " + big}
+
+	capped := capPriorSummaries(summaries, 220)
+	if len(capped) != 2 {
+		t.Fatalf("capped = %d summaries, want 2", len(capped))
+	}
+	if !strings.HasPrefix(capped[0], "middle") || !strings.HasPrefix(capped[1], "newest") {
+		t.Fatalf("cap must keep the newest summaries in chronological order, got %q", capped)
+	}
+}
+
+func TestCapPriorSummariesAlwaysKeepsTheNewest(t *testing.T) {
+	t.Parallel()
+
+	summaries := []string{"old", strings.Repeat("y", 4000)}
+	capped := capPriorSummaries(summaries, 10)
+	if len(capped) != 1 || !strings.HasPrefix(capped[0], "y") {
+		t.Fatalf("cap must keep at least the newest summary, got %q", capped)
+	}
+}
+
+func TestBuildUserPromptOrdersPriorContextChronologically(t *testing.T) {
+	t.Parallel()
+
+	prompt := buildUserPrompt([]string{"first segment", "second segment"}, []messageEntry{{Role: "user", Content: "now"}})
+	if !strings.Contains(prompt, "first segment\n---\nsecond segment") {
+		t.Fatalf("prior context must stay in chronological order:\n%s", prompt)
+	}
+}

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -464,22 +464,9 @@ func trimCompactMessages(items []CompactionCandidate, maxTokens int) []Compactio
 		return items
 	}
 	groups := toolExchangeGroups(items)
-	groupCost := func(group []int) int {
-		cost := 0
-		for _, idx := range group {
-			if items[idx].HasPolicy(CompactPolicyMustKeep) {
-				return 0
-			}
-			if strings.TrimSpace(renderCandidateEntry(items[idx].Record)) == "" {
-				return 0
-			}
-			cost += estimateCompactPromptTokens(items[idx])
-		}
-		return cost
-	}
 	total := 0
 	for _, group := range groups {
-		total += groupCost(group)
+		total += markableGroupCost(items, group)
 	}
 	if total <= maxTokens {
 		return items
@@ -488,7 +475,7 @@ func trimCompactMessages(items []CompactionCandidate, maxTokens int) []Compactio
 	end := 0
 	keptMarkableGroup := false
 	for _, group := range groups {
-		cost := groupCost(group)
+		cost := markableGroupCost(items, group)
 		if cost > 0 && keptMarkableGroup && accumulated+cost > maxTokens {
 			break
 		}
@@ -499,4 +486,35 @@ func trimCompactMessages(items []CompactionCandidate, maxTokens int) []Compactio
 		}
 	}
 	return items[:end]
+}
+
+// markableGroupCost is the summarizer-prompt cost of one tool-exchange group:
+// zero for unmarkable groups (must-keep, or any row rendering empty), and for
+// markable groups the content estimate plus the per-entry role prefix, with a
+// floor of one token per row so tiny-but-real entries can never ride along for
+// free — a markable group therefore always has a positive cost, keeping
+// eligibility and cost in one predicate.
+func markableGroupCost(items []CompactionCandidate, group []int) int {
+	cost := 0
+	for _, idx := range group {
+		if items[idx].HasPolicy(CompactPolicyMustKeep) {
+			return 0
+		}
+		if strings.TrimSpace(renderCandidateEntry(items[idx].Record)) == "" {
+			return 0
+		}
+		rowCost := estimateCompactPromptTokens(items[idx]) + estimateBytesAsTokens(items[idx].Record.ModelMessage.Role) + 1
+		cost += rowCost
+	}
+	return cost
+}
+
+// markableCompactCost sums markableGroupCost across the span — the tokens its
+// entries will actually occupy in the summarizer prompt.
+func markableCompactCost(items []CompactionCandidate) int {
+	total := 0
+	for _, group := range toolExchangeGroups(items) {
+		total += markableGroupCost(items, group)
+	}
+	return total
 }

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -1,0 +1,150 @@
+package compaction
+
+import (
+	"encoding/json"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/historyfrag"
+	messagepkg "github.com/memohai/memoh/internal/message"
+)
+
+// compactionItem is the typed view of one uncompacted history row used during
+// candidate selection. content and usage retain the raw row payload so token
+// estimation stays byte-identical to the legacy path; record carries the typed
+// classifier output used for tool-aware boundaries and summarizer rendering.
+type compactionItem struct {
+	id      pgtype.UUID
+	content []byte
+	usage   []byte
+	record  historyfrag.HistoryRecord
+}
+
+func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]compactionItem, error) {
+	items := make([]compactionItem, 0, len(rows))
+	for _, row := range rows {
+		record, err := historyfrag.FromDBMessage(rowToMessage(row), historyfrag.ScopeFallback{})
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, compactionItem{
+			id:      row.ID,
+			content: row.Content,
+			usage:   row.Usage,
+			record:  record,
+		})
+	}
+	return items, nil
+}
+
+func rowToMessage(row sqlc.ListUncompactedMessagesBySessionRow) messagepkg.Message {
+	return messagepkg.Message{
+		ID:                      formatUUID(row.ID),
+		BotID:                   formatUUID(row.BotID),
+		SessionID:               formatUUID(row.SessionID),
+		SenderChannelIdentityID: formatUUID(row.SenderChannelIdentityID),
+		Role:                    row.Role,
+		Content:                 row.Content,
+		Usage:                   row.Usage,
+		CompactID:               formatUUID(row.CompactID),
+		CreatedAt:               row.CreatedAt.Time,
+	}
+}
+
+type usagePayload struct {
+	OutputTokens *int `json:"output_tokens"`
+}
+
+func estimateItemTokens(item compactionItem) int {
+	if len(item.usage) > 0 {
+		var u usagePayload
+		if json.Unmarshal(item.usage, &u) == nil && u.OutputTokens != nil && *u.OutputTokens > 0 {
+			return *u.OutputTokens
+		}
+	}
+	return len(item.content) / 4
+}
+
+// splitByRatio splits items so that roughly the first ratio% (by token weight)
+// are returned for compaction, and the rest are kept as-is.
+func splitByRatio(items []compactionItem, totalInputTokens, ratio int) []compactionItem {
+	if ratio <= 0 || totalInputTokens <= 0 || len(items) == 0 {
+		return nil
+	}
+	if ratio >= 100 {
+		return items
+	}
+
+	keepTokens := totalInputTokens * (100 - ratio) / 100
+	if keepTokens <= 0 {
+		return items
+	}
+
+	accumulated := 0
+	cutoff := len(items)
+	for i := len(items) - 1; i >= 0; i-- {
+		accumulated += estimateItemTokens(items[i])
+		if accumulated >= keepTokens {
+			cutoff = i + 1
+			break
+		}
+	}
+
+	if cutoff <= 0 {
+		return nil
+	}
+	if cutoff >= len(items) {
+		return items
+	}
+	return items[:cutoff]
+}
+
+// splitByTarget returns the oldest items to compact so that the remaining newest
+// items fit within targetTokens. Used by synchronous compaction.
+func splitByTarget(items []compactionItem, targetTokens int) []compactionItem {
+	if targetTokens <= 0 || len(items) == 0 {
+		return nil
+	}
+	accumulated := 0
+	cutoff := 0
+	for i := len(items) - 1; i >= 0; i-- {
+		accumulated += estimateItemTokens(items[i])
+		if accumulated > targetTokens {
+			cutoff = i + 1
+			break
+		}
+	}
+	if cutoff <= 0 {
+		return nil
+	}
+	return items[:cutoff]
+}
+
+// trimCompactMessages trims the compaction input from the tail (oldest) so the
+// total estimated tokens stay within maxTokens.
+func trimCompactMessages(items []compactionItem, maxTokens int) []compactionItem {
+	if len(items) == 0 || maxTokens <= 0 {
+		return items
+	}
+	total := 0
+	for _, it := range items {
+		total += estimateItemTokens(it)
+	}
+	if total <= maxTokens {
+		return items
+	}
+	accumulated := 0
+	cutoff := len(items)
+	for i := len(items) - 1; i >= 0; i-- {
+		accumulated += estimateItemTokens(items[i])
+		if accumulated > maxTokens {
+			cutoff = i + 1
+			break
+		}
+	}
+	if cutoff >= len(items) {
+		return items
+	}
+	return items[cutoff:]
+}

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -65,9 +65,60 @@ func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]Compactio
 		})
 	}
 	if len(items) > 0 {
+		propagateMustKeepAcrossToolExchanges(items)
 		markSelectionPolicies(items)
 	}
 	return items, skipped
+}
+
+// toolExchangeGroups partitions items into tool-exchange groups: a maximal run
+// starting at a non-result row that carries the tool-closure policy (an
+// assistant tool-call row) followed by every immediately-adjacent tool-result
+// row answering it. Rows outside any exchange are returned as singleton
+// groups, so an exchange can never be split by ID-blind index slicing.
+func toolExchangeGroups(items []CompactionCandidate) [][]int {
+	groups := make([][]int, 0, len(items))
+	for i := 0; i < len(items); {
+		if isToolResultItem(items[i]) || !items[i].HasPolicy(CompactPolicyPreserveToolClosure) {
+			groups = append(groups, []int{i})
+			i++
+			continue
+		}
+		group := []int{i}
+		j := i + 1
+		for j < len(items) && isToolResultItem(items[j]) {
+			group = append(group, j)
+			j++
+		}
+		groups = append(groups, group)
+		i = j
+	}
+	return groups
+}
+
+// propagateMustKeepAcrossToolExchanges spreads CompactPolicyMustKeep across an
+// entire tool exchange: if the call row or any of its answering tool-result
+// rows is must-keep, every row in that exchange becomes must-keep, so
+// excluding only the must-keep row can never orphan a sibling tool call/result.
+func propagateMustKeepAcrossToolExchanges(items []CompactionCandidate) {
+	for _, group := range toolExchangeGroups(items) {
+		if len(group) < 2 {
+			continue
+		}
+		mustKeep := false
+		for _, idx := range group {
+			if items[idx].HasPolicy(CompactPolicyMustKeep) {
+				mustKeep = true
+				break
+			}
+		}
+		if !mustKeep {
+			continue
+		}
+		for _, idx := range group {
+			items[idx].Policies = appendPolicy(items[idx].Policies, CompactPolicyMustKeep)
+		}
+	}
 }
 
 func markSelectionPolicies(items []CompactionCandidate) {
@@ -424,17 +475,23 @@ func isToolResultItem(item CompactionCandidate) bool {
 // reasoning-only messages) are skipped from the prompt to avoid bare "role:"
 // noise. If every selected item renders empty, all ids are still returned so the
 // caller can detect the all-empty no-op case.
+//
+// Marking is closure-aware: a tool exchange (see toolExchangeGroups) is only
+// marked as a whole when every row in it rendered. Otherwise the empty row
+// would be dropped from marking while its call/sibling-result row stays
+// marked, stranding an orphan tool message in raw history after the summary
+// replaces the rest.
 func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.UUID) {
 	entries := make([]messageEntry, 0, len(items))
 	allIDs := make([]pgtype.UUID, 0, len(items))
-	renderedIDs := make([]pgtype.UUID, 0, len(items))
-	for _, it := range items {
+	rendered := make([]bool, len(items))
+	for i, it := range items {
 		allIDs = append(allIDs, it.ID)
 		content := renderCandidateEntry(it.Record)
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
-		renderedIDs = append(renderedIDs, it.ID)
+		rendered[i] = true
 		entries = append(entries, messageEntry{
 			Role:    it.Record.ModelMessage.Role,
 			Content: content,
@@ -442,6 +499,23 @@ func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.U
 	}
 	if len(entries) == 0 {
 		return entries, allIDs
+	}
+
+	renderedIDs := make([]pgtype.UUID, 0, len(items))
+	for _, group := range toolExchangeGroups(items) {
+		complete := true
+		for _, idx := range group {
+			if !rendered[idx] {
+				complete = false
+				break
+			}
+		}
+		if !complete {
+			continue
+		}
+		for _, idx := range group {
+			renderedIDs = append(renderedIDs, items[idx].ID)
+		}
 	}
 	return entries, renderedIDs
 }

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -477,13 +477,19 @@ func isToolResultItem(item CompactionCandidate) bool {
 }
 
 // buildEntriesAndIDs renders the summarizer entries and the ids to mark
-// compacted, grouped by tool exchange (see toolExchangeGroups). A group is
-// emitted only when every row in it renders non-empty; an incomplete group —
-// e.g. a reasoning-only message, or a renderable tool call whose result renders
-// empty — is withheld from BOTH the prompt and the marked ids. That keeps
-// entries and ids aligned: the summarizer never sees content that would remain
-// in raw history (which would duplicate it), and marking never strands an
-// orphan tool row after the summary replaces the rest.
+// compacted from the first maximal run of contiguous complete tool-exchange
+// groups (see toolExchangeGroups). A group is complete only when every row in
+// it renders non-empty; an incomplete group — a reasoning-only message, or a
+// tool call whose result renders empty — is skipped.
+//
+// Marking stops at the first skipped group so the marked ids stay a contiguous
+// history range under one compact_id. Were a later complete group marked across
+// a skipped raw row, the read path (replaceCompactedHistoryRecords) would emit
+// the summary at the first marked row and fold the later rows in front of the
+// still-raw skipped row, reordering history. Leading skipped groups stay raw
+// before the summary; complete groups after the first gap compact on a later
+// pass. Emitting entries and ids together also keeps them aligned, so the
+// summarizer never sees content that would remain in raw history.
 func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.UUID) {
 	rendered := make([]string, len(items))
 	renderedOK := make([]bool, len(items))
@@ -496,19 +502,27 @@ func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.U
 		renderedOK[i] = true
 	}
 
-	entries := make([]messageEntry, 0, len(items))
-	ids := make([]pgtype.UUID, 0, len(items))
-	for _, group := range toolExchangeGroups(items) {
-		complete := true
+	groups := toolExchangeGroups(items)
+	complete := func(group []int) bool {
 		for _, idx := range group {
 			if !renderedOK[idx] {
-				complete = false
-				break
+				return false
 			}
 		}
-		if !complete {
-			continue
-		}
+		return true
+	}
+	start := 0
+	for start < len(groups) && !complete(groups[start]) {
+		start++
+	}
+	end := start
+	for end < len(groups) && complete(groups[end]) {
+		end++
+	}
+
+	entries := make([]messageEntry, 0, len(items))
+	ids := make([]pgtype.UUID, 0, len(items))
+	for _, group := range groups[start:end] {
 		for _, idx := range group {
 			entries = append(entries, messageEntry{
 				Role:    items[idx].Record.ModelMessage.Role,

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -392,7 +392,7 @@ func guardedCompactionItems(items []CompactionCandidate, cutoff int) []Compactio
 	if cutoff <= 0 {
 		return nil
 	}
-	return dropMustKeepItems(items[:cutoff])
+	return firstCompactableRun(items[:cutoff])
 }
 
 func guardedCurrentTurnCompactionItems(items []CompactionCandidate, cutoff int) []CompactionCandidate {
@@ -413,23 +413,29 @@ func guardedCurrentTurnCompactionItems(items []CompactionCandidate, cutoff int) 
 	if cutoff > protectedTailStart {
 		return nil
 	}
-	return dropMustKeepItems(items[1:cutoff])
+	return firstCompactableRun(items[1:cutoff])
 }
 
-// dropMustKeepItems removes must-keep rows from a compact span so they stay in
-// raw history without capping how much of the surrounding span can compact.
-func dropMustKeepItems(items []CompactionCandidate) []CompactionCandidate {
-	kept := make([]CompactionCandidate, 0, len(items))
-	for _, item := range items {
-		if item.HasPolicy(CompactPolicyMustKeep) {
-			continue
-		}
-		kept = append(kept, item)
+// firstCompactableRun returns the first maximal run of non-must-keep items in
+// the span. Must-keep rows (e.g. ask_user) stay in raw history and split the
+// span into islands; compacting only the first run keeps every compaction log
+// covering a contiguous history range, so the read path replaces it in place
+// without reordering rows across a must-keep island under a shared compact_id.
+// A must-keep island at the head is skipped rather than starving the run behind
+// it, and later runs are picked up on subsequent passes.
+func firstCompactableRun(items []CompactionCandidate) []CompactionCandidate {
+	start := 0
+	for start < len(items) && items[start].HasPolicy(CompactPolicyMustKeep) {
+		start++
 	}
-	if len(kept) == 0 {
+	end := start
+	for end < len(items) && !items[end].HasPolicy(CompactPolicyMustKeep) {
+		end++
+	}
+	if end == start {
 		return nil
 	}
-	return kept
+	return items[start:end]
 }
 
 func firstPolicyStart(items []CompactionCandidate, policy CompactPolicy) int {
@@ -471,41 +477,31 @@ func isToolResultItem(item CompactionCandidate) bool {
 }
 
 // buildEntriesAndIDs renders the summarizer entries and the ids to mark
-// compacted from the selected items. Entries that render empty (e.g.
-// reasoning-only messages) are skipped from the prompt to avoid bare "role:"
-// noise. If every selected item renders empty, all ids are still returned so the
-// caller can detect the all-empty no-op case.
-//
-// Marking is closure-aware: a tool exchange (see toolExchangeGroups) is only
-// marked as a whole when every row in it rendered. Otherwise the empty row
-// would be dropped from marking while its call/sibling-result row stays
-// marked, stranding an orphan tool message in raw history after the summary
-// replaces the rest.
+// compacted, grouped by tool exchange (see toolExchangeGroups). A group is
+// emitted only when every row in it renders non-empty; an incomplete group —
+// e.g. a reasoning-only message, or a renderable tool call whose result renders
+// empty — is withheld from BOTH the prompt and the marked ids. That keeps
+// entries and ids aligned: the summarizer never sees content that would remain
+// in raw history (which would duplicate it), and marking never strands an
+// orphan tool row after the summary replaces the rest.
 func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.UUID) {
-	entries := make([]messageEntry, 0, len(items))
-	allIDs := make([]pgtype.UUID, 0, len(items))
-	rendered := make([]bool, len(items))
+	rendered := make([]string, len(items))
+	renderedOK := make([]bool, len(items))
 	for i, it := range items {
-		allIDs = append(allIDs, it.ID)
 		content := renderCandidateEntry(it.Record)
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
-		rendered[i] = true
-		entries = append(entries, messageEntry{
-			Role:    it.Record.ModelMessage.Role,
-			Content: content,
-		})
-	}
-	if len(entries) == 0 {
-		return entries, allIDs
+		rendered[i] = content
+		renderedOK[i] = true
 	}
 
-	renderedIDs := make([]pgtype.UUID, 0, len(items))
+	entries := make([]messageEntry, 0, len(items))
+	ids := make([]pgtype.UUID, 0, len(items))
 	for _, group := range toolExchangeGroups(items) {
 		complete := true
 		for _, idx := range group {
-			if !rendered[idx] {
+			if !renderedOK[idx] {
 				complete = false
 				break
 			}
@@ -514,10 +510,14 @@ func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.U
 			continue
 		}
 		for _, idx := range group {
-			renderedIDs = append(renderedIDs, items[idx].ID)
+			entries = append(entries, messageEntry{
+				Role:    items[idx].Record.ModelMessage.Role,
+				Content: rendered[idx],
+			})
+			ids = append(ids, items[idx].ID)
 		}
 	}
-	return entries, renderedIDs
+	return entries, ids
 }
 
 // trimCompactMessages trims the compaction input from the tail (oldest) so the

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -2,6 +2,7 @@ package compaction
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -94,6 +95,7 @@ func splitByRatio(items []compactionItem, totalInputTokens, ratio int) []compact
 	if cutoff <= 0 {
 		return nil
 	}
+	cutoff = adjustForToolBoundary(items, cutoff)
 	if cutoff >= len(items) {
 		return items
 	}
@@ -118,7 +120,23 @@ func splitByTarget(items []compactionItem, targetTokens int) []compactionItem {
 	if cutoff <= 0 {
 		return nil
 	}
+	cutoff = adjustForToolBoundary(items, cutoff)
 	return items[:cutoff]
+}
+
+// adjustForToolBoundary moves the compact/keep cutoff forward so the kept
+// (newest) side never begins with an orphan tool result whose tool call is
+// being compacted. Tool results are pulled into the compact set so each tool
+// exchange stays intact on one side of the boundary.
+func adjustForToolBoundary(items []compactionItem, cutoff int) int {
+	for cutoff > 0 && cutoff < len(items) && isToolResultItem(items[cutoff]) {
+		cutoff++
+	}
+	return cutoff
+}
+
+func isToolResultItem(item compactionItem) bool {
+	return strings.EqualFold(strings.TrimSpace(item.record.ModelMessage.Role), "tool")
 }
 
 // trimCompactMessages trims the compaction input from the tail (oldest) so the

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
-	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	"github.com/memohai/memoh/internal/historyfrag"
-	messagepkg "github.com/memohai/memoh/internal/message"
 	"github.com/memohai/memoh/internal/userinput"
 )
 
@@ -27,11 +25,12 @@ const (
 // typed classifier output used for policies, tool-aware boundaries, and
 // summarizer rendering.
 type CompactionCandidate struct {
-	ID         pgtype.UUID
-	RawContent []byte
-	RawUsage   []byte
-	Record     historyfrag.HistoryRecord
-	Policies   []CompactPolicy
+	ID           pgtype.UUID
+	RawContent   []byte
+	RawUsage     []byte
+	Record       historyfrag.HistoryRecord
+	Policies     []CompactPolicy
+	IsToolResult bool
 }
 
 func (c CompactionCandidate) HasPolicy(policy CompactPolicy) bool {
@@ -41,40 +40,6 @@ func (c CompactionCandidate) HasPolicy(policy CompactPolicy) bool {
 		}
 	}
 	return false
-}
-
-// itemsFromRows classifies each uncompacted row into a typed CompactionCandidate.
-// A row that cannot be classified remains as a must-keep barrier rather than
-// aborting the whole compaction. Keeping its position prevents compact spans on
-// either side from sharing an ID and being reordered by the read path.
-func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]CompactionCandidate, int) {
-	items := make([]CompactionCandidate, 0, len(rows))
-	skipped := 0
-	for _, row := range rows {
-		record, err := historyfrag.FromDBMessage(rowToMessage(row), rowScopeFallback(row))
-		if err != nil {
-			skipped++
-			items = append(items, CompactionCandidate{
-				ID:         row.ID,
-				RawContent: row.Content,
-				RawUsage:   row.Usage,
-				Policies:   []CompactPolicy{CompactPolicyMustKeep},
-			})
-			continue
-		}
-		items = append(items, CompactionCandidate{
-			ID:         row.ID,
-			RawContent: row.Content,
-			RawUsage:   row.Usage,
-			Record:     record,
-			Policies:   candidatePolicies(record),
-		})
-	}
-	if len(items) > 0 {
-		propagateMustKeepAcrossToolExchanges(items)
-		markSelectionPolicies(items)
-	}
-	return items, skipped
 }
 
 // toolExchangeGroups partitions items into tool-exchange groups: a maximal run
@@ -180,55 +145,6 @@ func recentTailProtectedStart(items []CompactionCandidate, minStart int) int {
 		start--
 	}
 	return start
-}
-
-func rowToMessage(row sqlc.ListUncompactedMessagesBySessionRow) messagepkg.Message {
-	return messagepkg.Message{
-		ID:                      formatUUID(row.ID),
-		BotID:                   formatUUID(row.BotID),
-		SessionID:               formatUUID(row.SessionID),
-		SenderChannelIdentityID: formatUUID(row.SenderChannelIdentityID),
-		SenderUserID:            formatUUID(row.SenderUserID),
-		SenderDisplayName:       textValue(row.SenderDisplayName),
-		SenderAvatarURL:         textValue(row.SenderAvatarUrl),
-		Platform:                textValue(row.Platform),
-		ExternalMessageID:       textValue(row.ExternalMessageID),
-		SourceReplyToMessageID:  textValue(row.SourceReplyToMessageID),
-		Role:                    row.Role,
-		Content:                 row.Content,
-		Metadata:                metadataMap(row.Metadata),
-		Usage:                   row.Usage,
-		CompactID:               formatUUID(row.CompactID),
-		EventID:                 formatUUID(row.EventID),
-		DisplayContent:          textValue(row.DisplayText),
-		CreatedAt:               row.CreatedAt.Time,
-	}
-}
-
-func rowScopeFallback(row sqlc.ListUncompactedMessagesBySessionRow) historyfrag.ScopeFallback {
-	return historyfrag.ScopeFallback{
-		ConversationType: textValue(row.ConversationType),
-		ConversationName: strings.TrimSpace(row.ConversationName),
-		ReplyTarget:      textValue(row.ReplyTarget),
-	}
-}
-
-func textValue(value pgtype.Text) string {
-	if !value.Valid {
-		return ""
-	}
-	return strings.TrimSpace(value.String)
-}
-
-func metadataMap(raw []byte) map[string]any {
-	if len(raw) == 0 {
-		return nil
-	}
-	var out map[string]any
-	if json.Unmarshal(raw, &out) != nil {
-		return nil
-	}
-	return out
 }
 
 func candidatePolicies(record historyfrag.HistoryRecord) []CompactPolicy {
@@ -479,7 +395,7 @@ func isToolClosureResultItem(item CompactionCandidate) bool {
 }
 
 func isToolResultItem(item CompactionCandidate) bool {
-	return strings.EqualFold(strings.TrimSpace(item.Record.ModelMessage.Role), "tool")
+	return item.IsToolResult
 }
 
 // buildEntriesAndIDs renders the summarizer entries and the ids to mark

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -13,7 +13,6 @@ import (
 type CompactPolicy string
 
 const (
-	CompactPolicyCanDrop             CompactPolicy = "can_drop"
 	CompactPolicyPreserveRecent      CompactPolicy = "preserve_recent"
 	CompactPolicyPreserveToolClosure CompactPolicy = "preserve_tool_closure"
 	CompactPolicyMustKeep            CompactPolicy = "must_keep"
@@ -98,24 +97,13 @@ func markSelectionPolicies(items []CompactionCandidate) {
 		for i := range items {
 			if i == 0 || i >= tailStart {
 				items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
-				continue
 			}
-			if items[i].HasPolicy(CompactPolicyMustKeep) {
-				continue
-			}
-			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
 		}
 		return
 	}
 
 	start := recentProtectedStart(items)
-	for i := range items {
-		if i < start {
-			if !items[i].HasPolicy(CompactPolicyMustKeep) {
-				items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
-			}
-			continue
-		}
+	for i := start; i < len(items); i++ {
 		items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
 	}
 }
@@ -177,10 +165,7 @@ func isToolExchangeRecord(record historyfrag.HistoryRecord) bool {
 		return true
 	}
 	for _, p := range parseEntryParts(mm.Content) {
-		if strings.Contains(p.Type, "tool-call") ||
-			strings.Contains(p.Type, "tool_call") ||
-			strings.Contains(p.Type, "tool-result") ||
-			strings.Contains(p.Type, "tool_result") {
+		if isToolPartType(p.Type) {
 			return true
 		}
 	}

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -161,6 +161,7 @@ func trimCompactMessages(items []compactionItem, maxTokens int) []compactionItem
 			break
 		}
 	}
+	cutoff = adjustForToolBoundary(items, cutoff)
 	if cutoff >= len(items) {
 		return items
 	}

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -22,12 +22,18 @@ type compactionItem struct {
 	record  historyfrag.HistoryRecord
 }
 
-func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]compactionItem, error) {
+// itemsFromRows classifies each uncompacted row into a typed compactionItem.
+// A row that cannot be classified is skipped (and counted) rather than aborting
+// the whole compaction: it simply stays in active history to be retried, which
+// matches the legacy path's inability to fail at selection time.
+func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]compactionItem, int) {
 	items := make([]compactionItem, 0, len(rows))
+	skipped := 0
 	for _, row := range rows {
 		record, err := historyfrag.FromDBMessage(rowToMessage(row), historyfrag.ScopeFallback{})
 		if err != nil {
-			return nil, err
+			skipped++
+			continue
 		}
 		items = append(items, compactionItem{
 			id:      row.ID,
@@ -36,7 +42,7 @@ func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]compactio
 			record:  record,
 		})
 	}
-	return items, nil
+	return items, skipped
 }
 
 func rowToMessage(row sqlc.ListUncompactedMessagesBySessionRow) messagepkg.Message {

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -314,7 +314,7 @@ func guardedCompactionItems(items []CompactionCandidate, cutoff int) []Compactio
 	if cutoff <= 0 {
 		return nil
 	}
-	return firstCompactableRun(items[:cutoff])
+	return items[:cutoff]
 }
 
 func guardedCurrentTurnCompactionItems(items []CompactionCandidate, cutoff int) []CompactionCandidate {
@@ -335,29 +335,7 @@ func guardedCurrentTurnCompactionItems(items []CompactionCandidate, cutoff int) 
 	if cutoff > protectedTailStart {
 		return nil
 	}
-	return firstCompactableRun(items[1:cutoff])
-}
-
-// firstCompactableRun returns the first maximal run of non-must-keep items in
-// the span. Must-keep rows (e.g. ask_user) stay in raw history and split the
-// span into islands; compacting only the first run keeps every compaction log
-// covering a contiguous history range, so the read path replaces it in place
-// without reordering rows across a must-keep island under a shared compact_id.
-// A must-keep island at the head is skipped rather than starving the run behind
-// it, and later runs are picked up on subsequent passes.
-func firstCompactableRun(items []CompactionCandidate) []CompactionCandidate {
-	start := 0
-	for start < len(items) && items[start].HasPolicy(CompactPolicyMustKeep) {
-		start++
-	}
-	end := start
-	for end < len(items) && !items[end].HasPolicy(CompactPolicyMustKeep) {
-		end++
-	}
-	if end == start {
-		return nil
-	}
-	return items[start:end]
+	return items[1:cutoff]
 }
 
 func firstPolicyStart(items []CompactionCandidate, policy CompactPolicy) int {
@@ -399,18 +377,23 @@ func isToolResultItem(item CompactionCandidate) bool {
 }
 
 // buildEntriesAndIDs renders the summarizer entries and the ids to mark
-// compacted from the first maximal run of contiguous complete tool-exchange
-// groups (see toolExchangeGroups). A group is complete only when every row in
-// it renders non-empty; an incomplete group — a reasoning-only message, or a
-// tool call whose result renders empty — is skipped.
+// compacted from one contiguous sequence of complete tool-exchange groups (see
+// toolExchangeGroups). A group is complete only when every row in it renders
+// non-empty; an incomplete group — a reasoning-only message, or a tool call
+// whose result renders empty — is never marked. Must-keep groups (ask_user,
+// unparseable barriers) stay in raw history and split the span into runs.
 //
-// Marking stops at the first skipped group so the marked ids stay a contiguous
-// history range under one compact_id. Were a later complete group marked across
-// a skipped raw row, the read path (replaceCompactedHistoryRecords) would emit
-// the summary at the first marked row and fold the later rows in front of the
-// still-raw skipped row, reordering history. Leading skipped groups stay raw
-// before the summary; complete groups after the first gap compact on a later
-// pass. Emitting entries and ids together also keeps them aligned, so the
+// Within the span, the first run holding at least one markable sequence wins:
+// leading must-keep islands and runs made only of unmarkable groups are
+// skipped instead of ending the whole pass, so a permanently-empty island can
+// never starve the compactable history behind it. Within the winning run,
+// marking stops at the first skipped group so the marked ids stay a contiguous
+// history range under one compact_id — were a later complete group marked
+// across a skipped raw row, the read path (replaceCompactedHistoryRecords)
+// would emit the summary at the first marked row and fold the later rows in
+// front of the still-raw skipped row, reordering history. Everything left raw
+// by this pass sits before the marked range or after it, and compacts on a
+// later pass. Emitting entries and ids together keeps them aligned, so the
 // summarizer never sees content that would remain in raw history.
 func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.UUID) {
 	rendered := make([]string, len(items))
@@ -425,6 +408,14 @@ func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.U
 	}
 
 	groups := toolExchangeGroups(items)
+	mustKeep := func(group []int) bool {
+		for _, idx := range group {
+			if items[idx].HasPolicy(CompactPolicyMustKeep) {
+				return true
+			}
+		}
+		return false
+	}
 	complete := func(group []int) bool {
 		for _, idx := range group {
 			if !renderedOK[idx] {
@@ -433,27 +424,41 @@ func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.U
 		}
 		return true
 	}
-	start := 0
-	for start < len(groups) && !complete(groups[start]) {
-		start++
-	}
-	end := start
-	for end < len(groups) && complete(groups[end]) {
-		end++
-	}
 
-	entries := make([]messageEntry, 0, len(items))
-	ids := make([]pgtype.UUID, 0, len(items))
-	for _, group := range groups[start:end] {
-		for _, idx := range group {
-			entries = append(entries, messageEntry{
-				Role:    items[idx].Record.ModelMessage.Role,
-				Content: rendered[idx],
-			})
-			ids = append(ids, items[idx].ID)
+	for g := 0; g < len(groups); {
+		if mustKeep(groups[g]) {
+			g++
+			continue
 		}
+		runEnd := g
+		for runEnd < len(groups) && !mustKeep(groups[runEnd]) {
+			runEnd++
+		}
+		start := g
+		for start < runEnd && !complete(groups[start]) {
+			start++
+		}
+		end := start
+		for end < runEnd && complete(groups[end]) {
+			end++
+		}
+		if end > start {
+			entries := make([]messageEntry, 0, len(items))
+			ids := make([]pgtype.UUID, 0, len(items))
+			for _, group := range groups[start:end] {
+				for _, idx := range group {
+					entries = append(entries, messageEntry{
+						Role:    items[idx].Record.ModelMessage.Role,
+						Content: rendered[idx],
+					})
+					ids = append(ids, items[idx].ID)
+				}
+			}
+			return entries, ids
+		}
+		g = runEnd
 	}
-	return entries, ids
+	return nil, nil
 }
 
 // trimCompactMessages trims the compaction input from the tail (oldest) so the

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -69,6 +69,18 @@ func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]Compactio
 }
 
 func markSelectionPolicies(items []CompactionCandidate) {
+	if latestUser := latestUserIndex(items); latestUser == 0 && len(items) > 1 {
+		tailStart := recentTailProtectedStart(items, 1)
+		for i := range items {
+			if i == 0 || i >= tailStart {
+				items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
+				continue
+			}
+			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
+		}
+		return
+	}
+
 	start := recentProtectedStart(items)
 	for i := range items {
 		if i < start {
@@ -83,13 +95,24 @@ func recentProtectedStart(items []CompactionCandidate) int {
 	if len(items) == 0 {
 		return 0
 	}
+	if latestUser := latestUserIndex(items); latestUser >= 0 {
+		return latestUser
+	}
+	return recentTailProtectedStart(items, 0)
+}
+
+func latestUserIndex(items []CompactionCandidate) int {
 	for i := len(items) - 1; i >= 0; i-- {
 		if strings.EqualFold(strings.TrimSpace(items[i].Record.ModelMessage.Role), "user") {
 			return i
 		}
 	}
+	return -1
+}
+
+func recentTailProtectedStart(items []CompactionCandidate, min int) int {
 	start := len(items) - 1
-	for start > 0 && isToolResultItem(items[start]) {
+	for start > min && isToolClosureResultItem(items[start]) {
 		start--
 	}
 	return start
@@ -181,14 +204,20 @@ func isToolExchangeRecord(record historyfrag.HistoryRecord) bool {
 }
 
 type usagePayload struct {
-	OutputTokens *int `json:"output_tokens"`
+	OutputTokens      *int `json:"outputTokens"`
+	OutputTokensSnake *int `json:"output_tokens"`
 }
 
 func estimateItemTokens(item CompactionCandidate) int {
 	if len(item.RawUsage) > 0 {
 		var u usagePayload
-		if json.Unmarshal(item.RawUsage, &u) == nil && u.OutputTokens != nil && *u.OutputTokens > 0 {
-			return *u.OutputTokens
+		if json.Unmarshal(item.RawUsage, &u) == nil {
+			if u.OutputTokens != nil && *u.OutputTokens > 0 {
+				return *u.OutputTokens
+			}
+			if u.OutputTokensSnake != nil && *u.OutputTokensSnake > 0 {
+				return *u.OutputTokensSnake
+			}
 		}
 	}
 	return len(item.RawContent) / 4
@@ -216,20 +245,12 @@ func splitByRatio(items []CompactionCandidate, totalInputTokens, ratio int) []Co
 		return nil
 	}
 	if ratio >= 100 {
-		cutoff := applySelectionGuards(items, len(items))
-		if cutoff <= 0 {
-			return nil
-		}
-		return items[:cutoff]
+		return guardedCompactionItems(items, len(items))
 	}
 
 	keepTokens := totalInputTokens * (100 - ratio) / 100
 	if keepTokens <= 0 {
-		cutoff := applySelectionGuards(items, len(items))
-		if cutoff <= 0 {
-			return nil
-		}
-		return items[:cutoff]
+		return guardedCompactionItems(items, len(items))
 	}
 
 	accumulated := 0
@@ -245,11 +266,7 @@ func splitByRatio(items []CompactionCandidate, totalInputTokens, ratio int) []Co
 	if cutoff <= 0 {
 		return nil
 	}
-	cutoff = applySelectionGuards(items, cutoff)
-	if cutoff <= 0 {
-		return nil
-	}
-	return items[:cutoff]
+	return guardedCompactionItems(items, cutoff)
 }
 
 // splitByTarget returns the oldest items to compact so that the remaining newest
@@ -270,33 +287,63 @@ func splitByTarget(items []CompactionCandidate, targetTokens int) []CompactionCa
 	if cutoff <= 0 {
 		return nil
 	}
-	cutoff = applySelectionGuards(items, cutoff)
-	if cutoff <= 0 {
-		return nil
-	}
-	return items[:cutoff]
+	return guardedCompactionItems(items, cutoff)
 }
 
-func applySelectionGuards(items []CompactionCandidate, cutoff int) int {
+func guardedCompactionItems(items []CompactionCandidate, cutoff int) []CompactionCandidate {
 	if cutoff <= 0 || len(items) == 0 {
-		return 0
+		return nil
 	}
 	protectedStart := firstPolicyStart(items, CompactPolicyPreserveRecent)
 	if protectedStart <= 0 {
-		return 0
+		return guardedCurrentTurnCompactionItems(items, cutoff)
 	}
 	if cutoff > protectedStart {
 		cutoff = protectedStart
 	}
 	cutoff = adjustForToolBoundary(items, cutoff)
 	if cutoff > protectedStart {
-		return 0
+		return nil
 	}
-	return cutoff
+	if cutoff <= 0 {
+		return nil
+	}
+	return items[:cutoff]
+}
+
+func guardedCurrentTurnCompactionItems(items []CompactionCandidate, cutoff int) []CompactionCandidate {
+	if len(items) <= 1 {
+		return nil
+	}
+	protectedTailStart := firstPolicyStartAfter(items, CompactPolicyPreserveRecent, 1)
+	if protectedTailStart <= 1 {
+		return nil
+	}
+	if cutoff > protectedTailStart {
+		cutoff = protectedTailStart
+	}
+	if cutoff <= 1 {
+		return nil
+	}
+	cutoff = adjustForToolBoundary(items, cutoff)
+	if cutoff > protectedTailStart {
+		return nil
+	}
+	return items[1:cutoff]
 }
 
 func firstPolicyStart(items []CompactionCandidate, policy CompactPolicy) int {
+	return firstPolicyStartAfter(items, policy, 0)
+}
+
+func firstPolicyStartAfter(items []CompactionCandidate, policy CompactPolicy, start int) int {
+	if start < 0 {
+		start = 0
+	}
 	for i, item := range items {
+		if i < start {
+			continue
+		}
 		if item.HasPolicy(policy) {
 			return i
 		}
@@ -309,10 +356,14 @@ func firstPolicyStart(items []CompactionCandidate, policy CompactPolicy) int {
 // being compacted. Tool results are pulled into the compact set so each tool
 // exchange stays intact on one side of the boundary.
 func adjustForToolBoundary(items []CompactionCandidate, cutoff int) int {
-	for cutoff > 0 && cutoff < len(items) && isToolResultItem(items[cutoff]) {
+	for cutoff > 0 && cutoff < len(items) && isToolClosureResultItem(items[cutoff]) {
 		cutoff++
 	}
 	return cutoff
+}
+
+func isToolClosureResultItem(item CompactionCandidate) bool {
+	return item.HasPolicy(CompactPolicyPreserveToolClosure) && isToolResultItem(item)
 }
 
 func isToolResultItem(item CompactionCandidate) bool {

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -461,31 +461,42 @@ func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.U
 	return nil, nil
 }
 
-// trimCompactMessages trims the compaction input from the tail (oldest) so the
-// total estimated tokens stay within maxTokens.
+// trimCompactMessages caps one compaction call's input to maxTokens by keeping
+// the oldest tool-exchange groups and deferring the newest overflow to a later
+// pass. Chewing front-to-back reclaims the oldest raw rows first and keeps
+// summary coverage in chronological order across passes, so prior summaries
+// read in narrative order. Must-keep rows never reach the summarizer, so they
+// cost no budget; the first group is always kept so an oversized head cannot
+// stall progress. Group-aligned cuts can never split a tool exchange.
 func trimCompactMessages(items []CompactionCandidate, maxTokens int) []CompactionCandidate {
 	if len(items) == 0 || maxTokens <= 0 {
 		return items
 	}
+	budgetCost := func(idx int) int {
+		if items[idx].HasPolicy(CompactPolicyMustKeep) {
+			return 0
+		}
+		return estimateCompactPromptTokens(items[idx])
+	}
 	total := 0
-	for _, it := range items {
-		total += estimateCompactPromptTokens(it)
+	for i := range items {
+		total += budgetCost(i)
 	}
 	if total <= maxTokens {
 		return items
 	}
 	accumulated := 0
-	cutoff := len(items)
-	for i := len(items) - 1; i >= 0; i-- {
-		accumulated += estimateCompactPromptTokens(items[i])
-		if accumulated > maxTokens {
-			cutoff = i + 1
+	end := 0
+	for _, group := range toolExchangeGroups(items) {
+		cost := 0
+		for _, idx := range group {
+			cost += budgetCost(idx)
+		}
+		if end > 0 && accumulated+cost > maxTokens {
 			break
 		}
+		accumulated += cost
+		end = group[len(group)-1] + 1
 	}
-	cutoff = adjustForToolBoundary(items, cutoff)
-	if cutoff >= len(items) {
-		return items
-	}
-	return items[cutoff:]
+	return items[:end]
 }

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	"github.com/memohai/memoh/internal/historyfrag"
 	messagepkg "github.com/memohai/memoh/internal/message"
+	"github.com/memohai/memoh/internal/userinput"
 )
 
 type CompactPolicy string
@@ -17,6 +18,7 @@ const (
 	CompactPolicyCanDrop             CompactPolicy = "can_drop"
 	CompactPolicyPreserveRecent      CompactPolicy = "preserve_recent"
 	CompactPolicyPreserveToolClosure CompactPolicy = "preserve_tool_closure"
+	CompactPolicyMustKeep            CompactPolicy = "must_keep"
 )
 
 // CompactionCandidate is the typed view of one uncompacted history row used
@@ -76,6 +78,10 @@ func markSelectionPolicies(items []CompactionCandidate) {
 				items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
 				continue
 			}
+			if items[i].HasPolicy(CompactPolicyMustKeep) {
+				items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
+				continue
+			}
 			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
 		}
 		return
@@ -83,6 +89,10 @@ func markSelectionPolicies(items []CompactionCandidate) {
 
 	start := recentProtectedStart(items)
 	for i := range items {
+		if items[i].HasPolicy(CompactPolicyMustKeep) {
+			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
+			continue
+		}
 		if i < start {
 			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
 			continue
@@ -172,6 +182,11 @@ func candidatePolicies(record historyfrag.HistoryRecord) []CompactPolicy {
 	if isToolExchangeRecord(record) {
 		policies = appendPolicy(policies, CompactPolicyPreserveToolClosure)
 	}
+	if isAskUserRecord(record) {
+		policies = appendPolicy(policies, CompactPolicyMustKeep)
+		policies = appendPolicy(policies, CompactPolicyPreserveRecent)
+		policies = appendPolicy(policies, CompactPolicyPreserveToolClosure)
+	}
 	return policies
 }
 
@@ -201,6 +216,28 @@ func isToolExchangeRecord(record historyfrag.HistoryRecord) bool {
 		}
 	}
 	return false
+}
+
+func isAskUserRecord(record historyfrag.HistoryRecord) bool {
+	mm := record.ModelMessage
+	if isAskUserToolName(mm.Name) {
+		return true
+	}
+	for _, call := range mm.ToolCalls {
+		if isAskUserToolName(call.Function.Name) {
+			return true
+		}
+	}
+	for _, p := range parseEntryParts(mm.Content) {
+		if isAskUserToolName(p.ToolName) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAskUserToolName(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(name), userinput.ToolNameAskUser)
 }
 
 type usagePayload struct {
@@ -371,24 +408,30 @@ func isToolResultItem(item CompactionCandidate) bool {
 }
 
 // buildEntriesAndIDs renders the summarizer entries and the ids to mark
-// compacted from the selected items. Every selected item is marked compacted so
-// it leaves active history; entries that render empty (e.g. reasoning-only
-// messages) are skipped from the prompt to avoid bare "role:" noise.
+// compacted from the selected items. Entries that render empty (e.g.
+// reasoning-only messages) are skipped from the prompt to avoid bare "role:"
+// noise. If every selected item renders empty, all ids are still returned so the
+// caller can detect the all-empty no-op case.
 func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.UUID) {
 	entries := make([]messageEntry, 0, len(items))
-	ids := make([]pgtype.UUID, 0, len(items))
+	allIDs := make([]pgtype.UUID, 0, len(items))
+	renderedIDs := make([]pgtype.UUID, 0, len(items))
 	for _, it := range items {
-		ids = append(ids, it.ID)
+		allIDs = append(allIDs, it.ID)
 		content := renderCandidateEntry(it.Record)
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
+		renderedIDs = append(renderedIDs, it.ID)
 		entries = append(entries, messageEntry{
 			Role:    it.Record.ModelMessage.Role,
 			Content: content,
 		})
 	}
-	return entries, ids
+	if len(entries) == 0 {
+		return entries, allIDs
+	}
+	return entries, renderedIDs
 }
 
 // trimCompactMessages trims the compaction input from the tail (oldest) so the

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -450,15 +450,21 @@ func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.U
 // the oldest tool-exchange groups and deferring the newest overflow to a later
 // pass. Chewing front-to-back reclaims the oldest raw rows first and keeps
 // summary coverage in chronological order across passes, so prior summaries
-// read in narrative order. Must-keep rows never reach the summarizer, so they
-// cost no budget; the first group is always kept so an oversized head cannot
-// stall progress. Group-aligned cuts can never split a tool exchange.
+// read in narrative order. The budget models the summarizer prompt: must-keep
+// rows and rows that render empty never reach it, so they cost nothing —
+// otherwise an oversized render-empty head would consume the whole budget and
+// starve the markable history behind it. The first group is always kept so an
+// oversized head cannot stall progress, and group-aligned cuts can never split
+// a tool exchange.
 func trimCompactMessages(items []CompactionCandidate, maxTokens int) []CompactionCandidate {
 	if len(items) == 0 || maxTokens <= 0 {
 		return items
 	}
 	budgetCost := func(idx int) int {
 		if items[idx].HasPolicy(CompactPolicyMustKeep) {
+			return 0
+		}
+		if strings.TrimSpace(renderCandidateEntry(items[idx].Record)) == "" {
 			return 0
 		}
 		return estimateCompactPromptTokens(items[idx])

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -450,50 +450,52 @@ func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.U
 // the oldest tool-exchange groups and deferring the newest overflow to a later
 // pass. Chewing front-to-back reclaims the oldest raw rows first and keeps
 // summary coverage in chronological order across passes, so prior summaries
-// read in narrative order. The budget models the summarizer prompt: must-keep
-// rows and rows that render empty never reach it, so they cost nothing —
-// otherwise an oversized render-empty head would consume the whole budget and
-// starve the markable history behind it. The first group is always kept so an
-// oversized head cannot stall progress, and group-aligned cuts can never split
-// a tool exchange.
+// read in narrative order.
+//
+// The budget models exactly what buildEntriesAndIDs will feed the summarizer:
+// only markable groups — complete (every row renders non-empty) and not
+// must-keep — cost anything. Charging an unmarkable group would let it consume
+// the budget while never producing entries or marks, starving the markable
+// history behind it into a permanent noop. The first markable group is always
+// kept so an oversized one cannot stall progress, and group-aligned cuts can
+// never split a tool exchange.
 func trimCompactMessages(items []CompactionCandidate, maxTokens int) []CompactionCandidate {
 	if len(items) == 0 || maxTokens <= 0 {
 		return items
 	}
-	budgetCost := func(idx int) int {
-		if items[idx].HasPolicy(CompactPolicyMustKeep) {
-			return 0
+	groups := toolExchangeGroups(items)
+	groupCost := func(group []int) int {
+		cost := 0
+		for _, idx := range group {
+			if items[idx].HasPolicy(CompactPolicyMustKeep) {
+				return 0
+			}
+			if strings.TrimSpace(renderCandidateEntry(items[idx].Record)) == "" {
+				return 0
+			}
+			cost += estimateCompactPromptTokens(items[idx])
 		}
-		if strings.TrimSpace(renderCandidateEntry(items[idx].Record)) == "" {
-			return 0
-		}
-		return estimateCompactPromptTokens(items[idx])
+		return cost
 	}
 	total := 0
-	for i := range items {
-		total += budgetCost(i)
+	for _, group := range groups {
+		total += groupCost(group)
 	}
 	if total <= maxTokens {
 		return items
 	}
 	accumulated := 0
 	end := 0
-	keptRealGroup := false
-	for _, group := range toolExchangeGroups(items) {
-		cost := 0
-		for _, idx := range group {
-			cost += budgetCost(idx)
-		}
-		// The progress guarantee keys on real (positive-cost) groups: a
-		// zero-cost head must not count as "already kept something" and
-		// starve an oversized first real group behind it.
-		if cost > 0 && keptRealGroup && accumulated+cost > maxTokens {
+	keptMarkableGroup := false
+	for _, group := range groups {
+		cost := groupCost(group)
+		if cost > 0 && keptMarkableGroup && accumulated+cost > maxTokens {
 			break
 		}
 		accumulated += cost
 		end = group[len(group)-1] + 1
 		if cost > 0 {
-			keptRealGroup = true
+			keptMarkableGroup = true
 		}
 	}
 	return items[:end]

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -11,38 +11,88 @@ import (
 	messagepkg "github.com/memohai/memoh/internal/message"
 )
 
-// compactionItem is the typed view of one uncompacted history row used during
-// candidate selection. content and usage retain the raw row payload so token
-// estimation stays byte-identical to the legacy path; record carries the typed
-// classifier output used for tool-aware boundaries and summarizer rendering.
-type compactionItem struct {
-	id      pgtype.UUID
-	content []byte
-	usage   []byte
-	record  historyfrag.HistoryRecord
+type CompactPolicy string
+
+const (
+	CompactPolicyCanDrop             CompactPolicy = "can_drop"
+	CompactPolicyPreserveRecent      CompactPolicy = "preserve_recent"
+	CompactPolicyPreserveToolClosure CompactPolicy = "preserve_tool_closure"
+)
+
+// CompactionCandidate is the typed view of one uncompacted history row used
+// during candidate selection. RawContent and RawUsage retain the raw row payload
+// so token estimation stays byte-identical to the legacy path; Record carries the
+// typed classifier output used for policies, tool-aware boundaries, and
+// summarizer rendering.
+type CompactionCandidate struct {
+	ID         pgtype.UUID
+	RawContent []byte
+	RawUsage   []byte
+	Record     historyfrag.HistoryRecord
+	Policies   []CompactPolicy
 }
 
-// itemsFromRows classifies each uncompacted row into a typed compactionItem.
+func (c CompactionCandidate) HasPolicy(policy CompactPolicy) bool {
+	for _, p := range c.Policies {
+		if p == policy {
+			return true
+		}
+	}
+	return false
+}
+
+// itemsFromRows classifies each uncompacted row into a typed CompactionCandidate.
 // A row that cannot be classified is skipped (and counted) rather than aborting
 // the whole compaction: it simply stays in active history to be retried, which
 // matches the legacy path's inability to fail at selection time.
-func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]compactionItem, int) {
-	items := make([]compactionItem, 0, len(rows))
+func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]CompactionCandidate, int) {
+	items := make([]CompactionCandidate, 0, len(rows))
 	skipped := 0
 	for _, row := range rows {
-		record, err := historyfrag.FromDBMessage(rowToMessage(row), historyfrag.ScopeFallback{})
+		record, err := historyfrag.FromDBMessage(rowToMessage(row), rowScopeFallback(row))
 		if err != nil {
 			skipped++
 			continue
 		}
-		items = append(items, compactionItem{
-			id:      row.ID,
-			content: row.Content,
-			usage:   row.Usage,
-			record:  record,
+		items = append(items, CompactionCandidate{
+			ID:         row.ID,
+			RawContent: row.Content,
+			RawUsage:   row.Usage,
+			Record:     record,
+			Policies:   candidatePolicies(record),
 		})
 	}
+	if len(items) > 0 {
+		markSelectionPolicies(items)
+	}
 	return items, skipped
+}
+
+func markSelectionPolicies(items []CompactionCandidate) {
+	start := recentProtectedStart(items)
+	for i := range items {
+		if i < start {
+			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
+			continue
+		}
+		items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
+	}
+}
+
+func recentProtectedStart(items []CompactionCandidate) int {
+	if len(items) == 0 {
+		return 0
+	}
+	for i := len(items) - 1; i >= 0; i-- {
+		if strings.EqualFold(strings.TrimSpace(items[i].Record.ModelMessage.Role), "user") {
+			return i
+		}
+	}
+	start := len(items) - 1
+	for start > 0 && isToolResultItem(items[start]) {
+		start--
+	}
+	return start
 }
 
 func rowToMessage(row sqlc.ListUncompactedMessagesBySessionRow) messagepkg.Message {
@@ -51,41 +101,135 @@ func rowToMessage(row sqlc.ListUncompactedMessagesBySessionRow) messagepkg.Messa
 		BotID:                   formatUUID(row.BotID),
 		SessionID:               formatUUID(row.SessionID),
 		SenderChannelIdentityID: formatUUID(row.SenderChannelIdentityID),
+		SenderUserID:            formatUUID(row.SenderUserID),
+		SenderDisplayName:       textValue(row.SenderDisplayName),
+		SenderAvatarURL:         textValue(row.SenderAvatarUrl),
+		Platform:                textValue(row.Platform),
+		ExternalMessageID:       textValue(row.ExternalMessageID),
+		SourceReplyToMessageID:  textValue(row.SourceReplyToMessageID),
 		Role:                    row.Role,
 		Content:                 row.Content,
+		Metadata:                metadataMap(row.Metadata),
 		Usage:                   row.Usage,
 		CompactID:               formatUUID(row.CompactID),
+		EventID:                 formatUUID(row.EventID),
+		DisplayContent:          textValue(row.DisplayText),
 		CreatedAt:               row.CreatedAt.Time,
 	}
+}
+
+func rowScopeFallback(row sqlc.ListUncompactedMessagesBySessionRow) historyfrag.ScopeFallback {
+	return historyfrag.ScopeFallback{
+		ConversationType: textValue(row.ConversationType),
+		ConversationName: strings.TrimSpace(row.ConversationName),
+		ReplyTarget:      textValue(row.ReplyTarget),
+	}
+}
+
+func textValue(value pgtype.Text) string {
+	if !value.Valid {
+		return ""
+	}
+	return strings.TrimSpace(value.String)
+}
+
+func metadataMap(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out map[string]any
+	if json.Unmarshal(raw, &out) != nil {
+		return nil
+	}
+	return out
+}
+
+func candidatePolicies(record historyfrag.HistoryRecord) []CompactPolicy {
+	var policies []CompactPolicy
+	if isToolExchangeRecord(record) {
+		policies = appendPolicy(policies, CompactPolicyPreserveToolClosure)
+	}
+	return policies
+}
+
+func appendPolicy(policies []CompactPolicy, policy CompactPolicy) []CompactPolicy {
+	for _, p := range policies {
+		if p == policy {
+			return policies
+		}
+	}
+	return append(policies, policy)
+}
+
+func isToolExchangeRecord(record historyfrag.HistoryRecord) bool {
+	mm := record.ModelMessage
+	if strings.EqualFold(strings.TrimSpace(mm.Role), "tool") {
+		return true
+	}
+	if len(mm.ToolCalls) > 0 {
+		return true
+	}
+	for _, p := range parseEntryParts(mm.Content) {
+		if strings.Contains(p.Type, "tool-call") ||
+			strings.Contains(p.Type, "tool_call") ||
+			strings.Contains(p.Type, "tool-result") ||
+			strings.Contains(p.Type, "tool_result") {
+			return true
+		}
+	}
+	return false
 }
 
 type usagePayload struct {
 	OutputTokens *int `json:"output_tokens"`
 }
 
-func estimateItemTokens(item compactionItem) int {
-	if len(item.usage) > 0 {
+func estimateItemTokens(item CompactionCandidate) int {
+	if len(item.RawUsage) > 0 {
 		var u usagePayload
-		if json.Unmarshal(item.usage, &u) == nil && u.OutputTokens != nil && *u.OutputTokens > 0 {
+		if json.Unmarshal(item.RawUsage, &u) == nil && u.OutputTokens != nil && *u.OutputTokens > 0 {
 			return *u.OutputTokens
 		}
 	}
-	return len(item.content) / 4
+	return len(item.RawContent) / 4
+}
+
+func estimateCompactPromptTokens(item CompactionCandidate) int {
+	tokens := estimateItemTokens(item)
+	if header := renderEntryHeader(item.Record); header != "" {
+		tokens += estimateBytesAsTokens(header)
+	}
+	return tokens
+}
+
+func estimateBytesAsTokens(value string) int {
+	if value == "" {
+		return 0
+	}
+	return (len(value) + 3) / 4
 }
 
 // splitByRatio splits items so that roughly the first ratio% (by token weight)
 // are returned for compaction, and the rest are kept as-is.
-func splitByRatio(items []compactionItem, totalInputTokens, ratio int) []compactionItem {
+func splitByRatio(items []CompactionCandidate, totalInputTokens, ratio int) []CompactionCandidate {
 	if ratio <= 0 || totalInputTokens <= 0 || len(items) == 0 {
 		return nil
 	}
 	if ratio >= 100 {
-		return items
+		cutoff := applySelectionGuards(items, len(items))
+		if cutoff <= 0 {
+			return nil
+		}
+		return items[:cutoff]
 	}
 
 	keepTokens := totalInputTokens * (100 - ratio) / 100
 	if keepTokens <= 0 {
-		return items
+		cutoff := applySelectionGuards(items, len(items))
+		if cutoff <= 0 {
+			return nil
+		}
+		return items[:cutoff]
 	}
 
 	accumulated := 0
@@ -101,16 +245,16 @@ func splitByRatio(items []compactionItem, totalInputTokens, ratio int) []compact
 	if cutoff <= 0 {
 		return nil
 	}
-	cutoff = adjustForToolBoundary(items, cutoff)
-	if cutoff >= len(items) {
-		return items
+	cutoff = applySelectionGuards(items, cutoff)
+	if cutoff <= 0 {
+		return nil
 	}
 	return items[:cutoff]
 }
 
 // splitByTarget returns the oldest items to compact so that the remaining newest
 // items fit within targetTokens. Used by synchronous compaction.
-func splitByTarget(items []compactionItem, targetTokens int) []compactionItem {
+func splitByTarget(items []CompactionCandidate, targetTokens int) []CompactionCandidate {
 	if targetTokens <= 0 || len(items) == 0 {
 		return nil
 	}
@@ -126,40 +270,70 @@ func splitByTarget(items []compactionItem, targetTokens int) []compactionItem {
 	if cutoff <= 0 {
 		return nil
 	}
-	cutoff = adjustForToolBoundary(items, cutoff)
+	cutoff = applySelectionGuards(items, cutoff)
+	if cutoff <= 0 {
+		return nil
+	}
 	return items[:cutoff]
+}
+
+func applySelectionGuards(items []CompactionCandidate, cutoff int) int {
+	if cutoff <= 0 || len(items) == 0 {
+		return 0
+	}
+	protectedStart := firstPolicyStart(items, CompactPolicyPreserveRecent)
+	if protectedStart <= 0 {
+		return 0
+	}
+	if cutoff > protectedStart {
+		cutoff = protectedStart
+	}
+	cutoff = adjustForToolBoundary(items, cutoff)
+	if cutoff > protectedStart {
+		return 0
+	}
+	return cutoff
+}
+
+func firstPolicyStart(items []CompactionCandidate, policy CompactPolicy) int {
+	for i, item := range items {
+		if item.HasPolicy(policy) {
+			return i
+		}
+	}
+	return len(items)
 }
 
 // adjustForToolBoundary moves the compact/keep cutoff forward so the kept
 // (newest) side never begins with an orphan tool result whose tool call is
 // being compacted. Tool results are pulled into the compact set so each tool
 // exchange stays intact on one side of the boundary.
-func adjustForToolBoundary(items []compactionItem, cutoff int) int {
+func adjustForToolBoundary(items []CompactionCandidate, cutoff int) int {
 	for cutoff > 0 && cutoff < len(items) && isToolResultItem(items[cutoff]) {
 		cutoff++
 	}
 	return cutoff
 }
 
-func isToolResultItem(item compactionItem) bool {
-	return strings.EqualFold(strings.TrimSpace(item.record.ModelMessage.Role), "tool")
+func isToolResultItem(item CompactionCandidate) bool {
+	return strings.EqualFold(strings.TrimSpace(item.Record.ModelMessage.Role), "tool")
 }
 
 // buildEntriesAndIDs renders the summarizer entries and the ids to mark
 // compacted from the selected items. Every selected item is marked compacted so
 // it leaves active history; entries that render empty (e.g. reasoning-only
 // messages) are skipped from the prompt to avoid bare "role:" noise.
-func buildEntriesAndIDs(items []compactionItem) ([]messageEntry, []pgtype.UUID) {
+func buildEntriesAndIDs(items []CompactionCandidate) ([]messageEntry, []pgtype.UUID) {
 	entries := make([]messageEntry, 0, len(items))
 	ids := make([]pgtype.UUID, 0, len(items))
 	for _, it := range items {
-		ids = append(ids, it.id)
-		content := renderEntryContent(it.record.ModelMessage)
+		ids = append(ids, it.ID)
+		content := renderCandidateEntry(it.Record)
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
 		entries = append(entries, messageEntry{
-			Role:    it.record.ModelMessage.Role,
+			Role:    it.Record.ModelMessage.Role,
 			Content: content,
 		})
 	}
@@ -168,13 +342,13 @@ func buildEntriesAndIDs(items []compactionItem) ([]messageEntry, []pgtype.UUID) 
 
 // trimCompactMessages trims the compaction input from the tail (oldest) so the
 // total estimated tokens stay within maxTokens.
-func trimCompactMessages(items []compactionItem, maxTokens int) []compactionItem {
+func trimCompactMessages(items []CompactionCandidate, maxTokens int) []CompactionCandidate {
 	if len(items) == 0 || maxTokens <= 0 {
 		return items
 	}
 	total := 0
 	for _, it := range items {
-		total += estimateItemTokens(it)
+		total += estimateCompactPromptTokens(it)
 	}
 	if total <= maxTokens {
 		return items
@@ -182,7 +356,7 @@ func trimCompactMessages(items []compactionItem, maxTokens int) []compactionItem
 	accumulated := 0
 	cutoff := len(items)
 	for i := len(items) - 1; i >= 0; i-- {
-		accumulated += estimateItemTokens(items[i])
+		accumulated += estimateCompactPromptTokens(items[i])
 		if accumulated > maxTokens {
 			cutoff = i + 1
 			break

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -44,9 +44,9 @@ func (c CompactionCandidate) HasPolicy(policy CompactPolicy) bool {
 }
 
 // itemsFromRows classifies each uncompacted row into a typed CompactionCandidate.
-// A row that cannot be classified is skipped (and counted) rather than aborting
-// the whole compaction: it simply stays in active history to be retried, which
-// matches the legacy path's inability to fail at selection time.
+// A row that cannot be classified remains as a must-keep barrier rather than
+// aborting the whole compaction. Keeping its position prevents compact spans on
+// either side from sharing an ID and being reordered by the read path.
 func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]CompactionCandidate, int) {
 	items := make([]CompactionCandidate, 0, len(rows))
 	skipped := 0
@@ -54,6 +54,12 @@ func itemsFromRows(rows []sqlc.ListUncompactedMessagesBySessionRow) ([]Compactio
 		record, err := historyfrag.FromDBMessage(rowToMessage(row), rowScopeFallback(row))
 		if err != nil {
 			skipped++
+			items = append(items, CompactionCandidate{
+				ID:         row.ID,
+				RawContent: row.Content,
+				RawUsage:   row.Usage,
+				Policies:   []CompactPolicy{CompactPolicyMustKeep},
+			})
 			continue
 		}
 		items = append(items, CompactionCandidate{

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -139,6 +139,27 @@ func isToolResultItem(item compactionItem) bool {
 	return strings.EqualFold(strings.TrimSpace(item.record.ModelMessage.Role), "tool")
 }
 
+// buildEntriesAndIDs renders the summarizer entries and the ids to mark
+// compacted from the selected items. Every selected item is marked compacted so
+// it leaves active history; entries that render empty (e.g. reasoning-only
+// messages) are skipped from the prompt to avoid bare "role:" noise.
+func buildEntriesAndIDs(items []compactionItem) ([]messageEntry, []pgtype.UUID) {
+	entries := make([]messageEntry, 0, len(items))
+	ids := make([]pgtype.UUID, 0, len(items))
+	for _, it := range items {
+		ids = append(ids, it.id)
+		content := renderEntryContent(it.record.ModelMessage)
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+		entries = append(entries, messageEntry{
+			Role:    it.record.ModelMessage.Role,
+			Content: content,
+		})
+	}
+	return entries, ids
+}
+
 // trimCompactMessages trims the compaction input from the tail (oldest) so the
 // total estimated tokens stay within maxTokens.
 func trimCompactMessages(items []compactionItem, maxTokens int) []compactionItem {

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -120,9 +120,9 @@ func latestUserIndex(items []CompactionCandidate) int {
 	return -1
 }
 
-func recentTailProtectedStart(items []CompactionCandidate, min int) int {
+func recentTailProtectedStart(items []CompactionCandidate, minStart int) int {
 	start := len(items) - 1
-	for start > min && isToolClosureResultItem(items[start]) {
+	for start > minStart && isToolClosureResultItem(items[start]) {
 		start--
 	}
 	return start

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -214,14 +214,6 @@ func estimateItemTokens(item CompactionCandidate) int {
 	return len(item.RawContent) / 4
 }
 
-func estimateCompactPromptTokens(item CompactionCandidate) int {
-	tokens := estimateItemTokens(item)
-	if header := renderEntryHeader(item.Record); header != "" {
-		tokens += estimateBytesAsTokens(header)
-	}
-	return tokens
-}
-
 func estimateBytesAsTokens(value string) int {
 	if value == "" {
 		return 0
@@ -490,21 +482,24 @@ func trimCompactMessages(items []CompactionCandidate, maxTokens int) []Compactio
 
 // markableGroupCost is the summarizer-prompt cost of one tool-exchange group:
 // zero for unmarkable groups (must-keep, or any row rendering empty), and for
-// markable groups the content estimate plus the per-entry role prefix, with a
-// floor of one token per row so tiny-but-real entries can never ride along for
-// free — a markable group therefore always has a positive cost, keeping
-// eligibility and cost in one predicate.
+// markable groups the rendered entry text — what buildUserPrompt actually
+// emits, headers included — plus the per-entry role prefix, with a floor of
+// one token per row so tiny-but-real entries can never ride along for free. A
+// markable group therefore always has a positive cost, keeping eligibility
+// and cost in one predicate. Costing the rendered bytes rather than the raw
+// usage estimate matters: a row whose generation cost five tokens can still
+// render a two-kilobyte tool outcome into the prompt.
 func markableGroupCost(items []CompactionCandidate, group []int) int {
 	cost := 0
 	for _, idx := range group {
 		if items[idx].HasPolicy(CompactPolicyMustKeep) {
 			return 0
 		}
-		if strings.TrimSpace(renderCandidateEntry(items[idx].Record)) == "" {
+		rendered := strings.TrimSpace(renderCandidateEntry(items[idx].Record))
+		if rendered == "" {
 			return 0
 		}
-		rowCost := estimateCompactPromptTokens(items[idx]) + estimateBytesAsTokens(items[idx].Record.ModelMessage.Role) + 1
-		cost += rowCost
+		cost += estimateBytesAsTokens(rendered) + estimateBytesAsTokens(items[idx].Record.ModelMessage.Role) + 1
 	}
 	return cost
 }

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -79,7 +79,6 @@ func markSelectionPolicies(items []CompactionCandidate) {
 				continue
 			}
 			if items[i].HasPolicy(CompactPolicyMustKeep) {
-				items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
 				continue
 			}
 			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
@@ -89,12 +88,10 @@ func markSelectionPolicies(items []CompactionCandidate) {
 
 	start := recentProtectedStart(items)
 	for i := range items {
-		if items[i].HasPolicy(CompactPolicyMustKeep) {
-			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
-			continue
-		}
 		if i < start {
-			items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
+			if !items[i].HasPolicy(CompactPolicyMustKeep) {
+				items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyCanDrop)
+			}
 			continue
 		}
 		items[i].Policies = appendPolicy(items[i].Policies, CompactPolicyPreserveRecent)
@@ -184,7 +181,6 @@ func candidatePolicies(record historyfrag.HistoryRecord) []CompactPolicy {
 	}
 	if isAskUserRecord(record) {
 		policies = appendPolicy(policies, CompactPolicyMustKeep)
-		policies = appendPolicy(policies, CompactPolicyPreserveRecent)
 		policies = appendPolicy(policies, CompactPolicyPreserveToolClosure)
 	}
 	return policies
@@ -345,7 +341,7 @@ func guardedCompactionItems(items []CompactionCandidate, cutoff int) []Compactio
 	if cutoff <= 0 {
 		return nil
 	}
-	return items[:cutoff]
+	return dropMustKeepItems(items[:cutoff])
 }
 
 func guardedCurrentTurnCompactionItems(items []CompactionCandidate, cutoff int) []CompactionCandidate {
@@ -366,7 +362,23 @@ func guardedCurrentTurnCompactionItems(items []CompactionCandidate, cutoff int) 
 	if cutoff > protectedTailStart {
 		return nil
 	}
-	return items[1:cutoff]
+	return dropMustKeepItems(items[1:cutoff])
+}
+
+// dropMustKeepItems removes must-keep rows from a compact span so they stay in
+// raw history without capping how much of the surrounding span can compact.
+func dropMustKeepItems(items []CompactionCandidate) []CompactionCandidate {
+	kept := make([]CompactionCandidate, 0, len(items))
+	for _, item := range items {
+		if item.HasPolicy(CompactPolicyMustKeep) {
+			continue
+		}
+		kept = append(kept, item)
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	return kept
 }
 
 func firstPolicyStart(items []CompactionCandidate, policy CompactPolicy) int {

--- a/internal/compaction/selection.go
+++ b/internal/compaction/selection.go
@@ -478,16 +478,23 @@ func trimCompactMessages(items []CompactionCandidate, maxTokens int) []Compactio
 	}
 	accumulated := 0
 	end := 0
+	keptRealGroup := false
 	for _, group := range toolExchangeGroups(items) {
 		cost := 0
 		for _, idx := range group {
 			cost += budgetCost(idx)
 		}
-		if end > 0 && accumulated+cost > maxTokens {
+		// The progress guarantee keys on real (positive-cost) groups: a
+		// zero-cost head must not count as "already kept something" and
+		// starve an oversized first real group behind it.
+		if cost > 0 && keptRealGroup && accumulated+cost > maxTokens {
 			break
 		}
 		accumulated += cost
 		end = group[len(group)-1] + 1
+		if cost > 0 {
+			keptRealGroup = true
+		}
 	}
 	return items[:end]
 }

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -187,22 +187,22 @@ func TestGuardedSelectionCompactsAroundMustKeepAskExchange(t *testing.T) {
 	}
 	items, _ := itemsFromRows(rows)
 
-	toCompact := splitByTarget(items, 200)
-	if len(toCompact) == 0 {
+	_, ids := buildEntriesAndIDs(splitByTarget(items, 200))
+	if len(ids) == 0 {
 		t.Fatal("a must-keep ask exchange at the window head must not starve compaction of newer history")
 	}
-	for _, item := range toCompact {
-		if item.ID == askCall.ID || item.ID == askResult.ID {
-			t.Fatalf("must-keep ask_user row was selected for compaction")
+	for _, id := range ids {
+		if id == askCall.ID || id == askResult.ID {
+			t.Fatalf("must-keep ask_user row was marked for compaction")
 		}
 		for _, protected := range []pgtype.UUID{rows[6].ID, rows[7].ID} {
-			if item.ID == protected {
-				t.Fatalf("current turn row was selected for compaction")
+			if id == protected {
+				t.Fatalf("current turn row was marked for compaction")
 			}
 		}
 	}
 
-	if ratioCompact := splitByRatio(items, 800, 80); len(ratioCompact) == 0 {
+	if _, ratioIDs := buildEntriesAndIDs(splitByRatio(items, 800, 80)); len(ratioIDs) == 0 {
 		t.Fatal("ratio-based selection must also compact around the must-keep island")
 	}
 }
@@ -229,16 +229,16 @@ func TestParallelToolCallsPropagateMustKeepToSiblingResult(t *testing.T) {
 
 	assertPolicy(t, items[2], CompactPolicyMustKeep)
 
-	toCompact := splitByTarget(items, 200)
-	if len(toCompact) == 0 {
+	_, ids := buildEntriesAndIDs(splitByTarget(items, 200))
+	if len(ids) == 0 {
 		t.Fatal("compaction should still proceed around the must-keep exchange")
 	}
-	for _, item := range toCompact {
-		if item.ID == assistantCall.ID {
-			t.Fatalf("must-keep assistant row with parallel tool calls was selected for compaction")
+	for _, id := range ids {
+		if id == assistantCall.ID {
+			t.Fatalf("must-keep assistant row with parallel tool calls was marked for compaction")
 		}
-		if item.ID == calcResult.ID {
-			t.Fatalf("sibling tool-result row of a must-keep exchange was selected for compaction")
+		if id == calcResult.ID {
+			t.Fatalf("sibling tool-result row of a must-keep exchange was marked for compaction")
 		}
 	}
 }
@@ -263,11 +263,7 @@ func TestGuardedSelectionKeepsCompactRunContiguousAcrossMustKeepIsland(t *testin
 	// One pass must select a single contiguous run so the read path can drop it
 	// in place. It may only be the rows before the first must-keep island, never
 	// straddling ask_user into "mid q"/"mid a" under a shared compact_id.
-	toCompact := splitByTarget(items, 200)
-	gotIDs := make([]pgtype.UUID, len(toCompact))
-	for i, item := range toCompact {
-		gotIDs[i] = item.ID
-	}
+	_, gotIDs := buildEntriesAndIDs(splitByTarget(items, 200))
 	wantIDs := []pgtype.UUID{rows[0].ID, rows[1].ID}
 	if len(gotIDs) != len(wantIDs) {
 		t.Fatalf("selected %d rows, want the contiguous pre-island run [old q, old a]", len(gotIDs))
@@ -281,13 +277,13 @@ func TestGuardedSelectionKeepsCompactRunContiguousAcrossMustKeepIsland(t *testin
 	// The run after the island is not starved: once the pre-island run is
 	// compacted away, the next pass makes progress on "mid q"/"mid a".
 	nextItems, _ := itemsFromRows(rows[2:])
-	nextCompact := splitByTarget(nextItems, 200)
-	if len(nextCompact) == 0 {
+	_, nextIDs := buildEntriesAndIDs(splitByTarget(nextItems, 200))
+	if len(nextIDs) == 0 {
 		t.Fatal("run after the must-keep island must be compactable on a later pass")
 	}
-	for _, item := range nextCompact {
-		if item.ID == askCall.ID || item.ID == askResult.ID {
-			t.Fatalf("must-keep ask_user row was selected for compaction")
+	for _, id := range nextIDs {
+		if id == askCall.ID || id == askResult.ID {
+			t.Fatalf("must-keep ask_user row was marked for compaction")
 		}
 	}
 }
@@ -333,9 +329,9 @@ func TestItemsFromRowsPreservesUnparseableRowsAsSelectionBarriers(t *testing.T) 
 		t.Fatalf("an unparseable row must remain as a selection barrier: %#v", items)
 	}
 
-	selected := splitByTarget(items, 100)
-	if len(selected) != 1 || selected[0].ID != before.ID {
-		t.Fatalf("selected = %#v, want only the contiguous run before the barrier", selected)
+	_, ids := buildEntriesAndIDs(splitByTarget(items, 100))
+	if len(ids) != 1 || ids[0] != before.ID {
+		t.Fatalf("marked = %#v, want only the contiguous run before the barrier", ids)
 	}
 }
 

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -24,7 +24,7 @@ func mkRow(t *testing.T, role, content string, outputTokens int) sqlc.ListUncomp
 		Content: json.RawMessage(content),
 	}
 	if outputTokens > 0 {
-		row.Usage = json.RawMessage(`{"output_tokens":` + strconv.Itoa(outputTokens) + `}`)
+		row.Usage = json.RawMessage(`{"outputTokens":` + strconv.Itoa(outputTokens) + `}`)
 	}
 	return row
 }
@@ -46,12 +46,23 @@ func TestEstimateItemTokensPrefersOutputTokensThenContentFallback(t *testing.T) 
 	}
 	items, _ := itemsFromRows(rows)
 	got := itemTokens(items)
-	// First: usage output_tokens. Second: len(content)/4 = 402/4 = 100.
+	// First: persisted usage outputTokens. Second: len(content)/4 = 402/4 = 100.
 	if got[0] != 50 {
 		t.Fatalf("usage token estimate = %d, want 50", got[0])
 	}
 	if got[1] != len(items[1].RawContent)/4 {
 		t.Fatalf("content token estimate = %d, want %d", got[1], len(items[1].RawContent)/4)
+	}
+}
+
+func TestEstimateItemTokensAcceptsSnakeCaseUsage(t *testing.T) {
+	t.Parallel()
+
+	row := mkRow(t, "assistant", `"hello"`, 0)
+	row.Usage = json.RawMessage(`{"output_tokens":77}`)
+	items, _ := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
+	if got := estimateItemTokens(items[0]); got != 77 {
+		t.Fatalf("snake-case usage token estimate = %d, want 77", got)
 	}
 }
 
@@ -135,6 +146,28 @@ func TestItemsFromRowsAnnotatesCompactionCandidatePolicy(t *testing.T) {
 	assertPolicy(t, items[4], CompactPolicyPreserveToolClosure)
 	assertPolicy(t, items[4], CompactPolicyPreserveRecent)
 	assertNoPolicy(t, items[4], CompactPolicyCanDrop)
+}
+
+func TestItemsFromRowsAllowsCurrentTurnMiddleCompaction(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"current instruction"`, 100),
+		mkRow(t, "assistant", `"loop step 1"`, 100),
+		mkRow(t, "assistant", `"loop step 2"`, 100),
+		mkRow(t, "assistant", `"latest tail"`, 100),
+	}
+	items, skipped := itemsFromRows(rows)
+	if skipped != 0 || len(items) != 4 {
+		t.Fatalf("items=%d skipped=%d, want four classified candidates", len(items), skipped)
+	}
+
+	assertPolicy(t, items[0], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[0], CompactPolicyCanDrop)
+	assertPolicy(t, items[1], CompactPolicyCanDrop)
+	assertPolicy(t, items[2], CompactPolicyCanDrop)
+	assertPolicy(t, items[3], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[3], CompactPolicyCanDrop)
 }
 
 func TestItemsFromRowsSkipsUnparseableRowsWithoutAborting(t *testing.T) {

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -207,6 +207,42 @@ func TestGuardedSelectionCompactsAroundMustKeepAskExchange(t *testing.T) {
 	}
 }
 
+func TestParallelToolCallsPropagateMustKeepToSiblingResult(t *testing.T) {
+	t.Parallel()
+
+	// One assistant message carries two parallel tool calls (ask_user + calc).
+	// The row is must-keep because of ask_user, but the calc result is a
+	// separate row that only carries the tool-closure policy on its own.
+	assistantCall := mkRow(t, "assistant", `[{"type":"tool-call","toolName":"`+userinput.ToolNameAskUser+`","toolCallId":"ask-1","input":{"questions":[]}},`+
+		`{"type":"tool-call","toolName":"calc","toolCallId":"calc-1","input":{}}]`, 100)
+	calcResult := mkRow(t, "tool", `[{"type":"tool-result","toolName":"calc","toolCallId":"calc-1","output":{"type":"text","value":"42"}}]`, 100)
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"question 1"`, 100),
+		assistantCall,
+		calcResult,
+		mkRow(t, "user", `"question 2"`, 100),
+		mkRow(t, "assistant", `"answer 2"`, 100),
+		mkRow(t, "user", `"current question"`, 100),
+		mkRow(t, "assistant", `"current answer"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+
+	assertPolicy(t, items[2], CompactPolicyMustKeep)
+
+	toCompact := splitByTarget(items, 200)
+	if len(toCompact) == 0 {
+		t.Fatal("compaction should still proceed around the must-keep exchange")
+	}
+	for _, item := range toCompact {
+		if item.ID == assistantCall.ID {
+			t.Fatalf("must-keep assistant row with parallel tool calls was selected for compaction")
+		}
+		if item.ID == calcResult.ID {
+			t.Fatalf("sibling tool-result row of a must-keep exchange was selected for compaction")
+		}
+	}
+}
+
 func TestItemsFromRowsAllowsCurrentTurnMiddleCompaction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -135,18 +135,15 @@ func TestItemsFromRowsAnnotatesCompactionCandidatePolicy(t *testing.T) {
 		t.Fatalf("items=%d barriers=%d, want five classified candidates", len(items), barrierCount)
 	}
 
-	assertPolicy(t, items[0], CompactPolicyCanDrop)
-	assertPolicy(t, items[1], CompactPolicyCanDrop)
 	assertNoPolicy(t, items[0], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[0], CompactPolicyMustKeep)
 	assertNoPolicy(t, items[1], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[1], CompactPolicyMustKeep)
 	assertPolicy(t, items[2], CompactPolicyPreserveRecent)
-	assertNoPolicy(t, items[2], CompactPolicyCanDrop)
 	assertPolicy(t, items[3], CompactPolicyPreserveToolClosure)
 	assertPolicy(t, items[3], CompactPolicyPreserveRecent)
-	assertNoPolicy(t, items[3], CompactPolicyCanDrop)
 	assertPolicy(t, items[4], CompactPolicyPreserveToolClosure)
 	assertPolicy(t, items[4], CompactPolicyPreserveRecent)
-	assertNoPolicy(t, items[4], CompactPolicyCanDrop)
 }
 
 func TestItemsFromRowsKeepsAskUserToolExchange(t *testing.T) {
@@ -166,7 +163,6 @@ func TestItemsFromRowsKeepsAskUserToolExchange(t *testing.T) {
 	for _, idx := range []int{1, 2} {
 		assertPolicy(t, items[idx], CompactPolicy("must_keep"))
 		assertPolicy(t, items[idx], CompactPolicyPreserveToolClosure)
-		assertNoPolicy(t, items[idx], CompactPolicyCanDrop)
 	}
 }
 
@@ -303,11 +299,11 @@ func TestItemsFromRowsAllowsCurrentTurnMiddleCompaction(t *testing.T) {
 	}
 
 	assertPolicy(t, items[0], CompactPolicyPreserveRecent)
-	assertNoPolicy(t, items[0], CompactPolicyCanDrop)
-	assertPolicy(t, items[1], CompactPolicyCanDrop)
-	assertPolicy(t, items[2], CompactPolicyCanDrop)
+	assertNoPolicy(t, items[1], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[1], CompactPolicyMustKeep)
+	assertNoPolicy(t, items[2], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[2], CompactPolicyMustKeep)
 	assertPolicy(t, items[3], CompactPolicyPreserveRecent)
-	assertNoPolicy(t, items[3], CompactPolicyCanDrop)
 }
 
 func TestItemsFromRowsPreservesUnparseableRowsAsSelectionBarriers(t *testing.T) {

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -314,21 +314,28 @@ func TestItemsFromRowsAllowsCurrentTurnMiddleCompaction(t *testing.T) {
 	assertNoPolicy(t, items[3], CompactPolicyCanDrop)
 }
 
-func TestItemsFromRowsSkipsUnparseableRowsWithoutAborting(t *testing.T) {
+func TestItemsFromRowsPreservesUnparseableRowsAsSelectionBarriers(t *testing.T) {
 	t.Parallel()
 
-	good := mkRow(t, "user", `"ok"`, 0)
+	before := mkRow(t, "user", `"before"`, 100)
 	bad := sqlc.ListUncompactedMessagesBySessionRow{
 		ID:      pgtype.UUID{Valid: false}, // empty id -> FromDBMessage rejects it
 		Role:    "user",
 		Content: json.RawMessage(`"x"`),
 	}
-	items, skipped := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{good, bad})
+	after := mkRow(t, "assistant", `"after"`, 100)
+	current := mkRow(t, "user", `"current"`, 100)
+	items, skipped := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{before, bad, after, current})
 	if skipped != 1 {
 		t.Fatalf("skipped = %d, want 1", skipped)
 	}
-	if len(items) != 1 || items[0].ID != good.ID {
-		t.Fatalf("a bad row must be skipped, not abort the batch: got %d items", len(items))
+	if len(items) != 4 || !items[1].HasPolicy(CompactPolicyMustKeep) {
+		t.Fatalf("an unparseable row must remain as a selection barrier: %#v", items)
+	}
+
+	selected := splitByTarget(items, 100)
+	if len(selected) != 1 || selected[0].ID != before.ID {
+		t.Fatalf("selected = %#v, want only the contiguous run before the barrier", selected)
 	}
 }
 

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -29,7 +29,7 @@ func mkRow(t *testing.T, role, content string, outputTokens int) sqlc.ListUncomp
 	return row
 }
 
-func itemTokens(items []compactionItem) []int {
+func itemTokens(items []CompactionCandidate) []int {
 	out := make([]int, len(items))
 	for i, it := range items {
 		out[i] = estimateItemTokens(it)
@@ -50,8 +50,8 @@ func TestEstimateItemTokensPrefersOutputTokensThenContentFallback(t *testing.T) 
 	if got[0] != 50 {
 		t.Fatalf("usage token estimate = %d, want 50", got[0])
 	}
-	if got[1] != len(items[1].content)/4 {
-		t.Fatalf("content token estimate = %d, want %d", got[1], len(items[1].content)/4)
+	if got[1] != len(items[1].RawContent)/4 {
+		t.Fatalf("content token estimate = %d, want %d", got[1], len(items[1].RawContent)/4)
 	}
 }
 
@@ -64,18 +64,77 @@ func TestItemsFromRowsPreservesIDContentAndClassifiesRecord(t *testing.T) {
 		t.Fatalf("items len = %d, want 1", len(items))
 	}
 	it := items[0]
-	if it.id != row.ID {
+	if it.ID != row.ID {
 		t.Fatalf("item id mismatch")
 	}
-	if string(it.content) != string(row.Content) {
-		t.Fatalf("item content = %q, want %q", it.content, row.Content)
+	if string(it.RawContent) != string(row.Content) {
+		t.Fatalf("item content = %q, want %q", it.RawContent, row.Content)
 	}
-	if it.record.ModelMessage.Role != "user" {
-		t.Fatalf("record role = %q, want user", it.record.ModelMessage.Role)
+	if it.Record.ModelMessage.Role != "user" {
+		t.Fatalf("record role = %q, want user", it.Record.ModelMessage.Role)
 	}
-	if it.record.ModelMessage.TextContent() != "hi there" {
-		t.Fatalf("record text = %q, want 'hi there'", it.record.ModelMessage.TextContent())
+	if it.Record.ModelMessage.TextContent() != "hi there" {
+		t.Fatalf("record text = %q, want 'hi there'", it.Record.ModelMessage.TextContent())
 	}
+}
+
+func TestItemsFromRowsPreservesDirectedSignalMetadata(t *testing.T) {
+	t.Parallel()
+
+	row := mkRow(t, "user", `"please check the reply"`, 0)
+	row.SenderUserID = testUUID(t)
+	row.ExternalMessageID = pgtype.Text{String: "msg-123", Valid: true}
+	row.SourceReplyToMessageID = pgtype.Text{String: "msg-parent", Valid: true}
+	row.EventID = testUUID(t)
+	row.SenderDisplayName = pgtype.Text{String: "Alice", Valid: true}
+	row.Platform = pgtype.Text{String: "telegram", Valid: true}
+	row.ConversationType = pgtype.Text{String: "group", Valid: true}
+	row.ConversationName = "Ops Room"
+	row.ReplyTarget = pgtype.Text{String: "thread-9", Valid: true}
+
+	items, skipped := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
+	if skipped != 0 || len(items) != 1 {
+		t.Fatalf("items=%d skipped=%d, want one classified row", len(items), skipped)
+	}
+	record := items[0].Record
+	if record.ExternalMessageID != "msg-123" ||
+		record.SourceReplyToMessageID != "msg-parent" ||
+		record.SenderDisplayName != "Alice" ||
+		record.Platform != "telegram" ||
+		record.Scope.ConversationType != "group" ||
+		record.Scope.ConversationName != "Ops Room" ||
+		record.Scope.ReplyTarget != "thread-9" {
+		t.Fatalf("directed signal was not preserved: %#v scope=%#v", record, record.Scope)
+	}
+}
+
+func TestItemsFromRowsAnnotatesCompactionCandidatePolicy(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"old question"`, 100),
+		mkRow(t, "assistant", `"old answer"`, 100),
+		mkRow(t, "user", `"current question"`, 100),
+		toolCallRow(t, 100),
+		toolResultRow(t, 100),
+	}
+	items, skipped := itemsFromRows(rows)
+	if skipped != 0 || len(items) != 5 {
+		t.Fatalf("items=%d skipped=%d, want five classified candidates", len(items), skipped)
+	}
+
+	assertPolicy(t, items[0], CompactPolicyCanDrop)
+	assertPolicy(t, items[1], CompactPolicyCanDrop)
+	assertNoPolicy(t, items[0], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[1], CompactPolicyPreserveRecent)
+	assertPolicy(t, items[2], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[2], CompactPolicyCanDrop)
+	assertPolicy(t, items[3], CompactPolicyPreserveToolClosure)
+	assertPolicy(t, items[3], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[3], CompactPolicyCanDrop)
+	assertPolicy(t, items[4], CompactPolicyPreserveToolClosure)
+	assertPolicy(t, items[4], CompactPolicyPreserveRecent)
+	assertNoPolicy(t, items[4], CompactPolicyCanDrop)
 }
 
 func TestItemsFromRowsSkipsUnparseableRowsWithoutAborting(t *testing.T) {
@@ -91,8 +150,22 @@ func TestItemsFromRowsSkipsUnparseableRowsWithoutAborting(t *testing.T) {
 	if skipped != 1 {
 		t.Fatalf("skipped = %d, want 1", skipped)
 	}
-	if len(items) != 1 || items[0].id != good.ID {
+	if len(items) != 1 || items[0].ID != good.ID {
 		t.Fatalf("a bad row must be skipped, not abort the batch: got %d items", len(items))
+	}
+}
+
+func assertPolicy(t *testing.T, item CompactionCandidate, policy CompactPolicy) {
+	t.Helper()
+	if !item.HasPolicy(policy) {
+		t.Fatalf("candidate %s missing policy %s; got %#v", formatUUID(item.ID), policy, item.Policies)
+	}
+}
+
+func assertNoPolicy(t *testing.T, item CompactionCandidate, policy CompactPolicy) {
+	t.Helper()
+	if item.HasPolicy(policy) {
+		t.Fatalf("candidate %s unexpectedly has policy %s; got %#v", formatUUID(item.ID), policy, item.Policies)
 	}
 }
 
@@ -111,7 +184,7 @@ func TestSplitByTargetCompactsOldestBeyondTarget(t *testing.T) {
 	if len(toCompact) != 2 {
 		t.Fatalf("compact count = %d, want 2", len(toCompact))
 	}
-	if toCompact[0].id != rows[0].ID || toCompact[1].id != rows[1].ID {
+	if toCompact[0].ID != rows[0].ID || toCompact[1].ID != rows[1].ID {
 		t.Fatalf("compacted the wrong (non-oldest) messages")
 	}
 }
@@ -130,7 +203,7 @@ func TestSplitByRatioKeepsNewestByRatio(t *testing.T) {
 	if len(toCompact) != 2 {
 		t.Fatalf("compact count = %d, want 2", len(toCompact))
 	}
-	if toCompact[0].id != rows[0].ID || toCompact[1].id != rows[1].ID {
+	if toCompact[0].ID != rows[0].ID || toCompact[1].ID != rows[1].ID {
 		t.Fatalf("compacted the wrong messages")
 	}
 }
@@ -147,8 +220,8 @@ func TestSplitByRatioBoundaryConditions(t *testing.T) {
 	if got := splitByRatio(items, 100, 0); got != nil {
 		t.Fatalf("zero ratio should yield nil, got %d", len(got))
 	}
-	if got := splitByRatio(items, 100, 100); len(got) != 1 {
-		t.Fatalf("ratio 100 should compact all, got %d", len(got))
+	if got := splitByRatio(items, 100, 100); len(got) != 0 {
+		t.Fatalf("ratio 100 should preserve the only recent candidate, got %d", len(got))
 	}
 }
 
@@ -167,8 +240,33 @@ func TestTrimCompactMessagesDropsOldestBeyondBudget(t *testing.T) {
 	if len(trimmed) != 1 {
 		t.Fatalf("trimmed count = %d, want 1", len(trimmed))
 	}
-	if trimmed[0].id != rows[2].ID {
+	if trimmed[0].ID != rows[2].ID {
 		t.Fatalf("trim should keep the newest message and drop older ones")
+	}
+}
+
+func TestTrimCompactMessagesAccountsForDirectedSignalHeaders(t *testing.T) {
+	t.Parallel()
+
+	longID := repeat("m", entryMetadataMaxBytes)
+	longSender := repeat("s", entryMetadataMaxBytes)
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "assistant", `"one"`, 1),
+		mkRow(t, "assistant", `"two"`, 1),
+		mkRow(t, "assistant", `"three"`, 1),
+	}
+	for i := range rows {
+		rows[i].ExternalMessageID = pgtype.Text{String: longID, Valid: true}
+		rows[i].SenderDisplayName = pgtype.Text{String: longSender, Valid: true}
+	}
+	items, _ := itemsFromRows(rows)
+
+	trimmed := trimCompactMessages(items, 300)
+	if len(trimmed) != 2 {
+		t.Fatalf("trimmed count = %d, want 2 after accounting for header tokens", len(trimmed))
+	}
+	if trimmed[0].ID != rows[1].ID || trimmed[1].ID != rows[2].ID {
+		t.Fatalf("trim should drop the oldest message when headers exceed budget")
 	}
 }
 

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -52,10 +52,7 @@ func TestEstimateItemTokensPrefersOutputTokensThenContentFallback(t *testing.T) 
 		mkRow(t, "user", `"hello"`, 50),
 		mkRow(t, "assistant", `"`+repeat("a", 400)+`"`, 0),
 	}
-	items, err := itemsFromRows(rows)
-	if err != nil {
-		t.Fatalf("itemsFromRows: %v", err)
-	}
+	items, _ := itemsFromRows(rows)
 	got := itemTokens(items)
 	// First: usage output_tokens. Second: len(content)/4 = 402/4 = 100.
 	if got[0] != 50 {
@@ -70,10 +67,7 @@ func TestItemsFromRowsPreservesIDContentAndClassifiesRecord(t *testing.T) {
 	t.Parallel()
 
 	row := mkRow(t, "user", `"hi there"`, 0)
-	items, err := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
-	if err != nil {
-		t.Fatalf("itemsFromRows: %v", err)
-	}
+	items, _ := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
 	if len(items) != 1 {
 		t.Fatalf("items len = %d, want 1", len(items))
 	}
@@ -92,6 +86,24 @@ func TestItemsFromRowsPreservesIDContentAndClassifiesRecord(t *testing.T) {
 	}
 }
 
+func TestItemsFromRowsSkipsUnparseableRowsWithoutAborting(t *testing.T) {
+	t.Parallel()
+
+	good := mkRow(t, "user", `"ok"`, 0)
+	bad := sqlc.ListUncompactedMessagesBySessionRow{
+		ID:      pgtype.UUID{Valid: false}, // empty id -> FromDBMessage rejects it
+		Role:    "user",
+		Content: json.RawMessage(`"x"`),
+	}
+	items, skipped := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{good, bad})
+	if skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", skipped)
+	}
+	if len(items) != 1 || items[0].id != good.ID {
+		t.Fatalf("a bad row must be skipped, not abort the batch: got %d items", len(items))
+	}
+}
+
 func TestSplitByTargetCompactsOldestBeyondTarget(t *testing.T) {
 	t.Parallel()
 
@@ -102,10 +114,7 @@ func TestSplitByTargetCompactsOldestBeyondTarget(t *testing.T) {
 		mkRow(t, "assistant", `"b"`, 100),
 		mkRow(t, "user", `"c"`, 100),
 	}
-	items, err := itemsFromRows(rows)
-	if err != nil {
-		t.Fatalf("itemsFromRows: %v", err)
-	}
+	items, _ := itemsFromRows(rows)
 	toCompact := splitByTarget(items, 150)
 	if len(toCompact) != 2 {
 		t.Fatalf("compact count = %d, want 2", len(toCompact))
@@ -124,10 +133,7 @@ func TestSplitByRatioKeepsNewestByRatio(t *testing.T) {
 		mkRow(t, "assistant", `"b"`, 100),
 		mkRow(t, "user", `"c"`, 100),
 	}
-	items, err := itemsFromRows(rows)
-	if err != nil {
-		t.Fatalf("itemsFromRows: %v", err)
-	}
+	items, _ := itemsFromRows(rows)
 	toCompact := splitByRatio(items, 300, 50)
 	if len(toCompact) != 2 {
 		t.Fatalf("compact count = %d, want 2", len(toCompact))

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -405,15 +405,16 @@ func TestTrimCompactMessagesDefersNewestBeyondBudget(t *testing.T) {
 	t.Parallel()
 
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
-		mkRow(t, "user", `"a"`, 100),
-		mkRow(t, "assistant", `"b"`, 100),
-		mkRow(t, "user", `"c"`, 100),
+		textRow(t, "user", 100),
+		textRow(t, "assistant", 100),
+		textRow(t, "user", 100),
 	}
 	items, _ := itemsFromRows(rows)
 	trimmed := trimCompactMessages(items, 150)
-	// Budget 150, accumulate from oldest: 100 (a) fits, +100 (b) = 200 > 150 ->
-	// keep the oldest row and defer the newer overflow to a later pass, so
-	// passes chew history front-to-back in chronological order.
+	// Budget 150, accumulate rendered costs from oldest: ~102 (a) fits,
+	// +~102 (b) > 150 -> keep the oldest row and defer the newer overflow to
+	// a later pass, so passes chew history front-to-back in chronological
+	// order.
 	if len(trimmed) != 1 {
 		t.Fatalf("trimmed count = %d, want 1", len(trimmed))
 	}
@@ -428,9 +429,9 @@ func TestTrimCompactMessagesAccountsForDirectedSignalHeaders(t *testing.T) {
 	longID := repeat("m", entryMetadataMaxBytes)
 	longSender := repeat("s", entryMetadataMaxBytes)
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
-		mkRow(t, "assistant", `"one"`, 1),
-		mkRow(t, "assistant", `"two"`, 1),
-		mkRow(t, "assistant", `"three"`, 1),
+		textRow(t, "assistant", 1),
+		textRow(t, "assistant", 1),
+		textRow(t, "assistant", 1),
 	}
 	for i := range rows {
 		rows[i].ExternalMessageID = pgtype.Text{String: longID, Valid: true}

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -165,9 +165,45 @@ func TestItemsFromRowsKeepsAskUserToolExchange(t *testing.T) {
 
 	for _, idx := range []int{1, 2} {
 		assertPolicy(t, items[idx], CompactPolicy("must_keep"))
-		assertPolicy(t, items[idx], CompactPolicyPreserveRecent)
 		assertPolicy(t, items[idx], CompactPolicyPreserveToolClosure)
 		assertNoPolicy(t, items[idx], CompactPolicyCanDrop)
+	}
+}
+
+func TestGuardedSelectionCompactsAroundMustKeepAskExchange(t *testing.T) {
+	t.Parallel()
+
+	askCall := mkRow(t, "assistant", `[{"type":"tool-call","toolName":"`+userinput.ToolNameAskUser+`","toolCallId":"ask-1","input":{"questions":[]}}]`, 100)
+	askResult := mkRow(t, "tool", `[{"type":"tool-result","toolName":"`+userinput.ToolNameAskUser+`","toolCallId":"ask-1","result":{"status":"submitted"}}]`, 100)
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		askCall,
+		askResult,
+		mkRow(t, "user", `"question 2"`, 100),
+		mkRow(t, "assistant", `"answer 2"`, 100),
+		mkRow(t, "user", `"question 3"`, 100),
+		mkRow(t, "assistant", `"answer 3"`, 100),
+		mkRow(t, "user", `"current question"`, 100),
+		mkRow(t, "assistant", `"current answer"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+
+	toCompact := splitByTarget(items, 200)
+	if len(toCompact) == 0 {
+		t.Fatal("a must-keep ask exchange at the window head must not starve compaction of newer history")
+	}
+	for _, item := range toCompact {
+		if item.ID == askCall.ID || item.ID == askResult.ID {
+			t.Fatalf("must-keep ask_user row was selected for compaction")
+		}
+		for _, protected := range []pgtype.UUID{rows[6].ID, rows[7].ID} {
+			if item.ID == protected {
+				t.Fatalf("current turn row was selected for compaction")
+			}
+		}
+	}
+
+	if ratioCompact := splitByRatio(items, 800, 80); len(ratioCompact) == 0 {
+		t.Fatal("ratio-based selection must also compact around the must-keep island")
 	}
 }
 

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -405,7 +405,7 @@ func TestSplitByRatioBoundaryConditions(t *testing.T) {
 	}
 }
 
-func TestTrimCompactMessagesDropsOldestBeyondBudget(t *testing.T) {
+func TestTrimCompactMessagesDefersNewestBeyondBudget(t *testing.T) {
 	t.Parallel()
 
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
@@ -415,13 +415,14 @@ func TestTrimCompactMessagesDropsOldestBeyondBudget(t *testing.T) {
 	}
 	items, _ := itemsFromRows(rows)
 	trimmed := trimCompactMessages(items, 150)
-	// Budget 150, accumulate from newest: 100 (c) fits, +100 (b) = 200 > 150 -> drop
-	// the oldest two (a, b) from the tail, keep only the newest (c).
+	// Budget 150, accumulate from oldest: 100 (a) fits, +100 (b) = 200 > 150 ->
+	// keep the oldest row and defer the newer overflow to a later pass, so
+	// passes chew history front-to-back in chronological order.
 	if len(trimmed) != 1 {
 		t.Fatalf("trimmed count = %d, want 1", len(trimmed))
 	}
-	if trimmed[0].ID != rows[2].ID {
-		t.Fatalf("trim should keep the newest message and drop older ones")
+	if trimmed[0].ID != rows[0].ID {
+		t.Fatalf("trim should keep the oldest message and defer newer ones")
 	}
 }
 
@@ -445,8 +446,8 @@ func TestTrimCompactMessagesAccountsForDirectedSignalHeaders(t *testing.T) {
 	if len(trimmed) != 2 {
 		t.Fatalf("trimmed count = %d, want 2 after accounting for header tokens", len(trimmed))
 	}
-	if trimmed[0].ID != rows[1].ID || trimmed[1].ID != rows[2].ID {
-		t.Fatalf("trim should drop the oldest message when headers exceed budget")
+	if trimmed[0].ID != rows[0].ID || trimmed[1].ID != rows[1].ID {
+		t.Fatalf("trim should defer the newest message when headers exceed budget")
 	}
 }
 

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/userinput"
 )
 
 func testUUID(t *testing.T) pgtype.UUID {
@@ -146,6 +147,28 @@ func TestItemsFromRowsAnnotatesCompactionCandidatePolicy(t *testing.T) {
 	assertPolicy(t, items[4], CompactPolicyPreserveToolClosure)
 	assertPolicy(t, items[4], CompactPolicyPreserveRecent)
 	assertNoPolicy(t, items[4], CompactPolicyCanDrop)
+}
+
+func TestItemsFromRowsKeepsAskUserToolExchange(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"current instruction"`, 100),
+		mkRow(t, "assistant", `[{"type":"tool-call","toolName":"`+userinput.ToolNameAskUser+`","toolCallId":"ask-1","input":{"questions":[]}}]`, 100),
+		mkRow(t, "tool", `[{"type":"tool-result","toolName":"`+userinput.ToolNameAskUser+`","toolCallId":"ask-1","result":{"status":"submitted"}}]`, 100),
+		mkRow(t, "assistant", `"latest tail"`, 100),
+	}
+	items, skipped := itemsFromRows(rows)
+	if skipped != 0 || len(items) != 4 {
+		t.Fatalf("items=%d skipped=%d, want four classified candidates", len(items), skipped)
+	}
+
+	for _, idx := range []int{1, 2} {
+		assertPolicy(t, items[idx], CompactPolicy("must_keep"))
+		assertPolicy(t, items[idx], CompactPolicyPreserveRecent)
+		assertPolicy(t, items[idx], CompactPolicyPreserveToolClosure)
+		assertNoPolicy(t, items[idx], CompactPolicyCanDrop)
+	}
 }
 
 func TestItemsFromRowsAllowsCurrentTurnMiddleCompaction(t *testing.T) {

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -243,6 +243,55 @@ func TestParallelToolCallsPropagateMustKeepToSiblingResult(t *testing.T) {
 	}
 }
 
+func TestGuardedSelectionKeepsCompactRunContiguousAcrossMustKeepIsland(t *testing.T) {
+	t.Parallel()
+
+	askCall := mkRow(t, "assistant", `[{"type":"tool-call","toolName":"`+userinput.ToolNameAskUser+`","toolCallId":"ask-1","input":{"questions":[]}}]`, 100)
+	askResult := mkRow(t, "tool", `[{"type":"tool-result","toolName":"`+userinput.ToolNameAskUser+`","toolCallId":"ask-1","result":{"status":"submitted"}}]`, 100)
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"old q"`, 100),          // 0 run before island
+		mkRow(t, "assistant", `"old a"`, 100),     // 1
+		askCall,                                   // 2 must-keep island
+		askResult,                                 // 3
+		mkRow(t, "user", `"mid q"`, 100),          // 4 run after island
+		mkRow(t, "assistant", `"mid a"`, 100),     // 5
+		mkRow(t, "user", `"current q"`, 100),      // 6 protected recent
+		mkRow(t, "assistant", `"current a"`, 100), // 7
+	}
+	items, _ := itemsFromRows(rows)
+
+	// One pass must select a single contiguous run so the read path can drop it
+	// in place. It may only be the rows before the first must-keep island, never
+	// straddling ask_user into "mid q"/"mid a" under a shared compact_id.
+	toCompact := splitByTarget(items, 200)
+	gotIDs := make([]pgtype.UUID, len(toCompact))
+	for i, item := range toCompact {
+		gotIDs[i] = item.ID
+	}
+	wantIDs := []pgtype.UUID{rows[0].ID, rows[1].ID}
+	if len(gotIDs) != len(wantIDs) {
+		t.Fatalf("selected %d rows, want the contiguous pre-island run [old q, old a]", len(gotIDs))
+	}
+	for i := range wantIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Fatalf("selected run must be the contiguous pre-island run, got id[%d]=%s", i, formatUUID(gotIDs[i]))
+		}
+	}
+
+	// The run after the island is not starved: once the pre-island run is
+	// compacted away, the next pass makes progress on "mid q"/"mid a".
+	nextItems, _ := itemsFromRows(rows[2:])
+	nextCompact := splitByTarget(nextItems, 200)
+	if len(nextCompact) == 0 {
+		t.Fatal("run after the must-keep island must be compactable on a later pass")
+	}
+	for _, item := range nextCompact {
+		if item.ID == askCall.ID || item.ID == askResult.ID {
+			t.Fatalf("must-keep ask_user row was selected for compaction")
+		}
+	}
+}
+
 func TestItemsFromRowsAllowsCurrentTurnMiddleCompaction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -104,9 +104,9 @@ func TestItemsFromRowsPreservesDirectedSignalMetadata(t *testing.T) {
 	row.ConversationName = "Ops Room"
 	row.ReplyTarget = pgtype.Text{String: "thread-9", Valid: true}
 
-	items, skipped := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
-	if skipped != 0 || len(items) != 1 {
-		t.Fatalf("items=%d skipped=%d, want one classified row", len(items), skipped)
+	items, barrierCount := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
+	if barrierCount != 0 || len(items) != 1 {
+		t.Fatalf("items=%d barriers=%d, want one classified row", len(items), barrierCount)
 	}
 	record := items[0].Record
 	if record.ExternalMessageID != "msg-123" ||
@@ -130,9 +130,9 @@ func TestItemsFromRowsAnnotatesCompactionCandidatePolicy(t *testing.T) {
 		toolCallRow(t, 100),
 		toolResultRow(t, 100),
 	}
-	items, skipped := itemsFromRows(rows)
-	if skipped != 0 || len(items) != 5 {
-		t.Fatalf("items=%d skipped=%d, want five classified candidates", len(items), skipped)
+	items, barrierCount := itemsFromRows(rows)
+	if barrierCount != 0 || len(items) != 5 {
+		t.Fatalf("items=%d barriers=%d, want five classified candidates", len(items), barrierCount)
 	}
 
 	assertPolicy(t, items[0], CompactPolicyCanDrop)
@@ -158,9 +158,9 @@ func TestItemsFromRowsKeepsAskUserToolExchange(t *testing.T) {
 		mkRow(t, "tool", `[{"type":"tool-result","toolName":"`+userinput.ToolNameAskUser+`","toolCallId":"ask-1","result":{"status":"submitted"}}]`, 100),
 		mkRow(t, "assistant", `"latest tail"`, 100),
 	}
-	items, skipped := itemsFromRows(rows)
-	if skipped != 0 || len(items) != 4 {
-		t.Fatalf("items=%d skipped=%d, want four classified candidates", len(items), skipped)
+	items, barrierCount := itemsFromRows(rows)
+	if barrierCount != 0 || len(items) != 4 {
+		t.Fatalf("items=%d barriers=%d, want four classified candidates", len(items), barrierCount)
 	}
 
 	for _, idx := range []int{1, 2} {
@@ -301,9 +301,9 @@ func TestItemsFromRowsAllowsCurrentTurnMiddleCompaction(t *testing.T) {
 		mkRow(t, "assistant", `"loop step 2"`, 100),
 		mkRow(t, "assistant", `"latest tail"`, 100),
 	}
-	items, skipped := itemsFromRows(rows)
-	if skipped != 0 || len(items) != 4 {
-		t.Fatalf("items=%d skipped=%d, want four classified candidates", len(items), skipped)
+	items, barrierCount := itemsFromRows(rows)
+	if barrierCount != 0 || len(items) != 4 {
+		t.Fatalf("items=%d barriers=%d, want four classified candidates", len(items), barrierCount)
 	}
 
 	assertPolicy(t, items[0], CompactPolicyPreserveRecent)
@@ -325,9 +325,9 @@ func TestItemsFromRowsPreservesUnparseableRowsAsSelectionBarriers(t *testing.T) 
 	}
 	after := mkRow(t, "assistant", `"after"`, 100)
 	current := mkRow(t, "user", `"current"`, 100)
-	items, skipped := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{before, bad, after, current})
-	if skipped != 1 {
-		t.Fatalf("skipped = %d, want 1", skipped)
+	items, barrierCount := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{before, bad, after, current})
+	if barrierCount != 1 {
+		t.Fatalf("barrier count = %d, want 1", barrierCount)
 	}
 	if len(items) != 4 || !items[1].HasPolicy(CompactPolicyMustKeep) {
 		t.Fatalf("an unparseable row must remain as a selection barrier: %#v", items)

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -1,0 +1,183 @@
+package compaction
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+func testUUID(t *testing.T) pgtype.UUID {
+	t.Helper()
+	return pgtype.UUID{Bytes: uuid.New(), Valid: true}
+}
+
+func mkRow(t *testing.T, role, content string, outputTokens int) sqlc.ListUncompactedMessagesBySessionRow {
+	t.Helper()
+	row := sqlc.ListUncompactedMessagesBySessionRow{
+		ID:      testUUID(t),
+		Role:    role,
+		Content: json.RawMessage(content),
+	}
+	if outputTokens > 0 {
+		row.Usage = json.RawMessage(`{"output_tokens":` + itoa(outputTokens) + `}`)
+	}
+	return row
+}
+
+func itoa(v int) string {
+	return string([]byte(jsonNumber(v)))
+}
+
+func jsonNumber(v int) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+func itemTokens(items []compactionItem) []int {
+	out := make([]int, len(items))
+	for i, it := range items {
+		out[i] = estimateItemTokens(it)
+	}
+	return out
+}
+
+func TestEstimateItemTokensPrefersOutputTokensThenContentFallback(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"hello"`, 50),
+		mkRow(t, "assistant", `"`+repeat("a", 400)+`"`, 0),
+	}
+	items, err := itemsFromRows(rows)
+	if err != nil {
+		t.Fatalf("itemsFromRows: %v", err)
+	}
+	got := itemTokens(items)
+	// First: usage output_tokens. Second: len(content)/4 = 402/4 = 100.
+	if got[0] != 50 {
+		t.Fatalf("usage token estimate = %d, want 50", got[0])
+	}
+	if got[1] != len(items[1].content)/4 {
+		t.Fatalf("content token estimate = %d, want %d", got[1], len(items[1].content)/4)
+	}
+}
+
+func TestItemsFromRowsPreservesIDContentAndClassifiesRecord(t *testing.T) {
+	t.Parallel()
+
+	row := mkRow(t, "user", `"hi there"`, 0)
+	items, err := itemsFromRows([]sqlc.ListUncompactedMessagesBySessionRow{row})
+	if err != nil {
+		t.Fatalf("itemsFromRows: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items len = %d, want 1", len(items))
+	}
+	it := items[0]
+	if it.id != row.ID {
+		t.Fatalf("item id mismatch")
+	}
+	if string(it.content) != string(row.Content) {
+		t.Fatalf("item content = %q, want %q", it.content, row.Content)
+	}
+	if it.record.ModelMessage.Role != "user" {
+		t.Fatalf("record role = %q, want user", it.record.ModelMessage.Role)
+	}
+	if it.record.ModelMessage.TextContent() != "hi there" {
+		t.Fatalf("record text = %q, want 'hi there'", it.record.ModelMessage.TextContent())
+	}
+}
+
+func TestSplitByTargetCompactsOldestBeyondTarget(t *testing.T) {
+	t.Parallel()
+
+	// Tokens (oldest -> newest): 100, 100, 100. Target 150: newest fits (100),
+	// adding the next exceeds 150, so keep the newest one and compact the oldest two.
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"a"`, 100),
+		mkRow(t, "assistant", `"b"`, 100),
+		mkRow(t, "user", `"c"`, 100),
+	}
+	items, err := itemsFromRows(rows)
+	if err != nil {
+		t.Fatalf("itemsFromRows: %v", err)
+	}
+	toCompact := splitByTarget(items, 150)
+	if len(toCompact) != 2 {
+		t.Fatalf("compact count = %d, want 2", len(toCompact))
+	}
+	if toCompact[0].id != rows[0].ID || toCompact[1].id != rows[1].ID {
+		t.Fatalf("compacted the wrong (non-oldest) messages")
+	}
+}
+
+func TestSplitByRatioKeepsNewestByRatio(t *testing.T) {
+	t.Parallel()
+
+	// total=300, ratio=50 -> keepTokens=150 -> keep newest one, compact oldest two.
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"a"`, 100),
+		mkRow(t, "assistant", `"b"`, 100),
+		mkRow(t, "user", `"c"`, 100),
+	}
+	items, err := itemsFromRows(rows)
+	if err != nil {
+		t.Fatalf("itemsFromRows: %v", err)
+	}
+	toCompact := splitByRatio(items, 300, 50)
+	if len(toCompact) != 2 {
+		t.Fatalf("compact count = %d, want 2", len(toCompact))
+	}
+	if toCompact[0].id != rows[0].ID || toCompact[1].id != rows[1].ID {
+		t.Fatalf("compacted the wrong messages")
+	}
+}
+
+func TestSplitByRatioBoundaryConditions(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{mkRow(t, "user", `"a"`, 100)}
+	items, _ := itemsFromRows(rows)
+
+	if got := splitByRatio(items, 0, 50); got != nil {
+		t.Fatalf("zero total tokens should yield nil, got %d", len(got))
+	}
+	if got := splitByRatio(items, 100, 0); got != nil {
+		t.Fatalf("zero ratio should yield nil, got %d", len(got))
+	}
+	if got := splitByRatio(items, 100, 100); len(got) != 1 {
+		t.Fatalf("ratio 100 should compact all, got %d", len(got))
+	}
+}
+
+func TestTrimCompactMessagesDropsOldestBeyondBudget(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"a"`, 100),
+		mkRow(t, "assistant", `"b"`, 100),
+		mkRow(t, "user", `"c"`, 100),
+	}
+	items, _ := itemsFromRows(rows)
+	trimmed := trimCompactMessages(items, 150)
+	// Budget 150, accumulate from newest: 100 (c) fits, +100 (b) = 200 > 150 -> drop
+	// the oldest two (a, b) from the tail, keep only the newest (c).
+	if len(trimmed) != 1 {
+		t.Fatalf("trimmed count = %d, want 1", len(trimmed))
+	}
+	if trimmed[0].id != rows[2].ID {
+		t.Fatalf("trim should keep the newest message and drop older ones")
+	}
+}
+
+func repeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}

--- a/internal/compaction/selection_test.go
+++ b/internal/compaction/selection_test.go
@@ -2,6 +2,7 @@ package compaction
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -23,18 +24,9 @@ func mkRow(t *testing.T, role, content string, outputTokens int) sqlc.ListUncomp
 		Content: json.RawMessage(content),
 	}
 	if outputTokens > 0 {
-		row.Usage = json.RawMessage(`{"output_tokens":` + itoa(outputTokens) + `}`)
+		row.Usage = json.RawMessage(`{"output_tokens":` + strconv.Itoa(outputTokens) + `}`)
 	}
 	return row
-}
-
-func itoa(v int) string {
-	return string([]byte(jsonNumber(v)))
-}
-
-func jsonNumber(v int) []byte {
-	b, _ := json.Marshal(v)
-	return b
 }
 
 func itemTokens(items []compactionItem) []int {

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -348,7 +348,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 	}
 	var priorSummaries []string
 	for _, l := range priorLogs {
-		if l.Summary != "" {
+		if strings.TrimSpace(l.Summary) != "" {
 			priorSummaries = append(priorSummaries, l.Summary)
 		}
 	}

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -21,14 +22,37 @@ type Service struct {
 	queries     dbstore.Queries
 	hookService *hooks.Service
 	logger      *slog.Logger
+
+	inflightMu sync.Mutex
+	inflight   map[string]struct{}
 }
 
 // NewService creates a new compaction Service.
 func NewService(log *slog.Logger, queries dbstore.Queries) *Service {
 	return &Service{
-		queries: queries,
-		logger:  log,
+		queries:  queries,
+		logger:   log,
+		inflight: make(map[string]struct{}),
 	}
+}
+
+// beginSessionCompaction marks a session as having a compaction in flight.
+// Overlapping runs would select overlapping candidate sets and race
+// MarkMessagesCompacted, so only one compaction may run per session at a time.
+func (s *Service) beginSessionCompaction(sessionID string) bool {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	if _, busy := s.inflight[sessionID]; busy {
+		return false
+	}
+	s.inflight[sessionID] = struct{}{}
+	return true
+}
+
+func (s *Service) endSessionCompaction(sessionID string) {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	delete(s.inflight, sessionID)
 }
 
 func (s *Service) SetHookService(h *hooks.Service) {
@@ -56,6 +80,15 @@ func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) erro
 }
 
 func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) error {
+	if !s.beginSessionCompaction(cfg.SessionID) {
+		s.logger.Info("compaction: already in flight for session, skipping",
+			slog.String("bot_id", cfg.BotID),
+			slog.String("session_id", cfg.SessionID),
+		)
+		return nil
+	}
+	defer s.endSessionCompaction(cfg.SessionID)
+
 	if err := s.runCompactionHook(ctx, hooks.EventPreCompact, cfg, nil); err != nil {
 		return err
 	}
@@ -80,19 +113,7 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) error {
 		return compactErr
 	}
 
-	logRow, err := s.queries.CreateCompactionLog(ctx, sqlc.CreateCompactionLogParams{
-		BotID:     botUUID,
-		SessionID: sessionUUID,
-	})
-	if err != nil {
-		compactErr = err
-		return compactErr
-	}
-
-	compactErr = s.doCompaction(ctx, logRow.ID, sessionUUID, cfg)
-	if compactErr != nil {
-		s.completeLog(ctx, logRow.ID, "error", "", compactErr.Error(), 0, nil, pgtype.UUID{})
-	}
+	compactErr = s.doCompaction(ctx, botUUID, sessionUUID, cfg)
 	return compactErr
 }
 
@@ -129,13 +150,12 @@ func (s *Service) runCompactionHook(ctx context.Context, eventName string, cfg T
 	return nil
 }
 
-func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUUID pgtype.UUID, cfg TriggerConfig) error {
+func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, sessionUUID pgtype.UUID, cfg TriggerConfig) error {
 	rows, err := s.queries.ListUncompactedMessagesBySession(ctx, sessionUUID)
 	if err != nil {
 		return err
 	}
 	if len(rows) == 0 {
-		s.completeLog(ctx, logID, "ok", "", "", 0, nil, pgtype.UUID{})
 		return nil
 	}
 
@@ -147,7 +167,6 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 		)
 	}
 	if len(messages) == 0 {
-		s.completeLog(ctx, logID, "ok", "", "", 0, nil, pgtype.UUID{})
 		return nil
 	}
 
@@ -161,7 +180,6 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 		toCompact = splitByRatio(messages, cfg.TotalInputTokens, cfg.Ratio)
 	}
 	if len(toCompact) == 0 {
-		s.completeLog(ctx, logID, "ok", "", "", 0, nil, pgtype.UUID{})
 		return nil
 	}
 
@@ -197,7 +215,6 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 	if len(entries) == 0 {
 		// Every selected message rendered empty (e.g. reasoning-only): summarizing
 		// nothing would destroy them for a junk summary. Leave them in history.
-		s.completeLog(ctx, logID, "ok", "", "", 0, nil, pgtype.UUID{})
 		return nil
 	}
 
@@ -217,12 +234,27 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 		systemPrompt, []sdk.Message{sdk.UserMessage(userPrompt)}, nil,
 	)
 
+	// The log row is created only once a real attempt starts, so no-op runs do
+	// not accumulate rows. Persistence uses a non-cancellable context: a client
+	// disconnect mid-run must not strand rows marked compacted without a
+	// completed summary.
+	persistCtx := context.WithoutCancel(ctx)
+	logRow, err := s.queries.CreateCompactionLog(persistCtx, sqlc.CreateCompactionLogParams{
+		BotID:     botUUID,
+		SessionID: sessionUUID,
+	})
+	if err != nil {
+		return err
+	}
+	logID := logRow.ID
+
 	result, err := sdk.GenerateTextResult(ctx,
 		sdk.WithModel(model),
 		sdk.WithSystem(systemPromptDecorated),
 		sdk.WithMessages(sdkMessages),
 	)
 	if err != nil {
+		s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
 		return err
 	}
 
@@ -230,14 +262,15 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 
 	modelUUID := db.ParseUUIDOrEmpty(cfg.ModelID)
 
-	if err := s.queries.MarkMessagesCompacted(ctx, sqlc.MarkMessagesCompactedParams{
+	if err := s.queries.MarkMessagesCompacted(persistCtx, sqlc.MarkMessagesCompactedParams{
 		CompactID: logID,
 		Column2:   messageIDs,
 	}); err != nil {
+		s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
 		return err
 	}
 
-	s.completeLog(ctx, logID, "ok", result.Text, "", len(messageIDs), usageJSON, modelUUID)
+	s.completeLog(persistCtx, logID, "ok", result.Text, "", len(messageIDs), usageJSON, modelUUID)
 	return nil
 }
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -322,12 +322,12 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		sdk.WithMessages(sdkMessages),
 	)
 	if err != nil {
-		s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
+		_ = s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
 		return Result{}, err
 	}
 
 	if strings.TrimSpace(result.Text) == "" {
-		s.completeLog(persistCtx, logID, "error", "", errEmptySummary.Error(), 0, nil, pgtype.UUID{})
+		_ = s.completeLog(persistCtx, logID, "error", "", errEmptySummary.Error(), 0, nil, pgtype.UUID{})
 		return Result{}, errEmptySummary
 	}
 
@@ -339,15 +339,20 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		CompactID: logID,
 		Column2:   messageIDs,
 	}); err != nil {
-		s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
+		_ = s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
 		return Result{}, err
 	}
 
-	s.completeLog(persistCtx, logID, "ok", result.Text, "", len(messageIDs), usageJSON, modelUUID)
+	if err := s.completeLog(persistCtx, logID, "ok", result.Text, "", len(messageIDs), usageJSON, modelUUID); err != nil {
+		// The rows are already marked, but the log never reached status=ok, so
+		// the reclaim SQL keeps them eligible for a later pass. Reporting ok
+		// here would claim a summary that was never persisted.
+		return Result{}, err
+	}
 	return Result{Status: StatusOK, Summary: result.Text, MessageCount: len(messageIDs)}, nil
 }
 
-func (s *Service) completeLog(ctx context.Context, logID pgtype.UUID, status, summary, errMsg string, messageCount int, usage []byte, modelID pgtype.UUID) {
+func (s *Service) completeLog(ctx context.Context, logID pgtype.UUID, status, summary, errMsg string, messageCount int, usage []byte, modelID pgtype.UUID) error {
 	if _, err := s.queries.CompleteCompactionLog(ctx, sqlc.CompleteCompactionLogParams{
 		ID:           logID,
 		Status:       status,
@@ -358,7 +363,9 @@ func (s *Service) completeLog(ctx context.Context, logID pgtype.UUID, status, su
 		ModelID:      modelID,
 	}); err != nil {
 		s.logger.Error("failed to complete compaction log", slog.String("error", err.Error()))
+		return err
 	}
+	return nil
 }
 
 // ListLogs returns paginated compaction logs for a bot.

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -130,16 +130,21 @@ func (s *Service) runCompactionHook(ctx context.Context, eventName string, cfg T
 }
 
 func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUUID pgtype.UUID, cfg TriggerConfig) error {
-	messages, err := s.queries.ListUncompactedMessagesBySession(ctx, sessionUUID)
+	rows, err := s.queries.ListUncompactedMessagesBySession(ctx, sessionUUID)
 	if err != nil {
 		return err
 	}
-	if len(messages) == 0 {
+	if len(rows) == 0 {
 		s.completeLog(ctx, logID, "ok", "", "", 0, nil, pgtype.UUID{})
 		return nil
 	}
 
-	var toCompact []sqlc.ListUncompactedMessagesBySessionRow
+	messages, err := itemsFromRows(rows)
+	if err != nil {
+		return err
+	}
+
+	var toCompact []compactionItem
 	if cfg.TargetTokens > 0 {
 		// Sync compaction: compress enough messages to bring context
 		// down to TargetTokens. Calculate how many tokens to keep
@@ -183,12 +188,12 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 
 	entries := make([]messageEntry, 0, len(toCompact))
 	messageIDs := make([]pgtype.UUID, 0, len(toCompact))
-	for _, m := range toCompact {
+	for _, it := range toCompact {
 		entries = append(entries, messageEntry{
-			Role:    m.Role,
-			Content: string(m.Content),
+			Role:    it.record.ModelMessage.Role,
+			Content: string(it.content),
 		})
-		messageIDs = append(messageIDs, m.ID)
+		messageIDs = append(messageIDs, it.id)
 	}
 
 	userPrompt := buildUserPrompt(priorSummaries, entries)
@@ -319,106 +324,4 @@ func formatUUID(id pgtype.UUID) string {
 		return ""
 	}
 	return uuid.UUID(id.Bytes).String()
-}
-
-// splitByRatio splits messages so that roughly the first ratio% (by token weight)
-// are returned for compaction, and the rest are kept as-is.
-// When ratio >= 100, all messages are returned for compaction.
-// When ratio <= 0 or totalInputTokens <= 0 or messages is empty, nil is returned (no compaction).
-func splitByRatio(messages []sqlc.ListUncompactedMessagesBySessionRow, totalInputTokens, ratio int) []sqlc.ListUncompactedMessagesBySessionRow {
-	if ratio <= 0 || totalInputTokens <= 0 || len(messages) == 0 {
-		return nil
-	}
-	if ratio >= 100 {
-		return messages
-	}
-
-	keepTokens := totalInputTokens * (100 - ratio) / 100
-	if keepTokens <= 0 {
-		return messages
-	}
-
-	accumulated := 0
-	cutoff := len(messages)
-	for i := len(messages) - 1; i >= 0; i-- {
-		accumulated += estimateRowTokens(messages[i])
-		if accumulated >= keepTokens {
-			cutoff = i + 1
-			break
-		}
-	}
-
-	if cutoff <= 0 {
-		return nil
-	}
-	if cutoff >= len(messages) {
-		return messages
-	}
-	return messages[:cutoff]
-}
-
-// splitByTarget returns the oldest messages to compact so that the remaining
-// newest messages fit within targetTokens. This is used for synchronous
-// compaction where the goal is to reduce context to a specific size.
-func splitByTarget(messages []sqlc.ListUncompactedMessagesBySessionRow, targetTokens int) []sqlc.ListUncompactedMessagesBySessionRow {
-	if targetTokens <= 0 || len(messages) == 0 {
-		return nil
-	}
-	// Scan from newest to oldest, keeping messages that fit within target.
-	accumulated := 0
-	cutoff := 0
-	for i := len(messages) - 1; i >= 0; i-- {
-		accumulated += estimateRowTokens(messages[i])
-		if accumulated > targetTokens {
-			cutoff = i + 1
-			break
-		}
-	}
-	if cutoff <= 0 {
-		return nil
-	}
-	return messages[:cutoff]
-}
-
-type usagePayload struct {
-	OutputTokens *int `json:"output_tokens"`
-}
-
-func estimateRowTokens(m sqlc.ListUncompactedMessagesBySessionRow) int {
-	if len(m.Usage) > 0 {
-		var u usagePayload
-		if json.Unmarshal(m.Usage, &u) == nil && u.OutputTokens != nil && *u.OutputTokens > 0 {
-			return *u.OutputTokens
-		}
-	}
-	return len(m.Content) / 4
-}
-
-// trimCompactMessages trims the compaction input from the tail (oldest)
-// so the total estimated tokens stay within maxTokens.
-func trimCompactMessages(messages []sqlc.ListUncompactedMessagesBySessionRow, maxTokens int) []sqlc.ListUncompactedMessagesBySessionRow {
-	if len(messages) == 0 || maxTokens <= 0 {
-		return messages
-	}
-	total := 0
-	for _, m := range messages {
-		total += estimateRowTokens(m)
-	}
-	if total <= maxTokens {
-		return messages
-	}
-	// Drop oldest messages from the tail until within budget.
-	accumulated := 0
-	cutoff := len(messages)
-	for i := len(messages) - 1; i >= 0; i-- {
-		accumulated += estimateRowTokens(messages[i])
-		if accumulated > maxTokens {
-			cutoff = i + 1
-			break
-		}
-	}
-	if cutoff >= len(messages) {
-		return messages
-	}
-	return messages[cutoff:]
 }

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,9 +35,10 @@ const compactionFailureCooldown = 5 * time.Minute
 // done closes after res/err are set, so concurrent sync callers can wait for
 // the owner and reuse its outcome instead of skipping or double-running.
 type inflightRun struct {
-	done chan struct{}
-	res  Result
-	err  error
+	done    chan struct{}
+	waiters atomic.Int32
+	res     Result
+	err     error
 }
 
 // Service manages context compaction for bot conversations.
@@ -142,6 +144,7 @@ func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) (Res
 	if owner == nil {
 		return res, err
 	}
+	owner.waiters.Add(1)
 	select {
 	case <-owner.done:
 		return owner.res, owner.err

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -151,7 +151,7 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 		return nil
 	}
 
-	var toCompact []compactionItem
+	var toCompact []CompactionCandidate
 	if cfg.TargetTokens > 0 {
 		// Sync compaction: compress enough messages to bring context
 		// down to TargetTokens. Calculate how many tokens to keep

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -275,6 +275,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 			priorSummaries = append(priorSummaries, l.Summary)
 		}
 	}
+	priorSummaries = capPriorSummaries(priorSummaries, maxCompactTokens/4)
 
 	entries, messageIDs := buildEntriesAndIDs(toCompact)
 	if len(entries) == 0 || len(messageIDs) == 0 {

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -194,6 +194,12 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 	}
 
 	entries, messageIDs := buildEntriesAndIDs(toCompact)
+	if len(entries) == 0 {
+		// Every selected message rendered empty (e.g. reasoning-only): summarizing
+		// nothing would destroy them for a junk summary. Leave them in history.
+		s.completeLog(ctx, logID, "ok", "", "", 0, nil, pgtype.UUID{})
+		return nil
+	}
 
 	userPrompt := buildUserPrompt(priorSummaries, entries)
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -89,7 +89,8 @@ func (s *Service) endSessionCompaction(sessionID string, run *inflightRun, res R
 }
 
 // inFailureCooldown reports whether sessionID failed compaction recently
-// enough that a new attempt should be skipped.
+// enough that a new attempt should be skipped. An entry found expired is
+// deleted so failedAt does not accumulate sessions that never run again.
 func (s *Service) inFailureCooldown(sessionID string) bool {
 	s.inflightMu.Lock()
 	defer s.inflightMu.Unlock()
@@ -97,7 +98,11 @@ func (s *Service) inFailureCooldown(sessionID string) bool {
 	if !ok {
 		return false
 	}
-	return s.nowFn().Sub(failedAt) < compactionFailureCooldown
+	if s.nowFn().Sub(failedAt) >= compactionFailureCooldown {
+		delete(s.failedAt, sessionID)
+		return false
+	}
+	return true
 }
 
 func (s *Service) recordCompactionFailure(sessionID string) {

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -413,8 +413,18 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 
 	// A single markable group larger than the whole budget survives trim by
 	// design (progress guarantee); truncate its rendered entries rather than
-	// send a prompt the model rejects on every pass.
+	// send a prompt the model rejects on every pass. Entry floors can still
+	// exceed the budget when that group holds enough rows, so recheck and
+	// surface the overshoot instead of claiming an unconditional cap.
 	entries = capEntriesToBudget(entries, maxCompactTokens-priorTokens)
+	if cost := entriesPromptCost(entries); cost+priorTokens > maxCompactTokens {
+		s.logger.Warn("compaction: entry floors exceed the budget, prompt may overflow the compaction window",
+			slog.Int("entries", len(entries)),
+			slog.Int("entry_tokens", cost),
+			slog.Int("max_compact_tokens", maxCompactTokens),
+			slog.String("session_id", cfg.SessionID),
+		)
+	}
 
 	userPrompt := buildUserPrompt(priorSummaries, entries)
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -141,16 +141,24 @@ func (s *Service) TriggerCompaction(ctx context.Context, cfg TriggerConfig) {
 // seconds away, and waiting removes a duplicate LLM call over the same span; a
 // canceled wait degrades to a noop.
 func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) (Result, error) {
-	res, owner, err := s.runCompaction(ctx, cfg)
-	if owner == nil {
-		return res, err
-	}
-	owner.waiters.Add(1)
-	select {
-	case <-owner.done:
-		return owner.res, owner.err
-	case <-ctx.Done():
-		return Result{Status: StatusNoop}, nil
+	for {
+		res, owner, err := s.runCompaction(ctx, cfg)
+		if owner == nil {
+			return res, err
+		}
+		owner.waiters.Add(1)
+		select {
+		case <-owner.done:
+			if cfg.Manual && owner.err == nil && owner.res.Status == StatusNoop {
+				// The owner may have been an automatic run that nooped on the
+				// failure cooldown; a manual request must still bypass it and
+				// attempt for real instead of inheriting the skip.
+				continue
+			}
+			return owner.res, owner.err
+		case <-ctx.Done():
+			return Result{Status: StatusNoop}, nil
+		}
 	}
 }
 
@@ -186,14 +194,12 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 		return compactRes, nil, nil
 	}
 
-	if err := s.runCompactionHook(ctx, hooks.EventPreCompact, cfg, nil); err != nil {
-		compactErr = err
-		return Result{}, nil, err
-	}
+	preHookRan := false
 	defer func() {
 		if r := recover(); r != nil {
-			// A panicking run must not publish a zero-value success to
-			// waiters or clear the cooldown as if it succeeded.
+			// A panicking run — the pre-hook included — must not publish a
+			// zero-value success to waiters or clear the cooldown as if it
+			// succeeded.
 			compactErr = fmt.Errorf("compaction panicked: %v", r)
 			compactRes = Result{}
 			s.recordCompactionFailure(cfg.SessionID)
@@ -202,6 +208,9 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 		switch {
 		case compactErr == nil:
 			s.clearCompactionFailure(cfg.SessionID)
+		case !preHookRan:
+			// A pre-hook error or deny is bot policy, not a model failure;
+			// it must not arm the cooldown (panics above still do).
 		case ctx.Err() != nil:
 			// The caller's request was canceled or hit its deadline — not a
 			// model failure. Arming the five-minute cooldown here would
@@ -212,6 +221,9 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 		default:
 			s.recordCompactionFailure(cfg.SessionID)
 		}
+		if !preHookRan {
+			return
+		}
 		extra := map[string]any{}
 		if compactErr != nil {
 			extra["error"] = compactErr.Error()
@@ -220,6 +232,12 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 			s.logger.Warn("post compaction hook failed", slog.String("bot_id", cfg.BotID), slog.Any("error", err))
 		}
 	}()
+
+	if err := s.runCompactionHook(ctx, hooks.EventPreCompact, cfg, nil); err != nil {
+		compactErr = err
+		return Result{}, nil, err
+	}
+	preHookRan = true
 	botUUID, err := db.ParseUUID(cfg.BotID)
 	if err != nil {
 		compactErr = err

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -266,12 +266,11 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 
 	entries, messageIDs := buildEntriesAndIDs(toCompact)
 	if len(entries) == 0 || len(messageIDs) == 0 {
-		// entries==0: every selected message rendered empty (e.g. reasoning-only);
-		// summarizing nothing would destroy them for a junk summary. messageIDs==0:
-		// all-or-none marking withheld every id (e.g. an incomplete tool exchange
-		// with a renderable call and an empty-rendering result sibling); summarizing
-		// rows we cannot mark would create an ok log with message_count=0 and
-		// pollute prior_context. Either way, leave the rows in history.
+		// No complete group survived: every selected group had a row that rendered
+		// empty (a reasoning-only message, or a tool exchange whose result renders
+		// empty). buildEntriesAndIDs withholds such a group from both entries and
+		// ids, so summarizing here would either destroy rows for a junk summary or
+		// mark rows we cannot faithfully summarize. Leave them in raw history.
 		return nil
 	}
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -225,10 +225,10 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		return Result{Status: StatusNoop}, nil
 	}
 
-	messages, skipped := itemsFromRows(rows)
-	if skipped > 0 {
+	messages, barrierCount := itemsFromRows(rows)
+	if barrierCount > 0 {
 		s.logger.Warn("compaction: kept unparseable history rows as span barriers",
-			slog.Int("skipped", skipped),
+			slog.Int("barrier_count", barrierCount),
 			slog.String("session_id", cfg.SessionID),
 		)
 	}

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -151,10 +151,13 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 		switch {
 		case compactErr == nil:
 			s.clearCompactionFailure(cfg.SessionID)
-		case ctx.Err() != nil, errors.Is(compactErr, context.Canceled), errors.Is(compactErr, context.DeadlineExceeded):
-			// An interrupted request is not a model failure: arming the
-			// five-minute cooldown here would silence auto-compaction for a
-			// healthy session just because the user canceled one request.
+		case ctx.Err() != nil:
+			// The caller's request was canceled or hit its deadline — not a
+			// model failure. Arming the five-minute cooldown here would
+			// silence auto-compaction for a healthy session just because the
+			// user aborted one request. A timeout with the caller's context
+			// still live (e.g. the HTTP client's own timeout on a model too
+			// slow to summarize) is a real failure and still arms it.
 		default:
 			s.recordCompactionFailure(cfg.SessionID)
 		}
@@ -250,20 +253,13 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 
 	// Cap the compaction input to avoid exceeding the compaction model's
 	// context window. MaxCompactTokens is typically set to 90% of the model's
-	// window. If not set, use a conservative default of 30K tokens.
+	// window. If not set, use a conservative default of 30K tokens. Prior
+	// summaries and message entries share this one budget — an additive prior
+	// allowance would let the combined prompt exceed the window headroom.
 	maxCompactTokens := cfg.MaxCompactTokens
 	if maxCompactTokens <= 0 {
 		maxCompactTokens = 30000
 	}
-	s.logger.Info("compaction: before trim",
-		slog.Int("messages", len(toCompact)),
-		slog.Int("total_uncompacted", len(messages)),
-		slog.Int("max_compact_tokens", maxCompactTokens),
-	)
-	toCompact = trimCompactMessages(toCompact, maxCompactTokens)
-	s.logger.Info("compaction: after trim",
-		slog.Int("messages", len(toCompact)),
-	)
 
 	priorLogs, err := s.queries.ListCompactionLogsBySession(ctx, sessionUUID)
 	if err != nil {
@@ -276,6 +272,28 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		}
 	}
 	priorSummaries = capPriorSummaries(priorSummaries, maxCompactTokens/4)
+	priorTokens := 0
+	for _, summary := range priorSummaries {
+		priorTokens += estimateBytesAsTokens(summary)
+	}
+	// capPriorSummaries always keeps the newest summary, so a single oversized
+	// one can exceed its allowance; floor the entries budget at half the total
+	// so compaction keeps making progress.
+	entriesBudget := maxCompactTokens - priorTokens
+	if entriesBudget < maxCompactTokens/2 {
+		entriesBudget = maxCompactTokens / 2
+	}
+
+	s.logger.Info("compaction: before trim",
+		slog.Int("messages", len(toCompact)),
+		slog.Int("total_uncompacted", len(messages)),
+		slog.Int("max_compact_tokens", maxCompactTokens),
+		slog.Int("prior_context_tokens", priorTokens),
+	)
+	toCompact = trimCompactMessages(toCompact, entriesBudget)
+	s.logger.Info("compaction: after trim",
+		slog.Int("messages", len(toCompact)),
+	)
 
 	entries, messageIDs := buildEntriesAndIDs(toCompact)
 	if len(entries) == 0 || len(messageIDs) == 0 {

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -186,15 +186,7 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 		}
 	}
 
-	entries := make([]messageEntry, 0, len(toCompact))
-	messageIDs := make([]pgtype.UUID, 0, len(toCompact))
-	for _, it := range toCompact {
-		entries = append(entries, messageEntry{
-			Role:    it.record.ModelMessage.Role,
-			Content: renderEntryContent(it.record.ModelMessage),
-		})
-		messageIDs = append(messageIDs, it.id)
-	}
+	entries, messageIDs := buildEntriesAndIDs(toCompact)
 
 	userPrompt := buildUserPrompt(priorSummaries, entries)
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -227,7 +227,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 
 	messages, skipped := itemsFromRows(rows)
 	if skipped > 0 {
-		s.logger.Warn("compaction: skipped unparseable history rows",
+		s.logger.Warn("compaction: kept unparseable history rows as span barriers",
 			slog.Int("skipped", skipped),
 			slog.String("session_id", cfg.SessionID),
 		)

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -152,7 +152,12 @@ func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) (Res
 			if cfg.Manual && owner.err == nil && owner.res.Status == StatusNoop {
 				// The owner may have been an automatic run that nooped on the
 				// failure cooldown; a manual request must still bypass it and
-				// attempt for real instead of inheriting the skip.
+				// attempt for real instead of inheriting the skip — unless the
+				// caller canceled while waiting, in which case retrying would
+				// start new side effects after cancellation.
+				if ctx.Err() != nil {
+					return Result{Status: StatusNoop}, nil
+				}
 				continue
 			}
 			return owner.res, owner.err

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -148,10 +148,15 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 	}
 	var compactErr error
 	defer func() {
-		if compactErr != nil {
-			s.recordCompactionFailure(cfg.SessionID)
-		} else {
+		switch {
+		case compactErr == nil:
 			s.clearCompactionFailure(cfg.SessionID)
+		case ctx.Err() != nil, errors.Is(compactErr, context.Canceled), errors.Is(compactErr, context.DeadlineExceeded):
+			// An interrupted request is not a model failure: arming the
+			// five-minute cooldown here would silence auto-compaction for a
+			// healthy session just because the user canceled one request.
+		default:
+			s.recordCompactionFailure(cfg.SessionID)
 		}
 		extra := map[string]any{}
 		if compactErr != nil {

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -24,14 +25,21 @@ import (
 // MarkMessagesCompacted.
 var errEmptySummary = errors.New("compaction: model returned an empty summary")
 
+// compactionFailureCooldown bounds how often a session may retry compaction
+// after a failure, so a persistently failing model can't burn an LLM call on
+// every blocking sync backstop or async trigger.
+const compactionFailureCooldown = 5 * time.Minute
+
 // Service manages context compaction for bot conversations.
 type Service struct {
 	queries     dbstore.Queries
 	hookService *hooks.Service
 	logger      *slog.Logger
+	nowFn       func() time.Time
 
 	inflightMu sync.Mutex
 	inflight   map[string]struct{}
+	failedAt   map[string]time.Time
 }
 
 // NewService creates a new compaction Service.
@@ -39,7 +47,9 @@ func NewService(log *slog.Logger, queries dbstore.Queries) *Service {
 	return &Service{
 		queries:  queries,
 		logger:   log,
+		nowFn:    time.Now,
 		inflight: make(map[string]struct{}),
+		failedAt: make(map[string]time.Time),
 	}
 }
 
@@ -60,6 +70,30 @@ func (s *Service) endSessionCompaction(sessionID string) {
 	s.inflightMu.Lock()
 	defer s.inflightMu.Unlock()
 	delete(s.inflight, sessionID)
+}
+
+// inFailureCooldown reports whether sessionID failed compaction recently
+// enough that a new attempt should be skipped.
+func (s *Service) inFailureCooldown(sessionID string) bool {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	failedAt, ok := s.failedAt[sessionID]
+	if !ok {
+		return false
+	}
+	return s.nowFn().Sub(failedAt) < compactionFailureCooldown
+}
+
+func (s *Service) recordCompactionFailure(sessionID string) {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	s.failedAt[sessionID] = s.nowFn()
+}
+
+func (s *Service) clearCompactionFailure(sessionID string) {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	delete(s.failedAt, sessionID)
 }
 
 func (s *Service) SetHookService(h *hooks.Service) {
@@ -87,6 +121,13 @@ func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) erro
 }
 
 func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) error {
+	if s.inFailureCooldown(cfg.SessionID) {
+		s.logger.Info("compaction: session in failure cooldown, skipping",
+			slog.String("bot_id", cfg.BotID),
+			slog.String("session_id", cfg.SessionID),
+		)
+		return nil
+	}
 	if !s.beginSessionCompaction(cfg.SessionID) {
 		s.logger.Info("compaction: already in flight for session, skipping",
 			slog.String("bot_id", cfg.BotID),
@@ -101,6 +142,11 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) error {
 	}
 	var compactErr error
 	defer func() {
+		if compactErr != nil {
+			s.recordCompactionFailure(cfg.SessionID)
+		} else {
+			s.clearCompactionFailure(cfg.SessionID)
+		}
 		extra := map[string]any{}
 		if compactErr != nil {
 			extra["error"] = compactErr.Error()

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -154,16 +155,10 @@ func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) (Res
 }
 
 func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result, *inflightRun, error) {
-	// Manual (user-initiated) compaction bypasses the cooldown: the user may
-	// have just fixed the failing model, and a silent skip would report success
-	// while nothing runs. Automatic per-request paths still honor the cooldown.
-	if !cfg.Manual && s.inFailureCooldown(cfg.SessionID) {
-		s.logger.Info("compaction: session in failure cooldown, skipping",
-			slog.String("bot_id", cfg.BotID),
-			slog.String("session_id", cfg.SessionID),
-		)
-		return Result{Status: StatusNoop}, nil, nil
-	}
+	// Attaching to an existing owner wins over the cooldown check: the
+	// cooldown exists to stop new failing runs, not to hide a run already in
+	// flight (a manual retry may be the owner precisely because it bypassed
+	// the cooldown, and sync callers should reuse its result).
 	run, ok := s.beginSessionCompaction(cfg.SessionID)
 	if !ok {
 		s.logger.Info("compaction: already in flight for session",
@@ -179,11 +174,31 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 		s.endSessionCompaction(cfg.SessionID, run, compactRes, compactErr)
 	}()
 
+	// Manual (user-initiated) compaction bypasses the cooldown: the user may
+	// have just fixed the failing model, and a silent skip would report success
+	// while nothing runs. Automatic per-request paths still honor the cooldown.
+	if !cfg.Manual && s.inFailureCooldown(cfg.SessionID) {
+		s.logger.Info("compaction: session in failure cooldown, skipping",
+			slog.String("bot_id", cfg.BotID),
+			slog.String("session_id", cfg.SessionID),
+		)
+		compactRes = Result{Status: StatusNoop}
+		return compactRes, nil, nil
+	}
+
 	if err := s.runCompactionHook(ctx, hooks.EventPreCompact, cfg, nil); err != nil {
 		compactErr = err
 		return Result{}, nil, err
 	}
 	defer func() {
+		if r := recover(); r != nil {
+			// A panicking run must not publish a zero-value success to
+			// waiters or clear the cooldown as if it succeeded.
+			compactErr = fmt.Errorf("compaction panicked: %v", r)
+			compactRes = Result{}
+			s.recordCompactionFailure(cfg.SessionID)
+			panic(r)
+		}
 		switch {
 		case compactErr == nil:
 			s.clearCompactionFailure(cfg.SessionID)
@@ -307,10 +322,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		}
 	}
 	priorSummaries = capPriorSummaries(priorSummaries, maxCompactTokens/4)
-	priorTokens := 0
-	for _, summary := range priorSummaries {
-		priorTokens += estimateBytesAsTokens(summary)
-	}
+	priorTokens := priorContextTokens(priorSummaries)
 	// capPriorSummaries always keeps the newest summary, so a single oversized
 	// one can exceed its allowance; floor the entries budget at half the total
 	// so compaction keeps making progress.
@@ -331,6 +343,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 	// to nothing) before letting the combined prompt exceed MaxCompactTokens.
 	if entriesCost := markableCompactCost(toCompact); entriesCost+priorTokens > maxCompactTokens {
 		priorSummaries = capPriorSummaries(priorSummaries, maxCompactTokens-entriesCost)
+		priorTokens = priorContextTokens(priorSummaries)
 	}
 	s.logger.Info("compaction: after trim",
 		slog.Int("messages", len(toCompact)),
@@ -346,6 +359,11 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		// mark rows we cannot faithfully summarize. Leave them in raw history.
 		return Result{Status: StatusNoop}, nil
 	}
+
+	// A single markable group larger than the whole budget survives trim by
+	// design (progress guarantee); truncate its rendered entries rather than
+	// send a prompt the model rejects on every pass.
+	entries = capEntriesToBudget(entries, maxCompactTokens-priorTokens)
 
 	userPrompt := buildUserPrompt(priorSummaries, entries)
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -265,9 +265,13 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 	}
 
 	entries, messageIDs := buildEntriesAndIDs(toCompact)
-	if len(entries) == 0 {
-		// Every selected message rendered empty (e.g. reasoning-only): summarizing
-		// nothing would destroy them for a junk summary. Leave them in history.
+	if len(entries) == 0 || len(messageIDs) == 0 {
+		// entries==0: every selected message rendered empty (e.g. reasoning-only);
+		// summarizing nothing would destroy them for a junk summary. messageIDs==0:
+		// all-or-none marking withheld every id (e.g. an incomplete tool exchange
+		// with a renderable call and an empty-rendering result sibling); summarizing
+		// rows we cannot mark would create an ok log with message_count=0 and
+		// pollute prior_context. Either way, leave the rows in history.
 		return nil
 	}
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -109,18 +109,27 @@ func ShouldCompact(inputTokens, threshold int) bool {
 func (s *Service) TriggerCompaction(ctx context.Context, cfg TriggerConfig) {
 	go func() {
 		bgCtx := context.WithoutCancel(ctx)
-		if err := s.runCompaction(bgCtx, cfg); err != nil {
+		if _, err := s.runCompaction(bgCtx, cfg); err != nil {
 			s.logger.Error("compaction failed", slog.String("bot_id", cfg.BotID), slog.String("session_id", cfg.SessionID), slog.String("error", err.Error()))
 		}
 	}()
 }
 
-// RunCompactionSync runs compaction synchronously and returns any error.
+// RunCompactionSync runs compaction synchronously and returns any error. Use
+// RunCompactionSyncResult when the caller needs this session's scoped outcome.
 func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) error {
+	_, err := s.runCompaction(ctx, cfg)
+	return err
+}
+
+// RunCompactionSyncResult runs compaction synchronously and reports this
+// session's scoped Result, so callers respond with their own outcome instead of
+// reading an unscoped bot-wide log that may belong to another session.
+func (s *Service) RunCompactionSyncResult(ctx context.Context, cfg TriggerConfig) (Result, error) {
 	return s.runCompaction(ctx, cfg)
 }
 
-func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) error {
+func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result, error) {
 	// Manual (user-initiated) compaction bypasses the cooldown: the user may
 	// have just fixed the failing model, and a silent skip would report success
 	// while nothing runs. Automatic per-request paths still honor the cooldown.
@@ -129,19 +138,19 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) error {
 			slog.String("bot_id", cfg.BotID),
 			slog.String("session_id", cfg.SessionID),
 		)
-		return nil
+		return Result{Status: StatusNoop}, nil
 	}
 	if !s.beginSessionCompaction(cfg.SessionID) {
 		s.logger.Info("compaction: already in flight for session, skipping",
 			slog.String("bot_id", cfg.BotID),
 			slog.String("session_id", cfg.SessionID),
 		)
-		return nil
+		return Result{Status: StatusNoop}, nil
 	}
 	defer s.endSessionCompaction(cfg.SessionID)
 
 	if err := s.runCompactionHook(ctx, hooks.EventPreCompact, cfg, nil); err != nil {
-		return err
+		return Result{}, err
 	}
 	var compactErr error
 	defer func() {
@@ -161,16 +170,17 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) error {
 	botUUID, err := db.ParseUUID(cfg.BotID)
 	if err != nil {
 		compactErr = err
-		return compactErr
+		return Result{}, compactErr
 	}
 	sessionUUID, err := db.ParseUUID(cfg.SessionID)
 	if err != nil {
 		compactErr = err
-		return compactErr
+		return Result{}, compactErr
 	}
 
-	compactErr = s.doCompaction(ctx, botUUID, sessionUUID, cfg)
-	return compactErr
+	res, err := s.doCompaction(ctx, botUUID, sessionUUID, cfg)
+	compactErr = err
+	return res, compactErr
 }
 
 func (s *Service) runCompactionHook(ctx context.Context, eventName string, cfg TriggerConfig, extra map[string]any) error {
@@ -206,13 +216,13 @@ func (s *Service) runCompactionHook(ctx context.Context, eventName string, cfg T
 	return nil
 }
 
-func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, sessionUUID pgtype.UUID, cfg TriggerConfig) error {
+func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, sessionUUID pgtype.UUID, cfg TriggerConfig) (Result, error) {
 	rows, err := s.queries.ListUncompactedMessagesBySession(ctx, sessionUUID)
 	if err != nil {
-		return err
+		return Result{}, err
 	}
 	if len(rows) == 0 {
-		return nil
+		return Result{Status: StatusNoop}, nil
 	}
 
 	messages, skipped := itemsFromRows(rows)
@@ -223,7 +233,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		)
 	}
 	if len(messages) == 0 {
-		return nil
+		return Result{Status: StatusNoop}, nil
 	}
 
 	var toCompact []CompactionCandidate
@@ -236,7 +246,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		toCompact = splitByRatio(messages, cfg.TotalInputTokens, cfg.Ratio)
 	}
 	if len(toCompact) == 0 {
-		return nil
+		return Result{Status: StatusNoop}, nil
 	}
 
 	// Cap the compaction input to avoid exceeding the compaction model's
@@ -258,7 +268,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 
 	priorLogs, err := s.queries.ListCompactionLogsBySession(ctx, sessionUUID)
 	if err != nil {
-		return err
+		return Result{}, err
 	}
 	var priorSummaries []string
 	for _, l := range priorLogs {
@@ -274,7 +284,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		// empty). buildEntriesAndIDs withholds such a group from both entries and
 		// ids, so summarizing here would either destroy rows for a junk summary or
 		// mark rows we cannot faithfully summarize. Leave them in raw history.
-		return nil
+		return Result{Status: StatusNoop}, nil
 	}
 
 	userPrompt := buildUserPrompt(priorSummaries, entries)
@@ -303,7 +313,7 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		SessionID: sessionUUID,
 	})
 	if err != nil {
-		return err
+		return Result{}, err
 	}
 	logID := logRow.ID
 
@@ -314,12 +324,12 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 	)
 	if err != nil {
 		s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
-		return err
+		return Result{}, err
 	}
 
 	if strings.TrimSpace(result.Text) == "" {
 		s.completeLog(persistCtx, logID, "error", "", errEmptySummary.Error(), 0, nil, pgtype.UUID{})
-		return errEmptySummary
+		return Result{}, errEmptySummary
 	}
 
 	usageJSON, _ := json.Marshal(result.Usage)
@@ -331,11 +341,11 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		Column2:   messageIDs,
 	}); err != nil {
 		s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
-		return err
+		return Result{}, err
 	}
 
 	s.completeLog(persistCtx, logID, "ok", result.Text, "", len(messageIDs), usageJSON, modelUUID)
-	return nil
+	return Result{Status: StatusOK, Summary: result.Text, MessageCount: len(messageIDs)}, nil
 }
 
 func (s *Service) completeLog(ctx context.Context, logID pgtype.UUID, status, summary, errMsg string, messageCount int, usage []byte, modelID pgtype.UUID) {

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -121,7 +121,10 @@ func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) erro
 }
 
 func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) error {
-	if s.inFailureCooldown(cfg.SessionID) {
+	// Manual (user-initiated) compaction bypasses the cooldown: the user may
+	// have just fixed the failing model, and a silent skip would report success
+	// while nothing runs. Automatic per-request paths still honor the cooldown.
+	if !cfg.Manual && s.inFailureCooldown(cfg.SessionID) {
 		s.logger.Info("compaction: session in failure cooldown, skipping",
 			slog.String("bot_id", cfg.BotID),
 			slog.String("session_id", cfg.SessionID),

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -191,7 +191,7 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 	for _, it := range toCompact {
 		entries = append(entries, messageEntry{
 			Role:    it.record.ModelMessage.Role,
-			Content: string(it.content),
+			Content: renderEntryContent(it.record.ModelMessage),
 		})
 		messageIDs = append(messageIDs, it.id)
 	}

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -139,9 +139,16 @@ func (s *Service) doCompaction(ctx context.Context, logID pgtype.UUID, sessionUU
 		return nil
 	}
 
-	messages, err := itemsFromRows(rows)
-	if err != nil {
-		return err
+	messages, skipped := itemsFromRows(rows)
+	if skipped > 0 {
+		s.logger.Warn("compaction: skipped unparseable history rows",
+			slog.Int("skipped", skipped),
+			slog.String("session_id", cfg.SessionID),
+		)
+	}
+	if len(messages) == 0 {
+		s.completeLog(ctx, logID, "ok", "", "", 0, nil, pgtype.UUID{})
+		return nil
 	}
 
 	var toCompact []compactionItem

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -30,6 +30,15 @@ var errEmptySummary = errors.New("compaction: model returned an empty summary")
 // every blocking sync backstop or async trigger.
 const compactionFailureCooldown = 5 * time.Minute
 
+// inflightRun is the completion signal for one session's running compaction.
+// done closes after res/err are set, so concurrent sync callers can wait for
+// the owner and reuse its outcome instead of skipping or double-running.
+type inflightRun struct {
+	done chan struct{}
+	res  Result
+	err  error
+}
+
 // Service manages context compaction for bot conversations.
 type Service struct {
 	queries     dbstore.Queries
@@ -38,7 +47,7 @@ type Service struct {
 	nowFn       func() time.Time
 
 	inflightMu sync.Mutex
-	inflight   map[string]struct{}
+	inflight   map[string]*inflightRun
 	failedAt   map[string]time.Time
 }
 
@@ -48,27 +57,31 @@ func NewService(log *slog.Logger, queries dbstore.Queries) *Service {
 		queries:  queries,
 		logger:   log,
 		nowFn:    time.Now,
-		inflight: make(map[string]struct{}),
+		inflight: make(map[string]*inflightRun),
 		failedAt: make(map[string]time.Time),
 	}
 }
 
 // beginSessionCompaction marks a session as having a compaction in flight.
 // Overlapping runs would select overlapping candidate sets and race
-// MarkMessagesCompacted, so only one compaction may run per session at a time.
-func (s *Service) beginSessionCompaction(sessionID string) bool {
+// MarkMessagesCompacted, so only one compaction may run per session at a time;
+// a busy session returns the owner's run for callers that want to wait on it.
+func (s *Service) beginSessionCompaction(sessionID string) (*inflightRun, bool) {
 	s.inflightMu.Lock()
 	defer s.inflightMu.Unlock()
-	if _, busy := s.inflight[sessionID]; busy {
-		return false
+	if owner, busy := s.inflight[sessionID]; busy {
+		return owner, false
 	}
-	s.inflight[sessionID] = struct{}{}
-	return true
+	run := &inflightRun{done: make(chan struct{})}
+	s.inflight[sessionID] = run
+	return run, true
 }
 
-func (s *Service) endSessionCompaction(sessionID string) {
+func (s *Service) endSessionCompaction(sessionID string, run *inflightRun, res Result, err error) {
 	s.inflightMu.Lock()
 	defer s.inflightMu.Unlock()
+	run.res, run.err = res, err
+	close(run.done)
 	delete(s.inflight, sessionID)
 }
 
@@ -105,11 +118,13 @@ func ShouldCompact(inputTokens, threshold int) bool {
 	return threshold > 0 && inputTokens >= threshold
 }
 
-// TriggerCompaction runs compaction in the background.
+// TriggerCompaction runs compaction in the background. A session with a run
+// already in flight is skipped: the async trigger fires per request, so the
+// next turn re-evaluates the demand.
 func (s *Service) TriggerCompaction(ctx context.Context, cfg TriggerConfig) {
 	go func() {
 		bgCtx := context.WithoutCancel(ctx)
-		if _, err := s.runCompaction(bgCtx, cfg); err != nil {
+		if _, _, err := s.runCompaction(bgCtx, cfg); err != nil {
 			s.logger.Error("compaction failed", slog.String("bot_id", cfg.BotID), slog.String("session_id", cfg.SessionID), slog.String("error", err.Error()))
 		}
 	}()
@@ -118,12 +133,24 @@ func (s *Service) TriggerCompaction(ctx context.Context, cfg TriggerConfig) {
 // RunCompactionSync runs compaction synchronously and reports this session's
 // scoped Result, so callers act on their own outcome (a noop keeps their
 // current context) instead of reading an unscoped bot-wide log that may belong
-// to another session.
+// to another session. When another run for the session is already in flight,
+// the sync path waits for the owner and reuses its outcome — the summary is
+// seconds away, and waiting removes a duplicate LLM call over the same span; a
+// canceled wait degrades to a noop.
 func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) (Result, error) {
-	return s.runCompaction(ctx, cfg)
+	res, owner, err := s.runCompaction(ctx, cfg)
+	if owner == nil {
+		return res, err
+	}
+	select {
+	case <-owner.done:
+		return owner.res, owner.err
+	case <-ctx.Done():
+		return Result{Status: StatusNoop}, nil
+	}
 }
 
-func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result, error) {
+func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result, *inflightRun, error) {
 	// Manual (user-initiated) compaction bypasses the cooldown: the user may
 	// have just fixed the failing model, and a silent skip would report success
 	// while nothing runs. Automatic per-request paths still honor the cooldown.
@@ -132,21 +159,27 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 			slog.String("bot_id", cfg.BotID),
 			slog.String("session_id", cfg.SessionID),
 		)
-		return Result{Status: StatusNoop}, nil
+		return Result{Status: StatusNoop}, nil, nil
 	}
-	if !s.beginSessionCompaction(cfg.SessionID) {
-		s.logger.Info("compaction: already in flight for session, skipping",
+	run, ok := s.beginSessionCompaction(cfg.SessionID)
+	if !ok {
+		s.logger.Info("compaction: already in flight for session",
 			slog.String("bot_id", cfg.BotID),
 			slog.String("session_id", cfg.SessionID),
 		)
-		return Result{Status: StatusNoop}, nil
+		return Result{Status: StatusNoop}, run, nil
 	}
-	defer s.endSessionCompaction(cfg.SessionID)
+
+	var compactRes Result
+	var compactErr error
+	defer func() {
+		s.endSessionCompaction(cfg.SessionID, run, compactRes, compactErr)
+	}()
 
 	if err := s.runCompactionHook(ctx, hooks.EventPreCompact, cfg, nil); err != nil {
-		return Result{}, err
+		compactErr = err
+		return Result{}, nil, err
 	}
-	var compactErr error
 	defer func() {
 		switch {
 		case compactErr == nil:
@@ -172,17 +205,16 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 	botUUID, err := db.ParseUUID(cfg.BotID)
 	if err != nil {
 		compactErr = err
-		return Result{}, compactErr
+		return Result{}, nil, compactErr
 	}
 	sessionUUID, err := db.ParseUUID(cfg.SessionID)
 	if err != nil {
 		compactErr = err
-		return Result{}, compactErr
+		return Result{}, nil, compactErr
 	}
 
-	res, err := s.doCompaction(ctx, botUUID, sessionUUID, cfg)
-	compactErr = err
-	return res, compactErr
+	compactRes, compactErr = s.doCompaction(ctx, botUUID, sessionUUID, cfg)
+	return compactRes, nil, compactErr
 }
 
 func (s *Service) runCompactionHook(ctx context.Context, eventName string, cfg TriggerConfig, extra map[string]any) error {
@@ -291,8 +323,15 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 		slog.Int("prior_context_tokens", priorTokens),
 	)
 	toCompact = trimCompactMessages(toCompact, entriesBudget)
+	// The progress guarantee may keep one oversized markable group past the
+	// entries budget; the prior context is reference-only, so shrink it (down
+	// to nothing) before letting the combined prompt exceed MaxCompactTokens.
+	if entriesCost := markableCompactCost(toCompact); entriesCost+priorTokens > maxCompactTokens {
+		priorSummaries = capPriorSummaries(priorSummaries, maxCompactTokens-entriesCost)
+	}
 	s.logger.Info("compaction: after trim",
 		slog.Int("messages", len(toCompact)),
+		slog.Int("prior_summaries", len(priorSummaries)),
 	)
 
 	entries, messageIDs := buildEntriesAndIDs(toCompact)

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -237,13 +237,7 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 		if !preHookRan {
 			return
 		}
-		extra := map[string]any{}
-		if compactErr != nil {
-			extra["error"] = compactErr.Error()
-		}
-		if err := s.runCompactionHook(context.WithoutCancel(ctx), hooks.EventPostCompact, cfg, extra); err != nil && s.logger != nil {
-			s.logger.Warn("post compaction hook failed", slog.String("bot_id", cfg.BotID), slog.Any("error", err))
-		}
+		s.runPostCompactHook(context.WithoutCancel(ctx), cfg, compactErr)
 	}()
 
 	if err := s.runCompactionHook(ctx, hooks.EventPreCompact, cfg, nil); err != nil {
@@ -264,6 +258,27 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 
 	compactRes, compactErr = s.doCompaction(ctx, botUUID, sessionUUID, cfg)
 	return compactRes, nil, compactErr
+}
+
+// runPostCompactHook dispatches PostCompact after the compaction outcome is
+// already decided and published state is settled. Post-hook failures are
+// advisory, so an error only logs a warning — and a panic is contained here:
+// letting it escape would blow past the recovery defer's already-spent
+// recover(), crash async triggers, and publish the pre-panic result to
+// waiters as if nothing happened.
+func (s *Service) runPostCompactHook(ctx context.Context, cfg TriggerConfig, compactErr error) {
+	defer func() {
+		if r := recover(); r != nil && s.logger != nil {
+			s.logger.Warn("post compaction hook panicked", slog.String("bot_id", cfg.BotID), slog.Any("panic", r))
+		}
+	}()
+	extra := map[string]any{}
+	if compactErr != nil {
+		extra["error"] = compactErr.Error()
+	}
+	if err := s.runCompactionHook(ctx, hooks.EventPostCompact, cfg, extra); err != nil && s.logger != nil {
+		s.logger.Warn("post compaction hook failed", slog.String("bot_id", cfg.BotID), slog.Any("error", err))
+	}
 }
 
 func (s *Service) runCompactionHook(ctx context.Context, eventName string, cfg TriggerConfig, extra map[string]any) error {

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -115,17 +115,11 @@ func (s *Service) TriggerCompaction(ctx context.Context, cfg TriggerConfig) {
 	}()
 }
 
-// RunCompactionSync runs compaction synchronously and returns any error. Use
-// RunCompactionSyncResult when the caller needs this session's scoped outcome.
-func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) error {
-	_, err := s.runCompaction(ctx, cfg)
-	return err
-}
-
-// RunCompactionSyncResult runs compaction synchronously and reports this
-// session's scoped Result, so callers respond with their own outcome instead of
-// reading an unscoped bot-wide log that may belong to another session.
-func (s *Service) RunCompactionSyncResult(ctx context.Context, cfg TriggerConfig) (Result, error) {
+// RunCompactionSync runs compaction synchronously and reports this session's
+// scoped Result, so callers act on their own outcome (a noop keeps their
+// current context) instead of reading an unscoped bot-wide log that may belong
+// to another session.
+func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) (Result, error) {
 	return s.runCompaction(ctx, cfg)
 }
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -146,24 +146,32 @@ func (s *Service) RunCompactionSync(ctx context.Context, cfg TriggerConfig) (Res
 		if owner == nil {
 			return res, err
 		}
-		owner.waiters.Add(1)
-		select {
-		case <-owner.done:
-			if cfg.Manual && owner.err == nil && owner.res.Status == StatusNoop {
-				// The owner may have been an automatic run that nooped on the
-				// failure cooldown; a manual request must still bypass it and
-				// attempt for real instead of inheriting the skip — unless the
-				// caller canceled while waiting, in which case retrying would
-				// start new side effects after cancellation.
-				if ctx.Err() != nil {
-					return Result{Status: StatusNoop}, nil
-				}
-				continue
-			}
-			return owner.res, owner.err
-		case <-ctx.Done():
-			return Result{Status: StatusNoop}, nil
+		res, retry, err := waitForOwner(ctx, cfg, owner)
+		if !retry {
+			return res, err
 		}
+	}
+}
+
+// waitForOwner blocks until the in-flight owner publishes its outcome or the
+// caller's context ends, reporting whether the caller should try again. Only
+// a manual request retries, and only through an owner that nooped without an
+// error — typically an automatic run skipped by the failure cooldown that the
+// manual request must still bypass. A canceled caller never retries: that
+// would start new side effects after cancellation.
+func waitForOwner(ctx context.Context, cfg TriggerConfig, owner *inflightRun) (Result, bool, error) {
+	owner.waiters.Add(1)
+	select {
+	case <-owner.done:
+		if cfg.Manual && owner.err == nil && owner.res.Status == StatusNoop {
+			if ctx.Err() != nil {
+				return Result{Status: StatusNoop}, false, nil
+			}
+			return Result{}, true, nil
+		}
+		return owner.res, false, owner.err
+	case <-ctx.Done():
+		return Result{Status: StatusNoop}, false, nil
 	}
 }
 

--- a/internal/compaction/service.go
+++ b/internal/compaction/service.go
@@ -3,7 +3,9 @@ package compaction
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -16,6 +18,11 @@ import (
 	"github.com/memohai/memoh/internal/hooks"
 	"github.com/memohai/memoh/internal/models"
 )
+
+// errEmptySummary marks a completed LLM call that produced no usable summary
+// text. The compacted rows must stay reclaimable, so this must never reach
+// MarkMessagesCompacted.
+var errEmptySummary = errors.New("compaction: model returned an empty summary")
 
 // Service manages context compaction for bot conversations.
 type Service struct {
@@ -256,6 +263,11 @@ func (s *Service) doCompaction(ctx context.Context, botUUID pgtype.UUID, session
 	if err != nil {
 		s.completeLog(persistCtx, logID, "error", "", err.Error(), 0, nil, pgtype.UUID{})
 		return err
+	}
+
+	if strings.TrimSpace(result.Text) == "" {
+		s.completeLog(persistCtx, logID, "error", "", errEmptySummary.Error(), 0, nil, pgtype.UUID{})
+		return errEmptySummary
 	}
 
 	usageJSON, _ := json.Marshal(result.Usage)

--- a/internal/compaction/service_barrier_test.go
+++ b/internal/compaction/service_barrier_test.go
@@ -38,7 +38,7 @@ func TestDoCompactionDoesNotSplitToolExchangeAtUnparseableBarrier(t *testing.T) 
 			q := &fakeQueries{uncompacted: rows}
 			stub := &stubModel{summary: "SUMMARY"}
 
-			if err := newMachineryService(q).RunCompactionSync(context.Background(), machineryConfig(stub, 200)); err != nil {
+			if _, err := newMachineryService(q).RunCompactionSync(context.Background(), machineryConfig(stub, 200)); err != nil {
 				t.Fatalf("RunCompactionSync: %v", err)
 			}
 

--- a/internal/compaction/service_barrier_test.go
+++ b/internal/compaction/service_barrier_test.go
@@ -15,9 +15,11 @@ func TestDoCompactionDoesNotSplitToolExchangeAtUnparseableBarrier(t *testing.T) 
 	tests := []struct {
 		name       string
 		breakIndex int
+		bareCall   bool
 	}{
 		{name: "call is unparseable", breakIndex: 0},
 		{name: "result is unparseable", breakIndex: 1},
+		{name: "bare call part is unparseable", breakIndex: 0, bareCall: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -28,6 +30,9 @@ func TestDoCompactionDoesNotSplitToolExchangeAtUnparseableBarrier(t *testing.T) 
 				mkRow(t, "assistant", `"old answer"`, 100),
 				mkRow(t, "user", `"current question"`, 100),
 				mkRow(t, "assistant", `"current answer"`, 100),
+			}
+			if tt.bareCall {
+				rows[0].Content = []byte(`{"type":"tool-call","toolCallId":"c1","toolName":"search","input":{}}`)
 			}
 			rows[tt.breakIndex].ID = pgtype.UUID{Valid: false}
 			q := &fakeQueries{uncompacted: rows}

--- a/internal/compaction/service_barrier_test.go
+++ b/internal/compaction/service_barrier_test.go
@@ -1,0 +1,45 @@
+package compaction
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+func TestDoCompactionDoesNotSplitToolExchangeAtUnparseableBarrier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		breakIndex int
+	}{
+		{name: "call is unparseable", breakIndex: 0},
+		{name: "result is unparseable", breakIndex: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := []sqlc.ListUncompactedMessagesBySessionRow{
+				toolCallRow(t, 100),
+				toolResultRow(t, 100),
+				mkRow(t, "user", `"old question"`, 100),
+				mkRow(t, "assistant", `"old answer"`, 100),
+				mkRow(t, "user", `"current question"`, 100),
+				mkRow(t, "assistant", `"current answer"`, 100),
+			}
+			rows[tt.breakIndex].ID = pgtype.UUID{Valid: false}
+			q := &fakeQueries{uncompacted: rows}
+			stub := &stubModel{summary: "SUMMARY"}
+
+			if err := newMachineryService(q).RunCompactionSync(context.Background(), machineryConfig(stub, 200)); err != nil {
+				t.Fatalf("RunCompactionSync: %v", err)
+			}
+
+			if len(q.markedIDs) != 2 || q.markedIDs[0] != rows[2].ID || q.markedIDs[1] != rows[3].ID {
+				t.Fatalf("marked ids = %#v, want only the complete run after the protected tool exchange", q.markedIDs)
+			}
+		})
+	}
+}

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -369,105 +371,88 @@ func TestDoCompactionEmptySummaryRecordsErrorWithoutMarking(t *testing.T) {
 	}
 }
 
-type gatedTransport struct {
-	started chan struct{}
-	release chan struct{}
-	inner   http.RoundTripper
-}
-
-func (g *gatedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	select {
-	case g.started <- struct{}{}:
-	default:
+func awaitWaiter(t *testing.T, run *inflightRun) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for run.waiters.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("waiter never attached to the in-flight owner")
+		}
+		runtime.Gosched()
 	}
-	<-g.release
-	return g.inner.RoundTrip(req)
 }
 
 func TestRunCompactionSyncWaitsForOwnerAndReusesItsResult(t *testing.T) {
-	rows := machineryCorpus(t)
-	q := &fakeQueries{uncompacted: rows}
-	stub := &stubModel{summary: "owner summary"}
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "unused"}
 	svc := newMachineryService(q)
-
 	cfg := machineryConfig(stub, 450)
-	gate := &gatedTransport{started: make(chan struct{}, 1), release: make(chan struct{}), inner: stub}
-	ownerCfg := cfg
-	ownerCfg.HTTPClient = &http.Client{Transport: gate}
 
-	ownerGot := make(chan Result, 1)
-	go func() {
-		res, err := svc.RunCompactionSync(context.Background(), ownerCfg)
-		if err != nil {
-			t.Errorf("owner: %v", err)
-		}
-		ownerGot <- res
-	}()
-	<-gate.started // the owner holds the session slot until its model call returns
+	run, ok := svc.beginSessionCompaction(cfg.SessionID)
+	if !ok {
+		t.Fatal("first acquisition must succeed")
+	}
 
-	waiterGot := make(chan Result, 1)
+	got := make(chan Result, 1)
 	go func() {
 		res, err := svc.RunCompactionSync(context.Background(), cfg)
 		if err != nil {
 			t.Errorf("waiter: %v", err)
 		}
-		waiterGot <- res
+		got <- res
 	}()
+	awaitWaiter(t, run)
 
-	close(gate.release)
-	ownerRes := <-ownerGot
-	waiterRes := <-waiterGot
-	if ownerRes.Status != StatusOK {
-		t.Fatalf("owner status = %q, want %q", ownerRes.Status, StatusOK)
+	want := Result{Status: StatusOK, Summary: "owner summary", MessageCount: 3}
+	svc.endSessionCompaction(cfg.SessionID, run, want, nil)
+
+	if res := <-got; res != want {
+		t.Fatalf("waiter must reuse the owner's result, got %#v", res)
 	}
-	if waiterRes != ownerRes {
-		t.Fatalf("waiter must reuse the owner's result: owner %#v waiter %#v", ownerRes, waiterRes)
-	}
-	if stub.calls != 1 {
-		t.Fatalf("model called %d times, want 1 (waiter must not double-run)", stub.calls)
+	if stub.calls != 0 || q.created || len(q.markedIDs) != 0 {
+		t.Fatalf("waiter must not run its own compaction (calls=%d created=%v marked=%d)", stub.calls, q.created, len(q.markedIDs))
 	}
 }
 
 func TestRunCompactionSyncCanceledWaiterDegradesToNoop(t *testing.T) {
-	rows := machineryCorpus(t)
-	q := &fakeQueries{uncompacted: rows}
-	stub := &stubModel{summary: "owner summary"}
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "healthy summary"}
 	svc := newMachineryService(q)
-
 	cfg := machineryConfig(stub, 450)
-	gate := &gatedTransport{started: make(chan struct{}, 1), release: make(chan struct{}), inner: stub}
-	ownerCfg := cfg
-	ownerCfg.HTTPClient = &http.Client{Transport: gate}
 
-	ownerGot := make(chan Result, 1)
-	go func() {
-		res, err := svc.RunCompactionSync(context.Background(), ownerCfg)
-		if err != nil {
-			t.Errorf("owner: %v", err)
-		}
-		ownerGot <- res
-	}()
-	<-gate.started
+	run, ok := svc.beginSessionCompaction(cfg.SessionID)
+	if !ok {
+		t.Fatal("first acquisition must succeed")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	waiterGot := make(chan Result, 1)
+	got := make(chan Result, 1)
 	go func() {
 		res, err := svc.RunCompactionSync(ctx, cfg)
 		if err != nil {
 			t.Errorf("canceled waiter: %v", err)
 		}
-		waiterGot <- res
+		got <- res
 	}()
+	awaitWaiter(t, run)
 	cancel()
-	if res := <-waiterGot; res.Status != StatusNoop {
+	if res := <-got; res.Status != StatusNoop {
 		t.Fatalf("canceled waiter must degrade to noop, got %#v", res)
 	}
-
-	close(gate.release)
-	if res := <-ownerGot; res.Status != StatusOK {
-		t.Fatalf("owner must still complete after a waiter cancels, got %#v", res)
+	if stub.calls != 0 || len(q.markedIDs) != 0 {
+		t.Fatalf("canceled waiter must not run compaction (calls=%d marked=%d)", stub.calls, len(q.markedIDs))
 	}
-	if stub.calls != 1 {
-		t.Fatalf("model called %d times, want 1", stub.calls)
+
+	svc.endSessionCompaction(cfg.SessionID, run, Result{Status: StatusNoop}, nil)
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("run after owner completion: %v", err)
+	}
+	if res.Status != StatusOK {
+		t.Fatalf("session must be usable after the owner completes, got %q", res.Status)
 	}
 }

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -369,22 +369,105 @@ func TestDoCompactionEmptySummaryRecordsErrorWithoutMarking(t *testing.T) {
 	}
 }
 
-func TestRunCompactionSkipsWhenSessionAlreadyInFlight(t *testing.T) {
+type gatedTransport struct {
+	started chan struct{}
+	release chan struct{}
+	inner   http.RoundTripper
+}
+
+func (g *gatedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	select {
+	case g.started <- struct{}{}:
+	default:
+	}
+	<-g.release
+	return g.inner.RoundTrip(req)
+}
+
+func TestRunCompactionSyncWaitsForOwnerAndReusesItsResult(t *testing.T) {
 	rows := machineryCorpus(t)
 	q := &fakeQueries{uncompacted: rows}
-	stub := &stubModel{summary: "unused"}
+	stub := &stubModel{summary: "owner summary"}
 	svc := newMachineryService(q)
 
 	cfg := machineryConfig(stub, 450)
-	if !svc.beginSessionCompaction(cfg.SessionID) {
-		t.Fatal("first acquisition must succeed")
-	}
-	defer svc.endSessionCompaction(cfg.SessionID)
+	gate := &gatedTransport{started: make(chan struct{}, 1), release: make(chan struct{}), inner: stub}
+	ownerCfg := cfg
+	ownerCfg.HTTPClient = &http.Client{Transport: gate}
 
-	if _, err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
-		t.Fatalf("in-flight skip must not error: %v", err)
+	ownerGot := make(chan Result, 1)
+	go func() {
+		res, err := svc.RunCompactionSync(context.Background(), ownerCfg)
+		if err != nil {
+			t.Errorf("owner: %v", err)
+		}
+		ownerGot <- res
+	}()
+	<-gate.started // the owner holds the session slot until its model call returns
+
+	waiterGot := make(chan Result, 1)
+	go func() {
+		res, err := svc.RunCompactionSync(context.Background(), cfg)
+		if err != nil {
+			t.Errorf("waiter: %v", err)
+		}
+		waiterGot <- res
+	}()
+
+	close(gate.release)
+	ownerRes := <-ownerGot
+	waiterRes := <-waiterGot
+	if ownerRes.Status != StatusOK {
+		t.Fatalf("owner status = %q, want %q", ownerRes.Status, StatusOK)
 	}
-	if stub.calls != 0 || q.created || len(q.markedIDs) != 0 {
-		t.Fatalf("in-flight session must skip entirely (calls=%d created=%v marked=%d)", stub.calls, q.created, len(q.markedIDs))
+	if waiterRes != ownerRes {
+		t.Fatalf("waiter must reuse the owner's result: owner %#v waiter %#v", ownerRes, waiterRes)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("model called %d times, want 1 (waiter must not double-run)", stub.calls)
+	}
+}
+
+func TestRunCompactionSyncCanceledWaiterDegradesToNoop(t *testing.T) {
+	rows := machineryCorpus(t)
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "owner summary"}
+	svc := newMachineryService(q)
+
+	cfg := machineryConfig(stub, 450)
+	gate := &gatedTransport{started: make(chan struct{}, 1), release: make(chan struct{}), inner: stub}
+	ownerCfg := cfg
+	ownerCfg.HTTPClient = &http.Client{Transport: gate}
+
+	ownerGot := make(chan Result, 1)
+	go func() {
+		res, err := svc.RunCompactionSync(context.Background(), ownerCfg)
+		if err != nil {
+			t.Errorf("owner: %v", err)
+		}
+		ownerGot <- res
+	}()
+	<-gate.started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	waiterGot := make(chan Result, 1)
+	go func() {
+		res, err := svc.RunCompactionSync(ctx, cfg)
+		if err != nil {
+			t.Errorf("canceled waiter: %v", err)
+		}
+		waiterGot <- res
+	}()
+	cancel()
+	if res := <-waiterGot; res.Status != StatusNoop {
+		t.Fatalf("canceled waiter must degrade to noop, got %#v", res)
+	}
+
+	close(gate.release)
+	if res := <-ownerGot; res.Status != StatusOK {
+		t.Fatalf("owner must still complete after a waiter cancels, got %#v", res)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("model called %d times, want 1", stub.calls)
 	}
 }

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -303,6 +303,55 @@ func TestDoCompactionMarksOnlyContiguousRunAcrossEmptyMiddleRow(t *testing.T) {
 	}
 }
 
+func TestRunCompactionSyncResultReportsScopedNoop(t *testing.T) {
+	// An already-compact/fresh session compacts nothing. The result must be a
+	// scoped no-op, so a caller (the HTTP endpoint) never has to fall back to an
+	// unscoped bot-wide log that could belong to another session.
+	q := &fakeQueries{}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+
+	res, err := svc.RunCompactionSyncResult(context.Background(), machineryConfig(stub, 100))
+	if err != nil {
+		t.Fatalf("no-op must not error: %v", err)
+	}
+	if res.Status != StatusNoop || res.MessageCount != 0 || res.Summary != "" {
+		t.Fatalf("no-op result = %+v, want noop/0/empty", res)
+	}
+	if stub.calls != 0 || q.created {
+		t.Fatalf("no-op must not call the model or create a log (calls=%d created=%v)", stub.calls, q.created)
+	}
+}
+
+func TestRunCompactionSyncResultReportsScopedSummaryOnSuccess(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "SUMMARY-OK"}
+	svc := newMachineryService(q)
+
+	res, err := svc.RunCompactionSyncResult(context.Background(), machineryConfig(stub, 450))
+	if err != nil {
+		t.Fatalf("RunCompactionSyncResult: %v", err)
+	}
+	if res.Status != StatusOK || res.Summary != "SUMMARY-OK" || res.MessageCount != len(q.markedIDs) {
+		t.Fatalf("success result = %+v, want ok/SUMMARY-OK/%d", res, len(q.markedIDs))
+	}
+}
+
+func TestRunCompactionSyncResultFailureSurfacesError(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	cfg := machineryConfig(&stubModel{}, 450)
+	cfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+
+	res, err := svc.RunCompactionSyncResult(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("a summarizer failure must surface an error, not a stale result")
+	}
+	if res.Status == StatusOK {
+		t.Fatalf("failed result must not report ok: %+v", res)
+	}
+}
+
 func TestDoCompactionEmptyHistoryNoOp(t *testing.T) {
 	q := &fakeQueries{}
 	stub := &stubModel{summary: "unused"}

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -211,6 +211,9 @@ func TestDoCompactionMarksToolAwareWindowAndRendersCleanPrompt(t *testing.T) {
 	if !strings.Contains(stub.prompt, "build ok done") {
 		t.Fatalf("structured tool outcome missing from prompt:\n%s", stub.prompt)
 	}
+	if !strings.Contains(stub.prompt, `"cmd":"make"`) {
+		t.Fatalf("tool call arguments missing from prompt:\n%s", stub.prompt)
+	}
 	if !strings.Contains(stub.prompt, "[media]") || strings.Contains(stub.prompt, "QUJDQUJDQUJD") {
 		t.Fatalf("base64 image result not scrubbed in prompt")
 	}

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -371,6 +371,75 @@ func TestRunCompactionFailureCooldownSkipsImmediateRetry(t *testing.T) {
 	}
 }
 
+func TestRunCompactionManualRequestBypassesFailureCooldown(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	autoCfg := machineryConfig(&stubModel{}, 450)
+	autoCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+	if err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
+		t.Fatal("first automatic attempt must run and fail, arming the cooldown")
+	}
+
+	// The user fixes the model and presses compact within the cooldown window.
+	// A manual request must actually run (not be skipped and reported as done):
+	// it compacts and reports a real result instead of a false success.
+	manualStub := &stubModel{summary: "recovered by manual run"}
+	manualCfg := autoCfg
+	manualCfg.Manual = true
+	manualCfg.HTTPClient = &http.Client{Transport: manualStub}
+	if err := svc.RunCompactionSync(context.Background(), manualCfg); err != nil {
+		t.Fatalf("manual compaction must run despite cooldown: %v", err)
+	}
+	if manualStub.calls != 1 {
+		t.Fatalf("manual request must call the model, not skip on cooldown (calls=%d)", manualStub.calls)
+	}
+	if !q.created || len(q.markedIDs) == 0 || q.completed.Status != "ok" {
+		t.Fatalf("manual run must do real work: created=%v marked=%d status=%q", q.created, len(q.markedIDs), q.completed.Status)
+	}
+
+	// An automatic request in the same window still respects the cooldown: the
+	// manual success above cleared it, so this one runs — proving cooldown is a
+	// shared per-session state that manual participates in, not a bypass leak.
+	autoRetry := &failingModel{}
+	autoRetryCfg := autoCfg
+	autoRetryCfg.HTTPClient = &http.Client{Transport: autoRetry}
+	if err := svc.RunCompactionSync(context.Background(), autoRetryCfg); err == nil {
+		t.Fatal("automatic retry after a successful manual run should proceed and fail")
+	}
+	if autoRetry.calls != 1 {
+		t.Fatalf("manual success must clear the shared cooldown for automatic runs too (calls=%d)", autoRetry.calls)
+	}
+}
+
+func TestRunCompactionManualFailureStillSurfacesError(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	autoCfg := machineryConfig(&stubModel{}, 450)
+	autoCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+	if err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
+		t.Fatal("automatic attempt must fail to arm the cooldown")
+	}
+
+	// A manual request that also fails must surface the real error, never a
+	// silent nil that callers render as "done".
+	manualFail := &failingModel{}
+	manualCfg := autoCfg
+	manualCfg.Manual = true
+	manualCfg.HTTPClient = &http.Client{Transport: manualFail}
+	if err := svc.RunCompactionSync(context.Background(), manualCfg); err == nil {
+		t.Fatal("a failing manual compaction must return an error, not a false success")
+	}
+	if manualFail.calls != 1 {
+		t.Fatalf("manual request must attempt the model despite cooldown (calls=%d)", manualFail.calls)
+	}
+}
+
 func TestRunCompactionFailureCooldownClearsOnSuccess(t *testing.T) {
 	q := &fakeQueries{uncompacted: machineryCorpus(t)}
 	svc := newMachineryService(q)

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -1,0 +1,264 @@
+package compaction
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+)
+
+// --- stub summarizer model (intercepts the SDK HTTP call) ---------------------
+
+type stubModel struct {
+	summary string
+	calls   int
+	prompt  string // decoded text of the captured request messages
+}
+
+func (s *stubModel) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.calls++
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		s.prompt = decodePromptMessages(body)
+	}
+	resp := `{"id":"stub","object":"chat.completion","created":0,"model":"stub",` +
+		`"choices":[{"index":0,"message":{"role":"assistant","content":` + jsonStr(s.summary) + `},"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120}}`
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(resp)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+func jsonStr(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func decodePromptMessages(body []byte) string {
+	var req struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	_ = json.Unmarshal(body, &req)
+	var sb strings.Builder
+	for _, m := range req.Messages {
+		var s string
+		if json.Unmarshal(m.Content, &s) == nil {
+			sb.WriteString(s)
+			sb.WriteByte('\n')
+			continue
+		}
+		var parts []struct {
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(m.Content, &parts) == nil {
+			for _, p := range parts {
+				sb.WriteString(p.Text)
+				sb.WriteByte('\n')
+			}
+		}
+	}
+	return sb.String()
+}
+
+// --- fake Queries (only the 5 methods compaction touches) ---------------------
+
+type fakeQueries struct {
+	dbstore.Queries // embedded interface; unimplemented methods would panic if called
+	uncompacted     []sqlc.ListUncompactedMessagesBySessionRow
+	priorLogs       []sqlc.BotHistoryMessageCompact
+
+	created   bool
+	markedIDs []pgtype.UUID
+	completed sqlc.CompleteCompactionLogParams
+}
+
+func (f *fakeQueries) CreateCompactionLog(_ context.Context, _ sqlc.CreateCompactionLogParams) (sqlc.BotHistoryMessageCompact, error) {
+	f.created = true
+	return sqlc.BotHistoryMessageCompact{ID: pgtype.UUID{Bytes: uuid.New(), Valid: true}}, nil
+}
+
+func (f *fakeQueries) ListUncompactedMessagesBySession(_ context.Context, _ pgtype.UUID) ([]sqlc.ListUncompactedMessagesBySessionRow, error) {
+	return f.uncompacted, nil
+}
+
+func (f *fakeQueries) ListCompactionLogsBySession(_ context.Context, _ pgtype.UUID) ([]sqlc.BotHistoryMessageCompact, error) {
+	return f.priorLogs, nil
+}
+
+func (f *fakeQueries) MarkMessagesCompacted(_ context.Context, arg sqlc.MarkMessagesCompactedParams) error {
+	f.markedIDs = append([]pgtype.UUID(nil), arg.Column2...)
+	return nil
+}
+
+func (f *fakeQueries) CompleteCompactionLog(_ context.Context, arg sqlc.CompleteCompactionLogParams) (sqlc.BotHistoryMessageCompact, error) {
+	f.completed = arg
+	return sqlc.BotHistoryMessageCompact{ID: arg.ID, Status: arg.Status, Summary: arg.Summary}, nil
+}
+
+// --- harness ------------------------------------------------------------------
+
+func newMachineryService(q dbstore.Queries) *Service {
+	return NewService(slog.New(slog.DiscardHandler), q)
+}
+
+func machineryConfig(stub *stubModel, targetTokens int) TriggerConfig {
+	return TriggerConfig{
+		BotID:        uuid.NewString(),
+		SessionID:    uuid.NewString(),
+		ModelID:      "stub-model",
+		ClientType:   "openai-completions",
+		APIKey:       "test",
+		BaseURL:      "http://stub.invalid",
+		HTTPClient:   &http.Client{Transport: stub},
+		TargetTokens: targetTokens,
+	}
+}
+
+func idSet(ids []pgtype.UUID) map[pgtype.UUID]bool {
+	m := make(map[pgtype.UUID]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+// machineryCorpus returns a deterministic session whose oldest portion contains
+// two tool exchanges (one base64-image result, one structured stdout result),
+// plus recent text turns. Indices are returned for precise assertions.
+func machineryCorpus(t *testing.T) []sqlc.ListUncompactedMessagesBySessionRow {
+	t.Helper()
+	b64 := strings.Repeat("QUJD", 100) // 400 base64 chars
+	return []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `[{"type":"text","text":"deploy please"}]`, 100),                                                                                          // 0
+		mkRow(t, "assistant", `[{"type":"text","text":"on it"},{"type":"tool-call","toolCallId":"A","toolName":"screenshot","input":{}}]`, 100),                    // 1 call A
+		mkRow(t, "tool", `[{"type":"tool-result","toolCallId":"A","toolName":"screenshot","result":{"mime":"image/png","data":"`+b64+`"}}]`, 100),                  // 2 result A (base64)
+		mkRow(t, "assistant", `[{"type":"text","text":"captured the screen"}]`, 100),                                                                               // 3
+		mkRow(t, "user", `[{"type":"text","text":"now build"}]`, 100),                                                                                              // 4
+		mkRow(t, "assistant", `[{"type":"text","text":"running"},{"type":"tool-call","toolCallId":"B","toolName":"exec_command","input":{"cmd":"make"}}]`, 100),    // 5 call B
+		mkRow(t, "tool", `[{"type":"tool-result","toolCallId":"B","toolName":"exec_command","result":{"exit_code":0,"stdout":"build ok done","stderr":""}}]`, 100), // 6 result B (structured)
+		mkRow(t, "assistant", `[{"type":"text","text":"build finished"}]`, 100),                                                                                    // 7
+		mkRow(t, "user", `[{"type":"text","text":"recent question"}]`, 100),                                                                                        // 8
+		mkRow(t, "assistant", `[{"type":"text","text":"recent answer"}]`, 100),                                                                                     // 9
+	}
+}
+
+// --- tests --------------------------------------------------------------------
+
+func TestDoCompactionMarksToolAwareWindowAndRendersCleanPrompt(t *testing.T) {
+	rows := machineryCorpus(t)
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "SUMMARY-OK"}
+	svc := newMachineryService(q)
+
+	// 10 msgs x 100 tokens. target 450: the naive cut would land at index 6
+	// (compact 0..5, keep 6..9) — orphaning tool result B at the keep-side head.
+	// The boundary guard must advance to 7, pulling result B in with its call, so
+	// the marked set is exactly 0..6. If adjustForToolBoundary regressed, this
+	// marks only 0..5 and the assertions below fail.
+	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+
+	if stub.calls != 1 {
+		t.Fatalf("summarizer called %d times, want 1", stub.calls)
+	}
+	if len(q.markedIDs) != 7 {
+		t.Fatalf("marked %d messages, want 7 (0..6, tool exchange kept whole)", len(q.markedIDs))
+	}
+	marked := idSet(q.markedIDs)
+	for i := 0; i <= 6; i++ {
+		if !marked[rows[i].ID] {
+			t.Fatalf("row %d should be marked compacted", i)
+		}
+	}
+	for i := 7; i <= 9; i++ {
+		if marked[rows[i].ID] {
+			t.Fatalf("row %d (recent) should NOT be marked", i)
+		}
+	}
+	if !marked[rows[6].ID] {
+		t.Fatalf("tool result B must be pulled into the compact set with its call")
+	}
+	if q.completed.Status != "ok" || q.completed.Summary != "SUMMARY-OK" || q.completed.MessageCount != 7 {
+		t.Fatalf("complete log = status=%q summary=%q count=%d", q.completed.Status, q.completed.Summary, q.completed.MessageCount)
+	}
+
+	// The summarizer prompt must carry clean rendered outcomes, no media, no noise.
+	if !strings.Contains(stub.prompt, "build ok done") {
+		t.Fatalf("structured tool outcome missing from prompt:\n%s", stub.prompt)
+	}
+	if !strings.Contains(stub.prompt, "[media]") || strings.Contains(stub.prompt, "QUJDQUJDQUJD") {
+		t.Fatalf("base64 image result not scrubbed in prompt")
+	}
+	if strings.Contains(stub.prompt, `{"type":"text"`) || strings.Contains(stub.prompt, `"toolCallId"`) {
+		t.Fatalf("raw JSON-envelope noise leaked into prompt:\n%s", stub.prompt)
+	}
+}
+
+func TestDoCompactionInjectsPriorContext(t *testing.T) {
+	rows := machineryCorpus(t)
+	q := &fakeQueries{
+		uncompacted: rows,
+		priorLogs:   []sqlc.BotHistoryMessageCompact{{Summary: "earlier-segment-summary", Status: "ok"}},
+	}
+	stub := &stubModel{summary: "S2"}
+	svc := newMachineryService(q)
+
+	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if !strings.Contains(stub.prompt, "prior_context") || !strings.Contains(stub.prompt, "earlier-segment-summary") {
+		t.Fatalf("prior summary not injected as prior context:\n%s", stub.prompt)
+	}
+}
+
+func TestDoCompactionAllEmptyWindowSkipsModelAndMarking(t *testing.T) {
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"thinking a"}]`, 100),
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"thinking b"}]`, 100),
+		mkRow(t, "assistant", `[{"type":"text","text":"recent kept"}]`, 100),
+	}
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+
+	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 150)); err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("summarizer should not be called for an all-empty window (calls=%d)", stub.calls)
+	}
+	if len(q.markedIDs) != 0 {
+		t.Fatalf("nothing should be marked for an all-empty window (marked=%d)", len(q.markedIDs))
+	}
+	if q.completed.Status != "ok" || q.completed.MessageCount != 0 {
+		t.Fatalf("all-empty window should complete ok with count 0, got status=%q count=%d", q.completed.Status, q.completed.MessageCount)
+	}
+}
+
+func TestDoCompactionEmptyHistoryNoOp(t *testing.T) {
+	q := &fakeQueries{}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+
+	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 100)); err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if stub.calls != 0 || len(q.markedIDs) != 0 {
+		t.Fatalf("empty history must be a no-op (calls=%d marked=%d)", stub.calls, len(q.markedIDs))
+	}
+}

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -83,6 +83,7 @@ type fakeQueries struct {
 	uncompacted     []sqlc.ListUncompactedMessagesBySessionRow
 	priorLogs       []sqlc.BotHistoryMessageCompact
 	completeErr     error
+	listPanic       bool
 
 	created   bool
 	markedIDs []pgtype.UUID
@@ -95,6 +96,9 @@ func (f *fakeQueries) CreateCompactionLog(_ context.Context, _ sqlc.CreateCompac
 }
 
 func (f *fakeQueries) ListUncompactedMessagesBySession(_ context.Context, _ pgtype.UUID) ([]sqlc.ListUncompactedMessagesBySessionRow, error) {
+	if f.listPanic {
+		panic("boom: injected query panic")
+	}
 	return f.uncompacted, nil
 }
 

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -3,6 +3,7 @@ package compaction
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -257,6 +258,44 @@ func TestDoCompactionSkipsWhitespaceOnlyPriorSummaries(t *testing.T) {
 	}
 	if strings.Contains(stub.prompt, "The following are summaries of earlier parts") {
 		t.Fatalf("whitespace-only prior summary injected as prior context:\n%s", stub.prompt)
+	}
+}
+
+// TestDoCompactionWarnsWhenEntryFloorsExceedBudget drives one unsplittable
+// tool exchange with more minimal entries than MaxCompactTokens can hold:
+// the progress guarantee still compacts it, but the overshoot must be
+// surfaced instead of silently trusted as capped.
+func TestDoCompactionWarnsWhenEntryFloorsExceedBudget(t *testing.T) {
+	const fanout = 40
+	callParts := make([]string, 0, fanout)
+	for i := 0; i < fanout; i++ {
+		callParts = append(callParts, fmt.Sprintf(`{"type":"tool-call","toolCallId":"c%d","toolName":"probe","input":{}}`, i))
+	}
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "assistant", "["+strings.Join(callParts, ",")+"]", 100),
+	}
+	for i := 0; i < fanout; i++ {
+		rows = append(rows, mkRow(t, "tool", fmt.Sprintf(`[{"type":"tool-result","toolCallId":"c%d","toolName":"probe","output":{"type":"text","value":"ok"}}]`, i), 100))
+	}
+	rows = append(rows, mkRow(t, "user", `[{"type":"text","text":"recent question"}]`, 100))
+
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "SUMMARY-OK"}
+	var logBuf strings.Builder
+	svc := NewService(slog.New(slog.NewTextHandler(&logBuf, nil)), q)
+
+	cfg := machineryConfig(stub, 100)
+	cfg.MaxCompactTokens = 40
+
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != StatusOK {
+		t.Fatalf("the oversized exchange must still compact (progress guarantee), got %q", res.Status)
+	}
+	if !strings.Contains(logBuf.String(), "entry floors exceed the budget") {
+		t.Fatalf("budget overshoot not surfaced in logs:\n%s", logBuf.String())
 	}
 }
 

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -251,6 +251,30 @@ func TestDoCompactionAllEmptyWindowSkipsModelAndMarking(t *testing.T) {
 	}
 }
 
+func TestDoCompactionIncompleteToolExchangeSkipsModelAndMarking(t *testing.T) {
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		toolCallRow(t, 100),
+		mkRow(t, "tool", `[]`, 100),
+		mkRow(t, "assistant", `[{"type":"text","text":"recent kept"}]`, 100),
+	}
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+
+	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 150)); err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("summarizer should not be called when no row can be marked (calls=%d)", stub.calls)
+	}
+	if q.created {
+		t.Fatal("a no-op compaction must not create a log row")
+	}
+	if len(q.markedIDs) != 0 {
+		t.Fatalf("nothing should be marked for an incomplete tool exchange (marked=%d)", len(q.markedIDs))
+	}
+}
+
 func TestDoCompactionEmptyHistoryNoOp(t *testing.T) {
 	q := &fakeQueries{}
 	stub := &stubModel{summary: "unused"}

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -82,6 +82,7 @@ type fakeQueries struct {
 	dbstore.Queries // embedded interface; unimplemented methods would panic if called
 	uncompacted     []sqlc.ListUncompactedMessagesBySessionRow
 	priorLogs       []sqlc.BotHistoryMessageCompact
+	completeErr     error
 
 	created   bool
 	markedIDs []pgtype.UUID
@@ -107,6 +108,9 @@ func (f *fakeQueries) MarkMessagesCompacted(_ context.Context, arg sqlc.MarkMess
 }
 
 func (f *fakeQueries) CompleteCompactionLog(_ context.Context, arg sqlc.CompleteCompactionLogParams) (sqlc.BotHistoryMessageCompact, error) {
+	if f.completeErr != nil {
+		return sqlc.BotHistoryMessageCompact{}, f.completeErr
+	}
 	f.completed = arg
 	return sqlc.BotHistoryMessageCompact{ID: arg.ID, Status: arg.Status, Summary: arg.Summary}, nil
 }
@@ -635,5 +639,21 @@ func TestRunCompactionSyncModelFailureStillArmsCooldown(t *testing.T) {
 	}
 	if stub.calls != 0 {
 		t.Fatalf("model called %d times during cooldown, want 0", stub.calls)
+	}
+}
+
+func TestRunCompactionSyncSurfacesCompletionPersistenceFailure(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t), completeErr: errors.New("db down")}
+	svc := newMachineryService(q)
+	stub := &stubModel{summary: "durable summary"}
+
+	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 200))
+	if err == nil {
+		t.Fatal("completion persistence failure must surface an error")
+	}
+	if res.Status == StatusOK {
+		t.Fatal("result must not claim ok when the summary was never persisted")
 	}
 }

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -84,6 +84,7 @@ type fakeQueries struct {
 	priorLogs       []sqlc.BotHistoryMessageCompact
 	completeErr     error
 	listPanic       bool
+	onComplete      func()
 
 	created   bool
 	markedIDs []pgtype.UUID
@@ -112,6 +113,9 @@ func (f *fakeQueries) MarkMessagesCompacted(_ context.Context, arg sqlc.MarkMess
 }
 
 func (f *fakeQueries) CompleteCompactionLog(_ context.Context, arg sqlc.CompleteCompactionLogParams) (sqlc.BotHistoryMessageCompact, error) {
+	if f.onComplete != nil {
+		f.onComplete()
+	}
 	if f.completeErr != nil {
 		return sqlc.BotHistoryMessageCompact{}, f.completeErr
 	}

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -275,6 +275,34 @@ func TestDoCompactionIncompleteToolExchangeSkipsModelAndMarking(t *testing.T) {
 	}
 }
 
+func TestDoCompactionMarksOnlyContiguousRunAcrossEmptyMiddleRow(t *testing.T) {
+	// Window: an empty-rendering reasoning row sits between two rendered rows.
+	// Marking both rendered rows under one compact_id would leave the raw
+	// reasoning row between them and let the read path fold history out of
+	// order. doCompaction must mark only the first contiguous run (row 0) and
+	// leave row 2 for a later pass.
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `[{"type":"text","text":"old question"}]`, 100),       // 0
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"thinking"}]`, 100), // 1 renders empty
+		mkRow(t, "assistant", `[{"type":"text","text":"old answer"}]`, 100),    // 2
+		mkRow(t, "user", `[{"type":"text","text":"recent question"}]`, 100),    // 3 kept
+		mkRow(t, "assistant", `[{"type":"text","text":"recent answer"}]`, 100), // 4 kept
+	}
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "SUMMARY"}
+	svc := newMachineryService(q)
+
+	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 250)); err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if len(q.markedIDs) != 1 || q.markedIDs[0] != rows[0].ID {
+		t.Fatalf("marked = %d ids, want only the contiguous leading run [row 0]", len(q.markedIDs))
+	}
+	if q.completed.Status != "ok" || q.completed.MessageCount != 1 {
+		t.Fatalf("complete log = status=%q count=%d, want ok/1", q.completed.Status, q.completed.MessageCount)
+	}
+}
+
 func TestDoCompactionEmptyHistoryNoOp(t *testing.T) {
 	q := &fakeQueries{}
 	stub := &stubModel{summary: "unused"}

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -3,13 +3,11 @@ package compaction
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -308,55 +306,6 @@ func TestDoCompactionMarksOnlyContiguousRunAcrossEmptyMiddleRow(t *testing.T) {
 	}
 }
 
-func TestRunCompactionSyncReportsScopedNoop(t *testing.T) {
-	// An already-compact/fresh session compacts nothing. The result must be a
-	// scoped no-op, so a caller (the HTTP endpoint) never has to fall back to an
-	// unscoped bot-wide log that could belong to another session.
-	q := &fakeQueries{}
-	stub := &stubModel{summary: "unused"}
-	svc := newMachineryService(q)
-
-	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 100))
-	if err != nil {
-		t.Fatalf("no-op must not error: %v", err)
-	}
-	if res.Status != StatusNoop || res.MessageCount != 0 || res.Summary != "" {
-		t.Fatalf("no-op result = %+v, want noop/0/empty", res)
-	}
-	if stub.calls != 0 || q.created {
-		t.Fatalf("no-op must not call the model or create a log (calls=%d created=%v)", stub.calls, q.created)
-	}
-}
-
-func TestRunCompactionSyncReportsScopedSummaryOnSuccess(t *testing.T) {
-	q := &fakeQueries{uncompacted: machineryCorpus(t)}
-	stub := &stubModel{summary: "SUMMARY-OK"}
-	svc := newMachineryService(q)
-
-	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450))
-	if err != nil {
-		t.Fatalf("RunCompactionSync: %v", err)
-	}
-	if res.Status != StatusOK || res.Summary != "SUMMARY-OK" || res.MessageCount != len(q.markedIDs) {
-		t.Fatalf("success result = %+v, want ok/SUMMARY-OK/%d", res, len(q.markedIDs))
-	}
-}
-
-func TestRunCompactionSyncFailureSurfacesError(t *testing.T) {
-	q := &fakeQueries{uncompacted: machineryCorpus(t)}
-	svc := newMachineryService(q)
-	cfg := machineryConfig(&stubModel{}, 450)
-	cfg.HTTPClient = &http.Client{Transport: &failingModel{}}
-
-	res, err := svc.RunCompactionSync(context.Background(), cfg)
-	if err == nil {
-		t.Fatal("a summarizer failure must surface an error, not a stale result")
-	}
-	if res.Status == StatusOK {
-		t.Fatalf("failed result must not report ok: %+v", res)
-	}
-}
-
 func TestDoCompactionEmptyHistoryNoOp(t *testing.T) {
 	q := &fakeQueries{}
 	stub := &stubModel{summary: "unused"}
@@ -420,144 +369,6 @@ func TestDoCompactionEmptySummaryRecordsErrorWithoutMarking(t *testing.T) {
 	}
 }
 
-func TestRunCompactionFailureCooldownSkipsImmediateRetry(t *testing.T) {
-	q := &fakeQueries{uncompacted: machineryCorpus(t)}
-	svc := newMachineryService(q)
-	now := time.Now()
-	svc.nowFn = func() time.Time { return now }
-
-	cfg := machineryConfig(&stubModel{}, 450)
-	fail := &failingModel{}
-	cfg.HTTPClient = &http.Client{Transport: fail}
-
-	if _, err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
-		t.Fatal("first attempt must run and fail")
-	}
-	if fail.calls != 1 {
-		t.Fatalf("calls = %d, want 1", fail.calls)
-	}
-
-	if _, err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
-		t.Fatalf("cooldown skip must not surface an error: %v", err)
-	}
-	if fail.calls != 1 {
-		t.Fatalf("immediate retry within cooldown must be skipped, calls=%d", fail.calls)
-	}
-
-	now = now.Add(compactionFailureCooldown + time.Second)
-	if _, err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
-		t.Fatal("attempt after cooldown must run and fail again")
-	}
-	if fail.calls != 2 {
-		t.Fatalf("attempt after cooldown should run, calls=%d", fail.calls)
-	}
-}
-
-func TestRunCompactionManualRequestBypassesFailureCooldown(t *testing.T) {
-	q := &fakeQueries{uncompacted: machineryCorpus(t)}
-	svc := newMachineryService(q)
-	now := time.Now()
-	svc.nowFn = func() time.Time { return now }
-
-	autoCfg := machineryConfig(&stubModel{}, 450)
-	autoCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
-	if _, err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
-		t.Fatal("first automatic attempt must run and fail, arming the cooldown")
-	}
-
-	// The user fixes the model and presses compact within the cooldown window.
-	// A manual request must actually run (not be skipped and reported as done):
-	// it compacts and reports a real result instead of a false success.
-	manualStub := &stubModel{summary: "recovered by manual run"}
-	manualCfg := autoCfg
-	manualCfg.Manual = true
-	manualCfg.HTTPClient = &http.Client{Transport: manualStub}
-	if _, err := svc.RunCompactionSync(context.Background(), manualCfg); err != nil {
-		t.Fatalf("manual compaction must run despite cooldown: %v", err)
-	}
-	if manualStub.calls != 1 {
-		t.Fatalf("manual request must call the model, not skip on cooldown (calls=%d)", manualStub.calls)
-	}
-	if !q.created || len(q.markedIDs) == 0 || q.completed.Status != "ok" {
-		t.Fatalf("manual run must do real work: created=%v marked=%d status=%q", q.created, len(q.markedIDs), q.completed.Status)
-	}
-
-	// An automatic request in the same window still respects the cooldown: the
-	// manual success above cleared it, so this one runs — proving cooldown is a
-	// shared per-session state that manual participates in, not a bypass leak.
-	autoRetry := &failingModel{}
-	autoRetryCfg := autoCfg
-	autoRetryCfg.HTTPClient = &http.Client{Transport: autoRetry}
-	if _, err := svc.RunCompactionSync(context.Background(), autoRetryCfg); err == nil {
-		t.Fatal("automatic retry after a successful manual run should proceed and fail")
-	}
-	if autoRetry.calls != 1 {
-		t.Fatalf("manual success must clear the shared cooldown for automatic runs too (calls=%d)", autoRetry.calls)
-	}
-}
-
-func TestRunCompactionManualFailureStillSurfacesError(t *testing.T) {
-	q := &fakeQueries{uncompacted: machineryCorpus(t)}
-	svc := newMachineryService(q)
-	now := time.Now()
-	svc.nowFn = func() time.Time { return now }
-
-	autoCfg := machineryConfig(&stubModel{}, 450)
-	autoCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
-	if _, err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
-		t.Fatal("automatic attempt must fail to arm the cooldown")
-	}
-
-	// A manual request that also fails must surface the real error, never a
-	// silent nil that callers render as "done".
-	manualFail := &failingModel{}
-	manualCfg := autoCfg
-	manualCfg.Manual = true
-	manualCfg.HTTPClient = &http.Client{Transport: manualFail}
-	if _, err := svc.RunCompactionSync(context.Background(), manualCfg); err == nil {
-		t.Fatal("a failing manual compaction must return an error, not a false success")
-	}
-	if manualFail.calls != 1 {
-		t.Fatalf("manual request must attempt the model despite cooldown (calls=%d)", manualFail.calls)
-	}
-}
-
-func TestRunCompactionFailureCooldownClearsOnSuccess(t *testing.T) {
-	q := &fakeQueries{uncompacted: machineryCorpus(t)}
-	svc := newMachineryService(q)
-	now := time.Now()
-	svc.nowFn = func() time.Time { return now }
-
-	sessionCfg := machineryConfig(&stubModel{}, 450)
-
-	failCfg := sessionCfg
-	failCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
-	if _, err := svc.RunCompactionSync(context.Background(), failCfg); err == nil {
-		t.Fatal("expected initial failure")
-	}
-
-	now = now.Add(compactionFailureCooldown + time.Second)
-	successStub := &stubModel{summary: "recovered"}
-	successCfg := sessionCfg
-	successCfg.HTTPClient = &http.Client{Transport: successStub}
-	if _, err := svc.RunCompactionSync(context.Background(), successCfg); err != nil {
-		t.Fatalf("attempt after cooldown should succeed: %v", err)
-	}
-	if successStub.calls != 1 {
-		t.Fatalf("success attempt should have called the model once, got %d", successStub.calls)
-	}
-
-	retryFail := &failingModel{}
-	retryCfg := sessionCfg
-	retryCfg.HTTPClient = &http.Client{Transport: retryFail}
-	if _, err := svc.RunCompactionSync(context.Background(), retryCfg); err == nil {
-		t.Fatal("expected failure from immediate retry model")
-	}
-	if retryFail.calls != 1 {
-		t.Fatalf("success must have cleared the cooldown, allowing an immediate retry; calls=%d", retryFail.calls)
-	}
-}
-
 func TestRunCompactionSkipsWhenSessionAlreadyInFlight(t *testing.T) {
 	rows := machineryCorpus(t)
 	q := &fakeQueries{uncompacted: rows}
@@ -575,85 +386,5 @@ func TestRunCompactionSkipsWhenSessionAlreadyInFlight(t *testing.T) {
 	}
 	if stub.calls != 0 || q.created || len(q.markedIDs) != 0 {
 		t.Fatalf("in-flight session must skip entirely (calls=%d created=%v marked=%d)", stub.calls, q.created, len(q.markedIDs))
-	}
-}
-
-type errTransport struct{ err error }
-
-func (t errTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, t.err }
-
-func TestRunCompactionSyncInterruptedRunDoesNotArmCooldown(t *testing.T) {
-	t.Parallel()
-
-	for _, tc := range []struct {
-		name string
-		err  error
-	}{
-		{"canceled mid-call", context.Canceled},
-		{"deadline exceeded mid-call", context.DeadlineExceeded},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			q := &fakeQueries{uncompacted: machineryCorpus(t)}
-			svc := newMachineryService(q)
-			stub := &stubModel{summary: "recovered summary"}
-			cfg := machineryConfig(stub, 200)
-
-			interrupted := cfg
-			interrupted.HTTPClient = &http.Client{Transport: errTransport{err: tc.err}}
-			if _, err := svc.RunCompactionSync(context.Background(), interrupted); err == nil {
-				t.Fatal("interrupted run must surface an error")
-			}
-
-			res, err := svc.RunCompactionSync(context.Background(), cfg)
-			if err != nil {
-				t.Fatalf("run after interruption: %v", err)
-			}
-			if res.Status != StatusOK {
-				t.Fatalf("status after interruption = %q, want %q (cooldown must not be armed)", res.Status, StatusOK)
-			}
-		})
-	}
-}
-
-func TestRunCompactionSyncModelFailureStillArmsCooldown(t *testing.T) {
-	t.Parallel()
-
-	q := &fakeQueries{uncompacted: machineryCorpus(t)}
-	svc := newMachineryService(q)
-	stub := &stubModel{summary: "healthy summary"}
-	cfg := machineryConfig(stub, 200)
-
-	failing := cfg
-	failing.HTTPClient = &http.Client{Transport: errTransport{err: errors.New("upstream 500")}}
-	if _, err := svc.RunCompactionSync(context.Background(), failing); err == nil {
-		t.Fatal("failing run must surface an error")
-	}
-
-	res, err := svc.RunCompactionSync(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("run during cooldown: %v", err)
-	}
-	if res.Status != StatusNoop {
-		t.Fatalf("status during cooldown = %q, want %q", res.Status, StatusNoop)
-	}
-	if stub.calls != 0 {
-		t.Fatalf("model called %d times during cooldown, want 0", stub.calls)
-	}
-}
-
-func TestRunCompactionSyncSurfacesCompletionPersistenceFailure(t *testing.T) {
-	t.Parallel()
-
-	q := &fakeQueries{uncompacted: machineryCorpus(t), completeErr: errors.New("db down")}
-	svc := newMachineryService(q)
-	stub := &stubModel{summary: "durable summary"}
-
-	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 200))
-	if err == nil {
-		t.Fatal("completion persistence failure must surface an error")
-	}
-	if res.Status == StatusOK {
-		t.Fatal("result must not claim ok when the summary was never persisted")
 	}
 }

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -245,8 +245,8 @@ func TestDoCompactionAllEmptyWindowSkipsModelAndMarking(t *testing.T) {
 	if len(q.markedIDs) != 0 {
 		t.Fatalf("nothing should be marked for an all-empty window (marked=%d)", len(q.markedIDs))
 	}
-	if q.completed.Status != "ok" || q.completed.MessageCount != 0 {
-		t.Fatalf("all-empty window should complete ok with count 0, got status=%q count=%d", q.completed.Status, q.completed.MessageCount)
+	if q.created {
+		t.Fatal("a no-op compaction must not create a log row")
 	}
 }
 
@@ -260,5 +260,58 @@ func TestDoCompactionEmptyHistoryNoOp(t *testing.T) {
 	}
 	if stub.calls != 0 || len(q.markedIDs) != 0 {
 		t.Fatalf("empty history must be a no-op (calls=%d marked=%d)", stub.calls, len(q.markedIDs))
+	}
+	if q.created {
+		t.Fatal("empty history must not create a log row")
+	}
+}
+
+type failingModel struct{ calls int }
+
+func (f *failingModel) RoundTrip(*http.Request) (*http.Response, error) {
+	f.calls++
+	return &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"boom"}}`)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+func TestDoCompactionSummarizerFailureRecordsErrorWithoutMarking(t *testing.T) {
+	rows := machineryCorpus(t)
+	q := &fakeQueries{uncompacted: rows}
+	svc := newMachineryService(q)
+
+	cfg := machineryConfig(&stubModel{}, 450)
+	cfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+
+	if err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
+		t.Fatal("summarizer failure must surface an error")
+	}
+	if len(q.markedIDs) != 0 {
+		t.Fatalf("nothing may be marked when the summarizer fails (marked=%d)", len(q.markedIDs))
+	}
+	if !q.created || q.completed.Status != "error" {
+		t.Fatalf("a failed attempt must leave an error log row (created=%v status=%q)", q.created, q.completed.Status)
+	}
+}
+
+func TestRunCompactionSkipsWhenSessionAlreadyInFlight(t *testing.T) {
+	rows := machineryCorpus(t)
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+
+	cfg := machineryConfig(stub, 450)
+	if !svc.beginSessionCompaction(cfg.SessionID) {
+		t.Fatal("first acquisition must succeed")
+	}
+	defer svc.endSessionCompaction(cfg.SessionID)
+
+	if err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
+		t.Fatalf("in-flight skip must not error: %v", err)
+	}
+	if stub.calls != 0 || q.created || len(q.markedIDs) != 0 {
+		t.Fatalf("in-flight session must skip entirely (calls=%d created=%v marked=%d)", stub.calls, q.created, len(q.markedIDs))
 	}
 }

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -310,6 +311,75 @@ func TestDoCompactionEmptySummaryRecordsErrorWithoutMarking(t *testing.T) {
 	}
 	if !q.created || q.completed.Status != "error" {
 		t.Fatalf("an empty summary must leave an error log row (created=%v status=%q)", q.created, q.completed.Status)
+	}
+}
+
+func TestRunCompactionFailureCooldownSkipsImmediateRetry(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	cfg := machineryConfig(&stubModel{}, 450)
+	fail := &failingModel{}
+	cfg.HTTPClient = &http.Client{Transport: fail}
+
+	if err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
+		t.Fatal("first attempt must run and fail")
+	}
+	if fail.calls != 1 {
+		t.Fatalf("calls = %d, want 1", fail.calls)
+	}
+
+	if err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
+		t.Fatalf("cooldown skip must not surface an error: %v", err)
+	}
+	if fail.calls != 1 {
+		t.Fatalf("immediate retry within cooldown must be skipped, calls=%d", fail.calls)
+	}
+
+	now = now.Add(compactionFailureCooldown + time.Second)
+	if err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
+		t.Fatal("attempt after cooldown must run and fail again")
+	}
+	if fail.calls != 2 {
+		t.Fatalf("attempt after cooldown should run, calls=%d", fail.calls)
+	}
+}
+
+func TestRunCompactionFailureCooldownClearsOnSuccess(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	sessionCfg := machineryConfig(&stubModel{}, 450)
+
+	failCfg := sessionCfg
+	failCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+	if err := svc.RunCompactionSync(context.Background(), failCfg); err == nil {
+		t.Fatal("expected initial failure")
+	}
+
+	now = now.Add(compactionFailureCooldown + time.Second)
+	successStub := &stubModel{summary: "recovered"}
+	successCfg := sessionCfg
+	successCfg.HTTPClient = &http.Client{Transport: successStub}
+	if err := svc.RunCompactionSync(context.Background(), successCfg); err != nil {
+		t.Fatalf("attempt after cooldown should succeed: %v", err)
+	}
+	if successStub.calls != 1 {
+		t.Fatalf("success attempt should have called the model once, got %d", successStub.calls)
+	}
+
+	retryFail := &failingModel{}
+	retryCfg := sessionCfg
+	retryCfg.HTTPClient = &http.Client{Transport: retryFail}
+	if err := svc.RunCompactionSync(context.Background(), retryCfg); err == nil {
+		t.Fatal("expected failure from immediate retry model")
+	}
+	if retryFail.calls != 1 {
+		t.Fatalf("success must have cleared the cooldown, allowing an immediate retry; calls=%d", retryFail.calls)
 	}
 }
 

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -3,6 +3,7 @@ package compaction
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -570,5 +571,69 @@ func TestRunCompactionSkipsWhenSessionAlreadyInFlight(t *testing.T) {
 	}
 	if stub.calls != 0 || q.created || len(q.markedIDs) != 0 {
 		t.Fatalf("in-flight session must skip entirely (calls=%d created=%v marked=%d)", stub.calls, q.created, len(q.markedIDs))
+	}
+}
+
+type errTransport struct{ err error }
+
+func (t errTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, t.err }
+
+func TestRunCompactionSyncInterruptedRunDoesNotArmCooldown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"canceled mid-call", context.Canceled},
+		{"deadline exceeded mid-call", context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &fakeQueries{uncompacted: machineryCorpus(t)}
+			svc := newMachineryService(q)
+			stub := &stubModel{summary: "recovered summary"}
+			cfg := machineryConfig(stub, 200)
+
+			interrupted := cfg
+			interrupted.HTTPClient = &http.Client{Transport: errTransport{err: tc.err}}
+			if _, err := svc.RunCompactionSync(context.Background(), interrupted); err == nil {
+				t.Fatal("interrupted run must surface an error")
+			}
+
+			res, err := svc.RunCompactionSync(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("run after interruption: %v", err)
+			}
+			if res.Status != StatusOK {
+				t.Fatalf("status after interruption = %q, want %q (cooldown must not be armed)", res.Status, StatusOK)
+			}
+		})
+	}
+}
+
+func TestRunCompactionSyncModelFailureStillArmsCooldown(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	stub := &stubModel{summary: "healthy summary"}
+	cfg := machineryConfig(stub, 200)
+
+	failing := cfg
+	failing.HTTPClient = &http.Client{Transport: errTransport{err: errors.New("upstream 500")}}
+	if _, err := svc.RunCompactionSync(context.Background(), failing); err == nil {
+		t.Fatal("failing run must surface an error")
+	}
+
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("run during cooldown: %v", err)
+	}
+	if res.Status != StatusNoop {
+		t.Fatalf("status during cooldown = %q, want %q", res.Status, StatusNoop)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("model called %d times during cooldown, want 0", stub.calls)
 	}
 }

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -239,6 +239,23 @@ func TestDoCompactionInjectsPriorContext(t *testing.T) {
 	}
 }
 
+func TestDoCompactionSkipsWhitespaceOnlyPriorSummaries(t *testing.T) {
+	rows := machineryCorpus(t)
+	q := &fakeQueries{
+		uncompacted: rows,
+		priorLogs:   []sqlc.BotHistoryMessageCompact{{Summary: "  \n\t", Status: "ok"}},
+	}
+	stub := &stubModel{summary: "S3"}
+	svc := newMachineryService(q)
+
+	if _, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if strings.Contains(stub.prompt, "The following are summaries of earlier parts") {
+		t.Fatalf("whitespace-only prior summary injected as prior context:\n%s", stub.prompt)
+	}
+}
+
 func TestDoCompactionAllEmptyWindowSkipsModelAndMarking(t *testing.T) {
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
 		mkRow(t, "assistant", `[{"type":"reasoning","text":"thinking a"}]`, 100),

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -296,6 +296,23 @@ func TestDoCompactionSummarizerFailureRecordsErrorWithoutMarking(t *testing.T) {
 	}
 }
 
+func TestDoCompactionEmptySummaryRecordsErrorWithoutMarking(t *testing.T) {
+	rows := machineryCorpus(t)
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "   "}
+	svc := newMachineryService(q)
+
+	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err == nil {
+		t.Fatal("an empty summary must surface an error")
+	}
+	if len(q.markedIDs) != 0 {
+		t.Fatalf("nothing may be marked when the summary is empty (marked=%d)", len(q.markedIDs))
+	}
+	if !q.created || q.completed.Status != "error" {
+		t.Fatalf("an empty summary must leave an error log row (created=%v status=%q)", q.created, q.completed.Status)
+	}
+}
+
 func TestRunCompactionSkipsWhenSessionAlreadyInFlight(t *testing.T) {
 	rows := machineryCorpus(t)
 	q := &fakeQueries{uncompacted: rows}

--- a/internal/compaction/service_machinery_test.go
+++ b/internal/compaction/service_machinery_test.go
@@ -170,7 +170,7 @@ func TestDoCompactionMarksToolAwareWindowAndRendersCleanPrompt(t *testing.T) {
 	// The boundary guard must advance to 7, pulling result B in with its call, so
 	// the marked set is exactly 0..6. If adjustForToolBoundary regressed, this
 	// marks only 0..5 and the assertions below fail.
-	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err != nil {
 		t.Fatalf("RunCompactionSync: %v", err)
 	}
 
@@ -219,7 +219,7 @@ func TestDoCompactionInjectsPriorContext(t *testing.T) {
 	stub := &stubModel{summary: "S2"}
 	svc := newMachineryService(q)
 
-	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err != nil {
 		t.Fatalf("RunCompactionSync: %v", err)
 	}
 	if !strings.Contains(stub.prompt, "prior_context") || !strings.Contains(stub.prompt, "earlier-segment-summary") {
@@ -237,7 +237,7 @@ func TestDoCompactionAllEmptyWindowSkipsModelAndMarking(t *testing.T) {
 	stub := &stubModel{summary: "unused"}
 	svc := newMachineryService(q)
 
-	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 150)); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 150)); err != nil {
 		t.Fatalf("RunCompactionSync: %v", err)
 	}
 	if stub.calls != 0 {
@@ -261,7 +261,7 @@ func TestDoCompactionIncompleteToolExchangeSkipsModelAndMarking(t *testing.T) {
 	stub := &stubModel{summary: "unused"}
 	svc := newMachineryService(q)
 
-	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 150)); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 150)); err != nil {
 		t.Fatalf("RunCompactionSync: %v", err)
 	}
 	if stub.calls != 0 {
@@ -292,7 +292,7 @@ func TestDoCompactionMarksOnlyContiguousRunAcrossEmptyMiddleRow(t *testing.T) {
 	stub := &stubModel{summary: "SUMMARY"}
 	svc := newMachineryService(q)
 
-	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 250)); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 250)); err != nil {
 		t.Fatalf("RunCompactionSync: %v", err)
 	}
 	if len(q.markedIDs) != 1 || q.markedIDs[0] != rows[0].ID {
@@ -303,7 +303,7 @@ func TestDoCompactionMarksOnlyContiguousRunAcrossEmptyMiddleRow(t *testing.T) {
 	}
 }
 
-func TestRunCompactionSyncResultReportsScopedNoop(t *testing.T) {
+func TestRunCompactionSyncReportsScopedNoop(t *testing.T) {
 	// An already-compact/fresh session compacts nothing. The result must be a
 	// scoped no-op, so a caller (the HTTP endpoint) never has to fall back to an
 	// unscoped bot-wide log that could belong to another session.
@@ -311,7 +311,7 @@ func TestRunCompactionSyncResultReportsScopedNoop(t *testing.T) {
 	stub := &stubModel{summary: "unused"}
 	svc := newMachineryService(q)
 
-	res, err := svc.RunCompactionSyncResult(context.Background(), machineryConfig(stub, 100))
+	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 100))
 	if err != nil {
 		t.Fatalf("no-op must not error: %v", err)
 	}
@@ -323,27 +323,27 @@ func TestRunCompactionSyncResultReportsScopedNoop(t *testing.T) {
 	}
 }
 
-func TestRunCompactionSyncResultReportsScopedSummaryOnSuccess(t *testing.T) {
+func TestRunCompactionSyncReportsScopedSummaryOnSuccess(t *testing.T) {
 	q := &fakeQueries{uncompacted: machineryCorpus(t)}
 	stub := &stubModel{summary: "SUMMARY-OK"}
 	svc := newMachineryService(q)
 
-	res, err := svc.RunCompactionSyncResult(context.Background(), machineryConfig(stub, 450))
+	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450))
 	if err != nil {
-		t.Fatalf("RunCompactionSyncResult: %v", err)
+		t.Fatalf("RunCompactionSync: %v", err)
 	}
 	if res.Status != StatusOK || res.Summary != "SUMMARY-OK" || res.MessageCount != len(q.markedIDs) {
 		t.Fatalf("success result = %+v, want ok/SUMMARY-OK/%d", res, len(q.markedIDs))
 	}
 }
 
-func TestRunCompactionSyncResultFailureSurfacesError(t *testing.T) {
+func TestRunCompactionSyncFailureSurfacesError(t *testing.T) {
 	q := &fakeQueries{uncompacted: machineryCorpus(t)}
 	svc := newMachineryService(q)
 	cfg := machineryConfig(&stubModel{}, 450)
 	cfg.HTTPClient = &http.Client{Transport: &failingModel{}}
 
-	res, err := svc.RunCompactionSyncResult(context.Background(), cfg)
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
 	if err == nil {
 		t.Fatal("a summarizer failure must surface an error, not a stale result")
 	}
@@ -357,7 +357,7 @@ func TestDoCompactionEmptyHistoryNoOp(t *testing.T) {
 	stub := &stubModel{summary: "unused"}
 	svc := newMachineryService(q)
 
-	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 100)); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 100)); err != nil {
 		t.Fatalf("RunCompactionSync: %v", err)
 	}
 	if stub.calls != 0 || len(q.markedIDs) != 0 {
@@ -387,7 +387,7 @@ func TestDoCompactionSummarizerFailureRecordsErrorWithoutMarking(t *testing.T) {
 	cfg := machineryConfig(&stubModel{}, 450)
 	cfg.HTTPClient = &http.Client{Transport: &failingModel{}}
 
-	if err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
 		t.Fatal("summarizer failure must surface an error")
 	}
 	if len(q.markedIDs) != 0 {
@@ -404,7 +404,7 @@ func TestDoCompactionEmptySummaryRecordsErrorWithoutMarking(t *testing.T) {
 	stub := &stubModel{summary: "   "}
 	svc := newMachineryService(q)
 
-	if err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450)); err == nil {
 		t.Fatal("an empty summary must surface an error")
 	}
 	if len(q.markedIDs) != 0 {
@@ -425,14 +425,14 @@ func TestRunCompactionFailureCooldownSkipsImmediateRetry(t *testing.T) {
 	fail := &failingModel{}
 	cfg.HTTPClient = &http.Client{Transport: fail}
 
-	if err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
 		t.Fatal("first attempt must run and fail")
 	}
 	if fail.calls != 1 {
 		t.Fatalf("calls = %d, want 1", fail.calls)
 	}
 
-	if err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
 		t.Fatalf("cooldown skip must not surface an error: %v", err)
 	}
 	if fail.calls != 1 {
@@ -440,7 +440,7 @@ func TestRunCompactionFailureCooldownSkipsImmediateRetry(t *testing.T) {
 	}
 
 	now = now.Add(compactionFailureCooldown + time.Second)
-	if err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
 		t.Fatal("attempt after cooldown must run and fail again")
 	}
 	if fail.calls != 2 {
@@ -456,7 +456,7 @@ func TestRunCompactionManualRequestBypassesFailureCooldown(t *testing.T) {
 
 	autoCfg := machineryConfig(&stubModel{}, 450)
 	autoCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
-	if err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
 		t.Fatal("first automatic attempt must run and fail, arming the cooldown")
 	}
 
@@ -467,7 +467,7 @@ func TestRunCompactionManualRequestBypassesFailureCooldown(t *testing.T) {
 	manualCfg := autoCfg
 	manualCfg.Manual = true
 	manualCfg.HTTPClient = &http.Client{Transport: manualStub}
-	if err := svc.RunCompactionSync(context.Background(), manualCfg); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), manualCfg); err != nil {
 		t.Fatalf("manual compaction must run despite cooldown: %v", err)
 	}
 	if manualStub.calls != 1 {
@@ -483,7 +483,7 @@ func TestRunCompactionManualRequestBypassesFailureCooldown(t *testing.T) {
 	autoRetry := &failingModel{}
 	autoRetryCfg := autoCfg
 	autoRetryCfg.HTTPClient = &http.Client{Transport: autoRetry}
-	if err := svc.RunCompactionSync(context.Background(), autoRetryCfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), autoRetryCfg); err == nil {
 		t.Fatal("automatic retry after a successful manual run should proceed and fail")
 	}
 	if autoRetry.calls != 1 {
@@ -499,7 +499,7 @@ func TestRunCompactionManualFailureStillSurfacesError(t *testing.T) {
 
 	autoCfg := machineryConfig(&stubModel{}, 450)
 	autoCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
-	if err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
 		t.Fatal("automatic attempt must fail to arm the cooldown")
 	}
 
@@ -509,7 +509,7 @@ func TestRunCompactionManualFailureStillSurfacesError(t *testing.T) {
 	manualCfg := autoCfg
 	manualCfg.Manual = true
 	manualCfg.HTTPClient = &http.Client{Transport: manualFail}
-	if err := svc.RunCompactionSync(context.Background(), manualCfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), manualCfg); err == nil {
 		t.Fatal("a failing manual compaction must return an error, not a false success")
 	}
 	if manualFail.calls != 1 {
@@ -527,7 +527,7 @@ func TestRunCompactionFailureCooldownClearsOnSuccess(t *testing.T) {
 
 	failCfg := sessionCfg
 	failCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
-	if err := svc.RunCompactionSync(context.Background(), failCfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), failCfg); err == nil {
 		t.Fatal("expected initial failure")
 	}
 
@@ -535,7 +535,7 @@ func TestRunCompactionFailureCooldownClearsOnSuccess(t *testing.T) {
 	successStub := &stubModel{summary: "recovered"}
 	successCfg := sessionCfg
 	successCfg.HTTPClient = &http.Client{Transport: successStub}
-	if err := svc.RunCompactionSync(context.Background(), successCfg); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), successCfg); err != nil {
 		t.Fatalf("attempt after cooldown should succeed: %v", err)
 	}
 	if successStub.calls != 1 {
@@ -545,7 +545,7 @@ func TestRunCompactionFailureCooldownClearsOnSuccess(t *testing.T) {
 	retryFail := &failingModel{}
 	retryCfg := sessionCfg
 	retryCfg.HTTPClient = &http.Client{Transport: retryFail}
-	if err := svc.RunCompactionSync(context.Background(), retryCfg); err == nil {
+	if _, err := svc.RunCompactionSync(context.Background(), retryCfg); err == nil {
 		t.Fatal("expected failure from immediate retry model")
 	}
 	if retryFail.calls != 1 {
@@ -565,7 +565,7 @@ func TestRunCompactionSkipsWhenSessionAlreadyInFlight(t *testing.T) {
 	}
 	defer svc.endSessionCompaction(cfg.SessionID)
 
-	if err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
+	if _, err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
 		t.Fatalf("in-flight skip must not error: %v", err)
 	}
 	if stub.calls != 0 || q.created || len(q.markedIDs) != 0 {

--- a/internal/compaction/service_starvation_test.go
+++ b/internal/compaction/service_starvation_test.go
@@ -1,0 +1,83 @@
+package compaction
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+// starvationCorpus reproduces the leading-unmarkable-island shape: a
+// reasoning-only row that renders empty, an ask_user exchange that is
+// must-keep, then ordinary old history, then the current turn.
+func starvationCorpus(t *testing.T) []sqlc.ListUncompactedMessagesBySessionRow {
+	t.Helper()
+	return []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"internal chain of thought"}]`, 400), // 0: renders empty
+		mkRow(t, "assistant", `[{"type":"tool-call","toolCallId":"U","toolName":"ask_user","input":{}}]`, 40),          // 1: must-keep call
+		mkRow(t, "tool", `[{"type":"tool-result","toolCallId":"U","toolName":"ask_user","output":"user said yes"}]`, 40), // 2: must-keep result
+		mkRow(t, "user", `"old question"`, 400),      // 3
+		mkRow(t, "assistant", `"old answer"`, 400),   // 4
+		mkRow(t, "user", `"current question"`, 40),   // 5: protected current turn
+	}
+}
+
+func TestDoCompactionAdvancesPastUnmarkableLeadingIsland(t *testing.T) {
+	t.Parallel()
+
+	rows := starvationCorpus(t)
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "compacted the old exchange"}
+	svc := newMachineryService(q)
+
+	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 100))
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q, want %q: an unmarkable leading island must not starve the history behind it", res.Status, StatusOK)
+	}
+
+	marked := idSet(q.markedIDs)
+	if len(marked) != 2 || !marked[rows[3].ID] || !marked[rows[4].ID] {
+		t.Fatalf("marked = %v, want exactly the old question/answer pair", q.markedIDs)
+	}
+	for _, frag := range []string{"old question", "old answer"} {
+		if !strings.Contains(stub.prompt, frag) {
+			t.Fatalf("summarizer prompt missing %q:\n%s", frag, stub.prompt)
+		}
+	}
+	for _, frag := range []string{"ask_user", "user said yes", "current question", "chain of thought"} {
+		if strings.Contains(stub.prompt, frag) {
+			t.Fatalf("summarizer prompt leaked raw-retained content %q:\n%s", frag, stub.prompt)
+		}
+	}
+}
+
+func TestDoCompactionNoopsWithoutModelCallWhenOnlyUnmarkableRowsRemain(t *testing.T) {
+	t.Parallel()
+
+	rows := starvationCorpus(t)
+	remaining := append([]sqlc.ListUncompactedMessagesBySessionRow{}, rows[0], rows[1], rows[2], rows[5])
+	q := &fakeQueries{uncompacted: remaining}
+	stub := &stubModel{summary: "should never be produced"}
+	svc := newMachineryService(q)
+
+	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 100))
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != StatusNoop {
+		t.Fatalf("status = %q, want %q", res.Status, StatusNoop)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("model called %d times for an unmarkable window, want 0", stub.calls)
+	}
+	if len(q.markedIDs) != 0 {
+		t.Fatalf("marked = %v, want none", q.markedIDs)
+	}
+	if q.created {
+		t.Fatal("a compaction log row was created for a no-op window")
+	}
+}

--- a/internal/compaction/service_starvation_test.go
+++ b/internal/compaction/service_starvation_test.go
@@ -110,3 +110,32 @@ func TestDoCompactionCompactsBehindOversizedRenderEmptyHead(t *testing.T) {
 		t.Fatalf("marked = %v, want exactly the old question/answer pair", q.markedIDs)
 	}
 }
+
+func TestDoCompactionCompactsBehindOversizedIncompleteExchange(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "assistant", `[{"type":"text","text":"running the tool"},{"type":"tool-call","toolCallId":"x","toolName":"exec","input":{}}]`, 40000),
+		mkRow(t, "tool", `[{"type":"binary","data":"opaque"}]`, 100), // unrecognized part renders empty -> exchange incomplete
+		mkRow(t, "user", `"old question"`, 100),
+		mkRow(t, "assistant", `"old answer"`, 100),
+		mkRow(t, "user", `"current question"`, 40),
+	}
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "old exchange condensed"}
+	svc := newMachineryService(q)
+
+	cfg := machineryConfig(stub, 100)
+	cfg.MaxCompactTokens = 10000 // smaller than the incomplete exchange's raw estimate
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q, want %q: an unmarkable oversized exchange must not eat the trim budget", res.Status, StatusOK)
+	}
+	marked := idSet(q.markedIDs)
+	if len(marked) != 2 || !marked[rows[2].ID] || !marked[rows[3].ID] {
+		t.Fatalf("marked = %v, want exactly the old question/answer pair", q.markedIDs)
+	}
+}

--- a/internal/compaction/service_starvation_test.go
+++ b/internal/compaction/service_starvation_test.go
@@ -14,12 +14,12 @@ import (
 func starvationCorpus(t *testing.T) []sqlc.ListUncompactedMessagesBySessionRow {
 	t.Helper()
 	return []sqlc.ListUncompactedMessagesBySessionRow{
-		mkRow(t, "assistant", `[{"type":"reasoning","text":"internal chain of thought"}]`, 400), // 0: renders empty
-		mkRow(t, "assistant", `[{"type":"tool-call","toolCallId":"U","toolName":"ask_user","input":{}}]`, 40),          // 1: must-keep call
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"internal chain of thought"}]`, 400),                          // 0: renders empty
+		mkRow(t, "assistant", `[{"type":"tool-call","toolCallId":"U","toolName":"ask_user","input":{}}]`, 40),            // 1: must-keep call
 		mkRow(t, "tool", `[{"type":"tool-result","toolCallId":"U","toolName":"ask_user","output":"user said yes"}]`, 40), // 2: must-keep result
-		mkRow(t, "user", `"old question"`, 400),      // 3
-		mkRow(t, "assistant", `"old answer"`, 400),   // 4
-		mkRow(t, "user", `"current question"`, 40),   // 5: protected current turn
+		mkRow(t, "user", `"old question"`, 400),    // 3
+		mkRow(t, "assistant", `"old answer"`, 400), // 4
+		mkRow(t, "user", `"current question"`, 40), // 5: protected current turn
 	}
 }
 

--- a/internal/compaction/service_starvation_test.go
+++ b/internal/compaction/service_starvation_test.go
@@ -81,3 +81,32 @@ func TestDoCompactionNoopsWithoutModelCallWhenOnlyUnmarkableRowsRemain(t *testin
 		t.Fatal("a compaction log row was created for a no-op window")
 	}
 }
+
+func TestDoCompactionCompactsBehindOversizedRenderEmptyHead(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"a"}]`, 20000), // renders empty, huge raw estimate
+		mkRow(t, "assistant", `[{"type":"reasoning","text":"b"}]`, 20000),
+		mkRow(t, "user", `"old question"`, 100),
+		mkRow(t, "assistant", `"old answer"`, 100),
+		mkRow(t, "user", `"current question"`, 40),
+	}
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "old exchange condensed"}
+	svc := newMachineryService(q)
+
+	cfg := machineryConfig(stub, 100)
+	cfg.MaxCompactTokens = 10000 // smaller than one reasoning row's raw estimate
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q, want %q: a render-empty head must not eat the trim budget", res.Status, StatusOK)
+	}
+	marked := idSet(q.markedIDs)
+	if len(marked) != 2 || !marked[rows[2].ID] || !marked[rows[3].ID] {
+		t.Fatalf("marked = %v, want exactly the old question/answer pair", q.markedIDs)
+	}
+}

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -520,3 +520,41 @@ func TestRunCompactionPanicArmsCooldownAndReleasesSlot(t *testing.T) {
 		t.Fatalf("the slot must be released after a panic, got %q", res.Status)
 	}
 }
+
+func TestManualRunBypassesACooldownNoopOwner(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "manual summary"}
+	svc := newMachineryService(q)
+	cfg := machineryConfig(stub, 450)
+
+	svc.recordCompactionFailure(cfg.SessionID)
+	run, ok := svc.beginSessionCompaction(cfg.SessionID) // an automatic run holding the slot
+	if !ok {
+		t.Fatal("owner acquisition must succeed")
+	}
+
+	manual := cfg
+	manual.Manual = true
+	got := make(chan Result, 1)
+	go func() {
+		res, err := svc.RunCompactionSync(context.Background(), manual)
+		if err != nil {
+			t.Errorf("manual: %v", err)
+		}
+		got <- res
+	}()
+	awaitWaiter(t, run)
+
+	// The automatic owner publishes its cooldown noop; the manual request must
+	// retry and actually run instead of inheriting the skip.
+	svc.endSessionCompaction(cfg.SessionID, run, Result{Status: StatusNoop}, nil)
+	res := <-got
+	if res.Status != StatusOK {
+		t.Fatalf("manual run inherited the owner's noop, got %#v", res)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("model called %d times, want 1", stub.calls)
+	}
+}

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -589,9 +589,6 @@ func TestCanceledManualWaiterDoesNotRetryThroughANoopOwner(t *testing.T) {
 	}()
 	awaitWaiter(t, run)
 
-	// Cancel while the owner's noop publication races the waiter's select:
-	// whichever branch wins, a canceled manual caller must not become a new
-	// owner and start real work after cancellation.
 	cancel()
 	svc.endSessionCompaction(cfg.SessionID, run, Result{Status: StatusNoop}, nil)
 	if res := <-got; res.Status != StatusNoop {
@@ -602,17 +599,78 @@ func TestCanceledManualWaiterDoesNotRetryThroughANoopOwner(t *testing.T) {
 	}
 }
 
+// TestWaitForOwnerManualBranches pins the owner-done arm deterministically:
+// the racing integration test above almost always wakes on ctx.Done(), so the
+// post-noop context recheck is driven directly through the seam.
+func TestWaitForOwnerManualBranches(t *testing.T) {
+	t.Parallel()
+
+	closedOwner := func(res Result, err error) *inflightRun {
+		run := &inflightRun{done: make(chan struct{}), res: res, err: err}
+		close(run.done)
+		return run
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	manual := TriggerConfig{Manual: true}
+
+	// doneHidden forces the owner-done select arm while Err() still reports
+	// cancellation, pinning the post-noop context recheck deterministically
+	// (with both channels ready the select would pick randomly).
+	doneHidden := doneHiddenContext{canceled}
+	res, retry, err := waitForOwner(doneHidden, manual, closedOwner(Result{Status: StatusNoop}, nil))
+	if retry || err != nil || res.Status != StatusNoop {
+		t.Fatalf("canceled manual caller must not retry through a noop owner: res=%#v err=%v retry=%v", res, err, retry)
+	}
+
+	res, retry, err = waitForOwner(canceled, manual, closedOwner(Result{Status: StatusNoop}, nil))
+	if retry || err != nil || res.Status != StatusNoop {
+		t.Fatalf("either select arm must degrade a canceled manual caller to noop: res=%#v err=%v retry=%v", res, err, retry)
+	}
+
+	_, retry, err = waitForOwner(context.Background(), manual, closedOwner(Result{Status: StatusNoop}, nil))
+	if !retry || err != nil {
+		t.Fatalf("live manual caller must retry through a noop owner: err=%v retry=%v", err, retry)
+	}
+
+	want := Result{Status: StatusOK, Summary: "s", MessageCount: 1}
+	res, retry, err = waitForOwner(doneHiddenContext{canceled}, manual, closedOwner(want, nil))
+	if retry || err != nil || res != want {
+		t.Fatalf("a completed owner's ok result must be reused even after cancel: res=%#v err=%v retry=%v", res, err, retry)
+	}
+
+	res, retry, err = waitForOwner(context.Background(), TriggerConfig{}, closedOwner(Result{Status: StatusNoop}, nil))
+	if retry || err != nil || res.Status != StatusNoop {
+		t.Fatalf("automatic callers never retry: res=%#v err=%v retry=%v", res, err, retry)
+	}
+}
+
 type panickingHookProvider struct {
-	armed atomic.Bool
-	calls atomic.Int32
+	armed   atomic.Bool
+	calls   atomic.Int32
+	entered chan struct{}
+	release chan struct{}
 }
 
 func (p *panickingHookProvider) MCPClient(context.Context, string) (*bridge.Client, error) {
 	p.calls.Add(1)
 	if p.armed.Load() {
+		if p.entered != nil {
+			select {
+			case p.entered <- struct{}{}:
+			default:
+			}
+			<-p.release
+		}
 		panic("boom: injected hook provider panic")
 	}
 	return nil, errors.New("no workspace client")
+}
+
+func (s *Service) inflightRunFor(sessionID string) *inflightRun {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	return s.inflight[sessionID]
 }
 
 func TestPreHookPanicArmsCooldownAndReleasesSlot(t *testing.T) {
@@ -621,7 +679,7 @@ func TestPreHookPanicArmsCooldownAndReleasesSlot(t *testing.T) {
 	q := &fakeQueries{uncompacted: machineryCorpus(t)}
 	stub := &stubModel{summary: "unused"}
 	svc := newMachineryService(q)
-	provider := &panickingHookProvider{}
+	provider := &panickingHookProvider{entered: make(chan struct{}, 1), release: make(chan struct{})}
 	provider.armed.Store(true)
 	svc.SetHookService(hooks.NewService(slog.New(slog.DiscardHandler), provider))
 	cfg := machineryConfig(stub, 450)
@@ -631,8 +689,25 @@ func TestPreHookPanicArmsCooldownAndReleasesSlot(t *testing.T) {
 		defer func() { recovered <- recover() }()
 		_, _ = svc.RunCompactionSync(context.Background(), cfg)
 	}()
+	<-provider.entered // the owner is inside the pre-hook, holding the slot
+
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := svc.RunCompactionSync(context.Background(), cfg)
+		waiterErr <- err
+	}()
+	run := svc.inflightRunFor(cfg.SessionID)
+	if run == nil {
+		t.Fatal("owner run must be registered while inside the pre-hook")
+	}
+	awaitWaiter(t, run)
+
+	close(provider.release)
 	if r := <-recovered; r == nil {
 		t.Fatal("a pre-hook panic must propagate, not be swallowed")
+	}
+	if err := <-waiterErr; err == nil {
+		t.Fatal("a waiter attached to a panicking owner must receive a failure, not a zero-value success")
 	}
 
 	provider.armed.Store(false)
@@ -657,3 +732,7 @@ func TestPreHookPanicArmsCooldownAndReleasesSlot(t *testing.T) {
 		t.Fatalf("model called %d times behind the failing pre-hook, want 0", stub.calls)
 	}
 }
+
+type doneHiddenContext struct{ context.Context }
+
+func (doneHiddenContext) Done() <-chan struct{} { return nil }

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -1,0 +1,276 @@
+package compaction
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRunCompactionSyncReportsScopedNoop(t *testing.T) {
+	// An already-compact/fresh session compacts nothing. The result must be a
+	// scoped no-op, so a caller (the HTTP endpoint) never has to fall back to an
+	// unscoped bot-wide log that could belong to another session.
+	q := &fakeQueries{}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+
+	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 100))
+	if err != nil {
+		t.Fatalf("no-op must not error: %v", err)
+	}
+	if res.Status != StatusNoop || res.MessageCount != 0 || res.Summary != "" {
+		t.Fatalf("no-op result = %+v, want noop/0/empty", res)
+	}
+	if stub.calls != 0 || q.created {
+		t.Fatalf("no-op must not call the model or create a log (calls=%d created=%v)", stub.calls, q.created)
+	}
+}
+
+func TestRunCompactionSyncReportsScopedSummaryOnSuccess(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "SUMMARY-OK"}
+	svc := newMachineryService(q)
+
+	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 450))
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != StatusOK || res.Summary != "SUMMARY-OK" || res.MessageCount != len(q.markedIDs) {
+		t.Fatalf("success result = %+v, want ok/SUMMARY-OK/%d", res, len(q.markedIDs))
+	}
+}
+
+func TestRunCompactionSyncFailureSurfacesError(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	cfg := machineryConfig(&stubModel{}, 450)
+	cfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("a summarizer failure must surface an error, not a stale result")
+	}
+	if res.Status == StatusOK {
+		t.Fatalf("failed result must not report ok: %+v", res)
+	}
+}
+
+func TestRunCompactionFailureCooldownSkipsImmediateRetry(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	cfg := machineryConfig(&stubModel{}, 450)
+	fail := &failingModel{}
+	cfg.HTTPClient = &http.Client{Transport: fail}
+
+	if _, err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
+		t.Fatal("first attempt must run and fail")
+	}
+	if fail.calls != 1 {
+		t.Fatalf("calls = %d, want 1", fail.calls)
+	}
+
+	if _, err := svc.RunCompactionSync(context.Background(), cfg); err != nil {
+		t.Fatalf("cooldown skip must not surface an error: %v", err)
+	}
+	if fail.calls != 1 {
+		t.Fatalf("immediate retry within cooldown must be skipped, calls=%d", fail.calls)
+	}
+
+	now = now.Add(compactionFailureCooldown + time.Second)
+	if _, err := svc.RunCompactionSync(context.Background(), cfg); err == nil {
+		t.Fatal("attempt after cooldown must run and fail again")
+	}
+	if fail.calls != 2 {
+		t.Fatalf("attempt after cooldown should run, calls=%d", fail.calls)
+	}
+}
+
+func TestRunCompactionManualRequestBypassesFailureCooldown(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	autoCfg := machineryConfig(&stubModel{}, 450)
+	autoCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+	if _, err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
+		t.Fatal("first automatic attempt must run and fail, arming the cooldown")
+	}
+
+	// The user fixes the model and presses compact within the cooldown window.
+	// A manual request must actually run (not be skipped and reported as done):
+	// it compacts and reports a real result instead of a false success.
+	manualStub := &stubModel{summary: "recovered by manual run"}
+	manualCfg := autoCfg
+	manualCfg.Manual = true
+	manualCfg.HTTPClient = &http.Client{Transport: manualStub}
+	if _, err := svc.RunCompactionSync(context.Background(), manualCfg); err != nil {
+		t.Fatalf("manual compaction must run despite cooldown: %v", err)
+	}
+	if manualStub.calls != 1 {
+		t.Fatalf("manual request must call the model, not skip on cooldown (calls=%d)", manualStub.calls)
+	}
+	if !q.created || len(q.markedIDs) == 0 || q.completed.Status != "ok" {
+		t.Fatalf("manual run must do real work: created=%v marked=%d status=%q", q.created, len(q.markedIDs), q.completed.Status)
+	}
+
+	// An automatic request in the same window still respects the cooldown: the
+	// manual success above cleared it, so this one runs — proving cooldown is a
+	// shared per-session state that manual participates in, not a bypass leak.
+	autoRetry := &failingModel{}
+	autoRetryCfg := autoCfg
+	autoRetryCfg.HTTPClient = &http.Client{Transport: autoRetry}
+	if _, err := svc.RunCompactionSync(context.Background(), autoRetryCfg); err == nil {
+		t.Fatal("automatic retry after a successful manual run should proceed and fail")
+	}
+	if autoRetry.calls != 1 {
+		t.Fatalf("manual success must clear the shared cooldown for automatic runs too (calls=%d)", autoRetry.calls)
+	}
+}
+
+func TestRunCompactionManualFailureStillSurfacesError(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	autoCfg := machineryConfig(&stubModel{}, 450)
+	autoCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+	if _, err := svc.RunCompactionSync(context.Background(), autoCfg); err == nil {
+		t.Fatal("automatic attempt must fail to arm the cooldown")
+	}
+
+	// A manual request that also fails must surface the real error, never a
+	// silent nil that callers render as "done".
+	manualFail := &failingModel{}
+	manualCfg := autoCfg
+	manualCfg.Manual = true
+	manualCfg.HTTPClient = &http.Client{Transport: manualFail}
+	if _, err := svc.RunCompactionSync(context.Background(), manualCfg); err == nil {
+		t.Fatal("a failing manual compaction must return an error, not a false success")
+	}
+	if manualFail.calls != 1 {
+		t.Fatalf("manual request must attempt the model despite cooldown (calls=%d)", manualFail.calls)
+	}
+}
+
+func TestRunCompactionFailureCooldownClearsOnSuccess(t *testing.T) {
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	sessionCfg := machineryConfig(&stubModel{}, 450)
+
+	failCfg := sessionCfg
+	failCfg.HTTPClient = &http.Client{Transport: &failingModel{}}
+	if _, err := svc.RunCompactionSync(context.Background(), failCfg); err == nil {
+		t.Fatal("expected initial failure")
+	}
+
+	now = now.Add(compactionFailureCooldown + time.Second)
+	successStub := &stubModel{summary: "recovered"}
+	successCfg := sessionCfg
+	successCfg.HTTPClient = &http.Client{Transport: successStub}
+	if _, err := svc.RunCompactionSync(context.Background(), successCfg); err != nil {
+		t.Fatalf("attempt after cooldown should succeed: %v", err)
+	}
+	if successStub.calls != 1 {
+		t.Fatalf("success attempt should have called the model once, got %d", successStub.calls)
+	}
+
+	retryFail := &failingModel{}
+	retryCfg := sessionCfg
+	retryCfg.HTTPClient = &http.Client{Transport: retryFail}
+	if _, err := svc.RunCompactionSync(context.Background(), retryCfg); err == nil {
+		t.Fatal("expected failure from immediate retry model")
+	}
+	if retryFail.calls != 1 {
+		t.Fatalf("success must have cleared the cooldown, allowing an immediate retry; calls=%d", retryFail.calls)
+	}
+}
+
+type errTransport struct{ err error }
+
+func (t errTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, t.err }
+
+func TestRunCompactionSyncInterruptedRunDoesNotArmCooldown(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"canceled mid-call", context.Canceled},
+		{"deadline exceeded mid-call", context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			q := &fakeQueries{uncompacted: machineryCorpus(t)}
+			svc := newMachineryService(q)
+			stub := &stubModel{summary: "recovered summary"}
+			cfg := machineryConfig(stub, 200)
+
+			interrupted := cfg
+			interrupted.HTTPClient = &http.Client{Transport: errTransport{err: tc.err}}
+			if _, err := svc.RunCompactionSync(context.Background(), interrupted); err == nil {
+				t.Fatal("interrupted run must surface an error")
+			}
+
+			res, err := svc.RunCompactionSync(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("run after interruption: %v", err)
+			}
+			if res.Status != StatusOK {
+				t.Fatalf("status after interruption = %q, want %q (cooldown must not be armed)", res.Status, StatusOK)
+			}
+		})
+	}
+}
+
+func TestRunCompactionSyncModelFailureStillArmsCooldown(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	stub := &stubModel{summary: "healthy summary"}
+	cfg := machineryConfig(stub, 200)
+
+	failing := cfg
+	failing.HTTPClient = &http.Client{Transport: errTransport{err: errors.New("upstream 500")}}
+	if _, err := svc.RunCompactionSync(context.Background(), failing); err == nil {
+		t.Fatal("failing run must surface an error")
+	}
+
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("run during cooldown: %v", err)
+	}
+	if res.Status != StatusNoop {
+		t.Fatalf("status during cooldown = %q, want %q", res.Status, StatusNoop)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("model called %d times during cooldown, want 0", stub.calls)
+	}
+}
+
+func TestRunCompactionSyncSurfacesCompletionPersistenceFailure(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t), completeErr: errors.New("db down")}
+	svc := newMachineryService(q)
+	stub := &stubModel{summary: "durable summary"}
+
+	res, err := svc.RunCompactionSync(context.Background(), machineryConfig(stub, 200))
+	if err == nil {
+		t.Fatal("completion persistence failure must surface an error")
+	}
+	if res.Status == StatusOK {
+		t.Fatal("result must not claim ok when the summary was never persisted")
+	}
+}

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -396,3 +396,127 @@ func TestDoCompactionSacrificesPriorContextForOversizedEntries(t *testing.T) {
 		t.Fatalf("combined prompt ~%d tokens, want within MaxCompactTokens plus the fixed overhead", got)
 	}
 }
+
+func TestDoCompactionCountsPriorSeparatorsInSharedBudget(t *testing.T) {
+	t.Parallel()
+
+	priors := make([]sqlc.BotHistoryMessageCompact, 0, 100)
+	for i := 0; i < 100; i++ {
+		priors = append(priors, sqlc.BotHistoryMessageCompact{Status: "ok", Summary: "abcd"})
+	}
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		textRow(t, "user", 917),
+		mkRow(t, "user", `"current"`, 40),
+	}
+	q := &fakeQueries{uncompacted: rows, priorLogs: priors}
+	stub := &stubModel{summary: "condensed"}
+	svc := newMachineryService(q)
+
+	cfg := machineryConfig(stub, 100)
+	cfg.MaxCompactTokens = 1000
+	if res, err := svc.RunCompactionSync(context.Background(), cfg); err != nil || res.Status != StatusOK {
+		t.Fatalf("RunCompactionSync = %v, %v", res, err)
+	}
+	if got := estimateBytesAsTokens(stub.prompt); got > 1000+320 {
+		t.Fatalf("combined prompt ~%d tokens: prior separators must count toward the shared budget", got)
+	}
+}
+
+func TestDoCompactionTruncatesEntriesPastTheTotalCap(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		textRow(t, "user", 1202),
+		mkRow(t, "user", `"current"`, 40),
+	}
+	q := &fakeQueries{uncompacted: rows}
+	stub := &stubModel{summary: "condensed"}
+	svc := newMachineryService(q)
+
+	cfg := machineryConfig(stub, 100)
+	cfg.MaxCompactTokens = 1000
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q, want %q", res.Status, StatusOK)
+	}
+	if len(q.markedIDs) != 1 || q.markedIDs[0] != rows[0].ID {
+		t.Fatalf("marked = %v, want the oversized row", q.markedIDs)
+	}
+	if !strings.Contains(stub.prompt, truncationMarker) {
+		t.Fatal("an entry larger than the whole budget must be truncated, not sent verbatim")
+	}
+	if got := estimateBytesAsTokens(stub.prompt); got > 1000+320 {
+		t.Fatalf("combined prompt ~%d tokens, want within the total cap plus fixed overhead", got)
+	}
+}
+
+func TestRunCompactionSyncAttachesToOwnerDuringCooldown(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+	cfg := machineryConfig(stub, 450)
+
+	svc.recordCompactionFailure(cfg.SessionID)
+	run, ok := svc.beginSessionCompaction(cfg.SessionID)
+	if !ok {
+		t.Fatal("manual owner acquisition must succeed")
+	}
+
+	got := make(chan Result, 1)
+	go func() {
+		res, err := svc.RunCompactionSync(context.Background(), cfg) // auto path, cooldown armed
+		if err != nil {
+			t.Errorf("waiter: %v", err)
+		}
+		got <- res
+	}()
+	awaitWaiter(t, run) // cooldown must not hide the running owner
+
+	want := Result{Status: StatusOK, Summary: "manual retry summary", MessageCount: 2}
+	svc.endSessionCompaction(cfg.SessionID, run, want, nil)
+	if res := <-got; res != want {
+		t.Fatalf("auto sync must reuse the cooldown-bypassing owner's result, got %#v", res)
+	}
+}
+
+func TestRunCompactionPanicArmsCooldownAndReleasesSlot(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t), listPanic: true}
+	stub := &stubModel{summary: "recovered"}
+	svc := newMachineryService(q)
+	cfg := machineryConfig(stub, 450)
+
+	recovered := make(chan any, 1)
+	go func() {
+		defer func() { recovered <- recover() }()
+		_, _ = svc.RunCompactionSync(context.Background(), cfg)
+	}()
+	if r := <-recovered; r == nil {
+		t.Fatal("the panic must propagate, not be swallowed")
+	}
+
+	q.listPanic = false
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("run after panic: %v", err)
+	}
+	if res.Status != StatusNoop {
+		t.Fatalf("a panicked run must arm the cooldown, got %q", res.Status)
+	}
+
+	manual := cfg
+	manual.Manual = true
+	res, err = svc.RunCompactionSync(context.Background(), manual)
+	if err != nil {
+		t.Fatalf("manual run after panic: %v", err)
+	}
+	if res.Status != StatusOK {
+		t.Fatalf("the slot must be released after a panic, got %q", res.Status)
+	}
+}

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -733,6 +733,54 @@ func TestPreHookPanicArmsCooldownAndReleasesSlot(t *testing.T) {
 	}
 }
 
+// TestPostCompactHookPanicDoesNotPoisonASuccessfulRun pins the post-hook
+// panic containment: the compaction itself succeeded and its outcome is
+// already persisted, so a panicking PostCompact hook must not escape the
+// recovery defer (crashing async triggers), must not turn the published
+// result into a lie, and must not arm the failure cooldown. The panicking
+// hook service is swapped in mid-run, after the pre-hook already passed.
+func TestPostCompactHookPanicDoesNotPoisonASuccessfulRun(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "SUMMARY-OK"}
+	svc := newMachineryService(q)
+	provider := &panickingHookProvider{}
+	provider.armed.Store(true)
+	q.onComplete = func() {
+		svc.SetHookService(hooks.NewService(slog.New(slog.DiscardHandler), provider))
+	}
+	cfg := machineryConfig(stub, 450)
+
+	recovered := make(chan any, 1)
+	results := make(chan Result, 1)
+	errs := make(chan error, 1)
+	go func() {
+		defer func() { recovered <- recover() }()
+		res, err := svc.RunCompactionSync(context.Background(), cfg)
+		results <- res
+		errs <- err
+	}()
+	if r := <-recovered; r != nil {
+		t.Fatalf("a post-hook panic must be contained, but escaped: %v", r)
+	}
+	if err := <-errs; err != nil {
+		t.Fatalf("a post-hook panic must not fail the completed compaction: %v", err)
+	}
+	if res := <-results; res.Status != StatusOK || res.Summary != "SUMMARY-OK" {
+		t.Fatalf("completed compaction result lost to a post-hook panic: %#v", res)
+	}
+	if provider.calls.Load() == 0 {
+		t.Fatal("the post-hook must actually have run (and panicked)")
+	}
+
+	q.onComplete = nil
+	svc.SetHookService(nil)
+	if res, err := svc.RunCompactionSync(context.Background(), cfg); err != nil || res.Status != StatusOK {
+		t.Fatalf("a contained post-hook panic must not arm the cooldown: res=%#v err=%v", res, err)
+	}
+}
+
 type doneHiddenContext struct{ context.Context }
 
 func (doneHiddenContext) Done() <-chan struct{} { return nil }

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -355,3 +355,42 @@ func TestDoCompactionSharesPromptBudgetWithPriorContext(t *testing.T) {
 		t.Fatalf("prior context must carve out of the entries budget: marked %d with prior, %d without", with, without)
 	}
 }
+
+func TestDoCompactionSacrificesPriorContextForOversizedEntries(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		mkRow(t, "user", `"the enormous old turn"`, 900),
+		mkRow(t, "user", `"small follow-up"`, 100),
+		mkRow(t, "user", `"current"`, 40),
+	}
+	prior := strings.Repeat("history so far ", 70) // ~262 tokens, within the 1/4 allowance
+	q := &fakeQueries{
+		uncompacted: rows,
+		priorLogs:   []sqlc.BotHistoryMessageCompact{{Status: "ok", Summary: prior}},
+	}
+	stub := &stubModel{summary: "condensed"}
+	svc := newMachineryService(q)
+
+	cfg := machineryConfig(stub, 100)
+	cfg.MaxCompactTokens = 1000
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q, want %q", res.Status, StatusOK)
+	}
+	if len(q.markedIDs) != 1 || q.markedIDs[0] != rows[0].ID {
+		t.Fatalf("marked = %v, want the oversized first markable turn", q.markedIDs)
+	}
+	// The oversized kept entries exceed their budget share, so the reference
+	// prior context must shrink (truncate) to keep the combined prompt within
+	// MaxCompactTokens instead of stacking on top of it.
+	if strings.Contains(stub.prompt, prior) {
+		t.Fatal("full prior context must not ride along with oversized entries")
+	}
+	if got := estimateBytesAsTokens(stub.prompt); got > 1000+150 {
+		t.Fatalf("combined prompt ~%d tokens, want within MaxCompactTokens plus the fixed wrapper", got)
+	}
+}

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -3,12 +3,16 @@ package compaction
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/hooks"
+	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
 func TestRunCompactionSyncReportsScopedNoop(t *testing.T) {
@@ -556,5 +560,100 @@ func TestManualRunBypassesACooldownNoopOwner(t *testing.T) {
 	}
 	if stub.calls != 1 {
 		t.Fatalf("model called %d times, want 1", stub.calls)
+	}
+}
+
+func TestCanceledManualWaiterDoesNotRetryThroughANoopOwner(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+	cfg := machineryConfig(stub, 450)
+
+	run, ok := svc.beginSessionCompaction(cfg.SessionID)
+	if !ok {
+		t.Fatal("owner acquisition must succeed")
+	}
+
+	manual := cfg
+	manual.Manual = true
+	ctx, cancel := context.WithCancel(context.Background())
+	got := make(chan Result, 1)
+	go func() {
+		res, err := svc.RunCompactionSync(ctx, manual)
+		if err != nil {
+			t.Errorf("canceled manual waiter: %v", err)
+		}
+		got <- res
+	}()
+	awaitWaiter(t, run)
+
+	// Cancel while the owner's noop publication races the waiter's select:
+	// whichever branch wins, a canceled manual caller must not become a new
+	// owner and start real work after cancellation.
+	cancel()
+	svc.endSessionCompaction(cfg.SessionID, run, Result{Status: StatusNoop}, nil)
+	if res := <-got; res.Status != StatusNoop {
+		t.Fatalf("canceled manual waiter must degrade to noop, got %#v", res)
+	}
+	if stub.calls != 0 || len(q.markedIDs) != 0 {
+		t.Fatalf("canceled manual waiter ran compaction (calls=%d marked=%d)", stub.calls, len(q.markedIDs))
+	}
+}
+
+type panickingHookProvider struct {
+	armed atomic.Bool
+	calls atomic.Int32
+}
+
+func (p *panickingHookProvider) MCPClient(context.Context, string) (*bridge.Client, error) {
+	p.calls.Add(1)
+	if p.armed.Load() {
+		panic("boom: injected hook provider panic")
+	}
+	return nil, errors.New("no workspace client")
+}
+
+func TestPreHookPanicArmsCooldownAndReleasesSlot(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	stub := &stubModel{summary: "unused"}
+	svc := newMachineryService(q)
+	provider := &panickingHookProvider{}
+	provider.armed.Store(true)
+	svc.SetHookService(hooks.NewService(slog.New(slog.DiscardHandler), provider))
+	cfg := machineryConfig(stub, 450)
+
+	recovered := make(chan any, 1)
+	go func() {
+		defer func() { recovered <- recover() }()
+		_, _ = svc.RunCompactionSync(context.Background(), cfg)
+	}()
+	if r := <-recovered; r == nil {
+		t.Fatal("a pre-hook panic must propagate, not be swallowed")
+	}
+
+	provider.armed.Store(false)
+	before := provider.calls.Load()
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("auto run after pre-hook panic: %v", err)
+	}
+	if res.Status != StatusNoop {
+		t.Fatalf("a pre-hook panic must arm the cooldown, got %q", res.Status)
+	}
+	if provider.calls.Load() != before {
+		t.Fatal("the cooldown noop must not reach the pre-hook provider")
+	}
+
+	manual := cfg
+	manual.Manual = true
+	if _, err := svc.RunCompactionSync(context.Background(), manual); err == nil {
+		t.Fatal("manual bypass must reach the failing pre-hook, proving the slot was released")
+	}
+	if stub.calls != 0 {
+		t.Fatalf("model called %d times behind the failing pre-hook, want 0", stub.calls)
 	}
 }

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -781,6 +781,33 @@ func TestPostCompactHookPanicDoesNotPoisonASuccessfulRun(t *testing.T) {
 	}
 }
 
+// TestExpiredFailureCooldownEntryIsDropped keeps failedAt from growing with
+// sessions that failed once and never came back: an entry found expired is
+// deleted on the spot instead of lingering until a later success or restart.
+func TestExpiredFailureCooldownEntryIsDropped(t *testing.T) {
+	t.Parallel()
+
+	svc := newMachineryService(&fakeQueries{})
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	svc.recordCompactionFailure("session-1")
+	if !svc.inFailureCooldown("session-1") {
+		t.Fatal("fresh failure must be in cooldown")
+	}
+
+	now = now.Add(compactionFailureCooldown + time.Second)
+	if svc.inFailureCooldown("session-1") {
+		t.Fatal("cooldown must expire")
+	}
+	svc.inflightMu.Lock()
+	_, lingering := svc.failedAt["session-1"]
+	svc.inflightMu.Unlock()
+	if lingering {
+		t.Fatal("expired cooldown entry must be dropped from failedAt")
+	}
+}
+
 type doneHiddenContext struct{ context.Context }
 
 func (doneHiddenContext) Done() <-chan struct{} { return nil }

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 )
 
 func TestRunCompactionSyncReportsScopedNoop(t *testing.T) {
@@ -204,10 +208,20 @@ func TestRunCompactionSyncInterruptedRunDoesNotArmCooldown(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		err  error
+		ctx  func(t *testing.T) context.Context
 	}{
-		{"canceled mid-call", context.Canceled},
-		{"deadline exceeded mid-call", context.DeadlineExceeded},
+		{"caller canceled", func(t *testing.T) context.Context {
+			t.Helper()
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			return ctx
+		}},
+		{"caller deadline exceeded", func(t *testing.T) context.Context {
+			t.Helper()
+			ctx, cancel := context.WithDeadline(context.Background(), time.Unix(0, 0))
+			t.Cleanup(cancel)
+			return ctx
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -216,9 +230,10 @@ func TestRunCompactionSyncInterruptedRunDoesNotArmCooldown(t *testing.T) {
 			stub := &stubModel{summary: "recovered summary"}
 			cfg := machineryConfig(stub, 200)
 
+			interruptedCtx := tc.ctx(t)
 			interrupted := cfg
-			interrupted.HTTPClient = &http.Client{Transport: errTransport{err: tc.err}}
-			if _, err := svc.RunCompactionSync(context.Background(), interrupted); err == nil {
+			interrupted.HTTPClient = &http.Client{Transport: errTransport{err: interruptedCtx.Err()}}
+			if _, err := svc.RunCompactionSync(interruptedCtx, interrupted); err == nil {
 				t.Fatal("interrupted run must surface an error")
 			}
 
@@ -230,6 +245,35 @@ func TestRunCompactionSyncInterruptedRunDoesNotArmCooldown(t *testing.T) {
 				t.Fatalf("status after interruption = %q, want %q (cooldown must not be armed)", res.Status, StatusOK)
 			}
 		})
+	}
+}
+
+func TestRunCompactionSyncClientTimeoutStillArmsCooldown(t *testing.T) {
+	t.Parallel()
+
+	// The HTTP client's own timeout fires with the caller's context still
+	// live: the model is genuinely too slow, so the cooldown must arm —
+	// otherwise the sync backstop re-attempts the same slow call every turn.
+	q := &fakeQueries{uncompacted: machineryCorpus(t)}
+	svc := newMachineryService(q)
+	stub := &stubModel{summary: "healthy summary"}
+	cfg := machineryConfig(stub, 200)
+
+	slow := cfg
+	slow.HTTPClient = &http.Client{Transport: errTransport{err: context.DeadlineExceeded}}
+	if _, err := svc.RunCompactionSync(context.Background(), slow); err == nil {
+		t.Fatal("timed-out run must surface an error")
+	}
+
+	res, err := svc.RunCompactionSync(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("run during cooldown: %v", err)
+	}
+	if res.Status != StatusNoop {
+		t.Fatalf("status during cooldown = %q, want %q", res.Status, StatusNoop)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("model called %d times during cooldown, want 0", stub.calls)
 	}
 }
 
@@ -272,5 +316,42 @@ func TestRunCompactionSyncSurfacesCompletionPersistenceFailure(t *testing.T) {
 	}
 	if res.Status == StatusOK {
 		t.Fatal("result must not claim ok when the summary was never persisted")
+	}
+}
+
+func TestDoCompactionSharesPromptBudgetWithPriorContext(t *testing.T) {
+	t.Parallel()
+
+	rows := make([]sqlc.ListUncompactedMessagesBySessionRow, 0, 13)
+	for i := 0; i < 12; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		rows = append(rows, mkRow(t, role, `"turn `+strconv.Itoa(i)+`"`, 100))
+	}
+	rows = append(rows, mkRow(t, "user", `"current"`, 40))
+
+	run := func(t *testing.T, priorLogs []sqlc.BotHistoryMessageCompact) int {
+		t.Helper()
+		q := &fakeQueries{uncompacted: rows, priorLogs: priorLogs}
+		stub := &stubModel{summary: "condensed"}
+		svc := newMachineryService(q)
+		cfg := machineryConfig(stub, 100)
+		cfg.MaxCompactTokens = 1000
+		res, err := svc.RunCompactionSync(context.Background(), cfg)
+		if err != nil {
+			t.Fatalf("RunCompactionSync: %v", err)
+		}
+		if res.Status != StatusOK {
+			t.Fatalf("status = %q, want %q", res.Status, StatusOK)
+		}
+		return len(q.markedIDs)
+	}
+
+	without := run(t, nil)
+	with := run(t, []sqlc.BotHistoryMessageCompact{{Status: "ok", Summary: strings.Repeat("p", 1200)}})
+	if with >= without {
+		t.Fatalf("prior context must carve out of the entries budget: marked %d with prior, %d without", with, without)
 	}
 }

--- a/internal/compaction/service_state_test.go
+++ b/internal/compaction/service_state_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -328,7 +327,7 @@ func TestDoCompactionSharesPromptBudgetWithPriorContext(t *testing.T) {
 		if i%2 == 1 {
 			role = "assistant"
 		}
-		rows = append(rows, mkRow(t, role, `"turn `+strconv.Itoa(i)+`"`, 100))
+		rows = append(rows, textRow(t, role, 100))
 	}
 	rows = append(rows, mkRow(t, "user", `"current"`, 40))
 
@@ -360,8 +359,8 @@ func TestDoCompactionSacrificesPriorContextForOversizedEntries(t *testing.T) {
 	t.Parallel()
 
 	rows := []sqlc.ListUncompactedMessagesBySessionRow{
-		mkRow(t, "user", `"the enormous old turn"`, 900),
-		mkRow(t, "user", `"small follow-up"`, 100),
+		textRow(t, "user", 900),
+		textRow(t, "user", 100),
 		mkRow(t, "user", `"current"`, 40),
 	}
 	prior := strings.Repeat("history so far ", 70) // ~262 tokens, within the 1/4 allowance
@@ -390,7 +389,10 @@ func TestDoCompactionSacrificesPriorContextForOversizedEntries(t *testing.T) {
 	if strings.Contains(stub.prompt, prior) {
 		t.Fatal("full prior context must not ride along with oversized entries")
 	}
-	if got := estimateBytesAsTokens(stub.prompt); got > 1000+150 {
-		t.Fatalf("combined prompt ~%d tokens, want within MaxCompactTokens plus the fixed wrapper", got)
+	// stub.prompt concatenates the fixed system prompt (~190 tokens) and the
+	// user-prompt wrapper (~90 tokens) on top of the budgeted prior+entries;
+	// an additive-budget regression overshoots this bound by the full prior.
+	if got := estimateBytesAsTokens(stub.prompt); got > 1000+320 {
+		t.Fatalf("combined prompt ~%d tokens, want within MaxCompactTokens plus the fixed overhead", got)
 	}
 }

--- a/internal/compaction/types.go
+++ b/internal/compaction/types.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// Compaction result statuses reported by RunCompactionSyncResult.
+// Compaction result statuses reported by RunCompactionSync.
 const (
 	StatusOK   = "ok"   // messages were compacted into a summary
 	StatusNoop = "noop" // nothing to compact (already compact, cooled down, or in flight)

--- a/internal/compaction/types.go
+++ b/internal/compaction/types.go
@@ -5,6 +5,21 @@ import (
 	"time"
 )
 
+// Compaction result statuses reported by RunCompactionSyncResult.
+const (
+	StatusOK   = "ok"   // messages were compacted into a summary
+	StatusNoop = "noop" // nothing to compact (already compact, cooled down, or in flight)
+)
+
+// Result is the scoped outcome of a synchronous compaction. Callers use it to
+// respond with this session's own result instead of reading unscoped bot-wide
+// logs. A failed attempt returns an error, not a Result.
+type Result struct {
+	Status       string
+	Summary      string
+	MessageCount int
+}
+
 // Log represents a compaction log entry.
 type Log struct {
 	ID           string     `json:"id"`

--- a/internal/compaction/types.go
+++ b/internal/compaction/types.go
@@ -41,4 +41,10 @@ type TriggerConfig struct {
 	MaxCompactTokens int // if > 0, cap compaction input to this many tokens (e.g. 90% of model window)
 	TargetTokens     int // if > 0, compaction goal: reduce context to this many tokens (used by sync compaction)
 	PromptCacheTTL   string
+
+	// Manual marks a user-initiated compaction (slash command, HTTP endpoint).
+	// Such a request bypasses the per-session failure cooldown so a user who
+	// just fixed their credentials/model isn't told "done" while nothing runs.
+	// Automatic per-request paths leave this false to keep the cooldown backstop.
+	Manual bool
 }

--- a/internal/conversation/flow/compaction_read_path_pairing_test.go
+++ b/internal/conversation/flow/compaction_read_path_pairing_test.go
@@ -1,0 +1,150 @@
+package flow
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/compaction"
+	"github.com/memohai/memoh/internal/contextfrag"
+	"github.com/memohai/memoh/internal/conversation"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/historyfrag"
+)
+
+type pairingQueries struct {
+	dbstore.Queries
+	uncompacted []sqlc.ListUncompactedMessagesBySessionRow
+	logID       pgtype.UUID
+	markedIDs   []pgtype.UUID
+}
+
+func (f *pairingQueries) ListUncompactedMessagesBySession(context.Context, pgtype.UUID) ([]sqlc.ListUncompactedMessagesBySessionRow, error) {
+	return f.uncompacted, nil
+}
+
+func (f *pairingQueries) ListCompactionLogsBySession(context.Context, pgtype.UUID) ([]sqlc.BotHistoryMessageCompact, error) {
+	return nil, nil
+}
+
+func (f *pairingQueries) CreateCompactionLog(context.Context, sqlc.CreateCompactionLogParams) (sqlc.BotHistoryMessageCompact, error) {
+	return sqlc.BotHistoryMessageCompact{ID: f.logID}, nil
+}
+
+func (f *pairingQueries) MarkMessagesCompacted(_ context.Context, arg sqlc.MarkMessagesCompactedParams) error {
+	f.markedIDs = append([]pgtype.UUID(nil), arg.Column2...)
+	return nil
+}
+
+func (f *pairingQueries) CompleteCompactionLog(_ context.Context, arg sqlc.CompleteCompactionLogParams) (sqlc.BotHistoryMessageCompact, error) {
+	return sqlc.BotHistoryMessageCompact{ID: arg.ID, Status: arg.Status, Summary: arg.Summary}, nil
+}
+
+type pairingSummarizer struct{ summary string }
+
+func (s pairingSummarizer) RoundTrip(*http.Request) (*http.Response, error) {
+	body := `{"id":"stub","object":"chat.completion","created":0,"model":"stub",` +
+		`"choices":[{"index":0,"message":{"role":"assistant","content":"` + s.summary + `"},"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}, nil
+}
+
+func pairingRow(t *testing.T, role, content string) sqlc.ListUncompactedMessagesBySessionRow {
+	t.Helper()
+	return sqlc.ListUncompactedMessagesBySessionRow{
+		ID:      pgtype.UUID{Bytes: uuid.New(), Valid: true},
+		Role:    role,
+		Content: []byte(content),
+		Usage:   []byte(`{"outputTokens":100}`),
+	}
+}
+
+// TestSelectorToReadPathPreservesOrderEndToEnd drives the real compaction
+// selector over a history with a must-keep ask_user island and feeds its
+// actual marked rows into replaceCompactedHistoryRecords. It pins the pair of
+// invariants that live in two packages: the selector marks one contiguous
+// pre-island run under one compact_id, and the read path substitutes it in
+// place — content behind the island (like "mid q") must never fold in front
+// of it.
+func TestSelectorToReadPathPreservesOrderEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	rows := []sqlc.ListUncompactedMessagesBySessionRow{
+		pairingRow(t, "user", `"old q"`),
+		pairingRow(t, "assistant", `"old a"`),
+		pairingRow(t, "assistant", `[{"type":"tool-call","toolCallId":"ask-1","toolName":"ask_user","input":{"questions":[]}}]`),
+		pairingRow(t, "tool", `[{"type":"tool-result","toolCallId":"ask-1","toolName":"ask_user","output":"answered"}]`),
+		pairingRow(t, "user", `"mid q"`),
+		pairingRow(t, "user", `"current q"`),
+	}
+	q := &pairingQueries{
+		uncompacted: rows,
+		logID:       pgtype.UUID{Bytes: uuid.New(), Valid: true},
+	}
+	svc := compaction.NewService(slog.New(slog.DiscardHandler), q)
+
+	res, err := svc.RunCompactionSync(context.Background(), compaction.TriggerConfig{
+		BotID:        uuid.NewString(),
+		SessionID:    uuid.NewString(),
+		ModelID:      "stub-model",
+		ClientType:   "openai-completions",
+		APIKey:       "test",
+		BaseURL:      "http://stub.invalid",
+		HTTPClient:   &http.Client{Transport: pairingSummarizer{summary: "condensed old exchange"}},
+		TargetTokens: 200,
+	})
+	if err != nil {
+		t.Fatalf("RunCompactionSync: %v", err)
+	}
+	if res.Status != compaction.StatusOK {
+		t.Fatalf("status = %q, want %q", res.Status, compaction.StatusOK)
+	}
+
+	marked := make(map[pgtype.UUID]bool, len(q.markedIDs))
+	for _, id := range q.markedIDs {
+		marked[id] = true
+	}
+	if len(marked) != 2 || !marked[rows[0].ID] || !marked[rows[1].ID] {
+		t.Fatalf("marked = %v, want exactly the contiguous pre-island run [old q, old a]", q.markedIDs)
+	}
+
+	compactID := uuid.UUID(q.logID.Bytes).String()
+	texts := []string{`old q`, `old a`, `ask you something`, `answered`, `mid q`, `current q`}
+	roles := []string{"user", "assistant", "assistant", "tool", "user", "user"}
+	records := make([]historyfrag.HistoryRecord, 0, len(rows))
+	for i, row := range rows {
+		id := uuid.UUID(row.ID.Bytes).String()
+		record := historyRecord(id, conversation.ModelMessage{
+			Role:    roles[i],
+			Content: conversation.NewTextContent(texts[i]),
+		}, nil)
+		if marked[row.ID] {
+			record.CompactID = compactID
+		}
+		records = append(records, record)
+	}
+
+	got := replaceCompactedHistoryRecords(records, map[string]string{compactID: res.Summary}, contextfrag.Scope{})
+	want := []conversation.ModelMessage{
+		{Role: "user", Content: conversation.NewTextContent("<summary>\n" + res.Summary + "\n</summary>")},
+		{Role: "assistant", Content: conversation.NewTextContent("ask you something")},
+		{Role: "tool", Content: conversation.NewTextContent("answered")},
+		{Role: "user", Content: conversation.NewTextContent("mid q")},
+		{Role: "user", Content: conversation.NewTextContent("current q")},
+	}
+	if gotMessages := historyfrag.ToModelMessages(got); !reflect.DeepEqual(gotMessages, want) {
+		t.Fatalf("selector output broke read-path ordering:\ngot  %#v\nwant %#v", gotMessages, want)
+	}
+}

--- a/internal/conversation/flow/compaction_read_path_pairing_test.go
+++ b/internal/conversation/flow/compaction_read_path_pairing_test.go
@@ -31,7 +31,7 @@ func (f *pairingQueries) ListUncompactedMessagesBySession(context.Context, pgtyp
 	return f.uncompacted, nil
 }
 
-func (f *pairingQueries) ListCompactionLogsBySession(context.Context, pgtype.UUID) ([]sqlc.BotHistoryMessageCompact, error) {
+func (*pairingQueries) ListCompactionLogsBySession(context.Context, pgtype.UUID) ([]sqlc.BotHistoryMessageCompact, error) {
 	return nil, nil
 }
 
@@ -44,7 +44,7 @@ func (f *pairingQueries) MarkMessagesCompacted(_ context.Context, arg sqlc.MarkM
 	return nil
 }
 
-func (f *pairingQueries) CompleteCompactionLog(_ context.Context, arg sqlc.CompleteCompactionLogParams) (sqlc.BotHistoryMessageCompact, error) {
+func (*pairingQueries) CompleteCompactionLog(_ context.Context, arg sqlc.CompleteCompactionLogParams) (sqlc.BotHistoryMessageCompact, error) {
 	return sqlc.BotHistoryMessageCompact{ID: arg.ID, Status: arg.Status, Summary: arg.Summary}, nil
 }
 

--- a/internal/conversation/flow/resolver.go
+++ b/internal/conversation/flow/resolver.go
@@ -390,33 +390,37 @@ func (r *Resolver) resolve(ctx context.Context, req conversation.ChatRequest) (r
 				slog.Int("context_token_budget", contextTokenBudget),
 				slog.Int("compaction_threshold", compactionThreshold),
 			)
-			r.runCompactionSync(ctx, req, estimatedTokens)
-			// Reload messages after compaction.
-			loaded, loadErr = r.loadHistoryRecords(ctx, historyFallback, req.SessionID, defaultMaxContextMinutes)
-			if loadErr != nil {
-				r.logger.Error("resolve: reload messages after compaction failed",
-					slog.String("bot_id", req.BotID),
-					slog.Any("error", loadErr),
-				)
-				return resolvedContext{}, loadErr
+			// Reload and post-process only when this run actually produced a
+			// summary. A noop (cooldown, in-flight, nothing markable) keeps
+			// this turn's context untouched — possibly still above the
+			// threshold — and the next turn re-evaluates.
+			if res := r.runCompactionSync(ctx, req, estimatedTokens); res.Status == compaction.StatusOK {
+				loaded, loadErr = r.loadHistoryRecords(ctx, historyFallback, req.SessionID, defaultMaxContextMinutes)
+				if loadErr != nil {
+					r.logger.Error("resolve: reload messages after compaction failed",
+						slog.String("bot_id", req.BotID),
+						slog.Any("error", loadErr),
+					)
+					return resolvedContext{}, loadErr
+				}
+				loaded = pruneHistoryForGateway(loaded)
+				loaded = filterMessagesBeforeID(loaded, req.HistoryCutoffBeforeMessageID)
+				loaded = dedupePersistedCurrentUserMessage(loaded, req)
+				loaded, loadErr = r.ensureRequiredHistoryMessage(ctx, loaded, req)
+				if loadErr != nil {
+					r.logger.Error("resolve: reload required history message failed",
+						slog.String("bot_id", req.BotID),
+						slog.Any("error", loadErr),
+					)
+					return resolvedContext{}, loadErr
+				}
+				loaded = r.replaceCompactedMessages(ctx, compactionSummaryScope(req.BotID, req.ChatID, req.SessionID, req.ConversationType, req.ConversationName, req.ReplyTarget), loaded)
+				messages, estimatedTokens = trimMessagesByTokens(r.logger, loaded, contextTokenBudget)
+				// Remove tool messages from the recent context — they are large
+				// and unnecessary when we already have a summary. Keep only
+				// user/assistant conversation turns.
+				messages = stripToolMessages(messages)
 			}
-			loaded = pruneHistoryForGateway(loaded)
-			loaded = filterMessagesBeforeID(loaded, req.HistoryCutoffBeforeMessageID)
-			loaded = dedupePersistedCurrentUserMessage(loaded, req)
-			loaded, loadErr = r.ensureRequiredHistoryMessage(ctx, loaded, req)
-			if loadErr != nil {
-				r.logger.Error("resolve: reload required history message failed",
-					slog.String("bot_id", req.BotID),
-					slog.Any("error", loadErr),
-				)
-				return resolvedContext{}, loadErr
-			}
-			loaded = r.replaceCompactedMessages(ctx, compactionSummaryScope(req.BotID, req.ChatID, req.SessionID, req.ConversationType, req.ConversationName, req.ReplyTarget), loaded)
-			messages, estimatedTokens = trimMessagesByTokens(r.logger, loaded, contextTokenBudget)
-			// Remove tool messages from the recent context — they are large
-			// and unnecessary when we already have a summary. Keep only
-			// user/assistant conversation turns.
-			messages = stripToolMessages(messages)
 		}
 		_ = estimatedTokens
 	}

--- a/internal/conversation/flow/resolver_compaction.go
+++ b/internal/conversation/flow/resolver_compaction.go
@@ -60,31 +60,34 @@ func (r *Resolver) maybeCompact(ctx context.Context, req conversation.ChatReques
 }
 
 // runCompactionSync runs compaction synchronously when context reaches
-// 70% of the model's context window. It blocks until compaction completes.
-func (r *Resolver) runCompactionSync(ctx context.Context, req conversation.ChatRequest, inputTokens int) {
+// 70% of the model's context window and reports the session-scoped result.
+// A noop (failure cooldown, another compaction in flight, or nothing to
+// compact) leaves this turn's context untouched: the request proceeds as-is,
+// possibly still above the threshold, and the next turn re-evaluates.
+func (r *Resolver) runCompactionSync(ctx context.Context, req conversation.ChatRequest, inputTokens int) compaction.Result {
 	if r.compactionService == nil || r.settingsService == nil {
 		r.logger.Warn("compaction sync: skipped, service or settings nil")
-		return
+		return compaction.Result{}
 	}
 	botSettings, err := r.settingsService.GetBot(ctx, req.BotID)
 	if err != nil {
 		r.logger.Warn("compaction sync: failed to load settings", slog.Any("error", err))
-		return
+		return compaction.Result{}
 	}
 	if !botSettings.CompactionEnabled {
 		r.logger.Warn("compaction sync: compaction disabled, skipping")
-		return
+		return compaction.Result{}
 	}
 
 	cfg, err := r.buildCompactionConfig(ctx, req, botSettings, inputTokens)
 	if err != nil {
 		r.logger.Warn("compaction sync: failed to build config", slog.Any("error", err))
-		return
+		return compaction.Result{}
 	}
 	if cfg.ModelID == "" {
 		// Same skip path as the async trigger above — no model or model
 		// disabled means there is nothing to compact.
-		return
+		return compaction.Result{}
 	}
 
 	r.logger.Info("compaction sync: running synchronously",
@@ -94,14 +97,17 @@ func (r *Resolver) runCompactionSync(ctx context.Context, req conversation.ChatR
 		slog.String("model_id", cfg.ModelID),
 	)
 
-	if err := r.compactionService.RunCompactionSync(ctx, cfg); err != nil {
+	res, err := r.compactionService.RunCompactionSync(ctx, cfg)
+	if err != nil {
 		r.logger.Warn("compaction sync: failed", slog.Any("error", err))
-	} else {
-		r.logger.Info("compaction sync: completed successfully",
-			slog.String("bot_id", req.BotID),
-			slog.String("session_id", req.SessionID),
-		)
+		return compaction.Result{}
 	}
+	r.logger.Info("compaction sync: finished",
+		slog.String("bot_id", req.BotID),
+		slog.String("session_id", req.SessionID),
+		slog.String("status", res.Status),
+	)
+	return res
 }
 
 // buildCompactionConfig resolves the compaction model, provider credentials,

--- a/internal/conversation/flow/resolver_history.go
+++ b/internal/conversation/flow/resolver_history.go
@@ -346,7 +346,7 @@ func (r *Resolver) replaceCompactedMessages(ctx context.Context, scope contextfr
 			r.logger.Warn("replaceCompactedMessages: failed to load compact log", slog.String("compact_id", compactID), slog.Any("error", err))
 			continue
 		}
-		if log.Status == "ok" && log.Summary != "" {
+		if log.Status == "ok" && strings.TrimSpace(log.Summary) != "" {
 			summaries[compactID] = log.Summary
 		}
 	}
@@ -387,7 +387,7 @@ func replaceCompactedHistoryRecords(messages []historyfrag.HistoryRecord, summar
 			continue
 		}
 		summary, ok := summaries[m.CompactID]
-		if !ok || summary == "" {
+		if !ok || strings.TrimSpace(summary) == "" {
 			for _, idx := range compactGroups[m.CompactID] {
 				result = append(result, messages[idx])
 			}

--- a/internal/conversation/flow/resolver_history_records_test.go
+++ b/internal/conversation/flow/resolver_history_records_test.go
@@ -148,6 +148,14 @@ func TestReplaceCompactedHistoryRecordsKeepsOriginalGroupWithoutSummary(t *testi
 	if gotMessages := historyfrag.ToModelMessages(gotEmpty); !reflect.DeepEqual(gotMessages, historyfrag.ToModelMessages(records)) {
 		t.Fatalf("empty summary should keep original group:\ngot  %#v\nwant %#v", gotMessages, historyfrag.ToModelMessages(records))
 	}
+
+	// A legacy status='ok' log can hold a whitespace-only summary (main never
+	// trimmed). Substituting it would drop the raw rows for nothing, and the
+	// reclaim SQL treats such rows as still eligible — the read path must agree.
+	gotWhitespace := replaceCompactedHistoryRecords(records, map[string]string{"compact-1": "  \n\t"}, contextfrag.Scope{})
+	if gotMessages := historyfrag.ToModelMessages(gotWhitespace); !reflect.DeepEqual(gotMessages, historyfrag.ToModelMessages(records)) {
+		t.Fatalf("whitespace-only summary should keep original group:\ngot  %#v\nwant %#v", gotMessages, historyfrag.ToModelMessages(records))
+	}
 }
 
 func TestReplaceCompactedHistoryRecordsKeepsMustKeepIslandOrdering(t *testing.T) {

--- a/internal/conversation/flow/resolver_history_records_test.go
+++ b/internal/conversation/flow/resolver_history_records_test.go
@@ -150,6 +150,36 @@ func TestReplaceCompactedHistoryRecordsKeepsOriginalGroupWithoutSummary(t *testi
 	}
 }
 
+func TestReplaceCompactedHistoryRecordsKeepsMustKeepIslandOrdering(t *testing.T) {
+	t.Parallel()
+
+	// The selector now marks only the contiguous run before a must-keep island
+	// (the ask_user exchange) under one compact_id; the island and the run after
+	// it stay raw. The read path must drop the summary in place and preserve
+	// order — "mid q" stays AFTER the ask_user exchange, never folded before it.
+	records := []historyfrag.HistoryRecord{
+		historyRecord("row-old", conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("old q")}, func(r *historyfrag.HistoryRecord) {
+			r.CompactID = "compact-1"
+		}),
+		historyRecord("row-ask-call", conversation.ModelMessage{Role: "assistant", Content: conversation.NewTextContent("ask you something")}, nil),
+		historyRecord("row-ask-result", conversation.ModelMessage{Role: "tool", Content: conversation.NewTextContent("answered")}, nil),
+		historyRecord("row-mid", conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("mid q")}, nil),
+		historyRecord("row-current", conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("current")}, nil),
+	}
+
+	got := replaceCompactedHistoryRecords(records, map[string]string{"compact-1": "condensed"}, contextfrag.Scope{})
+	want := []conversation.ModelMessage{
+		{Role: "user", Content: conversation.NewTextContent("<summary>\ncondensed\n</summary>")},
+		{Role: "assistant", Content: conversation.NewTextContent("ask you something")},
+		{Role: "tool", Content: conversation.NewTextContent("answered")},
+		{Role: "user", Content: conversation.NewTextContent("mid q")},
+		{Role: "user", Content: conversation.NewTextContent("current")},
+	}
+	if gotMessages := historyfrag.ToModelMessages(got); !reflect.DeepEqual(gotMessages, want) {
+		t.Fatalf("must-keep island ordering broken:\ngot  %#v\nwant %#v", gotMessages, want)
+	}
+}
+
 func TestHistoryRecordPathPreservesLegacyResolverMessagePipeline(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/postgres/sqlc/messages.sql.go
+++ b/internal/db/postgres/sqlc/messages.sql.go
@@ -4348,6 +4348,7 @@ LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_channel_routes r ON r.id = s.route_id
 WHERE m.session_id = $1
   AND m.compact_id IS NULL
+  AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
 `
 

--- a/internal/db/postgres/sqlc/messages.sql.go
+++ b/internal/db/postgres/sqlc/messages.sql.go
@@ -4347,11 +4347,14 @@ LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_channel_routes r ON r.id = s.route_id
 WHERE m.session_id = $1
-  -- Rows whose compact log never completed ok (crash between mark and
-  -- complete, deleted logs) stay eligible so their content is not lost.
+  -- Rows stay eligible unless their compact log holds a usable summary,
+  -- matching the read path's substitution predicate (status ok AND non-empty
+  -- summary). This also reclaims rows stranded by a crash between mark and
+  -- complete, by deleted logs, and legacy status='ok' rows whose summary is
+  -- empty (the pre-existing poison state).
   AND (m.compact_id IS NULL OR NOT EXISTS (
     SELECT 1 FROM bot_history_message_compacts c
-    WHERE c.id = m.compact_id AND c.status = 'ok'
+    WHERE c.id = m.compact_id AND c.status = 'ok' AND c.summary <> ''
   ))
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC

--- a/internal/db/postgres/sqlc/messages.sql.go
+++ b/internal/db/postgres/sqlc/messages.sql.go
@@ -4347,7 +4347,12 @@ LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
 LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_channel_routes r ON r.id = s.route_id
 WHERE m.session_id = $1
-  AND m.compact_id IS NULL
+  -- Rows whose compact log never completed ok (crash between mark and
+  -- complete, deleted logs) stay eligible so their content is not lost.
+  AND (m.compact_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM bot_history_message_compacts c
+    WHERE c.id = m.compact_id AND c.status = 'ok'
+  ))
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
 `

--- a/internal/db/postgres/sqlc/messages.sql.go
+++ b/internal/db/postgres/sqlc/messages.sql.go
@@ -4348,13 +4348,14 @@ LEFT JOIN bot_sessions s ON s.id = m.session_id
 LEFT JOIN bot_channel_routes r ON r.id = s.route_id
 WHERE m.session_id = $1
   -- Rows stay eligible unless their compact log holds a usable summary,
-  -- matching the read path's substitution predicate (status ok AND non-empty
+  -- matching the read path's substitution predicate (status ok AND non-blank
   -- summary). This also reclaims rows stranded by a crash between mark and
   -- complete, by deleted logs, and legacy status='ok' rows whose summary is
-  -- empty (the pre-existing poison state).
+  -- empty or whitespace-only (the pre-existing poison states).
   AND (m.compact_id IS NULL OR NOT EXISTS (
     SELECT 1 FROM bot_history_message_compacts c
-    WHERE c.id = m.compact_id AND c.status = 'ok' AND c.summary <> ''
+    WHERE c.id = m.compact_id AND c.status = 'ok'
+      AND NULLIF(BTRIM(c.summary, E' \t\n\r\f\x0B'), '') IS NOT NULL
   ))
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC

--- a/internal/db/postgres/sqlc/messages.sql.go
+++ b/internal/db/postgres/sqlc/messages.sql.go
@@ -4316,23 +4316,63 @@ func (q *Queries) ListObservedConversationsByChannelType(ctx context.Context, ar
 }
 
 const listUncompactedMessagesBySession = `-- name: ListUncompactedMessagesBySession :many
-SELECT id, bot_id, session_id, role, content, usage, sender_channel_identity_id, compact_id, created_at
-FROM bot_visible_history_messages
-WHERE session_id = $1
-  AND compact_id IS NULL
-ORDER BY turn_position ASC, turn_message_seq ASC, created_at ASC, id ASC
+SELECT
+  m.id,
+  m.bot_id,
+  m.session_id,
+  m.sender_channel_identity_id,
+  m.sender_account_user_id AS sender_user_id,
+  m.source_message_id AS external_message_id,
+  m.source_reply_to_message_id,
+  m.role,
+  m.content,
+  m.metadata,
+  m.usage,
+  m.event_id,
+  m.display_text,
+  m.compact_id,
+  m.created_at,
+  ci.display_name AS sender_display_name,
+  ci.avatar_url AS sender_avatar_url,
+  s.channel_type AS platform,
+  r.conversation_type AS conversation_type,
+  COALESCE(
+    NULLIF(TRIM(COALESCE(r.metadata->>'conversation_name', '')), ''),
+    NULLIF(TRIM(COALESCE(r.metadata->>'conversation_handle', '')), ''),
+    ''
+  )::text AS conversation_name,
+  r.default_reply_target AS reply_target
+FROM bot_visible_history_messages m
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
+LEFT JOIN bot_sessions s ON s.id = m.session_id
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id
+WHERE m.session_id = $1
+  AND m.compact_id IS NULL
+ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
 `
 
 type ListUncompactedMessagesBySessionRow struct {
 	ID                      pgtype.UUID        `json:"id"`
 	BotID                   pgtype.UUID        `json:"bot_id"`
 	SessionID               pgtype.UUID        `json:"session_id"`
+	SenderChannelIdentityID pgtype.UUID        `json:"sender_channel_identity_id"`
+	SenderUserID            pgtype.UUID        `json:"sender_user_id"`
+	ExternalMessageID       pgtype.Text        `json:"external_message_id"`
+	SourceReplyToMessageID  pgtype.Text        `json:"source_reply_to_message_id"`
 	Role                    string             `json:"role"`
 	Content                 []byte             `json:"content"`
+	Metadata                []byte             `json:"metadata"`
 	Usage                   []byte             `json:"usage"`
-	SenderChannelIdentityID pgtype.UUID        `json:"sender_channel_identity_id"`
+	EventID                 pgtype.UUID        `json:"event_id"`
+	DisplayText             pgtype.Text        `json:"display_text"`
 	CompactID               pgtype.UUID        `json:"compact_id"`
 	CreatedAt               pgtype.Timestamptz `json:"created_at"`
+	SenderDisplayName       pgtype.Text        `json:"sender_display_name"`
+	SenderAvatarUrl         pgtype.Text        `json:"sender_avatar_url"`
+	Platform                pgtype.Text        `json:"platform"`
+	ConversationType        pgtype.Text        `json:"conversation_type"`
+	ConversationName        string             `json:"conversation_name"`
+	ReplyTarget             pgtype.Text        `json:"reply_target"`
 }
 
 func (q *Queries) ListUncompactedMessagesBySession(ctx context.Context, sessionID pgtype.UUID) ([]ListUncompactedMessagesBySessionRow, error) {
@@ -4348,12 +4388,24 @@ func (q *Queries) ListUncompactedMessagesBySession(ctx context.Context, sessionI
 			&i.ID,
 			&i.BotID,
 			&i.SessionID,
+			&i.SenderChannelIdentityID,
+			&i.SenderUserID,
+			&i.ExternalMessageID,
+			&i.SourceReplyToMessageID,
 			&i.Role,
 			&i.Content,
+			&i.Metadata,
 			&i.Usage,
-			&i.SenderChannelIdentityID,
+			&i.EventID,
+			&i.DisplayText,
 			&i.CompactID,
 			&i.CreatedAt,
+			&i.SenderDisplayName,
+			&i.SenderAvatarUrl,
+			&i.Platform,
+			&i.ConversationType,
+			&i.ConversationName,
+			&i.ReplyTarget,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/uncompacted_messages_query_integration_test.go
+++ b/internal/db/uncompacted_messages_query_integration_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 )

--- a/internal/db/uncompacted_messages_query_integration_test.go
+++ b/internal/db/uncompacted_messages_query_integration_test.go
@@ -66,18 +66,20 @@ func TestListUncompactedMessagesReclaimEligibility(t *testing.T) {
 	}
 
 	logs := map[string]string{
-		"usable":  uuid.NewString(),
-		"error":   uuid.NewString(),
-		"pending": uuid.NewString(),
-		"poison":  uuid.NewString(),
+		"usable":     uuid.NewString(),
+		"error":      uuid.NewString(),
+		"pending":    uuid.NewString(),
+		"poison":     uuid.NewString(),
+		"whitespace": uuid.NewString(),
 	}
 	if _, err := tx.Exec(ctx, `
 INSERT INTO bot_history_message_compacts (id, bot_id, session_id, status, summary) VALUES
-  ($1, $5, $6, 'ok', 'a usable summary'),
-  ($2, $5, $6, 'error', ''),
-  ($3, $5, $6, 'pending', ''),
-  ($4, $5, $6, 'ok', '')
-`, logs["usable"], logs["error"], logs["pending"], logs["poison"], botID, sessionID); err != nil {
+  ($1, $6, $7, 'ok', 'a usable summary'),
+  ($2, $6, $7, 'error', ''),
+  ($3, $6, $7, 'pending', ''),
+  ($4, $6, $7, 'ok', ''),
+  ($5, $6, $7, 'ok', E'  \n\t')
+`, logs["usable"], logs["error"], logs["pending"], logs["poison"], logs["whitespace"], botID, sessionID); err != nil {
 		t.Fatalf("insert compact logs: %v", err)
 	}
 
@@ -93,6 +95,7 @@ INSERT INTO bot_history_message_compacts (id, bot_id, session_id, status, summar
 		{name: "log failed", compactID: logs["error"], eligible: true},
 		{name: "log never completed", compactID: logs["pending"], eligible: true},
 		{name: "legacy ok with empty summary", compactID: logs["poison"], eligible: true},
+		{name: "legacy ok with whitespace-only summary", compactID: logs["whitespace"], eligible: true},
 		{name: "passive sync", metadata: `{"trigger_mode":"passive_sync"}`, eligible: false},
 	}
 	wantEligible := make(map[string]string)

--- a/internal/db/uncompacted_messages_query_integration_test.go
+++ b/internal/db/uncompacted_messages_query_integration_test.go
@@ -1,0 +1,147 @@
+package db
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+// TestListUncompactedMessagesReclaimEligibility exercises the real SQL
+// eligibility predicate against PostgreSQL: rows stay selectable unless their
+// compact log holds a usable summary (status ok AND non-empty), matching the
+// read path's substitution predicate, and passive_sync rows never enter the
+// candidate set.
+func TestListUncompactedMessagesReclaimEligibility(t *testing.T) {
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("TEST_POSTGRES_DSN is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("ping postgres: %v", err)
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	schema := "uncompacted_query_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	quotedSchema := pgx.Identifier{schema}.Sanitize()
+	if _, err := tx.Exec(ctx, "CREATE SCHEMA "+quotedSchema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "SET LOCAL search_path TO "+quotedSchema+", public"); err != nil {
+		t.Fatalf("set search path: %v", err)
+	}
+	baseline := readEmbeddedMigration(t, "postgres/migrations/0001_init.up.sql")
+	if _, err := tx.Exec(ctx, baseline); err != nil {
+		t.Fatalf("apply 0001 baseline: %v", err)
+	}
+
+	userID := uuid.NewString()
+	botID := uuid.NewString()
+	sessionID := uuid.NewString()
+	if _, err := tx.Exec(ctx, `INSERT INTO users (id) VALUES ($1)`, userID); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO bots (id, owner_user_id, type, name) VALUES ($1, $2, 'personal', 'reclaim-test')`, botID, userID); err != nil {
+		t.Fatalf("insert bot: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO bot_sessions (id, bot_id) VALUES ($1, $2)`, sessionID, botID); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+
+	logs := map[string]string{
+		"usable":  uuid.NewString(),
+		"error":   uuid.NewString(),
+		"pending": uuid.NewString(),
+		"poison":  uuid.NewString(),
+	}
+	if _, err := tx.Exec(ctx, `
+INSERT INTO bot_history_message_compacts (id, bot_id, session_id, status, summary) VALUES
+  ($1, $5, $6, 'ok', 'a usable summary'),
+  ($2, $5, $6, 'error', ''),
+  ($3, $5, $6, 'pending', ''),
+  ($4, $5, $6, 'ok', '')
+`, logs["usable"], logs["error"], logs["pending"], logs["poison"], botID, sessionID); err != nil {
+		t.Fatalf("insert compact logs: %v", err)
+	}
+
+	type fixture struct {
+		name      string
+		compactID string
+		metadata  string
+		eligible  bool
+	}
+	fixtures := []fixture{
+		{name: "plain", eligible: true},
+		{name: "covered by usable summary", compactID: logs["usable"], eligible: false},
+		{name: "log failed", compactID: logs["error"], eligible: true},
+		{name: "log never completed", compactID: logs["pending"], eligible: true},
+		{name: "legacy ok with empty summary", compactID: logs["poison"], eligible: true},
+		{name: "passive sync", metadata: `{"trigger_mode":"passive_sync"}`, eligible: false},
+	}
+	wantEligible := make(map[string]string)
+	for i, f := range fixtures {
+		id := uuid.NewString()
+		metadata := f.metadata
+		if metadata == "" {
+			metadata = "{}"
+		}
+		var compactID any
+		if f.compactID != "" {
+			compactID = f.compactID
+		}
+		if _, err := tx.Exec(ctx, `
+INSERT INTO bot_history_messages
+  (id, bot_id, session_id, role, content, metadata, compact_id, turn_visible, turn_id, turn_position, turn_message_seq, created_at)
+VALUES
+  ($1, $2, $3, 'user', '[{"type":"text","text":"m"}]', $4, $5, true, $6, $7, 0, now() + make_interval(secs => $8))
+`, id, botID, sessionID, metadata, compactID, uuid.NewString(), i, i); err != nil {
+			t.Fatalf("insert message %q: %v", f.name, err)
+		}
+		if f.eligible {
+			wantEligible[id] = f.name
+		}
+	}
+
+	var sessionUUID pgtype.UUID
+	if err := sessionUUID.Scan(sessionID); err != nil {
+		t.Fatalf("scan session uuid: %v", err)
+	}
+	rows, err := sqlc.New(tx).ListUncompactedMessagesBySession(ctx, sessionUUID)
+	if err != nil {
+		t.Fatalf("ListUncompactedMessagesBySession: %v", err)
+	}
+
+	got := make(map[string]bool)
+	for i, row := range rows {
+		id := uuid.UUID(row.ID.Bytes).String()
+		got[id] = true
+		if i > 0 && row.CreatedAt.Time.Before(rows[i-1].CreatedAt.Time) {
+			t.Fatalf("rows not ordered by created_at: %v after %v", row.CreatedAt.Time, rows[i-1].CreatedAt.Time)
+		}
+	}
+	for id, name := range wantEligible {
+		if !got[id] {
+			t.Errorf("row %q missing from candidate set", name)
+		}
+	}
+	if len(got) != len(wantEligible) {
+		t.Errorf("candidate set size = %d, want %d (an excluded row leaked in)", len(got), len(wantEligible))
+	}
+}

--- a/internal/handlers/compaction.go
+++ b/internal/handlers/compaction.go
@@ -156,7 +156,7 @@ func (h *CompactionHandler) TriggerCompact(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	res, err := h.service.RunCompactionSyncResult(c.Request().Context(), cfg)
+	res, err := h.service.RunCompactionSync(c.Request().Context(), cfg)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/internal/handlers/compaction.go
+++ b/internal/handlers/compaction.go
@@ -212,6 +212,7 @@ func (h *CompactionHandler) buildTriggerConfig(ctx context.Context, botID, sessi
 		Ratio:            100,
 		TotalInputTokens: 1,
 		PromptCacheTTL:   providers.ProviderConfigString(compactProvider, "prompt_cache_ttl"),
+		Manual:           true,
 	}
 	if compactModel.Config.ContextWindow != nil && *compactModel.Config.ContextWindow > 0 {
 		cfg.MaxCompactTokens = *compactModel.Config.ContextWindow * 90 / 100

--- a/internal/handlers/compaction.go
+++ b/internal/handlers/compaction.go
@@ -156,19 +156,14 @@ func (h *CompactionHandler) TriggerCompact(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	if err := h.service.RunCompactionSync(c.Request().Context(), cfg); err != nil {
+	res, err := h.service.RunCompactionSyncResult(c.Request().Context(), cfg)
+	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-
-	logs, _, err := h.service.ListLogs(c.Request().Context(), botID, 1, 0)
-	if err != nil || len(logs) == 0 {
-		return c.JSON(http.StatusOK, TriggerCompactResponse{Status: "ok"})
-	}
-	latest := logs[0]
 	return c.JSON(http.StatusOK, TriggerCompactResponse{
-		Status:       latest.Status,
-		Summary:      latest.Summary,
-		MessageCount: latest.MessageCount,
+		Status:       res.Status,
+		Summary:      res.Summary,
+		MessageCount: res.MessageCount,
 	})
 }
 

--- a/internal/historyfrag/db_message.go
+++ b/internal/historyfrag/db_message.go
@@ -153,10 +153,35 @@ func modelMessageFromDBMessage(log *slog.Logger, msg messagepkg.Message) convers
 			Role:    strings.TrimSpace(msg.Role),
 			Content: cloneRawMessage(msg.Content),
 		}
-	} else {
-		modelMessage.Role = strings.TrimSpace(msg.Role)
+		return modelMessage
 	}
+
+	// A bare content-part object (e.g. {"type":"text","text":"hello"}) has no
+	// role/content/tool_calls keys, so it unmarshals successfully into an empty
+	// ModelMessage instead of erroring — unknown JSON fields are ignored. Detect
+	// that shape before the row's Role column gets stamped below, and normalize
+	// it into a one-element parts array so TextContent/ContentParts still see it.
+	if modelMessage.Role == "" && !modelMessage.HasContent() {
+		if wrapped, ok := bareContentPartArray(msg.Content); ok {
+			modelMessage.Content = wrapped
+		}
+	}
+
+	modelMessage.Role = strings.TrimSpace(msg.Role)
 	return modelMessage
+}
+
+// bareContentPartArray wraps a raw JSON object into a single-element parts
+// array, e.g. {"type":"text","text":"hello"} -> [{"type":"text","text":"hello"}].
+// Only a non-empty object is wrapped: `{}` carries no content to recover, and
+// unmarshal already guarantees non-object payloads (arrays/strings/scalars)
+// took the error branch above.
+func bareContentPartArray(raw json.RawMessage) (json.RawMessage, bool) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed[0] != '{' || trimmed == "{}" {
+		return nil, false
+	}
+	return json.RawMessage("[" + trimmed + "]"), true
 }
 
 func parseUsage(raw json.RawMessage) (*int, *int) {

--- a/internal/historyfrag/db_message_test.go
+++ b/internal/historyfrag/db_message_test.go
@@ -407,6 +407,105 @@ func TestFromDBMessageScopeFallbackDoesNotChangeDurableRefID(t *testing.T) {
 	}
 }
 
+// TestFromDBMessageNormalizesBareContentPartObject covers a persisted row whose
+// content is a bare content-part object (no role/content wrapper), which used
+// to unmarshal successfully into an empty ModelMessage — unknown JSON fields
+// are ignored — and silently render as empty downstream.
+func TestFromDBMessageNormalizesBareContentPartObject(t *testing.T) {
+	t.Parallel()
+
+	msg := messagepkg.Message{
+		ID:      "row-1",
+		BotID:   "bot-1",
+		Role:    "user",
+		Content: json.RawMessage(`{"type":"text","text":"hello"}`),
+	}
+	record, err := FromDBMessage(msg, ScopeFallback{})
+	if err != nil {
+		t.Fatalf("FromDBMessage failed: %v", err)
+	}
+	if got := record.ModelMessage.TextContent(); got != "hello" {
+		t.Fatalf("TextContent() = %q, want %q", got, "hello")
+	}
+	if !record.ModelMessage.HasContent() {
+		t.Fatalf("HasContent() = false, want true for normalized bare content part")
+	}
+	if record.ModelMessage.Role != "user" {
+		t.Fatalf("Role = %q, want %q", record.ModelMessage.Role, "user")
+	}
+}
+
+// TestFromDBMessageLegitimateEmptyToolRowUnaffected proves the bare-content-part
+// normalization does not misfire on a real (if empty) tool-result wrapper, whose
+// "role" key already makes it a valid ModelMessage.
+func TestFromDBMessageLegitimateEmptyToolRowUnaffected(t *testing.T) {
+	t.Parallel()
+
+	msg := messagepkg.Message{
+		ID:      "row-2",
+		BotID:   "bot-1",
+		Role:    "tool",
+		Content: json.RawMessage(`{"role":"tool","tool_call_id":"x","content":""}`),
+	}
+	record, err := FromDBMessage(msg, ScopeFallback{})
+	if err != nil {
+		t.Fatalf("FromDBMessage failed: %v", err)
+	}
+	if record.ModelMessage.Role != "tool" {
+		t.Fatalf("Role = %q, want %q", record.ModelMessage.Role, "tool")
+	}
+	if got := record.ModelMessage.TextContent(); got != "" {
+		t.Fatalf("TextContent() = %q, want empty", got)
+	}
+	if record.ModelMessage.HasContent() {
+		t.Fatalf("HasContent() = true, want false for legitimate empty tool row")
+	}
+}
+
+// TestFromDBMessageEmptyObjectContentNotWrapped proves an empty `{}` payload is
+// left alone: it carries no content to recover, so it must not be turned into
+// a `[{}]` parts array.
+func TestFromDBMessageEmptyObjectContentNotWrapped(t *testing.T) {
+	t.Parallel()
+
+	msg := messagepkg.Message{
+		ID:      "row-3",
+		BotID:   "bot-1",
+		Role:    "user",
+		Content: json.RawMessage(`{}`),
+	}
+	record, err := FromDBMessage(msg, ScopeFallback{})
+	if err != nil {
+		t.Fatalf("FromDBMessage failed: %v", err)
+	}
+	if got := record.ModelMessage.TextContent(); got != "" {
+		t.Fatalf("TextContent() = %q, want empty", got)
+	}
+	if string(record.ModelMessage.Content) == "[{}]" {
+		t.Fatalf("empty object must not be wrapped into a parts array, got Content = %s", record.ModelMessage.Content)
+	}
+}
+
+// TestFromDBMessageNormalWrapperUnchanged proves a legitimate ModelMessage
+// wrapper still round-trips exactly as before the fix.
+func TestFromDBMessageNormalWrapperUnchanged(t *testing.T) {
+	t.Parallel()
+
+	msg := messagepkg.Message{
+		ID:      "row-4",
+		BotID:   "bot-1",
+		Role:    "assistant",
+		Content: json.RawMessage(`{"role":"assistant","content":"hi"}`),
+	}
+	record, err := FromDBMessage(msg, ScopeFallback{})
+	if err != nil {
+		t.Fatalf("FromDBMessage failed: %v", err)
+	}
+	if got := record.ModelMessage.TextContent(); got != "hi" {
+		t.Fatalf("TextContent() = %q, want %q", got, "hi")
+	}
+}
+
 func persistedModelMessage(t *testing.T, msg conversation.ModelMessage) json.RawMessage {
 	t.Helper()
 	return mustJSON(t, msg)

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -453,6 +453,7 @@
     "compact": {
       "unavailable": "Compaction isn't available right now.",
       "done": "✅ Context compacted.",
+      "noop": "Nothing to compact right now.",
       "noModel": "No compaction or chat model is configured for this bot."
     },
     "toolApproval": {

--- a/internal/i18n/locales/ja.json
+++ b/internal/i18n/locales/ja.json
@@ -453,6 +453,7 @@
     "compact": {
       "unavailable": "現在、圧縮は利用できません。",
       "done": "✅ コンテキストが圧縮されました。",
+      "noop": "現在、圧縮できるコンテキストはありません。",
       "noModel": "このBotには圧縮Modelやチャット Modelが構成されていません。"
     },
     "toolApproval": {

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -453,6 +453,7 @@
     "compact": {
       "unavailable": "上下文压缩暂不可用。",
       "done": "✅ 上下文已压缩。",
+      "noop": "当前没有可压缩的内容。",
       "noModel": "此机器人未配置压缩模型或对话模型。"
     },
     "toolApproval": {


### PR DESCRIPTION
stacked on #713

## Summary
- 收紧 compaction selection 的选择窗口语义，selection 消费 typed history record。
- 不可解析行保留为 must-keep barrier；渲染为空的行（reasoning-only 等）不进入 summarizer prompt 也不被标记。
- **一个 compaction log 只覆盖一段连续历史区间**（single gap-free span per `compact_id`）：must-keep 岛（ask_user、barrier）把候选窗口切成 runs，单次 pass 只标记第一个可产出的 run；读路径按首行位置原位替换，永不跨岛重排。
- `CompactPolicyMustKeep` 跨整个 tool exchange 传播；ask_user 相关行不可进入压缩集合。
- entries 与 marked ids 由同一循环产出，summarizer 看到的内容与被标记的行严格一致；无法整体标记的 exchange 既不标记也不进 prompt。
- `RunCompactionSync` 返回 session 级 `Result{Status: ok|noop, Summary, MessageCount}`：resolver 仅在 `ok` 时 reload + strip（noop 保持本轮上下文原样，接受本轮可能仍超阈值、下一轮重估）；`/compact` 与 HTTP 端点如实报告 noop。
- 同 session 已有 compaction 在途时，同步调用方等待 owner 完成信号并复用其结果（ctx 可取消，取消降级 noop）；async trigger 保持立即跳过。attach 优先于冷却检查；manual 穿过 noop owner 时重试以兼顾 bypass 语义（已取消者不重试）。
- 每 session 失败冷却（5 分钟）：仅真实模型失败武装；调用方 ctx 取消/超时不武装（client 自身超时在 live ctx 下照常武装）；manual（slash/HTTP）绕过冷却且成功会清除冷却；panic（含 pre-hook）向 waiter 发布失败、武装冷却后重抛，pre-hook 普通策略错误不武装。
- 回收谓词与读路径对齐：行仅在其 compact log `status='ok' AND summary <> ''` 时被排除；崩溃搁浅行、error/pending log 行、旧版 `ok+空 summary` poison 行全部可重新选取（含 `TEST_POSTGRES_DSN` 门控的真实 SQL 集成测试）。
- summarizer prompt 预算统一且为硬界：prior_context 与 entries 共享 `MaxCompactTokens`（prior 上限 1/4、含分隔符记账与截断 marker 预留，从 entries 预算中扣除；entries 超额时 prior 优先牺牲至清零）；trim 成本按渲染字节计费（usage 域仅用于选择压力），仅可标记组计费、每行下限 1 token；单组超总额时截断渲染内容而非丢 entry（ids/entries 对齐不破坏，尾部最小成本预留保证总和精确守界）；输入按最旧 exchange group 前缀裁剪，多轮从前往后推进、coverage 保持时序。
- 持久化失败不再吞掉：`CompleteCompactionLog` 失败时本次运行报错（行保持可回收），不返回虚假 `ok`。

## Boundary
- selector 只判断"哪些历史记录可以被 compact / keep"，不负责生成 summary。
- tool closure 是不可破坏边界；ask_user 语义行必须保留在原文中。
- 一个 `compact_id` 的标记集必须是 gap-free 的连续历史区间——这是读路径原位替换不重排的前提，由 selector 侧保证并有 selector→read-path 端到端配对测试锁定。
- 数据库读取顺序稳定（turn_position, turn_message_seq, created_at, id）。
- 触发语义（TargetTokens/ratio、async 分子、阈值策略）不在本 PR 范围内，维持 main 现状。

## 已知遗留（非 block）
- 互斥与冷却为进程内状态；多副本部署的 DB 级 lease/CAS 与 atomic finalize 留给后续 executor-hardening PR（单实例部署安全）。
- SQL 谓词集成测试由 `TEST_POSTGRES_DSN` 门控，CI 尚未提供 Postgres 服务时会 skip（本地已跑通）。
- compaction log 的 `model_id` 写入的是 provider 模型字符串解析结果（恒 NULL），为 main 上既有问题，另行处理。
- OK 路径 reload 后 `stripToolMessages` 与后续通用路径各执行一次（幂等，仅多一次遍历）。
