### PR TITLE
feat(context): compaction summary parity for discuss and pipeline chat

### DIFF
--- a/cmd/internal/channel/providers.go
+++ b/cmd/internal/channel/providers.go
@@ -92,10 +92,11 @@ func provideEventStore(log *slog.Logger, queries dbstore.Queries) *timeline.Even
 	return timeline.NewEventStore(log, queries)
 }
 
-func provideDiscussDriver(log *slog.Logger, eventStore *timeline.EventStore, msgService *message.DBService) *discuss.DiscussDriver {
+func provideDiscussDriver(log *slog.Logger, eventStore *timeline.EventStore, msgService *message.DBService, queries dbstore.Queries) *discuss.DiscussDriver {
 	return discuss.NewDiscussDriver(discuss.DiscussDriverDeps{
 		MessageService: msgService,
 		CursorStore:    eventStore,
+		Artifacts:      compaction.NewTimelineArtifactSource(queries),
 		Logger:         log,
 	})
 }

--- a/db/postgres/migrations/0001_init.down.sql
+++ b/db/postgres/migrations/0001_init.down.sql
@@ -41,6 +41,7 @@ DROP TABLE IF EXISTS bot_session_events CASCADE;
 DROP TABLE IF EXISTS bot_session_discuss_cursors CASCADE;
 DROP TABLE IF EXISTS bot_sessions CASCADE;
 DROP SEQUENCE IF EXISTS session_runtime_fencing_token_seq;
+DROP SEQUENCE IF EXISTS bot_session_event_cursor_seq;
 DROP TABLE IF EXISTS bot_channel_routes CASCADE;
 DROP TABLE IF EXISTS channel_identity_bind_codes CASCADE;
 DROP TABLE IF EXISTS bot_channel_configs CASCADE;

--- a/db/postgres/migrations/0001_init.up.sql
+++ b/db/postgres/migrations/0001_init.up.sql
@@ -554,6 +554,11 @@ CREATE INDEX IF NOT EXISTS idx_bot_channel_routes_bot ON bot_channel_routes(bot_
 -- bot_sessions: chat sessions within a bot, optionally linked to a channel route.
 CREATE SEQUENCE IF NOT EXISTS session_runtime_fencing_token_seq AS BIGINT NO CYCLE;
 
+CREATE SEQUENCE IF NOT EXISTS bot_session_event_cursor_seq
+  AS BIGINT
+  MINVALUE 1
+  MAXVALUE 9007199254740991;
+
 CREATE TABLE IF NOT EXISTS bot_sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   bot_id UUID NOT NULL REFERENCES bots(id) ON DELETE CASCADE,
@@ -709,6 +714,7 @@ CREATE TABLE IF NOT EXISTS bot_session_discuss_cursors (
   route_id UUID REFERENCES bot_channel_routes(id) ON DELETE SET NULL,
   source TEXT NOT NULL DEFAULT '',
   consumed_cursor BIGINT NOT NULL DEFAULT 0,
+  consumed_event_cursor BIGINT NOT NULL DEFAULT 0,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (session_id, scope_key)
 );

--- a/db/postgres/migrations/0120_discuss_event_cursor.down.sql
+++ b/db/postgres/migrations/0120_discuss_event_cursor.down.sql
@@ -1,0 +1,7 @@
+-- 0120_discuss_event_cursor
+-- Drop the discuss event-cursor column and the session event cursor sequence.
+
+ALTER TABLE bot_session_discuss_cursors
+  DROP COLUMN IF EXISTS consumed_event_cursor;
+
+DROP SEQUENCE IF EXISTS bot_session_event_cursor_seq;

--- a/db/postgres/migrations/0120_discuss_event_cursor.up.sql
+++ b/db/postgres/migrations/0120_discuss_event_cursor.up.sql
@@ -1,0 +1,77 @@
+-- 0120_discuss_event_cursor
+-- Allocate monotonic JSON-safe session event cursors and track discuss
+-- consumption in the cursor domain alongside the legacy source-time cursor.
+
+CREATE SEQUENCE IF NOT EXISTS bot_session_event_cursor_seq
+  AS BIGINT
+  MINVALUE 1
+  MAXVALUE 9007199254740991;
+
+ALTER TABLE bot_session_discuss_cursors
+  ADD COLUMN IF NOT EXISTS consumed_event_cursor BIGINT NOT NULL DEFAULT 0;
+
+ALTER POLICY teams_self_select ON public.teams USING (true);
+
+DO $$
+DECLARE
+  migration_team_id UUID;
+  previous_team_id TEXT;
+  legacy_floor BIGINT := 1;
+  team_floor BIGINT;
+  current_floor BIGINT;
+  clock_floor BIGINT;
+  cursor_floor BIGINT;
+BEGIN
+  previous_team_id := current_setting('memoh.team_id', true);
+
+  FOR migration_team_id IN SELECT id FROM public.teams ORDER BY id LOOP
+    PERFORM set_config('memoh.team_id', migration_team_id::text, true);
+
+    SELECT COALESCE(MAX(
+      CASE
+        WHEN event_data->>'event_cursor' ~ '^[1-9][0-9]{0,15}$'
+          THEN LEAST((event_data->>'event_cursor')::numeric, 9007199254740991)::bigint
+        ELSE GREATEST(received_at_ms, 1)
+      END
+    ), 1)
+    INTO team_floor
+    FROM bot_session_events
+    WHERE team_id = migration_team_id;
+
+    legacy_floor := GREATEST(legacy_floor, team_floor);
+
+    UPDATE bot_session_discuss_cursors AS c
+    SET consumed_event_cursor = COALESCE((
+      SELECT COALESCE(
+        MAX(
+          CASE
+            WHEN e.event_data->>'event_cursor' ~ '^[1-9][0-9]{0,15}$' THEN
+              CASE
+                WHEN (e.event_data->>'event_cursor')::numeric <= 9007199254740991
+                  THEN (e.event_data->>'event_cursor')::bigint
+              END
+          END
+        ),
+        MAX(e.received_at_ms)
+      )
+      FROM bot_session_events AS e
+      WHERE e.team_id = migration_team_id
+        AND e.session_id = c.session_id
+        AND e.received_at_ms <= c.consumed_cursor
+    ), 0)
+    WHERE c.team_id = migration_team_id
+      AND c.consumed_event_cursor = 0;
+  END LOOP;
+
+  SELECT last_value INTO current_floor FROM bot_session_event_cursor_seq;
+  clock_floor := FLOOR(EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint;
+  cursor_floor := GREATEST(legacy_floor, current_floor, clock_floor);
+  IF cursor_floor >= 9007199254740991 THEN
+    RAISE EXCEPTION 'session event cursor exhausted JSON-safe integer range';
+  END IF;
+  PERFORM setval('bot_session_event_cursor_seq', cursor_floor, true);
+  PERFORM set_config('memoh.team_id', COALESCE(previous_team_id, ''), true);
+END $$;
+
+ALTER POLICY teams_self_select ON public.teams
+  USING (id = public.memoh_current_team_id());

--- a/db/postgres/migrations/0120_discuss_event_cursor.up.sql
+++ b/db/postgres/migrations/0120_discuss_event_cursor.up.sql
@@ -30,8 +30,9 @@ BEGIN
     SELECT COALESCE(MAX(
       CASE
         WHEN event_data->>'event_cursor' ~ '^[1-9][0-9]{0,15}$'
-          THEN LEAST((event_data->>'event_cursor')::numeric, 9007199254740991)::bigint
-        ELSE GREATEST(received_at_ms, 1)
+          AND (event_data->>'event_cursor')::numeric <= 4503599627370495
+          THEN (event_data->>'event_cursor')::bigint
+        ELSE LEAST(GREATEST(received_at_ms, 1), 4503599627370495)
       END
     ), 1)
     INTO team_floor
@@ -47,12 +48,12 @@ BEGIN
           CASE
             WHEN e.event_data->>'event_cursor' ~ '^[1-9][0-9]{0,15}$' THEN
               CASE
-                WHEN (e.event_data->>'event_cursor')::numeric <= 9007199254740991
+                WHEN (e.event_data->>'event_cursor')::numeric <= 4503599627370495
                   THEN (e.event_data->>'event_cursor')::bigint
               END
           END
         ),
-        MAX(e.received_at_ms)
+        LEAST(MAX(e.received_at_ms), 4503599627370495)
       )
       FROM bot_session_events AS e
       WHERE e.team_id = migration_team_id

--- a/db/postgres/migrations/0120_discuss_event_cursor.up.sql
+++ b/db/postgres/migrations/0120_discuss_event_cursor.up.sql
@@ -29,9 +29,12 @@ BEGIN
 
     SELECT COALESCE(MAX(
       CASE
-        WHEN event_data->>'event_cursor' ~ '^[1-9][0-9]{0,15}$'
-          AND (event_data->>'event_cursor')::numeric <= 4503599627370495
-          THEN (event_data->>'event_cursor')::bigint
+        WHEN event_data->>'event_cursor' ~ '^[1-9][0-9]{0,15}$' THEN
+          CASE
+            WHEN (event_data->>'event_cursor')::numeric <= 4503599627370495
+              THEN (event_data->>'event_cursor')::bigint
+            ELSE LEAST(GREATEST(received_at_ms, 1), 4503599627370495)
+          END
         ELSE LEAST(GREATEST(received_at_ms, 1), 4503599627370495)
       END
     ), 1)

--- a/db/postgres/queries/session_events.sql
+++ b/db/postgres/queries/session_events.sql
@@ -1,6 +1,12 @@
 -- name: NextSessionEventCursor :one
 SELECT nextval('bot_session_event_cursor_seq')::bigint;
 
+-- name: EnsureSessionEventCursorFloor :one
+SELECT setval('bot_session_event_cursor_seq', GREATEST(
+  nextval('bot_session_event_cursor_seq'),
+  sqlc.arg(min_cursor)::bigint
+), true)::bigint;
+
 -- name: CreateSessionEvent :one
 INSERT INTO bot_session_events (
   bot_id,

--- a/db/postgres/queries/session_events.sql
+++ b/db/postgres/queries/session_events.sql
@@ -1,3 +1,6 @@
+-- name: NextSessionEventCursor :one
+SELECT nextval('bot_session_event_cursor_seq')::bigint;
+
 -- name: CreateSessionEvent :one
 INSERT INTO bot_session_events (
   bot_id,

--- a/db/postgres/queries/session_events.sql
+++ b/db/postgres/queries/session_events.sql
@@ -17,12 +17,12 @@ RETURNING id;
 -- name: ListSessionEventsBySession :many
 SELECT * FROM bot_session_events
 WHERE team_id = public.memoh_current_team_id() AND session_id = $1
-ORDER BY received_at_ms ASC;
+ORDER BY received_at_ms ASC, created_at ASC, id ASC;
 
 -- name: ListSessionEventsBySessionAfter :many
 SELECT * FROM bot_session_events
 WHERE team_id = public.memoh_current_team_id() AND session_id = $1 AND received_at_ms >= $2
-ORDER BY received_at_ms ASC;
+ORDER BY received_at_ms ASC, created_at ASC, id ASC;
 
 -- name: ListSessionEventsByBot :many
 SELECT * FROM bot_session_events

--- a/db/postgres/queries/session_events.sql
+++ b/db/postgres/queries/session_events.sql
@@ -1,12 +1,6 @@
 -- name: NextSessionEventCursor :one
 SELECT nextval('bot_session_event_cursor_seq')::bigint;
 
--- name: EnsureSessionEventCursorFloor :one
-SELECT setval('bot_session_event_cursor_seq', GREATEST(
-  nextval('bot_session_event_cursor_seq'),
-  sqlc.arg(min_cursor)::bigint
-), true)::bigint;
-
 -- name: CreateSessionEvent :one
 INSERT INTO bot_session_events (
   bot_id,

--- a/db/postgres/queries/sessions.sql
+++ b/db/postgres/queries/sessions.sql
@@ -420,19 +420,21 @@ WHERE team_id = public.memoh_current_team_id()
 
 -- name: UpsertSessionDiscussCursor :one
 INSERT INTO bot_session_discuss_cursors (
-  session_id, scope_key, route_id, source, consumed_cursor
+  session_id, scope_key, route_id, source, consumed_cursor, consumed_event_cursor
 )
 VALUES (
   sqlc.arg(session_id),
   sqlc.arg(scope_key),
   sqlc.narg(route_id)::uuid,
   sqlc.arg(source),
-  sqlc.arg(consumed_cursor)
+  sqlc.arg(consumed_cursor),
+  sqlc.arg(consumed_event_cursor)
 )
 ON CONFLICT (team_id, session_id, scope_key) DO UPDATE
 SET route_id = COALESCE(EXCLUDED.route_id, bot_session_discuss_cursors.route_id),
     source = EXCLUDED.source,
     consumed_cursor = GREATEST(bot_session_discuss_cursors.consumed_cursor, EXCLUDED.consumed_cursor),
+    consumed_event_cursor = GREATEST(bot_session_discuss_cursors.consumed_event_cursor, EXCLUDED.consumed_event_cursor),
     updated_at = now()
 RETURNING *;
 

--- a/internal/agent/application/service_history_messages.go
+++ b/internal/agent/application/service_history_messages.go
@@ -9,6 +9,7 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/agent/context/compaction"
 	userinput "github.com/memohai/memoh/internal/agent/decision/input"
 	"github.com/memohai/memoh/internal/chat/timeline"
 )
@@ -28,13 +29,15 @@ func (s *Service) buildMessagesFromPipeline(ctx context.Context, req ChatRequest
 	}
 
 	trs := s.loadTurnResponses(ctx, sessionID)
+	artifacts := s.loadTimelineArtifacts(ctx, req.BotID, sessionID)
 
-	composed := timeline.ComposeContext(rc, trs)
+	composed := timeline.ComposeContextWithArtifacts(rc, trs, artifacts)
 	if composed == nil {
 		return nil
 	}
 
 	messages := make([]ModelMessage, 0, len(composed.Messages))
+	pinned := make([]bool, 0, len(composed.Messages))
 	for _, m := range composed.Messages {
 		contentJSON := m.RawContent
 		if len(contentJSON) == 0 {
@@ -48,19 +51,35 @@ func (s *Service) buildMessagesFromPipeline(ctx context.Context, req ChatRequest
 			Role:    m.Role,
 			Content: contentJSON,
 		})
+		pinned = append(pinned, m.CompactionArtifactID != "")
 	}
 
 	// Apply context token budget trimming to pipeline path as well.
 	if contextTokenBudget > 0 && len(messages) > 0 {
-		messages = trimPipelineMessagesByTokens(s.logger, messages, contextTokenBudget)
+		messages = trimPipelineMessagesByTokens(s.logger, messages, pinned, contextTokenBudget)
 	}
 
 	return messages
 }
 
+// loadTimelineArtifacts projects the session's active compaction frontier for
+// timeline composition. Failures degrade to uncompacted context.
+func (s *Service) loadTimelineArtifacts(ctx context.Context, botID, sessionID string) []timeline.CompactionArtifact {
+	if s.queries == nil {
+		return nil
+	}
+	artifacts, err := compaction.NewTimelineArtifactSource(s.queries).ActiveCompactionArtifacts(ctx, botID, sessionID)
+	if err != nil {
+		s.logger.Warn("load compaction artifacts failed", slog.String("session_id", sessionID), slog.Any("error", err))
+		return nil
+	}
+	return artifacts
+}
+
 // trimPipelineMessagesByTokens trims pipeline-assembled messages to fit within
-// the context token budget using character-based estimation.
-func trimPipelineMessagesByTokens(log *slog.Logger, messages []ModelMessage, maxTokens int) []ModelMessage {
+// the context token budget using character-based estimation. Pinned messages
+// (compaction summaries) survive the dropped prefix.
+func trimPipelineMessagesByTokens(log *slog.Logger, messages []ModelMessage, pinned []bool, maxTokens int) []ModelMessage {
 	totalTokens := 0
 	cutoff := 0
 	for i := len(messages) - 1; i >= 0; i-- {
@@ -76,16 +95,28 @@ func trimPipelineMessagesByTokens(log *slog.Logger, messages []ModelMessage, max
 		cutoff++
 	}
 
-	if cutoff > 0 && log != nil {
+	if cutoff == 0 {
+		return messages
+	}
+
+	kept := make([]ModelMessage, 0, len(messages)-cutoff)
+	for i := 0; i < cutoff; i++ {
+		if i < len(pinned) && pinned[i] {
+			kept = append(kept, messages[i])
+		}
+	}
+	kept = append(kept, messages[cutoff:]...)
+
+	if log != nil {
 		log.Info("trimPipelineMessagesByTokens: context trimmed",
 			slog.Int("total_messages", len(messages)),
 			slog.Int("estimated_tokens", totalTokens),
 			slog.Int("max_tokens", maxTokens),
-			slog.Int("kept_messages", len(messages)-cutoff),
+			slog.Int("kept_messages", len(kept)),
 		)
 	}
 
-	return messages[cutoff:]
+	return kept
 }
 
 // loadTurnResponses loads recent assistant/tool messages from bot_history_messages

--- a/internal/agent/application/service_history_messages.go
+++ b/internal/agent/application/service_history_messages.go
@@ -29,7 +29,7 @@ func (s *Service) buildMessagesFromPipeline(ctx context.Context, req ChatRequest
 
 	trs := s.loadTurnResponses(ctx, sessionID)
 
-	composed := timeline.ComposeContext(rc, trs, "")
+	composed := timeline.ComposeContext(rc, trs)
 	if composed == nil {
 		return nil
 	}

--- a/internal/agent/application/service_history_messages_test.go
+++ b/internal/agent/application/service_history_messages_test.go
@@ -1,0 +1,162 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	compaction "github.com/memohai/memoh/internal/agent/context/compaction"
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/chat/timeline"
+	dbpkg "github.com/memohai/memoh/internal/db"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+)
+
+const (
+	pipelineTestBotID     = "11111111-1111-1111-1111-111111111111"
+	pipelineTestSessionID = "22222222-2222-2222-2222-222222222222"
+)
+
+type fakeArtifactLineageQueries struct {
+	dbstore.Queries
+	rows []sqlc.BotHistoryMessageCompact
+}
+
+func (f fakeArtifactLineageQueries) ListCompactionArtifactLineageBySession(context.Context, pgtype.UUID) ([]sqlc.BotHistoryMessageCompact, error) {
+	return f.rows, nil
+}
+
+func (fakeArtifactLineageQueries) GetCompactionLogByID(context.Context, pgtype.UUID) (sqlc.BotHistoryMessageCompact, error) {
+	return sqlc.BotHistoryMessageCompact{}, pgx.ErrNoRows
+}
+
+func (fakeArtifactLineageQueries) ListCompactionArtifactParentIDsBySuccessor(context.Context, sqlc.ListCompactionArtifactParentIDsBySuccessorParams) ([]pgtype.UUID, error) {
+	return nil, nil
+}
+
+func compactionLogRow(t *testing.T, summary string, coveredExternalID string, createdAtMs int64) sqlc.BotHistoryMessageCompact {
+	t.Helper()
+	coverage, err := json.Marshal([]compaction.CoveredSource{{
+		Ref: contextfrag.ContextRef{
+			Namespace:   "bot_history_message",
+			ID:          "33333333-3333-3333-3333-333333333333",
+			Schema:      contextfrag.SchemaContextRef,
+			HashAlgo:    contextfrag.HashAlgoSHA256,
+			HashScope:   contextfrag.HashScopeSourcePayload,
+			ContentHash: "deadbeef",
+		},
+		ExternalMessageID: coveredExternalID,
+		CreatedAtMs:       createdAtMs,
+	}})
+	if err != nil {
+		t.Fatalf("encode coverage: %v", err)
+	}
+	id, err := dbpkg.ParseUUID("44444444-4444-4444-4444-444444444444")
+	if err != nil {
+		t.Fatalf("parse artifact id: %v", err)
+	}
+	botID, err := dbpkg.ParseUUID(pipelineTestBotID)
+	if err != nil {
+		t.Fatalf("parse bot id: %v", err)
+	}
+	sessionID, err := dbpkg.ParseUUID(pipelineTestSessionID)
+	if err != nil {
+		t.Fatalf("parse session id: %v", err)
+	}
+	return sqlc.BotHistoryMessageCompact{
+		ID:            id,
+		BotID:         botID,
+		SessionID:     sessionID,
+		Status:        "ok",
+		Summary:       summary,
+		Coverage:      coverage,
+		AnchorStartMs: createdAtMs,
+		AnchorEndMs:   createdAtMs,
+	}
+}
+
+func pipelineTextEvent(messageID string, atMs int64, text string) timeline.MessageEvent {
+	return timeline.MessageEvent{
+		SessionID:    pipelineTestSessionID,
+		MessageID:    messageID,
+		ReceivedAtMs: atMs,
+		TimestampSec: atMs / 1000,
+		Content:      []timeline.ContentNode{{Type: "text", Text: text}},
+		Conversation: timeline.ConversationMeta{Channel: "telegram", ConversationType: "group"},
+	}
+}
+
+func TestBuildMessagesFromPipelineInsertsArtifactSummary(t *testing.T) {
+	t.Parallel()
+
+	pipeline := timeline.NewPipeline(timeline.RenderParams{})
+	pipeline.PushEvent(pipelineTestSessionID, pipelineTextEvent("m1", 1000, "old original"))
+	pipeline.PushEvent(pipelineTestSessionID, pipelineTextEvent("m2", 2000, "current question"))
+
+	svc := &Service{
+		pipeline: pipeline,
+		queries:  fakeArtifactLineageQueries{rows: []sqlc.BotHistoryMessageCompact{compactionLogRow(t, "compacted window", "m1", 1000)}},
+		logger:   slog.New(slog.DiscardHandler),
+	}
+
+	messages := svc.buildMessagesFromPipeline(context.Background(), ChatRequest{
+		BotID:    pipelineTestBotID,
+		ThreadID: pipelineTestSessionID,
+	}, 0)
+
+	if len(messages) != 2 {
+		t.Fatalf("expected summary + current message, got %d: %s", len(messages), messagesDebug(messages))
+	}
+	var summaryText string
+	if err := json.Unmarshal(messages[0].Content, &summaryText); err != nil {
+		t.Fatalf("decode summary content: %v", err)
+	}
+	if !strings.Contains(summaryText, "<summary>") || !strings.Contains(summaryText, "compacted window") {
+		t.Fatalf("expected leading summary, got %q", summaryText)
+	}
+	joined := messagesDebug(messages)
+	if strings.Contains(joined, "old original") {
+		t.Fatalf("covered original must be replaced, got %s", joined)
+	}
+	if !strings.Contains(joined, "current question") {
+		t.Fatalf("uncovered message must survive, got %s", joined)
+	}
+}
+
+func messagesDebug(messages []ModelMessage) string {
+	parts := make([]string, 0, len(messages))
+	for _, m := range messages {
+		parts = append(parts, m.Role+":"+string(m.Content))
+	}
+	return strings.Join(parts, "|")
+}
+
+func TestTrimPipelineMessagesKeepsPinnedSummaries(t *testing.T) {
+	t.Parallel()
+
+	messages := []ModelMessage{
+		{Role: "user", Content: newTextContent("<summary>\nold window\n</summary>")},
+		{Role: "user", Content: newTextContent(strings.Repeat("a", 400))},
+		{Role: "assistant", Content: newTextContent(strings.Repeat("b", 400))},
+		{Role: "user", Content: newTextContent("recent")},
+	}
+	pinned := []bool{true, false, false, false}
+
+	trimmed := trimPipelineMessagesByTokens(nil, messages, pinned, 40)
+
+	if len(trimmed) != 2 {
+		t.Fatalf("expected pinned summary + recent, got %s", messagesDebug(trimmed))
+	}
+	if !strings.Contains(string(trimmed[0].Content), "old window") {
+		t.Fatalf("pinned summary must survive trim, got %s", messagesDebug(trimmed))
+	}
+	if !strings.Contains(string(trimmed[1].Content), "recent") {
+		t.Fatalf("recent message must survive trim, got %s", messagesDebug(trimmed))
+	}
+}

--- a/internal/agent/application/service_history_messages_test.go
+++ b/internal/agent/application/service_history_messages_test.go
@@ -160,3 +160,37 @@ func TestTrimPipelineMessagesKeepsPinnedSummaries(t *testing.T) {
 		t.Fatalf("recent message must survive trim, got %s", messagesDebug(trimmed))
 	}
 }
+
+func TestBuildMessagesFromPipelineKeepsSummaryUnderBudget(t *testing.T) {
+	t.Parallel()
+
+	pipeline := timeline.NewPipeline(timeline.RenderParams{})
+	pipeline.PushEvent(pipelineTestSessionID, pipelineTextEvent("m1", 1000, "old original"))
+	pipeline.PushEvent(pipelineTestSessionID, pipelineTextEvent("m2", 2000, strings.Repeat("x", 4000)))
+	pipeline.PushEvent(pipelineTestSessionID, pipelineTextEvent("m3", 3000, "current question"))
+
+	svc := &Service{
+		pipeline: pipeline,
+		queries:  fakeArtifactLineageQueries{rows: []sqlc.BotHistoryMessageCompact{compactionLogRow(t, "compacted window", "m1", 1000)}},
+		logger:   slog.New(slog.DiscardHandler),
+	}
+
+	messages := svc.buildMessagesFromPipeline(context.Background(), ChatRequest{
+		BotID:    pipelineTestBotID,
+		ThreadID: pipelineTestSessionID,
+	}, 200)
+
+	// Consecutive rendered segments merge into one user message, so the tail
+	// here is a single oversized block: without pinning the budget would drop
+	// everything and the model would receive no context at all.
+	if len(messages) == 0 {
+		t.Fatal("artifact summary must survive a budget that drops the whole tail")
+	}
+	joined := messagesDebug(messages)
+	if !strings.Contains(joined, "compacted window") {
+		t.Fatalf("artifact summary must survive the dropped prefix, got %s", joined)
+	}
+	if strings.Contains(joined, strings.Repeat("x", 4000)) {
+		t.Fatalf("oversized tail should have been trimmed, got %d messages", len(messages))
+	}
+}

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -189,27 +189,24 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 		}
 	}
 
-	go s.maybeCompactDiscuss(context.WithoutCancel(ctx), cmd, resolved.ModelID)
+	// Compute pressure on this goroutine so the detached trigger holds a few
+	// scalars instead of pinning the whole composed context until it runs.
+	if compactable := discussCompactableTokens(cmd.DiscussMessages); compactable > 0 && s.compactionService != nil && s.settingsService != nil {
+		go s.maybeCompactDiscuss(context.WithoutCancel(ctx), cmd.BotID, cmd.ThreadID, resolved.ModelID, compactable)
+	}
 }
 
 // maybeCompactDiscuss re-evaluates compaction pressure after a native discuss
 // turn with the same trigger policy as the chat path. ACP discuss turns run
 // through streamTurnChat and inherit its trigger directly.
-func (s *Service) maybeCompactDiscuss(ctx context.Context, cmd turn.StartTurnCommand, modelID string) {
-	if s.compactionService == nil || s.settingsService == nil {
-		return
-	}
-	compactable := discussCompactableTokens(cmd.DiscussMessages)
-	if compactable <= 0 {
-		return
-	}
+func (s *Service) maybeCompactDiscuss(ctx context.Context, botID, threadID, modelID string, compactable int) {
 	budget := 0
 	if s.modelsService != nil && strings.TrimSpace(modelID) != "" {
 		if model, err := s.modelsService.GetByID(ctx, modelID); err == nil && model.Config.ContextWindow != nil {
 			budget = *model.Config.ContextWindow
 		}
 	}
-	s.maybeCompact(ctx, ChatRequest{BotID: cmd.BotID, ThreadID: cmd.ThreadID}, resolvedContext{
+	s.maybeCompact(ctx, ChatRequest{BotID: botID, ThreadID: threadID}, resolvedContext{
 		compactableTokens:      compactable,
 		compactableTokensKnown: true,
 		contextTokenBudget:     budget,

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -221,7 +221,7 @@ func (s *Service) maybeCompactDiscuss(ctx context.Context, cmd turn.StartTurnCom
 func discussCompactableTokens(messages []turn.DiscussMessage) int {
 	total := 0
 	for _, message := range messages {
-		if strings.HasPrefix(strings.TrimSpace(message.Content), "<summary>") {
+		if message.CompactionArtifactID != "" {
 			continue
 		}
 		size := len(message.RawContent)

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -188,6 +188,49 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 			}
 		}
 	}
+
+	go s.maybeCompactDiscuss(context.WithoutCancel(ctx), cmd, resolved.ModelID)
+}
+
+// maybeCompactDiscuss re-evaluates compaction pressure after a native discuss
+// turn with the same trigger policy as the chat path. ACP discuss turns run
+// through streamTurnChat and inherit its trigger directly.
+func (s *Service) maybeCompactDiscuss(ctx context.Context, cmd turn.StartTurnCommand, modelID string) {
+	if s.compactionService == nil || s.settingsService == nil {
+		return
+	}
+	compactable := discussCompactableTokens(cmd.DiscussMessages)
+	if compactable <= 0 {
+		return
+	}
+	budget := 0
+	if s.modelsService != nil && strings.TrimSpace(modelID) != "" {
+		if model, err := s.modelsService.GetByID(ctx, modelID); err == nil && model.Config.ContextWindow != nil {
+			budget = *model.Config.ContextWindow
+		}
+	}
+	s.maybeCompact(ctx, ChatRequest{BotID: cmd.BotID, ThreadID: cmd.ThreadID}, resolvedContext{
+		compactableTokens:      compactable,
+		compactableTokensKnown: true,
+		contextTokenBudget:     budget,
+	}, compactable)
+}
+
+// discussCompactableTokens estimates the raw history share of a discuss
+// context, excluding artifact summaries, in the chat trigger's token unit.
+func discussCompactableTokens(messages []turn.DiscussMessage) int {
+	total := 0
+	for _, message := range messages {
+		if strings.HasPrefix(strings.TrimSpace(message.Content), "<summary>") {
+			continue
+		}
+		size := len(message.RawContent)
+		if size == 0 {
+			size = len(message.Content)
+		}
+		total += size / 4
+	}
+	return total
 }
 
 func (s *Service) pumpDiscussACP(ctx context.Context, cmd turn.StartTurnCommand, h *discussHandle) {

--- a/internal/agent/application/turn_discuss_compaction_test.go
+++ b/internal/agent/application/turn_discuss_compaction_test.go
@@ -1,0 +1,37 @@
+package application
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/agent/turn"
+)
+
+func TestDiscussCompactableTokensExcludesSummaries(t *testing.T) {
+	t.Parallel()
+
+	messages := []turn.DiscussMessage{
+		{Role: "user", Content: "<summary>\ncompacted window\n</summary>"},
+		{Role: "user", Content: strings.Repeat("a", 400)},
+		{Role: "assistant", Content: "[tool call: lookup]", RawContent: json.RawMessage(strings.Repeat("b", 800))},
+	}
+
+	got := discussCompactableTokens(messages)
+	want := 400/4 + 800/4
+	if got != want {
+		t.Fatalf("discussCompactableTokens = %d, want %d", got, want)
+	}
+}
+
+func TestDiscussCompactableTokensEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := discussCompactableTokens(nil); got != 0 {
+		t.Fatalf("expected 0 for empty messages, got %d", got)
+	}
+	summaryOnly := []turn.DiscussMessage{{Role: "user", Content: "<summary>\nx\n</summary>"}}
+	if got := discussCompactableTokens(summaryOnly); got != 0 {
+		t.Fatalf("expected 0 for summary-only messages, got %d", got)
+	}
+}

--- a/internal/agent/application/turn_discuss_compaction_test.go
+++ b/internal/agent/application/turn_discuss_compaction_test.go
@@ -12,13 +12,14 @@ func TestDiscussCompactableTokensExcludesSummaries(t *testing.T) {
 	t.Parallel()
 
 	messages := []turn.DiscussMessage{
-		{Role: "user", Content: "<summary>\ncompacted window\n</summary>"},
+		{Role: "user", Content: "<summary>\ncompacted window\n</summary>", CompactionArtifactID: "a1"},
 		{Role: "user", Content: strings.Repeat("a", 400)},
 		{Role: "assistant", Content: "[tool call: lookup]", RawContent: json.RawMessage(strings.Repeat("b", 800))},
+		{Role: "user", Content: "<summary> pasted by a user " + strings.Repeat("c", 373)},
 	}
 
 	got := discussCompactableTokens(messages)
-	want := 400/4 + 800/4
+	want := 400/4 + 800/4 + 400/4
 	if got != want {
 		t.Fatalf("discussCompactableTokens = %d, want %d", got, want)
 	}
@@ -30,7 +31,7 @@ func TestDiscussCompactableTokensEmpty(t *testing.T) {
 	if got := discussCompactableTokens(nil); got != 0 {
 		t.Fatalf("expected 0 for empty messages, got %d", got)
 	}
-	summaryOnly := []turn.DiscussMessage{{Role: "user", Content: "<summary>\nx\n</summary>"}}
+	summaryOnly := []turn.DiscussMessage{{Role: "user", Content: "<summary>\nx\n</summary>", CompactionArtifactID: "a1"}}
 	if got := discussCompactableTokens(summaryOnly); got != 0 {
 		t.Fatalf("expected 0 for summary-only messages, got %d", got)
 	}

--- a/internal/agent/context/compaction/timeline_artifacts.go
+++ b/internal/agent/context/compaction/timeline_artifacts.go
@@ -1,0 +1,62 @@
+package compaction
+
+import (
+	"context"
+	"strings"
+
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+// TimelineArtifactSource loads the active artifact frontier of a session as
+// timeline projections for context composition.
+type TimelineArtifactSource struct {
+	projection ArtifactProjection
+}
+
+func NewTimelineArtifactSource(queries artifactProjectionQueries) TimelineArtifactSource {
+	return TimelineArtifactSource{projection: NewArtifactProjection(queries)}
+}
+
+func (s TimelineArtifactSource) ActiveCompactionArtifacts(ctx context.Context, botID, sessionID string) ([]timeline.CompactionArtifact, error) {
+	frontier, err := s.projection.LoadActiveSession(ctx, ArtifactOwner{
+		BotID:          botID,
+		SessionID:      sessionID,
+		SessionIDKnown: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return TimelineArtifacts(frontier.Artifacts), nil
+}
+
+// TimelineArtifacts projects active artifacts onto the timeline contract.
+// Artifacts without a trustworthy summary or coverage must not swallow their
+// original sources, so they are omitted entirely.
+func TimelineArtifacts(artifacts []Artifact) []timeline.CompactionArtifact {
+	projected := make([]timeline.CompactionArtifact, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if artifact.CoverageMalformed || strings.TrimSpace(artifact.Summary) == "" {
+			continue
+		}
+		sources := make([]timeline.CompactionSource, 0, len(artifact.Coverage))
+		for _, source := range artifact.Coverage {
+			sources = append(sources, timeline.CompactionSource{
+				HistoryMessageID:  source.Ref.ID,
+				ExternalMessageID: source.ExternalMessageID,
+				CreatedAtMs:       source.CreatedAtMs,
+			})
+		}
+		coverageAsOfMs := int64(0)
+		if !artifact.StartedAt.IsZero() {
+			coverageAsOfMs = artifact.StartedAt.UnixMilli()
+		}
+		projected = append(projected, timeline.CompactionArtifact{
+			ID:             artifact.ID,
+			Summary:        artifact.Summary,
+			AnchorStartMs:  artifact.AnchorStartMs,
+			CoverageAsOfMs: coverageAsOfMs,
+			Sources:        sources,
+		})
+	}
+	return projected
+}

--- a/internal/agent/context/compaction/timeline_artifacts.go
+++ b/internal/agent/context/compaction/timeline_artifacts.go
@@ -31,11 +31,13 @@ func (s TimelineArtifactSource) ActiveCompactionArtifacts(ctx context.Context, b
 
 // TimelineArtifacts projects active artifacts onto the timeline contract.
 // Artifacts without a trustworthy summary or coverage must not swallow their
-// original sources, so they are omitted entirely.
+// original sources, and legacy artifacts without any coverage cannot replace
+// anything — injecting them would duplicate the history they summarize — so
+// both are omitted entirely.
 func TimelineArtifacts(artifacts []Artifact) []timeline.CompactionArtifact {
 	projected := make([]timeline.CompactionArtifact, 0, len(artifacts))
 	for _, artifact := range artifacts {
-		if artifact.CoverageMalformed || strings.TrimSpace(artifact.Summary) == "" {
+		if artifact.CoverageMalformed || len(artifact.Coverage) == 0 || strings.TrimSpace(artifact.Summary) == "" {
 			continue
 		}
 		sources := make([]timeline.CompactionSource, 0, len(artifact.Coverage))

--- a/internal/agent/context/compaction/timeline_artifacts_test.go
+++ b/internal/agent/context/compaction/timeline_artifacts_test.go
@@ -1,0 +1,59 @@
+package compaction
+
+import (
+	"testing"
+	"time"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestTimelineArtifactsProjectsFrontier(t *testing.T) {
+	started := time.UnixMilli(4000).UTC()
+	artifacts := []Artifact{{
+		ID:            "a1",
+		Summary:       "window summary",
+		AnchorStartMs: 1000,
+		StartedAt:     started,
+		Coverage: []CoveredSource{
+			{Ref: contextfrag.ContextRef{ID: "h1"}, ExternalMessageID: "m1", CreatedAtMs: 1000},
+			{Ref: contextfrag.ContextRef{ID: "h2"}, CreatedAtMs: 2000},
+		},
+	}}
+
+	projected := TimelineArtifacts(artifacts)
+	if len(projected) != 1 {
+		t.Fatalf("expected 1 artifact, got %d", len(projected))
+	}
+	artifact := projected[0]
+	if artifact.ID != "a1" || artifact.Summary != "window summary" || artifact.AnchorStartMs != 1000 {
+		t.Fatalf("unexpected artifact projection %+v", artifact)
+	}
+	if artifact.CoverageAsOfMs != 4000 {
+		t.Fatalf("expected coverage as-of from StartedAt, got %d", artifact.CoverageAsOfMs)
+	}
+	if len(artifact.Sources) != 2 {
+		t.Fatalf("expected 2 sources, got %+v", artifact.Sources)
+	}
+	if artifact.Sources[0].HistoryMessageID != "h1" || artifact.Sources[0].ExternalMessageID != "m1" || artifact.Sources[0].CreatedAtMs != 1000 {
+		t.Fatalf("unexpected first source %+v", artifact.Sources[0])
+	}
+	if artifact.Sources[1].HistoryMessageID != "h2" || artifact.Sources[1].ExternalMessageID != "" {
+		t.Fatalf("unexpected second source %+v", artifact.Sources[1])
+	}
+}
+
+func TestTimelineArtifactsSkipsUnusableArtifacts(t *testing.T) {
+	artifacts := []Artifact{
+		{ID: "blank", Summary: "   "},
+		{ID: "malformed", Summary: "usable text", CoverageMalformed: true},
+		{ID: "ok", Summary: "kept"},
+	}
+
+	projected := TimelineArtifacts(artifacts)
+	if len(projected) != 1 || projected[0].ID != "ok" {
+		t.Fatalf("expected only usable artifact, got %+v", projected)
+	}
+	if projected[0].CoverageAsOfMs != 0 {
+		t.Fatalf("expected zero coverage as-of without StartedAt, got %d", projected[0].CoverageAsOfMs)
+	}
+}

--- a/internal/agent/context/compaction/timeline_artifacts_test.go
+++ b/internal/agent/context/compaction/timeline_artifacts_test.go
@@ -44,9 +44,10 @@ func TestTimelineArtifactsProjectsFrontier(t *testing.T) {
 
 func TestTimelineArtifactsSkipsUnusableArtifacts(t *testing.T) {
 	artifacts := []Artifact{
-		{ID: "blank", Summary: "   "},
-		{ID: "malformed", Summary: "usable text", CoverageMalformed: true},
-		{ID: "ok", Summary: "kept"},
+		{ID: "blank", Summary: "   ", Coverage: []CoveredSource{{ExternalMessageID: "m0", CreatedAtMs: 1}}},
+		{ID: "malformed", Summary: "usable text", CoverageMalformed: true, Coverage: []CoveredSource{{ExternalMessageID: "m0", CreatedAtMs: 1}}},
+		{ID: "legacy-empty-coverage", Summary: "cannot replace anything"},
+		{ID: "ok", Summary: "kept", Coverage: []CoveredSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}}},
 	}
 
 	projected := TimelineArtifacts(artifacts)

--- a/internal/agent/turn/turn.go
+++ b/internal/agent/turn/turn.go
@@ -110,9 +110,10 @@ type StartTurnCommand struct {
 
 // DiscussMessage is one composed context message for a discuss turn.
 type DiscussMessage struct {
-	Role       string          `json:"role"`
-	Content    string          `json:"content"`
-	RawContent json.RawMessage `json:"raw_content,omitempty"`
+	Role                 string          `json:"role"`
+	Content              string          `json:"content"`
+	RawContent           json.RawMessage `json:"raw_content,omitempty"`
+	CompactionArtifactID string          `json:"compaction_artifact_id,omitempty"`
 }
 
 // DiscussImageRef references an image attachment to inline as vision input.

--- a/internal/botbackup/import.go
+++ b/internal/botbackup/import.go
@@ -1268,11 +1268,12 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 				continue
 			}
 			if _, err := q.UpsertSessionDiscussCursor(ctx, sqlc.UpsertSessionDiscussCursorParams{
-				SessionID:      sessionID,
-				ScopeKey:       cursor.ScopeKey,
-				RouteID:        pgtype.UUID{},
-				Source:         cursor.Source,
-				ConsumedCursor: cursor.ConsumedCursor,
+				SessionID:           sessionID,
+				ScopeKey:            cursor.ScopeKey,
+				RouteID:             pgtype.UUID{},
+				Source:              cursor.Source,
+				ConsumedCursor:      cursor.ConsumedCursor,
+				ConsumedEventCursor: cursor.ConsumedEventCursor,
 			}); err != nil {
 				return fmt.Errorf("discuss cursor: %w", err)
 			}
@@ -1285,6 +1286,7 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 		if err != nil {
 			return err
 		}
+		maxEventCursor := int64(0)
 		for _, item := range events {
 			sessionID := pgtype.UUID{}
 			if item.SessionID.Valid {
@@ -1306,6 +1308,14 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 				return fmt.Errorf("session event: %w", err)
 			}
 			eventMap[item.ID.String()] = created
+			if cursor := restoredEventCursor(item.EventData); cursor > maxEventCursor {
+				maxEventCursor = cursor
+			}
+		}
+		if maxEventCursor > 0 {
+			if _, err := q.EnsureSessionEventCursorFloor(ctx, maxEventCursor); err != nil {
+				return fmt.Errorf("session event cursor floor: %w", err)
+			}
 		}
 	}
 
@@ -2146,4 +2156,16 @@ func stringMapFromAny(value any) map[string]string {
 	default:
 		return nil
 	}
+}
+
+// restoredEventCursor extracts the source deployment's event cursor from a
+// restored payload so the local sequence can be raised above it.
+func restoredEventCursor(eventData []byte) int64 {
+	var payload struct {
+		EventCursor int64 `json:"event_cursor"`
+	}
+	if err := json.Unmarshal(eventData, &payload); err != nil {
+		return 0
+	}
+	return payload.EventCursor
 }

--- a/internal/botbackup/import.go
+++ b/internal/botbackup/import.go
@@ -25,6 +25,7 @@ import (
 	"github.com/memohai/memoh/internal/bots"
 	"github.com/memohai/memoh/internal/channel"
 	sessionpkg "github.com/memohai/memoh/internal/chat/thread"
+	"github.com/memohai/memoh/internal/chat/timeline"
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -2165,6 +2166,9 @@ func restoredEventCursor(eventData []byte) int64 {
 		EventCursor int64 `json:"event_cursor"`
 	}
 	if err := json.Unmarshal(eventData, &payload); err != nil {
+		return 0
+	}
+	if payload.EventCursor <= 0 || payload.EventCursor >= timeline.MaxJSONSafeEventCursor {
 		return 0
 	}
 	return payload.EventCursor

--- a/internal/botbackup/import.go
+++ b/internal/botbackup/import.go
@@ -1274,7 +1274,7 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 				RouteID:             pgtype.UUID{},
 				Source:              cursor.Source,
 				ConsumedCursor:      cursor.ConsumedCursor,
-				ConsumedEventCursor: cursor.ConsumedEventCursor,
+				ConsumedEventCursor: restoredConsumedEventCursor(cursor.ConsumedEventCursor),
 			}); err != nil {
 				return fmt.Errorf("discuss cursor: %w", err)
 			}
@@ -2168,8 +2168,17 @@ func restoredEventCursor(eventData []byte) int64 {
 	if err := json.Unmarshal(eventData, &payload); err != nil {
 		return 0
 	}
-	if payload.EventCursor <= 0 || payload.EventCursor >= timeline.MaxJSONSafeEventCursor {
+	if payload.EventCursor <= 0 || payload.EventCursor > timeline.MaxTrustedEventCursor {
 		return 0
 	}
 	return payload.EventCursor
+}
+
+// restoredConsumedEventCursor bounds a restored discuss watermark so a
+// poisoned backup cannot suppress future local events.
+func restoredConsumedEventCursor(cursor int64) int64 {
+	if cursor <= 0 || cursor > timeline.MaxTrustedEventCursor {
+		return 0
+	}
+	return cursor
 }

--- a/internal/botbackup/import.go
+++ b/internal/botbackup/import.go
@@ -25,7 +25,6 @@ import (
 	"github.com/memohai/memoh/internal/bots"
 	"github.com/memohai/memoh/internal/channel"
 	sessionpkg "github.com/memohai/memoh/internal/chat/thread"
-	"github.com/memohai/memoh/internal/chat/timeline"
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -1274,7 +1273,7 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 				RouteID:             pgtype.UUID{},
 				Source:              cursor.Source,
 				ConsumedCursor:      cursor.ConsumedCursor,
-				ConsumedEventCursor: restoredConsumedEventCursor(cursor.ConsumedEventCursor),
+				ConsumedEventCursor: 0,
 			}); err != nil {
 				return fmt.Errorf("discuss cursor: %w", err)
 			}
@@ -1287,7 +1286,6 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 		if err != nil {
 			return err
 		}
-		maxEventCursor := int64(0)
 		for _, item := range events {
 			sessionID := pgtype.UUID{}
 			if item.SessionID.Valid {
@@ -1300,7 +1298,7 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 				BotID:                   pgBotID,
 				SessionID:               sessionID,
 				EventKind:               item.EventKind,
-				EventData:               defaultJSONMap(item.EventData),
+				EventData:               sanitizeRestoredEventData(defaultJSONMap(item.EventData)),
 				ExternalMessageID:       item.ExternalMessageID,
 				SenderChannelIdentityID: pgtype.UUID{},
 				ReceivedAtMs:            item.ReceivedAtMs,
@@ -1309,14 +1307,6 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 				return fmt.Errorf("session event: %w", err)
 			}
 			eventMap[item.ID.String()] = created
-			if cursor := restoredEventCursor(item.EventData); cursor > maxEventCursor {
-				maxEventCursor = cursor
-			}
-		}
-		if maxEventCursor > 0 {
-			if _, err := q.EnsureSessionEventCursorFloor(ctx, maxEventCursor); err != nil {
-				return fmt.Errorf("session event cursor floor: %w", err)
-			}
 		}
 	}
 
@@ -2159,26 +2149,21 @@ func stringMapFromAny(value any) map[string]string {
 	}
 }
 
-// restoredEventCursor extracts the source deployment's event cursor from a
-// restored payload so the local sequence can be raised above it.
-func restoredEventCursor(eventData []byte) int64 {
-	var payload struct {
-		EventCursor int64 `json:"event_cursor"`
-	}
+// sanitizeRestoredEventData strips instance-local event cursors from restored
+// payloads: source-instance coordinates would race or poison the local
+// sequence, and cursor-less events gate correctly in the source-time domain.
+func sanitizeRestoredEventData(eventData []byte) []byte {
+	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(eventData, &payload); err != nil {
-		return 0
+		return eventData
 	}
-	if payload.EventCursor <= 0 || payload.EventCursor > timeline.MaxTrustedEventCursor {
-		return 0
+	if _, ok := payload["event_cursor"]; !ok {
+		return eventData
 	}
-	return payload.EventCursor
-}
-
-// restoredConsumedEventCursor bounds a restored discuss watermark so a
-// poisoned backup cannot suppress future local events.
-func restoredConsumedEventCursor(cursor int64) int64 {
-	if cursor <= 0 || cursor > timeline.MaxTrustedEventCursor {
-		return 0
+	delete(payload, "event_cursor")
+	sanitized, err := json.Marshal(payload)
+	if err != nil {
+		return eventData
 	}
-	return cursor
+	return sanitized
 }

--- a/internal/botbackup/import.go
+++ b/internal/botbackup/import.go
@@ -1267,14 +1267,7 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 			if !sessionID.Valid || strings.TrimSpace(cursor.ScopeKey) == "" {
 				continue
 			}
-			if _, err := q.UpsertSessionDiscussCursor(ctx, sqlc.UpsertSessionDiscussCursorParams{
-				SessionID:           sessionID,
-				ScopeKey:            cursor.ScopeKey,
-				RouteID:             pgtype.UUID{},
-				Source:              cursor.Source,
-				ConsumedCursor:      cursor.ConsumedCursor,
-				ConsumedEventCursor: 0,
-			}); err != nil {
+			if _, err := q.UpsertSessionDiscussCursor(ctx, restoredDiscussCursorParams(sessionID, cursor)); err != nil {
 				return fmt.Errorf("discuss cursor: %w", err)
 			}
 		}
@@ -1294,15 +1287,7 @@ func (s *Service) restoreHistory(ctx context.Context, actorUserID, botID string,
 			if !sessionID.Valid {
 				continue
 			}
-			created, err := q.CreateSessionEvent(ctx, sqlc.CreateSessionEventParams{
-				BotID:                   pgBotID,
-				SessionID:               sessionID,
-				EventKind:               item.EventKind,
-				EventData:               sanitizeRestoredEventData(defaultJSONMap(item.EventData)),
-				ExternalMessageID:       item.ExternalMessageID,
-				SenderChannelIdentityID: pgtype.UUID{},
-				ReceivedAtMs:            item.ReceivedAtMs,
-			})
+			created, err := q.CreateSessionEvent(ctx, restoredSessionEventParams(pgBotID, sessionID, item))
 			if err != nil {
 				return fmt.Errorf("session event: %w", err)
 			}
@@ -2146,6 +2131,35 @@ func stringMapFromAny(value any) map[string]string {
 		return out
 	default:
 		return nil
+	}
+}
+
+// restoredSessionEventParams builds the insert for one restored event. The
+// source deployment's cursors are instance-local coordinates that cannot be
+// compared against this deployment's sequence, so they are dropped and the
+// restored history gates in the source-time domain.
+func restoredSessionEventParams(botID, sessionID pgtype.UUID, item sqlc.BotSessionEvent) sqlc.CreateSessionEventParams {
+	return sqlc.CreateSessionEventParams{
+		BotID:                   botID,
+		SessionID:               sessionID,
+		EventKind:               item.EventKind,
+		EventData:               sanitizeRestoredEventData(defaultJSONMap(item.EventData)),
+		ExternalMessageID:       item.ExternalMessageID,
+		SenderChannelIdentityID: pgtype.UUID{},
+		ReceivedAtMs:            item.ReceivedAtMs,
+	}
+}
+
+// restoredDiscussCursorParams keeps the source-time watermark and drops the
+// instance-local event watermark for the same reason.
+func restoredDiscussCursorParams(sessionID pgtype.UUID, cursor sqlc.BotSessionDiscussCursor) sqlc.UpsertSessionDiscussCursorParams {
+	return sqlc.UpsertSessionDiscussCursorParams{
+		SessionID:           sessionID,
+		ScopeKey:            cursor.ScopeKey,
+		RouteID:             pgtype.UUID{},
+		Source:              cursor.Source,
+		ConsumedCursor:      cursor.ConsumedCursor,
+		ConsumedEventCursor: 0,
 	}
 }
 

--- a/internal/botbackup/import_test.go
+++ b/internal/botbackup/import_test.go
@@ -12,4 +12,10 @@ func TestRestoredEventCursor(t *testing.T) {
 	if got := restoredEventCursor([]byte(`not json`)); got != 0 {
 		t.Fatalf("malformed payload = %d, want 0", got)
 	}
+	if got := restoredEventCursor([]byte(`{"event_cursor":9007199254740991}`)); got != 0 {
+		t.Fatalf("cursor at sequence MAXVALUE must be rejected, got %d", got)
+	}
+	if got := restoredEventCursor([]byte(`{"event_cursor":-5}`)); got != 0 {
+		t.Fatalf("negative cursor must be rejected, got %d", got)
+	}
 }

--- a/internal/botbackup/import_test.go
+++ b/internal/botbackup/import_test.go
@@ -1,0 +1,15 @@
+package botbackup
+
+import "testing"
+
+func TestRestoredEventCursor(t *testing.T) {
+	if got := restoredEventCursor([]byte(`{"event_cursor":424242,"message_id":"m1"}`)); got != 424242 {
+		t.Fatalf("cursor = %d, want 424242", got)
+	}
+	if got := restoredEventCursor([]byte(`{"message_id":"m1"}`)); got != 0 {
+		t.Fatalf("missing cursor = %d, want 0", got)
+	}
+	if got := restoredEventCursor([]byte(`not json`)); got != 0 {
+		t.Fatalf("malformed payload = %d, want 0", got)
+	}
+}

--- a/internal/botbackup/import_test.go
+++ b/internal/botbackup/import_test.go
@@ -3,6 +3,10 @@ package botbackup
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 )
 
 func TestSanitizeRestoredEventData(t *testing.T) {
@@ -27,5 +31,40 @@ func TestSanitizeRestoredEventDataPassthrough(t *testing.T) {
 	malformed := []byte(`not json`)
 	if got := string(sanitizeRestoredEventData(malformed)); got != string(malformed) {
 		t.Fatalf("malformed payload must pass through, got %s", got)
+	}
+}
+
+func TestRestoredSessionEventParamsDropsInstanceLocalCursor(t *testing.T) {
+	params := restoredSessionEventParams(pgtype.UUID{}, pgtype.UUID{}, sqlc.BotSessionEvent{
+		EventKind:    "message",
+		EventData:    []byte(`{"event_cursor":424242,"message_id":"m1"}`),
+		ReceivedAtMs: 1700000000000,
+	})
+
+	var payload map[string]any
+	if err := json.Unmarshal(params.EventData, &payload); err != nil {
+		t.Fatalf("decode restored event data: %v", err)
+	}
+	if _, ok := payload["event_cursor"]; ok {
+		t.Fatal("restored events must not carry the source deployment's cursor")
+	}
+	if payload["message_id"] != "m1" || params.ReceivedAtMs != 1700000000000 {
+		t.Fatalf("restore must preserve source-time identity, got %v / %d", payload, params.ReceivedAtMs)
+	}
+}
+
+func TestRestoredDiscussCursorParamsDropsEventWatermark(t *testing.T) {
+	params := restoredDiscussCursorParams(pgtype.UUID{}, sqlc.BotSessionDiscussCursor{
+		ScopeKey:            "route:r1",
+		Source:              "telegram",
+		ConsumedCursor:      1700000000000,
+		ConsumedEventCursor: 999999,
+	})
+
+	if params.ConsumedEventCursor != 0 {
+		t.Fatalf("restored event watermark = %d, want 0", params.ConsumedEventCursor)
+	}
+	if params.ConsumedCursor != 1700000000000 || params.ScopeKey != "route:r1" {
+		t.Fatalf("source-time watermark and scope must survive, got %+v", params)
 	}
 }

--- a/internal/botbackup/import_test.go
+++ b/internal/botbackup/import_test.go
@@ -15,7 +15,22 @@ func TestRestoredEventCursor(t *testing.T) {
 	if got := restoredEventCursor([]byte(`{"event_cursor":9007199254740991}`)); got != 0 {
 		t.Fatalf("cursor at sequence MAXVALUE must be rejected, got %d", got)
 	}
+	if got := restoredEventCursor([]byte(`{"event_cursor":9007199254740990}`)); got != 0 {
+		t.Fatalf("cursor near sequence MAXVALUE must be rejected, got %d", got)
+	}
 	if got := restoredEventCursor([]byte(`{"event_cursor":-5}`)); got != 0 {
 		t.Fatalf("negative cursor must be rejected, got %d", got)
+	}
+}
+
+func TestRestoredConsumedEventCursor(t *testing.T) {
+	if got := restoredConsumedEventCursor(424242); got != 424242 {
+		t.Fatalf("valid consumed cursor = %d, want 424242", got)
+	}
+	if got := restoredConsumedEventCursor(9007199254740990); got != 0 {
+		t.Fatalf("poisoned consumed cursor must be dropped, got %d", got)
+	}
+	if got := restoredConsumedEventCursor(-1); got != 0 {
+		t.Fatalf("negative consumed cursor must be dropped, got %d", got)
 	}
 }

--- a/internal/botbackup/import_test.go
+++ b/internal/botbackup/import_test.go
@@ -1,36 +1,31 @@
 package botbackup
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
-func TestRestoredEventCursor(t *testing.T) {
-	if got := restoredEventCursor([]byte(`{"event_cursor":424242,"message_id":"m1"}`)); got != 424242 {
-		t.Fatalf("cursor = %d, want 424242", got)
+func TestSanitizeRestoredEventData(t *testing.T) {
+	stripped := sanitizeRestoredEventData([]byte(`{"event_cursor":424242,"message_id":"m1","received_at_ms":1000}`))
+	var payload map[string]any
+	if err := json.Unmarshal(stripped, &payload); err != nil {
+		t.Fatalf("decode sanitized payload: %v", err)
 	}
-	if got := restoredEventCursor([]byte(`{"message_id":"m1"}`)); got != 0 {
-		t.Fatalf("missing cursor = %d, want 0", got)
+	if _, ok := payload["event_cursor"]; ok {
+		t.Fatal("instance-local cursor must be stripped from restored payloads")
 	}
-	if got := restoredEventCursor([]byte(`not json`)); got != 0 {
-		t.Fatalf("malformed payload = %d, want 0", got)
-	}
-	if got := restoredEventCursor([]byte(`{"event_cursor":9007199254740991}`)); got != 0 {
-		t.Fatalf("cursor at sequence MAXVALUE must be rejected, got %d", got)
-	}
-	if got := restoredEventCursor([]byte(`{"event_cursor":9007199254740990}`)); got != 0 {
-		t.Fatalf("cursor near sequence MAXVALUE must be rejected, got %d", got)
-	}
-	if got := restoredEventCursor([]byte(`{"event_cursor":-5}`)); got != 0 {
-		t.Fatalf("negative cursor must be rejected, got %d", got)
+	if payload["message_id"] != "m1" || payload["received_at_ms"] != float64(1000) {
+		t.Fatalf("other fields must survive, got %v", payload)
 	}
 }
 
-func TestRestoredConsumedEventCursor(t *testing.T) {
-	if got := restoredConsumedEventCursor(424242); got != 424242 {
-		t.Fatalf("valid consumed cursor = %d, want 424242", got)
+func TestSanitizeRestoredEventDataPassthrough(t *testing.T) {
+	plain := []byte(`{"message_id":"m1"}`)
+	if got := string(sanitizeRestoredEventData(plain)); got != string(plain) {
+		t.Fatalf("payload without cursor must pass through, got %s", got)
 	}
-	if got := restoredConsumedEventCursor(9007199254740990); got != 0 {
-		t.Fatalf("poisoned consumed cursor must be dropped, got %d", got)
-	}
-	if got := restoredConsumedEventCursor(-1); got != 0 {
-		t.Fatalf("negative consumed cursor must be dropped, got %d", got)
+	malformed := []byte(`not json`)
+	if got := string(sanitizeRestoredEventData(malformed)); got != string(malformed) {
+		t.Fatalf("malformed payload must pass through, got %s", got)
 	}
 }

--- a/internal/channel/discuss/cursor.go
+++ b/internal/channel/discuss/cursor.go
@@ -25,14 +25,11 @@ func (t discussCursorTracker) Load(ctx context.Context, cfg DiscussSessionConfig
 }
 
 func (t discussCursorTracker) Advance(ctx context.Context, sess *discussSession, cfg DiscussSessionConfig, position timeline.DiscussCursorPosition, log *slog.Logger) {
-	gate := position.EventCursor
-	if gate == 0 {
-		gate = position.SourceCursor
-	}
-	if gate <= sess.lastProcessedCursor {
+	merged := sess.lastProcessed.Merge(position)
+	if merged == sess.lastProcessed {
 		return
 	}
-	sess.lastProcessedCursor = gate
+	sess.lastProcessed = merged
 	if t.store == nil {
 		return
 	}
@@ -42,9 +39,9 @@ func (t discussCursorTracker) Advance(ctx context.Context, sess *discussSession,
 		discussCursorScope(cfg),
 		strings.TrimSpace(cfg.RouteID),
 		strings.TrimSpace(cfg.CurrentPlatform),
-		position,
+		merged,
 	); err != nil {
-		log.Warn("discuss cursor persist failed", slog.Any("error", err), slog.Int64("cursor", gate))
+		log.Warn("discuss cursor persist failed", slog.Any("error", err), slog.Int64("cursor", merged.EventCursor), slog.Int64("source_cursor", merged.SourceCursor))
 	}
 }
 
@@ -62,13 +59,6 @@ func discussCursorScope(cfg DiscussSessionConfig) string {
 	default:
 		return "default"
 	}
-}
-
-func maxInt64(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 // anchorFromTRs returns the latest persisted turn request timestamp used to

--- a/internal/channel/discuss/cursor.go
+++ b/internal/channel/discuss/cursor.go
@@ -12,35 +12,39 @@ type discussCursorTracker struct {
 	store DiscussCursorStore
 }
 
-func (t discussCursorTracker) Load(ctx context.Context, cfg DiscussSessionConfig, log *slog.Logger) int64 {
+func (t discussCursorTracker) Load(ctx context.Context, cfg DiscussSessionConfig, log *slog.Logger) timeline.DiscussCursorPosition {
 	if t.store == nil {
-		return 0
+		return timeline.DiscussCursorPosition{}
 	}
-	cursor, err := t.store.GetDiscussConsumedCursor(ctx, cfg.ThreadID, discussCursorScope(cfg))
+	position, err := t.store.GetDiscussCursor(ctx, cfg.ThreadID, discussCursorScope(cfg))
 	if err != nil {
 		log.Warn("discuss cursor load failed", slog.Any("error", err))
-		return 0
+		return timeline.DiscussCursorPosition{}
 	}
-	return cursor
+	return position
 }
 
-func (t discussCursorTracker) Advance(ctx context.Context, sess *discussSession, cfg DiscussSessionConfig, cursor int64, log *slog.Logger) {
-	if cursor <= sess.lastProcessedMs {
+func (t discussCursorTracker) Advance(ctx context.Context, sess *discussSession, cfg DiscussSessionConfig, position timeline.DiscussCursorPosition, log *slog.Logger) {
+	gate := position.EventCursor
+	if gate == 0 {
+		gate = position.SourceCursor
+	}
+	if gate <= sess.lastProcessedCursor {
 		return
 	}
-	sess.lastProcessedMs = cursor
+	sess.lastProcessedCursor = gate
 	if t.store == nil {
 		return
 	}
-	if err := t.store.UpsertDiscussConsumedCursor(
+	if err := t.store.UpsertDiscussCursor(
 		ctx,
 		cfg.ThreadID,
 		discussCursorScope(cfg),
 		strings.TrimSpace(cfg.RouteID),
 		strings.TrimSpace(cfg.CurrentPlatform),
-		cursor,
+		position,
 	); err != nil {
-		log.Warn("discuss cursor persist failed", slog.Any("error", err), slog.Int64("cursor", cursor))
+		log.Warn("discuss cursor persist failed", slog.Any("error", err), slog.Int64("cursor", gate))
 	}
 }
 

--- a/internal/channel/discuss/driver.go
+++ b/internal/channel/discuss/driver.go
@@ -12,8 +12,8 @@ import (
 )
 
 type DiscussCursorStore interface {
-	GetDiscussConsumedCursor(ctx context.Context, sessionID, scopeKey string) (int64, error)
-	UpsertDiscussConsumedCursor(ctx context.Context, sessionID, scopeKey, routeID, source string, cursor int64) error
+	GetDiscussCursor(ctx context.Context, sessionID, scopeKey string) (timeline.DiscussCursorPosition, error)
+	UpsertDiscussCursor(ctx context.Context, sessionID, scopeKey, routeID, source string, position timeline.DiscussCursorPosition) error
 }
 
 // DiscussArtifactProvider projects the session's active compaction artifacts
@@ -70,11 +70,11 @@ type DiscussDriver struct {
 }
 
 type discussSession struct {
-	config          DiscussSessionConfig
-	rcCh            chan timeline.RenderedContext
-	stopCh          chan struct{}
-	cancel          context.CancelFunc
-	lastProcessedMs int64
+	config              DiscussSessionConfig
+	rcCh                chan timeline.RenderedContext
+	stopCh              chan struct{}
+	cancel              context.CancelFunc
+	lastProcessedCursor int64
 }
 
 // NewDiscussDriver creates a new DiscussDriver.

--- a/internal/channel/discuss/driver.go
+++ b/internal/channel/discuss/driver.go
@@ -16,6 +16,12 @@ type DiscussCursorStore interface {
 	UpsertDiscussConsumedCursor(ctx context.Context, sessionID, scopeKey, routeID, source string, cursor int64) error
 }
 
+// DiscussArtifactProvider projects the session's active compaction artifacts
+// for timeline composition. Implemented agent-side and injected at assembly.
+type DiscussArtifactProvider interface {
+	ActiveCompactionArtifacts(ctx context.Context, botID, sessionID string) ([]timeline.CompactionArtifact, error)
+}
+
 // DiscussStreamBroadcaster publishes stream events to local UI subscribers.
 // Implemented by local.RouteHub.
 type DiscussStreamBroadcaster interface {
@@ -27,6 +33,7 @@ type DiscussDriverDeps struct {
 	Turn           turn.Service
 	MessageService messagepkg.Service
 	CursorStore    DiscussCursorStore
+	Artifacts      DiscussArtifactProvider
 	Broadcaster    DiscussStreamBroadcaster
 	Logger         *slog.Logger
 }
@@ -51,14 +58,15 @@ type DiscussSessionConfig struct {
 // cursor persistence, turn execution, and stream projection live in dedicated
 // collaborators.
 type DiscussDriver struct {
-	mu       sync.Mutex
-	turn     turn.Service
-	sessions map[string]*discussSession
-	history  discussHistoryReader
-	cursor   discussCursorTracker
-	trigger  discussTriggerBuilder
-	runner   discussTurnRunner
-	logger   *slog.Logger
+	mu        sync.Mutex
+	turn      turn.Service
+	sessions  map[string]*discussSession
+	history   discussHistoryReader
+	cursor    discussCursorTracker
+	trigger   discussTriggerBuilder
+	runner    discussTurnRunner
+	artifacts DiscussArtifactProvider
+	logger    *slog.Logger
 }
 
 type discussSession struct {
@@ -78,12 +86,13 @@ func NewDiscussDriver(deps DiscussDriverDeps) *DiscussDriver {
 	logger = logger.With(slog.String("service", "channel/discuss"))
 	projector := newDiscussEventProjector(deps.Broadcaster)
 	return &DiscussDriver{
-		turn:     deps.Turn,
-		sessions: make(map[string]*discussSession),
-		history:  discussHistoryReader{messages: deps.MessageService, logger: logger},
-		cursor:   discussCursorTracker{store: deps.CursorStore},
-		runner:   discussTurnRunner{projector: projector},
-		logger:   logger,
+		turn:      deps.Turn,
+		sessions:  make(map[string]*discussSession),
+		history:   discussHistoryReader{messages: deps.MessageService, logger: logger},
+		cursor:    discussCursorTracker{store: deps.CursorStore},
+		runner:    discussTurnRunner{projector: projector},
+		artifacts: deps.Artifacts,
+		logger:    logger,
 	}
 }
 

--- a/internal/channel/discuss/driver.go
+++ b/internal/channel/discuss/driver.go
@@ -70,11 +70,11 @@ type DiscussDriver struct {
 }
 
 type discussSession struct {
-	config              DiscussSessionConfig
-	rcCh                chan timeline.RenderedContext
-	stopCh              chan struct{}
-	cancel              context.CancelFunc
-	lastProcessedCursor int64
+	config        DiscussSessionConfig
+	rcCh          chan timeline.RenderedContext
+	stopCh        chan struct{}
+	cancel        context.CancelFunc
+	lastProcessed timeline.DiscussCursorPosition
 }
 
 // NewDiscussDriver creates a new DiscussDriver.

--- a/internal/channel/discuss/driver_artifacts_test.go
+++ b/internal/channel/discuss/driver_artifacts_test.go
@@ -1,0 +1,104 @@
+package discuss
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+type fakeArtifactProvider struct {
+	artifacts []timeline.CompactionArtifact
+	botID     string
+	sessionID string
+}
+
+func (f *fakeArtifactProvider) ActiveCompactionArtifacts(_ context.Context, botID, sessionID string) ([]timeline.CompactionArtifact, error) {
+	f.botID = botID
+	f.sessionID = sessionID
+	return f.artifacts, nil
+}
+
+func TestHandleReplyWithTurn_InsertsArtifactSummary(t *testing.T) {
+	rc := timeline.RenderedContext{
+		{
+			MessageID:    "m1",
+			ReceivedAtMs: 100,
+			Content:      []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="m1">old original</message>`}},
+		},
+		{
+			MessageID:    "m2",
+			ReceivedAtMs: 200,
+			Content:      []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="m2">current question</message>`}},
+		},
+	}
+	artifacts := []timeline.CompactionArtifact{{
+		ID:            "a1",
+		Summary:       "compacted window",
+		AnchorStartMs: 100,
+		Sources:       []timeline.CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 100}},
+	}}
+	provider := &fakeArtifactProvider{artifacts: artifacts}
+	svc := &fakeTurnService{}
+	driver := NewDiscussDriver(DiscussDriverDeps{Artifacts: provider})
+	sess := &discussSession{
+		config: DiscussSessionConfig{TeamID: "team-1", BotID: "bot-1", ThreadID: "sess-1"},
+	}
+
+	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
+
+	if svc.calls != 1 {
+		t.Fatalf("StartTurn calls = %d, want 1", svc.calls)
+	}
+	if provider.botID != "bot-1" || provider.sessionID != "sess-1" {
+		t.Fatalf("artifact provider scoped to %q/%q", provider.botID, provider.sessionID)
+	}
+
+	cmd := svc.lastCmd
+	expected := timeline.ComposeContextWithArtifacts(rc, nil, artifacts)
+	if expected == nil || len(cmd.DiscussMessages) != len(expected.Messages) {
+		t.Fatalf("discuss messages diverge from shared composition: got %d, want %d", len(cmd.DiscussMessages), len(expected.Messages))
+	}
+	for i, message := range expected.Messages {
+		if cmd.DiscussMessages[i].Role != message.Role || cmd.DiscussMessages[i].Content != message.Content {
+			t.Fatalf("message %d diverges: %+v vs %+v", i, cmd.DiscussMessages[i], message)
+		}
+	}
+	if !strings.Contains(cmd.DiscussMessages[0].Content, "<summary>") || !strings.Contains(cmd.DiscussMessages[0].Content, "compacted window") {
+		t.Fatalf("expected leading summary, got %+v", cmd.DiscussMessages[0])
+	}
+	var joinedParts []string
+	for _, message := range cmd.DiscussMessages {
+		joinedParts = append(joinedParts, message.Content)
+	}
+	joined := strings.Join(joinedParts, "|")
+	if strings.Contains(joined, "old original") {
+		t.Fatalf("covered original must be replaced, got %s", joined)
+	}
+	if !strings.Contains(joined, "current question") {
+		t.Fatalf("uncovered message must survive, got %s", joined)
+	}
+}
+
+func TestHandleReplyWithTurn_NilArtifactProviderComposesPlain(t *testing.T) {
+	rc := timeline.RenderedContext{
+		{
+			MessageID:    "m1",
+			ReceivedAtMs: 200,
+			Content:      []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="m1">hello</message>`}},
+		},
+	}
+	svc := &fakeTurnService{}
+	driver := NewDiscussDriver(DiscussDriverDeps{})
+	sess := &discussSession{config: DiscussSessionConfig{BotID: "bot-1", ThreadID: "sess-1"}}
+
+	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
+
+	if svc.calls != 1 {
+		t.Fatalf("StartTurn calls = %d, want 1", svc.calls)
+	}
+	if len(svc.lastCmd.DiscussMessages) != 1 || !strings.Contains(svc.lastCmd.DiscussMessages[0].Content, "hello") {
+		t.Fatalf("expected plain composition, got %+v", svc.lastCmd.DiscussMessages)
+	}
+}

--- a/internal/channel/discuss/driver_artifacts_test.go
+++ b/internal/channel/discuss/driver_artifacts_test.go
@@ -193,3 +193,38 @@ func TestBuildSkipsImageRefsCoveredByArtifacts(t *testing.T) {
 		t.Fatalf("uncovered image must be attached, got %+v", planLive.command.DiscussImageRefs)
 	}
 }
+
+func TestHandleReplyWithTurn_ColdStartAnchorCoversCursorBearingSegments(t *testing.T) {
+	// Idle eviction makes cold start a hot path: the durable cursor row may be
+	// absent while persisted replies prove the context was already answered.
+	answered := timeline.RenderedSegment{
+		MessageID:       "m1",
+		ReceivedAtMs:    1000,
+		LastEventCursor: 5,
+		MentionsMe:      true,
+		Content:         []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="m1">@bot old ping</message>`}},
+	}
+	svc := &fakeTurnService{}
+	driver := NewDiscussDriver(DiscussDriverDeps{CursorStore: &fakeDiscussCursorStore{}})
+	driver.history = discussHistoryReader{messages: nil, logger: driver.logger}
+	sess := &discussSession{config: DiscussSessionConfig{BotID: "b", ThreadID: "s"}}
+	sess.lastProcessed = timeline.DiscussCursorPosition{SourceCursor: 3000}
+
+	driver.handleReplyWithTurn(context.Background(), sess, timeline.RenderedContext{answered}, driver.logger, svc)
+
+	if svc.calls != 0 {
+		t.Fatal("a cursor-bearing segment inside the answered window must not re-fire a turn")
+	}
+
+	fresh := timeline.RenderedSegment{
+		MessageID:       "m2",
+		ReceivedAtMs:    4000,
+		LastEventCursor: 6,
+		Content:         []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="m2">new</message>`}},
+	}
+	driver.handleReplyWithTurn(context.Background(), sess, timeline.RenderedContext{answered, fresh}, driver.logger, svc)
+
+	if svc.calls != 1 {
+		t.Fatalf("a segment past the anchor must fire a turn, got %d calls", svc.calls)
+	}
+}

--- a/internal/channel/discuss/driver_artifacts_test.go
+++ b/internal/channel/discuss/driver_artifacts_test.go
@@ -102,3 +102,57 @@ func TestHandleReplyWithTurn_NilArtifactProviderComposesPlain(t *testing.T) {
 		t.Fatalf("expected plain composition, got %+v", svc.lastCmd.DiscussMessages)
 	}
 }
+
+func TestWasRecentlyMentionedSkipsSelfSent(t *testing.T) {
+	selfMention := timeline.RenderedSegment{ReceivedAtMs: 200, MentionsMe: true, IsSelfSent: true}
+	ownMention := timeline.RenderedSegment{ReceivedAtMs: 300, RepliesToMe: true, IsMyself: true}
+	rc := timeline.RenderedContext{selfMention, ownMention}
+
+	if wasRecentlyMentioned(rc, 0) {
+		t.Fatal("self-sent mentions must not wake the bot")
+	}
+
+	external := timeline.RenderedSegment{ReceivedAtMs: 400, MentionsMe: true}
+	if !wasRecentlyMentioned(append(rc, external), 0) {
+		t.Fatal("external mention must wake the bot")
+	}
+}
+
+func TestBuildIgnoresMentionsCoveredByArtifacts(t *testing.T) {
+	coveredMention := timeline.RenderedSegment{
+		MessageID:    "m1",
+		ReceivedAtMs: 100,
+		MentionsMe:   true,
+		Content:      []timeline.RenderedContentPiece{{Type: "text", Text: "old @bot ping"}},
+	}
+	rc := timeline.RenderedContext{
+		coveredMention,
+		{
+			MessageID:    "m2",
+			ReceivedAtMs: 200,
+			Content:      []timeline.RenderedContentPiece{{Type: "text", Text: "unrelated chatter"}},
+		},
+	}
+	artifacts := []timeline.CompactionArtifact{{
+		ID:      "a1",
+		Summary: "covers the old mention",
+		Sources: []timeline.CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 100}},
+	}}
+
+	plan, ok := discussTriggerBuilder{}.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, 0, artifacts)
+	if !ok {
+		t.Fatal("expected a composed plan")
+	}
+	if plan.command.DiscussMentioned {
+		t.Fatal("compacted mention must not mark the session as mentioned")
+	}
+
+	uncovered := discussTriggerBuilder{}
+	planLive, ok := uncovered.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, 0, nil)
+	if !ok {
+		t.Fatal("expected a composed plan without artifacts")
+	}
+	if !planLive.command.DiscussMentioned {
+		t.Fatal("uncovered mention must mark the session as mentioned")
+	}
+}

--- a/internal/channel/discuss/driver_artifacts_test.go
+++ b/internal/channel/discuss/driver_artifacts_test.go
@@ -156,3 +156,41 @@ func TestBuildIgnoresMentionsCoveredByArtifacts(t *testing.T) {
 		t.Fatal("uncovered mention must mark the session as mentioned")
 	}
 }
+
+func TestBuildSkipsImageRefsCoveredByArtifacts(t *testing.T) {
+	imageMsg := timeline.RenderedSegment{
+		MessageID:    "m1",
+		ReceivedAtMs: 100,
+		Content:      []timeline.RenderedContentPiece{{Type: "text", Text: "photo drop"}},
+		ImageRefs:    []timeline.ImageAttachmentRef{{ContentHash: "img-1", Mime: "image/png"}},
+	}
+	rc := timeline.RenderedContext{
+		imageMsg,
+		{
+			MessageID:    "m2",
+			ReceivedAtMs: 200,
+			Content:      []timeline.RenderedContentPiece{{Type: "text", Text: "current"}},
+		},
+	}
+	artifacts := []timeline.CompactionArtifact{{
+		ID:      "a1",
+		Summary: "covers the image message",
+		Sources: []timeline.CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 100}},
+	}}
+
+	plan, ok := discussTriggerBuilder{}.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, timeline.DiscussCursorPosition{}, artifacts)
+	if !ok {
+		t.Fatal("expected a composed plan")
+	}
+	if len(plan.command.DiscussImageRefs) != 0 {
+		t.Fatalf("covered image must not be re-attached, got %+v", plan.command.DiscussImageRefs)
+	}
+
+	planLive, ok := discussTriggerBuilder{}.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, timeline.DiscussCursorPosition{}, nil)
+	if !ok {
+		t.Fatal("expected a composed plan without artifacts")
+	}
+	if len(planLive.command.DiscussImageRefs) != 1 {
+		t.Fatalf("uncovered image must be attached, got %+v", planLive.command.DiscussImageRefs)
+	}
+}

--- a/internal/channel/discuss/driver_artifacts_test.go
+++ b/internal/channel/discuss/driver_artifacts_test.go
@@ -118,15 +118,15 @@ func TestWasRecentlyMentionedSkipsSelfSent(t *testing.T) {
 	}
 }
 
-func TestBuildIgnoresMentionsCoveredByArtifacts(t *testing.T) {
-	coveredMention := timeline.RenderedSegment{
+func TestBuildMentionGatesOnWatermarkNotCoverage(t *testing.T) {
+	mention := timeline.RenderedSegment{
 		MessageID:    "m1",
 		ReceivedAtMs: 100,
 		MentionsMe:   true,
-		Content:      []timeline.RenderedContentPiece{{Type: "text", Text: "old @bot ping"}},
+		Content:      []timeline.RenderedContentPiece{{Type: "text", Text: "@bot ping"}},
 	}
 	rc := timeline.RenderedContext{
-		coveredMention,
+		mention,
 		{
 			MessageID:    "m2",
 			ReceivedAtMs: 200,
@@ -135,25 +135,24 @@ func TestBuildIgnoresMentionsCoveredByArtifacts(t *testing.T) {
 	}
 	artifacts := []timeline.CompactionArtifact{{
 		ID:      "a1",
-		Summary: "covers the old mention",
+		Summary: "covers the pending mention",
 		Sources: []timeline.CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 100}},
 	}}
 
-	plan, ok := discussTriggerBuilder{}.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, timeline.DiscussCursorPosition{}, artifacts)
+	pending, ok := discussTriggerBuilder{}.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, timeline.DiscussCursorPosition{}, artifacts)
 	if !ok {
 		t.Fatal("expected a composed plan")
 	}
-	if plan.command.DiscussMentioned {
-		t.Fatal("compacted mention must not mark the session as mentioned")
+	if !pending.command.DiscussMentioned {
+		t.Fatal("a mention the watermark has not consumed must wake the session even when compaction covers it")
 	}
 
-	uncovered := discussTriggerBuilder{}
-	planLive, ok := uncovered.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, timeline.DiscussCursorPosition{}, nil)
+	consumed, ok := discussTriggerBuilder{}.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, timeline.DiscussCursorPosition{SourceCursor: 150}, artifacts)
 	if !ok {
-		t.Fatal("expected a composed plan without artifacts")
+		t.Fatal("expected a composed plan past the mention")
 	}
-	if !planLive.command.DiscussMentioned {
-		t.Fatal("uncovered mention must mark the session as mentioned")
+	if consumed.command.DiscussMentioned {
+		t.Fatal("a consumed mention must not re-mark the session as mentioned")
 	}
 }
 

--- a/internal/channel/discuss/driver_artifacts_test.go
+++ b/internal/channel/discuss/driver_artifacts_test.go
@@ -108,12 +108,12 @@ func TestWasRecentlyMentionedSkipsSelfSent(t *testing.T) {
 	ownMention := timeline.RenderedSegment{ReceivedAtMs: 300, RepliesToMe: true, IsMyself: true}
 	rc := timeline.RenderedContext{selfMention, ownMention}
 
-	if wasRecentlyMentioned(rc, 0) {
+	if wasRecentlyMentioned(rc, timeline.DiscussCursorPosition{}) {
 		t.Fatal("self-sent mentions must not wake the bot")
 	}
 
 	external := timeline.RenderedSegment{ReceivedAtMs: 400, MentionsMe: true}
-	if !wasRecentlyMentioned(append(rc, external), 0) {
+	if !wasRecentlyMentioned(append(rc, external), timeline.DiscussCursorPosition{}) {
 		t.Fatal("external mention must wake the bot")
 	}
 }
@@ -139,7 +139,7 @@ func TestBuildIgnoresMentionsCoveredByArtifacts(t *testing.T) {
 		Sources: []timeline.CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 100}},
 	}}
 
-	plan, ok := discussTriggerBuilder{}.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, 0, artifacts)
+	plan, ok := discussTriggerBuilder{}.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, timeline.DiscussCursorPosition{}, artifacts)
 	if !ok {
 		t.Fatal("expected a composed plan")
 	}
@@ -148,7 +148,7 @@ func TestBuildIgnoresMentionsCoveredByArtifacts(t *testing.T) {
 	}
 
 	uncovered := discussTriggerBuilder{}
-	planLive, ok := uncovered.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, 0, nil)
+	planLive, ok := uncovered.Build(DiscussSessionConfig{ConversationType: "group"}, rc, nil, timeline.DiscussCursorPosition{}, nil)
 	if !ok {
 		t.Fatal("expected a composed plan without artifacts")
 	}

--- a/internal/channel/discuss/driver_artifacts_test.go
+++ b/internal/channel/discuss/driver_artifacts_test.go
@@ -20,8 +20,15 @@ func (f *fakeArtifactProvider) ActiveCompactionArtifacts(_ context.Context, botI
 	return f.artifacts, nil
 }
 
-func TestHandleReplyWithTurn_InsertsArtifactSummary(t *testing.T) {
+func TestHandleReplyWithTurn_InsertsArtifactSummaryAtCoveredSlot(t *testing.T) {
+	// The covered message sits between two survivors, so a blind prepend and a
+	// slot insert produce different orders and this test can tell them apart.
 	rc := timeline.RenderedContext{
+		{
+			MessageID:    "m0",
+			ReceivedAtMs: 50,
+			Content:      []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="m0">earliest survivor</message>`}},
+		},
 		{
 			MessageID:    "m1",
 			ReceivedAtMs: 100,
@@ -55,29 +62,23 @@ func TestHandleReplyWithTurn_InsertsArtifactSummary(t *testing.T) {
 		t.Fatalf("artifact provider scoped to %q/%q", provider.botID, provider.sessionID)
 	}
 
-	cmd := svc.lastCmd
-	expected := timeline.ComposeContextWithArtifacts(rc, nil, artifacts)
-	if expected == nil || len(cmd.DiscussMessages) != len(expected.Messages) {
-		t.Fatalf("discuss messages diverge from shared composition: got %d, want %d", len(cmd.DiscussMessages), len(expected.Messages))
+	msgs := svc.lastCmd.DiscussMessages
+	if len(msgs) != 3 {
+		t.Fatalf("expected survivor + summary + survivor, got %d: %+v", len(msgs), msgs)
 	}
-	for i, message := range expected.Messages {
-		if cmd.DiscussMessages[i].Role != message.Role || cmd.DiscussMessages[i].Content != message.Content {
-			t.Fatalf("message %d diverges: %+v vs %+v", i, cmd.DiscussMessages[i], message)
+	if !strings.Contains(msgs[0].Content, "earliest survivor") {
+		t.Fatalf("summary must not be prepended ahead of an earlier survivor, got %+v", msgs)
+	}
+	if msgs[1].CompactionArtifactID != "a1" || !strings.Contains(msgs[1].Content, "compacted window") {
+		t.Fatalf("summary must occupy the covered slot, got %+v", msgs)
+	}
+	if !strings.Contains(msgs[2].Content, "current question") {
+		t.Fatalf("later survivor must follow the summary, got %+v", msgs)
+	}
+	for _, message := range msgs {
+		if strings.Contains(message.Content, "old original") {
+			t.Fatalf("covered original must be replaced, got %+v", msgs)
 		}
-	}
-	if !strings.Contains(cmd.DiscussMessages[0].Content, "<summary>") || !strings.Contains(cmd.DiscussMessages[0].Content, "compacted window") {
-		t.Fatalf("expected leading summary, got %+v", cmd.DiscussMessages[0])
-	}
-	var joinedParts []string
-	for _, message := range cmd.DiscussMessages {
-		joinedParts = append(joinedParts, message.Content)
-	}
-	joined := strings.Join(joinedParts, "|")
-	if strings.Contains(joined, "old original") {
-		t.Fatalf("covered original must be replaced, got %s", joined)
-	}
-	if !strings.Contains(joined, "current question") {
-		t.Fatalf("uncovered message must survive, got %s", joined)
 	}
 }
 

--- a/internal/channel/discuss/driver_test.go
+++ b/internal/channel/discuss/driver_test.go
@@ -61,8 +61,8 @@ func TestHandleReplyWithTurn_PassesContextAndImageRefs(t *testing.T) {
 	svc := &fakeTurnService{}
 	driver := NewDiscussDriver(DiscussDriverDeps{})
 	sess := &discussSession{
-		config:          DiscussSessionConfig{TeamID: "team-1", BotID: "bot-1", ThreadID: "sess-1"},
-		lastProcessedMs: 0,
+		config:              DiscussSessionConfig{TeamID: "team-1", BotID: "bot-1", ThreadID: "sess-1"},
+		lastProcessedCursor: 0,
 	}
 
 	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
@@ -125,8 +125,8 @@ func TestHandleReplyWithTurn_ACPAdvancesCursorOnCleanTerminal(t *testing.T) {
 	if !cmd.DiscussAddressed {
 		t.Fatal("mentioned message must be addressed")
 	}
-	if sess.lastProcessedMs != 200 {
-		t.Fatalf("lastProcessedMs = %d, want 200", sess.lastProcessedMs)
+	if sess.lastProcessedCursor != 200 {
+		t.Fatalf("lastProcessedCursor = %d, want 200", sess.lastProcessedCursor)
 	}
 }
 
@@ -230,8 +230,8 @@ func TestHandleReplyWithTurn_NoCursorAdvanceOnStartError(t *testing.T) {
 
 	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
 
-	if sess.lastProcessedMs != 0 {
-		t.Fatalf("lastProcessedMs = %d, want 0 when the turn cannot start", sess.lastProcessedMs)
+	if sess.lastProcessedCursor != 0 {
+		t.Fatalf("lastProcessedCursor = %d, want 0 when the turn cannot start", sess.lastProcessedCursor)
 	}
 }
 
@@ -254,8 +254,8 @@ func TestHandleReplyWithTurn_ACPDoesNotAdvanceCursorOnRuntimeError(t *testing.T)
 	if svc.calls != 1 {
 		t.Fatalf("StartTurn calls = %d, want 1", svc.calls)
 	}
-	if sess.lastProcessedMs != 0 {
-		t.Fatalf("lastProcessedMs = %d, want 0 when ACP runtime stream fails", sess.lastProcessedMs)
+	if sess.lastProcessedCursor != 0 {
+		t.Fatalf("lastProcessedCursor = %d, want 0 when ACP runtime stream fails", sess.lastProcessedCursor)
 	}
 }
 
@@ -286,8 +286,8 @@ func TestHandleReplyWithTurn_ACPSkipsRuntimeForPassiveMessage(t *testing.T) {
 	if svc.lastCmd.DiscussAddressed {
 		t.Fatal("passive group message must not be addressed")
 	}
-	if sess.lastProcessedMs != 200 {
-		t.Fatalf("lastProcessedMs = %d, want 200 (cursor advanced on silent path)", sess.lastProcessedMs)
+	if sess.lastProcessedCursor != 200 {
+		t.Fatalf("lastProcessedCursor = %d, want 200 (cursor advanced on silent path)", sess.lastProcessedCursor)
 	}
 }
 
@@ -317,8 +317,8 @@ func TestHandleReplyWithTurn_ACPRepliesInDirectConversation(t *testing.T) {
 	if !svc.lastCmd.DiscussAddressed {
 		t.Fatal("direct (1:1) message must be addressed even without a mention")
 	}
-	if sess.lastProcessedMs != 200 {
-		t.Fatalf("lastProcessedMs = %d, want 200 (cursor advanced after direct reply)", sess.lastProcessedMs)
+	if sess.lastProcessedCursor != 200 {
+		t.Fatalf("lastProcessedCursor = %d, want 200 (cursor advanced after direct reply)", sess.lastProcessedCursor)
 	}
 	// A direct conversation is "addressed" without being mentioned; the ACP
 	// runtime uses this to render the addressed-directly nudge.
@@ -343,24 +343,8 @@ func TestAnchorFromTRs(t *testing.T) {
 	}
 }
 
-func TestLatestRCReceivedAtMs(t *testing.T) {
-	t.Parallel()
-
-	if got := latestRCReceivedAtMs(nil); got != 0 {
-		t.Fatalf("empty RC = %d, want 0", got)
-	}
-	got := latestRCReceivedAtMs(timeline.RenderedContext{
-		{ReceivedAtMs: 100},
-		{ReceivedAtMs: 900},
-		{ReceivedAtMs: 500, IsMyself: true},
-	})
-	if got != 900 {
-		t.Fatalf("latest = %d, want 900", got)
-	}
-}
-
 // TestHandleReplyWithTurn_ColdStartAnchoredByTR simulates idle-timeout
-// restart: the session's in-memory lastProcessedMs is 0, but RC replay has
+// restart: the session's in-memory lastProcessedCursor is 0, but RC replay has
 // brought back old user messages that were already answered in prior
 // LLM rounds (represented by TRs). The driver MUST NOT re-answer them.
 func TestHandleReplyWithTurn_ColdStartAnchoredByTR(t *testing.T) {
@@ -375,24 +359,24 @@ func TestHandleReplyWithTurn_ColdStartAnchoredByTR(t *testing.T) {
 		MessageService: nil,
 	})
 	sess := &discussSession{
-		config:          DiscussSessionConfig{BotID: "b", ThreadID: "s"},
-		lastProcessedMs: 0,
+		config:              DiscussSessionConfig{BotID: "b", ThreadID: "s"},
+		lastProcessedCursor: 0,
 	}
 
 	// Simulate a previously answered round by pre-stuffing a TR newer than
 	// the RC segment's ReceivedAtMs. Since we cannot inject MessageService
-	// easily, we instead pre-set lastProcessedMs as the anchor would.
-	sess.lastProcessedMs = 200 // mimic anchorFromTRs result
+	// easily, we instead pre-set lastProcessedCursor as the anchor would.
+	sess.lastProcessedCursor = 200 // mimic anchorFromTRs result
 
 	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
 
 	if svc.calls != 0 {
-		t.Fatal("turn must not start when all RC segments predate lastProcessedMs")
+		t.Fatal("turn must not start when all RC segments predate lastProcessedCursor")
 	}
 }
 
 // TestHandleReplyWithTurn_CursorAdvancesToRCNotWallClock ensures that after
-// a turn we set lastProcessedMs to the max ReceivedAtMs actually consumed in
+// a turn we set lastProcessedCursor to the max ReceivedAtMs actually consumed in
 // the RC snapshot, not time.Now(). This matters for messages that arrive
 // mid-turn: they end up in a fresher RC with ReceivedAtMs > cursor, which
 // correctly triggers the next round.
@@ -406,8 +390,8 @@ func TestHandleReplyWithTurn_CursorAdvancesToRCNotWallClock(t *testing.T) {
 	svc := &fakeTurnService{}
 	driver := NewDiscussDriver(DiscussDriverDeps{})
 	sess := &discussSession{
-		config:          DiscussSessionConfig{BotID: "b", ThreadID: "s"},
-		lastProcessedMs: 0,
+		config:              DiscussSessionConfig{BotID: "b", ThreadID: "s"},
+		lastProcessedCursor: 0,
 	}
 
 	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
@@ -415,13 +399,13 @@ func TestHandleReplyWithTurn_CursorAdvancesToRCNotWallClock(t *testing.T) {
 	if svc.calls != 1 {
 		t.Fatal("expected turn to start")
 	}
-	if sess.lastProcessedMs != 777 {
-		t.Fatalf("lastProcessedMs = %d, want 777 (max RC ReceivedAtMs)", sess.lastProcessedMs)
+	if sess.lastProcessedCursor != 777 {
+		t.Fatalf("lastProcessedCursor = %d, want 777 (max RC ReceivedAtMs)", sess.lastProcessedCursor)
 	}
 }
 
 func TestHandleReplyWithTurn_UsesPersistedDiscussCursor(t *testing.T) {
-	store := &fakeDiscussCursorStore{cursor: 500}
+	store := &fakeDiscussCursorStore{position: timeline.DiscussCursorPosition{SourceCursor: 500}}
 	svc := &fakeTurnService{}
 	driver := NewDiscussDriver(DiscussDriverDeps{
 		CursorStore: store,
@@ -442,8 +426,8 @@ func TestHandleReplyWithTurn_UsesPersistedDiscussCursor(t *testing.T) {
 	if svc.calls != 0 {
 		t.Fatal("turn must not start for RC covered by persisted cursor")
 	}
-	if sess.lastProcessedMs != 500 {
-		t.Fatalf("lastProcessedMs = %d, want persisted cursor 500", sess.lastProcessedMs)
+	if sess.lastProcessedCursor != 400 {
+		t.Fatalf("lastProcessedCursor = %d, want 400 (legacy boundary mapped onto RC)", sess.lastProcessedCursor)
 	}
 
 	driver.handleReplyWithTurn(context.Background(), sess, timeline.RenderedContext{
@@ -453,8 +437,8 @@ func TestHandleReplyWithTurn_UsesPersistedDiscussCursor(t *testing.T) {
 	if svc.calls != 1 {
 		t.Fatal("expected turn to start for RC past persisted cursor")
 	}
-	if store.upsertCursor != 700 {
-		t.Fatalf("persisted cursor = %d, want 700", store.upsertCursor)
+	if store.upsertPosition.SourceCursor != 700 {
+		t.Fatalf("persisted cursor = %+v, want source 700", store.upsertPosition)
 	}
 	if store.upsertScope != "route:route-1" {
 		t.Fatalf("scope = %q, want route:route-1", store.upsertScope)
@@ -579,19 +563,56 @@ func (*fakeRunHandle) AddOutboundAssets([]turn.OutboundAssetRef)        {}
 func (*fakeRunHandle) Cancel()                                          {}
 
 type fakeDiscussCursorStore struct {
-	cursor        int64
-	upsertCursor  int64
-	upsertScope   string
-	upsertRouteID string
+	position       timeline.DiscussCursorPosition
+	upsertPosition timeline.DiscussCursorPosition
+	upsertScope    string
+	upsertRouteID  string
 }
 
-func (f *fakeDiscussCursorStore) GetDiscussConsumedCursor(_ context.Context, _, _ string) (int64, error) {
-	return f.cursor, nil
+func (f *fakeDiscussCursorStore) GetDiscussCursor(_ context.Context, _, _ string) (timeline.DiscussCursorPosition, error) {
+	return f.position, nil
 }
 
-func (f *fakeDiscussCursorStore) UpsertDiscussConsumedCursor(_ context.Context, _, scopeKey, routeID, _ string, cursor int64) error {
+func (f *fakeDiscussCursorStore) UpsertDiscussCursor(_ context.Context, _, scopeKey, routeID, _ string, position timeline.DiscussCursorPosition) error {
 	f.upsertScope = scopeKey
 	f.upsertRouteID = routeID
-	f.upsertCursor = cursor
+	f.upsertPosition = position
 	return nil
+}
+
+func TestHandleReplyWithTurn_TrustsPersistedEventCursor(t *testing.T) {
+	store := &fakeDiscussCursorStore{position: timeline.DiscussCursorPosition{EventCursor: 9000, SourceCursor: 500}}
+	svc := &fakeTurnService{}
+	driver := NewDiscussDriver(DiscussDriverDeps{CursorStore: store})
+	sess := &discussSession{
+		config: DiscussSessionConfig{BotID: "b", ThreadID: "s", CurrentPlatform: "telegram"},
+	}
+
+	covered := timeline.RenderedSegment{
+		ReceivedAtMs:    400,
+		LastEventCursor: 8500,
+		Content:         []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="old">old</message>`}},
+	}
+	driver.handleReplyWithTurn(context.Background(), sess, timeline.RenderedContext{covered}, driver.logger, svc)
+
+	if svc.calls != 0 {
+		t.Fatal("turn must not start for segments at or below the persisted event cursor")
+	}
+	if sess.lastProcessedCursor != 9000 {
+		t.Fatalf("lastProcessedCursor = %d, want persisted event cursor 9000", sess.lastProcessedCursor)
+	}
+
+	fresh := timeline.RenderedSegment{
+		ReceivedAtMs:    700,
+		LastEventCursor: 9100,
+		Content:         []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="new">new</message>`}},
+	}
+	driver.handleReplyWithTurn(context.Background(), sess, timeline.RenderedContext{covered, fresh}, driver.logger, svc)
+
+	if svc.calls != 1 {
+		t.Fatal("expected turn for segment past the persisted event cursor")
+	}
+	if store.upsertPosition.EventCursor != 9100 || store.upsertPosition.SourceCursor != 700 {
+		t.Fatalf("persisted position = %+v, want cursor 9100 source 700", store.upsertPosition)
+	}
 }

--- a/internal/channel/discuss/driver_test.go
+++ b/internal/channel/discuss/driver_test.go
@@ -23,7 +23,7 @@ func TestExtractNewImageRefs(t *testing.T) {
 		{ReceivedAtMs: 400, ImageRefs: nil},
 	}
 
-	refs := extractNewImageRefs(rc, 150)
+	refs := extractNewImageRefs(rc, timeline.DiscussCursorPosition{SourceCursor: 150})
 	if len(refs) != 1 {
 		t.Fatalf("expected 1 ref, got %d", len(refs))
 	}
@@ -44,7 +44,7 @@ func TestExtractNewImageRefs_IncludesMultiple(t *testing.T) {
 		}},
 		{ReceivedAtMs: 300, ImageRefs: []timeline.ImageAttachmentRef{{ContentHash: "c"}}},
 	}
-	refs := extractNewImageRefs(rc, 50)
+	refs := extractNewImageRefs(rc, timeline.DiscussCursorPosition{SourceCursor: 50})
 	if len(refs) != 3 {
 		t.Fatalf("expected 3 refs, got %d", len(refs))
 	}
@@ -61,8 +61,7 @@ func TestHandleReplyWithTurn_PassesContextAndImageRefs(t *testing.T) {
 	svc := &fakeTurnService{}
 	driver := NewDiscussDriver(DiscussDriverDeps{})
 	sess := &discussSession{
-		config:              DiscussSessionConfig{TeamID: "team-1", BotID: "bot-1", ThreadID: "sess-1"},
-		lastProcessedCursor: 0,
+		config: DiscussSessionConfig{TeamID: "team-1", BotID: "bot-1", ThreadID: "sess-1"},
 	}
 
 	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
@@ -125,8 +124,8 @@ func TestHandleReplyWithTurn_ACPAdvancesCursorOnCleanTerminal(t *testing.T) {
 	if !cmd.DiscussAddressed {
 		t.Fatal("mentioned message must be addressed")
 	}
-	if sess.lastProcessedCursor != 200 {
-		t.Fatalf("lastProcessedCursor = %d, want 200", sess.lastProcessedCursor)
+	if sess.lastProcessed.SourceCursor != 200 {
+		t.Fatalf("lastProcessed = %+v, want source 200", sess.lastProcessed)
 	}
 }
 
@@ -230,8 +229,8 @@ func TestHandleReplyWithTurn_NoCursorAdvanceOnStartError(t *testing.T) {
 
 	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
 
-	if sess.lastProcessedCursor != 0 {
-		t.Fatalf("lastProcessedCursor = %d, want 0 when the turn cannot start", sess.lastProcessedCursor)
+	if sess.lastProcessed != (timeline.DiscussCursorPosition{}) {
+		t.Fatalf("lastProcessed = %+v, want zero when the turn cannot start", sess.lastProcessed)
 	}
 }
 
@@ -254,8 +253,8 @@ func TestHandleReplyWithTurn_ACPDoesNotAdvanceCursorOnRuntimeError(t *testing.T)
 	if svc.calls != 1 {
 		t.Fatalf("StartTurn calls = %d, want 1", svc.calls)
 	}
-	if sess.lastProcessedCursor != 0 {
-		t.Fatalf("lastProcessedCursor = %d, want 0 when ACP runtime stream fails", sess.lastProcessedCursor)
+	if sess.lastProcessed != (timeline.DiscussCursorPosition{}) {
+		t.Fatalf("lastProcessed = %+v, want zero when ACP runtime stream fails", sess.lastProcessed)
 	}
 }
 
@@ -286,8 +285,8 @@ func TestHandleReplyWithTurn_ACPSkipsRuntimeForPassiveMessage(t *testing.T) {
 	if svc.lastCmd.DiscussAddressed {
 		t.Fatal("passive group message must not be addressed")
 	}
-	if sess.lastProcessedCursor != 200 {
-		t.Fatalf("lastProcessedCursor = %d, want 200 (cursor advanced on silent path)", sess.lastProcessedCursor)
+	if sess.lastProcessed.SourceCursor != 200 {
+		t.Fatalf("lastProcessed = %+v, want source 200 (cursor advanced on silent path)", sess.lastProcessed)
 	}
 }
 
@@ -317,8 +316,8 @@ func TestHandleReplyWithTurn_ACPRepliesInDirectConversation(t *testing.T) {
 	if !svc.lastCmd.DiscussAddressed {
 		t.Fatal("direct (1:1) message must be addressed even without a mention")
 	}
-	if sess.lastProcessedCursor != 200 {
-		t.Fatalf("lastProcessedCursor = %d, want 200 (cursor advanced after direct reply)", sess.lastProcessedCursor)
+	if sess.lastProcessed.SourceCursor != 200 {
+		t.Fatalf("lastProcessed = %+v, want source 200 (cursor advanced after direct reply)", sess.lastProcessed)
 	}
 	// A direct conversation is "addressed" without being mentioned; the ACP
 	// runtime uses this to render the addressed-directly nudge.
@@ -359,14 +358,13 @@ func TestHandleReplyWithTurn_ColdStartAnchoredByTR(t *testing.T) {
 		MessageService: nil,
 	})
 	sess := &discussSession{
-		config:              DiscussSessionConfig{BotID: "b", ThreadID: "s"},
-		lastProcessedCursor: 0,
+		config: DiscussSessionConfig{BotID: "b", ThreadID: "s"},
 	}
 
 	// Simulate a previously answered round by pre-stuffing a TR newer than
 	// the RC segment's ReceivedAtMs. Since we cannot inject MessageService
-	// easily, we instead pre-set lastProcessedCursor as the anchor would.
-	sess.lastProcessedCursor = 200 // mimic anchorFromTRs result
+	// easily, we instead pre-set lastProcessed as the anchor would.
+	sess.lastProcessed = timeline.DiscussCursorPosition{SourceCursor: 200} // mimic anchorFromTRs result
 
 	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
 
@@ -390,8 +388,7 @@ func TestHandleReplyWithTurn_CursorAdvancesToRCNotWallClock(t *testing.T) {
 	svc := &fakeTurnService{}
 	driver := NewDiscussDriver(DiscussDriverDeps{})
 	sess := &discussSession{
-		config:              DiscussSessionConfig{BotID: "b", ThreadID: "s"},
-		lastProcessedCursor: 0,
+		config: DiscussSessionConfig{BotID: "b", ThreadID: "s"},
 	}
 
 	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
@@ -399,8 +396,8 @@ func TestHandleReplyWithTurn_CursorAdvancesToRCNotWallClock(t *testing.T) {
 	if svc.calls != 1 {
 		t.Fatal("expected turn to start")
 	}
-	if sess.lastProcessedCursor != 777 {
-		t.Fatalf("lastProcessedCursor = %d, want 777 (max RC ReceivedAtMs)", sess.lastProcessedCursor)
+	if sess.lastProcessed.SourceCursor != 777 {
+		t.Fatalf("lastProcessed = %+v, want source 777 (max RC ReceivedAtMs)", sess.lastProcessed)
 	}
 }
 
@@ -426,8 +423,8 @@ func TestHandleReplyWithTurn_UsesPersistedDiscussCursor(t *testing.T) {
 	if svc.calls != 0 {
 		t.Fatal("turn must not start for RC covered by persisted cursor")
 	}
-	if sess.lastProcessedCursor != 400 {
-		t.Fatalf("lastProcessedCursor = %d, want 400 (legacy boundary mapped onto RC)", sess.lastProcessedCursor)
+	if sess.lastProcessed.SourceCursor != 500 {
+		t.Fatalf("lastProcessed = %+v, want persisted source 500", sess.lastProcessed)
 	}
 
 	driver.handleReplyWithTurn(context.Background(), sess, timeline.RenderedContext{
@@ -598,8 +595,8 @@ func TestHandleReplyWithTurn_TrustsPersistedEventCursor(t *testing.T) {
 	if svc.calls != 0 {
 		t.Fatal("turn must not start for segments at or below the persisted event cursor")
 	}
-	if sess.lastProcessedCursor != 9000 {
-		t.Fatalf("lastProcessedCursor = %d, want persisted event cursor 9000", sess.lastProcessedCursor)
+	if sess.lastProcessed.EventCursor != 9000 {
+		t.Fatalf("lastProcessed = %+v, want persisted event cursor 9000", sess.lastProcessed)
 	}
 
 	fresh := timeline.RenderedSegment{

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -18,8 +18,8 @@ type discussTurnPlan struct {
 
 // Build composes the durable timeline and persisted turn responses into the
 // pure StartTurn command consumed by Agent.
-func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.RenderedContext, trs []timeline.TurnResponseEntry, afterMs int64) (discussTurnPlan, bool) {
-	composed := timeline.ComposeContext(rc, trs)
+func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.RenderedContext, trs []timeline.TurnResponseEntry, afterMs int64, artifacts []timeline.CompactionArtifact) (discussTurnPlan, bool) {
+	composed := timeline.ComposeContextWithArtifacts(rc, trs, artifacts)
 	if composed == nil {
 		return discussTurnPlan{}, false
 	}

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -24,7 +24,8 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 		return discussTurnPlan{}, false
 	}
 
-	isMentioned := wasRecentlyMentioned(timeline.ActiveRenderedContext(rc, artifacts), after)
+	activeRC := timeline.ActiveRenderedContext(rc, artifacts)
+	isMentioned := wasRecentlyMentioned(activeRC, after)
 	addressed := isMentioned || turn.IsPrivateConversationType(cfg.ConversationType)
 	msgs := make([]turn.DiscussMessage, 0, len(composed.Messages))
 	for _, message := range composed.Messages {
@@ -35,7 +36,7 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 		})
 	}
 	imageRefs := make([]turn.DiscussImageRef, 0)
-	for _, ref := range extractNewImageRefs(rc, after) {
+	for _, ref := range extractNewImageRefs(activeRC, after) {
 		imageRefs = append(imageRefs, turn.DiscussImageRef{
 			ContentHash: ref.ContentHash,
 			Mime:        ref.Mime,

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -11,20 +11,20 @@ type discussTriggerBuilder struct{}
 
 type discussTurnPlan struct {
 	command         turn.StartTurnCommand
-	consumedMs      int64
+	consumed        timeline.DiscussCursorPosition
 	messageCount    int
 	estimatedTokens int
 }
 
 // Build composes the durable timeline and persisted turn responses into the
 // pure StartTurn command consumed by Agent.
-func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.RenderedContext, trs []timeline.TurnResponseEntry, afterMs int64, artifacts []timeline.CompactionArtifact) (discussTurnPlan, bool) {
+func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.RenderedContext, trs []timeline.TurnResponseEntry, afterCursor int64, artifacts []timeline.CompactionArtifact) (discussTurnPlan, bool) {
 	composed := timeline.ComposeContextWithArtifacts(rc, trs, artifacts)
 	if composed == nil {
 		return discussTurnPlan{}, false
 	}
 
-	isMentioned := wasRecentlyMentioned(timeline.ActiveRenderedContext(rc, artifacts), afterMs)
+	isMentioned := wasRecentlyMentioned(timeline.ActiveRenderedContext(rc, artifacts), afterCursor)
 	addressed := isMentioned || turn.IsPrivateConversationType(cfg.ConversationType)
 	msgs := make([]turn.DiscussMessage, 0, len(composed.Messages))
 	for _, message := range composed.Messages {
@@ -35,7 +35,7 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 		})
 	}
 	imageRefs := make([]turn.DiscussImageRef, 0)
-	for _, ref := range extractNewImageRefs(rc, afterMs) {
+	for _, ref := range extractNewImageRefs(rc, afterCursor) {
 		imageRefs = append(imageRefs, turn.DiscussImageRef{
 			ContentHash: ref.ContentHash,
 			Mime:        ref.Mime,
@@ -63,42 +63,30 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 			DiscussMentioned:        isMentioned,
 			DiscussAddressed:        addressed,
 		},
-		consumedMs:      latestRCReceivedAtMs(rc),
+		consumed:        timeline.ConsumedDiscussCursor(rc),
 		messageCount:    len(composed.Messages),
 		estimatedTokens: composed.EstimatedTokens,
 	}, true
 }
 
-// latestRCReceivedAtMs returns the maximum ReceivedAtMs across all segments
-// in the given RC, or 0 if the RC is empty.
-func latestRCReceivedAtMs(rc timeline.RenderedContext) int64 {
-	var latest int64
-	for _, segment := range rc {
-		if segment.ReceivedAtMs > latest {
-			latest = segment.ReceivedAtMs
-		}
-	}
-	return latest
-}
-
 // extractNewImageRefs collects image references from external RC segments
 // that arrived after the last consumed cursor.
-func extractNewImageRefs(rc timeline.RenderedContext, afterMs int64) []timeline.ImageAttachmentRef {
+func extractNewImageRefs(rc timeline.RenderedContext, afterCursor int64) []timeline.ImageAttachmentRef {
 	var refs []timeline.ImageAttachmentRef
 	for _, segment := range rc {
-		if segment.ReceivedAtMs > afterMs && !segment.IsMyself && !segment.IsSelfSent {
+		if segment.GateCursor() > afterCursor && !segment.IsMyself && !segment.IsSelfSent {
 			refs = append(refs, segment.ImageRefs...)
 		}
 	}
 	return refs
 }
 
-func wasRecentlyMentioned(rc timeline.RenderedContext, afterMs int64) bool {
+func wasRecentlyMentioned(rc timeline.RenderedContext, afterCursor int64) bool {
 	for _, segment := range rc {
 		if segment.IsMyself || segment.IsSelfSent {
 			continue
 		}
-		if segment.ReceivedAtMs > afterMs && (segment.MentionsMe || segment.RepliesToMe) {
+		if segment.GateCursor() > afterCursor && (segment.MentionsMe || segment.RepliesToMe) {
 			return true
 		}
 	}

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -24,7 +24,7 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 		return discussTurnPlan{}, false
 	}
 
-	isMentioned := wasRecentlyMentioned(rc, afterMs)
+	isMentioned := wasRecentlyMentioned(timeline.ActiveRenderedContext(rc, artifacts), afterMs)
 	addressed := isMentioned || turn.IsPrivateConversationType(cfg.ConversationType)
 	msgs := make([]turn.DiscussMessage, 0, len(composed.Messages))
 	for _, message := range composed.Messages {
@@ -86,7 +86,7 @@ func latestRCReceivedAtMs(rc timeline.RenderedContext) int64 {
 func extractNewImageRefs(rc timeline.RenderedContext, afterMs int64) []timeline.ImageAttachmentRef {
 	var refs []timeline.ImageAttachmentRef
 	for _, segment := range rc {
-		if segment.ReceivedAtMs > afterMs && !segment.IsMyself {
+		if segment.ReceivedAtMs > afterMs && !segment.IsMyself && !segment.IsSelfSent {
 			refs = append(refs, segment.ImageRefs...)
 		}
 	}
@@ -95,6 +95,9 @@ func extractNewImageRefs(rc timeline.RenderedContext, afterMs int64) []timeline.
 
 func wasRecentlyMentioned(rc timeline.RenderedContext, afterMs int64) bool {
 	for _, segment := range rc {
+		if segment.IsMyself || segment.IsSelfSent {
+			continue
+		}
 		if segment.ReceivedAtMs > afterMs && (segment.MentionsMe || segment.RepliesToMe) {
 			return true
 		}

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -24,8 +24,7 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 		return discussTurnPlan{}, false
 	}
 
-	activeRC := timeline.ActiveRenderedContext(rc, artifacts)
-	isMentioned := wasRecentlyMentioned(activeRC, after)
+	isMentioned := wasRecentlyMentioned(rc, after)
 	addressed := isMentioned || turn.IsPrivateConversationType(cfg.ConversationType)
 	msgs := make([]turn.DiscussMessage, 0, len(composed.Messages))
 	for _, message := range composed.Messages {
@@ -36,7 +35,7 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 		})
 	}
 	imageRefs := make([]turn.DiscussImageRef, 0)
-	for _, ref := range extractNewImageRefs(activeRC, after) {
+	for _, ref := range extractNewImageRefs(timeline.ActiveRenderedContext(rc, artifacts), after) {
 		imageRefs = append(imageRefs, turn.DiscussImageRef{
 			ContentHash: ref.ContentHash,
 			Mime:        ref.Mime,

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -19,7 +19,7 @@ type discussTurnPlan struct {
 // Build composes the durable timeline and persisted turn responses into the
 // pure StartTurn command consumed by Agent.
 func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.RenderedContext, trs []timeline.TurnResponseEntry, afterMs int64) (discussTurnPlan, bool) {
-	composed := timeline.ComposeContext(rc, trs, "")
+	composed := timeline.ComposeContext(rc, trs)
 	if composed == nil {
 		return discussTurnPlan{}, false
 	}

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -18,13 +18,13 @@ type discussTurnPlan struct {
 
 // Build composes the durable timeline and persisted turn responses into the
 // pure StartTurn command consumed by Agent.
-func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.RenderedContext, trs []timeline.TurnResponseEntry, afterCursor int64, artifacts []timeline.CompactionArtifact) (discussTurnPlan, bool) {
+func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.RenderedContext, trs []timeline.TurnResponseEntry, after timeline.DiscussCursorPosition, artifacts []timeline.CompactionArtifact) (discussTurnPlan, bool) {
 	composed := timeline.ComposeContextWithArtifacts(rc, trs, artifacts)
 	if composed == nil {
 		return discussTurnPlan{}, false
 	}
 
-	isMentioned := wasRecentlyMentioned(timeline.ActiveRenderedContext(rc, artifacts), afterCursor)
+	isMentioned := wasRecentlyMentioned(timeline.ActiveRenderedContext(rc, artifacts), after)
 	addressed := isMentioned || turn.IsPrivateConversationType(cfg.ConversationType)
 	msgs := make([]turn.DiscussMessage, 0, len(composed.Messages))
 	for _, message := range composed.Messages {
@@ -35,7 +35,7 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 		})
 	}
 	imageRefs := make([]turn.DiscussImageRef, 0)
-	for _, ref := range extractNewImageRefs(rc, afterCursor) {
+	for _, ref := range extractNewImageRefs(rc, after) {
 		imageRefs = append(imageRefs, turn.DiscussImageRef{
 			ContentHash: ref.ContentHash,
 			Mime:        ref.Mime,
@@ -71,22 +71,22 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 
 // extractNewImageRefs collects image references from external RC segments
 // that arrived after the last consumed cursor.
-func extractNewImageRefs(rc timeline.RenderedContext, afterCursor int64) []timeline.ImageAttachmentRef {
+func extractNewImageRefs(rc timeline.RenderedContext, after timeline.DiscussCursorPosition) []timeline.ImageAttachmentRef {
 	var refs []timeline.ImageAttachmentRef
 	for _, segment := range rc {
-		if segment.GateCursor() > afterCursor && !segment.IsMyself && !segment.IsSelfSent {
+		if !after.Covers(segment) && !segment.IsMyself && !segment.IsSelfSent {
 			refs = append(refs, segment.ImageRefs...)
 		}
 	}
 	return refs
 }
 
-func wasRecentlyMentioned(rc timeline.RenderedContext, afterCursor int64) bool {
+func wasRecentlyMentioned(rc timeline.RenderedContext, after timeline.DiscussCursorPosition) bool {
 	for _, segment := range rc {
 		if segment.IsMyself || segment.IsSelfSent {
 			continue
 		}
-		if segment.GateCursor() > afterCursor && (segment.MentionsMe || segment.RepliesToMe) {
+		if !after.Covers(segment) && (segment.MentionsMe || segment.RepliesToMe) {
 			return true
 		}
 	}

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -29,9 +29,10 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 	msgs := make([]turn.DiscussMessage, 0, len(composed.Messages))
 	for _, message := range composed.Messages {
 		msgs = append(msgs, turn.DiscussMessage{
-			Role:       message.Role,
-			Content:    message.Content,
-			RawContent: message.RawContent,
+			Role:                 message.Role,
+			Content:              message.Content,
+			RawContent:           message.RawContent,
+			CompactionArtifactID: message.CompactionArtifactID,
 		})
 	}
 	imageRefs := make([]turn.DiscussImageRef, 0)

--- a/internal/channel/discuss/worker.go
+++ b/internal/channel/discuss/worker.go
@@ -54,7 +54,7 @@ func (d *DiscussDriver) runSession(ctx context.Context, sess *discussSession) {
 		if len(latestRC) == 0 {
 			continue
 		}
-		if timeline.LatestExternalEventMs(latestRC, sess.lastProcessedMs) == 0 {
+		if timeline.LatestExternalEventCursor(latestRC, sess.lastProcessedCursor) == 0 {
 			continue
 		}
 		d.handleReply(ctx, sess, latestRC, log)
@@ -85,16 +85,22 @@ func (d *DiscussDriver) handleReplyWithTurn(ctx context.Context, sess *discussSe
 	cfg := d.sessionConfigSnapshot(sess)
 	trs := d.history.Load(ctx, cfg.ThreadID)
 
-	// Cold-start / post-idle initialisation anchors the in-memory cursor to
-	// both persisted replies and the durable discuss cursor.
-	if sess.lastProcessedMs == 0 {
-		sess.lastProcessedMs = maxInt64(anchorFromTRs(trs), d.cursor.Load(ctx, cfg, log))
+	// Cold-start / post-idle initialisation trusts the durable event cursor;
+	// legacy source-time state is mapped onto the replayed timeline so the
+	// seeded gate lives in the cursor domain.
+	if sess.lastProcessedCursor == 0 {
+		persisted := d.cursor.Load(ctx, cfg, log)
+		if persisted.EventCursor > 0 {
+			sess.lastProcessedCursor = persisted.EventCursor
+		} else if boundary := maxInt64(anchorFromTRs(trs), persisted.SourceCursor); boundary > 0 {
+			d.cursor.Advance(ctx, sess, cfg, timeline.HistoryDiscussCursor(rc, boundary), log)
+		}
 	}
-	if timeline.LatestExternalEventMs(rc, sess.lastProcessedMs) == 0 {
+	if timeline.LatestExternalEventCursor(rc, sess.lastProcessedCursor) == 0 {
 		return
 	}
 
-	plan, ok := d.trigger.Build(cfg, rc, trs, sess.lastProcessedMs, d.loadArtifacts(ctx, cfg, log))
+	plan, ok := d.trigger.Build(cfg, rc, trs, sess.lastProcessedCursor, d.loadArtifacts(ctx, cfg, log))
 	if !ok {
 		return
 	}
@@ -112,9 +118,9 @@ func (d *DiscussDriver) handleReplyWithTurn(ctx context.Context, sess *discussSe
 	}
 	if outcome.runtimeType == sessionRuntimeACPAgent {
 		if outcome.skipped || (outcome.streamed && outcome.terminal && !outcome.failed) {
-			d.cursor.Advance(ctx, sess, cfg, plan.consumedMs, log)
+			d.cursor.Advance(ctx, sess, cfg, plan.consumed, log)
 		}
 		return
 	}
-	d.cursor.Advance(ctx, sess, cfg, plan.consumedMs, log)
+	d.cursor.Advance(ctx, sess, cfg, plan.consumed, log)
 }

--- a/internal/channel/discuss/worker.go
+++ b/internal/channel/discuss/worker.go
@@ -54,7 +54,7 @@ func (d *DiscussDriver) runSession(ctx context.Context, sess *discussSession) {
 		if len(latestRC) == 0 {
 			continue
 		}
-		if timeline.LatestExternalEventCursor(latestRC, sess.lastProcessedCursor) == 0 {
+		if !timeline.HasUncoveredExternalEvent(latestRC, sess.lastProcessed) {
 			continue
 		}
 		d.handleReply(ctx, sess, latestRC, log)
@@ -85,22 +85,18 @@ func (d *DiscussDriver) handleReplyWithTurn(ctx context.Context, sess *discussSe
 	cfg := d.sessionConfigSnapshot(sess)
 	trs := d.history.Load(ctx, cfg.ThreadID)
 
-	// Cold-start / post-idle initialisation trusts the durable event cursor;
-	// legacy source-time state is mapped onto the replayed timeline so the
-	// seeded gate lives in the cursor domain.
-	if sess.lastProcessedCursor == 0 {
+	// Cold-start / post-idle initialisation combines the durable position with
+	// the persisted-reply anchor; each segment is then gated inside its own
+	// cursor or source-time domain.
+	if sess.lastProcessed == (timeline.DiscussCursorPosition{}) {
 		persisted := d.cursor.Load(ctx, cfg, log)
-		if persisted.EventCursor > 0 {
-			sess.lastProcessedCursor = persisted.EventCursor
-		} else if boundary := maxInt64(anchorFromTRs(trs), persisted.SourceCursor); boundary > 0 {
-			d.cursor.Advance(ctx, sess, cfg, timeline.HistoryDiscussCursor(rc, boundary), log)
-		}
+		sess.lastProcessed = persisted.Merge(timeline.DiscussCursorPosition{SourceCursor: anchorFromTRs(trs)})
 	}
-	if timeline.LatestExternalEventCursor(rc, sess.lastProcessedCursor) == 0 {
+	if !timeline.HasUncoveredExternalEvent(rc, sess.lastProcessed) {
 		return
 	}
 
-	plan, ok := d.trigger.Build(cfg, rc, trs, sess.lastProcessedCursor, d.loadArtifacts(ctx, cfg, log))
+	plan, ok := d.trigger.Build(cfg, rc, trs, sess.lastProcessed, d.loadArtifacts(ctx, cfg, log))
 	if !ok {
 		return
 	}

--- a/internal/channel/discuss/worker.go
+++ b/internal/channel/discuss/worker.go
@@ -65,6 +65,20 @@ func (d *DiscussDriver) handleReply(ctx context.Context, sess *discussSession, r
 	d.handleReplyWithTurn(ctx, sess, rc, log, d.turnServiceSnapshot())
 }
 
+// loadArtifacts projects the session's active compaction frontier. Failures
+// degrade to uncompacted composition.
+func (d *DiscussDriver) loadArtifacts(ctx context.Context, cfg DiscussSessionConfig, log *slog.Logger) []timeline.CompactionArtifact {
+	if d.artifacts == nil {
+		return nil
+	}
+	artifacts, err := d.artifacts.ActiveCompactionArtifacts(ctx, cfg.BotID, cfg.ThreadID)
+	if err != nil {
+		log.Warn("load compaction artifacts failed", slog.Any("error", err))
+		return nil
+	}
+	return artifacts
+}
+
 // handleReplyWithTurn remains as a narrow seam for parity tests. Production
 // workers obtain the current service through turnServiceSnapshot.
 func (d *DiscussDriver) handleReplyWithTurn(ctx context.Context, sess *discussSession, rc timeline.RenderedContext, log *slog.Logger, turnSvc turn.Service) {
@@ -80,7 +94,7 @@ func (d *DiscussDriver) handleReplyWithTurn(ctx context.Context, sess *discussSe
 		return
 	}
 
-	plan, ok := d.trigger.Build(cfg, rc, trs, sess.lastProcessedMs)
+	plan, ok := d.trigger.Build(cfg, rc, trs, sess.lastProcessedMs, d.loadArtifacts(ctx, cfg, log))
 	if !ok {
 		return
 	}

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -862,13 +862,13 @@ func (p *ChannelInboundProcessor) HandleInbound(ctx context.Context, cfg channel
 		event := AdaptInbound(pipelineMsg, sessionID, identity.ChannelIdentityID, identity.DisplayName)
 		if p.eventStore != nil {
 			eid, persistedEvent, persistErr := p.eventStore.PersistEvent(ctx, identity.BotID, sessionID, event)
+			event = persistedEvent
 			if persistErr != nil {
 				if p.logger != nil {
 					p.logger.Warn("persist pipeline event failed", slog.Any("error", persistErr))
 				}
 			} else {
 				eventID = eid
-				event = persistedEvent
 			}
 		}
 		latestRC = p.pipeline.PushEvent(sessionID, event)

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -861,13 +861,14 @@ func (p *ChannelInboundProcessor) HandleInbound(ctx context.Context, cfg channel
 		pipelineMsg.Message.Attachments = resolvedAttachments
 		event := AdaptInbound(pipelineMsg, sessionID, identity.ChannelIdentityID, identity.DisplayName)
 		if p.eventStore != nil {
-			eid, persistErr := p.eventStore.PersistEvent(ctx, identity.BotID, sessionID, event)
+			eid, persistedEvent, persistErr := p.eventStore.PersistEvent(ctx, identity.BotID, sessionID, event)
 			if persistErr != nil {
 				if p.logger != nil {
 					p.logger.Warn("persist pipeline event failed", slog.Any("error", persistErr))
 				}
 			} else {
 				eventID = eid
+				event = persistedEvent
 			}
 		}
 		latestRC = p.pipeline.PushEvent(sessionID, event)

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -860,18 +860,11 @@ func (p *ChannelInboundProcessor) HandleInbound(ctx context.Context, cfg channel
 		pipelineMsg.Message = msg.Message
 		pipelineMsg.Message.Attachments = resolvedAttachments
 		event := AdaptInbound(pipelineMsg, sessionID, identity.ChannelIdentityID, identity.DisplayName)
+		var store sessionEventPersister
 		if p.eventStore != nil {
-			eid, persistedEvent, persistErr := p.eventStore.PersistEvent(ctx, identity.BotID, sessionID, event)
-			event = persistedEvent
-			if persistErr != nil {
-				if p.logger != nil {
-					p.logger.Warn("persist pipeline event failed", slog.Any("error", persistErr))
-				}
-			} else {
-				eventID = eid
-			}
+			store = p.eventStore
 		}
-		latestRC = p.pipeline.PushEvent(sessionID, event)
+		eventID, latestRC = persistAndProjectEvent(ctx, store, p.pipeline, p.logger, identity.BotID, sessionID, event)
 	}
 
 	// Discuss mode: dispatch to the discuss driver and return.

--- a/internal/channel/inbound/event_projection.go
+++ b/internal/channel/inbound/event_projection.go
@@ -1,0 +1,42 @@
+package inbound
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+// sessionEventPersister is the narrow slice of the timeline event store this
+// package needs to durably stamp an inbound event.
+type sessionEventPersister interface {
+	PersistEvent(ctx context.Context, botID, sessionID string, event timeline.CanonicalEvent) (string, timeline.CanonicalEvent, error)
+}
+
+// persistAndProjectEvent projects the persisted form of the event, not the
+// adapted input: the store stamps the durable event cursor that discuss
+// consumption gates on, so projecting the pre-persist value would silently
+// degrade every segment to source-time gating.
+func persistAndProjectEvent(
+	ctx context.Context,
+	store sessionEventPersister,
+	pipeline *timeline.Pipeline,
+	log *slog.Logger,
+	botID string,
+	sessionID string,
+	event timeline.CanonicalEvent,
+) (string, timeline.RenderedContext) {
+	eventID := ""
+	if store != nil {
+		id, persisted, err := store.PersistEvent(ctx, botID, sessionID, event)
+		event = persisted
+		if err != nil {
+			if log != nil {
+				log.Warn("persist pipeline event failed", slog.Any("error", err))
+			}
+		} else {
+			eventID = id
+		}
+	}
+	return eventID, pipeline.PushEvent(sessionID, event)
+}

--- a/internal/channel/inbound/event_projection_test.go
+++ b/internal/channel/inbound/event_projection_test.go
@@ -1,0 +1,73 @@
+package inbound
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+type stampingEventStore struct {
+	cursor int64
+	err    error
+	id     string
+}
+
+func (s stampingEventStore) PersistEvent(_ context.Context, _, _ string, event timeline.CanonicalEvent) (string, timeline.CanonicalEvent, error) {
+	msg, ok := event.(timeline.MessageEvent)
+	if !ok {
+		return "", event, errors.New("unexpected event type")
+	}
+	msg.EventCursor = s.cursor
+	return s.id, msg, s.err
+}
+
+func inboundTestEvent() timeline.MessageEvent {
+	return timeline.MessageEvent{
+		SessionID:    "s1",
+		MessageID:    "m1",
+		ReceivedAtMs: 1000,
+		TimestampSec: 1,
+		Content:      []timeline.ContentNode{{Type: "text", Text: "hello"}},
+		Conversation: timeline.ConversationMeta{Channel: "telegram", ConversationType: "group"},
+	}
+}
+
+func TestPersistAndProjectEventProjectsStampedCursor(t *testing.T) {
+	pipeline := timeline.NewPipeline(timeline.RenderParams{})
+	store := stampingEventStore{cursor: 4242, id: "event-1"}
+
+	id, rc := persistAndProjectEvent(context.Background(), store, pipeline, nil, "bot-1", "s1", inboundTestEvent())
+
+	if id != "event-1" {
+		t.Fatalf("event id = %q, want event-1", id)
+	}
+	if len(rc) != 1 || rc[0].LastEventCursor != 4242 {
+		t.Fatalf("projected segment must carry the stamped cursor, got %+v", rc)
+	}
+}
+
+func TestPersistAndProjectEventProjectsStampedCursorOnPersistFailure(t *testing.T) {
+	pipeline := timeline.NewPipeline(timeline.RenderParams{})
+	store := stampingEventStore{cursor: 4243, err: errors.New("insert unavailable"), id: "ignored"}
+
+	id, rc := persistAndProjectEvent(context.Background(), store, pipeline, nil, "bot-1", "s1", inboundTestEvent())
+
+	if id != "" {
+		t.Fatalf("failed persist must not report an event id, got %q", id)
+	}
+	if len(rc) != 1 || rc[0].LastEventCursor != 4243 {
+		t.Fatalf("projection must still use the store's event, got %+v", rc)
+	}
+}
+
+func TestPersistAndProjectEventWithoutStore(t *testing.T) {
+	pipeline := timeline.NewPipeline(timeline.RenderParams{})
+
+	id, rc := persistAndProjectEvent(context.Background(), nil, pipeline, nil, "bot-1", "s1", inboundTestEvent())
+
+	if id != "" || len(rc) != 1 || rc[0].LastEventCursor != 0 {
+		t.Fatalf("storeless projection must still render the event, got id=%q rc=%+v", id, rc)
+	}
+}

--- a/internal/chat/timeline/context.go
+++ b/internal/chat/timeline/context.go
@@ -53,20 +53,6 @@ type CompactionArtifact struct {
 	Sources        []CompactionSource `json:"sources,omitempty"`
 }
 
-// LatestExternalEventMs returns the receivedAtMs of the latest non-self segment
-// after afterMs, or 0 if none found.
-func LatestExternalEventMs(rc RenderedContext, afterMs int64) int64 {
-	var latest int64
-	for _, seg := range rc {
-		if seg.ReceivedAtMs > afterMs && !seg.IsMyself && !seg.IsSelfSent {
-			if seg.ReceivedAtMs > latest {
-				latest = seg.ReceivedAtMs
-			}
-		}
-	}
-	return latest
-}
-
 // ActiveRenderedContext removes only segments covered by usable artifacts.
 func ActiveRenderedContext(rc RenderedContext, artifacts []CompactionArtifact) RenderedContext {
 	return filterCoveredRenderedContext(rc, coveredExternalMessages(artifacts))

--- a/internal/chat/timeline/context.go
+++ b/internal/chat/timeline/context.go
@@ -46,11 +46,11 @@ type CompactionSource struct {
 // artifact. Callers preserve frontier order; composition keeps each artifact
 // separate so later restacks can supersede only the ranges they actually cover.
 type CompactionArtifact struct {
-	ID            string             `json:"id"`
-	Summary       string             `json:"summary"`
-	AnchorStartMs int64              `json:"anchor_start_ms,omitempty"`
-	CompletedAtMs int64              `json:"completed_at_ms,omitempty"`
-	Sources       []CompactionSource `json:"sources,omitempty"`
+	ID             string             `json:"id"`
+	Summary        string             `json:"summary"`
+	AnchorStartMs  int64              `json:"anchor_start_ms,omitempty"`
+	CoverageAsOfMs int64              `json:"coverage_as_of_ms,omitempty"`
+	Sources        []CompactionSource `json:"sources,omitempty"`
 }
 
 // LatestExternalEventMs returns the receivedAtMs of the latest non-self segment
@@ -308,7 +308,7 @@ func filterCoveredTurnResponses(trs []TurnResponseEntry, artifacts []CompactionA
 }
 
 type externalMessageCoverage struct {
-	completedAtMs int64
+	coverageAsOfMs int64
 }
 
 func coveredExternalMessages(artifacts []CompactionArtifact) map[string]externalMessageCoverage {
@@ -323,8 +323,8 @@ func coveredExternalMessages(artifacts []CompactionArtifact) map[string]external
 				continue
 			}
 			coverage := covered[id]
-			if artifact.CompletedAtMs > coverage.completedAtMs {
-				coverage.completedAtMs = artifact.CompletedAtMs
+			if artifact.CoverageAsOfMs > coverage.coverageAsOfMs {
+				coverage.coverageAsOfMs = artifact.CoverageAsOfMs
 			}
 			covered[id] = coverage
 		}
@@ -339,7 +339,7 @@ func renderedSegmentCovered(segment RenderedSegment, coverage externalMessageCov
 	if segment.EditedAtMs <= 0 {
 		return true
 	}
-	return coverage.completedAtMs > 0 && segment.EditedAtMs <= coverage.completedAtMs
+	return coverage.coverageAsOfMs > 0 && segment.EditedAtMs <= coverage.coverageAsOfMs
 }
 
 func (artifact CompactionArtifact) usable() bool {

--- a/internal/chat/timeline/context.go
+++ b/internal/chat/timeline/context.go
@@ -126,7 +126,27 @@ func appendTurnResponseEntries(entries []mergeEntry, trs []TurnResponseEntry) []
 		entries = append(entries, mergeEntry{
 			kind:         "tr",
 			time:         tr.RequestedAtMs,
-			step:         i,
+			step:         2 * i,
+			trRole:       tr.Role,
+			trContent:    tr.Content,
+			trRawContent: tr.RawContent,
+		})
+	}
+	return entries
+}
+
+// appendActiveTurnResponseEntries appends uncovered responses keyed by their
+// position in the full response list, so slot summaries and surviving
+// responses share one index space.
+func appendActiveTurnResponseEntries(entries []mergeEntry, trs []TurnResponseEntry, coveredIDs map[string]struct{}) []mergeEntry {
+	for i, tr := range trs {
+		if _, covered := coveredIDs[strings.TrimSpace(tr.SourceMessageID)]; covered {
+			continue
+		}
+		entries = append(entries, mergeEntry{
+			kind:         "tr",
+			time:         tr.RequestedAtMs,
+			step:         2 * i,
 			trRole:       tr.Role,
 			trContent:    tr.Content,
 			trRawContent: tr.RawContent,
@@ -155,7 +175,7 @@ func mergeKindOrder(kind string) int {
 		return 1
 	case "summary":
 		return 2
-	case "tr":
+	case "tr", "summary_tr_slot":
 		return 3
 	default:
 		return 4
@@ -184,7 +204,7 @@ func materializeMergeEntries(entries []mergeEntry) []ContextMessage {
 					pendingText.WriteString(piece.Text)
 				}
 			}
-		case "summary", "summary_slot", "summary_before_rc":
+		case "summary", "summary_slot", "summary_before_rc", "summary_tr_slot":
 			flushRC()
 			messages = append(messages, ContextMessage{
 				Role:                 "user",
@@ -214,14 +234,14 @@ func ComposeContext(rc RenderedContext, trs []TurnResponseEntry) *ComposeContext
 // artifact at the covered rendered slot when available, or its durable anchor.
 func ComposeContextWithArtifacts(rc RenderedContext, trs []TurnResponseEntry, artifacts []CompactionArtifact) *ComposeContextResult {
 	coveredMessages := coveredExternalMessages(artifacts)
-	activeTRs := filterCoveredTurnResponses(trs, artifacts)
-	entries := make([]mergeEntry, 0, len(rc)+len(activeTRs)+len(artifacts))
+	coveredResponseIDs := coveredHistoryMessageIDs(artifacts)
+	entries := make([]mergeEntry, 0, len(rc)+len(trs)+len(artifacts))
 	entries = appendActiveRenderedContextEntries(entries, rc, coveredMessages)
 	for i, artifact := range artifacts {
 		if !artifact.usable() {
 			continue
 		}
-		summaryAtMs, kind, step := artifactSummaryPlacement(artifact, rc, coveredMessages, i)
+		summaryAtMs, kind, step := artifactSummaryPlacement(artifact, rc, coveredMessages, trs, i)
 		entries = append(entries, mergeEntry{
 			kind:              kind,
 			time:              summaryAtMs,
@@ -230,7 +250,7 @@ func ComposeContextWithArtifacts(rc RenderedContext, trs []TurnResponseEntry, ar
 			summaryArtifactID: artifact.ID,
 		})
 	}
-	entries = appendTurnResponseEntries(entries, activeTRs)
+	entries = appendActiveTurnResponseEntries(entries, trs, coveredResponseIDs)
 	allMessages := mergeEntries(entries)
 	if len(allMessages) == 0 {
 		return nil
@@ -246,6 +266,7 @@ func artifactSummaryPlacement(
 	artifact CompactionArtifact,
 	rc RenderedContext,
 	coveredMessages map[string]externalMessageCoverage,
+	trs []TurnResponseEntry,
 	artifactIndex int,
 ) (int64, string, int) {
 	for _, source := range artifact.Sources {
@@ -269,6 +290,17 @@ func artifactSummaryPlacement(
 			}
 		}
 		break
+	}
+	for _, source := range artifact.Sources {
+		id := strings.TrimSpace(source.HistoryMessageID)
+		if id == "" {
+			continue
+		}
+		for i, tr := range trs {
+			if strings.TrimSpace(tr.SourceMessageID) == id {
+				return tr.RequestedAtMs, "summary_tr_slot", 2 * i
+			}
+		}
 	}
 	if artifact.AnchorStartMs <= 0 {
 		return earliestMergeTime, "summary", artifactIndex
@@ -294,7 +326,7 @@ func filterCoveredRenderedContext(
 	return filtered
 }
 
-func filterCoveredTurnResponses(trs []TurnResponseEntry, artifacts []CompactionArtifact) []TurnResponseEntry {
+func coveredHistoryMessageIDs(artifacts []CompactionArtifact) map[string]struct{} {
 	covered := make(map[string]struct{})
 	for _, artifact := range artifacts {
 		if !artifact.usable() {
@@ -306,17 +338,7 @@ func filterCoveredTurnResponses(trs []TurnResponseEntry, artifacts []CompactionA
 			}
 		}
 	}
-	if len(covered) == 0 {
-		return trs
-	}
-	filtered := make([]TurnResponseEntry, 0, len(trs))
-	for _, tr := range trs {
-		if _, ok := covered[strings.TrimSpace(tr.SourceMessageID)]; ok {
-			continue
-		}
-		filtered = append(filtered, tr)
-	}
-	return filtered
+	return covered
 }
 
 type externalMessageCoverage struct {

--- a/internal/chat/timeline/context.go
+++ b/internal/chat/timeline/context.go
@@ -87,12 +87,35 @@ func MergeContext(rc RenderedContext, trs []TurnResponseEntry) []ContextMessage 
 }
 
 func appendRenderedContextEntries(entries []mergeEntry, rc RenderedContext) []mergeEntry {
-	for _, seg := range rc {
+	for i, seg := range rc {
 		entries = append(entries, mergeEntry{
 			kind:      "rc",
 			time:      seg.ReceivedAtMs,
-			step:      -1,
+			step:      i,
 			rcContent: seg.Content,
+		})
+	}
+	return entries
+}
+
+// appendActiveRenderedContextEntries appends uncovered segments keyed by their
+// position in the full rendered context, so slot summaries and surviving
+// segments share one index space.
+func appendActiveRenderedContextEntries(
+	entries []mergeEntry,
+	rc RenderedContext,
+	coveredMessages map[string]externalMessageCoverage,
+) []mergeEntry {
+	for i, segment := range rc {
+		coverage, covered := coveredMessages[strings.TrimSpace(segment.MessageID)]
+		if covered && renderedSegmentCovered(segment, coverage) {
+			continue
+		}
+		entries = append(entries, mergeEntry{
+			kind:      "rc",
+			time:      segment.ReceivedAtMs,
+			step:      i,
+			rcContent: segment.Content,
 		})
 	}
 	return entries
@@ -117,8 +140,9 @@ func mergeEntries(entries []mergeEntry) []ContextMessage {
 		if entries[i].time != entries[j].time {
 			return entries[i].time < entries[j].time
 		}
-		if entries[i].kind != entries[j].kind {
-			return mergeKindOrder(entries[i].kind) < mergeKindOrder(entries[j].kind)
+		leftOrder, rightOrder := mergeKindOrder(entries[i].kind), mergeKindOrder(entries[j].kind)
+		if leftOrder != rightOrder {
+			return leftOrder < rightOrder
 		}
 		return entries[i].step < entries[j].step
 	})
@@ -129,7 +153,7 @@ func mergeKindOrder(kind string) int {
 	switch kind {
 	case "summary_before_rc":
 		return 0
-	case "rc":
+	case "rc", "summary_slot":
 		return 1
 	case "summary":
 		return 2
@@ -162,7 +186,7 @@ func materializeMergeEntries(entries []mergeEntry) []ContextMessage {
 					pendingText.WriteString(piece.Text)
 				}
 			}
-		case "summary", "summary_before_rc":
+		case "summary", "summary_slot", "summary_before_rc":
 			flushRC()
 			messages = append(messages, ContextMessage{
 				Role:                 "user",
@@ -192,23 +216,18 @@ func ComposeContext(rc RenderedContext, trs []TurnResponseEntry) *ComposeContext
 // artifact at the covered rendered slot when available, or its durable anchor.
 func ComposeContextWithArtifacts(rc RenderedContext, trs []TurnResponseEntry, artifacts []CompactionArtifact) *ComposeContextResult {
 	coveredMessages := coveredExternalMessages(artifacts)
-	activeRC := filterCoveredRenderedContext(rc, coveredMessages)
 	activeTRs := filterCoveredTurnResponses(trs, artifacts)
-	entries := make([]mergeEntry, 0, len(activeRC)+len(activeTRs)+len(artifacts))
-	entries = appendRenderedContextEntries(entries, activeRC)
+	entries := make([]mergeEntry, 0, len(rc)+len(activeTRs)+len(artifacts))
+	entries = appendActiveRenderedContextEntries(entries, rc, coveredMessages)
 	for i, artifact := range artifacts {
 		if !artifact.usable() {
 			continue
 		}
-		kind := "summary"
-		summaryAtMs, precedesRenderedContext := artifactSummaryPlacement(artifact, rc, coveredMessages)
-		if precedesRenderedContext {
-			kind = "summary_before_rc"
-		}
+		summaryAtMs, kind, step := artifactSummaryPlacement(artifact, rc, coveredMessages, i)
 		entries = append(entries, mergeEntry{
 			kind:              kind,
 			time:              summaryAtMs,
-			step:              i,
+			step:              step,
 			summaryContent:    "<summary>\n" + strings.TrimSpace(artifact.Summary) + "\n</summary>",
 			summaryArtifactID: artifact.ID,
 		})
@@ -229,7 +248,8 @@ func artifactSummaryPlacement(
 	artifact CompactionArtifact,
 	rc RenderedContext,
 	coveredMessages map[string]externalMessageCoverage,
-) (int64, bool) {
+	artifactIndex int,
+) (int64, string, int) {
 	for _, source := range artifact.Sources {
 		if source.CreatedAtMs <= 0 {
 			continue
@@ -242,17 +262,20 @@ func artifactSummaryPlacement(
 		if !covered {
 			break
 		}
-		for _, segment := range rc {
+		for i, segment := range rc {
 			if strings.TrimSpace(segment.MessageID) == id {
-				return segment.ReceivedAtMs, !renderedSegmentCovered(segment, coverage)
+				if renderedSegmentCovered(segment, coverage) {
+					return segment.ReceivedAtMs, "summary_slot", i
+				}
+				return segment.ReceivedAtMs, "summary_before_rc", i
 			}
 		}
 		break
 	}
 	if artifact.AnchorStartMs <= 0 {
-		return earliestMergeTime, false
+		return earliestMergeTime, "summary", artifactIndex
 	}
-	return artifact.AnchorStartMs, false
+	return artifact.AnchorStartMs, "summary", artifactIndex
 }
 
 func filterCoveredRenderedContext(

--- a/internal/chat/timeline/context.go
+++ b/internal/chat/timeline/context.go
@@ -58,13 +58,18 @@ type CompactionArtifact struct {
 func LatestExternalEventMs(rc RenderedContext, afterMs int64) int64 {
 	var latest int64
 	for _, seg := range rc {
-		if seg.ReceivedAtMs > afterMs && !seg.IsMyself {
+		if seg.ReceivedAtMs > afterMs && !seg.IsMyself && !seg.IsSelfSent {
 			if seg.ReceivedAtMs > latest {
 				latest = seg.ReceivedAtMs
 			}
 		}
 	}
 	return latest
+}
+
+// ActiveRenderedContext removes only segments covered by usable artifacts.
+func ActiveRenderedContext(rc RenderedContext, artifacts []CompactionArtifact) RenderedContext {
+	return filterCoveredRenderedContext(rc, coveredExternalMessages(artifacts))
 }
 
 const earliestMergeTime int64 = -1 << 63

--- a/internal/chat/timeline/context.go
+++ b/internal/chat/timeline/context.go
@@ -91,7 +91,7 @@ func appendRenderedContextEntries(entries []mergeEntry, rc RenderedContext) []me
 		entries = append(entries, mergeEntry{
 			kind:      "rc",
 			time:      seg.ReceivedAtMs,
-			step:      i,
+			step:      2 * i,
 			rcContent: seg.Content,
 		})
 	}
@@ -114,7 +114,7 @@ func appendActiveRenderedContextEntries(
 		entries = append(entries, mergeEntry{
 			kind:      "rc",
 			time:      segment.ReceivedAtMs,
-			step:      i,
+			step:      2 * i,
 			rcContent: segment.Content,
 		})
 	}
@@ -151,9 +151,7 @@ func mergeEntries(entries []mergeEntry) []ContextMessage {
 
 func mergeKindOrder(kind string) int {
 	switch kind {
-	case "summary_before_rc":
-		return 0
-	case "rc", "summary_slot":
+	case "rc", "summary_slot", "summary_before_rc":
 		return 1
 	case "summary":
 		return 2
@@ -265,9 +263,9 @@ func artifactSummaryPlacement(
 		for i, segment := range rc {
 			if strings.TrimSpace(segment.MessageID) == id {
 				if renderedSegmentCovered(segment, coverage) {
-					return segment.ReceivedAtMs, "summary_slot", i
+					return segment.ReceivedAtMs, "summary_slot", 2 * i
 				}
-				return segment.ReceivedAtMs, "summary_before_rc", i
+				return segment.ReceivedAtMs, "summary_before_rc", 2*i - 1
 			}
 		}
 		break

--- a/internal/chat/timeline/context.go
+++ b/internal/chat/timeline/context.go
@@ -12,23 +12,45 @@ const charsPerToken = 2
 // TurnResponseEntry represents an assistant or tool message from bot_history_messages,
 // used as the "TR" stream in context composition.
 type TurnResponseEntry struct {
-	RequestedAtMs int64           `json:"requested_at_ms"`
-	Role          string          `json:"role"`
-	Content       string          `json:"content"`
-	RawContent    json.RawMessage `json:"raw_content,omitempty"`
+	RequestedAtMs   int64           `json:"requested_at_ms"`
+	Role            string          `json:"role"`
+	Content         string          `json:"content"`
+	RawContent      json.RawMessage `json:"raw_content,omitempty"`
+	SourceMessageID string          `json:"source_message_id,omitempty"`
 }
 
 // ContextMessage is a unified message for LLM context, produced by MergeContext.
 type ContextMessage struct {
-	Role       string          `json:"role"`
-	Content    string          `json:"content"`
-	RawContent json.RawMessage `json:"raw_content,omitempty"`
+	Role                 string          `json:"role"`
+	Content              string          `json:"content"`
+	RawContent           json.RawMessage `json:"raw_content,omitempty"`
+	CompactionArtifactID string          `json:"compaction_artifact_id,omitempty"`
 }
 
 // ComposeContextResult holds the output of ComposeContext.
 type ComposeContextResult struct {
 	Messages        []ContextMessage
 	EstimatedTokens int
+}
+
+// CompactionSource identifies one durable history source covered by an active
+// compaction artifact. ExternalMessageID projects that source onto the rendered
+// stream; HistoryMessageID projects it onto persisted turn responses.
+type CompactionSource struct {
+	HistoryMessageID  string `json:"history_message_id,omitempty"`
+	ExternalMessageID string `json:"external_message_id,omitempty"`
+	CreatedAtMs       int64  `json:"created_at_ms,omitempty"`
+}
+
+// CompactionArtifact is the timeline-facing projection of one active compaction
+// artifact. Callers preserve frontier order; composition keeps each artifact
+// separate so later restacks can supersede only the ranges they actually cover.
+type CompactionArtifact struct {
+	ID            string             `json:"id"`
+	Summary       string             `json:"summary"`
+	AnchorStartMs int64              `json:"anchor_start_ms,omitempty"`
+	CompletedAtMs int64              `json:"completed_at_ms,omitempty"`
+	Sources       []CompactionSource `json:"sources,omitempty"`
 }
 
 // LatestExternalEventMs returns the receivedAtMs of the latest non-self segment
@@ -45,12 +67,17 @@ func LatestExternalEventMs(rc RenderedContext, afterMs int64) int64 {
 	return latest
 }
 
+const earliestMergeTime int64 = -1 << 63
+
 type mergeEntry struct {
-	kind string // "rc" or "tr"
+	kind string // "summary_before_rc", "rc", "summary", or "tr"
 	time int64
 	step int
 	// For RC entries
 	rcContent []RenderedContentPiece
+	// For summary entries
+	summaryContent    string
+	summaryArtifactID string
 	// For TR entries
 	trRole       string
 	trContent    string
@@ -63,7 +90,12 @@ type mergeEntry struct {
 // Consecutive RC entries between TR entries are merged into one user message.
 func MergeContext(rc RenderedContext, trs []TurnResponseEntry) []ContextMessage {
 	entries := make([]mergeEntry, 0, len(rc)+len(trs))
+	entries = appendRenderedContextEntries(entries, rc)
+	entries = appendTurnResponseEntries(entries, trs)
+	return mergeEntries(entries)
+}
 
+func appendRenderedContextEntries(entries []mergeEntry, rc RenderedContext) []mergeEntry {
 	for _, seg := range rc {
 		entries = append(entries, mergeEntry{
 			kind:      "rc",
@@ -72,7 +104,10 @@ func MergeContext(rc RenderedContext, trs []TurnResponseEntry) []ContextMessage 
 			rcContent: seg.Content,
 		})
 	}
+	return entries
+}
 
+func appendTurnResponseEntries(entries []mergeEntry, trs []TurnResponseEntry) []mergeEntry {
 	for i, tr := range trs {
 		entries = append(entries, mergeEntry{
 			kind:         "tr",
@@ -83,17 +118,38 @@ func MergeContext(rc RenderedContext, trs []TurnResponseEntry) []ContextMessage 
 			trRawContent: tr.RawContent,
 		})
 	}
+	return entries
+}
 
+func mergeEntries(entries []mergeEntry) []ContextMessage {
 	sort.SliceStable(entries, func(i, j int) bool {
 		if entries[i].time != entries[j].time {
 			return entries[i].time < entries[j].time
 		}
 		if entries[i].kind != entries[j].kind {
-			return entries[i].kind == "rc"
+			return mergeKindOrder(entries[i].kind) < mergeKindOrder(entries[j].kind)
 		}
 		return entries[i].step < entries[j].step
 	})
+	return materializeMergeEntries(entries)
+}
 
+func mergeKindOrder(kind string) int {
+	switch kind {
+	case "summary_before_rc":
+		return 0
+	case "rc":
+		return 1
+	case "summary":
+		return 2
+	case "tr":
+		return 3
+	default:
+		return 4
+	}
+}
+
+func materializeMergeEntries(entries []mergeEntry) []ContextMessage {
 	var messages []ContextMessage
 	var pendingText strings.Builder
 
@@ -105,7 +161,8 @@ func MergeContext(rc RenderedContext, trs []TurnResponseEntry) []ContextMessage 
 	}
 
 	for _, entry := range entries {
-		if entry.kind == "rc" {
+		switch entry.kind {
+		case "rc":
 			for _, piece := range entry.rcContent {
 				if piece.Type == "text" {
 					if pendingText.Len() > 0 {
@@ -114,7 +171,14 @@ func MergeContext(rc RenderedContext, trs []TurnResponseEntry) []ContextMessage 
 					pendingText.WriteString(piece.Text)
 				}
 			}
-		} else {
+		case "summary", "summary_before_rc":
+			flushRC()
+			messages = append(messages, ContextMessage{
+				Role:                 "user",
+				Content:              entry.summaryContent,
+				CompactionArtifactID: entry.summaryArtifactID,
+			})
+		case "tr":
 			flushRC()
 			messages = append(messages, ContextMessage{
 				Role:       entry.trRole,
@@ -128,22 +192,158 @@ func MergeContext(rc RenderedContext, trs []TurnResponseEntry) []ContextMessage 
 	return messages
 }
 
-// ComposeContext merges RC and TRs, optionally prepends a compaction summary.
-func ComposeContext(rc RenderedContext, trs []TurnResponseEntry, compactSummary string) *ComposeContextResult {
-	allMessages := MergeContext(rc, trs)
-	if len(allMessages) == 0 && compactSummary == "" {
-		return nil
-	}
+// ComposeContext merges un-compacted RC and TR streams.
+func ComposeContext(rc RenderedContext, trs []TurnResponseEntry) *ComposeContextResult {
+	return ComposeContextWithArtifacts(rc, trs, nil)
+}
 
-	if compactSummary != "" {
-		summary := ContextMessage{Role: "user", Content: "[Conversation summary]\n" + compactSummary}
-		allMessages = append([]ContextMessage{summary}, allMessages...)
+// ComposeContextWithArtifacts replaces covered RC/TR sources with each active
+// artifact at the covered rendered slot when available, or its durable anchor.
+func ComposeContextWithArtifacts(rc RenderedContext, trs []TurnResponseEntry, artifacts []CompactionArtifact) *ComposeContextResult {
+	coveredMessages := coveredExternalMessages(artifacts)
+	activeRC := filterCoveredRenderedContext(rc, coveredMessages)
+	activeTRs := filterCoveredTurnResponses(trs, artifacts)
+	entries := make([]mergeEntry, 0, len(activeRC)+len(activeTRs)+len(artifacts))
+	entries = appendRenderedContextEntries(entries, activeRC)
+	for i, artifact := range artifacts {
+		if !artifact.usable() {
+			continue
+		}
+		kind := "summary"
+		summaryAtMs, precedesRenderedContext := artifactSummaryPlacement(artifact, rc, coveredMessages)
+		if precedesRenderedContext {
+			kind = "summary_before_rc"
+		}
+		entries = append(entries, mergeEntry{
+			kind:              kind,
+			time:              summaryAtMs,
+			step:              i,
+			summaryContent:    "<summary>\n" + strings.TrimSpace(artifact.Summary) + "\n</summary>",
+			summaryArtifactID: artifact.ID,
+		})
+	}
+	entries = appendTurnResponseEntries(entries, activeTRs)
+	allMessages := mergeEntries(entries)
+	if len(allMessages) == 0 {
+		return nil
 	}
 
 	return &ComposeContextResult{
 		Messages:        allMessages,
 		EstimatedTokens: estimateMessagesTokens(allMessages),
 	}
+}
+
+func artifactSummaryPlacement(
+	artifact CompactionArtifact,
+	rc RenderedContext,
+	coveredMessages map[string]externalMessageCoverage,
+) (int64, bool) {
+	for _, source := range artifact.Sources {
+		if source.CreatedAtMs <= 0 {
+			continue
+		}
+		id := strings.TrimSpace(source.ExternalMessageID)
+		if id == "" {
+			break
+		}
+		coverage, covered := coveredMessages[id]
+		if !covered {
+			break
+		}
+		for _, segment := range rc {
+			if strings.TrimSpace(segment.MessageID) == id {
+				return segment.ReceivedAtMs, !renderedSegmentCovered(segment, coverage)
+			}
+		}
+		break
+	}
+	if artifact.AnchorStartMs <= 0 {
+		return earliestMergeTime, false
+	}
+	return artifact.AnchorStartMs, false
+}
+
+func filterCoveredRenderedContext(
+	rc RenderedContext,
+	coveredMessages map[string]externalMessageCoverage,
+) RenderedContext {
+	if len(coveredMessages) == 0 {
+		return rc
+	}
+	filtered := make(RenderedContext, 0, len(rc))
+	for _, segment := range rc {
+		coverage, covered := coveredMessages[strings.TrimSpace(segment.MessageID)]
+		if covered && renderedSegmentCovered(segment, coverage) {
+			continue
+		}
+		filtered = append(filtered, segment)
+	}
+	return filtered
+}
+
+func filterCoveredTurnResponses(trs []TurnResponseEntry, artifacts []CompactionArtifact) []TurnResponseEntry {
+	covered := make(map[string]struct{})
+	for _, artifact := range artifacts {
+		if !artifact.usable() {
+			continue
+		}
+		for _, source := range artifact.Sources {
+			if id := strings.TrimSpace(source.HistoryMessageID); id != "" {
+				covered[id] = struct{}{}
+			}
+		}
+	}
+	if len(covered) == 0 {
+		return trs
+	}
+	filtered := make([]TurnResponseEntry, 0, len(trs))
+	for _, tr := range trs {
+		if _, ok := covered[strings.TrimSpace(tr.SourceMessageID)]; ok {
+			continue
+		}
+		filtered = append(filtered, tr)
+	}
+	return filtered
+}
+
+type externalMessageCoverage struct {
+	completedAtMs int64
+}
+
+func coveredExternalMessages(artifacts []CompactionArtifact) map[string]externalMessageCoverage {
+	covered := make(map[string]externalMessageCoverage)
+	for _, artifact := range artifacts {
+		if !artifact.usable() {
+			continue
+		}
+		for _, source := range artifact.Sources {
+			id := strings.TrimSpace(source.ExternalMessageID)
+			if id == "" || source.CreatedAtMs <= 0 {
+				continue
+			}
+			coverage := covered[id]
+			if artifact.CompletedAtMs > coverage.completedAtMs {
+				coverage.completedAtMs = artifact.CompletedAtMs
+			}
+			covered[id] = coverage
+		}
+	}
+	return covered
+}
+
+// renderedSegmentCovered reports whether coverage may replace the segment. A
+// segment edited after the artifact completed carries content the summary has
+// never seen and must stay visible.
+func renderedSegmentCovered(segment RenderedSegment, coverage externalMessageCoverage) bool {
+	if segment.EditedAtMs <= 0 {
+		return true
+	}
+	return coverage.completedAtMs > 0 && segment.EditedAtMs <= coverage.completedAtMs
+}
+
+func (artifact CompactionArtifact) usable() bool {
+	return strings.TrimSpace(artifact.ID) != "" && strings.TrimSpace(artifact.Summary) != ""
 }
 
 func estimateMessagesTokens(messages []ContextMessage) int {

--- a/internal/chat/timeline/context_artifacts_test.go
+++ b/internal/chat/timeline/context_artifacts_test.go
@@ -261,3 +261,27 @@ func TestActiveRenderedContextFiltersCoveredSegments(t *testing.T) {
 		t.Fatalf("expected only live segment, got %+v", active)
 	}
 }
+
+func TestComposeContextWithArtifactsKeepsSlotOrderWithinSameMs(t *testing.T) {
+	rc := RenderedContext{
+		textSegment("m1", 1000, "covered first"),
+		textSegment("m2", 1000, "uncovered second"),
+	}
+	artifacts := []CompactionArtifact{{
+		ID:            "a1",
+		Summary:       "first slot",
+		AnchorStartMs: 1000,
+		Sources:       []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+	}}
+
+	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
+	if composed == nil || len(composed.Messages) != 2 {
+		t.Fatalf("expected summary + uncovered message, got %+v", composed)
+	}
+	if composed.Messages[0].CompactionArtifactID != "a1" {
+		t.Fatalf("summary must keep the covered segment's slot, got %v", messageTexts(composed.Messages))
+	}
+	if !strings.Contains(composed.Messages[1].Content, "uncovered second") {
+		t.Fatalf("uncovered same-ms message must follow the summary, got %v", messageTexts(composed.Messages))
+	}
+}

--- a/internal/chat/timeline/context_artifacts_test.go
+++ b/internal/chat/timeline/context_artifacts_test.go
@@ -142,11 +142,11 @@ func TestComposeContextWithArtifactsKeepsSegmentsEditedAfterCompletion(t *testin
 	edited.EditedAtMs = 5000
 	rc := RenderedContext{edited, textSegment("m2", 2000, "tail")}
 	artifacts := []CompactionArtifact{{
-		ID:            "a1",
-		Summary:       "stale coverage",
-		AnchorStartMs: 1000,
-		CompletedAtMs: 4000,
-		Sources:       []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+		ID:             "a1",
+		Summary:        "stale coverage",
+		AnchorStartMs:  1000,
+		CoverageAsOfMs: 4000,
+		Sources:        []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
 	}}
 
 	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
@@ -166,11 +166,11 @@ func TestComposeContextWithArtifactsDropsSegmentsEditedBeforeCompletion(t *testi
 	edited.EditedAtMs = 3500
 	rc := RenderedContext{edited, textSegment("m2", 2000, "tail")}
 	artifacts := []CompactionArtifact{{
-		ID:            "a1",
-		Summary:       "covers the edit",
-		AnchorStartMs: 1000,
-		CompletedAtMs: 4000,
-		Sources:       []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+		ID:             "a1",
+		Summary:        "covers the edit",
+		AnchorStartMs:  1000,
+		CoverageAsOfMs: 4000,
+		Sources:        []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
 	}}
 
 	composed := ComposeContextWithArtifacts(rc, nil, artifacts)

--- a/internal/chat/timeline/context_artifacts_test.go
+++ b/internal/chat/timeline/context_artifacts_test.go
@@ -339,3 +339,37 @@ func TestComposeContextWithArtifactsKeepsTurnResponseSlotOrderWithinSameMs(t *te
 		t.Fatalf("summary must take the covered response slot, got %v", messageTexts(composed.Messages))
 	}
 }
+
+// Two covered responses ahead of a survivor pin the response-side index space:
+// keying summaries by filtered position would land them after the survivor.
+func TestComposeContextWithArtifactsKeepsTurnResponseSlotAcrossMultipleCovered(t *testing.T) {
+	first := assistantTR(1000, "covered first reply")
+	first.SourceMessageID = "h1"
+	second := assistantTR(1000, "covered second reply")
+	second.SourceMessageID = "h2"
+	survivor := assistantTR(1000, "surviving reply")
+	survivor.SourceMessageID = "h3"
+	artifacts := []CompactionArtifact{
+		{
+			ID:      "a1",
+			Summary: "covers the first reply",
+			Sources: []CompactionSource{{HistoryMessageID: "h1", CreatedAtMs: 1000}},
+		},
+		{
+			ID:      "a2",
+			Summary: "covers the second reply",
+			Sources: []CompactionSource{{HistoryMessageID: "h2", CreatedAtMs: 1000}},
+		},
+	}
+
+	composed := ComposeContextWithArtifacts(nil, []TurnResponseEntry{first, second, survivor}, artifacts)
+	if composed == nil || len(composed.Messages) != 3 {
+		t.Fatalf("expected two summaries + survivor, got %+v", composed)
+	}
+	if composed.Messages[0].CompactionArtifactID != "a1" || composed.Messages[1].CompactionArtifactID != "a2" {
+		t.Fatalf("summaries must keep their covered slots in order, got %v", messageTexts(composed.Messages))
+	}
+	if !strings.Contains(composed.Messages[2].Content, "surviving reply") {
+		t.Fatalf("survivor must follow both summaries, got %v", messageTexts(composed.Messages))
+	}
+}

--- a/internal/chat/timeline/context_artifacts_test.go
+++ b/internal/chat/timeline/context_artifacts_test.go
@@ -1,0 +1,249 @@
+package timeline
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func textSegment(id string, atMs int64, text string) RenderedSegment {
+	return RenderedSegment{
+		MessageID:    id,
+		ReceivedAtMs: atMs,
+		Content:      []RenderedContentPiece{{Type: "text", Text: text}},
+	}
+}
+
+func assistantTR(atMs int64, text string) TurnResponseEntry {
+	return TurnResponseEntry{RequestedAtMs: atMs, Role: "assistant", Content: text}
+}
+
+func messageTexts(messages []ContextMessage) []string {
+	texts := make([]string, 0, len(messages))
+	for _, m := range messages {
+		texts = append(texts, m.Role+":"+m.Content)
+	}
+	return texts
+}
+
+func TestComposeContextWithArtifactsNoArtifactsMatchesComposeContext(t *testing.T) {
+	rc := RenderedContext{textSegment("m1", 1000, "hello"), textSegment("m2", 2000, "world")}
+	trs := []TurnResponseEntry{assistantTR(1500, "reply")}
+
+	plain := ComposeContext(rc, trs)
+	withArtifacts := ComposeContextWithArtifacts(rc, trs, nil)
+
+	if plain == nil || withArtifacts == nil {
+		t.Fatalf("expected non-nil results, got %v and %v", plain, withArtifacts)
+	}
+	if len(plain.Messages) != len(withArtifacts.Messages) {
+		t.Fatalf("expected same message count, got %d vs %d", len(plain.Messages), len(withArtifacts.Messages))
+	}
+	for i := range plain.Messages {
+		if !reflect.DeepEqual(plain.Messages[i], withArtifacts.Messages[i]) {
+			t.Fatalf("message %d differs: %+v vs %+v", i, plain.Messages[i], withArtifacts.Messages[i])
+		}
+	}
+}
+
+func TestComposeContextWithArtifactsReplacesCoveredSlot(t *testing.T) {
+	rc := RenderedContext{
+		textSegment("m1", 1000, "old-1"),
+		textSegment("m2", 2000, "old-2"),
+		textSegment("m3", 3000, "new"),
+	}
+	trs := []TurnResponseEntry{assistantTR(2500, "reply")}
+	artifacts := []CompactionArtifact{{
+		ID:            "a1",
+		Summary:       "summarized old",
+		AnchorStartMs: 1000,
+		Sources: []CompactionSource{
+			{ExternalMessageID: "m1", CreatedAtMs: 1000},
+			{ExternalMessageID: "m2", CreatedAtMs: 2000},
+		},
+	}}
+
+	composed := ComposeContextWithArtifacts(rc, trs, artifacts)
+	if composed == nil {
+		t.Fatal("expected composed result")
+	}
+	if len(composed.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d: %v", len(composed.Messages), messageTexts(composed.Messages))
+	}
+	summary := composed.Messages[0]
+	if summary.Role != "user" || summary.CompactionArtifactID != "a1" {
+		t.Fatalf("expected leading summary from a1, got %+v", summary)
+	}
+	if summary.Content != "<summary>\nsummarized old\n</summary>" {
+		t.Fatalf("unexpected summary content %q", summary.Content)
+	}
+	if strings.Contains(summary.Content+composed.Messages[1].Content+composed.Messages[2].Content, "old-1") {
+		t.Fatal("covered original content must not remain in context")
+	}
+	if composed.Messages[1].Role != "assistant" {
+		t.Fatalf("expected assistant reply second, got %+v", composed.Messages[1])
+	}
+	if composed.Messages[2].Role != "user" || !strings.Contains(composed.Messages[2].Content, "new") {
+		t.Fatalf("expected uncovered message last, got %+v", composed.Messages[2])
+	}
+}
+
+func TestComposeContextWithArtifactsAnchorFallback(t *testing.T) {
+	rc := RenderedContext{textSegment("m3", 3000, "new")}
+	artifacts := []CompactionArtifact{{
+		ID:            "a1",
+		Summary:       "aged out coverage",
+		AnchorStartMs: 1500,
+		Sources:       []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+	}}
+
+	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
+	if composed == nil || len(composed.Messages) != 2 {
+		t.Fatalf("expected summary + new message, got %+v", composed)
+	}
+	if composed.Messages[0].CompactionArtifactID != "a1" {
+		t.Fatalf("expected summary first, got %+v", composed.Messages[0])
+	}
+
+	noAnchor := []CompactionArtifact{{ID: "a2", Summary: "no anchor"}}
+	composed = ComposeContextWithArtifacts(rc, nil, noAnchor)
+	if composed == nil || len(composed.Messages) != 2 || composed.Messages[0].CompactionArtifactID != "a2" {
+		t.Fatalf("expected anchorless summary first, got %+v", composed)
+	}
+}
+
+func TestComposeContextWithArtifactsFiltersCoveredTurnResponses(t *testing.T) {
+	tr1 := assistantTR(1500, "covered reply")
+	tr1.SourceMessageID = "h1"
+	tr2 := assistantTR(2500, "live reply")
+	tr2.SourceMessageID = "h2"
+	artifacts := []CompactionArtifact{{
+		ID:      "a1",
+		Summary: "covers h1",
+		Sources: []CompactionSource{{HistoryMessageID: "h1"}},
+	}}
+
+	composed := ComposeContextWithArtifacts(nil, []TurnResponseEntry{tr1, tr2}, artifacts)
+	if composed == nil || len(composed.Messages) != 2 {
+		t.Fatalf("expected summary + live reply, got %+v", composed)
+	}
+	for _, m := range composed.Messages {
+		if strings.Contains(m.Content, "covered reply") {
+			t.Fatal("covered turn response must be dropped")
+		}
+	}
+	if !strings.Contains(composed.Messages[1].Content, "live reply") {
+		t.Fatalf("expected uncovered reply kept, got %+v", composed.Messages)
+	}
+}
+
+func TestComposeContextWithArtifactsKeepsSegmentsEditedAfterCompletion(t *testing.T) {
+	edited := textSegment("m1", 1000, "edited later")
+	edited.EditedAtMs = 5000
+	rc := RenderedContext{edited, textSegment("m2", 2000, "tail")}
+	artifacts := []CompactionArtifact{{
+		ID:            "a1",
+		Summary:       "stale coverage",
+		AnchorStartMs: 1000,
+		CompletedAtMs: 4000,
+		Sources:       []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+	}}
+
+	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
+	if composed == nil || len(composed.Messages) != 2 {
+		t.Fatalf("expected summary + merged rc, got %+v", composed)
+	}
+	if composed.Messages[0].CompactionArtifactID != "a1" {
+		t.Fatalf("expected summary before edited segment, got %+v", composed.Messages[0])
+	}
+	if !strings.Contains(composed.Messages[1].Content, "edited later") {
+		t.Fatalf("edited segment must survive coverage, got %+v", composed.Messages[1])
+	}
+}
+
+func TestComposeContextWithArtifactsDropsSegmentsEditedBeforeCompletion(t *testing.T) {
+	edited := textSegment("m1", 1000, "edited early")
+	edited.EditedAtMs = 3500
+	rc := RenderedContext{edited, textSegment("m2", 2000, "tail")}
+	artifacts := []CompactionArtifact{{
+		ID:            "a1",
+		Summary:       "covers the edit",
+		AnchorStartMs: 1000,
+		CompletedAtMs: 4000,
+		Sources:       []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+	}}
+
+	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
+	if composed == nil {
+		t.Fatal("expected composed result")
+	}
+	for _, m := range composed.Messages {
+		if strings.Contains(m.Content, "edited early") {
+			t.Fatal("segment edited before completion must be covered")
+		}
+	}
+}
+
+func TestComposeContextWithArtifactsKeepsEditedSegmentWhenCompletionUnknown(t *testing.T) {
+	edited := textSegment("m1", 1000, "edited unknown")
+	edited.EditedAtMs = 1200
+	rc := RenderedContext{edited}
+	artifacts := []CompactionArtifact{{
+		ID:      "a1",
+		Summary: "no completion time",
+		Sources: []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+	}}
+
+	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
+	if composed == nil {
+		t.Fatal("expected composed result")
+	}
+	found := false
+	for _, m := range composed.Messages {
+		if strings.Contains(m.Content, "edited unknown") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("edited segment must survive when completion time is unknown")
+	}
+}
+
+func TestComposeContextWithArtifactsIgnoresBlankSummary(t *testing.T) {
+	rc := RenderedContext{textSegment("m1", 1000, "original")}
+	artifacts := []CompactionArtifact{{
+		ID:      "a1",
+		Summary: "   \n ",
+		Sources: []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+	}}
+
+	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
+	if composed == nil || len(composed.Messages) != 1 {
+		t.Fatalf("expected original message only, got %+v", composed)
+	}
+	if composed.Messages[0].CompactionArtifactID != "" || !strings.Contains(composed.Messages[0].Content, "original") {
+		t.Fatalf("blank summary must not cover originals, got %+v", composed.Messages[0])
+	}
+}
+
+func TestComposeContextWithArtifactsOrdersMultipleArtifacts(t *testing.T) {
+	rc := RenderedContext{textSegment("m5", 5000, "current")}
+	artifacts := []CompactionArtifact{
+		{ID: "a2", Summary: "second window", AnchorStartMs: 3000},
+		{ID: "a1", Summary: "first window", AnchorStartMs: 1000},
+	}
+
+	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
+	if composed == nil || len(composed.Messages) != 3 {
+		t.Fatalf("expected 2 summaries + current, got %+v", composed)
+	}
+	if composed.Messages[0].CompactionArtifactID != "a1" || composed.Messages[1].CompactionArtifactID != "a2" {
+		t.Fatalf("expected summaries ordered by anchor, got %v", messageTexts(composed.Messages))
+	}
+}
+
+func TestComposeContextWithArtifactsEmptyInputs(t *testing.T) {
+	if composed := ComposeContextWithArtifacts(nil, nil, nil); composed != nil {
+		t.Fatalf("expected nil result for empty inputs, got %+v", composed)
+	}
+}

--- a/internal/chat/timeline/context_artifacts_test.go
+++ b/internal/chat/timeline/context_artifacts_test.go
@@ -285,3 +285,33 @@ func TestComposeContextWithArtifactsKeepsSlotOrderWithinSameMs(t *testing.T) {
 		t.Fatalf("uncovered same-ms message must follow the summary, got %v", messageTexts(composed.Messages))
 	}
 }
+
+func TestComposeContextWithArtifactsKeepsBeforeSlotOrderWithinSameMs(t *testing.T) {
+	edited := textSegment("m2", 1000, "edited survivor")
+	edited.EditedAtMs = 5000
+	rc := RenderedContext{
+		textSegment("m1", 1000, "uncovered first"),
+		edited,
+	}
+	artifacts := []CompactionArtifact{{
+		ID:             "a1",
+		Summary:        "covers the edited slot",
+		AnchorStartMs:  1000,
+		CoverageAsOfMs: 4000,
+		Sources:        []CompactionSource{{ExternalMessageID: "m2", CreatedAtMs: 1000}},
+	}}
+
+	composed := ComposeContextWithArtifacts(rc, nil, artifacts)
+	if composed == nil || len(composed.Messages) != 3 {
+		t.Fatalf("expected first + summary + edited, got %+v", composed)
+	}
+	if !strings.Contains(composed.Messages[0].Content, "uncovered first") {
+		t.Fatalf("uncovered earlier slot must stay first, got %v", messageTexts(composed.Messages))
+	}
+	if composed.Messages[1].CompactionArtifactID != "a1" {
+		t.Fatalf("summary must sit immediately before its kept slot, got %v", messageTexts(composed.Messages))
+	}
+	if !strings.Contains(composed.Messages[2].Content, "edited survivor") {
+		t.Fatalf("kept slot must follow its summary, got %v", messageTexts(composed.Messages))
+	}
+}

--- a/internal/chat/timeline/context_artifacts_test.go
+++ b/internal/chat/timeline/context_artifacts_test.go
@@ -248,21 +248,6 @@ func TestComposeContextWithArtifactsEmptyInputs(t *testing.T) {
 	}
 }
 
-func TestLatestExternalEventMsSkipsSelfSent(t *testing.T) {
-	selfSent := textSegment("m2", 2000, "bot echo")
-	selfSent.IsSelfSent = true
-	myself := textSegment("m3", 3000, "bot own")
-	myself.IsMyself = true
-	rc := RenderedContext{textSegment("m1", 1000, "external"), selfSent, myself}
-
-	if got := LatestExternalEventMs(rc, 0); got != 1000 {
-		t.Fatalf("LatestExternalEventMs = %d, want 1000", got)
-	}
-	if got := LatestExternalEventMs(rc, 1000); got != 0 {
-		t.Fatalf("expected no external events after 1000, got %d", got)
-	}
-}
-
 func TestActiveRenderedContextFiltersCoveredSegments(t *testing.T) {
 	rc := RenderedContext{textSegment("m1", 1000, "covered"), textSegment("m2", 2000, "live")}
 	artifacts := []CompactionArtifact{{

--- a/internal/chat/timeline/context_artifacts_test.go
+++ b/internal/chat/timeline/context_artifacts_test.go
@@ -315,3 +315,27 @@ func TestComposeContextWithArtifactsKeepsBeforeSlotOrderWithinSameMs(t *testing.
 		t.Fatalf("kept slot must follow its summary, got %v", messageTexts(composed.Messages))
 	}
 }
+
+func TestComposeContextWithArtifactsKeepsTurnResponseSlotOrderWithinSameMs(t *testing.T) {
+	early := assistantTR(1000, "uncovered early reply")
+	early.SourceMessageID = "h1"
+	covered := assistantTR(1000, "covered later reply")
+	covered.SourceMessageID = "h2"
+	artifacts := []CompactionArtifact{{
+		ID:            "a1",
+		Summary:       "covers the later reply",
+		AnchorStartMs: 1000,
+		Sources:       []CompactionSource{{HistoryMessageID: "h2", CreatedAtMs: 1000}},
+	}}
+
+	composed := ComposeContextWithArtifacts(nil, []TurnResponseEntry{early, covered}, artifacts)
+	if composed == nil || len(composed.Messages) != 2 {
+		t.Fatalf("expected early reply + summary, got %+v", composed)
+	}
+	if !strings.Contains(composed.Messages[0].Content, "uncovered early reply") {
+		t.Fatalf("uncovered earlier response must stay first, got %v", messageTexts(composed.Messages))
+	}
+	if composed.Messages[1].CompactionArtifactID != "a1" {
+		t.Fatalf("summary must take the covered response slot, got %v", messageTexts(composed.Messages))
+	}
+}

--- a/internal/chat/timeline/context_artifacts_test.go
+++ b/internal/chat/timeline/context_artifacts_test.go
@@ -247,3 +247,32 @@ func TestComposeContextWithArtifactsEmptyInputs(t *testing.T) {
 		t.Fatalf("expected nil result for empty inputs, got %+v", composed)
 	}
 }
+
+func TestLatestExternalEventMsSkipsSelfSent(t *testing.T) {
+	selfSent := textSegment("m2", 2000, "bot echo")
+	selfSent.IsSelfSent = true
+	myself := textSegment("m3", 3000, "bot own")
+	myself.IsMyself = true
+	rc := RenderedContext{textSegment("m1", 1000, "external"), selfSent, myself}
+
+	if got := LatestExternalEventMs(rc, 0); got != 1000 {
+		t.Fatalf("LatestExternalEventMs = %d, want 1000", got)
+	}
+	if got := LatestExternalEventMs(rc, 1000); got != 0 {
+		t.Fatalf("expected no external events after 1000, got %d", got)
+	}
+}
+
+func TestActiveRenderedContextFiltersCoveredSegments(t *testing.T) {
+	rc := RenderedContext{textSegment("m1", 1000, "covered"), textSegment("m2", 2000, "live")}
+	artifacts := []CompactionArtifact{{
+		ID:      "a1",
+		Summary: "covers m1",
+		Sources: []CompactionSource{{ExternalMessageID: "m1", CreatedAtMs: 1000}},
+	}}
+
+	active := ActiveRenderedContext(rc, artifacts)
+	if len(active) != 1 || active[0].MessageID != "m2" {
+		t.Fatalf("expected only live segment, got %+v", active)
+	}
+}

--- a/internal/chat/timeline/cursor.go
+++ b/internal/chat/timeline/cursor.go
@@ -8,10 +8,31 @@ import (
 const maxJSONSafeEventCursor int64 = 1<<53 - 1
 
 // DiscussCursorPosition tracks consumed discuss progress in both the durable
-// event-cursor domain and the legacy source-timestamp domain.
+// event-cursor domain and the legacy source-timestamp domain. Segments are
+// compared inside their own domain, so cursor magnitudes never race the wall
+// clock and cursor-less ingest degrades to source-time coverage.
 type DiscussCursorPosition struct {
 	EventCursor  int64
 	SourceCursor int64
+}
+
+// Covers reports whether the position already consumed the segment.
+func (p DiscussCursorPosition) Covers(seg RenderedSegment) bool {
+	if seg.LastEventCursor > 0 {
+		return seg.LastEventCursor <= p.EventCursor
+	}
+	return seg.ReceivedAtMs <= p.SourceCursor
+}
+
+// Merge returns the component-wise maximum of both positions.
+func (p DiscussCursorPosition) Merge(other DiscussCursorPosition) DiscussCursorPosition {
+	if other.EventCursor > p.EventCursor {
+		p.EventCursor = other.EventCursor
+	}
+	if other.SourceCursor > p.SourceCursor {
+		p.SourceCursor = other.SourceCursor
+	}
+	return p
 }
 
 func assignEventCursor(event CanonicalEvent, cursor int64) (CanonicalEvent, error) {
@@ -39,52 +60,18 @@ func assignEventCursor(event CanonicalEvent, cursor int64) (CanonicalEvent, erro
 	}
 }
 
-// GateCursor is the segment's trigger-gate value: the durable event cursor
-// when the segment has one, else its source timestamp. The cursor sequence is
-// seeded above the wall clock at migration, so legacy timestamps stay below
-// every allocated cursor.
-func (seg RenderedSegment) GateCursor() int64 {
-	if seg.LastEventCursor > 0 {
-		return seg.LastEventCursor
-	}
-	return seg.ReceivedAtMs
-}
-
-// LatestExternalEventCursor returns the highest gate value of non-self
-// segments past afterCursor, or 0 if none found.
-func LatestExternalEventCursor(rc RenderedContext, afterCursor int64) int64 {
-	var latest int64
+// HasUncoveredExternalEvent reports whether any non-self segment lies past the
+// consumed position.
+func HasUncoveredExternalEvent(rc RenderedContext, position DiscussCursorPosition) bool {
 	for _, seg := range rc {
 		if seg.IsMyself || seg.IsSelfSent {
 			continue
 		}
-		if gate := seg.GateCursor(); gate > afterCursor && gate > latest {
-			latest = gate
+		if !position.Covers(seg) {
+			return true
 		}
 	}
-	return latest
-}
-
-// HistoryDiscussCursor maps a legacy source-timestamp boundary onto the
-// rendered timeline, seeding a cursor-domain position from the segments the
-// boundary already covers.
-func HistoryDiscussCursor(rc RenderedContext, sourceBoundary int64) DiscussCursorPosition {
-	position := DiscussCursorPosition{}
-	if sourceBoundary <= 0 {
-		return position
-	}
-	for _, seg := range rc {
-		if seg.ReceivedAtMs > sourceBoundary {
-			continue
-		}
-		if seg.LastEventCursor > position.EventCursor {
-			position.EventCursor = seg.LastEventCursor
-		}
-		if seg.ReceivedAtMs > position.SourceCursor {
-			position.SourceCursor = seg.ReceivedAtMs
-		}
-	}
-	return position
+	return false
 }
 
 // ConsumedDiscussCursor is the position a discuss turn consumes when it

--- a/internal/chat/timeline/cursor.go
+++ b/internal/chat/timeline/cursor.go
@@ -1,0 +1,103 @@
+package timeline
+
+import (
+	"errors"
+	"fmt"
+)
+
+const maxJSONSafeEventCursor int64 = 1<<53 - 1
+
+// DiscussCursorPosition tracks consumed discuss progress in both the durable
+// event-cursor domain and the legacy source-timestamp domain.
+type DiscussCursorPosition struct {
+	EventCursor  int64
+	SourceCursor int64
+}
+
+func assignEventCursor(event CanonicalEvent, cursor int64) (CanonicalEvent, error) {
+	if event == nil {
+		return nil, errors.New("canonical event is nil")
+	}
+	if cursor <= 0 || cursor > maxJSONSafeEventCursor {
+		return nil, fmt.Errorf("event cursor %d is outside the JSON-safe range", cursor)
+	}
+	switch typed := event.(type) {
+	case MessageEvent:
+		typed.EventCursor = cursor
+		return typed, nil
+	case EditEvent:
+		typed.EventCursor = cursor
+		return typed, nil
+	case DeleteEvent:
+		typed.EventCursor = cursor
+		return typed, nil
+	case ServiceEvent:
+		typed.EventCursor = cursor
+		return typed, nil
+	default:
+		return nil, fmt.Errorf("unsupported canonical event type %T", event)
+	}
+}
+
+// GateCursor is the segment's trigger-gate value: the durable event cursor
+// when the segment has one, else its source timestamp. The cursor sequence is
+// seeded above the wall clock at migration, so legacy timestamps stay below
+// every allocated cursor.
+func (seg RenderedSegment) GateCursor() int64 {
+	if seg.LastEventCursor > 0 {
+		return seg.LastEventCursor
+	}
+	return seg.ReceivedAtMs
+}
+
+// LatestExternalEventCursor returns the highest gate value of non-self
+// segments past afterCursor, or 0 if none found.
+func LatestExternalEventCursor(rc RenderedContext, afterCursor int64) int64 {
+	var latest int64
+	for _, seg := range rc {
+		if seg.IsMyself || seg.IsSelfSent {
+			continue
+		}
+		if gate := seg.GateCursor(); gate > afterCursor && gate > latest {
+			latest = gate
+		}
+	}
+	return latest
+}
+
+// HistoryDiscussCursor maps a legacy source-timestamp boundary onto the
+// rendered timeline, seeding a cursor-domain position from the segments the
+// boundary already covers.
+func HistoryDiscussCursor(rc RenderedContext, sourceBoundary int64) DiscussCursorPosition {
+	position := DiscussCursorPosition{}
+	if sourceBoundary <= 0 {
+		return position
+	}
+	for _, seg := range rc {
+		if seg.ReceivedAtMs > sourceBoundary {
+			continue
+		}
+		if seg.LastEventCursor > position.EventCursor {
+			position.EventCursor = seg.LastEventCursor
+		}
+		if seg.ReceivedAtMs > position.SourceCursor {
+			position.SourceCursor = seg.ReceivedAtMs
+		}
+	}
+	return position
+}
+
+// ConsumedDiscussCursor is the position a discuss turn consumes when it
+// replies to the given rendered timeline.
+func ConsumedDiscussCursor(rc RenderedContext) DiscussCursorPosition {
+	position := DiscussCursorPosition{}
+	for _, seg := range rc {
+		if seg.LastEventCursor > position.EventCursor {
+			position.EventCursor = seg.LastEventCursor
+		}
+		if seg.ReceivedAtMs > position.SourceCursor {
+			position.SourceCursor = seg.ReceivedAtMs
+		}
+	}
+	return position
+}

--- a/internal/chat/timeline/cursor.go
+++ b/internal/chat/timeline/cursor.go
@@ -9,6 +9,12 @@ import (
 // sequence never exceeds it, so larger payload values are corrupt data.
 const MaxJSONSafeEventCursor int64 = 1<<53 - 1
 
+// MaxTrustedEventCursor bounds cursors read back from payloads or restores.
+// Clock-seeded allocation stays three orders of magnitude below it, while
+// accepting values near the sequence MAXVALUE would poison consumed
+// watermarks or exhaust the global sequence.
+const MaxTrustedEventCursor = MaxJSONSafeEventCursor / 2
+
 // DiscussCursorPosition tracks consumed discuss progress in both the durable
 // event-cursor domain and the legacy source-timestamp domain. Segments are
 // compared inside their own domain, so cursor magnitudes never race the wall
@@ -63,7 +69,7 @@ func assignEventCursor(event CanonicalEvent, cursor int64) (CanonicalEvent, erro
 }
 
 func sanitizedEventCursor(cursor int64) int64 {
-	if cursor <= 0 || cursor > MaxJSONSafeEventCursor {
+	if cursor <= 0 || cursor > MaxTrustedEventCursor {
 		return 0
 	}
 	return cursor

--- a/internal/chat/timeline/cursor.go
+++ b/internal/chat/timeline/cursor.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 )
 
-const maxJSONSafeEventCursor int64 = 1<<53 - 1
+// MaxJSONSafeEventCursor bounds legitimate event cursors; the allocation
+// sequence never exceeds it, so larger payload values are corrupt data.
+const MaxJSONSafeEventCursor int64 = 1<<53 - 1
 
 // DiscussCursorPosition tracks consumed discuss progress in both the durable
 // event-cursor domain and the legacy source-timestamp domain. Segments are
@@ -39,7 +41,7 @@ func assignEventCursor(event CanonicalEvent, cursor int64) (CanonicalEvent, erro
 	if event == nil {
 		return nil, errors.New("canonical event is nil")
 	}
-	if cursor <= 0 || cursor > maxJSONSafeEventCursor {
+	if cursor <= 0 || cursor > MaxJSONSafeEventCursor {
 		return nil, fmt.Errorf("event cursor %d is outside the JSON-safe range", cursor)
 	}
 	switch typed := event.(type) {
@@ -58,6 +60,13 @@ func assignEventCursor(event CanonicalEvent, cursor int64) (CanonicalEvent, erro
 	default:
 		return nil, fmt.Errorf("unsupported canonical event type %T", event)
 	}
+}
+
+func sanitizedEventCursor(cursor int64) int64 {
+	if cursor <= 0 || cursor > MaxJSONSafeEventCursor {
+		return 0
+	}
+	return cursor
 }
 
 // HasUncoveredExternalEvent reports whether any non-self segment lies past the

--- a/internal/chat/timeline/cursor.go
+++ b/internal/chat/timeline/cursor.go
@@ -24,12 +24,20 @@ type DiscussCursorPosition struct {
 	SourceCursor int64
 }
 
-// Covers reports whether the position already consumed the segment.
+// Covers reports whether the position already consumed the segment. Coverage
+// must hold in every domain that carries information: cursor allocation order
+// can invert against source order when concurrent workers stamp one thread, so
+// a covered cursor alone never proves consumption, and a watermark seeded from
+// persisted replies alone carries no cursor to compare against. Anything the
+// watermark cannot prove consumed is treated as new.
 func (p DiscussCursorPosition) Covers(seg RenderedSegment) bool {
-	if seg.LastEventCursor > 0 {
+	if seg.ReceivedAtMs > p.SourceCursor {
+		return false
+	}
+	if seg.LastEventCursor > 0 && p.EventCursor > 0 {
 		return seg.LastEventCursor <= p.EventCursor
 	}
-	return seg.ReceivedAtMs <= p.SourceCursor
+	return true
 }
 
 // Merge returns the component-wise maximum of both positions.

--- a/internal/chat/timeline/cursor_test.go
+++ b/internal/chat/timeline/cursor_test.go
@@ -146,6 +146,42 @@ func TestConsumedDiscussCursorTakesLatestGate(t *testing.T) {
 	}
 }
 
+func TestPushEventClampsOutOfRangeCursorOnEveryEventKind(t *testing.T) {
+	poisoned := MaxTrustedEventCursor + 1
+	pipeline := NewPipeline(RenderParams{})
+	pipeline.PushEvent("s1", MessageEvent{
+		SessionID: "s1", MessageID: "m1", EventCursor: 7001,
+		ReceivedAtMs: 1000, TimestampSec: 1,
+		Content: []ContentNode{{Type: "text", Text: "hello"}},
+	})
+
+	rc := pipeline.PushEvent("s1", EditEvent{
+		SessionID: "s1", MessageID: "m1", EventCursor: poisoned,
+		ReceivedAtMs: 2000, TimestampSec: 2,
+		Content: []ContentNode{{Type: "text", Text: "edited"}},
+	})
+	if len(rc) != 1 || rc[0].LastEventCursor != 7001 {
+		t.Fatalf("poisoned edit cursor must not bump the segment, got %+v", rc)
+	}
+
+	rc = pipeline.PushEvent("s1", DeleteEvent{
+		SessionID: "s1", MessageIDs: []string{"m1"}, EventCursor: poisoned,
+		ReceivedAtMs: 3000, TimestampSec: 3,
+	})
+	if len(rc) != 1 || rc[0].LastEventCursor != 7001 {
+		t.Fatalf("poisoned delete cursor must not bump the segment, got %+v", rc)
+	}
+
+	rc = pipeline.PushEvent("s1", ServiceEvent{
+		SessionID: "s1", Action: ServiceMemberLeft, EventCursor: poisoned,
+		ReceivedAtMs: 4000, TimestampSec: 4,
+		Member: &CanonicalUser{ID: "u1", DisplayName: "Someone"},
+	})
+	if len(rc) != 2 || rc[1].LastEventCursor != 0 {
+		t.Fatalf("poisoned service cursor must be dropped, got %+v", rc)
+	}
+}
+
 func TestPushEventClampsOutOfRangeCursor(t *testing.T) {
 	for _, poisoned := range []int64{MaxJSONSafeEventCursor + 1, MaxJSONSafeEventCursor, MaxTrustedEventCursor + 1} {
 		pipeline := NewPipeline(RenderParams{})

--- a/internal/chat/timeline/cursor_test.go
+++ b/internal/chat/timeline/cursor_test.go
@@ -1,0 +1,131 @@
+package timeline
+
+import (
+	"testing"
+)
+
+func TestAssignEventCursorStampsAllEventKinds(t *testing.T) {
+	events := []CanonicalEvent{
+		MessageEvent{SessionID: "s", MessageID: "m1", ReceivedAtMs: 1000},
+		EditEvent{SessionID: "s", MessageID: "m1", ReceivedAtMs: 1100},
+		DeleteEvent{SessionID: "s", MessageIDs: []string{"m1"}, ReceivedAtMs: 1200},
+		ServiceEvent{SessionID: "s", Action: ServiceMemberLeft, ReceivedAtMs: 1300},
+	}
+	for _, event := range events {
+		stamped, err := assignEventCursor(event, 5001)
+		if err != nil {
+			t.Fatalf("assign cursor to %T: %v", event, err)
+		}
+		if got := eventCursorOf(stamped); got != 5001 {
+			t.Fatalf("%T cursor = %d, want 5001", stamped, got)
+		}
+	}
+}
+
+func eventCursorOf(event CanonicalEvent) int64 {
+	switch typed := event.(type) {
+	case MessageEvent:
+		return typed.EventCursor
+	case EditEvent:
+		return typed.EventCursor
+	case DeleteEvent:
+		return typed.EventCursor
+	case ServiceEvent:
+		return typed.EventCursor
+	default:
+		return -1
+	}
+}
+
+func TestAssignEventCursorRejectsInvalid(t *testing.T) {
+	if _, err := assignEventCursor(nil, 1); err == nil {
+		t.Fatal("expected error for nil event")
+	}
+	if _, err := assignEventCursor(MessageEvent{}, 0); err == nil {
+		t.Fatal("expected error for non-positive cursor")
+	}
+	if _, err := assignEventCursor(MessageEvent{}, maxJSONSafeEventCursor+1); err == nil {
+		t.Fatal("expected error for cursor above the JSON-safe range")
+	}
+}
+
+func TestPushEventThreadsCursorIntoSegments(t *testing.T) {
+	pipeline := NewPipeline(RenderParams{})
+	rc := pipeline.PushEvent("s1", MessageEvent{
+		SessionID:    "s1",
+		MessageID:    "m1",
+		EventCursor:  7001,
+		ReceivedAtMs: 1000,
+		TimestampSec: 1,
+		Content:      []ContentNode{{Type: "text", Text: "hello"}},
+		Conversation: ConversationMeta{Channel: "telegram", ConversationType: "group"},
+	})
+	if len(rc) != 1 || rc[0].LastEventCursor != 7001 {
+		t.Fatalf("expected segment cursor 7001, got %+v", rc)
+	}
+
+	rc = pipeline.PushEvent("s1", EditEvent{
+		SessionID:    "s1",
+		MessageID:    "m1",
+		EventCursor:  7002,
+		ReceivedAtMs: 2000,
+		TimestampSec: 2,
+		Content:      []ContentNode{{Type: "text", Text: "hello edited"}},
+	})
+	if len(rc) != 1 || rc[0].LastEventCursor != 7002 {
+		t.Fatalf("expected edit to bump segment cursor to 7002, got %+v", rc)
+	}
+}
+
+func TestLatestExternalEventCursorGates(t *testing.T) {
+	withCursor := textSegment("m1", 1000, "external")
+	withCursor.LastEventCursor = 7001
+	selfSent := textSegment("m2", 2000, "bot echo")
+	selfSent.LastEventCursor = 7002
+	selfSent.IsSelfSent = true
+	myself := textSegment("m3", 3000, "bot own")
+	myself.LastEventCursor = 7003
+	myself.IsMyself = true
+	legacy := textSegment("m0", 500, "pre-migration")
+	rc := RenderedContext{legacy, withCursor, selfSent, myself}
+
+	if got := LatestExternalEventCursor(rc, 0); got != 7001 {
+		t.Fatalf("LatestExternalEventCursor = %d, want 7001", got)
+	}
+	if got := LatestExternalEventCursor(rc, 7001); got != 0 {
+		t.Fatalf("expected no external events past 7001, got %d", got)
+	}
+	if got := LatestExternalEventCursor(RenderedContext{legacy}, 400); got != 500 {
+		t.Fatalf("legacy segment must gate by receivedAtMs, got %d", got)
+	}
+}
+
+func TestHistoryDiscussCursorMapsSourceBoundary(t *testing.T) {
+	consumed := textSegment("m1", 1000, "consumed")
+	consumed.LastEventCursor = 7001
+	alsoConsumed := textSegment("m2", 1500, "consumed too")
+	alsoConsumed.LastEventCursor = 7002
+	pending := textSegment("m3", 3000, "pending")
+	pending.LastEventCursor = 7003
+	rc := RenderedContext{consumed, alsoConsumed, pending}
+
+	position := HistoryDiscussCursor(rc, 2000)
+	if position.EventCursor != 7002 || position.SourceCursor != 1500 {
+		t.Fatalf("position = %+v, want cursor 7002 source 1500", position)
+	}
+	if got := HistoryDiscussCursor(rc, 0); got != (DiscussCursorPosition{}) {
+		t.Fatalf("zero boundary must map to zero position, got %+v", got)
+	}
+}
+
+func TestConsumedDiscussCursorTakesLatestGate(t *testing.T) {
+	legacy := textSegment("m0", 900, "legacy")
+	current := textSegment("m1", 1000, "current")
+	current.LastEventCursor = 7001
+	rc := RenderedContext{legacy, current}
+
+	position := ConsumedDiscussCursor(rc)
+	if position.EventCursor != 7001 || position.SourceCursor != 1000 {
+		t.Fatalf("position = %+v, want cursor 7001 source 1000", position)
+	}
+}

--- a/internal/chat/timeline/cursor_test.go
+++ b/internal/chat/timeline/cursor_test.go
@@ -77,44 +77,60 @@ func TestPushEventThreadsCursorIntoSegments(t *testing.T) {
 	}
 }
 
-func TestLatestExternalEventCursorGates(t *testing.T) {
-	withCursor := textSegment("m1", 1000, "external")
+func TestDiscussCursorPositionCovers(t *testing.T) {
+	position := DiscussCursorPosition{EventCursor: 7001, SourceCursor: 1500}
+
+	withCursor := textSegment("m1", 9000, "cursor domain")
 	withCursor.LastEventCursor = 7001
+	if !position.Covers(withCursor) {
+		t.Fatal("segment at the consumed event cursor must be covered regardless of timestamps")
+	}
+	fresh := textSegment("m2", 100, "newer cursor")
+	fresh.LastEventCursor = 7002
+	if position.Covers(fresh) {
+		t.Fatal("segment past the consumed event cursor must not be covered")
+	}
+	legacy := textSegment("m0", 1400, "legacy")
+	if !position.Covers(legacy) {
+		t.Fatal("cursor-less segment inside the source window must be covered")
+	}
+	degraded := textSegment("m3", 1600, "degraded ingest")
+	if position.Covers(degraded) {
+		t.Fatal("cursor-less segment past the source window must not be covered")
+	}
+}
+
+func TestHasUncoveredExternalEvent(t *testing.T) {
+	position := DiscussCursorPosition{EventCursor: 7001, SourceCursor: 1500}
+	covered := textSegment("m1", 1000, "covered")
+	covered.LastEventCursor = 7001
 	selfSent := textSegment("m2", 2000, "bot echo")
 	selfSent.LastEventCursor = 7002
 	selfSent.IsSelfSent = true
 	myself := textSegment("m3", 3000, "bot own")
 	myself.LastEventCursor = 7003
 	myself.IsMyself = true
-	legacy := textSegment("m0", 500, "pre-migration")
-	rc := RenderedContext{legacy, withCursor, selfSent, myself}
+	rc := RenderedContext{covered, selfSent, myself}
 
-	if got := LatestExternalEventCursor(rc, 0); got != 7001 {
-		t.Fatalf("LatestExternalEventCursor = %d, want 7001", got)
+	if HasUncoveredExternalEvent(rc, position) {
+		t.Fatal("covered and self segments must not report new external activity")
 	}
-	if got := LatestExternalEventCursor(rc, 7001); got != 0 {
-		t.Fatalf("expected no external events past 7001, got %d", got)
+	fresh := textSegment("m4", 4000, "new")
+	fresh.LastEventCursor = 7004
+	if !HasUncoveredExternalEvent(append(rc, fresh), position) {
+		t.Fatal("uncovered external segment must report new activity")
 	}
-	if got := LatestExternalEventCursor(RenderedContext{legacy}, 400); got != 500 {
-		t.Fatalf("legacy segment must gate by receivedAtMs, got %d", got)
+	degraded := textSegment("m5", 1600, "no cursor")
+	if !HasUncoveredExternalEvent(append(rc, degraded), position) {
+		t.Fatal("cursor-less segment past the source window must report new activity")
 	}
 }
 
-func TestHistoryDiscussCursorMapsSourceBoundary(t *testing.T) {
-	consumed := textSegment("m1", 1000, "consumed")
-	consumed.LastEventCursor = 7001
-	alsoConsumed := textSegment("m2", 1500, "consumed too")
-	alsoConsumed.LastEventCursor = 7002
-	pending := textSegment("m3", 3000, "pending")
-	pending.LastEventCursor = 7003
-	rc := RenderedContext{consumed, alsoConsumed, pending}
-
-	position := HistoryDiscussCursor(rc, 2000)
-	if position.EventCursor != 7002 || position.SourceCursor != 1500 {
-		t.Fatalf("position = %+v, want cursor 7002 source 1500", position)
-	}
-	if got := HistoryDiscussCursor(rc, 0); got != (DiscussCursorPosition{}) {
-		t.Fatalf("zero boundary must map to zero position, got %+v", got)
+func TestDiscussCursorPositionMerge(t *testing.T) {
+	merged := DiscussCursorPosition{EventCursor: 7001, SourceCursor: 900}.Merge(
+		DiscussCursorPosition{EventCursor: 6000, SourceCursor: 1500})
+	if merged.EventCursor != 7001 || merged.SourceCursor != 1500 {
+		t.Fatalf("merged = %+v, want component-wise max", merged)
 	}
 }
 

--- a/internal/chat/timeline/cursor_test.go
+++ b/internal/chat/timeline/cursor_test.go
@@ -147,16 +147,18 @@ func TestConsumedDiscussCursorTakesLatestGate(t *testing.T) {
 }
 
 func TestPushEventClampsOutOfRangeCursor(t *testing.T) {
-	pipeline := NewPipeline(RenderParams{})
-	rc := pipeline.PushEvent("s1", MessageEvent{
-		SessionID:    "s1",
-		MessageID:    "m1",
-		EventCursor:  MaxJSONSafeEventCursor + 1,
-		ReceivedAtMs: 1000,
-		TimestampSec: 1,
-		Content:      []ContentNode{{Type: "text", Text: "poisoned"}},
-	})
-	if len(rc) != 1 || rc[0].LastEventCursor != 0 {
-		t.Fatalf("out-of-range payload cursor must be dropped, got %+v", rc)
+	for _, poisoned := range []int64{MaxJSONSafeEventCursor + 1, MaxJSONSafeEventCursor, MaxTrustedEventCursor + 1} {
+		pipeline := NewPipeline(RenderParams{})
+		rc := pipeline.PushEvent("s1", MessageEvent{
+			SessionID:    "s1",
+			MessageID:    "m1",
+			EventCursor:  poisoned,
+			ReceivedAtMs: 1000,
+			TimestampSec: 1,
+			Content:      []ContentNode{{Type: "text", Text: "poisoned"}},
+		})
+		if len(rc) != 1 || rc[0].LastEventCursor != 0 {
+			t.Fatalf("untrusted payload cursor %d must be dropped, got %+v", poisoned, rc)
+		}
 	}
 }

--- a/internal/chat/timeline/cursor_test.go
+++ b/internal/chat/timeline/cursor_test.go
@@ -44,7 +44,7 @@ func TestAssignEventCursorRejectsInvalid(t *testing.T) {
 	if _, err := assignEventCursor(MessageEvent{}, 0); err == nil {
 		t.Fatal("expected error for non-positive cursor")
 	}
-	if _, err := assignEventCursor(MessageEvent{}, maxJSONSafeEventCursor+1); err == nil {
+	if _, err := assignEventCursor(MessageEvent{}, MaxJSONSafeEventCursor+1); err == nil {
 		t.Fatal("expected error for cursor above the JSON-safe range")
 	}
 }
@@ -143,5 +143,20 @@ func TestConsumedDiscussCursorTakesLatestGate(t *testing.T) {
 	position := ConsumedDiscussCursor(rc)
 	if position.EventCursor != 7001 || position.SourceCursor != 1000 {
 		t.Fatalf("position = %+v, want cursor 7001 source 1000", position)
+	}
+}
+
+func TestPushEventClampsOutOfRangeCursor(t *testing.T) {
+	pipeline := NewPipeline(RenderParams{})
+	rc := pipeline.PushEvent("s1", MessageEvent{
+		SessionID:    "s1",
+		MessageID:    "m1",
+		EventCursor:  MaxJSONSafeEventCursor + 1,
+		ReceivedAtMs: 1000,
+		TimestampSec: 1,
+		Content:      []ContentNode{{Type: "text", Text: "poisoned"}},
+	})
+	if len(rc) != 1 || rc[0].LastEventCursor != 0 {
+		t.Fatalf("out-of-range payload cursor must be dropped, got %+v", rc)
 	}
 }

--- a/internal/chat/timeline/cursor_test.go
+++ b/internal/chat/timeline/cursor_test.go
@@ -80,12 +80,12 @@ func TestPushEventThreadsCursorIntoSegments(t *testing.T) {
 func TestDiscussCursorPositionCovers(t *testing.T) {
 	position := DiscussCursorPosition{EventCursor: 7001, SourceCursor: 1500}
 
-	withCursor := textSegment("m1", 9000, "cursor domain")
+	withCursor := textSegment("m1", 1400, "cursor domain")
 	withCursor.LastEventCursor = 7001
 	if !position.Covers(withCursor) {
-		t.Fatal("segment at the consumed event cursor must be covered regardless of timestamps")
+		t.Fatal("segment consumed in both domains must be covered")
 	}
-	fresh := textSegment("m2", 100, "newer cursor")
+	fresh := textSegment("m2", 1400, "newer cursor")
 	fresh.LastEventCursor = 7002
 	if position.Covers(fresh) {
 		t.Fatal("segment past the consumed event cursor must not be covered")
@@ -160,5 +160,48 @@ func TestPushEventClampsOutOfRangeCursor(t *testing.T) {
 		if len(rc) != 1 || rc[0].LastEventCursor != 0 {
 			t.Fatalf("untrusted payload cursor %d must be dropped, got %+v", poisoned, rc)
 		}
+	}
+}
+
+func TestCoversRequiresBothDomains(t *testing.T) {
+	// Cursor allocation order can invert against source order when concurrent
+	// inbound workers stamp events for one thread, so a lower cursor alone
+	// must not prove consumption.
+	position := DiscussCursorPosition{EventCursor: 101, SourceCursor: 1001}
+	inverted := textSegment("m2", 1002, "allocated first, delivered late")
+	inverted.LastEventCursor = 100
+
+	if position.Covers(inverted) {
+		t.Fatal("a segment newer in source time must not be covered by a higher cursor watermark")
+	}
+	if !HasUncoveredExternalEvent(RenderedContext{inverted}, position) {
+		t.Fatal("the inverted segment must still report new external activity")
+	}
+}
+
+func TestCoversFallsBackToSourceWhenWatermarkHasNoCursor(t *testing.T) {
+	// Cold start seeds the watermark from persisted replies, which only carry
+	// source timestamps; cursor-bearing segments must still be covered.
+	position := DiscussCursorPosition{SourceCursor: 3000}
+	answered := textSegment("m1", 1000, "already answered")
+	answered.LastEventCursor = 5
+
+	if !position.Covers(answered) {
+		t.Fatal("a cursor-bearing segment inside the answered source window must be covered")
+	}
+	if HasUncoveredExternalEvent(RenderedContext{answered}, position) {
+		t.Fatal("cold-start anchor must suppress already-answered context")
+	}
+}
+
+func TestCoversStillTriggersOnEditedSegments(t *testing.T) {
+	// The cursor domain exists so an edit to an old message re-triggers even
+	// though its source timestamp stays inside the consumed window.
+	position := DiscussCursorPosition{EventCursor: 102, SourceCursor: 1002}
+	edited := textSegment("m1", 1000, "edited after consumption")
+	edited.LastEventCursor = 104
+
+	if position.Covers(edited) {
+		t.Fatal("a segment whose latest event postdates the watermark must not be covered")
 	}
 }

--- a/internal/chat/timeline/cursor_test.go
+++ b/internal/chat/timeline/cursor_test.go
@@ -241,3 +241,49 @@ func TestCoversStillTriggersOnEditedSegments(t *testing.T) {
 		t.Fatal("a segment whose latest event postdates the watermark must not be covered")
 	}
 }
+
+// TestConsumedPositionCoversEverythingItConsumed pins the anti-loop invariant:
+// whatever a turn consumed must read as covered next round, or the driver would
+// re-trigger forever on its own context.
+func TestConsumedPositionCoversEverythingItConsumed(t *testing.T) {
+	cases := map[string]RenderedContext{
+		"cursor stamped": {
+			withCursor(textSegment("m1", 1000, "a"), 7001),
+			withCursor(textSegment("m2", 2000, "b"), 7002),
+		},
+		"cursor-less legacy": {
+			textSegment("m1", 1000, "a"),
+			textSegment("m2", 2000, "b"),
+		},
+		"mixed ingest": {
+			withCursor(textSegment("m1", 1000, "a"), 7001),
+			textSegment("m2", 2000, "b"),
+			withCursor(textSegment("m3", 3000, "c"), 7003),
+		},
+		"cursor order inverted against source order": {
+			withCursor(textSegment("m1", 2000, "late source, early cursor"), 7001),
+			withCursor(textSegment("m2", 1000, "early source, late cursor"), 7002),
+		},
+		"same millisecond": {
+			withCursor(textSegment("m1", 1000, "a"), 7001),
+			withCursor(textSegment("m2", 1000, "b"), 7002),
+		},
+	}
+
+	for name, rc := range cases {
+		position := ConsumedDiscussCursor(rc)
+		for i, seg := range rc {
+			if !position.Covers(seg) {
+				t.Fatalf("%s: segment %d (%+v) not covered by its own consumed position %+v", name, i, seg, position)
+			}
+		}
+		if HasUncoveredExternalEvent(rc, position) {
+			t.Fatalf("%s: consumed context must not report new external activity", name)
+		}
+	}
+}
+
+func withCursor(seg RenderedSegment, cursor int64) RenderedSegment {
+	seg.LastEventCursor = cursor
+	return seg
+}

--- a/internal/chat/timeline/persistence.go
+++ b/internal/chat/timeline/persistence.go
@@ -33,22 +33,31 @@ func NewEventStore(log *slog.Logger, queries dbstore.Queries) *EventStore {
 	}
 }
 
-// PersistEvent writes a CanonicalEvent to the bot_session_events table.
-// Returns the UUID of the persisted event row, or empty string if the event
-// was a duplicate (ON CONFLICT DO NOTHING).
-func (s *EventStore) PersistEvent(ctx context.Context, botID, sessionID string, event CanonicalEvent) (string, error) {
+// PersistEvent writes a CanonicalEvent to the bot_session_events table with a
+// freshly allocated monotonic event cursor stamped into its payload. Returns
+// the UUID of the persisted event row (empty for ON CONFLICT duplicates) and
+// the stamped event the caller must project instead of the input.
+func (s *EventStore) PersistEvent(ctx context.Context, botID, sessionID string, event CanonicalEvent) (string, CanonicalEvent, error) {
 	pgBotID, err := dbpkg.ParseUUID(botID)
 	if err != nil {
-		return "", fmt.Errorf("invalid bot id: %w", err)
+		return "", event, fmt.Errorf("invalid bot id: %w", err)
 	}
 	pgSessionID, err := dbpkg.ParseUUID(sessionID)
 	if err != nil {
-		return "", fmt.Errorf("invalid session id: %w", err)
+		return "", event, fmt.Errorf("invalid session id: %w", err)
+	}
+
+	if cursor, cursorErr := s.queries.NextSessionEventCursor(ctx); cursorErr != nil {
+		s.logger.Warn("allocate session event cursor failed", slog.Any("error", cursorErr))
+	} else if stamped, stampErr := assignEventCursor(event, cursor); stampErr != nil {
+		s.logger.Warn("stamp session event cursor failed", slog.Any("error", stampErr))
+	} else {
+		event = stamped
 	}
 
 	eventData, err := json.Marshal(event)
 	if err != nil {
-		return "", fmt.Errorf("marshal event data: %w", err)
+		return "", event, fmt.Errorf("marshal event data: %w", err)
 	}
 
 	externalMessageID := extractExternalMessageID(event)
@@ -77,15 +86,15 @@ func (s *EventStore) PersistEvent(ctx context.Context, botID, sessionID string, 
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", nil
+			return "", event, nil
 		}
-		return "", fmt.Errorf("persist session event: %w", err)
+		return "", event, fmt.Errorf("persist session event: %w", err)
 	}
 
 	if pgID.Valid {
-		return pgID.String(), nil
+		return pgID.String(), event, nil
 	}
-	return "", nil
+	return "", event, nil
 }
 
 // LoadEvents loads all events for a session, ordered by received_at_ms.
@@ -130,13 +139,13 @@ func (s *EventStore) HasEvents(ctx context.Context, sessionID string) (bool, err
 	return count > 0, nil
 }
 
-func (s *EventStore) GetDiscussConsumedCursor(ctx context.Context, sessionID, scopeKey string) (int64, error) {
+func (s *EventStore) GetDiscussCursor(ctx context.Context, sessionID, scopeKey string) (DiscussCursorPosition, error) {
 	if s == nil || s.queries == nil {
-		return 0, nil
+		return DiscussCursorPosition{}, nil
 	}
 	pgSessionID, err := dbpkg.ParseUUID(sessionID)
 	if err != nil {
-		return 0, fmt.Errorf("invalid session id: %w", err)
+		return DiscussCursorPosition{}, fmt.Errorf("invalid session id: %w", err)
 	}
 	row, err := s.queries.GetSessionDiscussCursor(ctx, sqlc.GetSessionDiscussCursorParams{
 		SessionID: pgSessionID,
@@ -144,15 +153,18 @@ func (s *EventStore) GetDiscussConsumedCursor(ctx context.Context, sessionID, sc
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return 0, nil
+			return DiscussCursorPosition{}, nil
 		}
-		return 0, fmt.Errorf("get discuss cursor: %w", err)
+		return DiscussCursorPosition{}, fmt.Errorf("get discuss cursor: %w", err)
 	}
-	return row.ConsumedCursor, nil
+	return DiscussCursorPosition{
+		SourceCursor: row.ConsumedCursor,
+		EventCursor:  row.ConsumedEventCursor,
+	}, nil
 }
 
-func (s *EventStore) UpsertDiscussConsumedCursor(ctx context.Context, sessionID, scopeKey, routeID, source string, cursor int64) error {
-	if s == nil || s.queries == nil || cursor <= 0 {
+func (s *EventStore) UpsertDiscussCursor(ctx context.Context, sessionID, scopeKey, routeID, source string, position DiscussCursorPosition) error {
+	if s == nil || s.queries == nil || (position.SourceCursor <= 0 && position.EventCursor <= 0) {
 		return nil
 	}
 	pgSessionID, err := dbpkg.ParseUUID(sessionID)
@@ -168,11 +180,12 @@ func (s *EventStore) UpsertDiscussConsumedCursor(ctx context.Context, sessionID,
 		pgRouteID = parsed
 	}
 	_, err = s.queries.UpsertSessionDiscussCursor(ctx, sqlc.UpsertSessionDiscussCursorParams{
-		SessionID:      pgSessionID,
-		ScopeKey:       normalizeDiscussCursorScope(scopeKey),
-		RouteID:        pgRouteID,
-		Source:         strings.TrimSpace(source),
-		ConsumedCursor: cursor,
+		SessionID:           pgSessionID,
+		ScopeKey:            normalizeDiscussCursorScope(scopeKey),
+		RouteID:             pgRouteID,
+		Source:              strings.TrimSpace(source),
+		ConsumedCursor:      position.SourceCursor,
+		ConsumedEventCursor: position.EventCursor,
 	})
 	if err != nil {
 		return fmt.Errorf("upsert discuss cursor: %w", err)

--- a/internal/chat/timeline/persistence.go
+++ b/internal/chat/timeline/persistence.go
@@ -47,6 +47,7 @@ func (s *EventStore) PersistEvent(ctx context.Context, botID, sessionID string, 
 		return "", event, fmt.Errorf("invalid session id: %w", err)
 	}
 
+	original := event
 	if cursor, cursorErr := s.queries.NextSessionEventCursor(ctx); cursorErr != nil {
 		s.logger.Warn("allocate session event cursor failed", slog.Any("error", cursorErr))
 	} else if stamped, stampErr := assignEventCursor(event, cursor); stampErr != nil {
@@ -86,7 +87,7 @@ func (s *EventStore) PersistEvent(ctx context.Context, botID, sessionID string, 
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", event, nil
+			return "", original, nil
 		}
 		return "", event, fmt.Errorf("persist session event: %w", err)
 	}
@@ -94,7 +95,7 @@ func (s *EventStore) PersistEvent(ctx context.Context, botID, sessionID string, 
 	if pgID.Valid {
 		return pgID.String(), event, nil
 	}
-	return "", event, nil
+	return "", original, nil
 }
 
 // LoadEvents loads all events for a session, ordered by received_at_ms.

--- a/internal/chat/timeline/persistence_test.go
+++ b/internal/chat/timeline/persistence_test.go
@@ -1,0 +1,70 @@
+package timeline
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	dbpkg "github.com/memohai/memoh/internal/db"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+)
+
+type fakeEventQueries struct {
+	dbstore.Queries
+	nextCursor int64
+	created    sqlc.CreateSessionEventParams
+}
+
+func (f *fakeEventQueries) NextSessionEventCursor(context.Context) (int64, error) {
+	return f.nextCursor, nil
+}
+
+func (f *fakeEventQueries) CreateSessionEvent(_ context.Context, arg sqlc.CreateSessionEventParams) (pgtype.UUID, error) {
+	f.created = arg
+	id, err := dbpkg.ParseUUID("55555555-5555-5555-5555-555555555555")
+	if err != nil {
+		return pgtype.UUID{}, err
+	}
+	return id, nil
+}
+
+func TestPersistEventStampsCursorIntoPayload(t *testing.T) {
+	queries := &fakeEventQueries{nextCursor: 424242}
+	store := NewEventStore(slog.New(slog.DiscardHandler), queries)
+
+	event := MessageEvent{
+		SessionID:    "66666666-6666-6666-6666-666666666666",
+		MessageID:    "m1",
+		ReceivedAtMs: 1000,
+		TimestampSec: 1,
+		Content:      []ContentNode{{Type: "text", Text: "hello"}},
+	}
+
+	id, stamped, err := store.PersistEvent(context.Background(),
+		"77777777-7777-7777-7777-777777777777",
+		"66666666-6666-6666-6666-666666666666",
+		event,
+	)
+	if err != nil {
+		t.Fatalf("persist event: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected persisted event id")
+	}
+	message, ok := stamped.(MessageEvent)
+	if !ok || message.EventCursor != 424242 {
+		t.Fatalf("expected stamped cursor 424242, got %+v", stamped)
+	}
+
+	var persisted MessageEvent
+	if err := json.Unmarshal(queries.created.EventData, &persisted); err != nil {
+		t.Fatalf("decode persisted event data: %v", err)
+	}
+	if persisted.EventCursor != 424242 {
+		t.Fatalf("persisted payload cursor = %d, want 424242", persisted.EventCursor)
+	}
+}

--- a/internal/chat/timeline/persistence_test.go
+++ b/internal/chat/timeline/persistence_test.go
@@ -3,6 +3,7 @@ package timeline
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -66,5 +67,31 @@ func TestPersistEventStampsCursorIntoPayload(t *testing.T) {
 	}
 	if persisted.EventCursor != 424242 {
 		t.Fatalf("persisted payload cursor = %d, want 424242", persisted.EventCursor)
+	}
+}
+
+type failingInsertEventQueries struct {
+	fakeEventQueries
+}
+
+func (*failingInsertEventQueries) CreateSessionEvent(context.Context, sqlc.CreateSessionEventParams) (pgtype.UUID, error) {
+	return pgtype.UUID{}, errors.New("insert unavailable")
+}
+
+func TestPersistEventReturnsStampedEventOnInsertFailure(t *testing.T) {
+	queries := &failingInsertEventQueries{fakeEventQueries{nextCursor: 515151}}
+	store := NewEventStore(slog.New(slog.DiscardHandler), queries)
+
+	_, stamped, err := store.PersistEvent(context.Background(),
+		"77777777-7777-7777-7777-777777777777",
+		"66666666-6666-6666-6666-666666666666",
+		MessageEvent{SessionID: "66666666-6666-6666-6666-666666666666", MessageID: "m1", ReceivedAtMs: 1000},
+	)
+	if err == nil {
+		t.Fatal("expected insert failure")
+	}
+	message, ok := stamped.(MessageEvent)
+	if !ok || message.EventCursor != 515151 {
+		t.Fatalf("stamped event must survive insert failure, got %+v", stamped)
 	}
 }

--- a/internal/chat/timeline/persistence_test.go
+++ b/internal/chat/timeline/persistence_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	dbpkg "github.com/memohai/memoh/internal/db"
@@ -93,5 +94,31 @@ func TestPersistEventReturnsStampedEventOnInsertFailure(t *testing.T) {
 	message, ok := stamped.(MessageEvent)
 	if !ok || message.EventCursor != 515151 {
 		t.Fatalf("stamped event must survive insert failure, got %+v", stamped)
+	}
+}
+
+type conflictingEventQueries struct {
+	fakeEventQueries
+}
+
+func (*conflictingEventQueries) CreateSessionEvent(context.Context, sqlc.CreateSessionEventParams) (pgtype.UUID, error) {
+	return pgtype.UUID{}, pgx.ErrNoRows
+}
+
+func TestPersistEventReturnsOriginalEventOnDedup(t *testing.T) {
+	queries := &conflictingEventQueries{fakeEventQueries{nextCursor: 616161}}
+	store := NewEventStore(slog.New(slog.DiscardHandler), queries)
+
+	id, projected, err := store.PersistEvent(context.Background(),
+		"77777777-7777-7777-7777-777777777777",
+		"66666666-6666-6666-6666-666666666666",
+		EditEvent{SessionID: "66666666-6666-6666-6666-666666666666", MessageID: "m1", ReceivedAtMs: 1000},
+	)
+	if err != nil || id != "" {
+		t.Fatalf("dedup must return no id and no error, got id=%q err=%v", id, err)
+	}
+	edit, ok := projected.(EditEvent)
+	if !ok || edit.EventCursor != 0 {
+		t.Fatalf("deduplicated delivery must project the original unstamped event, got %+v", projected)
 	}
 }

--- a/internal/chat/timeline/projection.go
+++ b/internal/chat/timeline/projection.go
@@ -187,7 +187,7 @@ func reduceMessage(ic *IntermediateContext, event MessageEvent) {
 				Type:            "system_event",
 				Kind:            "user_renamed",
 				ReceivedAtMs:    event.ReceivedAtMs,
-				LastEventCursor: event.EventCursor,
+				LastEventCursor: sanitizedEventCursor(event.EventCursor),
 				TimestampSec:    event.TimestampSec,
 				UTCOffsetMin:    event.UTCOffsetMin,
 				UserID:          event.Sender.ID,
@@ -203,7 +203,7 @@ func reduceMessage(ic *IntermediateContext, event MessageEvent) {
 		MessageID:       event.MessageID,
 		Sender:          event.Sender,
 		ReceivedAtMs:    event.ReceivedAtMs,
-		LastEventCursor: event.EventCursor,
+		LastEventCursor: sanitizedEventCursor(event.EventCursor),
 		TimestampSec:    event.TimestampSec,
 		UTCOffsetMin:    event.UTCOffsetMin,
 		Content:         event.Content,
@@ -271,8 +271,8 @@ func reduceEdit(ic *IntermediateContext, event EditEvent) {
 	msg.Attachments = event.Attachments
 	msg.EditedAtSec = event.TimestampSec
 	msg.EditUTCOffsetMin = event.UTCOffsetMin
-	if event.EventCursor > msg.LastEventCursor {
-		msg.LastEventCursor = event.EventCursor
+	if cursor := sanitizedEventCursor(event.EventCursor); cursor > msg.LastEventCursor {
+		msg.LastEventCursor = cursor
 	}
 }
 
@@ -284,8 +284,8 @@ func reduceDelete(ic *IntermediateContext, event DeleteEvent) {
 		}
 		if msg := ic.Nodes[idx].Message; msg != nil {
 			msg.Deleted = true
-			if event.EventCursor > msg.LastEventCursor {
-				msg.LastEventCursor = event.EventCursor
+			if cursor := sanitizedEventCursor(event.EventCursor); cursor > msg.LastEventCursor {
+				msg.LastEventCursor = cursor
 			}
 		}
 	}
@@ -295,7 +295,7 @@ func reduceService(ic *IntermediateContext, event ServiceEvent) {
 	base := ICSystemEvent{
 		Type:            "system_event",
 		ReceivedAtMs:    event.ReceivedAtMs,
-		LastEventCursor: event.EventCursor,
+		LastEventCursor: sanitizedEventCursor(event.EventCursor),
 		TimestampSec:    event.TimestampSec,
 		UTCOffsetMin:    event.UTCOffsetMin,
 		Actor:           event.Actor,

--- a/internal/chat/timeline/projection.go
+++ b/internal/chat/timeline/projection.go
@@ -8,6 +8,7 @@ type ICMessage struct {
 	MessageID        string           `json:"message_id"`
 	Sender           *CanonicalUser   `json:"sender,omitempty"`
 	ReceivedAtMs     int64            `json:"received_at_ms"`
+	LastEventCursor  int64            `json:"last_event_cursor,omitempty"`
 	TimestampSec     int64            `json:"timestamp_sec"`
 	UTCOffsetMin     int              `json:"utc_offset_min"`
 	Content          []ContentNode    `json:"content"`
@@ -27,12 +28,13 @@ type ICMessage struct {
 
 // ICSystemEvent represents a group lifecycle event in the IC.
 type ICSystemEvent struct {
-	Type         string         `json:"type"` // always "system_event"
-	Kind         string         `json:"kind"`
-	ReceivedAtMs int64          `json:"received_at_ms"`
-	TimestampSec int64          `json:"timestamp_sec"`
-	UTCOffsetMin int            `json:"utc_offset_min"`
-	Actor        *CanonicalUser `json:"actor,omitempty"`
+	Type            string         `json:"type"` // always "system_event"
+	Kind            string         `json:"kind"`
+	ReceivedAtMs    int64          `json:"received_at_ms"`
+	LastEventCursor int64          `json:"last_event_cursor,omitempty"`
+	TimestampSec    int64          `json:"timestamp_sec"`
+	UTCOffsetMin    int            `json:"utc_offset_min"`
+	Actor           *CanonicalUser `json:"actor,omitempty"`
 
 	// Kind-specific fields
 	UserID   string          `json:"user_id,omitempty"`
@@ -182,32 +184,34 @@ func reduceMessage(ic *IntermediateContext, event MessageEvent) {
 	if event.Sender != nil {
 		if existing, ok := ic.Users[event.Sender.ID]; ok && userChanged(existing.User, *event.Sender) {
 			sysEvt := &ICSystemEvent{
-				Type:         "system_event",
-				Kind:         "user_renamed",
-				ReceivedAtMs: event.ReceivedAtMs,
-				TimestampSec: event.TimestampSec,
-				UTCOffsetMin: event.UTCOffsetMin,
-				UserID:       event.Sender.ID,
-				OldUser:      &existing.User,
-				NewUser:      event.Sender,
+				Type:            "system_event",
+				Kind:            "user_renamed",
+				ReceivedAtMs:    event.ReceivedAtMs,
+				LastEventCursor: event.EventCursor,
+				TimestampSec:    event.TimestampSec,
+				UTCOffsetMin:    event.UTCOffsetMin,
+				UserID:          event.Sender.ID,
+				OldUser:         &existing.User,
+				NewUser:         event.Sender,
 			}
 			ic.Nodes = append(ic.Nodes, ICNode{SystemEvent: sysEvt})
 		}
 	}
 
 	msg := &ICMessage{
-		Type:         "message",
-		MessageID:    event.MessageID,
-		Sender:       event.Sender,
-		ReceivedAtMs: event.ReceivedAtMs,
-		TimestampSec: event.TimestampSec,
-		UTCOffsetMin: event.UTCOffsetMin,
-		Content:      event.Content,
-		Attachments:  event.Attachments,
-		IsSelfSent:   event.IsSelfSent,
-		MentionsMe:   event.MentionsMe,
-		RepliesToMe:  event.RepliesToMe,
-		Conversation: event.Conversation,
+		Type:            "message",
+		MessageID:       event.MessageID,
+		Sender:          event.Sender,
+		ReceivedAtMs:    event.ReceivedAtMs,
+		LastEventCursor: event.EventCursor,
+		TimestampSec:    event.TimestampSec,
+		UTCOffsetMin:    event.UTCOffsetMin,
+		Content:         event.Content,
+		Attachments:     event.Attachments,
+		IsSelfSent:      event.IsSelfSent,
+		MentionsMe:      event.MentionsMe,
+		RepliesToMe:     event.RepliesToMe,
+		Conversation:    event.Conversation,
 	}
 
 	if event.ReplyToMessageID != "" {
@@ -267,6 +271,9 @@ func reduceEdit(ic *IntermediateContext, event EditEvent) {
 	msg.Attachments = event.Attachments
 	msg.EditedAtSec = event.TimestampSec
 	msg.EditUTCOffsetMin = event.UTCOffsetMin
+	if event.EventCursor > msg.LastEventCursor {
+		msg.LastEventCursor = event.EventCursor
+	}
 }
 
 func reduceDelete(ic *IntermediateContext, event DeleteEvent) {
@@ -277,17 +284,21 @@ func reduceDelete(ic *IntermediateContext, event DeleteEvent) {
 		}
 		if msg := ic.Nodes[idx].Message; msg != nil {
 			msg.Deleted = true
+			if event.EventCursor > msg.LastEventCursor {
+				msg.LastEventCursor = event.EventCursor
+			}
 		}
 	}
 }
 
 func reduceService(ic *IntermediateContext, event ServiceEvent) {
 	base := ICSystemEvent{
-		Type:         "system_event",
-		ReceivedAtMs: event.ReceivedAtMs,
-		TimestampSec: event.TimestampSec,
-		UTCOffsetMin: event.UTCOffsetMin,
-		Actor:        event.Actor,
+		Type:            "system_event",
+		ReceivedAtMs:    event.ReceivedAtMs,
+		LastEventCursor: event.EventCursor,
+		TimestampSec:    event.TimestampSec,
+		UTCOffsetMin:    event.UTCOffsetMin,
+		Actor:           event.Actor,
 	}
 
 	switch event.Action {

--- a/internal/chat/timeline/rendering.go
+++ b/internal/chat/timeline/rendering.go
@@ -23,7 +23,9 @@ type ImageAttachmentRef struct {
 
 // RenderedSegment is a single segment of rendered context, one per IC node.
 type RenderedSegment struct {
+	MessageID    string                 `json:"message_id,omitempty"`
 	ReceivedAtMs int64                  `json:"received_at_ms"`
+	EditedAtMs   int64                  `json:"edited_at_ms,omitempty"`
 	Content      []RenderedContentPiece `json:"content"`
 	IsMyself     bool                   `json:"is_myself,omitempty"`
 	IsSelfSent   bool                   `json:"is_self_sent,omitempty"`
@@ -115,7 +117,9 @@ func renderMessage(msg *ICMessage, params RenderParams) RenderedSegment {
 	if msg.Deleted {
 		text := fmt.Sprintf("<message %s/>", strings.Join(attrs, " "))
 		return RenderedSegment{
+			MessageID:    msg.MessageID,
 			ReceivedAtMs: msg.ReceivedAtMs,
+			EditedAtMs:   msg.EditedAtSec * 1000,
 			Content:      []RenderedContentPiece{{Type: "text", Text: text}},
 			IsMyself:     isMyself,
 			IsSelfSent:   msg.IsSelfSent,
@@ -162,7 +166,9 @@ func renderMessage(msg *ICMessage, params RenderParams) RenderedSegment {
 	}
 
 	return RenderedSegment{
+		MessageID:    msg.MessageID,
 		ReceivedAtMs: msg.ReceivedAtMs,
+		EditedAtMs:   msg.EditedAtSec * 1000,
 		Content:      pieces,
 		IsMyself:     isMyself,
 		IsSelfSent:   msg.IsSelfSent,

--- a/internal/chat/timeline/rendering.go
+++ b/internal/chat/timeline/rendering.go
@@ -23,15 +23,16 @@ type ImageAttachmentRef struct {
 
 // RenderedSegment is a single segment of rendered context, one per IC node.
 type RenderedSegment struct {
-	MessageID    string                 `json:"message_id,omitempty"`
-	ReceivedAtMs int64                  `json:"received_at_ms"`
-	EditedAtMs   int64                  `json:"edited_at_ms,omitempty"`
-	Content      []RenderedContentPiece `json:"content"`
-	IsMyself     bool                   `json:"is_myself,omitempty"`
-	IsSelfSent   bool                   `json:"is_self_sent,omitempty"`
-	MentionsMe   bool                   `json:"mentions_me,omitempty"`
-	RepliesToMe  bool                   `json:"replies_to_me,omitempty"`
-	ImageRefs    []ImageAttachmentRef   `json:"image_refs,omitempty"`
+	MessageID       string                 `json:"message_id,omitempty"`
+	ReceivedAtMs    int64                  `json:"received_at_ms"`
+	LastEventCursor int64                  `json:"last_event_cursor,omitempty"`
+	EditedAtMs      int64                  `json:"edited_at_ms,omitempty"`
+	Content         []RenderedContentPiece `json:"content"`
+	IsMyself        bool                   `json:"is_myself,omitempty"`
+	IsSelfSent      bool                   `json:"is_self_sent,omitempty"`
+	MentionsMe      bool                   `json:"mentions_me,omitempty"`
+	RepliesToMe     bool                   `json:"replies_to_me,omitempty"`
+	ImageRefs       []ImageAttachmentRef   `json:"image_refs,omitempty"`
 }
 
 // RenderedContext is the output of the Rendering layer — a slice of segments.
@@ -117,14 +118,15 @@ func renderMessage(msg *ICMessage, params RenderParams) RenderedSegment {
 	if msg.Deleted {
 		text := fmt.Sprintf("<message %s/>", strings.Join(attrs, " "))
 		return RenderedSegment{
-			MessageID:    msg.MessageID,
-			ReceivedAtMs: msg.ReceivedAtMs,
-			EditedAtMs:   msg.EditedAtSec * 1000,
-			Content:      []RenderedContentPiece{{Type: "text", Text: text}},
-			IsMyself:     isMyself,
-			IsSelfSent:   msg.IsSelfSent,
-			MentionsMe:   mentionsMe,
-			RepliesToMe:  repliesToMe,
+			MessageID:       msg.MessageID,
+			ReceivedAtMs:    msg.ReceivedAtMs,
+			LastEventCursor: msg.LastEventCursor,
+			EditedAtMs:      msg.EditedAtSec * 1000,
+			Content:         []RenderedContentPiece{{Type: "text", Text: text}},
+			IsMyself:        isMyself,
+			IsSelfSent:      msg.IsSelfSent,
+			MentionsMe:      mentionsMe,
+			RepliesToMe:     repliesToMe,
 		}
 	}
 
@@ -166,23 +168,25 @@ func renderMessage(msg *ICMessage, params RenderParams) RenderedSegment {
 	}
 
 	return RenderedSegment{
-		MessageID:    msg.MessageID,
-		ReceivedAtMs: msg.ReceivedAtMs,
-		EditedAtMs:   msg.EditedAtSec * 1000,
-		Content:      pieces,
-		IsMyself:     isMyself,
-		IsSelfSent:   msg.IsSelfSent,
-		MentionsMe:   mentionsMe,
-		RepliesToMe:  repliesToMe,
-		ImageRefs:    imageRefs,
+		MessageID:       msg.MessageID,
+		ReceivedAtMs:    msg.ReceivedAtMs,
+		LastEventCursor: msg.LastEventCursor,
+		EditedAtMs:      msg.EditedAtSec * 1000,
+		Content:         pieces,
+		IsMyself:        isMyself,
+		IsSelfSent:      msg.IsSelfSent,
+		MentionsMe:      mentionsMe,
+		RepliesToMe:     repliesToMe,
+		ImageRefs:       imageRefs,
 	}
 }
 
 func renderSystemEvent(event *ICSystemEvent, params RenderParams) RenderedSegment {
 	text := renderSystemEventXML(event, params.ContactNames)
 	return RenderedSegment{
-		ReceivedAtMs: event.ReceivedAtMs,
-		Content:      []RenderedContentPiece{{Type: "text", Text: text}},
+		ReceivedAtMs:    event.ReceivedAtMs,
+		LastEventCursor: event.LastEventCursor,
+		Content:         []RenderedContentPiece{{Type: "text", Text: text}},
 	}
 }
 

--- a/internal/chat/timeline/rendering_test.go
+++ b/internal/chat/timeline/rendering_test.go
@@ -46,3 +46,45 @@ func TestRenderMessage_NoImageRefs(t *testing.T) {
 		t.Fatalf("expected 0 image refs, got %d", len(seg.ImageRefs))
 	}
 }
+
+func TestRenderMessagePopulatesSlotIdentityAndEditTime(t *testing.T) {
+	msg := &ICMessage{
+		MessageID:       "msg-slot",
+		ReceivedAtMs:    1000,
+		TimestampSec:    1,
+		EditedAtSec:     7,
+		LastEventCursor: 4242,
+		Content:         []ContentNode{{Type: "text", Text: "edited body"}},
+		Conversation:    ConversationMeta{Channel: "telegram", ConversationType: "group"},
+	}
+
+	seg := renderMessage(msg, RenderParams{})
+
+	if seg.MessageID != "msg-slot" {
+		t.Fatalf("MessageID = %q, want msg-slot (coverage matching depends on it)", seg.MessageID)
+	}
+	if seg.EditedAtMs != 7000 {
+		t.Fatalf("EditedAtMs = %d, want 7000 (EditedAtSec converted to ms)", seg.EditedAtMs)
+	}
+	if seg.LastEventCursor != 4242 {
+		t.Fatalf("LastEventCursor = %d, want 4242", seg.LastEventCursor)
+	}
+}
+
+func TestRenderDeletedMessagePopulatesSlotIdentityAndEditTime(t *testing.T) {
+	msg := &ICMessage{
+		MessageID:       "msg-deleted",
+		ReceivedAtMs:    2000,
+		TimestampSec:    2,
+		EditedAtSec:     9,
+		LastEventCursor: 5150,
+		Deleted:         true,
+		Conversation:    ConversationMeta{Channel: "telegram", ConversationType: "group"},
+	}
+
+	seg := renderMessage(msg, RenderParams{})
+
+	if seg.MessageID != "msg-deleted" || seg.EditedAtMs != 9000 || seg.LastEventCursor != 5150 {
+		t.Fatalf("deleted segment lost slot metadata: %+v", seg)
+	}
+}

--- a/internal/chat/timeline/turn_response.go
+++ b/internal/chat/timeline/turn_response.go
@@ -38,10 +38,11 @@ func DecodeTurnResponseEntry(msg messagepkg.Message) (TurnResponseEntry, bool) {
 	}
 
 	return TurnResponseEntry{
-		RequestedAtMs: msg.CreatedAt.UnixMilli(),
-		Role:          role,
-		Content:       debugContent(rawContent),
-		RawContent:    rawContent,
+		RequestedAtMs:   msg.CreatedAt.UnixMilli(),
+		Role:            role,
+		Content:         debugContent(rawContent),
+		RawContent:      rawContent,
+		SourceMessageID: msg.ID,
 	}, true
 }
 

--- a/internal/chat/timeline/types.go
+++ b/internal/chat/timeline/types.go
@@ -74,6 +74,7 @@ type ConversationMeta struct {
 type MessageEvent struct {
 	SessionID        string           `json:"session_id"`
 	EventID          string           `json:"event_id,omitempty"`
+	EventCursor      int64            `json:"event_cursor,omitempty"`
 	MessageID        string           `json:"message_id"`
 	Sender           *CanonicalUser   `json:"sender,omitempty"`
 	ReceivedAtMs     int64            `json:"received_at_ms"`
@@ -99,6 +100,7 @@ func (e MessageEvent) GetReceivedAtMs() int64 { return e.ReceivedAtMs }
 type EditEvent struct {
 	SessionID    string         `json:"session_id"`
 	EventID      string         `json:"event_id,omitempty"`
+	EventCursor  int64          `json:"event_cursor,omitempty"`
 	MessageID    string         `json:"message_id"`
 	Sender       *CanonicalUser `json:"sender,omitempty"`
 	ReceivedAtMs int64          `json:"received_at_ms"`
@@ -116,6 +118,7 @@ func (e EditEvent) GetReceivedAtMs() int64 { return e.ReceivedAtMs }
 type DeleteEvent struct {
 	SessionID    string   `json:"session_id"`
 	EventID      string   `json:"event_id,omitempty"`
+	EventCursor  int64    `json:"event_cursor,omitempty"`
 	MessageIDs   []string `json:"message_ids"`
 	ReceivedAtMs int64    `json:"received_at_ms"`
 	TimestampSec int64    `json:"timestamp_sec"`
@@ -142,6 +145,7 @@ const (
 type ServiceEvent struct {
 	SessionID    string         `json:"session_id"`
 	EventID      string         `json:"event_id,omitempty"`
+	EventCursor  int64          `json:"event_cursor,omitempty"`
 	Action       ServiceAction  `json:"action"`
 	Actor        *CanonicalUser `json:"actor,omitempty"`
 	ReceivedAtMs int64          `json:"received_at_ms"`

--- a/internal/db/discuss_event_cursor_migration_integration_test.go
+++ b/internal/db/discuss_event_cursor_migration_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestDiscussEventCursorMigrationRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+	dsn := teamMigrationDSN(t)
+
+	assertDiscussEventCursorSchema(t, ctx, pool, true, true)
+	stepDown(t, dsn, 1)
+	assertDiscussEventCursorSchema(t, ctx, pool, false, false)
+	stepUp(t, dsn, 1)
+	assertDiscussEventCursorSchema(t, ctx, pool, true, true)
+}
+
+// TestDiscussEventCursorSequenceSeededAboveClock pins the invariant the cursor
+// domain rests on: a freshly migrated deployment must never hand out cursors
+// that collide with the source-time watermarks of pre-migration history.
+func TestDiscussEventCursorSequenceSeededAboveClock(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	var seeded, clockMs int64
+	if err := pool.QueryRow(ctx, `
+		SELECT last_value, FLOOR(EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint
+		FROM bot_session_event_cursor_seq
+	`).Scan(&seeded, &clockMs); err != nil {
+		t.Fatalf("inspect session event cursor sequence: %v", err)
+	}
+	if seeded < clockMs-60_000 {
+		t.Fatalf("sequence seeded at %d, want at least the migration-time clock %d", seeded, clockMs)
+	}
+	if seeded >= 9007199254740991 {
+		t.Fatalf("sequence seeded at %d, want below the JSON-safe ceiling", seeded)
+	}
+}
+
+func assertDiscussEventCursorSchema(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	wantConsumedEventCursor bool,
+	wantSequence bool,
+) {
+	t.Helper()
+	var hasConsumedEventCursor, hasSequence bool
+	if err := pool.QueryRow(ctx, `
+		SELECT
+		  EXISTS (
+		    SELECT 1
+		    FROM information_schema.columns
+		    WHERE table_schema = 'public'
+		      AND table_name = 'bot_session_discuss_cursors'
+		      AND column_name = 'consumed_event_cursor'
+		  ),
+		  to_regclass('public.bot_session_event_cursor_seq') IS NOT NULL
+	`).Scan(&hasConsumedEventCursor, &hasSequence); err != nil {
+		t.Fatalf("inspect discuss event cursor schema: %v", err)
+	}
+	if hasConsumedEventCursor != wantConsumedEventCursor || hasSequence != wantSequence {
+		t.Fatalf(
+			"discuss event cursor schema = column:%t sequence:%t, want column:%t sequence:%t",
+			hasConsumedEventCursor,
+			hasSequence,
+			wantConsumedEventCursor,
+			wantSequence,
+		)
+	}
+}

--- a/internal/db/discuss_event_cursor_migration_integration_test.go
+++ b/internal/db/discuss_event_cursor_migration_integration_test.go
@@ -14,10 +14,12 @@ func TestDiscussEventCursorMigrationRoundTrip(t *testing.T) {
 	pool := freshMigratedDB(t)
 	dsn := teamMigrationDSN(t)
 
+	steps := countMigrationsFrom(t, "0120_discuss_event_cursor.up.sql")
+
 	assertDiscussEventCursorSchema(t, ctx, pool, true, true)
-	stepDown(t, dsn, 1)
+	stepDown(t, dsn, steps)
 	assertDiscussEventCursorSchema(t, ctx, pool, false, false)
-	stepUp(t, dsn, 1)
+	stepUp(t, dsn, steps)
 	assertDiscussEventCursorSchema(t, ctx, pool, true, true)
 }
 

--- a/internal/db/postgres/sqlc/models.go
+++ b/internal/db/postgres/sqlc/models.go
@@ -274,13 +274,14 @@ type BotSession struct {
 }
 
 type BotSessionDiscussCursor struct {
-	SessionID      pgtype.UUID        `json:"session_id"`
-	ScopeKey       string             `json:"scope_key"`
-	RouteID        pgtype.UUID        `json:"route_id"`
-	Source         string             `json:"source"`
-	ConsumedCursor int64              `json:"consumed_cursor"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-	TeamID         pgtype.UUID        `json:"team_id"`
+	SessionID           pgtype.UUID        `json:"session_id"`
+	ScopeKey            string             `json:"scope_key"`
+	RouteID             pgtype.UUID        `json:"route_id"`
+	Source              string             `json:"source"`
+	ConsumedCursor      int64              `json:"consumed_cursor"`
+	ConsumedEventCursor int64              `json:"consumed_event_cursor"`
+	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
+	TeamID              pgtype.UUID        `json:"team_id"`
 }
 
 type BotSessionEvent struct {

--- a/internal/db/postgres/sqlc/session_events.sql.go
+++ b/internal/db/postgres/sqlc/session_events.sql.go
@@ -187,3 +187,14 @@ func (q *Queries) ListSessionEventsBySessionAfter(ctx context.Context, arg ListS
 	}
 	return items, nil
 }
+
+const nextSessionEventCursor = `-- name: NextSessionEventCursor :one
+SELECT nextval('bot_session_event_cursor_seq')::bigint
+`
+
+func (q *Queries) NextSessionEventCursor(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, nextSessionEventCursor)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}

--- a/internal/db/postgres/sqlc/session_events.sql.go
+++ b/internal/db/postgres/sqlc/session_events.sql.go
@@ -72,20 +72,6 @@ func (q *Queries) DeleteSessionEventsByBot(ctx context.Context, botID pgtype.UUI
 	return err
 }
 
-const ensureSessionEventCursorFloor = `-- name: EnsureSessionEventCursorFloor :one
-SELECT setval('bot_session_event_cursor_seq', GREATEST(
-  nextval('bot_session_event_cursor_seq'),
-  $1::bigint
-), true)::bigint
-`
-
-func (q *Queries) EnsureSessionEventCursorFloor(ctx context.Context, minCursor int64) (int64, error) {
-	row := q.db.QueryRow(ctx, ensureSessionEventCursorFloor, minCursor)
-	var column_1 int64
-	err := row.Scan(&column_1)
-	return column_1, err
-}
-
 const listSessionEventsByBot = `-- name: ListSessionEventsByBot :many
 SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at, team_id FROM bot_session_events
 WHERE team_id = public.memoh_current_team_id() AND bot_id = $1

--- a/internal/db/postgres/sqlc/session_events.sql.go
+++ b/internal/db/postgres/sqlc/session_events.sql.go
@@ -72,6 +72,20 @@ func (q *Queries) DeleteSessionEventsByBot(ctx context.Context, botID pgtype.UUI
 	return err
 }
 
+const ensureSessionEventCursorFloor = `-- name: EnsureSessionEventCursorFloor :one
+SELECT setval('bot_session_event_cursor_seq', GREATEST(
+  nextval('bot_session_event_cursor_seq'),
+  $1::bigint
+), true)::bigint
+`
+
+func (q *Queries) EnsureSessionEventCursorFloor(ctx context.Context, minCursor int64) (int64, error) {
+	row := q.db.QueryRow(ctx, ensureSessionEventCursorFloor, minCursor)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const listSessionEventsByBot = `-- name: ListSessionEventsByBot :many
 SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at, team_id FROM bot_session_events
 WHERE team_id = public.memoh_current_team_id() AND bot_id = $1

--- a/internal/db/postgres/sqlc/session_events.sql.go
+++ b/internal/db/postgres/sqlc/session_events.sql.go
@@ -112,7 +112,7 @@ func (q *Queries) ListSessionEventsByBot(ctx context.Context, botID pgtype.UUID)
 const listSessionEventsBySession = `-- name: ListSessionEventsBySession :many
 SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at, team_id FROM bot_session_events
 WHERE team_id = public.memoh_current_team_id() AND session_id = $1
-ORDER BY received_at_ms ASC
+ORDER BY received_at_ms ASC, created_at ASC, id ASC
 `
 
 func (q *Queries) ListSessionEventsBySession(ctx context.Context, sessionID pgtype.UUID) ([]BotSessionEvent, error) {
@@ -149,7 +149,7 @@ func (q *Queries) ListSessionEventsBySession(ctx context.Context, sessionID pgty
 const listSessionEventsBySessionAfter = `-- name: ListSessionEventsBySessionAfter :many
 SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at, team_id FROM bot_session_events
 WHERE team_id = public.memoh_current_team_id() AND session_id = $1 AND received_at_ms >= $2
-ORDER BY received_at_ms ASC
+ORDER BY received_at_ms ASC, created_at ASC, id ASC
 `
 
 type ListSessionEventsBySessionAfterParams struct {

--- a/internal/db/postgres/sqlc/sessions.sql.go
+++ b/internal/db/postgres/sqlc/sessions.sql.go
@@ -422,7 +422,7 @@ func (q *Queries) GetSessionByID(ctx context.Context, id pgtype.UUID) (BotSessio
 }
 
 const getSessionDiscussCursor = `-- name: GetSessionDiscussCursor :one
-SELECT session_id, scope_key, route_id, source, consumed_cursor, updated_at, team_id
+SELECT session_id, scope_key, route_id, source, consumed_cursor, consumed_event_cursor, updated_at, team_id
 FROM bot_session_discuss_cursors
 WHERE team_id = public.memoh_current_team_id()
   AND session_id = $1
@@ -443,6 +443,7 @@ func (q *Queries) GetSessionDiscussCursor(ctx context.Context, arg GetSessionDis
 		&i.RouteID,
 		&i.Source,
 		&i.ConsumedCursor,
+		&i.ConsumedEventCursor,
 		&i.UpdatedAt,
 		&i.TeamID,
 	)
@@ -450,7 +451,7 @@ func (q *Queries) GetSessionDiscussCursor(ctx context.Context, arg GetSessionDis
 }
 
 const listSessionDiscussCursorsByBot = `-- name: ListSessionDiscussCursorsByBot :many
-SELECT c.session_id, c.scope_key, c.route_id, c.source, c.consumed_cursor, c.updated_at, c.team_id
+SELECT c.session_id, c.scope_key, c.route_id, c.source, c.consumed_cursor, c.consumed_event_cursor, c.updated_at, c.team_id
 FROM bot_session_discuss_cursors c
 JOIN bot_sessions s ON s.id = c.session_id
 WHERE c.team_id = public.memoh_current_team_id()
@@ -474,6 +475,7 @@ func (q *Queries) ListSessionDiscussCursorsByBot(ctx context.Context, botID pgty
 			&i.RouteID,
 			&i.Source,
 			&i.ConsumedCursor,
+			&i.ConsumedEventCursor,
 			&i.UpdatedAt,
 			&i.TeamID,
 		); err != nil {
@@ -1287,29 +1289,32 @@ func (q *Queries) UpdateSessionTypeAndMetadata(ctx context.Context, arg UpdateSe
 
 const upsertSessionDiscussCursor = `-- name: UpsertSessionDiscussCursor :one
 INSERT INTO bot_session_discuss_cursors (
-  session_id, scope_key, route_id, source, consumed_cursor
+  session_id, scope_key, route_id, source, consumed_cursor, consumed_event_cursor
 )
 VALUES (
   $1,
   $2,
   $3::uuid,
   $4,
-  $5
+  $5,
+  $6
 )
 ON CONFLICT (team_id, session_id, scope_key) DO UPDATE
 SET route_id = COALESCE(EXCLUDED.route_id, bot_session_discuss_cursors.route_id),
     source = EXCLUDED.source,
     consumed_cursor = GREATEST(bot_session_discuss_cursors.consumed_cursor, EXCLUDED.consumed_cursor),
+    consumed_event_cursor = GREATEST(bot_session_discuss_cursors.consumed_event_cursor, EXCLUDED.consumed_event_cursor),
     updated_at = now()
-RETURNING session_id, scope_key, route_id, source, consumed_cursor, updated_at, team_id
+RETURNING session_id, scope_key, route_id, source, consumed_cursor, consumed_event_cursor, updated_at, team_id
 `
 
 type UpsertSessionDiscussCursorParams struct {
-	SessionID      pgtype.UUID `json:"session_id"`
-	ScopeKey       string      `json:"scope_key"`
-	RouteID        pgtype.UUID `json:"route_id"`
-	Source         string      `json:"source"`
-	ConsumedCursor int64       `json:"consumed_cursor"`
+	SessionID           pgtype.UUID `json:"session_id"`
+	ScopeKey            string      `json:"scope_key"`
+	RouteID             pgtype.UUID `json:"route_id"`
+	Source              string      `json:"source"`
+	ConsumedCursor      int64       `json:"consumed_cursor"`
+	ConsumedEventCursor int64       `json:"consumed_event_cursor"`
 }
 
 func (q *Queries) UpsertSessionDiscussCursor(ctx context.Context, arg UpsertSessionDiscussCursorParams) (BotSessionDiscussCursor, error) {
@@ -1319,6 +1324,7 @@ func (q *Queries) UpsertSessionDiscussCursor(ctx context.Context, arg UpsertSess
 		arg.RouteID,
 		arg.Source,
 		arg.ConsumedCursor,
+		arg.ConsumedEventCursor,
 	)
 	var i BotSessionDiscussCursor
 	err := row.Scan(
@@ -1327,6 +1333,7 @@ func (q *Queries) UpsertSessionDiscussCursor(ctx context.Context, arg UpsertSess
 		&i.RouteID,
 		&i.Source,
 		&i.ConsumedCursor,
+		&i.ConsumedEventCursor,
 		&i.UpdatedAt,
 		&i.TeamID,
 	)

--- a/internal/db/store/queries.go
+++ b/internal/db/store/queries.go
@@ -50,6 +50,7 @@ type Queries interface {
 	CountScheduleLogsByBot(ctx context.Context, botID pgtype.UUID) (int64, error)
 	CountScheduleLogsBySchedule(ctx context.Context, scheduleID pgtype.UUID) (int64, error)
 	CountSessionEvents(ctx context.Context, sessionID pgtype.UUID) (int64, error)
+	EnsureSessionEventCursorFloor(ctx context.Context, minCursor int64) (int64, error)
 	NextSessionEventCursor(ctx context.Context) (int64, error)
 	CountTokenUsageRecords(ctx context.Context, arg dbsqlc.CountTokenUsageRecordsParams) (int64, error)
 	CreateAccount(ctx context.Context, arg dbsqlc.CreateAccountParams) (dbsqlc.CreateAccountRow, error)

--- a/internal/db/store/queries.go
+++ b/internal/db/store/queries.go
@@ -50,7 +50,6 @@ type Queries interface {
 	CountScheduleLogsByBot(ctx context.Context, botID pgtype.UUID) (int64, error)
 	CountScheduleLogsBySchedule(ctx context.Context, scheduleID pgtype.UUID) (int64, error)
 	CountSessionEvents(ctx context.Context, sessionID pgtype.UUID) (int64, error)
-	EnsureSessionEventCursorFloor(ctx context.Context, minCursor int64) (int64, error)
 	NextSessionEventCursor(ctx context.Context) (int64, error)
 	CountTokenUsageRecords(ctx context.Context, arg dbsqlc.CountTokenUsageRecordsParams) (int64, error)
 	CreateAccount(ctx context.Context, arg dbsqlc.CreateAccountParams) (dbsqlc.CreateAccountRow, error)

--- a/internal/db/store/queries.go
+++ b/internal/db/store/queries.go
@@ -50,6 +50,7 @@ type Queries interface {
 	CountScheduleLogsByBot(ctx context.Context, botID pgtype.UUID) (int64, error)
 	CountScheduleLogsBySchedule(ctx context.Context, scheduleID pgtype.UUID) (int64, error)
 	CountSessionEvents(ctx context.Context, sessionID pgtype.UUID) (int64, error)
+	NextSessionEventCursor(ctx context.Context) (int64, error)
 	CountTokenUsageRecords(ctx context.Context, arg dbsqlc.CountTokenUsageRecordsParams) (int64, error)
 	CreateAccount(ctx context.Context, arg dbsqlc.CreateAccountParams) (dbsqlc.CreateAccountRow, error)
 	CreateBot(ctx context.Context, arg dbsqlc.CreateBotParams) (dbsqlc.CreateBotRow, error)

--- a/internal/db/subagent_fork_history_migration_integration_test.go
+++ b/internal/db/subagent_fork_history_migration_integration_test.go
@@ -14,10 +14,12 @@ func TestSubagentForkHistoryMigrationRoundTrip(t *testing.T) {
 	pool := freshMigratedDB(t)
 	dsn := teamMigrationDSN(t)
 
+	steps := countMigrationsFrom(t, "0119_subagent_fork_history.up.sql")
+
 	assertSubagentForkHistorySchema(t, ctx, pool, false, true)
-	stepDown(t, dsn, 1)
+	stepDown(t, dsn, steps)
 	assertSubagentForkHistorySchema(t, ctx, pool, true, false)
-	stepUp(t, dsn, 1)
+	stepUp(t, dsn, steps)
 	assertSubagentForkHistorySchema(t, ctx, pool, false, true)
 }
 


### PR DESCRIPTION
Slimmed restack of this PR after #856 consolidated the chat/thread domains. The previous revision implemented summary parity by duplicating composition across the flow and pipeline paths; after #856 both paths converge on `timeline.ComposeContext`, so this revision implements artifact-aware composition once and wires both call sites. The durable event-delivery machinery from the previous revision (delivery claims, leases, queued/injected replay, decision redelivery) is split out and will follow the Run Journal shape from the channel-boundary spec (§6) as a separate PR.

## Summary

- **Artifact-aware composition, one implementation.** `timeline.ComposeContextWithArtifacts` replaces covered rendered segments and covered turn responses with their compaction summary at the covered slot — rendered slot first, then response slot, then the durable anchor — preserving order within same-millisecond ties in both domains. Segments edited after an artifact's coverage snapshot stay visible; blank, coverage-malformed, and coverage-less (pre-coverage legacy) artifacts are never projected, so they can never swallow or duplicate history.
- **Both call sites share it.** The chat pipeline branch (`buildMessagesFromPipeline`) and the discuss trigger load the session's active artifact frontier via `compaction.TimelineArtifactSource` and compose through the same function; parity is structural rather than mirrored. Budget trimming pins summaries so they survive a dropped prefix.
- **Discuss turns trigger compaction.** Native discuss turns re-evaluate compaction pressure with the chat trigger policy (summary-excluded numerator in the chat estimator's unit, budget-clamped threshold). Artifact summaries are identified by an explicit `CompactionArtifactID` carried through `turn.DiscussMessage`, never by content sniffing. ACP discuss already inherits the chat trigger through `streamTurnChat`.
- **Mention gating.** Self-sent segments never wake the bot; compaction coverage never erases an unconsumed mention (gating is watermark-only); image extraction uses the coverage-filtered timeline so a summarized image is not re-attached.
- **Monotonic event cursors.** `bot_session_events` payloads carry a JSON-safe monotonic cursor from a sequence seeded above both the wall clock and trusted-capped legacy data. Discuss consumption tracks a dual watermark and a segment counts as consumed only where every informative domain agrees — a covered cursor alone never proves consumption (concurrent inbound workers can allocate against source order), and a watermark seeded from persisted replies alone carries no cursor to compare. Payload cursors are trusted only within `(0, MaxTrustedEventCursor]`; backup import strips instance-local cursors and zeroes restored watermarks, so restored history gates in the source-time domain and import never mutates the local sequence.

## Boundary

- No delivery claims/leases, queued or injected durability, response replay, or decision-event redelivery here — that machinery follows as a separate PR aligned with the Run Journal (spec §6). In-process dispatch semantics on main are unchanged.
- Migration `0120_discuss_event_cursor` (renumbered after main claimed 0115–0119) contains only the cursor sequence, the discuss cursor column, and their trusted-capped backfill.
- Compaction selection and artifact persistence are unchanged; this PR only projects the existing frontier into composition.
- Accepted tradeoffs: (1) a hostile pre-existing dataset that drives the migration floor to the trusted ceiling degrades later allocations to source-time gating, chosen over widening projection trust; (2) losing a durable watermark over a compacted consumed mention may re-wake a session once, chosen over erasing pending mentions; (3) an insert-failure delivery keeps its stamped cursor and may replay once after recovery.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` — all clean.
- PostgreSQL migrate up → down → up on an ephemeral postgres:16; replayed against a seeded hostile dataset (oversized and non-numeric payload cursors) to confirm the migration neither aborts nor exhausts the sequence.
- Integration guards for 0120 (`internal/db/discuss_event_cursor_migration_integration_test.go`) run green against a live database, covering the schema round trip and the clock-seeded sequence floor.
- Review: 14 rounds of adversarial review (external reviewer) plus a four-lens internal review (concurrency, regressions vs base, schema/contract, test integrity). Each accepted finding was fixed test-first, and every new guard was mutation-verified — the implementation was reverted in a scratch copy to confirm the test actually fails.
- Exact head: `0e271333` — CI green (14 checks pass, publish job skipped as PR-only).
