### PR TITLE
fix(display): request full initial RFB frame

### DIFF
--- a/internal/display/service.go
+++ b/internal/display/service.go
@@ -1303,7 +1303,10 @@ func forceVP8FromEnv() bool {
 func gstreamerArgs(codec string, rfbPort, rtpPort int) []string {
 	base := []string{
 		"-q",
-		"rfbsrc", "host=127.0.0.1", fmt.Sprintf("port=%d", rfbPort), "shared=true", "incremental=true", "use-copyrect=true", "do-timestamp=true",
+		// Request a full framebuffer on startup. With incremental updates only,
+		// a quiet desktop can produce no RFB update and session.start will time
+		// out waiting for the first RTP packet.
+		"rfbsrc", "host=127.0.0.1", fmt.Sprintf("port=%d", rfbPort), "shared=true", "incremental=false", "use-copyrect=true", "do-timestamp=true",
 		"!", "videoconvert",
 		"!", "videorate",
 		"!", fmt.Sprintf("video/x-raw,framerate=%d/1", videoFrameRate),

--- a/internal/display/service_test.go
+++ b/internal/display/service_test.go
@@ -167,8 +167,8 @@ func TestSessionWaitsForInFlightStart(t *testing.T) {
 
 func TestGStreamerArgsH264UsesX264AndH264Pay(t *testing.T) {
 	args := gstreamerArgs(CodecH264, 5901, 5004)
-	if !containsString(args, "incremental=true") {
-		t.Fatal("live rfbsrc must request incremental updates")
+	if !containsString(args, "incremental=false") {
+		t.Fatal("live rfbsrc must request a full initial framebuffer")
 	}
 	if !containsString(args, "use-copyrect=true") {
 		t.Fatal("live rfbsrc must allow copyrect updates")


### PR DESCRIPTION
## Summary

This changes the live workspace display GStreamer pipeline from an incremental-only RFB startup to a full initial framebuffer request:

```diff
-rfbsrc ... incremental=true ...
+rfbsrc ... incremental=false ...
```

The screenshot pipeline already uses `incremental=false num-buffers=1`; this applies the same “request a complete first frame” principle to the live WebRTC pipeline startup.

## Problem Observed

Desktop remote display could get stuck at `Connecting desktop...` when running the Electron desktop app against the local dev server:

```sh
MEMOH_DESKTOP_RUNTIME_MODE=remote \
MEMOH_DESKTOP_REMOTE_BASE_URL=http://localhost:18082/api \
MEMOH_WEB_PROXY_TARGET=http://localhost:18082 \
MEMOH_VUE_DEVTOOLS=0 \
pnpm dev
```

This was intermittent: the same Desktop panel had connected successfully in earlier runs, but later attempts repeatedly hung or surfaced:

```text
gstreamer unavailable: display pipeline produced no frames within 30s
```

## Evidence From Debugging

The failure was not an auth/base URL issue:

- `http://localhost:18082/api/ping` returned 200.
- authenticated bot/display APIs were reachable.
- the target bot was `1f18c498-c942-480e-86a1-dc52c2723aca`.

The failing path was captured in server logs:

```text
GET /bots/1f18c498-c942-480e-86a1-dc52c2723aca/container/display status=200

display encoder started ... codec=video/H264 proxy_port=45865 rtp_port=44141

# about 30s later

display encoder stopped
POST /bots/1f18c498-c942-480e-86a1-dc52c2723aca/container/display/webrtc/offer status=503
```

On the browser side, Playwright showed the video element never received a track before the 503:

```json
{
  "readyState": 0,
  "videoWidth": 0,
  "videoHeight": 0,
  "srcObjectTracks": []
}
```

After the request failed, the UI showed:

```text
gstreamer unavailable: display pipeline produced no frames within 30s
```

So the failure was before WebRTC answer creation completed: `session.start()` was waiting for the first RTP packet from GStreamer, but no packet arrived within `firstPacketTimeout`.

## Why `incremental=true` Is Suspect

The live pipeline currently starts with:

```go
rfbsrc host=127.0.0.1 port=<proxy> shared=true incremental=true use-copyrect=true do-timestamp=true
```

`rfbsrc incremental=true` asks the VNC/RFB server for incremental framebuffer updates. That is fine once the desktop is already changing, but it makes initial stream startup depend on the server sending a framebuffer update. A quiet desktop can produce no update, which means:

1. `rfbsrc` emits no buffer.
2. the encoder/payloader emits no RTP packet.
3. `session.start()` waits for `firstPacket` until `firstPacketTimeout`.
4. the offer endpoint returns 503 before the peer is answered.
5. the frontend remains in connecting/unavailable state.

This matches the observed intermittency: if the desktop/browser happens to repaint during startup, the display may connect; if the desktop is quiet, startup can time out.

## Change

Request a full framebuffer at live pipeline startup:

```go
rfbsrc ... incremental=false ...
```

This makes startup independent of whether the desktop happens to repaint. The service still keeps the existing `videorate`, leaky queue, encoder, RTP payloader, `do-timestamp=true`, and `use-copyrect=true` behavior.

## Validation

Automated:

```sh
go test ./internal/display
```

Also passed through the original worktree's pre-commit Go test hook.

Manual dev-stack verification after `air` rebuilt `/workspace/tmp/memoh-server`:

- clicked Desktop reconnect in the web UI via Playwright
- `POST /display/webrtc/offer` returned 200 instead of 503
- server logged WebRTC ICE/connection state as `connected`
- active display session was visible from `/display/sessions`
- browser video element reached ready state and had a live video track:

```json
{
  "readyState": 4,
  "currentTime": 15.564,
  "videoWidth": 1280,
  "videoHeight": 960,
  "paused": false,
  "tracks": [
    {
      "kind": "video",
      "readyState": "live",
      "muted": false,
      "enabled": true
    }
  ]
}
```

Server log after this patch:

```text
display encoder started ... codec=video/H264 ...
display webrtc configured ...
POST /bots/.../container/display/webrtc/offer status=200
display webrtc ice state ... state=connected
display webrtc connection state ... state=connected
```

## Risk / Review Notes

The main tradeoff is bandwidth/work at startup. `incremental=false` requests a complete framebuffer instead of waiting only for deltas. For 1280x960 at display startup, this seems acceptable because the service already requires a first RTP packet before answering WebRTC, and a reliable first frame is more important than optimizing away the initial full-frame request.

Potential reviewer questions:

- Should the live pipeline switch back to incremental after the first full frame? That would be more complex because `rfbsrc` properties are pipeline startup configuration; this PR keeps the fix minimal.
- Should this instead force a desktop repaint from prepare/startup? That may help some cases, but it still leaves stream startup dependent on side effects outside the video pipeline.
- Should we extend `firstPacketTimeout` again? That would only make users wait longer when no first framebuffer update is emitted; it does not address the underlying no-buffer condition.

This PR is intentionally narrow: one GStreamer source option plus the matching test expectation.
