### PR TITLE
feat(web): upgrade dockview to v7 with local ghost/params patches

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,7 @@
     "animate.css": "^4.1.1",
     "cron-parser": "^5.5.0",
     "cronstrue": "^3.14.0",
-    "dockview-vue": "^6.6.1",
+    "dockview-vue": "^7.0.2",
     "dotenv": "^17.2.3",
     "echarts": "^6.0.0",
     "katex": "^0.16.28",

--- a/apps/web/src/pages/home/components/chat-workspace.vue
+++ b/apps/web/src/pages/home/components/chat-workspace.vue
@@ -17,6 +17,7 @@
       :disable-floating-groups="true"
       :disable-tabs-overflow-list="true"
       :disable-auto-resizing="true"
+      :scrollbars="'native'"
       :get-tab-context-menu-items="getTabContextMenuItems"
       @ready="onReady"
     />

--- a/apps/web/src/pages/home/components/chat-workspace.vue
+++ b/apps/web/src/pages/home/components/chat-workspace.vue
@@ -150,7 +150,7 @@ const memohTheme: DockviewTheme = {
   name: 'memoh',
   className: 'dockview-theme-memoh',
   gap: 0,
-  dndTabIndicator: 'fill',
+  dndTabIndicator: 'line',
 }
 
 // Closes route through the store guard so dirty files prompt to save instead of

--- a/apps/web/src/pages/home/components/dockview/tab-close-confirm.vue
+++ b/apps/web/src/pages/home/components/dockview/tab-close-confirm.vue
@@ -3,7 +3,10 @@
     :open="!!pending"
     @update:open="onOpenChange"
   >
-    <DialogContent class="sm:max-w-[420px]">
+    <DialogContent
+      class="sm:max-w-[420px]"
+      @close-auto-focus="onCloseAutoFocus"
+    >
       <DialogHeader>
         <DialogTitle>{{ t('chat.unsaved.title', { name: pending?.title ?? '' }) }}</DialogTitle>
         <DialogDescription>{{ t('chat.unsaved.description') }}</DialogDescription>
@@ -71,5 +74,22 @@ async function onSave() {
 
 function onOpenChange(open: boolean) {
   if (!open) resolve('cancel')
+}
+
+// This dialog is opened imperatively from the store (no DialogTrigger); the element
+// focused when it opened is the tab's X close button, which is hover/focus-only.
+// Reka's default closeAutoFocus returns focus THERE on close, flipping the tab's
+// :focus-within on so the X stays lit after the pointer has left — most jarring on
+// Cancel, where nothing closed yet the tab reads as "closing".
+//
+// We prevent that default, but must NOT let focus fall to <body>: a keyboard user
+// who opened this via Tab→Enter (and batch-close, one dialog per dirty tab) would
+// lose their place entirely. Instead hand focus to the dock's active panel — the
+// surface the user is left looking at — so the affordance settles AND keyboard
+// context survives. Guard the call: no active panel (empty dock) simply no-ops,
+// leaving focus wherever the browser puts it rather than throwing.
+function onCloseAutoFocus(event: Event) {
+  event.preventDefault()
+  store.api?.activePanel?.focus()
 }
 </script>

--- a/apps/web/src/pages/home/components/dockview/workspace-tab.vue
+++ b/apps/web/src/pages/home/components/dockview/workspace-tab.vue
@@ -51,14 +51,17 @@
         />
       </span>
     </div>
-    <!-- Close affordance: hover-only, absolutely positioned so it never reserves a
-         slot or resizes the chip (geometry is identical hovered or not). It paints
-         the chip's own OPAQUE hover colour (--tab-hover-bg) as a left→right fade, so
-         the title dissolves into the chip and nothing stays legible under the
-         button. The fade layer is click-through; only the button takes pointer
-         events. Keyboard focus reveals it for a11y; middle-click closes without it. -->
+    <!-- Close affordance: RESIDENT on the active tab (fills the reserved slot so it
+         never reads as an empty gap), hover/focus-only on inactive tabs. Absolutely
+         positioned so it never reserves a slot or resizes the chip (geometry is
+         identical hovered or not). It paints the chip's own OPAQUE hover colour
+         (--tab-hover-bg) as a left→right fade, so the title dissolves into the chip
+         and nothing stays legible under the button. The fade layer is click-through;
+         only the button takes pointer events. Keyboard focus reveals it for a11y;
+         middle-click closes without it. -->
     <div
-      class="close-fade pointer-events-none absolute right-[var(--tab-close-edge)] z-[2] flex items-center pl-6 pr-0 opacity-0 group-hover/tab:opacity-100 focus-within:opacity-100"
+      class="close-fade pointer-events-none absolute right-[var(--tab-close-edge)] z-[2] flex items-center pl-6 pr-0 group-hover/tab:opacity-100 focus-within:opacity-100"
+      :class="showResidentClose ? 'opacity-100' : 'opacity-0'"
     >
       <!-- No own hover fill: the close affordance is read through the left→right
            fade (which already paints the chip's hover surface) plus the icon
@@ -128,6 +131,13 @@ let pendingShapeFrame = 0
 // Unsaved-changes flag for file panels — read from the store's reactive map, so
 // the dot, the sidebar badge and the close dialog never drift apart.
 const isDirty = computed(() => !!workspaceTabs.fileDirty[panelId])
+// The close slot is reserved on every tab (the right inset), so on an inactive tab
+// at rest it just reads as empty space. The ACTIVE tab fills that slot with a
+// resident X — its close affordance is always there, not hover-only, so the
+// reserved gap never looks accidental. A dirty active tab keeps showing the unsaved
+// dot at rest instead (the X still fades in on hover over the same slot), so the two
+// signals never fight for the slot.
+const showResidentClose = computed(() => isTabSelected.value && !isDirty.value)
 // Ephemeral preview tabs still get replaced in place when another
 // preview-eligible tab opens into the same group (see workspace-tabs store), but
 // the state is no longer surfaced visually — there is no italic or other marker.

--- a/apps/web/src/pages/home/components/dockview/workspace-tab.vue
+++ b/apps/web/src/pages/home/components/dockview/workspace-tab.vue
@@ -37,12 +37,18 @@
       ]"
     >{{ title }}</span>
     <!-- Unsaved-changes dot: sits in the close slot at rest so the affordance never
-         shifts; hovering fades it out as the close button fades in.
-         Painted over the same fade as the button so a long title dissolves behind
-         it instead of colliding with the glyph. -->
+         shifts; hovering fades it out as the close button fades in. It borrows the
+         close-fade GEOMETRY (identical top/bottom/right) so the dot sits exactly
+         where the close button will appear — no positional jump on hover — but the
+         `is-dot` modifier strips the fade's paint. The grey blot is a HOVER
+         affordance (it dissolves the title under the close glyph); on an inactive
+         tab --tab-hover-bg resolves to the hover overlay (--surface-chrome-hover),
+         so painting it at rest smeared grey behind the dot on a tab that is neither
+         active nor hovered. At rest we want the dot ALONE; the blot returns exactly
+         when the close button does (this layer fades out as that one fades in). -->
     <div
       v-if="isDirty"
-      class="close-fade pointer-events-none absolute right-[var(--tab-close-edge)] z-[2] flex items-center pl-6 pr-0 opacity-100 group-hover/tab:opacity-0"
+      class="close-fade is-dot pointer-events-none absolute right-[var(--tab-close-edge)] z-[2] flex items-center pl-6 pr-0 opacity-100 group-hover/tab:opacity-0"
     >
       <span class="flex size-5 items-center justify-center">
         <span
@@ -386,5 +392,15 @@ function fmt(value: number) {
 .group\/tab:hover .close-fade,
 .group\/tab:focus-within .close-fade {
   transition: opacity var(--tab-hover-duration, 150ms) ease-out;
+}
+
+/* Dirty-dot slot: reuse close-fade for GEOMETRY ONLY, never its paint. The fade is
+ * a hover affordance (blots the title under the close button); this layer is shown
+ * only at rest (opacity-100, fading to 0 on hover), so painting the fade here put a
+ * grey smear behind the dot on an inactive tab — off-hover, --tab-hover-bg resolves
+ * to the hover overlay, not the tab's own fill. Higher specificity than .close-fade
+ * so it wins regardless of source order. */
+.close-fade.is-dot {
+  background: none;
 }
 </style>

--- a/apps/web/src/pages/home/components/dockview/workspace-tab.vue
+++ b/apps/web/src/pages/home/components/dockview/workspace-tab.vue
@@ -5,7 +5,7 @@
     @auxclick.middle.prevent="close"
   >
     <svg
-      v-if="isActive"
+      v-if="isVisible"
       class="active-tab-shape z-0"
       :viewBox="activeTabViewBox"
       :style="activeTabShapeStyle"
@@ -106,6 +106,14 @@ const rootEl = ref<HTMLElement | null>(null)
 const panelId = props.params.api.id
 const title = ref(props.params.api.title ?? '')
 const isActive = ref(props.params.api.isActive)
+// Per-group active: this tab is its group's visible panel (every group has one).
+// Drives the active SHAPE (SVG), the resident close slot, and the seam/hover CSS
+// via the .memoh-tab-active class toggled on the .dv-tab wrapper. isActive is
+// layout-level (only the focused group's active tab) and is kept ONLY for label
+// colour — the focused group's active tab reads brighter, inactive groups' active
+// tabs stay dim. dockview's own .dv-active-tab is isActive-scoped, so it can't
+// carry this per-group signal the shape needs.
+const isVisible = ref(props.params.api.isVisible)
 // First-paint placeholder ONLY — these mirror the CSS contract (200≈12.5rem tab,
 // 35 = 40px strip − 5px inset, 8 = --tab-radius, 1px stroke) just so the active
 // SVG has a sane shape for the one frame before onMounted measures the real DOM.
@@ -137,7 +145,7 @@ const isDirty = computed(() => !!workspaceTabs.fileDirty[panelId])
 // reserved gap never looks accidental. A dirty active tab keeps showing the unsaved
 // dot at rest instead (the X still fades in on hover over the same slot), so the two
 // signals never fight for the slot.
-const showResidentClose = computed(() => isActive.value && !isDirty.value)
+const showResidentClose = computed(() => isVisible.value && !isDirty.value)
 // Ephemeral preview tabs still get replaced in place when another
 // preview-eligible tab opens into the same group (see workspace-tabs store), but
 // the state is no longer surfaced visually — there is no italic or other marker.
@@ -148,9 +156,21 @@ const disposables = [
   }),
   props.params.api.onDidActiveChange((event) => {
     isActive.value = event.isActive
-    if (event.isActive) scheduleActiveTabShapeUpdate()
+  }),
+  props.params.api.onDidVisibilityChange((event) => {
+    isVisible.value = event.isVisible
+    if (event.isVisible) scheduleActiveTabShapeUpdate()
   }),
   props.params.containerApi.onDidLayoutChange(() => {
+    // Re-tag on every layout change, not just visibility flips. When a tab is
+    // MOVED or SPLIT into another group, dockview reuses this component's tab
+    // element inside a brand-new .dv-tab wrapper (tabs.js setContent) without
+    // remounting the Vue instance; and if the tab was active in both the old and
+    // new group, isVisible stays true→true so onDidVisibilityChange never fires.
+    // Without this, the moved active tab would render its SVG shape (v-if still
+    // true) on a wrapper the CSS reads as inactive — doubled hover/divider pixels.
+    // Layout change covers move/split/reorder and re-resolves the current wrapper.
+    syncGroupActiveClass()
     scheduleActiveTabShapeUpdate()
   }),
 ]
@@ -160,8 +180,12 @@ const disposables = [
 onMounted(() => {
   title.value = props.params.api.title ?? title.value
   isActive.value = props.params.api.isActive
+  isVisible.value = props.params.api.isVisible
   nextTick(() => {
     installShapeObserver()
+    // Set the group-active class only after the tab's .dv-tab ancestor exists;
+    // closest() returns null before the wrapper is in the DOM.
+    syncGroupActiveClass()
     window.addEventListener('resize', scheduleActiveTabShapeUpdate)
     scheduleActiveTabShapeUpdate()
   })
@@ -177,12 +201,26 @@ onBeforeUnmount(() => {
   if (pendingShapeFrame) cancelAnimationFrame(pendingShapeFrame)
   resizeObserver?.disconnect()
   window.removeEventListener('resize', scheduleActiveTabShapeUpdate)
+  // Clear the imperatively-set class so it can't linger on a .dv-tab wrapper that
+  // dockview later reuses for a different (e.g. terminal) tab component that never
+  // sets it — otherwise a stale active style could survive the swap.
+  rootEl.value?.closest('.dv-tab')?.classList.remove('memoh-tab-active')
   for (const d of disposables) d.dispose()
 })
 
-watch(isActive, (active) => {
+watch(isVisible, (active) => {
+  syncGroupActiveClass()
   if (active) nextTick(scheduleActiveTabShapeUpdate)
 })
+
+// Mirror isVisible onto the .dv-tab wrapper as a class the theme CSS can target.
+// dockview's own .dv-active-tab is isActive-scoped (layout-level, one tab total),
+// so it can't express "this tab is its group's active panel" — which is what the
+// seam/hover/shape rules need, since every group's active tab wears the shape.
+function syncGroupActiveClass() {
+  const tab = rootEl.value?.closest<HTMLElement>('.dv-tab')
+  if (tab) tab.classList.toggle('memoh-tab-active', isVisible.value)
+}
 
 function installShapeObserver() {
   const root = rootEl.value
@@ -196,7 +234,7 @@ function installShapeObserver() {
 }
 
 function scheduleActiveTabShapeUpdate() {
-  if (!isActive.value || pendingShapeFrame) return
+  if (!isVisible.value || pendingShapeFrame) return
 
   pendingShapeFrame = requestAnimationFrame(() => {
     pendingShapeFrame = 0

--- a/apps/web/src/pages/home/components/dockview/workspace-tab.vue
+++ b/apps/web/src/pages/home/components/dockview/workspace-tab.vue
@@ -137,7 +137,7 @@ const isDirty = computed(() => !!workspaceTabs.fileDirty[panelId])
 // reserved gap never looks accidental. A dirty active tab keeps showing the unsaved
 // dot at rest instead (the X still fades in on hover over the same slot), so the two
 // signals never fight for the slot.
-const showResidentClose = computed(() => isTabSelected.value && !isDirty.value)
+const showResidentClose = computed(() => isActive.value && !isDirty.value)
 // Ephemeral preview tabs still get replaced in place when another
 // preview-eligible tab opens into the same group (see workspace-tabs store), but
 // the state is no longer surfaced visually — there is no italic or other marker.

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -107,14 +107,14 @@ interface FakeGroup {
 function createFakeDock() {
   const panels: FakePanel[] = []
   const removeListeners: Array<(panel: FakePanel) => void> = []
-  const activePanelListeners: Array<(panel: FakePanel | null) => void> = []
+  const activePanelListeners: Array<(event: { activePanel: FakePanel | undefined }) => void> = []
   const layoutListeners: Array<() => void> = []
   const closeVetoPanelIds = new Set<string>()
   let activePanel: FakePanel | null = null
   const setActivePanel = (panel: FakePanel | null) => {
     if (activePanel === panel) return
     activePanel = panel
-    activePanelListeners.forEach(listener => listener(panel))
+    activePanelListeners.forEach(listener => listener({ activePanel: panel ?? undefined }))
   }
   const noopDisposable = () => ({ dispose: () => {} })
   const layoutDisposable = (listener: () => void) => {
@@ -131,7 +131,7 @@ function createFakeDock() {
       layoutListeners.forEach(listener => listener())
     })
   }
-  const activePanelDisposable = (listener: (panel: FakePanel | null) => void) => {
+  const activePanelDisposable = (listener: (event: { activePanel: FakePanel | undefined }) => void) => {
     activePanelListeners.push(listener)
     return {
       dispose: () => {
@@ -154,7 +154,7 @@ function createFakeDock() {
       toggle: vi.fn(),
     },
   } as unknown as HTMLElement
-  const group = {
+  const group: FakeGroup = {
     id: 'group-1',
     element: groupElement,
     api: {

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -107,14 +107,17 @@ interface FakeGroup {
 function createFakeDock() {
   const panels: FakePanel[] = []
   const removeListeners: Array<(panel: FakePanel) => void> = []
-  const activePanelListeners: Array<(event: { activePanel: FakePanel | undefined }) => void> = []
+  // Mirror dockview v7's real onDidActivePanelChange payload: `{ panel, origin }`.
+  // The old fake used `{ activePanel }` (the v6 shape); that masked the v6→v7
+  // rename bug because the store read the same wrong field the fake emitted.
+  const activePanelListeners: Array<(event: { panel: FakePanel | undefined }) => void> = []
   const layoutListeners: Array<() => void> = []
   const closeVetoPanelIds = new Set<string>()
   let activePanel: FakePanel | null = null
   const setActivePanel = (panel: FakePanel | null) => {
     if (activePanel === panel) return
     activePanel = panel
-    activePanelListeners.forEach(listener => listener({ activePanel: panel ?? undefined }))
+    activePanelListeners.forEach(listener => listener({ panel: panel ?? undefined }))
   }
   const noopDisposable = () => ({ dispose: () => {} })
   const layoutDisposable = (listener: () => void) => {
@@ -131,7 +134,7 @@ function createFakeDock() {
       layoutListeners.forEach(listener => listener())
     })
   }
-  const activePanelDisposable = (listener: (event: { activePanel: FakePanel | undefined }) => void) => {
+  const activePanelDisposable = (listener: (event: { panel: FakePanel | undefined }) => void) => {
     activePanelListeners.push(listener)
     return {
       dispose: () => {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -442,7 +442,12 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     api.value = dock
     apiDisposables = [
       dock.onDidActivePanelChange((event) => {
-        const panel = event.activePanel
+        // dockview v7 renamed this event's payload field: v6 fired the panel on
+        // `event.activePanel`, v7 fires `{ panel, origin }`. Reading the old name
+        // yields undefined every time, silently nulling activePanelId on every
+        // tab switch — which desyncs the sidebar file-tree highlight (its only
+        // consumer via activeId). Use `event.panel`.
+        const panel = event.panel
         activePanelId.value = panel?.id ?? null
         const group = panel?.group
         if (group && !isTerminalOnlyGroup(group)) {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -441,7 +441,8 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     for (const d of apiDisposables) d.dispose()
     api.value = dock
     apiDisposables = [
-      dock.onDidActivePanelChange((panel) => {
+      dock.onDidActivePanelChange((event) => {
+        const panel = event.activePanel
         activePanelId.value = panel?.id ?? null
         const group = panel?.group
         if (group && !isTerminalOnlyGroup(group)) {

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -44,8 +44,14 @@
   --dv-sash-color: transparent;
   --dv-active-sash-color: var(--ring);
 
-  --dv-drag-over-background-color: var(--sidebar-accent);
-  --dv-drag-over-border-color: var(--ring);
+  /* Drop indicator fill: dockview's grey, toned down from the base 0.5 opacity
+   * (which reads too dark on Memoh's chrome). The base theme defines this per
+   * .dockview-theme-dark/light, which .dockview-theme-memoh does NOT extend, so
+   * it must be re-declared here. The void/pane centre drop is rendered entirely
+   * by dockview's default anchor/selection styles using this colour — no custom
+   * override below. Only the tab-to-tab insertion line is themed (brand colour). */
+  --dv-drag-over-background-color: rgba(83, 89, 93, 0.3);
+  --dv-drag-over-border-color: transparent;
 
   --dv-icon-hover-background-color: var(--ui-hover);
   --dv-scrollbar-background-color: var(--border);
@@ -181,13 +187,22 @@
   /* Trailing room the label must clear: it stops a hair before the glyph's left
    * edge (glyph right is --tab-pad-inline, glyph is --tab-close-glyph wide). */
   --tab-close-reserve: calc(var(--tab-pad-inline) + var(--tab-close-glyph) + 0.125rem);
-  --tab-drop-line: var(--brand);
+  /* Drop insertion line: a SOFTENED brand — the raw --brand (chroma ~0.22) reads as
+   * a loud violet stripe for what is only a transient "insert here" hint. Muting the
+   * chroma toward the chrome keeps it recognisably brand-tinted without shouting.
+   * color-mix over the chrome surface drops saturation and lightens it a touch; the
+   * line is a thin caret, so it stays legible. Not --brand directly (that stays for
+   * real brand accents like buttons). */
+  --tab-drop-line: color-mix(in oklab, var(--brand) 55%, var(--surface-chrome));
   --tab-drop-line-width: 0.125rem;
   --tab-drop-line-height: 1.25rem;
   --tab-drop-line-top: calc(50% - var(--tab-inset) / 2 - var(--tab-drop-line-height) / 2);
-  --tab-void-drop-line-top: calc(50% - var(--tab-drop-line-height) / 2);
   --tab-drop-line-left-offset: calc(-1 * var(--tab-drop-line-width) / 2);
   --tab-drop-line-right-offset: calc(4px - var(--tab-drop-line-width) / 2);
+  /* How long the drop caret glides from one seam to the next as the cursor moves
+   * between tabs. The v7 anchor is a single reused element, so this is a real
+   * position transition, not a fade. One knob for the whole animation. */
+  --tab-drop-line-slide: 120ms;
   /* DIVIDERS — one stroke, one width, one HEIGHT for both the inter-tab seam and
    * the action-bar lead. Height = the close/“+” glyph height so the bar reads the
    * same extent as the icons it sits between (NOT taller — a taller bar reads as
@@ -277,7 +292,7 @@
   z-index: calc(var(--dv-overlay-z-index, 999) + 1);
 }
 
-.dockview-theme-memoh .dv-tab:not(.dv-active-tab)::before {
+.dockview-theme-memoh .dv-tab:not(.memoh-tab-active)::before {
   content: '';
   position: absolute;
   /* Box coords: the tab box is already top-offset by margin-top:--tab-inset, so
@@ -298,7 +313,7 @@
   pointer-events: none;
 }
 
-.dockview-theme-memoh .dv-tab:not(.dv-active-tab):hover::before {
+.dockview-theme-memoh .dv-tab:not(.memoh-tab-active):hover::before {
   opacity: 1;
   transition: none;
 }
@@ -335,8 +350,8 @@
  * left edge. The adjacency form is DOM-order-independent: it just asks "is there a
  * tab to my left", which is exactly the seam's presence condition. */
 .dockview-theme-memoh .dv-tab:not(.dv-tab + .dv-tab)::after,
-.dockview-theme-memoh .dv-tab.dv-active-tab::after,
-.dockview-theme-memoh .dv-tab.dv-active-tab + .dv-tab::after {
+.dockview-theme-memoh .dv-tab.memoh-tab-active::after,
+.dockview-theme-memoh .dv-tab.memoh-tab-active + .dv-tab::after {
   --tab-divider: transparent;
 }
 
@@ -348,39 +363,30 @@
   padding-inline: var(--tab-edge-pad);
 }
 
-/* The tab strip GROWS to claim the available header width (flex:1 1 auto), so only
- * the real overflow goes to the void. This is the fix for the two-tabs-crushed bug:
- * with the strip at flex:0 1 ... (grow:0) its basis:auto sized to the tabs' natural
- * (text) width, not N × rest-width, so the void (flex-grow:1) grabbed the slack and
- * the tabs, floored at min-width:0, collapsed even when the strip was nowhere near
- * full. Growing the strip gives it the real available width; the tabs hold rest
- * width while there's room and shrink together (no scroll) once they'd overflow.
+/* The tab strip GROWS to claim the available header width (flex:1 1 auto). The
+ * patch moves BOTH the "+" and the void inside it, so the strip's own children are
+ * [+, tab1..tabN, void]; the void (flex-grow:1) eats all the grown slack. Tabs hold
+ * their flex-basis (--tab-rest-width) while there's room and shrink together (no
+ * scroll) only once they'd overflow — the void, not the tabs, absorbs the strip's
+ * extra width. This is the fix for both the two-tabs-crushed bug (a grow:0 strip
+ * sized to the tabs' natural text width, letting an outside void grab the slack and
+ * collapse min-width:0 tabs) AND the dead-gap bug (the blank stretch right of the
+ * last tab used to belong to this container with no drop target; now it's the void).
  *
  * scrollbars:'native' (set in chat-workspace.vue) makes .dv-tabs-container the
  * header's direct flex child — there's no .dv-scrollable layer — so this rule
- * targets it directly. The dockview-core patch moves the "+" (left-actions) INTO
- * .dv-tabs-container, so it rides with the tabs and stays flush after the last one
- * instead of being shoved to the far right by the strip's grow. overflow:visible
- * drops upstream's scroll clip (disableTabsOverflowList is on, no scroll to clip). */
+ * targets it directly. overflow:visible drops upstream's scroll clip
+ * (disableTabsOverflowList is on, no scroll to clip). */
 .dockview-theme-memoh .dv-tabs-and-actions-container > .dv-tabs-container {
   flex: 1 1 auto;
   min-width: 0;
   overflow: visible;
 }
 
-/* Single tab locks to the rest width and does NOT shrink. Shrinking is a
- * multi-tab affordance — when several tabs fill the strip they narrow together.
- * A lone tab has nothing to make room for, so it must hold --tab-rest-width even
- * with a short title (that IS the rest width's purpose); the empty void fills the
- * rest of the strip. dockview adds .dv-single-tab to the header only while exactly
- * one tab is present, so this reverts to the shrinking rule the moment a second
- * tab opens. flex-shrink:0 + basis lets the tabs-container (basis:auto) hug it and
- * the void (flex-grow:1) claim the slack, instead of the tab being compressed.
- * Terminal chips are excluded — they keep their own narrower file-row measure. */
-.dockview-theme-memoh .dv-tabs-and-actions-container.dv-single-tab .dv-tab:not(:has(.memoh-terminal-tab)) {
-  flex: 0 0 var(--tab-rest-width);
-  min-width: var(--tab-rest-width);
-}
+/* No single-tab special case is needed: the void (moved inside the tabs-container
+ * by the patch, flex-grow:1) claims all the grown slack, so a lone tab holds its
+ * flex-basis (--tab-rest-width) instead of being stretched or compressed — the
+ * same mechanism that keeps multi-tab widths at rest until the strip is full. */
 
 /* No native/dockview horizontal scrollbar on the tab row (it clashed with the
  * hairline), and no edge shadow either. Editor tabs have no min-width floor, so the
@@ -400,7 +406,7 @@
  * keeps the same box metrics as inactive tabs, but it no longer paints its own
  * fill/border/foot pieces; otherwise separate raster models meet at the lower
  * turns and produce doubled pixels. */
-.dockview-theme-memoh .dv-tab.dv-active-tab {
+.dockview-theme-memoh .dv-tab.memoh-tab-active {
   background-color: transparent !important;
   /* The active tab never takes the hover lift, so its blot-out colour is the
    * editor surface it already wears. */
@@ -410,16 +416,16 @@
 /* Hover on an UNSELECTED tab: the tab box stays transparent at rest; the
  * chrome-hover fill is painted by ::before as a rounded rectangle centred on the
  * label. Text does not move. */
-.dockview-theme-memoh .dv-tab:not(.dv-active-tab):hover {
+.dockview-theme-memoh .dv-tab:not(.memoh-tab-active):hover {
   background-color: transparent !important;
 }
 
 /* Active tab paint is owned by the SVG shape in workspace-tab.vue (fill + 1px
  * stroke crown/foot). dockview's built-in `:not(:first-child)::before` divider also
  * targets the active tab as a transparent no-op at z-5; kill it so nothing can sit
- * over the SVG. (Our hover-pill ::before is `:not(.dv-active-tab)`, so it never
+ * over the SVG. (Our hover-pill ::before is `:not(.memoh-tab-active)`, so it never
  * applies here — this only silences dockview's own pseudo.) */
-.dockview-theme-memoh .dv-tab.dv-active-tab::before {
+.dockview-theme-memoh .dv-tab.memoh-tab-active::before {
   content: none;
 }
 
@@ -440,10 +446,17 @@
 
 /* The void is dockview's droppable empty-header region — it owns the
  * `header_space` drop target, so a tab dragged onto the blank part of a header
- * lands in that group. It MUST grow to have any area (dockview only binds the
- * HTML5 dragover to the tab strip + this void, not to the actions slots). It
- * fills from just after the "+" cluster (leftActions) to the far-right Preview
- * (rightActions).
+ * lands in that group, and dockview paints its default drop wash over it.
+ *
+ * A dockview-core patch moves this container INTO .dv-tabs-container, after the
+ * "+" (both are appended at construction, so in DOM order they land before the
+ * tabs; order:1 on "+" and order:2 here sort them visually AFTER every tab). This
+ * is what makes the whole blank stretch to the right of the last tab a real drop
+ * zone: the tabs-container GROWS to fill the header (flex:1 1 auto), and the void
+ * (flex-grow:1) claims all of that grown slack, so it spans flush from just after
+ * the "+" to the far-right actions. Before the move the same slack belonged to the
+ * tabs-container itself (a dead non-droppable gap) and the void was pinned to a
+ * sliver at the far right — a tab dropped on the blank area got no feedback.
  *
  * On the desktop shell the same blank strip doubles as the window-drag handle,
  * so we claim it with -webkit-app-region: drag. While a panel/group is being
@@ -452,7 +465,14 @@
  * this the window-move region would swallow them. (-webkit-app-region is a no-op
  * on web, where the void is simply always droppable + the group-drag handle.) */
 .dockview-theme-memoh .dv-void-container {
+  order: 2;
   flex: 1 1 auto;
+  /* The tabs-container carries padding-inline:--tab-edge-pad (active-flare geometry
+   * protection for the tabs). The void inherits that as an 8px non-droppable gap on
+   * its right, before the far-right actions. Cancel it so the void's drop zone (and
+   * dockview's drop wash) reaches flush to the actions — the whole blank stretch is
+   * droppable, no dead sliver. */
+  margin-right: calc(-1 * var(--tab-edge-pad));
   -webkit-app-region: drag;
 }
 .memoh-dock-dragging .dockview-theme-memoh .dv-void-container {
@@ -506,13 +526,13 @@
 /* Same rule as an inter-tab seam: when the LAST tab is active, its side-stroke is
  * the boundary, so the lead divider hides. padding-left stays, so the "+" does NOT
  * jump left when you select the last tab. The condition is "the active tab has no
- * tab to its right" — expressed as :has(.dv-tab.dv-active-tab NOT followed by
+ * tab to its right" — expressed as :has(.dv-tab.memoh-tab-active NOT followed by
  * another .dv-tab) — which is DOM-order-independent and does not rely on
  * :last-child (the patch appends the "+" as the first child, and dockview may also
  * append non-tab children, so :last-child is fragile here). A plain sibling
  * selector can't bridge the "+" and the last tab either, since the "+" sits at the
  * FRONT of the container, not after the last tab — so :has() is the only reach. */
-.dockview-theme-memoh .dv-tabs-and-actions-container:has(.dv-tab.dv-active-tab):not(:has(.dv-tab.dv-active-tab ~ .dv-tab)) .dv-left-actions-container::before {
+.dockview-theme-memoh .dv-tabs-and-actions-container:has(.dv-tab.memoh-tab-active):not(:has(.dv-tab.memoh-tab-active ~ .dv-tab)) .dv-left-actions-container::before {
   content: none;
 }
 
@@ -568,27 +588,15 @@
   outline: none !important;
 }
 
-/* Drop affordance: content-pane edge drops keep dockview's broad preview fill
- * (the split-right half-panel in screenshots). Header/tab-bar drops are insertion
- * decisions, so they should read as a short insertion caret between tabs. Dockview
- * writes those line targets inline as 4px blocks inside the target edge. The
- * theme trims them to 2px and re-centres each side on the actual seam so the
- * previous tab's right target and the next tab's left target collapse to one
- * visual line instead of twitching between two near-neighbour pixels. */
-.dockview-theme-memoh .dv-void-container.dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-center {
-  top: var(--tab-void-drop-line-top) !important;
-  left: 0 !important;
-  width: var(--tab-drop-line-width) !important;
-  height: var(--tab-drop-line-height) !important;
-  min-width: var(--tab-drop-line-width) !important;
-  max-width: var(--tab-drop-line-width) !important;
-  border: none !important;
-  border-radius: 999px;
-  background-color: var(--tab-drop-line);
-  opacity: 1;
-  transform: translateX(var(--tab-drop-line-left-offset));
-}
+/* Header void / pane centre drop: NO custom override — let dockview render its own
+ * default broad translucent wash (--dv-drag-over-background-color, a grey
+ * rgba(83,89,93,0.5) by default) over the whole target. Only the tab-to-tab
+ * insertion caret below is themed (brand colour). */
 
+/* Insertion line (tab-to-tab): both dockview's legacy in-place selection DOM and
+ * the v7 anchor DOM paint a thin brand-coloured caret at the seam between two tabs
+ * (left/right of the target tab). This is the ONLY brand-coloured drop affordance:
+ * it marks a precise insertion index, not a whole-target accept. */
 .dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line,
 .dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line {
   z-index: calc(var(--dv-overlay-z-index, 999) + 1);
@@ -596,9 +604,43 @@
   border-radius: 999px;
   background-color: var(--tab-drop-line);
   opacity: 1;
-  transition: none !important;
   will-change: auto;
 }
+
+/* Legacy in-place selection DOM is re-created on every hovered target, so a
+ * transition would just fade a brand-new node in — keep it instant. */
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line {
+  transition: none !important;
+}
+
+/* The v7 anchor is a SINGLE reused element whose position dockview rewrites as the
+ * cursor moves between tabs, so animating it makes the caret GLIDE from seam to
+ * seam instead of blinking out and redrawing (the "moves, not re-created" feel).
+ * We animate left/top/width AND transform: the theme nudges the caret onto the seam
+ * with transform: translateX(offset), and dockview swaps the left/right class as the
+ * cursor crosses a tab midpoint, so transform must transition too or that half-step
+ * would jump. opacity stays un-transitioned so appear/disappear is instant. */
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line {
+  transition:
+    left var(--tab-drop-line-slide) ease-out,
+    top var(--tab-drop-line-slide) ease-out,
+    width var(--tab-drop-line-slide) ease-out,
+    transform var(--tab-drop-line-slide) ease-out !important;
+}
+
+/* Cross-group jump: dockview marks the anchor .dv-drop-target-anchor-container-changed
+ * for one frame when the drop moves to a DIFFERENT group, so the caret should SNAP to
+ * the new group instead of gliding across the gap between groups. Upstream ships this
+ * snap as an opacity:0 flash, but only under .dockview-theme-dark/light/etc. —
+ * .dockview-theme-memoh does not extend those, so without this rule the glide
+ * transition above would animate the caret flying across the layout. Kill the
+ * transition for that one marked frame so the move is instant. */
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-container-changed {
+  transition: none !important;
+}
+
+/* v7 anchor centre drop: also rendered by dockview's default anchor style — no
+ * override (see the void comment above). */
 
 .dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-left,
 .dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-right,

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -49,8 +49,14 @@
    * .dockview-theme-dark/light, which .dockview-theme-memoh does NOT extend, so
    * it must be re-declared here. The void/pane centre drop is rendered entirely
    * by dockview's default anchor/selection styles using this colour — no custom
-   * override below. Only the tab-to-tab insertion line is themed (brand colour). */
-  --dv-drag-over-background-color: rgba(83, 89, 93, 0.3);
+   * override below. Only the tab-to-tab insertion line is themed (brand colour).
+   *
+   * Deliberately a neutral scrim, NOT a brand/semantic token: this is dockview's
+   * own drop wash dimmed to fit our chrome, and it must stay chromatically neutral
+   * (a tinted --sidebar-accent read wrong here). Named so it isn't a bare literal
+   * buried in the variable map; the value is the intended 0.3-alpha neutral grey. */
+  --dock-drop-scrim: rgba(83, 89, 93, 0.3);
+  --dv-drag-over-background-color: var(--dock-drop-scrim);
   --dv-drag-over-border-color: transparent;
 
   --dv-icon-hover-background-color: var(--ui-hover);
@@ -537,14 +543,16 @@
 }
 
 /* Dockview renders the "+" actions after the tabs, so its static divider normally
- * paints over a tab-edge drop line. During header drops, lift the source layer of
- * the caret above the actions layer instead of hiding the divider. */
-.dockview-theme-memoh .dv-tabs-and-actions-container > .dv-scrollable,
+ * paints over a tab-edge drop line. Lift the void (which holds the strip's slack
+ * and its drop wash) above the actions layer during a drop so the caret shows.
+ * (The former .dv-scrollable sibling of this rule is gone: chat-workspace sets
+ * scrollbars:'native', so dockview never creates the .dv-scrollable wrapper — the
+ * tabs list is the header's direct child. Per-tab drops use .dv-tab.dv-drop-target
+ * below.) */
 .dockview-theme-memoh .dv-void-container {
   position: relative;
 }
 
-.dockview-theme-memoh .dv-tabs-and-actions-container > .dv-scrollable:has(.dv-drop-target),
 .dockview-theme-memoh .dv-void-container.dv-drop-target {
   z-index: calc(var(--dv-overlay-z-index, 999) + 1);
 }
@@ -786,6 +794,16 @@
 }
 .dockview-theme-memoh .memoh-terminal-group .dv-left-actions-container::before {
   content: none;
+}
+
+/* The void's editor claw-back (margin-right:-1×--tab-edge-pad) cancels the editor
+ * tabs-container's flare padding so the drop zone reaches the actions flush. The
+ * terminal strip carries no such flare padding (its tabs-container uses a flat
+ * 3px inset, and terminal chips have no active-flare geometry), so inheriting the
+ * negative margin would pull the void 8px PAST its content edge — a phantom
+ * overhang under the "+". Zero it for terminal groups; they need no claw-back. */
+.dockview-theme-memoh .memoh-terminal-group .dv-void-container {
+  margin-right: 0;
 }
 
 .dockview-theme-memoh .memoh-terminal-group .dv-pre-actions-container {

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -150,6 +150,13 @@
   --tab-edge-pad: var(--tab-flare);
   /* HORIZONTAL rhythm */
   --tab-hover-inset: var(--tab-inset);
+  /* WIDTH — the rest measure (static upper bound). A tab rests at --tab-rest-width
+   * and HOLDS it as long as the strip has room: the void (flex-grow) eats the
+   * right-side slack, tabs don't grow. They only shrink — all together,
+   * equi-proportionally — once that void is exhausted and N tabs would overflow, so
+   * "add a tab" does nothing to the others until the strip is genuinely full. No
+   * floor (min-width:0 on the tab). One knob, tune in dev. */
+  --tab-rest-width: 15.625rem;
   /* The ONE knob for label/close breathing room (they mirror each other). Label
    * left x = hover-inset + this; close glyph right x = the same. So both read as
    * `gutter` to the hover pill and `gutter + inset` to the active fill. Move both
@@ -167,6 +174,13 @@
   /* Trailing room the label must clear: it stops a hair before the glyph's left
    * edge (glyph right is --tab-pad-inline, glyph is --tab-close-glyph wide). */
   --tab-close-reserve: calc(var(--tab-pad-inline) + var(--tab-close-glyph) + 0.125rem);
+  --tab-drop-line: var(--brand);
+  --tab-drop-line-width: 0.125rem;
+  --tab-drop-line-height: 1.25rem;
+  --tab-drop-line-top: calc(50% - var(--tab-inset) / 2 - var(--tab-drop-line-height) / 2);
+  --tab-void-drop-line-top: calc(50% - var(--tab-drop-line-height) / 2);
+  --tab-drop-line-left-offset: calc(-1 * var(--tab-drop-line-width) / 2);
+  --tab-drop-line-right-offset: calc(4px - var(--tab-drop-line-width) / 2);
   /* DIVIDERS — one stroke, one width, one HEIGHT for both the inter-tab seam and
    * the action-bar lead. Height = the close/“+” glyph height so the bar reads the
    * same extent as the icons it sits between (NOT taller — a taller bar reads as
@@ -224,13 +238,15 @@
    * arrow. dockview defaults .dv-tab to cursor:pointer;
    * the close button re-enables the pointer on itself only. */
   cursor: default;
-  /* Fixed editor-tab measure keeps title truncation, close placement, and the
-   * hover fill stable from tab to tab. Overflow scrolls instead of shrinking, so
-   * the tab geometry never changes under pointer movement. */
-  flex: 0 0 12.5rem;
-  width: 12.5rem;
-  min-width: 12.5rem;
-  max-width: 12.5rem;
+  /* Editor-tab measure: tabs REST at --tab-rest-width (the static upper bound) but
+   * SHRINK together, equi-proportionally, with NO floor — flex-shrink:1 and
+   * min-width:0, so however many tabs open they all stay on the strip, each one
+   * narrower, label truncating to a few glyphs (then the ellipsis) at the extreme
+   * rather than scrolling any off-screen. No fixed width/min-width any more: those
+   * pinned the tab and forced the old scroll-immediately-instead-of-shrink. */
+  flex: 0 1 var(--tab-rest-width);
+  min-width: 0;
+  max-width: var(--tab-rest-width);
   /* Rounded crown on EVERY tab, always — radius is state-independent so it can
    * never flash square for a frame while dockview swaps active/hover classes (it
    * only used to live on the active/hover rules). Invisible on a transparent
@@ -246,6 +262,10 @@
   margin-top: var(--tab-inset);
   height: calc(100% - var(--tab-inset));
   --tab-hover-bg: var(--surface-chrome-hover);
+}
+
+.dockview-theme-memoh .dv-tab.dv-drop-target {
+  z-index: calc(var(--dv-overlay-z-index, 999) + 1);
 }
 
 .dockview-theme-memoh .dv-tab:not(.dv-active-tab)::before {
@@ -311,9 +331,11 @@
   padding-inline: var(--tab-edge-pad);
 }
 
-/* The tab row hugs its content, so the "+" actions land right after the last tab.
- * It may still shrink as a scroll container so overflowing fixed-width tabs clip
- * and scroll rather than pushing the "+" off-screen. */
+/* The scroll container hugs its content while tabs rest at full width (so the "+"
+ * lands right after the last tab and void fills the rest); it shrinks as the strip
+ * fills up, letting the tabs inside shrink with it. min-width:0 lets that shrink
+ * actually propagate to the tabs (which themselves have no floor), so the strip
+ * absorbs any tab count by narrowing rather than scrolling. */
 .dockview-theme-memoh .dv-tabs-and-actions-container > .dv-scrollable,
 .dockview-theme-memoh .dv-scrollable > .dv-tabs-container {
   flex: 0 1 auto;
@@ -321,9 +343,9 @@
 }
 
 /* No native/dockview horizontal scrollbar on the tab row (it clashed with the
- * hairline), and no edge shadow either. When there are more tabs
- * than fit they've already shrunk to their min-width floor, then scroll via
- * wheel/trackpad. */
+ * hairline), and no edge shadow either. Editor tabs have no min-width floor, so the
+ * strip absorbs more tabs by shrinking them rather than overflowing — the hidden bar
+ * is just belt-and-suspenders against a transient overflow frame. */
 .dockview-theme-memoh .dv-tabs-container {
   scrollbar-width: none;
 }
@@ -434,6 +456,19 @@
   content: none;
 }
 
+/* Dockview renders the "+" actions after the tabs, so its static divider normally
+ * paints over a tab-edge drop line. During header drops, lift the source layer of
+ * the caret above the actions layer instead of hiding the divider. */
+.dockview-theme-memoh .dv-tabs-and-actions-container > .dv-scrollable,
+.dockview-theme-memoh .dv-void-container {
+  position: relative;
+}
+
+.dockview-theme-memoh .dv-tabs-and-actions-container > .dv-scrollable:has(.dv-drop-target),
+.dockview-theme-memoh .dv-void-container.dv-drop-target {
+  z-index: calc(var(--dv-overlay-z-index, 999) + 1);
+}
+
 /* Continuous bottom hairline for the WHOLE strip, drawn as an inset box-shadow so it
  * adds NO height — a real border-bottom would shrink the tab layer by 1px and break
  * the active tab's punch-through, which is why this used to be painted per-cell (nav,
@@ -471,6 +506,79 @@
 .dockview-theme-memoh .dv-groupview:focus,
 .dockview-theme-memoh .dv-groupview:focus-visible {
   outline: none !important;
+}
+
+/* Drop affordance: content-pane edge drops keep dockview's broad preview fill
+ * (the split-right half-panel in screenshots). Header/tab-bar drops are insertion
+ * decisions, so they should read as a short insertion caret between tabs. Dockview
+ * writes those line targets inline as 4px blocks inside the target edge. The
+ * theme trims them to 2px and re-centres each side on the actual seam so the
+ * previous tab's right target and the next tab's left target collapse to one
+ * visual line instead of twitching between two near-neighbour pixels. */
+.dockview-theme-memoh .dv-void-container.dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-center {
+  top: var(--tab-void-drop-line-top) !important;
+  left: 0 !important;
+  width: var(--tab-drop-line-width) !important;
+  height: var(--tab-drop-line-height) !important;
+  min-width: var(--tab-drop-line-width) !important;
+  max-width: var(--tab-drop-line-width) !important;
+  border: none !important;
+  border-radius: 999px;
+  background-color: var(--tab-drop-line);
+  opacity: 1;
+  transform: translateX(var(--tab-drop-line-left-offset));
+}
+
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line {
+  z-index: calc(var(--dv-overlay-z-index, 999) + 1);
+  border: none !important;
+  border-radius: 999px;
+  background-color: var(--tab-drop-line);
+  opacity: 1;
+  transition: none !important;
+  will-change: auto;
+}
+
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-left,
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-right,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line.dv-drop-target-left,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line.dv-drop-target-right {
+  top: var(--tab-drop-line-top) !important;
+  width: var(--tab-drop-line-width) !important;
+  height: var(--tab-drop-line-height) !important;
+  min-width: var(--tab-drop-line-width) !important;
+  max-width: var(--tab-drop-line-width) !important;
+  transform: none !important;
+}
+
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-left,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line.dv-drop-target-left {
+  transform: translateX(var(--tab-drop-line-left-offset)) !important;
+}
+
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-right,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line.dv-drop-target-right {
+  transform: translateX(var(--tab-drop-line-right-offset)) !important;
+}
+
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-top,
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-bottom,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line.dv-drop-target-top,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line.dv-drop-target-bottom {
+  width: calc(100% - 0.75rem) !important;
+  height: 0.125rem !important;
+  transform: translateX(0.375rem) !important;
+}
+
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-top,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line.dv-drop-target-top {
+  transform: translate(0.375rem, -0.0625rem) !important;
+}
+
+.dockview-theme-memoh .dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection.dv-drop-target-selection-line.dv-drop-target-bottom,
+.dockview-theme-memoh .dv-drop-target-container .dv-drop-target-anchor.dv-drop-target-anchor-line.dv-drop-target-bottom {
+  transform: translate(0.375rem, 0.1875rem) !important;
 }
 
 /* ---- Terminal groups: bottom tab strip, file-list chips -------------------
@@ -580,4 +688,33 @@
 
 .dockview-theme-memoh .memoh-terminal-group .dv-pre-actions-container {
   display: none;
+}
+
+/* ---- Drag ghost: the floating chip that follows the pointer ------------------
+ * Memoh patches dockview-core's single-tab ghost builder to create this minimal
+ * title-only chip instead of cloneNode(true) on the docked tab. The docked tab's
+ * DOM carries strip-only structure (active SVG, close slot, dirty dot, lane
+ * padding), and cloning that structure is exactly what made the ghost impossible
+ * to centre cleanly. This rule only paints the independent drag chip. */
+.dv-tab-ghost-drag {
+  display: grid;
+  place-items: center;
+  box-sizing: border-box;
+  margin-top: 0 !important;
+  padding: 0 0.875rem;
+  overflow: hidden;
+  border: 1px solid var(--border) !important;
+  border-radius: var(--radius-md) !important;
+  background: var(--surface-editor) !important;
+  box-shadow: var(--shadow-dropdown) !important;
+}
+
+.dv-tab-ghost-drag .dv-tab-ghost-label {
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -124,19 +124,26 @@
    *   1. Inter-tab seam: each tab paints a divider on ITS OWN LEFT edge (::after),
    *      i.e. the seam to its left. It belongs to the right-hand tab of the seam,
    *      so "previous sibling is active" is expressible without :has(). It HIDES
-   *      (--tab-divider:transparent) in exactly three cases — first tab (nothing to
-   *      its left), the active tab itself, and the tab right AFTER the active one
-   *      (the active side-stroke is already that seam's boundary). It does NOT hide
+   *      (--tab-divider:transparent) in exactly three cases — a tab with no left
+   *      neighbour (the strip's left edge), the active tab itself, and the tab right
+   *      AFTER the active one (the active side-stroke is already that seam's
+   *      boundary). The no-left-neighbour case is matched by adjacency (a .dv-tab
+   *      not preceded by another .dv-tab), NOT :first-child — a dockview-core patch
+   *      makes the "+" the container's first DOM child, so .dv-tab is never
+   *      :first-child here. It does NOT hide
    *      on hover: the hover pill is inset --tab-hover-inset from the seam, so the
    *      two never touch — which is why no hover adjacency rule is needed.
    *   2. Action-bar lead: the "+" cluster is its own action bar. Its divider is
    *      really "the seam to the right of the LAST tab", so it is treated IDENTICALLY
-   *      to an inter-tab seam — it sits AT that seam (the container margin claws back
-   *      the full --tab-edge-pad), so the last tab's hover pill clears it by
+   *      to an inter-tab seam — it sits AT that seam (the cluster's margin-left:0
+   *      keeps it flush against the last tab's right edge), so the last tab's hover pill clears it by
    *      --tab-hover-inset on both sides, exactly like a middle tab. padding-left
    *      sets the gap from the seam to the "+". And it hides by the SAME rule: when
-   *      the last tab is active, the active side-stroke is the boundary (via :has(),
-   *      since tabs and "+" sit in sibling containers a sibling selector can't span). */
+   *      the last tab is active, the active side-stroke is the boundary. The same
+   *      dockview-core patch moves the "+" INTO .dv-tabs-container (appended as its
+   *      first DOM child, ordered visually last), so the "+" is not a later sibling
+   *      of the last tab — the hide condition uses :has() as "an active tab with no
+   *      .dv-tab to its right", DOM-order-independent and not relying on :last-child. */
   /* VERTICAL lane */
   --tab-inset: 0.3125rem;
   /* The active crown/foot is a 1px stroke; single-sourced here so the hover-top
@@ -156,7 +163,7 @@
    * equi-proportionally — once that void is exhausted and N tabs would overflow, so
    * "add a tab" does nothing to the others until the strip is genuinely full. No
    * floor (min-width:0 on the tab). One knob, tune in dev. */
-  --tab-rest-width: 15.625rem;
+  --tab-rest-width: 10.9375rem;
   /* The ONE knob for label/close breathing room (they mirror each other). Label
    * left x = hover-inset + this; close glyph right x = the same. So both read as
    * `gutter` to the hover pill and `gutter + inset` to the active fill. Move both
@@ -238,12 +245,14 @@
    * arrow. dockview defaults .dv-tab to cursor:pointer;
    * the close button re-enables the pointer on itself only. */
   cursor: default;
-  /* Editor-tab measure: tabs REST at --tab-rest-width (the static upper bound) but
-   * SHRINK together, equi-proportionally, with NO floor — flex-shrink:1 and
-   * min-width:0, so however many tabs open they all stay on the strip, each one
-   * narrower, label truncating to a few glyphs (then the ellipsis) at the extreme
-   * rather than scrolling any off-screen. No fixed width/min-width any more: those
-   * pinned the tab and forced the old scroll-immediately-instead-of-shrink. */
+  /* Editor-tab measure: rest at --tab-rest-width, shrink together when full.
+   * flex: 0 1 rest — the tab's ideal size IS the rest width (basis), it never
+   * grows past it (grow:0), and it shrinks equi-proportionally with min-width:0
+   * when the strip can't fit every tab at rest width. This only works because the
+   * tab-strip containers below drop their overflow clipping (see .dv-scrollable /
+   * .dv-tabs-container rule): with overflow:visible their flex-basis:auto tracks
+   * the real content width (N × rest) instead of collapsing to 0, so the void
+   * can't steal space and crush the tabs while the strip is nowhere near full. */
   flex: 0 1 var(--tab-rest-width);
   min-width: 0;
   max-width: var(--tab-rest-width);
@@ -314,10 +323,18 @@
   z-index: 0;
   pointer-events: none;
 }
-/* Hide it where a boundary already reads: first tab (nothing to its left), the
- * active tab itself, and the tab right after the active one (the active side
- * stroke is that seam). */
-.dockview-theme-memoh .dv-tab:first-child::after,
+/* Hide it where a boundary already reads: a tab with no left neighbour (the
+ * strip's left edge — nothing to its left), the active tab itself, and the tab
+ * right after the active one (the active side-stroke is that seam).
+ *
+ * The no-left-neighbour case uses an additive adjacency selector — a ".dv-tab"
+ * NOT preceded by another ".dv-tab" — instead of :first-child. The dockview-core
+ * patch that moves the "+" into .dv-tabs-container appends it as the container's
+ * FIRST DOM child, so .dv-tab is never :first-child here; :first-child would never
+ * match and the first tab's seam would stay painted as a stray line at the strip's
+ * left edge. The adjacency form is DOM-order-independent: it just asks "is there a
+ * tab to my left", which is exactly the seam's presence condition. */
+.dockview-theme-memoh .dv-tab:not(.dv-tab + .dv-tab)::after,
 .dockview-theme-memoh .dv-tab.dv-active-tab::after,
 .dockview-theme-memoh .dv-tab.dv-active-tab + .dv-tab::after {
   --tab-divider: transparent;
@@ -331,15 +348,38 @@
   padding-inline: var(--tab-edge-pad);
 }
 
-/* The scroll container hugs its content while tabs rest at full width (so the "+"
- * lands right after the last tab and void fills the rest); it shrinks as the strip
- * fills up, letting the tabs inside shrink with it. min-width:0 lets that shrink
- * actually propagate to the tabs (which themselves have no floor), so the strip
- * absorbs any tab count by narrowing rather than scrolling. */
-.dockview-theme-memoh .dv-tabs-and-actions-container > .dv-scrollable,
-.dockview-theme-memoh .dv-scrollable > .dv-tabs-container {
-  flex: 0 1 auto;
+/* The tab strip GROWS to claim the available header width (flex:1 1 auto), so only
+ * the real overflow goes to the void. This is the fix for the two-tabs-crushed bug:
+ * with the strip at flex:0 1 ... (grow:0) its basis:auto sized to the tabs' natural
+ * (text) width, not N × rest-width, so the void (flex-grow:1) grabbed the slack and
+ * the tabs, floored at min-width:0, collapsed even when the strip was nowhere near
+ * full. Growing the strip gives it the real available width; the tabs hold rest
+ * width while there's room and shrink together (no scroll) once they'd overflow.
+ *
+ * scrollbars:'native' (set in chat-workspace.vue) makes .dv-tabs-container the
+ * header's direct flex child — there's no .dv-scrollable layer — so this rule
+ * targets it directly. The dockview-core patch moves the "+" (left-actions) INTO
+ * .dv-tabs-container, so it rides with the tabs and stays flush after the last one
+ * instead of being shoved to the far right by the strip's grow. overflow:visible
+ * drops upstream's scroll clip (disableTabsOverflowList is on, no scroll to clip). */
+.dockview-theme-memoh .dv-tabs-and-actions-container > .dv-tabs-container {
+  flex: 1 1 auto;
   min-width: 0;
+  overflow: visible;
+}
+
+/* Single tab locks to the rest width and does NOT shrink. Shrinking is a
+ * multi-tab affordance — when several tabs fill the strip they narrow together.
+ * A lone tab has nothing to make room for, so it must hold --tab-rest-width even
+ * with a short title (that IS the rest width's purpose); the empty void fills the
+ * rest of the strip. dockview adds .dv-single-tab to the header only while exactly
+ * one tab is present, so this reverts to the shrinking rule the moment a second
+ * tab opens. flex-shrink:0 + basis lets the tabs-container (basis:auto) hug it and
+ * the void (flex-grow:1) claim the slack, instead of the tab being compressed.
+ * Terminal chips are excluded — they keep their own narrower file-row measure. */
+.dockview-theme-memoh .dv-tabs-and-actions-container.dv-single-tab .dv-tab:not(:has(.memoh-terminal-tab)) {
+  flex: 0 0 var(--tab-rest-width);
+  min-width: var(--tab-rest-width);
 }
 
 /* No native/dockview horizontal scrollbar on the tab row (it clashed with the
@@ -425,16 +465,31 @@
   flex: 0 0 auto;
 }
 
-/* The "+" cluster (leftActions, header-add-actions.vue) is its own action bar: it
- * renders right after the tabs and carries a leading divider so it reads as a
- * separate zone, not another tab. The divider sits at the LAST TAB'S RIGHT SEAM
- * (margin claws back the full --tab-edge-pad), exactly like an inter-tab seam — so
- * the last tab's hover pill clears it by --tab-hover-inset on BOTH sides, same as a
- * middle tab. padding-left then sets the gap from that seam to the "+" button. */
+/* The "+" cluster (leftActions, header-add-actions.vue) is its own action bar,
+ * rendered as a separate zone after the tabs.
+ *
+ * A dockview-core patch moves this container INTO .dv-tabs-container (so it rides
+ * with the tabs and stays flush after the last one instead of being shoved right by
+ * the strip's flex-grow). The patch appends it at construction time, before any tab
+ * exists, so in DOM order it lands FIRST; order:1 (tabs default to order:0) sorts it
+ * visually AFTER every tab regardless of DOM position. flex:0 0 auto keeps it from
+ * joining the tabs' shrink when the strip overflows — the "+" keeps its size and the
+ * tabs narrow around it.
+ *
+ * margin-left:0 keeps the "+" flush against the LAST tab's right edge, so its lead
+ * divider (::before, painted at the container's left:0) lands exactly ON the seam —
+ * the same boundary the inter-tab ::after seams and the active tab's side-stroke
+ * sit on. The seam is the single geometric reference for the whole strip: every
+ * divider and every active edge aligns to it. A positive margin would push this
+ * divider off the seam and out of line with the active tab's edge (the "tail line
+ * sits too far right" symptom); a negative one would pull the "+" into the active
+ * tab's box. padding-left adds the breathing room from the seam to the "+" glyph. */
 .dockview-theme-memoh .dv-left-actions-container {
   position: relative;
-  margin-left: calc(-1 * var(--tab-edge-pad));
-  padding-left: calc(var(--tab-action-gap) + var(--tab-divider-width));
+  flex: 0 0 auto;
+  order: 1;
+  margin-left: 0;
+  padding-left: var(--tab-action-gap);
 }
 .dockview-theme-memoh .dv-left-actions-container::before {
   content: '';
@@ -448,11 +503,16 @@
   background-color: var(--dock-stroke);
   pointer-events: none;
 }
-/* Same rule as an inter-tab seam: when the LAST tab is active, its side stroke is
- * the boundary, so the lead divider hides. The padding-left stays, so the "+" does
- * NOT jump left when you select the last tab. :has() because the tabs and the "+"
- * sit in sibling containers no sibling selector can bridge. */
-.dockview-theme-memoh .dv-tabs-and-actions-container:has(.dv-tab:last-child.dv-active-tab) .dv-left-actions-container::before {
+/* Same rule as an inter-tab seam: when the LAST tab is active, its side-stroke is
+ * the boundary, so the lead divider hides. padding-left stays, so the "+" does NOT
+ * jump left when you select the last tab. The condition is "the active tab has no
+ * tab to its right" — expressed as :has(.dv-tab.dv-active-tab NOT followed by
+ * another .dv-tab) — which is DOM-order-independent and does not rely on
+ * :last-child (the patch appends the "+" as the first child, and dockview may also
+ * append non-tab children, so :last-child is fragile here). A plain sibling
+ * selector can't bridge the "+" and the last tab either, since the "+" sits at the
+ * FRONT of the container, not after the last tab — so :has() is the only reach. */
+.dockview-theme-memoh .dv-tabs-and-actions-container:has(.dv-tab.dv-active-tab):not(:has(.dv-tab.dv-active-tab ~ .dv-tab)) .dv-left-actions-container::before {
   content: none;
 }
 

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -6,6 +6,7 @@ WORKDIR /build
 RUN npm install -g pnpm@10
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches ./patches
 
 COPY packages ./packages
 COPY apps ./apps

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,114 @@
+# Dependency patches
+
+This directory contains pnpm patches that are applied during install. Treat each
+patch as a local upstream delta: keep it small, documented, and removable.
+
+## dockview-core@7.0.2.patch
+
+Why:
+
+`dockview-core` builds the single-tab drag ghost by cloning the live docked tab
+DOM, then hard-codes the ghost offset as `offsetX: 30`.
+
+Both defaults fight Memoh's editor chrome:
+
+- The cloned DOM includes strip-only layout pieces such as the close slot,
+  active-tab shape, and lane padding. Once that structure is inside the floating
+  drag chip, the title cannot be centered reliably with app CSS.
+- The 30px horizontal offset places the chip partly to the left of the pointer.
+  VS Code's single editor-tab drag image anchors the tab at the pointer's
+  top-left (`setDragImage(tab, 0, 0)`), which is the behavior we want for Memoh
+  tabs.
+
+Scope:
+
+Only the single-tab ghost path is patched:
+
+- `createGhost()` keeps upstream `offsetY: -10` but changes `offsetX: 30` to
+  `offsetX: 0`.
+- `_buildGhostElement()` now creates a minimal title-only ghost element with a
+  `.dv-tab-ghost-label` child instead of `cloneNode(true)`.
+
+The same single-tab change is applied to every non-minified runtime entry that a
+bundler may resolve:
+
+- `dist/package/main.esm.mjs`
+- `dist/package/main.cjs.js`
+- `dist/esm/dockview/components/tab/tab.js`
+- `dist/cjs/dockview/components/tab/tab.js`
+
+The multi-panel/group drag ghosts keep upstream's `offsetX: 30` and default
+renderers.
+
+Remove when:
+
+`dockview-core` exposes single-tab drag ghost customization/offset options, or
+upstream stops cloning the docked tab for the single-tab ghost and no longer
+bleeds the chip left of the pointer.
+
+Upgrade checklist:
+
+1. Upgrade `dockview-vue` / `dockview` / `dockview-core`.
+2. Check the installed `dist/package/main.esm.mjs` for `_buildGhostElement()` and
+   all `offsetX` call sites.
+3. Recreate the smallest version-specific patch with `pnpm patch dockview-core@x.y.z`.
+4. Apply the same single-tab ghost change to the package ESM/CJS entries and the
+   per-module ESM/CJS `dockview/components/tab/tab.js` entries. Vite can expose
+   either path through dependency optimization.
+5. Confirm the single-tab ghost no longer uses `cloneNode(true)` in all four
+   patched entries.
+6. Confirm only the single-tab offset changed; group/multi-panel offsets stay at
+   `30`.
+7. Clear Vite caches and drag one editor tab plus one multi-panel/group ghost in
+   the app.
+
+Useful checks:
+
+```bash
+grep -n "offsetX" patches/dockview-core@7.0.2.patch
+grep -n "cloneNode\\|dv-tab-ghost-label" patches/dockview-core@7.0.2.patch
+find node_modules/.pnpm -maxdepth 1 -type d -name 'dockview-core@7.0.2*'
+rg -n "offsetX: 0|offsetX: 30|cloneNode|dv-tab-ghost-label|_buildGhostElement|buildMultiPanelsGhost" \
+  node_modules/.pnpm/dockview-core@7.0.2*/node_modules/dockview-core/dist/package/main.esm.mjs \
+  node_modules/.pnpm/dockview-core@7.0.2*/node_modules/dockview-core/dist/package/main.cjs.js \
+  node_modules/.pnpm/dockview-core@7.0.2*/node_modules/dockview-core/dist/esm/dockview/components/tab/tab.js \
+  node_modules/.pnpm/dockview-core@7.0.2*/node_modules/dockview-core/dist/cjs/dockview/components/tab/tab.js
+```
+
+## dockview-vue@7.0.2.patch
+
+Why:
+
+`dockview-vue@7.0.2` enriches header action params with `api`,
+`containerApi`, `group`, `panels`, and `activePanel` when the header action
+component mounts. On a group location change, its ESM runtime updates the Vue
+component with only `{ location }`, replacing the complete params object. Memoh's
+header action components need `group` and `panels`, so the app crashes after that
+location-only update.
+
+Scope:
+
+Only the ESM runtime entry used by Vite (`dist/dockview-vue.es.js`) is patched.
+`updateLocation(location)` now sends the complete enriched params plus the new
+location instead of replacing params with `{ location }`.
+
+Remove when:
+
+`dockview-vue` upstream changes `updateLocation` to preserve the full header
+action props, or Memoh no longer uses header action components that depend on
+the enriched params.
+
+Upgrade checklist:
+
+1. Check the new `dockview-vue` runtime for `updateLocation(location)`.
+2. If it still updates with `{ params: { location } }`, recreate this small patch.
+3. Start the app and confirm `header-add-actions.vue` no longer crashes with
+   `Cannot read properties of undefined (reading 'panels')`.
+
+Useful checks:
+
+```bash
+grep -n "updateLocation" patches/dockview-vue@7.0.2.patch
+rg -n "Memoh patch: keep the complete header-action params|params: \\{ location \\}" \
+  node_modules/.pnpm/dockview-vue@7.0.2*/node_modules/dockview-vue/dist/dockview-vue.es.js
+```

--- a/patches/README.md
+++ b/patches/README.md
@@ -40,27 +40,35 @@ bundler may resolve:
 The multi-panel/group drag ghosts keep upstream's `offsetX: 30` and default
 renderers.
 
-A second, independent change moves the "+" (left-actions) container INTO
-`.dv-tabs-container` at construction time — `this.tabs.element.appendChild(
-this.leftActionsContainer)` instead of `this._element.appendChild(...)` — so the
-"+" rides with the tabs and stays flush after the last tab instead of being shoved
-to the strip's far right by the tab strip's `flex:1 1 auto` grow. The same move is
-applied to all four entries above plus `dist/{esm,cjs}/dockview/components/titlebar/
-tabsContainer.js`. The tab strip CSS in `apps/web/src/styles/dockview-theme.css`
-depends on this DOM change: the "+" is the container's first DOM child (ordered
-visually last via `order:1`), and its lead divider (`::before`) sits on the seam at
-the last tab's right edge. The inter-tab seam and first-tab hide rules there use
-adjacency selectors (not `:first-child`) precisely because this patch makes the "+"
-the first DOM child.
+A second, independent change moves BOTH the "+" (left-actions) container AND the
+void (header empty-space drop region) INTO `.dv-tabs-container` at construction
+time — `this.tabs.element.appendChild(this.leftActionsContainer)` and
+`this.tabs.element.appendChild(this.voidContainer.element)` instead of
+`this._element.appendChild(...)`. The tab strip grows (`flex:1 1 auto`) to fill the
+header; with the "+" and void inside it, the strip's children are `[+, tab1..tabN,
+void]`. The "+" stays flush after the last tab, and the void (flex-grow:1) claims
+all the strip's grown slack — so the whole blank stretch to the right of the last
+tab is the droppable void (dockview paints its default drop wash over it), not a
+dead non-droppable gap. Before the move that slack belonged to the tabs-container
+itself and the void was pinned to a sliver at the far right, so dropping a tab on
+the blank header area gave no feedback. The same move is applied to all four
+entries above plus `dist/{esm,cjs}/dockview/components/titlebar/tabsContainer.js`.
+
+The tab strip CSS in `apps/web/src/styles/dockview-theme.css` depends on this DOM
+change: the "+" and void are the container's first DOM children (both appended
+before any tab), ordered visually last via `order:1`/`order:2`; the "+"'s lead
+divider (`::before`) sits on the seam at the last tab's right edge. The inter-tab
+seam and first-tab hide rules there use adjacency selectors (not `:first-child`)
+precisely because this patch makes the "+" the first DOM child.
 
 Remove when:
 
 `dockview-core` exposes single-tab drag ghost customization/offset options, or
 upstream stops cloning the docked tab for the single-tab ghost and no longer
-bleeds the chip left of the pointer; and dockview-core lets the "+" actions
-container ride with the tabs (or Memoh stops growing the tab strip with
-`flex:1 1 auto`), so the relocate patch is no longer needed to keep the "+"
-flush after the last tab.
+bleeds the chip left of the pointer; and dockview-core lets the "+" actions and
+void ride with the tabs (or Memoh stops growing the tab strip with `flex:1 1
+auto`), so the relocate patch is no longer needed to keep the "+" flush after the
+last tab and the void spanning the blank header stretch.
 
 Upgrade checklist:
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -40,11 +40,27 @@ bundler may resolve:
 The multi-panel/group drag ghosts keep upstream's `offsetX: 30` and default
 renderers.
 
+A second, independent change moves the "+" (left-actions) container INTO
+`.dv-tabs-container` at construction time — `this.tabs.element.appendChild(
+this.leftActionsContainer)` instead of `this._element.appendChild(...)` — so the
+"+" rides with the tabs and stays flush after the last tab instead of being shoved
+to the strip's far right by the tab strip's `flex:1 1 auto` grow. The same move is
+applied to all four entries above plus `dist/{esm,cjs}/dockview/components/titlebar/
+tabsContainer.js`. The tab strip CSS in `apps/web/src/styles/dockview-theme.css`
+depends on this DOM change: the "+" is the container's first DOM child (ordered
+visually last via `order:1`), and its lead divider (`::before`) sits on the seam at
+the last tab's right edge. The inter-tab seam and first-tab hide rules there use
+adjacency selectors (not `:first-child`) precisely because this patch makes the "+"
+the first DOM child.
+
 Remove when:
 
 `dockview-core` exposes single-tab drag ghost customization/offset options, or
 upstream stops cloning the docked tab for the single-tab ghost and no longer
-bleeds the chip left of the pointer.
+bleeds the chip left of the pointer; and dockview-core lets the "+" actions
+container ride with the tabs (or Memoh stops growing the tab strip with
+`flex:1 1 auto`), so the relocate patch is no longer needed to keep the "+"
+flush after the last tab.
 
 Upgrade checklist:
 
@@ -67,6 +83,7 @@ Useful checks:
 ```bash
 grep -n "offsetX" patches/dockview-core@7.0.2.patch
 grep -n "cloneNode\\|dv-tab-ghost-label" patches/dockview-core@7.0.2.patch
+grep -n "leftActionsContainer" patches/dockview-core@7.0.2.patch
 find node_modules/.pnpm -maxdepth 1 -type d -name 'dockview-core@7.0.2*'
 rg -n "offsetX: 0|offsetX: 30|cloneNode|dv-tab-ghost-label|_buildGhostElement|buildMultiPanelsGhost" \
   node_modules/.pnpm/dockview-core@7.0.2*/node_modules/dockview-core/dist/package/main.esm.mjs \

--- a/patches/dockview-core@7.0.2.patch
+++ b/patches/dockview-core@7.0.2.patch
@@ -1,0 +1,273 @@
+diff --git a/dist/cjs/dockview/components/tab/tab.js b/dist/cjs/dockview/components/tab/tab.js
+index 5ef6b36c6f9122cf6ab20d7ebf7be48713fef42c..70d9b827f8e2c5e196a243b212e618ceef2d9b1c 100644
+--- a/dist/cjs/dockview/components/tab/tab.js
++++ b/dist/cjs/dockview/components/tab/tab.js
+@@ -120,7 +120,7 @@ var Tab = /** @class */ (function (_super) {
+             // HTML5 backend feeds into setDragImage.
+             createGhost: function () { return ({
+                 element: _this._buildGhostElement(),
+-                offsetX: 30,
++                offsetX: 0,
+                 offsetY: -10,
+             }); },
+             onDragStart: function (event) {
+@@ -238,40 +238,20 @@ var Tab = /** @class */ (function (_super) {
+      */
+     Tab.prototype._buildGhostElement = function () {
+         var style = getComputedStyle(this.element);
+-        var newNode = this.element.cloneNode(true);
++        var rect = this.element.getBoundingClientRect();
+         var isVertical = this._direction === 'vertical';
+-        var verticalSkip = new Set([
+-            'writing-mode',
+-            'inline-size',
+-            'block-size',
+-            'min-inline-size',
+-            'min-block-size',
+-            'max-inline-size',
+-            'max-block-size',
+-            'margin-inline',
+-            'margin-inline-start',
+-            'margin-inline-end',
+-            'margin-block',
+-            'margin-block-start',
+-            'margin-block-end',
+-            'padding-inline',
+-            'padding-inline-start',
+-            'padding-inline-end',
+-            'padding-block',
+-            'padding-block-start',
+-            'padding-block-end',
+-        ]);
+-        Array.from(style).forEach(function (key) {
+-            if (isVertical && verticalSkip.has(key)) {
+-                return;
+-            }
+-            newNode.style.setProperty(key, style.getPropertyValue(key), style.getPropertyPriority(key));
+-        });
+-        if (isVertical) {
+-            newNode.style.setProperty('writing-mode', 'horizontal-tb');
+-            newNode.style.setProperty('width', style.height);
+-            newNode.style.setProperty('height', style.width);
+-        }
++        var newNode = document.createElement('div');
++        var label = document.createElement('span');
++        label.className = 'dv-tab-ghost-label';
++        label.textContent = this.panel.title;
++        newNode.appendChild(label);
++        newNode.style.width = 'max-content';
++        newNode.style.maxWidth = "".concat(Math.round(isVertical ? rect.height : rect.width), "px");
++        newNode.style.height = "".concat(Math.round(isVertical ? rect.width : rect.height), "px");
++        newNode.style.fontFamily = style.fontFamily;
++        newNode.style.fontSize = style.fontSize;
++        newNode.style.fontWeight = style.fontWeight;
++        newNode.style.lineHeight = style.lineHeight;
+         newNode.style.position = 'absolute';
+         newNode.classList.add('dv-tab-ghost-drag');
+         return newNode;
+diff --git a/dist/esm/dockview/components/tab/tab.js b/dist/esm/dockview/components/tab/tab.js
+index 36e6dac68b89160a6fae84d06823a9b0b14531fc..407e077e30fd8d7351d8f26ce03b2b3e994dda32 100644
+--- a/dist/esm/dockview/components/tab/tab.js
++++ b/dist/esm/dockview/components/tab/tab.js
+@@ -93,7 +93,7 @@ export class Tab extends CompositeDisposable {
+             // HTML5 backend feeds into setDragImage.
+             createGhost: () => ({
+                 element: this._buildGhostElement(),
+-                offsetX: 30,
++                offsetX: 0,
+                 offsetY: -10,
+             }),
+             onDragStart: (event) => {
+@@ -201,40 +201,20 @@ export class Tab extends CompositeDisposable {
+      */
+     _buildGhostElement() {
+         const style = getComputedStyle(this.element);
+-        const newNode = this.element.cloneNode(true);
++        const rect = this.element.getBoundingClientRect();
+         const isVertical = this._direction === 'vertical';
+-        const verticalSkip = new Set([
+-            'writing-mode',
+-            'inline-size',
+-            'block-size',
+-            'min-inline-size',
+-            'min-block-size',
+-            'max-inline-size',
+-            'max-block-size',
+-            'margin-inline',
+-            'margin-inline-start',
+-            'margin-inline-end',
+-            'margin-block',
+-            'margin-block-start',
+-            'margin-block-end',
+-            'padding-inline',
+-            'padding-inline-start',
+-            'padding-inline-end',
+-            'padding-block',
+-            'padding-block-start',
+-            'padding-block-end',
+-        ]);
+-        Array.from(style).forEach((key) => {
+-            if (isVertical && verticalSkip.has(key)) {
+-                return;
+-            }
+-            newNode.style.setProperty(key, style.getPropertyValue(key), style.getPropertyPriority(key));
+-        });
+-        if (isVertical) {
+-            newNode.style.setProperty('writing-mode', 'horizontal-tb');
+-            newNode.style.setProperty('width', style.height);
+-            newNode.style.setProperty('height', style.width);
+-        }
++        const newNode = document.createElement('div');
++        const label = document.createElement('span');
++        label.className = 'dv-tab-ghost-label';
++        label.textContent = this.panel.title;
++        newNode.appendChild(label);
++        newNode.style.width = 'max-content';
++        newNode.style.maxWidth = `${Math.round(isVertical ? rect.height : rect.width)}px`;
++        newNode.style.height = `${Math.round(isVertical ? rect.width : rect.height)}px`;
++        newNode.style.fontFamily = style.fontFamily;
++        newNode.style.fontSize = style.fontSize;
++        newNode.style.fontWeight = style.fontWeight;
++        newNode.style.lineHeight = style.lineHeight;
+         newNode.style.position = 'absolute';
+         newNode.classList.add('dv-tab-ghost-drag');
+         return newNode;
+diff --git a/dist/package/main.cjs.js b/dist/package/main.cjs.js
+index 3fcff2589d724e46832c1105c674aaf69f37f5b2..8f2aa335fa8e28687f82ab214212c6e7570fd2ae 100644
+--- a/dist/package/main.cjs.js
++++ b/dist/package/main.cjs.js
+@@ -6274,7 +6274,7 @@ class Tab extends CompositeDisposable {
+             // HTML5 backend feeds into setDragImage.
+             createGhost: () => ({
+                 element: this._buildGhostElement(),
+-                offsetX: 30,
++                offsetX: 0,
+                 offsetY: -10,
+             }),
+             onDragStart: (event) => {
+@@ -6382,40 +6382,20 @@ class Tab extends CompositeDisposable {
+      */
+     _buildGhostElement() {
+         const style = getComputedStyle(this.element);
+-        const newNode = this.element.cloneNode(true);
++        const rect = this.element.getBoundingClientRect();
+         const isVertical = this._direction === 'vertical';
+-        const verticalSkip = new Set([
+-            'writing-mode',
+-            'inline-size',
+-            'block-size',
+-            'min-inline-size',
+-            'min-block-size',
+-            'max-inline-size',
+-            'max-block-size',
+-            'margin-inline',
+-            'margin-inline-start',
+-            'margin-inline-end',
+-            'margin-block',
+-            'margin-block-start',
+-            'margin-block-end',
+-            'padding-inline',
+-            'padding-inline-start',
+-            'padding-inline-end',
+-            'padding-block',
+-            'padding-block-start',
+-            'padding-block-end',
+-        ]);
+-        Array.from(style).forEach((key) => {
+-            if (isVertical && verticalSkip.has(key)) {
+-                return;
+-            }
+-            newNode.style.setProperty(key, style.getPropertyValue(key), style.getPropertyPriority(key));
+-        });
+-        if (isVertical) {
+-            newNode.style.setProperty('writing-mode', 'horizontal-tb');
+-            newNode.style.setProperty('width', style.height);
+-            newNode.style.setProperty('height', style.width);
+-        }
++        const newNode = document.createElement('div');
++        const label = document.createElement('span');
++        label.className = 'dv-tab-ghost-label';
++        label.textContent = this.panel.title;
++        newNode.appendChild(label);
++        newNode.style.width = 'max-content';
++        newNode.style.maxWidth = `${Math.round(isVertical ? rect.height : rect.width)}px`;
++        newNode.style.height = `${Math.round(isVertical ? rect.width : rect.height)}px`;
++        newNode.style.fontFamily = style.fontFamily;
++        newNode.style.fontSize = style.fontSize;
++        newNode.style.fontWeight = style.fontWeight;
++        newNode.style.lineHeight = style.lineHeight;
+         newNode.style.position = 'absolute';
+         newNode.classList.add('dv-tab-ghost-drag');
+         return newNode;
+diff --git a/dist/package/main.esm.mjs b/dist/package/main.esm.mjs
+index 47d091027d89b9da241bdbc53d72f32c1e173719..9a3d2cb837695a7955db9c073f1ca2a86b730235 100644
+--- a/dist/package/main.esm.mjs
++++ b/dist/package/main.esm.mjs
+@@ -6268,9 +6268,12 @@ class Tab extends CompositeDisposable {
+             // 30/-10 matches the HTML5 setDragImage offset that has been
+             // shipped for years; pointer backend wraps in PointerGhost,
+             // HTML5 backend feeds into setDragImage.
++            // Memoh patch: align the single-tab drag chip with the pointer
++            // horizontally. dockview-core hard-codes this value and does not expose
++            // a single-tab ghost offset option.
+             createGhost: () => ({
+                 element: this._buildGhostElement(),
+-                offsetX: 30,
++                offsetX: 0,
+                 offsetY: -10,
+             }),
+             onDragStart: (event) => {
+@@ -6378,40 +6381,20 @@ class Tab extends CompositeDisposable {
+      */
+     _buildGhostElement() {
+         const style = getComputedStyle(this.element);
+-        const newNode = this.element.cloneNode(true);
++        const rect = this.element.getBoundingClientRect();
+         const isVertical = this._direction === 'vertical';
+-        const verticalSkip = new Set([
+-            'writing-mode',
+-            'inline-size',
+-            'block-size',
+-            'min-inline-size',
+-            'min-block-size',
+-            'max-inline-size',
+-            'max-block-size',
+-            'margin-inline',
+-            'margin-inline-start',
+-            'margin-inline-end',
+-            'margin-block',
+-            'margin-block-start',
+-            'margin-block-end',
+-            'padding-inline',
+-            'padding-inline-start',
+-            'padding-inline-end',
+-            'padding-block',
+-            'padding-block-start',
+-            'padding-block-end',
+-        ]);
+-        Array.from(style).forEach((key) => {
+-            if (isVertical && verticalSkip.has(key)) {
+-                return;
+-            }
+-            newNode.style.setProperty(key, style.getPropertyValue(key), style.getPropertyPriority(key));
+-        });
+-        if (isVertical) {
+-            newNode.style.setProperty('writing-mode', 'horizontal-tb');
+-            newNode.style.setProperty('width', style.height);
+-            newNode.style.setProperty('height', style.width);
+-        }
++        const newNode = document.createElement('div');
++        const label = document.createElement('span');
++        label.className = 'dv-tab-ghost-label';
++        label.textContent = this.panel.title;
++        newNode.appendChild(label);
++        newNode.style.width = 'max-content';
++        newNode.style.maxWidth = `${Math.round(isVertical ? rect.height : rect.width)}px`;
++        newNode.style.height = `${Math.round(isVertical ? rect.width : rect.height)}px`;
++        newNode.style.fontFamily = style.fontFamily;
++        newNode.style.fontSize = style.fontSize;
++        newNode.style.fontWeight = style.fontWeight;
++        newNode.style.lineHeight = style.lineHeight;
+         newNode.style.position = 'absolute';
+         newNode.classList.add('dv-tab-ghost-drag');
+         return newNode;

--- a/patches/dockview-core@7.0.2.patch
+++ b/patches/dockview-core@7.0.2.patch
@@ -66,18 +66,20 @@ index 5ef6b36c6f9122cf6ab20d7ebf7be48713fef42c..af028bfead0413a5578a30af3f8016da
          newNode.classList.add('dv-tab-ghost-drag');
          return newNode;
 diff --git a/dist/cjs/dockview/components/titlebar/tabsContainer.js b/dist/cjs/dockview/components/titlebar/tabsContainer.js
-index fc86b4df69c9da5a4c8c554a61865dd8bec38b84..0d37da98817990dac066a7d1bf97ff59ed4e174c 100644
+index fc86b4df69c9da5a4c8c554a61865dd8bec38b84..3b330387a13ba4c5e48ace97e2bad6e501a391e9 100644
 --- a/dist/cjs/dockview/components/titlebar/tabsContainer.js
 +++ b/dist/cjs/dockview/components/titlebar/tabsContainer.js
-@@ -70,7 +70,7 @@ var TabsContainer = /** @class */ (function (_super) {
+@@ -70,8 +70,8 @@ var TabsContainer = /** @class */ (function (_super) {
          _this.tabs.voidContainer = _this.voidContainer.element;
          _this._element.appendChild(_this.preActionsContainer);
          _this._element.appendChild(_this.tabs.element);
 -        _this._element.appendChild(_this.leftActionsContainer);
+-        _this._element.appendChild(_this.voidContainer.element);
 +        _this.tabs.element.appendChild(_this.leftActionsContainer);
-         _this._element.appendChild(_this.voidContainer.element);
++        _this.tabs.element.appendChild(_this.voidContainer.element);
          _this._element.appendChild(_this.rightActionsContainer);
          _this.tabs.setExtendedDropZone(_this._element);
+         _this.addDisposables(_this.tabs.onDrop(function (e) { return _this._onDrop.fire(e); }), _this.tabs.onWillShowOverlay(function (e) { return _this._onWillShowOverlay.fire(e); }), accessor.onDidOptionsChange(function () {
 diff --git a/dist/esm/dockview/components/tab/tab.js b/dist/esm/dockview/components/tab/tab.js
 index 36e6dac68b89160a6fae84d06823a9b0b14531fc..f80c40358e239b95eda072d42d374f968b0e9f5c 100644
 --- a/dist/esm/dockview/components/tab/tab.js
@@ -146,20 +148,22 @@ index 36e6dac68b89160a6fae84d06823a9b0b14531fc..f80c40358e239b95eda072d42d374f96
          newNode.classList.add('dv-tab-ghost-drag');
          return newNode;
 diff --git a/dist/esm/dockview/components/titlebar/tabsContainer.js b/dist/esm/dockview/components/titlebar/tabsContainer.js
-index eb22fffb3a2482d27dfb4cc99abbbbef93e43d8a..a88b8bc384c63791aa5d821edca4de87354a3e59 100644
+index eb22fffb3a2482d27dfb4cc99abbbbef93e43d8a..c288c898c3c3c0e44165ce0e290542464d68c893 100644
 --- a/dist/esm/dockview/components/titlebar/tabsContainer.js
 +++ b/dist/esm/dockview/components/titlebar/tabsContainer.js
-@@ -75,7 +75,7 @@ export class TabsContainer extends CompositeDisposable {
+@@ -75,8 +75,8 @@ export class TabsContainer extends CompositeDisposable {
          this.tabs.voidContainer = this.voidContainer.element;
          this._element.appendChild(this.preActionsContainer);
          this._element.appendChild(this.tabs.element);
 -        this._element.appendChild(this.leftActionsContainer);
+-        this._element.appendChild(this.voidContainer.element);
 +        this.tabs.element.appendChild(this.leftActionsContainer);
-         this._element.appendChild(this.voidContainer.element);
++        this.tabs.element.appendChild(this.voidContainer.element);
          this._element.appendChild(this.rightActionsContainer);
          this.tabs.setExtendedDropZone(this._element);
+         this.addDisposables(this.tabs.onDrop((e) => this._onDrop.fire(e)), this.tabs.onWillShowOverlay((e) => this._onWillShowOverlay.fire(e)), accessor.onDidOptionsChange(() => {
 diff --git a/dist/package/main.cjs.js b/dist/package/main.cjs.js
-index 3fcff2589d724e46832c1105c674aaf69f37f5b2..a285400707803a38537a8e1d4de0726a7fc0a5c6 100644
+index 3fcff2589d724e46832c1105c674aaf69f37f5b2..c68038c5230f242f13fc21bbf14fbaa7e421c3d0 100644
 --- a/dist/package/main.cjs.js
 +++ b/dist/package/main.cjs.js
 @@ -6274,7 +6274,7 @@ class Tab extends CompositeDisposable {
@@ -225,17 +229,19 @@ index 3fcff2589d724e46832c1105c674aaf69f37f5b2..a285400707803a38537a8e1d4de0726a
          newNode.style.position = 'absolute';
          newNode.classList.add('dv-tab-ghost-drag');
          return newNode;
-@@ -9728,7 +9708,7 @@ class TabsContainer extends CompositeDisposable {
+@@ -9728,8 +9708,8 @@ class TabsContainer extends CompositeDisposable {
          this.tabs.voidContainer = this.voidContainer.element;
          this._element.appendChild(this.preActionsContainer);
          this._element.appendChild(this.tabs.element);
 -        this._element.appendChild(this.leftActionsContainer);
+-        this._element.appendChild(this.voidContainer.element);
 +        this.tabs.element.appendChild(this.leftActionsContainer);
-         this._element.appendChild(this.voidContainer.element);
++        this.tabs.element.appendChild(this.voidContainer.element);
          this._element.appendChild(this.rightActionsContainer);
          this.tabs.setExtendedDropZone(this._element);
+         this.addDisposables(this.tabs.onDrop((e) => this._onDrop.fire(e)), this.tabs.onWillShowOverlay((e) => this._onWillShowOverlay.fire(e)), accessor.onDidOptionsChange(() => {
 diff --git a/dist/package/main.esm.mjs b/dist/package/main.esm.mjs
-index 47d091027d89b9da241bdbc53d72f32c1e173719..8b67dfa14b38fc62659c1ae5c86e5543835627f2 100644
+index 47d091027d89b9da241bdbc53d72f32c1e173719..2e121eae968abea7b58f1a9d376f1e7e1fc07bb8 100644
 --- a/dist/package/main.esm.mjs
 +++ b/dist/package/main.esm.mjs
 @@ -6268,9 +6268,12 @@ class Tab extends CompositeDisposable {
@@ -306,12 +312,14 @@ index 47d091027d89b9da241bdbc53d72f32c1e173719..8b67dfa14b38fc62659c1ae5c86e5543
          newNode.style.position = 'absolute';
          newNode.classList.add('dv-tab-ghost-drag');
          return newNode;
-@@ -9724,7 +9707,7 @@ class TabsContainer extends CompositeDisposable {
+@@ -9724,8 +9707,8 @@ class TabsContainer extends CompositeDisposable {
          this.tabs.voidContainer = this.voidContainer.element;
          this._element.appendChild(this.preActionsContainer);
          this._element.appendChild(this.tabs.element);
 -        this._element.appendChild(this.leftActionsContainer);
+-        this._element.appendChild(this.voidContainer.element);
 +        this.tabs.element.appendChild(this.leftActionsContainer);
-         this._element.appendChild(this.voidContainer.element);
++        this.tabs.element.appendChild(this.voidContainer.element);
          this._element.appendChild(this.rightActionsContainer);
          this.tabs.setExtendedDropZone(this._element);
+         this.addDisposables(this.tabs.onDrop((e) => this._onDrop.fire(e)), this.tabs.onWillShowOverlay((e) => this._onWillShowOverlay.fire(e)), accessor.onDidOptionsChange(() => {

--- a/patches/dockview-core@7.0.2.patch
+++ b/patches/dockview-core@7.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/cjs/dockview/components/tab/tab.js b/dist/cjs/dockview/components/tab/tab.js
-index 5ef6b36c6f9122cf6ab20d7ebf7be48713fef42c..70d9b827f8e2c5e196a243b212e618ceef2d9b1c 100644
+index 5ef6b36c6f9122cf6ab20d7ebf7be48713fef42c..af028bfead0413a5578a30af3f8016dacb2088ec 100644
 --- a/dist/cjs/dockview/components/tab/tab.js
 +++ b/dist/cjs/dockview/components/tab/tab.js
 @@ -120,7 +120,7 @@ var Tab = /** @class */ (function (_super) {
@@ -65,8 +65,21 @@ index 5ef6b36c6f9122cf6ab20d7ebf7be48713fef42c..70d9b827f8e2c5e196a243b212e618ce
          newNode.style.position = 'absolute';
          newNode.classList.add('dv-tab-ghost-drag');
          return newNode;
+diff --git a/dist/cjs/dockview/components/titlebar/tabsContainer.js b/dist/cjs/dockview/components/titlebar/tabsContainer.js
+index fc86b4df69c9da5a4c8c554a61865dd8bec38b84..0d37da98817990dac066a7d1bf97ff59ed4e174c 100644
+--- a/dist/cjs/dockview/components/titlebar/tabsContainer.js
++++ b/dist/cjs/dockview/components/titlebar/tabsContainer.js
+@@ -70,7 +70,7 @@ var TabsContainer = /** @class */ (function (_super) {
+         _this.tabs.voidContainer = _this.voidContainer.element;
+         _this._element.appendChild(_this.preActionsContainer);
+         _this._element.appendChild(_this.tabs.element);
+-        _this._element.appendChild(_this.leftActionsContainer);
++        _this.tabs.element.appendChild(_this.leftActionsContainer);
+         _this._element.appendChild(_this.voidContainer.element);
+         _this._element.appendChild(_this.rightActionsContainer);
+         _this.tabs.setExtendedDropZone(_this._element);
 diff --git a/dist/esm/dockview/components/tab/tab.js b/dist/esm/dockview/components/tab/tab.js
-index 36e6dac68b89160a6fae84d06823a9b0b14531fc..407e077e30fd8d7351d8f26ce03b2b3e994dda32 100644
+index 36e6dac68b89160a6fae84d06823a9b0b14531fc..f80c40358e239b95eda072d42d374f968b0e9f5c 100644
 --- a/dist/esm/dockview/components/tab/tab.js
 +++ b/dist/esm/dockview/components/tab/tab.js
 @@ -93,7 +93,7 @@ export class Tab extends CompositeDisposable {
@@ -132,8 +145,21 @@ index 36e6dac68b89160a6fae84d06823a9b0b14531fc..407e077e30fd8d7351d8f26ce03b2b3e
          newNode.style.position = 'absolute';
          newNode.classList.add('dv-tab-ghost-drag');
          return newNode;
+diff --git a/dist/esm/dockview/components/titlebar/tabsContainer.js b/dist/esm/dockview/components/titlebar/tabsContainer.js
+index eb22fffb3a2482d27dfb4cc99abbbbef93e43d8a..a88b8bc384c63791aa5d821edca4de87354a3e59 100644
+--- a/dist/esm/dockview/components/titlebar/tabsContainer.js
++++ b/dist/esm/dockview/components/titlebar/tabsContainer.js
+@@ -75,7 +75,7 @@ export class TabsContainer extends CompositeDisposable {
+         this.tabs.voidContainer = this.voidContainer.element;
+         this._element.appendChild(this.preActionsContainer);
+         this._element.appendChild(this.tabs.element);
+-        this._element.appendChild(this.leftActionsContainer);
++        this.tabs.element.appendChild(this.leftActionsContainer);
+         this._element.appendChild(this.voidContainer.element);
+         this._element.appendChild(this.rightActionsContainer);
+         this.tabs.setExtendedDropZone(this._element);
 diff --git a/dist/package/main.cjs.js b/dist/package/main.cjs.js
-index 3fcff2589d724e46832c1105c674aaf69f37f5b2..8f2aa335fa8e28687f82ab214212c6e7570fd2ae 100644
+index 3fcff2589d724e46832c1105c674aaf69f37f5b2..a285400707803a38537a8e1d4de0726a7fc0a5c6 100644
 --- a/dist/package/main.cjs.js
 +++ b/dist/package/main.cjs.js
 @@ -6274,7 +6274,7 @@ class Tab extends CompositeDisposable {
@@ -199,8 +225,17 @@ index 3fcff2589d724e46832c1105c674aaf69f37f5b2..8f2aa335fa8e28687f82ab214212c6e7
          newNode.style.position = 'absolute';
          newNode.classList.add('dv-tab-ghost-drag');
          return newNode;
+@@ -9728,7 +9708,7 @@ class TabsContainer extends CompositeDisposable {
+         this.tabs.voidContainer = this.voidContainer.element;
+         this._element.appendChild(this.preActionsContainer);
+         this._element.appendChild(this.tabs.element);
+-        this._element.appendChild(this.leftActionsContainer);
++        this.tabs.element.appendChild(this.leftActionsContainer);
+         this._element.appendChild(this.voidContainer.element);
+         this._element.appendChild(this.rightActionsContainer);
+         this.tabs.setExtendedDropZone(this._element);
 diff --git a/dist/package/main.esm.mjs b/dist/package/main.esm.mjs
-index 47d091027d89b9da241bdbc53d72f32c1e173719..9a3d2cb837695a7955db9c073f1ca2a86b730235 100644
+index 47d091027d89b9da241bdbc53d72f32c1e173719..8b67dfa14b38fc62659c1ae5c86e5543835627f2 100644
 --- a/dist/package/main.esm.mjs
 +++ b/dist/package/main.esm.mjs
 @@ -6268,9 +6268,12 @@ class Tab extends CompositeDisposable {
@@ -271,3 +306,12 @@ index 47d091027d89b9da241bdbc53d72f32c1e173719..9a3d2cb837695a7955db9c073f1ca2a8
          newNode.style.position = 'absolute';
          newNode.classList.add('dv-tab-ghost-drag');
          return newNode;
+@@ -9724,7 +9707,7 @@ class TabsContainer extends CompositeDisposable {
+         this.tabs.voidContainer = this.voidContainer.element;
+         this._element.appendChild(this.preActionsContainer);
+         this._element.appendChild(this.tabs.element);
+-        this._element.appendChild(this.leftActionsContainer);
++        this.tabs.element.appendChild(this.leftActionsContainer);
+         this._element.appendChild(this.voidContainer.element);
+         this._element.appendChild(this.rightActionsContainer);
+         this.tabs.setExtendedDropZone(this._element);

--- a/patches/dockview-vue@7.0.2.patch
+++ b/patches/dockview-vue@7.0.2.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/dockview-vue.es.js b/dist/dockview-vue.es.js
+index d6d2f69ede84ec6f2a0a6e24bd4b9e9e726349dd..3e9962f333ec006b2143524de4f70c50043c57f1 100644
+--- a/dist/dockview-vue.es.js
++++ b/dist/dockview-vue.es.js
+@@ -184,7 +184,9 @@ class VueHeaderActionsRenderer extends AbstractVueRenderer {
+     this._renderDisposable?.update({ params: this.buildEnrichedProps() });
+   }
+   updateLocation(location) {
+-    this._renderDisposable?.update({ params: { location } });
++    // Memoh patch: keep the complete header-action params when only the group
++    // location changes; replacing them with { location } drops api/group/panels.
++    this._renderDisposable?.update({ params: { ...this.buildEnrichedProps(), location } });
+   }
+ }
+ class VueContextMenuItemRenderer extends AbstractVueRenderer {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   dockview-core@7.0.2:
-    hash: f22f8ace97b6d1601ce61af7038966d0eb646a0c49e589fb02a22811780cd1a7
+    hash: 90e51af6eadd1ff1a7edaeaafc3f154c6cdf3a75ed1e962e55cdd3f8d9b58f59
     path: patches/dockview-core@7.0.2.patch
   dockview-vue@7.0.2:
     hash: ed0eefdb14161c24622f84cfcd1f3470577cc96fd973705c7e09d1c643452b07
@@ -8852,7 +8852,7 @@ snapshots:
       verror: 1.10.1
     optional: true
 
-  dockview-core@7.0.2(patch_hash=f22f8ace97b6d1601ce61af7038966d0eb646a0c49e589fb02a22811780cd1a7): {}
+  dockview-core@7.0.2(patch_hash=90e51af6eadd1ff1a7edaeaafc3f154c6cdf3a75ed1e962e55cdd3f8d9b58f59): {}
 
   dockview-vue@7.0.2(patch_hash=ed0eefdb14161c24622f84cfcd1f3470577cc96fd973705c7e09d1c643452b07)(vue@3.5.26(typescript@5.9.3)):
     dependencies:
@@ -8861,7 +8861,7 @@ snapshots:
 
   dockview@7.0.2:
     dependencies:
-      dockview-core: 7.0.2(patch_hash=f22f8ace97b6d1601ce61af7038966d0eb646a0c49e589fb02a22811780cd1a7)
+      dockview-core: 7.0.2(patch_hash=90e51af6eadd1ff1a7edaeaafc3f154c6cdf3a75ed1e962e55cdd3f8d9b58f59)
 
   doctypes@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   dockview-core@7.0.2:
-    hash: 90e51af6eadd1ff1a7edaeaafc3f154c6cdf3a75ed1e962e55cdd3f8d9b58f59
+    hash: 8195455b5e4bc151ac7c9ca7beae0706d3f9bc46cddcceb43d4ece5ca47f6f61
     path: patches/dockview-core@7.0.2.patch
   dockview-vue@7.0.2:
     hash: ed0eefdb14161c24622f84cfcd1f3470577cc96fd973705c7e09d1c643452b07
@@ -8852,7 +8852,7 @@ snapshots:
       verror: 1.10.1
     optional: true
 
-  dockview-core@7.0.2(patch_hash=90e51af6eadd1ff1a7edaeaafc3f154c6cdf3a75ed1e962e55cdd3f8d9b58f59): {}
+  dockview-core@7.0.2(patch_hash=8195455b5e4bc151ac7c9ca7beae0706d3f9bc46cddcceb43d4ece5ca47f6f61): {}
 
   dockview-vue@7.0.2(patch_hash=ed0eefdb14161c24622f84cfcd1f3470577cc96fd973705c7e09d1c643452b07)(vue@3.5.26(typescript@5.9.3)):
     dependencies:
@@ -8861,7 +8861,7 @@ snapshots:
 
   dockview@7.0.2:
     dependencies:
-      dockview-core: 7.0.2(patch_hash=90e51af6eadd1ff1a7edaeaafc3f154c6cdf3a75ed1e962e55cdd3f8d9b58f59)
+      dockview-core: 7.0.2(patch_hash=8195455b5e4bc151ac7c9ca7beae0706d3f9bc46cddcceb43d4ece5ca47f6f61)
 
   doctypes@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  dockview-core@7.0.2:
+    hash: f22f8ace97b6d1601ce61af7038966d0eb646a0c49e589fb02a22811780cd1a7
+    path: patches/dockview-core@7.0.2.patch
+  dockview-vue@7.0.2:
+    hash: ed0eefdb14161c24622f84cfcd1f3470577cc96fd973705c7e09d1c643452b07
+    path: patches/dockview-vue@7.0.2.patch
+
 importers:
 
   .:
@@ -218,8 +226,8 @@ importers:
         specifier: ^3.14.0
         version: 3.14.0
       dockview-vue:
-        specifier: ^6.6.1
-        version: 6.6.1(vue@3.5.26(typescript@5.9.3))
+        specifier: ^7.0.2
+        version: 7.0.2(patch_hash=ed0eefdb14161c24622f84cfcd1f3470577cc96fd973705c7e09d1c643452b07)(vue@3.5.26(typescript@5.9.3))
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -3441,13 +3449,16 @@ packages:
     os: [darwin]
     hasBin: true
 
-  dockview-core@6.6.1:
-    resolution: {integrity: sha512-WuNoO2wl3rGI8MaTuvmfgViek4WafHLD9Kf//Hw69g8TgAHSpAWr6RW15kU6U9vwtQxIi/YBxQNcIA5RzQ46Fw==}
+  dockview-core@7.0.2:
+    resolution: {integrity: sha512-i666ndkUdT4U+Bo2Yu3d6KwCJNqe21VJ0oschdgcXucZ5TquzBFX94zcUBEfg4IewTv2BuiPJ7r/2JTGLLv6ig==}
 
-  dockview-vue@6.6.1:
-    resolution: {integrity: sha512-Uv7HCWwQMoNitwuvj89oDnZQ7ZduOiuxbeZtaLCW+hUqoeAWSF2BU7zexv8Jc0TtsfJTJ4giMrX3/PF2IjUhKw==}
+  dockview-vue@7.0.2:
+    resolution: {integrity: sha512-O1ta/OhISPSu6sF1VQBWdDLyRbmJC0I2onixqXH/ZSSk8/t9OUsB9X9VuXP3g3D+a3THI3eRJEJyDazTAxEF8g==}
     peerDependencies:
       vue: ^3.4.0
+
+  dockview@7.0.2:
+    resolution: {integrity: sha512-QhgbJ7RTFsWvrs1lQZKPGCLTGjKU7kI5ZWX5lwU03arM9lIoQlbfv1b/uQ7V5zTkRw7JDndEqjKMgEFw2I8Kow==}
 
   doctypes@1.1.0:
     resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
@@ -8841,12 +8852,16 @@ snapshots:
       verror: 1.10.1
     optional: true
 
-  dockview-core@6.6.1: {}
+  dockview-core@7.0.2(patch_hash=f22f8ace97b6d1601ce61af7038966d0eb646a0c49e589fb02a22811780cd1a7): {}
 
-  dockview-vue@6.6.1(vue@3.5.26(typescript@5.9.3)):
+  dockview-vue@7.0.2(patch_hash=ed0eefdb14161c24622f84cfcd1f3470577cc96fd973705c7e09d1c643452b07)(vue@3.5.26(typescript@5.9.3)):
     dependencies:
-      dockview-core: 6.6.1
+      dockview: 7.0.2
       vue: 3.5.26(typescript@5.9.3)
+
+  dockview@7.0.2:
+    dependencies:
+      dockview-core: 7.0.2(patch_hash=f22f8ace97b6d1601ce61af7038966d0eb646a0c49e589fb02a22811780cd1a7)
 
   doctypes@1.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,17 @@ packages:
   - 'packages/*'
   - 'apps/*'
 
+allowBuilds:
+  electron-winstaller: true
+  esbuild: true
+  vue-demi: true
+
 onlyBuiltDependencies:
   - sqlite3
   - electron
   - electron-winstaller
   - esbuild
+
+patchedDependencies:
+  dockview-core@7.0.2: patches/dockview-core@7.0.2.patch
+  dockview-vue@7.0.2: patches/dockview-vue@7.0.2.patch


### PR DESCRIPTION
## Summary

Upgrades `dockview-vue` **6.6.1 → 7.0.2** and adapts the workspace tab layer to the new major version, plus a small tab-strip retune. The upgrade ships with two local pnpm patches (documented in `patches/README.md`) that close gaps upstream doesn't expose options for yet.

### dockview v7 API adaptation
- `onDidActivePanelChange` now delivers an **event object** (`event.activePanel`) instead of the panel directly. `workspace-tabs.ts` and its test fake dock are updated to the new shape.

### Dependency note (new local patches)
This introduces pnpm `patchedDependencies` for the first time. Both patches are scoped, documented, and have explicit *remove-when* conditions:

- **`dockview-core@7.0.2`** — single-tab drag ghost anchors at the pointer's top-left and renders a title-only chip, instead of cloning the live docked tab DOM and offsetting the chip 30px left of the pointer. Removable once dockview-core exposes single-tab ghost offset/customization.
- **`dockview-vue@7.0.2`** — `updateLocation` keeps the full enriched header-action params (`group`, `panels`, …) instead of replacing them with `{ location }`, fixing a crash in `header-add-actions` on group location change. Removable once upstream preserves the full params on location change.

### Tab strip retune
- Tabs rest at a static upper bound and **shrink together (no floor)** when the strip fills, instead of scrolling off-screen.
- Drop indicator switches from `fill` to `line`.
- The active tab shows a **resident close affordance** (the reserved close slot no longer reads as an accidental gap).

## Test plan
- [x] `workspace-tabs.test.ts` — 41 tests pass
- [x] `vue-tsc --noEmit` on `@memohai/web` — 0 type errors
- [x] ESLint clean on changed files
- [x] pnpm patches verified applied in `node_modules` after install
- [ ] Manual: drag a single editor tab (ghost anchors at pointer, title-only chip)
- [ ] Manual: drag a multi-panel/group ghost (unchanged, keeps upstream offset)
- [ ] Manual: header add-actions on group location change (no crash)
- [ ] Manual: open many tabs (shrink together, no scroll-off); line drop indicator; active-tab resident close