### PR TITLE
test(boot): isolate ambient TZ in default timezone test

### DIFF
--- a/internal/boot/runtime_test.go
+++ b/internal/boot/runtime_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestProvideRuntimeConfig_DefaultTimezone(t *testing.T) {
-	t.Parallel()
+	// Isolate the ambient TZ so a developer's shell TZ does not override the
+	// configured default. Can't use t.Parallel() alongside t.Setenv.
+	t.Setenv("TZ", "")
 
 	cfg := config.Config{
 		Auth: config.AuthConfig{


### PR DESCRIPTION
## What

`TestProvideRuntimeConfig_DefaultTimezone` now isolates the ambient `TZ` env var (`t.Setenv("TZ", "")`) so it no longer depends on the developer's shell timezone.

## Why

`ProvideRuntimeConfig` intentionally lets a non-empty `TZ` env var override the configured timezone (production behavior, covered by the sibling `TestProvideRuntimeConfig_ResolvesTZEnv` which uses `t.Setenv`). But the default-timezone test asserts the resolved value equals the configured default (`UTC`) **without** isolating the ambient `TZ`.

Result: it passes on CI (which doesn't export `TZ`) but **fails on any developer whose shell exports `TZ`**, e.g.:

```
runtime_test.go:35: Timezone = "America/Los_Angeles", want "UTC"
```

Because `go test ./...` runs in the `pre-commit` hook, affected developers are forced to commit with `--no-verify` to get past it. This has been latent since the test was introduced in #282.

## Fix

Set `TZ=""` for this case, matching the explicit `t.Setenv` already used by the sibling `ResolvesTZEnv` test. `t.Parallel()` is dropped because it's incompatible with `t.Setenv`.

## Verification

`go test ./internal/boot/...` passes under all of:

- no `TZ` (emulates CI)
- `TZ=America/Los_Angeles`
- `TZ=Asia/Shanghai`

## Note (out of scope, not addressed here)

While reproducing this I also saw an unrelated **flaky** panic in `internal/acpclient` (`TestRunnerStartSessionStreamsEvents`, nil-pointer in the fake ACP agent's `RequestPermission` path) that only surfaces under the full concurrent `go test ./...` run — it passes reliably in isolation. Not timezone-related and left untouched here; flagging in case it's worth a separate look, since it can also intermittently block the pre-commit hook.