### PR TITLE
fix(web): surface the chat-model switcher on the bot settings page

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2034,7 +2034,7 @@
         "global": "Global Settings",
         "globalDescription": "Core preferences for this bot.",
         "interaction": "Interaction",
-        "interactionDescription": "Configure how the bot engages in conversations.",
+        "interactionDescription": "Choose the chat model and configure how the bot engages in conversations.",
         "multimedia": "Multimedia",
         "multimediaDescription": "Configure voice and image generation models.",
         "acp": "ACP Agent"

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -2016,7 +2016,7 @@
         "global": "グローバル設定",
         "globalDescription": "このBotの中心的な設定。",
         "interaction": "交流",
-        "interactionDescription": "Botが会話に参加する方法を構成します。",
+        "interactionDescription": "チャットModelを選択し、Botが会話に参加する方法を構成します。",
         "multimedia": "マルチメディア",
         "multimediaDescription": "音声と画像の生成Modelを構成します。",
         "acp": "エージェント",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -2034,7 +2034,7 @@
         "global": "全局设置",
         "globalDescription": "Bot 的核心偏好配置。",
         "interaction": "交互方式",
-        "interactionDescription": "配置 Bot 在对话中的行为习惯。",
+        "interactionDescription": "选择对话模型，并配置 Bot 在对话中的行为习惯。",
         "multimedia": "多媒体",
         "multimediaDescription": "配置语音与图片生成等相关模型。",
         "acp": "ACP Agent"

--- a/apps/web/src/pages/bots/detail.vue
+++ b/apps/web/src/pages/bots/detail.vue
@@ -431,7 +431,7 @@ const searchQuery = ref('')
 const searchIndex = computed(() => {
   return [
     { tab: 'general', key: 'bots.settings.blocks.global', keywords: ['name', 'avatar', 'description', 'timezone'] },
-    { tab: 'general', key: 'bots.settings.blocks.interaction', keywords: ['language', 'chat model', 'reasoning'] },
+    { tab: 'general', key: 'bots.settings.blocks.interaction', keywords: ['language', 'chat model', 'reasoning', 'model', 'llm', '模型', '换模型', '更换模型', 'モデル'] },
     { tab: 'general', key: 'bots.settings.blocks.context', keywords: ['browser', 'search', 'provider'] },
     { tab: 'general', key: 'bots.settings.blocks.multimedia', keywords: ['image', 'tts', 'transcription'] },
     { tab: 'general', key: 'bots.settings.dangerZone', keywords: ['delete', 'remove'] },


### PR DESCRIPTION
## Summary
- Reported as hard to find: the control to change an existing bot's chat model does exist (General tab → "Interaction" block), but nothing about the label or description mentions "model", so it's easy to miss while scanning the settings page.
- The in-page settings search also had no model-related keywords for this block in Chinese/Japanese, so searching "模型" surfaced nothing even though the feature is right there.
- Pure discoverability fix, no behavior change: reworded the "Interaction" block description in zh/en/ja to explicitly call out choosing the chat model, and added `model`/`llm`/`模型`/`换模型`/`更换模型`/`モデル` to its search keywords.

## Test plan
- [x] Verified all three locale JSON files still parse.
- [ ] Manual: open an existing bot → General tab, confirm the "Interaction" card description now mentions the chat model; search "模型"/"model"/"モデル" in the settings search and confirm it surfaces this block.