### PR TITLE
feat(providers): add Zhipu AI (bigmodel.cn) provider preset

### DIFF
--- a/apps/web/src/constants/provider-presets.ts
+++ b/apps/web/src/constants/provider-presets.ts
@@ -39,10 +39,20 @@ export const providerPresets: ProviderPreset[] = [
   {
     id: 'zai',
     name: 'Z.AI GLM',
+    registryName: '智谱AI / Z.AI / GLM',
     clientType: 'openai-completions',
     baseUrl: 'https://api.z.ai/api/paas/v4',
     icon: 'zhipu-color',
     source: 'zai.yaml',
+  },
+  {
+    id: 'zhipu',
+    name: 'Zhipu AI',
+    registryName: '智谱AI / BigModel / GLM',
+    clientType: 'openai-completions',
+    baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    icon: 'zhipu-color',
+    source: 'zhipu.yaml',
   },
   {
     id: 'together',

--- a/conf/providers/zhipu.yaml
+++ b/conf/providers/zhipu.yaml
@@ -1,0 +1,79 @@
+name: Zhipu AI
+client_type: openai-completions
+icon: zhipu-color
+base_url: https://open.bigmodel.cn/api/paas/v4
+
+models:
+  - model_id: glm-5.2
+    name: GLM-5.2
+    type: chat
+    config:
+      compatibilities: [tool-call, reasoning]
+      context_window: 1000000
+      thinking_mode: toggle
+      reasoning_efforts: [low, medium, high]
+
+  - model_id: glm-5.1
+    name: GLM-5.1
+    type: chat
+    config:
+      compatibilities: [tool-call, reasoning]
+      context_window: 202752
+      thinking_mode: toggle
+      reasoning_efforts: [low, medium, high]
+
+  - model_id: glm-5
+    name: GLM-5
+    type: chat
+    config:
+      compatibilities: [tool-call, reasoning]
+      context_window: 202752
+      thinking_mode: toggle
+      reasoning_efforts: [low, medium, high]
+
+  - model_id: glm-5-turbo
+    name: GLM-5 Turbo
+    type: chat
+    config:
+      compatibilities: [tool-call, reasoning]
+      context_window: 202752
+      thinking_mode: toggle
+      reasoning_efforts: [low, medium, high]
+
+  - model_id: glm-4.7
+    name: GLM-4.7
+    type: chat
+    config:
+      compatibilities: [tool-call, reasoning]
+      context_window: 202752
+      thinking_mode: toggle
+      reasoning_efforts: [low, medium, high]
+
+  - model_id: glm-4.6
+    name: GLM-4.6
+    type: chat
+    config:
+      compatibilities: [tool-call, reasoning]
+      context_window: 202752
+      thinking_mode: toggle
+      reasoning_efforts: [low, medium, high]
+
+  - model_id: glm-4.7-flash
+    name: GLM-4.7 Flash
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 202752
+
+  - model_id: glm-4-flash-250414
+    name: GLM-4 Flash
+    type: chat
+    config:
+      compatibilities: [tool-call]
+      context_window: 131072
+
+  - model_id: embedding-3
+    name: Embedding-3
+    type: embedding
+    config:
+      dimensions: 2048


### PR DESCRIPTION
## Summary
- The existing `zai` preset ("Z.AI GLM") only covers Z.AI's international endpoint (`api.z.ai`), which uses a separate account/API-key namespace from Zhipu AI's mainland China endpoint (`open.bigmodel.cn`) that most Chinese developers actually hold keys for.
- Searching "智谱" didn't match "Z.AI GLM" either, since it had no Chinese keyword to search against — so the provider was effectively undiscoverable in Chinese, regardless of which endpoint a user actually needed.
- Add `conf/providers/zhipu.yaml` targeting `open.bigmodel.cn` with the current GLM lineup (glm-5.2/5.1/5/5-turbo, glm-4.7/4.6, glm-4.7-flash, glm-4-flash, embedding-3), cross-checked against the official Zhipu API docs for model IDs/context windows/reasoning support, following the same schema as `moonshot.yaml`/`qwen.yaml`.
- Register it as a built-in preset in `provider-presets.ts`, and add a `registryName` to the existing `zai` preset too, so both endpoints surface when searching "智谱" and the user can pick whichever matches the API key they hold.

## Test plan
- [x] Verified `zhipu.yaml` parses cleanly and all 9 models load via `internal/registry.Load` (temporary test, removed before commit).
- [x] `go build ./...`, `go vet ./internal/registry/...`, full `go test ./...` (via pre-commit hook) pass.
- [x] `eslint` and `vue-tsc --noEmit` clean on the touched frontend files.
- [ ] Manual: add "Zhipu AI" from the built-in preset list with a real `open.bigmodel.cn` API key, confirm its models are selectable when creating a bot without any extra import/enable steps.