### PR TITLE
fix(web): apply mermaid theme selection + vivid, non-clipping settings preview

### DIFF
--- a/apps/web/src/components/themed-mermaid-block/index.test.ts
+++ b/apps/web/src/components/themed-mermaid-block/index.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, h, nextTick, reactive } from 'vue'
+import { createApp, h, nextTick, reactive, ref, type Ref } from 'vue'
 
 const settings = reactive({ mermaidTheme: 'auto' as string })
 
@@ -31,17 +31,15 @@ async function flushPromises() {
   await nextTick()
 }
 
-async function mountWith(theme: string, code: string) {
+async function mountWith(theme: string, code: string, version?: Ref<number>) {
   settings.mermaidTheme = theme
+  const node = { type: 'code_block', language: 'mermaid', code, raw: code }
   const ThemedMermaidBlock = (await import('./index.vue')).default
-  const app = createApp(ThemedMermaidBlock, {
-    node: { type: 'code_block', language: 'mermaid', code, raw: code },
-    isDark: false,
-  })
-  const root = document.createElement('div')
-  app.mount(root)
+  const app = createApp(ThemedMermaidBlock, { node, isDark: false })
+  if (version) app.provide('markstreamStreamVersion', version)
+  app.mount(document.createElement('div'))
   await flushPromises()
-  return app
+  return { app, node }
 }
 
 describe('ThemedMermaidBlock', () => {
@@ -50,15 +48,27 @@ describe('ThemedMermaidBlock', () => {
   })
 
   it('injects the theme directive into the source the renderer reads (node.code)', async () => {
-    const app = await mountWith('forest', 'graph TD\n  A-->B')
+    const { app } = await mountWith('forest', 'graph TD\n  A-->B')
     expect(captured?.node.code).toBe('%%{init: {"theme":"forest"}}%%\ngraph TD\n  A-->B')
     app.unmount()
   })
 
   it('passes the source through untouched for the auto theme', async () => {
     const source = 'graph TD\n  A-->B'
-    const app = await mountWith('auto', source)
+    const { app } = await mountWith('auto', source)
     expect(captured?.node.code).toBe(source)
+    app.unmount()
+  })
+
+  it('re-applies the theme when markstream mutates node.code in place during streaming', async () => {
+    const version = ref(0)
+    const { app, node } = await mountWith('forest', 'graph TD', version)
+    expect(captured?.node.code).toBe('%%{init: {"theme":"forest"}}%%\ngraph TD')
+
+    node.code = 'graph TD\n  A-->B'
+    version.value++
+    await flushPromises()
+    expect(captured?.node.code).toBe('%%{init: {"theme":"forest"}}%%\ngraph TD\n  A-->B')
     app.unmount()
   })
 })

--- a/apps/web/src/components/themed-mermaid-block/index.test.ts
+++ b/apps/web/src/components/themed-mermaid-block/index.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, reactive } from 'vue'
+
+const settings = reactive({ mermaidTheme: 'auto' as string })
+
+vi.mock('@/store/settings', () => ({
+  useSettingsStore: () => settings,
+}))
+
+interface CapturedProps {
+  node: { code: string }
+  loading?: boolean
+  isDark?: boolean
+}
+
+let captured: CapturedProps | null = null
+
+vi.mock('markstream-vue', () => ({
+  MermaidBlockNode: {
+    props: ['node', 'loading', 'isDark'],
+    setup(props: CapturedProps) {
+      captured = props
+      return () => h('div')
+    },
+  },
+}))
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+}
+
+async function mountWith(theme: string, code: string) {
+  settings.mermaidTheme = theme
+  const ThemedMermaidBlock = (await import('./index.vue')).default
+  const app = createApp(ThemedMermaidBlock, {
+    node: { type: 'code_block', language: 'mermaid', code, raw: code },
+    isDark: false,
+  })
+  const root = document.createElement('div')
+  app.mount(root)
+  await flushPromises()
+  return app
+}
+
+describe('ThemedMermaidBlock', () => {
+  afterEach(() => {
+    captured = null
+  })
+
+  it('injects the theme directive into the source the renderer reads (node.code)', async () => {
+    const app = await mountWith('forest', 'graph TD\n  A-->B')
+    expect(captured?.node.code).toBe('%%{init: {"theme":"forest"}}%%\ngraph TD\n  A-->B')
+    app.unmount()
+  })
+
+  it('passes the source through untouched for the auto theme', async () => {
+    const source = 'graph TD\n  A-->B'
+    const app = await mountWith('auto', source)
+    expect(captured?.node.code).toBe(source)
+    app.unmount()
+  })
+})

--- a/apps/web/src/components/themed-mermaid-block/index.vue
+++ b/apps/web/src/components/themed-mermaid-block/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject, type Ref } from 'vue'
 import { MermaidBlockNode, type CodeBlockNode } from 'markstream-vue'
 import { useSettingsStore } from '@/store/settings'
 import { applyMermaidThemeToSource, resolveMermaidIsDark } from '@/store/settings/mermaid'
@@ -14,8 +14,15 @@ const props = defineProps<{
 
 const settings = useSettingsStore()
 
+// markstream mutates `node.code` in place (same object reference) on every stream
+// tick and bumps this injected version ref to drive its own updates. Depend on it
+// so the themed copy re-derives as the source grows; otherwise a non-auto theme
+// freezes the diagram at its first partial frame. Key is markstream-internal.
+const streamVersion = inject<Ref<number> | undefined>('markstreamStreamVersion', undefined)
+
 const themedNode = computed<CodeBlockNode>(() => {
   if (settings.mermaidTheme === 'auto') return props.node
+  void streamVersion?.value
   const code = props.node?.code ?? ''
   const next = applyMermaidThemeToSource(code, settings.mermaidTheme)
   if (next === code) return props.node

--- a/apps/web/src/components/themed-mermaid-block/index.vue
+++ b/apps/web/src/components/themed-mermaid-block/index.vue
@@ -16,10 +16,10 @@ const settings = useSettingsStore()
 
 const themedNode = computed<CodeBlockNode>(() => {
   if (settings.mermaidTheme === 'auto') return props.node
-  const content = props.node?.content ?? ''
-  const next = applyMermaidThemeToSource(content, settings.mermaidTheme)
-  if (next === content) return props.node
-  return { ...props.node, content: next }
+  const code = props.node?.code ?? ''
+  const next = applyMermaidThemeToSource(code, settings.mermaidTheme)
+  if (next === code) return props.node
+  return { ...props.node, code: next }
 })
 
 const themedIsDark = computed(() =>

--- a/apps/web/src/components/themed-mermaid-block/preview-path.test.ts
+++ b/apps/web/src/components/themed-mermaid-block/preview-path.test.ts
@@ -32,8 +32,12 @@ async function flush() {
 }
 
 const PREVIEW_CONTENT = `\`\`\`mermaid
-flowchart LR
-  A([Idea]) --> B{Pick a theme}
+pie
+  title Theme palette
+  "Chat" : 38
+  "Memory" : 27
+  "Tools" : 20
+  "Skills" : 15
 \`\`\``
 
 describe('appearance preview render path (real MarkdownRender + custom-id)', () => {

--- a/apps/web/src/components/themed-mermaid-block/preview-path.test.ts
+++ b/apps/web/src/components/themed-mermaid-block/preview-path.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, reactive } from 'vue'
+
+// Real settings store stub: only mermaidTheme matters for injection.
+const settings = reactive({ mermaidTheme: 'auto' as string, isDark: false })
+vi.mock('@/store/settings', () => ({ useSettingsStore: () => settings }))
+
+// Use the REAL markstream-vue (MarkdownRender, setCustomComponents, enableMermaid),
+// but replace MermaidBlockNode with a spy so we can read the node.code that the
+// renderer actually receives after ThemedMermaidBlock injection.
+let captured: { node: { code: string } } | null = null
+vi.mock('markstream-vue', async () => {
+  const actual = await vi.importActual<typeof import('markstream-vue')>('markstream-vue')
+  return {
+    ...actual,
+    MermaidBlockNode: {
+      props: ['node', 'loading', 'isDark'],
+      setup(props: { node: { code: string } }) {
+        captured = props
+        return () => h('div', props.node?.code ?? '')
+      },
+    },
+  }
+})
+
+async function flush() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+const PREVIEW_CONTENT = `\`\`\`mermaid
+flowchart LR
+  A([Idea]) --> B{Pick a theme}
+\`\`\``
+
+describe('appearance preview render path (real MarkdownRender + custom-id)', () => {
+  afterEach(() => {
+    captured = null
+  })
+
+  const MERMAID_PREVIEW_PROPS = {
+    showHeader: false,
+    showModeToggle: false,
+    showCopyButton: false,
+    showExportButton: false,
+    showFullscreenButton: false,
+    showCollapseButton: false,
+    showZoomControls: false,
+    enableMermaidInteractions: false,
+  } as const
+
+  async function renderPreview(mermaidProps?: Record<string, unknown>) {
+    const markstream = await import('markstream-vue')
+    const ThemedMermaidBlock = (await import('./index.vue')).default
+    markstream.enableMermaid()
+    markstream.setCustomComponents({ mermaid: ThemedMermaidBlock })
+
+    settings.mermaidTheme = 'forest'
+    const MarkdownRender = markstream.default
+    const app = createApp(MarkdownRender, {
+      content: PREVIEW_CONTENT,
+      isDark: false,
+      typewriter: false,
+      fade: false,
+      customId: 'appearance-mermaid-preview',
+      ...(mermaidProps ? { mermaidProps } : {}),
+    })
+    app.mount(document.createElement('div'))
+    await flush()
+    return app
+  }
+
+  it('routes through ThemedMermaidBlock and injects the picked theme (no mermaidProps)', async () => {
+    const app = await renderPreview()
+    expect(captured).not.toBeNull()
+    expect(captured?.node.code.startsWith('%%{init: {"theme":"forest"}}%%')).toBe(true)
+    app.unmount()
+  })
+
+  it('still injects the theme when the appearance preview mermaidProps are passed', async () => {
+    const app = await renderPreview(MERMAID_PREVIEW_PROPS)
+    expect(captured).not.toBeNull()
+    expect(captured?.node.code.startsWith('%%{init: {"theme":"forest"}}%%')).toBe(true)
+    app.unmount()
+  })
+
+  // The preview must reflect a theme switch WITHOUT a forced :key remount — same
+  // reactive path that already works in chat. Proves removing the obsolete
+  // mermaidPreviewKey workaround is safe: changing the store theme re-injects.
+  it('re-injects the new theme reactively when the store theme changes (no remount)', async () => {
+    const app = await renderPreview(MERMAID_PREVIEW_PROPS)
+    expect(captured?.node.code.startsWith('%%{init: {"theme":"forest"}}%%')).toBe(true)
+
+    settings.mermaidTheme = 'neutral'
+    await flush()
+    expect(captured?.node.code.startsWith('%%{init: {"theme":"neutral"}}%%')).toBe(true)
+    app.unmount()
+  })
+})

--- a/apps/web/src/pages/appearance/index.vue
+++ b/apps/web/src/pages/appearance/index.vue
@@ -321,11 +321,12 @@ enableMermaid()
 setCustomComponents({ mermaid: ThemedMermaidBlock })
 
 const MERMAID_PREVIEW_CONTENT = `\`\`\`mermaid
-flowchart LR
-  A([Idea]) --> B{Pick a theme}
-  B -->|Auto| C[Match interface]
-  B -->|Forest| D[Forest]
-  B -->|Neutral| E[Neutral]
+pie
+  title Theme palette
+  "Chat" : 38
+  "Memory" : 27
+  "Tools" : 20
+  "Skills" : 15
 \`\`\``
 
 // Hide every chrome control on the preview's mermaid block; we want just the
@@ -483,8 +484,13 @@ function commitCodeFontFamilyDraft() {
   border-radius: 0;
   background: transparent;
 }
+/* markstream windows tall diagrams into a fixed min-height preview (360px) and
+   clips the overflow, which cut off the bottom of the square-ish pie. Raise the
+   window so the whole pie (~450px at full width) shows; min-height overrides
+   markstream's inline height without fighting its resize transitions. */
 .appearance-mermaid-preview :deep(.mermaid-preview-area) {
   background: transparent;
+  min-height: 470px;
 }
 
 /* The shiki preview keeps the theme's inline background-color on <pre>, so

--- a/apps/web/src/pages/appearance/index.vue
+++ b/apps/web/src/pages/appearance/index.vue
@@ -243,7 +243,7 @@
             <div class="shrink-0">
               <Select
                 :model-value="mermaidTheme"
-                @update:model-value="(value) => value && setMermaidTheme(value as MermaidTheme)"
+                @update:model-value="(value) => isMermaidTheme(value) && setMermaidTheme(value)"
               >
                 <SelectTrigger
                   size="sm"
@@ -298,7 +298,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@memohai/ui'
-import { useDark } from '@vueuse/core'
 import { Monitor, Moon, Sun } from 'lucide-vue-next'
 import { storeToRefs } from 'pinia'
 import { computed, onMounted, ref, watch } from 'vue'
@@ -315,6 +314,7 @@ import type { SearchableSelectOption } from '@/components/searchable-select-popo
 import ThemedMermaidBlock from '@/components/themed-mermaid-block/index.vue'
 import { colorSchemes, type ColorSchemeId, type ColorSchemeOption } from '@/constants/color-schemes'
 import { MERMAID_THEMES, type MermaidTheme, useSettingsStore, type ThemePreference } from '@/store/settings'
+import { isMermaidTheme } from '@/store/settings/mermaid'
 import { listBundledShikiThemes } from '@/store/settings/shiki-theme'
 import { cssFontFamilyDeclaration, DEFAULT_CODE_FONT_FAMILY, DEFAULT_CODE_FONT_SIZE_PX, DEFAULT_UI_FONT_SIZE_PX, normalizeCodeFontSizePx } from '@/store/settings/typography'
 
@@ -344,9 +344,8 @@ const MERMAID_PREVIEW_PROPS = {
 
 const { t } = useI18n()
 const settingsStore = useSettingsStore()
-const { language, theme, colorScheme, uiFontFamily, codeFontFamily, uiFontSizePx, codeFontSizePx, shikiThemeLight, shikiThemeDark, mermaidTheme, defaultUiFontFamily, defaultCodeFontFamily } = storeToRefs(settingsStore)
+const { language, theme, colorScheme, uiFontFamily, codeFontFamily, uiFontSizePx, codeFontSizePx, shikiThemeLight, shikiThemeDark, mermaidTheme, defaultUiFontFamily, defaultCodeFontFamily, isDark } = storeToRefs(settingsStore)
 const { setLanguage, setTheme, setColorScheme, setUiFontFamily, setCodeFontFamily, setUiFontSizePx, setCodeFontSizePx, setShikiTheme, setMermaidTheme } = settingsStore
-const isDark = useDark()
 
 const mermaidThemeLabels: Record<MermaidTheme, string> = {
   auto: 'Auto',

--- a/apps/web/src/pages/appearance/index.vue
+++ b/apps/web/src/pages/appearance/index.vue
@@ -270,7 +270,6 @@
           </div>
           <div class="appearance-mermaid-preview pointer-events-none mt-3">
             <MarkdownRender
-              :key="mermaidPreviewKey"
               :content="MERMAID_PREVIEW_CONTENT"
               :is-dark="isDark"
               :typewriter="false"
@@ -354,10 +353,6 @@ const mermaidThemeLabels: Record<MermaidTheme, string> = {
   forest: 'Forest',
   neutral: 'Neutral',
 }
-
-// Mermaid renders to SVG once per source+theme; force a remount when either
-// changes so the preview reflects the picked theme immediately.
-const mermaidPreviewKey = computed(() => `${mermaidTheme.value}:${isDark.value ? 'dark' : 'light'}`)
 
 const allShikiThemes = listBundledShikiThemes()
 const lightShikiThemeOptions = computed<SearchableSelectOption[]>(() =>


### PR DESCRIPTION
## Summary
The mermaid theme picker had no visible effect because the theme directive was injected into the wrong node field (`node.content` vs the `node.code` the renderer reads), so only `dark` (which flips `isDark`) ever changed anything. This fixes the root cause and hardens the surrounding preview.

- **Apply theme to `node.code`** so `default`/`forest`/`neutral` actually render.
- **Harden:** re-render on stream ticks, unify the dark-mode source of truth, and narrow the theme `<Select>` with `isMermaidTheme` instead of an `as` cast.
- **Drop the obsolete `:key` remount** on the settings preview — it was a workaround for the old bug and broke reactive re-render; now it matches chat.
- **Pie preview demo** so themes are instantly distinguishable, sized with a `min-height` so markstream's fixed preview window doesn't clip the pie.

## Test plan
- [x] `vitest` — themed-mermaid-block unit + real-`MarkdownRender` integration tests (theme injection on mount + reactive re-inject)
- [x] `eslint` + `vue-tsc` clean
- [x] Verified in a real headless browser: all four themes render distinctly and the pie is no longer clipped
- [x] Rebased on latest `main`, no conflicts
