### PR TITLE
fix(scripts): patched-deps guard broke Windows CI — stop matching .pnpm dir names

### DIFF
--- a/scripts/check-patched-deps.mjs
+++ b/scripts/check-patched-deps.mjs
@@ -115,25 +115,45 @@ function extractMarkers(patchFile) {
 }
 
 /** Locate every installed dir for a patched spec ("name@version").
- * Scoped names use pnpm's `+` encoding in the .pnpm directory. Plural on
- * purpose: peer-dependency variants materialize as separate `_patch_hash=…_…`
- * directories and EACH copy must carry the patch. The glob over the hash
- * suffix is intentional: we don't recompute the hash — the whole point is to
- * distrust it and read the content instead. */
+ * Deliberately name-blind: pnpm truncates virtual-store dir names longer than
+ * virtual-store-dir-max-length (default 120, but 60 ON WINDOWS) to
+ * `<prefix>_<32-hex md5>`, which cuts the literal `_patch_hash=` out of the
+ * name — matching on it broke Windows CI while passing everywhere else. So
+ * enumerate `.pnpm/<any>/node_modules/<name>/package.json` and match by
+ * CONTENT (name + version), consistent with the guard's core rule of never
+ * trusting directory names. Plural on purpose: peer-dependency variants
+ * materialize as separate dirs and EACH copy must carry the patch. Dependents'
+ * node_modules contain symlinks to the same materialization — dedupe by
+ * realpath so each copy is verified once. */
 function findInstalledDirs(spec) {
   // Versionless specs are legal pnpm keys: `pkg` has no `@` at all and
   // `@scope/pkg` has its only `@` at index 0 — in both cases the whole spec
   // is the name and ANY version may carry the patch.
   const at = spec.lastIndexOf('@')
   const name = at > 0 ? spec.slice(0, at) : spec
-  const encoded = name.replace(/\//g, '+')
+  const version = at > 0 ? spec.slice(at + 1) : null
   const pnpmDir = path.join(repoRoot, 'node_modules', '.pnpm')
   if (!fs.existsSync(pnpmDir)) return []
-  const prefix = at > 0 ? `${encoded}@${spec.slice(at + 1)}_patch_hash=` : `${encoded}@`
-  return fs
-    .readdirSync(pnpmDir)
-    .filter((d) => d.startsWith(prefix) && d.includes('_patch_hash='))
-    .map((d) => path.join(pnpmDir, d, 'node_modules', name))
+  const byRealpath = new Map()
+  for (const entry of fs.readdirSync(pnpmDir)) {
+    const candidate = path.join(pnpmDir, entry, 'node_modules', name)
+    let pkg
+    try {
+      pkg = JSON.parse(fs.readFileSync(path.join(candidate, 'package.json'), 'utf8'))
+    } catch {
+      continue // not a dir materializing <name> (or unreadable) — skip
+    }
+    if (pkg.name !== name) continue
+    if (version !== null && pkg.version !== version) continue
+    let real
+    try {
+      real = fs.realpathSync(candidate)
+    } catch {
+      real = candidate
+    }
+    if (!byRealpath.has(real)) byRealpath.set(real, candidate)
+  }
+  return [...byRealpath.values()]
 }
 
 function verifyInstalled() {
@@ -141,7 +161,7 @@ function verifyInstalled() {
   for (const { spec, patchPath } of readPatchedDependencies()) {
     const installedDirs = findInstalledDirs(spec)
     if (installedDirs.length === 0) {
-      failures.push(`${spec}: no _patch_hash directory found in node_modules/.pnpm (patch not applied at all?)`)
+      failures.push(`${spec}: no installed copy found in node_modules/.pnpm (package missing or patch config broken?)`)
       continue
     }
     let markers


### PR DESCRIPTION
## 问题

#746 合入后 main 的 Electron CI **windows-latest** job 在 postinstall 挂掉(macOS/Ubuntu 绿):

```
✖ patched-dependency verification failed:
  - dockview-core@7.0.2: no _patch_hash directory found in node_modules/.pnpm
```

## 根因

pnpm 对超过 `virtual-store-dir-max-length` 的虚拟 store 目录名做截断(默认 120,**Windows 默认 60**),截断形态为 `<前缀>_<32位md5>`。dockview-core 的完整目录名 95 字符——mac/linux 的 120 限制下完好,Windows 60 限制下被截成:

```
dockview-core@7.0.2_patch_h_fdc493c791a449dfaaa0f7fb94b48538
```

字面量 `_patch_hash=` 整段消失,而 `findInstalledDirs` 恰恰用这个子串定位目录 → 找不到 → 误报投毒 → 每次安装失败。

## 修法

和守卫自身的核心原则对齐(**从不信任目录名**):不再匹配 `.pnpm` 目录名,改为枚举 `.pnpm/<any>/node_modules/<name>/package.json`,按内容(name + version)定位安装副本,realpath 去重(依赖方 node_modules 里的 symlink 指向同一份物化)。顺带升级:"pnpm 根本没应用 patch"从名字启发式 miss 变成真正的内容校验失败。

## 验证

- 健康安装通过,枚举开销可忽略(全程 0.16s);
- 合成仓库:Windows 式截断目录名 + 已打补丁内容 → 通过;同名 + 未打补丁内容 → exit 1;
- eslint / pre-commit 通过。

合并后 #743 之后被挡的 PR 重跑 Electron CI 即可转绿(无需 rebase,pull_request 的 merge ref 会带上本修复)。