### PR TITLE
fix: image generation fails with 400 on DashScope/Volcano providers (#744)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/mailgun/mailgun-go/v5 v5.14.0
 	github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7
 	github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978
-	github.com/memohai/twilight-ai v0.4.1-0.20260623064358-a8230254367e
+	github.com/memohai/twilight-ai v0.4.1-0.20260708041258-f7bcb57fcaab
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0
@@ -197,7 +197,5 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.1.0 // indirect
 )
-
-replace github.com/memohai/twilight-ai => github.com/akazwz/twilight-ai v0.4.1-0.20260707044248-a3b78173e729
 
 tool github.com/swaggo/swag/cmd/swag

--- a/go.mod
+++ b/go.mod
@@ -198,4 +198,6 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v1.1.0 // indirect
 )
 
+replace github.com/memohai/twilight-ai => github.com/akazwz/twilight-ai v0.4.1-0.20260707044248-a3b78173e729
+
 tool github.com/swaggo/swag/cmd/swag

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/Microsoft/hcsshim v0.14.0-rc.1 h1:qAPXKwGOkVn8LlqgBN8GS0bxZ83hOJpcjxzmlQKxKsQ=
 github.com/Microsoft/hcsshim v0.14.0-rc.1/go.mod h1:hTKFGbnDtQb1wHiOWv4v0eN+7boSWAHyK/tNAaYZL0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/akazwz/twilight-ai v0.4.1-0.20260707044248-a3b78173e729 h1:ptdI1kxyEzz8Q9+SOICamySGfNNBPlWNnfd/o/okbaA=
-github.com/akazwz/twilight-ai v0.4.1-0.20260707044248-a3b78173e729/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -513,6 +511,8 @@ github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7 h1:beehwOQperqGWj4m4E
 github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7/go.mod h1:OvmxM7JmnXBmwJWWVqtreL3HSHSKuzPbtbhlg5MvBg0=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978 h1:6gD8DvZkimGmU0e3PjlusJPyw55SyeoE12CZQoYUa8g=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978/go.mod h1:2LMgK5QYFlTSvrGY+sI/j+jK2WK+YGHv4IMuiW+iPSc=
+github.com/memohai/twilight-ai v0.4.1-0.20260708041258-f7bcb57fcaab h1:Pl4dpUlmGWUi7/wEbIZt2PuGD4sO8VKutd7OnRbQx0A=
+github.com/memohai/twilight-ai v0.4.1-0.20260708041258-f7bcb57fcaab/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/Microsoft/hcsshim v0.14.0-rc.1 h1:qAPXKwGOkVn8LlqgBN8GS0bxZ83hOJpcjxzmlQKxKsQ=
 github.com/Microsoft/hcsshim v0.14.0-rc.1/go.mod h1:hTKFGbnDtQb1wHiOWv4v0eN+7boSWAHyK/tNAaYZL0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/akazwz/twilight-ai v0.4.1-0.20260707044248-a3b78173e729 h1:ptdI1kxyEzz8Q9+SOICamySGfNNBPlWNnfd/o/okbaA=
+github.com/akazwz/twilight-ai v0.4.1-0.20260707044248-a3b78173e729/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -511,8 +513,6 @@ github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7 h1:beehwOQperqGWj4m4E
 github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7/go.mod h1:OvmxM7JmnXBmwJWWVqtreL3HSHSKuzPbtbhlg5MvBg0=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978 h1:6gD8DvZkimGmU0e3PjlusJPyw55SyeoE12CZQoYUa8g=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978/go.mod h1:2LMgK5QYFlTSvrGY+sI/j+jK2WK+YGHv4IMuiW+iPSc=
-github.com/memohai/twilight-ai v0.4.1-0.20260623064358-a8230254367e h1:EOvyUxrczx5iGfx1KhCoG4m7UFOc7etxj+QUWTwvm3w=
-github.com/memohai/twilight-ai v0.4.1-0.20260623064358-a8230254367e/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1012,7 +1012,7 @@ func toolStreamEventToAgentEvent(evt tools.ToolStreamEvent) StreamEvent {
 		for _, a := range evt.Attachments {
 			atts = append(atts, fileAttachmentFromToolAttachment(a))
 		}
-		return StreamEvent{Type: EventAttachment, Attachments: atts}
+		return StreamEvent{Type: EventAttachment, ToolCallID: evt.ToolCallID, Attachments: atts}
 	case tools.StreamEventReaction:
 		rs := make([]ReactionItem, 0, len(evt.Reactions))
 		for _, r := range evt.Reactions {

--- a/internal/agent/tools/image_gen.go
+++ b/internal/agent/tools/image_gen.go
@@ -5,12 +5,20 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
 	"strings"
 	"time"
 
+	alibabaimages "github.com/memohai/twilight-ai/provider/alibabacloud/images"
+	openaiimages "github.com/memohai/twilight-ai/provider/openai/images"
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/models"
 	"github.com/memohai/memoh/internal/providers"
@@ -18,7 +26,29 @@ import (
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
-const imageGenDir = "/data/generated-images"
+const (
+	imageGenDir            = "/data/generated-images"
+	maxGeneratedImageBytes = 50 << 20
+	maxImageErrorBodyBytes = 512
+)
+
+type generatedImage struct {
+	Data      []byte
+	MediaType string
+}
+
+// imageModelTextResponseError signals that the chat-fallback image model
+// replied with text instead of an image (e.g. a refusal or a request for
+// clarification). This is not a tool failure — execGenerateImage relays the
+// text as a normal tool result so the agent can act on it, rather than
+// surfacing it as an execution error that counts against loop/retry guards.
+type imageModelTextResponseError struct {
+	text string
+}
+
+func (e *imageModelTextResponseError) Error() string {
+	return "no image generated; model response: " + e.text
+}
 
 type ImageGenProvider struct {
 	logger     *slog.Logger
@@ -65,27 +95,51 @@ func (p *ImageGenProvider) Tools(ctx context.Context, session SessionContext) ([
 	if strings.TrimSpace(botSettings.ImageModelID) == "" {
 		return nil, nil
 	}
+	description := "Generate an image from a text description using the configured image generation model. Returns the workspace file path of the generated image."
+	if session.CanUseLocalMessagingShortcut() {
+		description += " The generated image is automatically shown to the user in the current conversation."
+	} else {
+		description += " The image is not shown to the user automatically."
+	}
 	sess := session
 	return []sdk.Tool{
 		{
 			Name:        ToolGenerateImage().String(),
-			Description: "Generate an image from a text description using the configured image generation model. Returns the file path of the generated image in the workspace.",
+			Description: description,
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"prompt": map[string]any{"type": "string", "description": "Detailed description of the image to generate"},
-					"size":   map[string]any{"type": "string", "description": "Image size, e.g. 1024x1024, 1792x1024, 1024x1792. Defaults to 1024x1024."},
+					"size":   map[string]any{"type": "string", "description": "Optional image size, e.g. 1024x1024, 1792x1024, 1024x1792. Leave empty to use the provider default."},
 				},
 				"required": []string{"prompt"},
 			},
 			Execute: func(execCtx *sdk.ToolExecContext, input any) (any, error) {
-				return p.execGenerateImage(execCtx.Context, sess, inputAsMap(input))
+				return p.execGenerateImage(execCtx.Context, sess, execCtx.ToolCallID, inputAsMap(input))
 			},
 		},
 	}, nil
 }
 
-func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session SessionContext, args map[string]any) (any, error) {
+func (*ImageGenProvider) Usage(_ context.Context, session SessionContext, available AvailableTools) string {
+	genRef, ok := available.Ref(ToolGenerateImage())
+	if !ok {
+		return ""
+	}
+	sendRef, hasSend := available.Ref(ToolSend())
+	var items []string
+	if session.CanUseLocalMessagingShortcut() {
+		items = append(items, genRef+" already shows the generated image to the user in the current conversation; do not send it there again.")
+		if hasSend {
+			items = append(items, "To share a generated image with another channel or person, call "+sendRef+" with the returned path in `attachments`.")
+		}
+	} else if hasSend {
+		items = append(items, genRef+" only saves the image to the workspace; the user never sees it automatically. Share it by calling "+sendRef+" with the returned path in `attachments`.")
+	}
+	return usageSection("Image generation", items)
+}
+
+func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session SessionContext, toolCallID string, args map[string]any) (any, error) {
 	botID := strings.TrimSpace(session.BotID)
 	if botID == "" {
 		return nil, errors.New("bot_id is required")
@@ -95,9 +149,6 @@ func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session Sessio
 		return nil, errors.New("prompt is required")
 	}
 	size := strings.TrimSpace(StringArg(args, "size"))
-	if size == "" {
-		size = "1024x1024"
-	}
 
 	botSettings, err := p.settings.GetBot(ctx, botID)
 	if err != nil {
@@ -123,6 +174,9 @@ func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session Sessio
 	if err != nil {
 		return nil, fmt.Errorf("failed to load model provider: %w", err)
 	}
+	if !provider.Enable {
+		return nil, fmt.Errorf("image model provider %s is disabled", provider.Name)
+	}
 
 	authResolver := providers.NewService(nil, p.queries, "")
 	creds, err := authResolver.ResolveModelCredentials(ctx, provider)
@@ -130,48 +184,24 @@ func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session Sessio
 		return nil, fmt.Errorf("failed to resolve provider credentials: %w", err)
 	}
 
-	sdkModel := models.NewSDKChatModel(models.SDKModelConfig{
-		ModelID:    modelResp.ModelID,
-		ClientType: provider.ClientType,
-		APIKey:     creds.APIKey,
-		BaseURL:    providers.ProviderConfigString(provider, "base_url"),
-	})
-
-	userMsg := fmt.Sprintf("Generate an image with the following description. Size: %s\n\n%s", size, prompt)
-	system, messages, _ := models.ApplyPromptCache(
-		sdkModel,
-		providers.ProviderConfigString(provider, "prompt_cache_ttl"),
-		"",
-		[]sdk.Message{{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: userMsg}}}},
-		nil,
-	)
-	result, err := sdk.GenerateTextResult(ctx,
-		sdk.WithModel(sdkModel),
-		sdk.WithSystem(system),
-		sdk.WithMessages(messages),
-	)
+	image, err := p.generateImage(ctx, provider, creds.APIKey, modelResp.ModelID, prompt, size)
 	if err != nil {
+		var textResp *imageModelTextResponseError
+		if errors.As(err, &textResp) {
+			return map[string]any{
+				"model_response": textResp.text,
+				"note":           "the image model returned a text response instead of an image",
+			}, nil
+		}
 		return nil, fmt.Errorf("image generation failed: %w", err)
 	}
-
-	if len(result.Files) == 0 {
-		if result.Text != "" {
-			return map[string]any{"error": "no image generated", "model_response": result.Text}, nil
-		}
-		return nil, errors.New("no image was generated by the model")
-	}
-
-	file := result.Files[0]
-	imgBytes, err := base64.StdEncoding.DecodeString(file.Data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode generated image: %w", err)
-	}
+	imgBytes := image.Data
 
 	ext := "png"
 	switch {
-	case strings.Contains(file.MediaType, "jpeg"), strings.Contains(file.MediaType, "jpg"):
+	case strings.Contains(image.MediaType, "jpeg"), strings.Contains(image.MediaType, "jpg"):
 		ext = "jpg"
-	case strings.Contains(file.MediaType, "webp"):
+	case strings.Contains(image.MediaType, "webp"):
 		ext = "webp"
 	}
 
@@ -183,31 +213,406 @@ func (p *ImageGenProvider) execGenerateImage(ctx context.Context, session Sessio
 	}
 	containerPath := fmt.Sprintf("%s/%d.%s", imageDir, time.Now().UnixMilli(), ext)
 
-	client, clientErr := p.containers.MCPClient(ctx, botID)
-	if clientErr != nil {
-		return map[string]any{
-			"content": []map[string]any{
-				{"type": "text", "text": "Image generated (container not reachable, not saved to disk)"},
-				{"type": "image", "data": file.Data, "mimeType": file.MediaType},
-			},
-		}, nil
+	if p.containers == nil {
+		return p.unsavedImageResult(session, toolCallID, image, "Image generated (container not reachable, not saved to disk)"), nil
 	}
 
-	mkdirCmd := fmt.Sprintf("mkdir -p %s", imageDir)
+	client, clientErr := p.containers.MCPClient(ctx, botID)
+	if clientErr != nil {
+		return p.unsavedImageResult(session, toolCallID, image, "Image generated (container not reachable, not saved to disk)"), nil
+	}
+
+	// Best-effort mkdir: a transient exec failure must not block saving when the
+	// directory already exists — WriteFile below is the authoritative check.
+	mkdirCmd := fmt.Sprintf("mkdir -p %s", shellQuote(imageDir))
 	_, _ = client.Exec(ctx, mkdirCmd, "/", 5)
 
 	if writeErr := client.WriteFile(ctx, containerPath, imgBytes); writeErr != nil {
-		return map[string]any{
-			"content": []map[string]any{
-				{"type": "text", "text": fmt.Sprintf("Image generated (failed to save: %s)", writeErr.Error())},
-				{"type": "image", "data": file.Data, "mimeType": file.MediaType},
-			},
-		}, nil
+		return p.unsavedImageResult(session, toolCallID, image, fmt.Sprintf("Image generated (failed to save: %s)", writeErr.Error())), nil
 	}
 
-	return map[string]any{
+	result := map[string]any{
 		"path":       containerPath,
-		"media_type": file.MediaType,
+		"media_type": image.MediaType,
 		"size_bytes": len(imgBytes),
+	}
+	if p.deliverGeneratedImage(session, toolCallID, Attachment{
+		Type: "image",
+		Path: containerPath,
+		Name: path.Base(containerPath),
+		Mime: image.MediaType,
+		Size: int64(len(imgBytes)),
+	}) {
+		result["delivered"] = "current_conversation"
+	}
+	return result, nil
+}
+
+// deliverGeneratedImage shows the generated image to the user in the current
+// conversation via the live agent stream, mirroring how speak delivers
+// same-conversation voice attachments. Non-interactive runs return false and
+// rely on the model sharing the returned path through the send tool.
+func (*ImageGenProvider) deliverGeneratedImage(session SessionContext, toolCallID string, att Attachment) bool {
+	if !session.CanUseLocalMessagingShortcut() {
+		return false
+	}
+	session.Emitter(ToolStreamEvent{
+		Type:        StreamEventAttachment,
+		ToolCallID:  toolCallID,
+		Attachments: []Attachment{att},
+	})
+	return true
+}
+
+// unsavedImageResult handles images that could not be persisted to the
+// workspace: deliver them to the user inline when the live stream allows it,
+// otherwise fall back to returning the image content to the model.
+func (p *ImageGenProvider) unsavedImageResult(session SessionContext, toolCallID string, image generatedImage, text string) map[string]any {
+	if p.deliverGeneratedImage(session, toolCallID, Attachment{
+		Type: "image",
+		URL:  fmt.Sprintf("data:%s;base64,%s", image.MediaType, base64.StdEncoding.EncodeToString(image.Data)),
+		Mime: image.MediaType,
+		Size: int64(len(image.Data)),
+	}) {
+		return map[string]any{
+			"delivered":  "current_conversation",
+			"media_type": image.MediaType,
+			"size_bytes": len(image.Data),
+			"note":       text,
+		}
+	}
+	return map[string]any{
+		"content": []map[string]any{
+			{"type": "text", "text": text},
+			{"type": "image", "data": base64.StdEncoding.EncodeToString(image.Data), "mimeType": image.MediaType},
+		},
+	}
+}
+
+func (*ImageGenProvider) generateImage(ctx context.Context, provider sqlc.Provider, apiKey, modelID, prompt, size string) (generatedImage, error) {
+	baseURL := providers.ProviderConfigString(provider, "base_url")
+	httpClient := models.NewProviderHTTPClient(models.DefaultProviderRequestTimeout)
+
+	switch {
+	case shouldUseDashScopeImageGeneration(provider.ClientType, baseURL, modelID):
+		return generateDashScopeImage(ctx, httpClient, baseURL, apiKey, modelID, prompt, size)
+	case shouldUseOpenAIImagesGeneration(provider.ClientType, baseURL, modelID):
+		return generateOpenAIImagesImage(ctx, httpClient, baseURL, apiKey, modelID, prompt, size)
+	default:
+		return generateChatImage(ctx, provider, apiKey, modelID, prompt, size)
+	}
+}
+
+// shouldUseDashScopeImageGeneration routes to the DashScope native images API
+// only when the provider's base URL confirms DashScope. Routing by bare model
+// name (e.g. "qwen-image", "wan*") would send the DashScope request format to
+// any OpenAI-compatible aggregator that happens to host a same-named model,
+// which such aggregators serve through chat completions instead — so the base
+// URL is the authoritative signal and the chat fallback handles the rest.
+func shouldUseDashScopeImageGeneration(clientType, baseURL, _ string) bool {
+	ct := models.ClientType(clientType)
+	if ct != models.ClientTypeOpenAICompletions && ct != models.ClientTypeOpenAIResponses {
+		return false
+	}
+	lowerBase := strings.ToLower(strings.TrimSpace(baseURL))
+	return strings.Contains(lowerBase, "dashscope") ||
+		strings.Contains(lowerBase, "maas.aliyuncs.com")
+}
+
+// shouldUseOpenAIImagesGeneration routes to the OpenAI /images/generations API
+// only for base URLs known to serve it. As with DashScope, routing by bare
+// model name alone is unsafe on unknown bases, so those fall through to the
+// chat fallback rather than being forced onto the images endpoint.
+func shouldUseOpenAIImagesGeneration(clientType, baseURL, _ string) bool {
+	ct := models.ClientType(clientType)
+	if ct != models.ClientTypeOpenAICompletions && ct != models.ClientTypeOpenAIResponses {
+		return false
+	}
+	lowerBase := strings.ToLower(strings.TrimSpace(baseURL))
+	if strings.Contains(lowerBase, "openrouter.ai") {
+		return false
+	}
+	return strings.Contains(lowerBase, "api.openai.com") ||
+		strings.Contains(lowerBase, "volces.com") ||
+		strings.Contains(lowerBase, "bytepluses.com") ||
+		strings.Contains(lowerBase, "siliconflow")
+}
+
+func generateDashScopeImage(ctx context.Context, httpClient *http.Client, baseURL, apiKey, modelID, prompt, size string) (generatedImage, error) {
+	opts := []alibabaimages.Option{
+		alibabaimages.WithAPIKey(apiKey),
+		alibabaimages.WithHTTPClient(httpClient),
+	}
+	if strings.TrimSpace(baseURL) != "" {
+		opts = append(opts, alibabaimages.WithBaseURL(strings.TrimSpace(baseURL)))
+	}
+	provider := alibabaimages.New(opts...)
+	result, err := sdk.GenerateImage(ctx,
+		sdk.WithImageGenerationModel(provider.GenerationModel(modelID)),
+		sdk.WithImagePrompt(prompt),
+		sdk.WithImageSize(size),
+		sdk.WithImageN(1),
+	)
+	if err != nil {
+		return generatedImage{}, err
+	}
+	return imageResultToGeneratedImage(ctx, httpClient, result)
+}
+
+func generateOpenAIImagesImage(ctx context.Context, httpClient *http.Client, baseURL, apiKey, modelID, prompt, size string) (generatedImage, error) {
+	opts := []openaiimages.Option{
+		openaiimages.WithAPIKey(apiKey),
+		openaiimages.WithHTTPClient(httpClient),
+	}
+	if strings.TrimSpace(baseURL) != "" {
+		opts = append(opts, openaiimages.WithBaseURL(strings.TrimRight(strings.TrimSpace(baseURL), "/")))
+	}
+	provider := openaiimages.New(opts...)
+	imageModel := provider.GenerationModel(modelID)
+	result, err := sdk.GenerateImage(ctx,
+		sdk.WithImageGenerationModel(imageModel),
+		sdk.WithImagePrompt(prompt),
+		sdk.WithImageSize(size),
+		sdk.WithImageN(1),
+	)
+	if err != nil {
+		return generatedImage{}, err
+	}
+	return imageResultToGeneratedImage(ctx, httpClient, result)
+}
+
+func generateChatImage(ctx context.Context, provider sqlc.Provider, apiKey, modelID, prompt, size string) (generatedImage, error) {
+	if strings.TrimSpace(size) == "" {
+		size = "1024x1024"
+	}
+	sdkModel := models.NewSDKChatModel(models.SDKModelConfig{
+		ModelID:    modelID,
+		ClientType: provider.ClientType,
+		APIKey:     apiKey,
+		BaseURL:    providers.ProviderConfigString(provider, "base_url"),
+	})
+
+	userMsg := fmt.Sprintf("Generate an image with the following description. Size: %s\n\n%s", size, prompt)
+	system, messages, _ := models.ApplyPromptCache(
+		sdkModel,
+		providers.ProviderConfigString(provider, "prompt_cache_ttl"),
+		"",
+		[]sdk.Message{sdk.UserMessage(userMsg)},
+		nil,
+	)
+	result, err := sdk.GenerateTextResult(ctx,
+		sdk.WithModel(sdkModel),
+		sdk.WithSystem(system),
+		sdk.WithMessages(messages),
+	)
+	if err != nil {
+		return generatedImage{}, err
+	}
+
+	if len(result.Files) == 0 {
+		if result.Text != "" {
+			return generatedImage{}, &imageModelTextResponseError{text: result.Text}
+		}
+		return generatedImage{}, errors.New("no image was generated by the model")
+	}
+
+	file := result.Files[0]
+	imgBytes, err := base64.StdEncoding.DecodeString(file.Data)
+	if err != nil {
+		return generatedImage{}, fmt.Errorf("failed to decode generated image: %w", err)
+	}
+	return generatedImage{
+		Data:      imgBytes,
+		MediaType: normalizeImageMediaType(file.MediaType, imgBytes),
 	}, nil
+}
+
+func imageResultToGeneratedImage(ctx context.Context, httpClient *http.Client, result *sdk.ImageResult) (generatedImage, error) {
+	if result == nil || len(result.Data) == 0 {
+		return generatedImage{}, errors.New("no image was generated by the model")
+	}
+	first := result.Data[0]
+	if strings.TrimSpace(first.B64JSON) != "" {
+		data, err := base64.StdEncoding.DecodeString(first.B64JSON)
+		if err != nil {
+			return generatedImage{}, fmt.Errorf("failed to decode generated image: %w", err)
+		}
+		return generatedImage{Data: data, MediaType: normalizeImageMediaType("", data)}, nil
+	}
+	if strings.TrimSpace(first.URL) != "" {
+		return fetchGeneratedImageURL(ctx, httpClient, first.URL)
+	}
+	return generatedImage{}, errors.New("image response did not include image data or URL")
+}
+
+func fetchGeneratedImageURL(ctx context.Context, httpClient *http.Client, rawURL string) (generatedImage, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return generatedImage{}, fmt.Errorf("parse image URL: %w", err)
+	}
+	if err := validateImageDownloadURL(ctx, parsed); err != nil {
+		return generatedImage{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return generatedImage{}, fmt.Errorf("create image download request: %w", err)
+	}
+	resp, err := imageDownloadClient(httpClient).Do(req) //nolint:gosec // G704: provider-returned image URL; the download transport validates every dialed IP against restricted ranges at connect time (ssrfSafeDialContext), closing the DNS-rebinding TOCTOU
+	if err != nil {
+		return generatedImage{}, fmt.Errorf("download image: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxGeneratedImageBytes+1))
+	if err != nil {
+		return generatedImage{}, fmt.Errorf("read image response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return generatedImage{}, fmt.Errorf("download image failed with status %d: %s", resp.StatusCode, truncateForError(string(data), maxImageErrorBodyBytes))
+	}
+	if len(data) > maxGeneratedImageBytes {
+		return generatedImage{}, fmt.Errorf("download image exceeded %d bytes", maxGeneratedImageBytes)
+	}
+	if len(data) == 0 {
+		return generatedImage{}, errors.New("downloaded image response was empty")
+	}
+	mediaType, ok := detectImageMediaType(resp.Header.Get("Content-Type"), data)
+	if !ok {
+		return generatedImage{}, fmt.Errorf("downloaded content is not an image: %s", strings.TrimSpace(resp.Header.Get("Content-Type")))
+	}
+	return generatedImage{
+		Data:      data,
+		MediaType: mediaType,
+	}, nil
+}
+
+// imageDownloadClient wraps the provider HTTP client with an SSRF-safe
+// transport. IP validation happens inside the dialer (ssrfSafeDialContext), so
+// the address that is actually connected to is the one that was checked — this
+// closes the DNS-rebinding TOCTOU that a validate-then-Do split leaves open,
+// and covers every redirect hop because the transport dials each one.
+func imageDownloadClient(base *http.Client) *http.Client {
+	clone := &http.Client{
+		Transport:     imageDownloadTransport(),
+		CheckRedirect: checkImageRedirect,
+	}
+	if base != nil {
+		clone.Timeout = base.Timeout
+	}
+	return clone
+}
+
+func checkImageRedirect(req *http.Request, via []*http.Request) error {
+	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+		return fmt.Errorf("unsupported redirect scheme: %s", req.URL.Scheme)
+	}
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	return nil
+}
+
+func imageDownloadTransport() *http.Transport {
+	if base, ok := http.DefaultTransport.(*http.Transport); ok {
+		clone := base.Clone()
+		clone.DialContext = ssrfSafeDialContext
+		return clone
+	}
+	return &http.Transport{DialContext: ssrfSafeDialContext}
+}
+
+// ssrfSafeDialContext resolves the destination host, rejects any address in a
+// restricted range, and dials the validated IP literal directly. Because the
+// connection targets the exact IP that passed validation, a short-TTL rebinding
+// record cannot swap in an internal address between check and connect. TLS
+// verification still uses the original hostname (the transport sets ServerName
+// from the request URL, not from the dialed address).
+func ssrfSafeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	var ips []net.IP
+	if ip := net.ParseIP(host); ip != nil {
+		ips = []net.IP{ip}
+	} else {
+		addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("resolve image URL host %s: %w", host, err)
+		}
+		for _, a := range addrs {
+			ips = append(ips, a.IP)
+		}
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("resolve image URL host %s: no addresses", host)
+	}
+	var lastErr error
+	for _, ip := range ips {
+		if isRestrictedImageDownloadIP(ip) {
+			lastErr = fmt.Errorf("blocked image URL host %s resolved to restricted address %s", host, ip.String())
+			continue
+		}
+		conn, err := imageConnectDialer(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return conn, nil
+	}
+	return nil, lastErr
+}
+
+// imageConnectDialer performs the TCP connect after an address has passed SSRF
+// validation. It is a package variable so tests can redirect the connect to a
+// local server while still exercising the real IP-range validation above.
+var imageConnectDialer = (&net.Dialer{}).DialContext
+
+// validateImageDownloadURL is a cheap pre-flight check for a clear early error;
+// the authoritative IP-range enforcement lives in ssrfSafeDialContext, which
+// runs for the initial request and every redirect hop.
+func validateImageDownloadURL(_ context.Context, parsed *url.URL) error {
+	if parsed == nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || strings.TrimSpace(parsed.Hostname()) == "" {
+		return fmt.Errorf("unsupported image URL: %s", parsed)
+	}
+	return nil
+}
+
+func isRestrictedImageDownloadIP(ip net.IP) bool {
+	return ip == nil ||
+		ip.IsUnspecified() ||
+		ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast()
+}
+
+func detectImageMediaType(_ string, data []byte) (string, bool) {
+	if len(data) == 0 {
+		return "", false
+	}
+	detected := http.DetectContentType(data)
+	if strings.HasPrefix(detected, "image/") {
+		return detected, true
+	}
+	return "", false
+}
+
+// truncateForError bounds an untrusted response body before it is embedded in
+// an error message, so an expired-URL error page or junk payload cannot balloon
+// the tool result, conversation stream, and logs.
+func truncateForError(s string, limit int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "…(truncated)"
+}
+
+func normalizeImageMediaType(mediaType string, data []byte) string {
+	if detected, ok := detectImageMediaType(mediaType, data); ok {
+		return detected
+	}
+	return "image/png"
 }

--- a/internal/agent/tools/image_gen_test.go
+++ b/internal/agent/tools/image_gen_test.go
@@ -1,0 +1,477 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	"github.com/memohai/memoh/internal/models"
+)
+
+var testPNGBytes = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+
+func TestGenerateDashScopeImageUsesAsyncSDKProviderAndDownloadsImage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/image-generation/generation":
+			if got := r.Method; got != http.MethodPost {
+				t.Fatalf("method = %s, want POST", got)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer dashscope-key" {
+				t.Fatalf("authorization = %q, want bearer key", got)
+			}
+			if got := r.Header.Get("X-DashScope-Async"); got != "enable" {
+				t.Fatalf("X-DashScope-Async = %q, want enable", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "wan2.7-image-pro" {
+				t.Fatalf("model = %v, want wan2.7-image-pro", got)
+			}
+			input := body["input"].(map[string]any)
+			messages := input["messages"].([]any)
+			message := messages[0].(map[string]any)
+			content := message["content"].([]any)
+			textPart := content[0].(map[string]any)
+			if got := message["role"]; got != "user" {
+				t.Fatalf("role = %v, want user", got)
+			}
+			if got := textPart["text"]; got != "a red cube" {
+				t.Fatalf("prompt text = %v, want a red cube", got)
+			}
+			params := body["parameters"].(map[string]any)
+			if got := params["size"]; got != "1024*1024" {
+				t.Fatalf("size = %v, want 1024*1024", got)
+			}
+			if got := params["n"]; got != float64(1) {
+				t.Fatalf("n = %v, want 1", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"output":{"task_id":"task-1","task_status":"SUCCEEDED","choices":[{"message":{"content":[{"image":"` + publicTestURL("/image.png") + `","type":"image"}]}}]}}`))
+		case "/image.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(testPNGBytes)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	image, err := generateDashScopeImage(context.Background(), imageTestClient(t, server), server.URL+"/compatible-mode/v1", "dashscope-key", "wan2.7-image-pro", "a red cube", "1024x1024")
+	if err != nil {
+		t.Fatalf("generateDashScopeImage() error = %v", err)
+	}
+	if string(image.Data) != string(testPNGBytes) {
+		t.Fatalf("image bytes = %v, want %v", image.Data, testPNGBytes)
+	}
+	if image.MediaType != "image/png" {
+		t.Fatalf("media type = %q, want image/png", image.MediaType)
+	}
+}
+
+func TestGenerateDashScopeQwenImageUsesProviderDefaultSizeWhenUnspecified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/text2image/image-synthesis":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "qwen-image-plus" {
+				t.Fatalf("model = %v, want qwen-image-plus", got)
+			}
+			input := body["input"].(map[string]any)
+			if got := input["prompt"]; got != "a red cube" {
+				t.Fatalf("prompt = %v, want a red cube", got)
+			}
+			parameters := body["parameters"].(map[string]any)
+			if _, ok := parameters["size"]; ok {
+				t.Fatalf("size parameter was sent: %v", parameters["size"])
+			}
+			if got := parameters["n"]; got != float64(1) {
+				t.Fatalf("n = %v, want 1", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"output":{"task_status":"SUCCEEDED","results":[{"url":"` + publicTestURL("/qwen.png") + `"}]}}`))
+		case "/qwen.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(testPNGBytes)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	image, err := generateDashScopeImage(context.Background(), imageTestClient(t, server), server.URL+"/compatible-mode/v1", "dashscope-key", "qwen-image-plus", "a red cube", "")
+	if err != nil {
+		t.Fatalf("generateDashScopeImage() error = %v", err)
+	}
+	if string(image.Data) != string(testPNGBytes) {
+		t.Fatalf("image bytes = %v, want %v", image.Data, testPNGBytes)
+	}
+}
+
+func TestGenerateOpenAIImagesImageUsesImagesEndpointAndDownloadsURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/images/generations":
+			if got := r.Method; got != http.MethodPost {
+				t.Fatalf("method = %s, want POST", got)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer openai-key" {
+				t.Fatalf("authorization = %q, want bearer key", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "gpt-image-1" {
+				t.Fatalf("model = %v, want gpt-image-1", got)
+			}
+			if got := body["prompt"]; got != "a blue sphere" {
+				t.Fatalf("prompt = %v, want a blue sphere", got)
+			}
+			if got := body["size"]; got != "1024x1024" {
+				t.Fatalf("size = %v, want 1024x1024", got)
+			}
+			if got := body["n"]; got != float64(1) {
+				t.Fatalf("n = %v, want 1", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"created":1,"data":[{"url":"` + publicTestURL("/openai.png") + `"}]}`))
+		case "/openai.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(testPNGBytes)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	image, err := generateOpenAIImagesImage(context.Background(), imageTestClient(t, server), server.URL+"/api/v3", "openai-key", "gpt-image-1", "a blue sphere", "1024x1024")
+	if err != nil {
+		t.Fatalf("generateOpenAIImagesImage() error = %v", err)
+	}
+	if string(image.Data) != string(testPNGBytes) {
+		t.Fatalf("image bytes = %v, want %v", image.Data, testPNGBytes)
+	}
+	if image.MediaType != "image/png" {
+		t.Fatalf("media type = %q, want image/png", image.MediaType)
+	}
+}
+
+func TestImageResultToGeneratedImageDecodesB64JSON(t *testing.T) {
+	t.Parallel()
+
+	image, err := imageResultToGeneratedImage(context.Background(), http.DefaultClient, &sdk.ImageResult{
+		Data: []sdk.ImageData{{
+			B64JSON: base64.StdEncoding.EncodeToString(testPNGBytes),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("imageResultToGeneratedImage() error = %v", err)
+	}
+	if string(image.Data) != string(testPNGBytes) {
+		t.Fatalf("image bytes = %v, want %v", image.Data, testPNGBytes)
+	}
+	if image.MediaType != "image/png" {
+		t.Fatalf("media type = %q, want image/png", image.MediaType)
+	}
+}
+
+func TestImageResultToGeneratedImageRejectsNonImageURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"not":"an image"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := imageResultToGeneratedImage(context.Background(), imageTestClient(t, server), &sdk.ImageResult{
+		Data: []sdk.ImageData{{URL: publicTestURL("/")}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not an image") {
+		t.Fatalf("imageResultToGeneratedImage() error = %v, want non-image rejection", err)
+	}
+}
+
+func TestImageResultToGeneratedImageRejectsSpoofedImageContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte(`{"not":"an image"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := imageResultToGeneratedImage(context.Background(), imageTestClient(t, server), &sdk.ImageResult{
+		Data: []sdk.ImageData{{URL: publicTestURL("/")}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not an image") {
+		t.Fatalf("imageResultToGeneratedImage() error = %v, want spoofed image rejection", err)
+	}
+}
+
+func TestImageResultToGeneratedImageRejectsUnsupportedURLScheme(t *testing.T) {
+	t.Parallel()
+
+	_, err := imageResultToGeneratedImage(context.Background(), http.DefaultClient, &sdk.ImageResult{
+		Data: []sdk.ImageData{{URL: "file:///tmp/generated.png"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported image URL") {
+		t.Fatalf("imageResultToGeneratedImage() error = %v, want unsupported URL rejection", err)
+	}
+}
+
+func TestImageResultToGeneratedImageRejectsRestrictedImageURL(t *testing.T) {
+	_, err := imageResultToGeneratedImage(context.Background(), http.DefaultClient, &sdk.ImageResult{
+		Data: []sdk.ImageData{{URL: "http://127.0.0.1/image.png"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "restricted address") {
+		t.Fatalf("imageResultToGeneratedImage() error = %v, want restricted address rejection", err)
+	}
+}
+
+func TestImageResultToGeneratedImageRejectsRestrictedRedirectURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://127.0.0.1/image.png", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := imageResultToGeneratedImage(context.Background(), imageTestClient(t, server), &sdk.ImageResult{
+		Data: []sdk.ImageData{{URL: publicTestURL("/")}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "restricted address") {
+		t.Fatalf("imageResultToGeneratedImage() error = %v, want restricted redirect rejection", err)
+	}
+}
+
+// TestSSRFSafeDialContextBlocksRebindingToInternalIP is the regression test for
+// the DNS-rebinding TOCTOU: validation and connection must resolve the same
+// way. The dialer resolves and validates at connect time and dials only the
+// validated IP, so a host that resolves to a restricted address is blocked at
+// the dial step rather than after a separate, earlier check.
+func TestSSRFSafeDialContextBlocksRebindingToInternalIP(t *testing.T) {
+	_, err := ssrfSafeDialContext(context.Background(), "tcp", "127.0.0.1:80")
+	if err == nil || !strings.Contains(err.Error(), "restricted address") {
+		t.Fatalf("ssrfSafeDialContext to loopback = %v, want restricted address block", err)
+	}
+	// 169.254.169.254 is the cloud metadata endpoint — link-local, must block.
+	_, err = ssrfSafeDialContext(context.Background(), "tcp", "169.254.169.254:80")
+	if err == nil || !strings.Contains(err.Error(), "restricted address") {
+		t.Fatalf("ssrfSafeDialContext to metadata IP = %v, want restricted address block", err)
+	}
+}
+
+func TestFetchGeneratedImageRejectsEmptyBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		// 200 OK with a Content-Type of image/png but no body.
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := imageResultToGeneratedImage(context.Background(), imageTestClient(t, server), &sdk.ImageResult{
+		Data: []sdk.ImageData{{URL: publicTestURL("/")}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("imageResultToGeneratedImage() empty-body error = %v, want empty rejection", err)
+	}
+}
+
+func TestFetchGeneratedImageTruncatesLargeErrorBody(t *testing.T) {
+	huge := strings.Repeat("x", 200_000)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(huge))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := imageResultToGeneratedImage(context.Background(), imageTestClient(t, server), &sdk.ImageResult{
+		Data: []sdk.ImageData{{URL: publicTestURL("/")}},
+	})
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if len(err.Error()) > maxImageErrorBodyBytes+200 {
+		t.Fatalf("error length = %d, want bounded near %d (body must be truncated)", len(err.Error()), maxImageErrorBodyBytes)
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("error = %q, want truncation marker", err.Error())
+	}
+}
+
+func TestExecGenerateImageRelaysChatFallbackTextAsResult(t *testing.T) {
+	// A chat-fallback model that replies with text instead of an image must be
+	// relayed as a normal tool result, not a tool execution error.
+	textErr := &imageModelTextResponseError{text: "I can't create that image."}
+	var wrapped error = textErr
+	var got *imageModelTextResponseError
+	if !errors.As(wrapped, &got) {
+		t.Fatal("imageModelTextResponseError should be unwrappable via errors.As")
+	}
+	if got.text != "I can't create that image." {
+		t.Fatalf("text = %q, want the model's reply", got.text)
+	}
+}
+
+func TestImageGenerationRouting(t *testing.T) {
+	t.Parallel()
+
+	openAICompletions := string(models.ClientTypeOpenAICompletions)
+	if !shouldUseDashScopeImageGeneration(openAICompletions, "https://dashscope.aliyuncs.com/compatible-mode/v1", "qwen-plus") {
+		t.Fatal("dashscope base URL should use DashScope image generation")
+	}
+	// Routing is by base URL only: a DashScope-family model name on an unknown
+	// base must NOT be forced onto the DashScope API (it would 400 there); it
+	// falls through to the chat path instead.
+	if shouldUseDashScopeImageGeneration(openAICompletions, "https://some-aggregator.example/v1", "wan2.2-t2i-flash") {
+		t.Fatal("wan model on a non-dashscope base must not use DashScope image generation")
+	}
+	if shouldUseDashScopeImageGeneration(openAICompletions, "", "wan2.2-t2i-flash") {
+		t.Fatal("wan model with no base URL must not use DashScope image generation")
+	}
+	if !shouldUseOpenAIImagesGeneration(openAICompletions, "https://ark.cn-beijing.volces.com/api/v3", "doubao-seedream-3-0-t2i") {
+		t.Fatal("volcengine image model should use OpenAI images generation")
+	}
+	if !shouldUseOpenAIImagesGeneration(string(models.ClientTypeOpenAIResponses), "https://api.openai.com/v1", "gpt-image-1") {
+		t.Fatal("openai-responses image model should use OpenAI images generation")
+	}
+	// gpt-image name on an unknown base is not enough to route to the images API.
+	if shouldUseOpenAIImagesGeneration(openAICompletions, "https://some-aggregator.example/v1", "gpt-image-1") {
+		t.Fatal("gpt-image model on an unknown base must not use OpenAI images generation")
+	}
+	if shouldUseOpenAIImagesGeneration(openAICompletions, "https://openrouter.ai/api/v1", "gpt-image-1") {
+		t.Fatal("openrouter should not use OpenAI images generation")
+	}
+	if shouldUseOpenAIImagesGeneration(string(models.ClientTypeAnthropicMessages), "https://api.openai.com/v1", "gpt-image-1") {
+		t.Fatal("non-openai-completions client should not use OpenAI images generation")
+	}
+}
+
+// publicTestURL uses a TEST-NET-3 documentation address (RFC 5737): it is not
+// loopback/private, so it passes SSRF validation, while redirectImageDialerToServer
+// sends the actual connection to the local test server.
+func publicTestURL(path string) string {
+	return "http://198.51.100.10" + path
+}
+
+// imageTestClient points the SSRF-safe download dialer's connect step at the
+// local test server for the duration of the test and returns the client to
+// pass into the download path. IP-range validation still runs against the real
+// request host (so restricted addresses like 127.0.0.1 are still blocked before
+// this dialer is reached); only the final TCP connect for an allowed host is
+// redirected. Tests using it must not call t.Parallel() — the dialer seam is a
+// process-global swapped for the test's duration.
+func imageTestClient(t *testing.T, server *httptest.Server) *http.Client {
+	t.Helper()
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	prev := imageConnectDialer
+	imageConnectDialer = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, target.Host)
+	}
+	t.Cleanup(func() { imageConnectDialer = prev })
+	return http.DefaultClient
+}
+
+func liveShortcutSession(emitter StreamEmitter) SessionContext {
+	return SessionContext{
+		LiveStream:      true,
+		Emitter:         emitter,
+		CurrentPlatform: "local",
+		ReplyTarget:     "chat-1",
+	}
+}
+
+func TestImageGenProviderUsageGatesRegisteredTools(t *testing.T) {
+	t.Parallel()
+
+	provider := &ImageGenProvider{}
+	background := SessionContext{}
+
+	if got := provider.Usage(context.Background(), background, AvailableTools{}); got != "" {
+		t.Fatalf("Usage without available tools = %q, want empty", got)
+	}
+	if got := provider.Usage(context.Background(), background, availableToolsForTest(ToolGenerateImage())); got != "" {
+		t.Fatalf("Usage without send tool or live stream = %q, want empty", got)
+	}
+
+	got := provider.Usage(context.Background(), background, availableToolsForTest(ToolGenerateImage(), ToolSend()))
+	assertUsageItemsAreBulleted(t, got)
+	if !strings.Contains(got, "`generate_image`") || !strings.Contains(got, "`send`") || !strings.Contains(got, "attachments") {
+		t.Fatalf("Usage without live stream should tell the model to share images via send attachments, got:\n%s", got)
+	}
+
+	live := liveShortcutSession(func(ToolStreamEvent) {})
+	got = provider.Usage(context.Background(), live, availableToolsForTest(ToolGenerateImage(), ToolSend()))
+	assertUsageItemsAreBulleted(t, got)
+	if !strings.Contains(got, "already shows") {
+		t.Fatalf("Usage with live stream should say the image is shown automatically, got:\n%s", got)
+	}
+	if !strings.Contains(got, "`send`") {
+		t.Fatalf("Usage with live stream should still cover cross-conversation sharing via send, got:\n%s", got)
+	}
+}
+
+func TestDeliverGeneratedImageEmitsOnlyOnLiveShortcutSessions(t *testing.T) {
+	t.Parallel()
+
+	provider := &ImageGenProvider{}
+	att := Attachment{Type: "image", Path: "/data/generated-images/1.png", Mime: "image/png"}
+
+	var events []ToolStreamEvent
+	live := liveShortcutSession(func(evt ToolStreamEvent) { events = append(events, evt) })
+	if !provider.deliverGeneratedImage(live, "call-1", att) {
+		t.Fatal("deliverGeneratedImage on a live chat session should deliver")
+	}
+	if len(events) != 1 || events[0].Type != StreamEventAttachment {
+		t.Fatalf("events = %+v, want one attachment event", events)
+	}
+	if events[0].ToolCallID != "call-1" {
+		t.Fatalf("tool call id = %q, want call-1", events[0].ToolCallID)
+	}
+	if len(events[0].Attachments) != 1 || events[0].Attachments[0].Path != att.Path {
+		t.Fatalf("attachments = %+v, want the generated image path", events[0].Attachments)
+	}
+
+	background := liveShortcutSession(func(ToolStreamEvent) { t.Fatal("background session must not emit") })
+	background.SessionType = "schedule"
+	if provider.deliverGeneratedImage(background, "call-1", att) {
+		t.Fatal("deliverGeneratedImage on a background session should not deliver")
+	}
+}
+
+func TestUnsavedImageResultDeliversInlineOrReturnsContent(t *testing.T) {
+	t.Parallel()
+
+	provider := &ImageGenProvider{}
+	img := generatedImage{Data: testPNGBytes, MediaType: "image/png"}
+
+	var events []ToolStreamEvent
+	live := liveShortcutSession(func(evt ToolStreamEvent) { events = append(events, evt) })
+	result := provider.unsavedImageResult(live, "call-2", img, "not saved")
+	if result["delivered"] != "current_conversation" {
+		t.Fatalf("result = %+v, want delivered current_conversation", result)
+	}
+	if len(events) != 1 || len(events[0].Attachments) != 1 {
+		t.Fatalf("events = %+v, want one attachment event", events)
+	}
+	if !strings.HasPrefix(events[0].Attachments[0].URL, "data:image/png;base64,") {
+		t.Fatalf("attachment URL = %q, want data URL", events[0].Attachments[0].URL)
+	}
+
+	result = provider.unsavedImageResult(SessionContext{}, "call-2", img, "not saved")
+	if _, ok := result["content"]; !ok {
+		t.Fatalf("result = %+v, want inline content fallback for non-live sessions", result)
+	}
+}

--- a/internal/agent/tools/message.go
+++ b/internal/agent/tools/message.go
@@ -91,7 +91,7 @@ func (p *MessageProvider) Tools(_ context.Context, session SessionContext) ([]sd
 				"required": sendRequired,
 			},
 			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
-				return p.execSend(ctx.Context, sess, inputAsMap(input))
+				return p.execSend(ctx.Context, sess, ctx.ToolCallID, inputAsMap(input))
 			},
 		})
 	}
@@ -308,7 +308,7 @@ func reactToolPromptMetadata(session SessionContext) (description string, platfo
 		[]string{"message_id", "platform", "target"}
 }
 
-func (p *MessageProvider) execSend(ctx context.Context, session SessionContext, args map[string]any) (any, error) {
+func (p *MessageProvider) execSend(ctx context.Context, session SessionContext, toolCallID string, args map[string]any) (any, error) {
 	if session.SessionType == sessionmode.Discuss {
 		sendResult, err := p.exec.SendDirect(ctx, toMessagingSession(session), "", args)
 		if err != nil {
@@ -332,6 +332,7 @@ func (p *MessageProvider) execSend(ctx context.Context, session SessionContext, 
 		if len(atts) > 0 {
 			session.Emitter(ToolStreamEvent{
 				Type:        StreamEventAttachment,
+				ToolCallID:  toolCallID,
 				Attachments: atts,
 			})
 		}

--- a/internal/agent/tools/message_test.go
+++ b/internal/agent/tools/message_test.go
@@ -159,7 +159,7 @@ func TestExecSendDiscussTextUsesChannelAdapter(t *testing.T) {
 		SessionType:     sessionmode.Discuss,
 		CurrentPlatform: "telegram",
 		ReplyTarget:     "chat-1",
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"text": "observed reply",
 	})
 	if err != nil {
@@ -187,7 +187,7 @@ func TestExecSendDiscussExplicitTargetReportsTargetDelivery(t *testing.T) {
 		SessionType:     sessionmode.Discuss,
 		CurrentPlatform: "telegram",
 		ReplyTarget:     "chat-1",
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"target": "chat-2",
 		"text":   "cross target",
 	})
@@ -213,7 +213,7 @@ func TestExecSendCurrentConversationWithoutEmitterUsesChannelAdapter(t *testing.
 		SessionType:     sessionmode.Chat,
 		CurrentPlatform: "telegram",
 		ReplyTarget:     "chat-1",
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"attachments": []any{"screenshot.png"},
 	})
 	if err != nil {
@@ -251,7 +251,7 @@ func TestExecSendCurrentConversationCollectingEmitterUsesChannelAdapter(t *testi
 		Emitter: func(ToolStreamEvent) {
 			emitted = true
 		},
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"attachments": []any{"screenshot.png"},
 	})
 	if err != nil {
@@ -287,7 +287,7 @@ func TestExecSendCurrentConversationLiveStreamUsesEmitter(t *testing.T) {
 		Emitter: func(ToolStreamEvent) {
 			emitted++
 		},
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"attachments": []any{"screenshot.png"},
 	})
 	if err != nil {

--- a/internal/agent/tools/tts.go
+++ b/internal/agent/tools/tts.go
@@ -112,7 +112,7 @@ func (p *TTSProvider) Tools(ctx context.Context, session SessionContext) ([]sdk.
 				"required": required,
 			},
 			Execute: func(execCtx *sdk.ToolExecContext, input any) (any, error) {
-				return p.execSpeak(execCtx.Context, sess, inputAsMap(input))
+				return p.execSpeak(execCtx.Context, sess, execCtx.ToolCallID, inputAsMap(input))
 			},
 		},
 	}, nil
@@ -131,7 +131,7 @@ func speakToolPromptMetadata(session SessionContext) (description string, platfo
 		[]string{"text", "platform", "target"}
 }
 
-func (p *TTSProvider) execSpeak(ctx context.Context, session SessionContext, args map[string]any) (any, error) {
+func (p *TTSProvider) execSpeak(ctx context.Context, session SessionContext, toolCallID string, args map[string]any) (any, error) {
 	botID := strings.TrimSpace(session.BotID)
 	if botID == "" {
 		return nil, errors.New("bot_id is required")
@@ -173,7 +173,8 @@ func (p *TTSProvider) execSpeak(ctx context.Context, session SessionContext, arg
 	// Same-conversation: emit the synthesized audio as a voice attachment.
 	if isSameConv && session.CanUseLocalMessagingShortcut() {
 		session.Emitter(ToolStreamEvent{
-			Type: StreamEventAttachment,
+			Type:       StreamEventAttachment,
+			ToolCallID: toolCallID,
 			Attachments: []Attachment{{
 				Type: "voice",
 				URL:  dataURL,

--- a/internal/agent/tools/tts_test.go
+++ b/internal/agent/tools/tts_test.go
@@ -43,7 +43,7 @@ func TestExecSpeakRequiresTargetBeforeLoadingSettings(t *testing.T) {
 	_, err := provider.execSpeak(context.Background(), SessionContext{
 		BotID:           "bot_1",
 		CurrentPlatform: "telegram",
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"text": "hello",
 	})
 	if err == nil || !strings.Contains(err.Error(), "target is required") {
@@ -59,7 +59,7 @@ func TestExecSpeakWithDifferentPlatformDoesNotReuseCurrentTarget(t *testing.T) {
 		BotID:           "bot_1",
 		CurrentPlatform: "telegram",
 		ReplyTarget:     "telegram-chat-1",
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"platform": "discord",
 		"text":     "hello",
 	})
@@ -100,7 +100,7 @@ func TestExecSpeakCurrentConversationCollectingEmitterUsesChannelAdapter(t *test
 		Emitter: func(ToolStreamEvent) {
 			emitted = true
 		},
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"text": "hello",
 	})
 	if err != nil {
@@ -134,7 +134,7 @@ func TestExecSpeakCurrentConversationLiveStreamUsesEmitter(t *testing.T) {
 		Emitter: func(ToolStreamEvent) {
 			emitted++
 		},
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"text": "hello",
 	})
 	if err != nil {
@@ -167,7 +167,7 @@ func TestExecSpeakDiscussCurrentTargetUsesChannelAdapter(t *testing.T) {
 		Emitter: func(ToolStreamEvent) {
 			emitted = true
 		},
-	}, map[string]any{
+	}, "call-test", map[string]any{
 		"platform": "telegram",
 		"target":   "chat-1",
 		"text":     "hello",

--- a/internal/agent/tools/types.go
+++ b/internal/agent/tools/types.go
@@ -35,7 +35,11 @@ const (
 // current conversation (e.g. inline attachment, reaction, or TTS speech).
 // The agent framework converts these into the appropriate wire-level events.
 type ToolStreamEvent struct {
-	Type        StreamEventType
+	Type StreamEventType
+	// ToolCallID identifies the tool call that produced this side effect, so
+	// downstream persistence can anchor it to the right message (and keep the
+	// live ordering after a history reload). Empty when unknown.
+	ToolCallID  string
 	Attachments []Attachment
 	Reactions   []Reaction
 	Speeches    []Speech

--- a/internal/agent/tools/usage_test.go
+++ b/internal/agent/tools/usage_test.go
@@ -194,11 +194,12 @@ func TestBuiltInToolsHaveUsageGuidanceOrExplicitExemption(t *testing.T) {
 		ToolBrowserRemoteSession(): "browser",
 
 		ToolAskUser(): "user-input",
+
+		ToolGenerateImage(): "image-gen",
 	}
 	exempt := map[ToolName]string{
 		ToolWebSearch():         "self-describing one-shot search tool",
 		ToolWebFetch():          "self-describing one-shot fetch tool",
-		ToolGenerateImage():     "self-describing media generation tool",
 		ToolGenerateVideo():     "self-describing media generation tool",
 		ToolTranscribeAudio():   "self-describing media transcription tool",
 		ToolListEmailAccounts(): "email tool descriptions carry account/read/write semantics",

--- a/internal/conversation/flow/resolver_model_selection.go
+++ b/internal/conversation/flow/resolver_model_selection.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -49,6 +50,12 @@ func (r *Resolver) selectChatModel(ctx context.Context, req conversation.ChatReq
 			if err != nil {
 				return models.GetResponse{}, sqlc.Provider{}, err
 			}
+			if err := validateSelectedChatModel(m, prov); err != nil {
+				return models.GetResponse{}, sqlc.Provider{}, err
+			}
+			if !prov.Enable {
+				return models.GetResponse{}, sqlc.Provider{}, fmt.Errorf("chat model provider %s is disabled", prov.Name)
+			}
 			return m, prov, nil
 		}
 	}
@@ -80,20 +87,96 @@ func (r *Resolver) fetchChatModel(ctx context.Context, modelID string) (models.G
 	}
 
 resolved:
-	if model.Type != models.ModelTypeChat {
-		return models.GetResponse{}, sqlc.Provider{}, errors.New("model is not a chat model")
-	}
-	if !model.Enable {
-		return models.GetResponse{}, sqlc.Provider{}, fmt.Errorf("chat model %s is disabled", model.ModelID)
-	}
 	prov, err := models.FetchProviderByID(ctx, r.queries, model.ProviderID)
 	if err != nil {
+		return models.GetResponse{}, sqlc.Provider{}, err
+	}
+	if err := validateSelectedChatModel(model, prov); err != nil {
 		return models.GetResponse{}, sqlc.Provider{}, err
 	}
 	if !prov.Enable {
 		return models.GetResponse{}, sqlc.Provider{}, fmt.Errorf("chat model provider %s is disabled", prov.Name)
 	}
 	return model, prov, nil
+}
+
+func validateSelectedChatModel(model models.GetResponse, provider sqlc.Provider) error {
+	if model.Type != models.ModelTypeChat {
+		return errors.New("model is not a chat model")
+	}
+	if !model.Enable {
+		return fmt.Errorf("chat model %s is disabled", model.ModelID)
+	}
+	if isImageOnlyChatModel(model, provider) {
+		return fmt.Errorf("chat model %s is an image generation model; configure it as the bot image model and use a chat model for conversation", model.ModelID)
+	}
+	return nil
+}
+
+func isImageOnlyChatModel(model models.GetResponse, provider sqlc.Provider) bool {
+	// A model that advertises tool calling is usable as a chat model regardless
+	// of its name — this is the escape hatch for the name heuristic below, so a
+	// tool-capable model that merely looks like an image model (or a genuine
+	// multimodal chat model) is never blocked.
+	if model.HasCompatibility(models.CompatToolCall) {
+		return false
+	}
+	lowerModel := strings.ToLower(strings.TrimSpace(model.ModelID))
+	if lowerModel == "" {
+		return false
+	}
+	if isKnownStandaloneImageModelID(lowerModel) {
+		return true
+	}
+	lowerBase := strings.ToLower(providerConfigString(provider, "base_url"))
+	if strings.Contains(lowerBase, "dashscope") && strings.Contains(lowerModel, "image") {
+		return true
+	}
+	if !model.HasCompatibility(models.CompatImageOutput) {
+		return false
+	}
+	ct := models.ClientType(provider.ClientType)
+	if ct != models.ClientTypeOpenAICompletions && ct != models.ClientTypeOpenAIResponses {
+		return false
+	}
+	return strings.Contains(lowerBase, "maas.aliyuncs.com") ||
+		strings.Contains(lowerBase, "api.openai.com") ||
+		strings.Contains(lowerBase, "volces.com") ||
+		strings.Contains(lowerBase, "bytepluses.com") ||
+		strings.Contains(lowerBase, "siliconflow")
+}
+
+// isKnownStandaloneImageModelID matches the naming conventions of dedicated
+// text-to-image model families. Prefixes are kept specific enough not to catch
+// ordinary chat models that merely share a leading token — e.g. "wan2"/"wanx"
+// (Alibaba Wan image/video) rather than a bare "wan" that would also match a
+// chat model like "wanjuan-chat", and "flux-"/"flux."/"flux1" rather than a
+// bare "flux". A tool-calling model bypasses this check entirely (see
+// isImageOnlyChatModel), which is the override when a name collision is wrong.
+func isKnownStandaloneImageModelID(lowerModel string) bool {
+	return strings.HasPrefix(lowerModel, "qwen-image") ||
+		strings.HasPrefix(lowerModel, "wan2") ||
+		strings.HasPrefix(lowerModel, "wanx") ||
+		strings.HasPrefix(lowerModel, "z-image") ||
+		strings.HasPrefix(lowerModel, "flux-") ||
+		strings.HasPrefix(lowerModel, "flux.") ||
+		strings.HasPrefix(lowerModel, "flux1") ||
+		strings.HasPrefix(lowerModel, "stable-diffusion") ||
+		strings.HasPrefix(lowerModel, "gpt-image") ||
+		strings.HasPrefix(lowerModel, "dall-e") ||
+		strings.Contains(lowerModel, "seedream")
+}
+
+func providerConfigString(provider sqlc.Provider, key string) string {
+	var cfg map[string]any
+	if len(provider.Config) == 0 {
+		return ""
+	}
+	if err := json.Unmarshal(provider.Config, &cfg); err != nil {
+		return ""
+	}
+	value, _ := cfg[key].(string)
+	return strings.TrimSpace(value)
 }
 
 func matchesModelReference(model models.GetResponse, modelRef string) bool {

--- a/internal/conversation/flow/resolver_model_selection_test.go
+++ b/internal/conversation/flow/resolver_model_selection_test.go
@@ -453,3 +453,123 @@ func TestFetchChatModelReturnsEnabledModelAndProvider(t *testing.T) {
 		t.Fatal("fetchChatModel returned disabled provider, want enabled")
 	}
 }
+
+func TestFetchChatModelRejectsImageOnlyModel(t *testing.T) {
+	ctx := context.Background()
+	provider := modelSelectionProviderRow(t, "00000000-0000-0000-0000-000000000401", "openai-completions", true)
+	model := modelSelectionModelRow(t, "00000000-0000-0000-0000-000000000402", "qwen-image", provider.ID, models.ModelTypeChat, true)
+	model.Config = []byte(`{"compatibilities":["image-output"]}`)
+	fake := &modelSelectionFakeQueries{
+		models:   map[string]sqlc.Model{model.ModelID: model},
+		provider: provider,
+	}
+	resolver := newModelSelectionResolver(t, fake)
+
+	_, _, err := resolver.fetchChatModel(ctx, "qwen-image")
+	if err == nil || !strings.Contains(err.Error(), "image generation model") || !strings.Contains(err.Error(), "bot image model") {
+		t.Fatalf("fetchChatModel image-only model error = %v, want image model guidance", err)
+	}
+}
+
+func TestFetchChatModelRejectsImportedImageModelWithoutCompatibility(t *testing.T) {
+	ctx := context.Background()
+	provider := modelSelectionProviderRow(t, "00000000-0000-0000-0000-000000000501", "openai-completions", true)
+	model := modelSelectionModelRow(t, "00000000-0000-0000-0000-000000000502", "wan2.7-image-pro", provider.ID, models.ModelTypeChat, true)
+	fake := &modelSelectionFakeQueries{
+		models:   map[string]sqlc.Model{model.ModelID: model},
+		provider: provider,
+	}
+	resolver := newModelSelectionResolver(t, fake)
+
+	_, _, err := resolver.fetchChatModel(ctx, "wan2.7-image-pro")
+	if err == nil || !strings.Contains(err.Error(), "image generation model") {
+		t.Fatalf("fetchChatModel imported image model error = %v, want image model guidance", err)
+	}
+}
+
+func TestValidateSelectedChatModelAllowsToolCallingImageOutputModel(t *testing.T) {
+	t.Parallel()
+
+	model := models.GetResponse{
+		ModelID: "openrouter/auto",
+		Model: models.Model{
+			Type:   models.ModelTypeChat,
+			Enable: true,
+			Config: models.ModelConfig{
+				Compatibilities: []string{models.CompatToolCall, models.CompatImageOutput},
+			},
+		},
+	}
+	if err := validateSelectedChatModel(model, sqlc.Provider{}); err != nil {
+		t.Fatalf("validateSelectedChatModel() error = %v, want nil", err)
+	}
+}
+
+func TestValidateSelectedChatModelAllowsGoogleImageOutputModel(t *testing.T) {
+	t.Parallel()
+
+	model := models.GetResponse{
+		ModelID: "gemini-2.5-flash-image-preview",
+		Model: models.Model{
+			Type:   models.ModelTypeChat,
+			Enable: true,
+			Config: models.ModelConfig{
+				Compatibilities: []string{models.CompatImageOutput},
+			},
+		},
+	}
+	provider := sqlc.Provider{ClientType: string(models.ClientTypeGoogleGenerativeAI)}
+	if err := validateSelectedChatModel(model, provider); err != nil {
+		t.Fatalf("validateSelectedChatModel() error = %v, want nil", err)
+	}
+}
+
+func TestIsKnownStandaloneImageModelID(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{
+		"qwen-image-2.0", "wan2.7-image", "z-image-turbo",
+		"flux-schnell", "stable-diffusion-3.5-large-turbo",
+		"gpt-image-1", "dall-e-3", "doubao-seedream-4-0-250828",
+	} {
+		if !isKnownStandaloneImageModelID(id) {
+			t.Errorf("isKnownStandaloneImageModelID(%q) = false, want true", id)
+		}
+	}
+	for _, id := range []string{
+		"gpt-4o", "qwen-max", "deepseek-chat", "",
+		// Chat models that merely share a leading token must not match: the
+		// "wan"/"flux" prefixes are scoped to image-model naming conventions.
+		"wanjuan-chat", "want-to-talk", "fluxion-7b", "fluent-chat",
+	} {
+		if isKnownStandaloneImageModelID(id) {
+			t.Errorf("isKnownStandaloneImageModelID(%q) = true, want false", id)
+		}
+	}
+}
+
+func TestIsImageOnlyChatModelToolCallEscape(t *testing.T) {
+	t.Parallel()
+
+	// A model whose name looks like an image model but which advertises tool
+	// calling must not be classified as image-only — tool calling is the
+	// override that lets a name collision be used as a chat model.
+	toolCaller := models.GetResponse{
+		ModelID: "wan2.7-omni",
+		Model: models.Model{
+			Config: models.ModelConfig{Compatibilities: []string{models.CompatToolCall, models.CompatImageOutput}},
+		},
+	}
+	if isImageOnlyChatModel(toolCaller, sqlc.Provider{}) {
+		t.Fatal("a tool-calling model must not be treated as image-only, even with an image-like name")
+	}
+
+	// Without tool calling, the same name is still rejected.
+	imageOnly := models.GetResponse{
+		ModelID: "wan2.7-image",
+		Model:   models.Model{Config: models.ModelConfig{Compatibilities: []string{models.CompatImageOutput}}},
+	}
+	if !isImageOnlyChatModel(imageOnly, sqlc.Provider{}) {
+		t.Fatal("a non-tool-calling image model name should be treated as image-only")
+	}
+}

--- a/internal/conversation/flow/resolver_store.go
+++ b/internal/conversation/flow/resolver_store.go
@@ -544,9 +544,13 @@ func (r *Resolver) resolvePersistSenderIDs(ctx context.Context, req conversation
 	return senderChannelIdentityID, senderUserID
 }
 
-// LinkOutboundAssets links bot-generated assets to the latest assistant
-// message. When sessionID is provided, the search is scoped to that session;
-// otherwise it falls back to a bot-wide search.
+// LinkOutboundAssets links bot-generated assets to the assistant message that
+// produced them. Assets carrying a `tool_call_id` metadata entry are anchored
+// to the assistant message containing that tool call, so a history rebuild
+// keeps the live ordering (e.g. a generated image stays above the closing
+// text). Assets without one fall back to the latest assistant message. When
+// sessionID is provided, the search is scoped to that session; otherwise it
+// falls back to a bot-wide search.
 // Used by the WebSocket path where attachment ingestion happens after message
 // persistence.
 func (r *Resolver) LinkOutboundAssets(ctx context.Context, botID, sessionID string, assets []messagepkg.AssetRef) {
@@ -557,22 +561,75 @@ func (r *Resolver) LinkOutboundAssets(ctx context.Context, botID, sessionID stri
 		msgs []messagepkg.Message
 		err  error
 	)
+	// A single turn can span many rows (the originating tool-call assistant
+	// message, its tool-result row, and any follow-up assistant/tool messages
+	// such as sending the image to several channels). The window must comfortably
+	// cover a whole turn so tool-call anchoring below finds the originating
+	// message instead of silently falling back to the latest assistant message.
+	const anchorSearchWindow = 50
 	if strings.TrimSpace(sessionID) != "" {
-		msgs, err = r.messageService.ListLatestBySession(ctx, sessionID, 5)
+		msgs, err = r.messageService.ListLatestBySession(ctx, sessionID, anchorSearchWindow)
 	} else {
-		msgs, err = r.messageService.ListLatest(ctx, botID, 5)
+		msgs, err = r.messageService.ListLatest(ctx, botID, anchorSearchWindow)
 	}
 	if err != nil {
 		r.logger.Warn("LinkOutboundAssets: list latest failed", slog.Any("error", err))
 		return
 	}
+
+	latestAssistantID := ""
 	for _, msg := range msgs {
 		if msg.Role == "assistant" {
-			if linkErr := r.messageService.LinkAssets(ctx, msg.ID, assets); linkErr != nil {
-				r.logger.Warn("LinkOutboundAssets: link failed", slog.Any("error", linkErr))
-			}
-			return
+			latestAssistantID = msg.ID
+			break
 		}
 	}
-	r.logger.Warn("LinkOutboundAssets: no assistant message found", slog.String("bot_id", botID))
+	if latestAssistantID == "" {
+		r.logger.Warn("LinkOutboundAssets: no assistant message found", slog.String("bot_id", botID))
+		return
+	}
+
+	byMessage := map[string][]messagepkg.AssetRef{}
+	var order []string
+	for _, asset := range assets {
+		targetID := latestAssistantID
+		if toolCallID, _ := asset.Metadata["tool_call_id"].(string); strings.TrimSpace(toolCallID) != "" {
+			if id := findAssistantMessageForToolCall(msgs, strings.TrimSpace(toolCallID)); id != "" {
+				targetID = id
+			} else {
+				r.logger.Debug("LinkOutboundAssets: tool call not found in search window, anchoring to latest assistant",
+					slog.String("tool_call_id", strings.TrimSpace(toolCallID)))
+			}
+		}
+		if _, ok := byMessage[targetID]; !ok {
+			order = append(order, targetID)
+		}
+		byMessage[targetID] = append(byMessage[targetID], asset)
+	}
+	for _, id := range order {
+		group := byMessage[id]
+		for i := range group {
+			group[i].Ordinal = i
+		}
+		if linkErr := r.messageService.LinkAssets(ctx, id, group); linkErr != nil {
+			r.logger.Warn("LinkOutboundAssets: link failed", slog.Any("error", linkErr))
+		}
+	}
+}
+
+// findAssistantMessageForToolCall returns the ID of the assistant message
+// whose serialized content contains the given tool call ID as an exact JSON
+// string token. Tool call IDs are unique opaque tokens, so a quoted match
+// cannot collide with ordinary reply text.
+func findAssistantMessageForToolCall(msgs []messagepkg.Message, toolCallID string) string {
+	needle := `"` + toolCallID + `"`
+	for _, msg := range msgs {
+		if msg.Role != "assistant" || len(msg.Content) == 0 {
+			continue
+		}
+		if strings.Contains(string(msg.Content), needle) {
+			return msg.ID
+		}
+	}
+	return ""
 }

--- a/internal/conversation/flow/resolver_store_test.go
+++ b/internal/conversation/flow/resolver_store_test.go
@@ -187,3 +187,20 @@ func TestStoreMessagesUsesToolTailBatch(t *testing.T) {
 		t.Fatalf("persisted messages = %d, want 4", len(persisted))
 	}
 }
+
+func TestFindAssistantMessageForToolCall(t *testing.T) {
+	t.Parallel()
+
+	msgs := []messagepkg.Message{
+		{ID: "m3", Role: "assistant", Content: []byte(`{"role":"assistant","content":[{"type":"text","text":"done, see call-1 above"}]}`)},
+		{ID: "m2", Role: "tool", Content: []byte(`{"role":"tool","content":[{"type":"tool-result","toolCallId":"call-1"}]}`)},
+		{ID: "m1", Role: "assistant", Content: []byte(`{"role":"assistant","content":[{"type":"tool-call","toolCallId":"call-1","toolName":"generate_image"}]}`)},
+	}
+
+	if got := findAssistantMessageForToolCall(msgs, "call-1"); got != "m1" {
+		t.Fatalf("findAssistantMessageForToolCall = %q, want m1 (assistant tool-call row, not tool row or echoed text)", got)
+	}
+	if got := findAssistantMessageForToolCall(msgs, "call-404"); got != "" {
+		t.Fatalf("findAssistantMessageForToolCall unknown id = %q, want empty", got)
+	}
+}

--- a/internal/conversation/uimessage_stream.go
+++ b/internal/conversation/uimessage_stream.go
@@ -1,6 +1,9 @@
 package conversation
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 type uiTextStreamState struct {
 	ID      int
@@ -11,12 +14,28 @@ type uiToolStreamState struct {
 	Message UIMessage
 }
 
+// uiEmittedBlock records one block ID allocation in live-stream order so the
+// terminal snapshot replay can line its blocks up with the ones the client
+// already rendered (block order on the client is the ID order).
+type uiEmittedBlock struct {
+	Kind       UIMessageType
+	ToolCallID string
+	ID         int
+	// TagOnly marks a text block whose entire content is inline agent tags
+	// (<attachments>/<reactions>/<speech>). The terminal snapshot strips those
+	// tags and drops empty text blocks, so such a live block has no terminal
+	// counterpart and must be skipped during positional matching — otherwise it
+	// shifts the alignment and the final reply overwrites the wrong block.
+	TagOnly bool
+}
+
 // UIMessageStreamConverter converts low-level stream events into complete UI messages.
 type UIMessageStreamConverter struct {
 	nextID    int
 	text      *uiTextStreamState
 	reasoning *uiTextStreamState
 	tools     map[string]*uiToolStreamState
+	emitted   []uiEmittedBlock
 }
 
 // NewUIMessageStreamConverter creates a new UI stream converter.
@@ -29,13 +48,27 @@ func NewUIMessageStreamConverter() *UIMessageStreamConverter {
 // HandleEvent updates converter state and returns zero or one complete UI messages.
 func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIMessage {
 	switch strings.ToLower(strings.TrimSpace(event.Type)) {
+	case "retry":
+		// A retried attempt regenerates its output from scratch, so the terminal
+		// snapshot will contain only the surviving attempt's messages. Drop the
+		// bookkeeping for the discarded attempt (including the emitted-block log)
+		// so ConvertTerminalMessages aligns against the surviving attempt's
+		// blocks only — otherwise an orphaned pre-retry text/reasoning block
+		// shifts the positional match and the final reply overwrites the wrong
+		// block. IDs (c.nextID) keep advancing so re-emitted blocks stay unique.
+		c.text = nil
+		c.reasoning = nil
+		c.tools = map[string]*uiToolStreamState{}
+		c.emitted = nil
+		return nil
+
 	case "text_start":
-		c.text = &uiTextStreamState{ID: c.nextMessageID()}
+		c.text = &uiTextStreamState{ID: c.allocBlockID(UIMessageText, "")}
 		return nil
 
 	case "text_delta":
 		if c.text == nil {
-			c.text = &uiTextStreamState{ID: c.nextMessageID()}
+			c.text = &uiTextStreamState{ID: c.allocBlockID(UIMessageText, "")}
 		}
 		c.text.Content += event.Delta
 		return []UIMessage{{
@@ -45,16 +78,16 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 		}}
 
 	case "text_end":
-		c.text = nil
+		c.finalizeTextBlock()
 		return nil
 
 	case "reasoning_start":
-		c.reasoning = &uiTextStreamState{ID: c.nextMessageID()}
+		c.reasoning = &uiTextStreamState{ID: c.allocBlockID(UIMessageReasoning, "")}
 		return nil
 
 	case "reasoning_delta":
 		if c.reasoning == nil {
-			c.reasoning = &uiTextStreamState{ID: c.nextMessageID()}
+			c.reasoning = &uiTextStreamState{ID: c.allocBlockID(UIMessageReasoning, "")}
 		}
 		c.reasoning.Content += event.Delta
 		return []UIMessage{{
@@ -72,7 +105,7 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 		if state == nil {
 			state = &uiToolStreamState{
 				Message: UIMessage{
-					ID:         c.nextMessageID(),
+					ID:         c.allocBlockID(UIMessageTool, strings.TrimSpace(event.ToolCallID)),
 					Type:       UIMessageTool,
 					Name:       strings.TrimSpace(event.ToolName),
 					Input:      event.Input,
@@ -92,7 +125,7 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 			c.tools[trimmed] = state
 		}
 		state.Message.Running = uiBoolPtr(true)
-		c.text = nil
+		c.finalizeTextBlock()
 		return []UIMessage{cloneToolStreamMessage(state.Message)}
 
 	case "tool_call_progress":
@@ -100,7 +133,7 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 		if state == nil {
 			state = &uiToolStreamState{
 				Message: UIMessage{
-					ID:         c.nextMessageID(),
+					ID:         c.allocBlockID(UIMessageTool, strings.TrimSpace(event.ToolCallID)),
 					Type:       UIMessageTool,
 					Name:       strings.TrimSpace(event.ToolName),
 					Input:      event.Input,
@@ -123,7 +156,7 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 		if state == nil {
 			state = &uiToolStreamState{
 				Message: UIMessage{
-					ID:         c.nextMessageID(),
+					ID:         c.allocBlockID(UIMessageTool, strings.TrimSpace(event.ToolCallID)),
 					Type:       UIMessageTool,
 					Name:       strings.TrimSpace(event.ToolName),
 					Input:      event.Input,
@@ -162,7 +195,7 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 		if state == nil {
 			state = &uiToolStreamState{
 				Message: UIMessage{
-					ID:         c.nextMessageID(),
+					ID:         c.allocBlockID(UIMessageTool, strings.TrimSpace(event.ToolCallID)),
 					Type:       UIMessageTool,
 					Name:       strings.TrimSpace(event.ToolName),
 					Input:      event.Input,
@@ -206,7 +239,7 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 		if state == nil {
 			state = &uiToolStreamState{
 				Message: UIMessage{
-					ID:         c.nextMessageID(),
+					ID:         c.allocBlockID(UIMessageTool, strings.TrimSpace(event.ToolCallID)),
 					Type:       UIMessageTool,
 					Name:       strings.TrimSpace(event.ToolName),
 					Input:      event.Input,
@@ -228,7 +261,7 @@ func (c *UIMessageStreamConverter) HandleEvent(event UIMessageStreamEvent) []UIM
 			return nil
 		}
 		return []UIMessage{{
-			ID:          c.nextMessageID(),
+			ID:          c.allocBlockID(UIMessageAttachments, ""),
 			Type:        UIMessageAttachments,
 			Attachments: append([]UIAttachment(nil), event.Attachments...),
 		}}
@@ -242,6 +275,83 @@ func (c *UIMessageStreamConverter) nextMessageID() int {
 	id := c.nextID
 	c.nextID++
 	return id
+}
+
+// allocBlockID allocates the next block ID and records the allocation so
+// ConvertTerminalMessages can align the terminal snapshot with the live blocks.
+func (c *UIMessageStreamConverter) allocBlockID(kind UIMessageType, toolCallID string) int {
+	id := c.nextMessageID()
+	c.emitted = append(c.emitted, uiEmittedBlock{Kind: kind, ToolCallID: toolCallID, ID: id})
+	return id
+}
+
+// finalizeTextBlock closes the active text block, marking its emitted entry as
+// tag-only when stripping inline agent tags leaves no visible content (the
+// terminal snapshot drops such blocks, so they must not take part in
+// positional matching).
+func (c *UIMessageStreamConverter) finalizeTextBlock() {
+	if c.text == nil {
+		return
+	}
+	if stripPersistedAgentTags(c.text.Content) == "" {
+		for i := range c.emitted {
+			if c.emitted[i].Kind == UIMessageText && c.emitted[i].ID == c.text.ID {
+				c.emitted[i].TagOnly = true
+				break
+			}
+		}
+	}
+	c.text = nil
+}
+
+// ConvertTerminalMessages converts the terminal snapshot into UI messages whose
+// IDs line up with the blocks this converter emitted during the live stream.
+// The client orders and upserts blocks by ID, and the snapshot regenerates only
+// text/reasoning/tool blocks from raw model messages — attachments exist solely
+// as stream events. A plain sequential renumbering would therefore shift onto
+// the IDs of live attachment blocks and overwrite them at stream end (the
+// generated image flashes away, then reappears after the history refresh).
+// Instead each snapshot block reuses the ID of its live counterpart — tools are
+// matched by tool call ID, text/reasoning positionally within their kind — and
+// only blocks without one get fresh IDs.
+func (c *UIMessageStreamConverter) ConvertTerminalMessages(raw json.RawMessage) []UIMessage {
+	c.finalizeTextBlock()
+	blocks := ConvertRawModelMessagesToUIAssistantMessages(raw)
+	if len(blocks) == 0 {
+		return nil
+	}
+	consumed := make([]bool, len(c.emitted))
+	for i := range blocks {
+		if id, ok := c.reuseEmittedBlockID(blocks[i].Type, blocks[i].ToolCallID, consumed); ok {
+			blocks[i].ID = id
+			continue
+		}
+		blocks[i].ID = c.nextMessageID()
+	}
+	return blocks
+}
+
+func (c *UIMessageStreamConverter) reuseEmittedBlockID(kind UIMessageType, toolCallID string, consumed []bool) (int, bool) {
+	toolCallID = strings.TrimSpace(toolCallID)
+	if kind == UIMessageTool && toolCallID != "" {
+		for i, blk := range c.emitted {
+			if !consumed[i] && blk.Kind == kind && blk.ToolCallID == toolCallID {
+				consumed[i] = true
+				return blk.ID, true
+			}
+		}
+	}
+	for i, blk := range c.emitted {
+		if consumed[i] || blk.Kind != kind || blk.TagOnly {
+			continue
+		}
+		if kind == UIMessageTool && blk.ToolCallID != "" && toolCallID != "" && blk.ToolCallID != toolCallID {
+			continue
+		}
+		consumed[i] = true
+		return blk.ID, true
+	}
+	return 0, false
 }
 
 func (c *UIMessageStreamConverter) findToolState(toolCallID, toolName string) *uiToolStreamState {

--- a/internal/conversation/uimessage_test.go
+++ b/internal/conversation/uimessage_test.go
@@ -1509,3 +1509,188 @@ func mustUIMessageJSON(t *testing.T, message ModelMessage) json.RawMessage {
 	}
 	return data
 }
+
+func TestConvertTerminalMessagesReusesLiveBlockIDsAroundAttachments(t *testing.T) {
+	converter := NewUIMessageStreamConverter()
+
+	// Live stream: tool call starts, emits an attachment mid-execution, then
+	// the closing text streams in. IDs: tool=0, attachments=1, text=2.
+	converter.HandleEvent(UIMessageStreamEvent{Type: "tool_call_start", ToolCallID: "call-1", ToolName: "generate_image"})
+	attachmentBlocks := converter.HandleEvent(UIMessageStreamEvent{Type: "attachment_delta", Attachments: []UIAttachment{{Type: "image", ContentHash: "hash-1"}}})
+	if len(attachmentBlocks) != 1 || attachmentBlocks[0].ID != 1 {
+		t.Fatalf("attachment block = %#v, want id 1", attachmentBlocks)
+	}
+	converter.HandleEvent(UIMessageStreamEvent{Type: "tool_call_end", ToolCallID: "call-1", ToolName: "generate_image"})
+	textBlocks := converter.HandleEvent(UIMessageStreamEvent{Type: "text_delta", Delta: "done"})
+	if len(textBlocks) != 1 || textBlocks[0].ID != 2 {
+		t.Fatalf("text block = %#v, want id 2", textBlocks)
+	}
+
+	// Terminal snapshot regenerates only tool + text; without ID alignment the
+	// text would land on id 1 and overwrite the attachment block client-side.
+	raw := mustUIRawJSON(t, []ModelMessage{
+		{
+			Role: "assistant",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "tool-call", "toolCallId": "call-1", "toolName": "generate_image", "input": map[string]any{"prompt": "a cat"}},
+			}),
+		},
+		{
+			Role: "tool",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "tool-result", "toolCallId": "call-1", "toolName": "generate_image", "result": map[string]any{"path": "/data/generated-images/1.png"}},
+			}),
+		},
+		{
+			Role: "assistant",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "text", "text": "done"},
+			}),
+		},
+	})
+
+	blocks := converter.ConvertTerminalMessages(raw)
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 terminal blocks, got %d: %#v", len(blocks), blocks)
+	}
+	if blocks[0].Type != UIMessageTool || blocks[0].ID != 0 {
+		t.Fatalf("tool block = %#v, want live id 0", blocks[0])
+	}
+	if blocks[1].Type != UIMessageText || blocks[1].ID != 2 {
+		t.Fatalf("text block = %#v, want live id 2 (must not collide with attachment id 1)", blocks[1])
+	}
+}
+
+func TestConvertTerminalMessagesAllocatesFreshIDsForUnseenBlocks(t *testing.T) {
+	converter := NewUIMessageStreamConverter()
+
+	// No live blocks at all (e.g. events dropped): snapshot still renders with
+	// sequential fresh IDs.
+	raw := mustUIRawJSON(t, []ModelMessage{
+		{
+			Role: "assistant",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "text", "text": "hello"},
+			}),
+		},
+	})
+	blocks := converter.ConvertTerminalMessages(raw)
+	if len(blocks) != 1 || blocks[0].ID != 0 || blocks[0].Type != UIMessageText {
+		t.Fatalf("blocks = %#v, want one fresh text block with id 0", blocks)
+	}
+}
+
+func TestConvertTerminalMessagesAfterRetryIgnoresDiscardedAttemptBlocks(t *testing.T) {
+	converter := NewUIMessageStreamConverter()
+
+	// Attempt 1 streams a text block (ID 0), then the attempt is retried.
+	converter.HandleEvent(UIMessageStreamEvent{Type: "text_delta", Delta: "partial attempt one"})
+	converter.HandleEvent(UIMessageStreamEvent{Type: "retry"})
+
+	// Attempt 2 streams tool (ID 1), an attachment (ID 2), and the final text (ID 3).
+	converter.HandleEvent(UIMessageStreamEvent{Type: "tool_call_start", ToolCallID: "call-1", ToolName: "generate_image"})
+	converter.HandleEvent(UIMessageStreamEvent{Type: "attachment_delta", Attachments: []UIAttachment{{Type: "image", ContentHash: "hash-1"}}})
+	converter.HandleEvent(UIMessageStreamEvent{Type: "tool_call_end", ToolCallID: "call-1", ToolName: "generate_image"})
+	textBlocks := converter.HandleEvent(UIMessageStreamEvent{Type: "text_delta", Delta: "final answer"})
+	if len(textBlocks) != 1 {
+		t.Fatalf("expected 1 text block, got %d", len(textBlocks))
+	}
+	finalTextID := textBlocks[0].ID
+
+	// finalMessages hold only attempt 2 (tool-call + final text).
+	raw := mustUIRawJSON(t, []ModelMessage{
+		{
+			Role: "assistant",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "tool-call", "toolCallId": "call-1", "toolName": "generate_image", "input": map[string]any{"prompt": "a cat"}},
+			}),
+		},
+		{
+			Role: "tool",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "tool-result", "toolCallId": "call-1", "toolName": "generate_image", "result": map[string]any{"path": "/data/generated-images/1.png"}},
+			}),
+		},
+		{
+			Role: "assistant",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "text", "text": "final answer"},
+			}),
+		},
+	})
+
+	blocks := converter.ConvertTerminalMessages(raw)
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 terminal blocks, got %d: %#v", len(blocks), blocks)
+	}
+	// The final text must reuse the live final text block ID (attempt 2), not
+	// the discarded attempt-1 text block (ID 0), so it does not overwrite it.
+	var terminalText *UIMessage
+	for i := range blocks {
+		if blocks[i].Type == UIMessageText {
+			terminalText = &blocks[i]
+		}
+	}
+	if terminalText == nil {
+		t.Fatal("expected a terminal text block")
+	}
+	if terminalText.ID != finalTextID {
+		t.Fatalf("terminal text ID = %d, want live final text ID %d (retry must clear the discarded attempt's block)", terminalText.ID, finalTextID)
+	}
+	if terminalText.ID == 0 {
+		t.Fatal("terminal text must not reuse the discarded attempt-1 block ID 0")
+	}
+}
+
+func TestConvertTerminalMessagesSkipsTagOnlyLiveTextBlocks(t *testing.T) {
+	converter := NewUIMessageStreamConverter()
+
+	// Live: a standalone text segment that is entirely inline agent tags
+	// (ID 0), then a tool call (ID 1), then the real reply (ID 2). The terminal
+	// snapshot strips the tags and drops the empty text block, so it contains
+	// only the tool call and the real reply.
+	converter.HandleEvent(UIMessageStreamEvent{Type: "text_delta", Delta: `<attachments>{"path":"/tmp/a.png"}</attachments>`})
+	converter.HandleEvent(UIMessageStreamEvent{Type: "text_end"})
+	converter.HandleEvent(UIMessageStreamEvent{Type: "tool_call_start", ToolCallID: "call-1", ToolName: "generate_image"})
+	converter.HandleEvent(UIMessageStreamEvent{Type: "tool_call_end", ToolCallID: "call-1", ToolName: "generate_image"})
+	textBlocks := converter.HandleEvent(UIMessageStreamEvent{Type: "text_delta", Delta: "here you go"})
+	if len(textBlocks) != 1 {
+		t.Fatalf("expected 1 live text block, got %d", len(textBlocks))
+	}
+	realTextID := textBlocks[0].ID
+
+	raw := mustUIRawJSON(t, []ModelMessage{
+		{
+			Role: "assistant",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "tool-call", "toolCallId": "call-1", "toolName": "generate_image", "input": map[string]any{"prompt": "a cat"}},
+			}),
+		},
+		{
+			Role: "tool",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "tool-result", "toolCallId": "call-1", "toolName": "generate_image", "result": map[string]any{"path": "/tmp/a.png"}},
+			}),
+		},
+		{
+			Role: "assistant",
+			Content: mustUIRawJSON(t, []map[string]any{
+				{"type": "text", "text": "here you go"},
+			}),
+		},
+	})
+
+	blocks := converter.ConvertTerminalMessages(raw)
+	var terminalText *UIMessage
+	for i := range blocks {
+		if blocks[i].Type == UIMessageText {
+			terminalText = &blocks[i]
+		}
+	}
+	if terminalText == nil {
+		t.Fatal("expected a terminal text block")
+	}
+	if terminalText.ID != realTextID {
+		t.Fatalf("terminal text ID = %d, want %d (must skip the tag-only live block, not overwrite it)", terminalText.ID, realTextID)
+	}
+}

--- a/internal/handlers/local_channel.go
+++ b/internal/handlers/local_channel.go
@@ -982,7 +982,7 @@ func (h *LocalChannelHandler) forwardWSStreamEvents(ctx, assetCtx context.Contex
 				})
 				continue
 			case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort:
-				for _, uiMessage := range conversation.ConvertRawModelMessagesToUIAssistantMessages(streamEvent.Messages) {
+				for _, uiMessage := range converter.ConvertTerminalMessages(streamEvent.Messages) {
 					writer.SendJSON(wsOutboundEvent{
 						Type:      "message",
 						StreamID:  streamID,
@@ -1979,11 +1979,13 @@ func (h *LocalChannelHandler) buildTtsAttachment(ctx context.Context, botID, con
 func extractAssetRefsFromProcessedEvent(event json.RawMessage) []messagepkg.AssetRef {
 	var envelope struct {
 		Type        string           `json:"type"`
+		ToolCallID  string           `json:"toolCallId"`
 		Attachments []map[string]any `json:"attachments"`
 	}
 	if err := json.Unmarshal(event, &envelope); err != nil || envelope.Type != "attachment_delta" {
 		return nil
 	}
+	toolCallID := strings.TrimSpace(envelope.ToolCallID)
 	var refs []messagepkg.AssetRef
 	for i, att := range envelope.Attachments {
 		bundle := attachmentpkg.BundleFromMap(att)
@@ -1995,6 +1997,14 @@ func extractAssetRefsFromProcessedEvent(event json.RawMessage) []messagepkg.Asse
 		if name == "" && bundle.Metadata != nil {
 			name, _ = bundle.Metadata["name"].(string)
 		}
+		metadata := bundle.Metadata
+		if toolCallID != "" {
+			metadata = maps.Clone(metadata)
+			if metadata == nil {
+				metadata = map[string]any{}
+			}
+			metadata["tool_call_id"] = toolCallID
+		}
 		ref := messagepkg.AssetRef{
 			ContentHash: ch,
 			Role:        "attachment",
@@ -2002,7 +2012,7 @@ func extractAssetRefsFromProcessedEvent(event json.RawMessage) []messagepkg.Asse
 			Name:        name,
 			Mime:        strings.TrimSpace(bundle.Mime),
 			SizeBytes:   bundle.Size,
-			Metadata:    bundle.Metadata,
+			Metadata:    metadata,
 		}
 		ref.StorageKey = attachmentpkg.MetadataString(bundle.Metadata, attachmentpkg.MetadataKeyStorageKey)
 		refs = append(refs, ref)

--- a/internal/handlers/local_channel_test.go
+++ b/internal/handlers/local_channel_test.go
@@ -1464,3 +1464,26 @@ func newLocalChannelHandlerWithMedia() (*LocalChannelHandler, *localChannelMemor
 	handler.SetMediaService(media.NewService(slog.Default(), provider))
 	return handler, provider
 }
+
+func TestExtractAssetRefsFromProcessedEvent_CarriesToolCallID(t *testing.T) {
+	t.Parallel()
+
+	event, err := json.Marshal(map[string]any{
+		"type":       "attachment_delta",
+		"toolCallId": "call-42",
+		"attachments": []any{
+			map[string]any{"type": "image", "content_hash": "asset-1", "mime": "image/png"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	refs := extractAssetRefsFromProcessedEvent(event)
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 asset ref, got %d", len(refs))
+	}
+	if got, _ := refs[0].Metadata["tool_call_id"].(string); got != "call-42" {
+		t.Fatalf("tool_call_id metadata = %q, want call-42", got)
+	}
+}


### PR DESCRIPTION
Fixes #744

> [!NOTE]
> 依赖的 [memohai/twilight-ai#25](https://github.com/memohai/twilight-ai/pull/25) 已合并,`go.mod` 已升级到上游版本,无 replace。

## 问题

配置阿里云百炼或火山方舟的文生图模型后,让 bot 生图会直接失败:

```
openai: stream failed: api error 400: Invalid type for 'messages.[0].content'
```

根因是这类独立文生图模型(qwen-image、wan、doubao-seedream 等)不提供 chat completions 接口,但 `generate_image` 工具把所有图像模型都当聊天模型调用。

排查过程中还发现两个相关缺陷,一并修复:

1. 生成成功的图片只落盘到工作区,聊天里看不到;
2. 图片展示后,位置在实时流和刷新历史之间不一致(流结束时还会闪一下)。

## 改动

### 生成:按服务商路由到正确的 API(`internal/agent/tools/image_gen.go`)

- base URL 含 `dashscope` / `maas.aliyuncs.com` → twilight-ai 的 `alibabacloud/images` 原生 API(同步 multimodal 与异步任务轮询由 SDK 按模型自动选择);
- base URL 含 `api.openai.com` / `volces.com` / `bytepluses.com` / `siliconflow` → `/images/generations`;
- 其余保持原有 chat 路径(如 Gemini 聊天出图)。只按 base URL 判定,不按模型名猜测,未知服务商不会被错误路由。
- 返回 URL 的结果下载落盘:拨号时逐 IP 校验(loopback/私网/link-local 拒绝,重定向每跳同样生效),50MB 上限,拒绝空响应体,错误响应体截断 512B 后才进错误信息。
- chat 回退模型返回文本(安全拒绝、要求澄清)时作为正常工具结果转达,不再算工具失败。

### 展示:生成即投递(`image_gen.go`、`local_channel.go`)

`generate_image` 落盘后直接向实时流 emit 附件事件(与 `speak` 语音工具同一机制、同一 gating),web 端自动 ingest 成媒体资产并渲染,不再依赖模型额外调用 send。非交互会话(schedule/heartbeat 等)保持返回路径 + send 工具流程,工具的 `Usage()` 指引随会话形态自适应。

### 顺序:附件锚定与终态对齐(`resolver_store.go`、`uimessage_stream.go`)

- 附件事件全链路携带产生它的 `tool_call_id`(`ToolStreamEvent` 新增字段,`send`/`speak` 一并接入);持久化时 `LinkOutboundAssets` 把资产挂到包含该工具调用的 assistant 消息上,而不是笼统挂到最新一条,历史重建的顺序因此与实时一致。
- 流终态快照重放改经 `ConvertTerminalMessages`:重放块复用实时块的 ID(工具按 tool call ID,文本/推理按同类位置,跳过重试丢弃块与纯内联标签块),修复流结束瞬间附件块被重放文本覆盖导致的闪烁。

### 防呆:模型选择守卫(`resolver_model_selection.go`)

把纯文生图模型直接选作对话模型时(issue 的复现路径),返回明确提示"请配置为 bot 图像模型",不再透传上游 400。声明了 tool calling 的模型完全绕过名称判定,避免误伤名称相近的聊天模型。

## 测试

- 单元测试:路由判定、DashScope/OpenAI images 请求格式与 URL 下载(httptest)、SSRF 拨号拦截(loopback / 169.254.169.254)、空体与错误体截断、投递 gating、终态 ID 对齐(常规 / 重试 / 纯标签块)、资产锚定选行、模型选择守卫正反用例;涉及包通过 `go test -race`。
- 真实 API 验证:百炼 `qwen-image-2.0`、`wan2.7-image`、`z-image-turbo`,方舟 `doubao-seedream-4-0` / `5-0`,均经生产代码路径出图。
- Web 手动验证:图片内联渲染于回复气泡,实时流、流结束、刷新历史三个阶段顺序一致。

