### PR TITLE
feat(memory): auto-ingest agent memory files in heartbeat ticks

### DIFF
--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -360,6 +360,17 @@ func provideHeartbeatSessionCreator(sessionService *sessionpkg.Service) heartbea
 	return &sessionCreatorAdapter{svc: sessionService}
 }
 
+// provideHeartbeatService constructs the heartbeat service and wires its
+// optional memory-provider dependencies via setters (mirroring
+// provideMemoryHandler), so each heartbeat tick can converge agent-authored
+// memory files into the DB.
+func provideHeartbeatService(log *slog.Logger, queries dbstore.Queries, triggerer heartbeat.Triggerer, sessionCreator heartbeat.SessionCreator, runtimeConfig *boot.RuntimeConfig, memoryRegistry *memprovider.Registry, settingsService *settings.Service) *heartbeat.Service {
+	svc := heartbeat.NewService(log, queries, triggerer, sessionCreator, runtimeConfig)
+	svc.SetMemoryRegistry(memoryRegistry)
+	svc.SetSettingsService(settingsService)
+	return svc
+}
+
 func provideScheduleSessionCreator(sessionService *sessionpkg.Service) schedule.SessionCreator {
 	return &sessionCreatorAdapter{svc: sessionService}
 }

--- a/cmd/agent/module.go
+++ b/cmd/agent/module.go
@@ -20,7 +20,6 @@ import (
 	emailpkg "github.com/memohai/memoh/internal/email"
 	"github.com/memohai/memoh/internal/fetchproviders"
 	"github.com/memohai/memoh/internal/handlers"
-	"github.com/memohai/memoh/internal/heartbeat"
 	"github.com/memohai/memoh/internal/mcp"
 	memprovider "github.com/memohai/memoh/internal/memory/adapters"
 	"github.com/memohai/memoh/internal/message/event"
@@ -119,7 +118,7 @@ func options() fx.Option {
 			provideScheduleSessionCreator,
 			schedule.NewService,
 			provideHeartbeatTriggerer,
-			heartbeat.NewService,
+			provideHeartbeatService,
 			compaction.NewService,
 			provideContainerdHandler,
 			provideBotBackupService,

--- a/internal/heartbeat/service.go
+++ b/internal/heartbeat/service.go
@@ -18,6 +18,8 @@ import (
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
+	memprovider "github.com/memohai/memoh/internal/memory/adapters"
+	"github.com/memohai/memoh/internal/settings"
 )
 
 const heartbeatTokenTTL = 10 * time.Minute
@@ -38,11 +40,23 @@ type Service struct {
 	cron           *cron.Cron
 	triggerer      Triggerer
 	sessionCreator SessionCreator
+	memoryRegistry *memprovider.Registry
+	settingsSvc    *settings.Service
 	jwtSecret      string
 	logger         *slog.Logger
 	mu             sync.Mutex
 	jobs           map[string]cron.EntryID
 }
+
+// SetMemoryRegistry wires the memory provider registry so heartbeats can
+// converge agent-authored memory files into the DB. Set via setter (not the
+// constructor) to mirror the MemoryHandler/Resolver convention and keep
+// NewService's signature stable.
+func (s *Service) SetMemoryRegistry(r *memprovider.Registry) { s.memoryRegistry = r }
+
+// SetSettingsService wires the bot settings service used to resolve a bot's
+// configured memory provider.
+func (s *Service) SetSettingsService(svc *settings.Service) { s.settingsSvc = svc }
 
 func NewService(log *slog.Logger, queries dbstore.Queries, triggerer Triggerer, sessionCreator SessionCreator, runtimeConfig *boot.RuntimeConfig) *Service {
 	c := cron.New()
@@ -173,6 +187,78 @@ func (s *Service) runHeartbeat(ctx context.Context, cfg Config) {
 	modelID := db.ParseUUIDOrEmpty(result.ModelID)
 	s.completeLog(ctx, logRow.ID, result.Status, result.Text, "", result.UsageBytes, modelID)
 	s.logger.Info("heartbeat completed", slog.String("bot_id", cfg.BotID), slog.String("status", result.Status))
+
+	// Best-effort: converge agent-authored memory files into the DB so they
+	// become visible to search_memory without a manual /ingest. Runs after the
+	// trigger so files written during this tick are caught. Idempotent (ON
+	// CONFLICT upsert); failures are Warn-logged and never affect the tick.
+	s.ingestMemoryFiles(ctx, cfg.BotID)
+}
+
+// defaultBuiltinProviderID is the registry key under which the built-in graph
+// memory provider is registered (see app.go provideMemoryProviderRegistry). It
+// mirrors handlers.MemoryHandler.defaultBuiltinProviderID.
+const defaultBuiltinProviderID = "__builtin_default__"
+
+// ingestMemoryFiles resolves the bot's memory provider and, if it supports
+// markdown ingest, imports agent-authored /data/memory/*.md into the DB. This
+// mirrors MemoryHandler.resolveProvider + ChatIngest: it honours a bot's
+// configured provider and falls back to the default builtin, then type-asserts
+// to MarkdownIngestProvider. Non-supporting providers are a no-op (Debug log),
+// not an error — only the builtin graph runtime implements ingest today.
+func (s *Service) ingestMemoryFiles(ctx context.Context, botID string) {
+	botID = strings.TrimSpace(botID)
+	if botID == "" || s.memoryRegistry == nil {
+		return
+	}
+	provider, err := s.resolveMemoryProvider(ctx, botID)
+	if err != nil || provider == nil {
+		s.logger.Debug("memory ingest skipped: provider unavailable", slog.String("bot_id", botID), slog.Any("error", err))
+		return
+	}
+	ingest, ok := provider.(memprovider.MarkdownIngestProvider)
+	if !ok {
+		s.logger.Debug("memory ingest skipped: provider does not support markdown ingest", slog.String("bot_id", botID))
+		return
+	}
+	result, err := ingest.IngestFromMarkdown(ctx, botID)
+	if err != nil {
+		s.logger.Warn("memory ingest failed", slog.String("bot_id", botID), slog.Any("error", err))
+		return
+	}
+	if result.Ingested > 0 || result.Skipped > 0 {
+		s.logger.Info("memory ingest completed",
+			slog.String("bot_id", botID),
+			slog.Int("ingested", result.Ingested),
+			slog.Int("skipped", result.Skipped),
+		)
+	}
+}
+
+// resolveMemoryProvider resolves a bot's configured memory provider, falling
+// back to the default builtin when none is configured. Mirrors
+// handlers.MemoryHandler.resolveProvider so the heartbeat uses the same
+// resolution semantics as the HTTP /ingest endpoint.
+func (s *Service) resolveMemoryProvider(ctx context.Context, botID string) (memprovider.Provider, error) {
+	if s.settingsSvc != nil {
+		botSettings, err := s.settingsSvc.GetBot(ctx, botID)
+		if err == nil {
+			providerID := strings.TrimSpace(botSettings.MemoryProviderID)
+			if providerID != "" {
+				p, getErr := s.memoryRegistry.Get(providerID)
+				if getErr == nil {
+					return p, nil
+				}
+				s.logger.Warn("memory provider lookup failed", slog.String("provider_id", providerID), slog.Any("error", getErr))
+				return nil, fmt.Errorf("configured memory provider is unavailable: %w", getErr)
+			}
+		}
+	}
+	p, err := s.memoryRegistry.Get(defaultBuiltinProviderID)
+	if err != nil {
+		return nil, nil
+	}
+	return p, nil
 }
 
 func (s *Service) completeLog(ctx context.Context, logID pgtype.UUID, status, resultText, errorMessage string, usageBytes []byte, modelID pgtype.UUID) {

--- a/internal/heartbeat/service_test.go
+++ b/internal/heartbeat/service_test.go
@@ -1,6 +1,12 @@
 package heartbeat
 
-import "testing"
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	memprovider "github.com/memohai/memoh/internal/memory/adapters"
+)
 
 func TestNormalizeHeartbeatIntervalDefault(t *testing.T) {
 	t.Parallel()
@@ -13,5 +19,52 @@ func TestNormalizeHeartbeatIntervalDefault(t *testing.T) {
 	}
 	if got := normalizeHeartbeatInterval(60); got != 60 {
 		t.Fatalf("normalizeHeartbeatInterval(60) = %d, want 60", got)
+	}
+}
+
+// stubIngestProvider is a minimal Provider that also implements
+// MarkdownIngestProvider. It embeds memprovider.Provider (zero-value methods
+// for the unused surface) and only overrides Type + IngestFromMarkdown.
+type stubIngestProvider struct {
+	memprovider.Provider
+	ingested    memprovider.IngestResult
+	err         error
+	called      bool
+	calledBotID string
+}
+
+func (*stubIngestProvider) Type() string { return "builtin" }
+func (s *stubIngestProvider) IngestFromMarkdown(_ context.Context, botID string) (memprovider.IngestResult, error) {
+	s.called = true
+	s.calledBotID = botID
+	return s.ingested, s.err
+}
+
+func TestIngestMemoryFilesNoRegistry(t *testing.T) {
+	t.Parallel()
+	svc := &Service{logger: slog.Default()}
+	// No memoryRegistry set — should be a silent no-op, not a panic.
+	svc.ingestMemoryFiles(t.Context(), "bot-1")
+}
+
+func TestIngestMemoryFilesCallsProvider(t *testing.T) {
+	t.Parallel()
+	registry := memprovider.NewRegistry(slog.Default())
+	stub := &stubIngestProvider{
+		ingested: memprovider.IngestResult{Ingested: 3, Skipped: 1},
+	}
+	registry.Register(defaultBuiltinProviderID, stub)
+
+	svc := &Service{
+		memoryRegistry: registry,
+		logger:         slog.Default(),
+	}
+	svc.ingestMemoryFiles(t.Context(), "bot-1")
+
+	if !stub.called {
+		t.Fatal("expected IngestFromMarkdown to be called")
+	}
+	if stub.calledBotID != "bot-1" {
+		t.Fatalf("IngestFromMarkdown called with botID %q, want %q", stub.calledBotID, "bot-1")
 	}
 }


### PR DESCRIPTION
## Summary

Agent-authored `/data/memory/*.md` files persisted to disk but stayed invisible to `search_memory` until someone manually `POST /ingest` or `/rebuild`. This adds an idempotent `IngestFromMarkdown` pass at the end of each heartbeat tick, so memory files converge into the DB automatically — no manual trigger needed.

## Background

After #686 landed the DB-backed LLM wiki, there were two memory write paths:
1. **Chat extraction** (`OnAfterChat` → `runFormation` → LLM Extract/Decide → DB) — automatic
2. **Agent file writes** (`write_file` → `/data/memory/*.md`) — files persisted but stayed unsearchable until a manual ingest

This closes that gap by hooking the file→DB ingest into the heartbeat tick.

## Design

- **Why heartbeat, not `OnAfterChat`?** `OnAfterChat` fires on every reply; stacking a full file scan + edge rebuild there adds cost to high-frequency conversations. Heartbeat is low-frequency (default 1440 min), background, bot-autonomous — the right place for a best-effort convergence pass.
- **Runs after `TriggerHeartbeat`** so files written during the tick are caught this round, not next.
- **Best-effort non-fatal**: failures are `Warn`-logged and never abort the heartbeat (mirrors how `OnAfterChat` failures are handled in the resolver). `IngestMarkdownFiles` is `ON CONFLICT` upsert, so re-running on unchanged files is a no-op at the row level.
- **Setter injection** (`SetMemoryRegistry`/`SetSettingsService`) — same convention as `MemoryHandler` and `Resolver`, keeps `NewService` signature stable.
- **Provider resolution** mirrors `MemoryHandler.resolveProvider` (configured provider → `__builtin_default__` fallback) and type-asserts to `MarkdownIngestProvider`; non-builtin providers are a silent no-op (`Debug` log).

## Changes

| File | Change |
|------|--------|
| `internal/heartbeat/service.go` | `memoryRegistry`/`settingsSvc` fields + 2 setters + `ingestMemoryFiles` + `resolveMemoryProvider` + 1-line call in `runHeartbeat` |
| `cmd/agent/app.go` | `provideHeartbeatService` wrapper function |
| `cmd/agent/module.go` | `heartbeat.NewService` → `provideHeartbeatService`, drop now-unused import |
| `internal/heartbeat/service_test.go` | 3 tests: nil-registry no-op, normal call asserts botID, embed-based stub |

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./internal/heartbeat/... ./cmd/agent/...`
- `golangci-lint run ./internal/heartbeat/... ./cmd/agent/...`
- Pre-commit hook ran full `go test ./internal/...` (passed)