### PR TITLE
fix: docker compose web build context

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   web:
     build:
-      context: ..
+      context: .
       dockerfile: docker/Dockerfile.web
       args:
         - VITE_API_URL=${VITE_API_URL:-/api}


### PR DESCRIPTION
## Summary

- Restore the web service override build context to the repository root.
- Keep `docker/Dockerfile.web` resolved relative to that root when users run the documented layered compose command.

## Root cause

PR #686 changed `docker/docker-compose.yml` so the `web` service used `build.context: ..`. When this override file is combined with the root `docker-compose.yml`, Docker Compose resolves relative paths from the first compose file directory. From `/opt/Memoh`, that made the web build context `/opt` and the Dockerfile path `/opt/docker/Dockerfile.web`, which fails with `lstat /opt/docker: no such file or directory`.

## Validation

- `docker compose -f docker-compose.yml -f docker/docker-compose.yml config --format json | jq -r '.services.web.build.context, .services.web.build.dockerfile'`
- pre-commit Go test hook passed during commit