### PR TITLE
fix(historyfrag): update memory_query to the typed HistoryRecord API

### DIFF
--- a/internal/conversation/flow/memory_query.go
+++ b/internal/conversation/flow/memory_query.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/memohai/memoh/internal/conversation"
+	"github.com/memohai/memoh/internal/historyfrag"
 	"github.com/memohai/memoh/internal/prune"
 	"github.com/memohai/memoh/internal/textutil"
 )
@@ -49,7 +50,7 @@ func (r *Resolver) buildMemoryQuery(ctx context.Context, req conversation.ChatRe
 	if r == nil || r.messageService == nil {
 		return builder.Build(req, nil)
 	}
-	loaded, err := r.loadMessages(ctx, req.ChatID, req.SessionID, defaultMaxContextMinutes)
+	loaded, err := r.loadHistoryRecords(ctx, historyScopeFallbackFromChatRequest(req), req.SessionID, defaultMaxContextMinutes)
 	if err != nil {
 		if r.logger != nil {
 			r.logger.Warn("memory query history load failed",
@@ -61,12 +62,12 @@ func (r *Resolver) buildMemoryQuery(ctx context.Context, req conversation.ChatRe
 		}
 		return builder.Build(req, nil)
 	}
-	loaded = r.replaceCompactedMessages(ctx, loaded)
+	loaded = r.replaceCompactedMessages(ctx, compactionSummaryScope(req.BotID, req.ChatID, req.SessionID, req.ConversationType, req.ConversationName, req.ReplyTarget), loaded)
 	loaded = dedupePersistedCurrentUserMessage(loaded, req)
 	return builder.Build(req, loaded)
 }
 
-func (b memoryQueryBuilder) Build(req conversation.ChatRequest, history []messageWithUsage) memoryQuery {
+func (b memoryQueryBuilder) Build(req conversation.ChatRequest, history []historyfrag.HistoryRecord) memoryQuery {
 	current := strings.TrimSpace(req.Query)
 	if current == "" {
 		return memoryQuery{}
@@ -95,7 +96,7 @@ func (b memoryQueryBuilder) Build(req conversation.ChatRequest, history []messag
 	}
 }
 
-func (b memoryQueryBuilder) recentUserMessages(current string, history []messageWithUsage) []string {
+func (b memoryQueryBuilder) recentUserMessages(current string, history []historyfrag.HistoryRecord) []string {
 	if len(history) == 0 || b.MaxRecentMessages <= 0 {
 		return nil
 	}
@@ -103,7 +104,7 @@ func (b memoryQueryBuilder) recentUserMessages(current string, history []message
 	seen := map[string]bool{currentKey: true}
 	reversed := make([]string, 0, b.MaxRecentMessages)
 	for i := len(history) - 1; i >= 0 && len(reversed) < b.MaxRecentMessages; i-- {
-		msg := history[i].Message
+		msg := history[i].ModelMessage
 		if !strings.EqualFold(strings.TrimSpace(msg.Role), "user") {
 			continue
 		}

--- a/internal/conversation/flow/memory_query_test.go
+++ b/internal/conversation/flow/memory_query_test.go
@@ -5,17 +5,18 @@ import (
 	"testing"
 
 	"github.com/memohai/memoh/internal/conversation"
+	"github.com/memohai/memoh/internal/historyfrag"
 )
 
 func TestMemoryQueryBuilderCombinesRecentUserMessages(t *testing.T) {
 	t.Parallel()
 
 	builder := memoryQueryBuilder{MaxRecentMessages: 2, MaxBytes: 2000, MaxLines: 20, MaxMessageRunes: 200}
-	query := builder.Build(conversation.ChatRequest{Query: "What should I pack?"}, []messageWithUsage{
-		{Message: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("I am visiting Berlin next week")}},
-		{Message: conversation.ModelMessage{Role: "assistant", Content: conversation.NewTextContent("Sounds fun.")}},
-		{Message: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("I prefer tea over coffee")}},
-		{Message: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("What should I pack?")}},
+	query := builder.Build(conversation.ChatRequest{Query: "What should I pack?"}, []historyfrag.HistoryRecord{
+		{ModelMessage: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("I am visiting Berlin next week")}},
+		{ModelMessage: conversation.ModelMessage{Role: "assistant", Content: conversation.NewTextContent("Sounds fun.")}},
+		{ModelMessage: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("I prefer tea over coffee")}},
+		{ModelMessage: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("What should I pack?")}},
 	})
 
 	if query.Source != "current_query_with_history" {
@@ -38,8 +39,8 @@ func TestMemoryQueryBuilderTruncates(t *testing.T) {
 	t.Parallel()
 
 	builder := memoryQueryBuilder{MaxRecentMessages: 1, MaxBytes: 120, MaxLines: 6, MaxMessageRunes: 500}
-	query := builder.Build(conversation.ChatRequest{Query: strings.Repeat("current ", 30)}, []messageWithUsage{
-		{Message: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent(strings.Repeat("history ", 30))}},
+	query := builder.Build(conversation.ChatRequest{Query: strings.Repeat("current ", 30)}, []historyfrag.HistoryRecord{
+		{ModelMessage: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent(strings.Repeat("history ", 30))}},
 	})
 
 	if !query.Truncated {
@@ -53,8 +54,8 @@ func TestMemoryQueryBuilderTruncates(t *testing.T) {
 func TestMemoryQueryBuilderSkipsEmptyVisibleQuery(t *testing.T) {
 	t.Parallel()
 
-	query := defaultMemoryQueryBuilder().Build(conversation.ChatRequest{Query: "   "}, []messageWithUsage{
-		{Message: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("history")}},
+	query := defaultMemoryQueryBuilder().Build(conversation.ChatRequest{Query: "   "}, []historyfrag.HistoryRecord{
+		{ModelMessage: conversation.ModelMessage{Role: "user", Content: conversation.NewTextContent("history")}},
 	})
 	if query.Query != "" {
 		t.Fatalf("expected empty query, got %+v", query)


### PR DESCRIPTION
## Summary
- #713 merged with `main` broken: `internal/conversation/flow/memory_query.go` (and its test) were left on the pre-migration `messageWithUsage` / `loadMessages` / `replaceCompactedMessages(ctx, messages)` API while the rest of the PR (`resolver_history.go`, `resolver.go`, etc.) had already migrated to typed `historyfrag.HistoryRecord`. This was a rebase/merge artifact within #713's own stacked-branch history (`stacked on #712`) that the PR's own CI never caught, but broke the actual merged tree on `main` (build/lint/test all red post-merge: https://github.com/memohai/Memoh/actions/runs/28916986732, https://github.com/memohai/Memoh/actions/runs/28916986670).
- Updates `memory_query.go` to call `loadHistoryRecords` + `historyScopeFallbackFromChatRequest`, pass a `compactionSummaryScope` into `replaceCompactedMessages`, and use `historyfrag.HistoryRecord`/`.ModelMessage` in place of the removed `messageWithUsage`/`.Message`. No behavior change — this only re-aligns the file with the API the rest of the PR already established.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `golangci-lint run ./internal/conversation/flow/...`