### PR TITLE
fix(sql):  postgres retry fork state

### DIFF
--- a/db/postgres/migrations/0105_repair_superseded_message_visibility.down.sql
+++ b/db/postgres/migrations/0105_repair_superseded_message_visibility.down.sql
@@ -1,0 +1,3 @@
+-- 0105_repair_superseded_message_visibility (rollback)
+-- Repair migration only. No-op because the previous message visibility and
+-- incomplete-fork deleted state cannot be reconstructed safely.

--- a/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
+++ b/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
@@ -10,10 +10,110 @@ SET turn_visible = false
 WHERE turn_visible = true
   AND turn_superseded_at IS NOT NULL;
 
+WITH incomplete_fork_sessions AS (
+  SELECT s.id, s.created_at
+  FROM bot_sessions s
+  WHERE s.deleted_at IS NULL
+    AND s.type = 'chat'
+    AND s.session_mode = 'chat'
+    AND s.metadata ? 'forked_from'
+    AND (s.metadata->'forked_from') ? 'session_id'
+    AND (s.metadata->'forked_from') ? 'message_id'
+    AND NOT ((s.metadata->'forked_from') ? 'fork_message_id')
+),
+retained_incomplete_forks AS (
+  SELECT f.id, f.created_at
+  FROM incomplete_fork_sessions f
+  WHERE EXISTS (
+    SELECT 1
+    FROM bot_history_messages m
+    WHERE m.session_id = f.id
+      AND m.created_at > f.created_at
+  )
+),
+copied_prefix AS (
+  SELECT
+    f.id AS session_id,
+    COALESCE(MAX(m.turn_position), 0)::bigint AS max_position
+  FROM retained_incomplete_forks f
+  LEFT JOIN bot_history_messages m
+    ON m.session_id = f.id
+   AND m.turn_id IS NOT NULL
+   AND m.turn_position IS NOT NULL
+   AND m.created_at <= f.created_at
+  GROUP BY f.id
+),
+post_fork_turns AS (
+  SELECT
+    f.id AS session_id,
+    m.turn_id,
+    MIN(m.created_at) AS first_created_at,
+    MIN(m.turn_position) AS old_position
+  FROM retained_incomplete_forks f
+  JOIN bot_history_messages m
+    ON m.session_id = f.id
+   AND m.turn_id IS NOT NULL
+   AND m.turn_position IS NOT NULL
+  GROUP BY f.id, f.created_at, m.turn_id
+  HAVING MIN(m.created_at) > f.created_at
+),
+renumber_plan AS (
+  SELECT
+    p.session_id,
+    p.turn_id,
+    copied_prefix.max_position
+      + (ROW_NUMBER() OVER (
+          PARTITION BY p.session_id
+          ORDER BY p.first_created_at ASC, p.old_position ASC, p.turn_id ASC
+        ))::bigint AS turn_position
+  FROM post_fork_turns p
+  JOIN copied_prefix ON copied_prefix.session_id = p.session_id
+),
+renumbered_messages AS (
+  UPDATE bot_history_messages m
+  SET turn_position = renumber_plan.turn_position
+  FROM renumber_plan
+  WHERE m.session_id = renumber_plan.session_id
+    AND m.turn_id = renumber_plan.turn_id
+  RETURNING m.session_id
+),
+repaired_next_turn_position AS (
+  SELECT
+    f.id AS session_id,
+    (
+      GREATEST(
+        COALESCE(copied_prefix.max_position, 0),
+        COALESCE(MAX(renumber_plan.turn_position), 0)
+      ) + 1
+    )::bigint AS value
+  FROM retained_incomplete_forks f
+  JOIN copied_prefix ON copied_prefix.session_id = f.id
+  LEFT JOIN renumber_plan ON renumber_plan.session_id = f.id
+  GROUP BY f.id, copied_prefix.max_position
+)
+UPDATE bot_sessions s
+SET next_turn_position = GREATEST(s.next_turn_position, repaired_next_turn_position.value),
+    updated_at = now(),
+    metadata = jsonb_set(
+      s.metadata,
+      '{repair}',
+      COALESCE(s.metadata->'repair', '{}'::jsonb) || jsonb_build_object('0105_incomplete_fork_turn_positions', true),
+      true
+    )
+FROM repaired_next_turn_position
+WHERE s.id = repaired_next_turn_position.session_id
+  AND EXISTS (
+    SELECT 1
+    FROM renumbered_messages
+    WHERE renumbered_messages.session_id = s.id
+  );
+
 WITH incomplete_forks AS (
   SELECT s.id
   FROM bot_sessions s
   WHERE s.deleted_at IS NULL
+    AND s.type = 'chat'
+    AND s.session_mode = 'chat'
     AND s.metadata ? 'forked_from'
     AND (s.metadata->'forked_from') ? 'session_id'
     AND (s.metadata->'forked_from') ? 'message_id'

--- a/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
+++ b/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
@@ -139,13 +139,7 @@ repaired_next_turn_position AS (
 -- that merely match the filter but are already consistent are left untouched.
 UPDATE bot_sessions s
 SET next_turn_position = GREATEST(s.next_turn_position, repaired_next_turn_position.value),
-    updated_at = now(),
-    metadata = jsonb_set(
-      s.metadata,
-      '{repair}',
-      COALESCE(s.metadata->'repair', '{}'::jsonb) || jsonb_build_object('0105_incomplete_fork_turn_positions', true),
-      true
-    )
+    updated_at = now()
 FROM repaired_next_turn_position
 WHERE s.id = repaired_next_turn_position.session_id
   AND (

--- a/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
+++ b/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
@@ -12,16 +12,20 @@ WHERE turn_visible = true
   AND turn_superseded_at IS NOT NULL;
 
 WITH incomplete_fork_sessions AS (
-  SELECT s.id, s.created_at
+  SELECT s.id, s.created_at, s.next_turn_position
   FROM bot_sessions s
   WHERE s.deleted_at IS NULL
     AND s.type = 'chat'
     AND s.session_mode = 'chat'
-    AND s.metadata ? 'forked_from'
+    AND jsonb_typeof(s.metadata->'forked_from') = 'object'
     AND (s.metadata->'forked_from') ? 'session_id'
     AND (s.metadata->'forked_from') ? 'message_id'
     AND NOT ((s.metadata->'forked_from') ? 'fork_message_id')
 ),
+-- A missing fork_message_id alone does not prove broken data: the live retry
+-- flow legitimately removes the anchor from healthy forks. Repair only
+-- sessions whose turn state is actually damaged: two turns colliding on one
+-- position, or the allocator sitting at or below an occupied position.
 retained_incomplete_forks AS (
   SELECT f.id, f.created_at
   FROM incomplete_fork_sessions f
@@ -30,6 +34,26 @@ retained_incomplete_forks AS (
     FROM bot_history_messages m
     WHERE m.session_id = f.id
       AND m.created_at > f.created_at
+  )
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM bot_history_messages a
+      JOIN bot_history_messages b
+        ON b.session_id = a.session_id
+       AND b.turn_position = a.turn_position
+       AND b.turn_id <> a.turn_id
+      WHERE a.session_id = f.id
+        AND a.turn_id IS NOT NULL
+        AND a.turn_position IS NOT NULL
+        AND b.turn_id IS NOT NULL
+    )
+    OR f.next_turn_position <= (
+      SELECT MAX(m.turn_position)
+      FROM bot_history_messages m
+      WHERE m.session_id = f.id
+        AND m.turn_position IS NOT NULL
+    )
   )
 ),
 -- Classify turns, not messages: a retry replacement reuses the replaced turn's
@@ -136,7 +160,7 @@ WITH incomplete_forks AS (
   WHERE s.deleted_at IS NULL
     AND s.type = 'chat'
     AND s.session_mode = 'chat'
-    AND s.metadata ? 'forked_from'
+    AND jsonb_typeof(s.metadata->'forked_from') = 'object'
     AND (s.metadata->'forked_from') ? 'session_id'
     AND (s.metadata->'forked_from') ? 'message_id'
     AND NOT ((s.metadata->'forked_from') ? 'fork_message_id')

--- a/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
+++ b/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
@@ -1,9 +1,10 @@
 -- 0105_repair_superseded_message_visibility
 -- Hide superseded history messages that stayed visible because ReplaceHistoryTurn
 -- previously updated superseded metadata and visibility in separate CTE updates.
--- Also hide incomplete fork sessions left behind by the old
--- ForkSessionFromAssistantMessage CTE when the request returned an error after
--- copying messages.
+-- Repair the turn positions and position allocator of incomplete fork sessions
+-- that users kept using, and hide the incomplete fork sessions left behind by
+-- the old ForkSessionFromAssistantMessage CTE when the request returned an
+-- error after copying messages.
 
 UPDATE bot_history_messages
 SET turn_visible = false
@@ -31,31 +32,44 @@ retained_incomplete_forks AS (
       AND m.created_at > f.created_at
   )
 ),
-copied_prefix AS (
+-- Classify turns, not messages: a retry replacement reuses the replaced turn's
+-- user message, so a post-fork turn can still contain a message created before
+-- the fork session. A turn is copied prefix only when ALL of its messages
+-- predate the session; any post-fork message makes the whole turn post-fork.
+session_turns AS (
   SELECT
     f.id AS session_id,
-    COALESCE(MAX(m.turn_position), 0)::bigint AS max_position
-  FROM retained_incomplete_forks f
-  LEFT JOIN bot_history_messages m
-    ON m.session_id = f.id
-   AND m.turn_id IS NOT NULL
-   AND m.turn_position IS NOT NULL
-   AND m.created_at <= f.created_at
-  GROUP BY f.id
-),
-post_fork_turns AS (
-  SELECT
-    f.id AS session_id,
+    f.created_at AS session_created_at,
     m.turn_id,
+    MIN(m.turn_position) AS old_position,
     MIN(m.created_at) AS first_created_at,
-    MIN(m.turn_position) AS old_position
+    MAX(m.created_at) AS last_created_at
   FROM retained_incomplete_forks f
   JOIN bot_history_messages m
     ON m.session_id = f.id
    AND m.turn_id IS NOT NULL
    AND m.turn_position IS NOT NULL
   GROUP BY f.id, f.created_at, m.turn_id
-  HAVING MIN(m.created_at) > f.created_at
+),
+copied_prefix AS (
+  SELECT
+    f.id AS session_id,
+    COALESCE(
+      MAX(t.old_position) FILTER (WHERE t.last_created_at <= t.session_created_at),
+      0
+    )::bigint AS max_position
+  FROM retained_incomplete_forks f
+  LEFT JOIN session_turns t ON t.session_id = f.id
+  GROUP BY f.id
+),
+post_fork_turns AS (
+  SELECT
+    t.session_id,
+    t.turn_id,
+    t.first_created_at,
+    t.old_position
+  FROM session_turns t
+  WHERE t.last_created_at > t.session_created_at
 ),
 renumber_plan AS (
   SELECT
@@ -75,6 +89,7 @@ renumbered_messages AS (
   FROM renumber_plan
   WHERE m.session_id = renumber_plan.session_id
     AND m.turn_id = renumber_plan.turn_id
+    AND m.turn_position IS DISTINCT FROM renumber_plan.turn_position
   RETURNING m.session_id
 ),
 repaired_next_turn_position AS (
@@ -91,6 +106,10 @@ repaired_next_turn_position AS (
   LEFT JOIN renumber_plan ON renumber_plan.session_id = f.id
   GROUP BY f.id, copied_prefix.max_position
 )
+-- Touch a session only when the repair actually changed something: either
+-- messages were renumbered, or the allocator was behind the occupied positions
+-- (covers retained forks whose post-fork messages have no turn yet). Sessions
+-- that merely match the filter but are already consistent are left untouched.
 UPDATE bot_sessions s
 SET next_turn_position = GREATEST(s.next_turn_position, repaired_next_turn_position.value),
     updated_at = now(),
@@ -102,10 +121,13 @@ SET next_turn_position = GREATEST(s.next_turn_position, repaired_next_turn_posit
     )
 FROM repaired_next_turn_position
 WHERE s.id = repaired_next_turn_position.session_id
-  AND EXISTS (
-    SELECT 1
-    FROM renumbered_messages
-    WHERE renumbered_messages.session_id = s.id
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM renumbered_messages
+      WHERE renumbered_messages.session_id = s.id
+    )
+    OR s.next_turn_position < repaired_next_turn_position.value
   );
 
 WITH incomplete_forks AS (

--- a/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
+++ b/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
@@ -46,13 +46,16 @@ retained_incomplete_forks AS (
       WHERE a.session_id = f.id
         AND a.turn_id IS NOT NULL
         AND a.turn_position IS NOT NULL
+        AND a.turn_visible = true
         AND b.turn_id IS NOT NULL
+        AND b.turn_visible = true
     )
     OR f.next_turn_position <= (
       SELECT MAX(m.turn_position)
       FROM bot_history_messages m
       WHERE m.session_id = f.id
         AND m.turn_position IS NOT NULL
+        AND m.turn_visible = true
     )
   )
 ),

--- a/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
+++ b/db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql
@@ -1,0 +1,38 @@
+-- 0105_repair_superseded_message_visibility
+-- Hide superseded history messages that stayed visible because ReplaceHistoryTurn
+-- previously updated superseded metadata and visibility in separate CTE updates.
+-- Also hide incomplete fork sessions left behind by the old
+-- ForkSessionFromAssistantMessage CTE when the request returned an error after
+-- copying messages.
+
+UPDATE bot_history_messages
+SET turn_visible = false
+WHERE turn_visible = true
+  AND turn_superseded_at IS NOT NULL;
+
+WITH incomplete_forks AS (
+  SELECT s.id
+  FROM bot_sessions s
+  WHERE s.deleted_at IS NULL
+    AND s.metadata ? 'forked_from'
+    AND (s.metadata->'forked_from') ? 'session_id'
+    AND (s.metadata->'forked_from') ? 'message_id'
+    AND NOT ((s.metadata->'forked_from') ? 'fork_message_id')
+    AND NOT EXISTS (
+      SELECT 1
+      FROM bot_history_messages m
+      WHERE m.session_id = s.id
+        AND m.created_at > s.created_at
+    )
+)
+UPDATE bot_sessions s
+SET deleted_at = now(),
+    updated_at = now(),
+    metadata = jsonb_set(
+      s.metadata,
+      '{repair}',
+      COALESCE(s.metadata->'repair', '{}'::jsonb) || jsonb_build_object('0105_incomplete_fork_session', true),
+      true
+    )
+FROM incomplete_forks f
+WHERE s.id = f.id;

--- a/db/postgres/queries/messages.sql
+++ b/db/postgres/queries/messages.sql
@@ -1170,7 +1170,8 @@ updated AS (
   UPDATE bot_history_messages old
   SET turn_superseded_by_turn_id = replacement.id,
       turn_superseded_at = sqlc.arg(superseded_at),
-      turn_superseded_reason = sqlc.arg(superseded_reason)
+      turn_superseded_reason = sqlc.arg(superseded_reason),
+      turn_visible = false
   FROM replacement
   WHERE old.turn_id = sqlc.arg(old_turn_id)
     AND old.session_id = sqlc.arg(session_id)

--- a/db/postgres/queries/sessions.sql
+++ b/db/postgres/queries/sessions.sql
@@ -39,32 +39,6 @@ target_turn AS (
     AND vm.turn_position IS NOT NULL
   LIMIT 1
 ),
-created_session AS (
-  INSERT INTO bot_sessions (
-    bot_id,
-    channel_type,
-    type,
-    session_mode,
-    runtime_type,
-    runtime_metadata,
-    title,
-    metadata,
-    created_by_user_id
-  )
-  SELECT
-    s.bot_id,
-    s.channel_type,
-    s.type,
-    s.session_mode,
-    s.runtime_type,
-    s.runtime_metadata,
-    sqlc.arg(title),
-    sqlc.arg(metadata),
-    sqlc.narg(created_by_user_id)::uuid
-  FROM source_session s
-  JOIN target_turn tt ON true
-  RETURNING *
-),
 copy_messages AS (
   SELECT
     vm.id AS old_message_id,
@@ -104,6 +78,62 @@ copy_turns AS (
     FROM copy_messages
   ) cm
   ORDER BY cm.turn_position ASC
+),
+next_turn_position AS (
+  SELECT COALESCE(MAX(new_position), 0) + 1 AS value
+  FROM copy_turns
+),
+fork_anchor_message AS (
+  SELECT assistant_message.new_message_id
+  FROM target_turn tt
+  JOIN copy_messages assistant_message ON assistant_message.old_message_id = tt.message_id
+  LIMIT 1
+),
+prepared_metadata AS (
+  SELECT COALESCE(sqlc.arg(metadata)::jsonb, '{}'::jsonb) AS value
+),
+fork_plan AS (
+  SELECT
+    s.*,
+    fam.new_message_id AS fork_message_id,
+    ntp.value AS next_turn_position_value
+  FROM source_session s
+  JOIN fork_anchor_message fam ON true
+  CROSS JOIN next_turn_position ntp
+  WHERE EXISTS (SELECT 1 FROM copy_turns)
+),
+created_session AS (
+  INSERT INTO bot_sessions (
+    bot_id,
+    channel_type,
+    type,
+    session_mode,
+    runtime_type,
+    runtime_metadata,
+    title,
+    metadata,
+    next_turn_position,
+    created_by_user_id
+  )
+  SELECT
+    fp.bot_id,
+    fp.channel_type,
+    fp.type,
+    fp.session_mode,
+    fp.runtime_type,
+    fp.runtime_metadata,
+    sqlc.arg(title),
+    jsonb_set(
+      pm.value,
+      '{forked_from}',
+      COALESCE(pm.value->'forked_from', '{}'::jsonb) || jsonb_build_object('fork_message_id', fp.fork_message_id::text),
+      true
+    ),
+    fp.next_turn_position_value,
+    sqlc.narg(created_by_user_id)::uuid
+  FROM fork_plan fp
+  CROSS JOIN prepared_metadata pm
+  RETURNING *
 ),
 inserted_messages AS (
   INSERT INTO bot_history_messages (
@@ -154,16 +184,6 @@ inserted_messages AS (
   CROSS JOIN created_session cs
   RETURNING id
 ),
-copy_message_counts AS (
-  SELECT count(*) AS count FROM copy_messages
-),
-inserted_message_counts AS (
-  SELECT count(*) AS count FROM inserted_messages
-),
-next_turn_position AS (
-  SELECT COALESCE(MAX(new_position), 0) + 1 AS value
-  FROM copy_turns
-),
 copied_assets AS (
   INSERT INTO bot_history_message_assets (
     message_id,
@@ -184,35 +204,10 @@ copied_assets AS (
   JOIN copy_messages cm ON cm.old_message_id = a.message_id
   JOIN inserted_messages im ON im.id = cm.new_message_id
   RETURNING id
-),
-fork_anchor_message AS (
-  SELECT assistant_message.new_message_id
-  FROM target_turn tt
-  JOIN copy_messages assistant_message ON assistant_message.old_message_id = tt.message_id
-  LIMIT 1
-),
-updated_session AS (
-  UPDATE bot_sessions s
-  SET next_turn_position = ntp.value,
-      metadata = jsonb_set(
-        s.metadata,
-        '{forked_from}',
-        COALESCE(s.metadata->'forked_from', '{}'::jsonb) || jsonb_build_object('fork_message_id', fam.new_message_id::text),
-        true
-      )
-  FROM created_session cs
-  JOIN fork_anchor_message fam ON true
-  CROSS JOIN next_turn_position ntp
-  WHERE s.id = cs.id
-  RETURNING s.*
 )
-SELECT us.*
-FROM updated_session us
-CROSS JOIN (SELECT count(*) AS copied_asset_count FROM copied_assets) copied_asset_counts
-CROSS JOIN copy_message_counts
-CROSS JOIN inserted_message_counts
-WHERE EXISTS (SELECT 1 FROM copy_turns)
-  AND inserted_message_counts.count = copy_message_counts.count;
+SELECT cs.*
+FROM created_session cs
+CROSS JOIN (SELECT count(*) AS copied_asset_count FROM copied_assets) copied_asset_counts;
 
 -- name: GetSessionByID :one
 SELECT *

--- a/internal/db/postgres/sqlc/messages.sql.go
+++ b/internal/db/postgres/sqlc/messages.sql.go
@@ -4787,7 +4787,8 @@ updated AS (
   UPDATE bot_history_messages old
   SET turn_superseded_by_turn_id = replacement.id,
       turn_superseded_at = $5,
-      turn_superseded_reason = $6
+      turn_superseded_reason = $6,
+      turn_visible = false
   FROM replacement
   WHERE old.turn_id = $1
     AND old.session_id = $2

--- a/internal/db/postgres/sqlc/sessions.sql.go
+++ b/internal/db/postgres/sqlc/sessions.sql.go
@@ -117,32 +117,6 @@ target_turn AS (
     AND vm.turn_position IS NOT NULL
   LIMIT 1
 ),
-created_session AS (
-  INSERT INTO bot_sessions (
-    bot_id,
-    channel_type,
-    type,
-    session_mode,
-    runtime_type,
-    runtime_metadata,
-    title,
-    metadata,
-    created_by_user_id
-  )
-  SELECT
-    s.bot_id,
-    s.channel_type,
-    s.type,
-    s.session_mode,
-    s.runtime_type,
-    s.runtime_metadata,
-    $4,
-    $5,
-    $6::uuid
-  FROM source_session s
-  JOIN target_turn tt ON true
-  RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
-),
 copy_messages AS (
   SELECT
     vm.id AS old_message_id,
@@ -182,6 +156,62 @@ copy_turns AS (
     FROM copy_messages
   ) cm
   ORDER BY cm.turn_position ASC
+),
+next_turn_position AS (
+  SELECT COALESCE(MAX(new_position), 0) + 1 AS value
+  FROM copy_turns
+),
+fork_anchor_message AS (
+  SELECT assistant_message.new_message_id
+  FROM target_turn tt
+  JOIN copy_messages assistant_message ON assistant_message.old_message_id = tt.message_id
+  LIMIT 1
+),
+prepared_metadata AS (
+  SELECT COALESCE($4::jsonb, '{}'::jsonb) AS value
+),
+fork_plan AS (
+  SELECT
+    s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+    fam.new_message_id AS fork_message_id,
+    ntp.value AS next_turn_position_value
+  FROM source_session s
+  JOIN fork_anchor_message fam ON true
+  CROSS JOIN next_turn_position ntp
+  WHERE EXISTS (SELECT 1 FROM copy_turns)
+),
+created_session AS (
+  INSERT INTO bot_sessions (
+    bot_id,
+    channel_type,
+    type,
+    session_mode,
+    runtime_type,
+    runtime_metadata,
+    title,
+    metadata,
+    next_turn_position,
+    created_by_user_id
+  )
+  SELECT
+    fp.bot_id,
+    fp.channel_type,
+    fp.type,
+    fp.session_mode,
+    fp.runtime_type,
+    fp.runtime_metadata,
+    $5,
+    jsonb_set(
+      pm.value,
+      '{forked_from}',
+      COALESCE(pm.value->'forked_from', '{}'::jsonb) || jsonb_build_object('fork_message_id', fp.fork_message_id::text),
+      true
+    ),
+    fp.next_turn_position_value,
+    $6::uuid
+  FROM fork_plan fp
+  CROSS JOIN prepared_metadata pm
+  RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 ),
 inserted_messages AS (
   INSERT INTO bot_history_messages (
@@ -232,16 +262,6 @@ inserted_messages AS (
   CROSS JOIN created_session cs
   RETURNING id
 ),
-copy_message_counts AS (
-  SELECT count(*) AS count FROM copy_messages
-),
-inserted_message_counts AS (
-  SELECT count(*) AS count FROM inserted_messages
-),
-next_turn_position AS (
-  SELECT COALESCE(MAX(new_position), 0) + 1 AS value
-  FROM copy_turns
-),
 copied_assets AS (
   INSERT INTO bot_history_message_assets (
     message_id,
@@ -262,43 +282,18 @@ copied_assets AS (
   JOIN copy_messages cm ON cm.old_message_id = a.message_id
   JOIN inserted_messages im ON im.id = cm.new_message_id
   RETURNING id
-),
-fork_anchor_message AS (
-  SELECT assistant_message.new_message_id
-  FROM target_turn tt
-  JOIN copy_messages assistant_message ON assistant_message.old_message_id = tt.message_id
-  LIMIT 1
-),
-updated_session AS (
-  UPDATE bot_sessions s
-  SET next_turn_position = ntp.value,
-      metadata = jsonb_set(
-        s.metadata,
-        '{forked_from}',
-        COALESCE(s.metadata->'forked_from', '{}'::jsonb) || jsonb_build_object('fork_message_id', fam.new_message_id::text),
-        true
-      )
-  FROM created_session cs
-  JOIN fork_anchor_message fam ON true
-  CROSS JOIN next_turn_position ntp
-  WHERE s.id = cs.id
-  RETURNING s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at
 )
-SELECT us.id, us.bot_id, us.route_id, us.channel_type, us.type, us.session_mode, us.runtime_type, us.runtime_metadata, us.title, us.metadata, us.next_turn_position, us.parent_session_id, us.created_by_user_id, us.created_at, us.updated_at, us.deleted_at
-FROM updated_session us
+SELECT cs.id, cs.bot_id, cs.route_id, cs.channel_type, cs.type, cs.session_mode, cs.runtime_type, cs.runtime_metadata, cs.title, cs.metadata, cs.next_turn_position, cs.parent_session_id, cs.created_by_user_id, cs.created_at, cs.updated_at, cs.deleted_at
+FROM created_session cs
 CROSS JOIN (SELECT count(*) AS copied_asset_count FROM copied_assets) copied_asset_counts
-CROSS JOIN copy_message_counts
-CROSS JOIN inserted_message_counts
-WHERE EXISTS (SELECT 1 FROM copy_turns)
-  AND inserted_message_counts.count = copy_message_counts.count
 `
 
 type ForkSessionFromAssistantMessageParams struct {
 	SessionID       pgtype.UUID `json:"session_id"`
 	BotID           pgtype.UUID `json:"bot_id"`
 	MessageID       pgtype.UUID `json:"message_id"`
-	Title           string      `json:"title"`
 	Metadata        []byte      `json:"metadata"`
+	Title           string      `json:"title"`
 	CreatedByUserID pgtype.UUID `json:"created_by_user_id"`
 }
 
@@ -326,8 +321,8 @@ func (q *Queries) ForkSessionFromAssistantMessage(ctx context.Context, arg ForkS
 		arg.SessionID,
 		arg.BotID,
 		arg.MessageID,
-		arg.Title,
 		arg.Metadata,
+		arg.Title,
 		arg.CreatedByUserID,
 	)
 	var i ForkSessionFromAssistantMessageRow

--- a/internal/message/service_postgres_integration_test.go
+++ b/internal/message/service_postgres_integration_test.go
@@ -118,6 +118,43 @@ func TestPostgresReplaceTurnEditHidesSupersededTurn(t *testing.T) {
 	assertPostgresMessageVisibility(t, ctx, tx, oldAssistant.ID, false, true)
 }
 
+func TestPostgresRepairSupersededMessageVisibilityMigration(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresMessageTestTx(t, ctx)
+	setupPostgresMessageTestFixtures(t, ctx, tx)
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_history_messages (
+			id, bot_id, session_id, role, content,
+			turn_id, turn_position, turn_message_seq, turn_visible, turn_superseded_at
+		)
+		VALUES
+			(
+				'00000000-0000-0000-0000-000000074111',
+				$1, $2, 'assistant', '{"role":"assistant","content":"bad"}'::jsonb,
+				'00000000-0000-0000-0000-000000074121', 1, 2, true, now()
+			),
+			(
+				'00000000-0000-0000-0000-000000074112',
+				$1, $2, 'assistant', '{"role":"assistant","content":"good"}'::jsonb,
+				'00000000-0000-0000-0000-000000074122', 2, 2, true, NULL
+			)
+	`, postgresMessageTestBotID, postgresMessageTestSessionID); err != nil {
+		t.Fatalf("insert repair fixtures: %v", err)
+	}
+
+	sql, err := os.ReadFile("../../db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql")
+	if err != nil {
+		t.Fatalf("read repair migration: %v", err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("run repair migration: %v", err)
+	}
+
+	assertPostgresMessageVisibility(t, ctx, tx, "00000000-0000-0000-0000-000000074111", false, true)
+	assertPostgresMessageVisibility(t, ctx, tx, "00000000-0000-0000-0000-000000074112", true, false)
+}
+
 const (
 	postgresMessageTestUserID    = "00000000-0000-0000-0000-000000074101"
 	postgresMessageTestBotID     = "00000000-0000-0000-0000-000000074102"

--- a/internal/message/service_postgres_integration_test.go
+++ b/internal/message/service_postgres_integration_test.go
@@ -1,0 +1,210 @@
+package message
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dbpkg "github.com/memohai/memoh/internal/db"
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
+)
+
+func TestPostgresReplaceTurnRetryHidesSupersededAssistant(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresMessageTestTx(t, ctx)
+	setupPostgresMessageTestFixtures(t, ctx, tx)
+
+	svc := NewService(nil, postgresstore.NewQueries(dbsqlc.New(tx)))
+	user, err := svc.Persist(ctx, PersistInput{
+		BotID:     postgresMessageTestBotID,
+		SessionID: postgresMessageTestSessionID,
+		Role:      "user",
+		Content:   []byte(`{"role":"user","content":"hello"}`),
+	})
+	if err != nil {
+		t.Fatalf("persist user: %v", err)
+	}
+	assistant, err := svc.Persist(ctx, PersistInput{
+		BotID:     postgresMessageTestBotID,
+		SessionID: postgresMessageTestSessionID,
+		Role:      "assistant",
+		Content:   []byte(`{"role":"assistant","content":"old"}`),
+	})
+	if err != nil {
+		t.Fatalf("persist assistant: %v", err)
+	}
+	oldTurn, err := svc.GetVisibleTurnByMessage(ctx, postgresMessageTestSessionID, assistant.ID)
+	if err != nil {
+		t.Fatalf("get old turn: %v", err)
+	}
+	replacement, err := svc.Persist(ctx, PersistInput{
+		BotID:           postgresMessageTestBotID,
+		SessionID:       postgresMessageTestSessionID,
+		Role:            "assistant",
+		Content:         []byte(`{"role":"assistant","content":"new"}`),
+		SkipHistoryTurn: true,
+	})
+	if err != nil {
+		t.Fatalf("persist replacement assistant: %v", err)
+	}
+	if _, err := svc.ReplaceTurn(ctx, postgresMessageTestSessionID, oldTurn.ID, user.ID, replacement.ID, "retry"); err != nil {
+		t.Fatalf("replace turn: %v", err)
+	}
+
+	assertPostgresVisibleMessageIDs(t, ctx, svc, user.ID, replacement.ID)
+	assertPostgresMessageVisibility(t, ctx, tx, assistant.ID, false, true)
+}
+
+func TestPostgresReplaceTurnEditHidesSupersededTurn(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresMessageTestTx(t, ctx)
+	setupPostgresMessageTestFixtures(t, ctx, tx)
+
+	svc := NewService(nil, postgresstore.NewQueries(dbsqlc.New(tx)))
+	oldUser, err := svc.Persist(ctx, PersistInput{
+		BotID:     postgresMessageTestBotID,
+		SessionID: postgresMessageTestSessionID,
+		Role:      "user",
+		Content:   []byte(`{"role":"user","content":"old prompt"}`),
+	})
+	if err != nil {
+		t.Fatalf("persist old user: %v", err)
+	}
+	oldAssistant, err := svc.Persist(ctx, PersistInput{
+		BotID:     postgresMessageTestBotID,
+		SessionID: postgresMessageTestSessionID,
+		Role:      "assistant",
+		Content:   []byte(`{"role":"assistant","content":"old answer"}`),
+	})
+	if err != nil {
+		t.Fatalf("persist old assistant: %v", err)
+	}
+	oldTurn, err := svc.GetVisibleTurnByMessage(ctx, postgresMessageTestSessionID, oldAssistant.ID)
+	if err != nil {
+		t.Fatalf("get old turn: %v", err)
+	}
+	newUser, err := svc.Persist(ctx, PersistInput{
+		BotID:           postgresMessageTestBotID,
+		SessionID:       postgresMessageTestSessionID,
+		Role:            "user",
+		Content:         []byte(`{"role":"user","content":"new prompt"}`),
+		SkipHistoryTurn: true,
+	})
+	if err != nil {
+		t.Fatalf("persist new user: %v", err)
+	}
+	newAssistant, err := svc.Persist(ctx, PersistInput{
+		BotID:           postgresMessageTestBotID,
+		SessionID:       postgresMessageTestSessionID,
+		Role:            "assistant",
+		Content:         []byte(`{"role":"assistant","content":"new answer"}`),
+		SkipHistoryTurn: true,
+	})
+	if err != nil {
+		t.Fatalf("persist new assistant: %v", err)
+	}
+	if _, err := svc.ReplaceTurn(ctx, postgresMessageTestSessionID, oldTurn.ID, newUser.ID, newAssistant.ID, "edit"); err != nil {
+		t.Fatalf("replace turn: %v", err)
+	}
+
+	assertPostgresVisibleMessageIDs(t, ctx, svc, newUser.ID, newAssistant.ID)
+	assertPostgresMessageVisibility(t, ctx, tx, oldUser.ID, false, true)
+	assertPostgresMessageVisibility(t, ctx, tx, oldAssistant.ID, false, true)
+}
+
+const (
+	postgresMessageTestUserID    = "00000000-0000-0000-0000-000000074101"
+	postgresMessageTestBotID     = "00000000-0000-0000-0000-000000074102"
+	postgresMessageTestSessionID = "00000000-0000-0000-0000-000000074103"
+)
+
+func beginPostgresMessageTestTx(t *testing.T, ctx context.Context) pgx.Tx {
+	t.Helper()
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("skip postgres integration test: TEST_POSTGRES_DSN is not set")
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Skipf("skip postgres integration test: cannot connect to database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		t.Skipf("skip postgres integration test: database ping failed: %v", err)
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback(ctx) })
+	return tx
+}
+
+func setupPostgresMessageTestFixtures(t *testing.T, ctx context.Context, tx pgx.Tx) {
+	t.Helper()
+	name := fmt.Sprintf("postgres-message-test-%d", time.Now().UnixNano())
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO users (id, username, role, is_active)
+		VALUES ($1, $2, 'admin', true)
+	`, postgresMessageTestUserID, name); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bots (id, owner_user_id, name)
+		VALUES ($1, $2, $3)
+	`, postgresMessageTestBotID, postgresMessageTestUserID, name); err != nil {
+		t.Fatalf("insert bot: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_sessions (id, bot_id, channel_type)
+		VALUES ($1, $2, 'local')
+	`, postgresMessageTestSessionID, postgresMessageTestBotID); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+}
+
+func assertPostgresVisibleMessageIDs(t *testing.T, ctx context.Context, svc *DBService, want ...string) {
+	t.Helper()
+	messages, err := svc.ListBySession(ctx, postgresMessageTestSessionID)
+	if err != nil {
+		t.Fatalf("list session messages: %v", err)
+	}
+	got := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		got = append(got, msg.ID)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("visible message ids = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("visible message ids = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func assertPostgresMessageVisibility(t *testing.T, ctx context.Context, tx pgx.Tx, messageID string, wantVisible bool, wantSuperseded bool) {
+	t.Helper()
+	pgMessageID, err := dbpkg.ParseUUID(messageID)
+	if err != nil {
+		t.Fatalf("parse message id: %v", err)
+	}
+	var visible bool
+	var superseded bool
+	if err := tx.QueryRow(ctx, `
+		SELECT turn_visible, turn_superseded_at IS NOT NULL
+		FROM bot_history_messages
+		WHERE id = $1
+	`, pgMessageID).Scan(&visible, &superseded); err != nil {
+		t.Fatalf("read message visibility: %v", err)
+	}
+	if visible != wantVisible || superseded != wantSuperseded {
+		t.Fatalf("message %s visible/superseded = %v/%v, want %v/%v", messageID, visible, superseded, wantVisible, wantSuperseded)
+	}
+}

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -486,16 +486,25 @@ func TestPostgresRepairSkipsConsistentIncompleteForkMigration(t *testing.T) {
 		retriedReusedUser = "00000000-0000-0000-0000-000000075616"
 		retriedNewReply   = "00000000-0000-0000-0000-000000075617"
 
+		hiddenCollisionSessionID = "00000000-0000-0000-0000-000000075604"
+		hiddenCollisionPrefix    = "00000000-0000-0000-0000-000000075618"
+		hiddenCollisionHidden    = "00000000-0000-0000-0000-000000075619"
+		hiddenCollisionUser      = "00000000-0000-0000-0000-00000007561a"
+		hiddenCollisionVisible   = "00000000-0000-0000-0000-00000007561b"
+
 		arrayMetadataSessionID = "00000000-0000-0000-0000-000000075603"
 	)
-	// Three sessions that match the missing-fork_message_id filter but must
+	// Four sessions that match the missing-fork_message_id filter but must
 	// not be repaired:
 	// 1. positions and allocator already consistent
 	// 2. healthy fork whose post-fork turn was retried with the NEW
 	//    ReplaceHistoryTurn: the hidden superseded turn keeps its position and
 	//    the replacement reuses the user message, so message-time ordering
 	//    disagrees with positions — still consistent, must stay untouched
-	// 3. forked_from is a jsonb array, not an object (the ? operator matches
+	// 3. a hidden superseded turn shares a position with a visible turn: the
+	//    collision only exists among hidden rows, which never reach visible
+	//    history or turn allocation, so it must not count as damage
+	// 4. forked_from is a jsonb array, not an object (the ? operator matches
 	//    array elements, so a shape guard is required)
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO bot_sessions (id, bot_id, channel_type, title, metadata, next_turn_position, created_at, updated_at)
@@ -514,8 +523,13 @@ func TestPostgresRepairSkipsConsistentIncompleteForkMigration(t *testing.T) {
 				$4, $1, 'local', 'array metadata',
 				'{"forked_from":["session_id","message_id"]}'::jsonb,
 				1, now(), now()
+			),
+			(
+				$5, $1, 'local', 'hidden collision fork',
+				'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
+				3, now(), now()
 			)
-	`, postgresSessionTestBotID, sessionID, retriedSessionID, arrayMetadataSessionID); err != nil {
+	`, postgresSessionTestBotID, sessionID, retriedSessionID, arrayMetadataSessionID, hiddenCollisionSessionID); err != nil {
 		t.Fatalf("insert consistent fork sessions: %v", err)
 	}
 	if _, err := tx.Exec(ctx, `
@@ -559,9 +573,31 @@ func TestPostgresRepairSkipsConsistentIncompleteForkMigration(t *testing.T) {
 				$10, $1, $6, 'assistant', '{"role":"assistant","content":"retry reply"}'::jsonb,
 				'00000000-0000-0000-0000-000000075625', 3, 2, true, NULL,
 				(SELECT created_at + interval '4 minutes' FROM bot_sessions WHERE id = $6)
+			),
+			(
+				$12, $1, $11, 'assistant', '{"role":"assistant","content":"copied"}'::jsonb,
+				'00000000-0000-0000-0000-000000075626', 1, 2, true, NULL,
+				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $11)
+			),
+			(
+				$13, $1, $11, 'assistant', '{"role":"assistant","content":"superseded reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075627', 2, 2, false,
+				(SELECT created_at + interval '3 minutes' FROM bot_sessions WHERE id = $11),
+				(SELECT created_at + interval '1 minute' FROM bot_sessions WHERE id = $11)
+			),
+			(
+				$14, $1, $11, 'user', '{"role":"user","content":"replacement"}'::jsonb,
+				'00000000-0000-0000-0000-000000075628', 2, 1, true, NULL,
+				(SELECT created_at + interval '2 minutes' FROM bot_sessions WHERE id = $11)
+			),
+			(
+				$15, $1, $11, 'assistant', '{"role":"assistant","content":"replacement reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075628', 2, 2, true, NULL,
+				(SELECT created_at + interval '3 minutes' FROM bot_sessions WHERE id = $11)
 			)
 	`, postgresSessionTestBotID, sessionID, prefixAssistant, followUpUser, followUpAssistant,
-		retriedSessionID, retriedPrefixMsg, retriedHiddenMsg, retriedReusedUser, retriedNewReply); err != nil {
+		retriedSessionID, retriedPrefixMsg, retriedHiddenMsg, retriedReusedUser, retriedNewReply,
+		hiddenCollisionSessionID, hiddenCollisionPrefix, hiddenCollisionHidden, hiddenCollisionUser, hiddenCollisionVisible); err != nil {
 		t.Fatalf("insert consistent fork messages: %v", err)
 	}
 
@@ -592,6 +628,14 @@ func TestPostgresRepairSkipsConsistentIncompleteForkMigration(t *testing.T) {
 	assertPostgresSessionNextTurnPosition(t, ctx, tx, arrayMetadataSessionID, 1)
 	assertPostgresSessionRepairMarker(t, ctx, tx, arrayMetadataSessionID, "0105_incomplete_fork_session", false)
 	assertPostgresSessionRepairMarker(t, ctx, tx, arrayMetadataSessionID, "0105_incomplete_fork_turn_positions", false)
+
+	assertPostgresSessionDeleted(t, ctx, tx, hiddenCollisionSessionID, false)
+	assertPostgresMessageTurnPosition(t, ctx, tx, hiddenCollisionPrefix, 1)
+	assertPostgresMessageTurnPosition(t, ctx, tx, hiddenCollisionHidden, 2)
+	assertPostgresMessageTurnPosition(t, ctx, tx, hiddenCollisionUser, 2)
+	assertPostgresMessageTurnPosition(t, ctx, tx, hiddenCollisionVisible, 2)
+	assertPostgresSessionNextTurnPosition(t, ctx, tx, hiddenCollisionSessionID, 3)
+	assertPostgresSessionRepairMarker(t, ctx, tx, hiddenCollisionSessionID, "0105_incomplete_fork_turn_positions", false)
 }
 
 const (

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -1,0 +1,309 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
+	message "github.com/memohai/memoh/internal/message"
+)
+
+func TestPostgresForkFromAssistantMessageCopiesVisibleTurns(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresSessionTestTx(t, ctx)
+	setupPostgresSessionForkFixtures(t, ctx, tx)
+
+	svc := NewService(nil, postgresstore.NewQueries(dbsqlc.New(tx)), nil)
+	fork, err := svc.ForkFromAssistantMessage(ctx, ForkFromAssistantInput{
+		BotID:           postgresSessionTestBotID,
+		SessionID:       postgresSessionTestSessionID,
+		MessageID:       postgresSessionTestAssistant2ID,
+		Title:           "Forked",
+		CreatedByUserID: postgresSessionTestUserID,
+	})
+	if err != nil {
+		t.Fatalf("fork assistant message: %v", err)
+	}
+
+	forkedFrom, ok := fork.Metadata["forked_from"].(map[string]any)
+	if !ok {
+		t.Fatalf("fork metadata missing forked_from: %#v", fork.Metadata)
+	}
+	if got := forkedFrom["session_id"]; got != postgresSessionTestSessionID {
+		t.Fatalf("fork source session_id = %#v, want %s", got, postgresSessionTestSessionID)
+	}
+	if got := forkedFrom["message_id"]; got != postgresSessionTestAssistant2ID {
+		t.Fatalf("fork source message_id = %#v, want %s", got, postgresSessionTestAssistant2ID)
+	}
+	forkMessageID, _ := forkedFrom["fork_message_id"].(string)
+	if forkMessageID == "" || forkMessageID == postgresSessionTestAssistant2ID {
+		t.Fatalf("fork_message_id = %#v, want copied assistant message id", forkedFrom["fork_message_id"])
+	}
+
+	var nextTurnPosition int64
+	if err := tx.QueryRow(ctx, `
+		SELECT next_turn_position
+		FROM bot_sessions
+		WHERE id = $1
+	`, fork.ID).Scan(&nextTurnPosition); err != nil {
+		t.Fatalf("read fork next_turn_position: %v", err)
+	}
+	if nextTurnPosition != 3 {
+		t.Fatalf("next_turn_position = %d, want 3", nextTurnPosition)
+	}
+
+	rows, err := tx.Query(ctx, `
+		SELECT role, turn_position, turn_message_seq
+		FROM bot_history_messages
+		WHERE session_id = $1
+		ORDER BY turn_position ASC, turn_message_seq ASC
+	`, fork.ID)
+	if err != nil {
+		t.Fatalf("list fork messages: %v", err)
+	}
+	var got []string
+	for rows.Next() {
+		var role string
+		var position, seq int64
+		if err := rows.Scan(&role, &position, &seq); err != nil {
+			t.Fatalf("scan fork message: %v", err)
+		}
+		got = append(got, fmt.Sprintf("%s:%d:%d", role, position, seq))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate fork messages: %v", err)
+	}
+	rows.Close()
+	want := []string{"user:1:1", "assistant:1:2", "user:2:1", "assistant:2:2"}
+	if len(got) != len(want) {
+		t.Fatalf("fork messages = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("fork messages = %#v, want %#v", got, want)
+		}
+	}
+
+	var anchorRole string
+	var anchorPosition, anchorSeq int64
+	if err := tx.QueryRow(ctx, `
+		SELECT role, turn_position, turn_message_seq
+		FROM bot_history_messages
+		WHERE id = $1 AND session_id = $2
+	`, forkMessageID, fork.ID).Scan(&anchorRole, &anchorPosition, &anchorSeq); err != nil {
+		t.Fatalf("read fork anchor message: %v", err)
+	}
+	if anchorRole != "assistant" || anchorPosition != 2 || anchorSeq != 2 {
+		t.Fatalf("fork anchor = %s:%d:%d, want assistant:2:2", anchorRole, anchorPosition, anchorSeq)
+	}
+	var anchorAssetCount int
+	if err := tx.QueryRow(ctx, `
+		SELECT count(*)
+		FROM bot_history_message_assets
+		WHERE message_id = $1
+		  AND role = 'attachment'
+		  AND ordinal = 1
+		  AND content_hash = 'sha256:postgres-session-test-asset'
+		  AND name = 'fixture.txt'
+	`, forkMessageID).Scan(&anchorAssetCount); err != nil {
+		t.Fatalf("count fork anchor assets: %v", err)
+	}
+	if anchorAssetCount != 1 {
+		t.Fatalf("fork anchor asset count = %d, want 1", anchorAssetCount)
+	}
+
+	messageSvc := message.NewService(nil, postgresstore.NewQueries(dbsqlc.New(tx)))
+	newUser, err := messageSvc.Persist(ctx, message.PersistInput{
+		BotID:     postgresSessionTestBotID,
+		SessionID: fork.ID,
+		Role:      "user",
+		Content:   []byte(`{"role":"user","content":"third"}`),
+	})
+	if err != nil {
+		t.Fatalf("persist fork follow-up user: %v", err)
+	}
+	newAssistant, err := messageSvc.Persist(ctx, message.PersistInput{
+		BotID:                postgresSessionTestBotID,
+		SessionID:            fork.ID,
+		Role:                 "assistant",
+		TurnRequestMessageID: newUser.ID,
+		Content:              []byte(`{"role":"assistant","content":"third reply"}`),
+	})
+	if err != nil {
+		t.Fatalf("persist fork follow-up assistant: %v", err)
+	}
+
+	rows, err = tx.Query(ctx, `
+		SELECT id, role, turn_position, turn_message_seq
+		FROM bot_history_messages
+		WHERE id = ANY($1::uuid[])
+		ORDER BY turn_message_seq ASC
+	`, []string{newUser.ID, newAssistant.ID})
+	if err != nil {
+		t.Fatalf("list fork follow-up messages: %v", err)
+	}
+	got = got[:0]
+	for rows.Next() {
+		var id string
+		var role string
+		var position, seq int64
+		if err := rows.Scan(&id, &role, &position, &seq); err != nil {
+			t.Fatalf("scan fork follow-up message: %v", err)
+		}
+		got = append(got, fmt.Sprintf("%s:%d:%d", role, position, seq))
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate fork follow-up messages: %v", err)
+	}
+	rows.Close()
+	want = []string{"user:3:1", "assistant:3:2"}
+	if len(got) != len(want) {
+		t.Fatalf("fork follow-up messages = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("fork follow-up messages = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestPostgresForkFromAssistantMessageRejectsInvalidTargetWithoutSideEffects(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresSessionTestTx(t, ctx)
+	setupPostgresSessionForkFixtures(t, ctx, tx)
+
+	svc := NewService(nil, postgresstore.NewQueries(dbsqlc.New(tx)), nil)
+	beforeSessions := countPostgresSessionTestRows(t, ctx, tx, "bot_sessions")
+	beforeMessages := countPostgresSessionTestRows(t, ctx, tx, "bot_history_messages")
+
+	for _, messageID := range []string{postgresSessionTestUser1ID, postgresSessionTestHiddenAssistantID} {
+		_, err := svc.ForkFromAssistantMessage(ctx, ForkFromAssistantInput{
+			BotID:     postgresSessionTestBotID,
+			SessionID: postgresSessionTestSessionID,
+			MessageID: messageID,
+			Title:     "Should Not Exist",
+		})
+		if !errors.Is(err, ErrForkSourceNotReply) {
+			t.Fatalf("fork invalid message %s error = %v, want ErrForkSourceNotReply", messageID, err)
+		}
+
+		if got := countPostgresSessionTestRows(t, ctx, tx, "bot_sessions"); got != beforeSessions {
+			t.Fatalf("bot_sessions count after invalid fork = %d, want %d", got, beforeSessions)
+		}
+		if got := countPostgresSessionTestRows(t, ctx, tx, "bot_history_messages"); got != beforeMessages {
+			t.Fatalf("bot_history_messages count after invalid fork = %d, want %d", got, beforeMessages)
+		}
+	}
+}
+
+const (
+	postgresSessionTestUserID            = "00000000-0000-0000-0000-000000075101"
+	postgresSessionTestBotID             = "00000000-0000-0000-0000-000000075102"
+	postgresSessionTestSessionID         = "00000000-0000-0000-0000-000000075103"
+	postgresSessionTestUser1ID           = "00000000-0000-0000-0000-000000075111"
+	postgresSessionTestAssistant1ID      = "00000000-0000-0000-0000-000000075112"
+	postgresSessionTestUser2ID           = "00000000-0000-0000-0000-000000075113"
+	postgresSessionTestAssistant2ID      = "00000000-0000-0000-0000-000000075114"
+	postgresSessionTestHiddenAssistantID = "00000000-0000-0000-0000-000000075115"
+)
+
+func beginPostgresSessionTestTx(t *testing.T, ctx context.Context) pgx.Tx {
+	t.Helper()
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("skip postgres integration test: TEST_POSTGRES_DSN is not set")
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Skipf("skip postgres integration test: cannot connect to database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		t.Skipf("skip postgres integration test: database ping failed: %v", err)
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback(ctx) })
+	return tx
+}
+
+func setupPostgresSessionForkFixtures(t *testing.T, ctx context.Context, tx pgx.Tx) {
+	t.Helper()
+	name := fmt.Sprintf("postgres-session-test-%d", time.Now().UnixNano())
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO users (id, username, role, is_active)
+		VALUES ($1, $2, 'admin', true)
+	`, postgresSessionTestUserID, name); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bots (id, owner_user_id, name)
+		VALUES ($1, $2, $3)
+	`, postgresSessionTestBotID, postgresSessionTestUserID, name); err != nil {
+		t.Fatalf("insert bot: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_sessions (id, bot_id, channel_type, title, metadata)
+		VALUES ($1, $2, 'local', 'Source', '{"source":"fixture"}'::jsonb)
+	`, postgresSessionTestSessionID, postgresSessionTestBotID); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_history_messages (
+			id, bot_id, session_id, role, content,
+			turn_id, turn_position, turn_message_seq, turn_visible, turn_superseded_at, created_at
+		)
+		VALUES
+			(
+				$3, $1, $2, 'user', '{"role":"user","content":"first"}'::jsonb,
+				'00000000-0000-0000-0000-000000075201', 1, 1, true, NULL, now() - interval '4 minutes'
+			),
+			(
+				$4, $1, $2, 'assistant', '{"role":"assistant","content":"first reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075201', 1, 2, true, NULL, now() - interval '3 minutes'
+			),
+			(
+				$5, $1, $2, 'user', '{"role":"user","content":"second"}'::jsonb,
+				'00000000-0000-0000-0000-000000075202', 2, 1, true, NULL, now() - interval '2 minutes'
+			),
+			(
+				$6, $1, $2, 'assistant', '{"role":"assistant","content":"second reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075202', 2, 2, true, NULL, now() - interval '1 minutes'
+			),
+			(
+				$7, $1, $2, 'assistant', '{"role":"assistant","content":"hidden"}'::jsonb,
+				'00000000-0000-0000-0000-000000075203', 3, 2, false, now(), now()
+			)
+	`, postgresSessionTestBotID, postgresSessionTestSessionID, postgresSessionTestUser1ID, postgresSessionTestAssistant1ID, postgresSessionTestUser2ID, postgresSessionTestAssistant2ID, postgresSessionTestHiddenAssistantID); err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_history_message_assets (message_id, role, ordinal, content_hash, name, metadata)
+		VALUES ($1, 'attachment', 1, 'sha256:postgres-session-test-asset', 'fixture.txt', '{"source":"fixture"}'::jsonb)
+	`, postgresSessionTestAssistant2ID); err != nil {
+		t.Fatalf("insert message asset: %v", err)
+	}
+}
+
+func countPostgresSessionTestRows(t *testing.T, ctx context.Context, tx pgx.Tx, table string) int {
+	t.Helper()
+	if table != "bot_sessions" && table != "bot_history_messages" {
+		t.Fatalf("unexpected test table %q", table)
+	}
+	query := fmt.Sprintf("SELECT count(*) FROM %s WHERE bot_id = $1", table)
+	var count int
+	if err := tx.QueryRow(ctx, query, postgresSessionTestBotID).Scan(&count); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return count
+}

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -204,6 +204,84 @@ func TestPostgresForkFromAssistantMessageRejectsInvalidTargetWithoutSideEffects(
 	}
 }
 
+func TestPostgresRepairIncompleteForkSessionsMigration(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresSessionTestTx(t, ctx)
+	setupPostgresSessionForkFixtures(t, ctx, tx)
+
+	const (
+		pureResidualID      = "00000000-0000-0000-0000-000000075301"
+		withFollowUpID      = "00000000-0000-0000-0000-000000075302"
+		validForkID         = "00000000-0000-0000-0000-000000075303"
+		pureResidualMessage = "00000000-0000-0000-0000-000000075311"
+		followUpCopyMessage = "00000000-0000-0000-0000-000000075312"
+		followUpNewMessage  = "00000000-0000-0000-0000-000000075313"
+		validForkMessage    = "00000000-0000-0000-0000-000000075314"
+	)
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_sessions (id, bot_id, channel_type, title, metadata, created_at, updated_at)
+		VALUES
+			(
+				$2, $1, 'local', 'bad fork',
+				'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
+				now(), now()
+			),
+			(
+				$3, $1, 'local', 'bad fork with follow-up',
+				'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
+				now(), now()
+			),
+			(
+				$4, $1, 'local', 'valid fork',
+				'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114","fork_message_id":"00000000-0000-0000-0000-000000075314"}}'::jsonb,
+				now(), now()
+			)
+	`, postgresSessionTestBotID, pureResidualID, withFollowUpID, validForkID); err != nil {
+		t.Fatalf("insert repair fork sessions: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_history_messages (
+			id, bot_id, session_id, role, content,
+			turn_id, turn_position, turn_message_seq, turn_visible, created_at
+		)
+		VALUES
+			(
+				$3, $1, $2, 'assistant', '{"role":"assistant","content":"copied"}'::jsonb,
+				'00000000-0000-0000-0000-000000075321', 1, 2, true,
+				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$5, $1, $4, 'assistant', '{"role":"assistant","content":"copied"}'::jsonb,
+				'00000000-0000-0000-0000-000000075322', 1, 2, true,
+				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $4)
+			),
+			(
+				$6, $1, $4, 'user', '{"role":"user","content":"follow-up"}'::jsonb,
+				'00000000-0000-0000-0000-000000075323', 1, 1, true,
+				(SELECT created_at + interval '1 minute' FROM bot_sessions WHERE id = $4)
+			),
+			(
+				$8, $1, $7, 'assistant', '{"role":"assistant","content":"valid copied"}'::jsonb,
+				'00000000-0000-0000-0000-000000075324', 1, 2, true,
+				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $7)
+			)
+	`, postgresSessionTestBotID, pureResidualID, pureResidualMessage, withFollowUpID, followUpCopyMessage, followUpNewMessage, validForkID, validForkMessage); err != nil {
+		t.Fatalf("insert repair fork messages: %v", err)
+	}
+
+	sql, err := os.ReadFile("../../db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql")
+	if err != nil {
+		t.Fatalf("read fork repair migration: %v", err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("run fork repair migration: %v", err)
+	}
+
+	assertPostgresSessionDeleted(t, ctx, tx, pureResidualID, true)
+	assertPostgresSessionDeleted(t, ctx, tx, withFollowUpID, false)
+	assertPostgresSessionDeleted(t, ctx, tx, validForkID, false)
+}
+
 const (
 	postgresSessionTestUserID            = "00000000-0000-0000-0000-000000075101"
 	postgresSessionTestBotID             = "00000000-0000-0000-0000-000000075102"
@@ -306,4 +384,19 @@ func countPostgresSessionTestRows(t *testing.T, ctx context.Context, tx pgx.Tx, 
 		t.Fatalf("count %s: %v", table, err)
 	}
 	return count
+}
+
+func assertPostgresSessionDeleted(t *testing.T, ctx context.Context, tx pgx.Tx, sessionID string, wantDeleted bool) {
+	t.Helper()
+	var deleted bool
+	if err := tx.QueryRow(ctx, `
+		SELECT deleted_at IS NOT NULL
+		FROM bot_sessions
+		WHERE id = $1
+	`, sessionID).Scan(&deleted); err != nil {
+		t.Fatalf("read session deleted state: %v", err)
+	}
+	if deleted != wantDeleted {
+		t.Fatalf("session %s deleted = %v, want %v", sessionID, deleted, wantDeleted)
+	}
 }

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -377,7 +377,7 @@ func TestPostgresRepairIncompleteForkRetriedCopiedTurnMigration(t *testing.T) {
 	assertPostgresMessageTurnPosition(t, ctx, tx, reusedUser2, 3)
 	assertPostgresMessageTurnPosition(t, ctx, tx, replacementAssistant, 3)
 	assertPostgresSessionNextTurnPosition(t, ctx, tx, sessionID, 4)
-	assertPostgresSessionRepairMarker(t, ctx, tx, sessionID, "0105_incomplete_fork_turn_positions", true)
+	assertPostgresSessionRepairMarker(t, ctx, tx, sessionID, "0105_incomplete_fork_turn_positions", false)
 
 	var supersededVisible bool
 	if err := tx.QueryRow(ctx, `
@@ -454,7 +454,7 @@ func TestPostgresRepairIncompleteForkTurnlessFollowUpMigration(t *testing.T) {
 	assertPostgresSessionDeleted(t, ctx, tx, sessionID, false)
 	assertPostgresMessageTurnPosition(t, ctx, tx, copiedAssistant, 1)
 	assertPostgresSessionNextTurnPosition(t, ctx, tx, sessionID, 2)
-	assertPostgresSessionRepairMarker(t, ctx, tx, sessionID, "0105_incomplete_fork_turn_positions", true)
+	assertPostgresSessionRepairMarker(t, ctx, tx, sessionID, "0105_incomplete_fork_turn_positions", false)
 
 	var turnless bool
 	if err := tx.QueryRow(ctx, `

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -217,6 +217,8 @@ func TestPostgresRepairIncompleteForkSessionsMigration(t *testing.T) {
 		followUpCopyMessage = "00000000-0000-0000-0000-000000075312"
 		followUpNewMessage  = "00000000-0000-0000-0000-000000075313"
 		validForkMessage    = "00000000-0000-0000-0000-000000075314"
+		followUpCopySecond  = "00000000-0000-0000-0000-000000075315"
+		followUpNewReply    = "00000000-0000-0000-0000-000000075316"
 	)
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO bot_sessions (id, bot_id, channel_type, title, metadata, created_at, updated_at)
@@ -256,16 +258,26 @@ func TestPostgresRepairIncompleteForkSessionsMigration(t *testing.T) {
 				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $4)
 			),
 			(
+				$9, $1, $4, 'assistant', '{"role":"assistant","content":"copied second"}'::jsonb,
+				'00000000-0000-0000-0000-000000075325', 2, 2, true,
+				(SELECT created_at - interval '30 seconds' FROM bot_sessions WHERE id = $4)
+			),
+			(
 				$6, $1, $4, 'user', '{"role":"user","content":"follow-up"}'::jsonb,
 				'00000000-0000-0000-0000-000000075323', 1, 1, true,
 				(SELECT created_at + interval '1 minute' FROM bot_sessions WHERE id = $4)
+			),
+			(
+				$10, $1, $4, 'assistant', '{"role":"assistant","content":"follow-up reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075323', 1, 2, true,
+				(SELECT created_at + interval '2 minutes' FROM bot_sessions WHERE id = $4)
 			),
 			(
 				$8, $1, $7, 'assistant', '{"role":"assistant","content":"valid copied"}'::jsonb,
 				'00000000-0000-0000-0000-000000075324', 1, 2, true,
 				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $7)
 			)
-	`, postgresSessionTestBotID, pureResidualID, pureResidualMessage, withFollowUpID, followUpCopyMessage, followUpNewMessage, validForkID, validForkMessage); err != nil {
+	`, postgresSessionTestBotID, pureResidualID, pureResidualMessage, withFollowUpID, followUpCopyMessage, followUpNewMessage, validForkID, validForkMessage, followUpCopySecond, followUpNewReply); err != nil {
 		t.Fatalf("insert repair fork messages: %v", err)
 	}
 
@@ -280,6 +292,11 @@ func TestPostgresRepairIncompleteForkSessionsMigration(t *testing.T) {
 	assertPostgresSessionDeleted(t, ctx, tx, pureResidualID, true)
 	assertPostgresSessionDeleted(t, ctx, tx, withFollowUpID, false)
 	assertPostgresSessionDeleted(t, ctx, tx, validForkID, false)
+	assertPostgresMessageTurnPosition(t, ctx, tx, followUpCopyMessage, 1)
+	assertPostgresMessageTurnPosition(t, ctx, tx, followUpCopySecond, 2)
+	assertPostgresMessageTurnPosition(t, ctx, tx, followUpNewMessage, 3)
+	assertPostgresMessageTurnPosition(t, ctx, tx, followUpNewReply, 3)
+	assertPostgresSessionNextTurnPosition(t, ctx, tx, withFollowUpID, 4)
 }
 
 const (
@@ -398,5 +415,35 @@ func assertPostgresSessionDeleted(t *testing.T, ctx context.Context, tx pgx.Tx, 
 	}
 	if deleted != wantDeleted {
 		t.Fatalf("session %s deleted = %v, want %v", sessionID, deleted, wantDeleted)
+	}
+}
+
+func assertPostgresMessageTurnPosition(t *testing.T, ctx context.Context, tx pgx.Tx, messageID string, want int64) {
+	t.Helper()
+	var got int64
+	if err := tx.QueryRow(ctx, `
+		SELECT turn_position
+		FROM bot_history_messages
+		WHERE id = $1
+	`, messageID).Scan(&got); err != nil {
+		t.Fatalf("read message %s turn position: %v", messageID, err)
+	}
+	if got != want {
+		t.Fatalf("message %s turn_position = %d, want %d", messageID, got, want)
+	}
+}
+
+func assertPostgresSessionNextTurnPosition(t *testing.T, ctx context.Context, tx pgx.Tx, sessionID string, want int64) {
+	t.Helper()
+	var got int64
+	if err := tx.QueryRow(ctx, `
+		SELECT next_turn_position
+		FROM bot_sessions
+		WHERE id = $1
+	`, sessionID).Scan(&got); err != nil {
+		t.Fatalf("read session %s next turn position: %v", sessionID, err)
+	}
+	if got != want {
+		t.Fatalf("session %s next_turn_position = %d, want %d", sessionID, got, want)
 	}
 }

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -479,43 +479,89 @@ func TestPostgresRepairSkipsConsistentIncompleteForkMigration(t *testing.T) {
 		prefixAssistant   = "00000000-0000-0000-0000-000000075611"
 		followUpUser      = "00000000-0000-0000-0000-000000075612"
 		followUpAssistant = "00000000-0000-0000-0000-000000075613"
+
+		retriedSessionID  = "00000000-0000-0000-0000-000000075602"
+		retriedPrefixMsg  = "00000000-0000-0000-0000-000000075614"
+		retriedHiddenMsg  = "00000000-0000-0000-0000-000000075615"
+		retriedReusedUser = "00000000-0000-0000-0000-000000075616"
+		retriedNewReply   = "00000000-0000-0000-0000-000000075617"
+
+		arrayMetadataSessionID = "00000000-0000-0000-0000-000000075603"
 	)
-	// Session that matches the incomplete-fork filter (fork_message_id can be
-	// legitimately removed when its anchor turn is retried away) but whose
-	// positions and allocator are already consistent. The repair must not
-	// touch it: no renumbering, no marker, no allocator change.
+	// Three sessions that match the missing-fork_message_id filter but must
+	// not be repaired:
+	// 1. positions and allocator already consistent
+	// 2. healthy fork whose post-fork turn was retried with the NEW
+	//    ReplaceHistoryTurn: the hidden superseded turn keeps its position and
+	//    the replacement reuses the user message, so message-time ordering
+	//    disagrees with positions — still consistent, must stay untouched
+	// 3. forked_from is a jsonb array, not an object (the ? operator matches
+	//    array elements, so a shape guard is required)
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO bot_sessions (id, bot_id, channel_type, title, metadata, next_turn_position, created_at, updated_at)
-		VALUES (
-			$2, $1, 'local', 'consistent fork',
-			'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
-			3, now(), now()
-		)
-	`, postgresSessionTestBotID, sessionID); err != nil {
-		t.Fatalf("insert consistent fork session: %v", err)
+		VALUES
+			(
+				$2, $1, 'local', 'consistent fork',
+				'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
+				3, now(), now()
+			),
+			(
+				$3, $1, 'local', 'retried consistent fork',
+				'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
+				4, now(), now()
+			),
+			(
+				$4, $1, 'local', 'array metadata',
+				'{"forked_from":["session_id","message_id"]}'::jsonb,
+				1, now(), now()
+			)
+	`, postgresSessionTestBotID, sessionID, retriedSessionID, arrayMetadataSessionID); err != nil {
+		t.Fatalf("insert consistent fork sessions: %v", err)
 	}
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO bot_history_messages (
 			id, bot_id, session_id, role, content,
-			turn_id, turn_position, turn_message_seq, turn_visible, created_at
+			turn_id, turn_position, turn_message_seq, turn_visible, turn_superseded_at, created_at
 		)
 		VALUES
 			(
 				$3, $1, $2, 'assistant', '{"role":"assistant","content":"copied"}'::jsonb,
-				'00000000-0000-0000-0000-000000075621', 1, 2, true,
+				'00000000-0000-0000-0000-000000075621', 1, 2, true, NULL,
 				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $2)
 			),
 			(
 				$4, $1, $2, 'user', '{"role":"user","content":"follow-up"}'::jsonb,
-				'00000000-0000-0000-0000-000000075622', 2, 1, true,
+				'00000000-0000-0000-0000-000000075622', 2, 1, true, NULL,
 				(SELECT created_at + interval '1 minute' FROM bot_sessions WHERE id = $2)
 			),
 			(
 				$5, $1, $2, 'assistant', '{"role":"assistant","content":"follow-up reply"}'::jsonb,
-				'00000000-0000-0000-0000-000000075622', 2, 2, true,
+				'00000000-0000-0000-0000-000000075622', 2, 2, true, NULL,
 				(SELECT created_at + interval '2 minutes' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$7, $1, $6, 'assistant', '{"role":"assistant","content":"copied"}'::jsonb,
+				'00000000-0000-0000-0000-000000075623', 1, 2, true, NULL,
+				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $6)
+			),
+			(
+				$8, $1, $6, 'assistant', '{"role":"assistant","content":"superseded reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075624', 2, 2, false,
+				(SELECT created_at + interval '3 minutes' FROM bot_sessions WHERE id = $6),
+				(SELECT created_at + interval '2 minutes' FROM bot_sessions WHERE id = $6)
+			),
+			(
+				$9, $1, $6, 'user', '{"role":"user","content":"reused"}'::jsonb,
+				'00000000-0000-0000-0000-000000075625', 3, 1, true, NULL,
+				(SELECT created_at + interval '1 minute' FROM bot_sessions WHERE id = $6)
+			),
+			(
+				$10, $1, $6, 'assistant', '{"role":"assistant","content":"retry reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075625', 3, 2, true, NULL,
+				(SELECT created_at + interval '4 minutes' FROM bot_sessions WHERE id = $6)
 			)
-	`, postgresSessionTestBotID, sessionID, prefixAssistant, followUpUser, followUpAssistant); err != nil {
+	`, postgresSessionTestBotID, sessionID, prefixAssistant, followUpUser, followUpAssistant,
+		retriedSessionID, retriedPrefixMsg, retriedHiddenMsg, retriedReusedUser, retriedNewReply); err != nil {
 		t.Fatalf("insert consistent fork messages: %v", err)
 	}
 
@@ -533,6 +579,19 @@ func TestPostgresRepairSkipsConsistentIncompleteForkMigration(t *testing.T) {
 	assertPostgresMessageTurnPosition(t, ctx, tx, followUpAssistant, 2)
 	assertPostgresSessionNextTurnPosition(t, ctx, tx, sessionID, 3)
 	assertPostgresSessionRepairMarker(t, ctx, tx, sessionID, "0105_incomplete_fork_turn_positions", false)
+
+	assertPostgresSessionDeleted(t, ctx, tx, retriedSessionID, false)
+	assertPostgresMessageTurnPosition(t, ctx, tx, retriedPrefixMsg, 1)
+	assertPostgresMessageTurnPosition(t, ctx, tx, retriedHiddenMsg, 2)
+	assertPostgresMessageTurnPosition(t, ctx, tx, retriedReusedUser, 3)
+	assertPostgresMessageTurnPosition(t, ctx, tx, retriedNewReply, 3)
+	assertPostgresSessionNextTurnPosition(t, ctx, tx, retriedSessionID, 4)
+	assertPostgresSessionRepairMarker(t, ctx, tx, retriedSessionID, "0105_incomplete_fork_turn_positions", false)
+
+	assertPostgresSessionDeleted(t, ctx, tx, arrayMetadataSessionID, false)
+	assertPostgresSessionNextTurnPosition(t, ctx, tx, arrayMetadataSessionID, 1)
+	assertPostgresSessionRepairMarker(t, ctx, tx, arrayMetadataSessionID, "0105_incomplete_fork_session", false)
+	assertPostgresSessionRepairMarker(t, ctx, tx, arrayMetadataSessionID, "0105_incomplete_fork_turn_positions", false)
 }
 
 const (

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -299,6 +299,242 @@ func TestPostgresRepairIncompleteForkSessionsMigration(t *testing.T) {
 	assertPostgresSessionNextTurnPosition(t, ctx, tx, withFollowUpID, 4)
 }
 
+func TestPostgresRepairIncompleteForkRetriedCopiedTurnMigration(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresSessionTestTx(t, ctx)
+	setupPostgresSessionForkFixtures(t, ctx, tx)
+
+	const (
+		sessionID            = "00000000-0000-0000-0000-000000075401"
+		copiedUser1          = "00000000-0000-0000-0000-000000075411"
+		copiedAssistant1     = "00000000-0000-0000-0000-000000075412"
+		reusedUser2          = "00000000-0000-0000-0000-000000075413"
+		supersededAssistant2 = "00000000-0000-0000-0000-000000075414"
+		replacementAssistant = "00000000-0000-0000-0000-000000075415"
+	)
+	// Broken fork left by the old fork query, then retried with the old
+	// ReplaceHistoryTurn: the replacement turn reused the copied user message
+	// (which keeps its pre-fork created_at), got position 1 from the broken
+	// allocator, and the superseded copied assistant stayed visible.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_sessions (id, bot_id, channel_type, title, metadata, next_turn_position, created_at, updated_at)
+		VALUES (
+			$2, $1, 'local', 'retried broken fork',
+			'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
+			2, now(), now()
+		)
+	`, postgresSessionTestBotID, sessionID); err != nil {
+		t.Fatalf("insert retried fork session: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_history_messages (
+			id, bot_id, session_id, role, content,
+			turn_id, turn_position, turn_message_seq, turn_visible, turn_superseded_at, created_at
+		)
+		VALUES
+			(
+				$3, $1, $2, 'user', '{"role":"user","content":"copied first"}'::jsonb,
+				'00000000-0000-0000-0000-000000075421', 1, 1, true, NULL,
+				(SELECT created_at - interval '4 minutes' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$4, $1, $2, 'assistant', '{"role":"assistant","content":"copied first reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075421', 1, 2, true, NULL,
+				(SELECT created_at - interval '4 minutes' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$5, $1, $2, 'user', '{"role":"user","content":"copied second"}'::jsonb,
+				'00000000-0000-0000-0000-000000075423', 1, 1, true, NULL,
+				(SELECT created_at - interval '2 minutes' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$6, $1, $2, 'assistant', '{"role":"assistant","content":"superseded reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075422', 2, 2, true,
+				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $2),
+				(SELECT created_at - interval '2 minutes' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$7, $1, $2, 'assistant', '{"role":"assistant","content":"retry reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075423', 1, 2, true, NULL,
+				(SELECT created_at + interval '1 minute' FROM bot_sessions WHERE id = $2)
+			)
+	`, postgresSessionTestBotID, sessionID, copiedUser1, copiedAssistant1, reusedUser2, supersededAssistant2, replacementAssistant); err != nil {
+		t.Fatalf("insert retried fork messages: %v", err)
+	}
+
+	sql, err := os.ReadFile("../../db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql")
+	if err != nil {
+		t.Fatalf("read fork repair migration: %v", err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("run fork repair migration: %v", err)
+	}
+
+	assertPostgresSessionDeleted(t, ctx, tx, sessionID, false)
+	assertPostgresMessageTurnPosition(t, ctx, tx, copiedUser1, 1)
+	assertPostgresMessageTurnPosition(t, ctx, tx, copiedAssistant1, 1)
+	assertPostgresMessageTurnPosition(t, ctx, tx, supersededAssistant2, 2)
+	assertPostgresMessageTurnPosition(t, ctx, tx, reusedUser2, 3)
+	assertPostgresMessageTurnPosition(t, ctx, tx, replacementAssistant, 3)
+	assertPostgresSessionNextTurnPosition(t, ctx, tx, sessionID, 4)
+	assertPostgresSessionRepairMarker(t, ctx, tx, sessionID, "0105_incomplete_fork_turn_positions", true)
+
+	var supersededVisible bool
+	if err := tx.QueryRow(ctx, `
+		SELECT turn_visible
+		FROM bot_history_messages
+		WHERE id = $1
+	`, supersededAssistant2).Scan(&supersededVisible); err != nil {
+		t.Fatalf("read superseded assistant visibility: %v", err)
+	}
+	if supersededVisible {
+		t.Fatalf("superseded copied assistant is still visible after repair")
+	}
+
+	// Re-running the repair must be a no-op for the already repaired session.
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("re-run fork repair migration: %v", err)
+	}
+	assertPostgresMessageTurnPosition(t, ctx, tx, reusedUser2, 3)
+	assertPostgresMessageTurnPosition(t, ctx, tx, replacementAssistant, 3)
+	assertPostgresSessionNextTurnPosition(t, ctx, tx, sessionID, 4)
+}
+
+func TestPostgresRepairIncompleteForkTurnlessFollowUpMigration(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresSessionTestTx(t, ctx)
+	setupPostgresSessionForkFixtures(t, ctx, tx)
+
+	const (
+		sessionID       = "00000000-0000-0000-0000-000000075501"
+		copiedAssistant = "00000000-0000-0000-0000-000000075511"
+		turnlessMessage = "00000000-0000-0000-0000-000000075512"
+	)
+	// Broken fork the user continued, but the follow-up message never got a
+	// turn (e.g. the agent crashed before turn creation). There is nothing to
+	// renumber, yet the allocator must still move past the copied prefix.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_sessions (id, bot_id, channel_type, title, metadata, created_at, updated_at)
+		VALUES (
+			$2, $1, 'local', 'turnless follow-up fork',
+			'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
+			now(), now()
+		)
+	`, postgresSessionTestBotID, sessionID); err != nil {
+		t.Fatalf("insert turnless fork session: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_history_messages (
+			id, bot_id, session_id, role, content,
+			turn_id, turn_position, turn_message_seq, turn_visible, created_at
+		)
+		VALUES
+			(
+				$3, $1, $2, 'assistant', '{"role":"assistant","content":"copied"}'::jsonb,
+				'00000000-0000-0000-0000-000000075521', 1, 2, true,
+				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$4, $1, $2, 'user', '{"role":"user","content":"follow-up"}'::jsonb,
+				NULL, NULL, NULL, false,
+				(SELECT created_at + interval '1 minute' FROM bot_sessions WHERE id = $2)
+			)
+	`, postgresSessionTestBotID, sessionID, copiedAssistant, turnlessMessage); err != nil {
+		t.Fatalf("insert turnless fork messages: %v", err)
+	}
+
+	sql, err := os.ReadFile("../../db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql")
+	if err != nil {
+		t.Fatalf("read fork repair migration: %v", err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("run fork repair migration: %v", err)
+	}
+
+	assertPostgresSessionDeleted(t, ctx, tx, sessionID, false)
+	assertPostgresMessageTurnPosition(t, ctx, tx, copiedAssistant, 1)
+	assertPostgresSessionNextTurnPosition(t, ctx, tx, sessionID, 2)
+	assertPostgresSessionRepairMarker(t, ctx, tx, sessionID, "0105_incomplete_fork_turn_positions", true)
+
+	var turnless bool
+	if err := tx.QueryRow(ctx, `
+		SELECT turn_id IS NULL AND turn_position IS NULL
+		FROM bot_history_messages
+		WHERE id = $1
+	`, turnlessMessage).Scan(&turnless); err != nil {
+		t.Fatalf("read turnless follow-up message: %v", err)
+	}
+	if !turnless {
+		t.Fatalf("turnless follow-up message gained turn state during repair")
+	}
+}
+
+func TestPostgresRepairSkipsConsistentIncompleteForkMigration(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresSessionTestTx(t, ctx)
+	setupPostgresSessionForkFixtures(t, ctx, tx)
+
+	const (
+		sessionID         = "00000000-0000-0000-0000-000000075601"
+		prefixAssistant   = "00000000-0000-0000-0000-000000075611"
+		followUpUser      = "00000000-0000-0000-0000-000000075612"
+		followUpAssistant = "00000000-0000-0000-0000-000000075613"
+	)
+	// Session that matches the incomplete-fork filter (fork_message_id can be
+	// legitimately removed when its anchor turn is retried away) but whose
+	// positions and allocator are already consistent. The repair must not
+	// touch it: no renumbering, no marker, no allocator change.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_sessions (id, bot_id, channel_type, title, metadata, next_turn_position, created_at, updated_at)
+		VALUES (
+			$2, $1, 'local', 'consistent fork',
+			'{"forked_from":{"session_id":"00000000-0000-0000-0000-000000075103","message_id":"00000000-0000-0000-0000-000000075114"}}'::jsonb,
+			3, now(), now()
+		)
+	`, postgresSessionTestBotID, sessionID); err != nil {
+		t.Fatalf("insert consistent fork session: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_history_messages (
+			id, bot_id, session_id, role, content,
+			turn_id, turn_position, turn_message_seq, turn_visible, created_at
+		)
+		VALUES
+			(
+				$3, $1, $2, 'assistant', '{"role":"assistant","content":"copied"}'::jsonb,
+				'00000000-0000-0000-0000-000000075621', 1, 2, true,
+				(SELECT created_at - interval '1 minute' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$4, $1, $2, 'user', '{"role":"user","content":"follow-up"}'::jsonb,
+				'00000000-0000-0000-0000-000000075622', 2, 1, true,
+				(SELECT created_at + interval '1 minute' FROM bot_sessions WHERE id = $2)
+			),
+			(
+				$5, $1, $2, 'assistant', '{"role":"assistant","content":"follow-up reply"}'::jsonb,
+				'00000000-0000-0000-0000-000000075622', 2, 2, true,
+				(SELECT created_at + interval '2 minutes' FROM bot_sessions WHERE id = $2)
+			)
+	`, postgresSessionTestBotID, sessionID, prefixAssistant, followUpUser, followUpAssistant); err != nil {
+		t.Fatalf("insert consistent fork messages: %v", err)
+	}
+
+	sql, err := os.ReadFile("../../db/postgres/migrations/0105_repair_superseded_message_visibility.up.sql")
+	if err != nil {
+		t.Fatalf("read fork repair migration: %v", err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("run fork repair migration: %v", err)
+	}
+
+	assertPostgresSessionDeleted(t, ctx, tx, sessionID, false)
+	assertPostgresMessageTurnPosition(t, ctx, tx, prefixAssistant, 1)
+	assertPostgresMessageTurnPosition(t, ctx, tx, followUpUser, 2)
+	assertPostgresMessageTurnPosition(t, ctx, tx, followUpAssistant, 2)
+	assertPostgresSessionNextTurnPosition(t, ctx, tx, sessionID, 3)
+	assertPostgresSessionRepairMarker(t, ctx, tx, sessionID, "0105_incomplete_fork_turn_positions", false)
+}
+
 const (
 	postgresSessionTestUserID            = "00000000-0000-0000-0000-000000075101"
 	postgresSessionTestBotID             = "00000000-0000-0000-0000-000000075102"
@@ -445,5 +681,20 @@ func assertPostgresSessionNextTurnPosition(t *testing.T, ctx context.Context, tx
 	}
 	if got != want {
 		t.Fatalf("session %s next_turn_position = %d, want %d", sessionID, got, want)
+	}
+}
+
+func assertPostgresSessionRepairMarker(t *testing.T, ctx context.Context, tx pgx.Tx, sessionID string, marker string, want bool) {
+	t.Helper()
+	var got bool
+	if err := tx.QueryRow(ctx, `
+		SELECT COALESCE((metadata->'repair'->>$2)::boolean, false)
+		FROM bot_sessions
+		WHERE id = $1
+	`, sessionID, marker).Scan(&got); err != nil {
+		t.Fatalf("read session %s repair marker: %v", sessionID, err)
+	}
+	if got != want {
+		t.Fatalf("session %s repair marker %s = %v, want %v", sessionID, marker, got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes Postgres chat history state bugs around retry/edit and fork sessions.

This PR does two things:

1. Prevents new bad retry/edit/fork state from being written.
2. Repairs bad state already produced by the previous Postgres turn/fork logic.

## Bugs Fixed

### Retry / edit left superseded messages visible

`ReplaceHistoryTurn` wrote `turn_superseded_*` metadata and visibility changes in separate CTE updates against the same rows. In Postgres, when two CTEs of one statement update the same row, the second update is silently skipped — so the old messages got superseded metadata but never got hidden. This was deterministic, not occasional: every retry/edit on Postgres left rows with:

```sql
turn_superseded_at IS NOT NULL
AND turn_visible = true
```

That made old turns still appear in visible history after retry/edit.

### Fork always left an incomplete fork session

`ForkSessionFromAssistantMessage` previously inserted the fork session first, then updated the same session at the end of the statement with:

- `metadata.forked_from.fork_message_id`
- `next_turn_position`

In Postgres, an UPDATE inside a statement cannot see rows inserted by an earlier CTE of the same statement, so this trailing self-update never matched: every fork inserted the session and copied messages, then returned no rows to the caller, leaving a fork session with incomplete metadata and `next_turn_position` stuck at the default `1`.

### Retained incomplete forks could keep broken turn allocation

For incomplete fork sessions that users had already continued using, the repair path keeps the session to avoid deleting user data. Those retained sessions still needed allocator repair: copied turns could occupy positions `1..N`, while `bot_sessions.next_turn_position` remained at the default `1`, causing follow-up turns — including retry replacement turns — to share positions with copied history.

## Fix

### `ReplaceHistoryTurn`

The superseding update now sets `turn_visible = false` in the same UPDATE that writes:

- `turn_superseded_by_turn_id`
- `turn_superseded_at`
- `turn_superseded_reason`

This keeps superseded state and visible-history state consistent for old messages without relying on a second same-statement update.

### `ForkSessionFromAssistantMessage`

The fork query now computes the fork plan before inserting the new session:

- copied turn mapping
- copied assistant anchor message id
- new `next_turn_position`

Then it inserts the fork session with complete state in one step:

- `metadata.forked_from.fork_message_id`
- `next_turn_position`

A successful fork session is returned only after its metadata is complete, and a failed fork leaves no side effects.

### Repair migration

Adds `0105_repair_superseded_message_visibility`.

It repairs old Postgres data by:

- hiding messages where `turn_visible = true` and `turn_superseded_at IS NOT NULL`
- soft-deleting pure residual incomplete fork sessions that have `forked_from.session_id` / `message_id` but no `fork_message_id`, only when the fork session has no messages created after the session itself; these soft-deleted residual sessions get `metadata.repair.0105_incomplete_fork_session`
- preserving incomplete fork sessions that users already continued using, renumbering post-fork turns after the copied prefix and repairing `next_turn_position` without writing retained repair metadata
- limiting incomplete-fork repair to chat sessions

Repair details for retained incomplete forks:

- A missing `fork_message_id` alone does not prove broken data — the live retry flow legitimately removes the anchor from healthy forks. The repair therefore only fires on **actual damage**: two **visible** turns colliding on one `turn_position`, or `next_turn_position` sitting at or below an occupied **visible** position. Hidden superseded turns never reach visible history or turn allocation, so they do not count as damage. Healthy sessions matching the filter are left completely untouched (no renumbering, no repair marker, no `updated_at` bump), which also makes the repair idempotent.
- `metadata.forked_from` must be a jsonb **object** (`jsonb_typeof` guard): the jsonb `?` operator also matches array elements, so without the guard a session carrying array-shaped metadata could be misclassified and soft-deleted.
- Turns are classified at **turn level**, not message level: a turn counts as copied prefix only when all of its messages predate the fork session. This matters because a retry replacement turn reuses the replaced turn's user message (which keeps its pre-fork `created_at`) — message-level classification would misfile such turns as copied prefix and skip them.
- `next_turn_position` is repaired even when the session has no renumberable turn yet (e.g. a follow-up message that never got a turn), as long as the allocator is behind the occupied positions.
- The migration intentionally does not infer or rewrite `fork_message_id` for retained incomplete forks, because the correct anchor cannot always be reconstructed safely from old bad data. Retained repaired forks are treated as normal usable sessions and do not get `metadata.repair.0105_incomplete_fork_turn_positions`.

## Tests

Added Postgres integration coverage for:

- retry hides superseded assistant messages
- edit hides superseded old turns
- fork copies visible turns and assets
- fork writes `fork_message_id`
- fork initializes `next_turn_position`
- invalid fork targets do not leave side effects
- repair migration hides superseded visible messages
- repair migration soft-deletes only pure residual incomplete forks
- repair migration preserves continued incomplete forks, renumbers their post-fork turns, repairs `next_turn_position`, and does not leave retained repair metadata
- repair migration renumbers retry replacement turns that reused a copied user message without writing `0105_incomplete_fork_turn_positions`, and re-running it is a no-op
- repair migration repairs the allocator when the follow-up messages have no turn yet, without writing `0105_incomplete_fork_turn_positions`
- repair migration leaves already-consistent sessions untouched (no marker, no changes), including healthy forks with post-fork retries and sessions with array-shaped `forked_from` metadata

Verified with:

```bash
TEST_POSTGRES_DSN='postgres://memoh:memoh123@localhost:15432/memoh?sslmode=disable' go test ./internal/session ./internal/message -count=1
TEST_POSTGRES_DSN='postgres://memoh:memoh123@localhost:15432/memoh?sslmode=disable' go test ./internal/session ./internal/message ./internal/conversation/flow -count=1
```

Also verified on a fresh temporary Postgres database:

- clean migration from empty to `version=105 dirty=false`
- seeded v0.15-shaped bad data (retried broken fork, follow-up broken fork, pure residual fork, turnless follow-up fork, already-consistent fork), forced back to 104, re-ran the migration runner: all five shapes end in the expected state


