### PR TITLE
fix(web): make /help quick actions clickable and complete

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -534,7 +534,6 @@
                           v-for="item in commandResultItems"
                           :key="`${item.kind || 'item'}:${item.id || item.title}`"
                           :value="`${item.kind || 'item'}:${item.id || item.title}`"
-                          :disabled="item.kind !== 'skill'"
                           @select="selectCommandResultItem(item)"
                         >
                           <Sparkles
@@ -1015,6 +1014,7 @@ import ChatModelPicker from './chat-model-picker.vue'
 import { EFFORT_LABELS, REASONING_EFFORT_DISABLE, availableEffortsForMode, resolveEffortLevels, resolveThinkingMode } from '@/pages/bots/components/reasoning-effort'
 import { useMediaGallery } from '../composables/useMediaGallery'
 import { fetchSafeSkillCatalog, fetchSession, type ChatAttachment, type CommandActionError, type CommandActionListItem, type RequestedSkillSelection, type UIUserInput, type UIUserInputQuestion, type WSUserInputAnswer } from '@/composables/api/useChat'
+import { commandResultQuickActionText, isCommandResultItemSelectable } from './slash-command-result'
 import { onAuthSessionCleared } from '@/lib/auth-session'
 import { useACPRuntime } from '@/composables/useACPRuntime'
 import { ACP_DEFAULT_PROJECT_MODE, ACP_DEFAULT_PROJECT_PATH, acpAgentIcon, findMissingRequiredManagedField, isACPAgentEnabled, isACPNoProject, normalizeACPAgentID, readACPAgentConfig } from '@/utils/acp'
@@ -1720,6 +1720,7 @@ function clearCurrentCommandEvent() {
 const commandPanelEvent = computed(() => chatStore.commandEventForScope(currentPaneCommandScope()))
 const commandResult = computed(() => commandPanelEvent.value?.type === 'command_result' ? commandPanelEvent.value.result : null)
 const commandError = computed(() => commandPanelEvent.value?.type === 'command_error' ? commandPanelEvent.value.error : null)
+const commandPanelActionID = computed(() => commandPanelEvent.value?.action_id?.trim() ?? '')
 const commandPanelIsError = computed(() => !!commandError.value)
 const commandPanelTitle = computed(() => {
   if (commandError.value) return t('chat.slash.commandError')
@@ -1736,11 +1737,24 @@ function localizedCommandErrorMessage(error: CommandActionError): string {
 }
 
 const commandPanelText = computed(() => commandError.value ? localizedCommandErrorMessage(commandError.value) : commandResult.value?.text || '')
-const commandResultItems = computed(() => commandResult.value?.items ?? [])
+const commandResultItems = computed(() =>
+  (commandResult.value?.items ?? []).filter(item => isCommandResultItemSelectable(item, commandPanelActionID.value)),
+)
 
 function selectCommandResultItem(item: CommandActionListItem) {
+  const kind = item.kind?.trim().toLowerCase()
+  if (kind === 'quick_action') {
+    const label = commandResultQuickActionText(item, commandPanelActionID.value)
+    if (!label) return
+    clearCurrentCommandEvent()
+    selectSlashQuickAction({
+      id: item.id?.trim() || label,
+      label,
+    })
+    return
+  }
   if (!skillSlashEnabled.value) return
-  if (item.kind !== 'skill' || !item.id?.trim() || !item.title.trim()) return
+  if (kind !== 'skill' || !item.id?.trim() || !item.title.trim()) return
   addRequestedSkill({
     name: item.id.trim(),
     display_name: item.title,

--- a/apps/web/src/pages/home/components/slash-command-result.test.ts
+++ b/apps/web/src/pages/home/components/slash-command-result.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  commandResultQuickActionText,
+  isCommandResultItemSelectable,
+} from './slash-command-result'
+
+describe('slash command result helpers', () => {
+  it('maps known help quick actions to sendable slash text', () => {
+    expect(commandResultQuickActionText({ id: 'help', title: 'Help', kind: 'quick_action' })).toBe('/help')
+    expect(commandResultQuickActionText({ id: 'skill.list', title: 'Skills', kind: 'quick_action' })).toBe('/skill list')
+  })
+
+  it('allows server-provided slash titles for unknown quick actions', () => {
+    expect(commandResultQuickActionText({ id: 'custom', title: '/custom action', kind: 'quick_action' })).toBe('/custom action')
+  })
+
+  it('does not make the current quick action selectable from its own result', () => {
+    const item = { id: 'help', title: '/help', kind: 'quick_action' }
+
+    expect(commandResultQuickActionText(item, 'help')).toBe('')
+    expect(isCommandResultItemSelectable(item, 'help')).toBe(false)
+  })
+
+  it('marks only executable command result rows as selectable', () => {
+    expect(isCommandResultItemSelectable({ id: 'skill.list', title: '/skill list', kind: 'quick_action' })).toBe(true)
+    expect(isCommandResultItemSelectable({ id: 'skill-a', title: 'skill-a', kind: 'skill' })).toBe(true)
+    expect(isCommandResultItemSelectable({ id: 'note', title: 'Note', kind: 'quick_action' })).toBe(false)
+    expect(isCommandResultItemSelectable({ id: 'note', title: 'Note' })).toBe(false)
+  })
+})

--- a/apps/web/src/pages/home/components/slash-command-result.ts
+++ b/apps/web/src/pages/home/components/slash-command-result.ts
@@ -1,0 +1,36 @@
+import type { CommandActionListItem } from '@/composables/api/useChat'
+
+const QUICK_ACTION_SLASH_TEXT: Record<string, string> = {
+  help: '/help',
+  'skill.list': '/skill list',
+}
+
+function commandResultItemKind(item: CommandActionListItem): string {
+  return item.kind?.trim().toLowerCase() ?? ''
+}
+
+function commandResultQuickActionID(item: CommandActionListItem): string {
+  return item.id?.trim() ?? ''
+}
+
+function isCurrentQuickAction(item: CommandActionListItem, currentActionID = ''): boolean {
+  const id = commandResultQuickActionID(item)
+  return !!id && id === currentActionID.trim()
+}
+
+export function commandResultQuickActionText(item: CommandActionListItem, currentActionID = ''): string {
+  if (commandResultItemKind(item) !== 'quick_action') return ''
+  if (isCurrentQuickAction(item, currentActionID)) return ''
+  const id = commandResultQuickActionID(item)
+  if (id && QUICK_ACTION_SLASH_TEXT[id]) return QUICK_ACTION_SLASH_TEXT[id]
+
+  const title = item.title.trim()
+  return title.startsWith('/') ? title : ''
+}
+
+export function isCommandResultItemSelectable(item: CommandActionListItem, currentActionID = ''): boolean {
+  const kind = commandResultItemKind(item)
+  if (kind === 'quick_action') return !!commandResultQuickActionText(item, currentActionID)
+  if (kind === 'skill') return !!item.id?.trim() && !!item.title.trim()
+  return false
+}

--- a/internal/handlers/local_channel.go
+++ b/internal/handlers/local_channel.go
@@ -249,17 +249,27 @@ func (h *LocalChannelHandler) executeWebQuickAction(ctx context.Context, botID, 
 	case "help":
 		items := []CommandActionListItem{
 			{ID: "help", Title: "/help", Description: "Show available quick actions", Kind: "quick_action"},
+			{ID: "new", Title: "/new", Description: "Start a new session", Kind: "quick_action"},
+			{ID: "compact", Title: "/compact", Description: "Compact the current session history", Kind: "quick_action"},
 		}
-		text := "Available Web quick actions: /help."
+		labels := []string{"/help", "/new", "/compact"}
+		text := "Available Web quick actions: %s."
+		// skillActivationAllowed already reflects a plain (non-ACP) chat
+		// session, which is also the only context where the model picker
+		// applies, so it doubles as the /model gate.
 		if skillActivationAllowed {
-			items = append(items, CommandActionListItem{ID: "skill.list", Title: "/skill list", Description: "Show runtime-usable skills", Kind: "quick_action"})
-			text = "Available Web quick actions: /help, /skill list. To activate a skill, send /<skill-name> or /<skill-name> <prompt>."
+			items = append(items,
+				CommandActionListItem{ID: "skill.list", Title: "/skill list", Description: "Show runtime-usable skills", Kind: "quick_action"},
+				CommandActionListItem{ID: "model", Title: "/model", Description: "Switch the chat model", Kind: "quick_action"},
+			)
+			labels = append(labels, "/skill list", "/model")
+			text = "Available Web quick actions: %s. To activate a skill, send /<skill-name> or /<skill-name> <prompt>."
 		}
 		return &CommandActionResult{
 			Kind:  "list",
 			Title: "Quick actions",
 			Items: items,
-			Text:  text,
+			Text:  fmt.Sprintf(text, strings.Join(labels, ", ")),
 		}, nil
 	case "skill.list":
 		if !skillActivationAllowed {

--- a/internal/handlers/local_channel_test.go
+++ b/internal/handlers/local_channel_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1080,6 +1081,46 @@ func TestExecuteQuickActionAcceptsSessionIDAsCapabilityContext(t *testing.T) {
 	}
 	if !strings.Contains(event.Result.Text, "/skill list") {
 		t.Fatalf("help text = %q, want skill quick action guidance", event.Result.Text)
+	}
+}
+
+func TestExecuteWebQuickActionHelpListsAllQuickActions(t *testing.T) {
+	t.Parallel()
+
+	handler := &LocalChannelHandler{}
+
+	full, slashErr := handler.executeWebQuickAction(context.Background(), "bot-1", "help", true)
+	if slashErr != nil {
+		t.Fatalf("executeWebQuickAction: %v", slashErr)
+	}
+	gotIDs := make([]string, 0, len(full.Items))
+	for _, item := range full.Items {
+		gotIDs = append(gotIDs, item.ID)
+	}
+	wantIDs := []string{"help", "new", "compact", "skill.list", "model"}
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Fatalf("item ids = %v, want %v", gotIDs, wantIDs)
+	}
+	for _, label := range []string{"/help", "/new", "/compact", "/skill list", "/model"} {
+		if !strings.Contains(full.Text, label) {
+			t.Fatalf("help text = %q, missing %q", full.Text, label)
+		}
+	}
+
+	restricted, slashErr := handler.executeWebQuickAction(context.Background(), "bot-1", "help", false)
+	if slashErr != nil {
+		t.Fatalf("executeWebQuickAction: %v", slashErr)
+	}
+	gotRestrictedIDs := make([]string, 0, len(restricted.Items))
+	for _, item := range restricted.Items {
+		gotRestrictedIDs = append(gotRestrictedIDs, item.ID)
+	}
+	wantRestrictedIDs := []string{"help", "new", "compact"}
+	if !slices.Equal(gotRestrictedIDs, wantRestrictedIDs) {
+		t.Fatalf("restricted item ids = %v, want %v", gotRestrictedIDs, wantRestrictedIDs)
+	}
+	if strings.Contains(restricted.Text, "/skill list") || strings.Contains(restricted.Text, "/model") {
+		t.Fatalf("restricted help text should omit skill/model actions: %q", restricted.Text)
 	}
 }
 


### PR DESCRIPTION
## 问题

- 命令结果面板里之前只有 `kind === 'skill'` 的项可以点击,`quick_action` 类型的项(比如 `/help` 结果里的 `/skill list`)虽然显示出来,但点了没反应。
- `/help` 返回的指令列表里一直只有 `/help` 自己和 `/skill list`,但输入框敲 `/` 弹出的自动补全面板其实还有 `/new`、`/compact`、`/model`,两边不一致,容易让人以为 `/help` 就只支持这两个。

## 改动

- 新增 `apps/web/src/pages/home/components/slash-command-result.ts`,把"这一项是否可点""点击后该发送什么 slash 文本"的判断抽成纯函数,`quick_action` 和 `skill` 两种 kind 统一处理,并排除掉当前正在查看的那个 action 本身(避免在 `/help` 结果里又点一次 `/help`)。
- `chat-pane.vue` 改用这两个函数,去掉了原来"只有 skill 能点"的写死逻辑,以及现在恒为 `false` 的冗余 `:disabled` 判断。
- `internal/handlers/local_channel.go` 的 `help` case 补上 `/new`、`/compact`(无条件展示)和 `/model`(和 `/skill list` 一样,按 `skillActivationAllowed` 判断是否为普通非 ACP 会话),使其与自动补全面板列出的快捷指令保持一致。

## 测试

- `vitest run`:新增的 `slash-command-result.test.ts` + 既有 `store/chat-list.test.ts` 均通过
- `vue-tsc --noEmit`、`eslint` 检查改动的前端文件,无报错
- `go test ./internal/handlers/...`:含新增的 `TestExecuteWebQuickActionHelpListsAllQuickActions`,分别校验普通会话与 ACP 会话下 `/help` 返回的指令列表
- `go build ./...`、`go vet ./...`、`golangci-lint run ./internal/handlers/...` 均无报错