### PR TITLE
fix(web): dark-mode autofill readability on login page

### DIFF
--- a/.agents/skills/memoh-web/SKILL.md
+++ b/.agents/skills/memoh-web/SKILL.md
@@ -618,6 +618,25 @@ These are judgment rules. They are the difference between "it renders" and "it's
 
 ### 1. Interrogate every line of copy
 
+**P0 — Label ≠ placeholder (never show the same noun twice).** A field label and its
+placeholder must not be the same string, and must not read as the same bare noun sitting
+twice in the viewport (e.g. label `Password` + placeholder `Password`, or label `Email` +
+placeholder `Email`). The eye sees a stutter, not a hint. Placeholder is an *instruction*
+or a soft example, never a second label:
+
+- Prefer a verb lead-in: `Enter password`, `Enter your email`, `Enter email or username`.
+- Or a worked example: `name@company.com`, `e.g. acme-bot` — never the field's own name alone.
+- Same rule for the first step of a multi-step auth flow where there is *no* label and the
+  placeholder is the only chrome: still write `Enter your email`, not `Email` / `Username`.
+- Check **all three locales** — a language that glues verb+noun (`输入密码`) can accidentally
+  make the *page title* and the placeholder identical too; differentiate (e.g. title `输入密码`,
+  placeholder `请输入密码`, label `密码`).
+
+Lived fail (SaaS login, 2026-07): password step shipped label `Password` + placeholder
+`Password`; first step shipped placeholder `Email`. Fixed to `Enter password` /
+`Enter your email` / `Enter email or username`. Treat any new form field the same way before
+you ship.
+
 Before you write *any* user-facing line, slow down and ask, repeatedly:
 
 - The user already knows the page's **icon** and its **name in the sidebar**. So what do
@@ -690,6 +709,37 @@ matters (submit), and surface the error usefully then.
 Generalize this: the red-required box is just one instance. **Restraint applies to all
 external component signals.** Don't make a component shout a state the user did not ask
 about and does not benefit from.
+
+### 2b. Focus follows the job — every step lands the caret where the user will type
+
+This is not a layout rule and not "always autofocus the first field." It is a path rule:
+**when the view changes because the user advanced (or went back) in a multi-step flow, put
+keyboard focus on the field they are about to fill — not on the button they just pressed,
+and not nowhere.** Users expect to type immediately; making them click the field is a
+tax on a path they already committed to.
+
+Concrete tells (login is the worked example; apply the *path*, not a page template):
+
+- **Advance into a new step whose job is to type something** (e.g. identifier → password,
+  "send code" → OTP): after the step mounts, `focus()` that step's primary input. HTML
+  `autofocus` only fires on the *first* document load — it does **not** re-fire when a
+  `v-if` / step swap mounts a new field. Use `nextTick` + programmatic `focus()` (or a
+  shared helper) on the step transition itself.
+- **Back / Edit that returns to a prior field** (e.g. "Edit" on a readonly email, or
+  "Back" to the identifier step): focus that field again so the user can correct it
+  without an extra click. Same for dialog list→form→list when the form's job is input.
+- **One caret, one job.** Don't leave focus on Continue after it succeeded; don't focus a
+  readonly display field when the next action is typing in a different control; don't
+  steal focus mid-keystroke for ambient re-renders.
+- **Wrappers:** if the control is a composed field (`PasswordInput`, `InputGroup`), put a
+  stable `id` on the real `<input>` (or resolve it) before calling `focus()` — focusing the
+  outer shell does nothing useful.
+- **Don't invent a global "focus manager."** Wire focus at the transition site (`onContinue`,
+  `backToIdentifier`, dialog open, view-swap enter) where the *path* is known. A page that
+  has no step change needs no extra focus code beyond a sensible first-load `autofocus`.
+
+Review check: after every step / drill-in / back path you ship, tab away and re-enter with
+the keyboard only — can the user type the next thing without clicking?
 
 ### 3. Empty *and loading* states must hold the frame
 

--- a/apps/web/src/components/password-input/index.vue
+++ b/apps/web/src/components/password-input/index.vue
@@ -3,10 +3,9 @@
 // InputGroup atoms from @memohai/ui so it inherits the field-edge design
 // language and stays consistent with the secret-field pattern in channel-field.
 //
-// `class` is routed to the InputGroup wrapper (callers like the login page pass
-// `bg-background` so the field stays opaque over the animated dot matrix);
-// every other attr (id / placeholder / autocomplete / aria-invalid / v-model)
-// falls through to the input via $attrs.
+// `class` and `size` are routed to the InputGroup wrapper; every other attr
+// (id / placeholder / autocomplete / aria-invalid / v-model) falls through to
+// the input via $attrs.
 import type { HTMLAttributes } from 'vue'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -18,6 +17,7 @@ defineOptions({ inheritAttrs: false })
 const props = defineProps<{
   class?: HTMLAttributes['class']
   disabled?: boolean
+  size?: 'sm' | 'default' | 'lg'
 }>()
 
 const { t } = useI18n()
@@ -25,7 +25,10 @@ const revealed = ref(false)
 </script>
 
 <template>
-  <InputGroup :class="props.class">
+  <InputGroup
+    :class="props.class"
+    :size="props.size"
+  >
     <InputGroupInput
       v-bind="$attrs"
       :type="revealed ? 'text' : 'password'"

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -95,6 +95,7 @@
   "auth": {
     "welcome": "Welcome Back",
     "pageTitle": "Sign in",
+    "pageSubtitle": "Start building with Memoh",
     "continue": "Continue",
     "username": "Username",
     "password": "Password",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -99,6 +99,8 @@
     "continue": "Continue",
     "username": "Username",
     "password": "Password",
+    "usernamePlaceholder": "Enter username",
+    "passwordPlaceholder": "Enter password",
     "login": "Sign In",
     "register": "Sign Up",
     "logout": "Sign Out",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -92,6 +92,7 @@
   "auth": {
     "welcome": "おかえり",
     "pageTitle": "サインイン",
+    "pageSubtitle": "Memoh で構築を始めましょう",
     "continue": "続ける",
     "username": "ユーザー名",
     "password": "パスワード",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -96,6 +96,8 @@
     "continue": "続ける",
     "username": "ユーザー名",
     "password": "パスワード",
+    "usernamePlaceholder": "ユーザー名を入力",
+    "passwordPlaceholder": "パスワードを入力してください",
     "login": "サインイン",
     "register": "サインアップ",
     "logout": "サインアウト",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -99,6 +99,8 @@
     "continue": "继续",
     "username": "用户名",
     "password": "密码",
+    "usernamePlaceholder": "请输入用户名",
+    "passwordPlaceholder": "请输入密码",
     "login": "登录",
     "register": "注册账户",
     "logout": "退出登录",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -95,6 +95,7 @@
   "auth": {
     "welcome": "欢迎回来",
     "pageTitle": "登录",
+    "pageSubtitle": "开始用 Memoh 构建",
     "continue": "继续",
     "username": "用户名",
     "password": "密码",

--- a/apps/web/src/pages/login/components/dot-matrix-bg.vue
+++ b/apps/web/src/pages/login/components/dot-matrix-bg.vue
@@ -17,54 +17,61 @@ import {
   type ShapeDef,
 } from './dot-matrix-keyframes'
 
-/** 点阵背景:归一化轨迹 × 当前视口,canvas 矢量 + 渐变,再采样成点阵。 */
+/**
+ * 点阵背景:归一化关键帧轨迹驱动的几何形状,在常亮点网格上轮流点亮。
+ * 形状与键帧(dot-matrix-keyframes.ts)是初版原样;本文件的渲染管线
+ * 重写过一次,解决初版两大问题——
+ *   1. CPU 70-80%:初版每帧对全屏尺寸的离屏画布 getImageData(≈2M 像素)
+ *      再逐点画 ~1.5 万个独立 arc/fill。现在离屏"场"画布直接用点阵分辨率
+ *      (1 像素 = 1 个点,抗锯齿天然充当覆盖率采样),getImageData 缩到
+ *      ~1 万像素;常亮层用 resize 时缓存的 Path2D 一笔画完;点亮层按
+ *      量化档位聚合成少数几条 Path2D;再加 30fps 帧率上限。
+ *   2. 节奏太慢:初版 MOTION_RATE=0.55 全局降速,现在按键帧原速(1.0)播放。
+ * 颜色裁决:亮暗都不带彩——初版暗色用 accent 调色板逐点上色,已否决;
+ * 两种主题统一用 text-foreground 单色,暗色仅调点亮增益。
+ * 使用方:SaaS 登录页 + 实例创建/等待/无工作区页面。
+ */
 
-const GAP = 14
+/** 点间距(CSS px) */
+const GAP = 13.5
 const DOT_RADIUS = 1
+/** 点亮覆盖率量化档数(也是每帧点亮层的最大 fill 次数) */
 const LEVELS = 4
-const MOTION_RATE = 0.55
+/** 键帧播放速率;1 = 按 keyframes 原速 */
+const MOTION_RATE = 1
 /** 归一化坐标映射到视口时的内边距(含形状半径余量) */
 const VIEW_INSET = 0.08
-/** 离屏画布长边上限,避免 4K 全屏每帧 getImageData 过重 */
-const MAX_FIELD_DIM = 1920
+/** 帧率上限:背景动效 30fps 足够顺滑,渲染开销直接减半 */
+const FRAME_MS = 1000 / 30
 
-const AMBIENT_LIGHT = 0.08
+// 网格亮度(点色 × alpha),亮暗同值(设计裁决:暗色不单独加亮)
+const AMBIENT = 0.105
+// 点亮增益:暗色白点需要更高 alpha 才能与亮色的黑点等感知强度
 const GAIN_LIGHT = 0.32
-const AMBIENT_DARK = 0.12
-const GAIN_DARK = 0.72
-
-const ACCENT_VARS = [
-  '--accent-blue', '--accent-purple', '--accent-teal',
-  '--accent-green', '--accent-orange', '--accent-pink', '--accent-red',
-]
+const GAIN_DARK = 0.44
 
 const canvasEl = ref<HTMLCanvasElement | null>(null)
 
 let raf = 0
 let ctx: CanvasRenderingContext2D | null = null
+/** 点阵分辨率的离屏"场":alpha 通道即每个点的点亮覆盖率 */
 let field: HTMLCanvasElement | null = null
 let fieldCtx: CanvasRenderingContext2D | null = null
 let cols = 0
 let rows = 0
-let fieldW = 0
-let fieldH = 0
-let fieldScale = 1
 let viewW = 0
 let viewH = 0
 let dpr = 1
 let dotColor = 'currentColor'
 let isDark = false
-let paletteRGB: string[] = []
+let ambientPath: Path2D | null = null
 let lastNow = 0
+let lastFrameAt = 0
 let reduceMotion = false
 let animTime = 0
 let pageVisible = true
 
-function minDim(w: number, h: number) {
-  return Math.min(w, h)
-}
-
-/** 归一化 [0,1] → 视图像素,始终铺满当前窗口(含超宽/竖屏) */
+/** 归一化 [0,1] → 场像素,始终铺满当前窗口(含超宽/竖屏) */
 function normToPx(nx: number, ny: number, w: number, h: number): [number, number] {
   const span = 1 - 2 * VIEW_INSET
   return [
@@ -96,23 +103,11 @@ function sampleTrack(track: KeyframeTrack, frame: number, comp = 0): number {
   return na + (nb - na) * t
 }
 
-function toRGB(color: string): string {
-  if (!fieldCtx) return '255,255,255'
-  fieldCtx.fillStyle = color
-  fieldCtx.fillRect(0, 0, 1, 1)
-  const d = fieldCtx.getImageData(0, 0, 1, 1).data
-  return `${d[0]},${d[1]},${d[2]}`
-}
-
 function readColor() {
   if (!canvasEl.value) return
   const cs = getComputedStyle(canvasEl.value)
   dotColor = cs.color || 'currentColor'
   isDark = document.documentElement.classList.contains('dark')
-  paletteRGB = ACCENT_VARS
-    .map(v => cs.getPropertyValue(v).trim())
-    .filter(Boolean)
-    .map(toRGB)
 }
 
 function resize() {
@@ -125,22 +120,32 @@ function resize() {
   el.width = Math.max(1, Math.round(viewW * dpr))
   el.height = Math.max(1, Math.round(viewH * dpr))
 
-  const longEdge = Math.max(viewW, viewH)
-  fieldScale = longEdge > MAX_FIELD_DIM ? MAX_FIELD_DIM / longEdge : 1
-  fieldW = Math.max(1, Math.round(viewW * fieldScale))
-  fieldH = Math.max(1, Math.round(viewH * fieldScale))
-
   cols = Math.max(1, Math.ceil(viewW / GAP) + 1)
   rows = Math.max(1, Math.ceil(viewH / GAP) + 1)
 
+  // 场画布 = 点阵分辨率:1 像素对应 1 个点,是整个管线省 CPU 的关键
   if (!field) field = document.createElement('canvas')
-  field.width = fieldW
-  field.height = fieldH
+  field.width = cols
+  field.height = rows
   fieldCtx = field.getContext('2d', { willReadFrequently: true })
+
+  // 常亮网格一次成 Path,之后每帧一笔 fill
+  const TWO_PI = Math.PI * 2
+  ambientPath = new Path2D()
+  for (let y = 0; y < rows; y++) {
+    const py = y * GAP
+    for (let x = 0; x < cols; x++) {
+      const px = x * GAP
+      // 每个圆前先 moveTo,避免 Path2D 把上一个圆的终点连线过来
+      ambientPath.moveTo(px + DOT_RADIUS, py)
+      ambientPath.arc(px, py, DOT_RADIUS, 0, TWO_PI)
+    }
+  }
   readColor()
 }
 
-function shapeFillGradient(s: ShapeDef, rgb: string, alpha: number, unit: number) {
+/** 形状内的线性渐变:沿 gradAngle 从全亮衰减到 40%,让点亮有方向感 */
+function shapeFillGradient(s: ShapeDef, alpha: number, unit: number) {
   if (!fieldCtx) return '#fff'
   const r = s.radius * s.scale * unit
   const ang = s.gradAngle
@@ -149,8 +154,8 @@ function shapeFillGradient(s: ShapeDef, rgb: string, alpha: number, unit: number
   const hi = Math.min(1, alpha)
   const lo = Math.min(1, alpha * 0.4)
   const grad = fieldCtx.createLinearGradient(-dx, -dy, dx, dy)
-  grad.addColorStop(0, `rgba(${rgb},${hi})`)
-  grad.addColorStop(1, `rgba(${rgb},${lo})`)
+  grad.addColorStop(0, `rgba(255,255,255,${hi})`)
+  grad.addColorStop(1, `rgba(255,255,255,${lo})`)
   return grad
 }
 
@@ -178,27 +183,21 @@ function drawTri(r: number) {
   fieldCtx.closePath()
 }
 
-function drawShape(
-  s: ShapeDef,
-  frame: number,
-  vw: number,
-  vh: number,
-  rgb: string,
-) {
+function drawShape(s: ShapeDef, frame: number) {
   if (!fieldCtx) return
-  const unit = minDim(vw, vh)
+  const unit = Math.min(cols, rows)
   const nx = sampleTrack(s.pos, frame, 0)
   const ny = sampleTrack(s.pos, frame, 1)
   const rotDeg = sampleTrack(s.rot, frame, 0) + s.localRot
-  const [cx, cy] = normToPx(nx, ny, vw, vh)
+  const [cx, cy] = normToPx(nx, ny, cols, rows)
   const r = s.radius * s.scale * unit
   const alpha = isDark ? Math.max(s.opacity, 0.88) : 1
 
   fieldCtx.save()
   fieldCtx.translate(cx, cy)
   fieldCtx.rotate(rotDeg * (Math.PI / 180))
-  fieldCtx.fillStyle = shapeFillGradient(s, rgb, alpha, unit)
-  fieldCtx.strokeStyle = shapeFillGradient(s, rgb, alpha, unit)
+  fieldCtx.fillStyle = shapeFillGradient(s, alpha, unit)
+  fieldCtx.strokeStyle = shapeFillGradient(s, alpha, unit)
 
   switch (s.kind) {
     case 'circle':
@@ -237,14 +236,11 @@ function drawShape(
 
 function drawField(frame: number) {
   if (!fieldCtx || !field) return
-  fieldCtx.clearRect(0, 0, fieldW, fieldH)
+  fieldCtx.clearRect(0, 0, cols, rows)
+  // 形状构图仍按主题分(亮暗两套编排不同);颜色不分——统一无彩,
+  // 场里只写 alpha 覆盖率,着色在主画布用 dotColor 完成
   const theme = isDark ? THEMES.dark : THEMES.light
-  theme.shapes.forEach((s, i) => {
-    const rgb = isDark
-      ? (paletteRGB[i % paletteRGB.length] ?? '255,255,255')
-      : toRGB(dotColor)
-    drawShape(s, frame, fieldW, fieldH, rgb)
-  })
+  theme.shapes.forEach(s => drawShape(s, frame))
 }
 
 function scheduleFrame() {
@@ -254,7 +250,13 @@ function scheduleFrame() {
 }
 
 function render(now: number) {
-  if (!ctx || !fieldCtx || !field || !canvasEl.value) return
+  if (!ctx || !fieldCtx || !field || !canvasEl.value || !ambientPath) return
+  // 30fps 帧率闸:跳过的帧只重新排队,不推进时间轴
+  if (now - lastFrameAt < FRAME_MS) {
+    scheduleFrame()
+    return
+  }
+  lastFrameAt = now
   if (!lastNow) lastNow = now
   const dt = Math.min(0.05, (now - lastNow) / 1000)
   lastNow = now
@@ -262,45 +264,39 @@ function render(now: number) {
   const frame = (animTime * STAGE_FR) % STAGE_OP
 
   drawField(frame)
-  const data = fieldCtx.getImageData(0, 0, fieldW, fieldH).data
-  const el = canvasEl.value
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-  ctx.clearRect(0, 0, el.width, el.height)
+  const data = fieldCtx.getImageData(0, 0, cols, rows).data
 
-  const theme = isDark ? THEMES.dark : THEMES.light
-  const ambient = isDark ? AMBIENT_DARK : Math.max(AMBIENT_LIGHT, theme.bgOpacity * 0.65)
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.clearRect(0, 0, viewW, viewH)
+  ctx.fillStyle = dotColor
+
+  // 常亮层:一笔
+  ctx.globalAlpha = AMBIENT
+  ctx.fill(ambientPath)
+
+  // 点亮层:按量化档位聚合,每档一条 Path2D 一笔 fill
   const gain = isDark ? GAIN_DARK : GAIN_LIGHT
   const TWO_PI = Math.PI * 2
-
-  ctx.fillStyle = dotColor
-  ctx.globalAlpha = ambient
+  const buckets: (Path2D | null)[] = Array.from({ length: LEVELS }, () => null)
   for (let y = 0; y < rows; y++) {
     const py = y * GAP
+    const rowBase = y * cols
     for (let x = 0; x < cols; x++) {
-      ctx.beginPath()
-      ctx.arc(x * GAP, py, DOT_RADIUS, 0, TWO_PI)
-      ctx.fill()
+      const raw = data[(rowBase + x) * 4 + 3] / 255
+      if (raw <= 0.04) continue
+      const level = Math.min(LEVELS, Math.round(raw * LEVELS))
+      if (level <= 0) continue
+      const px = x * GAP
+      const path = (buckets[level - 1] ??= new Path2D())
+      path.moveTo(px + DOT_RADIUS, py)
+      path.arc(px, py, DOT_RADIUS, 0, TWO_PI)
     }
   }
-
-  if (!isDark) ctx.fillStyle = dotColor
-  for (let y = 0; y < rows; y++) {
-    const py = y * GAP
-    const fy = Math.min(fieldH - 1, Math.round(py * fieldScale))
-    for (let x = 0; x < cols; x++) {
-      const px = x * GAP
-      const fx = Math.min(fieldW - 1, Math.round(px * fieldScale))
-      const idx = (fy * fieldW + fx) * 4
-      const raw = data[idx + 3] / 255
-      if (raw <= 0.04) continue
-      const cov = Math.round(raw * LEVELS) / LEVELS
-      if (cov <= 0) continue
-      if (isDark) ctx.fillStyle = `rgb(${data[idx]},${data[idx + 1]},${data[idx + 2]})`
-      ctx.globalAlpha = cov * gain
-      ctx.beginPath()
-      ctx.arc(px, py, DOT_RADIUS, 0, TWO_PI)
-      ctx.fill()
-    }
+  for (let level = 1; level <= LEVELS; level++) {
+    const path = buckets[level - 1]
+    if (!path) continue
+    ctx.globalAlpha = (level / LEVELS) * gain
+    ctx.fill(path)
   }
   ctx.globalAlpha = 1
   scheduleFrame()
@@ -310,12 +306,18 @@ let resizeObserver: ResizeObserver | null = null
 let themeObserver: MutationObserver | null = null
 let mediaQuery: MediaQueryList | null = null
 
+/** reduce-motion 下仍画一帧静态点阵(含当前形状),只是不再推进 */
+function renderOnce() {
+  cancelAnimationFrame(raf)
+  raf = requestAnimationFrame(render)
+}
+
 function onReduceMotionChange() {
   reduceMotion = !!mediaQuery?.matches
   lastNow = 0
+  lastFrameAt = 0
   if (reduceMotion) {
-    cancelAnimationFrame(raf)
-    raf = requestAnimationFrame(render)
+    renderOnce()
     return
   }
   scheduleFrame()
@@ -324,6 +326,7 @@ function onReduceMotionChange() {
 function onVisibilityChange() {
   pageVisible = !document.hidden
   lastNow = 0
+  lastFrameAt = 0
   if (!pageVisible) {
     cancelAnimationFrame(raf)
     return
@@ -340,9 +343,15 @@ onMounted(() => {
   mediaQuery.addEventListener('change', onReduceMotionChange)
   document.addEventListener('visibilitychange', onVisibilityChange)
   resize()
-  resizeObserver = new ResizeObserver(() => resize())
+  resizeObserver = new ResizeObserver(() => {
+    resize()
+    if (reduceMotion) renderOnce()
+  })
   resizeObserver.observe(el)
-  themeObserver = new MutationObserver(() => readColor())
+  themeObserver = new MutationObserver(() => {
+    readColor()
+    if (reduceMotion) renderOnce()
+  })
   themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
   raf = requestAnimationFrame(render)
 })

--- a/apps/web/src/pages/login/index.vue
+++ b/apps/web/src/pages/login/index.vue
@@ -24,10 +24,10 @@
         </p>
       </div>
 
-      <!-- 无卡、无描边:两字段 + Continue 直接浮在点阵上(SaaS filled-control 语言)。
-           placeholder 用 Enter …,不与 label 裸词重复(P0 label≠placeholder)。 -->
+      <!-- 两字段 + Continue 等距 gap-2.5(不学 SaaS 密码步拉开 CTA)。
+           placeholder 用 Enter …(P0 label≠placeholder)。 -->
       <form
-        class="flex w-full flex-col"
+        class="flex w-full flex-col gap-2.5"
         @submit.prevent="login"
       >
         <Input
@@ -42,14 +42,12 @@
         <PasswordInput
           id="password"
           v-model="password"
-          class="mt-2.5"
           :placeholder="$t('auth.passwordPlaceholder')"
           autocomplete="current-password"
           :disabled="isSubmitting"
         />
         <LoadingButton
           type="submit"
-          class="login-entry-submit"
           block
           :loading="isSubmitting"
           :loading-delay="0"
@@ -125,17 +123,23 @@ const login = async () => {
 
 <!-- 非 scoped:scoped 内 :global(.dark) 组合选择器编译不可靠;用 .login-scope 限定。 -->
 <style>
-/* ── 登录页专属控件语言(与 SaaS 登录同源,2026-07)──────────────
- * 无卡、无描边:控件 = 比页面底色高一阶的填充块,浮在点阵动画上。
- * rest 用不透明实色;hover 用透明度叠在实色上。与产品内 field-edge
- * 是有意分叉(登录=营销面 / 产品内=工具面)。 */
+/* ── 登录页专属控件语言(与 SaaS 登录同源)────────────────────
+ * 浅色 rest = 纯白(非 #ececec 脏灰);暗色 #242424。
+ * hover = 白纱盖在 content 上(图标色不动,整体被洗亮),0ms。 */
 .login-scope {
-  --login-control: #ececec;
-  --login-control-hover: color-mix(in oklab, #ececec, rgb(0 0 0 / 0.05));
+  --login-control: #ffffff;
+  --login-outline-hover-opacity: 0.68;
+  --login-hover-duration: 10ms;
+  --login-primary-hover: color-mix(in oklab, var(--btn-primary), #fff 18%);
+  --login-primary-active: color-mix(in oklab, var(--btn-primary), #fff 28%);
+  --login-primary-disabled: color-mix(in oklab, var(--btn-primary), #fff 42%);
 }
 .dark .login-scope {
   --login-control: #242424;
-  --login-control-hover: color-mix(in oklab, #242424, rgb(255 255 255 / 0.07));
+  --login-outline-hover-opacity: 0.72;
+  --login-primary-hover: color-mix(in oklab, var(--btn-primary), #000 12%);
+  --login-primary-active: color-mix(in oklab, var(--btn-primary), #000 20%);
+  --login-primary-disabled: color-mix(in oklab, var(--btn-primary), #000 28%);
 }
 
 /* 防双击选中系统蓝框 */
@@ -144,7 +148,16 @@ const login = async () => {
   -webkit-user-select: none;
 }
 
-/* 禁用纱层:背景色叠在控件上,不引入第三色;loading 豁免 */
+/* outline hover = 整颗降透明度;10ms */
+.login-scope [data-button][data-variant="outline"]:not(:disabled) {
+  transition: opacity var(--login-hover-duration) ease-out;
+}
+.login-scope [data-button][data-variant="outline"]:not(:disabled):hover,
+.login-scope [data-button][data-variant="outline"]:not(:disabled):active {
+  opacity: var(--login-outline-hover-opacity);
+}
+
+/* ::after 仅禁用纱 */
 .login-scope [data-button]:not([data-variant="quiet"])::after {
   content: "";
   position: absolute;
@@ -156,8 +169,10 @@ const login = async () => {
   pointer-events: none;
   transition: opacity 0.2s ease-out;
 }
-.login-scope [data-button]:disabled:not([data-loading])::after {
-  opacity: 0.55;
+.login-scope [data-button]:not([data-variant="quiet"]):disabled:not([data-loading])::after,
+.login-scope [data-button]:not([data-variant="quiet"]):disabled:hover::after,
+.login-scope [data-button]:not([data-variant="quiet"]):disabled:active::after {
+  opacity: 0.32;
 }
 .login-scope [data-button]:disabled {
   opacity: 1;
@@ -165,15 +180,27 @@ const login = async () => {
   cursor: not-allowed;
 }
 
-/* 输入框:实心填充,无 field-edge;聚焦不变色 */
+/* 浅色描边两档:输入框 field-edge-rest(≈11%);按钮再淡到 ≈7%(大块+字重同浓度更重) */
+.login-scope {
+  --login-edge-field: inset 0 0 0 1px var(--field-edge-rest);
+  --login-edge-btn: inset 0 0 0 1px oklch(0 0 0 / 0.09);
+}
 .login-scope [data-slot="input"],
 .login-scope [data-slot="input-group"] {
   background-color: var(--login-control);
+  box-shadow: var(--login-edge-field);
+  transition: background-color 0.2s ease-out, box-shadow 0.06s ease-out;
+}
+.dark .login-scope [data-slot="input"],
+.dark .login-scope [data-slot="input-group"] {
   box-shadow: none;
-  transition: background-color 0.2s ease-out;
 }
 .login-scope [data-slot="input"]:focus,
 .login-scope [data-slot="input-group"]:focus-within {
+  box-shadow: var(--login-edge-field);
+}
+.dark .login-scope [data-slot="input"]:focus,
+.dark .login-scope [data-slot="input-group"]:focus-within {
   box-shadow: none;
 }
 .login-scope [data-slot="input"]:disabled,
@@ -183,8 +210,87 @@ const login = async () => {
   cursor: not-allowed;
 }
 
-/* 主按钮到字段:密码框→Continue 20px(与 SaaS 密码步同档) */
-.login-scope .login-entry-submit {
-  margin-top: 1.25rem;
+/* 浏览器原生自动填充覆盖(与 SaaS 登录页 saas/login.vue 同源,发现于该页
+ * 2026-07-09 的开发过程,详见其文件内注释):Chrome/Safari 对 autofill 的
+ * <input> 会强制刷一层它自己的背景,且只认 -webkit-text-fill-color、不认
+ * 普通 color——本页文字色是 --foreground(暗色下接近纯白),一旦浏览器把
+ * 背景抢成浅色,白字就读不出来了。用 inset box-shadow 撑满整个输入框把
+ * 浏览器的背景"挤"成看不见,再显式钉住文字色。
+ * transition delay 用大数字拖延 -webkit 的显示时机,是该 hack 的标准写法。
+ * ⚠ 与 saas/login.vue 保持同步:改这段前先看那边是否也要跟着改。
+ * ⚠ 选择器同时覆盖 [data-slot="input"] 和 [data-slot="input-group-control"]:
+ * 本页密码框走 PasswordInput → InputGroup → InputGroupInput,内层 <input>
+ * 的 data-slot 被 InputGroupInput 显式传成了 "input-group-control"(Vue
+ * fallthrough attrs 规则覆盖了 Input.vue 内部写死的 "input"),只写
+ * [data-slot="input"] 会漏掉密码框——账号用 Input(data-slot="input")没事,
+ * 密码这个最容易被浏览器自动填充命中的字段却选不中。
+ * input-group-control 不带 --login-edge-field:那圈描边已经画在外层
+ * [data-slot="input-group"] 容器上,内层再叠一份会形成双层描边。 */
+.login-scope [data-slot="input"]:-webkit-autofill,
+.login-scope [data-slot="input"]:-webkit-autofill:hover,
+.login-scope [data-slot="input"]:-webkit-autofill:focus,
+.login-scope [data-slot="input"]:-webkit-autofill:active {
+  box-shadow: var(--login-edge-field), 0 0 0px 1000px var(--login-control) inset;
+  -webkit-text-fill-color: var(--foreground);
+  caret-color: var(--foreground);
+  transition: background-color 99999s ease-in-out 0s;
+}
+.login-scope [data-slot="input-group-control"]:-webkit-autofill,
+.login-scope [data-slot="input-group-control"]:-webkit-autofill:hover,
+.login-scope [data-slot="input-group-control"]:-webkit-autofill:focus,
+.login-scope [data-slot="input-group-control"]:-webkit-autofill:active {
+  box-shadow: 0 0 0px 1000px var(--login-control) inset;
+  -webkit-text-fill-color: var(--foreground);
+  caret-color: var(--foreground);
+  transition: background-color 99999s ease-in-out 0s;
+}
+.dark .login-scope [data-slot="input"]:-webkit-autofill,
+.dark .login-scope [data-slot="input"]:-webkit-autofill:hover,
+.dark .login-scope [data-slot="input"]:-webkit-autofill:focus,
+.dark .login-scope [data-slot="input"]:-webkit-autofill:active,
+.dark .login-scope [data-slot="input-group-control"]:-webkit-autofill,
+.dark .login-scope [data-slot="input-group-control"]:-webkit-autofill:hover,
+.dark .login-scope [data-slot="input-group-control"]:-webkit-autofill:focus,
+.dark .login-scope [data-slot="input-group-control"]:-webkit-autofill:active {
+  box-shadow: 0 0 0px 1000px var(--login-control) inset;
+}
+
+/* outline:描边 hover 不摘;fill 不动,靠整颗 opacity */
+.login-scope [data-button][data-variant="outline"]::before,
+.login-scope [data-button][data-variant="outline"]:not(:disabled):hover::before,
+.login-scope [data-button][data-variant="outline"]:not(:disabled):active::before,
+.login-scope [data-button][data-variant="outline"]:disabled:hover::before,
+.login-scope [data-button][data-variant="outline"]:disabled:active::before {
+  background-color: var(--login-control);
+  box-shadow: var(--login-edge-btn);
+}
+.dark .login-scope [data-button][data-variant="outline"]::before,
+.dark .login-scope [data-button][data-variant="outline"]:not(:disabled):hover::before,
+.dark .login-scope [data-button][data-variant="outline"]:not(:disabled):active::before,
+.dark .login-scope [data-button][data-variant="outline"]:disabled:hover::before,
+.dark .login-scope [data-button][data-variant="outline"]:disabled:active::before {
+  background-color: var(--login-control);
+  box-shadow: none;
+}
+
+/* primary:轻抬 fill;10ms;不可点往白抬 */
+.login-scope [data-button]:is([data-variant="default"], [data-variant="primary"])::before,
+.dark .login-scope [data-button]:is([data-variant="default"], [data-variant="primary"])::before {
+  transition: background-color var(--login-hover-duration) ease-out;
+}
+.login-scope [data-button]:is([data-variant="default"], [data-variant="primary"]):not(:disabled):hover::before,
+.dark .login-scope [data-button]:is([data-variant="default"], [data-variant="primary"]):not(:disabled):hover::before {
+  background-color: var(--login-primary-hover);
+}
+.login-scope [data-button]:is([data-variant="default"], [data-variant="primary"]):not(:disabled):active::before,
+.login-scope [data-button]:is([data-variant="default"], [data-variant="primary"])[data-block]:not(:disabled):active::before,
+.dark .login-scope [data-button]:is([data-variant="default"], [data-variant="primary"]):not(:disabled):active::before,
+.dark .login-scope [data-button]:is([data-variant="default"], [data-variant="primary"])[data-block]:not(:disabled):active::before {
+  background-color: var(--login-primary-active);
+  transition: background-color var(--login-hover-duration) ease-out;
+}
+.login-scope [data-button]:is([data-variant="default"], [data-variant="primary"]):disabled:not([data-loading])::before,
+.dark .login-scope [data-button]:is([data-variant="default"], [data-variant="primary"]):disabled:not([data-loading])::before {
+  background-color: var(--login-primary-disabled);
 }
 </style>

--- a/apps/web/src/pages/login/index.vue
+++ b/apps/web/src/pages/login/index.vue
@@ -1,35 +1,27 @@
 <template>
   <main
-    class="w-screen h-screen flex flex-col items-center justify-center bg-background relative overflow-hidden p-6 pb-24"
+    class="w-screen h-screen flex flex-col items-center justify-center bg-background relative p-6 pb-24"
   >
-    <DotMatrixBg class="login-dots absolute inset-0 pointer-events-none" />
-
-    <div class="absolute top-6 left-6 flex items-center gap-2.5 z-(--z-raised)">
-      <img
-        src="/logo.svg"
-        class="size-7"
-        alt=""
-        aria-hidden="true"
-      >
-      <span class="text-control font-semibold text-foreground">Memoh</span>
-    </div>
-
     <section
-      class="relative z-(--z-raised) w-full max-w-[20.5rem] flex flex-col items-center gap-8 transition-all duration-[175ms] ease-out"
+      class="w-full max-w-[20.5rem] flex flex-col items-center gap-6 transition-all duration-[175ms] ease-out"
       :class="exiting ? 'scale-[0.88] opacity-0' : 'scale-100 opacity-100'"
     >
-      <div class="flex flex-col items-center gap-3">
+      <div class="flex flex-col items-center gap-3 text-center">
         <img
           src="/logo.svg"
-          class="size-12"
+          class="size-14"
           alt=""
           aria-hidden="true"
         >
         <h1 class="text-display font-semibold text-foreground">
           {{ $t('auth.pageTitle') }}
         </h1>
+        <p class="text-sm text-muted-foreground">
+          {{ $t('auth.pageSubtitle') }}
+        </p>
       </div>
 
+      <!-- 表单元素只有三个,不值得再包一层卡;直接摆在页面底色上 -->
       <form
         class="w-full flex flex-col gap-2.5"
         @submit.prevent="login"
@@ -41,7 +33,6 @@
           :placeholder="$t('auth.username')"
           :disabled="isSubmitting"
           autocomplete="username"
-          class="bg-background"
         />
         <PasswordInput
           id="password"
@@ -49,7 +40,6 @@
           :placeholder="$t('auth.password')"
           autocomplete="current-password"
           :disabled="isSubmitting"
-          class="bg-background"
         />
         <LoadingButton
           class="w-full mt-1"
@@ -75,7 +65,6 @@ import { useI18n } from 'vue-i18n'
 import { postAuthLogin } from '@memohai/sdk'
 import LoadingButton from '@/components/loading-button/index.vue'
 import PasswordInput from '@/components/password-input/index.vue'
-import DotMatrixBg from './components/dot-matrix-bg.vue'
 import { submitLogin } from './login-submit'
 import { safeSessionSet } from '@/utils/safe-storage'
 import { ONBOARDING_KEYS } from '@/pages/onboarding/constants'
@@ -117,36 +106,3 @@ const login = async () => {
   )
 }
 </script>
-
-<style scoped>
-/* 极轻的四角渐隐:圆心略偏右下,使左上角(有 logo)衰减略多,其余角几乎不遮;
- * 最深也仅到 ~82%,只是收一点点边角,不牺牲可见度 */
-.login-dots {
-  -webkit-mask-image: radial-gradient(ellipse 118% 118% at 58% 60%, #000 72%, rgba(0, 0, 0, 0.82) 100%);
-  mask-image: radial-gradient(ellipse 118% 118% at 58% 60%, #000 72%, rgba(0, 0, 0, 0.82) 100%);
-}
-
-form :deep([data-button]:active::before) {
-  scale: 1 !important;
-  transition: none !important;
-}
-
-/* 动画背景上:禁用态 opacity 会让点阵从按钮底下透出来 */
-form :deep([data-button]:is([data-variant="default"], [data-variant="primary"])) {
-  background-color: var(--btn-primary);
-}
-form :deep([data-button]:is([data-variant="default"], [data-variant="primary"]):disabled) {
-  opacity: 1;
-  cursor: not-allowed;
-}
-form :deep([data-button]:is([data-variant="default"], [data-variant="primary"]):disabled)::before {
-  background-color: var(--btn-primary-active);
-}
-
-/* 同一道理:禁用态的输入框也不能走 opacity,否则点阵会从框底透出。
- * 保持不透明,只用降阶文字色表达锁定态。 */
-form :deep(input:disabled) {
-  opacity: 1;
-  color: var(--muted-foreground);
-}
-</style>

--- a/apps/web/src/pages/login/index.vue
+++ b/apps/web/src/pages/login/index.vue
@@ -1,9 +1,12 @@
 <template>
+  <!-- 几何居中 + 光学上移(与 SaaS 登录同语言);无 OAuth / 多步,仅 username + password。 -->
   <main
-    class="w-screen h-screen flex flex-col items-center justify-center bg-background relative p-6 pb-24"
+    class="relative flex h-screen w-screen flex-col items-center justify-center overflow-hidden bg-background p-6"
   >
+    <DotMatrixBg class="pointer-events-none absolute inset-0" />
+
     <section
-      class="w-full max-w-[20.5rem] flex flex-col items-center gap-6 transition-all duration-[175ms] ease-out"
+      class="login-scope relative flex w-full max-w-[22rem] -translate-y-8 flex-col items-center gap-6 transition-[opacity,transform] duration-[175ms] ease-out"
       :class="exiting ? 'scale-[0.88] opacity-0' : 'scale-100 opacity-100'"
     >
       <div class="flex flex-col items-center gap-3 text-center">
@@ -16,34 +19,38 @@
         <h1 class="text-display font-semibold text-foreground">
           {{ $t('auth.pageTitle') }}
         </h1>
-        <p class="text-sm text-muted-foreground">
+        <p class="max-w-[18rem] text-sm text-muted-foreground">
           {{ $t('auth.pageSubtitle') }}
         </p>
       </div>
 
-      <!-- 表单元素只有三个,不值得再包一层卡;直接摆在页面底色上 -->
+      <!-- 无卡、无描边:两字段 + Continue 直接浮在点阵上(SaaS filled-control 语言)。
+           placeholder 用 Enter …,不与 label 裸词重复(P0 label≠placeholder)。 -->
       <form
-        class="w-full flex flex-col gap-2.5"
+        class="flex w-full flex-col"
         @submit.prevent="login"
       >
         <Input
           id="username"
           v-model="username"
           type="text"
-          :placeholder="$t('auth.username')"
+          :placeholder="$t('auth.usernamePlaceholder')"
           :disabled="isSubmitting"
           autocomplete="username"
+          autofocus
         />
         <PasswordInput
           id="password"
           v-model="password"
-          :placeholder="$t('auth.password')"
+          class="mt-2.5"
+          :placeholder="$t('auth.passwordPlaceholder')"
           autocomplete="current-password"
           :disabled="isSubmitting"
         />
         <LoadingButton
-          class="w-full mt-1"
           type="submit"
+          class="login-entry-submit"
+          block
           :loading="isSubmitting"
           :loading-delay="0"
           :disabled="!canSubmit"
@@ -65,6 +72,7 @@ import { useI18n } from 'vue-i18n'
 import { postAuthLogin } from '@memohai/sdk'
 import LoadingButton from '@/components/loading-button/index.vue'
 import PasswordInput from '@/components/password-input/index.vue'
+import DotMatrixBg from '@/pages/login/components/dot-matrix-bg.vue'
 import { submitLogin } from './login-submit'
 import { safeSessionSet } from '@/utils/safe-storage'
 import { ONBOARDING_KEYS } from '@/pages/onboarding/constants'
@@ -98,6 +106,7 @@ const login = async () => {
         await router.replace({ path: '/' })
       },
       notifyInvalidCredentials: () => {
+        // 可显隐密码框:失败不清空,用户多半只改账号或笔误。
         toast.error(t('auth.invalidCredentials'), {
           description: t('auth.retryHint'),
         })
@@ -106,3 +115,76 @@ const login = async () => {
   )
 }
 </script>
+
+<style scoped>
+/* placeholder 是主要可见文案,与全局 placeholder(360)相比提半档。 */
+.login-scope :deep(input)::placeholder {
+  font-weight: 450;
+}
+</style>
+
+<!-- 非 scoped:scoped 内 :global(.dark) 组合选择器编译不可靠;用 .login-scope 限定。 -->
+<style>
+/* ── 登录页专属控件语言(与 SaaS 登录同源,2026-07)──────────────
+ * 无卡、无描边:控件 = 比页面底色高一阶的填充块,浮在点阵动画上。
+ * rest 用不透明实色;hover 用透明度叠在实色上。与产品内 field-edge
+ * 是有意分叉(登录=营销面 / 产品内=工具面)。 */
+.login-scope {
+  --login-control: #ececec;
+  --login-control-hover: color-mix(in oklab, #ececec, rgb(0 0 0 / 0.05));
+}
+.dark .login-scope {
+  --login-control: #242424;
+  --login-control-hover: color-mix(in oklab, #242424, rgb(255 255 255 / 0.07));
+}
+
+/* 防双击选中系统蓝框 */
+.login-scope [data-button] {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* 禁用纱层:背景色叠在控件上,不引入第三色;loading 豁免 */
+.login-scope [data-button]:not([data-variant="quiet"])::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+  background-color: var(--background);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease-out;
+}
+.login-scope [data-button]:disabled:not([data-loading])::after {
+  opacity: 0.55;
+}
+.login-scope [data-button]:disabled {
+  opacity: 1;
+  pointer-events: auto;
+  cursor: not-allowed;
+}
+
+/* 输入框:实心填充,无 field-edge;聚焦不变色 */
+.login-scope [data-slot="input"],
+.login-scope [data-slot="input-group"] {
+  background-color: var(--login-control);
+  box-shadow: none;
+  transition: background-color 0.2s ease-out;
+}
+.login-scope [data-slot="input"]:focus,
+.login-scope [data-slot="input-group"]:focus-within {
+  box-shadow: none;
+}
+.login-scope [data-slot="input"]:disabled,
+.login-scope [data-slot="input-group"]:has(input:disabled) {
+  background-color: color-mix(in oklab, var(--background) 55%, var(--login-control));
+  opacity: 1;
+  cursor: not-allowed;
+}
+
+/* 主按钮到字段:密码框→Continue 20px(与 SaaS 密码步同档) */
+.login-scope .login-entry-submit {
+  margin-top: 1.25rem;
+}
+</style>

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -14,6 +14,9 @@ COPY scripts/check-patched-deps.mjs ./scripts/
 COPY packages ./packages
 COPY apps ./apps
 
+RUN test -f packages/ui/package.json || \
+    (echo "packages/ui is missing. Initialize git submodules before building: git submodule update --init --recursive" >&2; exit 1)
+
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     pnpm install
 

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -112,6 +112,19 @@
     scale: 0.974;
     box-shadow: none;
   }
+  /* press — BLOCK / full-width outline/secondary: mirrors the primary/ghost block
+     philosophy. A uniform press-scale on a wide button lurches sideways (each edge
+     travels ~width × 2.6%), so block secondary CTAs (e.g. the login OAuth buttons)
+     drop the scale and read the press through a deeper fill, applied INSTANT and
+     easing back on release via the base transition. Before this rule, wide
+     outline buttons fell through to the standalone scale above — the gap that
+     made full-width secondary actions lurch. */
+  [data-button]:is([data-variant="outline"], [data-variant="secondary"])[data-block]:active::before {
+    scale: 1 1;
+    background-color: var(--ui-pressed);
+    box-shadow: none;
+    transition: background-color 0s;
+  }
 
   /* ── Buttons inside a ButtonGroup — a "joined" relative of Toggle ────────────
      The group (button-group/index.ts) draws the single outer border + internal
@@ -922,6 +935,23 @@
 }
 .dark [data-button]:is([data-variant="outline"], [data-variant="secondary"])::before {
   transition-duration: 0.255s, 0.095s, 0.095s;
+}
+
+/* BLOCK buttons: pointer-driven color must be INSTANT, both directions.
+   A wide CTA already dropped press-scale (the block rules above); the remaining
+   motion cue is color, and any easing on it reads as lag under the cursor. So on
+   block primary/secondary the color/ring transitions go to 0s on the base shell —
+   hover-in, hover-out, press, release are all immediate; only the scale spring
+   keeps its duration (unused by block, kept for the transition-slot order).
+   Placed after the .dark overrides above and matching their specificity+order so
+   block wins in dark mode too. Loading keeps its own busy-hold rules. */
+[data-button]:is([data-variant="default"], [data-variant="primary"])[data-block]::before,
+.dark [data-button]:is([data-variant="default"], [data-variant="primary"])[data-block]::before {
+  transition-duration: 0.255s, 0s;
+}
+[data-button]:is([data-variant="outline"], [data-variant="secondary"])[data-block]::before,
+.dark [data-button]:is([data-variant="outline"], [data-variant="secondary"])[data-block]::before {
+  transition-duration: 0.255s, 0s, 0s;
 }
 
 :root {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -718,12 +718,22 @@ if [ -d "$DIR" ]; then
 else
     echo "Cloning Memoh into $WORKSPACE..."
     if [ -n "$MEMOH_VERSION" ]; then
-        git clone --depth 1 --branch "$MEMOH_VERSION" "$REPO" "$DIR"
+        git clone --depth 1 --recurse-submodules --shallow-submodules --branch "$MEMOH_VERSION" "$REPO" "$DIR"
     else
-        git clone --depth 1 "$REPO" "$DIR"
+        git clone --depth 1 --recurse-submodules --shallow-submodules "$REPO" "$DIR"
     fi
     cd "$DIR"
     CLONED_FRESH=true
+fi
+
+echo "Updating git submodules..."
+git submodule sync --recursive
+git submodule update --init --recursive --depth 1
+
+if [ -f .gitmodules ] && [ ! -f packages/ui/package.json ]; then
+  echo "${RED}Error: packages/ui submodule is not initialized.${NC}"
+  echo "Run: git submodule update --init --recursive"
+  exit 1
 fi
 
 COMPOSE_FILE_NAME="docker-compose.yml"


### PR DESCRIPTION
## Summary
- Browser-native autofill forces its own background on `<input>` and only honors `-webkit-text-fill-color`, not `color` — with `--foreground` white text in dark mode, autofilled fields (browser-remembered credentials) became unreadable.
- Ports the inset-box-shadow override hack from the SaaS login page (`memohai/Memoh-SaaS`), where this was found and fixed first.
- The password field needed its own selector: `PasswordInput` renders through `InputGroupInput`, which overrides `data-slot` to `"input-group-control"` via Vue's attrs fallthrough — a selector scoped to `[data-slot="input"]` alone silently misses it. Both are covered now, with a comment explaining why.

## Related
Companion fix in the SaaS repo (draft, held open for reference — that repo isn't a fork of this one so the CSS doesn't sync automatically): memohai/Memoh-SaaS#TBD

## Test plan
- [x] `vue-tsc --noEmit` clean
- [x] `eslint` clean
- [ ] Manual check: trigger browser autofill (saved username/password) on `/login` in both light and dark mode, confirm text is readable