### PR TITLE
fix: harden submodule development workflows

### DIFF
--- a/.agents/skills/memoh-ui-owners
+++ b/.agents/skills/memoh-ui-owners
@@ -1,1 +1,0 @@
-../../packages/ui/skills/memoh-ui-owners

--- a/.agents/skills/memoh-ui-owners/SKILL.md
+++ b/.agents/skills/memoh-ui-owners/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: memoh-ui-owners
+description: Read before editing Memoh Web settings pages, bot-detail tabs, forms, config panels, list rows, detail surfaces, or recurring layout shapes that should use the shared owner vocabulary.
+---
+
+# Memoh UI Owners Skill Forwarder
+
+The canonical skill is maintained with the UI package at
+`packages/ui/skills/memoh-ui-owners/SKILL.md`.
+
+Before changing an applicable Web surface, read that canonical file in full and
+follow it. Resolve its relative references from
+`packages/ui/skills/memoh-ui-owners/`. This wrapper is a real directory so skill
+discovery also works on Windows checkouts without Git symlinks.

--- a/.agents/skills/memoh-web
+++ b/.agents/skills/memoh-web
@@ -1,1 +1,0 @@
-../../packages/ui/skills/memoh-web

--- a/.agents/skills/memoh-web/SKILL.md
+++ b/.agents/skills/memoh-web/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: memoh-web
+description: Primary Web development skill for apps/web. Use before writing or changing Memoh Web frontend code, including pages, settings, lists, details, chat components, and polish work.
+---
+
+# Memoh Web Skill Forwarder
+
+The canonical skill is maintained with the UI package at
+`packages/ui/skills/memoh-web/SKILL.md`.
+
+Before changing `apps/web`, read that canonical file in full and follow it. Resolve
+its relative references from `packages/ui/skills/memoh-web/`. This wrapper is a real
+directory so skill discovery also works on Windows checkouts without Git symlinks.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,43 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  source-bundle:
+    name: Build complete source archives
+    needs: changelog
+    if: ${{ always() && (needs.changelog.result == 'success' || needs.changelog.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Package repository with submodules
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          ROOT="Memoh-${VERSION}"
+          STAGE="${RUNNER_TEMP}/${ROOT}"
+
+          test -f packages/ui/package.json
+          mkdir -p "$STAGE"
+          rsync -a \
+            --exclude='.git' \
+            --exclude='node_modules' \
+            --exclude='dist' \
+            ./ "$STAGE/"
+
+          tar -C "$RUNNER_TEMP" -czf "${RUNNER_TEMP}/${ROOT}-source.tar.gz" "$ROOT"
+          (cd "$RUNNER_TEMP" && zip -qr "${ROOT}-source.zip" "$ROOT")
+      - name: Upload complete source archives
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          gh release upload "$RELEASE_TAG" \
+            "${RUNNER_TEMP}/Memoh-${VERSION}-source.tar.gz" \
+            "${RUNNER_TEMP}/Memoh-${VERSION}-source.zip" \
+            --clobber
+
   npm-publish-felinic:
     name: Publish @felinic/ui
     runs-on: ubuntu-latest

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if command -v node >/dev/null 2>&1; then
+  node scripts/ensure-submodules.mjs || {
+    echo "Warning: packages/ui still needs manual submodule initialization."
+    exit 0
+  }
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ Memoh/
 │   ├── desktop/                #   Native Electron app (@memohai/desktop): hosted-server renderer, tray, menus, preload IPC
 │   └── web/                    #   Main web app (@memohai/web, Vue 3) — see apps/web/AGENTS.md
 ├── packages/                   # Shared TypeScript libraries
-│   ├── ui/                     #   Shared UI component library (@felinic/ui) — git submodule → github.com/memohai/ui; also ships the memoh-web / memoh-ui-owners agent skills (symlinked from .agents/skills/)
+│   ├── ui/                     #   Shared UI component library (@felinic/ui) — git submodule → github.com/memohai/ui; also owns the memoh-web / memoh-ui-owners agent skills (loaded through cross-platform wrappers in .agents/skills/)
 │   ├── sdk/                    #   TypeScript SDK (@memohai/sdk, auto-generated from OpenAPI)
 │   ├── icons/                  #   Brand/provider icon library (@memohai/icon)
 │   └── config/                 #   Shared configuration utilities (@memohai/config)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -20,6 +20,11 @@ cp conf/app.docker.toml config.toml
 nano config.toml   # Change passwords and JWT secret
 ```
 
+GitHub's automatic “Source code” archives omit submodule contents. Use a recursive clone or the
+complete `Memoh-<version>-source.zip` / `.tar.gz` asset attached to each release. Existing setup
+checkouts can continue using `git pull`; run `mise run submodule-init` once only if the post-merge
+hook was never installed.
+
 > On macOS or if your user is in the `docker` group, `sudo` is not required.
 
 > **Important**: You must create `config.toml` before starting. `docker-compose.yml` mounts `./config.toml` into the containers — running without it will fail.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ cp conf/app.docker.toml config.toml
 docker compose up -d
 ```
 
+Existing setup checkouts can keep using `git pull`: the post-merge hook initializes the new
+submodule, and setup enables recursive updates for future pulls. If that hook was never installed,
+run `mise run submodule-init` once after upgrading.
+GitHub's automatic “Source code” archives omit submodule contents. For a buildable release archive,
+use the attached `Memoh-<version>-source.zip` or `.tar.gz` asset instead.
+
 > **Use CN mirror for slow image pulls:**
 > ```bash
 > curl -fsSL https://memoh.sh | USE_CN_MIRROR=true sh

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,6 +60,12 @@ cp conf/app.docker.toml config.toml
 docker compose up -d
 ```
 
+执行过 setup 的已有仓库仍然可以继续使用 `git pull`：post-merge hook 会初始化新增的
+submodule，setup 也会为后续 pull 启用递归更新。如果从未安装过该 hook，升级后只需执行
+一次 `mise run submodule-init`。GitHub 自动生成的
+“Source code” 压缩包不包含 submodule，请改用 Release 附件中的
+`Memoh-<version>-source.zip` 或 `.tar.gz` 完整源码包。
+
 > **镜像拉取慢时可用国内镜像：**
 > ```bash
 > curl -fsSL https://memoh.sh | USE_CN_MIRROR=true sh

--- a/README_JA.md
+++ b/README_JA.md
@@ -62,6 +62,13 @@ cp conf/app.docker.toml config.toml
 docker compose up -d
 ```
 
+setup 済みの既存 checkout では、引き続き `git pull` を使用できます。post-merge hook
+が新しい submodule を初期化し、setup がそれ以降の pull で再帰更新を有効にします。
+hook が未導入の場合だけ、更新後に `mise run submodule-init` を一度実行してください。
+GitHub が自動生成する「Source code」
+アーカイブには submodule が含まれないため、Release に添付された
+`Memoh-<version>-source.zip` または `.tar.gz` を使用してください。
+
 > **イメージの pull が遅い場合は CN mirror を利用できます:**
 > ```bash
 > curl -fsSL https://memoh.sh | USE_CN_MIRROR=true sh

--- a/bump.config.ts
+++ b/bump.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'bumpp'
 
 export default defineConfig({
-  recursive: true,
+  files: [
+    'package.json',
+    'packages/sdk/package.json',
+    'packages/icons/package.json',
+    'packages/config/package.json',
+    'apps/web/package.json',
+    'apps/desktop/package.json',
+  ],
   commit: 'release: v%s',
   tag: 'v%s',
   push: true,

--- a/mise.toml
+++ b/mise.toml
@@ -26,7 +26,7 @@ experimental = true
 
 [tasks.submodule-init]
 description = "Init/update git submodules (packages/ui lives in memohai/ui)"
-run = "git submodule update --init --recursive"
+run = "node scripts/ensure-submodules.mjs"
 
 [tasks.pnpm-install]
 description = "Install dependencies"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.15.0",
   "scripts": {
+    "preinstall": "node scripts/ensure-submodules.mjs --check",
     "web:dev": "pnpm --filter @memohai/web dev",
     "web:build": "pnpm --filter @memohai/web build",
     "web:start": "pnpm --filter @memohai/web start",

--- a/scripts/ensure-submodules.mjs
+++ b/scripts/ensure-submodules.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, rmSync, rmdirSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const uiPath = join(root, 'packages', 'ui')
+const uiPackage = join(uiPath, 'package.json')
+const checkOnly = process.argv.includes('--check')
+
+function instruction() {
+  return 'Run `mise run submodule-init` or `git submodule update --init --recursive`, then run the command again.'
+}
+
+function fail(message) {
+  console.error(`\nError: ${message}`)
+  console.error(instruction())
+  process.exit(1)
+}
+
+function git(args, { optional = false } = {}) {
+  const result = spawnSync('git', args, { cwd: root, stdio: optional ? 'ignore' : 'inherit' })
+  if (!optional && result.status !== 0)
+    fail('Git could not initialize the packages/ui submodule.')
+  return result.status === 0
+}
+
+if (!existsSync(join(root, '.gitmodules')))
+  process.exit(0)
+
+if (checkOnly) {
+  if (!existsSync(uiPackage))
+    fail('packages/ui is not initialized, so the @felinic/ui workspace is missing.')
+  process.exit(0)
+}
+
+if (!existsSync(uiPackage) && existsSync(uiPath)) {
+  const entries = readdirSync(uiPath)
+  const safeLegacyEntries = new Set(['node_modules', '.DS_Store'])
+  const unexpected = entries.filter(entry => !safeLegacyEntries.has(entry))
+
+  if (unexpected.length > 0)
+    fail(`packages/ui contains files that Git must not overwrite: ${unexpected.join(', ')}`)
+
+  for (const entry of entries)
+    rmSync(join(uiPath, entry), { recursive: true, force: true })
+  rmdirSync(uiPath)
+}
+
+console.log('Initializing packages/ui submodule...')
+git(['submodule', 'sync', '--recursive'])
+git(['submodule', 'update', '--init', '--recursive'])
+git(['config', 'submodule.recurse', 'true'], { optional: true })
+
+if (!existsSync(uiPackage))
+  fail('packages/ui was not initialized successfully.')
+
+console.log('packages/ui is ready. Future `git pull` commands will recurse into initialized submodules.')


### PR DESCRIPTION
## Summary

- keep ordinary `git pull` working across the directory-to-submodule migration
- fail `pnpm install` clearly when `packages/ui` is missing
- prevent bumpp from modifying the UI submodule during local releases
- publish complete source archives that include submodule contents
- replace Agent skill symlinks with cross-platform forwarding directories

## Migration behavior

`scripts/ensure-submodules.mjs` is shared by mise and the Husky post-merge hook. It removes only known generated leftovers (`node_modules` and `.DS_Store`) before initializing `packages/ui`; any other content stops the migration without overwriting files. It also sets local `submodule.recurse=true`, so subsequent plain `git pull` commands update initialized submodules.

## Verification

- simulated a pre-#758 checkout with installed UI node_modules, then upgraded using plain `git pull`
- verified unexpected files under `packages/ui` are preserved and stop initialization
- verified missing-submodule `pnpm install` exits with an actionable error
- verified bumpp patch changes only the six host-owned package manifests and leaves the UI submodule clean
- generated and inspected complete ZIP and tar.gz source archives
- verified skill discovery with `core.symlinks=false`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @felinic/ui type-check`
- `pnpm web:build`
- ESLint on a clean-checkout-equivalent file set
- full pre-commit Go lint and test suite
