### PR TITLE
fix(web): copy submodule check into Docker builder

### DIFF
--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -7,9 +7,9 @@ RUN npm install -g pnpm@10
 
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY patches ./patches
-# Root postinstall verifies patchedDependencies content; the script must exist
-# before `pnpm install` or the lifecycle hook fails the build.
-COPY scripts/check-patched-deps.mjs ./scripts/
+# Root lifecycle hooks validate the UI submodule and patched dependencies; both
+# scripts must exist before `pnpm install` runs preinstall and postinstall.
+COPY scripts/ensure-submodules.mjs scripts/check-patched-deps.mjs ./scripts/
 
 COPY packages ./packages
 COPY apps ./apps


### PR DESCRIPTION
## Summary

- copy `scripts/ensure-submodules.mjs` into the Web Docker builder before `pnpm install`
- keep the Docker lifecycle-hook comment aligned with both root preinstall and postinstall checks

## Root cause

#763 added a root preinstall hook that runs `node scripts/ensure-submodules.mjs --check`, but `docker/Dockerfile.web` only copied the postinstall checker into the trimmed Docker build context. Both Web architecture builds therefore failed with `MODULE_NOT_FOUND` before dependency installation completed.

## Verification

- `git diff --check`
- `node scripts/ensure-submodules.mjs --check`
- `node scripts/check-patched-deps.mjs`
- `docker build --file docker/Dockerfile.web --target builder --tag memoh-web-ci-fix-check .`
  - root preinstall passed
  - root postinstall passed
  - Vite production build passed