### PR TITLE
fix(web): refine workspace divider rendering

### DIFF
--- a/apps/web/src/components/master-detail-sidebar-layout/index.vue
+++ b/apps/web/src/components/master-detail-sidebar-layout/index.vue
@@ -21,7 +21,7 @@
         <div
           class="flex-1 flex flex-col overflow-hidden min-h-0"
           :class="flush
-            ? 'bg-sidebar border-r border-sidebar-border'
+            ? 'workspace-divider-r bg-sidebar'
             : 'border border-border-soft bg-muted/10 rounded-lg'"
         >
           <!-- Integrated Header (if provided) -->

--- a/apps/web/src/components/settings-sidebar/index.vue
+++ b/apps/web/src/components/settings-sidebar/index.vue
@@ -10,7 +10,7 @@
   >
     <Sidebar
       collapsible="none"
-      :class="['border-r border-sidebar-border', desktopShell && 'h-dvh']"
+      :class="['workspace-divider-r', desktopShell && 'h-dvh']"
     >
       <div
         v-if="macTrafficReserve"

--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -6,7 +6,7 @@
        transitioned, so the resize handle still tracks the pointer 1:1. `inert`
        while closed so focus can't tab into the parked-off-screen rail. -->
   <aside
-    class="relative flex shrink-0 flex-col border-r border-sidebar-border bg-sidebar"
+    class="workspace-divider-r relative flex shrink-0 flex-col bg-sidebar"
     :style="asideStyle"
     :inert="!workbenchOpen || undefined"
   >

--- a/apps/web/src/pages/home/components/dockview/workspace-tab.vue
+++ b/apps/web/src/pages/home/components/dockview/workspace-tab.vue
@@ -16,6 +16,32 @@
       aria-hidden="true"
       focusable="false"
     >
+      <defs>
+        <linearGradient
+          :id="activeTabStrokeGradientId"
+          x1="0"
+          y1="0"
+          x2="1"
+          y2="0"
+        >
+          <stop
+            offset="0%"
+            stop-color="var(--dock-stroke)"
+          />
+          <stop
+            offset="5%"
+            stop-color="var(--workspace-tab-outline-color)"
+          />
+          <stop
+            offset="95%"
+            stop-color="var(--workspace-tab-outline-color)"
+          />
+          <stop
+            offset="100%"
+            stop-color="var(--dock-stroke)"
+          />
+        </linearGradient>
+      </defs>
       <path
         :d="activeTabFillPath"
         fill="var(--surface-editor)"
@@ -23,9 +49,8 @@
       <path
         :d="activeTabStrokePath"
         fill="none"
-        stroke="var(--dock-stroke)"
-        stroke-width="1"
-        vector-effect="non-scaling-stroke"
+        :stroke="`url(#${activeTabStrokeGradientId})`"
+        :stroke-width="activeTabStrokeWidth"
       />
     </svg>
     <!-- ui-allow-z: same tab-local stack as the root div above — this label
@@ -97,7 +122,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { X } from 'lucide-vue-next'
 import { Button } from '@felinic/ui'
@@ -118,6 +143,8 @@ const { t } = useI18n()
 const workspaceTabs = useWorkspaceTabsStore()
 
 const rootEl = ref<HTMLElement | null>(null)
+const DEFAULT_WORKSPACE_TAB_STROKE_WIDTH = 1
+const activeTabStrokeGradientId = `active-tab-stroke-${useId()}`
 const panelId = props.params.api.id
 const title = ref(props.params.api.title ?? '')
 const isActive = ref(props.params.api.isActive)
@@ -130,7 +157,7 @@ const isActive = ref(props.params.api.isActive)
 // carry this per-group signal the shape needs.
 const isVisible = ref(props.params.api.isVisible)
 // First-paint placeholder ONLY — these mirror the CSS contract (200≈12.5rem tab,
-// 35 = 40px strip − 5px inset, 8 = --tab-radius, 1px stroke) just so the active
+// 35 = 40px strip − 5px inset, 8 = --tab-radius, workspace hairline stroke) so the active
 // SVG has a sane shape for the one frame before onMounted measures the real DOM.
 // updateActiveTabShape() overwrites all of it; do NOT treat these as a source of
 // truth — the CSS tokens are. They exist because the path can't be empty pre-mount.
@@ -138,8 +165,9 @@ const initialTabShape = buildActiveTabShape({
   width: 200,
   height: 35,
   radius: 8,
-  strokeWidth: 1,
+  strokeWidth: DEFAULT_WORKSPACE_TAB_STROKE_WIDTH,
 })
+const activeTabStrokeWidth = ref(DEFAULT_WORKSPACE_TAB_STROKE_WIDTH)
 const activeTabViewBox = ref(initialTabShape.viewBox)
 const activeTabFillPath = ref(initialTabShape.fillPath)
 const activeTabStrokePath = ref(initialTabShape.strokePath)
@@ -273,6 +301,7 @@ function updateActiveTabShape() {
   const alignedBottom = snapToDevicePixel(tabRect.bottom, scale)
   const width = alignedRight - alignedLeft
   const height = alignedBottom - alignedTop
+  const strokeWidth = readWorkspaceTabStrokeWidth(tab)
   const radius = Math.min(
     snapToDevicePixel(readTabRadius(tab), scale),
     Math.max(0, width / 2),
@@ -283,9 +312,10 @@ function updateActiveTabShape() {
     width,
     height,
     radius,
-    strokeWidth: 1,
+    strokeWidth,
   })
 
+  activeTabStrokeWidth.value = strokeWidth
   activeTabViewBox.value = shape.viewBox
   activeTabFillPath.value = shape.fillPath
   activeTabStrokePath.value = shape.strokePath
@@ -295,6 +325,11 @@ function updateActiveTabShape() {
     width: `${formatPx(width + radius * 2)}`,
     height: `${formatPx(height)}`,
   }
+}
+
+function readWorkspaceTabStrokeWidth(tab: HTMLElement) {
+  const width = Number.parseFloat(getComputedStyle(tab).getPropertyValue('--workspace-tab-stroke-width'))
+  return Number.isFinite(width) && width > 0 ? width : DEFAULT_WORKSPACE_TAB_STROKE_WIDTH
 }
 
 function buildActiveTabShape({

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -69,6 +69,22 @@
    * separate .dark override is needed here. */
   --surface-chrome-hover: var(--sidebar-accent);
 
+  /* Workspace structural dividers separate the large shell planes (sidebar,
+   * dock groups, tab strip) without borrowing the darker component/card edge. */
+  --workspace-divider-width: 1.2px;
+  --workspace-tab-stroke-width: 1px;
+  --workspace-divider-color: rgb(240 239 237);
+  --workspace-tab-strip-color: color-mix(
+    in oklab,
+    var(--workspace-divider-color) 75%,
+    var(--border)
+  );
+  --workspace-tab-outline-color: color-mix(
+    in oklab,
+    var(--workspace-divider-color) 50%,
+    var(--border)
+  );
+
   /* Composer input surface — the chat input capsule. Differentiated from the
    * reading surface by COLOR in dark mode (gray body above the dark canvas),
    * but in light mode it stays the SAME pure white as the editor surface — a
@@ -110,6 +126,7 @@
   --surface-editor: var(--background);
   --surface-chrome: var(--sidebar);
   --surface-composer: var(--card);
+  --workspace-divider-color: var(--border);
   --composer-edge-rest: oklch(0.255 0 0);
   /* Dark = a solid deep purple ≈ rgb(83,45,141) with pure-white ink (a filled
    * "sent" bubble); same relative recipe, just a darker L and near-full C. */
@@ -125,6 +142,12 @@
   --color-chat-user-bubble: var(--chat-user-bubble);
   --color-chat-user-bubble-fg: var(--chat-user-bubble-fg);
   --color-cop-title: var(--cop-title);
+}
+
+/* Shell-divider owners outside dockview. Keep the colour role on the component;
+ * this utility only shares the workspace family's physical stroke width. */
+.workspace-divider-r {
+  border-right: var(--workspace-divider-width) solid var(--workspace-divider-color);
 }
 
 /* Chat composer edge — fainter at rest than a standard field, brightening to
@@ -1031,4 +1054,3 @@
     transform: none;
   }
 }
-

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -40,7 +40,7 @@
   --dv-tab-divider-color: transparent;
   --dv-tab-font-size: 12px;
 
-  --dv-separator-border: var(--border);
+  --dv-separator-border: var(--workspace-divider-color);
   --dv-sash-color: transparent;
   --dv-active-sash-color: var(--ring);
 
@@ -115,7 +115,7 @@
    *   is clipped.
    *
    * HOVER HEIGHT — the hover pill's TOP (only) drops by the active stroke width.
-   *   The active crown is a 1px STROKE whose solid core sits a stroke-width below
+   *   The active crown is the workspace hairline STROKE whose solid core sits a stroke-width below
    *   the chip's top edge; the hover pill is a solid FILL from its top edge up. At
    *   the same top y the fill therefore reads ~1px taller than the active crown.
    *   Trimming only the pill's top by --tab-active-stroke makes the two read as
@@ -129,7 +129,7 @@
    *   spill editor colour past the rounded corner onto the chrome strip. The
    *   close-fade is therefore a band centred on the 20px lane, never the full box.
    *
-   * DIVIDERS — two kinds, ONE stroke (--dock-stroke, --tab-active-stroke wide),
+   * DIVIDERS — two kinds, one shared tab stroke width (--tab-active-stroke),
    *   ONE height (--tab-divider-height = the glyph height, so the bar reads the
    *   same extent as the X/“+” icons beside it — a taller bar reads as "too high"
    *   even when centred), both centred on the 20px lane:
@@ -158,9 +158,10 @@
    *      .dv-tab to its right", DOM-order-independent and not relying on :last-child. */
   /* VERTICAL lane */
   --tab-inset: 0.3125rem;
-  /* The active crown/foot is a 1px stroke; single-sourced here so the hover-top
-   * trim that matches it can never drift from the SVG's stroke-width. */
-  --tab-active-stroke: 1px;
+  /* Keep the curved SVG crown on an integer hairline: fractional strokes look
+   * heavier around its arcs. This still single-sources the crown, hover trim,
+   * short tab seams, and SVG geometry while shell dividers use their own width. */
+  --tab-active-stroke: var(--workspace-tab-stroke-width);
   /* RADIUS — crown (and active SVG crown) vs the uniform floating hover pill */
   --tab-radius: var(--radius-md);
   --tab-hover-radius: var(--radius-sm);
@@ -222,11 +223,9 @@
   --tab-action-gap: 0.375rem;
   /* Shared timing for close-fade (workspace-tab.vue). Tab hover fill itself is instant. */
   --tab-hover-duration: 150ms;
-  /* ONE stroke colour for the whole dock outline — the strip's bottom hairline, the
-   * active tab's crown/side border, and the fillet-foot ring. It MUST be opaque, yet
-   * it must also read as the SAME line as the rest of the app's dividers (the sidebar's
-   * vertical --border, the panel seams): the dock is not a special-coloured zone, it
-   * just needs a special TECHNIQUE.
+  /* The tab strip sits one contrast rung above shell dividers. --dock-stroke
+   * paints its bottom hairline and short seams, and is also the endpoint colour
+   * where the active tab's stronger SVG outline rejoins that hairline.
    *
    * The design system's --border is a translucent white in dark mode (oklch(1 0 0/8%)).
    * Used directly it (a) reads at a different brightness on the chrome strip vs the
@@ -234,13 +233,10 @@
    * box-shadow vs a gradient ring), and (c) STACKS — where the foot ring overlaps the
    * side border the two translucent whites composite brighter, the "whitened fillet".
    *
-   * So --dock-stroke is the OPAQUE FLATTENING of that same --border over the chrome
-   * plane (8% white pre-composited onto --surface-chrome). It therefore lands at the
-   * exact brightness the sidebar's translucent --border already shows there — the
-   * horizontal hairline and the vertical sidebar divider become one continuous family —
-   * while being backdrop-/technique-independent and never building up. Light mode's
-   * --border is already opaque (no stacking), so it's reused as-is. */
-  --dock-stroke: var(--border);
+   * Dark mode therefore replaces the translucent token with its OPAQUE FLATTENING
+   * over the chrome plane, keeping overlapping paint techniques from building up. */
+  --dock-stroke: var(--workspace-tab-strip-color);
+  --tab-strip-junction-stroke: var(--workspace-divider-color);
 }
 
 /* Dark: the opaque equivalent of --border (8% white) sitting on the chrome plane, so
@@ -249,6 +245,8 @@
  * this single value is the one knob for the whole dock outline's weight. */
 .dark .dockview-theme-memoh {
   --dock-stroke: color-mix(in oklab, oklch(1 0 0) 8%, var(--surface-chrome));
+  --tab-strip-junction-stroke: var(--dock-stroke);
+  --workspace-tab-outline-color: var(--dock-stroke);
 }
 
 /* The custom tab content (workspace-tab.vue) owns its padding/ellipsis; .dv-tab
@@ -309,7 +307,7 @@
   /* Box coords: the tab box is already top-offset by margin-top:--tab-inset, so
    * top sits --tab-inset below the strip top. The TOP (only) is trimmed by the
    * active stroke width so the solid fill reads at the same optical height as the
-   * active crown's 1px stroke (whose solid core sits a stroke below its top edge).
+   * active crown's hairline stroke (whose solid core sits a stroke below its top edge).
    * right/bottom/left keep the equal --tab-inset margin — no such mismatch there. */
   top: var(--tab-active-stroke);
   right: var(--tab-hover-inset);
@@ -458,10 +456,26 @@
 
 /* Prefix actions container: renders navigation buttons before the tabs. */
 .dockview-theme-memoh .dv-pre-actions-container {
+  position: relative;
   display: flex;
   align-items: center;
   flex-shrink: 0;
   height: 100%;
+}
+
+/* The first group's nav cluster sits exactly where the lighter sidebar divider
+ * hands off to the stronger tab-strip hairline. Paint that container's measured
+ * width as the transition so web/desktop prefix padding can change without a
+ * hard-coded gradient stop. The strip-wide shadow remains underneath and carries
+ * the settled tab colour through the rest of the header. */
+.dockview-theme-memoh .dv-pre-actions-container::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  height: var(--workspace-divider-width);
+  background: linear-gradient(to right, var(--tab-strip-junction-stroke), var(--dock-stroke));
+  pointer-events: none;
 }
 
 /* The void is dockview's droppable empty-header region — it owns the
@@ -577,10 +591,49 @@
  * each tab, void, actions) and left the leftover gap after the last tab unlined. As a
  * single strip-wide shadow it spans nav · tabs · the leftover gap · void · actions in
  * one unbroken line. The active (and hovered) tab's OPAQUE background paints over this
- * 1px at its own slot, so that tab reads as continuous with the pane below
+ * hairline at its own slot, so that tab reads as continuous with the pane below
  * (punch-through); transparent inactive tabs and the leftover gap let the line show. */
 .dockview-theme-memoh .dv-tabs-and-actions-container {
-  box-shadow: inset 0 -1px 0 var(--dock-stroke);
+  box-shadow: inset 0 calc(-1 * var(--workspace-divider-width)) 0 var(--dock-stroke);
+}
+
+/* Dockview keeps a 4px sash hit target for comfortable resizing, while these
+ * rules reduce only the visible workspace divider and active sash indicator. */
+.dockview-theme-memoh .dv-split-view-container.dv-horizontal > .dv-view-container > .dv-view:not(:first-child)::before {
+  width: var(--workspace-divider-width);
+}
+
+.dockview-theme-memoh .dv-split-view-container.dv-vertical > .dv-view-container > .dv-view:not(:first-child)::before {
+  height: var(--workspace-divider-width);
+}
+
+.dockview-theme-memoh .dv-split-view-container > .dv-sash-container > .dv-sash {
+  background-color: transparent;
+}
+
+.dockview-theme-memoh .dv-split-view-container > .dv-sash-container > .dv-sash::after {
+  content: '';
+  position: absolute;
+  background-color: transparent;
+  pointer-events: none;
+}
+
+.dockview-theme-memoh .dv-split-view-container.dv-horizontal > .dv-sash-container > .dv-sash::after {
+  inset-block: 0;
+  left: 50%;
+  width: var(--workspace-divider-width);
+  transform: translateX(-50%);
+}
+
+.dockview-theme-memoh .dv-split-view-container.dv-vertical > .dv-sash-container > .dv-sash::after {
+  inset-inline: 0;
+  top: 50%;
+  height: var(--workspace-divider-width);
+  transform: translateY(-50%);
+}
+
+.dockview-theme-memoh .dv-split-view-container > .dv-sash-container > .dv-sash:not(.disabled):is(:hover, :active)::after {
+  background-color: var(--ring);
 }
 
 /* No vertical inter-tab divider lines: selecting a tab changes only fill, stroke,
@@ -715,7 +768,7 @@
    * panel is one continuous ground, split from the editor only by the border. */
   background-color: var(--surface-editor);
   box-shadow: none;
-  border-top: 1px solid var(--border);
+  border-top: var(--workspace-divider-width) solid var(--workspace-divider-color);
   height: auto;
   min-height: calc(1.6875rem + 0.375rem);
   padding-block: 0.1875rem;


### PR DESCRIPTION
## Summary

- fix active-tab SVG stroke rasterization in browsers by removing non-scaling stroke behavior and keeping curved geometry on an integer hairline
- introduce shared workspace divider width and color roles for shell, dock strip, and active-tab outlines
- blend the navigation-prefix hairline from the sidebar divider into the stronger tab-strip divider
- preserve the existing dark-mode flattened stroke behavior

## Verification

- visually verified on the Web client at multiple iterations
- `pnpm --filter @memohai/web exec vue-tsc --noEmit`
- targeted ESLint for the changed Vue components
- `node scripts/check-ui-contract.mjs`
- commit hooks: frontend lint, Go lint, and Go tests