### PR TITLE
fix(web): restore create bot tile

### DIFF
--- a/apps/web/src/pages/bots/index.vue
+++ b/apps/web/src/pages/bots/index.vue
@@ -104,6 +104,7 @@ import {
 import { Search, Plus, Upload } from 'lucide-vue-next'
 import { ref, computed, watch, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
+import PersonaTile from '@/components/persona-tile/index.vue'
 import BotCard from './components/bot-card.vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { getBotsQuery, getBotsQueryKey } from '@memohai/sdk/colada'


### PR DESCRIPTION
## Summary

- import the shared `PersonaTile` used by the Bots page create tile
- restore the missing Create Bot affordance
- remove the unresolved zero-width flex item that shifted a single bot card off the group center

## Regression

Introduced by `69d5ba29944124e83811436bd0335ba5e71a16db` when the inline create button was migrated to `PersonaTile` without importing the component in `apps/web/src/pages/bots/index.vue`.

## Verification

- `pnpm exec eslint apps/web/src/pages/bots/index.vue`
- `pnpm --filter @memohai/web build`
- visually verified in dark mode with one bot: Create Bot tile renders and the two-tile group is centered