### PR TITLE
test(web): refresh mocks after store refactors

### DIFF
--- a/apps/web/src/components/add-provider/index.test.ts
+++ b/apps/web/src/components/add-provider/index.test.ts
@@ -98,6 +98,7 @@ vi.mock('@felinic/ui', async () => {
   })
   return {
     Button: Passthrough,
+    FORM_ITEM_INJECTION_KEY: Symbol('form-item'),
     Input,
     FormField: Field,
     FormControl: Passthrough,

--- a/apps/web/src/pages/home/composables/useSubagentList.test.ts
+++ b/apps/web/src/pages/home/composables/useSubagentList.test.ts
@@ -5,6 +5,18 @@ import { useChatStore } from '@/store/chat-list'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { useSubagentList } from './useSubagentList'
 
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+    },
+  })
+})
+
 const api = vi.hoisted(() => ({
   connectWebSocket: vi.fn(),
   fetchBots: vi.fn(),
@@ -28,7 +40,10 @@ const colada = vi.hoisted(() => ({
   }),
 }))
 
-vi.mock('@/composables/api/useChat', () => api)
+vi.mock('@/composables/api/useChat', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/composables/api/useChat')>()
+  return { ...original, ...api }
+})
 vi.mock('@pinia/colada', () => ({ useQuery: colada.useQuery }))
 
 describe('useSubagentList', () => {


### PR DESCRIPTION
## Summary

- keep the useSubagentList test isolated on Node versions that expose an incomplete global localStorage
- partially mock the aggregated useChat module so unrelated exports added by store refactors remain available
- provide the form-item injection key required by the current FieldStack implementation in the add-provider test

These failures were test mock/isolation drift rather than production regressions. Production Web build and Desktop typecheck already passed before the test changes.

## Testing

- pnpm exec vitest run apps/web/src/pages/home/composables/useSubagentList.test.ts apps/web/src/components/add-provider/index.test.ts (9 tests)
- pnpm exec vitest run (72 files, 780 tests)
- pnpm exec eslint apps/web/src/pages/home/composables/useSubagentList.test.ts apps/web/src/components/add-provider/index.test.ts
- commit hooks: Go tests, Go lint, staged ESLint
