### PR TITLE
feat(models): add optional model descriptions

### DIFF
--- a/apps/web/src/components/create-model/index.vue
+++ b/apps/web/src/components/create-model/index.vue
@@ -95,6 +95,27 @@
             </FieldStack>
           </FormField>
 
+          <FormField
+            v-slot="{ componentField }"
+            name="description"
+          >
+            <FieldStack for="create-model-description">
+              <template #label>
+                <Label for="create-model-description">
+                  {{ $t('models.description') }}
+                  <span class="text-muted-foreground text-xs ml-1">({{ $t('common.optional') }})</span>
+                </Label>
+              </template>
+              <FormControl>
+                <Textarea
+                  id="create-model-description"
+                  :placeholder="$t('models.descriptionPlaceholder')"
+                  v-bind="componentField"
+                />
+              </FormControl>
+            </FieldStack>
+          </FormField>
+
           <!-- Dimensions (embedding only) -->
           <FormField
             v-if="selectedType === 'embedding'"
@@ -179,6 +200,7 @@ import {
   SelectValue,
   Checkbox,
   Label,
+  Textarea,
 } from '@felinic/ui'
 import type { ButtonVariants } from '@felinic/ui'
 import { useForm } from 'vee-validate'
@@ -193,6 +215,7 @@ import { COMPATIBILITY_OPTIONS } from '@/constants/compatibilities'
 import FormDialogShell from '@/components/form-dialog-shell/index.vue'
 import FieldStack from '@/components/settings/field-stack.vue'
 import { useDialogMutation } from '@/composables/useDialogMutation'
+import { buildModelConfig } from './model-config'
 
 interface ModelTypeOption {
   value: string
@@ -207,6 +230,7 @@ const formSchema = toTypedSchema(z.object({
   type: z.string().min(1, t('models.typeRequired')),
   model_id: z.string().min(1, t('models.modelIdRequired')),
   name: z.string().optional(),
+  description: z.string().optional(),
   dimensions: z.coerce.number().min(1, t('models.dimensionsMin')).optional(),
   context_window: z.coerce.number().min(1, t('models.contextWindowMin')).optional(),
 }))
@@ -305,18 +329,14 @@ async function addModel() {
 
   if (!type || !model_id) return
 
-  const config: Record<string, unknown> = {}
-
-  if (type === 'embedding') {
-    const dim = form.values.dimensions ?? (isEdit ? fallback!.config?.dimensions : undefined)
-    if (dim) config.dimensions = dim
-  }
-
-  if (type === 'chat') {
-    config.compatibilities = selectedCompat.value
-    const ctxWin = form.values.context_window ?? (isEdit ? fallback!.config?.context_window : undefined)
-    if (ctxWin) config.context_window = ctxWin
-  }
+  const config = buildModelConfig({
+    type,
+    description: form.values.description,
+    dimensions: form.values.dimensions ?? (isEdit ? fallback!.config?.dimensions : undefined),
+    contextWindow: form.values.context_window ?? (isEdit ? fallback!.config?.context_window : undefined),
+    compatibilities: selectedCompat.value,
+    existing: isEdit ? fallback!.config : undefined,
+  })
 
   const payload: Record<string, unknown> = {
     type,
@@ -369,6 +389,7 @@ watch(open, async () => {
         // Older models stored name === model_id. Don't surface that as a
         // "custom" name in the field — treat it as empty so editing starts clean.
         name: name && name !== model_id ? name : '',
+        description: config?.description ?? '',
         dimensions: config?.dimensions,
         context_window: config?.context_window,
       },
@@ -380,6 +401,7 @@ watch(open, async () => {
         type: props.defaultType,
         model_id: '',
         name: '',
+        description: '',
         dimensions: undefined,
         context_window: undefined,
       },

--- a/apps/web/src/components/create-model/model-config.test.ts
+++ b/apps/web/src/components/create-model/model-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { buildModelConfig } from './model-config'
+
+describe('buildModelConfig', () => {
+  it('omits an empty description for a new model', () => {
+    expect(buildModelConfig({
+      type: 'chat',
+      description: '   ',
+      compatibilities: ['tool-call'],
+    })).toEqual({ compatibilities: ['tool-call'] })
+  })
+
+  it('trims a new description', () => {
+    expect(buildModelConfig({
+      type: 'chat',
+      description: '  General purpose model.  ',
+      compatibilities: [],
+    })).toEqual({
+      description: 'General purpose model.',
+      compatibilities: [],
+    })
+  })
+
+  it('preserves unknown config and explicit clearing while editing', () => {
+    expect(buildModelConfig({
+      type: 'chat',
+      description: '   ',
+      compatibilities: ['vision'],
+      contextWindow: 128000,
+      existing: {
+        description: 'Old description',
+        thinking_mode: 'adaptive',
+        reasoning_efforts: ['low', 'high'],
+      },
+    })).toEqual({
+      description: '',
+      compatibilities: ['vision'],
+      context_window: 128000,
+      thinking_mode: 'adaptive',
+      reasoning_efforts: ['low', 'high'],
+    })
+  })
+})

--- a/apps/web/src/components/create-model/model-config.ts
+++ b/apps/web/src/components/create-model/model-config.ts
@@ -1,0 +1,34 @@
+import type { ModelsModelConfig } from '@memohai/sdk'
+
+interface BuildModelConfigInput {
+  type: string
+  description?: string
+  dimensions?: number
+  contextWindow?: number
+  compatibilities: string[]
+  existing?: ModelsModelConfig
+}
+
+export function buildModelConfig(input: BuildModelConfigInput): ModelsModelConfig {
+  const config: ModelsModelConfig = { ...(input.existing ?? {}) }
+  const description = input.description?.trim() ?? ''
+
+  if (input.existing) config.description = description
+  else if (description) config.description = description
+  else delete config.description
+
+  if (input.type === 'embedding') {
+    config.dimensions = input.dimensions
+    delete config.compatibilities
+    delete config.context_window
+    delete config.reasoning_efforts
+    delete config.thinking_mode
+    return config
+  }
+
+  delete config.dimensions
+  config.compatibilities = input.compatibilities
+  if (input.contextWindow) config.context_window = input.contextWindow
+  else delete config.context_window
+  return config
+}

--- a/apps/web/src/components/model-description-tooltip/index.test.ts
+++ b/apps/web/src/components/model-description-tooltip/index.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+/* eslint-disable vue/one-component-per-file */
+
+import { createApp, defineComponent, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const TooltipPart = (name: string) => defineComponent({
+  name,
+  setup(_, { slots }) {
+    return () => h('div', { [`data-${name}`]: '' }, slots.default?.())
+  },
+})
+
+vi.mock('@felinic/ui', () => ({
+  Tooltip: TooltipPart('tooltip'),
+  TooltipContent: TooltipPart('tooltip-content'),
+  TooltipProvider: TooltipPart('tooltip-provider'),
+  TooltipTrigger: TooltipPart('tooltip-trigger'),
+}))
+
+describe('ModelDescriptionTooltip', () => {
+  let app: ReturnType<typeof createApp> | undefined
+  let root: HTMLDivElement | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    root?.remove()
+    app = undefined
+    root = undefined
+  })
+
+  async function mount(description?: string) {
+    const ModelDescriptionTooltip = (await import('./index.vue')).default
+    root = document.createElement('div')
+    document.body.append(root)
+    app = createApp({
+      render: () => h(ModelDescriptionTooltip, { description }, {
+        default: () => h('button', 'Model'),
+      }),
+    })
+    app.mount(root)
+    await nextTick()
+    return root
+  }
+
+  it('renders tooltip content for a non-empty description', async () => {
+    const el = await mount('  General purpose model.  ')
+    expect(el.querySelector('[data-tooltip-content]')?.textContent).toBe('General purpose model.')
+  })
+
+  it('renders only the trigger slot for an empty description', async () => {
+    const el = await mount('   ')
+    expect(el.textContent).toBe('Model')
+    expect(el.querySelector('[data-tooltip]')).toBeNull()
+  })
+})

--- a/apps/web/src/components/model-description-tooltip/index.vue
+++ b/apps/web/src/components/model-description-tooltip/index.vue
@@ -1,0 +1,24 @@
+<template>
+  <TooltipProvider v-if="normalizedDescription">
+    <Tooltip>
+      <TooltipTrigger as-child>
+        <slot />
+      </TooltipTrigger>
+      <TooltipContent class="max-w-80 whitespace-pre-wrap text-left leading-relaxed">
+        {{ normalizedDescription }}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+  <slot v-else />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@felinic/ui'
+
+const props = defineProps<{
+  description?: string | null
+}>()
+
+const normalizedDescription = computed(() => props.description?.trim() || '')
+</script>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -944,6 +944,8 @@
     "modelIdRequired": "Model ID is required",
     "displayName": "Display Name",
     "displayNamePlaceholder": "Custom display name",
+    "description": "Description",
+    "descriptionPlaceholder": "Briefly describe the model's purpose or strengths",
     "dimensions": "Dimensions",
     "dimensionsPlaceholder": "e.g. 1536",
     "dimensionsMin": "Dimensions must be greater than 0",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -896,6 +896,8 @@
     "modelIdRequired": "モデル ID を入力してください",
     "displayName": "表示名",
     "displayNamePlaceholder": "カスタム表示名",
+    "description": "モデルの説明",
+    "descriptionPlaceholder": "モデルの用途や特徴を簡潔に入力",
     "dimensions": "寸法",
     "dimensionsPlaceholder": "例: 1536",
     "dimensionsMin": "次元数は 0 より大きい値にしてください",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -944,6 +944,8 @@
     "modelIdRequired": "请填写模型 ID",
     "displayName": "显示名称",
     "displayNamePlaceholder": "自定义显示名称",
+    "description": "模型说明",
+    "descriptionPlaceholder": "简要说明模型的用途或特点",
     "dimensions": "向量维度",
     "dimensionsPlaceholder": "例如 1536",
     "dimensionsMin": "向量维度需大于 0",

--- a/apps/web/src/pages/bots/components/model-options.vue
+++ b/apps/web/src/pages/bots/components/model-options.vue
@@ -44,28 +44,32 @@
           {{ vRow.row.label }}
         </div>
 
-        <button
+        <ModelDescriptionTooltip
           v-else
-          :id="`${listboxId}-${vRow.virtual.index}`"
-          type="button"
-          role="option"
-          :aria-selected="modelValue === vRow.row.option.value"
-          :aria-setsize="optionCount"
-          :aria-posinset="vRow.row.posinset"
-          :data-highlighted="activeIndex === vRow.virtual.index ? '' : undefined"
-          :class="menuItemClass"
-          @click="$emit('update:modelValue', vRow.row.option.value)"
-          @pointermove="activeIndex = vRow.virtual.index"
+          :description="vRow.row.option.description"
         >
-          <span
-            class="min-w-0 flex-1 truncate text-left"
-            :title="vRow.row.option.label"
-          >{{ vRow.row.option.label }}</span>
-          <Check
-            v-if="modelValue === vRow.row.option.value"
-            class="ml-2 size-4 shrink-0"
-          />
-        </button>
+          <button
+            :id="`${listboxId}-${vRow.virtual.index}`"
+            type="button"
+            role="option"
+            :aria-selected="modelValue === vRow.row.option.value"
+            :aria-setsize="optionCount"
+            :aria-posinset="vRow.row.posinset"
+            :data-highlighted="activeIndex === vRow.virtual.index ? '' : undefined"
+            :class="menuItemClass"
+            @click="$emit('update:modelValue', vRow.row.option.value)"
+            @pointermove="activeIndex = vRow.virtual.index"
+          >
+            <span
+              class="min-w-0 flex-1 truncate text-left"
+              :title="vRow.row.option.label"
+            >{{ vRow.row.option.label }}</span>
+            <Check
+              v-if="modelValue === vRow.row.option.value"
+              class="ml-2 size-4 shrink-0"
+            />
+          </button>
+        </ModelDescriptionTooltip>
       </div>
     </div>
   </div>
@@ -78,10 +82,13 @@ import { Check } from 'lucide-vue-next'
 import { menuItemClass, menuLabelClass, menuSearchHeaderClass, menuSearchInputClass, virtualListboxClass } from '@felinic/ui'
 import type { ModelsGetResponse, ModelsModelType, ProvidersGetResponse } from '@memohai/sdk'
 import { useListboxKeyboard } from '@/composables/useListboxKeyboard'
+import ModelDescriptionTooltip from '@/components/model-description-tooltip/index.vue'
+import { getModelDescription, matchesModelSearch } from '@/utils/model-description'
 
 export interface ModelOption {
   value: string
   label: string
+  modelId: string
   description?: string
   groupKey: string
   groupLabel: string
@@ -151,7 +158,8 @@ const options = computed<ModelOption[]>(() =>
     return {
       value: model.id || model.model_id || '',
       label: model.name || model.model_id || '',
-      description: model.name ? model.model_id : undefined,
+      modelId: model.model_id || '',
+      description: getModelDescription(model.config),
       groupKey: providerId,
       groupLabel: providerMap.value.get(providerId) ?? providerId,
       keywords: [model.model_id ?? '', model.name ?? ''],
@@ -166,6 +174,7 @@ const noneOption = computed<ModelOption | undefined>(() =>
     ? {
         value: '',
         label: props.noneLabel,
+        modelId: '',
         description: undefined,
         groupKey: '',
         groupLabel: '',
@@ -178,11 +187,7 @@ const filteredOptions = computed(() => {
   const keyword = searchTerm.value.trim().toLowerCase()
   if (!keyword) return options.value
   return options.value.filter((opt) => {
-    const terms = [opt.label, opt.description, ...opt.keywords]
-      .filter((t): t is string => Boolean(t))
-      .join(' ')
-      .toLowerCase()
-    return terms.includes(keyword)
+    return matchesModelSearch(keyword, [opt.label, opt.modelId, opt.description, ...opt.keywords])
   })
 })
 

--- a/apps/web/src/pages/home/components/chat-model-picker.vue
+++ b/apps/web/src/pages/home/components/chat-model-picker.vue
@@ -65,14 +65,16 @@
                 class="group/row relative flex items-center gap-1 rounded-md px-1 transition-colors duration-75"
                 :class="modelValue === vRow.row.option.value ? 'bg-[var(--overlay-hover)]' : 'hover:bg-[var(--overlay-hover-light)]'"
               >
-                <button
-                  type="button"
-                  class="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-control"
-                  :class="modelValue === vRow.row.option.value ? 'font-medium text-foreground' : 'text-foreground'"
-                  @click="commitModel(vRow.row.option.value)"
-                >
-                  <span class="min-w-0 flex-1 truncate">{{ vRow.row.option.label }}</span>
-                </button>
+                <ModelDescriptionTooltip :description="vRow.row.option.description">
+                  <button
+                    type="button"
+                    class="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-control"
+                    :class="modelValue === vRow.row.option.value ? 'font-medium text-foreground' : 'text-foreground'"
+                    @click="commitModel(vRow.row.option.value)"
+                  >
+                    <span class="min-w-0 flex-1 truncate">{{ vRow.row.option.label }}</span>
+                  </button>
+                </ModelDescriptionTooltip>
 
                 <div class="flex shrink-0 items-center gap-1 pr-1">
                   <Check
@@ -160,6 +162,8 @@ import {
   resolveEffortLevels,
   availableEffortsForMode,
 } from '@/pages/bots/components/reasoning-effort'
+import ModelDescriptionTooltip from '@/components/model-description-tooltip/index.vue'
+import { getModelDescription, matchesModelSearch } from '@/utils/model-description'
 
 const props = defineProps<{
   models: ModelsGetResponse[]
@@ -197,6 +201,8 @@ const typeFilteredModels = computed(() =>
 interface ModelOption {
   value: string
   label: string
+  modelId: string
+  description?: string
   groupKey: string
   groupLabel: string
   config: ModelsGetResponse['config']
@@ -223,6 +229,8 @@ const options = computed<ModelOption[]>(() =>
     return {
       value: model.id || model.model_id || '',
       label: model.name || model.model_id || '',
+      modelId: model.model_id || '',
+      description: getModelDescription(model.config),
       groupKey: providerId,
       groupLabel: providerMap.value.get(providerId) ?? providerId,
       config: model.config,
@@ -234,9 +242,7 @@ const options = computed<ModelOption[]>(() =>
 const filteredGroups = computed(() => {
   const keyword = searchTerm.value.trim().toLowerCase()
   const filtered = keyword
-    ? options.value.filter((opt) =>
-        [opt.label, opt.value].some((s) => s.toLowerCase().includes(keyword)),
-      )
+    ? options.value.filter(opt => matchesModelSearch(keyword, [opt.label, opt.modelId, opt.description]))
     : options.value
 
   const groups = new Map<string, { key: string; label: string; items: ModelOption[] }>()

--- a/apps/web/src/pages/providers/components/model-item.test.ts
+++ b/apps/web/src/pages/providers/components/model-item.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+/* eslint-disable vue/no-deprecated-model-definition, vue/one-component-per-file */
+
+import { createApp, defineComponent, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const SlotComponent = (name: string) => defineComponent({
+  name,
+  setup(_, { slots }) {
+    return () => h('div', slots.default?.())
+  },
+})
+
+const EmptyComponent = (name: string) => defineComponent({
+  name,
+  setup() {
+    return () => h('span')
+  },
+})
+
+vi.mock('@felinic/ui', () => ({
+  Badge: SlotComponent('Badge'),
+  Button: SlotComponent('Button'),
+  Spinner: EmptyComponent('Spinner'),
+  Switch: EmptyComponent('Switch'),
+  toast: { error: vi.fn() },
+}))
+
+vi.mock('lucide-vue-next', () => ({
+  Binary: EmptyComponent('Binary'),
+  Settings: EmptyComponent('Settings'),
+  Trash2: EmptyComponent('Trash2'),
+  Zap: EmptyComponent('Zap'),
+}))
+
+vi.mock('@/components/confirm-popover/index.vue', () => ({
+  default: SlotComponent('ConfirmPopover'),
+}))
+
+vi.mock('@/components/model-description-tooltip/index.vue', () => ({
+  default: SlotComponent('ModelDescriptionTooltip'),
+}))
+
+vi.mock('@memohai/sdk', () => ({
+  postModelsByIdTest: vi.fn(),
+  putModelsById: vi.fn(),
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useQueryCache: () => ({ invalidateQueries: vi.fn() }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+describe('Provider model item', () => {
+  let app: ReturnType<typeof createApp> | undefined
+  let root: HTMLDivElement | undefined
+
+  afterEach(() => {
+    app?.unmount()
+    root?.remove()
+    app = undefined
+    root = undefined
+  })
+
+  async function mount(description?: string) {
+    const ModelItem = (await import('./model-item.vue')).default
+    root = document.createElement('div')
+    document.body.append(root)
+    app = createApp(ModelItem, {
+      model: {
+        id: 'model-1',
+        provider_id: 'provider-1',
+        model_id: 'gpt-5.4',
+        name: 'GPT-5.4',
+        type: 'chat',
+        enable: true,
+        config: description === undefined ? {} : { description },
+      },
+      deleteLoading: false,
+    })
+    app.config.globalProperties.$t = (key: string) => key
+    app.mount(root)
+    await nextTick()
+    return root
+  }
+
+  it('shows the model description below the model metadata', async () => {
+    const el = await mount('General-purpose model with vision and tool calling.')
+
+    const description = el.querySelector('[data-model-description]')
+    expect(description?.textContent?.trim()).toBe(
+      'General-purpose model with vision and tool calling.',
+    )
+    expect(description?.classList).toContain('line-clamp-2')
+  })
+
+  it('does not reserve a description row when the model has no description', async () => {
+    const el = await mount()
+
+    expect(el.querySelector('[data-model-description]')).toBeNull()
+  })
+})

--- a/apps/web/src/pages/providers/components/model-item.vue
+++ b/apps/web/src/pages/providers/components/model-item.vue
@@ -14,9 +14,11 @@
       :class="{ 'pl-1': searchAligned }"
     >
       <div class="flex min-w-0 items-center gap-2">
-        <span class="truncate text-[13px] font-medium text-foreground">
-          {{ model.name || model.model_id }}
-        </span>
+        <ModelDescriptionTooltip :description="modelDescription">
+          <span class="truncate text-[13px] font-medium text-foreground">
+            {{ model.name || model.model_id }}
+          </span>
+        </ModelDescriptionTooltip>
         <Badge
           v-if="model.type === 'embedding'"
           variant="outline"
@@ -123,11 +125,13 @@ import {
 } from '@felinic/ui'
 import { Zap, Settings, Trash2, Binary } from 'lucide-vue-next'
 import ConfirmPopover from '@/components/confirm-popover/index.vue'
+import ModelDescriptionTooltip from '@/components/model-description-tooltip/index.vue'
 import { postModelsByIdTest, putModelsById } from '@memohai/sdk'
 import type { ModelsGetResponse, ModelsTestResponse, ModelsUpdateRequest } from '@memohai/sdk'
 import { useQueryCache } from '@pinia/colada'
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { getModelDescription } from '@/utils/model-description'
 
 const props = withDefaults(defineProps<{
   model: ModelsGetResponse
@@ -150,6 +154,7 @@ const enableLoading = ref(false)
 const enableOverride = ref<boolean | null>(null)
 
 const enabled = computed(() => enableOverride.value ?? props.model.enable ?? true)
+const modelDescription = computed(() => getModelDescription(props.model.config))
 
 // Show the id as a second line only when a real custom name is hiding it.
 const showModelId = computed(() => {

--- a/apps/web/src/pages/providers/components/model-item.vue
+++ b/apps/web/src/pages/providers/components/model-item.vue
@@ -63,6 +63,13 @@
           {{ testResult?.message }}
         </span>
       </div>
+      <p
+        v-if="modelDescription"
+        data-model-description
+        class="mt-1 line-clamp-2 whitespace-pre-wrap break-words text-body text-muted-foreground"
+      >
+        {{ modelDescription }}
+      </p>
     </div>
 
     <div class="flex shrink-0 items-center gap-0.5">

--- a/apps/web/src/utils/model-description.test.ts
+++ b/apps/web/src/utils/model-description.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { getModelDescription, matchesModelSearch } from './model-description'
+
+describe('model description helpers', () => {
+  it('normalizes optional config descriptions', () => {
+    expect(getModelDescription({ description: '  Fast coding model.  ' })).toBe('Fast coding model.')
+    expect(getModelDescription({ description: '   ' })).toBeUndefined()
+    expect(getModelDescription(undefined)).toBeUndefined()
+  })
+
+  it('matches a model by description', () => {
+    expect(matchesModelSearch('coding', ['GPT', 'gpt-test', 'Fast coding model.'])).toBe(true)
+    expect(matchesModelSearch('vision', ['GPT', 'gpt-test', 'Fast coding model.'])).toBe(false)
+  })
+})

--- a/apps/web/src/utils/model-description.ts
+++ b/apps/web/src/utils/model-description.ts
@@ -1,0 +1,12 @@
+export function getModelDescription(config: unknown): string | undefined {
+  if (!config || typeof config !== 'object') return undefined
+  const description = (config as { description?: unknown }).description
+  if (typeof description !== 'string') return undefined
+  return description.trim() || undefined
+}
+
+export function matchesModelSearch(query: string, values: Array<string | undefined>): boolean {
+  const keyword = query.trim().toLowerCase()
+  if (!keyword) return true
+  return values.some(value => value?.toLowerCase().includes(keyword))
+}

--- a/conf/providers/openai.yaml
+++ b/conf/providers/openai.yaml
@@ -8,6 +8,7 @@ models:
     name: GPT-5.4
     type: chat
     config:
+      description: General-purpose OpenAI model with vision, tool calling, and configurable reasoning.
       compatibilities: [vision, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle

--- a/db/postgres/queries/models.sql
+++ b/db/postgres/queries/models.sql
@@ -188,7 +188,11 @@ VALUES (sqlc.arg(model_id), sqlc.arg(name), sqlc.arg(provider_id), sqlc.arg(type
 ON CONFLICT (provider_id, model_id) DO UPDATE SET
   name = EXCLUDED.name,
   type = EXCLUDED.type,
-  config = EXCLUDED.config,
+  config = CASE
+    WHEN models.config ? 'description'
+      THEN EXCLUDED.config || jsonb_build_object('description', models.config -> 'description')
+    ELSE EXCLUDED.config
+  END,
   updated_at = now()
 RETURNING *;
 

--- a/internal/db/postgres/sqlc/models.sql.go
+++ b/internal/db/postgres/sqlc/models.sql.go
@@ -1456,7 +1456,11 @@ VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (provider_id, model_id) DO UPDATE SET
   name = EXCLUDED.name,
   type = EXCLUDED.type,
-  config = EXCLUDED.config,
+  config = CASE
+    WHEN models.config ? 'description'
+      THEN EXCLUDED.config || jsonb_build_object('description', models.config -> 'description')
+    ELSE EXCLUDED.config
+  END,
   updated_at = now()
 RETURNING id, model_id, name, provider_id, type, enable, config, created_at, updated_at
 `

--- a/internal/handlers/providers.go
+++ b/internal/handlers/providers.go
@@ -357,6 +357,7 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 			name = m.ID
 		}
 		cfg := models.ModelConfig{
+			Description:      m.Description,
 			Compatibilities:  compatibilities,
 			ReasoningEfforts: m.ReasoningEfforts,
 			ThinkingMode:     m.ThinkingMode,
@@ -428,6 +429,11 @@ func (h *ProvidersHandler) fillExistingModel(ctx context.Context, providerID, mo
 func mergeDiscoveredConfig(existing, discovered models.ModelConfig) (models.ModelConfig, bool) {
 	out := existing
 	changed := false
+	if out.Description == nil && discovered.Description != nil {
+		description := strings.TrimSpace(*discovered.Description)
+		out.Description = &description
+		changed = true
+	}
 	// Capability-discovery fields: a present discovery wins. The fetch layer
 	// (applyCapabilities) has already let an explicit upstream claim take
 	// precedence over the registry, so whatever arrives here is the freshest

--- a/internal/handlers/providers_description_test.go
+++ b/internal/handlers/providers_description_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/models"
+)
+
+func descriptionPointer(value string) *string { return &value }
+
+func TestMergeDiscoveredConfigFillsOnlyMissingDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		existing   *string
+		discovered *string
+		want       *string
+		changed    bool
+	}{
+		{name: "fills missing", discovered: descriptionPointer("Template"), want: descriptionPointer("Template"), changed: true},
+		{name: "preserves user value", existing: descriptionPointer("Custom"), discovered: descriptionPointer("Template"), want: descriptionPointer("Custom")},
+		{name: "preserves explicit clear", existing: descriptionPointer(""), discovered: descriptionPointer("Template"), want: descriptionPointer("")},
+		{name: "ignores missing discovery"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := mergeDiscoveredConfig(
+				models.ModelConfig{Description: tt.existing},
+				models.ModelConfig{Description: tt.discovered},
+			)
+			if changed != tt.changed {
+				t.Fatalf("changed = %v, want %v", changed, tt.changed)
+			}
+			if tt.want == nil {
+				if got.Description != nil {
+					t.Fatalf("description = %q, want nil", *got.Description)
+				}
+				return
+			}
+			if got.Description == nil || *got.Description != *tt.want {
+				t.Fatalf("description = %v, want %q", got.Description, *tt.want)
+			}
+		})
+	}
+}

--- a/internal/models/description_test.go
+++ b/internal/models/description_test.go
@@ -1,0 +1,34 @@
+package models
+
+import "testing"
+
+func stringPointer(value string) *string { return &value }
+
+func TestNormalizeModelConfigDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   *string
+		want *string
+	}{
+		{name: "missing remains missing"},
+		{name: "value is trimmed", in: stringPointer("  General purpose model.  "), want: stringPointer("General purpose model.")},
+		{name: "explicit empty remains present", in: stringPointer("   "), want: stringPointer("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := normalizeModelConfig(ModelConfig{Description: tt.in})
+			if tt.want == nil {
+				if cfg.Description != nil {
+					t.Fatalf("description = %q, want nil", *cfg.Description)
+				}
+				return
+			}
+			if cfg.Description == nil || *cfg.Description != *tt.want {
+				t.Fatalf("description = %v, want %q", cfg.Description, *tt.want)
+			}
+		})
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -40,6 +40,7 @@ func NewService(log *slog.Logger, queries dbstore.Queries) *Service {
 // Create adds a new model to the database.
 func (s *Service) Create(ctx context.Context, req AddRequest) (AddResponse, error) {
 	model := req.toModel(ResolveEnable(req.Enable, true))
+	model.Config = normalizeModelConfig(model.Config)
 	if err := model.Validate(); err != nil {
 		return AddResponse{}, fmt.Errorf("validation failed: %w", err)
 	}
@@ -263,6 +264,7 @@ func (s *Service) UpdateByID(ctx context.Context, id string, req UpdateRequest) 
 	}
 
 	model := req.toModel(ResolveEnable(req.Enable, current.Enable))
+	model.Config = normalizeModelConfig(model.Config)
 	if err := model.Validate(); err != nil {
 		return GetResponse{}, fmt.Errorf("validation failed: %w", err)
 	}
@@ -321,6 +323,7 @@ func (s *Service) UpdateByModelID(ctx context.Context, modelID string, req Updat
 	}
 
 	model := req.toModel(ResolveEnable(req.Enable, current.Enable))
+	model.Config = normalizeModelConfig(model.Config)
 	if err := model.Validate(); err != nil {
 		return GetResponse{}, fmt.Errorf("validation failed: %w", err)
 	}

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -110,11 +111,20 @@ var validThinkingModes = map[string]struct{}{
 // ThinkingMode is the discovered thinking behavior; empty = unknown (legacy data),
 // resolved via SupportsReasoning / ResolveThinkingMode.
 type ModelConfig struct {
+	Description      *string  `json:"description,omitempty"`
 	Dimensions       *int     `json:"dimensions,omitempty"`
 	Compatibilities  []string `json:"compatibilities,omitempty"`
 	ContextWindow    *int     `json:"context_window,omitempty"`
 	ReasoningEfforts []string `json:"reasoning_efforts,omitempty"`
 	ThinkingMode     string   `json:"thinking_mode,omitempty"`
+}
+
+func normalizeModelConfig(config ModelConfig) ModelConfig {
+	if config.Description != nil {
+		description := strings.TrimSpace(*config.Description)
+		config.Description = &description
+	}
+	return config
 }
 
 type Model struct {

--- a/internal/providers/description_test.go
+++ b/internal/providers/description_test.go
@@ -1,0 +1,29 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/registry"
+)
+
+func TestRemoteModelsFromTemplateIncludesOptionalDescription(t *testing.T) {
+	t.Parallel()
+
+	models := remoteModelsFromTemplate(registry.ProviderDefinition{
+		Models: []registry.ModelDefinition{{
+			ModelID: "gpt-test",
+			Name:    "GPT Test",
+			Type:    "chat",
+			Config: map[string]any{
+				"description": "  Template description.  ",
+			},
+		}},
+	})
+
+	if len(models) != 1 {
+		t.Fatalf("models count = %d, want 1", len(models))
+	}
+	if models[0].Description == nil || *models[0].Description != "Template description." {
+		t.Fatalf("description = %v, want trimmed template description", models[0].Description)
+	}
+}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -391,6 +391,7 @@ func remoteModelsFromTemplate(def registry.ProviderDefinition) []RemoteModel {
 		out = append(out, RemoteModel{
 			ID:               model.ModelID,
 			Name:             model.Name,
+			Description:      configStringPtr(cfg, "description"),
 			Type:             modelType,
 			Compatibilities:  configStringSlice(cfg, "compatibilities"),
 			ReasoningEfforts: configStringSlice(cfg, "reasoning_efforts"),
@@ -589,6 +590,18 @@ func configStringSlice(cfg map[string]any, key string) []string {
 	default:
 		return nil
 	}
+}
+
+func configStringPtr(cfg map[string]any, key string) *string {
+	if cfg == nil {
+		return nil
+	}
+	value, ok := cfg[key].(string)
+	if !ok {
+		return nil
+	}
+	value = strings.TrimSpace(value)
+	return &value
 }
 
 func configIntPtr(cfg map[string]any, key string) *int {

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -100,6 +100,7 @@ type OAuthAuthorizeResponse struct {
 // RemoteModel represents a model returned by the provider's /v1/models endpoint.
 type RemoteModel struct {
 	ID               string   `json:"id"`
+	Description      *string  `json:"description,omitempty"`
 	Object           string   `json:"object"`
 	Created          int64    `json:"created"`
 	OwnedBy          string   `json:"owned_by"`

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -158,7 +158,12 @@ func (f *fakeQueries) UpsertRegistryModel(_ context.Context, arg sqlc.UpsertRegi
 		if f.models[i].ProviderID == arg.ProviderID && f.models[i].ModelID == arg.ModelID {
 			f.models[i].Name = arg.Name
 			f.models[i].Type = arg.Type
-			f.models[i].Config = append([]byte(nil), arg.Config...)
+			existingConfig := jsonMapBytes(f.models[i].Config)
+			incomingConfig := jsonMapBytes(arg.Config)
+			if description, ok := existingConfig["description"]; ok {
+				incomingConfig["description"] = description
+			}
+			f.models[i].Config, _ = json.Marshal(incomingConfig)
 			return f.models[i], nil
 		}
 	}
@@ -174,6 +179,14 @@ func (f *fakeQueries) UpsertRegistryModel(_ context.Context, arg sqlc.UpsertRegi
 	f.models = append(f.models, m)
 	f.modelInserts++
 	return m, nil
+}
+
+func jsonMapBytes(raw []byte) map[string]any {
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
 }
 
 // mutateProvider applies direct row edits, standing in for the raw SQL UPDATEs
@@ -308,6 +321,38 @@ func TestSyncTwiceIsIdempotent(t *testing.T) {
 		t.Fatalf("model row id changed across syncs: %s -> %s", modelRowID.String(), q.models[0].ID.String())
 	}
 	assertRegistrySource(t, q.providers[0].Metadata, "openai.yaml")
+}
+
+func TestSyncSeedsDescriptionThenPreservesUserOverride(t *testing.T) {
+	ctx := context.Background()
+	q := newFakeQueries()
+	logger := discardLogger()
+
+	def := openAIDefinition()
+	def.Models[0].Config["description"] = "Template description"
+	if err := Sync(ctx, logger, q, []ProviderDefinition{def}); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if got := jsonMap(t, q.models[0].Config)["description"]; got != "Template description" {
+		t.Fatalf("description = %#v, want template description", got)
+	}
+
+	q.models[0].Config = []byte(`{"context_window":128000,"description":"Custom description"}`)
+	def.Models[0].Config["description"] = "Updated template description"
+	if err := Sync(ctx, logger, q, []ProviderDefinition{def}); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if got := jsonMap(t, q.models[0].Config)["description"]; got != "Custom description" {
+		t.Fatalf("description = %#v, want preserved custom description", got)
+	}
+
+	q.models[0].Config = []byte(`{"context_window":128000,"description":""}`)
+	if err := Sync(ctx, logger, q, []ProviderDefinition{def}); err != nil {
+		t.Fatalf("third sync: %v", err)
+	}
+	if got := jsonMap(t, q.models[0].Config)["description"]; got != "" {
+		t.Fatalf("description = %#v, want preserved explicit clear", got)
+	}
 }
 
 func TestSyncUpdatesProviderWhenRegistryNameChanges(t *testing.T) {

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -2329,6 +2329,7 @@ export type ModelsGetResponse = {
 export type ModelsModelConfig = {
     compatibilities?: Array<string>;
     context_window?: number;
+    description?: string;
     dimensions?: number;
     reasoning_efforts?: Array<string>;
     thinking_mode?: string;

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -18906,6 +18906,9 @@ const docTemplate = `{
                 "context_window": {
                     "type": "integer"
                 },
+                "description": {
+                    "type": "string"
+                },
                 "dimensions": {
                     "type": "integer"
                 },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -18897,6 +18897,9 @@
                 "context_window": {
                     "type": "integer"
                 },
+                "description": {
+                    "type": "string"
+                },
                 "dimensions": {
                     "type": "integer"
                 },

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -3883,6 +3883,8 @@ definitions:
         type: array
       context_window:
         type: integer
+      description:
+        type: string
       dimensions:
         type: integer
       reasoning_efforts:


### PR DESCRIPTION
## Summary

- add optional model descriptions under `config.description` across provider templates, model APIs, and generated SDK types
- preserve user-edited or explicitly cleared descriptions during registry sync and model re-import
- add model description editing, search, and hover/focus tooltips across provider, bot settings, and chat model pickers

## Validation

- `go test ./...` (commit hook)
- `golangci-lint run ./...` (commit hook)
- `pnpm vitest run apps/web/src/components/create-model/model-config.test.ts apps/web/src/components/model-description-tooltip/index.test.ts apps/web/src/utils/model-description.test.ts`
- `pnpm --filter @memohai/web exec vue-tsc --noEmit`
- `pnpm exec eslint . --ignore-pattern .claude/worktrees/**`
- `node scripts/check-ui-contract.mjs`
- manual UI verification in provider settings, bot model picker, and chat model picker