### PR TITLE
feat(providers): fetch Codex models dynamically

### DIFF
--- a/apps/web/src/pages/bots/components/reasoning-effort.test.ts
+++ b/apps/web/src/pages/bots/components/reasoning-effort.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { resolveEffortLevels } from './reasoning-effort'
+
+describe('resolveEffortLevels', () => {
+  it('preserves max for Codex and filters client-only efforts', () => {
+    expect(resolveEffortLevels({
+      reasoning_efforts: ['low', 'xhigh', 'max', 'ultra'],
+    }, 'openai-codex')).toEqual(['low', 'xhigh', 'max'])
+  })
+
+  it('filters max for generic OpenAI-format clients', () => {
+    expect(resolveEffortLevels({
+      reasoning_efforts: ['low', 'xhigh', 'max'],
+    }, 'openai-responses')).toEqual(['low', 'xhigh'])
+  })
+})

--- a/apps/web/src/pages/bots/components/reasoning-effort.ts
+++ b/apps/web/src/pages/bots/components/reasoning-effort.ts
@@ -9,9 +9,10 @@ export type ThinkingMode = 'toggle' | 'adaptive' | 'only_adaptive' | 'none'
 // Effort tiers the UI understands, ordered weakest → strongest.
 export const KNOWN_EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const
 
-// Keep in sync with isOpenAIReasoningWire in internal/conversation/flow/resolver.go
-// and the Twilight SDK's openai provider package.
-const OPENAI_FORMAT_CLIENT_TYPES = new Set(['openai-completions', 'openai-responses', 'openai-codex'])
+// Keep in sync with normalizesMaxReasoningEffort in internal/conversation/flow/resolver.go.
+// Generic OpenAI-format clients retain the existing max-to-xhigh compatibility
+// behavior; Codex uses the effort levels advertised by its catalog directly.
+const MAX_NORMALIZED_CLIENT_TYPES = new Set(['openai-completions', 'openai-responses'])
 
 export const EFFORT_LABELS: Record<string, string> = {
   [REASONING_EFFORT_DISABLE]: 'chat.reasoningOff',
@@ -56,15 +57,15 @@ export function resolveThinkingMode(config?: ModelConfigLike | null): ThinkingMo
 }
 
 // resolveEffortLevels returns the model's supported effort tiers (filtered to
-// known ones), falling back to the common low/medium/high subset. OpenAI-format
-// clients use xhigh as the highest effort tier, even when the underlying model
-// exposes an Anthropic-style max tier.
+// known ones), falling back to the common low/medium/high subset. Generic
+// OpenAI-format clients use xhigh as the highest effort tier, while Codex can
+// expose max directly.
 export function resolveEffortLevels(config?: ModelConfigLike | null, clientType?: string | null): string[] {
   const efforts = (config?.reasoning_efforts ?? []).filter((e) =>
     (KNOWN_EFFORTS as readonly string[]).includes(e),
   )
   const levels = efforts.length > 0 ? efforts : ['low', 'medium', 'high']
-  if (OPENAI_FORMAT_CLIENT_TYPES.has(clientType ?? '')) {
+  if (MAX_NORMALIZED_CLIENT_TYPES.has(clientType ?? '')) {
     return levels.filter((e) => e !== 'max')
   }
   return levels

--- a/conf/providers/codex.yaml
+++ b/conf/providers/codex.yaml
@@ -2,35 +2,3 @@ name: OpenAI Codex
 client_type: openai-codex
 icon: openai
 base_url: https://chatgpt.com/backend-api
-
-models:
-  - model_id: gpt-5.4
-    name: GPT-5.4
-    type: chat
-    config:
-      context_window: 1050000
-      compatibilities: [vision, tool-call, reasoning]
-      reasoning_efforts: [none, low, medium, high, xhigh]
-
-  - model_id: gpt-5.4-mini
-    name: GPT-5.4 mini
-    type: chat
-    config:
-      context_window: 400000
-      compatibilities: [vision, tool-call, reasoning]
-      reasoning_efforts: [none, low, medium, high, xhigh]
-
-  - model_id: gpt-5.3-codex
-    name: GPT-5.3 Codex
-    type: chat
-    config:
-      context_window: 400000
-      compatibilities: [vision, tool-call, reasoning]
-      reasoning_efforts: [low, medium, high, xhigh]
-
-  - model_id: gpt-5.3-codex-spark
-    name: GPT-5.3 Codex Spark (Research Preview)
-    type: chat
-    config:
-      context_window: 128000
-      compatibilities: [tool-call]

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/mailgun/mailgun-go/v5 v5.14.0
 	github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7
 	github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978
-	github.com/memohai/twilight-ai v0.4.1-0.20260708041258-f7bcb57fcaab
+	github.com/memohai/twilight-ai v0.4.1-0.20260713114708-c19f5170bfe6
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -513,6 +513,8 @@ github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978 h1:
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978/go.mod h1:2LMgK5QYFlTSvrGY+sI/j+jK2WK+YGHv4IMuiW+iPSc=
 github.com/memohai/twilight-ai v0.4.1-0.20260708041258-f7bcb57fcaab h1:Pl4dpUlmGWUi7/wEbIZt2PuGD4sO8VKutd7OnRbQx0A=
 github.com/memohai/twilight-ai v0.4.1-0.20260708041258-f7bcb57fcaab/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
+github.com/memohai/twilight-ai v0.4.1-0.20260713114708-c19f5170bfe6 h1:BdT1Pbef1v2GVNJCF9LuyIE4URkVU5fBMlpo633HfjU=
+github.com/memohai/twilight-ai v0.4.1-0.20260713114708-c19f5170bfe6/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=

--- a/internal/conversation/flow/resolver.go
+++ b/internal/conversation/flow/resolver.go
@@ -812,10 +812,11 @@ func pickEffort(requested string, botSettings settings.Settings, effortLevels []
 }
 
 // effectiveReasoningEfforts intersects the model's advertised effort levels
-// with the wire format's accepted set. OpenAI-format clients reject "max", so
-// it is excluded here. This is the primary filter; openAIWireEffort in
-// models/sdk.go and the Twilight SDK provider layer act as defence-in-depth.
-// Keep isOpenAIReasoningWire in sync with the frontend OPENAI_FORMAT_CLIENT_TYPES.
+// with the selected client's current wire policy. Generic OpenAI-format clients
+// retain the existing max-to-xhigh compatibility behavior, while Codex uses its
+// catalog levels directly. openAIWireEffort in models/sdk.go is defence-in-depth.
+// Keep normalizesMaxReasoningEffort in sync with the frontend
+// MAX_NORMALIZED_CLIENT_TYPES.
 func effectiveReasoningEfforts(effortLevels []string, clientType string) []string {
 	levels := effortLevels
 	if len(levels) == 0 {
@@ -823,7 +824,7 @@ func effectiveReasoningEfforts(effortLevels []string, clientType string) []strin
 	}
 	out := make([]string, 0, len(levels))
 	for _, e := range levels {
-		if isOpenAIReasoningWire(clientType) && e == models.ReasoningEffortMax {
+		if normalizesMaxReasoningEffort(clientType) && e == models.ReasoningEffortMax {
 			continue
 		}
 		if !hasEffort(out, e) {
@@ -833,11 +834,12 @@ func effectiveReasoningEfforts(effortLevels []string, clientType string) []strin
 	return out
 }
 
-// isOpenAIReasoningWire returns true for client types whose wire format rejects
-// "max" effort. Keep in sync with OPENAI_FORMAT_CLIENT_TYPES in reasoning-effort.ts.
-func isOpenAIReasoningWire(clientType string) bool {
+// normalizesMaxReasoningEffort reports whether the current compatibility policy
+// maps "max" to "xhigh". Keep in sync with MAX_NORMALIZED_CLIENT_TYPES in
+// reasoning-effort.ts.
+func normalizesMaxReasoningEffort(clientType string) bool {
 	switch models.ClientType(clientType) {
-	case models.ClientTypeOpenAICompletions, models.ClientTypeOpenAIResponses, models.ClientTypeOpenAICodex:
+	case models.ClientTypeOpenAICompletions, models.ClientTypeOpenAIResponses:
 		return true
 	default:
 		return false

--- a/internal/conversation/flow/resolver_model_selection_test.go
+++ b/internal/conversation/flow/resolver_model_selection_test.go
@@ -163,6 +163,14 @@ func TestResolveReasoningConfig(t *testing.T) {
 			},
 		},
 	}
+	codexModel := models.GetResponse{
+		Model: models.Model{
+			Config: models.ModelConfig{
+				ThinkingMode:     models.ThinkingModeToggle,
+				ReasoningEfforts: []string{"low", "medium", "high", "xhigh", "max"},
+			},
+		},
+	}
 	noneEffortModel := models.GetResponse{
 		Model: models.Model{
 			Config: models.ModelConfig{
@@ -267,11 +275,18 @@ func TestResolveReasoningConfig(t *testing.T) {
 			want:          &models.ReasoningConfig{Active: true, Adaptive: true, Effort: models.ReasoningEffortXHigh},
 		},
 		{
-			name:          "openai wire drops max and falls back to medium",
+			name:          "generic openai compatibility drops max and falls back to medium",
 			model:         adaptiveModel,
 			requestEffort: models.ReasoningEffortMax,
 			clientType:    string(models.ClientTypeOpenAICompletions),
 			want:          &models.ReasoningConfig{Active: true, Adaptive: true, Effort: models.ReasoningEffortMedium},
+		},
+		{
+			name:          "codex wire preserves max",
+			model:         codexModel,
+			requestEffort: models.ReasoningEffortMax,
+			clientType:    string(models.ClientTypeOpenAICodex),
+			want:          &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortMax},
 		},
 		{
 			name:          "anthropic wire preserves max",

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -40,6 +40,19 @@ func TestModel_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid chat model with ultra reasoning",
+			model: models.Model{
+				ModelID:    "gpt-5.6-sol",
+				Name:       "GPT-5.6-Sol",
+				ProviderID: "11111111-1111-1111-1111-111111111111",
+				Type:       models.ModelTypeChat,
+				Config: models.ModelConfig{
+					ReasoningEfforts: []string{"low", "medium", "high", "xhigh", "max", "ultra"},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid embedding model",
 			model: models.Model{
 				ModelID:    "text-embedding-ada-002",

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -40,7 +40,7 @@ func TestModel_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "valid chat model with ultra reasoning",
+			name: "invalid chat model with unsupported reasoning effort",
 			model: models.Model{
 				ModelID:    "gpt-5.6-sol",
 				Name:       "GPT-5.6-Sol",
@@ -50,7 +50,7 @@ func TestModel_Validate(t *testing.T) {
 					ReasoningEfforts: []string{"low", "medium", "high", "xhigh", "max", "ultra"},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "valid embedding model",

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -191,7 +191,7 @@ func BuildReasoningOptions(cfg SDKModelConfig) []sdk.GenerateOption {
 		case rc.Disabled:
 			return []sdk.GenerateOption{sdk.WithReasoningEffort(ReasoningEffortNone)}
 		case rc.Active && rc.Effort != "":
-			return []sdk.GenerateOption{sdk.WithReasoningEffort(openAIWireEffort(rc.Effort))}
+			return []sdk.GenerateOption{sdk.WithReasoningEffort(openAIWireEffort(ct, rc.Effort))}
 		default:
 			return nil
 		}
@@ -214,20 +214,20 @@ func BuildReasoningOptions(cfg SDKModelConfig) []sdk.GenerateOption {
 		return nil
 
 	case ClientTypeOpenAIResponses, ClientTypeOpenAICodex, ClientTypeOpenAICompletions:
-		return openAIEffortOptions(rc)
+		return openAIEffortOptions(ct, rc)
 
 	default:
-		return openAIEffortOptions(rc)
+		return openAIEffortOptions(ct, rc)
 	}
 }
 
 // openAIEffortOptions maps a reasoning decision to OpenAI-style reasoning.effort.
 // OpenAI models have no real on/off switch, so "off" is approximated by the
 // lowest effort the model supports (none when available, otherwise minimal).
-func openAIEffortOptions(rc *ReasoningConfig) []sdk.GenerateOption {
+func openAIEffortOptions(clientType ClientType, rc *ReasoningConfig) []sdk.GenerateOption {
 	switch {
 	case rc.Active:
-		effort := openAIWireEffort(rc.Effort)
+		effort := openAIWireEffort(clientType, rc.Effort)
 		if effort == "" {
 			effort = ReasoningEffortMedium
 		}
@@ -239,7 +239,7 @@ func openAIEffortOptions(rc *ReasoningConfig) []sdk.GenerateOption {
 		// When the model advertises no such off-ish tier, OffEffort is empty and
 		// we omit reasoning_effort entirely so the provider default (no thinking
 		// for toggle/Anthropic-compat models) applies.
-		off := openAIWireEffort(rc.OffEffort)
+		off := openAIWireEffort(clientType, rc.OffEffort)
 		if off == "" {
 			return nil
 		}
@@ -249,13 +249,10 @@ func openAIEffortOptions(rc *ReasoningConfig) []sdk.GenerateOption {
 	}
 }
 
-// openAIWireEffort is a last-resort guard that rewrites effort values the
-// OpenAI wire format rejects. The primary filter lives in the resolver's
-// effectiveReasoningEfforts (which removes "max" from the selectable set for
-// OpenAI-format clients), and the Twilight SDK's openai provider package
-// also normalizes max→xhigh independently. This function is defence-in-depth.
-func openAIWireEffort(effort string) string {
-	if effort == ReasoningEffortMax {
+// openAIWireEffort retains the generic OpenAI clients' existing max-to-xhigh
+// compatibility behavior. Codex accepts the catalog-advertised max value.
+func openAIWireEffort(clientType ClientType, effort string) string {
+	if clientType != ClientTypeOpenAICodex && effort == ReasoningEffortMax {
 		return ReasoningEffortXHigh
 	}
 	return effort

--- a/internal/models/sdk_test.go
+++ b/internal/models/sdk_test.go
@@ -387,6 +387,17 @@ func TestNewSDKChatModelOpenAIWireMapsMaxEffortToXHigh(t *testing.T) {
 	}
 }
 
+func TestOpenAIWireEffortPreservesMaxForCodex(t *testing.T) {
+	t.Parallel()
+
+	if got := openAIWireEffort(ClientTypeOpenAICodex, ReasoningEffortMax); got != ReasoningEffortMax {
+		t.Fatalf("openAIWireEffort() = %q, want %q", got, ReasoningEffortMax)
+	}
+	if got := openAIWireEffort(ClientTypeOpenAIResponses, ReasoningEffortMax); got != ReasoningEffortXHigh {
+		t.Fatalf("openAIWireEffort() = %q, want %q", got, ReasoningEffortXHigh)
+	}
+}
+
 func TestNewSDKChatModelAnthropicThinkingWire(t *testing.T) {
 	t.Parallel()
 

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -98,6 +98,12 @@ var validReasoningEfforts = map[string]struct{}{
 	ReasoningEffortUltra:   {},
 }
 
+// IsValidReasoningEffort reports whether effort can be stored in ModelConfig.
+func IsValidReasoningEffort(effort string) bool {
+	_, ok := validReasoningEfforts[effort]
+	return ok
+}
+
 var validThinkingModes = map[string]struct{}{
 	ThinkingModeAdaptive:     {},
 	ThinkingModeToggle:       {},
@@ -162,7 +168,7 @@ func (m *Model) Validate() error {
 		}
 	}
 	for _, effort := range m.Config.ReasoningEfforts {
-		if _, ok := validReasoningEfforts[effort]; !ok {
+		if !IsValidReasoningEffort(effort) {
 			return errors.New("invalid reasoning effort: " + effort)
 		}
 	}

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -60,6 +60,7 @@ const (
 	ReasoningEffortHigh    = "high"
 	ReasoningEffortXHigh   = "xhigh"
 	ReasoningEffortMax     = "max"
+	ReasoningEffortUltra   = "ultra"
 )
 
 // ThinkingMode describes how a model's extended-thinking control behaves. It is
@@ -94,6 +95,7 @@ var validReasoningEfforts = map[string]struct{}{
 	ReasoningEffortHigh:    {},
 	ReasoningEffortXHigh:   {},
 	ReasoningEffortMax:     {},
+	ReasoningEffortUltra:   {},
 }
 
 var validThinkingModes = map[string]struct{}{

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -60,7 +60,6 @@ const (
 	ReasoningEffortHigh    = "high"
 	ReasoningEffortXHigh   = "xhigh"
 	ReasoningEffortMax     = "max"
-	ReasoningEffortUltra   = "ultra"
 )
 
 // ThinkingMode describes how a model's extended-thinking control behaves. It is
@@ -95,7 +94,6 @@ var validReasoningEfforts = map[string]struct{}{
 	ReasoningEffortHigh:    {},
 	ReasoningEffortXHigh:   {},
 	ReasoningEffortMax:     {},
-	ReasoningEffortUltra:   {},
 }
 
 // IsValidReasoningEffort reports whether effort can be stored in ModelConfig.

--- a/internal/providers/codex_models.go
+++ b/internal/providers/codex_models.go
@@ -115,7 +115,7 @@ func (s *Service) listCodexRemoteModels(ctx context.Context, baseURL string, cre
 		reasoningEfforts := make([]string, 0, len(model.SupportedReasoningLevels))
 		for _, level := range model.SupportedReasoningLevels {
 			effort := strings.TrimSpace(level.Effort)
-			if effort != "" && !containsFold(reasoningEfforts, effort) {
+			if models.IsValidReasoningEffort(effort) && !containsFold(reasoningEfforts, effort) {
 				reasoningEfforts = append(reasoningEfforts, effort)
 			}
 		}

--- a/internal/providers/codex_models.go
+++ b/internal/providers/codex_models.go
@@ -1,0 +1,155 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/models"
+)
+
+const (
+	codexDefaultBaseURL = "https://chatgpt.com/backend-api"
+	// The catalog endpoint uses the client version for model-availability gates.
+	// Use the stable protocol target instead of coupling discovery to Memoh's release version.
+	codexModelsClientVersion  = "1.0.0"
+	codexModelsResponseLimit  = 8 << 20
+	codexModelsErrorBodyLimit = 16 << 10
+)
+
+type codexModelsResponse struct {
+	Models []codexModelInfo `json:"models"`
+}
+
+type codexModelInfo struct {
+	Slug                     string                       `json:"slug"`
+	DisplayName              string                       `json:"display_name"`
+	Visibility               string                       `json:"visibility"`
+	SupportedReasoningLevels []codexReasoningEffortPreset `json:"supported_reasoning_levels"`
+	ContextWindow            *int                         `json:"context_window"`
+	MaxContextWindow         *int                         `json:"max_context_window"`
+	InputModalities          []string                     `json:"input_modalities"`
+}
+
+type codexReasoningEffortPreset struct {
+	Effort string `json:"effort"`
+}
+
+func (s *Service) fetchCodexRemoteModels(ctx context.Context, provider sqlc.Provider) ([]RemoteModel, error) {
+	creds, err := s.ResolveModelCredentials(ctx, provider)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Codex credentials: %w", err)
+	}
+	baseURL := strings.TrimSpace(configString(providerConfig(provider.Config), "base_url"))
+	return s.listCodexRemoteModels(ctx, baseURL, creds)
+}
+
+func (s *Service) listCodexRemoteModels(ctx context.Context, baseURL string, creds ModelCredentials) ([]RemoteModel, error) {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = codexDefaultBaseURL
+	}
+	endpoint, err := url.Parse(strings.TrimRight(baseURL, "/") + "/codex/models")
+	if err != nil {
+		return nil, fmt.Errorf("parse Codex models URL: %w", err)
+	}
+	query := endpoint.Query()
+	query.Set("client_version", codexModelsClientVersion)
+	endpoint.RawQuery = query.Encode()
+
+	requestCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create Codex models request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+creds.APIKey)
+	req.Header.Set("chatgpt-account-id", creds.CodexAccountID)
+	req.Header.Set("OpenAI-Beta", "responses=experimental")
+	req.Header.Set("originator", "codex_cli_rs")
+	req.Header.Set("Accept", "application/json")
+
+	httpClient := s.httpClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: providerOAuthHTTPTimeout}
+	}
+	resp, err := httpClient.Do(req) //nolint:gosec // Provider base URLs are explicitly user-configurable throughout model discovery.
+	if err != nil {
+		return nil, fmt.Errorf("request Codex models: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, codexModelsErrorBodyLimit))
+		detail := strings.TrimSpace(string(body))
+		if detail == "" {
+			detail = http.StatusText(resp.StatusCode)
+		}
+		return nil, fmt.Errorf("codex models request failed (%d): %s", resp.StatusCode, detail)
+	}
+
+	var catalog codexModelsResponse
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, codexModelsResponseLimit))
+	if err := decoder.Decode(&catalog); err != nil {
+		return nil, fmt.Errorf("decode Codex models response: %w", err)
+	}
+
+	remoteModels := make([]RemoteModel, 0, len(catalog.Models))
+	for _, model := range catalog.Models {
+		modelID := strings.TrimSpace(model.Slug)
+		if modelID == "" || !strings.EqualFold(strings.TrimSpace(model.Visibility), "list") {
+			continue
+		}
+		name := strings.TrimSpace(model.DisplayName)
+		if name == "" {
+			name = modelID
+		}
+
+		compatibilities := []string{models.CompatToolCall}
+		if containsFold(model.InputModalities, "image") {
+			compatibilities = append(compatibilities, models.CompatVision)
+		}
+		reasoningEfforts := make([]string, 0, len(model.SupportedReasoningLevels))
+		for _, level := range model.SupportedReasoningLevels {
+			effort := strings.TrimSpace(level.Effort)
+			if effort != "" && !containsFold(reasoningEfforts, effort) {
+				reasoningEfforts = append(reasoningEfforts, effort)
+			}
+		}
+		thinkingMode := models.ThinkingModeNone
+		if len(reasoningEfforts) > 0 {
+			compatibilities = append(compatibilities, models.CompatReasoning)
+			thinkingMode = models.ThinkingModeToggle
+		}
+		contextWindow := model.ContextWindow
+		if contextWindow == nil {
+			contextWindow = model.MaxContextWindow
+		}
+
+		remoteModels = append(remoteModels, RemoteModel{
+			ID:               modelID,
+			Name:             name,
+			DisplayName:      name,
+			Object:           "model",
+			OwnedBy:          "openai-codex",
+			Type:             string(models.ModelTypeChat),
+			Compatibilities:  compatibilities,
+			ReasoningEfforts: reasoningEfforts,
+			ThinkingMode:     thinkingMode,
+			ContextWindow:    contextWindow,
+		})
+	}
+	return remoteModels, nil
+}
+
+func containsFold(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), target) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 	githubcopilot "github.com/memohai/twilight-ai/provider/github/copilot"
-	openaicodex "github.com/memohai/twilight-ai/provider/openai/codex"
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	memohcopilot "github.com/memohai/memoh/internal/copilot"
@@ -335,16 +334,19 @@ func (s *Service) FetchRemoteModels(ctx context.Context, id string) ([]RemoteMod
 		return nil, fmt.Errorf("get provider: %w", err)
 	}
 
+	clientType := models.ClientType(provider.ClientType)
+	if clientType == models.ClientTypeOpenAICodex {
+		return s.fetchCodexRemoteModels(ctx, provider)
+	}
+
 	if models, ok := s.fetchTemplateModels(provider); ok {
 		return models, nil
 	}
 
 	var remoteModels []RemoteModel
-	switch {
-	case models.ClientType(provider.ClientType) == models.ClientTypeGitHubCopilot:
+	switch clientType {
+	case models.ClientTypeGitHubCopilot:
 		remoteModels, err = s.fetchGitHubCopilotModels(ctx, provider)
-	case supportsOAuth(provider):
-		remoteModels = fetchCodexCatalogModels()
 	default:
 		remoteModels, err = s.fetchRemoteModelsViaSDK(ctx, provider)
 	}
@@ -429,30 +431,6 @@ func (s *Service) fetchGitHubCopilotModels(ctx context.Context, provider sqlc.Pr
 		})
 	}
 	return remoteModels, nil
-}
-
-func fetchCodexCatalogModels() []RemoteModel {
-	catalog := openaicodex.Catalog()
-	remoteModels := make([]RemoteModel, 0, len(catalog))
-	for _, model := range catalog {
-		compatibilities := make([]string, 0, 2)
-		if model.SupportsToolCall {
-			compatibilities = append(compatibilities, models.CompatToolCall)
-		}
-		if model.SupportsReasoning {
-			compatibilities = append(compatibilities, models.CompatReasoning)
-		}
-		remoteModels = append(remoteModels, RemoteModel{
-			ID:               model.ID,
-			Name:             model.DisplayName,
-			Object:           "model",
-			OwnedBy:          "openai-codex",
-			Type:             "chat",
-			Compatibilities:  compatibilities,
-			ReasoningEfforts: append([]string(nil), model.ReasoningEfforts...),
-		})
-	}
-	return remoteModels
 }
 
 func (s *Service) fetchRemoteModelsViaSDK(ctx context.Context, provider sqlc.Provider) ([]RemoteModel, error) {

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -128,6 +128,7 @@ func TestListCodexRemoteModels(t *testing.T) {
 						{"effort": "low"},
 						{"effort": "medium"},
 						{"effort": "high"},
+						{"effort": "future"},
 						{"effort": "xhigh"},
 						{"effort": "max"},
 						{"effort": "ultra"},

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -95,6 +95,86 @@ models:
 	}
 }
 
+func TestListCodexRemoteModels(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/backend-api/codex/models" {
+			t.Fatalf("path = %q, want /backend-api/codex/models", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("client_version"); got != codexModelsClientVersion {
+			t.Fatalf("client_version = %q, want %q", got, codexModelsClientVersion)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
+			t.Fatalf("authorization = %q", got)
+		}
+		if got := r.Header.Get("chatgpt-account-id"); got != "acct_123" {
+			t.Fatalf("chatgpt-account-id = %q", got)
+		}
+		if got := r.Header.Get("originator"); got != "codex_cli_rs" {
+			t.Fatalf("originator = %q", got)
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{
+				{
+					"slug":         "gpt-5.6-sol",
+					"display_name": "GPT-5.6-Sol",
+					"visibility":   "list",
+					"supported_reasoning_levels": []map[string]any{
+						{"effort": "low"},
+						{"effort": "medium"},
+						{"effort": "high"},
+						{"effort": "xhigh"},
+						{"effort": "max"},
+						{"effort": "ultra"},
+					},
+					"context_window":   372000,
+					"input_modalities": []string{"text", "image"},
+				},
+				{
+					"slug":                       "internal-model",
+					"display_name":               "Internal Model",
+					"visibility":                 "hide",
+					"supported_reasoning_levels": []map[string]any{{"effort": "medium"}},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	svc := &Service{httpClient: server.Client()}
+	remoteModels, err := svc.listCodexRemoteModels(context.Background(), server.URL+"/backend-api", ModelCredentials{
+		APIKey:         "access-token",
+		CodexAccountID: "acct_123",
+	})
+	if err != nil {
+		t.Fatalf("list Codex models: %v", err)
+	}
+	if len(remoteModels) != 1 {
+		t.Fatalf("models = %d, want 1", len(remoteModels))
+	}
+	model := remoteModels[0]
+	if model.ID != "gpt-5.6-sol" || model.Name != "GPT-5.6-Sol" {
+		t.Fatalf("unexpected model: %#v", model)
+	}
+	if got := strings.Join(model.Compatibilities, ","); got != "tool-call,vision,reasoning" {
+		t.Fatalf("compatibilities = %q", got)
+	}
+	if got := strings.Join(model.ReasoningEfforts, ","); got != "low,medium,high,xhigh,max,ultra" {
+		t.Fatalf("reasoning efforts = %q", got)
+	}
+	if model.ThinkingMode != models.ThinkingModeToggle {
+		t.Fatalf("thinking mode = %q", model.ThinkingMode)
+	}
+	if model.ContextWindow == nil || *model.ContextWindow != 372000 {
+		t.Fatalf("context window = %#v", model.ContextWindow)
+	}
+}
+
 func TestNormalizeProviderConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -98,24 +98,23 @@ models:
 func TestListCodexRemoteModels(t *testing.T) {
 	t.Parallel()
 
+	type observedRequest struct {
+		method        string
+		path          string
+		clientVersion string
+		authorization string
+		accountID     string
+		originator    string
+	}
+	requestCh := make(chan observedRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Fatalf("method = %s, want GET", r.Method)
-		}
-		if r.URL.Path != "/backend-api/codex/models" {
-			t.Fatalf("path = %q, want /backend-api/codex/models", r.URL.Path)
-		}
-		if got := r.URL.Query().Get("client_version"); got != codexModelsClientVersion {
-			t.Fatalf("client_version = %q, want %q", got, codexModelsClientVersion)
-		}
-		if got := r.Header.Get("Authorization"); got != "Bearer access-token" {
-			t.Fatalf("authorization = %q", got)
-		}
-		if got := r.Header.Get("chatgpt-account-id"); got != "acct_123" {
-			t.Fatalf("chatgpt-account-id = %q", got)
-		}
-		if got := r.Header.Get("originator"); got != "codex_cli_rs" {
-			t.Fatalf("originator = %q", got)
+		requestCh <- observedRequest{
+			method:        r.Method,
+			path:          r.URL.Path,
+			clientVersion: r.URL.Query().Get("client_version"),
+			authorization: r.Header.Get("Authorization"),
+			accountID:     r.Header.Get("chatgpt-account-id"),
+			originator:    r.Header.Get("originator"),
 		}
 
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -155,6 +154,25 @@ func TestListCodexRemoteModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list Codex models: %v", err)
 	}
+	request := <-requestCh
+	if request.method != http.MethodGet {
+		t.Errorf("method = %s, want GET", request.method)
+	}
+	if request.path != "/backend-api/codex/models" {
+		t.Errorf("path = %q, want /backend-api/codex/models", request.path)
+	}
+	if request.clientVersion != codexModelsClientVersion {
+		t.Errorf("client_version = %q, want %q", request.clientVersion, codexModelsClientVersion)
+	}
+	if request.authorization != "Bearer access-token" {
+		t.Errorf("authorization = %q", request.authorization)
+	}
+	if request.accountID != "acct_123" {
+		t.Errorf("chatgpt-account-id = %q", request.accountID)
+	}
+	if request.originator != "codex_cli_rs" {
+		t.Errorf("originator = %q", request.originator)
+	}
 	if len(remoteModels) != 1 {
 		t.Fatalf("models = %d, want 1", len(remoteModels))
 	}
@@ -165,7 +183,7 @@ func TestListCodexRemoteModels(t *testing.T) {
 	if got := strings.Join(model.Compatibilities, ","); got != "tool-call,vision,reasoning" {
 		t.Fatalf("compatibilities = %q", got)
 	}
-	if got := strings.Join(model.ReasoningEfforts, ","); got != "low,medium,high,xhigh,max,ultra" {
+	if got := strings.Join(model.ReasoningEfforts, ","); got != "low,medium,high,xhigh,max" {
 		t.Fatalf("reasoning efforts = %q", got)
 	}
 	if model.ThinkingMode != models.ThinkingModeToggle {


### PR DESCRIPTION
## What changed

- route every `openai-codex` provider through authenticated dynamic model discovery before preset-template lookup
- fetch `/backend-api/codex/models?client_version=1.0.0` with the provider OAuth token and ChatGPT account ID
- map remote visibility, input modalities, reasoning levels, and context-window metadata into importable Memoh models
- remove the static Codex model list from `conf/providers/codex.yaml`
- remove Memoh's use of Twilight's static `openaicodex.Catalog()`
- accept the newly advertised `ultra` reasoning level so models such as `gpt-5.6-sol` import successfully

## Why

Codex providers created from the UI preset previously read the frozen YAML model list, while OAuth Codex providers without preset metadata used Twilight's older static catalog. Both paths could miss models newly enabled for the authenticated ChatGPT account.

The Codex backend already exposes an account-aware model catalog, so model discovery should use that source of truth instead of duplicating model IDs and capabilities in Memoh.

## Impact

Both preset-derived and metadata-free OAuth Codex providers now discover the same current, account-visible catalog. Hidden entries are excluded, while model names, vision support, reasoning efforts, and context windows are preserved for import.

## Validation

- `go test ./internal/providers ./internal/models ./internal/registry ./internal/handlers`
- `golangci-lint run --new-from-rev=HEAD ./...`
- `git diff --check`
- pre-commit full Go test suite passed

Full repository lint still reports pre-existing staticcheck findings in unchanged tests under `internal/acpclient`, `internal/channel`, and `internal/handlers`; those are intentionally outside this PR.