### PR TITLE
feat(acp): upgrade Codex adapters dynamically

### DIFF
--- a/internal/acpagent/adapter_upgrade.go
+++ b/internal/acpagent/adapter_upgrade.go
@@ -24,16 +24,20 @@ type adapterVersionResolver interface {
 }
 
 type adapterUpgradeState struct {
-	once     sync.Once
+	mu       sync.Mutex
+	done     chan struct{}
+	resolved bool
 	version  string
 	err      error
 	disabled bool
 }
 
 // resolveDynamicAdapter performs at most one registry lookup per bot and
-// package during the lifetime of this server process. The exact result is
-// shared by all later cold starts; failures use the bundled adapter until the
-// server restarts.
+// package during the lifetime of this server process. The per-bot scope is
+// intentional because workspaces may use different registries or proxies. The
+// exact result is shared by all later cold starts; failures use the bundled
+// adapter until the server restarts. Canceled lookups are not cached, so a later
+// cold start can retry.
 func (p *SessionPool) resolveDynamicAdapter(
 	ctx context.Context,
 	botID string,
@@ -55,25 +59,54 @@ func (p *SessionPool) resolveDynamicAdapter(
 		p.adapterStates[key] = state
 	}
 	p.adapterMu.Unlock()
-	state.once.Do(func() {
-		state.version, state.err = resolver.ResolveACPAdapterVersion(ctx, botID, packageName, env)
-	})
-	p.adapterMu.Lock()
-	disabled := state.disabled
-	p.adapterMu.Unlock()
-	if disabled {
-		return state, "", nil
+
+	for {
+		state.mu.Lock()
+		if state.disabled {
+			state.mu.Unlock()
+			return state, "", nil
+		}
+		if state.resolved {
+			version, err := state.version, state.err
+			state.mu.Unlock()
+			return state, version, err
+		}
+		if state.done != nil {
+			done := state.done
+			state.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return state, "", ctx.Err()
+			case <-done:
+				continue
+			}
+		}
+
+		done := make(chan struct{})
+		state.done = done
+		state.mu.Unlock()
+
+		version, err := resolver.ResolveACPAdapterVersion(ctx, botID, packageName, env)
+		state.mu.Lock()
+		state.done = nil
+		if ctx.Err() == nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			state.resolved = true
+			state.version = version
+			state.err = err
+		}
+		close(done)
+		state.mu.Unlock()
+		return state, version, err
 	}
-	return state, state.version, state.err
 }
 
-func (p *SessionPool) disableDynamicAdapter(state *adapterUpgradeState) {
+func disableDynamicAdapter(state *adapterUpgradeState) {
 	if state == nil {
 		return
 	}
-	p.adapterMu.Lock()
+	state.mu.Lock()
 	state.disabled = true
-	p.adapterMu.Unlock()
+	state.mu.Unlock()
 }
 
 func (p *SessionPool) startDynamicAdapter(
@@ -101,7 +134,7 @@ func (p *SessionPool) startDynamicAdapter(
 		return nil, startCtx.Err()
 	}
 	if resolveErr != nil {
-		p.disableDynamicAdapter(state)
+		disableDynamicAdapter(state)
 	}
 	if version == "" || dynamicCtx.Err() != nil {
 		if err := dynamicCtx.Err(); err != nil {
@@ -127,7 +160,7 @@ func (p *SessionPool) startDynamicAdapter(
 		}
 		return nil, startCtx.Err()
 	}
-	p.disableDynamicAdapter(state)
+	disableDynamicAdapter(state)
 	if err == nil {
 		err = errors.New("dynamic ACP adapter returned no session")
 	}

--- a/internal/acpagent/adapter_upgrade.go
+++ b/internal/acpagent/adapter_upgrade.go
@@ -1,0 +1,213 @@
+package acpagent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/memohai/memoh/internal/acpclient"
+	"github.com/memohai/memoh/internal/acpprofile"
+	"github.com/memohai/memoh/internal/workspace/bridge"
+)
+
+const (
+	dynamicAdapterStartTimeout = 90 * time.Second
+	containerToolkitCABundle   = "/opt/memoh/toolkit/certs/ca-certificates.crt"
+)
+
+type adapterVersionResolver interface {
+	ResolveACPAdapterVersion(ctx context.Context, botID, packageName string, env []string) (string, error)
+}
+
+type adapterUpgradeState struct {
+	once     sync.Once
+	version  string
+	err      error
+	disabled bool
+}
+
+// resolveDynamicAdapter performs at most one registry lookup per bot and
+// package during the lifetime of this server process. The exact result is
+// shared by all later cold starts; failures use the bundled adapter until the
+// server restarts.
+func (p *SessionPool) resolveDynamicAdapter(
+	ctx context.Context,
+	botID string,
+	packageName string,
+	env []string,
+) (*adapterUpgradeState, string, error) {
+	resolver, ok := p.runner.(adapterVersionResolver)
+	if !ok {
+		return nil, "", nil
+	}
+	key := botID + "|" + packageName
+	p.adapterMu.Lock()
+	if p.adapterStates == nil {
+		p.adapterStates = make(map[string]*adapterUpgradeState)
+	}
+	state := p.adapterStates[key]
+	if state == nil {
+		state = &adapterUpgradeState{}
+		p.adapterStates[key] = state
+	}
+	p.adapterMu.Unlock()
+	state.once.Do(func() {
+		state.version, state.err = resolver.ResolveACPAdapterVersion(ctx, botID, packageName, env)
+	})
+	p.adapterMu.Lock()
+	disabled := state.disabled
+	p.adapterMu.Unlock()
+	if disabled {
+		return state, "", nil
+	}
+	return state, state.version, state.err
+}
+
+func (p *SessionPool) disableDynamicAdapter(state *adapterUpgradeState) {
+	if state == nil {
+		return
+	}
+	p.adapterMu.Lock()
+	state.disabled = true
+	p.adapterMu.Unlock()
+}
+
+func (p *SessionPool) startDynamicAdapter(
+	startCtx context.Context,
+	profile acpprofile.Profile,
+	workspaceInfo bridge.WorkspaceInfo,
+	startReq acpclient.StartRequest,
+	sink acpclient.EventSink,
+) (*acpclient.Session, error) {
+	packageName := strings.TrimSpace(profile.DynamicPackage)
+	if strings.TrimSpace(profile.DynamicCommand) == "" || packageName == "" {
+		return nil, nil
+	}
+
+	timeout := p.dynamicAdapterStartTimeout
+	if timeout <= 0 {
+		timeout = dynamicAdapterStartTimeout
+	}
+	dynamicCtx, cancel := context.WithTimeout(startCtx, timeout)
+	defer cancel()
+	useToolkitCA := p.containerToolkitCABundleAvailable(dynamicCtx, startReq.BotID, workspaceInfo)
+	dynamicEnv := dynamicACPEnv(startReq.Env, workspaceInfo, useToolkitCA)
+	state, version, resolveErr := p.resolveDynamicAdapter(dynamicCtx, startReq.BotID, packageName, adapterLookupEnv(dynamicEnv))
+	if resolveErr != nil && startCtx.Err() != nil {
+		return nil, startCtx.Err()
+	}
+	if resolveErr != nil {
+		p.disableDynamicAdapter(state)
+	}
+	if version == "" || dynamicCtx.Err() != nil {
+		if err := dynamicCtx.Err(); err != nil {
+			return nil, err
+		}
+		return nil, resolveErr
+	}
+
+	dynamicReq := startReq
+	dynamicReq.Command = profile.DynamicCommand
+	dynamicReq.Args = append(append([]string(nil), profile.DynamicArgs...), packageName+"@"+version)
+	dynamicReq.LocalCommand = profile.DynamicCommand
+	dynamicReq.LocalArgs = append([]string(nil), dynamicReq.Args...)
+	dynamicReq.Env = dynamicEnv
+
+	sess, err := p.runner.StartSession(dynamicCtx, dynamicReq, sink)
+	if err == nil && sess != nil {
+		return sess, nil
+	}
+	if startCtx.Err() != nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, startCtx.Err()
+	}
+	p.disableDynamicAdapter(state)
+	if err == nil {
+		err = errors.New("dynamic ACP adapter returned no session")
+	}
+	return nil, err
+}
+
+func (p *SessionPool) containerToolkitCABundleAvailable(ctx context.Context, botID string, workspaceInfo bridge.WorkspaceInfo) bool {
+	if !strings.EqualFold(strings.TrimSpace(workspaceInfo.Backend), bridge.WorkspaceBackendContainer) {
+		return false
+	}
+	runner, ok := p.runner.(workspaceClientRunner)
+	if !ok {
+		return false
+	}
+	client, err := runner.MCPClient(ctx, botID)
+	if err != nil {
+		p.logger.Debug("could not inspect workspace CA bundle", slog.String("bot_id", botID), slog.Any("error", err))
+		return false
+	}
+	if _, err := client.Stat(ctx, containerToolkitCABundle); err != nil {
+		if !errors.Is(err, bridge.ErrNotFound) {
+			p.logger.Debug("could not inspect workspace CA bundle", slog.String("bot_id", botID), slog.Any("error", err))
+		}
+		return false
+	}
+	return true
+}
+
+func dynamicACPEnv(env []string, workspaceInfo bridge.WorkspaceInfo, useToolkitCA bool) []string {
+	cacheDir := "/data/.memoh/acp/npm-cache"
+	if strings.EqualFold(strings.TrimSpace(workspaceInfo.Backend), bridge.WorkspaceBackendLocal) {
+		localDataRoot := strings.TrimSpace(workspaceInfo.LocalDataRoot)
+		if localDataRoot == "" {
+			return append([]string(nil), env...)
+		}
+		cacheDir = filepath.Join(localDataRoot, "acp", "npm-cache")
+	}
+
+	result := replaceEnvValue(env, "NPM_CONFIG_CACHE", cacheDir)
+	if useToolkitCA && !envHasKey(result, "SSL_CERT_FILE") {
+		result = append(result, "SSL_CERT_FILE="+containerToolkitCABundle)
+	}
+	return result
+}
+
+func replaceEnvValue(env []string, targetKey, value string) []string {
+	result := make([]string, 0, len(env)+1)
+	for _, item := range env {
+		key, _, ok := strings.Cut(item, "=")
+		if ok && strings.EqualFold(strings.TrimSpace(key), targetKey) {
+			continue
+		}
+		result = append(result, item)
+	}
+	return append(result, targetKey+"="+value)
+}
+
+func envHasKey(env []string, targetKey string) bool {
+	for _, item := range env {
+		key, _, ok := strings.Cut(item, "=")
+		if ok && strings.EqualFold(strings.TrimSpace(key), targetKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func adapterLookupEnv(env []string) []string {
+	result := make([]string, 0, 2)
+	for _, item := range env {
+		key, _, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		switch {
+		case strings.EqualFold(strings.TrimSpace(key), "NPM_CONFIG_CACHE"):
+			result = append(result, item)
+		case strings.EqualFold(strings.TrimSpace(key), "SSL_CERT_FILE"):
+			result = append(result, item)
+		}
+	}
+	return result
+}

--- a/internal/acpagent/session_pool.go
+++ b/internal/acpagent/session_pool.go
@@ -92,6 +92,10 @@ type SessionPool struct {
 	userInput pendingUserInputCanceller
 	timeout   time.Duration
 
+	adapterMu                  sync.Mutex
+	adapterStates              map[string]*adapterUpgradeState
+	dynamicAdapterStartTimeout time.Duration
+
 	mu        sync.RWMutex
 	runtimes  map[string]*runtimeHandle
 	bySession map[string]string
@@ -959,7 +963,7 @@ func (p *SessionPool) startRuntime(ctx context.Context, h *runtimeHandle, opts s
 	if err != nil {
 		return fail(err)
 	}
-	sess, err := p.runner.StartSession(startCtx, acpclient.StartRequest{
+	startReq := acpclient.StartRequest{
 		AgentID:                h.agentID,
 		BotID:                  h.botID,
 		ProjectPath:            h.projectPath,
@@ -984,7 +988,23 @@ func (p *SessionPool) startRuntime(ctx context.Context, h *runtimeHandle, opts s
 		ToolGateway:     p.tools,
 		ToolSession:     h.stableToolIdentity(),
 		ToolApproval:    p.approval,
-	}, opts.Sink)
+	}
+
+	var sess *acpclient.Session
+	sess, err = p.startDynamicAdapter(startCtx, profile, workspaceInfo, startReq, opts.Sink)
+	if err != nil {
+		if startCtx.Err() != nil {
+			return fail(err)
+		}
+		p.logger.Warn("dynamic ACP adapter unavailable; falling back to bundled version",
+			slog.String("bot_id", h.botID),
+			slog.String("agent_id", h.agentID),
+			slog.String("runtime_id", h.id),
+			slog.Any("error", err))
+	}
+	if sess == nil {
+		sess, err = p.runner.StartSession(startCtx, startReq, opts.Sink)
+	}
 	if err != nil {
 		return fail(err)
 	}

--- a/internal/acpagent/sessionpool_test.go
+++ b/internal/acpagent/sessionpool_test.go
@@ -1155,6 +1155,44 @@ func TestSessionPoolPinsExactAdapterVersionForProcess(t *testing.T) {
 	}
 }
 
+func TestSessionPoolPinsAdapterVersionsPerBot(t *testing.T) {
+	runner := &dynamicRecordingRunner{versions: []string{"1.2.0", "1.3.0"}}
+	pool := newSessionPool(nil, runner, fakeBotGetter{})
+	const packageName = "@agentclientprotocol/codex-acp"
+
+	for _, tc := range []struct {
+		botID string
+		want  string
+	}{
+		{botID: "bot-1", want: "1.2.0"},
+		{botID: "bot-2", want: "1.3.0"},
+	} {
+		version, err := resolveAdapterVersionForTest(pool, tc.botID, packageName)
+		if err != nil {
+			t.Fatalf("resolveDynamicAdapter(%s) error = %v", tc.botID, err)
+		}
+		if version != tc.want {
+			t.Fatalf("resolveDynamicAdapter(%s) = %q, want %q", tc.botID, version, tc.want)
+		}
+	}
+
+	for _, tc := range []struct {
+		botID string
+		want  string
+	}{
+		{botID: "bot-1", want: "1.2.0"},
+		{botID: "bot-2", want: "1.3.0"},
+	} {
+		version, err := resolveAdapterVersionForTest(pool, tc.botID, packageName)
+		if err != nil || version != tc.want {
+			t.Fatalf("cached resolveDynamicAdapter(%s) = %q, %v; want %q, nil", tc.botID, version, err, tc.want)
+		}
+	}
+	if got := runner.resolveCallCount(); got != 2 {
+		t.Fatalf("version lookups = %d, want one per bot", got)
+	}
+}
+
 func TestSessionPoolSharesAdapterLookupAcrossConcurrentColdStarts(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -1209,6 +1247,194 @@ func TestSessionPoolSharesAdapterLookupAcrossConcurrentColdStarts(t *testing.T) 
 	requests := runner.requests()
 	if len(requests) != 2 || requests[0].Args[1] != "@agentclientprotocol/codex-acp@1.2.0" || requests[1].Args[1] != "@agentclientprotocol/codex-acp@1.2.0" {
 		t.Fatalf("concurrent exact-version requests = %#v", requests)
+	}
+}
+
+func TestSessionPoolCanceledAdapterLookupCanRetry(t *testing.T) {
+	started := make(chan struct{})
+	runner := &dynamicRecordingRunner{
+		info:           bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"},
+		versions:       []string{"1.2.0"},
+		starts:         []dynamicStartResult{{session: &acpclient.Session{}}},
+		blockResolve:   true,
+		resolveStarted: started,
+	}
+	pool := newSessionPool(
+		nil,
+		runner,
+		fakeBotGetter{bot: enabledACPBot("bot-1", "api_key", map[string]any{"api_key": "sk-test"})},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := pool.Ensure(ctx, PromptInput{
+			BotID:                 "bot-1",
+			SessionID:             "session-1",
+			AgentID:               acpprofile.AgentCodexID,
+			ProjectPath:           "/data/project",
+			RuntimeOwnerAccountID: "user-1",
+		})
+		errCh <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter version lookup did not start")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Ensure() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ensure did not return after lookup cancellation")
+	}
+	if requests := runner.requests(); len(requests) != 0 {
+		t.Fatalf("StartSession requests after lookup cancellation = %#v", requests)
+	}
+
+	runner.mu.Lock()
+	runner.blockResolve = false
+	runner.mu.Unlock()
+	if _, err := pool.Ensure(context.Background(), PromptInput{
+		BotID:                 "bot-1",
+		SessionID:             "session-2",
+		AgentID:               acpprofile.AgentCodexID,
+		ProjectPath:           "/data/project",
+		RuntimeOwnerAccountID: "user-1",
+	}); err != nil {
+		t.Fatalf("Ensure after lookup cancellation error = %v", err)
+	}
+	if got := runner.resolveCallCount(); got != 2 {
+		t.Fatalf("version lookups = %d, want canceled lookup followed by retry", got)
+	}
+	requests := runner.requests()
+	if len(requests) != 1 || len(requests[0].Args) != 2 || requests[0].Args[1] != "@agentclientprotocol/codex-acp@1.2.0" {
+		t.Fatalf("dynamic request after lookup retry = %#v", requests)
+	}
+}
+
+func TestSessionPoolAdapterLookupWaiterCanCancel(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := &dynamicRecordingRunner{
+		versions:       []string{"1.2.0"},
+		blockResolve:   true,
+		resolveStarted: started,
+		resolveRelease: release,
+	}
+	pool := newSessionPool(nil, runner, fakeBotGetter{})
+	const packageName = "@agentclientprotocol/codex-acp"
+
+	type result struct {
+		version string
+		err     error
+	}
+	leaderResult := make(chan result, 1)
+	go func() {
+		version, err := resolveAdapterVersionForTest(pool, "bot-1", packageName)
+		leaderResult <- result{version: version, err: err}
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter version lookup did not start")
+	}
+
+	waiterCtx, cancelWaiter := context.WithCancel(context.Background())
+	waiterResult := make(chan error, 1)
+	go func() {
+		_, _, err := pool.resolveDynamicAdapter(waiterCtx, "bot-1", packageName, nil)
+		waiterResult <- err
+	}()
+	cancelWaiter()
+	select {
+	case err := <-waiterResult:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waiting resolveDynamicAdapter() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiting resolveDynamicAdapter did not return after cancellation")
+	}
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("version lookups while waiter canceled = %d, want 1", got)
+	}
+
+	close(release)
+	select {
+	case got := <-leaderResult:
+		if got.err != nil || got.version != "1.2.0" {
+			t.Fatalf("leading resolveDynamicAdapter() = %q, %v", got.version, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("leading resolveDynamicAdapter did not finish")
+	}
+	version, err := resolveAdapterVersionForTest(pool, "bot-1", packageName)
+	if err != nil || version != "1.2.0" {
+		t.Fatalf("cached resolveDynamicAdapter() = %q, %v", version, err)
+	}
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("version lookups after cached result = %d, want 1", got)
+	}
+}
+
+func TestSessionPoolAdapterLookupTimeoutFallsBackAndDisables(t *testing.T) {
+	started := make(chan struct{})
+	runner := &dynamicRecordingRunner{
+		info:           bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"},
+		blockResolve:   true,
+		resolveStarted: started,
+		starts: []dynamicStartResult{
+			{session: &acpclient.Session{}},
+			{session: &acpclient.Session{}},
+		},
+	}
+	pool := newSessionPool(
+		nil,
+		runner,
+		fakeBotGetter{bot: enabledACPBot("bot-1", "api_key", map[string]any{"api_key": "sk-test"})},
+	)
+	pool.dynamicAdapterStartTimeout = 20 * time.Millisecond
+
+	if _, err := pool.Ensure(context.Background(), PromptInput{
+		BotID:                 "bot-1",
+		SessionID:             "session-1",
+		AgentID:               acpprofile.AgentCodexID,
+		ProjectPath:           "/data/project",
+		RuntimeOwnerAccountID: "user-1",
+	}); err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("adapter version lookup did not start")
+	}
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("version lookups after timeout = %d, want 1", got)
+	}
+	requests := runner.requests()
+	if len(requests) != 1 || requests[0].Command != "codex-acp" {
+		t.Fatalf("requests after lookup timeout = %#v, want bundled fallback", requests)
+	}
+
+	if _, err := pool.Ensure(context.Background(), PromptInput{
+		BotID:                 "bot-1",
+		SessionID:             "session-2",
+		AgentID:               acpprofile.AgentCodexID,
+		ProjectPath:           "/data/project",
+		RuntimeOwnerAccountID: "user-1",
+	}); err != nil {
+		t.Fatalf("second Ensure() error = %v", err)
+	}
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("version lookups after disabled timeout = %d, want 1", got)
+	}
+	requests = runner.requests()
+	if len(requests) != 2 || requests[1].Command != "codex-acp" {
+		t.Fatalf("requests after disabled timeout = %#v, want bundled fallback", requests)
 	}
 }
 
@@ -2831,6 +3057,10 @@ type dynamicRecordingRunner struct {
 	versions       []string
 	resolveErrs    []error
 	resolveCalls   int
+	blockResolve   bool
+	resolveStarted chan struct{}
+	resolveRelease <-chan struct{}
+	resolveOnce    sync.Once
 	reqs           []acpclient.StartRequest
 	starts         []dynamicStartResult
 	blockDynamic   bool
@@ -2920,10 +3150,28 @@ func (r *dynamicRecordingRunner) WorkspaceInfo(context.Context, string) (bridge.
 	return r.info, nil
 }
 
-func (r *dynamicRecordingRunner) ResolveACPAdapterVersion(context.Context, string, string, []string) (string, error) {
+func (r *dynamicRecordingRunner) ResolveACPAdapterVersion(ctx context.Context, _ string, _ string, _ []string) (string, error) {
+	r.mu.Lock()
+	r.resolveCalls++
+	block := r.blockResolve
+	started := r.resolveStarted
+	release := r.resolveRelease
+	r.mu.Unlock()
+	if block {
+		r.resolveOnce.Do(func() {
+			if started != nil {
+				close(started)
+			}
+		})
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-release:
+		}
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.resolveCalls++
 	var err error
 	if len(r.resolveErrs) > 0 {
 		err = r.resolveErrs[0]
@@ -2977,6 +3225,11 @@ func (r *dynamicRecordingRunner) resolveCallCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.resolveCalls
+}
+
+func resolveAdapterVersionForTest(pool *SessionPool, botID, packageName string) (string, error) {
+	_, version, err := pool.resolveDynamicAdapter(context.Background(), botID, packageName, nil)
+	return version, err
 }
 
 func (*caBundleRunner) WorkspaceInfo(context.Context, string) (bridge.WorkspaceInfo, error) {

--- a/internal/acpagent/sessionpool_test.go
+++ b/internal/acpagent/sessionpool_test.go
@@ -62,6 +62,7 @@ func newFakeScriptPoolForBot(t *testing.T, bot bots.Bot) (*SessionPool, string) 
 		t.Fatal(err)
 	}
 	writeSessionPoolFakeAgentScript(t, binDir, "npx")
+	writeSessionPoolFakeNPMScript(t, binDir)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	runner := acpclient.NewRunner(nil, sessionPoolWorkspace{
 		client: newSessionPoolBridgeClient(t, root),
@@ -1104,6 +1105,395 @@ func TestSessionPoolRuntimeStatusReportsActiveDuringColdStart(t *testing.T) {
 	}
 }
 
+func TestSessionPoolPinsExactAdapterVersionForProcess(t *testing.T) {
+	runner := &dynamicRecordingRunner{
+		info:     bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"},
+		versions: []string{"1.2.0"},
+		starts: []dynamicStartResult{
+			{session: &acpclient.Session{}},
+			{session: &acpclient.Session{}},
+		},
+	}
+	pool := newSessionPool(
+		nil,
+		runner,
+		fakeBotGetter{bot: enabledACPBot("bot-1", "api_key", map[string]any{"api_key": "sk-test"})},
+	)
+	ensure := func(sessionID string) RuntimeStatus {
+		t.Helper()
+		status, err := pool.Ensure(context.Background(), PromptInput{
+			BotID:                 "bot-1",
+			SessionID:             sessionID,
+			AgentID:               acpprofile.AgentCodexID,
+			ProjectPath:           "/data/project",
+			RuntimeOwnerAccountID: "user-1",
+		})
+		if err != nil {
+			t.Fatalf("Ensure(%s) error = %v", sessionID, err)
+		}
+		return status
+	}
+
+	if status := ensure("session-1"); status.State != stateIdle {
+		t.Fatalf("first status = %#v", status)
+	}
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("version lookups after first cold start = %d, want 1", got)
+	}
+	requests := runner.requests()
+	if len(requests) != 1 || len(requests[0].Args) != 2 || requests[0].Args[1] != "@agentclientprotocol/codex-acp@1.2.0" {
+		t.Fatalf("first dynamic request = %#v", requests)
+	}
+
+	ensure("session-2")
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("version lookups after second cold start = %d, want 1", got)
+	}
+	requests = runner.requests()
+	if len(requests) != 2 || requests[1].Args[1] != "@agentclientprotocol/codex-acp@1.2.0" {
+		t.Fatalf("cached exact-version request = %#v", requests)
+	}
+}
+
+func TestSessionPoolSharesAdapterLookupAcrossConcurrentColdStarts(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := &dynamicRecordingRunner{
+		info:           bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"},
+		versions:       []string{"1.2.0"},
+		starts:         []dynamicStartResult{{session: &acpclient.Session{}}, {session: &acpclient.Session{}}},
+		blockDynamic:   true,
+		dynamicStarted: started,
+		dynamicRelease: release,
+	}
+	pool := newSessionPool(
+		nil,
+		runner,
+		fakeBotGetter{bot: enabledACPBot("bot-1", "api_key", map[string]any{"api_key": "sk-test"})},
+	)
+
+	errCh := make(chan error, 2)
+	ensure := func(sessionID string) {
+		_, err := pool.Ensure(context.Background(), PromptInput{
+			BotID:                 "bot-1",
+			SessionID:             sessionID,
+			AgentID:               acpprofile.AgentCodexID,
+			ProjectPath:           "/data/project",
+			RuntimeOwnerAccountID: "user-1",
+		})
+		errCh <- err
+	}
+	go ensure("session-1")
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dynamic adapter did not start")
+	}
+	go ensure("session-2")
+	deadline := time.Now().Add(2 * time.Second)
+	for len(runner.requests()) != 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := len(runner.requests()); got != 2 {
+		t.Fatalf("concurrent StartSession calls = %d, want 2", got)
+	}
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("concurrent version lookups = %d, want 1", got)
+	}
+	close(release)
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("Ensure() error = %v", err)
+		}
+	}
+	requests := runner.requests()
+	if len(requests) != 2 || requests[0].Args[1] != "@agentclientprotocol/codex-acp@1.2.0" || requests[1].Args[1] != "@agentclientprotocol/codex-acp@1.2.0" {
+		t.Fatalf("concurrent exact-version requests = %#v", requests)
+	}
+}
+
+func TestSessionPoolDynamicAdapterFailureFallsBackAndBinds(t *testing.T) {
+	fallbackSession := &acpclient.Session{}
+	runner := &dynamicRecordingRunner{
+		info:     bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"},
+		versions: []string{"1.2.0"},
+		starts: []dynamicStartResult{
+			{err: errors.New("dynamic unavailable")},
+			{session: fallbackSession},
+			{session: &acpclient.Session{}},
+		},
+	}
+	pool := newSessionPool(
+		nil,
+		runner,
+		fakeBotGetter{bot: enabledACPBot("bot-1", "api_key", map[string]any{"api_key": "sk-test"})},
+	)
+
+	status, err := pool.Ensure(context.Background(), PromptInput{
+		BotID:                 "bot-1",
+		SessionID:             "session-1",
+		AgentID:               acpprofile.AgentCodexID,
+		ProjectPath:           "/data/project",
+		RuntimeOwnerAccountID: "user-1",
+	})
+	if err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	if status.State != stateIdle {
+		t.Fatalf("fallback status = %#v", status)
+	}
+	h := pool.sessionHandle("session-1")
+	if h == nil || h.session != fallbackSession {
+		t.Fatalf("fallback session was not bound: %#v", h)
+	}
+	requests := runner.requests()
+	if len(requests) != 2 {
+		t.Fatalf("StartSession calls = %d, want dynamic then fallback", len(requests))
+	}
+	dynamic := requests[0]
+	if dynamic.Command != "npx" || len(dynamic.Args) != 2 || dynamic.Args[1] != "@agentclientprotocol/codex-acp@1.2.0" {
+		t.Fatalf("dynamic request = command %q args %#v", dynamic.Command, dynamic.Args)
+	}
+	if !startRequestEnvHas(dynamic.Env, "NPM_CONFIG_CACHE", "/data/.memoh/acp/npm-cache") {
+		t.Fatalf("dynamic request env = %#v, want persistent npm cache", dynamic.Env)
+	}
+	fallback := requests[1]
+	if fallback.Command != "codex-acp" || fallback.LocalCommand != "npx" || len(fallback.LocalArgs) != 2 || fallback.LocalArgs[1] != "@agentclientprotocol/codex-acp@1.1.4" {
+		t.Fatalf("fallback request = command %q, local %q %#v", fallback.Command, fallback.LocalCommand, fallback.LocalArgs)
+	}
+	if startRequestEnvHas(fallback.Env, "NPM_CONFIG_CACHE", "/data/.memoh/acp/npm-cache") {
+		t.Fatalf("fallback request unexpectedly carries dynamic cache env: %#v", fallback.Env)
+	}
+	if _, err := pool.Ensure(context.Background(), PromptInput{
+		BotID:                 "bot-1",
+		SessionID:             "session-2",
+		AgentID:               acpprofile.AgentCodexID,
+		ProjectPath:           "/data/project",
+		RuntimeOwnerAccountID: "user-1",
+	}); err != nil {
+		t.Fatalf("second Ensure() error = %v", err)
+	}
+	requests = runner.requests()
+	if runner.resolveCallCount() != 1 || len(requests) != 3 || requests[2].Command != "codex-acp" {
+		t.Fatalf("failed candidate was retried: lookups=%d requests=%#v", runner.resolveCallCount(), requests)
+	}
+}
+
+func TestSessionPoolDynamicAdapterCancellationDoesNotFallback(t *testing.T) {
+	started := make(chan struct{})
+	runner := &dynamicRecordingRunner{
+		info:           bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"},
+		versions:       []string{"1.2.0"},
+		starts:         []dynamicStartResult{{session: &acpclient.Session{}}},
+		blockDynamic:   true,
+		dynamicStarted: started,
+	}
+	pool := newSessionPool(
+		nil,
+		runner,
+		fakeBotGetter{bot: enabledACPBot("bot-1", "api_key", map[string]any{"api_key": "sk-test"})},
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := pool.Ensure(ctx, PromptInput{
+			BotID:                 "bot-1",
+			SessionID:             "session-1",
+			AgentID:               acpprofile.AgentCodexID,
+			ProjectPath:           "/data/project",
+			RuntimeOwnerAccountID: "user-1",
+		})
+		errCh <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dynamic adapter did not start")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Ensure() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ensure did not return after cancellation")
+	}
+	if got := len(runner.requests()); got != 1 {
+		t.Fatalf("StartSession calls = %d, want no fallback after cancellation", got)
+	}
+	runner.mu.Lock()
+	runner.blockDynamic = false
+	runner.mu.Unlock()
+	if _, err := pool.Ensure(context.Background(), PromptInput{
+		BotID:                 "bot-1",
+		SessionID:             "session-2",
+		AgentID:               acpprofile.AgentCodexID,
+		ProjectPath:           "/data/project",
+		RuntimeOwnerAccountID: "user-1",
+	}); err != nil {
+		t.Fatalf("Ensure after caller cancellation error = %v", err)
+	}
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("version lookups after caller cancellation = %d, want cached exact version", got)
+	}
+}
+
+func TestSessionPoolDynamicAdapterTimeoutFallsBack(t *testing.T) {
+	started := make(chan struct{})
+	runner := &dynamicRecordingRunner{
+		info:           bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"},
+		versions:       []string{"1.2.0"},
+		blockDynamic:   true,
+		dynamicStarted: started,
+		starts:         []dynamicStartResult{{session: &acpclient.Session{}}, {session: &acpclient.Session{}}},
+	}
+	pool := newSessionPool(
+		nil,
+		runner,
+		fakeBotGetter{bot: enabledACPBot("bot-1", "api_key", map[string]any{"api_key": "sk-test"})},
+	)
+	pool.dynamicAdapterStartTimeout = 20 * time.Millisecond
+
+	status, err := pool.Ensure(context.Background(), PromptInput{
+		BotID:                 "bot-1",
+		SessionID:             "session-1",
+		AgentID:               acpprofile.AgentCodexID,
+		ProjectPath:           "/data/project",
+		RuntimeOwnerAccountID: "user-1",
+	})
+	if err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	if status.State != stateIdle {
+		t.Fatalf("timeout fallback status = %#v", status)
+	}
+	if got := len(runner.requests()); got != 2 {
+		t.Fatalf("StartSession calls = %d, want timed-out dynamic then fallback", got)
+	}
+	if _, err := pool.Ensure(context.Background(), PromptInput{
+		BotID:                 "bot-1",
+		SessionID:             "session-2",
+		AgentID:               acpprofile.AgentCodexID,
+		ProjectPath:           "/data/project",
+		RuntimeOwnerAccountID: "user-1",
+	}); err != nil {
+		t.Fatalf("second Ensure() error = %v", err)
+	}
+	if runner.resolveCallCount() != 1 || len(runner.requests()) != 3 {
+		t.Fatalf("timed-out candidate was retried: lookups=%d requests=%#v", runner.resolveCallCount(), runner.requests())
+	}
+}
+
+func TestSessionPoolAdapterLookupFailureDisablesDynamicLaunchForProcess(t *testing.T) {
+	runner := &dynamicRecordingRunner{
+		info:        bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"},
+		resolveErrs: []error{errors.New("registry unavailable")},
+		starts: []dynamicStartResult{
+			{session: &acpclient.Session{}},
+			{session: &acpclient.Session{}},
+		},
+	}
+	pool := newSessionPool(
+		nil,
+		runner,
+		fakeBotGetter{bot: enabledACPBot("bot-1", "api_key", map[string]any{"api_key": "sk-test"})},
+	)
+
+	for _, sessionID := range []string{"session-1", "session-2"} {
+		if _, err := pool.Ensure(context.Background(), PromptInput{
+			BotID:                 "bot-1",
+			SessionID:             sessionID,
+			AgentID:               acpprofile.AgentCodexID,
+			ProjectPath:           "/data/project",
+			RuntimeOwnerAccountID: "user-1",
+		}); err != nil {
+			t.Fatalf("Ensure(%s) error = %v", sessionID, err)
+		}
+	}
+	if got := runner.resolveCallCount(); got != 1 {
+		t.Fatalf("version lookups after disabled lookup = %d, want 1", got)
+	}
+	for i, req := range runner.requests() {
+		if req.Command != "codex-acp" {
+			t.Fatalf("request %d command = %q, want bundled fallback", i, req.Command)
+		}
+	}
+}
+
+func TestDynamicACPEnvUsesLocalDataRootAndReplacesExistingCache(t *testing.T) {
+	root := t.TempDir()
+	env := dynamicACPEnv([]string{"CUSTOM=1", "npm_config_cache=/old"}, bridge.WorkspaceInfo{
+		Backend:       bridge.WorkspaceBackendLocal,
+		LocalDataRoot: root,
+	}, false)
+	if !startRequestEnvHas(env, "CUSTOM", "1") {
+		t.Fatalf("dynamic env dropped existing value: %#v", env)
+	}
+	if !startRequestEnvHas(env, "NPM_CONFIG_CACHE", filepath.Join(root, "acp", "npm-cache")) {
+		t.Fatalf("dynamic env = %#v, want local data-root cache", env)
+	}
+	if startRequestEnvHas(env, "npm_config_cache", "/old") {
+		t.Fatalf("dynamic env retained stale cache: %#v", env)
+	}
+}
+
+func TestDynamicACPEnvAddsToolkitCAOnlyWhenAvailableAndUnset(t *testing.T) {
+	env := dynamicACPEnv([]string{"CUSTOM=1"}, bridge.WorkspaceInfo{
+		Backend: bridge.WorkspaceBackendContainer,
+	}, true)
+	if !startRequestEnvHas(env, "SSL_CERT_FILE", containerToolkitCABundle) {
+		t.Fatalf("dynamic env = %#v, want toolkit CA bundle", env)
+	}
+
+	env = dynamicACPEnv([]string{"SSL_CERT_FILE=/custom/ca.pem"}, bridge.WorkspaceInfo{
+		Backend: bridge.WorkspaceBackendContainer,
+	}, true)
+	if !startRequestEnvHas(env, "SSL_CERT_FILE", "/custom/ca.pem") || startRequestEnvHas(env, "SSL_CERT_FILE", containerToolkitCABundle) {
+		t.Fatalf("dynamic env replaced explicit CA bundle: %#v", env)
+	}
+
+	env = dynamicACPEnv(nil, bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer}, false)
+	if startRequestEnvHas(env, "SSL_CERT_FILE", containerToolkitCABundle) {
+		t.Fatalf("dynamic env added missing toolkit CA bundle: %#v", env)
+	}
+}
+
+func TestSessionPoolDetectsContainerToolkitCABundle(t *testing.T) {
+	client, statServer := newCABundleStatClient(t)
+	runner := &caBundleRunner{client: client}
+	pool := newSessionPool(nil, runner, nil)
+	info := bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"}
+	if !pool.containerToolkitCABundleAvailable(context.Background(), "bot-1", info) {
+		t.Fatal("container toolkit CA bundle was not detected")
+	}
+	statServer.mu.Lock()
+	gotPath := statServer.path
+	statServer.mu.Unlock()
+	if gotPath != containerToolkitCABundle {
+		t.Fatalf("Stat path = %q, want %q", gotPath, containerToolkitCABundle)
+	}
+}
+
+func TestAdapterLookupEnvExcludesAgentCredentials(t *testing.T) {
+	env := adapterLookupEnv([]string{
+		"NPM_CONFIG_CACHE=/data/.memoh/acp/npm-cache",
+		"SSL_CERT_FILE=/opt/memoh/toolkit/certs/ca-certificates.crt",
+		"ANTHROPIC_API_KEY=sk-secret",
+		"CUSTOM_FLAG=1",
+	})
+	if len(env) != 2 || !startRequestEnvHas(env, "NPM_CONFIG_CACHE", "/data/.memoh/acp/npm-cache") ||
+		!startRequestEnvHas(env, "SSL_CERT_FILE", containerToolkitCABundle) {
+		t.Fatalf("adapter lookup env = %#v", env)
+	}
+	for _, key := range []string{"ANTHROPIC_API_KEY", "CUSTOM_FLAG"} {
+		if envHasKey(env, key) {
+			t.Fatalf("adapter lookup env unexpectedly contains %s: %#v", key, env)
+		}
+	}
+}
+
 func TestSessionPoolCloseDuringColdStartPreventsReinsert(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -1314,6 +1704,7 @@ func TestSessionPoolCloseSessionCancelsActivePrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeSessionPoolFakeAgentScript(t, binDir, "npx")
+	writeSessionPoolFakeNPMScript(t, binDir)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	runner := acpclient.NewRunner(nil, sessionPoolWorkspace{
@@ -1380,6 +1771,7 @@ func TestSessionPoolSerializesColdStartForSameSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeSessionPoolFakeAgentScript(t, binDir, "npx")
+	writeSessionPoolFakeNPMScript(t, binDir)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	startLog := filepath.Join(root, "starts.log")
 	t.Setenv("MEMOH_ACP_START_LOG", startLog)
@@ -2428,6 +2820,35 @@ type recordingRunner struct {
 	startErr error
 }
 
+type dynamicStartResult struct {
+	session *acpclient.Session
+	err     error
+}
+
+type dynamicRecordingRunner struct {
+	mu             sync.Mutex
+	info           bridge.WorkspaceInfo
+	versions       []string
+	resolveErrs    []error
+	resolveCalls   int
+	reqs           []acpclient.StartRequest
+	starts         []dynamicStartResult
+	blockDynamic   bool
+	dynamicStarted chan struct{}
+	dynamicRelease <-chan struct{}
+	startOnce      sync.Once
+}
+
+type caBundleRunner struct {
+	client *bridge.Client
+}
+
+type caBundleStatServer struct {
+	pb.UnimplementedContainerServiceServer
+	mu   sync.Mutex
+	path string
+}
+
 type hermesRecordingRunner struct {
 	info     bridge.WorkspaceInfo
 	client   *bridge.Client
@@ -2439,6 +2860,7 @@ type blockingRunner struct {
 	info    bridge.WorkspaceInfo
 	started chan struct{}
 	release chan struct{}
+	once    sync.Once
 }
 
 type delayedStartRunner struct {
@@ -2459,7 +2881,7 @@ func (r *blockingRunner) WorkspaceInfo(context.Context, string) (bridge.Workspac
 }
 
 func (r *blockingRunner) StartSession(context.Context, acpclient.StartRequest, acpclient.EventSink) (*acpclient.Session, error) {
-	close(r.started)
+	r.once.Do(func() { close(r.started) })
 	<-r.release
 	return nil, errors.New("released")
 }
@@ -2492,6 +2914,88 @@ func (r *recordingRunner) WorkspaceInfo(context.Context, string) (bridge.Workspa
 func (r *recordingRunner) StartSession(_ context.Context, req acpclient.StartRequest, _ acpclient.EventSink) (*acpclient.Session, error) {
 	r.req = req
 	return nil, r.startErr
+}
+
+func (r *dynamicRecordingRunner) WorkspaceInfo(context.Context, string) (bridge.WorkspaceInfo, error) {
+	return r.info, nil
+}
+
+func (r *dynamicRecordingRunner) ResolveACPAdapterVersion(context.Context, string, string, []string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.resolveCalls++
+	var err error
+	if len(r.resolveErrs) > 0 {
+		err = r.resolveErrs[0]
+		r.resolveErrs = r.resolveErrs[1:]
+	}
+	if err != nil {
+		return "", err
+	}
+	if len(r.versions) == 0 {
+		return "", errors.New("no fake npm version configured")
+	}
+	version := r.versions[0]
+	r.versions = r.versions[1:]
+	return version, nil
+}
+
+func (r *dynamicRecordingRunner) StartSession(ctx context.Context, req acpclient.StartRequest, _ acpclient.EventSink) (*acpclient.Session, error) {
+	r.mu.Lock()
+	r.reqs = append(r.reqs, req)
+	block := r.blockDynamic && req.Command == "npx"
+	r.mu.Unlock()
+	if block {
+		r.startOnce.Do(func() {
+			if r.dynamicStarted != nil {
+				close(r.dynamicStarted)
+			}
+		})
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-r.dynamicRelease:
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.starts) == 0 {
+		return nil, errors.New("no fake session start result configured")
+	}
+	result := r.starts[0]
+	r.starts = r.starts[1:]
+	return result.session, result.err
+}
+
+func (r *dynamicRecordingRunner) requests() []acpclient.StartRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]acpclient.StartRequest(nil), r.reqs...)
+}
+
+func (r *dynamicRecordingRunner) resolveCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.resolveCalls
+}
+
+func (*caBundleRunner) WorkspaceInfo(context.Context, string) (bridge.WorkspaceInfo, error) {
+	return bridge.WorkspaceInfo{Backend: bridge.WorkspaceBackendContainer, DefaultWorkDir: "/data"}, nil
+}
+
+func (*caBundleRunner) StartSession(context.Context, acpclient.StartRequest, acpclient.EventSink) (*acpclient.Session, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *caBundleRunner) MCPClient(context.Context, string) (*bridge.Client, error) {
+	return r.client, nil
+}
+
+func (s *caBundleStatServer) Stat(_ context.Context, req *pb.StatRequest) (*pb.StatResponse, error) {
+	s.mu.Lock()
+	s.path = req.GetPath()
+	s.mu.Unlock()
+	return &pb.StatResponse{Entry: &pb.FileEntry{Path: filepath.Base(req.GetPath())}}, nil
 }
 
 func (r *hermesRecordingRunner) WorkspaceInfo(context.Context, string) (bridge.WorkspaceInfo, error) {
@@ -2601,6 +3105,33 @@ func newSessionPoolBridgeClient(t *testing.T, root string) *bridge.Client {
 	return bridge.NewClientFromConn(conn)
 }
 
+func newCABundleStatClient(t *testing.T) (*bridge.Client, *caBundleStatServer) {
+	t.Helper()
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	statServer := &caBundleStatServer{}
+	pb.RegisterContainerServiceServer(server, statServer)
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///acpagent-ca-bundle-test",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return bridge.NewClientFromConn(conn), statServer
+}
+
 func readSessionPoolFile(t *testing.T, root string, parts ...string) string {
 	t.Helper()
 	pathParts := append([]string{root}, parts...)
@@ -2631,6 +3162,14 @@ func writeSessionPoolFakeAgentScript(t *testing.T, dir, name string) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+func writeSessionPoolFakeNPMScript(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, "npm")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf '\"1.1.4\"\\n'\n"), 0o700); err != nil { //nolint:gosec // test helper must be executable.
+		t.Fatal(err)
+	}
 }
 
 func TestSessionPoolFakeAgentHelper(_ *testing.T) {

--- a/internal/acpclient/client.go
+++ b/internal/acpclient/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -34,6 +35,10 @@ const (
 	// user decision, even though both happen to be generous.
 	approvalGrantTTL = 10 * time.Minute
 )
+
+const acpAdapterVersionLookupTimeoutSeconds int32 = 90
+
+var exactACPAdapterVersionPattern = regexp.MustCompile(`^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
 
 type Workspace interface {
 	bridge.Provider
@@ -104,6 +109,38 @@ func (r *Runner) MCPClient(ctx context.Context, botID string) (*bridge.Client, e
 		return nil, errors.New("ACP workspace provider is not configured")
 	}
 	return r.workspace.MCPClient(ctx, botID)
+}
+
+// ResolveACPAdapterVersion returns the exact version currently behind an npm
+// package's latest dist-tag in the target workspace.
+func (r *Runner) ResolveACPAdapterVersion(ctx context.Context, botID, packageName string, env []string) (string, error) {
+	info, err := r.WorkspaceInfo(ctx, botID)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace: %w", err)
+	}
+	client, err := r.MCPClient(ctx, botID)
+	if err != nil {
+		return "", fmt.Errorf("connect workspace bridge: %w", err)
+	}
+	command := buildShellCommand("npm", []string{"view", packageName, "dist-tags.latest", "--json"})
+	result, err := client.ExecWithOptions(ctx, command, info.DefaultWorkDir, acpAdapterVersionLookupTimeoutSeconds, nil, bridge.ExecOptions{
+		Env: append([]string(nil), env...),
+	})
+	if err != nil {
+		return "", fmt.Errorf("resolve adapter version: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return "", fmt.Errorf("resolve adapter version: npm exited with code %d: %s", result.ExitCode, strings.TrimSpace(result.Stderr))
+	}
+	var version string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(result.Stdout)), &version); err != nil {
+		return "", fmt.Errorf("parse adapter version: %w", err)
+	}
+	version = strings.TrimSpace(version)
+	if !exactACPAdapterVersionPattern.MatchString(version) {
+		return "", fmt.Errorf("npm returned invalid adapter version %q", version)
+	}
+	return version, nil
 }
 
 // Run is a convenience wrapper that performs a single-shot ACP exchange:

--- a/internal/acpclient/client_test.go
+++ b/internal/acpclient/client_test.go
@@ -65,6 +65,57 @@ func (w *rotatingTestWorkspace) WorkspaceInfo(context.Context, string) (bridge.W
 	return w.info, nil
 }
 
+func TestRunnerResolveACPAdapterVersion(t *testing.T) {
+	client, recorder := newRecordingBridgeClient(t)
+	command := "npm view @agentclientprotocol/codex-acp dist-tags.latest --json"
+	recorder.setStdout(command, "\"1.2.3-beta.1\"\n")
+	runner := NewRunner(nil, testWorkspace{
+		client: client,
+		info: bridge.WorkspaceInfo{
+			Backend:        bridge.WorkspaceBackendContainer,
+			DefaultWorkDir: "/data",
+		},
+	})
+	env := []string{"NPM_CONFIG_CACHE=/data/.memoh/acp/npm-cache", "SSL_CERT_FILE=/opt/memoh/toolkit/certs/ca-certificates.crt"}
+
+	version, err := runner.ResolveACPAdapterVersion(context.Background(), "bot-1", "@agentclientprotocol/codex-acp", env)
+	if err != nil {
+		t.Fatalf("ResolveACPAdapterVersion() error = %v", err)
+	}
+	if version != "1.2.3-beta.1" {
+		t.Fatalf("ResolveACPAdapterVersion() = %q", version)
+	}
+	records := recorder.records()
+	if len(records) != 1 {
+		t.Fatalf("adapter version exec records = %#v", records)
+	}
+	record := records[0]
+	if record.Command != command || record.WorkDir != "/data" || record.Timeout != acpAdapterVersionLookupTimeoutSeconds {
+		t.Fatalf("adapter version exec record = %#v", record)
+	}
+	if len(record.Env) != len(env) || record.Env[0] != env[0] || record.Env[1] != env[1] {
+		t.Fatalf("adapter version exec env = %#v, want %#v", record.Env, env)
+	}
+}
+
+func TestRunnerResolveACPAdapterVersionRejectsMutableOrUnsafeSpecs(t *testing.T) {
+	client, recorder := newRecordingBridgeClient(t)
+	command := "npm view @agentclientprotocol/codex-acp dist-tags.latest --json"
+	runner := NewRunner(nil, testWorkspace{
+		client: client,
+		info: bridge.WorkspaceInfo{
+			Backend:        bridge.WorkspaceBackendContainer,
+			DefaultWorkDir: "/data",
+		},
+	})
+	for _, output := range []string{`"latest"`, `"1.2"`, `"1.2.3; touch /tmp/pwned"`, `{}`} {
+		recorder.setStdout(command, output)
+		if _, err := runner.ResolveACPAdapterVersion(context.Background(), "bot-1", "@agentclientprotocol/codex-acp", nil); err == nil {
+			t.Fatalf("ResolveACPAdapterVersion() unexpectedly accepted %s", output)
+		}
+	}
+}
+
 func TestRunnerRunLocalWorkspaceFakeAgent(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "project")

--- a/internal/acpclient/process.go
+++ b/internal/acpclient/process.go
@@ -269,12 +269,13 @@ func prepareProcessEnv(ctx context.Context, client *bridge.Client, workDir strin
 // prepareLocalProcessEnv builds the managed env overrides for a local (desktop)
 // workspace. Local agents run as host processes that inherit the host
 // environment (the bridge appends our entries onto os.Environ), so we only add
-// the BYOK overrides and never touch HOME/PATH. Self mode returns no overrides
-// so the host's own agent login is used as-is.
+// the BYOK overrides and never touch HOME/PATH. Self mode keeps the host's own
+// agent login and config, but still carries the narrow runtime-isolation
+// overrides that do not affect authentication.
 func prepareLocalProcessEnv(opts processOptions) ([]string, error) {
 	mode := normalizeSetupMode(opts.SetupMode)
 	if mode == SetupModeSelf {
-		return nil, nil
+		return npmCacheEnv(opts.Env), nil
 	}
 	env := append([]string(nil), opts.Env...)
 	if isCodexAgent(opts.AgentID) {
@@ -525,6 +526,16 @@ func withoutEnvKeys(env []string, keys ...string) []string {
 		out = append(out, item)
 	}
 	return out
+}
+
+func npmCacheEnv(env []string) []string {
+	for i := len(env) - 1; i >= 0; i-- {
+		key, _, ok := strings.Cut(env[i], "=")
+		if ok && strings.EqualFold(key, "NPM_CONFIG_CACHE") {
+			return []string{env[i]}
+		}
+	}
+	return nil
 }
 
 func withoutBlockedEnvNames(env []string, blocked []string) []string {

--- a/internal/acpclient/process_test.go
+++ b/internal/acpclient/process_test.go
@@ -122,6 +122,36 @@ func TestPrepareProcessEnvLocalSelfHasNoOverrides(t *testing.T) {
 	}
 }
 
+func TestPrepareProcessEnvLocalSelfPreservesNPMCacheOnly(t *testing.T) {
+	client, _ := newRecordingBridgeClient(t)
+	env, cleanup, err := prepareProcessEnv(context.Background(), client, "/data", processOptions{
+		Backend:       WorkspaceBackendLocal,
+		AgentID:       "codex",
+		SetupMode:     SetupModeSelf,
+		WorkspaceRoot: "/home/user/ws",
+		Env: []string{
+			"NPM_CONFIG_CACHE=/memoh/acp/npm-cache",
+			"OPENAI_API_KEY=sk-should-not-pass",
+			"CODEX_HOME=/managed/codex",
+			"CUSTOM_FLAG=should-not-pass",
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepareProcessEnv() error = %v", err)
+	}
+	if cleanup != nil {
+		t.Fatalf("local cleanup should be nil")
+	}
+	if got := envValue(env, "NPM_CONFIG_CACHE"); got != "/memoh/acp/npm-cache" {
+		t.Fatalf("local self NPM_CONFIG_CACHE = %q, env=%v", got, env)
+	}
+	for _, key := range []string{"OPENAI_API_KEY", "CODEX_HOME", "CUSTOM_FLAG"} {
+		if envHasKey(env, key) {
+			t.Fatalf("local self env unexpectedly preserved %s: %v", key, env)
+		}
+	}
+}
+
 func TestPrepareProcessEnvLocalCodexSetsScopedCodexHome(t *testing.T) {
 	client, _ := newRecordingBridgeClient(t)
 	env, cleanup, err := prepareProcessEnv(context.Background(), client, "/home/user/ws/project", processOptions{
@@ -966,13 +996,14 @@ type writeRecord struct {
 type recordingBridgeServer struct {
 	pb.UnimplementedContainerServiceServer
 
-	mu    sync.Mutex
-	execs []execRecord
-	files []writeRecord
-	reads []string
-	dirs_ []string
-	exits map[string]int32
-	seqs  map[string][]int32
+	mu     sync.Mutex
+	execs  []execRecord
+	files  []writeRecord
+	reads  []string
+	dirs_  []string
+	exits  map[string]int32
+	seqs   map[string][]int32
+	stdout map[string]string
 }
 
 func (s *recordingBridgeServer) Exec(stream grpc.BidiStreamingServer[pb.ExecInput, pb.ExecOutput]) error {
@@ -982,6 +1013,7 @@ func (s *recordingBridgeServer) Exec(stream grpc.BidiStreamingServer[pb.ExecInpu
 	}
 	s.mu.Lock()
 	exitCode := s.exits[input.GetCommand()]
+	stdout := s.stdout[input.GetCommand()]
 	if len(s.seqs[input.GetCommand()]) > 0 {
 		exitCode = s.seqs[input.GetCommand()][0]
 		s.seqs[input.GetCommand()] = s.seqs[input.GetCommand()][1:]
@@ -995,6 +1027,11 @@ func (s *recordingBridgeServer) Exec(stream grpc.BidiStreamingServer[pb.ExecInpu
 		Timeout:  input.GetTimeoutSeconds(),
 	})
 	s.mu.Unlock()
+	if stdout != "" {
+		if err := stream.Send(&pb.ExecOutput{Stream: pb.ExecOutput_STDOUT, Data: []byte(stdout)}); err != nil {
+			return err
+		}
+	}
 	if err := stream.Send(&pb.ExecOutput{Stream: pb.ExecOutput_EXIT, ExitCode: exitCode}); err != nil {
 		return err
 	}
@@ -1017,6 +1054,15 @@ func (s *recordingBridgeServer) setExitCode(command string, code int32) {
 		s.exits = make(map[string]int32)
 	}
 	s.exits[command] = code
+}
+
+func (s *recordingBridgeServer) setStdout(command, output string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stdout == nil {
+		s.stdout = make(map[string]string)
+	}
+	s.stdout[command] = output
 }
 
 func (s *recordingBridgeServer) WriteFile(_ context.Context, req *pb.WriteFileRequest) (*pb.WriteFileResponse, error) {

--- a/internal/acpprofile/profile.go
+++ b/internal/acpprofile/profile.go
@@ -22,13 +22,23 @@ const (
 )
 
 type Profile struct {
-	ID           string
-	DisplayName  string
-	Description  string
-	Command      string
-	Args         []string
-	LocalCommand string
-	LocalArgs    []string
+	ID          string
+	DisplayName string
+	Description string
+	// DynamicCommand, DynamicArgs, and DynamicPackage describe an npm-backed
+	// launcher whose version can be refreshed independently of Memoh. The
+	// session pool resolves the dist-tag once per bot for the lifetime of the
+	// server process, launches the resulting exact package version, and falls
+	// back to Command/Args (or
+	// LocalCommand/LocalArgs) when lookup or startup fails. DynamicArgs are the
+	// arguments inserted before the exact package spec.
+	DynamicCommand string
+	DynamicArgs    []string
+	DynamicPackage string
+	Command        string
+	Args           []string
+	LocalCommand   string
+	LocalArgs      []string
 	// SessionModeID, when set, is the ACP session mode Memoh pins right after
 	// session/new so tool permissions flow through ACP regardless of ambient
 	// agent-side configuration (e.g. a host ~/.claude/settings.json).
@@ -194,9 +204,14 @@ func Register(profile Profile) {
 
 func codexProfile() Profile {
 	return Profile{
-		ID:                     AgentCodexID,
-		DisplayName:            AgentCodexName,
-		Description:            "OpenAI Codex ACP adapter",
+		ID:             AgentCodexID,
+		DisplayName:    AgentCodexName,
+		Description:    "OpenAI Codex ACP adapter",
+		DynamicCommand: "npx",
+		DynamicArgs: []string{
+			"-y",
+		},
+		DynamicPackage:         "@agentclientprotocol/codex-acp",
 		Command:                "codex-acp",
 		LocalCommand:           "npx",
 		DefaultReasoningEffort: "medium",
@@ -228,10 +243,15 @@ func codexProfile() Profile {
 
 func claudeCodeProfile() Profile {
 	return Profile{
-		ID:          AgentClaudeCodeID,
-		DisplayName: AgentClaudeCodeName,
-		Description: "Claude Code ACP adapter",
-		Command:     "claude-agent-acp",
+		ID:             AgentClaudeCodeID,
+		DisplayName:    AgentClaudeCodeName,
+		Description:    "Claude Code ACP adapter",
+		DynamicCommand: "npx",
+		DynamicArgs: []string{
+			"-y",
+		},
+		DynamicPackage: "@agentclientprotocol/claude-agent-acp",
+		Command:        "claude-agent-acp",
 		// "default" routes every gated tool through session/request_permission;
 		// without the pin a host-level Claude settings file (defaultMode auto /
 		// acceptEdits) silently bypasses Memoh's approval flow.

--- a/internal/acpprofile/profile_test.go
+++ b/internal/acpprofile/profile_test.go
@@ -14,6 +14,9 @@ func TestListIncludesClaudeCode(t *testing.T) {
 	if profile.Command != "claude-agent-acp" {
 		t.Fatalf("Claude Code command = %q", profile.Command)
 	}
+	if profile.DynamicCommand != "npx" || len(profile.DynamicArgs) != 1 || profile.DynamicArgs[0] != "-y" || profile.DynamicPackage != "@agentclientprotocol/claude-agent-acp" {
+		t.Fatalf("Claude Code dynamic launcher = %q %#v package %q", profile.DynamicCommand, profile.DynamicArgs, profile.DynamicPackage)
+	}
 	if len(profile.ManagedFields) == 0 || !profile.ManagedFields[0].Required {
 		t.Fatalf("Claude Code profile should expose required API key field: %#v", profile.ManagedFields)
 	}
@@ -32,6 +35,19 @@ func TestListIncludesClaudeCode(t *testing.T) {
 	}
 	if len(codex.LocalArgs) != 2 || codex.LocalArgs[1] != "@agentclientprotocol/codex-acp@1.1.4" {
 		t.Fatalf("Codex local args = %#v", codex.LocalArgs)
+	}
+}
+
+func TestCodexUsesControlledACPAdapterUpgradeWithPinnedFallback(t *testing.T) {
+	profile, ok := Lookup(AgentCodexID)
+	if !ok {
+		t.Fatal("Codex profile was not registered")
+	}
+	if profile.DynamicCommand != "npx" || len(profile.DynamicArgs) != 1 || profile.DynamicArgs[0] != "-y" || profile.DynamicPackage != "@agentclientprotocol/codex-acp" {
+		t.Fatalf("Codex dynamic launcher = %q %#v package %q", profile.DynamicCommand, profile.DynamicArgs, profile.DynamicPackage)
+	}
+	if profile.Command != "codex-acp" || profile.LocalCommand != "npx" || len(profile.LocalArgs) != 2 || profile.LocalArgs[1] != "@agentclientprotocol/codex-acp@1.1.4" {
+		t.Fatalf("Codex fallback launcher = command %q, local %q %#v", profile.Command, profile.LocalCommand, profile.LocalArgs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- prefer the latest published Codex and Claude Code ACP adapters on cold start
- reuse a persistent npm cache for local and container workspaces
- fall back to the bundled or pinned adapter when dynamic resolution, startup, or initialization fails
- avoid fallback restarts when startup is cancelled

## Why

Codex and Claude Code ACP adapters are currently pinned in Memoh, so receiving upstream fixes and model support requires rebuilding and releasing the workspace toolkit. This lets ACP runtimes pick up current adapters independently while retaining the known-good packaged versions as a safety net.

## User impact

The upgrade is transparent during ACP runtime startup. This PR does not add a version-management API or UI.

## Validation

- `go test ./...`
- `golangci-lint run --new-from-rev=HEAD ./...`
- `git diff --check`

The repository pre-commit hook's full lint pass still reports existing SA5011 findings in unchanged test files; all tests and lint for the new code pass.