### PR TITLE
feat(web): support concurrent chat session panels

### DIFF
--- a/apps/web/src/components/sidebar/recents.vue
+++ b/apps/web/src/components/sidebar/recents.vue
@@ -62,7 +62,7 @@
               <SessionItem
                 :session="vRow.session"
                 :is-active="sessionId === vRow.session.id"
-                :streaming="chatStore.isSessionStreaming(vRow.session.id)"
+                :streaming="chatStore.isSessionStreaming(currentBotId, vRow.session.id)"
                 @select="handleSelect"
                 @open-new-tab="handleOpenNewTab"
                 @rename="openRenameSessionDialog"

--- a/apps/web/src/pages/home/components/chat-fork-dialog.vue
+++ b/apps/web/src/pages/home/components/chat-fork-dialog.vue
@@ -38,15 +38,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Input, Spinner } from '@felinic/ui'
 import { useI18n } from 'vue-i18n'
-import { storeToRefs } from 'pinia'
 import { useChatStore } from '@/store/chat-list'
+import { useChatViewTarget } from '../composables/useChatViewContext'
 
 // Fork-from-message dialog. The parent only opens it with the target message
-// id; the fork call itself goes through the chat store here, so a successful
-// fork also switches the active session as a side effect of forkMessage.
+// id; the fork call itself goes through the chat store, which routes the result
+// back to this panel even if another split gains focus while it is being made.
 const props = defineProps<{
   open: boolean
   messageId: string
@@ -58,7 +58,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const chatStore = useChatStore()
-const { activeSession } = storeToRefs(chatStore)
+const chatViewTarget = useChatViewTarget()
+const activeSession = computed(() => chatStore.chatTargetFor(chatViewTarget.value).session)
 
 const forkSessionTitle = ref('')
 const forkSubmitting = ref(false)
@@ -80,7 +81,7 @@ async function handleCreateFork() {
   if (!messageId || !title || forkSubmitting.value) return
   forkSubmitting.value = true
   try {
-    const ok = await chatStore.forkMessage(messageId, { title })
+    const ok = await chatStore.forkMessage(messageId, { title, target: chatViewTarget.value })
     if (ok) emit('update:open', false)
   } finally {
     forkSubmitting.value = false

--- a/apps/web/src/pages/home/components/chat-pane-send.test.ts
+++ b/apps/web/src/pages/home/components/chat-pane-send.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { captureChatPaneSendContext, matchesChatPaneSendContext } from './chat-pane-send'
+
+describe('chat pane send context', () => {
+  it('keeps the original target after an ephemeral pane is repointed', () => {
+    const target = {
+      botId: 'bot-1',
+      sessionId: 'session-a',
+      viewId: 'chat:1',
+    }
+    const context = captureChatPaneSendContext(target, 'bot-1:chat:1')
+
+    target.sessionId = 'session-b'
+
+    expect(context.target).toEqual({
+      botId: 'bot-1',
+      sessionId: 'session-a',
+      viewId: 'chat:1',
+    })
+    expect(Object.isFrozen(context.target)).toBe(true)
+  })
+
+  it('restores a failed attachment conversion only into the original composer', () => {
+    const context = captureChatPaneSendContext({
+      botId: 'bot-1',
+      sessionId: 'session-a',
+      viewId: 'chat:1',
+    }, 'bot-1:chat:1')
+
+    expect(matchesChatPaneSendContext(context, {
+      botId: 'bot-1',
+      sessionId: 'session-a',
+      viewId: 'chat:1',
+    }, 'bot-1:chat:1')).toBe(true)
+    expect(matchesChatPaneSendContext(context, {
+      botId: 'bot-1',
+      sessionId: 'session-b',
+      viewId: 'chat:1',
+    }, 'bot-1:chat:1')).toBe(false)
+    expect(matchesChatPaneSendContext(context, {
+      botId: 'bot-1',
+      sessionId: 'session-a',
+      viewId: 'chat:2',
+    }, 'bot-1:chat:2')).toBe(false)
+  })
+})

--- a/apps/web/src/pages/home/components/chat-pane-send.ts
+++ b/apps/web/src/pages/home/components/chat-pane-send.ts
@@ -1,0 +1,27 @@
+import type { ChatViewTarget } from '@/store/chat-list'
+
+export interface ChatPaneSendContext {
+  readonly target: ChatViewTarget
+  readonly composerScope: string
+}
+
+export function captureChatPaneSendContext(
+  target: ChatViewTarget,
+  composerScope: string,
+): ChatPaneSendContext {
+  return Object.freeze({
+    target: Object.freeze({ ...target }),
+    composerScope: composerScope || 'chat',
+  })
+}
+
+export function matchesChatPaneSendContext(
+  context: ChatPaneSendContext,
+  target: ChatViewTarget,
+  composerScope: string,
+): boolean {
+  return context.target.botId === target.botId
+    && context.target.sessionId === target.sessionId
+    && context.target.viewId === target.viewId
+    && context.composerScope === (composerScope || 'chat')
+}

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -127,7 +127,7 @@
           <ChatScrollRail
             :messages="messages"
             :scroll-el="scrollEl"
-            :enabled="isActive && !loadingChats"
+            :enabled="isVisible && !loadingChats"
             @jump="handleRailJump"
           />
         </section>
@@ -772,7 +772,7 @@
                       :aria-label="streaming ? 'Stop generating response' : 'Send message'"
                       class="absolute inset-0 size-9 rounded-full transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none"
                       :class="(sendButtonVisible || streaming) ? 'scale-100 opacity-100' : 'pointer-events-none scale-0 opacity-0'"
-                      @click="streaming ? chatStore.abort() : handleSend()"
+                      @click="streaming ? chatStore.abort(paneTarget) : handleSend()"
                     >
                       <span
                         class="grid size-[20px] shrink-0 place-items-center"
@@ -838,6 +838,7 @@ import {
 } from 'lucide-vue-next'
 import { ScrollArea, Button, Popover, PopoverContent, PopoverTrigger, DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuLabel, DropdownMenuItem, DropdownMenuSeparator, Dialog, DialogContent, DialogHeader, DialogTitle, Command, CommandGroup, CommandItem, CommandKeyBridge, CommandList, CommandSeparator, Spinner, toast } from '@felinic/ui'
 import { useChatStore, type ACPAgentSessionInput, type ChatMessage } from '@/store/chat-list'
+import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { storeToRefs } from 'pinia'
 import { useIntersectionObserver } from '@vueuse/core'
 import { useQuery } from '@pinia/colada'
@@ -864,8 +865,10 @@ import { useMediaGallery } from '../composables/useMediaGallery'
 import { ATTACHMENT_ANIM_MS, attachmentToFile, fileToAttachment, useComposerAttachments } from '../composables/useComposerAttachments'
 import { useComposerDrafts } from '../composables/useComposerDrafts'
 import { useComposerLayout } from '../composables/useComposerLayout'
+import { provideChatViewTarget } from '../composables/useChatViewContext'
 import { fetchSafeSkillCatalog, fetchSession, type ChatAttachment, type CommandActionError, type CommandActionListItem, type RequestedSkillSelection, type UIUserInput } from '@/composables/api/useChat'
 import { commandResultQuickActionText, isCommandResultItemSelectable } from './slash-command-result'
+import { captureChatPaneSendContext, matchesChatPaneSendContext } from './chat-pane-send'
 import { onAuthSessionCleared } from '@/lib/auth-session'
 import { useACPRuntime } from '@/composables/useACPRuntime'
 import { ACP_DEFAULT_PROJECT_MODE, ACP_DEFAULT_PROJECT_PATH, acpAgentIcon, findMissingRequiredManagedField, isACPAgentEnabled, isACPNoProject, normalizeACPAgentID, readACPAgentConfig } from '@/utils/acp'
@@ -879,15 +882,18 @@ const props = withDefaults(defineProps<{
   // The session this pane renders (null = unsaved draft). Decoupled from tabId so
   // a draft→real promotion never remounts this pane.
   sessionId?: string | null
+  visible?: boolean
   active?: boolean
 }>(), {
   tabId: 'chat',
   sessionId: null,
+  visible: true,
   active: true,
 })
 
 const { t } = useI18n()
 const chatStore = useChatStore()
+const workspaceTabs = useWorkspaceTabsStore()
 const { pill: bgTaskPill, scrollToOffscreen, cleanup: cleanupBgTaskBeacons } = provideBgTaskBeacons()
 onBeforeUnmount(cleanupBgTaskBeacons)
 const {
@@ -914,30 +920,47 @@ const agentChanging = ref(false)
 const acpModelChanging = ref(false)
 
 const {
-  messages,
-  streaming,
   currentBotId,
   bots,
-  activeSession,
-  activeChatTarget,
-  activeChatReadOnly,
-  activeChatCanFork,
-  loadingOlder,
   loadingChats,
-  loadingMessages,
-  hasMoreOlder,
-  overrideModelId,
-  overrideReasoningEffort,
-  startupSendFailure,
-  pendingACPModelId,
-  pendingACPRuntimeStatus,
-  pendingACPRuntimeEnsuring,
   hasExplicitSessionSelection,
 } = storeToRefs(chatStore)
 
 const isActive = computed(() => props.active !== false)
+const isVisible = computed(() => props.visible !== false)
+const paneTarget = computed(() => ({
+  botId: currentBotId.value?.trim() ?? '',
+  sessionId: props.sessionId?.trim() || null,
+  viewId: props.tabId.trim() || 'chat',
+}))
+provideChatViewTarget(paneTarget)
+const pendingACPState = computed(() => chatStore.pendingACPStateFor(paneTarget.value))
+const pendingACPModelId = computed(() => pendingACPState.value?.modelId ?? '')
+const pendingACPRuntimeStatus = computed(() => pendingACPState.value?.runtimeStatus)
+const pendingACPRuntimeEnsuring = computed(() => pendingACPState.value?.ensuring ?? false)
+const paneView = computed(() => chatStore.chatView(paneTarget.value))
+const messages = computed(() => paneView.value.transcript.messages)
+const loadingMessages = computed(() => paneView.value.transcript.loadingMessages.value)
+const loadingOlder = computed(() => paneView.value.transcript.loadingOlder.value)
+const hasMoreOlder = computed(() => paneView.value.transcript.hasMoreOlder.value)
+const streaming = computed(() => chatStore.isChatViewStreaming(paneTarget.value))
+const creatingSession = computed(() => chatStore.isChatViewCreatingSession(paneTarget.value))
+const activeChatTarget = computed(() => chatStore.chatTargetFor(paneTarget.value))
+const activeSession = computed(() => activeChatTarget.value.session)
+const activeChatReadOnly = computed(() => chatStore.chatReadOnlyFor(paneTarget.value))
+const activeChatCanFork = computed(() => chatStore.chatCanForkFor(paneTarget.value))
+const overrideModelId = ref('')
+const overrideReasoningEffort = ref('')
+const paneComposerScope = computed(() => {
+  const botId = paneTarget.value.botId
+  return botId ? `${botId}:${paneTarget.value.viewId}` : 'chat'
+})
+const startupSendFailure = computed(() => chatStore.startupSendFailureFor(
+  paneTarget.value,
+  paneComposerScope.value,
+))
 const hasRenderedSession = computed(() =>
-  !!(props.sessionId || activeChatTarget.value.sessionId || chatStore.sessionId || '').trim(),
+  !!(paneTarget.value.sessionId || activeChatTarget.value.sessionId || '').trim(),
 )
 
 // A fresh, writable chat opens with the composer centred and a greeting above
@@ -1113,7 +1136,7 @@ const activeACPProjectLabel = computed(() => {
   const parts = path.split('/').filter(Boolean)
   return path ? parts[parts.length - 1] ?? path : t('chat.noProject')
 })
-const canChangeAgent = computed(() => !streaming.value && messages.value.length === 0)
+const canChangeAgent = computed(() => !streaming.value && !creatingSession.value && messages.value.length === 0)
 
 
 function messageMatchesForkSource(message: ChatMessage): boolean {
@@ -1146,7 +1169,7 @@ function showForkSourceDividerBefore(index: number): boolean {
 const composerMenuHasItems = computed(() =>
   (canChangeAgent.value && enabledACPProfiles.value.length > 0) || !activeIsACP.value,
 )
-const activeSessionId = computed(() => activeSession.value?.id ?? '')
+const activeSessionId = computed(() => paneTarget.value.sessionId ?? activeSession.value?.id ?? '')
 const requestedSkills = ref<RequestedSkillSelection[]>([])
 const skillSlashEnabled = computed(() => !activeIsACP.value && !activeIsPendingACP.value)
 const { data: safeSkillCatalog, isLoading: safeSkillCatalogLoading } = useQuery({
@@ -1178,7 +1201,7 @@ function addRequestedSkill(skill: RequestedSkillSelection) {
     inputText.value = ''
     saveInputDraft(inputDraftKey.value, '')
   }
-  chatStore.clearCommandEvent()
+  clearCurrentCommandEvent()
   void nextTick(focusTextarea)
 }
 
@@ -1190,13 +1213,13 @@ function removeRequestedSkill(skill: RequestedSkillSelection) {
 
 watch([currentBotId, activeSessionId], () => {
   requestedSkills.value = []
-  chatStore.clearCommandEvent()
+  clearCurrentCommandEvent()
 })
 
 watch(skillSlashEnabled, (enabled) => {
   if (enabled) return
   requestedSkills.value = []
-  chatStore.clearCommandEvent()
+  clearCurrentCommandEvent()
 })
 
 const slashQuickActions = computed(() => [
@@ -1280,6 +1303,9 @@ const {
   isCompacting: isCompactingSession,
   triggerCompact: triggerSessionCompact,
 } = useSessionInfo({
+  botId: computed(() => paneTarget.value.botId),
+  sessionId: computed(() => paneTarget.value.sessionId),
+  visible: isVisible,
   overrideModelId,
   fallbackContextWindow: computed(() => activeModel.value?.config?.context_window ?? null),
 })
@@ -1340,9 +1366,9 @@ function localQuickActionIDForSlash(text: string): string {
 }
 
 function currentPaneCommandScope() {
-  const activeBotId = (currentBotId.value ?? '').trim()
-  const renderedSessionId = (props.sessionId || activeSessionId.value || chatStore.sessionId || '').trim()
-  const paneScope = activeBotId && props.tabId.trim() ? `${activeBotId}:${props.tabId.trim()}` : 'chat'
+  const activeBotId = paneTarget.value.botId
+  const renderedSessionId = paneTarget.value.sessionId ?? ''
+  const paneScope = paneComposerScope.value
   return renderedSessionId
     ? { botId: activeBotId || undefined, sessionId: renderedSessionId, composerScope: paneScope }
     : { botId: activeBotId || undefined, composerScope: paneScope }
@@ -1585,25 +1611,27 @@ function pendingMatchesDefaultACP(input: ACPAgentSessionInput): boolean {
     && metadata?.acp_project_mode === (input.projectMode || ACP_DEFAULT_PROJECT_MODE)
 }
 
-watch([defaultACPUnavailableMessage, defaultACPLoading, currentBotId, hasExplicitSessionSelection], ([message, loading]) => {
+watch([defaultACPUnavailableMessage, defaultACPLoading, currentBotId, hasExplicitSessionSelection, isActive], ([message, loading, _bot, _explicit, focused]) => {
+  if (!focused) return
   clearDefaultACPComposerError()
   if (!message || !currentBotId.value) return
   if (hasExplicitSessionSelection.value) return
   if (!loading) {
-    chatStore.resetToEmptyComposer()
+    chatStore.resetToEmptyComposer({}, paneTarget.value)
   }
   defaultACPComposerError.value = message
   composerError.value = message
 }, { immediate: true })
 
-watch([defaultACPSessionInput, defaultACPLoading, currentBotId, hasExplicitSessionSelection, activeChatTarget], ([input, loading]) => {
+watch([defaultACPSessionInput, defaultACPLoading, currentBotId, hasExplicitSessionSelection, activeChatTarget, isActive], ([input, loading, _bot, _explicit, _target, focused]) => {
+  if (!focused) return
   if (!currentBotId.value) return
   if (!input) {
     if (!loading) {
       chatStore.cacheDefaultACPSession(null)
     }
     if (!loading && !hasExplicitSessionSelection.value && activeIsPendingACP.value) {
-      chatStore.resetToEmptyComposer()
+      chatStore.resetToEmptyComposer({}, paneTarget.value)
     }
     return
   }
@@ -1611,14 +1639,14 @@ watch([defaultACPSessionInput, defaultACPLoading, currentBotId, hasExplicitSessi
   if (hasExplicitSessionSelection.value) return
   clearDefaultACPComposerError()
   if (pendingMatchesDefaultACP(input)) return
-  chatStore.stageDefaultACPSession(input)
+  chatStore.stageDefaultACPSession(input, paneTarget.value)
 }, { immediate: true })
 
 watch([modelPopoverOpen, activeIsPendingACP, activeIsACP, activeSessionId], ([open, isPending, isACP, sessionID]) => {
   if (!open) return
   if (isPending) {
     if (pendingACPRuntimeStatus.value || pendingACPRuntimeEnsuring.value) return
-    void chatStore.ensurePendingACPRuntime().catch((error) => {
+    void chatStore.ensurePendingACPRuntime(paneTarget.value).catch((error) => {
       composerError.value = resolveApiErrorMessage(error, t('chat.agentSwitchFailed'))
     })
     return
@@ -1667,15 +1695,15 @@ async function selectACPAgent(profile: AcpprofilePublicProfile) {
   agentChanging.value = true
   composerError.value = ''
   try {
-    if (chatStore.sessionId) {
+    if (paneTarget.value.sessionId) {
       await withAgentSwitchTimeout(chatStore.updateCurrentSessionAgent({
         agentId,
-      }))
+      }, paneTarget.value))
     } else {
       chatStore.stageACPSession({
         agentId,
-      })
-      await withAgentSwitchTimeout(chatStore.ensurePendingACPRuntime())
+      }, {}, paneTarget.value)
+      await withAgentSwitchTimeout(chatStore.ensurePendingACPRuntime(paneTarget.value))
     }
     pendingFiles.value = []
   } catch (error) {
@@ -1688,8 +1716,8 @@ async function selectACPAgent(profile: AcpprofilePublicProfile) {
 async function selectMemohAgent() {
   if (agentChanging.value || !canChangeAgent.value) return
   agentPopoverOpen.value = false
-  if (!chatStore.sessionId) {
-    chatStore.resetToEmptyComposer({ explicitSelection: true })
+  if (!paneTarget.value.sessionId) {
+    chatStore.resetToEmptyComposer({ explicitSelection: true }, paneTarget.value)
     clearDefaultACPComposerError()
     composerError.value = ''
     pendingFiles.value = []
@@ -1699,7 +1727,7 @@ async function selectMemohAgent() {
   agentChanging.value = true
   composerError.value = ''
   try {
-    await withAgentSwitchTimeout(chatStore.updateCurrentSessionToMemoh())
+    await withAgentSwitchTimeout(chatStore.updateCurrentSessionToMemoh(paneTarget.value))
   } catch (error) {
     composerError.value = agentSwitchErrorMessage(error)
   } finally {
@@ -1724,7 +1752,7 @@ async function onACPModelSelected(model: AcpclientModelInfo) {
     acpModelChanging.value = true
     composerError.value = ''
     try {
-      await chatStore.setPendingACPModel(modelId)
+      await chatStore.setPendingACPModel(modelId, paneTarget.value)
     } catch (error) {
       composerError.value = resolveApiErrorMessage(error, t('chat.modelSwitchFailed'))
     } finally {
@@ -1750,7 +1778,7 @@ async function onPendingACPDefaultModelSelected() {
   composerError.value = ''
   try {
     // May reset the warm runtime back to the agent default model.
-    await chatStore.setPendingACPModel('')
+    await chatStore.setPendingACPModel('', paneTarget.value)
   } catch (error) {
     composerError.value = resolveApiErrorMessage(error, t('chat.modelSwitchFailed'))
   } finally {
@@ -1811,46 +1839,21 @@ const { inputDraftKey, saveInputDraft, clearAllDrafts } = useComposerDrafts({
 
 watch([
   startupSendFailure,
-  currentBotId,
-  () => chatStore.sessionId,
-  () => props.tabId,
-  isActive,
+  paneTarget,
+  isVisible,
 ], ([failure]) => {
-  if (!failure || !isActive.value) return
-  const discardFailure = () => chatStore.clearStartupSendFailure(failure.id)
-  if (failure.botId && failure.botId !== currentBotId.value) {
-    discardFailure()
-    return
-  }
+  if (!failure || !isVisible.value) return
+  if (failure.botId && failure.botId !== paneTarget.value.botId) return
   const failureScope = failure.composerScope?.trim()
   const paneScope = inputDraftKey.value || 'chat'
-  const renderedSessionId = (props.sessionId || activeSessionId.value || chatStore.sessionId || '').trim()
+  const renderedSessionId = paneTarget.value.sessionId ?? ''
   if (failureScope) {
-    if (failureScope !== paneScope) {
-      discardFailure()
-      return
-    }
+    if (failureScope !== paneScope) return
     if (failure.sessionId) {
-      if (renderedSessionId !== failure.sessionId) {
-        discardFailure()
-        return
-      }
-    } else if (renderedSessionId) {
-      discardFailure()
-      return
-    }
+      if (renderedSessionId !== failure.sessionId) return
+    } else if (renderedSessionId) return
   } else {
-    if (failure.sessionId && failure.sessionId !== chatStore.sessionId) {
-      discardFailure()
-      return
-    }
-    // This pane carries the session it renders directly now (was derived from tabId
-    // which is the stable panel id, not the session). A draft pane (null) still
-    // accepts the restore for the send it just attempted.
-    if (failure.sessionId && props.sessionId && props.sessionId !== failure.sessionId) {
-      discardFailure()
-      return
-    }
+    if (failure.sessionId && failure.sessionId !== renderedSessionId) return
   }
 
   inputText.value = failure.restoreInput
@@ -1932,8 +1935,8 @@ const {
   contentEl: descEl,
   lastTurnEl,
   messages,
-  isActive,
-  sessionId: computed(() => chatStore.sessionId),
+  isActive: isVisible,
+  sessionId: computed(() => paneTarget.value.sessionId ?? `draft:${paneTarget.value.viewId}`),
 })
 const showJumpToBottom = computed(() => showJumpToBottomFromScroll.value && !loadingChats.value)
 
@@ -1965,7 +1968,7 @@ async function ensureOlderLoaded() {
   if (!messages.value.length) return
   suppressAutoScrollForPrepend()
   try {
-    await chatStore.loadOlderMessages()
+    await chatStore.loadOlderMessages(paneTarget.value)
   } catch (error) {
     console.error('Failed to load older messages:', error)
   }
@@ -1974,7 +1977,7 @@ async function ensureOlderLoaded() {
 useIntersectionObserver(
   loadMoreSentinel,
   ([entry]) => {
-    if (!isActive.value) return
+    if (!isVisible.value) return
     if (!entry?.isIntersecting) return
     void ensureOlderLoaded()
   },
@@ -1996,9 +1999,9 @@ onDeactivated(() => {
 async function handleReplyJump(messageId: string) {
   const target = messageId.trim()
   if (!target) return
-  const localId = chatStore.findMessageIdByExternalId(target)
+  const localId = chatStore.findMessageIdByExternalId(target, paneTarget.value)
   if (localId && await scrollToMessage(localId)) return
-  const locatedId = await chatStore.locateMessageByExternalId(target)
+  const locatedId = await chatStore.locateMessageByExternalId(target, paneTarget.value)
   if (locatedId) {
     await scrollToMessage(locatedId)
   }
@@ -2008,10 +2011,17 @@ async function handleForkSourceClick() {
   const source = forkSource.value
   const botId = currentBotId.value?.trim() ?? ''
   if (!source || !botId || openingForkSource.value) return
+  const origin = { ...paneTarget.value }
   openingForkSource.value = true
   try {
     await fetchSession(botId, source.sessionId)
-    await chatStore.selectSession(source.sessionId, { explicitSelection: true })
+    workspaceTabs.openSessionChatFromView({
+      viewId: origin.viewId,
+      sessionId: source.sessionId,
+      title: source.title,
+      expectedSessionId: origin.sessionId,
+      explicitSelection: true,
+    })
   } catch {
     toast.error(t('chat.forkSourceUnavailable'))
   } finally {
@@ -2069,7 +2079,11 @@ function handleComposerKeydown(e: KeyboardEvent) {
 
 async function handleRetryMessage(messageId: string) {
   composerError.value = ''
-  const result = await chatStore.retryLatestAssistant(messageId)
+  const result = await chatStore.retryLatestAssistant(messageId, {
+    target: paneTarget.value,
+    modelId: overrideModelId.value,
+    reasoningEffort: overrideReasoningEffort.value,
+  })
   if (!result.ok && result.error) {
     composerError.value = result.error
   }
@@ -2078,7 +2092,11 @@ async function handleRetryMessage(messageId: string) {
 async function handleEditMessage(messageId: string, text: string, done?: (started: boolean) => void) {
   composerError.value = ''
   try {
-    const result = await chatStore.editLatestUser(messageId, text)
+    const result = await chatStore.editLatestUser(messageId, text, {
+      target: paneTarget.value,
+      modelId: overrideModelId.value,
+      reasoningEffort: overrideReasoningEffort.value,
+    })
     if (!result.ok && result.error) {
       composerError.value = result.error
     }
@@ -2123,9 +2141,12 @@ async function handleSend() {
   }
 
   const sentDraftKey = inputDraftKey.value
-  const sentComposerScope = inputDraftKey.value || 'chat'
-  const sentBotId = currentBotId.value ?? ''
-  const sentSessionId = activeSessionId.value || ''
+  const sentContext = captureChatPaneSendContext(
+    paneTarget.value,
+    inputDraftKey.value || 'chat',
+  )
+  const sentModelId = overrideModelId.value
+  const sentReasoningEffort = overrideReasoningEffort.value
   composerError.value = ''
   inputText.value = ''
   saveInputDraft(sentDraftKey, '')
@@ -2138,6 +2159,11 @@ async function handleSend() {
       attachments = await Promise.all(files.map(fileToAttachment))
     }
   } catch (error) {
+    if (!matchesChatPaneSendContext(
+      sentContext,
+      paneTarget.value,
+      inputDraftKey.value || 'chat',
+    )) return
     inputText.value = text
     pendingFiles.value = files
     requestedSkills.value = skills
@@ -2150,9 +2176,17 @@ async function handleSend() {
   // not leave a latent pin behind; startup failures roll the arm back.
   let rollbackPin: (() => void) | null = null
   const result = await chatStore.sendMessage(text, attachments, {
+    target: sentContext.target,
+    modelId: sentModelId,
+    reasoningEffort: sentReasoningEffort,
     requestedSkills: skills,
-    composerScope: sentComposerScope,
+    composerScope: sentContext.composerScope,
     onBeforeTurnAppend: () => {
+      if (!matchesChatPaneSendContext(
+        sentContext,
+        paneTarget.value,
+        inputDraftKey.value || 'chat',
+      )) return
       rollbackPin = pinAfterSend()
     },
     onTurnAppendAborted: () => {
@@ -2163,11 +2197,11 @@ async function handleSend() {
   rollbackPin = null
   if (!result.ok && result.stage === 'startup') {
     const restoreInput = result.restoreInput ?? text
-    const activeRenderedSessionId = (props.sessionId || activeSessionId.value || chatStore.sessionId || '').trim()
-    const stillOriginalComposer = (currentBotId.value ?? '') === sentBotId
-      && (inputDraftKey.value || 'chat') === sentComposerScope
-      && ((!sentSessionId && !activeRenderedSessionId) || (!!sentSessionId && activeRenderedSessionId === sentSessionId))
-    if (!stillOriginalComposer) return
+    if (!matchesChatPaneSendContext(
+      sentContext,
+      paneTarget.value,
+      inputDraftKey.value || 'chat',
+    )) return
     inputText.value = restoreInput
     saveInputDraft(sentDraftKey, restoreInput)
     pendingFiles.value = files

--- a/apps/web/src/pages/home/components/chat-scroll-rail.vue
+++ b/apps/web/src/pages/home/components/chat-scroll-rail.vue
@@ -66,7 +66,8 @@ const props = defineProps<{
   messages: ChatMessage[]
   // The chat scroll container; also observed here to track the active tick.
   scrollEl: Ref<HTMLElement | null> | HTMLElement | null
-  // Parent-level visibility gate (pane active + not booting).
+  // Parent-level visibility gate (pane visible + not booting). Split groups
+  // remain rendered together, even though dockview focuses only one of them.
   enabled: boolean
 }>()
 

--- a/apps/web/src/pages/home/components/chat-user-input-form.vue
+++ b/apps/web/src/pages/home/components/chat-user-input-form.vue
@@ -108,6 +108,7 @@ import { Button } from '@felinic/ui'
 import { Circle, CircleDot, Square, SquareCheck } from 'lucide-vue-next'
 import { useChatStore } from '@/store/chat-list'
 import type { UIUserInput, UIUserInputQuestion, WSUserInputAnswer } from '@/composables/api/useChat'
+import { useChatViewTarget } from '../composables/useChatViewContext'
 
 // Inline Q&A form for the ask_user tool. The parent decides WHICH pending
 // user-input to render (it scans the transcript); this component owns the
@@ -124,6 +125,7 @@ interface PendingUserInputDraft {
 }
 
 const chatStore = useChatStore()
+const chatViewTarget = useChatViewTarget()
 const drafts = ref<Record<string, PendingUserInputDraft>>({})
 
 const questions = computed(() => props.userInput.questions ?? [])
@@ -232,13 +234,13 @@ const canSubmit = computed(() => answers.value !== null)
 
 function handleSubmit() {
   if (!answers.value) return
-  void chatStore.respondUserInput(props.userInput, { answers: answers.value })
+  void chatStore.respondUserInput(props.userInput, { answers: answers.value }, chatViewTarget.value)
 }
 
 function handleCancel() {
   void chatStore.respondUserInput(props.userInput, {
     canceled: true,
     reason: 'user_canceled',
-  })
+  }, chatViewTarget.value)
 }
 </script>

--- a/apps/web/src/pages/home/components/dockview/panel-chat.vue
+++ b/apps/web/src/pages/home/components/dockview/panel-chat.vue
@@ -6,27 +6,28 @@
         :key="`chat-pane:${currentBotId}:${panelId}`"
         :tab-id="panelId"
         :session-id="paramsSessionId"
-        :active="visible"
+        :visible="visible"
+        :active="focused"
       />
     </KeepAlive>
   </DockPanelFrame>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import type { DockviewApi, DockviewPanelApi } from 'dockview-vue'
 import { useChatStore } from '@/store/chat-list'
 import ChatPane from '../chat-pane.vue'
-import { usePanelVisible } from './use-panel-visible'
+import { usePanelFocused, usePanelVisible } from './use-panel-visible'
 import DockPanelFrame from './panel-frame.vue'
 
 // A per-session chat tab. The panel id (chat:<n>) is stable for the tab's whole
 // life; the session it renders lives in params.sessionId (null = unsaved draft)
 // and the workspace store mutates it (draft→real promotion) via updateParameters
 // WITHOUT remounting ChatPane — the keep-alive key is the panel id, not the
-// session. The single global messages array means only the ACTIVE chat tab is
-// live; activating a tab selects its session (see workspace-tabs onDidActivePanelChange).
+// session. Session data is keyed independently from the focused selection, so
+// every visible split can stay live at the same time.
 // No breadcrumb: the tab already carries the session title.
 const props = defineProps<{
   params: {
@@ -40,6 +41,23 @@ const chatStore = useChatStore()
 const { currentBotId } = storeToRefs(chatStore)
 
 const visible = usePanelVisible(props.params.api)
+const focused = usePanelFocused(props.params.api)
 const panelId = props.params.api.id
 const paramsSessionId = computed(() => props.params.params.sessionId ?? null)
+
+watch([currentBotId, paramsSessionId, visible], ([botId, sessionId, isVisible]) => {
+  const bid = botId?.trim() ?? ''
+  if (!bid) return
+  chatStore.bindChatView(panelId, {
+    botId: bid,
+    sessionId,
+    viewId: panelId,
+  }, isVisible)
+}, { immediate: true })
+
+watch(focused, (isFocused) => {
+  if (isFocused) chatStore.focusChatView(panelId)
+}, { immediate: true })
+
+onBeforeUnmount(() => chatStore.unbindChatView(panelId))
 </script>

--- a/apps/web/src/pages/home/components/dockview/use-panel-visible.ts
+++ b/apps/web/src/pages/home/components/dockview/use-panel-visible.ts
@@ -12,3 +12,17 @@ export function usePanelVisible(api: DockviewPanelApi): Ref<boolean> {
   onBeforeUnmount(() => disposable.dispose())
   return visible
 }
+
+export function usePanelFocused(api: DockviewPanelApi): Ref<boolean> {
+  const focused = ref(api.isActive && api.isGroupActive)
+  const sync = () => {
+    focused.value = api.isActive && api.isGroupActive
+  }
+  const panelDisposable = api.onDidActiveChange(sync)
+  const groupDisposable = api.onDidActiveGroupChange(sync)
+  onBeforeUnmount(() => {
+    panelDisposable.dispose()
+    groupDisposable.dispose()
+  })
+  return focused
+}

--- a/apps/web/src/pages/home/components/tool-call-inline.vue
+++ b/apps/web/src/pages/home/components/tool-call-inline.vue
@@ -188,6 +188,7 @@ import { useI18n } from 'vue-i18n'
 import type { ToolCallBlock } from '@/store/chat-list'
 import { useChatStore } from '@/store/chat-list'
 import { openInFileManagerKey } from '../composables/useFileManagerProvider'
+import { useChatViewTarget } from '../composables/useChatViewContext'
 import {
   getToolDisplay,
   isDirPathTool,
@@ -203,6 +204,7 @@ import Capsule from './tool-detail/capsule.vue'
 const props = defineProps<{ block: ToolCallBlock, inGroup?: boolean }>()
 const { t } = useI18n()
 const chatStore = useChatStore()
+const chatViewTarget = useChatViewTarget()
 
 const openInFileManager = inject(openInFileManagerKey, undefined)
 
@@ -369,6 +371,6 @@ function handleOpenInFiles() {
 function handleApproval(decision: 'approve' | 'reject') {
   const approval = props.block.approval
   if (!approval) return
-  void chatStore.respondToolApproval(approval, decision)
+  void chatStore.respondToolApproval(approval, decision, chatViewTarget.value)
 }
 </script>

--- a/apps/web/src/pages/home/composables/useChatViewContext.ts
+++ b/apps/web/src/pages/home/composables/useChatViewContext.ts
@@ -1,0 +1,22 @@
+import { computed, hasInjectionContext, inject, provide, type InjectionKey, type Ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useChatStore, type ChatViewTarget } from '@/store/chat-list'
+
+const chatViewTargetKey: InjectionKey<Ref<ChatViewTarget>> = Symbol('chat-view-target')
+
+export function provideChatViewTarget(target: Ref<ChatViewTarget>) {
+  provide(chatViewTargetKey, target)
+}
+
+export function useChatViewTarget(): Ref<ChatViewTarget> {
+  const provided = hasInjectionContext() ? inject(chatViewTargetKey, null) : null
+  if (provided) return provided
+
+  const chatStore = useChatStore()
+  const { currentBotId, sessionId } = storeToRefs(chatStore)
+  return computed(() => ({
+    botId: currentBotId.value?.trim() ?? '',
+    sessionId: sessionId.value?.trim() || null,
+    viewId: 'chat',
+  }))
+}

--- a/apps/web/src/pages/home/composables/useSessionInfo.ts
+++ b/apps/web/src/pages/home/composables/useSessionInfo.ts
@@ -7,8 +7,11 @@ import { getBotsByBotIdSessionsBySessionIdStatus, postBotsByBotIdSessionsBySessi
 import type { HandlersSessionInfoResponse } from '@memohai/sdk'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import { useChatStore } from '@/store/chat-list'
+import { useChatViewTarget } from './useChatViewContext'
 
 interface UseSessionInfoOptions {
+  botId?: Ref<string | null | undefined>
+  sessionId?: Ref<string | null | undefined>
   visible?: Ref<boolean>
   overrideModelId?: Ref<string>
   // The session status only reports a context window once the backend can
@@ -19,7 +22,13 @@ interface UseSessionInfoOptions {
 
 export function useSessionInfo(options: UseSessionInfoOptions = {}) {
   const chatStore = useChatStore()
-  const { currentBotId, sessionId } = storeToRefs(chatStore)
+  const storeRefs = storeToRefs(chatStore)
+  const viewTarget = useChatViewTarget()
+  const currentBotId = options.botId ?? computed(() => viewTarget.value.botId || storeRefs.currentBotId.value)
+  // The injected target already falls back to the global selection when there
+  // is no ChatPane provider. Within a provided Draft, null is the real target
+  // and must not inherit another pane's focused Session.
+  const sessionId = options.sessionId ?? computed(() => viewTarget.value.sessionId)
   const visible = options.visible ?? ref(true)
 
   const { data: info } = useQuery({

--- a/apps/web/src/pages/home/composables/useSubagentList.test.ts
+++ b/apps/web/src/pages/home/composables/useSubagentList.test.ts
@@ -18,11 +18,17 @@ vi.hoisted(() => {
 })
 
 const api = vi.hoisted(() => ({
+  closeACPRuntime: vi.fn(),
   connectWebSocket: vi.fn(),
+  createACPRuntime: vi.fn(),
+  ensureACPRuntime: vi.fn(),
   fetchBots: vi.fn(),
   fetchMessagesUI: vi.fn(),
   fetchSession: vi.fn(),
   fetchSessions: vi.fn(),
+  locateMessageUI: vi.fn(),
+  setACPRuntimeModel: vi.fn(),
+  setACPRuntimeModelByID: vi.fn(),
   streamBotSessionsActivityEvents: vi.fn(),
   streamSessionMessageEvents: vi.fn(),
 }))
@@ -43,6 +49,18 @@ const colada = vi.hoisted(() => ({
 vi.mock('@/composables/api/useChat', async (importOriginal) => {
   const original = await importOriginal<typeof import('@/composables/api/useChat')>()
   return { ...original, ...api }
+})
+vi.mock('@/i18n', () => ({
+  default: { global: { t: (key: string) => key } },
+}))
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@vueuse/core')>()
+  const { ref } = await import('vue')
+  return {
+    ...actual,
+    useLocalStorage: (_key: string, initial: unknown) => ref(initial),
+    useStorage: (_key: string, initial: unknown) => ref(initial),
+  }
 })
 vi.mock('@pinia/colada', () => ({ useQuery: colada.useQuery }))
 
@@ -169,12 +187,13 @@ describe('useSubagentList', () => {
       title: 'Child task',
     }]
     const workspaceTabs = useWorkspaceTabsStore()
-    const openSessionChat = vi.spyOn(workspaceTabs, 'openSessionChat').mockImplementation(() => {})
+    const openSessionChat = vi.spyOn(workspaceTabs, 'openSessionChatFromView').mockImplementation(() => {})
 
     const { navigateToSession } = useSubagentList()
     navigateToSession('child-1')
 
     expect(openSessionChat).toHaveBeenCalledWith({
+      viewId: 'chat',
       sessionId: 'child-1',
       title: 'Child task',
     })

--- a/apps/web/src/pages/home/composables/useSubagentList.ts
+++ b/apps/web/src/pages/home/composables/useSubagentList.ts
@@ -1,11 +1,11 @@
 import { computed } from 'vue'
-import { storeToRefs } from 'pinia'
 import { useQuery } from '@pinia/colada'
 import { fetchSessions } from '@/composables/api/useChat'
 import { useChatStore } from '@/store/chat-list'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import type { SessionSummary } from '@/composables/api/useChat'
 import type { ToolCallBlock } from '@/store/chat-list'
+import { useChatViewTarget } from './useChatViewContext'
 
 export interface SubagentSession {
   id: string
@@ -20,7 +20,10 @@ const ACTIVE_BACKGROUND_STATUSES = new Set(['queued', 'running', 'stalled'])
 export function useSubagentList() {
   const chatStore = useChatStore()
   const workspaceTabs = useWorkspaceTabsStore()
-  const { currentBotId, sessionId, messages } = storeToRefs(chatStore)
+  const target = useChatViewTarget()
+  const currentBotId = computed(() => target.value.botId || null)
+  const sessionId = computed(() => target.value.sessionId)
+  const messages = computed(() => chatStore.chatView(target.value).transcript.messages)
 
   const activeSubagentTasks = computed<SubagentSession[]>(() => {
     const seen = new Set<string>()
@@ -73,7 +76,8 @@ export function useSubagentList() {
   function navigateToSession(subagentSessionId: string) {
     if (!subagentSessionId || !currentBotId.value) return
     const agent = subagents.value.find(item => item.id === subagentSessionId)
-    workspaceTabs.openSessionChat({
+    workspaceTabs.openSessionChatFromView({
+      viewId: target.value.viewId,
       sessionId: subagentSessionId,
       title: agent?.title || agent?.agentId,
     })

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -71,6 +71,18 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
+function applyLatestDraftRequest(store: ReturnType<typeof useChatStore>) {
+  const request = store.draftViewRequested
+  if (!request) throw new Error('Expected a Draft view request')
+  store.applyDraftViewRequest(request, true)
+}
+
+async function applyLatestForkRequest(store: ReturnType<typeof useChatStore>) {
+  const request = store.forkedSessionRequested
+  if (!request) throw new Error('Expected a Forked Session request')
+  await store.selectSession(request.sessionId)
+}
+
 function singleSelectUserInput(id = 'input-1'): UIUserInput {
   return {
     user_input_id: id,
@@ -138,6 +150,7 @@ describe('chat-list store', () => {
   // Captured but not driven by any test body yet; keep the capture so future
   // tests can simulate per-session SSE events without rewiring the mock.
   let _sessionMessageHandler: ((event: SessionMessageStreamEvent) => void) | null
+  let sessionMessageHandlers: Map<string, (event: SessionMessageStreamEvent) => void>
   let sessionsActivityHandler: ((event: BotSessionActivityEvent) => void) | null
   let sendEvents: UIStreamEvent[]
   let sentWSMessages: Array<Record<string, unknown>>
@@ -149,6 +162,7 @@ describe('chat-list store', () => {
     setActivePinia(createPinia())
     streamHandler = null
     _sessionMessageHandler = null
+    sessionMessageHandlers = new Map()
     sessionsActivityHandler = null
     lastStreamId = ''
     lastSessionId = ''
@@ -230,9 +244,14 @@ describe('chat-list store', () => {
     api.executeQuickAction.mockResolvedValue(null)
     api.fetchSafeSkillCatalog.mockResolvedValue([])
     sdk.getBotsByBotIdSettings.mockResolvedValue({ data: { chat_runtime: 'model' } })
-    api.streamSessionMessageEvents.mockImplementation((_botId: string, _sessionId: string, signal: AbortSignal, onEvent: (event: SessionMessageStreamEvent) => void) => new Promise<void>((resolve) => {
+    api.streamSessionMessageEvents.mockImplementation((botId: string, targetSessionId: string, signal: AbortSignal, onEvent: (event: SessionMessageStreamEvent) => void) => new Promise<void>((resolve) => {
       _sessionMessageHandler = onEvent
-      signal.addEventListener('abort', () => resolve(), { once: true })
+      const key = `${botId}:${targetSessionId}`
+      sessionMessageHandlers.set(key, onEvent)
+      signal.addEventListener('abort', () => {
+        if (sessionMessageHandlers.get(key) === onEvent) sessionMessageHandlers.delete(key)
+        resolve()
+      }, { once: true })
     }))
     api.streamBotSessionsActivityEvents.mockImplementation((_botId: string, signal: AbortSignal, onEvent: (event: BotSessionActivityEvent) => void) => new Promise<void>((resolve) => {
       sessionsActivityHandler = onEvent
@@ -341,6 +360,7 @@ describe('chat-list store', () => {
 
     await store.selectBot('bot-1')
     const result = await store.sendMessage('/new codex')
+    applyLatestDraftRequest(store)
 
     expect(result.ok).toBe(true)
     expect(api.createSession).not.toHaveBeenCalled()
@@ -385,6 +405,7 @@ describe('chat-list store', () => {
     })
 
     const commandResult = await store.sendMessage('/new codex')
+    applyLatestDraftRequest(store)
 
     expect(commandResult.ok).toBe(true)
     expect(store.sessionId).toBeNull()
@@ -411,6 +432,7 @@ describe('chat-list store', () => {
 
     await store.selectBot('bot-1')
     const result = await store.sendMessage('/new chat codex')
+    applyLatestDraftRequest(store)
 
     expect(result.ok).toBe(true)
     expect(sentWSMessages).toHaveLength(0)
@@ -512,6 +534,7 @@ describe('chat-list store', () => {
     await store.selectBot('bot-1')
     store.stageDefaultACPSession({ agentId: 'codex', projectPath: '/data', projectMode: 'project' })
     const result = await store.sendMessage('/new')
+    applyLatestDraftRequest(store)
 
     expect(result.ok).toBe(true)
     expect(store.sessionId).toBeNull()
@@ -532,6 +555,7 @@ describe('chat-list store', () => {
 
     await store.selectBot('bot-1')
     const result = await store.sendMessage('/new codex')
+    applyLatestDraftRequest(store)
 
     expect(result.ok).toBe(true)
     expect(store.pendingACPSessionMetadata).toMatchObject({
@@ -546,6 +570,7 @@ describe('chat-list store', () => {
 
     await store.selectBot('bot-1')
     const result = await store.sendMessage('/new discuss codex')
+    applyLatestDraftRequest(store)
 
     expect(result.ok).toBe(true)
     expect(sentWSMessages).toHaveLength(0)
@@ -847,7 +872,6 @@ describe('chat-list store', () => {
     await flushPromises()
     await flushPromises()
 
-    api.fetchMessagesUI.mockRejectedValueOnce(new Error('offline'))
     await store.selectSession('session-1')
     await flushPromises()
     await flushPromises()
@@ -2181,7 +2205,7 @@ describe('chat-list store', () => {
     api.fetchMessagesUI.mockClear()
 
     streamHandler?.({ type: 'start', stream_id: 'main-stream', session_id: 'session-1' } as UIStreamEvent)
-    expect(store.isSessionStreaming('session-1')).toBe(true)
+    expect(store.isSessionStreaming('bot-1', 'session-1')).toBe(true)
 
     const userInput = singleSelectUserInput()
     store.messages.push(askUserTurn(userInput))
@@ -3600,6 +3624,7 @@ describe('chat-list store', () => {
     await store.selectBot('bot-1')
     await flushPromises()
     const ok = await store.forkMessage('source-assistant', { title: 'Custom fork name' })
+    await applyLatestForkRequest(store)
     await flushPromises()
 
     expect(ok).toBe(true)
@@ -3678,6 +3703,7 @@ describe('chat-list store', () => {
     await store.selectBot('bot-1')
     await flushPromises()
     const ok = await store.forkMessage('source-assistant')
+    await applyLatestForkRequest(store)
     await flushPromises()
 
     expect(ok).toBe(true)
@@ -3731,6 +3757,7 @@ describe('chat-list store', () => {
       .mockReturnValueOnce(hydration.promise)
 
     await store.forkMessage('source-assistant')
+    await applyLatestForkRequest(store)
     await flushPromises()
     expect(store.messages.filter(message => message.role === 'assistant')).toHaveLength(1)
 
@@ -3762,7 +3789,7 @@ describe('chat-list store', () => {
     await flushPromises()
   })
 
-  it('does not write a fork response into the active store after switching sessions', async () => {
+  it('routes a late fork response to its origin view without changing the focused Session', async () => {
     api.fetchSessions.mockResolvedValueOnce({
       items: [
         { id: 'source-session', bot_id: 'bot-1', title: 'Source', type: 'chat' },
@@ -3803,8 +3830,14 @@ describe('chat-list store', () => {
 
     await store.selectBot('bot-1')
     await flushPromises()
-    const fork = store.forkMessage('source-assistant')
+    const targetA = { botId: 'bot-1', sessionId: 'source-session', viewId: 'chat:a' }
+    const targetB = { botId: 'bot-1', sessionId: 'other-session', viewId: 'chat:b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.focusChatView(targetA.viewId)
+    const fork = store.forkMessage('source-assistant', { target: targetA })
     await flushPromises()
+    store.bindChatView(targetB.viewId, targetB, true)
+    store.focusChatView(targetB.viewId)
     await store.selectSession('other-session')
     await flushPromises()
     resolveFork({
@@ -3826,8 +3859,52 @@ describe('chat-list store', () => {
     expect(ok).toBe(true)
     expect(store.sessionId).toBe('other-session')
     expect(store.messages.map(message => message.id)).toEqual(['other-user'])
-    expect(store.knownSessionSummary('fork-session')).toBeNull()
-    expect(api.fetchMessagesUI).not.toHaveBeenCalledWith('bot-1', 'fork-session', expect.anything())
+    expect(store.knownSessionSummary('fork-session')).toMatchObject({ id: 'fork-session' })
+    expect(api.fetchMessagesUI).toHaveBeenCalledWith('bot-1', 'fork-session', expect.anything())
+    expect(store.forkedSessionRequested).toMatchObject({
+      botId: 'bot-1',
+      viewId: targetA.viewId,
+      expectedSessionId: 'source-session',
+      sessionId: 'fork-session',
+      activate: true,
+    })
+  })
+
+  it('drops a late Fork result after the authenticated scope resets', async () => {
+    const windowTarget = new EventTarget()
+    vi.stubGlobal('window', windowTarget)
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'source-session', bot_id: 'bot-1', title: 'Source', type: 'chat' }],
+      nextCursor: null,
+    })
+    api.fetchMessagesUI.mockResolvedValueOnce([{
+      id: 'source-assistant',
+      role: 'assistant',
+      messages: [{ id: 1, type: 'text', content: 'answer' }],
+      timestamp: '2026-07-11T00:00:00Z',
+      streaming: false,
+    }])
+    const response = deferred<{
+      id: string
+      bot_id: string
+      title: string
+      type: string
+    }>()
+    api.forkSessionFromMessage.mockReturnValueOnce(response.promise)
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+
+    const fork = store.forkMessage('source-assistant')
+    windowTarget.dispatchEvent(new CustomEvent(AUTH_SESSION_CLEARED_EVENT, {
+      detail: { reason: 'logout' },
+    }))
+    response.resolve({ id: 'old-fork', bot_id: 'bot-1', title: 'Old fork', type: 'chat' })
+
+    await expect(fork).resolves.toBe(true)
+    expect(store.forkedSessionRequested).toBeNull()
+    expect(store.knownSessionSummary('old-fork')).toBeNull()
+    expect(api.fetchMessagesUI).not.toHaveBeenCalledWith('bot-1', 'old-fork', expect.anything())
   })
 
   it('does not fork non-chat sessions', async () => {
@@ -4319,7 +4396,9 @@ describe('chat-list store', () => {
     await flushPromises()
 
     expect(store.sessionId).toBe('session-b')
-    expect(store.knownSessionSummary('created-session')).toBeNull()
+    // The hidden Draft view still owns this stream, so its new Session is
+    // remembered without stealing global focus from session-b.
+    expect(store.knownSessionSummary('created-session')).not.toBeNull()
 
     streamHandler?.({ type: 'end', stream_id: streamId, session_id: 'created-session' } as UIStreamEvent)
     await sendPromise
@@ -4388,7 +4467,11 @@ describe('chat-list store', () => {
       composer_scope: 'bot-1:draft-a',
     })
     expect(draftCommandEvent?.session_id).toBeUndefined()
-    expect(store.startupSendFailure).toMatchObject({
+    expect(store.startupSendFailureFor({
+      botId: 'bot-1',
+      sessionId: null,
+      viewId: 'draft-a',
+    }, 'bot-1:draft-a')).toMatchObject({
       botId: 'bot-1',
       composerScope: 'bot-1:draft-a',
       restoreInput: 'hello with skill',
@@ -4546,7 +4629,7 @@ describe('chat-list store', () => {
     } as UIStreamEvent)
 
     expect(store.currentBotId).toBe('bot-2')
-    expect(store.isSessionStreaming('old-session')).toBe(false)
+    expect(store.isSessionStreaming('bot-1', 'old-session')).toBe(false)
     expect(store.messages).toHaveLength(0)
   })
 
@@ -4691,8 +4774,10 @@ describe('chat-list store', () => {
     await flushPromises()
     await flushPromises()
 
-    expect(store.messages).toHaveLength(1)
-    expect(store.messages[0]).toMatchObject({ role: 'assistant', streaming: true })
+    // The keyed Session view survives the round trip, including its optimistic
+    // user turn; a failed refresh no longer reconstructs only the assistant.
+    expect(store.messages.map(turn => turn.role)).toEqual(['user', 'assistant'])
+    expect(store.messages[1]).toMatchObject({ role: 'assistant', streaming: true })
 
     returningToSessionA = false
     streamHandler?.({ type: 'end', stream_id: streamId, session_id: 'session-a' } as UIStreamEvent)
@@ -4746,8 +4831,8 @@ describe('chat-list store', () => {
     const streamB = sent.find(item => item.session_id === 'session-b')?.stream_id
     expect(streamA).toBeTruthy()
     expect(streamB).toBeTruthy()
-    expect(store.isSessionStreaming('session-a')).toBe(true)
-    expect(store.isSessionStreaming('session-b')).toBe(true)
+    expect(store.isSessionStreaming('bot-1', 'session-a')).toBe(true)
+    expect(store.isSessionStreaming('bot-1', 'session-b')).toBe(true)
 
     streamHandler?.({
       type: 'message',
@@ -5269,6 +5354,48 @@ describe('chat-list store', () => {
     expect(store.sessionId).toBe('session-1')
   })
 
+  it('aborts a deleted Session stream and ignores its late events in the focused Session', async () => {
+    sendEvents = [{ type: 'start' } as UIStreamEvent]
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [
+        { id: 'session-1', bot_id: 'bot-1', title: 'A', type: 'chat' },
+        { id: 'session-2', bot_id: 'bot-1', title: 'B', type: 'chat' },
+      ],
+      nextCursor: null,
+    })
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+
+    const sending = store.sendMessage('stream in A')
+    await flushPromises()
+    const streamId = lastStreamId
+    expect(streamId).not.toBe('')
+
+    await store.selectSession('session-2')
+    api.deleteSession.mockResolvedValueOnce(undefined)
+    await store.removeSession('session-1')
+    await expect(sending).resolves.toMatchObject({ ok: false, stage: 'stream' })
+
+    streamHandler?.({
+      type: 'message',
+      stream_id: streamId,
+      session_id: 'session-1',
+      data: { id: 1, type: 'text', content: 'late A output' },
+    } as UIStreamEvent)
+    streamHandler?.({
+      type: 'end',
+      stream_id: streamId,
+      session_id: 'session-1',
+    } as UIStreamEvent)
+    await flushPromises()
+
+    expect(abortedWSStreams).toContain(streamId)
+    expect(store.sessionId).toBe('session-2')
+    expect(store.messages).toEqual([])
+    expect(store.sessions.map(session => session.id)).toEqual(['session-2'])
+  })
+
   it('does not fall back to a hidden schedule session after deleting the active recent session', async () => {
     api.fetchSessions.mockResolvedValueOnce({
       items: [
@@ -5357,6 +5484,21 @@ describe('chat-list store', () => {
     ])
     await store.selectBot('bot-2')
     await flushPromises()
+    sendEvents = [{ type: 'start' } as UIStreamEvent]
+    const botTwoSend = store.sendMessage('keep bot two streaming')
+    await flushPromises()
+    const botTwoStreamId = lastStreamId
+
+    expect(store.isChatViewStreaming({
+      botId: 'bot-1',
+      sessionId: 'shared-session',
+      viewId: 'chat:bot-1',
+    })).toBe(false)
+    expect(store.isChatViewStreaming({
+      botId: 'bot-2',
+      sessionId: 'shared-session',
+      viewId: 'chat:bot-2',
+    })).toBe(true)
 
     resolveDelete()
     await deletePromise
@@ -5364,12 +5506,19 @@ describe('chat-list store', () => {
     expect(store.currentBotId).toBe('bot-2')
     expect(store.sessions.map(session => session.id)).toEqual(['shared-session', 'session-b2'])
     expect(store.sessionId).toBe('shared-session')
-    expect(store.messages.map(message => message.id)).toEqual(['bot-2-user', 'bot-2-assistant'])
+    expect(store.messages.slice(0, 2).map(message => message.id)).toEqual(['bot-2-user', 'bot-2-assistant'])
+    expect(abortedWSStreams).not.toContain(botTwoStreamId)
     expect(store.deletedSession).toEqual({
       id: 'shared-session',
       botId: 'bot-1',
       seq: 1,
     })
+    streamHandler?.({
+      type: 'end',
+      stream_id: botTwoStreamId,
+      session_id: 'shared-session',
+    } as UIStreamEvent)
+    await expect(botTwoSend).resolves.toMatchObject({ ok: true })
   })
 
   it('does not resurrect a deleted session when an older same-bot list refresh resolves late', async () => {
@@ -5516,5 +5665,734 @@ describe('chat-list store', () => {
     await flushPromises()
 
     expect(store.sessions.map(s => s.id)).toEqual(['session-2', 'session-1'])
+  })
+
+  it('keeps A and B transcripts independent while non-focused B receives Session SSE', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [
+        { id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' },
+        { id: 'session-b', bot_id: 'bot-1', title: 'B', type: 'chat' },
+      ],
+      nextCursor: null,
+    })
+    const latest = new Map([
+      ['session-a', [{ id: 'a-1', role: 'user', text: 'from A', attachments: [], timestamp: '2026-07-11T00:00:00Z' }]],
+      ['session-b', [{ id: 'b-1', role: 'user', text: 'from B', attachments: [], timestamp: '2026-07-11T00:00:01Z' }]],
+    ])
+    api.fetchMessagesUI.mockImplementation(async (_botId: string, targetSessionId: string) => latest.get(targetSessionId) ?? [])
+    const store = useChatStore()
+
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:a' }
+    const targetB = { botId: 'bot-1', sessionId: 'session-b', viewId: 'chat:b' }
+    store.bindChatView('chat:a', targetA, true)
+    store.bindChatView('chat:b', targetB, true)
+    await flushPromises()
+    await flushPromises()
+
+    expect(store.chatView(targetA).transcript.messages.map(message => message.id)).toEqual(['a-1'])
+    expect(store.chatView(targetB).transcript.messages.map(message => message.id)).toEqual(['b-1'])
+    expect(sessionMessageHandlers.has('bot-1:session-a')).toBe(true)
+    expect(sessionMessageHandlers.has('bot-1:session-b')).toBe(true)
+
+    store.focusChatView('chat:a')
+    await store.selectSession('session-a')
+    latest.set('session-b', [
+      { id: 'b-1', role: 'user', text: 'from B', attachments: [], timestamp: '2026-07-11T00:00:01Z' },
+      { id: 'b-2', role: 'assistant', messages: [{ id: 0, type: 'text', content: 'B updated' }], timestamp: '2026-07-11T00:00:02Z' },
+    ])
+    sessionMessageHandlers.get('bot-1:session-b')?.({
+      type: 'message_created',
+      message: { id: 'b-2', session_id: 'session-b', created_at: '2026-07-11T00:00:02Z' },
+    } as never)
+    await new Promise(resolve => setTimeout(resolve, 150))
+    await flushPromises()
+
+    expect(store.sessionId).toBe('session-a')
+    expect(store.chatView(targetA).transcript.messages.map(message => message.id)).toEqual(['a-1'])
+    expect(store.chatView(targetB).transcript.messages.map(message => message.id)).toEqual(['b-1', 'b-2'])
+  })
+
+  it('hydrates a visible non-focused Session summary before it is activated', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+      nextCursor: null,
+    })
+    api.fetchSession.mockResolvedValueOnce({
+      id: 'session-b',
+      bot_id: 'bot-1',
+      title: 'Hidden subagent',
+      type: 'subagent',
+      runtime_type: 'acp_agent',
+      runtime_metadata: { acp_agent_id: 'codex' },
+    })
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+    const targetA = { botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:a' }
+    const targetB = { botId: 'bot-1', sessionId: 'session-b', viewId: 'chat:b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.focusChatView(targetA.viewId)
+
+    store.bindChatView(targetB.viewId, targetB, true)
+    await flushPromises()
+
+    expect(store.sessionId).toBe('session-a')
+    expect(store.chatTargetFor(targetB)).toMatchObject({
+      session: { id: 'session-b', type: 'subagent' },
+      runtimeType: 'acp_agent',
+      isACP: true,
+    })
+    expect(store.chatReadOnlyFor(targetB)).toBe(true)
+    expect(api.fetchSession).toHaveBeenCalledWith('bot-1', 'session-b')
+  })
+
+  it('keeps an unknown real Session read-only until its summary confirms it is writable', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+      nextCursor: null,
+    })
+    const summary = deferred<{
+      id: string
+      bot_id: string
+      title: string
+      type: string
+    }>()
+    api.fetchSession.mockReturnValueOnce(summary.promise)
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetB = { botId: 'bot-1', sessionId: 'session-b', viewId: 'chat:b' }
+    store.bindChatView(targetB.viewId, targetB, true)
+    await flushPromises()
+
+    expect(store.chatReadOnlyFor(targetB)).toBe(true)
+    await expect(store.sendMessage('must not send', undefined, { target: targetB })).resolves.toMatchObject({
+      ok: false,
+      stage: 'startup',
+    })
+    expect(sentWSMessages).toEqual([])
+
+    summary.resolve({ id: 'session-b', bot_id: 'bot-1', title: 'B', type: 'chat' })
+    await flushPromises()
+    expect(store.chatReadOnlyFor(targetB)).toBe(false)
+  })
+
+  it('does not remember a visible Session summary that resolves after deletion', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+      nextCursor: null,
+    })
+    const summary = deferred<{
+      id: string
+      bot_id: string
+      title: string
+      type: string
+    }>()
+    api.fetchSession.mockReturnValueOnce(summary.promise)
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetB = { botId: 'bot-1', sessionId: 'session-b', viewId: 'chat:b' }
+    store.bindChatView(targetB.viewId, targetB, true)
+    await flushPromises()
+
+    api.deleteSession.mockResolvedValueOnce(undefined)
+    await store.removeSession('session-b')
+    summary.resolve({ id: 'session-b', bot_id: 'bot-1', title: 'Deleted B', type: 'chat' })
+    await flushPromises()
+
+    expect(store.knownSessionSummary('session-b')).toBeNull()
+    expect(store.sessions.some(session => session.id === 'session-b')).toBe(false)
+  })
+
+  it('routes an optimistic send and abort only to its explicit pane target', async () => {
+    sendEvents = [{ type: 'start' } as UIStreamEvent]
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [
+        { id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' },
+        { id: 'session-b', bot_id: 'bot-1', title: 'B', type: 'chat' },
+      ],
+      nextCursor: null,
+    })
+    api.fetchMessagesUI.mockResolvedValue([])
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:a' }
+    const targetB = { botId: 'bot-1', sessionId: 'session-b', viewId: 'chat:b' }
+    store.bindChatView('chat:a', targetA, true)
+    store.bindChatView('chat:b', targetB, true)
+    store.focusChatView('chat:b')
+    await store.selectSession('session-b')
+
+    const sending = store.sendMessage('send to A', undefined, {
+      target: targetA,
+      composerScope: 'bot-1:chat:a',
+    })
+    await flushPromises()
+
+    expect(store.chatView(targetA).transcript.messages.map(message => message.role)).toEqual(['user', 'assistant'])
+    expect(store.chatView(targetB).transcript.messages).toEqual([])
+    expect(sentWSMessages.at(-1)).toMatchObject({ session_id: 'session-a', composer_scope: 'bot-1:chat:a' })
+
+    store.abort(targetA)
+    await expect(sending).resolves.toMatchObject({ ok: false, stage: 'stream' })
+    expect(store.sessionId).toBe('session-b')
+    expect(store.chatView(targetB).transcript.messages).toEqual([])
+  })
+
+  it('shares one Session transcript and one Session SSE across two visible panes', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+      nextCursor: null,
+    })
+    api.fetchMessagesUI.mockResolvedValue([
+      { id: 'a-1', role: 'user', text: 'shared', attachments: [], timestamp: '2026-07-11T00:00:00Z' },
+    ])
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const first = store.bindChatView('chat:left', {
+      botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:left',
+    }, true)
+    const second = store.bindChatView('chat:right', {
+      botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:right',
+    }, true)
+    await flushPromises()
+
+    expect(second).toBe(first)
+    expect(first.transcript.messages.map(message => message.id)).toEqual(['a-1'])
+    expect(api.streamSessionMessageEvents.mock.calls.filter(call => call[1] === 'session-a')).toHaveLength(1)
+  })
+
+  it('detaches the Session SSE when its last pane hides and reconnects from cache', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+      nextCursor: null,
+    })
+    api.fetchMessagesUI.mockResolvedValue([
+      { id: 'a-1', role: 'user', text: 'cached', attachments: [], timestamp: '2026-07-11T00:00:00Z' },
+    ])
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const target = { botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:left' }
+    const cached = store.bindChatView('chat:left', target, true)
+    store.bindChatView('chat:right', { ...target, viewId: 'chat:right' }, true)
+    await flushPromises()
+
+    expect(sessionMessageHandlers.has('bot-1:session-a')).toBe(true)
+    store.setChatViewVisible('chat:left', false)
+    expect(sessionMessageHandlers.has('bot-1:session-a')).toBe(true)
+
+    store.setChatViewVisible('chat:right', false)
+    expect(sessionMessageHandlers.has('bot-1:session-a')).toBe(false)
+    expect(store.chatView(target)).toBe(cached)
+    expect(cached.transcript.messages.map(message => message.id)).toEqual(['a-1'])
+
+    store.setChatViewVisible('chat:left', true)
+    await flushPromises()
+    expect(sessionMessageHandlers.has('bot-1:session-a')).toBe(true)
+    expect(store.chatView(target)).toBe(cached)
+  })
+
+  it('keeps Draft ACP Agent state scoped by pane and closes only the removed Draft runtime', async () => {
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    const targetB = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.bindChatView(targetB.viewId, targetB, true)
+
+    store.focusChatView(targetA.viewId)
+    store.stageACPSession({ agentId: 'codex', modelId: 'model-a' }, {}, targetA)
+    await store.ensurePendingACPRuntime(targetA)
+    store.focusChatView(targetB.viewId)
+    store.stageACPSession({ agentId: 'claude', modelId: 'model-b' }, {}, targetB)
+
+    expect(store.pendingACPStateFor(targetA)).toMatchObject({
+      metadata: { acp_agent_id: 'codex' },
+      modelId: 'model-a',
+      runtimeId: 'rt_warm',
+    })
+    expect(store.pendingACPStateFor(targetB)).toMatchObject({
+      metadata: { acp_agent_id: 'claude' },
+      modelId: 'model-b',
+    })
+    expect(api.closeACPRuntime).not.toHaveBeenCalled()
+
+    store.focusChatView(targetA.viewId)
+    expect(store.pendingACPSessionMetadata).toMatchObject({ acp_agent_id: 'codex' })
+    store.unbindChatView(targetA.viewId)
+
+    expect(api.closeACPRuntime).toHaveBeenCalledWith('bot-1', 'rt_warm')
+    expect(store.pendingACPStateFor(targetB)).toMatchObject({ metadata: { acp_agent_id: 'claude' } })
+  })
+
+  it('does not let a late native Draft creation steal focus from another Draft', async () => {
+    const creation = deferred<{
+      id: string
+      bot_id: string
+      title: string
+      type: string
+    }>()
+    api.createSession.mockReturnValueOnce(creation.promise)
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    const targetB = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.bindChatView(targetB.viewId, targetB, true)
+    store.focusChatView(targetA.viewId)
+
+    const sending = store.sendMessage('from A', undefined, { target: targetA })
+    await flushPromises()
+    store.focusChatView(targetB.viewId)
+    store.selectDraft({ explicitSelection: true })
+    creation.resolve({ id: 'session-a', bot_id: 'bot-1', title: '', type: 'chat' })
+    await sending
+
+    expect(store.sessionId).toBeNull()
+    expect(store.chatView({ ...targetA, sessionId: 'session-a' }).sessionId).toBe('session-a')
+    expect(store.chatView(targetB).kind).toBe('draft')
+    expect(store.userSentInSession).toMatchObject({ id: 'session-a', viewId: targetA.viewId })
+  })
+
+  it('drops a late Draft creation result after the authenticated scope resets', async () => {
+    const windowTarget = new EventTarget()
+    vi.stubGlobal('window', windowTarget)
+    const creation = deferred<{
+      id: string
+      bot_id: string
+      title: string
+      type: string
+    }>()
+    api.createSession.mockReturnValueOnce(creation.promise)
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const target = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    store.bindChatView(target.viewId, target, true)
+    store.focusChatView(target.viewId)
+
+    const sending = store.sendMessage('old user send', undefined, { target })
+    await flushPromises()
+    windowTarget.dispatchEvent(new CustomEvent(AUTH_SESSION_CLEARED_EVENT, {
+      detail: { reason: 'logout' },
+    }))
+    creation.resolve({ id: 'old-session', bot_id: 'bot-1', title: '', type: 'chat' })
+
+    await expect(sending).resolves.toMatchObject({ ok: false })
+    expect(store.sessions).toEqual([])
+    expect(store.knownSessionSummary('old-session')).toBeNull()
+    expect(store.currentBotId).toBeNull()
+    expect(store.isChatViewCreatingSession(target)).toBe(false)
+  })
+
+  it('restores a failed ACP creation to its owning Draft after focus moves', async () => {
+    const creation = deferred<{
+      id: string
+      bot_id: string
+      title: string
+      type: string
+    }>()
+    api.createSession.mockReturnValueOnce(creation.promise)
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    const targetB = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.bindChatView(targetB.viewId, targetB, true)
+    store.focusChatView(targetA.viewId)
+    store.stageACPSession({ agentId: 'codex' }, {}, targetA)
+
+    const sending = store.sendMessage('from ACP A', undefined, { target: targetA })
+    await flushPromises()
+    store.focusChatView(targetB.viewId)
+    store.selectDraft({ explicitSelection: true })
+    store.stageACPSession({ agentId: 'claude' }, {}, targetB)
+    creation.reject(new Error('create failed'))
+    await expect(sending).resolves.toMatchObject({ ok: false, stage: 'startup' })
+
+    expect(store.pendingACPStateFor(targetA)).toMatchObject({ metadata: { acp_agent_id: 'codex' } })
+    expect(store.pendingACPStateFor(targetB)).toMatchObject({ metadata: { acp_agent_id: 'claude' } })
+    expect(store.pendingACPSessionMetadata).toMatchObject({ acp_agent_id: 'claude' })
+    expect(store.sessionId).toBeNull()
+  })
+
+  it('creates an explicit non-focused ACP Draft with its saved Agent and warm runtime', async () => {
+    sendEvents = [{ type: 'start' } as UIStreamEvent]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    const targetB = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.bindChatView(targetB.viewId, targetB, true)
+    store.focusChatView(targetA.viewId)
+    store.stageACPSession({ agentId: 'codex' }, {}, targetA)
+    await store.ensurePendingACPRuntime(targetA)
+    store.focusChatView(targetB.viewId)
+    store.selectDraft({ explicitSelection: true })
+
+    const sending = store.sendMessage('run in A', undefined, { target: targetA })
+    await flushPromises()
+    await flushPromises()
+
+    expect(api.createSession).toHaveBeenLastCalledWith('bot-1', expect.objectContaining({
+      runtimeType: 'acp_agent',
+      acpRuntimeId: 'rt_warm',
+      runtimeMetadata: expect.objectContaining({ acp_agent_id: 'codex' }),
+    }))
+    expect(store.sessionId).toBeNull()
+    expect(store.pendingACPStateFor(targetA)).toBeNull()
+    expect(api.closeACPRuntime).not.toHaveBeenCalledWith('bot-1', 'rt_warm')
+
+    store.abort({ ...targetA, sessionId: 'session-1' })
+    await expect(sending).resolves.toMatchObject({ ok: false, stage: 'stream' })
+  })
+
+  it('does not resume an ACP Draft send on its old Bot after runtime setup resolves late', async () => {
+    api.fetchBots.mockResolvedValue([
+      { id: 'bot-1', status: 'active', name: 'Bot A' },
+      { id: 'bot-2', status: 'active', name: 'Bot B' },
+    ])
+    api.fetchSessions.mockResolvedValueOnce({ items: [], nextCursor: null })
+    const runtime = deferred<{
+      session_id: string
+      agent_id: string
+      models: { current_model_id: string; available_models: never[] }
+    }>()
+    api.ensureACPRuntime.mockReturnValueOnce(runtime.promise)
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const target = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    store.bindChatView(target.viewId, target, true)
+    store.focusChatView(target.viewId)
+    store.stageACPSession({ agentId: 'codex', startRuntime: true }, {}, target)
+
+    const sending = store.sendMessage('send on A', undefined, { target })
+    await flushPromises()
+    await flushPromises()
+    expect(api.ensureACPRuntime).toHaveBeenCalledWith('bot-1', 'session-1')
+
+    api.fetchSessions.mockResolvedValueOnce({ items: [], nextCursor: null })
+    await store.selectBot('bot-2')
+    runtime.resolve({
+      session_id: 'session-1',
+      agent_id: 'codex',
+      models: { current_model_id: '', available_models: [] },
+    })
+
+    await expect(sending).resolves.toMatchObject({ ok: false, stage: 'stream' })
+    expect(store.currentBotId).toBe('bot-2')
+    expect(sentWSMessages).toEqual([])
+  })
+
+  it('does not let a late session_created event steal focus from another Draft', async () => {
+    sendEvents = []
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    const targetB = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.bindChatView(targetB.viewId, targetB, true)
+    store.focusChatView(targetA.viewId)
+    const sending = store.sendMessage('activate A', undefined, {
+      target: targetA,
+      requestedSkills: [{ name: 'alpha' }],
+    })
+    await flushPromises()
+    const streamId = sentWSMessages[0]?.stream_id as string
+
+    store.focusChatView(targetB.viewId)
+    store.selectDraft({ explicitSelection: true })
+    streamHandler?.({
+      type: 'session_created',
+      stream_id: streamId,
+      session_id: 'session-a',
+    } as UIStreamEvent)
+
+    expect(store.sessionId).toBeNull()
+    expect(store.chatView({ ...targetA, sessionId: 'session-a' }).sessionId).toBe('session-a')
+    expect(store.chatView(targetB).kind).toBe('draft')
+
+    streamHandler?.({ type: 'end', stream_id: streamId, session_id: 'session-a' } as UIStreamEvent)
+    await expect(sending).resolves.toMatchObject({ ok: true })
+  })
+
+  it('cleans a non-focused deferred Session view and SSE after startup failure', async () => {
+    sendEvents = []
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    const targetB = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.bindChatView(targetB.viewId, targetB, true)
+    store.focusChatView(targetA.viewId)
+
+    const sending = store.sendMessage('activate A', [{
+      type: 'file',
+      base64: 'data:text/plain;base64,aGVsbG8=',
+      mime: 'text/plain',
+      name: 'note.txt',
+    }], {
+      target: targetA,
+      requestedSkills: [{ name: 'alpha' }],
+      composerScope: 'bot-1:chat:draft-a',
+    })
+    await flushPromises()
+    const streamId = sentWSMessages[0]?.stream_id as string
+    store.focusChatView(targetB.viewId)
+    store.selectDraft({ explicitSelection: true })
+
+    streamHandler?.({
+      type: 'session_created',
+      stream_id: streamId,
+      session_id: 'created-a',
+    } as UIStreamEvent)
+    await flushPromises()
+    expect(sessionMessageHandlers.has('bot-1:created-a')).toBe(true)
+
+    streamHandler?.({
+      type: 'command_error',
+      invocation_id: streamId,
+      stream_id: streamId,
+      session_id: 'created-a',
+      composer_scope: 'bot-1:chat:draft-a',
+      terminal: true,
+      error: { code: 'unsupported', message: 'preflight failed' },
+    } as UIStreamEvent)
+
+    await expect(sending).resolves.toMatchObject({ ok: false, stage: 'startup' })
+    expect(store.sessionId).toBeNull()
+    expect(store.deletedSession).toMatchObject({ id: 'created-a', botId: 'bot-1' })
+    expect(sessionMessageHandlers.has('bot-1:created-a')).toBe(false)
+  })
+
+  it('does not clear Draft B staging when Session A Agent update resolves late', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+      nextCursor: null,
+    })
+    const update = deferred<{
+      id: string
+      bot_id: string
+      title: string
+      type: string
+      runtime_type: string
+      metadata: Record<string, unknown>
+    }>()
+    api.updateSessionAgent.mockReturnValueOnce(update.promise)
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:session-a' }
+    const targetB = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.bindChatView(targetB.viewId, targetB, true)
+    store.focusChatView(targetA.viewId)
+    await store.selectSession('session-a')
+
+    const updating = store.updateCurrentSessionAgent({ agentId: 'codex' }, targetA)
+    store.focusChatView(targetB.viewId)
+    store.selectDraft({ explicitSelection: true })
+    store.stageACPSession({ agentId: 'claude' }, {}, targetB)
+    await store.ensurePendingACPRuntime(targetB)
+    update.resolve({
+      id: 'session-a',
+      bot_id: 'bot-1',
+      title: 'A',
+      type: 'acp_agent',
+      runtime_type: 'acp_agent',
+      metadata: { acp_agent_id: 'codex' },
+    })
+    await updating
+
+    expect(store.sessionId).toBeNull()
+    expect(store.pendingACPStateFor(targetB)).toMatchObject({
+      metadata: { acp_agent_id: 'claude' },
+      runtimeId: 'rt_warm',
+    })
+    expect(api.closeACPRuntime).not.toHaveBeenCalledWith('bot-1', 'rt_warm')
+  })
+
+  it('routes a late /new Agent result back to its origin Draft request', async () => {
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const targetA = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    const targetB = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-b' }
+    store.bindChatView(targetA.viewId, targetA, true)
+    store.bindChatView(targetB.viewId, targetB, true)
+    store.focusChatView(targetA.viewId)
+    const settings = deferred<{ data: {
+      chat_runtime: string
+      chat_acp_agent_id: string
+      chat_acp_project_path: string
+      chat_acp_project_mode: string
+    } }>()
+    sdk.getBotsByBotIdSettings.mockReturnValueOnce(settings.promise)
+
+    const command = store.sendMessage('/new codex', undefined, { target: targetA })
+    await flushPromises()
+    store.focusChatView(targetB.viewId)
+    store.selectDraft({ explicitSelection: true })
+    store.stageACPSession({ agentId: 'claude' }, {}, targetB)
+    settings.resolve({ data: {
+      chat_runtime: 'acp_agent',
+      chat_acp_agent_id: 'codex',
+      chat_acp_project_path: '/data/a',
+      chat_acp_project_mode: 'project',
+    } })
+
+    await expect(command).resolves.toMatchObject({ ok: true })
+    expect(store.sessionId).toBeNull()
+    expect(store.pendingACPStateFor(targetB)).toMatchObject({ metadata: { acp_agent_id: 'claude' } })
+    expect(store.draftViewRequested).toMatchObject({
+      botId: 'bot-1',
+      viewId: targetA.viewId,
+      expectedSessionId: null,
+      input: { agentId: 'codex', projectPath: '/data/a', projectMode: 'project' },
+      activate: true,
+    })
+  })
+
+  it('keeps the newest /new Agent choice when an older settings request resolves last', async () => {
+    const codexSettings = deferred<{ data: {
+      chat_runtime: string
+      chat_acp_agent_id: string
+      chat_acp_project_path: string
+      chat_acp_project_mode: string
+    } }>()
+    const claudeSettings = deferred<{ data: {
+      chat_runtime: string
+      chat_acp_agent_id: string
+      chat_acp_project_path: string
+      chat_acp_project_mode: string
+    } }>()
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    sdk.getBotsByBotIdSettings
+      .mockReturnValueOnce(codexSettings.promise)
+      .mockReturnValueOnce(claudeSettings.promise)
+    const target = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    store.bindChatView(target.viewId, target, true)
+    store.focusChatView(target.viewId)
+
+    const older = store.sendMessage('/new codex', undefined, { target })
+    await flushPromises()
+    const newer = store.sendMessage('/new claude-code', undefined, { target })
+    await flushPromises()
+    claudeSettings.resolve({ data: {
+      chat_runtime: 'acp_agent',
+      chat_acp_agent_id: 'claude-code',
+      chat_acp_project_path: '/data/claude',
+      chat_acp_project_mode: 'project',
+    } })
+    await newer
+    const latestRequest = store.draftViewRequested
+    expect(latestRequest).toMatchObject({
+      viewId: target.viewId,
+      input: { agentId: 'claude-code', projectPath: '/data/claude' },
+    })
+
+    codexSettings.resolve({ data: {
+      chat_runtime: 'acp_agent',
+      chat_acp_agent_id: 'codex',
+      chat_acp_project_path: '/data/codex',
+      chat_acp_project_mode: 'project',
+    } })
+    await older
+
+    expect(store.draftViewRequested).toBe(latestRequest)
+    expect(store.draftViewRequested?.input?.agentId).toBe('claude-code')
+  })
+
+  it('drops a late /new Agent result after the authenticated scope resets', async () => {
+    const windowTarget = new EventTarget()
+    vi.stubGlobal('window', windowTarget)
+    const settings = deferred<{ data: {
+      chat_runtime: string
+      chat_acp_agent_id: string
+      chat_acp_project_path: string
+      chat_acp_project_mode: string
+    } }>()
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    sdk.getBotsByBotIdSettings.mockReturnValueOnce(settings.promise)
+    const target = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    store.bindChatView(target.viewId, target, true)
+    store.focusChatView(target.viewId)
+
+    const command = store.sendMessage('/new codex', undefined, { target })
+    await flushPromises()
+    windowTarget.dispatchEvent(new CustomEvent(AUTH_SESSION_CLEARED_EVENT, {
+      detail: { reason: 'logout' },
+    }))
+    settings.resolve({ data: {
+      chat_runtime: 'acp_agent',
+      chat_acp_agent_id: 'codex',
+      chat_acp_project_path: '/data/a',
+      chat_acp_project_mode: 'project',
+    } })
+
+    await expect(command).resolves.toMatchObject({ ok: true })
+    expect(store.draftViewRequested).toBeNull()
+    expect(store.currentBotId).toBeNull()
+  })
+
+  it('rolls back ACP Session creation when runtime setup fails', async () => {
+    api.ensureACPRuntime.mockRejectedValueOnce(new Error('runtime setup failed'))
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    const target = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    store.bindChatView(target.viewId, target, true)
+    store.focusChatView(target.viewId)
+    store.stageACPSession({ agentId: 'codex', startRuntime: true }, {}, target)
+
+    const result = await store.sendMessage('keep this input', undefined, { target })
+
+    expect(result).toMatchObject({
+      ok: false,
+      stage: 'startup',
+      restoreInput: 'keep this input',
+    })
+    expect(api.deleteSession).toHaveBeenCalledWith('bot-1', 'session-1')
+    expect(sentWSMessages).toEqual([])
+    expect(store.sessionId).toBeNull()
+    expect(store.chatView(target).kind).toBe('draft')
+    expect(store.knownSessionSummary('session-1')).toBeNull()
+    expect(store.pendingACPStateFor(target)).toMatchObject({
+      metadata: { acp_agent_id: 'codex' },
+      runtimeId: '',
+    })
+  })
+
+  it('keeps a manual Draft Agent choice made after a deferred /new command', async () => {
+    const settings = deferred<{ data: {
+      chat_runtime: string
+      chat_acp_agent_id: string
+      chat_acp_project_path: string
+      chat_acp_project_mode: string
+    } }>()
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    sdk.getBotsByBotIdSettings.mockReturnValueOnce(settings.promise)
+    const target = { botId: 'bot-1', sessionId: null, viewId: 'chat:draft-a' }
+    store.bindChatView(target.viewId, target, true)
+    store.focusChatView(target.viewId)
+
+    const command = store.sendMessage('/new codex', undefined, { target })
+    await flushPromises()
+    store.stageACPSession({ agentId: 'claude' }, {}, target)
+    await store.ensurePendingACPRuntime(target)
+
+    settings.resolve({ data: {
+      chat_runtime: 'acp_agent',
+      chat_acp_agent_id: 'codex',
+      chat_acp_project_path: '/data/codex',
+      chat_acp_project_mode: 'project',
+    } })
+    await expect(command).resolves.toMatchObject({ ok: true })
+
+    expect(store.draftViewRequested).toBeNull()
+    expect(store.pendingACPStateFor(target)).toMatchObject({
+      metadata: { acp_agent_id: 'claude' },
+      runtimeId: 'rt_warm',
+    })
+    expect(api.closeACPRuntime).not.toHaveBeenCalledWith('bot-1', 'rt_warm')
   })
 })

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -1,5 +1,5 @@
 import { defineStore, storeToRefs } from 'pinia'
-import { computed, ref, watch } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { toast } from '@felinic/ui'
 import enMessages from '@/i18n/locales/en.json'
 import zhMessages from '@/i18n/locales/zh.json'
@@ -25,8 +25,16 @@ import {
 import { createFsChangeBeacon } from './chat/fs-beacon'
 import { createCommandEventRegistry } from './chat/command-events'
 import { createSessionList } from './chat/session-list'
-import { acpSessionMetadata, createACPStaging } from './chat/acp-staging'
+import {
+  acpSessionMetadata,
+  createACPStaging,
+  type DetachedACPSession,
+} from './chat/acp-staging'
 import { createTranscriptController } from './chat/transcript'
+import {
+  createChatViewRegistry,
+  type ChatViewEntry,
+} from './chat/view-registry'
 import { createAssistantStreamRegistry } from './chat/assistant-streams'
 import { createChatRealtimeController } from './chat/realtime'
 import { createACPRuntimeRegistry } from './chat/acp-runtime-registry'
@@ -44,7 +52,9 @@ import type {
   ACPAgentSessionInput,
   ActiveChatTarget,
   ChatAssistantTurn,
+  ChatMessage,
   ChatUserTurn,
+  ChatViewTarget,
   SendMessageOptions,
   SendMessageResult,
   SendMessageStage,
@@ -100,6 +110,7 @@ export type {
 // fs-change beacon lives in ./chat/fs-beacon; types re-exported so existing
 // consumers keep importing them from the store module.
 export type { FsChangeBatch, FsChangeEvent, FsToolKind } from './chat/fs-beacon'
+export type { ChatViewEntry, ChatViewTarget } from './chat/view-registry'
 
 function currentLocale() {
   const storage = globalThis.localStorage
@@ -196,7 +207,9 @@ export const useChatStore = defineStore('chat', () => {
     acpRuntimePending,
     acpRuntimeKey,
     clearACPRuntimeStatus,
+    ensureACPRuntimeFor,
     ensureACPRuntime,
+    setACPRuntimeModelFor,
     setACPRuntimeModel,
     resetACPRuntimeRegistry,
   } = acpRuntimeRegistry
@@ -216,61 +229,140 @@ export const useChatStore = defineStore('chat', () => {
     rememberBackgroundTask,
     applyPendingBackgroundEventsToTool,
   } = backgroundTasks
-  const transcript = createTranscriptController({
-    currentBotId,
-    sessionId,
+  const focusedChatViewId = ref('chat')
+  let transcriptSnapshotHook: (view: ChatViewEntry, targetSessionId: string | undefined, turns: import('@/composables/api/useChat.types').UITurn[]) => void = () => {}
+  let transcriptRefreshAppliedHook: (view: ChatViewEntry, targetSessionId: string, latestTimestamp?: string) => void = () => {}
+  let sessionStreamingProbe: (botId: string, targetSessionId: string) => boolean = () => false
+  let stopEvictedSessionStream: (botId: string, targetSessionId: string) => void = () => {}
+  let discardEvictedDraftStage: (view: ChatViewEntry) => void = () => {}
+  const chatViews = createChatViewRegistry({
     rememberBackgroundTask,
     applyPendingBackgroundEventsToTool,
     bumpFsChangedAtIfFsMutation,
     fetchMessages: fetchMessagesUI,
     locateMessage: locateMessageUI,
+    isSessionStreaming: (botId, targetSessionId) => sessionStreamingProbe(botId, targetSessionId),
+    onSnapshot: (view, targetSessionId, turns) => transcriptSnapshotHook(view, targetSessionId, turns),
+    onRefreshApplied: (view, targetSessionId, latestTimestamp) => {
+      transcriptRefreshAppliedHook(view, targetSessionId, latestTimestamp)
+    },
+    onEvict: (view) => {
+      if (view.kind === 'session' && view.sessionId) {
+        stopEvictedSessionStream(view.botId, view.sessionId)
+      } else if (view.kind === 'draft') {
+        discardEvictedDraftStage(view)
+      }
+    },
   })
-  const {
-    messages,
-    loadingMessages,
-    loadingOlder,
-    hasMoreOlder,
-    hasLoadedOlder,
-    normalizeTurn,
-    clearHistoryView,
-    prepareForInitialization,
-    markHistoryEmpty,
-    replaceHistoryView,
-    refreshCurrentSession,
-    loadInitialMessages,
-    fetchSessionWindow,
-    loadOlderMessages,
-    findMessageIdByExternalId,
-    locateMessageByExternalId,
-    isActiveSessionTarget,
-    appendTurnToSession,
-    reattachTurnToSession,
-    appendToView,
-    removeFromView,
-    removeTurnFromSession,
-    replaceTailFromTurn,
-    restoreTailFromOptimistic,
-    createOptimisticAssistantTurn,
-    createOptimisticUserTurn,
-    upsertAssistantUIMessage,
-    hasVisibleAssistantBlocks,
-    finishAssistantTurn,
-    snapshotToolApprovalStates,
-    assistantTurnForApproval,
-    restoreToolApprovalStates,
-    snapshotUserInputStates,
-    assistantTurnForUserInput,
-    restoreUserInputStates,
-    finalizeStreamFailure,
-    latestOptimisticUserText,
-    hasTurn,
-    findTurnByServerId,
-    isLatestVisibleUserTurn,
-    isLatestVisibleAssistantTurn,
-    markToolApprovalDecision,
-    markUserInputDecision,
-    resetUserScope: resetTranscriptUserScope,
-  } = transcript
+
+  function normalizedChatViewTarget(target?: Partial<ChatViewTarget>): ChatViewTarget {
+    const botId = (target?.botId ?? currentBotId.value ?? '').trim() || '__unbound__'
+    const targetSessionId = target && 'sessionId' in target
+      ? target.sessionId?.trim() || null
+      : sessionId.value?.trim() || null
+    const viewId = target?.viewId?.trim() || focusedChatViewId.value.trim() || 'chat'
+    return { botId, sessionId: targetSessionId, viewId }
+  }
+
+  function isFocusedChatTarget(target: ChatViewTarget): boolean {
+    const resolved = normalizedChatViewTarget(target)
+    if (
+      resolved.botId !== (currentBotId.value ?? '').trim()
+      || resolved.viewId !== focusedChatViewId.value
+    ) return false
+    const selectedSessionId = (sessionId.value ?? '').trim()
+    return resolved.sessionId
+      ? selectedSessionId === resolved.sessionId
+      : !selectedSessionId
+  }
+
+  const draftSessionCreations = reactive(new Set<string>())
+
+  function draftSessionCreationKey(target: ChatViewTarget): string {
+    const resolved = normalizedChatViewTarget(target)
+    return `${resolved.botId}\u0000${resolved.viewId}`
+  }
+
+  function isChatViewCreatingSession(target: ChatViewTarget): boolean {
+    const resolved = normalizedChatViewTarget(target)
+    return !resolved.sessionId && draftSessionCreations.has(draftSessionCreationKey(resolved))
+  }
+
+  function chatView(target?: Partial<ChatViewTarget>): ChatViewEntry {
+    return chatViews.getOrCreate(normalizedChatViewTarget(target))
+  }
+
+  function sessionTranscript(botId: string, targetSessionId: string) {
+    return chatViews.getOrCreate({
+      botId: botId.trim(),
+      sessionId: targetSessionId.trim(),
+      viewId: focusedChatViewId.value,
+    }).transcript
+  }
+
+  function activeTranscript() {
+    return chatView().transcript
+  }
+
+  function transcriptForTarget(target?: Partial<ChatViewTarget>) {
+    return chatView(target).transcript
+  }
+
+  function transcriptForTurn(turn: ChatMessage) {
+    return chatViews.entries().find(view => view.transcript.messages.includes(turn))?.transcript
+      ?? null
+  }
+
+  const messages = computed(() => activeTranscript().messages)
+  const loadingMessages = computed(() => activeTranscript().loadingMessages.value)
+  const loadingOlder = computed(() => activeTranscript().loadingOlder.value)
+  const hasMoreOlder = computed(() => activeTranscript().hasMoreOlder.value)
+  const hasLoadedOlder = computed({
+    get: () => activeTranscript().hasLoadedOlder.value,
+    set: value => { activeTranscript().hasLoadedOlder.value = value },
+  })
+
+  const normalizeTurn = (...args: Parameters<ReturnType<typeof createTranscriptController>['normalizeTurn']>) => activeTranscript().normalizeTurn(...args)
+  const clearHistoryView = (...args: Parameters<ReturnType<typeof createTranscriptController>['clearHistoryView']>) => activeTranscript().clearHistoryView(...args)
+  const prepareForInitialization = () => activeTranscript().prepareForInitialization()
+  const markHistoryEmpty = () => activeTranscript().markHistoryEmpty()
+  async function refreshCurrentSession(targetBotId?: string, targetSessionId?: string) {
+    const bid = (targetBotId ?? currentBotId.value ?? '').trim()
+    const sid = (targetSessionId ?? sessionId.value ?? '').trim()
+    if (!bid || !sid) return
+    await sessionTranscript(bid, sid).refreshCurrentSession(bid, sid)
+  }
+  async function loadInitialMessages(botId: string, targetSessionId: string) {
+    const view = chatViews.getOrCreate({ botId, sessionId: targetSessionId, viewId: focusedChatViewId.value })
+    await view.transcript.loadInitialMessages(botId, targetSessionId)
+    view.initialized = true
+  }
+  const fetchSessionWindow = (botId: string, targetSessionId: string) => sessionTranscript(botId, targetSessionId).fetchSessionWindow(botId, targetSessionId)
+  const loadOlderMessages = (target?: ChatViewTarget) => transcriptForTarget(target).loadOlderMessages()
+  const findMessageIdByExternalId = (externalMessageId: string, target?: ChatViewTarget) => transcriptForTarget(target).findMessageIdByExternalId(externalMessageId)
+  const locateMessageByExternalId = (externalMessageId: string, target?: ChatViewTarget) => transcriptForTarget(target).locateMessageByExternalId(externalMessageId)
+  function isActiveSessionTarget(botId: string, targetSessionId: string) {
+    return currentBotId.value === botId.trim() && sessionId.value === targetSessionId.trim()
+  }
+  const appendTurnToSession = (botId: string, targetSessionId: string, turn: ChatMessage) => sessionTranscript(botId, targetSessionId).appendTurnToSession(botId, targetSessionId, turn)
+  const reattachTurnToSession = (botId: string, targetSessionId: string, turn: ChatMessage) => sessionTranscript(botId, targetSessionId).reattachTurnToSession(botId, targetSessionId, turn)
+  const removeTurnFromSession = (botId: string, targetSessionId: string, turn: ChatMessage) => {
+    const transcript = targetSessionId.trim()
+      ? sessionTranscript(botId, targetSessionId)
+      : transcriptForTurn(turn)
+    transcript?.removeTurnFromSession(botId, targetSessionId, turn)
+  }
+  const restoreTailFromOptimistic = (botId: string, targetSessionId: string, optimisticUserTurn: ChatUserTurn | null, assistantTurn: ChatAssistantTurn, replacedTurns: ChatMessage[]) => sessionTranscript(botId, targetSessionId).restoreTailFromOptimistic(botId, targetSessionId, optimisticUserTurn, assistantTurn, replacedTurns)
+  const createOptimisticAssistantTurn = () => activeTranscript().createOptimisticAssistantTurn()
+  const upsertAssistantUIMessage = (...args: Parameters<ReturnType<typeof createTranscriptController>['upsertAssistantUIMessage']>) => transcriptForTurn(args[0])?.upsertAssistantUIMessage(...args)
+  const hasVisibleAssistantBlocks = (turn: ChatAssistantTurn) => transcriptForTurn(turn)?.hasVisibleAssistantBlocks(turn) ?? false
+  const finishAssistantTurn = (turn: ChatAssistantTurn) => { transcriptForTurn(turn)?.finishAssistantTurn(turn) }
+  const finalizeStreamFailure = (assistantTurn: ChatAssistantTurn, botId: string, targetSessionId: string, error: Error) => {
+    transcriptForTurn(assistantTurn)?.finalizeStreamFailure(assistantTurn, botId, targetSessionId, error)
+  }
+  const hasTurn = (turn: ChatMessage) => chatViews.entries().some(view => view.transcript.hasTurn(turn))
+  const markToolApprovalDecision = (approvalId: string, status: 'approved' | 'rejected' | 'pending') => activeTranscript().markToolApprovalDecision(approvalId, status)
+  const resetTranscriptUserScope = () => chatViews.resetAll()
   const assistantStreams = createAssistantStreamRegistry({ currentBotId, sessionId, finishAssistantTurn })
   const {
     streaming,
@@ -278,6 +370,7 @@ export const useChatStore = defineStore('chat', () => {
     assistantStreamsForSession,
     activeUnboundStreamIds,
     isSessionStreaming,
+    isUnboundComposerStreaming,
     streamIdForEvent,
     trackAssistantStream,
     getAssistantStream,
@@ -291,6 +384,17 @@ export const useChatStore = defineStore('chat', () => {
     forgetCreatedSession,
     clearStreamHistory,
   } = assistantStreams
+  sessionStreamingProbe = isSessionStreaming
+
+  function isChatViewStreaming(target: ChatViewTarget, composerScope?: string): boolean {
+    const resolved = normalizedChatViewTarget(target)
+    return resolved.sessionId
+      ? isSessionStreaming(resolved.botId, resolved.sessionId)
+      : isUnboundComposerStreaming(
+          resolved.botId,
+          composerScope?.trim() || `${resolved.botId}:${resolved.viewId}`,
+        )
+  }
   const approvalResponses = createApprovalResponseTracker({
     rollbackApproval: approvalId => markToolApprovalDecision(approvalId, 'pending'),
     onExpired: handleExpiredApprovalResponse,
@@ -336,10 +440,12 @@ export const useChatStore = defineStore('chat', () => {
     clearDeletedSessionIds,
     clearRememberedSessions,
   } = sessionList
-  transcript.setSnapshotHook(syncForkAnchorFromUITurns)
-  transcript.setRefreshAppliedHook((targetSessionId, latestTimestamp) => {
+  transcriptSnapshotHook = (_view, targetSessionId, turns) => {
+    syncForkAnchorFromUITurns(targetSessionId, turns)
+  }
+  transcriptRefreshAppliedHook = (_view, targetSessionId, latestTimestamp) => {
     touchSessionInList(targetSessionId, latestTimestamp)
-  })
+  }
   const refreshCoordinator = createChatRefreshCoordinator({
     currentBotId,
     sessionId,
@@ -354,7 +460,7 @@ export const useChatStore = defineStore('chat', () => {
   })
   const {
     refreshSessionsList,
-    scheduleRefreshCurrentSession,
+    scheduleSessionRefresh,
     resetRefreshCoordinator,
   } = refreshCoordinator
   const realtime = createChatRealtimeController({
@@ -374,6 +480,73 @@ export const useChatStore = defineStore('chat', () => {
     startBotSessionsActivityStream,
     stopStreams,
   } = realtime
+  stopEvictedSessionStream = (botId, targetSessionId) => {
+    stopSessionMessagesStream(botId, targetSessionId)
+  }
+
+  function releaseHiddenSessionView(view: ChatViewEntry | null) {
+    if (!view || view.kind !== 'session' || !view.sessionId) return
+    if (view.visiblePanelIds.size > 0) return
+    // Visibility owns the live subscription; the registry independently owns
+    // cached transcript retention for streaming and pending interactions.
+    stopSessionMessagesStream(view.botId, view.sessionId)
+    chatViews.prune()
+  }
+
+  function bindChatView(panelId: string, target: ChatViewTarget, visible = true): ChatViewEntry {
+    const change = chatViews.bindPanel(panelId, normalizedChatViewTarget(target), visible)
+    if (panelId.trim() === focusedChatViewId.value && change.view.kind === 'draft') {
+      activateDraftACPStage({
+        botId: change.view.botId,
+        sessionId: null,
+        viewId: change.view.viewId,
+      })
+    }
+    releaseHiddenSessionView(change.deactivatedSession)
+    if (change.activatedSession?.sessionId) {
+      startSessionMessagesStream(change.activatedSession.botId, change.activatedSession.sessionId)
+    }
+    if (visible && change.view.kind === 'session' && change.view.sessionId) {
+      void ensureVisibleSessionSummary(change.view.botId, change.view.sessionId)
+    }
+    return change.view
+  }
+
+  function setChatViewVisible(panelId: string, visible: boolean) {
+    const change = chatViews.setPanelVisible(panelId, visible)
+    if (!change) return
+    releaseHiddenSessionView(change.deactivatedSession)
+    if (change.activatedSession?.sessionId) {
+      startSessionMessagesStream(change.activatedSession.botId, change.activatedSession.sessionId)
+    }
+    if (visible && change.view.kind === 'session' && change.view.sessionId) {
+      void ensureVisibleSessionSummary(change.view.botId, change.view.sessionId)
+    }
+  }
+
+  function unbindChatView(panelId: string) {
+    releaseHiddenSessionView(chatViews.unbindPanel(panelId))
+  }
+
+  function focusChatView(viewId: string) {
+    const id = viewId.trim()
+    if (!id || id === focusedChatViewId.value) return
+    saveLiveDraftACPStage()
+    focusedChatViewId.value = id
+    const view = chatViews.getPanel(id)
+    if (view?.kind === 'draft') {
+      activateDraftACPStage({ botId: view.botId, sessionId: null, viewId: view.viewId })
+    }
+  }
+
+  function promoteDraftChatView(target: ChatViewTarget, targetSessionId: string): ChatViewEntry {
+    invalidateDraftViewCommand(target)
+    const promoted = chatViews.promoteDraft(target.botId, target.viewId, targetSessionId)
+    if (promoted.visiblePanelIds.size > 0 && promoted.sessionId) {
+      startSessionMessagesStream(promoted.botId, promoted.sessionId)
+    }
+    return promoted
+  }
   const loading = ref(false)
   // `loadingChats` covers the bot-level boot path (sessions list fetch), so
   // the sidebar can show its skeleton + suppress its empty-state placeholder
@@ -390,12 +563,33 @@ export const useChatStore = defineStore('chat', () => {
   const bots = ref<Bot[]>([])
   const overrideModelId = ref<string>('')
   const overrideReasoningEffort = ref<string>('')
-  const startupSendFailure = ref<StartupSendFailure | null>(null)
+  const startupSendFailures = ref<Record<string, StartupSendFailure>>({})
+  function startupSendFailureKey(botId: string, targetSessionId: string, composerScope = '') {
+    const bid = botId.trim()
+    const scope = composerScope.trim()
+    if (scope) return `composer:${bid}:${scope}`
+    return `session:${bid}:${targetSessionId.trim()}`
+  }
+  function startupSendFailureFor(target: ChatViewTarget, composerScope = ''): StartupSendFailure | null {
+    const resolved = normalizedChatViewTarget(target)
+    const scopedKey = startupSendFailureKey(resolved.botId, resolved.sessionId ?? '', composerScope)
+    const scoped = startupSendFailures.value[scopedKey]
+    if (scoped) return scoped
+    if (resolved.sessionId) {
+      return startupSendFailures.value[startupSendFailureKey(resolved.botId, resolved.sessionId)] ?? null
+    }
+    return null
+  }
+  const startupSendFailure = computed(() => startupSendFailureFor(
+    normalizedChatViewTarget(),
+    focusedChatViewId.value === 'chat'
+      ? 'chat'
+      : `${(currentBotId.value ?? '').trim()}:${focusedChatViewId.value}`,
+  ))
   // Slash-command event registry (see ./chat/command-events for scoping rules).
   const commandEventRegistry = createCommandEventRegistry({ currentBotId, sessionId })
   const {
     commandEvent,
-    currentCommandScope,
     commandEventForScope,
     rememberCommandEvent,
     showCommandError,
@@ -407,8 +601,37 @@ export const useChatStore = defineStore('chat', () => {
   // whether that send just promoted a draft (created the session). The workspace
   // tab store watches this to pin the chat tab — a session you have sent in is no
   // longer an ephemeral "preview" tab. seq forces the watch to fire on repeats.
-  const userSentInSession = ref<{ id: string, wasDraft: boolean, seq: number } | null>(null)
+  const userSentInSession = ref<{
+    id: string
+    botId: string
+    viewId: string
+    wasDraft: boolean
+    seq: number
+  } | null>(null)
   let userSendSeq = 0
+  const draftViewRequested = ref<{
+    botId: string
+    viewId: string
+    expectedSessionId: string | null
+    explicitSelection: boolean
+    input: ACPAgentSessionInput | null
+    activate: boolean
+    seq: number
+  } | null>(null)
+  let draftViewRequestSeq = 0
+  const draftViewCommandVersions = new Map<string, number>()
+  let draftViewCommandSequence = 0
+  const forkedSessionRequested = ref<{
+    botId: string
+    viewId: string
+    expectedSessionId: string
+    sessionId: string
+    title: string
+    explicitSelection: true
+    activate: boolean
+    seq: number
+  } | null>(null)
+  let forkedSessionRequestSeq = 0
   // Bumps after a session delete succeeds. Consumers that own per-session UI
   // chrome must not infer deletion from the paginated session list: a valid open
   // tab can fall off the current page without being deleted.
@@ -416,6 +639,7 @@ export const useChatStore = defineStore('chat', () => {
   let deletedSessionSeq = 0
 
   let selectSessionRequestId = 0
+  const visibleSessionSummaryRequests = new Map<string, Promise<SessionSummary | null>>()
 
   const hasExplicitSessionSelection = computed(() => explicitSessionSelection.value)
 
@@ -456,6 +680,34 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
+  function ensureVisibleSessionSummary(targetBotId: string, targetSessionId: string): Promise<SessionSummary | null> {
+    const bid = targetBotId.trim()
+    const sid = targetSessionId.trim()
+    if (!bid || !sid) return Promise.resolve(null)
+    const known = knownSessionSummary(sid)
+    if (known) return Promise.resolve(known)
+    const key = `${bid}\u0000${sid}`
+    const pending = visibleSessionSummaryRequests.get(key)
+    if (pending) return pending
+    const generation = userScopeGeneration
+    const request = (async () => {
+      try {
+        const fetched = await fetchSession(bid, sid)
+        if (generation !== userScopeGeneration || (currentBotId.value ?? '').trim() !== bid) return null
+        rememberSession(fetched)
+        return fetched
+      } catch {
+        return null
+      } finally {
+        if (visibleSessionSummaryRequests.get(key) === request) {
+          visibleSessionSummaryRequests.delete(key)
+        }
+      }
+    })()
+    visibleSessionSummaryRequests.set(key, request)
+    return request
+  }
+
 
 
 
@@ -471,13 +723,14 @@ export const useChatStore = defineStore('chat', () => {
     if (composerScope) deletedSignal.composerScope = composerScope
     deletedSession.value = deletedSignal
     clearACPRuntimeStatus(bid, sid)
+    stopSessionMessagesStream(bid, sid)
+    chatViews.removeSession(bid, sid)
     if ((currentBotId.value ?? '').trim() === bid) {
       removeSessionFromList(sid)
       if ((sessionId.value ?? '').trim() === sid) {
         sessionId.value = null
         explicitSessionSelection.value = false
         draftIntent.value = true
-        stopSessionMessagesStream()
         clearHistoryView()
       }
     }
@@ -506,7 +759,9 @@ export const useChatStore = defineStore('chat', () => {
       selectSessionRequestId++
     },
     clearTranscriptForDraft: () => {
-      stopSessionMessagesStream()
+      const bid = (currentBotId.value ?? '').trim()
+      const sid = (sessionId.value ?? '').trim()
+      if (bid && sid) stopSessionMessagesStream(bid, sid)
       clearHistoryView()
     },
   })
@@ -520,18 +775,216 @@ export const useChatStore = defineStore('chat', () => {
     rememberDefaultACPInput,
     cachedDefaultACPInput,
     cacheDefaultACPSession,
-    stageACPSession,
-    stageDefaultACPSession,
-    stageNewACPSession,
-    resetToEmptyComposer,
-    ensurePendingACPRuntime,
-    setPendingACPModel,
+    stageACPSession: stageFocusedACPSession,
+    stageDefaultACPSession: stageFocusedDefaultACPSession,
+    stageNewACPSession: stageFocusedNewACPSession,
+    resetToEmptyComposer: resetFocusedEmptyComposer,
+    ensurePendingACPRuntime: ensureFocusedPendingACPRuntime,
+    setPendingACPModel: setFocusedPendingACPModel,
     clearPendingACPSession,
     detachPendingACPSession,
     restorePendingACPSession,
     releasePendingACPSession,
-    pendingACPMatchesInput,
+    discardDetachedACPSession,
+    pendingACPMatchesInput: focusedPendingACPMatchesInput,
   } = acpStaging
+
+  interface DraftACPStage extends DetachedACPSession {
+    viewId: string
+  }
+
+  const draftACPStages = ref<Record<string, DraftACPStage>>({})
+  let liveDraftACP: { botId: string, viewId: string } | null = null
+
+  function draftACPStageKey(botId: string, viewId: string) {
+    return `${botId.trim()}\u0000${viewId.trim()}`
+  }
+
+  function sameDraftACPStage(left: { botId: string, viewId: string } | null, right: ChatViewTarget) {
+    return !!left
+      && left.botId === right.botId.trim()
+      && left.viewId === right.viewId.trim()
+      && !right.sessionId
+  }
+
+  function rememberDraftACPStage(target: Pick<ChatViewTarget, 'botId' | 'viewId'>, detached: DetachedACPSession) {
+    const key = draftACPStageKey(target.botId, target.viewId)
+    draftACPStages.value = {
+      ...draftACPStages.value,
+      [key]: {
+        botId: detached.botId.trim() || target.botId.trim(),
+        viewId: target.viewId.trim(),
+        input: { ...detached.input },
+        runtimeId: detached.runtimeId.trim(),
+      },
+    }
+  }
+
+  function syncLiveDraftACPStage() {
+    if (!liveDraftACP || !pendingACPSessionInput.value) return
+    rememberDraftACPStage(liveDraftACP, {
+      botId: liveDraftACP.botId,
+      input: pendingACPSessionInput.value,
+      runtimeId: pendingACPRuntimeId.value,
+    })
+  }
+
+  function saveLiveDraftACPStage() {
+    if (!liveDraftACP) return
+    const owner = liveDraftACP
+    const detached = detachPendingACPSession()
+    if (detached) rememberDraftACPStage(owner, detached)
+    liveDraftACP = null
+  }
+
+  function activateDraftACPStage(target: ChatViewTarget) {
+    const resolved = normalizedChatViewTarget(target)
+    if (resolved.sessionId || !resolved.botId || !resolved.viewId) return
+    if (sameDraftACPStage(liveDraftACP, resolved)) return
+    saveLiveDraftACPStage()
+    liveDraftACP = { botId: resolved.botId, viewId: resolved.viewId }
+    const saved = draftACPStages.value[draftACPStageKey(resolved.botId, resolved.viewId)]
+    if (saved) {
+      restorePendingACPSession(saved.input, saved.runtimeId, saved.botId)
+    } else {
+      releasePendingACPSession()
+    }
+  }
+
+  function forgetDraftACPStage(target: ChatViewTarget) {
+    const resolved = normalizedChatViewTarget(target)
+    const key = draftACPStageKey(resolved.botId, resolved.viewId)
+    if (sameDraftACPStage(liveDraftACP, resolved)) {
+      releasePendingACPSession()
+      liveDraftACP = null
+    }
+    if (!(key in draftACPStages.value)) return
+    const { [key]: _removed, ...rest } = draftACPStages.value
+    draftACPStages.value = rest
+  }
+
+  function discardDraftACPStage(target: ChatViewTarget) {
+    const resolved = normalizedChatViewTarget(target)
+    const key = draftACPStageKey(resolved.botId, resolved.viewId)
+    if (sameDraftACPStage(liveDraftACP, resolved)) {
+      clearPendingACPSession()
+      liveDraftACP = null
+    } else {
+      const saved = draftACPStages.value[key]
+      if (saved) discardDetachedACPSession(saved)
+    }
+    if (!(key in draftACPStages.value)) return
+    const { [key]: _removed, ...rest } = draftACPStages.value
+    draftACPStages.value = rest
+  }
+
+  discardEvictedDraftStage = (view) => {
+    draftViewCommandVersions.delete(draftSessionCreationKey({
+      botId: view.botId,
+      sessionId: null,
+      viewId: view.viewId,
+    }))
+    discardDraftACPStage({ botId: view.botId, sessionId: null, viewId: view.viewId })
+  }
+
+  function pendingACPStateFor(target: ChatViewTarget) {
+    const resolved = normalizedChatViewTarget(target)
+    if (resolved.sessionId) return null
+    const live = sameDraftACPStage(liveDraftACP, resolved)
+    const saved = live && pendingACPSessionInput.value
+      ? {
+          botId: liveDraftACP!.botId,
+          viewId: liveDraftACP!.viewId,
+          input: pendingACPSessionInput.value,
+          runtimeId: pendingACPRuntimeId.value,
+        }
+      : draftACPStages.value[draftACPStageKey(resolved.botId, resolved.viewId)]
+    if (!saved) return null
+    const runtimeKey = acpRuntimeKey(saved.botId, saved.runtimeId)
+    return {
+      input: { ...saved.input },
+      metadata: acpSessionMetadata(saved.input),
+      modelId: saved.input.modelId?.trim() ?? '',
+      runtimeId: saved.runtimeId,
+      runtimeStatus: runtimeKey ? acpRuntimeStatuses.value[runtimeKey] : undefined,
+      ensuring: live ? pendingACPRuntimeEnsuring.value : false,
+    }
+  }
+
+  function targetDraftForACP(target?: ChatViewTarget): ChatViewTarget {
+    const resolved = normalizedChatViewTarget(target)
+    return { ...resolved, sessionId: null }
+  }
+
+  function stageACPSession(
+    input: ACPAgentSessionInput,
+    options: { explicitSelection?: boolean } = {},
+    target?: ChatViewTarget,
+  ) {
+    const draft = targetDraftForACP(target)
+    invalidateDraftViewCommand(draft)
+    activateDraftACPStage(draft)
+    stageFocusedACPSession(input, options)
+    syncLiveDraftACPStage()
+  }
+
+  function stageDefaultACPSession(input: ACPAgentSessionInput, target?: ChatViewTarget) {
+    const draft = targetDraftForACP(target)
+    invalidateDraftViewCommand(draft)
+    activateDraftACPStage(draft)
+    stageFocusedDefaultACPSession(input)
+    syncLiveDraftACPStage()
+  }
+
+  function stageNewACPSession(input: ACPAgentSessionInput, target?: ChatViewTarget) {
+    const draft = targetDraftForACP(target)
+    invalidateDraftViewCommand(draft)
+    activateDraftACPStage(draft)
+    stageFocusedNewACPSession(input)
+    syncLiveDraftACPStage()
+  }
+
+  function resetToEmptyComposer(
+    options: { clearPendingACP?: boolean, explicitSelection?: boolean, draftIntent?: boolean } = {},
+    target?: ChatViewTarget,
+  ) {
+    const draft = targetDraftForACP(target)
+    invalidateDraftViewCommand(draft)
+    activateDraftACPStage(draft)
+    resetFocusedEmptyComposer(options)
+    if (options.clearPendingACP !== false) forgetDraftACPStage(draft)
+  }
+
+  async function ensurePendingACPRuntime(target?: ChatViewTarget) {
+    const draft = targetDraftForACP(target)
+    activateDraftACPStage(draft)
+    try {
+      return await ensureFocusedPendingACPRuntime()
+    } finally {
+      syncLiveDraftACPStage()
+    }
+  }
+
+  async function setPendingACPModel(modelId: string, target?: ChatViewTarget) {
+    const draft = targetDraftForACP(target)
+    invalidateDraftViewCommand(draft)
+    activateDraftACPStage(draft)
+    try {
+      await setFocusedPendingACPModel(modelId)
+    } finally {
+      syncLiveDraftACPStage()
+    }
+  }
+
+  function pendingACPMatchesInput(input: ACPAgentSessionInput, target?: ChatViewTarget) {
+    if (!target) return focusedPendingACPMatchesInput(input)
+    const state = pendingACPStateFor(target)
+    if (!state) return false
+    const metadata = acpSessionMetadata(input)
+    return state.metadata.acp_agent_id === metadata.acp_agent_id
+      && state.metadata.project_path === metadata.project_path
+      && state.metadata.acp_project_mode === metadata.acp_project_mode
+  }
 
   watch(currentBotId, (newId) => {
     if (newId) {
@@ -547,17 +1000,21 @@ export const useChatStore = defineStore('chat', () => {
 
   function refreshLoadingForSession(botId: string, targetSessionId: string) {
     if (!isActiveSessionTarget(botId, targetSessionId)) return
-    loading.value = isSessionStreaming(targetSessionId)
+    loading.value = isSessionStreaming(botId, targetSessionId)
+  }
+
+  function isActiveSessionStreaming() {
+    return isSessionStreaming(currentBotId.value, sessionId.value)
   }
 
 
-  function ensureDiscussStream(streamId: string, targetSessionId?: string) {
-    const id = streamIdForEvent({ stream_id: streamId, session_id: targetSessionId }, targetSessionId)
+  function ensureDiscussStream(streamId: string, targetSessionId: string, targetBotId: string) {
+    const id = streamIdForEvent(targetBotId, { stream_id: streamId, session_id: targetSessionId }, targetSessionId)
     const existing = getAssistantStream(id)
     if (existing) return existing
     if (isTerminalStream(id)) return null
-    const sid = (targetSessionId ?? sessionId.value ?? '').trim()
-    const bid = (currentBotId.value ?? '').trim()
+    const sid = targetSessionId.trim()
+    const bid = targetBotId.trim()
     const assistantTurn = createOptimisticAssistantTurn()
     appendTurnToSession(bid, sid, assistantTurn)
     void trackAssistantStream({ streamId: id, assistantTurn, botId: bid, sessionId: sid }).catch((error: Error) => {
@@ -574,8 +1031,9 @@ export const useChatStore = defineStore('chat', () => {
     const bid = (pending?.botId || sourceBotId || currentBotId.value || '').trim()
     if (!bid || !eventSessionId) return
     const sid = recordCreatedSession(event.stream_id, eventSessionId) || eventSessionId
+    const viewId = pending?.viewId?.trim() || focusedChatViewId.value
+    const promoted = promoteDraftChatView({ botId: bid, sessionId: null, viewId }, sid)
     if ((currentBotId.value ?? '').trim() !== bid) return
-    if (sessionId.value && sessionId.value !== sid) return
 
     const now = new Date().toISOString()
     if (!knownSessionSummary(sid)) {
@@ -585,30 +1043,46 @@ export const useChatStore = defineStore('chat', () => {
         type: 'chat',
         session_mode: 'chat',
         runtime_type: 'model',
-        title: provisionalSessionTitle(latestOptimisticUserText()),
+        title: provisionalSessionTitle(promoted.transcript.latestOptimisticUserText()),
         created_at: now,
         updated_at: now,
       })
     }
+    userSentInSession.value = {
+      id: sid,
+      botId: bid,
+      viewId,
+      wasDraft: true,
+      seq: ++userSendSeq,
+    }
+    if (focusedChatViewId.value !== viewId) return
+    if (sessionId.value && sessionId.value !== sid) return
     sessionId.value = sid
     explicitSessionSelection.value = true
     draftIntent.value = false
-    userSentInSession.value = { id: sid, wasDraft: true, seq: ++userSendSeq }
   }
 
   function rememberStartupSendFailure(failure: Omit<StartupSendFailure, 'id'>) {
-    startupSendFailure.value = {
+    const stored: StartupSendFailure = {
       ...failure,
       id: nextId(),
       restoreAttachments: failure.restoreAttachments ? [...failure.restoreAttachments] : undefined,
       restoreRequestedSkills: failure.restoreRequestedSkills ? failure.restoreRequestedSkills.map(skill => ({ ...skill })) : undefined,
     }
+    const key = startupSendFailureKey(failure.botId, failure.sessionId, failure.composerScope)
+    startupSendFailures.value = { ...startupSendFailures.value, [key]: stored }
   }
 
   function clearStartupSendFailure(id?: string) {
-    if (!id || startupSendFailure.value?.id === id) {
-      startupSendFailure.value = null
+    if (!id) {
+      startupSendFailures.value = {}
+      return
     }
+    const next = { ...startupSendFailures.value }
+    for (const [key, failure] of Object.entries(next)) {
+      if (failure.id === id) delete next[key]
+    }
+    startupSendFailures.value = next
   }
 
   function pruneEmptyAssistantTurnIfPending(streamId: string) {
@@ -640,7 +1114,7 @@ export const useChatStore = defineStore('chat', () => {
     if (event.type === 'user_message') {
       const sid = (event.session_id ?? targetSessionId ?? sessionId.value ?? '').trim()
       const bid = sourceBotId || currentBotId.value || ''
-      const streamId = streamIdForEvent(event, sid)
+      const streamId = streamIdForEvent(bid, event, sid)
       if (isTerminalStream(streamId) || isTerminalApprovalResponse(streamId)) return
       appendTurnToSession(bid, sid, normalizeTurn(event.data))
       const pending = getAssistantStream(streamId)
@@ -661,14 +1135,15 @@ export const useChatStore = defineStore('chat', () => {
         if (pending) {
           const message = event.error?.message || 'slash command failed'
           rejectAssistantStream(invocationId, new CommandStreamError(message))
-          loading.value = isSessionStreaming(sessionId.value)
+          loading.value = isActiveSessionStreaming()
         }
       }
       return
     }
 
     const sid = (event.session_id ?? targetSessionId ?? sessionId.value ?? '').trim()
-    const streamId = streamIdForEvent(event, sid)
+    const bid = sourceBotId || currentBotId.value || ''
+    const streamId = streamIdForEvent(bid, event, sid)
     // The server may emit end after error. It must not recreate the stream, but
     // it still triggers the final authoritative refresh below.
     if ((isTerminalStream(streamId) || isTerminalApprovalResponse(streamId)) && event.type !== 'end') return
@@ -681,17 +1156,17 @@ export const useChatStore = defineStore('chat', () => {
         } else {
           settleApprovalResponse(streamId, 'succeeded')
         }
-        loading.value = isSessionStreaming(sessionId.value)
+        loading.value = isActiveSessionStreaming()
       }
       return
     }
 
     switch (event.type) {
       case 'start':
-        ensureDiscussStream(streamId, sid)
+        ensureDiscussStream(streamId, sid, bid)
         break
       case 'message':
-        const messageStream = ensureDiscussStream(streamId, sid)
+        const messageStream = ensureDiscussStream(streamId, sid, bid)
         if (messageStream) upsertAssistantUIMessage(messageStream.assistantTurn, event.data)
         break
       case 'end':
@@ -701,32 +1176,26 @@ export const useChatStore = defineStore('chat', () => {
         settleApprovalResponse(streamId, 'succeeded')
         pruneEmptyAssistantTurnIfPending(streamId)
         resolveAssistantStream(streamId)
-        loading.value = isSessionStreaming(sessionId.value)
-        // Only refresh when the ended stream belongs to the active session.
-        // Otherwise the REST round trip lands after the user has switched
-        // away and `refreshCurrentSession` drops the result anyway.
-        if (
-          endedSessionId
-          && !isSessionStreaming(endedSessionId)
-          && endedSessionId === (sessionId.value ?? '').trim()
-          && endedBotId === (currentBotId.value ?? '').trim()
-        ) {
-          void refreshCurrentSession(endedBotId, endedSessionId)
-        } else if (endedSessionId && !isSessionStreaming(endedSessionId)) {
-          // Background session: skip the REST refresh, but still bump the
-          // sidebar timestamp so the ended session floats to the top of the
-          // list instead of remaining ordered by its last streamed delta.
-          touchSessionInList(endedSessionId, new Date().toISOString())
+        loading.value = isActiveSessionStreaming()
+        if (endedSessionId && !isSessionStreaming(endedBotId, endedSessionId)) {
+          const endedView = chatViews.getSession(endedBotId, endedSessionId)
+          if (endedView) {
+            void refreshCurrentSession(endedBotId, endedSessionId)
+              .finally(() => releaseHiddenSessionView(endedView))
+          } else {
+            touchSessionInList(endedSessionId, new Date().toISOString())
+          }
         }
         break
       case 'error': {
-        const session = getAssistantStream(streamId) ?? ensureDiscussStream(streamId, sid)
+        const session = getAssistantStream(streamId) ?? ensureDiscussStream(streamId, sid, bid)
         if (!session) break
         const message = event.message || 'stream error'
         const stage: SendMessageStage = hasVisibleAssistantBlocks(session.assistantTurn) ? 'stream' : 'startup'
         settleApprovalResponse(streamId, 'failed')
         rejectAssistantStream(streamId, new StreamFailureError(message, stage))
-        loading.value = isSessionStreaming(sessionId.value)
+        loading.value = isActiveSessionStreaming()
+        releaseHiddenSessionView(chatViews.getSession(session.botId, session.sessionId) ?? null)
         break
       }
     }
@@ -753,6 +1222,8 @@ export const useChatStore = defineStore('chat', () => {
       currentBotId.value = null
     }
     resetTranscriptUserScope()
+    draftACPStages.value = {}
+    liveDraftACP = null
     loading.value = false
     loadingChats.value = false
     initializing.value = false
@@ -761,7 +1232,12 @@ export const useChatStore = defineStore('chat', () => {
     initializePromise = null
     overrideModelId.value = ''
     overrideReasoningEffort.value = ''
-    startupSendFailure.value = null
+    startupSendFailures.value = {}
+    draftViewRequested.value = null
+    forkedSessionRequested.value = null
+    draftViewCommandVersions.clear()
+    visibleSessionSummaryRequests.clear()
+    draftSessionCreations.clear()
     resetCommandEvents()
     resetFsBeacon()
     resetACPRuntimeRegistry()
@@ -803,7 +1279,13 @@ export const useChatStore = defineStore('chat', () => {
       if (eventSessionId && eventSessionId !== targetSessionId) return
       const task = normalizeBackgroundTask(event, event.type)
       if (!task) return
-      backgroundTasks.mergeBackgroundTaskIntoMatchingTools(rememberBackgroundTask(task), messages)
+      const view = chatViews.getSession(targetBotId, targetSessionId)
+      if (view) {
+        backgroundTasks.mergeBackgroundTaskIntoMatchingTools(
+          rememberBackgroundTask(task),
+          view.transcript.messages,
+        )
+      }
       if (eventSessionId) touchSessionInList(eventSessionId)
       return
     }
@@ -822,15 +1304,21 @@ export const useChatStore = defineStore('chat', () => {
     // already-known message ids — the comparison was unsound anyway because
     // `messages` holds aggregated UI turns whose ids live in a different
     // namespace from raw bot_history_messages.id. The downstream
-    // `scheduleRefreshCurrentSession` is debounced and idempotent, so an
+    // The keyed session refresh is debounced and idempotent, so an
     // occasional redundant REST round trip is cheap.
     const raw = event.message
     if (!raw) return
     const messageSessionId = String(raw.session_id ?? '').trim()
     if (messageSessionId && messageSessionId !== targetSessionId) return
     if (messageSessionId) touchSessionInList(messageSessionId, raw.created_at)
-    if (!shouldRefreshFromMessageCreated(targetBotId, sessionId.value, streamingSessionId.value, event)) return
-    scheduleRefreshCurrentSession(messageSessionId)
+    const sid = messageSessionId || targetSessionId
+    if (!shouldRefreshFromMessageCreated(
+      targetBotId,
+      sid,
+      isSessionStreaming(targetBotId, sid) ? sid : null,
+      event,
+    )) return
+    scheduleSessionRefresh(targetBotId, sid)
   }
 
   function handleBotSessionsActivityEvent(targetBotId: string, event: BotSessionActivityEvent) {
@@ -891,24 +1379,28 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  function abort() {
+  function abort(target?: ChatViewTarget) {
+    const resolved = normalizedChatViewTarget(target)
     const abortError = new Error('aborted')
     abortError.name = 'AbortError'
     const approvalStreamIds = abortApprovalResponses(
-      pendingApprovalResponsesForSession(currentBotId.value ?? '', sessionId.value ?? ''),
+      pendingApprovalResponsesForSession(resolved.botId, resolved.sessionId ?? ''),
       'failed',
     )
-    const activeSessionId = (sessionId.value ?? '').trim()
-    const streamIds = activeSessionId
-      ? assistantStreams.activeStreamIdsForSession(activeSessionId)
-      : activeUnboundStreamIds(currentBotId.value)
+    const streamIds = resolved.sessionId
+      ? assistantStreamsForSession(resolved.botId, resolved.sessionId).map(stream => stream.streamId)
+      : activeUnboundStreamIds(
+          resolved.botId,
+          target ? `${resolved.botId}:${resolved.viewId}` : undefined,
+        )
     for (const streamId of streamIds) {
       if (!approvalStreamIds.has(streamId)) {
         abortWebSocketStream(streamId, getAssistantStream(streamId)?.botId)
       }
       rejectAssistantStream(streamId, abortError)
     }
-    loading.value = isSessionStreaming(sessionId.value)
+    loading.value = isActiveSessionStreaming()
+    chatViews.prune()
   }
 
   function abortApprovalResponses(responses: ApprovalResponse[], outcome: ApprovalResponseOutcome): Set<string> {
@@ -984,11 +1476,14 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  const activeChatTarget = computed<ActiveChatTarget>(() => {
-    const explicitSelection = explicitSessionSelection.value
-    const sid = (sessionId.value ?? '').trim()
+  function chatTargetFor(target?: ChatViewTarget): ActiveChatTarget {
+    const resolved = normalizedChatViewTarget(target)
+    const focused = resolved.viewId === focusedChatViewId.value
+      && resolved.botId === (currentBotId.value ?? '').trim()
+    const explicitSelection = focused ? explicitSessionSelection.value : false
+    const sid = (resolved.sessionId ?? '').trim()
     if (sid) {
-      const session = activeSession.value
+      const session = knownSessionSummary(sid)
       const runtimeType = session ? normalizedRuntimeType(session) : 'unknown'
       return {
         kind: 'session',
@@ -1002,8 +1497,8 @@ export const useChatStore = defineStore('chat', () => {
       }
     }
 
-    const metadata = pendingACPSessionMetadata.value
-    if (metadata) {
+    const pendingState = pendingACPStateFor(resolved)
+    if (pendingState) {
       return {
         kind: 'draft-acp',
         sessionId: null,
@@ -1011,7 +1506,7 @@ export const useChatStore = defineStore('chat', () => {
         runtimeType: 'acp_agent',
         isACP: true,
         isPendingACP: true,
-        metadata,
+        metadata: pendingState.metadata,
         explicitSelection,
       }
     }
@@ -1026,7 +1521,23 @@ export const useChatStore = defineStore('chat', () => {
       metadata: {},
       explicitSelection,
     }
-  })
+  }
+
+  const activeChatTarget = computed<ActiveChatTarget>(() => chatTargetFor())
+
+  function chatReadOnlyFor(target: ChatViewTarget): boolean {
+    const resolved = normalizedChatViewTarget(target)
+    const session = chatTargetFor(resolved).session
+    if (!session) return Boolean(resolved.sessionId)
+    const type = session.type ?? 'chat'
+    if (type === 'heartbeat' || type === 'schedule' || type === 'subagent') return true
+    const channelType = (session.channel_type ?? '').trim().toLowerCase()
+    return Boolean(channelType && channelType !== 'local')
+  }
+
+  function chatCanForkFor(target: ChatViewTarget): boolean {
+    return chatTargetFor(target).session?.type === 'chat'
+  }
 
 
 
@@ -1050,15 +1561,18 @@ export const useChatStore = defineStore('chat', () => {
 
 
 
-  async function createACPSession(input: ACPAgentSessionInput): Promise<{ session: SessionSummary; runtime?: AcpagentRuntimeStatus }> {
-    const bid = currentBotId.value ?? await ensureBot()
+  async function createACPSessionRecord(
+    botId: string,
+    input: ACPAgentSessionInput,
+  ): Promise<SessionSummary> {
+    const bid = botId.trim()
     if (!bid) throw new Error('Bot not ready')
     const metadata = acpSessionMetadata(input)
     const runtimeId = input.runtimeId?.trim() ?? ''
     const sessionMode = input.sessionMode === 'discuss' ? 'discuss' : 'chat'
     // The warm staged runtime is bound server-side inside session creation;
     // no separate adopt/bind round trip and nothing for a watcher to race.
-    const created = await createSession(bid, {
+    return createSession(bid, {
       title: input.title ?? '',
       type: sessionMode,
       sessionMode,
@@ -1067,29 +1581,139 @@ export const useChatStore = defineStore('chat', () => {
       runtimeMetadata: metadata,
       acpRuntimeId: runtimeId || undefined,
     })
-    upsertSession(created)
-    sessionId.value = created.id
-    explicitSessionSelection.value = true
-    draftIntent.value = false
-    clearHistoryView()
-    if (runtimeId) {
-      // The staged runtime now belongs to the session — reset local staging
-      // without closing it.
-      releasePendingACPSession()
-    } else {
-      clearPendingACPSession()
+  }
+
+  async function configureCreatedACPRuntime(
+    created: SessionSummary,
+    input: ACPAgentSessionInput,
+    botId: string,
+    generation: number,
+  ): Promise<AcpagentRuntimeStatus | undefined> {
+    const modelId = input.modelId?.trim() ?? ''
+    if (!input.startRuntime && !modelId) return undefined
+    const assertCurrentScope = () => {
+      if (generation === userScopeGeneration && (currentBotId.value ?? '').trim() === botId) return
+      const error = new Error('Chat scope changed during ACP runtime setup')
+      error.name = 'AbortError'
+      throw error
     }
-    const runtime = input.startRuntime ? await ensureACPRuntime(created.id) : undefined
+    assertCurrentScope()
+    let runtime = await ensureACPRuntimeFor(botId, created.id)
+    assertCurrentScope()
+    if (modelId && runtime.models?.current_model_id?.trim() !== modelId) {
+      runtime = await setACPRuntimeModelFor(botId, created.id, modelId)
+      assertCurrentScope()
+    }
+    return runtime
+  }
+
+  async function createACPSessionForTarget(
+    input: ACPAgentSessionInput,
+    target: ChatViewTarget,
+  ): Promise<{ session: SessionSummary; runtime?: AcpagentRuntimeStatus }> {
+    const draft = targetDraftForACP(target)
+    const generation = userScopeGeneration
+    const stagedBeforeCreate = pendingACPStateFor(draft)
+    const runtimeId = input.runtimeId?.trim() ?? ''
+    const created = await createACPSessionRecord(draft.botId, input)
+    const assertCurrentScope = () => {
+      if (
+        generation === userScopeGeneration
+        && (currentBotId.value ?? '').trim() === draft.botId
+      ) return
+      const error = new Error('Chat scope changed during ACP Session creation')
+      error.name = 'AbortError'
+      throw error
+    }
+
+    let runtime: AcpagentRuntimeStatus | undefined
+    try {
+      assertCurrentScope()
+      runtime = await configureCreatedACPRuntime(created, input, draft.botId, generation)
+      assertCurrentScope()
+    } catch (error) {
+      await rollbackFailedACPSessionCreation(created, draft, stagedBeforeCreate?.input ?? input, runtimeId, generation)
+      throw error
+    }
+
+    upsertSession(created)
+    rememberSession(created)
+    if (runtimeId) clearACPRuntimeStatus(draft.botId, runtimeId)
+    promoteDraftChatView(draft, created.id)
+    if (stagedBeforeCreate) {
+      if (runtimeId && stagedBeforeCreate.runtimeId === runtimeId) {
+        forgetDraftACPStage(draft)
+      } else {
+        discardDraftACPStage(draft)
+      }
+    }
+    if (isFocusedChatTarget(draft)) {
+      sessionId.value = created.id
+      explicitSessionSelection.value = true
+      draftIntent.value = false
+    }
     return { session: created, runtime }
   }
 
-  async function updateCurrentSessionAgent(input: ACPAgentSessionInput): Promise<{ session: SessionSummary; runtime?: AcpagentRuntimeStatus }> {
-    if (!sessionId.value) return createACPSession(input)
-    const bid = currentBotId.value ?? ''
-    const sid = sessionId.value
+  async function rollbackFailedACPSessionCreation(
+    created: SessionSummary,
+    draft: ChatViewTarget,
+    stagedInput: ACPAgentSessionInput,
+    stagedRuntimeId: string,
+    generation: number,
+  ) {
+    if (generation !== userScopeGeneration) return
+
+    markSessionDeleted(draft.botId, created.id)
+    stopSessionMessagesStream(draft.botId, created.id)
+    chatViews.removeSession(draft.botId, created.id)
+    clearACPRuntimeStatus(draft.botId, created.id)
+    if (stagedRuntimeId) clearACPRuntimeStatus(draft.botId, stagedRuntimeId)
+    if ((currentBotId.value ?? '').trim() === draft.botId) {
+      removeSessionFromList(created.id)
+    }
+
+    if (sameDraftACPStage(liveDraftACP, draft)) {
+      releasePendingACPSession()
+      liveDraftACP = null
+    }
+    rememberDraftACPStage(draft, {
+      botId: draft.botId,
+      input: normalizedACPInput({ ...stagedInput, runtimeId: undefined }),
+      runtimeId: '',
+    })
+    if (isFocusedChatTarget(draft)) activateDraftACPStage(draft)
+
+    try {
+      await requestDeleteSession(draft.botId, created.id)
+    } catch {
+      // The tombstone keeps a failed cleanup out of this client until auth reset.
+    }
+  }
+
+  async function createACPSession(input: ACPAgentSessionInput): Promise<{ session: SessionSummary; runtime?: AcpagentRuntimeStatus }> {
+    const bid = currentBotId.value ?? await ensureBot()
+    if (!bid) throw new Error('Bot not ready')
+    return createACPSessionForTarget(input, {
+      botId: bid,
+      sessionId: null,
+      viewId: focusedChatViewId.value,
+    })
+  }
+
+  async function updateCurrentSessionAgent(
+    input: ACPAgentSessionInput,
+    target?: ChatViewTarget,
+  ): Promise<{ session: SessionSummary; runtime?: AcpagentRuntimeStatus }> {
+    const resolved = normalizedChatViewTarget(target)
+    if (!resolved.sessionId) return createACPSessionForTarget(input, resolved)
+    const bid = resolved.botId
+    const sid = resolved.sessionId
     if (!bid) throw new Error('Bot not selected')
     const metadata = acpSessionMetadata(input)
-    const sessionMode = activeSession.value?.session_mode || (activeSession.value?.type === 'discuss' ? 'discuss' : 'chat')
+    const targetSession = knownSessionSummary(sid)
+    const sessionMode = targetSession?.session_mode || (targetSession?.type === 'discuss' ? 'discuss' : 'chat')
+    const generation = userScopeGeneration
     const updated = await requestUpdateSessionAgent(bid, sid, {
       type: sessionMode === 'discuss' ? 'discuss' : 'acp_agent',
       sessionMode,
@@ -1097,21 +1721,28 @@ export const useChatStore = defineStore('chat', () => {
       metadata,
       runtimeMetadata: metadata,
     })
+    if (generation !== userScopeGeneration || (currentBotId.value ?? '').trim() !== bid) return { session: updated }
     upsertSession(updated)
-    explicitSessionSelection.value = true
-    draftIntent.value = false
-    clearPendingACPSession()
+    if (isFocusedChatTarget(resolved)) {
+      explicitSessionSelection.value = true
+      draftIntent.value = false
+    }
     clearACPRuntimeStatus(bid, sid)
-    const runtime = input.startRuntime ? await ensureACPRuntime(sid) : undefined
+    const runtime = input.startRuntime ? await ensureACPRuntimeFor(bid, sid) : undefined
+    if (generation !== userScopeGeneration || (currentBotId.value ?? '').trim() !== bid) {
+      return { session: updated }
+    }
     return { session: updated, runtime }
   }
 
-  async function updateCurrentSessionToMemoh(): Promise<SessionSummary | null> {
-    clearPendingACPSession()
-    const bid = currentBotId.value ?? ''
-    const sid = sessionId.value ?? ''
+  async function updateCurrentSessionToMemoh(target?: ChatViewTarget): Promise<SessionSummary | null> {
+    const resolved = normalizedChatViewTarget(target)
+    const bid = resolved.botId
+    const sid = resolved.sessionId ?? ''
     if (!bid || !sid) return null
-    const sessionMode = activeSession.value?.session_mode || (activeSession.value?.type === 'discuss' ? 'discuss' : 'chat')
+    const targetSession = knownSessionSummary(sid)
+    const sessionMode = targetSession?.session_mode || (targetSession?.type === 'discuss' ? 'discuss' : 'chat')
+    const generation = userScopeGeneration
     const updated = await requestUpdateSessionAgent(bid, sid, {
       type: sessionMode === 'discuss' ? 'discuss' : 'chat',
       sessionMode,
@@ -1119,66 +1750,61 @@ export const useChatStore = defineStore('chat', () => {
       metadata: {},
       runtimeMetadata: {},
     })
+    if (generation !== userScopeGeneration || (currentBotId.value ?? '').trim() !== bid) return null
     upsertSession(updated)
-    explicitSessionSelection.value = true
-    draftIntent.value = false
+    if (isFocusedChatTarget(resolved)) {
+      explicitSessionSelection.value = true
+      draftIntent.value = false
+    }
     clearACPRuntimeStatus(bid, sid)
     return updated
   }
 
-  async function ensureActiveSession(firstPrompt?: string) {
-    if (sessionId.value) return
-    if (pendingACPSessionInput.value) {
-      const detached = detachPendingACPSession()
-      if (!detached) return
-      const pending = detached.input
-      const pendingModelId = pending.modelId?.trim() ?? ''
-      const runtimeId = detached.runtimeId
-      let created: SessionSummary
-      try {
-        ({ session: created } = await createACPSession({ ...pending, runtimeId }))
-      } catch (error) {
-        // Session creation failed: restore the staged agent (and keep its
-        // warm runtime) so the user can simply retry.
-        if (!pendingACPSessionInput.value && !sessionId.value) {
-          restorePendingACPSession(pending, runtimeId, detached.botId)
+  async function ensureChatViewSession(target: ChatViewTarget, firstPrompt?: string): Promise<ChatViewTarget> {
+    if (target.sessionId) return target
+    const creationKey = draftSessionCreationKey(target)
+    if (draftSessionCreations.has(creationKey)) {
+      throw new StreamFailureError('Session creation is already in progress', 'startup')
+    }
+    draftSessionCreations.add(creationKey)
+    try {
+      const pendingACP = pendingACPStateFor(target)
+      if (pendingACP) {
+        const { session: created } = await createACPSessionForTarget({
+          ...pendingACP.input,
+          runtimeId: pendingACP.runtimeId,
+        }, target)
+        if (firstPrompt?.trim() && !created.title?.trim()) {
+          created.title = provisionalSessionTitle(firstPrompt)
+          upsertSession(created)
+          rememberSession(created)
         }
+        return { ...target, sessionId: created.id }
+      }
+
+      const generation = userScopeGeneration
+      const created = await createSession(target.botId)
+      if (
+        generation !== userScopeGeneration
+        || (currentBotId.value ?? '').trim() !== target.botId
+      ) {
+        const error = new Error('Chat scope changed during Session creation')
+        error.name = 'AbortError'
         throw error
       }
-      const bid = currentBotId.value ?? ''
-      if (bid && runtimeId) {
-        clearACPRuntimeStatus(bid, runtimeId)
+      if (firstPrompt?.trim()) created.title = provisionalSessionTitle(firstPrompt)
+      upsertSession(created)
+      rememberSession(created)
+      promoteDraftChatView(target, created.id)
+      if (isFocusedChatTarget(target)) {
+        sessionId.value = created.id
+        explicitSessionSelection.value = true
+        draftIntent.value = false
       }
-      if (pendingModelId) {
-        // Bind carries the staged model with the runtime. Only when the bind
-        // fell back to a cold start does the model need re-applying.
-        const runtime = await ensureACPRuntime(created.id)
-        const currentModelId = runtime?.models?.current_model_id?.trim() ?? ''
-        if (currentModelId !== pendingModelId) {
-          await setACPRuntimeModel(pendingModelId)
-        }
-      }
-      return
+      return { ...target, sessionId: created.id }
+    } finally {
+      draftSessionCreations.delete(creationKey)
     }
-    const bid = currentBotId.value ?? await ensureBot()
-    if (!bid) throw new Error('Bot not ready')
-    const created = await createSession(bid)
-    // Show the first prompt optimistically as the title so the sidebar/tab never
-    // flashes "Untitled Session" while the server's title model runs. This is a
-    // LOCAL display value only — the server creates the session untitled and
-    // persists the real title via the title-generation flow. Keeping the session
-    // untitled server-side preserves the "title empty ⇒ needs an LLM title"
-    // invariant the backend guards on (restart-safe), and the optimistic value
-    // mirrors backend fallbackSessionTitle so the SSE-confirmed title lands
-    // without flicker.
-    if (firstPrompt?.trim()) {
-      created.title = provisionalSessionTitle(firstPrompt)
-    }
-    upsertSession(created)
-    sessionId.value = created.id
-    draftIntent.value = false
-    explicitSessionSelection.value = true
-    clearHistoryView()
   }
 
   // defaultRuntimeIsACP reports whether the bot's default chat runtime is an
@@ -1406,12 +2032,8 @@ export const useChatStore = defineStore('chat', () => {
     await run
   }
 
-  // Switching sessions is an explicit operation: stop the active SSE, blank
-  // the view, restart the SSE for the new session. We do NOT use a watcher on
-  // `sessionId` — a watcher fires asynchronously and races with operations
-  // that mutate `messages` between the assignment and the watcher microtask
-  // (e.g. an optimistic turn appended during `sendMessage` is wiped when the
-  // pending watcher finally runs `clearHistoryView()`).
+  // Selection changes focus only. Visible panel bindings own Session SSE
+  // lifetimes, and keyed transcript views retain their own cached history.
   //
   // We deliberately do NOT call `abortAllAssistantStreams()` here: an
   // assistant stream that started in session A keeps running server-side
@@ -1419,11 +2041,13 @@ export const useChatStore = defineStore('chat', () => {
   // the user comes back (the `appendTurnToSession` / WS handlers are
   // already gated on `sessionId.value === <stream's sessionId>`, so the
   // orphan does not bleed into B's view).
-  function switchActiveSession(sid: string) {
-    stopSessionMessagesStream()
-    clearHistoryView()
+  function switchActiveSession(sid: string, previousSessionId = '') {
     const bid = (currentBotId.value ?? '').trim()
     if (!bid || !sid) return
+    const previous = previousSessionId.trim()
+    if (previous && previous !== sid) {
+      releaseHiddenSessionView(chatViews.getSession(bid, previous) ?? null)
+    }
     startSessionMessagesStream(bid, sid)
   }
 
@@ -1445,14 +2069,15 @@ export const useChatStore = defineStore('chat', () => {
   async function selectSession(targetSessionId: string, options: { explicitSelection?: boolean } = {}) {
     const sid = targetSessionId.trim()
     if (!sid) return
-    const sameSession = sid === sessionId.value
+    const previousSessionId = (sessionId.value ?? '').trim()
+    const sameSession = sid === previousSessionId
     const requestId = ++selectSessionRequestId
     const bid = (currentBotId.value ?? '').trim()
     clearPendingACPSession()
     sessionId.value = sid
     draftIntent.value = false
     explicitSessionSelection.value = options.explicitSelection !== false
-    if (!sameSession) switchActiveSession(sid)
+    if (!sameSession) switchActiveSession(sid, previousSessionId)
     // Even when `sid` is already the persisted selection, a page refresh may
     // have no summary for it yet (for example an ACP session outside the first
     // sidebar page). Hydrate before consumers branch on runtime_type.
@@ -1484,9 +2109,86 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  async function handleWebNewCommand(text: string, attachments?: ChatAttachment[]): Promise<WebNewCommandResult> {
+  function normalizedACPInput(input: ACPAgentSessionInput): ACPAgentSessionInput {
+    const metadata = acpSessionMetadata(input)
+    return {
+      ...input,
+      agentId: String(metadata.acp_agent_id ?? ''),
+      projectPath: String(metadata.project_path ?? ''),
+      projectMode: String(metadata.acp_project_mode ?? ''),
+      modelId: input.modelId?.trim() ?? '',
+    }
+  }
+
+  function applyDraftViewRequest(
+    request: NonNullable<typeof draftViewRequested.value>,
+    mirrorGlobalSelection: boolean,
+  ) {
+    const target: ChatViewTarget = {
+      botId: request.botId,
+      sessionId: null,
+      viewId: request.viewId,
+    }
+    if (mirrorGlobalSelection) {
+      if (request.input) stageNewACPSession(request.input, target)
+      else resetToEmptyComposer({ explicitSelection: request.explicitSelection, draftIntent: true }, target)
+      return
+    }
+
+    const draft = chatView(target)
+    draft.transcript.clearHistoryView()
+    discardDraftACPStage(target)
+    if (request.input) {
+      rememberDraftACPStage(target, {
+        botId: request.botId,
+        input: normalizedACPInput(request.input),
+        runtimeId: '',
+      })
+    }
+  }
+
+  function requestDraftView(target: ChatViewTarget, input: ACPAgentSessionInput | null, activate = isFocusedChatTarget(target)) {
+    const resolved = normalizedChatViewTarget(target)
+    const request = {
+      botId: resolved.botId,
+      viewId: resolved.viewId,
+      expectedSessionId: resolved.sessionId,
+      explicitSelection: true,
+      input: input ? normalizedACPInput(input) : null,
+      activate,
+      seq: ++draftViewRequestSeq,
+    }
+    draftViewRequested.value = request
+  }
+
+  function invalidateDraftViewCommand(target: ChatViewTarget) {
+    const key = draftSessionCreationKey(target)
+    draftViewCommandVersions.delete(key)
+  }
+
+  function beginDraftViewCommand(target: ChatViewTarget) {
+    const key = draftSessionCreationKey(target)
+    const version = ++draftViewCommandSequence
+    draftViewCommandVersions.set(key, version)
+    return {
+      isCurrent: () => draftViewCommandVersions.get(key) === version,
+      finish: () => {
+        if (draftViewCommandVersions.get(key) === version) {
+          draftViewCommandVersions.delete(key)
+        }
+      },
+    }
+  }
+
+  async function handleWebNewCommand(
+    text: string,
+    attachments: ChatAttachment[] | undefined,
+    target: ChatViewTarget,
+  ): Promise<WebNewCommandResult> {
     const parsed = parseWebNewCommand(text)
     if (!parsed) return { kind: 'none' }
+    const generation = userScopeGeneration
+    const activate = isFocusedChatTarget(target)
     if (attachments?.length) {
       return { kind: 'error', message: 'Attachments are not supported with /new' }
     }
@@ -1495,21 +2197,36 @@ export const useChatStore = defineStore('chat', () => {
       if (parsed.mode === 'discuss') {
         return { kind: 'error', message: 'Discuss ACP sessions require an agent, for example /new discuss codex' }
       }
-      await createNewSession({ explicitSelection: true })
+      const command = beginDraftViewCommand(target)
+      if (command.isCurrent()) requestDraftView(target, null, activate)
+      command.finish()
       return { kind: 'handled' }
     }
     if (agentId !== 'codex' && agentId !== 'claude-code') {
       return { kind: 'error', message: `Unknown ACP agent "${agentId}"` }
     }
-    const bid = await ensureBot()
-    if (!bid) return { kind: 'error', message: 'Bot not ready' }
-    const defaults = await defaultACPSettingsForAgent(bid, agentId)
-    stageNewACPSession({
-      agentId,
-      sessionMode: parsed.mode === 'discuss' ? 'discuss' : 'chat',
-      ...defaults,
-    })
-    return { kind: 'handled' }
+    const command = beginDraftViewCommand(target)
+    try {
+      const targetBotId = target.botId === '__unbound__' ? '' : target.botId
+      const bid = targetBotId || await ensureBot()
+      if (!bid) return { kind: 'error', message: 'Bot not ready' }
+      const defaults = await defaultACPSettingsForAgent(bid, agentId)
+      if (
+        generation !== userScopeGeneration
+        || (currentBotId.value ?? '').trim() !== bid
+        || !command.isCurrent()
+      ) {
+        return { kind: 'handled' }
+      }
+      requestDraftView(target, {
+        agentId,
+        sessionMode: parsed.mode === 'discuss' ? 'discuss' : 'chat',
+        ...defaults,
+      }, activate)
+      return { kind: 'handled' }
+    } finally {
+      command.finish()
+    }
   }
 
   function isWebSlashInput(text: string): boolean {
@@ -1525,16 +2242,27 @@ export const useChatStore = defineStore('chat', () => {
     return ''
   }
 
-  async function handleWebSlashCommand(text: string, hasRequestedSkills = false, composerScope = 'chat'): Promise<WebSlashCommandResult> {
+  async function handleWebSlashCommand(
+    text: string,
+    hasRequestedSkills = false,
+    composerScope = 'chat',
+    target?: ChatViewTarget,
+  ): Promise<WebSlashCommandResult> {
     if (!isWebSlashInput(text) || hasRequestedSkills) return { kind: 'none' }
-    const bid = currentBotId.value ?? ''
+    const resolved = normalizedChatViewTarget(target)
+    const bid = resolved.botId
     if (!bid) return { kind: 'error', message: 'Bot not selected' }
-    const sid = sessionId.value ?? ''
+    const sid = resolved.sessionId ?? ''
     const scope = composerScope.trim() || 'chat'
+    const commandScope = {
+      botId: bid,
+      sessionId: sid || undefined,
+      composerScope: scope,
+    }
 
     const actionID = quickActionIDForSlash(text)
     if (!actionID) return { kind: 'none' }
-    const skillActivationAllowed = !activeChatTarget.value.isACP
+    const skillActivationAllowed = !chatTargetFor(resolved).isACP
     let event: CommandEventResponse | null
     try {
       event = await executeQuickAction(bid, actionID, {
@@ -1545,16 +2273,12 @@ export const useChatStore = defineStore('chat', () => {
       })
     } catch (error) {
       const message = resolveApiErrorMessage(error, commandErrorMessage('generic'))
-      showCommandError('generic', message, {
-        botId: bid,
-        sessionId: sid || undefined,
-        composerScope: scope,
-      })
+      showCommandError('generic', message, commandScope)
       return { kind: 'error', message }
     }
 
     if (!event) return { kind: 'none' }
-    rememberCommandEvent(event, { botId: bid, sessionId: sid || undefined, composerScope: scope })
+    rememberCommandEvent(event, commandScope)
     if (event.type === 'command_error') {
       return { kind: 'error', message: event.error?.message || commandErrorMessage('generic') }
     }
@@ -1567,8 +2291,11 @@ export const useChatStore = defineStore('chat', () => {
     const bid = currentBotId.value ?? ''
     if (!bid) throw new Error('Bot not selected')
     await requestDeleteSession(bid, delId)
+    abort({ botId: bid, sessionId: delId, viewId: focusedChatViewId.value })
     markSessionDeleted(bid, delId)
     deletedSession.value = { id: delId, botId: bid, seq: ++deletedSessionSeq }
+    stopSessionMessagesStream(bid, delId)
+    chatViews.removeSession(bid, delId)
     if ((currentBotId.value ?? '').trim() !== bid) return
     clearACPRuntimeStatus(bid, delId)
     removeSessionFromList(delId)
@@ -1579,7 +2306,6 @@ export const useChatStore = defineStore('chat', () => {
       sessionId.value = null
       explicitSessionSelection.value = false
       draftIntent.value = false
-      stopSessionMessagesStream()
       clearHistoryView()
       return
     }
@@ -1587,7 +2313,7 @@ export const useChatStore = defineStore('chat', () => {
     sessionId.value = next
     explicitSessionSelection.value = false
     draftIntent.value = false
-    switchActiveSession(next)
+    switchActiveSession(next, delId)
   }
 
   async function renameSession(targetSessionId: string, title: string): Promise<SessionSummary> {
@@ -1603,44 +2329,52 @@ export const useChatStore = defineStore('chat', () => {
     return updated
   }
 
-  async function forkMessage(messageId: string, options: { title?: string } = {}): Promise<boolean> {
-    const bid = (currentBotId.value ?? '').trim()
-    const sid = (sessionId.value ?? '').trim()
+  async function forkMessage(messageId: string, options: { title?: string, target?: ChatViewTarget } = {}): Promise<boolean> {
+    const target = normalizedChatViewTarget(options.target)
+    const bid = target.botId
+    const sid = target.sessionId ?? ''
     const mid = messageId.trim()
-    if (!bid || !sid || !mid || activeChatReadOnly.value || !activeChatCanFork.value || streaming.value || loadingMessages.value) return false
+    const view = chatView(target)
+    const generation = userScopeGeneration
+    const activate = isFocusedChatTarget(target)
+    if (
+      !bid || !sid || !mid
+      || chatReadOnlyFor(target)
+      || !chatCanForkFor(target)
+      || isChatViewStreaming(target)
+      || view.transcript.loadingMessages.value
+    ) return false
 
     const key = `${bid}:${sid}:${mid}`
     if (forkingMessages.has(key)) return false
     forkingMessages.add(key)
     try {
       const forked = await requestForkSessionFromMessage(bid, sid, mid, { title: options.title })
-      if ((currentBotId.value ?? '').trim() !== bid || (sessionId.value ?? '').trim() !== sid) {
-        void refreshSessionsList(bid)
-        return true
-      }
+      if (generation !== userScopeGeneration || (currentBotId.value ?? '').trim() !== bid) return true
 
       upsertSession(forked)
       rememberSession(forked)
       void refreshSessionsList(bid)
 
       const turns = await fetchSessionWindow(bid, forked.id)
+      if (generation !== userScopeGeneration || (currentBotId.value ?? '').trim() !== bid) return true
       const anchoredForked = withForkAnchorFromUITurns(forked, turns)
       if (anchoredForked !== forked) {
         upsertSession(anchoredForked)
         rememberSession(anchoredForked)
       }
-      if ((currentBotId.value ?? '').trim() !== bid || (sessionId.value ?? '').trim() !== sid) {
-        return true
+      sessionTranscript(bid, forked.id).replaceHistoryView(turns, forked.id)
+      forkedSessionRequested.value = {
+        botId: bid,
+        viewId: target.viewId,
+        expectedSessionId: sid,
+        sessionId: forked.id,
+        title: (anchoredForked.title ?? options.title ?? '').trim(),
+        explicitSelection: true,
+        activate,
+        seq: ++forkedSessionRequestSeq,
       }
-
-      selectSessionRequestId++
-      clearPendingACPSession()
-      stopSessionMessagesStream()
-      sessionId.value = forked.id
-      explicitSessionSelection.value = true
-      draftIntent.value = false
-      replaceHistoryView(turns, forked.id)
-      startSessionMessagesStream(bid, forked.id)
+      chatViews.prune()
       return true
     } catch (error) {
       toast.error(resolveApiErrorMessage(error, forkFailedMessage()))
@@ -1653,33 +2387,49 @@ export const useChatStore = defineStore('chat', () => {
   async function sendMessage(text: string, attachments?: ChatAttachment[], options: SendMessageOptions = {}): Promise<SendMessageResult> {
     const trimmed = text.trim()
     const requestedSkills = normalizeRequestedSkills(options.requestedSkills)
-    const composerScope = options.composerScope?.trim() || 'chat'
+    let viewTarget = normalizedChatViewTarget(options.target)
+    const composerScope = options.composerScope?.trim()
+      || (options.target ? `${viewTarget.botId}:${viewTarget.viewId}` : 'chat')
+    const commandScope = {
+      botId: viewTarget.botId,
+      sessionId: viewTarget.sessionId ?? undefined,
+      composerScope,
+    }
     if (!trimmed && !attachments?.length && requestedSkills.length === 0) return { ok: false, stage: 'startup' }
 
     if (requestedSkills.length > 0 && isWebSlashInput(trimmed)) {
       const message = commandErrorMessage('invalid_skill_slash_syntax')
-      showCommandError('invalid_skill_slash_syntax', message, currentCommandScope(composerScope))
+      showCommandError('invalid_skill_slash_syntax', message, commandScope)
       return { ok: false, stage: 'startup', error: message, restoreInput: text, restoreAttachments: attachments, restoreRequestedSkills: cloneRequestedSkills(requestedSkills) }
     }
 
     if (isWebSlashInput(trimmed) && attachments?.length) {
       const message = commandErrorMessage('slash_attachments_unsupported')
-      showCommandError('slash_attachments_unsupported', message, currentCommandScope(composerScope))
+      showCommandError('slash_attachments_unsupported', message, commandScope)
       return { ok: false, stage: 'startup', error: message, restoreInput: text, restoreAttachments: attachments, restoreRequestedSkills: cloneRequestedSkills(requestedSkills) }
     }
 
-    const newCommand = await handleWebNewCommand(trimmed, attachments)
+    const newCommand = await handleWebNewCommand(trimmed, attachments, viewTarget)
     if (newCommand.kind === 'handled') return { ok: true }
     if (newCommand.kind === 'error') {
       return { ok: false, stage: 'startup', error: newCommand.message, restoreInput: text, restoreAttachments: attachments, restoreRequestedSkills: cloneRequestedSkills(requestedSkills) }
     }
-    const slashCommand = await handleWebSlashCommand(trimmed, requestedSkills.length > 0, composerScope)
+    const slashCommand = await handleWebSlashCommand(trimmed, requestedSkills.length > 0, composerScope, viewTarget)
     if (slashCommand.kind === 'handled') return { ok: true }
     if (slashCommand.kind === 'error') {
       return { ok: false, stage: 'startup', error: slashCommand.message, restoreInput: text, restoreAttachments: attachments, restoreRequestedSkills: cloneRequestedSkills(requestedSkills) }
     }
-    clearCommandEvent(currentCommandScope(composerScope))
-    if (streaming.value || loadingMessages.value || !currentBotId.value) return { ok: false, stage: 'startup' }
+    if (viewTarget.sessionId && chatReadOnlyFor(viewTarget)) {
+      return { ok: false, stage: 'startup' }
+    }
+    clearCommandEvent(commandScope)
+    const initialView = chatView(viewTarget)
+    if (
+      isChatViewStreaming(viewTarget, composerScope)
+      || isChatViewCreatingSession(viewTarget)
+      || initialView.transcript.loadingMessages.value
+      || !viewTarget.botId
+    ) return { ok: false, stage: 'startup' }
 
     let assistantTurn: ChatAssistantTurn | null = null
     let userTurn: ChatUserTurn | null = null
@@ -1688,12 +2438,16 @@ export const useChatStore = defineStore('chat', () => {
     let sendStreamId = ''
     let turnAppendStarted = false
 
-    const wasDraft = !sessionId.value
+    const wasDraft = !viewTarget.sessionId
     const serverSlashActivation = isWebSlashInput(trimmed) && quickActionIDForSlash(trimmed) === ''
     const serverSkillActivation = requestedSkills.length > 0 || serverSlashActivation
-    if (serverSkillActivation && !sessionId.value && pendingACPSessionInput.value) {
+    if (
+      serverSkillActivation
+      && wasDraft
+      && pendingACPStateFor(viewTarget)
+    ) {
       const message = commandErrorMessage('unsupported_skill_slash_context')
-      showCommandError('unsupported_skill_slash_context', message, currentCommandScope(composerScope))
+      showCommandError('unsupported_skill_slash_context', message, commandScope)
       return { ok: false, stage: 'startup', error: message, restoreInput: text, restoreAttachments: attachments, restoreRequestedSkills: cloneRequestedSkills(requestedSkills), composerScope }
     }
 
@@ -1701,30 +2455,37 @@ export const useChatStore = defineStore('chat', () => {
     const deferSessionCreation = serverSkillActivation && wasDraft
     try {
       if (!deferSessionCreation) {
-        await ensureActiveSession(wasDraft ? trimmed : undefined)
+        viewTarget = await ensureChatViewSession(viewTarget, wasDraft ? trimmed : undefined)
       }
 
-      const bid = currentBotId.value!
-      const sid = sessionId.value ?? ''
+      const bid = viewTarget.botId
+      const sid = viewTarget.sessionId ?? ''
       if (!sid && !deferSessionCreation) throw new Error('Session not selected')
       sendBotId = bid
       sendSessionId = sid
       sendStreamId = createStreamId()
+      const sendTranscript = transcriptForTarget(viewTarget)
       // Tell the tab store to pin (and, for a draft, repoint) this session's tab.
       if (sid) {
-        userSentInSession.value = { id: sid, wasDraft, seq: ++userSendSeq }
+        userSentInSession.value = {
+          id: sid,
+          botId: bid,
+          viewId: viewTarget.viewId,
+          wasDraft,
+          seq: ++userSendSeq,
+        }
       }
 
-      assistantTurn = createOptimisticAssistantTurn()
+      assistantTurn = sendTranscript.createOptimisticAssistantTurn()
       turnAppendStarted = true
       options.onBeforeTurnAppend?.()
       if (!serverSkillActivation) {
-        userTurn = createOptimisticUserTurn(trimmed, attachments)
-        appendToView(userTurn, assistantTurn)
+        userTurn = sendTranscript.createOptimisticUserTurn(trimmed, attachments)
+        sendTranscript.appendToView(userTurn, assistantTurn)
       }
 
-      const modelId = overrideModelId.value || undefined
-      const effort = overrideReasoningEffort.value
+      const modelId = options.modelId?.trim() || overrideModelId.value || undefined
+      const effort = options.reasoningEffort?.trim() || overrideReasoningEffort.value
       const reasoningEffort = effort || undefined
 
       if (!ensureWebSocketConnected(bid)) {
@@ -1736,6 +2497,7 @@ export const useChatStore = defineStore('chat', () => {
         botId: bid,
         sessionId: sid,
         composerScope,
+        viewId: viewTarget.viewId,
       })
       if (!sendWebSocketMessage(bid, {
         type: 'message',
@@ -1751,7 +2513,9 @@ export const useChatStore = defineStore('chat', () => {
       })) throw new StreamFailureError('WebSocket is not connected', 'startup')
       await completion
       const createdSessionId = createdSessionIdForStream(sendStreamId)
-      const fallbackActiveSessionId = (currentBotId.value ?? '').trim() === bid ? sessionId.value ?? '' : ''
+      const fallbackActiveSessionId = !options.target && (currentBotId.value ?? '').trim() === bid
+        ? sessionId.value ?? ''
+        : ''
       const refreshSessionId = sendSessionId || createdSessionId || fallbackActiveSessionId
       forgetCreatedSession(sendStreamId)
       if (refreshSessionId) await refreshCurrentSession(bid, refreshSessionId)
@@ -1767,8 +2531,8 @@ export const useChatStore = defineStore('chat', () => {
         ? err.stage
         : (assistantTurn && hasVisibleAssistantBlocks(assistantTurn) ? 'stream' : 'startup')
       const createdSessionId = sendStreamId ? createdSessionIdForStream(sendStreamId) : ''
-      const bid = sendBotId || currentBotId.value || ''
-      const sid = sendSessionId || (deferSessionCreation ? '' : sessionId.value || '')
+      const bid = sendBotId || viewTarget.botId || currentBotId.value || ''
+      const sid = sendSessionId || createdSessionId
 
       if (assistantTurn) finalizeStreamFailure(assistantTurn, bid, sid, err)
       if (!isAbort && stage === 'startup' && userTurn) {
@@ -1790,7 +2554,12 @@ export const useChatStore = defineStore('chat', () => {
       if (stage === 'startup') {
         const currentBid = (currentBotId.value ?? '').trim()
         const currentSid = (sessionId.value ?? '').trim()
-        const stillCurrent = currentBid === bid && (!sid || currentSid === sid)
+        const restoredOriginalDraft = deferSessionCreation
+          && wasDraft
+          && !currentSid
+          && focusedChatViewId.value === viewTarget.viewId
+        const stillCurrent = currentBid === bid
+          && (!sid || currentSid === sid || restoredOriginalDraft)
         const deferredDraftStillCurrent = !(deferSessionCreation && wasDraft && currentSid)
         const commandErrorRestoredDraft = isCommandError && deferSessionCreation && wasDraft && !currentSid
         if (stillCurrent && deferredDraftStillCurrent && (!isCommandError || commandErrorRestoredDraft)) {
@@ -1802,19 +2571,24 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  async function retryLatestAssistant(messageId: string): Promise<SendMessageResult> {
-    const bid = currentBotId.value ?? ''
-    const sid = sessionId.value ?? ''
+  async function retryLatestAssistant(
+    messageId: string,
+    options: { target?: ChatViewTarget, modelId?: string, reasoningEffort?: string } = {},
+  ): Promise<SendMessageResult> {
+    const viewTarget = normalizedChatViewTarget(options.target)
+    const bid = viewTarget.botId
+    const sid = viewTarget.sessionId ?? ''
+    const transcript = transcriptForTarget(viewTarget)
     const targetID = messageId.trim()
-    if (!bid || !sid || !targetID) return { ok: false, stage: 'startup' }
-    if (streaming.value || loadingMessages.value) return { ok: false, stage: 'startup' }
-    const target = findTurnByServerId(targetID)
-    if (!target || !isLatestVisibleAssistantTurn(target)) return { ok: false, stage: 'startup' }
+    if (!bid || !sid || !targetID || chatReadOnlyFor(viewTarget)) return { ok: false, stage: 'startup' }
+    if (isChatViewStreaming(viewTarget) || transcript.loadingMessages.value) return { ok: false, stage: 'startup' }
+    const target = transcript.findTurnByServerId(targetID)
+    if (!target || !transcript.isLatestVisibleAssistantTurn(target)) return { ok: false, stage: 'startup' }
 
     const streamId = createStreamId()
-    const assistantTurn = createOptimisticAssistantTurn()
-    const restoreForkAnchor = updateForkAnchorForReplacedMessage(sid, target)
-    const replacedTurns = replaceTailFromTurn(target, [assistantTurn])
+    const assistantTurn = transcript.createOptimisticAssistantTurn()
+    const restoreForkAnchor = updateForkAnchorForReplacedMessage(sid, target, transcript.messages)
+    const replacedTurns = transcript.replaceTailFromTurn(target, [assistantTurn])
     loading.value = true
     try {
       if (!ensureWebSocketConnected(bid)) {
@@ -1826,8 +2600,8 @@ export const useChatStore = defineStore('chat', () => {
         stream_id: streamId,
         session_id: sid,
         message_id: targetID,
-        model_id: overrideModelId.value || undefined,
-        reasoning_effort: overrideReasoningEffort.value || undefined,
+        model_id: options.modelId?.trim() || overrideModelId.value || undefined,
+        reasoning_effort: options.reasoningEffort?.trim() || overrideReasoningEffort.value || undefined,
       })) throw new StreamFailureError('WebSocket is not connected', 'startup')
       await completion
       await refreshCurrentSession(bid, sid)
@@ -1851,22 +2625,28 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  async function editLatestUser(messageId: string, text: string): Promise<SendMessageResult> {
+  async function editLatestUser(
+    messageId: string,
+    text: string,
+    options: { target?: ChatViewTarget, modelId?: string, reasoningEffort?: string } = {},
+  ): Promise<SendMessageResult> {
     const trimmed = text.trim()
-    const bid = currentBotId.value ?? ''
-    const sid = sessionId.value ?? ''
+    const viewTarget = normalizedChatViewTarget(options.target)
+    const bid = viewTarget.botId
+    const sid = viewTarget.sessionId ?? ''
+    const transcript = transcriptForTarget(viewTarget)
     const targetID = messageId.trim()
-    if (!bid || !sid || !targetID || !trimmed) return { ok: false, stage: 'startup' }
-    if (streaming.value || loadingMessages.value) return { ok: false, stage: 'startup' }
-    const target = findTurnByServerId(targetID)
-    if (!target || !isLatestVisibleUserTurn(target)) return { ok: false, stage: 'startup' }
+    if (!bid || !sid || !targetID || !trimmed || chatReadOnlyFor(viewTarget)) return { ok: false, stage: 'startup' }
+    if (isChatViewStreaming(viewTarget) || transcript.loadingMessages.value) return { ok: false, stage: 'startup' }
+    const target = transcript.findTurnByServerId(targetID)
+    if (!target || !transcript.isLatestVisibleUserTurn(target)) return { ok: false, stage: 'startup' }
     if (hasUserAttachments(target)) return { ok: false, stage: 'startup' }
 
     const streamId = createStreamId()
-    const userTurn = createOptimisticUserTurn(trimmed)
-    const assistantTurn = createOptimisticAssistantTurn()
-    const restoreForkAnchor = updateForkAnchorForReplacedMessage(sid, target)
-    const replacedTurns = replaceTailFromTurn(target, [userTurn, assistantTurn])
+    const userTurn = transcript.createOptimisticUserTurn(trimmed)
+    const assistantTurn = transcript.createOptimisticAssistantTurn()
+    const restoreForkAnchor = updateForkAnchorForReplacedMessage(sid, target, transcript.messages)
+    const replacedTurns = transcript.replaceTailFromTurn(target, [userTurn, assistantTurn])
     loading.value = true
     try {
       if (!ensureWebSocketConnected(bid)) {
@@ -1879,8 +2659,8 @@ export const useChatStore = defineStore('chat', () => {
         session_id: sid,
         message_id: targetID,
         text: trimmed,
-        model_id: overrideModelId.value || undefined,
-        reasoning_effort: overrideReasoningEffort.value || undefined,
+        model_id: options.modelId?.trim() || overrideModelId.value || undefined,
+        reasoning_effort: options.reasoningEffort?.trim() || overrideReasoningEffort.value || undefined,
       })) throw new StreamFailureError('WebSocket is not connected', 'startup')
       await completion
       await refreshCurrentSession(bid, sid)
@@ -1904,9 +2684,15 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
-  async function respondToolApproval(approval: UIToolApproval, decision: 'approve' | 'reject') {
-    const bid = currentBotId.value ?? ''
-    const sid = sessionId.value ?? ''
+  async function respondToolApproval(
+    approval: UIToolApproval,
+    decision: 'approve' | 'reject',
+    target?: ChatViewTarget,
+  ) {
+    const viewTarget = normalizedChatViewTarget(target)
+    const bid = viewTarget.botId
+    const sid = viewTarget.sessionId ?? ''
+    const transcript = transcriptForTarget(viewTarget)
     const approvalId = approval.approval_id?.trim()
     if (!bid || !sid || !approvalId) return false
     if (approval.status !== 'pending' || approval.can_approve === false) return false
@@ -1916,22 +2702,22 @@ export const useChatStore = defineStore('chat', () => {
       return false
     }
     const streamId = createStreamId()
-    const silent = isSessionStreaming(sid)
-    const previousApprovalStates = snapshotToolApprovalStates(approvalId)
+    const silent = isSessionStreaming(bid, sid)
+    const previousApprovalStates = transcript.snapshotToolApprovalStates(approvalId)
     if (!beginApprovalResponse({
       streamId,
       approvalId,
       botId: bid,
       sessionId: sid,
       silent,
-      rollback: () => restoreToolApprovalStates(previousApprovalStates),
+      rollback: () => transcript.restoreToolApprovalStates(previousApprovalStates),
     })) return false
     let assistantTurn: ChatAssistantTurn | null = null
     let appendedAssistantTurn = false
     if (!silent) {
-      assistantTurn = assistantTurnForApproval(approvalId) ?? createOptimisticAssistantTurn()
-      appendedAssistantTurn = !hasTurn(assistantTurn)
-      if (appendedAssistantTurn) appendToView(assistantTurn)
+      assistantTurn = transcript.assistantTurnForApproval(approvalId) ?? transcript.createOptimisticAssistantTurn()
+      appendedAssistantTurn = !transcript.hasTurn(assistantTurn)
+      if (appendedAssistantTurn) transcript.appendToView(assistantTurn)
       assistantTurn.streaming = true
       void trackAssistantStream({ streamId, assistantTurn, botId: bid, sessionId: sid }).catch((error: Error) => {
         finalizeStreamFailure(assistantTurn, bid, sid, error)
@@ -1940,7 +2726,7 @@ export const useChatStore = defineStore('chat', () => {
     }
     // Optimistically update the approved/rejected tool block before the
     // server snapshot arrives so the buttons disappear immediately.
-    markToolApprovalDecision(approvalId, decision === 'approve' ? 'approved' : 'rejected')
+    transcript.markToolApprovalDecision(approvalId, decision === 'approve' ? 'approved' : 'rejected')
     try {
       if (!sendWebSocketMessage(bid, {
         type: 'tool_approval_response',
@@ -1951,11 +2737,11 @@ export const useChatStore = defineStore('chat', () => {
         decision,
       })) throw new Error('WebSocket is not connected')
     } catch (error) {
-      restoreToolApprovalStates(previousApprovalStates)
+      transcript.restoreToolApprovalStates(previousApprovalStates)
       settleApprovalResponse(streamId, 'canceled')
       if (!silent) {
         discardAssistantStream(streamId)
-        if (assistantTurn && appendedAssistantTurn) removeFromView(assistantTurn)
+        if (assistantTurn && appendedAssistantTurn) transcript.removeFromView(assistantTurn)
       }
       loading.value = false
       toast.error(resolveApiErrorMessage(error, 'Failed to send tool approval response.'))
@@ -1967,41 +2753,44 @@ export const useChatStore = defineStore('chat', () => {
   async function respondUserInput(
     userInput: UIUserInput,
     payload: { answers?: WSUserInputAnswer[]; canceled?: boolean; reason?: string },
+    target?: ChatViewTarget,
   ) {
-    const bid = currentBotId.value ?? ''
-    const sid = sessionId.value ?? ''
+    const viewTarget = normalizedChatViewTarget(target)
+    const bid = viewTarget.botId
+    const sid = viewTarget.sessionId ?? ''
+    const transcript = transcriptForTarget(viewTarget)
     if (!bid || !sid || !userInput.user_input_id) return
     if (!ensureWebSocketConnected(bid)) {
       toast.error(userInputConnectionLostMessage())
       return
     }
     const streamId = createStreamId()
-    const previousUserInputStates = snapshotUserInputStates(userInput.user_input_id)
-    const assistantTurn = assistantTurnForUserInput(userInput.user_input_id) ?? createOptimisticAssistantTurn()
-    const appendedAssistantTurn = !hasTurn(assistantTurn)
-    if (appendedAssistantTurn) appendToView(assistantTurn)
+    const previousUserInputStates = transcript.snapshotUserInputStates(userInput.user_input_id)
+    const assistantTurn = transcript.assistantTurnForUserInput(userInput.user_input_id) ?? transcript.createOptimisticAssistantTurn()
+    const appendedAssistantTurn = !transcript.hasTurn(assistantTurn)
+    if (appendedAssistantTurn) transcript.appendToView(assistantTurn)
     assistantTurn.streaming = true
     void trackAssistantStream({ streamId, assistantTurn, botId: bid, sessionId: sid }).catch((error: Error) => {
       finalizeStreamFailure(assistantTurn, bid, sid, error)
       if (error.name === 'AbortError') {
-        restoreUserInputStates(previousUserInputStates)
+        transcript.restoreUserInputStates(previousUserInputStates)
         return
       }
       // While the main session stream is still active a refresh would
       // clobber its in-flight state; roll back and let its end refresh
       // bring truth.
-      if (isSessionStreaming(sid)) {
-        restoreUserInputStates(previousUserInputStates)
+      if (isSessionStreaming(bid, sid)) {
+        transcript.restoreUserInputStates(previousUserInputStates)
         return
       }
       void refreshCurrentSession(bid, sid).catch(() => {
-        restoreUserInputStates(previousUserInputStates)
+        transcript.restoreUserInputStates(previousUserInputStates)
       })
     })
     loading.value = true
 
     const status = payload.canceled ? 'canceled' : 'submitted'
-    markUserInputDecision(userInput.user_input_id, status)
+    transcript.markUserInputDecision(userInput.user_input_id, status)
 
     try {
       if (!sendWebSocketMessage(bid, {
@@ -2015,9 +2804,9 @@ export const useChatStore = defineStore('chat', () => {
         reason: payload.reason,
       })) throw new Error('WebSocket is not connected')
     } catch (error) {
-      restoreUserInputStates(previousUserInputStates)
+      transcript.restoreUserInputStates(previousUserInputStates)
       discardAssistantStream(streamId)
-      if (appendedAssistantTurn) removeFromView(assistantTurn)
+      if (appendedAssistantTurn) transcript.removeFromView(assistantTurn)
       loading.value = false
       toast.error(resolveApiErrorMessage(error, 'Failed to send user input response.'))
     }
@@ -2025,6 +2814,17 @@ export const useChatStore = defineStore('chat', () => {
 
   return {
     messages,
+    chatView,
+    bindChatView,
+    setChatViewVisible,
+    unbindChatView,
+    focusChatView,
+    promoteDraftChatView,
+    chatTargetFor,
+    chatReadOnlyFor,
+    chatCanForkFor,
+    isChatViewStreaming,
+    isChatViewCreatingSession,
     streaming,
     streamingSessionId,
     sessions,
@@ -2040,6 +2840,7 @@ export const useChatStore = defineStore('chat', () => {
     pendingACPRuntimeId,
     pendingACPRuntimeStatus,
     pendingACPRuntimeEnsuring,
+    pendingACPStateFor,
     sessionId,
     hasExplicitSessionSelection,
     currentBotId,
@@ -2062,6 +2863,7 @@ export const useChatStore = defineStore('chat', () => {
     overrideModelId,
     overrideReasoningEffort,
     startupSendFailure,
+    startupSendFailureFor,
     commandEvent,
     commandEventForScope,
     showCommandError,
@@ -2089,6 +2891,9 @@ export const useChatStore = defineStore('chat', () => {
     createNewSession,
     selectDraft,
     userSentInSession,
+    draftViewRequested,
+    applyDraftViewRequest,
+    forkedSessionRequested,
     deletedSession,
     removeSession,
     renameSession,

--- a/apps/web/src/store/chat/acp-runtime-registry.ts
+++ b/apps/web/src/store/chat/acp-runtime-registry.ts
@@ -70,9 +70,9 @@ export function createACPRuntimeRegistry(
     setACPRuntimePending(botId, targetSessionId, false)
   }
 
-  async function ensureACPRuntime(sessionID?: string): Promise<AcpagentRuntimeStatus> {
-    const bid = currentBotId.value?.trim() ?? ''
-    const sid = sessionID?.trim() || sessionId.value?.trim() || ''
+  async function ensureACPRuntimeFor(botID: string, sessionID: string): Promise<AcpagentRuntimeStatus> {
+    const bid = botID.trim()
+    const sid = sessionID.trim()
     if (!bid || !sid) throw new Error('ACP session is not selected')
     const key = acpRuntimeKey(bid, sid)
     const existing = requests.get(key)
@@ -101,9 +101,15 @@ export function createACPRuntimeRegistry(
     return request
   }
 
-  async function setACPRuntimeModel(modelID: string, sessionID?: string): Promise<AcpagentRuntimeStatus> {
+  async function ensureACPRuntime(sessionID?: string): Promise<AcpagentRuntimeStatus> {
     const bid = currentBotId.value?.trim() ?? ''
     const sid = sessionID?.trim() || sessionId.value?.trim() || ''
+    return ensureACPRuntimeFor(bid, sid)
+  }
+
+  async function setACPRuntimeModelFor(botID: string, sessionID: string, modelID: string): Promise<AcpagentRuntimeStatus> {
+    const bid = botID.trim()
+    const sid = sessionID.trim()
     const mid = modelID.trim()
     if (!bid || !sid || !mid) throw new Error('ACP model is not selected')
     const key = acpRuntimeKey(bid, sid)
@@ -115,6 +121,12 @@ export function createACPRuntimeRegistry(
       setACPRuntimeStatus(bid, sid, runtime)
     }
     return runtime
+  }
+
+  async function setACPRuntimeModel(modelID: string, sessionID?: string): Promise<AcpagentRuntimeStatus> {
+    const bid = currentBotId.value?.trim() ?? ''
+    const sid = sessionID?.trim() || sessionId.value?.trim() || ''
+    return setACPRuntimeModelFor(bid, sid, modelID)
   }
 
   function resetACPRuntimeRegistry() {
@@ -131,7 +143,9 @@ export function createACPRuntimeRegistry(
     acpRuntimeKey,
     setACPRuntimeStatus,
     clearACPRuntimeStatus,
+    ensureACPRuntimeFor,
     ensureACPRuntime,
+    setACPRuntimeModelFor,
     setACPRuntimeModel,
     resetACPRuntimeRegistry,
   }

--- a/apps/web/src/store/chat/acp-staging.ts
+++ b/apps/web/src/store/chat/acp-staging.ts
@@ -28,6 +28,12 @@ interface PendingACPStageSnapshot {
   modelId: string
 }
 
+export interface DetachedACPSession {
+  input: ACPAgentSessionInput
+  runtimeId: string
+  botId: string
+}
+
 export function acpSessionMetadata(input: ACPAgentSessionInput): Record<string, unknown> {
   const agentId = input.agentId.trim()
   const projectMode = input.projectMode?.trim() || ACP_DEFAULT_PROJECT_MODE
@@ -356,7 +362,7 @@ export function createACPStaging(deps: ACPStagingDeps) {
 
   // Detaches the staged ACP session without closing its warm runtime, so the
   // first send can bind the runtime to the real session.
-  function detachPendingACPSession(): { input: ACPAgentSessionInput; runtimeId: string; botId: string } | null {
+  function detachPendingACPSession(): DetachedACPSession | null {
     const pending = pendingACPSessionInput.value
     if (!pending) return null
     const runtimeId = pendingACPRuntimeId.value
@@ -383,6 +389,10 @@ export function createACPStaging(deps: ACPStagingDeps) {
     pendingACPSessionInput.value = null
     pendingACPRuntimeId.value = ''
     pendingACPBotId.value = ''
+  }
+
+  function discardDetachedACPSession(detached: DetachedACPSession) {
+    closeStagedRuntime(detached.botId, detached.runtimeId)
   }
 
   function pendingACPMatchesInput(input: ACPAgentSessionInput): boolean {
@@ -415,6 +425,7 @@ export function createACPStaging(deps: ACPStagingDeps) {
     detachPendingACPSession,
     restorePendingACPSession,
     releasePendingACPSession,
+    discardDetachedACPSession,
     pendingACPMatchesInput,
   }
 }

--- a/apps/web/src/store/chat/assistant-streams.test.ts
+++ b/apps/web/src/store/chat/assistant-streams.test.ts
@@ -28,12 +28,13 @@ function track(
   registry: ReturnType<typeof createAssistantStreamRegistry>,
   streamId: string,
   targetSessionId = 'session-a',
+  botId = 'bot-1',
 ) {
   const turn = assistantTurn(`turn-${streamId}`)
   const completion = registry.trackAssistantStream({
     streamId,
     assistantTurn: turn,
-    botId: 'bot-1',
+    botId,
     sessionId: targetSessionId,
   })
   return { turn, completion }
@@ -88,19 +89,27 @@ describe('assistant stream registry', () => {
     await expect(track(registry, 'stream-1').completion).rejects.toThrow('stream_id stream-1 is already terminal')
   })
 
-  it('reactively prioritizes the selected streaming session', async () => {
-    const { registry, sessionId } = makeRegistry('session-b')
+  it('reactively prioritizes only the selected bot streaming session', async () => {
+    const { registry, currentBotId, sessionId } = makeRegistry('session-b')
     const first = track(registry, 'stream-a', 'session-a')
     const second = track(registry, 'stream-b', 'session-b')
+    const otherBot = track(registry, 'stream-other', 'session-b', 'bot-2')
 
     expect(registry.streaming.value).toBe(true)
     expect(registry.streamingSessionId.value).toBe('session-b')
     expect(registry.assistantStreamsForSession('bot-1', 'session-a').map(stream => stream.streamId)).toEqual(['stream-a'])
     expect(registry.assistantStreamsForSession('bot-2', 'session-a')).toEqual([])
+    expect(registry.isSessionStreaming('bot-1', 'session-b')).toBe(true)
+    expect(registry.isSessionStreaming('bot-2', 'session-b')).toBe(true)
 
     sessionId.value = 'session-c'
     expect(registry.streaming.value).toBe(false)
     expect(registry.streamingSessionId.value).toBe('session-a')
+
+    currentBotId.value = 'bot-2'
+    expect(registry.streaming.value).toBe(false)
+    expect(registry.streamingSessionId.value).toBe('session-b')
+    currentBotId.value = 'bot-1'
 
     registry.resolveAssistantStream('stream-a')
     await first.completion
@@ -109,18 +118,21 @@ describe('assistant stream registry', () => {
     registry.resolveAssistantStream('stream-b')
     await second.completion
     expect(registry.streamingSessionId.value).toBeNull()
+
+    registry.resolveAssistantStream('stream-other')
+    await otherBot.completion
   })
 
   it('routes missing event ids only when the session has one unambiguous stream', async () => {
     const { registry } = makeRegistry()
     const first = track(registry, 'stream-a')
 
-    expect(registry.streamIdForEvent({ session_id: 'session-a' })).toBe('stream-a')
-    expect(registry.streamIdForEvent({ stream_id: 'explicit', session_id: 'session-a' })).toBe('explicit')
+    expect(registry.streamIdForEvent('bot-1', { session_id: 'session-a' })).toBe('stream-a')
+    expect(registry.streamIdForEvent('bot-1', { stream_id: 'explicit', session_id: 'session-a' })).toBe('explicit')
 
     const second = track(registry, 'stream-b')
-    expect(registry.streamIdForEvent({ session_id: 'session-a' })).toBe('session:session-a:agent-stream')
-    expect(registry.streamIdForEvent({}, '')).toBe('legacy-stream')
+    expect(registry.streamIdForEvent('bot-1', { session_id: 'session-a' })).toBe('session:bot-1:session-a:agent-stream')
+    expect(registry.streamIdForEvent('bot-1', {}, '')).toBe('bot:bot-1:legacy-stream')
 
     registry.resolveAssistantStream('stream-a')
     registry.resolveAssistantStream('stream-b')
@@ -187,7 +199,7 @@ describe('assistant stream registry', () => {
     expect(registry.isTerminalStream('terminal-stream')).toBe(false)
   })
 
-  it('rejects session and global snapshots in insertion order', async () => {
+  it('rejects the global stream snapshot in insertion order', async () => {
     const { registry } = makeRegistry()
     const first = track(registry, 'stream-a1', 'session-a')
     const second = track(registry, 'stream-b1', 'session-b')
@@ -196,18 +208,11 @@ describe('assistant stream registry', () => {
     const failure = new Error('aborted')
     const beforeReject: string[] = []
 
-    registry.rejectSessionStreams('session-a', failure, (streamId) => {
-      expect(registry.getAssistantStream(streamId)).toBeDefined()
-      beforeReject.push(streamId)
-    })
-    expect(beforeReject).toEqual(['stream-a1', 'stream-a2'])
-    expect(registry.getAssistantStream('stream-b1')).toBeDefined()
-
     registry.rejectAllStreams(failure, (streamId) => {
       expect(registry.getAssistantStream(streamId)).toBeDefined()
       beforeReject.push(streamId)
     })
-    expect(beforeReject).toEqual(['stream-a1', 'stream-a2', 'stream-b1'])
+    expect(beforeReject).toEqual(['stream-a1', 'stream-b1', 'stream-a2'])
     expect(await Promise.all(completions)).toEqual([failure, failure, failure])
   })
 })

--- a/apps/web/src/store/chat/assistant-streams.ts
+++ b/apps/web/src/store/chat/assistant-streams.ts
@@ -7,6 +7,7 @@ export interface AssistantStream {
   readonly botId: string
   readonly sessionId: string
   readonly composerScope: string
+  readonly viewId: string
 }
 
 interface PendingAssistantStream extends AssistantStream {
@@ -26,6 +27,7 @@ export interface TrackAssistantStreamInput {
   botId: string
   sessionId: string
   composerScope?: string
+  viewId?: string
 }
 
 interface AssistantStreamRegistryDeps {
@@ -47,14 +49,6 @@ export function createAssistantStreamRegistry({ currentBotId, sessionId, finishA
     return [...streams.values()]
   }
 
-  function activeStreamIdsForSession(targetSessionId?: string | null): string[] {
-    const sid = (targetSessionId ?? '').trim()
-    if (!sid) return []
-    return activeStreams()
-      .filter(stream => stream.sessionId === sid)
-      .map(stream => stream.streamId)
-  }
-
   function activeUnboundStreamIds(botId: string | null | undefined, composerScope?: string): string[] {
     const bid = (botId ?? '').trim()
     const scope = composerScope?.trim()
@@ -66,15 +60,21 @@ export function createAssistantStreamRegistry({ currentBotId, sessionId, finishA
       .map(stream => stream.streamId)
   }
 
-  function assistantStreamsForSession(botId: string, targetSessionId: string): AssistantStream[] {
-    const bid = botId.trim()
-    const sid = targetSessionId.trim()
+  function assistantStreamsForSession(
+    botId: string | null | undefined,
+    targetSessionId: string | null | undefined,
+  ): AssistantStream[] {
+    const bid = (botId ?? '').trim()
+    const sid = (targetSessionId ?? '').trim()
     if (!bid || !sid) return []
     return activeStreams().filter(stream => stream.botId === bid && stream.sessionId === sid)
   }
 
-  function isSessionStreaming(targetSessionId?: string | null): boolean {
-    return activeStreamIdsForSession(targetSessionId).length > 0
+  function isSessionStreaming(
+    botId: string | null | undefined,
+    targetSessionId: string | null | undefined,
+  ): boolean {
+    return assistantStreamsForSession(botId, targetSessionId).length > 0
   }
 
   function isUnboundComposerStreaming(botId: string | null | undefined, composerScope?: string): boolean {
@@ -82,30 +82,36 @@ export function createAssistantStreamRegistry({ currentBotId, sessionId, finishA
   }
 
   const streamingSessionId = computed(() => {
+    const bid = (currentBotId.value ?? '').trim()
     const activeSid = (sessionId.value ?? '').trim()
-    const activeSessionIds = activeStreams().map(stream => stream.sessionId).filter(Boolean)
+    const activeSessionIds = activeStreams()
+      .filter(stream => stream.botId === bid)
+      .map(stream => stream.sessionId)
+      .filter(Boolean)
     if (activeSid && activeSessionIds.includes(activeSid)) return activeSid
     return activeSessionIds[0] ?? null
   })
 
   const streaming = computed(() => {
+    const bid = (currentBotId.value ?? '').trim()
     const activeSid = (sessionId.value ?? '').trim()
     return activeSid
-      ? isSessionStreaming(activeSid)
-      : isUnboundComposerStreaming(currentBotId.value)
+      ? isSessionStreaming(bid, activeSid)
+      : isUnboundComposerStreaming(bid)
   })
 
-  function fallbackStreamId(targetSessionId?: string | null): string {
-    const sid = (targetSessionId ?? sessionId.value ?? '').trim()
-    return sid ? `session:${sid}:agent-stream` : 'legacy-stream'
+  function fallbackStreamId(botId: string, targetSessionId?: string | null): string {
+    const bid = botId.trim() || 'unbound'
+    const sid = (targetSessionId ?? '').trim()
+    return sid ? `session:${bid}:${sid}:agent-stream` : `bot:${bid}:legacy-stream`
   }
 
-  function streamIdForEvent(event: StreamIdentity, targetSessionId?: string): string {
+  function streamIdForEvent(botId: string, event: StreamIdentity, targetSessionId?: string): string {
     const explicit = (event.stream_id ?? '').trim()
     if (explicit) return explicit
     const sid = (event.session_id ?? targetSessionId ?? '').trim()
-    const activeIds = activeStreamIdsForSession(sid)
-    return activeIds.length === 1 ? activeIds[0]! : fallbackStreamId(sid)
+    const activeIds = assistantStreamsForSession(botId, sid).map(stream => stream.streamId)
+    return activeIds.length === 1 ? activeIds[0]! : fallbackStreamId(botId, sid)
   }
 
   // Promise construction registers synchronously. Callers rely on the stream
@@ -131,6 +137,7 @@ export function createAssistantStreamRegistry({ currentBotId, sessionId, finishA
         botId: input.botId,
         sessionId: input.sessionId.trim(),
         composerScope: input.composerScope?.trim() || 'chat',
+        viewId: input.viewId?.trim() || 'chat',
         resolve,
         reject,
       })
@@ -178,13 +185,6 @@ export function createAssistantStreamRegistry({ currentBotId, sessionId, finishA
     finishAssistantStream(streamId)?.resolve()
   }
 
-  function rejectSessionStreams(targetSessionId: string | null | undefined, error: Error, beforeReject?: BeforeReject) {
-    for (const streamId of activeStreamIdsForSession(targetSessionId)) {
-      beforeReject?.(streamId)
-      rejectAssistantStream(streamId, error)
-    }
-  }
-
   function rejectAllStreams(error: Error, beforeReject?: BeforeReject) {
     for (const stream of activeStreams()) {
       beforeReject?.(stream.streamId)
@@ -221,7 +221,6 @@ export function createAssistantStreamRegistry({ currentBotId, sessionId, finishA
   return {
     streaming,
     streamingSessionId,
-    activeStreamIdsForSession,
     activeUnboundStreamIds,
     assistantStreamsForSession,
     isSessionStreaming,
@@ -233,7 +232,6 @@ export function createAssistantStreamRegistry({ currentBotId, sessionId, finishA
     rejectAssistantStream,
     discardAssistantStream,
     isTerminalStream,
-    rejectSessionStreams,
     rejectAllStreams,
     recordCreatedSession,
     createdSessionIdForStream,

--- a/apps/web/src/store/chat/realtime.test.ts
+++ b/apps/web/src/store/chat/realtime.test.ts
@@ -42,10 +42,12 @@ function createSocket(connected = true): ChatWebSocket & { send: ReturnType<type
 
 function makeController() {
   const sockets: Array<{ botId: string, handler: (event: UIStreamEvent) => void, socket: ReturnType<typeof createSocket> }> = []
-  const sessionRetry = createFakeRetryingStream()
-  const activityRetry = createFakeRetryingStream()
-  const retryingStreams = [sessionRetry, activityRetry]
-  const sessionHandlers: Array<(event: SessionMessageStreamEvent) => void> = []
+  const retryingStreams: FakeRetryingStream[] = []
+  const sessionHandlers: Array<{
+    botId: string
+    sessionId: string
+    handler: (event: SessionMessageStreamEvent) => void
+  }> = []
   const activityHandlers: Array<(event: BotSessionActivityEvent) => void> = []
   const callbacks: ChatRealtimeCallbacks = {
     onWebSocketEvent: vi.fn(),
@@ -59,23 +61,27 @@ function makeController() {
       sockets.push({ botId, handler, socket })
       return socket
     }),
-    streamSessionMessageEvents: vi.fn(async (_botId, _sessionId, _signal, handler) => {
-      sessionHandlers.push(handler)
+    streamSessionMessageEvents: vi.fn(async (botId, sessionId, _signal, handler) => {
+      sessionHandlers.push({ botId, sessionId, handler })
     }),
     streamBotSessionsActivityEvents: vi.fn(async (_botId, _signal, handler) => {
       activityHandlers.push(handler)
     }),
-    createRetryingStream: vi.fn(() => retryingStreams.shift()!),
+    createRetryingStream: vi.fn(() => {
+      const stream = createFakeRetryingStream()
+      retryingStreams.push(stream)
+      return stream
+    }),
   }
+  const controller = createChatRealtimeController(callbacks, transport)
   return {
     callbacks,
     transport,
     sockets,
     sessionHandlers,
     activityHandlers,
-    sessionRetry,
-    activityRetry,
-    controller: createChatRealtimeController(callbacks, transport),
+    retryingStreams,
+    controller,
   }
 }
 
@@ -118,25 +124,103 @@ describe('chat realtime controller', () => {
     expect(sockets[0]!.socket.abort).toHaveBeenCalledWith('stream-1')
   })
 
-  it('prepares every session attempt and suppresses events after replacement', async () => {
-    const { controller, callbacks, sessionRetry, sessionHandlers } = makeController()
+  it('starts the same session once and prepares every retry attempt', async () => {
+    const { controller, callbacks, transport, retryingStreams, sessionHandlers } = makeController()
     controller.startSessionMessagesStream('bot-1', 'session-1')
-    await sessionRetry.attempt!(new AbortController().signal)
-    expect(callbacks.prepareSessionMessages).toHaveBeenCalledWith('bot-1', 'session-1')
-    const staleHandler = sessionHandlers[0]!
+    controller.startSessionMessagesStream(' bot-1 ', ' session-1 ')
 
-    controller.startSessionMessagesStream('bot-1', 'session-2')
+    const sessionRetry = retryingStreams[1]!
+    expect(transport.createRetryingStream).toHaveBeenCalledTimes(2)
+    expect(sessionRetry.start).toHaveBeenCalledOnce()
+
     await sessionRetry.attempt!(new AbortController().signal)
+    const staleHandler = sessionHandlers[0]!.handler
+    await sessionRetry.attempt!(new AbortController().signal)
+    expect(callbacks.prepareSessionMessages).toHaveBeenCalledTimes(2)
+    expect(callbacks.prepareSessionMessages).toHaveBeenNthCalledWith(1, 'bot-1', 'session-1')
+    expect(callbacks.prepareSessionMessages).toHaveBeenNthCalledWith(2, 'bot-1', 'session-1')
+
     staleHandler({ type: 'ping' } as SessionMessageStreamEvent)
-    sessionHandlers[1]!({ type: 'ping' } as SessionMessageStreamEvent)
+    sessionHandlers[1]!.handler({ type: 'ping' } as SessionMessageStreamEvent)
 
+    expect(callbacks.onSessionMessageEvent).toHaveBeenCalledOnce()
+    expect(callbacks.onSessionMessageEvent).toHaveBeenCalledWith('bot-1', 'session-1', { type: 'ping' })
+  })
+
+  it('keeps different session streams alive concurrently', async () => {
+    const { controller, callbacks, retryingStreams, sessionHandlers } = makeController()
+    controller.startSessionMessagesStream('bot-1', 'session-1')
+    controller.startSessionMessagesStream('bot-1', 'session-2')
+
+    const firstRetry = retryingStreams[1]!
+    const secondRetry = retryingStreams[2]!
+    await firstRetry.attempt!(new AbortController().signal)
+    await secondRetry.attempt!(new AbortController().signal)
+
+    sessionHandlers.find(item => item.sessionId === 'session-1')!.handler({ type: 'ping' })
+    sessionHandlers.find(item => item.sessionId === 'session-2')!.handler({ type: 'ping' })
+
+    expect(firstRetry.stop).not.toHaveBeenCalled()
+    expect(secondRetry.stop).not.toHaveBeenCalled()
+    expect(callbacks.onSessionMessageEvent).toHaveBeenCalledTimes(2)
+    expect(callbacks.onSessionMessageEvent).toHaveBeenCalledWith('bot-1', 'session-1', { type: 'ping' })
+    expect(callbacks.onSessionMessageEvent).toHaveBeenCalledWith('bot-1', 'session-2', { type: 'ping' })
+  })
+
+  it('stops only the requested session and suppresses its late events', async () => {
+    const { controller, callbacks, retryingStreams, sessionHandlers } = makeController()
+    controller.startSessionMessagesStream('bot-1', 'session-1')
+    controller.startSessionMessagesStream('bot-1', 'session-2')
+
+    const firstRetry = retryingStreams[1]!
+    const secondRetry = retryingStreams[2]!
+    await firstRetry.attempt!(new AbortController().signal)
+    await secondRetry.attempt!(new AbortController().signal)
+    const firstHandler = sessionHandlers.find(item => item.sessionId === 'session-1')!.handler
+    const secondHandler = sessionHandlers.find(item => item.sessionId === 'session-2')!.handler
+
+    controller.stopSessionMessagesStream('bot-1', 'session-1')
+    firstHandler({ type: 'ping' })
+    secondHandler({ type: 'ping' })
+
+    expect(firstRetry.stop).toHaveBeenCalledOnce()
+    expect(secondRetry.stop).not.toHaveBeenCalled()
     expect(callbacks.onSessionMessageEvent).toHaveBeenCalledOnce()
     expect(callbacks.onSessionMessageEvent).toHaveBeenCalledWith('bot-1', 'session-2', { type: 'ping' })
   })
 
+  it('restarts a stopped session without accepting events from the old connection', async () => {
+    const { controller, callbacks, retryingStreams, sessionHandlers } = makeController()
+    controller.startSessionMessagesStream('bot-1', 'session-1')
+    await retryingStreams[1]!.attempt!(new AbortController().signal)
+    const staleHandler = sessionHandlers[0]!.handler
+
+    controller.stopSessionMessagesStream('bot-1', 'session-1')
+    controller.startSessionMessagesStream('bot-1', 'session-1')
+    await retryingStreams[2]!.attempt!(new AbortController().signal)
+
+    staleHandler({ type: 'ping' })
+    sessionHandlers[1]!.handler({ type: 'ping' })
+
+    expect(callbacks.onSessionMessageEvent).toHaveBeenCalledOnce()
+    expect(callbacks.onSessionMessageEvent).toHaveBeenCalledWith('bot-1', 'session-1', { type: 'ping' })
+  })
+
+  it('stops every session stream when no target is provided', () => {
+    const { controller, retryingStreams } = makeController()
+    controller.startSessionMessagesStream('bot-1', 'session-1')
+    controller.startSessionMessagesStream('bot-1', 'session-2')
+
+    controller.stopSessionMessagesStream()
+
+    expect(retryingStreams[1]!.stop).toHaveBeenCalledOnce()
+    expect(retryingStreams[2]!.stop).toHaveBeenCalledOnce()
+  })
+
   it('suppresses bot activity from a stopped generation', async () => {
-    const { controller, callbacks, activityRetry, activityHandlers } = makeController()
+    const { controller, callbacks, retryingStreams, activityHandlers } = makeController()
     controller.startBotSessionsActivityStream('bot-1')
+    const activityRetry = retryingStreams[0]!
     await activityRetry.attempt!(new AbortController().signal)
     const staleHandler = activityHandlers[0]!
 

--- a/apps/web/src/store/chat/realtime.ts
+++ b/apps/web/src/store/chat/realtime.ts
@@ -15,6 +15,11 @@ interface RetryingStream {
   stop: () => void
 }
 
+interface SessionMessagesConnection {
+  stream: RetryingStream
+  generation: number
+}
+
 export interface ChatRealtimeCallbacks {
   onWebSocketEvent: (botId: string, event: UIStreamEvent) => void
   prepareSessionMessages: (botId: string, sessionId: string) => Promise<void>
@@ -45,9 +50,8 @@ export function createChatRealtimeController(
   let activeWebSocket: ChatWebSocket | null = null
   let activeWebSocketBotId = ''
   let webSocketGeneration = 0
-  let sessionMessagesGeneration = 0
   let botSessionsActivityGeneration = 0
-  const sessionMessagesStream = transport.createRetryingStream()
+  const sessionMessagesConnections = new Map<string, SessionMessagesConnection>()
   const botSessionsActivityStream = transport.createRetryingStream()
 
   function stopWebSocket() {
@@ -98,27 +102,59 @@ export function createChatRealtimeController(
     return true
   }
 
-  function stopSessionMessagesStream() {
-    sessionMessagesGeneration += 1
-    sessionMessagesStream.stop()
+  function sessionMessagesKey(botId: string, sessionId: string) {
+    return `${botId}\u0000${sessionId}`
+  }
+
+  function stopSessionMessagesConnection(key: string, connection: SessionMessagesConnection) {
+    if (sessionMessagesConnections.get(key) !== connection) return
+    connection.generation += 1
+    sessionMessagesConnections.delete(key)
+    connection.stream.stop()
+  }
+
+  function stopSessionMessagesStream(botId?: string, sessionId?: string) {
+    if (botId === undefined && sessionId === undefined) {
+      for (const [key, connection] of sessionMessagesConnections) {
+        stopSessionMessagesConnection(key, connection)
+      }
+      return
+    }
+
+    const bid = (botId ?? '').trim()
+    const sid = (sessionId ?? '').trim()
+    if (!bid || !sid) return
+    const key = sessionMessagesKey(bid, sid)
+    const connection = sessionMessagesConnections.get(key)
+    if (connection) stopSessionMessagesConnection(key, connection)
   }
 
   function startSessionMessagesStream(botId: string, sessionId: string) {
-    stopSessionMessagesStream()
     const bid = botId.trim()
     const sid = sessionId.trim()
     if (!bid || !sid) return
+    const key = sessionMessagesKey(bid, sid)
+    if (sessionMessagesConnections.has(key)) return
 
-    const generation = sessionMessagesGeneration
-    sessionMessagesStream.start(async (signal) => {
+    const connection: SessionMessagesConnection = {
+      stream: transport.createRetryingStream(),
+      generation: 0,
+    }
+    sessionMessagesConnections.set(key, connection)
+    connection.stream.start(async (signal) => {
+      const generation = ++connection.generation
+      const isCurrent = () => sessionMessagesConnections.get(key) === connection
+        && connection.generation === generation
       try {
         await callbacks.prepareSessionMessages(bid, sid)
       } catch (error) {
-        console.error('Failed to load session messages:', error)
+        if (isCurrent() && !signal.aborted) {
+          console.error('Failed to load session messages:', error)
+        }
       }
-      if (generation !== sessionMessagesGeneration || signal.aborted) return
+      if (!isCurrent() || signal.aborted) return
       await transport.streamSessionMessageEvents(bid, sid, signal, (event) => {
-        if (generation !== sessionMessagesGeneration) return
+        if (!isCurrent() || signal.aborted) return
         callbacks.onSessionMessageEvent(bid, sid, event)
       })
     })

--- a/apps/web/src/store/chat/refresh-coordinator.test.ts
+++ b/apps/web/src/store/chat/refresh-coordinator.test.ts
@@ -95,46 +95,97 @@ describe('chat refresh coordinator', () => {
     expect(applySessionsSnapshot).not.toHaveBeenCalled()
   })
 
-  it('binds a debounced transcript refresh to its original bot and session', async () => {
+  it('binds the compatibility refresh to its original bot and session', async () => {
     vi.useFakeTimers()
     const { coordinator, sessionId, refreshCurrentSession } = makeCoordinator()
 
     coordinator.scheduleRefreshCurrentSession('session-1')
     sessionId.value = 'session-2'
-    await vi.runAllTimersAsync()
-    expect(refreshCurrentSession).not.toHaveBeenCalled()
-
-    sessionId.value = 'session-1'
-    coordinator.scheduleRefreshCurrentSession('session-1')
     await vi.runAllTimersAsync()
     expect(refreshCurrentSession).toHaveBeenCalledWith('bot-1', 'session-1')
   })
 
-  it('replaces an old-session debounce when the active session changes', async () => {
+  it('schedules transcript refreshes independently for different sessions', async () => {
     vi.useFakeTimers()
-    const { coordinator, sessionId, refreshCurrentSession } = makeCoordinator()
+    const { coordinator, refreshCurrentSession } = makeCoordinator()
 
-    coordinator.scheduleRefreshCurrentSession('session-1')
-    sessionId.value = 'session-2'
-    coordinator.scheduleRefreshCurrentSession('session-2')
+    coordinator.scheduleSessionRefresh('bot-1', 'session-a')
+    coordinator.scheduleSessionRefresh('bot-1', 'session-b')
     await vi.runAllTimersAsync()
 
-    expect(refreshCurrentSession).toHaveBeenCalledOnce()
-    expect(refreshCurrentSession).toHaveBeenCalledWith('bot-1', 'session-2')
+    expect(refreshCurrentSession).toHaveBeenCalledTimes(2)
+    expect(refreshCurrentSession).toHaveBeenCalledWith('bot-1', 'session-a')
+    expect(refreshCurrentSession).toHaveBeenCalledWith('bot-1', 'session-b')
   })
 
-  it('cancels scheduled refreshes and skips sessions that are still streaming', async () => {
+  it('debounces each session key without delaying other session keys', async () => {
+    vi.useFakeTimers()
+    const { coordinator, refreshCurrentSession } = makeCoordinator()
+
+    coordinator.scheduleSessionRefresh('bot-1', 'session-a')
+    coordinator.scheduleSessionRefresh('bot-1', 'session-b')
+    await vi.advanceTimersByTimeAsync(50)
+    coordinator.scheduleSessionRefresh('bot-1', 'session-a')
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(refreshCurrentSession).toHaveBeenCalledOnce()
+    expect(refreshCurrentSession).toHaveBeenCalledWith('bot-1', 'session-b')
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(refreshCurrentSession).toHaveBeenCalledTimes(2)
+    expect(refreshCurrentSession).toHaveBeenCalledWith('bot-1', 'session-a')
+  })
+
+  it('cancels all scheduled session refreshes on reset', async () => {
+    vi.useFakeTimers()
+    const { coordinator, refreshCurrentSession } = makeCoordinator()
+
+    coordinator.scheduleSessionRefresh('bot-1', 'session-a')
+    coordinator.scheduleSessionRefresh('bot-1', 'session-b')
+    coordinator.resetRefreshCoordinator()
+    await vi.runAllTimersAsync()
+
+    expect(refreshCurrentSession).not.toHaveBeenCalled()
+  })
+
+  it('skips only the target sessions that are still streaming', async () => {
     vi.useFakeTimers()
     const { coordinator, isSessionStreaming, refreshCurrentSession } = makeCoordinator()
 
-    coordinator.scheduleRefreshCurrentSession('session-1')
-    coordinator.resetRefreshCoordinator()
+    vi.mocked(isSessionStreaming).mockImplementation((botId, session) =>
+      botId === 'bot-1' && session === 'session-a',
+    )
+    coordinator.scheduleSessionRefresh('bot-1', 'session-a')
+    coordinator.scheduleSessionRefresh('bot-1', 'session-b')
     await vi.runAllTimersAsync()
-    expect(refreshCurrentSession).not.toHaveBeenCalled()
 
-    vi.mocked(isSessionStreaming).mockReturnValue(true)
-    coordinator.scheduleRefreshCurrentSession('session-1')
+    expect(refreshCurrentSession).toHaveBeenCalledOnce()
+    expect(refreshCurrentSession).toHaveBeenCalledWith('bot-1', 'session-b')
+  })
+
+  it('does not confuse the same session id across different bots', async () => {
+    vi.useFakeTimers()
+    const { coordinator, isSessionStreaming, refreshCurrentSession } = makeCoordinator()
+
+    vi.mocked(isSessionStreaming).mockImplementation((botId, session) =>
+      botId === 'bot-2' && session === 'shared-session',
+    )
+    coordinator.scheduleSessionRefresh('bot-1', 'shared-session')
     await vi.runAllTimersAsync()
+
+    expect(isSessionStreaming).toHaveBeenCalledWith('bot-1', 'shared-session')
+    expect(refreshCurrentSession).toHaveBeenCalledOnce()
+    expect(refreshCurrentSession).toHaveBeenCalledWith('bot-1', 'shared-session')
+  })
+
+  it('drops a scheduled session refresh when its bot is no longer active', async () => {
+    vi.useFakeTimers()
+    const { coordinator, currentBotId, refreshCurrentSession } = makeCoordinator()
+
+    coordinator.scheduleSessionRefresh('bot-1', 'session-a')
+    currentBotId.value = 'bot-2'
+    await vi.runAllTimersAsync()
+
     expect(refreshCurrentSession).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/store/chat/refresh-coordinator.ts
+++ b/apps/web/src/store/chat/refresh-coordinator.ts
@@ -6,7 +6,7 @@ interface ChatRefreshCoordinatorDeps {
   sessionId: Ref<string | null>
   fetchSessions: (botId: string) => Promise<FetchSessionsResult>
   applySessionsSnapshot: (response: FetchSessionsResult) => void
-  isSessionStreaming: (sessionId: string) => boolean
+  isSessionStreaming: (botId: string, sessionId: string) => boolean
   refreshCurrentSession: (botId: string, sessionId: string) => Promise<void>
 }
 
@@ -19,8 +19,7 @@ export function createChatRefreshCoordinator({
   refreshCurrentSession,
 }: ChatRefreshCoordinatorDeps) {
   const sessionListRequests = new Map<string, Promise<void>>()
-  let refreshTimer: ReturnType<typeof setTimeout> | null = null
-  let scheduledRefreshKey = ''
+  const sessionRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
   let scopeGeneration = 0
 
   function refreshSessionsList(botId: string): Promise<void> {
@@ -48,39 +47,50 @@ export function createChatRefreshCoordinator({
     return promise
   }
 
+  function scheduleSessionRefresh(botId: string, targetSessionId: string, delay = 100) {
+    const bid = botId.trim()
+    const sid = targetSessionId.trim()
+    if (!bid || !sid) return
+    const key = `${bid}:${sid}`
+    const previousTimer = sessionRefreshTimers.get(key)
+    if (previousTimer) clearTimeout(previousTimer)
+
+    const generation = scopeGeneration
+    const timer = setTimeout(() => {
+      if (sessionRefreshTimers.get(key) === timer) {
+        sessionRefreshTimers.delete(key)
+      }
+      if (generation !== scopeGeneration) return
+      if ((currentBotId.value ?? '').trim() !== bid) return
+      if (isSessionStreaming(bid, sid)) return
+      void refreshCurrentSession(bid, sid)
+    }, delay)
+    sessionRefreshTimers.set(key, timer)
+  }
+
+  // Compatibility for callers that still mean "the session focused right now".
+  // Capture that target at schedule time; later focus changes must not redirect
+  // or cancel the queued refresh.
   function scheduleRefreshCurrentSession(expectedSessionId?: string, delay = 100) {
     const bid = (currentBotId.value ?? '').trim()
     const sid = (sessionId.value ?? '').trim()
     if (!bid || !sid) return
     if (expectedSessionId?.trim() && expectedSessionId.trim() !== sid) return
-    const key = `${bid}:${sid}`
-    if (refreshTimer && scheduledRefreshKey === key) return
-    if (refreshTimer) clearTimeout(refreshTimer)
-
-    const generation = scopeGeneration
-    scheduledRefreshKey = key
-    refreshTimer = setTimeout(() => {
-      refreshTimer = null
-      scheduledRefreshKey = ''
-      if (generation !== scopeGeneration) return
-      if ((currentBotId.value ?? '').trim() !== bid || (sessionId.value ?? '').trim() !== sid) return
-      if (isSessionStreaming(sid)) return
-      void refreshCurrentSession(bid, sid)
-    }, delay)
+    scheduleSessionRefresh(bid, sid, delay)
   }
 
   function resetRefreshCoordinator() {
     scopeGeneration += 1
     sessionListRequests.clear()
-    if (refreshTimer) {
-      clearTimeout(refreshTimer)
-      refreshTimer = null
+    for (const timer of sessionRefreshTimers.values()) {
+      clearTimeout(timer)
     }
-    scheduledRefreshKey = ''
+    sessionRefreshTimers.clear()
   }
 
   return {
     refreshSessionsList,
+    scheduleSessionRefresh,
     scheduleRefreshCurrentSession,
     resetRefreshCoordinator,
   }

--- a/apps/web/src/store/chat/session-list.ts
+++ b/apps/web/src/store/chat/session-list.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type Ref } from 'vue'
+import { computed, isRef, ref, type Ref } from 'vue'
 import type { SessionSummary, UITurn } from '@/composables/api/useChat.types'
 import {
   isSessionVisibleInSidebarMode,
@@ -23,7 +23,7 @@ export interface SessionListDeps {
   currentBotId: Ref<string | null>
   sessionId: Ref<string | null>
   // The active transcript, read (never written) by fork-anchor relocation.
-  messages: ChatMessage[]
+  messages: ChatMessage[] | Ref<ChatMessage[]>
 }
 
 export type SessionLookupSource = 'listed' | 'remembered' | 'unknown'
@@ -45,6 +45,7 @@ export function createSessionList({ currentBotId, sessionId, messages }: Session
   const sessionsCursor = ref<string | null>(null)
   const hasMoreSessions = ref(false)
   const loadingMoreSessions = ref(false)
+  const activeMessages = () => isRef(messages) ? messages.value : messages
 
   const activeSession = computed(() => knownSessionSummary(sessionId.value ?? ''))
   const knownSessions = computed<SessionSummary[]>(() => {
@@ -153,11 +154,15 @@ export function createSessionList({ currentBotId, sessionId, messages }: Session
     return Boolean(target) && forkMessageCandidates(message).includes(target)
   }
 
-  function latestInheritedAssistantBefore(index: number, session?: SessionSummary | null): string {
+  function latestInheritedAssistantBefore(
+    index: number,
+    session?: SessionSummary | null,
+    transcript = activeMessages(),
+  ): string {
     const cutoff = Date.parse(session?.created_at ?? '')
     const hasCutoff = Number.isFinite(cutoff)
     for (let i = index - 1; i >= 0; i--) {
-      const message = messages[i]
+      const message = transcript[i]
       if (message?.role !== 'assistant') continue
       if (hasCutoff) {
         const timestamp = Date.parse(message.timestamp)
@@ -168,7 +173,11 @@ export function createSessionList({ currentBotId, sessionId, messages }: Session
     return ''
   }
 
-  function updateForkAnchorForReplacedMessage(targetSessionId: string, target: ChatMessage): (() => void) | null {
+  function updateForkAnchorForReplacedMessage(
+    targetSessionId: string,
+    target: ChatMessage,
+    transcript = activeMessages(),
+  ): (() => void) | null {
     const sid = targetSessionId.trim()
     if (!sid) return null
     const known = knownSessionSummary(sid)
@@ -176,13 +185,13 @@ export function createSessionList({ currentBotId, sessionId, messages }: Session
     const currentAnchor = String(fork?.fork_message_id ?? '').trim()
     if (!known || !fork || !currentAnchor) return null
 
-    const targetIndex = messages.indexOf(target)
+    const targetIndex = transcript.indexOf(target)
     if (targetIndex < 0) return null
-    const replacedTailContainsAnchor = messages
+    const replacedTailContainsAnchor = transcript
       .slice(targetIndex)
       .some(message => messageMatchesForkAnchor(message, currentAnchor))
     if (!replacedTailContainsAnchor) return null
-    const nextAnchor = latestInheritedAssistantBefore(targetIndex, known)
+    const nextAnchor = latestInheritedAssistantBefore(targetIndex, known, transcript)
     if (nextAnchor === currentAnchor) return null
 
     const metadata = known.metadata && typeof known.metadata === 'object' ? known.metadata : {}
@@ -297,6 +306,8 @@ export function createSessionList({ currentBotId, sessionId, messages }: Session
   }
 
   function rememberSession(updated: SessionSummary) {
+    const bid = (updated.bot_id ?? currentBotId.value ?? '').trim()
+    if (deletedSessionIdsByBot.get(bid)?.has(updated.id)) return
     rememberedSessions.value = {
       ...rememberedSessions.value,
       [updated.id]: updated,

--- a/apps/web/src/store/chat/types.ts
+++ b/apps/web/src/store/chat/types.ts
@@ -51,6 +51,12 @@ export interface ToolCallBlock extends UIToolMessage {
 
 export type ContentBlock = TextBlock | ThinkingBlock | ToolCallBlock | AttachmentBlock | ErrorBlock
 
+export interface ChatViewTarget {
+  botId: string
+  sessionId: string | null
+  viewId: string
+}
+
 export type ActiveChatTarget =
   | {
       kind: 'session'
@@ -148,6 +154,9 @@ export interface SendMessageResult {
 }
 
 export interface SendMessageOptions {
+  target?: ChatViewTarget
+  modelId?: string
+  reasoningEffort?: string
   requestedSkills?: RequestedSkillSelection[]
   composerScope?: string
   /** Called immediately before a real chat turn is appended or dispatched. */

--- a/apps/web/src/store/chat/view-registry.test.ts
+++ b/apps/web/src/store/chat/view-registry.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createChatViewRegistry } from './view-registry'
+import type { ChatAssistantTurn, ChatUserTurn } from './types'
+
+vi.mock('@/store/user', () => ({
+  useUserStore: () => ({ userInfo: { id: 'user-1' } }),
+}))
+
+function userTurn(id: string, text = id): ChatUserTurn {
+  return {
+    id,
+    role: 'user',
+    text,
+    attachments: [],
+    timestamp: '2026-01-01T00:00:00.000Z',
+    streaming: false,
+    isSelf: true,
+  }
+}
+
+function pendingApprovalTurn(id: string): ChatAssistantTurn {
+  return {
+    id,
+    role: 'assistant',
+    messages: [{
+      id: 1,
+      type: 'tool',
+      name: 'exec',
+      input: {},
+      tool_call_id: `call-${id}`,
+      running: false,
+      toolCallId: `call-${id}`,
+      toolName: 'exec',
+      result: null,
+      done: true,
+      approval: {
+        approval_id: `approval-${id}`,
+        status: 'pending',
+        can_approve: true,
+      },
+    }],
+    timestamp: '2026-01-01T00:00:01.000Z',
+    streaming: false,
+  }
+}
+
+function pendingUserInputTurn(id: string): ChatAssistantTurn {
+  return {
+    id,
+    role: 'assistant',
+    messages: [{
+      id: 1,
+      type: 'tool',
+      name: 'ask_user',
+      input: {},
+      tool_call_id: `call-${id}`,
+      running: false,
+      toolCallId: `call-${id}`,
+      toolName: 'ask_user',
+      result: null,
+      done: true,
+      userInput: {
+        user_input_id: `input-${id}`,
+        status: 'pending',
+        questions: [],
+        can_respond: true,
+      },
+    }],
+    timestamp: '2026-01-01T00:00:01.000Z',
+    streaming: false,
+  }
+}
+
+function makeRegistry(options: { cacheLimit?: number, streaming?: Set<string> } = {}) {
+  const onEvict = vi.fn()
+  const registry = createChatViewRegistry({
+    cacheLimit: options.cacheLimit,
+    rememberBackgroundTask: task => task,
+    applyPendingBackgroundEventsToTool: () => {},
+    bumpFsChangedAtIfFsMutation: () => {},
+    fetchMessages: vi.fn().mockResolvedValue([]),
+    locateMessage: vi.fn().mockResolvedValue({ items: [] }),
+    isSessionStreaming: (botId, sessionId) => options.streaming?.has(`${botId}:${sessionId}`) === true,
+    onEvict,
+  })
+  return { registry, onEvict }
+}
+
+describe('chat view registry', () => {
+  it('shares real sessions while isolating different sessions', () => {
+    const { registry } = makeRegistry()
+    const first = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:1' })
+    const duplicate = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:2' })
+    const second = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-b', viewId: 'chat:3' })
+
+    first.transcript.appendToView(userTurn('a'))
+    second.transcript.appendToView(userTurn('b'))
+
+    expect(duplicate).toBe(first)
+    expect(first.transcript.messages.map(message => message.id)).toEqual(['a'])
+    expect(second.transcript.messages.map(message => message.id)).toEqual(['b'])
+  })
+
+  it('keeps loading and pagination state independent between Sessions', () => {
+    const { registry } = makeRegistry()
+    const first = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:1' })
+    const second = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-b', viewId: 'chat:2' })
+
+    first.transcript.loadingMessages.value = true
+    first.transcript.loadingOlder.value = true
+    first.transcript.hasMoreOlder.value = false
+    first.transcript.hasLoadedOlder.value = true
+
+    expect(second.transcript.loadingMessages.value).toBe(false)
+    expect(second.transcript.loadingOlder.value).toBe(false)
+    expect(second.transcript.hasMoreOlder.value).toBe(true)
+    expect(second.transcript.hasLoadedOlder.value).toBe(false)
+  })
+
+  it('keeps drafts isolated and promotes only the matching panel view', () => {
+    const { registry } = makeRegistry()
+    const first = registry.getOrCreate({ botId: 'bot-1', sessionId: null, viewId: 'chat:1' })
+    const second = registry.getOrCreate({ botId: 'bot-1', sessionId: null, viewId: 'chat:2' })
+    first.transcript.appendToView(userTurn('draft-a'))
+    second.transcript.appendToView(userTurn('draft-b'))
+
+    registry.bindPanel('chat:1', { botId: 'bot-1', sessionId: null, viewId: 'chat:1' }, true)
+    registry.bindPanel('chat:2', { botId: 'bot-1', sessionId: null, viewId: 'chat:2' }, true)
+    const promoted = registry.promoteDraft('bot-1', 'chat:1', 'session-a')
+
+    expect(promoted.transcript.messages.map(message => message.id)).toEqual(['draft-a'])
+    expect(registry.getSession('bot-1', 'session-a')).toBe(promoted)
+    expect(registry.getDraft('bot-1', 'chat:1')).toBeUndefined()
+    expect(registry.getDraft('bot-1', 'chat:2')?.transcript.messages.map(message => message.id)).toEqual(['draft-b'])
+  })
+
+  it('reference-counts visible panels for a shared session', () => {
+    const { registry } = makeRegistry()
+    const target = { botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:1' }
+
+    const first = registry.bindPanel('chat:1', target, true)
+    const second = registry.bindPanel('chat:2', { ...target, viewId: 'chat:2' }, true)
+    const stillVisible = registry.setPanelVisible('chat:1', false)
+    const hidden = registry.setPanelVisible('chat:2', false)
+
+    expect(first.activatedSession?.sessionId).toBe('session-a')
+    expect(second.activatedSession).toBeNull()
+    expect(stillVisible?.deactivatedSession).toBeNull()
+    expect(hidden?.deactivatedSession?.sessionId).toBe('session-a')
+  })
+
+  it('keeps a shared Session intact when one of its panels closes', () => {
+    const { registry } = makeRegistry()
+    const target = { botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:left' }
+    const shared = registry.bindPanel('chat:left', target, true).view
+    registry.bindPanel('chat:right', { ...target, viewId: 'chat:right' }, true)
+    shared.transcript.appendToView(userTurn('shared'))
+
+    registry.unbindPanel('chat:left')
+
+    expect(registry.getPanel('chat:left')).toBeUndefined()
+    expect(registry.getPanel('chat:right')).toBe(shared)
+    expect(shared.transcript.messages.map(message => message.id)).toEqual(['shared'])
+    expect(shared.visiblePanelIds).toEqual(new Set(['chat:right']))
+  })
+
+  it('evicts an attached hidden Session and recreates it when the panel returns', () => {
+    const { registry, onEvict } = makeRegistry({ cacheLimit: 0 })
+    const target = { botId: 'bot-1', sessionId: 'session-a', viewId: 'chat:1' }
+    const attached = registry.bindPanel('chat:1', target, true).view
+    attached.transcript.appendToView(userTurn('kept'))
+
+    registry.setPanelVisible('chat:1', false)
+    registry.prune()
+
+    expect(registry.getPanel('chat:1')).toBeUndefined()
+    expect(onEvict).toHaveBeenCalledWith(attached)
+    const rebound = registry.bindPanel('chat:1', target, true).view
+    expect(rebound).not.toBe(attached)
+    expect(rebound.transcript.messages).toEqual([])
+  })
+
+  it('counts attached hidden Sessions against the shared cache limit', () => {
+    const { registry } = makeRegistry({ cacheLimit: 1 })
+    registry.bindPanel('chat:1', {
+      botId: 'bot-1',
+      sessionId: 'session-attached',
+      viewId: 'chat:1',
+    }, false)
+    const detached = registry.getOrCreate({
+      botId: 'bot-1',
+      sessionId: 'session-detached',
+      viewId: 'chat:2',
+    })
+
+    registry.prune()
+
+    expect(registry.getPanel('chat:1')).toBeUndefined()
+    expect(registry.getSession('bot-1', 'session-attached')).toBeUndefined()
+    expect(registry.getSession('bot-1', 'session-detached')).toBe(detached)
+  })
+
+  it('evicts least-recent hidden sessions but protects visible, streaming, and pending views', () => {
+    const streaming = new Set(['bot-1:streaming'])
+    const { registry, onEvict } = makeRegistry({ cacheLimit: 4, streaming })
+    registry.bindPanel('chat:visible', { botId: 'bot-1', sessionId: 'visible', viewId: 'chat:visible' }, true)
+    registry.getOrCreate({ botId: 'bot-1', sessionId: 'streaming', viewId: 'chat:streaming' })
+    const pending = registry.getOrCreate({ botId: 'bot-1', sessionId: 'pending', viewId: 'chat:pending' })
+    pending.transcript.appendToView(pendingApprovalTurn('pending'))
+    const asking = registry.getOrCreate({ botId: 'bot-1', sessionId: 'asking', viewId: 'chat:asking' })
+    asking.transcript.appendToView(pendingUserInputTurn('asking'))
+    registry.getOrCreate({ botId: 'bot-1', sessionId: 'oldest', viewId: 'chat:oldest' })
+    registry.getOrCreate({ botId: 'bot-1', sessionId: 'newest', viewId: 'chat:newest' })
+
+    registry.prune()
+
+    expect(registry.getSession('bot-1', 'visible')).toBeDefined()
+    expect(registry.getSession('bot-1', 'streaming')).toBeDefined()
+    expect(registry.getSession('bot-1', 'pending')).toBeDefined()
+    expect(registry.getSession('bot-1', 'asking')).toBeDefined()
+    expect(registry.getSession('bot-1', 'oldest')).toBeUndefined()
+    expect(onEvict).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'oldest' }))
+  })
+})

--- a/apps/web/src/store/chat/view-registry.ts
+++ b/apps/web/src/store/chat/view-registry.ts
@@ -1,0 +1,345 @@
+import { ref } from 'vue'
+import type { UITurn } from '@/composables/api/useChat.types'
+import { createTranscriptController, type TranscriptDeps } from './transcript'
+import type { ChatMessage, ChatViewTarget } from './types'
+
+export const CHAT_SESSION_VIEW_CACHE_LIMIT = 12
+
+export type { ChatViewTarget } from './types'
+
+export type ChatViewKind = 'session' | 'draft'
+export type ChatTranscriptController = ReturnType<typeof createTranscriptController>
+
+export interface ChatViewEntry {
+  key: string
+  kind: ChatViewKind
+  botId: string
+  sessionId: string | null
+  viewId: string
+  transcript: ChatTranscriptController
+  attachedPanelIds: Set<string>
+  visiblePanelIds: Set<string>
+  initialized: boolean
+  lastAccess: number
+}
+
+interface ChatViewRegistryDeps extends Omit<TranscriptDeps, 'currentBotId' | 'sessionId'> {
+  cacheLimit?: number
+  isSessionStreaming?: (botId: string, sessionId: string) => boolean
+  onSnapshot?: (view: ChatViewEntry, targetSessionId: string | undefined, turns: UITurn[]) => void
+  onRefreshApplied?: (view: ChatViewEntry, targetSessionId: string, latestTimestamp?: string) => void
+  onEvict?: (view: ChatViewEntry) => void
+}
+
+export interface ChatViewBindingChange {
+  view: ChatViewEntry
+  activatedSession: ChatViewEntry | null
+  deactivatedSession: ChatViewEntry | null
+}
+
+function normalize(value: string | null | undefined): string {
+  return value?.trim() ?? ''
+}
+
+export function chatSessionViewKey(botId: string, sessionId: string): string {
+  return `session:${normalize(botId)}:${normalize(sessionId)}`
+}
+
+export function chatDraftViewKey(botId: string, viewId: string): string {
+  return `draft:${normalize(botId)}:${normalize(viewId)}`
+}
+
+export function chatViewKey(target: ChatViewTarget): string {
+  const botId = normalize(target.botId)
+  const sessionId = normalize(target.sessionId)
+  const viewId = normalize(target.viewId)
+  return sessionId
+    ? chatSessionViewKey(botId, sessionId)
+    : chatDraftViewKey(botId, viewId)
+}
+
+function hasPendingInteraction(messages: ChatMessage[]): boolean {
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue
+    for (const block of message.messages) {
+      if (block.type !== 'tool') continue
+      if (
+        block.approval?.status === 'pending'
+        && block.approval.can_approve !== false
+      ) return true
+      if (
+        block.userInput?.status === 'pending'
+        && block.userInput.can_respond !== false
+      ) return true
+    }
+  }
+  return false
+}
+
+// Owns the in-memory working set for chat panes. Session entries are shared by
+// (bot, session); drafts are isolated by their stable dockview panel id.
+export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
+  const cacheLimit = Math.max(0, deps.cacheLimit ?? CHAT_SESSION_VIEW_CACHE_LIMIT)
+  const views = new Map<string, ChatViewEntry>()
+  const panelKeys = new Map<string, string>()
+  let accessClock = 0
+
+  function touch(view: ChatViewEntry) {
+    view.lastAccess = ++accessClock
+    return view
+  }
+
+  function createView(target: ChatViewTarget): ChatViewEntry {
+    const botId = normalize(target.botId)
+    const sessionId = normalize(target.sessionId) || null
+    const viewId = normalize(target.viewId)
+    if (!botId) throw new Error('Chat view requires a bot id')
+    if (!sessionId && !viewId) throw new Error('Draft chat view requires a stable view id')
+
+    const currentBotId = ref<string | null>(botId)
+    const currentSessionId = ref<string | null>(sessionId)
+    const transcript = createTranscriptController({
+      currentBotId,
+      sessionId: currentSessionId,
+      rememberBackgroundTask: deps.rememberBackgroundTask,
+      applyPendingBackgroundEventsToTool: deps.applyPendingBackgroundEventsToTool,
+      bumpFsChangedAtIfFsMutation: deps.bumpFsChangedAtIfFsMutation,
+      fetchMessages: deps.fetchMessages,
+      locateMessage: deps.locateMessage,
+    })
+    const view: ChatViewEntry = {
+      key: chatViewKey({ botId, sessionId, viewId }),
+      kind: sessionId ? 'session' : 'draft',
+      botId,
+      sessionId,
+      viewId,
+      transcript,
+      attachedPanelIds: new Set<string>(),
+      visiblePanelIds: new Set<string>(),
+      initialized: false,
+      lastAccess: 0,
+    }
+    transcript.setSnapshotHook((targetSessionId, turns) => {
+      deps.onSnapshot?.(view, targetSessionId, turns)
+    })
+    transcript.setRefreshAppliedHook((targetSessionId, latestTimestamp) => {
+      view.initialized = true
+      deps.onRefreshApplied?.(view, targetSessionId, latestTimestamp)
+    })
+    views.set(view.key, view)
+    return touch(view)
+  }
+
+  function get(target: ChatViewTarget): ChatViewEntry | undefined {
+    const view = views.get(chatViewKey(target))
+    return view ? touch(view) : undefined
+  }
+
+  function getOrCreate(target: ChatViewTarget): ChatViewEntry {
+    return get(target) ?? createView(target)
+  }
+
+  function getSession(botId: string, sessionId: string): ChatViewEntry | undefined {
+    const view = views.get(chatSessionViewKey(botId, sessionId))
+    return view ? touch(view) : undefined
+  }
+
+  function getDraft(botId: string, viewId: string): ChatViewEntry | undefined {
+    const view = views.get(chatDraftViewKey(botId, viewId))
+    return view ? touch(view) : undefined
+  }
+
+  function getPanel(panelId: string): ChatViewEntry | undefined {
+    const key = panelKeys.get(normalize(panelId))
+    const view = key ? views.get(key) : undefined
+    return view ? touch(view) : undefined
+  }
+
+  function mustRetain(view: ChatViewEntry): boolean {
+    // A dock tab is only an address back to this view. Keeping it attached must
+    // not turn an arbitrary number of hidden tabs into an unbounded cache.
+    if (view.visiblePanelIds.size > 0) return true
+    if (view.kind !== 'session' || !view.sessionId) return false
+    if (deps.isSessionStreaming?.(view.botId, view.sessionId)) return true
+    return hasPendingInteraction(view.transcript.messages)
+  }
+
+  function evict(view: ChatViewEntry) {
+    views.delete(view.key)
+    for (const panelId of view.attachedPanelIds) {
+      if (panelKeys.get(panelId) === view.key) panelKeys.delete(panelId)
+    }
+    view.attachedPanelIds.clear()
+    view.visiblePanelIds.clear()
+    view.transcript.resetUserScope()
+    deps.onEvict?.(view)
+  }
+
+  function prune() {
+    const hiddenSessions = [...views.values()]
+      .filter(view => view.kind === 'session'
+        && view.visiblePanelIds.size === 0)
+      .sort((left, right) => left.lastAccess - right.lastAccess)
+    let excess = hiddenSessions.length - cacheLimit
+    if (excess <= 0) return
+    for (const view of hiddenSessions) {
+      if (excess <= 0) break
+      if (mustRetain(view)) continue
+      evict(view)
+      excess -= 1
+    }
+  }
+
+  function removePanelFromView(panelId: string, view: ChatViewEntry): ChatViewEntry | null {
+    const wasLastVisibleSession = view.kind === 'session'
+      && view.visiblePanelIds.has(panelId)
+      && view.visiblePanelIds.size === 1
+    view.attachedPanelIds.delete(panelId)
+    view.visiblePanelIds.delete(panelId)
+    if (panelKeys.get(panelId) === view.key) panelKeys.delete(panelId)
+    touch(view)
+    if (view.kind === 'draft' && view.attachedPanelIds.size === 0) {
+      evict(view)
+    }
+    return wasLastVisibleSession ? view : null
+  }
+
+  function bindPanel(panelId: string, target: ChatViewTarget, visible: boolean): ChatViewBindingChange {
+    const id = normalize(panelId)
+    if (!id) throw new Error('Chat view binding requires a panel id')
+    const next = getOrCreate(target)
+    const previousKey = panelKeys.get(id)
+    let deactivatedSession: ChatViewEntry | null = null
+    if (previousKey && previousKey !== next.key) {
+      const previous = views.get(previousKey)
+      if (previous) deactivatedSession = removePanelFromView(id, previous)
+    }
+
+    const wasVisible = next.visiblePanelIds.size > 0
+    next.attachedPanelIds.add(id)
+    if (visible) next.visiblePanelIds.add(id)
+    else next.visiblePanelIds.delete(id)
+    panelKeys.set(id, next.key)
+    touch(next)
+    const activatedSession = next.kind === 'session' && visible && !wasVisible ? next : null
+    prune()
+    return { view: next, activatedSession, deactivatedSession }
+  }
+
+  function setPanelVisible(panelId: string, visible: boolean): ChatViewBindingChange | null {
+    const id = normalize(panelId)
+    const key = panelKeys.get(id)
+    const view = key ? views.get(key) : undefined
+    if (!view) return null
+    const wasVisible = view.visiblePanelIds.size > 0
+    const panelWasVisible = view.visiblePanelIds.has(id)
+    if (visible) view.visiblePanelIds.add(id)
+    else view.visiblePanelIds.delete(id)
+    touch(view)
+    const activatedSession = view.kind === 'session' && visible && !wasVisible ? view : null
+    const deactivatedSession = view.kind === 'session'
+      && !visible
+      && panelWasVisible
+      && view.visiblePanelIds.size === 0
+      ? view
+      : null
+    prune()
+    return { view, activatedSession, deactivatedSession }
+  }
+
+  function unbindPanel(panelId: string): ChatViewEntry | null {
+    const id = normalize(panelId)
+    const key = panelKeys.get(id)
+    const view = key ? views.get(key) : undefined
+    if (!view) return null
+    const deactivated = removePanelFromView(id, view)
+    prune()
+    return deactivated
+  }
+
+  function promoteDraft(botId: string, viewId: string, sessionId: string): ChatViewEntry {
+    const bid = normalize(botId)
+    const vid = normalize(viewId)
+    const sid = normalize(sessionId)
+    if (!bid || !vid || !sid) throw new Error('Draft promotion requires bot, view, and session ids')
+    const draft = getDraft(bid, vid)
+    if (!draft) return getOrCreate({ botId: bid, sessionId: sid, viewId: vid })
+
+    const sessionKey = chatSessionViewKey(bid, sid)
+    const existing = views.get(sessionKey)
+    if (existing && existing !== draft) {
+      const knownTurns = new Set(existing.transcript.messages)
+      existing.transcript.appendToView(
+        ...draft.transcript.messages.filter(turn => !knownTurns.has(turn)),
+      )
+      existing.initialized ||= draft.initialized
+      for (const panelId of draft.attachedPanelIds) {
+        existing.attachedPanelIds.add(panelId)
+        panelKeys.set(panelId, existing.key)
+      }
+      for (const panelId of draft.visiblePanelIds) existing.visiblePanelIds.add(panelId)
+      views.delete(draft.key)
+      draft.attachedPanelIds.clear()
+      draft.visiblePanelIds.clear()
+      touch(existing)
+      prune()
+      return existing
+    }
+
+    views.delete(draft.key)
+    // The transcript's target refs are intentionally private. Replacing its
+    // draft controller would lose optimistic object identity, so move the
+    // existing turns into a session-bound controller instead.
+    const replacement = createView({ botId: bid, sessionId: sid, viewId: vid })
+    replacement.transcript.appendToView(...draft.transcript.messages)
+    replacement.initialized = draft.initialized
+    for (const panelId of draft.attachedPanelIds) {
+      replacement.attachedPanelIds.add(panelId)
+      panelKeys.set(panelId, replacement.key)
+    }
+    for (const panelId of draft.visiblePanelIds) replacement.visiblePanelIds.add(panelId)
+    draft.attachedPanelIds.clear()
+    draft.visiblePanelIds.clear()
+    touch(replacement)
+    prune()
+    return replacement
+  }
+
+  function removeSession(botId: string, sessionId: string) {
+    const view = views.get(chatSessionViewKey(botId, sessionId))
+    if (view) evict(view)
+  }
+
+  function resetBot(botId: string) {
+    const bid = normalize(botId)
+    for (const view of [...views.values()]) {
+      if (view.botId === bid) evict(view)
+    }
+  }
+
+  function resetAll() {
+    for (const view of [...views.values()]) evict(view)
+    panelKeys.clear()
+  }
+
+  function entries(): ChatViewEntry[] {
+    return [...views.values()]
+  }
+
+  return {
+    get,
+    getOrCreate,
+    getSession,
+    getDraft,
+    getPanel,
+    bindPanel,
+    setPanelVisible,
+    unbindPanel,
+    promoteDraft,
+    removeSession,
+    prune,
+    resetBot,
+    resetAll,
+    entries,
+  }
+}

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -84,6 +84,34 @@ const chatStoreMock = vi.hoisted(() => ({
   createNewSession: vi.fn(async () => {}),
   deletedSession: undefined as unknown as ReturnType<typeof ref<{ id: string, botId: string, seq: number, composerScope?: string } | null>>,
   pendingACPSessionInput: undefined as unknown as ReturnType<typeof ref<Record<string, unknown> | null>>,
+  draftViewRequested: undefined as unknown as ReturnType<typeof ref<{
+    botId: string
+    viewId: string
+    expectedSessionId: string | null
+    explicitSelection: boolean
+    input: Record<string, unknown> | null
+    activate: boolean
+    seq: number
+  } | null>>,
+  applyDraftViewRequest: vi.fn(),
+  forkedSessionRequested: undefined as unknown as ReturnType<typeof ref<{
+    botId: string
+    viewId: string
+    expectedSessionId: string
+    sessionId: string
+    title: string
+    explicitSelection: true
+    activate: boolean
+    seq: number
+  } | null>>,
+  userSentInSession: undefined as unknown as ReturnType<typeof ref<{
+    id: string
+    botId: string
+    viewId: string
+    wasDraft: boolean
+    seq: number
+  } | null>>,
+  focusChatView: vi.fn(),
   selectSession: vi.fn(async (sessionId: string, options?: { explicitSelection?: boolean }) => {
     useChatSelectionStore().setSession(sessionId, options)
     chatStoreMock.sessionId = sessionId
@@ -115,9 +143,17 @@ vi.mock('@/store/chat-list', () => ({
       return chatStoreMock.loadingChats
     },
     activeSession: null,
-    userSentInSession: null,
+    get userSentInSession() {
+      return chatStoreMock.userSentInSession.value
+    },
     get pendingACPSessionInput() {
       return chatStoreMock.pendingACPSessionInput.value
+    },
+    get draftViewRequested() {
+      return chatStoreMock.draftViewRequested.value
+    },
+    get forkedSessionRequested() {
+      return chatStoreMock.forkedSessionRequested.value
     },
     get deletedSession() {
       return chatStoreMock.deletedSession.value
@@ -135,8 +171,10 @@ vi.mock('@/store/chat-list', () => ({
     isSessionStreaming: vi.fn(() => false),
     knownSessionSummary: chatStoreMock.knownSessionSummary,
     createNewSession: chatStoreMock.createNewSession,
+    focusChatView: chatStoreMock.focusChatView,
     selectSession: chatStoreMock.selectSession,
     selectDraft: chatStoreMock.selectDraft,
+    applyDraftViewRequest: chatStoreMock.applyDraftViewRequest,
   }),
 }))
 
@@ -145,6 +183,7 @@ interface FakePanel {
   component: string
   params: Record<string, unknown>
   title: string
+  renderer?: string
   group?: FakeGroup
   api: {
     setActive: () => void
@@ -171,6 +210,8 @@ interface FakeGroup {
 
 function createFakeDock() {
   const panels: FakePanel[] = []
+  const groups: FakeGroup[] = []
+  const groupActivePanels = new Map<string, FakePanel | null>()
   const removeListeners: Array<(panel: FakePanel) => void> = []
   // Mirror dockview v7's real onDidActivePanelChange payload: `{ panel, origin }`.
   // The old fake used `{ activePanel }` (the v6 shape); that masked the v6→v7
@@ -179,7 +220,9 @@ function createFakeDock() {
   const layoutListeners: Array<() => void> = []
   const closeVetoPanelIds = new Set<string>()
   let activePanel: FakePanel | null = null
+  let nextGroupNumber = 1
   const setActivePanel = (panel: FakePanel | null) => {
+    if (panel?.group) groupActivePanels.set(panel.group.id, panel)
     if (activePanel === panel) return
     activePanel = panel
     activePanelListeners.forEach(listener => listener({ panel: panel ?? undefined }))
@@ -217,37 +260,42 @@ function createFakeDock() {
       },
     }
   }
-  const groupElement = {
-    classList: {
-      toggle: vi.fn(),
-    },
-  } as unknown as HTMLElement
-  const group: FakeGroup = {
-    id: 'group-1',
-    element: groupElement,
-    api: {
-      getHeaderPosition: () => 'top' as const,
-      setHeaderPosition: vi.fn(),
-      setActivePanel: (panel: FakePanel) => setActivePanel(panel),
-      setActive: () => setActivePanel(activePanel ?? panels[0] ?? null),
-      setSize: vi.fn(),
-    },
-    get panels() {
-      return panels
-    },
-    get activePanel() {
-      return activePanel
-    },
+  const createGroup = (id = `group-${++nextGroupNumber}`): FakeGroup => {
+    const groupElement = {
+      classList: {
+        toggle: vi.fn(),
+      },
+    } as unknown as HTMLElement
+    const group: FakeGroup = {
+      id,
+      element: groupElement,
+      api: {
+        getHeaderPosition: () => 'top' as const,
+        setHeaderPosition: vi.fn(),
+        setActivePanel: (panel: FakePanel) => setActivePanel(panel),
+        setActive: () => setActivePanel(group.activePanel),
+        setSize: vi.fn(),
+      },
+      get panels() {
+        return panels.filter(panel => panel.group === group)
+      },
+      get activePanel() {
+        return groupActivePanels.get(group.id) ?? group.panels[0] ?? null
+      },
+    }
+    groups.push(group)
+    return group
   }
+  const primaryGroup = createGroup('group-1')
 
   const dock = {
     panels,
-    groups: [group],
+    groups,
     get activePanel() {
       return activePanel
     },
     get activeGroup() {
-      return activePanel?.group ?? group
+      return activePanel?.group ?? primaryGroup
     },
     onDidActivePanelChange: activePanelDisposable,
     onDidLayoutChange: layoutDisposable,
@@ -259,7 +307,7 @@ function createFakeDock() {
     onWillDragPanel: noopDisposable,
     onWillDragGroup: noopDisposable,
     getGroup(id: string) {
-      return id === 'group-1' ? group : undefined
+      return groups.find(group => group.id === id)
     },
     getPanel(id: string) {
       return panels.find((p) => p.id === id)
@@ -269,21 +317,42 @@ function createFakeDock() {
       component: string
       title?: string
       params?: Record<string, unknown>
+      renderer?: string
+      inactive?: boolean
       position?: { referenceGroup: string; direction: string }
     }) {
+      const referenceGroup = options.position
+        ? groups.find(group => group.id === options.position?.referenceGroup)
+        : undefined
+      const targetGroup = options.position?.direction === 'within'
+        ? referenceGroup ?? activePanel?.group ?? primaryGroup
+        : options.position
+          ? createGroup()
+          : activePanel?.group ?? primaryGroup
       const panel: FakePanel = {
         id: options.id,
         component: options.component,
         params: { ...(options.params ?? {}) },
         title: options.title ?? '',
+        renderer: options.renderer,
         api: {
           setActive: () => setActivePanel(panel),
           close: () => {
             if (closeVetoPanelIds.has(panel.id)) return
+            const ownerGroup = panel.group
             const idx = panels.indexOf(panel)
             if (idx >= 0) panels.splice(idx, 1)
+            const replacement = ownerGroup?.panels[0] ?? null
+            if (ownerGroup && groupActivePanels.get(ownerGroup.id) === panel) {
+              groupActivePanels.set(ownerGroup.id, replacement)
+            }
+            if (ownerGroup && ownerGroup !== primaryGroup && ownerGroup.panels.length === 0) {
+              const groupIndex = groups.indexOf(ownerGroup)
+              if (groupIndex >= 0) groups.splice(groupIndex, 1)
+              groupActivePanels.delete(ownerGroup.id)
+            }
             removeListeners.forEach(listener => listener(panel))
-            if (activePanel === panel) setActivePanel(panels[0] ?? null)
+            if (activePanel === panel) setActivePanel(replacement ?? panels[0] ?? null)
             emitLayoutChange()
           },
           setTitle: (title: string) => {
@@ -297,14 +366,16 @@ function createFakeDock() {
           },
         },
       }
-      panel.group = group
+      panel.group = targetGroup
       panels.push(panel)
-      setActivePanel(panel)
+      if (!options.inactive) setActivePanel(panel)
       emitLayoutChange()
       return panel
     },
     clear() {
       panels.splice(0, panels.length)
+      groups.splice(1, groups.length - 1)
+      groupActivePanels.clear()
       setActivePanel(null)
       emitLayoutChange()
     },
@@ -332,15 +403,62 @@ function createFakeDock() {
       }
     },
     fromJSON(data?: {
+      grid?: {
+        root?: {
+          type: 'leaf' | 'branch'
+          data: unknown
+        }
+      }
       panels?: Record<string, {
         id?: string
         contentComponent?: string
         title?: string
         params?: Record<string, unknown>
       }>
+      activeGroup?: string
     }) {
       dock.clear()
+      type SerializedNode = {
+        type: 'leaf' | 'branch'
+        data: SerializedNode[] | { id?: string; views?: string[]; activeView?: string }
+      }
+      const leaves: Array<{ id?: string; views?: string[]; activeView?: string }> = []
+      const visit = (node?: SerializedNode) => {
+        if (!node) return
+        if (node.type === 'branch') {
+          for (const child of node.data as SerializedNode[]) visit(child)
+          return
+        }
+        leaves.push(node.data as { id?: string; views?: string[]; activeView?: string })
+      }
+      visit(data?.grid?.root as SerializedNode | undefined)
+
+      if (leaves.length === 0) {
+        leaves.push({ id: primaryGroup.id, views: Object.keys(data?.panels ?? {}) })
+      }
+      const serializedGroups = new Map<string, FakeGroup>()
+      leaves.forEach((leaf, index) => {
+        const group = index === 0 ? primaryGroup : createGroup()
+        if (leaf.id) serializedGroups.set(leaf.id, group)
+        for (const id of leaf.views ?? []) {
+          const panel = data?.panels?.[id]
+          if (!panel) continue
+          dock.addPanel({
+            id: panel.id ?? id,
+            component: panel.contentComponent ?? 'unknown',
+            title: panel.title,
+            params: panel.params,
+            inactive: true,
+            position: { referenceGroup: group.id, direction: 'within' },
+          })
+        }
+        const active = group.panels.find(panel => panel.id === leaf.activeView) ?? group.panels[0] ?? null
+        groupActivePanels.set(group.id, active)
+      })
+      const activeGroup = data?.activeGroup ? serializedGroups.get(data.activeGroup) : primaryGroup
+      setActivePanel(activeGroup?.activePanel ?? panels[0] ?? null)
       for (const [id, panel] of Object.entries(data?.panels ?? {})) {
+        if (dock.getPanel(id)) continue
         dock.addPanel({
           id: panel.id ?? id,
           component: panel.contentComponent ?? 'unknown',
@@ -385,13 +503,18 @@ describe('workspace layout store', () => {
     localStorage.clear()
     window.localStorage.clear()
     chatStoreMock.createNewSession.mockClear()
+    chatStoreMock.focusChatView.mockClear()
     chatStoreMock.selectSession.mockClear()
     chatStoreMock.selectDraft.mockClear()
+    chatStoreMock.applyDraftViewRequest.mockClear()
     chatStoreMock.sessionId = null
     chatStoreMock.hasExplicitSessionSelection = false
     chatStoreMock.loadingChats = false
     chatStoreMock.deletedSession = ref(null)
     chatStoreMock.pendingACPSessionInput = ref(null)
+    chatStoreMock.draftViewRequested = ref(null)
+    chatStoreMock.forkedSessionRequested = ref(null)
+    chatStoreMock.userSentInSession = ref(null)
     chatStoreMock.sessions = reactive([]) as typeof chatStoreMock.sessions
     chatStoreMock.knownSessions = reactive([]) as typeof chatStoreMock.knownSessions
     chatStoreMock.knownSessionSummary.mockImplementation((sessionId: string) =>
@@ -416,6 +539,22 @@ describe('workspace layout store', () => {
   function emitDeletedSession(id: string, botId = 'bot-1', composerScope?: string) {
     const prevSeq = chatStoreMock.deletedSession.value?.seq ?? 0
     chatStoreMock.deletedSession.value = { id, botId, seq: prevSeq + 1, composerScope }
+  }
+
+  function emitUserSentInSession(
+    id: string,
+    viewId: string,
+    wasDraft: boolean,
+    botId = 'bot-1',
+  ) {
+    const prevSeq = chatStoreMock.userSentInSession.value?.seq ?? 0
+    chatStoreMock.userSentInSession.value = {
+      id,
+      botId,
+      viewId,
+      wasDraft,
+      seq: prevSeq + 1,
+    }
   }
 
   it('opens browser panels and updates their address', () => {
@@ -504,6 +643,41 @@ describe('workspace layout store', () => {
 
     expect(dock.panels.filter((p) => p.component === 'chat')).toHaveLength(1)
     expect(dock.activePanel?.component).toBe('chat')
+  })
+
+  it('keeps drafts group-scoped and promotes only the view that sent', async () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+
+    store.openDraftChat({ title: 'Left draft', groupId: 'group-1' })
+    const leftDraft = dock.activePanel!
+    store.splitGroup('group-1', 'right')
+    const rightDraft = dock.activePanel!
+
+    expect(rightDraft.id).not.toBe(leftDraft.id)
+    expect(rightDraft.group?.id).not.toBe(leftDraft.group?.id)
+    expect(dock.panels.filter(panel => panel.component === 'chat')).toHaveLength(2)
+
+    // An explicit group focuses that group's own draft, even while another
+    // draft exists elsewhere in the dock.
+    store.openDraftChat({ groupId: leftDraft.group!.id })
+    expect(dock.activePanel?.id).toBe(leftDraft.id)
+
+    emitUserSentInSession('ignored-session', rightDraft.id, true, 'other-bot')
+    await nextTick()
+    expect(leftDraft.params.sessionId ?? null).toBeNull()
+    expect(rightDraft.params.sessionId ?? null).toBeNull()
+
+    // The signal points at the inactive right view. Promotion must not guess the
+    // active (left) draft.
+    emitUserSentInSession('right-session', rightDraft.id, true)
+    await nextTick()
+
+    expect(leftDraft.params.sessionId ?? null).toBeNull()
+    expect(rightDraft.params.sessionId).toBe('right-session')
+    expect(store.ephemeralPanels[leftDraft.id]).toBe(true)
+    expect(store.ephemeralPanels[rightDraft.id]).toBeUndefined()
   })
 
   it('marks sidebar-created draft chats as non-explicit so default ACP can stage', () => {
@@ -1027,15 +1201,311 @@ describe('workspace layout store', () => {
     expect(chat.title).toBe('New Session')
   })
 
-  it('does not split chat panels (single global session)', () => {
+  it('splits a chat session into a second group and reuses the split preview in place', () => {
     const store = useWorkspaceTabsStore()
     const dock = createFakeDock()
     store.registerApi(dock as never)
 
-    store.openSessionChat({ sessionId: 's1', title: 'Session' })
+    store.openSessionChat({
+      sessionId: 's1',
+      title: 'Session',
+      explicitSelection: false,
+    })
+    const source = dock.panels.find(panel => panel.component === 'chat')!
     store.splitGroup('group-1', 'right')
 
-    expect(dock.panels.filter((p) => p.component === 'chat')).toHaveLength(1)
+    const split = dock.panels.find(panel => panel.component === 'chat' && panel.id !== source.id)!
+    expect(dock.panels.filter(panel => panel.component === 'chat')).toHaveLength(2)
+    expect(split.params).toMatchObject({ sessionId: 's1', explicitSelection: false })
+    expect(split.title).toBe('Session')
+    expect(split.renderer).toBe('always')
+    expect(split.group?.id).not.toBe(source.group?.id)
+    expect(store.ephemeralPanels[split.id]).toBe(true)
+    expect(chatStoreMock.focusChatView).toHaveBeenLastCalledWith(split.id)
+
+    store.openSessionChat({
+      sessionId: 's2',
+      title: 'Other session',
+      groupId: split.group!.id,
+    })
+
+    expect(dock.panels.filter(panel => panel.component === 'chat')).toHaveLength(2)
+    expect(dock.getPanel(source.id)?.params.sessionId).toBe('s1')
+    expect(dock.getPanel(split.id)?.params.sessionId).toBe('s2')
+    expect(dock.getPanel(split.id)?.title).toBe('Other session')
+  })
+
+  it('applies a late Draft request only to its originating split', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openSessionChat({ sessionId: 'session-a', title: 'A' })
+    const origin = dock.activePanel!
+    store.splitGroup(origin.group!.id, 'right')
+    const other = dock.activePanel!
+    store.openSessionChat({ sessionId: 'session-b', title: 'B', groupId: other.group!.id })
+    expect(dock.activePanel?.id).toBe(other.id)
+
+    const request = {
+      botId: 'bot-1',
+      viewId: origin.id,
+      expectedSessionId: 'session-a',
+      explicitSelection: true,
+      input: { agentId: 'codex' },
+      activate: true,
+      seq: 1,
+    }
+    chatStoreMock.draftViewRequested.value = request
+
+    expect(dock.getPanel(origin.id)?.params).toMatchObject({ sessionId: null, explicitSelection: true })
+    expect(dock.getPanel(origin.id)?.title).toBe('New Session')
+    expect(dock.getPanel(other.id)?.params.sessionId).toBe('session-b')
+    expect(dock.activePanel?.id).toBe(other.id)
+    expect(chatStoreMock.applyDraftViewRequest).toHaveBeenCalledWith(request, false)
+  })
+
+  it('keeps a pinned Session and opens its requested Draft as a new preview', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openSessionChatPinned({ sessionId: 'session-a', title: 'A' })
+    const origin = dock.activePanel!
+
+    const request = {
+      botId: 'bot-1',
+      viewId: origin.id,
+      expectedSessionId: 'session-a',
+      explicitSelection: true,
+      input: { agentId: 'codex' },
+      activate: true,
+      seq: 1,
+    }
+    chatStoreMock.draftViewRequested.value = request
+
+    const draft = dock.panels.find(panel => panel.component === 'chat' && panel.params.sessionId == null)!
+    expect(dock.panels.filter(panel => panel.component === 'chat')).toHaveLength(2)
+    expect(origin.params.sessionId).toBe('session-a')
+    expect(store.ephemeralPanels[origin.id]).toBeUndefined()
+    expect(draft.group?.id).toBe(origin.group?.id)
+    expect(store.ephemeralPanels[draft.id]).toBe(true)
+    expect(dock.activePanel?.id).toBe(draft.id)
+    expect(chatStoreMock.applyDraftViewRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ ...request, viewId: draft.id }),
+      true,
+    )
+  })
+
+  it('does not focus a pinned Session Draft when its request resolves behind another split', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openSessionChatPinned({ sessionId: 'session-a', title: 'A' })
+    const origin = dock.activePanel!
+    store.splitGroup(origin.group!.id, 'right')
+    const other = dock.activePanel!
+    store.openSessionChat({ sessionId: 'session-b', title: 'B', groupId: other.group!.id })
+
+    chatStoreMock.draftViewRequested.value = {
+      botId: 'bot-1',
+      viewId: origin.id,
+      expectedSessionId: 'session-a',
+      explicitSelection: true,
+      input: null,
+      activate: true,
+      seq: 1,
+    }
+
+    const draft = origin.group!.panels.find(panel => panel.params.sessionId == null)!
+    expect(origin.params.sessionId).toBe('session-a')
+    expect(draft).toBeTruthy()
+    expect(store.ephemeralPanels[draft.id]).toBe(true)
+    expect(dock.activePanel?.id).toBe(other.id)
+    expect(chatStoreMock.applyDraftViewRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ viewId: draft.id, expectedSessionId: 'session-a' }),
+      false,
+    )
+  })
+
+  it('routes a late Fork to its originating preview without changing the focused split', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openSessionChat({ sessionId: 'session-a', title: 'A' })
+    const origin = dock.activePanel!
+    store.splitGroup(origin.group!.id, 'right')
+    const other = dock.activePanel!
+    store.openSessionChat({ sessionId: 'session-b', title: 'B', groupId: other.group!.id })
+
+    chatStoreMock.forkedSessionRequested.value = {
+      botId: 'bot-1',
+      viewId: origin.id,
+      expectedSessionId: 'session-a',
+      sessionId: 'fork-a',
+      title: 'Fork A',
+      explicitSelection: true,
+      activate: true,
+      seq: 1,
+    }
+
+    expect(origin.params.sessionId).toBe('fork-a')
+    expect(origin.title).toBe('Fork A')
+    expect(other.params.sessionId).toBe('session-b')
+    expect(dock.activePanel?.id).toBe(other.id)
+  })
+
+  it('keeps a pinned Fork source and opens the Fork in the same group', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openSessionChatPinned({ sessionId: 'session-a', title: 'A' })
+    const origin = dock.activePanel!
+
+    chatStoreMock.forkedSessionRequested.value = {
+      botId: 'bot-1',
+      viewId: origin.id,
+      expectedSessionId: 'session-a',
+      sessionId: 'fork-a',
+      title: 'Fork A',
+      explicitSelection: true,
+      activate: true,
+      seq: 1,
+    }
+
+    const fork = dock.panels.find(panel => panel.params.sessionId === 'fork-a')!
+    expect(origin.params.sessionId).toBe('session-a')
+    expect(fork.group?.id).toBe(origin.group?.id)
+    expect(store.ephemeralPanels[fork.id]).toBe(true)
+    expect(dock.activePanel?.id).toBe(fork.id)
+  })
+
+  it('ignores a Fork result after its origin has been rebound', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openSessionChat({ sessionId: 'session-a', title: 'A' })
+    const origin = dock.activePanel!
+    store.openSessionChat({ sessionId: 'session-c', title: 'C', groupId: origin.group!.id })
+
+    chatStoreMock.forkedSessionRequested.value = {
+      botId: 'bot-1',
+      viewId: origin.id,
+      expectedSessionId: 'session-a',
+      sessionId: 'fork-a',
+      title: 'Fork A',
+      explicitSelection: true,
+      activate: true,
+      seq: 1,
+    }
+
+    expect(origin.params.sessionId).toBe('session-c')
+    expect(dock.panels.some(panel => panel.params.sessionId === 'fork-a')).toBe(false)
+  })
+
+  it('routes a Fork only to the same-Session split where it was requested', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openSessionChat({ sessionId: 'session-a', title: 'A' })
+    const left = dock.activePanel!
+    store.splitGroup(left.group!.id, 'right')
+    const right = dock.activePanel!
+
+    chatStoreMock.forkedSessionRequested.value = {
+      botId: 'bot-1',
+      viewId: right.id,
+      expectedSessionId: 'session-a',
+      sessionId: 'fork-right',
+      title: 'Fork right',
+      explicitSelection: true,
+      activate: true,
+      seq: 1,
+    }
+
+    expect(left.params.sessionId).toBe('session-a')
+    expect(right.params.sessionId).toBe('fork-right')
+    expect(dock.activePanel?.id).toBe(right.id)
+  })
+
+  it('opens a related Session in the originating split instead of the focused split', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openSessionChat({ sessionId: 'session-a', title: 'A' })
+    const origin = dock.activePanel!
+    store.splitGroup(origin.group!.id, 'right')
+    const other = dock.activePanel!
+    store.openSessionChat({ sessionId: 'session-b', title: 'B', groupId: other.group!.id })
+
+    store.openSessionChatFromView({
+      viewId: origin.id,
+      sessionId: 'child-a',
+      title: 'Child A',
+      expectedSessionId: 'session-a',
+    })
+
+    expect(dock.getPanel(origin.id)?.params.sessionId).toBe('child-a')
+    expect(dock.getPanel(origin.id)?.title).toBe('Child A')
+    expect(dock.getPanel(other.id)?.params.sessionId).toBe('session-b')
+    expect(dock.activePanel?.id).toBe(origin.id)
+  })
+
+  it('restores two Chat panels without crossing their Session params', async () => {
+    localStorage.setItem('workspace-layout', JSON.stringify({
+      'bot-1': {
+        layout: {
+          grid: {
+            root: {
+              type: 'branch',
+              data: [
+                {
+                  type: 'leaf',
+                  size: 600,
+                  data: { id: 'left', views: ['chat:1'], activeView: 'chat:1' },
+                },
+                {
+                  type: 'leaf',
+                  size: 600,
+                  data: { id: 'right', views: ['chat:2'], activeView: 'chat:2' },
+                },
+              ],
+            },
+            width: 1200,
+            height: 800,
+            orientation: 'HORIZONTAL',
+          },
+          panels: {
+            'chat:1': {
+              id: 'chat:1',
+              contentComponent: 'chat',
+              title: 'A',
+              params: { sessionId: 'session-a', explicitSelection: true },
+            },
+            'chat:2': {
+              id: 'chat:2',
+              contentComponent: 'chat',
+              title: 'B',
+              params: { sessionId: 'session-b', explicitSelection: true },
+            },
+          },
+          activeGroup: 'left',
+        },
+        chatCounter: 2,
+        ephemeralIds: [],
+      },
+    }))
+    chatStoreMock.sessionId = 'session-a'
+    chatStoreMock.hasExplicitSessionSelection = true
+    useChatSelectionStore().setSession('session-a')
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+
+    store.registerApi(dock as never)
+    await nextTick()
+
+    expect(dock.getPanel('chat:1')?.params.sessionId).toBe('session-a')
+    expect(dock.getPanel('chat:2')?.params.sessionId).toBe('session-b')
+    expect(dock.getPanel('chat:1')?.group?.id).not.toBe(dock.getPanel('chat:2')?.group?.id)
+    expect(chatStoreMock.focusChatView).toHaveBeenLastCalledWith('chat:1')
   })
 
   it('opens multiple schedule panels and focuses an existing schedule', () => {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -21,9 +21,9 @@ import i18n from '@/i18n'
 //   display panels, splits, tab order) persisted per bot
 // - the left activity-bar + side-panel state (active view, collapsed, width)
 //
-// The active chat session itself lives in the chat-selection store. The chat
-// panel is a singleton dockview panel whose content follows the active
-// session; files/terminals/browsers are multi-instance panels. Desktop is a
+// The active chat session itself lives in the chat-selection store. Chat
+// panels are multi-instance dockview views keyed by panel id; the global
+// selection still follows whichever chat view is active. Desktop is a
 // singleton WebRTC viewer per bot (DISPLAY_PANEL_ID).
 
 export type SidebarView = 'sessions' | 'files' | 'schedule'
@@ -620,7 +620,10 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       id,
       component: 'chat',
       title: chatTitleFallbackFor(sid),
-      params: { sessionId: sid },
+      params: {
+        sessionId: sid,
+        explicitSelection: chatStore.hasExplicitSessionSelection === true,
+      },
     })) {
       markEphemeral(id)
     }
@@ -746,12 +749,13 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     title: string
     params?: Record<string, unknown>
     groupId?: string
+    inactive?: boolean
   }): boolean {
     const dock = api.value
     if (!dock) return false
     const existing = dock.getPanel(opts.id)
     if (existing) {
-      focusPanel(existing)
+      if (!opts.inactive) focusPanel(existing)
       return true
     }
     const target = nonTerminalTarget(dock, opts.groupId)
@@ -769,6 +773,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       title: opts.title,
       params: opts.params,
       renderer: 'always',
+      inactive: opts.inactive,
       ...(target ? { position: target } : {}),
     })
     markEphemeral(opts.id)
@@ -886,7 +891,14 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
    * is focused; otherwise the open reuses the target group's ephemeral slot (so
    * browsing sessions in the sidebar swaps one preview tab, VS Code-style). The
    * tab starts ephemeral and pins when the user sends a message in it. */
-  function openSessionChat(opts: { sessionId: string, title?: string, groupId?: string, explicitSelection?: boolean }) {
+  function openSessionChat(opts: {
+    sessionId: string
+    title?: string
+    groupId?: string
+    explicitSelection?: boolean
+    groupLocal?: boolean
+    activate?: boolean
+  }) {
     const dock = api.value
     if (!dock) return
     const sid = opts.sessionId.trim()
@@ -896,9 +908,16 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     if (isDeletedSessionForCurrentBot(sid)) return
     const title = opts.title?.trim() || chatTitleFallbackFor(sid)
     const explicitSelection = opts.explicitSelection !== false
-    const existing = chatPanelForSession(sid)
+    const activate = opts.activate !== false
+    const existing = opts.groupLocal && opts.groupId
+      ? dock.getGroup(opts.groupId)?.panels.find(
+          panel => panelComponentOf(panel.id) === 'chat' && panelSessionId(panel) === sid,
+        )
+      : chatPanelForSession(sid)
     if (existing) {
       existing.api.setTitle(title)
+      existing.api.updateParameters({ explicitSelection })
+      if (!activate) return
       if (dock.activePanel?.id === existing.id) {
         selectChatSession(sid, explicitSelection)
         return
@@ -922,8 +941,9 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
         )
       : undefined
     if (reusable) {
-      reusable.api.updateParameters({ sessionId: sid })
+      reusable.api.updateParameters({ sessionId: sid, explicitSelection })
       reusable.api.setTitle(title)
+      if (!activate) return
       setNextChatActivationExplicit(reusable.id, explicitSelection)
       focusPanel(reusable)
       // Repointing an already-active panel doesn't refire activation, so select
@@ -937,8 +957,31 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       id,
       component: 'chat',
       title,
-      params: { sessionId: sid },
+      params: { sessionId: sid, explicitSelection },
       groupId: opts.groupId,
+      inactive: !activate,
+    })
+  }
+
+  function openSessionChatFromView(opts: {
+    viewId: string
+    sessionId: string
+    title?: string
+    expectedSessionId?: string | null
+    explicitSelection?: boolean
+    activate?: boolean
+  }) {
+    const dock = api.value
+    const origin = dock?.getPanel(opts.viewId)
+    if (!dock || !origin || panelComponentOf(origin.id) !== 'chat') return
+    if ('expectedSessionId' in opts && panelSessionId(origin) !== opts.expectedSessionId) return
+    openSessionChat({
+      sessionId: opts.sessionId,
+      title: opts.title,
+      groupId: origin.group.id,
+      explicitSelection: opts.explicitSelection,
+      groupLocal: true,
+      activate: opts.activate,
     })
   }
 
@@ -946,11 +989,8 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
    * in New Tab": a single click (openSessionChat) reuses the group's ephemeral
    * chat slot so browsing the sidebar swaps one preview tab, but an explicit
    * right-click means "give me a separate tab" — so it lands as a pinned chat
-   * tab the preview slot can never evict. Stays in ONE group (chat split is
-   * disabled — a single global messages array means two visible chat panels
-   * would both render the active session), and tabs are mutually exclusive, so
-   * a pinned chat tab is safe: activating it renders its session. An already-open
-   * tab for the session is promoted to pinned + focused. */
+   * tab the preview slot can never evict. An already-open tab for the session is
+   * promoted to pinned + focused. */
   function openSessionChatPinned(opts: { sessionId: string, title?: string, groupId?: string }) {
     const dock = api.value
     if (!dock) return
@@ -974,19 +1014,23 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       id: nextChatPanelId(bid),
       component: 'chat',
       title,
-      params: { sessionId: sid },
+      params: { sessionId: sid, explicitSelection: true },
       renderer: 'always',
       ...(target ? { position: target } : {}),
     })
   }
 
-  /** Open or focus the single draft chat tab (no session yet). */
+  /** Open or focus a draft chat tab (no session yet). An explicit group owns its
+   * own draft; callers without a group retain the legacy global-first behavior. */
   function openDraftChat(opts?: { title?: string, groupId?: string, explicitSelection?: boolean }) {
     const dock = api.value
     if (!dock) return
     const bid = (currentBotId.value ?? '').trim()
     if (!bid) return
-    const existingDraft = dock.panels.find(
+    const draftCandidates = opts?.groupId
+      ? dock.getGroup(opts.groupId)?.panels ?? []
+      : dock.panels
+    const existingDraft = draftCandidates.find(
       p => panelComponentOf(p.id) === 'chat' && panelSessionId(p) === null,
     )
     if (existingDraft) {
@@ -1009,8 +1053,8 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     })
   }
 
-  // Activating a chat tab makes its session the live one (single global messages
-  // array). Gated to chat panels by the caller.
+  // Activating a chat tab focuses its panel-scoped state and mirrors its session
+  // into the global selection. Gated to chat panels by the caller.
   function activateChatSession(
     panel: { id: string, params?: Record<string, unknown> },
     options?: { explicitSelection?: boolean },
@@ -1019,10 +1063,19 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     // That is not a user click, and must not promote a stale restored chat tab into
     // an explicit chat-selection entry before chat initialization/default ACP wins.
     if (suppressPersist) return
+    // Switch the panel-scoped chat state before the global selection changes. ACP
+    // draft staging uses this transition to persist the old view before loading
+    // the newly focused panel.
+    chatStore.focusChatView(panel.id)
     const explicitOverride = consumeNextChatActivationExplicit(panel.id)
     const sid = panelSessionId(panel)
     if (sid) {
-      const explicitSelection = options?.explicitSelection ?? explicitOverride !== false
+      const panelExplicitSelection = typeof panel.params?.explicitSelection === 'boolean'
+        ? panel.params.explicitSelection
+        : true
+      const explicitSelection = options?.explicitSelection
+        ?? explicitOverride
+        ?? panelExplicitSelection
       selectChatSession(sid, explicitSelection)
     }
     else {
@@ -1052,12 +1105,16 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       // selection. Once loading settles, the loading watcher calls this again.
       if (!explicitSelection && chatStore.loadingChats) return
       if (isDeletedSessionForCurrentBot(sid)) return
-      if (activeIsChat && activeSession === sid) return
+      if (activeIsChat && activeSession === sid) {
+        chatStore.focusChatView(active.id)
+        return
+      }
       openSessionChat({ sessionId: sid, groupId, explicitSelection })
       return
     }
     if (!activeIsChat) return
     if (activeSession === null) {
+      chatStore.focusChatView(active.id)
       if (active.params?.explicitSelection !== explicitSelection) {
         active.api.updateParameters({ explicitSelection })
       }
@@ -1079,11 +1136,10 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     const dock = api.value
     if (!dock) return
     const explicitSelection = !chatStore.sessionId && chatStore.hasExplicitSessionSelection === true
-    for (const panel of dock.panels) {
-      if (panelComponentOf(panel.id) !== 'chat' || panelSessionId(panel) !== null) continue
-      if (panel.params?.explicitSelection === explicitSelection) continue
-      panel.api.updateParameters({ explicitSelection })
-    }
+    const panel = dock.activePanel
+    if (!panel || panelComponentOf(panel.id) !== 'chat' || panelSessionId(panel) !== null) return
+    if (panel.params?.explicitSelection === explicitSelection) return
+    panel.api.updateParameters({ explicitSelection })
   }
 
   // Keep each open chat tab's title in step with its session's server title. Draft
@@ -1468,6 +1524,30 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     const params = source.params as Record<string, unknown> | undefined
 
     switch (comp) {
+      case 'chat': {
+        const bid = (currentBotId.value ?? '').trim()
+        if (!bid) return
+        const id = nextChatPanelId(bid)
+        const explicitSelection = typeof params?.explicitSelection === 'boolean'
+          ? params.explicitSelection
+          : chatStore.hasExplicitSessionSelection === true
+        setNextChatActivationExplicit(id, explicitSelection)
+        dock.addPanel({
+          id,
+          component: 'chat',
+          title,
+          params: {
+            sessionId: params?.sessionId ?? null,
+            explicitSelection,
+          },
+          renderer: 'always',
+          position,
+        })
+        // Each split starts as this new group's preview slot. Choosing another
+        // session in that group repoints the split in place until the user sends.
+        markEphemeral(id)
+        break
+      }
       case 'terminal': {
         if (!hasCurrentPermission('workspace_exec')) return
         const bid = (currentBotId.value ?? '').trim()
@@ -1541,9 +1621,6 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
         })
         break
       }
-      // No 'chat' case: the single global messages array means two chat panels in
-      // separate groups would both render the ACTIVE session (wrong data, not just
-      // stale). Splitting chat is disabled until per-session message state exists.
     }
   }
 
@@ -1855,25 +1932,88 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     () => prunePanels(),
   )
 
-  // A sent message pins the session's chat tab (it is no longer a preview). For a
-  // draft, this also repoints the active draft tab to the freshly created session.
+  // A sent message pins exactly the originating chat view (it is no longer a
+  // preview). Draft promotion also repoints only that view to the new session.
   watch(() => chatStore.userSentInSession, (sig) => {
     if (!sig) return
     const dock = api.value
-    if (!dock) return
-    let panel = chatPanelForSession(sig.id)
-    if (!panel && sig.wasDraft) {
-      const active = dock.activePanel
-      if (active && panelComponentOf(active.id) === 'chat' && panelSessionId(active) === null) {
-        active.api.updateParameters({ sessionId: sig.id })
-        panel = active
-      }
+    const bid = (currentBotId.value ?? '').trim()
+    if (!dock || !bid || sig.botId !== bid) return
+    const panel = dock.getPanel(sig.viewId)
+    if (!panel || panelComponentOf(panel.id) !== 'chat') return
+    const currentSessionId = panelSessionId(panel)
+    if (sig.wasDraft) {
+      // A delayed create must not overwrite a panel that has since been reused
+      // for another session.
+      if (currentSessionId && currentSessionId !== sig.id) return
+      panel.api.updateParameters({ sessionId: sig.id })
     }
-    if (panel) {
-      pinPanel(panel.id)
-      syncChatTitles()
-    }
+    else if (currentSessionId !== sig.id) return
+    pinPanel(panel.id)
+    syncChatTitles()
   })
+
+  // `/new` can finish resolving Agent defaults after focus has moved to a
+  // different split. The workspace owns the final Draft panel id because a
+  // preview can be reused in place while a pinned source must remain open and
+  // receive a new preview beside it.
+  watch(() => chatStore.draftViewRequested, (request) => {
+    if (!request) return
+    const dock = api.value
+    const bid = (currentBotId.value ?? '').trim()
+    if (!dock || request.botId !== bid) return
+    const panel = dock.getPanel(request.viewId)
+    if (!panel || panelComponentOf(panel.id) !== 'chat') return
+    if (panelSessionId(panel) !== request.expectedSessionId) return
+
+    const activate = request.activate && dock.activePanel?.id === panel.id
+    if (ephemeralPanels.value[panel.id]) {
+      chatStore.applyDraftViewRequest(request, activate)
+      panel.api.updateParameters({
+        sessionId: null,
+        explicitSelection: request.explicitSelection,
+      })
+      panel.api.setTitle(DEFAULT_CHAT_TITLE)
+      return
+    }
+
+    const id = nextChatPanelId(bid)
+    const draftRequest = { ...request, viewId: id }
+    if (activate) setNextChatActivationExplicit(id, request.explicitSelection)
+    if (!openEphemeral({
+      id,
+      component: 'chat',
+      title: DEFAULT_CHAT_TITLE,
+      params: {
+        sessionId: null,
+        explicitSelection: request.explicitSelection,
+      },
+      groupId: panel.group.id,
+      inactive: !activate,
+    })) return
+    chatStore.applyDraftViewRequest(draftRequest, activate)
+  }, { flush: 'sync' })
+
+  // A Fork belongs to the panel where it was requested, even if hydration
+  // completes after another split gains focus. Preview sources are repointed;
+  // pinned sources keep their Session and get a new preview in the same group.
+  watch(() => chatStore.forkedSessionRequested, (request) => {
+    if (!request) return
+    const dock = api.value
+    const bid = (currentBotId.value ?? '').trim()
+    if (!dock || request.botId !== bid) return
+    const panel = dock.getPanel(request.viewId)
+    if (!panel || panelComponentOf(panel.id) !== 'chat') return
+    if (panelSessionId(panel) !== request.expectedSessionId) return
+    openSessionChatFromView({
+      viewId: request.viewId,
+      sessionId: request.sessionId,
+      title: request.title,
+      expectedSessionId: request.expectedSessionId,
+      explicitSelection: request.explicitSelection,
+      activate: request.activate && dock.activePanel?.id === panel.id,
+    })
+  }, { flush: 'sync' })
 
   // Keep the active chat tab in step with the global session when it is set from
   // OUTSIDE a tab activation (initialize picking a session, an ACP session being
@@ -1960,6 +2100,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     showWorkbench,
     hideWorkbench,
     openSessionChat,
+    openSessionChatFromView,
     openSessionChatPinned,
     openDraftChat,
     openFile,


### PR DESCRIPTION
## Summary

- key real chat views by `(botId, sessionId)` so multiple panes share one Session controller without sharing Draft state
- isolate Draft composers by stable Dockview `viewId`, including text, attachments, model, reasoning, skills, and async ownership
- support same-Session splits, different Sessions side by side, exact Draft promotion, targeted `/new`, Fork, retry, edit, approval, and `ask_user`
- render the scroll minimap for every visible split pane, not only the focused Dockview group

## State model

1. A visible pane attaches to one Session SSE keyed by `(botId, sessionId)`; panes showing the same Session share that subscription.
2. When the last pane hides, the SSE detaches while the keyed transcript remains available from memory.
3. Every hidden Session, including one with an attached Dockview tab, enters the same 12-entry LRU; visible, streaming, approval-pending, and `ask_user`-pending Sessions are retained.

Assistant stream lookup, fallback event routing, loading state, approvals, and sidebar indicators all use the same `(botId, sessionId)` key. The bot activity stream remains a single bot-scoped subscription.

## Correctness

The implementation guards late async results from ACP setup, attachment conversion, Session deletion, bot switches, Fork, and `/new` so work cannot move into a different pane or bot. Unknown real Sessions remain read-only until their summary is hydrated.

## Verification

- Web Vitest: 71 files, 814 tests passed
- Desktop Vitest: 7 files, 28 tests passed
- Web and Desktop TypeScript checks passed
- ESLint passed for the affected Web stores, home components, composables, and sidebar consumer
- Web production build passed
- UI contract passed with two pre-existing `packages/ui` sidebar warnings
- Commit hook Go lint and full Go test suite passed
- Electron manual verification covers two independently streaming Session panes, shared same-Session rendering, independent drafts, layout restore, and minimaps on both visible panes