### PR TITLE
feat(providers): OpenAI Codex device authorization with managed model catalog

### DIFF
--- a/apps/web/src/components/device-code-panel/index.vue
+++ b/apps/web/src/components/device-code-panel/index.vue
@@ -1,0 +1,172 @@
+<template>
+  <!-- 结构:一句指引 → 英雄码 → 唯一动作 → 倒计时。验证码是给人读的展示物,
+       不是输入框;动作只有一颗(复制并打开,同一次手势里完成)。
+       —— 间距是本面板单独设计的,不套卡内通用模板(space-y-4 均布) ——
+       注意这不是"输入 OTP"屏,是"展示 code 让用户带走"屏(方向相反),且码是
+       字母串、容易和句子文本发生视觉牵连,又不能用卡内嵌卡把它框出来 —— 所以
+       靠留白隔离,间距最终裁决为均布 gap-4(人眼定稿 2026-07-13):曾试过
+       1.5/5 的强分组和 2/4/2.5 的渐变,都读得出"刻意分坨";层次全部交给字号
+       (xs↔3xl)和元素顺序表达,留白保持匀速 —— 均布反而最自然。别再调回
+       不均匀节奏,除非人眼重新裁决。
+       图标位置即语义:外链箭头放尾缀 = 这颗按钮的落点是"打开页面"(复制只是
+       顺带);若把 Copy 图标放前缀,按钮读作"复制为主" —— 位置选错会误导预期。
+       图标间距由 Button 自带的 gap 负责,不许再手加 ml/mr(叠加会把内容挤偏)。 -->
+  <div class="flex flex-col items-center gap-4 text-center">
+    <p class="text-xs text-muted-foreground">
+      {{ hint }}
+    </p>
+    <div
+      class="font-mono text-3xl font-medium tracking-widest select-all"
+      :class="expired ? 'text-muted-foreground line-through' : 'text-foreground'"
+    >
+      {{ code }}
+    </div>
+    <Button
+      v-if="!expired"
+      type="button"
+      variant="outline"
+      @click="copyAndOpen"
+    >
+      {{ $t('deviceCode.copyAndOpen') }}
+      <ExternalLink />
+    </Button>
+    <Button
+      v-else
+      type="button"
+      variant="outline"
+      :loading="retryLoading"
+      loading-mode="manual"
+      @click="$emit('retry')"
+    >
+      <!-- manual loading:同尺寸 spinner 原位替换图标,文字不动(同 Connect 按钮)。 -->
+      <Spinner v-if="retryLoading" />
+      <RefreshCw v-else />
+      {{ $t('deviceCode.retry') }}
+    </Button>
+    <p
+      v-if="expiresAt"
+      class="text-xs tabular-nums"
+      :class="expired ? 'text-destructive' : 'text-muted-foreground'"
+    >
+      {{ expired ? $t('deviceCode.codeExpired') : $t('deviceCode.expiresIn', { time: remainingLabel }) }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+// DeviceCodePanel — 设备码授权(RFC 8628)的"输码时刻"面板。仓库里同一形状已出现
+// 三处(providers OAuth、bots ACP、onboarding Step4),此为 owner。
+//
+// 契约(试点期踩出来的,改动前先读):
+// - 动作语义分两层:面板只拥有"复制并打开"与过期后的"重新获取"(emit retry);
+//   "取消整个流程"属于 caller 的入口控件(providers 页是行上的 Connect↔Cancel
+//   开关) —— 两个动作语义不同,不是重复,不要合并或砍掉其中一个。
+// - 复制并打开的顺序有讲究:新标签页必须在用户手势内同步打开(等剪贴板 Promise
+//   回来再 open 会被弹窗拦截),所以先开空白页占位,复制失败再收回、只报错不跳转。
+// - 倒计时是面板唯一的活性信号(不放 spinner 行;授权轮询是 caller 的事,静默),
+//   秒级 ticker 带页面可见性守卫,后台 tab 不空转,回前台立即校准。
+// - 防钓鱼提示归属 caller 的 hint 文案(ACP 的 hint 即含警示语);面板不内置,
+//   因为"复制并打开"已保证用户只会到达后端下发的官方地址。
+// - expiresAt 缺省时不渲染倒计时行,也永不判过期(某些流程不下发过期时间)。
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { Button, Spinner, toast } from '@felinic/ui'
+import { ExternalLink, RefreshCw } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+import { useClipboard } from '@/composables/useClipboard'
+
+const props = withDefaults(defineProps<{
+  /** 一次性用户码,原样展示(上游自带分组连字符)。 */
+  code: string
+  /** 官方验证页地址,来自后端 —— 面板不做任何拼接。 */
+  verificationUri: string
+  /** ISO 过期时间;缺省则不显示倒计时、永不判过期。 */
+  expiresAt?: string
+  /** 指引文案(caller 的 i18n;含防钓鱼警示时也写在这里)。 */
+  hint: string
+  /** 过期后"重新获取"按钮的 loading 态,与 caller 的签发请求对齐。 */
+  retryLoading?: boolean
+}>(), {
+  expiresAt: '',
+  retryLoading: false,
+})
+
+const emit = defineEmits<{
+  /** 码过期后用户点了"重新获取" —— caller 负责签发新码并更新 props。 */
+  retry: []
+}>()
+void emit
+
+const { t } = useI18n()
+const { copyText } = useClipboard()
+
+const nowMs = ref(Date.now())
+let ticker: ReturnType<typeof setInterval> | undefined
+
+function stopTicker() {
+  if (ticker !== undefined) {
+    clearInterval(ticker)
+    ticker = undefined
+  }
+}
+
+// 回前台立即校准一次(后台期间 tick 被跳过,nowMs 是旧的)。
+function onVisibilityChange() {
+  if (document.visibilityState === 'visible') nowMs.value = Date.now()
+}
+
+const expiresAtMs = computed(() => {
+  if (!props.expiresAt) return 0
+  const ms = new Date(props.expiresAt).getTime()
+  return Number.isNaN(ms) ? 0 : ms
+})
+
+const expired = computed(() => expiresAtMs.value > 0 && nowMs.value >= expiresAtMs.value)
+
+const remainingLabel = computed(() => {
+  const ms = Math.max(0, expiresAtMs.value - nowMs.value)
+  const totalSec = Math.ceil(ms / 1000)
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+})
+
+watch(expiresAtMs, (expiresAt) => {
+  stopTicker()
+  if (!expiresAt) return
+  nowMs.value = Date.now()
+  ticker = setInterval(() => {
+    // 页面不可见时跳过:后台 tab 不需要每秒重渲染倒计时。
+    if (document.visibilityState === 'hidden') return
+    nowMs.value = Date.now()
+    if (nowMs.value >= expiresAt) stopTicker()
+  }, 1000)
+}, { immediate: true })
+
+onMounted(() => {
+  document.addEventListener('visibilitychange', onVisibilityChange)
+})
+onBeforeUnmount(() => {
+  stopTicker()
+  document.removeEventListener('visibilitychange', onVisibilityChange)
+})
+
+async function copyAndOpen() {
+  const userCode = props.code.trim()
+  const verificationUri = props.verificationUri.trim()
+  if (!userCode || !verificationUri) return
+
+  const tab = window.open('', '_blank')
+  const copied = await copyText(userCode)
+  if (!copied) {
+    tab?.close()
+    toast.error(t('deviceCode.copyFailed'))
+    return
+  }
+  if (tab) {
+    tab.location.href = verificationUri
+    tab.focus()
+    return
+  }
+  window.open(verificationUri, '_blank')
+}
+</script>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -936,6 +936,7 @@
     "searchNoResults": "No matching models",
     "emptyTitle": "No models yet",
     "emptyDescription": "Add one manually, or import the full list from this provider.",
+    "managedEmptyDescription": "Authorize the provider, then refresh the managed model catalog.",
     "clientType": "Client Type",
     "clientTypePlaceholder": "Select client type",
     "typeRequired": "Type is required",
@@ -969,6 +970,9 @@
     "importModels": "Import Models",
     "importSuccess": "Successfully imported {created} models, skipped {skipped}",
     "importFailed": "Failed to import models",
+    "refreshModels": "Refresh Models",
+    "refreshSuccess": "Model catalog refreshed: {created} added, {updated} updated",
+    "refreshFailed": "Failed to refresh the model catalog",
     "importConfirmHint": "Models will be imported from this provider's API with default compatibilities (vision, tool-call, reasoning).",
     "showingCount": "Showing {count} of {total}"
   },
@@ -1016,30 +1020,19 @@
       "descriptionOff": "Disabling caching rebills the full system prompt and tool list on every request. Only use this for strict context isolation."
     },
     "oauth": {
-      "openaiTitle": "OpenAI OAuth",
-      "openaiDescription": "Authorize this provider with your ChatGPT account for Codex-compatible OpenAI access.",
+      "openaiDeviceHint": "Enter this one-time code on OpenAI's verification page.",
       "openaiCreateHint": "Save the provider first, then authorize it from the provider details panel.",
-      "githubTitle": "GitHub Copilot OAuth",
-      "githubDescription": "Connect the current Memoh account with GitHub Copilot.",
-      "githubDeviceTitle": "GitHub Copilot Device Authorization",
-      "githubDeviceDescription": "Start device authorization, open GitHub's verification page, and enter the user code shown below.",
       "githubCreateHint": "Save the provider first, then start device authorization from the provider details panel.",
-      "githubDeviceHint": "Open the verification URL below and enter this user code to authorize the current Memoh account.",
-      "authorize": "Authorize",
-      "deviceAuthorize": "Start Device Authorization",
+      "githubDeviceHint": "Enter this one-time code on GitHub's verification page.",
       "authorizeFailed": "Failed to start authorization",
-      "authorizeTimedOut": "Authorization timed out. Try again.",
       "authorizeSuccess": "Authorization successful",
       "revoke": "Revoke",
       "revokeFailed": "Failed to revoke authorization",
       "revokeSuccess": "Authorization revoked",
       "copyFailed": "Failed to copy device code",
-      "connectedAccount": "Connected Account",
-      "callback": "Callback URL",
       "deviceVerificationUri": "Verification URL",
       "deviceUserCode": "User Code",
       "deviceExpiresAt": "Expires At",
-      "statusFailed": "Failed to load OAuth status",
       "status": {
         "checking": "Checking authorization status...",
         "authorized": "Authorized",
@@ -1049,7 +1042,15 @@
         "expired": "Authorization expired. Re-authorize to continue.",
         "missing": "Not authorized yet.",
         "notConfigured": "This provider is not configured for OAuth."
-      }
+      },
+      "sectionTitle": "Account",
+      "chatgptAccount": "ChatGPT account",
+      "githubAccount": "GitHub account",
+      "connect": "Connect",
+      "openaiConnectHint": "Sign in with your ChatGPT account to use its models.",
+      "githubConnectHint": "Sign in with GitHub to use Copilot models.",
+      "revokeConfirm": "Revoke authorization for this account?",
+      "connecting": "Connecting"
     }
   },
   "webSearch": {
@@ -3143,5 +3144,12 @@
       "saveFailed": "Failed to save, please try again",
       "noProviderWarning": "You haven't configured an AI provider yet. Your bot won't be able to reply until you add one in Settings → Providers"
     }
+  },
+  "deviceCode": {
+    "copyAndOpen": "Copy & Open",
+    "retry": "Get a new code",
+    "expiresIn": "Expires in {time}",
+    "codeExpired": "Code expired",
+    "copyFailed": "Failed to copy the code"
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -888,6 +888,7 @@
     "searchNoResults": "一致するモデルがありません",
     "emptyTitle": "モデルはまだありません",
     "emptyDescription": "手動で追加するか、このプロバイダーから完全なリストをインポートします。",
+    "managedEmptyDescription": "認証を完了してから、管理対象の Model カタログを更新してください。",
     "clientType": "クライアントの種類",
     "clientTypePlaceholder": "クライアントの種類を選択してください",
     "typeRequired": "種類を選択してください",
@@ -921,6 +922,9 @@
     "importModels": "モデルをインポート",
     "importSuccess": "{created}件のモデルをインポートしました。{skipped}件はスキップされました",
     "importFailed": "モデルのインポートに失敗しました",
+    "refreshModels": "Model を更新",
+    "refreshSuccess": "Model カタログを更新しました: {created} 件追加、{updated} 件更新",
+    "refreshFailed": "Model カタログの更新に失敗しました",
     "importConfirmHint": "このプロバイダーの API から、デフォルトの互換性（ビジョン、ツール呼び出し、推論）付きでモデルをインポートします。",
     "showingCount": "{total} の {count} を表示中"
   },
@@ -968,30 +972,19 @@
       "descriptionOff": "キャッシュを無効にすると、リクエストごとに完全なシステムプロンプトとツール一覧が再課金されます。厳密なコンテキスト分離が必要な場合にのみ使用してください。"
     },
     "oauth": {
-      "openaiTitle": "OpenAI OAuth",
-      "openaiDescription": "Codex 互換の OpenAI アクセスのために、ChatGPT アカウントでこのプロバイダーを認可します。",
+      "openaiDeviceHint": "OpenAI の確認ページでこのワンタイムコードを入力してください。",
       "openaiCreateHint": "まずプロバイダーを保存し、その後プロバイダーの詳細パネルから認可します。",
-      "githubTitle": "GitHub コパイロット OAuth",
-      "githubDescription": "現在の Memoh アカウントを GitHub Copilot に接続します。",
-      "githubDeviceTitle": "GitHub Copilot デバイスの認証",
-      "githubDeviceDescription": "デバイス認証を開始し、GitHubの認証ページを開き、以下のユーザーコードを入力します。",
       "githubCreateHint": "まずプロバイダーを保存し、その後プロバイダーの詳細パネルからデバイス認証を開始します。",
-      "githubDeviceHint": "検証を開くURL以下にこのユーザー コードを入力して、現在の Memoh アカウントを認証します。",
-      "authorize": "承認する",
-      "deviceAuthorize": "デバイス認証を開始する",
+      "githubDeviceHint": "GitHub の確認ページでこのワンタイムコードを入力してください。",
       "authorizeFailed": "認証の開始に失敗しました",
-      "authorizeTimedOut": "認証がタイムアウトしました。もう一度やり直してください。",
       "authorizeSuccess": "認可成功",
       "revoke": "取り消す",
       "revokeFailed": "認可の取り消しに失敗しました",
       "revokeSuccess": "認可が取り消されました",
       "copyFailed": "デバイスコードのコピーに失敗しました",
-      "connectedAccount": "接続されたアカウント",
-      "callback": "コールバック URL",
       "deviceVerificationUri": "検証URL",
       "deviceUserCode": "ユーザーコード",
       "deviceExpiresAt": "有効期限",
-      "statusFailed": "OAuthステータスのロードに失敗しました",
       "status": {
         "checking": "認証ステータスを確認しています...",
         "authorized": "認可された",
@@ -1001,7 +994,15 @@
         "expired": "認証の有効期限が切れました。続行するには再認証してください。",
         "missing": "まだ認可されていません。",
         "notConfigured": "このプロバイダーは OAuth 用に設定されていません。"
-      }
+      },
+      "sectionTitle": "アカウント",
+      "chatgptAccount": "ChatGPT アカウント",
+      "githubAccount": "GitHub アカウント",
+      "connect": "接続",
+      "openaiConnectHint": "ChatGPT アカウントでサインインすると、そのモデルを利用できます。",
+      "githubConnectHint": "GitHub アカウントでサインインすると、Copilot のモデルを利用できます。",
+      "revokeConfirm": "このアカウントの認可を取り消しますか?",
+      "connecting": "接続中"
     }
   },
   "webSearch": {
@@ -3108,5 +3109,12 @@
       "saveFailed": "保存できませんでした。もう一度お試しください。",
       "noProviderWarning": "AIプロバイダーがまだ設定されていません。「設定」→「プロバイダー」で追加するまで、Bot は応答できません。"
     }
+  },
+  "deviceCode": {
+    "copyAndOpen": "コピーして開く",
+    "retry": "新しいコードを取得",
+    "expiresIn": "{time}で期限切れになります",
+    "codeExpired": "コードは期限切れです",
+    "copyFailed": "コードをコピーできませんでした"
   }
 }

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -936,6 +936,7 @@
     "searchNoResults": "没有匹配的模型",
     "emptyTitle": "暂无模型",
     "emptyDescription": "手动添加，或从该服务商导入完整列表。",
+    "managedEmptyDescription": "请先完成授权，再刷新托管模型目录。",
     "clientType": "客户端类型",
     "clientTypePlaceholder": "选择客户端类型",
     "typeRequired": "请选择类型",
@@ -969,6 +970,9 @@
     "importModels": "导入模型",
     "importSuccess": "成功导入 {created} 个模型，跳过 {skipped} 个",
     "importFailed": "导入模型失败",
+    "refreshModels": "刷新模型",
+    "refreshSuccess": "模型目录已刷新：新增 {created} 个，更新 {updated} 个",
+    "refreshFailed": "刷新模型目录失败",
     "importConfirmHint": "将从该服务商的 API 导入模型，默认兼容性为视觉、工具调用和推理。",
     "showingCount": "显示 {count} / {total}"
   },
@@ -1016,30 +1020,19 @@
       "descriptionOff": "关闭后每次请求都会重新计费完整的系统提示词与工具列表，仅在需要严格隔离上下文时使用。"
     },
     "oauth": {
-      "openaiTitle": "OpenAI OAuth",
-      "openaiDescription": "使用你的 ChatGPT 账号为该提供商授权，以启用 Codex 兼容的 OpenAI 访问。",
+      "openaiDeviceHint": "在 OpenAI 验证页面输入此一次性验证码。",
       "openaiCreateHint": "请先保存提供商，再到详情面板完成授权。",
-      "githubTitle": "GitHub Copilot OAuth",
-      "githubDescription": "为当前 Memoh 账号连接 GitHub Copilot。",
-      "githubDeviceTitle": "GitHub Copilot Device Authorization",
-      "githubDeviceDescription": "启动设备授权后，打开 GitHub 验证页面并输入下方显示的用户代码。",
       "githubCreateHint": "请先保存提供商，再到详情面板启动设备授权。",
-      "githubDeviceHint": "打开下方验证地址，并输入这个用户代码，为当前 Memoh 账号完成授权。",
-      "authorize": "授权",
-      "deviceAuthorize": "启动设备授权",
+      "githubDeviceHint": "在 GitHub 验证页面输入此一次性验证码。",
       "authorizeFailed": "启动授权失败",
-      "authorizeTimedOut": "授权超时，请重试。",
       "authorizeSuccess": "授权成功",
       "revoke": "撤销授权",
       "revokeFailed": "撤销授权失败",
       "revokeSuccess": "授权已撤销",
       "copyFailed": "复制设备代码失败",
-      "connectedAccount": "已连接账号",
-      "callback": "回调地址",
       "deviceVerificationUri": "验证地址",
       "deviceUserCode": "用户代码",
       "deviceExpiresAt": "过期时间",
-      "statusFailed": "加载 OAuth 状态失败",
       "status": {
         "checking": "正在检查授权状态...",
         "authorized": "已授权",
@@ -1049,7 +1042,15 @@
         "expired": "授权已过期，请重新授权。",
         "missing": "尚未授权。",
         "notConfigured": "当前提供商未正确配置 OAuth。"
-      }
+      },
+      "sectionTitle": "账号",
+      "chatgptAccount": "ChatGPT 账号",
+      "githubAccount": "GitHub 账号",
+      "connect": "连接",
+      "openaiConnectHint": "登录 ChatGPT 账号后即可使用其模型。",
+      "githubConnectHint": "登录 GitHub 账号后即可使用 Copilot 模型。",
+      "revokeConfirm": "确定撤销此账号的授权？",
+      "connecting": "连接中"
     }
   },
   "webSearch": {
@@ -3143,5 +3144,12 @@
       "saveFailed": "保存失败，请重试",
       "noProviderWarning": "你尚未配置 AI 服务商，Bot 将无法回复消息。请前往 设置 → 服务商 添加"
     }
+  },
+  "deviceCode": {
+    "copyAndOpen": "复制并打开",
+    "retry": "重新获取验证码",
+    "expiresIn": "{time} 后过期",
+    "codeExpired": "验证码已过期",
+    "copyFailed": "复制验证码失败"
   }
 }

--- a/apps/web/src/pages/providers/components/model-item.vue
+++ b/apps/web/src/pages/providers/components/model-item.vue
@@ -93,6 +93,7 @@
       </Button>
 
       <Button
+        v-if="!managed"
         type="button"
         variant="ghost"
         size="icon-sm"
@@ -103,6 +104,7 @@
       </Button>
 
       <ConfirmPopover
+        v-if="!managed"
         :message="$t('models.deleteModelConfirm')"
         :loading="deleteLoading"
         @confirm="$emit('delete', model.id ?? '')"
@@ -144,8 +146,10 @@ const props = withDefaults(defineProps<{
   model: ModelsGetResponse
   deleteLoading: boolean
   searchAligned?: boolean
+  managed?: boolean
 }>(), {
   searchAligned: false,
+  managed: false,
 })
 
 defineEmits<{

--- a/apps/web/src/pages/providers/components/model-list.vue
+++ b/apps/web/src/pages/providers/components/model-list.vue
@@ -22,14 +22,27 @@
         v-if="providerId"
         class="ml-auto flex items-center gap-2"
       >
-        <ImportModelsDialog
-          :provider-id="providerId"
+        <LoadingButton
+          v-if="managed"
+          type="button"
+          variant="outline"
           size="sm"
-        />
-        <CreateModel
-          :id="providerId"
-          size="sm"
-        />
+          :loading="refreshLoading"
+          @click="refreshManagedModels"
+        >
+          <RefreshCw />
+          {{ $t('models.refreshModels') }}
+        </LoadingButton>
+        <template v-else>
+          <ImportModelsDialog
+            :provider-id="providerId"
+            size="sm"
+          />
+          <CreateModel
+            :id="providerId"
+            size="sm"
+          />
+        </template>
       </div>
     </div>
 
@@ -44,6 +57,7 @@
           :model="model"
           :delete-loading="deleteModelLoading"
           :search-aligned="searchVisible"
+          :managed="managed"
           @edit="(model) => $emit('edit', model)"
           @delete="(id) => $emit('delete', id)"
         />
@@ -110,13 +124,16 @@
         </EmptyMedia>
       </EmptyHeader>
       <EmptyTitle>{{ $t('models.emptyTitle') }}</EmptyTitle>
-      <EmptyDescription>{{ $t('models.emptyDescription') }}</EmptyDescription>
+      <EmptyDescription>
+        {{ $t(managed ? 'models.managedEmptyDescription' : 'models.emptyDescription') }}
+      </EmptyDescription>
     </Empty>
   </SettingsSection>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useQueryCache } from '@pinia/colada'
 import {
   Empty,
   EmptyDescription,
@@ -135,12 +152,16 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from '@felinic/ui'
-import { Search, List } from 'lucide-vue-next'
+import { Search, List, RefreshCw } from 'lucide-vue-next'
 import CreateModel from '@/components/create-model/index.vue'
 import ImportModelsDialog from '@/components/import-models-dialog/index.vue'
+import LoadingButton from '@/components/loading-button/index.vue'
 import SettingsSection from '@/components/settings/section.vue'
 import ModelItem from './model-item.vue'
+import { postProvidersByIdImportModels } from '@memohai/sdk'
 import type { ModelsGetResponse } from '@memohai/sdk'
+import { toast } from '@felinic/ui'
+import { useI18n } from 'vue-i18n'
 
 const PAGE_SIZE = 8
 
@@ -148,6 +169,7 @@ const props = defineProps<{
   providerId: string | undefined
   models: ModelsGetResponse[] | undefined
   deleteModelLoading: boolean
+  managed?: boolean
 }>()
 
 defineEmits<{
@@ -157,6 +179,31 @@ defineEmits<{
 
 const searchQuery = ref('')
 const currentPage = ref(1)
+const refreshLoading = ref(false)
+const queryCache = useQueryCache()
+const { t } = useI18n()
+
+async function refreshManagedModels() {
+  if (!props.providerId) return
+  refreshLoading.value = true
+  try {
+    const { data } = await postProvidersByIdImportModels({
+      path: { id: props.providerId },
+      throwOnError: true,
+    })
+    queryCache.invalidateQueries({ key: ['provider-models'] })
+    queryCache.invalidateQueries({ key: ['models'] })
+    queryCache.invalidateQueries({ key: ['all-models'] })
+    toast.success(t('models.refreshSuccess', {
+      created: data?.created ?? 0,
+      updated: data?.updated ?? 0,
+    }))
+  } catch {
+    toast.error(t('models.refreshFailed'))
+  } finally {
+    refreshLoading.value = false
+  }
+}
 
 // Always offer search once there are models, so the box never disappears for a
 // short list (which read as inconsistent between providers). When it's shown,
@@ -165,9 +212,12 @@ const searchVisible = computed(() => !!props.models && props.models.length > 0)
 
 const filteredModels = computed(() => {
   if (!props.models) return []
-  if (!searchQuery.value) return props.models
+  const availableModels = props.managed
+    ? props.models.filter(model => model.config?.catalog_available !== false)
+    : props.models
+  if (!searchQuery.value) return availableModels
   const keyword = searchQuery.value.toLowerCase()
-  return props.models.filter((model) => {
+  return availableModels.filter((model) => {
     const name = (model.name ?? '').toLowerCase()
     const modelId = (model.model_id ?? '').toLowerCase()
     return name.includes(keyword) || modelId.includes(keyword)

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -1,6 +1,9 @@
 <template>
   <form @submit="editProvider">
-    <SettingsSection :title="$t('provider.configurationTitle')">
+    <SettingsSection
+      v-if="!isCodexProvider"
+      :title="$t('provider.configurationTitle')"
+    >
       <!-- Field rows are grouped so the LAST one keeps its `last:border-b-0`
            (no trailing inset hairline) — the footer below owns the only divider,
            and it spans full width. -->
@@ -203,160 +206,121 @@
       </template>
     </SettingsSection>
 
-    <!-- OAuth -->
+    <!-- OAuth 账号:设备码授权。结构镜像 profile/connected-accounts-section(同一
+         形状的已重构参考):一行账号状态 + 行内动作,等待输码时才在卡片内追加
+         居中的验证码块(倒计时 + 复制并打开),轮询在后台静默完成授权。 -->
     <SettingsSection
       v-if="isProviderOAuthClientType(form.values.client_type)"
-      class="mt-6"
+      :title="$t('provider.oauth.sectionTitle')"
+      :class="{ 'mt-6': !isCodexProvider }"
     >
-      <div class="p-4 space-y-3 text-xs">
-        <div class="space-y-1">
-          <div class="font-medium">
-            {{ $t(form.values.client_type === 'github-copilot' ? 'provider.oauth.githubDeviceTitle' : 'provider.oauth.openaiTitle') }}
-          </div>
-          <div class="text-muted-foreground">
-            {{ $t(form.values.client_type === 'github-copilot' ? 'provider.oauth.githubDeviceDescription' : 'provider.oauth.openaiDescription') }}
-          </div>
-          <div
-            class="text-xs"
-            :class="oauthExpired ? 'text-destructive' : 'text-muted-foreground'"
-          >
-            <template v-if="oauthStatusLoading">
-              {{ $t('provider.oauth.status.checking') }}
-            </template>
-            <template v-else-if="oauthStatus && !oauthStatus.configured">
-              {{ $t('provider.oauth.status.notConfigured') }}
-            </template>
-            <template v-else-if="oauthExpired">
-              {{ $t('provider.oauth.status.expired') }}
-            </template>
-            <template v-else-if="oauthStatus?.has_token">
-              {{ $t(form.values.client_type === 'github-copilot' ? 'provider.oauth.status.authorizedCurrent' : 'provider.oauth.status.authorized') }}
-            </template>
-            <template v-else-if="oauthStatus?.device?.pending">
-              {{ $t('provider.oauth.status.pendingDevice') }}
-            </template>
-            <template v-else>
-              {{ $t('provider.oauth.status.missing') }}
-            </template>
-          </div>
-          <div
-            v-if="oauthStatus?.callback_url"
-            class="text-xs text-muted-foreground"
-          >
-            {{ $t('provider.oauth.callback') }}: {{ oauthStatus.callback_url }}
-          </div>
-        </div>
+      <!-- AutoHeight:状态切换(尤其设备码块出现/收起)让卡片平滑生长,不硬切。 -->
+      <AutoHeight>
+        <!-- 首次加载:借行高稳住卡片,状态到达时不跳动。
+             ui-allow-shape: skeleton borrowing the row height, not a data row. -->
         <div
-          v-if="form.values.client_type === 'github-copilot'
-            && oauthStatus?.device?.pending
-            && !oauthStatus?.has_token
-            && oauthStatus?.device?.user_code
-            && oauthStatus?.device?.verification_uri"
-          class="rounded-md bg-muted-soft p-3 space-y-2"
+          v-if="oauthStatusLoading && !oauthStatus"
+          class="mx-4 flex min-h-[3.75rem] items-center justify-center py-3"
         >
-          <div class="text-muted-foreground">
-            {{ $t('provider.oauth.githubDeviceHint') }}
-          </div>
-          <div class="space-y-1">
-            <div class="font-medium">
-              {{ $t('provider.oauth.deviceVerificationUri') }}
-            </div>
-            <code class="block break-all rounded bg-background px-2 py-1 select-all">{{ oauthStatus?.device?.verification_uri }}</code>
-          </div>
-          <div class="space-y-1">
-            <div class="font-medium">
-              {{ $t('provider.oauth.deviceUserCode') }}
-            </div>
-            <div class="flex items-center gap-2">
-              <code class="block flex-1 rounded bg-background px-2 py-1 text-sm tracking-[0.3em] select-all">{{ oauthStatus?.device?.user_code }}</code>
+          <Spinner class="size-5 text-muted-foreground" />
+        </div>
+
+        <!-- 已连接:身份就是这一行的全部内容;撤销会切断在用的授权,须经确认。 -->
+        <SettingsRow
+          v-else-if="oauthConnected"
+          :label="accountLabel"
+          :description="connectedIdentity || $t('provider.oauth.status.authorizedCurrent')"
+        >
+          <ConfirmPopover
+            :message="$t('provider.oauth.revokeConfirm')"
+            :confirm-text="$t('provider.oauth.revoke')"
+            :loading="revokeLoading"
+            @confirm="handleRevoke"
+          >
+            <template #trigger>
               <Button
                 type="button"
                 variant="ghost"
                 size="sm"
-                @click="handleCopyDeviceCode"
+                class="shrink-0 text-muted-foreground"
+                :disabled="revokeLoading"
               >
-                <Copy />
-                {{ $t('common.copy') }}
+                {{ $t('provider.oauth.revoke') }}
               </Button>
-            </div>
-          </div>
+            </template>
+          </ConfirmPopover>
+        </SettingsRow>
+
+        <!-- 后端未配置 OAuth:说明原因,没有可给的动作。 -->
+        <SettingsRow
+          v-else-if="oauthStatus && !oauthStatus.configured"
+          :label="accountLabel"
+          :description="$t('provider.oauth.status.notConfigured')"
+        />
+
+        <template v-else>
+          <!-- 未连接 / 已过期:一行状态 + 长显的开关按钮。设备码流程进行中时它翻成
+               "取消"(前端本地收起,服务端的码留给它自然过期);再点"连接"签发新码。 -->
+          <SettingsRow
+            :label="accountLabel"
+            :description="oauthExpired ? $t('provider.oauth.status.expired') : connectDescription"
+          >
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              class="shrink-0"
+              :disabled="!props.provider?.id"
+              :loading="authorizeLoading"
+              loading-mode="manual"
+              @click="devicePending ? cancelDeviceAuthorization() : handleAuthorize()"
+            >
+              <!-- 三态 label:Connect → Connecting…(按下变长,给等待一个视觉
+                   挽留点) → Cancel(码到手收短)。宽度过渡由 LabelSwap 负责;
+                   manual loading 只借 busy 铬层挡双击,spinner 在 connecting
+                   slot 里占图标位,文字不被盖。 -->
+              <LabelSwap :active="authorizeLoading ? 'connecting' : devicePending ? 'cancel' : 'connect'">
+                <template #connect>
+                  <KeyRound />
+                  {{ $t('provider.oauth.connect') }}
+                </template>
+                <template #connecting>
+                  <Spinner />
+                  {{ $t('provider.oauth.connecting') }}
+                </template>
+                <template #cancel>
+                  {{ $t('common.cancel') }}
+                </template>
+              </LabelSwap>
+            </Button>
+          </SettingsRow>
+
+          <!-- 输码时刻交给 owner;这层 wrapper 只负责它在卡片里的定位。
+               py-6 是有意偏离 connected-accounts link-code 块的 py-4:那是行内
+               工具块(说明+输入行),这是居中英雄面板 —— 关系不同,留白档位不同;
+               贴着分隔线的英雄内容需要更大的呼吸(人眼裁决 2026-07-13)。 -->
           <div
-            v-if="oauthStatus?.device?.expires_at"
-            class="text-muted-foreground"
+            v-if="devicePending"
+            class="mx-4 border-b border-border py-6 last:border-b-0"
           >
-            {{ $t('provider.oauth.deviceExpiresAt') }}: {{ oauthStatus.device.expires_at }}
+            <DeviceCodePanel
+              :code="oauthStatus?.device?.user_code ?? ''"
+              :verification-uri="oauthStatus?.device?.verification_uri ?? ''"
+              :expires-at="oauthStatus?.device?.expires_at ?? ''"
+              :hint="$t(form.values.client_type === 'github-copilot' ? 'provider.oauth.githubDeviceHint' : 'provider.oauth.openaiDeviceHint')"
+              :retry-loading="authorizeLoading"
+              @retry="handleAuthorize"
+            />
           </div>
-          <div class="flex items-center gap-2 text-foreground">
-            <Spinner class="size-4" />
-            <span>{{ $t('provider.oauth.status.oauthing') }}</span>
-          </div>
-        </div>
-        <div
-          v-if="form.values.client_type === 'github-copilot' && oauthStatus?.has_token && !oauthExpired"
-          class="rounded-md bg-muted-soft p-3 space-y-1"
-        >
-          <div class="font-medium">
-            {{ $t('provider.oauth.connectedAccount') }}
-          </div>
-          <div class="text-sm font-medium">
-            {{ oauthStatus?.account?.email || oauthStatus?.account?.label || oauthStatus?.account?.name || oauthStatus?.account?.login || $t('provider.oauth.status.authorizedCurrent') }}
-          </div>
-          <div
-            v-if="[oauthStatus?.account?.login?.trim() ? `@${oauthStatus.account.login.trim()}` : '', oauthStatus?.account?.email?.trim() ?? ''].filter(Boolean).join(' · ')"
-            class="text-xs text-muted-foreground"
-          >
-            {{ [oauthStatus?.account?.login?.trim() ? `@${oauthStatus.account.login.trim()}` : '', oauthStatus?.account?.email?.trim() ?? ''].filter(Boolean).join(' · ') }}
-          </div>
-        </div>
-        <div class="flex gap-2">
-          <LoadingButton
-            v-if="props.provider?.id
-              && isProviderOAuthClientType(form.values.client_type)
-              && !(
-                form.values.client_type === 'github-copilot'
-                && oauthStatus?.device?.pending
-                && !oauthStatus?.has_token
-                && oauthStatus?.device?.user_code
-                && oauthStatus?.device?.verification_uri
-              )
-              && (!oauthStatus?.has_token || oauthExpired)"
-            type="button"
-            variant="outline"
-            size="sm"
-            :disabled="!props.provider?.id || !isProviderOAuthClientType(form.values.client_type) || oauthStatusLoading"
-            :loading="authorizeLoading"
-            @click="handleAuthorize"
-          >
-            <KeyRound />
-            {{ $t(form.values.client_type === 'github-copilot' ? 'provider.oauth.deviceAuthorize' : 'provider.oauth.authorize') }}
-          </LoadingButton>
-          <Button
-            v-if="webOAuthFlow"
-            type="button"
-            variant="ghost"
-            size="sm"
-            @click="cancelWebOAuthAuthorization"
-          >
-            {{ $t('common.cancel') }}
-          </Button>
-          <LoadingButton
-            v-if="oauthStatus?.has_token"
-            type="button"
-            variant="ghost"
-            size="sm"
-            :loading="revokeLoading"
-            @click="handleRevoke"
-          >
-            {{ $t('provider.oauth.revoke') }}
-          </LoadingButton>
-        </div>
-      </div>
+        </template>
+      </AutoHeight>
     </SettingsSection>
   </form>
 </template>
 
 <script setup lang="ts">
 import {
+  AutoHeight,
   Input,
   Button,
   FormControl,
@@ -366,6 +330,7 @@ import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
+  LabelSwap,
   Select,
   SelectContent,
   SelectItem,
@@ -373,11 +338,12 @@ import {
   SelectValue,
   Spinner,
 } from '@felinic/ui'
-import { AlertCircle, Copy, KeyRound, RefreshCw } from 'lucide-vue-next'
+import { AlertCircle, KeyRound, RefreshCw } from 'lucide-vue-next'
+import ConfirmPopover from '@/components/confirm-popover/index.vue'
+import DeviceCodePanel from '@/components/device-code-panel/index.vue'
 import LoadingButton from '@/components/loading-button/index.vue'
 import SettingsRow from '@/components/settings/row.vue'
 import SettingsSection from '@/components/settings/section.vue'
-import { useClipboard } from '@/composables/useClipboard'
 import { LLM_CLIENT_TYPE_LIST } from '@/constants/client-types'
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { toTypedSchema } from '@vee-validate/zod'
@@ -398,10 +364,8 @@ import type {
 } from '@memohai/sdk'
 import { useI18n } from 'vue-i18n'
 import { toast } from '@felinic/ui'
-import { startOAuthPopupFlow, type OAuthPopupFlowController } from '@/utils/oauth/popup-flow'
 
 const { t } = useI18n()
-const { copyText } = useClipboard()
 
 type ProviderWithAuth = Partial<ProvidersGetResponse>
 
@@ -434,6 +398,8 @@ const props = defineProps<{
   editLoading: boolean
 }>()
 
+const isCodexProvider = computed(() => props.provider?.client_type === 'openai-codex')
+
 const emit = defineEmits<{
   submit: [values: Record<string, unknown>]
 }>()
@@ -446,9 +412,6 @@ const oauthStatusLoading = ref(false)
 const authorizeLoading = ref(false)
 const revokeLoading = ref(false)
 const devicePollTimer = ref<number | null>(null)
-const webOAuthFlow = ref<OAuthPopupFlowController | null>(null)
-const webOAuthPollIntervalMs = 2000
-const webOAuthPollTimeoutMs = 5 * 60 * 1000
 
 const testStatus = computed(() => {
   if (testResult.value?.status === 'ok') return 'ok'
@@ -640,22 +603,41 @@ const editProvider = form.handleSubmit(async (value) => {
 })
 
 const oauthExpired = computed(() => Boolean(oauthStatus.value?.has_token && oauthStatus.value?.expired))
+const oauthConnected = computed(() => Boolean(oauthStatus.value?.has_token) && !oauthExpired.value)
+
+// 行标签按账号体系命名(用户的 outcome),而不是"设备授权"这类流程名。
+const accountLabel = computed(() =>
+  t(form.values.client_type === 'github-copilot' ? 'provider.oauth.githubAccount' : 'provider.oauth.chatgptAccount'),
+)
+
+const connectDescription = computed(() =>
+  t(form.values.client_type === 'github-copilot' ? 'provider.oauth.githubConnectHint' : 'provider.oauth.openaiConnectHint'),
+)
+
+// 连接后的身份行:优先邮箱/显示名,附 @login;两者皆空时由模板回退到"已连接"。
+const connectedIdentity = computed(() => {
+  const account = oauthStatus.value?.account
+  if (!account) return ''
+  const login = account.login?.trim()
+  return [
+    account.email?.trim() || account.label?.trim() || account.name?.trim() || '',
+    login ? `@${login}` : '',
+  ].filter(Boolean).join(' · ')
+})
+
+const devicePending = computed(() => Boolean(
+  oauthStatus.value?.mode === 'device'
+  && oauthStatus.value.device?.pending
+  && !oauthStatus.value.has_token
+  && oauthStatus.value.device.user_code
+  && oauthStatus.value.device.verification_uri,
+))
 
 function clearDevicePollTimer() {
   if (devicePollTimer.value !== null) {
     window.clearTimeout(devicePollTimer.value)
     devicePollTimer.value = null
   }
-}
-
-function clearWebPollTimer() {
-  webOAuthFlow.value?.cancel()
-  webOAuthFlow.value = null
-}
-
-function clearPollTimers() {
-  clearDevicePollTimer()
-  clearWebPollTimer()
 }
 
 async function fetchOAuthStatus(): Promise<ProvidersOAuthStatus | null> {
@@ -679,7 +661,7 @@ async function fetchOAuthStatus(): Promise<ProvidersOAuthStatus | null> {
 }
 
 async function pollOAuthAuthorization(notifyOnSuccess = false) {
-  if (!props.provider?.id || form.values.client_type !== 'github-copilot') return
+  if (!props.provider?.id || oauthStatus.value?.mode !== 'device') return
   try {
     const { data } = await postProvidersByIdOauthPoll({
       path: { id: props.provider.id },
@@ -700,10 +682,7 @@ async function pollOAuthAuthorization(notifyOnSuccess = false) {
 
 watch(oauthStatus, (status) => {
   clearDevicePollTimer()
-  if (form.values.client_type !== 'github-copilot') {
-    return
-  }
-  if (!status?.device?.pending || status.has_token) {
+  if (status?.mode !== 'device' || !status.device?.pending || status.has_token) {
     return
   }
   const intervalSeconds = Math.max(status.device.interval_seconds ?? 5, 1)
@@ -713,11 +692,16 @@ watch(oauthStatus, (status) => {
 })
 
 onBeforeUnmount(() => {
-  clearPollTimers()
+  clearDevicePollTimer()
 })
 
-function cancelWebOAuthAuthorization() {
-  webOAuthFlow.value?.cancel()
+// 前端本地取消:providers 侧没有 cancel API(ACP 有),只能清掉本地 device 状态、
+// 停掉轮询,服务端签发的码留给它自然过期。代价:刷新后 status 若仍带 pending 会
+// 重新展开 —— 已报备,待后端补 cancel endpoint 后在此接上。
+function cancelDeviceAuthorization() {
+  clearDevicePollTimer()
+  if (!oauthStatus.value) return
+  oauthStatus.value = { ...oauthStatus.value, device: undefined }
 }
 
 async function handleAuthorize() {
@@ -730,83 +714,27 @@ async function handleAuthorize() {
     })
     if (!data) throw new Error(t('provider.oauth.authorizeFailed'))
     const result = data as ProvidersOAuthAuthorizeResponse
-    if (result.mode === 'device') {
-      oauthStatus.value = {
-        configured: true,
-        mode: 'device',
-        has_token: false,
-        expired: false,
-        callback_url: '',
-        device: result.device,
-      }
-      authorizeLoading.value = false
-      return
+    if (result.mode !== 'device' || !result.device) {
+      throw new Error(t('provider.oauth.authorizeFailed'))
     }
-    if (!result.auth_url) throw new Error(t('provider.oauth.authorizeFailed'))
-    const popup = window.open(result.auth_url, 'provider-oauth', 'width=600,height=720')
-    if (!popup) throw new Error(t('provider.oauth.authorizeFailed'))
-    // Supersede any in-flight popup silently: dispose() (not cancel()) so the
-    // previous flow's onAborted doesn't clear this attempt's loading state or
-    // close the window we just reused.
-    webOAuthFlow.value?.dispose()
-    webOAuthFlow.value = startOAuthPopupFlow<ProvidersOAuthStatus>({
-      popup,
-      target: window,
-      expectedSource: popup,
-      messageType: 'memoh-provider-oauth-success',
-      pollIntervalMs: webOAuthPollIntervalMs,
-      timeoutMs: webOAuthPollTimeoutMs,
-      pollStatus: fetchOAuthStatus,
-      isAuthorized: status => Boolean(status?.has_token && !status.expired),
-      onAuthorized: async () => {
-        webOAuthFlow.value = null
-        toast.success(t('provider.oauth.authorizeSuccess'))
-        await fetchOAuthStatus()
-        authorizeLoading.value = false
-      },
-      onAborted: (reason) => {
-        webOAuthFlow.value = null
-        authorizeLoading.value = false
-        if (reason === 'timeout') {
-          toast.error(t('provider.oauth.authorizeTimedOut'))
-        }
-      },
-    })
+    oauthStatus.value = {
+      configured: true,
+      mode: 'device',
+      has_token: false,
+      expired: false,
+      callback_url: '',
+      device: result.device,
+    }
   } catch (error) {
-    clearWebPollTimer()
     toast.error(error instanceof Error ? error.message : t('provider.oauth.authorizeFailed'))
+  } finally {
     authorizeLoading.value = false
   }
 }
 
-async function handleCopyDeviceCode() {
-  const userCode = oauthStatus.value?.device?.user_code?.trim()
-  const verificationUri = oauthStatus.value?.device?.verification_uri?.trim()
-  if (!userCode || !verificationUri) return
-
-  const popup = window.open('', 'provider-device-oauth', 'width=960,height=720')
-  const copied = await copyText(userCode)
-
-  if (!copied) {
-    popup?.close()
-    toast.error(t('provider.oauth.copyFailed'))
-    return
-  }
-
-  toast.success(t('common.copied'))
-
-  if (popup) {
-    popup.location.href = verificationUri
-    popup.focus()
-    return
-  }
-
-  window.open(verificationUri, '_blank', 'width=960,height=720')
-}
-
 async function handleRevoke() {
   if (!props.provider?.id) return
-  clearPollTimers()
+  clearDevicePollTimer()
   revokeLoading.value = true
   try {
     await deleteProvidersByIdOauthToken({

--- a/apps/web/src/pages/providers/model-setting.vue
+++ b/apps/web/src/pages/providers/model-setting.vue
@@ -56,6 +56,7 @@
       <ModelList
         :provider-id="curProvider?.id"
         :models="modelDataList"
+        :managed="curProvider?.client_type === 'openai-codex'"
         :delete-model-loading="deleteModelLoading"
         @edit="handleEditModel"
         @delete="deleteModel"

--- a/db/postgres/migrations/0001_init.up.sql
+++ b/db/postgres/migrations/0001_init.up.sql
@@ -947,6 +947,7 @@ CREATE TABLE IF NOT EXISTS provider_oauth_tokens (
   token_type TEXT NOT NULL DEFAULT '',
   state TEXT NOT NULL DEFAULT '',
   pkce_code_verifier TEXT NOT NULL DEFAULT '',
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/db/postgres/migrations/0106_provider_oauth_metadata.down.sql
+++ b/db/postgres/migrations/0106_provider_oauth_metadata.down.sql
@@ -1,0 +1,4 @@
+-- 0106_provider_oauth_metadata
+-- Remove provider OAuth metadata storage.
+ALTER TABLE provider_oauth_tokens
+  DROP COLUMN IF EXISTS metadata;

--- a/db/postgres/migrations/0106_provider_oauth_metadata.up.sql
+++ b/db/postgres/migrations/0106_provider_oauth_metadata.up.sql
@@ -1,0 +1,4 @@
+-- 0106_provider_oauth_metadata
+-- Persist short-lived device authorization state and token-derived account metadata.
+ALTER TABLE provider_oauth_tokens
+  ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/db/postgres/queries/provider_oauth.sql
+++ b/db/postgres/queries/provider_oauth.sql
@@ -7,7 +7,8 @@ INSERT INTO provider_oauth_tokens (
   scope,
   token_type,
   state,
-  pkce_code_verifier
+  pkce_code_verifier,
+  metadata
 )
 VALUES (
   sqlc.arg(provider_id),
@@ -17,7 +18,8 @@ VALUES (
   sqlc.arg(scope),
   sqlc.arg(token_type),
   sqlc.arg(state),
-  sqlc.arg(pkce_code_verifier)
+  sqlc.arg(pkce_code_verifier),
+  sqlc.arg(metadata)
 )
 ON CONFLICT (provider_id) DO UPDATE SET
   access_token = EXCLUDED.access_token,
@@ -27,6 +29,7 @@ ON CONFLICT (provider_id) DO UPDATE SET
   token_type = EXCLUDED.token_type,
   state = EXCLUDED.state,
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
+  metadata = EXCLUDED.metadata,
   updated_at = now()
 RETURNING *;
 
@@ -37,15 +40,17 @@ SELECT * FROM provider_oauth_tokens WHERE provider_id = sqlc.arg(provider_id);
 SELECT * FROM provider_oauth_tokens WHERE state = sqlc.arg(state) AND state != '';
 
 -- name: UpdateProviderOAuthState :exec
-INSERT INTO provider_oauth_tokens (provider_id, state, pkce_code_verifier)
+INSERT INTO provider_oauth_tokens (provider_id, state, pkce_code_verifier, metadata)
 VALUES (
   sqlc.arg(provider_id),
   sqlc.arg(state),
-  sqlc.arg(pkce_code_verifier)
+  sqlc.arg(pkce_code_verifier),
+  sqlc.arg(metadata)
 )
 ON CONFLICT (provider_id) DO UPDATE SET
   state = EXCLUDED.state,
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
+  metadata = EXCLUDED.metadata,
   updated_at = now();
 
 -- name: DeleteProviderOAuthToken :exec

--- a/internal/db/postgres/sqlc/models.go
+++ b/internal/db/postgres/sqlc/models.go
@@ -562,6 +562,7 @@ type ProviderOauthToken struct {
 	TokenType        string             `json:"token_type"`
 	State            string             `json:"state"`
 	PkceCodeVerifier string             `json:"pkce_code_verifier"`
+	Metadata         []byte             `json:"metadata"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
 }

--- a/internal/db/postgres/sqlc/provider_oauth.sql.go
+++ b/internal/db/postgres/sqlc/provider_oauth.sql.go
@@ -21,7 +21,7 @@ func (q *Queries) DeleteProviderOAuthToken(ctx context.Context, providerID pgtyp
 }
 
 const getProviderOAuthTokenByProvider = `-- name: GetProviderOAuthTokenByProvider :one
-SELECT id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, created_at, updated_at FROM provider_oauth_tokens WHERE provider_id = $1
+SELECT id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at FROM provider_oauth_tokens WHERE provider_id = $1
 `
 
 func (q *Queries) GetProviderOAuthTokenByProvider(ctx context.Context, providerID pgtype.UUID) (ProviderOauthToken, error) {
@@ -37,6 +37,7 @@ func (q *Queries) GetProviderOAuthTokenByProvider(ctx context.Context, providerI
 		&i.TokenType,
 		&i.State,
 		&i.PkceCodeVerifier,
+		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -44,7 +45,7 @@ func (q *Queries) GetProviderOAuthTokenByProvider(ctx context.Context, providerI
 }
 
 const getProviderOAuthTokenByState = `-- name: GetProviderOAuthTokenByState :one
-SELECT id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, created_at, updated_at FROM provider_oauth_tokens WHERE state = $1 AND state != ''
+SELECT id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at FROM provider_oauth_tokens WHERE state = $1 AND state != ''
 `
 
 func (q *Queries) GetProviderOAuthTokenByState(ctx context.Context, state string) (ProviderOauthToken, error) {
@@ -60,6 +61,7 @@ func (q *Queries) GetProviderOAuthTokenByState(ctx context.Context, state string
 		&i.TokenType,
 		&i.State,
 		&i.PkceCodeVerifier,
+		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -67,15 +69,17 @@ func (q *Queries) GetProviderOAuthTokenByState(ctx context.Context, state string
 }
 
 const updateProviderOAuthState = `-- name: UpdateProviderOAuthState :exec
-INSERT INTO provider_oauth_tokens (provider_id, state, pkce_code_verifier)
+INSERT INTO provider_oauth_tokens (provider_id, state, pkce_code_verifier, metadata)
 VALUES (
   $1,
   $2,
-  $3
+  $3,
+  $4
 )
 ON CONFLICT (provider_id) DO UPDATE SET
   state = EXCLUDED.state,
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
+  metadata = EXCLUDED.metadata,
   updated_at = now()
 `
 
@@ -83,10 +87,16 @@ type UpdateProviderOAuthStateParams struct {
 	ProviderID       pgtype.UUID `json:"provider_id"`
 	State            string      `json:"state"`
 	PkceCodeVerifier string      `json:"pkce_code_verifier"`
+	Metadata         []byte      `json:"metadata"`
 }
 
 func (q *Queries) UpdateProviderOAuthState(ctx context.Context, arg UpdateProviderOAuthStateParams) error {
-	_, err := q.db.Exec(ctx, updateProviderOAuthState, arg.ProviderID, arg.State, arg.PkceCodeVerifier)
+	_, err := q.db.Exec(ctx, updateProviderOAuthState,
+		arg.ProviderID,
+		arg.State,
+		arg.PkceCodeVerifier,
+		arg.Metadata,
+	)
 	return err
 }
 
@@ -99,7 +109,8 @@ INSERT INTO provider_oauth_tokens (
   scope,
   token_type,
   state,
-  pkce_code_verifier
+  pkce_code_verifier,
+  metadata
 )
 VALUES (
   $1,
@@ -109,7 +120,8 @@ VALUES (
   $5,
   $6,
   $7,
-  $8
+  $8,
+  $9
 )
 ON CONFLICT (provider_id) DO UPDATE SET
   access_token = EXCLUDED.access_token,
@@ -119,8 +131,9 @@ ON CONFLICT (provider_id) DO UPDATE SET
   token_type = EXCLUDED.token_type,
   state = EXCLUDED.state,
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
+  metadata = EXCLUDED.metadata,
   updated_at = now()
-RETURNING id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, created_at, updated_at
+RETURNING id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at
 `
 
 type UpsertProviderOAuthTokenParams struct {
@@ -132,6 +145,7 @@ type UpsertProviderOAuthTokenParams struct {
 	TokenType        string             `json:"token_type"`
 	State            string             `json:"state"`
 	PkceCodeVerifier string             `json:"pkce_code_verifier"`
+	Metadata         []byte             `json:"metadata"`
 }
 
 func (q *Queries) UpsertProviderOAuthToken(ctx context.Context, arg UpsertProviderOAuthTokenParams) (ProviderOauthToken, error) {
@@ -144,6 +158,7 @@ func (q *Queries) UpsertProviderOAuthToken(ctx context.Context, arg UpsertProvid
 		arg.TokenType,
 		arg.State,
 		arg.PkceCodeVerifier,
+		arg.Metadata,
 	)
 	var i ProviderOauthToken
 	err := row.Scan(
@@ -156,6 +171,7 @@ func (q *Queries) UpsertProviderOAuthToken(ctx context.Context, arg UpsertProvid
 		&i.TokenType,
 		&i.State,
 		&i.PkceCodeVerifier,
+		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/internal/handlers/providers.go
+++ b/internal/handlers/providers.go
@@ -331,6 +331,8 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 	resp := providers.ImportModelsResponse{
 		Models: make([]string, 0),
 	}
+	managedCodex := models.ClientType(provider.ClientType) == models.ClientTypeOpenAICodex
+	availableModelIDs := make(map[string]struct{}, len(remoteModels))
 
 	// Bulk import lands disabled — the user picks which ones to expose in
 	// model pickers afterward, to avoid flooding bot config with dozens of
@@ -338,6 +340,7 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 	disabled := false
 
 	for _, m := range remoteModels {
+		availableModelIDs[m.ID] = struct{}{}
 		modelType := models.ModelTypeChat
 		if strings.TrimSpace(m.Type) == string(models.ModelTypeEmbedding) {
 			modelType = models.ModelTypeEmbedding
@@ -363,6 +366,10 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 			ThinkingMode:     m.ThinkingMode,
 			ContextWindow:    m.ContextWindow,
 			Dimensions:       m.Dimensions,
+		}
+		if managedCodex {
+			available := true
+			cfg.CatalogAvailable = &available
 		}
 		_, err := h.modelsService.Create(ctx, models.AddRequest{
 			ModelID:    m.ID,
@@ -390,8 +397,39 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 		resp.Created++
 		resp.Models = append(resp.Models, m.ID)
 	}
+	if managedCodex {
+		h.markUnavailableCodexModels(ctx, id, availableModelIDs)
+	}
 
 	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *ProvidersHandler) markUnavailableCodexModels(ctx context.Context, providerID string, available map[string]struct{}) {
+	existingModels, err := h.modelsService.ListByProviderID(ctx, providerID)
+	if err != nil {
+		h.logger.Warn("failed to list Codex models for catalog reconciliation", slog.Any("error", err))
+		return
+	}
+	for _, existing := range existingModels {
+		if _, ok := available[existing.ModelID]; ok {
+			continue
+		}
+		unavailable := false
+		if existing.Config.CatalogAvailable != nil && !*existing.Config.CatalogAvailable {
+			continue
+		}
+		config := existing.Config
+		config.CatalogAvailable = &unavailable
+		if _, err := h.modelsService.UpdateByProviderAndModelID(ctx, providerID, existing.ModelID, models.UpdateRequest{
+			ModelID:    existing.ModelID,
+			Name:       existing.Name,
+			ProviderID: existing.ProviderID,
+			Type:       existing.Type,
+			Config:     config,
+		}); err != nil {
+			h.logger.Warn("failed to mark stale Codex model unavailable", slog.String("model_id", existing.ModelID), slog.Any("error", err))
+		}
+	}
 }
 
 // fillExistingModel refreshes an existing model's capability-discovery fields
@@ -449,6 +487,10 @@ func mergeDiscoveredConfig(existing, discovered models.ModelConfig) (models.Mode
 	}
 	if discovered.ContextWindow != nil && (out.ContextWindow == nil || *discovered.ContextWindow != *out.ContextWindow) {
 		out.ContextWindow = discovered.ContextWindow
+		changed = true
+	}
+	if discovered.CatalogAvailable != nil && (out.CatalogAvailable == nil || *discovered.CatalogAvailable != *out.CatalogAvailable) {
+		out.CatalogAvailable = discovered.CatalogAvailable
 		changed = true
 	}
 	// Compatibilities are additive: keep anything already present and add the

--- a/internal/models/catalog_availability_test.go
+++ b/internal/models/catalog_availability_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+)
+
+func TestConvertToEnabledGetResponseListFiltersUnavailableCatalogModels(t *testing.T) {
+	t.Parallel()
+
+	available := true
+	unavailable := false
+	configJSON := func(value *bool) []byte {
+		data, err := json.Marshal(ModelConfig{CatalogAvailable: value})
+		if err != nil {
+			t.Fatalf("marshal model config: %v", err)
+		}
+		return data
+	}
+
+	service := &Service{logger: slog.Default()}
+	models := service.convertToEnabledGetResponseList([]sqlc.Model{
+		{ModelID: "legacy-model", Config: configJSON(nil)},
+		{ModelID: "available-model", Config: configJSON(&available)},
+		{ModelID: "unavailable-model", Config: configJSON(&unavailable)},
+	})
+
+	if len(models) != 2 {
+		t.Fatalf("models = %d, want 2", len(models))
+	}
+	if models[0].ModelID != "legacy-model" || models[1].ModelID != "available-model" {
+		t.Fatalf("unexpected enabled models: %#v", models)
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -163,7 +163,7 @@ func (s *Service) ListEnabled(ctx context.Context) ([]GetResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to list enabled models: %w", err)
 	}
-	return s.convertToGetResponseList(dbModels), nil
+	return s.convertToEnabledGetResponseList(dbModels), nil
 }
 
 // ListEnabledByType returns models from enabled providers filtered by type.
@@ -175,7 +175,7 @@ func (s *Service) ListEnabledByType(ctx context.Context, modelType ModelType) ([
 	if err != nil {
 		return nil, fmt.Errorf("failed to list enabled models by type: %w", err)
 	}
-	return s.convertToGetResponseList(dbModels), nil
+	return s.convertToEnabledGetResponseList(dbModels), nil
 }
 
 // ListEnabledByProviderClientType returns models from enabled providers with
@@ -188,7 +188,7 @@ func (s *Service) ListEnabledByProviderClientType(ctx context.Context, clientTyp
 	if err != nil {
 		return nil, fmt.Errorf("failed to list enabled models by provider client type: %w", err)
 	}
-	return s.convertToGetResponseList(dbModels), nil
+	return s.convertToEnabledGetResponseList(dbModels), nil
 }
 
 // ListByProviderID returns models filtered by provider ID.
@@ -447,6 +447,20 @@ func (s *Service) convertToGetResponseList(dbModels []sqlc.Model) []GetResponse 
 	responses := make([]GetResponse, 0, len(dbModels))
 	for _, dbModel := range dbModels {
 		responses = append(responses, s.convertToGetResponse(dbModel))
+	}
+	return responses
+}
+
+func (s *Service) convertToEnabledGetResponseList(dbModels []sqlc.Model) []GetResponse {
+	responses := make([]GetResponse, 0, len(dbModels))
+	for _, dbModel := range dbModels {
+		response := s.convertToGetResponse(dbModel)
+		// Catalog availability is independent from the user's enable choice. Keeping
+		// that choice stored lets a temporarily removed model return enabled later.
+		if response.Config.CatalogAvailable != nil && !*response.Config.CatalogAvailable {
+			continue
+		}
+		responses = append(responses, response)
 	}
 	return responses
 }

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -123,6 +123,7 @@ type ModelConfig struct {
 	ContextWindow    *int     `json:"context_window,omitempty"`
 	ReasoningEfforts []string `json:"reasoning_efforts,omitempty"`
 	ThinkingMode     string   `json:"thinking_mode,omitempty"`
+	CatalogAvailable *bool    `json:"catalog_available,omitempty"`
 }
 
 func normalizeModelConfig(config ModelConfig) ModelConfig {

--- a/internal/providers/credentials.go
+++ b/internal/providers/credentials.go
@@ -49,9 +49,16 @@ func (s *Service) ResolveModelCredentials(ctx context.Context, provider sqlc.Pro
 		if err != nil {
 			return ModelCredentials{}, err
 		}
-		accountID, err := codexAccountIDFromToken(token)
-		if err != nil {
-			return ModelCredentials{}, err
+		accountID, tokenErr := codexAccountIDFromToken(token)
+		if tokenErr != nil {
+			tokenRow, rowErr := s.getOAuthToken(ctx, provider.ID.String())
+			if rowErr != nil {
+				return ModelCredentials{}, tokenErr
+			}
+			accountID = strings.TrimSpace(stringValue(tokenRow.Metadata, metadataCodexAccountIDKey))
+			if accountID == "" {
+				return ModelCredentials{}, tokenErr
+			}
 		}
 		return ModelCredentials{
 			APIKey:         token,

--- a/internal/providers/oauth.go
+++ b/internal/providers/oauth.go
@@ -40,6 +40,7 @@ const (
 	defaultGitHubUserEmailsURL    = "https://api.github.com/user/emails"          //nolint:gosec // OAuth endpoint URL, not a credential
 	oauthExpirySkew               = 30 * time.Second
 	providerOAuthHTTPTimeout      = 15 * time.Second
+	openAICodexDeviceTimeout      = 15 * time.Minute
 	metadataOAuthClientIDKey      = "oauth_client_id"
 	metadataOAuthAuthorizeURLKey  = "oauth_authorize_url"
 	metadataOAuthDeviceCodeURLKey = "oauth_device_code_url"
@@ -53,6 +54,7 @@ const (
 	metadataDeviceVerifyURIKey    = "device_verification_uri"
 	metadataDeviceIntervalKey     = "device_interval_seconds"
 	metadataDeviceExpiresAtKey    = "device_expires_at"
+	metadataCodexAccountIDKey     = "codex_account_id"
 	metadataAccountLabelKey       = "account_label"
 	metadataAccountLoginKey       = "account_login"
 	metadataAccountNameKey        = "account_name"
@@ -255,6 +257,28 @@ func (s *Service) StartOAuthAuthorization(ctx context.Context, providerID string
 		return nil, err
 	}
 	cfg := s.oauthConfigForProvider(provider)
+	if models.ClientType(provider.ClientType) == models.ClientTypeOpenAICodex {
+		deviceAuth, err := s.StartOpenAICodexACPDeviceAuthorization(ctx)
+		if err != nil {
+			return nil, err
+		}
+		device := oauthDeviceMetadata{
+			DeviceCode:      deviceAuth.DeviceAuthID,
+			UserCode:        deviceAuth.UserCode,
+			VerificationURI: deviceAuth.VerificationURL,
+			ExpiresAt:       time.Now().Add(openAICodexDeviceTimeout),
+			IntervalSeconds: deviceAuth.IntervalSeconds,
+		}
+		// Starting a new login intentionally replaces an expired/old credential so
+		// status cannot report both "authorized" and a pending one-time code.
+		if err := s.saveOAuthToken(ctx, providerID, oauthTokenRecord{
+			ProviderID: providerID,
+			Metadata:   device.toMetadata(),
+		}); err != nil {
+			return nil, err
+		}
+		return &OAuthAuthorizeResponse{Mode: "device", Device: device.toStatus()}, nil
+	}
 
 	if isUserScopedOAuthProvider(provider) {
 		userID := oauthctx.UserIDFromContext(ctx)
@@ -293,7 +317,7 @@ func (s *Service) StartOAuthAuthorization(ctx context.Context, providerID string
 	if err != nil {
 		return nil, fmt.Errorf("generate code verifier: %w", err)
 	}
-	if err := s.updateOAuthState(ctx, providerID, state, codeVerifier); err != nil {
+	if err := s.updateOAuthState(ctx, providerID, state, codeVerifier, nil); err != nil {
 		return nil, err
 	}
 	params.Set("scope", cfg.Scopes)
@@ -695,7 +719,7 @@ func (s *Service) GetOAuthStatus(ctx context.Context, providerID string) (*OAuth
 	if !status.Configured {
 		return status, nil
 	}
-	if isUserScopedOAuthProvider(provider) {
+	if isUserScopedOAuthProvider(provider) || models.ClientType(provider.ClientType) == models.ClientTypeOpenAICodex {
 		status.Mode = "device"
 		status.CallbackURL = ""
 	}
@@ -724,8 +748,10 @@ func (s *Service) GetOAuthStatus(ctx context.Context, providerID string) (*OAuth
 		status.ExpiresAt = &expiresAt
 		status.Expired = time.Now().After(token.ExpiresAt)
 	}
-	if isUserScopedOAuthProvider(provider) {
+	if status.Mode == "device" {
 		status.Device = deviceMetadataFromMap(token.Metadata).toStatus()
+	}
+	if isUserScopedOAuthProvider(provider) {
 		account, accountErr := s.resolveGitHubOAuthAccount(ctx, providerID, userID, token)
 		if accountErr != nil {
 			return nil, accountErr
@@ -740,8 +766,11 @@ func (s *Service) PollOAuthAuthorization(ctx context.Context, providerID string)
 	if err != nil {
 		return nil, err
 	}
+	if models.ClientType(provider.ClientType) == models.ClientTypeOpenAICodex {
+		return s.pollOpenAICodexProviderAuthorization(ctx, provider)
+	}
 	if !isUserScopedOAuthProvider(provider) {
-		return nil, errors.New("device authorization is only supported for github copilot")
+		return nil, errors.New("provider does not support device authorization")
 	}
 
 	userID := oauthctx.UserIDFromContext(ctx)
@@ -808,6 +837,54 @@ func (s *Service) PollOAuthAuthorization(ctx context.Context, providerID string)
 		Scope:        firstNonEmpty(resp.Scope, token.Scope),
 		TokenType:    firstNonEmpty(resp.TokenType, "bearer"),
 		Metadata:     account.toMetadata(),
+	}); err != nil {
+		return nil, err
+	}
+	return s.GetOAuthStatus(ctx, providerID)
+}
+
+func (s *Service) pollOpenAICodexProviderAuthorization(ctx context.Context, provider sqlc.Provider) (*OAuthStatus, error) {
+	providerID := provider.ID.String()
+	token, err := s.getOAuthToken(ctx, providerID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return s.GetOAuthStatus(ctx, providerID)
+		}
+		return nil, err
+	}
+	device := deviceMetadataFromMap(token.Metadata)
+	if strings.TrimSpace(device.DeviceCode) == "" {
+		return s.GetOAuthStatus(ctx, providerID)
+	}
+	if !device.ExpiresAt.IsZero() && time.Now().After(device.ExpiresAt) {
+		if err := s.updateOAuthState(ctx, providerID, "", "", nil); err != nil {
+			return nil, err
+		}
+		return s.GetOAuthStatus(ctx, providerID)
+	}
+
+	poll, err := s.PollOpenAICodexACPDeviceAuthorization(ctx, device.DeviceCode, device.UserCode)
+	if err != nil {
+		return nil, err
+	}
+	if poll.Pending {
+		return s.GetOAuthStatus(ctx, providerID)
+	}
+	credentials, err := s.ExchangeOpenAICodexACPDeviceCode(ctx, poll.AuthorizationCode, poll.CodeVerifier)
+	if err != nil {
+		return nil, err
+	}
+	metadata := map[string]any{}
+	if credentials.AccountID != "" {
+		metadata[metadataCodexAccountIDKey] = credentials.AccountID
+	}
+	if err := s.saveOAuthToken(ctx, providerID, oauthTokenRecord{
+		ProviderID:   providerID,
+		AccessToken:  credentials.AccessToken,
+		RefreshToken: credentials.RefreshToken,
+		ExpiresAt:    credentials.ExpiresAt,
+		TokenType:    "Bearer",
+		Metadata:     metadata,
 	}); err != nil {
 		return nil, err
 	}
@@ -959,7 +1036,7 @@ func (s *Service) getOAuthTokenByState(ctx context.Context, state string) (*oaut
 	return toProviderOAuthToken(row), nil
 }
 
-func (s *Service) updateOAuthState(ctx context.Context, providerID, state, codeVerifier string) error {
+func (s *Service) updateOAuthState(ctx context.Context, providerID, state, codeVerifier string, metadata map[string]any) error {
 	providerUUID, err := db.ParseUUID(providerID)
 	if err != nil {
 		return err
@@ -968,6 +1045,7 @@ func (s *Service) updateOAuthState(ctx context.Context, providerID, state, codeV
 		ProviderID:       providerUUID,
 		State:            state,
 		PkceCodeVerifier: codeVerifier,
+		Metadata:         metadataJSON(metadata),
 	})
 }
 
@@ -989,6 +1067,7 @@ func (s *Service) saveOAuthToken(ctx context.Context, providerID string, token o
 		TokenType:        token.TokenType,
 		State:            token.State,
 		PkceCodeVerifier: token.PKCECodeVerifier,
+		Metadata:         metadataJSON(token.Metadata),
 	})
 	return err
 }
@@ -1090,7 +1169,7 @@ func toProviderOAuthToken(row sqlc.ProviderOauthToken) *oauthTokenRecord {
 		TokenType:        row.TokenType,
 		State:            row.State,
 		PKCECodeVerifier: row.PkceCodeVerifier,
-		Metadata:         map[string]any{},
+		Metadata:         providerMetadata(row.Metadata),
 	}
 	if row.ExpiresAt.Valid {
 		token.ExpiresAt = row.ExpiresAt.Time

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -2327,6 +2327,7 @@ export type ModelsGetResponse = {
 };
 
 export type ModelsModelConfig = {
+    catalog_available?: boolean;
     compatibilities?: Array<string>;
     context_window?: number;
     description?: string;

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -18897,6 +18897,9 @@ const docTemplate = `{
         "models.ModelConfig": {
             "type": "object",
             "properties": {
+                "catalog_available": {
+                    "type": "boolean"
+                },
                 "compatibilities": {
                     "type": "array",
                     "items": {

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -18888,6 +18888,9 @@
         "models.ModelConfig": {
             "type": "object",
             "properties": {
+                "catalog_available": {
+                    "type": "boolean"
+                },
                 "compatibilities": {
                     "type": "array",
                     "items": {

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -3877,6 +3877,8 @@ definitions:
     type: object
   models.ModelConfig:
     properties:
+      catalog_available:
+        type: boolean
       compatibilities:
         items:
           type: string


### PR DESCRIPTION
## Summary

**Backend**
- Device-code OAuth flow (RFC 8628) for `openai-codex` providers: authorize / poll / status endpoints, device session persisted in provider OAuth metadata (migration `0106_provider_oauth_metadata`, canonical `0001` updated in step)
- Managed model catalog refresh for Codex providers (`Refresh Models`) reusing the live catalog from #777; models removed upstream are marked unavailable and excluded from enabled model lists without losing the user's enable preference
- Removed the web popup OAuth path for providers — device mode is the only flow

**Web**
- Provider OAuth card rebuilt in the refactored design language: a single account row (`SettingsSection`/`SettingsRow`) whose trailing control is a three-state toggle — **Connect → Connecting → Cancel** — width-tweened by the new `LabelSwap` primitive; card growth/collapse animated by `AutoHeight`
- New **`DeviceCodePanel`** owner (registered in the ui-owners skill): hero one-time code, a single *Copy & Open* action (tab opened synchronously inside the user gesture to survive popup blockers, clipboard verified before navigation), visibility-guarded mm:ss countdown, expired → retry in place. Legacy same-shape call sites (bots ACP panel, onboarding Step4) noted for follow-up migration
- Revoke gated behind `ConfirmPopover`; pending device flow cancellable client-side (no provider cancel API yet — noted in-code; server code expires naturally)
- Panel copy moved to a `deviceCode.*` i18n namespace (en/zh/ja); orphaned `provider.oauth.*` keys removed

## Dependencies

**memohai/ui#4** is merged. The submodule pointer references its squash commit `26c702e` (LabelSwap primitive + Button gap forwarding).

## Test plan

- [x] Go lint + full test suite (pre-commit; one pre-existing flaky watchdog timing test noted, passes standalone)
- [x] Web: eslint, vue-tsc, vitest 754/754, `check-ui-contract.mjs` clean
- [ ] Manual: Codex provider connect → verification page → paste code → auto-completes to connected row; cancel mid-flow; code expiry → retry; revoke with confirm
- [ ] Manual: GitHub Copilot device flow regression (shares the same card)
- [ ] Visual: dark mode, narrow + zh/ja, LabelSwap width transition & icon gap, Connecting spinner state