### PR TITLE
fix(web): keep the optimistic user turn through the first-send history race

### DIFF
--- a/apps/web/src/store/chat/transcript.test.ts
+++ b/apps/web/src/store/chat/transcript.test.ts
@@ -244,6 +244,58 @@ describe('chat transcript controller', () => {
     expect(tool.done).toBe(true)
   })
 
+  it('keeps optimistic turns the initial-history snapshot does not contain yet', async () => {
+    // First send from a draft: promoteDraftChatView starts the per-session
+    // SSE, whose prepare step refreshes history. That fetch can resolve
+    // AFTER the optimistic user+assistant turns were appended but BEFORE the
+    // server persisted the send — the snapshot comes back empty. The refresh
+    // replace must carry the unmatched optimistic turns over instead of
+    // blanking the user's own message until the stream-end refresh.
+    const { transcript, fetchMessages } = makeTranscript()
+    const pending = deferred<UITurn[]>()
+    fetchMessages.mockReturnValueOnce(pending.promise)
+
+    const loading = transcript.loadInitialMessages('bot-1', 'session-1')
+    const assistantTurn = transcript.createOptimisticAssistantTurn()
+    const userTurn = transcript.createOptimisticUserTurn('hello first')
+    transcript.appendToView(userTurn, assistantTurn)
+
+    pending.resolve([])
+    await loading
+    // The user turn is carried over by the replace itself; the streaming
+    // assistant is restored by the caller's reattach step (chat-list's
+    // prepareSessionMessages finally block), mirrored here.
+    transcript.reattachTurnToSession('bot-1', 'session-1', assistantTurn)
+
+    expect(transcript.messages.map(turn => turn.role)).toEqual(['user', 'assistant'])
+    expect(transcript.messages[0]).toMatchObject({ role: 'user', text: 'hello first' })
+  })
+
+  it('adopts carried-over optimistic turns once the snapshot contains their server twins', async () => {
+    const { transcript, fetchMessages } = makeTranscript()
+    // Round 1: optimistic turns survive an empty snapshot (as above).
+    fetchMessages.mockResolvedValueOnce([])
+    const loading = transcript.loadInitialMessages('bot-1', 'session-1')
+    const assistantTurn = transcript.createOptimisticAssistantTurn()
+    const userTurn = transcript.createOptimisticUserTurn('hello first')
+    transcript.appendToView(userTurn, assistantTurn)
+    await loading
+
+    // Round 2 (stream-end refresh): the server now returns persisted twins —
+    // no duplicates, the optimistic pair collapses into the server rows.
+    // Server timestamps sit next to the optimistic client clock (the twin
+    // match tolerates 5s of skew), unlike the fixed dates used elsewhere.
+    const now = new Date().toISOString()
+    fetchMessages.mockResolvedValueOnce([
+      rawUser('server-user', 'hello first', now),
+      rawAssistant('server-assistant', [], now),
+    ])
+    await transcript.refreshCurrentSession('bot-1', 'session-1')
+
+    expect(transcript.messages.map(turn => turn.role)).toEqual(['user', 'assistant'])
+    expect(transcript.messages.filter(turn => turn.role === 'user')).toHaveLength(1)
+  })
+
   it('owns refresh state and reports the latest applied timestamp', async () => {
     const { transcript, fetchMessages } = makeTranscript()
     const onRefreshApplied = vi.fn()

--- a/apps/web/src/store/chat/transcript.test.ts
+++ b/apps/web/src/store/chat/transcript.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { ref, toRaw } from 'vue'
 import type { UIMessage, UITurn } from '@/composables/api/useChat.types'
+import { isOptimisticTurn } from '@/store/chat-list.normalize'
 import { createBackgroundTaskTracker } from './background-tasks'
 import { createTranscriptController } from './transcript'
 import type { ChatAssistantTurn, ChatUserTurn, ToolCallBlock } from './types'
@@ -294,6 +295,36 @@ describe('chat transcript controller', () => {
 
     expect(transcript.messages.map(turn => turn.role)).toEqual(['user', 'assistant'])
     expect(transcript.messages.filter(turn => turn.role === 'user')).toHaveLength(1)
+  })
+
+  it('does not let an older persisted twin swallow a re-sent optimistic prompt', async () => {
+    // The user sends the SAME text again in a session whose history already
+    // contains that prompt. The racing snapshot returns only the OLD row —
+    // the new send is not persisted yet. A text-set match would treat the
+    // new optimistic turn as "already present" and drop it; the count-based
+    // match reserves the old row for the old (non-optimistic) local turn.
+    const { transcript, fetchMessages } = makeTranscript()
+    transcript.replaceHistoryView([
+      rawUser('server-user-old', 'same prompt', '2026-01-01T00:00:00.000Z'),
+      rawAssistant('server-assistant-old', [], '2026-01-01T00:00:01.000Z'),
+    ], 'session-1')
+
+    const pending = deferred<UITurn[]>()
+    fetchMessages.mockReturnValueOnce(pending.promise)
+    const loading = transcript.loadInitialMessages('bot-1', 'session-1')
+    const assistantTurn = transcript.createOptimisticAssistantTurn()
+    const userTurn = transcript.createOptimisticUserTurn('same prompt')
+    transcript.appendToView(userTurn, assistantTurn)
+
+    pending.resolve([
+      rawUser('server-user-old', 'same prompt', '2026-01-01T00:00:00.000Z'),
+      rawAssistant('server-assistant-old', [], '2026-01-01T00:00:01.000Z'),
+    ])
+    await loading
+    transcript.reattachTurnToSession('bot-1', 'session-1', assistantTurn)
+
+    expect(transcript.messages.map(turn => `${turn.role}${isOptimisticTurn(turn) ? '*' : ''}`))
+      .toEqual(['user', 'assistant', 'user*', 'assistant*'])
   })
 
   it('owns refresh state and reports the latest applied timestamp', async () => {

--- a/apps/web/src/store/chat/transcript.ts
+++ b/apps/web/src/store/chat/transcript.ts
@@ -358,14 +358,35 @@ export function createTranscriptController({
       if (sendInFlight) {
         // Text match (not isSameLogicalTurn): its 5s timestamp tolerance can
         // reject a genuine server twin (clock skew, slow persist), which
-        // would duplicate the user turn here.
-        const nextUserTexts = new Set(
-          next.filter(turn => turn.role === 'user').map(turn => turn.text.trim()),
-        )
-        const orphans = messages.filter(turn =>
-          isOptimisticTurn(turn)
-          && turn.role === 'user'
-          && !nextUserTexts.has(turn.text.trim()))
+        // would duplicate the user turn here. Counted per occurrence, not a
+        // set: the snapshot absorbs one optimistic turn per matching row, so
+        // re-sending a prompt whose text already exists in history does not
+        // get swallowed by its older persisted twin.
+        const nextUserTextCounts = new Map<string, number>()
+        for (const turn of next) {
+          if (turn.role !== 'user') continue
+          const text = turn.text.trim()
+          nextUserTextCounts.set(text, (nextUserTextCounts.get(text) ?? 0) + 1)
+        }
+        // The snapshot's rows first cover the user turns that were already
+        // non-optimistic locally (they ARE those rows, minus paging drift);
+        // only the remainder can absorb optimistic turns.
+        for (const turn of messages) {
+          if (turn.role !== 'user' || isOptimisticTurn(turn)) continue
+          const text = turn.text.trim()
+          const left = nextUserTextCounts.get(text)
+          if (left) nextUserTextCounts.set(text, left - 1)
+        }
+        const orphans = messages.filter((turn) => {
+          if (!isOptimisticTurn(turn) || turn.role !== 'user') return false
+          const text = turn.text.trim()
+          const left = nextUserTextCounts.get(text)
+          if (left) {
+            nextUserTextCounts.set(text, left - 1)
+            return false
+          }
+          return true
+        })
         messages.splice(0, messages.length, ...next, ...orphans)
         return
       }

--- a/apps/web/src/store/chat/transcript.ts
+++ b/apps/web/src/store/chat/transcript.ts
@@ -339,10 +339,37 @@ export function createTranscriptController({
     }
   }
 
-  function replaceMessages(items: UITurn[], targetSessionId?: string) {
+  function replaceMessages(items: UITurn[], targetSessionId?: string, options: { preserveOptimistic?: boolean } = {}) {
     onSnapshot(targetSessionId, items)
     const next = normalizeTurns(items, targetSessionId)
     adoptRenderIdentity(next)
+    if (options.preserveOptimistic) {
+      // A refresh snapshot can race the server persisting a just-sent turn:
+      // the first-send history fetch resolves after the optimistic user turn
+      // was appended but before the server has stored it, so the snapshot
+      // comes back without it. Carry unmatched optimistic USER turns over —
+      // assistants are excluded because the live stream re-attaches its own
+      // turn (reattachTurnToSession) and carrying it here would duplicate it
+      // against a persisted twin. Gated on an in-flight send (a streaming
+      // optimistic assistant): once the stream settled, the snapshot is
+      // authoritative and failed sends must not resurrect their turns.
+      const sendInFlight = messages.some(turn =>
+        isOptimisticTurn(turn) && turn.role === 'assistant' && turn.streaming)
+      if (sendInFlight) {
+        // Text match (not isSameLogicalTurn): its 5s timestamp tolerance can
+        // reject a genuine server twin (clock skew, slow persist), which
+        // would duplicate the user turn here.
+        const nextUserTexts = new Set(
+          next.filter(turn => turn.role === 'user').map(turn => turn.text.trim()),
+        )
+        const orphans = messages.filter(turn =>
+          isOptimisticTurn(turn)
+          && turn.role === 'user'
+          && !nextUserTexts.has(turn.text.trim()))
+        messages.splice(0, messages.length, ...next, ...orphans)
+        return
+      }
+    }
     messages.splice(0, messages.length, ...next)
   }
 
@@ -429,7 +456,11 @@ export function createTranscriptController({
       if (hasLoadedOlder.value) {
         mergeMessages(turns, sid)
       } else {
-        replaceMessages(turns, sid)
+        // preserveOptimistic: this refresh races the server persisting a
+        // just-sent turn (first send from a draft resolves history while the
+        // user message is still only optimistic locally) — a plain replace
+        // would blank the user's own message until the next refresh.
+        replaceMessages(turns, sid, { preserveOptimistic: true })
         // The API pages raw DB rows but returns merged UI turns, so a short
         // page is not proof that history ended. Only pagination can settle it.
         hasMoreOlder.value = true


### PR DESCRIPTION
## Summary

First send from the welcome-page draft loses the user's own message until the assistant finishes. Regression window: every first send in a fresh draft since #779.

Mechanism:
1. First send promotes the draft; `promoteDraftChatView` starts the per-session messages SSE.
2. The SSE prepare step fetches history. The server has not persisted the just-sent user message yet, so the snapshot comes back **empty** — and it resolves *after* the optimistic user+assistant turns were appended.
3. `replaceMessages()` blanks the transcript. The assistant turn is rescued by the stream-reattach path; the user turn has no rescue, so it vanishes until the stream-end refresh returns the persisted row.

Console trace from a live repro (user turn drops at the empty-snapshot replace, returns with the persisted rows):

```
[+5046ms] msgs=[user:... | assistant*:...] loadingMsgs=true
[+5254ms] msgs=[assistant*:...]            loadingMsgs=false   <- user turn wiped
[+8653ms] msgs=[user:server | assistant:server]                <- back after persist
```

## Fix

`refreshCurrentSession`'s replace branch carries over unmatched optimistic **user** turns, with two guards:

- Only while the send is in flight (a streaming optimistic assistant is present) — settled failures stay authoritative, failed sends are not resurrected.
- Matched by trimmed text against the snapshot's user turns, so a genuine server twin never duplicates (isSameLogicalTurn's 5s timestamp tolerance can reject a real twin under clock skew).

Assistant turns are deliberately excluded — the live stream re-attaches its own turn and carrying it here would duplicate it against a persisted twin.

## Test plan

- [x] 2 new transcript unit tests: optimistic user turn survives an empty initial snapshot; carried-over turn collapses into its server twin on the next refresh (no duplicate)
- [x] Full vitest suite green (847/847 on the refactor branch, 167/167 for the affected files on this branch)
- [x] Manually reproduced before / verified after in the browser