### PR TITLE
feat(agent): support idle-aware background waits

### DIFF
--- a/internal/agent/background/manager.go
+++ b/internal/agent/background/manager.go
@@ -26,6 +26,12 @@ const (
 	MaxExecTimeout int32 = 600
 	// BackgroundExecTimeout is the timeout for background tasks (30 minutes).
 	BackgroundExecTimeout int32 = 1800
+	// DefaultWaitTimeout bounds a single wait_until call. The task keeps
+	// running afterwards; callers re-wait to keep observing.
+	DefaultWaitTimeout = 120 * time.Second
+	// DefaultIdleThreshold is how long an exec task's output must stay quiet
+	// before a waiter is woken with WaitIdle.
+	DefaultIdleThreshold = 20 * time.Second
 	// DefaultCleanupInterval is how often the manager prunes old completed tasks.
 	DefaultCleanupInterval = time.Hour
 	// DefaultTaskRetention is how long completed tasks are retained in memory.
@@ -582,27 +588,63 @@ func (m *Manager) KillForSession(botID, sessionID, taskID string) error {
 }
 
 // WaitForSessionTask waits until a task reaches a terminal state or needs
-// attention. It returns the current snapshot when the task is completed,
-// failed, killed, or stalled.
-func (m *Manager) WaitForSessionTask(ctx context.Context, botID, sessionID, taskID string) (TaskSnapshot, error) {
+// attention, and reports why the wait ended. Besides completed/failed/killed/
+// stalled, a running exec task whose output stays quiet for idleThreshold
+// returns WaitIdle — the signal that a server-style command has settled and
+// its ready banner is in the output tail. idleThreshold <= 0 disables idle
+// wake-ups; non-exec kinds (agent, spawn, video) have no output stream, so
+// idle never applies to them.
+func (m *Manager) WaitForSessionTask(ctx context.Context, botID, sessionID, taskID string, idleThreshold time.Duration) (TaskSnapshot, WaitOutcome, error) {
 	task := m.GetForSession(botID, sessionID, taskID)
 	if task == nil {
-		return TaskSnapshot{}, fmt.Errorf("task %s not found", taskID)
+		return TaskSnapshot{}, "", fmt.Errorf("task %s not found", taskID)
 	}
 	for {
 		task.mu.Lock()
 		status := task.Status
 		stalled := task.stalled && status == TaskRunning
-		done := status == TaskCompleted || status == TaskFailed || status == TaskKilled || stalled
+		kind := task.Kind
+		lastOutputAt := task.lastOutputAt
+		if lastOutputAt.IsZero() {
+			lastOutputAt = task.StartedAt
+		}
 		ch := task.changeChanLocked()
 		task.mu.Unlock()
-		if done {
-			return task.Snapshot(), nil
+
+		switch {
+		case status == TaskCompleted:
+			return task.Snapshot(), WaitCompleted, nil
+		case status == TaskFailed:
+			return task.Snapshot(), WaitFailed, nil
+		case status == TaskKilled:
+			return task.Snapshot(), WaitKilled, nil
+		case stalled:
+			return task.Snapshot(), WaitStalled, nil
+		}
+
+		var idleC <-chan time.Time
+		var idleTimer *time.Timer
+		if idleThreshold > 0 && kind == KindExec && status == TaskRunning {
+			remaining := time.Until(lastOutputAt.Add(idleThreshold))
+			if remaining <= 0 {
+				return task.Snapshot(), WaitIdle, nil
+			}
+			idleTimer = time.NewTimer(remaining)
+			idleC = idleTimer.C
 		}
 		select {
 		case <-ctx.Done():
-			return task.Snapshot(), ctx.Err()
+			if idleTimer != nil {
+				idleTimer.Stop()
+			}
+			return task.Snapshot(), "", ctx.Err()
 		case <-ch:
+			if idleTimer != nil {
+				idleTimer.Stop()
+			}
+		case <-idleC:
+			// Re-loop: output may have grown since the timer was armed, in
+			// which case the next iteration re-arms with the new deadline.
 		}
 	}
 }

--- a/internal/agent/background/manager_test.go
+++ b/internal/agent/background/manager_test.go
@@ -31,12 +31,12 @@ func TestSpawnCompletesAndWaits(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	snap, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID)
+	snap, outcome, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}
-	if snap.Status != TaskCompleted {
-		t.Fatalf("status = %s, want completed", snap.Status)
+	if snap.Status != TaskCompleted || outcome != WaitCompleted {
+		t.Fatalf("status = %s outcome = %s, want completed", snap.Status, outcome)
 	}
 	if snap.OutputTail != "ok\n" {
 		t.Fatalf("output tail = %q, want ok", snap.OutputTail)
@@ -61,12 +61,12 @@ func TestSpawnFailurePreservesUnknownExitCode(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	snap, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID)
+	snap, outcome, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}
-	if snap.Status != TaskFailed {
-		t.Fatalf("status = %s, want failed", snap.Status)
+	if snap.Status != TaskFailed || outcome != WaitFailed {
+		t.Fatalf("status = %s outcome = %s, want failed", snap.Status, outcome)
 	}
 	if snap.ExitCode != -1 {
 		t.Fatalf("exit code = %d, want -1", snap.ExitCode)
@@ -95,7 +95,7 @@ func TestKillWakesWaiter(t *testing.T) {
 	done := make(chan TaskSnapshot, 1)
 	errCh := make(chan error, 1)
 	go func() {
-		snap, err := mgr.WaitForSessionTask(waitCtx, "bot1", "sess1", taskID)
+		snap, _, err := mgr.WaitForSessionTask(waitCtx, "bot1", "sess1", taskID, 0)
 		if err != nil {
 			errCh <- err
 			return
@@ -144,12 +144,62 @@ func TestWaitForSessionTaskReturnsStalled(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	snap, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID)
+	snap, outcome, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}
-	if !snap.Stalled || snap.Status != TaskRunning {
-		t.Fatalf("snapshot = %+v, want running stalled task", snap)
+	if !snap.Stalled || snap.Status != TaskRunning || outcome != WaitStalled {
+		t.Fatalf("snapshot = %+v outcome = %s, want running stalled task", snap, outcome)
+	}
+	_ = mgr.Kill(taskID)
+}
+
+func TestWaitForSessionTaskReturnsIdleWhenOutputSettles(t *testing.T) {
+	mgr := New(nil)
+	taskID, _ := mgr.Spawn(
+		context.Background(),
+		"bot1",
+		"sess1",
+		"npm run dev",
+		"/data",
+		"Dev server",
+		func(ctx context.Context, _, _ string, _ int32) (*bridge.ExecResult, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		nil,
+		nil,
+	)
+	mgr.RecordOutput(taskID, "stdout", "VITE ready\n  ➜  Local: http://localhost:5173/\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	snap, outcome, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForSessionTask returned error: %v", err)
+	}
+	if outcome != WaitIdle {
+		t.Fatalf("outcome = %s, want idle", outcome)
+	}
+	if snap.Status != TaskRunning {
+		t.Fatalf("status = %s, want running", snap.Status)
+	}
+	if !strings.Contains(snap.OutputTail, "localhost:5173") {
+		t.Fatalf("output tail = %q, want ready banner", snap.OutputTail)
+	}
+	_ = mgr.Kill(taskID)
+}
+
+func TestWaitForSessionTaskIdleIgnoresNonExecTasks(t *testing.T) {
+	mgr := New(nil)
+	taskID, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "long spawn")
+	if err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if _, _, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 20*time.Millisecond); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want deadline exceeded (idle must not fire for spawn tasks)", err)
 	}
 	_ = mgr.Kill(taskID)
 }

--- a/internal/agent/background/spawn_task_test.go
+++ b/internal/agent/background/spawn_task_test.go
@@ -24,7 +24,7 @@ func TestCompleteAgentTaskStoresResultAndWakesWaiter(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	snap, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID)
+	snap, _, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestCompleteSpawnTaskStoresBranches(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	snap, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID)
+	snap, _, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}

--- a/internal/agent/background/types.go
+++ b/internal/agent/background/types.go
@@ -41,13 +41,31 @@ type Task struct {
 	StartedAt      time.Time
 	CompletedAt    time.Time
 
-	mu       sync.Mutex
-	cancel   context.CancelFunc
-	stalled  bool            // true once the task appears stuck on interactive input
-	changed  chan struct{}   // closed and replaced whenever waiters should re-check task state
-	output   strings.Builder // buffered output tail
-	branches []SpawnBranch   // spawn-kind branch outcomes, set at completion
+	mu           sync.Mutex
+	cancel       context.CancelFunc
+	stalled      bool            // true once the task appears stuck on interactive input
+	changed      chan struct{}   // closed and replaced whenever waiters should re-check task state
+	output       strings.Builder // buffered output tail
+	lastOutputAt time.Time       // when output last grew; zero means no output yet
+	branches     []SpawnBranch   // spawn-kind branch outcomes, set at completion
 }
+
+// WaitOutcome explains why a wait on a task returned.
+type WaitOutcome string
+
+const (
+	WaitCompleted WaitOutcome = "completed"
+	WaitFailed    WaitOutcome = "failed"
+	WaitKilled    WaitOutcome = "killed"
+	WaitStalled   WaitOutcome = "stalled"
+	// WaitIdle means the command is still running but produced no new output
+	// for the idle threshold — for server-style commands this usually means
+	// startup is done and the ready banner is already in the output tail.
+	WaitIdle WaitOutcome = "idle"
+	// WaitTimeout is never returned by the manager itself; the tool layer uses
+	// it when the caller-supplied wait budget elapses before any other outcome.
+	WaitTimeout WaitOutcome = "timeout"
+)
 
 // TaskSnapshot is a lock-safe, immutable view of a task for handler/UI code.
 type TaskSnapshot struct {
@@ -72,6 +90,7 @@ type TaskSnapshot struct {
 	Branches       []SpawnBranch
 	StartedAt      time.Time
 	CompletedAt    time.Time
+	LastOutputAt   time.Time
 	Duration       time.Duration
 	Stalled        bool
 }
@@ -110,6 +129,7 @@ func (t *Task) Snapshot() TaskSnapshot {
 		Branches:       append([]SpawnBranch(nil), t.branches...),
 		StartedAt:      t.StartedAt,
 		CompletedAt:    t.CompletedAt,
+		LastOutputAt:   t.lastOutputAt,
 		Duration:       duration,
 		Stalled:        t.stalled && t.Status == TaskRunning,
 	}
@@ -146,6 +166,7 @@ func (t *Task) AppendOutput(s string) {
 
 func (t *Task) appendOutputLocked(s string) {
 	t.output.WriteString(s)
+	t.lastOutputAt = time.Now()
 	// Keep tail bounded
 	if t.output.Len() > maxTailBytes*2 {
 		tail := t.output.String()

--- a/internal/agent/background/video_task_test.go
+++ b/internal/agent/background/video_task_test.go
@@ -29,7 +29,7 @@ func TestVideoTaskCompletesStoresResultAndWakesWaiter(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	snap, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID)
+	snap, _, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}

--- a/internal/agent/background_exec_e2e_test.go
+++ b/internal/agent/background_exec_e2e_test.go
@@ -357,7 +357,7 @@ func TestE2E_ForegroundTimeoutFlip(t *testing.T) {
 	// Wait for the background task to complete and verify the snapshot result.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	snap, err := bgMgr.WaitForSessionTask(ctx, "bot-test-2", "sess-2", taskID)
+	snap, _, err := bgMgr.WaitForSessionTask(ctx, "bot-test-2", "sess-2", taskID, 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}

--- a/internal/agent/tools/background.go
+++ b/internal/agent/tools/background.go
@@ -17,6 +17,11 @@ import (
 const (
 	maxWaitDuration                = 300 * time.Second
 	backgroundWaitProgressInterval = 30 * time.Second
+
+	minWaitUntilTimeout = 1 * time.Second
+	maxWaitUntilTimeout = 600 * time.Second
+	minIdleTimeout      = 1 * time.Second
+	maxIdleTimeout      = 300 * time.Second
 )
 
 // BackgroundProvider exposes background task observation and control tools.
@@ -39,7 +44,7 @@ func (*BackgroundProvider) Usage(_ context.Context, _ SessionContext, available 
 		parts = append(parts, ref+": wait for a short fixed duration when there is no specific task to observe")
 	}
 	if ref, ok := available.Ref(ToolWaitUntil()); ok {
-		parts = append(parts, ref+": wait for a background task to complete, fail, be killed, or appear stalled")
+		parts = append(parts, ref+": observe a background task until it finishes, stalls, goes quiet (idle), or the wait times out")
 	}
 	if ref, ok := available.Ref(ToolGetBackgroundStatus()); ok {
 		parts = append(parts, ref+": inspect a background task and read its result")
@@ -50,7 +55,7 @@ func (*BackgroundProvider) Usage(_ context.Context, _ SessionContext, available 
 	if len(parts) == 0 {
 		return ""
 	}
-	parts = append(parts, "After starting long work in the background, call `wait_until(task_id)` and then `get_background_status(task_id)` to read `result`.")
+	parts = append(parts, "After starting long work in the background, call `wait_until(task_id)`: it returns with a `reason` (completed/failed/killed/stalled/idle/timeout) and the latest `output_tail`. For finite work (installs, builds, tests), re-wait until it completes, then read `result` via `get_background_status(task_id)`. For servers/watchers that never exit, `reason: \"idle\"` with a ready message in `output_tail` means the service is up — proceed instead of waiting for completion.")
 	return usageSection("Background Tasks", parts)
 }
 
@@ -87,11 +92,13 @@ func (p *BackgroundProvider) Tools(_ context.Context, session SessionContext) ([
 		},
 		{
 			Name:        ToolWaitUntil().String(),
-			Description: "Wait until a background task completes, fails, is killed, or appears stalled. Call get_background_status afterward to inspect result.",
+			Description: "Observe a background task for a bounded time. Returns with a reason: completed/failed/killed, stalled (interactive prompt), idle (still running but output quiet for idle_timeout), or timeout — always with the latest output_tail. For servers/watchers that never exit (dev server, watch mode), reason 'idle' plus a ready message in output_tail (e.g. a local URL) means the service is up; do not keep waiting for completion.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"task_id": map[string]any{"type": "string", "description": "Background task ID"},
+					"task_id":      map[string]any{"type": "string", "description": "Background task ID"},
+					"timeout":      map[string]any{"type": "number", "description": "Max seconds to wait before returning with reason 'timeout'. Default 120, max 600. The task keeps running; call wait_until again to keep observing.", "minimum": 1, "maximum": 600},
+					"idle_timeout": map[string]any{"type": "number", "description": "Seconds of output silence after which a running command returns with reason 'idle'. Default 20, max 300. Only applies to exec tasks.", "minimum": 1, "maximum": 300},
 				},
 				"required": []string{"task_id"},
 			},
@@ -187,18 +194,34 @@ func (p *BackgroundProvider) execWaitUntil(ctx context.Context, session SessionC
 	if taskID == "" {
 		return nil, errors.New("task_id is required")
 	}
-	waitCtx, cancel := context.WithTimeout(ctx, time.Duration(background.BackgroundExecTimeout)*time.Second)
-	defer cancel()
-	s, err := p.waitForSessionTaskWithProgress(waitCtx, session.BotID, session.SessionID, taskID, sendProgress)
+	timeout, err := optionalDurationArg(args, "timeout", background.DefaultWaitTimeout, minWaitUntilTimeout, maxWaitUntilTimeout)
 	if err != nil {
 		return nil, err
+	}
+	idleThreshold, err := optionalDurationArg(args, "idle_timeout", background.DefaultIdleThreshold, minIdleTimeout, maxIdleTimeout)
+	if err != nil {
+		return nil, err
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	s, outcome, err := p.waitForSessionTaskWithProgress(waitCtx, session.BotID, session.SessionID, taskID, idleThreshold, sendProgress)
+	if err != nil {
+		if !errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+			return nil, err
+		}
+		// The wait budget elapsed; the task itself is still running.
+		outcome = background.WaitTimeout
 	}
 	result := map[string]any{
 		"task_id":    s.TaskID,
 		"kind":       string(s.Kind),
 		"status":     statusString(s),
+		"reason":     string(outcome),
 		"stalled":    s.Stalled,
 		"started_at": session.FormatTime(s.StartedAt),
+	}
+	if s.OutputTail != "" {
+		result["output_tail"] = s.OutputTail
 	}
 	if s.CompletedAt.IsZero() {
 		return result, nil
@@ -208,19 +231,20 @@ func (p *BackgroundProvider) execWaitUntil(ctx context.Context, session SessionC
 	return result, nil
 }
 
-func (p *BackgroundProvider) waitForSessionTaskWithProgress(ctx context.Context, botID, sessionID, taskID string, sendProgress func(any)) (background.TaskSnapshot, error) {
+func (p *BackgroundProvider) waitForSessionTaskWithProgress(ctx context.Context, botID, sessionID, taskID string, idleThreshold time.Duration, sendProgress func(any)) (background.TaskSnapshot, background.WaitOutcome, error) {
 	if sendProgress == nil {
-		return p.bgManager.WaitForSessionTask(ctx, botID, sessionID, taskID)
+		return p.bgManager.WaitForSessionTask(ctx, botID, sessionID, taskID, idleThreshold)
 	}
 
 	type waitResult struct {
 		snapshot background.TaskSnapshot
+		outcome  background.WaitOutcome
 		err      error
 	}
 	resultCh := make(chan waitResult, 1)
 	go func() {
-		s, err := p.bgManager.WaitForSessionTask(ctx, botID, sessionID, taskID)
-		resultCh <- waitResult{snapshot: s, err: err}
+		s, outcome, err := p.bgManager.WaitForSessionTask(ctx, botID, sessionID, taskID, idleThreshold)
+		resultCh <- waitResult{snapshot: s, outcome: outcome, err: err}
 	}()
 
 	progress := func() {
@@ -235,9 +259,16 @@ func (p *BackgroundProvider) waitForSessionTaskWithProgress(ctx context.Context,
 	for {
 		select {
 		case result := <-resultCh:
-			return result.snapshot, result.err
+			return result.snapshot, result.outcome, result.err
 		case <-ctx.Done():
-			return background.TaskSnapshot{}, ctx.Err()
+			// Give the waiter goroutine a moment to hand back the snapshot it
+			// captured at cancellation, so timeout results still carry a tail.
+			select {
+			case result := <-resultCh:
+				return result.snapshot, result.outcome, result.err
+			case <-time.After(time.Second):
+				return background.TaskSnapshot{}, "", ctx.Err()
+			}
 		case <-ticker.C:
 			progress()
 		}
@@ -334,12 +365,13 @@ func backgroundStatusMap(session SessionContext, s background.TaskSnapshot) map[
 	default:
 		result["command"] = s.Command
 		result["output_file"] = s.OutputFile
-		execResult := map[string]any{"output_file": s.OutputFile}
+		// The tail is live while the task runs — it is how the agent sees a
+		// server's ready banner without waiting for the process to exit.
+		result["output_tail"] = s.OutputTail
+		execResult := map[string]any{"output_file": s.OutputFile, "output_tail": s.OutputTail}
 		if s.Status != background.TaskRunning && s.Status != background.TaskQueued {
 			result["exit_code"] = s.ExitCode
-			result["output_tail"] = s.OutputTail
 			execResult["exit_code"] = s.ExitCode
-			execResult["output_tail"] = s.OutputTail
 		}
 		result["result"] = execResult
 	}
@@ -358,6 +390,37 @@ func durationArg(args map[string]any, key string) (time.Duration, error) {
 	if !ok {
 		return 0, fmt.Errorf("%s is required", key)
 	}
+	duration, err := secondsValue(raw, key)
+	if err != nil {
+		return 0, err
+	}
+	if duration > maxWaitDuration {
+		duration = maxWaitDuration
+	}
+	return duration, nil
+}
+
+// optionalDurationArg reads a seconds argument, falling back to def when the
+// key is absent and clamping present values into [minD, maxD].
+func optionalDurationArg(args map[string]any, key string, def, minD, maxD time.Duration) (time.Duration, error) {
+	raw, ok := args[key]
+	if !ok || raw == nil {
+		return def, nil
+	}
+	duration, err := secondsValue(raw, key)
+	if err != nil {
+		return 0, err
+	}
+	if duration < minD {
+		duration = minD
+	}
+	if duration > maxD {
+		duration = maxD
+	}
+	return duration, nil
+}
+
+func secondsValue(raw any, key string) (time.Duration, error) {
 	var seconds float64
 	switch v := raw.(type) {
 	case float64:
@@ -380,11 +443,7 @@ func durationArg(args map[string]any, key string) (time.Duration, error) {
 	if math.IsNaN(seconds) || math.IsInf(seconds, 0) || seconds <= 0 {
 		return 0, fmt.Errorf("%s must be > 0", key)
 	}
-	duration := time.Duration(seconds * float64(time.Second))
-	if duration > maxWaitDuration {
-		duration = maxWaitDuration
-	}
-	return duration, nil
+	return time.Duration(seconds * float64(time.Second)), nil
 }
 
 type jsonNumber interface {

--- a/internal/agent/tools/background_test.go
+++ b/internal/agent/tools/background_test.go
@@ -2,12 +2,14 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	"github.com/memohai/memoh/internal/agent/background"
+	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
 func TestBackgroundProviderWaitAndInspectAgentResult(t *testing.T) {
@@ -233,6 +235,98 @@ func TestBackgroundProviderWaitUntilEmitsProgressWhileWaiting(t *testing.T) {
 	}
 	if waitRes.(map[string]any)["status"] != "completed" {
 		t.Fatalf("wait_until payload = %v, want completed", waitRes)
+	}
+}
+
+func startRunningExecTask(t *testing.T, mgr *background.Manager) string {
+	t.Helper()
+	taskID, _ := mgr.Spawn(
+		context.Background(),
+		"bot1",
+		"sess1",
+		"npm run dev",
+		"/data",
+		"Dev server",
+		func(ctx context.Context, _, _ string, _ int32) (*bridge.ExecResult, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		nil,
+		nil,
+	)
+	t.Cleanup(func() { _ = mgr.Kill(taskID) })
+	return taskID
+}
+
+func TestGetBackgroundStatusIncludesTailWhileRunning(t *testing.T) {
+	mgr := background.New(nil)
+	p := NewBackgroundProvider(nil, mgr)
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+
+	taskID := startRunningExecTask(t, mgr)
+	mgr.RecordOutput(taskID, "stdout", "  ➜  Local: http://localhost:5173/\n")
+
+	statusRes, err := p.execGetBackgroundStatus(context.Background(), session, map[string]any{"task_id": taskID})
+	if err != nil {
+		t.Fatalf("get_background_status failed: %v", err)
+	}
+	sm := statusRes.(map[string]any)
+	if sm["status"] != "running" {
+		t.Fatalf("status = %v, want running", sm["status"])
+	}
+	tail, _ := sm["output_tail"].(string)
+	if !strings.Contains(tail, "localhost:5173") {
+		t.Fatalf("output_tail = %q, want live tail while running", tail)
+	}
+	if _, ok := sm["exit_code"]; ok {
+		t.Fatalf("running status should not expose exit_code: %v", sm)
+	}
+}
+
+func TestWaitUntilReturnsIdleWithTailForQuietService(t *testing.T) {
+	mgr := background.New(nil)
+	p := NewBackgroundProvider(nil, mgr)
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+
+	taskID := startRunningExecTask(t, mgr)
+	mgr.RecordOutput(taskID, "stdout", "  ➜  Local: http://localhost:5173/\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := p.execWaitUntil(ctx, session, map[string]any{"task_id": taskID, "idle_timeout": 1, "timeout": 30}, nil)
+	if err != nil {
+		t.Fatalf("wait_until failed: %v", err)
+	}
+	rm := res.(map[string]any)
+	if rm["reason"] != "idle" || rm["status"] != "running" {
+		t.Fatalf("wait_until payload = %v, want running/idle", rm)
+	}
+	tail, _ := rm["output_tail"].(string)
+	if !strings.Contains(tail, "localhost:5173") {
+		t.Fatalf("output_tail = %q, want ready banner", tail)
+	}
+}
+
+func TestWaitUntilTimeoutReturnsSnapshotInsteadOfError(t *testing.T) {
+	mgr := background.New(nil)
+	p := NewBackgroundProvider(nil, mgr)
+	session := SessionContext{BotID: "bot1", SessionID: "sess1"}
+
+	taskID, _, err := mgr.StartSpawnTask(context.Background(), "bot1", "sess1", "long spawn")
+	if err != nil {
+		t.Fatalf("StartSpawnTask failed: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Kill(taskID) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	res, err := p.execWaitUntil(ctx, session, map[string]any{"task_id": taskID, "timeout": 1}, nil)
+	if err != nil {
+		t.Fatalf("wait_until should return a snapshot on timeout, got error: %v", err)
+	}
+	rm := res.(map[string]any)
+	if rm["reason"] != "timeout" || rm["status"] != "running" {
+		t.Fatalf("wait_until payload = %v, want running/timeout", rm)
 	}
 }
 

--- a/internal/agent/tools/container.go
+++ b/internal/agent/tools/container.go
@@ -230,7 +230,8 @@ Delete a file:
 # Instructions
 - Use this tool to run shell commands for installing packages, running scripts, building code, running tests, and other system operations.
 - If your command will take a long time (package installs, builds, test suites), set run_in_background to true. The call returns a task ID immediately. You do not need to add '&' at the end of the command when using this parameter.
-- If waiting for a background task, use wait_until(task_id), then get_background_status(task_id) to inspect result.
+- If waiting for a background task, use wait_until(task_id): it returns with a reason (completed/failed/killed/stalled/idle/timeout) and the latest output_tail. Then use get_background_status(task_id) to inspect result.
+- For processes that never exit on their own (dev servers, watch mode), use run_in_background, then wait_until(task_id): once output settles it returns with reason 'idle' — check output_tail for the ready message (e.g. a local URL) and proceed. Do not wait for such processes to complete.
 - You may specify a custom timeout (up to %d seconds) for commands you know will take longer than the default %d seconds. If a foreground command times out, it will be automatically moved to the background; use wait_until(task_id), then get_background_status(task_id).
 - Avoid unnecessary sleep commands:
   - Do not sleep between commands that can run immediately — just run them.
@@ -245,7 +246,7 @@ Delete a file:
 					"work_dir":          map[string]any{"type": "string", "description": fmt.Sprintf("Working directory (default: %s)", wd)},
 					"description":       map[string]any{"type": "string", "description": `Clear, concise description of what this command does in active voice. For simple commands keep it brief (5-10 words): ls -la → "List files with details". For complex commands add enough context: curl -s url | jq '.data[]' → "Fetch JSON and extract data array".`},
 					"timeout":           map[string]any{"type": "integer", "description": fmt.Sprintf("Timeout in seconds (default: %d, max: %d). Only applies to foreground execution. Commands that exceed this timeout are automatically moved to background.", background.DefaultExecTimeout, background.MaxExecTimeout), "minimum": 1, "maximum": background.MaxExecTimeout},
-					"run_in_background": map[string]any{"type": "boolean", "description": "If true, run the command in the background. Returns immediately with a task ID. Use wait_until(task_id), then get_background_status(task_id) to inspect result. Use for long-running commands (installs, builds, test suites). You do not need to use '&' at the end of the command."},
+					"run_in_background": map[string]any{"type": "boolean", "description": "If true, run the command in the background. Returns immediately with a task ID. Use wait_until(task_id), then get_background_status(task_id) to inspect result. Use for long-running commands (installs, builds, test suites) and for processes that never exit (dev servers, watch mode). You do not need to use '&' at the end of the command."},
 				},
 				"required": []string{"command"},
 			},
@@ -927,6 +928,8 @@ func (p *ContainerProvider) flipToBackground(
 		session.BotID, session.SessionID, command, workDir, description,
 		reader.Result(), writeFn,
 	)
+	// SetChunkHandler replays output collected during the foreground phase
+	// into the task buffer, so the tail below already contains it.
 	reader.SetChunkHandler(func(stream, chunk string) {
 		p.bgManager.RecordOutput(taskID, stream, chunk)
 	})
@@ -937,18 +940,25 @@ func (p *ContainerProvider) flipToBackground(
 		slog.Int("soft_timeout_seconds", int(softTimeout)),
 	)
 
-	return map[string]any{
+	result := map[string]any{
 		"status":      "auto_backgrounded",
 		"task_id":     taskID,
 		"output_file": outputFile,
 		"message": fmt.Sprintf(
 			"Command exceeded the foreground timeout (%ds) and has been moved to the background with task ID: %s. "+
-				"The process is still running — no work was lost. "+
-				"Output is being written to: %s. Use wait_until(task_id) to wait, then get_background_status(task_id) to inspect result. "+
+				"The process is still running — no work was lost; output collected so far is in output_tail. "+
+				"Use wait_until(task_id) to keep observing: it returns when the task finishes, stalls, or goes quiet (reason 'idle') — for servers, a ready message in output_tail means it is up. "+
+				"The full log is written to %s after the task ends. "+
 				"For long-running commands, use run_in_background: true from the start to avoid this delay.",
 			softTimeout, taskID, outputFile,
 		),
-	}, nil
+	}
+	if task := p.bgManager.Get(taskID); task != nil {
+		if tail := task.OutputTail(); tail != "" {
+			result["output_tail"] = tail
+		}
+	}
+	return result, nil
 }
 
 // detectBlockedSleep checks if the command starts with `sleep N` where N >= 2.
@@ -995,7 +1005,12 @@ func (p *ContainerProvider) execExecBackground(
 		"status":      "background_started",
 		"task_id":     taskID,
 		"output_file": outputFile,
-		"message":     fmt.Sprintf("Command started in background with task ID: %s. Output is being written to: %s. Use wait_until(task_id) to wait, then get_background_status(task_id) to inspect result.", taskID, outputFile),
+		"message": fmt.Sprintf(
+			"Command started in background with task ID: %s. "+
+				"Use wait_until(task_id) to observe it: it returns when the task finishes, stalls on a prompt, or output goes quiet (reason 'idle'), always with the latest output_tail — for servers, a ready message there means it is up. "+
+				"get_background_status(task_id) also shows output_tail while running. The full log is written to %s after the task ends.",
+			taskID, outputFile,
+		),
 	}, nil
 }
 

--- a/internal/agent/tools/subagent_bg_test.go
+++ b/internal/agent/tools/subagent_bg_test.go
@@ -463,7 +463,7 @@ func TestBusyAgentQueuesAndRunsFIFO(t *testing.T) {
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	snap, err := mgr.WaitForSessionTask(ctx, session.BotID, session.SessionID, third["task_id"].(string))
+	snap, _, err := mgr.WaitForSessionTask(ctx, session.BotID, session.SessionID, third["task_id"].(string), 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}
@@ -572,7 +572,7 @@ func TestBackgroundWaitTimeoutDoesNotCancelRunningAgentTask(t *testing.T) {
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
-	if _, err := mgr.WaitForSessionTask(waitCtx, session.BotID, session.SessionID, started["task_id"].(string)); err == nil {
+	if _, _, err := mgr.WaitForSessionTask(waitCtx, session.BotID, session.SessionID, started["task_id"].(string), 0); err == nil {
 		t.Fatal("expected wait timeout")
 	}
 	if task := mgr.GetForSession("bot1", "parent1", started["task_id"].(string)); task == nil || task.Snapshot().Status != background.TaskRunning {

--- a/internal/agent/tools/video_gen_test.go
+++ b/internal/agent/tools/video_gen_test.go
@@ -124,7 +124,7 @@ func waitForVideoTask(t *testing.T, mgr *background.Manager, taskID string) back
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	snap, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID)
+	snap, _, err := mgr.WaitForSessionTask(ctx, "bot1", "sess1", taskID, 0)
 	if err != nil {
 		t.Fatalf("WaitForSessionTask returned error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- add explicit wait outcomes for completed, failed, killed, stalled, idle, and timed-out background tasks
- return live output tails while exec tasks are still running
- let long-running servers and watchers report readiness after their output becomes idle
- preserve foreground output when a command is automatically moved to the background

## Why

Background server processes do not terminate after startup, so waiting only for completion leaves the agent unable to distinguish a ready service from a still-starting process. An idle outcome plus the latest output tail makes that state observable without stopping the task.

## Impact

Finite jobs continue to be re-waited until completion. Long-running exec tasks can now return a bounded idle result while remaining active.

## Checks

- `git diff --check`
- `go test ./internal/agent/background ./internal/agent/tools ./internal/agent`