### PR TITLE
fix(messaging): deliver local attachments with text

### DIFF
--- a/internal/agent/tools/message.go
+++ b/internal/agent/tools/message.go
@@ -341,6 +341,10 @@ func (p *MessageProvider) execSend(ctx context.Context, session SessionContext, 
 			"delivered":   "current_conversation",
 			"attachments": len(atts),
 		}
+		if result.LocalTextOmitted {
+			resp["text_delivered"] = false
+			resp["note"] = "attachments were delivered to the current conversation, but message text is never sent this way; include it in your assistant reply text instead"
+		}
 		if result.MessageID != "" {
 			resp["message_id"] = result.MessageID
 		}

--- a/internal/agent/tools/message_test.go
+++ b/internal/agent/tools/message_test.go
@@ -305,6 +305,47 @@ func TestExecSendCurrentConversationLiveStreamUsesEmitter(t *testing.T) {
 	}
 }
 
+func TestExecSendCurrentConversationLiveStreamAttachmentWithTextEmitsAndFlagsText(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingSender{}
+	provider := NewMessageProvider(nil, sender, usageTestReactor{}, usageTestResolver{}, messageTestAssetResolver{})
+	var emitted int
+	result, err := provider.execSend(context.Background(), SessionContext{
+		BotID:           "bot_1",
+		SessionType:     sessionmode.Chat,
+		CurrentPlatform: "telegram",
+		ReplyTarget:     "chat-1",
+		LiveStream:      true,
+		Emitter: func(ToolStreamEvent) {
+			emitted++
+		},
+	}, "call-test", map[string]any{
+		"text":        "这是当前 blog 的页面截图。",
+		"attachments": []any{"screenshot.png"},
+	})
+	if err != nil {
+		t.Fatalf("execSend returned error: %v", err)
+	}
+	if emitted != 1 {
+		t.Fatalf("expected live stream emitter called once, got %d", emitted)
+	}
+	if sender.called != 0 {
+		t.Fatalf("expected sender not called for live stream shortcut, got %d", sender.called)
+	}
+	resp, ok := result.(map[string]any)
+	if !ok || resp["ok"] != true || resp["delivered"] != "current_conversation" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if resp["text_delivered"] != false {
+		t.Fatalf("expected text_delivered=false in result, got %#v", result)
+	}
+	note, _ := resp["note"].(string)
+	if !strings.Contains(note, "assistant reply") {
+		t.Fatalf("expected note guiding assistant reply, got %#v", result)
+	}
+}
+
 type recordingReactor struct {
 	called int
 	req    channel.ReactRequest

--- a/internal/messaging/executor.go
+++ b/internal/messaging/executor.go
@@ -67,6 +67,10 @@ type SendResult struct {
 	// The caller should emit the resolved attachments as stream events.
 	Local            bool
 	LocalAttachments []channel.Attachment
+	// LocalTextOmitted is true when the local shortcut delivered the
+	// attachments but dropped accompanying text/parts; the caller should tell
+	// the model to restate that text in its assistant reply.
+	LocalTextOmitted bool
 }
 
 // ReactResult is the success payload returned after reacting.
@@ -142,6 +146,7 @@ func (e *Executor) sendWithMode(
 			Target:           plan.target,
 			Local:            true,
 			LocalAttachments: plan.message.Attachments,
+			LocalTextOmitted: localShortcutOmitsText(plan.message),
 		}, nil
 	}
 
@@ -242,13 +247,20 @@ func validateSendArguments(args map[string]any) error {
 	return nil
 }
 
+// localShortcutCanRepresent reports whether the message can be delivered by
+// emitting stream events into the current reply: it must carry attachments and
+// nothing that requires a real channel send (actions, reply refs, forwards).
+// Text and parts are tolerated but not delivered — the model is told to
+// restate them in its assistant reply (see SendResult.LocalTextOmitted).
 func localShortcutCanRepresent(msg channel.Message) bool {
-	return strings.TrimSpace(msg.Text) == "" &&
-		len(msg.Parts) == 0 &&
-		len(msg.Attachments) > 0 &&
+	return len(msg.Attachments) > 0 &&
 		len(msg.Actions) == 0 &&
 		msg.Reply == nil &&
 		msg.Forward == nil
+}
+
+func localShortcutOmitsText(msg channel.Message) bool {
+	return strings.TrimSpace(msg.Text) != "" || len(msg.Parts) > 0
 }
 
 func (e *Executor) buildOutboundMessage(

--- a/internal/messaging/executor_test.go
+++ b/internal/messaging/executor_test.go
@@ -788,7 +788,43 @@ func TestSendSameConversationTextOnlyFails(t *testing.T) {
 	}
 }
 
-func TestSendSameConversationAttachmentWithTextFails(t *testing.T) {
+func TestSendSameConversationAttachmentWithTextDeliversAttachments(t *testing.T) {
+	t.Parallel()
+
+	sender := &testSender{}
+	exec := &Executor{
+		Sender:   sender,
+		Resolver: testResolver{},
+	}
+
+	result, err := exec.Send(context.Background(), SessionContext{
+		BotID:              "bot_1",
+		CanOmitTarget:      true,
+		AllowLocalShortcut: true,
+		CurrentPlatform:    "feishu",
+		ReplyTarget:        "chat_id:oc_group_1",
+	}, map[string]any{
+		"text":        "caption",
+		"attachments": []any{"screenshot.png"},
+	})
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !result.Local {
+		t.Fatal("expected local shortcut result")
+	}
+	if len(result.LocalAttachments) != 1 {
+		t.Fatalf("expected 1 local attachment, got %d", len(result.LocalAttachments))
+	}
+	if !result.LocalTextOmitted {
+		t.Fatal("expected LocalTextOmitted to be true")
+	}
+	if sender.called != 0 {
+		t.Fatalf("expected sender not called, got %d", sender.called)
+	}
+}
+
+func TestSendSameConversationAttachmentWithActionsFails(t *testing.T) {
 	t.Parallel()
 
 	sender := &testSender{}
@@ -804,8 +840,10 @@ func TestSendSameConversationAttachmentWithTextFails(t *testing.T) {
 		CurrentPlatform:    "feishu",
 		ReplyTarget:        "chat_id:oc_group_1",
 	}, map[string]any{
-		"text":        "caption",
-		"attachments": []any{"screenshot.png"},
+		"message": map[string]any{
+			"attachments": []any{"screenshot.png"},
+			"actions":     []any{map[string]any{"label": "Open", "url": "https://example.com"}},
+		},
 	})
 	if err == nil || !strings.Contains(err.Error(), "standalone files or attachments") {
 		t.Fatalf("Send error = %v, want standalone attachment guidance", err)


### PR DESCRIPTION
## Summary

- allow current-conversation local delivery when a message contains attachments plus text or structured parts
- emit the attachments through the live reply stream
- report that accompanying text was omitted and must be restated in the assistant reply
- keep actions, replies, and forwards outside the local shortcut

## Why

The local shortcut previously rejected an otherwise valid attachment whenever the tool call also included explanatory text, preventing screenshots and files from reaching the current conversation.

## Impact

Attachments are delivered reliably without duplicating channel text, while the tool result gives the model explicit guidance to include the omitted text in its assistant response.

## Checks

- `git diff --check`
- `go test ./internal/agent/tools ./internal/messaging`