### PR TITLE
feat(providers): sync managed OAuth model catalogs

### DIFF
--- a/apps/web/src/components/add-provider/index.vue
+++ b/apps/web/src/components/add-provider/index.vue
@@ -98,7 +98,7 @@
             </FieldStack>
           </FormField>
           <div
-            v-else-if="isOAuthClientType(form.values.client_type)"
+            v-else-if="isManagedOAuthClientType(form.values.client_type)"
             class="rounded-lg border p-3 text-xs text-muted-foreground"
           >
             {{ $t(form.values.client_type === 'github-copilot' ? 'provider.oauth.githubCreateHint' : 'provider.oauth.openaiCreateHint') }}
@@ -193,7 +193,11 @@ import FormDialogShell from '@/components/form-dialog-shell/index.vue'
 import FieldStack from '@/components/settings/field-stack.vue'
 import { useDialogMutation } from '@/composables/useDialogMutation'
 import SearchableSelectPopover from '@/components/searchable-select-popover/index.vue'
-import { LLM_CLIENT_TYPE_LIST, CLIENT_TYPE_META } from '@/constants/client-types'
+import {
+  CLIENT_TYPE_META,
+  isManagedOAuthClientType,
+  MANUAL_LLM_CLIENT_TYPE_LIST,
+} from '@/constants/client-types'
 import { toast } from '@felinic/ui'
 import { computed, ref, watch } from 'vue'
 import { providerPresets } from '@/constants/provider-presets'
@@ -248,17 +252,13 @@ function getPresetById(id: string | undefined): ProviderPreset | null {
   return providerPresets.find(preset => preset.id === id) ?? null
 }
 
-function isOAuthClientType(clientType: unknown): boolean {
-  return clientType === 'openai-codex' || clientType === 'github-copilot'
-}
-
 const apiKeyRequired = computed(() => {
-  if (isOAuthClientType(form.values.client_type)) return false
+  if (isManagedOAuthClientType(form.values.client_type)) return false
   return selectedPreset.value?.requiresApiKey !== false
 })
 
 const clientTypeOptions = computed(() =>
-  LLM_CLIENT_TYPE_LIST.map((ct) => ({
+  MANUAL_LLM_CLIENT_TYPE_LIST.map((ct) => ({
     value: ct.value,
     label: ct.label,
     description: ct.hint,
@@ -327,7 +327,7 @@ const providerSchema = toTypedSchema(z.object({
   client_type: z.string().min(1, t('provider.clientTypeRequired')),
   auto_import: z.boolean().optional(),
 }).superRefine((value, ctx) => {
-  const requiresApiKey = !isOAuthClientType(value.client_type) && selectedPreset.value?.requiresApiKey !== false
+  const requiresApiKey = !isManagedOAuthClientType(value.client_type) && selectedPreset.value?.requiresApiKey !== false
   if (requiresApiKey && !value.api_key?.trim()) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/apps/web/src/components/import-models-dialog/index.vue
+++ b/apps/web/src/components/import-models-dialog/index.vue
@@ -1,9 +1,9 @@
 <template>
   <FormDialogShell
     v-model:open="open"
-    :title="$t('models.importModels')"
+    :title="$t(isRefresh ? 'models.refreshModels' : 'models.importModels')"
     :cancel-text="$t('common.cancel')"
-    :submit-text="$t('common.import')"
+    :submit-text="$t(isRefresh ? 'models.refreshModels' : 'common.import')"
     :submit-disabled="false"
     :loading="isLoading"
     @submit="handleImport"
@@ -14,14 +14,15 @@
         :size="size"
         class="flex items-center gap-2"
       >
-        <FileInput />
-        {{ $t('models.importModels') }}
+        <RefreshCw v-if="isRefresh" />
+        <FileInput v-else />
+        {{ $t(isRefresh ? 'models.refreshModels' : 'models.importModels') }}
       </Button>
     </template>
     <template #body>
       <div class="flex flex-col gap-3 mt-4">
         <p class="text-xs text-muted-foreground">
-          {{ $t('models.importConfirmHint') }}
+          {{ $t(isRefresh ? 'models.refreshConfirmHint' : 'models.importConfirmHint') }}
         </p>
       </div>
     </template>
@@ -29,54 +30,49 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useMutation, useQueryCache } from '@pinia/colada'
-import { postProvidersByIdImportModels } from '@memohai/sdk'
+import { useMutation } from '@pinia/colada'
 import { toast } from '@felinic/ui'
-import { FileInput } from 'lucide-vue-next'
+import { FileInput, RefreshCw } from 'lucide-vue-next'
 import { Button } from '@felinic/ui'
 import type { ButtonVariants } from '@felinic/ui'
 import FormDialogShell from '@/components/form-dialog-shell/index.vue'
 import { useDialogMutation } from '@/composables/useDialogMutation'
+import { useProviderModelCatalog } from '@/composables/useProviderModelCatalog'
 
 const props = withDefaults(defineProps<{
   providerId: string
   size?: ButtonVariants['size']
+  mode?: 'import' | 'refresh'
 }>(), {
   size: 'default',
+  mode: 'import',
 })
 
 const open = ref(false)
 const { t } = useI18n()
 const { run } = useDialogMutation()
-const queryCache = useQueryCache()
+const { syncProviderModelCatalog } = useProviderModelCatalog()
+const isRefresh = computed(() => props.mode === 'refresh')
 
 const { mutateAsync: importModelsMutation, isLoading } = useMutation({
-  mutation: async () => {
-    const { data } = await postProvidersByIdImportModels({
-      path: { id: props.providerId },
-      throwOnError: true,
-    })
-    return data
-  },
-  onSettled: () => {
-    queryCache.invalidateQueries({ key: ['provider-models'] })
-    queryCache.invalidateQueries({ key: ['models'] })
-  },
+  mutation: () => syncProviderModelCatalog(props.providerId),
 })
 
 async function handleImport() {
   await run(
     () => importModelsMutation(),
     {
-      fallbackMessage: t('models.importFailed'),
+      fallbackMessage: t(isRefresh.value ? 'models.refreshFailed' : 'models.importFailed'),
       onSuccess: (data) => {
         if (data) {
-          toast.success(t('models.importSuccess', {
-            created: data.created,
-            skipped: data.skipped,
-          }))
+          toast.success(t(
+            isRefresh.value ? 'models.refreshSuccess' : 'models.importSuccess',
+            isRefresh.value
+              ? { created: data.created, updated: data.updated }
+              : { created: data.created, skipped: data.skipped },
+          ))
         }
         open.value = false
       },

--- a/apps/web/src/components/settings/back-button.vue
+++ b/apps/web/src/components/settings/back-button.vue
@@ -4,14 +4,9 @@
        geometry below is tuned in exactly one place — this used to be
        copy-pasted into every caller and drifted.
 
-       Geometry (both values coupled, derived together):
-         px-4  — a roomier chip: 16px of air on each side of the
-                 chevron+label, replacing the default svg padding (12px).
-         -ml-4 — shifts the button left by exactly that padding, so the
-                 CHEVRON's left pixel lands on the wrapper's content edge —
-                 the same x as the cards below (optical alignment: the glyph
-                 aligns, the hover chip overhangs into the gutter).
-       Keep them equal-and-opposite; re-derive both if one changes. -->
+       The button surface shares the detail body's left rail, so its hover /
+       pressed fill aligns with the card edge below instead of hanging into
+       the outer gutter. px-4 keeps the chevron and label comfortably inset. -->
   <Button
     variant="ghost"
     :class="buttonClass"
@@ -34,5 +29,5 @@ const emit = defineEmits<{ click: [] }>()
 
 // Geometry rationale in the template comment above. The /85 dim is tuned for
 // this sole owner — one consumer doesn't earn a global -soft token.
-const buttonClass = '-ml-4 max-w-full px-4 text-foreground/85' /* ui-allow-alpha: sole owner, see comment above */
+const buttonClass = 'max-w-full px-4 text-foreground/85' /* ui-allow-alpha: sole owner, see comment above */
 </script>

--- a/apps/web/src/composables/useDialogMutation.test.ts
+++ b/apps/web/src/composables/useDialogMutation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@felinic/ui', () => ({
+  toast: { error: vi.fn() },
+}))
+
+vi.mock('@/utils/api-error', () => ({
+  resolveApiErrorMessage: vi.fn(() => 'resolved error'),
+}))
+
+import { useDialogMutation } from './useDialogMutation'
+
+describe('useDialogMutation', () => {
+  it('passes the mutation result to the success callback', async () => {
+    const onSuccess = vi.fn()
+    const { run } = useDialogMutation()
+
+    await expect(run(
+      async () => ({ created: 2, updated: 1 }),
+      { fallbackMessage: 'failed', onSuccess },
+    )).resolves.toBe(true)
+
+    expect(onSuccess).toHaveBeenCalledWith({ created: 2, updated: 1 })
+  })
+})

--- a/apps/web/src/composables/useDialogMutation.ts
+++ b/apps/web/src/composables/useDialogMutation.ts
@@ -1,19 +1,19 @@
 import { toast } from '@felinic/ui'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 
-interface DialogMutationOptions {
+interface DialogMutationOptions<T> {
   fallbackMessage: string
-  onSuccess?: () => void | Promise<void>
+  onSuccess?: (result: T) => void | Promise<void>
 }
 
 export function useDialogMutation() {
-  async function run(
-    mutation: () => Promise<unknown>,
-    options: DialogMutationOptions,
+  async function run<T>(
+    mutation: () => Promise<T>,
+    options: DialogMutationOptions<T>,
   ): Promise<boolean> {
     try {
-      await mutation()
-      await options.onSuccess?.()
+      const result = await mutation()
+      await options.onSuccess?.(result)
       return true
     } catch (error) {
       toast.error(resolveApiErrorMessage(error, options.fallbackMessage, { prefixFallback: true }))

--- a/apps/web/src/composables/useProviderModelCatalog.test.ts
+++ b/apps/web/src/composables/useProviderModelCatalog.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  importModels: vi.fn(),
+  invalidateQueries: vi.fn(),
+}))
+
+vi.mock('@memohai/sdk', () => ({
+  postProvidersByIdImportModels: mocks.importModels,
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useQueryCache: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}))
+
+import { useProviderModelCatalog } from './useProviderModelCatalog'
+
+describe('useProviderModelCatalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('syncs the provider catalog and invalidates every model picker query', async () => {
+    const result = { created: 2, updated: 3, skipped: 1, models: ['one', 'two'] }
+    mocks.importModels.mockResolvedValue({ data: result })
+
+    const { syncProviderModelCatalog } = useProviderModelCatalog()
+
+    await expect(syncProviderModelCatalog('provider-id')).resolves.toEqual(result)
+    expect(mocks.importModels).toHaveBeenCalledWith({
+      path: { id: 'provider-id' },
+      throwOnError: true,
+    })
+    expect(mocks.invalidateQueries.mock.calls).toEqual([
+      [{ key: ['provider-models'] }],
+      [{ key: ['models'] }],
+      [{ key: ['all-models'] }],
+    ])
+  })
+})

--- a/apps/web/src/composables/useProviderModelCatalog.ts
+++ b/apps/web/src/composables/useProviderModelCatalog.ts
@@ -1,0 +1,23 @@
+import { useQueryCache } from '@pinia/colada'
+import { postProvidersByIdImportModels } from '@memohai/sdk'
+
+const MODEL_QUERY_KEYS = ['provider-models', 'models', 'all-models'] as const
+
+export function useProviderModelCatalog() {
+  const queryCache = useQueryCache()
+
+  async function syncProviderModelCatalog(providerId: string) {
+    const { data } = await postProvidersByIdImportModels({
+      path: { id: providerId },
+      throwOnError: true,
+    })
+    for (const key of MODEL_QUERY_KEYS) {
+      queryCache.invalidateQueries({ key: [key] })
+    }
+    return data
+  }
+
+  return {
+    syncProviderModelCatalog,
+  }
+}

--- a/apps/web/src/constants/client-types.test.ts
+++ b/apps/web/src/constants/client-types.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isManagedModelCatalogClientType,
+  isManagedOAuthClientType,
+  LLM_CLIENT_TYPE_LIST,
+  MANUAL_LLM_CLIENT_TYPE_LIST,
+} from './client-types'
+
+describe('LLM client type lists', () => {
+  it('keeps managed OAuth types available to presets but out of manual selectors', () => {
+    const allTypes = LLM_CLIENT_TYPE_LIST.map(type => type.value)
+    const manualTypes = MANUAL_LLM_CLIENT_TYPE_LIST.map(type => type.value)
+
+    expect(allTypes).toEqual(expect.arrayContaining(['openai-codex', 'github-copilot']))
+    expect(manualTypes).not.toContain('openai-codex')
+    expect(manualTypes).not.toContain('github-copilot')
+    expect(manualTypes).toContain('openai-completions')
+  })
+
+  it('identifies only the dedicated OAuth provider types', () => {
+    expect(isManagedOAuthClientType('openai-codex')).toBe(true)
+    expect(isManagedOAuthClientType('github-copilot')).toBe(true)
+    expect(isManagedOAuthClientType('openai-completions')).toBe(false)
+    expect(isManagedOAuthClientType(undefined)).toBe(false)
+  })
+
+  it('uses managed OAuth providers for account-scoped model catalogs', () => {
+    expect(isManagedModelCatalogClientType('openai-codex')).toBe(true)
+    expect(isManagedModelCatalogClientType('github-copilot')).toBe(true)
+    expect(isManagedModelCatalogClientType('anthropic-messages')).toBe(false)
+  })
+})

--- a/apps/web/src/constants/client-types.ts
+++ b/apps/web/src/constants/client-types.ts
@@ -4,6 +4,16 @@ export interface ClientTypeMeta {
   hint: string
 }
 
+const MANAGED_OAUTH_CLIENT_TYPES = new Set(['openai-codex', 'github-copilot'])
+
+export function isManagedOAuthClientType(clientType: unknown): boolean {
+  return typeof clientType === 'string' && MANAGED_OAUTH_CLIENT_TYPES.has(clientType)
+}
+
+export function isManagedModelCatalogClientType(clientType: unknown): boolean {
+  return isManagedOAuthClientType(clientType)
+}
+
 export const CLIENT_TYPE_META: Record<string, ClientTypeMeta> = {
   'openai-responses': {
     value: 'openai-responses',
@@ -131,3 +141,8 @@ export const CLIENT_TYPE_LIST: ClientTypeMeta[] = Object.values(CLIENT_TYPE_META
 
 export const LLM_CLIENT_TYPE_LIST: ClientTypeMeta[] = CLIENT_TYPE_LIST
   .filter(ct => !ct.value.endsWith('-speech') && !ct.value.endsWith('-transcription') && !ct.value.endsWith('-video'))
+
+// Managed OAuth providers are created from their dedicated presets. Keeping
+// them out of generic selectors prevents partially configured instances.
+export const MANUAL_LLM_CLIENT_TYPE_LIST: ClientTypeMeta[] = LLM_CLIENT_TYPE_LIST
+  .filter(ct => !isManagedOAuthClientType(ct.value))

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -973,6 +973,7 @@
     "refreshModels": "Refresh Models",
     "refreshSuccess": "Model catalog refreshed: {created} added, {updated} updated",
     "refreshFailed": "Failed to refresh the model catalog",
+    "refreshConfirmHint": "Fetch the latest models available to this account and remove unavailable models from model pickers.",
     "importConfirmHint": "Models will be imported from this provider's API with default compatibilities (vision, tool-call, reasoning).",
     "showingCount": "Showing {count} of {total}"
   },

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -925,6 +925,7 @@
     "refreshModels": "Model を更新",
     "refreshSuccess": "Model カタログを更新しました: {created} 件追加、{updated} 件更新",
     "refreshFailed": "Model カタログの更新に失敗しました",
+    "refreshConfirmHint": "このアカウントで現在利用できる最新の Model を取得し、利用できない Model を選択肢から除外します。",
     "importConfirmHint": "このプロバイダーの API から、デフォルトの互換性（ビジョン、ツール呼び出し、推論）付きでモデルをインポートします。",
     "showingCount": "{total} の {count} を表示中"
   },

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -973,6 +973,7 @@
     "refreshModels": "刷新模型",
     "refreshSuccess": "模型目录已刷新：新增 {created} 个，更新 {updated} 个",
     "refreshFailed": "刷新模型目录失败",
+    "refreshConfirmHint": "获取此账号当前可用的最新模型，并从模型选择器中移除已不可用的模型。",
     "importConfirmHint": "将从该服务商的 API 导入模型，默认兼容性为视觉、工具调用和推理。",
     "showingCount": "显示 {count} / {total}"
   },

--- a/apps/web/src/pages/onboarding/steps/useProviderSetup.ts
+++ b/apps/web/src/pages/onboarding/steps/useProviderSetup.ts
@@ -13,7 +13,7 @@ import {
   type ProvidersCreateRequest,
   type ModelsGetResponse,
 } from '@memohai/sdk'
-import { LLM_CLIENT_TYPE_LIST } from '@/constants/client-types'
+import { MANUAL_LLM_CLIENT_TYPE_LIST } from '@/constants/client-types'
 import type { ProviderPreset } from '@/constants/provider-presets'
 
 export function useProviderSetup(options: {
@@ -62,7 +62,7 @@ export function useProviderSetup(options: {
   const providerModels = computed<ModelsGetResponse[]>(() => providerModelsState.value.data ?? [])
 
   const availableClientTypes = computed(() =>
-    LLM_CLIENT_TYPE_LIST.filter(ct => !['openai-codex', 'github-copilot'].includes(ct.value)),
+    MANUAL_LLM_CLIENT_TYPE_LIST,
   )
 
   const baseUrlPlaceholder = computed(() => {

--- a/apps/web/src/pages/providers/components/model-list.vue
+++ b/apps/web/src/pages/providers/components/model-list.vue
@@ -22,27 +22,16 @@
         v-if="providerId"
         class="ml-auto flex items-center gap-2"
       >
-        <LoadingButton
-          v-if="managed"
-          type="button"
-          variant="outline"
+        <ImportModelsDialog
+          :provider-id="providerId"
           size="sm"
-          :loading="refreshLoading"
-          @click="refreshManagedModels"
-        >
-          <RefreshCw />
-          {{ $t('models.refreshModels') }}
-        </LoadingButton>
-        <template v-else>
-          <ImportModelsDialog
-            :provider-id="providerId"
-            size="sm"
-          />
-          <CreateModel
-            :id="providerId"
-            size="sm"
-          />
-        </template>
+          :mode="(models?.length ?? 0) > 0 ? 'refresh' : 'import'"
+        />
+        <CreateModel
+          v-if="!managed"
+          :id="providerId"
+          size="sm"
+        />
       </div>
     </div>
 
@@ -133,7 +122,6 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { useQueryCache } from '@pinia/colada'
 import {
   Empty,
   EmptyDescription,
@@ -152,16 +140,12 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from '@felinic/ui'
-import { Search, List, RefreshCw } from 'lucide-vue-next'
+import { Search, List } from 'lucide-vue-next'
 import CreateModel from '@/components/create-model/index.vue'
 import ImportModelsDialog from '@/components/import-models-dialog/index.vue'
-import LoadingButton from '@/components/loading-button/index.vue'
 import SettingsSection from '@/components/settings/section.vue'
 import ModelItem from './model-item.vue'
-import { postProvidersByIdImportModels } from '@memohai/sdk'
 import type { ModelsGetResponse } from '@memohai/sdk'
-import { toast } from '@felinic/ui'
-import { useI18n } from 'vue-i18n'
 
 const PAGE_SIZE = 8
 
@@ -179,32 +163,6 @@ defineEmits<{
 
 const searchQuery = ref('')
 const currentPage = ref(1)
-const refreshLoading = ref(false)
-const queryCache = useQueryCache()
-const { t } = useI18n()
-
-async function refreshManagedModels() {
-  if (!props.providerId) return
-  refreshLoading.value = true
-  try {
-    const { data } = await postProvidersByIdImportModels({
-      path: { id: props.providerId },
-      throwOnError: true,
-    })
-    queryCache.invalidateQueries({ key: ['provider-models'] })
-    queryCache.invalidateQueries({ key: ['models'] })
-    queryCache.invalidateQueries({ key: ['all-models'] })
-    toast.success(t('models.refreshSuccess', {
-      created: data?.created ?? 0,
-      updated: data?.updated ?? 0,
-    }))
-  } catch {
-    toast.error(t('models.refreshFailed'))
-  } finally {
-    refreshLoading.value = false
-  }
-}
-
 // Always offer search once there are models, so the box never disappears for a
 // short list (which read as inconsistent between providers). When it's shown,
 // model rows align their text to the search placeholder.

--- a/apps/web/src/pages/providers/components/provider-form.test.ts
+++ b/apps/web/src/pages/providers/components/provider-form.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import type { Slots } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  getOAuthStatus: vi.fn(),
+  pollOAuth: vi.fn(),
+  syncCatalog: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+function translate(key: string) {
+  return key
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: translate }),
+}))
+
+vi.mock('@memohai/sdk', () => ({
+  deleteProvidersByIdOauthToken: vi.fn(),
+  getProvidersByIdOauthAuthorize: vi.fn(),
+  getProvidersByIdOauthStatus: mocks.getOAuthStatus,
+  postProvidersByIdOauthPoll: mocks.pollOAuth,
+  postProvidersByIdTest: vi.fn(),
+}))
+
+vi.mock('@/composables/useProviderModelCatalog', () => ({
+  useProviderModelCatalog: () => ({ syncProviderModelCatalog: mocks.syncCatalog }),
+}))
+
+vi.mock('lucide-vue-next', () => ({
+  AlertCircle: () => h('span'),
+  KeyRound: () => h('span'),
+  RefreshCw: () => h('span'),
+}))
+
+vi.mock('@felinic/ui', async () => {
+  const { h } = await import('vue')
+  const Passthrough = (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.())
+  const FormField = (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.({
+    componentField: {},
+    errorMessage: '',
+  }))
+  return {
+    AutoHeight: Passthrough,
+    Button: Passthrough,
+    FormControl: Passthrough,
+    FormField,
+    FormItem: Passthrough,
+    FormMessage: Passthrough,
+    HoverCard: Passthrough,
+    HoverCardContent: Passthrough,
+    HoverCardTrigger: Passthrough,
+    Input: Passthrough,
+    LabelSwap: Passthrough,
+    Select: Passthrough,
+    SelectContent: Passthrough,
+    SelectItem: Passthrough,
+    SelectTrigger: Passthrough,
+    SelectValue: Passthrough,
+    Spinner: Passthrough,
+    toast: {
+      success: mocks.toastSuccess,
+      error: mocks.toastError,
+    },
+  }
+})
+
+vi.mock('@/components/confirm-popover/index.vue', () => ({ default: { template: '<div><slot /></div>' } }))
+vi.mock('@/components/device-code-panel/index.vue', () => ({ default: { template: '<div><slot /></div>' } }))
+vi.mock('@/components/loading-button/index.vue', () => ({ default: { template: '<div><slot /></div>' } }))
+vi.mock('@/components/settings/row.vue', () => ({ default: { template: '<div><slot /></div>' } }))
+vi.mock('@/components/settings/section.vue', () => ({ default: { template: '<div><slot /></div>' } }))
+
+describe('provider OAuth model sync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    mocks.getOAuthStatus.mockResolvedValue({
+      data: {
+        configured: true,
+        mode: 'device',
+        has_token: false,
+        expired: false,
+        device: {
+          pending: true,
+          user_code: 'ABCD-EFGH',
+          verification_uri: 'https://github.com/login/device',
+          interval_seconds: 1,
+        },
+      },
+    })
+    mocks.pollOAuth.mockResolvedValue({
+      data: {
+        configured: true,
+        mode: 'device',
+        has_token: true,
+        expired: false,
+      },
+    })
+    mocks.syncCatalog.mockResolvedValue({ created: 2, updated: 1 })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('syncs the managed catalog when device authorization completes', async () => {
+    const ProviderForm = (await import('./provider-form.vue')).default
+    const root = document.createElement('div')
+    document.body.append(root)
+    const app = createApp(ProviderForm, {
+      provider: {
+        id: 'provider-id',
+        name: 'GitHub Copilot',
+        client_type: 'github-copilot',
+        enable: true,
+        config: {},
+      },
+      editLoading: false,
+    })
+    app.config.globalProperties.$t = translate
+    app.mount(root)
+    await flushPromises()
+
+    expect(mocks.getOAuthStatus).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(1000)
+    await flushPromises()
+
+    expect(mocks.pollOAuth).toHaveBeenCalledOnce()
+    expect(mocks.syncCatalog).toHaveBeenCalledOnce()
+    expect(mocks.syncCatalog).toHaveBeenCalledWith('provider-id')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('provider.oauth.authorizeSuccess')
+
+    app.unmount()
+    root.remove()
+  })
+})

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -1,7 +1,7 @@
 <template>
   <form @submit="editProvider">
     <SettingsSection
-      v-if="!isCodexProvider"
+      v-if="!isManagedOAuthProvider"
       :title="$t('provider.configurationTitle')"
     >
       <!-- Field rows are grouped so the LAST one keeps its `last:border-b-0`
@@ -81,7 +81,7 @@
         </FormField>
 
         <FormField
-          v-if="!isProviderOAuthClientType(form.values.client_type)"
+          v-if="!isManagedOAuthClientType(form.values.client_type)"
           v-slot="{ componentField, errorMessage }"
           name="api_key"
         >
@@ -210,9 +210,9 @@
          形状的已重构参考):一行账号状态 + 行内动作,等待输码时才在卡片内追加
          居中的验证码块(倒计时 + 复制并打开),轮询在后台静默完成授权。 -->
     <SettingsSection
-      v-if="isProviderOAuthClientType(form.values.client_type)"
+      v-if="isManagedOAuthClientType(form.values.client_type)"
       :title="$t('provider.oauth.sectionTitle')"
-      :class="{ 'mt-6': !isCodexProvider }"
+      :class="{ 'mt-6': !isManagedOAuthProvider }"
     >
       <!-- AutoHeight:状态切换(尤其设备码块出现/收起)让卡片平滑生长,不硬切。 -->
       <AutoHeight>
@@ -344,7 +344,10 @@ import DeviceCodePanel from '@/components/device-code-panel/index.vue'
 import LoadingButton from '@/components/loading-button/index.vue'
 import SettingsRow from '@/components/settings/row.vue'
 import SettingsSection from '@/components/settings/section.vue'
-import { LLM_CLIENT_TYPE_LIST } from '@/constants/client-types'
+import {
+  isManagedOAuthClientType,
+  MANUAL_LLM_CLIENT_TYPE_LIST,
+} from '@/constants/client-types'
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { toTypedSchema } from '@vee-validate/zod'
 import z from 'zod'
@@ -364,8 +367,10 @@ import type {
 } from '@memohai/sdk'
 import { useI18n } from 'vue-i18n'
 import { toast } from '@felinic/ui'
+import { useProviderModelCatalog } from '@/composables/useProviderModelCatalog'
 
 const { t } = useI18n()
+const { syncProviderModelCatalog } = useProviderModelCatalog()
 
 type ProviderWithAuth = Partial<ProvidersGetResponse>
 
@@ -389,16 +394,12 @@ function supportsPromptCache(clientType: string | undefined): boolean {
   return !!clientType && PROMPT_CACHE_CLIENT_TYPES.has(clientType)
 }
 
-function isProviderOAuthClientType(clientType: string | undefined): boolean {
-  return clientType === 'openai-codex' || clientType === 'github-copilot'
-}
-
 const props = defineProps<{
   provider: ProviderWithAuth | undefined
   editLoading: boolean
 }>()
 
-const isCodexProvider = computed(() => props.provider?.client_type === 'openai-codex')
+const isManagedOAuthProvider = computed(() => isManagedOAuthClientType(props.provider?.client_type))
 
 const emit = defineEmits<{
   submit: [values: Record<string, unknown>]
@@ -478,7 +479,7 @@ watch(() => props.provider?.id, () => {
 })
 
 const clientTypeOptions = computed(() =>
-  LLM_CLIENT_TYPE_LIST.map((ct) => ({
+  MANUAL_LLM_CLIENT_TYPE_LIST.map((ct) => ({
     value: ct.value,
     label: ct.label,
   })),
@@ -495,7 +496,7 @@ const providerSchema = toTypedSchema(z.object({
   const existingSecret = getStoredSecret(
     props.provider?.config as Record<string, unknown> | undefined,
   )
-  if (!isProviderOAuthClientType(value.client_type) && !value.api_key?.trim() && !existingSecret.trim()) {
+  if (!isManagedOAuthClientType(value.client_type) && !value.api_key?.trim() && !existingSecret.trim()) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['api_key'],
@@ -530,7 +531,7 @@ watch(() => props.provider, (newVal) => {
 }, { immediate: true })
 
 watch(() => form.values.client_type, (clientType) => {
-  if (!isProviderOAuthClientType(clientType)) {
+  if (!isManagedOAuthClientType(clientType)) {
     oauthStatus.value = null
   }
   if (clientType === 'openai-codex' && !form.values.base_url) {
@@ -542,7 +543,7 @@ watch(() => form.values.client_type, (clientType) => {
 })
 
 watch(() => [props.provider?.id, form.values.client_type] as const, async ([id, clientType]) => {
-  if (!id || (clientType !== 'openai-codex' && clientType !== 'github-copilot')) {
+  if (!id || !isManagedOAuthClientType(clientType)) {
     oauthStatus.value = null
     return
   }
@@ -673,6 +674,14 @@ async function pollOAuthAuthorization(notifyOnSuccess = false) {
     oauthStatus.value = nextStatus
     if (notifyOnSuccess && becameAuthorized) {
       toast.success(t('provider.oauth.authorizeSuccess'))
+      // Both managed OAuth providers need an account-scoped model catalog.
+      // Sync immediately after the token is stored so the provider is usable
+      // without a second manual action; failure leaves Refresh available.
+      try {
+        await syncProviderModelCatalog(props.provider.id)
+      } catch {
+        toast.error(t('models.refreshFailed'))
+      }
     }
   } catch (error) {
     clearDevicePollTimer()

--- a/apps/web/src/pages/providers/model-setting.vue
+++ b/apps/web/src/pages/providers/model-setting.vue
@@ -56,7 +56,7 @@
       <ModelList
         :provider-id="curProvider?.id"
         :models="modelDataList"
-        :managed="curProvider?.client_type === 'openai-codex'"
+        :managed="isManagedModelCatalogClientType(curProvider?.client_type)"
         :delete-model-loading="deleteModelLoading"
         @edit="handleEditModel"
         @delete="deleteModel"
@@ -81,6 +81,7 @@ import { putProvidersById, deleteProvidersById, getProvidersByIdModels, deleteMo
 import type { ModelsGetResponse, ProvidersGetResponse, ProvidersUpdateRequest } from '@memohai/sdk'
 import { useI18n } from 'vue-i18n'
 import { toast } from '@felinic/ui'
+import { isManagedModelCatalogClientType } from '@/constants/client-types'
 
 // ---- Model 编辑状态（provide 给 CreateModel） ----
 const openModel = reactive<{

--- a/db/postgres/migrations/0001_init.up.sql
+++ b/db/postgres/migrations/0001_init.up.sql
@@ -954,7 +954,8 @@ CREATE TABLE IF NOT EXISTS provider_oauth_tokens (
 
 CREATE INDEX IF NOT EXISTS idx_provider_oauth_tokens_state ON provider_oauth_tokens(state) WHERE state != '';
 
--- user_provider_oauth_tokens: per-user OAuth2 tokens for providers with user-scoped auth (e.g. GitHub Copilot)
+-- user_provider_oauth_tokens: legacy per-user OAuth2 storage retained for rollback compatibility.
+-- Active Codex and GitHub Copilot credentials are provider-scoped in provider_oauth_tokens.
 CREATE TABLE IF NOT EXISTS user_provider_oauth_tokens (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   provider_id UUID NOT NULL REFERENCES providers(id) ON DELETE CASCADE,

--- a/db/postgres/queries/user_provider_oauth.sql
+++ b/db/postgres/queries/user_provider_oauth.sql
@@ -1,3 +1,6 @@
+-- Legacy per-user OAuth storage retained for rollback compatibility.
+-- Active provider OAuth flows do not read or write these rows.
+
 -- name: UpsertUserProviderOAuthToken :one
 INSERT INTO user_provider_oauth_tokens (
   provider_id,

--- a/internal/handlers/providers.go
+++ b/internal/handlers/providers.go
@@ -331,7 +331,7 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 	resp := providers.ImportModelsResponse{
 		Models: make([]string, 0),
 	}
-	managedCodex := models.ClientType(provider.ClientType) == models.ClientTypeOpenAICodex
+	managedCatalog := providers.IsManagedModelCatalogClientType(models.ClientType(provider.ClientType))
 	availableModelIDs := make(map[string]struct{}, len(remoteModels))
 
 	// Bulk import lands disabled — the user picks which ones to expose in
@@ -346,7 +346,7 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 			modelType = models.ModelTypeEmbedding
 		}
 		compatibilities := m.Compatibilities
-		if len(compatibilities) == 0 && modelType == models.ModelTypeChat {
+		if len(compatibilities) == 0 && modelType == models.ModelTypeChat && !m.CapabilitiesKnown {
 			// No capability info at all (no upstream claim, no registry match):
 			// fall back to a permissive default, but respect an explicit
 			// "no reasoning" discovery so we don't advertise thinking falsely.
@@ -367,7 +367,7 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 			ContextWindow:    m.ContextWindow,
 			Dimensions:       m.Dimensions,
 		}
-		if managedCodex {
+		if managedCatalog {
 			available := true
 			cfg.CatalogAvailable = &available
 		}
@@ -383,7 +383,7 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 			if errors.Is(err, models.ErrModelIDAlreadyExists) {
 				// Upsert/assert: re-importing fills in newly discovered
 				// capabilities on existing models without clobbering user config.
-				if h.fillExistingModel(ctx, id, m.ID, cfg) {
+				if h.fillExistingModel(ctx, id, m.ID, cfg, managedCatalog && m.CapabilitiesKnown) {
 					resp.Updated++
 				} else {
 					resp.Skipped++
@@ -397,17 +397,17 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 		resp.Created++
 		resp.Models = append(resp.Models, m.ID)
 	}
-	if managedCodex {
-		h.markUnavailableCodexModels(ctx, id, availableModelIDs)
+	if managedCatalog {
+		h.markUnavailableManagedModels(ctx, id, availableModelIDs)
 	}
 
 	return c.JSON(http.StatusOK, resp)
 }
 
-func (h *ProvidersHandler) markUnavailableCodexModels(ctx context.Context, providerID string, available map[string]struct{}) {
+func (h *ProvidersHandler) markUnavailableManagedModels(ctx context.Context, providerID string, available map[string]struct{}) {
 	existingModels, err := h.modelsService.ListByProviderID(ctx, providerID)
 	if err != nil {
-		h.logger.Warn("failed to list Codex models for catalog reconciliation", slog.Any("error", err))
+		h.logger.Warn("failed to list managed models for catalog reconciliation", slog.Any("error", err))
 		return
 	}
 	for _, existing := range existingModels {
@@ -427,27 +427,31 @@ func (h *ProvidersHandler) markUnavailableCodexModels(ctx context.Context, provi
 			Type:       existing.Type,
 			Config:     config,
 		}); err != nil {
-			h.logger.Warn("failed to mark stale Codex model unavailable", slog.String("model_id", existing.ModelID), slog.Any("error", err))
+			h.logger.Warn("failed to mark stale managed model unavailable", slog.String("model_id", existing.ModelID), slog.Any("error", err))
 		}
 	}
 }
 
 // fillExistingModel refreshes an existing model's capability-discovery fields
-// from the latest trusted discovery (upstream + litellm registry) and adds
-// missing compatibility tokens. Re-import is a refresh: newer discovery
-// overwrites stale capability values (thinking_mode / effort tiers / context
-// window) rather than only filling blanks, so an old, less-accurate import
-// (e.g. an effort list missing xhigh/max) cannot survive. Returns true if the
-// model was changed and persisted.
+// from the latest trusted discovery. Managed catalogs replace authoritative
+// capability fields exactly, including removal; generic discovery keeps its
+// additive compatibility behavior because an empty field can mean unknown.
+// Returns true if the model was changed and persisted.
 //
 // The lookup is provider-scoped because model_id is only unique per provider;
 // same-named models under other providers must not affect this refresh.
-func (h *ProvidersHandler) fillExistingModel(ctx context.Context, providerID, modelID string, discovered models.ModelConfig) bool {
+func (h *ProvidersHandler) fillExistingModel(ctx context.Context, providerID, modelID string, discovered models.ModelConfig, replaceCapabilities bool) bool {
 	existing, err := h.modelsService.GetByProviderAndModelID(ctx, providerID, modelID)
 	if err != nil {
 		return false
 	}
-	merged, changed := mergeDiscoveredConfig(existing.Config, discovered)
+	var merged models.ModelConfig
+	var changed bool
+	if replaceCapabilities {
+		merged, changed = mergeManagedDiscoveredConfig(existing.Config, discovered)
+	} else {
+		merged, changed = mergeDiscoveredConfig(existing.Config, discovered)
+	}
 	if !changed {
 		return false
 	}
@@ -462,6 +466,23 @@ func (h *ProvidersHandler) fillExistingModel(ctx context.Context, providerID, mo
 		return false
 	}
 	return true
+}
+
+func mergeManagedDiscoveredConfig(existing, discovered models.ModelConfig) (models.ModelConfig, bool) {
+	out, changed := mergeDiscoveredConfig(existing, discovered)
+	if !slices.Equal(out.Compatibilities, discovered.Compatibilities) {
+		out.Compatibilities = append([]string(nil), discovered.Compatibilities...)
+		changed = true
+	}
+	if !slices.Equal(out.ReasoningEfforts, discovered.ReasoningEfforts) {
+		out.ReasoningEfforts = append([]string(nil), discovered.ReasoningEfforts...)
+		changed = true
+	}
+	if discovered.ThinkingMode != "" && out.ThinkingMode != discovered.ThinkingMode {
+		out.ThinkingMode = discovered.ThinkingMode
+		changed = true
+	}
+	return out, changed
 }
 
 func mergeDiscoveredConfig(existing, discovered models.ModelConfig) (models.ModelConfig, bool) {

--- a/internal/handlers/providers_description_test.go
+++ b/internal/handlers/providers_description_test.go
@@ -45,3 +45,31 @@ func TestMergeDiscoveredConfigFillsOnlyMissingDescription(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeManagedDiscoveredConfigReplacesCapabilities(t *testing.T) {
+	t.Parallel()
+
+	existing := models.ModelConfig{
+		Compatibilities:  []string{models.CompatVision, models.CompatToolCall, models.CompatReasoning},
+		ReasoningEfforts: []string{models.ReasoningEffortHigh},
+		ThinkingMode:     models.ThinkingModeToggle,
+	}
+	discovered := models.ModelConfig{
+		Compatibilities: []string{models.CompatToolCall},
+		ThinkingMode:    models.ThinkingModeNone,
+	}
+
+	got, changed := mergeManagedDiscoveredConfig(existing, discovered)
+	if !changed {
+		t.Fatal("expected managed capability refresh to report a change")
+	}
+	if len(got.Compatibilities) != 1 || got.Compatibilities[0] != models.CompatToolCall {
+		t.Fatalf("compatibilities = %#v", got.Compatibilities)
+	}
+	if len(got.ReasoningEfforts) != 0 {
+		t.Fatalf("reasoning efforts = %#v, want empty", got.ReasoningEfforts)
+	}
+	if got.ThinkingMode != models.ThinkingModeNone {
+		t.Fatalf("thinking mode = %q, want none", got.ThinkingMode)
+	}
+}

--- a/internal/models/probe.go
+++ b/internal/models/probe.go
@@ -20,7 +20,6 @@ import (
 	memohcopilot "github.com/memohai/memoh/internal/copilot"
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
-	"github.com/memohai/memoh/internal/oauthctx"
 )
 
 const probeTimeout = DefaultProviderProbeTimeout
@@ -236,18 +235,7 @@ func (s *Service) resolveModelCredentials(ctx context.Context, provider sqlc.Pro
 }
 
 func (s *Service) resolveGitHubCopilotAccessToken(ctx context.Context, provider sqlc.Provider) (string, error) {
-	userID := oauthctx.UserIDFromContext(ctx)
-	if userID == "" {
-		return "", errors.New("github copilot requires a current user")
-	}
-	userUUID, err := db.ParseUUID(userID)
-	if err != nil {
-		return "", err
-	}
-	row, err := s.queries.GetUserProviderOAuthToken(ctx, sqlc.GetUserProviderOAuthTokenParams{
-		ProviderID: provider.ID,
-		UserID:     userUUID,
-	})
+	row, err := s.queries.GetProviderOAuthTokenByProvider(ctx, provider.ID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/providers/codex_models.go
+++ b/internal/providers/codex_models.go
@@ -130,16 +130,17 @@ func (s *Service) listCodexRemoteModels(ctx context.Context, baseURL string, cre
 		}
 
 		remoteModels = append(remoteModels, RemoteModel{
-			ID:               modelID,
-			Name:             name,
-			DisplayName:      name,
-			Object:           "model",
-			OwnedBy:          "openai-codex",
-			Type:             string(models.ModelTypeChat),
-			Compatibilities:  compatibilities,
-			ReasoningEfforts: reasoningEfforts,
-			ThinkingMode:     thinkingMode,
-			ContextWindow:    contextWindow,
+			ID:                modelID,
+			Name:              name,
+			DisplayName:       name,
+			Object:            "model",
+			OwnedBy:           "openai-codex",
+			Type:              string(models.ModelTypeChat),
+			Compatibilities:   compatibilities,
+			ReasoningEfforts:  reasoningEfforts,
+			ThinkingMode:      thinkingMode,
+			ContextWindow:     contextWindow,
+			CapabilitiesKnown: true,
 		})
 	}
 	return remoteModels, nil

--- a/internal/providers/copilot_models.go
+++ b/internal/providers/copilot_models.go
@@ -1,0 +1,173 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	memohcopilot "github.com/memohai/memoh/internal/copilot"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/models"
+)
+
+const (
+	copilotModelsResponseLimit  = 8 << 20
+	copilotModelsErrorBodyLimit = 16 << 10
+)
+
+type copilotModelsResponse struct {
+	Data []copilotModelInfo `json:"data"`
+}
+
+type copilotModelInfo struct {
+	ID                 string                   `json:"id"`
+	Name               string                   `json:"name"`
+	Vendor             string                   `json:"vendor"`
+	ModelPickerEnabled bool                     `json:"model_picker_enabled"`
+	Policy             copilotModelPolicy       `json:"policy"`
+	SupportedEndpoints []string                 `json:"supported_endpoints"`
+	Capabilities       copilotModelCapabilities `json:"capabilities"`
+}
+
+type copilotModelPolicy struct {
+	State string `json:"state"`
+}
+
+type copilotModelCapabilities struct {
+	Type     string               `json:"type"`
+	Limits   copilotModelLimits   `json:"limits"`
+	Supports copilotModelSupports `json:"supports"`
+}
+
+type copilotModelLimits struct {
+	MaxContextWindowTokens *int `json:"max_context_window_tokens"`
+}
+
+type copilotModelSupports struct {
+	ToolCalls       bool     `json:"tool_calls"`
+	Vision          bool     `json:"vision"`
+	ReasoningEffort []string `json:"reasoning_effort"`
+}
+
+func (s *Service) fetchGitHubCopilotModels(ctx context.Context, provider sqlc.Provider) ([]RemoteModel, error) {
+	// Model discovery is authorized by the long-lived GitHub OAuth token. The
+	// short-lived Copilot inference token is valid for generation requests but
+	// is rejected by the account-scoped /models endpoint.
+	githubToken, err := s.GetValidAccessToken(ctx, provider.ID.String())
+	if err != nil {
+		return nil, fmt.Errorf("resolve GitHub Copilot OAuth token: %w", err)
+	}
+	return s.listGitHubCopilotRemoteModels(ctx, memohcopilot.DefaultAPIBaseURL, githubToken)
+}
+
+func (s *Service) listGitHubCopilotRemoteModels(ctx context.Context, baseURL, githubToken string) ([]RemoteModel, error) {
+	endpoint, err := url.Parse(strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/models")
+	if err != nil {
+		return nil, fmt.Errorf("parse GitHub Copilot models URL: %w", err)
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create GitHub Copilot models request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(githubToken))
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := memohcopilot.NewHTTPClient(s.httpClient).Do(req) //nolint:gosec // The production endpoint is fixed; the parameter exists for isolated tests.
+	if err != nil {
+		return nil, fmt.Errorf("request GitHub Copilot models: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, copilotModelsErrorBodyLimit))
+		detail := strings.TrimSpace(string(body))
+		if detail == "" {
+			detail = http.StatusText(resp.StatusCode)
+		}
+		return nil, fmt.Errorf("github copilot models request failed (%d): %s", resp.StatusCode, detail)
+	}
+
+	var catalog copilotModelsResponse
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, copilotModelsResponseLimit))
+	if err := decoder.Decode(&catalog); err != nil {
+		return nil, fmt.Errorf("decode GitHub Copilot models response: %w", err)
+	}
+
+	// Some OAuth clients receive a catalog where every picker flag is false,
+	// even though policy still identifies usable models. Honor picker flags when
+	// the response contains an enabled picker model; otherwise fall back to all
+	// models that are not explicitly disabled by account policy.
+	hasPickerModels := false
+	for _, model := range catalog.Data {
+		if model.ModelPickerEnabled {
+			hasPickerModels = true
+			break
+		}
+	}
+
+	remoteModels := make([]RemoteModel, 0, len(catalog.Data))
+	for _, model := range catalog.Data {
+		modelID := strings.TrimSpace(model.ID)
+		if modelID == "" || strings.EqualFold(strings.TrimSpace(model.Policy.State), "disabled") {
+			continue
+		}
+		if hasPickerModels && !model.ModelPickerEnabled {
+			continue
+		}
+		modelType := strings.ToLower(strings.TrimSpace(model.Capabilities.Type))
+		if modelType != "" && modelType != string(models.ModelTypeChat) {
+			continue
+		}
+		// Older catalog responses omit supported_endpoints for ordinary chat
+		// models. A non-empty endpoint list is authoritative, so reject models
+		// that can only use transports Twilight's Copilot provider lacks.
+		if len(model.SupportedEndpoints) > 0 && !containsFold(model.SupportedEndpoints, "/chat/completions") {
+			continue
+		}
+
+		name := strings.TrimSpace(model.Name)
+		if name == "" {
+			name = modelID
+		}
+		compatibilities := make([]string, 0, 3)
+		if model.Capabilities.Supports.ToolCalls {
+			compatibilities = append(compatibilities, models.CompatToolCall)
+		}
+		if model.Capabilities.Supports.Vision {
+			compatibilities = append(compatibilities, models.CompatVision)
+		}
+		reasoningEfforts := make([]string, 0, len(model.Capabilities.Supports.ReasoningEffort))
+		for _, effort := range model.Capabilities.Supports.ReasoningEffort {
+			effort = strings.ToLower(strings.TrimSpace(effort))
+			if models.IsValidReasoningEffort(effort) && !containsFold(reasoningEfforts, effort) {
+				reasoningEfforts = append(reasoningEfforts, effort)
+			}
+		}
+		thinkingMode := models.ThinkingModeNone
+		if len(reasoningEfforts) > 0 {
+			compatibilities = append(compatibilities, models.CompatReasoning)
+			thinkingMode = models.ThinkingModeToggle
+		}
+
+		remoteModels = append(remoteModels, RemoteModel{
+			ID:                modelID,
+			Name:              name,
+			DisplayName:       name,
+			Object:            "model",
+			OwnedBy:           strings.TrimSpace(model.Vendor),
+			Type:              string(models.ModelTypeChat),
+			Compatibilities:   compatibilities,
+			ReasoningEfforts:  reasoningEfforts,
+			ThinkingMode:      thinkingMode,
+			ContextWindow:     model.Capabilities.Limits.MaxContextWindowTokens,
+			CapabilitiesKnown: true,
+		})
+	}
+	return remoteModels, nil
+}

--- a/internal/providers/copilot_models_test.go
+++ b/internal/providers/copilot_models_test.go
@@ -1,0 +1,155 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/models"
+)
+
+func TestListGitHubCopilotRemoteModels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses picker catalog and maps capabilities", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/models" {
+				t.Fatalf("path = %q, want /models", r.URL.Path)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer github-oauth-token" {
+				t.Fatalf("authorization = %q", got)
+			}
+			if got := r.Header.Get("Copilot-Integration-Id"); got == "" {
+				t.Fatal("Copilot-Integration-Id header is missing")
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					{
+						"id":                   "reasoning-model",
+						"name":                 "Reasoning Model",
+						"vendor":               "Example",
+						"model_picker_enabled": true,
+						"policy":               map[string]any{"state": "enabled"},
+						"supported_endpoints":  []string{"/chat/completions", "/responses"},
+						"capabilities": map[string]any{
+							"type":   "chat",
+							"limits": map[string]any{"max_context_window_tokens": 200000},
+							"supports": map[string]any{
+								"tool_calls":       true,
+								"vision":           true,
+								"reasoning_effort": []string{"low", "max", "ultra", "low"},
+							},
+						},
+					},
+					{
+						"id": "not-in-picker", "model_picker_enabled": false,
+						"capabilities": map[string]any{"type": "chat"},
+					},
+					{
+						"id": "disabled", "model_picker_enabled": true,
+						"policy":       map[string]any{"state": "disabled"},
+						"capabilities": map[string]any{"type": "chat"},
+					},
+					{
+						"id": "responses-only", "model_picker_enabled": true,
+						"supported_endpoints": []string{"/responses"},
+						"capabilities":        map[string]any{"type": "chat"},
+					},
+					{
+						"id": "embedding", "model_picker_enabled": true,
+						"capabilities": map[string]any{"type": "embeddings"},
+					},
+				},
+			})
+		}))
+		defer server.Close()
+
+		svc := &Service{httpClient: server.Client()}
+		remoteModels, err := svc.listGitHubCopilotRemoteModels(context.Background(), server.URL, "github-oauth-token")
+		if err != nil {
+			t.Fatalf("list GitHub Copilot models: %v", err)
+		}
+		if len(remoteModels) != 1 {
+			t.Fatalf("models = %d, want 1: %#v", len(remoteModels), remoteModels)
+		}
+		model := remoteModels[0]
+		if model.ID != "reasoning-model" || model.Name != "Reasoning Model" || model.OwnedBy != "Example" {
+			t.Fatalf("unexpected model: %#v", model)
+		}
+		if got := strings.Join(model.Compatibilities, ","); got != "tool-call,vision,reasoning" {
+			t.Fatalf("compatibilities = %q", got)
+		}
+		if got := strings.Join(model.ReasoningEfforts, ","); got != "low,max" {
+			t.Fatalf("reasoning efforts = %q", got)
+		}
+		if model.ThinkingMode != models.ThinkingModeToggle {
+			t.Fatalf("thinking mode = %q", model.ThinkingMode)
+		}
+		if model.ContextWindow == nil || *model.ContextWindow != 200000 {
+			t.Fatalf("context window = %#v", model.ContextWindow)
+		}
+		if !model.CapabilitiesKnown {
+			t.Fatal("Copilot catalog capabilities should be authoritative")
+		}
+	})
+
+	t.Run("falls back when all picker flags are false", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{
+					{
+						"id":           "default-chat",
+						"capabilities": map[string]any{"type": "chat"},
+					},
+					{
+						"id":                  "enabled-chat",
+						"policy":              map[string]any{"state": "enabled"},
+						"supported_endpoints": []string{"/chat/completions"},
+						"capabilities":        map[string]any{"type": "chat"},
+					},
+					{
+						"id":           "disabled-chat",
+						"policy":       map[string]any{"state": "disabled"},
+						"capabilities": map[string]any{"type": "chat"},
+					},
+					{
+						"id":                  "responses-only",
+						"supported_endpoints": []string{"/responses"},
+						"capabilities":        map[string]any{"type": "chat"},
+					},
+				},
+			})
+		}))
+		defer server.Close()
+
+		svc := &Service{httpClient: server.Client()}
+		remoteModels, err := svc.listGitHubCopilotRemoteModels(context.Background(), server.URL, "github-oauth-token")
+		if err != nil {
+			t.Fatalf("list GitHub Copilot models: %v", err)
+		}
+		if len(remoteModels) != 2 || remoteModels[0].ID != "default-chat" || remoteModels[1].ID != "enabled-chat" {
+			t.Fatalf("unexpected fallback models: %#v", remoteModels)
+		}
+	})
+}
+
+func TestIsManagedModelCatalogClientType(t *testing.T) {
+	t.Parallel()
+
+	if !IsManagedModelCatalogClientType(models.ClientTypeOpenAICodex) {
+		t.Fatal("Codex should use a managed model catalog")
+	}
+	if !IsManagedModelCatalogClientType(models.ClientTypeGitHubCopilot) {
+		t.Fatal("GitHub Copilot should use a managed model catalog")
+	}
+	if IsManagedModelCatalogClientType(models.ClientTypeOpenAICompletions) {
+		t.Fatal("OpenAI Completions should remain manually managed")
+	}
+}

--- a/internal/providers/oauth.go
+++ b/internal/providers/oauth.go
@@ -24,7 +24,6 @@ import (
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	"github.com/memohai/memoh/internal/models"
-	"github.com/memohai/memoh/internal/oauthctx"
 )
 
 const (
@@ -74,7 +73,6 @@ var (
 
 type oauthTokenRecord struct {
 	ProviderID       string
-	UserID           string
 	AccessToken      string //nolint:gosec // Runtime token payload persisted encrypted at rest.
 	RefreshToken     string //nolint:gosec // Runtime token payload persisted encrypted at rest.
 	ExpiresAt        time.Time
@@ -170,13 +168,10 @@ func providerMetadata(raw []byte) map[string]any {
 	return metadata
 }
 
-func oauthLogAttrs(providerID, userID string, err error) []any {
+func oauthLogAttrs(providerID string, err error) []any {
 	attrs := []any{}
 	if strings.TrimSpace(providerID) != "" {
 		attrs = append(attrs, slog.String("provider_id", providerID))
-	}
-	if strings.TrimSpace(userID) != "" {
-		attrs = append(attrs, slog.String("user_id", userID))
 	}
 	if err != nil {
 		attrs = append(attrs, slog.Any("error", err))
@@ -247,10 +242,6 @@ func supportsOAuth(provider sqlc.Provider) bool {
 	}
 }
 
-func isUserScopedOAuthProvider(provider sqlc.Provider) bool {
-	return models.ClientType(provider.ClientType) == models.ClientTypeGitHubCopilot
-}
-
 func (s *Service) StartOAuthAuthorization(ctx context.Context, providerID string) (*OAuthAuthorizeResponse, error) {
 	provider, err := s.loadOAuthProvider(ctx, providerID)
 	if err != nil {
@@ -280,12 +271,8 @@ func (s *Service) StartOAuthAuthorization(ctx context.Context, providerID string
 		return &OAuthAuthorizeResponse{Mode: "device", Device: device.toStatus()}, nil
 	}
 
-	if isUserScopedOAuthProvider(provider) {
-		userID := oauthctx.UserIDFromContext(ctx)
-		if userID == "" {
-			return nil, errors.New("github copilot oauth requires a current user")
-		}
-		device, err := s.startGitHubDeviceAuthorization(ctx, providerID, userID, cfg)
+	if models.ClientType(provider.ClientType) == models.ClientTypeGitHubCopilot {
+		device, err := s.startGitHubDeviceAuthorization(ctx, providerID, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -581,12 +568,6 @@ func (s *Service) ExchangeOpenAICodexACPDeviceCode(ctx context.Context, authoriz
 }
 
 func (s *Service) HandleOAuthCallback(ctx context.Context, state, code string) (string, error) {
-	if userToken, err := s.getUserOAuthTokenByState(ctx, state); err == nil {
-		return s.handleUserScopedOAuthCallback(ctx, userToken, code)
-	} else if !errors.Is(err, pgx.ErrNoRows) {
-		return "", err
-	}
-
 	token, err := s.getOAuthTokenByState(ctx, state)
 	if err != nil {
 		return "", err
@@ -648,45 +629,7 @@ func openAICodexACPAuthIssuerBase() string {
 	return issuer
 }
 
-func (s *Service) handleUserScopedOAuthCallback(ctx context.Context, token *oauthTokenRecord, code string) (string, error) {
-	providerUUID, err := db.ParseUUID(token.ProviderID)
-	if err != nil {
-		return "", err
-	}
-	provider, err := s.queries.GetProviderByID(ctx, providerUUID)
-	if err != nil {
-		return "", fmt.Errorf("get provider: %w", err)
-	}
-	if !isUserScopedOAuthProvider(provider) {
-		return "", errors.New("provider does not use user-scoped oauth")
-	}
-
-	cfg := s.oauthConfigForProvider(provider)
-	resp, err := s.exchangeCode(ctx, cfg, code, token.PKCECodeVerifier)
-	if err != nil {
-		return "", err
-	}
-	if err := s.saveUserOAuthToken(ctx, token.ProviderID, token.UserID, oauthTokenRecord{
-		ProviderID:  token.ProviderID,
-		UserID:      token.UserID,
-		AccessToken: resp.AccessToken,
-		RefreshToken: firstNonEmpty(
-			resp.RefreshToken,
-			token.RefreshToken,
-		),
-		ExpiresAt:        expiresAtFromNow(resp.ExpiresIn),
-		Scope:            firstNonEmpty(resp.Scope, cfg.Scopes),
-		TokenType:        firstNonEmpty(resp.TokenType, "bearer"),
-		State:            "",
-		PKCECodeVerifier: "",
-		Metadata:         token.Metadata,
-	}); err != nil {
-		return "", err
-	}
-	return provider.ID.String(), nil
-}
-
-func (s *Service) startGitHubDeviceAuthorization(ctx context.Context, providerID, userID string, cfg oauthConfig) (*OAuthDeviceStatus, error) {
+func (s *Service) startGitHubDeviceAuthorization(ctx context.Context, providerID string, cfg oauthConfig) (*OAuthDeviceStatus, error) {
 	resp, err := s.requestDeviceAuthorization(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -699,7 +642,13 @@ func (s *Service) startGitHubDeviceAuthorization(ctx context.Context, providerID
 		ExpiresAt:       expiresAtFromNow(resp.ExpiresIn),
 		IntervalSeconds: resp.Interval,
 	}
-	if err := s.updateUserOAuthState(ctx, providerID, userID, "", "", device.toMetadata()); err != nil {
+	// Copilot is a shared Provider credential, just like Codex and API-key
+	// providers. Starting a new login replaces the previous shared credential
+	// so status cannot mix an authorized account with a pending device code.
+	if err := s.saveOAuthToken(ctx, providerID, oauthTokenRecord{
+		ProviderID: providerID,
+		Metadata:   device.toMetadata(),
+	}); err != nil {
 		return nil, err
 	}
 	return device.toStatus(), nil
@@ -719,22 +668,13 @@ func (s *Service) GetOAuthStatus(ctx context.Context, providerID string) (*OAuth
 	if !status.Configured {
 		return status, nil
 	}
-	if isUserScopedOAuthProvider(provider) || models.ClientType(provider.ClientType) == models.ClientTypeOpenAICodex {
+	if models.ClientType(provider.ClientType) == models.ClientTypeOpenAICodex ||
+		models.ClientType(provider.ClientType) == models.ClientTypeGitHubCopilot {
 		status.Mode = "device"
 		status.CallbackURL = ""
 	}
 
-	userID := ""
-	var token *oauthTokenRecord
-	if isUserScopedOAuthProvider(provider) {
-		userID = oauthctx.UserIDFromContext(ctx)
-		if userID == "" {
-			return nil, errors.New("github copilot oauth requires a current user")
-		}
-		token, err = s.getUserOAuthToken(ctx, providerID, userID)
-	} else {
-		token, err = s.getOAuthToken(ctx, providerID)
-	}
+	token, err := s.getOAuthToken(ctx, providerID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return status, nil
@@ -751,8 +691,8 @@ func (s *Service) GetOAuthStatus(ctx context.Context, providerID string) (*OAuth
 	if status.Mode == "device" {
 		status.Device = deviceMetadataFromMap(token.Metadata).toStatus()
 	}
-	if isUserScopedOAuthProvider(provider) {
-		account, accountErr := s.resolveGitHubOAuthAccount(ctx, providerID, userID, token)
+	if models.ClientType(provider.ClientType) == models.ClientTypeGitHubCopilot {
+		account, accountErr := s.resolveGitHubOAuthAccount(ctx, providerID, token)
 		if accountErr != nil {
 			return nil, accountErr
 		}
@@ -766,19 +706,19 @@ func (s *Service) PollOAuthAuthorization(ctx context.Context, providerID string)
 	if err != nil {
 		return nil, err
 	}
-	if models.ClientType(provider.ClientType) == models.ClientTypeOpenAICodex {
+	switch models.ClientType(provider.ClientType) {
+	case models.ClientTypeOpenAICodex:
 		return s.pollOpenAICodexProviderAuthorization(ctx, provider)
-	}
-	if !isUserScopedOAuthProvider(provider) {
+	case models.ClientTypeGitHubCopilot:
+		return s.pollGitHubCopilotProviderAuthorization(ctx, provider)
+	default:
 		return nil, errors.New("provider does not support device authorization")
 	}
+}
 
-	userID := oauthctx.UserIDFromContext(ctx)
-	if userID == "" {
-		return nil, errors.New("github copilot oauth requires a current user")
-	}
-
-	token, err := s.getUserOAuthToken(ctx, providerID, userID)
+func (s *Service) pollGitHubCopilotProviderAuthorization(ctx context.Context, provider sqlc.Provider) (*OAuthStatus, error) {
+	providerID := provider.ID.String()
+	token, err := s.getOAuthToken(ctx, providerID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return s.GetOAuthStatus(ctx, providerID)
@@ -790,7 +730,7 @@ func (s *Service) PollOAuthAuthorization(ctx context.Context, providerID string)
 		return s.GetOAuthStatus(ctx, providerID)
 	}
 	if !device.ExpiresAt.IsZero() && time.Now().After(device.ExpiresAt) {
-		if err := s.updateUserOAuthState(ctx, providerID, userID, "", "", nil); err != nil {
+		if err := s.updateOAuthState(ctx, providerID, "", "", nil); err != nil {
 			return nil, err
 		}
 		return s.GetOAuthStatus(ctx, providerID)
@@ -808,13 +748,13 @@ func (s *Service) PollOAuthAuthorization(ctx context.Context, providerID string)
 		case "slow_down":
 			if resp.Interval > 0 {
 				device.IntervalSeconds = resp.Interval
-				if err := s.updateUserOAuthState(ctx, providerID, userID, "", "", device.toMetadata()); err != nil {
+				if err := s.updateOAuthState(ctx, providerID, "", "", device.toMetadata()); err != nil {
 					return nil, err
 				}
 			}
 			return s.GetOAuthStatus(ctx, providerID)
 		case "expired_token", "access_denied", "incorrect_device_code", "unsupported_grant_type":
-			if err := s.updateUserOAuthState(ctx, providerID, userID, "", "", nil); err != nil {
+			if err := s.updateOAuthState(ctx, providerID, "", "", nil); err != nil {
 				return nil, err
 			}
 			return s.GetOAuthStatus(ctx, providerID)
@@ -825,12 +765,11 @@ func (s *Service) PollOAuthAuthorization(ctx context.Context, providerID string)
 
 	account, err := s.fetchGitHubOAuthAccount(ctx, resp.AccessToken)
 	if err != nil {
-		s.logger.Warn("fetch github oauth account failed", oauthLogAttrs(providerID, userID, err)...)
+		s.logger.Warn("fetch github oauth account failed", oauthLogAttrs(providerID, err)...)
 	}
 
-	if err := s.saveUserOAuthToken(ctx, providerID, userID, oauthTokenRecord{
+	if err := s.saveOAuthToken(ctx, providerID, oauthTokenRecord{
 		ProviderID:   providerID,
-		UserID:       userID,
 		AccessToken:  resp.AccessToken,
 		RefreshToken: firstNonEmpty(resp.RefreshToken, token.RefreshToken),
 		ExpiresAt:    expiresAtFromNow(resp.ExpiresIn),
@@ -900,13 +839,6 @@ func (s *Service) RevokeOAuthToken(ctx context.Context, providerID string) error
 		return errors.New("provider does not support oauth")
 	}
 
-	if isUserScopedOAuthProvider(provider) {
-		userID := oauthctx.UserIDFromContext(ctx)
-		if userID == "" {
-			return errors.New("github copilot oauth requires a current user")
-		}
-		return s.deleteUserOAuthToken(ctx, providerID, userID)
-	}
 	return s.queries.DeleteProviderOAuthToken(ctx, provider.ID)
 }
 
@@ -916,18 +848,6 @@ func (s *Service) GetValidAccessToken(ctx context.Context, providerID string) (s
 		return "", err
 	}
 	cfg := s.oauthConfigForProvider(provider)
-
-	if isUserScopedOAuthProvider(provider) {
-		userID := oauthctx.UserIDFromContext(ctx)
-		if userID == "" {
-			return "", errors.New("github copilot requires a current user")
-		}
-		token, err := s.getUserOAuthToken(ctx, providerID, userID)
-		if err != nil {
-			return "", err
-		}
-		return s.resolveValidUserOAuthToken(ctx, cfg, token)
-	}
 
 	token, err := s.getOAuthToken(ctx, providerID)
 	if err != nil {
@@ -963,39 +883,6 @@ func (s *Service) resolveValidProviderOAuthToken(ctx context.Context, cfg oauthC
 		Metadata:         token.Metadata,
 	}
 	if err := s.saveOAuthToken(ctx, token.ProviderID, saved); err != nil {
-		return "", err
-	}
-	return saved.AccessToken, nil
-}
-
-func (s *Service) resolveValidUserOAuthToken(ctx context.Context, cfg oauthConfig, token *oauthTokenRecord) (string, error) {
-	if strings.TrimSpace(token.AccessToken) == "" {
-		return "", errors.New("oauth token is missing access token")
-	}
-	if token.ExpiresAt.IsZero() || time.Now().Add(oauthExpirySkew).Before(token.ExpiresAt) {
-		return token.AccessToken, nil
-	}
-	if strings.TrimSpace(token.RefreshToken) == "" {
-		return "", errors.New("oauth token expired and no refresh token is available")
-	}
-
-	refreshed, err := s.refreshAccessToken(ctx, cfg, token.RefreshToken)
-	if err != nil {
-		return "", err
-	}
-	saved := oauthTokenRecord{
-		ProviderID:       token.ProviderID,
-		UserID:           token.UserID,
-		AccessToken:      refreshed.AccessToken,
-		RefreshToken:     firstNonEmpty(refreshed.RefreshToken, token.RefreshToken),
-		ExpiresAt:        expiresAtFromNow(refreshed.ExpiresIn),
-		Scope:            firstNonEmpty(refreshed.Scope, token.Scope),
-		TokenType:        firstNonEmpty(refreshed.TokenType, token.TokenType),
-		State:            token.State,
-		PKCECodeVerifier: token.PKCECodeVerifier,
-		Metadata:         token.Metadata,
-	}
-	if err := s.saveUserOAuthToken(ctx, token.ProviderID, token.UserID, saved); err != nil {
 		return "", err
 	}
 	return saved.AccessToken, nil
@@ -1072,115 +959,9 @@ func (s *Service) saveOAuthToken(ctx context.Context, providerID string, token o
 	return err
 }
 
-func (s *Service) getUserOAuthToken(ctx context.Context, providerID, userID string) (*oauthTokenRecord, error) {
-	providerUUID, err := db.ParseUUID(providerID)
-	if err != nil {
-		return nil, err
-	}
-	userUUID, err := db.ParseUUID(userID)
-	if err != nil {
-		return nil, err
-	}
-	row, err := s.queries.GetUserProviderOAuthToken(ctx, sqlc.GetUserProviderOAuthTokenParams{
-		ProviderID: providerUUID,
-		UserID:     userUUID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return toUserProviderOAuthToken(row), nil
-}
-
-func (s *Service) getUserOAuthTokenByState(ctx context.Context, state string) (*oauthTokenRecord, error) {
-	row, err := s.queries.GetUserProviderOAuthTokenByState(ctx, state)
-	if err != nil {
-		return nil, err
-	}
-	return toUserProviderOAuthToken(row), nil
-}
-
-func (s *Service) updateUserOAuthState(ctx context.Context, providerID, userID, state, codeVerifier string, metadata map[string]any) error {
-	providerUUID, err := db.ParseUUID(providerID)
-	if err != nil {
-		return err
-	}
-	userUUID, err := db.ParseUUID(userID)
-	if err != nil {
-		return err
-	}
-	return s.queries.UpdateUserProviderOAuthState(ctx, sqlc.UpdateUserProviderOAuthStateParams{
-		ProviderID:       providerUUID,
-		UserID:           userUUID,
-		State:            state,
-		PkceCodeVerifier: codeVerifier,
-		Metadata:         metadataJSON(metadata),
-	})
-}
-
-func (s *Service) saveUserOAuthToken(ctx context.Context, providerID, userID string, token oauthTokenRecord) error {
-	providerUUID, err := db.ParseUUID(providerID)
-	if err != nil {
-		return err
-	}
-	userUUID, err := db.ParseUUID(userID)
-	if err != nil {
-		return err
-	}
-	var expiresAt pgtype.Timestamptz
-	if !token.ExpiresAt.IsZero() {
-		expiresAt = pgtype.Timestamptz{Time: token.ExpiresAt, Valid: true}
-	}
-	_, err = s.queries.UpsertUserProviderOAuthToken(ctx, sqlc.UpsertUserProviderOAuthTokenParams{
-		ProviderID:       providerUUID,
-		UserID:           userUUID,
-		AccessToken:      token.AccessToken,
-		RefreshToken:     token.RefreshToken,
-		ExpiresAt:        expiresAt,
-		Scope:            token.Scope,
-		TokenType:        token.TokenType,
-		State:            token.State,
-		PkceCodeVerifier: token.PKCECodeVerifier,
-		Metadata:         metadataJSON(token.Metadata),
-	})
-	return err
-}
-
-func (s *Service) deleteUserOAuthToken(ctx context.Context, providerID, userID string) error {
-	providerUUID, err := db.ParseUUID(providerID)
-	if err != nil {
-		return err
-	}
-	userUUID, err := db.ParseUUID(userID)
-	if err != nil {
-		return err
-	}
-	return s.queries.DeleteUserProviderOAuthToken(ctx, sqlc.DeleteUserProviderOAuthTokenParams{
-		ProviderID: providerUUID,
-		UserID:     userUUID,
-	})
-}
-
 func toProviderOAuthToken(row sqlc.ProviderOauthToken) *oauthTokenRecord {
 	token := &oauthTokenRecord{
 		ProviderID:       row.ProviderID.String(),
-		AccessToken:      row.AccessToken,
-		RefreshToken:     row.RefreshToken,
-		Scope:            row.Scope,
-		TokenType:        row.TokenType,
-		State:            row.State,
-		PKCECodeVerifier: row.PkceCodeVerifier,
-		Metadata:         providerMetadata(row.Metadata),
-	}
-	if row.ExpiresAt.Valid {
-		token.ExpiresAt = row.ExpiresAt.Time
-	}
-	return token
-}
-
-func toUserProviderOAuthToken(row sqlc.UserProviderOauthToken) *oauthTokenRecord {
-	token := &oauthTokenRecord{
-		ProviderID:       row.ProviderID.String(),
-		UserID:           row.UserID.String(),
 		AccessToken:      row.AccessToken,
 		RefreshToken:     row.RefreshToken,
 		Scope:            row.Scope,
@@ -1331,7 +1112,7 @@ func (a oauthAccountMetadata) isZero() bool {
 	return a.Label == "" && a.Login == "" && a.Name == "" && a.Email == "" && a.AvatarURL == "" && a.ProfileURL == ""
 }
 
-func (s *Service) resolveGitHubOAuthAccount(ctx context.Context, providerID, userID string, token *oauthTokenRecord) (*OAuthAccount, error) {
+func (s *Service) resolveGitHubOAuthAccount(ctx context.Context, providerID string, token *oauthTokenRecord) (*OAuthAccount, error) {
 	account := accountMetadataFromMap(token.Metadata)
 	if status := account.toStatus(); status != nil {
 		return status, nil
@@ -1342,13 +1123,13 @@ func (s *Service) resolveGitHubOAuthAccount(ctx context.Context, providerID, use
 
 	refreshedAccount, err := s.fetchGitHubOAuthAccount(ctx, token.AccessToken)
 	if err != nil {
-		s.logger.Warn("refresh github oauth account metadata failed", oauthLogAttrs(providerID, userID, err)...)
+		s.logger.Warn("refresh github oauth account metadata failed", oauthLogAttrs(providerID, err)...)
 		return nil, nil
 	}
 
 	updatedToken := *token
 	updatedToken.Metadata = refreshedAccount.toMetadata()
-	if err := s.saveUserOAuthToken(ctx, providerID, userID, updatedToken); err != nil {
+	if err := s.saveOAuthToken(ctx, providerID, updatedToken); err != nil {
 		return nil, err
 	}
 	return refreshedAccount.toStatus(), nil

--- a/internal/providers/oauth_scope_test.go
+++ b/internal/providers/oauth_scope_test.go
@@ -1,0 +1,55 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+)
+
+type providerScopedOAuthQueries struct {
+	dbstore.Queries
+	provider           sqlc.Provider
+	token              sqlc.ProviderOauthToken
+	providerTokenReads int
+}
+
+func (q *providerScopedOAuthQueries) GetProviderByID(context.Context, pgtype.UUID) (sqlc.Provider, error) {
+	return q.provider, nil
+}
+
+func (q *providerScopedOAuthQueries) GetProviderOAuthTokenByProvider(context.Context, pgtype.UUID) (sqlc.ProviderOauthToken, error) {
+	q.providerTokenReads++
+	return q.token, nil
+}
+
+func TestGitHubCopilotOAuthUsesProviderScopedToken(t *testing.T) {
+	t.Parallel()
+
+	providerID := pgtype.UUID{Bytes: [16]byte{1}, Valid: true}
+	queries := &providerScopedOAuthQueries{
+		provider: sqlc.Provider{
+			ID:         providerID,
+			ClientType: "github-copilot",
+		},
+		token: sqlc.ProviderOauthToken{
+			ProviderID:  providerID,
+			AccessToken: "shared-github-token",
+		},
+	}
+	service := NewService(nil, queries, "")
+
+	token, err := service.GetValidAccessToken(context.Background(), providerID.String())
+	if err != nil {
+		t.Fatalf("get shared Copilot OAuth token: %v", err)
+	}
+	if token != "shared-github-token" {
+		t.Fatalf("token = %q, want shared provider token", token)
+	}
+	if queries.providerTokenReads != 1 {
+		t.Fatalf("provider token reads = %d, want 1", queries.providerTokenReads)
+	}
+}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -11,10 +11,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
-	githubcopilot "github.com/memohai/twilight-ai/provider/github/copilot"
 	sdk "github.com/memohai/twilight-ai/sdk"
 
-	memohcopilot "github.com/memohai/memoh/internal/copilot"
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -335,21 +333,18 @@ func (s *Service) FetchRemoteModels(ctx context.Context, id string) ([]RemoteMod
 	}
 
 	clientType := models.ClientType(provider.ClientType)
-	if clientType == models.ClientTypeOpenAICodex {
+	switch clientType {
+	case models.ClientTypeOpenAICodex:
 		return s.fetchCodexRemoteModels(ctx, provider)
+	case models.ClientTypeGitHubCopilot:
+		return s.fetchGitHubCopilotModels(ctx, provider)
 	}
 
 	if models, ok := s.fetchTemplateModels(provider); ok {
 		return models, nil
 	}
 
-	var remoteModels []RemoteModel
-	switch clientType {
-	case models.ClientTypeGitHubCopilot:
-		remoteModels, err = s.fetchGitHubCopilotModels(ctx, provider)
-	default:
-		remoteModels, err = s.fetchRemoteModelsViaSDK(ctx, provider)
-	}
+	remoteModels, err := s.fetchRemoteModelsViaSDK(ctx, provider)
 	if err != nil {
 		return nil, err
 	}
@@ -403,35 +398,6 @@ func remoteModelsFromTemplate(def registry.ProviderDefinition) []RemoteModel {
 		})
 	}
 	return out
-}
-
-func (s *Service) fetchGitHubCopilotModels(ctx context.Context, provider sqlc.Provider) ([]RemoteModel, error) {
-	creds, err := s.ResolveModelCredentials(ctx, provider)
-	if err != nil {
-		return nil, err
-	}
-	sdkProvider := memohcopilot.NewProvider(creds.APIKey, nil)
-	if result := sdkProvider.Test(ctx); result.Status != sdk.ProviderStatusOK {
-		return nil, fmt.Errorf("github copilot provider test failed: %s", result.Message)
-	}
-
-	catalog := githubcopilot.Catalog()
-	remoteModels := make([]RemoteModel, 0, len(catalog))
-	for _, model := range catalog {
-		remoteModels = append(remoteModels, RemoteModel{
-			ID:      model.ID,
-			Name:    model.DisplayName,
-			Object:  "model",
-			OwnedBy: "github-copilot",
-			Type:    "chat",
-			Compatibilities: []string{
-				models.CompatVision,
-				models.CompatToolCall,
-				models.CompatReasoning,
-			},
-		})
-	}
-	return remoteModels, nil
 }
 
 func (s *Service) fetchRemoteModelsViaSDK(ctx context.Context, provider sqlc.Provider) ([]RemoteModel, error) {

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -1,6 +1,10 @@
 package providers
 
-import "time"
+import (
+	"time"
+
+	"github.com/memohai/memoh/internal/models"
+)
 
 // CreateRequest represents a request to create a new provider.
 type CreateRequest struct {
@@ -99,19 +103,20 @@ type OAuthAuthorizeResponse struct {
 
 // RemoteModel represents a model returned by the provider's /v1/models endpoint.
 type RemoteModel struct {
-	ID               string   `json:"id"`
-	Description      *string  `json:"description,omitempty"`
-	Object           string   `json:"object"`
-	Created          int64    `json:"created"`
-	OwnedBy          string   `json:"owned_by"`
-	Name             string   `json:"name,omitempty"`
-	DisplayName      string   `json:"display_name,omitempty"`
-	Type             string   `json:"type,omitempty"`
-	Compatibilities  []string `json:"compatibilities,omitempty"`
-	ReasoningEfforts []string `json:"reasoning_efforts,omitempty"`
-	ThinkingMode     string   `json:"thinking_mode,omitempty"`
-	ContextWindow    *int     `json:"context_window,omitempty"`
-	Dimensions       *int     `json:"dimensions,omitempty"`
+	ID                string   `json:"id"`
+	Description       *string  `json:"description,omitempty"`
+	Object            string   `json:"object"`
+	Created           int64    `json:"created"`
+	OwnedBy           string   `json:"owned_by"`
+	Name              string   `json:"name,omitempty"`
+	DisplayName       string   `json:"display_name,omitempty"`
+	Type              string   `json:"type,omitempty"`
+	Compatibilities   []string `json:"compatibilities,omitempty"`
+	ReasoningEfforts  []string `json:"reasoning_efforts,omitempty"`
+	ThinkingMode      string   `json:"thinking_mode,omitempty"`
+	ContextWindow     *int     `json:"context_window,omitempty"`
+	Dimensions        *int     `json:"dimensions,omitempty"`
+	CapabilitiesKnown bool     `json:"-"`
 }
 
 // ImportModelsResponse represents the response for importing models.
@@ -120,4 +125,10 @@ type ImportModelsResponse struct {
 	Updated int      `json:"updated"`
 	Skipped int      `json:"skipped"`
 	Models  []string `json:"models"`
+}
+
+// IsManagedModelCatalogClientType reports whether model rows are reconciled
+// against an account-scoped upstream catalog instead of manually maintained.
+func IsManagedModelCatalogClientType(clientType models.ClientType) bool {
+	return clientType == models.ClientTypeOpenAICodex || clientType == models.ClientTypeGitHubCopilot
 }


### PR DESCRIPTION
## Summary

- add dynamic GitHub Copilot model discovery and reconcile model availability and capabilities for managed Codex/Copilot catalogs
- align GitHub Copilot with Codex by storing and resolving one shared OAuth credential per provider
- automatically sync the managed model catalog after device OAuth completes
- use one Import/Refresh Models dialog for all providers, with its label determined by whether stored models exist
- hide generic configuration for managed OAuth providers and align the shared provider back button

## Testing

- `go test ./...` via the commit hook
- `mise run lint:go`
- targeted provider/composable Vitest coverage
- targeted ESLint checks
- `pnpm --filter @memohai/web build`

## Notes

- Existing per-user Copilot tokens are not promoted into a shared provider credential; the provider must be authorized once after upgrading.
- Real-account OAuth was not exercised end to end; the unauthorized-to-authorized polling transition and single catalog sync are covered by a component test.