### PR TITLE
feat(db): add team-scoped PostgreSQL schema and RLS

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -99,4 +99,4 @@ jobs:
       - name: Test PostgreSQL query and compaction lifecycle paths
         env:
           TEST_POSTGRES_DSN: postgres://memoh:memoh123@127.0.0.1:5432/memoh_test?sslmode=disable
-        run: go test -count=1 ./internal/db ./internal/message
+        run: go test -tags=integration -count=1 ./internal/db ./internal/message

--- a/cmd/agent/app.go
+++ b/cmd/agent/app.go
@@ -337,12 +337,12 @@ func provideMemoryLLM(modelsService *models.Service, settingsService *settings.S
 func provideMemoryProviderRegistry(log *slog.Logger, llm memprovider.LLM, chatService *conversation.Service, accountService *accounts.Service, provider bridge.Provider, queries dbstore.Queries, vectorStore *pgvectordb.Store, wikiStore *wikistore.Store) *memprovider.Registry {
 	registry := memprovider.NewRegistry(log)
 	fileStore := storefs.New(log, provider)
-	registry.RegisterFactory(string(memprovider.ProviderBuiltin), func(_ string, providerConfig map[string]any) (memprovider.Provider, error) {
+	registry.RegisterFactory(string(memprovider.ProviderBuiltin), func(ctx context.Context, teamID, _ string, providerConfig map[string]any) (memprovider.Provider, error) {
 		var ws wikistore.Store
 		if wikiStore != nil {
 			ws = *wikiStore
 		}
-		runtime, err := membuiltin.NewBuiltinRuntimeFromConfig(log, providerConfig, fileStore, queries, vectorStore, ws)
+		runtime, err := membuiltin.NewBuiltinRuntimeFromConfigContext(ctx, log, providerConfig, fileStore, queries, vectorStore, ws, memprovider.FixedTeamIDResolver(teamID))
 		if err != nil {
 			return nil, err
 		}
@@ -351,10 +351,10 @@ func provideMemoryProviderRegistry(log *slog.Logger, llm memprovider.LLM, chatSe
 		p.ApplyProviderConfig(providerConfig)
 		return p, nil
 	})
-	registry.RegisterFactory(string(memprovider.ProviderMem0), func(_ string, providerConfig map[string]any) (memprovider.Provider, error) {
+	registry.RegisterFactory(string(memprovider.ProviderMem0), func(_ context.Context, _, _ string, providerConfig map[string]any) (memprovider.Provider, error) {
 		return memmem0.NewMem0Provider(log, providerConfig, fileStore)
 	})
-	registry.RegisterFactory(string(memprovider.ProviderOpenViking), func(_ string, providerConfig map[string]any) (memprovider.Provider, error) {
+	registry.RegisterFactory(string(memprovider.ProviderOpenViking), func(_ context.Context, _, _ string, providerConfig map[string]any) (memprovider.Provider, error) {
 		return memopenviking.NewOpenVikingProvider(log, providerConfig)
 	})
 	// Default provider for bots without an explicit memory_provider_id. Uses the

--- a/db/pgvector/migrations/0002_team_isolation.down.sql
+++ b/db/pgvector/migrations/0002_team_isolation.down.sql
@@ -1,0 +1,47 @@
+-- 0002_team_isolation
+-- Remove team scoping from the semantic-memory embeddings table.
+
+DROP POLICY IF EXISTS memory_node_embeddings_team_delete
+    ON public.memory_node_embeddings;
+DROP POLICY IF EXISTS memory_node_embeddings_team_update
+    ON public.memory_node_embeddings;
+DROP POLICY IF EXISTS memory_node_embeddings_team_insert
+    ON public.memory_node_embeddings;
+DROP POLICY IF EXISTS memory_node_embeddings_team_select
+    ON public.memory_node_embeddings;
+
+ALTER TABLE public.memory_node_embeddings NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.memory_node_embeddings DISABLE ROW LEVEL SECURITY;
+
+DROP INDEX IF EXISTS public.idx_memory_node_embeddings_team_bot_model;
+
+DO $memory_embeddings_pk$
+DECLARE
+    current_pk_name TEXT;
+BEGIN
+    SELECT conname
+      INTO current_pk_name
+      FROM pg_constraint
+     WHERE conrelid = 'public.memory_node_embeddings'::regclass
+       AND contype = 'p';
+
+    IF current_pk_name IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE public.memory_node_embeddings DROP CONSTRAINT %I',
+            current_pk_name
+        );
+    END IF;
+
+    ALTER TABLE public.memory_node_embeddings
+        ADD CONSTRAINT memory_node_embeddings_pkey
+        PRIMARY KEY (bot_id, node_id, model_id);
+END
+$memory_embeddings_pk$;
+
+ALTER TABLE public.memory_node_embeddings
+    DROP COLUMN IF EXISTS team_id;
+
+CREATE INDEX IF NOT EXISTS idx_memory_node_embeddings_bot_model
+    ON public.memory_node_embeddings (bot_id, model_id);
+
+DROP FUNCTION IF EXISTS public.memoh_pgvector_current_team_id();

--- a/db/pgvector/migrations/0002_team_isolation.up.sql
+++ b/db/pgvector/migrations/0002_team_isolation.up.sql
@@ -1,0 +1,102 @@
+-- 0002_team_isolation
+-- Scope semantic-memory embeddings to a team and enforce fail-closed RLS.
+
+CREATE OR REPLACE FUNCTION public.memoh_pgvector_current_team_id()
+RETURNS UUID
+LANGUAGE plpgsql
+STABLE
+SECURITY INVOKER
+SET search_path = pg_catalog, pg_temp
+AS $current_team$
+DECLARE
+    raw TEXT;
+BEGIN
+    raw := pg_catalog.current_setting('memoh.team_id', true);
+    IF raw IS NULL OR pg_catalog.btrim(raw) = '' THEN
+        RAISE EXCEPTION 'memoh.team_id is not set'
+            USING ERRCODE = '42501';
+    END IF;
+    BEGIN
+        RETURN raw::UUID;
+    EXCEPTION
+        WHEN invalid_text_representation THEN
+            RAISE EXCEPTION 'memoh.team_id is invalid'
+                USING ERRCODE = '22P02';
+    END;
+END;
+$current_team$;
+
+ALTER TABLE public.memory_node_embeddings
+    ADD COLUMN IF NOT EXISTS team_id UUID;
+
+UPDATE public.memory_node_embeddings
+SET team_id = '00000000-0000-0000-0000-000000000001'
+WHERE team_id IS NULL;
+
+ALTER TABLE public.memory_node_embeddings
+    ALTER COLUMN team_id SET DEFAULT public.memoh_pgvector_current_team_id(),
+    ALTER COLUMN team_id SET NOT NULL;
+
+DO $memory_embeddings_pk$
+DECLARE
+    current_pk_name TEXT;
+    current_pk_def  TEXT;
+BEGIN
+    SELECT conname, pg_get_constraintdef(oid)
+      INTO current_pk_name, current_pk_def
+      FROM pg_constraint
+     WHERE conrelid = 'public.memory_node_embeddings'::regclass
+       AND contype = 'p';
+
+    IF current_pk_name IS NOT NULL
+       AND current_pk_def <> 'PRIMARY KEY (team_id, bot_id, node_id, model_id)' THEN
+        EXECUTE format(
+            'ALTER TABLE public.memory_node_embeddings DROP CONSTRAINT %I',
+            current_pk_name
+        );
+        current_pk_name := NULL;
+    END IF;
+
+    IF current_pk_name IS NULL THEN
+        ALTER TABLE public.memory_node_embeddings
+            ADD CONSTRAINT memory_node_embeddings_pkey
+            PRIMARY KEY (team_id, bot_id, node_id, model_id);
+    END IF;
+END
+$memory_embeddings_pk$;
+
+DROP INDEX IF EXISTS public.idx_memory_node_embeddings_bot_model;
+CREATE INDEX IF NOT EXISTS idx_memory_node_embeddings_team_bot_model
+    ON public.memory_node_embeddings (team_id, bot_id, model_id);
+
+ALTER TABLE public.memory_node_embeddings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.memory_node_embeddings FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS memory_node_embeddings_team_select
+    ON public.memory_node_embeddings;
+CREATE POLICY memory_node_embeddings_team_select
+    ON public.memory_node_embeddings
+    FOR SELECT
+    USING (team_id = public.memoh_pgvector_current_team_id());
+
+DROP POLICY IF EXISTS memory_node_embeddings_team_insert
+    ON public.memory_node_embeddings;
+CREATE POLICY memory_node_embeddings_team_insert
+    ON public.memory_node_embeddings
+    FOR INSERT
+    WITH CHECK (team_id = public.memoh_pgvector_current_team_id());
+
+DROP POLICY IF EXISTS memory_node_embeddings_team_update
+    ON public.memory_node_embeddings;
+CREATE POLICY memory_node_embeddings_team_update
+    ON public.memory_node_embeddings
+    FOR UPDATE
+    USING (team_id = public.memoh_pgvector_current_team_id())
+    WITH CHECK (team_id = public.memoh_pgvector_current_team_id());
+
+DROP POLICY IF EXISTS memory_node_embeddings_team_delete
+    ON public.memory_node_embeddings;
+CREATE POLICY memory_node_embeddings_team_delete
+    ON public.memory_node_embeddings
+    FOR DELETE
+    USING (team_id = public.memoh_pgvector_current_team_id());

--- a/db/pgvector/queries/embeddings.sql
+++ b/db/pgvector/queries/embeddings.sql
@@ -1,8 +1,9 @@
 -- name: UpsertMemoryNodeEmbedding :exec
 INSERT INTO public.memory_node_embeddings (
-  bot_id, node_id, model_id, dimensions, body_hash, embedding
+  team_id, bot_id, node_id, model_id, dimensions, body_hash, embedding
 )
 VALUES (
+  sqlc.arg(team_id),
   sqlc.arg(bot_id),
   sqlc.arg(node_id),
   sqlc.arg(model_id),
@@ -10,7 +11,7 @@ VALUES (
   sqlc.arg(body_hash),
   sqlc.arg(embedding)
 )
-ON CONFLICT (bot_id, node_id, model_id) DO UPDATE SET
+ON CONFLICT (team_id, bot_id, node_id, model_id) DO UPDATE SET
   dimensions = EXCLUDED.dimensions,
   body_hash = EXCLUDED.body_hash,
   embedding = EXCLUDED.embedding,
@@ -21,29 +22,34 @@ SELECT
   node_id,
   CAST(1.0 - (embedding <=> sqlc.arg(embedding)::vector) AS double precision) AS score
 FROM public.memory_node_embeddings
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = sqlc.arg(team_id)
+  AND bot_id = sqlc.arg(bot_id)
   AND model_id = sqlc.arg(model_id)
 ORDER BY embedding <=> sqlc.arg(embedding)::vector
 LIMIT sqlc.arg(row_limit);
 
 -- name: DeleteMemoryNodeEmbeddings :exec
 DELETE FROM public.memory_node_embeddings
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = sqlc.arg(team_id)
+  AND bot_id = sqlc.arg(bot_id)
   AND node_id = ANY(sqlc.arg(node_ids)::text[]);
 
 -- name: DeleteBotMemoryNodeEmbeddings :exec
 DELETE FROM public.memory_node_embeddings
-WHERE bot_id = sqlc.arg(bot_id);
+WHERE team_id = sqlc.arg(team_id)
+  AND bot_id = sqlc.arg(bot_id);
 
 -- name: CountMemoryNodeEmbeddings :one
 SELECT COUNT(*)
 FROM public.memory_node_embeddings
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = sqlc.arg(team_id)
+  AND bot_id = sqlc.arg(bot_id)
   AND model_id = sqlc.arg(model_id);
 
 -- name: MemoryNodeEmbeddingsExist :one
 SELECT EXISTS (
   SELECT 1
   FROM public.memory_node_embeddings
+  WHERE team_id = sqlc.arg(team_id)
   LIMIT 1
 );

--- a/db/postgres/migrations/0111_team_core.down.sql
+++ b/db/postgres/migrations/0111_team_core.down.sql
@@ -1,0 +1,400 @@
+-- 0111_team_core (down)
+-- Reverse the team core in dependency order.
+
+-- ---------------------------------------------------------------------------
+-- Restore secondary indexes
+-- ---------------------------------------------------------------------------
+-- Rebuild the team_id-leading secondary indexes back to their original form
+-- (strip the leading team_id column). Only affects btree indexes whose first
+-- column is team_id and whose second column onward is the original definition.
+
+DO $$
+DECLARE
+    rec record;
+    idxdef text;
+BEGIN
+    FOR rec IN
+        SELECT ic.relname AS index_name, pg_get_indexdef(i.indexrelid) AS def
+          FROM pg_index i
+          JOIN pg_class ic ON ic.oid = i.indexrelid
+          JOIN pg_class tc ON tc.oid = i.indrelid
+          JOIN pg_namespace n ON n.oid = tc.relnamespace
+          JOIN pg_am am ON am.oid = ic.relam
+         WHERE n.nspname = 'public'
+           AND NOT i.indisprimary AND NOT i.indisunique
+           AND am.amname = 'btree'
+           AND EXISTS (
+               SELECT 1
+                 FROM pg_constraint con
+                 JOIN pg_class parent ON parent.oid = con.confrelid
+                WHERE con.conrelid = tc.oid
+                  AND con.contype = 'f'
+                  AND parent.relnamespace = n.oid
+                  AND parent.relname = 'teams'
+           )
+           AND (SELECT attname FROM pg_attribute
+                 WHERE attrelid = i.indrelid AND attnum = i.indkey[0]) = 'team_id'
+           AND array_length(i.indkey, 1) > 1
+    LOOP
+        idxdef := regexp_replace(rec.def, '(USING btree \()team_id, ', '\1');
+        EXECUTE format('DROP INDEX IF EXISTS public.%I', rec.index_name);
+        EXECUTE idxdef;
+    END LOOP;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Restore history view
+-- ---------------------------------------------------------------------------
+-- Restore the view to its pre-team shape (the 0103 definition: no team_id
+-- projection, no security_invoker). This reverts to the prior state; the
+-- security fix lives only in the up.
+
+-- Column order changes (team_id-first back to turn_id-first), so drop+recreate.
+DROP VIEW IF EXISTS bot_visible_history_messages;
+
+CREATE VIEW bot_visible_history_messages AS
+SELECT
+  m.turn_id,
+  m.turn_position,
+  m.turn_message_seq,
+  m.id,
+  m.bot_id,
+  m.session_id,
+  m.sender_channel_identity_id,
+  m.sender_account_user_id,
+  m.source_message_id,
+  m.source_reply_to_message_id,
+  m.role,
+  m.content,
+  m.metadata,
+  m.usage,
+  m.compact_id,
+  m.session_mode,
+  m.runtime_type,
+  m.model_id,
+  m.event_id,
+  m.display_text,
+  m.created_at
+FROM bot_history_messages m
+WHERE m.turn_visible = true
+  AND m.turn_id IS NOT NULL
+  AND m.turn_position IS NOT NULL
+  AND m.turn_message_seq IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- Remove team row-level security
+-- ---------------------------------------------------------------------------
+-- Remove team policies and disable row-level security.
+
+DO $$
+DECLARE
+    tbl text;
+BEGIN
+    FOR tbl IN
+        SELECT c.relname
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relkind IN ('r', 'p')
+           AND n.nspname = 'public'
+           AND EXISTS (
+               SELECT 1
+                 FROM pg_constraint con
+                 JOIN pg_class parent ON parent.oid = con.confrelid
+                WHERE con.conrelid = c.oid
+                  AND con.contype = 'f'
+                  AND parent.relnamespace = n.oid
+                  AND parent.relname = 'teams'
+           )
+    LOOP
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', tbl || '_team_select', tbl);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', tbl || '_team_insert', tbl);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', tbl || '_team_update', tbl);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', tbl || '_team_delete', tbl);
+        EXECUTE format('ALTER TABLE public.%I NO FORCE ROW LEVEL SECURITY', tbl);
+        EXECUTE format('ALTER TABLE public.%I DISABLE ROW LEVEL SECURITY', tbl);
+    END LOOP;
+END
+$$;
+
+DROP POLICY IF EXISTS teams_self_select ON public.teams;
+ALTER TABLE public.teams NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.teams DISABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- Restore keys and foreign keys
+-- ---------------------------------------------------------------------------
+-- Reverse the team-scoped unique keys and composite foreign keys.
+--
+-- Down safety gate: only safe on a clean singleton database (no non-default
+-- team rows anywhere). If multiple teams share natural keys, restoring a
+-- global UNIQUE constraints could collide. The down migration therefore only
+-- restores the pre-team single-column shape and delete semantics when the
+-- data is still a clean singleton.
+--
+DO $$
+DECLARE
+    rec record;
+    default_team constant uuid := '00000000-0000-0000-0000-000000000001';
+    orig_del text;
+    orig_upd text;
+    has_non_default boolean;
+BEGIN
+    CREATE TEMP TABLE _team_tables (table_name text PRIMARY KEY) ON COMMIT DROP;
+    INSERT INTO _team_tables
+    SELECT c.relname
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_attribute a ON a.attrelid = c.oid
+      JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
+     WHERE n.nspname = 'public'
+       AND c.relkind IN ('r', 'p')
+       AND a.attname = 'team_id'
+       AND NOT a.attisdropped
+       AND pg_get_expr(d.adbin, d.adrelid) LIKE '%memoh_current_team_id()%';
+
+    -- Fail-closed gate: refuse if any team table holds a non-default team_id.
+    FOR rec IN SELECT table_name FROM _team_tables LOOP
+        EXECUTE format(
+            'SELECT EXISTS (SELECT 1 FROM public.%I WHERE team_id <> %L)',
+            rec.table_name, default_team
+        ) INTO has_non_default;
+        IF has_non_default THEN
+            RAISE EXCEPTION 'refusing team-key rollback: % has non-default team rows', rec.table_name;
+        END IF;
+    END LOOP;
+
+    -- Save the current composite business FKs. Their action codes still carry
+    -- the exact pre-team semantics, including column-scoped SET NULL.
+    CREATE TEMP TABLE _fk_saved ON COMMIT DROP AS
+    SELECT c.relname AS child_table,
+           con.conname AS fk_name,
+           rt.relname AS parent_table,
+           con.confdeltype AS del_type,
+           con.confupdtype AS upd_type,
+           (SELECT a.attname FROM pg_attribute a
+             WHERE a.attrelid = con.conrelid AND a.attnum = con.conkey[2]) AS child_col,
+           (SELECT a.attname FROM pg_attribute a
+             WHERE a.attrelid = con.confrelid AND a.attnum = con.confkey[2]) AS parent_col
+      FROM pg_constraint con
+      JOIN pg_class c ON c.oid = con.conrelid
+      JOIN pg_class rt ON rt.oid = con.confrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE con.contype = 'f'
+       AND n.nspname = 'public'
+       AND c.relname IN (SELECT table_name FROM _team_tables)
+       AND rt.relname IN (SELECT table_name FROM _team_tables)
+       AND cardinality(con.conkey) = 2
+       AND (SELECT a.attname FROM pg_attribute a
+             WHERE a.attrelid = con.conrelid AND a.attnum = con.conkey[1]) = 'team_id';
+
+    -- Drop the composite business FKs and team-root FKs only.
+    FOR rec IN
+        SELECT c.relname AS child_table, con.conname AS fk_name
+          FROM pg_constraint con
+          JOIN pg_class c ON c.oid = con.conrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE con.contype = 'f' AND n.nspname = 'public'
+           AND c.relname IN (SELECT table_name FROM _team_tables)
+           AND EXISTS (
+               SELECT 1 FROM pg_attribute a
+                WHERE a.attrelid = con.conrelid
+                  AND a.attnum = ANY(con.conkey)
+                  AND a.attname = 'team_id'
+           )
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', rec.child_table, rec.fk_name);
+    END LOOP;
+
+    -- Drop the helper unique keys added for unchanged primary keys.
+    FOR rec IN
+        SELECT c.relname AS table_name, con.conname
+          FROM pg_constraint con
+          JOIN pg_class c ON c.oid = con.conrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE con.contype = 'u' AND n.nspname = 'public'
+           AND c.relname IN (SELECT table_name FROM _team_tables)
+           AND con.conname LIKE 'memoh_team_key_%'
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', rec.table_name, rec.conname);
+    END LOOP;
+
+    -- Restore single-column UNIQUE constraints (strip leading team_id).
+    FOR rec IN
+        SELECT c.relname AS table_name, con.conname, con.conrelid, con.conkey,
+               i.indnullsnotdistinct AS nulls_not_distinct
+          FROM pg_constraint con
+          JOIN pg_class c ON c.oid = con.conrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          JOIN pg_index i ON i.indexrelid = con.conindid
+         WHERE con.contype = 'u' AND n.nspname = 'public'
+           AND c.relname IN (SELECT table_name FROM _team_tables)
+           AND con.conname NOT LIKE 'memoh_team_key_%'
+    LOOP
+        IF (SELECT attname FROM pg_attribute WHERE attrelid=rec.conrelid AND attnum=rec.conkey[1]) <> 'team_id' THEN
+            CONTINUE;
+        END IF;
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', rec.table_name, rec.conname);
+        EXECUTE format('ALTER TABLE public.%I ADD CONSTRAINT %I UNIQUE %s (%s)',
+            rec.table_name, rec.conname,
+            CASE WHEN rec.nulls_not_distinct THEN 'NULLS NOT DISTINCT' ELSE '' END,
+            (SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord)
+               FROM unnest(rec.conkey) WITH ORDINALITY AS k(attnum, ord)
+               JOIN pg_attribute a ON a.attrelid=rec.conrelid AND a.attnum=k.attnum
+              WHERE k.ord > 1));
+    END LOOP;
+
+    -- Recreate the original single-column FKs with their exact actions.
+    FOR rec IN SELECT * FROM _fk_saved LOOP
+        orig_del := CASE rec.del_type WHEN 'c' THEN 'CASCADE' WHEN 'r' THEN 'RESTRICT'
+                                      WHEN 'n' THEN 'SET NULL' WHEN 'd' THEN 'SET DEFAULT'
+                                      ELSE 'NO ACTION' END;
+        orig_upd := CASE rec.upd_type WHEN 'c' THEN 'CASCADE' WHEN 'r' THEN 'RESTRICT'
+                                      WHEN 'n' THEN 'SET NULL' WHEN 'd' THEN 'SET DEFAULT'
+                                      ELSE 'NO ACTION' END;
+        EXECUTE format(
+            'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (%I) REFERENCES public.%I (%I) ON UPDATE %s ON DELETE %s',
+            rec.child_table, rec.fk_name, rec.child_col, rec.parent_table, rec.parent_col, orig_upd, orig_del);
+    END LOOP;
+
+END
+$$;
+
+-- Restore the partial / expression unique indexes to their original (global) shape.
+DROP INDEX IF EXISTS idx_bot_channel_external_identity;
+CREATE UNIQUE INDEX idx_bot_channel_external_identity
+    ON public.bot_channel_configs (channel_type, external_identity);
+
+DROP INDEX IF EXISTS idx_bot_channel_routes_unique;
+CREATE UNIQUE INDEX idx_bot_channel_routes_unique
+    ON public.bot_channel_routes
+       (bot_id, channel_type, external_conversation_id, COALESCE(external_thread_id, ''::text));
+
+DROP INDEX IF EXISTS idx_bot_history_messages_turn_seq_unique;
+CREATE UNIQUE INDEX idx_bot_history_messages_turn_seq_unique
+    ON public.bot_history_messages (turn_id, turn_message_seq)
+    WHERE ((turn_id IS NOT NULL) AND (turn_message_seq IS NOT NULL));
+
+DROP INDEX IF EXISTS idx_bot_user_grants_unique_everyone;
+CREATE UNIQUE INDEX idx_bot_user_grants_unique_everyone
+    ON public.bot_user_grants (bot_id)
+    WHERE (subject_type = 'everyone'::text);
+
+DROP INDEX IF EXISTS idx_bot_user_grants_unique_user;
+CREATE UNIQUE INDEX idx_bot_user_grants_unique_user
+    ON public.bot_user_grants (bot_id, user_id)
+    WHERE (subject_type = 'user'::text);
+
+DROP INDEX IF EXISTS idx_bots_name;
+CREATE UNIQUE INDEX idx_bots_name
+    ON public.bots (name);
+
+DROP INDEX IF EXISTS idx_session_events_dedup;
+CREATE UNIQUE INDEX idx_session_events_dedup
+    ON public.bot_session_events (session_id, event_kind, external_message_id)
+    WHERE ((external_message_id IS NOT NULL) AND (external_message_id <> ''::text));
+
+DROP INDEX IF EXISTS idx_snapshots_container_runtime_name;
+CREATE UNIQUE INDEX idx_snapshots_container_runtime_name
+    ON public.snapshots (container_id, runtime_snapshot_name);
+
+-- ---------------------------------------------------------------------------
+-- Remove team columns
+-- ---------------------------------------------------------------------------
+-- Drop the team_id column from every team business table.
+--
+-- Down safety gate: only allow rollback on a clean singleton database — no
+-- row in any team table may carry a non-default team_id. If a non-default
+-- team's data exists, dropping team_id would destroy the only isolation
+-- marker, so we fail closed (never wipe as rollback).
+
+DO $$
+DECLARE
+    tbl text;
+    default_team constant uuid := '00000000-0000-0000-0000-000000000001';
+    bad bigint;
+BEGIN
+    -- Fail-closed gate: refuse if any team table holds non-default team_id.
+    FOR tbl IN
+        SELECT c.relname
+          FROM pg_catalog.pg_class c
+          JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relkind IN ('r', 'p')
+           AND EXISTS (
+               SELECT 1
+                 FROM pg_attribute a
+                 JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+                WHERE a.attrelid = c.oid
+                  AND a.attname = 'team_id'
+                  AND NOT a.attisdropped
+                  AND pg_get_expr(d.adbin, d.adrelid) LIKE '%memoh_current_team_id()%'
+           )
+    LOOP
+        EXECUTE format(
+            'SELECT count(*) FROM public.%I WHERE team_id IS NOT NULL AND team_id <> %L',
+            tbl, default_team
+        ) INTO bad;
+        IF bad > 0 THEN
+            RAISE EXCEPTION
+                'refusing to drop team_id from %: % rows carry a non-default team_id (multi-team database)',
+                tbl, bad;
+        END IF;
+    END LOOP;
+
+    -- Safe: drop only columns introduced by the matching up migration. User
+    -- tables that happen to define their own team_id are left untouched.
+    FOR tbl IN
+        SELECT c.relname
+          FROM pg_catalog.pg_class c
+          JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relkind IN ('r', 'p')
+           AND EXISTS (
+               SELECT 1
+                 FROM pg_attribute a
+                 JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+                WHERE a.attrelid = c.oid
+                  AND a.attname = 'team_id'
+                  AND NOT a.attisdropped
+                  AND pg_get_expr(d.adbin, d.adrelid) LIKE '%memoh_current_team_id()%'
+           )
+         ORDER BY c.relname
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I DROP COLUMN IF EXISTS team_id', tbl);
+    END LOOP;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Remove team context
+-- ---------------------------------------------------------------------------
+-- Remove the public team context helper.
+
+DROP FUNCTION IF EXISTS public.memoh_current_team_id();
+
+-- ---------------------------------------------------------------------------
+-- Remove team root
+-- ---------------------------------------------------------------------------
+-- Reverse the teams root introduction.
+--
+-- Down safety gate: only allow rollback when the database is still a clean
+-- singleton — i.e. there is no team other than the default. If any
+-- non-default team exists, dropping the root would orphan team data, so we
+-- fail closed rather
+-- than silently destroy data. (A wipe is never an acceptable rollback.)
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM teams
+        WHERE id <> '00000000-0000-0000-0000-000000000001'::uuid
+    ) THEN
+        RAISE EXCEPTION
+            'refusing to drop teams root: non-default team rows present (multi-team database)';
+    END IF;
+END
+$$;
+
+DROP INDEX IF EXISTS teams_slug_unique;
+DROP TABLE IF EXISTS teams;

--- a/db/postgres/migrations/0111_team_core.up.sql
+++ b/db/postgres/migrations/0111_team_core.up.sql
@@ -228,23 +228,6 @@ BEGIN
 END
 $$;
 
--- The official Compose deployment creates this NOLOGIN role during database
--- initialization. Migrations continue to run as the database owner, while the
--- server uses SET ROLE so superuser/BYPASSRLS cannot bypass forced RLS. External
--- deployments may omit the role and provide their own non-superuser login.
-DO $memoh_app_grants$
-BEGIN
-    IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'memoh_app') THEN
-        EXECUTE 'GRANT USAGE ON SCHEMA public TO memoh_app';
-        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO memoh_app';
-        EXECUTE 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO memoh_app';
-        EXECUTE 'GRANT EXECUTE ON FUNCTION public.memoh_current_team_id() TO memoh_app';
-        EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO memoh_app';
-        EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO memoh_app';
-    END IF;
-END
-$memoh_app_grants$;
-
 -- ---------------------------------------------------------------------------
 -- Team-scoped keys and foreign keys
 -- ---------------------------------------------------------------------------

--- a/db/postgres/migrations/0111_team_core.up.sql
+++ b/db/postgres/migrations/0111_team_core.up.sql
@@ -1,0 +1,615 @@
+-- 0111_team_core
+-- Add the singleton team root, team-scoped schema, query context, RLS,
+-- team-safe view, and team-prefixed indexes.
+
+-- ---------------------------------------------------------------------------
+-- Team root
+-- ---------------------------------------------------------------------------
+-- Introduce the teams root table and seed the default singleton team.
+--
+-- This is the first migration of the team-core work. teams is the unique
+-- root special case: its own id IS the team id, so it must NOT carry a
+-- redundant team_id column. Existing installs upgrade in place (no wipe): the
+-- single default team is seeded idempotently and every existing business row
+-- is later backfilled to DefaultTeamID by subsequent migrations.
+--
+-- DefaultTeamID is the fixed constant published in internal/team/id.go
+-- (00000000-0000-0000-0000-000000000001). It must never be generated per install.
+
+CREATE TABLE IF NOT EXISTS teams (
+    id         UUID        PRIMARY KEY,
+    slug       TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    metadata   JSONB       NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- slug is an optional directory field, not an identity/authorization boundary.
+-- When present it must be unique cell-wide; NULL slugs are allowed and excluded.
+CREATE UNIQUE INDEX IF NOT EXISTS teams_slug_unique ON teams (slug) WHERE slug IS NOT NULL;
+
+-- Seed the singleton team idempotently. Existing self-hosted installations
+-- continue to use this team without any configuration changes.
+INSERT INTO teams (id, slug)
+VALUES ('00000000-0000-0000-0000-000000000001', 'default')
+ON CONFLICT (id) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Team context
+-- ---------------------------------------------------------------------------
+-- Add the fail-closed team context helper used by team-scoped queries and
+-- row-level security policies.
+
+CREATE OR REPLACE FUNCTION public.memoh_current_team_id()
+RETURNS uuid
+LANGUAGE plpgsql
+STABLE
+SECURITY INVOKER
+SET search_path = pg_catalog, pg_temp
+AS $$
+DECLARE
+  raw text;
+BEGIN
+  raw := pg_catalog.current_setting('memoh.team_id', true);
+  IF raw IS NULL OR pg_catalog.btrim(raw) = '' THEN
+    RAISE EXCEPTION 'memoh.team_id is not set'
+      USING ERRCODE = '42501';
+  END IF;
+  BEGIN
+    RETURN raw::uuid;
+  EXCEPTION
+    WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'memoh.team_id is invalid'
+        USING ERRCODE = '22P02';
+  END;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Team columns and singleton backfill
+-- ---------------------------------------------------------------------------
+-- Add a nullable team_id column to every team business table (STATIC ALTERs
+-- so sqlc can see the column) and backfill it to the default singleton team
+-- before team-scoped constraints are installed.
+--
+-- New incremental (existing migrations untouched). team_id is added NULLABLE,
+-- given a DEFAULT of public.memoh_current_team_id() (so INSERTs auto-fill the current
+-- team), and backfilled to the default singleton; a later migration tightens
+-- it to NOT NULL after composite keys/FKs land. Existing installs upgrade in
+-- place (no wipe).
+--
+-- The ADD COLUMN statements are STATIC (one literal ALTER per table) rather than
+-- a dynamic DO/EXECUTE loop, because sqlc parses the schema declaratively and
+-- cannot see columns added inside DO/EXECUTE blocks. `ALTER TABLE IF EXISTS ...
+-- ADD COLUMN IF NOT EXISTS` is a safe no-op on the legacy upgrade path where a
+-- table (e.g. tts_providers/tts_models) does not exist. The table list is the
+-- applied fresh-install team set (53 tables), excluding schema_migrations
+-- tooling and the teams root.
+
+ALTER TABLE IF EXISTS public.bot_acl_rules ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_channel_admins ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_channel_configs ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_channel_routes ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_email_bindings ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_heartbeat_logs ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_history_message_assets ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_history_message_compacts ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_history_messages ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_plugin_installations ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_plugin_resources ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_remote_runtime_bindings ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_session_discuss_cursors ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_session_events ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_sessions ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_storage_bindings ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_user_grants ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bot_workspace_resource_limits ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.bots ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.channel_identities ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.channel_link_codes ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.container_versions ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.containers ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.email_oauth_tokens ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.email_outbox ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.email_providers ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.fetch_providers ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.lifecycle_events ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.mcp_connections ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.mcp_oauth_tokens ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.media_assets ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.memory_edges ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.memory_nodes ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.memory_providers ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.model_variants ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.models ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.provider_oauth_tokens ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.providers ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.schedule ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.schedule_logs ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.search_providers ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.snapshots ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.storage_providers ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.tasks ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.tool_approval_requests ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.tts_models ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.tts_providers ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.user_channel_bindings ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.user_channel_identity_bindings ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.user_input_requests ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.user_provider_oauth_tokens ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.user_runtimes ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE IF EXISTS public.users ADD COLUMN IF NOT EXISTS team_id uuid;
+
+
+-- Give team_id a DEFAULT so any INSERT (sqlc-generated or raw) auto-fills the
+-- current team from the session/transaction GUC. Fail-closed: if the GUC is
+-- unset, public.memoh_current_team_id() raises rather than inserting a NULL/guessed team.
+ALTER TABLE IF EXISTS public.bot_acl_rules ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_channel_admins ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_channel_configs ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_channel_routes ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_email_bindings ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_heartbeat_logs ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_history_message_assets ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_history_message_compacts ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_history_messages ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_plugin_installations ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_plugin_resources ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_remote_runtime_bindings ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_session_discuss_cursors ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_session_events ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_sessions ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_storage_bindings ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_user_grants ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bot_workspace_resource_limits ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.bots ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.channel_identities ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.channel_link_codes ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.container_versions ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.containers ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.email_oauth_tokens ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.email_outbox ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.email_providers ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.fetch_providers ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.lifecycle_events ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.mcp_connections ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.mcp_oauth_tokens ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.media_assets ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.memory_edges ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.memory_nodes ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.memory_providers ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.model_variants ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.models ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.provider_oauth_tokens ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.providers ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.schedule ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.schedule_logs ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.search_providers ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.snapshots ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.storage_providers ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.tasks ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.tool_approval_requests ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.tts_models ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.tts_providers ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.user_channel_bindings ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.user_channel_identity_bindings ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.user_input_requests ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.user_provider_oauth_tokens ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.user_runtimes ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+ALTER TABLE IF EXISTS public.users ALTER COLUMN team_id SET DEFAULT public.memoh_current_team_id();
+
+-- Backfill every present team table to the default singleton. Dynamic because
+-- sqlc ignores UPDATE statements; enumerating the applied schema keeps this
+-- correct across the fresh/legacy path divergence.
+DO $$
+DECLARE
+    tbl text;
+    default_team constant uuid := '00000000-0000-0000-0000-000000000001';
+BEGIN
+    FOR tbl IN
+        SELECT c.relname
+          FROM pg_catalog.pg_class c
+          JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relkind IN ('r', 'p')
+           AND EXISTS (
+               SELECT 1
+                 FROM pg_attribute a
+                 JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+                WHERE a.attrelid = c.oid
+                  AND a.attname = 'team_id'
+                  AND NOT a.attisdropped
+                  AND pg_get_expr(d.adbin, d.adrelid) LIKE '%memoh_current_team_id()%'
+           )
+         ORDER BY c.relname
+    LOOP
+        EXECUTE format('UPDATE public.%I SET team_id = %L WHERE team_id IS NULL', tbl, default_team);
+    END LOOP;
+END
+$$;
+
+-- The official Compose deployment creates this NOLOGIN role during database
+-- initialization. Migrations continue to run as the database owner, while the
+-- server uses SET ROLE so superuser/BYPASSRLS cannot bypass forced RLS. External
+-- deployments may omit the role and provide their own non-superuser login.
+DO $memoh_app_grants$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'memoh_app') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA public TO memoh_app';
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO memoh_app';
+        EXECUTE 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO memoh_app';
+        EXECUTE 'GRANT EXECUTE ON FUNCTION public.memoh_current_team_id() TO memoh_app';
+        EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO memoh_app';
+        EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO memoh_app';
+    END IF;
+END
+$memoh_app_grants$;
+
+-- ---------------------------------------------------------------------------
+-- Team-scoped keys and foreign keys
+-- ---------------------------------------------------------------------------
+-- Add team-scoped unique keys and composite foreign keys while preserving the
+-- existing primary keys and delete behavior.
+--
+-- This work is atomic because in PostgreSQL an FK binds to a specific unique
+-- index: you cannot rebuild a referenced key without dropping and recreating its
+-- dependent FKs in the same operation. Splitting across migrations would fight
+-- that coupling; doing it atomically is both correct and simpler to reason about.
+--
+-- Preconditions (from earlier sections): every team table already has a
+-- backfilled team_id and the teams root exists. Team tables are identified
+-- by the team default installed above, so user-managed
+-- tables in the public schema are not modified.
+--
+-- Existing ON DELETE SET NULL constraints use PostgreSQL's column-list form,
+-- SET NULL (child_column), so the reference is cleared without clearing the
+-- non-null team_id column.
+
+DO $$
+DECLARE
+    rec record;
+    cols text;
+    delete_action text;
+    update_action text;
+BEGIN
+    CREATE TEMP TABLE _team_tables (table_name text PRIMARY KEY) ON COMMIT DROP;
+    INSERT INTO _team_tables
+    SELECT c.relname
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_attribute a ON a.attrelid = c.oid
+      JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
+     WHERE n.nspname = 'public'
+       AND c.relkind IN ('r', 'p')
+       AND a.attname = 'team_id'
+       AND NOT a.attisdropped
+       AND pg_get_expr(d.adbin, d.adrelid) LIKE '%memoh_current_team_id()%';
+
+    CREATE TEMP TABLE _fk_saved ON COMMIT DROP AS
+    SELECT con.oid,
+           c.relname            AS child_table,
+           con.conname          AS fk_name,
+           rt.relname           AS parent_table,
+           con.confdeltype      AS del_type,
+           con.confupdtype      AS upd_type,
+           (SELECT a.attname FROM pg_attribute a
+             WHERE a.attrelid = con.conrelid AND a.attnum = con.conkey[1])  AS child_col,
+           (SELECT a.attname FROM pg_attribute a
+             WHERE a.attrelid = con.confrelid AND a.attnum = con.confkey[1]) AS parent_col,
+           cardinality(con.conkey) AS ncols
+      FROM pg_constraint con
+      JOIN pg_class c  ON c.oid  = con.conrelid
+      JOIN pg_class rt ON rt.oid = con.confrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE con.contype = 'f'
+       AND n.nspname = 'public'
+       AND c.relname IN (SELECT table_name FROM _team_tables)
+       AND rt.relname IN (SELECT table_name FROM _team_tables)
+       AND cardinality(con.conkey) = 1;
+
+    -- Safety: this algorithm only handles single-column business FKs.
+    IF EXISTS (SELECT 1 FROM _fk_saved WHERE ncols <> 1) THEN
+        RAISE EXCEPTION 'multi-column FK present; composite re-key algorithm needs revision';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM _fk_saved WHERE upd_type IN ('n', 'd')) THEN
+        RAISE EXCEPTION 'ON UPDATE SET NULL/DEFAULT requires an explicit team-safe migration';
+    END IF;
+
+    FOR rec IN SELECT child_table, fk_name FROM _fk_saved LOOP
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', rec.child_table, rec.fk_name);
+    END LOOP;
+
+    -- Keep existing primary keys stable. Add a team-prefixed unique key for
+    -- each primary key so composite foreign keys have a valid target.
+    FOR rec IN
+        SELECT c.relname AS table_name, con.conname, con.conrelid, con.conkey
+          FROM pg_constraint con
+          JOIN pg_class c ON c.oid = con.conrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE con.contype = 'p' AND n.nspname = 'public'
+           AND c.relname IN (SELECT table_name FROM _team_tables)
+    LOOP
+        SELECT 'team_id, ' || string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord)
+          INTO cols
+          FROM unnest(rec.conkey) WITH ORDINALITY AS k(attnum, ord)
+          JOIN pg_attribute a ON a.attrelid = rec.conrelid AND a.attnum = k.attnum;
+        EXECUTE format('ALTER TABLE public.%I ALTER COLUMN team_id SET NOT NULL', rec.table_name);
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+             WHERE conrelid = rec.conrelid
+               AND conname = 'memoh_team_key_' || substr(md5(rec.table_name || ':' || rec.conname), 1, 12)
+        ) THEN
+            EXECUTE format('ALTER TABLE public.%I ADD CONSTRAINT %I UNIQUE (%s)',
+                rec.table_name,
+                'memoh_team_key_' || substr(md5(rec.table_name || ':' || rec.conname), 1, 12),
+                cols);
+        END IF;
+    END LOOP;
+
+    -- ===== Phase 3: rebuild UNIQUE constraints with team_id prepended =====
+    FOR rec IN
+        SELECT c.relname AS table_name, con.conname, con.conrelid, con.conkey,
+               i.indnullsnotdistinct AS nulls_not_distinct
+          FROM pg_constraint con
+          JOIN pg_class c ON c.oid = con.conrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          JOIN pg_index i ON i.indexrelid = con.conindid
+         WHERE con.contype = 'u' AND n.nspname = 'public'
+           AND c.relname IN (SELECT table_name FROM _team_tables)
+           AND con.conname NOT LIKE 'memoh_team_key_%'
+    LOOP
+        IF (SELECT attname FROM pg_attribute
+              WHERE attrelid = rec.conrelid AND attnum = rec.conkey[1]) = 'team_id' THEN
+            CONTINUE;
+        END IF;
+        SELECT 'team_id, ' || string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord)
+          INTO cols
+          FROM unnest(rec.conkey) WITH ORDINALITY AS k(attnum, ord)
+          JOIN pg_attribute a ON a.attrelid = rec.conrelid AND a.attnum = k.attnum;
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', rec.table_name, rec.conname);
+        -- Preserve NULLS NOT DISTINCT: a bare UNIQUE would widen the semantics
+        -- (NULLs become distinct), letting duplicate rows with NULL key columns
+        -- through (e.g. bot_acl_rules_unique_target).
+        EXECUTE format('ALTER TABLE public.%I ADD CONSTRAINT %I UNIQUE %s (%s)',
+                       rec.table_name, rec.conname,
+                       CASE WHEN rec.nulls_not_distinct THEN 'NULLS NOT DISTINCT' ELSE '' END,
+                       cols);
+    END LOOP;
+
+    FOR rec IN SELECT * FROM _fk_saved LOOP
+        update_action := CASE rec.upd_type WHEN 'c' THEN 'CASCADE' WHEN 'r' THEN 'RESTRICT'
+                          ELSE 'NO ACTION' END;
+        delete_action := CASE rec.del_type
+            WHEN 'c' THEN 'CASCADE'
+            WHEN 'r' THEN 'RESTRICT'
+            WHEN 'n' THEN format('SET NULL (%I)', rec.child_col)
+            WHEN 'd' THEN format('SET DEFAULT (%I)', rec.child_col)
+            ELSE 'NO ACTION'
+        END;
+        EXECUTE format(
+            'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (team_id, %I) '
+            || 'REFERENCES public.%I (team_id, %I) ON UPDATE %s ON DELETE %s',
+            rec.child_table, rec.fk_name, rec.child_col,
+            rec.parent_table, rec.parent_col,
+            update_action, delete_action
+        );
+    END LOOP;
+
+    -- ===== Phase 4b: add root FK (team_id) -> teams(id) on every table =====
+    FOR rec IN
+        SELECT c.relname AS table_name
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relkind IN ('r', 'p') AND n.nspname = 'public'
+           AND c.relname IN (SELECT table_name FROM _team_tables)
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint con
+              JOIN pg_class rt ON rt.oid = con.confrelid
+             WHERE con.contype = 'f'
+               AND con.conrelid = ('public.'||quote_ident(rec.table_name))::regclass
+               AND rt.relname = 'teams'
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (team_id) '
+                || 'REFERENCES public.teams (id) ON DELETE RESTRICT',
+                rec.table_name, rec.table_name || '_team_id_fkey');
+        END IF;
+    END LOOP;
+END
+$$;
+
+-- ===== Phase 3b: partial / expression unique indexes with team_id prepended =====
+DROP INDEX IF EXISTS idx_bot_channel_external_identity;
+CREATE UNIQUE INDEX idx_bot_channel_external_identity
+    ON public.bot_channel_configs (team_id, channel_type, external_identity);
+
+DROP INDEX IF EXISTS idx_bot_channel_routes_unique;
+CREATE UNIQUE INDEX idx_bot_channel_routes_unique
+    ON public.bot_channel_routes
+       (team_id, bot_id, channel_type, external_conversation_id, COALESCE(external_thread_id, ''::text));
+
+DROP INDEX IF EXISTS idx_bot_history_messages_turn_seq_unique;
+CREATE UNIQUE INDEX idx_bot_history_messages_turn_seq_unique
+    ON public.bot_history_messages (team_id, turn_id, turn_message_seq)
+    WHERE ((turn_id IS NOT NULL) AND (turn_message_seq IS NOT NULL));
+
+DROP INDEX IF EXISTS idx_bot_user_grants_unique_everyone;
+CREATE UNIQUE INDEX idx_bot_user_grants_unique_everyone
+    ON public.bot_user_grants (team_id, bot_id)
+    WHERE (subject_type = 'everyone'::text);
+
+DROP INDEX IF EXISTS idx_bot_user_grants_unique_user;
+CREATE UNIQUE INDEX idx_bot_user_grants_unique_user
+    ON public.bot_user_grants (team_id, bot_id, user_id)
+    WHERE (subject_type = 'user'::text);
+
+DROP INDEX IF EXISTS idx_bots_name;
+CREATE UNIQUE INDEX idx_bots_name
+    ON public.bots (team_id, name);
+
+DROP INDEX IF EXISTS idx_session_events_dedup;
+CREATE UNIQUE INDEX idx_session_events_dedup
+    ON public.bot_session_events (team_id, session_id, event_kind, external_message_id)
+    WHERE ((external_message_id IS NOT NULL) AND (external_message_id <> ''::text));
+
+DROP INDEX IF EXISTS idx_snapshots_container_runtime_name;
+CREATE UNIQUE INDEX idx_snapshots_container_runtime_name
+    ON public.snapshots (team_id, container_id, runtime_snapshot_name);
+
+-- ---------------------------------------------------------------------------
+-- Team row-level security
+-- ---------------------------------------------------------------------------
+-- Enable and force row-level security on Memoh team tables. Policies apply
+-- to the connecting role, so installations do not need cluster-wide roles or
+-- elevated CREATEROLE/BYPASSRLS privileges.
+
+DO $$
+DECLARE
+    tbl text;
+BEGIN
+    FOR tbl IN
+        SELECT c.relname
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relkind IN ('r', 'p')
+           AND n.nspname = 'public'
+           AND EXISTS (
+               SELECT 1
+                 FROM pg_constraint con
+                 JOIN pg_class parent ON parent.oid = con.confrelid
+                WHERE con.conrelid = c.oid
+                  AND con.contype = 'f'
+                  AND parent.relnamespace = n.oid
+                  AND parent.relname = 'teams'
+           )
+         ORDER BY c.relname
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', tbl);
+        EXECUTE format('ALTER TABLE public.%I FORCE ROW LEVEL SECURITY', tbl);
+
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', tbl || '_team_select', tbl);
+        EXECUTE format(
+            'CREATE POLICY %I ON public.%I FOR SELECT USING (team_id = public.memoh_current_team_id())',
+            tbl || '_team_select', tbl);
+
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', tbl || '_team_insert', tbl);
+        EXECUTE format(
+            'CREATE POLICY %I ON public.%I FOR INSERT WITH CHECK (team_id = public.memoh_current_team_id())',
+            tbl || '_team_insert', tbl);
+
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', tbl || '_team_update', tbl);
+        EXECUTE format(
+            'CREATE POLICY %I ON public.%I FOR UPDATE '
+            || 'USING (team_id = public.memoh_current_team_id()) '
+            || 'WITH CHECK (team_id = public.memoh_current_team_id())',
+            tbl || '_team_update', tbl);
+
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', tbl || '_team_delete', tbl);
+        EXECUTE format(
+            'CREATE POLICY %I ON public.%I FOR DELETE USING (team_id = public.memoh_current_team_id())',
+            tbl || '_team_delete', tbl);
+    END LOOP;
+END
+$$;
+
+ALTER TABLE public.teams ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.teams FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS teams_self_select ON public.teams;
+CREATE POLICY teams_self_select ON public.teams
+    FOR SELECT USING (id = public.memoh_current_team_id());
+
+-- ---------------------------------------------------------------------------
+-- Team-safe history view
+-- ---------------------------------------------------------------------------
+-- Fix the bot_visible_history_messages view so it cannot bypass team RLS.
+--
+-- The view was created without security_invoker, so it executed with its
+-- owner's privileges and could bypass the caller's RLS policies. This migration:
+--   1. recreates the view WITH (security_invoker = true) so it runs under the
+--      caller's privileges — the base table's RLS then scopes it automatically;
+--   2. projects team_id so consuming queries can carry explicit scope
+--      (defense-in-depth) and so the schema guard can verify the view;
+
+-- Adding team_id as the first projected column changes column order, which
+-- CREATE OR REPLACE VIEW rejects, so drop and recreate. No other object depends
+-- on this view (verified), so a plain DROP is safe.
+DROP VIEW IF EXISTS bot_visible_history_messages;
+
+CREATE VIEW bot_visible_history_messages
+WITH (security_invoker = true) AS
+SELECT
+  m.team_id,
+  m.turn_id,
+  m.turn_position,
+  m.turn_message_seq,
+  m.id,
+  m.bot_id,
+  m.session_id,
+  m.sender_channel_identity_id,
+  m.sender_account_user_id,
+  m.source_message_id,
+  m.source_reply_to_message_id,
+  m.role,
+  m.content,
+  m.metadata,
+  m.usage,
+  m.compact_id,
+  m.session_mode,
+  m.runtime_type,
+  m.model_id,
+  m.event_id,
+  m.display_text,
+  m.created_at
+FROM bot_history_messages m
+WHERE m.turn_visible = true
+  AND m.turn_id IS NOT NULL
+  AND m.turn_position IS NOT NULL
+  AND m.turn_message_seq IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- Team-prefixed secondary indexes
+-- ---------------------------------------------------------------------------
+-- Prepend team_id to every non-unique btree secondary index on a team table
+-- that does not already lead with it. Team queries filter by team_id (RLS +
+-- explicit public.memoh_current_team_id()), so a team_id-leading index lets the
+-- planner scan only the current team's slice. Purely a performance change.
+--
+-- New incremental (existing migrations untouched). Each index is dropped and
+-- recreated with team_id prepended, preserving its column list, partial WHERE,
+-- and (btree) access method. Non-btree (gin/gist) indexes are left untouched.
+
+DO $$
+DECLARE
+    rec record;
+    idxdef text;
+BEGIN
+    FOR rec IN
+        SELECT ic.relname AS index_name, pg_get_indexdef(i.indexrelid) AS def
+          FROM pg_index i
+          JOIN pg_class ic ON ic.oid = i.indexrelid
+          JOIN pg_class tc ON tc.oid = i.indrelid
+          JOIN pg_namespace n ON n.oid = tc.relnamespace
+          JOIN pg_am am ON am.oid = ic.relam
+         WHERE n.nspname = 'public'
+           AND NOT i.indisprimary AND NOT i.indisunique
+           AND am.amname = 'btree'
+           AND EXISTS (
+               SELECT 1
+                 FROM pg_constraint con
+                 JOIN pg_class parent ON parent.oid = con.confrelid
+                WHERE con.conrelid = tc.oid
+                  AND con.contype = 'f'
+                  AND parent.relnamespace = n.oid
+                  AND parent.relname = 'teams'
+           )
+           AND (SELECT attname FROM pg_attribute
+                 WHERE attrelid = i.indrelid AND attnum = i.indkey[0]) <> 'team_id'
+    LOOP
+        idxdef := regexp_replace(rec.def, '(USING btree \()', '\1team_id, ');
+        EXECUTE format('DROP INDEX IF EXISTS public.%I', rec.index_name);
+        EXECUTE idxdef;
+    END LOOP;
+END
+$$;

--- a/db/postgres/migrations/0112_team_core.down.sql
+++ b/db/postgres/migrations/0112_team_core.down.sql
@@ -1,4 +1,4 @@
--- 0111_team_core (down)
+-- 0112_team_core (down)
 -- Reverse the team core in dependency order.
 
 -- ---------------------------------------------------------------------------

--- a/db/postgres/migrations/0112_team_core.up.sql
+++ b/db/postgres/migrations/0112_team_core.up.sql
@@ -1,4 +1,4 @@
--- 0111_team_core
+-- 0112_team_core
 -- Add the singleton team root, team-scoped schema, query context, RLS,
 -- team-safe view, and team-prefixed indexes.
 

--- a/db/postgres/queries/acl.sql
+++ b/db/postgres/queries/acl.sql
@@ -4,7 +4,7 @@
 SELECT COALESCE((
   SELECT r.effect
   FROM bot_acl_rules r
-  WHERE r.bot_id = b.id
+  WHERE r.team_id = public.memoh_current_team_id() AND r.bot_id = b.id
     AND r.enabled = true
     AND r.action = sqlc.arg(action)
     AND r.effect <> b.acl_default_effect
@@ -16,13 +16,13 @@ SELECT COALESCE((
   LIMIT 1
 ), b.acl_default_effect) AS effect
 FROM bots b
-WHERE b.id = sqlc.arg(bot_id);
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = sqlc.arg(bot_id);
 
 -- name: GetBotACLDefaultEffect :one
-SELECT acl_default_effect FROM bots WHERE id = $1;
+SELECT acl_default_effect FROM bots WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: SetBotACLDefaultEffect :exec
-UPDATE bots SET acl_default_effect = $2, updated_at = now() WHERE id = $1;
+UPDATE bots SET acl_default_effect = $2, updated_at = now() WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: ListBotACLRules :many
 SELECT
@@ -51,13 +51,14 @@ SELECT
   )::text AS source_conversation_name,
   COALESCE(NULLIF(TRIM(COALESCE(source_route.metadata->>'conversation_avatar_url', '')), ''), '')::text AS source_conversation_avatar_url
 FROM bot_acl_rules r
-LEFT JOIN channel_identities ci ON ci.id = r.channel_identity_id
-LEFT JOIN bot_channel_routes source_route ON source_route.bot_id = r.bot_id
+LEFT JOIN channel_identities ci ON ci.id = r.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_channel_routes source_route ON source_route.team_id = public.memoh_current_team_id()
+  AND source_route.bot_id = r.bot_id
   AND r.source_conversation_id IS NOT NULL
   AND source_route.external_conversation_id = r.source_conversation_id
   AND COALESCE(source_route.external_thread_id, '') = COALESCE(r.source_thread_id, '')
   AND (r.source_channel IS NULL OR source_route.channel_type = r.source_channel)
-WHERE r.bot_id = $1
+WHERE r.team_id = public.memoh_current_team_id() AND r.bot_id = $1
   AND r.action = 'chat.trigger'
 ORDER BY r.created_at DESC;
 
@@ -105,8 +106,8 @@ SET
   source_conversation_id = sqlc.narg(source_conversation_id)::text,
   source_thread_id = sqlc.narg(source_thread_id)::text,
   updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING *;
 
 -- name: DeleteBotACLRuleByID :exec
-DELETE FROM bot_acl_rules WHERE id = $1;
+DELETE FROM bot_acl_rules WHERE team_id = public.memoh_current_team_id() AND id = $1;

--- a/db/postgres/queries/bot_channel_admins.sql
+++ b/db/postgres/queries/bot_channel_admins.sql
@@ -12,8 +12,8 @@ SELECT
   ci.display_name AS channel_identity_display_name,
   ci.avatar_url AS channel_identity_avatar_url
 FROM bot_channel_admins a
-LEFT JOIN channel_identities ci ON ci.id = a.channel_identity_id
-WHERE a.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = a.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+WHERE a.team_id = public.memoh_current_team_id() AND a.bot_id = $1
 ORDER BY a.created_at DESC;
 
 -- name: UpsertBotChannelAdmin :one
@@ -29,16 +29,16 @@ VALUES (
   $3,
   sqlc.narg(created_by_user_id)::uuid
 )
-ON CONFLICT (bot_id, channel_identity_id) DO UPDATE
+ON CONFLICT (team_id, bot_id, channel_identity_id) DO UPDATE
   SET granted = EXCLUDED.granted,
       updated_at = now()
 RETURNING *;
 
 -- name: DeleteBotChannelAdmin :exec
 DELETE FROM bot_channel_admins
-WHERE bot_id = $1 AND channel_identity_id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_identity_id = $2;
 
 -- name: GetBotChannelAdmin :one
-SELECT id, bot_id, channel_identity_id, granted, created_by_user_id, created_at, updated_at
+SELECT id, bot_id, channel_identity_id, granted, created_by_user_id, created_at, updated_at, team_id
 FROM bot_channel_admins
-WHERE bot_id = $1 AND channel_identity_id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_identity_id = $2;

--- a/db/postgres/queries/bot_user_grants.sql
+++ b/db/postgres/queries/bot_user_grants.sql
@@ -12,19 +12,20 @@ SELECT
   u.display_name AS user_display_name,
   u.avatar_url AS user_avatar_url
 FROM bot_user_grants g
-LEFT JOIN users u ON u.id = g.user_id
-WHERE g.bot_id = $1
+LEFT JOIN users u ON u.id = g.user_id AND u.team_id = public.memoh_current_team_id()
+WHERE g.team_id = public.memoh_current_team_id() AND g.bot_id = $1
 ORDER BY g.subject_type DESC, g.created_at ASC;
 
 -- name: GetBotUserGrantByID :one
-SELECT id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at
+SELECT id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at, team_id
 FROM bot_user_grants
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: ListBotUserGrantsForUser :many
 SELECT id, bot_id, subject_type, user_id, permissions
 FROM bot_user_grants
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND (
     subject_type = 'everyone'
     OR (subject_type = 'user' AND user_id = sqlc.narg(user_id)::uuid)
@@ -39,14 +40,14 @@ VALUES (
   $3,
   sqlc.narg(created_by_user_id)::uuid
 )
-RETURNING id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at;
+RETURNING id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at, team_id;
 
 -- name: UpdateBotUserGrantPermissions :one
 UPDATE bot_user_grants
 SET permissions = $2,
     updated_at = now()
-WHERE id = $1
-RETURNING id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at;
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at, team_id;
 
 -- name: DeleteBotUserGrantByID :exec
-DELETE FROM bot_user_grants WHERE id = $1;
+DELETE FROM bot_user_grants WHERE team_id = public.memoh_current_team_id() AND id = $1;

--- a/db/postgres/queries/bots.sql
+++ b/db/postgres/queries/bots.sql
@@ -6,31 +6,35 @@ RETURNING id, owner_user_id, name, display_name, avatar_url, timezone, is_active
 -- name: GetBotByID :one
 SELECT id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id, metadata, created_at, updated_at
 FROM bots
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: GetBotByName :one
 SELECT id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id, metadata, created_at, updated_at
 FROM bots
-WHERE name = $1;
+WHERE team_id = public.memoh_current_team_id() AND name = $1;
 
 -- name: ListBotsByOwner :many
 SELECT id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, metadata, created_at, updated_at
 FROM bots
-WHERE owner_user_id = $1
+WHERE team_id = public.memoh_current_team_id() AND owner_user_id = $1
 ORDER BY created_at DESC;
 
 -- name: ListAccessibleBots :many
 SELECT id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, metadata, created_at, updated_at
 FROM bots b
-WHERE b.owner_user_id = $1
-   OR EXISTS (
-     SELECT 1 FROM bot_user_grants g
-     WHERE g.bot_id = b.id
-       AND (
-         g.subject_type = 'everyone'
-         OR (g.subject_type = 'user' AND g.user_id = $1)
-       )
-   )
+WHERE b.team_id = public.memoh_current_team_id()
+  AND (
+    b.owner_user_id = $1
+    OR EXISTS (
+      SELECT 1 FROM bot_user_grants g
+      WHERE g.team_id = b.team_id
+        AND g.bot_id = b.id
+        AND (
+          g.subject_type = 'everyone'
+          OR (g.subject_type = 'user' AND g.user_id = $1)
+        )
+    )
+  )
 ORDER BY b.created_at DESC;
 
 -- name: UpdateBotProfile :one
@@ -42,34 +46,36 @@ SET name = $2,
     is_active = $6,
     metadata = $7,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, metadata, created_at, updated_at;
 
 -- name: UpdateBotOwner :one
 UPDATE bots
 SET owner_user_id = $2,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, metadata, created_at, updated_at;
 
 -- name: UpdateBotStatus :exec
 UPDATE bots
 SET status = $2,
     updated_at = now()
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: DeleteBotByID :exec
 WITH target_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.bot_id = sqlc.arg(id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.bot_id = sqlc.arg(id)
   ORDER BY session.id
   FOR UPDATE
 ),
 target_compaction_artifacts AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.bot_id = sqlc.arg(id)
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.bot_id = sqlc.arg(id)
     AND (SELECT count(*) FROM target_sessions) >= 0
   ORDER BY compact.id
   FOR UPDATE
@@ -77,13 +83,15 @@ target_compaction_artifacts AS MATERIALIZED (
 deleted_compaction_artifacts AS (
   DELETE FROM bot_history_message_compacts compact
   USING target_compaction_artifacts target
-  WHERE compact.id = target.id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = target.id
   RETURNING compact.id
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.bot_id = sqlc.arg(id)
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.bot_id = sqlc.arg(id)
     AND (SELECT count(*) FROM target_sessions) >= 0
     AND (SELECT count(*) FROM deleted_compaction_artifacts) >= 0
   ORDER BY message.id
@@ -92,22 +100,25 @@ target_messages AS MATERIALIZED (
 deleted_messages AS (
   DELETE FROM bot_history_messages message
   USING target_messages target
-  WHERE message.id = target.id
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = target.id
   RETURNING message.id
 ),
 deleted_sessions AS (
   DELETE FROM bot_sessions session
   USING target_sessions target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
     AND (SELECT count(*) FROM deleted_messages) >= 0
   RETURNING session.id
 )
 DELETE FROM bots bot
-WHERE bot.id = sqlc.arg(id)
+WHERE bot.team_id = public.memoh_current_team_id()
+  AND bot.id = sqlc.arg(id)
   AND (SELECT count(*) FROM target_sessions) >= 0
   AND (SELECT count(*) FROM deleted_sessions) >= 0;
 
 -- name: ListHeartbeatEnabledBots :many
 SELECT id, owner_user_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt
 FROM bots
-WHERE heartbeat_enabled = true AND status = 'ready';
+WHERE team_id = public.memoh_current_team_id() AND heartbeat_enabled = true AND status = 'ready';

--- a/db/postgres/queries/channel_identities.sql
+++ b/db/postgres/queries/channel_identities.sql
@@ -1,34 +1,34 @@
 -- name: CreateChannelIdentity :one
 INSERT INTO channel_identities (channel_type, channel_subject_id, display_name, avatar_url, metadata)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at;
+RETURNING id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id;
 
 -- name: GetChannelIdentityByID :one
-SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at
+SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id
 FROM channel_identities
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: GetChannelIdentityByIDForUpdate :one
-SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at
+SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id
 FROM channel_identities
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 FOR UPDATE;
 
 -- name: GetChannelIdentityByChannelSubject :one
-SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at
+SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id
 FROM channel_identities
-WHERE channel_type = $1 AND channel_subject_id = $2;
+WHERE team_id = public.memoh_current_team_id() AND channel_type = $1 AND channel_subject_id = $2;
 
 -- name: UpsertChannelIdentityByChannelSubject :one
 INSERT INTO channel_identities (channel_type, channel_subject_id, display_name, avatar_url, metadata)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (channel_type, channel_subject_id)
+ON CONFLICT (team_id, channel_type, channel_subject_id)
 DO UPDATE SET
   display_name = COALESCE(NULLIF(EXCLUDED.display_name, ''), channel_identities.display_name),
   avatar_url = COALESCE(NULLIF(EXCLUDED.avatar_url, ''), channel_identities.avatar_url),
   metadata = EXCLUDED.metadata,
   updated_at = now()
-RETURNING id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at;
+RETURNING id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id;
 
 -- name: SearchChannelIdentities :many
 SELECT
@@ -39,13 +39,17 @@ SELECT
   ci.avatar_url,
   ci.metadata,
   ci.created_at,
-  ci.updated_at
+  ci.updated_at,
+  ci.team_id
 FROM channel_identities ci
 WHERE
-  sqlc.arg(query)::text = ''
-  OR ci.channel_type ILIKE '%' || sqlc.arg(query)::text || '%'
-  OR ci.channel_subject_id ILIKE '%' || sqlc.arg(query)::text || '%'
-  OR COALESCE(ci.display_name, '') ILIKE '%' || sqlc.arg(query)::text || '%'
+  ci.team_id = public.memoh_current_team_id()
+  AND (
+    sqlc.arg(query)::text = ''
+    OR ci.channel_type ILIKE '%' || sqlc.arg(query)::text || '%'
+    OR ci.channel_subject_id ILIKE '%' || sqlc.arg(query)::text || '%'
+    OR COALESCE(ci.display_name, '') ILIKE '%' || sqlc.arg(query)::text || '%'
+  )
 ORDER BY ci.updated_at DESC
 LIMIT sqlc.arg(limit_count);
 

--- a/db/postgres/queries/channel_identity_bindings.sql
+++ b/db/postgres/queries/channel_identity_bindings.sql
@@ -1,19 +1,20 @@
 -- name: CreateChannelLinkCode :one
 INSERT INTO channel_link_codes (token, user_id, channel_type, expires_at)
 VALUES ($1, $2, sqlc.narg(channel_type)::text, $3)
-RETURNING token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at;
+RETURNING token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at, team_id;
 
 -- name: GetChannelLinkCodeByToken :one
-SELECT token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at
+SELECT token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at, team_id
 FROM channel_link_codes
-WHERE token = $1;
+WHERE team_id = public.memoh_current_team_id() AND token = $1;
 
 -- name: RedeemChannelLinkCode :one
 WITH claimed AS (
   UPDATE channel_link_codes
   SET consumed_at = now(),
       consumed_channel_identity_id = $2
-  WHERE token = $1
+  WHERE team_id = public.memoh_current_team_id()
+    AND token = $1
     AND consumed_at IS NULL
     AND expires_at > now()
   RETURNING user_id
@@ -21,23 +22,23 @@ WITH claimed AS (
 INSERT INTO user_channel_identity_bindings (user_id, channel_identity_id)
 SELECT user_id, $2
 FROM claimed
-ON CONFLICT (user_id, channel_identity_id) DO UPDATE
+ON CONFLICT (team_id, user_id, channel_identity_id) DO UPDATE
   SET updated_at = now()
-RETURNING id, user_id, channel_identity_id, created_at, updated_at;
+RETURNING id, user_id, channel_identity_id, created_at, updated_at, team_id;
 
 -- name: MarkChannelLinkCodeConsumed :one
 UPDATE channel_link_codes
 SET consumed_at = now(),
     consumed_channel_identity_id = $2
-WHERE token = $1 AND consumed_at IS NULL AND expires_at > now()
-RETURNING token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at;
+WHERE team_id = public.memoh_current_team_id() AND token = $1 AND consumed_at IS NULL AND expires_at > now()
+RETURNING token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at, team_id;
 
 -- name: UpsertUserChannelIdentityBinding :one
 INSERT INTO user_channel_identity_bindings (user_id, channel_identity_id)
 VALUES ($1, $2)
-ON CONFLICT (user_id, channel_identity_id) DO UPDATE
+ON CONFLICT (team_id, user_id, channel_identity_id) DO UPDATE
   SET updated_at = now()
-RETURNING id, user_id, channel_identity_id, created_at, updated_at;
+RETURNING id, user_id, channel_identity_id, created_at, updated_at, team_id;
 
 -- name: ListChannelIdentityBindingsForUser :many
 SELECT
@@ -51,8 +52,8 @@ SELECT
   ci.display_name AS channel_identity_display_name,
   ci.avatar_url AS channel_identity_avatar_url
 FROM user_channel_identity_bindings b
-LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id
-WHERE b.user_id = $1
+LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.user_id = $1
 ORDER BY b.created_at DESC;
 
 -- name: ListChannelIdentityBindingsForBot :many
@@ -67,8 +68,9 @@ SELECT DISTINCT
   ci.display_name AS channel_identity_display_name,
   ci.avatar_url AS channel_identity_avatar_url
 FROM user_channel_identity_bindings b
-INNER JOIN bot_user_grants g ON g.user_id = b.user_id AND g.bot_id = $1 AND g.subject_type = 'user'
-LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id
+INNER JOIN bot_user_grants g ON g.user_id = b.user_id AND g.bot_id = $1 AND g.subject_type = 'user' AND g.team_id = public.memoh_current_team_id()
+LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id()
 ORDER BY b.created_at DESC;
 
 -- name: ListChannelIdentityBindings :many
@@ -83,14 +85,15 @@ SELECT
   ci.display_name AS channel_identity_display_name,
   ci.avatar_url AS channel_identity_avatar_url
 FROM user_channel_identity_bindings b
-LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id
+LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id()
 ORDER BY b.created_at DESC;
 
 -- name: DeleteUserChannelIdentityBinding :exec
 DELETE FROM user_channel_identity_bindings
-WHERE user_id = $1 AND channel_identity_id = $2;
+WHERE team_id = public.memoh_current_team_id() AND user_id = $1 AND channel_identity_id = $2;
 
 -- name: ListUserIDsByChannelIdentity :many
 SELECT user_id
 FROM user_channel_identity_bindings
-WHERE channel_identity_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND channel_identity_id = $1;

--- a/db/postgres/queries/channel_routes.sql
+++ b/db/postgres/queries/channel_routes.sql
@@ -43,7 +43,8 @@ SELECT
   created_at,
   updated_at
 FROM bot_channel_routes
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND channel_type = sqlc.arg(platform)
   AND external_conversation_id = sqlc.arg(conversation_id)
   AND COALESCE(external_thread_id, '') = COALESCE(sqlc.narg(thread_id), '')
@@ -65,7 +66,7 @@ SELECT
   created_at,
   updated_at
 FROM bot_channel_routes
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: ListChatRoutes :many
 SELECT
@@ -83,24 +84,25 @@ SELECT
   created_at,
   updated_at
 FROM bot_channel_routes
-WHERE bot_id = sqlc.arg(chat_id)
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(chat_id)
 ORDER BY created_at ASC;
 
 -- name: UpdateChatRouteReplyTarget :exec
 UPDATE bot_channel_routes
 SET default_reply_target = sqlc.arg(reply_target), updated_at = now()
-WHERE id = sqlc.arg(id);
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: UpdateChatRouteMetadata :exec
 UPDATE bot_channel_routes
 SET metadata = sqlc.arg(metadata), updated_at = now()
-WHERE id = sqlc.arg(id);
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: SetRouteActiveSession :exec
 WITH destination_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = sqlc.narg(active_session_id)::uuid
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = sqlc.narg(active_session_id)::uuid
   FOR KEY SHARE
 )
 UPDATE bot_channel_routes route
@@ -109,16 +111,19 @@ SET active_session_id = COALESCE(
       sqlc.narg(active_session_id)::uuid
     ),
     updated_at = now()
-WHERE route.id = sqlc.arg(id);
+WHERE route.team_id = public.memoh_current_team_id()
+  AND route.id = sqlc.arg(id);
 
 -- name: DeleteChatRoute :exec
 WITH route_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.route_id = sqlc.arg(id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.route_id = sqlc.arg(id)
   ORDER BY session.id
   FOR UPDATE
 )
 DELETE FROM bot_channel_routes route
-WHERE route.id = sqlc.arg(id)
+WHERE route.team_id = public.memoh_current_team_id()
+  AND route.id = sqlc.arg(id)
   AND (SELECT count(*) FROM route_sessions) >= 0;

--- a/db/postgres/queries/channels.sql
+++ b/db/postgres/queries/channels.sql
@@ -1,17 +1,17 @@
 -- name: DeleteBotChannelConfig :exec
 DELETE FROM bot_channel_configs
-WHERE bot_id = $1 AND channel_type = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_type = $2;
 
 -- name: GetBotChannelConfig :one
-SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id
 FROM bot_channel_configs
-WHERE bot_id = $1 AND channel_type = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_type = $2
 LIMIT 1;
 
 -- name: GetBotChannelConfigByExternalIdentity :one
-SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id
 FROM bot_channel_configs
-WHERE channel_type = $1 AND external_identity = $2
+WHERE team_id = public.memoh_current_team_id() AND channel_type = $1 AND external_identity = $2
 LIMIT 1;
 
 -- name: UpsertBotChannelConfig :one
@@ -19,7 +19,7 @@ INSERT INTO bot_channel_configs (
   bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-ON CONFLICT (bot_id, channel_type)
+ON CONFLICT (team_id, bot_id, channel_type)
 DO UPDATE SET
   credentials = EXCLUDED.credentials,
   external_identity = EXCLUDED.external_identity,
@@ -29,15 +29,15 @@ DO UPDATE SET
   disabled = EXCLUDED.disabled,
   verified_at = EXCLUDED.verified_at,
   updated_at = now()
-RETURNING id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at;
+RETURNING id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id;
 
 -- name: UpdateBotChannelConfigDisabled :one
 UPDATE bot_channel_configs
 SET
   disabled = $3,
   updated_at = now()
-WHERE bot_id = $1 AND channel_type = $2
-RETURNING id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_type = $2
+RETURNING id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id;
 
 -- name: SaveMatrixSyncSinceToken :execrows
 UPDATE bot_channel_configs
@@ -45,31 +45,31 @@ SET routing = COALESCE(routing, '{}'::jsonb) || jsonb_build_object(
   '_matrix',
   COALESCE(routing->'_matrix', '{}'::jsonb) || jsonb_build_object('since_token', sqlc.arg(since_token)::text)
 )
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: ListBotChannelConfigsByType :many
-SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id
 FROM bot_channel_configs
-WHERE channel_type = $1
+WHERE team_id = public.memoh_current_team_id() AND channel_type = $1
 ORDER BY created_at DESC;
 
 -- name: GetUserChannelBinding :one
-SELECT id, user_id, channel_type, config, created_at, updated_at
+SELECT id, user_id, channel_type, config, created_at, updated_at, team_id
 FROM user_channel_bindings
-WHERE user_id = $1 AND channel_type = $2
+WHERE team_id = public.memoh_current_team_id() AND user_id = $1 AND channel_type = $2
 LIMIT 1;
 
 -- name: UpsertUserChannelBinding :one
 INSERT INTO user_channel_bindings (user_id, channel_type, config)
 VALUES ($1, $2, $3)
-ON CONFLICT (user_id, channel_type)
+ON CONFLICT (team_id, user_id, channel_type)
 DO UPDATE SET
   config = EXCLUDED.config,
   updated_at = now()
-RETURNING id, user_id, channel_type, config, created_at, updated_at;
+RETURNING id, user_id, channel_type, config, created_at, updated_at, team_id;
 
 -- name: ListUserChannelBindingsByPlatform :many
-SELECT id, user_id, channel_type, config, created_at, updated_at
+SELECT id, user_id, channel_type, config, created_at, updated_at, team_id
 FROM user_channel_bindings
-WHERE channel_type = $1
+WHERE team_id = public.memoh_current_team_id() AND channel_type = $1
 ORDER BY created_at DESC;

--- a/db/postgres/queries/compaction_logs.sql
+++ b/db/postgres/queries/compaction_logs.sql
@@ -1,38 +1,48 @@
 -- name: CreateCompactionLog :one
 WITH owner_session AS MATERIALIZED (
-  SELECT session.id, session.bot_id, session.compaction_epoch
+  SELECT session.id, session.bot_id, session.compaction_epoch, session.team_id
   FROM bot_sessions session
-  WHERE session.id = sqlc.arg(session_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = sqlc.arg(session_id)
     AND session.bot_id = sqlc.arg(bot_id)
     AND session.compaction_epoch = sqlc.arg(expected_epoch)
   FOR UPDATE
 )
-INSERT INTO bot_history_message_compacts (bot_id, session_id, compaction_epoch)
-SELECT sqlc.arg(bot_id), owner_session.id, owner_session.compaction_epoch
+INSERT INTO bot_history_message_compacts (bot_id, session_id, compaction_epoch, team_id)
+SELECT sqlc.arg(bot_id), owner_session.id, owner_session.compaction_epoch, owner_session.team_id
 FROM owner_session
 RETURNING id, bot_id, session_id, status, summary, message_count, error_message, usage, model_id,
           artifact_version, coverage, anchor_start_ms, anchor_end_ms, artifact_level, parent_ids,
-          superseded_by, superseded_at, compaction_epoch, started_at, completed_at;
+          superseded_by, superseded_at, compaction_epoch, started_at, completed_at, team_id;
 
 -- name: CompleteCompactionLog :one
 WITH target_compact AS MATERIALIZED (
-  SELECT compact.id, compact.session_id
+  SELECT compact.id, compact.session_id, compact.team_id
   FROM bot_history_message_compacts compact
-  WHERE compact.id = $1
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = $1
     AND compact.status = 'pending'
 ),
 owner_session AS MATERIALIZED (
-  SELECT session.id, session.bot_id, session.compaction_epoch
+  SELECT session.id, session.bot_id, session.compaction_epoch, session.team_id
   FROM bot_sessions session
-  JOIN target_compact compact ON compact.session_id = session.id
+  JOIN target_compact compact
+    ON compact.session_id = session.id
+   AND compact.team_id = session.team_id
+  WHERE session.team_id = public.memoh_current_team_id()
   FOR UPDATE OF session
 ),
 locked_compact AS MATERIALIZED (
-  SELECT compact.id
+  SELECT compact.id, compact.team_id
   FROM bot_history_message_compacts compact
-  JOIN target_compact target ON target.id = compact.id
-  LEFT JOIN owner_session owner ON owner.id = target.session_id
-  WHERE target.session_id IS NULL OR owner.id IS NOT NULL
+  JOIN target_compact target
+    ON target.id = compact.id
+   AND target.team_id = compact.team_id
+  LEFT JOIN owner_session owner
+    ON owner.id = target.session_id
+   AND owner.team_id = target.team_id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND (target.session_id IS NULL OR owner.id IS NOT NULL)
   FOR UPDATE OF compact
 )
 UPDATE bot_history_message_compacts compact
@@ -47,7 +57,9 @@ SET status = $2,
     anchor_end_ms = $10,
     completed_at = now()
 FROM locked_compact locked
-WHERE compact.id = locked.id
+WHERE compact.team_id = public.memoh_current_team_id()
+  AND compact.team_id = locked.team_id
+  AND compact.id = locked.id
   AND compact.status = 'pending'
   AND (
     $2 <> 'ok'
@@ -57,7 +69,8 @@ WHERE compact.id = locked.id
         OR EXISTS (
           SELECT 1
           FROM owner_session owner
-          WHERE owner.id = compact.session_id
+          WHERE owner.team_id = compact.team_id
+            AND owner.id = compact.session_id
             AND owner.bot_id = compact.bot_id
             AND owner.compaction_epoch = compact.compaction_epoch
         )
@@ -65,7 +78,8 @@ WHERE compact.id = locked.id
       AND (
         SELECT count(*)
         FROM bot_history_messages source_message
-        WHERE source_message.compact_id = compact.id
+        WHERE source_message.team_id = compact.team_id
+          AND source_message.compact_id = compact.id
       ) = $4
     )
   )
@@ -73,20 +87,22 @@ RETURNING compact.id, compact.bot_id, compact.session_id, compact.status, compac
           compact.message_count, compact.error_message, compact.usage, compact.model_id,
           compact.artifact_version, compact.coverage, compact.anchor_start_ms, compact.anchor_end_ms,
           compact.artifact_level, compact.parent_ids, compact.superseded_by, compact.superseded_at,
-          compact.compaction_epoch, compact.started_at, compact.completed_at;
+          compact.compaction_epoch, compact.started_at, compact.completed_at, compact.team_id;
 
 -- name: GetCompactionLogByID :one
 SELECT id, bot_id, session_id, status, summary, message_count, error_message, usage, model_id,
        artifact_version, coverage, anchor_start_ms, anchor_end_ms, artifact_level, parent_ids,
-       superseded_by, superseded_at, compaction_epoch, started_at, completed_at
+       superseded_by, superseded_at, compaction_epoch, started_at, completed_at, team_id
 FROM bot_history_message_compacts compact
-WHERE compact.id = $1
+WHERE compact.team_id = public.memoh_current_team_id()
+  AND compact.id = $1
   AND (
     compact.session_id IS NULL
     OR EXISTS (
       SELECT 1
       FROM bot_sessions owner_session
-      WHERE owner_session.id = compact.session_id
+      WHERE owner_session.team_id = compact.team_id
+        AND owner_session.id = compact.session_id
         AND owner_session.bot_id = compact.bot_id
         AND owner_session.compaction_epoch = compact.compaction_epoch
     )
@@ -98,7 +114,9 @@ FROM bot_history_message_compacts parent
 JOIN bot_sessions owner_session
   ON owner_session.id = sqlc.narg(session_id)::uuid
  AND owner_session.bot_id = sqlc.arg(bot_id)
-WHERE parent.superseded_by = sqlc.arg(successor_id)
+ AND owner_session.team_id = parent.team_id
+WHERE parent.team_id = public.memoh_current_team_id()
+  AND parent.superseded_by = sqlc.arg(successor_id)
   AND parent.bot_id = owner_session.bot_id
   AND parent.session_id = owner_session.id
   AND parent.compaction_epoch = owner_session.compaction_epoch
@@ -106,7 +124,8 @@ WHERE parent.superseded_by = sqlc.arg(successor_id)
   AND EXISTS (
     SELECT 1
     FROM bot_history_message_compacts successor
-    WHERE successor.id = parent.superseded_by
+    WHERE successor.team_id = parent.team_id
+      AND successor.id = parent.superseded_by
       AND successor.bot_id = owner_session.bot_id
       AND successor.session_id = owner_session.id
       AND successor.compaction_epoch = owner_session.compaction_epoch
@@ -116,31 +135,34 @@ ORDER BY parent.id ASC;
 -- name: ListCompactionLogsByBot :many
 SELECT id, bot_id, session_id, status, summary, message_count, error_message, usage, model_id,
        artifact_version, coverage, anchor_start_ms, anchor_end_ms, artifact_level, parent_ids,
-       superseded_by, superseded_at, compaction_epoch, started_at, completed_at
+       superseded_by, superseded_at, compaction_epoch, started_at, completed_at, team_id
 FROM bot_history_message_compacts
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: CountCompactionLogsByBot :one
-SELECT count(*) FROM bot_history_message_compacts WHERE bot_id = $1;
+SELECT count(*) FROM bot_history_message_compacts WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: ListCompactionArtifactLineageBySession :many
 SELECT c.id, c.bot_id, c.session_id, c.status, c.summary, c.message_count, c.error_message, c.usage, c.model_id,
        c.artifact_version, c.coverage, c.anchor_start_ms, c.anchor_end_ms, c.artifact_level, c.parent_ids,
-       c.superseded_by, c.superseded_at, c.compaction_epoch, c.started_at, c.completed_at
+       c.superseded_by, c.superseded_at, c.compaction_epoch, c.started_at, c.completed_at, c.team_id
 FROM bot_history_message_compacts c
 JOIN bot_sessions owner_session
   ON owner_session.id = $1
  AND owner_session.bot_id = c.bot_id
-WHERE c.session_id = owner_session.id
+ AND owner_session.team_id = c.team_id
+WHERE c.team_id = public.memoh_current_team_id()
+  AND c.session_id = owner_session.id
   AND c.compaction_epoch = owner_session.compaction_epoch
   AND (
     c.status = 'ok'
     OR EXISTS (
       SELECT 1
       FROM bot_history_message_compacts parent
-      WHERE parent.bot_id = owner_session.bot_id
+      WHERE parent.team_id = c.team_id
+        AND parent.bot_id = owner_session.bot_id
         AND parent.session_id = owner_session.id
         AND parent.compaction_epoch = owner_session.compaction_epoch
         AND parent.status = 'ok'
@@ -153,7 +175,8 @@ ORDER BY c.anchor_start_ms ASC, c.started_at ASC, c.id ASC;
 WITH target_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.bot_id = sqlc.arg(target_bot_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.bot_id = sqlc.arg(target_bot_id)
   ORDER BY session.id
   FOR UPDATE
 ),
@@ -161,17 +184,20 @@ invalidated_sessions AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
   FROM target_sessions target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
   RETURNING session.id
 ),
 target_compaction_logs AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.bot_id = sqlc.arg(target_bot_id)
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.bot_id = sqlc.arg(target_bot_id)
     AND (SELECT count(*) FROM target_sessions) >= 0
   ORDER BY compact.id
   FOR UPDATE
 )
 DELETE FROM bot_history_message_compacts AS compacts
 USING target_compaction_logs target
-WHERE compacts.id = target.id;
+WHERE compacts.team_id = public.memoh_current_team_id()
+  AND compacts.id = target.id;

--- a/db/postgres/queries/containers.sql
+++ b/db/postgres/queries/containers.sql
@@ -16,7 +16,7 @@ VALUES (
   sqlc.arg(last_started_at),
   sqlc.arg(last_stopped_at)
 )
-ON CONFLICT (container_id) DO UPDATE SET
+ON CONFLICT (team_id, container_id) DO UPDATE SET
   bot_id = EXCLUDED.bot_id,
   container_name = EXCLUDED.container_name,
   image = EXCLUDED.image,
@@ -30,25 +30,25 @@ ON CONFLICT (container_id) DO UPDATE SET
   updated_at = now();
 
 -- name: GetContainerByBotID :one
-SELECT * FROM containers WHERE bot_id = sqlc.arg(bot_id) ORDER BY updated_at DESC LIMIT 1;
+SELECT * FROM containers WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id) ORDER BY updated_at DESC LIMIT 1;
 
 -- name: DeleteContainerByBotID :exec
-DELETE FROM containers WHERE bot_id = sqlc.arg(bot_id);
+DELETE FROM containers WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id);
 
 -- name: UpdateContainerStatus :exec
 UPDATE containers
 SET status = sqlc.arg(status), updated_at = now()
-WHERE bot_id = sqlc.arg(bot_id);
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id);
 
 -- name: UpdateContainerStarted :exec
 UPDATE containers
 SET status = 'running', last_started_at = now(), updated_at = now()
-WHERE bot_id = sqlc.arg(bot_id);
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id);
 
 -- name: UpdateContainerStopped :exec
 UPDATE containers
 SET status = 'stopped', last_stopped_at = now(), updated_at = now()
-WHERE bot_id = sqlc.arg(bot_id);
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id);
 
 -- name: ListAutoStartContainers :many
-SELECT * FROM containers WHERE auto_start = true ORDER BY updated_at DESC;
+SELECT * FROM containers WHERE team_id = public.memoh_current_team_id() AND auto_start = true ORDER BY updated_at DESC;

--- a/db/postgres/queries/conversations.sql
+++ b/db/postgres/queries/conversations.sql
@@ -11,8 +11,8 @@ SELECT
   b.created_at,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = sqlc.arg(bot_id)
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = sqlc.arg(bot_id)
 LIMIT 1;
 
 -- name: GetChatByID :one
@@ -28,8 +28,8 @@ SELECT
   b.created_at,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $1;
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1;
 
 -- name: ListChatsByBotAndUser :many
 SELECT
@@ -44,8 +44,8 @@ SELECT
   b.created_at,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = sqlc.arg(bot_id)
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = sqlc.arg(bot_id)
   AND b.owner_user_id = sqlc.arg(user_id)
 ORDER BY b.updated_at DESC;
 
@@ -68,8 +68,8 @@ SELECT
   END)::text AS participant_role,
   NULL::timestamptz AS last_observed_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = sqlc.arg(bot_id)
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = sqlc.arg(bot_id)
   AND b.owner_user_id = sqlc.arg(user_id)
 ORDER BY b.updated_at DESC;
 
@@ -79,7 +79,7 @@ SELECT
   'owner'::text AS participant_role,
   NULL::timestamptz AS last_observed_at
 FROM bots b
-WHERE b.id = sqlc.arg(chat_id)
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = sqlc.arg(chat_id)
   AND b.owner_user_id = sqlc.arg(user_id)
 LIMIT 1;
 
@@ -96,8 +96,8 @@ SELECT
   b.created_at,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $1
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1
 ORDER BY b.created_at DESC;
 
 -- name: UpdateChatTitle :one
@@ -105,7 +105,7 @@ WITH updated AS (
   UPDATE bots
   SET display_name = sqlc.arg(title),
       updated_at = now()
-  WHERE bots.id = sqlc.arg(bot_id)
+  WHERE bots.team_id = public.memoh_current_team_id() AND bots.id = sqlc.arg(bot_id)
   RETURNING *
 )
 SELECT
@@ -120,25 +120,27 @@ SELECT
   updated.created_at,
   updated.updated_at
 FROM updated
-LEFT JOIN models chat_models ON chat_models.id = updated.chat_model_id;
+LEFT JOIN models chat_models ON chat_models.id = updated.chat_model_id AND chat_models.team_id = public.memoh_current_team_id();
 
 -- name: TouchChat :exec
 UPDATE bots
 SET updated_at = now()
-WHERE id = sqlc.arg(chat_id);
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(chat_id);
 
 -- name: DeleteChat :exec
 WITH target_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.bot_id = sqlc.arg(chat_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.bot_id = sqlc.arg(chat_id)
   ORDER BY session.id
   FOR UPDATE
 ),
 target_compaction_artifacts AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.bot_id = sqlc.arg(chat_id)
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.bot_id = sqlc.arg(chat_id)
     AND (SELECT count(*) FROM target_sessions) >= 0
   ORDER BY compact.id
   FOR UPDATE
@@ -146,13 +148,15 @@ target_compaction_artifacts AS MATERIALIZED (
 deleted_compaction_artifacts AS (
   DELETE FROM bot_history_message_compacts compact
   USING target_compaction_artifacts target
-  WHERE compact.id = target.id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = target.id
   RETURNING compact.id
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.bot_id = sqlc.arg(chat_id)
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.bot_id = sqlc.arg(chat_id)
     AND (SELECT count(*) FROM target_sessions) >= 0
     AND (SELECT count(*) FROM deleted_compaction_artifacts) >= 0
   ORDER BY message.id
@@ -161,30 +165,33 @@ target_messages AS MATERIALIZED (
 deleted_messages AS (
   DELETE FROM bot_history_messages message
   USING target_messages target
-  WHERE message.id = target.id
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = target.id
   RETURNING message.id
 ),
 deleted_sessions AS (
   DELETE FROM bot_sessions session
   USING target_sessions target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
     AND (SELECT count(*) FROM deleted_messages) >= 0
   RETURNING session.id
 )
 DELETE FROM bot_channel_routes bcr
-WHERE bcr.bot_id = sqlc.arg(chat_id)
+WHERE bcr.team_id = public.memoh_current_team_id()
+  AND bcr.bot_id = sqlc.arg(chat_id)
   AND (SELECT count(*) FROM deleted_sessions) >= 0;
 
 -- name: GetChatParticipant :one
 SELECT b.id AS chat_id, b.owner_user_id AS user_id, 'owner'::text AS role, b.created_at AS joined_at
 FROM bots b
-WHERE b.id = sqlc.arg(chat_id) AND b.owner_user_id = sqlc.arg(user_id)
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = sqlc.arg(chat_id) AND b.owner_user_id = sqlc.arg(user_id)
 LIMIT 1;
 
 -- name: ListChatParticipants :many
 SELECT b.id AS chat_id, b.owner_user_id AS user_id, 'owner'::text AS role, b.created_at AS joined_at
 FROM bots b
-WHERE b.id = sqlc.arg(chat_id)
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = sqlc.arg(chat_id)
 ORDER BY joined_at ASC;
 
 -- name: RemoveChatParticipant :exec
@@ -192,7 +199,7 @@ SELECT 1
 WHERE EXISTS (
   SELECT 1
   FROM bots b
-  WHERE b.id = sqlc.arg(chat_id)
+  WHERE b.team_id = public.memoh_current_team_id() AND b.id = sqlc.arg(chat_id)
     AND b.owner_user_id = sqlc.arg(user_id)
 );
 
@@ -204,7 +211,7 @@ updated AS (
   UPDATE bots
   SET chat_model_id = COALESCE(sqlc.narg(chat_model_id)::uuid, bots.chat_model_id),
       updated_at = now()
-  WHERE bots.id = sqlc.arg(id)
+  WHERE bots.team_id = public.memoh_current_team_id() AND bots.id = sqlc.arg(id)
   RETURNING bots.id, bots.chat_model_id, bots.updated_at
 )
 SELECT
@@ -212,7 +219,7 @@ SELECT
   chat_models.id AS model_id,
   updated.updated_at
 FROM updated
-LEFT JOIN models chat_models ON chat_models.id = updated.chat_model_id;
+LEFT JOIN models chat_models ON chat_models.id = updated.chat_model_id AND chat_models.team_id = public.memoh_current_team_id();
 
 -- name: GetChatSettings :one
 SELECT
@@ -220,5 +227,5 @@ SELECT
   chat_models.id AS model_id,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $1;
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1;

--- a/db/postgres/queries/email_bindings.sql
+++ b/db/postgres/queries/email_bindings.sql
@@ -12,25 +12,25 @@ VALUES (
 RETURNING *;
 
 -- name: GetBotEmailBindingByID :one
-SELECT * FROM bot_email_bindings WHERE id = sqlc.arg(id);
+SELECT * FROM bot_email_bindings WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: GetBotEmailBindingByBotAndProvider :one
 SELECT * FROM bot_email_bindings
-WHERE bot_id = sqlc.arg(bot_id) AND email_provider_id = sqlc.arg(email_provider_id);
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id) AND email_provider_id = sqlc.arg(email_provider_id);
 
 -- name: ListBotEmailBindings :many
 SELECT * FROM bot_email_bindings
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id)
 ORDER BY created_at DESC;
 
 -- name: ListBotEmailBindingsByProvider :many
 SELECT * FROM bot_email_bindings
-WHERE email_provider_id = sqlc.arg(email_provider_id)
+WHERE team_id = public.memoh_current_team_id() AND email_provider_id = sqlc.arg(email_provider_id)
 ORDER BY created_at DESC;
 
 -- name: ListReadableBindingsByProvider :many
 SELECT * FROM bot_email_bindings
-WHERE email_provider_id = sqlc.arg(email_provider_id) AND can_read = TRUE
+WHERE team_id = public.memoh_current_team_id() AND email_provider_id = sqlc.arg(email_provider_id) AND can_read = TRUE
 ORDER BY created_at DESC;
 
 -- name: UpdateBotEmailBinding :one
@@ -42,8 +42,8 @@ SET
   can_delete = sqlc.arg(can_delete),
   config = sqlc.arg(config),
   updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: DeleteBotEmailBinding :exec
-DELETE FROM bot_email_bindings WHERE id = sqlc.arg(id);
+DELETE FROM bot_email_bindings WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);

--- a/db/postgres/queries/email_oauth_tokens.sql
+++ b/db/postgres/queries/email_oauth_tokens.sql
@@ -1,7 +1,7 @@
 -- name: UpsertEmailOAuthToken :one
 INSERT INTO email_oauth_tokens (email_provider_id, email_address, access_token, refresh_token, expires_at, scope, state)
 VALUES (sqlc.arg(email_provider_id), sqlc.arg(email_address), sqlc.arg(access_token), sqlc.arg(refresh_token), sqlc.arg(expires_at), sqlc.arg(scope), sqlc.arg(state))
-ON CONFLICT (email_provider_id) DO UPDATE SET
+ON CONFLICT (team_id, email_provider_id) DO UPDATE SET
   email_address  = EXCLUDED.email_address,
   access_token   = EXCLUDED.access_token,
   refresh_token  = EXCLUDED.refresh_token,
@@ -12,17 +12,17 @@ ON CONFLICT (email_provider_id) DO UPDATE SET
 RETURNING *;
 
 -- name: GetEmailOAuthTokenByProvider :one
-SELECT * FROM email_oauth_tokens WHERE email_provider_id = sqlc.arg(email_provider_id);
+SELECT * FROM email_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND email_provider_id = sqlc.arg(email_provider_id);
 
 -- name: GetEmailOAuthTokenByState :one
-SELECT * FROM email_oauth_tokens WHERE state = sqlc.arg(state) AND state != '';
+SELECT * FROM email_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND state = sqlc.arg(state) AND state != '';
 
 -- name: UpdateEmailOAuthState :exec
 INSERT INTO email_oauth_tokens (email_provider_id, state)
 VALUES (sqlc.arg(email_provider_id), sqlc.arg(state))
-ON CONFLICT (email_provider_id) DO UPDATE SET
+ON CONFLICT (team_id, email_provider_id) DO UPDATE SET
   state      = EXCLUDED.state,
   updated_at = now();
 
 -- name: DeleteEmailOAuthToken :exec
-DELETE FROM email_oauth_tokens WHERE email_provider_id = sqlc.arg(email_provider_id);
+DELETE FROM email_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND email_provider_id = sqlc.arg(email_provider_id);

--- a/db/postgres/queries/email_outbox.sql
+++ b/db/postgres/queries/email_outbox.sql
@@ -14,24 +14,24 @@ VALUES (
 RETURNING *;
 
 -- name: GetEmailOutboxByID :one
-SELECT * FROM email_outbox WHERE id = sqlc.arg(id);
+SELECT * FROM email_outbox WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: ListEmailOutboxByBot :many
 SELECT * FROM email_outbox
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id)
 ORDER BY created_at DESC
 LIMIT sqlc.arg(lim) OFFSET sqlc.arg(off);
 
 -- name: CountEmailOutboxByBot :one
 SELECT count(*) FROM email_outbox
-WHERE bot_id = sqlc.arg(bot_id);
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id);
 
 -- name: UpdateEmailOutboxSent :exec
 UPDATE email_outbox
 SET message_id = sqlc.arg(message_id), status = 'sent', sent_at = now()
-WHERE id = sqlc.arg(id);
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: UpdateEmailOutboxFailed :exec
 UPDATE email_outbox
 SET status = 'failed', error = sqlc.arg(error)
-WHERE id = sqlc.arg(id);
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);

--- a/db/postgres/queries/email_providers.sql
+++ b/db/postgres/queries/email_providers.sql
@@ -9,35 +9,36 @@ VALUES (
 RETURNING *;
 
 -- name: GetEmailProviderByID :one
-SELECT * FROM email_providers WHERE id = sqlc.arg(id);
+SELECT * FROM email_providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: GetEmailProviderByIDAndUser :one
 SELECT * FROM email_providers
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
   AND user_id = sqlc.arg(user_id);
 
 -- name: GetEmailProviderByNameAndUser :one
 SELECT * FROM email_providers
-WHERE user_id = sqlc.arg(user_id)
+WHERE team_id = public.memoh_current_team_id() AND user_id = sqlc.arg(user_id)
   AND name = sqlc.arg(name);
 
 -- name: ListEmailProviders :many
 SELECT * FROM email_providers
+WHERE team_id = public.memoh_current_team_id()
 ORDER BY created_at DESC;
 
 -- name: ListEmailProvidersByUser :many
 SELECT * FROM email_providers
-WHERE user_id = sqlc.arg(user_id)
+WHERE team_id = public.memoh_current_team_id() AND user_id = sqlc.arg(user_id)
 ORDER BY created_at DESC;
 
 -- name: ListEmailProvidersByProvider :many
 SELECT * FROM email_providers
-WHERE provider = sqlc.arg(provider)
+WHERE team_id = public.memoh_current_team_id() AND provider = sqlc.arg(provider)
 ORDER BY created_at DESC;
 
 -- name: ListEmailProvidersByUserAndProvider :many
 SELECT * FROM email_providers
-WHERE user_id = sqlc.arg(user_id)
+WHERE team_id = public.memoh_current_team_id() AND user_id = sqlc.arg(user_id)
   AND provider = sqlc.arg(provider)
 ORDER BY created_at DESC;
 
@@ -48,7 +49,7 @@ SET
   provider = sqlc.arg(provider),
   config = sqlc.arg(config),
   updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: UpdateEmailProviderByIDAndUser :one
@@ -58,14 +59,14 @@ SET
   provider = sqlc.arg(provider),
   config = sqlc.arg(config),
   updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
   AND user_id = sqlc.arg(user_id)
 RETURNING *;
 
 -- name: DeleteEmailProvider :exec
-DELETE FROM email_providers WHERE id = sqlc.arg(id);
+DELETE FROM email_providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: DeleteEmailProviderByIDAndUser :exec
 DELETE FROM email_providers
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
   AND user_id = sqlc.arg(user_id);

--- a/db/postgres/queries/fetch_providers.sql
+++ b/db/postgres/queries/fetch_providers.sql
@@ -9,18 +9,19 @@ VALUES (
 RETURNING *;
 
 -- name: GetFetchProviderByID :one
-SELECT * FROM fetch_providers WHERE id = sqlc.arg(id);
+SELECT * FROM fetch_providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: GetFetchProviderByName :one
-SELECT * FROM fetch_providers WHERE name = sqlc.arg(name);
+SELECT * FROM fetch_providers WHERE team_id = public.memoh_current_team_id() AND name = sqlc.arg(name);
 
 -- name: ListFetchProviders :many
 SELECT * FROM fetch_providers
+WHERE team_id = public.memoh_current_team_id()
 ORDER BY created_at DESC;
 
 -- name: ListFetchProvidersByProvider :many
 SELECT * FROM fetch_providers
-WHERE provider = sqlc.arg(provider)
+WHERE team_id = public.memoh_current_team_id() AND provider = sqlc.arg(provider)
 ORDER BY created_at DESC;
 
 -- name: UpdateFetchProvider :one
@@ -31,8 +32,8 @@ SET
   config = sqlc.arg(config),
   enable = sqlc.arg(enable),
   updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: DeleteFetchProvider :exec
-DELETE FROM fetch_providers WHERE id = sqlc.arg(id);
+DELETE FROM fetch_providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);

--- a/db/postgres/queries/heartbeat_logs.sql
+++ b/db/postgres/queries/heartbeat_logs.sql
@@ -11,18 +11,18 @@ SET status = $2,
     usage = $5,
     model_id = $6,
     completed_at = now()
-WHERE id = $1
-RETURNING id, bot_id, session_id, status, result_text, error_message, usage, model_id, started_at, completed_at;
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, bot_id, session_id, status, result_text, error_message, usage, model_id, started_at, completed_at, team_id;
 
 -- name: ListHeartbeatLogsByBot :many
 SELECT id, bot_id, session_id, status, result_text, error_message, usage, started_at, completed_at
 FROM bot_heartbeat_logs
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: CountHeartbeatLogsByBot :one
-SELECT count(*) FROM bot_heartbeat_logs WHERE bot_id = $1;
+SELECT count(*) FROM bot_heartbeat_logs WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: DeleteHeartbeatLogsByBot :exec
-DELETE FROM bot_heartbeat_logs WHERE bot_id = $1;
+DELETE FROM bot_heartbeat_logs WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;

--- a/db/postgres/queries/mcp.sql
+++ b/db/postgres/queries/mcp.sql
@@ -1,22 +1,22 @@
 -- name: GetMCPConnectionByID :one
 SELECT id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-       managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at
+       managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id
 FROM mcp_connections
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 LIMIT 1;
 
 -- name: ListMCPConnectionsByBotID :many
 SELECT id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-       managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at
+       managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id
 FROM mcp_connections
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY created_at DESC;
 
 -- name: CreateMCPConnection :one
 INSERT INTO mcp_connections (bot_id, name, type, config, is_active, auth_type)
 VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at;
+          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id;
 
 -- name: CreateManagedMCPConnection :one
 INSERT INTO mcp_connections (
@@ -25,7 +25,7 @@ INSERT INTO mcp_connections (
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at;
+          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id;
 
 -- name: UpdateMCPConnection :one
 UPDATE mcp_connections
@@ -35,21 +35,21 @@ SET name = $3,
     is_active = $6,
     auth_type = $7,
     updated_at = now()
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 RETURNING id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at;
+          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id;
 
 -- name: UpdateMCPConnectionActive :exec
 UPDATE mcp_connections
 SET is_active = $3,
     updated_at = now()
-WHERE bot_id = $1 AND id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2;
 
 -- name: UpdateMCPConnectionsActiveByPlugin :exec
 UPDATE mcp_connections
 SET is_active = $3,
     updated_at = now()
-WHERE bot_id = $1 AND managed_by_plugin_installation_id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND managed_by_plugin_installation_id = $2;
 
 -- name: UpdateMCPConnectionProbeResult :exec
 UPDATE mcp_connections
@@ -58,28 +58,28 @@ SET status = $3,
     last_probed_at = now(),
     status_message = $5,
     updated_at = now()
-WHERE bot_id = $1 AND id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2;
 
 -- name: UpdateMCPConnectionAuthType :exec
 UPDATE mcp_connections
 SET auth_type = $2,
     updated_at = now()
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: DeleteMCPConnection :exec
 DELETE FROM mcp_connections
-WHERE bot_id = $1 AND id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2;
 
 -- name: DeleteMCPConnectionsByPlugin :exec
 DELETE FROM mcp_connections
-WHERE bot_id = $1 AND managed_by_plugin_installation_id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND managed_by_plugin_installation_id = $2;
 
 -- name: UpsertMCPConnectionByName :one
 INSERT INTO mcp_connections (bot_id, name, type, config)
 VALUES ($1, $2, $3, $4)
-ON CONFLICT (bot_id, name)
+ON CONFLICT (team_id, bot_id, name)
 DO UPDATE SET type = EXCLUDED.type,
               config = EXCLUDED.config,
               updated_at = now()
 RETURNING id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at;
+          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id;

--- a/db/postgres/queries/mcp_oauth.sql
+++ b/db/postgres/queries/mcp_oauth.sql
@@ -3,9 +3,9 @@ SELECT id, connection_id, resource_metadata_url, authorization_server_url,
        authorization_endpoint, token_endpoint, registration_endpoint,
        scopes_supported, client_id, client_secret, access_token, refresh_token,
        token_type, expires_at, scope, pkce_code_verifier, state_param,
-       resource_uri, redirect_uri, created_at, updated_at
+       resource_uri, redirect_uri, created_at, updated_at, team_id
 FROM mcp_oauth_tokens
-WHERE connection_id = $1
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1
 LIMIT 1;
 
 -- name: GetMCPOAuthTokenByState :one
@@ -13,9 +13,9 @@ SELECT id, connection_id, resource_metadata_url, authorization_server_url,
        authorization_endpoint, token_endpoint, registration_endpoint,
        scopes_supported, client_id, client_secret, access_token, refresh_token,
        token_type, expires_at, scope, pkce_code_verifier, state_param,
-       resource_uri, redirect_uri, created_at, updated_at
+       resource_uri, redirect_uri, created_at, updated_at, team_id
 FROM mcp_oauth_tokens
-WHERE state_param = $1
+WHERE team_id = public.memoh_current_team_id() AND state_param = $1
 LIMIT 1;
 
 -- name: UpsertMCPOAuthDiscovery :one
@@ -23,7 +23,7 @@ INSERT INTO mcp_oauth_tokens (connection_id, resource_metadata_url, authorizatio
     authorization_endpoint, token_endpoint, registration_endpoint, scopes_supported,
     resource_uri)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-ON CONFLICT (connection_id)
+ON CONFLICT (team_id, connection_id)
 DO UPDATE SET resource_metadata_url = EXCLUDED.resource_metadata_url,
               authorization_server_url = EXCLUDED.authorization_server_url,
               authorization_endpoint = EXCLUDED.authorization_endpoint,
@@ -36,7 +36,7 @@ RETURNING id, connection_id, resource_metadata_url, authorization_server_url,
           authorization_endpoint, token_endpoint, registration_endpoint,
           scopes_supported, client_id, client_secret, access_token, refresh_token,
           token_type, expires_at, scope, pkce_code_verifier, state_param,
-          resource_uri, redirect_uri, created_at, updated_at;
+          resource_uri, redirect_uri, created_at, updated_at, team_id;
 
 -- name: UpdateMCPOAuthPKCEState :exec
 UPDATE mcp_oauth_tokens
@@ -45,7 +45,7 @@ SET pkce_code_verifier = $2,
     client_id = $4,
     redirect_uri = $5,
     updated_at = now()
-WHERE connection_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1;
 
 -- name: UpdateMCPOAuthTokens :exec
 UPDATE mcp_oauth_tokens
@@ -57,7 +57,7 @@ SET access_token = $2,
     pkce_code_verifier = '',
     state_param = '',
     updated_at = now()
-WHERE connection_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1;
 
 -- name: ClearMCPOAuthTokens :exec
 UPDATE mcp_oauth_tokens
@@ -69,14 +69,14 @@ SET access_token = '',
     state_param = '',
     redirect_uri = '',
     updated_at = now()
-WHERE connection_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1;
 
 -- name: UpdateMCPOAuthClientSecret :exec
 UPDATE mcp_oauth_tokens
 SET client_secret = $2,
     updated_at = now()
-WHERE connection_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1;
 
 -- name: DeleteMCPOAuthToken :exec
 DELETE FROM mcp_oauth_tokens
-WHERE connection_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1;

--- a/db/postgres/queries/media.sql
+++ b/db/postgres/queries/media.sql
@@ -4,36 +4,39 @@ VALUES (sqlc.arg(name), sqlc.arg(provider), sqlc.arg(config))
 RETURNING *;
 
 -- name: GetStorageProviderByID :one
-SELECT * FROM storage_providers WHERE id = sqlc.arg(id);
+SELECT * FROM storage_providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: GetStorageProviderByName :one
-SELECT * FROM storage_providers WHERE name = sqlc.arg(name);
+SELECT * FROM storage_providers WHERE team_id = public.memoh_current_team_id() AND name = sqlc.arg(name);
 
 -- name: ListStorageProviders :many
-SELECT * FROM storage_providers ORDER BY created_at DESC;
+SELECT * FROM storage_providers WHERE team_id = public.memoh_current_team_id() ORDER BY created_at DESC;
 
 -- name: UpsertBotStorageBinding :one
 INSERT INTO bot_storage_bindings (bot_id, storage_provider_id, base_path)
 VALUES (sqlc.arg(bot_id), sqlc.arg(storage_provider_id), sqlc.arg(base_path))
-ON CONFLICT (bot_id) DO UPDATE SET
+ON CONFLICT (team_id, bot_id) DO UPDATE SET
   storage_provider_id = EXCLUDED.storage_provider_id,
   base_path = EXCLUDED.base_path,
   updated_at = now()
 RETURNING *;
 
 -- name: GetBotStorageBinding :one
-SELECT * FROM bot_storage_bindings WHERE bot_id = sqlc.arg(bot_id);
+SELECT * FROM bot_storage_bindings WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id);
 
 -- name: CreateMessageAsset :one
 WITH message_locator AS MATERIALIZED (
   SELECT message.id, message.session_id
   FROM bot_history_messages message
-  WHERE message.id = sqlc.arg(message_id)
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = sqlc.arg(message_id)
 ),
 owner_session AS MATERIALIZED (
   SELECT session.id, session.bot_id, session.compaction_epoch
   FROM bot_sessions session
-  JOIN message_locator message ON message.session_id = session.id
+  JOIN message_locator message
+    ON message.session_id = session.id
+   AND session.team_id = public.memoh_current_team_id()
   FOR UPDATE
 ),
 target_message AS MATERIALIZED (
@@ -41,7 +44,8 @@ target_message AS MATERIALIZED (
   FROM bot_history_messages message
   JOIN message_locator locator ON locator.id = message.id
   LEFT JOIN owner_session owner ON owner.id = locator.session_id
-  WHERE locator.session_id IS NULL OR owner.id IS NOT NULL
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND (locator.session_id IS NULL OR owner.id IS NOT NULL)
   FOR UPDATE OF message
 ),
 changed_asset AS MATERIALIZED (
@@ -49,6 +53,7 @@ changed_asset AS MATERIALIZED (
   FROM target_message target
   LEFT JOIN bot_history_message_assets existing
     ON existing.message_id = target.id
+   AND existing.team_id = public.memoh_current_team_id()
    AND existing.content_hash = sqlc.arg(content_hash)
   WHERE existing.id IS NULL
      OR existing.role IS DISTINCT FROM sqlc.arg(role)
@@ -61,8 +66,11 @@ invalidated_session AS (
   SET compaction_epoch = session.compaction_epoch + 1
   FROM changed_asset changed
   JOIN owner_session owner ON owner.id = changed.session_id
-  JOIN bot_history_message_compacts compact ON compact.id = changed.compact_id
-  WHERE session.id = owner.id
+  JOIN bot_history_message_compacts compact
+    ON compact.id = changed.compact_id
+   AND compact.team_id = public.memoh_current_team_id()
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = owner.id
     AND compact.bot_id = owner.bot_id
     AND compact.session_id = owner.id
     AND compact.compaction_epoch = owner.compaction_epoch
@@ -80,7 +88,7 @@ upserted_asset AS (
     sqlc.arg(metadata)
   FROM target_message target
   CROSS JOIN (SELECT count(*) FROM invalidated_session) invalidation_done
-  ON CONFLICT (message_id, content_hash) DO UPDATE SET
+  ON CONFLICT (team_id, message_id, content_hash) DO UPDATE SET
     role = EXCLUDED.role,
     ordinal = EXCLUDED.ordinal,
     name = EXCLUDED.name,
@@ -93,20 +101,20 @@ FROM upserted_asset;
 -- name: ListMessageAssets :many
 SELECT id AS rel_id, message_id, role, ordinal, content_hash, name, metadata
 FROM bot_history_message_assets
-WHERE message_id = sqlc.arg(message_id)
+WHERE team_id = public.memoh_current_team_id() AND message_id = sqlc.arg(message_id)
 ORDER BY ordinal ASC;
 
 -- name: ListMessageAssetsBatch :many
 SELECT id AS rel_id, message_id, role, ordinal, content_hash, name, metadata
 FROM bot_history_message_assets
-WHERE message_id = ANY(sqlc.arg(message_ids)::uuid[])
+WHERE team_id = public.memoh_current_team_id() AND message_id = ANY(sqlc.arg(message_ids)::uuid[])
 ORDER BY message_id, ordinal ASC;
 
 -- name: CountMessageAssetsByBot :one
 SELECT COUNT(*)
 FROM bot_history_message_assets a
 JOIN bot_history_messages m ON m.id = a.message_id
-WHERE m.bot_id = sqlc.arg(bot_id);
+WHERE a.team_id = public.memoh_current_team_id() AND m.team_id = public.memoh_current_team_id() AND m.bot_id = sqlc.arg(bot_id);
 
 -- name: DeleteMessageAssets :exec
-DELETE FROM bot_history_message_assets WHERE message_id = sqlc.arg(message_id);
+DELETE FROM bot_history_message_assets WHERE team_id = public.memoh_current_team_id() AND message_id = sqlc.arg(message_id);

--- a/db/postgres/queries/memory_providers.sql
+++ b/db/postgres/queries/memory_providers.sql
@@ -1,11 +1,11 @@
 -- name: ListMemoryProviders :many
-SELECT * FROM memory_providers ORDER BY created_at ASC;
+SELECT * FROM memory_providers WHERE team_id = public.memoh_current_team_id() ORDER BY created_at ASC;
 
 -- name: GetMemoryProviderByID :one
-SELECT * FROM memory_providers WHERE id = $1;
+SELECT * FROM memory_providers WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: GetDefaultMemoryProvider :one
-SELECT * FROM memory_providers WHERE is_default = true LIMIT 1;
+SELECT * FROM memory_providers WHERE team_id = public.memoh_current_team_id() AND is_default = true LIMIT 1;
 
 -- name: CreateMemoryProvider :one
 INSERT INTO memory_providers (name, provider, config, is_default)
@@ -17,11 +17,11 @@ UPDATE memory_providers
 SET name = $2,
     config = $3,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING *;
 
 -- name: DeleteMemoryProvider :exec
-DELETE FROM memory_providers WHERE id = $1;
+DELETE FROM memory_providers WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: CountMemoryProvidersByDefault :one
-SELECT COUNT(*) FROM memory_providers WHERE is_default = true;
+SELECT COUNT(*) FROM memory_providers WHERE team_id = public.memoh_current_team_id() AND is_default = true;

--- a/db/postgres/queries/memory_wiki.sql
+++ b/db/postgres/queries/memory_wiki.sql
@@ -4,7 +4,7 @@ INSERT INTO memory_nodes (
   metadata, source_message_ids, profile_ref, topic, captured_at, expires_at
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-ON CONFLICT (id) DO UPDATE SET
+ON CONFLICT (team_id, id) DO UPDATE SET
   body = EXCLUDED.body,
   hash = EXCLUDED.hash,
   layer = EXCLUDED.layer,
@@ -21,67 +21,67 @@ RETURNING *;
 
 -- name: GetMemoryNode :one
 SELECT * FROM memory_nodes
-WHERE bot_id = $1 AND id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2;
 
 -- name: ListMemoryNodesByBot :many
 SELECT * FROM memory_nodes
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY captured_at ASC;
 
 -- name: ListMemoryNodesByBotLayer :many
 SELECT * FROM memory_nodes
-WHERE bot_id = $1 AND layer = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND layer = $2
 ORDER BY captured_at ASC;
 
 -- name: ListMemoryNodesByBotProfile :many
 SELECT * FROM memory_nodes
-WHERE bot_id = $1 AND profile_ref = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND profile_ref = $2
 ORDER BY captured_at ASC;
 
 -- name: DeleteMemoryNode :exec
 DELETE FROM memory_nodes
-WHERE bot_id = $1 AND id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2;
 
 -- name: DeleteAllMemoryNodesByBot :exec
 DELETE FROM memory_nodes
-WHERE bot_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: CountMemoryNodesByBot :one
 SELECT COUNT(*) FROM memory_nodes
-WHERE bot_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: InsertMemoryEdge :exec
 INSERT INTO memory_edges (bot_id, src_node, dst_node, rel, weight, metadata)
 VALUES ($1, $2, $3, $4, $5, $6)
-ON CONFLICT (bot_id, src_node, dst_node, rel) DO UPDATE SET
+ON CONFLICT (team_id, bot_id, src_node, dst_node, rel) DO UPDATE SET
   weight = EXCLUDED.weight,
   metadata = EXCLUDED.metadata;
 
 -- name: ListMemoryEdgesFromNode :many
 SELECT * FROM memory_edges
-WHERE bot_id = $1 AND src_node = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND src_node = $2
 ORDER BY weight DESC;
 
 -- name: ListMemoryEdgesByBot :many
 SELECT * FROM memory_edges
-WHERE bot_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: ListMemoryEdgesByRel :many
 SELECT * FROM memory_edges
-WHERE bot_id = $1 AND rel = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND rel = $2;
 
 -- name: DeleteMemoryEdgesForNode :exec
 DELETE FROM memory_edges
-WHERE bot_id = $1 AND (src_node = $2 OR dst_node = $2);
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND (src_node = $2 OR dst_node = $2);
 
 -- name: DeleteAllMemoryEdgesByBot :exec
 DELETE FROM memory_edges
-WHERE bot_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: CountMemoryEdgesByBot :one
 SELECT COUNT(*) FROM memory_edges
-WHERE bot_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: DeleteMemoryEdgesByRelForBot :exec
 DELETE FROM memory_edges
-WHERE bot_id = $1 AND rel = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND rel = $2;

--- a/db/postgres/queries/messages.sql
+++ b/db/postgres/queries/messages.sql
@@ -59,7 +59,7 @@ WITH target AS (
     existing.turn_position,
     bool_or(existing.turn_visible) AS turn_visible
   FROM bot_history_messages existing
-  WHERE existing.turn_id = sqlc.arg(turn_id)
+  WHERE existing.team_id = public.memoh_current_team_id() AND existing.turn_id = sqlc.arg(turn_id)
     AND existing.session_id = sqlc.narg(session_id)::uuid
     AND existing.bot_id = sqlc.arg(bot_id)
     AND existing.turn_position IS NOT NULL
@@ -131,14 +131,14 @@ RETURNING
 -- name: AllocateSessionTurnPosition :one
 UPDATE bot_sessions
 SET next_turn_position = next_turn_position + 1
-WHERE id = sqlc.arg(session_id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(session_id)
 RETURNING (next_turn_position - 1)::bigint AS position;
 
 -- name: CreateMessageWithHistoryTurn :one
 WITH next_position AS (
   UPDATE bot_sessions
   SET next_turn_position = next_turn_position + 1
-  WHERE bot_sessions.id = sqlc.arg(session_id)
+  WHERE bot_sessions.team_id = public.memoh_current_team_id() AND bot_sessions.id = sqlc.arg(session_id)
   RETURNING (next_turn_position - 1)::bigint AS position
 ),
 inserted_message AS (
@@ -199,7 +199,8 @@ FROM inserted_message;
 WITH owner_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = sqlc.arg(session_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = sqlc.arg(session_id)
   FOR UPDATE
 ),
 target AS MATERIALIZED (
@@ -211,7 +212,7 @@ target AS MATERIALIZED (
       WHEN sqlc.arg(role)::text = 'assistant' AND NOT EXISTS (
         SELECT 1
         FROM bot_history_messages assistant
-        WHERE assistant.turn_id = turns.turn_id
+        WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = turns.turn_id
           AND assistant.role = 'assistant'
           AND assistant.turn_message_seq = 2
           AND assistant.turn_visible = true
@@ -219,14 +220,15 @@ target AS MATERIALIZED (
       ELSE COALESCE((
         SELECT existing.turn_message_seq + 1
         FROM bot_history_messages existing
-        WHERE existing.turn_id = turns.turn_id
+        WHERE existing.team_id = public.memoh_current_team_id() AND existing.turn_id = turns.turn_id
         ORDER BY existing.turn_message_seq DESC
         LIMIT 1
       ), 1)
     END AS turn_message_seq
   FROM bot_history_messages turns
   JOIN owner_session owner ON owner.id = turns.session_id
-  WHERE turns.session_id = sqlc.arg(session_id)
+  WHERE turns.team_id = public.memoh_current_team_id()
+    AND turns.session_id = sqlc.arg(session_id)
     AND turns.id = sqlc.arg(request_message_id)
     AND turns.turn_id IS NOT NULL
     AND turns.turn_position IS NOT NULL
@@ -318,7 +320,8 @@ FROM inserted;
 WITH owner_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = sqlc.arg(session_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = sqlc.arg(session_id)
   FOR UPDATE
 ),
 target AS MATERIALIZED (
@@ -330,7 +333,7 @@ target AS MATERIALIZED (
       WHEN sqlc.arg(role)::text = 'assistant' AND NOT EXISTS (
         SELECT 1
         FROM bot_history_messages assistant
-        WHERE assistant.turn_id = turns.turn_id
+        WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = turns.turn_id
           AND assistant.role = 'assistant'
           AND assistant.turn_message_seq = 2
           AND assistant.turn_visible = true
@@ -338,14 +341,15 @@ target AS MATERIALIZED (
       ELSE COALESCE((
         SELECT existing.turn_message_seq + 1
         FROM bot_history_messages existing
-        WHERE existing.turn_id = turns.turn_id
+        WHERE existing.team_id = public.memoh_current_team_id() AND existing.turn_id = turns.turn_id
         ORDER BY existing.turn_message_seq DESC
         LIMIT 1
       ), 1)
     END AS turn_message_seq
   FROM bot_history_messages turns
   JOIN owner_session owner ON owner.id = turns.session_id
-  WHERE turns.session_id = sqlc.arg(session_id)
+  WHERE turns.team_id = public.memoh_current_team_id()
+    AND turns.session_id = sqlc.arg(session_id)
     AND turns.id = sqlc.arg(request_message_id)
     AND turns.turn_id IS NOT NULL
     AND turns.turn_position IS NOT NULL
@@ -498,7 +502,7 @@ WITH input_rows(
 next_position AS (
   UPDATE bot_sessions
   SET next_turn_position = next_turn_position + 1
-  WHERE bot_sessions.id = sqlc.arg(session_id)
+  WHERE bot_sessions.team_id = public.memoh_current_team_id() AND bot_sessions.id = sqlc.arg(session_id)
   RETURNING (next_turn_position - 1)::bigint AS position
 ),
 inserted_messages AS (
@@ -556,7 +560,7 @@ ORDER BY inserted_messages.turn_message_seq;
 WITH next_position AS (
   UPDATE bot_sessions
   SET next_turn_position = next_turn_position + 1
-  WHERE bot_sessions.id = sqlc.arg(session_id)
+  WHERE bot_sessions.team_id = public.memoh_current_team_id() AND bot_sessions.id = sqlc.arg(session_id)
   RETURNING next_turn_position - 1 AS position
 ),
 input AS (
@@ -579,7 +583,7 @@ linked_request AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.request_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.request_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -594,7 +598,7 @@ linked_assistant AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.assistant_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.assistant_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -622,7 +626,7 @@ WHERE linked_summary.linked_count > 0;
 WITH next_position AS (
   UPDATE bot_sessions
   SET next_turn_position = next_turn_position + 1
-  WHERE bot_sessions.id = sqlc.arg(session_id)
+  WHERE bot_sessions.team_id = public.memoh_current_team_id() AND bot_sessions.id = sqlc.arg(session_id)
   RETURNING next_turn_position - 1 AS position
 ),
 input AS (
@@ -645,7 +649,7 @@ linked_request AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.request_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.request_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -660,7 +664,7 @@ linked_assistant AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.assistant_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.assistant_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -704,7 +708,7 @@ linked_request AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.request_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.request_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -719,7 +723,7 @@ linked_assistant AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.assistant_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.assistant_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -753,14 +757,14 @@ WITH target AS (
     request.id AS request_message_id,
     request.created_at AS request_created_at
   FROM bot_history_messages request
-  WHERE request.session_id = sqlc.arg(session_id)
+  WHERE request.team_id = public.memoh_current_team_id() AND request.session_id = sqlc.arg(session_id)
     AND request.id = sqlc.arg(request_message_id)
     AND request.turn_id IS NOT NULL
     AND request.turn_visible = true
     AND NOT EXISTS (
       SELECT 1
       FROM bot_history_messages assistant
-      WHERE assistant.turn_id = request.turn_id
+      WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = request.turn_id
         AND assistant.role = 'assistant'
         AND assistant.turn_message_seq = 2
         AND assistant.turn_visible = true
@@ -778,7 +782,7 @@ linked AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM target
-  WHERE assistant.id = sqlc.arg(assistant_message_id)
+  WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.id = sqlc.arg(assistant_message_id)
     AND assistant.session_id = target.session_id
   RETURNING assistant.id AS assistant_message_id, assistant.created_at AS assistant_created_at
 )
@@ -802,7 +806,7 @@ WITH target AS (
     request.id AS request_message_id,
     request.created_at AS request_created_at
   FROM bot_history_messages request
-  WHERE request.session_id = sqlc.arg(session_id)
+  WHERE request.team_id = public.memoh_current_team_id() AND request.session_id = sqlc.arg(session_id)
     AND request.role = 'user'
     AND request.turn_message_seq = 1
     AND request.turn_id IS NOT NULL
@@ -810,7 +814,7 @@ WITH target AS (
     AND NOT EXISTS (
       SELECT 1
       FROM bot_history_messages assistant
-      WHERE assistant.turn_id = request.turn_id
+      WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = request.turn_id
         AND assistant.role = 'assistant'
         AND assistant.turn_message_seq = 2
         AND assistant.turn_visible = true
@@ -829,7 +833,7 @@ linked AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM target
-  WHERE assistant.id = sqlc.arg(assistant_message_id)
+  WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.id = sqlc.arg(assistant_message_id)
     AND assistant.session_id = target.session_id
   RETURNING assistant.id AS assistant_message_id, assistant.created_at AS assistant_created_at
 )
@@ -851,7 +855,7 @@ WITH target AS (
     existing.turn_position,
     bool_or(existing.turn_visible) AS turn_visible
   FROM bot_history_messages existing
-  WHERE existing.turn_id = sqlc.arg(turn_id)
+  WHERE existing.team_id = public.memoh_current_team_id() AND existing.turn_id = sqlc.arg(turn_id)
     AND existing.turn_position IS NOT NULL
   GROUP BY existing.turn_id, existing.session_id, existing.turn_position
   LIMIT 1
@@ -865,14 +869,14 @@ SET turn_id = target.turn_id,
     turn_superseded_at = NULL,
     turn_superseded_reason = NULL
 FROM target
-WHERE m.id = sqlc.arg(message_id)
+WHERE m.team_id = public.memoh_current_team_id() AND m.id = sqlc.arg(message_id)
   AND m.session_id = target.session_id
 RETURNING m.id;
 
 -- name: LockHistoryTurnAppendByRequest :exec
 SELECT pg_advisory_xact_lock(hashtextextended(m.turn_id::text, 0))
 FROM bot_history_messages m
-WHERE m.session_id = sqlc.arg(session_id)
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.id = sqlc.arg(request_message_id)
   AND m.turn_id IS NOT NULL
 LIMIT 1;
@@ -881,7 +885,7 @@ LIMIT 1;
 WITH target AS (
   SELECT request.turn_id, request.session_id, request.turn_position
   FROM bot_history_messages request
-  WHERE request.session_id = sqlc.arg(session_id)
+  WHERE request.team_id = public.memoh_current_team_id() AND request.session_id = sqlc.arg(session_id)
     AND request.id = sqlc.arg(request_message_id)
     AND request.turn_id IS NOT NULL
     AND request.turn_position IS NOT NULL
@@ -896,7 +900,7 @@ next_seq AS (
     target.turn_position,
     COALESCE(MAX(existing.turn_message_seq), 0) + 1 AS turn_message_seq
   FROM target
-  JOIN bot_history_messages existing ON existing.turn_id = target.turn_id
+  JOIN bot_history_messages existing ON existing.turn_id = target.turn_id AND existing.team_id = public.memoh_current_team_id()
   GROUP BY target.turn_id, target.session_id, target.turn_position
 )
 UPDATE bot_history_messages m
@@ -908,7 +912,7 @@ SET turn_id = next_seq.turn_id,
     turn_superseded_at = NULL,
     turn_superseded_reason = NULL
 FROM next_seq
-WHERE m.id = sqlc.arg(message_id)
+WHERE m.team_id = public.memoh_current_team_id() AND m.id = sqlc.arg(message_id)
   AND m.session_id = next_seq.session_id
   AND m.turn_id IS NULL
 RETURNING m.id;
@@ -917,7 +921,7 @@ RETURNING m.id;
 WITH latest AS (
   SELECT visible.turn_id, visible.session_id, visible.turn_position
   FROM bot_history_messages visible
-  WHERE visible.session_id = sqlc.arg(session_id)
+  WHERE visible.team_id = public.memoh_current_team_id() AND visible.session_id = sqlc.arg(session_id)
     AND visible.turn_id IS NOT NULL
     AND visible.turn_position IS NOT NULL
     AND visible.turn_message_seq IS NOT NULL
@@ -933,7 +937,7 @@ next_seq AS (
     latest.turn_position,
     COALESCE(MAX(existing.turn_message_seq), 0) + 1 AS turn_message_seq
   FROM latest
-  JOIN bot_history_messages existing ON existing.turn_id = latest.turn_id
+  JOIN bot_history_messages existing ON existing.turn_id = latest.turn_id AND existing.team_id = public.memoh_current_team_id()
   GROUP BY latest.turn_id, latest.session_id, latest.turn_position
 )
 UPDATE bot_history_messages m
@@ -945,7 +949,7 @@ SET turn_id = next_seq.turn_id,
     turn_superseded_at = NULL,
     turn_superseded_reason = NULL
 FROM next_seq
-WHERE m.id = sqlc.arg(message_id)
+WHERE m.team_id = public.memoh_current_team_id() AND m.id = sqlc.arg(message_id)
   AND m.session_id = next_seq.session_id
   AND m.turn_id IS NULL
 RETURNING m.id;
@@ -959,7 +963,7 @@ WITH target AS (
     assistant.created_at AS assistant_created_at,
     assistant.id AS assistant_id
   FROM bot_history_messages assistant
-  WHERE assistant.turn_id = sqlc.arg(turn_id)
+  WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = sqlc.arg(turn_id)
     AND assistant.role = 'assistant'
     AND assistant.turn_message_seq = 2
     AND assistant.turn_visible = true
@@ -975,7 +979,7 @@ tail AS (
   JOIN bot_history_messages m
     ON m.session_id = target.session_id
    AND m.role IN ('assistant', 'tool')
-  WHERE m.id <> target.assistant_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id <> target.assistant_id
     AND m.turn_id IS NULL
     AND (m.created_at, m.id) > (target.assistant_created_at, target.assistant_id)
 )
@@ -985,13 +989,13 @@ SET turn_id = tail.turn_id,
     turn_visible = true,
     turn_message_seq = tail.turn_message_seq
 FROM tail
-WHERE m.id = tail.message_id;
+WHERE m.team_id = public.memoh_current_team_id() AND m.id = tail.message_id;
 
 -- name: GetVisibleHistoryTurnByMessage :one
 WITH target AS (
   SELECT m.turn_id, m.session_id, m.turn_position
   FROM bot_history_messages m
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
     AND m.id = sqlc.arg(message_id)
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -1012,7 +1016,8 @@ SELECT
   COALESCE(MAX(m.turn_superseded_at), MAX(m.created_at))::timestamptz AS updated_at
 FROM target
 JOIN bot_history_messages m
-  ON m.turn_id = target.turn_id
+  ON m.team_id = public.memoh_current_team_id()
+ AND m.turn_id = target.turn_id
  AND m.session_id = target.session_id
 GROUP BY target.turn_id, target.session_id, target.turn_position;
 
@@ -1020,7 +1025,7 @@ GROUP BY target.turn_id, target.session_id, target.turn_position;
 WITH target AS (
   SELECT m.turn_id, m.session_id, m.turn_position
   FROM bot_history_messages m
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
     AND m.turn_visible = true
@@ -1041,7 +1046,8 @@ SELECT
   COALESCE(MAX(m.turn_superseded_at), MAX(m.created_at))::timestamptz AS updated_at
 FROM target
 JOIN bot_history_messages m
-  ON m.turn_id = target.turn_id
+  ON m.team_id = public.memoh_current_team_id()
+ AND m.turn_id = target.turn_id
  AND m.session_id = target.session_id
 GROUP BY target.turn_id, target.session_id, target.turn_position;
 
@@ -1049,7 +1055,7 @@ GROUP BY target.turn_id, target.session_id, target.turn_position;
 WITH target AS (
   SELECT m.turn_id, m.session_id, m.turn_position
   FROM bot_history_messages m
-  WHERE m.turn_id = sqlc.arg(old_turn_id)
+  WHERE m.team_id = public.memoh_current_team_id() AND m.turn_id = sqlc.arg(old_turn_id)
     AND m.session_id = sqlc.arg(session_id)
     AND m.turn_position IS NOT NULL
     AND m.turn_visible = true
@@ -1069,7 +1075,8 @@ SELECT
   COALESCE(MAX(m.turn_superseded_at), MAX(m.created_at))::timestamptz AS updated_at
 FROM target
 JOIN bot_history_messages m
-  ON m.turn_id = target.turn_id
+  ON m.team_id = public.memoh_current_team_id()
+ AND m.turn_id = target.turn_id
  AND m.session_id = target.session_id
 GROUP BY target.turn_id, target.session_id, target.turn_position;
 
@@ -1077,14 +1084,16 @@ GROUP BY target.turn_id, target.session_id, target.turn_position;
 WITH owner_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = sqlc.arg(session_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = sqlc.arg(session_id)
   FOR UPDATE
 ),
 old_turn_target AS (
   SELECT m.turn_id, m.session_id, m.turn_position
   FROM bot_history_messages m
   JOIN owner_session owner ON owner.id = m.session_id
-  WHERE m.turn_id = sqlc.arg(old_turn_id)
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.turn_id = sqlc.arg(old_turn_id)
     AND m.turn_position IS NOT NULL
     AND m.turn_visible = true
   LIMIT 1
@@ -1104,7 +1113,8 @@ old_turn AS (
     MAX(m.created_at)::timestamptz AS updated_at
   FROM old_turn_target
   JOIN bot_history_messages m
-    ON m.turn_id = old_turn_target.turn_id
+    ON m.team_id = public.memoh_current_team_id()
+   AND m.turn_id = old_turn_target.turn_id
    AND m.session_id = old_turn_target.session_id
   GROUP BY old_turn_target.turn_id, old_turn_target.session_id, old_turn_target.turn_position
 ),
@@ -1112,6 +1122,7 @@ old_lock AS (
   SELECT m.id, m.bot_id, m.session_id, m.compact_id
   FROM bot_history_messages m
   JOIN old_turn ON old_turn.id = m.turn_id
+  WHERE m.team_id = public.memoh_current_team_id()
   FOR UPDATE
 ),
 old_lock_guard AS (
@@ -1120,7 +1131,7 @@ old_lock_guard AS (
 latest_turn AS (
   SELECT m.turn_id AS id
   FROM bot_history_messages m
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
     AND m.turn_visible = true
@@ -1140,7 +1151,7 @@ replacement_input AS (
       OR EXISTS (
         SELECT 1
         FROM bot_history_messages request_message
-        WHERE request_message.id = sqlc.narg(request_message_id)::uuid
+        WHERE request_message.team_id = public.memoh_current_team_id() AND request_message.id = sqlc.narg(request_message_id)::uuid
           AND request_message.session_id = old_turn.session_id
           AND request_message.role = 'user'
           AND (
@@ -1155,7 +1166,7 @@ replacement_input AS (
       OR EXISTS (
         SELECT 1
         FROM bot_history_messages assistant_message
-        WHERE assistant_message.id = sqlc.narg(assistant_message_id)::uuid
+        WHERE assistant_message.team_id = public.memoh_current_team_id() AND assistant_message.id = sqlc.narg(assistant_message_id)::uuid
           AND assistant_message.session_id = old_turn.session_id
           AND assistant_message.role = 'assistant'
           AND assistant_message.turn_id IS NULL
@@ -1167,8 +1178,12 @@ affected_compaction_sessions AS MATERIALIZED (
   SELECT DISTINCT locked.session_id
   FROM old_lock locked
   JOIN replacement_input ON replacement_input.session_id = locked.session_id
-  JOIN bot_history_message_compacts compact ON compact.id = locked.compact_id
-  JOIN bot_sessions session ON session.id = locked.session_id
+  JOIN bot_history_message_compacts compact
+    ON compact.id = locked.compact_id
+   AND compact.team_id = public.memoh_current_team_id()
+  JOIN bot_sessions session
+    ON session.id = locked.session_id
+   AND session.team_id = public.memoh_current_team_id()
   WHERE locked.id IS DISTINCT FROM replacement_input.replacement_request_message_id
     AND locked.id IS DISTINCT FROM replacement_input.replacement_assistant_message_id
     AND compact.bot_id = locked.bot_id
@@ -1187,7 +1202,7 @@ next_position AS (
         ELSE 0
       END
   FROM replacement_input
-  WHERE s.id = replacement_input.session_id
+  WHERE s.team_id = public.memoh_current_team_id() AND s.id = replacement_input.session_id
   RETURNING s.next_turn_position - 1 AS position
 ),
 replacement AS (
@@ -1213,7 +1228,7 @@ updated AS (
       turn_superseded_reason = sqlc.arg(superseded_reason),
       turn_visible = false
   FROM replacement
-  WHERE old.turn_id = sqlc.arg(old_turn_id)
+  WHERE old.team_id = public.memoh_current_team_id() AND old.turn_id = sqlc.arg(old_turn_id)
     AND old.session_id = sqlc.arg(session_id)
     AND old.turn_superseded_at IS NULL
     AND old.id IS DISTINCT FROM replacement.request_message_id
@@ -1227,7 +1242,7 @@ hidden_old_messages AS (
   UPDATE bot_history_messages m
   SET turn_visible = false
   FROM updated_turn, replacement
-  WHERE m.turn_id = updated_turn.id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.turn_id = updated_turn.id
     AND m.id IS DISTINCT FROM replacement.request_message_id
     AND m.id IS DISTINCT FROM replacement.assistant_message_id
   RETURNING m.id
@@ -1251,18 +1266,21 @@ linked_anchors AS (
   FROM replacement
   CROSS JOIN hidden_done
   JOIN updated_turn ON true
-  WHERE (
-      m.id = replacement.request_message_id
-      AND m.role = 'user'
-      AND (
-        m.turn_id IS NULL
-        OR m.turn_id = updated_turn.id
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND (
+      (
+        m.id = replacement.request_message_id
+        AND m.role = 'user'
+        AND (
+          m.turn_id IS NULL
+          OR m.turn_id = updated_turn.id
+        )
       )
-    )
-    OR (
-      m.id = replacement.assistant_message_id
-      AND m.role = 'assistant'
-      AND m.turn_id IS NULL
+      OR (
+        m.id = replacement.assistant_message_id
+        AND m.role = 'assistant'
+        AND m.turn_id IS NULL
+      )
     )
   RETURNING m.id
 ),
@@ -1282,15 +1300,15 @@ linked_tail AS (
       replacement.position AS turn_position,
       2 + ROW_NUMBER() OVER (ORDER BY m.created_at, m.id) AS turn_message_seq
     FROM replacement
-    JOIN bot_history_messages assistant ON assistant.id = replacement.assistant_message_id
+    JOIN bot_history_messages assistant ON assistant.id = replacement.assistant_message_id AND assistant.team_id = public.memoh_current_team_id()
     JOIN bot_history_messages m
       ON m.session_id = replacement.session_id
      AND m.role IN ('assistant', 'tool')
-    WHERE m.id <> replacement.assistant_message_id
+    WHERE m.team_id = public.memoh_current_team_id() AND m.id <> replacement.assistant_message_id
       AND m.turn_id IS NULL
       AND (m.created_at, m.id) > (assistant.created_at, assistant.id)
   ) tail
-  WHERE m.id = tail.message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = tail.message_id
   RETURNING m.id
 ),
 linked_anchors_done AS (
@@ -1312,7 +1330,8 @@ CROSS JOIN linked_tail_done;
 WITH owner_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = sqlc.arg(session_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = sqlc.arg(session_id)
   FOR UPDATE
 ),
 updated AS (
@@ -1322,7 +1341,8 @@ updated AS (
       turn_superseded_reason = sqlc.arg(superseded_reason),
       turn_visible = false
   FROM owner_session owner
-  WHERE m.turn_id = sqlc.arg(old_turn_id)
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.turn_id = sqlc.arg(old_turn_id)
     AND m.session_id = owner.id
     AND m.turn_superseded_at IS NULL
   RETURNING
@@ -1342,10 +1362,13 @@ updated AS (
 compaction_epoch_bump AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
-  WHERE EXISTS (
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND EXISTS (
     SELECT 1
     FROM updated changed
-    JOIN bot_history_message_compacts compact ON compact.id = changed.compact_id
+    JOIN bot_history_message_compacts compact
+      ON compact.id = changed.compact_id
+     AND compact.team_id = public.memoh_current_team_id()
     WHERE changed.session_id = session.id
       AND compact.bot_id = changed.bot_id
       AND compact.session_id = session.id
@@ -1376,7 +1399,8 @@ GROUP BY updated.turn_id, updated.session_id, updated.turn_position;
 WITH session_locator AS MATERIALIZED (
   SELECT DISTINCT message.session_id
   FROM bot_history_messages message
-  WHERE message.turn_id = sqlc.arg(turn_id)
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.turn_id = sqlc.arg(turn_id)
     AND message.turn_visible = true
     AND message.session_id IS NOT NULL
 ),
@@ -1384,13 +1408,15 @@ owner_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
   JOIN session_locator locator ON locator.session_id = session.id
+  WHERE session.team_id = public.memoh_current_team_id()
   ORDER BY session.id
   FOR UPDATE
 ),
 hidden AS (
   UPDATE bot_history_messages
   SET turn_visible = false
-  WHERE turn_id = sqlc.arg(turn_id)
+  WHERE team_id = public.memoh_current_team_id()
+    AND turn_id = sqlc.arg(turn_id)
     AND turn_visible = true
     AND (SELECT count(*) FROM owner_sessions) >= 0
   RETURNING session_id, compact_id
@@ -1398,10 +1424,13 @@ hidden AS (
 compaction_epoch_bump AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
-  WHERE EXISTS (
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND EXISTS (
     SELECT 1
     FROM hidden changed
-    JOIN bot_history_message_compacts compact ON compact.id = changed.compact_id
+    JOIN bot_history_message_compacts compact
+      ON compact.id = changed.compact_id
+     AND compact.team_id = public.memoh_current_team_id()
     WHERE changed.session_id = session.id
       AND compact.bot_id = session.bot_id
       AND compact.session_id = session.id
@@ -1433,9 +1462,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = sqlc.arg(bot_id)
 ORDER BY m.created_at ASC, m.id ASC
 LIMIT 10000;
 
@@ -1468,9 +1498,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = sqlc.arg(bot_id)
 ORDER BY m.created_at ASC, m.id ASC;
 
 -- name: ListHistoryTurnsByBot :many
@@ -1487,7 +1517,7 @@ SELECT
   MIN(m.created_at)::timestamptz AS created_at,
   COALESCE(MAX(m.turn_superseded_at), MAX(m.created_at))::timestamptz AS updated_at
 FROM bot_history_messages m
-WHERE m.bot_id = sqlc.arg(bot_id)
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = sqlc.arg(bot_id)
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
   AND m.session_id IS NOT NULL
@@ -1516,9 +1546,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = sqlc.arg(session_id)
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
 LIMIT 10000;
 
@@ -1544,9 +1575,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = sqlc.arg(bot_id)
   AND m.created_at >= sqlc.arg(created_at)
 ORDER BY m.created_at ASC, m.id ASC;
 
@@ -1572,9 +1604,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = sqlc.arg(session_id)
   AND m.created_at >= sqlc.arg(created_at)
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC;
 
@@ -1601,9 +1634,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = sqlc.arg(bot_id)
   AND m.created_at >= sqlc.arg(created_at)
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.created_at ASC, m.id ASC;
@@ -1631,9 +1665,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = sqlc.arg(session_id)
   AND m.created_at >= sqlc.arg(created_at)
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC;
@@ -1660,9 +1695,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = sqlc.arg(bot_id)
   AND m.created_at < sqlc.arg(created_at)
 ORDER BY m.created_at DESC, m.id DESC
 LIMIT sqlc.arg(max_count);
@@ -1689,9 +1725,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -1722,9 +1758,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -1733,7 +1769,7 @@ WHERE m.session_id = sqlc.arg(session_id)
     < (
       SELECT c.turn_position, c.turn_message_seq, c.created_at, c.id
       FROM bot_history_messages c
-      WHERE c.session_id = sqlc.arg(session_id)
+      WHERE c.team_id = public.memoh_current_team_id() AND c.session_id = sqlc.arg(session_id)
         AND c.turn_visible = true
         AND c.turn_id IS NOT NULL
         AND c.turn_position IS NOT NULL
@@ -1766,9 +1802,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = sqlc.arg(bot_id)
 ORDER BY m.created_at DESC, m.id DESC
 LIMIT sqlc.arg(max_count);
 
@@ -1794,9 +1831,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -1822,9 +1859,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -1854,9 +1891,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.id = sqlc.arg(message_id)
 LIMIT 1;
@@ -1883,9 +1920,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -1901,7 +1938,7 @@ SELECT
   m.turn_message_seq,
   m.created_at
 FROM bot_history_messages m
-WHERE m.session_id = sqlc.arg(session_id)
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -1917,7 +1954,7 @@ SELECT
   m.turn_message_seq,
   m.created_at
 FROM bot_history_messages m
-WHERE m.session_id = sqlc.arg(session_id)
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -1949,9 +1986,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -1968,7 +2005,7 @@ WITH target AS (
     m.turn_message_seq,
     m.created_at
   FROM bot_history_messages m
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
     AND m.turn_visible = true
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -1981,7 +2018,7 @@ before_rows AS (
   SELECT m.id
   FROM bot_history_messages m
   CROSS JOIN target
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
     AND m.turn_visible = true
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -1995,7 +2032,7 @@ after_rows AS (
   SELECT m.id
   FROM bot_history_messages m
   CROSS JOIN target
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
     AND m.turn_visible = true
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -2037,9 +2074,9 @@ SELECT
 FROM window_rows w
 CROSS JOIN target
 JOIN bot_history_messages m ON m.id = w.id
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC;
 
@@ -2065,9 +2102,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2098,9 +2135,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2109,7 +2146,7 @@ WHERE m.session_id = sqlc.arg(session_id)
     > (
       SELECT c.turn_position, c.turn_message_seq, c.created_at, c.id
       FROM bot_history_messages c
-      WHERE c.session_id = sqlc.arg(session_id)
+      WHERE c.team_id = public.memoh_current_team_id() AND c.session_id = sqlc.arg(session_id)
         AND c.turn_visible = true
         AND c.turn_id IS NOT NULL
         AND c.turn_position IS NOT NULL
@@ -2142,9 +2179,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2181,9 +2218,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2202,7 +2239,7 @@ LIMIT sqlc.arg(max_count);
 WITH cursor_message AS (
   SELECT m.turn_position
   FROM bot_history_messages m
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
     AND m.turn_visible = true
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -2232,9 +2269,9 @@ SELECT
   s.channel_type AS platform
 FROM bot_history_messages m
 CROSS JOIN cursor_message cursor
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = sqlc.arg(session_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = sqlc.arg(session_id)
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2244,13 +2281,15 @@ ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
 
 -- name: CountMessagesByBot :one
 SELECT COUNT(*) FROM bot_visible_history_messages
-WHERE bot_id = sqlc.arg(bot_id);
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id);
 
 -- name: ClearHistoryByBot :exec
 WITH target_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.bot_id = sqlc.arg(target_bot_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.bot_id = sqlc.arg(target_bot_id)
   ORDER BY session.id
   FOR UPDATE
 ),
@@ -2258,13 +2297,15 @@ invalidated_sessions AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
   FROM target_sessions target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
   RETURNING session.id
 ),
 target_compaction_artifacts AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.bot_id = sqlc.arg(target_bot_id)
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.bot_id = sqlc.arg(target_bot_id)
     AND (SELECT count(*) FROM target_sessions) >= 0
   ORDER BY compact.id
   FOR UPDATE
@@ -2272,13 +2313,15 @@ target_compaction_artifacts AS MATERIALIZED (
 deleted_compaction_artifacts AS (
   DELETE FROM bot_history_message_compacts AS compact
   USING target_compaction_artifacts target
-  WHERE compact.id = target.id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = target.id
   RETURNING compact.id
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.bot_id = sqlc.arg(target_bot_id)
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.bot_id = sqlc.arg(target_bot_id)
     AND (SELECT count(*) FROM target_sessions) >= 0
     AND (SELECT count(*) FROM deleted_compaction_artifacts) >= 0
   ORDER BY message.id
@@ -2286,26 +2329,30 @@ target_messages AS MATERIALIZED (
 )
 DELETE FROM bot_history_messages AS message
 USING target_messages target
-WHERE message.id = target.id;
+WHERE message.team_id = public.memoh_current_team_id()
+  AND message.id = target.id;
 
 -- name: ClearHistoryBySession :exec
 WITH target_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = sqlc.arg(target_session_id)
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = sqlc.arg(target_session_id)
   FOR UPDATE
 ),
 invalidated_session AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
   FROM target_session target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
   RETURNING session.id
 ),
 target_compaction_artifacts AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.session_id = sqlc.arg(target_session_id)
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.session_id = sqlc.arg(target_session_id)
     AND (SELECT count(*) FROM target_session) >= 0
   ORDER BY compact.id
   FOR UPDATE
@@ -2313,13 +2360,15 @@ target_compaction_artifacts AS MATERIALIZED (
 deleted_compaction_artifacts AS (
   DELETE FROM bot_history_message_compacts AS compact
   USING target_compaction_artifacts target
-  WHERE compact.id = target.id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = target.id
   RETURNING compact.id
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.session_id = sqlc.arg(target_session_id)
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.session_id = sqlc.arg(target_session_id)
     AND (SELECT count(*) FROM target_session) >= 0
     AND (SELECT count(*) FROM deleted_compaction_artifacts) >= 0
   ORDER BY message.id
@@ -2327,26 +2376,30 @@ target_messages AS MATERIALIZED (
 )
 DELETE FROM bot_history_messages AS message
 USING target_messages target
-WHERE message.id = target.id;
+WHERE message.team_id = public.memoh_current_team_id()
+  AND message.id = target.id;
 
 -- name: DeleteMessagesByIDs :exec
 WITH session_locator AS MATERIALIZED (
   SELECT DISTINCT message.session_id
   FROM bot_history_messages message
-  WHERE message.id = ANY(sqlc.arg(ids)::uuid[])
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = ANY(sqlc.arg(ids)::uuid[])
     AND message.session_id IS NOT NULL
 ),
 owner_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
   JOIN session_locator locator ON locator.session_id = session.id
+  WHERE session.team_id = public.memoh_current_team_id()
   ORDER BY session.id
   FOR UPDATE
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.id = ANY(sqlc.arg(ids)::uuid[])
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = ANY(sqlc.arg(ids)::uuid[])
     AND (SELECT count(*) FROM owner_sessions) >= 0
   ORDER BY message.id
   FOR UPDATE
@@ -2354,16 +2407,20 @@ target_messages AS MATERIALIZED (
 deleted AS (
   DELETE FROM bot_history_messages message
   USING target_messages target
-  WHERE message.id = target.id
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = target.id
   RETURNING message.session_id, message.compact_id
 ),
 compaction_epoch_bump AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
-  WHERE EXISTS (
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND EXISTS (
     SELECT 1
     FROM deleted changed
-    JOIN bot_history_message_compacts compact ON compact.id = changed.compact_id
+    JOIN bot_history_message_compacts compact
+      ON compact.id = changed.compact_id
+     AND compact.team_id = public.memoh_current_team_id()
     WHERE changed.session_id = session.id
       AND compact.bot_id = session.bot_id
       AND compact.session_id = session.id
@@ -2379,8 +2436,9 @@ WITH observed_routes AS (
     s.route_id,
     MAX(m.created_at)::timestamptz AS last_observed_at
   FROM bot_visible_history_messages m
-  JOIN bot_sessions s ON s.id = m.session_id
-  WHERE m.bot_id = sqlc.arg(bot_id)
+  JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.bot_id = sqlc.arg(bot_id)
     AND m.sender_channel_identity_id = sqlc.arg(channel_identity_id)::uuid
     AND s.route_id IS NOT NULL
   GROUP BY s.route_id
@@ -2403,7 +2461,7 @@ SELECT
   COALESCE(NULLIF(TRIM(COALESCE(r.metadata->>'conversation_avatar_url', '')), ''), '')::text AS conversation_avatar_url,
   rr.last_observed_at
 FROM observed_routes rr
-JOIN bot_channel_routes r ON r.id = rr.route_id
+JOIN bot_channel_routes r ON r.id = rr.route_id AND r.team_id = public.memoh_current_team_id()
 GROUP BY
   r.id,
   r.channel_type,
@@ -2421,9 +2479,10 @@ WITH observed_routes AS (
     s.route_id,
     MAX(m.created_at)::timestamptz AS last_observed_at
   FROM bot_visible_history_messages m
-  JOIN bot_sessions s ON s.id = m.session_id
-  JOIN bot_channel_routes r ON r.id = s.route_id
-  WHERE m.bot_id = sqlc.arg(bot_id)
+  JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+  JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.bot_id = sqlc.arg(bot_id)
     AND LOWER(TRIM(r.channel_type)) = LOWER(TRIM(sqlc.arg(channel_type)))
     AND s.route_id IS NOT NULL
   GROUP BY s.route_id
@@ -2446,7 +2505,7 @@ SELECT
   COALESCE(NULLIF(TRIM(COALESCE(r.metadata->>'conversation_avatar_url', '')), ''), '')::text AS conversation_avatar_url,
   rr.last_observed_at
 FROM observed_routes rr
-JOIN bot_channel_routes r ON r.id = rr.route_id
+JOIN bot_channel_routes r ON r.id = rr.route_id AND r.team_id = public.memoh_current_team_id()
 GROUP BY
   r.id,
   r.channel_type,
@@ -2469,9 +2528,10 @@ SELECT
   ci.display_name AS sender_display_name,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = sqlc.arg(bot_id)
   AND (sqlc.narg(session_id)::uuid IS NULL OR m.session_id = sqlc.narg(session_id)::uuid)
   AND (sqlc.narg(contact_id)::uuid IS NULL OR m.sender_channel_identity_id = sqlc.narg(contact_id)::uuid)
   AND (sqlc.narg(start_time)::timestamptz IS NULL OR m.created_at >= sqlc.narg(start_time)::timestamptz)
@@ -2500,8 +2560,11 @@ WITH expected_claims AS MATERIALIZED (
 ), artifact_locator AS MATERIALIZED (
   SELECT compact.id, compact.session_id
   FROM bot_history_message_compacts compact
-  WHERE compact.id = sqlc.arg(compact_id)
-    OR compact.id = ANY(sqlc.arg(expected_compact_ids)::uuid[])
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND (
+      compact.id = sqlc.arg(compact_id)
+      OR compact.id = ANY(sqlc.arg(expected_compact_ids)::uuid[])
+    )
 ), owner_sessions AS MATERIALIZED (
   SELECT session.id, session.bot_id, session.compaction_epoch
   FROM bot_sessions session
@@ -2510,6 +2573,7 @@ WITH expected_claims AS MATERIALIZED (
     FROM artifact_locator locator
     WHERE locator.session_id IS NOT NULL
   ) owner ON owner.session_id = session.id
+  WHERE session.team_id = public.memoh_current_team_id()
   ORDER BY session.id
   FOR UPDATE OF session
 ), locked_artifacts AS MATERIALIZED (
@@ -2523,7 +2587,8 @@ WITH expected_claims AS MATERIALIZED (
     compact.started_at
   FROM bot_history_message_compacts compact
   JOIN artifact_locator locator ON locator.id = compact.id
-  WHERE (SELECT count(*) FROM owner_sessions) >= 0
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND (SELECT count(*) FROM owner_sessions) >= 0
     AND (
       compact.session_id IS NULL
       OR EXISTS (
@@ -2585,7 +2650,8 @@ WITH expected_claims AS MATERIALIZED (
   FROM bot_history_messages message
   JOIN expected_claims claim ON claim.message_id = message.id
   CROSS JOIN target_compact target
-  WHERE CARDINALITY(sqlc.arg(message_ids)::uuid[]) = CARDINALITY(sqlc.arg(expected_compact_ids)::uuid[])
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND CARDINALITY(sqlc.arg(message_ids)::uuid[]) = CARDINALITY(sqlc.arg(expected_compact_ids)::uuid[])
     AND message.compact_id IS NOT DISTINCT FROM claim.expected_compact_id
     AND message.bot_id = target.bot_id
     AND message.session_id = target.session_id
@@ -2624,7 +2690,8 @@ WITH expected_claims AS MATERIALIZED (
       error_message = 'source lease reclaimed',
       completed_at = now()
   FROM claims_to_reclaim reclaimable
-  WHERE current_claim.id = reclaimable.id
+  WHERE current_claim.team_id = public.memoh_current_team_id()
+    AND current_claim.id = reclaimable.id
     AND current_claim.status = 'pending'
   RETURNING current_claim.id
 )
@@ -2632,7 +2699,8 @@ UPDATE bot_history_messages message
 SET compact_id = target.id
 FROM locked_messages locked,
      target_compact target
-WHERE message.id = locked.id
+WHERE message.team_id = public.memoh_current_team_id()
+  AND message.id = locked.id
   AND message.compact_id IS NOT DISTINCT FROM locked.expected_compact_id
   AND message.bot_id = target.bot_id
   AND message.session_id = target.session_id
@@ -2688,16 +2756,24 @@ SELECT
   )::text AS conversation_name,
   r.default_reply_target AS reply_target
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci
+  ON ci.id = m.sender_channel_identity_id
+ AND ci.team_id = public.memoh_current_team_id()
+JOIN bot_sessions s
+  ON s.id = m.session_id
+ AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_channel_routes r
+  ON r.id = s.route_id
+ AND r.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = $1
   -- A fresh pending claim is a 15-minute cross-process lease. Stale pending,
   -- error, deleted, and blank-summary claims remain reclaimable; current OK
   -- summaries stay ineligible exactly as on the read path.
   AND (m.compact_id IS NULL OR NOT EXISTS (
     SELECT 1 FROM bot_history_message_compacts c
-    WHERE c.id = m.compact_id
+    WHERE c.team_id = public.memoh_current_team_id()
+      AND c.id = m.compact_id
       AND c.bot_id = m.bot_id
       AND c.session_id = s.id
       AND c.compaction_epoch = s.compaction_epoch
@@ -2717,5 +2793,6 @@ SELECT
   m.bot_id,
   m.session_id
 FROM bot_history_messages m
-WHERE m.compact_id = $1
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.compact_id = $1
 ORDER BY m.created_at ASC, m.id ASC;

--- a/db/postgres/queries/models.sql
+++ b/db/postgres/queries/models.sql
@@ -11,17 +11,17 @@ VALUES (
 RETURNING *;
 
 -- name: GetProviderByID :one
-SELECT * FROM providers WHERE id = sqlc.arg(id);
+SELECT * FROM providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: GetProviderByName :one
-SELECT * FROM providers WHERE name = sqlc.arg(name);
+SELECT * FROM providers WHERE team_id = public.memoh_current_team_id() AND name = sqlc.arg(name);
 
 -- name: GetProviderByClientType :one
-SELECT * FROM providers WHERE client_type = sqlc.arg(client_type);
+SELECT * FROM providers WHERE team_id = public.memoh_current_team_id() AND client_type = sqlc.arg(client_type);
 
 -- name: ListProviders :many
 SELECT * FROM providers
-WHERE client_type NOT IN (
+WHERE team_id = public.memoh_current_team_id() AND client_type NOT IN (
   'edge-speech',
   'openai-speech',
   'openai-transcription',
@@ -53,16 +53,16 @@ SET
   config = sqlc.arg(config),
   metadata = sqlc.arg(metadata),
   updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: DeleteProvider :exec
-DELETE FROM providers WHERE id = sqlc.arg(id);
+DELETE FROM providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: CountProviders :one
 SELECT COUNT(*)
 FROM providers
-WHERE client_type NOT IN (
+WHERE team_id = public.memoh_current_team_id() AND client_type NOT IN (
   'edge-speech',
   'openai-speech',
   'openai-transcription',
@@ -96,35 +96,35 @@ VALUES (
 RETURNING *;
 
 -- name: GetModelByID :one
-SELECT * FROM models WHERE id = sqlc.arg(id);
+SELECT * FROM models WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: GetModelByModelID :one
-SELECT * FROM models WHERE model_id = sqlc.arg(model_id);
+SELECT * FROM models WHERE team_id = public.memoh_current_team_id() AND model_id = sqlc.arg(model_id);
 
 -- name: ListModelsByModelID :many
 SELECT * FROM models
-WHERE model_id = sqlc.arg(model_id)
+WHERE team_id = public.memoh_current_team_id() AND model_id = sqlc.arg(model_id)
 ORDER BY created_at DESC;
 
 -- name: ListModels :many
 SELECT * FROM models
-WHERE type NOT IN ('speech', 'transcription', 'video')
+WHERE team_id = public.memoh_current_team_id() AND type NOT IN ('speech', 'transcription', 'video')
 ORDER BY created_at DESC;
 
 -- name: ListModelsByType :many
 SELECT * FROM models
-WHERE type = sqlc.arg(type)
+WHERE team_id = public.memoh_current_team_id() AND type = sqlc.arg(type)
 ORDER BY created_at DESC;
 
 -- name: ListModelsByProviderID :many
 SELECT * FROM models
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND type NOT IN ('speech', 'transcription', 'video')
 ORDER BY created_at DESC;
 
 -- name: ListModelsByProviderIDAndType :many
 SELECT * FROM models
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND type = sqlc.arg(type)
 ORDER BY created_at DESC;
 
@@ -132,7 +132,7 @@ ORDER BY created_at DESC;
 SELECT m.*
 FROM models m
 JOIN providers p ON m.provider_id = p.id
-WHERE p.client_type = sqlc.arg(client_type)
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND p.client_type = sqlc.arg(client_type)
 ORDER BY m.created_at DESC;
 
 -- name: UpdateModel :one
@@ -145,38 +145,38 @@ SET
   enable = sqlc.arg(enable),
   config = sqlc.arg(config),
   updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: DeleteModel :exec
-DELETE FROM models WHERE id = sqlc.arg(id);
+DELETE FROM models WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: DeleteModelByModelID :exec
-DELETE FROM models WHERE model_id = sqlc.arg(model_id);
+DELETE FROM models WHERE team_id = public.memoh_current_team_id() AND model_id = sqlc.arg(model_id);
 
 -- name: DeleteModelByProviderIDAndModelID :exec
 DELETE FROM models
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND model_id = sqlc.arg(model_id);
 
 -- name: DeleteModelByProviderAndType :exec
 DELETE FROM models
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND model_id = sqlc.arg(model_id)
   AND type = sqlc.arg(type);
 
 -- name: CountModels :one
 SELECT COUNT(*) FROM models
-WHERE type NOT IN ('speech', 'transcription', 'video');
+WHERE team_id = public.memoh_current_team_id() AND type NOT IN ('speech', 'transcription', 'video');
 
 -- name: CountModelsByType :one
-SELECT COUNT(*) FROM models WHERE type = sqlc.arg(type);
+SELECT COUNT(*) FROM models WHERE team_id = public.memoh_current_team_id() AND type = sqlc.arg(type);
 
 
 -- name: UpsertRegistryProvider :one
 INSERT INTO providers (name, client_type, icon, enable, config, metadata)
 VALUES (sqlc.arg(name), sqlc.arg(client_type), sqlc.arg(icon), false, sqlc.arg(config), '{}')
-ON CONFLICT (name) DO UPDATE SET
+ON CONFLICT (team_id, name) DO UPDATE SET
   icon = EXCLUDED.icon,
   client_type = EXCLUDED.client_type,
   updated_at = now()
@@ -185,7 +185,7 @@ RETURNING *;
 -- name: UpsertRegistryModel :one
 INSERT INTO models (model_id, name, provider_id, type, config)
 VALUES (sqlc.arg(model_id), sqlc.arg(name), sqlc.arg(provider_id), sqlc.arg(type), sqlc.arg(config))
-ON CONFLICT (provider_id, model_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id, model_id) DO UPDATE SET
   name = EXCLUDED.name,
   type = EXCLUDED.type,
   config = CASE
@@ -200,7 +200,7 @@ RETURNING *;
 SELECT m.*
 FROM models m
 JOIN providers p ON m.provider_id = p.id
-WHERE p.enable = true
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND p.enable = true
   AND m.enable = true
   AND m.type NOT IN ('speech', 'transcription', 'video')
 ORDER BY m.created_at DESC;
@@ -209,7 +209,7 @@ ORDER BY m.created_at DESC;
 SELECT m.*
 FROM models m
 JOIN providers p ON m.provider_id = p.id
-WHERE p.enable = true
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND p.enable = true
   AND m.enable = true
   AND m.type = sqlc.arg(type)
 ORDER BY m.created_at DESC;
@@ -218,7 +218,7 @@ ORDER BY m.created_at DESC;
 SELECT m.*
 FROM models m
 JOIN providers p ON m.provider_id = p.id
-WHERE p.enable = true
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND p.enable = true
   AND m.enable = true
   AND p.client_type = sqlc.arg(client_type)
 ORDER BY m.created_at DESC;
@@ -235,7 +235,7 @@ RETURNING *;
 
 -- name: ListModelVariantsByModelUUID :many
 SELECT * FROM model_variants
-WHERE model_uuid = sqlc.arg(model_uuid)
+WHERE team_id = public.memoh_current_team_id() AND model_uuid = sqlc.arg(model_uuid)
 ORDER BY weight DESC, created_at DESC;
 
 -- name: GetSpeechModelWithProvider :one
@@ -244,12 +244,12 @@ SELECT
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.id = sqlc.arg(id)
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.id = sqlc.arg(id)
   AND m.type = 'speech';
 
 -- name: ListSpeechProviders :many
 SELECT * FROM providers
-WHERE client_type IN (
+WHERE team_id = public.memoh_current_team_id() AND client_type IN (
   'edge-speech',
   'openai-speech',
   'openrouter-speech',
@@ -264,7 +264,7 @@ ORDER BY created_at DESC;
 
 -- name: ListTranscriptionProviders :many
 SELECT * FROM providers
-WHERE client_type IN (
+WHERE team_id = public.memoh_current_team_id() AND client_type IN (
   'openai-transcription',
   'openrouter-transcription',
   'elevenlabs-transcription',
@@ -278,20 +278,20 @@ SELECT m.*,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.type = 'speech'
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.type = 'speech'
   AND m.enable = true
 ORDER BY m.created_at DESC;
 
 -- name: ListSpeechModelsByProviderID :many
 SELECT * FROM models
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND type = 'speech'
   AND enable = true
 ORDER BY created_at DESC;
 
 -- name: GetModelByProviderAndModelID :one
 SELECT * FROM models
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND model_id = sqlc.arg(model_id)
 LIMIT 1;
 
@@ -301,7 +301,7 @@ SELECT
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.id = sqlc.arg(id)
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.id = sqlc.arg(id)
   AND m.type = 'transcription';
 
 -- name: ListTranscriptionModels :many
@@ -309,13 +309,13 @@ SELECT m.*,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.type = 'transcription'
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.type = 'transcription'
   AND m.enable = true
 ORDER BY m.created_at DESC;
 
 -- name: ListTranscriptionModelsByProviderID :many
 SELECT * FROM models
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND type = 'transcription'
   AND enable = true
 ORDER BY created_at DESC;
@@ -327,12 +327,12 @@ SELECT
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.id = sqlc.arg(id)
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.id = sqlc.arg(id)
   AND m.type = 'video';
 
 -- name: ListVideoProviders :many
 SELECT * FROM providers
-WHERE client_type IN (
+WHERE team_id = public.memoh_current_team_id() AND client_type IN (
   'openrouter-video',
   'modelark-video',
   'volcengine-video'
@@ -344,13 +344,13 @@ SELECT m.*,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.type = 'video'
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.type = 'video'
   AND m.enable = true
 ORDER BY m.created_at DESC;
 
 -- name: ListVideoModelsByProviderID :many
 SELECT * FROM models
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND type = 'video'
   AND enable = true
 ORDER BY created_at DESC;

--- a/db/postgres/queries/network.sql
+++ b/db/postgres/queries/network.sql
@@ -4,4 +4,4 @@ SELECT
   overlay_provider,
   overlay_config
 FROM bots
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;

--- a/db/postgres/queries/plugins.sql
+++ b/db/postgres/queries/plugins.sql
@@ -3,7 +3,7 @@ INSERT INTO bot_plugin_installations (
   bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-ON CONFLICT (bot_id, plugin_id)
+ON CONFLICT (team_id, bot_id, plugin_id)
 DO UPDATE SET plugin_name = EXCLUDED.plugin_name,
               version = EXCLUDED.version,
               status = EXCLUDED.status,
@@ -12,18 +12,18 @@ DO UPDATE SET plugin_name = EXCLUDED.plugin_name,
               metadata = EXCLUDED.metadata,
               manifest = EXCLUDED.manifest,
               updated_at = now()
-RETURNING id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at;
+RETURNING id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at, team_id;
 
 -- name: GetBotPluginInstallationByID :one
-SELECT id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at
+SELECT id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at, team_id
 FROM bot_plugin_installations
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 LIMIT 1;
 
 -- name: ListBotPluginInstallations :many
-SELECT id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at
+SELECT id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at, team_id
 FROM bot_plugin_installations
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY installed_at DESC;
 
 -- name: UpdateBotPluginInstallationStatus :one
@@ -31,31 +31,31 @@ UPDATE bot_plugin_installations
 SET status = $3,
     enabled = $4,
     updated_at = now()
-WHERE bot_id = $1 AND id = $2
-RETURNING id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
+RETURNING id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at, team_id;
 
 -- name: DeleteBotPluginInstallation :exec
 DELETE FROM bot_plugin_installations
-WHERE bot_id = $1 AND id = $2;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2;
 
 -- name: UpsertBotPluginResource :one
 INSERT INTO bot_plugin_resources (
   installation_id, resource_type, resource_key, resource_id, status, metadata
 )
 VALUES ($1, $2, $3, $4, $5, $6)
-ON CONFLICT (installation_id, resource_type, resource_key)
+ON CONFLICT (team_id, installation_id, resource_type, resource_key)
 DO UPDATE SET resource_id = EXCLUDED.resource_id,
               status = EXCLUDED.status,
               metadata = EXCLUDED.metadata,
               updated_at = now()
-RETURNING id, installation_id, resource_type, resource_key, resource_id, status, metadata, created_at, updated_at;
+RETURNING id, installation_id, resource_type, resource_key, resource_id, status, metadata, created_at, updated_at, team_id;
 
 -- name: ListBotPluginResources :many
-SELECT id, installation_id, resource_type, resource_key, resource_id, status, metadata, created_at, updated_at
+SELECT id, installation_id, resource_type, resource_key, resource_id, status, metadata, created_at, updated_at, team_id
 FROM bot_plugin_resources
-WHERE installation_id = $1
+WHERE team_id = public.memoh_current_team_id() AND installation_id = $1
 ORDER BY resource_type ASC, resource_key ASC;
 
 -- name: DeleteBotPluginResources :exec
 DELETE FROM bot_plugin_resources
-WHERE installation_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND installation_id = $1;

--- a/db/postgres/queries/provider_oauth.sql
+++ b/db/postgres/queries/provider_oauth.sql
@@ -21,7 +21,7 @@ VALUES (
   sqlc.arg(pkce_code_verifier),
   sqlc.arg(metadata)
 )
-ON CONFLICT (provider_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id) DO UPDATE SET
   access_token = EXCLUDED.access_token,
   refresh_token = EXCLUDED.refresh_token,
   expires_at = EXCLUDED.expires_at,
@@ -34,10 +34,10 @@ ON CONFLICT (provider_id) DO UPDATE SET
 RETURNING *;
 
 -- name: GetProviderOAuthTokenByProvider :one
-SELECT * FROM provider_oauth_tokens WHERE provider_id = sqlc.arg(provider_id);
+SELECT * FROM provider_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id);
 
 -- name: GetProviderOAuthTokenByState :one
-SELECT * FROM provider_oauth_tokens WHERE state = sqlc.arg(state) AND state != '';
+SELECT * FROM provider_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND state = sqlc.arg(state) AND state != '';
 
 -- name: UpdateProviderOAuthState :exec
 INSERT INTO provider_oauth_tokens (provider_id, state, pkce_code_verifier, metadata)
@@ -47,11 +47,11 @@ VALUES (
   sqlc.arg(pkce_code_verifier),
   sqlc.arg(metadata)
 )
-ON CONFLICT (provider_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id) DO UPDATE SET
   state = EXCLUDED.state,
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
   metadata = EXCLUDED.metadata,
   updated_at = now();
 
 -- name: DeleteProviderOAuthToken :exec
-DELETE FROM provider_oauth_tokens WHERE provider_id = sqlc.arg(provider_id);
+DELETE FROM provider_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id);

--- a/db/postgres/queries/schedule.sql
+++ b/db/postgres/queries/schedule.sql
@@ -1,23 +1,23 @@
 -- name: CreateSchedule :one
 INSERT INTO schedule (name, description, pattern, max_calls, enabled, command, bot_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id;
+RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id;
 
 -- name: GetScheduleByID :one
-SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 FROM schedule
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: ListSchedulesByBot :many
-SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 FROM schedule
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY created_at DESC;
 
 -- name: ListEnabledSchedules :many
-SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 FROM schedule
-WHERE enabled = true
+WHERE team_id = public.memoh_current_team_id() AND enabled = true
 ORDER BY created_at DESC;
 
 -- name: UpdateSchedule :one
@@ -29,12 +29,12 @@ SET name = $2,
     enabled = $6,
     command = $7,
     updated_at = now()
-WHERE id = $1
-RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id;
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id;
 
 -- name: DeleteSchedule :exec
 DELETE FROM schedule
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: IncrementScheduleCalls :one
 UPDATE schedule
@@ -44,6 +44,6 @@ SET current_calls = current_calls + 1,
       ELSE enabled
     END,
     updated_at = now()
-WHERE id = $1
-RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id;
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id;
 

--- a/db/postgres/queries/schedule_logs.sql
+++ b/db/postgres/queries/schedule_logs.sql
@@ -11,31 +11,31 @@ SET status = $2,
     usage = $5,
     model_id = $6,
     completed_at = now()
-WHERE id = $1
-RETURNING id, schedule_id, bot_id, session_id, status, result_text, error_message, usage, model_id, started_at, completed_at;
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, schedule_id, bot_id, session_id, status, result_text, error_message, usage, model_id, started_at, completed_at, team_id;
 
 -- name: ListScheduleLogsByBot :many
 SELECT id, schedule_id, bot_id, session_id, status, result_text, error_message, usage, started_at, completed_at
 FROM schedule_logs
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: CountScheduleLogsByBot :one
-SELECT count(*) FROM schedule_logs WHERE bot_id = $1;
+SELECT count(*) FROM schedule_logs WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: ListScheduleLogsBySchedule :many
 SELECT id, schedule_id, bot_id, session_id, status, result_text, error_message, usage, started_at, completed_at
 FROM schedule_logs
-WHERE schedule_id = $1
+WHERE team_id = public.memoh_current_team_id() AND schedule_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: CountScheduleLogsBySchedule :one
-SELECT count(*) FROM schedule_logs WHERE schedule_id = $1;
+SELECT count(*) FROM schedule_logs WHERE team_id = public.memoh_current_team_id() AND schedule_id = $1;
 
 -- name: DeleteScheduleLogsByBot :exec
-DELETE FROM schedule_logs WHERE bot_id = $1;
+DELETE FROM schedule_logs WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;
 
 -- name: DeleteScheduleLogsBySchedule :exec
-DELETE FROM schedule_logs WHERE schedule_id = $1;
+DELETE FROM schedule_logs WHERE team_id = public.memoh_current_team_id() AND schedule_id = $1;

--- a/db/postgres/queries/search_providers.sql
+++ b/db/postgres/queries/search_providers.sql
@@ -9,18 +9,19 @@ VALUES (
 RETURNING *;
 
 -- name: GetSearchProviderByID :one
-SELECT * FROM search_providers WHERE id = sqlc.arg(id);
+SELECT * FROM search_providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);
 
 -- name: GetSearchProviderByName :one
-SELECT * FROM search_providers WHERE name = sqlc.arg(name);
+SELECT * FROM search_providers WHERE team_id = public.memoh_current_team_id() AND name = sqlc.arg(name);
 
 -- name: ListSearchProviders :many
 SELECT * FROM search_providers
+WHERE team_id = public.memoh_current_team_id()
 ORDER BY created_at DESC;
 
 -- name: ListSearchProvidersByProvider :many
 SELECT * FROM search_providers
-WHERE provider = sqlc.arg(provider)
+WHERE team_id = public.memoh_current_team_id() AND provider = sqlc.arg(provider)
 ORDER BY created_at DESC;
 
 -- name: UpdateSearchProvider :one
@@ -31,8 +32,8 @@ SET
   config = sqlc.arg(config),
   enable = sqlc.arg(enable),
   updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: DeleteSearchProvider :exec
-DELETE FROM search_providers WHERE id = sqlc.arg(id);
+DELETE FROM search_providers WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id);

--- a/db/postgres/queries/session_events.sql
+++ b/db/postgres/queries/session_events.sql
@@ -13,23 +13,23 @@ RETURNING id;
 
 -- name: ListSessionEventsBySession :many
 SELECT * FROM bot_session_events
-WHERE session_id = $1
+WHERE team_id = public.memoh_current_team_id() AND session_id = $1
 ORDER BY received_at_ms ASC;
 
 -- name: ListSessionEventsBySessionAfter :many
 SELECT * FROM bot_session_events
-WHERE session_id = $1 AND received_at_ms >= $2
+WHERE team_id = public.memoh_current_team_id() AND session_id = $1 AND received_at_ms >= $2
 ORDER BY received_at_ms ASC;
 
 -- name: ListSessionEventsByBot :many
 SELECT * FROM bot_session_events
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY received_at_ms ASC, id ASC;
 
 -- name: CountSessionEvents :one
 SELECT COUNT(*) FROM bot_session_events
-WHERE session_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND session_id = $1;
 
 -- name: DeleteSessionEventsByBot :exec
 DELETE FROM bot_session_events
-WHERE bot_id = $1;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1;

--- a/db/postgres/queries/session_info.sql
+++ b/db/postgres/queries/session_info.sql
@@ -1,13 +1,14 @@
 -- name: CountMessagesBySession :one
 SELECT COUNT(*)::bigint AS message_count
 FROM bot_visible_history_messages
-WHERE session_id = sqlc.arg(session_id);
+WHERE team_id = public.memoh_current_team_id() AND session_id = sqlc.arg(session_id);
 
 -- name: GetLatestAssistantUsage :one
 SELECT
   COALESCE((m.usage->>'inputTokens')::bigint, 0)::bigint AS input_tokens
 FROM bot_visible_history_messages m
-WHERE m.session_id = sqlc.arg(session_id)
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = sqlc.arg(session_id)
   AND m.role = 'assistant'
   AND m.usage IS NOT NULL
 ORDER BY m.created_at DESC
@@ -26,13 +27,15 @@ SELECT
   COALESCE(SUM((m.usage->>'inputTokens')::bigint), 0)::bigint AS total_input_tokens,
   COALESCE(SUM((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint), 0)::bigint AS cache_read_tokens
 FROM bot_visible_history_messages m
-WHERE m.session_id = sqlc.arg(session_id)
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = sqlc.arg(session_id)
   AND m.usage IS NOT NULL;
 
 -- name: GetLatestSessionIDByBot :one
 SELECT s.id
 FROM bot_sessions s
-WHERE s.bot_id = sqlc.arg(bot_id)
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = sqlc.arg(bot_id)
   AND s.type = 'chat'
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC
@@ -55,7 +58,8 @@ WITH requested AS (
            ELSE '[]'::jsonb
       END
     ) AS item
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.session_id = sqlc.arg(session_id)
     AND m.role = 'user'
     AND item->>'name' IS NOT NULL
     AND item->>'name' != ''
@@ -69,7 +73,8 @@ tool_payloads AS (
          ELSE '[]'::jsonb
     END AS content_json
   FROM bot_visible_history_messages m
-  WHERE m.session_id = sqlc.arg(session_id)
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.session_id = sqlc.arg(session_id)
     AND m.role = 'assistant'
 ),
 tool_used AS (

--- a/db/postgres/queries/sessions.sql
+++ b/db/postgres/queries/sessions.sql
@@ -21,7 +21,8 @@ RETURNING *;
 WITH source_session AS (
   SELECT s.*
   FROM bot_sessions s
-  WHERE s.id = sqlc.arg(session_id)
+  WHERE s.team_id = public.memoh_current_team_id()
+    AND s.id = sqlc.arg(session_id)
     AND s.bot_id = sqlc.arg(bot_id)
     AND s.type = 'chat'
     AND s.deleted_at IS NULL
@@ -32,7 +33,8 @@ target_turn AS (
     vm.turn_position AS position,
     vm.id AS message_id
   FROM source_session s
-  JOIN bot_visible_history_messages vm ON vm.session_id = s.id
+  JOIN bot_visible_history_messages vm ON vm.team_id = public.memoh_current_team_id()
+    AND vm.session_id = s.id
     AND vm.id = sqlc.arg(message_id)
     AND vm.role = 'assistant'
     AND vm.turn_id IS NOT NULL
@@ -64,7 +66,8 @@ copy_messages AS (
     vm.turn_position < tt.position
     OR vm.turn_position = tt.position
   )
-  WHERE vm.session_id = sqlc.arg(session_id)
+  WHERE vm.team_id = public.memoh_current_team_id()
+    AND vm.session_id = sqlc.arg(session_id)
   ORDER BY vm.turn_position ASC, vm.turn_message_seq ASC, vm.created_at ASC, vm.id ASC
 ),
 copy_turns AS (
@@ -203,6 +206,7 @@ copied_assets AS (
   FROM bot_history_message_assets a
   JOIN copy_messages cm ON cm.old_message_id = a.message_id
   JOIN inserted_messages im ON im.id = cm.new_message_id
+  WHERE a.team_id = public.memoh_current_team_id()
   RETURNING id
 )
 SELECT cs.*
@@ -212,7 +216,8 @@ CROSS JOIN (SELECT count(*) AS copied_asset_count FROM copied_assets) copied_ass
 -- name: GetSessionByID :one
 SELECT *
 FROM bot_sessions
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $1
   AND deleted_at IS NULL;
 
 -- name: ListSessionsByBot :many
@@ -222,8 +227,9 @@ SELECT
   r.metadata AS route_metadata,
   r.conversation_type AS route_conversation_type
 FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = sqlc.arg(bot_id)
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = sqlc.arg(bot_id)
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC;
 
@@ -234,8 +240,9 @@ SELECT
   r.metadata AS route_metadata,
   r.conversation_type AS route_conversation_type
 FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = sqlc.arg(bot_id)
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = sqlc.arg(bot_id)
   AND s.created_by_user_id = sqlc.arg(created_by_user_id)
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC;
@@ -250,8 +257,9 @@ SELECT
   r.metadata AS route_metadata,
   r.conversation_type AS route_conversation_type
 FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = sqlc.arg(bot_id)
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = sqlc.arg(bot_id)
   AND s.deleted_at IS NULL
   AND s.type = ANY(sqlc.arg(types)::text[])
   AND (
@@ -272,8 +280,9 @@ SELECT
   r.metadata AS route_metadata,
   r.conversation_type AS route_conversation_type
 FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = sqlc.arg(bot_id)
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = sqlc.arg(bot_id)
   AND s.created_by_user_id = sqlc.arg(created_by_user_id)
   AND s.deleted_at IS NULL
   AND s.type = ANY(sqlc.arg(types)::text[])
@@ -291,20 +300,21 @@ LIMIT sqlc.arg(limit_count)::int;
 -- name: ListSessionsByRoute :many
 SELECT *
 FROM bot_sessions
-WHERE route_id = sqlc.arg(route_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND route_id = sqlc.arg(route_id)
   AND deleted_at IS NULL
 ORDER BY updated_at DESC;
 
 -- name: UpdateSessionTitle :one
 UPDATE bot_sessions
 SET title = sqlc.arg(title), updated_at = now()
-WHERE id = sqlc.arg(id) AND deleted_at IS NULL
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id) AND deleted_at IS NULL
 RETURNING *;
 
 -- name: UpdateSessionMetadata :one
 UPDATE bot_sessions
 SET metadata = sqlc.arg(metadata), updated_at = now()
-WHERE id = sqlc.arg(id) AND deleted_at IS NULL
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id) AND deleted_at IS NULL
 RETURNING *;
 
 -- name: UpdateSessionTypeAndMetadata :one
@@ -315,43 +325,48 @@ SET type = sqlc.arg(type),
     runtime_metadata = sqlc.arg(runtime_metadata),
     metadata = sqlc.arg(metadata),
     updated_at = now()
-WHERE id = sqlc.arg(id) AND deleted_at IS NULL
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id) AND deleted_at IS NULL
 RETURNING *;
 
 -- name: SoftDeleteSession :exec
 UPDATE bot_sessions
 SET deleted_at = now(), updated_at = now()
-WHERE id = sqlc.arg(id) AND deleted_at IS NULL;
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id) AND deleted_at IS NULL;
 
 -- name: TouchSession :exec
 UPDATE bot_sessions
 SET updated_at = now()
-WHERE id = sqlc.arg(id) AND deleted_at IS NULL;
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id) AND deleted_at IS NULL;
 
 -- name: SetSessionNextTurnPosition :exec
 UPDATE bot_sessions
 SET next_turn_position = sqlc.arg(next_turn_position)::bigint
-WHERE id = sqlc.arg(session_id);
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(session_id);
 
 -- name: GetSessionDiscussCursor :one
 SELECT *
 FROM bot_session_discuss_cursors
-WHERE session_id = sqlc.arg(session_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND session_id = sqlc.arg(session_id)
   AND scope_key = sqlc.arg(scope_key);
 
 -- name: ListSessionDiscussCursorsByBot :many
 SELECT c.*
 FROM bot_session_discuss_cursors c
 JOIN bot_sessions s ON s.id = c.session_id
-WHERE s.bot_id = sqlc.arg(bot_id)
+WHERE c.team_id = public.memoh_current_team_id()
+  AND s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = sqlc.arg(bot_id)
 ORDER BY c.updated_at ASC, c.session_id ASC, c.scope_key ASC;
 
 -- name: DeleteSessionDiscussCursorsByBot :exec
 DELETE FROM bot_session_discuss_cursors
-WHERE session_id IN (
+WHERE team_id = public.memoh_current_team_id()
+  AND session_id IN (
   SELECT id
   FROM bot_sessions
-  WHERE bot_id = sqlc.arg(bot_id)
+  WHERE team_id = public.memoh_current_team_id()
+    AND bot_id = sqlc.arg(bot_id)
 );
 
 -- name: UpsertSessionDiscussCursor :one
@@ -365,7 +380,7 @@ VALUES (
   sqlc.arg(source),
   sqlc.arg(consumed_cursor)
 )
-ON CONFLICT (session_id, scope_key) DO UPDATE
+ON CONFLICT (team_id, session_id, scope_key) DO UPDATE
 SET route_id = COALESCE(EXCLUDED.route_id, bot_session_discuss_cursors.route_id),
     source = EXCLUDED.source,
     consumed_cursor = GREATEST(bot_session_discuss_cursors.consumed_cursor, EXCLUDED.consumed_cursor),
@@ -376,17 +391,20 @@ RETURNING *;
 SELECT s.*
 FROM bot_sessions s
 JOIN bot_channel_routes r ON r.active_session_id = s.id
-WHERE r.id = sqlc.arg(route_id)
+WHERE s.team_id = public.memoh_current_team_id()
+  AND r.team_id = public.memoh_current_team_id()
+  AND r.id = sqlc.arg(route_id)
   AND s.deleted_at IS NULL;
 
 -- name: ListSubagentSessionsByParent :many
 SELECT *
 FROM bot_sessions
-WHERE parent_session_id = sqlc.arg(parent_session_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND parent_session_id = sqlc.arg(parent_session_id)
   AND deleted_at IS NULL
 ORDER BY created_at DESC;
 
 -- name: SoftDeleteSessionsByBot :exec
 UPDATE bot_sessions
 SET deleted_at = now(), updated_at = now()
-WHERE bot_id = sqlc.arg(bot_id) AND deleted_at IS NULL;
+WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id) AND deleted_at IS NULL;

--- a/db/postgres/queries/settings.sql
+++ b/db/postgres/queries/settings.sql
@@ -35,18 +35,18 @@ SELECT
   bots.overlay_config,
   bots.command_ui_language
 FROM bots
-LEFT JOIN models AS chat_models ON chat_models.id = bots.chat_model_id
-LEFT JOIN models AS heartbeat_models ON heartbeat_models.id = bots.heartbeat_model_id
-LEFT JOIN models AS compaction_models ON compaction_models.id = bots.compaction_model_id
-LEFT JOIN models AS title_models ON title_models.id = bots.title_model_id
-LEFT JOIN models AS image_models ON image_models.id = bots.image_model_id
-LEFT JOIN search_providers ON search_providers.id = bots.search_provider_id
-LEFT JOIN fetch_providers ON fetch_providers.id = bots.fetch_provider_id
-LEFT JOIN memory_providers ON memory_providers.id = bots.memory_provider_id
-LEFT JOIN models AS tts_models ON tts_models.id = bots.tts_model_id
-LEFT JOIN models AS transcription_models ON transcription_models.id = bots.transcription_model_id
-LEFT JOIN models AS video_models ON video_models.id = bots.video_model_id
-WHERE bots.id = $1;
+LEFT JOIN models AS chat_models ON chat_models.id = bots.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS heartbeat_models ON heartbeat_models.id = bots.heartbeat_model_id AND heartbeat_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS compaction_models ON compaction_models.id = bots.compaction_model_id AND compaction_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS title_models ON title_models.id = bots.title_model_id AND title_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS image_models ON image_models.id = bots.image_model_id AND image_models.team_id = public.memoh_current_team_id()
+LEFT JOIN search_providers ON search_providers.id = bots.search_provider_id AND search_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN fetch_providers ON fetch_providers.id = bots.fetch_provider_id AND fetch_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN memory_providers ON memory_providers.id = bots.memory_provider_id AND memory_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS tts_models ON tts_models.id = bots.tts_model_id AND tts_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS transcription_models ON transcription_models.id = bots.transcription_model_id AND transcription_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS video_models ON video_models.id = bots.video_model_id AND video_models.team_id = public.memoh_current_team_id()
+WHERE bots.team_id = public.memoh_current_team_id() AND bots.id = $1;
 
 -- name: UpsertBotSettings :one
 WITH updated AS (
@@ -88,7 +88,7 @@ WITH updated AS (
       overlay_config = sqlc.arg(overlay_config),
       command_ui_language = sqlc.arg(command_ui_language),
       updated_at = now()
-  WHERE bots.id = sqlc.arg(id)
+  WHERE bots.team_id = public.memoh_current_team_id() AND bots.id = sqlc.arg(id)
   RETURNING bots.id, bots.language, bots.reasoning_enabled, bots.reasoning_effort, bots.heartbeat_enabled, bots.heartbeat_interval, bots.heartbeat_prompt, bots.compaction_enabled, bots.compaction_threshold, bots.compaction_ratio, bots.timezone, bots.chat_model_id, bots.chat_runtime, bots.chat_acp_agent_id, bots.chat_acp_project_path, bots.chat_acp_project_mode, bots.heartbeat_model_id, bots.compaction_model_id, bots.title_model_id, bots.image_model_id, bots.search_provider_id, bots.fetch_provider_id, bots.memory_provider_id, bots.tts_model_id, bots.transcription_model_id, bots.video_model_id, bots.persist_full_tool_results, bots.show_tool_calls_in_im, bots.tool_approval_config, bots.display_enabled, bots.overlay_provider, bots.overlay_enabled, bots.overlay_config, bots.command_ui_language
 )
 SELECT
@@ -127,17 +127,17 @@ SELECT
   updated.overlay_config,
   updated.command_ui_language
 FROM updated
-LEFT JOIN models AS chat_models ON chat_models.id = updated.chat_model_id
-LEFT JOIN models AS heartbeat_models ON heartbeat_models.id = updated.heartbeat_model_id
-LEFT JOIN models AS compaction_models ON compaction_models.id = updated.compaction_model_id
-LEFT JOIN models AS title_models ON title_models.id = updated.title_model_id
-LEFT JOIN models AS image_models ON image_models.id = updated.image_model_id
-LEFT JOIN search_providers ON search_providers.id = updated.search_provider_id
-LEFT JOIN fetch_providers ON fetch_providers.id = updated.fetch_provider_id
-LEFT JOIN memory_providers ON memory_providers.id = updated.memory_provider_id
-LEFT JOIN models AS tts_models ON tts_models.id = updated.tts_model_id
-LEFT JOIN models AS transcription_models ON transcription_models.id = updated.transcription_model_id
-LEFT JOIN models AS video_models ON video_models.id = updated.video_model_id;
+LEFT JOIN models AS chat_models ON chat_models.id = updated.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS heartbeat_models ON heartbeat_models.id = updated.heartbeat_model_id AND heartbeat_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS compaction_models ON compaction_models.id = updated.compaction_model_id AND compaction_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS title_models ON title_models.id = updated.title_model_id AND title_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS image_models ON image_models.id = updated.image_model_id AND image_models.team_id = public.memoh_current_team_id()
+LEFT JOIN search_providers ON search_providers.id = updated.search_provider_id AND search_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN fetch_providers ON fetch_providers.id = updated.fetch_provider_id AND fetch_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN memory_providers ON memory_providers.id = updated.memory_provider_id AND memory_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS tts_models ON tts_models.id = updated.tts_model_id AND tts_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS transcription_models ON transcription_models.id = updated.transcription_model_id AND transcription_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS video_models ON video_models.id = updated.video_model_id AND video_models.team_id = public.memoh_current_team_id();
 
 -- name: DeleteSettingsByBotID :exec
 UPDATE bots
@@ -174,4 +174,4 @@ SET language = 'auto',
     overlay_enabled = false,
     overlay_config = '{}'::jsonb,
     updated_at = now()
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;

--- a/db/postgres/queries/snapshots.sql
+++ b/db/postgres/queries/snapshots.sql
@@ -15,13 +15,13 @@ VALUES (
   sqlc.arg(snapshotter),
   sqlc.arg(source)
 )
-ON CONFLICT (container_id, runtime_snapshot_name) DO UPDATE
+ON CONFLICT (team_id, container_id, runtime_snapshot_name) DO UPDATE
 SET
   display_name = EXCLUDED.display_name,
   parent_runtime_snapshot_name = EXCLUDED.parent_runtime_snapshot_name,
   snapshotter = EXCLUDED.snapshotter,
   source = EXCLUDED.source
-RETURNING id, container_id, runtime_snapshot_name, display_name, parent_runtime_snapshot_name, snapshotter, source, created_at;
+RETURNING id, container_id, runtime_snapshot_name, display_name, parent_runtime_snapshot_name, snapshotter, source, created_at, team_id;
 
 -- name: ListSnapshotsByContainerID :many
 SELECT
@@ -32,9 +32,10 @@ SELECT
   parent_runtime_snapshot_name,
   snapshotter,
   source,
-  created_at
+  created_at,
+  team_id
 FROM snapshots
-WHERE container_id = sqlc.arg(container_id)
+WHERE team_id = public.memoh_current_team_id() AND container_id = sqlc.arg(container_id)
 ORDER BY created_at DESC;
 
 -- name: ListSnapshotsWithVersionByContainerID :many
@@ -49,8 +50,8 @@ SELECT
   s.created_at,
   cv.version
 FROM snapshots s
-LEFT JOIN container_versions cv ON cv.snapshot_id = s.id
-WHERE s.container_id = sqlc.arg(container_id)
+LEFT JOIN container_versions cv ON cv.snapshot_id = s.id AND cv.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id() AND s.container_id = sqlc.arg(container_id)
 ORDER BY s.created_at DESC;
 
 -- name: GetSnapshotByContainerAndRuntimeName :one
@@ -62,8 +63,9 @@ SELECT
   parent_runtime_snapshot_name,
   snapshotter,
   source,
-  created_at
+  created_at,
+  team_id
 FROM snapshots
-WHERE container_id = sqlc.arg(container_id)
+WHERE team_id = public.memoh_current_team_id() AND container_id = sqlc.arg(container_id)
   AND runtime_snapshot_name = sqlc.arg(runtime_snapshot_name)
 LIMIT 1;

--- a/db/postgres/queries/token_usage.sql
+++ b/db/postgres/queries/token_usage.sql
@@ -26,9 +26,9 @@ SELECT
   COALESCE(SUM((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint), 0)::bigint AS cache_read_tokens,
   COALESCE(SUM((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint), 0)::bigint AS reasoning_tokens
 FROM bot_history_messages m
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id AND ps.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = sqlc.arg(bot_id)
   AND m.usage IS NOT NULL
   AND m.created_at >= sqlc.arg(from_time)
   AND m.created_at < sqlc.arg(to_time)
@@ -73,11 +73,11 @@ SELECT
   COALESCE(SUM((m.usage->>'inputTokens')::bigint), 0)::bigint AS input_tokens,
   COALESCE(SUM((m.usage->>'outputTokens')::bigint), 0)::bigint AS output_tokens
 FROM bot_history_messages m
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-LEFT JOIN models mo ON mo.id = m.model_id
-LEFT JOIN providers lp ON lp.id = mo.provider_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id AND ps.team_id = public.memoh_current_team_id()
+LEFT JOIN models mo ON mo.id = m.model_id AND mo.team_id = public.memoh_current_team_id()
+LEFT JOIN providers lp ON lp.id = mo.provider_id AND lp.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = sqlc.arg(bot_id)
   AND m.usage IS NOT NULL
   AND m.created_at >= sqlc.arg(from_time)
   AND m.created_at < sqlc.arg(to_time)
@@ -146,11 +146,11 @@ SELECT
   COALESCE((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint, 0)::bigint AS cache_read_tokens,
   COALESCE((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint, 0)::bigint AS reasoning_tokens
 FROM bot_history_messages m
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-LEFT JOIN models mo ON mo.id = m.model_id
-LEFT JOIN providers lp ON lp.id = mo.provider_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id AND ps.team_id = public.memoh_current_team_id()
+LEFT JOIN models mo ON mo.id = m.model_id AND mo.team_id = public.memoh_current_team_id()
+LEFT JOIN providers lp ON lp.id = mo.provider_id AND lp.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = sqlc.arg(bot_id)
   AND m.usage IS NOT NULL
   AND m.created_at >= sqlc.arg(from_time)
   AND m.created_at < sqlc.arg(to_time)
@@ -190,9 +190,9 @@ OFFSET sqlc.arg(page_offset);
 -- name: CountTokenUsageRecords :one
 SELECT COUNT(*)::bigint AS total
 FROM bot_history_messages m
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-WHERE m.bot_id = sqlc.arg(bot_id)
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id AND ps.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = sqlc.arg(bot_id)
   AND m.usage IS NOT NULL
   AND m.created_at >= sqlc.arg(from_time)
   AND m.created_at < sqlc.arg(to_time)

--- a/db/postgres/queries/tool_approval.sql
+++ b/db/postgres/queries/tool_approval.sql
@@ -28,7 +28,8 @@ INSERT INTO tool_approval_requests (
   (
     SELECT COALESCE(MAX(short_id), 0) + 1
     FROM tool_approval_requests
-    WHERE session_id = sqlc.arg(session_id)
+    WHERE team_id = public.memoh_current_team_id()
+      AND session_id = sqlc.arg(session_id)
   ),
   sqlc.narg(requested_by_channel_identity_id),
   sqlc.narg(requested_message_id),
@@ -36,7 +37,7 @@ INSERT INTO tool_approval_requests (
   sqlc.arg(reply_target),
   sqlc.arg(conversation_type)
 )
-ON CONFLICT (session_id, tool_call_id) DO UPDATE
+ON CONFLICT (team_id, session_id, tool_call_id) DO UPDATE
 SET tool_input = CASE
   WHEN tool_approval_requests.status = 'pending' THEN EXCLUDED.tool_input
   ELSE tool_approval_requests.tool_input
@@ -50,12 +51,13 @@ RETURNING *;
 -- name: GetToolApprovalRequest :one
 SELECT *
 FROM tool_approval_requests
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: GetPendingToolApprovalBySessionShortID :one
 SELECT *
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND short_id = $3
   AND status = 'pending';
@@ -63,7 +65,8 @@ WHERE bot_id = $1
 -- name: GetLatestPendingToolApprovalBySession :one
 SELECT *
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND status = 'pending'
 ORDER BY created_at DESC, short_id DESC
@@ -72,7 +75,8 @@ LIMIT 1;
 -- name: GetPendingToolApprovalByReplyMessage :one
 SELECT *
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND prompt_external_message_id = $3
   AND status = 'pending'
@@ -83,7 +87,7 @@ LIMIT 1;
 UPDATE tool_approval_requests
 SET prompt_message_id = sqlc.narg(prompt_message_id),
     prompt_external_message_id = sqlc.arg(prompt_external_message_id)
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: ApproveToolApprovalRequest :one
@@ -92,7 +96,8 @@ SET status = 'approved',
     decision_reason = sqlc.arg(reason),
     decided_by_channel_identity_id = sqlc.narg(decided_by_channel_identity_id),
     decided_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id()
+  AND id = sqlc.arg(id)
   AND status = 'pending'
 RETURNING *;
 
@@ -102,7 +107,8 @@ SET status = 'rejected',
     decision_reason = sqlc.arg(reason),
     decided_by_channel_identity_id = sqlc.narg(decided_by_channel_identity_id),
     decided_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id()
+  AND id = sqlc.arg(id)
   AND status = 'pending'
 RETURNING *;
 
@@ -111,7 +117,8 @@ UPDATE tool_approval_requests
 SET status = 'cancelled',
     decision_reason = sqlc.arg(reason),
     decided_at = now()
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id)
   AND session_id = sqlc.arg(session_id)
   AND status = 'pending'
 RETURNING *;
@@ -119,7 +126,8 @@ RETURNING *;
 -- name: ListPendingToolApprovalsBySession :many
 SELECT *
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND status = 'pending'
 ORDER BY created_at ASC, short_id ASC;
@@ -127,14 +135,16 @@ ORDER BY created_at ASC, short_id ASC;
 -- name: ListToolApprovalsBySession :many
 SELECT *
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
 ORDER BY created_at ASC, short_id ASC;
 
 -- name: ListToolApprovalsBySessionToolCalls :many
 SELECT *
 FROM tool_approval_requests
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id)
   AND session_id = sqlc.arg(session_id)
   AND tool_call_id = ANY(sqlc.arg(tool_call_ids)::text[])
 ORDER BY created_at ASC, short_id ASC;

--- a/db/postgres/queries/user_input.sql
+++ b/db/postgres/queries/user_input.sql
@@ -2,13 +2,15 @@
 WITH locked_session AS (
   SELECT id
   FROM bot_sessions
-  WHERE id = sqlc.arg(session_id)
+  WHERE team_id = public.memoh_current_team_id()
+    AND id = sqlc.arg(session_id)
   FOR UPDATE
 ),
 next_short_id AS (
   SELECT COALESCE(MAX(user_input_requests.short_id), 0) + 1 AS short_id
   FROM locked_session
   LEFT JOIN user_input_requests ON user_input_requests.session_id = locked_session.id
+    AND user_input_requests.team_id = public.memoh_current_team_id()
 )
 INSERT INTO user_input_requests (
   bot_id,
@@ -46,7 +48,7 @@ INSERT INTO user_input_requests (
   sqlc.narg(expires_at)
 FROM locked_session
 CROSS JOIN next_short_id
-ON CONFLICT (session_id, tool_call_id) DO UPDATE
+ON CONFLICT (team_id, session_id, tool_call_id) DO UPDATE
 SET input_json = EXCLUDED.input_json,
     ui_payload_json = EXCLUDED.ui_payload_json,
     provider_metadata = EXCLUDED.provider_metadata,
@@ -64,18 +66,20 @@ RETURNING *;
 -- name: GetUserInputRequest :one
 SELECT *
 FROM user_input_requests
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: GetUserInputRequestBySessionToolCall :one
 SELECT *
 FROM user_input_requests
-WHERE session_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND session_id = $1
   AND tool_call_id = $2;
 
 -- name: GetPendingUserInputBySessionShortID :one
 SELECT *
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND short_id = $3
   AND status = 'pending'
@@ -84,7 +88,8 @@ WHERE bot_id = $1
 -- name: GetLatestPendingUserInputBySession :one
 SELECT *
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
@@ -94,7 +99,8 @@ LIMIT 1;
 -- name: GetPendingUserInputByReplyMessage :one
 SELECT *
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND prompt_external_message_id = $3
   AND status = 'pending'
@@ -107,7 +113,7 @@ UPDATE user_input_requests
 SET prompt_message_id = sqlc.narg(prompt_message_id),
     prompt_external_message_id = sqlc.arg(prompt_external_message_id),
     updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: UpdateUserInputInteraction :one
@@ -125,14 +131,14 @@ RETURNING *;
 UPDATE user_input_requests
 SET assistant_message_id = sqlc.narg(assistant_message_id),
     updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: UpdateUserInputToolResultMessage :one
 UPDATE user_input_requests
 SET tool_result_message_id = sqlc.narg(tool_result_message_id),
     updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(id)
 RETURNING *;
 
 -- name: SubmitUserInputRequest :one
@@ -142,7 +148,8 @@ SET status = 'submitted',
     responded_by_channel_identity_id = sqlc.narg(responded_by_channel_identity_id),
     responded_at = now(),
     updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id()
+  AND id = sqlc.arg(id)
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
 RETURNING *;
@@ -155,7 +162,8 @@ SET status = 'canceled',
     responded_at = now(),
     canceled_at = now(),
     updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id()
+  AND id = sqlc.arg(id)
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
 RETURNING *;
@@ -167,7 +175,8 @@ SET status = 'canceled',
     responded_at = now(),
     canceled_at = now(),
     updated_at = now()
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id)
   AND session_id = sqlc.arg(session_id)
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
@@ -178,7 +187,8 @@ UPDATE user_input_requests
 SET status = 'failed',
     result_json = sqlc.arg(result_json),
     updated_at = now()
-WHERE id = sqlc.arg(id)
+WHERE team_id = public.memoh_current_team_id()
+  AND id = sqlc.arg(id)
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
 RETURNING *;
@@ -186,7 +196,8 @@ RETURNING *;
 -- name: ListPendingUserInputsBySession :many
 SELECT *
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
@@ -195,14 +206,16 @@ ORDER BY created_at ASC, short_id ASC;
 -- name: ListUserInputsBySession :many
 SELECT *
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
 ORDER BY created_at ASC, short_id ASC;
 
 -- name: ListUserInputsBySessionToolCalls :many
 SELECT *
 FROM user_input_requests
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id)
   AND session_id = sqlc.arg(session_id)
   AND tool_call_id = ANY(sqlc.arg(tool_call_ids)::text[])
 ORDER BY created_at ASC, short_id ASC;

--- a/db/postgres/queries/user_provider_oauth.sql
+++ b/db/postgres/queries/user_provider_oauth.sql
@@ -26,7 +26,7 @@ VALUES (
   sqlc.arg(pkce_code_verifier),
   sqlc.arg(metadata)
 )
-ON CONFLICT (provider_id, user_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id, user_id) DO UPDATE SET
   access_token = EXCLUDED.access_token,
   refresh_token = EXCLUDED.refresh_token,
   expires_at = EXCLUDED.expires_at,
@@ -40,12 +40,12 @@ RETURNING *;
 
 -- name: GetUserProviderOAuthToken :one
 SELECT * FROM user_provider_oauth_tokens
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND user_id = sqlc.arg(user_id);
 
 -- name: GetUserProviderOAuthTokenByState :one
 SELECT * FROM user_provider_oauth_tokens
-WHERE state = sqlc.arg(state)
+WHERE team_id = public.memoh_current_team_id() AND state = sqlc.arg(state)
   AND state != '';
 
 -- name: UpdateUserProviderOAuthState :exec
@@ -57,7 +57,7 @@ VALUES (
   sqlc.arg(pkce_code_verifier),
   sqlc.arg(metadata)
 )
-ON CONFLICT (provider_id, user_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id, user_id) DO UPDATE SET
   state = EXCLUDED.state,
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
   metadata = EXCLUDED.metadata,
@@ -65,5 +65,5 @@ ON CONFLICT (provider_id, user_id) DO UPDATE SET
 
 -- name: DeleteUserProviderOAuthToken :exec
 DELETE FROM user_provider_oauth_tokens
-WHERE provider_id = sqlc.arg(provider_id)
+WHERE team_id = public.memoh_current_team_id() AND provider_id = sqlc.arg(provider_id)
   AND user_id = sqlc.arg(user_id);

--- a/db/postgres/queries/user_runtimes.sql
+++ b/db/postgres/queries/user_runtimes.sql
@@ -8,19 +8,23 @@ SELECT runtime.*
 FROM user_runtimes runtime
 JOIN users owner
   ON owner.id = runtime.user_id
+ AND owner.team_id = public.memoh_current_team_id()
  AND owner.is_active = TRUE
-WHERE runtime.api_token = sqlc.arg(api_token)
+WHERE runtime.team_id = public.memoh_current_team_id()
+  AND runtime.api_token = sqlc.arg(api_token)
   AND runtime.revoked_at IS NULL;
 
 -- name: ListUserRuntimes :many
 SELECT * FROM user_runtimes
-WHERE user_id = sqlc.arg(user_id) AND revoked_at IS NULL
+WHERE team_id = public.memoh_current_team_id()
+  AND user_id = sqlc.arg(user_id) AND revoked_at IS NULL
 ORDER BY created_at ASC, id ASC;
 
 -- name: RevokeUserRuntime :one
 UPDATE user_runtimes
 SET revoked_at = now(), updated_at = now()
-WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id) AND revoked_at IS NULL
+WHERE team_id = public.memoh_current_team_id()
+  AND id = sqlc.arg(id) AND user_id = sqlc.arg(user_id) AND revoked_at IS NULL
 RETURNING *;
 
 -- name: CreateOrUpdateBotRemoteRuntimeMount :one
@@ -29,13 +33,16 @@ SELECT b.id, r.id, sqlc.arg(workspace_path)
 FROM bots b
 JOIN user_runtimes r
   ON r.id = sqlc.arg(runtime_id)
+ AND r.team_id = public.memoh_current_team_id()
  AND r.user_id = b.owner_user_id
  AND r.revoked_at IS NULL
 JOIN users owner
   ON owner.id = b.owner_user_id
+ AND owner.team_id = public.memoh_current_team_id()
  AND owner.is_active = TRUE
-WHERE b.id = sqlc.arg(bot_id)
-ON CONFLICT (bot_id, runtime_id) DO UPDATE SET
+WHERE b.team_id = public.memoh_current_team_id()
+  AND b.id = sqlc.arg(bot_id)
+ON CONFLICT (team_id, bot_id, runtime_id) DO UPDATE SET
   workspace_path = EXCLUDED.workspace_path,
   updated_at = now()
 RETURNING id;
@@ -55,10 +62,11 @@ SELECT
   (runtime.revoked_at IS NOT NULL OR NOT owner.is_active) AS runtime_unavailable,
   bot.owner_user_id AS bot_owner_user_id
 FROM bot_remote_runtime_bindings binding
-JOIN user_runtimes runtime ON runtime.id = binding.runtime_id
-JOIN bots bot ON bot.id = binding.bot_id
-JOIN users owner ON owner.id = bot.owner_user_id
-WHERE binding.bot_id = sqlc.arg(bot_id)
+JOIN user_runtimes runtime ON runtime.id = binding.runtime_id AND runtime.team_id = public.memoh_current_team_id()
+JOIN bots bot ON bot.id = binding.bot_id AND bot.team_id = public.memoh_current_team_id()
+JOIN users owner ON owner.id = bot.owner_user_id AND owner.team_id = public.memoh_current_team_id()
+WHERE binding.team_id = public.memoh_current_team_id()
+  AND binding.bot_id = sqlc.arg(bot_id)
 ORDER BY binding.created_at ASC, binding.id ASC;
 
 -- name: GetBotRemoteRuntimeMount :one
@@ -76,10 +84,11 @@ SELECT
   (runtime.revoked_at IS NOT NULL OR NOT owner.is_active) AS runtime_unavailable,
   bot.owner_user_id AS bot_owner_user_id
 FROM bot_remote_runtime_bindings binding
-JOIN user_runtimes runtime ON runtime.id = binding.runtime_id
-JOIN bots bot ON bot.id = binding.bot_id
-JOIN users owner ON owner.id = bot.owner_user_id
-WHERE binding.bot_id = sqlc.arg(bot_id)
+JOIN user_runtimes runtime ON runtime.id = binding.runtime_id AND runtime.team_id = public.memoh_current_team_id()
+JOIN bots bot ON bot.id = binding.bot_id AND bot.team_id = public.memoh_current_team_id()
+JOIN users owner ON owner.id = bot.owner_user_id AND owner.team_id = public.memoh_current_team_id()
+WHERE binding.team_id = public.memoh_current_team_id()
+  AND binding.bot_id = sqlc.arg(bot_id)
   AND binding.id = sqlc.arg(target_id);
 
 -- name: GetPrimaryBotRemoteRuntimeMount :one
@@ -97,35 +106,40 @@ SELECT
   (runtime.revoked_at IS NOT NULL OR NOT owner.is_active) AS runtime_unavailable,
   bot.owner_user_id AS bot_owner_user_id
 FROM bot_remote_runtime_bindings binding
-JOIN user_runtimes runtime ON runtime.id = binding.runtime_id
-JOIN bots bot ON bot.id = binding.bot_id
-JOIN users owner ON owner.id = bot.owner_user_id
-WHERE binding.bot_id = sqlc.arg(bot_id)
+JOIN user_runtimes runtime ON runtime.id = binding.runtime_id AND runtime.team_id = public.memoh_current_team_id()
+JOIN bots bot ON bot.id = binding.bot_id AND bot.team_id = public.memoh_current_team_id()
+JOIN users owner ON owner.id = bot.owner_user_id AND owner.team_id = public.memoh_current_team_id()
+WHERE binding.team_id = public.memoh_current_team_id()
+  AND binding.bot_id = sqlc.arg(bot_id)
   AND binding.is_primary = TRUE;
 
 -- name: ClearBotRemoteRuntimePrimary :exec
 UPDATE bot_remote_runtime_bindings
 SET is_primary = FALSE,
     updated_at = CASE WHEN is_primary THEN now() ELSE updated_at END
-WHERE bot_id = sqlc.arg(bot_id);
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id);
 
 -- name: SetBotRemoteRuntimePrimary :execrows
 UPDATE bot_remote_runtime_bindings
 SET is_primary = TRUE,
     updated_at = CASE WHEN is_primary THEN updated_at ELSE now() END
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id)
   AND id = sqlc.arg(target_id);
 
 -- name: UpdateBotRemoteRuntimeMountToolApproval :one
 UPDATE bot_remote_runtime_bindings
 SET tool_approval_config = sqlc.arg(tool_approval_config),
     updated_at = now()
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id)
   AND id = sqlc.arg(target_id)
 RETURNING id;
 
 -- name: DeleteBotRemoteRuntimeMount :one
 DELETE FROM bot_remote_runtime_bindings
-WHERE bot_id = sqlc.arg(bot_id)
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = sqlc.arg(bot_id)
   AND id = sqlc.arg(target_id)
 RETURNING id;

--- a/db/postgres/queries/users.sql
+++ b/db/postgres/queries/users.sql
@@ -6,7 +6,7 @@ RETURNING *;
 -- name: GetUserByID :one
 SELECT *
 FROM users
-WHERE id = $1;
+WHERE team_id = public.memoh_current_team_id() AND id = $1;
 
 -- name: CreateAccount :one
 UPDATE users
@@ -19,7 +19,7 @@ SET username = sqlc.arg(username),
     is_active = sqlc.arg(is_active),
     data_root = sqlc.arg(data_root),
     updated_at = now()
-WHERE id = sqlc.arg(user_id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(user_id)
 RETURNING *;
 
 -- name: UpsertAccountByUsername :one
@@ -36,7 +36,7 @@ VALUES (
   sqlc.arg(data_root),
   '{}'::jsonb
 )
-ON CONFLICT (username) DO UPDATE SET
+ON CONFLICT (team_id, username) DO UPDATE SET
   email = EXCLUDED.email,
   password_hash = EXCLUDED.password_hash,
   role = EXCLUDED.role,
@@ -48,26 +48,28 @@ ON CONFLICT (username) DO UPDATE SET
 RETURNING *;
 
 -- name: GetAccountByIdentity :one
-SELECT * FROM users WHERE username = sqlc.arg(identity) OR email = sqlc.arg(identity);
+SELECT * FROM users WHERE team_id = public.memoh_current_team_id() AND (username = sqlc.arg(identity) OR email = sqlc.arg(identity));
 
 -- name: GetAccountByUserID :one
-SELECT * FROM users WHERE id = sqlc.arg(user_id);
+SELECT * FROM users WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(user_id);
 
 -- name: CountAccounts :one
 SELECT COUNT(*)::bigint AS count
 FROM users
-WHERE username IS NOT NULL
+WHERE team_id = public.memoh_current_team_id()
+  AND username IS NOT NULL
   AND password_hash IS NOT NULL;
 
 -- name: ListAccounts :many
 SELECT * FROM users
-WHERE username IS NOT NULL
+WHERE team_id = public.memoh_current_team_id() AND username IS NOT NULL
 ORDER BY created_at DESC;
 
 -- name: SearchAccounts :many
 SELECT *
 FROM users
-WHERE username IS NOT NULL
+WHERE team_id = public.memoh_current_team_id()
+  AND username IS NOT NULL
   AND (
     sqlc.arg(query)::text = ''
     OR username ILIKE '%' || sqlc.arg(query)::text || '%'
@@ -85,7 +87,7 @@ SET display_name = $2,
     is_active = $5,
     metadata = $6,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING *;
 
 -- name: UpdateAccountAdmin :one
@@ -95,14 +97,14 @@ SET role = sqlc.arg(role)::user_role,
     avatar_url = sqlc.arg(avatar_url),
     is_active = sqlc.arg(is_active),
     updated_at = now()
-WHERE id = sqlc.arg(user_id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(user_id)
 RETURNING *;
 
 -- name: UpdateAccountPassword :one
 UPDATE users
 SET password_hash = $2,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING *;
 
 -- name: RemoveMember :one
@@ -115,12 +117,12 @@ SET username = NULL,
     data_root = NULL,
     is_active = FALSE,
     updated_at = now()
-WHERE id = sqlc.arg(user_id)
+WHERE team_id = public.memoh_current_team_id() AND id = sqlc.arg(user_id)
 RETURNING id;
 
 -- name: UpdateAccountLastLogin :one
 UPDATE users
 SET last_login_at = now(),
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING *;

--- a/db/postgres/queries/versions.sql
+++ b/db/postgres/queries/versions.sql
@@ -9,11 +9,11 @@ SELECT
   s.display_name
 FROM container_versions cv
 JOIN snapshots s ON s.id = cv.snapshot_id
-WHERE cv.container_id = sqlc.arg(container_id)
+WHERE cv.team_id = public.memoh_current_team_id() AND s.team_id = public.memoh_current_team_id() AND cv.container_id = sqlc.arg(container_id)
 ORDER BY cv.version ASC;
 
 -- name: NextVersion :one
-SELECT COALESCE(MAX(version), 0) + 1 FROM container_versions WHERE container_id = sqlc.arg(container_id);
+SELECT COALESCE(MAX(version), 0) + 1 FROM container_versions WHERE team_id = public.memoh_current_team_id() AND container_id = sqlc.arg(container_id);
 
 -- name: InsertVersion :one
 INSERT INTO container_versions (container_id, snapshot_id, version)
@@ -22,11 +22,11 @@ VALUES (
   sqlc.arg(snapshot_id),
   sqlc.arg(version)
 )
-RETURNING id, container_id, snapshot_id, version, created_at;
+RETURNING id, container_id, snapshot_id, version, created_at, team_id;
 
 -- name: GetVersionSnapshotRuntimeName :one
 SELECT s.runtime_snapshot_name
 FROM container_versions cv
 JOIN snapshots s ON s.id = cv.snapshot_id
-WHERE cv.container_id = sqlc.arg(container_id)
+WHERE cv.team_id = public.memoh_current_team_id() AND s.team_id = public.memoh_current_team_id() AND cv.container_id = sqlc.arg(container_id)
   AND cv.version = sqlc.arg(version);

--- a/db/postgres/queries/workspace_resource_limits.sql
+++ b/db/postgres/queries/workspace_resource_limits.sql
@@ -1,5 +1,5 @@
 -- name: GetBotWorkspaceResourceLimits :one
-SELECT * FROM bot_workspace_resource_limits WHERE bot_id = sqlc.arg(bot_id);
+SELECT * FROM bot_workspace_resource_limits WHERE team_id = public.memoh_current_team_id() AND bot_id = sqlc.arg(bot_id);
 
 -- name: UpsertBotWorkspaceResourceLimits :one
 INSERT INTO bot_workspace_resource_limits (
@@ -11,7 +11,7 @@ VALUES (
   sqlc.arg(memory_bytes),
   sqlc.arg(storage_bytes)
 )
-ON CONFLICT (bot_id) DO UPDATE SET
+ON CONFLICT (team_id, bot_id) DO UPDATE SET
   cpu_millicores = EXCLUDED.cpu_millicores,
   memory_bytes = EXCLUDED.memory_bytes,
   storage_bytes = EXCLUDED.storage_bytes,

--- a/internal/agent/tools/memory.go
+++ b/internal/agent/tools/memory.go
@@ -97,7 +97,7 @@ func (p *MemoryProvider) resolveProvider(ctx context.Context, botID string) memp
 	if providerID == "" {
 		return nil
 	}
-	prov, err := p.registry.Get(providerID)
+	prov, err := p.registry.Get(ctx, providerID)
 	if err != nil {
 		return nil
 	}

--- a/internal/bots/service_test.go
+++ b/internal/bots/service_test.go
@@ -182,7 +182,7 @@ func TestCreateRejectsUnknownACLPreset(t *testing.T) {
 	db := &fakeDBTX{
 		queryRowFunc: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "FROM users") && strings.Contains(sql, "WHERE id = $1"):
+			case strings.Contains(sql, "FROM users") && strings.Contains(sql, "id = $1"):
 				return &fakeRow{scanFunc: func(_ ...any) error { return nil }}
 			case strings.Contains(sql, "INSERT INTO bots"):
 				createCalled = true
@@ -213,7 +213,7 @@ func TestCreateTreatsStoreNotFoundAsMissingOwner(t *testing.T) {
 	dbtx := &fakeDBTX{
 		queryRowFunc: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "FROM users") && strings.Contains(sql, "WHERE id = $1"):
+			case strings.Contains(sql, "FROM users") && strings.Contains(sql, "id = $1"):
 				return &fakeRow{scanFunc: func(_ ...any) error { return db.ErrNotFound }}
 			case strings.Contains(sql, "INSERT INTO bots"):
 				createCalled = true

--- a/internal/channel/adapters/dingtalk/dingtalk.go
+++ b/internal/channel/adapters/dingtalk/dingtalk.go
@@ -26,7 +26,7 @@ type DingTalkAdapter struct {
 	clients    map[string]*dtsdk.StreamClient
 	apiClients map[string]*apiClient
 
-	// webhookCache stores recent sessionWebhook contexts keyed by msgId.
+	// webhookCache stores recent sessionWebhook contexts by config ID and msgId.
 	webhookCache *sessionWebhookCache
 }
 
@@ -202,7 +202,7 @@ func (a *DingTalkAdapter) Send(ctx context.Context, cfg channel.ChannelConfig, m
 	// Session webhook fast path: immediate reply without access_token round-trip.
 	// Webhooks only support text/markdown; attachments fall through to the OpenAPI.
 	if len(msg.Message.Attachments) == 0 {
-		if whCtx, ok := a.lookupWebhook(logicalMsg.Reply); ok && whCtx.isValid() {
+		if whCtx, ok := a.lookupWebhook(cfg.ID, logicalMsg.Reply); ok && whCtx.isValid() {
 			body, bodyErr := buildWebhookBody(logicalMsg)
 			if bodyErr == nil {
 				apiCli := a.getOrNewAPIClient(cfg)
@@ -376,7 +376,7 @@ func (a *DingTalkAdapter) newChatBotHandler(cfg channel.ChannelConfig, handler c
 
 		// Cache the session webhook so that Send can use the fast-reply path.
 		if strings.TrimSpace(data.MsgId) != "" && strings.TrimSpace(data.SessionWebhook) != "" {
-			a.rememberWebhook(data.MsgId, sessionWebhookContext{
+			a.rememberWebhook(cfg.ID, data.MsgId, sessionWebhookContext{
 				SessionWebhook: data.SessionWebhook,
 				ExpiredTime:    data.SessionWebhookExpiredTime,
 				ConversationID: data.ConversationId,
@@ -424,7 +424,7 @@ func (a *DingTalkAdapter) getOrNewAPIClient(cfg channel.ChannelConfig) *apiClien
 	return newAPIClient(parsed.AppKey, parsed.AppSecret)
 }
 
-func (a *DingTalkAdapter) lookupWebhook(reply *channel.ReplyRef) (sessionWebhookContext, bool) {
+func (a *DingTalkAdapter) lookupWebhook(configID string, reply *channel.ReplyRef) (sessionWebhookContext, bool) {
 	if reply == nil {
 		return sessionWebhookContext{}, false
 	}
@@ -432,10 +432,10 @@ func (a *DingTalkAdapter) lookupWebhook(reply *channel.ReplyRef) (sessionWebhook
 	if msgID == "" {
 		return sessionWebhookContext{}, false
 	}
-	return a.webhookCache.get(msgID)
+	return a.webhookCache.get(configID, msgID)
 }
 
-func (a *DingTalkAdapter) rememberWebhook(msgID string, whCtx sessionWebhookContext) {
+func (a *DingTalkAdapter) rememberWebhook(configID, msgID string, whCtx sessionWebhookContext) {
 	msgID = strings.TrimSpace(msgID)
 	if msgID == "" || strings.TrimSpace(whCtx.SessionWebhook) == "" {
 		return
@@ -443,5 +443,5 @@ func (a *DingTalkAdapter) rememberWebhook(msgID string, whCtx sessionWebhookCont
 	if whCtx.CreatedAt.IsZero() {
 		whCtx.CreatedAt = time.Now().UTC()
 	}
-	a.webhookCache.put(msgID, whCtx)
+	a.webhookCache.put(configID, msgID, whCtx)
 }

--- a/internal/channel/adapters/dingtalk/inbound.go
+++ b/internal/channel/adapters/dingtalk/inbound.go
@@ -31,7 +31,9 @@ func (w sessionWebhookContext) isValid() bool {
 	return time.Now().UnixMilli() < w.ExpiredTime
 }
 
-// sessionWebhookCache stores recent sessionWebhook contexts keyed by msgId.
+// sessionWebhookCache stores recent sessionWebhook contexts by channel config
+// and msgId. DingTalk message IDs are external-account scoped, so msgId alone
+// cannot isolate multiple configured bots in the same process.
 type sessionWebhookCache struct {
 	mu    sync.RWMutex
 	items map[string]sessionWebhookContext
@@ -48,8 +50,8 @@ func newSessionWebhookCache(ttl time.Duration) *sessionWebhookCache {
 	}
 }
 
-func (c *sessionWebhookCache) put(msgID string, ctx sessionWebhookContext) {
-	key := strings.TrimSpace(msgID)
+func (c *sessionWebhookCache) put(configID, msgID string, ctx sessionWebhookContext) {
+	key := sessionWebhookCacheKey(configID, msgID)
 	if key == "" {
 		return
 	}
@@ -62,8 +64,8 @@ func (c *sessionWebhookCache) put(msgID string, ctx sessionWebhookContext) {
 	c.mu.Unlock()
 }
 
-func (c *sessionWebhookCache) get(msgID string) (sessionWebhookContext, bool) {
-	key := strings.TrimSpace(msgID)
+func (c *sessionWebhookCache) get(configID, msgID string) (sessionWebhookContext, bool) {
+	key := sessionWebhookCacheKey(configID, msgID)
 	if key == "" {
 		return sessionWebhookContext{}, false
 	}
@@ -80,6 +82,15 @@ func (c *sessionWebhookCache) get(msgID string) (sessionWebhookContext, bool) {
 		return sessionWebhookContext{}, false
 	}
 	return item, true
+}
+
+func sessionWebhookCacheKey(configID, msgID string) string {
+	configID = strings.TrimSpace(configID)
+	msgID = strings.TrimSpace(msgID)
+	if configID == "" || msgID == "" {
+		return ""
+	}
+	return configID + "\x00" + msgID
 }
 
 func (c *sessionWebhookCache) gcLocked() {

--- a/internal/channel/adapters/dingtalk/stream_test.go
+++ b/internal/channel/adapters/dingtalk/stream_test.go
@@ -86,11 +86,11 @@ func TestOutboundStreamRejectsPushAfterClose(t *testing.T) {
 
 func TestSessionWebhookCacheExpiryAndValidity(t *testing.T) {
 	cache := newSessionWebhookCache(time.Hour)
-	cache.put("msg-1", sessionWebhookContext{
+	cache.put("config-a", "msg-1", sessionWebhookContext{
 		SessionWebhook: "https://example.com/hook",
 		ExpiredTime:    time.Now().Add(time.Minute).UnixMilli(),
 	})
-	got, ok := cache.get("msg-1")
+	got, ok := cache.get("config-a", "msg-1")
 	if !ok {
 		t.Fatal("expected cached webhook")
 	}
@@ -98,17 +98,38 @@ func TestSessionWebhookCacheExpiryAndValidity(t *testing.T) {
 		t.Fatal("expected webhook to be valid")
 	}
 
-	cache.put("msg-2", sessionWebhookContext{
+	cache.put("config-a", "msg-2", sessionWebhookContext{
 		SessionWebhook: "https://example.com/old",
 		ExpiredTime:    time.Now().Add(time.Minute).UnixMilli(),
 		CreatedAt:      time.Now().Add(-2 * time.Hour),
 	})
-	if _, ok := cache.get("msg-2"); ok {
+	if _, ok := cache.get("config-a", "msg-2"); ok {
 		t.Fatal("expected stale webhook to be evicted")
 	}
 
 	if (sessionWebhookContext{SessionWebhook: "https://example.com/expired", ExpiredTime: time.Now().Add(-time.Second).UnixMilli()}).isValid() {
 		t.Fatal("expected expired webhook to be invalid")
+	}
+}
+
+func TestSessionWebhookCacheIsScopedByConfig(t *testing.T) {
+	cache := newSessionWebhookCache(time.Hour)
+	cache.put("config-a", "shared-message", sessionWebhookContext{
+		SessionWebhook: "https://example.com/config-a",
+		ExpiredTime:    time.Now().Add(time.Minute).UnixMilli(),
+	})
+	cache.put("config-b", "shared-message", sessionWebhookContext{
+		SessionWebhook: "https://example.com/config-b",
+		ExpiredTime:    time.Now().Add(time.Minute).UnixMilli(),
+	})
+
+	first, ok := cache.get("config-a", "shared-message")
+	if !ok || first.SessionWebhook != "https://example.com/config-a" {
+		t.Fatalf("config-a webhook = %#v, found=%v", first, ok)
+	}
+	second, ok := cache.get("config-b", "shared-message")
+	if !ok || second.SessionWebhook != "https://example.com/config-b" {
+		t.Fatalf("config-b webhook = %#v, found=%v", second, ok)
 	}
 }
 

--- a/internal/channel/adapters/discord/discord.go
+++ b/internal/channel/adapters/discord/discord.go
@@ -36,9 +36,9 @@ type assetOpener interface {
 type DiscordAdapter struct {
 	logger          *slog.Logger
 	mu              sync.RWMutex
-	sessions        map[string]*discordgo.Session // keyed by bot token
-	handlerRemovers map[string]func()             // keyed by bot token
-	seenMessages    map[string]time.Time          // keyed by token:messageID
+	sessions        map[string]*discordgo.Session // keyed by config ID + bot token
+	handlerRemovers map[string]func()             // keyed by config ID + bot token
+	seenMessages    map[string]time.Time          // keyed by config ID + message ID
 	assets          assetOpener
 }
 
@@ -112,8 +112,9 @@ func (*DiscordAdapter) Descriptor() channel.Descriptor {
 
 func (a *DiscordAdapter) getOrCreateSession(token, configID string) (*discordgo.Session, error) {
 	channel.SetIMErrorSecrets("discord:"+configID, token)
+	cacheKey := discordSessionCacheKey(configID, token)
 	a.mu.RLock()
-	session, ok := a.sessions[token]
+	session, ok := a.sessions[cacheKey]
 	a.mu.RUnlock()
 	if ok {
 		return session, nil
@@ -121,7 +122,7 @@ func (a *DiscordAdapter) getOrCreateSession(token, configID string) (*discordgo.
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if s, ok := a.sessions[token]; ok {
+	if s, ok := a.sessions[cacheKey]; ok {
 		return s, nil
 	}
 
@@ -133,8 +134,12 @@ func (a *DiscordAdapter) getOrCreateSession(token, configID string) (*discordgo.
 
 	session.Identify.Intents = discordgo.IntentsAll
 
-	a.sessions[token] = session
+	a.sessions[cacheKey] = session
 	return session, nil
+}
+
+func discordSessionCacheKey(configID, token string) string {
+	return strings.TrimSpace(configID) + "\x00" + strings.TrimSpace(token)
 }
 
 func (a *DiscordAdapter) Connect(ctx context.Context, cfg channel.ChannelConfig, handler channel.InboundHandler) (channel.Connection, error) {
@@ -161,7 +166,7 @@ func (a *DiscordAdapter) Connect(ctx context.Context, cfg channel.ChannelConfig,
 			return
 		}
 
-		if a.isDuplicateInbound(discordCfg.BotToken, m.ID) {
+		if a.isDuplicateInbound(cfg.ID, m.ID) {
 			return
 		}
 
@@ -253,7 +258,8 @@ func (a *DiscordAdapter) Connect(ctx context.Context, cfg channel.ChannelConfig,
 		}()
 	})
 
-	a.swapHandlerRemover(discordCfg.BotToken, remove)
+	sessionKey := discordSessionCacheKey(cfg.ID, discordCfg.BotToken)
+	a.swapHandlerRemover(sessionKey, remove)
 
 	if err := session.Open(); err != nil {
 		return nil, fmt.Errorf("discord open connection: %w", err)
@@ -263,7 +269,7 @@ func (a *DiscordAdapter) Connect(ctx context.Context, cfg channel.ChannelConfig,
 		if a.logger != nil {
 			a.logger.Info("stop", slog.String("config_id", cfg.ID))
 		}
-		remove := a.clearSessionState(discordCfg.BotToken)
+		remove := a.clearSessionState(sessionKey)
 		if remove != nil {
 			remove()
 		}
@@ -708,8 +714,8 @@ func (*DiscordAdapter) isBotMentioned(msg *discordgo.Message, botID string) bool
 		strings.Contains(content, strings.ToLower(botNickMention))
 }
 
-func (a *DiscordAdapter) isDuplicateInbound(token, messageID string) bool {
-	if strings.TrimSpace(token) == "" || strings.TrimSpace(messageID) == "" {
+func (a *DiscordAdapter) isDuplicateInbound(configID, messageID string) bool {
+	if strings.TrimSpace(configID) == "" || strings.TrimSpace(messageID) == "" {
 		return false
 	}
 
@@ -725,7 +731,7 @@ func (a *DiscordAdapter) isDuplicateInbound(token, messageID string) bool {
 		}
 	}
 
-	seenKey := token + ":" + messageID
+	seenKey := configID + ":" + messageID
 	if _, ok := a.seenMessages[seenKey]; ok {
 		return true
 	}
@@ -733,20 +739,20 @@ func (a *DiscordAdapter) isDuplicateInbound(token, messageID string) bool {
 	return false
 }
 
-func (a *DiscordAdapter) swapHandlerRemover(token string, remove func()) {
+func (a *DiscordAdapter) swapHandlerRemover(sessionKey string, remove func()) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if oldRemove := a.handlerRemovers[token]; oldRemove != nil {
+	if oldRemove := a.handlerRemovers[sessionKey]; oldRemove != nil {
 		oldRemove()
 	}
-	a.handlerRemovers[token] = remove
+	a.handlerRemovers[sessionKey] = remove
 }
 
-func (a *DiscordAdapter) clearSessionState(token string) func() {
+func (a *DiscordAdapter) clearSessionState(sessionKey string) func() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	remove := a.handlerRemovers[token]
-	delete(a.handlerRemovers, token)
-	delete(a.sessions, token)
+	remove := a.handlerRemovers[sessionKey]
+	delete(a.handlerRemovers, sessionKey)
+	delete(a.sessions, sessionKey)
 	return remove
 }

--- a/internal/channel/adapters/discord/discord_test.go
+++ b/internal/channel/adapters/discord/discord_test.go
@@ -22,6 +22,39 @@ func TestDiscordDescriptorAdvertisesRichText(t *testing.T) {
 	}
 }
 
+func TestDiscordRuntimeStateIsScopedByConfig(t *testing.T) {
+	adapter := NewDiscordAdapter(nil)
+
+	first, err := adapter.getOrCreateSession("shared-token", "config-a")
+	if err != nil {
+		t.Fatalf("create first session: %v", err)
+	}
+	firstAgain, err := adapter.getOrCreateSession("shared-token", "config-a")
+	if err != nil {
+		t.Fatalf("reuse first session: %v", err)
+	}
+	second, err := adapter.getOrCreateSession("shared-token", "config-b")
+	if err != nil {
+		t.Fatalf("create second session: %v", err)
+	}
+	if firstAgain != first {
+		t.Fatal("same config and credentials must reuse its Discord session")
+	}
+	if second == first {
+		t.Fatal("different configs must not share a Discord session even when credentials match")
+	}
+
+	if adapter.isDuplicateInbound("config-a", "message-1") {
+		t.Fatal("first config-a message must not be a duplicate")
+	}
+	if !adapter.isDuplicateInbound("config-a", "message-1") {
+		t.Fatal("repeated config-a message must be a duplicate")
+	}
+	if adapter.isDuplicateInbound("config-b", "message-1") {
+		t.Fatal("same external message ID under another config must not collide")
+	}
+}
+
 func TestDiscordDescriptorAdvertisesURLButtonsOnly(t *testing.T) {
 	t.Parallel()
 

--- a/internal/channel/adapters/telegram/telegram.go
+++ b/internal/channel/adapters/telegram/telegram.go
@@ -129,11 +129,7 @@ func (a *TelegramAdapter) getOrCreateBot(cfg Config, configID string) (*tele.Bot
 	if getOrCreateBotForTest != nil {
 		return getOrCreateBotForTest(a, cfg.BotToken, configID)
 	}
-	cacheKey := strings.Join([]string{
-		cfg.BotToken,
-		cfg.baseURL(),
-		cfg.HTTPProxy.CacheKey(),
-	}, "\x00")
+	cacheKey := telegramBotCacheKey(cfg, configID)
 	a.mu.RLock()
 	bot, ok := a.bots[cacheKey]
 	a.mu.RUnlock()
@@ -171,6 +167,15 @@ func (a *TelegramAdapter) getOrCreateBot(cfg Config, configID string) (*tele.Bot
 	a.bots[cacheKey] = bot
 	a.fileEndpoints[bot] = cfg.fileEndpoint()
 	return bot, nil
+}
+
+func telegramBotCacheKey(cfg Config, configID string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(configID),
+		cfg.BotToken,
+		cfg.baseURL(),
+		cfg.HTTPProxy.CacheKey(),
+	}, "\x00")
 }
 
 // getFileDirectURL resolves a file ID to a direct download URL,

--- a/internal/channel/adapters/telegram/telegram_test.go
+++ b/internal/channel/adapters/telegram/telegram_test.go
@@ -596,6 +596,19 @@ func TestSeenTelegramUpdate(t *testing.T) {
 	}
 }
 
+func TestTelegramBotCacheKeyIsScopedByConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{BotToken: "shared-token"}
+	first := telegramBotCacheKey(cfg, "config-a")
+	if got := telegramBotCacheKey(cfg, "config-a"); got != first {
+		t.Fatalf("same config cache key changed: %q != %q", got, first)
+	}
+	if second := telegramBotCacheKey(cfg, "config-b"); second == first {
+		t.Fatal("different configs must not share a Telegram bot cache key")
+	}
+}
+
 func TestIsTelegramMediaGroupForChat(t *testing.T) {
 	t.Parallel()
 

--- a/internal/channel/adapters/wecom/adapter_integration_test.go
+++ b/internal/channel/adapters/wecom/adapter_integration_test.go
@@ -94,6 +94,7 @@ func TestWeComAdapter_ReplyUsesRespondCmd(t *testing.T) {
 
 	adapter := NewWeComAdapter(nil)
 	cfg := channel.ChannelConfig{
+		ID: "config-a",
 		Credentials: map[string]any{
 			"botId":  "bot",
 			"secret": "sec",

--- a/internal/channel/adapters/wecom/callback_cache.go
+++ b/internal/channel/adapters/wecom/callback_cache.go
@@ -30,8 +30,8 @@ func newCallbackContextCache(ttl time.Duration) *callbackContextCache {
 	}
 }
 
-func (c *callbackContextCache) Put(messageID string, ctx callbackContext) {
-	key := strings.TrimSpace(messageID)
+func (c *callbackContextCache) Put(configID, messageID string, ctx callbackContext) {
+	key := callbackContextCacheKey(configID, messageID)
 	if key == "" {
 		return
 	}
@@ -44,8 +44,8 @@ func (c *callbackContextCache) Put(messageID string, ctx callbackContext) {
 	c.mu.Unlock()
 }
 
-func (c *callbackContextCache) Get(messageID string) (callbackContext, bool) {
-	key := strings.TrimSpace(messageID)
+func (c *callbackContextCache) Get(configID, messageID string) (callbackContext, bool) {
+	key := callbackContextCacheKey(configID, messageID)
 	if key == "" {
 		return callbackContext{}, false
 	}
@@ -62,6 +62,15 @@ func (c *callbackContextCache) Get(messageID string) (callbackContext, bool) {
 		return callbackContext{}, false
 	}
 	return item, true
+}
+
+func callbackContextCacheKey(configID, messageID string) string {
+	configID = strings.TrimSpace(configID)
+	messageID = strings.TrimSpace(messageID)
+	if configID == "" || messageID == "" {
+		return ""
+	}
+	return configID + "\x00" + messageID
 }
 
 func (c *callbackContextCache) gcLocked() {

--- a/internal/channel/adapters/wecom/callback_cache_test.go
+++ b/internal/channel/adapters/wecom/callback_cache_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestCallbackContextCache_PutGet(t *testing.T) {
 	cache := newCallbackContextCache(1 * time.Hour)
-	cache.Put("m1", callbackContext{ReqID: "r1"})
-	got, ok := cache.Get("m1")
+	cache.Put("config-a", "m1", callbackContext{ReqID: "r1"})
+	got, ok := cache.Get("config-a", "m1")
 	if !ok {
 		t.Fatal("expected cache hit")
 	}
@@ -19,11 +19,33 @@ func TestCallbackContextCache_PutGet(t *testing.T) {
 
 func TestCallbackContextCache_Expires(t *testing.T) {
 	cache := newCallbackContextCache(1 * time.Second)
-	cache.Put("m1", callbackContext{
+	cache.Put("config-a", "m1", callbackContext{
 		ReqID:     "r1",
 		CreatedAt: time.Now().Add(-2 * time.Second),
 	})
-	if _, ok := cache.Get("m1"); ok {
+	if _, ok := cache.Get("config-a", "m1"); ok {
 		t.Fatal("expected cache miss due to expiry")
+	}
+}
+
+func TestCallbackContextCacheIsScopedByConfig(t *testing.T) {
+	cache := newCallbackContextCache(time.Hour)
+	cache.Put("config-a", "shared-message", callbackContext{ReqID: "request-a"})
+	cache.Put("config-b", "shared-message", callbackContext{ReqID: "request-b"})
+
+	first, ok := cache.Get("config-a", "shared-message")
+	if !ok || first.ReqID != "request-a" {
+		t.Fatalf("config-a callback = %#v, found=%v", first, ok)
+	}
+	second, ok := cache.Get("config-b", "shared-message")
+	if !ok || second.ReqID != "request-b" {
+		t.Fatalf("config-b callback = %#v, found=%v", second, ok)
+	}
+}
+
+func TestWeComClientCacheKeyIsScopedByConfig(t *testing.T) {
+	first := wecomClientCacheKey("config-a", "shared-bot")
+	if second := wecomClientCacheKey("config-b", "shared-bot"); second == first {
+		t.Fatal("different configs must not share a WeCom client cache key")
 	}
 }

--- a/internal/channel/adapters/wecom/inbound.go
+++ b/internal/channel/adapters/wecom/inbound.go
@@ -22,7 +22,7 @@ func (a *WeComAdapter) handleFrame(ctx context.Context, cfg channel.ChannelConfi
 		if !ok {
 			return nil
 		}
-		a.rememberCallback(body.MsgID, frame.Headers.ReqID, body.ResponseURL, body.ChatID, body.From.UserID)
+		a.rememberCallback(cfg.ID, body.MsgID, frame.Headers.ReqID, body.ResponseURL, body.ChatID, body.From.UserID)
 		return handler(ctx, cfg, msg)
 	case WSCmdEventCallback:
 		if handler == nil {
@@ -36,7 +36,7 @@ func (a *WeComAdapter) handleFrame(ctx context.Context, cfg channel.ChannelConfi
 		if !ok {
 			return nil
 		}
-		a.rememberCallback(body.MsgID, frame.Headers.ReqID, body.ResponseURL, body.ChatID, body.From.UserID)
+		a.rememberCallback(cfg.ID, body.MsgID, frame.Headers.ReqID, body.ResponseURL, body.ChatID, body.From.UserID)
 		return handler(ctx, cfg, msg)
 	default:
 		return nil
@@ -314,7 +314,7 @@ func parseCreateTime(ts int64) time.Time {
 	return time.Now().UTC()
 }
 
-func (a *WeComAdapter) rememberCallback(msgID, reqID, responseURL, chatID, userID string) {
+func (a *WeComAdapter) rememberCallback(configID, msgID, reqID, responseURL, chatID, userID string) {
 	if a == nil || a.cache == nil {
 		return
 	}
@@ -325,7 +325,7 @@ func (a *WeComAdapter) rememberCallback(msgID, reqID, responseURL, chatID, userI
 	if strings.TrimSpace(reqID) == "" {
 		return
 	}
-	a.cache.Put(msgID, callbackContext{
+	a.cache.Put(configID, msgID, callbackContext{
 		ReqID:       strings.TrimSpace(reqID),
 		ResponseURL: strings.TrimSpace(responseURL),
 		ChatID:      strings.TrimSpace(chatID),

--- a/internal/channel/adapters/wecom/outbound.go
+++ b/internal/channel/adapters/wecom/outbound.go
@@ -401,8 +401,8 @@ func extractBase64Content(v string) string {
 	return value
 }
 
-func (a *WeComAdapter) getClient(botID string) *WSClient {
-	key := strings.TrimSpace(botID)
+func (a *WeComAdapter) getClient(configID, botID string) *WSClient {
+	key := wecomClientCacheKey(configID, botID)
 	if key == "" {
 		return nil
 	}
@@ -411,7 +411,16 @@ func (a *WeComAdapter) getClient(botID string) *WSClient {
 	return a.clients[key]
 }
 
-func (a *WeComAdapter) lookupCallbackContext(reply *channel.ReplyRef) (callbackContext, bool) {
+func wecomClientCacheKey(configID, botID string) string {
+	configID = strings.TrimSpace(configID)
+	botID = strings.TrimSpace(botID)
+	if configID == "" || botID == "" {
+		return ""
+	}
+	return configID + "\x00" + botID
+}
+
+func (a *WeComAdapter) lookupCallbackContext(configID string, reply *channel.ReplyRef) (callbackContext, bool) {
 	if a == nil || a.cache == nil || reply == nil {
 		return callbackContext{}, false
 	}
@@ -419,5 +428,5 @@ func (a *WeComAdapter) lookupCallbackContext(reply *channel.ReplyRef) (callbackC
 	if messageID == "" {
 		return callbackContext{}, false
 	}
-	return a.cache.Get(messageID)
+	return a.cache.Get(configID, messageID)
 }

--- a/internal/channel/adapters/wecom/wecom.go
+++ b/internal/channel/adapters/wecom/wecom.go
@@ -138,7 +138,7 @@ func (a *WeComAdapter) Connect(ctx context.Context, cfg channel.ChannelConfig, h
 		ReconnectMaxDelay:  30 * time.Second,
 	})
 
-	key := strings.TrimSpace(parsed.BotID)
+	key := wecomClientCacheKey(cfg.ID, parsed.BotID)
 	a.mu.Lock()
 	a.clients[key] = client
 	a.mu.Unlock()
@@ -185,7 +185,7 @@ func (a *WeComAdapter) Send(ctx context.Context, cfg channel.ChannelConfig, msg 
 	if err != nil {
 		return err
 	}
-	client := a.getClient(parsed.BotID)
+	client := a.getClient(cfg.ID, parsed.BotID)
 	if client == nil {
 		return errors.New("wecom connection is not active")
 	}
@@ -198,7 +198,7 @@ func (a *WeComAdapter) Send(ctx context.Context, cfg channel.ChannelConfig, msg 
 		reqID    string
 		buildErr error
 	)
-	if ctxMeta, ok := a.lookupCallbackContext(msg.Message.Message.Reply); ok {
+	if ctxMeta, ok := a.lookupCallbackContext(cfg.ID, msg.Message.Message.Reply); ok {
 		payload, cmd, reqID, buildErr = buildPreparedRespondPayload(ctx, msg.Message, ctxMeta.ReqID)
 	} else {
 		_ = targetKind
@@ -347,7 +347,7 @@ func (s *wecomOutboundStream) flush(ctx context.Context) error {
 	if msg.LogicalMessage().IsEmpty() {
 		return nil
 	}
-	if ctxMeta, ok := s.adapter.lookupCallbackContext(msg.Message.Reply); ok {
+	if ctxMeta, ok := s.adapter.lookupCallbackContext(s.cfg.ID, msg.Message.Reply); ok {
 		if err := s.adapter.sendRespondStream(ctx, s.cfg, msg, ctxMeta.ReqID, streamID, true); err != nil {
 			return err
 		}
@@ -400,7 +400,7 @@ func (s *wecomOutboundStream) pushPreview(ctx context.Context) error {
 		return nil
 	}
 	s.mu.Unlock()
-	if ctxMeta, ok := s.adapter.lookupCallbackContext(msg.Message.Reply); ok {
+	if ctxMeta, ok := s.adapter.lookupCallbackContext(s.cfg.ID, msg.Message.Reply); ok {
 		if err := s.adapter.sendRespondStream(ctx, s.cfg, msg, ctxMeta.ReqID, streamID, false); err != nil {
 			return err
 		}
@@ -444,7 +444,7 @@ func (a *WeComAdapter) sendRespondStream(ctx context.Context, cfg channel.Channe
 	if err != nil {
 		return err
 	}
-	client := a.getClient(parsed.BotID)
+	client := a.getClient(cfg.ID, parsed.BotID)
 	if client == nil {
 		return errors.New("wecom connection is not active")
 	}

--- a/internal/channel/identities/service_identity_integration_test.go
+++ b/internal/channel/identities/service_identity_integration_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/memohai/memoh/internal/channel/identities"
+	dbpkg "github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -25,7 +24,7 @@ func setupChannelIdentityIdentityIntegrationTest(t *testing.T) (*identities.Serv
 	}
 
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
+	pool, err := dbpkg.OpenPostgresDSN(ctx, dsn)
 	if err != nil {
 		t.Skipf("skip integration test: cannot connect to database: %v", err)
 	}

--- a/internal/channel/identities/service_integration_test.go
+++ b/internal/channel/identities/service_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
+	dbpkg "github.com/memohai/memoh/internal/db"
 
 	"github.com/memohai/memoh/internal/channel/identities"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
@@ -27,7 +27,7 @@ func setupIntegrationTest(t *testing.T) (*identities.Service, dbstore.Queries, f
 	}
 
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
+	pool, err := dbpkg.OpenPostgresDSN(ctx, dsn)
 	if err != nil {
 		t.Skipf("skip integration test: cannot connect to database: %v", err)
 	}

--- a/internal/channelaccess/service_test.go
+++ b/internal/channelaccess/service_test.go
@@ -15,7 +15,7 @@ import (
 
 // TestListManagersEveryoneUsesScopedBindings verifies that when "everyone" carries
 // Manage, ListManagers uses the bot-scoped query (ListChannelIdentityBindingsForBot)
-// instead of the global ListChannelIdentityBindings. This prevents cross-tenant
+// instead of the global ListChannelIdentityBindings. This prevents cross-team
 // data leaks while still showing workspace members' bound identities.
 func TestListManagersEveryoneUsesScopedBindings(t *testing.T) {
 	ctx := context.Background()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -343,22 +343,24 @@ func WorkspaceImagePullCandidates(ref string) []string {
 }
 
 type PostgresConfig struct {
-	Host     string `toml:"host"`
-	Port     int    `toml:"port"`
-	User     string `toml:"user"`
-	Password string `toml:"password" json:"-"`
-	Database string `toml:"database"`
-	SSLMode  string `toml:"sslmode"`
+	Host        string `toml:"host"`
+	Port        int    `toml:"port"`
+	User        string `toml:"user"`
+	Password    string `toml:"password" json:"-"`
+	Database    string `toml:"database"`
+	SSLMode     string `toml:"sslmode"`
+	RuntimeRole string `toml:"runtime_role"`
 }
 
 type PGVectorConfig struct {
-	Enabled  bool   `toml:"enabled"`
-	Host     string `toml:"host"`
-	Port     int    `toml:"port"`
-	User     string `toml:"user"`
-	Password string `toml:"password" json:"-"`
-	Database string `toml:"database"`
-	SSLMode  string `toml:"sslmode"`
+	Enabled     bool   `toml:"enabled"`
+	Host        string `toml:"host"`
+	Port        int    `toml:"port"`
+	User        string `toml:"user"`
+	Password    string `toml:"password" json:"-"`
+	Database    string `toml:"database"`
+	SSLMode     string `toml:"sslmode"`
+	RuntimeRole string `toml:"runtime_role"`
 }
 
 func (c PGVectorConfig) PostgresConfig() PostgresConfig {
@@ -383,12 +385,13 @@ func (c PGVectorConfig) PostgresConfig() PostgresConfig {
 		sslMode = DefaultPGVectorSSLMode
 	}
 	return PostgresConfig{
-		Host:     host,
-		Port:     port,
-		User:     user,
-		Password: c.Password,
-		Database: database,
-		SSLMode:  sslMode,
+		Host:        host,
+		Port:        port,
+		User:        user,
+		Password:    c.Password,
+		Database:    database,
+		SSLMode:     sslMode,
+		RuntimeRole: strings.TrimSpace(c.RuntimeRole),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -343,24 +343,22 @@ func WorkspaceImagePullCandidates(ref string) []string {
 }
 
 type PostgresConfig struct {
-	Host        string `toml:"host"`
-	Port        int    `toml:"port"`
-	User        string `toml:"user"`
-	Password    string `toml:"password" json:"-"`
-	Database    string `toml:"database"`
-	SSLMode     string `toml:"sslmode"`
-	RuntimeRole string `toml:"runtime_role"`
+	Host     string `toml:"host"`
+	Port     int    `toml:"port"`
+	User     string `toml:"user"`
+	Password string `toml:"password" json:"-"`
+	Database string `toml:"database"`
+	SSLMode  string `toml:"sslmode"`
 }
 
 type PGVectorConfig struct {
-	Enabled     bool   `toml:"enabled"`
-	Host        string `toml:"host"`
-	Port        int    `toml:"port"`
-	User        string `toml:"user"`
-	Password    string `toml:"password" json:"-"`
-	Database    string `toml:"database"`
-	SSLMode     string `toml:"sslmode"`
-	RuntimeRole string `toml:"runtime_role"`
+	Enabled  bool   `toml:"enabled"`
+	Host     string `toml:"host"`
+	Port     int    `toml:"port"`
+	User     string `toml:"user"`
+	Password string `toml:"password" json:"-"`
+	Database string `toml:"database"`
+	SSLMode  string `toml:"sslmode"`
 }
 
 func (c PGVectorConfig) PostgresConfig() PostgresConfig {
@@ -385,13 +383,12 @@ func (c PGVectorConfig) PostgresConfig() PostgresConfig {
 		sslMode = DefaultPGVectorSSLMode
 	}
 	return PostgresConfig{
-		Host:        host,
-		Port:        port,
-		User:        user,
-		Password:    c.Password,
-		Database:    database,
-		SSLMode:     sslMode,
-		RuntimeRole: strings.TrimSpace(c.RuntimeRole),
+		Host:     host,
+		Port:     port,
+		User:     user,
+		Password: c.Password,
+		Database: database,
+		SSLMode:  sslMode,
 	}
 }
 

--- a/internal/conversation/flow/resolver_memory.go
+++ b/internal/conversation/flow/resolver_memory.go
@@ -34,7 +34,7 @@ func (r *Resolver) resolveMemoryProviderWithID(ctx context.Context, botID string
 	if providerID == "" {
 		return "", nil
 	}
-	p, err := r.memoryRegistry.Get(providerID)
+	p, err := r.memoryRegistry.Get(ctx, providerID)
 	if err != nil {
 		r.logger.Warn("memory provider lookup failed", slog.String("provider_id", providerID), slog.Any("error", err))
 		return "", nil

--- a/internal/db/compaction_artifact_migration_integration_test.go
+++ b/internal/db/compaction_artifact_migration_integration_test.go
@@ -42,15 +42,18 @@ func TestCompactionArtifactMigrationPostgresPath(t *testing.T) {
 	if _, err := tx.Exec(ctx, "SET LOCAL search_path TO "+quotedSchema); err != nil {
 		t.Fatalf("set search path: %v", err)
 	}
+	bindTeamQueryFixture(t, ctx, tx)
 	if _, err := tx.Exec(ctx, `
 CREATE TABLE bot_sessions (
   id UUID PRIMARY KEY,
-  bot_id UUID NOT NULL
+  bot_id UUID NOT NULL,
+  team_id UUID NOT NULL DEFAULT public.memoh_current_team_id()
 );
 
 CREATE TABLE bot_history_message_compacts (
   id UUID PRIMARY KEY,
   bot_id UUID NOT NULL,
+  team_id UUID NOT NULL DEFAULT public.memoh_current_team_id(),
   session_id UUID,
   status TEXT NOT NULL DEFAULT 'pending',
   summary TEXT NOT NULL DEFAULT '',
@@ -65,6 +68,7 @@ CREATE TABLE bot_history_message_compacts (
 CREATE TABLE bot_history_messages (
   id UUID PRIMARY KEY,
   bot_id UUID NOT NULL,
+  team_id UUID NOT NULL DEFAULT public.memoh_current_team_id(),
   session_id UUID,
   compact_id UUID REFERENCES bot_history_message_compacts(id) ON DELETE SET NULL,
   turn_visible BOOLEAN NOT NULL DEFAULT true,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,10 +3,13 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/memohai/memoh/internal/config"
+	"github.com/memohai/memoh/internal/team"
 )
 
 func Open(ctx context.Context, cfg config.Config) (*pgxpool.Pool, error) {
@@ -23,5 +26,44 @@ func OpenPostgres(ctx context.Context, cfg config.PostgresConfig) (*pgxpool.Pool
 	if err != nil {
 		return nil, err
 	}
+	// Bind the singleton team on every new connection. Team business queries
+	// scope themselves with public.memoh_current_team_id(), which fail-closed raises if
+	// memoh.team_id is unset. Upstream is single-team, so we set the default
+	// team at the session level here.
+	poolCfg.AfterConnect = SetDefaultTeamAndRoleOnConnect(cfg.RuntimeRole)
 	return pgxpool.NewWithConfig(ctx, poolCfg)
+}
+
+// SetDefaultTeamAndRoleOnConnect switches application sessions to the
+// configured non-superuser role before binding the singleton team.
+func SetDefaultTeamAndRoleOnConnect(runtimeRole string) func(context.Context, *pgx.Conn) error {
+	return func(ctx context.Context, conn *pgx.Conn) error {
+		if role := strings.TrimSpace(runtimeRole); role != "" {
+			if _, err := conn.Exec(ctx, "SET ROLE "+pgx.Identifier{role}.Sanitize()); err != nil {
+				return fmt.Errorf("set postgres runtime role %q: %w", role, err)
+			}
+		}
+		return SetDefaultTeamOnConnect(ctx, conn)
+	}
+}
+
+// SetDefaultTeamOnConnect is a pgxpool AfterConnect hook that binds the
+// singleton team GUC (memoh.team_id) at the session level. It is exported so
+// single-team test harnesses can install it on their own pools, matching the
+// production connection setup.
+func SetDefaultTeamOnConnect(ctx context.Context, conn *pgx.Conn) error {
+	_, err := conn.Exec(ctx, "SELECT set_config('memoh.team_id', $1, false)", team.DefaultTeamID)
+	return err
+}
+
+// OpenPostgresDSN opens a pool from a raw libpq DSN with the default-team
+// AfterConnect hook installed. Single-team test harnesses use this so their
+// pools bind the team GUC exactly like production.
+func OpenPostgresDSN(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	cfg.AfterConnect = SetDefaultTeamOnConnect
+	return pgxpool.NewWithConfig(ctx, cfg)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -30,21 +29,8 @@ func OpenPostgres(ctx context.Context, cfg config.PostgresConfig) (*pgxpool.Pool
 	// scope themselves with public.memoh_current_team_id(), which fail-closed raises if
 	// memoh.team_id is unset. Upstream is single-team, so we set the default
 	// team at the session level here.
-	poolCfg.AfterConnect = SetDefaultTeamAndRoleOnConnect(cfg.RuntimeRole)
+	poolCfg.AfterConnect = SetDefaultTeamOnConnect
 	return pgxpool.NewWithConfig(ctx, poolCfg)
-}
-
-// SetDefaultTeamAndRoleOnConnect switches application sessions to the
-// configured non-superuser role before binding the singleton team.
-func SetDefaultTeamAndRoleOnConnect(runtimeRole string) func(context.Context, *pgx.Conn) error {
-	return func(ctx context.Context, conn *pgx.Conn) error {
-		if role := strings.TrimSpace(runtimeRole); role != "" {
-			if _, err := conn.Exec(ctx, "SET ROLE "+pgx.Identifier{role}.Sanitize()); err != nil {
-				return fmt.Errorf("set postgres runtime role %q: %w", role, err)
-			}
-		}
-		return SetDefaultTeamOnConnect(ctx, conn)
-	}
 }
 
 // SetDefaultTeamOnConnect is a pgxpool AfterConnect hook that binds the

--- a/internal/db/delete_chat_compaction_postgres_integration_test.go
+++ b/internal/db/delete_chat_compaction_postgres_integration_test.go
@@ -38,21 +38,29 @@ func TestDeleteChatClearsCompactionArtifactsPostgresPath(t *testing.T) {
 	if _, err := tx.Exec(ctx, "SET LOCAL search_path TO "+quotedSchema); err != nil {
 		t.Fatalf("set search path: %v", err)
 	}
+	bindTeamQueryFixture(t, ctx, tx)
 	if _, err := tx.Exec(ctx, `
-CREATE TABLE bot_channel_routes (id UUID PRIMARY KEY, bot_id UUID NOT NULL);
+CREATE TABLE bot_channel_routes (
+  id UUID PRIMARY KEY,
+  bot_id UUID NOT NULL,
+  team_id UUID NOT NULL DEFAULT public.memoh_current_team_id()
+);
 CREATE TABLE bot_sessions (
   id UUID PRIMARY KEY,
   bot_id UUID NOT NULL,
+  team_id UUID NOT NULL DEFAULT public.memoh_current_team_id(),
   route_id UUID REFERENCES bot_channel_routes(id) ON DELETE SET NULL
 );
 CREATE TABLE bot_history_message_compacts (
   id UUID PRIMARY KEY,
   bot_id UUID NOT NULL,
+  team_id UUID NOT NULL DEFAULT public.memoh_current_team_id(),
   session_id UUID REFERENCES bot_sessions(id) ON DELETE CASCADE
 );
 CREATE TABLE bot_history_messages (
   id UUID PRIMARY KEY,
   bot_id UUID NOT NULL,
+  team_id UUID NOT NULL DEFAULT public.memoh_current_team_id(),
   session_id UUID REFERENCES bot_sessions(id) ON DELETE SET NULL,
   compact_id UUID REFERENCES bot_history_message_compacts(id) ON DELETE SET NULL
 );

--- a/internal/db/pgvector/migrate.go
+++ b/internal/db/pgvector/migrate.go
@@ -13,7 +13,7 @@ import (
 const migrationsPath = "pgvector/migrations"
 
 // SchemaVersion is the newest pgvector migration understood by this binary.
-const SchemaVersion = uint(1)
+const SchemaVersion = uint(2)
 
 // MigrationsFS returns the independently versioned pgvector migration set.
 func MigrationsFS() (fs.FS, error) {

--- a/internal/db/pgvector/migrate_test.go
+++ b/internal/db/pgvector/migrate_test.go
@@ -160,6 +160,13 @@ INSERT INTO public.memory_node_embeddings (
 	if legacyRows != 1 {
 		t.Fatalf("legacy rows = %d, want 1", legacyRows)
 	}
+	var legacyTeamID string
+	if err := conn.QueryRow(ctx, `SELECT team_id::text FROM public.memory_node_embeddings WHERE node_id = 'legacy-node'`).Scan(&legacyTeamID); err != nil {
+		t.Fatalf("read legacy team: %v", err)
+	}
+	if legacyTeamID != "00000000-0000-0000-0000-000000000001" {
+		t.Fatalf("legacy team = %q", legacyTeamID)
+	}
 
 	store, err := Open(ctx, slog.New(slog.DiscardHandler), vectorCfg)
 	if err != nil {
@@ -167,9 +174,11 @@ INSERT INTO public.memory_node_embeddings (
 	}
 	defer store.Close()
 	queries := store.Queries()
+	teamID := uuidValue(1)
 	botID := uuidValue(3)
 	modelID := uuidValue(4)
 	if err := queries.UpsertMemoryNodeEmbedding(ctx, pgvectorsqlc.UpsertMemoryNodeEmbeddingParams{
+		TeamID:     teamID,
 		BotID:      botID,
 		NodeID:     "sqlc-node",
 		ModelID:    modelID,
@@ -181,6 +190,7 @@ INSERT INTO public.memory_node_embeddings (
 	}
 	rows, err := queries.SearchMemoryNodeEmbeddings(ctx, pgvectorsqlc.SearchMemoryNodeEmbeddingsParams{
 		Embedding: pgvector.NewVector([]float32{1, 0}),
+		TeamID:    teamID,
 		BotID:     botID,
 		ModelID:   modelID,
 		RowLimit:  5,
@@ -192,10 +202,73 @@ INSERT INTO public.memory_node_embeddings (
 		t.Fatalf("sqlc search rows = %#v", rows)
 	}
 
+	teamTwo := uuidValue(2)
+	if err := queries.UpsertMemoryNodeEmbedding(ctx, pgvectorsqlc.UpsertMemoryNodeEmbeddingParams{
+		TeamID:     teamTwo,
+		BotID:      botID,
+		NodeID:     "other-team-node",
+		ModelID:    modelID,
+		Dimensions: 2,
+		BodyHash:   "other-team-hash",
+		Embedding:  pgvector.NewVector([]float32{0, 1}),
+	}); err != nil {
+		t.Fatalf("seed other team: %v", err)
+	}
+	func() {
+		role := fmt.Sprintf("memoh_pgvector_rls_test_%d_%d", os.Getpid(), time.Now().UnixNano())
+		quotedRole := pgx.Identifier{role}.Sanitize()
+		if _, err := conn.Exec(ctx, "CREATE ROLE "+quotedRole+" NOLOGIN NOSUPERUSER NOBYPASSRLS"); err != nil {
+			t.Fatalf("create RLS role: %v", err)
+		}
+		defer func() {
+			_, _ = conn.Exec(ctx, "RESET ROLE")
+			_, _ = conn.Exec(ctx, "DROP OWNED BY "+quotedRole)
+			_, _ = conn.Exec(ctx, "DROP ROLE IF EXISTS "+quotedRole)
+		}()
+		for _, grant := range []string{
+			"GRANT USAGE ON SCHEMA public TO " + quotedRole,
+			"GRANT SELECT ON public.memory_node_embeddings TO " + quotedRole,
+			"GRANT EXECUTE ON FUNCTION public.memoh_pgvector_current_team_id() TO " + quotedRole,
+		} {
+			if _, err := conn.Exec(ctx, grant); err != nil {
+				t.Fatalf("grant RLS role: %v", err)
+			}
+		}
+		if _, err := conn.Exec(ctx, "SET ROLE "+quotedRole); err != nil {
+			t.Fatalf("set RLS role: %v", err)
+		}
+		if _, err := conn.Exec(ctx, "SELECT set_config('memoh.team_id', $1, false)", teamID.String()); err != nil {
+			t.Fatalf("bind RLS team: %v", err)
+		}
+		rlsQueries := pgvectorsqlc.New(conn)
+		visible, err := rlsQueries.CountMemoryNodeEmbeddings(ctx, pgvectorsqlc.CountMemoryNodeEmbeddingsParams{
+			TeamID:  teamID,
+			BotID:   botID,
+			ModelID: modelID,
+		})
+		if err != nil {
+			t.Fatalf("count current team through RLS: %v", err)
+		}
+		if visible != 1 {
+			t.Fatalf("current-team rows = %d, want 1", visible)
+		}
+		hidden, err := rlsQueries.CountMemoryNodeEmbeddings(ctx, pgvectorsqlc.CountMemoryNodeEmbeddingsParams{
+			TeamID:  teamTwo,
+			BotID:   botID,
+			ModelID: modelID,
+		})
+		if err != nil {
+			t.Fatalf("count other team through RLS: %v", err)
+		}
+		if hidden != 0 {
+			t.Fatalf("other-team rows visible through RLS = %d", hidden)
+		}
+	}()
+
 	if _, err := conn.Exec(ctx, `DROP TABLE public.memory_node_embeddings`); err != nil {
 		t.Fatalf("drop embeddings table: %v", err)
 	}
-	if _, err := queries.MemoryNodeEmbeddingsExist(ctx); err == nil {
+	if _, err := queries.MemoryNodeEmbeddingsExist(ctx, teamID); err == nil {
 		t.Fatal("read-only health query repaired a missing table")
 	}
 	if err := MigrateUp(slog.New(slog.DiscardHandler), vectorCfg); err != nil {

--- a/internal/db/pgvector/sqlc/embeddings.sql.go
+++ b/internal/db/pgvector/sqlc/embeddings.sql.go
@@ -15,17 +15,19 @@ import (
 const countMemoryNodeEmbeddings = `-- name: CountMemoryNodeEmbeddings :one
 SELECT COUNT(*)
 FROM public.memory_node_embeddings
-WHERE bot_id = $1
-  AND model_id = $2
+WHERE team_id = $1
+  AND bot_id = $2
+  AND model_id = $3
 `
 
 type CountMemoryNodeEmbeddingsParams struct {
+	TeamID  pgtype.UUID `json:"team_id"`
 	BotID   pgtype.UUID `json:"bot_id"`
 	ModelID pgtype.UUID `json:"model_id"`
 }
 
 func (q *Queries) CountMemoryNodeEmbeddings(ctx context.Context, arg CountMemoryNodeEmbeddingsParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countMemoryNodeEmbeddings, arg.BotID, arg.ModelID)
+	row := q.db.QueryRow(ctx, countMemoryNodeEmbeddings, arg.TeamID, arg.BotID, arg.ModelID)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -33,27 +35,35 @@ func (q *Queries) CountMemoryNodeEmbeddings(ctx context.Context, arg CountMemory
 
 const deleteBotMemoryNodeEmbeddings = `-- name: DeleteBotMemoryNodeEmbeddings :exec
 DELETE FROM public.memory_node_embeddings
-WHERE bot_id = $1
+WHERE team_id = $1
+  AND bot_id = $2
 `
 
-func (q *Queries) DeleteBotMemoryNodeEmbeddings(ctx context.Context, botID pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, deleteBotMemoryNodeEmbeddings, botID)
+type DeleteBotMemoryNodeEmbeddingsParams struct {
+	TeamID pgtype.UUID `json:"team_id"`
+	BotID  pgtype.UUID `json:"bot_id"`
+}
+
+func (q *Queries) DeleteBotMemoryNodeEmbeddings(ctx context.Context, arg DeleteBotMemoryNodeEmbeddingsParams) error {
+	_, err := q.db.Exec(ctx, deleteBotMemoryNodeEmbeddings, arg.TeamID, arg.BotID)
 	return err
 }
 
 const deleteMemoryNodeEmbeddings = `-- name: DeleteMemoryNodeEmbeddings :exec
 DELETE FROM public.memory_node_embeddings
-WHERE bot_id = $1
-  AND node_id = ANY($2::text[])
+WHERE team_id = $1
+  AND bot_id = $2
+  AND node_id = ANY($3::text[])
 `
 
 type DeleteMemoryNodeEmbeddingsParams struct {
+	TeamID  pgtype.UUID `json:"team_id"`
 	BotID   pgtype.UUID `json:"bot_id"`
 	NodeIds []string    `json:"node_ids"`
 }
 
 func (q *Queries) DeleteMemoryNodeEmbeddings(ctx context.Context, arg DeleteMemoryNodeEmbeddingsParams) error {
-	_, err := q.db.Exec(ctx, deleteMemoryNodeEmbeddings, arg.BotID, arg.NodeIds)
+	_, err := q.db.Exec(ctx, deleteMemoryNodeEmbeddings, arg.TeamID, arg.BotID, arg.NodeIds)
 	return err
 }
 
@@ -61,12 +71,13 @@ const memoryNodeEmbeddingsExist = `-- name: MemoryNodeEmbeddingsExist :one
 SELECT EXISTS (
   SELECT 1
   FROM public.memory_node_embeddings
+  WHERE team_id = $1
   LIMIT 1
 )
 `
 
-func (q *Queries) MemoryNodeEmbeddingsExist(ctx context.Context) (bool, error) {
-	row := q.db.QueryRow(ctx, memoryNodeEmbeddingsExist)
+func (q *Queries) MemoryNodeEmbeddingsExist(ctx context.Context, teamID pgtype.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, memoryNodeEmbeddingsExist, teamID)
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err
@@ -77,14 +88,16 @@ SELECT
   node_id,
   CAST(1.0 - (embedding <=> $1::vector) AS double precision) AS score
 FROM public.memory_node_embeddings
-WHERE bot_id = $2
-  AND model_id = $3
+WHERE team_id = $2
+  AND bot_id = $3
+  AND model_id = $4
 ORDER BY embedding <=> $1::vector
-LIMIT $4
+LIMIT $5
 `
 
 type SearchMemoryNodeEmbeddingsParams struct {
 	Embedding pgvector_go.Vector `json:"embedding"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 	BotID     pgtype.UUID        `json:"bot_id"`
 	ModelID   pgtype.UUID        `json:"model_id"`
 	RowLimit  int32              `json:"row_limit"`
@@ -98,6 +111,7 @@ type SearchMemoryNodeEmbeddingsRow struct {
 func (q *Queries) SearchMemoryNodeEmbeddings(ctx context.Context, arg SearchMemoryNodeEmbeddingsParams) ([]SearchMemoryNodeEmbeddingsRow, error) {
 	rows, err := q.db.Query(ctx, searchMemoryNodeEmbeddings,
 		arg.Embedding,
+		arg.TeamID,
 		arg.BotID,
 		arg.ModelID,
 		arg.RowLimit,
@@ -122,7 +136,7 @@ func (q *Queries) SearchMemoryNodeEmbeddings(ctx context.Context, arg SearchMemo
 
 const upsertMemoryNodeEmbedding = `-- name: UpsertMemoryNodeEmbedding :exec
 INSERT INTO public.memory_node_embeddings (
-  bot_id, node_id, model_id, dimensions, body_hash, embedding
+  team_id, bot_id, node_id, model_id, dimensions, body_hash, embedding
 )
 VALUES (
   $1,
@@ -130,9 +144,10 @@ VALUES (
   $3,
   $4,
   $5,
-  $6
+  $6,
+  $7
 )
-ON CONFLICT (bot_id, node_id, model_id) DO UPDATE SET
+ON CONFLICT (team_id, bot_id, node_id, model_id) DO UPDATE SET
   dimensions = EXCLUDED.dimensions,
   body_hash = EXCLUDED.body_hash,
   embedding = EXCLUDED.embedding,
@@ -140,6 +155,7 @@ ON CONFLICT (bot_id, node_id, model_id) DO UPDATE SET
 `
 
 type UpsertMemoryNodeEmbeddingParams struct {
+	TeamID     pgtype.UUID        `json:"team_id"`
 	BotID      pgtype.UUID        `json:"bot_id"`
 	NodeID     string             `json:"node_id"`
 	ModelID    pgtype.UUID        `json:"model_id"`
@@ -150,6 +166,7 @@ type UpsertMemoryNodeEmbeddingParams struct {
 
 func (q *Queries) UpsertMemoryNodeEmbedding(ctx context.Context, arg UpsertMemoryNodeEmbeddingParams) error {
 	_, err := q.db.Exec(ctx, upsertMemoryNodeEmbedding,
+		arg.TeamID,
 		arg.BotID,
 		arg.NodeID,
 		arg.ModelID,

--- a/internal/db/pgvector/sqlc/models.go
+++ b/internal/db/pgvector/sqlc/models.go
@@ -18,4 +18,5 @@ type MemoryNodeEmbedding struct {
 	Embedding  pgvector_go.Vector `json:"embedding"`
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	TeamID     pgtype.UUID        `json:"team_id"`
 }

--- a/internal/db/pgvector/store.go
+++ b/internal/db/pgvector/store.go
@@ -2,9 +2,11 @@ package pgvector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	pgxvec "github.com/pgvector/pgvector-go/pgx"
 
@@ -44,6 +46,13 @@ func (s *Store) Queries() *pgvectorsqlc.Queries {
 		return nil
 	}
 	return s.queries
+}
+
+func (s *Store) Begin(ctx context.Context) (pgx.Tx, error) {
+	if s == nil || s.pool == nil {
+		return nil, errors.New("pgvector: store is not open")
+	}
+	return s.pool.Begin(ctx)
 }
 
 func (s *Store) Close() {

--- a/internal/db/postgres/sqlc/acl.sql.go
+++ b/internal/db/postgres/sqlc/acl.sql.go
@@ -40,7 +40,7 @@ VALUES (
   $11::text,
   $4
 )
-RETURNING id, bot_id, action, effect, channel_identity_id, source_channel, source_conversation_type, source_conversation_id, source_thread_id, created_by_user_id, created_at, updated_at, enabled, description, subject_channel_type
+RETURNING id, bot_id, action, effect, channel_identity_id, source_channel, source_conversation_type, source_conversation_id, source_thread_id, created_by_user_id, created_at, updated_at, enabled, description, subject_channel_type, team_id
 `
 
 type CreateBotACLRuleParams struct {
@@ -88,12 +88,13 @@ func (q *Queries) CreateBotACLRule(ctx context.Context, arg CreateBotACLRulePara
 		&i.Enabled,
 		&i.Description,
 		&i.SubjectChannelType,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteBotACLRuleByID = `-- name: DeleteBotACLRuleByID :exec
-DELETE FROM bot_acl_rules WHERE id = $1
+DELETE FROM bot_acl_rules WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteBotACLRuleByID(ctx context.Context, id pgtype.UUID) error {
@@ -105,7 +106,7 @@ const evaluateBotACLRule = `-- name: EvaluateBotACLRule :one
 SELECT COALESCE((
   SELECT r.effect
   FROM bot_acl_rules r
-  WHERE r.bot_id = b.id
+  WHERE r.team_id = public.memoh_current_team_id() AND r.bot_id = b.id
     AND r.enabled = true
     AND r.action = $1
     AND r.effect <> b.acl_default_effect
@@ -117,7 +118,7 @@ SELECT COALESCE((
   LIMIT 1
 ), b.acl_default_effect) AS effect
 FROM bots b
-WHERE b.id = $7
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $7
 `
 
 type EvaluateBotACLRuleParams struct {
@@ -148,7 +149,7 @@ func (q *Queries) EvaluateBotACLRule(ctx context.Context, arg EvaluateBotACLRule
 }
 
 const getBotACLDefaultEffect = `-- name: GetBotACLDefaultEffect :one
-SELECT acl_default_effect FROM bots WHERE id = $1
+SELECT acl_default_effect FROM bots WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetBotACLDefaultEffect(ctx context.Context, id pgtype.UUID) (string, error) {
@@ -185,13 +186,14 @@ SELECT
   )::text AS source_conversation_name,
   COALESCE(NULLIF(TRIM(COALESCE(source_route.metadata->>'conversation_avatar_url', '')), ''), '')::text AS source_conversation_avatar_url
 FROM bot_acl_rules r
-LEFT JOIN channel_identities ci ON ci.id = r.channel_identity_id
-LEFT JOIN bot_channel_routes source_route ON source_route.bot_id = r.bot_id
+LEFT JOIN channel_identities ci ON ci.id = r.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_channel_routes source_route ON source_route.team_id = public.memoh_current_team_id()
+  AND source_route.bot_id = r.bot_id
   AND r.source_conversation_id IS NOT NULL
   AND source_route.external_conversation_id = r.source_conversation_id
   AND COALESCE(source_route.external_thread_id, '') = COALESCE(r.source_thread_id, '')
   AND (r.source_channel IS NULL OR source_route.channel_type = r.source_channel)
-WHERE r.bot_id = $1
+WHERE r.team_id = public.memoh_current_team_id() AND r.bot_id = $1
   AND r.action = 'chat.trigger'
 ORDER BY r.created_at DESC
 `
@@ -261,7 +263,7 @@ func (q *Queries) ListBotACLRules(ctx context.Context, botID pgtype.UUID) ([]Lis
 }
 
 const setBotACLDefaultEffect = `-- name: SetBotACLDefaultEffect :exec
-UPDATE bots SET acl_default_effect = $2, updated_at = now() WHERE id = $1
+UPDATE bots SET acl_default_effect = $2, updated_at = now() WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 type SetBotACLDefaultEffectParams struct {
@@ -287,8 +289,8 @@ SET
   source_conversation_id = $9::text,
   source_thread_id = $10::text,
   updated_at = now()
-WHERE id = $1
-RETURNING id, bot_id, action, effect, channel_identity_id, source_channel, source_conversation_type, source_conversation_id, source_thread_id, created_by_user_id, created_at, updated_at, enabled, description, subject_channel_type
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, bot_id, action, effect, channel_identity_id, source_channel, source_conversation_type, source_conversation_id, source_thread_id, created_by_user_id, created_at, updated_at, enabled, description, subject_channel_type, team_id
 `
 
 type UpdateBotACLRuleParams struct {
@@ -334,6 +336,7 @@ func (q *Queries) UpdateBotACLRule(ctx context.Context, arg UpdateBotACLRulePara
 		&i.Enabled,
 		&i.Description,
 		&i.SubjectChannelType,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/bot_channel_admins.sql.go
+++ b/internal/db/postgres/sqlc/bot_channel_admins.sql.go
@@ -13,7 +13,7 @@ import (
 
 const deleteBotChannelAdmin = `-- name: DeleteBotChannelAdmin :exec
 DELETE FROM bot_channel_admins
-WHERE bot_id = $1 AND channel_identity_id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_identity_id = $2
 `
 
 type DeleteBotChannelAdminParams struct {
@@ -27,9 +27,9 @@ func (q *Queries) DeleteBotChannelAdmin(ctx context.Context, arg DeleteBotChanne
 }
 
 const getBotChannelAdmin = `-- name: GetBotChannelAdmin :one
-SELECT id, bot_id, channel_identity_id, granted, created_by_user_id, created_at, updated_at
+SELECT id, bot_id, channel_identity_id, granted, created_by_user_id, created_at, updated_at, team_id
 FROM bot_channel_admins
-WHERE bot_id = $1 AND channel_identity_id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_identity_id = $2
 `
 
 type GetBotChannelAdminParams struct {
@@ -48,6 +48,7 @@ func (q *Queries) GetBotChannelAdmin(ctx context.Context, arg GetBotChannelAdmin
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -66,8 +67,8 @@ SELECT
   ci.display_name AS channel_identity_display_name,
   ci.avatar_url AS channel_identity_avatar_url
 FROM bot_channel_admins a
-LEFT JOIN channel_identities ci ON ci.id = a.channel_identity_id
-WHERE a.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = a.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+WHERE a.team_id = public.memoh_current_team_id() AND a.bot_id = $1
 ORDER BY a.created_at DESC
 `
 
@@ -130,10 +131,10 @@ VALUES (
   $3,
   $4::uuid
 )
-ON CONFLICT (bot_id, channel_identity_id) DO UPDATE
+ON CONFLICT (team_id, bot_id, channel_identity_id) DO UPDATE
   SET granted = EXCLUDED.granted,
       updated_at = now()
-RETURNING id, bot_id, channel_identity_id, granted, created_by_user_id, created_at, updated_at
+RETURNING id, bot_id, channel_identity_id, granted, created_by_user_id, created_at, updated_at, team_id
 `
 
 type UpsertBotChannelAdminParams struct {
@@ -159,6 +160,7 @@ func (q *Queries) UpsertBotChannelAdmin(ctx context.Context, arg UpsertBotChanne
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/bot_user_grants.sql.go
+++ b/internal/db/postgres/sqlc/bot_user_grants.sql.go
@@ -20,7 +20,7 @@ VALUES (
   $3,
   $5::uuid
 )
-RETURNING id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at
+RETURNING id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at, team_id
 `
 
 type CreateBotUserGrantParams struct {
@@ -49,12 +49,13 @@ func (q *Queries) CreateBotUserGrant(ctx context.Context, arg CreateBotUserGrant
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteBotUserGrantByID = `-- name: DeleteBotUserGrantByID :exec
-DELETE FROM bot_user_grants WHERE id = $1
+DELETE FROM bot_user_grants WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteBotUserGrantByID(ctx context.Context, id pgtype.UUID) error {
@@ -63,9 +64,9 @@ func (q *Queries) DeleteBotUserGrantByID(ctx context.Context, id pgtype.UUID) er
 }
 
 const getBotUserGrantByID = `-- name: GetBotUserGrantByID :one
-SELECT id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at
+SELECT id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at, team_id
 FROM bot_user_grants
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetBotUserGrantByID(ctx context.Context, id pgtype.UUID) (BotUserGrant, error) {
@@ -80,6 +81,7 @@ func (q *Queries) GetBotUserGrantByID(ctx context.Context, id pgtype.UUID) (BotU
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -98,8 +100,8 @@ SELECT
   u.display_name AS user_display_name,
   u.avatar_url AS user_avatar_url
 FROM bot_user_grants g
-LEFT JOIN users u ON u.id = g.user_id
-WHERE g.bot_id = $1
+LEFT JOIN users u ON u.id = g.user_id AND u.team_id = public.memoh_current_team_id()
+WHERE g.team_id = public.memoh_current_team_id() AND g.bot_id = $1
 ORDER BY g.subject_type DESC, g.created_at ASC
 `
 
@@ -152,7 +154,8 @@ func (q *Queries) ListBotUserGrants(ctx context.Context, botID pgtype.UUID) ([]L
 const listBotUserGrantsForUser = `-- name: ListBotUserGrantsForUser :many
 SELECT id, bot_id, subject_type, user_id, permissions
 FROM bot_user_grants
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND (
     subject_type = 'everyone'
     OR (subject_type = 'user' AND user_id = $2::uuid)
@@ -202,8 +205,8 @@ const updateBotUserGrantPermissions = `-- name: UpdateBotUserGrantPermissions :o
 UPDATE bot_user_grants
 SET permissions = $2,
     updated_at = now()
-WHERE id = $1
-RETURNING id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, bot_id, subject_type, user_id, permissions, created_by_user_id, created_at, updated_at, team_id
 `
 
 type UpdateBotUserGrantPermissionsParams struct {
@@ -223,6 +226,7 @@ func (q *Queries) UpdateBotUserGrantPermissions(ctx context.Context, arg UpdateB
 		&i.CreatedByUserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/bots.sql.go
+++ b/internal/db/postgres/sqlc/bots.sql.go
@@ -92,14 +92,16 @@ const deleteBotByID = `-- name: DeleteBotByID :exec
 WITH target_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.bot_id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.bot_id = $1
   ORDER BY session.id
   FOR UPDATE
 ),
 target_compaction_artifacts AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.bot_id = $1
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.bot_id = $1
     AND (SELECT count(*) FROM target_sessions) >= 0
   ORDER BY compact.id
   FOR UPDATE
@@ -107,13 +109,15 @@ target_compaction_artifacts AS MATERIALIZED (
 deleted_compaction_artifacts AS (
   DELETE FROM bot_history_message_compacts compact
   USING target_compaction_artifacts target
-  WHERE compact.id = target.id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = target.id
   RETURNING compact.id
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.bot_id = $1
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.bot_id = $1
     AND (SELECT count(*) FROM target_sessions) >= 0
     AND (SELECT count(*) FROM deleted_compaction_artifacts) >= 0
   ORDER BY message.id
@@ -122,18 +126,21 @@ target_messages AS MATERIALIZED (
 deleted_messages AS (
   DELETE FROM bot_history_messages message
   USING target_messages target
-  WHERE message.id = target.id
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = target.id
   RETURNING message.id
 ),
 deleted_sessions AS (
   DELETE FROM bot_sessions session
   USING target_sessions target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
     AND (SELECT count(*) FROM deleted_messages) >= 0
   RETURNING session.id
 )
 DELETE FROM bots bot
-WHERE bot.id = $1
+WHERE bot.team_id = public.memoh_current_team_id()
+  AND bot.id = $1
   AND (SELECT count(*) FROM target_sessions) >= 0
   AND (SELECT count(*) FROM deleted_sessions) >= 0
 `
@@ -146,7 +153,7 @@ func (q *Queries) DeleteBotByID(ctx context.Context, id pgtype.UUID) error {
 const getBotByID = `-- name: GetBotByID :one
 SELECT id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id, metadata, created_at, updated_at
 FROM bots
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 type GetBotByIDRow struct {
@@ -211,7 +218,7 @@ func (q *Queries) GetBotByID(ctx context.Context, id pgtype.UUID) (GetBotByIDRow
 const getBotByName = `-- name: GetBotByName :one
 SELECT id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id, metadata, created_at, updated_at
 FROM bots
-WHERE name = $1
+WHERE team_id = public.memoh_current_team_id() AND name = $1
 `
 
 type GetBotByNameRow struct {
@@ -276,15 +283,19 @@ func (q *Queries) GetBotByName(ctx context.Context, name string) (GetBotByNameRo
 const listAccessibleBots = `-- name: ListAccessibleBots :many
 SELECT id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, metadata, created_at, updated_at
 FROM bots b
-WHERE b.owner_user_id = $1
-   OR EXISTS (
-     SELECT 1 FROM bot_user_grants g
-     WHERE g.bot_id = b.id
-       AND (
-         g.subject_type = 'everyone'
-         OR (g.subject_type = 'user' AND g.user_id = $1)
-       )
-   )
+WHERE b.team_id = public.memoh_current_team_id()
+  AND (
+    b.owner_user_id = $1
+    OR EXISTS (
+      SELECT 1 FROM bot_user_grants g
+      WHERE g.team_id = b.team_id
+        AND g.bot_id = b.id
+        AND (
+          g.subject_type = 'everyone'
+          OR (g.subject_type = 'user' AND g.user_id = $1)
+        )
+    )
+  )
 ORDER BY b.created_at DESC
 `
 
@@ -355,7 +366,7 @@ func (q *Queries) ListAccessibleBots(ctx context.Context, ownerUserID pgtype.UUI
 const listBotsByOwner = `-- name: ListBotsByOwner :many
 SELECT id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, metadata, created_at, updated_at
 FROM bots
-WHERE owner_user_id = $1
+WHERE team_id = public.memoh_current_team_id() AND owner_user_id = $1
 ORDER BY created_at DESC
 `
 
@@ -426,7 +437,7 @@ func (q *Queries) ListBotsByOwner(ctx context.Context, ownerUserID pgtype.UUID) 
 const listHeartbeatEnabledBots = `-- name: ListHeartbeatEnabledBots :many
 SELECT id, owner_user_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt
 FROM bots
-WHERE heartbeat_enabled = true AND status = 'ready'
+WHERE team_id = public.memoh_current_team_id() AND heartbeat_enabled = true AND status = 'ready'
 `
 
 type ListHeartbeatEnabledBotsRow struct {
@@ -467,7 +478,7 @@ const updateBotOwner = `-- name: UpdateBotOwner :one
 UPDATE bots
 SET owner_user_id = $2,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, metadata, created_at, updated_at
 `
 
@@ -536,7 +547,7 @@ SET name = $2,
     is_active = $6,
     metadata = $7,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, reasoning_enabled, reasoning_effort, chat_model_id, search_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, metadata, created_at, updated_at
 `
 
@@ -613,7 +624,7 @@ const updateBotStatus = `-- name: UpdateBotStatus :exec
 UPDATE bots
 SET status = $2,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 type UpdateBotStatusParams struct {

--- a/internal/db/postgres/sqlc/channel_identities.sql.go
+++ b/internal/db/postgres/sqlc/channel_identities.sql.go
@@ -14,7 +14,7 @@ import (
 const createChannelIdentity = `-- name: CreateChannelIdentity :one
 INSERT INTO channel_identities (channel_type, channel_subject_id, display_name, avatar_url, metadata)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at
+RETURNING id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id
 `
 
 type CreateChannelIdentityParams struct {
@@ -43,14 +43,15 @@ func (q *Queries) CreateChannelIdentity(ctx context.Context, arg CreateChannelId
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getChannelIdentityByChannelSubject = `-- name: GetChannelIdentityByChannelSubject :one
-SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at
+SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id
 FROM channel_identities
-WHERE channel_type = $1 AND channel_subject_id = $2
+WHERE team_id = public.memoh_current_team_id() AND channel_type = $1 AND channel_subject_id = $2
 `
 
 type GetChannelIdentityByChannelSubjectParams struct {
@@ -70,14 +71,15 @@ func (q *Queries) GetChannelIdentityByChannelSubject(ctx context.Context, arg Ge
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getChannelIdentityByID = `-- name: GetChannelIdentityByID :one
-SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at
+SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id
 FROM channel_identities
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetChannelIdentityByID(ctx context.Context, id pgtype.UUID) (ChannelIdentity, error) {
@@ -92,14 +94,15 @@ func (q *Queries) GetChannelIdentityByID(ctx context.Context, id pgtype.UUID) (C
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getChannelIdentityByIDForUpdate = `-- name: GetChannelIdentityByIDForUpdate :one
-SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at
+SELECT id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id
 FROM channel_identities
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 FOR UPDATE
 `
 
@@ -115,6 +118,7 @@ func (q *Queries) GetChannelIdentityByIDForUpdate(ctx context.Context, id pgtype
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -128,13 +132,17 @@ SELECT
   ci.avatar_url,
   ci.metadata,
   ci.created_at,
-  ci.updated_at
+  ci.updated_at,
+  ci.team_id
 FROM channel_identities ci
 WHERE
-  $1::text = ''
-  OR ci.channel_type ILIKE '%' || $1::text || '%'
-  OR ci.channel_subject_id ILIKE '%' || $1::text || '%'
-  OR COALESCE(ci.display_name, '') ILIKE '%' || $1::text || '%'
+  ci.team_id = public.memoh_current_team_id()
+  AND (
+    $1::text = ''
+    OR ci.channel_type ILIKE '%' || $1::text || '%'
+    OR ci.channel_subject_id ILIKE '%' || $1::text || '%'
+    OR COALESCE(ci.display_name, '') ILIKE '%' || $1::text || '%'
+  )
 ORDER BY ci.updated_at DESC
 LIMIT $2
 `
@@ -162,6 +170,7 @@ func (q *Queries) SearchChannelIdentities(ctx context.Context, arg SearchChannel
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -176,13 +185,13 @@ func (q *Queries) SearchChannelIdentities(ctx context.Context, arg SearchChannel
 const upsertChannelIdentityByChannelSubject = `-- name: UpsertChannelIdentityByChannelSubject :one
 INSERT INTO channel_identities (channel_type, channel_subject_id, display_name, avatar_url, metadata)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (channel_type, channel_subject_id)
+ON CONFLICT (team_id, channel_type, channel_subject_id)
 DO UPDATE SET
   display_name = COALESCE(NULLIF(EXCLUDED.display_name, ''), channel_identities.display_name),
   avatar_url = COALESCE(NULLIF(EXCLUDED.avatar_url, ''), channel_identities.avatar_url),
   metadata = EXCLUDED.metadata,
   updated_at = now()
-RETURNING id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at
+RETURNING id, channel_type, channel_subject_id, display_name, avatar_url, metadata, created_at, updated_at, team_id
 `
 
 type UpsertChannelIdentityByChannelSubjectParams struct {
@@ -211,6 +220,7 @@ func (q *Queries) UpsertChannelIdentityByChannelSubject(ctx context.Context, arg
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/channel_identity_bindings.sql.go
+++ b/internal/db/postgres/sqlc/channel_identity_bindings.sql.go
@@ -14,7 +14,7 @@ import (
 const createChannelLinkCode = `-- name: CreateChannelLinkCode :one
 INSERT INTO channel_link_codes (token, user_id, channel_type, expires_at)
 VALUES ($1, $2, $4::text, $3)
-RETURNING token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at
+RETURNING token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at, team_id
 `
 
 type CreateChannelLinkCodeParams struct {
@@ -40,13 +40,14 @@ func (q *Queries) CreateChannelLinkCode(ctx context.Context, arg CreateChannelLi
 		&i.ConsumedAt,
 		&i.ConsumedChannelIdentityID,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteUserChannelIdentityBinding = `-- name: DeleteUserChannelIdentityBinding :exec
 DELETE FROM user_channel_identity_bindings
-WHERE user_id = $1 AND channel_identity_id = $2
+WHERE team_id = public.memoh_current_team_id() AND user_id = $1 AND channel_identity_id = $2
 `
 
 type DeleteUserChannelIdentityBindingParams struct {
@@ -60,9 +61,9 @@ func (q *Queries) DeleteUserChannelIdentityBinding(ctx context.Context, arg Dele
 }
 
 const getChannelLinkCodeByToken = `-- name: GetChannelLinkCodeByToken :one
-SELECT token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at
+SELECT token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at, team_id
 FROM channel_link_codes
-WHERE token = $1
+WHERE team_id = public.memoh_current_team_id() AND token = $1
 `
 
 func (q *Queries) GetChannelLinkCodeByToken(ctx context.Context, token string) (ChannelLinkCode, error) {
@@ -76,6 +77,7 @@ func (q *Queries) GetChannelLinkCodeByToken(ctx context.Context, token string) (
 		&i.ConsumedAt,
 		&i.ConsumedChannelIdentityID,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -92,7 +94,8 @@ SELECT
   ci.display_name AS channel_identity_display_name,
   ci.avatar_url AS channel_identity_avatar_url
 FROM user_channel_identity_bindings b
-LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id
+LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id()
 ORDER BY b.created_at DESC
 `
 
@@ -150,8 +153,9 @@ SELECT DISTINCT
   ci.display_name AS channel_identity_display_name,
   ci.avatar_url AS channel_identity_avatar_url
 FROM user_channel_identity_bindings b
-INNER JOIN bot_user_grants g ON g.user_id = b.user_id AND g.bot_id = $1 AND g.subject_type = 'user'
-LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id
+INNER JOIN bot_user_grants g ON g.user_id = b.user_id AND g.bot_id = $1 AND g.subject_type = 'user' AND g.team_id = public.memoh_current_team_id()
+LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id()
 ORDER BY b.created_at DESC
 `
 
@@ -209,8 +213,8 @@ SELECT
   ci.display_name AS channel_identity_display_name,
   ci.avatar_url AS channel_identity_avatar_url
 FROM user_channel_identity_bindings b
-LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id
-WHERE b.user_id = $1
+LEFT JOIN channel_identities ci ON ci.id = b.channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.user_id = $1
 ORDER BY b.created_at DESC
 `
 
@@ -259,7 +263,7 @@ func (q *Queries) ListChannelIdentityBindingsForUser(ctx context.Context, userID
 const listUserIDsByChannelIdentity = `-- name: ListUserIDsByChannelIdentity :many
 SELECT user_id
 FROM user_channel_identity_bindings
-WHERE channel_identity_id = $1
+WHERE team_id = public.memoh_current_team_id() AND channel_identity_id = $1
 `
 
 func (q *Queries) ListUserIDsByChannelIdentity(ctx context.Context, channelIdentityID pgtype.UUID) ([]pgtype.UUID, error) {
@@ -286,8 +290,8 @@ const markChannelLinkCodeConsumed = `-- name: MarkChannelLinkCodeConsumed :one
 UPDATE channel_link_codes
 SET consumed_at = now(),
     consumed_channel_identity_id = $2
-WHERE token = $1 AND consumed_at IS NULL AND expires_at > now()
-RETURNING token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at
+WHERE team_id = public.memoh_current_team_id() AND token = $1 AND consumed_at IS NULL AND expires_at > now()
+RETURNING token, user_id, channel_type, expires_at, consumed_at, consumed_channel_identity_id, created_at, team_id
 `
 
 type MarkChannelLinkCodeConsumedParams struct {
@@ -306,6 +310,7 @@ func (q *Queries) MarkChannelLinkCodeConsumed(ctx context.Context, arg MarkChann
 		&i.ConsumedAt,
 		&i.ConsumedChannelIdentityID,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -315,7 +320,8 @@ WITH claimed AS (
   UPDATE channel_link_codes
   SET consumed_at = now(),
       consumed_channel_identity_id = $2
-  WHERE token = $1
+  WHERE team_id = public.memoh_current_team_id()
+    AND token = $1
     AND consumed_at IS NULL
     AND expires_at > now()
   RETURNING user_id
@@ -323,9 +329,9 @@ WITH claimed AS (
 INSERT INTO user_channel_identity_bindings (user_id, channel_identity_id)
 SELECT user_id, $2
 FROM claimed
-ON CONFLICT (user_id, channel_identity_id) DO UPDATE
+ON CONFLICT (team_id, user_id, channel_identity_id) DO UPDATE
   SET updated_at = now()
-RETURNING id, user_id, channel_identity_id, created_at, updated_at
+RETURNING id, user_id, channel_identity_id, created_at, updated_at, team_id
 `
 
 type RedeemChannelLinkCodeParams struct {
@@ -342,6 +348,7 @@ func (q *Queries) RedeemChannelLinkCode(ctx context.Context, arg RedeemChannelLi
 		&i.ChannelIdentityID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -349,9 +356,9 @@ func (q *Queries) RedeemChannelLinkCode(ctx context.Context, arg RedeemChannelLi
 const upsertUserChannelIdentityBinding = `-- name: UpsertUserChannelIdentityBinding :one
 INSERT INTO user_channel_identity_bindings (user_id, channel_identity_id)
 VALUES ($1, $2)
-ON CONFLICT (user_id, channel_identity_id) DO UPDATE
+ON CONFLICT (team_id, user_id, channel_identity_id) DO UPDATE
   SET updated_at = now()
-RETURNING id, user_id, channel_identity_id, created_at, updated_at
+RETURNING id, user_id, channel_identity_id, created_at, updated_at, team_id
 `
 
 type UpsertUserChannelIdentityBindingParams struct {
@@ -368,6 +375,7 @@ func (q *Queries) UpsertUserChannelIdentityBinding(ctx context.Context, arg Upse
 		&i.ChannelIdentityID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/channel_routes.sql.go
+++ b/internal/db/postgres/sqlc/channel_routes.sql.go
@@ -104,12 +104,14 @@ const deleteChatRoute = `-- name: DeleteChatRoute :exec
 WITH route_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.route_id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.route_id = $1
   ORDER BY session.id
   FOR UPDATE
 )
 DELETE FROM bot_channel_routes route
-WHERE route.id = $1
+WHERE route.team_id = public.memoh_current_team_id()
+  AND route.id = $1
   AND (SELECT count(*) FROM route_sessions) >= 0
 `
 
@@ -134,7 +136,8 @@ SELECT
   created_at,
   updated_at
 FROM bot_channel_routes
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND channel_type = $2
   AND external_conversation_id = $3
   AND COALESCE(external_thread_id, '') = COALESCE($4, '')
@@ -206,7 +209,7 @@ SELECT
   created_at,
   updated_at
 FROM bot_channel_routes
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 type GetChatRouteByIDRow struct {
@@ -262,7 +265,7 @@ SELECT
   created_at,
   updated_at
 FROM bot_channel_routes
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY created_at ASC
 `
 
@@ -320,7 +323,8 @@ const setRouteActiveSession = `-- name: SetRouteActiveSession :exec
 WITH destination_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = $1::uuid
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = $1::uuid
   FOR KEY SHARE
 )
 UPDATE bot_channel_routes route
@@ -329,7 +333,8 @@ SET active_session_id = COALESCE(
       $1::uuid
     ),
     updated_at = now()
-WHERE route.id = $2
+WHERE route.team_id = public.memoh_current_team_id()
+  AND route.id = $2
 `
 
 type SetRouteActiveSessionParams struct {
@@ -345,7 +350,7 @@ func (q *Queries) SetRouteActiveSession(ctx context.Context, arg SetRouteActiveS
 const updateChatRouteMetadata = `-- name: UpdateChatRouteMetadata :exec
 UPDATE bot_channel_routes
 SET metadata = $1, updated_at = now()
-WHERE id = $2
+WHERE team_id = public.memoh_current_team_id() AND id = $2
 `
 
 type UpdateChatRouteMetadataParams struct {
@@ -361,7 +366,7 @@ func (q *Queries) UpdateChatRouteMetadata(ctx context.Context, arg UpdateChatRou
 const updateChatRouteReplyTarget = `-- name: UpdateChatRouteReplyTarget :exec
 UPDATE bot_channel_routes
 SET default_reply_target = $1, updated_at = now()
-WHERE id = $2
+WHERE team_id = public.memoh_current_team_id() AND id = $2
 `
 
 type UpdateChatRouteReplyTargetParams struct {

--- a/internal/db/postgres/sqlc/channels.sql.go
+++ b/internal/db/postgres/sqlc/channels.sql.go
@@ -13,7 +13,7 @@ import (
 
 const deleteBotChannelConfig = `-- name: DeleteBotChannelConfig :exec
 DELETE FROM bot_channel_configs
-WHERE bot_id = $1 AND channel_type = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_type = $2
 `
 
 type DeleteBotChannelConfigParams struct {
@@ -27,9 +27,9 @@ func (q *Queries) DeleteBotChannelConfig(ctx context.Context, arg DeleteBotChann
 }
 
 const getBotChannelConfig = `-- name: GetBotChannelConfig :one
-SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id
 FROM bot_channel_configs
-WHERE bot_id = $1 AND channel_type = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_type = $2
 LIMIT 1
 `
 
@@ -54,14 +54,15 @@ func (q *Queries) GetBotChannelConfig(ctx context.Context, arg GetBotChannelConf
 		&i.VerifiedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getBotChannelConfigByExternalIdentity = `-- name: GetBotChannelConfigByExternalIdentity :one
-SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id
 FROM bot_channel_configs
-WHERE channel_type = $1 AND external_identity = $2
+WHERE team_id = public.memoh_current_team_id() AND channel_type = $1 AND external_identity = $2
 LIMIT 1
 `
 
@@ -86,14 +87,15 @@ func (q *Queries) GetBotChannelConfigByExternalIdentity(ctx context.Context, arg
 		&i.VerifiedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getUserChannelBinding = `-- name: GetUserChannelBinding :one
-SELECT id, user_id, channel_type, config, created_at, updated_at
+SELECT id, user_id, channel_type, config, created_at, updated_at, team_id
 FROM user_channel_bindings
-WHERE user_id = $1 AND channel_type = $2
+WHERE team_id = public.memoh_current_team_id() AND user_id = $1 AND channel_type = $2
 LIMIT 1
 `
 
@@ -112,14 +114,15 @@ func (q *Queries) GetUserChannelBinding(ctx context.Context, arg GetUserChannelB
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listBotChannelConfigsByType = `-- name: ListBotChannelConfigsByType :many
-SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+SELECT id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id
 FROM bot_channel_configs
-WHERE channel_type = $1
+WHERE team_id = public.memoh_current_team_id() AND channel_type = $1
 ORDER BY created_at DESC
 `
 
@@ -145,6 +148,7 @@ func (q *Queries) ListBotChannelConfigsByType(ctx context.Context, channelType s
 			&i.VerifiedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -157,9 +161,9 @@ func (q *Queries) ListBotChannelConfigsByType(ctx context.Context, channelType s
 }
 
 const listUserChannelBindingsByPlatform = `-- name: ListUserChannelBindingsByPlatform :many
-SELECT id, user_id, channel_type, config, created_at, updated_at
+SELECT id, user_id, channel_type, config, created_at, updated_at, team_id
 FROM user_channel_bindings
-WHERE channel_type = $1
+WHERE team_id = public.memoh_current_team_id() AND channel_type = $1
 ORDER BY created_at DESC
 `
 
@@ -179,6 +183,7 @@ func (q *Queries) ListUserChannelBindingsByPlatform(ctx context.Context, channel
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -196,7 +201,7 @@ SET routing = COALESCE(routing, '{}'::jsonb) || jsonb_build_object(
   '_matrix',
   COALESCE(routing->'_matrix', '{}'::jsonb) || jsonb_build_object('since_token', $2::text)
 )
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 type SaveMatrixSyncSinceTokenParams struct {
@@ -217,8 +222,8 @@ UPDATE bot_channel_configs
 SET
   disabled = $3,
   updated_at = now()
-WHERE bot_id = $1 AND channel_type = $2
-RETURNING id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND channel_type = $2
+RETURNING id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id
 `
 
 type UpdateBotChannelConfigDisabledParams struct {
@@ -243,6 +248,7 @@ func (q *Queries) UpdateBotChannelConfigDisabled(ctx context.Context, arg Update
 		&i.VerifiedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -252,7 +258,7 @@ INSERT INTO bot_channel_configs (
   bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-ON CONFLICT (bot_id, channel_type)
+ON CONFLICT (team_id, bot_id, channel_type)
 DO UPDATE SET
   credentials = EXCLUDED.credentials,
   external_identity = EXCLUDED.external_identity,
@@ -262,7 +268,7 @@ DO UPDATE SET
   disabled = EXCLUDED.disabled,
   verified_at = EXCLUDED.verified_at,
   updated_at = now()
-RETURNING id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at
+RETURNING id, bot_id, channel_type, credentials, external_identity, self_identity, routing, capabilities, disabled, verified_at, created_at, updated_at, team_id
 `
 
 type UpsertBotChannelConfigParams struct {
@@ -303,6 +309,7 @@ func (q *Queries) UpsertBotChannelConfig(ctx context.Context, arg UpsertBotChann
 		&i.VerifiedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -310,11 +317,11 @@ func (q *Queries) UpsertBotChannelConfig(ctx context.Context, arg UpsertBotChann
 const upsertUserChannelBinding = `-- name: UpsertUserChannelBinding :one
 INSERT INTO user_channel_bindings (user_id, channel_type, config)
 VALUES ($1, $2, $3)
-ON CONFLICT (user_id, channel_type)
+ON CONFLICT (team_id, user_id, channel_type)
 DO UPDATE SET
   config = EXCLUDED.config,
   updated_at = now()
-RETURNING id, user_id, channel_type, config, created_at, updated_at
+RETURNING id, user_id, channel_type, config, created_at, updated_at, team_id
 `
 
 type UpsertUserChannelBindingParams struct {
@@ -333,6 +340,7 @@ func (q *Queries) UpsertUserChannelBinding(ctx context.Context, arg UpsertUserCh
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/compaction_logs.sql.go
+++ b/internal/db/postgres/sqlc/compaction_logs.sql.go
@@ -13,23 +13,32 @@ import (
 
 const completeCompactionLog = `-- name: CompleteCompactionLog :one
 WITH target_compact AS MATERIALIZED (
-  SELECT compact.id, compact.session_id
+  SELECT compact.id, compact.session_id, compact.team_id
   FROM bot_history_message_compacts compact
-  WHERE compact.id = $1
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = $1
     AND compact.status = 'pending'
 ),
 owner_session AS MATERIALIZED (
-  SELECT session.id, session.bot_id, session.compaction_epoch
+  SELECT session.id, session.bot_id, session.compaction_epoch, session.team_id
   FROM bot_sessions session
-  JOIN target_compact compact ON compact.session_id = session.id
+  JOIN target_compact compact
+    ON compact.session_id = session.id
+   AND compact.team_id = session.team_id
+  WHERE session.team_id = public.memoh_current_team_id()
   FOR UPDATE OF session
 ),
 locked_compact AS MATERIALIZED (
-  SELECT compact.id
+  SELECT compact.id, compact.team_id
   FROM bot_history_message_compacts compact
-  JOIN target_compact target ON target.id = compact.id
-  LEFT JOIN owner_session owner ON owner.id = target.session_id
-  WHERE target.session_id IS NULL OR owner.id IS NOT NULL
+  JOIN target_compact target
+    ON target.id = compact.id
+   AND target.team_id = compact.team_id
+  LEFT JOIN owner_session owner
+    ON owner.id = target.session_id
+   AND owner.team_id = target.team_id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND (target.session_id IS NULL OR owner.id IS NOT NULL)
   FOR UPDATE OF compact
 )
 UPDATE bot_history_message_compacts compact
@@ -44,7 +53,9 @@ SET status = $2,
     anchor_end_ms = $10,
     completed_at = now()
 FROM locked_compact locked
-WHERE compact.id = locked.id
+WHERE compact.team_id = public.memoh_current_team_id()
+  AND compact.team_id = locked.team_id
+  AND compact.id = locked.id
   AND compact.status = 'pending'
   AND (
     $2 <> 'ok'
@@ -54,7 +65,8 @@ WHERE compact.id = locked.id
         OR EXISTS (
           SELECT 1
           FROM owner_session owner
-          WHERE owner.id = compact.session_id
+          WHERE owner.team_id = compact.team_id
+            AND owner.id = compact.session_id
             AND owner.bot_id = compact.bot_id
             AND owner.compaction_epoch = compact.compaction_epoch
         )
@@ -62,7 +74,8 @@ WHERE compact.id = locked.id
       AND (
         SELECT count(*)
         FROM bot_history_messages source_message
-        WHERE source_message.compact_id = compact.id
+        WHERE source_message.team_id = compact.team_id
+          AND source_message.compact_id = compact.id
       ) = $4
     )
   )
@@ -70,7 +83,7 @@ RETURNING compact.id, compact.bot_id, compact.session_id, compact.status, compac
           compact.message_count, compact.error_message, compact.usage, compact.model_id,
           compact.artifact_version, compact.coverage, compact.anchor_start_ms, compact.anchor_end_ms,
           compact.artifact_level, compact.parent_ids, compact.superseded_by, compact.superseded_at,
-          compact.compaction_epoch, compact.started_at, compact.completed_at
+          compact.compaction_epoch, compact.started_at, compact.completed_at, compact.team_id
 `
 
 type CompleteCompactionLogParams struct {
@@ -121,12 +134,13 @@ func (q *Queries) CompleteCompactionLog(ctx context.Context, arg CompleteCompact
 		&i.CompactionEpoch,
 		&i.StartedAt,
 		&i.CompletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const countCompactionLogsByBot = `-- name: CountCompactionLogsByBot :one
-SELECT count(*) FROM bot_history_message_compacts WHERE bot_id = $1
+SELECT count(*) FROM bot_history_message_compacts WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) CountCompactionLogsByBot(ctx context.Context, botID pgtype.UUID) (int64, error) {
@@ -138,19 +152,20 @@ func (q *Queries) CountCompactionLogsByBot(ctx context.Context, botID pgtype.UUI
 
 const createCompactionLog = `-- name: CreateCompactionLog :one
 WITH owner_session AS MATERIALIZED (
-  SELECT session.id, session.bot_id, session.compaction_epoch
+  SELECT session.id, session.bot_id, session.compaction_epoch, session.team_id
   FROM bot_sessions session
-  WHERE session.id = $2
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = $2
     AND session.bot_id = $1
     AND session.compaction_epoch = $3
   FOR UPDATE
 )
-INSERT INTO bot_history_message_compacts (bot_id, session_id, compaction_epoch)
-SELECT $1, owner_session.id, owner_session.compaction_epoch
+INSERT INTO bot_history_message_compacts (bot_id, session_id, compaction_epoch, team_id)
+SELECT $1, owner_session.id, owner_session.compaction_epoch, owner_session.team_id
 FROM owner_session
 RETURNING id, bot_id, session_id, status, summary, message_count, error_message, usage, model_id,
           artifact_version, coverage, anchor_start_ms, anchor_end_ms, artifact_level, parent_ids,
-          superseded_by, superseded_at, compaction_epoch, started_at, completed_at
+          superseded_by, superseded_at, compaction_epoch, started_at, completed_at, team_id
 `
 
 type CreateCompactionLogParams struct {
@@ -183,6 +198,7 @@ func (q *Queries) CreateCompactionLog(ctx context.Context, arg CreateCompactionL
 		&i.CompactionEpoch,
 		&i.StartedAt,
 		&i.CompletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -191,7 +207,8 @@ const deleteCompactionLogsByBot = `-- name: DeleteCompactionLogsByBot :exec
 WITH target_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.bot_id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.bot_id = $1
   ORDER BY session.id
   FOR UPDATE
 ),
@@ -199,20 +216,23 @@ invalidated_sessions AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
   FROM target_sessions target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
   RETURNING session.id
 ),
 target_compaction_logs AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.bot_id = $1
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.bot_id = $1
     AND (SELECT count(*) FROM target_sessions) >= 0
   ORDER BY compact.id
   FOR UPDATE
 )
 DELETE FROM bot_history_message_compacts AS compacts
 USING target_compaction_logs target
-WHERE compacts.id = target.id
+WHERE compacts.team_id = public.memoh_current_team_id()
+  AND compacts.id = target.id
 `
 
 func (q *Queries) DeleteCompactionLogsByBot(ctx context.Context, targetBotID pgtype.UUID) error {
@@ -223,15 +243,17 @@ func (q *Queries) DeleteCompactionLogsByBot(ctx context.Context, targetBotID pgt
 const getCompactionLogByID = `-- name: GetCompactionLogByID :one
 SELECT id, bot_id, session_id, status, summary, message_count, error_message, usage, model_id,
        artifact_version, coverage, anchor_start_ms, anchor_end_ms, artifact_level, parent_ids,
-       superseded_by, superseded_at, compaction_epoch, started_at, completed_at
+       superseded_by, superseded_at, compaction_epoch, started_at, completed_at, team_id
 FROM bot_history_message_compacts compact
-WHERE compact.id = $1
+WHERE compact.team_id = public.memoh_current_team_id()
+  AND compact.id = $1
   AND (
     compact.session_id IS NULL
     OR EXISTS (
       SELECT 1
       FROM bot_sessions owner_session
-      WHERE owner_session.id = compact.session_id
+      WHERE owner_session.team_id = compact.team_id
+        AND owner_session.id = compact.session_id
         AND owner_session.bot_id = compact.bot_id
         AND owner_session.compaction_epoch = compact.compaction_epoch
     )
@@ -262,6 +284,7 @@ func (q *Queries) GetCompactionLogByID(ctx context.Context, id pgtype.UUID) (Bot
 		&i.CompactionEpoch,
 		&i.StartedAt,
 		&i.CompletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -269,19 +292,22 @@ func (q *Queries) GetCompactionLogByID(ctx context.Context, id pgtype.UUID) (Bot
 const listCompactionArtifactLineageBySession = `-- name: ListCompactionArtifactLineageBySession :many
 SELECT c.id, c.bot_id, c.session_id, c.status, c.summary, c.message_count, c.error_message, c.usage, c.model_id,
        c.artifact_version, c.coverage, c.anchor_start_ms, c.anchor_end_ms, c.artifact_level, c.parent_ids,
-       c.superseded_by, c.superseded_at, c.compaction_epoch, c.started_at, c.completed_at
+       c.superseded_by, c.superseded_at, c.compaction_epoch, c.started_at, c.completed_at, c.team_id
 FROM bot_history_message_compacts c
 JOIN bot_sessions owner_session
   ON owner_session.id = $1
  AND owner_session.bot_id = c.bot_id
-WHERE c.session_id = owner_session.id
+ AND owner_session.team_id = c.team_id
+WHERE c.team_id = public.memoh_current_team_id()
+  AND c.session_id = owner_session.id
   AND c.compaction_epoch = owner_session.compaction_epoch
   AND (
     c.status = 'ok'
     OR EXISTS (
       SELECT 1
       FROM bot_history_message_compacts parent
-      WHERE parent.bot_id = owner_session.bot_id
+      WHERE parent.team_id = c.team_id
+        AND parent.bot_id = owner_session.bot_id
         AND parent.session_id = owner_session.id
         AND parent.compaction_epoch = owner_session.compaction_epoch
         AND parent.status = 'ok'
@@ -321,6 +347,7 @@ func (q *Queries) ListCompactionArtifactLineageBySession(ctx context.Context, id
 			&i.CompactionEpoch,
 			&i.StartedAt,
 			&i.CompletedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -338,7 +365,9 @@ FROM bot_history_message_compacts parent
 JOIN bot_sessions owner_session
   ON owner_session.id = $1::uuid
  AND owner_session.bot_id = $2
-WHERE parent.superseded_by = $3
+ AND owner_session.team_id = parent.team_id
+WHERE parent.team_id = public.memoh_current_team_id()
+  AND parent.superseded_by = $3
   AND parent.bot_id = owner_session.bot_id
   AND parent.session_id = owner_session.id
   AND parent.compaction_epoch = owner_session.compaction_epoch
@@ -346,7 +375,8 @@ WHERE parent.superseded_by = $3
   AND EXISTS (
     SELECT 1
     FROM bot_history_message_compacts successor
-    WHERE successor.id = parent.superseded_by
+    WHERE successor.team_id = parent.team_id
+      AND successor.id = parent.superseded_by
       AND successor.bot_id = owner_session.bot_id
       AND successor.session_id = owner_session.id
       AND successor.compaction_epoch = owner_session.compaction_epoch
@@ -383,9 +413,9 @@ func (q *Queries) ListCompactionArtifactParentIDsBySuccessor(ctx context.Context
 const listCompactionLogsByBot = `-- name: ListCompactionLogsByBot :many
 SELECT id, bot_id, session_id, status, summary, message_count, error_message, usage, model_id,
        artifact_version, coverage, anchor_start_ms, anchor_end_ms, artifact_level, parent_ids,
-       superseded_by, superseded_at, compaction_epoch, started_at, completed_at
+       superseded_by, superseded_at, compaction_epoch, started_at, completed_at, team_id
 FROM bot_history_message_compacts
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3
 `
@@ -426,6 +456,7 @@ func (q *Queries) ListCompactionLogsByBot(ctx context.Context, arg ListCompactio
 			&i.CompactionEpoch,
 			&i.StartedAt,
 			&i.CompletedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/postgres/sqlc/containers.sql.go
+++ b/internal/db/postgres/sqlc/containers.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const deleteContainerByBotID = `-- name: DeleteContainerByBotID :exec
-DELETE FROM containers WHERE bot_id = $1
+DELETE FROM containers WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) DeleteContainerByBotID(ctx context.Context, botID pgtype.UUID) error {
@@ -21,7 +21,7 @@ func (q *Queries) DeleteContainerByBotID(ctx context.Context, botID pgtype.UUID)
 }
 
 const getContainerByBotID = `-- name: GetContainerByBotID :one
-SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, workspace_backend, created_at, updated_at, last_started_at, last_stopped_at FROM containers WHERE bot_id = $1 ORDER BY updated_at DESC LIMIT 1
+SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, workspace_backend, created_at, updated_at, last_started_at, last_stopped_at, team_id FROM containers WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 ORDER BY updated_at DESC LIMIT 1
 `
 
 func (q *Queries) GetContainerByBotID(ctx context.Context, botID pgtype.UUID) (Container, error) {
@@ -42,12 +42,13 @@ func (q *Queries) GetContainerByBotID(ctx context.Context, botID pgtype.UUID) (C
 		&i.UpdatedAt,
 		&i.LastStartedAt,
 		&i.LastStoppedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listAutoStartContainers = `-- name: ListAutoStartContainers :many
-SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, workspace_backend, created_at, updated_at, last_started_at, last_stopped_at FROM containers WHERE auto_start = true ORDER BY updated_at DESC
+SELECT id, bot_id, container_id, container_name, image, status, namespace, auto_start, container_path, workspace_backend, created_at, updated_at, last_started_at, last_stopped_at, team_id FROM containers WHERE team_id = public.memoh_current_team_id() AND auto_start = true ORDER BY updated_at DESC
 `
 
 func (q *Queries) ListAutoStartContainers(ctx context.Context) ([]Container, error) {
@@ -74,6 +75,7 @@ func (q *Queries) ListAutoStartContainers(ctx context.Context) ([]Container, err
 			&i.UpdatedAt,
 			&i.LastStartedAt,
 			&i.LastStoppedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -88,7 +90,7 @@ func (q *Queries) ListAutoStartContainers(ctx context.Context) ([]Container, err
 const updateContainerStarted = `-- name: UpdateContainerStarted :exec
 UPDATE containers
 SET status = 'running', last_started_at = now(), updated_at = now()
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) UpdateContainerStarted(ctx context.Context, botID pgtype.UUID) error {
@@ -99,7 +101,7 @@ func (q *Queries) UpdateContainerStarted(ctx context.Context, botID pgtype.UUID)
 const updateContainerStatus = `-- name: UpdateContainerStatus :exec
 UPDATE containers
 SET status = $1, updated_at = now()
-WHERE bot_id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $2
 `
 
 type UpdateContainerStatusParams struct {
@@ -115,7 +117,7 @@ func (q *Queries) UpdateContainerStatus(ctx context.Context, arg UpdateContainer
 const updateContainerStopped = `-- name: UpdateContainerStopped :exec
 UPDATE containers
 SET status = 'stopped', last_stopped_at = now(), updated_at = now()
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) UpdateContainerStopped(ctx context.Context, botID pgtype.UUID) error {
@@ -141,7 +143,7 @@ VALUES (
   $10,
   $11
 )
-ON CONFLICT (container_id) DO UPDATE SET
+ON CONFLICT (team_id, container_id) DO UPDATE SET
   bot_id = EXCLUDED.bot_id,
   container_name = EXCLUDED.container_name,
   image = EXCLUDED.image,

--- a/internal/db/postgres/sqlc/conversations.sql.go
+++ b/internal/db/postgres/sqlc/conversations.sql.go
@@ -24,8 +24,8 @@ SELECT
   b.created_at,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $6
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $6
 LIMIT 1
 `
 
@@ -80,14 +80,16 @@ const deleteChat = `-- name: DeleteChat :exec
 WITH target_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.bot_id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.bot_id = $1
   ORDER BY session.id
   FOR UPDATE
 ),
 target_compaction_artifacts AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.bot_id = $1
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.bot_id = $1
     AND (SELECT count(*) FROM target_sessions) >= 0
   ORDER BY compact.id
   FOR UPDATE
@@ -95,13 +97,15 @@ target_compaction_artifacts AS MATERIALIZED (
 deleted_compaction_artifacts AS (
   DELETE FROM bot_history_message_compacts compact
   USING target_compaction_artifacts target
-  WHERE compact.id = target.id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = target.id
   RETURNING compact.id
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.bot_id = $1
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.bot_id = $1
     AND (SELECT count(*) FROM target_sessions) >= 0
     AND (SELECT count(*) FROM deleted_compaction_artifacts) >= 0
   ORDER BY message.id
@@ -110,18 +114,21 @@ target_messages AS MATERIALIZED (
 deleted_messages AS (
   DELETE FROM bot_history_messages message
   USING target_messages target
-  WHERE message.id = target.id
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = target.id
   RETURNING message.id
 ),
 deleted_sessions AS (
   DELETE FROM bot_sessions session
   USING target_sessions target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
     AND (SELECT count(*) FROM deleted_messages) >= 0
   RETURNING session.id
 )
 DELETE FROM bot_channel_routes bcr
-WHERE bcr.bot_id = $1
+WHERE bcr.team_id = public.memoh_current_team_id()
+  AND bcr.bot_id = $1
   AND (SELECT count(*) FROM deleted_sessions) >= 0
 `
 
@@ -143,8 +150,8 @@ SELECT
   b.created_at,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $1
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1
 `
 
 type GetChatByIDRow struct {
@@ -181,7 +188,7 @@ func (q *Queries) GetChatByID(ctx context.Context, id pgtype.UUID) (GetChatByIDR
 const getChatParticipant = `-- name: GetChatParticipant :one
 SELECT b.id AS chat_id, b.owner_user_id AS user_id, 'owner'::text AS role, b.created_at AS joined_at
 FROM bots b
-WHERE b.id = $1 AND b.owner_user_id = $2
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1 AND b.owner_user_id = $2
 LIMIT 1
 `
 
@@ -215,7 +222,7 @@ SELECT
   'owner'::text AS participant_role,
   NULL::timestamptz AS last_observed_at
 FROM bots b
-WHERE b.id = $1
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1
   AND b.owner_user_id = $2
 LIMIT 1
 `
@@ -244,8 +251,8 @@ SELECT
   chat_models.id AS model_id,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $1
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1
 `
 
 type GetChatSettingsRow struct {
@@ -264,7 +271,7 @@ func (q *Queries) GetChatSettings(ctx context.Context, id pgtype.UUID) (GetChatS
 const listChatParticipants = `-- name: ListChatParticipants :many
 SELECT b.id AS chat_id, b.owner_user_id AS user_id, 'owner'::text AS role, b.created_at AS joined_at
 FROM bots b
-WHERE b.id = $1
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1
 ORDER BY joined_at ASC
 `
 
@@ -313,8 +320,8 @@ SELECT
   b.created_at,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $1
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1
   AND b.owner_user_id = $2
 ORDER BY b.updated_at DESC
 `
@@ -381,8 +388,8 @@ SELECT
   b.created_at,
   b.updated_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $1
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1
 ORDER BY b.created_at DESC
 `
 
@@ -449,8 +456,8 @@ SELECT
   END)::text AS participant_role,
   NULL::timestamptz AS last_observed_at
 FROM bots b
-LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id
-WHERE b.id = $2
+LEFT JOIN models chat_models ON chat_models.id = b.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+WHERE b.team_id = public.memoh_current_team_id() AND b.id = $2
   AND b.owner_user_id = $1
 ORDER BY b.updated_at DESC
 `
@@ -515,7 +522,7 @@ SELECT 1
 WHERE EXISTS (
   SELECT 1
   FROM bots b
-  WHERE b.id = $1
+  WHERE b.team_id = public.memoh_current_team_id() AND b.id = $1
     AND b.owner_user_id = $2
 )
 `
@@ -533,7 +540,7 @@ func (q *Queries) RemoveChatParticipant(ctx context.Context, arg RemoveChatParti
 const touchChat = `-- name: TouchChat :exec
 UPDATE bots
 SET updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) TouchChat(ctx context.Context, chatID pgtype.UUID) error {
@@ -546,8 +553,8 @@ WITH updated AS (
   UPDATE bots
   SET display_name = $1,
       updated_at = now()
-  WHERE bots.id = $2
-  RETURNING id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, command_ui_language, reasoning_enabled, reasoning_effort, chat_model_id, chat_runtime, chat_acp_agent_id, chat_acp_project_path, chat_acp_project_mode, search_provider_id, fetch_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, heartbeat_model_id, compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id, title_model_id, image_model_id, discuss_probe_model_id, tts_model_id, transcription_model_id, video_model_id, persist_full_tool_results, show_tool_calls_in_im, tool_approval_config, display_enabled, overlay_provider, overlay_enabled, overlay_config, metadata, created_at, updated_at, acl_default_effect
+  WHERE bots.team_id = public.memoh_current_team_id() AND bots.id = $2
+  RETURNING id, owner_user_id, name, display_name, avatar_url, timezone, is_active, status, language, command_ui_language, reasoning_enabled, reasoning_effort, chat_model_id, chat_runtime, chat_acp_agent_id, chat_acp_project_path, chat_acp_project_mode, search_provider_id, fetch_provider_id, memory_provider_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt, heartbeat_model_id, compaction_enabled, compaction_threshold, compaction_ratio, compaction_model_id, title_model_id, image_model_id, discuss_probe_model_id, tts_model_id, transcription_model_id, video_model_id, persist_full_tool_results, show_tool_calls_in_im, tool_approval_config, display_enabled, overlay_provider, overlay_enabled, overlay_config, metadata, created_at, updated_at, acl_default_effect, team_id
 )
 SELECT
   updated.id AS id,
@@ -561,7 +568,7 @@ SELECT
   updated.created_at,
   updated.updated_at
 FROM updated
-LEFT JOIN models chat_models ON chat_models.id = updated.chat_model_id
+LEFT JOIN models chat_models ON chat_models.id = updated.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
 `
 
 type UpdateChatTitleParams struct {
@@ -607,7 +614,7 @@ updated AS (
   UPDATE bots
   SET chat_model_id = COALESCE($1::uuid, bots.chat_model_id),
       updated_at = now()
-  WHERE bots.id = $2
+  WHERE bots.team_id = public.memoh_current_team_id() AND bots.id = $2
   RETURNING bots.id, bots.chat_model_id, bots.updated_at
 )
 SELECT
@@ -615,7 +622,7 @@ SELECT
   chat_models.id AS model_id,
   updated.updated_at
 FROM updated
-LEFT JOIN models chat_models ON chat_models.id = updated.chat_model_id
+LEFT JOIN models chat_models ON chat_models.id = updated.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
 `
 
 type UpsertChatSettingsParams struct {

--- a/internal/db/postgres/sqlc/email_bindings.sql.go
+++ b/internal/db/postgres/sqlc/email_bindings.sql.go
@@ -22,7 +22,7 @@ VALUES (
   $6,
   $7
 )
-RETURNING id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at
+RETURNING id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at, team_id
 `
 
 type CreateBotEmailBindingParams struct {
@@ -57,12 +57,13 @@ func (q *Queries) CreateBotEmailBinding(ctx context.Context, arg CreateBotEmailB
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteBotEmailBinding = `-- name: DeleteBotEmailBinding :exec
-DELETE FROM bot_email_bindings WHERE id = $1
+DELETE FROM bot_email_bindings WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteBotEmailBinding(ctx context.Context, id pgtype.UUID) error {
@@ -71,8 +72,8 @@ func (q *Queries) DeleteBotEmailBinding(ctx context.Context, id pgtype.UUID) err
 }
 
 const getBotEmailBindingByBotAndProvider = `-- name: GetBotEmailBindingByBotAndProvider :one
-SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at FROM bot_email_bindings
-WHERE bot_id = $1 AND email_provider_id = $2
+SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at, team_id FROM bot_email_bindings
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND email_provider_id = $2
 `
 
 type GetBotEmailBindingByBotAndProviderParams struct {
@@ -94,12 +95,13 @@ func (q *Queries) GetBotEmailBindingByBotAndProvider(ctx context.Context, arg Ge
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getBotEmailBindingByID = `-- name: GetBotEmailBindingByID :one
-SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at FROM bot_email_bindings WHERE id = $1
+SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at, team_id FROM bot_email_bindings WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetBotEmailBindingByID(ctx context.Context, id pgtype.UUID) (BotEmailBinding, error) {
@@ -116,13 +118,14 @@ func (q *Queries) GetBotEmailBindingByID(ctx context.Context, id pgtype.UUID) (B
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listBotEmailBindings = `-- name: ListBotEmailBindings :many
-SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at FROM bot_email_bindings
-WHERE bot_id = $1
+SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at, team_id FROM bot_email_bindings
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY created_at DESC
 `
 
@@ -146,6 +149,7 @@ func (q *Queries) ListBotEmailBindings(ctx context.Context, botID pgtype.UUID) (
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -158,8 +162,8 @@ func (q *Queries) ListBotEmailBindings(ctx context.Context, botID pgtype.UUID) (
 }
 
 const listBotEmailBindingsByProvider = `-- name: ListBotEmailBindingsByProvider :many
-SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at FROM bot_email_bindings
-WHERE email_provider_id = $1
+SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at, team_id FROM bot_email_bindings
+WHERE team_id = public.memoh_current_team_id() AND email_provider_id = $1
 ORDER BY created_at DESC
 `
 
@@ -183,6 +187,7 @@ func (q *Queries) ListBotEmailBindingsByProvider(ctx context.Context, emailProvi
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -195,8 +200,8 @@ func (q *Queries) ListBotEmailBindingsByProvider(ctx context.Context, emailProvi
 }
 
 const listReadableBindingsByProvider = `-- name: ListReadableBindingsByProvider :many
-SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at FROM bot_email_bindings
-WHERE email_provider_id = $1 AND can_read = TRUE
+SELECT id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at, team_id FROM bot_email_bindings
+WHERE team_id = public.memoh_current_team_id() AND email_provider_id = $1 AND can_read = TRUE
 ORDER BY created_at DESC
 `
 
@@ -220,6 +225,7 @@ func (q *Queries) ListReadableBindingsByProvider(ctx context.Context, emailProvi
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -240,8 +246,8 @@ SET
   can_delete = $4,
   config = $5,
   updated_at = now()
-WHERE id = $6
-RETURNING id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $6
+RETURNING id, bot_id, email_provider_id, email_address, can_read, can_write, can_delete, config, created_at, updated_at, team_id
 `
 
 type UpdateBotEmailBindingParams struct {
@@ -274,6 +280,7 @@ func (q *Queries) UpdateBotEmailBinding(ctx context.Context, arg UpdateBotEmailB
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/email_oauth_tokens.sql.go
+++ b/internal/db/postgres/sqlc/email_oauth_tokens.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const deleteEmailOAuthToken = `-- name: DeleteEmailOAuthToken :exec
-DELETE FROM email_oauth_tokens WHERE email_provider_id = $1
+DELETE FROM email_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND email_provider_id = $1
 `
 
 func (q *Queries) DeleteEmailOAuthToken(ctx context.Context, emailProviderID pgtype.UUID) error {
@@ -21,7 +21,7 @@ func (q *Queries) DeleteEmailOAuthToken(ctx context.Context, emailProviderID pgt
 }
 
 const getEmailOAuthTokenByProvider = `-- name: GetEmailOAuthTokenByProvider :one
-SELECT id, email_provider_id, email_address, access_token, refresh_token, expires_at, scope, state, created_at, updated_at FROM email_oauth_tokens WHERE email_provider_id = $1
+SELECT id, email_provider_id, email_address, access_token, refresh_token, expires_at, scope, state, created_at, updated_at, team_id FROM email_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND email_provider_id = $1
 `
 
 func (q *Queries) GetEmailOAuthTokenByProvider(ctx context.Context, emailProviderID pgtype.UUID) (EmailOauthToken, error) {
@@ -38,12 +38,13 @@ func (q *Queries) GetEmailOAuthTokenByProvider(ctx context.Context, emailProvide
 		&i.State,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getEmailOAuthTokenByState = `-- name: GetEmailOAuthTokenByState :one
-SELECT id, email_provider_id, email_address, access_token, refresh_token, expires_at, scope, state, created_at, updated_at FROM email_oauth_tokens WHERE state = $1 AND state != ''
+SELECT id, email_provider_id, email_address, access_token, refresh_token, expires_at, scope, state, created_at, updated_at, team_id FROM email_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND state = $1 AND state != ''
 `
 
 func (q *Queries) GetEmailOAuthTokenByState(ctx context.Context, state string) (EmailOauthToken, error) {
@@ -60,6 +61,7 @@ func (q *Queries) GetEmailOAuthTokenByState(ctx context.Context, state string) (
 		&i.State,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -67,7 +69,7 @@ func (q *Queries) GetEmailOAuthTokenByState(ctx context.Context, state string) (
 const updateEmailOAuthState = `-- name: UpdateEmailOAuthState :exec
 INSERT INTO email_oauth_tokens (email_provider_id, state)
 VALUES ($1, $2)
-ON CONFLICT (email_provider_id) DO UPDATE SET
+ON CONFLICT (team_id, email_provider_id) DO UPDATE SET
   state      = EXCLUDED.state,
   updated_at = now()
 `
@@ -85,7 +87,7 @@ func (q *Queries) UpdateEmailOAuthState(ctx context.Context, arg UpdateEmailOAut
 const upsertEmailOAuthToken = `-- name: UpsertEmailOAuthToken :one
 INSERT INTO email_oauth_tokens (email_provider_id, email_address, access_token, refresh_token, expires_at, scope, state)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
-ON CONFLICT (email_provider_id) DO UPDATE SET
+ON CONFLICT (team_id, email_provider_id) DO UPDATE SET
   email_address  = EXCLUDED.email_address,
   access_token   = EXCLUDED.access_token,
   refresh_token  = EXCLUDED.refresh_token,
@@ -93,7 +95,7 @@ ON CONFLICT (email_provider_id) DO UPDATE SET
   scope          = EXCLUDED.scope,
   state          = EXCLUDED.state,
   updated_at     = now()
-RETURNING id, email_provider_id, email_address, access_token, refresh_token, expires_at, scope, state, created_at, updated_at
+RETURNING id, email_provider_id, email_address, access_token, refresh_token, expires_at, scope, state, created_at, updated_at, team_id
 `
 
 type UpsertEmailOAuthTokenParams struct {
@@ -128,6 +130,7 @@ func (q *Queries) UpsertEmailOAuthToken(ctx context.Context, arg UpsertEmailOAut
 		&i.State,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/email_outbox.sql.go
+++ b/internal/db/postgres/sqlc/email_outbox.sql.go
@@ -13,7 +13,7 @@ import (
 
 const countEmailOutboxByBot = `-- name: CountEmailOutboxByBot :one
 SELECT count(*) FROM email_outbox
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) CountEmailOutboxByBot(ctx context.Context, botID pgtype.UUID) (int64, error) {
@@ -36,7 +36,7 @@ VALUES (
   $8,
   $9
 )
-RETURNING id, provider_id, bot_id, message_id, from_address, to_addresses, subject, body_text, body_html, attachments, status, error, sent_at, created_at
+RETURNING id, provider_id, bot_id, message_id, from_address, to_addresses, subject, body_text, body_html, attachments, status, error, sent_at, created_at, team_id
 `
 
 type CreateEmailOutboxParams struct {
@@ -79,12 +79,13 @@ func (q *Queries) CreateEmailOutbox(ctx context.Context, arg CreateEmailOutboxPa
 		&i.Error,
 		&i.SentAt,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getEmailOutboxByID = `-- name: GetEmailOutboxByID :one
-SELECT id, provider_id, bot_id, message_id, from_address, to_addresses, subject, body_text, body_html, attachments, status, error, sent_at, created_at FROM email_outbox WHERE id = $1
+SELECT id, provider_id, bot_id, message_id, from_address, to_addresses, subject, body_text, body_html, attachments, status, error, sent_at, created_at, team_id FROM email_outbox WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetEmailOutboxByID(ctx context.Context, id pgtype.UUID) (EmailOutbox, error) {
@@ -105,13 +106,14 @@ func (q *Queries) GetEmailOutboxByID(ctx context.Context, id pgtype.UUID) (Email
 		&i.Error,
 		&i.SentAt,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listEmailOutboxByBot = `-- name: ListEmailOutboxByBot :many
-SELECT id, provider_id, bot_id, message_id, from_address, to_addresses, subject, body_text, body_html, attachments, status, error, sent_at, created_at FROM email_outbox
-WHERE bot_id = $1
+SELECT id, provider_id, bot_id, message_id, from_address, to_addresses, subject, body_text, body_html, attachments, status, error, sent_at, created_at, team_id FROM email_outbox
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY created_at DESC
 LIMIT $3 OFFSET $2
 `
@@ -146,6 +148,7 @@ func (q *Queries) ListEmailOutboxByBot(ctx context.Context, arg ListEmailOutboxB
 			&i.Error,
 			&i.SentAt,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -160,7 +163,7 @@ func (q *Queries) ListEmailOutboxByBot(ctx context.Context, arg ListEmailOutboxB
 const updateEmailOutboxFailed = `-- name: UpdateEmailOutboxFailed :exec
 UPDATE email_outbox
 SET status = 'failed', error = $1
-WHERE id = $2
+WHERE team_id = public.memoh_current_team_id() AND id = $2
 `
 
 type UpdateEmailOutboxFailedParams struct {
@@ -176,7 +179,7 @@ func (q *Queries) UpdateEmailOutboxFailed(ctx context.Context, arg UpdateEmailOu
 const updateEmailOutboxSent = `-- name: UpdateEmailOutboxSent :exec
 UPDATE email_outbox
 SET message_id = $1, status = 'sent', sent_at = now()
-WHERE id = $2
+WHERE team_id = public.memoh_current_team_id() AND id = $2
 `
 
 type UpdateEmailOutboxSentParams struct {

--- a/internal/db/postgres/sqlc/email_providers.sql.go
+++ b/internal/db/postgres/sqlc/email_providers.sql.go
@@ -19,7 +19,7 @@ VALUES (
   $3,
   $4
 )
-RETURNING id, user_id, name, provider, config, created_at, updated_at
+RETURNING id, user_id, name, provider, config, created_at, updated_at, team_id
 `
 
 type CreateEmailProviderParams struct {
@@ -45,12 +45,13 @@ func (q *Queries) CreateEmailProvider(ctx context.Context, arg CreateEmailProvid
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteEmailProvider = `-- name: DeleteEmailProvider :exec
-DELETE FROM email_providers WHERE id = $1
+DELETE FROM email_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteEmailProvider(ctx context.Context, id pgtype.UUID) error {
@@ -60,7 +61,7 @@ func (q *Queries) DeleteEmailProvider(ctx context.Context, id pgtype.UUID) error
 
 const deleteEmailProviderByIDAndUser = `-- name: DeleteEmailProviderByIDAndUser :exec
 DELETE FROM email_providers
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
   AND user_id = $2
 `
 
@@ -75,7 +76,7 @@ func (q *Queries) DeleteEmailProviderByIDAndUser(ctx context.Context, arg Delete
 }
 
 const getEmailProviderByID = `-- name: GetEmailProviderByID :one
-SELECT id, user_id, name, provider, config, created_at, updated_at FROM email_providers WHERE id = $1
+SELECT id, user_id, name, provider, config, created_at, updated_at, team_id FROM email_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetEmailProviderByID(ctx context.Context, id pgtype.UUID) (EmailProvider, error) {
@@ -89,13 +90,14 @@ func (q *Queries) GetEmailProviderByID(ctx context.Context, id pgtype.UUID) (Ema
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getEmailProviderByIDAndUser = `-- name: GetEmailProviderByIDAndUser :one
-SELECT id, user_id, name, provider, config, created_at, updated_at FROM email_providers
-WHERE id = $1
+SELECT id, user_id, name, provider, config, created_at, updated_at, team_id FROM email_providers
+WHERE team_id = public.memoh_current_team_id() AND id = $1
   AND user_id = $2
 `
 
@@ -115,13 +117,14 @@ func (q *Queries) GetEmailProviderByIDAndUser(ctx context.Context, arg GetEmailP
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getEmailProviderByNameAndUser = `-- name: GetEmailProviderByNameAndUser :one
-SELECT id, user_id, name, provider, config, created_at, updated_at FROM email_providers
-WHERE user_id = $1
+SELECT id, user_id, name, provider, config, created_at, updated_at, team_id FROM email_providers
+WHERE team_id = public.memoh_current_team_id() AND user_id = $1
   AND name = $2
 `
 
@@ -141,12 +144,14 @@ func (q *Queries) GetEmailProviderByNameAndUser(ctx context.Context, arg GetEmai
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listEmailProviders = `-- name: ListEmailProviders :many
-SELECT id, user_id, name, provider, config, created_at, updated_at FROM email_providers
+SELECT id, user_id, name, provider, config, created_at, updated_at, team_id FROM email_providers
+WHERE team_id = public.memoh_current_team_id()
 ORDER BY created_at DESC
 `
 
@@ -167,6 +172,7 @@ func (q *Queries) ListEmailProviders(ctx context.Context) ([]EmailProvider, erro
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -179,8 +185,8 @@ func (q *Queries) ListEmailProviders(ctx context.Context) ([]EmailProvider, erro
 }
 
 const listEmailProvidersByProvider = `-- name: ListEmailProvidersByProvider :many
-SELECT id, user_id, name, provider, config, created_at, updated_at FROM email_providers
-WHERE provider = $1
+SELECT id, user_id, name, provider, config, created_at, updated_at, team_id FROM email_providers
+WHERE team_id = public.memoh_current_team_id() AND provider = $1
 ORDER BY created_at DESC
 `
 
@@ -201,6 +207,7 @@ func (q *Queries) ListEmailProvidersByProvider(ctx context.Context, provider str
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -213,8 +220,8 @@ func (q *Queries) ListEmailProvidersByProvider(ctx context.Context, provider str
 }
 
 const listEmailProvidersByUser = `-- name: ListEmailProvidersByUser :many
-SELECT id, user_id, name, provider, config, created_at, updated_at FROM email_providers
-WHERE user_id = $1
+SELECT id, user_id, name, provider, config, created_at, updated_at, team_id FROM email_providers
+WHERE team_id = public.memoh_current_team_id() AND user_id = $1
 ORDER BY created_at DESC
 `
 
@@ -235,6 +242,7 @@ func (q *Queries) ListEmailProvidersByUser(ctx context.Context, userID pgtype.UU
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -247,8 +255,8 @@ func (q *Queries) ListEmailProvidersByUser(ctx context.Context, userID pgtype.UU
 }
 
 const listEmailProvidersByUserAndProvider = `-- name: ListEmailProvidersByUserAndProvider :many
-SELECT id, user_id, name, provider, config, created_at, updated_at FROM email_providers
-WHERE user_id = $1
+SELECT id, user_id, name, provider, config, created_at, updated_at, team_id FROM email_providers
+WHERE team_id = public.memoh_current_team_id() AND user_id = $1
   AND provider = $2
 ORDER BY created_at DESC
 `
@@ -275,6 +283,7 @@ func (q *Queries) ListEmailProvidersByUserAndProvider(ctx context.Context, arg L
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -293,8 +302,8 @@ SET
   provider = $2,
   config = $3,
   updated_at = now()
-WHERE id = $4
-RETURNING id, user_id, name, provider, config, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $4
+RETURNING id, user_id, name, provider, config, created_at, updated_at, team_id
 `
 
 type UpdateEmailProviderParams struct {
@@ -320,6 +329,7 @@ func (q *Queries) UpdateEmailProvider(ctx context.Context, arg UpdateEmailProvid
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -331,9 +341,9 @@ SET
   provider = $2,
   config = $3,
   updated_at = now()
-WHERE id = $4
+WHERE team_id = public.memoh_current_team_id() AND id = $4
   AND user_id = $5
-RETURNING id, user_id, name, provider, config, created_at, updated_at
+RETURNING id, user_id, name, provider, config, created_at, updated_at, team_id
 `
 
 type UpdateEmailProviderByIDAndUserParams struct {
@@ -361,6 +371,7 @@ func (q *Queries) UpdateEmailProviderByIDAndUser(ctx context.Context, arg Update
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/fetch_providers.sql.go
+++ b/internal/db/postgres/sqlc/fetch_providers.sql.go
@@ -19,7 +19,7 @@ VALUES (
   $3,
   $4
 )
-RETURNING id, name, provider, config, enable, created_at, updated_at
+RETURNING id, name, provider, config, enable, created_at, updated_at, team_id
 `
 
 type CreateFetchProviderParams struct {
@@ -45,12 +45,13 @@ func (q *Queries) CreateFetchProvider(ctx context.Context, arg CreateFetchProvid
 		&i.Enable,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteFetchProvider = `-- name: DeleteFetchProvider :exec
-DELETE FROM fetch_providers WHERE id = $1
+DELETE FROM fetch_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteFetchProvider(ctx context.Context, id pgtype.UUID) error {
@@ -59,7 +60,7 @@ func (q *Queries) DeleteFetchProvider(ctx context.Context, id pgtype.UUID) error
 }
 
 const getFetchProviderByID = `-- name: GetFetchProviderByID :one
-SELECT id, name, provider, config, enable, created_at, updated_at FROM fetch_providers WHERE id = $1
+SELECT id, name, provider, config, enable, created_at, updated_at, team_id FROM fetch_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetFetchProviderByID(ctx context.Context, id pgtype.UUID) (FetchProvider, error) {
@@ -73,12 +74,13 @@ func (q *Queries) GetFetchProviderByID(ctx context.Context, id pgtype.UUID) (Fet
 		&i.Enable,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getFetchProviderByName = `-- name: GetFetchProviderByName :one
-SELECT id, name, provider, config, enable, created_at, updated_at FROM fetch_providers WHERE name = $1
+SELECT id, name, provider, config, enable, created_at, updated_at, team_id FROM fetch_providers WHERE team_id = public.memoh_current_team_id() AND name = $1
 `
 
 func (q *Queries) GetFetchProviderByName(ctx context.Context, name string) (FetchProvider, error) {
@@ -92,12 +94,14 @@ func (q *Queries) GetFetchProviderByName(ctx context.Context, name string) (Fetc
 		&i.Enable,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listFetchProviders = `-- name: ListFetchProviders :many
-SELECT id, name, provider, config, enable, created_at, updated_at FROM fetch_providers
+SELECT id, name, provider, config, enable, created_at, updated_at, team_id FROM fetch_providers
+WHERE team_id = public.memoh_current_team_id()
 ORDER BY created_at DESC
 `
 
@@ -118,6 +122,7 @@ func (q *Queries) ListFetchProviders(ctx context.Context) ([]FetchProvider, erro
 			&i.Enable,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -130,8 +135,8 @@ func (q *Queries) ListFetchProviders(ctx context.Context) ([]FetchProvider, erro
 }
 
 const listFetchProvidersByProvider = `-- name: ListFetchProvidersByProvider :many
-SELECT id, name, provider, config, enable, created_at, updated_at FROM fetch_providers
-WHERE provider = $1
+SELECT id, name, provider, config, enable, created_at, updated_at, team_id FROM fetch_providers
+WHERE team_id = public.memoh_current_team_id() AND provider = $1
 ORDER BY created_at DESC
 `
 
@@ -152,6 +157,7 @@ func (q *Queries) ListFetchProvidersByProvider(ctx context.Context, provider str
 			&i.Enable,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -171,8 +177,8 @@ SET
   config = $3,
   enable = $4,
   updated_at = now()
-WHERE id = $5
-RETURNING id, name, provider, config, enable, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $5
+RETURNING id, name, provider, config, enable, created_at, updated_at, team_id
 `
 
 type UpdateFetchProviderParams struct {
@@ -200,6 +206,7 @@ func (q *Queries) UpdateFetchProvider(ctx context.Context, arg UpdateFetchProvid
 		&i.Enable,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/heartbeat_logs.sql.go
+++ b/internal/db/postgres/sqlc/heartbeat_logs.sql.go
@@ -19,8 +19,8 @@ SET status = $2,
     usage = $5,
     model_id = $6,
     completed_at = now()
-WHERE id = $1
-RETURNING id, bot_id, session_id, status, result_text, error_message, usage, model_id, started_at, completed_at
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, bot_id, session_id, status, result_text, error_message, usage, model_id, started_at, completed_at, team_id
 `
 
 type CompleteHeartbeatLogParams struct {
@@ -53,12 +53,13 @@ func (q *Queries) CompleteHeartbeatLog(ctx context.Context, arg CompleteHeartbea
 		&i.ModelID,
 		&i.StartedAt,
 		&i.CompletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const countHeartbeatLogsByBot = `-- name: CountHeartbeatLogsByBot :one
-SELECT count(*) FROM bot_heartbeat_logs WHERE bot_id = $1
+SELECT count(*) FROM bot_heartbeat_logs WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) CountHeartbeatLogsByBot(ctx context.Context, botID pgtype.UUID) (int64, error) {
@@ -109,7 +110,7 @@ func (q *Queries) CreateHeartbeatLog(ctx context.Context, arg CreateHeartbeatLog
 }
 
 const deleteHeartbeatLogsByBot = `-- name: DeleteHeartbeatLogsByBot :exec
-DELETE FROM bot_heartbeat_logs WHERE bot_id = $1
+DELETE FROM bot_heartbeat_logs WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) DeleteHeartbeatLogsByBot(ctx context.Context, botID pgtype.UUID) error {
@@ -120,7 +121,7 @@ func (q *Queries) DeleteHeartbeatLogsByBot(ctx context.Context, botID pgtype.UUI
 const listHeartbeatLogsByBot = `-- name: ListHeartbeatLogsByBot :many
 SELECT id, bot_id, session_id, status, result_text, error_message, usage, started_at, completed_at
 FROM bot_heartbeat_logs
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3
 `

--- a/internal/db/postgres/sqlc/mcp.sql.go
+++ b/internal/db/postgres/sqlc/mcp.sql.go
@@ -15,7 +15,7 @@ const createMCPConnection = `-- name: CreateMCPConnection :one
 INSERT INTO mcp_connections (bot_id, name, type, config, is_active, auth_type)
 VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at
+          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id
 `
 
 type CreateMCPConnectionParams struct {
@@ -55,6 +55,7 @@ func (q *Queries) CreateMCPConnection(ctx context.Context, arg CreateMCPConnecti
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -66,7 +67,7 @@ INSERT INTO mcp_connections (
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at
+          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id
 `
 
 type CreateManagedMCPConnectionParams struct {
@@ -114,13 +115,14 @@ func (q *Queries) CreateManagedMCPConnection(ctx context.Context, arg CreateMana
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteMCPConnection = `-- name: DeleteMCPConnection :exec
 DELETE FROM mcp_connections
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 `
 
 type DeleteMCPConnectionParams struct {
@@ -135,7 +137,7 @@ func (q *Queries) DeleteMCPConnection(ctx context.Context, arg DeleteMCPConnecti
 
 const deleteMCPConnectionsByPlugin = `-- name: DeleteMCPConnectionsByPlugin :exec
 DELETE FROM mcp_connections
-WHERE bot_id = $1 AND managed_by_plugin_installation_id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND managed_by_plugin_installation_id = $2
 `
 
 type DeleteMCPConnectionsByPluginParams struct {
@@ -150,9 +152,9 @@ func (q *Queries) DeleteMCPConnectionsByPlugin(ctx context.Context, arg DeleteMC
 
 const getMCPConnectionByID = `-- name: GetMCPConnectionByID :one
 SELECT id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-       managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at
+       managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id
 FROM mcp_connections
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 LIMIT 1
 `
 
@@ -182,15 +184,16 @@ func (q *Queries) GetMCPConnectionByID(ctx context.Context, arg GetMCPConnection
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listMCPConnectionsByBotID = `-- name: ListMCPConnectionsByBotID :many
 SELECT id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-       managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at
+       managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id
 FROM mcp_connections
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY created_at DESC
 `
 
@@ -221,6 +224,7 @@ func (q *Queries) ListMCPConnectionsByBotID(ctx context.Context, botID pgtype.UU
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -240,9 +244,9 @@ SET name = $3,
     is_active = $6,
     auth_type = $7,
     updated_at = now()
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 RETURNING id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at
+          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id
 `
 
 type UpdateMCPConnectionParams struct {
@@ -284,6 +288,7 @@ func (q *Queries) UpdateMCPConnection(ctx context.Context, arg UpdateMCPConnecti
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -292,7 +297,7 @@ const updateMCPConnectionActive = `-- name: UpdateMCPConnectionActive :exec
 UPDATE mcp_connections
 SET is_active = $3,
     updated_at = now()
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 `
 
 type UpdateMCPConnectionActiveParams struct {
@@ -310,7 +315,7 @@ const updateMCPConnectionAuthType = `-- name: UpdateMCPConnectionAuthType :exec
 UPDATE mcp_connections
 SET auth_type = $2,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 type UpdateMCPConnectionAuthTypeParams struct {
@@ -330,7 +335,7 @@ SET status = $3,
     last_probed_at = now(),
     status_message = $5,
     updated_at = now()
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 `
 
 type UpdateMCPConnectionProbeResultParams struct {
@@ -356,7 +361,7 @@ const updateMCPConnectionsActiveByPlugin = `-- name: UpdateMCPConnectionsActiveB
 UPDATE mcp_connections
 SET is_active = $3,
     updated_at = now()
-WHERE bot_id = $1 AND managed_by_plugin_installation_id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND managed_by_plugin_installation_id = $2
 `
 
 type UpdateMCPConnectionsActiveByPluginParams struct {
@@ -373,12 +378,12 @@ func (q *Queries) UpdateMCPConnectionsActiveByPlugin(ctx context.Context, arg Up
 const upsertMCPConnectionByName = `-- name: UpsertMCPConnectionByName :one
 INSERT INTO mcp_connections (bot_id, name, type, config)
 VALUES ($1, $2, $3, $4)
-ON CONFLICT (bot_id, name)
+ON CONFLICT (team_id, bot_id, name)
 DO UPDATE SET type = EXCLUDED.type,
               config = EXCLUDED.config,
               updated_at = now()
 RETURNING id, bot_id, name, type, config, is_active, status, tools_cache, last_probed_at, status_message, auth_type,
-          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at
+          managed_by_plugin_installation_id, managed_resource_key, visible, metadata, created_at, updated_at, team_id
 `
 
 type UpsertMCPConnectionByNameParams struct {
@@ -414,6 +419,7 @@ func (q *Queries) UpsertMCPConnectionByName(ctx context.Context, arg UpsertMCPCo
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/mcp_oauth.sql.go
+++ b/internal/db/postgres/sqlc/mcp_oauth.sql.go
@@ -21,7 +21,7 @@ SET access_token = '',
     state_param = '',
     redirect_uri = '',
     updated_at = now()
-WHERE connection_id = $1
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1
 `
 
 func (q *Queries) ClearMCPOAuthTokens(ctx context.Context, connectionID pgtype.UUID) error {
@@ -31,7 +31,7 @@ func (q *Queries) ClearMCPOAuthTokens(ctx context.Context, connectionID pgtype.U
 
 const deleteMCPOAuthToken = `-- name: DeleteMCPOAuthToken :exec
 DELETE FROM mcp_oauth_tokens
-WHERE connection_id = $1
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1
 `
 
 func (q *Queries) DeleteMCPOAuthToken(ctx context.Context, connectionID pgtype.UUID) error {
@@ -44,9 +44,9 @@ SELECT id, connection_id, resource_metadata_url, authorization_server_url,
        authorization_endpoint, token_endpoint, registration_endpoint,
        scopes_supported, client_id, client_secret, access_token, refresh_token,
        token_type, expires_at, scope, pkce_code_verifier, state_param,
-       resource_uri, redirect_uri, created_at, updated_at
+       resource_uri, redirect_uri, created_at, updated_at, team_id
 FROM mcp_oauth_tokens
-WHERE connection_id = $1
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1
 LIMIT 1
 `
 
@@ -75,6 +75,7 @@ func (q *Queries) GetMCPOAuthToken(ctx context.Context, connectionID pgtype.UUID
 		&i.RedirectUri,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -84,9 +85,9 @@ SELECT id, connection_id, resource_metadata_url, authorization_server_url,
        authorization_endpoint, token_endpoint, registration_endpoint,
        scopes_supported, client_id, client_secret, access_token, refresh_token,
        token_type, expires_at, scope, pkce_code_verifier, state_param,
-       resource_uri, redirect_uri, created_at, updated_at
+       resource_uri, redirect_uri, created_at, updated_at, team_id
 FROM mcp_oauth_tokens
-WHERE state_param = $1
+WHERE team_id = public.memoh_current_team_id() AND state_param = $1
 LIMIT 1
 `
 
@@ -115,6 +116,7 @@ func (q *Queries) GetMCPOAuthTokenByState(ctx context.Context, stateParam string
 		&i.RedirectUri,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -123,7 +125,7 @@ const updateMCPOAuthClientSecret = `-- name: UpdateMCPOAuthClientSecret :exec
 UPDATE mcp_oauth_tokens
 SET client_secret = $2,
     updated_at = now()
-WHERE connection_id = $1
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1
 `
 
 type UpdateMCPOAuthClientSecretParams struct {
@@ -143,7 +145,7 @@ SET pkce_code_verifier = $2,
     client_id = $4,
     redirect_uri = $5,
     updated_at = now()
-WHERE connection_id = $1
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1
 `
 
 type UpdateMCPOAuthPKCEStateParams struct {
@@ -175,7 +177,7 @@ SET access_token = $2,
     pkce_code_verifier = '',
     state_param = '',
     updated_at = now()
-WHERE connection_id = $1
+WHERE team_id = public.memoh_current_team_id() AND connection_id = $1
 `
 
 type UpdateMCPOAuthTokensParams struct {
@@ -204,7 +206,7 @@ INSERT INTO mcp_oauth_tokens (connection_id, resource_metadata_url, authorizatio
     authorization_endpoint, token_endpoint, registration_endpoint, scopes_supported,
     resource_uri)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-ON CONFLICT (connection_id)
+ON CONFLICT (team_id, connection_id)
 DO UPDATE SET resource_metadata_url = EXCLUDED.resource_metadata_url,
               authorization_server_url = EXCLUDED.authorization_server_url,
               authorization_endpoint = EXCLUDED.authorization_endpoint,
@@ -217,7 +219,7 @@ RETURNING id, connection_id, resource_metadata_url, authorization_server_url,
           authorization_endpoint, token_endpoint, registration_endpoint,
           scopes_supported, client_id, client_secret, access_token, refresh_token,
           token_type, expires_at, scope, pkce_code_verifier, state_param,
-          resource_uri, redirect_uri, created_at, updated_at
+          resource_uri, redirect_uri, created_at, updated_at, team_id
 `
 
 type UpsertMCPOAuthDiscoveryParams struct {
@@ -265,6 +267,7 @@ func (q *Queries) UpsertMCPOAuthDiscovery(ctx context.Context, arg UpsertMCPOAut
 		&i.RedirectUri,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/media.sql.go
+++ b/internal/db/postgres/sqlc/media.sql.go
@@ -15,7 +15,7 @@ const countMessageAssetsByBot = `-- name: CountMessageAssetsByBot :one
 SELECT COUNT(*)
 FROM bot_history_message_assets a
 JOIN bot_history_messages m ON m.id = a.message_id
-WHERE m.bot_id = $1
+WHERE a.team_id = public.memoh_current_team_id() AND m.team_id = public.memoh_current_team_id() AND m.bot_id = $1
 `
 
 func (q *Queries) CountMessageAssetsByBot(ctx context.Context, botID pgtype.UUID) (int64, error) {
@@ -29,12 +29,15 @@ const createMessageAsset = `-- name: CreateMessageAsset :one
 WITH message_locator AS MATERIALIZED (
   SELECT message.id, message.session_id
   FROM bot_history_messages message
-  WHERE message.id = $1
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = $1
 ),
 owner_session AS MATERIALIZED (
   SELECT session.id, session.bot_id, session.compaction_epoch
   FROM bot_sessions session
-  JOIN message_locator message ON message.session_id = session.id
+  JOIN message_locator message
+    ON message.session_id = session.id
+   AND session.team_id = public.memoh_current_team_id()
   FOR UPDATE
 ),
 target_message AS MATERIALIZED (
@@ -42,7 +45,8 @@ target_message AS MATERIALIZED (
   FROM bot_history_messages message
   JOIN message_locator locator ON locator.id = message.id
   LEFT JOIN owner_session owner ON owner.id = locator.session_id
-  WHERE locator.session_id IS NULL OR owner.id IS NOT NULL
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND (locator.session_id IS NULL OR owner.id IS NOT NULL)
   FOR UPDATE OF message
 ),
 changed_asset AS MATERIALIZED (
@@ -50,6 +54,7 @@ changed_asset AS MATERIALIZED (
   FROM target_message target
   LEFT JOIN bot_history_message_assets existing
     ON existing.message_id = target.id
+   AND existing.team_id = public.memoh_current_team_id()
    AND existing.content_hash = $2
   WHERE existing.id IS NULL
      OR existing.role IS DISTINCT FROM $3
@@ -62,8 +67,11 @@ invalidated_session AS (
   SET compaction_epoch = session.compaction_epoch + 1
   FROM changed_asset changed
   JOIN owner_session owner ON owner.id = changed.session_id
-  JOIN bot_history_message_compacts compact ON compact.id = changed.compact_id
-  WHERE session.id = owner.id
+  JOIN bot_history_message_compacts compact
+    ON compact.id = changed.compact_id
+   AND compact.team_id = public.memoh_current_team_id()
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = owner.id
     AND compact.bot_id = owner.bot_id
     AND compact.session_id = owner.id
     AND compact.compaction_epoch = owner.compaction_epoch
@@ -81,7 +89,7 @@ upserted_asset AS (
     $6
   FROM target_message target
   CROSS JOIN (SELECT count(*) FROM invalidated_session) invalidation_done
-  ON CONFLICT (message_id, content_hash) DO UPDATE SET
+  ON CONFLICT (team_id, message_id, content_hash) DO UPDATE SET
     role = EXCLUDED.role,
     ordinal = EXCLUDED.ordinal,
     name = EXCLUDED.name,
@@ -138,7 +146,7 @@ func (q *Queries) CreateMessageAsset(ctx context.Context, arg CreateMessageAsset
 const createStorageProvider = `-- name: CreateStorageProvider :one
 INSERT INTO storage_providers (name, provider, config)
 VALUES ($1, $2, $3)
-RETURNING id, name, provider, config, created_at, updated_at
+RETURNING id, name, provider, config, created_at, updated_at, team_id
 `
 
 type CreateStorageProviderParams struct {
@@ -157,12 +165,13 @@ func (q *Queries) CreateStorageProvider(ctx context.Context, arg CreateStoragePr
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteMessageAssets = `-- name: DeleteMessageAssets :exec
-DELETE FROM bot_history_message_assets WHERE message_id = $1
+DELETE FROM bot_history_message_assets WHERE team_id = public.memoh_current_team_id() AND message_id = $1
 `
 
 func (q *Queries) DeleteMessageAssets(ctx context.Context, messageID pgtype.UUID) error {
@@ -171,7 +180,7 @@ func (q *Queries) DeleteMessageAssets(ctx context.Context, messageID pgtype.UUID
 }
 
 const getBotStorageBinding = `-- name: GetBotStorageBinding :one
-SELECT id, bot_id, storage_provider_id, base_path, created_at, updated_at FROM bot_storage_bindings WHERE bot_id = $1
+SELECT id, bot_id, storage_provider_id, base_path, created_at, updated_at, team_id FROM bot_storage_bindings WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) GetBotStorageBinding(ctx context.Context, botID pgtype.UUID) (BotStorageBinding, error) {
@@ -184,12 +193,13 @@ func (q *Queries) GetBotStorageBinding(ctx context.Context, botID pgtype.UUID) (
 		&i.BasePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getStorageProviderByID = `-- name: GetStorageProviderByID :one
-SELECT id, name, provider, config, created_at, updated_at FROM storage_providers WHERE id = $1
+SELECT id, name, provider, config, created_at, updated_at, team_id FROM storage_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetStorageProviderByID(ctx context.Context, id pgtype.UUID) (StorageProvider, error) {
@@ -202,12 +212,13 @@ func (q *Queries) GetStorageProviderByID(ctx context.Context, id pgtype.UUID) (S
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getStorageProviderByName = `-- name: GetStorageProviderByName :one
-SELECT id, name, provider, config, created_at, updated_at FROM storage_providers WHERE name = $1
+SELECT id, name, provider, config, created_at, updated_at, team_id FROM storage_providers WHERE team_id = public.memoh_current_team_id() AND name = $1
 `
 
 func (q *Queries) GetStorageProviderByName(ctx context.Context, name string) (StorageProvider, error) {
@@ -220,6 +231,7 @@ func (q *Queries) GetStorageProviderByName(ctx context.Context, name string) (St
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -227,7 +239,7 @@ func (q *Queries) GetStorageProviderByName(ctx context.Context, name string) (St
 const listMessageAssets = `-- name: ListMessageAssets :many
 SELECT id AS rel_id, message_id, role, ordinal, content_hash, name, metadata
 FROM bot_history_message_assets
-WHERE message_id = $1
+WHERE team_id = public.memoh_current_team_id() AND message_id = $1
 ORDER BY ordinal ASC
 `
 
@@ -272,7 +284,7 @@ func (q *Queries) ListMessageAssets(ctx context.Context, messageID pgtype.UUID) 
 const listMessageAssetsBatch = `-- name: ListMessageAssetsBatch :many
 SELECT id AS rel_id, message_id, role, ordinal, content_hash, name, metadata
 FROM bot_history_message_assets
-WHERE message_id = ANY($1::uuid[])
+WHERE team_id = public.memoh_current_team_id() AND message_id = ANY($1::uuid[])
 ORDER BY message_id, ordinal ASC
 `
 
@@ -315,7 +327,7 @@ func (q *Queries) ListMessageAssetsBatch(ctx context.Context, messageIds []pgtyp
 }
 
 const listStorageProviders = `-- name: ListStorageProviders :many
-SELECT id, name, provider, config, created_at, updated_at FROM storage_providers ORDER BY created_at DESC
+SELECT id, name, provider, config, created_at, updated_at, team_id FROM storage_providers WHERE team_id = public.memoh_current_team_id() ORDER BY created_at DESC
 `
 
 func (q *Queries) ListStorageProviders(ctx context.Context) ([]StorageProvider, error) {
@@ -334,6 +346,7 @@ func (q *Queries) ListStorageProviders(ctx context.Context) ([]StorageProvider, 
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -348,11 +361,11 @@ func (q *Queries) ListStorageProviders(ctx context.Context) ([]StorageProvider, 
 const upsertBotStorageBinding = `-- name: UpsertBotStorageBinding :one
 INSERT INTO bot_storage_bindings (bot_id, storage_provider_id, base_path)
 VALUES ($1, $2, $3)
-ON CONFLICT (bot_id) DO UPDATE SET
+ON CONFLICT (team_id, bot_id) DO UPDATE SET
   storage_provider_id = EXCLUDED.storage_provider_id,
   base_path = EXCLUDED.base_path,
   updated_at = now()
-RETURNING id, bot_id, storage_provider_id, base_path, created_at, updated_at
+RETURNING id, bot_id, storage_provider_id, base_path, created_at, updated_at, team_id
 `
 
 type UpsertBotStorageBindingParams struct {
@@ -371,6 +384,7 @@ func (q *Queries) UpsertBotStorageBinding(ctx context.Context, arg UpsertBotStor
 		&i.BasePath,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/memory_providers.sql.go
+++ b/internal/db/postgres/sqlc/memory_providers.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const countMemoryProvidersByDefault = `-- name: CountMemoryProvidersByDefault :one
-SELECT COUNT(*) FROM memory_providers WHERE is_default = true
+SELECT COUNT(*) FROM memory_providers WHERE team_id = public.memoh_current_team_id() AND is_default = true
 `
 
 func (q *Queries) CountMemoryProvidersByDefault(ctx context.Context) (int64, error) {
@@ -25,7 +25,7 @@ func (q *Queries) CountMemoryProvidersByDefault(ctx context.Context) (int64, err
 const createMemoryProvider = `-- name: CreateMemoryProvider :one
 INSERT INTO memory_providers (name, provider, config, is_default)
 VALUES ($1, $2, $3, $4)
-RETURNING id, name, provider, config, is_default, created_at, updated_at
+RETURNING id, name, provider, config, is_default, created_at, updated_at, team_id
 `
 
 type CreateMemoryProviderParams struct {
@@ -51,12 +51,13 @@ func (q *Queries) CreateMemoryProvider(ctx context.Context, arg CreateMemoryProv
 		&i.IsDefault,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteMemoryProvider = `-- name: DeleteMemoryProvider :exec
-DELETE FROM memory_providers WHERE id = $1
+DELETE FROM memory_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteMemoryProvider(ctx context.Context, id pgtype.UUID) error {
@@ -65,7 +66,7 @@ func (q *Queries) DeleteMemoryProvider(ctx context.Context, id pgtype.UUID) erro
 }
 
 const getDefaultMemoryProvider = `-- name: GetDefaultMemoryProvider :one
-SELECT id, name, provider, config, is_default, created_at, updated_at FROM memory_providers WHERE is_default = true LIMIT 1
+SELECT id, name, provider, config, is_default, created_at, updated_at, team_id FROM memory_providers WHERE team_id = public.memoh_current_team_id() AND is_default = true LIMIT 1
 `
 
 func (q *Queries) GetDefaultMemoryProvider(ctx context.Context) (MemoryProvider, error) {
@@ -79,12 +80,13 @@ func (q *Queries) GetDefaultMemoryProvider(ctx context.Context) (MemoryProvider,
 		&i.IsDefault,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getMemoryProviderByID = `-- name: GetMemoryProviderByID :one
-SELECT id, name, provider, config, is_default, created_at, updated_at FROM memory_providers WHERE id = $1
+SELECT id, name, provider, config, is_default, created_at, updated_at, team_id FROM memory_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetMemoryProviderByID(ctx context.Context, id pgtype.UUID) (MemoryProvider, error) {
@@ -98,12 +100,13 @@ func (q *Queries) GetMemoryProviderByID(ctx context.Context, id pgtype.UUID) (Me
 		&i.IsDefault,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listMemoryProviders = `-- name: ListMemoryProviders :many
-SELECT id, name, provider, config, is_default, created_at, updated_at FROM memory_providers ORDER BY created_at ASC
+SELECT id, name, provider, config, is_default, created_at, updated_at, team_id FROM memory_providers WHERE team_id = public.memoh_current_team_id() ORDER BY created_at ASC
 `
 
 func (q *Queries) ListMemoryProviders(ctx context.Context) ([]MemoryProvider, error) {
@@ -123,6 +126,7 @@ func (q *Queries) ListMemoryProviders(ctx context.Context) ([]MemoryProvider, er
 			&i.IsDefault,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -139,8 +143,8 @@ UPDATE memory_providers
 SET name = $2,
     config = $3,
     updated_at = now()
-WHERE id = $1
-RETURNING id, name, provider, config, is_default, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, name, provider, config, is_default, created_at, updated_at, team_id
 `
 
 type UpdateMemoryProviderParams struct {
@@ -160,6 +164,7 @@ func (q *Queries) UpdateMemoryProvider(ctx context.Context, arg UpdateMemoryProv
 		&i.IsDefault,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/memory_wiki.sql.go
+++ b/internal/db/postgres/sqlc/memory_wiki.sql.go
@@ -13,7 +13,7 @@ import (
 
 const countMemoryEdgesByBot = `-- name: CountMemoryEdgesByBot :one
 SELECT COUNT(*) FROM memory_edges
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) CountMemoryEdgesByBot(ctx context.Context, botID pgtype.UUID) (int64, error) {
@@ -25,7 +25,7 @@ func (q *Queries) CountMemoryEdgesByBot(ctx context.Context, botID pgtype.UUID) 
 
 const countMemoryNodesByBot = `-- name: CountMemoryNodesByBot :one
 SELECT COUNT(*) FROM memory_nodes
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) CountMemoryNodesByBot(ctx context.Context, botID pgtype.UUID) (int64, error) {
@@ -37,7 +37,7 @@ func (q *Queries) CountMemoryNodesByBot(ctx context.Context, botID pgtype.UUID) 
 
 const deleteAllMemoryEdgesByBot = `-- name: DeleteAllMemoryEdgesByBot :exec
 DELETE FROM memory_edges
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) DeleteAllMemoryEdgesByBot(ctx context.Context, botID pgtype.UUID) error {
@@ -47,7 +47,7 @@ func (q *Queries) DeleteAllMemoryEdgesByBot(ctx context.Context, botID pgtype.UU
 
 const deleteAllMemoryNodesByBot = `-- name: DeleteAllMemoryNodesByBot :exec
 DELETE FROM memory_nodes
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) DeleteAllMemoryNodesByBot(ctx context.Context, botID pgtype.UUID) error {
@@ -57,7 +57,7 @@ func (q *Queries) DeleteAllMemoryNodesByBot(ctx context.Context, botID pgtype.UU
 
 const deleteMemoryEdgesByRelForBot = `-- name: DeleteMemoryEdgesByRelForBot :exec
 DELETE FROM memory_edges
-WHERE bot_id = $1 AND rel = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND rel = $2
 `
 
 type DeleteMemoryEdgesByRelForBotParams struct {
@@ -72,7 +72,7 @@ func (q *Queries) DeleteMemoryEdgesByRelForBot(ctx context.Context, arg DeleteMe
 
 const deleteMemoryEdgesForNode = `-- name: DeleteMemoryEdgesForNode :exec
 DELETE FROM memory_edges
-WHERE bot_id = $1 AND (src_node = $2 OR dst_node = $2)
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND (src_node = $2 OR dst_node = $2)
 `
 
 type DeleteMemoryEdgesForNodeParams struct {
@@ -87,7 +87,7 @@ func (q *Queries) DeleteMemoryEdgesForNode(ctx context.Context, arg DeleteMemory
 
 const deleteMemoryNode = `-- name: DeleteMemoryNode :exec
 DELETE FROM memory_nodes
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 `
 
 type DeleteMemoryNodeParams struct {
@@ -101,8 +101,8 @@ func (q *Queries) DeleteMemoryNode(ctx context.Context, arg DeleteMemoryNodePara
 }
 
 const getMemoryNode = `-- name: GetMemoryNode :one
-SELECT id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at FROM memory_nodes
-WHERE bot_id = $1 AND id = $2
+SELECT id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at, team_id FROM memory_nodes
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 `
 
 type GetMemoryNodeParams struct {
@@ -130,6 +130,7 @@ func (q *Queries) GetMemoryNode(ctx context.Context, arg GetMemoryNodeParams) (M
 		&i.ExpiresAt,
 		&i.UpdatedAt,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -137,7 +138,7 @@ func (q *Queries) GetMemoryNode(ctx context.Context, arg GetMemoryNodeParams) (M
 const insertMemoryEdge = `-- name: InsertMemoryEdge :exec
 INSERT INTO memory_edges (bot_id, src_node, dst_node, rel, weight, metadata)
 VALUES ($1, $2, $3, $4, $5, $6)
-ON CONFLICT (bot_id, src_node, dst_node, rel) DO UPDATE SET
+ON CONFLICT (team_id, bot_id, src_node, dst_node, rel) DO UPDATE SET
   weight = EXCLUDED.weight,
   metadata = EXCLUDED.metadata
 `
@@ -164,8 +165,8 @@ func (q *Queries) InsertMemoryEdge(ctx context.Context, arg InsertMemoryEdgePara
 }
 
 const listMemoryEdgesByBot = `-- name: ListMemoryEdgesByBot :many
-SELECT id, bot_id, src_node, dst_node, rel, weight, metadata, created_at FROM memory_edges
-WHERE bot_id = $1
+SELECT id, bot_id, src_node, dst_node, rel, weight, metadata, created_at, team_id FROM memory_edges
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) ListMemoryEdgesByBot(ctx context.Context, botID pgtype.UUID) ([]MemoryEdge, error) {
@@ -186,6 +187,7 @@ func (q *Queries) ListMemoryEdgesByBot(ctx context.Context, botID pgtype.UUID) (
 			&i.Weight,
 			&i.Metadata,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -198,8 +200,8 @@ func (q *Queries) ListMemoryEdgesByBot(ctx context.Context, botID pgtype.UUID) (
 }
 
 const listMemoryEdgesByRel = `-- name: ListMemoryEdgesByRel :many
-SELECT id, bot_id, src_node, dst_node, rel, weight, metadata, created_at FROM memory_edges
-WHERE bot_id = $1 AND rel = $2
+SELECT id, bot_id, src_node, dst_node, rel, weight, metadata, created_at, team_id FROM memory_edges
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND rel = $2
 `
 
 type ListMemoryEdgesByRelParams struct {
@@ -225,6 +227,7 @@ func (q *Queries) ListMemoryEdgesByRel(ctx context.Context, arg ListMemoryEdgesB
 			&i.Weight,
 			&i.Metadata,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -237,8 +240,8 @@ func (q *Queries) ListMemoryEdgesByRel(ctx context.Context, arg ListMemoryEdgesB
 }
 
 const listMemoryEdgesFromNode = `-- name: ListMemoryEdgesFromNode :many
-SELECT id, bot_id, src_node, dst_node, rel, weight, metadata, created_at FROM memory_edges
-WHERE bot_id = $1 AND src_node = $2
+SELECT id, bot_id, src_node, dst_node, rel, weight, metadata, created_at, team_id FROM memory_edges
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND src_node = $2
 ORDER BY weight DESC
 `
 
@@ -265,6 +268,7 @@ func (q *Queries) ListMemoryEdgesFromNode(ctx context.Context, arg ListMemoryEdg
 			&i.Weight,
 			&i.Metadata,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -277,8 +281,8 @@ func (q *Queries) ListMemoryEdgesFromNode(ctx context.Context, arg ListMemoryEdg
 }
 
 const listMemoryNodesByBot = `-- name: ListMemoryNodesByBot :many
-SELECT id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at FROM memory_nodes
-WHERE bot_id = $1
+SELECT id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at, team_id FROM memory_nodes
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY captured_at ASC
 `
 
@@ -308,6 +312,7 @@ func (q *Queries) ListMemoryNodesByBot(ctx context.Context, botID pgtype.UUID) (
 			&i.ExpiresAt,
 			&i.UpdatedAt,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -320,8 +325,8 @@ func (q *Queries) ListMemoryNodesByBot(ctx context.Context, botID pgtype.UUID) (
 }
 
 const listMemoryNodesByBotLayer = `-- name: ListMemoryNodesByBotLayer :many
-SELECT id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at FROM memory_nodes
-WHERE bot_id = $1 AND layer = $2
+SELECT id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at, team_id FROM memory_nodes
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND layer = $2
 ORDER BY captured_at ASC
 `
 
@@ -356,6 +361,7 @@ func (q *Queries) ListMemoryNodesByBotLayer(ctx context.Context, arg ListMemoryN
 			&i.ExpiresAt,
 			&i.UpdatedAt,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -368,8 +374,8 @@ func (q *Queries) ListMemoryNodesByBotLayer(ctx context.Context, arg ListMemoryN
 }
 
 const listMemoryNodesByBotProfile = `-- name: ListMemoryNodesByBotProfile :many
-SELECT id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at FROM memory_nodes
-WHERE bot_id = $1 AND profile_ref = $2
+SELECT id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at, team_id FROM memory_nodes
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND profile_ref = $2
 ORDER BY captured_at ASC
 `
 
@@ -404,6 +410,7 @@ func (q *Queries) ListMemoryNodesByBotProfile(ctx context.Context, arg ListMemor
 			&i.ExpiresAt,
 			&i.UpdatedAt,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -421,7 +428,7 @@ INSERT INTO memory_nodes (
   metadata, source_message_ids, profile_ref, topic, captured_at, expires_at
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-ON CONFLICT (id) DO UPDATE SET
+ON CONFLICT (team_id, id) DO UPDATE SET
   body = EXCLUDED.body,
   hash = EXCLUDED.hash,
   layer = EXCLUDED.layer,
@@ -434,7 +441,7 @@ ON CONFLICT (id) DO UPDATE SET
   topic = EXCLUDED.topic,
   expires_at = EXCLUDED.expires_at,
   updated_at = now()
-RETURNING id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at
+RETURNING id, bot_id, body, hash, layer, fact_type, subject, confidence, metadata, source_message_ids, profile_ref, topic, captured_at, expires_at, updated_at, created_at, team_id
 `
 
 type UpsertMemoryNodeParams struct {
@@ -489,6 +496,7 @@ func (q *Queries) UpsertMemoryNode(ctx context.Context, arg UpsertMemoryNodePara
 		&i.ExpiresAt,
 		&i.UpdatedAt,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/messages.sql.go
+++ b/internal/db/postgres/sqlc/messages.sql.go
@@ -14,7 +14,7 @@ import (
 const allocateSessionTurnPosition = `-- name: AllocateSessionTurnPosition :one
 UPDATE bot_sessions
 SET next_turn_position = next_turn_position + 1
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING (next_turn_position - 1)::bigint AS position
 `
 
@@ -29,7 +29,7 @@ const appendMessageToHistoryTurnByRequest = `-- name: AppendMessageToHistoryTurn
 WITH target AS (
   SELECT request.turn_id, request.session_id, request.turn_position
   FROM bot_history_messages request
-  WHERE request.session_id = $2
+  WHERE request.team_id = public.memoh_current_team_id() AND request.session_id = $2
     AND request.id = $3
     AND request.turn_id IS NOT NULL
     AND request.turn_position IS NOT NULL
@@ -44,7 +44,7 @@ next_seq AS (
     target.turn_position,
     COALESCE(MAX(existing.turn_message_seq), 0) + 1 AS turn_message_seq
   FROM target
-  JOIN bot_history_messages existing ON existing.turn_id = target.turn_id
+  JOIN bot_history_messages existing ON existing.turn_id = target.turn_id AND existing.team_id = public.memoh_current_team_id()
   GROUP BY target.turn_id, target.session_id, target.turn_position
 )
 UPDATE bot_history_messages m
@@ -56,7 +56,7 @@ SET turn_id = next_seq.turn_id,
     turn_superseded_at = NULL,
     turn_superseded_reason = NULL
 FROM next_seq
-WHERE m.id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND m.id = $1
   AND m.session_id = next_seq.session_id
   AND m.turn_id IS NULL
 RETURNING m.id
@@ -79,7 +79,7 @@ const appendMessageToLatestHistoryTurn = `-- name: AppendMessageToLatestHistoryT
 WITH latest AS (
   SELECT visible.turn_id, visible.session_id, visible.turn_position
   FROM bot_history_messages visible
-  WHERE visible.session_id = $2
+  WHERE visible.team_id = public.memoh_current_team_id() AND visible.session_id = $2
     AND visible.turn_id IS NOT NULL
     AND visible.turn_position IS NOT NULL
     AND visible.turn_message_seq IS NOT NULL
@@ -95,7 +95,7 @@ next_seq AS (
     latest.turn_position,
     COALESCE(MAX(existing.turn_message_seq), 0) + 1 AS turn_message_seq
   FROM latest
-  JOIN bot_history_messages existing ON existing.turn_id = latest.turn_id
+  JOIN bot_history_messages existing ON existing.turn_id = latest.turn_id AND existing.team_id = public.memoh_current_team_id()
   GROUP BY latest.turn_id, latest.session_id, latest.turn_position
 )
 UPDATE bot_history_messages m
@@ -107,7 +107,7 @@ SET turn_id = next_seq.turn_id,
     turn_superseded_at = NULL,
     turn_superseded_reason = NULL
 FROM next_seq
-WHERE m.id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND m.id = $1
   AND m.session_id = next_seq.session_id
   AND m.turn_id IS NULL
 RETURNING m.id
@@ -135,14 +135,14 @@ WITH target AS (
     request.id AS request_message_id,
     request.created_at AS request_created_at
   FROM bot_history_messages request
-  WHERE request.session_id = $1
+  WHERE request.team_id = public.memoh_current_team_id() AND request.session_id = $1
     AND request.id = $2
     AND request.turn_id IS NOT NULL
     AND request.turn_visible = true
     AND NOT EXISTS (
       SELECT 1
       FROM bot_history_messages assistant
-      WHERE assistant.turn_id = request.turn_id
+      WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = request.turn_id
         AND assistant.role = 'assistant'
         AND assistant.turn_message_seq = 2
         AND assistant.turn_visible = true
@@ -160,7 +160,7 @@ linked AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM target
-  WHERE assistant.id = $3
+  WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.id = $3
     AND assistant.session_id = target.session_id
   RETURNING assistant.id AS assistant_message_id, assistant.created_at AS assistant_created_at
 )
@@ -224,7 +224,7 @@ WITH target AS (
     request.id AS request_message_id,
     request.created_at AS request_created_at
   FROM bot_history_messages request
-  WHERE request.session_id = $1
+  WHERE request.team_id = public.memoh_current_team_id() AND request.session_id = $1
     AND request.role = 'user'
     AND request.turn_message_seq = 1
     AND request.turn_id IS NOT NULL
@@ -232,7 +232,7 @@ WITH target AS (
     AND NOT EXISTS (
       SELECT 1
       FROM bot_history_messages assistant
-      WHERE assistant.turn_id = request.turn_id
+      WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = request.turn_id
         AND assistant.role = 'assistant'
         AND assistant.turn_message_seq = 2
         AND assistant.turn_visible = true
@@ -251,7 +251,7 @@ linked AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM target
-  WHERE assistant.id = $2
+  WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.id = $2
     AND assistant.session_id = target.session_id
   RETURNING assistant.id AS assistant_message_id, assistant.created_at AS assistant_created_at
 )
@@ -308,7 +308,8 @@ const clearHistoryByBot = `-- name: ClearHistoryByBot :exec
 WITH target_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.bot_id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.bot_id = $1
   ORDER BY session.id
   FOR UPDATE
 ),
@@ -316,13 +317,15 @@ invalidated_sessions AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
   FROM target_sessions target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
   RETURNING session.id
 ),
 target_compaction_artifacts AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.bot_id = $1
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.bot_id = $1
     AND (SELECT count(*) FROM target_sessions) >= 0
   ORDER BY compact.id
   FOR UPDATE
@@ -330,13 +333,15 @@ target_compaction_artifacts AS MATERIALIZED (
 deleted_compaction_artifacts AS (
   DELETE FROM bot_history_message_compacts AS compact
   USING target_compaction_artifacts target
-  WHERE compact.id = target.id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = target.id
   RETURNING compact.id
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.bot_id = $1
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.bot_id = $1
     AND (SELECT count(*) FROM target_sessions) >= 0
     AND (SELECT count(*) FROM deleted_compaction_artifacts) >= 0
   ORDER BY message.id
@@ -344,7 +349,8 @@ target_messages AS MATERIALIZED (
 )
 DELETE FROM bot_history_messages AS message
 USING target_messages target
-WHERE message.id = target.id
+WHERE message.team_id = public.memoh_current_team_id()
+  AND message.id = target.id
 `
 
 func (q *Queries) ClearHistoryByBot(ctx context.Context, targetBotID pgtype.UUID) error {
@@ -356,20 +362,23 @@ const clearHistoryBySession = `-- name: ClearHistoryBySession :exec
 WITH target_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = $1
   FOR UPDATE
 ),
 invalidated_session AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
   FROM target_session target
-  WHERE session.id = target.id
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
   RETURNING session.id
 ),
 target_compaction_artifacts AS MATERIALIZED (
   SELECT compact.id
   FROM bot_history_message_compacts compact
-  WHERE compact.session_id = $1
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.session_id = $1
     AND (SELECT count(*) FROM target_session) >= 0
   ORDER BY compact.id
   FOR UPDATE
@@ -377,13 +386,15 @@ target_compaction_artifacts AS MATERIALIZED (
 deleted_compaction_artifacts AS (
   DELETE FROM bot_history_message_compacts AS compact
   USING target_compaction_artifacts target
-  WHERE compact.id = target.id
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND compact.id = target.id
   RETURNING compact.id
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.session_id = $1
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.session_id = $1
     AND (SELECT count(*) FROM target_session) >= 0
     AND (SELECT count(*) FROM deleted_compaction_artifacts) >= 0
   ORDER BY message.id
@@ -391,7 +402,8 @@ target_messages AS MATERIALIZED (
 )
 DELETE FROM bot_history_messages AS message
 USING target_messages target
-WHERE message.id = target.id
+WHERE message.team_id = public.memoh_current_team_id()
+  AND message.id = target.id
 `
 
 func (q *Queries) ClearHistoryBySession(ctx context.Context, targetSessionID pgtype.UUID) error {
@@ -401,7 +413,8 @@ func (q *Queries) ClearHistoryBySession(ctx context.Context, targetSessionID pgt
 
 const countMessagesByBot = `-- name: CountMessagesByBot :one
 SELECT COUNT(*) FROM bot_visible_history_messages
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
 `
 
 func (q *Queries) CountMessagesByBot(ctx context.Context, botID pgtype.UUID) (int64, error) {
@@ -415,7 +428,7 @@ const createHistoryTurn = `-- name: CreateHistoryTurn :one
 WITH next_position AS (
   UPDATE bot_sessions
   SET next_turn_position = next_turn_position + 1
-  WHERE bot_sessions.id = $1
+  WHERE bot_sessions.team_id = public.memoh_current_team_id() AND bot_sessions.id = $1
   RETURNING next_turn_position - 1 AS position
 ),
 input AS (
@@ -438,7 +451,7 @@ linked_request AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.request_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.request_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -453,7 +466,7 @@ linked_assistant AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.assistant_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.assistant_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -527,7 +540,7 @@ const createHistoryTurnWithID = `-- name: CreateHistoryTurnWithID :one
 WITH next_position AS (
   UPDATE bot_sessions
   SET next_turn_position = next_turn_position + 1
-  WHERE bot_sessions.id = $1
+  WHERE bot_sessions.team_id = public.memoh_current_team_id() AND bot_sessions.id = $1
   RETURNING next_turn_position - 1 AS position
 ),
 input AS (
@@ -550,7 +563,7 @@ linked_request AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.request_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.request_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -565,7 +578,7 @@ linked_assistant AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.assistant_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.assistant_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -657,7 +670,7 @@ linked_request AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.request_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.request_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -672,7 +685,7 @@ linked_assistant AS (
       turn_superseded_at = NULL,
       turn_superseded_reason = NULL
   FROM input
-  WHERE m.id = input.assistant_message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = input.assistant_message_id
     AND m.session_id = input.session_id
     AND m.bot_id = input.bot_id
   RETURNING m.id, m.created_at
@@ -881,7 +894,8 @@ const createMessageInHistoryTurnByRequest = `-- name: CreateMessageInHistoryTurn
 WITH owner_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = $1
   FOR UPDATE
 ),
 target AS MATERIALIZED (
@@ -893,7 +907,7 @@ target AS MATERIALIZED (
       WHEN $2::text = 'assistant' AND NOT EXISTS (
         SELECT 1
         FROM bot_history_messages assistant
-        WHERE assistant.turn_id = turns.turn_id
+        WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = turns.turn_id
           AND assistant.role = 'assistant'
           AND assistant.turn_message_seq = 2
           AND assistant.turn_visible = true
@@ -901,14 +915,15 @@ target AS MATERIALIZED (
       ELSE COALESCE((
         SELECT existing.turn_message_seq + 1
         FROM bot_history_messages existing
-        WHERE existing.turn_id = turns.turn_id
+        WHERE existing.team_id = public.memoh_current_team_id() AND existing.turn_id = turns.turn_id
         ORDER BY existing.turn_message_seq DESC
         LIMIT 1
       ), 1)
     END AS turn_message_seq
   FROM bot_history_messages turns
   JOIN owner_session owner ON owner.id = turns.session_id
-  WHERE turns.session_id = $1
+  WHERE turns.team_id = public.memoh_current_team_id()
+    AND turns.session_id = $1
     AND turns.id = $3
     AND turns.turn_id IS NOT NULL
     AND turns.turn_position IS NOT NULL
@@ -1080,7 +1095,8 @@ const createMessageInHistoryTurnByRequestAndBind = `-- name: CreateMessageInHist
 WITH owner_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = $1
   FOR UPDATE
 ),
 target AS MATERIALIZED (
@@ -1092,7 +1108,7 @@ target AS MATERIALIZED (
       WHEN $2::text = 'assistant' AND NOT EXISTS (
         SELECT 1
         FROM bot_history_messages assistant
-        WHERE assistant.turn_id = turns.turn_id
+        WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = turns.turn_id
           AND assistant.role = 'assistant'
           AND assistant.turn_message_seq = 2
           AND assistant.turn_visible = true
@@ -1100,14 +1116,15 @@ target AS MATERIALIZED (
       ELSE COALESCE((
         SELECT existing.turn_message_seq + 1
         FROM bot_history_messages existing
-        WHERE existing.turn_id = turns.turn_id
+        WHERE existing.team_id = public.memoh_current_team_id() AND existing.turn_id = turns.turn_id
         ORDER BY existing.turn_message_seq DESC
         LIMIT 1
       ), 1)
     END AS turn_message_seq
   FROM bot_history_messages turns
   JOIN owner_session owner ON owner.id = turns.session_id
-  WHERE turns.session_id = $1
+  WHERE turns.team_id = public.memoh_current_team_id()
+    AND turns.session_id = $1
     AND turns.id = $3
     AND turns.turn_id IS NOT NULL
     AND turns.turn_position IS NOT NULL
@@ -1222,7 +1239,7 @@ const createMessageWithHistoryTurn = `-- name: CreateMessageWithHistoryTurn :one
 WITH next_position AS (
   UPDATE bot_sessions
   SET next_turn_position = next_turn_position + 1
-  WHERE bot_sessions.id = $1
+  WHERE bot_sessions.team_id = public.memoh_current_team_id() AND bot_sessions.id = $1
   RETURNING (next_turn_position - 1)::bigint AS position
 ),
 inserted_message AS (
@@ -1340,7 +1357,7 @@ WITH target AS (
     existing.turn_position,
     bool_or(existing.turn_visible) AS turn_visible
   FROM bot_history_messages existing
-  WHERE existing.turn_id = $17
+  WHERE existing.team_id = public.memoh_current_team_id() AND existing.turn_id = $17
     AND existing.session_id = $18::uuid
     AND existing.bot_id = $2
     AND existing.turn_position IS NOT NULL
@@ -1584,7 +1601,7 @@ WITH input_rows(
 next_position AS (
   UPDATE bot_sessions
   SET next_turn_position = next_turn_position + 1
-  WHERE bot_sessions.id = $53
+  WHERE bot_sessions.team_id = public.memoh_current_team_id() AND bot_sessions.id = $53
   RETURNING (next_turn_position - 1)::bigint AS position
 ),
 inserted_messages AS (
@@ -1782,20 +1799,23 @@ const deleteMessagesByIDs = `-- name: DeleteMessagesByIDs :exec
 WITH session_locator AS MATERIALIZED (
   SELECT DISTINCT message.session_id
   FROM bot_history_messages message
-  WHERE message.id = ANY($1::uuid[])
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = ANY($1::uuid[])
     AND message.session_id IS NOT NULL
 ),
 owner_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
   JOIN session_locator locator ON locator.session_id = session.id
+  WHERE session.team_id = public.memoh_current_team_id()
   ORDER BY session.id
   FOR UPDATE
 ),
 target_messages AS MATERIALIZED (
   SELECT message.id
   FROM bot_history_messages message
-  WHERE message.id = ANY($1::uuid[])
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = ANY($1::uuid[])
     AND (SELECT count(*) FROM owner_sessions) >= 0
   ORDER BY message.id
   FOR UPDATE
@@ -1803,16 +1823,20 @@ target_messages AS MATERIALIZED (
 deleted AS (
   DELETE FROM bot_history_messages message
   USING target_messages target
-  WHERE message.id = target.id
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.id = target.id
   RETURNING message.session_id, message.compact_id
 ),
 compaction_epoch_bump AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
-  WHERE EXISTS (
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND EXISTS (
     SELECT 1
     FROM deleted changed
-    JOIN bot_history_message_compacts compact ON compact.id = changed.compact_id
+    JOIN bot_history_message_compacts compact
+      ON compact.id = changed.compact_id
+     AND compact.team_id = public.memoh_current_team_id()
     WHERE changed.session_id = session.id
       AND compact.bot_id = session.bot_id
       AND compact.session_id = session.id
@@ -1832,7 +1856,7 @@ const getHistoryTurnByID = `-- name: GetHistoryTurnByID :one
 WITH target AS (
   SELECT m.turn_id, m.session_id, m.turn_position
   FROM bot_history_messages m
-  WHERE m.turn_id = $1
+  WHERE m.team_id = public.memoh_current_team_id() AND m.turn_id = $1
     AND m.session_id = $2
     AND m.turn_position IS NOT NULL
     AND m.turn_visible = true
@@ -1852,7 +1876,8 @@ SELECT
   COALESCE(MAX(m.turn_superseded_at), MAX(m.created_at))::timestamptz AS updated_at
 FROM target
 JOIN bot_history_messages m
-  ON m.turn_id = target.turn_id
+  ON m.team_id = public.memoh_current_team_id()
+ AND m.turn_id = target.turn_id
  AND m.session_id = target.session_id
 GROUP BY target.turn_id, target.session_id, target.turn_position
 `
@@ -1899,7 +1924,7 @@ const getLatestVisibleHistoryTurnBySession = `-- name: GetLatestVisibleHistoryTu
 WITH target AS (
   SELECT m.turn_id, m.session_id, m.turn_position
   FROM bot_history_messages m
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
     AND m.turn_visible = true
@@ -1920,7 +1945,8 @@ SELECT
   COALESCE(MAX(m.turn_superseded_at), MAX(m.created_at))::timestamptz AS updated_at
 FROM target
 JOIN bot_history_messages m
-  ON m.turn_id = target.turn_id
+  ON m.team_id = public.memoh_current_team_id()
+ AND m.turn_id = target.turn_id
  AND m.session_id = target.session_id
 GROUP BY target.turn_id, target.session_id, target.turn_position
 `
@@ -1982,9 +2008,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2074,9 +2100,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2162,9 +2188,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.id = $2
 LIMIT 1
@@ -2228,7 +2254,7 @@ const getVisibleHistoryTurnByMessage = `-- name: GetVisibleHistoryTurnByMessage 
 WITH target AS (
   SELECT m.turn_id, m.session_id, m.turn_position
   FROM bot_history_messages m
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
     AND m.id = $2
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -2249,7 +2275,8 @@ SELECT
   COALESCE(MAX(m.turn_superseded_at), MAX(m.created_at))::timestamptz AS updated_at
 FROM target
 JOIN bot_history_messages m
-  ON m.turn_id = target.turn_id
+  ON m.team_id = public.memoh_current_team_id()
+ AND m.turn_id = target.turn_id
  AND m.session_id = target.session_id
 GROUP BY target.turn_id, target.session_id, target.turn_position
 `
@@ -2299,7 +2326,7 @@ SELECT
   m.turn_message_seq,
   m.created_at
 FROM bot_history_messages m
-WHERE m.session_id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2340,7 +2367,7 @@ SELECT
   m.turn_message_seq,
   m.created_at
 FROM bot_history_messages m
-WHERE m.session_id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -2377,7 +2404,8 @@ const hideMessagesByHistoryTurn = `-- name: HideMessagesByHistoryTurn :exec
 WITH session_locator AS MATERIALIZED (
   SELECT DISTINCT message.session_id
   FROM bot_history_messages message
-  WHERE message.turn_id = $1
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND message.turn_id = $1
     AND message.turn_visible = true
     AND message.session_id IS NOT NULL
 ),
@@ -2385,13 +2413,15 @@ owner_sessions AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
   JOIN session_locator locator ON locator.session_id = session.id
+  WHERE session.team_id = public.memoh_current_team_id()
   ORDER BY session.id
   FOR UPDATE
 ),
 hidden AS (
   UPDATE bot_history_messages
   SET turn_visible = false
-  WHERE turn_id = $1
+  WHERE team_id = public.memoh_current_team_id()
+    AND turn_id = $1
     AND turn_visible = true
     AND (SELECT count(*) FROM owner_sessions) >= 0
   RETURNING session_id, compact_id
@@ -2399,10 +2429,13 @@ hidden AS (
 compaction_epoch_bump AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
-  WHERE EXISTS (
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND EXISTS (
     SELECT 1
     FROM hidden changed
-    JOIN bot_history_message_compacts compact ON compact.id = changed.compact_id
+    JOIN bot_history_message_compacts compact
+      ON compact.id = changed.compact_id
+     AND compact.team_id = public.memoh_current_team_id()
     WHERE changed.session_id = session.id
       AND compact.bot_id = session.bot_id
       AND compact.session_id = session.id
@@ -2426,7 +2459,7 @@ WITH target AS (
     existing.turn_position,
     bool_or(existing.turn_visible) AS turn_visible
   FROM bot_history_messages existing
-  WHERE existing.turn_id = $3
+  WHERE existing.team_id = public.memoh_current_team_id() AND existing.turn_id = $3
     AND existing.turn_position IS NOT NULL
   GROUP BY existing.turn_id, existing.session_id, existing.turn_position
   LIMIT 1
@@ -2440,7 +2473,7 @@ SET turn_id = target.turn_id,
     turn_superseded_at = NULL,
     turn_superseded_reason = NULL
 FROM target
-WHERE m.id = $2
+WHERE m.team_id = public.memoh_current_team_id() AND m.id = $2
   AND m.session_id = target.session_id
 RETURNING m.id
 `
@@ -2467,7 +2500,7 @@ WITH target AS (
     assistant.created_at AS assistant_created_at,
     assistant.id AS assistant_id
   FROM bot_history_messages assistant
-  WHERE assistant.turn_id = $1
+  WHERE assistant.team_id = public.memoh_current_team_id() AND assistant.turn_id = $1
     AND assistant.role = 'assistant'
     AND assistant.turn_message_seq = 2
     AND assistant.turn_visible = true
@@ -2483,7 +2516,7 @@ tail AS (
   JOIN bot_history_messages m
     ON m.session_id = target.session_id
    AND m.role IN ('assistant', 'tool')
-  WHERE m.id <> target.assistant_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id <> target.assistant_id
     AND m.turn_id IS NULL
     AND (m.created_at, m.id) > (target.assistant_created_at, target.assistant_id)
 )
@@ -2493,7 +2526,7 @@ SET turn_id = tail.turn_id,
     turn_visible = true,
     turn_message_seq = tail.turn_message_seq
 FROM tail
-WHERE m.id = tail.message_id
+WHERE m.team_id = public.memoh_current_team_id() AND m.id = tail.message_id
 `
 
 func (q *Queries) LinkUnassignedMessagesAfterHistoryTurnAssistant(ctx context.Context, turnID pgtype.UUID) error {
@@ -2524,9 +2557,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = $1
   AND m.created_at >= $2
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.created_at ASC, m.id ASC
@@ -2624,9 +2658,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = $1
   AND m.created_at >= $2
   AND (m.metadata->>'trigger_mode' IS NULL OR m.metadata->>'trigger_mode' != 'passive_sync')
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
@@ -2730,9 +2765,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = $1
 ORDER BY m.created_at ASC, m.id ASC
 `
 
@@ -2826,7 +2861,7 @@ SELECT
   MIN(m.created_at)::timestamptz AS created_at,
   COALESCE(MAX(m.turn_superseded_at), MAX(m.created_at))::timestamptz AS updated_at
 FROM bot_history_messages m
-WHERE m.bot_id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = $1
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
   AND m.session_id IS NOT NULL
@@ -2886,7 +2921,8 @@ SELECT
   m.bot_id,
   m.session_id
 FROM bot_history_messages m
-WHERE m.compact_id = $1
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.compact_id = $1
 ORDER BY m.created_at ASC, m.id ASC
 `
 
@@ -2940,9 +2976,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = $1
 ORDER BY m.created_at ASC, m.id ASC
 LIMIT 10000
 `
@@ -3031,9 +3068,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -3133,9 +3170,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -3251,9 +3288,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -3262,7 +3299,7 @@ WHERE m.session_id = $1
     > (
       SELECT c.turn_position, c.turn_message_seq, c.created_at, c.id
       FROM bot_history_messages c
-      WHERE c.session_id = $1
+      WHERE c.team_id = public.memoh_current_team_id() AND c.session_id = $1
         AND c.turn_visible = true
         AND c.turn_id IS NOT NULL
         AND c.turn_position IS NOT NULL
@@ -3364,9 +3401,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = $1
   AND m.created_at < $2
 ORDER BY m.created_at DESC, m.id DESC
 LIMIT $3
@@ -3462,9 +3500,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -3564,9 +3602,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -3682,9 +3720,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -3693,7 +3731,7 @@ WHERE m.session_id = $1
     < (
       SELECT c.turn_position, c.turn_message_seq, c.created_at, c.id
       FROM bot_history_messages c
-      WHERE c.session_id = $1
+      WHERE c.team_id = public.memoh_current_team_id() AND c.session_id = $1
         AND c.turn_visible = true
         AND c.turn_id IS NOT NULL
         AND c.turn_position IS NOT NULL
@@ -3795,9 +3833,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = $1
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
 LIMIT 10000
 `
@@ -3886,9 +3925,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = $1
 ORDER BY m.created_at DESC, m.id DESC
 LIMIT $2
 `
@@ -3982,9 +4022,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -4078,9 +4118,9 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -4170,9 +4210,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = $1
   AND m.created_at >= $2
 ORDER BY m.created_at ASC, m.id ASC
 `
@@ -4266,9 +4307,10 @@ SELECT
   ci.avatar_url AS sender_avatar_url,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = $1
   AND m.created_at >= $2
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
 `
@@ -4346,8 +4388,9 @@ WITH observed_routes AS (
     s.route_id,
     MAX(m.created_at)::timestamptz AS last_observed_at
   FROM bot_visible_history_messages m
-  JOIN bot_sessions s ON s.id = m.session_id
-  WHERE m.bot_id = $1
+  JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.bot_id = $1
     AND m.sender_channel_identity_id = $2::uuid
     AND s.route_id IS NOT NULL
   GROUP BY s.route_id
@@ -4370,7 +4413,7 @@ SELECT
   COALESCE(NULLIF(TRIM(COALESCE(r.metadata->>'conversation_avatar_url', '')), ''), '')::text AS conversation_avatar_url,
   rr.last_observed_at
 FROM observed_routes rr
-JOIN bot_channel_routes r ON r.id = rr.route_id
+JOIN bot_channel_routes r ON r.id = rr.route_id AND r.team_id = public.memoh_current_team_id()
 GROUP BY
   r.id,
   r.channel_type,
@@ -4433,9 +4476,10 @@ WITH observed_routes AS (
     s.route_id,
     MAX(m.created_at)::timestamptz AS last_observed_at
   FROM bot_visible_history_messages m
-  JOIN bot_sessions s ON s.id = m.session_id
-  JOIN bot_channel_routes r ON r.id = s.route_id
-  WHERE m.bot_id = $1
+  JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+  JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.bot_id = $1
     AND LOWER(TRIM(r.channel_type)) = LOWER(TRIM($2))
     AND s.route_id IS NOT NULL
   GROUP BY s.route_id
@@ -4458,7 +4502,7 @@ SELECT
   COALESCE(NULLIF(TRIM(COALESCE(r.metadata->>'conversation_avatar_url', '')), ''), '')::text AS conversation_avatar_url,
   rr.last_observed_at
 FROM observed_routes rr
-JOIN bot_channel_routes r ON r.id = rr.route_id
+JOIN bot_channel_routes r ON r.id = rr.route_id AND r.team_id = public.memoh_current_team_id()
 GROUP BY
   r.id,
   r.channel_type,
@@ -4545,16 +4589,24 @@ SELECT
   )::text AS conversation_name,
   r.default_reply_target AS reply_target
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci
+  ON ci.id = m.sender_channel_identity_id
+ AND ci.team_id = public.memoh_current_team_id()
+JOIN bot_sessions s
+  ON s.id = m.session_id
+ AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_channel_routes r
+  ON r.id = s.route_id
+ AND r.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = $1
   -- A fresh pending claim is a 15-minute cross-process lease. Stale pending,
   -- error, deleted, and blank-summary claims remain reclaimable; current OK
   -- summaries stay ineligible exactly as on the read path.
   AND (m.compact_id IS NULL OR NOT EXISTS (
     SELECT 1 FROM bot_history_message_compacts c
-    WHERE c.id = m.compact_id
+    WHERE c.team_id = public.memoh_current_team_id()
+      AND c.id = m.compact_id
       AND c.bot_id = m.bot_id
       AND c.session_id = s.id
       AND c.compaction_epoch = s.compaction_epoch
@@ -4639,7 +4691,7 @@ const listVisibleMessagesFromBySession = `-- name: ListVisibleMessagesFromBySess
 WITH cursor_message AS (
   SELECT m.turn_position
   FROM bot_history_messages m
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
     AND m.turn_visible = true
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -4669,9 +4721,9 @@ SELECT
   s.channel_type AS platform
 FROM bot_history_messages m
 CROSS JOIN cursor_message cursor
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
   AND m.turn_id IS NOT NULL
   AND m.turn_position IS NOT NULL
@@ -4757,7 +4809,7 @@ WITH target AS (
     m.turn_message_seq,
     m.created_at
   FROM bot_history_messages m
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
     AND m.turn_visible = true
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -4770,7 +4822,7 @@ before_rows AS (
   SELECT m.id
   FROM bot_history_messages m
   CROSS JOIN target
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
     AND m.turn_visible = true
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -4784,7 +4836,7 @@ after_rows AS (
   SELECT m.id
   FROM bot_history_messages m
   CROSS JOIN target
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
     AND m.turn_visible = true
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
@@ -4826,9 +4878,9 @@ SELECT
 FROM window_rows w
 CROSS JOIN target
 JOIN bot_history_messages m ON m.id = w.id
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.session_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.turn_visible = true
 ORDER BY m.turn_position ASC, m.turn_message_seq ASC, m.created_at ASC, m.id ASC
 `
@@ -4914,7 +4966,7 @@ func (q *Queries) LocateMessagesWindowByExternalIDBySession(ctx context.Context,
 const lockHistoryTurnAppendByRequest = `-- name: LockHistoryTurnAppendByRequest :exec
 SELECT pg_advisory_xact_lock(hashtextextended(m.turn_id::text, 0))
 FROM bot_history_messages m
-WHERE m.session_id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
   AND m.id = $2
   AND m.turn_id IS NOT NULL
 LIMIT 1
@@ -4939,8 +4991,11 @@ WITH expected_claims AS MATERIALIZED (
 ), artifact_locator AS MATERIALIZED (
   SELECT compact.id, compact.session_id
   FROM bot_history_message_compacts compact
-  WHERE compact.id = $3
-    OR compact.id = ANY($2::uuid[])
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND (
+      compact.id = $3
+      OR compact.id = ANY($2::uuid[])
+    )
 ), owner_sessions AS MATERIALIZED (
   SELECT session.id, session.bot_id, session.compaction_epoch
   FROM bot_sessions session
@@ -4949,6 +5004,7 @@ WITH expected_claims AS MATERIALIZED (
     FROM artifact_locator locator
     WHERE locator.session_id IS NOT NULL
   ) owner ON owner.session_id = session.id
+  WHERE session.team_id = public.memoh_current_team_id()
   ORDER BY session.id
   FOR UPDATE OF session
 ), locked_artifacts AS MATERIALIZED (
@@ -4962,7 +5018,8 @@ WITH expected_claims AS MATERIALIZED (
     compact.started_at
   FROM bot_history_message_compacts compact
   JOIN artifact_locator locator ON locator.id = compact.id
-  WHERE (SELECT count(*) FROM owner_sessions) >= 0
+  WHERE compact.team_id = public.memoh_current_team_id()
+    AND (SELECT count(*) FROM owner_sessions) >= 0
     AND (
       compact.session_id IS NULL
       OR EXISTS (
@@ -5024,7 +5081,8 @@ WITH expected_claims AS MATERIALIZED (
   FROM bot_history_messages message
   JOIN expected_claims claim ON claim.message_id = message.id
   CROSS JOIN target_compact target
-  WHERE CARDINALITY($1::uuid[]) = CARDINALITY($2::uuid[])
+  WHERE message.team_id = public.memoh_current_team_id()
+    AND CARDINALITY($1::uuid[]) = CARDINALITY($2::uuid[])
     AND message.compact_id IS NOT DISTINCT FROM claim.expected_compact_id
     AND message.bot_id = target.bot_id
     AND message.session_id = target.session_id
@@ -5063,7 +5121,8 @@ WITH expected_claims AS MATERIALIZED (
       error_message = 'source lease reclaimed',
       completed_at = now()
   FROM claims_to_reclaim reclaimable
-  WHERE current_claim.id = reclaimable.id
+  WHERE current_claim.team_id = public.memoh_current_team_id()
+    AND current_claim.id = reclaimable.id
     AND current_claim.status = 'pending'
   RETURNING current_claim.id
 )
@@ -5071,7 +5130,8 @@ UPDATE bot_history_messages message
 SET compact_id = target.id
 FROM locked_messages locked,
      target_compact target
-WHERE message.id = locked.id
+WHERE message.team_id = public.memoh_current_team_id()
+  AND message.id = locked.id
   AND message.compact_id IS NOT DISTINCT FROM locked.expected_compact_id
   AND message.bot_id = target.bot_id
   AND message.session_id = target.session_id
@@ -5117,14 +5177,16 @@ const replaceHistoryTurn = `-- name: ReplaceHistoryTurn :one
 WITH owner_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = $1
   FOR UPDATE
 ),
 old_turn_target AS (
   SELECT m.turn_id, m.session_id, m.turn_position
   FROM bot_history_messages m
   JOIN owner_session owner ON owner.id = m.session_id
-  WHERE m.turn_id = $2
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.turn_id = $2
     AND m.turn_position IS NOT NULL
     AND m.turn_visible = true
   LIMIT 1
@@ -5144,7 +5206,8 @@ old_turn AS (
     MAX(m.created_at)::timestamptz AS updated_at
   FROM old_turn_target
   JOIN bot_history_messages m
-    ON m.turn_id = old_turn_target.turn_id
+    ON m.team_id = public.memoh_current_team_id()
+   AND m.turn_id = old_turn_target.turn_id
    AND m.session_id = old_turn_target.session_id
   GROUP BY old_turn_target.turn_id, old_turn_target.session_id, old_turn_target.turn_position
 ),
@@ -5152,6 +5215,7 @@ old_lock AS (
   SELECT m.id, m.bot_id, m.session_id, m.compact_id
   FROM bot_history_messages m
   JOIN old_turn ON old_turn.id = m.turn_id
+  WHERE m.team_id = public.memoh_current_team_id()
   FOR UPDATE
 ),
 old_lock_guard AS (
@@ -5160,7 +5224,7 @@ old_lock_guard AS (
 latest_turn AS (
   SELECT m.turn_id AS id
   FROM bot_history_messages m
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id() AND m.session_id = $1
     AND m.turn_id IS NOT NULL
     AND m.turn_position IS NOT NULL
     AND m.turn_visible = true
@@ -5180,7 +5244,7 @@ replacement_input AS (
       OR EXISTS (
         SELECT 1
         FROM bot_history_messages request_message
-        WHERE request_message.id = $3::uuid
+        WHERE request_message.team_id = public.memoh_current_team_id() AND request_message.id = $3::uuid
           AND request_message.session_id = old_turn.session_id
           AND request_message.role = 'user'
           AND (
@@ -5195,7 +5259,7 @@ replacement_input AS (
       OR EXISTS (
         SELECT 1
         FROM bot_history_messages assistant_message
-        WHERE assistant_message.id = $4::uuid
+        WHERE assistant_message.team_id = public.memoh_current_team_id() AND assistant_message.id = $4::uuid
           AND assistant_message.session_id = old_turn.session_id
           AND assistant_message.role = 'assistant'
           AND assistant_message.turn_id IS NULL
@@ -5207,8 +5271,12 @@ affected_compaction_sessions AS MATERIALIZED (
   SELECT DISTINCT locked.session_id
   FROM old_lock locked
   JOIN replacement_input ON replacement_input.session_id = locked.session_id
-  JOIN bot_history_message_compacts compact ON compact.id = locked.compact_id
-  JOIN bot_sessions session ON session.id = locked.session_id
+  JOIN bot_history_message_compacts compact
+    ON compact.id = locked.compact_id
+   AND compact.team_id = public.memoh_current_team_id()
+  JOIN bot_sessions session
+    ON session.id = locked.session_id
+   AND session.team_id = public.memoh_current_team_id()
   WHERE locked.id IS DISTINCT FROM replacement_input.replacement_request_message_id
     AND locked.id IS DISTINCT FROM replacement_input.replacement_assistant_message_id
     AND compact.bot_id = locked.bot_id
@@ -5227,7 +5295,7 @@ next_position AS (
         ELSE 0
       END
   FROM replacement_input
-  WHERE s.id = replacement_input.session_id
+  WHERE s.team_id = public.memoh_current_team_id() AND s.id = replacement_input.session_id
   RETURNING s.next_turn_position - 1 AS position
 ),
 replacement AS (
@@ -5253,7 +5321,7 @@ updated AS (
       turn_superseded_reason = $6,
       turn_visible = false
   FROM replacement
-  WHERE old.turn_id = $2
+  WHERE old.team_id = public.memoh_current_team_id() AND old.turn_id = $2
     AND old.session_id = $1
     AND old.turn_superseded_at IS NULL
     AND old.id IS DISTINCT FROM replacement.request_message_id
@@ -5267,7 +5335,7 @@ hidden_old_messages AS (
   UPDATE bot_history_messages m
   SET turn_visible = false
   FROM updated_turn, replacement
-  WHERE m.turn_id = updated_turn.id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.turn_id = updated_turn.id
     AND m.id IS DISTINCT FROM replacement.request_message_id
     AND m.id IS DISTINCT FROM replacement.assistant_message_id
   RETURNING m.id
@@ -5291,18 +5359,21 @@ linked_anchors AS (
   FROM replacement
   CROSS JOIN hidden_done
   JOIN updated_turn ON true
-  WHERE (
-      m.id = replacement.request_message_id
-      AND m.role = 'user'
-      AND (
-        m.turn_id IS NULL
-        OR m.turn_id = updated_turn.id
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND (
+      (
+        m.id = replacement.request_message_id
+        AND m.role = 'user'
+        AND (
+          m.turn_id IS NULL
+          OR m.turn_id = updated_turn.id
+        )
       )
-    )
-    OR (
-      m.id = replacement.assistant_message_id
-      AND m.role = 'assistant'
-      AND m.turn_id IS NULL
+      OR (
+        m.id = replacement.assistant_message_id
+        AND m.role = 'assistant'
+        AND m.turn_id IS NULL
+      )
     )
   RETURNING m.id
 ),
@@ -5322,15 +5393,15 @@ linked_tail AS (
       replacement.position AS turn_position,
       2 + ROW_NUMBER() OVER (ORDER BY m.created_at, m.id) AS turn_message_seq
     FROM replacement
-    JOIN bot_history_messages assistant ON assistant.id = replacement.assistant_message_id
+    JOIN bot_history_messages assistant ON assistant.id = replacement.assistant_message_id AND assistant.team_id = public.memoh_current_team_id()
     JOIN bot_history_messages m
       ON m.session_id = replacement.session_id
      AND m.role IN ('assistant', 'tool')
-    WHERE m.id <> replacement.assistant_message_id
+    WHERE m.team_id = public.memoh_current_team_id() AND m.id <> replacement.assistant_message_id
       AND m.turn_id IS NULL
       AND (m.created_at, m.id) > (assistant.created_at, assistant.id)
   ) tail
-  WHERE m.id = tail.message_id
+  WHERE m.team_id = public.memoh_current_team_id() AND m.id = tail.message_id
   RETURNING m.id
 ),
 linked_anchors_done AS (
@@ -5410,9 +5481,10 @@ SELECT
   ci.display_name AS sender_display_name,
   s.channel_type AS platform
 FROM bot_visible_history_messages m
-LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-WHERE m.bot_id = $1
+LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.bot_id = $1
   AND ($2::uuid IS NULL OR m.session_id = $2::uuid)
   AND ($3::uuid IS NULL OR m.sender_channel_identity_id = $3::uuid)
   AND ($4::timestamptz IS NULL OR m.created_at >= $4::timestamptz)
@@ -5499,7 +5571,8 @@ const supersedeHistoryTurn = `-- name: SupersedeHistoryTurn :one
 WITH owner_session AS MATERIALIZED (
   SELECT session.id
   FROM bot_sessions session
-  WHERE session.id = $1
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = $1
   FOR UPDATE
 ),
 updated AS (
@@ -5509,7 +5582,8 @@ updated AS (
       turn_superseded_reason = $4,
       turn_visible = false
   FROM owner_session owner
-  WHERE m.turn_id = $5
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.turn_id = $5
     AND m.session_id = owner.id
     AND m.turn_superseded_at IS NULL
   RETURNING
@@ -5529,10 +5603,13 @@ updated AS (
 compaction_epoch_bump AS (
   UPDATE bot_sessions session
   SET compaction_epoch = session.compaction_epoch + 1
-  WHERE EXISTS (
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND EXISTS (
     SELECT 1
     FROM updated changed
-    JOIN bot_history_message_compacts compact ON compact.id = changed.compact_id
+    JOIN bot_history_message_compacts compact
+      ON compact.id = changed.compact_id
+     AND compact.team_id = public.memoh_current_team_id()
     WHERE changed.session_id = session.id
       AND compact.bot_id = changed.bot_id
       AND compact.session_id = session.id

--- a/internal/db/postgres/sqlc/models.go
+++ b/internal/db/postgres/sqlc/models.go
@@ -54,6 +54,7 @@ type Bot struct {
 	CreatedAt              pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt              pgtype.Timestamptz `json:"updated_at"`
 	AclDefaultEffect       string             `json:"acl_default_effect"`
+	TeamID                 pgtype.UUID        `json:"team_id"`
 }
 
 type BotAclRule struct {
@@ -72,6 +73,7 @@ type BotAclRule struct {
 	Enabled                bool               `json:"enabled"`
 	Description            pgtype.Text        `json:"description"`
 	SubjectChannelType     pgtype.Text        `json:"subject_channel_type"`
+	TeamID                 pgtype.UUID        `json:"team_id"`
 }
 
 type BotChannelAdmin struct {
@@ -82,6 +84,7 @@ type BotChannelAdmin struct {
 	CreatedByUserID   pgtype.UUID        `json:"created_by_user_id"`
 	CreatedAt         pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+	TeamID            pgtype.UUID        `json:"team_id"`
 }
 
 type BotChannelConfig struct {
@@ -97,6 +100,7 @@ type BotChannelConfig struct {
 	VerifiedAt       pgtype.Timestamptz `json:"verified_at"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	TeamID           pgtype.UUID        `json:"team_id"`
 }
 
 type BotChannelRoute struct {
@@ -112,6 +116,7 @@ type BotChannelRoute struct {
 	Metadata               []byte             `json:"metadata"`
 	CreatedAt              pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt              pgtype.Timestamptz `json:"updated_at"`
+	TeamID                 pgtype.UUID        `json:"team_id"`
 }
 
 type BotEmailBinding struct {
@@ -125,6 +130,7 @@ type BotEmailBinding struct {
 	Config          []byte             `json:"config"`
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	TeamID          pgtype.UUID        `json:"team_id"`
 }
 
 type BotHeartbeatLog struct {
@@ -138,6 +144,7 @@ type BotHeartbeatLog struct {
 	ModelID      pgtype.UUID        `json:"model_id"`
 	StartedAt    pgtype.Timestamptz `json:"started_at"`
 	CompletedAt  pgtype.Timestamptz `json:"completed_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 }
 
 type BotHistoryMessage struct {
@@ -166,6 +173,7 @@ type BotHistoryMessage struct {
 	TurnSupersededAt        pgtype.Timestamptz `json:"turn_superseded_at"`
 	TurnSupersededReason    pgtype.Text        `json:"turn_superseded_reason"`
 	CreatedAt               pgtype.Timestamptz `json:"created_at"`
+	TeamID                  pgtype.UUID        `json:"team_id"`
 }
 
 type BotHistoryMessageAsset struct {
@@ -177,6 +185,7 @@ type BotHistoryMessageAsset struct {
 	Name        string             `json:"name"`
 	Metadata    []byte             `json:"metadata"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	TeamID      pgtype.UUID        `json:"team_id"`
 }
 
 type BotHistoryMessageCompact struct {
@@ -200,6 +209,7 @@ type BotHistoryMessageCompact struct {
 	CompactionEpoch int64              `json:"compaction_epoch"`
 	StartedAt       pgtype.Timestamptz `json:"started_at"`
 	CompletedAt     pgtype.Timestamptz `json:"completed_at"`
+	TeamID          pgtype.UUID        `json:"team_id"`
 }
 
 type BotPluginInstallation struct {
@@ -215,6 +225,7 @@ type BotPluginInstallation struct {
 	Manifest    []byte             `json:"manifest"`
 	InstalledAt pgtype.Timestamptz `json:"installed_at"`
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+	TeamID      pgtype.UUID        `json:"team_id"`
 }
 
 type BotPluginResource struct {
@@ -227,6 +238,7 @@ type BotPluginResource struct {
 	Metadata       []byte             `json:"metadata"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	TeamID         pgtype.UUID        `json:"team_id"`
 }
 
 type BotRemoteRuntimeBinding struct {
@@ -238,6 +250,7 @@ type BotRemoteRuntimeBinding struct {
 	ToolApprovalConfig []byte             `json:"tool_approval_config"`
 	CreatedAt          pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
+	TeamID             pgtype.UUID        `json:"team_id"`
 }
 
 type BotSession struct {
@@ -258,6 +271,7 @@ type BotSession struct {
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
 	DeletedAt        pgtype.Timestamptz `json:"deleted_at"`
+	TeamID           pgtype.UUID        `json:"team_id"`
 }
 
 type BotSessionDiscussCursor struct {
@@ -267,6 +281,7 @@ type BotSessionDiscussCursor struct {
 	Source         string             `json:"source"`
 	ConsumedCursor int64              `json:"consumed_cursor"`
 	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	TeamID         pgtype.UUID        `json:"team_id"`
 }
 
 type BotSessionEvent struct {
@@ -279,6 +294,7 @@ type BotSessionEvent struct {
 	SenderChannelIdentityID pgtype.UUID        `json:"sender_channel_identity_id"`
 	ReceivedAtMs            int64              `json:"received_at_ms"`
 	CreatedAt               pgtype.Timestamptz `json:"created_at"`
+	TeamID                  pgtype.UUID        `json:"team_id"`
 }
 
 type BotStorageBinding struct {
@@ -288,6 +304,7 @@ type BotStorageBinding struct {
 	BasePath          string             `json:"base_path"`
 	CreatedAt         pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+	TeamID            pgtype.UUID        `json:"team_id"`
 }
 
 type BotUserGrant struct {
@@ -299,9 +316,11 @@ type BotUserGrant struct {
 	CreatedByUserID pgtype.UUID        `json:"created_by_user_id"`
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	TeamID          pgtype.UUID        `json:"team_id"`
 }
 
 type BotVisibleHistoryMessage struct {
+	TeamID                  pgtype.UUID        `json:"team_id"`
 	TurnID                  pgtype.UUID        `json:"turn_id"`
 	TurnPosition            pgtype.Int8        `json:"turn_position"`
 	TurnMessageSeq          pgtype.Int8        `json:"turn_message_seq"`
@@ -332,6 +351,7 @@ type BotWorkspaceResourceLimit struct {
 	StorageBytes  int64              `json:"storage_bytes"`
 	CreatedAt     pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
+	TeamID        pgtype.UUID        `json:"team_id"`
 }
 
 type ChannelIdentity struct {
@@ -343,6 +363,7 @@ type ChannelIdentity struct {
 	Metadata         []byte             `json:"metadata"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	TeamID           pgtype.UUID        `json:"team_id"`
 }
 
 type ChannelLinkCode struct {
@@ -353,6 +374,7 @@ type ChannelLinkCode struct {
 	ConsumedAt                pgtype.Timestamptz `json:"consumed_at"`
 	ConsumedChannelIdentityID pgtype.UUID        `json:"consumed_channel_identity_id"`
 	CreatedAt                 pgtype.Timestamptz `json:"created_at"`
+	TeamID                    pgtype.UUID        `json:"team_id"`
 }
 
 type Container struct {
@@ -370,6 +392,7 @@ type Container struct {
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
 	LastStartedAt    pgtype.Timestamptz `json:"last_started_at"`
 	LastStoppedAt    pgtype.Timestamptz `json:"last_stopped_at"`
+	TeamID           pgtype.UUID        `json:"team_id"`
 }
 
 type ContainerVersion struct {
@@ -378,6 +401,7 @@ type ContainerVersion struct {
 	SnapshotID  pgtype.UUID        `json:"snapshot_id"`
 	Version     int32              `json:"version"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	TeamID      pgtype.UUID        `json:"team_id"`
 }
 
 type EmailOauthToken struct {
@@ -391,6 +415,7 @@ type EmailOauthToken struct {
 	State           string             `json:"state"`
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	TeamID          pgtype.UUID        `json:"team_id"`
 }
 
 type EmailOutbox struct {
@@ -408,6 +433,7 @@ type EmailOutbox struct {
 	Error       string             `json:"error"`
 	SentAt      pgtype.Timestamptz `json:"sent_at"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	TeamID      pgtype.UUID        `json:"team_id"`
 }
 
 type EmailProvider struct {
@@ -418,6 +444,7 @@ type EmailProvider struct {
 	Config    []byte             `json:"config"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }
 
 type FetchProvider struct {
@@ -428,6 +455,7 @@ type FetchProvider struct {
 	Enable    bool               `json:"enable"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }
 
 type LifecycleEvent struct {
@@ -436,6 +464,7 @@ type LifecycleEvent struct {
 	EventType   string             `json:"event_type"`
 	Payload     []byte             `json:"payload"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	TeamID      pgtype.UUID        `json:"team_id"`
 }
 
 type McpConnection struct {
@@ -456,6 +485,7 @@ type McpConnection struct {
 	Metadata                      []byte             `json:"metadata"`
 	CreatedAt                     pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt                     pgtype.Timestamptz `json:"updated_at"`
+	TeamID                        pgtype.UUID        `json:"team_id"`
 }
 
 type McpOauthToken struct {
@@ -480,6 +510,7 @@ type McpOauthToken struct {
 	RedirectUri            string             `json:"redirect_uri"`
 	CreatedAt              pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt              pgtype.Timestamptz `json:"updated_at"`
+	TeamID                 pgtype.UUID        `json:"team_id"`
 }
 
 type MediaAsset struct {
@@ -497,6 +528,7 @@ type MediaAsset struct {
 	DurationMs        pgtype.Int8        `json:"duration_ms"`
 	Metadata          []byte             `json:"metadata"`
 	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	TeamID            pgtype.UUID        `json:"team_id"`
 }
 
 type MemoryEdge struct {
@@ -508,6 +540,7 @@ type MemoryEdge struct {
 	Weight    float32            `json:"weight"`
 	Metadata  []byte             `json:"metadata"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }
 
 type MemoryNode struct {
@@ -527,6 +560,7 @@ type MemoryNode struct {
 	ExpiresAt        pgtype.Timestamptz `json:"expires_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
+	TeamID           pgtype.UUID        `json:"team_id"`
 }
 
 type MemoryProvider struct {
@@ -537,6 +571,7 @@ type MemoryProvider struct {
 	IsDefault bool               `json:"is_default"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }
 
 type Model struct {
@@ -549,6 +584,7 @@ type Model struct {
 	Config     []byte             `json:"config"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	TeamID     pgtype.UUID        `json:"team_id"`
 }
 
 type ModelVariant struct {
@@ -559,6 +595,7 @@ type ModelVariant struct {
 	Metadata  []byte             `json:"metadata"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }
 
 type Provider struct {
@@ -571,6 +608,7 @@ type Provider struct {
 	Metadata   []byte             `json:"metadata"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	TeamID     pgtype.UUID        `json:"team_id"`
 }
 
 type ProviderOauthToken struct {
@@ -586,6 +624,7 @@ type ProviderOauthToken struct {
 	Metadata         []byte             `json:"metadata"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	TeamID           pgtype.UUID        `json:"team_id"`
 }
 
 type Schedule struct {
@@ -600,6 +639,7 @@ type Schedule struct {
 	Enabled      bool               `json:"enabled"`
 	Command      string             `json:"command"`
 	BotID        pgtype.UUID        `json:"bot_id"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 }
 
 type ScheduleLog struct {
@@ -614,6 +654,7 @@ type ScheduleLog struct {
 	ModelID      pgtype.UUID        `json:"model_id"`
 	StartedAt    pgtype.Timestamptz `json:"started_at"`
 	CompletedAt  pgtype.Timestamptz `json:"completed_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 }
 
 type SearchProvider struct {
@@ -624,6 +665,7 @@ type SearchProvider struct {
 	Enable    bool               `json:"enable"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }
 
 type Snapshot struct {
@@ -635,6 +677,7 @@ type Snapshot struct {
 	Snapshotter               string             `json:"snapshotter"`
 	Source                    string             `json:"source"`
 	CreatedAt                 pgtype.Timestamptz `json:"created_at"`
+	TeamID                    pgtype.UUID        `json:"team_id"`
 }
 
 type StorageProvider struct {
@@ -644,6 +687,7 @@ type StorageProvider struct {
 	Config    []byte             `json:"config"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }
 
 type Task struct {
@@ -656,6 +700,15 @@ type Task struct {
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 	ExecID    pgtype.Text        `json:"exec_id"`
 	Pid       pgtype.Int4        `json:"pid"`
+	TeamID    pgtype.UUID        `json:"team_id"`
+}
+
+type Team struct {
+	ID        pgtype.UUID        `json:"id"`
+	Slug      pgtype.Text        `json:"slug"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	Metadata  []byte             `json:"metadata"`
 }
 
 type ToolApprovalRequest struct {
@@ -682,6 +735,7 @@ type ToolApprovalRequest struct {
 	ConversationType             string             `json:"conversation_type"`
 	CreatedAt                    pgtype.Timestamptz `json:"created_at"`
 	DecidedAt                    pgtype.Timestamptz `json:"decided_at"`
+	TeamID                       pgtype.UUID        `json:"team_id"`
 }
 
 type TtsModel struct {
@@ -692,6 +746,7 @@ type TtsModel struct {
 	Config        []byte             `json:"config"`
 	CreatedAt     pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
+	TeamID        pgtype.UUID        `json:"team_id"`
 }
 
 type TtsProvider struct {
@@ -702,6 +757,7 @@ type TtsProvider struct {
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 	Enable    bool               `json:"enable"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }
 
 type User struct {
@@ -719,6 +775,7 @@ type User struct {
 	Metadata     []byte             `json:"metadata"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 }
 
 type UserChannelBinding struct {
@@ -728,6 +785,7 @@ type UserChannelBinding struct {
 	Config      []byte             `json:"config"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+	TeamID      pgtype.UUID        `json:"team_id"`
 }
 
 type UserChannelIdentityBinding struct {
@@ -736,6 +794,7 @@ type UserChannelIdentityBinding struct {
 	ChannelIdentityID pgtype.UUID        `json:"channel_identity_id"`
 	CreatedAt         pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+	TeamID            pgtype.UUID        `json:"team_id"`
 }
 
 type UserInputRequest struct {
@@ -769,6 +828,7 @@ type UserInputRequest struct {
 	RespondedAt                  pgtype.Timestamptz `json:"responded_at"`
 	CanceledAt                   pgtype.Timestamptz `json:"canceled_at"`
 	UpdatedAt                    pgtype.Timestamptz `json:"updated_at"`
+	TeamID                       pgtype.UUID        `json:"team_id"`
 }
 
 type UserProviderOauthToken struct {
@@ -785,6 +845,7 @@ type UserProviderOauthToken struct {
 	Metadata         []byte             `json:"metadata"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	TeamID           pgtype.UUID        `json:"team_id"`
 }
 
 type UserRuntime struct {
@@ -795,4 +856,5 @@ type UserRuntime struct {
 	RevokedAt pgtype.Timestamptz `json:"revoked_at"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	TeamID    pgtype.UUID        `json:"team_id"`
 }

--- a/internal/db/postgres/sqlc/models.sql.go
+++ b/internal/db/postgres/sqlc/models.sql.go
@@ -13,7 +13,7 @@ import (
 
 const countModels = `-- name: CountModels :one
 SELECT COUNT(*) FROM models
-WHERE type NOT IN ('speech', 'transcription', 'video')
+WHERE team_id = public.memoh_current_team_id() AND type NOT IN ('speech', 'transcription', 'video')
 `
 
 func (q *Queries) CountModels(ctx context.Context) (int64, error) {
@@ -24,7 +24,7 @@ func (q *Queries) CountModels(ctx context.Context) (int64, error) {
 }
 
 const countModelsByType = `-- name: CountModelsByType :one
-SELECT COUNT(*) FROM models WHERE type = $1
+SELECT COUNT(*) FROM models WHERE team_id = public.memoh_current_team_id() AND type = $1
 `
 
 func (q *Queries) CountModelsByType(ctx context.Context, type_ string) (int64, error) {
@@ -37,7 +37,7 @@ func (q *Queries) CountModelsByType(ctx context.Context, type_ string) (int64, e
 const countProviders = `-- name: CountProviders :one
 SELECT COUNT(*)
 FROM providers
-WHERE client_type NOT IN (
+WHERE team_id = public.memoh_current_team_id() AND client_type NOT IN (
   'edge-speech',
   'openai-speech',
   'openai-transcription',
@@ -76,7 +76,7 @@ VALUES (
   $5,
   $6
 )
-RETURNING id, model_id, name, provider_id, type, enable, config, created_at, updated_at
+RETURNING id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id
 `
 
 type CreateModelParams struct {
@@ -108,6 +108,7 @@ func (q *Queries) CreateModel(ctx context.Context, arg CreateModelParams) (Model
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -120,7 +121,7 @@ VALUES (
   $3,
   $4
 )
-RETURNING id, model_uuid, variant_id, weight, metadata, created_at, updated_at
+RETURNING id, model_uuid, variant_id, weight, metadata, created_at, updated_at, team_id
 `
 
 type CreateModelVariantParams struct {
@@ -146,6 +147,7 @@ func (q *Queries) CreateModelVariant(ctx context.Context, arg CreateModelVariant
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -160,7 +162,7 @@ VALUES (
   $5,
   $6
 )
-RETURNING id, name, client_type, icon, enable, config, metadata, created_at, updated_at
+RETURNING id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id
 `
 
 type CreateProviderParams struct {
@@ -192,12 +194,13 @@ func (q *Queries) CreateProvider(ctx context.Context, arg CreateProviderParams) 
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteModel = `-- name: DeleteModel :exec
-DELETE FROM models WHERE id = $1
+DELETE FROM models WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteModel(ctx context.Context, id pgtype.UUID) error {
@@ -206,7 +209,7 @@ func (q *Queries) DeleteModel(ctx context.Context, id pgtype.UUID) error {
 }
 
 const deleteModelByModelID = `-- name: DeleteModelByModelID :exec
-DELETE FROM models WHERE model_id = $1
+DELETE FROM models WHERE team_id = public.memoh_current_team_id() AND model_id = $1
 `
 
 func (q *Queries) DeleteModelByModelID(ctx context.Context, modelID string) error {
@@ -216,7 +219,7 @@ func (q *Queries) DeleteModelByModelID(ctx context.Context, modelID string) erro
 
 const deleteModelByProviderAndType = `-- name: DeleteModelByProviderAndType :exec
 DELETE FROM models
-WHERE provider_id = $1
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND model_id = $2
   AND type = $3
 `
@@ -234,7 +237,7 @@ func (q *Queries) DeleteModelByProviderAndType(ctx context.Context, arg DeleteMo
 
 const deleteModelByProviderIDAndModelID = `-- name: DeleteModelByProviderIDAndModelID :exec
 DELETE FROM models
-WHERE provider_id = $1
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND model_id = $2
 `
 
@@ -249,7 +252,7 @@ func (q *Queries) DeleteModelByProviderIDAndModelID(ctx context.Context, arg Del
 }
 
 const deleteProvider = `-- name: DeleteProvider :exec
-DELETE FROM providers WHERE id = $1
+DELETE FROM providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteProvider(ctx context.Context, id pgtype.UUID) error {
@@ -258,7 +261,7 @@ func (q *Queries) DeleteProvider(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getModelByID = `-- name: GetModelByID :one
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models WHERE id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetModelByID(ctx context.Context, id pgtype.UUID) (Model, error) {
@@ -274,12 +277,13 @@ func (q *Queries) GetModelByID(ctx context.Context, id pgtype.UUID) (Model, erro
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getModelByModelID = `-- name: GetModelByModelID :one
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models WHERE model_id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models WHERE team_id = public.memoh_current_team_id() AND model_id = $1
 `
 
 func (q *Queries) GetModelByModelID(ctx context.Context, modelID string) (Model, error) {
@@ -295,13 +299,14 @@ func (q *Queries) GetModelByModelID(ctx context.Context, modelID string) (Model,
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getModelByProviderAndModelID = `-- name: GetModelByProviderAndModelID :one
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE provider_id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND model_id = $2
 LIMIT 1
 `
@@ -324,12 +329,13 @@ func (q *Queries) GetModelByProviderAndModelID(ctx context.Context, arg GetModel
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getProviderByClientType = `-- name: GetProviderByClientType :one
-SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at FROM providers WHERE client_type = $1
+SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id FROM providers WHERE team_id = public.memoh_current_team_id() AND client_type = $1
 `
 
 func (q *Queries) GetProviderByClientType(ctx context.Context, clientType string) (Provider, error) {
@@ -345,12 +351,13 @@ func (q *Queries) GetProviderByClientType(ctx context.Context, clientType string
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getProviderByID = `-- name: GetProviderByID :one
-SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at FROM providers WHERE id = $1
+SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id FROM providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetProviderByID(ctx context.Context, id pgtype.UUID) (Provider, error) {
@@ -366,12 +373,13 @@ func (q *Queries) GetProviderByID(ctx context.Context, id pgtype.UUID) (Provider
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getProviderByName = `-- name: GetProviderByName :one
-SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at FROM providers WHERE name = $1
+SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id FROM providers WHERE team_id = public.memoh_current_team_id() AND name = $1
 `
 
 func (q *Queries) GetProviderByName(ctx context.Context, name string) (Provider, error) {
@@ -387,17 +395,18 @@ func (q *Queries) GetProviderByName(ctx context.Context, name string) (Provider,
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getSpeechModelWithProvider = `-- name: GetSpeechModelWithProvider :one
 SELECT
-  m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at,
+  m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.id = $1
   AND m.type = 'speech'
 `
 
@@ -411,6 +420,7 @@ type GetSpeechModelWithProviderRow struct {
 	Config       []byte             `json:"config"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 	ProviderType string             `json:"provider_type"`
 }
 
@@ -427,6 +437,7 @@ func (q *Queries) GetSpeechModelWithProvider(ctx context.Context, id pgtype.UUID
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 		&i.ProviderType,
 	)
 	return i, err
@@ -434,11 +445,11 @@ func (q *Queries) GetSpeechModelWithProvider(ctx context.Context, id pgtype.UUID
 
 const getTranscriptionModelWithProvider = `-- name: GetTranscriptionModelWithProvider :one
 SELECT
-  m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at,
+  m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.id = $1
   AND m.type = 'transcription'
 `
 
@@ -452,6 +463,7 @@ type GetTranscriptionModelWithProviderRow struct {
 	Config       []byte             `json:"config"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 	ProviderType string             `json:"provider_type"`
 }
 
@@ -468,6 +480,7 @@ func (q *Queries) GetTranscriptionModelWithProvider(ctx context.Context, id pgty
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 		&i.ProviderType,
 	)
 	return i, err
@@ -475,11 +488,11 @@ func (q *Queries) GetTranscriptionModelWithProvider(ctx context.Context, id pgty
 
 const getVideoModelWithProvider = `-- name: GetVideoModelWithProvider :one
 SELECT
-  m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at,
+  m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.id = $1
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.id = $1
   AND m.type = 'video'
 `
 
@@ -493,6 +506,7 @@ type GetVideoModelWithProviderRow struct {
 	Config       []byte             `json:"config"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 	ProviderType string             `json:"provider_type"`
 }
 
@@ -509,16 +523,17 @@ func (q *Queries) GetVideoModelWithProvider(ctx context.Context, id pgtype.UUID)
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 		&i.ProviderType,
 	)
 	return i, err
 }
 
 const listEnabledModels = `-- name: ListEnabledModels :many
-SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at
+SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id
 FROM models m
 JOIN providers p ON m.provider_id = p.id
-WHERE p.enable = true
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND p.enable = true
   AND m.enable = true
   AND m.type NOT IN ('speech', 'transcription', 'video')
 ORDER BY m.created_at DESC
@@ -543,6 +558,7 @@ func (q *Queries) ListEnabledModels(ctx context.Context) ([]Model, error) {
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -555,10 +571,10 @@ func (q *Queries) ListEnabledModels(ctx context.Context) ([]Model, error) {
 }
 
 const listEnabledModelsByProviderClientType = `-- name: ListEnabledModelsByProviderClientType :many
-SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at
+SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id
 FROM models m
 JOIN providers p ON m.provider_id = p.id
-WHERE p.enable = true
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND p.enable = true
   AND m.enable = true
   AND p.client_type = $1
 ORDER BY m.created_at DESC
@@ -583,6 +599,7 @@ func (q *Queries) ListEnabledModelsByProviderClientType(ctx context.Context, cli
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -595,10 +612,10 @@ func (q *Queries) ListEnabledModelsByProviderClientType(ctx context.Context, cli
 }
 
 const listEnabledModelsByType = `-- name: ListEnabledModelsByType :many
-SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at
+SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id
 FROM models m
 JOIN providers p ON m.provider_id = p.id
-WHERE p.enable = true
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND p.enable = true
   AND m.enable = true
   AND m.type = $1
 ORDER BY m.created_at DESC
@@ -623,6 +640,7 @@ func (q *Queries) ListEnabledModelsByType(ctx context.Context, type_ string) ([]
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -635,8 +653,8 @@ func (q *Queries) ListEnabledModelsByType(ctx context.Context, type_ string) ([]
 }
 
 const listModelVariantsByModelUUID = `-- name: ListModelVariantsByModelUUID :many
-SELECT id, model_uuid, variant_id, weight, metadata, created_at, updated_at FROM model_variants
-WHERE model_uuid = $1
+SELECT id, model_uuid, variant_id, weight, metadata, created_at, updated_at, team_id FROM model_variants
+WHERE team_id = public.memoh_current_team_id() AND model_uuid = $1
 ORDER BY weight DESC, created_at DESC
 `
 
@@ -657,6 +675,7 @@ func (q *Queries) ListModelVariantsByModelUUID(ctx context.Context, modelUuid pg
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -669,8 +688,8 @@ func (q *Queries) ListModelVariantsByModelUUID(ctx context.Context, modelUuid pg
 }
 
 const listModels = `-- name: ListModels :many
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE type NOT IN ('speech', 'transcription', 'video')
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND type NOT IN ('speech', 'transcription', 'video')
 ORDER BY created_at DESC
 `
 
@@ -693,6 +712,7 @@ func (q *Queries) ListModels(ctx context.Context) ([]Model, error) {
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -705,8 +725,8 @@ func (q *Queries) ListModels(ctx context.Context) ([]Model, error) {
 }
 
 const listModelsByModelID = `-- name: ListModelsByModelID :many
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE model_id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND model_id = $1
 ORDER BY created_at DESC
 `
 
@@ -729,6 +749,7 @@ func (q *Queries) ListModelsByModelID(ctx context.Context, modelID string) ([]Mo
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -741,10 +762,10 @@ func (q *Queries) ListModelsByModelID(ctx context.Context, modelID string) ([]Mo
 }
 
 const listModelsByProviderClientType = `-- name: ListModelsByProviderClientType :many
-SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at
+SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id
 FROM models m
 JOIN providers p ON m.provider_id = p.id
-WHERE p.client_type = $1
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND p.client_type = $1
 ORDER BY m.created_at DESC
 `
 
@@ -767,6 +788,7 @@ func (q *Queries) ListModelsByProviderClientType(ctx context.Context, clientType
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -779,8 +801,8 @@ func (q *Queries) ListModelsByProviderClientType(ctx context.Context, clientType
 }
 
 const listModelsByProviderID = `-- name: ListModelsByProviderID :many
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE provider_id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND type NOT IN ('speech', 'transcription', 'video')
 ORDER BY created_at DESC
 `
@@ -804,6 +826,7 @@ func (q *Queries) ListModelsByProviderID(ctx context.Context, providerID pgtype.
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -816,8 +839,8 @@ func (q *Queries) ListModelsByProviderID(ctx context.Context, providerID pgtype.
 }
 
 const listModelsByProviderIDAndType = `-- name: ListModelsByProviderIDAndType :many
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE provider_id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND type = $2
 ORDER BY created_at DESC
 `
@@ -846,6 +869,7 @@ func (q *Queries) ListModelsByProviderIDAndType(ctx context.Context, arg ListMod
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -858,8 +882,8 @@ func (q *Queries) ListModelsByProviderIDAndType(ctx context.Context, arg ListMod
 }
 
 const listModelsByType = `-- name: ListModelsByType :many
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE type = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND type = $1
 ORDER BY created_at DESC
 `
 
@@ -882,6 +906,7 @@ func (q *Queries) ListModelsByType(ctx context.Context, type_ string) ([]Model, 
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -894,8 +919,8 @@ func (q *Queries) ListModelsByType(ctx context.Context, type_ string) ([]Model, 
 }
 
 const listProviders = `-- name: ListProviders :many
-SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at FROM providers
-WHERE client_type NOT IN (
+SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id FROM providers
+WHERE team_id = public.memoh_current_team_id() AND client_type NOT IN (
   'edge-speech',
   'openai-speech',
   'openai-transcription',
@@ -937,6 +962,7 @@ func (q *Queries) ListProviders(ctx context.Context) ([]Provider, error) {
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -949,11 +975,11 @@ func (q *Queries) ListProviders(ctx context.Context) ([]Provider, error) {
 }
 
 const listSpeechModels = `-- name: ListSpeechModels :many
-SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at,
+SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.type = 'speech'
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.type = 'speech'
   AND m.enable = true
 ORDER BY m.created_at DESC
 `
@@ -968,6 +994,7 @@ type ListSpeechModelsRow struct {
 	Config       []byte             `json:"config"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 	ProviderType string             `json:"provider_type"`
 }
 
@@ -990,6 +1017,7 @@ func (q *Queries) ListSpeechModels(ctx context.Context) ([]ListSpeechModelsRow, 
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 			&i.ProviderType,
 		); err != nil {
 			return nil, err
@@ -1003,8 +1031,8 @@ func (q *Queries) ListSpeechModels(ctx context.Context) ([]ListSpeechModelsRow, 
 }
 
 const listSpeechModelsByProviderID = `-- name: ListSpeechModelsByProviderID :many
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE provider_id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND type = 'speech'
   AND enable = true
 ORDER BY created_at DESC
@@ -1029,6 +1057,7 @@ func (q *Queries) ListSpeechModelsByProviderID(ctx context.Context, providerID p
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -1041,8 +1070,8 @@ func (q *Queries) ListSpeechModelsByProviderID(ctx context.Context, providerID p
 }
 
 const listSpeechProviders = `-- name: ListSpeechProviders :many
-SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at FROM providers
-WHERE client_type IN (
+SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id FROM providers
+WHERE team_id = public.memoh_current_team_id() AND client_type IN (
   'edge-speech',
   'openai-speech',
   'openrouter-speech',
@@ -1075,6 +1104,7 @@ func (q *Queries) ListSpeechProviders(ctx context.Context) ([]Provider, error) {
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -1087,11 +1117,11 @@ func (q *Queries) ListSpeechProviders(ctx context.Context) ([]Provider, error) {
 }
 
 const listTranscriptionModels = `-- name: ListTranscriptionModels :many
-SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at,
+SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.type = 'transcription'
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.type = 'transcription'
   AND m.enable = true
 ORDER BY m.created_at DESC
 `
@@ -1106,6 +1136,7 @@ type ListTranscriptionModelsRow struct {
 	Config       []byte             `json:"config"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 	ProviderType string             `json:"provider_type"`
 }
 
@@ -1128,6 +1159,7 @@ func (q *Queries) ListTranscriptionModels(ctx context.Context) ([]ListTranscript
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 			&i.ProviderType,
 		); err != nil {
 			return nil, err
@@ -1141,8 +1173,8 @@ func (q *Queries) ListTranscriptionModels(ctx context.Context) ([]ListTranscript
 }
 
 const listTranscriptionModelsByProviderID = `-- name: ListTranscriptionModelsByProviderID :many
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE provider_id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND type = 'transcription'
   AND enable = true
 ORDER BY created_at DESC
@@ -1167,6 +1199,7 @@ func (q *Queries) ListTranscriptionModelsByProviderID(ctx context.Context, provi
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -1179,8 +1212,8 @@ func (q *Queries) ListTranscriptionModelsByProviderID(ctx context.Context, provi
 }
 
 const listTranscriptionProviders = `-- name: ListTranscriptionProviders :many
-SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at FROM providers
-WHERE client_type IN (
+SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id FROM providers
+WHERE team_id = public.memoh_current_team_id() AND client_type IN (
   'openai-transcription',
   'openrouter-transcription',
   'elevenlabs-transcription',
@@ -1209,6 +1242,7 @@ func (q *Queries) ListTranscriptionProviders(ctx context.Context) ([]Provider, e
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -1221,11 +1255,11 @@ func (q *Queries) ListTranscriptionProviders(ctx context.Context) ([]Provider, e
 }
 
 const listVideoModels = `-- name: ListVideoModels :many
-SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at,
+SELECT m.id, m.model_id, m.name, m.provider_id, m.type, m.enable, m.config, m.created_at, m.updated_at, m.team_id,
   p.client_type AS provider_type
 FROM models m
 JOIN providers p ON p.id = m.provider_id
-WHERE m.type = 'video'
+WHERE m.team_id = public.memoh_current_team_id() AND p.team_id = public.memoh_current_team_id() AND m.type = 'video'
   AND m.enable = true
 ORDER BY m.created_at DESC
 `
@@ -1240,6 +1274,7 @@ type ListVideoModelsRow struct {
 	Config       []byte             `json:"config"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
 	ProviderType string             `json:"provider_type"`
 }
 
@@ -1262,6 +1297,7 @@ func (q *Queries) ListVideoModels(ctx context.Context) ([]ListVideoModelsRow, er
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 			&i.ProviderType,
 		); err != nil {
 			return nil, err
@@ -1275,8 +1311,8 @@ func (q *Queries) ListVideoModels(ctx context.Context) ([]ListVideoModelsRow, er
 }
 
 const listVideoModelsByProviderID = `-- name: ListVideoModelsByProviderID :many
-SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at FROM models
-WHERE provider_id = $1
+SELECT id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id FROM models
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND type = 'video'
   AND enable = true
 ORDER BY created_at DESC
@@ -1301,6 +1337,7 @@ func (q *Queries) ListVideoModelsByProviderID(ctx context.Context, providerID pg
 			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -1313,8 +1350,8 @@ func (q *Queries) ListVideoModelsByProviderID(ctx context.Context, providerID pg
 }
 
 const listVideoProviders = `-- name: ListVideoProviders :many
-SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at FROM providers
-WHERE client_type IN (
+SELECT id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id FROM providers
+WHERE team_id = public.memoh_current_team_id() AND client_type IN (
   'openrouter-video',
   'modelark-video',
   'volcengine-video'
@@ -1341,6 +1378,7 @@ func (q *Queries) ListVideoProviders(ctx context.Context) ([]Provider, error) {
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -1362,8 +1400,8 @@ SET
   enable = $5,
   config = $6,
   updated_at = now()
-WHERE id = $7
-RETURNING id, model_id, name, provider_id, type, enable, config, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $7
+RETURNING id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id
 `
 
 type UpdateModelParams struct {
@@ -1397,6 +1435,7 @@ func (q *Queries) UpdateModel(ctx context.Context, arg UpdateModelParams) (Model
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -1411,8 +1450,8 @@ SET
   config = $5,
   metadata = $6,
   updated_at = now()
-WHERE id = $7
-RETURNING id, name, client_type, icon, enable, config, metadata, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $7
+RETURNING id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id
 `
 
 type UpdateProviderParams struct {
@@ -1446,6 +1485,7 @@ func (q *Queries) UpdateProvider(ctx context.Context, arg UpdateProviderParams) 
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -1453,7 +1493,7 @@ func (q *Queries) UpdateProvider(ctx context.Context, arg UpdateProviderParams) 
 const upsertRegistryModel = `-- name: UpsertRegistryModel :one
 INSERT INTO models (model_id, name, provider_id, type, config)
 VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (provider_id, model_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id, model_id) DO UPDATE SET
   name = EXCLUDED.name,
   type = EXCLUDED.type,
   config = CASE
@@ -1462,7 +1502,7 @@ ON CONFLICT (provider_id, model_id) DO UPDATE SET
     ELSE EXCLUDED.config
   END,
   updated_at = now()
-RETURNING id, model_id, name, provider_id, type, enable, config, created_at, updated_at
+RETURNING id, model_id, name, provider_id, type, enable, config, created_at, updated_at, team_id
 `
 
 type UpsertRegistryModelParams struct {
@@ -1492,6 +1532,7 @@ func (q *Queries) UpsertRegistryModel(ctx context.Context, arg UpsertRegistryMod
 		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -1499,11 +1540,11 @@ func (q *Queries) UpsertRegistryModel(ctx context.Context, arg UpsertRegistryMod
 const upsertRegistryProvider = `-- name: UpsertRegistryProvider :one
 INSERT INTO providers (name, client_type, icon, enable, config, metadata)
 VALUES ($1, $2, $3, false, $4, '{}')
-ON CONFLICT (name) DO UPDATE SET
+ON CONFLICT (team_id, name) DO UPDATE SET
   icon = EXCLUDED.icon,
   client_type = EXCLUDED.client_type,
   updated_at = now()
-RETURNING id, name, client_type, icon, enable, config, metadata, created_at, updated_at
+RETURNING id, name, client_type, icon, enable, config, metadata, created_at, updated_at, team_id
 `
 
 type UpsertRegistryProviderParams struct {
@@ -1531,6 +1572,7 @@ func (q *Queries) UpsertRegistryProvider(ctx context.Context, arg UpsertRegistry
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/network.sql.go
+++ b/internal/db/postgres/sqlc/network.sql.go
@@ -17,7 +17,7 @@ SELECT
   overlay_provider,
   overlay_config
 FROM bots
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 type GetBotOverlayConfigRow struct {

--- a/internal/db/postgres/sqlc/plugins.sql.go
+++ b/internal/db/postgres/sqlc/plugins.sql.go
@@ -16,7 +16,7 @@ INSERT INTO bot_plugin_installations (
   bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-ON CONFLICT (bot_id, plugin_id)
+ON CONFLICT (team_id, bot_id, plugin_id)
 DO UPDATE SET plugin_name = EXCLUDED.plugin_name,
               version = EXCLUDED.version,
               status = EXCLUDED.status,
@@ -25,7 +25,7 @@ DO UPDATE SET plugin_name = EXCLUDED.plugin_name,
               metadata = EXCLUDED.metadata,
               manifest = EXCLUDED.manifest,
               updated_at = now()
-RETURNING id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at
+RETURNING id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at, team_id
 `
 
 type CreateBotPluginInstallationParams struct {
@@ -66,13 +66,14 @@ func (q *Queries) CreateBotPluginInstallation(ctx context.Context, arg CreateBot
 		&i.Manifest,
 		&i.InstalledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteBotPluginInstallation = `-- name: DeleteBotPluginInstallation :exec
 DELETE FROM bot_plugin_installations
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 `
 
 type DeleteBotPluginInstallationParams struct {
@@ -87,7 +88,7 @@ func (q *Queries) DeleteBotPluginInstallation(ctx context.Context, arg DeleteBot
 
 const deleteBotPluginResources = `-- name: DeleteBotPluginResources :exec
 DELETE FROM bot_plugin_resources
-WHERE installation_id = $1
+WHERE team_id = public.memoh_current_team_id() AND installation_id = $1
 `
 
 func (q *Queries) DeleteBotPluginResources(ctx context.Context, installationID pgtype.UUID) error {
@@ -96,9 +97,9 @@ func (q *Queries) DeleteBotPluginResources(ctx context.Context, installationID p
 }
 
 const getBotPluginInstallationByID = `-- name: GetBotPluginInstallationByID :one
-SELECT id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at
+SELECT id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at, team_id
 FROM bot_plugin_installations
-WHERE bot_id = $1 AND id = $2
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
 LIMIT 1
 `
 
@@ -123,14 +124,15 @@ func (q *Queries) GetBotPluginInstallationByID(ctx context.Context, arg GetBotPl
 		&i.Manifest,
 		&i.InstalledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listBotPluginInstallations = `-- name: ListBotPluginInstallations :many
-SELECT id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at
+SELECT id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at, team_id
 FROM bot_plugin_installations
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY installed_at DESC
 `
 
@@ -156,6 +158,7 @@ func (q *Queries) ListBotPluginInstallations(ctx context.Context, botID pgtype.U
 			&i.Manifest,
 			&i.InstalledAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -168,9 +171,9 @@ func (q *Queries) ListBotPluginInstallations(ctx context.Context, botID pgtype.U
 }
 
 const listBotPluginResources = `-- name: ListBotPluginResources :many
-SELECT id, installation_id, resource_type, resource_key, resource_id, status, metadata, created_at, updated_at
+SELECT id, installation_id, resource_type, resource_key, resource_id, status, metadata, created_at, updated_at, team_id
 FROM bot_plugin_resources
-WHERE installation_id = $1
+WHERE team_id = public.memoh_current_team_id() AND installation_id = $1
 ORDER BY resource_type ASC, resource_key ASC
 `
 
@@ -193,6 +196,7 @@ func (q *Queries) ListBotPluginResources(ctx context.Context, installationID pgt
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -209,8 +213,8 @@ UPDATE bot_plugin_installations
 SET status = $3,
     enabled = $4,
     updated_at = now()
-WHERE bot_id = $1 AND id = $2
-RETURNING id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND id = $2
+RETURNING id, bot_id, plugin_id, plugin_name, version, status, enabled, config, metadata, manifest, installed_at, updated_at, team_id
 `
 
 type UpdateBotPluginInstallationStatusParams struct {
@@ -241,6 +245,7 @@ func (q *Queries) UpdateBotPluginInstallationStatus(ctx context.Context, arg Upd
 		&i.Manifest,
 		&i.InstalledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -250,12 +255,12 @@ INSERT INTO bot_plugin_resources (
   installation_id, resource_type, resource_key, resource_id, status, metadata
 )
 VALUES ($1, $2, $3, $4, $5, $6)
-ON CONFLICT (installation_id, resource_type, resource_key)
+ON CONFLICT (team_id, installation_id, resource_type, resource_key)
 DO UPDATE SET resource_id = EXCLUDED.resource_id,
               status = EXCLUDED.status,
               metadata = EXCLUDED.metadata,
               updated_at = now()
-RETURNING id, installation_id, resource_type, resource_key, resource_id, status, metadata, created_at, updated_at
+RETURNING id, installation_id, resource_type, resource_key, resource_id, status, metadata, created_at, updated_at, team_id
 `
 
 type UpsertBotPluginResourceParams struct {
@@ -287,6 +292,7 @@ func (q *Queries) UpsertBotPluginResource(ctx context.Context, arg UpsertBotPlug
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/provider_oauth.sql.go
+++ b/internal/db/postgres/sqlc/provider_oauth.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const deleteProviderOAuthToken = `-- name: DeleteProviderOAuthToken :exec
-DELETE FROM provider_oauth_tokens WHERE provider_id = $1
+DELETE FROM provider_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
 `
 
 func (q *Queries) DeleteProviderOAuthToken(ctx context.Context, providerID pgtype.UUID) error {
@@ -21,7 +21,7 @@ func (q *Queries) DeleteProviderOAuthToken(ctx context.Context, providerID pgtyp
 }
 
 const getProviderOAuthTokenByProvider = `-- name: GetProviderOAuthTokenByProvider :one
-SELECT id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at FROM provider_oauth_tokens WHERE provider_id = $1
+SELECT id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at, team_id FROM provider_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
 `
 
 func (q *Queries) GetProviderOAuthTokenByProvider(ctx context.Context, providerID pgtype.UUID) (ProviderOauthToken, error) {
@@ -40,12 +40,13 @@ func (q *Queries) GetProviderOAuthTokenByProvider(ctx context.Context, providerI
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getProviderOAuthTokenByState = `-- name: GetProviderOAuthTokenByState :one
-SELECT id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at FROM provider_oauth_tokens WHERE state = $1 AND state != ''
+SELECT id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at, team_id FROM provider_oauth_tokens WHERE team_id = public.memoh_current_team_id() AND state = $1 AND state != ''
 `
 
 func (q *Queries) GetProviderOAuthTokenByState(ctx context.Context, state string) (ProviderOauthToken, error) {
@@ -64,6 +65,7 @@ func (q *Queries) GetProviderOAuthTokenByState(ctx context.Context, state string
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -76,7 +78,7 @@ VALUES (
   $3,
   $4
 )
-ON CONFLICT (provider_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id) DO UPDATE SET
   state = EXCLUDED.state,
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
   metadata = EXCLUDED.metadata,
@@ -123,7 +125,7 @@ VALUES (
   $8,
   $9
 )
-ON CONFLICT (provider_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id) DO UPDATE SET
   access_token = EXCLUDED.access_token,
   refresh_token = EXCLUDED.refresh_token,
   expires_at = EXCLUDED.expires_at,
@@ -133,7 +135,7 @@ ON CONFLICT (provider_id) DO UPDATE SET
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
   metadata = EXCLUDED.metadata,
   updated_at = now()
-RETURNING id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at
+RETURNING id, provider_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at, team_id
 `
 
 type UpsertProviderOAuthTokenParams struct {
@@ -174,6 +176,7 @@ func (q *Queries) UpsertProviderOAuthToken(ctx context.Context, arg UpsertProvid
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/schedule.sql.go
+++ b/internal/db/postgres/sqlc/schedule.sql.go
@@ -14,7 +14,7 @@ import (
 const createSchedule = `-- name: CreateSchedule :one
 INSERT INTO schedule (name, description, pattern, max_calls, enabled, command, bot_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 `
 
 type CreateScheduleParams struct {
@@ -50,13 +50,14 @@ func (q *Queries) CreateSchedule(ctx context.Context, arg CreateScheduleParams) 
 		&i.Enabled,
 		&i.Command,
 		&i.BotID,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteSchedule = `-- name: DeleteSchedule :exec
 DELETE FROM schedule
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteSchedule(ctx context.Context, id pgtype.UUID) error {
@@ -65,9 +66,9 @@ func (q *Queries) DeleteSchedule(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getScheduleByID = `-- name: GetScheduleByID :one
-SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 FROM schedule
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetScheduleByID(ctx context.Context, id pgtype.UUID) (Schedule, error) {
@@ -85,6 +86,7 @@ func (q *Queries) GetScheduleByID(ctx context.Context, id pgtype.UUID) (Schedule
 		&i.Enabled,
 		&i.Command,
 		&i.BotID,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -97,8 +99,8 @@ SET current_calls = current_calls + 1,
       ELSE enabled
     END,
     updated_at = now()
-WHERE id = $1
-RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 `
 
 func (q *Queries) IncrementScheduleCalls(ctx context.Context, id pgtype.UUID) (Schedule, error) {
@@ -116,14 +118,15 @@ func (q *Queries) IncrementScheduleCalls(ctx context.Context, id pgtype.UUID) (S
 		&i.Enabled,
 		&i.Command,
 		&i.BotID,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listEnabledSchedules = `-- name: ListEnabledSchedules :many
-SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 FROM schedule
-WHERE enabled = true
+WHERE team_id = public.memoh_current_team_id() AND enabled = true
 ORDER BY created_at DESC
 `
 
@@ -148,6 +151,7 @@ func (q *Queries) ListEnabledSchedules(ctx context.Context) ([]Schedule, error) 
 			&i.Enabled,
 			&i.Command,
 			&i.BotID,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -160,9 +164,9 @@ func (q *Queries) ListEnabledSchedules(ctx context.Context) ([]Schedule, error) 
 }
 
 const listSchedulesByBot = `-- name: ListSchedulesByBot :many
-SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+SELECT id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 FROM schedule
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY created_at DESC
 `
 
@@ -187,6 +191,7 @@ func (q *Queries) ListSchedulesByBot(ctx context.Context, botID pgtype.UUID) ([]
 			&i.Enabled,
 			&i.Command,
 			&i.BotID,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -207,8 +212,8 @@ SET name = $2,
     enabled = $6,
     command = $7,
     updated_at = now()
-WHERE id = $1
-RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, name, description, pattern, max_calls, current_calls, created_at, updated_at, enabled, command, bot_id, team_id
 `
 
 type UpdateScheduleParams struct {
@@ -244,6 +249,7 @@ func (q *Queries) UpdateSchedule(ctx context.Context, arg UpdateScheduleParams) 
 		&i.Enabled,
 		&i.Command,
 		&i.BotID,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/schedule_logs.sql.go
+++ b/internal/db/postgres/sqlc/schedule_logs.sql.go
@@ -19,8 +19,8 @@ SET status = $2,
     usage = $5,
     model_id = $6,
     completed_at = now()
-WHERE id = $1
-RETURNING id, schedule_id, bot_id, session_id, status, result_text, error_message, usage, model_id, started_at, completed_at
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, schedule_id, bot_id, session_id, status, result_text, error_message, usage, model_id, started_at, completed_at, team_id
 `
 
 type CompleteScheduleLogParams struct {
@@ -54,12 +54,13 @@ func (q *Queries) CompleteScheduleLog(ctx context.Context, arg CompleteScheduleL
 		&i.ModelID,
 		&i.StartedAt,
 		&i.CompletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const countScheduleLogsByBot = `-- name: CountScheduleLogsByBot :one
-SELECT count(*) FROM schedule_logs WHERE bot_id = $1
+SELECT count(*) FROM schedule_logs WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) CountScheduleLogsByBot(ctx context.Context, botID pgtype.UUID) (int64, error) {
@@ -70,7 +71,7 @@ func (q *Queries) CountScheduleLogsByBot(ctx context.Context, botID pgtype.UUID)
 }
 
 const countScheduleLogsBySchedule = `-- name: CountScheduleLogsBySchedule :one
-SELECT count(*) FROM schedule_logs WHERE schedule_id = $1
+SELECT count(*) FROM schedule_logs WHERE team_id = public.memoh_current_team_id() AND schedule_id = $1
 `
 
 func (q *Queries) CountScheduleLogsBySchedule(ctx context.Context, scheduleID pgtype.UUID) (int64, error) {
@@ -124,7 +125,7 @@ func (q *Queries) CreateScheduleLog(ctx context.Context, arg CreateScheduleLogPa
 }
 
 const deleteScheduleLogsByBot = `-- name: DeleteScheduleLogsByBot :exec
-DELETE FROM schedule_logs WHERE bot_id = $1
+DELETE FROM schedule_logs WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) DeleteScheduleLogsByBot(ctx context.Context, botID pgtype.UUID) error {
@@ -133,7 +134,7 @@ func (q *Queries) DeleteScheduleLogsByBot(ctx context.Context, botID pgtype.UUID
 }
 
 const deleteScheduleLogsBySchedule = `-- name: DeleteScheduleLogsBySchedule :exec
-DELETE FROM schedule_logs WHERE schedule_id = $1
+DELETE FROM schedule_logs WHERE team_id = public.memoh_current_team_id() AND schedule_id = $1
 `
 
 func (q *Queries) DeleteScheduleLogsBySchedule(ctx context.Context, scheduleID pgtype.UUID) error {
@@ -144,7 +145,7 @@ func (q *Queries) DeleteScheduleLogsBySchedule(ctx context.Context, scheduleID p
 const listScheduleLogsByBot = `-- name: ListScheduleLogsByBot :many
 SELECT id, schedule_id, bot_id, session_id, status, result_text, error_message, usage, started_at, completed_at
 FROM schedule_logs
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3
 `
@@ -202,7 +203,7 @@ func (q *Queries) ListScheduleLogsByBot(ctx context.Context, arg ListScheduleLog
 const listScheduleLogsBySchedule = `-- name: ListScheduleLogsBySchedule :many
 SELECT id, schedule_id, bot_id, session_id, status, result_text, error_message, usage, started_at, completed_at
 FROM schedule_logs
-WHERE schedule_id = $1
+WHERE team_id = public.memoh_current_team_id() AND schedule_id = $1
 ORDER BY started_at DESC
 LIMIT $2 OFFSET $3
 `

--- a/internal/db/postgres/sqlc/search_providers.sql.go
+++ b/internal/db/postgres/sqlc/search_providers.sql.go
@@ -19,7 +19,7 @@ VALUES (
   $3,
   $4
 )
-RETURNING id, name, provider, config, enable, created_at, updated_at
+RETURNING id, name, provider, config, enable, created_at, updated_at, team_id
 `
 
 type CreateSearchProviderParams struct {
@@ -45,12 +45,13 @@ func (q *Queries) CreateSearchProvider(ctx context.Context, arg CreateSearchProv
 		&i.Enable,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteSearchProvider = `-- name: DeleteSearchProvider :exec
-DELETE FROM search_providers WHERE id = $1
+DELETE FROM search_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteSearchProvider(ctx context.Context, id pgtype.UUID) error {
@@ -59,7 +60,7 @@ func (q *Queries) DeleteSearchProvider(ctx context.Context, id pgtype.UUID) erro
 }
 
 const getSearchProviderByID = `-- name: GetSearchProviderByID :one
-SELECT id, name, provider, config, enable, created_at, updated_at FROM search_providers WHERE id = $1
+SELECT id, name, provider, config, enable, created_at, updated_at, team_id FROM search_providers WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetSearchProviderByID(ctx context.Context, id pgtype.UUID) (SearchProvider, error) {
@@ -73,12 +74,13 @@ func (q *Queries) GetSearchProviderByID(ctx context.Context, id pgtype.UUID) (Se
 		&i.Enable,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getSearchProviderByName = `-- name: GetSearchProviderByName :one
-SELECT id, name, provider, config, enable, created_at, updated_at FROM search_providers WHERE name = $1
+SELECT id, name, provider, config, enable, created_at, updated_at, team_id FROM search_providers WHERE team_id = public.memoh_current_team_id() AND name = $1
 `
 
 func (q *Queries) GetSearchProviderByName(ctx context.Context, name string) (SearchProvider, error) {
@@ -92,12 +94,14 @@ func (q *Queries) GetSearchProviderByName(ctx context.Context, name string) (Sea
 		&i.Enable,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listSearchProviders = `-- name: ListSearchProviders :many
-SELECT id, name, provider, config, enable, created_at, updated_at FROM search_providers
+SELECT id, name, provider, config, enable, created_at, updated_at, team_id FROM search_providers
+WHERE team_id = public.memoh_current_team_id()
 ORDER BY created_at DESC
 `
 
@@ -118,6 +122,7 @@ func (q *Queries) ListSearchProviders(ctx context.Context) ([]SearchProvider, er
 			&i.Enable,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -130,8 +135,8 @@ func (q *Queries) ListSearchProviders(ctx context.Context) ([]SearchProvider, er
 }
 
 const listSearchProvidersByProvider = `-- name: ListSearchProvidersByProvider :many
-SELECT id, name, provider, config, enable, created_at, updated_at FROM search_providers
-WHERE provider = $1
+SELECT id, name, provider, config, enable, created_at, updated_at, team_id FROM search_providers
+WHERE team_id = public.memoh_current_team_id() AND provider = $1
 ORDER BY created_at DESC
 `
 
@@ -152,6 +157,7 @@ func (q *Queries) ListSearchProvidersByProvider(ctx context.Context, provider st
 			&i.Enable,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -171,8 +177,8 @@ SET
   config = $3,
   enable = $4,
   updated_at = now()
-WHERE id = $5
-RETURNING id, name, provider, config, enable, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $5
+RETURNING id, name, provider, config, enable, created_at, updated_at, team_id
 `
 
 type UpdateSearchProviderParams struct {
@@ -200,6 +206,7 @@ func (q *Queries) UpdateSearchProvider(ctx context.Context, arg UpdateSearchProv
 		&i.Enable,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/session_events.sql.go
+++ b/internal/db/postgres/sqlc/session_events.sql.go
@@ -13,7 +13,7 @@ import (
 
 const countSessionEvents = `-- name: CountSessionEvents :one
 SELECT COUNT(*) FROM bot_session_events
-WHERE session_id = $1
+WHERE team_id = public.memoh_current_team_id() AND session_id = $1
 `
 
 func (q *Queries) CountSessionEvents(ctx context.Context, sessionID pgtype.UUID) (int64, error) {
@@ -64,7 +64,7 @@ func (q *Queries) CreateSessionEvent(ctx context.Context, arg CreateSessionEvent
 
 const deleteSessionEventsByBot = `-- name: DeleteSessionEventsByBot :exec
 DELETE FROM bot_session_events
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) DeleteSessionEventsByBot(ctx context.Context, botID pgtype.UUID) error {
@@ -73,8 +73,8 @@ func (q *Queries) DeleteSessionEventsByBot(ctx context.Context, botID pgtype.UUI
 }
 
 const listSessionEventsByBot = `-- name: ListSessionEventsByBot :many
-SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at FROM bot_session_events
-WHERE bot_id = $1
+SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at, team_id FROM bot_session_events
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 ORDER BY received_at_ms ASC, id ASC
 `
 
@@ -97,6 +97,7 @@ func (q *Queries) ListSessionEventsByBot(ctx context.Context, botID pgtype.UUID)
 			&i.SenderChannelIdentityID,
 			&i.ReceivedAtMs,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -109,8 +110,8 @@ func (q *Queries) ListSessionEventsByBot(ctx context.Context, botID pgtype.UUID)
 }
 
 const listSessionEventsBySession = `-- name: ListSessionEventsBySession :many
-SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at FROM bot_session_events
-WHERE session_id = $1
+SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at, team_id FROM bot_session_events
+WHERE team_id = public.memoh_current_team_id() AND session_id = $1
 ORDER BY received_at_ms ASC
 `
 
@@ -133,6 +134,7 @@ func (q *Queries) ListSessionEventsBySession(ctx context.Context, sessionID pgty
 			&i.SenderChannelIdentityID,
 			&i.ReceivedAtMs,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -145,8 +147,8 @@ func (q *Queries) ListSessionEventsBySession(ctx context.Context, sessionID pgty
 }
 
 const listSessionEventsBySessionAfter = `-- name: ListSessionEventsBySessionAfter :many
-SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at FROM bot_session_events
-WHERE session_id = $1 AND received_at_ms >= $2
+SELECT id, bot_id, session_id, event_kind, event_data, external_message_id, sender_channel_identity_id, received_at_ms, created_at, team_id FROM bot_session_events
+WHERE team_id = public.memoh_current_team_id() AND session_id = $1 AND received_at_ms >= $2
 ORDER BY received_at_ms ASC
 `
 
@@ -174,6 +176,7 @@ func (q *Queries) ListSessionEventsBySessionAfter(ctx context.Context, arg ListS
 			&i.SenderChannelIdentityID,
 			&i.ReceivedAtMs,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/postgres/sqlc/session_info.sql.go
+++ b/internal/db/postgres/sqlc/session_info.sql.go
@@ -14,7 +14,7 @@ import (
 const countMessagesBySession = `-- name: CountMessagesBySession :one
 SELECT COUNT(*)::bigint AS message_count
 FROM bot_visible_history_messages
-WHERE session_id = $1
+WHERE team_id = public.memoh_current_team_id() AND session_id = $1
 `
 
 func (q *Queries) CountMessagesBySession(ctx context.Context, sessionID pgtype.UUID) (int64, error) {
@@ -28,7 +28,8 @@ const getLatestAssistantUsage = `-- name: GetLatestAssistantUsage :one
 SELECT
   COALESCE((m.usage->>'inputTokens')::bigint, 0)::bigint AS input_tokens
 FROM bot_visible_history_messages m
-WHERE m.session_id = $1
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = $1
   AND m.role = 'assistant'
   AND m.usage IS NOT NULL
 ORDER BY m.created_at DESC
@@ -45,7 +46,8 @@ func (q *Queries) GetLatestAssistantUsage(ctx context.Context, sessionID pgtype.
 const getLatestSessionIDByBot = `-- name: GetLatestSessionIDByBot :one
 SELECT s.id
 FROM bot_sessions s
-WHERE s.bot_id = $1
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = $1
   AND s.type = 'chat'
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC
@@ -80,7 +82,8 @@ SELECT
   COALESCE(SUM((m.usage->>'inputTokens')::bigint), 0)::bigint AS total_input_tokens,
   COALESCE(SUM((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint), 0)::bigint AS cache_read_tokens
 FROM bot_visible_history_messages m
-WHERE m.session_id = $1
+WHERE m.team_id = public.memoh_current_team_id()
+  AND m.session_id = $1
   AND m.usage IS NOT NULL
 `
 
@@ -113,7 +116,8 @@ WITH requested AS (
            ELSE '[]'::jsonb
       END
     ) AS item
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.session_id = $1
     AND m.role = 'user'
     AND item->>'name' IS NOT NULL
     AND item->>'name' != ''
@@ -127,7 +131,8 @@ tool_payloads AS (
          ELSE '[]'::jsonb
     END AS content_json
   FROM bot_visible_history_messages m
-  WHERE m.session_id = $1
+  WHERE m.team_id = public.memoh_current_team_id()
+    AND m.session_id = $1
     AND m.role = 'assistant'
 ),
 tool_used AS (

--- a/internal/db/postgres/sqlc/sessions.sql.go
+++ b/internal/db/postgres/sqlc/sessions.sql.go
@@ -28,7 +28,7 @@ VALUES (
   $10::uuid,
   $11::uuid
 )
-RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at, team_id
 `
 
 type CreateSessionParams struct {
@@ -78,16 +78,19 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (B
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteSessionDiscussCursorsByBot = `-- name: DeleteSessionDiscussCursorsByBot :exec
 DELETE FROM bot_session_discuss_cursors
-WHERE session_id IN (
+WHERE team_id = public.memoh_current_team_id()
+  AND session_id IN (
   SELECT id
   FROM bot_sessions
-  WHERE bot_id = $1
+  WHERE team_id = public.memoh_current_team_id()
+    AND bot_id = $1
 )
 `
 
@@ -98,9 +101,10 @@ func (q *Queries) DeleteSessionDiscussCursorsByBot(ctx context.Context, botID pg
 
 const forkSessionFromAssistantMessage = `-- name: ForkSessionFromAssistantMessage :one
 WITH source_session AS (
-  SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.compaction_epoch, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at
+  SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.compaction_epoch, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at, s.team_id
   FROM bot_sessions s
-  WHERE s.id = $1
+  WHERE s.team_id = public.memoh_current_team_id()
+    AND s.id = $1
     AND s.bot_id = $2
     AND s.type = 'chat'
     AND s.deleted_at IS NULL
@@ -111,7 +115,8 @@ target_turn AS (
     vm.turn_position AS position,
     vm.id AS message_id
   FROM source_session s
-  JOIN bot_visible_history_messages vm ON vm.session_id = s.id
+  JOIN bot_visible_history_messages vm ON vm.team_id = public.memoh_current_team_id()
+    AND vm.session_id = s.id
     AND vm.id = $3
     AND vm.role = 'assistant'
     AND vm.turn_id IS NOT NULL
@@ -143,7 +148,8 @@ copy_messages AS (
     vm.turn_position < tt.position
     OR vm.turn_position = tt.position
   )
-  WHERE vm.session_id = $1
+  WHERE vm.team_id = public.memoh_current_team_id()
+    AND vm.session_id = $1
   ORDER BY vm.turn_position ASC, vm.turn_message_seq ASC, vm.created_at ASC, vm.id ASC
 ),
 copy_turns AS (
@@ -173,7 +179,7 @@ prepared_metadata AS (
 ),
 fork_plan AS (
   SELECT
-    s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.compaction_epoch, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+    s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.compaction_epoch, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at, s.team_id,
     fam.new_message_id AS fork_message_id,
     ntp.value AS next_turn_position_value
   FROM source_session s
@@ -212,7 +218,7 @@ created_session AS (
     $6::uuid
   FROM fork_plan fp
   CROSS JOIN prepared_metadata pm
-  RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+  RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at, team_id
 ),
 inserted_messages AS (
   INSERT INTO bot_history_messages (
@@ -282,9 +288,10 @@ copied_assets AS (
   FROM bot_history_message_assets a
   JOIN copy_messages cm ON cm.old_message_id = a.message_id
   JOIN inserted_messages im ON im.id = cm.new_message_id
+  WHERE a.team_id = public.memoh_current_team_id()
   RETURNING id
 )
-SELECT cs.id, cs.bot_id, cs.route_id, cs.channel_type, cs.type, cs.session_mode, cs.runtime_type, cs.runtime_metadata, cs.title, cs.metadata, cs.next_turn_position, cs.compaction_epoch, cs.parent_session_id, cs.created_by_user_id, cs.created_at, cs.updated_at, cs.deleted_at
+SELECT cs.id, cs.bot_id, cs.route_id, cs.channel_type, cs.type, cs.session_mode, cs.runtime_type, cs.runtime_metadata, cs.title, cs.metadata, cs.next_turn_position, cs.compaction_epoch, cs.parent_session_id, cs.created_by_user_id, cs.created_at, cs.updated_at, cs.deleted_at, cs.team_id
 FROM created_session cs
 CROSS JOIN (SELECT count(*) AS copied_asset_count FROM copied_assets) copied_asset_counts
 `
@@ -316,6 +323,7 @@ type ForkSessionFromAssistantMessageRow struct {
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
 	DeletedAt        pgtype.Timestamptz `json:"deleted_at"`
+	TeamID           pgtype.UUID        `json:"team_id"`
 }
 
 func (q *Queries) ForkSessionFromAssistantMessage(ctx context.Context, arg ForkSessionFromAssistantMessageParams) (ForkSessionFromAssistantMessageRow, error) {
@@ -346,15 +354,18 @@ func (q *Queries) ForkSessionFromAssistantMessage(ctx context.Context, arg ForkS
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getActiveSessionForRoute = `-- name: GetActiveSessionForRoute :one
-SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.compaction_epoch, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at
+SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.compaction_epoch, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at, s.team_id
 FROM bot_sessions s
 JOIN bot_channel_routes r ON r.active_session_id = s.id
-WHERE r.id = $1
+WHERE s.team_id = public.memoh_current_team_id()
+  AND r.team_id = public.memoh_current_team_id()
+  AND r.id = $1
   AND s.deleted_at IS NULL
 `
 
@@ -379,14 +390,16 @@ func (q *Queries) GetActiveSessionForRoute(ctx context.Context, routeID pgtype.U
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getSessionByID = `-- name: GetSessionByID :one
-SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at, team_id
 FROM bot_sessions
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $1
   AND deleted_at IS NULL
 `
 
@@ -411,14 +424,16 @@ func (q *Queries) GetSessionByID(ctx context.Context, id pgtype.UUID) (BotSessio
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getSessionDiscussCursor = `-- name: GetSessionDiscussCursor :one
-SELECT session_id, scope_key, route_id, source, consumed_cursor, updated_at
+SELECT session_id, scope_key, route_id, source, consumed_cursor, updated_at, team_id
 FROM bot_session_discuss_cursors
-WHERE session_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND session_id = $1
   AND scope_key = $2
 `
 
@@ -437,15 +452,18 @@ func (q *Queries) GetSessionDiscussCursor(ctx context.Context, arg GetSessionDis
 		&i.Source,
 		&i.ConsumedCursor,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listSessionDiscussCursorsByBot = `-- name: ListSessionDiscussCursorsByBot :many
-SELECT c.session_id, c.scope_key, c.route_id, c.source, c.consumed_cursor, c.updated_at
+SELECT c.session_id, c.scope_key, c.route_id, c.source, c.consumed_cursor, c.updated_at, c.team_id
 FROM bot_session_discuss_cursors c
 JOIN bot_sessions s ON s.id = c.session_id
-WHERE s.bot_id = $1
+WHERE c.team_id = public.memoh_current_team_id()
+  AND s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = $1
 ORDER BY c.updated_at ASC, c.session_id ASC, c.scope_key ASC
 `
 
@@ -465,6 +483,7 @@ func (q *Queries) ListSessionDiscussCursorsByBot(ctx context.Context, botID pgty
 			&i.Source,
 			&i.ConsumedCursor,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -483,8 +502,9 @@ SELECT
   r.metadata AS route_metadata,
   r.conversation_type AS route_conversation_type
 FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = $1
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = $1
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC
 `
@@ -554,8 +574,9 @@ SELECT
   r.metadata AS route_metadata,
   r.conversation_type AS route_conversation_type
 FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = $1
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = $1
   AND s.created_by_user_id = $2
   AND s.deleted_at IS NULL
 ORDER BY s.updated_at DESC
@@ -631,8 +652,9 @@ SELECT
   r.metadata AS route_metadata,
   r.conversation_type AS route_conversation_type
 FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = $1
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = $1
   AND s.created_by_user_id = $2
   AND s.deleted_at IS NULL
   AND s.type = ANY($3::text[])
@@ -735,8 +757,9 @@ SELECT
   r.metadata AS route_metadata,
   r.conversation_type AS route_conversation_type
 FROM bot_sessions s
-LEFT JOIN bot_channel_routes r ON r.id = s.route_id
-WHERE s.bot_id = $1
+LEFT JOIN bot_channel_routes r ON r.id = s.route_id AND r.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id()
+  AND s.bot_id = $1
   AND s.deleted_at IS NULL
   AND s.type = ANY($2::text[])
   AND (
@@ -833,9 +856,10 @@ func (q *Queries) ListSessionsByBotPaged(ctx context.Context, arg ListSessionsBy
 }
 
 const listSessionsByRoute = `-- name: ListSessionsByRoute :many
-SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at, team_id
 FROM bot_sessions
-WHERE route_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND route_id = $1
   AND deleted_at IS NULL
 ORDER BY updated_at DESC
 `
@@ -867,6 +891,7 @@ func (q *Queries) ListSessionsByRoute(ctx context.Context, routeID pgtype.UUID) 
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -879,9 +904,10 @@ func (q *Queries) ListSessionsByRoute(ctx context.Context, routeID pgtype.UUID) 
 }
 
 const listSubagentSessionsByParent = `-- name: ListSubagentSessionsByParent :many
-SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at, team_id
 FROM bot_sessions
-WHERE parent_session_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND parent_session_id = $1
   AND deleted_at IS NULL
 ORDER BY created_at DESC
 `
@@ -913,6 +939,7 @@ func (q *Queries) ListSubagentSessionsByParent(ctx context.Context, parentSessio
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -927,7 +954,7 @@ func (q *Queries) ListSubagentSessionsByParent(ctx context.Context, parentSessio
 const setSessionNextTurnPosition = `-- name: SetSessionNextTurnPosition :exec
 UPDATE bot_sessions
 SET next_turn_position = $1::bigint
-WHERE id = $2
+WHERE team_id = public.memoh_current_team_id() AND id = $2
 `
 
 type SetSessionNextTurnPositionParams struct {
@@ -943,7 +970,7 @@ func (q *Queries) SetSessionNextTurnPosition(ctx context.Context, arg SetSession
 const softDeleteSession = `-- name: SoftDeleteSession :exec
 UPDATE bot_sessions
 SET deleted_at = now(), updated_at = now()
-WHERE id = $1 AND deleted_at IS NULL
+WHERE team_id = public.memoh_current_team_id() AND id = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) SoftDeleteSession(ctx context.Context, id pgtype.UUID) error {
@@ -954,7 +981,7 @@ func (q *Queries) SoftDeleteSession(ctx context.Context, id pgtype.UUID) error {
 const softDeleteSessionsByBot = `-- name: SoftDeleteSessionsByBot :exec
 UPDATE bot_sessions
 SET deleted_at = now(), updated_at = now()
-WHERE bot_id = $1 AND deleted_at IS NULL
+WHERE team_id = public.memoh_current_team_id() AND bot_id = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) SoftDeleteSessionsByBot(ctx context.Context, botID pgtype.UUID) error {
@@ -965,7 +992,7 @@ func (q *Queries) SoftDeleteSessionsByBot(ctx context.Context, botID pgtype.UUID
 const touchSession = `-- name: TouchSession :exec
 UPDATE bot_sessions
 SET updated_at = now()
-WHERE id = $1 AND deleted_at IS NULL
+WHERE team_id = public.memoh_current_team_id() AND id = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) TouchSession(ctx context.Context, id pgtype.UUID) error {
@@ -976,8 +1003,8 @@ func (q *Queries) TouchSession(ctx context.Context, id pgtype.UUID) error {
 const updateSessionMetadata = `-- name: UpdateSessionMetadata :one
 UPDATE bot_sessions
 SET metadata = $1, updated_at = now()
-WHERE id = $2 AND deleted_at IS NULL
-RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+WHERE team_id = public.memoh_current_team_id() AND id = $2 AND deleted_at IS NULL
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at, team_id
 `
 
 type UpdateSessionMetadataParams struct {
@@ -1006,6 +1033,7 @@ func (q *Queries) UpdateSessionMetadata(ctx context.Context, arg UpdateSessionMe
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -1013,8 +1041,8 @@ func (q *Queries) UpdateSessionMetadata(ctx context.Context, arg UpdateSessionMe
 const updateSessionTitle = `-- name: UpdateSessionTitle :one
 UPDATE bot_sessions
 SET title = $1, updated_at = now()
-WHERE id = $2 AND deleted_at IS NULL
-RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+WHERE team_id = public.memoh_current_team_id() AND id = $2 AND deleted_at IS NULL
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at, team_id
 `
 
 type UpdateSessionTitleParams struct {
@@ -1043,6 +1071,7 @@ func (q *Queries) UpdateSessionTitle(ctx context.Context, arg UpdateSessionTitle
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -1055,8 +1084,8 @@ SET type = $1,
     runtime_metadata = $4,
     metadata = $5,
     updated_at = now()
-WHERE id = $6 AND deleted_at IS NULL
-RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+WHERE team_id = public.memoh_current_team_id() AND id = $6 AND deleted_at IS NULL
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, compaction_epoch, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at, team_id
 `
 
 type UpdateSessionTypeAndMetadataParams struct {
@@ -1096,6 +1125,7 @@ func (q *Queries) UpdateSessionTypeAndMetadata(ctx context.Context, arg UpdateSe
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -1111,12 +1141,12 @@ VALUES (
   $4,
   $5
 )
-ON CONFLICT (session_id, scope_key) DO UPDATE
+ON CONFLICT (team_id, session_id, scope_key) DO UPDATE
 SET route_id = COALESCE(EXCLUDED.route_id, bot_session_discuss_cursors.route_id),
     source = EXCLUDED.source,
     consumed_cursor = GREATEST(bot_session_discuss_cursors.consumed_cursor, EXCLUDED.consumed_cursor),
     updated_at = now()
-RETURNING session_id, scope_key, route_id, source, consumed_cursor, updated_at
+RETURNING session_id, scope_key, route_id, source, consumed_cursor, updated_at, team_id
 `
 
 type UpsertSessionDiscussCursorParams struct {
@@ -1143,6 +1173,7 @@ func (q *Queries) UpsertSessionDiscussCursor(ctx context.Context, arg UpsertSess
 		&i.Source,
 		&i.ConsumedCursor,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/settings.sql.go
+++ b/internal/db/postgres/sqlc/settings.sql.go
@@ -46,7 +46,7 @@ SET language = 'auto',
     overlay_enabled = false,
     overlay_config = '{}'::jsonb,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) DeleteSettingsByBotID(ctx context.Context, id pgtype.UUID) error {
@@ -91,18 +91,18 @@ SELECT
   bots.overlay_config,
   bots.command_ui_language
 FROM bots
-LEFT JOIN models AS chat_models ON chat_models.id = bots.chat_model_id
-LEFT JOIN models AS heartbeat_models ON heartbeat_models.id = bots.heartbeat_model_id
-LEFT JOIN models AS compaction_models ON compaction_models.id = bots.compaction_model_id
-LEFT JOIN models AS title_models ON title_models.id = bots.title_model_id
-LEFT JOIN models AS image_models ON image_models.id = bots.image_model_id
-LEFT JOIN search_providers ON search_providers.id = bots.search_provider_id
-LEFT JOIN fetch_providers ON fetch_providers.id = bots.fetch_provider_id
-LEFT JOIN memory_providers ON memory_providers.id = bots.memory_provider_id
-LEFT JOIN models AS tts_models ON tts_models.id = bots.tts_model_id
-LEFT JOIN models AS transcription_models ON transcription_models.id = bots.transcription_model_id
-LEFT JOIN models AS video_models ON video_models.id = bots.video_model_id
-WHERE bots.id = $1
+LEFT JOIN models AS chat_models ON chat_models.id = bots.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS heartbeat_models ON heartbeat_models.id = bots.heartbeat_model_id AND heartbeat_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS compaction_models ON compaction_models.id = bots.compaction_model_id AND compaction_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS title_models ON title_models.id = bots.title_model_id AND title_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS image_models ON image_models.id = bots.image_model_id AND image_models.team_id = public.memoh_current_team_id()
+LEFT JOIN search_providers ON search_providers.id = bots.search_provider_id AND search_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN fetch_providers ON fetch_providers.id = bots.fetch_provider_id AND fetch_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN memory_providers ON memory_providers.id = bots.memory_provider_id AND memory_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS tts_models ON tts_models.id = bots.tts_model_id AND tts_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS transcription_models ON transcription_models.id = bots.transcription_model_id AND transcription_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS video_models ON video_models.id = bots.video_model_id AND video_models.team_id = public.memoh_current_team_id()
+WHERE bots.team_id = public.memoh_current_team_id() AND bots.id = $1
 `
 
 type GetSettingsByBotIDRow struct {
@@ -224,7 +224,7 @@ WITH updated AS (
       overlay_config = $33,
       command_ui_language = $34,
       updated_at = now()
-  WHERE bots.id = $35
+  WHERE bots.team_id = public.memoh_current_team_id() AND bots.id = $35
   RETURNING bots.id, bots.language, bots.reasoning_enabled, bots.reasoning_effort, bots.heartbeat_enabled, bots.heartbeat_interval, bots.heartbeat_prompt, bots.compaction_enabled, bots.compaction_threshold, bots.compaction_ratio, bots.timezone, bots.chat_model_id, bots.chat_runtime, bots.chat_acp_agent_id, bots.chat_acp_project_path, bots.chat_acp_project_mode, bots.heartbeat_model_id, bots.compaction_model_id, bots.title_model_id, bots.image_model_id, bots.search_provider_id, bots.fetch_provider_id, bots.memory_provider_id, bots.tts_model_id, bots.transcription_model_id, bots.video_model_id, bots.persist_full_tool_results, bots.show_tool_calls_in_im, bots.tool_approval_config, bots.display_enabled, bots.overlay_provider, bots.overlay_enabled, bots.overlay_config, bots.command_ui_language
 )
 SELECT
@@ -263,17 +263,17 @@ SELECT
   updated.overlay_config,
   updated.command_ui_language
 FROM updated
-LEFT JOIN models AS chat_models ON chat_models.id = updated.chat_model_id
-LEFT JOIN models AS heartbeat_models ON heartbeat_models.id = updated.heartbeat_model_id
-LEFT JOIN models AS compaction_models ON compaction_models.id = updated.compaction_model_id
-LEFT JOIN models AS title_models ON title_models.id = updated.title_model_id
-LEFT JOIN models AS image_models ON image_models.id = updated.image_model_id
-LEFT JOIN search_providers ON search_providers.id = updated.search_provider_id
-LEFT JOIN fetch_providers ON fetch_providers.id = updated.fetch_provider_id
-LEFT JOIN memory_providers ON memory_providers.id = updated.memory_provider_id
-LEFT JOIN models AS tts_models ON tts_models.id = updated.tts_model_id
-LEFT JOIN models AS transcription_models ON transcription_models.id = updated.transcription_model_id
-LEFT JOIN models AS video_models ON video_models.id = updated.video_model_id
+LEFT JOIN models AS chat_models ON chat_models.id = updated.chat_model_id AND chat_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS heartbeat_models ON heartbeat_models.id = updated.heartbeat_model_id AND heartbeat_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS compaction_models ON compaction_models.id = updated.compaction_model_id AND compaction_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS title_models ON title_models.id = updated.title_model_id AND title_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS image_models ON image_models.id = updated.image_model_id AND image_models.team_id = public.memoh_current_team_id()
+LEFT JOIN search_providers ON search_providers.id = updated.search_provider_id AND search_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN fetch_providers ON fetch_providers.id = updated.fetch_provider_id AND fetch_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN memory_providers ON memory_providers.id = updated.memory_provider_id AND memory_providers.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS tts_models ON tts_models.id = updated.tts_model_id AND tts_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS transcription_models ON transcription_models.id = updated.transcription_model_id AND transcription_models.team_id = public.memoh_current_team_id()
+LEFT JOIN models AS video_models ON video_models.id = updated.video_model_id AND video_models.team_id = public.memoh_current_team_id()
 `
 
 type UpsertBotSettingsParams struct {

--- a/internal/db/postgres/sqlc/snapshots.sql.go
+++ b/internal/db/postgres/sqlc/snapshots.sql.go
@@ -20,9 +20,10 @@ SELECT
   parent_runtime_snapshot_name,
   snapshotter,
   source,
-  created_at
+  created_at,
+  team_id
 FROM snapshots
-WHERE container_id = $1
+WHERE team_id = public.memoh_current_team_id() AND container_id = $1
   AND runtime_snapshot_name = $2
 LIMIT 1
 `
@@ -44,6 +45,7 @@ func (q *Queries) GetSnapshotByContainerAndRuntimeName(ctx context.Context, arg 
 		&i.Snapshotter,
 		&i.Source,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -57,9 +59,10 @@ SELECT
   parent_runtime_snapshot_name,
   snapshotter,
   source,
-  created_at
+  created_at,
+  team_id
 FROM snapshots
-WHERE container_id = $1
+WHERE team_id = public.memoh_current_team_id() AND container_id = $1
 ORDER BY created_at DESC
 `
 
@@ -81,6 +84,7 @@ func (q *Queries) ListSnapshotsByContainerID(ctx context.Context, containerID st
 			&i.Snapshotter,
 			&i.Source,
 			&i.CreatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -104,8 +108,8 @@ SELECT
   s.created_at,
   cv.version
 FROM snapshots s
-LEFT JOIN container_versions cv ON cv.snapshot_id = s.id
-WHERE s.container_id = $1
+LEFT JOIN container_versions cv ON cv.snapshot_id = s.id AND cv.team_id = public.memoh_current_team_id()
+WHERE s.team_id = public.memoh_current_team_id() AND s.container_id = $1
 ORDER BY s.created_at DESC
 `
 
@@ -168,13 +172,13 @@ VALUES (
   $5,
   $6
 )
-ON CONFLICT (container_id, runtime_snapshot_name) DO UPDATE
+ON CONFLICT (team_id, container_id, runtime_snapshot_name) DO UPDATE
 SET
   display_name = EXCLUDED.display_name,
   parent_runtime_snapshot_name = EXCLUDED.parent_runtime_snapshot_name,
   snapshotter = EXCLUDED.snapshotter,
   source = EXCLUDED.source
-RETURNING id, container_id, runtime_snapshot_name, display_name, parent_runtime_snapshot_name, snapshotter, source, created_at
+RETURNING id, container_id, runtime_snapshot_name, display_name, parent_runtime_snapshot_name, snapshotter, source, created_at, team_id
 `
 
 type UpsertSnapshotParams struct {
@@ -205,6 +209,7 @@ func (q *Queries) UpsertSnapshot(ctx context.Context, arg UpsertSnapshotParams) 
 		&i.Snapshotter,
 		&i.Source,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/token_usage.sql.go
+++ b/internal/db/postgres/sqlc/token_usage.sql.go
@@ -14,9 +14,9 @@ import (
 const countTokenUsageRecords = `-- name: CountTokenUsageRecords :one
 SELECT COUNT(*)::bigint AS total
 FROM bot_history_messages m
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-WHERE m.bot_id = $1
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id AND ps.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = $1
   AND m.usage IS NOT NULL
   AND m.created_at >= $2
   AND m.created_at < $3
@@ -100,9 +100,9 @@ SELECT
   COALESCE(SUM((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint), 0)::bigint AS cache_read_tokens,
   COALESCE(SUM((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint), 0)::bigint AS reasoning_tokens
 FROM bot_history_messages m
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-WHERE m.bot_id = $1
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id AND ps.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = $1
   AND m.usage IS NOT NULL
   AND m.created_at >= $2
   AND m.created_at < $3
@@ -198,11 +198,11 @@ SELECT
   COALESCE(SUM((m.usage->>'inputTokens')::bigint), 0)::bigint AS input_tokens,
   COALESCE(SUM((m.usage->>'outputTokens')::bigint), 0)::bigint AS output_tokens
 FROM bot_history_messages m
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-LEFT JOIN models mo ON mo.id = m.model_id
-LEFT JOIN providers lp ON lp.id = mo.provider_id
-WHERE m.bot_id = $1
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id AND ps.team_id = public.memoh_current_team_id()
+LEFT JOIN models mo ON mo.id = m.model_id AND mo.team_id = public.memoh_current_team_id()
+LEFT JOIN providers lp ON lp.id = mo.provider_id AND lp.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = $1
   AND m.usage IS NOT NULL
   AND m.created_at >= $2
   AND m.created_at < $3
@@ -320,11 +320,11 @@ SELECT
   COALESCE((m.usage->'inputTokenDetails'->>'cacheReadTokens')::bigint, 0)::bigint AS cache_read_tokens,
   COALESCE((m.usage->'outputTokenDetails'->>'reasoningTokens')::bigint, 0)::bigint AS reasoning_tokens
 FROM bot_history_messages m
-LEFT JOIN bot_sessions s ON s.id = m.session_id
-LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id
-LEFT JOIN models mo ON mo.id = m.model_id
-LEFT JOIN providers lp ON lp.id = mo.provider_id
-WHERE m.bot_id = $1
+LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
+LEFT JOIN bot_sessions ps ON ps.id = s.parent_session_id AND ps.team_id = public.memoh_current_team_id()
+LEFT JOIN models mo ON mo.id = m.model_id AND mo.team_id = public.memoh_current_team_id()
+LEFT JOIN providers lp ON lp.id = mo.provider_id AND lp.team_id = public.memoh_current_team_id()
+WHERE m.team_id = public.memoh_current_team_id() AND m.bot_id = $1
   AND m.usage IS NOT NULL
   AND m.created_at >= $2
   AND m.created_at < $3

--- a/internal/db/postgres/sqlc/tool_approval.sql.go
+++ b/internal/db/postgres/sqlc/tool_approval.sql.go
@@ -17,9 +17,10 @@ SET status = 'approved',
     decision_reason = $1,
     decided_by_channel_identity_id = $2,
     decided_at = now()
-WHERE id = $3
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $3
   AND status = 'pending'
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 `
 
 type ApproveToolApprovalRequestParams struct {
@@ -55,6 +56,7 @@ func (q *Queries) ApproveToolApprovalRequest(ctx context.Context, arg ApproveToo
 		&i.ConversationType,
 		&i.CreatedAt,
 		&i.DecidedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -64,10 +66,11 @@ UPDATE tool_approval_requests
 SET status = 'cancelled',
     decision_reason = $1,
     decided_at = now()
-WHERE bot_id = $2
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $2
   AND session_id = $3
   AND status = 'pending'
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 `
 
 type CancelPendingToolApprovalsBySessionParams struct {
@@ -109,6 +112,7 @@ func (q *Queries) CancelPendingToolApprovalsBySession(ctx context.Context, arg C
 			&i.ConversationType,
 			&i.CreatedAt,
 			&i.DecidedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -150,7 +154,8 @@ INSERT INTO tool_approval_requests (
   (
     SELECT COALESCE(MAX(short_id), 0) + 1
     FROM tool_approval_requests
-    WHERE session_id = $2
+    WHERE team_id = public.memoh_current_team_id()
+      AND session_id = $2
   ),
   $10,
   $11,
@@ -158,7 +163,7 @@ INSERT INTO tool_approval_requests (
   $13,
   $14
 )
-ON CONFLICT (session_id, tool_call_id) DO UPDATE
+ON CONFLICT (team_id, session_id, tool_call_id) DO UPDATE
 SET tool_input = CASE
   WHEN tool_approval_requests.status = 'pending' THEN EXCLUDED.tool_input
   ELSE tool_approval_requests.tool_input
@@ -167,7 +172,7 @@ workspace_target_id = CASE
   WHEN tool_approval_requests.status = 'pending' THEN EXCLUDED.workspace_target_id
   ELSE tool_approval_requests.workspace_target_id
 END
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 `
 
 type CreateToolApprovalRequestParams struct {
@@ -229,14 +234,16 @@ func (q *Queries) CreateToolApprovalRequest(ctx context.Context, arg CreateToolA
 		&i.ConversationType,
 		&i.CreatedAt,
 		&i.DecidedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getLatestPendingToolApprovalBySession = `-- name: GetLatestPendingToolApprovalBySession :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND status = 'pending'
 ORDER BY created_at DESC, short_id DESC
@@ -275,14 +282,16 @@ func (q *Queries) GetLatestPendingToolApprovalBySession(ctx context.Context, arg
 		&i.ConversationType,
 		&i.CreatedAt,
 		&i.DecidedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getPendingToolApprovalByReplyMessage = `-- name: GetPendingToolApprovalByReplyMessage :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND prompt_external_message_id = $3
   AND status = 'pending'
@@ -323,14 +332,16 @@ func (q *Queries) GetPendingToolApprovalByReplyMessage(ctx context.Context, arg 
 		&i.ConversationType,
 		&i.CreatedAt,
 		&i.DecidedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getPendingToolApprovalBySessionShortID = `-- name: GetPendingToolApprovalBySessionShortID :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND short_id = $3
   AND status = 'pending'
@@ -369,14 +380,15 @@ func (q *Queries) GetPendingToolApprovalBySessionShortID(ctx context.Context, ar
 		&i.ConversationType,
 		&i.CreatedAt,
 		&i.DecidedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getToolApprovalRequest = `-- name: GetToolApprovalRequest :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 FROM tool_approval_requests
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetToolApprovalRequest(ctx context.Context, id pgtype.UUID) (ToolApprovalRequest, error) {
@@ -406,14 +418,16 @@ func (q *Queries) GetToolApprovalRequest(ctx context.Context, id pgtype.UUID) (T
 		&i.ConversationType,
 		&i.CreatedAt,
 		&i.DecidedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listPendingToolApprovalsBySession = `-- name: ListPendingToolApprovalsBySession :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND status = 'pending'
 ORDER BY created_at ASC, short_id ASC
@@ -457,6 +471,7 @@ func (q *Queries) ListPendingToolApprovalsBySession(ctx context.Context, arg Lis
 			&i.ConversationType,
 			&i.CreatedAt,
 			&i.DecidedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -469,9 +484,10 @@ func (q *Queries) ListPendingToolApprovalsBySession(ctx context.Context, arg Lis
 }
 
 const listToolApprovalsBySession = `-- name: ListToolApprovalsBySession :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
 ORDER BY created_at ASC, short_id ASC
 `
@@ -514,6 +530,7 @@ func (q *Queries) ListToolApprovalsBySession(ctx context.Context, arg ListToolAp
 			&i.ConversationType,
 			&i.CreatedAt,
 			&i.DecidedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -526,9 +543,10 @@ func (q *Queries) ListToolApprovalsBySession(ctx context.Context, arg ListToolAp
 }
 
 const listToolApprovalsBySessionToolCalls = `-- name: ListToolApprovalsBySessionToolCalls :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 FROM tool_approval_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND tool_call_id = ANY($3::text[])
 ORDER BY created_at ASC, short_id ASC
@@ -573,6 +591,7 @@ func (q *Queries) ListToolApprovalsBySessionToolCalls(ctx context.Context, arg L
 			&i.ConversationType,
 			&i.CreatedAt,
 			&i.DecidedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -590,9 +609,10 @@ SET status = 'rejected',
     decision_reason = $1,
     decided_by_channel_identity_id = $2,
     decided_at = now()
-WHERE id = $3
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $3
   AND status = 'pending'
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 `
 
 type RejectToolApprovalRequestParams struct {
@@ -628,6 +648,7 @@ func (q *Queries) RejectToolApprovalRequest(ctx context.Context, arg RejectToolA
 		&i.ConversationType,
 		&i.CreatedAt,
 		&i.DecidedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -636,8 +657,8 @@ const updateToolApprovalPromptMessage = `-- name: UpdateToolApprovalPromptMessag
 UPDATE tool_approval_requests
 SET prompt_message_id = $1,
     prompt_external_message_id = $2
-WHERE id = $3
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+WHERE team_id = public.memoh_current_team_id() AND id = $3
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at, team_id
 `
 
 type UpdateToolApprovalPromptMessageParams struct {
@@ -673,6 +694,7 @@ func (q *Queries) UpdateToolApprovalPromptMessage(ctx context.Context, arg Updat
 		&i.ConversationType,
 		&i.CreatedAt,
 		&i.DecidedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/user_input.sql.go
+++ b/internal/db/postgres/sqlc/user_input.sql.go
@@ -18,11 +18,12 @@ SET status = 'canceled',
     responded_at = now(),
     canceled_at = now(),
     updated_at = now()
-WHERE bot_id = $2
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $2
   AND session_id = $3
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type CancelPendingUserInputsBySessionParams struct {
@@ -71,6 +72,7 @@ func (q *Queries) CancelPendingUserInputsBySession(ctx context.Context, arg Canc
 			&i.RespondedAt,
 			&i.CanceledAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -90,10 +92,11 @@ SET status = 'canceled',
     responded_at = now(),
     canceled_at = now(),
     updated_at = now()
-WHERE id = $3
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $3
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type CancelUserInputRequestParams struct {
@@ -136,6 +139,7 @@ func (q *Queries) CancelUserInputRequest(ctx context.Context, arg CancelUserInpu
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -144,13 +148,15 @@ const createUserInputRequest = `-- name: CreateUserInputRequest :one
 WITH locked_session AS (
   SELECT id
   FROM bot_sessions
-  WHERE id = $2
+  WHERE team_id = public.memoh_current_team_id()
+    AND id = $2
   FOR UPDATE
 ),
 next_short_id AS (
   SELECT COALESCE(MAX(user_input_requests.short_id), 0) + 1 AS short_id
   FROM locked_session
   LEFT JOIN user_input_requests ON user_input_requests.session_id = locked_session.id
+    AND user_input_requests.team_id = public.memoh_current_team_id()
 )
 INSERT INTO user_input_requests (
   bot_id,
@@ -188,7 +194,7 @@ INSERT INTO user_input_requests (
   $15
 FROM locked_session
 CROSS JOIN next_short_id
-ON CONFLICT (session_id, tool_call_id) DO UPDATE
+ON CONFLICT (team_id, session_id, tool_call_id) DO UPDATE
 SET input_json = EXCLUDED.input_json,
     ui_payload_json = EXCLUDED.ui_payload_json,
     provider_metadata = EXCLUDED.provider_metadata,
@@ -201,7 +207,7 @@ SET input_json = EXCLUDED.input_json,
     updated_at = now()
 WHERE user_input_requests.status = 'pending'
   AND (user_input_requests.expires_at IS NULL OR user_input_requests.expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type CreateUserInputRequestParams struct {
@@ -272,6 +278,7 @@ func (q *Queries) CreateUserInputRequest(ctx context.Context, arg CreateUserInpu
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -281,10 +288,11 @@ UPDATE user_input_requests
 SET status = 'failed',
     result_json = $1,
     updated_at = now()
-WHERE id = $2
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $2
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type FailUserInputRequestParams struct {
@@ -326,14 +334,16 @@ func (q *Queries) FailUserInputRequest(ctx context.Context, arg FailUserInputReq
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getLatestPendingUserInputBySession = `-- name: GetLatestPendingUserInputBySession :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
@@ -380,14 +390,16 @@ func (q *Queries) GetLatestPendingUserInputBySession(ctx context.Context, arg Ge
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getPendingUserInputByReplyMessage = `-- name: GetPendingUserInputByReplyMessage :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND prompt_external_message_id = $3
   AND status = 'pending'
@@ -436,14 +448,16 @@ func (q *Queries) GetPendingUserInputByReplyMessage(ctx context.Context, arg Get
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getPendingUserInputBySessionShortID = `-- name: GetPendingUserInputBySessionShortID :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND short_id = $3
   AND status = 'pending'
@@ -490,14 +504,15 @@ func (q *Queries) GetPendingUserInputBySessionShortID(ctx context.Context, arg G
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getUserInputRequest = `-- name: GetUserInputRequest :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 FROM user_input_requests
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetUserInputRequest(ctx context.Context, id pgtype.UUID) (UserInputRequest, error) {
@@ -534,14 +549,16 @@ func (q *Queries) GetUserInputRequest(ctx context.Context, id pgtype.UUID) (User
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getUserInputRequestBySessionToolCall = `-- name: GetUserInputRequestBySessionToolCall :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 FROM user_input_requests
-WHERE session_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND session_id = $1
   AND tool_call_id = $2
 `
 
@@ -584,14 +601,16 @@ func (q *Queries) GetUserInputRequestBySessionToolCall(ctx context.Context, arg 
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listPendingUserInputsBySession = `-- name: ListPendingUserInputsBySession :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
@@ -643,6 +662,7 @@ func (q *Queries) ListPendingUserInputsBySession(ctx context.Context, arg ListPe
 			&i.RespondedAt,
 			&i.CanceledAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -655,9 +675,10 @@ func (q *Queries) ListPendingUserInputsBySession(ctx context.Context, arg ListPe
 }
 
 const listUserInputsBySession = `-- name: ListUserInputsBySession :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
 ORDER BY created_at ASC, short_id ASC
 `
@@ -707,6 +728,7 @@ func (q *Queries) ListUserInputsBySession(ctx context.Context, arg ListUserInput
 			&i.RespondedAt,
 			&i.CanceledAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -719,9 +741,10 @@ func (q *Queries) ListUserInputsBySession(ctx context.Context, arg ListUserInput
 }
 
 const listUserInputsBySessionToolCalls = `-- name: ListUserInputsBySessionToolCalls :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 FROM user_input_requests
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND session_id = $2
   AND tool_call_id = ANY($3::text[])
 ORDER BY created_at ASC, short_id ASC
@@ -773,6 +796,7 @@ func (q *Queries) ListUserInputsBySessionToolCalls(ctx context.Context, arg List
 			&i.RespondedAt,
 			&i.CanceledAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -791,10 +815,11 @@ SET status = 'submitted',
     responded_by_channel_identity_id = $2,
     responded_at = now(),
     updated_at = now()
-WHERE id = $3
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $3
   AND status = 'pending'
   AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type SubmitUserInputRequestParams struct {
@@ -837,6 +862,7 @@ func (q *Queries) SubmitUserInputRequest(ctx context.Context, arg SubmitUserInpu
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -845,8 +871,8 @@ const updateUserInputAssistantMessage = `-- name: UpdateUserInputAssistantMessag
 UPDATE user_input_requests
 SET assistant_message_id = $1,
     updated_at = now()
-WHERE id = $2
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $2
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type UpdateUserInputAssistantMessageParams struct {
@@ -888,6 +914,7 @@ func (q *Queries) UpdateUserInputAssistantMessage(ctx context.Context, arg Updat
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -901,7 +928,7 @@ WHERE id = $2
   AND status = 'pending'
   AND interaction_revision = $3
   AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type UpdateUserInputInteractionParams struct {
@@ -944,6 +971,7 @@ func (q *Queries) UpdateUserInputInteraction(ctx context.Context, arg UpdateUser
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -953,8 +981,8 @@ UPDATE user_input_requests
 SET prompt_message_id = $1,
     prompt_external_message_id = $2,
     updated_at = now()
-WHERE id = $3
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $3
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type UpdateUserInputPromptMessageParams struct {
@@ -997,6 +1025,7 @@ func (q *Queries) UpdateUserInputPromptMessage(ctx context.Context, arg UpdateUs
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -1005,8 +1034,8 @@ const updateUserInputToolResultMessage = `-- name: UpdateUserInputToolResultMess
 UPDATE user_input_requests
 SET tool_result_message_id = $1,
     updated_at = now()
-WHERE id = $2
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $2
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, workspace_target_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, interaction_json, interaction_revision, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at, team_id
 `
 
 type UpdateUserInputToolResultMessageParams struct {
@@ -1048,6 +1077,7 @@ func (q *Queries) UpdateUserInputToolResultMessage(ctx context.Context, arg Upda
 		&i.RespondedAt,
 		&i.CanceledAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/user_provider_oauth.sql.go
+++ b/internal/db/postgres/sqlc/user_provider_oauth.sql.go
@@ -13,7 +13,7 @@ import (
 
 const deleteUserProviderOAuthToken = `-- name: DeleteUserProviderOAuthToken :exec
 DELETE FROM user_provider_oauth_tokens
-WHERE provider_id = $1
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND user_id = $2
 `
 
@@ -28,8 +28,8 @@ func (q *Queries) DeleteUserProviderOAuthToken(ctx context.Context, arg DeleteUs
 }
 
 const getUserProviderOAuthToken = `-- name: GetUserProviderOAuthToken :one
-SELECT id, provider_id, user_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at FROM user_provider_oauth_tokens
-WHERE provider_id = $1
+SELECT id, provider_id, user_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at, team_id FROM user_provider_oauth_tokens
+WHERE team_id = public.memoh_current_team_id() AND provider_id = $1
   AND user_id = $2
 `
 
@@ -55,13 +55,14 @@ func (q *Queries) GetUserProviderOAuthToken(ctx context.Context, arg GetUserProv
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getUserProviderOAuthTokenByState = `-- name: GetUserProviderOAuthTokenByState :one
-SELECT id, provider_id, user_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at FROM user_provider_oauth_tokens
-WHERE state = $1
+SELECT id, provider_id, user_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at, team_id FROM user_provider_oauth_tokens
+WHERE team_id = public.memoh_current_team_id() AND state = $1
   AND state != ''
 `
 
@@ -82,6 +83,7 @@ func (q *Queries) GetUserProviderOAuthTokenByState(ctx context.Context, state st
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -95,7 +97,7 @@ VALUES (
   $4,
   $5
 )
-ON CONFLICT (provider_id, user_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id, user_id) DO UPDATE SET
   state = EXCLUDED.state,
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
   metadata = EXCLUDED.metadata,
@@ -147,7 +149,7 @@ VALUES (
   $9,
   $10
 )
-ON CONFLICT (provider_id, user_id) DO UPDATE SET
+ON CONFLICT (team_id, provider_id, user_id) DO UPDATE SET
   access_token = EXCLUDED.access_token,
   refresh_token = EXCLUDED.refresh_token,
   expires_at = EXCLUDED.expires_at,
@@ -157,7 +159,7 @@ ON CONFLICT (provider_id, user_id) DO UPDATE SET
   pkce_code_verifier = EXCLUDED.pkce_code_verifier,
   metadata = EXCLUDED.metadata,
   updated_at = now()
-RETURNING id, provider_id, user_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at
+RETURNING id, provider_id, user_id, access_token, refresh_token, expires_at, scope, token_type, state, pkce_code_verifier, metadata, created_at, updated_at, team_id
 `
 
 type UpsertUserProviderOAuthTokenParams struct {
@@ -203,6 +205,7 @@ func (q *Queries) UpsertUserProviderOAuthToken(ctx context.Context, arg UpsertUs
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/user_runtimes.sql.go
+++ b/internal/db/postgres/sqlc/user_runtimes.sql.go
@@ -15,7 +15,8 @@ const clearBotRemoteRuntimePrimary = `-- name: ClearBotRemoteRuntimePrimary :exe
 UPDATE bot_remote_runtime_bindings
 SET is_primary = FALSE,
     updated_at = CASE WHEN is_primary THEN now() ELSE updated_at END
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
 `
 
 func (q *Queries) ClearBotRemoteRuntimePrimary(ctx context.Context, botID pgtype.UUID) error {
@@ -29,13 +30,16 @@ SELECT b.id, r.id, $1
 FROM bots b
 JOIN user_runtimes r
   ON r.id = $2
+ AND r.team_id = public.memoh_current_team_id()
  AND r.user_id = b.owner_user_id
  AND r.revoked_at IS NULL
 JOIN users owner
   ON owner.id = b.owner_user_id
+ AND owner.team_id = public.memoh_current_team_id()
  AND owner.is_active = TRUE
-WHERE b.id = $3
-ON CONFLICT (bot_id, runtime_id) DO UPDATE SET
+WHERE b.team_id = public.memoh_current_team_id()
+  AND b.id = $3
+ON CONFLICT (team_id, bot_id, runtime_id) DO UPDATE SET
   workspace_path = EXCLUDED.workspace_path,
   updated_at = now()
 RETURNING id
@@ -57,7 +61,7 @@ func (q *Queries) CreateOrUpdateBotRemoteRuntimeMount(ctx context.Context, arg C
 const createUserRuntime = `-- name: CreateUserRuntime :one
 INSERT INTO user_runtimes (user_id, name, api_token)
 VALUES ($1, $2, $3)
-RETURNING id, user_id, name, api_token, revoked_at, created_at, updated_at
+RETURNING id, user_id, name, api_token, revoked_at, created_at, updated_at, team_id
 `
 
 type CreateUserRuntimeParams struct {
@@ -77,13 +81,15 @@ func (q *Queries) CreateUserRuntime(ctx context.Context, arg CreateUserRuntimePa
 		&i.RevokedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const deleteBotRemoteRuntimeMount = `-- name: DeleteBotRemoteRuntimeMount :one
 DELETE FROM bot_remote_runtime_bindings
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND id = $2
 RETURNING id
 `
@@ -115,10 +121,11 @@ SELECT
   (runtime.revoked_at IS NOT NULL OR NOT owner.is_active) AS runtime_unavailable,
   bot.owner_user_id AS bot_owner_user_id
 FROM bot_remote_runtime_bindings binding
-JOIN user_runtimes runtime ON runtime.id = binding.runtime_id
-JOIN bots bot ON bot.id = binding.bot_id
-JOIN users owner ON owner.id = bot.owner_user_id
-WHERE binding.bot_id = $1
+JOIN user_runtimes runtime ON runtime.id = binding.runtime_id AND runtime.team_id = public.memoh_current_team_id()
+JOIN bots bot ON bot.id = binding.bot_id AND bot.team_id = public.memoh_current_team_id()
+JOIN users owner ON owner.id = bot.owner_user_id AND owner.team_id = public.memoh_current_team_id()
+WHERE binding.team_id = public.memoh_current_team_id()
+  AND binding.bot_id = $1
   AND binding.id = $2
 `
 
@@ -177,10 +184,11 @@ SELECT
   (runtime.revoked_at IS NOT NULL OR NOT owner.is_active) AS runtime_unavailable,
   bot.owner_user_id AS bot_owner_user_id
 FROM bot_remote_runtime_bindings binding
-JOIN user_runtimes runtime ON runtime.id = binding.runtime_id
-JOIN bots bot ON bot.id = binding.bot_id
-JOIN users owner ON owner.id = bot.owner_user_id
-WHERE binding.bot_id = $1
+JOIN user_runtimes runtime ON runtime.id = binding.runtime_id AND runtime.team_id = public.memoh_current_team_id()
+JOIN bots bot ON bot.id = binding.bot_id AND bot.team_id = public.memoh_current_team_id()
+JOIN users owner ON owner.id = bot.owner_user_id AND owner.team_id = public.memoh_current_team_id()
+WHERE binding.team_id = public.memoh_current_team_id()
+  AND binding.bot_id = $1
   AND binding.is_primary = TRUE
 `
 
@@ -220,12 +228,14 @@ func (q *Queries) GetPrimaryBotRemoteRuntimeMount(ctx context.Context, botID pgt
 }
 
 const getUserRuntimeByAPIToken = `-- name: GetUserRuntimeByAPIToken :one
-SELECT runtime.id, runtime.user_id, runtime.name, runtime.api_token, runtime.revoked_at, runtime.created_at, runtime.updated_at
+SELECT runtime.id, runtime.user_id, runtime.name, runtime.api_token, runtime.revoked_at, runtime.created_at, runtime.updated_at, runtime.team_id
 FROM user_runtimes runtime
 JOIN users owner
   ON owner.id = runtime.user_id
+ AND owner.team_id = public.memoh_current_team_id()
  AND owner.is_active = TRUE
-WHERE runtime.api_token = $1
+WHERE runtime.team_id = public.memoh_current_team_id()
+  AND runtime.api_token = $1
   AND runtime.revoked_at IS NULL
 `
 
@@ -240,6 +250,7 @@ func (q *Queries) GetUserRuntimeByAPIToken(ctx context.Context, apiToken string)
 		&i.RevokedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -259,10 +270,11 @@ SELECT
   (runtime.revoked_at IS NOT NULL OR NOT owner.is_active) AS runtime_unavailable,
   bot.owner_user_id AS bot_owner_user_id
 FROM bot_remote_runtime_bindings binding
-JOIN user_runtimes runtime ON runtime.id = binding.runtime_id
-JOIN bots bot ON bot.id = binding.bot_id
-JOIN users owner ON owner.id = bot.owner_user_id
-WHERE binding.bot_id = $1
+JOIN user_runtimes runtime ON runtime.id = binding.runtime_id AND runtime.team_id = public.memoh_current_team_id()
+JOIN bots bot ON bot.id = binding.bot_id AND bot.team_id = public.memoh_current_team_id()
+JOIN users owner ON owner.id = bot.owner_user_id AND owner.team_id = public.memoh_current_team_id()
+WHERE binding.team_id = public.memoh_current_team_id()
+  AND binding.bot_id = $1
 ORDER BY binding.created_at ASC, binding.id ASC
 `
 
@@ -315,8 +327,9 @@ func (q *Queries) ListBotRemoteRuntimeMounts(ctx context.Context, botID pgtype.U
 }
 
 const listUserRuntimes = `-- name: ListUserRuntimes :many
-SELECT id, user_id, name, api_token, revoked_at, created_at, updated_at FROM user_runtimes
-WHERE user_id = $1 AND revoked_at IS NULL
+SELECT id, user_id, name, api_token, revoked_at, created_at, updated_at, team_id FROM user_runtimes
+WHERE team_id = public.memoh_current_team_id()
+  AND user_id = $1 AND revoked_at IS NULL
 ORDER BY created_at ASC, id ASC
 `
 
@@ -337,6 +350,7 @@ func (q *Queries) ListUserRuntimes(ctx context.Context, userID pgtype.UUID) ([]U
 			&i.RevokedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -351,8 +365,9 @@ func (q *Queries) ListUserRuntimes(ctx context.Context, userID pgtype.UUID) ([]U
 const revokeUserRuntime = `-- name: RevokeUserRuntime :one
 UPDATE user_runtimes
 SET revoked_at = now(), updated_at = now()
-WHERE id = $1 AND user_id = $2 AND revoked_at IS NULL
-RETURNING id, user_id, name, api_token, revoked_at, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $1 AND user_id = $2 AND revoked_at IS NULL
+RETURNING id, user_id, name, api_token, revoked_at, created_at, updated_at, team_id
 `
 
 type RevokeUserRuntimeParams struct {
@@ -371,6 +386,7 @@ func (q *Queries) RevokeUserRuntime(ctx context.Context, arg RevokeUserRuntimePa
 		&i.RevokedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -379,7 +395,8 @@ const setBotRemoteRuntimePrimary = `-- name: SetBotRemoteRuntimePrimary :execrow
 UPDATE bot_remote_runtime_bindings
 SET is_primary = TRUE,
     updated_at = CASE WHEN is_primary THEN updated_at ELSE now() END
-WHERE bot_id = $1
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $1
   AND id = $2
 `
 
@@ -400,7 +417,8 @@ const updateBotRemoteRuntimeMountToolApproval = `-- name: UpdateBotRemoteRuntime
 UPDATE bot_remote_runtime_bindings
 SET tool_approval_config = $1,
     updated_at = now()
-WHERE bot_id = $2
+WHERE team_id = public.memoh_current_team_id()
+  AND bot_id = $2
   AND id = $3
 RETURNING id
 `

--- a/internal/db/postgres/sqlc/users.sql.go
+++ b/internal/db/postgres/sqlc/users.sql.go
@@ -14,7 +14,8 @@ import (
 const countAccounts = `-- name: CountAccounts :one
 SELECT COUNT(*)::bigint AS count
 FROM users
-WHERE username IS NOT NULL
+WHERE team_id = public.memoh_current_team_id()
+  AND username IS NOT NULL
   AND password_hash IS NOT NULL
 `
 
@@ -36,8 +37,8 @@ SET username = $1,
     is_active = $7,
     data_root = $8,
     updated_at = now()
-WHERE id = $9
-RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $9
+RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 `
 
 type CreateAccountParams struct {
@@ -80,6 +81,7 @@ func (q *Queries) CreateAccount(ctx context.Context, arg CreateAccountParams) (U
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -87,7 +89,7 @@ func (q *Queries) CreateAccount(ctx context.Context, arg CreateAccountParams) (U
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (is_active, metadata)
 VALUES ($1, $2)
-RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 `
 
 type CreateUserParams struct {
@@ -113,12 +115,13 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getAccountByIdentity = `-- name: GetAccountByIdentity :one
-SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at FROM users WHERE username = $1 OR email = $1
+SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id FROM users WHERE team_id = public.memoh_current_team_id() AND (username = $1 OR email = $1)
 `
 
 func (q *Queries) GetAccountByIdentity(ctx context.Context, identity pgtype.Text) (User, error) {
@@ -139,12 +142,13 @@ func (q *Queries) GetAccountByIdentity(ctx context.Context, identity pgtype.Text
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getAccountByUserID = `-- name: GetAccountByUserID :one
-SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at FROM users WHERE id = $1
+SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id FROM users WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetAccountByUserID(ctx context.Context, userID pgtype.UUID) (User, error) {
@@ -165,14 +169,15 @@ func (q *Queries) GetAccountByUserID(ctx context.Context, userID pgtype.UUID) (U
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 FROM users
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 `
 
 func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (User, error) {
@@ -193,13 +198,14 @@ func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (User, error)
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
 
 const listAccounts = `-- name: ListAccounts :many
-SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at FROM users
-WHERE username IS NOT NULL
+SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id FROM users
+WHERE team_id = public.memoh_current_team_id() AND username IS NOT NULL
 ORDER BY created_at DESC
 `
 
@@ -227,6 +233,7 @@ func (q *Queries) ListAccounts(ctx context.Context) ([]User, error) {
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -248,7 +255,7 @@ SET username = NULL,
     data_root = NULL,
     is_active = FALSE,
     updated_at = now()
-WHERE id = $1
+WHERE team_id = public.memoh_current_team_id() AND id = $1
 RETURNING id
 `
 
@@ -260,9 +267,10 @@ func (q *Queries) RemoveMember(ctx context.Context, userID pgtype.UUID) (pgtype.
 }
 
 const searchAccounts = `-- name: SearchAccounts :many
-SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+SELECT id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 FROM users
-WHERE username IS NOT NULL
+WHERE team_id = public.memoh_current_team_id()
+  AND username IS NOT NULL
   AND (
     $1::text = ''
     OR username ILIKE '%' || $1::text || '%'
@@ -302,6 +310,7 @@ func (q *Queries) SearchAccounts(ctx context.Context, arg SearchAccountsParams) 
 			&i.Metadata,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TeamID,
 		); err != nil {
 			return nil, err
 		}
@@ -320,8 +329,8 @@ SET role = $1::user_role,
     avatar_url = $3,
     is_active = $4,
     updated_at = now()
-WHERE id = $5
-RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $5
+RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 `
 
 type UpdateAccountAdminParams struct {
@@ -356,6 +365,7 @@ func (q *Queries) UpdateAccountAdmin(ctx context.Context, arg UpdateAccountAdmin
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -364,8 +374,8 @@ const updateAccountLastLogin = `-- name: UpdateAccountLastLogin :one
 UPDATE users
 SET last_login_at = now(),
     updated_at = now()
-WHERE id = $1
-RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 `
 
 func (q *Queries) UpdateAccountLastLogin(ctx context.Context, id pgtype.UUID) (User, error) {
@@ -386,6 +396,7 @@ func (q *Queries) UpdateAccountLastLogin(ctx context.Context, id pgtype.UUID) (U
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -394,8 +405,8 @@ const updateAccountPassword = `-- name: UpdateAccountPassword :one
 UPDATE users
 SET password_hash = $2,
     updated_at = now()
-WHERE id = $1
-RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 `
 
 type UpdateAccountPasswordParams struct {
@@ -421,6 +432,7 @@ func (q *Queries) UpdateAccountPassword(ctx context.Context, arg UpdateAccountPa
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -433,8 +445,8 @@ SET display_name = $2,
     is_active = $5,
     metadata = $6,
     updated_at = now()
-WHERE id = $1
-RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+WHERE team_id = public.memoh_current_team_id() AND id = $1
+RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 `
 
 type UpdateAccountProfileParams struct {
@@ -471,6 +483,7 @@ func (q *Queries) UpdateAccountProfile(ctx context.Context, arg UpdateAccountPro
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -489,7 +502,7 @@ VALUES (
   $9,
   '{}'::jsonb
 )
-ON CONFLICT (username) DO UPDATE SET
+ON CONFLICT (team_id, username) DO UPDATE SET
   email = EXCLUDED.email,
   password_hash = EXCLUDED.password_hash,
   role = EXCLUDED.role,
@@ -498,7 +511,7 @@ ON CONFLICT (username) DO UPDATE SET
   is_active = EXCLUDED.is_active,
   data_root = EXCLUDED.data_root,
   updated_at = now()
-RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at
+RETURNING id, username, email, password_hash, role, display_name, avatar_url, timezone, data_root, last_login_at, is_active, metadata, created_at, updated_at, team_id
 `
 
 type UpsertAccountByUsernameParams struct {
@@ -541,6 +554,7 @@ func (q *Queries) UpsertAccountByUsername(ctx context.Context, arg UpsertAccount
 		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/postgres/sqlc/versions.sql.go
+++ b/internal/db/postgres/sqlc/versions.sql.go
@@ -15,7 +15,7 @@ const getVersionSnapshotRuntimeName = `-- name: GetVersionSnapshotRuntimeName :o
 SELECT s.runtime_snapshot_name
 FROM container_versions cv
 JOIN snapshots s ON s.id = cv.snapshot_id
-WHERE cv.container_id = $1
+WHERE cv.team_id = public.memoh_current_team_id() AND s.team_id = public.memoh_current_team_id() AND cv.container_id = $1
   AND cv.version = $2
 `
 
@@ -38,7 +38,7 @@ VALUES (
   $2,
   $3
 )
-RETURNING id, container_id, snapshot_id, version, created_at
+RETURNING id, container_id, snapshot_id, version, created_at, team_id
 `
 
 type InsertVersionParams struct {
@@ -56,6 +56,7 @@ func (q *Queries) InsertVersion(ctx context.Context, arg InsertVersionParams) (C
 		&i.SnapshotID,
 		&i.Version,
 		&i.CreatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -71,7 +72,7 @@ SELECT
   s.display_name
 FROM container_versions cv
 JOIN snapshots s ON s.id = cv.snapshot_id
-WHERE cv.container_id = $1
+WHERE cv.team_id = public.memoh_current_team_id() AND s.team_id = public.memoh_current_team_id() AND cv.container_id = $1
 ORDER BY cv.version ASC
 `
 
@@ -114,7 +115,7 @@ func (q *Queries) ListVersionsByContainerID(ctx context.Context, containerID str
 }
 
 const nextVersion = `-- name: NextVersion :one
-SELECT COALESCE(MAX(version), 0) + 1 FROM container_versions WHERE container_id = $1
+SELECT COALESCE(MAX(version), 0) + 1 FROM container_versions WHERE team_id = public.memoh_current_team_id() AND container_id = $1
 `
 
 func (q *Queries) NextVersion(ctx context.Context, containerID string) (int32, error) {

--- a/internal/db/postgres/sqlc/workspace_resource_limits.sql.go
+++ b/internal/db/postgres/sqlc/workspace_resource_limits.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getBotWorkspaceResourceLimits = `-- name: GetBotWorkspaceResourceLimits :one
-SELECT bot_id, cpu_millicores, memory_bytes, storage_bytes, created_at, updated_at FROM bot_workspace_resource_limits WHERE bot_id = $1
+SELECT bot_id, cpu_millicores, memory_bytes, storage_bytes, created_at, updated_at, team_id FROM bot_workspace_resource_limits WHERE team_id = public.memoh_current_team_id() AND bot_id = $1
 `
 
 func (q *Queries) GetBotWorkspaceResourceLimits(ctx context.Context, botID pgtype.UUID) (BotWorkspaceResourceLimit, error) {
@@ -25,6 +25,7 @@ func (q *Queries) GetBotWorkspaceResourceLimits(ctx context.Context, botID pgtyp
 		&i.StorageBytes,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }
@@ -39,12 +40,12 @@ VALUES (
   $3,
   $4
 )
-ON CONFLICT (bot_id) DO UPDATE SET
+ON CONFLICT (team_id, bot_id) DO UPDATE SET
   cpu_millicores = EXCLUDED.cpu_millicores,
   memory_bytes = EXCLUDED.memory_bytes,
   storage_bytes = EXCLUDED.storage_bytes,
   updated_at = now()
-RETURNING bot_id, cpu_millicores, memory_bytes, storage_bytes, created_at, updated_at
+RETURNING bot_id, cpu_millicores, memory_bytes, storage_bytes, created_at, updated_at, team_id
 `
 
 type UpsertBotWorkspaceResourceLimitsParams struct {
@@ -69,6 +70,7 @@ func (q *Queries) UpsertBotWorkspaceResourceLimits(ctx context.Context, arg Upse
 		&i.StorageBytes,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TeamID,
 	)
 	return i, err
 }

--- a/internal/db/team_backfill_integration_test.go
+++ b/internal/db/team_backfill_integration_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTeamIDBackfilledOnFreshInstall(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	// Enumerate applied team tables.
+	rows, err := pool.Query(ctx, `
+		SELECT table_name FROM information_schema.tables
+		WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+		  AND table_name NOT IN ('schema_migrations', 'teams')
+		ORDER BY table_name`)
+	if err != nil {
+		t.Fatalf("enumerate team tables: %v", err)
+	}
+	var tables []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		tables = append(tables, n)
+	}
+	rows.Close()
+	if len(tables) == 0 {
+		t.Fatal("expected a non-empty set of team tables")
+	}
+
+	// Every team table must now have a team_id column, and it must be fully
+	// backfilled (zero NULLs) to DefaultTeamID.
+	for _, tbl := range tables {
+		var hasCol bool
+		if err := pool.QueryRow(ctx, `
+			SELECT EXISTS (SELECT 1 FROM information_schema.columns
+				WHERE table_schema='public' AND table_name=$1 AND column_name='team_id')`, tbl,
+		).Scan(&hasCol); err != nil {
+			t.Fatalf("check team_id on %s: %v", tbl, err)
+		}
+		if !hasCol {
+			t.Fatalf("team table %q is missing a team_id column", tbl)
+		}
+
+		var nulls int
+		if err := pool.QueryRow(ctx,
+			"SELECT count(*) FROM "+quoteIdent(tbl)+" WHERE team_id IS NULL",
+		).Scan(&nulls); err != nil {
+			t.Fatalf("count NULL team_id on %s: %v", tbl, err)
+		}
+		if nulls != 0 {
+			t.Fatalf("team table %q has %d rows with NULL team_id after backfill", tbl, nulls)
+		}
+	}
+
+}
+
+// quoteIdent double-quotes a SQL identifier for safe interpolation of a table
+// name that comes from information_schema (not user input).
+func quoteIdent(id string) string {
+	out := make([]byte, 0, len(id)+2)
+	out = append(out, '"')
+	for i := 0; i < len(id); i++ {
+		if id[i] == '"' {
+			out = append(out, '"')
+		}
+		out = append(out, id[i])
+	}
+	out = append(out, '"')
+	return string(out)
+}

--- a/internal/db/team_composite_keys_integration_test.go
+++ b/internal/db/team_composite_keys_integration_test.go
@@ -1,0 +1,238 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestTeamCompositeKeys verifies the team-key migration:
+//   - existing primary keys stay stable and gain a team-prefixed unique key
+//   - every team table has a root FK (team_id) -> teams(id)
+//   - every business FK is composite and carries team_id
+//   - ON DELETE SET NULL clears only the original reference column
+//   - a cross-team child insert is rejected; same-team self-reference works
+func TestTeamCompositeKeys(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	// (1) Every team table has a helper unique key leading with team_id.
+	rows, err := pool.Query(ctx, `
+		SELECT c.relname, count(helper.oid)
+		  FROM pg_constraint con
+		  JOIN pg_class c ON c.oid = con.conrelid
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		  LEFT JOIN pg_constraint helper
+		    ON helper.conrelid=con.conrelid AND helper.contype='u'
+		   AND helper.conname LIKE 'memoh_team_key_%'
+		 WHERE con.contype = 'p' AND n.nspname = 'public'
+		   AND EXISTS (SELECT 1 FROM pg_attribute a
+		                WHERE a.attrelid=c.oid AND a.attname='team_id' AND NOT a.attisdropped)
+		 GROUP BY c.relname`)
+	if err != nil {
+		t.Fatalf("enumerate PKs: %v", err)
+	}
+	for rows.Next() {
+		var tbl string
+		var helperCount int
+		if err := rows.Scan(&tbl, &helperCount); err != nil {
+			t.Fatalf("scan pk: %v", err)
+		}
+		if helperCount != 1 {
+			t.Errorf("%s must have one team-prefixed helper key, got %d", tbl, helperCount)
+		}
+	}
+	rows.Close()
+
+	// (2) SET NULL must never include team_id in its target column list.
+	var unsafeSetNull int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM pg_constraint con
+		  JOIN pg_class c ON c.oid = con.conrelid
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE con.contype = 'f' AND con.confdeltype = 'n'
+		   AND n.nspname = 'public'
+		   AND (con.confdelsetcols IS NULL OR EXISTS (
+		       SELECT 1 FROM pg_attribute a
+		        WHERE a.attrelid=con.conrelid AND a.attnum=ANY(con.confdelsetcols)
+		          AND a.attname='team_id'))`).Scan(&unsafeSetNull); err != nil {
+		t.Fatalf("count SET NULL: %v", err)
+	}
+	if unsafeSetNull != 0 {
+		t.Errorf("found %d SET NULL FKs that can clear team_id", unsafeSetNull)
+	}
+
+	// (3) Every team table must have a root FK (team_id) -> teams(id).
+	assertRootFKs(ctx, t, pool)
+
+	// (4) Every non-root business FK must include team_id.
+	assertBusinessFKsCarryTeamID(ctx, t, pool)
+
+	// (5) Cross-team child insert rejected; same-team self-ref works.
+	assertCrossTeamFKRejected(ctx, t, pool)
+}
+
+// TestRuntimeResourceIDsRemainGlobalUUIDKeys protects the identity contract
+// used by process-local registries and filesystem/runtime resources. These
+// resources are keyed by their globally unique database IDs; team_id is an
+// isolation qualifier and must not replace or join the stable primary key.
+func TestRuntimeResourceIDsRemainGlobalUUIDKeys(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	tables := []string{
+		"bot_channel_configs",
+		"bot_channel_routes",
+		"bot_sessions",
+		"bots",
+		"channel_identities",
+		"containers",
+		"email_providers",
+		"fetch_providers",
+		"mcp_connections",
+		"models",
+		"providers",
+		"schedule",
+		"search_providers",
+		"storage_providers",
+	}
+	for _, table := range tables {
+		t.Run(table, func(t *testing.T) {
+			rows, err := pool.Query(ctx, `
+				SELECT a.attname,
+				       pg_catalog.format_type(a.atttypid, a.atttypmod),
+				       COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), '')
+				  FROM pg_constraint con
+				  JOIN LATERAL unnest(con.conkey) WITH ORDINALITY key(attnum, ord) ON true
+				  JOIN pg_attribute a
+				    ON a.attrelid = con.conrelid AND a.attnum = key.attnum
+				  LEFT JOIN pg_attrdef d
+				    ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+				 WHERE con.contype = 'p'
+				   AND con.conrelid = ('public.' || quote_ident($1))::regclass
+				 ORDER BY key.ord`, table)
+			if err != nil {
+				t.Fatalf("query primary key: %v", err)
+			}
+			defer rows.Close()
+
+			type keyColumn struct {
+				name, dataType, defaultExpr string
+			}
+			var columns []keyColumn
+			for rows.Next() {
+				var column keyColumn
+				if err := rows.Scan(&column.name, &column.dataType, &column.defaultExpr); err != nil {
+					t.Fatalf("scan primary key: %v", err)
+				}
+				columns = append(columns, column)
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("iterate primary key: %v", err)
+			}
+			if len(columns) != 1 || columns[0].name != "id" || columns[0].dataType != "uuid" {
+				t.Fatalf("runtime resource primary key = %#v, want single UUID id", columns)
+			}
+			if columns[0].defaultExpr != "gen_random_uuid()" {
+				t.Fatalf("runtime resource id default = %q, want gen_random_uuid()", columns[0].defaultExpr)
+			}
+		})
+	}
+}
+
+func assertRootFKs(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	rows, err := pool.Query(ctx, `
+		SELECT c.relname FROM pg_class c
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE c.relkind = 'r' AND n.nspname = 'public'
+		   AND c.relname NOT IN ('schema_migrations', 'teams')`)
+	if err != nil {
+		t.Fatalf("enumerate tables: %v", err)
+	}
+	var tables []string
+	for rows.Next() {
+		var n string
+		_ = rows.Scan(&n)
+		tables = append(tables, n)
+	}
+	rows.Close()
+
+	for _, tbl := range tables {
+		var hasRootFK bool
+		if err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_constraint con
+				  JOIN pg_class rt ON rt.oid = con.confrelid
+				  JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = ANY(con.conkey)
+				 WHERE con.contype = 'f'
+				   AND con.conrelid = ('public.'||quote_ident($1))::regclass
+				   AND rt.relname = 'teams'
+				   AND a.attname = 'team_id'
+			)`, tbl).Scan(&hasRootFK); err != nil {
+			t.Fatalf("check root FK on %s: %v", tbl, err)
+		}
+		if !hasRootFK {
+			t.Errorf("team table %s is missing a root FK (team_id) -> teams(id)", tbl)
+		}
+	}
+}
+
+func assertBusinessFKsCarryTeamID(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	// Every FK from a team table to another team table (parent != teams)
+	// must include the team_id column in its key.
+	rows, err := pool.Query(ctx, `
+		SELECT c.relname, con.conname, rt.relname AS parent
+		  FROM pg_constraint con
+		  JOIN pg_class c ON c.oid = con.conrelid
+		  JOIN pg_class rt ON rt.oid = con.confrelid
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE con.contype = 'f' AND n.nspname = 'public'
+		   AND rt.relname NOT IN ('teams')
+		   AND NOT EXISTS (
+		       SELECT 1 FROM pg_attribute a
+		        WHERE a.attrelid = con.conrelid AND a.attnum = ANY(con.conkey)
+		          AND a.attname = 'team_id')`)
+	if err != nil {
+		t.Fatalf("enumerate business FKs: %v", err)
+	}
+	for rows.Next() {
+		var tbl, fk, parent string
+		_ = rows.Scan(&tbl, &fk, &parent)
+		t.Errorf("business FK %s on %s -> %s does not include team_id", fk, tbl, parent)
+	}
+	rows.Close()
+}
+
+func assertCrossTeamFKRejected(ctx context.Context, t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	const t1 = "00000000-0000-0000-0000-000000000001"
+	const t2 = "00000000-0000-0000-0000-0000000000f2"
+	if _, err := pool.Exec(ctx, `INSERT INTO teams (id, slug) VALUES ($1, 'ct2')`, t2); err != nil {
+		t.Fatalf("seed team2: %v", err)
+	}
+	// Create a provider in t1, then try to create a model in t2 that references
+	// it — must fail, because the composite FK (team_id, provider_id) ->
+	// providers(team_id, id) cannot match across teams.
+	var providerID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO providers (team_id, name, client_type) VALUES ($1, 'p', 'openai-completions') RETURNING id`, t1,
+	).Scan(&providerID); err != nil {
+		t.Fatalf("insert provider t1: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO models (team_id, provider_id, model_id, type) VALUES ($1, $2, 'm', 'chat')`, t2, providerID,
+	); sqlState(err) != "23503" {
+		t.Fatalf("cross-team model->provider FK must be rejected (23503), got %q", sqlState(err))
+	}
+	// Same-team reference succeeds.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO models (team_id, provider_id, model_id, type) VALUES ($1, $2, 'm', 'chat')`, t1, providerID,
+	); err != nil {
+		t.Fatalf("same-team model->provider must succeed: %v", err)
+	}
+}

--- a/internal/db/team_legacy_upgrade_integration_test.go
+++ b/internal/db/team_legacy_upgrade_integration_test.go
@@ -1,0 +1,189 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMigrateLegacyInstallPreservesRows simulates upgrading an EXISTING
+// (pre-team) install: it applies the migration chain up to the last
+// pre-team migration, seeds representative business data, then applies the
+// the consolidated team migration. It asserts no rows are lost, every row is
+// backfilled to the default team, and the schema reached the final
+// team-scoped shape. Existing installs upgrade in place without a wipe.
+func TestMigrateLegacyInstallPreservesRows(t *testing.T) {
+	ctx := context.Background()
+	dsn := teamMigrationDSN(t)
+	pool := resetToEmpty(t)
+
+	teamSteps := countTeamMigrations(t)
+
+	// Apply the chain up to (but not including) the team migrations — the
+	// "legacy install" state.
+	stepUpToPreTeam(t, dsn, teamSteps)
+
+	// teams must not exist yet (pre-team baseline).
+	var teamsExists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM information_schema.tables
+			WHERE table_schema='public' AND table_name='teams')`).Scan(&teamsExists); err != nil {
+		t.Fatalf("check teams pre-upgrade: %v", err)
+	}
+	if teamsExists {
+		t.Fatal("teams must not exist before the team migrations")
+	}
+
+	// Seed representative legacy business data: a user + a bot owned by it.
+	var userID, botID string
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (username, email, is_active, metadata) VALUES ('legacy-user', 'u@example.com', true, '{}') RETURNING id`,
+	).Scan(&userID); err != nil {
+		t.Fatalf("seed legacy user: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO bots (owner_user_id, name, status, metadata) VALUES ($1, 'legacy-bot', 'ready', '{}') RETURNING id`, userID,
+	).Scan(&botID); err != nil {
+		t.Fatalf("seed legacy bot: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO bot_sessions (bot_id, channel_type, title, metadata) VALUES ($1, 'local', 'legacy session', '{}')`, botID,
+	); err != nil {
+		t.Fatalf("seed legacy session: %v", err)
+	}
+
+	// Apply the team migrations (the upgrade).
+	stepUp(t, dsn, teamSteps)
+
+	// Rows preserved.
+	assertCount := func(table string, want int) {
+		var n int
+		if err := pool.QueryRow(ctx, "SELECT count(*) FROM "+table).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if n != want {
+			t.Errorf("%s row count = %d, want %d (upgrade must preserve rows)", table, n, want)
+		}
+	}
+	assertCount("users", 1)
+	assertCount("bots", 1)
+	assertCount("bot_sessions", 1)
+
+	// Every seeded row is backfilled to the default team.
+	const defaultTeam = "00000000-0000-0000-0000-000000000001"
+	for _, table := range []string{"users", "bots", "bot_sessions"} {
+		var nonDefault int
+		if err := pool.QueryRow(ctx,
+			"SELECT count(*) FROM "+table+" WHERE team_id IS DISTINCT FROM $1", defaultTeam,
+		).Scan(&nonDefault); err != nil {
+			t.Fatalf("check backfill %s: %v", table, err)
+		}
+		if nonDefault != 0 {
+			t.Errorf("%s has %d rows not backfilled to the default team", table, nonDefault)
+		}
+	}
+
+	// The final schema keeps the existing PK and adds a team-prefixed unique
+	// key that composite foreign keys can reference.
+	var teamKeyCount int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM pg_constraint con
+		 WHERE con.contype='u' AND con.conrelid='public.bots'::regclass
+		   AND con.conname LIKE 'memoh_team_key_%'
+		   AND (SELECT a.attname FROM pg_attribute a
+		         WHERE a.attrelid=con.conrelid AND a.attnum=con.conkey[1])='team_id'`).Scan(&teamKeyCount); err != nil {
+		t.Fatalf("bots team key: %v", err)
+	}
+	if teamKeyCount != 1 {
+		t.Errorf("after upgrade bots must have one team-prefixed key, got %d", teamKeyCount)
+	}
+}
+
+// TestMigrateDownFailClosedForMultiTeam asserts that once a non-default team
+// exists, stepping the team migrations down fails closed rather than
+// destroying team data.
+func TestMigrateDownFailClosedForMultiTeam(t *testing.T) {
+	ctx := context.Background()
+	dsn := teamMigrationDSN(t)
+	pool := freshMigratedDB(t)
+
+	const t2 = "00000000-0000-0000-0000-0000000000f2"
+	if _, err := pool.Exec(ctx, `INSERT INTO teams (id, slug) VALUES ($1, 'other')`, t2); err != nil {
+		t.Fatalf("insert non-default team: %v", err)
+	}
+	// Stepping the team migrations down must fail closed.
+	if downErr := tryStepDown(t, dsn, countTeamMigrations(t)); downErr == nil {
+		t.Fatal("stepping team migrations down must fail closed with a non-default team present")
+	}
+}
+
+// TestMigrateDownSingletonSafe asserts a clean singleton database can step the
+// team migrations down and back up (reversibility on the supported down path).
+func TestMigrateDownSingletonSafe(t *testing.T) {
+	ctx := context.Background()
+	dsn := teamMigrationDSN(t)
+	pool := freshMigratedDB(t)
+
+	steps := countTeamMigrations(t)
+	stepDown(t, dsn, steps)
+	var teamsExists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM information_schema.tables
+			WHERE table_schema='public' AND table_name='teams')`).Scan(&teamsExists); err != nil {
+		t.Fatalf("check teams after down: %v", err)
+	}
+	if teamsExists {
+		t.Error("clean singleton must be able to drop the team schema on down")
+	}
+	stepUp(t, dsn, steps)
+}
+
+func TestTeamMigrationsLeaveUserTablesUntouched(t *testing.T) {
+	ctx := context.Background()
+	dsn := teamMigrationDSN(t)
+	pool := resetToEmpty(t)
+	teamSteps := countTeamMigrations(t)
+	stepUpToPreTeam(t, dsn, teamSteps)
+
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE public.user_extension_data (
+			id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			team_id uuid,
+			payload text NOT NULL
+		);
+		INSERT INTO public.user_extension_data (team_id, payload)
+		VALUES ('00000000-0000-0000-0000-0000000000ee', 'preserve me')`); err != nil {
+		t.Fatalf("create user table: %v", err)
+	}
+
+	stepUp(t, dsn, teamSteps)
+
+	var rls, forced bool
+	if err := pool.QueryRow(ctx, `
+		SELECT relrowsecurity, relforcerowsecurity
+		  FROM pg_class WHERE oid='public.user_extension_data'::regclass`).Scan(&rls, &forced); err != nil {
+		t.Fatalf("read user table RLS: %v", err)
+	}
+	if rls || forced {
+		t.Errorf("team migrations changed user table RLS: enabled=%v forced=%v", rls, forced)
+	}
+	var teamFKs int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM pg_constraint con
+		 JOIN pg_class parent ON parent.oid=con.confrelid
+		 WHERE con.conrelid='public.user_extension_data'::regclass
+		   AND con.contype='f' AND parent.relname='teams'`).Scan(&teamFKs); err != nil {
+		t.Fatalf("read user table FKs: %v", err)
+	}
+	if teamFKs != 0 {
+		t.Errorf("team migrations added %d team FKs to user table", teamFKs)
+	}
+	var payload string
+	if err := pool.QueryRow(ctx, `SELECT payload FROM public.user_extension_data`).Scan(&payload); err != nil {
+		t.Fatalf("read user table row: %v", err)
+	}
+	if payload != "preserve me" {
+		t.Errorf("user table payload = %q", payload)
+	}
+}

--- a/internal/db/team_migrate_integration_test.go
+++ b/internal/db/team_migrate_integration_test.go
@@ -1,0 +1,429 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	embeddeddb "github.com/memohai/memoh/db"
+	"github.com/memohai/memoh/internal/config"
+	"github.com/memohai/memoh/internal/db"
+	"github.com/memohai/memoh/internal/team"
+)
+
+func sqlState(err error) string {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code
+	}
+	return ""
+}
+
+var (
+	teamTestDBSeq atomic.Uint64
+	teamTestDBs   sync.Map
+)
+
+// teamMigrationDSN creates a database dedicated to the current test. Team
+// migration tests drop schemas and step migrations backward, so they must not
+// share TEST_POSTGRES_DSN with other integration packages.
+func teamMigrationDSN(t *testing.T) string {
+	t.Helper()
+	if dsn, ok := teamTestDBs.Load(t.Name()); ok {
+		return dsn.(string)
+	}
+
+	baseDSN := os.Getenv("TEST_POSTGRES_DSN")
+	if baseDSN == "" {
+		t.Skip("TEST_POSTGRES_DSN is not set")
+	}
+	cfg, err := pgxpool.ParseConfig(baseDSN)
+	if err != nil {
+		t.Fatalf("parse TEST_POSTGRES_DSN: %v", err)
+	}
+	admin, err := pgxpool.NewWithConfig(context.Background(), cfg.Copy())
+	if err != nil {
+		t.Fatalf("connect admin database: %v", err)
+	}
+	defer admin.Close()
+
+	dbName := "memoh_team_test_" + strconv.Itoa(os.Getpid()) + "_" + strconv.FormatUint(teamTestDBSeq.Add(1), 10)
+	if _, err := admin.Exec(context.Background(), "CREATE DATABASE "+dbName); err != nil {
+		t.Fatalf("create isolated test database: %v", err)
+	}
+	testCfg := cfg.Copy()
+	testCfg.ConnConfig.Database = dbName
+	sslMode := "disable"
+	if testCfg.ConnConfig.TLSConfig != nil {
+		sslMode = "require"
+	}
+	testDSN := db.DSN(config.PostgresConfig{
+		Host:     testCfg.ConnConfig.Host,
+		Port:     int(testCfg.ConnConfig.Port),
+		User:     testCfg.ConnConfig.User,
+		Password: testCfg.ConnConfig.Password,
+		Database: dbName,
+		SSLMode:  sslMode,
+	})
+	teamTestDBs.Store(t.Name(), testDSN)
+	t.Cleanup(func() {
+		teamTestDBs.Delete(t.Name())
+		cleanup, err := pgxpool.NewWithConfig(context.Background(), cfg.Copy())
+		if err != nil {
+			return
+		}
+		defer cleanup.Close()
+		_, _ = cleanup.Exec(context.Background(), "DROP DATABASE IF EXISTS "+dbName+" WITH (FORCE)")
+	})
+	return testDSN
+}
+
+// pgConfigFromDSN parses a libpq DSN/URL into the repo's PostgresConfig.
+func pgConfigFromDSN(t *testing.T, dsn string) config.PostgresConfig {
+	t.Helper()
+	pc, err := pgconn.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse dsn: %v", err)
+	}
+	ssl := "disable"
+	if pc.TLSConfig != nil {
+		ssl = "require"
+	}
+	return config.PostgresConfig{
+		Host:     pc.Host,
+		Port:     int(pc.Port),
+		User:     pc.User,
+		Password: pc.Password,
+		Database: pc.Database,
+		SSLMode:  ssl,
+	}
+}
+
+// postgresMigrationsFS returns the embedded PostgreSQL migrations sub-tree.
+func postgresMigrationsFS(t *testing.T) fs.FS {
+	t.Helper()
+	sub, err := fs.Sub(embeddeddb.MigrationsFS, "postgres/migrations")
+	if err != nil {
+		t.Fatalf("migrations fs: %v", err)
+	}
+	return sub
+}
+
+// freshMigratedDB applies the full migration chain to the test's isolated DB.
+func freshMigratedDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := teamMigrationDSN(t)
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	if err := db.RunMigrate(logger, pgConfigFromDSN(t, dsn), postgresMigrationsFS(t), "up", nil); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+	return pool
+}
+
+func TestSingletonTeamSeededAfterMigrate(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	var count int
+	if err := pool.QueryRow(ctx, "SELECT count(*) FROM teams").Scan(&count); err != nil {
+		t.Fatalf("count teams: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 seeded team, got %d", count)
+	}
+
+	var id, slug string
+	if err := pool.QueryRow(ctx, "SELECT id::text, slug FROM teams").Scan(&id, &slug); err != nil {
+		t.Fatalf("select team: %v", err)
+	}
+	if id != team.DefaultTeamID {
+		t.Fatalf("seeded team id = %q, want DefaultTeamID %q", id, team.DefaultTeamID)
+	}
+	if slug != "default" {
+		t.Fatalf("seeded team slug = %q, want %q", slug, "default")
+	}
+
+	// teams root must NOT carry a redundant team_id column (it is the root:
+	// its own id IS the team id).
+	var hasTeamID bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = 'public' AND table_name = 'teams' AND column_name = 'team_id'
+		)`).Scan(&hasTeamID); err != nil {
+		t.Fatalf("check teams columns: %v", err)
+	}
+	if hasTeamID {
+		t.Fatal("teams root must not have a redundant team_id column")
+	}
+}
+
+func TestMigrationsDoNotRequireClusterRolePrivileges(t *testing.T) {
+	ctx := context.Background()
+	adminDSN := teamMigrationDSN(t)
+	adminCfg, err := pgconn.ParseConfig(adminDSN)
+	if err != nil {
+		t.Fatalf("parse isolated database DSN: %v", err)
+	}
+	admin, err := pgxpool.New(ctx, adminDSN)
+	if err != nil {
+		t.Fatalf("connect isolated database: %v", err)
+	}
+
+	role := "memoh_migration_test_" + strconv.Itoa(os.Getpid()) + "_" + strconv.FormatUint(teamTestDBSeq.Add(1), 10)
+	const password = "migration_test_password"
+	if _, err := admin.Exec(ctx, "CREATE ROLE "+role+" LOGIN NOSUPERUSER NOCREATEROLE NOBYPASSRLS PASSWORD '"+password+"'"); err != nil {
+		t.Fatalf("create limited migration role: %v", err)
+	}
+	if _, err := admin.Exec(ctx, "ALTER DATABASE "+adminCfg.Database+" OWNER TO "+role); err != nil {
+		t.Fatalf("assign test database owner: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = admin.Exec(ctx, "ALTER DATABASE "+adminCfg.Database+" OWNER TO "+adminCfg.User)
+		_, _ = admin.Exec(ctx, "DROP OWNED BY "+role)
+		_, _ = admin.Exec(ctx, "DROP ROLE IF EXISTS "+role)
+		admin.Close()
+	})
+
+	limitedDSN := db.DSN(config.PostgresConfig{
+		Host:     adminCfg.Host,
+		Port:     int(adminCfg.Port),
+		User:     role,
+		Password: password,
+		Database: adminCfg.Database,
+		SSLMode:  "disable",
+	})
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	if err := db.RunMigrate(logger, pgConfigFromDSN(t, limitedDSN), postgresMigrationsFS(t), "up", nil); err != nil {
+		t.Fatalf("migrate as database owner without CREATEROLE/BYPASSRLS: %v", err)
+	}
+}
+
+// stepDown rolls back exactly n migration steps using the golang-migrate library
+// directly. The repo's RunMigrate("down") rolls back ALL migrations, so tests
+// that need single-step reversibility use this helper instead.
+func stepDown(t *testing.T, dsn string, n int) {
+	t.Helper()
+	src, err := iofs.New(postgresMigrationsFS(t), ".")
+	if err != nil {
+		t.Fatalf("iofs: %v", err)
+	}
+	m, err := migrate.NewWithSourceInstance("iofs", src, dsn)
+	if err != nil {
+		t.Fatalf("migrate init: %v", err)
+	}
+	defer func() { _, _ = m.Close() }()
+	if err := m.Steps(-n); err != nil {
+		t.Fatalf("step down %d: %v", n, err)
+	}
+}
+
+// stepUp applies exactly n migration steps using the golang-migrate library.
+func stepUp(t *testing.T, dsn string, n int) {
+	t.Helper()
+	src, err := iofs.New(postgresMigrationsFS(t), ".")
+	if err != nil {
+		t.Fatalf("iofs: %v", err)
+	}
+	m, err := migrate.NewWithSourceInstance("iofs", src, dsn)
+	if err != nil {
+		t.Fatalf("migrate init: %v", err)
+	}
+	defer func() { _, _ = m.Close() }()
+	if err := m.Steps(n); err != nil {
+		t.Fatalf("step up %d: %v", n, err)
+	}
+}
+
+// tryStepDown steps n migrations down and RETURNS any error (instead of failing
+// the test), so callers can assert a fail-closed down gate.
+func tryStepDown(t *testing.T, dsn string, n int) error {
+	t.Helper()
+	src, err := iofs.New(postgresMigrationsFS(t), ".")
+	if err != nil {
+		t.Fatalf("iofs: %v", err)
+	}
+	m, err := migrate.NewWithSourceInstance("iofs", src, dsn)
+	if err != nil {
+		t.Fatalf("migrate init: %v", err)
+	}
+	defer func() { _, _ = m.Close() }()
+	return m.Steps(-n)
+}
+
+// resetToEmpty returns a connection to the test's isolated, empty database.
+func resetToEmpty(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := teamMigrationDSN(t)
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	return pool
+}
+
+// stepUpToPreTeam applies the migration chain up to (but not including) the
+// teamSteps team migrations — i.e. the "legacy install" pre-team state.
+func stepUpToPreTeam(t *testing.T, dsn string, teamSteps int) {
+	t.Helper()
+	src, err := iofs.New(postgresMigrationsFS(t), ".")
+	if err != nil {
+		t.Fatalf("iofs: %v", err)
+	}
+	m, err := migrate.NewWithSourceInstance("iofs", src, dsn)
+	if err != nil {
+		t.Fatalf("migrate init: %v", err)
+	}
+	defer func() { _, _ = m.Close() }()
+	total := countAllMigrations(t)
+	if err := m.Steps(total - teamSteps); err != nil {
+		t.Fatalf("step up to pre-team (%d steps): %v", total-teamSteps, err)
+	}
+}
+
+// countAllMigrations returns the number of up migrations in the embedded FS.
+func countAllMigrations(t *testing.T) int {
+	t.Helper()
+	entries, err := fs.ReadDir(postgresMigrationsFS(t), ".")
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+	n := 0
+	for _, e := range entries {
+		if len(e.Name()) > 7 && e.Name()[len(e.Name())-7:] == ".up.sql" {
+			n++
+		}
+	}
+	return n
+}
+
+// TestTeamChainReversible verifies the full team migration chain
+// is cleanly reversible: stepping down the consolidated team migration
+// removes all team objects, and a step-up re-applies them. It also verifies
+// the down safety gate refuses to drop the teams root when a non-default
+// team exists.
+func TestTeamChainReversible(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+	dsn := teamMigrationDSN(t)
+
+	// The team core is intentionally one consolidated migration.
+	teamSteps := countTeamMigrations(t)
+
+	// Step the team migration down; teams + the public helper must be gone.
+	stepDown(t, dsn, teamSteps)
+	var teamsExists, helperExists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM information_schema.tables
+			WHERE table_schema='public' AND table_name='teams')`).Scan(&teamsExists); err != nil {
+		t.Fatalf("check teams after step down: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT to_regprocedure('public.memoh_current_team_id()') IS NOT NULL`).Scan(&helperExists); err != nil {
+		t.Fatalf("check team helper after step down: %v", err)
+	}
+	if teamsExists {
+		t.Error("teams root must be dropped after stepping down the team migrations")
+	}
+	if helperExists {
+		t.Error("team helper must be dropped after stepping down the team migration")
+	}
+
+	// Re-apply and confirm SET NULL actions target only the original reference
+	// column rather than the non-null team_id column.
+	stepUp(t, dsn, teamSteps)
+	var unsafeSetNull int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM pg_constraint con
+		  JOIN pg_class c ON c.oid = con.conrelid
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE con.contype='f' AND con.confdeltype='n' AND n.nspname='public'
+		   AND (con.confdelsetcols IS NULL OR EXISTS (
+		       SELECT 1 FROM pg_attribute a
+		        WHERE a.attrelid=con.conrelid AND a.attnum=ANY(con.confdelsetcols)
+		          AND a.attname='team_id'))`).Scan(&unsafeSetNull); err != nil {
+		t.Fatalf("count set null after re-up: %v", err)
+	}
+	if unsafeSetNull != 0 {
+		t.Errorf("after re-up found %d SET NULL FKs that can clear team_id", unsafeSetNull)
+	}
+}
+
+// TestTeamsRootDownSafetyGate verifies the root down safety gate: when a
+// non-default team exists, stepping the team migrations down must fail
+// closed rather than dropping team data.
+func TestTeamsRootDownSafetyGate(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+	dsn := teamMigrationDSN(t)
+
+	// Seed a second team so rollback must preserve the team root.
+	const t2 = "00000000-0000-0000-0000-0000000000f2"
+	if _, err := pool.Exec(ctx, `INSERT INTO teams (id, slug) VALUES ($1, 'other')`, t2); err != nil {
+		t.Fatalf("insert non-default team: %v", err)
+	}
+
+	// Stepping the team migration down must fail closed.
+	src, err := iofs.New(postgresMigrationsFS(t), ".")
+	if err != nil {
+		t.Fatalf("iofs: %v", err)
+	}
+	m, err := migrate.NewWithSourceInstance("iofs", src, dsn)
+	if err != nil {
+		t.Fatalf("migrate init: %v", err)
+	}
+	defer func() { _, _ = m.Close() }()
+	if err := m.Steps(-countTeamMigrations(t)); err == nil {
+		t.Fatal("stepping team migrations down must fail closed with a non-default team present")
+	}
+}
+
+// countTeamMigrations asserts that this PR contributes exactly one migration.
+func countTeamMigrations(t *testing.T) int {
+	t.Helper()
+	entries, err := fs.ReadDir(postgresMigrationsFS(t), ".")
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+	const teamMigration = "0111_team_core.up.sql"
+	found := false
+	for _, e := range entries {
+		if e.Name() == teamMigration {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("missing consolidated team migration %s", teamMigration)
+	}
+	return 1
+}

--- a/internal/db/team_migrate_integration_test.go
+++ b/internal/db/team_migrate_integration_test.go
@@ -414,7 +414,7 @@ func countTeamMigrations(t *testing.T) int {
 	if err != nil {
 		t.Fatalf("read migrations dir: %v", err)
 	}
-	const teamMigration = "0111_team_core.up.sql"
+	const teamMigration = "0112_team_core.up.sql"
 	found := false
 	for _, e := range entries {
 		if e.Name() == teamMigration {

--- a/internal/db/team_query_fixture_test.go
+++ b/internal/db/team_query_fixture_test.go
@@ -1,0 +1,24 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func bindTeamQueryFixture(t *testing.T, ctx context.Context, tx pgx.Tx) {
+	t.Helper()
+	if _, err := tx.Exec(ctx, `
+CREATE OR REPLACE FUNCTION public.memoh_current_team_id()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = pg_catalog, pg_temp
+AS $$ SELECT pg_catalog.current_setting('memoh.team_id')::uuid $$;
+SELECT set_config('memoh.team_id', '00000000-0000-0000-0000-000000000001', true);
+`); err != nil {
+		t.Fatalf("bind team query fixture: %v", err)
+	}
+}

--- a/internal/db/team_rls_integration_test.go
+++ b/internal/db/team_rls_integration_test.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/memohai/memoh/internal/team"
+)
+
+// rlsConn returns a connection running as a non-superuser test role. Roles are
+// test setup only; production migrations intentionally do not create roles.
+func rlsConn(t *testing.T, ownerPool *pgxpool.Pool, dsn string) *pgx.Conn {
+	t.Helper()
+	ctx := context.Background()
+	role := fmt.Sprintf("memoh_rls_test_%d_%d", os.Getpid(), teamTestDBSeq.Add(1))
+	if _, err := ownerPool.Exec(ctx, "CREATE ROLE "+role+" NOLOGIN NOSUPERUSER NOBYPASSRLS"); err != nil {
+		t.Fatalf("create RLS test role: %v", err)
+	}
+	grants := []string{
+		"GRANT USAGE ON SCHEMA public TO " + role,
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO " + role,
+		"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO " + role,
+		"GRANT EXECUTE ON FUNCTION public.memoh_current_team_id() TO " + role,
+	}
+	for _, grant := range grants {
+		if _, err := ownerPool.Exec(ctx, grant); err != nil {
+			t.Fatalf("grant RLS test role: %v", err)
+		}
+	}
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect for RLS test: %v", err)
+	}
+	if _, err := conn.Exec(ctx, "SET ROLE "+role); err != nil {
+		_ = conn.Close(ctx)
+		t.Fatalf("set RLS test role: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close(ctx)
+		_, _ = ownerPool.Exec(ctx, "DROP OWNED BY "+role)
+		_, _ = ownerPool.Exec(ctx, "DROP ROLE IF EXISTS "+role)
+	})
+	return conn
+}
+
+func TestTeamRLSForceEnabled(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	rows, err := pool.Query(ctx, `
+		SELECT c.relname, c.relrowsecurity, c.relforcerowsecurity
+		  FROM pg_class c
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE c.relkind IN ('r', 'p') AND n.nspname = 'public'
+		   AND (c.relname='teams' OR EXISTS (
+		       SELECT 1 FROM pg_constraint con
+		       JOIN pg_class parent ON parent.oid=con.confrelid
+		        WHERE con.conrelid=c.oid AND con.contype='f' AND parent.relname='teams'))`)
+	if err != nil {
+		t.Fatalf("enumerate team tables: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		var enabled, forced bool
+		if err := rows.Scan(&name, &enabled, &forced); err != nil {
+			t.Fatalf("scan team table: %v", err)
+		}
+		if !enabled || !forced {
+			t.Errorf("table %s must have RLS enabled and forced", name)
+		}
+	}
+}
+
+func TestComposeRuntimeRoleEnforcesRLS(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	var roleExists bool
+	if err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'memoh_app')`).Scan(&roleExists); err != nil {
+		t.Fatalf("check memoh_app role: %v", err)
+	}
+	if !roleExists {
+		t.Skip("memoh_app role is provisioned by the Compose database bootstrap")
+	}
+
+	const (
+		teamTwo = "00000000-0000-0000-0000-000000000002"
+		userOne = "00000000-0000-0000-0000-000000000101"
+		userTwo = "00000000-0000-0000-0000-000000000102"
+	)
+	if _, err := pool.Exec(ctx, `INSERT INTO teams (id, slug) VALUES ($1, 'runtime-role-team') ON CONFLICT (id) DO NOTHING`, teamTwo); err != nil {
+		t.Fatalf("seed runtime role team: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, team_id) VALUES ($1, $2), ($3, $4)`, userOne, team.DefaultTeamID, userTwo, teamTwo); err != nil {
+		t.Fatalf("seed runtime role rows: %v", err)
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire runtime role connection: %v", err)
+	}
+	defer conn.Release()
+	defer func() { _, _ = conn.Exec(ctx, "RESET ROLE") }()
+	if _, err := conn.Exec(ctx, "SET ROLE memoh_app"); err != nil {
+		t.Fatalf("set runtime role: %v", err)
+	}
+	if _, err := conn.Exec(ctx, "SELECT set_config('memoh.team_id', $1, false)", teamTwo); err != nil {
+		t.Fatalf("bind runtime role team: %v", err)
+	}
+	var currentUser string
+	if err := conn.QueryRow(ctx, "SELECT current_user").Scan(&currentUser); err != nil {
+		t.Fatalf("read current user: %v", err)
+	}
+	if currentUser != "memoh_app" {
+		t.Fatalf("current_user = %q, want memoh_app", currentUser)
+	}
+	var visible int
+	if err := conn.QueryRow(ctx, "SELECT count(*) FROM users WHERE id = ANY($1::uuid[])", []string{userOne, userTwo}).Scan(&visible); err != nil {
+		t.Fatalf("query users as runtime role: %v", err)
+	}
+	if visible != 1 {
+		t.Fatalf("runtime role sees %d team fixture rows, want 1", visible)
+	}
+}
+
+func TestTeamRLSDynamicIsolation(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+	dsn := teamMigrationDSN(t)
+	const t1 = "00000000-0000-0000-0000-000000000001"
+	const t2 = "00000000-0000-0000-0000-0000000000f2"
+
+	if _, err := pool.Exec(ctx, `INSERT INTO teams (id, slug) VALUES ($1, 't2')`, t2); err != nil {
+		t.Fatalf("seed team2: %v", err)
+	}
+	rc := rlsConn(t, pool, dsn)
+
+	writeAs := func(teamID string, fn func(pgx.Tx) error) error {
+		tx, err := rc.Begin(ctx)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if _, err := tx.Exec(ctx, "SELECT set_config('memoh.team_id', $1, true)", teamID); err != nil {
+			return err
+		}
+		if err := fn(tx); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	}
+
+	for _, tc := range []struct{ teamID, name string }{{t1, "p1"}, {t2, "p1"}} {
+		if err := writeAs(tc.teamID, func(tx pgx.Tx) error {
+			_, err := tx.Exec(ctx,
+				`INSERT INTO providers (team_id, name, client_type) VALUES ($1, $2, 'openai-completions')`,
+				tc.teamID, tc.name)
+			return err
+		}); err != nil {
+			t.Fatalf("insert provider for %s: %v", tc.teamID, err)
+		}
+	}
+
+	readCount := func(teamID string) int {
+		tx, err := rc.Begin(ctx)
+		if err != nil {
+			t.Fatalf("begin read: %v", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		if _, err := tx.Exec(ctx, "SELECT set_config('memoh.team_id', $1, true)", teamID); err != nil {
+			t.Fatalf("bind team: %v", err)
+		}
+		var count int
+		if err := tx.QueryRow(ctx, "SELECT count(*) FROM providers").Scan(&count); err != nil {
+			t.Fatalf("count providers: %v", err)
+		}
+		return count
+	}
+	if got := readCount(t1); got != 1 {
+		t.Errorf("team 1 saw %d providers, want 1", got)
+	}
+	if got := readCount(t2); got != 1 {
+		t.Errorf("team 2 saw %d providers, want 1", got)
+	}
+
+	err := writeAs(t1, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO providers (team_id, name, client_type) VALUES ($1, 'cross', 'openai-completions')`, t2)
+		return err
+	})
+	if sqlState(err) != "42501" {
+		t.Errorf("cross-team insert SQLSTATE = %q, want 42501", sqlState(err))
+	}
+
+	tx, err := rc.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin missing-context write: %v", err)
+	}
+	_, writeErr := tx.Exec(ctx,
+		`INSERT INTO providers (team_id, name, client_type) VALUES ($1, 'missing', 'openai-completions')`, t1)
+	_ = tx.Rollback(ctx)
+	if sqlState(writeErr) != "42501" {
+		t.Errorf("missing team context SQLSTATE = %q, want 42501", sqlState(writeErr))
+	}
+}

--- a/internal/db/team_rls_integration_test.go
+++ b/internal/db/team_rls_integration_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/memohai/memoh/internal/team"
 )
 
 // rlsConn returns a connection running as a non-superuser test role. Roles are
@@ -76,58 +74,6 @@ func TestTeamRLSForceEnabled(t *testing.T) {
 		if !enabled || !forced {
 			t.Errorf("table %s must have RLS enabled and forced", name)
 		}
-	}
-}
-
-func TestComposeRuntimeRoleEnforcesRLS(t *testing.T) {
-	ctx := context.Background()
-	pool := freshMigratedDB(t)
-
-	var roleExists bool
-	if err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'memoh_app')`).Scan(&roleExists); err != nil {
-		t.Fatalf("check memoh_app role: %v", err)
-	}
-	if !roleExists {
-		t.Skip("memoh_app role is provisioned by the Compose database bootstrap")
-	}
-
-	const (
-		teamTwo = "00000000-0000-0000-0000-000000000002"
-		userOne = "00000000-0000-0000-0000-000000000101"
-		userTwo = "00000000-0000-0000-0000-000000000102"
-	)
-	if _, err := pool.Exec(ctx, `INSERT INTO teams (id, slug) VALUES ($1, 'runtime-role-team') ON CONFLICT (id) DO NOTHING`, teamTwo); err != nil {
-		t.Fatalf("seed runtime role team: %v", err)
-	}
-	if _, err := pool.Exec(ctx, `INSERT INTO users (id, team_id) VALUES ($1, $2), ($3, $4)`, userOne, team.DefaultTeamID, userTwo, teamTwo); err != nil {
-		t.Fatalf("seed runtime role rows: %v", err)
-	}
-
-	conn, err := pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire runtime role connection: %v", err)
-	}
-	defer conn.Release()
-	defer func() { _, _ = conn.Exec(ctx, "RESET ROLE") }()
-	if _, err := conn.Exec(ctx, "SET ROLE memoh_app"); err != nil {
-		t.Fatalf("set runtime role: %v", err)
-	}
-	if _, err := conn.Exec(ctx, "SELECT set_config('memoh.team_id', $1, false)", teamTwo); err != nil {
-		t.Fatalf("bind runtime role team: %v", err)
-	}
-	var currentUser string
-	if err := conn.QueryRow(ctx, "SELECT current_user").Scan(&currentUser); err != nil {
-		t.Fatalf("read current user: %v", err)
-	}
-	if currentUser != "memoh_app" {
-		t.Fatalf("current_user = %q, want memoh_app", currentUser)
-	}
-	var visible int
-	if err := conn.QueryRow(ctx, "SELECT count(*) FROM users WHERE id = ANY($1::uuid[])", []string{userOne, userTwo}).Scan(&visible); err != nil {
-		t.Fatalf("query users as runtime role: %v", err)
-	}
-	if visible != 1 {
-		t.Fatalf("runtime role sees %d team fixture rows, want 1", visible)
 	}
 }
 

--- a/internal/db/team_schema_guard_integration_test.go
+++ b/internal/db/team_schema_guard_integration_test.go
@@ -1,0 +1,238 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// nonTeamPublicTables are the public tables that are NOT team business
+// tables: tooling metadata and the teams root (whose own id IS the team id).
+var nonTeamPublicTables = map[string]bool{
+	"schema_migrations": true,
+	"teams":             true,
+}
+
+// TestTeamViewGuard verifies that views over team tables do not bypass RLS.
+// Every public view must run with
+// security_invoker = true (so the caller's RLS applies), project a team_id
+// column (so consumers can scope explicitly and the isolation is auditable).
+func TestTeamViewGuard(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	rows, err := pool.Query(ctx, `
+		SELECT c.relname,
+		       COALESCE((SELECT option_value FROM pg_options_to_table(c.reloptions)
+		                  WHERE option_name='security_invoker'), 'false') AS security_invoker
+		  FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+		 WHERE c.relkind='v' AND n.nspname='public'`)
+	if err != nil {
+		t.Fatalf("list views: %v", err)
+	}
+	type view struct{ name, secInvoker string }
+	var views []view
+	for rows.Next() {
+		var v view
+		_ = rows.Scan(&v.name, &v.secInvoker)
+		views = append(views, v)
+	}
+	rows.Close()
+
+	for _, v := range views {
+		// (1) security_invoker must be true.
+		if v.secInvoker != "true" {
+			t.Errorf("view %s must be WITH (security_invoker = true) to respect caller RLS, got %q", v.name, v.secInvoker)
+		}
+		// (2) must project a team_id column.
+		var hasTeamID bool
+		if err := pool.QueryRow(ctx, `
+			SELECT EXISTS (SELECT 1 FROM information_schema.columns
+				WHERE table_schema='public' AND table_name=$1 AND column_name='team_id')`, v.name).Scan(&hasTeamID); err != nil {
+			t.Fatalf("view %s columns: %v", v.name, err)
+		}
+		if !hasTeamID {
+			t.Errorf("view %s must project team_id", v.name)
+		}
+	}
+}
+
+// TestTeamSchemaGuard asserts the team schema invariants structurally.
+func TestTeamSchemaGuard(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	tables := publicBaseTables(t, ctx, pool)
+	if len(tables) < 48 {
+		t.Fatalf("expected >= 48 public base tables, got %d", len(tables))
+	}
+
+	for _, tbl := range tables {
+		if nonTeamPublicTables[tbl] {
+			continue
+		}
+		// (1) team_id column exists and is NOT NULL.
+		var isNullable string
+		if err := pool.QueryRow(ctx, `
+			SELECT is_nullable FROM information_schema.columns
+			 WHERE table_schema='public' AND table_name=$1 AND column_name='team_id'`, tbl).Scan(&isNullable); err != nil {
+			t.Errorf("team table %s: missing team_id column: %v", tbl, err)
+			continue
+		}
+		if isNullable != "NO" {
+			t.Errorf("team table %s: team_id must be NOT NULL", tbl)
+		}
+
+		// (2) Existing PK remains stable and has a team-prefixed helper key.
+		var helperKeys int
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*) FROM pg_constraint
+			 WHERE conrelid=('public.'||quote_ident($1))::regclass
+			   AND contype='u' AND conname LIKE 'memoh_team_key_%'`, tbl).Scan(&helperKeys); err != nil {
+			t.Fatalf("team key check %s: %v", tbl, err)
+		}
+		if helperKeys != 1 {
+			t.Errorf("team table %s: expected one team-prefixed helper key, got %d", tbl, helperKeys)
+		}
+
+		// (3) has a root FK (team_id) -> teams(id).
+		var hasRootFK bool
+		if err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_constraint con
+				  JOIN pg_class rt ON rt.oid = con.confrelid
+				  JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = ANY(con.conkey)
+				 WHERE con.contype='f' AND con.conrelid = ('public.'||quote_ident($1))::regclass
+				   AND rt.relname='teams' AND a.attname='team_id')`, tbl).Scan(&hasRootFK); err != nil {
+			t.Fatalf("root FK check %s: %v", tbl, err)
+		}
+		if !hasRootFK {
+			t.Errorf("team table %s: missing root FK (team_id) -> teams(id)", tbl)
+		}
+
+		// (4) RLS enabled + forced.
+		var rls, force bool
+		if err := pool.QueryRow(ctx, `
+			SELECT c.relrowsecurity, c.relforcerowsecurity FROM pg_class c
+			  JOIN pg_namespace n ON n.oid=c.relnamespace
+			 WHERE n.nspname='public' AND c.relname=$1`, tbl).Scan(&rls, &force); err != nil {
+			t.Fatalf("rls check %s: %v", tbl, err)
+		}
+		if !rls || !force {
+			t.Errorf("team table %s: must have RLS enabled+forced (got rls=%v force=%v)", tbl, rls, force)
+		}
+
+	}
+
+	// (5) SET NULL may clear the original reference, but never team_id.
+	var unsafeSetNull int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM pg_constraint con
+		  JOIN pg_class c ON c.oid=con.conrelid
+		  JOIN pg_namespace n ON n.oid=c.relnamespace
+		 WHERE con.contype='f' AND con.confdeltype='n' AND n.nspname='public'
+		   AND (con.confdelsetcols IS NULL OR EXISTS (
+		       SELECT 1 FROM pg_attribute a
+		        WHERE a.attrelid=con.conrelid AND a.attnum=ANY(con.confdelsetcols)
+		          AND a.attname='team_id'))`).Scan(&unsafeSetNull); err != nil {
+		t.Fatalf("set null check: %v", err)
+	}
+	if unsafeSetNull != 0 {
+		t.Errorf("found %d SET NULL FKs that can clear team_id", unsafeSetNull)
+	}
+
+	// (6) teams root special case: PK is (id) only, no redundant team_id, FORCE RLS.
+	var rootHasTeamID bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM information_schema.columns
+			WHERE table_schema='public' AND table_name='teams' AND column_name='team_id')`).Scan(&rootHasTeamID); err != nil {
+		t.Fatalf("root team_id check: %v", err)
+	}
+	if rootHasTeamID {
+		t.Error("teams root must not have a redundant team_id column")
+	}
+	var rootRLS, rootForce bool
+	_ = pool.QueryRow(ctx, `SELECT relrowsecurity, relforcerowsecurity FROM pg_class WHERE oid='public.teams'::regclass`).Scan(&rootRLS, &rootForce)
+	if !rootRLS || !rootForce {
+		t.Error("teams root must have RLS enabled+forced")
+	}
+
+	// (7) NULLS NOT DISTINCT must be preserved on bot_acl_rules_unique_target
+	// (the composite-key rebuild must not silently widen it to a plain UNIQUE,
+	// which would let duplicate ACL rules with NULL key columns through).
+	var nnd bool
+	if err := pool.QueryRow(ctx, `
+		SELECT i.indnullsnotdistinct FROM pg_constraint con
+		  JOIN pg_index i ON i.indexrelid = con.conindid
+		 WHERE con.conname = 'bot_acl_rules_unique_target'`).Scan(&nnd); err != nil {
+		t.Fatalf("nulls-not-distinct check: %v", err)
+	}
+	if !nnd {
+		t.Error("bot_acl_rules_unique_target must be UNIQUE NULLS NOT DISTINCT (semantics widened)")
+	}
+}
+
+// TestRLSPolicyGuard verifies every team table has four team-only policies.
+func TestRLSPolicyGuard(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+
+	for _, tbl := range publicBaseTables(t, ctx, pool) {
+		if nonTeamPublicTables[tbl] {
+			continue
+		}
+		var policyCount int
+		if err := pool.QueryRow(ctx, `
+			SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename=$1`, tbl).Scan(&policyCount); err != nil {
+			t.Fatalf("policy count %s: %v", tbl, err)
+		}
+		if policyCount < 4 {
+			t.Errorf("team table %s: expected >= 4 per-command policies, got %d", tbl, policyCount)
+		}
+
+		// Every policy must resolve the team from the database context and must
+		// not depend on deployment-specific write-fencing helpers.
+		rows, err := pool.Query(ctx, `
+			SELECT cmd, COALESCE(qual,''), COALESCE(with_check,'')
+			  FROM pg_policies WHERE schemaname='public' AND tablename=$1`, tbl)
+		if err != nil {
+			t.Fatalf("policies %s: %v", tbl, err)
+		}
+		for rows.Next() {
+			var cmd, qual, withCheck string
+			_ = rows.Scan(&cmd, &qual, &withCheck)
+			body := qual + " " + withCheck
+			if !strings.Contains(body, "current_team_id") {
+				t.Errorf("%s policy %s must call current_team_id()", tbl, cmd)
+			}
+			if strings.Contains(body, "fence") {
+				t.Errorf("%s policy %s must not contain deployment-specific fencing", tbl, cmd)
+			}
+		}
+		rows.Close()
+	}
+}
+
+// --- helpers ---
+
+func publicBaseTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) []string {
+	t.Helper()
+	rows, err := pool.Query(ctx, `
+		SELECT c.relname FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+		 WHERE c.relkind='r' AND n.nspname='public' ORDER BY c.relname`)
+	if err != nil {
+		t.Fatalf("list tables: %v", err)
+	}
+	var out []string
+	for rows.Next() {
+		var n string
+		_ = rows.Scan(&n)
+		out = append(out, n)
+	}
+	rows.Close()
+	return out
+}

--- a/internal/db/team_view_rls_integration_test.go
+++ b/internal/db/team_view_rls_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// TestViewDoesNotBypassRLS is the regression test for a cross-team read
+// through the bot_visible_history_messages view. A view without security_invoker
+// runs as its (superuser) owner and bypasses FORCE RLS; this test seeds a
+// team-1 message and asserts a non-superuser connection bound to team 2 sees
+// zero rows through the view.
+func TestViewDoesNotBypassRLS(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+	dsn := teamMigrationDSN(t)
+	const t1 = "00000000-0000-0000-0000-000000000001"
+	const t2 = "00000000-0000-0000-0000-0000000000f2"
+
+	// Seed team 2.
+	if _, err := pool.Exec(ctx, `INSERT INTO teams (id, slug) VALUES ($1, 't2')`, t2); err != nil {
+		t.Fatalf("seed team2: %v", err)
+	}
+	// Seed a team-1 visible message (as owner/migrator, bypassing RLS for setup).
+	if _, err := pool.Exec(ctx, `
+		WITH u AS (
+			INSERT INTO users (team_id, username, is_active, metadata)
+			VALUES ($1, 't1u', true, '{}') RETURNING id
+		), b AS (
+			INSERT INTO bots (team_id, owner_user_id, name, status, metadata)
+			SELECT $1, u.id, 'secretbot', 'ready', '{}' FROM u RETURNING id
+		), s AS (
+			INSERT INTO bot_sessions (team_id, bot_id, channel_type, title, metadata)
+			SELECT $1, b.id, 'local', 's', '{}' FROM b RETURNING id, bot_id
+		)
+		INSERT INTO bot_history_messages
+			(team_id, bot_id, session_id, role, content, metadata, usage,
+			 turn_id, turn_position, turn_message_seq, turn_visible)
+		SELECT $1, s.bot_id, s.id, 'assistant', '"SECRET-TEAM1"'::jsonb, '{}', '{}',
+			gen_random_uuid(), 1, 1, true
+		FROM s`, t1); err != nil {
+		t.Fatalf("seed team1 message: %v", err)
+	}
+
+	rc := rlsConn(t, pool, dsn)
+
+	// Bind runtime to team 2.
+	if _, err := rc.Exec(ctx, "SELECT set_config('memoh.team_id', $1, false)", t2); err != nil {
+		t.Fatalf("bind team2: %v", err)
+	}
+
+	// The test role can read the base table and view through the standard table
+	// grants installed by rlsConn.
+	var baseRows, viewRows int
+	if err := rc.QueryRow(ctx, "SELECT count(*) FROM bot_history_messages").Scan(&baseRows); err != nil {
+		t.Fatalf("read base table: %v", err)
+	}
+	if err := rc.QueryRow(ctx, "SELECT count(*) FROM bot_visible_history_messages").Scan(&viewRows); err != nil {
+		t.Fatalf("read team view: %v", err)
+	}
+
+	// The base table is correctly RLS-scoped (0 team-1 rows visible to team 2).
+	if baseRows != 0 {
+		t.Errorf("base table leaked %d team-1 rows to team 2 (RLS broken)", baseRows)
+	}
+	// The view must NOT bypass RLS.
+	if viewRows != 0 {
+		t.Errorf("view leaked %d team-1 rows to team 2", viewRows)
+	}
+
+	// The view must project team_id and it must equal the caller's team.
+	var vTeam string
+	err := rc.QueryRow(ctx, "SELECT team_id::text FROM bot_visible_history_messages LIMIT 1").Scan(&vTeam)
+	if err != nil && err != pgx.ErrNoRows {
+		t.Fatalf("view must project team_id: %v", err)
+	}
+}

--- a/internal/db/uncompacted_messages_query_integration_test.go
+++ b/internal/db/uncompacted_messages_query_integration_test.go
@@ -49,6 +49,49 @@ func TestListUncompactedMessagesReclaimEligibility(t *testing.T) {
 	if _, err := tx.Exec(ctx, baseline); err != nil {
 		t.Fatalf("apply 0001 baseline: %v", err)
 	}
+	bindTeamQueryFixture(t, ctx, tx)
+	if _, err := tx.Exec(ctx, `
+ALTER TABLE users ADD COLUMN team_id UUID NOT NULL DEFAULT public.memoh_current_team_id();
+ALTER TABLE bots ADD COLUMN team_id UUID NOT NULL DEFAULT public.memoh_current_team_id();
+ALTER TABLE bot_sessions ADD COLUMN team_id UUID NOT NULL DEFAULT public.memoh_current_team_id();
+ALTER TABLE bot_channel_routes ADD COLUMN team_id UUID NOT NULL DEFAULT public.memoh_current_team_id();
+ALTER TABLE channel_identities ADD COLUMN team_id UUID NOT NULL DEFAULT public.memoh_current_team_id();
+ALTER TABLE bot_history_message_compacts ADD COLUMN team_id UUID NOT NULL DEFAULT public.memoh_current_team_id();
+ALTER TABLE bot_history_messages ADD COLUMN team_id UUID NOT NULL DEFAULT public.memoh_current_team_id();
+
+DROP VIEW bot_visible_history_messages;
+CREATE VIEW bot_visible_history_messages AS
+SELECT
+  m.team_id,
+  m.turn_id,
+  m.turn_position,
+  m.turn_message_seq,
+  m.id,
+  m.bot_id,
+  m.session_id,
+  m.sender_channel_identity_id,
+  m.sender_account_user_id,
+  m.source_message_id,
+  m.source_reply_to_message_id,
+  m.role,
+  m.content,
+  m.metadata,
+  m.usage,
+  m.compact_id,
+  m.session_mode,
+  m.runtime_type,
+  m.model_id,
+  m.event_id,
+  m.display_text,
+  m.created_at
+FROM bot_history_messages m
+WHERE m.turn_visible = true
+  AND m.turn_id IS NOT NULL
+  AND m.turn_position IS NOT NULL
+  AND m.turn_message_seq IS NOT NULL;
+`); err != nil {
+		t.Fatalf("add team query fixture schema: %v", err)
+	}
 
 	userID := uuid.NewString()
 	botID := uuid.NewString()

--- a/internal/handlers/memory.go
+++ b/internal/handlers/memory.go
@@ -69,7 +69,7 @@ type namespaceScope struct {
 
 const (
 	sharedMemoryNamespace    = "bot"
-	defaultBuiltinProviderID = "__builtin_default__"
+	defaultBuiltinProviderID = memprovider.DefaultBuiltinProviderID
 )
 
 // NewMemoryHandler creates a MemoryHandler.
@@ -103,7 +103,7 @@ func (h *MemoryHandler) resolveProvider(ctx context.Context, botID string) (memp
 		if err == nil {
 			providerID := strings.TrimSpace(botSettings.MemoryProviderID)
 			if providerID != "" {
-				p, getErr := h.memoryRegistry.Get(providerID)
+				p, getErr := h.memoryRegistry.Get(ctx, providerID)
 				if getErr == nil {
 					return p, nil
 				}
@@ -112,7 +112,7 @@ func (h *MemoryHandler) resolveProvider(ctx context.Context, botID string) (memp
 			}
 		}
 	}
-	p, err := h.memoryRegistry.Get(defaultBuiltinProviderID)
+	p, err := h.memoryRegistry.Get(ctx, defaultBuiltinProviderID)
 	if err != nil {
 		return nil, nil
 	}

--- a/internal/handlers/skills_test.go
+++ b/internal/handlers/skills_test.go
@@ -502,7 +502,7 @@ func (*skillsTestDB) Query(context.Context, string, ...interface{}) (pgx.Rows, e
 
 func (d *skillsTestDB) QueryRow(_ context.Context, sql string, _ ...interface{}) pgx.Row {
 	switch {
-	case strings.Contains(sql, "FROM users WHERE id = $1"):
+	case strings.Contains(sql, "FROM users") && strings.Contains(sql, "id = $1"):
 		return makeUserRow(mustParseUUID(d.userID), "user")
 	case strings.Contains(sql, "FROM bots"):
 		return makeBotRow(mustParseUUID(d.botID), mustParseUUID(d.userID), d.metadataJSON)

--- a/internal/handlers/users_create_bot_stream_test.go
+++ b/internal/handlers/users_create_bot_stream_test.go
@@ -469,7 +469,7 @@ func (*createBotStreamDB) Query(context.Context, string, ...interface{}) (pgx.Ro
 
 func (d *createBotStreamDB) QueryRow(_ context.Context, query string, args ...any) pgx.Row {
 	switch {
-	case strings.Contains(query, "FROM users") && strings.Contains(query, "WHERE id = $1"):
+	case strings.Contains(query, "FROM users") && strings.Contains(query, "id = $1"):
 		return &createBotStreamRow{scanFunc: func(_ ...any) error { return nil }}
 	case strings.Contains(query, "INSERT INTO bots"):
 		if len(args) > 6 {
@@ -486,7 +486,7 @@ func (d *createBotStreamDB) QueryRow(_ context.Context, query string, args ...an
 		d.metadata = append([]byte(nil), payload...)
 		d.persistedMetadata = append([]byte(nil), payload...)
 		return d.botRow(bots.BotStatusReady)
-	case strings.Contains(query, "FROM bots") && strings.Contains(query, "WHERE id = $1"):
+	case strings.Contains(query, "FROM bots") && strings.Contains(query, "id = $1"):
 		return d.botRow(bots.BotStatusReady)
 	case strings.Contains(query, "FROM bots") && strings.Contains(query, "WHERE name = $1"):
 		return &createBotStreamRow{scanFunc: func(_ ...any) error { return pgx.ErrNoRows }}

--- a/internal/memory/adapters/builtin/builtin.go
+++ b/internal/memory/adapters/builtin/builtin.go
@@ -77,6 +77,18 @@ func (p *BuiltinProvider) SetLLM(llm adapters.LLM) {
 	p.llm = llm
 }
 
+// Close releases runtime-owned resources such as the semantic retry worker.
+// The process-level pgvector Store owns its shared connection pool.
+func (p *BuiltinProvider) Close() error {
+	if p == nil || p.service == nil {
+		return nil
+	}
+	if closer, ok := p.service.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
 // SetPackerConfig overrides the default context packing configuration.
 // Zero-valued fields fall back to defaults.
 func (p *BuiltinProvider) SetPackerConfig(cfg contextPackerConfig) {

--- a/internal/memory/adapters/builtin/factory.go
+++ b/internal/memory/adapters/builtin/factory.go
@@ -1,11 +1,13 @@
 package builtin
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 
 	pgvectordb "github.com/memohai/memoh/internal/db/pgvector"
 	dbstore "github.com/memohai/memoh/internal/db/store"
+	adapters "github.com/memohai/memoh/internal/memory/adapters"
 	storefs "github.com/memohai/memoh/internal/memory/storefs"
 	"github.com/memohai/memoh/internal/memory/wikistore"
 )
@@ -19,14 +21,21 @@ import (
 // relational store. The pgvector semantic seed index itself uses the dedicated
 // [pgvector] database, so Local stores intentionally run graph-only.
 func NewBuiltinRuntimeFromConfig(logger *slog.Logger, providerConfig map[string]any, store *storefs.Service, queries dbstore.Queries, vectorStore *pgvectordb.Store, wikiStore wikistore.Store) (Runtime, error) {
+	return NewBuiltinRuntimeFromConfigContext(context.Background(), logger, providerConfig, store, queries, vectorStore, wikiStore, nil)
+}
+
+// NewBuiltinRuntimeFromConfigContext builds a team-owned runtime. resolver is
+// fixed by the registry at provider instantiation time so asynchronous index
+// retries retain the same team after the request context is gone.
+func NewBuiltinRuntimeFromConfigContext(ctx context.Context, logger *slog.Logger, providerConfig map[string]any, store *storefs.Service, queries dbstore.Queries, vectorStore *pgvectordb.Store, wikiStore wikistore.Store, resolver adapters.TeamIDResolver) (Runtime, error) {
 	if wikiStore == nil {
 		return nil, errors.New("graph runtime: wiki store not configured")
 	}
 	runtime := NewGraphRuntime(logger, wikiStore, store)
-	semantic, err := newPGVectorIndex(logger, providerConfig, queries, vectorStore)
+	semantic, err := newPGVectorIndex(ctx, logger, providerConfig, queries, vectorStore, resolver)
 	if err != nil {
 		return nil, err
 	}
-	runtime.SetSemanticIndex(semantic)
+	runtime.SetSemanticIndex(ctx, semantic)
 	return runtime, nil
 }

--- a/internal/memory/adapters/builtin/graph_runtime.go
+++ b/internal/memory/adapters/builtin/graph_runtime.go
@@ -53,17 +53,27 @@ func NewGraphRuntime(logger *slog.Logger, wikiStore wikistore.Store, fs memorySt
 
 // SetSemanticIndex wires an optional Postgres pgvector seed index. It never
 // owns the memory source of truth; failures only degrade to graph lexical recall.
-func (r *graphRuntime) SetSemanticIndex(index *pgvectorIndex) {
+func (r *graphRuntime) SetSemanticIndex(ctx context.Context, index *pgvectorIndex) {
 	if index == nil {
 		return
 	}
 	r.semantic = index
 	// Failed upserts go to a small per-runtime retry queue; the background
 	// loop drains it so the seed index converges without failing writes.
-	r.retry.start(index)
+	r.retry.start(ctx, index)
 }
 
 func (*graphRuntime) Mode() string { return string(ModeGraph) }
+
+func (r *graphRuntime) Close() error {
+	if r == nil {
+		return nil
+	}
+	if r.retry != nil {
+		r.retry.stop()
+	}
+	return nil
+}
 
 func (r *graphRuntime) MemoryVersion(_ context.Context, botID string) string {
 	if r == nil || r.cache == nil {

--- a/internal/memory/adapters/builtin/pgvector_index.go
+++ b/internal/memory/adapters/builtin/pgvector_index.go
@@ -19,6 +19,7 @@ import (
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	adapters "github.com/memohai/memoh/internal/memory/adapters"
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/team"
 )
 
 const (
@@ -27,12 +28,13 @@ const (
 )
 
 type pgvectorIndex struct {
-	queries    *pgvectorsqlc.Queries
-	lookup     dbstore.Queries
-	embedModel *sdk.EmbeddingModel
-	model      embeddingModelSpec
-	modelRef   string
-	logger     *slog.Logger
+	store       *pgvectordb.Store
+	lookup      dbstore.Queries
+	embedModel  *sdk.EmbeddingModel
+	model       embeddingModelSpec
+	modelRef    string
+	resolveTeam adapters.TeamIDResolver
+	logger      *slog.Logger
 }
 
 type embeddingModelSpec struct {
@@ -44,7 +46,7 @@ type embeddingModelSpec struct {
 	dimensions int
 }
 
-func newPGVectorIndex(logger *slog.Logger, providerConfig map[string]any, queries dbstore.Queries, vectorStore *pgvectordb.Store) (*pgvectorIndex, error) {
+func newPGVectorIndex(ctx context.Context, logger *slog.Logger, providerConfig map[string]any, queries dbstore.Queries, vectorStore *pgvectordb.Store, resolver adapters.TeamIDResolver) (*pgvectorIndex, error) {
 	modelRef := strings.TrimSpace(adapters.StringFromConfig(providerConfig, "embedding_model_id"))
 	if modelRef == "" {
 		return nil, nil
@@ -60,17 +62,21 @@ func newPGVectorIndex(logger *slog.Logger, providerConfig map[string]any, querie
 		logger.Debug("graph: pgvector semantic index disabled without relational query store", slog.String("embedding_model_id", modelRef))
 		return nil, nil
 	}
-	spec, err := resolveEmbeddingModel(context.Background(), queries, modelRef)
+	if resolver == nil {
+		resolver = adapters.FixedTeamIDResolver(team.DefaultTeamID)
+	}
+	spec, err := resolveEmbeddingModel(ctx, queries, modelRef)
 	if err != nil {
 		return nil, err
 	}
 	index := &pgvectorIndex{
-		queries:    vectorStore.Queries(),
-		lookup:     queries,
-		embedModel: models.NewSDKEmbeddingModel(spec.clientType, spec.baseURL, spec.apiKey, spec.modelID, semanticEmbedTimeout, nil),
-		model:      spec,
-		modelRef:   modelRef,
-		logger:     logger,
+		store:       vectorStore,
+		lookup:      queries,
+		embedModel:  models.NewSDKEmbeddingModel(spec.clientType, spec.baseURL, spec.apiKey, spec.modelID, semanticEmbedTimeout, nil),
+		model:       spec,
+		modelRef:    modelRef,
+		resolveTeam: resolver,
+		logger:      logger,
 	}
 	return index, nil
 }
@@ -110,6 +116,49 @@ func (r *pgvectorIndex) lookupQueries() dbstore.Queries {
 	return r.lookup
 }
 
+func (r *pgvectorIndex) teamUUID(ctx context.Context) (pgtype.UUID, error) {
+	if r == nil || r.resolveTeam == nil {
+		return pgtype.UUID{}, errors.New("pgvector semantic index: team resolver is not configured")
+	}
+	teamID, err := r.resolveTeam(ctx)
+	if err != nil {
+		return pgtype.UUID{}, fmt.Errorf("pgvector semantic index: resolve team: %w", err)
+	}
+	teamUUID, err := db.ParseUUID(strings.TrimSpace(teamID))
+	if err != nil {
+		return pgtype.UUID{}, fmt.Errorf("pgvector semantic index: invalid team id: %w", err)
+	}
+	return teamUUID, nil
+}
+
+// withTeamTx binds the RLS context transaction-locally. Queries also include
+// team_id explicitly, so the GUC is a second isolation boundary rather than
+// the only one.
+func (r *pgvectorIndex) withTeamTx(ctx context.Context, fn func(*pgvectorsqlc.Queries, pgtype.UUID) error) error {
+	if r == nil || r.store == nil {
+		return nil
+	}
+	teamUUID, err := r.teamUUID(ctx)
+	if err != nil {
+		return err
+	}
+	tx, err := r.store.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("pgvector semantic index: begin team transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SELECT set_config('memoh.team_id', $1, true)", teamUUID.String()); err != nil {
+		return fmt.Errorf("pgvector semantic index: bind team: %w", err)
+	}
+	if err := fn(r.store.Queries().WithTx(tx), teamUUID); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("pgvector semantic index: commit team transaction: %w", err)
+	}
+	return nil
+}
+
 func (r *pgvectorIndex) embedText(ctx context.Context, text string) ([]float32, error) {
 	if err := r.ensureEmbeddingEnabled(ctx); err != nil {
 		return nil, err
@@ -127,7 +176,7 @@ func (r *pgvectorIndex) embedText(ctx context.Context, text string) ([]float32, 
 }
 
 func (r *pgvectorIndex) Upsert(ctx context.Context, botID, nodeID, body, hash string) error {
-	if r == nil || r.queries == nil || strings.TrimSpace(body) == "" {
+	if r == nil || r.store == nil || strings.TrimSpace(body) == "" {
 		return nil
 	}
 	botUUID, err := db.ParseUUID(botID)
@@ -142,13 +191,16 @@ func (r *pgvectorIndex) Upsert(ctx context.Context, botID, nodeID, body, hash st
 	if err != nil {
 		return err
 	}
-	err = r.queries.UpsertMemoryNodeEmbedding(ctx, pgvectorsqlc.UpsertMemoryNodeEmbeddingParams{
-		BotID:      botUUID,
-		NodeID:     strings.TrimSpace(nodeID),
-		ModelID:    r.model.uuid,
-		Dimensions: dimensions,
-		BodyHash:   strings.TrimSpace(hash),
-		Embedding:  pgvector.NewVector(vec),
+	err = r.withTeamTx(ctx, func(teamQueries *pgvectorsqlc.Queries, teamUUID pgtype.UUID) error {
+		return teamQueries.UpsertMemoryNodeEmbedding(ctx, pgvectorsqlc.UpsertMemoryNodeEmbeddingParams{
+			TeamID:     teamUUID,
+			BotID:      botUUID,
+			NodeID:     strings.TrimSpace(nodeID),
+			ModelID:    r.model.uuid,
+			Dimensions: dimensions,
+			BodyHash:   strings.TrimSpace(hash),
+			Embedding:  pgvector.NewVector(vec),
+		})
 	})
 	if err != nil {
 		return fmt.Errorf("pgvector semantic index: upsert: %w", err)
@@ -157,7 +209,7 @@ func (r *pgvectorIndex) Upsert(ctx context.Context, botID, nodeID, body, hash st
 }
 
 func (r *pgvectorIndex) SearchSeeds(ctx context.Context, botID, query string, limit int) (map[string]float64, error) {
-	if r == nil || r.queries == nil || strings.TrimSpace(query) == "" || limit <= 0 {
+	if r == nil || r.store == nil || strings.TrimSpace(query) == "" || limit <= 0 {
 		return nil, nil
 	}
 	botUUID, err := db.ParseUUID(botID)
@@ -172,23 +224,30 @@ func (r *pgvectorIndex) SearchSeeds(ctx context.Context, botID, query string, li
 	if err != nil {
 		return nil, err
 	}
-	rows, err := r.queries.SearchMemoryNodeEmbeddings(ctx, pgvectorsqlc.SearchMemoryNodeEmbeddingsParams{
-		Embedding: pgvector.NewVector(vec),
-		BotID:     botUUID,
-		ModelID:   r.model.uuid,
-		RowLimit:  rowLimit,
+	seeds := map[string]float64{}
+	err = r.withTeamTx(ctx, func(teamQueries *pgvectorsqlc.Queries, teamUUID pgtype.UUID) error {
+		rows, queryErr := teamQueries.SearchMemoryNodeEmbeddings(ctx, pgvectorsqlc.SearchMemoryNodeEmbeddingsParams{
+			Embedding: pgvector.NewVector(vec),
+			TeamID:    teamUUID,
+			BotID:     botUUID,
+			ModelID:   r.model.uuid,
+			RowLimit:  rowLimit,
+		})
+		if queryErr != nil {
+			return queryErr
+		}
+		for _, row := range rows {
+			nodeID := strings.TrimSpace(row.NodeID)
+			if nodeID != "" {
+				seeds[nodeID] = row.Score
+			}
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("pgvector semantic index: search: %w", err)
 	}
 
-	seeds := map[string]float64{}
-	for _, row := range rows {
-		nodeID := strings.TrimSpace(row.NodeID)
-		if nodeID != "" {
-			seeds[nodeID] = row.Score
-		}
-	}
 	return seeds, nil
 }
 
@@ -200,7 +259,7 @@ func checkedPgvectorInt32(name string, n int) (int32, error) {
 }
 
 func (r *pgvectorIndex) DeleteNodes(ctx context.Context, botID string, nodeIDs []string) error {
-	if r == nil || r.queries == nil || len(nodeIDs) == 0 {
+	if r == nil || r.store == nil || len(nodeIDs) == 0 {
 		return nil
 	}
 	botUUID, err := db.ParseUUID(botID)
@@ -217,9 +276,12 @@ func (r *pgvectorIndex) DeleteNodes(ctx context.Context, botID string, nodeIDs [
 	if len(ids) == 0 {
 		return nil
 	}
-	err = r.queries.DeleteMemoryNodeEmbeddings(ctx, pgvectorsqlc.DeleteMemoryNodeEmbeddingsParams{
-		BotID:   botUUID,
-		NodeIds: ids,
+	err = r.withTeamTx(ctx, func(teamQueries *pgvectorsqlc.Queries, teamUUID pgtype.UUID) error {
+		return teamQueries.DeleteMemoryNodeEmbeddings(ctx, pgvectorsqlc.DeleteMemoryNodeEmbeddingsParams{
+			TeamID:  teamUUID,
+			BotID:   botUUID,
+			NodeIds: ids,
+		})
 	})
 	if err != nil {
 		return fmt.Errorf("pgvector semantic index: delete nodes: %w", err)
@@ -228,14 +290,19 @@ func (r *pgvectorIndex) DeleteNodes(ctx context.Context, botID string, nodeIDs [
 }
 
 func (r *pgvectorIndex) DeleteBot(ctx context.Context, botID string) error {
-	if r == nil || r.queries == nil {
+	if r == nil || r.store == nil {
 		return nil
 	}
 	botUUID, err := db.ParseUUID(botID)
 	if err != nil {
 		return err
 	}
-	err = r.queries.DeleteBotMemoryNodeEmbeddings(ctx, botUUID)
+	err = r.withTeamTx(ctx, func(teamQueries *pgvectorsqlc.Queries, teamUUID pgtype.UUID) error {
+		return teamQueries.DeleteBotMemoryNodeEmbeddings(ctx, pgvectorsqlc.DeleteBotMemoryNodeEmbeddingsParams{
+			TeamID: teamUUID,
+			BotID:  botUUID,
+		})
+	})
 	if err != nil {
 		return fmt.Errorf("pgvector semantic index: delete bot: %w", err)
 	}
@@ -243,16 +310,22 @@ func (r *pgvectorIndex) DeleteBot(ctx context.Context, botID string) error {
 }
 
 func (r *pgvectorIndex) Count(ctx context.Context, botID string) (int, error) {
-	if r == nil || r.queries == nil {
+	if r == nil || r.store == nil {
 		return 0, nil
 	}
 	botUUID, err := db.ParseUUID(botID)
 	if err != nil {
 		return 0, err
 	}
-	count, err := r.queries.CountMemoryNodeEmbeddings(ctx, pgvectorsqlc.CountMemoryNodeEmbeddingsParams{
-		BotID:   botUUID,
-		ModelID: r.model.uuid,
+	var count int64
+	err = r.withTeamTx(ctx, func(teamQueries *pgvectorsqlc.Queries, teamUUID pgtype.UUID) error {
+		var queryErr error
+		count, queryErr = teamQueries.CountMemoryNodeEmbeddings(ctx, pgvectorsqlc.CountMemoryNodeEmbeddingsParams{
+			TeamID:  teamUUID,
+			BotID:   botUUID,
+			ModelID: r.model.uuid,
+		})
+		return queryErr
 	})
 	if err != nil {
 		return 0, fmt.Errorf("pgvector semantic index: count: %w", err)
@@ -264,13 +337,16 @@ func (r *pgvectorIndex) Count(ctx context.Context, botID string) (int, error) {
 }
 
 func (r *pgvectorIndex) Health(ctx context.Context) error {
-	if r == nil || r.queries == nil {
+	if r == nil || r.store == nil {
 		return nil
 	}
 	if err := r.ensureEmbeddingEnabled(ctx); err != nil {
 		return err
 	}
-	if _, err := r.queries.MemoryNodeEmbeddingsExist(ctx); err != nil {
+	if err := r.withTeamTx(ctx, func(teamQueries *pgvectorsqlc.Queries, teamUUID pgtype.UUID) error {
+		_, queryErr := teamQueries.MemoryNodeEmbeddingsExist(ctx, teamUUID)
+		return queryErr
+	}); err != nil {
 		return fmt.Errorf("pgvector semantic index: health: %w", err)
 	}
 	return nil

--- a/internal/memory/adapters/builtin/pgvector_index_test.go
+++ b/internal/memory/adapters/builtin/pgvector_index_test.go
@@ -1,6 +1,13 @@
 package builtin
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+
+	adapters "github.com/memohai/memoh/internal/memory/adapters"
+	"github.com/memohai/memoh/internal/team"
+)
 
 func TestCheckedPGVectorInt32(t *testing.T) {
 	t.Parallel()
@@ -12,5 +19,31 @@ func TestCheckedPGVectorInt32(t *testing.T) {
 	}
 	if _, err := checkedPgvectorInt32("limit", int(maxPgvectorInt32)+1); err == nil {
 		t.Fatal("checkedPgvectorInt32(max+1) succeeded")
+	}
+}
+
+func TestPGVectorTeamResolverDefaultsToSingleton(t *testing.T) {
+	t.Parallel()
+	index := &pgvectorIndex{resolveTeam: adapters.FixedTeamIDResolver(team.DefaultTeamID)}
+	got, err := index.teamUUID(context.Background())
+	if err != nil {
+		t.Fatalf("teamUUID() error = %v", err)
+	}
+	if got.String() != team.DefaultTeamID {
+		t.Fatalf("teamUUID() = %s, want %s", got.String(), team.DefaultTeamID)
+	}
+}
+
+func TestPGVectorTeamResolverFailsClosed(t *testing.T) {
+	t.Parallel()
+	index := &pgvectorIndex{resolveTeam: func(context.Context) (string, error) {
+		return "", errors.New("team missing")
+	}}
+	if _, err := index.teamUUID(context.Background()); err == nil {
+		t.Fatal("teamUUID() without team succeeded")
+	}
+	index.resolveTeam = adapters.FixedTeamIDResolver("not-a-uuid")
+	if _, err := index.teamUUID(context.Background()); err == nil {
+		t.Fatal("teamUUID() with invalid team succeeded")
 	}
 }

--- a/internal/memory/adapters/builtin/retry.go
+++ b/internal/memory/adapters/builtin/retry.go
@@ -36,11 +36,16 @@ type semanticRetryEntry struct {
 // mean the semantic seed index is temporarily behind — never that a write was
 // lost. Deduped by (botID, nodeID): the newest body/hash wins.
 type semanticRetryQueue struct {
-	mu      sync.Mutex
-	pending map[string]semanticRetryEntry
-	order   []string // FIFO keys for capacity eviction
-	started bool
-	logger  *slog.Logger
+	mu       sync.Mutex
+	pending  map[string]semanticRetryEntry
+	order    []string // FIFO keys for capacity eviction
+	started  bool
+	stopped  bool
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	cancel   context.CancelFunc
+	done     chan struct{}
+	logger   *slog.Logger
 }
 
 func newSemanticRetryQueue(logger *slog.Logger) *semanticRetryQueue {
@@ -49,6 +54,7 @@ func newSemanticRetryQueue(logger *slog.Logger) *semanticRetryQueue {
 	}
 	return &semanticRetryQueue{
 		pending: map[string]semanticRetryEntry{},
+		stopCh:  make(chan struct{}),
 		logger:  logger,
 	}
 }
@@ -163,25 +169,61 @@ func (q *semanticRetryQueue) flush(ctx context.Context, index semanticUpserter) 
 	}
 }
 
-// start launches the background retry loop. Idempotent. The loop lives for
-// the process lifetime, matching the runtime it belongs to.
-func (q *semanticRetryQueue) start(index semanticUpserter) {
+// start launches the background retry loop. Idempotent. The loop lives until
+// the owning runtime closes it.
+func (q *semanticRetryQueue) start(ctx context.Context, index semanticUpserter) {
+	if index == nil {
+		return
+	}
+	workerCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	q.mu.Lock()
-	if q.started || index == nil {
+	if q.started || q.stopped {
 		q.mu.Unlock()
+		cancel()
 		return
 	}
 	q.started = true
+	q.cancel = cancel
+	q.done = make(chan struct{})
+	done := q.done
 	q.mu.Unlock()
 
 	go func() {
+		defer close(done)
 		ticker := time.NewTicker(semanticRetryInterval)
 		defer ticker.Stop()
-		for range ticker.C {
-			if q.depth("") == 0 {
-				continue
+		for {
+			select {
+			case <-ticker.C:
+				if q.depth("") == 0 {
+					continue
+				}
+				q.flush(workerCtx, index)
+			case <-workerCtx.Done():
+				return
+			case <-q.stopCh:
+				return
 			}
-			q.flush(context.Background(), index)
 		}
 	}()
+}
+
+func (q *semanticRetryQueue) stop() {
+	if q == nil {
+		return
+	}
+	q.stopOnce.Do(func() {
+		q.mu.Lock()
+		q.stopped = true
+		cancel := q.cancel
+		done := q.done
+		q.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		close(q.stopCh)
+		if done != nil {
+			<-done
+		}
+	})
 }

--- a/internal/memory/adapters/builtin/retry_test.go
+++ b/internal/memory/adapters/builtin/retry_test.go
@@ -138,3 +138,23 @@ func TestSemanticRetryQueueCapacityEvictsOldest(t *testing.T) {
 		t.Fatal("newest entry should be present")
 	}
 }
+
+func TestSemanticRetryQueueStopIsIdempotent(t *testing.T) {
+	t.Parallel()
+	q := newSemanticRetryQueue(nil)
+	q.start(context.Background(), &fakeUpserter{})
+
+	q.stop()
+	q.stop()
+
+	select {
+	case <-q.stopCh:
+	default:
+		t.Fatal("stop channel remains open")
+	}
+	select {
+	case <-q.done:
+	default:
+		t.Fatal("retry worker remains active after stop")
+	}
+}

--- a/internal/memory/adapters/provider.go
+++ b/internal/memory/adapters/provider.go
@@ -8,6 +8,10 @@ import (
 
 const ToolSearchMemory = "search_memory"
 
+// DefaultBuiltinProviderID is the virtual provider selected when a bot has no
+// persisted memory_provider_id. Registries materialize it per team.
+const DefaultBuiltinProviderID = "__builtin_default__"
+
 // Provider is the unified interface for memory systems. Each provider type
 // (builtin, mem0, openviking, etc.) implements this independently with its
 // own storage, retrieval, and tool logic.

--- a/internal/memory/adapters/registry.go
+++ b/internal/memory/adapters/registry.go
@@ -1,35 +1,86 @@
 package adapters
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
+
+	"github.com/memohai/memoh/internal/team"
 )
 
 // Factory creates a Provider from a provider type string and JSON config.
 // The registry uses factories to lazily instantiate providers from DB rows.
-type Factory func(id string, config map[string]any) (Provider, error)
+type Factory func(ctx context.Context, teamID, id string, config map[string]any) (Provider, error)
+
+// TeamIDResolver resolves the team that owns a memory operation. Hosted
+// deployments can inject a strict request-context resolver; upstream defaults
+// to its published singleton team.
+type TeamIDResolver func(context.Context) (string, error)
+
+// ProviderConfigLoader loads one provider configuration under the team
+// already bound to ctx. It lets a registry lazily instantiate providers on
+// first use instead of requiring an all-team startup scan.
+type ProviderConfigLoader func(ctx context.Context, id string) (providerType string, config map[string]any, err error)
+
+// TeamDefaultFactory creates the builtin fallback independently for each
+// team. It is used for bots without an explicit memory provider.
+type TeamDefaultFactory func(ctx context.Context, teamID string) (Provider, error)
+
+type providerCloser interface {
+	Close() error
+}
+
+type registryKey struct {
+	teamID     string
+	providerID string
+}
 
 // Registry manages provider instances keyed by their DB id.
 // It caches instantiated providers and uses registered factories to create
 // them on demand from stored configuration.
 type Registry struct {
-	mu        sync.RWMutex
-	instances map[string]Provider
-	factories map[string]Factory
-	logger    *slog.Logger
+	mu             sync.RWMutex
+	instances      map[registryKey]Provider
+	factories      map[string]Factory
+	resolveTeam    TeamIDResolver
+	configLoader   ProviderConfigLoader
+	defaultFactory TeamDefaultFactory
+	logger         *slog.Logger
 }
 
-func NewRegistry(log *slog.Logger) *Registry {
+func NewRegistry(log *slog.Logger, resolvers ...TeamIDResolver) *Registry {
 	if log == nil {
 		log = slog.Default()
 	}
+	resolver := defaultTeamIDResolver
+	if len(resolvers) > 0 && resolvers[0] != nil {
+		resolver = resolvers[0]
+	}
 	return &Registry{
-		instances: map[string]Provider{},
-		factories: map[string]Factory{},
-		logger:    log.With(slog.String("component", "memory_provider_registry")),
+		instances:   map[registryKey]Provider{},
+		factories:   map[string]Factory{},
+		resolveTeam: resolver,
+		logger:      log.With(slog.String("component", "memory_provider_registry")),
+	}
+}
+
+func defaultTeamIDResolver(context.Context) (string, error) {
+	return team.DefaultTeamID, nil
+}
+
+// FixedTeamIDResolver returns a resolver permanently scoped to teamID.
+// Provider factories use this for team-owned runtimes whose background work
+// may outlive the request context that instantiated them.
+func FixedTeamIDResolver(teamID string) TeamIDResolver {
+	teamID = strings.TrimSpace(teamID)
+	return func(context.Context) (string, error) {
+		if teamID == "" {
+			return "", errors.New("memory team id is required")
+		}
+		return teamID, nil
 	}
 }
 
@@ -40,64 +91,176 @@ func (r *Registry) RegisterFactory(providerType string, factory Factory) {
 	r.factories[strings.TrimSpace(providerType)] = factory
 }
 
-// Register adds a pre-built provider instance by ID.
-func (r *Registry) Register(id string, provider Provider) {
+// SetConfigLoader configures lazy provider lookup for cache misses.
+func (r *Registry) SetConfigLoader(loader ProviderConfigLoader) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.instances[strings.TrimSpace(id)] = provider
+	r.configLoader = loader
 }
 
-// Get returns the provider for the given DB record ID.
-func (r *Registry) Get(id string) (Provider, error) {
+// SetTeamDefaultFactory configures lazy, team-owned builtin fallbacks.
+func (r *Registry) SetTeamDefaultFactory(factory TeamDefaultFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.defaultFactory = factory
+}
+
+// Register adds a pre-built provider instance by ID.
+func (r *Registry) Register(id string, provider Provider) {
+	if err := r.RegisterContext(context.Background(), id, provider); err != nil {
+		r.logger.Error("register memory provider failed", slog.String("id", id), slog.Any("error", err))
+	}
+}
+
+// RegisterContext adds a pre-built provider under the team resolved from ctx.
+func (r *Registry) RegisterContext(ctx context.Context, id string, provider Provider) error {
+	key, err := r.key(ctx, id)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	previous := r.instances[key]
+	r.instances[key] = provider
+	r.mu.Unlock()
+	if previous != nil && previous != provider {
+		closeProvider(previous)
+	}
+	return nil
+}
+
+// Get returns the team-owned provider for the given DB record ID. Cache
+// misses are loaded and instantiated under the same team scope.
+func (r *Registry) Get(ctx context.Context, id string) (Provider, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return nil, errors.New("provider id is required")
 	}
+	key, err := r.key(ctx, id)
+	if err != nil {
+		return nil, err
+	}
 	r.mu.RLock()
-	p, ok := r.instances[id]
+	p, ok := r.instances[key]
+	loader := r.configLoader
+	defaultFactory := r.defaultFactory
 	r.mu.RUnlock()
 	if ok {
 		return p, nil
+	}
+	if id == DefaultBuiltinProviderID && defaultFactory != nil {
+		return r.instantiateDefault(ctx, key, defaultFactory)
+	}
+	if loader != nil {
+		providerType, config, err := loader(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("load memory provider %s for team %s: %w", id, key.teamID, err)
+		}
+		return r.instantiate(ctx, key, providerType, config)
 	}
 	return nil, fmt.Errorf("memory provider not found: %s", id)
 }
 
 // Instantiate creates a provider from a DB row and caches it.
 // If the instance already exists, it is returned directly.
-func (r *Registry) Instantiate(id, providerType string, config map[string]any) (Provider, error) {
+func (r *Registry) Instantiate(ctx context.Context, id, providerType string, config map[string]any) (Provider, error) {
 	id = strings.TrimSpace(id)
 	providerType = strings.TrimSpace(providerType)
-
-	r.mu.RLock()
-	if p, ok := r.instances[id]; ok {
-		r.mu.RUnlock()
-		return p, nil
+	key, err := r.key(ctx, id)
+	if err != nil {
+		return nil, err
 	}
-	r.mu.RUnlock()
+	return r.instantiate(ctx, key, providerType, config)
+}
 
+func (r *Registry) instantiate(ctx context.Context, key registryKey, providerType string, config map[string]any) (Provider, error) {
+	// Factory construction is serialized with Remove. Besides deduplicating
+	// concurrent cache misses, this prevents an in-flight old configuration
+	// from being stored after Update has evicted it.
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
-	// Double-check after acquiring write lock.
-	if p, ok := r.instances[id]; ok {
+	if p, ok := r.instances[key]; ok {
 		return p, nil
 	}
-
 	factory, ok := r.factories[providerType]
 	if !ok {
 		return nil, fmt.Errorf("unknown memory provider type: %s", providerType)
 	}
-	p, err := factory(id, config)
+	p, err := factory(ctx, key.teamID, key.providerID, config)
 	if err != nil {
-		return nil, fmt.Errorf("instantiate memory provider %s (%s): %w", id, providerType, err)
+		return nil, fmt.Errorf("instantiate memory provider %s (%s) for team %s: %w", key.providerID, providerType, key.teamID, err)
 	}
-	r.instances[id] = p
+	r.instances[key] = p
+	return p, nil
+}
+
+func (r *Registry) instantiateDefault(ctx context.Context, key registryKey, factory TeamDefaultFactory) (Provider, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if p, ok := r.instances[key]; ok {
+		return p, nil
+	}
+	p, err := factory(ctx, key.teamID)
+	if err != nil {
+		return nil, fmt.Errorf("instantiate default memory provider for team %s: %w", key.teamID, err)
+	}
+	r.instances[key] = p
 	return p, nil
 }
 
 // Remove evicts a cached provider instance (e.g. after config update or delete).
-func (r *Registry) Remove(id string) {
+func (r *Registry) Remove(ctx context.Context, id string) error {
+	key, err := r.key(ctx, id)
+	if err != nil {
+		return err
+	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.instances, strings.TrimSpace(id))
+	provider := r.instances[key]
+	delete(r.instances, key)
+	r.mu.Unlock()
+	closeProvider(provider)
+	return nil
+}
+
+// Close releases every instantiated provider. It is safe to call more than
+// once and is used during process shutdown as well as team registry teardown.
+func (r *Registry) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	providers := make([]Provider, 0, len(r.instances))
+	for key, provider := range r.instances {
+		providers = append(providers, provider)
+		delete(r.instances, key)
+	}
+	r.mu.Unlock()
+	for _, provider := range providers {
+		closeProvider(provider)
+	}
+	return nil
+}
+
+func closeProvider(provider Provider) {
+	if closer, ok := provider.(providerCloser); ok && closer != nil {
+		_ = closer.Close()
+	}
+}
+
+func (r *Registry) key(ctx context.Context, id string) (registryKey, error) {
+	if r == nil || r.resolveTeam == nil {
+		return registryKey{}, errors.New("memory team resolver is not configured")
+	}
+	teamID, err := r.resolveTeam(ctx)
+	if err != nil {
+		return registryKey{}, fmt.Errorf("resolve memory team: %w", err)
+	}
+	teamID = strings.TrimSpace(teamID)
+	id = strings.TrimSpace(id)
+	if teamID == "" {
+		return registryKey{}, errors.New("memory team id is required")
+	}
+	if id == "" {
+		return registryKey{}, errors.New("provider id is required")
+	}
+	return registryKey{teamID: teamID, providerID: id}, nil
 }

--- a/internal/memory/adapters/service.go
+++ b/internal/memory/adapters/service.go
@@ -144,7 +144,7 @@ func (s *Service) Create(ctx context.Context, req ProviderCreateRequest) (Provid
 		return ProviderGetResponse{}, fmt.Errorf("create memory provider: %w", err)
 	}
 	resp := s.toGetResponse(row)
-	s.tryInstantiate(resp.ID, resp.Provider, resp.Config)
+	s.tryInstantiate(ctx, resp.ID, resp.Provider, resp.Config)
 	return resp, nil
 }
 
@@ -199,7 +199,7 @@ func (s *Service) InstantiateAll(ctx context.Context) (int, error) {
 	loaded := 0
 	for _, row := range rows {
 		resp := s.toGetResponse(row)
-		if _, err := s.registry.Instantiate(resp.ID, resp.Provider, resp.Config); err != nil {
+		if _, err := s.registry.Instantiate(ctx, resp.ID, resp.Provider, resp.Config); err != nil {
 			s.logger.Warn("auto-instantiate memory provider failed",
 				slog.String("id", resp.ID), slog.String("provider", resp.Provider), slog.Any("error", err))
 			continue
@@ -239,7 +239,7 @@ func (s *Service) Update(ctx context.Context, id string, req ProviderUpdateReque
 		return ProviderGetResponse{}, fmt.Errorf("update memory provider: %w", err)
 	}
 	resp := s.toGetResponse(updated)
-	s.tryEvictAndReinstantiate(resp.ID, resp.Provider, resp.Config)
+	s.tryEvictAndReinstantiate(ctx, resp.ID, resp.Provider, resp.Config)
 	return resp, nil
 }
 
@@ -252,7 +252,9 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	if s.registry != nil {
-		s.registry.Remove(id)
+		if err := s.registry.Remove(ctx, id); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -294,22 +296,25 @@ func (s *Service) toGetResponse(row sqlc.MemoryProvider) ProviderGetResponse {
 	}
 }
 
-func (s *Service) tryInstantiate(id, providerType string, config map[string]any) {
+func (s *Service) tryInstantiate(ctx context.Context, id, providerType string, config map[string]any) {
 	if s.registry == nil {
 		return
 	}
-	if _, err := s.registry.Instantiate(id, providerType, config); err != nil {
+	if _, err := s.registry.Instantiate(ctx, id, providerType, config); err != nil {
 		s.logger.Warn("auto-instantiate memory provider failed",
 			slog.String("id", id), slog.String("provider", providerType), slog.Any("error", err))
 	}
 }
 
-func (s *Service) tryEvictAndReinstantiate(id, providerType string, config map[string]any) {
+func (s *Service) tryEvictAndReinstantiate(ctx context.Context, id, providerType string, config map[string]any) {
 	if s.registry == nil {
 		return
 	}
-	s.registry.Remove(id)
-	s.tryInstantiate(id, providerType, config)
+	if err := s.registry.Remove(ctx, id); err != nil {
+		s.logger.Warn("evict memory provider failed", slog.String("id", id), slog.Any("error", err))
+		return
+	}
+	s.tryInstantiate(ctx, id, providerType, config)
 }
 
 func isValidProviderType(t ProviderType) bool {

--- a/internal/memory/adapters/service_test.go
+++ b/internal/memory/adapters/service_test.go
@@ -2,8 +2,12 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -24,9 +28,17 @@ func (q *providerBootstrapQueries) ListMemoryProviders(context.Context) ([]sqlc.
 
 type bootstrapProvider struct {
 	providerType string
+	closeCalls   *atomic.Int32
 }
 
 func (p *bootstrapProvider) Type() string { return p.providerType }
+
+func (p *bootstrapProvider) Close() error {
+	if p.closeCalls != nil {
+		p.closeCalls.Add(1)
+	}
+	return nil
+}
 
 func (*bootstrapProvider) OnBeforeChat(context.Context, BeforeChatRequest) (*BeforeChatResult, error) {
 	return nil, nil
@@ -83,7 +95,7 @@ func TestInstantiateAllLoadsConfiguredProvidersIntoRegistry(t *testing.T) {
 
 	providerID := pgtype.UUID{Bytes: [16]byte{1, 2, 3}, Valid: true}
 	registry := NewRegistry(slog.Default())
-	registry.RegisterFactory(string(ProviderMem0), func(_ string, _ map[string]any) (Provider, error) {
+	registry.RegisterFactory(string(ProviderMem0), func(_ context.Context, _, _ string, _ map[string]any) (Provider, error) {
 		return &bootstrapProvider{providerType: string(ProviderMem0)}, nil
 	})
 	service := NewService(slog.Default(), &providerBootstrapQueries{
@@ -103,7 +115,209 @@ func TestInstantiateAllLoadsConfiguredProvidersIntoRegistry(t *testing.T) {
 	if loaded != 1 {
 		t.Fatalf("loaded providers = %d, want 1", loaded)
 	}
-	if _, err := registry.Get(providerID.String()); err != nil {
+	if _, err := registry.Get(context.Background(), providerID.String()); err != nil {
 		t.Fatalf("registry missing configured provider after InstantiateAll(): %v", err)
+	}
+}
+
+type registryTeamContextKey struct{}
+
+func registryTeamResolver(ctx context.Context) (string, error) {
+	teamID, _ := ctx.Value(registryTeamContextKey{}).(string)
+	if teamID == "" {
+		return "", errors.New("team missing")
+	}
+	return teamID, nil
+}
+
+func teamRegistryContext(teamID string) context.Context {
+	return context.WithValue(context.Background(), registryTeamContextKey{}, teamID)
+}
+
+func TestRegistryIsolatesSameProviderIDByTeam(t *testing.T) {
+	t.Parallel()
+	registry := NewRegistry(slog.Default(), registryTeamResolver)
+	registry.RegisterFactory(string(ProviderMem0), func(_ context.Context, teamID, _ string, _ map[string]any) (Provider, error) {
+		return &bootstrapProvider{providerType: teamID}, nil
+	})
+	registry.SetConfigLoader(func(_ context.Context, _ string) (string, map[string]any, error) {
+		return string(ProviderMem0), map[string]any{}, nil
+	})
+
+	teamA := teamRegistryContext("team-a")
+	teamB := teamRegistryContext("team-b")
+	providerA, err := registry.Get(teamA, "shared-provider-id")
+	if err != nil {
+		t.Fatalf("Get(team-a) error = %v", err)
+	}
+	providerB, err := registry.Get(teamB, "shared-provider-id")
+	if err != nil {
+		t.Fatalf("Get(team-b) error = %v", err)
+	}
+	if providerA == providerB {
+		t.Fatal("same provider id reused one instance across teams")
+	}
+	providerAAgain, err := registry.Get(teamA, "shared-provider-id")
+	if err != nil {
+		t.Fatalf("second Get(team-a) error = %v", err)
+	}
+	if providerAAgain != providerA {
+		t.Fatal("team-local provider instance was not cached")
+	}
+}
+
+func TestRegistryConcurrentMissInstantiatesOnce(t *testing.T) {
+	t.Parallel()
+	registry := NewRegistry(slog.Default())
+	var factoryCalls atomic.Int32
+	registry.RegisterFactory(string(ProviderMem0), func(_ context.Context, _, _ string, _ map[string]any) (Provider, error) {
+		factoryCalls.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		return &bootstrapProvider{providerType: string(ProviderMem0)}, nil
+	})
+	registry.SetConfigLoader(func(_ context.Context, _ string) (string, map[string]any, error) {
+		return string(ProviderMem0), map[string]any{}, nil
+	})
+
+	const workers = 24
+	providers := make([]Provider, workers)
+	errs := make([]error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := range workers {
+		go func() {
+			defer wg.Done()
+			providers[i], errs[i] = registry.Get(context.Background(), "provider-id")
+		}()
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Get() worker %d error = %v", i, err)
+		}
+		if providers[i] != providers[0] {
+			t.Fatalf("worker %d received a different provider instance", i)
+		}
+	}
+	if got := factoryCalls.Load(); got != 1 {
+		t.Fatalf("factory calls = %d, want 1", got)
+	}
+}
+
+func TestRegistryUpdateCannotBeOverwrittenByInflightLoad(t *testing.T) {
+	t.Parallel()
+	registry := NewRegistry(slog.Default())
+	oldFactoryStarted := make(chan struct{})
+	releaseOldFactory := make(chan struct{})
+	registry.RegisterFactory(string(ProviderMem0), func(_ context.Context, _, _ string, config map[string]any) (Provider, error) {
+		version, _ := config["version"].(string)
+		if version == "old" {
+			close(oldFactoryStarted)
+			<-releaseOldFactory
+		}
+		return &bootstrapProvider{providerType: version}, nil
+	})
+	registry.SetConfigLoader(func(_ context.Context, _ string) (string, map[string]any, error) {
+		return string(ProviderMem0), map[string]any{"version": "old"}, nil
+	})
+
+	oldResult := make(chan Provider, 1)
+	oldErr := make(chan error, 1)
+	go func() {
+		provider, err := registry.Get(context.Background(), "provider-id")
+		oldResult <- provider
+		oldErr <- err
+	}()
+	<-oldFactoryStarted
+
+	updateErr := make(chan error, 1)
+	go func() {
+		if err := registry.Remove(context.Background(), "provider-id"); err != nil {
+			updateErr <- err
+			return
+		}
+		_, err := registry.Instantiate(context.Background(), "provider-id", string(ProviderMem0), map[string]any{"version": "new"})
+		updateErr <- err
+	}()
+	close(releaseOldFactory)
+	if err := <-oldErr; err != nil {
+		t.Fatalf("in-flight Get() error = %v", err)
+	}
+	if provider := <-oldResult; provider == nil {
+		t.Fatal("in-flight Get() returned nil provider")
+	}
+	if err := <-updateErr; err != nil {
+		t.Fatalf("update registry error = %v", err)
+	}
+
+	provider, err := registry.Get(context.Background(), "provider-id")
+	if err != nil {
+		t.Fatalf("Get() after update error = %v", err)
+	}
+	if got := provider.Type(); got != "new" {
+		t.Fatalf("provider after update = %q, want new", got)
+	}
+}
+
+func TestRegistryFailsClosedWithoutTeam(t *testing.T) {
+	t.Parallel()
+	registry := NewRegistry(slog.Default(), registryTeamResolver)
+	if _, err := registry.Get(context.Background(), "provider-id"); err == nil {
+		t.Fatal("Get() without team context succeeded")
+	}
+}
+
+func TestRegistryRemoveClosesProvider(t *testing.T) {
+	t.Parallel()
+	registry := NewRegistry(slog.Default())
+	var closeCalls atomic.Int32
+	provider := &bootstrapProvider{providerType: string(ProviderMem0), closeCalls: &closeCalls}
+	if err := registry.RegisterContext(context.Background(), "provider-id", provider); err != nil {
+		t.Fatalf("RegisterContext() error = %v", err)
+	}
+
+	if err := registry.Remove(context.Background(), "provider-id"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if got := closeCalls.Load(); got != 1 {
+		t.Fatalf("Close() calls after Remove() = %d, want 1", got)
+	}
+	if err := registry.Remove(context.Background(), "provider-id"); err != nil {
+		t.Fatalf("second Remove() error = %v", err)
+	}
+	if got := closeCalls.Load(); got != 1 {
+		t.Fatalf("Close() calls after second Remove() = %d, want 1", got)
+	}
+}
+
+func TestRegistryCloseClosesAllProvidersOnce(t *testing.T) {
+	t.Parallel()
+	registry := NewRegistry(slog.Default())
+	var firstCloseCalls atomic.Int32
+	var secondCloseCalls atomic.Int32
+	if err := registry.RegisterContext(context.Background(), "first", &bootstrapProvider{
+		providerType: string(ProviderMem0),
+		closeCalls:   &firstCloseCalls,
+	}); err != nil {
+		t.Fatalf("RegisterContext(first) error = %v", err)
+	}
+	if err := registry.RegisterContext(context.Background(), "second", &bootstrapProvider{
+		providerType: string(ProviderMem0),
+		closeCalls:   &secondCloseCalls,
+	}); err != nil {
+		t.Fatalf("RegisterContext(second) error = %v", err)
+	}
+
+	if err := registry.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if err := registry.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+	if got := firstCloseCalls.Load(); got != 1 {
+		t.Fatalf("first provider Close() calls = %d, want 1", got)
+	}
+	if got := secondCloseCalls.Load(); got != 1 {
+		t.Fatalf("second provider Close() calls = %d, want 1", got)
 	}
 }

--- a/internal/message/compaction_concurrency_postgres_integration_test.go
+++ b/internal/message/compaction_concurrency_postgres_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	dbpkg "github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
 	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
 )
@@ -32,7 +33,7 @@ func setupCommittedCompactionFixture(t *testing.T) committedCompactionFixture {
 		t.Skip("TEST_POSTGRES_DSN is not set")
 	}
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
+	pool, err := dbpkg.OpenPostgresDSN(ctx, dsn)
 	if err != nil {
 		t.Fatalf("connect postgres: %v", err)
 	}

--- a/internal/message/service_postgres_integration_test.go
+++ b/internal/message/service_postgres_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
 	dbpkg "github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
@@ -266,7 +265,7 @@ func beginPostgresMessageTestTx(t *testing.T, ctx context.Context) pgx.Tx {
 	if dsn == "" {
 		t.Skip("skip postgres integration test: TEST_POSTGRES_DSN is not set")
 	}
-	pool, err := pgxpool.New(ctx, dsn)
+	pool, err := dbpkg.OpenPostgresDSN(ctx, dsn)
 	if err != nil {
 		t.Fatalf("connect to configured postgres integration database: %v", err)
 	}

--- a/internal/schedule/service_integration_test.go
+++ b/internal/schedule/service_integration_test.go
@@ -28,7 +28,7 @@ func setupScheduleIntegrationTest(t *testing.T) (*schedule.Service, dbstore.Quer
 	}
 
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
+	pool, err := db.OpenPostgresDSN(ctx, dsn)
 	if err != nil {
 		t.Skipf("skip integration test: cannot connect to database: %v", err)
 	}
@@ -80,6 +80,7 @@ func createUserBotAndSchedule(ctx context.Context, t *testing.T, queries dbstore
 	meta, _ := json.Marshal(map[string]any{"source": "schedule-integration-test"})
 	botRow, err := queries.CreateBot(ctx, sqlc.CreateBotParams{
 		OwnerUserID: pgOwnerID,
+		Name:        "schedule-test-bot",
 		DisplayName: pgtype.Text{String: "schedule-test-bot", Valid: true},
 		AvatarUrl:   pgtype.Text{},
 		IsActive:    true,

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
+	dbpkg "github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
 	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
 	message "github.com/memohai/memoh/internal/message"
@@ -655,7 +655,7 @@ func beginPostgresSessionTestTx(t *testing.T, ctx context.Context) pgx.Tx {
 	if dsn == "" {
 		t.Skip("skip postgres integration test: TEST_POSTGRES_DSN is not set")
 	}
-	pool, err := pgxpool.New(ctx, dsn)
+	pool, err := dbpkg.OpenPostgresDSN(ctx, dsn)
 	if err != nil {
 		t.Skipf("skip postgres integration test: cannot connect to database: %v", err)
 	}

--- a/internal/team/id.go
+++ b/internal/team/id.go
@@ -1,0 +1,11 @@
+// Package team holds the default team identity used by self-hosted Memoh.
+package team
+
+// DefaultTeamID is the stable, published identity of the singleton team used
+// by self-hosted (single-team) installs. It is a fixed constant — NEVER
+// generated per install — so that migrations, fixtures, and application code can
+// reference the same value across environments.
+//
+// It is seeded by migration 0111_team_core and referenced as the backfill
+// value when propagating team_id onto existing business rows.
+const DefaultTeamID = "00000000-0000-0000-0000-000000000001"

--- a/internal/team/id.go
+++ b/internal/team/id.go
@@ -6,6 +6,6 @@ package team
 // generated per install — so that migrations, fixtures, and application code can
 // reference the same value across environments.
 //
-// It is seeded by migration 0111_team_core and referenced as the backfill
+// It is seeded by migration 0112_team_core and referenced as the backfill
 // value when propagating team_id onto existing business rows.
 const DefaultTeamID = "00000000-0000-0000-0000-000000000001"


### PR DESCRIPTION
## Summary

Adds a first-class team core to the PostgreSQL data plane as a compatible
in-place upgrade. Self-hosted Memoh remains single-team by default.

- `teams` root plus a stable default singleton team
- `team_id` propagation and in-place backfill across all Memoh-owned tables,
  including `user_runtimes` and `bot_remote_runtime_bindings`
- Existing primary keys remain stable; team-prefixed unique keys support
  composite team-safe foreign keys
- Natural unique constraints and indexes are team-scoped
- Existing `ON DELETE SET NULL` behavior is preserved with PostgreSQL column
  lists, so only the reference column is cleared and `team_id` stays intact
- `public.memoh_current_team_id()` plus `memoh.team_id` connection binding
- Explicit team predicates across sqlc queries
- ENABLE + FORCE RLS team policies and a minimal `memoh_app` runtime role for
  the official Compose deployment
- `security_invoker` team-safe history view and team-prefixed btree indexes
- Memory providers are cached by `(team_id, provider_id)` with lazy loading and cleanup
- Runtime pgvector embeddings carry `team_id`, explicit DML scope, and FORCE RLS
- Pgvector schema bootstrap is database-versioned and serialized with a
  transaction advisory lock; Health performs no DDL
- DingTalk, Discord, Telegram, and WeCom mutable caches are channel-config scoped
- Existing Compose volumes idempotently provision `memoh_app` before migrations;
  one-click upgrades add missing runtime-role fields without overriding explicit
  or external-database configuration

## Upstream Boundary

This PR targets the open-source singleton runtime. Upstream now defines the
minimum deployment contract required for RLS to be real: application queries
must run as a role without `SUPERUSER`/`BYPASSRLS`. The official Compose stack
provisions one NOLOGIN `memoh_app` role, migrations remain database-owner
operations, and server/pgvector pools use `SET ROLE memoh_app` on connect.

It intentionally does not include hosted deployment topology:

- no hosted owner/migrator/read-only/break-glass role hierarchy
- no `CREATEROLE` or `BYPASSRLS` migration requirement
- no write-fence table, fencing token, or CAS functions
- no trusted-header, placement, Cell, or per-team pool adapter
- no request-scoped hosted team context fallback
- no Cloud fork packages or private planning inventory

Dynamic DDL is limited to Memoh-managed tables identified by the team default
or root FK. User-created tables in `public` are left untouched. Third-party
protocol terminology such as Feishu `TenantKey` remains unchanged.

## Migration Facts

- Rebased baseline: `7ade26bd` (`origin/main`)
- PostgreSQL migration head before this PR: `0110_decision_workspace_target`
- This PR contributes exactly one paired migration:
  `0111_team_core.{up,down}.sql`
- Existing migrations through `0110`, including historical `0001`, are untouched
- The migration remains runnable by a database owner without `CREATEROLE`,
  superuser, or `BYPASSRLS`

## Compose Upgrade Behavior

- `postgres-bootstrap` and `pgvector-bootstrap` run after database health and
  before migrations/server, including for volumes created by older releases
- The bootstrap creates or hardens `memoh_app` as
  `NOLOGIN NOSUPERUSER NOBYPASSRLS` and grants owner membership
- The one-click installer adds `runtime_role = "memoh_app"` only when a legacy
  config still targets the official `postgres`/`pgvector` service and omits the
  field; explicit values, empty values, external hosts, and file permissions are
  preserved
- The minimal installed workspace retains the bootstrap script referenced by
  Compose after the temporary clone is removed

## Verification

- [x] `mise run lint`
- [x] `go test ./...`
- [x] targeted memory/channel race tests
- [x] deterministic `mise run sqlc-generate`
- [x] PostgreSQL 18 full chain through `0110 -> 0111`
- [x] PostgreSQL 18 team up/down/up and legacy upgrade row preservation
- [x] Cross-team FK and RLS isolation tests, including the Compose `memoh_app` role
- [x] `user_runtimes` and `bot_remote_runtime_bindings` composite key/FK/RLS coverage
- [x] Column-scoped `ON DELETE SET NULL` regression tests
- [x] Fresh and existing-volume Compose role/extension bootstrap validation
- [x] Legacy config upgrade, explicit-value preservation, and `0600` mode preservation
- [x] Production, China mirror, dev, and minify Compose configuration validation
- [x] Pgvector bootstrap twice against PostgreSQL 18 with version and runtime-role checks
- [x] User-created `public` table remains unchanged
- [x] Existing schedule, session, channel identity, message, and compaction
  PostgreSQL integration suites

The branch history is organized as four final-design commits covering the data
plane, channel caches, memory/pgvector, and deployment. The post-rewrite CI run
is green; the PR remains draft for final maintainer review.
