### PR TITLE
feat(runtime): add local session state core

### DIFF
--- a/internal/conversation/types.go
+++ b/internal/conversation/types.go
@@ -316,6 +316,7 @@ type InjectMessage struct {
 	Text            string
 	Attachments     []ChatAttachment
 	HeaderifiedText string
+	Applied         func()
 }
 
 // InjectedMessageRecord records a message that was injected via PrepareStep,

--- a/internal/sessionruntime/commands.go
+++ b/internal/sessionruntime/commands.go
@@ -1,0 +1,616 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func (m *Manager) StreamRef(ctx context.Context, streamID string) (StreamRef, bool, error) {
+	streamID = strings.TrimSpace(streamID)
+	if m == nil || m.backend == nil || streamID == "" {
+		return StreamRef{}, false, nil
+	}
+	if ctrl := m.localControl(streamID); ctrl != nil {
+		return StreamRef{BotID: ctrl.botID, SessionID: ctrl.sessionID, StreamID: ctrl.streamID}, true, nil
+	}
+	if m.distributed == nil {
+		return StreamRef{}, false, nil
+	}
+	return m.distributed.LoadStreamRef(ctx, streamID)
+}
+
+// ValidateRunOwnership fails closed before durable side effects when this
+// process no longer owns the active runtime run.
+func (m *Manager) ValidateRunOwnership(ctx context.Context, botID, sessionID, streamID string) error {
+	if m == nil || m.backend == nil {
+		return errors.New("session runtime manager is not configured")
+	}
+	streamID = strings.TrimSpace(streamID)
+	ctrl := m.localControl(streamID)
+	if ctrl == nil || ctrl.botID != strings.TrimSpace(botID) || ctrl.sessionID != strings.TrimSpace(sessionID) {
+		return ErrRunOwnershipLost
+	}
+	key := Key{BotID: strings.TrimSpace(botID), SessionID: strings.TrimSpace(sessionID)}
+	if m.distributed == nil {
+		snapshot, ok, err := m.backend.Load(ctx, key)
+		if err != nil {
+			return fmt.Errorf("validate runtime ownership: %w", err)
+		}
+		if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != streamID || !m.runOwnerMatches(snapshot.CurrentRunView) || !isEventAcceptingRunStatus(snapshot.CurrentRunView.Status) {
+			return ErrRunOwnershipLost
+		}
+		return nil
+	}
+	if !ctrl.leaseIsValidAt(time.Now()) {
+		return ErrRunOwnershipLost
+	}
+	now, err := m.backend.Now(ctx)
+	if err != nil {
+		return fmt.Errorf("validate runtime ownership time: %w", err)
+	}
+	ref, refOK, err := m.distributed.LoadStreamRef(ctx, streamID)
+	if err != nil {
+		return fmt.Errorf("validate runtime stream lease: %w", err)
+	}
+	if !refOK || ref.BotID != key.BotID || ref.SessionID != key.SessionID || ref.StreamID != streamID || ref.OwnerID != m.ownerID {
+		return ErrRunOwnershipLost
+	}
+	snapshot, ok, err := m.backend.Load(ctx, key)
+	if err != nil {
+		return fmt.Errorf("validate runtime ownership: %w", err)
+	}
+	if !ok || snapshot.CurrentRunView == nil {
+		return ErrRunOwnershipLost
+	}
+	run := snapshot.CurrentRunView
+	if run.StreamID != streamID || !m.runOwnerMatches(run) || !isEventAcceptingRunStatus(run.Status) || m.leaseExpired(run, now) {
+		return ErrRunOwnershipLost
+	}
+	return nil
+}
+
+func (m *Manager) Abort(ctx context.Context, streamID string) (bool, error) {
+	streamID = strings.TrimSpace(streamID)
+	if m == nil || m.backend == nil || streamID == "" {
+		return false, nil
+	}
+	if ctrl := m.localControl(streamID); ctrl != nil {
+		return m.abortLocal(ctx, ctrl)
+	}
+	if m.distributed == nil {
+		return false, nil
+	}
+	ref, ok, err := m.distributed.LoadStreamRef(ctx, streamID)
+	if err != nil || !ok || strings.TrimSpace(ref.OwnerID) == "" {
+		return false, err
+	}
+	if err := m.distributed.PublishCommand(ctx, ref.OwnerID, Command{
+		Type:      CommandAbort,
+		BotID:     ref.BotID,
+		SessionID: ref.SessionID,
+		StreamID:  ref.StreamID,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		return false, err
+	}
+	if err := m.waitForAbortAck(ctx, ref); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *Manager) abortLocal(ctx context.Context, ctrl *runControl) (bool, error) {
+	if ctrl == nil || m.localControl(ctrl.streamID) != ctrl {
+		return false, ErrCommandTargetNotActive
+	}
+	if m.distributed != nil && !ctrl.leaseIsValidAt(time.Now()) {
+		m.cancelRunControl(ctrl)
+		return false, ErrCommandTargetNotActive
+	}
+	if err := m.requestAbort(ctx, ctrl); err != nil {
+		return false, err
+	}
+	select {
+	case ctrl.abortCh <- struct{}{}:
+	default:
+	}
+	if ctrl.cancel != nil {
+		ctrl.cancel()
+	}
+	return true, nil
+}
+
+// DispatchActiveCommand routes a response for a UI request embedded in the
+// current run to that run's owner. A false handled result means the target is
+// not part of the active run and the caller may use its deferred flow.
+func (m *Manager) DispatchActiveCommand(ctx context.Context, botID, sessionID, commandType, targetID string, payload []byte) (bool, error) {
+	if m == nil || m.backend == nil {
+		return false, nil
+	}
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
+	targetID = strings.TrimSpace(targetID)
+	if botID == "" || sessionID == "" || targetID == "" {
+		return false, nil
+	}
+	if commandType != CommandToolApprovalResponse && commandType != CommandUserInputResponse {
+		return false, fmt.Errorf("unsupported active runtime command %q", commandType)
+	}
+	snapshot, err := m.Snapshot(ctx, botID, sessionID)
+	if err != nil {
+		return false, err
+	}
+	run := snapshot.CurrentRunView
+	if run == nil || !isActiveRunStatus(run.Status) || !runtimeCommandTargetPresent(run, commandType, targetID) {
+		return false, nil
+	}
+	if m.distributed == nil {
+		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
+		defer cancel()
+		return true, m.applyRoutedCommand(commandCtx, Command{
+			Type: commandType, ID: uuid.NewString(), BotID: botID, SessionID: sessionID,
+			StreamID: strings.TrimSpace(run.StreamID), TargetID: targetID,
+			Payload: append([]byte(nil), payload...), CreatedAt: time.Now().UTC(),
+		})
+	}
+	ownerID := strings.TrimSpace(run.OwnerID)
+	if ownerID == "" {
+		return true, errors.New("target runtime owner is unknown")
+	}
+	cmd := Command{
+		Type:         commandType,
+		ID:           uuid.NewString(),
+		ReplyOwnerID: m.ownerID,
+		BotID:        botID,
+		SessionID:    sessionID,
+		StreamID:     strings.TrimSpace(run.StreamID),
+		TargetID:     targetID,
+		Payload:      append([]byte(nil), payload...),
+		CreatedAt:    time.Now().UTC(),
+	}
+	if ownerID == m.ownerID {
+		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
+		defer cancel()
+		return true, m.applyRoutedCommand(commandCtx, cmd)
+	}
+
+	result := make(chan error, 1)
+	m.mu.Lock()
+	if m.isClosed() {
+		m.mu.Unlock()
+		return true, ErrManagerClosed
+	}
+	m.pendingCommands[cmd.ID] = result
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		if m.pendingCommands[cmd.ID] == result {
+			delete(m.pendingCommands, cmd.ID)
+		}
+		m.mu.Unlock()
+	}()
+	if err := m.distributed.PublishCommand(ctx, ownerID, cmd); err != nil {
+		return true, err
+	}
+	timeout := m.commandTimeout()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-result:
+		return true, err
+	case <-ctx.Done():
+		return true, ctx.Err()
+	case <-timer.C:
+		return true, errors.New("runtime command was not acknowledged")
+	}
+}
+
+func (m *Manager) requestAbort(ctx context.Context, ctrl *runControl) error {
+	if ctrl == nil {
+		return nil
+	}
+	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: ctrl.botID, SessionID: ctrl.sessionID}, ctrl.streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		run := snapshot.CurrentRunView
+		if run.StreamID != ctrl.streamID || !m.runOwnerMatches(run) || !isActiveRunStatus(run.Status) {
+			return snapshot, false, nil
+		}
+		if strings.EqualFold(run.Status, RunStatusAborting) {
+			return snapshot, false, nil
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		run.Status = RunStatusAborting
+		run.UpdatedAt = now
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return runtimeRunPatch(snapshot, true, false, false, false)
+	})
+	return err
+}
+
+func (m *Manager) Steer(ctx context.Context, botID, sessionID, streamID, text string) (SteerState, error) {
+	if m == nil || m.backend == nil {
+		return SteerState{}, errors.New("session runtime manager is not configured")
+	}
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
+	streamID = strings.TrimSpace(streamID)
+	text = strings.TrimSpace(text)
+	if botID == "" || sessionID == "" || text == "" {
+		return SteerState{}, errors.New("bot_id, session_id, and text are required")
+	}
+	if streamID == "" {
+		snapshot, err := m.Snapshot(ctx, botID, sessionID)
+		if err != nil {
+			return SteerState{}, err
+		}
+		if snapshot.CurrentRunView == nil {
+			return SteerState{}, errors.New("no active runtime run")
+		}
+		streamID = strings.TrimSpace(snapshot.CurrentRunView.StreamID)
+	}
+	var steer SteerState
+	var ownerID string
+	var commandCreatedAt time.Time
+	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if snapshot.CurrentRunView.StreamID != streamID || !strings.EqualFold(snapshot.CurrentRunView.Status, RunStatusRunning) {
+			return snapshot, false, errors.New("target runtime run is not active")
+		}
+		if snapshot.CurrentRunView.Steer != nil && isPendingSteerStatus(snapshot.CurrentRunView.Steer.Status) {
+			return snapshot, false, errors.New("another runtime steer command is still pending")
+		}
+		steer = SteerState{
+			ID:        uuid.NewString(),
+			Status:    SteerStatusPending,
+			Text:      text,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		commandCreatedAt = now
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView.Steer = &steer
+		snapshot.CurrentRunView.UpdatedAt = now
+		ownerID = strings.TrimSpace(snapshot.CurrentRunView.OwnerID)
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return runtimeRunPatch(snapshot, false, false, true, false)
+	})
+	if err != nil {
+		return SteerState{}, err
+	}
+
+	cmd := Command{Type: CommandSteer, BotID: botID, SessionID: sessionID, StreamID: streamID, SteerID: steer.ID, Text: text, CreatedAt: commandCreatedAt}
+	if ctrl := m.localControl(streamID); ctrl != nil {
+		m.applyCommand(ctx, cmd)
+	} else {
+		if ownerID == "" {
+			return steer, errors.New("target runtime owner is unknown")
+		}
+		if m.distributed == nil {
+			return steer, errors.New("active runtime is not local")
+		}
+		if err := m.distributed.PublishCommand(ctx, ownerID, cmd); err != nil {
+			_ = m.updateSteerStatus(context.WithoutCancel(ctx), botID, sessionID, streamID, steer.ID, SteerStatusRejected, err.Error())
+			return steer, err
+		}
+	}
+	m.rejectPendingSteerAfterTimeout(context.WithoutCancel(ctx), botID, sessionID, streamID, steer.ID)
+	return steer, nil
+}
+
+func (m *Manager) applyCommand(ctx context.Context, cmd Command) {
+	switch strings.TrimSpace(cmd.Type) {
+	case CommandAbort:
+		ctrl := m.localControl(strings.TrimSpace(cmd.StreamID))
+		if ctrl == nil || ctrl.botID != strings.TrimSpace(cmd.BotID) || ctrl.sessionID != strings.TrimSpace(cmd.SessionID) {
+			m.logger.Warn("ignore abort command for inactive local run", slog.String("stream_id", cmd.StreamID))
+			return
+		}
+		if _, err := m.abortLocal(ctx, ctrl); err != nil {
+			m.logger.Warn("apply abort command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+		}
+	case CommandSteer:
+		m.applySteerCommand(ctx, cmd)
+	case CommandToolApprovalResponse, CommandUserInputResponse:
+		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
+		err := m.applyRoutedCommand(commandCtx, cmd)
+		cancel()
+		m.publishCommandResult(ctx, cmd, err)
+	case CommandResult:
+		m.completePendingCommand(cmd)
+	}
+}
+
+func (m *Manager) applyRoutedCommand(ctx context.Context, cmd Command) error {
+	ctrl := m.localControl(strings.TrimSpace(cmd.StreamID))
+	if ctrl == nil || ctrl.botID != strings.TrimSpace(cmd.BotID) || ctrl.sessionID != strings.TrimSpace(cmd.SessionID) {
+		return ErrCommandTargetNotActive
+	}
+	if err := m.ValidateRunOwnership(ctx, cmd.BotID, cmd.SessionID, cmd.StreamID); err != nil {
+		return ErrCommandTargetNotActive
+	}
+	snapshot, ok, err := m.backend.Load(ctx, Key{BotID: cmd.BotID, SessionID: cmd.SessionID})
+	if err != nil {
+		return err
+	}
+	if !ok || snapshot.CurrentRunView == nil {
+		return ErrCommandTargetNotActive
+	}
+	run := snapshot.CurrentRunView
+	if run.StreamID != ctrl.streamID || !m.runOwnerMatches(run) || !isActiveRunStatus(run.Status) || !runtimeCommandTargetPresent(run, cmd.Type, cmd.TargetID) {
+		return ErrCommandTargetNotActive
+	}
+	m.mu.Lock()
+	handler := m.commandHandler
+	m.mu.Unlock()
+	if handler == nil {
+		return errors.New("runtime command handler is not configured")
+	}
+	return handler(ctx, cmd)
+}
+
+func (m *Manager) publishCommandResult(ctx context.Context, request Command, err error) {
+	replyOwnerID := strings.TrimSpace(request.ReplyOwnerID)
+	if replyOwnerID == "" {
+		return
+	}
+	if m.distributed == nil {
+		return
+	}
+	result := Command{Type: CommandResult, ID: request.ID, CreatedAt: time.Now().UTC()}
+	if err != nil {
+		result.Error = err.Error()
+		if errors.Is(err, ErrCommandTargetNotActive) {
+			result.ErrorCode = "target_not_active"
+		} else {
+			result.ErrorCode = "runtime_command_failed"
+		}
+	}
+	publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.commandTimeout())
+	defer cancel()
+	if publishErr := m.distributed.PublishCommand(publishCtx, replyOwnerID, result); publishErr != nil {
+		m.logger.Warn("publish runtime command result failed", slog.Any("error", publishErr), slog.String("command_id", request.ID))
+	}
+}
+
+func (m *Manager) commandTimeout() time.Duration {
+	if m != nil && m.commandAckTTL > 0 {
+		return m.commandAckTTL
+	}
+	return defaultCommandAckTTL
+}
+
+func (m *Manager) completePendingCommand(result Command) {
+	m.mu.Lock()
+	pending := m.pendingCommands[strings.TrimSpace(result.ID)]
+	if pending != nil {
+		delete(m.pendingCommands, strings.TrimSpace(result.ID))
+	}
+	m.mu.Unlock()
+	if pending == nil {
+		return
+	}
+	var err error
+	if strings.TrimSpace(result.Error) != "" {
+		if result.ErrorCode == "target_not_active" {
+			err = fmt.Errorf("%w: %s", ErrCommandTargetNotActive, result.Error)
+		} else {
+			err = errors.New(result.Error)
+		}
+	}
+	pending <- err
+}
+
+func runtimeCommandTargetPresent(run *CurrentRunView, commandType, targetID string) bool {
+	targetID = strings.TrimSpace(targetID)
+	if run == nil || targetID == "" {
+		return false
+	}
+	for _, message := range run.Messages {
+		switch commandType {
+		case CommandToolApprovalResponse:
+			if message.Approval != nil && (strings.TrimSpace(message.Approval.ApprovalID) == targetID || strconv.Itoa(message.Approval.ShortID) == targetID) {
+				return true
+			}
+		case CommandUserInputResponse:
+			if message.UserInput != nil && (strings.TrimSpace(message.UserInput.UserInputID) == targetID || strconv.Itoa(message.UserInput.ShortID) == targetID) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m *Manager) applySteerCommand(ctx context.Context, cmd Command) {
+	if err := m.ValidateRunOwnership(ctx, cmd.BotID, cmd.SessionID, cmd.StreamID); err != nil {
+		_ = m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, ErrRunOwnershipLost.Error())
+		return
+	}
+	if !m.steerCommandIsPending(context.WithoutCancel(ctx), cmd) {
+		return
+	}
+	now, err := m.backend.Now(ctx)
+	if err != nil {
+		m.logger.Warn("load runtime backend time for steer command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+		return
+	}
+	if m.commandAckTTL > 0 && !cmd.CreatedAt.IsZero() && now.After(cmd.CreatedAt.Add(m.commandAckTTL)) {
+		if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, steerNotAcknowledgedError); err != nil {
+			m.logger.Warn("reject expired steer command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+		}
+		return
+	}
+
+	ctrl := m.localControl(cmd.StreamID)
+	errText := ""
+	if ctrl != nil && ctrl.injectCh != nil && strings.TrimSpace(cmd.Text) != "" {
+		queued, err := m.transitionSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusQueued, "")
+		if err != nil {
+			m.logger.Warn("acknowledge queued steer failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+			return
+		}
+		if !queued {
+			return
+		}
+		select {
+		case ctrl.injectCh <- conversation.InjectMessage{
+			Text: strings.TrimSpace(cmd.Text),
+			Applied: func() {
+				if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusApplied, ""); err != nil {
+					m.logger.Warn("acknowledge applied steer failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+				}
+			},
+		}:
+			return
+		case <-ctx.Done():
+			errText = ctx.Err().Error()
+		default:
+			errText = "active runtime is not accepting steer messages"
+		}
+	} else {
+		errText = "active runtime is not available"
+	}
+	if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, errText); err != nil {
+		m.logger.Warn("update steer status failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+	}
+}
+
+func (m *Manager) steerCommandIsPending(ctx context.Context, cmd Command) bool {
+	if strings.TrimSpace(cmd.SteerID) == "" {
+		return false
+	}
+	snapshot, ok, err := m.backend.Load(ctx, Key{BotID: cmd.BotID, SessionID: cmd.SessionID})
+	if err != nil {
+		m.logger.Warn("load steer state failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+		return false
+	}
+	if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != strings.TrimSpace(cmd.StreamID) {
+		return false
+	}
+	steer := snapshot.CurrentRunView.Steer
+	return steer != nil && steer.ID == strings.TrimSpace(cmd.SteerID) && strings.EqualFold(steer.Status, SteerStatusPending)
+}
+
+func (m *Manager) updateSteerStatus(ctx context.Context, botID, sessionID, streamID, steerID, status, errText string) error {
+	_, err := m.transitionSteerStatus(ctx, botID, sessionID, streamID, steerID, status, errText)
+	return err
+}
+
+func (m *Manager) transitionSteerStatus(ctx context.Context, botID, sessionID, streamID, steerID, status, errText string) (bool, error) {
+	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if snapshot.CurrentRunView.StreamID != streamID {
+			return snapshot, false, nil
+		}
+		if snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.ID != steerID {
+			return snapshot, false, nil
+		}
+		currentStatus := snapshot.CurrentRunView.Steer.Status
+		if !validSteerTransition(currentStatus, status) {
+			return snapshot, false, nil
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView.UpdatedAt = now
+		snapshot.CurrentRunView.Steer.Status = status
+		snapshot.CurrentRunView.Steer.Error = strings.TrimSpace(errText)
+		snapshot.CurrentRunView.Steer.UpdatedAt = now
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return runtimeRunPatch(snapshot, false, false, true, false)
+	})
+	return changed, err
+}
+
+const steerNotAcknowledgedError = "runtime steer command was not acknowledged"
+
+func (m *Manager) rejectPendingSteerAfterTimeout(ctx context.Context, botID, sessionID, streamID, steerID string) {
+	timeout := m.commandAckTTL
+	if timeout <= 0 {
+		return
+	}
+	time.AfterFunc(timeout, func() {
+		select {
+		case <-m.closeCh:
+			return
+		default:
+		}
+		err := m.rejectUnacknowledgedSteer(ctx, botID, sessionID, streamID, steerID)
+		if err != nil {
+			m.logger.Warn("reject pending steer failed", slog.Any("error", err), slog.String("stream_id", streamID))
+		}
+	})
+}
+
+func (m *Manager) rejectUnacknowledgedSteer(ctx context.Context, botID, sessionID, streamID, steerID string) error {
+	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if snapshot.CurrentRunView.StreamID != streamID {
+			return snapshot, false, nil
+		}
+		steer := snapshot.CurrentRunView.Steer
+		if steer == nil || steer.ID != steerID || !strings.EqualFold(steer.Status, SteerStatusPending) {
+			return snapshot, false, nil
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView.UpdatedAt = now
+		steer.Status = SteerStatusRejected
+		steer.Error = steerNotAcknowledgedError
+		steer.UpdatedAt = now
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return runtimeRunPatch(snapshot, false, false, true, false)
+	})
+	return err
+}
+
+func isPendingSteerStatus(status string) bool {
+	return strings.EqualFold(status, SteerStatusPending) || strings.EqualFold(status, SteerStatusQueued)
+}
+
+func validSteerTransition(current, next string) bool {
+	switch strings.ToLower(strings.TrimSpace(next)) {
+	case SteerStatusQueued:
+		return strings.EqualFold(current, SteerStatusPending)
+	case SteerStatusRejected:
+		return isPendingSteerStatus(current)
+	case SteerStatusApplied:
+		return isPendingSteerStatus(current)
+	default:
+		return false
+	}
+}
+
+func (m *Manager) waitForAbortAck(ctx context.Context, ref StreamRef) error {
+	timeout := m.commandAckTTL
+	if timeout <= 0 {
+		return nil
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(commandAckPollInterval(timeout))
+	defer ticker.Stop()
+	for {
+		snapshot, err := m.Snapshot(waitCtx, ref.BotID, ref.SessionID)
+		if err != nil {
+			return err
+		}
+		if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != ref.StreamID || strings.EqualFold(snapshot.CurrentRunView.Status, RunStatusAborting) || !isActiveRunStatus(snapshot.CurrentRunView.Status) {
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			return errors.New("runtime abort command was not acknowledged")
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/sessionruntime/control.go
+++ b/internal/sessionruntime/control.go
@@ -1,0 +1,163 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+func (m *Manager) localControl(streamID string) *runControl {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.controls[strings.TrimSpace(streamID)]
+}
+
+func (m *Manager) forgetLocalControl(ctx context.Context, streamID string) {
+	m.mu.Lock()
+	ctrl := m.controls[strings.TrimSpace(streamID)]
+	delete(m.controls, strings.TrimSpace(streamID))
+	m.mu.Unlock()
+	_ = waitRunControlReady(ctx, ctrl)
+	m.stopLeaseRenewal(ctrl)
+}
+
+func (m *Manager) removeLocalControl(streamID string, expected *runControl) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := strings.TrimSpace(streamID)
+	if m.controls[key] == expected {
+		delete(m.controls, key)
+	}
+}
+
+func (m *Manager) stopAllLocalControls(ctx context.Context) {
+	m.mu.Lock()
+	controls := make([]*runControl, 0, len(m.controls))
+	for streamID, ctrl := range m.controls {
+		controls = append(controls, ctrl)
+		delete(m.controls, streamID)
+	}
+	m.mu.Unlock()
+	for _, ctrl := range controls {
+		select {
+		case ctrl.abortCh <- struct{}{}:
+		default:
+		}
+		if ctrl.cancel != nil {
+			ctrl.cancel()
+		}
+		_ = waitRunControlReady(ctx, ctrl)
+		m.stopLeaseRenewal(ctrl)
+	}
+}
+
+func (c *runControl) markReady() {
+	if c == nil {
+		return
+	}
+	c.readyOnce.Do(func() { close(c.ready) })
+}
+
+func waitRunControlReady(ctx context.Context, ctrl *runControl) error {
+	if ctrl == nil || ctrl.ready == nil {
+		return nil
+	}
+	select {
+	case <-ctrl.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *Manager) startLeaseRenewal(ctx context.Context, ctrl *runControl) {
+	if m == nil || ctrl == nil || m.distributed == nil || m.ownerLeaseTTL <= 0 {
+		return
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	ctrl.leaseStop = cancel
+	ctrl.leaseDone = done
+	interval := leaseRenewInterval(m.ownerLeaseTTL)
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if !ctrl.leaseIsValidAt(time.Now()) {
+					m.cancelRunControl(ctrl)
+					return
+				}
+				now, err := m.backend.Now(ctx)
+				if err == nil {
+					err = m.distributed.RenewLease(ctx, Key{BotID: ctrl.botID, SessionID: ctrl.sessionID}, ctrl.streamID, m.ownerID, now, now.Add(m.ownerLeaseTTL))
+				}
+				if err == nil {
+					ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+					continue
+				}
+				if ctx.Err() != nil {
+					return
+				}
+				m.logger.Warn("renew runtime owner lease failed", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
+				if errors.Is(err, ErrRunOwnershipLost) || !ctrl.leaseIsValidAt(time.Now()) {
+					m.cancelRunControl(ctrl)
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (c *runControl) setLeaseValidUntil(deadline time.Time) {
+	if c == nil {
+		return
+	}
+	c.leaseMu.Lock()
+	c.leaseValidUntil = deadline
+	c.leaseMu.Unlock()
+}
+
+func (c *runControl) leaseIsValidAt(now time.Time) bool {
+	if c == nil {
+		return false
+	}
+	c.leaseMu.RLock()
+	deadline := c.leaseValidUntil
+	c.leaseMu.RUnlock()
+	return !deadline.IsZero() && now.Before(deadline)
+}
+
+func (*Manager) cancelRunControl(ctrl *runControl) {
+	if ctrl == nil {
+		return
+	}
+	select {
+	case ctrl.abortCh <- struct{}{}:
+	default:
+	}
+	if ctrl.cancel != nil {
+		ctrl.cancel()
+	}
+}
+
+func (*Manager) stopLeaseRenewal(ctrl *runControl) {
+	if ctrl == nil || ctrl.leaseStop == nil {
+		return
+	}
+	ctrl.leaseStop()
+	if ctrl.leaseDone != nil {
+		<-ctrl.leaseDone
+	}
+	ctrl.leaseStop = nil
+	ctrl.leaseDone = nil
+}

--- a/internal/sessionruntime/manager.go
+++ b/internal/sessionruntime/manager.go
@@ -1,0 +1,908 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+type Manager struct {
+	backend       Backend
+	distributed   DistributedBackend
+	ownerID       string
+	stateTTL      time.Duration
+	ownerLeaseTTL time.Duration
+	commandAckTTL time.Duration
+	logger        *slog.Logger
+
+	mu              sync.Mutex
+	controls        map[string]*runControl
+	commandHandler  func(context.Context, Command) error
+	pendingCommands map[string]chan error
+
+	commandCancel context.CancelFunc
+	commandDone   chan struct{}
+	closeCh       chan struct{}
+	closeOnce     sync.Once
+}
+
+type runControl struct {
+	botID           string
+	sessionID       string
+	streamID        string
+	abortCh         chan<- struct{}
+	cancel          context.CancelFunc
+	injectCh        chan<- conversation.InjectMessage
+	converter       *conversation.UIMessageStreamConverter
+	leaseStop       func()
+	leaseDone       chan struct{}
+	leaseMu         sync.RWMutex
+	leaseValidUntil time.Time
+	ready           chan struct{}
+	readyOnce       sync.Once
+	finishRetryOnce sync.Once
+}
+
+type Options struct {
+	OwnerID       string
+	StateTTL      time.Duration
+	OwnerLeaseTTL time.Duration
+	CommandAckTTL time.Duration
+	Logger        *slog.Logger
+}
+
+const defaultCommandAckTTL = 2 * time.Second
+
+func NewManager(backend Backend, opts Options) *Manager {
+	ownerID := strings.TrimSpace(opts.OwnerID)
+	if ownerID == "" {
+		ownerID = uuid.NewString()
+	}
+	stateTTL := opts.StateTTL
+	if stateTTL <= 0 {
+		stateTTL = 24 * time.Hour
+	}
+	leaseTTL := opts.OwnerLeaseTTL
+	if leaseTTL <= 0 {
+		leaseTTL = 30 * time.Second
+	}
+	commandAckTTL := opts.CommandAckTTL
+	if commandAckTTL <= 0 {
+		commandAckTTL = defaultCommandAckTTL
+	}
+	log := opts.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	distributed, _ := backend.(DistributedBackend)
+	return &Manager{
+		backend:         backend,
+		distributed:     distributed,
+		ownerID:         ownerID,
+		stateTTL:        stateTTL,
+		ownerLeaseTTL:   leaseTTL,
+		commandAckTTL:   commandAckTTL,
+		logger:          log.With(slog.String("component", "session_runtime")),
+		controls:        make(map[string]*runControl),
+		pendingCommands: make(map[string]chan error),
+		closeCh:         make(chan struct{}),
+	}
+}
+
+func (m *Manager) isClosed() bool {
+	if m == nil || m.closeCh == nil {
+		return false
+	}
+	select {
+	case <-m.closeCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// SetCommandHandler installs the owner-local executor for routed runtime
+// commands whose domain behavior lives outside the sessionruntime package.
+func (m *Manager) SetCommandHandler(handler func(context.Context, Command) error) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.commandHandler = handler
+	m.mu.Unlock()
+}
+
+func (m *Manager) Start(ctx context.Context) error {
+	if m == nil || m.distributed == nil {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	sub, err := m.distributed.SubscribeCommands(ctx, m.ownerID)
+	if err != nil {
+		cancel()
+		if m.isClosed() {
+			return ErrManagerClosed
+		}
+		return err
+	}
+	stopCommands := sync.OnceFunc(func() {
+		cancel()
+		sub.Close()
+	})
+	commandDone := make(chan struct{})
+	m.mu.Lock()
+	if m.isClosed() {
+		m.mu.Unlock()
+		stopCommands()
+		return ErrManagerClosed
+	}
+	if m.commandCancel != nil || m.commandDone != nil {
+		m.mu.Unlock()
+		stopCommands()
+		return errors.New("session runtime manager is already started")
+	}
+	m.commandCancel = stopCommands
+	m.commandDone = commandDone
+	m.mu.Unlock()
+	go func() {
+		defer close(commandDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case cmd, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				m.applyCommand(context.WithoutCancel(ctx), cmd)
+			}
+		}
+	}()
+	return nil
+}
+
+func (m *Manager) Close() error {
+	return m.CloseContext(context.Background())
+}
+
+func (m *Manager) CloseContext(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	if m.closeCh != nil {
+		m.closeOnce.Do(func() { close(m.closeCh) })
+	}
+	m.mu.Lock()
+	commandCancel := m.commandCancel
+	commandDone := m.commandDone
+	m.commandCancel = nil
+	m.commandDone = nil
+	pendingCommands := make([]chan error, 0, len(m.pendingCommands))
+	for commandID, pending := range m.pendingCommands {
+		pendingCommands = append(pendingCommands, pending)
+		delete(m.pendingCommands, commandID)
+	}
+	m.mu.Unlock()
+	if commandCancel != nil {
+		commandCancel()
+	}
+	for _, pending := range pendingCommands {
+		pending <- ErrManagerClosed
+	}
+	m.stopAllLocalControls(ctx)
+	if commandDone != nil {
+		select {
+		case <-commandDone:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if m.backend != nil {
+		return m.backend.Close()
+	}
+	return nil
+}
+
+func (m *Manager) StartRun(ctx context.Context, botID, sessionID, streamID string, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	return m.StartRunWithAdmission(ctx, botID, sessionID, streamID, RunAdmissionView{}, abortCh, cancel, injectCh)
+}
+
+func (m *Manager) StartRunWithOperation(ctx context.Context, botID, sessionID, streamID string, operation *RunOperationView, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	return m.StartRunWithAdmission(ctx, botID, sessionID, streamID, RunAdmissionView{Operation: operation}, abortCh, cancel, injectCh)
+}
+
+func (m *Manager) StartRunWithAdmission(ctx context.Context, botID, sessionID, streamID string, admission RunAdmissionView, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	return m.StartRunWithAdmissionBuilder(ctx, botID, sessionID, streamID, func(context.Context) (RunAdmissionView, error) {
+		return admission, nil
+	}, abortCh, cancel, injectCh)
+}
+
+func (m *Manager) StartRunWithOperationBuilder(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context) (*RunOperationView, error), abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	if builder == nil {
+		return errors.New("runtime operation builder is required")
+	}
+	return m.StartRunWithAdmissionBuilder(ctx, botID, sessionID, streamID, func(ctx context.Context) (RunAdmissionView, error) {
+		operation, err := builder(ctx)
+		return RunAdmissionView{Operation: operation}, err
+	}, abortCh, cancel, injectCh)
+}
+
+// StartRunWithAdmissionBuilder reserves the cross-server run before executing
+// builder, then publishes the running view only after the canonical request
+// turn and optional replacement operation are ready.
+func (m *Manager) StartRunWithAdmissionBuilder(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context) (RunAdmissionView, error), abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	if m == nil || m.backend == nil {
+		return nil
+	}
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
+	streamID = strings.TrimSpace(streamID)
+	if botID == "" || sessionID == "" || streamID == "" {
+		return errors.New("bot_id, session_id, and stream_id are required")
+	}
+	if builder == nil {
+		return errors.New("runtime admission builder is required")
+	}
+
+	ctrl := &runControl{
+		botID:     botID,
+		sessionID: sessionID,
+		streamID:  streamID,
+		abortCh:   abortCh,
+		cancel:    cancel,
+		injectCh:  injectCh,
+		converter: conversation.NewUIMessageStreamConverter(),
+		ready:     make(chan struct{}),
+	}
+	defer ctrl.markReady()
+	m.mu.Lock()
+	select {
+	case <-m.closeCh:
+		m.mu.Unlock()
+		return ErrManagerClosed
+	default:
+	}
+	if _, exists := m.controls[streamID]; exists {
+		m.mu.Unlock()
+		return fmt.Errorf("stream_id %q is already owned by this runtime manager", streamID)
+	}
+	m.controls[streamID] = ctrl
+	m.mu.Unlock()
+
+	now, err := m.backend.Now(ctx)
+	if err != nil {
+		m.removeLocalControl(streamID, ctrl)
+		return fmt.Errorf("load runtime backend time: %w", err)
+	}
+	key := Key{BotID: botID, SessionID: sessionID}
+	ownerID := ""
+	var leaseExpiresAt *time.Time
+	if m.distributed != nil {
+		ownerID = m.ownerID
+		expiresAt := now.Add(m.ownerLeaseTTL)
+		leaseExpiresAt = &expiresAt
+		// The backend claim below is authoritative, but a local deadline must
+		// exist before it returns so an abort can cancel blocked admission.
+		ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+	}
+	var expiredStreamID string
+	claim := func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+		if snapshot.CurrentRunView != nil && isActiveRunStatus(snapshot.CurrentRunView.Status) && snapshot.CurrentRunView.StreamID != streamID {
+			if m.distributed == nil || !m.markLostIfExpired(&snapshot, now) {
+				return snapshot, false, fmt.Errorf("session %q already has an active runtime run", sessionID)
+			}
+			expiredStreamID = snapshot.CurrentRunView.StreamID
+		}
+		snapshot.BotID = botID
+		snapshot.SessionID = sessionID
+		snapshot.Seq++
+		snapshot.Queue = nonNilQueue(snapshot.Queue)
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView = &CurrentRunView{
+			StreamID:            streamID,
+			Status:              RunStatusAdmitting,
+			OwnerID:             ownerID,
+			OwnerLeaseExpiresAt: leaseExpiresAt,
+			StartedAt:           now,
+			UpdatedAt:           now,
+			Messages:            []conversation.UIMessage{},
+		}
+		return snapshot, true, nil
+	}
+	var claimedSnapshot Snapshot
+	var changed bool
+	if m.distributed != nil {
+		claimedSnapshot, changed, err = m.distributed.StartRun(ctx, key, StreamRef{
+			BotID: botID, SessionID: sessionID, StreamID: streamID, OwnerID: m.ownerID,
+		}, claim)
+	} else {
+		claimedSnapshot, changed, err = m.backend.Update(ctx, key, claim)
+	}
+	if err != nil {
+		m.removeLocalControl(streamID, ctrl)
+		return err
+	}
+	if !changed {
+		m.removeLocalControl(streamID, ctrl)
+		return nil
+	}
+	if err := m.publishRuntimeDelta(context.WithoutCancel(ctx), claimedSnapshot, streamID, RuntimeDelta{CurrentRunView: claimedSnapshot.CurrentRunView}); err != nil {
+		m.logger.Warn("publish admitting runtime checkpoint failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+	if expiredStreamID != "" && m.distributed != nil {
+		_ = m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), expiredStreamID)
+	}
+	if m.distributed != nil {
+		renewedAt, renewErr := m.backend.Now(context.WithoutCancel(ctx))
+		if renewErr == nil {
+			renewErr = m.distributed.RenewLease(context.WithoutCancel(ctx), key, streamID, m.ownerID, renewedAt, renewedAt.Add(m.ownerLeaseTTL))
+		}
+		if renewErr != nil {
+			ctrl.markReady()
+			if errors.Is(renewErr, ErrRunOwnershipLost) {
+				m.forgetLocalControl(context.WithoutCancel(ctx), streamID)
+			} else {
+				_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, RunStatusErrored, renewErr.Error())
+			}
+			return fmt.Errorf("confirm runtime owner lease: %w", renewErr)
+		}
+		ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+		m.startLeaseRenewal(context.WithoutCancel(ctx), ctrl)
+	}
+	admission, err := builder(ctx)
+	if err != nil {
+		ctrl.markReady()
+		status := RunStatusErrored
+		message := err.Error()
+		if errors.Is(err, context.Canceled) {
+			status = RunStatusAborted
+			message = ""
+		}
+		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, status, message)
+		return err
+	}
+	if m.isClosed() {
+		return ErrManagerClosed
+	}
+	if m.localControl(streamID) != ctrl {
+		return ErrRunOwnershipLost
+	}
+	admission, err = normalizeRunAdmission(admission)
+	if err != nil {
+		ctrl.markReady()
+		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, RunStatusErrored, err.Error())
+		return err
+	}
+	_, changed, err = m.updateActiveAndPublish(context.WithoutCancel(ctx), key, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if m.isClosed() {
+			return snapshot, false, ErrManagerClosed
+		}
+		if m.localControl(streamID) != ctrl {
+			return snapshot, false, ErrRunOwnershipLost
+		}
+		run := snapshot.CurrentRunView
+		if run.StreamID == streamID && m.runOwnerMatches(run) && strings.EqualFold(run.Status, RunStatusAborting) {
+			return snapshot, false, context.Canceled
+		}
+		if run.StreamID != streamID || !m.runOwnerMatches(run) || !strings.EqualFold(run.Status, RunStatusAdmitting) {
+			return snapshot, false, errors.New("reserved runtime run is no longer owned by this manager")
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		run.Status = RunStatusRunning
+		run.RequestUserTurn = admission.RequestUserTurn
+		run.Operation = admission.Operation
+		run.UpdatedAt = now
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return RuntimeDelta{CurrentRunView: snapshot.CurrentRunView}
+	})
+	if err != nil || !changed {
+		ctrl.markReady()
+		if errors.Is(err, ErrManagerClosed) || errors.Is(err, ErrRunOwnershipLost) {
+			return err
+		}
+		if err == nil {
+			err = errors.New("reserved runtime run could not be activated")
+		}
+		status := RunStatusErrored
+		message := err.Error()
+		if errors.Is(err, context.Canceled) {
+			status = RunStatusAborted
+			message = ""
+		}
+		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, status, message)
+		return err
+	}
+	ctrl.markReady()
+	return nil
+}
+
+func (m *Manager) FinishRun(ctx context.Context, botID, sessionID, streamID, status, message string) error {
+	if m == nil || m.backend == nil {
+		return nil
+	}
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
+	streamID = strings.TrimSpace(streamID)
+	if botID == "" || sessionID == "" || streamID == "" {
+		return nil
+	}
+	status = strings.TrimSpace(status)
+	finishMessage := strings.TrimSpace(message)
+	changed, err := m.finishRunState(ctx, botID, sessionID, streamID, status, finishMessage)
+	if err == nil || changed {
+		m.cleanupFinishedRun(context.WithoutCancel(ctx), streamID)
+		return err
+	}
+	if errors.Is(err, ErrRunOwnershipLost) {
+		snapshot, ok, loadErr := m.backend.Load(context.WithoutCancel(ctx), Key{BotID: botID, SessionID: sessionID})
+		if loadErr == nil && ok && snapshot.CurrentRunView != nil && snapshot.CurrentRunView.StreamID == streamID && !isActiveRunStatus(snapshot.CurrentRunView.Status) {
+			m.cleanupFinishedRun(context.WithoutCancel(ctx), streamID)
+			return nil
+		}
+		m.forgetLocalControl(context.WithoutCancel(ctx), streamID)
+		return err
+	}
+	if ctrl := m.localControl(streamID); ctrl != nil {
+		retryCtx := context.WithoutCancel(ctx)
+		ctrl.finishRetryOnce.Do(func() {
+			go m.retryFinishRun(retryCtx, ctrl, status, finishMessage)
+		})
+	}
+	return err
+}
+
+const steerRunFinishedError = "runtime run finished before steer was applied"
+
+func rejectPendingSteerOnRunFinish(run *CurrentRunView, now time.Time) {
+	if run == nil || run.Steer == nil || !isPendingSteerStatus(run.Steer.Status) {
+		return
+	}
+	run.Steer.Status = SteerStatusRejected
+	run.Steer.Error = steerRunFinishedError
+	run.Steer.UpdatedAt = now
+}
+
+func (m *Manager) finishRunState(ctx context.Context, botID, sessionID, streamID, status, finishMessage string) (bool, error) {
+	admissionTerminal := false
+	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		run := snapshot.CurrentRunView
+		if !isActiveRunStatus(run.Status) {
+			return snapshot, false, nil
+		}
+		if !m.runOwnerMatches(run) {
+			return snapshot, false, ErrRunOwnershipLost
+		}
+		admissionTerminal = strings.EqualFold(run.Status, RunStatusAdmitting)
+		finalStatus := status
+		if finalStatus == "" {
+			finalStatus = RunStatusCompleted
+			if strings.EqualFold(snapshot.CurrentRunView.Status, RunStatusAborting) {
+				finalStatus = RunStatusAborted
+			} else if strings.TrimSpace(snapshot.CurrentRunView.Error) != "" {
+				finalStatus = RunStatusErrored
+			}
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView.Status = finalStatus
+		snapshot.CurrentRunView.UpdatedAt = now
+		switch {
+		case finishMessage != "":
+			snapshot.CurrentRunView.Error = finishMessage
+		case finalStatus == RunStatusCompleted || finalStatus == RunStatusAborted:
+			snapshot.CurrentRunView.Error = ""
+		}
+		snapshot.CurrentRunView.OwnerLeaseExpiresAt = nil
+		rejectPendingSteerOnRunFinish(snapshot.CurrentRunView, now)
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		if admissionTerminal {
+			return RuntimeDelta{CurrentRunView: snapshot.CurrentRunView}
+		}
+		return runtimeRunPatch(snapshot, true, true, true, m.distributed != nil)
+	})
+	return changed, err
+}
+
+func (m *Manager) retryFinishRun(ctx context.Context, ctrl *runControl, status, message string) {
+	if ctrl == nil {
+		return
+	}
+	delay := 100 * time.Millisecond
+	for {
+		select {
+		case <-m.closeCh:
+			return
+		case <-time.After(delay):
+		}
+		if m.localControl(ctrl.streamID) != ctrl {
+			return
+		}
+		changed, err := m.finishRunState(ctx, ctrl.botID, ctrl.sessionID, ctrl.streamID, status, message)
+		if err == nil || changed {
+			if err != nil {
+				m.logger.Warn("publish runtime finish failed after state commit", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
+			}
+			m.cleanupFinishedRun(ctx, ctrl.streamID)
+			return
+		}
+		if errors.Is(err, ErrRunOwnershipLost) {
+			m.forgetLocalControl(ctx, ctrl.streamID)
+			return
+		}
+		m.logger.Warn("retry runtime finish failed", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
+		if delay < time.Second {
+			delay *= 2
+			if delay > time.Second {
+				delay = time.Second
+			}
+		}
+	}
+}
+
+func (m *Manager) cleanupFinishedRun(ctx context.Context, streamID string) {
+	m.forgetLocalControl(ctx, streamID)
+	if m.distributed == nil {
+		return
+	}
+	if err := m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), streamID); err != nil {
+		m.logger.Warn("delete finished runtime stream reference failed", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+}
+
+func (m *Manager) HandleAgentEvent(ctx context.Context, botID, sessionID, streamID string, event agentpkg.StreamEvent) ([]conversation.UIMessage, error) {
+	if m == nil || m.backend == nil {
+		return nil, nil
+	}
+	ctrl := m.localControl(streamID)
+	if ctrl == nil {
+		return nil, nil
+	}
+	if err := waitRunControlReady(ctx, ctrl); err != nil {
+		return nil, err
+	}
+	if m.localControl(streamID) != ctrl {
+		return nil, nil
+	}
+
+	var messages []conversation.UIMessage
+	switch event.Type {
+	case agentpkg.EventAgentStart:
+	case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort:
+		messages = ctrl.converter.ConvertTerminalMessages(event.Messages)
+	case agentpkg.EventError:
+	default:
+		messages = ctrl.converter.HandleEvent(conversation.UIStreamEventFromAgentEvent(event))
+	}
+	delta, visibleChange := runtimeDeltaForAgentEvent(event, messages)
+	if !visibleChange {
+		return messages, nil
+	}
+
+	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		run := snapshot.CurrentRunView
+		if run.StreamID != streamID || !m.runOwnerMatches(run) || !isEventAcceptingRunStatus(run.Status) {
+			return snapshot, false, nil
+		}
+		snapshot.Seq++
+		snapshot.Queue = nonNilQueue(snapshot.Queue)
+		snapshot.UpdatedAt = now
+		run.UpdatedAt = now
+		if event.Type == agentpkg.EventRetry {
+			run.Messages = []conversation.UIMessage{}
+		}
+		for _, msg := range messages {
+			run.Messages = upsertUIMessage(run.Messages, msg)
+		}
+		switch event.Type {
+		case agentpkg.EventAgentEnd:
+			switch {
+			case strings.TrimSpace(run.Error) != "":
+				run.Status = RunStatusErrored
+			case strings.EqualFold(run.Status, RunStatusAborting):
+				run.Status = RunStatusAborted
+			default:
+				run.Status = RunStatusCompleted
+			}
+			run.OwnerLeaseExpiresAt = nil
+			rejectPendingSteerOnRunFinish(run, now)
+		case agentpkg.EventAgentAbort:
+			if strings.TrimSpace(run.Error) != "" {
+				run.Status = RunStatusErrored
+			} else {
+				run.Status = RunStatusAborted
+			}
+			run.OwnerLeaseExpiresAt = nil
+			rejectPendingSteerOnRunFinish(run, now)
+		case agentpkg.EventError:
+			run.Error = strings.TrimSpace(event.Error)
+			if run.Error == "" {
+				run.Error = "stream error"
+			}
+		}
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		switch event.Type {
+		case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort:
+			delta.Run = runtimeRunPatch(snapshot, true, true, true, m.distributed != nil).Run
+		case agentpkg.EventError:
+			delta.Run = runtimeRunPatch(snapshot, false, true, false, false).Run
+		}
+		return delta
+	})
+	if err != nil {
+		if errors.Is(err, ErrRunOwnershipLost) {
+			return nil, err
+		}
+		return messages, err
+	}
+	if !changed {
+		return nil, nil
+	}
+	return messages, nil
+}
+
+func (m *Manager) Snapshot(ctx context.Context, botID, sessionID string) (Snapshot, error) {
+	if m == nil || m.backend == nil {
+		return EmptySnapshot(botID, sessionID), nil
+	}
+	key := Key{BotID: strings.TrimSpace(botID), SessionID: strings.TrimSpace(sessionID)}
+	snapshot, ok, err := m.backend.Load(ctx, key)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if !ok {
+		return EmptySnapshot(key.BotID, key.SessionID), nil
+	}
+	if m.distributed != nil {
+		now, err := m.backend.Now(ctx)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("load runtime backend time: %w", err)
+		}
+		if !m.leaseExpired(snapshot.CurrentRunView, now) {
+			snapshot.Queue = nonNilQueue(snapshot.Queue)
+			return snapshot, nil
+		}
+		lostStreamID := snapshot.CurrentRunView.StreamID
+		updated, changed, err := m.updateAndPublish(ctx, key, lostStreamID, func(current Snapshot, ok bool) (Snapshot, bool, error) {
+			if !ok {
+				return current, false, nil
+			}
+			if !m.markLostIfExpired(&current, now) {
+				return current, false, nil
+			}
+			return current, true, nil
+		}, func(snapshot Snapshot) RuntimeDelta {
+			return runtimeRunPatch(snapshot, true, true, false, true)
+		})
+		if err != nil {
+			return Snapshot{}, err
+		}
+		snapshot = updated
+		if changed && lostStreamID != "" {
+			_ = m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), lostStreamID)
+			if ctrl := m.localControl(lostStreamID); ctrl != nil {
+				m.cancelRunControl(ctrl)
+			}
+		}
+	}
+	snapshot.Queue = nonNilQueue(snapshot.Queue)
+	return snapshot, nil
+}
+
+func (m *Manager) Subscribe(ctx context.Context, botID, sessionID string) (Subscription, error) {
+	if m == nil || m.backend == nil {
+		ch := make(chan Event)
+		close(ch)
+		return Subscription{C: ch, Close: func() {}}, nil
+	}
+	key := Key{BotID: strings.TrimSpace(botID), SessionID: strings.TrimSpace(sessionID)}
+	subCtx, cancel := context.WithCancel(ctx)
+	backendSub, err := m.backend.Subscribe(subCtx, key)
+	if err != nil {
+		cancel()
+		return Subscription{}, err
+	}
+
+	out := make(chan Event, 64)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(out)
+		defer backendSub.Close()
+		reconcileInterval := 2 * time.Second
+		if m.distributed != nil {
+			reconcileInterval = runtimeReconcileInterval(m.ownerLeaseTTL)
+		}
+		ticker := time.NewTicker(reconcileInterval)
+		defer ticker.Stop()
+		var lastSeq int64
+		var lastUpdatedAt time.Time
+		events := backendSub.C
+		for {
+			select {
+			case <-subCtx.Done():
+				return
+			case event, ok := <-events:
+				if !ok {
+					events = nil
+					enqueueRuntimeEvent(out, Event{
+						Type:      EventRuntimeDropped,
+						BotID:     key.BotID,
+						SessionID: key.SessionID,
+						Message:   "runtime backend subscription closed",
+					})
+					continue
+				}
+				updatedAt := time.Time{}
+				if event.UpdatedAt != nil {
+					updatedAt = *event.UpdatedAt
+				}
+				if event.Snapshot != nil {
+					updatedAt = event.Snapshot.UpdatedAt
+				}
+				if event.Seq < lastSeq {
+					if !updatedAt.After(lastUpdatedAt) {
+						continue
+					}
+					resetSnapshot, err := m.Snapshot(subCtx, key.BotID, key.SessionID)
+					if err != nil {
+						enqueueRuntimeEvent(out, Event{
+							Type:      EventRuntimeDropped,
+							BotID:     key.BotID,
+							SessionID: key.SessionID,
+							Seq:       lastSeq,
+							Message:   "runtime sequence epoch changed",
+						})
+						continue
+					}
+					event = Event{
+						Type:      EventRuntimeSnapshot,
+						BotID:     key.BotID,
+						SessionID: key.SessionID,
+						Seq:       resetSnapshot.Seq,
+						Snapshot:  &resetSnapshot,
+					}
+					updatedAt = resetSnapshot.UpdatedAt
+				}
+				selfContained := event.Delta != nil && event.Delta.CurrentRunView != nil
+				if event.Type == EventRuntimeDelta && !selfContained && lastSeq > 0 && event.Seq > lastSeq+1 {
+					enqueueRuntimeEvent(out, Event{
+						Type:      EventRuntimeDropped,
+						BotID:     key.BotID,
+						SessionID: key.SessionID,
+						Seq:       lastSeq,
+						Message:   "runtime delta sequence gap",
+					})
+				}
+				if event.Seq > 0 {
+					lastSeq = event.Seq
+				}
+				if updatedAt.After(lastUpdatedAt) {
+					lastUpdatedAt = updatedAt
+				}
+				enqueueRuntimeEvent(out, event)
+			case <-ticker.C:
+				snapshot, err := m.Snapshot(subCtx, key.BotID, key.SessionID)
+				if err != nil {
+					if subCtx.Err() == nil {
+						m.logger.Warn("reconcile runtime subscription failed", slog.Any("error", err), slog.String("session_id", key.SessionID))
+					}
+					continue
+				}
+				reset := snapshot.Seq < lastSeq && (snapshot.CurrentRunView == nil || snapshot.UpdatedAt.After(lastUpdatedAt))
+				if snapshot.Seq <= lastSeq && !reset {
+					continue
+				}
+				lastSeq = snapshot.Seq
+				lastUpdatedAt = snapshot.UpdatedAt
+				enqueueRuntimeEvent(out, Event{
+					Type:      EventRuntimeSnapshot,
+					BotID:     key.BotID,
+					SessionID: key.SessionID,
+					Seq:       snapshot.Seq,
+					Snapshot:  &snapshot,
+				})
+			}
+		}
+	}()
+	var closeOnce sync.Once
+	return Subscription{
+		C: out,
+		Close: func() {
+			closeOnce.Do(func() {
+				cancel()
+				<-done
+			})
+		},
+	}, nil
+}
+
+func (m *Manager) updateAndPublish(ctx context.Context, key Key, streamID string, update SnapshotUpdate, buildDelta func(Snapshot) RuntimeDelta) (Snapshot, bool, error) {
+	snapshot, changed, err := m.backend.Update(ctx, key, update)
+	if err != nil || !changed {
+		return snapshot, changed, err
+	}
+	delta := RuntimeDelta{}
+	if buildDelta != nil {
+		delta = buildDelta(snapshot)
+	}
+	if err := m.publishRuntimeDelta(ctx, snapshot, streamID, delta); err != nil {
+		m.logger.Warn("publish runtime delta failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+	return snapshot, true, nil
+}
+
+func (m *Manager) updateActiveAndPublish(ctx context.Context, key Key, streamID string, update ActiveRunUpdate, buildDelta func(Snapshot) RuntimeDelta) (Snapshot, bool, error) {
+	var snapshot Snapshot
+	var changed bool
+	var err error
+	if m.distributed != nil {
+		snapshot, changed, err = m.distributed.UpdateActiveRun(ctx, key, streamID, update)
+	} else {
+		if m.localControl(streamID) == nil {
+			return Snapshot{}, false, ErrRunOwnershipLost
+		}
+		snapshot, changed, err = m.backend.Update(ctx, key, func(snapshot Snapshot, ok bool) (Snapshot, bool, error) {
+			if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != streamID || !isActiveRunStatus(snapshot.CurrentRunView.Status) {
+				return snapshot, false, ErrRunOwnershipLost
+			}
+			now, nowErr := m.backend.Now(ctx)
+			if nowErr != nil {
+				return snapshot, false, nowErr
+			}
+			return update(snapshot, now)
+		})
+	}
+	if err != nil || !changed {
+		return snapshot, changed, err
+	}
+	delta := RuntimeDelta{}
+	if buildDelta != nil {
+		delta = buildDelta(snapshot)
+	}
+	if err := m.publishRuntimeDelta(ctx, snapshot, streamID, delta); err != nil {
+		m.logger.Warn("publish runtime delta failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+	return snapshot, true, nil
+}
+
+func (m *Manager) runOwnerMatches(run *CurrentRunView) bool {
+	if run == nil {
+		return false
+	}
+	if m.distributed == nil {
+		return strings.TrimSpace(run.OwnerID) == "" && run.OwnerLeaseExpiresAt == nil
+	}
+	return strings.TrimSpace(run.OwnerID) == m.ownerID
+}
+
+func (m *Manager) publishRuntimeDelta(ctx context.Context, snapshot Snapshot, streamID string, delta RuntimeDelta) error {
+	eventStreamID := strings.TrimSpace(streamID)
+	if eventStreamID == "" && snapshot.CurrentRunView != nil {
+		eventStreamID = snapshot.CurrentRunView.StreamID
+	}
+	// No defensive clone here: both backends isolate on publish (memory clones
+	// the event once for its subscribers, redis marshals it immediately).
+	updatedAt := snapshot.UpdatedAt
+	return m.backend.Publish(ctx, Event{
+		Type:      EventRuntimeDelta,
+		BotID:     snapshot.BotID,
+		SessionID: snapshot.SessionID,
+		StreamID:  eventStreamID,
+		Seq:       snapshot.Seq,
+		UpdatedAt: &updatedAt,
+		Delta:     &delta,
+	})
+}

--- a/internal/sessionruntime/manager_test.go
+++ b/internal/sessionruntime/manager_test.go
@@ -1,0 +1,1108 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+const (
+	testBotID     = "bot-runtime"
+	testSessionID = "session-runtime"
+	testStreamID  = "stream-runtime"
+)
+
+type runtimeBackendContractSuite struct {
+	newBackend        func(t *testing.T) Backend
+	newSharedBackends func(t *testing.T, count int) []Backend
+}
+
+func memoryRuntimeBackendSuite() runtimeBackendContractSuite {
+	return runtimeBackendContractSuite{
+		newBackend: func(t *testing.T) Backend {
+			t.Helper()
+			return NewMemoryBackend()
+		},
+		newSharedBackends: func(t *testing.T, count int) []Backend {
+			t.Helper()
+			backend := NewMemoryBackend()
+			backends := make([]Backend, count)
+			for i := range backends {
+				backends[i] = backend
+			}
+			return backends
+		},
+	}
+}
+
+func testRuntimeManager(t *testing.T, backend Backend, ownerID string) *Manager {
+	t.Helper()
+	manager := NewManager(backend, Options{
+		OwnerID:       ownerID,
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 2 * time.Second,
+	})
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = manager.Close()
+	})
+	return manager
+}
+
+func testRuntimeManagerWithOptions(t *testing.T, backend Backend, opts Options) *Manager {
+	t.Helper()
+	manager := NewManager(backend, opts)
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = manager.Close()
+	})
+	return manager
+}
+
+type gatedCommandSubscribeBackend struct {
+	DistributedBackend
+	entered  chan struct{}
+	release  chan struct{}
+	commands chan Command
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func (b *gatedCommandSubscribeBackend) SubscribeCommands(context.Context, string) (CommandSubscription, error) {
+	close(b.entered)
+	<-b.release
+	return CommandSubscription{C: b.commands, Close: b.closeSubscription}, nil
+}
+
+func (*gatedCommandSubscribeBackend) Close() error {
+	return nil
+}
+
+func (b *gatedCommandSubscribeBackend) closeSubscription() {
+	b.once.Do(func() {
+		close(b.commands)
+		close(b.closed)
+	})
+}
+
+type activationGateBackend struct {
+	Backend
+	calls   atomic.Int64
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *activationGateBackend) Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error) {
+	if b.calls.Add(1) == 2 {
+		b.once.Do(func() { close(b.entered) })
+		select {
+		case <-b.release:
+		case <-ctx.Done():
+			return Snapshot{}, false, ctx.Err()
+		}
+	}
+	return b.Backend.Update(ctx, key, update)
+}
+
+func richRuntimeAgentScript() []agentpkg.StreamEvent {
+	return []agentpkg.StreamEvent{
+		{Type: agentpkg.EventAgentStart},
+		{Type: agentpkg.EventReasoningDelta, Delta: "I need to inspect the workspace."},
+		{Type: agentpkg.EventTextDelta, Delta: "I will check the current state."},
+		{Type: agentpkg.EventToolCallStart, ToolName: "exec", ToolCallID: "call-exec", Input: map[string]any{"command": "pwd"}},
+		{Type: agentpkg.EventToolCallProgress, ToolName: "exec", ToolCallID: "call-exec", Progress: "queued"},
+		{Type: agentpkg.EventToolCallEnd, ToolName: "exec", ToolCallID: "call-exec", Result: map[string]any{"stdout": "/workspace\n"}},
+		{Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-approval", Input: map[string]any{"command": "rm -rf build"}, ApprovalID: "approval-1", ShortID: 7, Status: "pending"},
+		{Type: agentpkg.EventUserInputRequest, ToolName: "ask_user", ToolCallID: "call-ask", Input: map[string]any{"questions": []any{map[string]any{"text": "Continue?", "kind": "single_select"}}}, UserInputID: "input-1", ShortID: 8, Status: "pending", Metadata: map[string]any{"ui_payload": map[string]any{"version": 2, "questions": []any{map[string]any{"id": "q1", "text": "Continue?", "kind": "single_select"}}}}},
+	}
+}
+
+func TestMemoryRuntimeManagerContract(t *testing.T) {
+	t.Parallel()
+	runCommonRuntimeManagerContract(t, memoryRuntimeBackendSuite())
+}
+
+func waitRuntimeEvent(t *testing.T, events <-chan Event, pred func(Event) bool) Event {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatal("runtime subscription closed")
+			}
+			if pred(event) {
+				return event
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for runtime event")
+		}
+	}
+}
+
+func receiveTestResult[T any](t *testing.T, label string, ch <-chan T) T {
+	t.Helper()
+	select {
+	case result := <-ch:
+		return result
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+		var zero T
+		return zero
+	}
+}
+
+func TestRuntimeManagerRejectsRunAfterClose(t *testing.T) {
+	manager := NewManager(NewMemoryBackend(), Options{})
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	err := manager.StartRun(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-after-close",
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("start run after close error = %v, want ErrManagerClosed", err)
+	}
+	if ctrl := manager.localControl("stream-after-close"); ctrl != nil {
+		t.Fatalf("closed manager retained run control: %#v", ctrl)
+	}
+}
+
+func TestRuntimeManagerDoesNotActivateAdmissionAfterClose(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := NewManager(backend, Options{})
+	builderStarted := make(chan struct{})
+	releaseBuilder := make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- manager.StartRunWithAdmissionBuilder(
+			context.Background(),
+			testBotID,
+			"session-close-during-admission",
+			"stream-close-during-admission",
+			func(context.Context) (RunAdmissionView, error) {
+				close(builderStarted)
+				<-releaseBuilder
+				return RunAdmissionView{}, nil
+			},
+			make(chan struct{}, 1),
+			func() {},
+			make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	<-builderStarted
+
+	shutdownCtx, cancelShutdown := context.WithCancel(context.Background())
+	cancelShutdown()
+	if err := manager.CloseContext(shutdownCtx); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	close(releaseBuilder)
+	if err := receiveTestResult(t, "closed admission", startDone); !errors.Is(err, ErrManagerClosed) && !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("closed admission error = %v, want manager closed or ownership lost", err)
+	}
+	snapshot, ok, err := backend.Load(context.Background(), Key{BotID: testBotID, SessionID: "session-close-during-admission"})
+	if err != nil || !ok {
+		t.Fatalf("load closed admission = ok:%v err:%v", ok, err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status == RunStatusRunning {
+		t.Fatalf("closed admission snapshot = %#v, must not activate", snapshot.CurrentRunView)
+	}
+}
+
+func TestRuntimeManagerDoesNotStartCommandLoopAfterClose(t *testing.T) {
+	backend := &gatedCommandSubscribeBackend{
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+		commands: make(chan Command),
+		closed:   make(chan struct{}),
+	}
+	t.Cleanup(backend.closeSubscription)
+	manager := NewManager(backend, Options{OwnerID: "owner-start-close-race"})
+	t.Cleanup(func() { _ = manager.Close() })
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- manager.Start(context.Background())
+	}()
+	<-backend.entered
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	close(backend.release)
+	if err := receiveTestResult(t, "manager start after close", startDone); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("start after close error = %v, want ErrManagerClosed", err)
+	}
+	receiveTestResult(t, "late command subscription close", backend.closed)
+}
+
+func TestRuntimeManagerDoesNotTerminalizeAdmissionRejectedByClose(t *testing.T) {
+	backend := &activationGateBackend{
+		Backend: NewMemoryBackend(),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	manager := NewManager(backend, Options{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- manager.StartRun(
+			context.Background(), testBotID, "session-close-activation", "stream-close-activation",
+			make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	<-backend.entered
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- manager.Close() }()
+	deadline := time.After(time.Second)
+	for !manager.isClosed() {
+		select {
+		case <-deadline:
+			t.Fatal("manager close did not start")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	close(backend.release)
+	if err := receiveTestResult(t, "activation rejected by close", startDone); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("start run error = %v, want ErrManagerClosed", err)
+	}
+	if err := receiveTestResult(t, "manager close after activation rejection", closeDone); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	snapshot, ok, err := backend.Load(context.Background(), Key{BotID: testBotID, SessionID: "session-close-activation"})
+	if err != nil || !ok {
+		t.Fatalf("load rejected activation = ok:%v err:%v", ok, err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusAdmitting {
+		t.Fatalf("rejected activation = %#v, want admitting reservation", snapshot.CurrentRunView)
+	}
+}
+
+func TestMemoryBackendExpiresSnapshots(t *testing.T) {
+	backend := NewMemoryBackendWithTTL(30 * time.Millisecond)
+	t.Cleanup(func() { _ = backend.Close() })
+	key := Key{BotID: testBotID, SessionID: "session-memory-ttl"}
+	if _, _, err := backend.Update(context.Background(), key, func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+		snapshot.BotID = key.BotID
+		snapshot.SessionID = key.SessionID
+		snapshot.Seq = 1
+		snapshot.Queue = []QueuedRunView{}
+		return snapshot, true, nil
+	}); err != nil {
+		t.Fatalf("start memory run: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, ok, err := backend.Load(context.Background(), key); err != nil || ok {
+		t.Fatalf("expired snapshot = ok:%v err:%v", ok, err)
+	}
+}
+
+func TestLocalRuntimeDoesNotUseOwnerLeases(t *testing.T) {
+	t.Parallel()
+
+	manager := testRuntimeManagerWithOptions(t, NewMemoryBackendWithTTL(20*time.Millisecond), Options{
+		OwnerID:       "must-not-leak-into-local-state",
+		StateTTL:      20 * time.Millisecond,
+		OwnerLeaseTTL: 20 * time.Millisecond,
+	})
+	if err := manager.StartRun(context.Background(), testBotID, "session-local-no-lease", "stream-local-no-lease", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start local run: %v", err)
+	}
+	ctrl := manager.localControl("stream-local-no-lease")
+	if ctrl == nil {
+		t.Fatal("local run control missing")
+	}
+	if ctrl.leaseStop != nil || ctrl.leaseDone != nil || !ctrl.leaseValidUntil.IsZero() {
+		t.Fatalf("local control unexpectedly has lease state: %#v", ctrl)
+	}
+
+	time.Sleep(3 * 20 * time.Millisecond)
+	if err := manager.ValidateRunOwnership(context.Background(), testBotID, "session-local-no-lease", "stream-local-no-lease"); err != nil {
+		t.Fatalf("local ownership expired after lease TTL: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, "session-local-no-lease", "stream-local-no-lease", agentpkg.StreamEvent{Type: agentpkg.EventTextDelta, Delta: "still running"}); err != nil {
+		t.Fatalf("handle local event after lease TTL: %v", err)
+	}
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, "session-local-no-lease")
+	if err != nil {
+		t.Fatalf("load local snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusRunning {
+		t.Fatalf("local run = %#v, want running", snapshot.CurrentRunView)
+	}
+	if snapshot.CurrentRunView.OwnerID != "" || snapshot.CurrentRunView.OwnerLeaseExpiresAt != nil {
+		t.Fatalf("local run leaked distributed ownership: %#v", snapshot.CurrentRunView)
+	}
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageText, "", "still running")
+}
+
+func runCommonRuntimeManagerContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+	t.Run("snapshots rich active run and publishes deltas", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerSnapshotsRichActiveRunContract(t, suite)
+	})
+	t.Run("shares validated replacement operation snapshots", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerSharesReplacementOperationContract(t, suite)
+	})
+	t.Run("shares canonical request user turn snapshots", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerSharesRequestUserTurnContract(t, suite)
+	})
+	t.Run("keeps queued steer valid past command acknowledgement timeout", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerKeepsQueuedSteerPastAckTimeoutContract(t, suite)
+	})
+	t.Run("rejects queued steer when the run finishes", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRejectsQueuedSteerOnFinishContract(t, suite)
+	})
+	t.Run("rejects queued steer when the agent sends a terminal event", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRejectsQueuedSteerOnAgentTerminalContract(t, suite)
+	})
+	t.Run("signals subscriber buffer overflow", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerSignalsSubscriberOverflowContract(t, suite)
+	})
+	t.Run("keeps errored streams errored when abort terminal follows", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerKeepsErroredStreamErroredAfterAbortContract(t, suite)
+	})
+	t.Run("keeps errored streams errored when end terminal follows", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerKeepsErroredStreamErroredAfterEndContract(t, suite)
+	})
+	t.Run("serializes concurrent snapshot updates", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeBackendSerializesConcurrentSnapshotUpdatesContract(t, suite)
+	})
+}
+
+func runRuntimeManagerKeepsQueuedSteerPastAckTimeoutContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	const commandAckTTL = 500 * time.Millisecond
+	manager := testRuntimeManagerWithOptions(t, suite.newBackend(t), Options{
+		OwnerID:       "owner-queued-steer",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+		CommandAckTTL: commandAckTTL,
+	})
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	steer, err := manager.Steer(context.Background(), testBotID, testSessionID, testStreamID, "wait for the next model step")
+	if err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+
+	queued := waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+		return snapshot.CurrentRunView != nil &&
+			snapshot.CurrentRunView.Steer != nil &&
+			snapshot.CurrentRunView.Steer.ID == steer.ID &&
+			snapshot.CurrentRunView.Steer.Status == SteerStatusQueued
+	})
+	if queued.CurrentRunView == nil || queued.CurrentRunView.Steer == nil {
+		t.Fatal("queued steer is missing")
+	}
+	time.Sleep(2 * commandAckTTL)
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot queued steer after acknowledgement timeout: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.ID != steer.ID || snapshot.CurrentRunView.Steer.Status != SteerStatusQueued {
+		t.Fatalf("steer after acknowledgement timeout = %#v, want queued", snapshot.CurrentRunView)
+	}
+
+	select {
+	case injected := <-injectCh:
+		if injected.Applied == nil {
+			t.Fatal("queued steer is missing its applied acknowledgement")
+		}
+		injected.Applied()
+	case <-time.After(time.Second):
+		t.Fatal("queued steer was not delivered to the agent")
+	}
+	waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+		return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Steer != nil && snapshot.CurrentRunView.Steer.Status == SteerStatusApplied
+	})
+}
+
+func TestRuntimeManagerPublishesAdmittingCheckpoint(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := testRuntimeManager(t, backend, "owner-admitting")
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+
+	builderStarted := make(chan struct{})
+	releaseBuilder := make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- manager.StartRunWithOperationBuilder(
+			context.Background(),
+			testBotID,
+			testSessionID,
+			"stream-admitting",
+			func(context.Context) (*RunOperationView, error) {
+				close(builderStarted)
+				<-releaseBuilder
+				return &RunOperationView{Kind: RunOperationRetry, ReplaceFromMessageID: "assistant-old"}, nil
+			},
+			make(chan struct{}, 1),
+			func() {},
+			make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	<-builderStarted
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot reserved run: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusAdmitting {
+		t.Fatalf("reserved run = %#v, want admitting", snapshot.CurrentRunView)
+	}
+	event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Delta != nil && event.Delta.CurrentRunView != nil && event.Delta.CurrentRunView.Status == RunStatusAdmitting
+	})
+	if event.Snapshot != nil || event.Seq != snapshot.Seq {
+		t.Fatalf("admitting checkpoint = %#v", event)
+	}
+
+	close(releaseBuilder)
+	if err := <-startDone; err != nil {
+		t.Fatalf("activate run: %v", err)
+	}
+	event = waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Delta != nil && event.Delta.CurrentRunView != nil && event.Delta.CurrentRunView.Status == RunStatusRunning
+	})
+	if event.Delta == nil || event.Delta.CurrentRunView == nil || event.Delta.CurrentRunView.Status != RunStatusRunning || event.Snapshot != nil {
+		t.Fatalf("activated event = %#v", event)
+	}
+}
+
+func TestRuntimeManagerBuilderFailureReleasesReservation(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := testRuntimeManager(t, backend, "owner-builder-failure")
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	err = manager.StartRunWithOperationBuilder(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-builder-failure",
+		func(context.Context) (*RunOperationView, error) { return nil, errors.New("prepare operation failed") },
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err == nil || !strings.Contains(err.Error(), "prepare operation failed") {
+		t.Fatalf("builder error = %v", err)
+	}
+	if _, ok, err := manager.StreamRef(context.Background(), "stream-builder-failure"); err != nil || ok {
+		t.Fatalf("reservation stream ref = ok:%v err:%v", ok, err)
+	}
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusErrored {
+		t.Fatalf("failed admission snapshot = %#v", snapshot.CurrentRunView)
+	}
+	event := waitRuntimeEvent(t, sub.C, func(event Event) bool { return event.Seq == snapshot.Seq })
+	if event.Delta == nil || event.Delta.CurrentRunView == nil || event.Delta.CurrentRunView.Status != RunStatusErrored {
+		t.Fatalf("failed admission event = %#v, want self-contained terminal run", event)
+	}
+}
+
+func runRuntimeManagerRejectsQueuedSteerOnFinishContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	manager := testRuntimeManager(t, suite.newBackend(t), "owner-finished-steer")
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	steer, err := manager.Steer(context.Background(), testBotID, testSessionID, testStreamID, "adjust before finish")
+	if err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+		return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Steer != nil &&
+			snapshot.CurrentRunView.Steer.ID == steer.ID && snapshot.CurrentRunView.Steer.Status == SteerStatusQueued
+	})
+	if err := manager.FinishRun(context.Background(), testBotID, testSessionID, testStreamID, RunStatusCompleted, ""); err != nil {
+		t.Fatalf("finish run: %v", err)
+	}
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.Status != SteerStatusRejected {
+		t.Fatalf("finished steer = %#v, want rejected", snapshot.CurrentRunView)
+	}
+	if snapshot.CurrentRunView.Steer.Error != steerRunFinishedError {
+		t.Fatalf("finished steer error = %q", snapshot.CurrentRunView.Steer.Error)
+	}
+	select {
+	case injected := <-injectCh:
+		if injected.Applied != nil {
+			injected.Applied()
+		}
+	default:
+		t.Fatal("queued steer was not delivered")
+	}
+	snapshot, err = manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot after late apply: %v", err)
+	}
+	if snapshot.CurrentRunView.Steer.Status != SteerStatusRejected {
+		t.Fatalf("late apply changed terminal steer = %#v", snapshot.CurrentRunView.Steer)
+	}
+}
+
+func runRuntimeManagerRejectsQueuedSteerOnAgentTerminalContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	for _, tc := range []struct {
+		name       string
+		event      agentpkg.StreamEvent
+		wantStatus string
+	}{
+		{name: "end", event: agentpkg.StreamEvent{Type: agentpkg.EventAgentEnd}, wantStatus: RunStatusCompleted},
+		{name: "abort", event: agentpkg.StreamEvent{Type: agentpkg.EventAgentAbort}, wantStatus: RunStatusAborted},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := testRuntimeManager(t, suite.newBackend(t), "owner-agent-terminal-steer-"+tc.name)
+			sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+			if err != nil {
+				t.Fatalf("subscribe: %v", err)
+			}
+			defer sub.Close()
+			injectCh := make(chan conversation.InjectMessage, 1)
+			if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+				t.Fatalf("start run: %v", err)
+			}
+			steer, err := manager.Steer(context.Background(), testBotID, testSessionID, testStreamID, "adjust before agent "+tc.name)
+			if err != nil {
+				t.Fatalf("steer: %v", err)
+			}
+			select {
+			case <-injectCh:
+			case <-time.After(time.Second):
+				t.Fatal("queued steer was not delivered")
+			}
+			waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+				return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Steer != nil &&
+					snapshot.CurrentRunView.Steer.ID == steer.ID && snapshot.CurrentRunView.Steer.Status == SteerStatusQueued
+			})
+			if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, tc.event); err != nil {
+				t.Fatalf("handle agent %s: %v", tc.name, err)
+			}
+
+			snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+			if err != nil {
+				t.Fatalf("snapshot: %v", err)
+			}
+			if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.Status != SteerStatusRejected {
+				t.Fatalf("agent-terminal steer = %#v, want rejected", snapshot.CurrentRunView)
+			}
+			if snapshot.CurrentRunView.Steer.Error != steerRunFinishedError {
+				t.Fatalf("agent-terminal steer error = %q", snapshot.CurrentRunView.Steer.Error)
+			}
+			event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+				return event.Delta != nil && event.Delta.Run != nil && event.Delta.Run.Status != nil && *event.Delta.Run.Status == tc.wantStatus
+			})
+			if event.Delta.Run.Steer == nil || event.Delta.Run.Steer.Status != SteerStatusRejected {
+				t.Fatalf("agent-terminal delta = %#v, want rejected steer", event.Delta)
+			}
+		})
+	}
+}
+
+func runRuntimeManagerSharesReplacementOperationContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-operation")
+	observer := testRuntimeManager(t, backends[1], "observer-operation")
+	replacement := &conversation.UITurn{
+		Role:      "user",
+		Text:      "edited prompt",
+		Timestamp: time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	}
+	operation := &RunOperationView{
+		Kind:                 RunOperationEdit,
+		ReplaceFromMessageID: "user-old",
+		ReplacementUserTurn:  replacement,
+	}
+	if err := owner.StartRunWithOperation(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		testStreamID,
+		operation,
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	); err != nil {
+		t.Fatalf("start replacement run: %v", err)
+	}
+
+	snapshot, err := observer.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("observer snapshot: %v", err)
+	}
+	got := snapshot.CurrentRunView
+	if got == nil || got.Operation == nil {
+		t.Fatalf("current run operation = %#v", got)
+	}
+	if got.Operation.Kind != RunOperationEdit || got.Operation.ReplaceFromMessageID != "user-old" {
+		t.Fatalf("operation = %#v", got.Operation)
+	}
+	if got.Operation.ReplacementUserTurn == nil || got.Operation.ReplacementUserTurn.Text != "edited prompt" {
+		t.Fatalf("replacement user turn = %#v", got.Operation.ReplacementUserTurn)
+	}
+}
+
+func runRuntimeManagerSharesRequestUserTurnContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-request-turn")
+	observer := testRuntimeManager(t, backends[1], "observer-request-turn")
+	requestTurn := &conversation.UITurn{
+		Role:              "user",
+		Text:              "inspect the workspace",
+		Attachments:       []conversation.UIAttachment{{Type: "file", Name: "notes.txt", ContentHash: "sha256:notes"}},
+		Timestamp:         time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+		Platform:          "local",
+		SenderUserID:      "user-request-turn",
+		ExternalMessageID: testStreamID,
+	}
+	if err := owner.StartRunWithAdmission(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		testStreamID,
+		RunAdmissionView{RequestUserTurn: requestTurn},
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	); err != nil {
+		t.Fatalf("start run with request user turn: %v", err)
+	}
+
+	snapshot, err := observer.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("observer snapshot: %v", err)
+	}
+	got := snapshot.CurrentRunView
+	if got == nil || got.RequestUserTurn == nil {
+		t.Fatalf("current run request user turn = %#v", got)
+	}
+	if got.RequestUserTurn.Text != requestTurn.Text || got.RequestUserTurn.ExternalMessageID != testStreamID {
+		t.Fatalf("request user turn = %#v", got.RequestUserTurn)
+	}
+	if len(got.RequestUserTurn.Attachments) != 1 || got.RequestUserTurn.Attachments[0].ContentHash != "sha256:notes" {
+		t.Fatalf("request user turn attachments = %#v", got.RequestUserTurn.Attachments)
+	}
+
+	requestTurn.Text = "mutated by caller"
+	requestTurn.Attachments[0].Name = "mutated.txt"
+	if got.RequestUserTurn.Text != "inspect the workspace" || got.RequestUserTurn.Attachments[0].Name != "notes.txt" {
+		t.Fatalf("runtime request user turn aliases caller state: %#v", got.RequestUserTurn)
+	}
+}
+
+func TestRuntimeManagerRejectsNonUserRequestTurn(t *testing.T) {
+	t.Parallel()
+
+	manager := testRuntimeManager(t, NewMemoryBackend(), "owner-invalid-request-turn")
+	err := manager.StartRunWithAdmission(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-invalid-request-turn",
+		RunAdmissionView{RequestUserTurn: &conversation.UITurn{Role: "assistant", Text: "invalid"}},
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err == nil || !strings.Contains(err.Error(), "must have role user") {
+		t.Fatalf("start run error = %v, want invalid request user turn", err)
+	}
+	snapshot, snapshotErr := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if snapshotErr != nil {
+		t.Fatalf("load errored snapshot: %v", snapshotErr)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusErrored {
+		t.Fatalf("invalid admission snapshot = %#v", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerSnapshotsRichActiveRunContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	manager := testRuntimeManager(t, suite.newBackend(t), "owner-1")
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+
+	abortCh := make(chan struct{}, 1)
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, abortCh, func() {}, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	for _, event := range richRuntimeAgentScript() {
+		if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, event); err != nil {
+			t.Fatalf("handle event %s: %v", event.Type, err)
+		}
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != testStreamID || snapshot.CurrentRunView.Status != RunStatusRunning {
+		t.Fatalf("current run = %#v", snapshot.CurrentRunView)
+	}
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageReasoning, "", "I need to inspect the workspace.")
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageText, "", "I will check the current state.")
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageTool, "call-exec", "")
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageTool, "call-approval", "")
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageTool, "call-ask", "")
+	if snapshot.Queue == nil {
+		t.Fatal("queue must be an empty array, not nil")
+	}
+
+	var sawDelta bool
+	deadline := time.After(2 * time.Second)
+	for !sawDelta {
+		select {
+		case event := <-sub.C:
+			sawDelta = event.Type == EventRuntimeDelta && event.Seq == snapshot.Seq && event.Delta != nil && event.Snapshot == nil
+		case <-deadline:
+			t.Fatal("timed out waiting for runtime delta")
+		}
+	}
+}
+
+func TestRuntimeManagerPublishesBoundedTextAppendPayloads(t *testing.T) {
+	manager := testRuntimeManager(t, NewMemoryBackend(), "owner-bounded-delta")
+	sub, err := manager.Subscribe(context.Background(), testBotID, "session-bounded-delta")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	if err := manager.StartRun(context.Background(), testBotID, "session-bounded-delta", "stream-bounded-delta", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	_ = waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Type == EventRuntimeDelta && event.Delta != nil && event.Delta.CurrentRunView != nil
+	})
+
+	chunk := strings.Repeat("x", 1024)
+	var lastWireSize int
+	for i := 0; i < 32; i++ {
+		if _, err := manager.HandleAgentEvent(context.Background(), testBotID, "session-bounded-delta", "stream-bounded-delta", agentpkg.StreamEvent{
+			Type:  agentpkg.EventTextDelta,
+			Delta: chunk,
+		}); err != nil {
+			t.Fatalf("handle text delta %d: %v", i, err)
+		}
+		event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+			return event.Type == EventRuntimeDelta && event.Delta != nil && len(event.Delta.MessageAppends) == 1
+		})
+		if event.Snapshot != nil || event.Delta.MessageAppends[0].Content != chunk {
+			t.Fatalf("text delta %d = %#v", i, event)
+		}
+		wire, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal text delta %d: %v", i, err)
+		}
+		lastWireSize = len(wire)
+		if lastWireSize > len(chunk)+512 {
+			t.Fatalf("text delta %d wire size = %d, want bounded near chunk size %d", i, lastWireSize, len(chunk))
+		}
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, "session-bounded-delta")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	snapshotWire, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	if lastWireSize*10 >= len(snapshotWire) {
+		t.Fatalf("last delta size = %d, snapshot size = %d; delta appears to carry accumulated output", lastWireSize, len(snapshotWire))
+	}
+}
+
+func TestRuntimeManagerRehydratesSnapshotWhenSequenceEpochResets(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "observer-sequence-reset",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 100 * time.Millisecond,
+	})
+	key := Key{BotID: testBotID, SessionID: "session-sequence-reset"}
+	firstUpdatedAt := time.Now().UTC()
+	if _, _, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Seq: 100, Queue: []QueuedRunView{}, UpdatedAt: firstUpdatedAt}, true, nil
+	}); err != nil {
+		t.Fatalf("seed first epoch: %v", err)
+	}
+	sub, err := manager.Subscribe(context.Background(), key.BotID, key.SessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	_ = waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Type == EventRuntimeSnapshot && event.Seq == 100
+	})
+
+	secondUpdatedAt := firstUpdatedAt.Add(time.Second)
+	if _, _, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Seq: 2, Queue: []QueuedRunView{}, UpdatedAt: secondUpdatedAt}, true, nil
+	}); err != nil {
+		t.Fatalf("seed second epoch: %v", err)
+	}
+	if err := backend.Publish(context.Background(), Event{
+		Type:      EventRuntimeDelta,
+		BotID:     key.BotID,
+		SessionID: key.SessionID,
+		Seq:       2,
+		UpdatedAt: &secondUpdatedAt,
+		Delta:     &RuntimeDelta{},
+	}); err != nil {
+		t.Fatalf("publish second epoch delta: %v", err)
+	}
+	event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Type == EventRuntimeSnapshot && event.Seq == 2
+	})
+	if event.Snapshot == nil || event.Delta != nil || event.Snapshot.Seq != 2 {
+		t.Fatalf("sequence reset event = %#v", event)
+	}
+}
+
+func runRuntimeManagerSignalsSubscriberOverflowContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	backend := suite.newBackend(t)
+	manager := testRuntimeManager(t, backend, "observer-overflow")
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	for seq := int64(1); seq <= 256; seq++ {
+		updatedAt := time.Now().UTC()
+		if err := backend.Publish(context.Background(), Event{
+			Type:      EventRuntimeDelta,
+			BotID:     testBotID,
+			SessionID: testSessionID,
+			Seq:       seq,
+			UpdatedAt: &updatedAt,
+			Delta:     &RuntimeDelta{},
+		}); err != nil {
+			t.Fatalf("publish event %d: %v", seq, err)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case event := <-sub.C:
+			if event.Type == EventRuntimeDropped {
+				return
+			}
+		case <-deadline:
+			t.Fatal("subscriber overflow did not produce runtime_dropped")
+		}
+	}
+}
+
+func runRuntimeManagerKeepsErroredStreamErroredAfterAbortContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	manager := testRuntimeManager(t, suite.newBackend(t), "owner-error")
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+		Type:  agentpkg.EventError,
+		Error: "runtime interrupted",
+	}); err != nil {
+		t.Fatalf("handle error event: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+		Type: agentpkg.EventAgentAbort,
+	}); err != nil {
+		t.Fatalf("handle abort terminal event: %v", err)
+	}
+	if err := manager.FinishRun(context.Background(), testBotID, testSessionID, testStreamID, "", ""); err != nil {
+		t.Fatalf("finish errored run: %v", err)
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusErrored {
+		t.Fatalf("current run = %#v, want errored", snapshot.CurrentRunView)
+	}
+	if snapshot.CurrentRunView.Error != "runtime interrupted" {
+		t.Fatalf("error = %q, want runtime interrupted", snapshot.CurrentRunView.Error)
+	}
+}
+
+func runRuntimeManagerKeepsErroredStreamErroredAfterEndContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	manager := testRuntimeManager(t, suite.newBackend(t), "owner-error-end")
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+		Type:  agentpkg.EventError,
+		Error: "provider failed",
+	}); err != nil {
+		t.Fatalf("handle error event: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+		Type: agentpkg.EventAgentEnd,
+	}); err != nil {
+		t.Fatalf("handle end terminal event: %v", err)
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusErrored || snapshot.CurrentRunView.Error != "provider failed" {
+		t.Fatalf("current run = %#v, want errored provider failure", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeBackendSerializesConcurrentSnapshotUpdatesContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	key := Key{BotID: testBotID, SessionID: "session-concurrent"}
+	backends := suite.newSharedBackends(t, 4)
+	for _, backend := range backends {
+		backend := backend
+		t.Cleanup(func() { _ = backend.Close() })
+	}
+	const updates = 40
+	var wg sync.WaitGroup
+	errCh := make(chan error, updates)
+	for i := 0; i < updates; i++ {
+		i := i
+		backend := backends[i%len(backends)]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := backend.Update(context.Background(), key, func(snapshot Snapshot, ok bool) (Snapshot, bool, error) {
+				if !ok {
+					snapshot = Snapshot{BotID: key.BotID, SessionID: key.SessionID, Queue: []QueuedRunView{}}
+				}
+				snapshot.Seq++
+				snapshot.UpdatedAt = time.Now().UTC()
+				snapshot.Queue = append(nonNilQueue(snapshot.Queue), QueuedRunView{StreamID: fmt.Sprintf("queued-%02d", i)})
+				return snapshot, true, nil
+			})
+			if err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("update: %v", err)
+		}
+	}
+	snapshot, ok, err := backends[0].Load(context.Background(), key)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !ok {
+		t.Fatal("snapshot missing after concurrent updates")
+	}
+	if snapshot.Seq != updates {
+		t.Fatalf("seq = %d, want %d", snapshot.Seq, updates)
+	}
+	if len(snapshot.Queue) != updates {
+		t.Fatalf("queue len = %d, want %d", len(snapshot.Queue), updates)
+	}
+}
+
+func assertRuntimeBlock(t *testing.T, messages []conversation.UIMessage, kind conversation.UIMessageType, toolCallID, content string) {
+	t.Helper()
+	for _, message := range messages {
+		if message.Type != kind {
+			continue
+		}
+		if toolCallID != "" && message.ToolCallID != toolCallID {
+			continue
+		}
+		if content != "" && message.Content != content {
+			continue
+		}
+		return
+	}
+	data, _ := json.Marshal(messages)
+	t.Fatalf("missing runtime block kind=%s tool=%q content=%q in %s", kind, toolCallID, content, data)
+}
+
+func waitRuntimeSnapshot(t *testing.T, manager *Manager, botID, sessionID string, pred func(Snapshot) bool) Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot, err := manager.Snapshot(context.Background(), botID, sessionID)
+		if err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+		if pred(snapshot) {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	snapshot, _ := manager.Snapshot(context.Background(), botID, sessionID)
+	t.Fatalf("timed out waiting for snapshot, last=%#v", snapshot)
+	return Snapshot{}
+}

--- a/internal/sessionruntime/memory.go
+++ b/internal/sessionruntime/memory.go
@@ -1,0 +1,355 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+// subscriberSet tracks per-key subscriber channels. All methods must be called
+// with the owning backend's mutex held.
+type subscriberSet[T any] struct {
+	nextID int
+	subs   map[string]map[int]chan T
+}
+
+func newSubscriberSet[T any]() *subscriberSet[T] {
+	return &subscriberSet[T]{subs: make(map[string]map[int]chan T)}
+}
+
+func (s *subscriberSet[T]) register(key string) (int, chan T) {
+	s.nextID++
+	id := s.nextID
+	ch := make(chan T, 64)
+	if s.subs[key] == nil {
+		s.subs[key] = make(map[int]chan T)
+	}
+	s.subs[key][id] = ch
+	return id, ch
+}
+
+func (s *subscriberSet[T]) unregister(key string, id int) {
+	subs := s.subs[key]
+	if subs == nil {
+		return
+	}
+	if target := subs[id]; target != nil {
+		delete(subs, id)
+		close(target)
+	}
+	if len(subs) == 0 {
+		delete(s.subs, key)
+	}
+}
+
+func (s *subscriberSet[T]) closeAll() {
+	for key, subs := range s.subs {
+		for id, ch := range subs {
+			delete(subs, id)
+			close(ch)
+		}
+		delete(s.subs, key)
+	}
+}
+
+type MemoryBackend struct {
+	mu                sync.Mutex
+	stateTTL          time.Duration
+	nextCleanup       time.Time
+	snapshots         map[string]Snapshot
+	snapshotExpiresAt map[string]time.Time
+	subscribers       *subscriberSet[Event]
+	closed            bool
+}
+
+func NewMemoryBackend() *MemoryBackend {
+	return NewMemoryBackendWithTTL(24 * time.Hour)
+}
+
+func NewMemoryBackendWithTTL(stateTTL time.Duration) *MemoryBackend {
+	if stateTTL <= 0 {
+		stateTTL = 24 * time.Hour
+	}
+	return &MemoryBackend{
+		stateTTL:          stateTTL,
+		snapshots:         make(map[string]Snapshot),
+		snapshotExpiresAt: make(map[string]time.Time),
+		subscribers:       newSubscriberSet[Event](),
+	}
+}
+
+func (*MemoryBackend) Now(ctx context.Context) (time.Time, error) {
+	if err := contextError(ctx); err != nil {
+		return time.Time{}, err
+	}
+	return time.Now().UTC(), nil
+}
+
+func (b *MemoryBackend) Load(ctx context.Context, key Key) (Snapshot, bool, error) {
+	if err := contextError(ctx); err != nil {
+		return Snapshot{}, false, err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := contextError(ctx); err != nil {
+		return Snapshot{}, false, err
+	}
+	now := time.Now()
+	b.purgeExpiredLocked(now)
+	k := key.String()
+	snapshot, ok := b.snapshots[k]
+	if !ok {
+		return Snapshot{}, false, nil
+	}
+	cloned, err := cloneSnapshot(snapshot)
+	return cloned, true, err
+}
+
+func (b *MemoryBackend) Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error) {
+	if update == nil {
+		return Snapshot{}, false, errors.New("snapshot update is required")
+	}
+	if err := contextError(ctx); err != nil {
+		return Snapshot{}, false, err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := contextError(ctx); err != nil {
+		return Snapshot{}, false, err
+	}
+	now := time.Now()
+	b.purgeExpiredLocked(now)
+	k := key.String()
+	snapshot, ok := b.snapshots[k]
+	// The callback receives a private clone and owns whatever it returns, so
+	// only the stored copy needs re-isolation before handing `next` back.
+	current, err := cloneSnapshot(snapshot)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	next, changed, err := update(current, ok)
+	if err != nil || !changed {
+		return next, changed, err
+	}
+	next.Queue = nonNilQueue(next.Queue)
+	stored, err := cloneSnapshot(next)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	b.snapshots[k] = stored
+	b.snapshotExpiresAt[k] = now.Add(b.stateTTL)
+	b.scheduleCleanupLocked(b.snapshotExpiresAt[k])
+	return next, true, nil
+}
+
+func (b *MemoryBackend) Publish(ctx context.Context, event Event) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	shared, err := cloneEvent(event)
+	if err != nil {
+		return err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	subs := b.subscribers.subs[Key{BotID: event.BotID, SessionID: event.SessionID}.String()]
+	if len(subs) == 0 {
+		return nil
+	}
+	// Consumers treat events as read-only, so one isolation clone shared by
+	// every subscriber decouples them all from the publisher's copy.
+	for _, ch := range subs {
+		enqueueRuntimeEvent(ch, shared)
+	}
+	return nil
+}
+
+func (b *MemoryBackend) Subscribe(ctx context.Context, key Key) (Subscription, error) {
+	if err := contextError(ctx); err != nil {
+		return Subscription{}, err
+	}
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan Event)
+		close(ch)
+		return Subscription{C: ch, Close: func() {}}, nil
+	}
+	k := key.String()
+	id, ch := b.subscribers.register(k)
+	b.mu.Unlock()
+	var once sync.Once
+	closeSub := func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			b.subscribers.unregister(k, id)
+		})
+	}
+	if done := ctx.Done(); done != nil {
+		go func() {
+			<-done
+			closeSub()
+		}()
+	}
+	return Subscription{
+		C:     ch,
+		Close: closeSub,
+	}, nil
+}
+
+func (b *MemoryBackend) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	b.subscribers.closeAll()
+	return nil
+}
+
+func cloneSnapshot(snapshot Snapshot) (Snapshot, error) {
+	var messages []conversation.UIMessage
+	if snapshot.CurrentRunView != nil {
+		messages = snapshot.CurrentRunView.Messages
+		currentRun := *snapshot.CurrentRunView
+		currentRun.Messages = nil
+		snapshot.CurrentRunView = &currentRun
+	}
+	var out Snapshot
+	if err := cloneJSON(snapshot, &out); err != nil {
+		return Snapshot{}, err
+	}
+	if out.CurrentRunView != nil {
+		clonedMessages, err := cloneUIMessages(messages)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		out.CurrentRunView.Messages = clonedMessages
+	}
+	out.Queue = nonNilQueue(out.Queue)
+	return out, nil
+}
+
+func cloneUIMessages(messages []conversation.UIMessage) ([]conversation.UIMessage, error) {
+	if messages == nil {
+		return nil, nil
+	}
+	out := make([]conversation.UIMessage, len(messages))
+	for i := range messages {
+		message := messages[i]
+		if message.Running != nil {
+			running := *message.Running
+			message.Running = &running
+		}
+		var err error
+		if message.Input, err = cloneJSONValue(message.Input); err != nil {
+			return nil, err
+		}
+		if message.Output, err = cloneJSONValue(message.Output); err != nil {
+			return nil, err
+		}
+		if len(message.Progress) > 0 {
+			message.Progress = make([]any, len(messages[i].Progress))
+			for j := range messages[i].Progress {
+				message.Progress[j], err = cloneJSONValue(messages[i].Progress[j])
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		if err := cloneJSON(messages[i].Attachments, &message.Attachments); err != nil {
+			return nil, err
+		}
+		if messages[i].Approval != nil {
+			approval := *messages[i].Approval
+			message.Approval = &approval
+		}
+		if messages[i].UserInput != nil {
+			var userInput conversation.UIUserInput
+			if err := cloneJSON(messages[i].UserInput, &userInput); err != nil {
+				return nil, err
+			}
+			message.UserInput = &userInput
+		}
+		if messages[i].Background != nil {
+			background := *messages[i].Background
+			message.Background = &background
+		}
+		out[i] = message
+	}
+	return out, nil
+}
+
+func cloneJSONValue(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	var out any
+	if err := cloneJSON(value, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (b *MemoryBackend) purgeExpiredLocked(now time.Time) {
+	if !b.nextCleanup.IsZero() && now.Before(b.nextCleanup) {
+		return
+	}
+	nextCleanup := time.Time{}
+	for key, expiresAt := range b.snapshotExpiresAt {
+		if !now.Before(expiresAt) {
+			if snapshot, ok := b.snapshots[key]; ok && snapshot.CurrentRunView != nil && isActiveRunStatus(snapshot.CurrentRunView.Status) {
+				// Active local runs are owned by their in-process runControl and
+				// live until they terminalize or the process exits.
+				delete(b.snapshotExpiresAt, key)
+				continue
+			}
+			delete(b.snapshots, key)
+			delete(b.snapshotExpiresAt, key)
+		} else if nextCleanup.IsZero() || expiresAt.Before(nextCleanup) {
+			nextCleanup = expiresAt
+		}
+	}
+	b.nextCleanup = nextCleanup
+}
+
+func (b *MemoryBackend) scheduleCleanupLocked(expiresAt time.Time) {
+	if expiresAt.IsZero() {
+		return
+	}
+	if b.nextCleanup.IsZero() || expiresAt.Before(b.nextCleanup) {
+		b.nextCleanup = expiresAt
+	}
+}
+
+func cloneEvent(event Event) (Event, error) {
+	var out Event
+	if err := cloneJSON(event, &out); err != nil {
+		return Event{}, err
+	}
+	return out, nil
+}
+
+func cloneJSON(in, out any) error {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, out)
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}

--- a/internal/sessionruntime/memory_test.go
+++ b/internal/sessionruntime/memory_test.go
@@ -1,0 +1,66 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func TestMemoryBackendRejectsUnserializableSnapshotWithoutCorruptingState(t *testing.T) {
+	backend := NewMemoryBackend()
+	key := Key{BotID: "bot-1", SessionID: "session-1"}
+	if _, changed, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Seq: 1, Queue: []QueuedRunView{}}, true, nil
+	}); err != nil || !changed {
+		t.Fatalf("seed snapshot: changed=%v err=%v", changed, err)
+	}
+
+	if _, changed, err := backend.Update(context.Background(), key, func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+		snapshot.Seq = 2
+		snapshot.CurrentRunView = &CurrentRunView{
+			StreamID: "stream-1",
+			Status:   RunStatusRunning,
+			Messages: []conversation.UIMessage{{ID: 1, Type: conversation.UIMessageTool, Input: make(chan struct{})}},
+		}
+		return snapshot, true, nil
+	}); err == nil || changed {
+		t.Fatalf("unserializable update: changed=%v err=%v", changed, err)
+	}
+
+	snapshot, ok, err := backend.Load(context.Background(), key)
+	if err != nil || !ok {
+		t.Fatalf("load preserved snapshot: ok=%v err=%v", ok, err)
+	}
+	if snapshot.Seq != 1 || snapshot.CurrentRunView != nil {
+		t.Fatalf("snapshot corrupted after rejected update: %#v", snapshot)
+	}
+}
+
+func TestMemoryBackendRejectsCanceledOperations(t *testing.T) {
+	backend := NewMemoryBackend()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	key := Key{BotID: "bot-1", SessionID: "session-1"}
+
+	if _, _, err := backend.Load(ctx, key); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Load error = %v, want context.Canceled", err)
+	}
+	if _, _, err := backend.Update(ctx, key, func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+		return snapshot, true, nil
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Update error = %v, want context.Canceled", err)
+	}
+	if _, err := backend.Subscribe(ctx, key); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Subscribe error = %v, want context.Canceled", err)
+	}
+}
+
+func TestMemoryBackendDoesNotImplementDistributedCoordination(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := any(NewMemoryBackend()).(DistributedBackend); ok {
+		t.Fatal("MemoryBackend unexpectedly implements DistributedBackend")
+	}
+}

--- a/internal/sessionruntime/state.go
+++ b/internal/sessionruntime/state.go
@@ -1,0 +1,238 @@
+package sessionruntime
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func runtimeDeltaForAgentEvent(event agentpkg.StreamEvent, messages []conversation.UIMessage) (RuntimeDelta, bool) {
+	switch event.Type {
+	case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort, agentpkg.EventError:
+		return RuntimeDelta{MessageUpserts: append([]conversation.UIMessage(nil), messages...)}, true
+	case agentpkg.EventRetry:
+		return RuntimeDelta{ResetMessages: true}, true
+	case agentpkg.EventTextDelta, agentpkg.EventReasoningDelta:
+		if event.Delta == "" || len(messages) == 0 {
+			return RuntimeDelta{}, false
+		}
+		message := messages[len(messages)-1]
+		return RuntimeDelta{MessageAppends: []RuntimeMessageAppend{{
+			ID:      message.ID,
+			Type:    message.Type,
+			Content: event.Delta,
+		}}}, true
+	case agentpkg.EventToolCallProgress:
+		if len(messages) == 0 {
+			return RuntimeDelta{}, false
+		}
+		message := messages[len(messages)-1]
+		return RuntimeDelta{ProgressAppends: []RuntimeProgressAppend{{
+			ID:       message.ID,
+			Progress: event.Progress,
+			Input:    event.Input,
+		}}}, true
+	default:
+		if len(messages) == 0 {
+			return RuntimeDelta{}, false
+		}
+		return RuntimeDelta{MessageUpserts: append([]conversation.UIMessage(nil), messages...)}, true
+	}
+}
+
+func runtimeRunPatch(snapshot Snapshot, status, runError, steer, lease bool) RuntimeDelta {
+	run := snapshot.CurrentRunView
+	if run == nil {
+		return RuntimeDelta{}
+	}
+	updatedAt := run.UpdatedAt
+	patch := &CurrentRunPatch{
+		StreamID:  run.StreamID,
+		UpdatedAt: &updatedAt,
+	}
+	if status {
+		value := run.Status
+		patch.Status = &value
+	}
+	if runError {
+		value := run.Error
+		patch.Error = &value
+	}
+	if steer && run.Steer != nil {
+		value := *run.Steer
+		patch.Steer = &value
+	}
+	if lease {
+		value := time.Time{}
+		if run.OwnerLeaseExpiresAt != nil {
+			value = *run.OwnerLeaseExpiresAt
+		}
+		patch.OwnerLeaseExpiresAt = &value
+	}
+	return RuntimeDelta{Run: patch}
+}
+
+// leaseExpired is independent of process-local control. Once the backend
+// lease expires, the old owner must not revive it even if its goroutine resumes.
+func (*Manager) leaseExpired(run *CurrentRunView, now time.Time) bool {
+	if run == nil || !isActiveRunStatus(run.Status) || run.OwnerLeaseExpiresAt == nil || now.Before(*run.OwnerLeaseExpiresAt) {
+		return false
+	}
+	return true
+}
+
+func isActiveRunStatus(status string) bool {
+	return strings.EqualFold(status, RunStatusAdmitting) || strings.EqualFold(status, RunStatusRunning) || strings.EqualFold(status, RunStatusAborting)
+}
+
+func isEventAcceptingRunStatus(status string) bool {
+	return strings.EqualFold(status, RunStatusRunning) || strings.EqualFold(status, RunStatusAborting)
+}
+
+func (m *Manager) markLostIfExpired(snapshot *Snapshot, now time.Time) bool {
+	if snapshot == nil || !m.leaseExpired(snapshot.CurrentRunView, now) {
+		return false
+	}
+	run := snapshot.CurrentRunView
+	snapshot.Seq++
+	snapshot.UpdatedAt = now
+	run.Status = RunStatusLost
+	run.Error = "runtime owner lease expired"
+	run.UpdatedAt = now
+	run.OwnerLeaseExpiresAt = nil
+	return true
+}
+
+func nonNilQueue(queue []QueuedRunView) []QueuedRunView {
+	if queue != nil {
+		return queue
+	}
+	return []QueuedRunView{}
+}
+
+func normalizeRunOperation(operation *RunOperationView) (*RunOperationView, error) {
+	if operation == nil {
+		return nil, nil
+	}
+	kind := strings.ToLower(strings.TrimSpace(operation.Kind))
+	replaceFrom := strings.TrimSpace(operation.ReplaceFromMessageID)
+	if replaceFrom == "" {
+		return nil, errors.New("runtime operation replace_from_message_id is required")
+	}
+	if kind != RunOperationRetry && kind != RunOperationEdit {
+		return nil, fmt.Errorf("unsupported runtime operation %q", operation.Kind)
+	}
+	clone := &RunOperationView{
+		Kind:                 kind,
+		ReplaceFromMessageID: replaceFrom,
+	}
+	if operation.ReplacementUserTurn != nil {
+		turn := *operation.ReplacementUserTurn
+		turn.Attachments = append([]conversation.UIAttachment(nil), turn.Attachments...)
+		clone.ReplacementUserTurn = &turn
+	}
+	if kind == RunOperationEdit && (clone.ReplacementUserTurn == nil || !strings.EqualFold(strings.TrimSpace(clone.ReplacementUserTurn.Role), "user")) {
+		return nil, errors.New("edit runtime operation requires a replacement user turn")
+	}
+	return clone, nil
+}
+
+func normalizeRunAdmission(admission RunAdmissionView) (RunAdmissionView, error) {
+	operation, err := normalizeRunOperation(admission.Operation)
+	if err != nil {
+		return RunAdmissionView{}, err
+	}
+	requestUserTurn, err := normalizeRequestUserTurn(admission.RequestUserTurn)
+	if err != nil {
+		return RunAdmissionView{}, err
+	}
+	return RunAdmissionView{RequestUserTurn: requestUserTurn, Operation: operation}, nil
+}
+
+func normalizeRequestUserTurn(turn *conversation.UITurn) (*conversation.UITurn, error) {
+	if turn == nil {
+		return nil, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(turn.Role), "user") {
+		return nil, errors.New("runtime request_user_turn must have role user")
+	}
+	clone := *turn
+	clone.Role = "user"
+	clone.Attachments = append([]conversation.UIAttachment(nil), turn.Attachments...)
+	clone.Messages = append([]conversation.UIMessage(nil), turn.Messages...)
+	return &clone, nil
+}
+
+func leaseRenewInterval(ttl time.Duration) time.Duration {
+	interval := ttl / 3
+	if interval <= 0 {
+		return 100 * time.Millisecond
+	}
+	if interval < 10*time.Millisecond {
+		return 10 * time.Millisecond
+	}
+	return interval
+}
+
+func commandAckPollInterval(timeout time.Duration) time.Duration {
+	interval := timeout / 10
+	if interval <= 0 || interval > 50*time.Millisecond {
+		return 50 * time.Millisecond
+	}
+	if interval < 5*time.Millisecond {
+		return 5 * time.Millisecond
+	}
+	return interval
+}
+
+func runtimeReconcileInterval(ownerLeaseTTL time.Duration) time.Duration {
+	interval := ownerLeaseTTL / 3
+	if interval < 50*time.Millisecond {
+		return 50 * time.Millisecond
+	}
+	if interval > 2*time.Second {
+		return 2 * time.Second
+	}
+	return interval
+}
+
+func enqueueRuntimeEvent(ch chan Event, event Event) {
+	select {
+	case ch <- event:
+		return
+	default:
+	}
+	select {
+	case <-ch:
+	default:
+	}
+	select {
+	case ch <- Event{
+		Type:      EventRuntimeDropped,
+		BotID:     event.BotID,
+		SessionID: event.SessionID,
+		StreamID:  event.StreamID,
+		Seq:       event.Seq,
+		Message:   "runtime subscriber buffer overflow",
+	}:
+	default:
+	}
+}
+
+func upsertUIMessage(messages []conversation.UIMessage, incoming conversation.UIMessage) []conversation.UIMessage {
+	for i := range messages {
+		if incoming.Type == conversation.UIMessageTool && strings.TrimSpace(incoming.ToolCallID) != "" && messages[i].Type == conversation.UIMessageTool && messages[i].ToolCallID == incoming.ToolCallID {
+			messages[i] = incoming
+			return messages
+		}
+		if messages[i].ID == incoming.ID {
+			messages[i] = incoming
+			return messages
+		}
+	}
+	return append(messages, incoming)
+}

--- a/internal/sessionruntime/types.go
+++ b/internal/sessionruntime/types.go
@@ -1,0 +1,222 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+const (
+	EventRuntimeSnapshot = "runtime_snapshot"
+	EventRuntimeDelta    = "runtime_delta"
+	EventRuntimeDropped  = "runtime_dropped"
+
+	RunStatusRunning   = "running"
+	RunStatusAdmitting = "admitting"
+	RunStatusAborting  = "aborting"
+	RunStatusCompleted = "completed"
+	RunStatusAborted   = "aborted"
+	RunStatusErrored   = "errored"
+	RunStatusLost      = "lost"
+
+	SteerStatusPending  = "pending"
+	SteerStatusQueued   = "queued"
+	SteerStatusApplied  = "applied"
+	SteerStatusRejected = "rejected"
+
+	RunOperationRetry = "retry"
+	RunOperationEdit  = "edit"
+
+	CommandAbort                = "abort"
+	CommandSteer                = "steer_current_run"
+	CommandToolApprovalResponse = "tool_approval_response"
+	CommandUserInputResponse    = "user_input_response"
+	CommandResult               = "command_result"
+)
+
+var (
+	ErrCommandOwnerUnavailable = errors.New("runtime command owner is unavailable")
+	ErrCommandTargetNotActive  = errors.New("runtime command target is not active")
+	ErrManagerClosed           = errors.New("session runtime manager is closed")
+	ErrRunOwnershipLost        = errors.New("runtime run ownership was lost")
+)
+
+type Key struct {
+	BotID     string `json:"bot_id"`
+	SessionID string `json:"session_id"`
+}
+
+// String returns the canonical "botID:sessionID" composite used to key
+// per-session state across backends and subscription registries.
+func (k Key) String() string {
+	return strings.TrimSpace(k.BotID) + ":" + strings.TrimSpace(k.SessionID)
+}
+
+type StreamRef struct {
+	BotID     string `json:"bot_id"`
+	SessionID string `json:"session_id"`
+	StreamID  string `json:"stream_id"`
+	OwnerID   string `json:"owner_id"`
+}
+
+type Snapshot struct {
+	BotID          string          `json:"bot_id"`
+	SessionID      string          `json:"session_id"`
+	Seq            int64           `json:"seq"`
+	CurrentRunView *CurrentRunView `json:"current_run_view,omitempty"`
+	Queue          []QueuedRunView `json:"queue"`
+	UpdatedAt      time.Time       `json:"updated_at"`
+}
+
+// EmptySnapshot returns the canonical empty runtime snapshot for a session.
+func EmptySnapshot(botID, sessionID string) Snapshot {
+	return Snapshot{
+		BotID:     strings.TrimSpace(botID),
+		SessionID: strings.TrimSpace(sessionID),
+		Queue:     []QueuedRunView{},
+	}
+}
+
+type QueuedRunView struct {
+	StreamID string `json:"stream_id,omitempty"`
+}
+
+type CurrentRunView struct {
+	StreamID            string                   `json:"stream_id"`
+	Status              string                   `json:"status"`
+	OwnerID             string                   `json:"owner_id,omitempty"`
+	OwnerLeaseExpiresAt *time.Time               `json:"owner_lease_expires_at,omitempty"`
+	StartedAt           time.Time                `json:"started_at"`
+	UpdatedAt           time.Time                `json:"updated_at"`
+	Messages            []conversation.UIMessage `json:"messages"`
+	RequestUserTurn     *conversation.UITurn     `json:"request_user_turn,omitempty"`
+	Error               string                   `json:"error,omitempty"`
+	Steer               *SteerState              `json:"steer,omitempty"`
+	Operation           *RunOperationView        `json:"operation,omitempty"`
+}
+
+// RunAdmissionView is the canonical state published when a reserved run
+// becomes active. RequestUserTurn is intentionally runtime state rather than
+// a durable history row; ordinary sends still persist user + assistant
+// together when the run reaches a terminal result.
+type RunAdmissionView struct {
+	RequestUserTurn *conversation.UITurn
+	Operation       *RunOperationView
+}
+
+type RunOperationView struct {
+	Kind                 string               `json:"kind" validate:"required" enums:"retry,edit"`
+	ReplaceFromMessageID string               `json:"replace_from_message_id" validate:"required"`
+	ReplacementUserTurn  *conversation.UITurn `json:"replacement_user_turn,omitempty"`
+}
+
+type SteerState struct {
+	ID        string    `json:"id"`
+	Status    string    `json:"status"`
+	Text      string    `json:"text,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type Event struct {
+	Type      string        `json:"type"`
+	BotID     string        `json:"bot_id"`
+	SessionID string        `json:"session_id"`
+	StreamID  string        `json:"stream_id,omitempty"`
+	Seq       int64         `json:"seq"`
+	UpdatedAt *time.Time    `json:"updated_at,omitempty"`
+	Snapshot  *Snapshot     `json:"snapshot,omitempty"`
+	Delta     *RuntimeDelta `json:"delta,omitempty"`
+	Message   string        `json:"message,omitempty"`
+}
+
+// RuntimeDelta carries only the state changed by one committed runtime
+// transition. Full snapshots are reserved for hydration and gap recovery.
+type RuntimeDelta struct {
+	CurrentRunView  *CurrentRunView          `json:"current_run_view,omitempty"`
+	Run             *CurrentRunPatch         `json:"run,omitempty"`
+	MessageAppends  []RuntimeMessageAppend   `json:"message_appends,omitempty"`
+	ProgressAppends []RuntimeProgressAppend  `json:"progress_appends,omitempty"`
+	MessageUpserts  []conversation.UIMessage `json:"message_upserts,omitempty"`
+	ResetMessages   bool                     `json:"reset_messages,omitempty"`
+}
+
+type CurrentRunPatch struct {
+	StreamID            string      `json:"stream_id"`
+	Status              *string     `json:"status,omitempty"`
+	Error               *string     `json:"error,omitempty"`
+	Steer               *SteerState `json:"steer,omitempty"`
+	UpdatedAt           *time.Time  `json:"updated_at,omitempty"`
+	OwnerLeaseExpiresAt *time.Time  `json:"owner_lease_expires_at,omitempty"`
+}
+
+type RuntimeMessageAppend struct {
+	ID      int                        `json:"id"`
+	Type    conversation.UIMessageType `json:"type"`
+	Content string                     `json:"content"`
+}
+
+type RuntimeProgressAppend struct {
+	ID       int `json:"id"`
+	Progress any `json:"progress"`
+	Input    any `json:"input,omitempty"`
+}
+
+type Command struct {
+	Type         string          `json:"type"`
+	ID           string          `json:"id,omitempty"`
+	ReplyOwnerID string          `json:"reply_owner_id,omitempty"`
+	BotID        string          `json:"bot_id"`
+	SessionID    string          `json:"session_id"`
+	StreamID     string          `json:"stream_id"`
+	TargetID     string          `json:"target_id,omitempty"`
+	SteerID      string          `json:"steer_id,omitempty"`
+	Text         string          `json:"text,omitempty"`
+	Payload      json.RawMessage `json:"payload,omitempty"`
+	ErrorCode    string          `json:"error_code,omitempty"`
+	Error        string          `json:"error,omitempty"`
+	CreatedAt    time.Time       `json:"created_at"`
+}
+
+type Subscription struct {
+	C     <-chan Event
+	Close func()
+}
+
+type (
+	SnapshotUpdate  func(snapshot Snapshot, exists bool) (Snapshot, bool, error)
+	ActiveRunUpdate func(snapshot Snapshot, now time.Time) (Snapshot, bool, error)
+)
+
+type Backend interface {
+	Now(ctx context.Context) (time.Time, error)
+	// Load returns a snapshot the caller owns and may freely mutate.
+	Load(ctx context.Context, key Key) (Snapshot, bool, error)
+	Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error)
+	Publish(ctx context.Context, event Event) error
+	Subscribe(ctx context.Context, key Key) (Subscription, error)
+	Close() error
+}
+
+// DistributedBackend adds cross-process run ownership and command routing.
+// MemoryBackend intentionally does not implement this interface.
+type DistributedBackend interface {
+	Backend
+	UpdateActiveRun(ctx context.Context, key Key, streamID string, update ActiveRunUpdate) (Snapshot, bool, error)
+	StartRun(ctx context.Context, key Key, ref StreamRef, update SnapshotUpdate) (Snapshot, bool, error)
+	RenewLease(ctx context.Context, key Key, streamID, ownerID string, renewedAt, expiresAt time.Time) error
+	LoadStreamRef(ctx context.Context, streamID string) (StreamRef, bool, error)
+	DeleteStreamRef(ctx context.Context, streamID string) error
+	PublishCommand(ctx context.Context, ownerID string, command Command) error
+	SubscribeCommands(ctx context.Context, ownerID string) (CommandSubscription, error)
+}
+
+type CommandSubscription struct {
+	C     <-chan Command
+	Close func()
+}


### PR DESCRIPTION
## Summary

- add the in-process session runtime manager and canonical snapshot/delta state model
- keep the memory backend local with session subscriptions, abort, and steer routing
- cover lifecycle, sequencing, replacement, and command behavior with focused Go tests

## Stack

Depends on #790.

## Verification

- `go test ./internal/sessionruntime`