### PR TITLE
feat(runtime): add PostgreSQL fencing foundation

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,6 +10,7 @@ on:
       - "apps/**/*.ts"
       - "apps/**/*.tsx"
       - "apps/**/*.vue"
+      - "apps/web/src/store/__fixtures__/runtime-*.contract.json"
       - "packages/**"
       - "packages/**/*.js"
       - "packages/**/*.ts"
@@ -20,6 +21,7 @@ on:
       - "pnpm-workspace.yaml"
       - "eslint.config.mjs"
       - "tsconfig.json"
+      - "vitest.config.ts"
       - ".github/workflows/eslint.yml"
   pull_request:
     branches: ["main"]
@@ -30,6 +32,7 @@ on:
       - "apps/**/*.ts"
       - "apps/**/*.tsx"
       - "apps/**/*.vue"
+      - "apps/web/src/store/__fixtures__/runtime-*.contract.json"
       - "packages/**"
       - "packages/**/*.js"
       - "packages/**/*.ts"
@@ -40,6 +43,7 @@ on:
       - "pnpm-workspace.yaml"
       - "eslint.config.mjs"
       - "tsconfig.json"
+      - "vitest.config.ts"
       - ".github/workflows/eslint.yml"
   workflow_dispatch:
 
@@ -70,3 +74,23 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run ESLint
         run: pnpm lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run Vitest
+        run: pnpm test --run --testTimeout=15000 apps/web/src/composables/api/useChat.ws.test.ts apps/web/src/store/chat-list.test.ts

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -104,3 +104,40 @@ jobs:
           RUNTIME_URL: redis://127.0.0.1:${{ job.services.runtime.ports['6379'] }}/0
           RUNTIME_ENV_NAME: ${{ matrix.env_name }}
         run: env "$RUNTIME_ENV_NAME=$RUNTIME_URL" go test -v -race -count=1 -timeout 90s ./internal/sessionruntime
+
+  session-runtime-postgres:
+    name: Session Runtime (PostgreSQL fencing)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_DB: memoh_runtime_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd "pg_isready -U postgres -d memoh_runtime_test"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run durable runtime fencing contracts
+        env:
+          MEMOH_TEST_POSTGRES_REQUIRED: "1"
+          TEST_POSTGRES_BOOTSTRAP_SCHEMA: "1"
+          TEST_POSTGRES_DSN: postgres://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/memoh_runtime_test?sslmode=disable
+        run: |
+          go test -v -race -count=1 -timeout 90s \
+            -run '^TestPostgresRuntimeFence' ./internal/runtimefence
+          TEST_POSTGRES_BOOTSTRAP_SCHEMA=0 go test -v -race -count=1 -timeout 90s \
+            -run '^TestPostgresRuntimeFence' ./internal/message
+          TEST_POSTGRES_BOOTSTRAP_SCHEMA=0 go test -v -race -count=1 -timeout 90s \
+            -run '^TestPostgresRuntimeFence' ./internal/acpagent

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -67,3 +67,40 @@ jobs:
           name: go-coverage
           path: coverage.txt
           if-no-files-found: error
+
+  session-runtime-backend:
+    name: Session Runtime (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: Redis
+            image: redis:8-alpine
+            env_name: MEMOH_TEST_REDIS_URL
+          - target: Valkey
+            image: valkey/valkey:8-alpine
+            env_name: MEMOH_TEST_VALKEY_URL
+    services:
+      runtime:
+        image: ${{ matrix.image }}
+        ports:
+          - 6379/tcp
+        options: >-
+          --health-cmd "sh -c 'redis-cli ping || valkey-cli ping'"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run distributed session runtime contracts
+        env:
+          MEMOH_TEST_DISTRIBUTED_REQUIRED: "1"
+          RUNTIME_URL: redis://127.0.0.1:${{ job.services.runtime.ports['6379'] }}/0
+          RUNTIME_ENV_NAME: ${{ matrix.env_name }}
+        run: env "$RUNTIME_ENV_NAME=$RUNTIME_URL" go test -v -race -count=1 -timeout 90s ./internal/sessionruntime

--- a/apps/web/src/composables/api/useChat.ws.test.ts
+++ b/apps/web/src/composables/api/useChat.ws.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { client } from '@memohai/sdk/client'
 import { connectWebSocket } from './useChat.ws'
 
@@ -36,6 +36,10 @@ class MockWebSocket {
     this.readyState = MockWebSocket.OPEN
     this.onopen?.()
   }
+
+  emit(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) })
+  }
 }
 
 describe('useChat.ws', () => {
@@ -53,6 +57,10 @@ describe('useChat.ws', () => {
       getItem: vi.fn(() => ''),
     })
     vi.stubGlobal('WebSocket', MockWebSocket)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('queues outbound messages until socket opens', () => {
@@ -85,6 +93,92 @@ describe('useChat.ws', () => {
     expect(JSON.parse(socket.sent[0]!)).toEqual({
       type: 'abort',
       stream_id: 'stream-1',
+    })
+  })
+
+  it('sends steer_current_run command payloads through the existing bot websocket', () => {
+    const ws = connectWebSocket('bot-1', vi.fn())
+    const socket = MockWebSocket.instances[0]!
+    socket.open()
+
+    ws.send({
+      type: 'steer_current_run',
+      stream_id: 'stream-1',
+      session_id: 'session-1',
+      text: 'adjust course',
+    })
+
+    expect(JSON.parse(socket.sent[0]!)).toEqual({
+      type: 'steer_current_run',
+      stream_id: 'stream-1',
+      session_id: 'session-1',
+      text: 'adjust course',
+    })
+  })
+
+  it('sends runtime_subscribe command payloads through the existing bot websocket', () => {
+    const ws = connectWebSocket('bot-1', vi.fn())
+    const socket = MockWebSocket.instances[0]!
+    socket.open()
+
+    ws.send({
+      type: 'runtime_subscribe',
+      session_id: 'session-1',
+    })
+
+    expect(JSON.parse(socket.sent[0]!)).toEqual({
+      type: 'runtime_subscribe',
+      session_id: 'session-1',
+    })
+  })
+
+  it('lets scripted server events drive each websocket client independently', () => {
+    const firstHandler = vi.fn()
+    const secondHandler = vi.fn()
+    connectWebSocket('bot-1', firstHandler)
+    connectWebSocket('bot-1', secondHandler)
+    const first = MockWebSocket.instances[0]!
+    const second = MockWebSocket.instances[1]!
+    first.open()
+    second.open()
+
+    first.emit({ type: 'start', stream_id: 'stream-a', session_id: 'session-1' })
+    second.emit({ type: 'message', stream_id: 'stream-b', session_id: 'session-2', data: { id: 0, type: 'text', content: 'hello' } })
+
+    expect(firstHandler).toHaveBeenCalledTimes(1)
+    expect(firstHandler).toHaveBeenCalledWith({ type: 'start', stream_id: 'stream-a', session_id: 'session-1' })
+    expect(secondHandler).toHaveBeenCalledTimes(1)
+    expect(secondHandler).toHaveBeenCalledWith({ type: 'message', stream_id: 'stream-b', session_id: 'session-2', data: { id: 0, type: 'text', content: 'hello' } })
+  })
+
+  it('reconnects after disconnect and flushes queued messages on the new socket', () => {
+    vi.useFakeTimers()
+    const ws = connectWebSocket('bot-1', vi.fn())
+    const first = MockWebSocket.instances[0]!
+    first.open()
+
+    first.close()
+    expect(ws.connected).toBe(false)
+
+    ws.send({
+      type: 'message',
+      stream_id: 'stream-after-reconnect',
+      session_id: 'session-1',
+      text: 'resume',
+    })
+
+    vi.advanceTimersByTime(1000)
+    const second = MockWebSocket.instances[1]!
+    expect(second).toBeDefined()
+    expect(second.sent).toEqual([])
+
+    second.open()
+
+    expect(JSON.parse(second.sent[0]!)).toEqual({
+      type: 'message',
+      stream_id: 'stream-after-reconnect',
+      session_id: 'session-1',
+      text: 'resume',
     })
   })
 

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -145,6 +145,113 @@ function approvalTurn(approval: UIToolApproval) {
   }
 }
 
+function richActiveRunStoreScript(sessionId = 'session-1', streamId = 'stream-rich'): UIStreamEvent[] {
+  return [
+    { type: 'start', stream_id: streamId, session_id: sessionId } as UIStreamEvent,
+    {
+      type: 'message',
+      stream_id: streamId,
+      session_id: sessionId,
+      data: { id: 0, type: 'reasoning', content: 'I need to inspect the workspace.' },
+    } as UIStreamEvent,
+    {
+      type: 'message',
+      stream_id: streamId,
+      session_id: sessionId,
+      data: { id: 1, type: 'text', content: 'I will check the current state.' },
+    } as UIStreamEvent,
+    {
+      type: 'message',
+      stream_id: streamId,
+      session_id: sessionId,
+      data: {
+        id: 2,
+        type: 'tool',
+        name: 'exec',
+        tool_call_id: 'call-exec',
+        input: { command: 'pwd' },
+        running: true,
+        progress: ['queued'],
+      },
+    } as UIStreamEvent,
+    {
+      type: 'message',
+      stream_id: streamId,
+      session_id: sessionId,
+      data: {
+        id: 2,
+        type: 'tool',
+        name: 'exec',
+        tool_call_id: 'call-exec',
+        input: { command: 'pwd' },
+        output: { structuredContent: { stdout: '/workspace\n' } },
+        running: false,
+        progress: ['queued', { stdout: '/workspace\n' }],
+      },
+    } as UIStreamEvent,
+    {
+      type: 'message',
+      stream_id: streamId,
+      session_id: sessionId,
+      data: {
+        id: 3,
+        type: 'tool',
+        name: 'exec',
+        tool_call_id: 'call-approval',
+        input: { command: 'rm -rf build' },
+        running: false,
+        approval: {
+          approval_id: 'approval-1',
+          short_id: 7,
+          status: 'pending',
+          can_approve: true,
+        },
+      },
+    } as UIStreamEvent,
+    {
+      type: 'message',
+      stream_id: streamId,
+      session_id: sessionId,
+      data: {
+        id: 4,
+        type: 'tool',
+        name: 'ask_user',
+        tool_call_id: 'call-ask',
+        input: { questions: [{ text: 'Continue?', kind: 'single_select' }] },
+        running: false,
+        user_input: {
+          user_input_id: 'input-1',
+          short_id: 8,
+          status: 'pending',
+          can_respond: true,
+          questions: [{
+            id: 'q1',
+            text: 'Continue?',
+            kind: 'single_select',
+            options: [
+              { id: 'yes', label: 'Yes' },
+              { id: 'no', label: 'No' },
+            ],
+          }],
+        },
+      },
+    } as UIStreamEvent,
+  ]
+}
+
+function interruptedRunStoreScript(sessionId = 'session-1', streamId = 'stream-interrupted'): UIStreamEvent[] {
+  return [
+    { type: 'start', stream_id: streamId, session_id: sessionId } as UIStreamEvent,
+    {
+      type: 'message',
+      stream_id: streamId,
+      session_id: sessionId,
+      data: { id: 0, type: 'text', content: 'partial output' },
+    } as UIStreamEvent,
+    { type: 'error', stream_id: streamId, session_id: sessionId, message: 'runtime interrupted' } as UIStreamEvent,
+  ]
+}
+
 describe('chat-list store', () => {
   let streamHandler: UIStreamEventHandler | null
   // Captured but not driven by any test body yet; keep the capture so future
@@ -6395,4 +6502,122 @@ describe('chat-list store', () => {
     })
     expect(api.closeACPRuntime).not.toHaveBeenCalledWith('bot-1', 'rt_warm')
   })
+  it('applies the rich active-run contract script to the current assistant turn', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'session-1', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+      nextCursor: null,
+    })
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+
+    sendEvents = richActiveRunStoreScript()
+    const sendPromise = store.sendMessage('please inspect')
+    await flushPromises()
+    await flushPromises()
+
+    expect(sentWSMessages[0]).toMatchObject({
+      type: 'message',
+      text: 'please inspect',
+      session_id: 'session-1',
+    })
+
+    const assistant = store.messages.find(turn => turn.role === 'assistant')
+    expect(assistant?.role).toBe('assistant')
+    if (assistant?.role !== 'assistant') throw new Error('missing assistant turn')
+
+    expect(assistant.messages.find(block => block.type === 'reasoning')).toMatchObject({
+      content: 'I need to inspect the workspace.',
+    })
+    expect(assistant.messages.find(block => block.type === 'text')).toMatchObject({
+      content: 'I will check the current state.',
+    })
+
+    const execTool = assistant.messages.find(block => block.type === 'tool' && block.toolCallId === 'call-exec')
+    expect(execTool).toMatchObject({
+      type: 'tool',
+      toolName: 'exec',
+      done: true,
+      running: false,
+      progress: ['queued', { stdout: '/workspace\n' }],
+    })
+
+    const approvalTool = assistant.messages.find(block => block.type === 'tool' && block.toolCallId === 'call-approval')
+    expect(approvalTool).toMatchObject({
+      approval: {
+        approval_id: 'approval-1',
+        status: 'pending',
+        can_approve: true,
+      },
+    })
+
+    const askUserTool = assistant.messages.find(block => block.type === 'tool' && block.toolCallId === 'call-ask')
+    expect(askUserTool).toMatchObject({
+      userInput: {
+        user_input_id: 'input-1',
+        status: 'pending',
+        can_respond: true,
+        questions: [expect.objectContaining({ text: 'Continue?' })],
+      },
+    })
+
+    streamHandler?.({ type: 'end', stream_id: lastStreamId, session_id: lastSessionId } as UIStreamEvent)
+    await sendPromise
+  })
+
+  it('records interrupted runtime streams as stream-stage failures after visible output', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [{ id: 'session-1', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+      nextCursor: null,
+    })
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+
+    sendEvents = interruptedRunStoreScript()
+    const result = await store.sendMessage('please run')
+
+    expect(result).toMatchObject({
+      ok: false,
+      stage: 'stream',
+      error: 'runtime interrupted',
+    })
+    const assistant = store.messages.find(turn => turn.role === 'assistant')
+    expect(assistant?.role).toBe('assistant')
+    if (assistant?.role !== 'assistant') throw new Error('missing assistant turn')
+    expect(assistant.messages.some(block => block.type === 'text' && block.content === 'partial output')).toBe(true)
+    expect(assistant.messages.some(block => block.type === 'error' && block.content === 'runtime interrupted')).toBe(true)
+  })
+
+  it('does not let stale active-run events for another session pollute the visible transcript', async () => {
+    api.fetchSessions.mockResolvedValueOnce({
+      items: [
+        { id: 'session-1', bot_id: 'bot-1', title: 'A', type: 'chat' },
+        { id: 'session-2', bot_id: 'bot-1', title: 'B', type: 'chat' },
+      ],
+      nextCursor: null,
+    })
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+    await flushPromises()
+
+    api.fetchMessagesUI.mockResolvedValueOnce([])
+    store.selectSession('session-2')
+    await flushPromises()
+    expect(store.sessionId).toBe('session-2')
+    expect(store.messages).toEqual([])
+
+    streamHandler?.({ type: 'start', stream_id: 'stream-old', session_id: 'session-1' } as UIStreamEvent)
+    streamHandler?.({
+      type: 'message',
+      stream_id: 'stream-old',
+      session_id: 'session-1',
+      data: { id: 0, type: 'text', content: 'old session output' },
+    } as UIStreamEvent)
+
+    expect(store.messages).toEqual([])
+
+    streamHandler?.({ type: 'end', stream_id: 'stream-old', session_id: 'session-1' } as UIStreamEvent)
+  })
+
 })

--- a/conf/app.example.toml
+++ b/conf/app.example.toml
@@ -52,6 +52,20 @@ tool_output_max_bytes = 65536
 tool_output_max_lines = 2000
 system_files_max_bytes = 32768
 
+[session_runtime]
+# Stores live run snapshots for WebSocket attach/reconnect. memory is best for
+# single-server deployments. redis uses the Redis protocol and works with
+# Redis or Valkey servers to share state and commands across servers.
+backend = "memory"
+state_ttl = "24h"
+# Used only when backend = "redis".
+owner_lease_ttl = "30s"
+
+[session_runtime.redis]
+# Redis or Valkey server URL. Keep the redis:// scheme.
+url = "redis://127.0.0.1:6379/0"
+key_prefix = "memoh:session_runtime:"
+
 [database]
 # Memoh now supports PostgreSQL only.
 driver = "postgres"

--- a/db/postgres/migrations/0001_init.down.sql
+++ b/db/postgres/migrations/0001_init.down.sql
@@ -28,6 +28,7 @@ DROP TABLE IF EXISTS bot_history_messages CASCADE;
 DROP TABLE IF EXISTS bot_session_events CASCADE;
 DROP TABLE IF EXISTS bot_session_discuss_cursors CASCADE;
 DROP TABLE IF EXISTS bot_sessions CASCADE;
+DROP SEQUENCE IF EXISTS session_runtime_fencing_token_seq;
 DROP TABLE IF EXISTS bot_channel_routes CASCADE;
 DROP TABLE IF EXISTS channel_identity_bind_codes CASCADE;
 DROP TABLE IF EXISTS bot_channel_configs CASCADE;

--- a/db/postgres/migrations/0001_init.up.sql
+++ b/db/postgres/migrations/0001_init.up.sql
@@ -446,6 +446,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_bot_channel_routes_unique
 CREATE INDEX IF NOT EXISTS idx_bot_channel_routes_bot ON bot_channel_routes(bot_id);
 
 -- bot_sessions: chat sessions within a bot, optionally linked to a channel route.
+CREATE SEQUENCE IF NOT EXISTS session_runtime_fencing_token_seq AS BIGINT NO CYCLE;
+
 CREATE TABLE IF NOT EXISTS bot_sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   bot_id UUID NOT NULL REFERENCES bots(id) ON DELETE CASCADE,
@@ -458,6 +460,7 @@ CREATE TABLE IF NOT EXISTS bot_sessions (
   title TEXT NOT NULL DEFAULT '',
   metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
   next_turn_position BIGINT NOT NULL DEFAULT 1,
+  runtime_fencing_token BIGINT NOT NULL DEFAULT 0 CHECK (runtime_fencing_token >= 0),
   parent_session_id UUID REFERENCES bot_sessions(id) ON DELETE SET NULL,
   created_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -614,6 +617,7 @@ CREATE TABLE IF NOT EXISTS tool_approval_requests (
   tool_input JSONB NOT NULL,
   short_id INTEGER NOT NULL,
   status TEXT NOT NULL DEFAULT 'pending',
+  runtime_fencing_token BIGINT,
   decision_reason TEXT NOT NULL DEFAULT '',
   requested_by_channel_identity_id UUID REFERENCES channel_identities(id) ON DELETE SET NULL,
   decided_by_channel_identity_id UUID REFERENCES channel_identities(id) ON DELETE SET NULL,
@@ -649,6 +653,7 @@ CREATE TABLE IF NOT EXISTS user_input_requests (
   tool_name TEXT NOT NULL DEFAULT 'ask_user',
   short_id INTEGER NOT NULL,
   status TEXT NOT NULL DEFAULT 'pending',
+  runtime_fencing_token BIGINT,
   input_json JSONB NOT NULL,
   ui_payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   result_json JSONB NOT NULL DEFAULT '{}'::jsonb,

--- a/db/postgres/migrations/0106_session_runtime_fencing_token.down.sql
+++ b/db/postgres/migrations/0106_session_runtime_fencing_token.down.sql
@@ -1,0 +1,13 @@
+-- 0106_session_runtime_fencing_token
+-- Remove the distributed session runtime persistence fence.
+
+ALTER TABLE user_input_requests
+  DROP COLUMN IF EXISTS runtime_fencing_token;
+
+ALTER TABLE tool_approval_requests
+  DROP COLUMN IF EXISTS runtime_fencing_token;
+
+ALTER TABLE bot_sessions
+  DROP COLUMN IF EXISTS runtime_fencing_token;
+
+DROP SEQUENCE IF EXISTS session_runtime_fencing_token_seq;

--- a/db/postgres/migrations/0106_session_runtime_fencing_token.up.sql
+++ b/db/postgres/migrations/0106_session_runtime_fencing_token.up.sql
@@ -1,0 +1,24 @@
+-- 0106_session_runtime_fencing_token
+-- Add a monotonic PostgreSQL fence for distributed session runtime writes.
+
+CREATE SEQUENCE IF NOT EXISTS session_runtime_fencing_token_seq AS BIGINT NO CYCLE;
+
+ALTER TABLE bot_sessions
+  ADD COLUMN IF NOT EXISTS runtime_fencing_token BIGINT NOT NULL DEFAULT 0
+  CHECK (runtime_fencing_token >= 0);
+
+ALTER TABLE tool_approval_requests
+  ADD COLUMN IF NOT EXISTS runtime_fencing_token BIGINT;
+
+ALTER TABLE user_input_requests
+  ADD COLUMN IF NOT EXISTS runtime_fencing_token BIGINT;
+
+SELECT setval(
+  'session_runtime_fencing_token_seq',
+  GREATEST(
+    (SELECT last_value FROM session_runtime_fencing_token_seq),
+    COALESCE((SELECT MAX(runtime_fencing_token) FROM bot_sessions), 0),
+    1
+  ),
+  true
+);

--- a/db/postgres/migrations/0107_session_runtime_fencing_token.down.sql
+++ b/db/postgres/migrations/0107_session_runtime_fencing_token.down.sql
@@ -1,4 +1,4 @@
--- 0106_session_runtime_fencing_token
+-- 0107_session_runtime_fencing_token
 -- Remove the distributed session runtime persistence fence.
 
 ALTER TABLE user_input_requests

--- a/db/postgres/migrations/0107_session_runtime_fencing_token.up.sql
+++ b/db/postgres/migrations/0107_session_runtime_fencing_token.up.sql
@@ -1,4 +1,4 @@
--- 0106_session_runtime_fencing_token
+-- 0107_session_runtime_fencing_token
 -- Add a monotonic PostgreSQL fence for distributed session runtime writes.
 
 CREATE SEQUENCE IF NOT EXISTS session_runtime_fencing_token_seq AS BIGINT NO CYCLE;

--- a/db/postgres/queries/bots.sql
+++ b/db/postgres/queries/bots.sql
@@ -61,6 +61,12 @@ WHERE id = $1;
 -- name: DeleteBotByID :exec
 DELETE FROM bots WHERE id = $1;
 
+-- name: LockBotForSessionWrite :one
+SELECT id
+FROM bots
+WHERE id = $1
+FOR KEY SHARE;
+
 -- name: ListHeartbeatEnabledBots :many
 SELECT id, owner_user_id, heartbeat_enabled, heartbeat_interval, heartbeat_prompt
 FROM bots

--- a/db/postgres/queries/sessions.sql
+++ b/db/postgres/queries/sessions.sql
@@ -215,6 +215,43 @@ FROM bot_sessions
 WHERE id = $1
   AND deleted_at IS NULL;
 
+-- name: NextSessionRuntimeFenceToken :one
+SELECT nextval('session_runtime_fencing_token_seq')::bigint;
+
+-- name: ActivateSessionRuntimeFence :one
+UPDATE bot_sessions
+SET runtime_fencing_token = sqlc.arg(runtime_fencing_token)
+WHERE id = sqlc.arg(session_id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND runtime_fencing_token <= sqlc.arg(runtime_fencing_token)
+  AND deleted_at IS NULL
+RETURNING runtime_fencing_token;
+
+-- name: LockSessionRuntimeFenceForActivation :one
+SELECT runtime_fencing_token
+FROM bot_sessions
+WHERE id = sqlc.arg(session_id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND deleted_at IS NULL
+FOR UPDATE;
+
+-- name: LockSessionRuntimeFence :one
+SELECT runtime_fencing_token
+FROM bot_sessions
+WHERE id = sqlc.arg(session_id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND runtime_fencing_token = sqlc.arg(runtime_fencing_token)
+  AND deleted_at IS NULL
+FOR NO KEY UPDATE;
+
+-- name: LockSessionDecisionSequence :one
+SELECT id
+FROM bot_sessions
+WHERE id = sqlc.arg(session_id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND deleted_at IS NULL
+FOR UPDATE;
+
 -- name: ListSessionsByBot :many
 SELECT
   s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata,
@@ -301,10 +338,28 @@ SET title = sqlc.arg(title), updated_at = now()
 WHERE id = sqlc.arg(id) AND deleted_at IS NULL
 RETURNING *;
 
+-- name: UpdateSessionTitleWithRuntimeFence :one
+UPDATE bot_sessions
+SET title = sqlc.arg(title), updated_at = now()
+WHERE id = sqlc.arg(id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND runtime_fencing_token = sqlc.arg(runtime_fencing_token)
+  AND deleted_at IS NULL
+RETURNING *;
+
 -- name: UpdateSessionMetadata :one
 UPDATE bot_sessions
 SET metadata = sqlc.arg(metadata), updated_at = now()
 WHERE id = sqlc.arg(id) AND deleted_at IS NULL
+RETURNING *;
+
+-- name: UpdateSessionMetadataWithRuntimeFence :one
+UPDATE bot_sessions
+SET metadata = sqlc.arg(metadata), updated_at = now()
+WHERE id = sqlc.arg(id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND runtime_fencing_token = sqlc.arg(runtime_fencing_token)
+  AND deleted_at IS NULL
 RETURNING *;
 
 -- name: UpdateSessionTypeAndMetadata :one

--- a/db/postgres/queries/tool_approval.sql
+++ b/db/postgres/queries/tool_approval.sql
@@ -1,4 +1,15 @@
 -- name: CreateToolApprovalRequest :one
+WITH locked_session AS (
+  SELECT id
+  FROM bot_sessions
+  WHERE id = sqlc.arg(session_id)
+  FOR UPDATE
+),
+next_short_id AS (
+  SELECT COALESCE(MAX(tool_approval_requests.short_id), 0) + 1 AS short_id
+  FROM locked_session
+  LEFT JOIN tool_approval_requests ON tool_approval_requests.session_id = locked_session.id
+)
 INSERT INTO tool_approval_requests (
   bot_id,
   session_id,
@@ -9,12 +20,13 @@ INSERT INTO tool_approval_requests (
   operation,
   tool_input,
   short_id,
+  runtime_fencing_token,
   requested_by_channel_identity_id,
   requested_message_id,
   source_platform,
   reply_target,
   conversation_type
-) VALUES (
+) SELECT
   sqlc.arg(bot_id),
   sqlc.arg(session_id),
   sqlc.narg(route_id),
@@ -23,28 +35,38 @@ INSERT INTO tool_approval_requests (
   sqlc.arg(tool_name),
   sqlc.arg(operation),
   sqlc.arg(tool_input),
-  (
-    SELECT COALESCE(MAX(short_id), 0) + 1
-    FROM tool_approval_requests
-    WHERE session_id = sqlc.arg(session_id)
-  ),
+  next_short_id.short_id,
+  sqlc.narg(runtime_fencing_token),
   sqlc.narg(requested_by_channel_identity_id),
   sqlc.narg(requested_message_id),
   sqlc.arg(source_platform),
   sqlc.arg(reply_target),
   sqlc.arg(conversation_type)
-)
+FROM locked_session
+CROSS JOIN next_short_id
 ON CONFLICT (session_id, tool_call_id) DO UPDATE
-SET tool_input = CASE
-  WHEN tool_approval_requests.status = 'pending' THEN EXCLUDED.tool_input
-  ELSE tool_approval_requests.tool_input
-END
+SET tool_input = tool_approval_requests.tool_input
+WHERE tool_approval_requests.status = 'pending'
+  AND tool_approval_requests.runtime_fencing_token IS NOT DISTINCT FROM EXCLUDED.runtime_fencing_token
+  AND tool_approval_requests.tool_name = EXCLUDED.tool_name
+  AND tool_approval_requests.operation = EXCLUDED.operation
+  AND tool_approval_requests.tool_input = EXCLUDED.tool_input
 RETURNING *;
 
 -- name: GetToolApprovalRequest :one
 SELECT *
 FROM tool_approval_requests
 WHERE id = $1;
+
+-- name: ClaimToolApprovalRequestForRuntime :one
+UPDATE tool_approval_requests
+SET runtime_fencing_token = sqlc.arg(runtime_fencing_token)
+WHERE id = sqlc.arg(id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND session_id = sqlc.arg(session_id)
+  AND status = 'pending'
+  AND (runtime_fencing_token IS NULL OR runtime_fencing_token <= sqlc.arg(runtime_fencing_token))
+RETURNING *;
 
 -- name: GetPendingToolApprovalBySessionShortID :one
 SELECT *
@@ -88,6 +110,7 @@ SET status = 'approved',
     decided_at = now()
 WHERE id = sqlc.arg(id)
   AND status = 'pending'
+  AND (runtime_fencing_token IS NULL OR runtime_fencing_token = sqlc.narg(runtime_fencing_token)::bigint)
 RETURNING *;
 
 -- name: RejectToolApprovalRequest :one
@@ -98,6 +121,7 @@ SET status = 'rejected',
     decided_at = now()
 WHERE id = sqlc.arg(id)
   AND status = 'pending'
+  AND (runtime_fencing_token IS NULL OR runtime_fencing_token = sqlc.narg(runtime_fencing_token)::bigint)
 RETURNING *;
 
 -- name: CancelPendingToolApprovalsBySession :many
@@ -108,6 +132,19 @@ SET status = 'cancelled',
 WHERE bot_id = sqlc.arg(bot_id)
   AND session_id = sqlc.arg(session_id)
   AND status = 'pending'
+  AND (runtime_fencing_token IS NULL OR runtime_fencing_token = sqlc.narg(runtime_fencing_token)::bigint)
+RETURNING *;
+
+-- name: SupersedePendingToolApprovalsBySession :many
+UPDATE tool_approval_requests
+SET status = 'cancelled',
+    decision_reason = sqlc.arg(reason),
+    decided_at = now()
+WHERE bot_id = sqlc.arg(bot_id)
+  AND session_id = sqlc.arg(session_id)
+  AND status = 'pending'
+  AND runtime_fencing_token IS NOT NULL
+  AND id IS DISTINCT FROM sqlc.narg(preserve_id)::uuid
 RETURNING *;
 
 -- name: ListPendingToolApprovalsBySession :many

--- a/db/postgres/queries/user_input.sql
+++ b/db/postgres/queries/user_input.sql
@@ -18,6 +18,7 @@ INSERT INTO user_input_requests (
   tool_call_id,
   tool_name,
   short_id,
+  runtime_fencing_token,
   input_json,
   ui_payload_json,
   provider_metadata,
@@ -34,6 +35,7 @@ INSERT INTO user_input_requests (
   sqlc.arg(tool_call_id),
   sqlc.arg(tool_name),
   next_short_id.short_id,
+  sqlc.narg(runtime_fencing_token),
   sqlc.arg(input_json),
   sqlc.arg(ui_payload_json),
   sqlc.arg(provider_metadata),
@@ -45,23 +47,54 @@ INSERT INTO user_input_requests (
 FROM locked_session
 CROSS JOIN next_short_id
 ON CONFLICT (session_id, tool_call_id) DO UPDATE
-SET input_json = EXCLUDED.input_json,
-    ui_payload_json = EXCLUDED.ui_payload_json,
-    provider_metadata = EXCLUDED.provider_metadata,
-    requested_by_channel_identity_id = EXCLUDED.requested_by_channel_identity_id,
-    source_platform = EXCLUDED.source_platform,
-    reply_target = EXCLUDED.reply_target,
-    conversation_type = EXCLUDED.conversation_type,
-    expires_at = EXCLUDED.expires_at,
-    updated_at = now()
+SET updated_at = user_input_requests.updated_at
 WHERE user_input_requests.status = 'pending'
+  AND user_input_requests.runtime_fencing_token IS NOT DISTINCT FROM EXCLUDED.runtime_fencing_token
   AND (user_input_requests.expires_at IS NULL OR user_input_requests.expires_at > now())
+  AND user_input_requests.input_json = EXCLUDED.input_json
+  AND user_input_requests.ui_payload_json = EXCLUDED.ui_payload_json
+  AND user_input_requests.provider_metadata = EXCLUDED.provider_metadata
+  AND user_input_requests.expires_at IS NOT DISTINCT FROM EXCLUDED.expires_at
 RETURNING *;
 
 -- name: GetUserInputRequest :one
 SELECT *
 FROM user_input_requests
 WHERE id = $1;
+
+-- name: GetRespondableUserInputRequest :one
+SELECT *
+FROM user_input_requests
+WHERE id = sqlc.arg(id)
+  AND status = 'pending'
+  AND (
+    (
+      sqlc.narg(runtime_fencing_token)::bigint IS NOT NULL
+      AND runtime_fencing_token = sqlc.narg(runtime_fencing_token)::bigint
+    )
+    OR (
+      sqlc.narg(runtime_fencing_token)::bigint IS NULL
+      AND runtime_fencing_token IS NULL
+      AND (expires_at IS NULL OR expires_at > now())
+    )
+  );
+
+-- name: ClaimUserInputRequestForRuntime :one
+UPDATE user_input_requests
+SET runtime_fencing_token = sqlc.arg(runtime_fencing_token),
+    updated_at = now()
+WHERE id = sqlc.arg(id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND session_id = sqlc.arg(session_id)
+  AND status = 'pending'
+  AND (
+    runtime_fencing_token = sqlc.arg(runtime_fencing_token)
+    OR (
+      (runtime_fencing_token IS NULL OR runtime_fencing_token < sqlc.arg(runtime_fencing_token))
+      AND (expires_at IS NULL OR expires_at > now())
+    )
+  )
+RETURNING *;
 
 -- name: GetUserInputRequestBySessionToolCall :one
 SELECT *
@@ -130,7 +163,10 @@ SET status = 'submitted',
     updated_at = now()
 WHERE id = sqlc.arg(id)
   AND status = 'pending'
-  AND (expires_at IS NULL OR expires_at > now())
+  AND (
+    runtime_fencing_token = sqlc.narg(runtime_fencing_token)::bigint
+    OR (runtime_fencing_token IS NULL AND (expires_at IS NULL OR expires_at > now()))
+  )
 RETURNING *;
 
 -- name: CancelUserInputRequest :one
@@ -143,7 +179,10 @@ SET status = 'canceled',
     updated_at = now()
 WHERE id = sqlc.arg(id)
   AND status = 'pending'
-  AND (expires_at IS NULL OR expires_at > now())
+  AND (
+    runtime_fencing_token = sqlc.narg(runtime_fencing_token)::bigint
+    OR (runtime_fencing_token IS NULL AND (expires_at IS NULL OR expires_at > now()))
+  )
 RETURNING *;
 
 -- name: CancelPendingUserInputsBySession :many
@@ -156,7 +195,24 @@ SET status = 'canceled',
 WHERE bot_id = sqlc.arg(bot_id)
   AND session_id = sqlc.arg(session_id)
   AND status = 'pending'
-  AND (expires_at IS NULL OR expires_at > now())
+  AND (
+    runtime_fencing_token = sqlc.narg(runtime_fencing_token)::bigint
+    OR (runtime_fencing_token IS NULL AND (expires_at IS NULL OR expires_at > now()))
+  )
+RETURNING *;
+
+-- name: SupersedePendingUserInputsBySession :many
+UPDATE user_input_requests
+SET status = 'canceled',
+    result_json = sqlc.arg(result_json),
+    responded_at = now(),
+    canceled_at = now(),
+    updated_at = now()
+WHERE bot_id = sqlc.arg(bot_id)
+  AND session_id = sqlc.arg(session_id)
+  AND status = 'pending'
+  AND runtime_fencing_token IS NOT NULL
+  AND id IS DISTINCT FROM sqlc.narg(preserve_id)::uuid
 RETURNING *;
 
 -- name: FailUserInputRequest :one
@@ -166,7 +222,10 @@ SET status = 'failed',
     updated_at = now()
 WHERE id = sqlc.arg(id)
   AND status = 'pending'
-  AND (expires_at IS NULL OR expires_at > now())
+  AND (
+    runtime_fencing_token = sqlc.narg(runtime_fencing_token)::bigint
+    OR (runtime_fencing_token IS NULL AND (expires_at IS NULL OR expires_at > now()))
+  )
 RETURNING *;
 
 -- name: ListPendingUserInputsBySession :many

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/pion/rtp v1.10.2
 	github.com/pion/sdp/v3 v3.0.18
 	github.com/pion/webrtc/v4 v4.2.12
+	github.com/redis/go-redis/v9 v9.21.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/slack-go/slack v0.19.0
 	github.com/stretchr/testify v1.11.1
@@ -181,6 +182,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,10 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -460,6 +464,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
 github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
+github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -651,6 +657,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAtL9E=
+github.com/redis/go-redis/v9 v9.21.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
@@ -746,6 +754,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
 github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=
 go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.4/go.mod h1:Ud+VUwIi9/uQHOMA+4ekToJ12lTxlv0zB/+DHwTGEbU=
@@ -781,6 +791,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/dig v1.19.0 h1:BACLhebsYdpQ7IROQ1AGPjrXcP5dF80U3gKoFzbaq/4=
 go.uber.org/dig v1.19.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 go.uber.org/fx v1.24.0 h1:wE8mruvpg2kiiL1Vqd0CC+tr0/24XIB10Iwp2lLWzkg=

--- a/internal/acpagent/runtime_fence_postgres_integration_test.go
+++ b/internal/acpagent/runtime_fence_postgres_integration_test.go
@@ -1,0 +1,216 @@
+package acpagent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dbpkg "github.com/memohai/memoh/internal/db"
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
+	"github.com/memohai/memoh/internal/runtimefence"
+	"github.com/memohai/memoh/internal/toolapproval"
+	"github.com/memohai/memoh/internal/userinput"
+)
+
+func TestPostgresRuntimeFenceStaleACPHandleCannotCancelCurrentDecisions(t *testing.T) {
+	ctx := context.Background()
+	pool := openACPRuntimeFencePostgresPool(t, ctx)
+	botID, sessionID := createACPRuntimeFenceFixtures(t, ctx, pool)
+	queries := dbsqlc.New(pool)
+	store := postgresstore.NewQueriesWithPool(pool, queries)
+	approvals := &recordingPostgresApprovalService{Service: toolapproval.NewService(nil, store, nil)}
+	inputs := &recordingPostgresUserInputService{Service: userinput.NewService(nil, store)}
+
+	tokenA, err := queries.NextSessionRuntimeFenceToken(ctx)
+	if err != nil {
+		t.Fatalf("allocate owner A token: %v", err)
+	}
+	fenceA := runtimefence.Fence{BotID: botID.String(), SessionID: sessionID.String(), Token: tokenA}
+	if err := runtimefence.Activate(ctx, store, fenceA); err != nil {
+		t.Fatalf("activate owner A token: %v", err)
+	}
+	tokenB, err := queries.NextSessionRuntimeFenceToken(ctx)
+	if err != nil {
+		t.Fatalf("allocate owner B token: %v", err)
+	}
+	fenceB := runtimefence.Fence{BotID: botID.String(), SessionID: sessionID.String(), Token: tokenB}
+	if err := runtimefence.Activate(ctx, store, fenceB); err != nil {
+		t.Fatalf("activate owner B token: %v", err)
+	}
+	ownerB := runtimefence.WithContext(ctx, fenceB)
+
+	approval, err := approvals.CreatePending(ownerB, toolapproval.CreatePendingInput{
+		BotID: fenceB.BotID, SessionID: fenceB.SessionID, ToolCallID: "approval-current-owner", ToolName: "write",
+		ToolInput: map[string]any{"path": "current-owner.txt"},
+	})
+	if err != nil {
+		t.Fatalf("create current owner approval: %v", err)
+	}
+	input, err := inputs.CreatePending(ownerB, userinput.CreatePendingInput{
+		BotID: fenceB.BotID, SessionID: fenceB.SessionID, ToolCallID: "input-current-owner", ToolName: userinput.ToolNameAskUser,
+		Input: map[string]any{"questions": []any{map[string]any{
+			"text": "Choose", "kind": userinput.QuestionKindSingleSelect,
+			"options": []any{map[string]any{"label": "A"}, map[string]any{"label": "B"}},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("create current owner user input: %v", err)
+	}
+
+	runtimePool := newSessionPool(nil, nil, nil)
+	runtimePool.SetToolApprovalService(approvals)
+	runtimePool.SetUserInputService(inputs)
+	stale := &runtimeHandle{
+		id:               "rt-stale-postgres-owner",
+		botID:            fenceA.BotID,
+		boundSession:     fenceA.SessionID,
+		status:           stateIdle,
+		lastActive:       time.Now(),
+		persistenceFence: fenceA,
+		hadPrompt:        true,
+	}
+	runtimePool.mu.Lock()
+	runtimePool.runtimes[stale.id] = stale
+	runtimePool.bySession[stale.boundSession] = stale.id
+	runtimePool.mu.Unlock()
+	if err := runtimePool.closeHandle(stale); err != nil {
+		t.Fatalf("close stale ACP handle: %v", err)
+	}
+	for name, fences := range map[string][]runtimefence.Fence{
+		"approval":   approvals.recordedCleanupFences(),
+		"user input": inputs.recordedCleanupFences(),
+	} {
+		if len(fences) != 2 {
+			t.Fatalf("%s cleanup calls = %d, want pre and final cleanup", name, len(fences))
+		}
+		for _, fence := range fences {
+			if fence != fenceA {
+				t.Fatalf("%s cleanup fence = %#v, want %#v", name, fence, fenceA)
+			}
+		}
+	}
+
+	gotApproval, err := approvals.Get(ctx, approval.ID)
+	if err != nil || gotApproval.Status != toolapproval.StatusPending {
+		t.Fatalf("current approval after stale ACP cleanup = (%#v, %v)", gotApproval, err)
+	}
+	gotInput, err := inputs.Get(ctx, input.ID)
+	if err != nil || gotInput.Status != userinput.StatusPending {
+		t.Fatalf("current user input after stale ACP cleanup = (%#v, %v)", gotInput, err)
+	}
+}
+
+type recordingPostgresApprovalService struct {
+	*toolapproval.Service
+	mu     sync.Mutex
+	fences []runtimefence.Fence
+}
+
+func (s *recordingPostgresApprovalService) CancelPendingForSession(ctx context.Context, botID, sessionID, reason string) ([]toolapproval.Request, error) {
+	fence, _ := runtimefence.FromContext(ctx)
+	s.mu.Lock()
+	s.fences = append(s.fences, fence)
+	s.mu.Unlock()
+	return s.Service.CancelPendingForSession(ctx, botID, sessionID, reason)
+}
+
+func (s *recordingPostgresApprovalService) recordedCleanupFences() []runtimefence.Fence {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]runtimefence.Fence(nil), s.fences...)
+}
+
+type recordingPostgresUserInputService struct {
+	*userinput.Service
+	mu     sync.Mutex
+	fences []runtimefence.Fence
+}
+
+func (s *recordingPostgresUserInputService) CancelPendingForSession(ctx context.Context, botID, sessionID, reason string) ([]userinput.Request, error) {
+	fence, _ := runtimefence.FromContext(ctx)
+	s.mu.Lock()
+	s.fences = append(s.fences, fence)
+	s.mu.Unlock()
+	return s.Service.CancelPendingForSession(ctx, botID, sessionID, reason)
+}
+
+func (s *recordingPostgresUserInputService) recordedCleanupFences() []runtimefence.Fence {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]runtimefence.Fence(nil), s.fences...)
+}
+
+func openACPRuntimeFencePostgresPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	dsn := strings.TrimSpace(os.Getenv("TEST_POSTGRES_DSN"))
+	if dsn == "" {
+		if os.Getenv("MEMOH_TEST_POSTGRES_REQUIRED") == "1" {
+			t.Fatal("ACP postgres runtime fence test is required, but TEST_POSTGRES_DSN is not set")
+		}
+		t.Skip("set TEST_POSTGRES_DSN to run ACP runtime fence integration")
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("create ACP runtime fence pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("ping ACP runtime fence postgres: %v", err)
+	}
+	if os.Getenv("TEST_POSTGRES_BOOTSTRAP_SCHEMA") == "1" {
+		schema, err := os.ReadFile("../../db/postgres/migrations/0001_init.up.sql")
+		if err != nil {
+			t.Fatalf("read canonical postgres schema: %v", err)
+		}
+		if _, err := pool.Exec(ctx, string(schema)); err != nil {
+			t.Fatalf("apply canonical postgres schema: %v", err)
+		}
+	}
+	migration, err := os.ReadFile("../../db/postgres/migrations/0106_session_runtime_fencing_token.up.sql")
+	if err != nil {
+		t.Fatalf("read runtime fence migration: %v", err)
+	}
+	if _, err := pool.Exec(ctx, string(migration)); err != nil {
+		t.Fatalf("apply runtime fence migration: %v", err)
+	}
+	return pool
+}
+
+func createACPRuntimeFenceFixtures(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (pgtype.UUID, pgtype.UUID) {
+	t.Helper()
+	userID := uuid.New()
+	botUUID := uuid.New()
+	sessionUUID := uuid.New()
+	name := fmt.Sprintf("acp-runtime-fence-%s", uuid.NewString())
+	if _, err := pool.Exec(ctx, "INSERT INTO users (id, username, role, is_active) VALUES ($1, $2, 'admin', true)", userID, name); err != nil {
+		t.Fatalf("create ACP runtime fence user: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "INSERT INTO bots (id, owner_user_id, type, name) VALUES ($1, $2, 'personal', $3)", botUUID, userID, name); err != nil {
+		t.Fatalf("create ACP runtime fence bot: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "INSERT INTO bot_sessions (id, bot_id, channel_type) VALUES ($1, $2, 'local')", sessionUUID, botUUID); err != nil {
+		t.Fatalf("create ACP runtime fence session: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM bots WHERE id = $1", botUUID)
+		_, _ = pool.Exec(ctx, "DELETE FROM users WHERE id = $1", userID)
+	})
+	botID, err := dbpkg.ParseUUID(botUUID.String())
+	if err != nil {
+		t.Fatalf("parse ACP runtime fence bot id: %v", err)
+	}
+	sessionID, err := dbpkg.ParseUUID(sessionUUID.String())
+	if err != nil {
+		t.Fatalf("parse ACP runtime fence session id: %v", err)
+	}
+	return botID, sessionID
+}

--- a/internal/acpagent/runtime_fence_postgres_integration_test.go
+++ b/internal/acpagent/runtime_fence_postgres_integration_test.go
@@ -175,7 +175,7 @@ func openACPRuntimeFencePostgresPool(t *testing.T, ctx context.Context) *pgxpool
 			t.Fatalf("apply canonical postgres schema: %v", err)
 		}
 	}
-	migration, err := os.ReadFile("../../db/postgres/migrations/0106_session_runtime_fencing_token.up.sql")
+	migration, err := os.ReadFile("../../db/postgres/migrations/0107_session_runtime_fencing_token.up.sql")
 	if err != nil {
 		t.Fatalf("read runtime fence migration: %v", err)
 	}

--- a/internal/acpagent/session_pool.go
+++ b/internal/acpagent/session_pool.go
@@ -27,6 +27,7 @@ import (
 	"github.com/memohai/memoh/internal/agent/event"
 	"github.com/memohai/memoh/internal/bots"
 	"github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/runtimefence"
 	"github.com/memohai/memoh/internal/session"
 	"github.com/memohai/memoh/internal/toolapproval"
 	"github.com/memohai/memoh/internal/userinput"
@@ -131,15 +132,19 @@ type runtimeHandle struct {
 
 	// state guards the mutable snapshot below. Leaf lock: never acquire
 	// other locks while holding it.
-	state          sync.Mutex
-	session        *acpclient.Session
-	status         string
-	lastActive     time.Time
-	boundSession   string
-	defaultModelID string
-	active         *acpclient.ToolSessionContext
-	startCancel    context.CancelFunc
-	closed         bool
+	state                    sync.Mutex
+	session                  *acpclient.Session
+	status                   string
+	lastActive               time.Time
+	boundSession             string
+	defaultModelID           string
+	active                   *acpclient.ToolSessionContext
+	persistenceFence         runtimefence.Fence
+	startCancel              context.CancelFunc
+	closed                   bool
+	hadPrompt                bool
+	decisionPreCleanupOnce   sync.Once
+	decisionFinalCleanupOnce sync.Once
 }
 
 // PromptInput carries one prompt (or runtime control call) for a chat
@@ -171,6 +176,7 @@ type PromptInput struct {
 	RuntimeOwnerAccountID string
 	ForceFreshRuntime     bool
 	Sink                  acpclient.EventSink
+	RuntimeGuard          func(context.Context) error
 }
 
 // CreateRuntimeInput describes a pre-session runtime creation request.
@@ -574,8 +580,12 @@ func (p *SessionPool) promptOnHandle(ctx context.Context, h *runtimeHandle, inpu
 	sess := h.session
 	h.status = stateActive
 	h.lastActive = time.Now()
-	toolCtx := toolSessionContext(input, h)
+	toolCtx := toolSessionContext(ctx, input, h)
 	h.active = &toolCtx
+	h.hadPrompt = true
+	if toolCtx.RuntimeFence.Valid() {
+		h.persistenceFence = toolCtx.RuntimeFence
+	}
 	h.state.Unlock()
 	// Cleanup is defer-based so error paths can never leave a stale
 	// per-prompt context or sink behind.
@@ -971,8 +981,12 @@ func (p *SessionPool) closeHandle(h *runtimeHandle) error {
 	h.startCancel = nil
 	bound := h.boundSession
 	activeSession := ""
+	fence := h.persistenceFence
 	if h.active != nil {
 		activeSession = strings.TrimSpace(h.active.SessionID)
+		if h.active.RuntimeFence.Valid() {
+			fence = h.active.RuntimeFence
+		}
 		h.active = nil
 	}
 	h.state.Unlock()
@@ -980,15 +994,15 @@ func (p *SessionPool) closeHandle(h *runtimeHandle) error {
 	if cancel != nil {
 		cancel()
 	}
-	var closeErr error
-	if sess != nil {
-		closeErr = sess.Close()
-	}
 	sessionID := strings.TrimSpace(bound)
 	if sessionID == "" {
 		sessionID = activeSession
 	}
-	p.cancelPendingDecisions(h.botID, sessionID, "decision cancelled: ACP runtime closed before a response arrived")
+	p.cancelHandlePendingDecisions(h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
+	var closeErr error
+	if sess != nil {
+		closeErr = sess.Close()
+	}
 
 	h.op.Lock()
 	defer h.op.Unlock()
@@ -1039,18 +1053,20 @@ func (p *SessionPool) teardown(h *runtimeHandle) error {
 	h.startCancel = nil
 	bound := h.boundSession
 	activeSession := ""
+	fence := h.persistenceFence
 	if h.active != nil {
 		activeSession = strings.TrimSpace(h.active.SessionID)
+		if h.active.RuntimeFence.Valid() {
+			fence = h.active.RuntimeFence
+		}
 	}
 	h.active = nil
 	h.state.Unlock()
-
-	p.mu.Lock()
-	delete(p.runtimes, h.id)
-	if bound != "" && p.bySession[bound] == h.id {
-		delete(p.bySession, bound)
+	sessionID := strings.TrimSpace(bound)
+	if sessionID == "" {
+		sessionID = activeSession
 	}
-	p.mu.Unlock()
+	p.cancelHandlePendingDecisions(h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
 
 	if cancel != nil {
 		cancel()
@@ -1059,40 +1075,104 @@ func (p *SessionPool) teardown(h *runtimeHandle) error {
 	if sess != nil {
 		closeErr = sess.Close()
 	}
-	sessionID := strings.TrimSpace(bound)
-	if sessionID == "" {
-		sessionID = activeSession
+	p.cancelHandlePendingDecisions(h, sessionID, fence, decisionCleanupFinal, "decision cancelled: ACP runtime closed before a response arrived")
+
+	p.mu.Lock()
+	delete(p.runtimes, h.id)
+	if bound != "" && p.bySession[bound] == h.id {
+		delete(p.bySession, bound)
 	}
-	p.cancelPendingDecisions(h.botID, sessionID, "decision cancelled: ACP runtime closed before a response arrived")
+	p.mu.Unlock()
 	return closeErr
 }
 
-func (p *SessionPool) cancelPendingDecisions(botID, sessionID, reason string) {
+type decisionCleanupPhase uint8
+
+const (
+	decisionCleanupPre decisionCleanupPhase = iota
+	decisionCleanupFinal
+)
+
+func (p *SessionPool) cancelHandlePendingDecisions(h *runtimeHandle, sessionID string, fence runtimefence.Fence, phase decisionCleanupPhase, reason string) {
+	if p == nil || h == nil {
+		return
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return
+	}
+	h.state.Lock()
+	hadPrompt := h.hadPrompt
+	h.state.Unlock()
+	if !fence.Valid() && !hadPrompt {
+		return
+	}
+	p.mu.RLock()
+	currentID := p.bySession[sessionID]
+	p.mu.RUnlock()
+	if currentID != "" && currentID != h.id {
+		return
+	}
+	var once *sync.Once
+	switch phase {
+	case decisionCleanupPre:
+		once = &h.decisionPreCleanupOnce
+	case decisionCleanupFinal:
+		once = &h.decisionFinalCleanupOnce
+	default:
+		return
+	}
+	once.Do(func() {
+		ctx := context.Background()
+		if fence.Valid() {
+			ctx = runtimefence.WithContext(ctx, fence)
+		}
+		p.cancelPendingDecisions(ctx, h.botID, sessionID, reason)
+	})
+}
+
+//nolint:contextcheck // lifecycle cleanup is detached from the closed prompt but retains its fence value.
+func (p *SessionPool) cancelPendingDecisions(parent context.Context, botID, sessionID, reason string) {
 	botID = strings.TrimSpace(botID)
 	sessionID = strings.TrimSpace(sessionID)
 	if p == nil || botID == "" || sessionID == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	if parent == nil {
+		parent = context.Background()
+	}
+	var cleanup sync.WaitGroup
 	if approval, ok := p.approval.(interface {
 		CancelPendingForSession(context.Context, string, string, string) ([]toolapproval.Request, error)
 	}); ok {
-		if _, err := approval.CancelPendingForSession(ctx, botID, sessionID, reason); err != nil {
-			p.logger.Warn("cancel pending ACP approvals failed",
-				slog.Any("error", err),
-				slog.String("bot_id", botID),
-				slog.String("session_id", sessionID))
-		}
+		cleanup.Add(1)
+		go func() {
+			defer cleanup.Done()
+			ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), 5*time.Second)
+			defer cancel()
+			if _, err := approval.CancelPendingForSession(ctx, botID, sessionID, reason); err != nil && !errors.Is(err, runtimefence.ErrStale) {
+				p.logger.Warn("cancel pending ACP approvals failed",
+					slog.Any("error", err),
+					slog.String("bot_id", botID),
+					slog.String("session_id", sessionID))
+			}
+		}()
 	}
 	if p.userInput != nil {
-		if _, err := p.userInput.CancelPendingForSession(ctx, botID, sessionID, reason); err != nil {
-			p.logger.Warn("cancel pending ACP user inputs failed",
-				slog.Any("error", err),
-				slog.String("bot_id", botID),
-				slog.String("session_id", sessionID))
-		}
+		cleanup.Add(1)
+		go func() {
+			defer cleanup.Done()
+			ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), 5*time.Second)
+			defer cancel()
+			if _, err := p.userInput.CancelPendingForSession(ctx, botID, sessionID, reason); err != nil && !errors.Is(err, runtimefence.ErrStale) {
+				p.logger.Warn("cancel pending ACP user inputs failed",
+					slog.Any("error", err),
+					slog.String("bot_id", botID),
+					slog.String("session_id", sessionID))
+			}
+		}()
 	}
+	cleanup.Wait()
 }
 
 func (p *SessionPool) CloseAll() {
@@ -1377,6 +1457,11 @@ func (h *runtimeHandle) toolContext() mcp.ToolSessionContext {
 	if h.active.SupportsImageInput {
 		ctx.SupportsImageInput = true
 	}
+	if h.active.RuntimeFence.Valid() {
+		ctx.RuntimeFence = h.active.RuntimeFence
+	}
+	ctx.RunContext = h.active.RunContext
+	ctx.RuntimeGuard = h.active.RuntimeGuard
 	return ctx
 }
 
@@ -1399,7 +1484,8 @@ func (h *runtimeHandle) setStatus(status string) {
 	h.state.Unlock()
 }
 
-func toolSessionContext(input PromptInput, h *runtimeHandle) acpclient.ToolSessionContext {
+func toolSessionContext(ctx context.Context, input PromptInput, h *runtimeHandle) acpclient.ToolSessionContext {
+	fence, _ := runtimefence.FromContext(ctx)
 	return acpclient.ToolSessionContext{
 		BotID:               h.botID,
 		ChatID:              firstNonEmpty(input.ChatID, h.botID),
@@ -1416,6 +1502,9 @@ func toolSessionContext(input PromptInput, h *runtimeHandle) acpclient.ToolSessi
 		CanRequestUserInput: input.CanRequestUserInput,
 		IsSubagent:          false,
 		SupportsImageInput:  input.SupportsImageInput,
+		RuntimeFence:        fence,
+		RunContext:          ctx,
+		RuntimeGuard:        input.RuntimeGuard,
 	}
 }
 

--- a/internal/acpagent/sessionpool_test.go
+++ b/internal/acpagent/sessionpool_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/memohai/memoh/internal/bots"
 	"github.com/memohai/memoh/internal/config"
 	"github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/runtimefence"
 	sessionpkg "github.com/memohai/memoh/internal/session"
 	"github.com/memohai/memoh/internal/toolapproval"
 	"github.com/memohai/memoh/internal/userinput"
@@ -1594,6 +1595,10 @@ func TestRuntimeHandleToolContextOverlaysActivePrompt(t *testing.T) {
 	}
 
 	// During a prompt the live per-prompt fields overlay.
+	wantFence := runtimefence.Fence{BotID: "bot-1", SessionID: "session-1", Token: 29}
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	defer cancelRun()
+	guardCalls := 0
 	active := acpclient.ToolSessionContext{
 		ChatID:             "chat-1",
 		SessionID:          "session-1",
@@ -1603,6 +1608,12 @@ func TestRuntimeHandleToolContextOverlaysActivePrompt(t *testing.T) {
 		ReplyTarget:        "reply-7",
 		ConversationType:   "private",
 		SupportsImageInput: true,
+		RuntimeFence:       wantFence,
+		RunContext:         runCtx,
+		RuntimeGuard: func(context.Context) error {
+			guardCalls++
+			return nil
+		},
 	}
 	h.state.Lock()
 	h.active = &active
@@ -1620,12 +1631,34 @@ func TestRuntimeHandleToolContextOverlaysActivePrompt(t *testing.T) {
 	if !ctx.SupportsImageInput {
 		t.Fatalf("active tool context lost image capability: %#v", ctx)
 	}
+	if ctx.RuntimeFence != wantFence {
+		t.Fatalf("active tool context fence = %#v, want %#v", ctx.RuntimeFence, wantFence)
+	}
+	if ctx.RunContext != runCtx || ctx.RuntimeGuard == nil {
+		t.Fatalf("active tool context lost runtime lifecycle: %#v", ctx)
+	}
+	if err := ctx.RuntimeGuard(context.Background()); err != nil || guardCalls != 1 {
+		t.Fatalf("runtime guard = (%v, calls:%d), want one successful call", err, guardCalls)
+	}
 
 	// clearActive removes every per-prompt field again.
 	h.clearActive()
 	ctx = h.toolContext()
-	if ctx.StreamID != "" || ctx.SessionToken != "" || ctx.ChatID != "bot-1" || ctx.RuntimeActive || ctx.SupportsImageInput || !ctx.CanListUserInput {
+	if ctx.StreamID != "" || ctx.SessionToken != "" || ctx.ChatID != "bot-1" || ctx.RuntimeActive || ctx.SupportsImageInput || !ctx.CanListUserInput || ctx.RunContext != nil || ctx.RuntimeGuard != nil {
 		t.Fatalf("cleared tool context = %#v", ctx)
+	}
+}
+
+func TestToolSessionContextCarriesPromptRuntimeFence(t *testing.T) {
+	want := runtimefence.Fence{BotID: "bot-1", SessionID: "session-1", Token: 31}
+	ctx := runtimefence.WithContext(context.Background(), want)
+	guard := func(context.Context) error { return nil }
+	got := toolSessionContext(ctx, PromptInput{SessionID: want.SessionID, StreamID: "stream-1", RuntimeGuard: guard}, &runtimeHandle{id: "rt-1", botID: want.BotID})
+	if got.RuntimeFence != want {
+		t.Fatalf("tool session fence = %#v, want %#v", got.RuntimeFence, want)
+	}
+	if got.RunContext != ctx || got.RuntimeGuard == nil {
+		t.Fatalf("tool session runtime lifecycle = context:%v guard:%v", got.RunContext, got.RuntimeGuard != nil)
 	}
 }
 
@@ -1822,6 +1855,7 @@ func TestCloseSessionCancelsPendingDecisions(t *testing.T) {
 		status:       stateIdle,
 		boundSession: "session-1",
 		lastActive:   time.Now(),
+		hadPrompt:    true,
 	})
 
 	if err := pool.CloseSession("session-1"); err != nil {
@@ -1832,6 +1866,112 @@ func TestCloseSessionCancelsPendingDecisions(t *testing.T) {
 	}
 	if userInput.cancelBotID != "bot-1" || userInput.cancelSessionID != "session-1" || userInput.cancelReason == "" {
 		t.Fatalf("cancel pending user inputs = bot:%q session:%q reason:%q", userInput.cancelBotID, userInput.cancelSessionID, userInput.cancelReason)
+	}
+	if approval.cancelCount != 2 || userInput.cancelCount != 2 {
+		t.Fatalf("decision cleanup count = approval:%d user_input:%d, want pre and final cleanup", approval.cancelCount, userInput.cancelCount)
+	}
+}
+
+func TestCloseSessionWithoutPromptDoesNotCancelPendingDecisions(t *testing.T) {
+	t.Parallel()
+
+	approval := &fakeToolApprovalService{}
+	userInput := &fakeUserInputCanceller{}
+	pool := newSessionPool(nil, nil, fakeBotGetter{})
+	pool.SetToolApprovalService(approval)
+	pool.SetUserInputService(userInput)
+	injectRuntime(pool, &runtimeHandle{
+		id: "rt-ensure-only", botID: "bot-1", status: stateIdle,
+		boundSession: "session-1", lastActive: time.Now(),
+	})
+
+	if err := pool.CloseSession("session-1"); err != nil {
+		t.Fatalf("CloseSession() error = %v", err)
+	}
+	if approval.cancelCount != 0 || userInput.cancelCount != 0 {
+		t.Fatalf("ensure-only cleanup reached session decisions: approval=%d user_input=%d", approval.cancelCount, userInput.cancelCount)
+	}
+}
+
+func TestPendingDecisionCleanupRunsServicesIndependently(t *testing.T) {
+	t.Parallel()
+
+	approvalStarted := make(chan struct{}, 1)
+	approvalRelease := make(chan struct{})
+	inputStarted := make(chan struct{}, 1)
+	approval := &fakeToolApprovalService{cancelStarted: approvalStarted, cancelRelease: approvalRelease}
+	userInput := &fakeUserInputCanceller{cancelStarted: inputStarted}
+	pool := newSessionPool(nil, nil, fakeBotGetter{})
+	pool.SetToolApprovalService(approval)
+	pool.SetUserInputService(userInput)
+	done := make(chan struct{})
+	go func() {
+		pool.cancelPendingDecisions(context.Background(), "bot-1", "session-1", "cleanup")
+		close(done)
+	}()
+
+	select {
+	case <-approvalStarted:
+	case <-time.After(time.Second):
+		t.Fatal("approval cleanup did not start")
+	}
+	select {
+	case <-inputStarted:
+	case <-time.After(time.Second):
+		t.Fatal("user input cleanup waited for blocked approval cleanup")
+	}
+	close(approvalRelease)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("decision cleanup did not finish")
+	}
+}
+
+func TestCloseSessionCarriesLatestRuntimeFenceToDecisionCleanup(t *testing.T) {
+	want := runtimefence.Fence{BotID: "bot-1", SessionID: "session-1", Token: 37}
+	approval := &fakeToolApprovalService{}
+	userInput := &fakeUserInputCanceller{}
+	pool := newSessionPool(nil, nil, fakeBotGetter{})
+	pool.SetToolApprovalService(approval)
+	pool.SetUserInputService(userInput)
+	injectRuntime(pool, &runtimeHandle{
+		id:               "rt-fenced-cleanup",
+		botID:            want.BotID,
+		status:           stateIdle,
+		boundSession:     want.SessionID,
+		persistenceFence: want,
+		lastActive:       time.Now(),
+		hadPrompt:        true,
+	})
+
+	if err := pool.CloseSession(want.SessionID); err != nil {
+		t.Fatalf("CloseSession() error = %v", err)
+	}
+	if approval.cancelFence != want || userInput.cancelFence != want {
+		t.Fatalf("decision cleanup fences = approval:%#v user_input:%#v, want %#v", approval.cancelFence, userInput.cancelFence, want)
+	}
+	if approval.cancelCount != 2 || userInput.cancelCount != 2 {
+		t.Fatalf("fenced cleanup count = approval:%d user_input:%d, want pre and final cleanup", approval.cancelCount, userInput.cancelCount)
+	}
+}
+
+func TestStaleRuntimeHandleDoesNotCancelNewHandleDecisions(t *testing.T) {
+	approval := &fakeToolApprovalService{}
+	userInput := &fakeUserInputCanceller{}
+	pool := newSessionPool(nil, nil, fakeBotGetter{})
+	pool.SetToolApprovalService(approval)
+	pool.SetUserInputService(userInput)
+	old := &runtimeHandle{id: "rt-old", botID: "bot-1", boundSession: "session-1", status: stateIdle, lastActive: time.Now(), hadPrompt: true}
+	current := &runtimeHandle{id: "rt-current", botID: "bot-1", boundSession: "session-1", status: stateIdle, lastActive: time.Now(), hadPrompt: true}
+	injectRuntime(pool, old)
+	injectRuntime(pool, current)
+
+	if err := pool.closeHandle(old); err != nil {
+		t.Fatalf("close stale handle: %v", err)
+	}
+	if approval.cancelCount != 0 || userInput.cancelCount != 0 {
+		t.Fatalf("stale cleanup reached current decisions: approval=%d user_input=%d", approval.cancelCount, userInput.cancelCount)
 	}
 }
 
@@ -1857,6 +1997,10 @@ type fakeToolApprovalService struct {
 	cancelBotID     string
 	cancelSessionID string
 	cancelReason    string
+	cancelCount     int
+	cancelFence     runtimefence.Fence
+	cancelStarted   chan<- struct{}
+	cancelRelease   <-chan struct{}
 }
 
 func (*fakeToolApprovalService) EvaluatePolicy(context.Context, toolapproval.CreatePendingInput) (toolapproval.Evaluation, error) {
@@ -1883,10 +2027,18 @@ func (*fakeToolApprovalService) RegisterWaiter(string) func() {
 	return func() {}
 }
 
-func (f *fakeToolApprovalService) CancelPendingForSession(_ context.Context, botID, sessionID, reason string) ([]toolapproval.Request, error) {
+func (f *fakeToolApprovalService) CancelPendingForSession(ctx context.Context, botID, sessionID, reason string) ([]toolapproval.Request, error) {
+	if f.cancelStarted != nil {
+		f.cancelStarted <- struct{}{}
+	}
+	if f.cancelRelease != nil {
+		<-f.cancelRelease
+	}
 	f.cancelBotID = botID
 	f.cancelSessionID = sessionID
 	f.cancelReason = reason
+	f.cancelCount++
+	f.cancelFence, _ = runtimefence.FromContext(ctx)
 	return nil, nil
 }
 
@@ -1894,12 +2046,20 @@ type fakeUserInputCanceller struct {
 	cancelBotID     string
 	cancelSessionID string
 	cancelReason    string
+	cancelCount     int
+	cancelFence     runtimefence.Fence
+	cancelStarted   chan<- struct{}
 }
 
-func (f *fakeUserInputCanceller) CancelPendingForSession(_ context.Context, botID, sessionID, reason string) ([]userinput.Request, error) {
+func (f *fakeUserInputCanceller) CancelPendingForSession(ctx context.Context, botID, sessionID, reason string) ([]userinput.Request, error) {
+	if f.cancelStarted != nil {
+		f.cancelStarted <- struct{}{}
+	}
 	f.cancelBotID = botID
 	f.cancelSessionID = sessionID
 	f.cancelReason = reason
+	f.cancelCount++
+	f.cancelFence, _ = runtimefence.FromContext(ctx)
 	return nil, nil
 }
 

--- a/internal/acpclient/client.go
+++ b/internal/acpclient/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/memohai/memoh/internal/acpprofile"
 	"github.com/memohai/memoh/internal/agent/event"
 	"github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/runtimefence"
 	"github.com/memohai/memoh/internal/toolapproval"
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
@@ -241,6 +242,10 @@ func (c *clientCallbacks) setPromptState(collector *eventCollector, sink EventSi
 }
 
 func (c *clientCallbacks) ReadTextFile(ctx context.Context, p acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
+	session := c.currentToolSession()
+	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	defer cancel()
+
 	toolID := "read-" + uuid.NewString()
 	input := map[string]any{"path": p.Path}
 	if p.Line != nil && *p.Line > 0 {
@@ -281,6 +286,10 @@ func (c *clientCallbacks) ReadTextFile(ctx context.Context, p acp.ReadTextFileRe
 	if p.Limit != nil && *p.Limit > 0 {
 		limit = boundedPositiveInt32(*p.Limit)
 	}
+	if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
+		toolErr = err
+		return acp.ReadTextFileResponse{}, err
+	}
 	resp, err := c.client.ReadFile(ctx, path, line, limit)
 	if err != nil {
 		toolErr = err
@@ -318,6 +327,10 @@ func (c *clientCallbacks) limitedApprovalRejectionMessage(toolName string, appro
 }
 
 func (c *clientCallbacks) WriteTextFile(ctx context.Context, p acp.WriteTextFileRequest) (acp.WriteTextFileResponse, error) {
+	session := c.currentToolSession()
+	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	defer cancel()
+
 	toolID := "write-" + uuid.NewString()
 	input := writeToolInput(p.Path, p.Content)
 	toolID, approval, err := c.approveCallbackTool(ctx, toolID, "write", input)
@@ -341,6 +354,10 @@ func (c *clientCallbacks) WriteTextFile(ctx context.Context, p acp.WriteTextFile
 
 	path, err := c.resolvePath(p.Path)
 	if err != nil {
+		toolErr = err
+		return acp.WriteTextFileResponse{}, err
+	}
+	if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
 		toolErr = err
 		return acp.WriteTextFileResponse{}, err
 	}
@@ -427,6 +444,19 @@ func (c *clientCallbacks) RequestPermission(ctx context.Context, p acp.RequestPe
 	if c == nil {
 		return cancelledPermission(), nil
 	}
+	session := c.currentToolSession()
+	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	defer cancel()
+	allowWithGuard := func() (acp.RequestPermissionResponse, error) {
+		resp := allowOncePermission(p)
+		if resp.Outcome.Cancelled != nil {
+			return resp, nil
+		}
+		if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
+			return acp.RequestPermissionResponse{}, err
+		}
+		return resp, nil
+	}
 	if err := c.validatePermissionScope(p); err != nil {
 		// Security-relevant rejection: an agent asked to act outside the
 		// workspace root. Log it (an agent probing the boundary is exactly what
@@ -459,10 +489,10 @@ func (c *clientCallbacks) RequestPermission(ctx context.Context, p acp.RequestPe
 				slog.String("title", title),
 				slog.String("kind", kind))
 		}
-		return allowOncePermission(p), nil
+		return allowWithGuard()
 	}
 	if c.approval == nil {
-		return allowOncePermission(p), nil
+		return allowWithGuard()
 	}
 	result, err := c.requireToolApproval(ctx, toolCallID, toolName, input)
 	if err != nil {
@@ -478,7 +508,10 @@ func (c *clientCallbacks) RequestPermission(ctx context.Context, p acp.RequestPe
 		// cancel the request: there was no user decision to report.
 		return cancelledPermission(), nil
 	}
-	resp := allowOncePermission(p)
+	resp, err := allowWithGuard()
+	if err != nil {
+		return acp.RequestPermissionResponse{}, err
+	}
 	if resp.Outcome.Cancelled != nil {
 		// The user approved but the agent offered no allow_once option, so the
 		// agent sees a cancellation and will not act - leaving a consumable
@@ -545,6 +578,7 @@ func (c *clientCallbacks) requireToolApproval(ctx context.Context, toolCallID, t
 	if strings.TrimSpace(session.BotID) == "" || strings.TrimSpace(session.SessionID) == "" {
 		return toolapproval.FlowResult{}, nil
 	}
+	ctx = runtimefence.WithContext(ctx, session.RuntimeFence)
 	return toolapproval.RunFlow(ctx, c.approval, toolapproval.FlowRequest{
 		Input: toolapproval.CreatePendingInput{
 			BotID:                        session.BotID,
@@ -961,6 +995,9 @@ func (c *clientCallbacks) SessionUpdate(_ context.Context, p acp.SessionNotifica
 }
 
 func (c *clientCallbacks) CreateTerminal(ctx context.Context, p acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
+	session := c.currentToolSession()
+	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	defer cancel()
 	return c.terminals.CreateTerminal(ctx, p, func(toolCallID string, input map[string]any) (terminalApprovalResult, error) {
 		id, approval, err := c.approveCallbackTool(ctx, toolCallID, "exec", input)
 		return terminalApprovalResult{
@@ -968,6 +1005,11 @@ func (c *clientCallbacks) CreateTerminal(ctx context.Context, p acp.CreateTermin
 			ToolCallID:       id,
 			RejectionMessage: c.limitedApprovalRejectionMessage("exec", approval),
 		}, err
+	}, terminalRuntimeScope{
+		validate: func(guardCtx context.Context) error {
+			return mcp.ValidateRuntimeGuard(guardCtx, session)
+		},
+		runContext: session.RunContext,
 	})
 }
 

--- a/internal/acpclient/client_test.go
+++ b/internal/acpclient/client_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/memohai/memoh/internal/acpprofile"
 	"github.com/memohai/memoh/internal/agent/event"
 	"github.com/memohai/memoh/internal/config"
+	"github.com/memohai/memoh/internal/conversation"
 	"github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/runtimefence"
+	"github.com/memohai/memoh/internal/sessionruntime"
 	"github.com/memohai/memoh/internal/toolapproval"
 	"github.com/memohai/memoh/internal/workspace/bridge"
 	pb "github.com/memohai/memoh/internal/workspace/bridgepb"
@@ -1113,6 +1116,7 @@ func TestRequestPermissionOnlyAutoAllowsOnce(t *testing.T) {
 func TestRequestPermissionUsesMemohToolApproval(t *testing.T) {
 	t.Parallel()
 
+	wantFence := runtimefence.Fence{BotID: "bot-1", SessionID: "session-1", Token: 23}
 	approval := &fakeACPToolApproval{
 		decision: toolapproval.Request{
 			ID:      "approval-1",
@@ -1132,6 +1136,7 @@ func TestRequestPermissionUsesMemohToolApproval(t *testing.T) {
 			ChannelIdentityID: "channel-1",
 			CurrentPlatform:   "web",
 			ConversationType:  "private",
+			RuntimeFence:      wantFence,
 		},
 		events: &toolEventEmitter{},
 	}
@@ -1162,6 +1167,9 @@ func TestRequestPermissionUsesMemohToolApproval(t *testing.T) {
 	}
 	if approval.created.ToolCallID != "write-1" || approval.created.ToolName != "write" {
 		t.Fatalf("approval input = %#v", approval.created)
+	}
+	if approval.evaluateFence != wantFence {
+		t.Fatalf("approval fence = %#v, want %#v", approval.evaluateFence, wantFence)
 	}
 	if approval.created.BotID != "bot-1" || approval.created.SessionID != "session-1" || approval.created.ChannelIdentityID != "channel-1" {
 		t.Fatalf("approval context = %#v", approval.created)
@@ -2087,6 +2095,203 @@ func TestWriteTextFileUsesMemohToolApproval(t *testing.T) {
 	}
 	assertSingleApprovalWithStartEnd(t, collector.result().Events, approval.created.ToolCallID, "write", "approval-write")
 }
+
+func TestACPFileCallbacksRecheckRuntimeGuardAfterApproval(t *testing.T) {
+	guardErr := errors.New("runtime ownership lost")
+	tests := []struct {
+		name string
+		run  func(context.Context, *clientCallbacks) error
+	}{
+		{
+			name: "read",
+			run: func(ctx context.Context, callbacks *clientCallbacks) error {
+				_, err := callbacks.ReadTextFile(ctx, acp.ReadTextFileRequest{Path: "/data/input.txt"})
+				return err
+			},
+		},
+		{
+			name: "write",
+			run: func(ctx context.Context, callbacks *clientCallbacks) error {
+				_, err := callbacks.WriteTextFile(ctx, acp.WriteTextFileRequest{Path: "/data/output.txt", Content: "stale\n"})
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, server := newRecordingBridgeClient(t)
+			approval := &fakeACPToolApproval{decision: toolapproval.Request{
+				ID: "approval-" + tt.name, Status: toolapproval.StatusApproved,
+			}}
+			guardCalls := 0
+			callbacks := newClientCallbacks(
+				context.Background(), client, "/data", "/data", time.Second,
+				nil, nil, false, nil, true, approval, nil,
+				ToolSessionContext{
+					BotID: "bot-1", SessionID: "session-1", StreamID: "stream-1",
+					RuntimeGuard: func(context.Context) error {
+						guardCalls++
+						return guardErr
+					},
+				},
+				acpprofile.DefaultToolQuirks(),
+			)
+			callbacks.setPromptState(newEventCollector(), nil, callbacks.baseSession)
+
+			if err := tt.run(context.Background(), callbacks); !errors.Is(err, guardErr) {
+				t.Fatalf("%s error = %v, want runtime guard error", tt.name, err)
+			}
+			if approval.createdCount() != 1 || guardCalls != 1 {
+				t.Fatalf("%s approval/guard calls = %d/%d, want 1/1", tt.name, approval.createdCount(), guardCalls)
+			}
+			if reads, writes := server.readPaths(), server.writes(); len(reads) != 0 || len(writes) != 0 {
+				t.Fatalf("%s bridge effects after guard rejection = reads:%#v writes:%#v", tt.name, reads, writes)
+			}
+		})
+	}
+}
+
+func TestACPCreateTerminalRechecksRuntimeGuardAfterApproval(t *testing.T) {
+	guardErr := errors.New("runtime ownership lost")
+	client, server := newRecordingBridgeClient(t)
+	approval := &fakeACPToolApproval{decision: toolapproval.Request{
+		ID: "approval-terminal-guard", Status: toolapproval.StatusApproved,
+	}}
+	callbacks := newClientCallbacks(
+		context.Background(), client, "/workspace", "/workspace", time.Second,
+		nil, nil, false, nil, false, approval, nil,
+		ToolSessionContext{
+			BotID: "bot-1", SessionID: "session-1", StreamID: "stream-1",
+			RuntimeGuard: func(context.Context) error { return guardErr },
+		},
+		acpprofile.DefaultToolQuirks(),
+	)
+	callbacks.setPromptState(newEventCollector(), nil, callbacks.baseSession)
+
+	if _, err := callbacks.CreateTerminal(context.Background(), acp.CreateTerminalRequest{Command: "echo stale"}); !errors.Is(err, guardErr) {
+		t.Fatalf("CreateTerminal() error = %v, want runtime guard error", err)
+	}
+	if approval.createdCount() != 1 {
+		t.Fatalf("terminal approval calls = %d, want 1", approval.createdCount())
+	}
+	if records := server.records(); len(records) != 0 {
+		t.Fatalf("terminal effects after guard rejection = %#v", records)
+	}
+}
+
+func TestACPWorkspaceEffectsRejectStaleRedisOwner(t *testing.T) {
+	redisURL := strings.TrimSpace(os.Getenv("MEMOH_TEST_REDIS_URL"))
+	if redisURL == "" {
+		redisURL = strings.TrimSpace(os.Getenv("MEMOH_TEST_VALKEY_URL"))
+	}
+	if redisURL == "" {
+		if os.Getenv("MEMOH_TEST_DISTRIBUTED_REQUIRED") == "1" {
+			t.Fatal("distributed ACP workspace guard test is required, but Redis or Valkey is not configured")
+		}
+		t.Skip("set MEMOH_TEST_REDIS_URL or MEMOH_TEST_VALKEY_URL to run distributed ACP workspace guard test")
+	}
+
+	ctx := context.Background()
+	prefix := fmt.Sprintf("memoh:test:acp-workspace-guard:%d:", time.Now().UnixNano())
+	rawOwnerBackend, err := sessionruntime.NewRedisBackend(ctx, sessionruntime.RedisOptions{URL: redisURL, KeyPrefix: prefix, StateTTL: time.Minute})
+	if err != nil {
+		t.Fatalf("create stale owner backend: %v", err)
+	}
+	t.Cleanup(func() { _ = rawOwnerBackend.Close() })
+	owner := sessionruntime.NewManager(nonClosingDistributedBackend{DistributedBackend: rawOwnerBackend}, sessionruntime.Options{
+		OwnerID: "acp-workspace-owner-a", StateTTL: time.Minute, OwnerLeaseTTL: 100 * time.Millisecond,
+	})
+	if err := owner.Start(ctx); err != nil {
+		t.Fatalf("start stale owner manager: %v", err)
+	}
+	backendB, err := sessionruntime.NewRedisBackend(ctx, sessionruntime.RedisOptions{URL: redisURL, KeyPrefix: prefix, StateTTL: time.Minute})
+	if err != nil {
+		t.Fatalf("create takeover backend: %v", err)
+	}
+	takeover := sessionruntime.NewManager(backendB, sessionruntime.Options{
+		OwnerID: "acp-workspace-owner-b", StateTTL: time.Minute, OwnerLeaseTTL: 100 * time.Millisecond,
+	})
+	if err := takeover.Start(ctx); err != nil {
+		t.Fatalf("start takeover manager: %v", err)
+	}
+	t.Cleanup(func() { _ = takeover.Close() })
+
+	const (
+		botID     = "bot-acp-workspace-guard"
+		sessionID = "session-acp-workspace-guard"
+		streamA   = "stream-acp-workspace-owner-a"
+		streamB   = "stream-acp-workspace-owner-b"
+	)
+	ownerHandle, err := owner.StartRunHandle(ctx, botID, sessionID, streamA, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1))
+	if err != nil {
+		t.Fatalf("start stale owner run: %v", err)
+	}
+	ownerSnapshot, ok, err := rawOwnerBackend.Load(ctx, sessionruntime.Key{BotID: botID, SessionID: sessionID})
+	if err != nil || !ok || ownerSnapshot.CurrentRunView == nil || ownerSnapshot.CurrentRunView.OwnerLeaseExpiresAt == nil {
+		t.Fatalf("load stale owner lease = snapshot:%#v ok:%v err:%v", ownerSnapshot, ok, err)
+	}
+	ownerDeadline := *ownerSnapshot.CurrentRunView.OwnerLeaseExpiresAt
+	if err := owner.Close(); err != nil {
+		t.Fatalf("stop stale owner lease renewal: %v", err)
+	}
+	for {
+		now, err := backendB.Now(ctx)
+		if err != nil {
+			t.Fatalf("load Redis time: %v", err)
+		}
+		if !now.Before(ownerDeadline.Add(10 * time.Millisecond)) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if _, err := takeover.Snapshot(ctx, botID, sessionID); err != nil {
+		t.Fatalf("reconcile expired owner: %v", err)
+	}
+	if err := takeover.StartRun(ctx, botID, sessionID, streamB, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start takeover run: %v", err)
+	}
+
+	bridgeClient, bridgeServer := newRecordingBridgeClient(t)
+	approval := &fakeACPToolApproval{decision: toolapproval.Request{ID: "approval-stale-owner", Status: toolapproval.StatusApproved}}
+	callbacks := newClientCallbacks(
+		ctx, bridgeClient, "/data", "/data", time.Second, nil, nil, false, nil, true, approval, nil,
+		ToolSessionContext{
+			BotID: botID, SessionID: sessionID, StreamID: streamA,
+			RuntimeGuard: func(guardCtx context.Context) error {
+				return owner.ValidateRunOwnership(guardCtx, ownerHandle)
+			},
+		},
+		acpprofile.DefaultToolQuirks(),
+	)
+	callbacks.setPromptState(newEventCollector(), nil, callbacks.baseSession)
+	for name, call := range map[string]func() error{
+		"read": func() error {
+			_, err := callbacks.ReadTextFile(ctx, acp.ReadTextFileRequest{Path: "/data/input.txt"})
+			return err
+		},
+		"write": func() error {
+			_, err := callbacks.WriteTextFile(ctx, acp.WriteTextFileRequest{Path: "/data/output.txt", Content: "stale\n"})
+			return err
+		},
+		"terminal": func() error {
+			_, err := callbacks.CreateTerminal(ctx, acp.CreateTerminalRequest{Command: "echo stale"})
+			return err
+		},
+	} {
+		if err := call(); !errors.Is(err, sessionruntime.ErrRunOwnershipLost) {
+			t.Fatalf("stale %s error = %v, want ErrRunOwnershipLost", name, err)
+		}
+	}
+	if reads, writes, execs := bridgeServer.readPaths(), bridgeServer.writes(), bridgeServer.records(); len(reads) != 0 || len(writes) != 0 || len(execs) != 0 {
+		t.Fatalf("stale owner bridge effects = reads:%#v writes:%#v execs:%#v", reads, writes, execs)
+	}
+}
+
+type nonClosingDistributedBackend struct {
+	sessionruntime.DistributedBackend
+}
+
+func (nonClosingDistributedBackend) Close() error { return nil }
 
 func TestWriteTextFileWithoutToolSessionIsRejectedWhenApprovalEnabled(t *testing.T) {
 	t.Parallel()
@@ -3124,17 +3329,22 @@ func (*fakeACPAgent) SetSessionMode(context.Context, acp.SetSessionModeRequest) 
 }
 
 type fakeACPToolApproval struct {
-	mu          sync.Mutex
-	created     toolapproval.CreatePendingInput
-	createCount int
-	decision    toolapproval.Request
-	evaluation  toolapproval.Evaluation
-	waiters     int
+	mu            sync.Mutex
+	created       toolapproval.CreatePendingInput
+	createCount   int
+	decision      toolapproval.Request
+	evaluation    toolapproval.Evaluation
+	waiters       int
+	evaluateFence runtimefence.Fence
 }
 
-func (f *fakeACPToolApproval) EvaluatePolicy(context.Context, toolapproval.CreatePendingInput) (toolapproval.Evaluation, error) {
-	if strings.TrimSpace(f.evaluation.Decision) != "" {
-		return f.evaluation, nil
+func (f *fakeACPToolApproval) EvaluatePolicy(ctx context.Context, _ toolapproval.CreatePendingInput) (toolapproval.Evaluation, error) {
+	f.mu.Lock()
+	f.evaluateFence, _ = runtimefence.FromContext(ctx)
+	evaluation := f.evaluation
+	f.mu.Unlock()
+	if strings.TrimSpace(evaluation.Decision) != "" {
+		return evaluation, nil
 	}
 	return toolapproval.Evaluation{Decision: toolapproval.DecisionNeedsApproval}, nil
 }

--- a/internal/acpclient/process_test.go
+++ b/internal/acpclient/process_test.go
@@ -497,7 +497,7 @@ func TestCreateTerminalFiltersBlockedHermesEnv(t *testing.T) {
 			{Name: "OPENROUTER_API_KEY", Value: "sk-router"},
 			{Name: "CUSTOM_FLAG", Value: "1"},
 		},
-	}, nil)
+	}, nil, terminalRuntimeScope{})
 	if err != nil {
 		t.Fatalf("CreateTerminal() error = %v", err)
 	}
@@ -542,7 +542,7 @@ func TestCreateTerminalPassesUnsetEnvWithoutCleanEnv(t *testing.T) {
 		false,
 		nil,
 	)
-	term, err := manager.CreateTerminal(context.Background(), acp.CreateTerminalRequest{Command: "env"}, nil)
+	term, err := manager.CreateTerminal(context.Background(), acp.CreateTerminalRequest{Command: "env"}, nil, terminalRuntimeScope{})
 	if err != nil {
 		t.Fatalf("CreateTerminal() error = %v", err)
 	}
@@ -969,6 +969,7 @@ type recordingBridgeServer struct {
 	mu    sync.Mutex
 	execs []execRecord
 	files []writeRecord
+	reads []string
 	dirs_ []string
 	exits map[string]int32
 	seqs  map[string][]int32
@@ -1028,6 +1029,13 @@ func (s *recordingBridgeServer) WriteFile(_ context.Context, req *pb.WriteFileRe
 	return &pb.WriteFileResponse{}, nil
 }
 
+func (s *recordingBridgeServer) ReadFile(_ context.Context, req *pb.ReadFileRequest) (*pb.ReadFileResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reads = append(s.reads, req.GetPath())
+	return &pb.ReadFileResponse{Content: "recorded input\n", TotalLines: 1}, nil
+}
+
 func (s *recordingBridgeServer) Mkdir(_ context.Context, req *pb.MkdirRequest) (*pb.MkdirResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1049,6 +1057,12 @@ func (s *recordingBridgeServer) writes() []writeRecord {
 	out := make([]writeRecord, len(s.files))
 	copy(out, s.files)
 	return out
+}
+
+func (s *recordingBridgeServer) readPaths() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.reads...)
 }
 
 func (s *recordingBridgeServer) dirs() []string {

--- a/internal/acpclient/terminal.go
+++ b/internal/acpclient/terminal.go
@@ -41,7 +41,15 @@ type terminalManager struct {
 	terminals map[string]*terminal
 }
 
-type terminalApprovalFunc func(toolCallID string, input map[string]any) (terminalApprovalResult, error)
+type (
+	terminalApprovalFunc func(toolCallID string, input map[string]any) (terminalApprovalResult, error)
+	terminalRuntimeGuard func(context.Context) error
+)
+
+type terminalRuntimeScope struct {
+	validate   terminalRuntimeGuard
+	runContext context.Context
+}
 
 type terminalApprovalResult struct {
 	Approved   bool
@@ -51,10 +59,11 @@ type terminalApprovalResult struct {
 }
 
 type terminal struct {
-	stream      *bridge.ExecStream
-	outputLimit ToolOutputLimit
-	id          string
-	input       map[string]any
+	stream         *bridge.ExecStream
+	outputLimit    ToolOutputLimit
+	id             string
+	input          map[string]any
+	releaseContext func()
 
 	mu        sync.Mutex
 	output    string
@@ -103,7 +112,7 @@ func (m *terminalManager) setToolOutputLimit(limit ToolOutputLimit) {
 	m.mu.Unlock()
 }
 
-func (m *terminalManager) CreateTerminal(_ context.Context, p acp.CreateTerminalRequest, approve terminalApprovalFunc) (acp.CreateTerminalResponse, error) {
+func (m *terminalManager) CreateTerminal(ctx context.Context, p acp.CreateTerminalRequest, approve terminalApprovalFunc, runtimeScope terminalRuntimeScope) (acp.CreateTerminalResponse, error) {
 	cwd := m.defaultCwd
 	if p.Cwd != nil && strings.TrimSpace(*p.Cwd) != "" {
 		resolved, err := m.resolvePath(*p.Cwd)
@@ -175,17 +184,38 @@ func (m *terminalManager) CreateTerminal(_ context.Context, p acp.CreateTerminal
 		}
 		env = append(env, name+"="+item.Value)
 	}
-	stream, err := m.client.ExecStreamWithOptions(m.ctx, command, cwd, m.timeout, bridge.ExecOptions{ //nolint:contextcheck // use the ACP turn context so terminal output survives the create RPC.
+	if runtimeScope.validate != nil {
+		if err := runtimeScope.validate(ctx); err != nil {
+			m.emitToolCallEnd(toolCallID, "exec", input, toolErrorResult(err), err)
+			return acp.CreateTerminalResponse{}, err
+		}
+	}
+	execCtx := m.ctx
+	releaseExecContext := func() {}
+	if runtimeScope.runContext != nil {
+		var cancelExec context.CancelFunc
+		execCtx, cancelExec = context.WithCancel(m.ctx)
+		stopRunCancel := context.AfterFunc(runtimeScope.runContext, cancelExec) //nolint:contextcheck // The owning run is deliberately independent from the ACP callback context.
+		if runtimeScope.runContext.Err() != nil {
+			cancelExec()
+		}
+		releaseExecContext = func() {
+			stopRunCancel()
+			cancelExec()
+		}
+	}
+	stream, err := m.client.ExecStreamWithOptions(execCtx, command, cwd, m.timeout, bridge.ExecOptions{ //nolint:contextcheck // execution outlives the create RPC but not its owning run.
 		Env:      env,
 		CleanEnv: m.cleanEnv,
 		UnsetEnv: m.unsetEnv,
 	})
 	if err != nil {
+		releaseExecContext()
 		m.emitToolCallEnd(toolCallID, "exec", input, toolErrorResult(err), err)
 		return acp.CreateTerminalResponse{}, err
 	}
 
-	term := &terminal{stream: stream, outputLimit: outputLimit, id: toolCallID, input: input, done: make(chan struct{}), endReported: make(chan struct{}), onDone: m.emitTerminalEnd}
+	term := &terminal{stream: stream, outputLimit: outputLimit, id: toolCallID, input: input, releaseContext: releaseExecContext, done: make(chan struct{}), endReported: make(chan struct{}), onDone: m.emitTerminalEnd}
 	m.mu.Lock()
 	m.terminals[id] = term
 	m.mu.Unlock()
@@ -495,6 +525,9 @@ func (t *terminal) kill(signal string) {
 
 func (t *terminal) finish(code *int, signal *string) {
 	t.doneOnce.Do(func() {
+		if t.releaseContext != nil {
+			t.releaseContext()
+		}
 		t.mu.Lock()
 		if code != nil {
 			v := *code

--- a/internal/acpclient/terminal_test.go
+++ b/internal/acpclient/terminal_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	acp "github.com/coder/acp-go-sdk"
@@ -133,7 +134,7 @@ func TestCreateTerminalHonorsOutputByteLimitRequest(t *testing.T) {
 				Command:         "printf",
 				Args:            []string{"HEAD" + strings.Repeat("x", 5000) + "TAIL"},
 				OutputByteLimit: &maxBytes,
-			}, nil)
+			}, nil, terminalRuntimeScope{})
 			if err != nil {
 				t.Fatalf("CreateTerminal returned error: %v", err)
 			}
@@ -161,6 +162,28 @@ func TestCreateTerminalHonorsOutputByteLimitRequest(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCreateTerminalStopsWhenOwningRunIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	manager := newTerminalManager(context.Background(), newTestBridgeClient(t, root), "/data", "/data", 30, nil, true, nil, false, nil)
+	term, err := manager.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		Command: "sleep",
+		Args:    []string{"30"},
+	}, nil, terminalRuntimeScope{runContext: runCtx})
+	if err != nil {
+		cancelRun()
+		t.Fatalf("CreateTerminal() error = %v", err)
+	}
+	cancelRun()
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelWait()
+	if _, err := manager.WaitForTerminalExit(waitCtx, acp.WaitForTerminalExitRequest{TerminalId: term.TerminalId}); err != nil {
+		t.Fatalf("terminal did not stop with its owning run: %v", err)
 	}
 }
 

--- a/internal/agent/tools/native_source.go
+++ b/internal/agent/tools/native_source.go
@@ -181,6 +181,9 @@ func (s *NativeToolSource) CallTool(ctx context.Context, session mcp.ToolSession
 		if !approval.approved {
 			return s.limitMCPResult(toolName, mcp.BuildToolErrorResult(approval.message)), nil
 		}
+		if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
+			return nil, err
+		}
 		result, err := tool.Execute(&sdk.ToolExecContext{
 			Context:  ctx,
 			ToolName: toolName,

--- a/internal/agent/tools/native_source_test.go
+++ b/internal/agent/tools/native_source_test.go
@@ -394,6 +394,38 @@ func TestNativeToolSourceWaitsForApprovalAndPublishesRequest(t *testing.T) {
 	}
 }
 
+func TestNativeToolSourceRechecksRuntimeGuardAfterApproval(t *testing.T) {
+	guardErr := errors.New("runtime ownership lost")
+	executed := false
+	provider := &nativeSourceTestProvider{tools: []sdk.Tool{{
+		Name: ToolExec().String(), Parameters: map[string]any{"type": "object"},
+		Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
+			executed = true
+			return "executed", nil
+		},
+	}}}
+	approval := &nativeSourceApproval{decision: toolapproval.Request{
+		ID: "approval-guard", Status: toolapproval.StatusApproved,
+	}}
+	source := NewNativeToolSource(nil, []ToolProvider{provider}, NativeToolSourceOptions{
+		AllowAll: true, Approval: approval, ToolEvents: &nativeSourceToolEvents{delivered: true},
+	})
+
+	_, err := source.CallTool(context.Background(), mcp.ToolSessionContext{
+		BotID: "bot-1", SessionID: "session-1", StreamID: "stream-1",
+		RuntimeGuard: func(context.Context) error { return guardErr },
+	}, ToolExec().String(), map[string]any{"command": "touch stale"})
+	if !errors.Is(err, guardErr) {
+		t.Fatalf("CallTool() error = %v, want runtime guard error", err)
+	}
+	if approval.created.ToolName != ToolExec().String() {
+		t.Fatalf("approval input = %#v, want approval before guard", approval.created)
+	}
+	if executed {
+		t.Fatal("tool executed after runtime guard rejection")
+	}
+}
+
 func TestNativeToolSourceRejectedApprovalDoesNotExecute(t *testing.T) {
 	executed := false
 	provider := &nativeSourceTestProvider{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -47,27 +48,28 @@ const (
 )
 
 type Config struct {
-	Log           LogConfig           `toml:"log"`
-	Server        ServerConfig        `toml:"server"`
-	Admin         AdminConfig         `toml:"admin"`
-	Auth          AuthConfig          `toml:"auth"`
-	Agent         AgentConfig         `toml:"agent"`
-	Timezone      string              `toml:"timezone"`
-	Database      DatabaseConfig      `toml:"database"`
-	Container     ContainerConfig     `toml:"container"`
-	Containerd    ContainerdConfig    `toml:"containerd"`
-	Docker        DockerConfig        `toml:"docker"`
-	Apple         AppleConfig         `toml:"apple"`
-	Local         LocalConfig         `toml:"local"`
-	Workspace     WorkspaceConfig     `toml:"workspace"`
-	Postgres      PostgresConfig      `toml:"postgres"`
-	PGVector      PGVectorConfig      `toml:"pgvector"`
-	Registry      RegistryConfig      `toml:"registry"`
-	Supermarket   SupermarketConfig   `toml:"supermarket"`
-	OAuthClients  OAuthClientsConfig  `toml:"oauth_clients"`
-	InstanceID    string              `toml:"instance_id"`
-	BridgeTLS     BridgeTLSConfig     `toml:"bridge_tls"`
-	WebhookTunnel WebhookTunnelConfig `toml:"webhook_tunnel"`
+	Log            LogConfig            `toml:"log"`
+	Server         ServerConfig         `toml:"server"`
+	Admin          AdminConfig          `toml:"admin"`
+	Auth           AuthConfig           `toml:"auth"`
+	Agent          AgentConfig          `toml:"agent"`
+	Timezone       string               `toml:"timezone"`
+	Database       DatabaseConfig       `toml:"database"`
+	Container      ContainerConfig      `toml:"container"`
+	Containerd     ContainerdConfig     `toml:"containerd"`
+	Docker         DockerConfig         `toml:"docker"`
+	Apple          AppleConfig          `toml:"apple"`
+	Local          LocalConfig          `toml:"local"`
+	Workspace      WorkspaceConfig      `toml:"workspace"`
+	Postgres       PostgresConfig       `toml:"postgres"`
+	PGVector       PGVectorConfig       `toml:"pgvector"`
+	Registry       RegistryConfig       `toml:"registry"`
+	Supermarket    SupermarketConfig    `toml:"supermarket"`
+	OAuthClients   OAuthClientsConfig   `toml:"oauth_clients"`
+	SessionRuntime SessionRuntimeConfig `toml:"session_runtime"`
+	InstanceID     string               `toml:"instance_id"`
+	BridgeTLS      BridgeTLSConfig      `toml:"bridge_tls"`
+	WebhookTunnel  WebhookTunnelConfig  `toml:"webhook_tunnel"`
 }
 
 const (
@@ -165,6 +167,98 @@ type AgentConfig struct {
 	ToolOutputMaxBytes  int `toml:"tool_output_max_bytes"`
 	ToolOutputMaxLines  int `toml:"tool_output_max_lines"`
 	SystemFilesMaxBytes int `toml:"system_files_max_bytes"`
+}
+
+const (
+	SessionRuntimeBackendMemory = "memory"
+	SessionRuntimeBackendRedis  = "redis"
+
+	DefaultSessionRuntimeStateTTL       = "24h"
+	DefaultSessionRuntimeOwnerLeaseTTL  = "30s"
+	DefaultSessionRuntimeRedisURL       = "redis://127.0.0.1:6379/0"
+	DefaultSessionRuntimeRedisKeyPrefix = "memoh:session_runtime:"
+	MinSessionRuntimeOwnerLeaseTTL      = time.Second
+)
+
+type SessionRuntimeConfig struct {
+	Backend       string                    `toml:"backend"`
+	StateTTL      string                    `toml:"state_ttl"`
+	OwnerLeaseTTL string                    `toml:"owner_lease_ttl"`
+	Redis         SessionRuntimeRedisConfig `toml:"redis"`
+}
+
+type SessionRuntimeRedisConfig struct {
+	URL       string `toml:"url"`
+	KeyPrefix string `toml:"key_prefix"`
+}
+
+func (c SessionRuntimeConfig) BackendOrDefault() string {
+	backend := strings.TrimSpace(strings.ToLower(c.Backend))
+	if backend == "" {
+		return SessionRuntimeBackendMemory
+	}
+	return backend
+}
+
+func (c SessionRuntimeConfig) StateTTLOrDefault() string {
+	if strings.TrimSpace(c.StateTTL) != "" {
+		return strings.TrimSpace(c.StateTTL)
+	}
+	return DefaultSessionRuntimeStateTTL
+}
+
+func (c SessionRuntimeConfig) OwnerLeaseTTLOrDefault() string {
+	if strings.TrimSpace(c.OwnerLeaseTTL) != "" {
+		return strings.TrimSpace(c.OwnerLeaseTTL)
+	}
+	return DefaultSessionRuntimeOwnerLeaseTTL
+}
+
+func (c SessionRuntimeRedisConfig) URLOrDefault() string {
+	if strings.TrimSpace(c.URL) != "" {
+		return strings.TrimSpace(c.URL)
+	}
+	return DefaultSessionRuntimeRedisURL
+}
+
+func (c SessionRuntimeRedisConfig) KeyPrefixOrDefault() string {
+	if strings.TrimSpace(c.KeyPrefix) != "" {
+		return strings.TrimSpace(c.KeyPrefix)
+	}
+	return DefaultSessionRuntimeRedisKeyPrefix
+}
+
+func (c SessionRuntimeConfig) Validate() error {
+	backend := c.BackendOrDefault()
+	switch backend {
+	case SessionRuntimeBackendMemory, SessionRuntimeBackendRedis:
+	default:
+		return fmt.Errorf("unsupported session_runtime backend %q", c.Backend)
+	}
+	stateTTL, err := time.ParseDuration(c.StateTTLOrDefault())
+	if err != nil {
+		return fmt.Errorf("invalid session_runtime state_ttl %q: %w", c.StateTTL, err)
+	}
+	if stateTTL <= 0 {
+		return fmt.Errorf("invalid session_runtime state_ttl %q: must be positive", c.StateTTLOrDefault())
+	}
+	if backend == SessionRuntimeBackendMemory {
+		return nil
+	}
+	ownerLeaseTTL, err := time.ParseDuration(c.OwnerLeaseTTLOrDefault())
+	if err != nil {
+		return fmt.Errorf("invalid session_runtime owner_lease_ttl %q: %w", c.OwnerLeaseTTL, err)
+	}
+	if ownerLeaseTTL <= 0 {
+		return fmt.Errorf("invalid session_runtime owner_lease_ttl %q: must be positive", c.OwnerLeaseTTLOrDefault())
+	}
+	if ownerLeaseTTL < MinSessionRuntimeOwnerLeaseTTL {
+		return fmt.Errorf("invalid session_runtime owner_lease_ttl %q: must be at least %s", c.OwnerLeaseTTLOrDefault(), MinSessionRuntimeOwnerLeaseTTL)
+	}
+	if stateTTL < ownerLeaseTTL {
+		return fmt.Errorf("invalid session_runtime state_ttl %q: must be greater than or equal to owner_lease_ttl %q", c.StateTTLOrDefault(), c.OwnerLeaseTTLOrDefault())
+	}
+	return nil
 }
 
 type DatabaseConfig struct {
@@ -482,6 +576,15 @@ func Load(path string) (Config, error) {
 			Database: DefaultPGDatabase,
 			SSLMode:  DefaultPGSSLMode,
 		},
+		SessionRuntime: SessionRuntimeConfig{
+			Backend:       SessionRuntimeBackendMemory,
+			StateTTL:      DefaultSessionRuntimeStateTTL,
+			OwnerLeaseTTL: DefaultSessionRuntimeOwnerLeaseTTL,
+			Redis: SessionRuntimeRedisConfig{
+				URL:       DefaultSessionRuntimeRedisURL,
+				KeyPrefix: DefaultSessionRuntimeRedisKeyPrefix,
+			},
+		},
 	}
 
 	if path == "" {
@@ -547,6 +650,9 @@ func (cfg Config) validate() error {
 		return fmt.Errorf("unsupported database driver %q", cfg.Database.DriverOrDefault())
 	}
 	if err := cfg.WebhookTunnel.Validate(); err != nil {
+		return err
+	}
+	if err := cfg.SessionRuntime.Validate(); err != nil {
 		return err
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -231,6 +231,163 @@ func TestLoadRejectsInvalidWebhookTunnelModeFromEnv(t *testing.T) {
 	}
 }
 
+func TestLoadDefaultsSessionRuntimeToMemory(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "missing.toml"))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.SessionRuntime.BackendOrDefault() != SessionRuntimeBackendMemory {
+		t.Fatalf("session runtime backend = %q, want memory", cfg.SessionRuntime.BackendOrDefault())
+	}
+	if cfg.SessionRuntime.StateTTLOrDefault() != DefaultSessionRuntimeStateTTL {
+		t.Fatalf("session runtime state ttl = %q, want %q", cfg.SessionRuntime.StateTTLOrDefault(), DefaultSessionRuntimeStateTTL)
+	}
+	if cfg.SessionRuntime.OwnerLeaseTTLOrDefault() != DefaultSessionRuntimeOwnerLeaseTTL {
+		t.Fatalf("session runtime owner lease ttl = %q, want %q", cfg.SessionRuntime.OwnerLeaseTTLOrDefault(), DefaultSessionRuntimeOwnerLeaseTTL)
+	}
+}
+
+func TestLoadReadsSessionRuntimeRedisConfig(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	data := []byte(`
+[session_runtime]
+backend = "redis"
+state_ttl = "12h"
+owner_lease_ttl = "45s"
+
+[session_runtime.redis]
+url = "redis://redis.example:6379/2"
+key_prefix = "test:runtime:"
+`)
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.SessionRuntime.BackendOrDefault() != SessionRuntimeBackendRedis {
+		t.Fatalf("session runtime backend = %q, want redis", cfg.SessionRuntime.BackendOrDefault())
+	}
+	if cfg.SessionRuntime.StateTTLOrDefault() != "12h" || cfg.SessionRuntime.OwnerLeaseTTLOrDefault() != "45s" {
+		t.Fatalf("session runtime ttl config = %#v", cfg.SessionRuntime)
+	}
+	if cfg.SessionRuntime.Redis.URLOrDefault() != "redis://redis.example:6379/2" {
+		t.Fatalf("redis url = %q", cfg.SessionRuntime.Redis.URLOrDefault())
+	}
+	if cfg.SessionRuntime.Redis.KeyPrefixOrDefault() != "test:runtime:" {
+		t.Fatalf("redis key prefix = %q", cfg.SessionRuntime.Redis.KeyPrefixOrDefault())
+	}
+}
+
+func TestLoadRejectsInvalidSessionRuntimeBackend(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("[session_runtime]\nbackend = \"nats\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("expected invalid session runtime backend to fail")
+	}
+	if !strings.Contains(err.Error(), "unsupported session_runtime backend") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadRejectsInvalidSessionRuntimeDuration(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("[session_runtime]\nstate_ttl = \"forever\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("expected invalid session runtime duration to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid session_runtime state_ttl") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadRejectsNonPositiveSessionRuntimeDuration(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("[session_runtime]\nbackend = \"redis\"\nowner_lease_ttl = \"-1s\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("expected non-positive session runtime duration to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid session_runtime owner_lease_ttl") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadRejectsSessionRuntimeOwnerLeaseBelowMinimum(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("[session_runtime]\nbackend = \"redis\"\nowner_lease_ttl = \"500ms\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("expected too-small session runtime owner lease to fail")
+	}
+	if !strings.Contains(err.Error(), "must be at least 1s") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadRejectsSessionRuntimeStateTTLShorterThanOwnerLease(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	data := []byte(`
+[session_runtime]
+backend = "redis"
+state_ttl = "10s"
+owner_lease_ttl = "30s"
+`)
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("expected session runtime state ttl shorter than owner lease to fail")
+	}
+	if !strings.Contains(err.Error(), "must be greater than or equal to owner_lease_ttl") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadMemorySessionRuntimeIgnoresOwnerLeaseTTL(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("[session_runtime]\nbackend = \"memory\"\nowner_lease_ttl = \"not-used\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := Load(configPath); err != nil {
+		t.Fatalf("memory runtime rejected unused owner lease config: %v", err)
+	}
+}
+
 func TestLoadDefaultsContainerdRuntimeType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/conversation/runtime_contract_test.go
+++ b/internal/conversation/runtime_contract_test.go
@@ -1,0 +1,117 @@
+package conversation
+
+import "testing"
+
+func richActiveRunContractScript() []UIMessageStreamEvent {
+	return []UIMessageStreamEvent{
+		{Type: "reasoning_delta", Delta: "I need to inspect the workspace."},
+		{Type: "text_delta", Delta: "I will check the current state."},
+		{
+			Type:       "tool_call_start",
+			ToolName:   "exec",
+			ToolCallID: "call-exec",
+			Input:      map[string]any{"command": "pwd"},
+		},
+		{
+			Type:       "tool_call_progress",
+			ToolName:   "exec",
+			ToolCallID: "call-exec",
+			Progress:   "queued",
+		},
+		{
+			Type:       "tool_call_progress",
+			ToolName:   "exec",
+			ToolCallID: "call-exec",
+			Progress:   map[string]any{"stdout": "/workspace\n"},
+		},
+		{
+			Type:       "tool_call_end",
+			ToolName:   "exec",
+			ToolCallID: "call-exec",
+			Output:     map[string]any{"structuredContent": map[string]any{"stdout": "/workspace\n"}},
+		},
+		{
+			Type:       "tool_approval_request",
+			ToolName:   "exec",
+			ToolCallID: "call-approval",
+			Input:      map[string]any{"command": "rm -rf build"},
+			ApprovalID: "approval-1",
+			ShortID:    7,
+			Status:     "pending",
+		},
+		{
+			Type:        "user_input_request",
+			ToolName:    "ask_user",
+			ToolCallID:  "call-ask",
+			Input:       map[string]any{"questions": []any{map[string]any{"text": "Continue?", "kind": "single_select"}}},
+			UserInputID: "input-1",
+			ShortID:     8,
+			Status:      "pending",
+			Metadata: map[string]any{
+				"ui_payload": map[string]any{
+					"version": 2,
+					"questions": []any{map[string]any{
+						"id":   "q1",
+						"text": "Continue?",
+						"kind": "single_select",
+						"options": []any{
+							map[string]any{"id": "yes", "label": "Yes"},
+							map[string]any{"id": "no", "label": "No"},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func TestRuntimeContractScriptAggregatesCurrentRunUIBlocks(t *testing.T) {
+	t.Parallel()
+
+	converter := NewUIMessageStreamConverter()
+	blocksByID := map[int]UIMessage{}
+	for _, event := range richActiveRunContractScript() {
+		for _, block := range converter.HandleEvent(event) {
+			blocksByID[block.ID] = block
+		}
+	}
+
+	var reasoning, text, execTool, approvalTool, askUserTool *UIMessage
+	for _, block := range blocksByID {
+		block := block
+		switch {
+		case block.Type == UIMessageReasoning:
+			reasoning = &block
+		case block.Type == UIMessageText:
+			text = &block
+		case block.Type == UIMessageTool && block.ToolCallID == "call-exec":
+			execTool = &block
+		case block.Type == UIMessageTool && block.ToolCallID == "call-approval":
+			approvalTool = &block
+		case block.Type == UIMessageTool && block.ToolCallID == "call-ask":
+			askUserTool = &block
+		}
+	}
+
+	if reasoning == nil || reasoning.Content != "I need to inspect the workspace." {
+		t.Fatalf("reasoning block = %#v, want scripted reasoning", reasoning)
+	}
+	if text == nil || text.Content != "I will check the current state." {
+		t.Fatalf("text block = %#v, want scripted text", text)
+	}
+	if execTool == nil || execTool.Name != "exec" || execTool.Running == nil || *execTool.Running {
+		t.Fatalf("exec tool block = %#v, want completed exec tool", execTool)
+	}
+	if len(execTool.Progress) != 2 {
+		t.Fatalf("exec progress = %#v, want two progress snapshots", execTool.Progress)
+	}
+	if approvalTool == nil || approvalTool.Approval == nil || !approvalTool.Approval.CanApprove {
+		t.Fatalf("approval block = %#v, want pending approval", approvalTool)
+	}
+	if askUserTool == nil || askUserTool.UserInput == nil || !askUserTool.UserInput.CanRespond {
+		t.Fatalf("ask_user block = %#v, want pending user input", askUserTool)
+	}
+	if len(askUserTool.UserInput.Questions) != 1 || askUserTool.UserInput.Questions[0].Text != "Continue?" {
+		t.Fatalf("ask_user questions = %#v, want scripted question", askUserTool.UserInput.Questions)
+	}
+}

--- a/internal/conversation/types.go
+++ b/internal/conversation/types.go
@@ -316,6 +316,7 @@ type InjectMessage struct {
 	Text            string
 	Attachments     []ChatAttachment
 	HeaderifiedText string
+	Applied         func()
 }
 
 // InjectedMessageRecord records a message that was injected via PrepareStep,

--- a/internal/db/postgres/sqlc/bots.sql.go
+++ b/internal/db/postgres/sqlc/bots.sql.go
@@ -417,6 +417,20 @@ func (q *Queries) ListHeartbeatEnabledBots(ctx context.Context) ([]ListHeartbeat
 	return items, nil
 }
 
+const lockBotForSessionWrite = `-- name: LockBotForSessionWrite :one
+SELECT id
+FROM bots
+WHERE id = $1
+FOR KEY SHARE
+`
+
+func (q *Queries) LockBotForSessionWrite(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, lockBotForSessionWrite, id)
+	var id_2 pgtype.UUID
+	err := row.Scan(&id_2)
+	return id_2, err
+}
+
 const updateBotOwner = `-- name: UpdateBotOwner :one
 UPDATE bots
 SET owner_user_id = $2,

--- a/internal/db/postgres/sqlc/models.go
+++ b/internal/db/postgres/sqlc/models.go
@@ -221,22 +221,23 @@ type BotPluginResource struct {
 }
 
 type BotSession struct {
-	ID               pgtype.UUID        `json:"id"`
-	BotID            pgtype.UUID        `json:"bot_id"`
-	RouteID          pgtype.UUID        `json:"route_id"`
-	ChannelType      pgtype.Text        `json:"channel_type"`
-	Type             string             `json:"type"`
-	SessionMode      string             `json:"session_mode"`
-	RuntimeType      string             `json:"runtime_type"`
-	RuntimeMetadata  []byte             `json:"runtime_metadata"`
-	Title            string             `json:"title"`
-	Metadata         []byte             `json:"metadata"`
-	NextTurnPosition int64              `json:"next_turn_position"`
-	ParentSessionID  pgtype.UUID        `json:"parent_session_id"`
-	CreatedByUserID  pgtype.UUID        `json:"created_by_user_id"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
-	DeletedAt        pgtype.Timestamptz `json:"deleted_at"`
+	ID                  pgtype.UUID        `json:"id"`
+	BotID               pgtype.UUID        `json:"bot_id"`
+	RouteID             pgtype.UUID        `json:"route_id"`
+	ChannelType         pgtype.Text        `json:"channel_type"`
+	Type                string             `json:"type"`
+	SessionMode         string             `json:"session_mode"`
+	RuntimeType         string             `json:"runtime_type"`
+	RuntimeMetadata     []byte             `json:"runtime_metadata"`
+	Title               string             `json:"title"`
+	Metadata            []byte             `json:"metadata"`
+	NextTurnPosition    int64              `json:"next_turn_position"`
+	RuntimeFencingToken int64              `json:"runtime_fencing_token"`
+	ParentSessionID     pgtype.UUID        `json:"parent_session_id"`
+	CreatedByUserID     pgtype.UUID        `json:"created_by_user_id"`
+	CreatedAt           pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
+	DeletedAt           pgtype.Timestamptz `json:"deleted_at"`
 }
 
 type BotSessionDiscussCursor struct {
@@ -649,6 +650,7 @@ type ToolApprovalRequest struct {
 	ToolInput                    []byte             `json:"tool_input"`
 	ShortID                      int32              `json:"short_id"`
 	Status                       string             `json:"status"`
+	RuntimeFencingToken          pgtype.Int8        `json:"runtime_fencing_token"`
 	DecisionReason               string             `json:"decision_reason"`
 	RequestedByChannelIdentityID pgtype.UUID        `json:"requested_by_channel_identity_id"`
 	DecidedByChannelIdentityID   pgtype.UUID        `json:"decided_by_channel_identity_id"`
@@ -726,6 +728,7 @@ type UserInputRequest struct {
 	ToolName                     string             `json:"tool_name"`
 	ShortID                      int32              `json:"short_id"`
 	Status                       string             `json:"status"`
+	RuntimeFencingToken          pgtype.Int8        `json:"runtime_fencing_token"`
 	InputJson                    []byte             `json:"input_json"`
 	UiPayloadJson                []byte             `json:"ui_payload_json"`
 	ResultJson                   []byte             `json:"result_json"`

--- a/internal/db/postgres/sqlc/sessions.sql.go
+++ b/internal/db/postgres/sqlc/sessions.sql.go
@@ -11,6 +11,29 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const activateSessionRuntimeFence = `-- name: ActivateSessionRuntimeFence :one
+UPDATE bot_sessions
+SET runtime_fencing_token = $1
+WHERE id = $2
+  AND bot_id = $3
+  AND runtime_fencing_token <= $1
+  AND deleted_at IS NULL
+RETURNING runtime_fencing_token
+`
+
+type ActivateSessionRuntimeFenceParams struct {
+	RuntimeFencingToken int64       `json:"runtime_fencing_token"`
+	SessionID           pgtype.UUID `json:"session_id"`
+	BotID               pgtype.UUID `json:"bot_id"`
+}
+
+func (q *Queries) ActivateSessionRuntimeFence(ctx context.Context, arg ActivateSessionRuntimeFenceParams) (int64, error) {
+	row := q.db.QueryRow(ctx, activateSessionRuntimeFence, arg.RuntimeFencingToken, arg.SessionID, arg.BotID)
+	var runtime_fencing_token int64
+	err := row.Scan(&runtime_fencing_token)
+	return runtime_fencing_token, err
+}
+
 const createSession = `-- name: CreateSession :one
 INSERT INTO bot_sessions (
   bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, parent_session_id, created_by_user_id
@@ -28,7 +51,7 @@ VALUES (
   $10::uuid,
   $11::uuid
 )
-RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 `
 
 type CreateSessionParams struct {
@@ -72,6 +95,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (B
 		&i.Title,
 		&i.Metadata,
 		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
 		&i.ParentSessionID,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
@@ -97,7 +121,7 @@ func (q *Queries) DeleteSessionDiscussCursorsByBot(ctx context.Context, botID pg
 
 const forkSessionFromAssistantMessage = `-- name: ForkSessionFromAssistantMessage :one
 WITH source_session AS (
-  SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at
+  SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.runtime_fencing_token, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at
   FROM bot_sessions s
   WHERE s.id = $1
     AND s.bot_id = $2
@@ -172,7 +196,7 @@ prepared_metadata AS (
 ),
 fork_plan AS (
   SELECT
-    s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
+    s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.runtime_fencing_token, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at,
     fam.new_message_id AS fork_message_id,
     ntp.value AS next_turn_position_value
   FROM source_session s
@@ -211,7 +235,7 @@ created_session AS (
     $6::uuid
   FROM fork_plan fp
   CROSS JOIN prepared_metadata pm
-  RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+  RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 ),
 inserted_messages AS (
   INSERT INTO bot_history_messages (
@@ -283,7 +307,7 @@ copied_assets AS (
   JOIN inserted_messages im ON im.id = cm.new_message_id
   RETURNING id
 )
-SELECT cs.id, cs.bot_id, cs.route_id, cs.channel_type, cs.type, cs.session_mode, cs.runtime_type, cs.runtime_metadata, cs.title, cs.metadata, cs.next_turn_position, cs.parent_session_id, cs.created_by_user_id, cs.created_at, cs.updated_at, cs.deleted_at
+SELECT cs.id, cs.bot_id, cs.route_id, cs.channel_type, cs.type, cs.session_mode, cs.runtime_type, cs.runtime_metadata, cs.title, cs.metadata, cs.next_turn_position, cs.runtime_fencing_token, cs.parent_session_id, cs.created_by_user_id, cs.created_at, cs.updated_at, cs.deleted_at
 FROM created_session cs
 CROSS JOIN (SELECT count(*) AS copied_asset_count FROM copied_assets) copied_asset_counts
 `
@@ -298,22 +322,23 @@ type ForkSessionFromAssistantMessageParams struct {
 }
 
 type ForkSessionFromAssistantMessageRow struct {
-	ID               pgtype.UUID        `json:"id"`
-	BotID            pgtype.UUID        `json:"bot_id"`
-	RouteID          pgtype.UUID        `json:"route_id"`
-	ChannelType      pgtype.Text        `json:"channel_type"`
-	Type             string             `json:"type"`
-	SessionMode      string             `json:"session_mode"`
-	RuntimeType      string             `json:"runtime_type"`
-	RuntimeMetadata  []byte             `json:"runtime_metadata"`
-	Title            string             `json:"title"`
-	Metadata         []byte             `json:"metadata"`
-	NextTurnPosition int64              `json:"next_turn_position"`
-	ParentSessionID  pgtype.UUID        `json:"parent_session_id"`
-	CreatedByUserID  pgtype.UUID        `json:"created_by_user_id"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
-	DeletedAt        pgtype.Timestamptz `json:"deleted_at"`
+	ID                  pgtype.UUID        `json:"id"`
+	BotID               pgtype.UUID        `json:"bot_id"`
+	RouteID             pgtype.UUID        `json:"route_id"`
+	ChannelType         pgtype.Text        `json:"channel_type"`
+	Type                string             `json:"type"`
+	SessionMode         string             `json:"session_mode"`
+	RuntimeType         string             `json:"runtime_type"`
+	RuntimeMetadata     []byte             `json:"runtime_metadata"`
+	Title               string             `json:"title"`
+	Metadata            []byte             `json:"metadata"`
+	NextTurnPosition    int64              `json:"next_turn_position"`
+	RuntimeFencingToken int64              `json:"runtime_fencing_token"`
+	ParentSessionID     pgtype.UUID        `json:"parent_session_id"`
+	CreatedByUserID     pgtype.UUID        `json:"created_by_user_id"`
+	CreatedAt           pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
+	DeletedAt           pgtype.Timestamptz `json:"deleted_at"`
 }
 
 func (q *Queries) ForkSessionFromAssistantMessage(ctx context.Context, arg ForkSessionFromAssistantMessageParams) (ForkSessionFromAssistantMessageRow, error) {
@@ -338,6 +363,7 @@ func (q *Queries) ForkSessionFromAssistantMessage(ctx context.Context, arg ForkS
 		&i.Title,
 		&i.Metadata,
 		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
 		&i.ParentSessionID,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
@@ -348,7 +374,7 @@ func (q *Queries) ForkSessionFromAssistantMessage(ctx context.Context, arg ForkS
 }
 
 const getActiveSessionForRoute = `-- name: GetActiveSessionForRoute :one
-SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at
+SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.title, s.metadata, s.next_turn_position, s.runtime_fencing_token, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at
 FROM bot_sessions s
 JOIN bot_channel_routes r ON r.active_session_id = s.id
 WHERE r.id = $1
@@ -370,6 +396,7 @@ func (q *Queries) GetActiveSessionForRoute(ctx context.Context, routeID pgtype.U
 		&i.Title,
 		&i.Metadata,
 		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
 		&i.ParentSessionID,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
@@ -380,7 +407,7 @@ func (q *Queries) GetActiveSessionForRoute(ctx context.Context, routeID pgtype.U
 }
 
 const getSessionByID = `-- name: GetSessionByID :one
-SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 FROM bot_sessions
 WHERE id = $1
   AND deleted_at IS NULL
@@ -401,6 +428,7 @@ func (q *Queries) GetSessionByID(ctx context.Context, id pgtype.UUID) (BotSessio
 		&i.Title,
 		&i.Metadata,
 		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
 		&i.ParentSessionID,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
@@ -828,7 +856,7 @@ func (q *Queries) ListSessionsByBotPaged(ctx context.Context, arg ListSessionsBy
 }
 
 const listSessionsByRoute = `-- name: ListSessionsByRoute :many
-SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 FROM bot_sessions
 WHERE route_id = $1
   AND deleted_at IS NULL
@@ -856,6 +884,7 @@ func (q *Queries) ListSessionsByRoute(ctx context.Context, routeID pgtype.UUID) 
 			&i.Title,
 			&i.Metadata,
 			&i.NextTurnPosition,
+			&i.RuntimeFencingToken,
 			&i.ParentSessionID,
 			&i.CreatedByUserID,
 			&i.CreatedAt,
@@ -873,7 +902,7 @@ func (q *Queries) ListSessionsByRoute(ctx context.Context, routeID pgtype.UUID) 
 }
 
 const listSubagentSessionsByParent = `-- name: ListSubagentSessionsByParent :many
-SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 FROM bot_sessions
 WHERE parent_session_id = $1
   AND deleted_at IS NULL
@@ -901,6 +930,7 @@ func (q *Queries) ListSubagentSessionsByParent(ctx context.Context, parentSessio
 			&i.Title,
 			&i.Metadata,
 			&i.NextTurnPosition,
+			&i.RuntimeFencingToken,
 			&i.ParentSessionID,
 			&i.CreatedByUserID,
 			&i.CreatedAt,
@@ -915,6 +945,82 @@ func (q *Queries) ListSubagentSessionsByParent(ctx context.Context, parentSessio
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockSessionDecisionSequence = `-- name: LockSessionDecisionSequence :one
+SELECT id
+FROM bot_sessions
+WHERE id = $1
+  AND bot_id = $2
+  AND deleted_at IS NULL
+FOR UPDATE
+`
+
+type LockSessionDecisionSequenceParams struct {
+	SessionID pgtype.UUID `json:"session_id"`
+	BotID     pgtype.UUID `json:"bot_id"`
+}
+
+func (q *Queries) LockSessionDecisionSequence(ctx context.Context, arg LockSessionDecisionSequenceParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, lockSessionDecisionSequence, arg.SessionID, arg.BotID)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const lockSessionRuntimeFence = `-- name: LockSessionRuntimeFence :one
+SELECT runtime_fencing_token
+FROM bot_sessions
+WHERE id = $1
+  AND bot_id = $2
+  AND runtime_fencing_token = $3
+  AND deleted_at IS NULL
+FOR NO KEY UPDATE
+`
+
+type LockSessionRuntimeFenceParams struct {
+	SessionID           pgtype.UUID `json:"session_id"`
+	BotID               pgtype.UUID `json:"bot_id"`
+	RuntimeFencingToken int64       `json:"runtime_fencing_token"`
+}
+
+func (q *Queries) LockSessionRuntimeFence(ctx context.Context, arg LockSessionRuntimeFenceParams) (int64, error) {
+	row := q.db.QueryRow(ctx, lockSessionRuntimeFence, arg.SessionID, arg.BotID, arg.RuntimeFencingToken)
+	var runtime_fencing_token int64
+	err := row.Scan(&runtime_fencing_token)
+	return runtime_fencing_token, err
+}
+
+const lockSessionRuntimeFenceForActivation = `-- name: LockSessionRuntimeFenceForActivation :one
+SELECT runtime_fencing_token
+FROM bot_sessions
+WHERE id = $1
+  AND bot_id = $2
+  AND deleted_at IS NULL
+FOR UPDATE
+`
+
+type LockSessionRuntimeFenceForActivationParams struct {
+	SessionID pgtype.UUID `json:"session_id"`
+	BotID     pgtype.UUID `json:"bot_id"`
+}
+
+func (q *Queries) LockSessionRuntimeFenceForActivation(ctx context.Context, arg LockSessionRuntimeFenceForActivationParams) (int64, error) {
+	row := q.db.QueryRow(ctx, lockSessionRuntimeFenceForActivation, arg.SessionID, arg.BotID)
+	var runtime_fencing_token int64
+	err := row.Scan(&runtime_fencing_token)
+	return runtime_fencing_token, err
+}
+
+const nextSessionRuntimeFenceToken = `-- name: NextSessionRuntimeFenceToken :one
+SELECT nextval('session_runtime_fencing_token_seq')::bigint
+`
+
+func (q *Queries) NextSessionRuntimeFenceToken(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, nextSessionRuntimeFenceToken)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const setSessionNextTurnPosition = `-- name: SetSessionNextTurnPosition :exec
@@ -970,7 +1076,7 @@ const updateSessionMetadata = `-- name: UpdateSessionMetadata :one
 UPDATE bot_sessions
 SET metadata = $1, updated_at = now()
 WHERE id = $2 AND deleted_at IS NULL
-RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 `
 
 type UpdateSessionMetadataParams struct {
@@ -993,6 +1099,54 @@ func (q *Queries) UpdateSessionMetadata(ctx context.Context, arg UpdateSessionMe
 		&i.Title,
 		&i.Metadata,
 		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
+		&i.ParentSessionID,
+		&i.CreatedByUserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
+const updateSessionMetadataWithRuntimeFence = `-- name: UpdateSessionMetadataWithRuntimeFence :one
+UPDATE bot_sessions
+SET metadata = $1, updated_at = now()
+WHERE id = $2
+  AND bot_id = $3
+  AND runtime_fencing_token = $4
+  AND deleted_at IS NULL
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+`
+
+type UpdateSessionMetadataWithRuntimeFenceParams struct {
+	Metadata            []byte      `json:"metadata"`
+	ID                  pgtype.UUID `json:"id"`
+	BotID               pgtype.UUID `json:"bot_id"`
+	RuntimeFencingToken int64       `json:"runtime_fencing_token"`
+}
+
+func (q *Queries) UpdateSessionMetadataWithRuntimeFence(ctx context.Context, arg UpdateSessionMetadataWithRuntimeFenceParams) (BotSession, error) {
+	row := q.db.QueryRow(ctx, updateSessionMetadataWithRuntimeFence,
+		arg.Metadata,
+		arg.ID,
+		arg.BotID,
+		arg.RuntimeFencingToken,
+	)
+	var i BotSession
+	err := row.Scan(
+		&i.ID,
+		&i.BotID,
+		&i.RouteID,
+		&i.ChannelType,
+		&i.Type,
+		&i.SessionMode,
+		&i.RuntimeType,
+		&i.RuntimeMetadata,
+		&i.Title,
+		&i.Metadata,
+		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
 		&i.ParentSessionID,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
@@ -1006,7 +1160,7 @@ const updateSessionTitle = `-- name: UpdateSessionTitle :one
 UPDATE bot_sessions
 SET title = $1, updated_at = now()
 WHERE id = $2 AND deleted_at IS NULL
-RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 `
 
 type UpdateSessionTitleParams struct {
@@ -1029,6 +1183,54 @@ func (q *Queries) UpdateSessionTitle(ctx context.Context, arg UpdateSessionTitle
 		&i.Title,
 		&i.Metadata,
 		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
+		&i.ParentSessionID,
+		&i.CreatedByUserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+	)
+	return i, err
+}
+
+const updateSessionTitleWithRuntimeFence = `-- name: UpdateSessionTitleWithRuntimeFence :one
+UPDATE bot_sessions
+SET title = $1, updated_at = now()
+WHERE id = $2
+  AND bot_id = $3
+  AND runtime_fencing_token = $4
+  AND deleted_at IS NULL
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+`
+
+type UpdateSessionTitleWithRuntimeFenceParams struct {
+	Title               string      `json:"title"`
+	ID                  pgtype.UUID `json:"id"`
+	BotID               pgtype.UUID `json:"bot_id"`
+	RuntimeFencingToken int64       `json:"runtime_fencing_token"`
+}
+
+func (q *Queries) UpdateSessionTitleWithRuntimeFence(ctx context.Context, arg UpdateSessionTitleWithRuntimeFenceParams) (BotSession, error) {
+	row := q.db.QueryRow(ctx, updateSessionTitleWithRuntimeFence,
+		arg.Title,
+		arg.ID,
+		arg.BotID,
+		arg.RuntimeFencingToken,
+	)
+	var i BotSession
+	err := row.Scan(
+		&i.ID,
+		&i.BotID,
+		&i.RouteID,
+		&i.ChannelType,
+		&i.Type,
+		&i.SessionMode,
+		&i.RuntimeType,
+		&i.RuntimeMetadata,
+		&i.Title,
+		&i.Metadata,
+		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
 		&i.ParentSessionID,
 		&i.CreatedByUserID,
 		&i.CreatedAt,
@@ -1047,7 +1249,7 @@ SET type = $1,
     metadata = $5,
     updated_at = now()
 WHERE id = $6 AND deleted_at IS NULL
-RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
+RETURNING id, bot_id, route_id, channel_type, type, session_mode, runtime_type, runtime_metadata, title, metadata, next_turn_position, runtime_fencing_token, parent_session_id, created_by_user_id, created_at, updated_at, deleted_at
 `
 
 type UpdateSessionTypeAndMetadataParams struct {
@@ -1081,6 +1283,7 @@ func (q *Queries) UpdateSessionTypeAndMetadata(ctx context.Context, arg UpdateSe
 		&i.Title,
 		&i.Metadata,
 		&i.NextTurnPosition,
+		&i.RuntimeFencingToken,
 		&i.ParentSessionID,
 		&i.CreatedByUserID,
 		&i.CreatedAt,

--- a/internal/db/postgres/sqlc/tool_approval.sql.go
+++ b/internal/db/postgres/sqlc/tool_approval.sql.go
@@ -19,17 +19,24 @@ SET status = 'approved',
     decided_at = now()
 WHERE id = $3
   AND status = 'pending'
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+  AND (runtime_fencing_token IS NULL OR runtime_fencing_token = $4::bigint)
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 `
 
 type ApproveToolApprovalRequestParams struct {
 	Reason                     string      `json:"reason"`
 	DecidedByChannelIdentityID pgtype.UUID `json:"decided_by_channel_identity_id"`
 	ID                         pgtype.UUID `json:"id"`
+	RuntimeFencingToken        pgtype.Int8 `json:"runtime_fencing_token"`
 }
 
 func (q *Queries) ApproveToolApprovalRequest(ctx context.Context, arg ApproveToolApprovalRequestParams) (ToolApprovalRequest, error) {
-	row := q.db.QueryRow(ctx, approveToolApprovalRequest, arg.Reason, arg.DecidedByChannelIdentityID, arg.ID)
+	row := q.db.QueryRow(ctx, approveToolApprovalRequest,
+		arg.Reason,
+		arg.DecidedByChannelIdentityID,
+		arg.ID,
+		arg.RuntimeFencingToken,
+	)
 	var i ToolApprovalRequest
 	err := row.Scan(
 		&i.ID,
@@ -43,6 +50,7 @@ func (q *Queries) ApproveToolApprovalRequest(ctx context.Context, arg ApproveToo
 		&i.ToolInput,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.DecisionReason,
 		&i.RequestedByChannelIdentityID,
 		&i.DecidedByChannelIdentityID,
@@ -66,17 +74,24 @@ SET status = 'cancelled',
 WHERE bot_id = $2
   AND session_id = $3
   AND status = 'pending'
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+  AND (runtime_fencing_token IS NULL OR runtime_fencing_token = $4::bigint)
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 `
 
 type CancelPendingToolApprovalsBySessionParams struct {
-	Reason    string      `json:"reason"`
-	BotID     pgtype.UUID `json:"bot_id"`
-	SessionID pgtype.UUID `json:"session_id"`
+	Reason              string      `json:"reason"`
+	BotID               pgtype.UUID `json:"bot_id"`
+	SessionID           pgtype.UUID `json:"session_id"`
+	RuntimeFencingToken pgtype.Int8 `json:"runtime_fencing_token"`
 }
 
 func (q *Queries) CancelPendingToolApprovalsBySession(ctx context.Context, arg CancelPendingToolApprovalsBySessionParams) ([]ToolApprovalRequest, error) {
-	rows, err := q.db.Query(ctx, cancelPendingToolApprovalsBySession, arg.Reason, arg.BotID, arg.SessionID)
+	rows, err := q.db.Query(ctx, cancelPendingToolApprovalsBySession,
+		arg.Reason,
+		arg.BotID,
+		arg.SessionID,
+		arg.RuntimeFencingToken,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +111,7 @@ func (q *Queries) CancelPendingToolApprovalsBySession(ctx context.Context, arg C
 			&i.ToolInput,
 			&i.ShortID,
 			&i.Status,
+			&i.RuntimeFencingToken,
 			&i.DecisionReason,
 			&i.RequestedByChannelIdentityID,
 			&i.DecidedByChannelIdentityID,
@@ -118,7 +134,72 @@ func (q *Queries) CancelPendingToolApprovalsBySession(ctx context.Context, arg C
 	return items, nil
 }
 
+const claimToolApprovalRequestForRuntime = `-- name: ClaimToolApprovalRequestForRuntime :one
+UPDATE tool_approval_requests
+SET runtime_fencing_token = $1
+WHERE id = $2
+  AND bot_id = $3
+  AND session_id = $4
+  AND status = 'pending'
+  AND (runtime_fencing_token IS NULL OR runtime_fencing_token <= $1)
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+`
+
+type ClaimToolApprovalRequestForRuntimeParams struct {
+	RuntimeFencingToken pgtype.Int8 `json:"runtime_fencing_token"`
+	ID                  pgtype.UUID `json:"id"`
+	BotID               pgtype.UUID `json:"bot_id"`
+	SessionID           pgtype.UUID `json:"session_id"`
+}
+
+func (q *Queries) ClaimToolApprovalRequestForRuntime(ctx context.Context, arg ClaimToolApprovalRequestForRuntimeParams) (ToolApprovalRequest, error) {
+	row := q.db.QueryRow(ctx, claimToolApprovalRequestForRuntime,
+		arg.RuntimeFencingToken,
+		arg.ID,
+		arg.BotID,
+		arg.SessionID,
+	)
+	var i ToolApprovalRequest
+	err := row.Scan(
+		&i.ID,
+		&i.BotID,
+		&i.SessionID,
+		&i.RouteID,
+		&i.ChannelIdentityID,
+		&i.ToolCallID,
+		&i.ToolName,
+		&i.Operation,
+		&i.ToolInput,
+		&i.ShortID,
+		&i.Status,
+		&i.RuntimeFencingToken,
+		&i.DecisionReason,
+		&i.RequestedByChannelIdentityID,
+		&i.DecidedByChannelIdentityID,
+		&i.RequestedMessageID,
+		&i.PromptMessageID,
+		&i.PromptExternalMessageID,
+		&i.SourcePlatform,
+		&i.ReplyTarget,
+		&i.ConversationType,
+		&i.CreatedAt,
+		&i.DecidedAt,
+	)
+	return i, err
+}
+
 const createToolApprovalRequest = `-- name: CreateToolApprovalRequest :one
+WITH locked_session AS (
+  SELECT id
+  FROM bot_sessions
+  WHERE id = $2
+  FOR UPDATE
+),
+next_short_id AS (
+  SELECT COALESCE(MAX(tool_approval_requests.short_id), 0) + 1 AS short_id
+  FROM locked_session
+  LEFT JOIN tool_approval_requests ON tool_approval_requests.session_id = locked_session.id
+)
 INSERT INTO tool_approval_requests (
   bot_id,
   session_id,
@@ -129,12 +210,13 @@ INSERT INTO tool_approval_requests (
   operation,
   tool_input,
   short_id,
+  runtime_fencing_token,
   requested_by_channel_identity_id,
   requested_message_id,
   source_platform,
   reply_target,
   conversation_type
-) VALUES (
+) SELECT
   $1,
   $2,
   $3,
@@ -143,23 +225,23 @@ INSERT INTO tool_approval_requests (
   $6,
   $7,
   $8,
-  (
-    SELECT COALESCE(MAX(short_id), 0) + 1
-    FROM tool_approval_requests
-    WHERE session_id = $2
-  ),
+  next_short_id.short_id,
   $9,
   $10,
   $11,
   $12,
-  $13
-)
+  $13,
+  $14
+FROM locked_session
+CROSS JOIN next_short_id
 ON CONFLICT (session_id, tool_call_id) DO UPDATE
-SET tool_input = CASE
-  WHEN tool_approval_requests.status = 'pending' THEN EXCLUDED.tool_input
-  ELSE tool_approval_requests.tool_input
-END
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SET tool_input = tool_approval_requests.tool_input
+WHERE tool_approval_requests.status = 'pending'
+  AND tool_approval_requests.runtime_fencing_token IS NOT DISTINCT FROM EXCLUDED.runtime_fencing_token
+  AND tool_approval_requests.tool_name = EXCLUDED.tool_name
+  AND tool_approval_requests.operation = EXCLUDED.operation
+  AND tool_approval_requests.tool_input = EXCLUDED.tool_input
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 `
 
 type CreateToolApprovalRequestParams struct {
@@ -171,6 +253,7 @@ type CreateToolApprovalRequestParams struct {
 	ToolName                     string      `json:"tool_name"`
 	Operation                    string      `json:"operation"`
 	ToolInput                    []byte      `json:"tool_input"`
+	RuntimeFencingToken          pgtype.Int8 `json:"runtime_fencing_token"`
 	RequestedByChannelIdentityID pgtype.UUID `json:"requested_by_channel_identity_id"`
 	RequestedMessageID           pgtype.UUID `json:"requested_message_id"`
 	SourcePlatform               string      `json:"source_platform"`
@@ -188,6 +271,7 @@ func (q *Queries) CreateToolApprovalRequest(ctx context.Context, arg CreateToolA
 		arg.ToolName,
 		arg.Operation,
 		arg.ToolInput,
+		arg.RuntimeFencingToken,
 		arg.RequestedByChannelIdentityID,
 		arg.RequestedMessageID,
 		arg.SourcePlatform,
@@ -207,6 +291,7 @@ func (q *Queries) CreateToolApprovalRequest(ctx context.Context, arg CreateToolA
 		&i.ToolInput,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.DecisionReason,
 		&i.RequestedByChannelIdentityID,
 		&i.DecidedByChannelIdentityID,
@@ -223,7 +308,7 @@ func (q *Queries) CreateToolApprovalRequest(ctx context.Context, arg CreateToolA
 }
 
 const getLatestPendingToolApprovalBySession = `-- name: GetLatestPendingToolApprovalBySession :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 FROM tool_approval_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -252,6 +337,7 @@ func (q *Queries) GetLatestPendingToolApprovalBySession(ctx context.Context, arg
 		&i.ToolInput,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.DecisionReason,
 		&i.RequestedByChannelIdentityID,
 		&i.DecidedByChannelIdentityID,
@@ -268,7 +354,7 @@ func (q *Queries) GetLatestPendingToolApprovalBySession(ctx context.Context, arg
 }
 
 const getPendingToolApprovalByReplyMessage = `-- name: GetPendingToolApprovalByReplyMessage :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 FROM tool_approval_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -299,6 +385,7 @@ func (q *Queries) GetPendingToolApprovalByReplyMessage(ctx context.Context, arg 
 		&i.ToolInput,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.DecisionReason,
 		&i.RequestedByChannelIdentityID,
 		&i.DecidedByChannelIdentityID,
@@ -315,7 +402,7 @@ func (q *Queries) GetPendingToolApprovalByReplyMessage(ctx context.Context, arg 
 }
 
 const getPendingToolApprovalBySessionShortID = `-- name: GetPendingToolApprovalBySessionShortID :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 FROM tool_approval_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -344,6 +431,7 @@ func (q *Queries) GetPendingToolApprovalBySessionShortID(ctx context.Context, ar
 		&i.ToolInput,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.DecisionReason,
 		&i.RequestedByChannelIdentityID,
 		&i.DecidedByChannelIdentityID,
@@ -360,7 +448,7 @@ func (q *Queries) GetPendingToolApprovalBySessionShortID(ctx context.Context, ar
 }
 
 const getToolApprovalRequest = `-- name: GetToolApprovalRequest :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 FROM tool_approval_requests
 WHERE id = $1
 `
@@ -380,6 +468,7 @@ func (q *Queries) GetToolApprovalRequest(ctx context.Context, id pgtype.UUID) (T
 		&i.ToolInput,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.DecisionReason,
 		&i.RequestedByChannelIdentityID,
 		&i.DecidedByChannelIdentityID,
@@ -396,7 +485,7 @@ func (q *Queries) GetToolApprovalRequest(ctx context.Context, id pgtype.UUID) (T
 }
 
 const listPendingToolApprovalsBySession = `-- name: ListPendingToolApprovalsBySession :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 FROM tool_approval_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -430,6 +519,7 @@ func (q *Queries) ListPendingToolApprovalsBySession(ctx context.Context, arg Lis
 			&i.ToolInput,
 			&i.ShortID,
 			&i.Status,
+			&i.RuntimeFencingToken,
 			&i.DecisionReason,
 			&i.RequestedByChannelIdentityID,
 			&i.DecidedByChannelIdentityID,
@@ -453,7 +543,7 @@ func (q *Queries) ListPendingToolApprovalsBySession(ctx context.Context, arg Lis
 }
 
 const listToolApprovalsBySession = `-- name: ListToolApprovalsBySession :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 FROM tool_approval_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -486,6 +576,7 @@ func (q *Queries) ListToolApprovalsBySession(ctx context.Context, arg ListToolAp
 			&i.ToolInput,
 			&i.ShortID,
 			&i.Status,
+			&i.RuntimeFencingToken,
 			&i.DecisionReason,
 			&i.RequestedByChannelIdentityID,
 			&i.DecidedByChannelIdentityID,
@@ -509,7 +600,7 @@ func (q *Queries) ListToolApprovalsBySession(ctx context.Context, arg ListToolAp
 }
 
 const listToolApprovalsBySessionToolCalls = `-- name: ListToolApprovalsBySessionToolCalls :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 FROM tool_approval_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -544,6 +635,7 @@ func (q *Queries) ListToolApprovalsBySessionToolCalls(ctx context.Context, arg L
 			&i.ToolInput,
 			&i.ShortID,
 			&i.Status,
+			&i.RuntimeFencingToken,
 			&i.DecisionReason,
 			&i.RequestedByChannelIdentityID,
 			&i.DecidedByChannelIdentityID,
@@ -574,17 +666,24 @@ SET status = 'rejected',
     decided_at = now()
 WHERE id = $3
   AND status = 'pending'
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+  AND (runtime_fencing_token IS NULL OR runtime_fencing_token = $4::bigint)
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 `
 
 type RejectToolApprovalRequestParams struct {
 	Reason                     string      `json:"reason"`
 	DecidedByChannelIdentityID pgtype.UUID `json:"decided_by_channel_identity_id"`
 	ID                         pgtype.UUID `json:"id"`
+	RuntimeFencingToken        pgtype.Int8 `json:"runtime_fencing_token"`
 }
 
 func (q *Queries) RejectToolApprovalRequest(ctx context.Context, arg RejectToolApprovalRequestParams) (ToolApprovalRequest, error) {
-	row := q.db.QueryRow(ctx, rejectToolApprovalRequest, arg.Reason, arg.DecidedByChannelIdentityID, arg.ID)
+	row := q.db.QueryRow(ctx, rejectToolApprovalRequest,
+		arg.Reason,
+		arg.DecidedByChannelIdentityID,
+		arg.ID,
+		arg.RuntimeFencingToken,
+	)
 	var i ToolApprovalRequest
 	err := row.Scan(
 		&i.ID,
@@ -598,6 +697,7 @@ func (q *Queries) RejectToolApprovalRequest(ctx context.Context, arg RejectToolA
 		&i.ToolInput,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.DecisionReason,
 		&i.RequestedByChannelIdentityID,
 		&i.DecidedByChannelIdentityID,
@@ -613,12 +713,81 @@ func (q *Queries) RejectToolApprovalRequest(ctx context.Context, arg RejectToolA
 	return i, err
 }
 
+const supersedePendingToolApprovalsBySession = `-- name: SupersedePendingToolApprovalsBySession :many
+UPDATE tool_approval_requests
+SET status = 'cancelled',
+    decision_reason = $1,
+    decided_at = now()
+WHERE bot_id = $2
+  AND session_id = $3
+  AND status = 'pending'
+  AND runtime_fencing_token IS NOT NULL
+  AND id IS DISTINCT FROM $4::uuid
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+`
+
+type SupersedePendingToolApprovalsBySessionParams struct {
+	Reason     string      `json:"reason"`
+	BotID      pgtype.UUID `json:"bot_id"`
+	SessionID  pgtype.UUID `json:"session_id"`
+	PreserveID pgtype.UUID `json:"preserve_id"`
+}
+
+func (q *Queries) SupersedePendingToolApprovalsBySession(ctx context.Context, arg SupersedePendingToolApprovalsBySessionParams) ([]ToolApprovalRequest, error) {
+	rows, err := q.db.Query(ctx, supersedePendingToolApprovalsBySession,
+		arg.Reason,
+		arg.BotID,
+		arg.SessionID,
+		arg.PreserveID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ToolApprovalRequest
+	for rows.Next() {
+		var i ToolApprovalRequest
+		if err := rows.Scan(
+			&i.ID,
+			&i.BotID,
+			&i.SessionID,
+			&i.RouteID,
+			&i.ChannelIdentityID,
+			&i.ToolCallID,
+			&i.ToolName,
+			&i.Operation,
+			&i.ToolInput,
+			&i.ShortID,
+			&i.Status,
+			&i.RuntimeFencingToken,
+			&i.DecisionReason,
+			&i.RequestedByChannelIdentityID,
+			&i.DecidedByChannelIdentityID,
+			&i.RequestedMessageID,
+			&i.PromptMessageID,
+			&i.PromptExternalMessageID,
+			&i.SourcePlatform,
+			&i.ReplyTarget,
+			&i.ConversationType,
+			&i.CreatedAt,
+			&i.DecidedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateToolApprovalPromptMessage = `-- name: UpdateToolApprovalPromptMessage :one
 UPDATE tool_approval_requests
 SET prompt_message_id = $1,
     prompt_external_message_id = $2
 WHERE id = $3
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, operation, tool_input, short_id, status, runtime_fencing_token, decision_reason, requested_by_channel_identity_id, decided_by_channel_identity_id, requested_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, created_at, decided_at
 `
 
 type UpdateToolApprovalPromptMessageParams struct {
@@ -642,6 +811,7 @@ func (q *Queries) UpdateToolApprovalPromptMessage(ctx context.Context, arg Updat
 		&i.ToolInput,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.DecisionReason,
 		&i.RequestedByChannelIdentityID,
 		&i.DecidedByChannelIdentityID,

--- a/internal/db/postgres/sqlc/user_input.sql.go
+++ b/internal/db/postgres/sqlc/user_input.sql.go
@@ -21,18 +21,27 @@ SET status = 'canceled',
 WHERE bot_id = $2
   AND session_id = $3
   AND status = 'pending'
-  AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+  AND (
+    runtime_fencing_token = $4::bigint
+    OR (runtime_fencing_token IS NULL AND (expires_at IS NULL OR expires_at > now()))
+  )
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 `
 
 type CancelPendingUserInputsBySessionParams struct {
-	ResultJson []byte      `json:"result_json"`
-	BotID      pgtype.UUID `json:"bot_id"`
-	SessionID  pgtype.UUID `json:"session_id"`
+	ResultJson          []byte      `json:"result_json"`
+	BotID               pgtype.UUID `json:"bot_id"`
+	SessionID           pgtype.UUID `json:"session_id"`
+	RuntimeFencingToken pgtype.Int8 `json:"runtime_fencing_token"`
 }
 
 func (q *Queries) CancelPendingUserInputsBySession(ctx context.Context, arg CancelPendingUserInputsBySessionParams) ([]UserInputRequest, error) {
-	rows, err := q.db.Query(ctx, cancelPendingUserInputsBySession, arg.ResultJson, arg.BotID, arg.SessionID)
+	rows, err := q.db.Query(ctx, cancelPendingUserInputsBySession,
+		arg.ResultJson,
+		arg.BotID,
+		arg.SessionID,
+		arg.RuntimeFencingToken,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +59,7 @@ func (q *Queries) CancelPendingUserInputsBySession(ctx context.Context, arg Canc
 			&i.ToolName,
 			&i.ShortID,
 			&i.Status,
+			&i.RuntimeFencingToken,
 			&i.InputJson,
 			&i.UiPayloadJson,
 			&i.ResultJson,
@@ -89,18 +99,27 @@ SET status = 'canceled',
     updated_at = now()
 WHERE id = $3
   AND status = 'pending'
-  AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+  AND (
+    runtime_fencing_token = $4::bigint
+    OR (runtime_fencing_token IS NULL AND (expires_at IS NULL OR expires_at > now()))
+  )
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 `
 
 type CancelUserInputRequestParams struct {
 	ResultJson                   []byte      `json:"result_json"`
 	RespondedByChannelIdentityID pgtype.UUID `json:"responded_by_channel_identity_id"`
 	ID                           pgtype.UUID `json:"id"`
+	RuntimeFencingToken          pgtype.Int8 `json:"runtime_fencing_token"`
 }
 
 func (q *Queries) CancelUserInputRequest(ctx context.Context, arg CancelUserInputRequestParams) (UserInputRequest, error) {
-	row := q.db.QueryRow(ctx, cancelUserInputRequest, arg.ResultJson, arg.RespondedByChannelIdentityID, arg.ID)
+	row := q.db.QueryRow(ctx, cancelUserInputRequest,
+		arg.ResultJson,
+		arg.RespondedByChannelIdentityID,
+		arg.ID,
+		arg.RuntimeFencingToken,
+	)
 	var i UserInputRequest
 	err := row.Scan(
 		&i.ID,
@@ -112,6 +131,73 @@ func (q *Queries) CancelUserInputRequest(ctx context.Context, arg CancelUserInpu
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
+		&i.InputJson,
+		&i.UiPayloadJson,
+		&i.ResultJson,
+		&i.ProviderMetadata,
+		&i.RequestedByChannelIdentityID,
+		&i.RespondedByChannelIdentityID,
+		&i.AssistantMessageID,
+		&i.ToolResultMessageID,
+		&i.PromptMessageID,
+		&i.PromptExternalMessageID,
+		&i.SourcePlatform,
+		&i.ReplyTarget,
+		&i.ConversationType,
+		&i.ExpiresAt,
+		&i.CreatedAt,
+		&i.RespondedAt,
+		&i.CanceledAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const claimUserInputRequestForRuntime = `-- name: ClaimUserInputRequestForRuntime :one
+UPDATE user_input_requests
+SET runtime_fencing_token = $1,
+    updated_at = now()
+WHERE id = $2
+  AND bot_id = $3
+  AND session_id = $4
+  AND status = 'pending'
+  AND (
+    runtime_fencing_token = $1
+    OR (
+      (runtime_fencing_token IS NULL OR runtime_fencing_token < $1)
+      AND (expires_at IS NULL OR expires_at > now())
+    )
+  )
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+`
+
+type ClaimUserInputRequestForRuntimeParams struct {
+	RuntimeFencingToken pgtype.Int8 `json:"runtime_fencing_token"`
+	ID                  pgtype.UUID `json:"id"`
+	BotID               pgtype.UUID `json:"bot_id"`
+	SessionID           pgtype.UUID `json:"session_id"`
+}
+
+func (q *Queries) ClaimUserInputRequestForRuntime(ctx context.Context, arg ClaimUserInputRequestForRuntimeParams) (UserInputRequest, error) {
+	row := q.db.QueryRow(ctx, claimUserInputRequestForRuntime,
+		arg.RuntimeFencingToken,
+		arg.ID,
+		arg.BotID,
+		arg.SessionID,
+	)
+	var i UserInputRequest
+	err := row.Scan(
+		&i.ID,
+		&i.BotID,
+		&i.SessionID,
+		&i.RouteID,
+		&i.ChannelIdentityID,
+		&i.ToolCallID,
+		&i.ToolName,
+		&i.ShortID,
+		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -154,6 +240,7 @@ INSERT INTO user_input_requests (
   tool_call_id,
   tool_name,
   short_id,
+  runtime_fencing_token,
   input_json,
   ui_payload_json,
   provider_metadata,
@@ -177,22 +264,20 @@ INSERT INTO user_input_requests (
   $11,
   $12,
   $13,
-  $14
+  $14,
+  $15
 FROM locked_session
 CROSS JOIN next_short_id
 ON CONFLICT (session_id, tool_call_id) DO UPDATE
-SET input_json = EXCLUDED.input_json,
-    ui_payload_json = EXCLUDED.ui_payload_json,
-    provider_metadata = EXCLUDED.provider_metadata,
-    requested_by_channel_identity_id = EXCLUDED.requested_by_channel_identity_id,
-    source_platform = EXCLUDED.source_platform,
-    reply_target = EXCLUDED.reply_target,
-    conversation_type = EXCLUDED.conversation_type,
-    expires_at = EXCLUDED.expires_at,
-    updated_at = now()
+SET updated_at = user_input_requests.updated_at
 WHERE user_input_requests.status = 'pending'
+  AND user_input_requests.runtime_fencing_token IS NOT DISTINCT FROM EXCLUDED.runtime_fencing_token
   AND (user_input_requests.expires_at IS NULL OR user_input_requests.expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+  AND user_input_requests.input_json = EXCLUDED.input_json
+  AND user_input_requests.ui_payload_json = EXCLUDED.ui_payload_json
+  AND user_input_requests.provider_metadata = EXCLUDED.provider_metadata
+  AND user_input_requests.expires_at IS NOT DISTINCT FROM EXCLUDED.expires_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 `
 
 type CreateUserInputRequestParams struct {
@@ -202,6 +287,7 @@ type CreateUserInputRequestParams struct {
 	ChannelIdentityID            pgtype.UUID        `json:"channel_identity_id"`
 	ToolCallID                   string             `json:"tool_call_id"`
 	ToolName                     string             `json:"tool_name"`
+	RuntimeFencingToken          pgtype.Int8        `json:"runtime_fencing_token"`
 	InputJson                    []byte             `json:"input_json"`
 	UiPayloadJson                []byte             `json:"ui_payload_json"`
 	ProviderMetadata             []byte             `json:"provider_metadata"`
@@ -220,6 +306,7 @@ func (q *Queries) CreateUserInputRequest(ctx context.Context, arg CreateUserInpu
 		arg.ChannelIdentityID,
 		arg.ToolCallID,
 		arg.ToolName,
+		arg.RuntimeFencingToken,
 		arg.InputJson,
 		arg.UiPayloadJson,
 		arg.ProviderMetadata,
@@ -240,6 +327,7 @@ func (q *Queries) CreateUserInputRequest(ctx context.Context, arg CreateUserInpu
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -269,17 +357,21 @@ SET status = 'failed',
     updated_at = now()
 WHERE id = $2
   AND status = 'pending'
-  AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+  AND (
+    runtime_fencing_token = $3::bigint
+    OR (runtime_fencing_token IS NULL AND (expires_at IS NULL OR expires_at > now()))
+  )
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 `
 
 type FailUserInputRequestParams struct {
-	ResultJson []byte      `json:"result_json"`
-	ID         pgtype.UUID `json:"id"`
+	ResultJson          []byte      `json:"result_json"`
+	ID                  pgtype.UUID `json:"id"`
+	RuntimeFencingToken pgtype.Int8 `json:"runtime_fencing_token"`
 }
 
 func (q *Queries) FailUserInputRequest(ctx context.Context, arg FailUserInputRequestParams) (UserInputRequest, error) {
-	row := q.db.QueryRow(ctx, failUserInputRequest, arg.ResultJson, arg.ID)
+	row := q.db.QueryRow(ctx, failUserInputRequest, arg.ResultJson, arg.ID, arg.RuntimeFencingToken)
 	var i UserInputRequest
 	err := row.Scan(
 		&i.ID,
@@ -291,6 +383,7 @@ func (q *Queries) FailUserInputRequest(ctx context.Context, arg FailUserInputReq
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -314,7 +407,7 @@ func (q *Queries) FailUserInputRequest(ctx context.Context, arg FailUserInputReq
 }
 
 const getLatestPendingUserInputBySession = `-- name: GetLatestPendingUserInputBySession :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 FROM user_input_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -342,6 +435,7 @@ func (q *Queries) GetLatestPendingUserInputBySession(ctx context.Context, arg Ge
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -365,7 +459,7 @@ func (q *Queries) GetLatestPendingUserInputBySession(ctx context.Context, arg Ge
 }
 
 const getPendingUserInputByReplyMessage = `-- name: GetPendingUserInputByReplyMessage :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 FROM user_input_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -395,6 +489,7 @@ func (q *Queries) GetPendingUserInputByReplyMessage(ctx context.Context, arg Get
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -418,7 +513,7 @@ func (q *Queries) GetPendingUserInputByReplyMessage(ctx context.Context, arg Get
 }
 
 const getPendingUserInputBySessionShortID = `-- name: GetPendingUserInputBySessionShortID :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 FROM user_input_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -446,6 +541,66 @@ func (q *Queries) GetPendingUserInputBySessionShortID(ctx context.Context, arg G
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
+		&i.InputJson,
+		&i.UiPayloadJson,
+		&i.ResultJson,
+		&i.ProviderMetadata,
+		&i.RequestedByChannelIdentityID,
+		&i.RespondedByChannelIdentityID,
+		&i.AssistantMessageID,
+		&i.ToolResultMessageID,
+		&i.PromptMessageID,
+		&i.PromptExternalMessageID,
+		&i.SourcePlatform,
+		&i.ReplyTarget,
+		&i.ConversationType,
+		&i.ExpiresAt,
+		&i.CreatedAt,
+		&i.RespondedAt,
+		&i.CanceledAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getRespondableUserInputRequest = `-- name: GetRespondableUserInputRequest :one
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+FROM user_input_requests
+WHERE id = $1
+  AND status = 'pending'
+  AND (
+    (
+      $2::bigint IS NOT NULL
+      AND runtime_fencing_token = $2::bigint
+    )
+    OR (
+      $2::bigint IS NULL
+      AND runtime_fencing_token IS NULL
+      AND (expires_at IS NULL OR expires_at > now())
+    )
+  )
+`
+
+type GetRespondableUserInputRequestParams struct {
+	ID                  pgtype.UUID `json:"id"`
+	RuntimeFencingToken pgtype.Int8 `json:"runtime_fencing_token"`
+}
+
+func (q *Queries) GetRespondableUserInputRequest(ctx context.Context, arg GetRespondableUserInputRequestParams) (UserInputRequest, error) {
+	row := q.db.QueryRow(ctx, getRespondableUserInputRequest, arg.ID, arg.RuntimeFencingToken)
+	var i UserInputRequest
+	err := row.Scan(
+		&i.ID,
+		&i.BotID,
+		&i.SessionID,
+		&i.RouteID,
+		&i.ChannelIdentityID,
+		&i.ToolCallID,
+		&i.ToolName,
+		&i.ShortID,
+		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -469,7 +624,7 @@ func (q *Queries) GetPendingUserInputBySessionShortID(ctx context.Context, arg G
 }
 
 const getUserInputRequest = `-- name: GetUserInputRequest :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 FROM user_input_requests
 WHERE id = $1
 `
@@ -487,6 +642,7 @@ func (q *Queries) GetUserInputRequest(ctx context.Context, id pgtype.UUID) (User
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -510,7 +666,7 @@ func (q *Queries) GetUserInputRequest(ctx context.Context, id pgtype.UUID) (User
 }
 
 const getUserInputRequestBySessionToolCall = `-- name: GetUserInputRequestBySessionToolCall :one
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 FROM user_input_requests
 WHERE session_id = $1
   AND tool_call_id = $2
@@ -534,6 +690,7 @@ func (q *Queries) GetUserInputRequestBySessionToolCall(ctx context.Context, arg 
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -557,7 +714,7 @@ func (q *Queries) GetUserInputRequestBySessionToolCall(ctx context.Context, arg 
 }
 
 const listPendingUserInputsBySession = `-- name: ListPendingUserInputsBySession :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 FROM user_input_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -590,6 +747,7 @@ func (q *Queries) ListPendingUserInputsBySession(ctx context.Context, arg ListPe
 			&i.ToolName,
 			&i.ShortID,
 			&i.Status,
+			&i.RuntimeFencingToken,
 			&i.InputJson,
 			&i.UiPayloadJson,
 			&i.ResultJson,
@@ -620,7 +778,7 @@ func (q *Queries) ListPendingUserInputsBySession(ctx context.Context, arg ListPe
 }
 
 const listUserInputsBySession = `-- name: ListUserInputsBySession :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 FROM user_input_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -651,6 +809,7 @@ func (q *Queries) ListUserInputsBySession(ctx context.Context, arg ListUserInput
 			&i.ToolName,
 			&i.ShortID,
 			&i.Status,
+			&i.RuntimeFencingToken,
 			&i.InputJson,
 			&i.UiPayloadJson,
 			&i.ResultJson,
@@ -681,7 +840,7 @@ func (q *Queries) ListUserInputsBySession(ctx context.Context, arg ListUserInput
 }
 
 const listUserInputsBySessionToolCalls = `-- name: ListUserInputsBySessionToolCalls :many
-SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+SELECT id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 FROM user_input_requests
 WHERE bot_id = $1
   AND session_id = $2
@@ -714,6 +873,7 @@ func (q *Queries) ListUserInputsBySessionToolCalls(ctx context.Context, arg List
 			&i.ToolName,
 			&i.ShortID,
 			&i.Status,
+			&i.RuntimeFencingToken,
 			&i.InputJson,
 			&i.UiPayloadJson,
 			&i.ResultJson,
@@ -752,18 +912,27 @@ SET status = 'submitted',
     updated_at = now()
 WHERE id = $3
   AND status = 'pending'
-  AND (expires_at IS NULL OR expires_at > now())
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+  AND (
+    runtime_fencing_token = $4::bigint
+    OR (runtime_fencing_token IS NULL AND (expires_at IS NULL OR expires_at > now()))
+  )
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 `
 
 type SubmitUserInputRequestParams struct {
 	ResultJson                   []byte      `json:"result_json"`
 	RespondedByChannelIdentityID pgtype.UUID `json:"responded_by_channel_identity_id"`
 	ID                           pgtype.UUID `json:"id"`
+	RuntimeFencingToken          pgtype.Int8 `json:"runtime_fencing_token"`
 }
 
 func (q *Queries) SubmitUserInputRequest(ctx context.Context, arg SubmitUserInputRequestParams) (UserInputRequest, error) {
-	row := q.db.QueryRow(ctx, submitUserInputRequest, arg.ResultJson, arg.RespondedByChannelIdentityID, arg.ID)
+	row := q.db.QueryRow(ctx, submitUserInputRequest,
+		arg.ResultJson,
+		arg.RespondedByChannelIdentityID,
+		arg.ID,
+		arg.RuntimeFencingToken,
+	)
 	var i UserInputRequest
 	err := row.Scan(
 		&i.ID,
@@ -775,6 +944,7 @@ func (q *Queries) SubmitUserInputRequest(ctx context.Context, arg SubmitUserInpu
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -797,12 +967,88 @@ func (q *Queries) SubmitUserInputRequest(ctx context.Context, arg SubmitUserInpu
 	return i, err
 }
 
+const supersedePendingUserInputsBySession = `-- name: SupersedePendingUserInputsBySession :many
+UPDATE user_input_requests
+SET status = 'canceled',
+    result_json = $1,
+    responded_at = now(),
+    canceled_at = now(),
+    updated_at = now()
+WHERE bot_id = $2
+  AND session_id = $3
+  AND status = 'pending'
+  AND runtime_fencing_token IS NOT NULL
+  AND id IS DISTINCT FROM $4::uuid
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+`
+
+type SupersedePendingUserInputsBySessionParams struct {
+	ResultJson []byte      `json:"result_json"`
+	BotID      pgtype.UUID `json:"bot_id"`
+	SessionID  pgtype.UUID `json:"session_id"`
+	PreserveID pgtype.UUID `json:"preserve_id"`
+}
+
+func (q *Queries) SupersedePendingUserInputsBySession(ctx context.Context, arg SupersedePendingUserInputsBySessionParams) ([]UserInputRequest, error) {
+	rows, err := q.db.Query(ctx, supersedePendingUserInputsBySession,
+		arg.ResultJson,
+		arg.BotID,
+		arg.SessionID,
+		arg.PreserveID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []UserInputRequest
+	for rows.Next() {
+		var i UserInputRequest
+		if err := rows.Scan(
+			&i.ID,
+			&i.BotID,
+			&i.SessionID,
+			&i.RouteID,
+			&i.ChannelIdentityID,
+			&i.ToolCallID,
+			&i.ToolName,
+			&i.ShortID,
+			&i.Status,
+			&i.RuntimeFencingToken,
+			&i.InputJson,
+			&i.UiPayloadJson,
+			&i.ResultJson,
+			&i.ProviderMetadata,
+			&i.RequestedByChannelIdentityID,
+			&i.RespondedByChannelIdentityID,
+			&i.AssistantMessageID,
+			&i.ToolResultMessageID,
+			&i.PromptMessageID,
+			&i.PromptExternalMessageID,
+			&i.SourcePlatform,
+			&i.ReplyTarget,
+			&i.ConversationType,
+			&i.ExpiresAt,
+			&i.CreatedAt,
+			&i.RespondedAt,
+			&i.CanceledAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateUserInputAssistantMessage = `-- name: UpdateUserInputAssistantMessage :one
 UPDATE user_input_requests
 SET assistant_message_id = $1,
     updated_at = now()
 WHERE id = $2
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 `
 
 type UpdateUserInputAssistantMessageParams struct {
@@ -823,6 +1069,7 @@ func (q *Queries) UpdateUserInputAssistantMessage(ctx context.Context, arg Updat
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -851,7 +1098,7 @@ SET prompt_message_id = $1,
     prompt_external_message_id = $2,
     updated_at = now()
 WHERE id = $3
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 `
 
 type UpdateUserInputPromptMessageParams struct {
@@ -873,6 +1120,7 @@ func (q *Queries) UpdateUserInputPromptMessage(ctx context.Context, arg UpdateUs
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,
@@ -900,7 +1148,7 @@ UPDATE user_input_requests
 SET tool_result_message_id = $1,
     updated_at = now()
 WHERE id = $2
-RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
+RETURNING id, bot_id, session_id, route_id, channel_identity_id, tool_call_id, tool_name, short_id, status, runtime_fencing_token, input_json, ui_payload_json, result_json, provider_metadata, requested_by_channel_identity_id, responded_by_channel_identity_id, assistant_message_id, tool_result_message_id, prompt_message_id, prompt_external_message_id, source_platform, reply_target, conversation_type, expires_at, created_at, responded_at, canceled_at, updated_at
 `
 
 type UpdateUserInputToolResultMessageParams struct {
@@ -921,6 +1169,7 @@ func (q *Queries) UpdateUserInputToolResultMessage(ctx context.Context, arg Upda
 		&i.ToolName,
 		&i.ShortID,
 		&i.Status,
+		&i.RuntimeFencingToken,
 		&i.InputJson,
 		&i.UiPayloadJson,
 		&i.ResultJson,

--- a/internal/db/postgres/store/queries.go
+++ b/internal/db/postgres/store/queries.go
@@ -27,6 +27,13 @@ func (*Queries) SupportsAtomicDirectHistoryTurnWrites() bool {
 	return true
 }
 
+// SupportsTransactions reports whether InTx opens a real PostgreSQL
+// transaction. The pool-less wrapper intentionally retains its historical
+// direct-execution fallback for tests and legacy callers.
+func (q *Queries) SupportsTransactions() bool {
+	return q != nil && q.pool != nil
+}
+
 func (q *Queries) WithTx(tx pgx.Tx) dbstore.Queries {
 	if q == nil {
 		return nil

--- a/internal/db/store/queries.go
+++ b/internal/db/store/queries.go
@@ -215,6 +215,7 @@ type Queries interface {
 	GetTokenUsageByModel(ctx context.Context, arg dbsqlc.GetTokenUsageByModelParams) ([]dbsqlc.GetTokenUsageByModelRow, error)
 	GetToolApprovalRequest(ctx context.Context, id pgtype.UUID) (dbsqlc.ToolApprovalRequest, error)
 	GetUserInputRequest(ctx context.Context, id pgtype.UUID) (dbsqlc.UserInputRequest, error)
+	GetRespondableUserInputRequest(ctx context.Context, arg dbsqlc.GetRespondableUserInputRequestParams) (dbsqlc.UserInputRequest, error)
 	GetUserInputRequestBySessionToolCall(ctx context.Context, arg dbsqlc.GetUserInputRequestBySessionToolCallParams) (dbsqlc.UserInputRequest, error)
 	GetTranscriptionModelWithProvider(ctx context.Context, id pgtype.UUID) (dbsqlc.GetTranscriptionModelWithProviderRow, error)
 	GetUserByID(ctx context.Context, id pgtype.UUID) (dbsqlc.User, error)

--- a/internal/decision/transaction.go
+++ b/internal/decision/transaction.go
@@ -1,0 +1,76 @@
+package decision
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/runtimefence"
+)
+
+type transactionRunner interface {
+	InTx(context.Context, func(dbstore.Queries) error) error
+}
+
+type transactionCapability interface {
+	SupportsTransactions() bool
+}
+
+type sequenceLocker interface {
+	LockSessionDecisionSequence(context.Context, sqlc.LockSessionDecisionSequenceParams) (pgtype.UUID, error)
+}
+
+// InCreateTransaction serializes per-session decision short IDs before the
+// INSERT statement takes its MVCC snapshot. Non-transactional test stores
+// retain their own local serialization.
+func InCreateTransaction(ctx context.Context, queries dbstore.Queries, botID, sessionID string, create func(dbstore.Queries) error) error {
+	if create == nil {
+		return errors.New("decision create callback is required")
+	}
+	if _, fenced := runtimefence.FromContext(ctx); fenced {
+		return runtimefence.InTransaction(ctx, queries, botID, sessionID, func(txQueries dbstore.Queries) error {
+			return lockAndCreate(ctx, txQueries, botID, sessionID, create)
+		})
+	}
+	txer, txOK := queries.(transactionRunner)
+	capability, capabilityOK := queries.(transactionCapability)
+	if !txOK || !capabilityOK || !capability.SupportsTransactions() {
+		return create(queries)
+	}
+	return txer.InTx(ctx, func(txQueries dbstore.Queries) error {
+		return lockAndCreate(ctx, txQueries, botID, sessionID, create)
+	})
+}
+
+func lockAndCreate(ctx context.Context, queries dbstore.Queries, botID, sessionID string, create func(dbstore.Queries) error) error {
+	pgBotID, err := db.ParseUUID(botID)
+	if err != nil {
+		return err
+	}
+	pgSessionID, err := db.ParseUUID(sessionID)
+	if err != nil {
+		return err
+	}
+	if err := runtimefence.LockBotForSessionWrite(ctx, queries, botID); err != nil {
+		return err
+	}
+	locker, ok := queries.(sequenceLocker)
+	if !ok {
+		return errors.New("decision store does not support session sequence locking")
+	}
+	if _, err := locker.LockSessionDecisionSequence(ctx, sqlc.LockSessionDecisionSequenceParams{
+		SessionID: pgSessionID,
+		BotID:     pgBotID,
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return runtimefence.ErrStale
+		}
+		return err
+	}
+	return create(queries)
+}

--- a/internal/decision/transaction_test.go
+++ b/internal/decision/transaction_test.go
@@ -1,0 +1,60 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+)
+
+type createTransactionQueries struct {
+	dbstore.Queries
+	parentLocked  bool
+	sessionLocked bool
+}
+
+func (*createTransactionQueries) SupportsTransactions() bool { return true }
+
+func (q *createTransactionQueries) InTx(_ context.Context, fn func(dbstore.Queries) error) error {
+	return fn(q)
+}
+
+func (q *createTransactionQueries) LockBotForSessionWrite(_ context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	q.parentLocked = true
+	return id, nil
+}
+
+func (q *createTransactionQueries) LockSessionDecisionSequence(_ context.Context, _ sqlc.LockSessionDecisionSequenceParams) (pgtype.UUID, error) {
+	if !q.parentLocked {
+		return pgtype.UUID{}, errors.New("session locked before bot parent")
+	}
+	q.sessionLocked = true
+	return pgtype.UUID{Valid: true}, nil
+}
+
+func TestInCreateTransactionLocksBotBeforeSession(t *testing.T) {
+	t.Parallel()
+
+	queries := &createTransactionQueries{}
+	called := false
+	err := InCreateTransaction(context.Background(), queries,
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222",
+		func(dbstore.Queries) error {
+			called = true
+			if !queries.parentLocked || !queries.sessionLocked {
+				t.Fatal("create callback ran before parent and session locks")
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("InCreateTransaction() error = %v", err)
+	}
+	if !called {
+		t.Fatal("create callback did not run")
+	}
+}

--- a/internal/handlers/local_channel_runtime_contract_test.go
+++ b/internal/handlers/local_channel_runtime_contract_test.go
@@ -1,0 +1,252 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/conversation/flow"
+)
+
+const (
+	runtimeContractBotID     = "11111111-1111-1111-1111-111111111111"
+	runtimeContractSessionID = "22222222-2222-2222-2222-222222222222"
+	runtimeContractStreamID  = "stream-runtime-contract"
+)
+
+func rawRuntimeContractEvent(t *testing.T, ev agentpkg.StreamEvent) flow.WSStreamEvent {
+	t.Helper()
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal runtime event: %v", err)
+	}
+	return data
+}
+
+func richActiveRunWSContractScript(t *testing.T) []flow.WSStreamEvent {
+	t.Helper()
+	return []flow.WSStreamEvent{
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{Type: agentpkg.EventAgentStart}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{Type: agentpkg.EventReasoningDelta, Delta: "I need to inspect the workspace."}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{Type: agentpkg.EventTextDelta, Delta: "I will check the current state."}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{
+			Type:       agentpkg.EventToolCallStart,
+			ToolName:   "exec",
+			ToolCallID: "call-exec",
+			Input:      map[string]any{"command": "pwd"},
+		}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{
+			Type:       agentpkg.EventToolCallProgress,
+			ToolName:   "exec",
+			ToolCallID: "call-exec",
+			Progress:   "queued",
+		}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{
+			Type:       agentpkg.EventToolCallProgress,
+			ToolName:   "exec",
+			ToolCallID: "call-exec",
+			Progress:   map[string]any{"stdout": "/workspace\n"},
+		}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{
+			Type:       agentpkg.EventToolCallEnd,
+			ToolName:   "exec",
+			ToolCallID: "call-exec",
+			Result:     map[string]any{"structuredContent": map[string]any{"stdout": "/workspace\n"}},
+		}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{
+			Type:       agentpkg.EventToolApprovalRequest,
+			ToolName:   "exec",
+			ToolCallID: "call-approval",
+			Input:      map[string]any{"command": "rm -rf build"},
+			ApprovalID: "approval-1",
+			ShortID:    7,
+			Status:     "pending",
+		}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{
+			Type:        agentpkg.EventUserInputRequest,
+			ToolName:    "ask_user",
+			ToolCallID:  "call-ask",
+			Input:       map[string]any{"questions": []any{map[string]any{"text": "Continue?", "kind": "single_select"}}},
+			UserInputID: "input-1",
+			ShortID:     8,
+			Status:      "pending",
+			Metadata: map[string]any{
+				"ui_payload": map[string]any{
+					"version": 2,
+					"questions": []any{map[string]any{
+						"id":   "q1",
+						"text": "Continue?",
+						"kind": "single_select",
+						"options": []any{
+							map[string]any{"id": "yes", "label": "Yes"},
+							map[string]any{"id": "no", "label": "No"},
+						},
+					}},
+				},
+			},
+		}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{Type: agentpkg.EventAgentEnd}),
+	}
+}
+
+func interruptedRunWSContractScript(t *testing.T) []flow.WSStreamEvent {
+	t.Helper()
+	return []flow.WSStreamEvent{
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{Type: agentpkg.EventAgentStart}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{Type: agentpkg.EventTextDelta, Delta: "partial output"}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{Type: agentpkg.EventError, Error: "runtime interrupted"}),
+		rawRuntimeContractEvent(t, agentpkg.StreamEvent{Type: agentpkg.EventAgentAbort}),
+	}
+}
+
+func collectRuntimeContractWSEvents(t *testing.T, script []flow.WSStreamEvent, stopAt string) []map[string]any {
+	t.Helper()
+
+	closeWriter := make(chan struct{})
+	var closeWriterOnce sync.Once
+	handlerDone := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := (&websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}).Upgrade(w, r, nil)
+		if err != nil {
+			handlerDone <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		writer := newWSWriter(conn)
+		eventCh := make(chan flow.WSStreamEvent, len(script))
+		for _, event := range script {
+			eventCh <- event
+		}
+		close(eventCh)
+
+		(&LocalChannelHandler{logger: slog.Default()}).forwardWSStreamEvents(
+			r.Context(),
+			r.Context(),
+			writer,
+			runtimeContractBotID,
+			runtimeContractSessionID,
+			runtimeContractStreamID,
+			eventCh,
+		)
+
+		<-closeWriter
+		writer.Close()
+		handlerDone <- nil
+	}))
+	defer server.Close()
+	defer closeWriterOnce.Do(func() { close(closeWriter) })
+
+	client, resp, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	var events []map[string]any
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if err := client.SetReadDeadline(deadline); err != nil {
+			t.Fatalf("set read deadline: %v", err)
+		}
+		var event map[string]any
+		if err := client.ReadJSON(&event); err != nil {
+			t.Fatalf("read ws event: %v; events=%#v", err, events)
+		}
+		events = append(events, event)
+		if event["type"] == stopAt {
+			break
+		}
+	}
+
+	closeWriterOnce.Do(func() { close(closeWriter) })
+	select {
+	case err := <-handlerDone:
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for handler")
+	}
+
+	return events
+}
+
+func TestLocalChannelRuntimeContractForwardsRichActiveRunUIState(t *testing.T) {
+	t.Parallel()
+
+	events := collectRuntimeContractWSEvents(t, richActiveRunWSContractScript(t), "end")
+	if len(events) < 8 {
+		t.Fatalf("got %d events, want rich stream events: %#v", len(events), events)
+	}
+	if events[0]["type"] != "start" {
+		t.Fatalf("first event = %#v, want start", events[0])
+	}
+
+	var reasoning, text, execTool, approvalTool, askUserTool map[string]any
+	for _, event := range events {
+		data, _ := event["data"].(map[string]any)
+		switch {
+		case data["type"] == "reasoning":
+			reasoning = data
+		case data["type"] == "text":
+			text = data
+		case data["type"] == "tool" && data["tool_call_id"] == "call-exec":
+			execTool = data
+		case data["type"] == "tool" && data["tool_call_id"] == "call-approval":
+			approvalTool = data
+		case data["type"] == "tool" && data["tool_call_id"] == "call-ask":
+			askUserTool = data
+		}
+	}
+
+	if reasoning["content"] != "I need to inspect the workspace." {
+		t.Fatalf("reasoning = %#v", reasoning)
+	}
+	if text["content"] != "I will check the current state." {
+		t.Fatalf("text = %#v", text)
+	}
+	if execTool["running"] != false {
+		t.Fatalf("exec tool = %#v, want completed running=false", execTool)
+	}
+	if progress, _ := execTool["progress"].([]any); len(progress) != 2 {
+		t.Fatalf("exec progress = %#v, want two entries", execTool["progress"])
+	}
+	approval, _ := approvalTool["approval"].(map[string]any)
+	if approval["approval_id"] != "approval-1" || approval["can_approve"] != true {
+		t.Fatalf("approval tool = %#v", approvalTool)
+	}
+	userInput, _ := askUserTool["user_input"].(map[string]any)
+	if userInput["user_input_id"] != "input-1" || userInput["can_respond"] != true {
+		t.Fatalf("ask_user tool = %#v", askUserTool)
+	}
+	if events[len(events)-1]["type"] != "end" {
+		t.Fatalf("last event = %#v, want end", events[len(events)-1])
+	}
+}
+
+func TestLocalChannelRuntimeContractForwardsInterruptedRunError(t *testing.T) {
+	t.Parallel()
+
+	events := collectRuntimeContractWSEvents(t, interruptedRunWSContractScript(t), "end")
+	if len(events) != 4 {
+		t.Fatalf("events = %#v, want start, partial message, error, end", events)
+	}
+	if events[0]["type"] != "start" || events[1]["type"] != "message" || events[2]["type"] != "error" || events[3]["type"] != "end" {
+		t.Fatalf("unexpected interrupted event sequence: %#v", events)
+	}
+	if events[2]["message"] != "runtime interrupted" {
+		t.Fatalf("error event = %#v", events[2])
+	}
+}

--- a/internal/mcp/http_tools_test.go
+++ b/internal/mcp/http_tools_test.go
@@ -3,12 +3,88 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/memohai/memoh/internal/runtimefence"
 )
+
+type fenceCapturingToolSource struct {
+	fence runtimefence.Fence
+	calls int
+}
+
+func (*fenceCapturingToolSource) ListTools(context.Context, ToolSessionContext) ([]ToolDescriptor, error) {
+	return []ToolDescriptor{{Name: "fenced_tool", InputSchema: map[string]any{"type": "object"}}}, nil
+}
+
+func (s *fenceCapturingToolSource) CallTool(ctx context.Context, _ ToolSessionContext, _ string, _ map[string]any) (map[string]any, error) {
+	s.calls++
+	s.fence, _ = runtimefence.FromContext(ctx)
+	return BuildToolSuccessResult(map[string]any{"ok": true}), nil
+}
+
+func TestToolGatewayMiddlewareChecksRuntimeGuardBeforeToolEffect(t *testing.T) {
+	guardErr := errors.New("runtime ownership lost")
+	source := &fenceCapturingToolSource{}
+	service := NewToolGatewayService(nil, []ToolSource{source})
+	middleware := ToolGatewayMiddleware(service, nil, ToolSessionContext{
+		BotID: "bot-1", RuntimeID: "rt-guarded", RuntimeActive: true,
+		RuntimeGuard: func(context.Context) error { return guardErr },
+	})(nil)
+
+	if _, err := middleware(context.Background(), "tools/call", callToolRequest("fenced_tool")); !errors.Is(err, guardErr) {
+		t.Fatalf("tools/call error = %v, want runtime guard error", err)
+	}
+	if source.calls != 0 {
+		t.Fatalf("tool source calls = %d, want zero after guard rejection", source.calls)
+	}
+}
+
+func TestToolGatewayMiddlewareStopsWhenOwningRunIsCanceled(t *testing.T) {
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	cancelRun()
+	source := &fenceCapturingToolSource{}
+	service := NewToolGatewayService(nil, []ToolSource{source})
+	middleware := ToolGatewayMiddleware(service, nil, ToolSessionContext{
+		BotID: "bot-1", RuntimeID: "rt-canceled", RuntimeActive: true, RunContext: runCtx,
+	})(nil)
+
+	if _, err := middleware(context.Background(), "tools/call", callToolRequest("fenced_tool")); !errors.Is(err, context.Canceled) {
+		t.Fatalf("tools/call error = %v, want context.Canceled", err)
+	}
+	if source.calls != 0 {
+		t.Fatalf("tool source calls = %d, want zero for canceled run", source.calls)
+	}
+}
+
+func TestValidateRuntimeGuardRejectsCancellationDuringGuard(t *testing.T) {
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	session := ToolSessionContext{RunContext: runCtx}
+	bound, cancelBound := BindRuntimeContext(context.Background(), session)
+	defer cancelBound()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		session.RuntimeGuard = func(context.Context) error {
+			close(started)
+			<-release
+			return nil
+		}
+		done <- ValidateRuntimeGuard(bound, session)
+	}()
+	<-started
+	cancelRun()
+	close(release)
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("runtime guard error = %v, want context.Canceled", err)
+	}
+}
 
 func TestToolGatewayMiddlewareScopesRuntimeToolCallsToActivePrompts(t *testing.T) {
 	provider := &gatewayTestProvider{
@@ -39,6 +115,26 @@ func TestToolGatewayMiddlewareScopesRuntimeToolCallsToActivePrompts(t *testing.T
 	}
 	if _, ok := result.(*sdkmcp.CallToolResult); !ok {
 		t.Fatalf("tools/call result = %#v", result)
+	}
+}
+
+func TestToolGatewayMiddlewareRestoresRuntimeFenceForToolCall(t *testing.T) {
+	want := runtimefence.Fence{BotID: "bot-1", SessionID: "session-1", Token: 19}
+	source := &fenceCapturingToolSource{}
+	service := NewToolGatewayService(nil, []ToolSource{source})
+	middleware := ToolGatewayMiddleware(service, nil, ToolSessionContext{
+		BotID:         want.BotID,
+		SessionID:     want.SessionID,
+		RuntimeID:     "rt-fenced",
+		RuntimeActive: true,
+		RuntimeFence:  want,
+	})(nil)
+
+	if _, err := middleware(context.Background(), "tools/call", callToolRequest("fenced_tool")); err != nil {
+		t.Fatalf("tools/call error = %v", err)
+	}
+	if source.fence != want {
+		t.Fatalf("tool call fence = %#v, want %#v", source.fence, want)
 	}
 }
 

--- a/internal/mcp/sources/federation/source.go
+++ b/internal/mcp/sources/federation/source.go
@@ -125,6 +125,9 @@ func (s *Source) CallTool(ctx context.Context, session mcpgw.ToolSessionContext,
 
 	callCtx, callCancel := context.WithTimeout(ctx, mcpCallTimeout)
 	defer callCancel()
+	if err := mcpgw.ValidateRuntimeGuard(callCtx, session); err != nil {
+		return nil, err
+	}
 
 	var (
 		payload map[string]any

--- a/internal/mcp/sources/federation/source_test.go
+++ b/internal/mcp/sources/federation/source_test.go
@@ -2,6 +2,7 @@ package federation
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -122,6 +123,31 @@ func TestSourceCallToolRoutesToSSEConnection(t *testing.T) {
 	}
 	if ok, _ := result["ok"].(bool); !ok {
 		t.Fatalf("expected ok=true in result")
+	}
+}
+
+func TestSourceCallToolRechecksRuntimeGuardBeforeFederatedEffect(t *testing.T) {
+	guardErr := errors.New("runtime ownership lost")
+	gateway := &testGateway{listSSE: []mcpgw.ToolDescriptor{{
+		Name: "search", InputSchema: map[string]any{"type": "object"},
+	}}}
+	lister := &testConnectionLister{items: []mcpgw.Connection{{
+		ID: "conn-guard", Name: "Remote SSE", Type: "sse", Active: true,
+		Config: map[string]any{"url": "http://example.com/sse"},
+	}}}
+	source := NewSource(slog.Default(), gateway, lister)
+	if _, err := source.ListTools(context.Background(), mcpgw.ToolSessionContext{BotID: "bot-1"}); err != nil {
+		t.Fatalf("prime routes: %v", err)
+	}
+
+	_, err := source.CallTool(context.Background(), mcpgw.ToolSessionContext{
+		BotID: "bot-1", RuntimeGuard: func(context.Context) error { return guardErr },
+	}, "remote_sse_search", nil)
+	if !errors.Is(err, guardErr) {
+		t.Fatalf("CallTool() error = %v, want runtime guard error", err)
+	}
+	if gateway.lastCallType != "" {
+		t.Fatalf("federated effect executed through %q after guard rejection", gateway.lastCallType)
 	}
 }
 

--- a/internal/mcp/tool_gateway_service.go
+++ b/internal/mcp/tool_gateway_service.go
@@ -93,6 +93,9 @@ func (s *ToolGatewayService) LookupTool(ctx context.Context, session ToolSession
 }
 
 func (s *ToolGatewayService) CallTool(ctx context.Context, session ToolSessionContext, payload ToolCallPayload) (map[string]any, error) {
+	ctx, cancel := BindRuntimeContext(ctx, session)
+	defer cancel()
+
 	toolName := strings.TrimSpace(payload.Name)
 	if toolName == "" {
 		return nil, errors.New("tool name is required")
@@ -117,6 +120,9 @@ func (s *ToolGatewayService) CallTool(ctx context.Context, session ToolSessionCo
 	arguments := payload.Arguments
 	if arguments == nil {
 		arguments = map[string]any{}
+	}
+	if err := ValidateRuntimeGuard(ctx, session); err != nil {
+		return nil, err
 	}
 	result, err := source.CallTool(ctx, session, toolName, arguments)
 	if err != nil {

--- a/internal/mcp/tool_session_store.go
+++ b/internal/mcp/tool_session_store.go
@@ -276,5 +276,14 @@ func MergeToolSessionContext(base, latest ToolSessionContext) ToolSessionContext
 	if latest.SupportsImageInput {
 		merged.SupportsImageInput = true
 	}
+	if latest.RuntimeFence.Valid() {
+		merged.RuntimeFence = latest.RuntimeFence
+	}
+	if latest.RunContext != nil {
+		merged.RunContext = latest.RunContext
+	}
+	if latest.RuntimeGuard != nil {
+		merged.RuntimeGuard = latest.RuntimeGuard
+	}
 	return merged
 }

--- a/internal/mcp/tool_session_store_test.go
+++ b/internal/mcp/tool_session_store_test.go
@@ -1,6 +1,9 @@
 package mcp
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestToolSessionContextStoreMergesLatestPromptContext(t *testing.T) {
 	store := NewToolSessionContextStore()
@@ -39,6 +42,17 @@ func TestToolSessionContextMergePreservesUserInputCapability(t *testing.T) {
 	merged := MergeToolSessionContext(base, ToolSessionContext{CanRequestUserInput: true})
 	if !merged.CanRequestUserInput {
 		t.Fatalf("CanRequestUserInput = false, want true")
+	}
+}
+
+func TestToolSessionContextMergePreservesRuntimeLifecycle(t *testing.T) {
+	runCtx := context.Background()
+	guard := func(context.Context) error { return nil }
+	merged := MergeToolSessionContext(ToolSessionContext{BotID: "bot-1"}, ToolSessionContext{
+		RunContext: runCtx, RuntimeGuard: guard,
+	})
+	if merged.RunContext != runCtx || merged.RuntimeGuard == nil {
+		t.Fatalf("runtime lifecycle = context:%v guard:%v", merged.RunContext, merged.RuntimeGuard != nil)
 	}
 }
 

--- a/internal/mcp/tool_types.go
+++ b/internal/mcp/tool_types.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
+
+	"github.com/memohai/memoh/internal/runtimefence"
 )
 
 // ToolSessionContext carries request-scoped identity for tool execution.
@@ -30,6 +33,63 @@ type ToolSessionContext struct {
 	IsSubagent          bool
 	RuntimeActive       bool
 	SupportsImageInput  bool
+	RuntimeFence        runtimefence.Fence          `json:"-"`
+	RunContext          context.Context             `json:"-"`
+	RuntimeGuard        func(context.Context) error `json:"-"`
+}
+
+const runtimeGuardTimeout = 5 * time.Second
+
+// BindRuntimeContext makes a tool request stop when its owning run stops.
+// Runtime-only values remain process-local and are never serialized.
+func BindRuntimeContext(ctx context.Context, session ToolSessionContext) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = runtimefence.WithContext(ctx, session.RuntimeFence)
+	if session.RunContext == nil {
+		return ctx, func() {}
+	}
+	bound, cancel := context.WithCancel(ctx)
+	stop := context.AfterFunc(session.RunContext, cancel)
+	if session.RunContext.Err() != nil {
+		cancel()
+	}
+	return bound, func() {
+		stop()
+		cancel()
+	}
+}
+
+// ValidateRuntimeGuard performs the last ownership check immediately before
+// a tool effect. The check remains bound to both the request and owning run.
+func ValidateRuntimeGuard(ctx context.Context, session ToolSessionContext) error {
+	if ctx == nil {
+		return errors.New("runtime guard context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if session.RunContext != nil {
+		if err := session.RunContext.Err(); err != nil {
+			return err
+		}
+	}
+	if session.RuntimeGuard == nil {
+		return nil
+	}
+	guardCtx, cancel := context.WithTimeout(ctx, runtimeGuardTimeout)
+	defer cancel()
+	guardCtx = runtimefence.WithContext(guardCtx, session.RuntimeFence)
+	if err := session.RuntimeGuard(guardCtx); err != nil {
+		return err
+	}
+	if session.RunContext != nil {
+		if err := session.RunContext.Err(); err != nil {
+			return err
+		}
+	}
+	return guardCtx.Err()
 }
 
 // ToolDescriptor is the MCP tools/list item shape used by the gateway.

--- a/internal/message/runtime_fence_postgres_integration_test.go
+++ b/internal/message/runtime_fence_postgres_integration_test.go
@@ -1,0 +1,383 @@
+package message
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dbpkg "github.com/memohai/memoh/internal/db"
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
+	"github.com/memohai/memoh/internal/runtimefence"
+)
+
+var (
+	runtimeFenceSchemaOnce sync.Once
+	runtimeFenceSchemaErr  error
+)
+
+func TestPostgresRuntimeFenceRejectsStaleRoundAndReplacement(t *testing.T) {
+	ctx := context.Background()
+	pool := openRuntimeFencePostgresPool(t, ctx)
+	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
+	queries := dbsqlc.New(pool)
+	service := NewService(nil, postgresstore.NewQueriesWithPool(pool, queries))
+
+	token1 := acquireRuntimeFenceToken(t, ctx, queries, botID, sessionID)
+	owner1 := runtimefence.WithContext(ctx, runtimefence.Fence{BotID: botID.String(), SessionID: sessionID.String(), Token: token1})
+	persisted, handled, err := service.PersistRound(owner1, []PersistInput{
+		{BotID: botID.String(), SessionID: sessionID.String(), Role: "user", Content: []byte(`{"role":"user","content":"hello"}`)},
+		{BotID: botID.String(), SessionID: sessionID.String(), Role: "assistant", Content: []byte(`{"role":"assistant","content":"owner one"}`)},
+	}, RoundPersistenceOptions{})
+	if err != nil || !handled || len(persisted) != 2 {
+		t.Fatalf("persist owner-one round = (%d, %v, %v), want (2, true, nil)", len(persisted), handled, err)
+	}
+	oldTurn, err := service.GetVisibleTurnByMessage(ctx, sessionID.String(), persisted[1].ID)
+	if err != nil {
+		t.Fatalf("load owner-one turn: %v", err)
+	}
+
+	token2 := acquireRuntimeFenceToken(t, ctx, queries, botID, sessionID)
+	owner2 := runtimefence.WithContext(ctx, runtimefence.Fence{BotID: botID.String(), SessionID: sessionID.String(), Token: token2})
+	var beforeFailedReplacement int
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM bot_history_messages WHERE session_id = $1", sessionID).Scan(&beforeFailedReplacement); err != nil {
+		t.Fatalf("count messages before failed replacement: %v", err)
+	}
+	_, handled, err = service.PersistRound(owner2, []PersistInput{{
+		BotID:           botID.String(),
+		SessionID:       sessionID.String(),
+		Role:            "assistant",
+		Content:         []byte(`{"role":"assistant","content":"must roll back"}`),
+		SkipHistoryTurn: true,
+	}}, RoundPersistenceOptions{Replacement: &TurnReplacement{
+		OldTurnID:        uuid.NewString(),
+		RequestMessageID: persisted[0].ID,
+		Reason:           "retry",
+	}})
+	if err == nil || !handled {
+		t.Fatalf("invalid atomic replacement = handled %v, error %v", handled, err)
+	}
+	var afterFailedReplacement int
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM bot_history_messages WHERE session_id = $1", sessionID).Scan(&afterFailedReplacement); err != nil {
+		t.Fatalf("count messages after failed replacement: %v", err)
+	}
+	if afterFailedReplacement != beforeFailedReplacement {
+		t.Fatalf("failed replacement left orphan messages: before=%d after=%d", beforeFailedReplacement, afterFailedReplacement)
+	}
+	replacement, handled, err := service.PersistRound(owner2, []PersistInput{{
+		BotID:           botID.String(),
+		SessionID:       sessionID.String(),
+		Role:            "assistant",
+		Content:         []byte(`{"role":"assistant","content":"owner two"}`),
+		SkipHistoryTurn: true,
+	}}, RoundPersistenceOptions{Replacement: &TurnReplacement{
+		OldTurnID:        oldTurn.ID,
+		RequestMessageID: persisted[0].ID,
+		Reason:           "retry",
+	}})
+	if err != nil || !handled || len(replacement) != 1 {
+		t.Fatalf("persist owner-two replacement = (%d, %v, %v), want (1, true, nil)", len(replacement), handled, err)
+	}
+
+	_, _, err = service.PersistRound(owner1, []PersistInput{{
+		BotID: botID.String(), SessionID: sessionID.String(), Role: "assistant",
+		Content: []byte(`{"role":"assistant","content":"stale"}`),
+	}}, RoundPersistenceOptions{})
+	if !errors.Is(err, runtimefence.ErrStale) {
+		t.Fatalf("stale PersistRound error = %v, want ErrStale", err)
+	}
+	if _, err := service.ReplaceTurn(owner1, sessionID.String(), oldTurn.ID, persisted[0].ID, replacement[0].ID, "retry"); !errors.Is(err, runtimefence.ErrStale) {
+		t.Fatalf("stale ReplaceTurn error = %v, want ErrStale", err)
+	}
+
+	visible, err := service.ListBySession(ctx, sessionID.String())
+	if err != nil {
+		t.Fatalf("list visible messages: %v", err)
+	}
+	if len(visible) != 2 || visible[0].ID != persisted[0].ID || visible[1].ID != replacement[0].ID {
+		t.Fatalf("visible messages changed after stale writes: %#v", visible)
+	}
+}
+
+func TestPostgresRuntimeFenceLockSerializesTokenAdvance(t *testing.T) {
+	ctx := context.Background()
+	pool := openRuntimeFencePostgresPool(t, ctx)
+	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
+	queries := dbsqlc.New(pool)
+	token1 := acquireRuntimeFenceToken(t, ctx, queries, botID, sessionID)
+	token2, err := queries.NextSessionRuntimeFenceToken(ctx)
+	if err != nil {
+		t.Fatalf("allocate owner-two fence: %v", err)
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin fence lock transaction: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := dbsqlc.New(tx).LockSessionRuntimeFence(ctx, dbsqlc.LockSessionRuntimeFenceParams{
+		SessionID:           sessionID,
+		BotID:               botID,
+		RuntimeFencingToken: token1,
+	}); err != nil {
+		t.Fatalf("lock owner-one fence: %v", err)
+	}
+
+	type activateResult struct {
+		token int64
+		err   error
+	}
+	resultCh := make(chan activateResult, 1)
+	go func() {
+		token, err := queries.ActivateSessionRuntimeFence(ctx, dbsqlc.ActivateSessionRuntimeFenceParams{SessionID: sessionID, BotID: botID, RuntimeFencingToken: token2})
+		resultCh <- activateResult{token: token, err: err}
+	}()
+	select {
+	case result := <-resultCh:
+		t.Fatalf("fence activated while persistence lock was held: %#v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit fence lock transaction: %v", err)
+	}
+	select {
+	case result := <-resultCh:
+		if result.err != nil || result.token != token2 {
+			t.Fatalf("fence activation after commit = %#v, want token %d", result, token2)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for fence advance after lock release")
+	}
+}
+
+func TestPostgresRuntimeFenceLockSerializesConcurrentWritersBeforeUpdate(t *testing.T) {
+	ctx := context.Background()
+	pool := openRuntimeFencePostgresPool(t, ctx)
+	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
+	queries := dbsqlc.New(pool)
+	token := acquireRuntimeFenceToken(t, ctx, queries, botID, sessionID)
+	params := dbsqlc.LockSessionRuntimeFenceParams{
+		SessionID:           sessionID,
+		BotID:               botID,
+		RuntimeFencingToken: token,
+	}
+
+	tx1, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin first writer: %v", err)
+	}
+	defer func() { _ = tx1.Rollback(ctx) }()
+	if _, err := dbsqlc.New(tx1).LockSessionRuntimeFence(ctx, params); err != nil {
+		t.Fatalf("lock first writer fence: %v", err)
+	}
+
+	type writerResult struct {
+		stage string
+		err   error
+	}
+	backendPID := make(chan int32, 1)
+	locked := make(chan writerResult, 1)
+	proceed := make(chan struct{})
+	done := make(chan writerResult, 1)
+	go func() {
+		tx2, err := pool.Begin(ctx)
+		if err != nil {
+			locked <- writerResult{stage: "begin", err: err}
+			return
+		}
+		defer func() { _ = tx2.Rollback(ctx) }()
+		var pid int32
+		if err := tx2.QueryRow(ctx, "SELECT pg_backend_pid()").Scan(&pid); err != nil {
+			locked <- writerResult{stage: "backend pid", err: err}
+			return
+		}
+		backendPID <- pid
+		if _, err := dbsqlc.New(tx2).LockSessionRuntimeFence(ctx, params); err != nil {
+			locked <- writerResult{stage: "lock", err: err}
+			return
+		}
+		locked <- writerResult{stage: "locked"}
+		<-proceed
+		if _, err := tx2.Exec(ctx, "UPDATE bot_sessions SET next_turn_position = next_turn_position + 1 WHERE id = $1", sessionID); err != nil {
+			done <- writerResult{stage: "update", err: err}
+			return
+		}
+		done <- writerResult{stage: "commit", err: tx2.Commit(ctx)}
+	}()
+
+	var pid int32
+	select {
+	case pid = <-backendPID:
+	case result := <-locked:
+		t.Fatalf("second writer failed before fence lock: %#v", result)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out starting second writer")
+	}
+	var early *writerResult
+	blocked := false
+	deadline := time.Now().Add(2 * time.Second)
+	for !blocked && early == nil && time.Now().Before(deadline) {
+		select {
+		case result := <-locked:
+			early = &result
+		default:
+			if err := pool.QueryRow(ctx, "SELECT COALESCE(wait_event_type = 'Lock', false) FROM pg_stat_activity WHERE pid = $1", pid).Scan(&blocked); err != nil {
+				t.Fatalf("inspect second writer lock wait: %v", err)
+			}
+			if !blocked {
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}
+	if early != nil {
+		_ = tx1.Rollback(ctx)
+		if early.stage == "locked" {
+			close(proceed)
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+			}
+		}
+		t.Fatalf("second writer passed fence lock before first writer committed: %#v", *early)
+	}
+	if !blocked {
+		_ = tx1.Rollback(ctx)
+		select {
+		case result := <-locked:
+			if result.stage == "locked" {
+				close(proceed)
+				select {
+				case <-done:
+				case <-time.After(2 * time.Second):
+				}
+			}
+		case <-time.After(2 * time.Second):
+		}
+		t.Fatal("second writer never reached the PostgreSQL fence lock wait")
+	}
+	if _, err := tx1.Exec(ctx, "UPDATE bot_sessions SET next_turn_position = next_turn_position + 1 WHERE id = $1", sessionID); err != nil {
+		t.Fatalf("update first writer: %v", err)
+	}
+	if err := tx1.Commit(ctx); err != nil {
+		t.Fatalf("commit first writer: %v", err)
+	}
+	select {
+	case result := <-locked:
+		if result.err != nil || result.stage != "locked" {
+			t.Fatalf("second writer lock after first commit = %#v", result)
+		}
+		close(proceed)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second writer fence lock")
+	}
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("second writer %s: %v", result.stage, result.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second writer commit")
+	}
+}
+
+func openRuntimeFencePostgresPool(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		if os.Getenv("MEMOH_TEST_POSTGRES_REQUIRED") == "1" {
+			t.Fatal("postgres runtime fence tests are required, but TEST_POSTGRES_DSN is not set")
+		}
+		t.Skip("skip postgres runtime fence test: TEST_POSTGRES_DSN is not set")
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		if os.Getenv("MEMOH_TEST_POSTGRES_REQUIRED") == "1" {
+			t.Fatalf("create required postgres pool: %v", err)
+		}
+		t.Skipf("skip postgres runtime fence test: cannot connect to database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		if os.Getenv("MEMOH_TEST_POSTGRES_REQUIRED") == "1" {
+			t.Fatalf("required postgres ping failed: %v", err)
+		}
+		t.Skipf("skip postgres runtime fence test: database ping failed: %v", err)
+	}
+	if os.Getenv("TEST_POSTGRES_BOOTSTRAP_SCHEMA") == "1" {
+		runtimeFenceSchemaOnce.Do(func() {
+			schema, readErr := os.ReadFile("../../db/postgres/migrations/0001_init.up.sql")
+			if readErr != nil {
+				runtimeFenceSchemaErr = fmt.Errorf("read canonical postgres schema: %w", readErr)
+				return
+			}
+			if _, execErr := pool.Exec(ctx, string(schema)); execErr != nil {
+				runtimeFenceSchemaErr = fmt.Errorf("apply canonical postgres schema: %w", execErr)
+			}
+		})
+		if runtimeFenceSchemaErr != nil {
+			t.Fatal(runtimeFenceSchemaErr)
+		}
+	}
+	migration, err := os.ReadFile("../../db/postgres/migrations/0106_session_runtime_fencing_token.up.sql")
+	if err != nil {
+		t.Fatalf("read runtime fence migration: %v", err)
+	}
+	if _, err := pool.Exec(ctx, string(migration)); err != nil {
+		t.Fatalf("apply runtime fence migration: %v", err)
+	}
+	return pool
+}
+
+func createRuntimeFenceFixtures(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (pgtype.UUID, pgtype.UUID) {
+	t.Helper()
+	userID := uuid.New()
+	botID := uuid.New()
+	sessionID := uuid.New()
+	name := fmt.Sprintf("runtime-fence-test-%s", uuid.NewString())
+	if _, err := pool.Exec(ctx, "INSERT INTO users (id, username, role, is_active) VALUES ($1, $2, 'admin', true)", userID, name); err != nil {
+		t.Fatalf("create runtime fence user: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "INSERT INTO bots (id, owner_user_id, type, name) VALUES ($1, $2, 'personal', $3)", botID, userID, name); err != nil {
+		t.Fatalf("create runtime fence bot: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "INSERT INTO bot_sessions (id, bot_id, channel_type) VALUES ($1, $2, 'local')", sessionID, botID); err != nil {
+		t.Fatalf("create runtime fence session: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM bots WHERE id = $1", botID)
+		_, _ = pool.Exec(ctx, "DELETE FROM users WHERE id = $1", userID)
+	})
+	pgBotID, err := dbpkg.ParseUUID(botID.String())
+	if err != nil {
+		t.Fatalf("parse runtime fence bot id: %v", err)
+	}
+	pgSessionID, err := dbpkg.ParseUUID(sessionID.String())
+	if err != nil {
+		t.Fatalf("parse runtime fence session id: %v", err)
+	}
+	return pgBotID, pgSessionID
+}
+
+func acquireRuntimeFenceToken(t *testing.T, ctx context.Context, queries *dbsqlc.Queries, botID, sessionID pgtype.UUID) int64 {
+	t.Helper()
+	token, err := queries.NextSessionRuntimeFenceToken(ctx)
+	if err != nil {
+		t.Fatalf("allocate runtime fence: %v", err)
+	}
+	activated, err := queries.ActivateSessionRuntimeFence(ctx, dbsqlc.ActivateSessionRuntimeFenceParams{SessionID: sessionID, BotID: botID, RuntimeFencingToken: token})
+	if err != nil {
+		t.Fatalf("activate runtime fence: %v", err)
+	}
+	if activated != token {
+		t.Fatalf("activated runtime fence = %d, want %d", activated, token)
+	}
+	return token
+}

--- a/internal/message/runtime_fence_postgres_integration_test.go
+++ b/internal/message/runtime_fence_postgres_integration_test.go
@@ -326,7 +326,7 @@ func openRuntimeFencePostgresPool(t *testing.T, ctx context.Context) *pgxpool.Po
 			t.Fatal(runtimeFenceSchemaErr)
 		}
 	}
-	migration, err := os.ReadFile("../../db/postgres/migrations/0106_session_runtime_fencing_token.up.sql")
+	migration, err := os.ReadFile("../../db/postgres/migrations/0107_session_runtime_fencing_token.up.sql")
 	if err != nil {
 		t.Fatalf("read runtime fence migration: %v", err)
 	}

--- a/internal/message/service.go
+++ b/internal/message/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/message/event"
+	"github.com/memohai/memoh/internal/runtimefence"
 )
 
 // DBService persists and reads bot history messages.
@@ -65,6 +66,10 @@ type transactionalQueries interface {
 	InTx(ctx context.Context, fn func(dbstore.Queries) error) error
 }
 
+type runtimeFencedSessionMetadataWriter interface {
+	UpdateSessionMetadataWithRuntimeFence(ctx context.Context, arg sqlc.UpdateSessionMetadataWithRuntimeFenceParams) (sqlc.BotSession, error)
+}
+
 // NewService creates a message service.
 func NewService(log *slog.Logger, queries dbstore.Queries, publishers ...event.Publisher) *DBService {
 	if log == nil {
@@ -102,6 +107,19 @@ func (s *DBService) Persist(ctx context.Context, input PersistInput) (Message, e
 }
 
 func (s *DBService) persistOnce(ctx context.Context, input PersistInput) (Message, error) {
+	if _, fenced := runtimefence.FromContext(ctx); fenced {
+		var result Message
+		if err := runtimefence.InTransaction(ctx, s.queries, input.BotID, input.SessionID, func(queries dbstore.Queries) error {
+			txService := *s
+			txService.queries = queries
+			var err error
+			result, err = txService.persist(ctx, input)
+			return err
+		}); err != nil {
+			return Message{}, err
+		}
+		return result, nil
+	}
 	if result, handled, err := s.persistDirectWithoutTx(ctx, input); handled || err != nil {
 		if err != nil {
 			return Message{}, err
@@ -243,6 +261,72 @@ func (s *DBService) PersistToolTailRound(ctx context.Context, inputs []PersistIn
 		s.publishMessageCreated(messages[i])
 	}
 	return messages, true, nil
+}
+
+// PersistRound writes all messages and history links under one PostgreSQL
+// transaction while holding the session's runtime fence lock.
+func (s *DBService) PersistRound(ctx context.Context, inputs []PersistInput, options RoundPersistenceOptions) ([]Message, bool, error) {
+	if s == nil || s.queries == nil || len(inputs) == 0 {
+		return nil, false, nil
+	}
+	if _, fenced := runtimefence.FromContext(ctx); !fenced {
+		return nil, false, nil
+	}
+	botID := strings.TrimSpace(inputs[0].BotID)
+	sessionID := strings.TrimSpace(inputs[0].SessionID)
+	if botID == "" || sessionID == "" {
+		return nil, true, errors.New("runtime-fenced round requires bot and session ids")
+	}
+	for _, input := range inputs[1:] {
+		if strings.TrimSpace(input.BotID) != botID || strings.TrimSpace(input.SessionID) != sessionID {
+			return nil, true, errors.New("runtime-fenced round spans multiple sessions")
+		}
+	}
+
+	const maxTurnSequenceRetries = 3
+	var lastErr error
+	for attempt := 0; attempt < maxTurnSequenceRetries; attempt++ {
+		persisted := make([]Message, 0, len(inputs))
+		err := runtimefence.InTransaction(ctx, s.queries, botID, sessionID, func(queries dbstore.Queries) error {
+			txService := *s
+			txService.queries = queries
+			txService.publisher = nil
+			turnRequestMessageID := strings.TrimSpace(inputs[0].TurnRequestMessageID)
+			for _, original := range inputs {
+				input := original
+				if !input.SkipHistoryTurn {
+					input.TurnRequestMessageID = turnRequestMessageID
+				}
+				message, err := txService.persist(ctx, input)
+				if err != nil {
+					return err
+				}
+				if strings.EqualFold(strings.TrimSpace(input.Role), "user") && !input.SkipHistoryTurn {
+					turnRequestMessageID = message.ID
+				}
+				persisted = append(persisted, message)
+			}
+			if options.Replacement != nil {
+				if err := txService.replacePersistedRound(ctx, sessionID, persisted, *options.Replacement); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err == nil {
+			for i, message := range persisted {
+				if !inputs[i].SkipHistoryTurn {
+					s.publishMessageCreated(message)
+				}
+			}
+			return persisted, true, nil
+		}
+		lastErr = err
+		if !isTurnSequenceUniqueViolation(err) {
+			return nil, true, err
+		}
+	}
+	return nil, true, lastErr
 }
 
 func isToolTailRoundShape(inputs []PersistInput) bool {
@@ -515,7 +599,7 @@ func (s *DBService) finishPersistedMessage(ctx context.Context, result Message, 
 			Name:        ref.Name,
 			Metadata:    marshalMetadata(ref.Metadata),
 		}); assetErr != nil {
-			s.logger.Warn("create message asset link failed", slog.String("message_id", result.ID), slog.Any("error", assetErr))
+			return Message{}, fmt.Errorf("create message asset link for %s: %w", result.ID, assetErr)
 		}
 	}
 
@@ -1110,28 +1194,93 @@ func (s *DBService) GetLatestVisibleTurnBySession(ctx context.Context, sessionID
 	return toHistoryTurn(row), nil
 }
 
-func (s *DBService) ReplaceTurn(ctx context.Context, sessionID string, oldTurnID string, requestMessageID string, assistantMessageID string, reason string) (HistoryTurn, error) {
+func (s *DBService) replacePersistedRound(ctx context.Context, sessionID string, persisted []Message, replacement TurnReplacement) error {
+	requestMessageID := strings.TrimSpace(replacement.RequestMessageID)
+	if requestMessageID == "" {
+		requestMessageID = firstPersistedRoleID(persisted, "user")
+	}
+	assistantMessageID := firstPersistedRoleID(persisted, "assistant")
+	if assistantMessageID == "" {
+		return errors.New("replacement assistant message was not persisted")
+	}
+	if _, err := replaceHistoryTurn(ctx, s.queries, sessionID, replacement.OldTurnID, requestMessageID, assistantMessageID, replacement.Reason); err != nil {
+		return fmt.Errorf("replace persisted history turn: %w", err)
+	}
+	if replacement.SessionMetadata == nil {
+		return nil
+	}
+	fence, ok := runtimefence.FromContext(ctx)
+	if !ok {
+		return errors.New("replacement metadata update requires a runtime fence")
+	}
+	writer, ok := s.queries.(runtimeFencedSessionMetadataWriter)
+	if !ok {
+		return errors.New("message store does not support fenced session metadata updates")
+	}
+	metadata, err := json.Marshal(replacement.SessionMetadata)
+	if err != nil {
+		return fmt.Errorf("marshal replacement session metadata: %w", err)
+	}
+	pgBotID, err := dbpkg.ParseUUID(fence.BotID)
+	if err != nil {
+		return err
+	}
+	pgSessionID, err := dbpkg.ParseUUID(fence.SessionID)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.UpdateSessionMetadataWithRuntimeFence(ctx, sqlc.UpdateSessionMetadataWithRuntimeFenceParams{
+		Metadata:            metadata,
+		ID:                  pgSessionID,
+		BotID:               pgBotID,
+		RuntimeFencingToken: fence.Token,
+	}); errors.Is(err, pgx.ErrNoRows) {
+		return runtimefence.ErrStale
+	} else if err != nil {
+		return fmt.Errorf("update replacement session metadata: %w", err)
+	}
+	return nil
+}
+
+func firstPersistedRoleID(messages []Message, role string) string {
+	for _, message := range messages {
+		if strings.EqualFold(strings.TrimSpace(message.Role), role) && strings.TrimSpace(message.ID) != "" {
+			return strings.TrimSpace(message.ID)
+		}
+	}
+	return ""
+}
+
+func replaceHistoryTurn(
+	ctx context.Context,
+	queries dbstore.Queries,
+	sessionID string,
+	oldTurnID string,
+	requestMessageID string,
+	assistantMessageID string,
+	reason string,
+) (sqlc.ReplaceHistoryTurnRow, error) {
 	pgSessionID, err := dbpkg.ParseUUID(sessionID)
 	if err != nil {
-		return HistoryTurn{}, err
+		return sqlc.ReplaceHistoryTurnRow{}, err
 	}
 	pgOldTurnID, err := dbpkg.ParseUUID(oldTurnID)
 	if err != nil {
-		return HistoryTurn{}, fmt.Errorf("invalid old turn id: %w", err)
+		return sqlc.ReplaceHistoryTurnRow{}, fmt.Errorf("invalid old turn id: %w", err)
 	}
 	pgRequestMessageID, err := parseOptionalUUID(requestMessageID)
 	if err != nil {
-		return HistoryTurn{}, fmt.Errorf("invalid request message id: %w", err)
+		return sqlc.ReplaceHistoryTurnRow{}, fmt.Errorf("invalid request message id: %w", err)
 	}
 	pgAssistantMessageID, err := parseOptionalUUID(assistantMessageID)
 	if err != nil {
-		return HistoryTurn{}, fmt.Errorf("invalid assistant message id: %w", err)
+		return sqlc.ReplaceHistoryTurnRow{}, fmt.Errorf("invalid assistant message id: %w", err)
 	}
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
 		reason = "replace"
 	}
-	row, err := s.queries.ReplaceHistoryTurn(ctx, sqlc.ReplaceHistoryTurnParams{
+	return queries.ReplaceHistoryTurn(ctx, sqlc.ReplaceHistoryTurnParams{
 		OldTurnID:          pgOldTurnID,
 		SessionID:          pgSessionID,
 		RequestMessageID:   pgRequestMessageID,
@@ -1139,6 +1288,19 @@ func (s *DBService) ReplaceTurn(ctx context.Context, sessionID string, oldTurnID
 		SupersededAt:       pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true},
 		SupersededReason:   pgtype.Text{String: reason, Valid: true},
 	})
+}
+
+func (s *DBService) ReplaceTurn(ctx context.Context, sessionID string, oldTurnID string, requestMessageID string, assistantMessageID string, reason string) (HistoryTurn, error) {
+	var row sqlc.ReplaceHistoryTurnRow
+	var err error
+	if _, fenced := runtimefence.FromContext(ctx); fenced {
+		err = runtimefence.InTransaction(ctx, s.queries, "", sessionID, func(queries dbstore.Queries) error {
+			row, err = replaceHistoryTurn(ctx, queries, sessionID, oldTurnID, requestMessageID, assistantMessageID, reason)
+			return err
+		})
+	} else {
+		row, err = replaceHistoryTurn(ctx, s.queries, sessionID, oldTurnID, requestMessageID, assistantMessageID, reason)
+	}
 	if err != nil {
 		return HistoryTurn{}, err
 	}
@@ -1151,30 +1313,49 @@ func (s *DBService) LinkAssets(ctx context.Context, messageID string, assets []A
 	if err != nil {
 		return fmt.Errorf("invalid message id: %w", err)
 	}
-	for _, ref := range assets {
-		contentHash := strings.TrimSpace(ref.ContentHash)
-		if contentHash == "" {
-			continue
+	link := func(queries dbstore.Queries) error {
+		if fence, fenced := runtimefence.FromContext(ctx); fenced {
+			pgSessionID, parseErr := dbpkg.ParseUUID(fence.SessionID)
+			if parseErr != nil {
+				return parseErr
+			}
+			row, loadErr := queries.GetMessageByIDBySession(ctx, sqlc.GetMessageByIDBySessionParams{SessionID: pgSessionID, MessageID: pgMsgID})
+			if loadErr != nil {
+				return loadErr
+			}
+			if row.BotID.String() != fence.BotID {
+				return runtimefence.ErrStale
+			}
 		}
-		role := ref.Role
-		if strings.TrimSpace(role) == "" {
-			role = "attachment"
+		for _, ref := range assets {
+			contentHash := strings.TrimSpace(ref.ContentHash)
+			if contentHash == "" {
+				continue
+			}
+			role := ref.Role
+			if strings.TrimSpace(role) == "" {
+				role = "attachment"
+			}
+			if ref.Ordinal < math.MinInt32 || ref.Ordinal > math.MaxInt32 {
+				return fmt.Errorf("asset ordinal out of range: %d", ref.Ordinal)
+			}
+			if _, assetErr := queries.CreateMessageAsset(ctx, sqlc.CreateMessageAssetParams{
+				MessageID:   pgMsgID,
+				Role:        role,
+				Ordinal:     int32(ref.Ordinal),
+				ContentHash: contentHash,
+				Name:        ref.Name,
+				Metadata:    marshalMetadata(ref.Metadata),
+			}); assetErr != nil {
+				return fmt.Errorf("link asset to message %s: %w", messageID, assetErr)
+			}
 		}
-		if ref.Ordinal < math.MinInt32 || ref.Ordinal > math.MaxInt32 {
-			return fmt.Errorf("asset ordinal out of range: %d", ref.Ordinal)
-		}
-		if _, assetErr := s.queries.CreateMessageAsset(ctx, sqlc.CreateMessageAssetParams{
-			MessageID:   pgMsgID,
-			Role:        role,
-			Ordinal:     int32(ref.Ordinal),
-			ContentHash: contentHash,
-			Name:        ref.Name,
-			Metadata:    marshalMetadata(ref.Metadata),
-		}); assetErr != nil {
-			s.logger.Warn("link asset failed", slog.String("message_id", messageID), slog.Any("error", assetErr))
-		}
+		return nil
 	}
-	return nil
+	if _, fenced := runtimefence.FromContext(ctx); fenced {
+		return runtimefence.InTransaction(ctx, s.queries, "", "", link)
+	}
+	return link(s.queries)
 }
 
 // DeleteByBot deletes all messages for a bot.

--- a/internal/message/types.go
+++ b/internal/message/types.go
@@ -110,6 +110,23 @@ type ToolTailRoundPersister interface {
 	PersistToolTailRound(ctx context.Context, inputs []PersistInput) ([]Message, bool, error)
 }
 
+type TurnReplacement struct {
+	OldTurnID        string
+	RequestMessageID string
+	Reason           string
+	SessionMetadata  map[string]any
+}
+
+type RoundPersistenceOptions struct {
+	Replacement *TurnReplacement
+}
+
+// AtomicRoundPersister writes a complete runtime round in one transaction.
+// Implementations must enforce any runtime fence carried by ctx.
+type AtomicRoundPersister interface {
+	PersistRound(ctx context.Context, inputs []PersistInput, options RoundPersistenceOptions) ([]Message, bool, error)
+}
+
 // Service defines message read/write behavior.
 type Service interface {
 	Writer

--- a/internal/runtimefence/fence.go
+++ b/internal/runtimefence/fence.go
@@ -1,0 +1,71 @@
+package runtimefence
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+var (
+	ErrStale                        = errors.New("session runtime persistence fence is stale")
+	ErrTransactionsUnsupported      = errors.New("session runtime persistence fencing requires real transactions")
+	ErrPreservedDecisionUnavailable = errors.New("preserved runtime decision is no longer pending")
+)
+
+// Fence identifies the PostgreSQL generation allowed to persist one runtime
+// run. A newer run increments Token and permanently invalidates older fences.
+type Fence struct {
+	BotID     string
+	SessionID string
+	Token     int64
+}
+
+const (
+	DecisionToolApproval = "tool_approval"
+	DecisionUserInput    = "user_input"
+)
+
+type PreservedDecision struct {
+	Kind string
+	ID   string
+}
+
+type ActivationOptions struct {
+	PreserveDecision *PreservedDecision
+}
+
+func (f Fence) Valid() bool {
+	return strings.TrimSpace(f.BotID) != "" && strings.TrimSpace(f.SessionID) != "" && f.Token > 0
+}
+
+type contextKey struct{}
+
+func WithContext(ctx context.Context, fence Fence) context.Context {
+	if ctx == nil || !fence.Valid() {
+		return ctx
+	}
+	fence.BotID = strings.TrimSpace(fence.BotID)
+	fence.SessionID = strings.TrimSpace(fence.SessionID)
+	return context.WithValue(ctx, contextKey{}, fence)
+}
+
+func FromContext(ctx context.Context) (Fence, bool) {
+	if ctx == nil {
+		return Fence{}, false
+	}
+	fence, ok := ctx.Value(contextKey{}).(Fence)
+	return fence, ok && fence.Valid()
+}
+
+// ValidateScope rejects a durable write that does not belong to the session
+// represented by the context fence. Unfenced contexts remain unchanged.
+func ValidateScope(ctx context.Context, botID, sessionID string) error {
+	fence, ok := FromContext(ctx)
+	if !ok {
+		return nil
+	}
+	if strings.TrimSpace(botID) != fence.BotID || strings.TrimSpace(sessionID) != fence.SessionID {
+		return ErrStale
+	}
+	return nil
+}

--- a/internal/runtimefence/fence_test.go
+++ b/internal/runtimefence/fence_test.go
@@ -1,0 +1,39 @@
+package runtimefence
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestContextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := Fence{BotID: " bot-1 ", SessionID: " session-1 ", Token: 3}
+	ctx := WithContext(context.Background(), want)
+	got, ok := FromContext(ctx)
+	if !ok {
+		t.Fatal("runtime fence missing from context")
+	}
+	if got.BotID != "bot-1" || got.SessionID != "session-1" || got.Token != want.Token {
+		t.Fatalf("runtime fence = %#v", got)
+	}
+}
+
+func TestInvalidFenceIsNotStored(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithContext(context.Background(), Fence{BotID: "bot-1", SessionID: "session-1"})
+	if _, ok := FromContext(ctx); ok {
+		t.Fatal("invalid runtime fence was stored")
+	}
+}
+
+func TestValidateScopeRejectsAnotherSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithContext(context.Background(), Fence{BotID: "bot-1", SessionID: "session-1", Token: 2})
+	if err := ValidateScope(ctx, "bot-1", "session-2"); !errors.Is(err, ErrStale) {
+		t.Fatalf("ValidateScope() error = %v, want ErrStale", err)
+	}
+}

--- a/internal/runtimefence/postgres.go
+++ b/internal/runtimefence/postgres.go
@@ -1,0 +1,339 @@
+package runtimefence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	dbpkg "github.com/memohai/memoh/internal/db"
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+)
+
+type transactionRunner interface {
+	InTx(ctx context.Context, fn func(dbstore.Queries) error) error
+}
+
+type transactionCapability interface {
+	SupportsTransactions() bool
+}
+
+type persistenceFenceLocker interface {
+	LockSessionRuntimeFence(ctx context.Context, arg sqlc.LockSessionRuntimeFenceParams) (int64, error)
+}
+
+type sessionWriteParentLocker interface {
+	LockBotForSessionWrite(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error)
+}
+
+type persistenceFenceActivationLocker interface {
+	LockSessionRuntimeFenceForActivation(ctx context.Context, arg sqlc.LockSessionRuntimeFenceForActivationParams) (int64, error)
+}
+
+type persistenceFenceActivator interface {
+	ActivateSessionRuntimeFence(ctx context.Context, arg sqlc.ActivateSessionRuntimeFenceParams) (int64, error)
+}
+
+type preservedToolApprovalClaimer interface {
+	ClaimToolApprovalRequestForRuntime(ctx context.Context, arg sqlc.ClaimToolApprovalRequestForRuntimeParams) (sqlc.ToolApprovalRequest, error)
+}
+
+type preservedUserInputClaimer interface {
+	ClaimUserInputRequestForRuntime(ctx context.Context, arg sqlc.ClaimUserInputRequestForRuntimeParams) (sqlc.UserInputRequest, error)
+}
+
+type pendingToolApprovalSuperseder interface {
+	SupersedePendingToolApprovalsBySession(ctx context.Context, arg sqlc.SupersedePendingToolApprovalsBySessionParams) ([]sqlc.ToolApprovalRequest, error)
+}
+
+type pendingUserInputSuperseder interface {
+	SupersedePendingUserInputsBySession(ctx context.Context, arg sqlc.SupersedePendingUserInputsBySessionParams) ([]sqlc.UserInputRequest, error)
+}
+
+// Activate is the persistence ownership cutover. Redis may already reserve the
+// successor as admitting, but a writer holding the previous token still
+// linearizes before this transaction if it acquired the session lock first.
+// Once activation commits, the previous token can never write again. Cleanup
+// uses later statements in the same transaction so it sees rows committed by a
+// writer that activation had to wait for.
+func Activate(ctx context.Context, queries dbstore.Queries, fence Fence) error {
+	return ActivateWithOptions(ctx, queries, fence, ActivationOptions{})
+}
+
+func ActivateWithOptions(ctx context.Context, queries dbstore.Queries, fence Fence, options ActivationOptions) error {
+	if !fence.Valid() {
+		return errors.New("runtime persistence fence is invalid")
+	}
+	txer, ok := queries.(transactionRunner)
+	if !ok {
+		return ErrTransactionsUnsupported
+	}
+	capability, ok := queries.(transactionCapability)
+	if !ok || !capability.SupportsTransactions() {
+		return ErrTransactionsUnsupported
+	}
+	pgBotID, err := dbpkg.ParseUUID(fence.BotID)
+	if err != nil {
+		return fmt.Errorf("invalid runtime fence bot id: %w", err)
+	}
+	pgSessionID, err := dbpkg.ParseUUID(fence.SessionID)
+	if err != nil {
+		return fmt.Errorf("invalid runtime fence session id: %w", err)
+	}
+	var preserveToolApprovalID, preserveUserInputID pgtype.UUID
+	if preserved := options.PreserveDecision; preserved != nil {
+		preserveID, parseErr := dbpkg.ParseUUID(preserved.ID)
+		if parseErr != nil {
+			return fmt.Errorf("invalid preserved runtime decision id: %w", parseErr)
+		}
+		switch strings.TrimSpace(preserved.Kind) {
+		case DecisionToolApproval:
+			preserveToolApprovalID = preserveID
+		case DecisionUserInput:
+			preserveUserInputID = preserveID
+		default:
+			return fmt.Errorf("unsupported preserved runtime decision kind %q", preserved.Kind)
+		}
+	}
+	inputResult, err := json.Marshal(map[string]any{
+		"status":      "canceled",
+		"reason":      "runtime_superseded",
+		"instruction": "The request was canceled because a newer runtime run took ownership.",
+	})
+	if err != nil {
+		return fmt.Errorf("encode superseded runtime input result: %w", err)
+	}
+
+	err = txer.InTx(ctx, func(txQueries dbstore.Queries) error {
+		if err := LockBotForSessionWrite(ctx, txQueries, fence.BotID); err != nil {
+			return err
+		}
+		locker, ok := txQueries.(persistenceFenceActivationLocker)
+		if !ok {
+			return errors.New("persistence store does not support runtime fence activation locking")
+		}
+		activator, ok := txQueries.(persistenceFenceActivator)
+		if !ok {
+			return errors.New("persistence store does not support runtime fence activation")
+		}
+		current, err := locker.LockSessionRuntimeFenceForActivation(ctx, sqlc.LockSessionRuntimeFenceForActivationParams{
+			SessionID: pgSessionID,
+			BotID:     pgBotID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrStale
+		}
+		if err != nil {
+			return fmt.Errorf("lock runtime fence for activation: %w", err)
+		}
+		switch {
+		case current > fence.Token:
+			return ErrStale
+		case current == fence.Token:
+			return nil
+		}
+		if preserved := options.PreserveDecision; preserved != nil {
+			if err := claimPreservedDecision(ctx, txQueries, *preserved, preserveToolApprovalID, preserveUserInputID, pgBotID, pgSessionID, fence.Token); err != nil {
+				return err
+			}
+		}
+		activated, err := activator.ActivateSessionRuntimeFence(ctx, sqlc.ActivateSessionRuntimeFenceParams{
+			SessionID:           pgSessionID,
+			BotID:               pgBotID,
+			RuntimeFencingToken: fence.Token,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrStale
+		}
+		if err != nil {
+			return fmt.Errorf("advance runtime persistence fence: %w", err)
+		}
+		if activated != fence.Token {
+			return ErrStale
+		}
+		toolSuperseder, ok := txQueries.(pendingToolApprovalSuperseder)
+		if !ok {
+			return errors.New("persistence store does not support superseding tool approvals")
+		}
+		if _, err := toolSuperseder.SupersedePendingToolApprovalsBySession(ctx, sqlc.SupersedePendingToolApprovalsBySessionParams{
+			Reason:     "tool approval cancelled: superseded by a newer runtime run",
+			BotID:      pgBotID,
+			SessionID:  pgSessionID,
+			PreserveID: preserveToolApprovalID,
+		}); err != nil {
+			return fmt.Errorf("cancel superseded tool approvals: %w", err)
+		}
+		userInputSuperseder, ok := txQueries.(pendingUserInputSuperseder)
+		if !ok {
+			return errors.New("persistence store does not support superseding user inputs")
+		}
+		if _, err := userInputSuperseder.SupersedePendingUserInputsBySession(ctx, sqlc.SupersedePendingUserInputsBySessionParams{
+			ResultJson: inputResult,
+			BotID:      pgBotID,
+			SessionID:  pgSessionID,
+			PreserveID: preserveUserInputID,
+		}); err != nil {
+			return fmt.Errorf("cancel superseded user inputs: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("activate runtime persistence fence: %w", err)
+	}
+	return nil
+}
+
+func claimPreservedDecision(
+	ctx context.Context,
+	queries dbstore.Queries,
+	preserved PreservedDecision,
+	toolApprovalID, userInputID, botID, sessionID pgtype.UUID,
+	token int64,
+) error {
+	claimToken := pgtype.Int8{Int64: token, Valid: true}
+	switch strings.TrimSpace(preserved.Kind) {
+	case DecisionToolApproval:
+		claimer, ok := queries.(preservedToolApprovalClaimer)
+		if !ok {
+			return errors.New("persistence store does not support runtime tool approval claims")
+		}
+		_, err := claimer.ClaimToolApprovalRequestForRuntime(ctx, sqlc.ClaimToolApprovalRequestForRuntimeParams{
+			RuntimeFencingToken: claimToken,
+			ID:                  toolApprovalID,
+			BotID:               botID,
+			SessionID:           sessionID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrPreservedDecisionUnavailable
+		}
+		if err != nil {
+			return fmt.Errorf("claim preserved tool approval: %w", err)
+		}
+	case DecisionUserInput:
+		claimer, ok := queries.(preservedUserInputClaimer)
+		if !ok {
+			return errors.New("persistence store does not support runtime user input claims")
+		}
+		_, err := claimer.ClaimUserInputRequestForRuntime(ctx, sqlc.ClaimUserInputRequestForRuntimeParams{
+			RuntimeFencingToken: claimToken,
+			ID:                  userInputID,
+			BotID:               botID,
+			SessionID:           sessionID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrPreservedDecisionUnavailable
+		}
+		if err != nil {
+			return fmt.Errorf("claim preserved user input: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported preserved runtime decision kind %q", preserved.Kind)
+	}
+	return nil
+}
+
+// InTransaction locks and validates the durable token in the same real
+// PostgreSQL transaction as fn. Redis admission reserves control ownership;
+// token activation is the linearization point for persistence ownership.
+func InTransaction(
+	ctx context.Context,
+	queries dbstore.Queries,
+	botID string,
+	sessionID string,
+	fn func(dbstore.Queries) error,
+) error {
+	if fn == nil {
+		return errors.New("runtime-fenced transaction callback is required")
+	}
+	fence, ok := FromContext(ctx)
+	if !ok {
+		return errors.New("runtime persistence fence is missing")
+	}
+	if strings.TrimSpace(botID) == "" {
+		botID = fence.BotID
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		sessionID = fence.SessionID
+	}
+	if err := ValidateScope(ctx, botID, sessionID); err != nil {
+		return err
+	}
+	txer, ok := queries.(transactionRunner)
+	if !ok {
+		return ErrTransactionsUnsupported
+	}
+	capability, ok := queries.(transactionCapability)
+	if !ok || !capability.SupportsTransactions() {
+		return ErrTransactionsUnsupported
+	}
+	return txer.InTx(ctx, func(txQueries dbstore.Queries) error {
+		if err := LockBotForSessionWrite(ctx, txQueries, botID); err != nil {
+			return err
+		}
+		if err := Lock(ctx, txQueries, botID, sessionID); err != nil {
+			return err
+		}
+		return fn(txQueries)
+	})
+}
+
+// LockBotForSessionWrite establishes parent-before-child lock ordering before
+// a transaction locks a session and writes rows that reference its bot.
+func LockBotForSessionWrite(ctx context.Context, queries dbstore.Queries, botID string) error {
+	locker, ok := queries.(sessionWriteParentLocker)
+	if !ok {
+		return errors.New("persistence store does not support bot parent locking")
+	}
+	pgBotID, err := dbpkg.ParseUUID(botID)
+	if err != nil {
+		return fmt.Errorf("invalid runtime fence bot id: %w", err)
+	}
+	if _, err := locker.LockBotForSessionWrite(ctx, pgBotID); errors.Is(err, pgx.ErrNoRows) {
+		return ErrStale
+	} else if err != nil {
+		return fmt.Errorf("lock runtime persistence bot: %w", err)
+	}
+	return nil
+}
+
+// Lock validates the current fence and serializes writers on the session row
+// until the caller's transaction ends. A successor cannot activate its token
+// until that write commits, and an older token cannot write after activation.
+func Lock(ctx context.Context, queries dbstore.Queries, botID, sessionID string) error {
+	fence, ok := FromContext(ctx)
+	if !ok {
+		return errors.New("runtime persistence fence is missing")
+	}
+	if err := ValidateScope(ctx, botID, sessionID); err != nil {
+		return err
+	}
+	locker, ok := queries.(persistenceFenceLocker)
+	if !ok {
+		return errors.New("persistence store does not support runtime fence locking")
+	}
+	pgBotID, err := dbpkg.ParseUUID(fence.BotID)
+	if err != nil {
+		return fmt.Errorf("invalid runtime fence bot id: %w", err)
+	}
+	pgSessionID, err := dbpkg.ParseUUID(fence.SessionID)
+	if err != nil {
+		return fmt.Errorf("invalid runtime fence session id: %w", err)
+	}
+	_, err = locker.LockSessionRuntimeFence(ctx, sqlc.LockSessionRuntimeFenceParams{
+		SessionID:           pgSessionID,
+		BotID:               pgBotID,
+		RuntimeFencingToken: fence.Token,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrStale
+	}
+	if err != nil {
+		return fmt.Errorf("lock runtime persistence fence: %w", err)
+	}
+	return nil
+}

--- a/internal/runtimefence/postgres_integration_test.go
+++ b/internal/runtimefence/postgres_integration_test.go
@@ -297,7 +297,7 @@ func openRuntimeFencePostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
 			t.Fatalf("bootstrap PostgreSQL schema: %v", runtimeFenceSchemaErr)
 		}
 	}
-	migration, err := os.ReadFile("../../db/postgres/migrations/0106_session_runtime_fencing_token.up.sql")
+	migration, err := os.ReadFile("../../db/postgres/migrations/0107_session_runtime_fencing_token.up.sql")
 	if err != nil {
 		t.Fatalf("read runtime fence migration: %v", err)
 	}

--- a/internal/runtimefence/postgres_integration_test.go
+++ b/internal/runtimefence/postgres_integration_test.go
@@ -1,0 +1,365 @@
+package runtimefence_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/runtimefence"
+	"github.com/memohai/memoh/internal/toolapproval"
+	"github.com/memohai/memoh/internal/userinput"
+)
+
+var (
+	runtimeFenceSchemaOnce sync.Once
+	runtimeFenceSchemaErr  error
+)
+
+func TestPostgresRuntimeFenceActivationLeavesUnfencedDecisionsAlone(t *testing.T) {
+	ctx := context.Background()
+	pool := openRuntimeFencePostgres(t, ctx)
+	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
+	store := postgresstore.NewQueriesWithPool(pool, dbsqlc.New(pool))
+	approvals := toolapproval.NewService(nil, store, nil)
+	inputs := userinput.NewService(nil, store)
+
+	approval, err := approvals.CreatePending(ctx, toolapproval.CreatePendingInput{
+		BotID: botID, SessionID: sessionID, ToolCallID: "unfenced-approval", ToolName: "write",
+		ToolInput: map[string]any{"path": "channel.txt"},
+	})
+	if err != nil {
+		t.Fatalf("create unfenced approval: %v", err)
+	}
+	input := createRuntimeFenceUserInput(t, ctx, inputs, botID, sessionID, "unfenced-input", nil)
+	fence := nextRuntimeFence(t, ctx, dbsqlc.New(pool), botID, sessionID)
+	if err := runtimefence.Activate(ctx, store, fence); err != nil {
+		t.Fatalf("activate runtime fence: %v", err)
+	}
+
+	gotApproval, err := approvals.Get(ctx, approval.ID)
+	if err != nil || gotApproval.Status != toolapproval.StatusPending {
+		t.Fatalf("unfenced approval after activation = (%#v, %v)", gotApproval, err)
+	}
+	gotInput, err := inputs.Get(ctx, input.ID)
+	if err != nil || gotInput.Status != userinput.StatusPending {
+		t.Fatalf("unfenced user input after activation = (%#v, %v)", gotInput, err)
+	}
+
+	ownerCtx := runtimefence.WithContext(ctx, fence)
+	runtimeApproval, err := approvals.CreatePending(ownerCtx, toolapproval.CreatePendingInput{
+		BotID: botID, SessionID: sessionID, ToolCallID: "fenced-approval", ToolName: "write",
+		ToolInput: map[string]any{"path": "runtime.txt"},
+	})
+	if err != nil {
+		t.Fatalf("create fenced approval: %v", err)
+	}
+	runtimeInput := createRuntimeFenceUserInput(t, ownerCtx, inputs, botID, sessionID, "fenced-input", nil)
+	nextFence := nextRuntimeFence(t, ctx, dbsqlc.New(pool), botID, sessionID)
+	if err := runtimefence.Activate(ctx, store, nextFence); err != nil {
+		t.Fatalf("activate successor runtime fence: %v", err)
+	}
+	if got, err := approvals.Get(ctx, runtimeApproval.ID); err != nil || got.Status != toolapproval.StatusCancelled {
+		t.Fatalf("fenced approval after takeover = (%#v, %v)", got, err)
+	}
+	if got, err := inputs.Get(ctx, runtimeInput.ID); err != nil || got.Status != userinput.StatusCanceled {
+		t.Fatalf("fenced user input after takeover = (%#v, %v)", got, err)
+	}
+	if got, err := approvals.Get(ctx, approval.ID); err != nil || got.Status != toolapproval.StatusPending {
+		t.Fatalf("unfenced approval after successor activation = (%#v, %v)", got, err)
+	}
+	if got, err := inputs.Get(ctx, input.ID); err != nil || got.Status != userinput.StatusPending {
+		t.Fatalf("unfenced input after successor activation = (%#v, %v)", got, err)
+	}
+}
+
+func TestPostgresRuntimeFenceSerializesToolApprovalShortIDs(t *testing.T) {
+	ctx := context.Background()
+	pool := openRuntimeFencePostgres(t, ctx)
+	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
+	approvals := toolapproval.NewService(nil, postgresstore.NewQueriesWithPool(pool, dbsqlc.New(pool)), nil)
+
+	const count = 16
+	start := make(chan struct{})
+	results := make(chan toolapproval.Request, count)
+	errs := make(chan error, count)
+	var workers sync.WaitGroup
+	workers.Add(count)
+	for i := 0; i < count; i++ {
+		i := i
+		go func() {
+			defer workers.Done()
+			<-start
+			request, err := approvals.CreatePending(ctx, toolapproval.CreatePendingInput{
+				BotID: botID, SessionID: sessionID, ToolCallID: fmt.Sprintf("parallel-approval-%02d", i), ToolName: "write",
+				ToolInput: map[string]any{"index": i},
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- request
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent approval creation: %v", err)
+		}
+	}
+	shortIDs := make([]int, 0, count)
+	for request := range results {
+		shortIDs = append(shortIDs, request.ShortID)
+	}
+	if len(shortIDs) != count {
+		t.Fatalf("created approvals = %d, want %d", len(shortIDs), count)
+	}
+	sort.Ints(shortIDs)
+	for i, shortID := range shortIDs {
+		if shortID != i+1 {
+			t.Fatalf("sorted short ids = %v, want contiguous 1..%d", shortIDs, count)
+		}
+	}
+}
+
+func TestPostgresRuntimeFenceLocksBotBeforeSessionWrites(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool := openRuntimeFencePostgres(t, ctx)
+	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
+	queries := dbsqlc.New(pool)
+	store := postgresstore.NewQueriesWithPool(pool, queries)
+	fence := nextRuntimeFence(t, ctx, queries, botID, sessionID)
+	if err := runtimefence.Activate(ctx, store, fence); err != nil {
+		t.Fatalf("activate runtime fence: %v", err)
+	}
+	ownerCtx := runtimefence.WithContext(ctx, fence)
+	botUUID := mustRuntimeFencePGUUID(t, botID)
+	sessionUUID := mustRuntimeFencePGUUID(t, sessionID)
+
+	writerLocked := make(chan struct{})
+	releaseWriter := make(chan struct{})
+	writerDone := make(chan error, 1)
+	go func() {
+		writerDone <- runtimefence.InTransaction(ownerCtx, store, botID, sessionID, func(txQueries dbstore.Queries) error {
+			close(writerLocked)
+			select {
+			case <-releaseWriter:
+			case <-ownerCtx.Done():
+				return ownerCtx.Err()
+			}
+			_, err := txQueries.CreateToolApprovalRequest(ownerCtx, dbsqlc.CreateToolApprovalRequestParams{
+				BotID: botUUID, SessionID: sessionUUID, ToolCallID: "parent-lock-order", ToolName: "write",
+				Operation: toolapproval.OperationWrite, ToolInput: []byte(`{}`),
+				RuntimeFencingToken: pgtype.Int8{Int64: fence.Token, Valid: true},
+			})
+			return err
+		})
+	}()
+	select {
+	case <-writerLocked:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for fenced writer locks")
+	}
+
+	deleteConn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire bot delete connection: %v", err)
+	}
+	defer deleteConn.Release()
+	var deletePID int32
+	if err := deleteConn.QueryRow(ctx, "SELECT pg_backend_pid()").Scan(&deletePID); err != nil {
+		t.Fatalf("load bot delete backend pid: %v", err)
+	}
+	deleteDone := make(chan error, 1)
+	go func() {
+		_, deleteErr := deleteConn.Exec(ctx, "DELETE FROM bots WHERE id = $1", botUUID)
+		deleteDone <- deleteErr
+	}()
+	waitForPostgresLockWait(t, ctx, pool, deletePID, deleteDone)
+	close(releaseWriter)
+	if err := <-writerDone; err != nil {
+		t.Fatalf("fenced child write: %v", err)
+	}
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("delete bot after fenced child write: %v", err)
+	}
+}
+
+func waitForPostgresLockWait(t *testing.T, ctx context.Context, pool *pgxpool.Pool, backendPID int32, done <-chan error) {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var waiting bool
+		if err := pool.QueryRow(ctx, `
+SELECT EXISTS (
+    SELECT 1
+    FROM pg_stat_activity
+    WHERE pid = $1 AND wait_event_type = 'Lock'
+)`, backendPID).Scan(&waiting); err != nil {
+			t.Fatalf("inspect bot delete lock wait: %v", err)
+		}
+		if waiting {
+			return
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("bot delete completed before waiting on the fenced writer: %v", err)
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for bot delete lock wait")
+		case <-ticker.C:
+		}
+	}
+}
+
+func TestPostgresRuntimeFenceClaimedInputRemainsRespondableAfterExpiry(t *testing.T) {
+	ctx := context.Background()
+	pool := openRuntimeFencePostgres(t, ctx)
+	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
+	queries := dbsqlc.New(pool)
+	store := postgresstore.NewQueriesWithPool(pool, queries)
+	inputs := userinput.NewService(nil, store)
+	expiresAt := time.Now().Add(250 * time.Millisecond)
+	target := createRuntimeFenceUserInput(t, ctx, inputs, botID, sessionID, "claimed-expiring-input", &expiresAt)
+	fence := nextRuntimeFence(t, ctx, queries, botID, sessionID)
+	if err := runtimefence.ActivateWithOptions(ctx, store, fence, runtimefence.ActivationOptions{
+		PreserveDecision: &runtimefence.PreservedDecision{Kind: runtimefence.DecisionUserInput, ID: target.ID},
+	}); err != nil {
+		t.Fatalf("claim expiring input: %v", err)
+	}
+	time.Sleep(time.Until(expiresAt) + 50*time.Millisecond)
+	ownerCtx := runtimefence.WithContext(ctx, fence)
+	resolved, err := inputs.ResolveTarget(ownerCtx, userinput.ResolveInput{
+		BotID: botID, SessionID: sessionID, ExplicitID: target.ID,
+	})
+	if err != nil || resolved.ID != target.ID {
+		t.Fatalf("resolve claimed expired input = (%#v, %v)", resolved, err)
+	}
+	question := target.UIPayload.Questions[0]
+	option := question.Options[0]
+	submitted, err := inputs.Submit(ownerCtx, userinput.SubmitInput{
+		RequestID: target.ID,
+		Answers:   []userinput.QuestionAnswer{{QuestionID: question.ID, OptionIDs: []string{option.ID}}},
+	})
+	if err != nil || submitted.Status != userinput.StatusSubmitted {
+		t.Fatalf("submit claimed expired input = (%#v, %v)", submitted, err)
+	}
+	if _, err := inputs.ResolveTarget(ctx, userinput.ResolveInput{
+		BotID: botID, SessionID: sessionID, ExplicitID: target.ID,
+	}); !errors.Is(err, userinput.ErrNotFound) {
+		t.Fatalf("resolved input remains respondable without fence: %v", err)
+	}
+}
+
+func openRuntimeFencePostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	dsn := strings.TrimSpace(os.Getenv("TEST_POSTGRES_DSN"))
+	if dsn == "" {
+		if os.Getenv("MEMOH_TEST_POSTGRES_REQUIRED") == "1" {
+			t.Fatal("PostgreSQL runtime fencing contracts are required, but TEST_POSTGRES_DSN is not set")
+		}
+		t.Skip("set TEST_POSTGRES_DSN to run PostgreSQL runtime fencing contracts")
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("create PostgreSQL pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("ping PostgreSQL: %v", err)
+	}
+	if os.Getenv("TEST_POSTGRES_BOOTSTRAP_SCHEMA") == "1" {
+		runtimeFenceSchemaOnce.Do(func() {
+			schema, readErr := os.ReadFile("../../db/postgres/migrations/0001_init.up.sql")
+			if readErr != nil {
+				runtimeFenceSchemaErr = readErr
+				return
+			}
+			_, runtimeFenceSchemaErr = pool.Exec(ctx, string(schema))
+		})
+		if runtimeFenceSchemaErr != nil {
+			t.Fatalf("bootstrap PostgreSQL schema: %v", runtimeFenceSchemaErr)
+		}
+	}
+	migration, err := os.ReadFile("../../db/postgres/migrations/0106_session_runtime_fencing_token.up.sql")
+	if err != nil {
+		t.Fatalf("read runtime fence migration: %v", err)
+	}
+	if _, err := pool.Exec(ctx, string(migration)); err != nil {
+		t.Fatalf("apply runtime fence migration: %v", err)
+	}
+	return pool
+}
+
+func createRuntimeFenceFixtures(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (string, string) {
+	t.Helper()
+	userID := uuid.New()
+	botID := uuid.New()
+	sessionID := uuid.New()
+	name := "rtf-" + uuid.NewString()[:12]
+	if _, err := pool.Exec(ctx, "INSERT INTO users (id, username, role, is_active) VALUES ($1, $2, 'admin', true)", userID, name); err != nil {
+		t.Fatalf("create user fixture: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "INSERT INTO bots (id, owner_user_id, type, name) VALUES ($1, $2, 'personal', $3)", botID, userID, name); err != nil {
+		t.Fatalf("create bot fixture: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "INSERT INTO bot_sessions (id, bot_id, channel_type) VALUES ($1, $2, 'local')", sessionID, botID); err != nil {
+		t.Fatalf("create session fixture: %v", err)
+	}
+	cleanupCtx := context.WithoutCancel(ctx)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(cleanupCtx, "DELETE FROM bots WHERE id = $1", botID)
+		_, _ = pool.Exec(cleanupCtx, "DELETE FROM users WHERE id = $1", userID)
+	})
+	return botID.String(), sessionID.String()
+}
+
+func mustRuntimeFencePGUUID(t *testing.T, value string) pgtype.UUID {
+	t.Helper()
+	var id pgtype.UUID
+	if err := id.Scan(value); err != nil {
+		t.Fatalf("parse UUID %q: %v", value, err)
+	}
+	return id
+}
+
+func nextRuntimeFence(t *testing.T, ctx context.Context, queries *dbsqlc.Queries, botID, sessionID string) runtimefence.Fence {
+	t.Helper()
+	token, err := queries.NextSessionRuntimeFenceToken(ctx)
+	if err != nil {
+		t.Fatalf("allocate runtime fence token: %v", err)
+	}
+	return runtimefence.Fence{BotID: botID, SessionID: sessionID, Token: token}
+}
+
+func createRuntimeFenceUserInput(t *testing.T, ctx context.Context, inputs *userinput.Service, botID, sessionID, callID string, expiresAt *time.Time) userinput.Request {
+	t.Helper()
+	request, err := inputs.CreatePending(ctx, userinput.CreatePendingInput{
+		BotID: botID, SessionID: sessionID, ToolCallID: callID, ToolName: userinput.ToolNameAskUser,
+		Input: map[string]any{"questions": []any{map[string]any{
+			"text": "Continue?", "kind": userinput.QuestionKindSingleSelect,
+			"options": []any{map[string]any{"label": "Yes"}, map[string]any{"label": "No"}},
+		}}},
+		ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		t.Fatalf("create user input: %v", err)
+	}
+	return request
+}

--- a/internal/runtimefence/postgres_test.go
+++ b/internal/runtimefence/postgres_test.go
@@ -1,0 +1,242 @@
+package runtimefence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+)
+
+const (
+	testBotID     = "11111111-1111-1111-1111-111111111111"
+	testSessionID = "22222222-2222-2222-2222-222222222222"
+)
+
+type transactionTestQueries struct {
+	dbstore.Queries
+	supportsTransactions bool
+	lockErr              error
+	inTransaction        bool
+	lockCalled           bool
+	parentLockCalled     bool
+}
+
+type activationTestQueries struct {
+	dbstore.Queries
+	current              int64
+	toolApprovalCancel   sqlc.SupersedePendingToolApprovalsBySessionParams
+	userInputCancel      sqlc.SupersedePendingUserInputsBySessionParams
+	toolApprovalCanceled bool
+	userInputCanceled    bool
+	toolApprovalClaimed  bool
+	userInputClaimed     bool
+	toolApprovalClaim    sqlc.ClaimToolApprovalRequestForRuntimeParams
+	userInputClaim       sqlc.ClaimUserInputRequestForRuntimeParams
+	preservedApproval    sqlc.ToolApprovalRequest
+	preservedInput       sqlc.UserInputRequest
+	parentLockCalled     bool
+}
+
+func (*activationTestQueries) SupportsTransactions() bool { return true }
+
+func (q *activationTestQueries) InTx(_ context.Context, fn func(dbstore.Queries) error) error {
+	return fn(q)
+}
+
+func (q *activationTestQueries) LockBotForSessionWrite(_ context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	q.parentLockCalled = true
+	return id, nil
+}
+
+func (q *activationTestQueries) LockSessionRuntimeFenceForActivation(context.Context, sqlc.LockSessionRuntimeFenceForActivationParams) (int64, error) {
+	if !q.parentLockCalled {
+		return 0, errors.New("session lock acquired before bot parent lock")
+	}
+	return q.current, nil
+}
+
+func (q *activationTestQueries) ActivateSessionRuntimeFence(_ context.Context, arg sqlc.ActivateSessionRuntimeFenceParams) (int64, error) {
+	q.current = arg.RuntimeFencingToken
+	return q.current, nil
+}
+
+func (q *activationTestQueries) SupersedePendingToolApprovalsBySession(_ context.Context, arg sqlc.SupersedePendingToolApprovalsBySessionParams) ([]sqlc.ToolApprovalRequest, error) {
+	q.toolApprovalCancel = arg
+	q.toolApprovalCanceled = true
+	return nil, nil
+}
+
+func (q *activationTestQueries) SupersedePendingUserInputsBySession(_ context.Context, arg sqlc.SupersedePendingUserInputsBySessionParams) ([]sqlc.UserInputRequest, error) {
+	q.userInputCancel = arg
+	q.userInputCanceled = true
+	return nil, nil
+}
+
+func (q *activationTestQueries) ClaimToolApprovalRequestForRuntime(_ context.Context, arg sqlc.ClaimToolApprovalRequestForRuntimeParams) (sqlc.ToolApprovalRequest, error) {
+	q.toolApprovalClaimed = true
+	q.toolApprovalClaim = arg
+	return q.preservedApproval, nil
+}
+
+func (q *activationTestQueries) ClaimUserInputRequestForRuntime(_ context.Context, arg sqlc.ClaimUserInputRequestForRuntimeParams) (sqlc.UserInputRequest, error) {
+	q.userInputClaimed = true
+	q.userInputClaim = arg
+	return q.preservedInput, nil
+}
+
+func (q *transactionTestQueries) SupportsTransactions() bool {
+	return q.supportsTransactions
+}
+
+func (q *transactionTestQueries) InTx(_ context.Context, fn func(dbstore.Queries) error) error {
+	q.inTransaction = true
+	return fn(q)
+}
+
+func (q *transactionTestQueries) LockBotForSessionWrite(_ context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	q.parentLockCalled = true
+	return id, nil
+}
+
+func (q *transactionTestQueries) LockSessionRuntimeFence(_ context.Context, arg sqlc.LockSessionRuntimeFenceParams) (int64, error) {
+	if !q.parentLockCalled {
+		return 0, errors.New("session lock acquired before bot parent lock")
+	}
+	q.lockCalled = true
+	if arg.RuntimeFencingToken != 7 {
+		return 0, errors.New("unexpected token")
+	}
+	if q.lockErr != nil {
+		return 0, q.lockErr
+	}
+	return arg.RuntimeFencingToken, nil
+}
+
+func TestInTransactionRequiresRealTransactionCapability(t *testing.T) {
+	t.Parallel()
+
+	queries := &transactionTestQueries{}
+	ctx := WithContext(context.Background(), Fence{BotID: testBotID, SessionID: testSessionID, Token: 7})
+	called := false
+	err := InTransaction(ctx, queries, testBotID, testSessionID, func(dbstore.Queries) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, ErrTransactionsUnsupported) {
+		t.Fatalf("InTransaction() error = %v, want ErrTransactionsUnsupported", err)
+	}
+	if called || queries.inTransaction || queries.lockCalled {
+		t.Fatal("unsupported transaction store executed fenced write")
+	}
+}
+
+func TestInTransactionLocksFenceBeforeCallback(t *testing.T) {
+	t.Parallel()
+
+	queries := &transactionTestQueries{supportsTransactions: true}
+	ctx := WithContext(context.Background(), Fence{BotID: testBotID, SessionID: testSessionID, Token: 7})
+	called := false
+	err := InTransaction(ctx, queries, testBotID, testSessionID, func(got dbstore.Queries) error {
+		called = true
+		if got != queries || !queries.lockCalled {
+			t.Fatal("callback ran before the fence lock")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("InTransaction() error = %v", err)
+	}
+	if !called || !queries.inTransaction {
+		t.Fatal("fenced transaction callback did not run")
+	}
+}
+
+func TestInTransactionMapsMissingFenceRowToStale(t *testing.T) {
+	t.Parallel()
+
+	queries := &transactionTestQueries{supportsTransactions: true, lockErr: pgx.ErrNoRows}
+	ctx := WithContext(context.Background(), Fence{BotID: testBotID, SessionID: testSessionID, Token: 7})
+	err := InTransaction(ctx, queries, testBotID, testSessionID, func(dbstore.Queries) error {
+		t.Fatal("stale fence executed callback")
+		return nil
+	})
+	if !errors.Is(err, ErrStale) {
+		t.Fatalf("InTransaction() error = %v, want ErrStale", err)
+	}
+}
+
+func TestActivateWithOptionsPreservesOnlyTheSelectedDecisionKind(t *testing.T) {
+	t.Parallel()
+
+	const decisionID = "33333333-3333-3333-3333-333333333333"
+	tests := []struct {
+		name               string
+		kind               string
+		wantToolPreserved  bool
+		wantInputPreserved bool
+	}{
+		{name: "tool approval", kind: DecisionToolApproval, wantToolPreserved: true},
+		{name: "user input", kind: DecisionUserInput, wantInputPreserved: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			queries := &activationTestQueries{
+				current: 6,
+				preservedApproval: sqlc.ToolApprovalRequest{
+					BotID: mustTestUUID(t, testBotID), SessionID: mustTestUUID(t, testSessionID), Status: "pending",
+				},
+				preservedInput: sqlc.UserInputRequest{
+					BotID: mustTestUUID(t, testBotID), SessionID: mustTestUUID(t, testSessionID), Status: "pending",
+				},
+			}
+			err := ActivateWithOptions(context.Background(), queries, Fence{
+				BotID: testBotID, SessionID: testSessionID, Token: 7,
+			}, ActivationOptions{PreserveDecision: &PreservedDecision{Kind: tt.kind, ID: decisionID}})
+			if err != nil {
+				t.Fatalf("ActivateWithOptions() error = %v", err)
+			}
+			if !queries.toolApprovalCanceled || !queries.userInputCanceled {
+				t.Fatal("activation did not run both superseded-decision cleanup queries")
+			}
+			if queries.toolApprovalCancel.PreserveID.Valid != tt.wantToolPreserved {
+				t.Fatalf("tool approval preserve id valid = %v, want %v", queries.toolApprovalCancel.PreserveID.Valid, tt.wantToolPreserved)
+			}
+			if queries.userInputCancel.PreserveID.Valid != tt.wantInputPreserved {
+				t.Fatalf("user input preserve id valid = %v, want %v", queries.userInputCancel.PreserveID.Valid, tt.wantInputPreserved)
+			}
+			if queries.toolApprovalClaimed != tt.wantToolPreserved {
+				t.Fatalf("tool approval claimed = %v, want %v", queries.toolApprovalClaimed, tt.wantToolPreserved)
+			}
+			if queries.userInputClaimed != tt.wantInputPreserved {
+				t.Fatalf("user input claimed = %v, want %v", queries.userInputClaimed, tt.wantInputPreserved)
+			}
+			if tt.wantToolPreserved && queries.toolApprovalCancel.PreserveID.String() != decisionID {
+				t.Fatalf("tool approval preserve id = %q", queries.toolApprovalCancel.PreserveID.String())
+			}
+			if tt.wantInputPreserved && queries.userInputCancel.PreserveID.String() != decisionID {
+				t.Fatalf("user input preserve id = %q", queries.userInputCancel.PreserveID.String())
+			}
+			if tt.wantToolPreserved && (!queries.toolApprovalClaim.RuntimeFencingToken.Valid || queries.toolApprovalClaim.RuntimeFencingToken.Int64 != 7) {
+				t.Fatalf("tool approval claim token = %#v", queries.toolApprovalClaim.RuntimeFencingToken)
+			}
+			if tt.wantInputPreserved && (!queries.userInputClaim.RuntimeFencingToken.Valid || queries.userInputClaim.RuntimeFencingToken.Int64 != 7) {
+				t.Fatalf("user input claim token = %#v", queries.userInputClaim.RuntimeFencingToken)
+			}
+		})
+	}
+}
+
+func mustTestUUID(t *testing.T, value string) pgtype.UUID {
+	t.Helper()
+	var id pgtype.UUID
+	if err := id.Scan(value); err != nil {
+		t.Fatalf("parse UUID %q: %v", value, err)
+	}
+	return id
+}

--- a/internal/session/runtime_fence_test.go
+++ b/internal/session/runtime_fence_test.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/runtimefence"
+)
+
+type runtimeFenceSessionQueries struct {
+	dbstore.Queries
+	titleParams    *dbsqlc.UpdateSessionTitleWithRuntimeFenceParams
+	metadataParams *dbsqlc.UpdateSessionMetadataWithRuntimeFenceParams
+	err            error
+}
+
+func (q *runtimeFenceSessionQueries) UpdateSessionTitleWithRuntimeFence(_ context.Context, arg dbsqlc.UpdateSessionTitleWithRuntimeFenceParams) (dbsqlc.BotSession, error) {
+	q.titleParams = &arg
+	return runtimeFenceSessionRow(arg.ID, arg.BotID), q.err
+}
+
+func (q *runtimeFenceSessionQueries) UpdateSessionMetadataWithRuntimeFence(_ context.Context, arg dbsqlc.UpdateSessionMetadataWithRuntimeFenceParams) (dbsqlc.BotSession, error) {
+	q.metadataParams = &arg
+	return runtimeFenceSessionRow(arg.ID, arg.BotID), q.err
+}
+
+func TestSessionUpdatesUseRuntimeFence(t *testing.T) {
+	t.Parallel()
+
+	const (
+		botID     = "11111111-1111-1111-1111-111111111111"
+		sessionID = "22222222-2222-2222-2222-222222222222"
+	)
+	queries := &runtimeFenceSessionQueries{}
+	service := NewService(nil, queries, nil)
+	ctx := runtimefence.WithContext(context.Background(), runtimefence.Fence{BotID: botID, SessionID: sessionID, Token: 9})
+
+	if _, err := service.UpdateTitle(ctx, sessionID, "fenced title"); err != nil {
+		t.Fatalf("UpdateTitle() error = %v", err)
+	}
+	if _, err := service.UpdateMetadata(ctx, sessionID, map[string]any{"fenced": true}); err != nil {
+		t.Fatalf("UpdateMetadata() error = %v", err)
+	}
+	if queries.titleParams == nil || queries.titleParams.RuntimeFencingToken != 9 {
+		t.Fatalf("title fence params = %#v", queries.titleParams)
+	}
+	if queries.metadataParams == nil || queries.metadataParams.RuntimeFencingToken != 9 {
+		t.Fatalf("metadata fence params = %#v", queries.metadataParams)
+	}
+}
+
+func TestSessionUpdateMapsMissingFenceToStale(t *testing.T) {
+	t.Parallel()
+
+	const (
+		botID     = "11111111-1111-1111-1111-111111111111"
+		sessionID = "22222222-2222-2222-2222-222222222222"
+	)
+	queries := &runtimeFenceSessionQueries{err: pgx.ErrNoRows}
+	service := NewService(nil, queries, nil)
+	ctx := runtimefence.WithContext(context.Background(), runtimefence.Fence{BotID: botID, SessionID: sessionID, Token: 3})
+
+	if _, err := service.UpdateMetadata(ctx, sessionID, map[string]any{}); !errors.Is(err, runtimefence.ErrStale) {
+		t.Fatalf("UpdateMetadata() error = %v, want ErrStale", err)
+	}
+}
+
+func runtimeFenceSessionRow(sessionID, botID pgtype.UUID) dbsqlc.BotSession {
+	return dbsqlc.BotSession{
+		ID:              sessionID,
+		BotID:           botID,
+		Type:            TypeChat,
+		SessionMode:     TypeChat,
+		RuntimeType:     RuntimeModel,
+		RuntimeMetadata: []byte(`{}`),
+		Metadata:        []byte(`{}`),
+	}
+}

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -20,7 +20,13 @@ import (
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/hooks"
 	"github.com/memohai/memoh/internal/message/event"
+	"github.com/memohai/memoh/internal/runtimefence"
 )
+
+type runtimeFencedSessionWriter interface {
+	UpdateSessionTitleWithRuntimeFence(ctx context.Context, arg sqlc.UpdateSessionTitleWithRuntimeFenceParams) (sqlc.BotSession, error)
+	UpdateSessionMetadataWithRuntimeFence(ctx context.Context, arg sqlc.UpdateSessionMetadataWithRuntimeFenceParams) (sqlc.BotSession, error)
+}
 
 // Session represents a chat session within a bot.
 type Session struct {
@@ -743,10 +749,34 @@ func (s *Service) UpdateTitle(ctx context.Context, sessionID, title string) (Ses
 	if err != nil {
 		return Session{}, fmt.Errorf("invalid session id: %w", err)
 	}
-	row, err := s.queries.UpdateSessionTitle(ctx, sqlc.UpdateSessionTitleParams{
-		ID:    pgID,
-		Title: title,
-	})
+	var row sqlc.BotSession
+	if fence, fenced := runtimefence.FromContext(ctx); fenced {
+		if strings.TrimSpace(sessionID) != fence.SessionID {
+			return Session{}, runtimefence.ErrStale
+		}
+		writer, ok := s.queries.(runtimeFencedSessionWriter)
+		if !ok {
+			return Session{}, errors.New("session store does not support runtime fencing")
+		}
+		pgBotID, parseErr := dbpkg.ParseUUID(fence.BotID)
+		if parseErr != nil {
+			return Session{}, fmt.Errorf("invalid runtime fence bot id: %w", parseErr)
+		}
+		row, err = writer.UpdateSessionTitleWithRuntimeFence(ctx, sqlc.UpdateSessionTitleWithRuntimeFenceParams{
+			Title:               title,
+			ID:                  pgID,
+			BotID:               pgBotID,
+			RuntimeFencingToken: fence.Token,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Session{}, runtimefence.ErrStale
+		}
+	} else {
+		row, err = s.queries.UpdateSessionTitle(ctx, sqlc.UpdateSessionTitleParams{
+			ID:    pgID,
+			Title: title,
+		})
+	}
 	if err != nil {
 		return Session{}, err
 	}
@@ -766,10 +796,34 @@ func (s *Service) UpdateMetadata(ctx context.Context, sessionID string, metadata
 	if err != nil {
 		return Session{}, fmt.Errorf("marshal metadata: %w", err)
 	}
-	row, err := s.queries.UpdateSessionMetadata(ctx, sqlc.UpdateSessionMetadataParams{
-		ID:       pgID,
-		Metadata: metaBytes,
-	})
+	var row sqlc.BotSession
+	if fence, fenced := runtimefence.FromContext(ctx); fenced {
+		if strings.TrimSpace(sessionID) != fence.SessionID {
+			return Session{}, runtimefence.ErrStale
+		}
+		writer, ok := s.queries.(runtimeFencedSessionWriter)
+		if !ok {
+			return Session{}, errors.New("session store does not support runtime fencing")
+		}
+		pgBotID, parseErr := dbpkg.ParseUUID(fence.BotID)
+		if parseErr != nil {
+			return Session{}, fmt.Errorf("invalid runtime fence bot id: %w", parseErr)
+		}
+		row, err = writer.UpdateSessionMetadataWithRuntimeFence(ctx, sqlc.UpdateSessionMetadataWithRuntimeFenceParams{
+			Metadata:            metaBytes,
+			ID:                  pgID,
+			BotID:               pgBotID,
+			RuntimeFencingToken: fence.Token,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Session{}, runtimefence.ErrStale
+		}
+	} else {
+		row, err = s.queries.UpdateSessionMetadata(ctx, sqlc.UpdateSessionMetadataParams{
+			ID:       pgID,
+			Metadata: metaBytes,
+		})
+	}
 	if err != nil {
 		return Session{}, err
 	}

--- a/internal/sessionruntime/commands.go
+++ b/internal/sessionruntime/commands.go
@@ -2,6 +2,7 @@ package sessionruntime
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -20,7 +21,11 @@ func (m *Manager) StreamRef(ctx context.Context, streamID string) (StreamRef, bo
 		return StreamRef{}, false, nil
 	}
 	if ctrl := m.localControl(streamID); ctrl != nil {
-		return StreamRef{BotID: ctrl.botID, SessionID: ctrl.sessionID, StreamID: ctrl.streamID}, true, nil
+		ownerID := ""
+		if m.distributed != nil {
+			ownerID = m.ownerID
+		}
+		return StreamRef{BotID: ctrl.botID, SessionID: ctrl.sessionID, StreamID: ctrl.streamID, OwnerID: ownerID, Generation: ctrl.generation}, true, nil
 	}
 	if m.distributed == nil {
 		return StreamRef{}, false, nil
@@ -28,24 +33,31 @@ func (m *Manager) StreamRef(ctx context.Context, streamID string) (StreamRef, bo
 	return m.distributed.LoadStreamRef(ctx, streamID)
 }
 
+func runHandleForCommand(cmd Command) RunHandle {
+	return RunHandle{BotID: cmd.BotID, SessionID: cmd.SessionID, StreamID: cmd.StreamID, Generation: cmd.Generation}.normalized()
+}
+
 // ValidateRunOwnership fails closed before durable side effects when this
 // process no longer owns the active runtime run.
-func (m *Manager) ValidateRunOwnership(ctx context.Context, botID, sessionID, streamID string) error {
+func (m *Manager) ValidateRunOwnership(ctx context.Context, handle RunHandle) error {
 	if m == nil || m.backend == nil {
 		return errors.New("session runtime manager is not configured")
 	}
-	streamID = strings.TrimSpace(streamID)
-	ctrl := m.localControl(streamID)
-	if ctrl == nil || ctrl.botID != strings.TrimSpace(botID) || ctrl.sessionID != strings.TrimSpace(sessionID) {
+	handle = handle.normalized()
+	if !handle.valid() {
 		return ErrRunOwnershipLost
 	}
-	key := Key{BotID: strings.TrimSpace(botID), SessionID: strings.TrimSpace(sessionID)}
+	ctrl := m.localControlForHandle(handle)
+	if ctrl == nil {
+		return ErrRunOwnershipLost
+	}
+	key := handle.key()
 	if m.distributed == nil {
 		snapshot, ok, err := m.backend.Load(ctx, key)
 		if err != nil {
 			return fmt.Errorf("validate runtime ownership: %w", err)
 		}
-		if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != streamID || !m.runOwnerMatches(snapshot.CurrentRunView) || !isEventAcceptingRunStatus(snapshot.CurrentRunView.Status) {
+		if !ok || !runMatchesHandle(snapshot.CurrentRunView, handle) || !m.runOwnerMatches(snapshot.CurrentRunView) || !isActiveRunStatus(snapshot.CurrentRunView.Status) {
 			return ErrRunOwnershipLost
 		}
 		return nil
@@ -53,38 +65,53 @@ func (m *Manager) ValidateRunOwnership(ctx context.Context, botID, sessionID, st
 	if !ctrl.leaseIsValidAt(time.Now()) {
 		return ErrRunOwnershipLost
 	}
-	now, err := m.backend.Now(ctx)
-	if err != nil {
-		return fmt.Errorf("validate runtime ownership time: %w", err)
-	}
-	ref, refOK, err := m.distributed.LoadStreamRef(ctx, streamID)
-	if err != nil {
-		return fmt.Errorf("validate runtime stream lease: %w", err)
-	}
-	if !refOK || ref.BotID != key.BotID || ref.SessionID != key.SessionID || ref.StreamID != streamID || ref.OwnerID != m.ownerID {
-		return ErrRunOwnershipLost
-	}
-	snapshot, ok, err := m.backend.Load(ctx, key)
-	if err != nil {
+	ref := StreamRef{BotID: handle.BotID, SessionID: handle.SessionID, StreamID: handle.StreamID, OwnerID: m.ownerID, Generation: handle.Generation}
+	if err := m.distributed.ValidateRunOwnership(ctx, key, ref); err != nil {
+		if errors.Is(err, ErrRunOwnershipLost) {
+			return ErrRunOwnershipLost
+		}
 		return fmt.Errorf("validate runtime ownership: %w", err)
 	}
-	if !ok || snapshot.CurrentRunView == nil {
-		return ErrRunOwnershipLost
-	}
-	run := snapshot.CurrentRunView
-	if run.StreamID != streamID || !m.runOwnerMatches(run) || !isEventAcceptingRunStatus(run.Status) || m.leaseExpired(run, now) {
+	// A Redis round trip can consume the final part of the conservative local
+	// lease window. Recheck after the atomic server-side decision before any
+	// durable side effect begins.
+	if !ctrl.leaseIsValidAt(time.Now()) || m.localControlForHandle(handle) != ctrl {
 		return ErrRunOwnershipLost
 	}
 	return nil
 }
 
-func (m *Manager) Abort(ctx context.Context, streamID string) (bool, error) {
+func (m *Manager) Abort(ctx context.Context, botID, sessionID, streamID string) (bool, error) {
+	return m.abort(ctx, botID, sessionID, streamID, "")
+}
+
+func (m *Manager) AbortRun(ctx context.Context, handle RunHandle) (bool, error) {
+	handle = handle.normalized()
+	if !handle.valid() {
+		return false, ErrRunOwnershipLost
+	}
+	return m.abort(ctx, handle.BotID, handle.SessionID, handle.StreamID, handle.Generation)
+}
+
+func (m *Manager) abort(ctx context.Context, botID, sessionID, streamID, expectedGeneration string) (bool, error) {
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
 	streamID = strings.TrimSpace(streamID)
-	if m == nil || m.backend == nil || streamID == "" {
+	expectedGeneration = strings.TrimSpace(expectedGeneration)
+	if m == nil || m.backend == nil || botID == "" || sessionID == "" || streamID == "" {
 		return false, nil
 	}
 	if ctrl := m.localControl(streamID); ctrl != nil {
-		return m.abortLocal(ctx, ctrl)
+		if ctrl.botID != botID || ctrl.sessionID != sessionID {
+			return false, ErrCommandTargetMismatch
+		}
+		if expectedGeneration != "" && ctrl.generation != expectedGeneration {
+			if m.distributed == nil {
+				return false, ErrRunOwnershipLost
+			}
+		} else {
+			return m.abortLocal(ctx, ctrl)
+		}
 	}
 	if m.distributed == nil {
 		return false, nil
@@ -93,16 +120,27 @@ func (m *Manager) Abort(ctx context.Context, streamID string) (bool, error) {
 	if err != nil || !ok || strings.TrimSpace(ref.OwnerID) == "" {
 		return false, err
 	}
-	if err := m.distributed.PublishCommand(ctx, ref.OwnerID, Command{
-		Type:      CommandAbort,
-		BotID:     ref.BotID,
-		SessionID: ref.SessionID,
-		StreamID:  ref.StreamID,
-		CreatedAt: time.Now().UTC(),
-	}); err != nil {
-		return false, err
+	if ref.BotID != botID || ref.SessionID != sessionID {
+		return false, ErrCommandTargetMismatch
 	}
-	if err := m.waitForAbortAck(ctx, ref); err != nil {
+	if expectedGeneration != "" && ref.Generation != expectedGeneration {
+		return false, ErrRunOwnershipLost
+	}
+	createdAt, err := m.backend.Now(ctx)
+	if err != nil {
+		return false, fmt.Errorf("load runtime command time: %w", err)
+	}
+	cmd := Command{
+		Type:       CommandAbort,
+		ID:         "abort-" + uuid.NewString(),
+		BotID:      ref.BotID,
+		SessionID:  ref.SessionID,
+		StreamID:   ref.StreamID,
+		Generation: ref.Generation,
+		CreatedAt:  createdAt,
+		ExpiresAt:  createdAt.Add(m.commandTimeout()),
+	}
+	if err := m.dispatchRemoteCommand(ctx, ref.OwnerID, cmd); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -119,6 +157,7 @@ func (m *Manager) abortLocal(ctx context.Context, ctrl *runControl) (bool, error
 	if err := m.requestAbort(ctx, ctrl); err != nil {
 		return false, err
 	}
+	ctrl.stopCommands()
 	select {
 	case ctrl.abortCh <- struct{}{}:
 	default:
@@ -150,75 +189,116 @@ func (m *Manager) DispatchActiveCommand(ctx context.Context, botID, sessionID, c
 		return false, err
 	}
 	run := snapshot.CurrentRunView
-	if run == nil || !isActiveRunStatus(run.Status) || !runtimeCommandTargetPresent(run, commandType, targetID) {
+	if run == nil {
 		return false, nil
 	}
+	canonicalTargetID, targetPresent := runtimeCommandTargetID(run, commandType, targetID)
+	if !targetPresent {
+		return false, nil
+	}
+	cmd := Command{
+		Type: commandType, ID: activeCommandID(botID, sessionID, run, commandType, canonicalTargetID),
+		BotID: botID, SessionID: sessionID, StreamID: strings.TrimSpace(run.StreamID),
+		Generation: strings.TrimSpace(run.Generation), TargetID: canonicalTargetID,
+		Payload: append([]byte(nil), payload...), PayloadHash: commandPayloadHash(payload),
+	}
+	timeout := m.commandTimeout()
+	if m.distributed != nil {
+		loadCtx, cancel := context.WithTimeout(ctx, min(timeout, 100*time.Millisecond))
+		result, ok, loadErr := m.loadCommandResult(loadCtx, cmd.ID)
+		cancel()
+		if loadErr != nil {
+			return true, loadErr
+		} else if ok {
+			return true, commandResultErrorFor(cmd, result)
+		}
+	}
+	if !isActiveRunStatus(run.Status) {
+		return false, nil
+	}
+	createdAt, err := m.backend.Now(ctx)
+	if err != nil {
+		return true, fmt.Errorf("load runtime command time: %w", err)
+	}
+	cmd.CreatedAt = createdAt
+	cmd.ExpiresAt = createdAt.Add(timeout)
 	if m.distributed == nil {
-		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
+		commandCtx, cancel, commandErr := m.activeCommandContext(ctx, cmd)
 		defer cancel()
-		return true, m.applyRoutedCommand(commandCtx, Command{
-			Type: commandType, ID: uuid.NewString(), BotID: botID, SessionID: sessionID,
-			StreamID: strings.TrimSpace(run.StreamID), TargetID: targetID,
-			Payload: append([]byte(nil), payload...), CreatedAt: time.Now().UTC(),
-		})
+		if commandErr != nil {
+			return true, commandErr
+		}
+		return true, m.applyRoutedCommand(commandCtx, cmd)
 	}
 	ownerID := strings.TrimSpace(run.OwnerID)
 	if ownerID == "" {
 		return true, errors.New("target runtime owner is unknown")
 	}
-	cmd := Command{
-		Type:         commandType,
-		ID:           uuid.NewString(),
-		ReplyOwnerID: m.ownerID,
-		BotID:        botID,
-		SessionID:    sessionID,
-		StreamID:     strings.TrimSpace(run.StreamID),
-		TargetID:     targetID,
-		Payload:      append([]byte(nil), payload...),
-		CreatedAt:    time.Now().UTC(),
-	}
 	if ownerID == m.ownerID {
-		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
-		defer cancel()
-		return true, m.applyRoutedCommand(commandCtx, cmd)
+		result := m.executeRoutedCommand(ctx, cmd)
+		return true, commandResultErrorFor(cmd, result)
 	}
+	return true, m.dispatchRemoteCommand(ctx, ownerID, cmd)
+}
 
-	result := make(chan error, 1)
+func (m *Manager) dispatchRemoteCommand(ctx context.Context, ownerID string, cmd Command) error {
+	ownerID = strings.TrimSpace(ownerID)
+	cmd.ID = strings.TrimSpace(cmd.ID)
+	if ownerID == "" {
+		return errors.New("target runtime owner is unknown")
+	}
+	if cmd.ID == "" {
+		return errors.New("runtime command id is required")
+	}
+	cmd.ReplyOwnerID = m.ownerID
+	waiter := &commandWaiter{result: make(chan error, 1), payloadHash: cmd.PayloadHash}
 	m.mu.Lock()
 	if m.isClosed() {
 		m.mu.Unlock()
-		return true, ErrManagerClosed
+		return ErrManagerClosed
 	}
-	m.pendingCommands[cmd.ID] = result
+	waiters := m.pendingCommands[cmd.ID]
+	if waiters == nil {
+		waiters = make(map[*commandWaiter]struct{})
+		m.pendingCommands[cmd.ID] = waiters
+	}
+	waiters[waiter] = struct{}{}
 	m.mu.Unlock()
 	defer func() {
 		m.mu.Lock()
-		if m.pendingCommands[cmd.ID] == result {
-			delete(m.pendingCommands, cmd.ID)
+		if waiters := m.pendingCommands[cmd.ID]; waiters != nil {
+			delete(waiters, waiter)
+			if len(waiters) == 0 {
+				delete(m.pendingCommands, cmd.ID)
+			}
 		}
 		m.mu.Unlock()
 	}()
 	if err := m.distributed.PublishCommand(ctx, ownerID, cmd); err != nil {
-		return true, err
+		return err
 	}
-	timeout := m.commandTimeout()
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case err := <-result:
-		return true, err
-	case <-ctx.Done():
-		return true, ctx.Err()
-	case <-timer.C:
-		return true, errors.New("runtime command was not acknowledged")
+	return m.waitCommandResult(ctx, cmd, waiter.result, m.commandTimeout())
+}
+
+func activeCommandID(botID, sessionID string, run *CurrentRunView, commandType, targetID string) string {
+	parts := []string{
+		strings.TrimSpace(botID), strings.TrimSpace(sessionID), strings.TrimSpace(run.StreamID),
+		strings.TrimSpace(run.Generation), strings.TrimSpace(commandType), strings.TrimSpace(targetID),
 	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return fmt.Sprintf("active-response-%x", sum[:])
+}
+
+func commandPayloadHash(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return fmt.Sprintf("sha256:%x", sum[:])
 }
 
 func (m *Manager) requestAbort(ctx context.Context, ctrl *runControl) error {
 	if ctrl == nil {
 		return nil
 	}
-	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: ctrl.botID, SessionID: ctrl.sessionID}, ctrl.streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+	_, _, err := m.updateActiveAndPublish(ctx, ctrl.handle(), func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
 		run := snapshot.CurrentRunView
 		if run.StreamID != ctrl.streamID || !m.runOwnerMatches(run) || !isActiveRunStatus(run.Status) {
 			return snapshot, false, nil
@@ -238,30 +318,55 @@ func (m *Manager) requestAbort(ctx context.Context, ctrl *runControl) error {
 }
 
 func (m *Manager) Steer(ctx context.Context, botID, sessionID, streamID, text string) (SteerState, error) {
+	return m.steer(ctx, botID, sessionID, streamID, "", text)
+}
+
+func (m *Manager) SteerRun(ctx context.Context, handle RunHandle, text string) (SteerState, error) {
+	handle = handle.normalized()
+	if !handle.valid() {
+		return SteerState{}, ErrRunOwnershipLost
+	}
+	return m.steer(ctx, handle.BotID, handle.SessionID, handle.StreamID, handle.Generation, text)
+}
+
+func (m *Manager) steer(ctx context.Context, botID, sessionID, streamID, expectedGeneration, text string) (SteerState, error) {
 	if m == nil || m.backend == nil {
 		return SteerState{}, errors.New("session runtime manager is not configured")
 	}
 	botID = strings.TrimSpace(botID)
 	sessionID = strings.TrimSpace(sessionID)
 	streamID = strings.TrimSpace(streamID)
+	expectedGeneration = strings.TrimSpace(expectedGeneration)
 	text = strings.TrimSpace(text)
 	if botID == "" || sessionID == "" || text == "" {
 		return SteerState{}, errors.New("bot_id, session_id, and text are required")
 	}
+	snapshot, err := m.Snapshot(ctx, botID, sessionID)
+	if err != nil {
+		return SteerState{}, err
+	}
+	if snapshot.CurrentRunView == nil {
+		return SteerState{}, errors.New("no active runtime run")
+	}
 	if streamID == "" {
-		snapshot, err := m.Snapshot(ctx, botID, sessionID)
-		if err != nil {
-			return SteerState{}, err
-		}
-		if snapshot.CurrentRunView == nil {
-			return SteerState{}, errors.New("no active runtime run")
-		}
 		streamID = strings.TrimSpace(snapshot.CurrentRunView.StreamID)
 	}
+	if snapshot.CurrentRunView.StreamID != streamID {
+		return SteerState{}, errors.New("target runtime run is not active")
+	}
+	if expectedGeneration != "" && strings.TrimSpace(snapshot.CurrentRunView.Generation) != expectedGeneration {
+		return SteerState{}, ErrRunOwnershipLost
+	}
+	generation := strings.TrimSpace(snapshot.CurrentRunView.Generation)
+	if expectedGeneration != "" {
+		generation = expectedGeneration
+	}
+	handle := RunHandle{BotID: botID, SessionID: sessionID, StreamID: streamID, Generation: generation}.normalized()
 	var steer SteerState
 	var ownerID string
+	var commandGeneration string
 	var commandCreatedAt time.Time
-	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+	_, _, err = m.updateActiveAndPublish(ctx, handle, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
 		if snapshot.CurrentRunView.StreamID != streamID || !strings.EqualFold(snapshot.CurrentRunView.Status, RunStatusRunning) {
 			return snapshot, false, errors.New("target runtime run is not active")
 		}
@@ -281,6 +386,7 @@ func (m *Manager) Steer(ctx context.Context, botID, sessionID, streamID, text st
 		snapshot.CurrentRunView.Steer = &steer
 		snapshot.CurrentRunView.UpdatedAt = now
 		ownerID = strings.TrimSpace(snapshot.CurrentRunView.OwnerID)
+		commandGeneration = strings.TrimSpace(snapshot.CurrentRunView.Generation)
 		return snapshot, true, nil
 	}, func(snapshot Snapshot) RuntimeDelta {
 		return runtimeRunPatch(snapshot, false, false, true, false)
@@ -289,8 +395,12 @@ func (m *Manager) Steer(ctx context.Context, botID, sessionID, streamID, text st
 		return SteerState{}, err
 	}
 
-	cmd := Command{Type: CommandSteer, BotID: botID, SessionID: sessionID, StreamID: streamID, SteerID: steer.ID, Text: text, CreatedAt: commandCreatedAt}
-	if ctrl := m.localControl(streamID); ctrl != nil {
+	cmd := Command{
+		Type: CommandSteer, BotID: botID, SessionID: sessionID, StreamID: streamID,
+		Generation: commandGeneration, SteerID: steer.ID, Text: text, CreatedAt: commandCreatedAt,
+		ExpiresAt: commandCreatedAt.Add(m.commandTimeout()),
+	}
+	if ctrl := m.localControlForHandle(handle); ctrl != nil {
 		m.applyCommand(ctx, cmd)
 	} else {
 		if ownerID == "" {
@@ -300,46 +410,76 @@ func (m *Manager) Steer(ctx context.Context, botID, sessionID, streamID, text st
 			return steer, errors.New("active runtime is not local")
 		}
 		if err := m.distributed.PublishCommand(ctx, ownerID, cmd); err != nil {
-			_ = m.updateSteerStatus(context.WithoutCancel(ctx), botID, sessionID, streamID, steer.ID, SteerStatusRejected, err.Error())
+			_ = m.updateSteerStatus(context.WithoutCancel(ctx), handle, steer.ID, SteerStatusRejected, err.Error())
 			return steer, err
 		}
 	}
-	m.rejectPendingSteerAfterTimeout(context.WithoutCancel(ctx), botID, sessionID, streamID, steer.ID)
+	m.rejectPendingSteerAfterTimeout(context.WithoutCancel(ctx), handle, steer.ID)
 	return steer, nil
 }
 
 func (m *Manager) applyCommand(ctx context.Context, cmd Command) {
 	switch strings.TrimSpace(cmd.Type) {
-	case CommandAbort:
-		ctrl := m.localControl(strings.TrimSpace(cmd.StreamID))
-		if ctrl == nil || ctrl.botID != strings.TrimSpace(cmd.BotID) || ctrl.sessionID != strings.TrimSpace(cmd.SessionID) {
-			m.logger.Warn("ignore abort command for inactive local run", slog.String("stream_id", cmd.StreamID))
+	case CommandAbort, CommandToolApprovalResponse, CommandUserInputResponse:
+		m.publishStoredCommandResult(ctx, cmd, m.executeRoutedCommand(ctx, cmd))
+	case CommandSteer:
+		commandCtx, cancel, err := m.activeCommandContext(ctx, cmd)
+		if err != nil {
+			_ = m.updateSteerStatus(context.WithoutCancel(ctx), runHandleForCommand(cmd), cmd.SteerID, SteerStatusRejected, steerNotAcknowledgedError)
 			return
 		}
-		if _, err := m.abortLocal(ctx, ctrl); err != nil {
-			m.logger.Warn("apply abort command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
-		}
-	case CommandSteer:
-		m.applySteerCommand(ctx, cmd)
-	case CommandToolApprovalResponse, CommandUserInputResponse:
-		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
-		err := m.applyRoutedCommand(commandCtx, cmd)
+		m.applySteerCommand(commandCtx, cmd)
 		cancel()
-		m.publishCommandResult(ctx, cmd, err)
 	case CommandResult:
 		m.completePendingCommand(cmd)
 	}
 }
 
+func (m *Manager) activeCommandContext(ctx context.Context, cmd Command) (context.Context, context.CancelFunc, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	lookupCtx, lookupCancel := context.WithTimeout(ctx, m.commandTimeout())
+	lookupStarted := time.Now()
+	now, err := m.backend.Now(lookupCtx)
+	lookupElapsed := time.Since(lookupStarted)
+	if err != nil {
+		lookupCancel()
+		return nil, func() {}, fmt.Errorf("load runtime command time: %w", err)
+	}
+	expiresAt := cmd.ExpiresAt
+	if expiresAt.IsZero() || (!cmd.CreatedAt.IsZero() && !expiresAt.After(cmd.CreatedAt)) {
+		lookupCancel()
+		return nil, func() {}, ErrCommandExpired
+	}
+	remaining := expiresAt.Sub(now) - lookupElapsed
+	if remaining <= 0 {
+		lookupCancel()
+		return nil, func() {}, ErrCommandExpired
+	}
+	lookupCancel()
+	commandCtx, commandCancel := context.WithTimeout(ctx, remaining)
+	return commandCtx, commandCancel, nil
+}
+
 func (m *Manager) applyRoutedCommand(ctx context.Context, cmd Command) error {
 	ctrl := m.localControl(strings.TrimSpace(cmd.StreamID))
-	if ctrl == nil || ctrl.botID != strings.TrimSpace(cmd.BotID) || ctrl.sessionID != strings.TrimSpace(cmd.SessionID) {
+	if ctrl == nil || ctrl.botID != strings.TrimSpace(cmd.BotID) || ctrl.sessionID != strings.TrimSpace(cmd.SessionID) || ctrl.generation != strings.TrimSpace(cmd.Generation) {
 		return ErrCommandTargetNotActive
 	}
-	if err := m.ValidateRunOwnership(ctx, cmd.BotID, cmd.SessionID, cmd.StreamID); err != nil {
+	commandCtx, cancel := ctrl.commandContext(ctx)
+	defer cancel()
+	if !ctrl.commandsActive() || commandCtx.Err() != nil {
 		return ErrCommandTargetNotActive
 	}
-	snapshot, ok, err := m.backend.Load(ctx, Key{BotID: cmd.BotID, SessionID: cmd.SessionID})
+	handle := runHandleForCommand(cmd)
+	if err := m.ValidateRunOwnership(commandCtx, handle); err != nil {
+		if errors.Is(err, ErrRunOwnershipLost) {
+			return ErrCommandTargetNotActive
+		}
+		return err
+	}
+	snapshot, ok, err := m.backend.Load(commandCtx, Key{BotID: cmd.BotID, SessionID: cmd.SessionID})
 	if err != nil {
 		return err
 	}
@@ -347,7 +487,14 @@ func (m *Manager) applyRoutedCommand(ctx context.Context, cmd Command) error {
 		return ErrCommandTargetNotActive
 	}
 	run := snapshot.CurrentRunView
-	if run.StreamID != ctrl.streamID || !m.runOwnerMatches(run) || !isActiveRunStatus(run.Status) || !runtimeCommandTargetPresent(run, cmd.Type, cmd.TargetID) {
+	if run.StreamID != ctrl.streamID || run.Generation != ctrl.generation || !m.runOwnerMatches(run) || !isActiveRunStatus(run.Status) {
+		return ErrCommandTargetNotActive
+	}
+	if strings.TrimSpace(cmd.Type) == CommandAbort {
+		_, err := m.abortLocal(commandCtx, ctrl)
+		return err
+	}
+	if !runtimeCommandTargetPresent(run, cmd.Type, cmd.TargetID) {
 		return ErrCommandTargetNotActive
 	}
 	m.mu.Lock()
@@ -356,7 +503,105 @@ func (m *Manager) applyRoutedCommand(ctx context.Context, cmd Command) error {
 	if handler == nil {
 		return errors.New("runtime command handler is not configured")
 	}
-	return handler(ctx, cmd)
+	if !m.beginCommandTarget(cmd) {
+		return ErrCommandBusy
+	}
+	defer m.endCommandTarget(cmd)
+	err = handler(commandCtx, cmd)
+	return err
+}
+
+func (m *Manager) executeRoutedCommand(ctx context.Context, cmd Command) Command {
+	leader, executionDone := m.beginCommandExecution(cmd.ID)
+	if !leader {
+		select {
+		case <-executionDone:
+		case <-ctx.Done():
+			return newCommandResult(cmd, ctx.Err())
+		}
+		if result, ok, err := m.loadCommandResultForExecution(ctx, cmd.ID); err != nil {
+			return newCommandResult(cmd, err)
+		} else if ok {
+			if errors.Is(commandResultErrorFor(cmd, result), ErrCommandPayloadConflict) {
+				return newCommandResult(cmd, ErrCommandPayloadConflict)
+			}
+			return result
+		}
+		return newCommandResult(cmd, errors.New("runtime command result is unavailable"))
+	}
+	defer m.finishCommandExecution(cmd.ID, executionDone)
+
+	if result, ok, err := m.loadCommandResultForExecution(ctx, cmd.ID); err != nil {
+		return newCommandResult(cmd, err)
+	} else if ok {
+		if errors.Is(commandResultErrorFor(cmd, result), ErrCommandPayloadConflict) {
+			return newCommandResult(cmd, ErrCommandPayloadConflict)
+		}
+		return result
+	}
+	commandCtx, cancel, err := m.activeCommandContext(ctx, cmd)
+	if err == nil {
+		err = m.applyRoutedCommand(commandCtx, cmd)
+	}
+	cancel()
+	return m.persistCommandResult(ctx, cmd, err)
+}
+
+func newCommandResult(request Command, err error) Command {
+	result := Command{
+		Type: CommandResult, ID: request.ID, BotID: request.BotID, SessionID: request.SessionID,
+		StreamID: request.StreamID, Generation: request.Generation, TargetID: request.TargetID,
+		PayloadHash: request.PayloadHash, CreatedAt: time.Now().UTC(),
+	}
+	if err == nil {
+		return result
+	}
+	result.Error = err.Error()
+	switch {
+	case errors.Is(err, ErrCommandTargetNotActive):
+		result.ErrorCode = "target_not_active"
+	case errors.Is(err, ErrCommandExpired):
+		result.ErrorCode = "command_expired"
+	case errors.Is(err, context.Canceled):
+		result.ErrorCode = "context_canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		result.ErrorCode = "deadline_exceeded"
+	case errors.Is(err, ErrCommandBusy):
+		result.ErrorCode = "command_busy"
+	case errors.Is(err, ErrCommandPayloadConflict):
+		result.ErrorCode = "payload_conflict"
+	default:
+		result.ErrorCode = "runtime_command_failed"
+	}
+	return result
+}
+
+func (m *Manager) persistCommandResult(ctx context.Context, request Command, err error) Command {
+	result := newCommandResult(request, err)
+	if m == nil || m.distributed == nil || strings.TrimSpace(request.ID) == "" {
+		return result
+	}
+	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.commandTimeout())
+	defer cancel()
+	if storeErr := m.distributed.StoreCommandResult(persistCtx, result, m.commandResultTTL()); storeErr != nil {
+		m.logger.Warn("store runtime command result failed", slog.Any("error", storeErr), slog.String("command_id", request.ID))
+		return result
+	}
+	stored, ok, loadErr := m.distributed.LoadCommandResult(persistCtx, request.ID)
+	if loadErr != nil {
+		m.logger.Warn("reload runtime command result failed", slog.Any("error", loadErr), slog.String("command_id", request.ID))
+		return result
+	}
+	if ok {
+		return stored
+	}
+	return result
+}
+
+func (m *Manager) loadCommandResultForExecution(ctx context.Context, commandID string) (Command, bool, error) {
+	loadCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
+	defer cancel()
+	return m.loadCommandResult(loadCtx, commandID)
 }
 
 func (m *Manager) publishCommandResult(ctx context.Context, request Command, err error) {
@@ -367,19 +612,30 @@ func (m *Manager) publishCommandResult(ctx context.Context, request Command, err
 	if m.distributed == nil {
 		return
 	}
-	result := Command{Type: CommandResult, ID: request.ID, CreatedAt: time.Now().UTC()}
-	if err != nil {
-		result.Error = err.Error()
-		if errors.Is(err, ErrCommandTargetNotActive) {
-			result.ErrorCode = "target_not_active"
-		} else {
-			result.ErrorCode = "runtime_command_failed"
-		}
-	}
+	result := m.persistCommandResult(ctx, request, err)
 	publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.commandTimeout())
 	defer cancel()
 	if publishErr := m.distributed.PublishCommand(publishCtx, replyOwnerID, result); publishErr != nil {
 		m.logger.Warn("publish runtime command result failed", slog.Any("error", publishErr), slog.String("command_id", request.ID))
+	}
+}
+
+func (m *Manager) publishStoredCommandResult(ctx context.Context, request, result Command) {
+	if m == nil || m.distributed == nil || strings.TrimSpace(request.ReplyOwnerID) == "" {
+		return
+	}
+	if err := commandResultErrorFor(request, result); errors.Is(err, ErrCommandPayloadConflict) {
+		result = Command{
+			Type: CommandResult, ID: request.ID, BotID: request.BotID, SessionID: request.SessionID,
+			StreamID: request.StreamID, Generation: request.Generation, TargetID: request.TargetID,
+			PayloadHash: request.PayloadHash, ErrorCode: "payload_conflict", Error: ErrCommandPayloadConflict.Error(),
+			CreatedAt: time.Now().UTC(),
+		}
+	}
+	publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.commandTimeout())
+	defer cancel()
+	if err := m.distributed.PublishCommand(publishCtx, request.ReplyOwnerID, result); err != nil {
+		m.logger.Warn("republish stored runtime command result failed", slog.Any("error", err), slog.String("command_id", request.ID))
 	}
 }
 
@@ -390,71 +646,236 @@ func (m *Manager) commandTimeout() time.Duration {
 	return defaultCommandAckTTL
 }
 
+func (m *Manager) commandResultTTL() time.Duration {
+	ttl := 4 * m.commandTimeout()
+	if ttl < 30*time.Second {
+		return 30 * time.Second
+	}
+	return ttl
+}
+
+func (m *Manager) waitCommandResult(ctx context.Context, request Command, pending <-chan error, timeout time.Duration) error {
+	waitCtx, cancelWait := context.WithTimeout(ctx, timeout)
+	defer cancelWait()
+	pollEvery := timeout / 4
+	if pollEvery < time.Millisecond {
+		pollEvery = time.Millisecond
+	}
+	if pollEvery > 50*time.Millisecond {
+		pollEvery = 50 * time.Millisecond
+	}
+	poll := time.NewTicker(pollEvery)
+	defer poll.Stop()
+	for {
+		select {
+		case err := <-pending:
+			return err
+		case <-waitCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return errors.New("runtime command was not acknowledged")
+		case <-poll.C:
+			result, ok, loadErr := m.loadCommandResult(waitCtx, request.ID)
+			if loadErr == nil && ok {
+				return commandResultErrorFor(request, result)
+			}
+		}
+	}
+}
+
+func (m *Manager) loadCommandResult(ctx context.Context, commandID string) (Command, bool, error) {
+	if m == nil || m.distributed == nil || strings.TrimSpace(commandID) == "" {
+		return Command{}, false, nil
+	}
+	return m.distributed.LoadCommandResult(ctx, commandID)
+}
+
 func (m *Manager) completePendingCommand(result Command) {
 	m.mu.Lock()
-	pending := m.pendingCommands[strings.TrimSpace(result.ID)]
-	if pending != nil {
+	waiters := m.pendingCommands[strings.TrimSpace(result.ID)]
+	if waiters != nil {
 		delete(m.pendingCommands, strings.TrimSpace(result.ID))
 	}
 	m.mu.Unlock()
-	if pending == nil {
+	if waiters == nil {
 		return
 	}
-	var err error
-	if strings.TrimSpace(result.Error) != "" {
-		if result.ErrorCode == "target_not_active" {
-			err = fmt.Errorf("%w: %s", ErrCommandTargetNotActive, result.Error)
-		} else {
-			err = errors.New(result.Error)
-		}
+	for waiter := range waiters {
+		waiter.result <- commandResultErrorFor(Command{PayloadHash: waiter.payloadHash}, result)
 	}
-	pending <- err
 }
 
-func runtimeCommandTargetPresent(run *CurrentRunView, commandType, targetID string) bool {
+func commandResultErrorFor(request, result Command) error {
+	expected := strings.TrimSpace(request.PayloadHash)
+	actual := strings.TrimSpace(result.PayloadHash)
+	if expected != "" && actual != "" && expected != actual {
+		return ErrCommandPayloadConflict
+	}
+	return commandResultError(result)
+}
+
+func commandResultError(result Command) error {
+	if strings.TrimSpace(result.Error) == "" {
+		return nil
+	}
+	switch result.ErrorCode {
+	case "target_not_active":
+		return fmt.Errorf("%w: %s", ErrCommandTargetNotActive, result.Error)
+	case "command_expired":
+		return fmt.Errorf("%w: %s", ErrCommandExpired, result.Error)
+	case "context_canceled":
+		return fmt.Errorf("%w: %s", context.Canceled, result.Error)
+	case "deadline_exceeded":
+		return fmt.Errorf("%w: %s", context.DeadlineExceeded, result.Error)
+	case "command_busy":
+		return fmt.Errorf("%w: %s", ErrCommandBusy, result.Error)
+	case "payload_conflict":
+		return fmt.Errorf("%w: %s", ErrCommandPayloadConflict, result.Error)
+	default:
+		return errors.New(result.Error)
+	}
+}
+
+func commandTargetKey(cmd Command) string {
+	return strings.Join([]string{
+		strings.TrimSpace(cmd.BotID), strings.TrimSpace(cmd.SessionID), strings.TrimSpace(cmd.StreamID),
+		strings.TrimSpace(cmd.Generation), strings.TrimSpace(cmd.Type), strings.TrimSpace(cmd.TargetID),
+	}, "\x00")
+}
+
+func (m *Manager) beginCommandTarget(cmd Command) bool {
+	key := commandTargetKey(cmd)
+	if key == "\x00\x00\x00\x00\x00" {
+		return true
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.inflightCommandTargets[key]; exists {
+		return false
+	}
+	m.inflightCommandTargets[key] = struct{}{}
+	return true
+}
+
+func (m *Manager) endCommandTarget(cmd Command) {
+	key := commandTargetKey(cmd)
+	m.mu.Lock()
+	delete(m.inflightCommandTargets, key)
+	m.mu.Unlock()
+}
+
+func (m *Manager) beginCommandExecution(commandID string) (bool, chan struct{}) {
+	commandID = strings.TrimSpace(commandID)
+	if commandID == "" {
+		done := make(chan struct{})
+		return true, done
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if done := m.commandExecutions[commandID]; done != nil {
+		return false, done
+	}
+	done := make(chan struct{})
+	m.commandExecutions[commandID] = done
+	return true, done
+}
+
+func (m *Manager) finishCommandExecution(commandID string, done chan struct{}) {
+	commandID = strings.TrimSpace(commandID)
+	m.mu.Lock()
+	if commandID != "" && m.commandExecutions[commandID] == done {
+		close(done)
+		delete(m.commandExecutions, commandID)
+		m.mu.Unlock()
+		return
+	}
+	m.mu.Unlock()
+	close(done)
+}
+
+func isDurableRoutedCommand(cmd Command) bool {
+	switch strings.TrimSpace(cmd.Type) {
+	case CommandAbort, CommandToolApprovalResponse, CommandUserInputResponse:
+		return strings.TrimSpace(cmd.ID) != ""
+	default:
+		return false
+	}
+}
+
+func (m *Manager) admitCommand(cmd Command) bool {
+	if !isDurableRoutedCommand(cmd) {
+		return true
+	}
+	commandID := strings.TrimSpace(cmd.ID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.admittedCommands[commandID]; exists {
+		return false
+	}
+	m.admittedCommands[commandID] = struct{}{}
+	return true
+}
+
+func (m *Manager) releaseCommandAdmission(cmd Command) {
+	if !isDurableRoutedCommand(cmd) {
+		return
+	}
+	m.mu.Lock()
+	delete(m.admittedCommands, strings.TrimSpace(cmd.ID))
+	m.mu.Unlock()
+}
+
+func runtimeCommandTargetID(run *CurrentRunView, commandType, targetID string) (string, bool) {
 	targetID = strings.TrimSpace(targetID)
 	if run == nil || targetID == "" {
-		return false
+		return "", false
 	}
 	for _, message := range run.Messages {
 		switch commandType {
 		case CommandToolApprovalResponse:
 			if message.Approval != nil && (strings.TrimSpace(message.Approval.ApprovalID) == targetID || strconv.Itoa(message.Approval.ShortID) == targetID) {
-				return true
+				canonical := strings.TrimSpace(message.Approval.ApprovalID)
+				if canonical == "" {
+					canonical = strconv.Itoa(message.Approval.ShortID)
+				}
+				return canonical, true
 			}
 		case CommandUserInputResponse:
 			if message.UserInput != nil && (strings.TrimSpace(message.UserInput.UserInputID) == targetID || strconv.Itoa(message.UserInput.ShortID) == targetID) {
-				return true
+				canonical := strings.TrimSpace(message.UserInput.UserInputID)
+				if canonical == "" {
+					canonical = strconv.Itoa(message.UserInput.ShortID)
+				}
+				return canonical, true
 			}
 		}
 	}
-	return false
+	return "", false
+}
+
+func runtimeCommandTargetPresent(run *CurrentRunView, commandType, targetID string) bool {
+	_, ok := runtimeCommandTargetID(run, commandType, targetID)
+	return ok
 }
 
 func (m *Manager) applySteerCommand(ctx context.Context, cmd Command) {
-	if err := m.ValidateRunOwnership(ctx, cmd.BotID, cmd.SessionID, cmd.StreamID); err != nil {
-		_ = m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, ErrRunOwnershipLost.Error())
+	handle := runHandleForCommand(cmd)
+	if err := m.ValidateRunOwnership(ctx, handle); err != nil {
+		_ = m.updateSteerStatus(context.WithoutCancel(ctx), handle, cmd.SteerID, SteerStatusRejected, ErrRunOwnershipLost.Error())
 		return
 	}
-	if !m.steerCommandIsPending(context.WithoutCancel(ctx), cmd) {
+	if !m.steerCommandIsPending(ctx, cmd) {
 		return
 	}
-	now, err := m.backend.Now(ctx)
-	if err != nil {
-		m.logger.Warn("load runtime backend time for steer command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
-		return
-	}
-	if m.commandAckTTL > 0 && !cmd.CreatedAt.IsZero() && now.After(cmd.CreatedAt.Add(m.commandAckTTL)) {
-		if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, steerNotAcknowledgedError); err != nil {
-			m.logger.Warn("reject expired steer command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
-		}
-		return
-	}
-
 	ctrl := m.localControl(cmd.StreamID)
+	if ctrl == nil || ctrl.generation != strings.TrimSpace(cmd.Generation) {
+		_ = m.updateSteerStatus(context.WithoutCancel(ctx), handle, cmd.SteerID, SteerStatusRejected, ErrRunOwnershipLost.Error())
+		return
+	}
 	errText := ""
-	if ctrl != nil && ctrl.injectCh != nil && strings.TrimSpace(cmd.Text) != "" {
-		queued, err := m.transitionSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusQueued, "")
+	if ctrl.injectCh != nil && strings.TrimSpace(cmd.Text) != "" {
+		queued, err := m.transitionSteerStatus(ctx, handle, cmd.SteerID, SteerStatusQueued, "")
 		if err != nil {
 			m.logger.Warn("acknowledge queued steer failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
 			return
@@ -462,25 +883,22 @@ func (m *Manager) applySteerCommand(ctx context.Context, cmd Command) {
 		if !queued {
 			return
 		}
-		select {
-		case ctrl.injectCh <- conversation.InjectMessage{
+		sent, sendError := ctrl.sendInject(ctx, conversation.InjectMessage{
 			Text: strings.TrimSpace(cmd.Text),
 			Applied: func() {
-				if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusApplied, ""); err != nil {
+				if err := m.updateSteerStatus(context.WithoutCancel(ctx), handle, cmd.SteerID, SteerStatusApplied, ""); err != nil {
 					m.logger.Warn("acknowledge applied steer failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
 				}
 			},
-		}:
+		})
+		if sent {
 			return
-		case <-ctx.Done():
-			errText = ctx.Err().Error()
-		default:
-			errText = "active runtime is not accepting steer messages"
 		}
+		errText = sendError
 	} else {
 		errText = "active runtime is not available"
 	}
-	if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, errText); err != nil {
+	if err := m.updateSteerStatus(context.WithoutCancel(ctx), handle, cmd.SteerID, SteerStatusRejected, errText); err != nil {
 		m.logger.Warn("update steer status failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
 	}
 }
@@ -494,21 +912,21 @@ func (m *Manager) steerCommandIsPending(ctx context.Context, cmd Command) bool {
 		m.logger.Warn("load steer state failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
 		return false
 	}
-	if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != strings.TrimSpace(cmd.StreamID) {
+	if !ok || !runMatchesHandle(snapshot.CurrentRunView, runHandleForCommand(cmd)) {
 		return false
 	}
 	steer := snapshot.CurrentRunView.Steer
 	return steer != nil && steer.ID == strings.TrimSpace(cmd.SteerID) && strings.EqualFold(steer.Status, SteerStatusPending)
 }
 
-func (m *Manager) updateSteerStatus(ctx context.Context, botID, sessionID, streamID, steerID, status, errText string) error {
-	_, err := m.transitionSteerStatus(ctx, botID, sessionID, streamID, steerID, status, errText)
+func (m *Manager) updateSteerStatus(ctx context.Context, handle RunHandle, steerID, status, errText string) error {
+	_, err := m.transitionSteerStatus(ctx, handle, steerID, status, errText)
 	return err
 }
 
-func (m *Manager) transitionSteerStatus(ctx context.Context, botID, sessionID, streamID, steerID, status, errText string) (bool, error) {
-	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
-		if snapshot.CurrentRunView.StreamID != streamID {
+func (m *Manager) transitionSteerStatus(ctx context.Context, handle RunHandle, steerID, status, errText string) (bool, error) {
+	_, changed, err := m.updateActiveAndPublish(ctx, handle, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if !runMatchesHandle(snapshot.CurrentRunView, handle) {
 			return snapshot, false, nil
 		}
 		if snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.ID != steerID {
@@ -533,7 +951,7 @@ func (m *Manager) transitionSteerStatus(ctx context.Context, botID, sessionID, s
 
 const steerNotAcknowledgedError = "runtime steer command was not acknowledged"
 
-func (m *Manager) rejectPendingSteerAfterTimeout(ctx context.Context, botID, sessionID, streamID, steerID string) {
+func (m *Manager) rejectPendingSteerAfterTimeout(ctx context.Context, handle RunHandle, steerID string) {
 	timeout := m.commandAckTTL
 	if timeout <= 0 {
 		return
@@ -544,16 +962,16 @@ func (m *Manager) rejectPendingSteerAfterTimeout(ctx context.Context, botID, ses
 			return
 		default:
 		}
-		err := m.rejectUnacknowledgedSteer(ctx, botID, sessionID, streamID, steerID)
+		err := m.rejectUnacknowledgedSteer(ctx, handle, steerID)
 		if err != nil {
-			m.logger.Warn("reject pending steer failed", slog.Any("error", err), slog.String("stream_id", streamID))
+			m.logger.Warn("reject pending steer failed", slog.Any("error", err), slog.String("stream_id", handle.StreamID))
 		}
 	})
 }
 
-func (m *Manager) rejectUnacknowledgedSteer(ctx context.Context, botID, sessionID, streamID, steerID string) error {
-	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
-		if snapshot.CurrentRunView.StreamID != streamID {
+func (m *Manager) rejectUnacknowledgedSteer(ctx context.Context, handle RunHandle, steerID string) error {
+	_, _, err := m.updateActiveAndPublish(ctx, handle, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if !runMatchesHandle(snapshot.CurrentRunView, handle) {
 			return snapshot, false, nil
 		}
 		steer := snapshot.CurrentRunView.Steer
@@ -587,30 +1005,5 @@ func validSteerTransition(current, next string) bool {
 		return isPendingSteerStatus(current)
 	default:
 		return false
-	}
-}
-
-func (m *Manager) waitForAbortAck(ctx context.Context, ref StreamRef) error {
-	timeout := m.commandAckTTL
-	if timeout <= 0 {
-		return nil
-	}
-	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	ticker := time.NewTicker(commandAckPollInterval(timeout))
-	defer ticker.Stop()
-	for {
-		snapshot, err := m.Snapshot(waitCtx, ref.BotID, ref.SessionID)
-		if err != nil {
-			return err
-		}
-		if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != ref.StreamID || strings.EqualFold(snapshot.CurrentRunView.Status, RunStatusAborting) || !isActiveRunStatus(snapshot.CurrentRunView.Status) {
-			return nil
-		}
-		select {
-		case <-waitCtx.Done():
-			return errors.New("runtime abort command was not acknowledged")
-		case <-ticker.C:
-		}
 	}
 }

--- a/internal/sessionruntime/commands.go
+++ b/internal/sessionruntime/commands.go
@@ -1,0 +1,616 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func (m *Manager) StreamRef(ctx context.Context, streamID string) (StreamRef, bool, error) {
+	streamID = strings.TrimSpace(streamID)
+	if m == nil || m.backend == nil || streamID == "" {
+		return StreamRef{}, false, nil
+	}
+	if ctrl := m.localControl(streamID); ctrl != nil {
+		return StreamRef{BotID: ctrl.botID, SessionID: ctrl.sessionID, StreamID: ctrl.streamID}, true, nil
+	}
+	if m.distributed == nil {
+		return StreamRef{}, false, nil
+	}
+	return m.distributed.LoadStreamRef(ctx, streamID)
+}
+
+// ValidateRunOwnership fails closed before durable side effects when this
+// process no longer owns the active runtime run.
+func (m *Manager) ValidateRunOwnership(ctx context.Context, botID, sessionID, streamID string) error {
+	if m == nil || m.backend == nil {
+		return errors.New("session runtime manager is not configured")
+	}
+	streamID = strings.TrimSpace(streamID)
+	ctrl := m.localControl(streamID)
+	if ctrl == nil || ctrl.botID != strings.TrimSpace(botID) || ctrl.sessionID != strings.TrimSpace(sessionID) {
+		return ErrRunOwnershipLost
+	}
+	key := Key{BotID: strings.TrimSpace(botID), SessionID: strings.TrimSpace(sessionID)}
+	if m.distributed == nil {
+		snapshot, ok, err := m.backend.Load(ctx, key)
+		if err != nil {
+			return fmt.Errorf("validate runtime ownership: %w", err)
+		}
+		if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != streamID || !m.runOwnerMatches(snapshot.CurrentRunView) || !isEventAcceptingRunStatus(snapshot.CurrentRunView.Status) {
+			return ErrRunOwnershipLost
+		}
+		return nil
+	}
+	if !ctrl.leaseIsValidAt(time.Now()) {
+		return ErrRunOwnershipLost
+	}
+	now, err := m.backend.Now(ctx)
+	if err != nil {
+		return fmt.Errorf("validate runtime ownership time: %w", err)
+	}
+	ref, refOK, err := m.distributed.LoadStreamRef(ctx, streamID)
+	if err != nil {
+		return fmt.Errorf("validate runtime stream lease: %w", err)
+	}
+	if !refOK || ref.BotID != key.BotID || ref.SessionID != key.SessionID || ref.StreamID != streamID || ref.OwnerID != m.ownerID {
+		return ErrRunOwnershipLost
+	}
+	snapshot, ok, err := m.backend.Load(ctx, key)
+	if err != nil {
+		return fmt.Errorf("validate runtime ownership: %w", err)
+	}
+	if !ok || snapshot.CurrentRunView == nil {
+		return ErrRunOwnershipLost
+	}
+	run := snapshot.CurrentRunView
+	if run.StreamID != streamID || !m.runOwnerMatches(run) || !isEventAcceptingRunStatus(run.Status) || m.leaseExpired(run, now) {
+		return ErrRunOwnershipLost
+	}
+	return nil
+}
+
+func (m *Manager) Abort(ctx context.Context, streamID string) (bool, error) {
+	streamID = strings.TrimSpace(streamID)
+	if m == nil || m.backend == nil || streamID == "" {
+		return false, nil
+	}
+	if ctrl := m.localControl(streamID); ctrl != nil {
+		return m.abortLocal(ctx, ctrl)
+	}
+	if m.distributed == nil {
+		return false, nil
+	}
+	ref, ok, err := m.distributed.LoadStreamRef(ctx, streamID)
+	if err != nil || !ok || strings.TrimSpace(ref.OwnerID) == "" {
+		return false, err
+	}
+	if err := m.distributed.PublishCommand(ctx, ref.OwnerID, Command{
+		Type:      CommandAbort,
+		BotID:     ref.BotID,
+		SessionID: ref.SessionID,
+		StreamID:  ref.StreamID,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		return false, err
+	}
+	if err := m.waitForAbortAck(ctx, ref); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *Manager) abortLocal(ctx context.Context, ctrl *runControl) (bool, error) {
+	if ctrl == nil || m.localControl(ctrl.streamID) != ctrl {
+		return false, ErrCommandTargetNotActive
+	}
+	if m.distributed != nil && !ctrl.leaseIsValidAt(time.Now()) {
+		m.cancelRunControl(ctrl)
+		return false, ErrCommandTargetNotActive
+	}
+	if err := m.requestAbort(ctx, ctrl); err != nil {
+		return false, err
+	}
+	select {
+	case ctrl.abortCh <- struct{}{}:
+	default:
+	}
+	if ctrl.cancel != nil {
+		ctrl.cancel()
+	}
+	return true, nil
+}
+
+// DispatchActiveCommand routes a response for a UI request embedded in the
+// current run to that run's owner. A false handled result means the target is
+// not part of the active run and the caller may use its deferred flow.
+func (m *Manager) DispatchActiveCommand(ctx context.Context, botID, sessionID, commandType, targetID string, payload []byte) (bool, error) {
+	if m == nil || m.backend == nil {
+		return false, nil
+	}
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
+	targetID = strings.TrimSpace(targetID)
+	if botID == "" || sessionID == "" || targetID == "" {
+		return false, nil
+	}
+	if commandType != CommandToolApprovalResponse && commandType != CommandUserInputResponse {
+		return false, fmt.Errorf("unsupported active runtime command %q", commandType)
+	}
+	snapshot, err := m.Snapshot(ctx, botID, sessionID)
+	if err != nil {
+		return false, err
+	}
+	run := snapshot.CurrentRunView
+	if run == nil || !isActiveRunStatus(run.Status) || !runtimeCommandTargetPresent(run, commandType, targetID) {
+		return false, nil
+	}
+	if m.distributed == nil {
+		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
+		defer cancel()
+		return true, m.applyRoutedCommand(commandCtx, Command{
+			Type: commandType, ID: uuid.NewString(), BotID: botID, SessionID: sessionID,
+			StreamID: strings.TrimSpace(run.StreamID), TargetID: targetID,
+			Payload: append([]byte(nil), payload...), CreatedAt: time.Now().UTC(),
+		})
+	}
+	ownerID := strings.TrimSpace(run.OwnerID)
+	if ownerID == "" {
+		return true, errors.New("target runtime owner is unknown")
+	}
+	cmd := Command{
+		Type:         commandType,
+		ID:           uuid.NewString(),
+		ReplyOwnerID: m.ownerID,
+		BotID:        botID,
+		SessionID:    sessionID,
+		StreamID:     strings.TrimSpace(run.StreamID),
+		TargetID:     targetID,
+		Payload:      append([]byte(nil), payload...),
+		CreatedAt:    time.Now().UTC(),
+	}
+	if ownerID == m.ownerID {
+		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
+		defer cancel()
+		return true, m.applyRoutedCommand(commandCtx, cmd)
+	}
+
+	result := make(chan error, 1)
+	m.mu.Lock()
+	if m.isClosed() {
+		m.mu.Unlock()
+		return true, ErrManagerClosed
+	}
+	m.pendingCommands[cmd.ID] = result
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		if m.pendingCommands[cmd.ID] == result {
+			delete(m.pendingCommands, cmd.ID)
+		}
+		m.mu.Unlock()
+	}()
+	if err := m.distributed.PublishCommand(ctx, ownerID, cmd); err != nil {
+		return true, err
+	}
+	timeout := m.commandTimeout()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-result:
+		return true, err
+	case <-ctx.Done():
+		return true, ctx.Err()
+	case <-timer.C:
+		return true, errors.New("runtime command was not acknowledged")
+	}
+}
+
+func (m *Manager) requestAbort(ctx context.Context, ctrl *runControl) error {
+	if ctrl == nil {
+		return nil
+	}
+	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: ctrl.botID, SessionID: ctrl.sessionID}, ctrl.streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		run := snapshot.CurrentRunView
+		if run.StreamID != ctrl.streamID || !m.runOwnerMatches(run) || !isActiveRunStatus(run.Status) {
+			return snapshot, false, nil
+		}
+		if strings.EqualFold(run.Status, RunStatusAborting) {
+			return snapshot, false, nil
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		run.Status = RunStatusAborting
+		run.UpdatedAt = now
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return runtimeRunPatch(snapshot, true, false, false, false)
+	})
+	return err
+}
+
+func (m *Manager) Steer(ctx context.Context, botID, sessionID, streamID, text string) (SteerState, error) {
+	if m == nil || m.backend == nil {
+		return SteerState{}, errors.New("session runtime manager is not configured")
+	}
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
+	streamID = strings.TrimSpace(streamID)
+	text = strings.TrimSpace(text)
+	if botID == "" || sessionID == "" || text == "" {
+		return SteerState{}, errors.New("bot_id, session_id, and text are required")
+	}
+	if streamID == "" {
+		snapshot, err := m.Snapshot(ctx, botID, sessionID)
+		if err != nil {
+			return SteerState{}, err
+		}
+		if snapshot.CurrentRunView == nil {
+			return SteerState{}, errors.New("no active runtime run")
+		}
+		streamID = strings.TrimSpace(snapshot.CurrentRunView.StreamID)
+	}
+	var steer SteerState
+	var ownerID string
+	var commandCreatedAt time.Time
+	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if snapshot.CurrentRunView.StreamID != streamID || !strings.EqualFold(snapshot.CurrentRunView.Status, RunStatusRunning) {
+			return snapshot, false, errors.New("target runtime run is not active")
+		}
+		if snapshot.CurrentRunView.Steer != nil && isPendingSteerStatus(snapshot.CurrentRunView.Steer.Status) {
+			return snapshot, false, errors.New("another runtime steer command is still pending")
+		}
+		steer = SteerState{
+			ID:        uuid.NewString(),
+			Status:    SteerStatusPending,
+			Text:      text,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		commandCreatedAt = now
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView.Steer = &steer
+		snapshot.CurrentRunView.UpdatedAt = now
+		ownerID = strings.TrimSpace(snapshot.CurrentRunView.OwnerID)
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return runtimeRunPatch(snapshot, false, false, true, false)
+	})
+	if err != nil {
+		return SteerState{}, err
+	}
+
+	cmd := Command{Type: CommandSteer, BotID: botID, SessionID: sessionID, StreamID: streamID, SteerID: steer.ID, Text: text, CreatedAt: commandCreatedAt}
+	if ctrl := m.localControl(streamID); ctrl != nil {
+		m.applyCommand(ctx, cmd)
+	} else {
+		if ownerID == "" {
+			return steer, errors.New("target runtime owner is unknown")
+		}
+		if m.distributed == nil {
+			return steer, errors.New("active runtime is not local")
+		}
+		if err := m.distributed.PublishCommand(ctx, ownerID, cmd); err != nil {
+			_ = m.updateSteerStatus(context.WithoutCancel(ctx), botID, sessionID, streamID, steer.ID, SteerStatusRejected, err.Error())
+			return steer, err
+		}
+	}
+	m.rejectPendingSteerAfterTimeout(context.WithoutCancel(ctx), botID, sessionID, streamID, steer.ID)
+	return steer, nil
+}
+
+func (m *Manager) applyCommand(ctx context.Context, cmd Command) {
+	switch strings.TrimSpace(cmd.Type) {
+	case CommandAbort:
+		ctrl := m.localControl(strings.TrimSpace(cmd.StreamID))
+		if ctrl == nil || ctrl.botID != strings.TrimSpace(cmd.BotID) || ctrl.sessionID != strings.TrimSpace(cmd.SessionID) {
+			m.logger.Warn("ignore abort command for inactive local run", slog.String("stream_id", cmd.StreamID))
+			return
+		}
+		if _, err := m.abortLocal(ctx, ctrl); err != nil {
+			m.logger.Warn("apply abort command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+		}
+	case CommandSteer:
+		m.applySteerCommand(ctx, cmd)
+	case CommandToolApprovalResponse, CommandUserInputResponse:
+		commandCtx, cancel := context.WithTimeout(ctx, m.commandTimeout())
+		err := m.applyRoutedCommand(commandCtx, cmd)
+		cancel()
+		m.publishCommandResult(ctx, cmd, err)
+	case CommandResult:
+		m.completePendingCommand(cmd)
+	}
+}
+
+func (m *Manager) applyRoutedCommand(ctx context.Context, cmd Command) error {
+	ctrl := m.localControl(strings.TrimSpace(cmd.StreamID))
+	if ctrl == nil || ctrl.botID != strings.TrimSpace(cmd.BotID) || ctrl.sessionID != strings.TrimSpace(cmd.SessionID) {
+		return ErrCommandTargetNotActive
+	}
+	if err := m.ValidateRunOwnership(ctx, cmd.BotID, cmd.SessionID, cmd.StreamID); err != nil {
+		return ErrCommandTargetNotActive
+	}
+	snapshot, ok, err := m.backend.Load(ctx, Key{BotID: cmd.BotID, SessionID: cmd.SessionID})
+	if err != nil {
+		return err
+	}
+	if !ok || snapshot.CurrentRunView == nil {
+		return ErrCommandTargetNotActive
+	}
+	run := snapshot.CurrentRunView
+	if run.StreamID != ctrl.streamID || !m.runOwnerMatches(run) || !isActiveRunStatus(run.Status) || !runtimeCommandTargetPresent(run, cmd.Type, cmd.TargetID) {
+		return ErrCommandTargetNotActive
+	}
+	m.mu.Lock()
+	handler := m.commandHandler
+	m.mu.Unlock()
+	if handler == nil {
+		return errors.New("runtime command handler is not configured")
+	}
+	return handler(ctx, cmd)
+}
+
+func (m *Manager) publishCommandResult(ctx context.Context, request Command, err error) {
+	replyOwnerID := strings.TrimSpace(request.ReplyOwnerID)
+	if replyOwnerID == "" {
+		return
+	}
+	if m.distributed == nil {
+		return
+	}
+	result := Command{Type: CommandResult, ID: request.ID, CreatedAt: time.Now().UTC()}
+	if err != nil {
+		result.Error = err.Error()
+		if errors.Is(err, ErrCommandTargetNotActive) {
+			result.ErrorCode = "target_not_active"
+		} else {
+			result.ErrorCode = "runtime_command_failed"
+		}
+	}
+	publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.commandTimeout())
+	defer cancel()
+	if publishErr := m.distributed.PublishCommand(publishCtx, replyOwnerID, result); publishErr != nil {
+		m.logger.Warn("publish runtime command result failed", slog.Any("error", publishErr), slog.String("command_id", request.ID))
+	}
+}
+
+func (m *Manager) commandTimeout() time.Duration {
+	if m != nil && m.commandAckTTL > 0 {
+		return m.commandAckTTL
+	}
+	return defaultCommandAckTTL
+}
+
+func (m *Manager) completePendingCommand(result Command) {
+	m.mu.Lock()
+	pending := m.pendingCommands[strings.TrimSpace(result.ID)]
+	if pending != nil {
+		delete(m.pendingCommands, strings.TrimSpace(result.ID))
+	}
+	m.mu.Unlock()
+	if pending == nil {
+		return
+	}
+	var err error
+	if strings.TrimSpace(result.Error) != "" {
+		if result.ErrorCode == "target_not_active" {
+			err = fmt.Errorf("%w: %s", ErrCommandTargetNotActive, result.Error)
+		} else {
+			err = errors.New(result.Error)
+		}
+	}
+	pending <- err
+}
+
+func runtimeCommandTargetPresent(run *CurrentRunView, commandType, targetID string) bool {
+	targetID = strings.TrimSpace(targetID)
+	if run == nil || targetID == "" {
+		return false
+	}
+	for _, message := range run.Messages {
+		switch commandType {
+		case CommandToolApprovalResponse:
+			if message.Approval != nil && (strings.TrimSpace(message.Approval.ApprovalID) == targetID || strconv.Itoa(message.Approval.ShortID) == targetID) {
+				return true
+			}
+		case CommandUserInputResponse:
+			if message.UserInput != nil && (strings.TrimSpace(message.UserInput.UserInputID) == targetID || strconv.Itoa(message.UserInput.ShortID) == targetID) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m *Manager) applySteerCommand(ctx context.Context, cmd Command) {
+	if err := m.ValidateRunOwnership(ctx, cmd.BotID, cmd.SessionID, cmd.StreamID); err != nil {
+		_ = m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, ErrRunOwnershipLost.Error())
+		return
+	}
+	if !m.steerCommandIsPending(context.WithoutCancel(ctx), cmd) {
+		return
+	}
+	now, err := m.backend.Now(ctx)
+	if err != nil {
+		m.logger.Warn("load runtime backend time for steer command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+		return
+	}
+	if m.commandAckTTL > 0 && !cmd.CreatedAt.IsZero() && now.After(cmd.CreatedAt.Add(m.commandAckTTL)) {
+		if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, steerNotAcknowledgedError); err != nil {
+			m.logger.Warn("reject expired steer command failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+		}
+		return
+	}
+
+	ctrl := m.localControl(cmd.StreamID)
+	errText := ""
+	if ctrl != nil && ctrl.injectCh != nil && strings.TrimSpace(cmd.Text) != "" {
+		queued, err := m.transitionSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusQueued, "")
+		if err != nil {
+			m.logger.Warn("acknowledge queued steer failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+			return
+		}
+		if !queued {
+			return
+		}
+		select {
+		case ctrl.injectCh <- conversation.InjectMessage{
+			Text: strings.TrimSpace(cmd.Text),
+			Applied: func() {
+				if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusApplied, ""); err != nil {
+					m.logger.Warn("acknowledge applied steer failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+				}
+			},
+		}:
+			return
+		case <-ctx.Done():
+			errText = ctx.Err().Error()
+		default:
+			errText = "active runtime is not accepting steer messages"
+		}
+	} else {
+		errText = "active runtime is not available"
+	}
+	if err := m.updateSteerStatus(context.WithoutCancel(ctx), cmd.BotID, cmd.SessionID, cmd.StreamID, cmd.SteerID, SteerStatusRejected, errText); err != nil {
+		m.logger.Warn("update steer status failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+	}
+}
+
+func (m *Manager) steerCommandIsPending(ctx context.Context, cmd Command) bool {
+	if strings.TrimSpace(cmd.SteerID) == "" {
+		return false
+	}
+	snapshot, ok, err := m.backend.Load(ctx, Key{BotID: cmd.BotID, SessionID: cmd.SessionID})
+	if err != nil {
+		m.logger.Warn("load steer state failed", slog.Any("error", err), slog.String("stream_id", cmd.StreamID))
+		return false
+	}
+	if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != strings.TrimSpace(cmd.StreamID) {
+		return false
+	}
+	steer := snapshot.CurrentRunView.Steer
+	return steer != nil && steer.ID == strings.TrimSpace(cmd.SteerID) && strings.EqualFold(steer.Status, SteerStatusPending)
+}
+
+func (m *Manager) updateSteerStatus(ctx context.Context, botID, sessionID, streamID, steerID, status, errText string) error {
+	_, err := m.transitionSteerStatus(ctx, botID, sessionID, streamID, steerID, status, errText)
+	return err
+}
+
+func (m *Manager) transitionSteerStatus(ctx context.Context, botID, sessionID, streamID, steerID, status, errText string) (bool, error) {
+	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if snapshot.CurrentRunView.StreamID != streamID {
+			return snapshot, false, nil
+		}
+		if snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.ID != steerID {
+			return snapshot, false, nil
+		}
+		currentStatus := snapshot.CurrentRunView.Steer.Status
+		if !validSteerTransition(currentStatus, status) {
+			return snapshot, false, nil
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView.UpdatedAt = now
+		snapshot.CurrentRunView.Steer.Status = status
+		snapshot.CurrentRunView.Steer.Error = strings.TrimSpace(errText)
+		snapshot.CurrentRunView.Steer.UpdatedAt = now
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return runtimeRunPatch(snapshot, false, false, true, false)
+	})
+	return changed, err
+}
+
+const steerNotAcknowledgedError = "runtime steer command was not acknowledged"
+
+func (m *Manager) rejectPendingSteerAfterTimeout(ctx context.Context, botID, sessionID, streamID, steerID string) {
+	timeout := m.commandAckTTL
+	if timeout <= 0 {
+		return
+	}
+	time.AfterFunc(timeout, func() {
+		select {
+		case <-m.closeCh:
+			return
+		default:
+		}
+		err := m.rejectUnacknowledgedSteer(ctx, botID, sessionID, streamID, steerID)
+		if err != nil {
+			m.logger.Warn("reject pending steer failed", slog.Any("error", err), slog.String("stream_id", streamID))
+		}
+	})
+}
+
+func (m *Manager) rejectUnacknowledgedSteer(ctx context.Context, botID, sessionID, streamID, steerID string) error {
+	_, _, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if snapshot.CurrentRunView.StreamID != streamID {
+			return snapshot, false, nil
+		}
+		steer := snapshot.CurrentRunView.Steer
+		if steer == nil || steer.ID != steerID || !strings.EqualFold(steer.Status, SteerStatusPending) {
+			return snapshot, false, nil
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView.UpdatedAt = now
+		steer.Status = SteerStatusRejected
+		steer.Error = steerNotAcknowledgedError
+		steer.UpdatedAt = now
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return runtimeRunPatch(snapshot, false, false, true, false)
+	})
+	return err
+}
+
+func isPendingSteerStatus(status string) bool {
+	return strings.EqualFold(status, SteerStatusPending) || strings.EqualFold(status, SteerStatusQueued)
+}
+
+func validSteerTransition(current, next string) bool {
+	switch strings.ToLower(strings.TrimSpace(next)) {
+	case SteerStatusQueued:
+		return strings.EqualFold(current, SteerStatusPending)
+	case SteerStatusRejected:
+		return isPendingSteerStatus(current)
+	case SteerStatusApplied:
+		return isPendingSteerStatus(current)
+	default:
+		return false
+	}
+}
+
+func (m *Manager) waitForAbortAck(ctx context.Context, ref StreamRef) error {
+	timeout := m.commandAckTTL
+	if timeout <= 0 {
+		return nil
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(commandAckPollInterval(timeout))
+	defer ticker.Stop()
+	for {
+		snapshot, err := m.Snapshot(waitCtx, ref.BotID, ref.SessionID)
+		if err != nil {
+			return err
+		}
+		if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != ref.StreamID || strings.EqualFold(snapshot.CurrentRunView.Status, RunStatusAborting) || !isActiveRunStatus(snapshot.CurrentRunView.Status) {
+			return nil
+		}
+		select {
+		case <-waitCtx.Done():
+			return errors.New("runtime abort command was not acknowledged")
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/sessionruntime/config.go
+++ b/internal/sessionruntime/config.go
@@ -1,0 +1,41 @@
+package sessionruntime
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/memohai/memoh/internal/config"
+)
+
+func NewManagerFromConfig(log *slog.Logger, cfg config.SessionRuntimeConfig) (*Manager, error) {
+	stateTTL, err := time.ParseDuration(cfg.StateTTLOrDefault())
+	if err != nil {
+		return nil, err
+	}
+	var backend Backend
+	var leaseTTL time.Duration
+	switch cfg.BackendOrDefault() {
+	case config.SessionRuntimeBackendRedis:
+		leaseTTL, err = time.ParseDuration(cfg.OwnerLeaseTTLOrDefault())
+		if err != nil {
+			return nil, err
+		}
+		redisBackend, err := newRedisBackend(RedisOptions{
+			URL:       cfg.Redis.URLOrDefault(),
+			KeyPrefix: cfg.Redis.KeyPrefixOrDefault(),
+			StateTTL:  stateTTL,
+		})
+		if err != nil {
+			return nil, err
+		}
+		backend = redisBackend
+	default:
+		backend = NewMemoryBackendWithTTL(stateTTL)
+	}
+
+	return NewManager(backend, Options{
+		StateTTL:      stateTTL,
+		OwnerLeaseTTL: leaseTTL,
+		Logger:        log,
+	}), nil
+}

--- a/internal/sessionruntime/config_test.go
+++ b/internal/sessionruntime/config_test.go
@@ -1,0 +1,34 @@
+package sessionruntime
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/memohai/memoh/internal/config"
+)
+
+func TestNewManagerFromConfigDefersRedisIOUntilStart(t *testing.T) {
+	t.Parallel()
+
+	manager, err := NewManagerFromConfig(slog.Default(), config.SessionRuntimeConfig{
+		Backend:       config.SessionRuntimeBackendRedis,
+		StateTTL:      "1h",
+		OwnerLeaseTTL: "30s",
+		Redis: config.SessionRuntimeRedisConfig{
+			URL:       "redis://127.0.0.1:1/0",
+			KeyPrefix: "memoh:test:deferred-start:",
+		},
+	})
+	if err != nil {
+		t.Fatalf("construct manager without Redis I/O: %v", err)
+	}
+	t.Cleanup(func() { _ = manager.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := manager.Start(ctx); err == nil {
+		t.Fatal("start unexpectedly succeeded against unavailable Redis")
+	}
+}

--- a/internal/sessionruntime/control.go
+++ b/internal/sessionruntime/control.go
@@ -5,7 +5,11 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/memohai/memoh/internal/conversation"
+	"github.com/memohai/memoh/internal/runtimefence"
 )
 
 func (m *Manager) localControl(streamID string) *runControl {
@@ -17,25 +21,58 @@ func (m *Manager) localControl(streamID string) *runControl {
 	return m.controls[strings.TrimSpace(streamID)]
 }
 
+func (m *Manager) localControlForHandle(handle RunHandle) *runControl {
+	handle = handle.normalized()
+	ctrl := m.localControl(handle.StreamID)
+	if ctrl == nil || ctrl.botID != handle.BotID || ctrl.sessionID != handle.SessionID || ctrl.generation != handle.Generation {
+		return nil
+	}
+	return ctrl
+}
+
+func (m *Manager) forgetLocalControlForHandle(ctx context.Context, handle RunHandle) {
+	handle = handle.normalized()
+	m.mu.Lock()
+	ctrl := m.controls[handle.StreamID]
+	if ctrl == nil || ctrl.botID != handle.BotID || ctrl.sessionID != handle.SessionID || ctrl.generation != handle.Generation {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.controls, handle.StreamID)
+	m.mu.Unlock()
+	ctrl.stopCommands()
+	_ = waitRunControlReady(ctx, ctrl)
+	_ = m.stopLeaseRenewalContext(ctx, ctrl)
+	ctrl.revokeOwnership(context.Canceled)
+}
+
 func (m *Manager) forgetLocalControl(ctx context.Context, streamID string) {
 	m.mu.Lock()
 	ctrl := m.controls[strings.TrimSpace(streamID)]
 	delete(m.controls, strings.TrimSpace(streamID))
 	m.mu.Unlock()
+	ctrl.stopCommands()
 	_ = waitRunControlReady(ctx, ctrl)
-	m.stopLeaseRenewal(ctrl)
+	_ = m.stopLeaseRenewalContext(ctx, ctrl)
+	ctrl.revokeOwnership(context.Canceled)
 }
 
 func (m *Manager) removeLocalControl(streamID string, expected *runControl) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	key := strings.TrimSpace(streamID)
+	removed := false
 	if m.controls[key] == expected {
 		delete(m.controls, key)
+		removed = true
+	}
+	m.mu.Unlock()
+	if removed {
+		expected.stopCommands()
+		expected.revokeOwnership(ErrRunOwnershipLost)
 	}
 }
 
-func (m *Manager) stopAllLocalControls(ctx context.Context) {
+func (m *Manager) stopAllLocalControls(ctx context.Context) error {
 	m.mu.Lock()
 	controls := make([]*runControl, 0, len(m.controls))
 	for streamID, ctrl := range m.controls {
@@ -43,7 +80,10 @@ func (m *Manager) stopAllLocalControls(ctx context.Context) {
 		delete(m.controls, streamID)
 	}
 	m.mu.Unlock()
+	var stopErr error
 	for _, ctrl := range controls {
+		ctrl.revokeOwnership(context.Canceled)
+		ctrl.stopCommands()
 		select {
 		case ctrl.abortCh <- struct{}{}:
 		default:
@@ -51,9 +91,107 @@ func (m *Manager) stopAllLocalControls(ctx context.Context) {
 		if ctrl.cancel != nil {
 			ctrl.cancel()
 		}
-		_ = waitRunControlReady(ctx, ctrl)
-		m.stopLeaseRenewal(ctrl)
+		if err := waitRunControlReady(ctx, ctrl); err != nil && stopErr == nil {
+			stopErr = err
+		}
+		if err := m.stopLeaseRenewalContext(ctx, ctrl); err != nil && stopErr == nil {
+			stopErr = err
+		}
 	}
+	return stopErr
+}
+
+const runtimeOwnerShutdownError = "runtime owner shut down"
+
+func (m *Manager) releaseAllLocalRuns(ctx context.Context) error {
+	if m == nil || m.distributed == nil {
+		return nil
+	}
+	m.mu.Lock()
+	controls := make([]*runControl, 0, len(m.controls))
+	for _, ctrl := range m.controls {
+		controls = append(controls, ctrl)
+	}
+	m.mu.Unlock()
+
+	var releaseErr error
+	for _, ctrl := range controls {
+		_, err := m.finishRunState(ctx, ctrl.handle(), RunStatusLost, runtimeOwnerShutdownError)
+		if err == nil || errors.Is(err, ErrRunOwnershipLost) {
+			continue
+		}
+		if releaseErr == nil {
+			releaseErr = err
+		}
+		m.logger.Warn("release runtime run during shutdown failed", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
+	}
+	return releaseErr
+}
+
+func (c *runControl) commandContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if c != nil {
+		if fence, ok := runtimefence.FromContext(c.lifecycleCtx); ok {
+			parent = runtimefence.WithContext(parent, fence)
+		}
+	}
+	ctx, cancel := context.WithCancel(parent)
+	if c == nil || c.lifecycleCtx == nil {
+		return ctx, cancel
+	}
+	stop := context.AfterFunc(c.lifecycleCtx, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
+}
+
+func (c *runControl) commandsActive() bool {
+	return c != nil && c.lifecycleCtx != nil && c.lifecycleCtx.Err() == nil
+}
+
+func (c *runControl) stopCommands() {
+	if c == nil {
+		return
+	}
+	if c.lifecycleCancel != nil {
+		c.lifecycleCancel()
+	}
+	c.closeInject()
+}
+
+func (c *runControl) sendInject(ctx context.Context, message conversation.InjectMessage) (bool, string) {
+	if c == nil {
+		return false, "active runtime is not available"
+	}
+	c.injectMu.Lock()
+	defer c.injectMu.Unlock()
+	if c.injectClosed || c.injectCh == nil {
+		return false, "active runtime is not available"
+	}
+	select {
+	case c.injectCh <- message:
+		return true, ""
+	case <-ctx.Done():
+		return false, ctx.Err().Error()
+	default:
+		return false, "active runtime is not accepting steer messages"
+	}
+}
+
+func (c *runControl) closeInject() {
+	if c == nil {
+		return
+	}
+	c.injectMu.Lock()
+	defer c.injectMu.Unlock()
+	if c.injectClosed || c.injectCh == nil {
+		return
+	}
+	close(c.injectCh)
+	c.injectClosed = true
 }
 
 func (c *runControl) markReady() {
@@ -81,11 +219,15 @@ func (m *Manager) startLeaseRenewal(ctx context.Context, ctrl *runControl) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
+	ctrl.leaseLifecycleMu.Lock()
 	ctrl.leaseStop = cancel
 	ctrl.leaseDone = done
+	ctrl.leaseLifecycleMu.Unlock()
 	interval := leaseRenewInterval(m.ownerLeaseTTL)
+	var workers sync.WaitGroup
+	workers.Add(2)
 	go func() {
-		defer close(done)
+		defer workers.Done()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -97,12 +239,26 @@ func (m *Manager) startLeaseRenewal(ctx context.Context, ctrl *runControl) {
 					m.cancelRunControl(ctrl)
 					return
 				}
-				now, err := m.backend.Now(ctx)
-				if err == nil {
-					err = m.distributed.RenewLease(ctx, Key{BotID: ctrl.botID, SessionID: ctrl.sessionID}, ctrl.streamID, m.ownerID, now, now.Add(m.ownerLeaseTTL))
+				localRenewalStarted := time.Now()
+				leaseDeadline := ctrl.leaseDeadline()
+				if leaseDeadline.IsZero() || !localRenewalStarted.Before(leaseDeadline) {
+					m.cancelRunControl(ctrl)
+					return
 				}
+				renewCtx, renewCancel := context.WithDeadline(ctx, leaseDeadline)
+				now, err := m.backend.Now(renewCtx)
 				if err == nil {
-					ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+					err = m.distributed.RenewLease(renewCtx, Key{BotID: ctrl.botID, SessionID: ctrl.sessionID}, ctrl.streamID, m.ownerID, ctrl.generation, now, now.Add(m.ownerLeaseTTL))
+				}
+				renewCancel()
+				if err == nil {
+					deadline := localRenewalStarted.Add(m.ownerLeaseTTL)
+					if !time.Now().Before(deadline) {
+						m.cancelRunControl(ctrl)
+						cancel()
+						return
+					}
+					ctrl.setLeaseValidUntil(deadline)
 					continue
 				}
 				if ctx.Err() != nil {
@@ -116,6 +272,14 @@ func (m *Manager) startLeaseRenewal(ctx context.Context, ctrl *runControl) {
 			}
 		}
 	}()
+	go func() {
+		defer workers.Done()
+		m.watchLeaseDeadline(ctx, cancel, ctrl)
+	}()
+	go func() {
+		workers.Wait()
+		close(done)
+	}()
 }
 
 func (c *runControl) setLeaseValidUntil(deadline time.Time) {
@@ -125,6 +289,63 @@ func (c *runControl) setLeaseValidUntil(deadline time.Time) {
 	c.leaseMu.Lock()
 	c.leaseValidUntil = deadline
 	c.leaseMu.Unlock()
+	if c.leaseChanged != nil {
+		select {
+		case c.leaseChanged <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (m *Manager) watchLeaseDeadline(ctx context.Context, stop context.CancelFunc, ctrl *runControl) {
+	for {
+		deadline := ctrl.leaseDeadline()
+		if deadline.IsZero() {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ctrl.leaseChanged:
+				continue
+			}
+		}
+		timer := time.NewTimer(time.Until(deadline))
+		select {
+		case <-ctx.Done():
+			stopTimer(timer)
+			return
+		case <-ctrl.leaseChanged:
+			stopTimer(timer)
+			continue
+		case <-timer.C:
+			if ctrl.leaseIsValidAt(time.Now()) {
+				continue
+			}
+			stop()
+			m.cancelRunControl(ctrl)
+			return
+		}
+	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func (c *runControl) leaseDeadline() time.Time {
+	if c == nil {
+		return time.Time{}
+	}
+	c.leaseMu.RLock()
+	defer c.leaseMu.RUnlock()
+	return c.leaseValidUntil
 }
 
 func (c *runControl) leaseIsValidAt(now time.Time) bool {
@@ -141,6 +362,8 @@ func (*Manager) cancelRunControl(ctrl *runControl) {
 	if ctrl == nil {
 		return
 	}
+	ctrl.revokeOwnership(ErrRunOwnershipLost)
+	ctrl.stopCommands()
 	select {
 	case ctrl.abortCh <- struct{}{}:
 	default:
@@ -150,14 +373,39 @@ func (*Manager) cancelRunControl(ctrl *runControl) {
 	}
 }
 
-func (*Manager) stopLeaseRenewal(ctrl *runControl) {
-	if ctrl == nil || ctrl.leaseStop == nil {
+func (c *runControl) revokeOwnership(cause error) {
+	if c == nil || c.ownershipCancel == nil {
 		return
 	}
-	ctrl.leaseStop()
-	if ctrl.leaseDone != nil {
-		<-ctrl.leaseDone
+	c.ownershipOnce.Do(func() { c.ownershipCancel(cause) })
+}
+
+func (m *Manager) stopLeaseRenewal(ctrl *runControl) {
+	_ = m.stopLeaseRenewalContext(context.Background(), ctrl)
+}
+
+func (*Manager) stopLeaseRenewalContext(ctx context.Context, ctrl *runControl) error {
+	if ctrl == nil {
+		return nil
 	}
+	ctrl.leaseLifecycleMu.Lock()
+	stop := ctrl.leaseStop
+	done := ctrl.leaseDone
+	ctrl.leaseLifecycleMu.Unlock()
+	if stop == nil {
+		return nil
+	}
+	stop()
+	if done != nil {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	ctrl.leaseLifecycleMu.Lock()
 	ctrl.leaseStop = nil
 	ctrl.leaseDone = nil
+	ctrl.leaseLifecycleMu.Unlock()
+	return nil
 }

--- a/internal/sessionruntime/control.go
+++ b/internal/sessionruntime/control.go
@@ -1,0 +1,163 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+func (m *Manager) localControl(streamID string) *runControl {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.controls[strings.TrimSpace(streamID)]
+}
+
+func (m *Manager) forgetLocalControl(ctx context.Context, streamID string) {
+	m.mu.Lock()
+	ctrl := m.controls[strings.TrimSpace(streamID)]
+	delete(m.controls, strings.TrimSpace(streamID))
+	m.mu.Unlock()
+	_ = waitRunControlReady(ctx, ctrl)
+	m.stopLeaseRenewal(ctrl)
+}
+
+func (m *Manager) removeLocalControl(streamID string, expected *runControl) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := strings.TrimSpace(streamID)
+	if m.controls[key] == expected {
+		delete(m.controls, key)
+	}
+}
+
+func (m *Manager) stopAllLocalControls(ctx context.Context) {
+	m.mu.Lock()
+	controls := make([]*runControl, 0, len(m.controls))
+	for streamID, ctrl := range m.controls {
+		controls = append(controls, ctrl)
+		delete(m.controls, streamID)
+	}
+	m.mu.Unlock()
+	for _, ctrl := range controls {
+		select {
+		case ctrl.abortCh <- struct{}{}:
+		default:
+		}
+		if ctrl.cancel != nil {
+			ctrl.cancel()
+		}
+		_ = waitRunControlReady(ctx, ctrl)
+		m.stopLeaseRenewal(ctrl)
+	}
+}
+
+func (c *runControl) markReady() {
+	if c == nil {
+		return
+	}
+	c.readyOnce.Do(func() { close(c.ready) })
+}
+
+func waitRunControlReady(ctx context.Context, ctrl *runControl) error {
+	if ctrl == nil || ctrl.ready == nil {
+		return nil
+	}
+	select {
+	case <-ctrl.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *Manager) startLeaseRenewal(ctx context.Context, ctrl *runControl) {
+	if m == nil || ctrl == nil || m.distributed == nil || m.ownerLeaseTTL <= 0 {
+		return
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	ctrl.leaseStop = cancel
+	ctrl.leaseDone = done
+	interval := leaseRenewInterval(m.ownerLeaseTTL)
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if !ctrl.leaseIsValidAt(time.Now()) {
+					m.cancelRunControl(ctrl)
+					return
+				}
+				now, err := m.backend.Now(ctx)
+				if err == nil {
+					err = m.distributed.RenewLease(ctx, Key{BotID: ctrl.botID, SessionID: ctrl.sessionID}, ctrl.streamID, m.ownerID, now, now.Add(m.ownerLeaseTTL))
+				}
+				if err == nil {
+					ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+					continue
+				}
+				if ctx.Err() != nil {
+					return
+				}
+				m.logger.Warn("renew runtime owner lease failed", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
+				if errors.Is(err, ErrRunOwnershipLost) || !ctrl.leaseIsValidAt(time.Now()) {
+					m.cancelRunControl(ctrl)
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (c *runControl) setLeaseValidUntil(deadline time.Time) {
+	if c == nil {
+		return
+	}
+	c.leaseMu.Lock()
+	c.leaseValidUntil = deadline
+	c.leaseMu.Unlock()
+}
+
+func (c *runControl) leaseIsValidAt(now time.Time) bool {
+	if c == nil {
+		return false
+	}
+	c.leaseMu.RLock()
+	deadline := c.leaseValidUntil
+	c.leaseMu.RUnlock()
+	return !deadline.IsZero() && now.Before(deadline)
+}
+
+func (*Manager) cancelRunControl(ctrl *runControl) {
+	if ctrl == nil {
+		return
+	}
+	select {
+	case ctrl.abortCh <- struct{}{}:
+	default:
+	}
+	if ctrl.cancel != nil {
+		ctrl.cancel()
+	}
+}
+
+func (*Manager) stopLeaseRenewal(ctrl *runControl) {
+	if ctrl == nil || ctrl.leaseStop == nil {
+		return
+	}
+	ctrl.leaseStop()
+	if ctrl.leaseDone != nil {
+		<-ctrl.leaseDone
+	}
+	ctrl.leaseStop = nil
+	ctrl.leaseDone = nil
+}

--- a/internal/sessionruntime/manager.go
+++ b/internal/sessionruntime/manager.go
@@ -1,0 +1,908 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+type Manager struct {
+	backend       Backend
+	distributed   DistributedBackend
+	ownerID       string
+	stateTTL      time.Duration
+	ownerLeaseTTL time.Duration
+	commandAckTTL time.Duration
+	logger        *slog.Logger
+
+	mu              sync.Mutex
+	controls        map[string]*runControl
+	commandHandler  func(context.Context, Command) error
+	pendingCommands map[string]chan error
+
+	commandCancel context.CancelFunc
+	commandDone   chan struct{}
+	closeCh       chan struct{}
+	closeOnce     sync.Once
+}
+
+type runControl struct {
+	botID           string
+	sessionID       string
+	streamID        string
+	abortCh         chan<- struct{}
+	cancel          context.CancelFunc
+	injectCh        chan<- conversation.InjectMessage
+	converter       *conversation.UIMessageStreamConverter
+	leaseStop       func()
+	leaseDone       chan struct{}
+	leaseMu         sync.RWMutex
+	leaseValidUntil time.Time
+	ready           chan struct{}
+	readyOnce       sync.Once
+	finishRetryOnce sync.Once
+}
+
+type Options struct {
+	OwnerID       string
+	StateTTL      time.Duration
+	OwnerLeaseTTL time.Duration
+	CommandAckTTL time.Duration
+	Logger        *slog.Logger
+}
+
+const defaultCommandAckTTL = 2 * time.Second
+
+func NewManager(backend Backend, opts Options) *Manager {
+	ownerID := strings.TrimSpace(opts.OwnerID)
+	if ownerID == "" {
+		ownerID = uuid.NewString()
+	}
+	stateTTL := opts.StateTTL
+	if stateTTL <= 0 {
+		stateTTL = 24 * time.Hour
+	}
+	leaseTTL := opts.OwnerLeaseTTL
+	if leaseTTL <= 0 {
+		leaseTTL = 30 * time.Second
+	}
+	commandAckTTL := opts.CommandAckTTL
+	if commandAckTTL <= 0 {
+		commandAckTTL = defaultCommandAckTTL
+	}
+	log := opts.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	distributed, _ := backend.(DistributedBackend)
+	return &Manager{
+		backend:         backend,
+		distributed:     distributed,
+		ownerID:         ownerID,
+		stateTTL:        stateTTL,
+		ownerLeaseTTL:   leaseTTL,
+		commandAckTTL:   commandAckTTL,
+		logger:          log.With(slog.String("component", "session_runtime")),
+		controls:        make(map[string]*runControl),
+		pendingCommands: make(map[string]chan error),
+		closeCh:         make(chan struct{}),
+	}
+}
+
+func (m *Manager) isClosed() bool {
+	if m == nil || m.closeCh == nil {
+		return false
+	}
+	select {
+	case <-m.closeCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// SetCommandHandler installs the owner-local executor for routed runtime
+// commands whose domain behavior lives outside the sessionruntime package.
+func (m *Manager) SetCommandHandler(handler func(context.Context, Command) error) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.commandHandler = handler
+	m.mu.Unlock()
+}
+
+func (m *Manager) Start(ctx context.Context) error {
+	if m == nil || m.distributed == nil {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	sub, err := m.distributed.SubscribeCommands(ctx, m.ownerID)
+	if err != nil {
+		cancel()
+		if m.isClosed() {
+			return ErrManagerClosed
+		}
+		return err
+	}
+	stopCommands := sync.OnceFunc(func() {
+		cancel()
+		sub.Close()
+	})
+	commandDone := make(chan struct{})
+	m.mu.Lock()
+	if m.isClosed() {
+		m.mu.Unlock()
+		stopCommands()
+		return ErrManagerClosed
+	}
+	if m.commandCancel != nil || m.commandDone != nil {
+		m.mu.Unlock()
+		stopCommands()
+		return errors.New("session runtime manager is already started")
+	}
+	m.commandCancel = stopCommands
+	m.commandDone = commandDone
+	m.mu.Unlock()
+	go func() {
+		defer close(commandDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case cmd, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				m.applyCommand(context.WithoutCancel(ctx), cmd)
+			}
+		}
+	}()
+	return nil
+}
+
+func (m *Manager) Close() error {
+	return m.CloseContext(context.Background())
+}
+
+func (m *Manager) CloseContext(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	if m.closeCh != nil {
+		m.closeOnce.Do(func() { close(m.closeCh) })
+	}
+	m.mu.Lock()
+	commandCancel := m.commandCancel
+	commandDone := m.commandDone
+	m.commandCancel = nil
+	m.commandDone = nil
+	pendingCommands := make([]chan error, 0, len(m.pendingCommands))
+	for commandID, pending := range m.pendingCommands {
+		pendingCommands = append(pendingCommands, pending)
+		delete(m.pendingCommands, commandID)
+	}
+	m.mu.Unlock()
+	if commandCancel != nil {
+		commandCancel()
+	}
+	for _, pending := range pendingCommands {
+		pending <- ErrManagerClosed
+	}
+	m.stopAllLocalControls(ctx)
+	if commandDone != nil {
+		select {
+		case <-commandDone:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if m.backend != nil {
+		return m.backend.Close()
+	}
+	return nil
+}
+
+func (m *Manager) StartRun(ctx context.Context, botID, sessionID, streamID string, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	return m.StartRunWithAdmission(ctx, botID, sessionID, streamID, RunAdmissionView{}, abortCh, cancel, injectCh)
+}
+
+func (m *Manager) StartRunWithOperation(ctx context.Context, botID, sessionID, streamID string, operation *RunOperationView, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	return m.StartRunWithAdmission(ctx, botID, sessionID, streamID, RunAdmissionView{Operation: operation}, abortCh, cancel, injectCh)
+}
+
+func (m *Manager) StartRunWithAdmission(ctx context.Context, botID, sessionID, streamID string, admission RunAdmissionView, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	return m.StartRunWithAdmissionBuilder(ctx, botID, sessionID, streamID, func(context.Context) (RunAdmissionView, error) {
+		return admission, nil
+	}, abortCh, cancel, injectCh)
+}
+
+func (m *Manager) StartRunWithOperationBuilder(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context) (*RunOperationView, error), abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	if builder == nil {
+		return errors.New("runtime operation builder is required")
+	}
+	return m.StartRunWithAdmissionBuilder(ctx, botID, sessionID, streamID, func(ctx context.Context) (RunAdmissionView, error) {
+		operation, err := builder(ctx)
+		return RunAdmissionView{Operation: operation}, err
+	}, abortCh, cancel, injectCh)
+}
+
+// StartRunWithAdmissionBuilder reserves the cross-server run before executing
+// builder, then publishes the running view only after the canonical request
+// turn and optional replacement operation are ready.
+func (m *Manager) StartRunWithAdmissionBuilder(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context) (RunAdmissionView, error), abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	if m == nil || m.backend == nil {
+		return nil
+	}
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
+	streamID = strings.TrimSpace(streamID)
+	if botID == "" || sessionID == "" || streamID == "" {
+		return errors.New("bot_id, session_id, and stream_id are required")
+	}
+	if builder == nil {
+		return errors.New("runtime admission builder is required")
+	}
+
+	ctrl := &runControl{
+		botID:     botID,
+		sessionID: sessionID,
+		streamID:  streamID,
+		abortCh:   abortCh,
+		cancel:    cancel,
+		injectCh:  injectCh,
+		converter: conversation.NewUIMessageStreamConverter(),
+		ready:     make(chan struct{}),
+	}
+	defer ctrl.markReady()
+	m.mu.Lock()
+	select {
+	case <-m.closeCh:
+		m.mu.Unlock()
+		return ErrManagerClosed
+	default:
+	}
+	if _, exists := m.controls[streamID]; exists {
+		m.mu.Unlock()
+		return fmt.Errorf("stream_id %q is already owned by this runtime manager", streamID)
+	}
+	m.controls[streamID] = ctrl
+	m.mu.Unlock()
+
+	now, err := m.backend.Now(ctx)
+	if err != nil {
+		m.removeLocalControl(streamID, ctrl)
+		return fmt.Errorf("load runtime backend time: %w", err)
+	}
+	key := Key{BotID: botID, SessionID: sessionID}
+	ownerID := ""
+	var leaseExpiresAt *time.Time
+	if m.distributed != nil {
+		ownerID = m.ownerID
+		expiresAt := now.Add(m.ownerLeaseTTL)
+		leaseExpiresAt = &expiresAt
+		// The backend claim below is authoritative, but a local deadline must
+		// exist before it returns so an abort can cancel blocked admission.
+		ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+	}
+	var expiredStreamID string
+	claim := func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+		if snapshot.CurrentRunView != nil && isActiveRunStatus(snapshot.CurrentRunView.Status) && snapshot.CurrentRunView.StreamID != streamID {
+			if m.distributed == nil || !m.markLostIfExpired(&snapshot, now) {
+				return snapshot, false, fmt.Errorf("session %q already has an active runtime run", sessionID)
+			}
+			expiredStreamID = snapshot.CurrentRunView.StreamID
+		}
+		snapshot.BotID = botID
+		snapshot.SessionID = sessionID
+		snapshot.Seq++
+		snapshot.Queue = nonNilQueue(snapshot.Queue)
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView = &CurrentRunView{
+			StreamID:            streamID,
+			Status:              RunStatusAdmitting,
+			OwnerID:             ownerID,
+			OwnerLeaseExpiresAt: leaseExpiresAt,
+			StartedAt:           now,
+			UpdatedAt:           now,
+			Messages:            []conversation.UIMessage{},
+		}
+		return snapshot, true, nil
+	}
+	var claimedSnapshot Snapshot
+	var changed bool
+	if m.distributed != nil {
+		claimedSnapshot, changed, err = m.distributed.StartRun(ctx, key, StreamRef{
+			BotID: botID, SessionID: sessionID, StreamID: streamID, OwnerID: m.ownerID,
+		}, claim)
+	} else {
+		claimedSnapshot, changed, err = m.backend.Update(ctx, key, claim)
+	}
+	if err != nil {
+		m.removeLocalControl(streamID, ctrl)
+		return err
+	}
+	if !changed {
+		m.removeLocalControl(streamID, ctrl)
+		return nil
+	}
+	if err := m.publishRuntimeDelta(context.WithoutCancel(ctx), claimedSnapshot, streamID, RuntimeDelta{CurrentRunView: claimedSnapshot.CurrentRunView}); err != nil {
+		m.logger.Warn("publish admitting runtime checkpoint failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+	if expiredStreamID != "" && m.distributed != nil {
+		_ = m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), expiredStreamID)
+	}
+	if m.distributed != nil {
+		renewedAt, renewErr := m.backend.Now(context.WithoutCancel(ctx))
+		if renewErr == nil {
+			renewErr = m.distributed.RenewLease(context.WithoutCancel(ctx), key, streamID, m.ownerID, renewedAt, renewedAt.Add(m.ownerLeaseTTL))
+		}
+		if renewErr != nil {
+			ctrl.markReady()
+			if errors.Is(renewErr, ErrRunOwnershipLost) {
+				m.forgetLocalControl(context.WithoutCancel(ctx), streamID)
+			} else {
+				_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, RunStatusErrored, renewErr.Error())
+			}
+			return fmt.Errorf("confirm runtime owner lease: %w", renewErr)
+		}
+		ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+		m.startLeaseRenewal(context.WithoutCancel(ctx), ctrl)
+	}
+	admission, err := builder(ctx)
+	if err != nil {
+		ctrl.markReady()
+		status := RunStatusErrored
+		message := err.Error()
+		if errors.Is(err, context.Canceled) {
+			status = RunStatusAborted
+			message = ""
+		}
+		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, status, message)
+		return err
+	}
+	if m.isClosed() {
+		return ErrManagerClosed
+	}
+	if m.localControl(streamID) != ctrl {
+		return ErrRunOwnershipLost
+	}
+	admission, err = normalizeRunAdmission(admission)
+	if err != nil {
+		ctrl.markReady()
+		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, RunStatusErrored, err.Error())
+		return err
+	}
+	_, changed, err = m.updateActiveAndPublish(context.WithoutCancel(ctx), key, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		if m.isClosed() {
+			return snapshot, false, ErrManagerClosed
+		}
+		if m.localControl(streamID) != ctrl {
+			return snapshot, false, ErrRunOwnershipLost
+		}
+		run := snapshot.CurrentRunView
+		if run.StreamID == streamID && m.runOwnerMatches(run) && strings.EqualFold(run.Status, RunStatusAborting) {
+			return snapshot, false, context.Canceled
+		}
+		if run.StreamID != streamID || !m.runOwnerMatches(run) || !strings.EqualFold(run.Status, RunStatusAdmitting) {
+			return snapshot, false, errors.New("reserved runtime run is no longer owned by this manager")
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		run.Status = RunStatusRunning
+		run.RequestUserTurn = admission.RequestUserTurn
+		run.Operation = admission.Operation
+		run.UpdatedAt = now
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		return RuntimeDelta{CurrentRunView: snapshot.CurrentRunView}
+	})
+	if err != nil || !changed {
+		ctrl.markReady()
+		if errors.Is(err, ErrManagerClosed) || errors.Is(err, ErrRunOwnershipLost) {
+			return err
+		}
+		if err == nil {
+			err = errors.New("reserved runtime run could not be activated")
+		}
+		status := RunStatusErrored
+		message := err.Error()
+		if errors.Is(err, context.Canceled) {
+			status = RunStatusAborted
+			message = ""
+		}
+		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, status, message)
+		return err
+	}
+	ctrl.markReady()
+	return nil
+}
+
+func (m *Manager) FinishRun(ctx context.Context, botID, sessionID, streamID, status, message string) error {
+	if m == nil || m.backend == nil {
+		return nil
+	}
+	botID = strings.TrimSpace(botID)
+	sessionID = strings.TrimSpace(sessionID)
+	streamID = strings.TrimSpace(streamID)
+	if botID == "" || sessionID == "" || streamID == "" {
+		return nil
+	}
+	status = strings.TrimSpace(status)
+	finishMessage := strings.TrimSpace(message)
+	changed, err := m.finishRunState(ctx, botID, sessionID, streamID, status, finishMessage)
+	if err == nil || changed {
+		m.cleanupFinishedRun(context.WithoutCancel(ctx), streamID)
+		return err
+	}
+	if errors.Is(err, ErrRunOwnershipLost) {
+		snapshot, ok, loadErr := m.backend.Load(context.WithoutCancel(ctx), Key{BotID: botID, SessionID: sessionID})
+		if loadErr == nil && ok && snapshot.CurrentRunView != nil && snapshot.CurrentRunView.StreamID == streamID && !isActiveRunStatus(snapshot.CurrentRunView.Status) {
+			m.cleanupFinishedRun(context.WithoutCancel(ctx), streamID)
+			return nil
+		}
+		m.forgetLocalControl(context.WithoutCancel(ctx), streamID)
+		return err
+	}
+	if ctrl := m.localControl(streamID); ctrl != nil {
+		retryCtx := context.WithoutCancel(ctx)
+		ctrl.finishRetryOnce.Do(func() {
+			go m.retryFinishRun(retryCtx, ctrl, status, finishMessage)
+		})
+	}
+	return err
+}
+
+const steerRunFinishedError = "runtime run finished before steer was applied"
+
+func rejectPendingSteerOnRunFinish(run *CurrentRunView, now time.Time) {
+	if run == nil || run.Steer == nil || !isPendingSteerStatus(run.Steer.Status) {
+		return
+	}
+	run.Steer.Status = SteerStatusRejected
+	run.Steer.Error = steerRunFinishedError
+	run.Steer.UpdatedAt = now
+}
+
+func (m *Manager) finishRunState(ctx context.Context, botID, sessionID, streamID, status, finishMessage string) (bool, error) {
+	admissionTerminal := false
+	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		run := snapshot.CurrentRunView
+		if !isActiveRunStatus(run.Status) {
+			return snapshot, false, nil
+		}
+		if !m.runOwnerMatches(run) {
+			return snapshot, false, ErrRunOwnershipLost
+		}
+		admissionTerminal = strings.EqualFold(run.Status, RunStatusAdmitting)
+		finalStatus := status
+		if finalStatus == "" {
+			finalStatus = RunStatusCompleted
+			if strings.EqualFold(snapshot.CurrentRunView.Status, RunStatusAborting) {
+				finalStatus = RunStatusAborted
+			} else if strings.TrimSpace(snapshot.CurrentRunView.Error) != "" {
+				finalStatus = RunStatusErrored
+			}
+		}
+		snapshot.Seq++
+		snapshot.UpdatedAt = now
+		snapshot.CurrentRunView.Status = finalStatus
+		snapshot.CurrentRunView.UpdatedAt = now
+		switch {
+		case finishMessage != "":
+			snapshot.CurrentRunView.Error = finishMessage
+		case finalStatus == RunStatusCompleted || finalStatus == RunStatusAborted:
+			snapshot.CurrentRunView.Error = ""
+		}
+		snapshot.CurrentRunView.OwnerLeaseExpiresAt = nil
+		rejectPendingSteerOnRunFinish(snapshot.CurrentRunView, now)
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		if admissionTerminal {
+			return RuntimeDelta{CurrentRunView: snapshot.CurrentRunView}
+		}
+		return runtimeRunPatch(snapshot, true, true, true, m.distributed != nil)
+	})
+	return changed, err
+}
+
+func (m *Manager) retryFinishRun(ctx context.Context, ctrl *runControl, status, message string) {
+	if ctrl == nil {
+		return
+	}
+	delay := 100 * time.Millisecond
+	for {
+		select {
+		case <-m.closeCh:
+			return
+		case <-time.After(delay):
+		}
+		if m.localControl(ctrl.streamID) != ctrl {
+			return
+		}
+		changed, err := m.finishRunState(ctx, ctrl.botID, ctrl.sessionID, ctrl.streamID, status, message)
+		if err == nil || changed {
+			if err != nil {
+				m.logger.Warn("publish runtime finish failed after state commit", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
+			}
+			m.cleanupFinishedRun(ctx, ctrl.streamID)
+			return
+		}
+		if errors.Is(err, ErrRunOwnershipLost) {
+			m.forgetLocalControl(ctx, ctrl.streamID)
+			return
+		}
+		m.logger.Warn("retry runtime finish failed", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
+		if delay < time.Second {
+			delay *= 2
+			if delay > time.Second {
+				delay = time.Second
+			}
+		}
+	}
+}
+
+func (m *Manager) cleanupFinishedRun(ctx context.Context, streamID string) {
+	m.forgetLocalControl(ctx, streamID)
+	if m.distributed == nil {
+		return
+	}
+	if err := m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), streamID); err != nil {
+		m.logger.Warn("delete finished runtime stream reference failed", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+}
+
+func (m *Manager) HandleAgentEvent(ctx context.Context, botID, sessionID, streamID string, event agentpkg.StreamEvent) ([]conversation.UIMessage, error) {
+	if m == nil || m.backend == nil {
+		return nil, nil
+	}
+	ctrl := m.localControl(streamID)
+	if ctrl == nil {
+		return nil, nil
+	}
+	if err := waitRunControlReady(ctx, ctrl); err != nil {
+		return nil, err
+	}
+	if m.localControl(streamID) != ctrl {
+		return nil, nil
+	}
+
+	var messages []conversation.UIMessage
+	switch event.Type {
+	case agentpkg.EventAgentStart:
+	case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort:
+		messages = ctrl.converter.ConvertTerminalMessages(event.Messages)
+	case agentpkg.EventError:
+	default:
+		messages = ctrl.converter.HandleEvent(conversation.UIStreamEventFromAgentEvent(event))
+	}
+	delta, visibleChange := runtimeDeltaForAgentEvent(event, messages)
+	if !visibleChange {
+		return messages, nil
+	}
+
+	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+		run := snapshot.CurrentRunView
+		if run.StreamID != streamID || !m.runOwnerMatches(run) || !isEventAcceptingRunStatus(run.Status) {
+			return snapshot, false, nil
+		}
+		snapshot.Seq++
+		snapshot.Queue = nonNilQueue(snapshot.Queue)
+		snapshot.UpdatedAt = now
+		run.UpdatedAt = now
+		if event.Type == agentpkg.EventRetry {
+			run.Messages = []conversation.UIMessage{}
+		}
+		for _, msg := range messages {
+			run.Messages = upsertUIMessage(run.Messages, msg)
+		}
+		switch event.Type {
+		case agentpkg.EventAgentEnd:
+			switch {
+			case strings.TrimSpace(run.Error) != "":
+				run.Status = RunStatusErrored
+			case strings.EqualFold(run.Status, RunStatusAborting):
+				run.Status = RunStatusAborted
+			default:
+				run.Status = RunStatusCompleted
+			}
+			run.OwnerLeaseExpiresAt = nil
+			rejectPendingSteerOnRunFinish(run, now)
+		case agentpkg.EventAgentAbort:
+			if strings.TrimSpace(run.Error) != "" {
+				run.Status = RunStatusErrored
+			} else {
+				run.Status = RunStatusAborted
+			}
+			run.OwnerLeaseExpiresAt = nil
+			rejectPendingSteerOnRunFinish(run, now)
+		case agentpkg.EventError:
+			run.Error = strings.TrimSpace(event.Error)
+			if run.Error == "" {
+				run.Error = "stream error"
+			}
+		}
+		return snapshot, true, nil
+	}, func(snapshot Snapshot) RuntimeDelta {
+		switch event.Type {
+		case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort:
+			delta.Run = runtimeRunPatch(snapshot, true, true, true, m.distributed != nil).Run
+		case agentpkg.EventError:
+			delta.Run = runtimeRunPatch(snapshot, false, true, false, false).Run
+		}
+		return delta
+	})
+	if err != nil {
+		if errors.Is(err, ErrRunOwnershipLost) {
+			return nil, err
+		}
+		return messages, err
+	}
+	if !changed {
+		return nil, nil
+	}
+	return messages, nil
+}
+
+func (m *Manager) Snapshot(ctx context.Context, botID, sessionID string) (Snapshot, error) {
+	if m == nil || m.backend == nil {
+		return EmptySnapshot(botID, sessionID), nil
+	}
+	key := Key{BotID: strings.TrimSpace(botID), SessionID: strings.TrimSpace(sessionID)}
+	snapshot, ok, err := m.backend.Load(ctx, key)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if !ok {
+		return EmptySnapshot(key.BotID, key.SessionID), nil
+	}
+	if m.distributed != nil {
+		now, err := m.backend.Now(ctx)
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("load runtime backend time: %w", err)
+		}
+		if !m.leaseExpired(snapshot.CurrentRunView, now) {
+			snapshot.Queue = nonNilQueue(snapshot.Queue)
+			return snapshot, nil
+		}
+		lostStreamID := snapshot.CurrentRunView.StreamID
+		updated, changed, err := m.updateAndPublish(ctx, key, lostStreamID, func(current Snapshot, ok bool) (Snapshot, bool, error) {
+			if !ok {
+				return current, false, nil
+			}
+			if !m.markLostIfExpired(&current, now) {
+				return current, false, nil
+			}
+			return current, true, nil
+		}, func(snapshot Snapshot) RuntimeDelta {
+			return runtimeRunPatch(snapshot, true, true, false, true)
+		})
+		if err != nil {
+			return Snapshot{}, err
+		}
+		snapshot = updated
+		if changed && lostStreamID != "" {
+			_ = m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), lostStreamID)
+			if ctrl := m.localControl(lostStreamID); ctrl != nil {
+				m.cancelRunControl(ctrl)
+			}
+		}
+	}
+	snapshot.Queue = nonNilQueue(snapshot.Queue)
+	return snapshot, nil
+}
+
+func (m *Manager) Subscribe(ctx context.Context, botID, sessionID string) (Subscription, error) {
+	if m == nil || m.backend == nil {
+		ch := make(chan Event)
+		close(ch)
+		return Subscription{C: ch, Close: func() {}}, nil
+	}
+	key := Key{BotID: strings.TrimSpace(botID), SessionID: strings.TrimSpace(sessionID)}
+	subCtx, cancel := context.WithCancel(ctx)
+	backendSub, err := m.backend.Subscribe(subCtx, key)
+	if err != nil {
+		cancel()
+		return Subscription{}, err
+	}
+
+	out := make(chan Event, 64)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(out)
+		defer backendSub.Close()
+		reconcileInterval := 2 * time.Second
+		if m.distributed != nil {
+			reconcileInterval = runtimeReconcileInterval(m.ownerLeaseTTL)
+		}
+		ticker := time.NewTicker(reconcileInterval)
+		defer ticker.Stop()
+		var lastSeq int64
+		var lastUpdatedAt time.Time
+		events := backendSub.C
+		for {
+			select {
+			case <-subCtx.Done():
+				return
+			case event, ok := <-events:
+				if !ok {
+					events = nil
+					enqueueRuntimeEvent(out, Event{
+						Type:      EventRuntimeDropped,
+						BotID:     key.BotID,
+						SessionID: key.SessionID,
+						Message:   "runtime backend subscription closed",
+					})
+					continue
+				}
+				updatedAt := time.Time{}
+				if event.UpdatedAt != nil {
+					updatedAt = *event.UpdatedAt
+				}
+				if event.Snapshot != nil {
+					updatedAt = event.Snapshot.UpdatedAt
+				}
+				if event.Seq < lastSeq {
+					if !updatedAt.After(lastUpdatedAt) {
+						continue
+					}
+					resetSnapshot, err := m.Snapshot(subCtx, key.BotID, key.SessionID)
+					if err != nil {
+						enqueueRuntimeEvent(out, Event{
+							Type:      EventRuntimeDropped,
+							BotID:     key.BotID,
+							SessionID: key.SessionID,
+							Seq:       lastSeq,
+							Message:   "runtime sequence epoch changed",
+						})
+						continue
+					}
+					event = Event{
+						Type:      EventRuntimeSnapshot,
+						BotID:     key.BotID,
+						SessionID: key.SessionID,
+						Seq:       resetSnapshot.Seq,
+						Snapshot:  &resetSnapshot,
+					}
+					updatedAt = resetSnapshot.UpdatedAt
+				}
+				selfContained := event.Delta != nil && event.Delta.CurrentRunView != nil
+				if event.Type == EventRuntimeDelta && !selfContained && lastSeq > 0 && event.Seq > lastSeq+1 {
+					enqueueRuntimeEvent(out, Event{
+						Type:      EventRuntimeDropped,
+						BotID:     key.BotID,
+						SessionID: key.SessionID,
+						Seq:       lastSeq,
+						Message:   "runtime delta sequence gap",
+					})
+				}
+				if event.Seq > 0 {
+					lastSeq = event.Seq
+				}
+				if updatedAt.After(lastUpdatedAt) {
+					lastUpdatedAt = updatedAt
+				}
+				enqueueRuntimeEvent(out, event)
+			case <-ticker.C:
+				snapshot, err := m.Snapshot(subCtx, key.BotID, key.SessionID)
+				if err != nil {
+					if subCtx.Err() == nil {
+						m.logger.Warn("reconcile runtime subscription failed", slog.Any("error", err), slog.String("session_id", key.SessionID))
+					}
+					continue
+				}
+				reset := snapshot.Seq < lastSeq && (snapshot.CurrentRunView == nil || snapshot.UpdatedAt.After(lastUpdatedAt))
+				if snapshot.Seq <= lastSeq && !reset {
+					continue
+				}
+				lastSeq = snapshot.Seq
+				lastUpdatedAt = snapshot.UpdatedAt
+				enqueueRuntimeEvent(out, Event{
+					Type:      EventRuntimeSnapshot,
+					BotID:     key.BotID,
+					SessionID: key.SessionID,
+					Seq:       snapshot.Seq,
+					Snapshot:  &snapshot,
+				})
+			}
+		}
+	}()
+	var closeOnce sync.Once
+	return Subscription{
+		C: out,
+		Close: func() {
+			closeOnce.Do(func() {
+				cancel()
+				<-done
+			})
+		},
+	}, nil
+}
+
+func (m *Manager) updateAndPublish(ctx context.Context, key Key, streamID string, update SnapshotUpdate, buildDelta func(Snapshot) RuntimeDelta) (Snapshot, bool, error) {
+	snapshot, changed, err := m.backend.Update(ctx, key, update)
+	if err != nil || !changed {
+		return snapshot, changed, err
+	}
+	delta := RuntimeDelta{}
+	if buildDelta != nil {
+		delta = buildDelta(snapshot)
+	}
+	if err := m.publishRuntimeDelta(ctx, snapshot, streamID, delta); err != nil {
+		m.logger.Warn("publish runtime delta failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+	return snapshot, true, nil
+}
+
+func (m *Manager) updateActiveAndPublish(ctx context.Context, key Key, streamID string, update ActiveRunUpdate, buildDelta func(Snapshot) RuntimeDelta) (Snapshot, bool, error) {
+	var snapshot Snapshot
+	var changed bool
+	var err error
+	if m.distributed != nil {
+		snapshot, changed, err = m.distributed.UpdateActiveRun(ctx, key, streamID, update)
+	} else {
+		if m.localControl(streamID) == nil {
+			return Snapshot{}, false, ErrRunOwnershipLost
+		}
+		snapshot, changed, err = m.backend.Update(ctx, key, func(snapshot Snapshot, ok bool) (Snapshot, bool, error) {
+			if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != streamID || !isActiveRunStatus(snapshot.CurrentRunView.Status) {
+				return snapshot, false, ErrRunOwnershipLost
+			}
+			now, nowErr := m.backend.Now(ctx)
+			if nowErr != nil {
+				return snapshot, false, nowErr
+			}
+			return update(snapshot, now)
+		})
+	}
+	if err != nil || !changed {
+		return snapshot, changed, err
+	}
+	delta := RuntimeDelta{}
+	if buildDelta != nil {
+		delta = buildDelta(snapshot)
+	}
+	if err := m.publishRuntimeDelta(ctx, snapshot, streamID, delta); err != nil {
+		m.logger.Warn("publish runtime delta failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+	return snapshot, true, nil
+}
+
+func (m *Manager) runOwnerMatches(run *CurrentRunView) bool {
+	if run == nil {
+		return false
+	}
+	if m.distributed == nil {
+		return strings.TrimSpace(run.OwnerID) == "" && run.OwnerLeaseExpiresAt == nil
+	}
+	return strings.TrimSpace(run.OwnerID) == m.ownerID
+}
+
+func (m *Manager) publishRuntimeDelta(ctx context.Context, snapshot Snapshot, streamID string, delta RuntimeDelta) error {
+	eventStreamID := strings.TrimSpace(streamID)
+	if eventStreamID == "" && snapshot.CurrentRunView != nil {
+		eventStreamID = snapshot.CurrentRunView.StreamID
+	}
+	// No defensive clone here: both backends isolate on publish (memory clones
+	// the event once for its subscribers, redis marshals it immediately).
+	updatedAt := snapshot.UpdatedAt
+	return m.backend.Publish(ctx, Event{
+		Type:      EventRuntimeDelta,
+		BotID:     snapshot.BotID,
+		SessionID: snapshot.SessionID,
+		StreamID:  eventStreamID,
+		Seq:       snapshot.Seq,
+		UpdatedAt: &updatedAt,
+		Delta:     &delta,
+	})
+}

--- a/internal/sessionruntime/manager.go
+++ b/internal/sessionruntime/manager.go
@@ -16,18 +16,24 @@ import (
 )
 
 type Manager struct {
-	backend       Backend
-	distributed   DistributedBackend
-	ownerID       string
-	stateTTL      time.Duration
-	ownerLeaseTTL time.Duration
-	commandAckTTL time.Duration
-	logger        *slog.Logger
+	backend        Backend
+	distributed    DistributedBackend
+	ownerID        string
+	stateTTL       time.Duration
+	ownerLeaseTTL  time.Duration
+	commandAckTTL  time.Duration
+	commandWorkers int
+	logger         *slog.Logger
+	newEpoch       func() string
+	newGeneration  func() string
 
-	mu              sync.Mutex
-	controls        map[string]*runControl
-	commandHandler  func(context.Context, Command) error
-	pendingCommands map[string]chan error
+	mu                     sync.Mutex
+	controls               map[string]*runControl
+	commandHandler         func(context.Context, Command) error
+	pendingCommands        map[string]map[*commandWaiter]struct{}
+	inflightCommandTargets map[string]struct{}
+	commandExecutions      map[string]chan struct{}
+	admittedCommands       map[string]struct{}
 
 	commandCancel context.CancelFunc
 	commandDone   chan struct{}
@@ -35,32 +41,60 @@ type Manager struct {
 	closeOnce     sync.Once
 }
 
+type commandWaiter struct {
+	result      chan error
+	payloadHash string
+}
+
 type runControl struct {
-	botID           string
-	sessionID       string
-	streamID        string
-	abortCh         chan<- struct{}
-	cancel          context.CancelFunc
-	injectCh        chan<- conversation.InjectMessage
-	converter       *conversation.UIMessageStreamConverter
-	leaseStop       func()
-	leaseDone       chan struct{}
-	leaseMu         sync.RWMutex
-	leaseValidUntil time.Time
-	ready           chan struct{}
-	readyOnce       sync.Once
-	finishRetryOnce sync.Once
+	botID            string
+	sessionID        string
+	streamID         string
+	generation       string
+	abortCh          chan<- struct{}
+	cancel           context.CancelFunc
+	lifecycleCtx     context.Context
+	lifecycleCancel  context.CancelFunc
+	injectCh         chan<- conversation.InjectMessage
+	injectMu         sync.Mutex
+	injectClosed     bool
+	converter        *conversation.UIMessageStreamConverter
+	leaseStop        func()
+	leaseDone        chan struct{}
+	leaseLifecycleMu sync.Mutex
+	leaseMu          sync.RWMutex
+	leaseValidUntil  time.Time
+	leaseChanged     chan struct{}
+	ready            chan struct{}
+	readyOnce        sync.Once
+	finishRetryOnce  sync.Once
+	ownershipCancel  context.CancelCauseFunc
+	ownershipOnce    sync.Once
+}
+
+func (c *runControl) handle() RunHandle {
+	if c == nil {
+		return RunHandle{}
+	}
+	return RunHandle{BotID: c.botID, SessionID: c.sessionID, StreamID: c.streamID, Generation: c.generation}
 }
 
 type Options struct {
-	OwnerID       string
-	StateTTL      time.Duration
-	OwnerLeaseTTL time.Duration
-	CommandAckTTL time.Duration
-	Logger        *slog.Logger
+	OwnerID                string
+	StateTTL               time.Duration
+	OwnerLeaseTTL          time.Duration
+	CommandAckTTL          time.Duration
+	CommandWorkerLimit     int
+	Logger                 *slog.Logger
+	EpochGenerator         func() string
+	RunGenerationGenerator func() string
 }
 
-const defaultCommandAckTTL = 2 * time.Second
+const (
+	defaultCommandAckTTL        = 2 * time.Second
+	defaultCommandWorkerLimit   = 32
+	defaultCommandRejectBacklog = 256
+)
 
 func NewManager(backend Backend, opts Options) *Manager {
 	ownerID := strings.TrimSpace(opts.OwnerID)
@@ -79,23 +113,47 @@ func NewManager(backend Backend, opts Options) *Manager {
 	if commandAckTTL <= 0 {
 		commandAckTTL = defaultCommandAckTTL
 	}
+	commandWorkers := opts.CommandWorkerLimit
+	if commandWorkers <= 0 {
+		commandWorkers = defaultCommandWorkerLimit
+	}
 	log := opts.Logger
 	if log == nil {
 		log = slog.Default()
 	}
 	distributed, _ := backend.(DistributedBackend)
-	return &Manager{
-		backend:         backend,
-		distributed:     distributed,
-		ownerID:         ownerID,
-		stateTTL:        stateTTL,
-		ownerLeaseTTL:   leaseTTL,
-		commandAckTTL:   commandAckTTL,
-		logger:          log.With(slog.String("component", "session_runtime")),
-		controls:        make(map[string]*runControl),
-		pendingCommands: make(map[string]chan error),
-		closeCh:         make(chan struct{}),
+	newEpoch := opts.EpochGenerator
+	if newEpoch == nil {
+		newEpoch = uuid.NewString
 	}
+	newGeneration := opts.RunGenerationGenerator
+	if newGeneration == nil {
+		newGeneration = uuid.NewString
+	}
+	return &Manager{
+		backend:                backend,
+		distributed:            distributed,
+		ownerID:                ownerID,
+		stateTTL:               stateTTL,
+		ownerLeaseTTL:          leaseTTL,
+		commandAckTTL:          commandAckTTL,
+		commandWorkers:         commandWorkers,
+		logger:                 log.With(slog.String("component", "session_runtime")),
+		newEpoch:               newEpoch,
+		newGeneration:          newGeneration,
+		controls:               make(map[string]*runControl),
+		pendingCommands:        make(map[string]map[*commandWaiter]struct{}),
+		inflightCommandTargets: make(map[string]struct{}),
+		commandExecutions:      make(map[string]chan struct{}),
+		admittedCommands:       make(map[string]struct{}),
+		closeCh:                make(chan struct{}),
+	}
+}
+
+// IsDistributed reports whether this manager coordinates owners through a
+// cross-process backend. Memory managers intentionally return false.
+func (m *Manager) IsDistributed() bool {
+	return m != nil && m.distributed != nil
 }
 
 func (m *Manager) isClosed() bool {
@@ -125,12 +183,25 @@ func (m *Manager) Start(ctx context.Context) error {
 	if m == nil || m.distributed == nil {
 		return nil
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	sub, err := m.distributed.SubscribeCommands(ctx, m.ownerID)
+	if m.isClosed() {
+		return ErrManagerClosed
+	}
+	if checker, ok := m.distributed.(startupHealthChecker); ok {
+		if err := checker.CheckHealth(ctx); err != nil {
+			return err
+		}
+	}
+	commandCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	stopStartupCancellation := context.AfterFunc(ctx, cancel)
+	sub, err := m.distributed.SubscribeCommands(commandCtx, m.ownerID)
 	if err != nil {
+		stopStartupCancellation()
 		cancel()
 		if m.isClosed() {
 			return ErrManagerClosed
+		}
+		if startupErr := ctx.Err(); startupErr != nil {
+			return startupErr
 		}
 		return err
 	}
@@ -138,6 +209,13 @@ func (m *Manager) Start(ctx context.Context) error {
 		cancel()
 		sub.Close()
 	})
+	if !stopStartupCancellation() {
+		stopCommands()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return context.Canceled
+	}
 	commandDone := make(chan struct{})
 	m.mu.Lock()
 	if m.isClosed() {
@@ -154,16 +232,58 @@ func (m *Manager) Start(ctx context.Context) error {
 	m.commandDone = commandDone
 	m.mu.Unlock()
 	go func() {
-		defer close(commandDone)
+		jobs := make(chan Command, m.commandWorkers)
+		rejected := make(chan Command, defaultCommandRejectBacklog)
+		var workers sync.WaitGroup
+		for range m.commandWorkers {
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				for cmd := range jobs {
+					m.applyCommand(commandCtx, cmd)
+					m.releaseCommandAdmission(cmd)
+				}
+			}()
+		}
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for cmd := range rejected {
+				m.publishCommandResult(commandCtx, cmd, ErrCommandBusy)
+				m.releaseCommandAdmission(cmd)
+			}
+		}()
+		defer func() {
+			close(jobs)
+			close(rejected)
+			workers.Wait()
+			close(commandDone)
+		}()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-commandCtx.Done():
 				return
 			case cmd, ok := <-sub.C:
 				if !ok {
 					return
 				}
-				m.applyCommand(context.WithoutCancel(ctx), cmd)
+				if strings.TrimSpace(cmd.Type) == CommandResult {
+					m.applyCommand(commandCtx, cmd)
+					continue
+				}
+				if !m.admitCommand(cmd) {
+					continue
+				}
+				select {
+				case jobs <- cmd:
+				default:
+					select {
+					case rejected <- cmd:
+					case <-commandCtx.Done():
+						m.releaseCommandAdmission(cmd)
+						return
+					}
+				}
 			}
 		}
 	}()
@@ -186,9 +306,11 @@ func (m *Manager) CloseContext(ctx context.Context) error {
 	commandDone := m.commandDone
 	m.commandCancel = nil
 	m.commandDone = nil
-	pendingCommands := make([]chan error, 0, len(m.pendingCommands))
-	for commandID, pending := range m.pendingCommands {
-		pendingCommands = append(pendingCommands, pending)
+	pendingCommands := make([]*commandWaiter, 0, len(m.pendingCommands))
+	for commandID, waiters := range m.pendingCommands {
+		for pending := range waiters {
+			pendingCommands = append(pendingCommands, pending)
+		}
 		delete(m.pendingCommands, commandID)
 	}
 	m.mu.Unlock()
@@ -196,32 +318,50 @@ func (m *Manager) CloseContext(ctx context.Context) error {
 		commandCancel()
 	}
 	for _, pending := range pendingCommands {
-		pending <- ErrManagerClosed
+		pending.result <- ErrManagerClosed
 	}
-	m.stopAllLocalControls(ctx)
+	releaseErr := m.releaseAllLocalRuns(ctx)
+	controlErr := m.stopAllLocalControls(ctx)
+	var commandErr error
 	if commandDone != nil {
 		select {
 		case <-commandDone:
 		case <-ctx.Done():
-			return ctx.Err()
+			commandErr = ctx.Err()
 		}
 	}
+	var backendErr error
 	if m.backend != nil {
-		return m.backend.Close()
+		backendErr = m.backend.Close()
 	}
-	return nil
+	return errors.Join(releaseErr, controlErr, commandErr, backendErr)
 }
 
 func (m *Manager) StartRun(ctx context.Context, botID, sessionID, streamID string, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
-	return m.StartRunWithAdmission(ctx, botID, sessionID, streamID, RunAdmissionView{}, abortCh, cancel, injectCh)
+	_, err := m.StartRunHandle(ctx, botID, sessionID, streamID, abortCh, cancel, injectCh)
+	return err
+}
+
+func (m *Manager) StartRunHandle(ctx context.Context, botID, sessionID, streamID string, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) (RunHandle, error) {
+	return m.StartRunWithAdmissionHandle(ctx, botID, sessionID, streamID, RunAdmissionView{}, abortCh, cancel, injectCh)
 }
 
 func (m *Manager) StartRunWithOperation(ctx context.Context, botID, sessionID, streamID string, operation *RunOperationView, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
-	return m.StartRunWithAdmission(ctx, botID, sessionID, streamID, RunAdmissionView{Operation: operation}, abortCh, cancel, injectCh)
+	_, err := m.StartRunWithOperationHandle(ctx, botID, sessionID, streamID, operation, abortCh, cancel, injectCh)
+	return err
+}
+
+func (m *Manager) StartRunWithOperationHandle(ctx context.Context, botID, sessionID, streamID string, operation *RunOperationView, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) (RunHandle, error) {
+	return m.StartRunWithAdmissionHandle(ctx, botID, sessionID, streamID, RunAdmissionView{Operation: operation}, abortCh, cancel, injectCh)
 }
 
 func (m *Manager) StartRunWithAdmission(ctx context.Context, botID, sessionID, streamID string, admission RunAdmissionView, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
-	return m.StartRunWithAdmissionBuilder(ctx, botID, sessionID, streamID, func(context.Context) (RunAdmissionView, error) {
+	_, err := m.StartRunWithAdmissionHandle(ctx, botID, sessionID, streamID, admission, abortCh, cancel, injectCh)
+	return err
+}
+
+func (m *Manager) StartRunWithAdmissionHandle(ctx context.Context, botID, sessionID, streamID string, admission RunAdmissionView, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) (RunHandle, error) {
+	return m.StartRunWithAdmissionBuilderHandle(ctx, botID, sessionID, streamID, func(context.Context, RunHandle) (RunAdmissionView, error) {
 		return admission, nil
 	}, abortCh, cancel, injectCh)
 }
@@ -230,8 +370,18 @@ func (m *Manager) StartRunWithOperationBuilder(ctx context.Context, botID, sessi
 	if builder == nil {
 		return errors.New("runtime operation builder is required")
 	}
-	return m.StartRunWithAdmissionBuilder(ctx, botID, sessionID, streamID, func(ctx context.Context) (RunAdmissionView, error) {
-		operation, err := builder(ctx)
+	_, err := m.StartRunWithOperationBuilderHandle(ctx, botID, sessionID, streamID, func(ctx context.Context, _ RunHandle) (*RunOperationView, error) {
+		return builder(ctx)
+	}, abortCh, cancel, injectCh)
+	return err
+}
+
+func (m *Manager) StartRunWithOperationBuilderHandle(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context, RunHandle) (*RunOperationView, error), abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) (RunHandle, error) {
+	if builder == nil {
+		return RunHandle{}, errors.New("runtime operation builder is required")
+	}
+	return m.StartRunWithAdmissionBuilderHandle(ctx, botID, sessionID, streamID, func(ctx context.Context, handle RunHandle) (RunAdmissionView, error) {
+		operation, err := builder(ctx, handle)
 		return RunAdmissionView{Operation: operation}, err
 	}, abortCh, cancel, injectCh)
 }
@@ -240,48 +390,99 @@ func (m *Manager) StartRunWithOperationBuilder(ctx context.Context, botID, sessi
 // builder, then publishes the running view only after the canonical request
 // turn and optional replacement operation are ready.
 func (m *Manager) StartRunWithAdmissionBuilder(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context) (RunAdmissionView, error), abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	if builder == nil {
+		return errors.New("runtime admission builder is required")
+	}
+	_, err := m.StartRunWithAdmissionBuilderHandle(ctx, botID, sessionID, streamID, func(ctx context.Context, _ RunHandle) (RunAdmissionView, error) {
+		return builder(ctx)
+	}, abortCh, cancel, injectCh)
+	return err
+}
+
+func (m *Manager) StartRunWithAdmissionBuilderAndOwnership(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context) (RunAdmissionView, error), ownershipCancel context.CancelCauseFunc, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) error {
+	if builder == nil {
+		if ownershipCancel != nil {
+			ownershipCancel(ErrRunOwnershipLost)
+		}
+		return errors.New("runtime admission builder is required")
+	}
+	_, err := m.StartRunWithAdmissionBuilderAndOwnershipHandle(ctx, botID, sessionID, streamID, func(ctx context.Context, _ RunHandle) (RunAdmissionView, error) {
+		return builder(ctx)
+	}, ownershipCancel, abortCh, cancel, injectCh)
+	return err
+}
+
+func (m *Manager) StartRunWithAdmissionBuilderHandle(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context, RunHandle) (RunAdmissionView, error), abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) (RunHandle, error) {
+	return m.startRunWithAdmissionBuilder(ctx, botID, sessionID, streamID, builder, nil, abortCh, cancel, injectCh)
+}
+
+func (m *Manager) StartRunWithAdmissionBuilderAndOwnershipHandle(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context, RunHandle) (RunAdmissionView, error), ownershipCancel context.CancelCauseFunc, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) (RunHandle, error) {
+	return m.startRunWithAdmissionBuilder(ctx, botID, sessionID, streamID, builder, ownershipCancel, abortCh, cancel, injectCh)
+}
+
+func (m *Manager) startRunWithAdmissionBuilder(ctx context.Context, botID, sessionID, streamID string, builder func(context.Context, RunHandle) (RunAdmissionView, error), ownershipCancel context.CancelCauseFunc, abortCh chan<- struct{}, cancel context.CancelFunc, injectCh chan<- conversation.InjectMessage) (RunHandle, error) {
 	if m == nil || m.backend == nil {
-		return nil
+		if ownershipCancel != nil {
+			ownershipCancel(ErrRunOwnershipLost)
+		}
+		return RunHandle{}, nil
 	}
 	botID = strings.TrimSpace(botID)
 	sessionID = strings.TrimSpace(sessionID)
 	streamID = strings.TrimSpace(streamID)
 	if botID == "" || sessionID == "" || streamID == "" {
-		return errors.New("bot_id, session_id, and stream_id are required")
+		if ownershipCancel != nil {
+			ownershipCancel(ErrRunOwnershipLost)
+		}
+		return RunHandle{}, errors.New("bot_id, session_id, and stream_id are required")
 	}
 	if builder == nil {
-		return errors.New("runtime admission builder is required")
+		if ownershipCancel != nil {
+			ownershipCancel(ErrRunOwnershipLost)
+		}
+		return RunHandle{}, errors.New("runtime admission builder is required")
 	}
 
+	runGeneration := m.newGeneration()
+	handle := RunHandle{BotID: botID, SessionID: sessionID, StreamID: streamID, Generation: runGeneration}
+	lifecycleCtx, lifecycleCancel := context.WithCancel(context.WithoutCancel(ctx))
 	ctrl := &runControl{
-		botID:     botID,
-		sessionID: sessionID,
-		streamID:  streamID,
-		abortCh:   abortCh,
-		cancel:    cancel,
-		injectCh:  injectCh,
-		converter: conversation.NewUIMessageStreamConverter(),
-		ready:     make(chan struct{}),
+		botID:           botID,
+		sessionID:       sessionID,
+		streamID:        streamID,
+		generation:      runGeneration,
+		abortCh:         abortCh,
+		cancel:          cancel,
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
+		injectCh:        injectCh,
+		converter:       conversation.NewUIMessageStreamConverter(),
+		leaseChanged:    make(chan struct{}, 1),
+		ready:           make(chan struct{}),
+		ownershipCancel: ownershipCancel,
 	}
 	defer ctrl.markReady()
 	m.mu.Lock()
 	select {
 	case <-m.closeCh:
 		m.mu.Unlock()
-		return ErrManagerClosed
+		ctrl.revokeOwnership(ErrRunOwnershipLost)
+		return RunHandle{}, ErrManagerClosed
 	default:
 	}
 	if _, exists := m.controls[streamID]; exists {
 		m.mu.Unlock()
-		return fmt.Errorf("stream_id %q is already owned by this runtime manager", streamID)
+		ctrl.revokeOwnership(ErrRunOwnershipLost)
+		return RunHandle{}, fmt.Errorf("stream_id %q is already owned by this runtime manager", streamID)
 	}
 	m.controls[streamID] = ctrl
 	m.mu.Unlock()
 
+	localLeaseStarted := time.Now()
 	now, err := m.backend.Now(ctx)
 	if err != nil {
 		m.removeLocalControl(streamID, ctrl)
-		return fmt.Errorf("load runtime backend time: %w", err)
+		return RunHandle{}, fmt.Errorf("load runtime backend time: %w", err)
 	}
 	key := Key{BotID: botID, SessionID: sessionID}
 	ownerID := ""
@@ -292,23 +493,28 @@ func (m *Manager) StartRunWithAdmissionBuilder(ctx context.Context, botID, sessi
 		leaseExpiresAt = &expiresAt
 		// The backend claim below is authoritative, but a local deadline must
 		// exist before it returns so an abort can cancel blocked admission.
-		ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+		ctrl.setLeaseValidUntil(localLeaseStarted.Add(m.ownerLeaseTTL))
 	}
-	var expiredStreamID string
+	epoch := m.newEpoch()
+	var expiredRef StreamRef
 	claim := func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
 		if snapshot.CurrentRunView != nil && isActiveRunStatus(snapshot.CurrentRunView.Status) && snapshot.CurrentRunView.StreamID != streamID {
 			if m.distributed == nil || !m.markLostIfExpired(&snapshot, now) {
 				return snapshot, false, fmt.Errorf("session %q already has an active runtime run", sessionID)
 			}
-			expiredStreamID = snapshot.CurrentRunView.StreamID
+			expiredRef = streamRefForRun(snapshot.BotID, snapshot.SessionID, snapshot.CurrentRunView)
 		}
 		snapshot.BotID = botID
 		snapshot.SessionID = sessionID
+		if strings.TrimSpace(snapshot.Epoch) == "" {
+			snapshot.Epoch = epoch
+		}
 		snapshot.Seq++
 		snapshot.Queue = nonNilQueue(snapshot.Queue)
 		snapshot.UpdatedAt = now
 		snapshot.CurrentRunView = &CurrentRunView{
 			StreamID:            streamID,
+			Generation:          runGeneration,
 			Status:              RunStatusAdmitting,
 			OwnerID:             ownerID,
 			OwnerLeaseExpiresAt: leaseExpiresAt,
@@ -322,43 +528,60 @@ func (m *Manager) StartRunWithAdmissionBuilder(ctx context.Context, botID, sessi
 	var changed bool
 	if m.distributed != nil {
 		claimedSnapshot, changed, err = m.distributed.StartRun(ctx, key, StreamRef{
-			BotID: botID, SessionID: sessionID, StreamID: streamID, OwnerID: m.ownerID,
+			BotID: botID, SessionID: sessionID, StreamID: streamID, OwnerID: m.ownerID, Generation: runGeneration,
 		}, claim)
 	} else {
 		claimedSnapshot, changed, err = m.backend.Update(ctx, key, claim)
 	}
 	if err != nil {
 		m.removeLocalControl(streamID, ctrl)
-		return err
+		return RunHandle{}, err
 	}
 	if !changed {
 		m.removeLocalControl(streamID, ctrl)
-		return nil
+		return RunHandle{}, nil
 	}
 	if err := m.publishRuntimeDelta(context.WithoutCancel(ctx), claimedSnapshot, streamID, RuntimeDelta{CurrentRunView: claimedSnapshot.CurrentRunView}); err != nil {
 		m.logger.Warn("publish admitting runtime checkpoint failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", streamID))
 	}
-	if expiredStreamID != "" && m.distributed != nil {
-		_ = m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), expiredStreamID)
+	if expiredRef.StreamID != "" && m.distributed != nil {
+		_, _ = m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), expiredRef)
 	}
 	if m.distributed != nil {
-		renewedAt, renewErr := m.backend.Now(context.WithoutCancel(ctx))
+		localRenewalStarted := time.Now()
+		confirmCtx, confirmCancel := context.WithDeadline(context.WithoutCancel(ctx), ctrl.leaseDeadline())
+		renewedAt, renewErr := m.backend.Now(confirmCtx)
 		if renewErr == nil {
-			renewErr = m.distributed.RenewLease(context.WithoutCancel(ctx), key, streamID, m.ownerID, renewedAt, renewedAt.Add(m.ownerLeaseTTL))
+			renewErr = m.distributed.RenewLease(confirmCtx, key, streamID, m.ownerID, runGeneration, renewedAt, renewedAt.Add(m.ownerLeaseTTL))
 		}
+		confirmCancel()
 		if renewErr != nil {
 			ctrl.markReady()
-			if errors.Is(renewErr, ErrRunOwnershipLost) {
-				m.forgetLocalControl(context.WithoutCancel(ctx), streamID)
-			} else {
-				_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, RunStatusErrored, renewErr.Error())
+			if m.isClosed() {
+				m.removeLocalControl(streamID, ctrl)
+				return RunHandle{}, ErrManagerClosed
 			}
-			return fmt.Errorf("confirm runtime owner lease: %w", renewErr)
+			if errors.Is(renewErr, ErrRunOwnershipLost) || !ctrl.leaseIsValidAt(time.Now()) {
+				m.removeLocalControl(streamID, ctrl)
+				renewErr = ErrRunOwnershipLost
+			} else {
+				_ = m.FinishRun(context.WithoutCancel(ctx), handle, RunStatusErrored, renewErr.Error())
+			}
+			return RunHandle{}, fmt.Errorf("confirm runtime owner lease: %w", renewErr)
 		}
-		ctrl.setLeaseValidUntil(time.Now().Add(m.ownerLeaseTTL))
+		deadline := localRenewalStarted.Add(m.ownerLeaseTTL)
+		if !time.Now().Before(deadline) {
+			ctrl.markReady()
+			m.removeLocalControl(streamID, ctrl)
+			if m.isClosed() {
+				return RunHandle{}, ErrManagerClosed
+			}
+			return RunHandle{}, fmt.Errorf("confirm runtime owner lease: %w", ErrRunOwnershipLost)
+		}
+		ctrl.setLeaseValidUntil(deadline)
 		m.startLeaseRenewal(context.WithoutCancel(ctx), ctrl)
 	}
-	admission, err := builder(ctx)
+	admission, err := builder(ctx, handle)
 	if err != nil {
 		ctrl.markReady()
 		status := RunStatusErrored
@@ -367,26 +590,26 @@ func (m *Manager) StartRunWithAdmissionBuilder(ctx context.Context, botID, sessi
 			status = RunStatusAborted
 			message = ""
 		}
-		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, status, message)
-		return err
+		_ = m.FinishRun(context.WithoutCancel(ctx), handle, status, message)
+		return RunHandle{}, err
 	}
 	if m.isClosed() {
-		return ErrManagerClosed
+		return RunHandle{}, ErrManagerClosed
 	}
-	if m.localControl(streamID) != ctrl {
-		return ErrRunOwnershipLost
+	if m.localControlForHandle(handle) != ctrl {
+		return RunHandle{}, ErrRunOwnershipLost
 	}
 	admission, err = normalizeRunAdmission(admission)
 	if err != nil {
 		ctrl.markReady()
-		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, RunStatusErrored, err.Error())
-		return err
+		_ = m.FinishRun(context.WithoutCancel(ctx), handle, RunStatusErrored, err.Error())
+		return RunHandle{}, err
 	}
-	_, changed, err = m.updateActiveAndPublish(context.WithoutCancel(ctx), key, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+	_, changed, err = m.updateActiveAndPublish(context.WithoutCancel(ctx), handle, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
 		if m.isClosed() {
 			return snapshot, false, ErrManagerClosed
 		}
-		if m.localControl(streamID) != ctrl {
+		if m.localControlForHandle(handle) != ctrl {
 			return snapshot, false, ErrRunOwnershipLost
 		}
 		run := snapshot.CurrentRunView
@@ -409,7 +632,7 @@ func (m *Manager) StartRunWithAdmissionBuilder(ctx context.Context, botID, sessi
 	if err != nil || !changed {
 		ctrl.markReady()
 		if errors.Is(err, ErrManagerClosed) || errors.Is(err, ErrRunOwnershipLost) {
-			return err
+			return RunHandle{}, err
 		}
 		if err == nil {
 			err = errors.New("reserved runtime run could not be activated")
@@ -420,40 +643,42 @@ func (m *Manager) StartRunWithAdmissionBuilder(ctx context.Context, botID, sessi
 			status = RunStatusAborted
 			message = ""
 		}
-		_ = m.FinishRun(context.WithoutCancel(ctx), botID, sessionID, streamID, status, message)
-		return err
+		_ = m.FinishRun(context.WithoutCancel(ctx), handle, status, message)
+		return RunHandle{}, err
 	}
 	ctrl.markReady()
-	return nil
+	return handle, nil
 }
 
-func (m *Manager) FinishRun(ctx context.Context, botID, sessionID, streamID, status, message string) error {
+func (m *Manager) FinishRun(ctx context.Context, handle RunHandle, status, message string) error {
 	if m == nil || m.backend == nil {
 		return nil
 	}
-	botID = strings.TrimSpace(botID)
-	sessionID = strings.TrimSpace(sessionID)
-	streamID = strings.TrimSpace(streamID)
-	if botID == "" || sessionID == "" || streamID == "" {
-		return nil
+	handle = handle.normalized()
+	if !handle.valid() {
+		return ErrRunOwnershipLost
+	}
+	ctrl := m.localControlForHandle(handle)
+	if ctrl != nil {
+		ctrl.stopCommands()
 	}
 	status = strings.TrimSpace(status)
 	finishMessage := strings.TrimSpace(message)
-	changed, err := m.finishRunState(ctx, botID, sessionID, streamID, status, finishMessage)
+	changed, err := m.finishRunState(ctx, handle, status, finishMessage)
 	if err == nil || changed {
-		m.cleanupFinishedRun(context.WithoutCancel(ctx), streamID)
+		m.cleanupFinishedRun(context.WithoutCancel(ctx), handle)
 		return err
 	}
 	if errors.Is(err, ErrRunOwnershipLost) {
-		snapshot, ok, loadErr := m.backend.Load(context.WithoutCancel(ctx), Key{BotID: botID, SessionID: sessionID})
-		if loadErr == nil && ok && snapshot.CurrentRunView != nil && snapshot.CurrentRunView.StreamID == streamID && !isActiveRunStatus(snapshot.CurrentRunView.Status) {
-			m.cleanupFinishedRun(context.WithoutCancel(ctx), streamID)
+		snapshot, ok, loadErr := m.backend.Load(context.WithoutCancel(ctx), handle.key())
+		if loadErr == nil && ok && runMatchesHandle(snapshot.CurrentRunView, handle) && !isActiveRunStatus(snapshot.CurrentRunView.Status) {
+			m.cleanupFinishedRun(context.WithoutCancel(ctx), handle)
 			return nil
 		}
-		m.forgetLocalControl(context.WithoutCancel(ctx), streamID)
+		m.forgetLocalControlForHandle(context.WithoutCancel(ctx), handle)
 		return err
 	}
-	if ctrl := m.localControl(streamID); ctrl != nil {
+	if ctrl != nil && m.localControlForHandle(handle) == ctrl {
 		retryCtx := context.WithoutCancel(ctx)
 		ctrl.finishRetryOnce.Do(func() {
 			go m.retryFinishRun(retryCtx, ctrl, status, finishMessage)
@@ -473,9 +698,9 @@ func rejectPendingSteerOnRunFinish(run *CurrentRunView, now time.Time) {
 	run.Steer.UpdatedAt = now
 }
 
-func (m *Manager) finishRunState(ctx context.Context, botID, sessionID, streamID, status, finishMessage string) (bool, error) {
+func (m *Manager) finishRunState(ctx context.Context, handle RunHandle, status, finishMessage string) (bool, error) {
 	admissionTerminal := false
-	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+	_, changed, err := m.releaseActiveAndPublish(ctx, handle, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
 		run := snapshot.CurrentRunView
 		if !isActiveRunStatus(run.Status) {
 			return snapshot, false, nil
@@ -529,16 +754,16 @@ func (m *Manager) retryFinishRun(ctx context.Context, ctrl *runControl, status, 
 		if m.localControl(ctrl.streamID) != ctrl {
 			return
 		}
-		changed, err := m.finishRunState(ctx, ctrl.botID, ctrl.sessionID, ctrl.streamID, status, message)
+		changed, err := m.finishRunState(ctx, ctrl.handle(), status, message)
 		if err == nil || changed {
 			if err != nil {
 				m.logger.Warn("publish runtime finish failed after state commit", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
 			}
-			m.cleanupFinishedRun(ctx, ctrl.streamID)
+			m.cleanupFinishedRun(ctx, ctrl.handle())
 			return
 		}
 		if errors.Is(err, ErrRunOwnershipLost) {
-			m.forgetLocalControl(ctx, ctrl.streamID)
+			m.forgetLocalControlForHandle(ctx, ctrl.handle())
 			return
 		}
 		m.logger.Warn("retry runtime finish failed", slog.Any("error", err), slog.String("stream_id", ctrl.streamID))
@@ -551,29 +776,39 @@ func (m *Manager) retryFinishRun(ctx context.Context, ctrl *runControl, status, 
 	}
 }
 
-func (m *Manager) cleanupFinishedRun(ctx context.Context, streamID string) {
-	m.forgetLocalControl(ctx, streamID)
+func (m *Manager) cleanupFinishedRun(ctx context.Context, handle RunHandle) {
+	handle = handle.normalized()
+	ctrl := m.localControlForHandle(handle)
+	ref := m.streamRefForControl(ctrl)
+	m.forgetLocalControlForHandle(ctx, handle)
 	if m.distributed == nil {
 		return
 	}
-	if err := m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), streamID); err != nil {
-		m.logger.Warn("delete finished runtime stream reference failed", slog.Any("error", err), slog.String("stream_id", streamID))
+	if ref.StreamID == "" {
+		ref = StreamRef{BotID: handle.BotID, SessionID: handle.SessionID, StreamID: handle.StreamID, OwnerID: m.ownerID, Generation: handle.Generation}
+	}
+	if _, err := m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), ref); err != nil {
+		m.logger.Warn("delete finished runtime stream reference failed", slog.Any("error", err), slog.String("stream_id", handle.StreamID))
 	}
 }
 
-func (m *Manager) HandleAgentEvent(ctx context.Context, botID, sessionID, streamID string, event agentpkg.StreamEvent) ([]conversation.UIMessage, error) {
+func (m *Manager) HandleAgentEvent(ctx context.Context, handle RunHandle, event agentpkg.StreamEvent) ([]conversation.UIMessage, error) {
 	if m == nil || m.backend == nil {
 		return nil, nil
 	}
-	ctrl := m.localControl(streamID)
+	handle = handle.normalized()
+	if !handle.valid() {
+		return nil, ErrRunOwnershipLost
+	}
+	ctrl := m.localControlForHandle(handle)
 	if ctrl == nil {
-		return nil, nil
+		return nil, ErrRunOwnershipLost
 	}
 	if err := waitRunControlReady(ctx, ctrl); err != nil {
 		return nil, err
 	}
-	if m.localControl(streamID) != ctrl {
-		return nil, nil
+	if m.localControlForHandle(handle) != ctrl {
+		return nil, ErrRunOwnershipLost
 	}
 
 	var messages []conversation.UIMessage
@@ -590,9 +825,9 @@ func (m *Manager) HandleAgentEvent(ctx context.Context, botID, sessionID, stream
 		return messages, nil
 	}
 
-	_, changed, err := m.updateActiveAndPublish(ctx, Key{BotID: botID, SessionID: sessionID}, streamID, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
+	_, changed, err := m.updateActiveAndPublish(ctx, handle, func(snapshot Snapshot, now time.Time) (Snapshot, bool, error) {
 		run := snapshot.CurrentRunView
-		if run.StreamID != streamID || !m.runOwnerMatches(run) || !isEventAcceptingRunStatus(run.Status) {
+		if !runMatchesHandle(run, handle) || !m.runOwnerMatches(run) || !isEventAcceptingRunStatus(run.Status) {
 			return snapshot, false, nil
 		}
 		snapshot.Seq++
@@ -662,8 +897,28 @@ func (m *Manager) Snapshot(ctx context.Context, botID, sessionID string) (Snapsh
 	if err != nil {
 		return Snapshot{}, err
 	}
-	if !ok {
-		return EmptySnapshot(key.BotID, key.SessionID), nil
+	if !ok || strings.TrimSpace(snapshot.Epoch) == "" {
+		now, nowErr := m.backend.Now(ctx)
+		if nowErr != nil {
+			return Snapshot{}, fmt.Errorf("load runtime backend time: %w", nowErr)
+		}
+		epoch := m.newEpoch()
+		snapshot, _, err = m.backend.Update(ctx, key, func(snapshot Snapshot, ok bool) (Snapshot, bool, error) {
+			if ok && strings.TrimSpace(snapshot.Epoch) != "" {
+				return snapshot, false, nil
+			}
+			if !ok {
+				snapshot = EmptySnapshot(key.BotID, key.SessionID)
+			}
+			snapshot.BotID = key.BotID
+			snapshot.SessionID = key.SessionID
+			snapshot.Epoch = epoch
+			snapshot.UpdatedAt = now
+			return snapshot, true, nil
+		})
+		if err != nil {
+			return Snapshot{}, err
+		}
 	}
 	if m.distributed != nil {
 		now, err := m.backend.Now(ctx)
@@ -674,8 +929,8 @@ func (m *Manager) Snapshot(ctx context.Context, botID, sessionID string) (Snapsh
 			snapshot.Queue = nonNilQueue(snapshot.Queue)
 			return snapshot, nil
 		}
-		lostStreamID := snapshot.CurrentRunView.StreamID
-		updated, changed, err := m.updateAndPublish(ctx, key, lostStreamID, func(current Snapshot, ok bool) (Snapshot, bool, error) {
+		lostRef := streamRefForRun(snapshot.BotID, snapshot.SessionID, snapshot.CurrentRunView)
+		updated, changed, err := m.updateAndPublish(ctx, key, lostRef.StreamID, func(current Snapshot, ok bool) (Snapshot, bool, error) {
 			if !ok {
 				return current, false, nil
 			}
@@ -690,9 +945,10 @@ func (m *Manager) Snapshot(ctx context.Context, botID, sessionID string) (Snapsh
 			return Snapshot{}, err
 		}
 		snapshot = updated
-		if changed && lostStreamID != "" {
-			_ = m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), lostStreamID)
-			if ctrl := m.localControl(lostStreamID); ctrl != nil {
+		if changed && lostRef.StreamID != "" {
+			_, _ = m.distributed.DeleteStreamRef(context.WithoutCancel(ctx), lostRef)
+			lostHandle := RunHandle{BotID: lostRef.BotID, SessionID: lostRef.SessionID, StreamID: lostRef.StreamID, Generation: lostRef.Generation}
+			if ctrl := m.localControlForHandle(lostHandle); ctrl != nil {
 				m.cancelRunControl(ctrl)
 			}
 		}
@@ -727,11 +983,13 @@ func (m *Manager) Subscribe(ctx context.Context, botID, sessionID string) (Subsc
 		}
 		ticker := time.NewTicker(reconcileInterval)
 		defer ticker.Stop()
+		var lastEpoch string
 		var lastSeq int64
-		var lastUpdatedAt time.Time
 		events := backendSub.C
 		for {
 			select {
+			case <-m.closeCh:
+				return
 			case <-subCtx.Done():
 				return
 			case event, ok := <-events:
@@ -745,17 +1003,19 @@ func (m *Manager) Subscribe(ctx context.Context, botID, sessionID string) (Subsc
 					})
 					continue
 				}
-				updatedAt := time.Time{}
-				if event.UpdatedAt != nil {
-					updatedAt = *event.UpdatedAt
+				eventEpoch := runtimeEventEpoch(event)
+				if lastEpoch != "" && eventEpoch == "" {
+					enqueueRuntimeEvent(out, Event{
+						Type:      EventRuntimeDropped,
+						BotID:     key.BotID,
+						SessionID: key.SessionID,
+						Epoch:     lastEpoch,
+						Seq:       lastSeq,
+						Message:   "runtime event is missing epoch",
+					})
+					continue
 				}
-				if event.Snapshot != nil {
-					updatedAt = event.Snapshot.UpdatedAt
-				}
-				if event.Seq < lastSeq {
-					if !updatedAt.After(lastUpdatedAt) {
-						continue
-					}
+				if lastEpoch != "" && eventEpoch != "" && eventEpoch != lastEpoch {
 					resetSnapshot, err := m.Snapshot(subCtx, key.BotID, key.SessionID)
 					if err != nil {
 						enqueueRuntimeEvent(out, Event{
@@ -763,7 +1023,8 @@ func (m *Manager) Subscribe(ctx context.Context, botID, sessionID string) (Subsc
 							BotID:     key.BotID,
 							SessionID: key.SessionID,
 							Seq:       lastSeq,
-							Message:   "runtime sequence epoch changed",
+							Epoch:     lastEpoch,
+							Message:   "runtime epoch changed",
 						})
 						continue
 					}
@@ -771,10 +1032,14 @@ func (m *Manager) Subscribe(ctx context.Context, botID, sessionID string) (Subsc
 						Type:      EventRuntimeSnapshot,
 						BotID:     key.BotID,
 						SessionID: key.SessionID,
+						Epoch:     resetSnapshot.Epoch,
 						Seq:       resetSnapshot.Seq,
 						Snapshot:  &resetSnapshot,
 					}
-					updatedAt = resetSnapshot.UpdatedAt
+					eventEpoch = resetSnapshot.Epoch
+				}
+				if eventEpoch == lastEpoch && event.Seq < lastSeq {
+					continue
 				}
 				selfContained := event.Delta != nil && event.Delta.CurrentRunView != nil
 				if event.Type == EventRuntimeDelta && !selfContained && lastSeq > 0 && event.Seq > lastSeq+1 {
@@ -782,15 +1047,16 @@ func (m *Manager) Subscribe(ctx context.Context, botID, sessionID string) (Subsc
 						Type:      EventRuntimeDropped,
 						BotID:     key.BotID,
 						SessionID: key.SessionID,
+						Epoch:     lastEpoch,
 						Seq:       lastSeq,
 						Message:   "runtime delta sequence gap",
 					})
 				}
+				if eventEpoch != "" {
+					lastEpoch = eventEpoch
+				}
 				if event.Seq > 0 {
 					lastSeq = event.Seq
-				}
-				if updatedAt.After(lastUpdatedAt) {
-					lastUpdatedAt = updatedAt
 				}
 				enqueueRuntimeEvent(out, event)
 			case <-ticker.C:
@@ -801,16 +1067,16 @@ func (m *Manager) Subscribe(ctx context.Context, botID, sessionID string) (Subsc
 					}
 					continue
 				}
-				reset := snapshot.Seq < lastSeq && (snapshot.CurrentRunView == nil || snapshot.UpdatedAt.After(lastUpdatedAt))
-				if snapshot.Seq <= lastSeq && !reset {
+				if snapshot.Epoch == lastEpoch && snapshot.Seq <= lastSeq {
 					continue
 				}
+				lastEpoch = snapshot.Epoch
 				lastSeq = snapshot.Seq
-				lastUpdatedAt = snapshot.UpdatedAt
 				enqueueRuntimeEvent(out, Event{
 					Type:      EventRuntimeSnapshot,
 					BotID:     key.BotID,
 					SessionID: key.SessionID,
+					Epoch:     snapshot.Epoch,
 					Seq:       snapshot.Seq,
 					Snapshot:  &snapshot,
 				})
@@ -844,18 +1110,21 @@ func (m *Manager) updateAndPublish(ctx context.Context, key Key, streamID string
 	return snapshot, true, nil
 }
 
-func (m *Manager) updateActiveAndPublish(ctx context.Context, key Key, streamID string, update ActiveRunUpdate, buildDelta func(Snapshot) RuntimeDelta) (Snapshot, bool, error) {
+func (m *Manager) updateActiveAndPublish(ctx context.Context, handle RunHandle, update ActiveRunUpdate, buildDelta func(Snapshot) RuntimeDelta) (Snapshot, bool, error) {
+	handle = handle.normalized()
+	if !handle.valid() {
+		return Snapshot{}, false, ErrRunOwnershipLost
+	}
+	key := handle.key()
+	streamID := handle.StreamID
 	var snapshot Snapshot
 	var changed bool
 	var err error
 	if m.distributed != nil {
-		snapshot, changed, err = m.distributed.UpdateActiveRun(ctx, key, streamID, update)
+		snapshot, changed, err = m.distributed.UpdateActiveRun(ctx, key, streamID, handle.Generation, update)
 	} else {
-		if m.localControl(streamID) == nil {
-			return Snapshot{}, false, ErrRunOwnershipLost
-		}
 		snapshot, changed, err = m.backend.Update(ctx, key, func(snapshot Snapshot, ok bool) (Snapshot, bool, error) {
-			if !ok || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != streamID || !isActiveRunStatus(snapshot.CurrentRunView.Status) {
+			if !ok || !runMatchesHandle(snapshot.CurrentRunView, handle) || !isActiveRunStatus(snapshot.CurrentRunView.Status) {
 				return snapshot, false, ErrRunOwnershipLost
 			}
 			now, nowErr := m.backend.Now(ctx)
@@ -874,6 +1143,32 @@ func (m *Manager) updateActiveAndPublish(ctx context.Context, key Key, streamID 
 	}
 	if err := m.publishRuntimeDelta(ctx, snapshot, streamID, delta); err != nil {
 		m.logger.Warn("publish runtime delta failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", streamID))
+	}
+	return snapshot, true, nil
+}
+
+func (m *Manager) releaseActiveAndPublish(ctx context.Context, handle RunHandle, update ActiveRunUpdate, buildDelta func(Snapshot) RuntimeDelta) (Snapshot, bool, error) {
+	handle = handle.normalized()
+	if m.distributed == nil {
+		return m.updateActiveAndPublish(ctx, handle, update, buildDelta)
+	}
+	if !handle.valid() {
+		return Snapshot{}, false, ErrRunOwnershipLost
+	}
+	ref := StreamRef{
+		BotID: handle.BotID, SessionID: handle.SessionID, StreamID: handle.StreamID,
+		OwnerID: m.ownerID, Generation: handle.Generation,
+	}
+	snapshot, changed, err := m.distributed.ReleaseRun(ctx, handle.key(), ref, update)
+	if err != nil || !changed {
+		return snapshot, changed, err
+	}
+	delta := RuntimeDelta{}
+	if buildDelta != nil {
+		delta = buildDelta(snapshot)
+	}
+	if err := m.publishRuntimeDelta(ctx, snapshot, handle.StreamID, delta); err != nil {
+		m.logger.Warn("publish runtime release delta failed; subscribers will reconcile from snapshot", slog.Any("error", err), slog.String("stream_id", handle.StreamID))
 	}
 	return snapshot, true, nil
 }
@@ -900,6 +1195,7 @@ func (m *Manager) publishRuntimeDelta(ctx context.Context, snapshot Snapshot, st
 		Type:      EventRuntimeDelta,
 		BotID:     snapshot.BotID,
 		SessionID: snapshot.SessionID,
+		Epoch:     snapshot.Epoch,
 		StreamID:  eventStreamID,
 		Seq:       snapshot.Seq,
 		UpdatedAt: &updatedAt,

--- a/internal/sessionruntime/manager_test.go
+++ b/internal/sessionruntime/manager_test.go
@@ -21,9 +21,107 @@ const (
 	testStreamID  = "stream-runtime"
 )
 
+func requireRunHandle(t *testing.T, manager *Manager, botID, sessionID, streamID string) RunHandle {
+	t.Helper()
+	ref, ok, err := manager.StreamRef(context.Background(), streamID)
+	if err != nil || !ok {
+		t.Fatalf("load run handle for %q = ok:%v err:%v", streamID, ok, err)
+	}
+	if ref.BotID != botID || ref.SessionID != sessionID {
+		t.Fatalf("run handle scope = %s/%s, want %s/%s", ref.BotID, ref.SessionID, botID, sessionID)
+	}
+	return RunHandle{BotID: ref.BotID, SessionID: ref.SessionID, StreamID: ref.StreamID, Generation: ref.Generation}
+}
+
 type runtimeBackendContractSuite struct {
 	newBackend        func(t *testing.T) Backend
 	newSharedBackends func(t *testing.T, count int) []Backend
+}
+
+type blockingCommandResultLoadBackend struct {
+	DistributedBackend
+	started chan struct{}
+	once    sync.Once
+}
+
+type gatedCommandResultLoadBackend struct {
+	DistributedBackend
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingCommandResultLoadBackend) LoadCommandResult(ctx context.Context, _ string) (Command, bool, error) {
+	b.once.Do(func() { close(b.started) })
+	<-ctx.Done()
+	return Command{}, false, ctx.Err()
+}
+
+func (b *gatedCommandResultLoadBackend) LoadCommandResult(ctx context.Context, commandID string) (Command, bool, error) {
+	b.once.Do(func() { close(b.started) })
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return Command{}, false, ctx.Err()
+	}
+	return b.DistributedBackend.LoadCommandResult(ctx, commandID)
+}
+
+func TestRuntimeCommandResultPollingHonorsAcknowledgementDeadline(t *testing.T) {
+	backend := &blockingCommandResultLoadBackend{started: make(chan struct{})}
+	manager := NewManager(backend, Options{CommandAckTTL: 40 * time.Millisecond})
+	request := Command{ID: "command-deadline", PayloadHash: commandPayloadHash([]byte(`{"decision":"approve"}`))}
+
+	startedAt := time.Now()
+	err := manager.waitCommandResult(context.Background(), request, make(chan error), manager.commandTimeout())
+	elapsed := time.Since(startedAt)
+	if err == nil || !strings.Contains(err.Error(), "not acknowledged") {
+		t.Fatalf("wait error = %v, want acknowledgement timeout", err)
+	}
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("blocked result lookup exceeded acknowledgement deadline: %s", elapsed)
+	}
+	select {
+	case <-backend.started:
+	default:
+		t.Fatal("result polling did not reach the backend")
+	}
+}
+
+func TestRuntimeCommandAdmissionDeduplicatesBeforeWorkerScheduling(t *testing.T) {
+	manager := NewManager(NewMemoryBackend(), Options{})
+	cmd := Command{Type: CommandToolApprovalResponse, ID: "stable-command-id"}
+	if !manager.admitCommand(cmd) {
+		t.Fatal("first command was not admitted")
+	}
+	if manager.admitCommand(cmd) {
+		t.Fatal("duplicate command was admitted while the original was queued")
+	}
+	manager.releaseCommandAdmission(cmd)
+	if !manager.admitCommand(cmd) {
+		t.Fatal("command was not admitted after the original completed")
+	}
+}
+
+type distributedRuntimeBackendContractSuite struct {
+	newBackend        func(t *testing.T) DistributedBackend
+	newSharedBackends func(t *testing.T, count int) []DistributedBackend
+}
+
+func (s distributedRuntimeBackendContractSuite) common() runtimeBackendContractSuite {
+	return runtimeBackendContractSuite{
+		newBackend: func(t *testing.T) Backend {
+			return s.newBackend(t)
+		},
+		newSharedBackends: func(t *testing.T, count int) []Backend {
+			distributed := s.newSharedBackends(t, count)
+			backends := make([]Backend, len(distributed))
+			for i := range distributed {
+				backends[i] = distributed[i]
+			}
+			return backends
+		},
+	}
 }
 
 func memoryRuntimeBackendSuite() runtimeBackendContractSuite {
@@ -72,6 +170,18 @@ func testRuntimeManagerWithOptions(t *testing.T, backend Backend, opts Options) 
 	return manager
 }
 
+type dropCommandBackend struct {
+	DistributedBackend
+	published chan Command
+}
+
+func (b dropCommandBackend) PublishCommand(_ context.Context, _ string, command Command) error {
+	if b.published != nil {
+		b.published <- command
+	}
+	return nil
+}
+
 type gatedCommandSubscribeBackend struct {
 	DistributedBackend
 	entered  chan struct{}
@@ -79,6 +189,32 @@ type gatedCommandSubscribeBackend struct {
 	commands chan Command
 	closed   chan struct{}
 	once     sync.Once
+}
+
+type contextBlockingCommandSubscribeBackend struct {
+	DistributedBackend
+	entered chan struct{}
+}
+
+type contextBlockingHealthBackend struct {
+	DistributedBackend
+	checked chan struct{}
+}
+
+func (b *contextBlockingHealthBackend) CheckHealth(ctx context.Context) error {
+	close(b.checked)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (*contextBlockingHealthBackend) SubscribeCommands(context.Context, string) (CommandSubscription, error) {
+	panic("command subscription must not start before health check succeeds")
+}
+
+func (b *contextBlockingCommandSubscribeBackend) SubscribeCommands(ctx context.Context, _ string) (CommandSubscription, error) {
+	close(b.entered)
+	<-ctx.Done()
+	return CommandSubscription{}, ctx.Err()
 }
 
 func (b *gatedCommandSubscribeBackend) SubscribeCommands(context.Context, string) (CommandSubscription, error) {
@@ -98,12 +234,177 @@ func (b *gatedCommandSubscribeBackend) closeSubscription() {
 	})
 }
 
+type startRunGateBackend struct {
+	DistributedBackend
+	claimed chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
 type activationGateBackend struct {
 	Backend
 	calls   atomic.Int64
 	entered chan struct{}
 	release chan struct{}
 	once    sync.Once
+}
+
+type delayedOwnershipValidationBackend struct {
+	DistributedBackend
+	validated chan struct{}
+	release   chan struct{}
+}
+
+type delayedStreamRefCleanupBackend struct {
+	DistributedBackend
+	targetGeneration string
+	deleted          chan struct{}
+	release          chan struct{}
+	once             sync.Once
+}
+
+func (b *delayedStreamRefCleanupBackend) DeleteStreamRef(ctx context.Context, ref StreamRef) (bool, error) {
+	deleted, err := b.DistributedBackend.DeleteStreamRef(ctx, ref)
+	if ref.Generation != b.targetGeneration {
+		return deleted, err
+	}
+	b.once.Do(func() { close(b.deleted) })
+	select {
+	case <-b.release:
+		return deleted, err
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}
+
+type blockedLeaseRenewalBackend struct {
+	DistributedBackend
+	calls   atomic.Int64
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+type uninterruptibleLeaseRenewalBackend struct {
+	DistributedBackend
+	calls   atomic.Int64
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockedLeaseRenewalBackend) RenewLease(ctx context.Context, key Key, streamID, ownerID, generation string, now, expiresAt time.Time) error {
+	if b.calls.Add(1) == 1 {
+		return b.DistributedBackend.RenewLease(ctx, key, streamID, ownerID, generation, now, expiresAt)
+	}
+	b.once.Do(func() { close(b.started) })
+	select {
+	case <-b.release:
+		return b.DistributedBackend.RenewLease(ctx, key, streamID, ownerID, generation, now, expiresAt)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *uninterruptibleLeaseRenewalBackend) RenewLease(ctx context.Context, key Key, streamID, ownerID, generation string, now, expiresAt time.Time) error {
+	if b.calls.Add(1) == 1 {
+		return b.DistributedBackend.RenewLease(ctx, key, streamID, ownerID, generation, now, expiresAt)
+	}
+	b.once.Do(func() { close(b.started) })
+	<-b.release
+	return ctx.Err()
+}
+
+func (b *delayedOwnershipValidationBackend) ValidateRunOwnership(ctx context.Context, key Key, ref StreamRef) error {
+	if err := b.DistributedBackend.ValidateRunOwnership(ctx, key, ref); err != nil {
+		return err
+	}
+	close(b.validated)
+	select {
+	case <-b.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type toggledUpdateFailureBackend struct {
+	DistributedBackend
+	failing atomic.Bool
+}
+
+type toggledNowFailureBackend struct {
+	DistributedBackend
+	failing atomic.Bool
+}
+
+type countCommandPublishBackend struct {
+	DistributedBackend
+	publishes atomic.Int64
+}
+
+type delayedNowBackend struct {
+	Backend
+	delay time.Duration
+}
+
+func (b delayedNowBackend) Now(ctx context.Context) (time.Time, error) {
+	now, err := b.Backend.Now(ctx)
+	if err != nil {
+		return time.Time{}, err
+	}
+	timer := time.NewTimer(b.delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return now, nil
+	case <-ctx.Done():
+		return time.Time{}, ctx.Err()
+	}
+}
+
+func (b *toggledNowFailureBackend) Now(ctx context.Context) (time.Time, error) {
+	if b.failing.Load() {
+		return time.Time{}, context.DeadlineExceeded
+	}
+	return b.DistributedBackend.Now(ctx)
+}
+
+func (b *countCommandPublishBackend) PublishCommand(ctx context.Context, ownerID string, command Command) error {
+	b.publishes.Add(1)
+	return b.DistributedBackend.PublishCommand(ctx, ownerID, command)
+}
+
+func (b *toggledUpdateFailureBackend) Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error) {
+	if b.failing.Load() {
+		return Snapshot{}, false, errors.New("injected persistent update failure")
+	}
+	return b.DistributedBackend.Update(ctx, key, update)
+}
+
+func (b *toggledUpdateFailureBackend) UpdateActiveRun(ctx context.Context, key Key, streamID, generation string, update ActiveRunUpdate) (Snapshot, bool, error) {
+	if b.failing.Load() {
+		return Snapshot{}, false, errors.New("injected persistent update failure")
+	}
+	return b.DistributedBackend.UpdateActiveRun(ctx, key, streamID, generation, update)
+}
+
+func (b *toggledUpdateFailureBackend) ReleaseRun(ctx context.Context, key Key, ref StreamRef, update ActiveRunUpdate) (Snapshot, bool, error) {
+	if b.failing.Load() {
+		return Snapshot{}, false, errors.New("injected persistent update failure")
+	}
+	return b.DistributedBackend.ReleaseRun(ctx, key, ref, update)
+}
+
+func (b *startRunGateBackend) StartRun(ctx context.Context, key Key, ref StreamRef, update SnapshotUpdate) (Snapshot, bool, error) {
+	snapshot, changed, err := b.DistributedBackend.StartRun(ctx, key, ref, update)
+	b.once.Do(func() { close(b.claimed) })
+	select {
+	case <-b.release:
+		return snapshot, changed, err
+	case <-ctx.Done():
+		return Snapshot{}, false, ctx.Err()
+	}
 }
 
 func (b *activationGateBackend) Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error) {
@@ -136,6 +437,74 @@ func TestMemoryRuntimeManagerContract(t *testing.T) {
 	runCommonRuntimeManagerContract(t, memoryRuntimeBackendSuite())
 }
 
+func TestActiveCommandContextRequiresAbsoluteExpiry(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(NewMemoryBackend(), Options{CommandAckTTL: time.Second})
+	ctx, cancel, err := manager.activeCommandContext(context.Background(), Command{CreatedAt: time.Now().UTC()})
+	cancel()
+	if ctx != nil || !errors.Is(err, ErrCommandExpired) {
+		t.Fatalf("command context = (%v, %v), want ErrCommandExpired", ctx, err)
+	}
+}
+
+func TestActiveCommandContextAccountsForBackendTimeLatency(t *testing.T) {
+	t.Parallel()
+
+	backend := delayedNowBackend{Backend: NewMemoryBackend(), delay: 40 * time.Millisecond}
+	manager := NewManager(backend, Options{CommandAckTTL: time.Second})
+	createdAt := time.Now().UTC()
+	ctx, cancel, err := manager.activeCommandContext(context.Background(), Command{
+		CreatedAt: createdAt,
+		ExpiresAt: createdAt.Add(25 * time.Millisecond),
+	})
+	cancel()
+	if ctx != nil || !errors.Is(err, ErrCommandExpired) {
+		t.Fatalf("delayed command context = (%v, %v), want ErrCommandExpired", ctx, err)
+	}
+}
+
+func TestFinishRunSerializesInjectSendAndClose(t *testing.T) {
+	manager := testRuntimeManager(t, NewMemoryBackend(), "owner-inject-close")
+
+	for i := range 100 {
+		sessionID := fmt.Sprintf("session-inject-close-%d", i)
+		streamID := fmt.Sprintf("stream-inject-close-%d", i)
+		injectCh := make(chan conversation.InjectMessage, 1)
+		if err := manager.StartRun(context.Background(), testBotID, sessionID, streamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+			t.Fatalf("start run %d: %v", i, err)
+		}
+		start := make(chan struct{})
+		steerDone := make(chan struct{})
+		go func() {
+			<-start
+			_, _ = manager.Steer(context.Background(), testBotID, sessionID, streamID, "race teardown")
+			close(steerDone)
+		}()
+		close(start)
+		if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, sessionID, streamID), RunStatusCompleted, ""); err != nil {
+			t.Fatalf("finish run %d: %v", i, err)
+		}
+		receiveTestResult(t, "concurrent steer", steerDone)
+		waitInjectChannelClosed(t, injectCh)
+	}
+}
+
+func waitInjectChannelClosed(t *testing.T, injectCh <-chan conversation.InjectMessage) {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case _, ok := <-injectCh:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("runtime inject channel was not closed")
+		}
+	}
+}
+
 func waitRuntimeEvent(t *testing.T, events <-chan Event, pred func(Event) bool) Event {
 	t.Helper()
 	deadline := time.After(5 * time.Second)
@@ -151,18 +520,6 @@ func waitRuntimeEvent(t *testing.T, events <-chan Event, pred func(Event) bool) 
 		case <-deadline:
 			t.Fatal("timed out waiting for runtime event")
 		}
-	}
-}
-
-func receiveTestResult[T any](t *testing.T, label string, ch <-chan T) T {
-	t.Helper()
-	select {
-	case result := <-ch:
-		return result
-	case <-time.After(5 * time.Second):
-		t.Fatalf("timed out waiting for %s", label)
-		var zero T
-		return zero
 	}
 }
 
@@ -188,6 +545,18 @@ func TestRuntimeManagerRejectsRunAfterClose(t *testing.T) {
 	}
 }
 
+func receiveTestResult[T any](t *testing.T, label string, ch <-chan T) T {
+	t.Helper()
+	select {
+	case result := <-ch:
+		return result
+	case <-time.After(5 * time.Second):
+		var zero T
+		t.Fatalf("timed out waiting for %s", label)
+		return zero
+	}
+}
+
 func TestRuntimeManagerDoesNotActivateAdmissionAfterClose(t *testing.T) {
 	backend := NewMemoryBackend()
 	manager := NewManager(backend, Options{})
@@ -195,12 +564,12 @@ func TestRuntimeManagerDoesNotActivateAdmissionAfterClose(t *testing.T) {
 	releaseBuilder := make(chan struct{})
 	startDone := make(chan error, 1)
 	go func() {
-		startDone <- manager.StartRunWithAdmissionBuilder(
+		_, err := manager.StartRunWithAdmissionBuilderHandle(
 			context.Background(),
 			testBotID,
 			"session-close-during-admission",
 			"stream-close-during-admission",
-			func(context.Context) (RunAdmissionView, error) {
+			func(context.Context, RunHandle) (RunAdmissionView, error) {
 				close(builderStarted)
 				<-releaseBuilder
 				return RunAdmissionView{}, nil
@@ -209,13 +578,14 @@ func TestRuntimeManagerDoesNotActivateAdmissionAfterClose(t *testing.T) {
 			func() {},
 			make(chan conversation.InjectMessage, 1),
 		)
+		startDone <- err
 	}()
 	<-builderStarted
 
 	shutdownCtx, cancelShutdown := context.WithCancel(context.Background())
 	cancelShutdown()
-	if err := manager.CloseContext(shutdownCtx); err != nil {
-		t.Fatalf("close manager: %v", err)
+	if err := manager.CloseContext(shutdownCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("close manager error = %v, want context canceled", err)
 	}
 	close(releaseBuilder)
 	if err := receiveTestResult(t, "closed admission", startDone); !errors.Is(err, ErrManagerClosed) && !errors.Is(err, ErrRunOwnershipLost) {
@@ -253,6 +623,67 @@ func TestRuntimeManagerDoesNotStartCommandLoopAfterClose(t *testing.T) {
 		t.Fatalf("start after close error = %v, want ErrManagerClosed", err)
 	}
 	receiveTestResult(t, "late command subscription close", backend.closed)
+}
+
+func TestRuntimeManagerStartHonorsStartupDeadlineDuringCommandSubscribe(t *testing.T) {
+	t.Parallel()
+
+	backend := &contextBlockingCommandSubscribeBackend{entered: make(chan struct{})}
+	manager := NewManager(backend, Options{OwnerID: "owner-start-deadline"})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := manager.Start(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("start error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("start ignored startup deadline for %s", elapsed)
+	}
+}
+
+func TestRuntimeManagerStartHonorsStartupDeadlineDuringHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	backend := &contextBlockingHealthBackend{checked: make(chan struct{})}
+	manager := NewManager(backend, Options{OwnerID: "owner-health-deadline"})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	err := manager.Start(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("start error = %v, want context deadline exceeded", err)
+	}
+	select {
+	case <-backend.checked:
+	default:
+		t.Fatal("startup health check was not called")
+	}
+}
+
+func TestRuntimeManagerCloseStopsSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(NewMemoryBackend(), Options{})
+	sub, err := manager.Subscribe(context.Background(), testBotID, "session-close-subscription")
+	if err != nil {
+		t.Fatalf("subscribe runtime: %v", err)
+	}
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case _, ok := <-sub.C:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("runtime subscription remained open after manager close")
+		}
+	}
 }
 
 func TestRuntimeManagerDoesNotTerminalizeAdmissionRejectedByClose(t *testing.T) {
@@ -297,6 +728,221 @@ func TestRuntimeManagerDoesNotTerminalizeAdmissionRejectedByClose(t *testing.T) 
 	}
 }
 
+func testGateCleanup(t *testing.T, cancel context.CancelFunc, gate chan struct{}) func() {
+	t.Helper()
+	release := sync.OnceFunc(func() { close(gate) })
+	t.Cleanup(func() {
+		cancel()
+		release()
+	})
+	return release
+}
+
+func runManagerAbortAcknowledgesReservedRunBeforeTerminalCompletion(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	backend := &startRunGateBackend{
+		DistributedBackend: suite.newBackend(t),
+		claimed:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-start-abort",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 60 * time.Millisecond,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	releaseGate := testGateCleanup(t, cancelRun, backend.release)
+
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- manager.StartRun(
+			runCtx,
+			testBotID,
+			testSessionID,
+			testStreamID,
+			make(chan struct{}, 1),
+			func() {},
+			make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	receiveTestResult(t, "reserved run claim", backend.claimed)
+	handle := manager.localControl(testStreamID).handle()
+
+	type abortResult struct {
+		ok  bool
+		err error
+	}
+	aborted := make(chan abortResult, 1)
+	go func() {
+		ok, err := manager.Abort(runCtx, testBotID, testSessionID, testStreamID)
+		aborted <- abortResult{ok: ok, err: err}
+	}()
+	result := receiveTestResult(t, "reserved run abort", aborted)
+	if result.err != nil || !result.ok {
+		t.Fatalf("abort = ok:%v err:%v", result.ok, result.err)
+	}
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusAborting {
+		t.Fatalf("current run = %#v, want aborting", snapshot.CurrentRunView)
+	}
+
+	releaseGate()
+	if err := receiveTestResult(t, "aborted run admission", startErr); err == nil {
+		t.Fatal("start run unexpectedly activated after abort")
+	}
+	if err := manager.FinishRun(context.Background(), handle, RunStatusAborted, ""); err != nil {
+		t.Fatalf("finish aborted run: %v", err)
+	}
+	snapshot, err = manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusAborted {
+		t.Fatalf("terminal snapshot = %#v err:%v", snapshot.CurrentRunView, err)
+	}
+}
+
+func runManagerDoesNotActivateAdmissionAfterClaimLeaseExpires(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	const leaseTTL = 500 * time.Millisecond
+	backend := &startRunGateBackend{
+		DistributedBackend: suite.newBackend(t),
+		claimed:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-expired-admission",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+		CommandAckTTL: 30 * time.Millisecond,
+	})
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	releaseGate := testGateCleanup(t, cancelRun, backend.release)
+	builderCalled := make(chan struct{}, 1)
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- manager.StartRunWithAdmissionBuilder(
+			runCtx,
+			testBotID,
+			testSessionID,
+			"stream-expired-admission",
+			func(context.Context) (RunAdmissionView, error) {
+				builderCalled <- struct{}{}
+				return RunAdmissionView{}, nil
+			},
+			make(chan struct{}, 1),
+			func() {},
+			make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	receiveTestResult(t, "expiring run claim", backend.claimed)
+	time.Sleep(leaseTTL + leaseTTL/2)
+	releaseGate()
+	if err := receiveTestResult(t, "expired run admission", startErr); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("expired admission error = %v, want ErrRunOwnershipLost", err)
+	}
+	select {
+	case <-builderCalled:
+		t.Fatal("expired admission executed its builder")
+	default:
+	}
+	if manager.localControl("stream-expired-admission") != nil {
+		t.Fatal("expired admission retained local control")
+	}
+}
+
+func runManagerDoesNotRetryFinishAfterOwnershipLoss(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	const leaseTTL = 500 * time.Millisecond
+	manager := testRuntimeManagerWithOptions(t, suite.newBackend(t), Options{
+		OwnerID:       "owner-expired-finish",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+		CommandAckTTL: 30 * time.Millisecond,
+	})
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, "stream-expired-finish", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	manager.stopLeaseRenewal(manager.localControl("stream-expired-finish"))
+	time.Sleep(leaseTTL + leaseTTL/2)
+	if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, testSessionID, "stream-expired-finish"), RunStatusCompleted, ""); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("finish expired run error = %v, want ErrRunOwnershipLost", err)
+	}
+	if manager.localControl("stream-expired-finish") != nil {
+		t.Fatal("ownership-lost finish retained a retrying local control")
+	}
+}
+
+func runManagerCloseWaitsForStartRunAndCancelsControl(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	backend := &startRunGateBackend{
+		DistributedBackend: suite.newBackend(t),
+		claimed:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	manager := NewManager(backend, Options{
+		OwnerID:       "owner-start-close",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+	})
+	closeDone := make(chan struct{})
+	var closeOnce sync.Once
+	var closeErr error
+	startManagerClose := func() {
+		closeOnce.Do(func() {
+			go func() {
+				closeErr = manager.Close()
+				close(closeDone)
+			}()
+		})
+	}
+	t.Cleanup(func() {
+		startManagerClose()
+		receiveTestResult(t, "manager cleanup", closeDone)
+		if closeErr != nil {
+			t.Errorf("close manager during cleanup: %v", closeErr)
+		}
+	})
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	releaseGate := testGateCleanup(t, cancelRun, backend.release)
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
+
+	canceled := make(chan struct{}, 1)
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- manager.StartRun(
+			runCtx,
+			testBotID,
+			testSessionID,
+			testStreamID,
+			make(chan struct{}, 1),
+			func() { canceled <- struct{}{} },
+			make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	receiveTestResult(t, "run claim before manager close", backend.claimed)
+
+	startManagerClose()
+	select {
+	case <-closeDone:
+		t.Fatalf("close completed before StartRun initialized: %v", closeErr)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	releaseGate()
+	if err := receiveTestResult(t, "run admission before manager close", startErr); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("start run error = %v, want ErrManagerClosed", err)
+	}
+	receiveTestResult(t, "manager close", closeDone)
+	if closeErr != nil {
+		t.Fatalf("close manager: %v", closeErr)
+	}
+	receiveTestResult(t, "active run cancellation", canceled)
+}
+
 func TestMemoryBackendExpiresSnapshots(t *testing.T) {
 	backend := NewMemoryBackendWithTTL(30 * time.Millisecond)
 	t.Cleanup(func() { _ = backend.Close() })
@@ -336,10 +982,11 @@ func TestLocalRuntimeDoesNotUseOwnerLeases(t *testing.T) {
 	}
 
 	time.Sleep(3 * 20 * time.Millisecond)
-	if err := manager.ValidateRunOwnership(context.Background(), testBotID, "session-local-no-lease", "stream-local-no-lease"); err != nil {
+	handle := requireRunHandle(t, manager, testBotID, "session-local-no-lease", "stream-local-no-lease")
+	if err := manager.ValidateRunOwnership(context.Background(), handle); err != nil {
 		t.Fatalf("local ownership expired after lease TTL: %v", err)
 	}
-	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, "session-local-no-lease", "stream-local-no-lease", agentpkg.StreamEvent{Type: agentpkg.EventTextDelta, Delta: "still running"}); err != nil {
+	if _, err := manager.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{Type: agentpkg.EventTextDelta, Delta: "still running"}); err != nil {
 		t.Fatalf("handle local event after lease TTL: %v", err)
 	}
 	snapshot, err := manager.Snapshot(context.Background(), testBotID, "session-local-no-lease")
@@ -393,10 +1040,723 @@ func runCommonRuntimeManagerContract(t *testing.T, suite runtimeBackendContractS
 		t.Parallel()
 		runRuntimeManagerKeepsErroredStreamErroredAfterEndContract(t, suite)
 	})
+	t.Run("fences delayed owner mutations after stream id reuse", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerFencesDelayedOwnerMutationsContract(t, suite)
+	})
 	t.Run("serializes concurrent snapshot updates", func(t *testing.T) {
 		t.Parallel()
 		runRuntimeBackendSerializesConcurrentSnapshotUpdatesContract(t, suite)
 	})
+}
+
+func runRuntimeManagerFencesDelayedOwnerMutationsContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+	var generation atomic.Int64
+	manager := testRuntimeManagerWithOptions(t, suite.newBackend(t), Options{
+		OwnerID:       "owner-delayed-mutation",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+		RunGenerationGenerator: func() string {
+			return fmt.Sprintf("generation-%d", generation.Add(1))
+		},
+	})
+
+	oldInject := make(chan conversation.InjectMessage, 1)
+	oldHandle, err := manager.StartRunHandle(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, oldInject)
+	if err != nil {
+		t.Fatalf("start first generation: %v", err)
+	}
+	if _, err := manager.Steer(context.Background(), testBotID, testSessionID, testStreamID, "old generation steer"); err != nil {
+		t.Fatalf("steer first generation: %v", err)
+	}
+	var delayedApplied func()
+	select {
+	case injected := <-oldInject:
+		delayedApplied = injected.Applied
+	case <-time.After(time.Second):
+		t.Fatal("first generation steer was not delivered")
+	}
+	if delayedApplied == nil {
+		t.Fatal("first generation steer has no applied callback")
+	}
+	if err := manager.FinishRun(context.Background(), oldHandle, RunStatusCompleted, ""); err != nil {
+		t.Fatalf("finish first generation: %v", err)
+	}
+	newAbort := make(chan struct{}, 1)
+	newInject := make(chan conversation.InjectMessage, 1)
+	newHandle, err := manager.StartRunHandle(context.Background(), testBotID, testSessionID, testStreamID, newAbort, func() {}, newInject)
+	if err != nil {
+		t.Fatalf("start second generation: %v", err)
+	}
+	if oldHandle.Generation == newHandle.Generation {
+		t.Fatalf("generation reused: %q", oldHandle.Generation)
+	}
+	if ok, err := manager.AbortRun(context.Background(), oldHandle); ok || !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("stale abort = ok:%v err:%v, want ErrRunOwnershipLost", ok, err)
+	}
+	if _, err := manager.SteerRun(context.Background(), oldHandle, "late steer command"); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("stale steer error = %v, want ErrRunOwnershipLost", err)
+	}
+	select {
+	case <-newAbort:
+		t.Fatal("stale abort signaled the new generation")
+	case injected := <-newInject:
+		t.Fatalf("stale steer reached the new generation: %#v", injected)
+	default:
+	}
+
+	if _, err := manager.HandleAgentEvent(context.Background(), oldHandle, agentpkg.StreamEvent{Type: agentpkg.EventTextDelta, Delta: "late output"}); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("late event error = %v, want ErrRunOwnershipLost", err)
+	}
+	if err := manager.FinishRun(context.Background(), oldHandle, RunStatusErrored, "late finish"); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("late finish error = %v, want ErrRunOwnershipLost", err)
+	}
+	delayedApplied()
+	if manager.localControlForHandle(newHandle) == nil {
+		t.Fatal("late mutation removed the current run control")
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("load current generation: %v", err)
+	}
+	if !runMatchesHandle(snapshot.CurrentRunView, newHandle) || snapshot.CurrentRunView.Status != RunStatusRunning || len(snapshot.CurrentRunView.Messages) != 0 || snapshot.CurrentRunView.Error != "" {
+		t.Fatalf("current generation changed by stale callback: %#v", snapshot.CurrentRunView)
+	}
+}
+
+func runDistributedRuntimeManagerContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	t.Run("does not prepare rejected run operations", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerDoesNotBuildRejectedOperationContract(t, suite)
+	})
+	t.Run("routes abort and steer across managers", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRoutesAbortAndSteerAcrossManagersContract(t, suite)
+	})
+	t.Run("routes abort past a stale local generation", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRoutesAbortPastStaleLocalGeneration(t, suite)
+	})
+	t.Run("acknowledges abort after rapid run replacement", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerAcknowledgesAbortAfterRunReplacement(t, suite)
+	})
+	t.Run("routes active response commands to the run owner", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRoutesActiveResponsesAcrossManagersContract(t, suite)
+	})
+	t.Run("preserves remote command deadline errors", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerPreservesRemoteCommandDeadlineError(t, suite)
+	})
+	t.Run("releases pending routed commands when the manager closes", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerReleasesPendingCommandOnClose(t, suite)
+	})
+	t.Run("releases owned runs when the manager closes", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerReleasesOwnedRunOnClose(t, suite)
+	})
+	t.Run("does not block command results behind slow handlers", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerDoesNotBlockCommandResultsBehindSlowHandlers(t, suite)
+	})
+	t.Run("preserves ownership lookup deadline errors", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerPreservesOwnershipDeadlineError(t, suite)
+	})
+	t.Run("acknowledges an applied response that finishes the run", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerAcknowledgesAppliedResponseAfterFinish(t, suite)
+	})
+	t.Run("keeps command routing alive after startup context cancellation", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerCommandRoutingOutlivesStartContext(t, suite)
+	})
+	t.Run("cancels active response handlers when the run finishes", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerCancelsActiveResponseOnFinish(t, suite)
+	})
+	t.Run("cancels active response handlers when the manager closes", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerCancelsActiveResponseOnClose(t, suite)
+	})
+	t.Run("bounds active response handlers by command expiry", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerExpiresActiveResponseHandlers(t, suite)
+	})
+	t.Run("aborts a run while operation admission is blocked", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerAbortsBlockedAdmissionContract(t, suite)
+	})
+	t.Run("marks expired owner lease lost", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerMarksExpiredOwnerLeaseLostContract(t, suite)
+	})
+	t.Run("rejects expired owner lease revival", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRejectsExpiredLeaseRevivalContract(t, suite)
+	})
+	t.Run("fences stale owner events after lease takeover", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerFencesStaleOwnerEventsContract(t, suite)
+	})
+	t.Run("cancels local execution when lease ownership is lost", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerCancelsExecutionAfterOwnershipLossContract(t, suite)
+	})
+	t.Run("keeps terminal hook authority for a user abort", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerKeepsHookAuthorityForUserAbort(t, suite)
+	})
+	t.Run("renews idle owner lease until owner stops", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRenewsIdleOwnerLeaseContract(t, suite)
+	})
+	t.Run("notifies attached subscribers when owner lease expires", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerNotifiesLeaseLostContract(t, suite)
+	})
+	t.Run("reconciles snapshots whose publish was missed", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerReconcilesMissedPublishContract(t, suite)
+	})
+	t.Run("does not acknowledge dropped runtime commands", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerDroppedCommandAckContract(t, suite)
+	})
+	t.Run("acknowledges abort while run admission is reserved", func(t *testing.T) {
+		runManagerAbortAcknowledgesReservedRunBeforeTerminalCompletion(t, suite)
+	})
+	t.Run("does not activate admission after claim lease expires", func(t *testing.T) {
+		runManagerDoesNotActivateAdmissionAfterClaimLeaseExpires(t, suite)
+	})
+	t.Run("does not retry finish after ownership loss", func(t *testing.T) {
+		runManagerDoesNotRetryFinishAfterOwnershipLoss(t, suite)
+	})
+	t.Run("close waits for run admission and cancels control", func(t *testing.T) {
+		runManagerCloseWaitsForStartRunAndCancelsControl(t, suite)
+	})
+	t.Run("retries terminal update before dropping owner route", func(t *testing.T) {
+		runRuntimeManagerRetriesTerminalUpdateBeforeDroppingOwnerRoute(t, suite)
+	})
+	t.Run("abort command does not republish stale self reference", func(t *testing.T) {
+		runRuntimeManagerAbortCommandDoesNotRepublishStaleSelfReference(t, suite)
+	})
+	t.Run("scopes stream reference cleanup to one run generation", func(t *testing.T) {
+		runRuntimeManagerScopesStreamRefCleanupToGeneration(t, suite)
+	})
+	t.Run("rejects delayed commands from an older run generation", func(t *testing.T) {
+		runRuntimeManagerRejectsDelayedOldGenerationCommand(t, suite)
+	})
+	t.Run("rejects ownership validation that returns after the local lease deadline", func(t *testing.T) {
+		runRuntimeManagerRejectsValidationAfterLocalLeaseDeadline(t, suite)
+	})
+	t.Run("lease watchdog revokes ownership while renewal is blocked", func(t *testing.T) {
+		runRuntimeManagerLeaseWatchdogRevokesBlockedRenewal(t, suite)
+	})
+	t.Run("close deadline bounds an uninterruptible lease renewal", func(t *testing.T) {
+		runRuntimeManagerCloseDeadlineBoundsLeaseRenewal(t, suite)
+	})
+	t.Run("expired snapshot cleanup cannot cancel a reused stream generation", func(t *testing.T) {
+		runRuntimeManagerExpiredCleanupScopesLocalControlToGeneration(t, suite)
+	})
+}
+
+func runRuntimeManagerRoutesAbortPastStaleLocalGeneration(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	backends := suite.newSharedBackends(t, 2)
+	caller := testRuntimeManager(t, backends[0], "owner-stale-local-caller")
+	owner := testRuntimeManager(t, backends[1], "owner-current-generation")
+	abortCh := make(chan struct{}, 1)
+	handle, err := owner.StartRunHandle(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-reused-generation",
+		abortCh,
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err != nil {
+		t.Fatalf("start current run: %v", err)
+	}
+	ready := make(chan struct{})
+	close(ready)
+	caller.mu.Lock()
+	caller.controls[handle.StreamID] = &runControl{
+		botID: testBotID, sessionID: testSessionID, streamID: handle.StreamID,
+		generation: "stale-generation", ready: ready,
+	}
+	caller.mu.Unlock()
+
+	ok, err := caller.AbortRun(context.Background(), handle)
+	if err != nil || !ok {
+		t.Fatalf("route abort past stale local generation = ok:%v err:%v", ok, err)
+	}
+	select {
+	case <-abortCh:
+	case <-time.After(time.Second):
+		t.Fatal("current run owner did not receive routed abort")
+	}
+}
+
+func runRuntimeManagerAcknowledgesAbortAfterRunReplacement(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-abort-replacement")
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	gated := &gatedCommandResultLoadBackend{
+		DistributedBackend: backends[1],
+		started:            loadStarted,
+		release:            releaseLoad,
+	}
+	droppedResult := make(chan Command, 1)
+	remote := testRuntimeManager(t, dropCommandResultSubscriptionBackend{
+		DistributedBackend: gated,
+		dropped:            droppedResult,
+	}, "remote-abort-replacement")
+
+	abortCh := make(chan struct{}, 1)
+	handle, err := owner.StartRunHandle(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-abort-replacement",
+		abortCh,
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err != nil {
+		t.Fatalf("start aborted run: %v", err)
+	}
+
+	type abortResult struct {
+		ok  bool
+		err error
+	}
+	resultCh := make(chan abortResult, 1)
+	go func() {
+		ok, abortErr := remote.AbortRun(context.Background(), handle)
+		resultCh <- abortResult{ok: ok, err: abortErr}
+	}()
+	receiveTestResult(t, "owner abort signal", abortCh)
+	resultCommand := receiveTestResult(t, "dropped abort result", droppedResult)
+	if resultCommand.Type != CommandResult || resultCommand.ID == "" {
+		t.Fatalf("abort result command = %#v", resultCommand)
+	}
+	receiveTestResult(t, "abort result polling", loadStarted)
+
+	if err := owner.FinishRun(context.Background(), handle, RunStatusAborted, ""); err != nil {
+		t.Fatalf("finish aborted run: %v", err)
+	}
+	replacement, err := owner.StartRunHandle(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-after-abort",
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err != nil {
+		t.Fatalf("start replacement run: %v", err)
+	}
+	close(releaseLoad)
+
+	result := receiveTestResult(t, "remote abort acknowledgement", resultCh)
+	if result.err != nil || !result.ok {
+		t.Fatalf("remote abort after replacement = ok:%v err:%v", result.ok, result.err)
+	}
+	snapshot, err := remote.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("load replacement snapshot: %v", err)
+	}
+	if !runMatchesHandle(snapshot.CurrentRunView, replacement) {
+		t.Fatalf("replacement run changed by abort acknowledgement: %#v", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerCloseDeadlineBoundsLeaseRenewal(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	const leaseTTL = time.Second
+	backend := &uninterruptibleLeaseRenewalBackend{
+		DistributedBackend: suite.newBackend(t),
+		started:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	releaseBackend := sync.OnceFunc(func() { close(backend.release) })
+	t.Cleanup(releaseBackend)
+	manager := NewManager(backend, Options{
+		OwnerID:       "owner-close-deadline",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+	})
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, "stream-close-deadline", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	select {
+	case <-backend.started:
+	case <-time.After(leaseTTL):
+		t.Fatal("lease renewal did not start")
+	}
+	ctrl := manager.localControl("stream-close-deadline")
+	if ctrl == nil {
+		t.Fatal("local run control is missing")
+	}
+	closeCtx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+	startedAt := time.Now()
+	err := manager.CloseContext(closeCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("close error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 500*time.Millisecond {
+		t.Fatalf("close ignored its deadline for %s", elapsed)
+	}
+	releaseBackend()
+	select {
+	case <-ctrl.leaseDone:
+	case <-time.After(time.Second):
+		t.Fatal("lease renewal worker did not exit after backend release")
+	}
+}
+
+func runRuntimeManagerLeaseWatchdogRevokesBlockedRenewal(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	const leaseTTL = 120 * time.Millisecond
+	backend := &blockedLeaseRenewalBackend{
+		DistributedBackend: suite.newBackend(t),
+		started:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	releaseBackend := sync.OnceFunc(func() { close(backend.release) })
+	t.Cleanup(func() { backend.once.Do(func() { close(backend.started) }); releaseBackend() })
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-blocked-renewal",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+	})
+	abortCh := make(chan struct{}, 1)
+	canceled := make(chan struct{}, 1)
+	authorityCtx, revokeAuthority := context.WithCancelCause(context.Background())
+	handle, err := manager.StartRunWithAdmissionBuilderAndOwnershipHandle(
+		context.Background(), testBotID, testSessionID, "stream-blocked-renewal",
+		func(context.Context, RunHandle) (RunAdmissionView, error) { return RunAdmissionView{}, nil },
+		revokeAuthority,
+		abortCh,
+		func() {
+			select {
+			case canceled <- struct{}{}:
+			default:
+			}
+		},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	select {
+	case <-backend.started:
+	case <-time.After(time.Second):
+		t.Fatal("lease renewal did not block")
+	}
+	select {
+	case <-authorityCtx.Done():
+		if !errors.Is(context.Cause(authorityCtx), ErrRunOwnershipLost) {
+			t.Fatalf("authority cancellation = %v, want ErrRunOwnershipLost", context.Cause(authorityCtx))
+		}
+	case <-time.After(2 * leaseTTL):
+		t.Fatal("lease watchdog did not revoke ownership at the local deadline")
+	}
+	select {
+	case <-abortCh:
+	case <-time.After(time.Second):
+		t.Fatal("lease watchdog did not signal abort")
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("lease watchdog did not cancel agent execution")
+	}
+	if err := manager.ValidateRunOwnership(context.Background(), handle); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("ownership validation error = %v, want ErrRunOwnershipLost", err)
+	}
+}
+
+func runRuntimeManagerExpiredCleanupScopesLocalControlToGeneration(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	const leaseTTL = 80 * time.Millisecond
+	backend := &delayedStreamRefCleanupBackend{
+		DistributedBackend: suite.newBackend(t),
+		deleted:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	releaseBackend := sync.OnceFunc(func() { close(backend.release) })
+	t.Cleanup(func() { backend.once.Do(func() { close(backend.deleted) }); releaseBackend() })
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-expired-cleanup-generation",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+	})
+	oldHandle, err := manager.StartRunHandle(context.Background(), testBotID, testSessionID, "stream-reused-after-expiry", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1))
+	if err != nil {
+		t.Fatalf("start old generation: %v", err)
+	}
+	backend.targetGeneration = oldHandle.Generation
+	manager.stopLeaseRenewal(manager.localControlForHandle(oldHandle))
+	time.Sleep(leaseTTL + 30*time.Millisecond)
+
+	snapshotDone := make(chan error, 1)
+	go func() {
+		_, snapshotErr := manager.Snapshot(context.Background(), testBotID, testSessionID)
+		snapshotDone <- snapshotErr
+	}()
+	select {
+	case <-backend.deleted:
+	case <-time.After(time.Second):
+		t.Fatal("expired stream reference cleanup did not start")
+	}
+	manager.forgetLocalControlForHandle(context.Background(), oldHandle)
+	newAbort := make(chan struct{}, 1)
+	newCanceled := make(chan struct{}, 1)
+	newHandle, err := manager.StartRunHandle(context.Background(), testBotID, testSessionID, "stream-reused-after-expiry", newAbort, func() {
+		select {
+		case newCanceled <- struct{}{}:
+		default:
+		}
+	}, make(chan conversation.InjectMessage, 1))
+	if err != nil {
+		t.Fatalf("start reused generation: %v", err)
+	}
+	if newHandle.Generation == oldHandle.Generation {
+		t.Fatalf("generation was reused: %q", newHandle.Generation)
+	}
+	releaseBackend()
+	select {
+	case err := <-snapshotDone:
+		if err != nil {
+			t.Fatalf("reconcile expired snapshot: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expired snapshot cleanup did not finish")
+	}
+	select {
+	case <-newAbort:
+		t.Fatal("expired cleanup aborted the reused generation")
+	case <-newCanceled:
+		t.Fatal("expired cleanup canceled the reused generation")
+	case <-time.After(30 * time.Millisecond):
+	}
+	if err := manager.ValidateRunOwnership(context.Background(), newHandle); err != nil {
+		t.Fatalf("validate reused generation: %v", err)
+	}
+}
+
+func runRuntimeManagerRejectsValidationAfterLocalLeaseDeadline(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	const leaseTTL = 120 * time.Millisecond
+	backend := &delayedOwnershipValidationBackend{
+		DistributedBackend: suite.newBackend(t),
+		validated:          make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-delayed-validation",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+	})
+	handle, err := manager.StartRunHandle(context.Background(), testBotID, testSessionID, "stream-delayed-validation", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	manager.stopLeaseRenewal(manager.localControlForHandle(handle))
+
+	result := make(chan error, 1)
+	go func() {
+		result <- manager.ValidateRunOwnership(context.Background(), handle)
+	}()
+	receiveTestResult(t, "atomic ownership validation", backend.validated)
+	time.Sleep(leaseTTL + 20*time.Millisecond)
+	close(backend.release)
+	if err := receiveTestResult(t, "delayed ownership validation", result); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("delayed ownership validation error = %v, want ErrRunOwnershipLost", err)
+	}
+}
+
+func runRuntimeManagerScopesStreamRefCleanupToGeneration(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backend := suite.newBackend(t)
+	var generation atomic.Int64
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-generation-cleanup",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+		RunGenerationGenerator: func() string {
+			return fmt.Sprintf("generation-%d", generation.Add(1))
+		},
+	})
+	const streamID = "stream-generation-cleanup"
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, streamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start first generation: %v", err)
+	}
+	oldRef, ok, err := backend.LoadStreamRef(context.Background(), streamID)
+	if err != nil || !ok {
+		t.Fatalf("load first generation ref = ok:%v err:%v", ok, err)
+	}
+	if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, testSessionID, streamID), RunStatusCompleted, ""); err != nil {
+		t.Fatalf("finish first generation: %v", err)
+	}
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, streamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start second generation: %v", err)
+	}
+	newRef, ok, err := backend.LoadStreamRef(context.Background(), streamID)
+	if err != nil || !ok {
+		t.Fatalf("load second generation ref = ok:%v err:%v", ok, err)
+	}
+	if oldRef.Generation == newRef.Generation {
+		t.Fatalf("run generation was reused: %q", oldRef.Generation)
+	}
+	deleted, err := backend.DeleteStreamRef(context.Background(), oldRef)
+	if err != nil {
+		t.Fatalf("delete stale generation ref: %v", err)
+	}
+	if deleted {
+		t.Fatal("stale generation cleanup deleted the current stream reference")
+	}
+	currentRef, ok, err := backend.LoadStreamRef(context.Background(), streamID)
+	if err != nil || !ok || currentRef != newRef {
+		t.Fatalf("current stream ref after stale cleanup = (%#v, %v, %v), want %#v", currentRef, ok, err, newRef)
+	}
+}
+
+func runRuntimeManagerRejectsDelayedOldGenerationCommand(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backend := suite.newBackend(t)
+	var generation atomic.Int64
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-generation-command",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+		CommandAckTTL: 200 * time.Millisecond,
+		RunGenerationGenerator: func() string {
+			return fmt.Sprintf("generation-%d", generation.Add(1))
+		},
+	})
+	const streamID = "stream-generation-command"
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, streamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start first generation: %v", err)
+	}
+	oldRef, ok, err := backend.LoadStreamRef(context.Background(), streamID)
+	if err != nil || !ok {
+		t.Fatalf("load first generation ref = ok:%v err:%v", ok, err)
+	}
+	if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, testSessionID, streamID), RunStatusCompleted, ""); err != nil {
+		t.Fatalf("finish first generation: %v", err)
+	}
+	newAbort := make(chan struct{}, 1)
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, streamID, newAbort, func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start second generation: %v", err)
+	}
+	now, err := backend.Now(context.Background())
+	if err != nil {
+		t.Fatalf("load backend time: %v", err)
+	}
+	if err := backend.PublishCommand(context.Background(), oldRef.OwnerID, Command{
+		Type:       CommandAbort,
+		BotID:      oldRef.BotID,
+		SessionID:  oldRef.SessionID,
+		StreamID:   oldRef.StreamID,
+		Generation: oldRef.Generation,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("publish delayed old-generation command: %v", err)
+	}
+	select {
+	case <-newAbort:
+		t.Fatal("old-generation command aborted the current run")
+	case <-time.After(250 * time.Millisecond):
+	}
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("load current generation snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Generation == oldRef.Generation || snapshot.CurrentRunView.Status != RunStatusRunning {
+		t.Fatalf("current run after delayed command = %#v", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerRejectsExpiredLeaseRevivalContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	const leaseTTL = 100 * time.Millisecond
+	backend := suite.newBackend(t)
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-expired-revival",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+		CommandAckTTL: 30 * time.Millisecond,
+	})
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, "stream-expired-revival", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	ctrl := manager.localControl("stream-expired-revival")
+	if ctrl == nil {
+		t.Fatal("local run control is missing")
+	}
+	manager.stopLeaseRenewal(ctrl)
+
+	initial, ok, err := backend.Load(context.Background(), Key{BotID: testBotID, SessionID: testSessionID})
+	if err != nil || !ok || initial.CurrentRunView == nil {
+		t.Fatalf("load initial lease: snapshot=%#v err=%v", initial, err)
+	}
+	deadline := *initial.CurrentRunView.OwnerLeaseExpiresAt
+	for {
+		now, nowErr := backend.Now(context.Background())
+		if nowErr != nil {
+			t.Fatalf("load backend time: %v", nowErr)
+		}
+		if !now.Before(deadline.Add(10 * time.Millisecond)) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if err := backend.RenewLease(
+		context.Background(),
+		Key{BotID: testBotID, SessionID: testSessionID},
+		"stream-expired-revival",
+		"owner-expired-revival",
+		initial.CurrentRunView.Generation,
+		deadline.Add(-time.Millisecond),
+		deadline.Add(leaseTTL),
+	); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("renew expired lease error = %v, want ErrRunOwnershipLost", err)
+	}
+	if _, ok, err := backend.LoadStreamRef(context.Background(), "stream-expired-revival"); err != nil || ok {
+		t.Fatalf("expired stream ref = ok:%v err:%v, want absent", ok, err)
+	}
+	if err := manager.ValidateRunOwnership(context.Background(), RunHandle{BotID: testBotID, SessionID: testSessionID, StreamID: "stream-expired-revival", Generation: initial.CurrentRunView.Generation}); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("validate expired ownership error = %v, want ErrRunOwnershipLost", err)
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot expired run: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusLost {
+		t.Fatalf("expired current run = %#v, want lost", snapshot.CurrentRunView)
+	}
 }
 
 func runRuntimeManagerKeepsQueuedSteerPastAckTimeoutContract(t *testing.T, suite runtimeBackendContractSuite) {
@@ -450,6 +1810,213 @@ func runRuntimeManagerKeepsQueuedSteerPastAckTimeoutContract(t *testing.T, suite
 	})
 }
 
+func runRuntimeManagerCancelsExecutionAfterOwnershipLossContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backend := suite.newBackend(t)
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "owner-before-takeover",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 90 * time.Millisecond,
+		CommandAckTTL: 30 * time.Millisecond,
+	})
+	abortCh := make(chan struct{}, 1)
+	canceled := make(chan struct{}, 1)
+	injectCh := make(chan conversation.InjectMessage, 1)
+	authorityCtx, revokeAuthority := context.WithCancelCause(context.Background())
+	handle, err := manager.StartRunWithAdmissionBuilderAndOwnershipHandle(context.Background(), testBotID, testSessionID, testStreamID, func(context.Context, RunHandle) (RunAdmissionView, error) {
+		return RunAdmissionView{}, nil
+	}, revokeAuthority, abortCh, func() {
+		select {
+		case canceled <- struct{}{}:
+		default:
+		}
+	}, injectCh)
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if _, changed, err := backend.Update(context.Background(), Key{BotID: testBotID, SessionID: testSessionID}, func(snapshot Snapshot, ok bool) (Snapshot, bool, error) {
+		if !ok || snapshot.CurrentRunView == nil {
+			return snapshot, false, errors.New("active run is missing")
+		}
+		snapshot.CurrentRunView.OwnerID = "owner-after-takeover"
+		return snapshot, true, nil
+	}); err != nil || !changed {
+		t.Fatalf("replace runtime owner = changed:%v err:%v", changed, err)
+	}
+
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("ownership loss did not cancel local execution")
+	}
+	select {
+	case <-abortCh:
+	case <-time.After(time.Second):
+		t.Fatal("ownership loss did not signal the agent abort channel")
+	}
+	if err := manager.ValidateRunOwnership(context.Background(), handle); !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("ownership validation error = %v, want ErrRunOwnershipLost", err)
+	}
+	select {
+	case <-authorityCtx.Done():
+		if !errors.Is(context.Cause(authorityCtx), ErrRunOwnershipLost) {
+			t.Fatalf("hook authority cause = %v, want ErrRunOwnershipLost", context.Cause(authorityCtx))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ownership loss did not revoke terminal hook authority")
+	}
+	waitInjectChannelClosed(t, injectCh)
+}
+
+func runRuntimeManagerKeepsHookAuthorityForUserAbort(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-user-abort-authority")
+	remote := testRuntimeManager(t, backends[1], "remote-user-abort-authority")
+	authorityCtx, revokeAuthority := context.WithCancelCause(context.Background())
+	if err := owner.StartRunWithAdmissionBuilderAndOwnership(context.Background(), testBotID, testSessionID, testStreamID, func(context.Context) (RunAdmissionView, error) {
+		return RunAdmissionView{}, nil
+	}, revokeAuthority, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	if ok, err := remote.Abort(context.Background(), testBotID, testSessionID, testStreamID); err != nil || !ok {
+		t.Fatalf("remote abort = ok:%v err:%v", ok, err)
+	}
+	select {
+	case <-authorityCtx.Done():
+		t.Fatalf("user abort revoked terminal hook authority: %v", context.Cause(authorityCtx))
+	default:
+	}
+	if err := owner.FinishRun(context.Background(), requireRunHandle(t, owner, testBotID, testSessionID, testStreamID), RunStatusAborted, ""); err != nil {
+		t.Fatalf("finish aborted run: %v", err)
+	}
+	select {
+	case <-authorityCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("finished run did not release terminal hook authority")
+	}
+}
+
+func runRuntimeManagerAbortsBlockedAdmissionContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-admitting-abort")
+	remote := testRuntimeManager(t, backends[1], "remote-admitting-abort")
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	defer streamCancel()
+	builderStarted := make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- owner.StartRunWithOperationBuilder(
+			streamCtx,
+			testBotID,
+			testSessionID,
+			"stream-admitting-abort",
+			func(ctx context.Context) (*RunOperationView, error) {
+				close(builderStarted)
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+			make(chan struct{}, 1),
+			streamCancel,
+			make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	select {
+	case <-builderStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("operation builder did not start")
+	}
+
+	aborted, err := remote.Abort(context.Background(), testBotID, testSessionID, "stream-admitting-abort")
+	if err != nil || !aborted {
+		t.Fatalf("remote abort during admission = ok:%v err:%v", aborted, err)
+	}
+	if err := <-startDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("admitting start error = %v, want context canceled", err)
+	}
+	snapshot, err := remote.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot after admission abort: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusAborted {
+		t.Fatalf("admission abort snapshot = %#v", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerRetriesTerminalUpdateBeforeDroppingOwnerRoute(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	backend := &toggledUpdateFailureBackend{DistributedBackend: suite.newBackend(t)}
+	manager := testRuntimeManager(t, backend, "owner-finish-retry")
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, "stream-finish-retry", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	backend.failing.Store(true)
+	if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, testSessionID, "stream-finish-retry"), RunStatusErrored, "stream failed"); err == nil {
+		t.Fatal("terminal update unexpectedly succeeded")
+	}
+	if manager.localControl("stream-finish-retry") == nil {
+		t.Fatal("terminal update failure dropped local owner control")
+	}
+	if _, ok, err := manager.StreamRef(context.Background(), "stream-finish-retry"); err != nil || !ok {
+		t.Fatalf("terminal update failure stream ref = ok:%v err:%v", ok, err)
+	}
+
+	backend.failing.Store(false)
+	snapshot := waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+		return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Status == RunStatusErrored
+	})
+	if snapshot.CurrentRunView.Error != "stream failed" {
+		t.Fatalf("terminal retry error = %q", snapshot.CurrentRunView.Error)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, ok, err := manager.StreamRef(context.Background(), "stream-finish-retry")
+		if err == nil && !ok && manager.localControl("stream-finish-retry") == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("terminal retry did not clean owner route")
+}
+
+func runRuntimeManagerDoesNotBuildRejectedOperationContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-admitted")
+	contender := testRuntimeManager(t, backends[1], "owner-rejected")
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, "stream-admitted", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start admitted run: %v", err)
+	}
+
+	var built atomic.Bool
+	err := contender.StartRunWithOperationBuilder(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-rejected",
+		func(context.Context) (*RunOperationView, error) {
+			built.Store(true)
+			return &RunOperationView{Kind: RunOperationRetry, ReplaceFromMessageID: "assistant-old"}, nil
+		},
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err == nil {
+		t.Fatal("competing run admission succeeded")
+	}
+	if built.Load() {
+		t.Fatal("operation builder ran before cross-server admission")
+	}
+}
+
 func TestRuntimeManagerPublishesAdmittingCheckpoint(t *testing.T) {
 	backend := NewMemoryBackend()
 	manager := testRuntimeManager(t, backend, "owner-admitting")
@@ -490,7 +2057,7 @@ func TestRuntimeManagerPublishesAdmittingCheckpoint(t *testing.T) {
 	event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
 		return event.Delta != nil && event.Delta.CurrentRunView != nil && event.Delta.CurrentRunView.Status == RunStatusAdmitting
 	})
-	if event.Snapshot != nil || event.Seq != snapshot.Seq {
+	if event.Snapshot != nil || event.Seq != snapshot.Seq || event.Delta.CurrentRunView.Generation == "" {
 		t.Fatalf("admitting checkpoint = %#v", event)
 	}
 
@@ -559,7 +2126,7 @@ func runRuntimeManagerRejectsQueuedSteerOnFinishContract(t *testing.T, suite run
 		return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Steer != nil &&
 			snapshot.CurrentRunView.Steer.ID == steer.ID && snapshot.CurrentRunView.Steer.Status == SteerStatusQueued
 	})
-	if err := manager.FinishRun(context.Background(), testBotID, testSessionID, testStreamID, RunStatusCompleted, ""); err != nil {
+	if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, testSessionID, testStreamID), RunStatusCompleted, ""); err != nil {
 		t.Fatalf("finish run: %v", err)
 	}
 	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
@@ -608,10 +2175,11 @@ func runRuntimeManagerRejectsQueuedSteerOnAgentTerminalContract(t *testing.T, su
 			}
 			defer sub.Close()
 			injectCh := make(chan conversation.InjectMessage, 1)
-			if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+			handle, err := manager.StartRunHandle(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh)
+			if err != nil {
 				t.Fatalf("start run: %v", err)
 			}
-			steer, err := manager.Steer(context.Background(), testBotID, testSessionID, testStreamID, "adjust before agent "+tc.name)
+			steer, err := manager.SteerRun(context.Background(), handle, "adjust before agent "+tc.name)
 			if err != nil {
 				t.Fatalf("steer: %v", err)
 			}
@@ -624,7 +2192,7 @@ func runRuntimeManagerRejectsQueuedSteerOnAgentTerminalContract(t *testing.T, su
 				return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Steer != nil &&
 					snapshot.CurrentRunView.Steer.ID == steer.ID && snapshot.CurrentRunView.Steer.Status == SteerStatusQueued
 			})
-			if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, tc.event); err != nil {
+			if _, err := manager.HandleAgentEvent(context.Background(), handle, tc.event); err != nil {
 				t.Fatalf("handle agent %s: %v", tc.name, err)
 			}
 
@@ -785,7 +2353,7 @@ func runRuntimeManagerSnapshotsRichActiveRunContract(t *testing.T, suite runtime
 		t.Fatalf("start run: %v", err)
 	}
 	for _, event := range richRuntimeAgentScript() {
-		if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, event); err != nil {
+		if _, err := manager.HandleAgentEvent(context.Background(), requireRunHandle(t, manager, testBotID, testSessionID, testStreamID), event); err != nil {
 			t.Fatalf("handle event %s: %v", event.Type, err)
 		}
 	}
@@ -796,6 +2364,9 @@ func runRuntimeManagerSnapshotsRichActiveRunContract(t *testing.T, suite runtime
 	}
 	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != testStreamID || snapshot.CurrentRunView.Status != RunStatusRunning {
 		t.Fatalf("current run = %#v", snapshot.CurrentRunView)
+	}
+	if snapshot.Epoch == "" || snapshot.CurrentRunView.Generation == "" {
+		t.Fatalf("runtime identity is incomplete: epoch=%q generation=%q", snapshot.Epoch, snapshot.CurrentRunView.Generation)
 	}
 	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageReasoning, "", "I need to inspect the workspace.")
 	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageText, "", "I will check the current state.")
@@ -811,7 +2382,7 @@ func runRuntimeManagerSnapshotsRichActiveRunContract(t *testing.T, suite runtime
 	for !sawDelta {
 		select {
 		case event := <-sub.C:
-			sawDelta = event.Type == EventRuntimeDelta && event.Seq == snapshot.Seq && event.Delta != nil && event.Snapshot == nil
+			sawDelta = event.Type == EventRuntimeDelta && event.Epoch == snapshot.Epoch && event.Seq == snapshot.Seq && event.Delta != nil && event.Snapshot == nil
 		case <-deadline:
 			t.Fatal("timed out waiting for runtime delta")
 		}
@@ -835,7 +2406,7 @@ func TestRuntimeManagerPublishesBoundedTextAppendPayloads(t *testing.T) {
 	chunk := strings.Repeat("x", 1024)
 	var lastWireSize int
 	for i := 0; i < 32; i++ {
-		if _, err := manager.HandleAgentEvent(context.Background(), testBotID, "session-bounded-delta", "stream-bounded-delta", agentpkg.StreamEvent{
+		if _, err := manager.HandleAgentEvent(context.Background(), requireRunHandle(t, manager, testBotID, "session-bounded-delta", "stream-bounded-delta"), agentpkg.StreamEvent{
 			Type:  agentpkg.EventTextDelta,
 			Delta: chunk,
 		}); err != nil {
@@ -880,7 +2451,7 @@ func TestRuntimeManagerRehydratesSnapshotWhenSequenceEpochResets(t *testing.T) {
 	key := Key{BotID: testBotID, SessionID: "session-sequence-reset"}
 	firstUpdatedAt := time.Now().UTC()
 	if _, _, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
-		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Seq: 100, Queue: []QueuedRunView{}, UpdatedAt: firstUpdatedAt}, true, nil
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Epoch: "epoch-1", Seq: 100, Queue: []QueuedRunView{}, UpdatedAt: firstUpdatedAt}, true, nil
 	}); err != nil {
 		t.Fatalf("seed first epoch: %v", err)
 	}
@@ -895,7 +2466,7 @@ func TestRuntimeManagerRehydratesSnapshotWhenSequenceEpochResets(t *testing.T) {
 
 	secondUpdatedAt := firstUpdatedAt.Add(time.Second)
 	if _, _, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
-		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Seq: 2, Queue: []QueuedRunView{}, UpdatedAt: secondUpdatedAt}, true, nil
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Epoch: "epoch-2", Seq: 2, Queue: []QueuedRunView{}, UpdatedAt: secondUpdatedAt}, true, nil
 	}); err != nil {
 		t.Fatalf("seed second epoch: %v", err)
 	}
@@ -903,6 +2474,7 @@ func TestRuntimeManagerRehydratesSnapshotWhenSequenceEpochResets(t *testing.T) {
 		Type:      EventRuntimeDelta,
 		BotID:     key.BotID,
 		SessionID: key.SessionID,
+		Epoch:     "epoch-2",
 		Seq:       2,
 		UpdatedAt: &secondUpdatedAt,
 		Delta:     &RuntimeDelta{},
@@ -912,8 +2484,695 @@ func TestRuntimeManagerRehydratesSnapshotWhenSequenceEpochResets(t *testing.T) {
 	event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
 		return event.Type == EventRuntimeSnapshot && event.Seq == 2
 	})
-	if event.Snapshot == nil || event.Delta != nil || event.Snapshot.Seq != 2 {
+	if event.Epoch != "epoch-2" || event.Snapshot == nil || event.Delta != nil || event.Snapshot.Epoch != "epoch-2" || event.Snapshot.Seq != 2 {
 		t.Fatalf("sequence reset event = %#v", event)
+	}
+}
+
+func TestRuntimeManagerDropsEpochlessEventsAfterEpochIsEstablished(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := testRuntimeManager(t, backend, "observer-missing-epoch")
+	key := Key{BotID: testBotID, SessionID: "session-missing-epoch"}
+	now := time.Now().UTC()
+	if _, _, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Epoch: "epoch-1", Seq: 1, Queue: []QueuedRunView{}, UpdatedAt: now}, true, nil
+	}); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+	sub, err := manager.Subscribe(context.Background(), key.BotID, key.SessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	_ = waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Type == EventRuntimeSnapshot && event.Epoch == "epoch-1"
+	})
+	if err := backend.Publish(context.Background(), Event{
+		Type: EventRuntimeDelta, BotID: key.BotID, SessionID: key.SessionID, Seq: 2, Delta: &RuntimeDelta{},
+	}); err != nil {
+		t.Fatalf("publish epochless event: %v", err)
+	}
+	event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Type == EventRuntimeDropped && event.Message == "runtime event is missing epoch"
+	})
+	if event.Epoch != "epoch-1" || event.Seq != 1 {
+		t.Fatalf("dropped event cursor = epoch:%q seq:%d", event.Epoch, event.Seq)
+	}
+}
+
+func runRuntimeManagerRoutesAbortAndSteerAcrossManagersContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-1")
+	remote := testRuntimeManager(t, backends[1], "owner-2")
+	abortCh := make(chan struct{}, 1)
+	injectCh := make(chan conversation.InjectMessage, 1)
+	canceled := make(chan struct{}, 1)
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testStreamID, abortCh, func() { canceled <- struct{}{} }, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if ok, err := remote.Abort(context.Background(), testBotID, testSessionID, testStreamID); err != nil || !ok {
+		if err != nil {
+			t.Fatalf("remote abort: %v", err)
+		}
+		t.Fatal("remote abort returned false")
+	}
+	select {
+	case <-abortCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for remote abort")
+	}
+	select {
+	case <-canceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cancel")
+	}
+	snapshot := waitRuntimeSnapshot(t, owner, testBotID, testSessionID, func(s Snapshot) bool {
+		return s.CurrentRunView != nil && s.CurrentRunView.Status == RunStatusAborting
+	})
+	if snapshot.CurrentRunView.Error != "" {
+		t.Fatalf("abort error = %q, want empty", snapshot.CurrentRunView.Error)
+	}
+	if err := owner.FinishRun(context.Background(), requireRunHandle(t, owner, testBotID, testSessionID, testStreamID), RunStatusAborted, ""); err != nil {
+		t.Fatalf("finish aborted run: %v", err)
+	}
+	snapshot, err := owner.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot after errored finish: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusAborted {
+		t.Fatalf("abort status changed after errored finish: %#v", snapshot.CurrentRunView)
+	}
+
+	steerInjectCh := make(chan conversation.InjectMessage, 1)
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, "stream-steer", make(chan struct{}, 1), func() {}, steerInjectCh); err != nil {
+		t.Fatalf("start steer run: %v", err)
+	}
+	steer, err := remote.Steer(context.Background(), testBotID, testSessionID, "stream-steer", "adjust course")
+	if err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	if steer.Status != SteerStatusPending {
+		t.Fatalf("initial steer = %#v", steer)
+	}
+	select {
+	case injected := <-steerInjectCh:
+		if injected.Text != "adjust course" {
+			t.Fatalf("injected text = %q", injected.Text)
+		}
+		pending, err := remote.Snapshot(context.Background(), testBotID, testSessionID)
+		if err != nil {
+			t.Fatalf("snapshot pending steer: %v", err)
+		}
+		if pending.CurrentRunView == nil || pending.CurrentRunView.Steer == nil || pending.CurrentRunView.Steer.Status != SteerStatusQueued {
+			t.Fatalf("steer was not acknowledged as queued before agent consumption: %#v", pending.CurrentRunView)
+		}
+		if _, err := remote.Steer(context.Background(), testBotID, testSessionID, "stream-steer", "overlapping adjustment"); err == nil {
+			t.Fatal("concurrent steer should be rejected while the first command is pending")
+		}
+		if injected.Applied == nil {
+			t.Fatal("steer injection is missing its agent-consumption acknowledgement")
+		}
+		injected.Applied()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for steer injection")
+	}
+
+	snapshot = waitRuntimeSnapshot(t, remote, testBotID, testSessionID, func(s Snapshot) bool {
+		return s.CurrentRunView != nil && s.CurrentRunView.Steer != nil && s.CurrentRunView.Steer.Status == SteerStatusApplied
+	})
+	if snapshot.CurrentRunView.Steer.ID == "" {
+		t.Fatalf("steer state = %#v", snapshot.CurrentRunView.Steer)
+	}
+}
+
+func runRuntimeManagerRoutesActiveResponsesAcrossManagersContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "response-owner")
+	remote := testRuntimeManager(t, backends[1], "response-remote")
+	commands := make(chan Command, 2)
+	owner.SetCommandHandler(func(_ context.Context, command Command) error {
+		commands <- command
+		return nil
+	})
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start response run: %v", err)
+	}
+	for _, event := range []agentpkg.StreamEvent{
+		{Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-approval", ApprovalID: "approval-1", Status: "pending"},
+		{Type: agentpkg.EventUserInputRequest, ToolName: "ask_user", ToolCallID: "call-input", UserInputID: "input-1", Status: "pending"},
+	} {
+		if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, testSessionID, testStreamID), event); err != nil {
+			t.Fatalf("record response target: %v", err)
+		}
+	}
+
+	for _, request := range []struct {
+		commandType string
+		targetID    string
+	}{
+		{commandType: CommandToolApprovalResponse, targetID: "approval-1"},
+		{commandType: CommandUserInputResponse, targetID: "input-1"},
+	} {
+		handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, testSessionID, request.commandType, request.targetID, []byte(`{"ok":true}`))
+		if err != nil || !handled {
+			t.Fatalf("dispatch %s = handled:%v err:%v", request.commandType, handled, err)
+		}
+		select {
+		case command := <-commands:
+			if command.Type != request.commandType || command.TargetID != request.targetID || command.StreamID != testStreamID {
+				t.Fatalf("routed command = %#v", command)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %s", request.commandType)
+		}
+	}
+	if handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, testSessionID, CommandToolApprovalResponse, "approval-old", nil); err != nil || handled {
+		t.Fatalf("unrelated target = handled:%v err:%v", handled, err)
+	}
+}
+
+func runRuntimeManagerPreservesRemoteCommandDeadlineError(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "deadline-owner")
+	remote := testRuntimeManager(t, backends[1], "deadline-remote")
+	owner.SetCommandHandler(func(context.Context, Command) error {
+		return context.DeadlineExceeded
+	})
+	if err := owner.StartRun(context.Background(), testBotID, "session-deadline", "stream-deadline", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start deadline run: %v", err)
+	}
+	if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, "session-deadline", "stream-deadline"), agentpkg.StreamEvent{
+		Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-deadline",
+		ApprovalID: "approval-deadline", Status: "pending",
+	}); err != nil {
+		t.Fatalf("record deadline approval: %v", err)
+	}
+
+	handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, "session-deadline", CommandToolApprovalResponse, "approval-deadline", []byte(`{"action":"approve"}`))
+	if !handled || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("remote deadline result = handled:%v err:%v, want context.DeadlineExceeded", handled, err)
+	}
+}
+
+func runRuntimeManagerPreservesOwnershipDeadlineError(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	ownerBackend := &toggledNowFailureBackend{DistributedBackend: backends[0]}
+	owner := testRuntimeManager(t, ownerBackend, "ownership-deadline-owner")
+	remote := testRuntimeManager(t, backends[1], "ownership-deadline-remote")
+	var handlerCalls atomic.Int64
+	owner.SetCommandHandler(func(context.Context, Command) error {
+		handlerCalls.Add(1)
+		return nil
+	})
+	if err := owner.StartRun(context.Background(), testBotID, "session-ownership-deadline", "stream-ownership-deadline", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start ownership deadline run: %v", err)
+	}
+	if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, "session-ownership-deadline", "stream-ownership-deadline"), agentpkg.StreamEvent{
+		Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-ownership-deadline",
+		ApprovalID: "approval-ownership-deadline", Status: "pending",
+	}); err != nil {
+		t.Fatalf("record ownership deadline approval: %v", err)
+	}
+	ownerBackend.failing.Store(true)
+
+	handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, "session-ownership-deadline", CommandToolApprovalResponse, "approval-ownership-deadline", []byte(`{"action":"approve"}`))
+	if !handled || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ownership deadline result = handled:%v err:%v, want context.DeadlineExceeded", handled, err)
+	}
+	if calls := handlerCalls.Load(); calls != 0 {
+		t.Fatalf("command handler calls = %d, want zero after ownership lookup failure", calls)
+	}
+}
+
+func runRuntimeManagerAcknowledgesAppliedResponseAfterFinish(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "response-applied-owner")
+	remote := testRuntimeManager(t, backends[1], "response-applied-remote")
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start response run: %v", err)
+	}
+	handle := requireRunHandle(t, owner, testBotID, testSessionID, testStreamID)
+	owner.SetCommandHandler(func(ctx context.Context, _ Command) error {
+		return owner.FinishRun(context.WithoutCancel(ctx), handle, RunStatusCompleted, "")
+	})
+	if _, err := owner.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{
+		Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-applied",
+		ApprovalID: "approval-applied", Status: "pending",
+	}); err != nil {
+		t.Fatalf("record approval request: %v", err)
+	}
+
+	handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, testSessionID, CommandToolApprovalResponse, "approval-applied", []byte(`{"action":"approve"}`))
+	if err != nil || !handled {
+		t.Fatalf("applied response = handled:%v err:%v, want acknowledged success", handled, err)
+	}
+	snapshot, err := remote.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusCompleted {
+		t.Fatalf("applied response run = %#v, want completed", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerCommandRoutingOutlivesStartContext(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := NewManager(backends[0], Options{
+		OwnerID: "startup-context-owner", StateTTL: time.Hour,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: time.Second,
+	})
+	startCtx, cancelStart := context.WithCancel(context.Background())
+	if err := owner.Start(startCtx); err != nil {
+		t.Fatalf("start owner manager: %v", err)
+	}
+	cancelStart()
+	t.Cleanup(func() { _ = owner.Close() })
+	remote := testRuntimeManager(t, backends[1], "startup-context-remote")
+	abortCh := make(chan struct{}, 1)
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testStreamID, abortCh, func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run after startup context cancellation: %v", err)
+	}
+
+	if ok, err := remote.Abort(context.Background(), testBotID, testSessionID, testStreamID); err != nil || !ok {
+		t.Fatalf("remote abort after startup context cancellation = ok:%v err:%v", ok, err)
+	}
+	receiveTestResult(t, "abort routed after startup context cancellation", abortCh)
+}
+
+func runRuntimeManagerCancelsActiveResponseOnFinish(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "response-finish-owner")
+	remote := testRuntimeManager(t, backends[1], "response-finish-remote")
+	handlerStarted := make(chan struct{})
+	handlerCanceled := make(chan error, 1)
+	owner.SetCommandHandler(func(ctx context.Context, _ Command) error {
+		close(handlerStarted)
+		<-ctx.Done()
+		handlerCanceled <- ctx.Err()
+		return ctx.Err()
+	})
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start response run: %v", err)
+	}
+	handle := requireRunHandle(t, owner, testBotID, testSessionID, testStreamID)
+	if _, err := owner.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{
+		Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-finish",
+		ApprovalID: "approval-finish", Status: "pending",
+	}); err != nil {
+		t.Fatalf("record approval request: %v", err)
+	}
+
+	type dispatchResult struct {
+		handled bool
+		err     error
+	}
+	dispatchDone := make(chan dispatchResult, 1)
+	go func() {
+		handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, testSessionID, CommandToolApprovalResponse, "approval-finish", []byte(`{"action":"approve"}`))
+		dispatchDone <- dispatchResult{handled: handled, err: err}
+	}()
+	receiveTestResult(t, "active response handler start", handlerStarted)
+	if err := owner.FinishRun(context.Background(), handle, RunStatusCompleted, ""); err != nil {
+		t.Fatalf("finish run with active response: %v", err)
+	}
+	if err := receiveTestResult(t, "active response handler cancellation", handlerCanceled); !errors.Is(err, context.Canceled) {
+		t.Fatalf("handler cancellation error = %v, want context.Canceled", err)
+	}
+	result := receiveTestResult(t, "active response acknowledgement", dispatchDone)
+	if !result.handled || !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("dispatch after finish = handled:%v err:%v, want handler cancellation", result.handled, result.err)
+	}
+}
+
+func runRuntimeManagerExpiresActiveResponseHandlers(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	const commandTTL = 200 * time.Millisecond
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManagerWithOptions(t, backends[0], Options{
+		OwnerID: "response-expiry-owner", StateTTL: time.Hour,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: commandTTL,
+	})
+	remote := testRuntimeManagerWithOptions(t, backends[1], Options{
+		OwnerID: "response-expiry-remote", StateTTL: time.Hour,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: commandTTL,
+	})
+	handlerResults := make(chan error, 2)
+	owner.SetCommandHandler(func(ctx context.Context, _ Command) error {
+		<-ctx.Done()
+		handlerResults <- ctx.Err()
+		return ctx.Err()
+	})
+	if err := owner.StartRun(context.Background(), testBotID, "session-response-expiry", "stream-response-expiry", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start response run: %v", err)
+	}
+	for _, event := range []agentpkg.StreamEvent{
+		{Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-expiry-approval", ApprovalID: "approval-expiry", Status: "pending"},
+		{Type: agentpkg.EventUserInputRequest, ToolName: "ask_user", ToolCallID: "call-expiry-input", UserInputID: "input-expiry", Status: "pending"},
+	} {
+		if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, "session-response-expiry", "stream-response-expiry"), event); err != nil {
+			t.Fatalf("record response target: %v", err)
+		}
+	}
+	for _, request := range []struct {
+		commandType string
+		targetID    string
+	}{
+		{commandType: CommandToolApprovalResponse, targetID: "approval-expiry"},
+		{commandType: CommandUserInputResponse, targetID: "input-expiry"},
+	} {
+		handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, "session-response-expiry", request.commandType, request.targetID, []byte(`{"ok":true}`))
+		if !handled || err == nil {
+			t.Fatalf("expiring %s dispatch = handled:%v err:%v, want deadline error", request.commandType, handled, err)
+		}
+		if handlerErr := receiveTestResult(t, "active response handler expiry", handlerResults); !errors.Is(handlerErr, context.DeadlineExceeded) {
+			t.Fatalf("handler expiry error = %v, want context deadline exceeded", handlerErr)
+		}
+	}
+}
+
+func runRuntimeManagerCancelsActiveResponseOnClose(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	manager := NewManager(suite.newBackend(t), Options{
+		OwnerID: "response-close-owner", StateTTL: time.Hour,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: time.Second,
+	})
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
+	handlerStarted := make(chan struct{})
+	handlerCanceled := make(chan error, 1)
+	manager.SetCommandHandler(func(ctx context.Context, _ Command) error {
+		close(handlerStarted)
+		<-ctx.Done()
+		handlerCanceled <- ctx.Err()
+		return ctx.Err()
+	})
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := manager.StartRun(context.Background(), testBotID, "session-response-close", "stream-response-close", make(chan struct{}, 1), func() {}, injectCh); err != nil {
+		t.Fatalf("start response run: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), requireRunHandle(t, manager, testBotID, "session-response-close", "stream-response-close"), agentpkg.StreamEvent{
+		Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-close",
+		ApprovalID: "approval-close", Status: "pending",
+	}); err != nil {
+		t.Fatalf("record approval request: %v", err)
+	}
+
+	type dispatchResult struct {
+		handled bool
+		err     error
+	}
+	dispatchDone := make(chan dispatchResult, 1)
+	go func() {
+		handled, err := manager.DispatchActiveCommand(context.Background(), testBotID, "session-response-close", CommandToolApprovalResponse, "approval-close", []byte(`{"action":"approve"}`))
+		dispatchDone <- dispatchResult{handled: handled, err: err}
+	}()
+	receiveTestResult(t, "active response handler start", handlerStarted)
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	if err := receiveTestResult(t, "active response handler cancellation", handlerCanceled); !errors.Is(err, context.Canceled) {
+		t.Fatalf("handler cancellation error = %v, want context.Canceled", err)
+	}
+	result := receiveTestResult(t, "active response after close", dispatchDone)
+	if !result.handled || !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("dispatch after close = handled:%v err:%v, want handler cancellation", result.handled, result.err)
+	}
+	waitInjectChannelClosed(t, injectCh)
+}
+
+func runRuntimeManagerAbortCommandDoesNotRepublishStaleSelfReference(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	backend := &countCommandPublishBackend{DistributedBackend: suite.newBackend(t)}
+	manager := testRuntimeManager(t, backend, "stale-self-owner")
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start stale self run: %v", err)
+	}
+	ctrl := manager.localControl(testStreamID)
+	manager.removeLocalControl(testStreamID, ctrl)
+	createdAt := time.Now().UTC()
+	manager.applyCommand(context.Background(), Command{
+		Type:      CommandAbort,
+		BotID:     testBotID,
+		SessionID: testSessionID,
+		StreamID:  testStreamID,
+		CreatedAt: createdAt,
+		ExpiresAt: createdAt.Add(time.Second),
+	})
+	if got := backend.publishes.Load(); got != 0 {
+		t.Fatalf("stale self abort republished %d command(s)", got)
+	}
+}
+
+func runRuntimeManagerMarksExpiredOwnerLeaseLostContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backend := suite.newBackend(t)
+	manager := testRuntimeManager(t, backend, "owner-1")
+	expired := time.Now().Add(-time.Minute).UTC()
+	seed := Snapshot{
+		BotID:     testBotID,
+		SessionID: testSessionID,
+		Seq:       3,
+		Queue:     []QueuedRunView{},
+		CurrentRunView: &CurrentRunView{
+			StreamID:            testStreamID,
+			Status:              RunStatusRunning,
+			OwnerID:             "dead-owner",
+			OwnerLeaseExpiresAt: &expired,
+			StartedAt:           expired,
+			UpdatedAt:           expired,
+		},
+	}
+	if _, _, err := backend.Update(context.Background(), Key{BotID: testBotID, SessionID: testSessionID}, func(Snapshot, bool) (Snapshot, bool, error) {
+		return seed, true, nil
+	}); err != nil {
+		t.Fatalf("save expired snapshot: %v", err)
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusLost {
+		t.Fatalf("current run = %#v, want lost", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerFencesStaleOwnerEventsContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	oldOwner := testRuntimeManagerWithOptions(t, backends[0], Options{
+		OwnerID:       "owner-stale",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 60 * time.Millisecond,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	newOwner := testRuntimeManagerWithOptions(t, backends[1], Options{
+		OwnerID:       "owner-current",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 60 * time.Millisecond,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	if err := oldOwner.StartRun(context.Background(), testBotID, testSessionID, "stream-stale", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start stale owner run: %v", err)
+	}
+	staleControl := oldOwner.localControl("stream-stale")
+	oldOwner.stopLeaseRenewal(staleControl)
+	time.Sleep(80 * time.Millisecond)
+
+	lost, err := newOwner.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("mark old owner lost: %v", err)
+	}
+	if lost.CurrentRunView == nil || lost.CurrentRunView.Status != RunStatusLost {
+		t.Fatalf("expired run = %#v, want lost", lost.CurrentRunView)
+	}
+	if err := newOwner.StartRun(context.Background(), testBotID, testSessionID, "stream-current", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start replacement run: %v", err)
+	}
+
+	messages, err := oldOwner.HandleAgentEvent(context.Background(), requireRunHandle(t, oldOwner, testBotID, testSessionID, "stream-stale"), agentpkg.StreamEvent{
+		Type:  agentpkg.EventTextDelta,
+		Delta: "late stale output",
+	})
+	if !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("handle stale event error = %v, want ErrRunOwnershipLost", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("stale event produced UI messages: %#v", messages)
+	}
+	snapshot, err := newOwner.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot replacement run: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != "stream-current" || snapshot.CurrentRunView.OwnerID != "owner-current" {
+		t.Fatalf("stale owner replaced current run: %#v", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerRenewsIdleOwnerLeaseContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManagerWithOptions(t, backends[0], Options{
+		OwnerID:       "owner-lease",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 200 * time.Millisecond,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	remote := testRuntimeManagerWithOptions(t, backends[1], Options{
+		OwnerID:       "remote-lease",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 200 * time.Millisecond,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	first, err := remote.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("initial snapshot: %v", err)
+	}
+	if first.CurrentRunView == nil {
+		t.Fatal("initial current run missing")
+	}
+	firstLease := *first.CurrentRunView.OwnerLeaseExpiresAt
+
+	time.Sleep(3 * 200 * time.Millisecond)
+	snapshot, err := remote.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot after idle lease renewal: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusRunning {
+		t.Fatalf("idle current run = %#v, want running", snapshot.CurrentRunView)
+	}
+	if snapshot.CurrentRunView.OwnerLeaseExpiresAt == nil || !snapshot.CurrentRunView.OwnerLeaseExpiresAt.After(firstLease) {
+		t.Fatalf("owner lease was not renewed: first=%s current=%s", firstLease, snapshot.CurrentRunView.OwnerLeaseExpiresAt)
+	}
+
+	owner.forgetLocalControl(context.Background(), testStreamID)
+	time.Sleep(2 * 200 * time.Millisecond)
+	snapshot, err = remote.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot after owner stop: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusLost {
+		t.Fatalf("stopped owner current run = %#v, want lost", snapshot.CurrentRunView)
+	}
+	if _, ok, err := remote.StreamRef(context.Background(), testStreamID); err != nil || ok {
+		if err != nil {
+			t.Fatalf("stream ref after lost: %v", err)
+		}
+		t.Fatal("stream ref should be removed after owner lease is lost")
+	}
+}
+
+func runRuntimeManagerNotifiesLeaseLostContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+	const leaseTTL = 500 * time.Millisecond
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManagerWithOptions(t, backends[0], Options{
+		OwnerID:       "owner-notify-lost",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	observer := testRuntimeManagerWithOptions(t, backends[1], Options{
+		OwnerID:       "observer-notify-lost",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: leaseTTL,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	sub, err := observer.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe observer: %v", err)
+	}
+	defer sub.Close()
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	owner.stopLeaseRenewal(owner.localControl(testStreamID))
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case event := <-sub.C:
+			if event.Snapshot != nil && event.Snapshot.CurrentRunView != nil && event.Snapshot.CurrentRunView.Status == RunStatusLost {
+				return
+			}
+		case <-deadline:
+			t.Fatal("attached subscriber did not receive owner lease loss")
+		}
+	}
+}
+
+func runRuntimeManagerReconcilesMissedPublishContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backend := suite.newBackend(t)
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "observer-missed-publish",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 150 * time.Millisecond,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	now := time.Now().UTC()
+	seed := Snapshot{
+		BotID:     testBotID,
+		SessionID: testSessionID,
+		Seq:       7,
+		Queue:     []QueuedRunView{},
+		UpdatedAt: now,
+		CurrentRunView: &CurrentRunView{
+			StreamID:  "stream-missed-publish",
+			Status:    RunStatusCompleted,
+			OwnerID:   "owner-missed-publish",
+			StartedAt: now,
+			UpdatedAt: now,
+			Messages:  []conversation.UIMessage{},
+		},
+	}
+	if _, _, err := backend.Update(context.Background(), Key{BotID: testBotID, SessionID: testSessionID}, func(Snapshot, bool) (Snapshot, bool, error) {
+		return seed, true, nil
+	}); err != nil {
+		t.Fatalf("commit snapshot without publish: %v", err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case event := <-sub.C:
+			if event.Type == EventRuntimeSnapshot && event.Snapshot != nil && event.Snapshot.Seq == seed.Seq {
+				return
+			}
+		case <-deadline:
+			t.Fatal("subscription did not reconcile committed snapshot after missed publish")
+		}
 	}
 }
 
@@ -955,6 +3214,223 @@ func runRuntimeManagerSignalsSubscriberOverflowContract(t *testing.T, suite runt
 	}
 }
 
+func runRuntimeManagerDroppedCommandAckContract(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManagerWithOptions(t, backends[0], Options{
+		OwnerID:       "owner-command",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	remote := testRuntimeManagerWithOptions(t, dropCommandBackend{DistributedBackend: backends[1]}, Options{
+		OwnerID:       "remote-command",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+		CommandAckTTL: 50 * time.Millisecond,
+	})
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if ok, err := remote.Abort(context.Background(), testBotID, testSessionID, testStreamID); err == nil || ok {
+		t.Fatalf("dropped abort = ok:%v err:%v, want acknowledgement error", ok, err)
+	}
+	snapshot, err := remote.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot after dropped abort: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusRunning {
+		t.Fatalf("dropped abort status = %#v, want still running", snapshot.CurrentRunView)
+	}
+
+	steer, err := remote.Steer(context.Background(), testBotID, testSessionID, testStreamID, "adjust course")
+	if err != nil {
+		t.Fatalf("dropped steer initial publish: %v", err)
+	}
+	if steer.Status != SteerStatusPending {
+		t.Fatalf("initial dropped steer = %#v", steer)
+	}
+	snapshot = waitRuntimeSnapshot(t, remote, testBotID, testSessionID, func(s Snapshot) bool {
+		return s.CurrentRunView != nil &&
+			s.CurrentRunView.Steer != nil &&
+			s.CurrentRunView.Steer.ID == steer.ID &&
+			s.CurrentRunView.Steer.Status == SteerStatusRejected
+	})
+	if snapshot.CurrentRunView.Steer.Error != "runtime steer command was not acknowledged" {
+		t.Fatalf("dropped steer state = %#v", snapshot.CurrentRunView.Steer)
+	}
+
+	owner.applyCommand(context.Background(), Command{
+		Type:      CommandSteer,
+		BotID:     testBotID,
+		SessionID: testSessionID,
+		StreamID:  testStreamID,
+		SteerID:   steer.ID,
+		Text:      "late adjust course",
+		CreatedAt: time.Now().UTC().Add(-time.Second),
+	})
+	select {
+	case injected := <-injectCh:
+		t.Fatalf("late rejected steer was injected: %#v", injected)
+	default:
+	}
+	snapshot, err = remote.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot after late steer command: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.Status != SteerStatusRejected {
+		t.Fatalf("late steer command state = %#v, want rejected", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerReleasesPendingCommandOnClose(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-pending-close")
+	published := make(chan Command, 1)
+	remote := testRuntimeManagerWithOptions(t, dropCommandBackend{DistributedBackend: backends[1], published: published}, Options{
+		OwnerID:       "remote-pending-close",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+		CommandAckTTL: time.Hour,
+	})
+	handle, err := owner.StartRunHandle(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	if _, err := owner.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{
+		Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-pending-close",
+		ApprovalID: "approval-pending-close", Status: "pending",
+	}); err != nil {
+		t.Fatalf("publish approval request: %v", err)
+	}
+
+	dispatchCtx, cancelDispatch := context.WithCancel(context.Background())
+	defer cancelDispatch()
+	type dispatchResult struct {
+		handled bool
+		err     error
+	}
+	dispatchDone := make(chan dispatchResult, 1)
+	go func() {
+		handled, dispatchErr := remote.DispatchActiveCommand(
+			dispatchCtx, testBotID, testSessionID, CommandToolApprovalResponse,
+			"approval-pending-close", json.RawMessage(`{"status":"approved"}`),
+		)
+		dispatchDone <- dispatchResult{handled: handled, err: dispatchErr}
+	}()
+	receiveTestResult(t, "dropped routed command publish", published)
+	if err := remote.Close(); err != nil {
+		t.Fatalf("close remote manager: %v", err)
+	}
+	remote.mu.Lock()
+	pendingCount := len(remote.pendingCommands)
+	remote.mu.Unlock()
+	if pendingCount != 0 {
+		t.Fatalf("pending commands after close = %d, want 0", pendingCount)
+	}
+	result := receiveTestResult(t, "pending routed command close", dispatchDone)
+	if !result.handled || !errors.Is(result.err, ErrManagerClosed) {
+		t.Fatalf("dispatch after close = handled:%v err:%v, want ErrManagerClosed", result.handled, result.err)
+	}
+}
+
+func runRuntimeManagerReleasesOwnedRunOnClose(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManagerWithOptions(t, backends[0], Options{
+		OwnerID: "owner-graceful-release", StateTTL: time.Hour, OwnerLeaseTTL: 30 * time.Second,
+	})
+	remote := testRuntimeManagerWithOptions(t, backends[1], Options{
+		OwnerID: "remote-graceful-release", StateTTL: time.Hour, OwnerLeaseTTL: 30 * time.Second,
+	})
+	if err := owner.StartRun(context.Background(), testBotID, "session-graceful-release", "stream-graceful-release", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start owned run: %v", err)
+	}
+
+	if err := owner.CloseContext(context.Background()); err != nil {
+		t.Fatalf("close owner: %v", err)
+	}
+	snapshot, err := remote.Snapshot(context.Background(), testBotID, "session-graceful-release")
+	if err != nil {
+		t.Fatalf("load released snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusLost || snapshot.CurrentRunView.Error != runtimeOwnerShutdownError || snapshot.CurrentRunView.OwnerLeaseExpiresAt != nil {
+		t.Fatalf("released snapshot = %#v", snapshot.CurrentRunView)
+	}
+	if _, ok, err := backends[1].LoadStreamRef(context.Background(), "stream-graceful-release"); err != nil || ok {
+		t.Fatalf("released stream ref = ok:%v err:%v", ok, err)
+	}
+	if err := remote.StartRun(context.Background(), testBotID, "session-graceful-release", "stream-after-graceful-release", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start replacement run immediately after close: %v", err)
+	}
+}
+
+func runRuntimeManagerDoesNotBlockCommandResultsBehindSlowHandlers(t *testing.T, suite distributedRuntimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	const ackTTL = 750 * time.Millisecond
+	ownerA := testRuntimeManagerWithOptions(t, backends[0], Options{
+		OwnerID: "owner-command-hol-a", StateTTL: time.Hour, OwnerLeaseTTL: 5 * time.Second, CommandAckTTL: ackTTL,
+	})
+	ownerB := testRuntimeManagerWithOptions(t, backends[1], Options{
+		OwnerID: "owner-command-hol-b", StateTTL: time.Hour, OwnerLeaseTTL: 5 * time.Second, CommandAckTTL: 5 * time.Second,
+	})
+
+	blockedHandlerEntered := make(chan struct{})
+	releaseBlockedHandler := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseHandler := func() { releaseOnce.Do(func() { close(releaseBlockedHandler) }) }
+	t.Cleanup(releaseHandler)
+	ownerA.SetCommandHandler(func(ctx context.Context, _ Command) error {
+		close(blockedHandlerEntered)
+		select {
+		case <-releaseBlockedHandler:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+	ownerB.SetCommandHandler(func(context.Context, Command) error { return nil })
+
+	startApprovalRun := func(manager *Manager, sessionID, streamID, approvalID string) {
+		t.Helper()
+		if err := manager.StartRun(context.Background(), testBotID, sessionID, streamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+			t.Fatalf("start %s: %v", streamID, err)
+		}
+		handle := requireRunHandle(t, manager, testBotID, sessionID, streamID)
+		if _, err := manager.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{
+			Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-" + approvalID, ApprovalID: approvalID, Status: "pending",
+		}); err != nil {
+			t.Fatalf("record approval %s: %v", approvalID, err)
+		}
+	}
+	startApprovalRun(ownerA, "session-command-hol-a", "stream-command-hol-a", "approval-command-hol-a")
+	startApprovalRun(ownerB, "session-command-hol-b", "stream-command-hol-b", "approval-command-hol-b")
+
+	blockedDispatchDone := make(chan error, 1)
+	go func() {
+		_, err := ownerB.DispatchActiveCommand(context.Background(), testBotID, "session-command-hol-a", CommandToolApprovalResponse, "approval-command-hol-a", []byte(`{"decision":"approve"}`))
+		blockedDispatchDone <- err
+	}()
+	receiveTestResult(t, "blocked owner command handler", blockedHandlerEntered)
+
+	handled, err := ownerA.DispatchActiveCommand(context.Background(), testBotID, "session-command-hol-b", CommandToolApprovalResponse, "approval-command-hol-b", []byte(`{"decision":"approve"}`))
+	if err != nil || !handled {
+		t.Fatalf("unrelated command behind blocked handler = handled:%v err:%v", handled, err)
+	}
+	releaseHandler()
+	if err := receiveTestResult(t, "blocked command completion", blockedDispatchDone); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("blocked command completion: %v", err)
+	}
+}
+
 func runRuntimeManagerKeepsErroredStreamErroredAfterAbortContract(t *testing.T, suite runtimeBackendContractSuite) {
 	t.Helper()
 
@@ -962,18 +3438,19 @@ func runRuntimeManagerKeepsErroredStreamErroredAfterAbortContract(t *testing.T, 
 	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
 		t.Fatalf("start run: %v", err)
 	}
-	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+	handle := requireRunHandle(t, manager, testBotID, testSessionID, testStreamID)
+	if _, err := manager.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{
 		Type:  agentpkg.EventError,
 		Error: "runtime interrupted",
 	}); err != nil {
 		t.Fatalf("handle error event: %v", err)
 	}
-	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+	if _, err := manager.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{
 		Type: agentpkg.EventAgentAbort,
 	}); err != nil {
 		t.Fatalf("handle abort terminal event: %v", err)
 	}
-	if err := manager.FinishRun(context.Background(), testBotID, testSessionID, testStreamID, "", ""); err != nil {
+	if err := manager.FinishRun(context.Background(), handle, "", ""); err != nil {
 		t.Fatalf("finish errored run: %v", err)
 	}
 
@@ -996,13 +3473,14 @@ func runRuntimeManagerKeepsErroredStreamErroredAfterEndContract(t *testing.T, su
 	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
 		t.Fatalf("start run: %v", err)
 	}
-	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+	handle := requireRunHandle(t, manager, testBotID, testSessionID, testStreamID)
+	if _, err := manager.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{
 		Type:  agentpkg.EventError,
 		Error: "provider failed",
 	}); err != nil {
 		t.Fatalf("handle error event: %v", err)
 	}
-	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+	if _, err := manager.HandleAgentEvent(context.Background(), handle, agentpkg.StreamEvent{
 		Type: agentpkg.EventAgentEnd,
 	}); err != nil {
 		t.Fatalf("handle end terminal event: %v", err)

--- a/internal/sessionruntime/manager_test.go
+++ b/internal/sessionruntime/manager_test.go
@@ -1,0 +1,1108 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+const (
+	testBotID     = "bot-runtime"
+	testSessionID = "session-runtime"
+	testStreamID  = "stream-runtime"
+)
+
+type runtimeBackendContractSuite struct {
+	newBackend        func(t *testing.T) Backend
+	newSharedBackends func(t *testing.T, count int) []Backend
+}
+
+func memoryRuntimeBackendSuite() runtimeBackendContractSuite {
+	return runtimeBackendContractSuite{
+		newBackend: func(t *testing.T) Backend {
+			t.Helper()
+			return NewMemoryBackend()
+		},
+		newSharedBackends: func(t *testing.T, count int) []Backend {
+			t.Helper()
+			backend := NewMemoryBackend()
+			backends := make([]Backend, count)
+			for i := range backends {
+				backends[i] = backend
+			}
+			return backends
+		},
+	}
+}
+
+func testRuntimeManager(t *testing.T, backend Backend, ownerID string) *Manager {
+	t.Helper()
+	manager := NewManager(backend, Options{
+		OwnerID:       ownerID,
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 2 * time.Second,
+	})
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = manager.Close()
+	})
+	return manager
+}
+
+func testRuntimeManagerWithOptions(t *testing.T, backend Backend, opts Options) *Manager {
+	t.Helper()
+	manager := NewManager(backend, opts)
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = manager.Close()
+	})
+	return manager
+}
+
+type gatedCommandSubscribeBackend struct {
+	DistributedBackend
+	entered  chan struct{}
+	release  chan struct{}
+	commands chan Command
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func (b *gatedCommandSubscribeBackend) SubscribeCommands(context.Context, string) (CommandSubscription, error) {
+	close(b.entered)
+	<-b.release
+	return CommandSubscription{C: b.commands, Close: b.closeSubscription}, nil
+}
+
+func (*gatedCommandSubscribeBackend) Close() error {
+	return nil
+}
+
+func (b *gatedCommandSubscribeBackend) closeSubscription() {
+	b.once.Do(func() {
+		close(b.commands)
+		close(b.closed)
+	})
+}
+
+type activationGateBackend struct {
+	Backend
+	calls   atomic.Int64
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *activationGateBackend) Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error) {
+	if b.calls.Add(1) == 2 {
+		b.once.Do(func() { close(b.entered) })
+		select {
+		case <-b.release:
+		case <-ctx.Done():
+			return Snapshot{}, false, ctx.Err()
+		}
+	}
+	return b.Backend.Update(ctx, key, update)
+}
+
+func richRuntimeAgentScript() []agentpkg.StreamEvent {
+	return []agentpkg.StreamEvent{
+		{Type: agentpkg.EventAgentStart},
+		{Type: agentpkg.EventReasoningDelta, Delta: "I need to inspect the workspace."},
+		{Type: agentpkg.EventTextDelta, Delta: "I will check the current state."},
+		{Type: agentpkg.EventToolCallStart, ToolName: "exec", ToolCallID: "call-exec", Input: map[string]any{"command": "pwd"}},
+		{Type: agentpkg.EventToolCallProgress, ToolName: "exec", ToolCallID: "call-exec", Progress: "queued"},
+		{Type: agentpkg.EventToolCallEnd, ToolName: "exec", ToolCallID: "call-exec", Result: map[string]any{"stdout": "/workspace\n"}},
+		{Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-approval", Input: map[string]any{"command": "rm -rf build"}, ApprovalID: "approval-1", ShortID: 7, Status: "pending"},
+		{Type: agentpkg.EventUserInputRequest, ToolName: "ask_user", ToolCallID: "call-ask", Input: map[string]any{"questions": []any{map[string]any{"text": "Continue?", "kind": "single_select"}}}, UserInputID: "input-1", ShortID: 8, Status: "pending", Metadata: map[string]any{"ui_payload": map[string]any{"version": 2, "questions": []any{map[string]any{"id": "q1", "text": "Continue?", "kind": "single_select"}}}}},
+	}
+}
+
+func TestMemoryRuntimeManagerContract(t *testing.T) {
+	t.Parallel()
+	runCommonRuntimeManagerContract(t, memoryRuntimeBackendSuite())
+}
+
+func waitRuntimeEvent(t *testing.T, events <-chan Event, pred func(Event) bool) Event {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				t.Fatal("runtime subscription closed")
+			}
+			if pred(event) {
+				return event
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for runtime event")
+		}
+	}
+}
+
+func receiveTestResult[T any](t *testing.T, label string, ch <-chan T) T {
+	t.Helper()
+	select {
+	case result := <-ch:
+		return result
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+		var zero T
+		return zero
+	}
+}
+
+func TestRuntimeManagerRejectsRunAfterClose(t *testing.T) {
+	manager := NewManager(NewMemoryBackend(), Options{})
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	err := manager.StartRun(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-after-close",
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("start run after close error = %v, want ErrManagerClosed", err)
+	}
+	if ctrl := manager.localControl("stream-after-close"); ctrl != nil {
+		t.Fatalf("closed manager retained run control: %#v", ctrl)
+	}
+}
+
+func TestRuntimeManagerDoesNotActivateAdmissionAfterClose(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := NewManager(backend, Options{})
+	builderStarted := make(chan struct{})
+	releaseBuilder := make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- manager.StartRunWithAdmissionBuilder(
+			context.Background(),
+			testBotID,
+			"session-close-during-admission",
+			"stream-close-during-admission",
+			func(context.Context) (RunAdmissionView, error) {
+				close(builderStarted)
+				<-releaseBuilder
+				return RunAdmissionView{}, nil
+			},
+			make(chan struct{}, 1),
+			func() {},
+			make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	<-builderStarted
+
+	shutdownCtx, cancelShutdown := context.WithCancel(context.Background())
+	cancelShutdown()
+	if err := manager.CloseContext(shutdownCtx); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	close(releaseBuilder)
+	if err := receiveTestResult(t, "closed admission", startDone); !errors.Is(err, ErrManagerClosed) && !errors.Is(err, ErrRunOwnershipLost) {
+		t.Fatalf("closed admission error = %v, want manager closed or ownership lost", err)
+	}
+	snapshot, ok, err := backend.Load(context.Background(), Key{BotID: testBotID, SessionID: "session-close-during-admission"})
+	if err != nil || !ok {
+		t.Fatalf("load closed admission = ok:%v err:%v", ok, err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status == RunStatusRunning {
+		t.Fatalf("closed admission snapshot = %#v, must not activate", snapshot.CurrentRunView)
+	}
+}
+
+func TestRuntimeManagerDoesNotStartCommandLoopAfterClose(t *testing.T) {
+	backend := &gatedCommandSubscribeBackend{
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+		commands: make(chan Command),
+		closed:   make(chan struct{}),
+	}
+	t.Cleanup(backend.closeSubscription)
+	manager := NewManager(backend, Options{OwnerID: "owner-start-close-race"})
+	t.Cleanup(func() { _ = manager.Close() })
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- manager.Start(context.Background())
+	}()
+	<-backend.entered
+	if err := manager.Close(); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	close(backend.release)
+	if err := receiveTestResult(t, "manager start after close", startDone); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("start after close error = %v, want ErrManagerClosed", err)
+	}
+	receiveTestResult(t, "late command subscription close", backend.closed)
+}
+
+func TestRuntimeManagerDoesNotTerminalizeAdmissionRejectedByClose(t *testing.T) {
+	backend := &activationGateBackend{
+		Backend: NewMemoryBackend(),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	manager := NewManager(backend, Options{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- manager.StartRun(
+			context.Background(), testBotID, "session-close-activation", "stream-close-activation",
+			make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	<-backend.entered
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- manager.Close() }()
+	deadline := time.After(time.Second)
+	for !manager.isClosed() {
+		select {
+		case <-deadline:
+			t.Fatal("manager close did not start")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	close(backend.release)
+	if err := receiveTestResult(t, "activation rejected by close", startDone); !errors.Is(err, ErrManagerClosed) {
+		t.Fatalf("start run error = %v, want ErrManagerClosed", err)
+	}
+	if err := receiveTestResult(t, "manager close after activation rejection", closeDone); err != nil {
+		t.Fatalf("close manager: %v", err)
+	}
+	snapshot, ok, err := backend.Load(context.Background(), Key{BotID: testBotID, SessionID: "session-close-activation"})
+	if err != nil || !ok {
+		t.Fatalf("load rejected activation = ok:%v err:%v", ok, err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusAdmitting {
+		t.Fatalf("rejected activation = %#v, want admitting reservation", snapshot.CurrentRunView)
+	}
+}
+
+func TestMemoryBackendExpiresSnapshots(t *testing.T) {
+	backend := NewMemoryBackendWithTTL(30 * time.Millisecond)
+	t.Cleanup(func() { _ = backend.Close() })
+	key := Key{BotID: testBotID, SessionID: "session-memory-ttl"}
+	if _, _, err := backend.Update(context.Background(), key, func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+		snapshot.BotID = key.BotID
+		snapshot.SessionID = key.SessionID
+		snapshot.Seq = 1
+		snapshot.Queue = []QueuedRunView{}
+		return snapshot, true, nil
+	}); err != nil {
+		t.Fatalf("start memory run: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, ok, err := backend.Load(context.Background(), key); err != nil || ok {
+		t.Fatalf("expired snapshot = ok:%v err:%v", ok, err)
+	}
+}
+
+func TestLocalRuntimeDoesNotUseOwnerLeases(t *testing.T) {
+	t.Parallel()
+
+	manager := testRuntimeManagerWithOptions(t, NewMemoryBackendWithTTL(20*time.Millisecond), Options{
+		OwnerID:       "must-not-leak-into-local-state",
+		StateTTL:      20 * time.Millisecond,
+		OwnerLeaseTTL: 20 * time.Millisecond,
+	})
+	if err := manager.StartRun(context.Background(), testBotID, "session-local-no-lease", "stream-local-no-lease", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start local run: %v", err)
+	}
+	ctrl := manager.localControl("stream-local-no-lease")
+	if ctrl == nil {
+		t.Fatal("local run control missing")
+	}
+	if ctrl.leaseStop != nil || ctrl.leaseDone != nil || !ctrl.leaseValidUntil.IsZero() {
+		t.Fatalf("local control unexpectedly has lease state: %#v", ctrl)
+	}
+
+	time.Sleep(3 * 20 * time.Millisecond)
+	if err := manager.ValidateRunOwnership(context.Background(), testBotID, "session-local-no-lease", "stream-local-no-lease"); err != nil {
+		t.Fatalf("local ownership expired after lease TTL: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, "session-local-no-lease", "stream-local-no-lease", agentpkg.StreamEvent{Type: agentpkg.EventTextDelta, Delta: "still running"}); err != nil {
+		t.Fatalf("handle local event after lease TTL: %v", err)
+	}
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, "session-local-no-lease")
+	if err != nil {
+		t.Fatalf("load local snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusRunning {
+		t.Fatalf("local run = %#v, want running", snapshot.CurrentRunView)
+	}
+	if snapshot.CurrentRunView.OwnerID != "" || snapshot.CurrentRunView.OwnerLeaseExpiresAt != nil {
+		t.Fatalf("local run leaked distributed ownership: %#v", snapshot.CurrentRunView)
+	}
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageText, "", "still running")
+}
+
+func runCommonRuntimeManagerContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+	t.Run("snapshots rich active run and publishes deltas", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerSnapshotsRichActiveRunContract(t, suite)
+	})
+	t.Run("shares validated replacement operation snapshots", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerSharesReplacementOperationContract(t, suite)
+	})
+	t.Run("shares canonical request user turn snapshots", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerSharesRequestUserTurnContract(t, suite)
+	})
+	t.Run("keeps queued steer valid past command acknowledgement timeout", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerKeepsQueuedSteerPastAckTimeoutContract(t, suite)
+	})
+	t.Run("rejects queued steer when the run finishes", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRejectsQueuedSteerOnFinishContract(t, suite)
+	})
+	t.Run("rejects queued steer when the agent sends a terminal event", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerRejectsQueuedSteerOnAgentTerminalContract(t, suite)
+	})
+	t.Run("signals subscriber buffer overflow", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerSignalsSubscriberOverflowContract(t, suite)
+	})
+	t.Run("keeps errored streams errored when abort terminal follows", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerKeepsErroredStreamErroredAfterAbortContract(t, suite)
+	})
+	t.Run("keeps errored streams errored when end terminal follows", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeManagerKeepsErroredStreamErroredAfterEndContract(t, suite)
+	})
+	t.Run("serializes concurrent snapshot updates", func(t *testing.T) {
+		t.Parallel()
+		runRuntimeBackendSerializesConcurrentSnapshotUpdatesContract(t, suite)
+	})
+}
+
+func runRuntimeManagerKeepsQueuedSteerPastAckTimeoutContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	const commandAckTTL = 500 * time.Millisecond
+	manager := testRuntimeManagerWithOptions(t, suite.newBackend(t), Options{
+		OwnerID:       "owner-queued-steer",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: time.Second,
+		CommandAckTTL: commandAckTTL,
+	})
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	steer, err := manager.Steer(context.Background(), testBotID, testSessionID, testStreamID, "wait for the next model step")
+	if err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+
+	queued := waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+		return snapshot.CurrentRunView != nil &&
+			snapshot.CurrentRunView.Steer != nil &&
+			snapshot.CurrentRunView.Steer.ID == steer.ID &&
+			snapshot.CurrentRunView.Steer.Status == SteerStatusQueued
+	})
+	if queued.CurrentRunView == nil || queued.CurrentRunView.Steer == nil {
+		t.Fatal("queued steer is missing")
+	}
+	time.Sleep(2 * commandAckTTL)
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot queued steer after acknowledgement timeout: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.ID != steer.ID || snapshot.CurrentRunView.Steer.Status != SteerStatusQueued {
+		t.Fatalf("steer after acknowledgement timeout = %#v, want queued", snapshot.CurrentRunView)
+	}
+
+	select {
+	case injected := <-injectCh:
+		if injected.Applied == nil {
+			t.Fatal("queued steer is missing its applied acknowledgement")
+		}
+		injected.Applied()
+	case <-time.After(time.Second):
+		t.Fatal("queued steer was not delivered to the agent")
+	}
+	waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+		return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Steer != nil && snapshot.CurrentRunView.Steer.Status == SteerStatusApplied
+	})
+}
+
+func TestRuntimeManagerPublishesAdmittingCheckpoint(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := testRuntimeManager(t, backend, "owner-admitting")
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+
+	builderStarted := make(chan struct{})
+	releaseBuilder := make(chan struct{})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- manager.StartRunWithOperationBuilder(
+			context.Background(),
+			testBotID,
+			testSessionID,
+			"stream-admitting",
+			func(context.Context) (*RunOperationView, error) {
+				close(builderStarted)
+				<-releaseBuilder
+				return &RunOperationView{Kind: RunOperationRetry, ReplaceFromMessageID: "assistant-old"}, nil
+			},
+			make(chan struct{}, 1),
+			func() {},
+			make(chan conversation.InjectMessage, 1),
+		)
+	}()
+	<-builderStarted
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot reserved run: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusAdmitting {
+		t.Fatalf("reserved run = %#v, want admitting", snapshot.CurrentRunView)
+	}
+	event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Delta != nil && event.Delta.CurrentRunView != nil && event.Delta.CurrentRunView.Status == RunStatusAdmitting
+	})
+	if event.Snapshot != nil || event.Seq != snapshot.Seq {
+		t.Fatalf("admitting checkpoint = %#v", event)
+	}
+
+	close(releaseBuilder)
+	if err := <-startDone; err != nil {
+		t.Fatalf("activate run: %v", err)
+	}
+	event = waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Delta != nil && event.Delta.CurrentRunView != nil && event.Delta.CurrentRunView.Status == RunStatusRunning
+	})
+	if event.Delta == nil || event.Delta.CurrentRunView == nil || event.Delta.CurrentRunView.Status != RunStatusRunning || event.Snapshot != nil {
+		t.Fatalf("activated event = %#v", event)
+	}
+}
+
+func TestRuntimeManagerBuilderFailureReleasesReservation(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := testRuntimeManager(t, backend, "owner-builder-failure")
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	err = manager.StartRunWithOperationBuilder(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-builder-failure",
+		func(context.Context) (*RunOperationView, error) { return nil, errors.New("prepare operation failed") },
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err == nil || !strings.Contains(err.Error(), "prepare operation failed") {
+		t.Fatalf("builder error = %v", err)
+	}
+	if _, ok, err := manager.StreamRef(context.Background(), "stream-builder-failure"); err != nil || ok {
+		t.Fatalf("reservation stream ref = ok:%v err:%v", ok, err)
+	}
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusErrored {
+		t.Fatalf("failed admission snapshot = %#v", snapshot.CurrentRunView)
+	}
+	event := waitRuntimeEvent(t, sub.C, func(event Event) bool { return event.Seq == snapshot.Seq })
+	if event.Delta == nil || event.Delta.CurrentRunView == nil || event.Delta.CurrentRunView.Status != RunStatusErrored {
+		t.Fatalf("failed admission event = %#v, want self-contained terminal run", event)
+	}
+}
+
+func runRuntimeManagerRejectsQueuedSteerOnFinishContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	manager := testRuntimeManager(t, suite.newBackend(t), "owner-finished-steer")
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	steer, err := manager.Steer(context.Background(), testBotID, testSessionID, testStreamID, "adjust before finish")
+	if err != nil {
+		t.Fatalf("steer: %v", err)
+	}
+	waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+		return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Steer != nil &&
+			snapshot.CurrentRunView.Steer.ID == steer.ID && snapshot.CurrentRunView.Steer.Status == SteerStatusQueued
+	})
+	if err := manager.FinishRun(context.Background(), testBotID, testSessionID, testStreamID, RunStatusCompleted, ""); err != nil {
+		t.Fatalf("finish run: %v", err)
+	}
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.Status != SteerStatusRejected {
+		t.Fatalf("finished steer = %#v, want rejected", snapshot.CurrentRunView)
+	}
+	if snapshot.CurrentRunView.Steer.Error != steerRunFinishedError {
+		t.Fatalf("finished steer error = %q", snapshot.CurrentRunView.Steer.Error)
+	}
+	select {
+	case injected := <-injectCh:
+		if injected.Applied != nil {
+			injected.Applied()
+		}
+	default:
+		t.Fatal("queued steer was not delivered")
+	}
+	snapshot, err = manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot after late apply: %v", err)
+	}
+	if snapshot.CurrentRunView.Steer.Status != SteerStatusRejected {
+		t.Fatalf("late apply changed terminal steer = %#v", snapshot.CurrentRunView.Steer)
+	}
+}
+
+func runRuntimeManagerRejectsQueuedSteerOnAgentTerminalContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	for _, tc := range []struct {
+		name       string
+		event      agentpkg.StreamEvent
+		wantStatus string
+	}{
+		{name: "end", event: agentpkg.StreamEvent{Type: agentpkg.EventAgentEnd}, wantStatus: RunStatusCompleted},
+		{name: "abort", event: agentpkg.StreamEvent{Type: agentpkg.EventAgentAbort}, wantStatus: RunStatusAborted},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := testRuntimeManager(t, suite.newBackend(t), "owner-agent-terminal-steer-"+tc.name)
+			sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+			if err != nil {
+				t.Fatalf("subscribe: %v", err)
+			}
+			defer sub.Close()
+			injectCh := make(chan conversation.InjectMessage, 1)
+			if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+				t.Fatalf("start run: %v", err)
+			}
+			steer, err := manager.Steer(context.Background(), testBotID, testSessionID, testStreamID, "adjust before agent "+tc.name)
+			if err != nil {
+				t.Fatalf("steer: %v", err)
+			}
+			select {
+			case <-injectCh:
+			case <-time.After(time.Second):
+				t.Fatal("queued steer was not delivered")
+			}
+			waitRuntimeSnapshot(t, manager, testBotID, testSessionID, func(snapshot Snapshot) bool {
+				return snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Steer != nil &&
+					snapshot.CurrentRunView.Steer.ID == steer.ID && snapshot.CurrentRunView.Steer.Status == SteerStatusQueued
+			})
+			if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, tc.event); err != nil {
+				t.Fatalf("handle agent %s: %v", tc.name, err)
+			}
+
+			snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+			if err != nil {
+				t.Fatalf("snapshot: %v", err)
+			}
+			if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Steer == nil || snapshot.CurrentRunView.Steer.Status != SteerStatusRejected {
+				t.Fatalf("agent-terminal steer = %#v, want rejected", snapshot.CurrentRunView)
+			}
+			if snapshot.CurrentRunView.Steer.Error != steerRunFinishedError {
+				t.Fatalf("agent-terminal steer error = %q", snapshot.CurrentRunView.Steer.Error)
+			}
+			event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+				return event.Delta != nil && event.Delta.Run != nil && event.Delta.Run.Status != nil && *event.Delta.Run.Status == tc.wantStatus
+			})
+			if event.Delta.Run.Steer == nil || event.Delta.Run.Steer.Status != SteerStatusRejected {
+				t.Fatalf("agent-terminal delta = %#v, want rejected steer", event.Delta)
+			}
+		})
+	}
+}
+
+func runRuntimeManagerSharesReplacementOperationContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-operation")
+	observer := testRuntimeManager(t, backends[1], "observer-operation")
+	replacement := &conversation.UITurn{
+		Role:      "user",
+		Text:      "edited prompt",
+		Timestamp: time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	}
+	operation := &RunOperationView{
+		Kind:                 RunOperationEdit,
+		ReplaceFromMessageID: "user-old",
+		ReplacementUserTurn:  replacement,
+	}
+	if err := owner.StartRunWithOperation(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		testStreamID,
+		operation,
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	); err != nil {
+		t.Fatalf("start replacement run: %v", err)
+	}
+
+	snapshot, err := observer.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("observer snapshot: %v", err)
+	}
+	got := snapshot.CurrentRunView
+	if got == nil || got.Operation == nil {
+		t.Fatalf("current run operation = %#v", got)
+	}
+	if got.Operation.Kind != RunOperationEdit || got.Operation.ReplaceFromMessageID != "user-old" {
+		t.Fatalf("operation = %#v", got.Operation)
+	}
+	if got.Operation.ReplacementUserTurn == nil || got.Operation.ReplacementUserTurn.Text != "edited prompt" {
+		t.Fatalf("replacement user turn = %#v", got.Operation.ReplacementUserTurn)
+	}
+}
+
+func runRuntimeManagerSharesRequestUserTurnContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	backends := suite.newSharedBackends(t, 2)
+	owner := testRuntimeManager(t, backends[0], "owner-request-turn")
+	observer := testRuntimeManager(t, backends[1], "observer-request-turn")
+	requestTurn := &conversation.UITurn{
+		Role:              "user",
+		Text:              "inspect the workspace",
+		Attachments:       []conversation.UIAttachment{{Type: "file", Name: "notes.txt", ContentHash: "sha256:notes"}},
+		Timestamp:         time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+		Platform:          "local",
+		SenderUserID:      "user-request-turn",
+		ExternalMessageID: testStreamID,
+	}
+	if err := owner.StartRunWithAdmission(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		testStreamID,
+		RunAdmissionView{RequestUserTurn: requestTurn},
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	); err != nil {
+		t.Fatalf("start run with request user turn: %v", err)
+	}
+
+	snapshot, err := observer.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("observer snapshot: %v", err)
+	}
+	got := snapshot.CurrentRunView
+	if got == nil || got.RequestUserTurn == nil {
+		t.Fatalf("current run request user turn = %#v", got)
+	}
+	if got.RequestUserTurn.Text != requestTurn.Text || got.RequestUserTurn.ExternalMessageID != testStreamID {
+		t.Fatalf("request user turn = %#v", got.RequestUserTurn)
+	}
+	if len(got.RequestUserTurn.Attachments) != 1 || got.RequestUserTurn.Attachments[0].ContentHash != "sha256:notes" {
+		t.Fatalf("request user turn attachments = %#v", got.RequestUserTurn.Attachments)
+	}
+
+	requestTurn.Text = "mutated by caller"
+	requestTurn.Attachments[0].Name = "mutated.txt"
+	if got.RequestUserTurn.Text != "inspect the workspace" || got.RequestUserTurn.Attachments[0].Name != "notes.txt" {
+		t.Fatalf("runtime request user turn aliases caller state: %#v", got.RequestUserTurn)
+	}
+}
+
+func TestRuntimeManagerRejectsNonUserRequestTurn(t *testing.T) {
+	t.Parallel()
+
+	manager := testRuntimeManager(t, NewMemoryBackend(), "owner-invalid-request-turn")
+	err := manager.StartRunWithAdmission(
+		context.Background(),
+		testBotID,
+		testSessionID,
+		"stream-invalid-request-turn",
+		RunAdmissionView{RequestUserTurn: &conversation.UITurn{Role: "assistant", Text: "invalid"}},
+		make(chan struct{}, 1),
+		func() {},
+		make(chan conversation.InjectMessage, 1),
+	)
+	if err == nil || !strings.Contains(err.Error(), "must have role user") {
+		t.Fatalf("start run error = %v, want invalid request user turn", err)
+	}
+	snapshot, snapshotErr := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if snapshotErr != nil {
+		t.Fatalf("load errored snapshot: %v", snapshotErr)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusErrored {
+		t.Fatalf("invalid admission snapshot = %#v", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeManagerSnapshotsRichActiveRunContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	manager := testRuntimeManager(t, suite.newBackend(t), "owner-1")
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+
+	abortCh := make(chan struct{}, 1)
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, abortCh, func() {}, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	for _, event := range richRuntimeAgentScript() {
+		if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, event); err != nil {
+			t.Fatalf("handle event %s: %v", event.Type, err)
+		}
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.StreamID != testStreamID || snapshot.CurrentRunView.Status != RunStatusRunning {
+		t.Fatalf("current run = %#v", snapshot.CurrentRunView)
+	}
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageReasoning, "", "I need to inspect the workspace.")
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageText, "", "I will check the current state.")
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageTool, "call-exec", "")
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageTool, "call-approval", "")
+	assertRuntimeBlock(t, snapshot.CurrentRunView.Messages, conversation.UIMessageTool, "call-ask", "")
+	if snapshot.Queue == nil {
+		t.Fatal("queue must be an empty array, not nil")
+	}
+
+	var sawDelta bool
+	deadline := time.After(2 * time.Second)
+	for !sawDelta {
+		select {
+		case event := <-sub.C:
+			sawDelta = event.Type == EventRuntimeDelta && event.Seq == snapshot.Seq && event.Delta != nil && event.Snapshot == nil
+		case <-deadline:
+			t.Fatal("timed out waiting for runtime delta")
+		}
+	}
+}
+
+func TestRuntimeManagerPublishesBoundedTextAppendPayloads(t *testing.T) {
+	manager := testRuntimeManager(t, NewMemoryBackend(), "owner-bounded-delta")
+	sub, err := manager.Subscribe(context.Background(), testBotID, "session-bounded-delta")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	if err := manager.StartRun(context.Background(), testBotID, "session-bounded-delta", "stream-bounded-delta", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	_ = waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Type == EventRuntimeDelta && event.Delta != nil && event.Delta.CurrentRunView != nil
+	})
+
+	chunk := strings.Repeat("x", 1024)
+	var lastWireSize int
+	for i := 0; i < 32; i++ {
+		if _, err := manager.HandleAgentEvent(context.Background(), testBotID, "session-bounded-delta", "stream-bounded-delta", agentpkg.StreamEvent{
+			Type:  agentpkg.EventTextDelta,
+			Delta: chunk,
+		}); err != nil {
+			t.Fatalf("handle text delta %d: %v", i, err)
+		}
+		event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+			return event.Type == EventRuntimeDelta && event.Delta != nil && len(event.Delta.MessageAppends) == 1
+		})
+		if event.Snapshot != nil || event.Delta.MessageAppends[0].Content != chunk {
+			t.Fatalf("text delta %d = %#v", i, event)
+		}
+		wire, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal text delta %d: %v", i, err)
+		}
+		lastWireSize = len(wire)
+		if lastWireSize > len(chunk)+512 {
+			t.Fatalf("text delta %d wire size = %d, want bounded near chunk size %d", i, lastWireSize, len(chunk))
+		}
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, "session-bounded-delta")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	snapshotWire, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	if lastWireSize*10 >= len(snapshotWire) {
+		t.Fatalf("last delta size = %d, snapshot size = %d; delta appears to carry accumulated output", lastWireSize, len(snapshotWire))
+	}
+}
+
+func TestRuntimeManagerRehydratesSnapshotWhenSequenceEpochResets(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := testRuntimeManagerWithOptions(t, backend, Options{
+		OwnerID:       "observer-sequence-reset",
+		StateTTL:      time.Hour,
+		OwnerLeaseTTL: 100 * time.Millisecond,
+	})
+	key := Key{BotID: testBotID, SessionID: "session-sequence-reset"}
+	firstUpdatedAt := time.Now().UTC()
+	if _, _, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Seq: 100, Queue: []QueuedRunView{}, UpdatedAt: firstUpdatedAt}, true, nil
+	}); err != nil {
+		t.Fatalf("seed first epoch: %v", err)
+	}
+	sub, err := manager.Subscribe(context.Background(), key.BotID, key.SessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	_ = waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Type == EventRuntimeSnapshot && event.Seq == 100
+	})
+
+	secondUpdatedAt := firstUpdatedAt.Add(time.Second)
+	if _, _, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Seq: 2, Queue: []QueuedRunView{}, UpdatedAt: secondUpdatedAt}, true, nil
+	}); err != nil {
+		t.Fatalf("seed second epoch: %v", err)
+	}
+	if err := backend.Publish(context.Background(), Event{
+		Type:      EventRuntimeDelta,
+		BotID:     key.BotID,
+		SessionID: key.SessionID,
+		Seq:       2,
+		UpdatedAt: &secondUpdatedAt,
+		Delta:     &RuntimeDelta{},
+	}); err != nil {
+		t.Fatalf("publish second epoch delta: %v", err)
+	}
+	event := waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Type == EventRuntimeSnapshot && event.Seq == 2
+	})
+	if event.Snapshot == nil || event.Delta != nil || event.Snapshot.Seq != 2 {
+		t.Fatalf("sequence reset event = %#v", event)
+	}
+}
+
+func runRuntimeManagerSignalsSubscriberOverflowContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	backend := suite.newBackend(t)
+	manager := testRuntimeManager(t, backend, "observer-overflow")
+	sub, err := manager.Subscribe(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Close()
+	for seq := int64(1); seq <= 256; seq++ {
+		updatedAt := time.Now().UTC()
+		if err := backend.Publish(context.Background(), Event{
+			Type:      EventRuntimeDelta,
+			BotID:     testBotID,
+			SessionID: testSessionID,
+			Seq:       seq,
+			UpdatedAt: &updatedAt,
+			Delta:     &RuntimeDelta{},
+		}); err != nil {
+			t.Fatalf("publish event %d: %v", seq, err)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case event := <-sub.C:
+			if event.Type == EventRuntimeDropped {
+				return
+			}
+		case <-deadline:
+			t.Fatal("subscriber overflow did not produce runtime_dropped")
+		}
+	}
+}
+
+func runRuntimeManagerKeepsErroredStreamErroredAfterAbortContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	manager := testRuntimeManager(t, suite.newBackend(t), "owner-error")
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+		Type:  agentpkg.EventError,
+		Error: "runtime interrupted",
+	}); err != nil {
+		t.Fatalf("handle error event: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+		Type: agentpkg.EventAgentAbort,
+	}); err != nil {
+		t.Fatalf("handle abort terminal event: %v", err)
+	}
+	if err := manager.FinishRun(context.Background(), testBotID, testSessionID, testStreamID, "", ""); err != nil {
+		t.Fatalf("finish errored run: %v", err)
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusErrored {
+		t.Fatalf("current run = %#v, want errored", snapshot.CurrentRunView)
+	}
+	if snapshot.CurrentRunView.Error != "runtime interrupted" {
+		t.Fatalf("error = %q, want runtime interrupted", snapshot.CurrentRunView.Error)
+	}
+}
+
+func runRuntimeManagerKeepsErroredStreamErroredAfterEndContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	manager := testRuntimeManager(t, suite.newBackend(t), "owner-error-end")
+	if err := manager.StartRun(context.Background(), testBotID, testSessionID, testStreamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+		Type:  agentpkg.EventError,
+		Error: "provider failed",
+	}); err != nil {
+		t.Fatalf("handle error event: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), testBotID, testSessionID, testStreamID, agentpkg.StreamEvent{
+		Type: agentpkg.EventAgentEnd,
+	}); err != nil {
+		t.Fatalf("handle end terminal event: %v", err)
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), testBotID, testSessionID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != RunStatusErrored || snapshot.CurrentRunView.Error != "provider failed" {
+		t.Fatalf("current run = %#v, want errored provider failure", snapshot.CurrentRunView)
+	}
+}
+
+func runRuntimeBackendSerializesConcurrentSnapshotUpdatesContract(t *testing.T, suite runtimeBackendContractSuite) {
+	t.Helper()
+
+	key := Key{BotID: testBotID, SessionID: "session-concurrent"}
+	backends := suite.newSharedBackends(t, 4)
+	for _, backend := range backends {
+		backend := backend
+		t.Cleanup(func() { _ = backend.Close() })
+	}
+	const updates = 40
+	var wg sync.WaitGroup
+	errCh := make(chan error, updates)
+	for i := 0; i < updates; i++ {
+		i := i
+		backend := backends[i%len(backends)]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, err := backend.Update(context.Background(), key, func(snapshot Snapshot, ok bool) (Snapshot, bool, error) {
+				if !ok {
+					snapshot = Snapshot{BotID: key.BotID, SessionID: key.SessionID, Queue: []QueuedRunView{}}
+				}
+				snapshot.Seq++
+				snapshot.UpdatedAt = time.Now().UTC()
+				snapshot.Queue = append(nonNilQueue(snapshot.Queue), QueuedRunView{StreamID: fmt.Sprintf("queued-%02d", i)})
+				return snapshot, true, nil
+			})
+			if err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("update: %v", err)
+		}
+	}
+	snapshot, ok, err := backends[0].Load(context.Background(), key)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !ok {
+		t.Fatal("snapshot missing after concurrent updates")
+	}
+	if snapshot.Seq != updates {
+		t.Fatalf("seq = %d, want %d", snapshot.Seq, updates)
+	}
+	if len(snapshot.Queue) != updates {
+		t.Fatalf("queue len = %d, want %d", len(snapshot.Queue), updates)
+	}
+}
+
+func assertRuntimeBlock(t *testing.T, messages []conversation.UIMessage, kind conversation.UIMessageType, toolCallID, content string) {
+	t.Helper()
+	for _, message := range messages {
+		if message.Type != kind {
+			continue
+		}
+		if toolCallID != "" && message.ToolCallID != toolCallID {
+			continue
+		}
+		if content != "" && message.Content != content {
+			continue
+		}
+		return
+	}
+	data, _ := json.Marshal(messages)
+	t.Fatalf("missing runtime block kind=%s tool=%q content=%q in %s", kind, toolCallID, content, data)
+}
+
+func waitRuntimeSnapshot(t *testing.T, manager *Manager, botID, sessionID string, pred func(Snapshot) bool) Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot, err := manager.Snapshot(context.Background(), botID, sessionID)
+		if err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+		if pred(snapshot) {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	snapshot, _ := manager.Snapshot(context.Background(), botID, sessionID)
+	t.Fatalf("timed out waiting for snapshot, last=%#v", snapshot)
+	return Snapshot{}
+}

--- a/internal/sessionruntime/memory.go
+++ b/internal/sessionruntime/memory.go
@@ -1,0 +1,355 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+// subscriberSet tracks per-key subscriber channels. All methods must be called
+// with the owning backend's mutex held.
+type subscriberSet[T any] struct {
+	nextID int
+	subs   map[string]map[int]chan T
+}
+
+func newSubscriberSet[T any]() *subscriberSet[T] {
+	return &subscriberSet[T]{subs: make(map[string]map[int]chan T)}
+}
+
+func (s *subscriberSet[T]) register(key string) (int, chan T) {
+	s.nextID++
+	id := s.nextID
+	ch := make(chan T, 64)
+	if s.subs[key] == nil {
+		s.subs[key] = make(map[int]chan T)
+	}
+	s.subs[key][id] = ch
+	return id, ch
+}
+
+func (s *subscriberSet[T]) unregister(key string, id int) {
+	subs := s.subs[key]
+	if subs == nil {
+		return
+	}
+	if target := subs[id]; target != nil {
+		delete(subs, id)
+		close(target)
+	}
+	if len(subs) == 0 {
+		delete(s.subs, key)
+	}
+}
+
+func (s *subscriberSet[T]) closeAll() {
+	for key, subs := range s.subs {
+		for id, ch := range subs {
+			delete(subs, id)
+			close(ch)
+		}
+		delete(s.subs, key)
+	}
+}
+
+type MemoryBackend struct {
+	mu                sync.Mutex
+	stateTTL          time.Duration
+	nextCleanup       time.Time
+	snapshots         map[string]Snapshot
+	snapshotExpiresAt map[string]time.Time
+	subscribers       *subscriberSet[Event]
+	closed            bool
+}
+
+func NewMemoryBackend() *MemoryBackend {
+	return NewMemoryBackendWithTTL(24 * time.Hour)
+}
+
+func NewMemoryBackendWithTTL(stateTTL time.Duration) *MemoryBackend {
+	if stateTTL <= 0 {
+		stateTTL = 24 * time.Hour
+	}
+	return &MemoryBackend{
+		stateTTL:          stateTTL,
+		snapshots:         make(map[string]Snapshot),
+		snapshotExpiresAt: make(map[string]time.Time),
+		subscribers:       newSubscriberSet[Event](),
+	}
+}
+
+func (*MemoryBackend) Now(ctx context.Context) (time.Time, error) {
+	if err := contextError(ctx); err != nil {
+		return time.Time{}, err
+	}
+	return time.Now().UTC(), nil
+}
+
+func (b *MemoryBackend) Load(ctx context.Context, key Key) (Snapshot, bool, error) {
+	if err := contextError(ctx); err != nil {
+		return Snapshot{}, false, err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := contextError(ctx); err != nil {
+		return Snapshot{}, false, err
+	}
+	now := time.Now()
+	b.purgeExpiredLocked(now)
+	k := key.String()
+	snapshot, ok := b.snapshots[k]
+	if !ok {
+		return Snapshot{}, false, nil
+	}
+	cloned, err := cloneSnapshot(snapshot)
+	return cloned, true, err
+}
+
+func (b *MemoryBackend) Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error) {
+	if update == nil {
+		return Snapshot{}, false, errors.New("snapshot update is required")
+	}
+	if err := contextError(ctx); err != nil {
+		return Snapshot{}, false, err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := contextError(ctx); err != nil {
+		return Snapshot{}, false, err
+	}
+	now := time.Now()
+	b.purgeExpiredLocked(now)
+	k := key.String()
+	snapshot, ok := b.snapshots[k]
+	// The callback receives a private clone and owns whatever it returns, so
+	// only the stored copy needs re-isolation before handing `next` back.
+	current, err := cloneSnapshot(snapshot)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	next, changed, err := update(current, ok)
+	if err != nil || !changed {
+		return next, changed, err
+	}
+	next.Queue = nonNilQueue(next.Queue)
+	stored, err := cloneSnapshot(next)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	b.snapshots[k] = stored
+	b.snapshotExpiresAt[k] = now.Add(b.stateTTL)
+	b.scheduleCleanupLocked(b.snapshotExpiresAt[k])
+	return next, true, nil
+}
+
+func (b *MemoryBackend) Publish(ctx context.Context, event Event) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	shared, err := cloneEvent(event)
+	if err != nil {
+		return err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	subs := b.subscribers.subs[Key{BotID: event.BotID, SessionID: event.SessionID}.String()]
+	if len(subs) == 0 {
+		return nil
+	}
+	// Consumers treat events as read-only, so one isolation clone shared by
+	// every subscriber decouples them all from the publisher's copy.
+	for _, ch := range subs {
+		enqueueRuntimeEvent(ch, shared)
+	}
+	return nil
+}
+
+func (b *MemoryBackend) Subscribe(ctx context.Context, key Key) (Subscription, error) {
+	if err := contextError(ctx); err != nil {
+		return Subscription{}, err
+	}
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		ch := make(chan Event)
+		close(ch)
+		return Subscription{C: ch, Close: func() {}}, nil
+	}
+	k := key.String()
+	id, ch := b.subscribers.register(k)
+	b.mu.Unlock()
+	var once sync.Once
+	closeSub := func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			b.subscribers.unregister(k, id)
+		})
+	}
+	if done := ctx.Done(); done != nil {
+		go func() {
+			<-done
+			closeSub()
+		}()
+	}
+	return Subscription{
+		C:     ch,
+		Close: closeSub,
+	}, nil
+}
+
+func (b *MemoryBackend) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	b.subscribers.closeAll()
+	return nil
+}
+
+func cloneSnapshot(snapshot Snapshot) (Snapshot, error) {
+	var messages []conversation.UIMessage
+	if snapshot.CurrentRunView != nil {
+		messages = snapshot.CurrentRunView.Messages
+		currentRun := *snapshot.CurrentRunView
+		currentRun.Messages = nil
+		snapshot.CurrentRunView = &currentRun
+	}
+	var out Snapshot
+	if err := cloneJSON(snapshot, &out); err != nil {
+		return Snapshot{}, err
+	}
+	if out.CurrentRunView != nil {
+		clonedMessages, err := cloneUIMessages(messages)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		out.CurrentRunView.Messages = clonedMessages
+	}
+	out.Queue = nonNilQueue(out.Queue)
+	return out, nil
+}
+
+func cloneUIMessages(messages []conversation.UIMessage) ([]conversation.UIMessage, error) {
+	if messages == nil {
+		return nil, nil
+	}
+	out := make([]conversation.UIMessage, len(messages))
+	for i := range messages {
+		message := messages[i]
+		if message.Running != nil {
+			running := *message.Running
+			message.Running = &running
+		}
+		var err error
+		if message.Input, err = cloneJSONValue(message.Input); err != nil {
+			return nil, err
+		}
+		if message.Output, err = cloneJSONValue(message.Output); err != nil {
+			return nil, err
+		}
+		if len(message.Progress) > 0 {
+			message.Progress = make([]any, len(messages[i].Progress))
+			for j := range messages[i].Progress {
+				message.Progress[j], err = cloneJSONValue(messages[i].Progress[j])
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		if err := cloneJSON(messages[i].Attachments, &message.Attachments); err != nil {
+			return nil, err
+		}
+		if messages[i].Approval != nil {
+			approval := *messages[i].Approval
+			message.Approval = &approval
+		}
+		if messages[i].UserInput != nil {
+			var userInput conversation.UIUserInput
+			if err := cloneJSON(messages[i].UserInput, &userInput); err != nil {
+				return nil, err
+			}
+			message.UserInput = &userInput
+		}
+		if messages[i].Background != nil {
+			background := *messages[i].Background
+			message.Background = &background
+		}
+		out[i] = message
+	}
+	return out, nil
+}
+
+func cloneJSONValue(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	var out any
+	if err := cloneJSON(value, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (b *MemoryBackend) purgeExpiredLocked(now time.Time) {
+	if !b.nextCleanup.IsZero() && now.Before(b.nextCleanup) {
+		return
+	}
+	nextCleanup := time.Time{}
+	for key, expiresAt := range b.snapshotExpiresAt {
+		if !now.Before(expiresAt) {
+			if snapshot, ok := b.snapshots[key]; ok && snapshot.CurrentRunView != nil && isActiveRunStatus(snapshot.CurrentRunView.Status) {
+				// Active local runs are owned by their in-process runControl and
+				// live until they terminalize or the process exits.
+				delete(b.snapshotExpiresAt, key)
+				continue
+			}
+			delete(b.snapshots, key)
+			delete(b.snapshotExpiresAt, key)
+		} else if nextCleanup.IsZero() || expiresAt.Before(nextCleanup) {
+			nextCleanup = expiresAt
+		}
+	}
+	b.nextCleanup = nextCleanup
+}
+
+func (b *MemoryBackend) scheduleCleanupLocked(expiresAt time.Time) {
+	if expiresAt.IsZero() {
+		return
+	}
+	if b.nextCleanup.IsZero() || expiresAt.Before(b.nextCleanup) {
+		b.nextCleanup = expiresAt
+	}
+}
+
+func cloneEvent(event Event) (Event, error) {
+	var out Event
+	if err := cloneJSON(event, &out); err != nil {
+		return Event{}, err
+	}
+	return out, nil
+}
+
+func cloneJSON(in, out any) error {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, out)
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}

--- a/internal/sessionruntime/memory_test.go
+++ b/internal/sessionruntime/memory_test.go
@@ -1,0 +1,66 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func TestMemoryBackendRejectsUnserializableSnapshotWithoutCorruptingState(t *testing.T) {
+	backend := NewMemoryBackend()
+	key := Key{BotID: "bot-1", SessionID: "session-1"}
+	if _, changed, err := backend.Update(context.Background(), key, func(Snapshot, bool) (Snapshot, bool, error) {
+		return Snapshot{BotID: key.BotID, SessionID: key.SessionID, Seq: 1, Queue: []QueuedRunView{}}, true, nil
+	}); err != nil || !changed {
+		t.Fatalf("seed snapshot: changed=%v err=%v", changed, err)
+	}
+
+	if _, changed, err := backend.Update(context.Background(), key, func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+		snapshot.Seq = 2
+		snapshot.CurrentRunView = &CurrentRunView{
+			StreamID: "stream-1",
+			Status:   RunStatusRunning,
+			Messages: []conversation.UIMessage{{ID: 1, Type: conversation.UIMessageTool, Input: make(chan struct{})}},
+		}
+		return snapshot, true, nil
+	}); err == nil || changed {
+		t.Fatalf("unserializable update: changed=%v err=%v", changed, err)
+	}
+
+	snapshot, ok, err := backend.Load(context.Background(), key)
+	if err != nil || !ok {
+		t.Fatalf("load preserved snapshot: ok=%v err=%v", ok, err)
+	}
+	if snapshot.Seq != 1 || snapshot.CurrentRunView != nil {
+		t.Fatalf("snapshot corrupted after rejected update: %#v", snapshot)
+	}
+}
+
+func TestMemoryBackendRejectsCanceledOperations(t *testing.T) {
+	backend := NewMemoryBackend()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	key := Key{BotID: "bot-1", SessionID: "session-1"}
+
+	if _, _, err := backend.Load(ctx, key); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Load error = %v, want context.Canceled", err)
+	}
+	if _, _, err := backend.Update(ctx, key, func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+		return snapshot, true, nil
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Update error = %v, want context.Canceled", err)
+	}
+	if _, err := backend.Subscribe(ctx, key); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Subscribe error = %v, want context.Canceled", err)
+	}
+}
+
+func TestMemoryBackendDoesNotImplementDistributedCoordination(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := any(NewMemoryBackend()).(DistributedBackend); ok {
+		t.Fatal("MemoryBackend unexpectedly implements DistributedBackend")
+	}
+}

--- a/internal/sessionruntime/redis.go
+++ b/internal/sessionruntime/redis.go
@@ -1,0 +1,716 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type RedisOptions struct {
+	URL       string
+	KeyPrefix string
+	StateTTL  time.Duration
+}
+
+type RedisBackend struct {
+	client    *redis.Client
+	keyPrefix string
+	stateTTL  time.Duration
+}
+
+var renewRedisLeaseScript = redis.NewScript(`
+local current_state = redis.call('GET', KEYS[1])
+local current_ref = redis.call('GET', KEYS[2])
+if not current_state or not current_ref then
+  return -1
+end
+if current_state ~= ARGV[1] or current_ref ~= ARGV[2] then
+  return 0
+end
+local now = redis.call('TIME')
+local now_ms = tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+local expires_at_ms = tonumber(ARGV[5])
+if not expires_at_ms or expires_at_ms <= now_ms then
+  return -1
+end
+redis.call('SET', KEYS[1], ARGV[3], 'PX', ARGV[6])
+redis.call('SET', KEYS[2], ARGV[4], 'PXAT', ARGV[5])
+return 1
+`)
+
+var deleteRedisStreamRefScript = redis.NewScript(`
+local current_ref = redis.call('GET', KEYS[1])
+if not current_ref or current_ref ~= ARGV[1] then
+  return 0
+end
+redis.call('DEL', KEYS[1])
+return 1
+`)
+
+var validateRedisRunOwnershipScript = redis.NewScript(`
+local current_state = redis.call('GET', KEYS[1])
+local current_ref = redis.call('GET', KEYS[2])
+if not current_state or not current_ref then
+  return 0
+end
+
+local ok_ref, ref = pcall(cjson.decode, current_ref)
+local ok_state, state = pcall(cjson.decode, current_state)
+if not ok_ref or not ok_state or not state.current_run_view then
+  return 0
+end
+
+local run = state.current_run_view
+if ref.bot_id ~= ARGV[1] or ref.session_id ~= ARGV[2] or
+   ref.stream_id ~= ARGV[3] or ref.owner_id ~= ARGV[4] or ref.generation ~= ARGV[5] or
+   state.bot_id ~= ARGV[1] or state.session_id ~= ARGV[2] or
+   run.stream_id ~= ARGV[3] or run.owner_id ~= ARGV[4] or run.generation ~= ARGV[5] then
+  return 0
+end
+
+if run.status ~= 'admitting' and run.status ~= 'running' and run.status ~= 'aborting' then
+  return 0
+end
+
+-- PTTL and TIME are evaluated by Redis in this atomic script, so expiry cannot
+-- pass between separate client reads. TIME is intentionally sampled here to
+-- keep the ownership decision on the Redis server clock.
+local now = redis.call('TIME')
+local ttl = redis.call('PTTL', KEYS[2])
+if not now or ttl <= 0 then
+  return 0
+end
+return 1
+`)
+
+func NewRedisBackend(ctx context.Context, opts RedisOptions) (*RedisBackend, error) {
+	backend, err := newRedisBackend(opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := backend.CheckHealth(ctx); err != nil {
+		_ = backend.Close()
+		return nil, err
+	}
+	return backend, nil
+}
+
+func newRedisBackend(opts RedisOptions) (*RedisBackend, error) {
+	redisOpts, err := redis.ParseURL(strings.TrimSpace(opts.URL))
+	if err != nil {
+		return nil, err
+	}
+	redisOpts.ContextTimeoutEnabled = true
+	client := redis.NewClient(redisOpts)
+	ttl := opts.StateTTL
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+	prefix := strings.TrimSpace(opts.KeyPrefix)
+	if prefix == "" {
+		prefix = "memoh:session_runtime:"
+	}
+	return &RedisBackend{client: client, keyPrefix: prefix, stateTTL: ttl}, nil
+}
+
+func (b *RedisBackend) CheckHealth(ctx context.Context) error {
+	return b.client.Ping(ctx).Err()
+}
+
+func (b *RedisBackend) Now(ctx context.Context) (time.Time, error) {
+	return b.client.Time(ctx).Result()
+}
+
+func (b *RedisBackend) Load(ctx context.Context, key Key) (Snapshot, bool, error) {
+	data, err := b.client.Get(ctx, b.stateKey(key)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return Snapshot{}, false, nil
+	}
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return Snapshot{}, false, err
+	}
+	snapshot.Queue = nonNilQueue(snapshot.Queue)
+	return snapshot, true, nil
+}
+
+func (b *RedisBackend) Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error) {
+	if update == nil {
+		return Snapshot{}, false, errors.New("snapshot update is required")
+	}
+	stateKey := b.stateKey(key)
+	for {
+		var updated Snapshot
+		var changed bool
+		err := b.client.Watch(ctx, func(tx *redis.Tx) error {
+			// current is freshly unmarshaled per attempt and next is
+			// transaction-local, so neither needs a defensive clone.
+			current, ok, err := loadRedisSnapshot(ctx, tx, stateKey)
+			if err != nil {
+				return err
+			}
+			next, apply, err := update(current, ok)
+			if err != nil {
+				return err
+			}
+			if !apply {
+				updated = next
+				changed = false
+				return nil
+			}
+			next.Queue = nonNilQueue(next.Queue)
+			data, err := json.Marshal(next)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, stateKey, data, b.stateTTL)
+				return nil
+			}); err != nil {
+				return err
+			}
+			updated = next
+			changed = true
+			return nil
+		}, stateKey)
+		if errors.Is(err, redis.TxFailedErr) {
+			continue
+		}
+		return updated, changed, err
+	}
+}
+
+func (b *RedisBackend) UpdateActiveRun(ctx context.Context, key Key, streamID, generation string, update ActiveRunUpdate) (Snapshot, bool, error) {
+	if update == nil {
+		return Snapshot{}, false, errors.New("active run update is required")
+	}
+	streamID = strings.TrimSpace(streamID)
+	generation = strings.TrimSpace(generation)
+	if streamID == "" || generation == "" {
+		return Snapshot{}, false, errors.New("stream_id and generation are required")
+	}
+	stateKey := b.stateKey(key)
+	streamKey := b.streamKey(streamID)
+	for {
+		var updated Snapshot
+		var changed bool
+		err := b.client.Watch(ctx, func(tx *redis.Tx) error {
+			now, err := tx.Time(ctx).Result()
+			if err != nil {
+				return err
+			}
+			ref, ok, err := loadRedisStreamRef(ctx, tx, streamKey)
+			if err != nil {
+				return err
+			}
+			current, stateOK, err := loadRedisSnapshot(ctx, tx, stateKey)
+			if err != nil {
+				return err
+			}
+			if !ok || !stateOK || current.CurrentRunView == nil {
+				return ErrRunOwnershipLost
+			}
+			run := current.CurrentRunView
+			if run.StreamID != streamID || run.Generation != generation || ref.StreamID != streamID || ref.Generation != generation || ref.OwnerID != run.OwnerID || ref.BotID != key.BotID || ref.SessionID != key.SessionID || !isActiveRunStatus(run.Status) || run.OwnerLeaseExpiresAt == nil || !now.Before(*run.OwnerLeaseExpiresAt) {
+				return ErrRunOwnershipLost
+			}
+			next, apply, err := update(current, now)
+			if err != nil {
+				return err
+			}
+			if !apply {
+				updated = next
+				changed = false
+				return nil
+			}
+			next.Queue = nonNilQueue(next.Queue)
+			data, err := json.Marshal(next)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, stateKey, data, b.stateTTL)
+				return nil
+			}); err != nil {
+				return err
+			}
+			updated = next
+			changed = true
+			return nil
+		}, stateKey, streamKey)
+		if errors.Is(err, redis.TxFailedErr) {
+			continue
+		}
+		return updated, changed, err
+	}
+}
+
+func (b *RedisBackend) ReleaseRun(ctx context.Context, key Key, ref StreamRef, update ActiveRunUpdate) (Snapshot, bool, error) {
+	if update == nil {
+		return Snapshot{}, false, errors.New("active run update is required")
+	}
+	ref.BotID = strings.TrimSpace(ref.BotID)
+	ref.SessionID = strings.TrimSpace(ref.SessionID)
+	ref.StreamID = strings.TrimSpace(ref.StreamID)
+	ref.OwnerID = strings.TrimSpace(ref.OwnerID)
+	ref.Generation = strings.TrimSpace(ref.Generation)
+	if ref.BotID != strings.TrimSpace(key.BotID) || ref.SessionID != strings.TrimSpace(key.SessionID) || ref.StreamID == "" || ref.OwnerID == "" || ref.Generation == "" {
+		return Snapshot{}, false, ErrRunOwnershipLost
+	}
+	stateKey := b.stateKey(key)
+	streamKey := b.streamKey(ref.StreamID)
+	for {
+		var updated Snapshot
+		var changed bool
+		err := b.client.Watch(ctx, func(tx *redis.Tx) error {
+			now, err := tx.Time(ctx).Result()
+			if err != nil {
+				return err
+			}
+			storedRef, ok, err := loadRedisStreamRef(ctx, tx, streamKey)
+			if err != nil {
+				return err
+			}
+			current, stateOK, err := loadRedisSnapshot(ctx, tx, stateKey)
+			if err != nil {
+				return err
+			}
+			if !ok || !stateOK || current.CurrentRunView == nil {
+				return ErrRunOwnershipLost
+			}
+			run := current.CurrentRunView
+			if storedRef != ref || run.StreamID != ref.StreamID || run.Generation != ref.Generation || run.OwnerID != ref.OwnerID || !isActiveRunStatus(run.Status) || run.OwnerLeaseExpiresAt == nil || !now.Before(*run.OwnerLeaseExpiresAt) {
+				return ErrRunOwnershipLost
+			}
+			next, apply, err := update(current, now)
+			if err != nil {
+				return err
+			}
+			if !apply {
+				updated = next
+				changed = false
+				return nil
+			}
+			next.Queue = nonNilQueue(next.Queue)
+			data, err := json.Marshal(next)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, stateKey, data, b.stateTTL)
+				pipe.Del(ctx, streamKey)
+				return nil
+			}); err != nil {
+				return err
+			}
+			updated = next
+			changed = true
+			return nil
+		}, stateKey, streamKey)
+		if errors.Is(err, redis.TxFailedErr) {
+			continue
+		}
+		return updated, changed, err
+	}
+}
+
+func (b *RedisBackend) StartRun(ctx context.Context, key Key, ref StreamRef, update SnapshotUpdate) (Snapshot, bool, error) {
+	if update == nil {
+		return Snapshot{}, false, errors.New("snapshot update is required")
+	}
+	streamID := strings.TrimSpace(ref.StreamID)
+	ref.Generation = strings.TrimSpace(ref.Generation)
+	if streamID == "" || ref.Generation == "" {
+		return Snapshot{}, false, errors.New("stream_id and generation are required")
+	}
+	ref.StreamID = streamID
+	refData, err := json.Marshal(ref)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	stateKey := b.stateKey(key)
+	streamKey := b.streamKey(streamID)
+	for {
+		var updated Snapshot
+		var changed bool
+		err := b.client.Watch(ctx, func(tx *redis.Tx) error {
+			if existing, ok, err := loadRedisStreamRef(ctx, tx, streamKey); err != nil {
+				return err
+			} else if ok {
+				return fmt.Errorf("stream_id %q is already registered for session %q", streamID, existing.SessionID)
+			}
+			current, ok, err := loadRedisSnapshot(ctx, tx, stateKey)
+			if err != nil {
+				return err
+			}
+			next, apply, err := update(current, ok)
+			if err != nil {
+				return err
+			}
+			if !apply {
+				updated = next
+				changed = false
+				return nil
+			}
+			next.Queue = nonNilQueue(next.Queue)
+			stateData, err := json.Marshal(next)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, stateKey, stateData, b.stateTTL)
+				pipe.Set(ctx, streamKey, refData, 0)
+				pipe.PExpireAt(ctx, streamKey, streamLeaseExpiry(next, streamID, time.Now().Add(b.stateTTL)))
+				return nil
+			}); err != nil {
+				return err
+			}
+			updated = next
+			changed = true
+			return nil
+		}, stateKey, streamKey)
+		if errors.Is(err, redis.TxFailedErr) {
+			continue
+		}
+		return updated, changed, err
+	}
+}
+
+func (b *RedisBackend) RenewLease(ctx context.Context, key Key, streamID, ownerID, generation string, renewedAt, expiresAt time.Time) error {
+	streamID = strings.TrimSpace(streamID)
+	ownerID = strings.TrimSpace(ownerID)
+	generation = strings.TrimSpace(generation)
+	if streamID == "" || ownerID == "" || generation == "" {
+		return nil
+	}
+	if renewedAt.IsZero() || !renewedAt.Before(expiresAt) {
+		return ErrRunOwnershipLost
+	}
+	stateKey := b.stateKey(key)
+	streamKey := b.streamKey(streamID)
+	for {
+		stateData, err := b.client.Get(ctx, stateKey).Bytes()
+		if errors.Is(err, redis.Nil) {
+			return ErrRunOwnershipLost
+		}
+		if err != nil {
+			return err
+		}
+		refData, err := b.client.Get(ctx, streamKey).Bytes()
+		if errors.Is(err, redis.Nil) {
+			return ErrRunOwnershipLost
+		}
+		if err != nil {
+			return err
+		}
+		var ref StreamRef
+		if err := json.Unmarshal(refData, &ref); err != nil {
+			return err
+		}
+		if ref.OwnerID != ownerID || ref.BotID != key.BotID || ref.SessionID != key.SessionID || ref.StreamID != streamID || ref.Generation != generation {
+			return ErrRunOwnershipLost
+		}
+		var snapshot Snapshot
+		if err := json.Unmarshal(stateData, &snapshot); err != nil {
+			return err
+		}
+		if snapshot.CurrentRunView == nil {
+			return ErrRunOwnershipLost
+		}
+		run := snapshot.CurrentRunView
+		if run.StreamID != streamID || run.OwnerID != ownerID || run.Generation != generation || run.OwnerLeaseExpiresAt == nil {
+			return ErrRunOwnershipLost
+		}
+		if !isActiveRunStatus(run.Status) {
+			return nil
+		}
+		run.OwnerLeaseExpiresAt = &expiresAt
+		snapshot.Queue = nonNilQueue(snapshot.Queue)
+		nextStateData, err := json.Marshal(snapshot)
+		if err != nil {
+			return err
+		}
+		result, err := renewRedisLeaseScript.Run(ctx, b.client, []string{stateKey, streamKey},
+			stateData, refData, nextStateData, refData, expiresAt.UnixMilli(), b.stateTTL.Milliseconds(),
+		).Int64()
+		if err != nil {
+			return err
+		}
+		switch result {
+		case 1:
+			return nil
+		case 0:
+			continue
+		default:
+			return ErrRunOwnershipLost
+		}
+	}
+}
+
+func (b *RedisBackend) ValidateRunOwnership(ctx context.Context, key Key, ref StreamRef) error {
+	ref.BotID = strings.TrimSpace(ref.BotID)
+	ref.SessionID = strings.TrimSpace(ref.SessionID)
+	ref.StreamID = strings.TrimSpace(ref.StreamID)
+	ref.OwnerID = strings.TrimSpace(ref.OwnerID)
+	ref.Generation = strings.TrimSpace(ref.Generation)
+	if ref.BotID != strings.TrimSpace(key.BotID) || ref.SessionID != strings.TrimSpace(key.SessionID) || ref.StreamID == "" || ref.OwnerID == "" || ref.Generation == "" {
+		return ErrRunOwnershipLost
+	}
+	valid, err := validateRedisRunOwnershipScript.Run(ctx, b.client, []string{b.stateKey(key), b.streamKey(ref.StreamID)},
+		ref.BotID, ref.SessionID, ref.StreamID, ref.OwnerID, ref.Generation,
+	).Int64()
+	if err != nil {
+		return err
+	}
+	if valid != 1 {
+		return ErrRunOwnershipLost
+	}
+	return nil
+}
+
+func (b *RedisBackend) Publish(ctx context.Context, event Event) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	return b.client.Publish(ctx, b.sessionChannel(Key{BotID: event.BotID, SessionID: event.SessionID}), data).Err()
+}
+
+func (b *RedisBackend) Subscribe(ctx context.Context, key Key) (Subscription, error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	pubsub := b.client.Subscribe(subCtx, b.sessionChannel(key))
+	if _, err := pubsub.Receive(subCtx); err != nil {
+		cancel()
+		_ = pubsub.Close()
+		return Subscription{}, err
+	}
+	ch := make(chan Event, 64)
+	done := make(chan struct{})
+	go func() {
+		defer close(ch)
+		defer close(done)
+		defer cancel()
+		defer func() { _ = pubsub.Close() }()
+		for {
+			msg, err := pubsub.ReceiveMessage(subCtx)
+			if err != nil {
+				if !waitRedisSubscriptionRetry(subCtx) {
+					return
+				}
+				continue
+			}
+			var event Event
+			if err := json.Unmarshal([]byte(msg.Payload), &event); err != nil {
+				continue
+			}
+			enqueueRuntimeEvent(ch, event)
+		}
+	}()
+	return Subscription{
+		C: ch,
+		Close: func() {
+			cancel()
+			_ = pubsub.Close()
+			<-done
+		},
+	}, nil
+}
+
+func (b *RedisBackend) LoadStreamRef(ctx context.Context, streamID string) (StreamRef, bool, error) {
+	data, err := b.client.Get(ctx, b.streamKey(streamID)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return StreamRef{}, false, nil
+	}
+	if err != nil {
+		return StreamRef{}, false, err
+	}
+	var ref StreamRef
+	if err := json.Unmarshal(data, &ref); err != nil {
+		return StreamRef{}, false, err
+	}
+	return ref, true, nil
+}
+
+func (b *RedisBackend) DeleteStreamRef(ctx context.Context, ref StreamRef) (bool, error) {
+	ref.StreamID = strings.TrimSpace(ref.StreamID)
+	ref.Generation = strings.TrimSpace(ref.Generation)
+	if ref.StreamID == "" || ref.Generation == "" {
+		return false, nil
+	}
+	data, err := json.Marshal(ref)
+	if err != nil {
+		return false, err
+	}
+	deleted, err := deleteRedisStreamRefScript.Run(ctx, b.client, []string{b.streamKey(ref.StreamID)}, data).Int64()
+	return deleted == 1, err
+}
+
+func (b *RedisBackend) PublishCommand(ctx context.Context, ownerID string, command Command) error {
+	data, err := json.Marshal(command)
+	if err != nil {
+		return err
+	}
+	count, err := b.client.Publish(ctx, b.commandChannel(ownerID), data).Result()
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return ErrCommandOwnerUnavailable
+	}
+	return nil
+}
+
+func (b *RedisBackend) SubscribeCommands(ctx context.Context, ownerID string) (CommandSubscription, error) {
+	subCtx, cancel := context.WithCancel(ctx)
+	pubsub := b.client.Subscribe(subCtx, b.commandChannel(ownerID))
+	if _, err := pubsub.Receive(subCtx); err != nil {
+		cancel()
+		_ = pubsub.Close()
+		return CommandSubscription{}, err
+	}
+	ch := make(chan Command, 64)
+	done := make(chan struct{})
+	go func() {
+		defer close(ch)
+		defer close(done)
+		defer cancel()
+		defer func() { _ = pubsub.Close() }()
+		for {
+			msg, err := pubsub.ReceiveMessage(subCtx)
+			if err != nil {
+				if !waitRedisSubscriptionRetry(subCtx) {
+					return
+				}
+				continue
+			}
+			var command Command
+			if err := json.Unmarshal([]byte(msg.Payload), &command); err != nil {
+				continue
+			}
+			select {
+			case ch <- command:
+			case <-subCtx.Done():
+				return
+			}
+		}
+	}()
+	return CommandSubscription{
+		C: ch,
+		Close: func() {
+			cancel()
+			_ = pubsub.Close()
+			<-done
+		},
+	}, nil
+}
+
+func (b *RedisBackend) StoreCommandResult(ctx context.Context, result Command, ttl time.Duration) error {
+	commandID := strings.TrimSpace(result.ID)
+	if strings.TrimSpace(result.Type) != CommandResult || commandID == "" {
+		return errors.New("command result type and id are required")
+	}
+	if ttl <= 0 {
+		return errors.New("command result ttl must be positive")
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	return b.client.SetNX(ctx, b.commandResultKey(commandID), data, ttl).Err()
+}
+
+func (b *RedisBackend) LoadCommandResult(ctx context.Context, commandID string) (Command, bool, error) {
+	commandID = strings.TrimSpace(commandID)
+	if commandID == "" {
+		return Command{}, false, nil
+	}
+	data, err := b.client.Get(ctx, b.commandResultKey(commandID)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return Command{}, false, nil
+	}
+	if err != nil {
+		return Command{}, false, err
+	}
+	var result Command
+	if err := json.Unmarshal(data, &result); err != nil {
+		return Command{}, false, err
+	}
+	if strings.TrimSpace(result.Type) != CommandResult || strings.TrimSpace(result.ID) != commandID {
+		return Command{}, false, errors.New("stored runtime command result is invalid")
+	}
+	return result, true, nil
+}
+
+func (b *RedisBackend) Close() error {
+	return b.client.Close()
+}
+
+func loadRedisSnapshot(ctx context.Context, tx *redis.Tx, key string) (Snapshot, bool, error) {
+	data, err := tx.Get(ctx, key).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return Snapshot{}, false, nil
+	}
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return Snapshot{}, false, err
+	}
+	snapshot.Queue = nonNilQueue(snapshot.Queue)
+	return snapshot, true, nil
+}
+
+func waitRedisSubscriptionRetry(ctx context.Context) bool {
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func loadRedisStreamRef(ctx context.Context, tx *redis.Tx, key string) (StreamRef, bool, error) {
+	data, err := tx.Get(ctx, key).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return StreamRef{}, false, nil
+	}
+	if err != nil {
+		return StreamRef{}, false, err
+	}
+	var ref StreamRef
+	if err := json.Unmarshal(data, &ref); err != nil {
+		return StreamRef{}, false, err
+	}
+	return ref, true, nil
+}
+
+func (b *RedisBackend) stateKey(key Key) string {
+	return b.keyPrefix + "state:" + key.String()
+}
+
+func (b *RedisBackend) streamKey(streamID string) string {
+	return b.keyPrefix + "stream:" + strings.TrimSpace(streamID)
+}
+
+func (b *RedisBackend) sessionChannel(key Key) string {
+	return b.keyPrefix + "events:" + key.String()
+}
+
+func (b *RedisBackend) commandChannel(ownerID string) string {
+	return b.keyPrefix + "commands:" + strings.TrimSpace(ownerID)
+}
+
+func (b *RedisBackend) commandResultKey(commandID string) string {
+	return b.keyPrefix + "command_result:" + strings.TrimSpace(commandID)
+}

--- a/internal/sessionruntime/redis_test.go
+++ b/internal/sessionruntime/redis_test.go
@@ -1,0 +1,767 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+var runtimeBackendPrefixSequence atomic.Uint64
+
+type delayedCommandSubscriptionBackend struct {
+	DistributedBackend
+	delay    time.Duration
+	observed chan<- Command
+}
+
+type dropCommandResultSubscriptionBackend struct {
+	DistributedBackend
+	dropped chan<- Command
+}
+
+func (b dropCommandResultSubscriptionBackend) SubscribeCommands(ctx context.Context, ownerID string) (CommandSubscription, error) {
+	sub, err := b.DistributedBackend.SubscribeCommands(ctx, ownerID)
+	if err != nil {
+		return CommandSubscription{}, err
+	}
+	forwardCtx, cancel := context.WithCancel(ctx)
+	commands := make(chan Command, 64)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(commands)
+		for {
+			select {
+			case <-forwardCtx.Done():
+				return
+			case command, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				if command.Type == CommandResult {
+					select {
+					case b.dropped <- command:
+					default:
+					}
+					continue
+				}
+				select {
+				case commands <- command:
+				case <-forwardCtx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return CommandSubscription{
+		C: commands,
+		Close: func() {
+			cancel()
+			sub.Close()
+			<-done
+		},
+	}, nil
+}
+
+func (b delayedCommandSubscriptionBackend) SubscribeCommands(ctx context.Context, ownerID string) (CommandSubscription, error) {
+	sub, err := b.DistributedBackend.SubscribeCommands(ctx, ownerID)
+	if err != nil {
+		return CommandSubscription{}, err
+	}
+	forwardCtx, cancel := context.WithCancel(ctx)
+	commands := make(chan Command, 64)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(commands)
+		for {
+			select {
+			case <-forwardCtx.Done():
+				return
+			case command, ok := <-sub.C:
+				if !ok {
+					return
+				}
+				select {
+				case b.observed <- command:
+				default:
+				}
+				timer := time.NewTimer(b.delay)
+				select {
+				case <-timer.C:
+				case <-forwardCtx.Done():
+					timer.Stop()
+					return
+				}
+				select {
+				case commands <- command:
+				case <-forwardCtx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return CommandSubscription{
+		C: commands,
+		Close: func() {
+			cancel()
+			sub.Close()
+			<-done
+		},
+	}, nil
+}
+
+func uniqueRuntimeBackendPrefix(scope string) string {
+	return fmt.Sprintf("memoh:test:session_runtime:%s:%d:%d:", scope, time.Now().UnixNano(), runtimeBackendPrefixSequence.Add(1))
+}
+
+func redisRuntimeBackendSuite(redisURL string) distributedRuntimeBackendContractSuite {
+	newRedisBackend := func(t *testing.T, prefix string) DistributedBackend {
+		t.Helper()
+		backend, err := NewRedisBackend(context.Background(), RedisOptions{
+			URL:       redisURL,
+			KeyPrefix: prefix,
+			StateTTL:  time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("redis backend: %v", err)
+		}
+		return backend
+	}
+	return distributedRuntimeBackendContractSuite{
+		newBackend: func(t *testing.T) DistributedBackend {
+			t.Helper()
+			return newRedisBackend(t, uniqueRuntimeBackendPrefix("backend"))
+		},
+		newSharedBackends: func(t *testing.T, count int) []DistributedBackend {
+			t.Helper()
+			prefix := uniqueRuntimeBackendPrefix("shared")
+			backends := make([]DistributedBackend, count)
+			for i := range backends {
+				backends[i] = newRedisBackend(t, prefix)
+			}
+			return backends
+		},
+	}
+}
+
+func TestRedisValkeyRuntimeManagerContractOptional(t *testing.T) {
+	targets := []struct {
+		name string
+		url  string
+	}{
+		{name: "redis", url: os.Getenv("MEMOH_TEST_REDIS_URL")},
+		{name: "valkey", url: os.Getenv("MEMOH_TEST_VALKEY_URL")},
+	}
+	var ran bool
+	for _, target := range targets {
+		target := target
+		if target.url == "" {
+			continue
+		}
+		ran = true
+		t.Run(target.name, func(t *testing.T) {
+			suite := redisRuntimeBackendSuite(target.url)
+			runCommonRuntimeManagerContract(t, suite.common())
+			runDistributedRuntimeManagerContract(t, suite)
+			runRedisSubscriptionReconnectContract(t, target.url)
+			runRedisExpiredActiveResponseTransportContract(t, target.url)
+			runRedisDurableCommandResultContract(t, target.url)
+			runRedisBoundedCommandWorkersContract(t, target.url)
+			runRedisDuplicateCommandSaturationContract(t, target.url)
+		})
+	}
+	if !ran {
+		if os.Getenv("MEMOH_TEST_DISTRIBUTED_REQUIRED") == "1" {
+			t.Fatal("distributed session runtime contracts are required, but neither MEMOH_TEST_REDIS_URL nor MEMOH_TEST_VALKEY_URL is set")
+		}
+		t.Skip("set MEMOH_TEST_REDIS_URL and/or MEMOH_TEST_VALKEY_URL to run Redis and/or Valkey session runtime contracts")
+	}
+}
+
+func runRedisDurableCommandResultContract(t *testing.T, redisURL string) {
+	t.Helper()
+
+	prefix := uniqueRuntimeBackendPrefix("durable-command-result")
+	newBackend := func() *RedisBackend {
+		backend, err := NewRedisBackend(context.Background(), RedisOptions{
+			URL: redisURL, KeyPrefix: prefix, StateTTL: time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("redis backend: %v", err)
+		}
+		return backend
+	}
+	owner := testRuntimeManagerWithOptions(t, newBackend(), Options{
+		OwnerID: "durable-result-owner", StateTTL: time.Minute,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: 750 * time.Millisecond,
+	})
+	dropped := make(chan Command, 1)
+	remoteBackend := dropCommandResultSubscriptionBackend{DistributedBackend: newBackend(), dropped: dropped}
+	remote := testRuntimeManagerWithOptions(t, remoteBackend, Options{
+		OwnerID: "durable-result-remote", StateTTL: time.Minute,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: 750 * time.Millisecond,
+	})
+	handled := make(chan Command, 1)
+	owner.SetCommandHandler(func(_ context.Context, command Command) error {
+		handled <- command
+		return nil
+	})
+	const (
+		sessionID  = "session-durable-result"
+		streamID   = "stream-durable-result"
+		approvalID = "approval-durable-result"
+	)
+	if err := owner.StartRun(context.Background(), testBotID, sessionID, streamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, sessionID, streamID), agentpkg.StreamEvent{
+		Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-durable-result", ApprovalID: approvalID, Status: "pending",
+	}); err != nil {
+		t.Fatalf("record approval: %v", err)
+	}
+
+	handledResult, err := remote.DispatchActiveCommand(context.Background(), testBotID, sessionID, CommandToolApprovalResponse, approvalID, []byte(`{"decision":"approve"}`))
+	if err != nil || !handledResult {
+		t.Fatalf("dispatch with dropped pubsub result = handled:%v err:%v", handledResult, err)
+	}
+	receiveTestResult(t, "owner command handler", handled)
+	result := receiveTestResult(t, "dropped pubsub command result", dropped)
+	stored, ok, err := remoteBackend.LoadCommandResult(context.Background(), result.ID)
+	if err != nil || !ok || stored.ID != result.ID || stored.Error != "" {
+		t.Fatalf("durable command result = ok:%v err:%v result:%#v", ok, err, stored)
+	}
+	if stored.PayloadHash != commandPayloadHash([]byte(`{"decision":"approve"}`)) {
+		t.Fatalf("durable command payload hash = %q", stored.PayloadHash)
+	}
+	if err := remote.Close(); err != nil {
+		t.Fatalf("close original requester: %v", err)
+	}
+	restarted := testRuntimeManagerWithOptions(t, newBackend(), Options{
+		OwnerID: "durable-result-restarted", StateTTL: time.Minute,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: 750 * time.Millisecond,
+	})
+	handledResult, err = restarted.DispatchActiveCommand(context.Background(), testBotID, sessionID, CommandToolApprovalResponse, approvalID, []byte(`{"decision":"approve"}`))
+	if err != nil || !handledResult {
+		t.Fatalf("dispatch after requester restart = handled:%v err:%v", handledResult, err)
+	}
+	select {
+	case duplicate := <-handled:
+		t.Fatalf("stable retry executed the owner handler twice: %#v", duplicate)
+	case <-time.After(50 * time.Millisecond):
+	}
+	handledResult, err = restarted.DispatchActiveCommand(context.Background(), testBotID, sessionID, CommandToolApprovalResponse, approvalID, []byte(`{"decision":"reject"}`))
+	if !handledResult || !errors.Is(err, ErrCommandPayloadConflict) {
+		t.Fatalf("conflicting stable retry = handled:%v err:%v, want payload conflict", handledResult, err)
+	}
+
+	const localApprovalID = "approval-durable-result-local-owner"
+	if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, sessionID, streamID), agentpkg.StreamEvent{
+		Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-durable-result-local-owner", ApprovalID: localApprovalID, Status: "pending",
+	}); err != nil {
+		t.Fatalf("record owner-local approval: %v", err)
+	}
+	for attempt := range 2 {
+		handledResult, err = owner.DispatchActiveCommand(context.Background(), testBotID, sessionID, CommandToolApprovalResponse, localApprovalID, []byte(`{"decision":"approve"}`))
+		if err != nil || !handledResult {
+			t.Fatalf("owner-local dispatch %d = handled:%v err:%v", attempt, handledResult, err)
+		}
+		if attempt == 0 {
+			receiveTestResult(t, "owner-local command handler", handled)
+		}
+	}
+	select {
+	case duplicate := <-handled:
+		t.Fatalf("owner-local stable retry executed twice: %#v", duplicate)
+	case <-time.After(50 * time.Millisecond):
+	}
+	handledResult, err = owner.DispatchActiveCommand(context.Background(), testBotID, sessionID, CommandToolApprovalResponse, localApprovalID, []byte(`{"decision":"reject"}`))
+	if !handledResult || !errors.Is(err, ErrCommandPayloadConflict) {
+		t.Fatalf("owner-local conflicting retry = handled:%v err:%v, want payload conflict", handledResult, err)
+	}
+}
+
+func runRedisBoundedCommandWorkersContract(t *testing.T, redisURL string) {
+	t.Helper()
+
+	prefix := uniqueRuntimeBackendPrefix("bounded-command-workers")
+	newBackend := func() *RedisBackend {
+		backend, err := NewRedisBackend(context.Background(), RedisOptions{
+			URL: redisURL, KeyPrefix: prefix, StateTTL: time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("redis backend: %v", err)
+		}
+		return backend
+	}
+	owner := testRuntimeManagerWithOptions(t, newBackend(), Options{
+		OwnerID: "bounded-worker-owner", StateTTL: time.Minute, OwnerLeaseTTL: 5 * time.Second,
+		CommandAckTTL: 2 * time.Second, CommandWorkerLimit: 1,
+	})
+	remote := testRuntimeManagerWithOptions(t, newBackend(), Options{
+		OwnerID: "bounded-worker-remote", StateTTL: time.Minute,
+		OwnerLeaseTTL: 5 * time.Second, CommandAckTTL: 2 * time.Second,
+	})
+
+	const commandCount = 8
+	for i := range commandCount {
+		sessionID := fmt.Sprintf("session-bounded-worker-%d", i)
+		streamID := fmt.Sprintf("stream-bounded-worker-%d", i)
+		approvalID := fmt.Sprintf("approval-bounded-worker-%d", i)
+		if err := owner.StartRun(context.Background(), testBotID, sessionID, streamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+			t.Fatalf("start run %d: %v", i, err)
+		}
+		if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, sessionID, streamID), agentpkg.StreamEvent{
+			Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: fmt.Sprintf("call-bounded-worker-%d", i), ApprovalID: approvalID, Status: "pending",
+		}); err != nil {
+			t.Fatalf("record approval %d: %v", i, err)
+		}
+	}
+
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	var active atomic.Int64
+	var maxActive atomic.Int64
+	owner.SetCommandHandler(func(ctx context.Context, _ Command) error {
+		current := active.Add(1)
+		defer active.Add(-1)
+		for {
+			observed := maxActive.Load()
+			if current <= observed || maxActive.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	type dispatchResult struct {
+		handled bool
+		err     error
+	}
+	results := make(chan dispatchResult, commandCount)
+	for i := range commandCount {
+		i := i
+		go func() {
+			handled, err := remote.DispatchActiveCommand(
+				context.Background(), testBotID, fmt.Sprintf("session-bounded-worker-%d", i),
+				CommandToolApprovalResponse, fmt.Sprintf("approval-bounded-worker-%d", i), []byte(`{"decision":"approve"}`),
+			)
+			results <- dispatchResult{handled: handled, err: err}
+		}()
+	}
+	receiveTestResult(t, "first bounded command handler", entered)
+
+	completed := make([]dispatchResult, 0, commandCount)
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for len(completed) < commandCount {
+		select {
+		case result := <-results:
+			completed = append(completed, result)
+			if errors.Is(result.err, ErrCommandBusy) {
+				releaseOnce.Do(func() { close(release) })
+			}
+		case <-deadline.C:
+			releaseOnce.Do(func() { close(release) })
+			t.Fatalf("timed out waiting for bounded command results; completed=%d", len(completed))
+		}
+	}
+	busy := 0
+	for _, result := range completed {
+		if !result.handled {
+			t.Fatalf("bounded command was not handled: %#v", result)
+		}
+		if errors.Is(result.err, ErrCommandBusy) {
+			busy++
+			continue
+		}
+		if result.err != nil {
+			t.Fatalf("bounded command result: %v", result.err)
+		}
+	}
+	if busy == 0 {
+		t.Fatal("command worker saturation did not return ErrCommandBusy")
+	}
+	if got := maxActive.Load(); got > 1 {
+		t.Fatalf("maximum concurrent command handlers = %d, want <= 1", got)
+	}
+}
+
+func runRedisDuplicateCommandSaturationContract(t *testing.T, redisURL string) {
+	t.Helper()
+
+	prefix := uniqueRuntimeBackendPrefix("duplicate-command-saturation")
+	newBackend := func() *RedisBackend {
+		backend, err := NewRedisBackend(context.Background(), RedisOptions{
+			URL: redisURL, KeyPrefix: prefix, StateTTL: time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("redis backend: %v", err)
+		}
+		return backend
+	}
+	owner := testRuntimeManagerWithOptions(t, newBackend(), Options{
+		OwnerID: "duplicate-saturation-owner", StateTTL: time.Minute,
+		OwnerLeaseTTL: 5 * time.Second, CommandAckTTL: 2 * time.Second, CommandWorkerLimit: 1,
+	})
+	remote := testRuntimeManagerWithOptions(t, newBackend(), Options{
+		OwnerID: "duplicate-saturation-remote", StateTTL: time.Minute,
+		OwnerLeaseTTL: 5 * time.Second, CommandAckTTL: 2 * time.Second,
+	})
+
+	const (
+		sessionA  = "session-duplicate-saturation-a"
+		streamA   = "stream-duplicate-saturation-a"
+		approvalA = "approval-duplicate-saturation-a"
+		sessionB  = "session-duplicate-saturation-b"
+		streamB   = "stream-duplicate-saturation-b"
+		approvalB = "approval-duplicate-saturation-b"
+	)
+	startApproval := func(sessionID, streamID, approvalID string) {
+		t.Helper()
+		if err := owner.StartRun(context.Background(), testBotID, sessionID, streamID, make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+			t.Fatalf("start %s: %v", streamID, err)
+		}
+		if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, sessionID, streamID), agentpkg.StreamEvent{
+			Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-" + approvalID, ApprovalID: approvalID, Status: "pending",
+		}); err != nil {
+			t.Fatalf("record %s: %v", approvalID, err)
+		}
+	}
+	startApproval(sessionA, streamA, approvalA)
+	startApproval(sessionB, streamB, approvalB)
+
+	enteredA := make(chan struct{})
+	releaseA := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseA) }) })
+	var callsA atomic.Int64
+	var callsB atomic.Int64
+	owner.SetCommandHandler(func(ctx context.Context, command Command) error {
+		switch command.TargetID {
+		case approvalA:
+			if callsA.Add(1) == 1 {
+				close(enteredA)
+			}
+			select {
+			case <-releaseA:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		case approvalB:
+			callsB.Add(1)
+		}
+		return nil
+	})
+
+	type dispatchResult struct {
+		name    string
+		handled bool
+		err     error
+	}
+	results := make(chan dispatchResult, 3)
+	dispatch := func(name, sessionID, approvalID string) {
+		go func() {
+			handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, sessionID, CommandToolApprovalResponse, approvalID, []byte(`{"decision":"approve"}`))
+			results <- dispatchResult{name: name, handled: handled, err: err}
+		}()
+	}
+	dispatch("first-a", sessionA, approvalA)
+	receiveTestResult(t, "first duplicate-saturation handler", enteredA)
+
+	snapshotB, err := owner.Snapshot(context.Background(), testBotID, sessionB)
+	if err != nil || snapshotB.CurrentRunView == nil {
+		t.Fatalf("load queued run B: %v %#v", err, snapshotB.CurrentRunView)
+	}
+	commandBID := activeCommandID(testBotID, sessionB, snapshotB.CurrentRunView, CommandToolApprovalResponse, approvalB)
+	dispatch("queued-b", sessionB, approvalB)
+	deadline := time.Now().Add(time.Second)
+	for {
+		owner.mu.Lock()
+		_, admitted := owner.admittedCommands[commandBID]
+		owner.mu.Unlock()
+		if admitted {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("second command was not queued behind the blocked worker")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	dispatch("duplicate-a", sessionA, approvalA)
+	snapshotA, err := owner.Snapshot(context.Background(), testBotID, sessionA)
+	if err != nil || snapshotA.CurrentRunView == nil {
+		t.Fatalf("load active run A: %v %#v", err, snapshotA.CurrentRunView)
+	}
+	commandAID := activeCommandID(testBotID, sessionA, snapshotA.CurrentRunView, CommandToolApprovalResponse, approvalA)
+	deadline = time.Now().Add(time.Second)
+	for {
+		remote.mu.Lock()
+		waiters := len(remote.pendingCommands[commandAID])
+		remote.mu.Unlock()
+		if waiters == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("duplicate requester waiters = %d, want 2", waiters)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	releaseOnce.Do(func() { close(releaseA) })
+	for range 3 {
+		result := receiveTestResult(t, "duplicate-saturation dispatch", results)
+		if !result.handled || result.err != nil {
+			t.Fatalf("%s = handled:%v err:%v", result.name, result.handled, result.err)
+		}
+	}
+	if got := callsA.Load(); got != 1 {
+		t.Fatalf("duplicate A handler calls = %d, want 1", got)
+	}
+	if got := callsB.Load(); got != 1 {
+		t.Fatalf("queued B handler calls = %d, want 1", got)
+	}
+	stored, ok, err := remote.distributed.LoadCommandResult(context.Background(), commandAID)
+	if err != nil || !ok || stored.Error != "" {
+		t.Fatalf("stable command result after saturation = ok:%v err:%v result:%#v", ok, err, stored)
+	}
+}
+
+func runRedisExpiredActiveResponseTransportContract(t *testing.T, redisURL string) {
+	t.Helper()
+
+	const (
+		commandTTL   = 75 * time.Millisecond
+		commandDelay = 125 * time.Millisecond
+	)
+	prefix := uniqueRuntimeBackendPrefix("expired-command-transport")
+	newBackend := func() *RedisBackend {
+		backend, err := NewRedisBackend(context.Background(), RedisOptions{
+			URL: redisURL, KeyPrefix: prefix, StateTTL: time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("redis backend: %v", err)
+		}
+		return backend
+	}
+	observed := make(chan Command, 4)
+	owner := testRuntimeManagerWithOptions(t, delayedCommandSubscriptionBackend{
+		DistributedBackend: newBackend(), delay: commandDelay, observed: observed,
+	}, Options{
+		OwnerID: "expired-command-owner", StateTTL: time.Minute,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: commandTTL,
+	})
+	remote := testRuntimeManagerWithOptions(t, newBackend(), Options{
+		OwnerID: "expired-command-remote", StateTTL: time.Minute,
+		OwnerLeaseTTL: time.Second, CommandAckTTL: commandTTL,
+	})
+	handledCommands := make(chan Command, 2)
+	owner.SetCommandHandler(func(_ context.Context, command Command) error {
+		handledCommands <- command
+		return nil
+	})
+	if err := owner.StartRun(context.Background(), testBotID, "session-expired-command", "stream-expired-command", make(chan struct{}, 1), func() {}, make(chan conversation.InjectMessage, 1)); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	for _, event := range []agentpkg.StreamEvent{
+		{Type: agentpkg.EventToolApprovalRequest, ToolName: "exec", ToolCallID: "call-expired-approval", ApprovalID: "approval-expired", Status: "pending"},
+		{Type: agentpkg.EventUserInputRequest, ToolName: "ask_user", ToolCallID: "call-expired-input", UserInputID: "input-expired", Status: "pending"},
+	} {
+		if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, "session-expired-command", "stream-expired-command"), event); err != nil {
+			t.Fatalf("record response target: %v", err)
+		}
+	}
+
+	for _, request := range []struct {
+		commandType string
+		targetID    string
+	}{
+		{commandType: CommandToolApprovalResponse, targetID: "approval-expired"},
+		{commandType: CommandUserInputResponse, targetID: "input-expired"},
+	} {
+		type dispatchResult struct {
+			handled bool
+			err     error
+		}
+		dispatchDone := make(chan dispatchResult, 1)
+		go func() {
+			handled, err := remote.DispatchActiveCommand(context.Background(), testBotID, "session-expired-command", request.commandType, request.targetID, []byte(`{"ok":true}`))
+			dispatchDone <- dispatchResult{handled: handled, err: err}
+		}()
+		command := receiveTestResult(t, "serialized runtime command", observed)
+		if command.Type != request.commandType || command.TargetID != request.targetID {
+			t.Fatalf("transported command = %#v", command)
+		}
+		if command.CreatedAt.IsZero() || command.ExpiresAt.IsZero() || !command.ExpiresAt.After(command.CreatedAt) {
+			t.Fatalf("transported command expiry = created:%s expires:%s", command.CreatedAt, command.ExpiresAt)
+		}
+		result := receiveTestResult(t, "expired command dispatch", dispatchDone)
+		if !result.handled || result.err == nil {
+			t.Fatalf("expired command dispatch = handled:%v err:%v, want timeout", result.handled, result.err)
+		}
+	}
+	time.Sleep(2 * commandDelay)
+	select {
+	case command := <-handledCommands:
+		t.Fatalf("expired command reached handler: %#v", command)
+	default:
+	}
+}
+
+func runRedisSubscriptionReconnectContract(t *testing.T, redisURL string) {
+	t.Helper()
+
+	prefix := uniqueRuntimeBackendPrefix("reconnect")
+	clientName := fmt.Sprintf("memoh-runtime-reconnect-%d", runtimeBackendPrefixSequence.Add(1))
+	parsedURL, err := url.Parse(redisURL)
+	if err != nil {
+		t.Fatalf("parse redis url: %v", err)
+	}
+	query := parsedURL.Query()
+	query.Set("client_name", clientName)
+	parsedURL.RawQuery = query.Encode()
+	newBackend := func() *RedisBackend {
+		backend, err := NewRedisBackend(context.Background(), RedisOptions{URL: parsedURL.String(), KeyPrefix: prefix, StateTTL: time.Minute})
+		if err != nil {
+			t.Fatalf("redis backend: %v", err)
+		}
+		return backend
+	}
+	ownerBackend := newBackend()
+	remoteBackend := newBackend()
+	owner := NewManager(ownerBackend, Options{OwnerID: "owner-reconnect", StateTTL: time.Minute, OwnerLeaseTTL: time.Second, CommandAckTTL: time.Second})
+	remote := NewManager(remoteBackend, Options{OwnerID: "remote-reconnect", StateTTL: time.Minute, OwnerLeaseTTL: time.Second, CommandAckTTL: time.Second})
+	if err := owner.Start(context.Background()); err != nil {
+		t.Fatalf("start owner manager: %v", err)
+	}
+	if err := remote.Start(context.Background()); err != nil {
+		t.Fatalf("start remote manager: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = remote.Close()
+		_ = owner.Close()
+	})
+	sub, err := remote.Subscribe(context.Background(), testBotID, "session-reconnect")
+	if err != nil {
+		t.Fatalf("subscribe runtime: %v", err)
+	}
+	t.Cleanup(sub.Close)
+	injectCh := make(chan conversation.InjectMessage, 1)
+	if err := owner.StartRun(context.Background(), testBotID, "session-reconnect", "stream-reconnect", make(chan struct{}, 1), func() {}, injectCh); err != nil {
+		t.Fatalf("start reconnect run: %v", err)
+	}
+	waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Delta != nil && event.Delta.CurrentRunView != nil && event.Delta.CurrentRunView.StreamID == "stream-reconnect"
+	})
+
+	redisOptions, err := redis.ParseURL(redisURL)
+	if err != nil {
+		t.Fatalf("parse redis url: %v", err)
+	}
+	admin := redis.NewClient(redisOptions)
+	t.Cleanup(func() { _ = admin.Close() })
+	killRedisPubSubClientsByName(t, admin, clientName)
+	waitRedisSubscriptions(t, admin,
+		ownerBackend.commandChannel("owner-reconnect"),
+		remoteBackend.commandChannel("remote-reconnect"),
+		remoteBackend.sessionChannel(Key{BotID: testBotID, SessionID: "session-reconnect"}),
+	)
+
+	if _, err := owner.HandleAgentEvent(context.Background(), requireRunHandle(t, owner, testBotID, "session-reconnect", "stream-reconnect"), agentpkg.StreamEvent{Type: agentpkg.EventTextDelta, Delta: "after reconnect"}); err != nil {
+		t.Fatalf("handle event after reconnect: %v", err)
+	}
+	waitRuntimeEvent(t, sub.C, func(event Event) bool {
+		return event.Delta != nil && len(event.Delta.MessageAppends) == 1 && event.Delta.MessageAppends[0].Content == "after reconnect"
+	})
+	if _, err := remote.Steer(context.Background(), testBotID, "session-reconnect", "stream-reconnect", "steer after reconnect"); err != nil {
+		t.Fatalf("steer after reconnect: %v", err)
+	}
+	select {
+	case injected := <-injectCh:
+		if injected.Text != "steer after reconnect" {
+			t.Fatalf("injected text = %q", injected.Text)
+		}
+		if injected.Applied != nil {
+			injected.Applied()
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("remote steer was not delivered after Pub/Sub reconnect")
+	}
+}
+
+func killRedisPubSubClientsByName(t *testing.T, client *redis.Client, clientName string) {
+	t.Helper()
+	clientList, err := client.Do(context.Background(), "CLIENT", "LIST", "TYPE", "pubsub").Text()
+	if err != nil {
+		t.Fatalf("list pubsub clients: %v", err)
+	}
+	var ids []string
+	for _, line := range strings.Split(clientList, "\n") {
+		fields := make(map[string]string)
+		for _, field := range strings.Fields(line) {
+			key, value, ok := strings.Cut(field, "=")
+			if ok {
+				fields[key] = value
+			}
+		}
+		if fields["name"] == clientName && fields["id"] != "" {
+			ids = append(ids, fields["id"])
+		}
+	}
+	if len(ids) == 0 {
+		t.Fatalf("no pubsub clients found for %q", clientName)
+	}
+	for _, id := range ids {
+		if _, err := client.ClientKillByFilter(context.Background(), "ID", id, "SKIPME", "yes").Result(); err != nil {
+			t.Fatalf("kill pubsub client %s for %q: %v", id, clientName, err)
+		}
+	}
+}
+
+func waitRedisSubscriptions(t *testing.T, client *redis.Client, channels ...string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		counts, err := client.PubSubNumSub(context.Background(), channels...).Result()
+		if err != nil {
+			t.Fatalf("read pubsub subscription counts: %v", err)
+		}
+		ready := true
+		for _, channel := range channels {
+			if counts[channel] == 0 {
+				ready = false
+				break
+			}
+		}
+		if ready {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("pubsub channels were not restored: %v", channels)
+}

--- a/internal/sessionruntime/state.go
+++ b/internal/sessionruntime/state.go
@@ -1,0 +1,238 @@
+package sessionruntime
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	agentpkg "github.com/memohai/memoh/internal/agent"
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+func runtimeDeltaForAgentEvent(event agentpkg.StreamEvent, messages []conversation.UIMessage) (RuntimeDelta, bool) {
+	switch event.Type {
+	case agentpkg.EventAgentEnd, agentpkg.EventAgentAbort, agentpkg.EventError:
+		return RuntimeDelta{MessageUpserts: append([]conversation.UIMessage(nil), messages...)}, true
+	case agentpkg.EventRetry:
+		return RuntimeDelta{ResetMessages: true}, true
+	case agentpkg.EventTextDelta, agentpkg.EventReasoningDelta:
+		if event.Delta == "" || len(messages) == 0 {
+			return RuntimeDelta{}, false
+		}
+		message := messages[len(messages)-1]
+		return RuntimeDelta{MessageAppends: []RuntimeMessageAppend{{
+			ID:      message.ID,
+			Type:    message.Type,
+			Content: event.Delta,
+		}}}, true
+	case agentpkg.EventToolCallProgress:
+		if len(messages) == 0 {
+			return RuntimeDelta{}, false
+		}
+		message := messages[len(messages)-1]
+		return RuntimeDelta{ProgressAppends: []RuntimeProgressAppend{{
+			ID:       message.ID,
+			Progress: event.Progress,
+			Input:    event.Input,
+		}}}, true
+	default:
+		if len(messages) == 0 {
+			return RuntimeDelta{}, false
+		}
+		return RuntimeDelta{MessageUpserts: append([]conversation.UIMessage(nil), messages...)}, true
+	}
+}
+
+func runtimeRunPatch(snapshot Snapshot, status, runError, steer, lease bool) RuntimeDelta {
+	run := snapshot.CurrentRunView
+	if run == nil {
+		return RuntimeDelta{}
+	}
+	updatedAt := run.UpdatedAt
+	patch := &CurrentRunPatch{
+		StreamID:  run.StreamID,
+		UpdatedAt: &updatedAt,
+	}
+	if status {
+		value := run.Status
+		patch.Status = &value
+	}
+	if runError {
+		value := run.Error
+		patch.Error = &value
+	}
+	if steer && run.Steer != nil {
+		value := *run.Steer
+		patch.Steer = &value
+	}
+	if lease {
+		value := time.Time{}
+		if run.OwnerLeaseExpiresAt != nil {
+			value = *run.OwnerLeaseExpiresAt
+		}
+		patch.OwnerLeaseExpiresAt = &value
+	}
+	return RuntimeDelta{Run: patch}
+}
+
+// leaseExpired is independent of process-local control. Once the backend
+// lease expires, the old owner must not revive it even if its goroutine resumes.
+func (*Manager) leaseExpired(run *CurrentRunView, now time.Time) bool {
+	if run == nil || !isActiveRunStatus(run.Status) || run.OwnerLeaseExpiresAt == nil || now.Before(*run.OwnerLeaseExpiresAt) {
+		return false
+	}
+	return true
+}
+
+func isActiveRunStatus(status string) bool {
+	return strings.EqualFold(status, RunStatusAdmitting) || strings.EqualFold(status, RunStatusRunning) || strings.EqualFold(status, RunStatusAborting)
+}
+
+func isEventAcceptingRunStatus(status string) bool {
+	return strings.EqualFold(status, RunStatusRunning) || strings.EqualFold(status, RunStatusAborting)
+}
+
+func (m *Manager) markLostIfExpired(snapshot *Snapshot, now time.Time) bool {
+	if snapshot == nil || !m.leaseExpired(snapshot.CurrentRunView, now) {
+		return false
+	}
+	run := snapshot.CurrentRunView
+	snapshot.Seq++
+	snapshot.UpdatedAt = now
+	run.Status = RunStatusLost
+	run.Error = "runtime owner lease expired"
+	run.UpdatedAt = now
+	run.OwnerLeaseExpiresAt = nil
+	return true
+}
+
+func nonNilQueue(queue []QueuedRunView) []QueuedRunView {
+	if queue != nil {
+		return queue
+	}
+	return []QueuedRunView{}
+}
+
+func normalizeRunOperation(operation *RunOperationView) (*RunOperationView, error) {
+	if operation == nil {
+		return nil, nil
+	}
+	kind := strings.ToLower(strings.TrimSpace(operation.Kind))
+	replaceFrom := strings.TrimSpace(operation.ReplaceFromMessageID)
+	if replaceFrom == "" {
+		return nil, errors.New("runtime operation replace_from_message_id is required")
+	}
+	if kind != RunOperationRetry && kind != RunOperationEdit {
+		return nil, fmt.Errorf("unsupported runtime operation %q", operation.Kind)
+	}
+	clone := &RunOperationView{
+		Kind:                 kind,
+		ReplaceFromMessageID: replaceFrom,
+	}
+	if operation.ReplacementUserTurn != nil {
+		turn := *operation.ReplacementUserTurn
+		turn.Attachments = append([]conversation.UIAttachment(nil), turn.Attachments...)
+		clone.ReplacementUserTurn = &turn
+	}
+	if kind == RunOperationEdit && (clone.ReplacementUserTurn == nil || !strings.EqualFold(strings.TrimSpace(clone.ReplacementUserTurn.Role), "user")) {
+		return nil, errors.New("edit runtime operation requires a replacement user turn")
+	}
+	return clone, nil
+}
+
+func normalizeRunAdmission(admission RunAdmissionView) (RunAdmissionView, error) {
+	operation, err := normalizeRunOperation(admission.Operation)
+	if err != nil {
+		return RunAdmissionView{}, err
+	}
+	requestUserTurn, err := normalizeRequestUserTurn(admission.RequestUserTurn)
+	if err != nil {
+		return RunAdmissionView{}, err
+	}
+	return RunAdmissionView{RequestUserTurn: requestUserTurn, Operation: operation}, nil
+}
+
+func normalizeRequestUserTurn(turn *conversation.UITurn) (*conversation.UITurn, error) {
+	if turn == nil {
+		return nil, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(turn.Role), "user") {
+		return nil, errors.New("runtime request_user_turn must have role user")
+	}
+	clone := *turn
+	clone.Role = "user"
+	clone.Attachments = append([]conversation.UIAttachment(nil), turn.Attachments...)
+	clone.Messages = append([]conversation.UIMessage(nil), turn.Messages...)
+	return &clone, nil
+}
+
+func leaseRenewInterval(ttl time.Duration) time.Duration {
+	interval := ttl / 3
+	if interval <= 0 {
+		return 100 * time.Millisecond
+	}
+	if interval < 10*time.Millisecond {
+		return 10 * time.Millisecond
+	}
+	return interval
+}
+
+func commandAckPollInterval(timeout time.Duration) time.Duration {
+	interval := timeout / 10
+	if interval <= 0 || interval > 50*time.Millisecond {
+		return 50 * time.Millisecond
+	}
+	if interval < 5*time.Millisecond {
+		return 5 * time.Millisecond
+	}
+	return interval
+}
+
+func runtimeReconcileInterval(ownerLeaseTTL time.Duration) time.Duration {
+	interval := ownerLeaseTTL / 3
+	if interval < 50*time.Millisecond {
+		return 50 * time.Millisecond
+	}
+	if interval > 2*time.Second {
+		return 2 * time.Second
+	}
+	return interval
+}
+
+func enqueueRuntimeEvent(ch chan Event, event Event) {
+	select {
+	case ch <- event:
+		return
+	default:
+	}
+	select {
+	case <-ch:
+	default:
+	}
+	select {
+	case ch <- Event{
+		Type:      EventRuntimeDropped,
+		BotID:     event.BotID,
+		SessionID: event.SessionID,
+		StreamID:  event.StreamID,
+		Seq:       event.Seq,
+		Message:   "runtime subscriber buffer overflow",
+	}:
+	default:
+	}
+}
+
+func upsertUIMessage(messages []conversation.UIMessage, incoming conversation.UIMessage) []conversation.UIMessage {
+	for i := range messages {
+		if incoming.Type == conversation.UIMessageTool && strings.TrimSpace(incoming.ToolCallID) != "" && messages[i].Type == conversation.UIMessageTool && messages[i].ToolCallID == incoming.ToolCallID {
+			messages[i] = incoming
+			return messages
+		}
+		if messages[i].ID == incoming.ID {
+			messages[i] = incoming
+			return messages
+		}
+	}
+	return append(messages, incoming)
+}

--- a/internal/sessionruntime/state.go
+++ b/internal/sessionruntime/state.go
@@ -107,11 +107,63 @@ func (m *Manager) markLostIfExpired(snapshot *Snapshot, now time.Time) bool {
 	return true
 }
 
+func streamLeaseExpiry(snapshot Snapshot, streamID string, fallback time.Time) time.Time {
+	if snapshot.CurrentRunView != nil && snapshot.CurrentRunView.StreamID == streamID && snapshot.CurrentRunView.OwnerLeaseExpiresAt != nil {
+		return *snapshot.CurrentRunView.OwnerLeaseExpiresAt
+	}
+	return fallback
+}
+
 func nonNilQueue(queue []QueuedRunView) []QueuedRunView {
 	if queue != nil {
 		return queue
 	}
 	return []QueuedRunView{}
+}
+
+func runtimeEventEpoch(event Event) string {
+	if epoch := strings.TrimSpace(event.Epoch); epoch != "" {
+		return epoch
+	}
+	if event.Snapshot != nil {
+		return strings.TrimSpace(event.Snapshot.Epoch)
+	}
+	return ""
+}
+
+func streamRefForRun(botID, sessionID string, run *CurrentRunView) StreamRef {
+	if run == nil {
+		return StreamRef{}
+	}
+	return StreamRef{
+		BotID:      strings.TrimSpace(botID),
+		SessionID:  strings.TrimSpace(sessionID),
+		StreamID:   strings.TrimSpace(run.StreamID),
+		OwnerID:    strings.TrimSpace(run.OwnerID),
+		Generation: strings.TrimSpace(run.Generation),
+	}
+}
+
+func runMatchesHandle(run *CurrentRunView, handle RunHandle) bool {
+	handle = handle.normalized()
+	return run != nil && run.StreamID == handle.StreamID && run.Generation == handle.Generation
+}
+
+func (m *Manager) streamRefForControl(ctrl *runControl) StreamRef {
+	if ctrl == nil {
+		return StreamRef{}
+	}
+	ownerID := ""
+	if m != nil && m.distributed != nil {
+		ownerID = m.ownerID
+	}
+	return StreamRef{
+		BotID:      ctrl.botID,
+		SessionID:  ctrl.sessionID,
+		StreamID:   ctrl.streamID,
+		OwnerID:    ownerID,
+		Generation: ctrl.generation,
+	}
 }
 
 func normalizeRunOperation(operation *RunOperationView) (*RunOperationView, error) {
@@ -174,17 +226,6 @@ func leaseRenewInterval(ttl time.Duration) time.Duration {
 	}
 	if interval < 10*time.Millisecond {
 		return 10 * time.Millisecond
-	}
-	return interval
-}
-
-func commandAckPollInterval(timeout time.Duration) time.Duration {
-	interval := timeout / 10
-	if interval <= 0 || interval > 50*time.Millisecond {
-		return 50 * time.Millisecond
-	}
-	if interval < 5*time.Millisecond {
-		return 5 * time.Millisecond
 	}
 	return interval
 }

--- a/internal/sessionruntime/types.go
+++ b/internal/sessionruntime/types.go
@@ -41,6 +41,10 @@ const (
 var (
 	ErrCommandOwnerUnavailable = errors.New("runtime command owner is unavailable")
 	ErrCommandTargetNotActive  = errors.New("runtime command target is not active")
+	ErrCommandTargetMismatch   = errors.New("stream does not belong to this session")
+	ErrCommandExpired          = errors.New("runtime command expired before acknowledgement")
+	ErrCommandBusy             = errors.New("runtime command executor is busy")
+	ErrCommandPayloadConflict  = errors.New("runtime command payload conflicts with an earlier request")
 	ErrManagerClosed           = errors.New("session runtime manager is closed")
 	ErrRunOwnershipLost        = errors.New("runtime run ownership was lost")
 )
@@ -57,15 +61,44 @@ func (k Key) String() string {
 }
 
 type StreamRef struct {
-	BotID     string `json:"bot_id"`
-	SessionID string `json:"session_id"`
-	StreamID  string `json:"stream_id"`
-	OwnerID   string `json:"owner_id"`
+	BotID      string `json:"bot_id"`
+	SessionID  string `json:"session_id"`
+	StreamID   string `json:"stream_id"`
+	OwnerID    string `json:"owner_id"`
+	Generation string `json:"generation"`
+}
+
+// RunHandle identifies one admitted run. Stream IDs may be reused after a run
+// finishes, so owner-side mutations must also carry the run generation.
+type RunHandle struct {
+	BotID      string
+	SessionID  string
+	StreamID   string
+	Generation string
+}
+
+func (h RunHandle) normalized() RunHandle {
+	h.BotID = strings.TrimSpace(h.BotID)
+	h.SessionID = strings.TrimSpace(h.SessionID)
+	h.StreamID = strings.TrimSpace(h.StreamID)
+	h.Generation = strings.TrimSpace(h.Generation)
+	return h
+}
+
+func (h RunHandle) valid() bool {
+	h = h.normalized()
+	return h.BotID != "" && h.SessionID != "" && h.StreamID != "" && h.Generation != ""
+}
+
+func (h RunHandle) key() Key {
+	h = h.normalized()
+	return Key{BotID: h.BotID, SessionID: h.SessionID}
 }
 
 type Snapshot struct {
 	BotID          string          `json:"bot_id"`
 	SessionID      string          `json:"session_id"`
+	Epoch          string          `json:"epoch"`
 	Seq            int64           `json:"seq"`
 	CurrentRunView *CurrentRunView `json:"current_run_view,omitempty"`
 	Queue          []QueuedRunView `json:"queue"`
@@ -87,6 +120,7 @@ type QueuedRunView struct {
 
 type CurrentRunView struct {
 	StreamID            string                   `json:"stream_id"`
+	Generation          string                   `json:"generation"`
 	Status              string                   `json:"status"`
 	OwnerID             string                   `json:"owner_id,omitempty"`
 	OwnerLeaseExpiresAt *time.Time               `json:"owner_lease_expires_at,omitempty"`
@@ -127,6 +161,7 @@ type Event struct {
 	Type      string        `json:"type"`
 	BotID     string        `json:"bot_id"`
 	SessionID string        `json:"session_id"`
+	Epoch     string        `json:"epoch,omitempty"`
 	StreamID  string        `json:"stream_id,omitempty"`
 	Seq       int64         `json:"seq"`
 	UpdatedAt *time.Time    `json:"updated_at,omitempty"`
@@ -174,13 +209,16 @@ type Command struct {
 	BotID        string          `json:"bot_id"`
 	SessionID    string          `json:"session_id"`
 	StreamID     string          `json:"stream_id"`
+	Generation   string          `json:"generation"`
 	TargetID     string          `json:"target_id,omitempty"`
 	SteerID      string          `json:"steer_id,omitempty"`
 	Text         string          `json:"text,omitempty"`
 	Payload      json.RawMessage `json:"payload,omitempty"`
+	PayloadHash  string          `json:"payload_hash,omitempty"`
 	ErrorCode    string          `json:"error_code,omitempty"`
 	Error        string          `json:"error,omitempty"`
 	CreatedAt    time.Time       `json:"created_at"`
+	ExpiresAt    time.Time       `json:"expires_at,omitempty"`
 }
 
 type Subscription struct {
@@ -207,13 +245,21 @@ type Backend interface {
 // MemoryBackend intentionally does not implement this interface.
 type DistributedBackend interface {
 	Backend
-	UpdateActiveRun(ctx context.Context, key Key, streamID string, update ActiveRunUpdate) (Snapshot, bool, error)
+	UpdateActiveRun(ctx context.Context, key Key, streamID, generation string, update ActiveRunUpdate) (Snapshot, bool, error)
 	StartRun(ctx context.Context, key Key, ref StreamRef, update SnapshotUpdate) (Snapshot, bool, error)
-	RenewLease(ctx context.Context, key Key, streamID, ownerID string, renewedAt, expiresAt time.Time) error
+	ReleaseRun(ctx context.Context, key Key, ref StreamRef, update ActiveRunUpdate) (Snapshot, bool, error)
+	RenewLease(ctx context.Context, key Key, streamID, ownerID, generation string, renewedAt, expiresAt time.Time) error
+	ValidateRunOwnership(ctx context.Context, key Key, ref StreamRef) error
 	LoadStreamRef(ctx context.Context, streamID string) (StreamRef, bool, error)
-	DeleteStreamRef(ctx context.Context, streamID string) error
+	DeleteStreamRef(ctx context.Context, ref StreamRef) (bool, error)
 	PublishCommand(ctx context.Context, ownerID string, command Command) error
 	SubscribeCommands(ctx context.Context, ownerID string) (CommandSubscription, error)
+	StoreCommandResult(ctx context.Context, result Command, ttl time.Duration) error
+	LoadCommandResult(ctx context.Context, commandID string) (Command, bool, error)
+}
+
+type startupHealthChecker interface {
+	CheckHealth(ctx context.Context) error
 }
 
 type CommandSubscription struct {

--- a/internal/sessionruntime/types.go
+++ b/internal/sessionruntime/types.go
@@ -1,0 +1,222 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/memohai/memoh/internal/conversation"
+)
+
+const (
+	EventRuntimeSnapshot = "runtime_snapshot"
+	EventRuntimeDelta    = "runtime_delta"
+	EventRuntimeDropped  = "runtime_dropped"
+
+	RunStatusRunning   = "running"
+	RunStatusAdmitting = "admitting"
+	RunStatusAborting  = "aborting"
+	RunStatusCompleted = "completed"
+	RunStatusAborted   = "aborted"
+	RunStatusErrored   = "errored"
+	RunStatusLost      = "lost"
+
+	SteerStatusPending  = "pending"
+	SteerStatusQueued   = "queued"
+	SteerStatusApplied  = "applied"
+	SteerStatusRejected = "rejected"
+
+	RunOperationRetry = "retry"
+	RunOperationEdit  = "edit"
+
+	CommandAbort                = "abort"
+	CommandSteer                = "steer_current_run"
+	CommandToolApprovalResponse = "tool_approval_response"
+	CommandUserInputResponse    = "user_input_response"
+	CommandResult               = "command_result"
+)
+
+var (
+	ErrCommandOwnerUnavailable = errors.New("runtime command owner is unavailable")
+	ErrCommandTargetNotActive  = errors.New("runtime command target is not active")
+	ErrManagerClosed           = errors.New("session runtime manager is closed")
+	ErrRunOwnershipLost        = errors.New("runtime run ownership was lost")
+)
+
+type Key struct {
+	BotID     string `json:"bot_id"`
+	SessionID string `json:"session_id"`
+}
+
+// String returns the canonical "botID:sessionID" composite used to key
+// per-session state across backends and subscription registries.
+func (k Key) String() string {
+	return strings.TrimSpace(k.BotID) + ":" + strings.TrimSpace(k.SessionID)
+}
+
+type StreamRef struct {
+	BotID     string `json:"bot_id"`
+	SessionID string `json:"session_id"`
+	StreamID  string `json:"stream_id"`
+	OwnerID   string `json:"owner_id"`
+}
+
+type Snapshot struct {
+	BotID          string          `json:"bot_id"`
+	SessionID      string          `json:"session_id"`
+	Seq            int64           `json:"seq"`
+	CurrentRunView *CurrentRunView `json:"current_run_view,omitempty"`
+	Queue          []QueuedRunView `json:"queue"`
+	UpdatedAt      time.Time       `json:"updated_at"`
+}
+
+// EmptySnapshot returns the canonical empty runtime snapshot for a session.
+func EmptySnapshot(botID, sessionID string) Snapshot {
+	return Snapshot{
+		BotID:     strings.TrimSpace(botID),
+		SessionID: strings.TrimSpace(sessionID),
+		Queue:     []QueuedRunView{},
+	}
+}
+
+type QueuedRunView struct {
+	StreamID string `json:"stream_id,omitempty"`
+}
+
+type CurrentRunView struct {
+	StreamID            string                   `json:"stream_id"`
+	Status              string                   `json:"status"`
+	OwnerID             string                   `json:"owner_id,omitempty"`
+	OwnerLeaseExpiresAt *time.Time               `json:"owner_lease_expires_at,omitempty"`
+	StartedAt           time.Time                `json:"started_at"`
+	UpdatedAt           time.Time                `json:"updated_at"`
+	Messages            []conversation.UIMessage `json:"messages"`
+	RequestUserTurn     *conversation.UITurn     `json:"request_user_turn,omitempty"`
+	Error               string                   `json:"error,omitempty"`
+	Steer               *SteerState              `json:"steer,omitempty"`
+	Operation           *RunOperationView        `json:"operation,omitempty"`
+}
+
+// RunAdmissionView is the canonical state published when a reserved run
+// becomes active. RequestUserTurn is intentionally runtime state rather than
+// a durable history row; ordinary sends still persist user + assistant
+// together when the run reaches a terminal result.
+type RunAdmissionView struct {
+	RequestUserTurn *conversation.UITurn
+	Operation       *RunOperationView
+}
+
+type RunOperationView struct {
+	Kind                 string               `json:"kind" validate:"required" enums:"retry,edit"`
+	ReplaceFromMessageID string               `json:"replace_from_message_id" validate:"required"`
+	ReplacementUserTurn  *conversation.UITurn `json:"replacement_user_turn,omitempty"`
+}
+
+type SteerState struct {
+	ID        string    `json:"id"`
+	Status    string    `json:"status"`
+	Text      string    `json:"text,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type Event struct {
+	Type      string        `json:"type"`
+	BotID     string        `json:"bot_id"`
+	SessionID string        `json:"session_id"`
+	StreamID  string        `json:"stream_id,omitempty"`
+	Seq       int64         `json:"seq"`
+	UpdatedAt *time.Time    `json:"updated_at,omitempty"`
+	Snapshot  *Snapshot     `json:"snapshot,omitempty"`
+	Delta     *RuntimeDelta `json:"delta,omitempty"`
+	Message   string        `json:"message,omitempty"`
+}
+
+// RuntimeDelta carries only the state changed by one committed runtime
+// transition. Full snapshots are reserved for hydration and gap recovery.
+type RuntimeDelta struct {
+	CurrentRunView  *CurrentRunView          `json:"current_run_view,omitempty"`
+	Run             *CurrentRunPatch         `json:"run,omitempty"`
+	MessageAppends  []RuntimeMessageAppend   `json:"message_appends,omitempty"`
+	ProgressAppends []RuntimeProgressAppend  `json:"progress_appends,omitempty"`
+	MessageUpserts  []conversation.UIMessage `json:"message_upserts,omitempty"`
+	ResetMessages   bool                     `json:"reset_messages,omitempty"`
+}
+
+type CurrentRunPatch struct {
+	StreamID            string      `json:"stream_id"`
+	Status              *string     `json:"status,omitempty"`
+	Error               *string     `json:"error,omitempty"`
+	Steer               *SteerState `json:"steer,omitempty"`
+	UpdatedAt           *time.Time  `json:"updated_at,omitempty"`
+	OwnerLeaseExpiresAt *time.Time  `json:"owner_lease_expires_at,omitempty"`
+}
+
+type RuntimeMessageAppend struct {
+	ID      int                        `json:"id"`
+	Type    conversation.UIMessageType `json:"type"`
+	Content string                     `json:"content"`
+}
+
+type RuntimeProgressAppend struct {
+	ID       int `json:"id"`
+	Progress any `json:"progress"`
+	Input    any `json:"input,omitempty"`
+}
+
+type Command struct {
+	Type         string          `json:"type"`
+	ID           string          `json:"id,omitempty"`
+	ReplyOwnerID string          `json:"reply_owner_id,omitempty"`
+	BotID        string          `json:"bot_id"`
+	SessionID    string          `json:"session_id"`
+	StreamID     string          `json:"stream_id"`
+	TargetID     string          `json:"target_id,omitempty"`
+	SteerID      string          `json:"steer_id,omitempty"`
+	Text         string          `json:"text,omitempty"`
+	Payload      json.RawMessage `json:"payload,omitempty"`
+	ErrorCode    string          `json:"error_code,omitempty"`
+	Error        string          `json:"error,omitempty"`
+	CreatedAt    time.Time       `json:"created_at"`
+}
+
+type Subscription struct {
+	C     <-chan Event
+	Close func()
+}
+
+type (
+	SnapshotUpdate  func(snapshot Snapshot, exists bool) (Snapshot, bool, error)
+	ActiveRunUpdate func(snapshot Snapshot, now time.Time) (Snapshot, bool, error)
+)
+
+type Backend interface {
+	Now(ctx context.Context) (time.Time, error)
+	// Load returns a snapshot the caller owns and may freely mutate.
+	Load(ctx context.Context, key Key) (Snapshot, bool, error)
+	Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error)
+	Publish(ctx context.Context, event Event) error
+	Subscribe(ctx context.Context, key Key) (Subscription, error)
+	Close() error
+}
+
+// DistributedBackend adds cross-process run ownership and command routing.
+// MemoryBackend intentionally does not implement this interface.
+type DistributedBackend interface {
+	Backend
+	UpdateActiveRun(ctx context.Context, key Key, streamID string, update ActiveRunUpdate) (Snapshot, bool, error)
+	StartRun(ctx context.Context, key Key, ref StreamRef, update SnapshotUpdate) (Snapshot, bool, error)
+	RenewLease(ctx context.Context, key Key, streamID, ownerID string, renewedAt, expiresAt time.Time) error
+	LoadStreamRef(ctx context.Context, streamID string) (StreamRef, bool, error)
+	DeleteStreamRef(ctx context.Context, streamID string) error
+	PublishCommand(ctx context.Context, ownerID string, command Command) error
+	SubscribeCommands(ctx context.Context, ownerID string) (CommandSubscription, error)
+}
+
+type CommandSubscription struct {
+	C     <-chan Command
+	Close func()
+}

--- a/internal/toolapproval/runtime_fence_test.go
+++ b/internal/toolapproval/runtime_fence_test.go
@@ -1,0 +1,57 @@
+package toolapproval
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/runtimefence"
+)
+
+type staleApprovalQueries struct {
+	dbstore.Queries
+	approveCalled bool
+}
+
+func (*staleApprovalQueries) SupportsTransactions() bool { return true }
+
+func (q *staleApprovalQueries) InTx(_ context.Context, fn func(dbstore.Queries) error) error {
+	return fn(q)
+}
+
+func (*staleApprovalQueries) LockBotForSessionWrite(_ context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	return id, nil
+}
+
+func (*staleApprovalQueries) LockSessionRuntimeFence(context.Context, sqlc.LockSessionRuntimeFenceParams) (int64, error) {
+	return 0, pgx.ErrNoRows
+}
+
+func (q *staleApprovalQueries) ApproveToolApprovalRequest(context.Context, sqlc.ApproveToolApprovalRequestParams) (sqlc.ToolApprovalRequest, error) {
+	q.approveCalled = true
+	return sqlc.ToolApprovalRequest{}, nil
+}
+
+func TestApproveRejectsStaleRuntimeFence(t *testing.T) {
+	t.Parallel()
+
+	queries := &staleApprovalQueries{}
+	service := NewService(nil, queries, nil)
+	ctx := runtimefence.WithContext(context.Background(), runtimefence.Fence{
+		BotID:     "11111111-1111-1111-1111-111111111111",
+		SessionID: "22222222-2222-2222-2222-222222222222",
+		Token:     4,
+	})
+	_, err := service.Approve(ctx, "33333333-3333-3333-3333-333333333333", "", "")
+	if !errors.Is(err, runtimefence.ErrStale) {
+		t.Fatalf("Approve() error = %v, want ErrStale", err)
+	}
+	if queries.approveCalled {
+		t.Fatal("stale approval updated the request")
+	}
+}

--- a/internal/toolapproval/service.go
+++ b/internal/toolapproval/service.go
@@ -18,6 +18,7 @@ import (
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/decision"
 	"github.com/memohai/memoh/internal/hooks"
+	"github.com/memohai/memoh/internal/runtimefence"
 	"github.com/memohai/memoh/internal/settings"
 )
 
@@ -106,7 +107,7 @@ func (s *Service) CreatePending(ctx context.Context, input CreatePendingInput) (
 	if err := s.runApprovalHook(ctx, hooks.EventBeforeApprovalCreate, input, Request{}, true); err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.CreateToolApprovalRequest(ctx, sqlc.CreateToolApprovalRequestParams{
+	params := sqlc.CreateToolApprovalRequestParams{
 		BotID:                        botID,
 		SessionID:                    sessionID,
 		RouteID:                      optionalUUID(input.RouteID),
@@ -115,13 +116,23 @@ func (s *Service) CreatePending(ctx context.Context, input CreatePendingInput) (
 		ToolName:                     strings.TrimSpace(input.ToolName),
 		Operation:                    operation,
 		ToolInput:                    toolInput,
+		RuntimeFencingToken:          runtimeFencingToken(ctx),
 		RequestedByChannelIdentityID: requestedByID,
 		RequestedMessageID:           optionalUUID(input.RequestedMessageID),
 		SourcePlatform:               strings.TrimSpace(input.SourcePlatform),
 		ReplyTarget:                  strings.TrimSpace(input.ReplyTarget),
 		ConversationType:             strings.TrimSpace(input.ConversationType),
+	}
+	var row sqlc.ToolApprovalRequest
+	err = decision.InCreateTransaction(ctx, s.queries, input.BotID, input.SessionID, func(queries dbstore.Queries) error {
+		var createErr error
+		row, createErr = queries.CreateToolApprovalRequest(ctx, params)
+		return createErr
 	})
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Request{}, ErrAlreadyDecided
+		}
 		return Request{}, err
 	}
 	req := requestFromRow(row)
@@ -207,10 +218,20 @@ func (s *Service) Approve(ctx context.Context, approvalID, actorID, reason strin
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.ApproveToolApprovalRequest(ctx, sqlc.ApproveToolApprovalRequestParams{
-		ID:                         id,
-		Reason:                     strings.TrimSpace(reason),
-		DecidedByChannelIdentityID: decidedBy,
+	runtimeToken := runtimeFencingToken(ctx)
+	var row sqlc.ToolApprovalRequest
+	err = s.withRuntimeFence(ctx, "", "", func(queries dbstore.Queries) error {
+		if err := validateToolApprovalFence(ctx, queries, id); err != nil {
+			return err
+		}
+		var approveErr error
+		row, approveErr = queries.ApproveToolApprovalRequest(ctx, sqlc.ApproveToolApprovalRequestParams{
+			ID:                         id,
+			Reason:                     strings.TrimSpace(reason),
+			DecidedByChannelIdentityID: decidedBy,
+			RuntimeFencingToken:        runtimeToken,
+		})
+		return approveErr
 	})
 	req, err := s.resolveAndNotify(ctx, approvalID, row, err)
 	if err == nil && strings.TrimSpace(actorID) != "" {
@@ -231,10 +252,20 @@ func (s *Service) Reject(ctx context.Context, approvalID, actorID, reason string
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.RejectToolApprovalRequest(ctx, sqlc.RejectToolApprovalRequestParams{
-		ID:                         id,
-		Reason:                     strings.TrimSpace(reason),
-		DecidedByChannelIdentityID: decidedBy,
+	runtimeToken := runtimeFencingToken(ctx)
+	var row sqlc.ToolApprovalRequest
+	err = s.withRuntimeFence(ctx, "", "", func(queries dbstore.Queries) error {
+		if err := validateToolApprovalFence(ctx, queries, id); err != nil {
+			return err
+		}
+		var rejectErr error
+		row, rejectErr = queries.RejectToolApprovalRequest(ctx, sqlc.RejectToolApprovalRequestParams{
+			ID:                         id,
+			Reason:                     strings.TrimSpace(reason),
+			DecidedByChannelIdentityID: decidedBy,
+			RuntimeFencingToken:        runtimeToken,
+		})
+		return rejectErr
 	})
 	req, err := s.resolveAndNotify(ctx, approvalID, row, err)
 	if err == nil && strings.TrimSpace(actorID) != "" {
@@ -264,10 +295,17 @@ func (s *Service) CancelPendingForSession(ctx context.Context, botID, sessionID,
 	if reason == "" {
 		reason = "tool approval cancelled: the turn that requested it ended"
 	}
-	rows, err := s.queries.CancelPendingToolApprovalsBySession(ctx, sqlc.CancelPendingToolApprovalsBySessionParams{
-		BotID:     pgBotID,
-		SessionID: pgSessionID,
-		Reason:    reason,
+	params := sqlc.CancelPendingToolApprovalsBySessionParams{
+		BotID:               pgBotID,
+		SessionID:           pgSessionID,
+		Reason:              reason,
+		RuntimeFencingToken: runtimeFencingToken(ctx),
+	}
+	var rows []sqlc.ToolApprovalRequest
+	err = s.withRuntimeFence(ctx, botID, sessionID, func(queries dbstore.Queries) error {
+		var cancelErr error
+		rows, cancelErr = queries.CancelPendingToolApprovalsBySession(ctx, params)
+		return cancelErr
 	})
 	if err != nil {
 		return nil, err
@@ -279,6 +317,33 @@ func (s *Service) CancelPendingForSession(ctx context.Context, botID, sessionID,
 		s.notifyResolved(req)
 	}
 	return requests, nil
+}
+
+func (s *Service) withRuntimeFence(ctx context.Context, botID, sessionID string, fn func(dbstore.Queries) error) error {
+	if _, fenced := runtimefence.FromContext(ctx); !fenced {
+		return fn(s.queries)
+	}
+	return runtimefence.InTransaction(ctx, s.queries, botID, sessionID, fn)
+}
+
+func runtimeFencingToken(ctx context.Context) pgtype.Int8 {
+	fence, ok := runtimefence.FromContext(ctx)
+	if !ok {
+		return pgtype.Int8{}
+	}
+	return pgtype.Int8{Int64: fence.Token, Valid: true}
+}
+
+func validateToolApprovalFence(ctx context.Context, queries dbstore.Queries, id pgtype.UUID) error {
+	if _, fenced := runtimefence.FromContext(ctx); !fenced {
+		return nil
+	}
+	row, err := queries.GetToolApprovalRequest(ctx, id)
+	if err != nil {
+		return err
+	}
+	request := requestFromRow(row)
+	return runtimefence.ValidateScope(ctx, request.BotID, request.SessionID)
 }
 
 func (s *Service) Get(ctx context.Context, approvalID string) (Request, error) {
@@ -408,8 +473,11 @@ func (s *Service) resolveAndNotify(ctx context.Context, approvalID string, row s
 	req, err := requestFromRowOrErr(row, err)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			if existing, getErr := s.Get(ctx, approvalID); getErr == nil && existing.Status != StatusPending {
-				return Request{}, ErrAlreadyDecided
+			if id, parseErr := db.ParseUUID(approvalID); parseErr == nil {
+				if existing, getErr := s.queries.GetToolApprovalRequest(ctx, id); getErr == nil &&
+					(existing.Status != StatusPending || existing.RuntimeFencingToken.Valid) {
+					return Request{}, ErrAlreadyDecided
+				}
 			}
 		}
 		return Request{}, err
@@ -439,10 +507,18 @@ func (s *Service) UpdatePromptMessage(ctx context.Context, approvalID, promptMes
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.UpdateToolApprovalPromptMessage(ctx, sqlc.UpdateToolApprovalPromptMessageParams{
-		ID:                      id,
-		PromptMessageID:         optionalUUID(promptMessageID),
-		PromptExternalMessageID: strings.TrimSpace(externalID),
+	var row sqlc.ToolApprovalRequest
+	err = s.withRuntimeFence(ctx, "", "", func(queries dbstore.Queries) error {
+		if err := validateToolApprovalFence(ctx, queries, id); err != nil {
+			return err
+		}
+		var updateErr error
+		row, updateErr = queries.UpdateToolApprovalPromptMessage(ctx, sqlc.UpdateToolApprovalPromptMessageParams{
+			ID:                      id,
+			PromptMessageID:         optionalUUID(promptMessageID),
+			PromptExternalMessageID: strings.TrimSpace(externalID),
+		})
+		return updateErr
 	})
 	return requestFromRowOrErr(row, err)
 }

--- a/internal/userinput/runtime_fence_test.go
+++ b/internal/userinput/runtime_fence_test.go
@@ -1,0 +1,57 @@
+package userinput
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/runtimefence"
+)
+
+type staleUserInputQueries struct {
+	dbstore.Queries
+	cancelCalled bool
+}
+
+func (*staleUserInputQueries) SupportsTransactions() bool { return true }
+
+func (q *staleUserInputQueries) InTx(_ context.Context, fn func(dbstore.Queries) error) error {
+	return fn(q)
+}
+
+func (*staleUserInputQueries) LockBotForSessionWrite(_ context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	return id, nil
+}
+
+func (*staleUserInputQueries) LockSessionRuntimeFence(context.Context, sqlc.LockSessionRuntimeFenceParams) (int64, error) {
+	return 0, pgx.ErrNoRows
+}
+
+func (q *staleUserInputQueries) CancelUserInputRequest(context.Context, sqlc.CancelUserInputRequestParams) (sqlc.UserInputRequest, error) {
+	q.cancelCalled = true
+	return sqlc.UserInputRequest{}, nil
+}
+
+func TestCancelRejectsStaleRuntimeFence(t *testing.T) {
+	t.Parallel()
+
+	queries := &staleUserInputQueries{}
+	service := NewService(nil, queries)
+	ctx := runtimefence.WithContext(context.Background(), runtimefence.Fence{
+		BotID:     "11111111-1111-1111-1111-111111111111",
+		SessionID: "22222222-2222-2222-2222-222222222222",
+		Token:     4,
+	})
+	_, err := service.Cancel(ctx, CancelInput{RequestID: "33333333-3333-3333-3333-333333333333"})
+	if !errors.Is(err, runtimefence.ErrStale) {
+		t.Fatalf("Cancel() error = %v, want ErrStale", err)
+	}
+	if queries.cancelCalled {
+		t.Fatal("stale user input response updated the request")
+	}
+}

--- a/internal/userinput/service.go
+++ b/internal/userinput/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/decision"
+	"github.com/memohai/memoh/internal/runtimefence"
 )
 
 const (
@@ -91,8 +92,12 @@ func (s *Service) resolveAndNotify(ctx context.Context, requestID string, row sq
 	resolved, err := requestFromRowOrErr(row, err)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
-			if req, getErr := s.Get(ctx, requestID); getErr == nil && req.Status != StatusPending {
-				return Request{}, ErrAlreadyDecided
+			if id, parseErr := db.ParseUUID(requestID); parseErr == nil {
+				if existing, getErr := s.queries.GetUserInputRequest(ctx, id); getErr == nil &&
+					(existing.Status != StatusPending || existing.RuntimeFencingToken.Valid ||
+						(existing.ExpiresAt.Valid && !existing.ExpiresAt.Time.After(time.Now()))) {
+					return Request{}, ErrAlreadyDecided
+				}
 			}
 		}
 		return Request{}, err
@@ -155,6 +160,7 @@ func (s *Service) CreatePending(ctx context.Context, input CreatePendingInput) (
 		ChannelIdentityID:            channelIdentityID,
 		ToolCallID:                   toolCallID,
 		ToolName:                     toolName,
+		RuntimeFencingToken:          runtimeFencingToken(ctx),
 		InputJson:                    rawInput,
 		UiPayloadJson:                uiPayloadJSON,
 		ProviderMetadata:             providerMetadata,
@@ -164,19 +170,20 @@ func (s *Service) CreatePending(ctx context.Context, input CreatePendingInput) (
 		ConversationType:             strings.TrimSpace(input.ConversationType),
 		ExpiresAt:                    optionalTime(input.ExpiresAt),
 	}
-	row, err := s.queries.CreateUserInputRequest(ctx, params)
+	var row sqlc.UserInputRequest
+	err = decision.InCreateTransaction(ctx, s.queries, input.BotID, input.SessionID, func(queries dbstore.Queries) error {
+		var createErr error
+		row, createErr = queries.CreateUserInputRequest(ctx, params)
+		return createErr
+	})
 	if err != nil {
 		if errors.Is(mapLookupErr(err), ErrNotFound) {
-			existing, getErr := s.queries.GetUserInputRequestBySessionToolCall(ctx, sqlc.GetUserInputRequestBySessionToolCallParams{
+			_, getErr := s.queries.GetUserInputRequestBySessionToolCall(ctx, sqlc.GetUserInputRequestBySessionToolCallParams{
 				SessionID:  sessionID,
 				ToolCallID: toolCallID,
 			})
 			if getErr == nil {
-				existingReq := requestFromRow(existing)
-				if existingReq.Status != StatusPending {
-					return Request{}, ErrAlreadyDecided
-				}
-				return existingReq, nil
+				return Request{}, ErrAlreadyDecided
 			}
 		}
 		return Request{}, mapLookupErr(err)
@@ -195,12 +202,15 @@ func (s *Service) ResolveTarget(ctx context.Context, input ResolveInput) (Reques
 	explicit := strings.TrimSpace(input.ExplicitID)
 	if strings.TrimSpace(input.SessionID) == "" && explicit != "" {
 		if parsed, err := db.ParseUUID(explicit); err == nil {
-			row, err := s.queries.GetUserInputRequest(ctx, parsed)
+			row, err := s.queries.GetRespondableUserInputRequest(ctx, sqlc.GetRespondableUserInputRequestParams{
+				ID:                  parsed,
+				RuntimeFencingToken: runtimeFencingToken(ctx),
+			})
 			if err != nil {
 				return Request{}, mapLookupErr(err)
 			}
-			req := requestFromRow(row)
-			if req.BotID != uuid.UUID(botID.Bytes).String() || req.Status != StatusPending {
+			req := requestFromRespondableRow(row)
+			if req.BotID != uuid.UUID(botID.Bytes).String() {
 				return Request{}, ErrNotFound
 			}
 			return req, nil
@@ -221,12 +231,15 @@ func (s *Service) ResolveTarget(ctx context.Context, input ResolveInput) (Reques
 			return requestFromRowOrErr(row, err)
 		}
 		if parsed, err := db.ParseUUID(explicit); err == nil {
-			row, err := s.queries.GetUserInputRequest(ctx, parsed)
+			row, err := s.queries.GetRespondableUserInputRequest(ctx, sqlc.GetRespondableUserInputRequestParams{
+				ID:                  parsed,
+				RuntimeFencingToken: runtimeFencingToken(ctx),
+			})
 			if err != nil {
 				return Request{}, mapLookupErr(err)
 			}
-			req := requestFromRow(row)
-			if req.BotID != uuid.UUID(botID.Bytes).String() || req.SessionID != uuid.UUID(sessionID.Bytes).String() || req.Status != StatusPending {
+			req := requestFromRespondableRow(row)
+			if req.BotID != uuid.UUID(botID.Bytes).String() || req.SessionID != uuid.UUID(sessionID.Bytes).String() {
 				return Request{}, ErrNotFound
 			}
 			return req, nil
@@ -322,12 +335,19 @@ func (s *Service) Submit(ctx context.Context, input SubmitInput) (Request, error
 	if err != nil {
 		return Request{}, err
 	}
-	req, err := s.Get(ctx, input.RequestID)
+	respondableRow, err := s.queries.GetRespondableUserInputRequest(ctx, sqlc.GetRespondableUserInputRequestParams{
+		ID:                  id,
+		RuntimeFencingToken: runtimeFencingToken(ctx),
+	})
 	if err != nil {
+		if errors.Is(mapLookupErr(err), ErrNotFound) {
+			return Request{}, ErrAlreadyDecided
+		}
 		return Request{}, err
 	}
-	if req.Status != StatusPending {
-		return Request{}, ErrAlreadyDecided
+	req := requestFromRespondableRow(respondableRow)
+	if err := runtimefence.ValidateScope(ctx, req.BotID, req.SessionID); err != nil {
+		return Request{}, err
 	}
 	result, err := submittedResult(req.UIPayload, input.Answers)
 	if err != nil {
@@ -337,10 +357,17 @@ func (s *Service) Submit(ctx context.Context, input SubmitInput) (Request, error
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.SubmitUserInputRequest(ctx, sqlc.SubmitUserInputRequestParams{
-		ID:                           id,
-		ResultJson:                   resultJSON,
-		RespondedByChannelIdentityID: actorID,
+	runtimeToken := runtimeFencingToken(ctx)
+	var row sqlc.UserInputRequest
+	err = s.withRuntimeFence(ctx, req.BotID, req.SessionID, func(queries dbstore.Queries) error {
+		var submitErr error
+		row, submitErr = queries.SubmitUserInputRequest(ctx, sqlc.SubmitUserInputRequestParams{
+			ID:                           id,
+			ResultJson:                   resultJSON,
+			RespondedByChannelIdentityID: actorID,
+			RuntimeFencingToken:          runtimeToken,
+		})
+		return submitErr
 	})
 	return s.resolveAndNotify(ctx, input.RequestID, row, err)
 }
@@ -362,10 +389,20 @@ func (s *Service) Cancel(ctx context.Context, input CancelInput) (Request, error
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.CancelUserInputRequest(ctx, sqlc.CancelUserInputRequestParams{
-		ID:                           id,
-		ResultJson:                   resultJSON,
-		RespondedByChannelIdentityID: actorID,
+	runtimeToken := runtimeFencingToken(ctx)
+	var row sqlc.UserInputRequest
+	err = s.withRuntimeFence(ctx, "", "", func(queries dbstore.Queries) error {
+		if err := validateUserInputFence(ctx, queries, id); err != nil {
+			return err
+		}
+		var cancelErr error
+		row, cancelErr = queries.CancelUserInputRequest(ctx, sqlc.CancelUserInputRequestParams{
+			ID:                           id,
+			ResultJson:                   resultJSON,
+			RespondedByChannelIdentityID: actorID,
+			RuntimeFencingToken:          runtimeToken,
+		})
+		return cancelErr
 	})
 	return s.resolveAndNotify(ctx, input.RequestID, row, err)
 }
@@ -386,10 +423,17 @@ func (s *Service) CancelPendingForSession(ctx context.Context, botID, sessionID,
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.queries.CancelPendingUserInputsBySession(ctx, sqlc.CancelPendingUserInputsBySessionParams{
-		BotID:      pgBotID,
-		SessionID:  pgSessionID,
-		ResultJson: resultJSON,
+	params := sqlc.CancelPendingUserInputsBySessionParams{
+		BotID:               pgBotID,
+		SessionID:           pgSessionID,
+		ResultJson:          resultJSON,
+		RuntimeFencingToken: runtimeFencingToken(ctx),
+	}
+	var rows []sqlc.UserInputRequest
+	err = s.withRuntimeFence(ctx, botID, sessionID, func(queries dbstore.Queries) error {
+		var cancelErr error
+		rows, cancelErr = queries.CancelPendingUserInputsBySession(ctx, params)
+		return cancelErr
 	})
 	if err != nil {
 		return nil, err
@@ -418,9 +462,19 @@ func (s *Service) Fail(ctx context.Context, requestID string, result map[string]
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.FailUserInputRequest(ctx, sqlc.FailUserInputRequestParams{
-		ID:         id,
-		ResultJson: resultJSON,
+	runtimeToken := runtimeFencingToken(ctx)
+	var row sqlc.UserInputRequest
+	err = s.withRuntimeFence(ctx, "", "", func(queries dbstore.Queries) error {
+		if err := validateUserInputFence(ctx, queries, id); err != nil {
+			return err
+		}
+		var failErr error
+		row, failErr = queries.FailUserInputRequest(ctx, sqlc.FailUserInputRequestParams{
+			ID:                  id,
+			ResultJson:          resultJSON,
+			RuntimeFencingToken: runtimeToken,
+		})
+		return failErr
 	})
 	return s.resolveAndNotify(ctx, requestID, row, err)
 }
@@ -430,10 +484,18 @@ func (s *Service) UpdatePromptMessage(ctx context.Context, requestID, promptMess
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.UpdateUserInputPromptMessage(ctx, sqlc.UpdateUserInputPromptMessageParams{
-		ID:                      id,
-		PromptMessageID:         optionalUUID(promptMessageID),
-		PromptExternalMessageID: strings.TrimSpace(externalID),
+	var row sqlc.UserInputRequest
+	err = s.withRuntimeFence(ctx, "", "", func(queries dbstore.Queries) error {
+		if err := validateUserInputFence(ctx, queries, id); err != nil {
+			return err
+		}
+		var updateErr error
+		row, updateErr = queries.UpdateUserInputPromptMessage(ctx, sqlc.UpdateUserInputPromptMessageParams{
+			ID:                      id,
+			PromptMessageID:         optionalUUID(promptMessageID),
+			PromptExternalMessageID: strings.TrimSpace(externalID),
+		})
+		return updateErr
 	})
 	return requestFromRowOrErr(row, err)
 }
@@ -443,9 +505,17 @@ func (s *Service) UpdateAssistantMessage(ctx context.Context, requestID, message
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.UpdateUserInputAssistantMessage(ctx, sqlc.UpdateUserInputAssistantMessageParams{
-		ID:                 id,
-		AssistantMessageID: optionalUUID(messageID),
+	var row sqlc.UserInputRequest
+	err = s.withRuntimeFence(ctx, "", "", func(queries dbstore.Queries) error {
+		if err := validateUserInputFence(ctx, queries, id); err != nil {
+			return err
+		}
+		var updateErr error
+		row, updateErr = queries.UpdateUserInputAssistantMessage(ctx, sqlc.UpdateUserInputAssistantMessageParams{
+			ID:                 id,
+			AssistantMessageID: optionalUUID(messageID),
+		})
+		return updateErr
 	})
 	return requestFromRowOrErr(row, err)
 }
@@ -455,15 +525,50 @@ func (s *Service) UpdateToolResultMessage(ctx context.Context, requestID, messag
 	if err != nil {
 		return Request{}, err
 	}
-	row, err := s.queries.UpdateUserInputToolResultMessage(ctx, sqlc.UpdateUserInputToolResultMessageParams{
-		ID:                  id,
-		ToolResultMessageID: optionalUUID(messageID),
+	var row sqlc.UserInputRequest
+	err = s.withRuntimeFence(ctx, "", "", func(queries dbstore.Queries) error {
+		if err := validateUserInputFence(ctx, queries, id); err != nil {
+			return err
+		}
+		var updateErr error
+		row, updateErr = queries.UpdateUserInputToolResultMessage(ctx, sqlc.UpdateUserInputToolResultMessageParams{
+			ID:                  id,
+			ToolResultMessageID: optionalUUID(messageID),
+		})
+		return updateErr
 	})
 	return requestFromRowOrErr(row, err)
 }
 
 func (s *Service) ListPendingBySession(ctx context.Context, botID, sessionID string) ([]Request, error) {
 	return s.listBySession(ctx, botID, sessionID, true)
+}
+
+func (s *Service) withRuntimeFence(ctx context.Context, botID, sessionID string, fn func(dbstore.Queries) error) error {
+	if _, fenced := runtimefence.FromContext(ctx); !fenced {
+		return fn(s.queries)
+	}
+	return runtimefence.InTransaction(ctx, s.queries, botID, sessionID, fn)
+}
+
+func runtimeFencingToken(ctx context.Context) pgtype.Int8 {
+	fence, ok := runtimefence.FromContext(ctx)
+	if !ok {
+		return pgtype.Int8{}
+	}
+	return pgtype.Int8{Int64: fence.Token, Valid: true}
+}
+
+func validateUserInputFence(ctx context.Context, queries dbstore.Queries, id pgtype.UUID) error {
+	if _, fenced := runtimefence.FromContext(ctx); !fenced {
+		return nil
+	}
+	row, err := queries.GetUserInputRequest(ctx, id)
+	if err != nil {
+		return err
+	}
+	request := requestFromRow(row)
+	return runtimefence.ValidateScope(ctx, request.BotID, request.SessionID)
 }
 
 func (s *Service) ListBySession(ctx context.Context, botID, sessionID string) ([]Request, error) {
@@ -563,6 +668,11 @@ func DeferredMetadata(req Request) map[string]any {
 
 // submittedResult validates the user's answers against the stored payload and
 // builds the tool result returned to the model. Every question must be answered.
+func ValidateAnswers(payload UIPayload, answers []QuestionAnswer) error {
+	_, err := submittedResult(payload, answers)
+	return err
+}
+
 func submittedResult(payload UIPayload, answers []QuestionAnswer) (map[string]any, error) {
 	if len(payload.Questions) == 0 {
 		return nil, errors.New("user input request has no questions")
@@ -698,6 +808,12 @@ func requestFromRowOrErr(row sqlc.UserInputRequest, err error) (Request, error) 
 		return Request{}, mapLookupErr(err)
 	}
 	return requestFromRow(row), nil
+}
+
+func requestFromRespondableRow(row sqlc.UserInputRequest) Request {
+	request := requestFromRow(row)
+	request.Status = strings.TrimSpace(row.Status)
+	return request
 }
 
 func mapLookupErr(err error) error {

--- a/internal/userinput/service_store_test.go
+++ b/internal/userinput/service_store_test.go
@@ -1,6 +1,7 @@
 package userinput
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/decision"
+	"github.com/memohai/memoh/internal/runtimefence"
 )
 
 const (
@@ -73,19 +75,13 @@ func (q *fakeUserInputQueries) CreateUserInputRequest(_ context.Context, arg sql
 	now := time.Now()
 	if id, ok := q.byCall[storeCallKey(arg.SessionID, arg.ToolCallID)]; ok {
 		row := q.rows[id]
-		if !storeRowIsLivePending(row, now) {
+		sameExpiry := row.ExpiresAt.Valid == arg.ExpiresAt.Valid && (!row.ExpiresAt.Valid || row.ExpiresAt.Time.Equal(arg.ExpiresAt.Time))
+		if !storeRowIsLivePending(row, now) || row.RuntimeFencingToken.Valid ||
+			!bytes.Equal(row.InputJson, arg.InputJson) || !bytes.Equal(row.UiPayloadJson, arg.UiPayloadJson) ||
+			!bytes.Equal(row.ProviderMetadata, arg.ProviderMetadata) || !sameExpiry {
 			// ON CONFLICT DO UPDATE ... WHERE status='pending' matched no row.
 			return sqlc.UserInputRequest{}, pgx.ErrNoRows
 		}
-		row.InputJson = arg.InputJson
-		row.UiPayloadJson = arg.UiPayloadJson
-		row.ProviderMetadata = arg.ProviderMetadata
-		row.RequestedByChannelIdentityID = arg.RequestedByChannelIdentityID
-		row.SourcePlatform = arg.SourcePlatform
-		row.ReplyTarget = arg.ReplyTarget
-		row.ConversationType = arg.ConversationType
-		row.ExpiresAt = arg.ExpiresAt
-		row.UpdatedAt = pgtype.Timestamptz{Time: now, Valid: true}
 		return *row, nil
 	}
 	sessionKey := storeUUIDKey(arg.SessionID)
@@ -100,6 +96,7 @@ func (q *fakeUserInputQueries) CreateUserInputRequest(_ context.Context, arg sql
 		ToolName:                     arg.ToolName,
 		ShortID:                      q.nextShort[sessionKey],
 		Status:                       StatusPending,
+		RuntimeFencingToken:          arg.RuntimeFencingToken,
 		InputJson:                    arg.InputJson,
 		UiPayloadJson:                arg.UiPayloadJson,
 		ResultJson:                   []byte("{}"),
@@ -122,6 +119,23 @@ func (q *fakeUserInputQueries) GetUserInputRequest(_ context.Context, id pgtype.
 	defer q.mu.Unlock()
 	row, ok := q.rows[storeUUIDKey(id)]
 	if !ok {
+		return sqlc.UserInputRequest{}, pgx.ErrNoRows
+	}
+	return *row, nil
+}
+
+func (q *fakeUserInputQueries) GetRespondableUserInputRequest(_ context.Context, arg sqlc.GetRespondableUserInputRequestParams) (sqlc.UserInputRequest, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	row, ok := q.rows[storeUUIDKey(arg.ID)]
+	if !ok || row.Status != StatusPending {
+		return sqlc.UserInputRequest{}, pgx.ErrNoRows
+	}
+	if arg.RuntimeFencingToken.Valid {
+		if !row.RuntimeFencingToken.Valid || row.RuntimeFencingToken.Int64 != arg.RuntimeFencingToken.Int64 {
+			return sqlc.UserInputRequest{}, pgx.ErrNoRows
+		}
+	} else if row.RuntimeFencingToken.Valid || !storeRowIsLivePending(row, time.Now()) {
 		return sqlc.UserInputRequest{}, pgx.ErrNoRows
 	}
 	return *row, nil
@@ -411,7 +425,10 @@ func TestServiceCreatePendingIsIdempotentPerToolCall(t *testing.T) {
 		ToolCallID: "call-1",
 		Input: map[string]any{
 			"questions": []any{
-				map[string]any{"text": "Updated question?", "kind": QuestionKindText},
+				map[string]any{
+					"text": "Which plan?", "kind": QuestionKindSingleSelect,
+					"options": []any{map[string]any{"label": "Plan A"}, map[string]any{"label": "Plan B"}},
+				},
 			},
 		},
 	})
@@ -424,10 +441,20 @@ func TestServiceCreatePendingIsIdempotentPerToolCall(t *testing.T) {
 	if second.ShortID != first.ShortID {
 		t.Fatalf("duplicate tool call short_id = %d, want %d", second.ShortID, first.ShortID)
 	}
+	if _, err := svc.CreatePending(context.Background(), CreatePendingInput{
+		BotID:      storeTestBotID,
+		SessionID:  storeTestSessionID,
+		ToolCallID: "call-1",
+		Input: map[string]any{
+			"questions": []any{map[string]any{"text": "Changed question?", "kind": QuestionKindText}},
+		},
+	}); !errors.Is(err, ErrAlreadyDecided) {
+		t.Fatalf("changed duplicate payload error = %v, want ErrAlreadyDecided", err)
+	}
 
 	if _, err := svc.Submit(context.Background(), SubmitInput{
 		RequestID: second.ID,
-		Answers:   []QuestionAnswer{{QuestionID: "q1", Text: "done"}},
+		Answers:   []QuestionAnswer{{QuestionID: "q1", OptionIDs: []string{"q1.o1"}}},
 	}); err != nil {
 		t.Fatalf("submit duplicate row: %v", err)
 	}
@@ -539,6 +566,11 @@ func TestServiceExpiredRequestIsClosed(t *testing.T) {
 	}); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("resolve target error = %v, want ErrNotFound", err)
 	}
+	if _, err := svc.ResolveTarget(context.Background(), ResolveInput{
+		BotID: storeTestBotID, SessionID: storeTestSessionID, ExplicitID: req.ID,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("resolve expired explicit target error = %v, want ErrNotFound", err)
+	}
 
 	pending, err := svc.ListPendingBySession(context.Background(), storeTestBotID, storeTestSessionID)
 	if err != nil {
@@ -563,6 +595,40 @@ func TestServiceExpiredRequestIsClosed(t *testing.T) {
 		Answers:   []QuestionAnswer{{QuestionID: "q1", OptionIDs: []string{"q1.o1"}}},
 	}); err != nil {
 		t.Fatalf("submit live: %v", err)
+	}
+}
+
+func TestServiceResolveTargetKeepsClaimedRequestRespondableAfterExpiry(t *testing.T) {
+	t.Parallel()
+
+	queries := newFakeUserInputQueries()
+	svc := NewService(slog.New(slog.DiscardHandler), queries)
+	expired := time.Now().Add(-time.Minute)
+	req := createStorePending(t, svc, &expired, "call-claimed-expired")
+	queries.mu.Lock()
+	row := queries.rows[req.ID]
+	row.RuntimeFencingToken = pgtype.Int8{Int64: 7, Valid: true}
+	queries.mu.Unlock()
+	ctx := runtimefence.WithContext(context.Background(), runtimefence.Fence{
+		BotID: storeTestBotID, SessionID: storeTestSessionID, Token: 7,
+	})
+
+	resolved, err := svc.ResolveTarget(ctx, ResolveInput{
+		BotID: storeTestBotID, SessionID: storeTestSessionID, ExplicitID: req.ID,
+	})
+	if err != nil {
+		t.Fatalf("resolve claimed expired request: %v", err)
+	}
+	if resolved.ID != req.ID {
+		t.Fatalf("resolved request = %q, want %q", resolved.ID, req.ID)
+	}
+	if resolved.Status != StatusPending {
+		t.Fatalf("resolved status = %q, want pending", resolved.Status)
+	}
+	if _, err := svc.ResolveTarget(context.Background(), ResolveInput{
+		BotID: storeTestBotID, SessionID: storeTestSessionID, ExplicitID: req.ID,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unfenced resolve error = %v, want ErrNotFound", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add durable PostgreSQL fencing tokens for runtime-owned persistence
- fence message, approval, user-input, ACP, and MCP side effects against stale owners
- add schema migrations, sqlc queries, transactional decision helpers, and integration coverage

## Stack

Depends on the Redis coordination PR created immediately before this one. This fork-only stack remains based on `main`; review the top commit until preceding layers merge.

## Verification

- runtime fencing unit and PostgreSQL integration suites
- full repository pre-commit Go tests