### PR TITLE
fix(web): restore provider detail after refresh

### DIFF
--- a/apps/web/src/components/settings/back-button.vue
+++ b/apps/web/src/components/settings/back-button.vue
@@ -4,14 +4,9 @@
        geometry below is tuned in exactly one place — this used to be
        copy-pasted into every caller and drifted.
 
-       Geometry (both values coupled, derived together):
-         px-4  — a roomier chip: 16px of air on each side of the
-                 chevron+label, replacing the default svg padding (12px).
-         -ml-4 — shifts the button left by exactly that padding, so the
-                 CHEVRON's left pixel lands on the wrapper's content edge —
-                 the same x as the cards below (optical alignment: the glyph
-                 aligns, the hover chip overhangs into the gutter).
-       Keep them equal-and-opposite; re-derive both if one changes. -->
+       The button surface shares the detail body's left rail, so its hover /
+       pressed fill aligns with the card edge below instead of hanging into
+       the outer gutter. px-4 keeps the chevron and label comfortably inset. -->
   <Button
     variant="ghost"
     :class="buttonClass"
@@ -34,5 +29,5 @@ const emit = defineEmits<{ click: [] }>()
 
 // Geometry rationale in the template comment above. The /85 dim is tuned for
 // this sole owner — one consumer doesn't earn a global -soft token.
-const buttonClass = '-ml-4 max-w-full px-4 text-foreground/85' /* ui-allow-alpha: sole owner, see comment above */
+const buttonClass = 'max-w-full px-4 text-foreground/85' /* ui-allow-alpha: sole owner, see comment above */
 </script>

--- a/apps/web/src/components/settings/detail-pane.vue
+++ b/apps/web/src/components/settings/detail-pane.vue
@@ -14,19 +14,50 @@
       />
     </div>
 
-    <slot />
+    <!-- Loading hold: same shell rails + card shape as a real detail form so a
+         slow refresh / cold load does not flash an empty DetailPane. Slot content
+         only mounts once the page has resolved its selected resource. -->
+    <div
+      v-if="loading"
+      class="mx-auto w-full px-4 pb-12 pt-2 md:px-6"
+      :class="widthClass"
+      data-testid="detail-pane-skeleton"
+    >
+      <div class="space-y-6">
+        <div class="flex items-center gap-3 rounded-[var(--radius-menu-shell)] border border-border bg-card px-4 py-3">
+          <Skeleton class="size-9 shrink-0 rounded-full" />
+          <Skeleton class="h-4 w-32" />
+          <Skeleton class="ml-auto size-8 rounded-[var(--radius-control)]" />
+        </div>
+        <div class="overflow-hidden rounded-[var(--radius-menu-shell)] border border-border bg-card">
+          <div
+            v-for="i in 4"
+            :key="i"
+            class="mx-4 flex items-center justify-between border-b border-border py-3.5 last:border-b-0"
+          >
+            <Skeleton class="h-4 w-24" />
+            <Skeleton class="h-8 w-48 max-w-[55%]" />
+          </div>
+        </div>
+      </div>
+    </div>
+    <slot v-else />
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { Skeleton } from '@felinic/ui'
 import SettingsBackButton from '@/components/settings/back-button.vue'
 
 const props = withDefaults(defineProps<{
   backLabel: string
   width?: 'narrow' | 'standard' | 'wide'
+  /** True while the URL asks for detail but the resource is still resolving. */
+  loading?: boolean
 }>(), {
   width: 'standard',
+  loading: false,
 })
 
 const emit = defineEmits<{ back: [] }>()

--- a/apps/web/src/components/settings/detail-pane.vue
+++ b/apps/web/src/components/settings/detail-pane.vue
@@ -2,8 +2,8 @@
   <div>
     <!-- Back row, width-matched to the reused detail body below (which brings
          its own SettingsShell) so the header shares the content's rails. The
-         button itself (geometry, alignment, hover-chip overhang) is
-         SettingsBackButton — one shared spec, tuned there only. -->
+         button itself (geometry / rail alignment) is SettingsBackButton —
+         one shared spec, tuned there only. -->
     <div
       class="mx-auto w-full px-4 pt-4 md:px-6 md:pt-6"
       :class="widthClass"
@@ -14,33 +14,47 @@
       />
     </div>
 
-    <!-- Loading hold: same shell rails + card shape as a real detail form so a
-         slow refresh / cold load does not flash an empty DetailPane. Slot content
-         only mounts once the page has resolved its selected resource. -->
-    <div
+    <!-- Loading hold: reuse SettingsShell so rails / top gap match the real
+         detail body (model-setting etc.). Header card mirrors the provider
+         identity row 1:1 — round avatar, flex-1 title, trailing icon + switch
+         — so the frame does not jump when content swaps in. -->
+    <SettingsShell
       v-if="loading"
-      class="mx-auto w-full px-4 pb-12 pt-2 md:px-6"
-      :class="widthClass"
+      :width="width"
       data-testid="detail-pane-skeleton"
     >
       <div class="space-y-6">
-        <div class="flex items-center gap-3 rounded-[var(--radius-menu-shell)] border border-border bg-card px-4 py-3">
-          <Skeleton class="size-9 shrink-0 rounded-full" />
-          <Skeleton class="h-4 w-32" />
-          <Skeleton class="ml-auto size-8 rounded-[var(--radius-control)]" />
-        </div>
+        <section class="flex items-center gap-3 rounded-[var(--radius-menu-shell)] border border-border bg-card px-4 py-3">
+          <!-- Real header uses size-9 rounded-full avatar; force full round so the
+               Skeleton base rounded-lg cannot leave a square chip. -->
+          <Skeleton class="size-9 shrink-0 !rounded-full" />
+          <div class="min-w-0 flex-1">
+            <Skeleton class="h-4 w-36 max-w-full !rounded-md" />
+          </div>
+          <div class="ml-auto flex shrink-0 items-center gap-2">
+            <!-- icon-sm trash affordance — use solid Tailwind radius tokens.
+                 Arbitrary rounded-[var(--radius-control)] was not applying, so
+                 the block rendered as a sharp square. -->
+            <Skeleton class="size-8 shrink-0 !rounded-md" />
+            <!-- Switch track (h-5 w-9 rounded-full), not a square block -->
+            <Skeleton class="h-5 w-9 shrink-0 !rounded-full" />
+          </div>
+        </section>
+
+        <!-- Form card: SettingsRow geometry (mx-4 / py-3.5 / inset hairlines) +
+             h-9 field controls matching real Input / Select height. -->
         <div class="overflow-hidden rounded-[var(--radius-menu-shell)] border border-border bg-card">
           <div
             v-for="i in 4"
             :key="i"
             class="mx-4 flex items-center justify-between border-b border-border py-3.5 last:border-b-0"
           >
-            <Skeleton class="h-4 w-24" />
-            <Skeleton class="h-8 w-48 max-w-[55%]" />
+            <Skeleton class="h-4 w-24 shrink-0 !rounded-md" />
+            <Skeleton class="h-9 w-80 max-w-[55%] !rounded-md" />
           </div>
         </div>
       </div>
-    </div>
+    </SettingsShell>
     <slot v-else />
   </div>
 </template>
@@ -49,6 +63,7 @@
 import { computed } from 'vue'
 import { Skeleton } from '@felinic/ui'
 import SettingsBackButton from '@/components/settings/back-button.vue'
+import SettingsShell from '@/components/settings-shell/index.vue'
 
 const props = withDefaults(defineProps<{
   backLabel: string

--- a/apps/web/src/composables/useViewSwap.test.ts
+++ b/apps/web/src/composables/useViewSwap.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { effectScope, nextTick, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useRoutedViewSwap } from './useViewSwap'
+
+const mocks = vi.hoisted(() => ({
+  route: { query: {} as Record<string, string> },
+  replace: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => ({ replace: mocks.replace }),
+}))
+
+interface Item {
+  routeValue: string
+}
+
+function setupSwap() {
+  const items = ref<Item[]>([])
+  const selected = ref<Item>()
+  const loading = ref(false)
+  const ready = ref(false)
+  const scope = effectScope()
+  const swap = scope.run(() => useRoutedViewSwap({
+    key: 'provider',
+    items: () => items.value,
+    selected: () => selected.value,
+    select: item => selected.value = item,
+    getRouteValue: item => item.routeValue,
+    isLoading: () => loading.value,
+    isReady: () => ready.value,
+  }))!
+
+  return { items, selected, loading, ready, scope, swap }
+}
+
+describe('useRoutedViewSwap', () => {
+  beforeEach(() => {
+    mocks.route.query = {}
+    mocks.replace.mockReset()
+  })
+
+  it('waits for fresh data before resolving a typed resource key', async () => {
+    mocks.route.query = { provider: 'fetch:two' }
+    const state = setupSwap()
+    state.items.value = [{ routeValue: 'search:one' }]
+    state.loading.value = true
+    state.ready.value = true
+    await nextTick()
+
+    expect(state.selected.value).toBeUndefined()
+    expect(mocks.replace).not.toHaveBeenCalled()
+
+    state.items.value = [
+      { routeValue: 'search:one' },
+      { routeValue: 'fetch:two' },
+    ]
+    state.loading.value = false
+    await nextTick()
+
+    expect(state.selected.value?.routeValue).toBe('fetch:two')
+    state.scope.stop()
+  })
+
+  it('removes an invalid resource key once its source is ready', async () => {
+    mocks.route.query = { provider: 'search:missing', tab: 'voice' }
+    const state = setupSwap()
+    state.ready.value = true
+    await nextTick()
+
+    expect(mocks.replace).toHaveBeenCalledWith({ query: { tab: 'voice' } })
+    state.scope.stop()
+  })
+
+  it('writes the selected resource key without creating history', () => {
+    mocks.route.query = { tab: 'voice' }
+    const state = setupSwap()
+
+    state.swap.openDetail({ routeValue: 'speech:one' })
+
+    expect(state.selected.value?.routeValue).toBe('speech:one')
+    expect(mocks.replace).toHaveBeenCalledWith({
+      query: { tab: 'voice', provider: 'speech:one' },
+    })
+    state.scope.stop()
+  })
+})

--- a/apps/web/src/composables/useViewSwap.test.ts
+++ b/apps/web/src/composables/useViewSwap.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { effectScope, nextTick } from 'vue'
+import { effectScope, nextTick, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useViewSwap } from './useViewSwap'
+import { useRoutedViewSwap, useViewSwap } from './useViewSwap'
 
 const mocks = vi.hoisted(() => ({
   route: { query: {} as Record<string, string | undefined> },
@@ -13,10 +13,33 @@ vi.mock('vue-router', () => ({
   useRouter: () => ({ replace: mocks.replace }),
 }))
 
+interface Item {
+  routeValue: string
+}
+
 function setupSwap(key = 'provider') {
   const scope = effectScope()
   const swap = scope.run(() => useViewSwap(key))!
   return { scope, swap }
+}
+
+function setupRouted(key = 'provider') {
+  const items = ref<Item[]>([])
+  const selected = ref<Item>()
+  const loading = ref(false)
+  const ready = ref(false)
+  const scope = effectScope()
+  const swap = scope.run(() => useRoutedViewSwap({
+    key,
+    items: () => items.value,
+    selected: () => selected.value,
+    select: item => selected.value = item,
+    getRouteValue: item => item.routeValue,
+    isLoading: () => loading.value,
+    isReady: () => ready.value,
+  }))!
+
+  return { items, selected, loading, ready, scope, swap }
 }
 
 describe('useViewSwap', () => {
@@ -25,7 +48,7 @@ describe('useViewSwap', () => {
     mocks.replace.mockReset()
   })
 
-  it('writes the resource id into a page-owned query key without history', () => {
+  it('writes a non-empty resource id without history', () => {
     mocks.route.query = { tab: 'kept' }
     const { scope, swap } = setupSwap('emailProvider')
 
@@ -35,6 +58,17 @@ describe('useViewSwap', () => {
     expect(mocks.replace).toHaveBeenCalledWith({
       query: { tab: 'kept', emailProvider: 'email-1' },
     })
+    scope.stop()
+  })
+
+  it('refuses to write an empty resource id (no silent 1 fallback)', () => {
+    const { scope, swap } = setupSwap('provider')
+
+    swap.openDetail('')
+    swap.openDetail(undefined)
+
+    expect(swap.view.value).toBe('list')
+    expect(mocks.replace).not.toHaveBeenCalled()
     scope.stop()
   })
 
@@ -57,5 +91,110 @@ describe('useViewSwap', () => {
     expect(swap.view.value).toBe('list')
     expect(mocks.replace).toHaveBeenCalledWith({ query: { tab: 'kept' } })
     scope.stop()
+  })
+
+  it('allows unkeyed local swaps without writing the URL', () => {
+    const scope = effectScope()
+    const swap = scope.run(() => useViewSwap())!
+
+    swap.openDetail()
+    expect(swap.view.value).toBe('detail')
+    expect(mocks.replace).not.toHaveBeenCalled()
+
+    swap.backToList()
+    expect(swap.view.value).toBe('list')
+    expect(mocks.replace).not.toHaveBeenCalled()
+    scope.stop()
+  })
+})
+
+describe('useRoutedViewSwap', () => {
+  beforeEach(() => {
+    mocks.route.query = {}
+    mocks.replace.mockReset()
+  })
+
+  it('waits for fresh data before resolving a resource key', async () => {
+    mocks.route.query = { provider: 'fetch:two' }
+    const state = setupRouted()
+    state.items.value = [{ routeValue: 'search:one' }]
+    state.loading.value = true
+    state.ready.value = true
+    await nextTick()
+
+    expect(state.selected.value).toBeUndefined()
+    expect(state.swap.isDetailLoading.value).toBe(true)
+    expect(mocks.replace).not.toHaveBeenCalled()
+
+    state.items.value = [
+      { routeValue: 'search:one' },
+      { routeValue: 'fetch:two' },
+    ]
+    state.loading.value = false
+    await nextTick()
+
+    expect(state.selected.value?.routeValue).toBe('fetch:two')
+    expect(state.swap.isDetailLoading.value).toBe(false)
+    state.scope.stop()
+  })
+
+  it('removes an invalid resource key once its source is ready', async () => {
+    mocks.route.query = { provider: 'search:missing', tab: 'voice' }
+    const state = setupRouted()
+    state.ready.value = true
+    await nextTick()
+
+    expect(mocks.replace).toHaveBeenCalledWith({ query: { tab: 'voice' } })
+    state.scope.stop()
+  })
+
+  it('writes the selected resource key without creating history', () => {
+    mocks.route.query = { tab: 'voice' }
+    const state = setupRouted()
+
+    state.swap.openDetail({ routeValue: 'speech:one' })
+
+    expect(state.selected.value?.routeValue).toBe('speech:one')
+    expect(mocks.replace).toHaveBeenCalledWith({
+      query: { tab: 'voice', provider: 'speech:one' },
+    })
+    state.scope.stop()
+  })
+
+  it('does not strip another page key under KeepAlive (unique keys)', async () => {
+    // Simulate two settings pages still mounted: providers (cached) and email (active).
+    mocks.route.query = { emailProvider: 'email-1' }
+
+    const providers = setupRouted('provider')
+    providers.items.value = [{ routeValue: 'llm-1' }]
+    providers.ready.value = true
+    providers.loading.value = false
+
+    const email = setupRouted('emailProvider')
+    email.items.value = [{ routeValue: 'email-1' }]
+    email.ready.value = true
+    email.loading.value = false
+    await nextTick()
+
+    // Providers page sees no `provider` key — must not touch emailProvider.
+    expect(providers.selected.value).toBeUndefined()
+    expect(email.selected.value?.routeValue).toBe('email-1')
+    expect(mocks.replace).not.toHaveBeenCalled()
+
+    providers.scope.stop()
+    email.scope.stop()
+  })
+
+  it('would race if two pages shared one key (documents why keys must be unique)', async () => {
+    mocks.route.query = { provider: 'email-1' }
+
+    const providers = setupRouted('provider')
+    providers.items.value = [{ routeValue: 'llm-1' }]
+    providers.ready.value = true
+    await nextTick()
+
+    // Shared key + foreign id → cached page strips the query.
+    expect(mocks.replace).toHaveBeenCalledWith({ query: {} })
+    providers.scope.stop()
   })
 })

--- a/apps/web/src/composables/useViewSwap.test.ts
+++ b/apps/web/src/composables/useViewSwap.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
-import { effectScope, nextTick, ref } from 'vue'
+import { effectScope, nextTick } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useRoutedViewSwap } from './useViewSwap'
+import { useViewSwap } from './useViewSwap'
 
 const mocks = vi.hoisted(() => ({
-  route: { query: {} as Record<string, string> },
+  route: { query: {} as Record<string, string | undefined> },
   replace: vi.fn(),
 }))
 
@@ -13,77 +13,49 @@ vi.mock('vue-router', () => ({
   useRouter: () => ({ replace: mocks.replace }),
 }))
 
-interface Item {
-  routeValue: string
-}
-
-function setupSwap() {
-  const items = ref<Item[]>([])
-  const selected = ref<Item>()
-  const loading = ref(false)
-  const ready = ref(false)
+function setupSwap(key = 'provider') {
   const scope = effectScope()
-  const swap = scope.run(() => useRoutedViewSwap({
-    key: 'provider',
-    items: () => items.value,
-    selected: () => selected.value,
-    select: item => selected.value = item,
-    getRouteValue: item => item.routeValue,
-    isLoading: () => loading.value,
-    isReady: () => ready.value,
-  }))!
-
-  return { items, selected, loading, ready, scope, swap }
+  const swap = scope.run(() => useViewSwap(key))!
+  return { scope, swap }
 }
 
-describe('useRoutedViewSwap', () => {
+describe('useViewSwap', () => {
   beforeEach(() => {
     mocks.route.query = {}
     mocks.replace.mockReset()
   })
 
-  it('waits for fresh data before resolving a typed resource key', async () => {
-    mocks.route.query = { provider: 'fetch:two' }
-    const state = setupSwap()
-    state.items.value = [{ routeValue: 'search:one' }]
-    state.loading.value = true
-    state.ready.value = true
-    await nextTick()
+  it('writes the resource id into a page-owned query key without history', () => {
+    mocks.route.query = { tab: 'kept' }
+    const { scope, swap } = setupSwap('emailProvider')
 
-    expect(state.selected.value).toBeUndefined()
-    expect(mocks.replace).not.toHaveBeenCalled()
+    swap.openDetail('email-1')
 
-    state.items.value = [
-      { routeValue: 'search:one' },
-      { routeValue: 'fetch:two' },
-    ]
-    state.loading.value = false
-    await nextTick()
-
-    expect(state.selected.value?.routeValue).toBe('fetch:two')
-    state.scope.stop()
-  })
-
-  it('removes an invalid resource key once its source is ready', async () => {
-    mocks.route.query = { provider: 'search:missing', tab: 'voice' }
-    const state = setupSwap()
-    state.ready.value = true
-    await nextTick()
-
-    expect(mocks.replace).toHaveBeenCalledWith({ query: { tab: 'voice' } })
-    state.scope.stop()
-  })
-
-  it('writes the selected resource key without creating history', () => {
-    mocks.route.query = { tab: 'voice' }
-    const state = setupSwap()
-
-    state.swap.openDetail({ routeValue: 'speech:one' })
-
-    expect(state.selected.value?.routeValue).toBe('speech:one')
+    expect(swap.view.value).toBe('detail')
     expect(mocks.replace).toHaveBeenCalledWith({
-      query: { tab: 'voice', provider: 'speech:one' },
+      query: { tab: 'kept', emailProvider: 'email-1' },
     })
-    state.scope.stop()
+    scope.stop()
+  })
+
+  it('opens detail from a non-empty query value on mount', () => {
+    mocks.route.query = { provider: 'abc' }
+    const { scope, swap } = setupSwap('provider')
+
+    expect(swap.view.value).toBe('detail')
+    expect(swap.queryValue.value).toBe('abc')
+    scope.stop()
+  })
+
+  it('clears only its own query key when returning to the list', async () => {
+    mocks.route.query = { provider: 'abc', tab: 'kept' }
+    const { scope, swap } = setupSwap('provider')
+
+    swap.backToList()
+    await nextTick()
+
+    expect(swap.view.value).toBe('list')
+    expect(mocks.replace).toHaveBeenCalledWith({ query: { tab: 'kept' } })
+    scope.stop()
   })
 })

--- a/apps/web/src/composables/useViewSwap.ts
+++ b/apps/web/src/composables/useViewSwap.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch, watchEffect } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 // Motion for the in-place list <-> detail swap (a frontend page switch with no
@@ -18,52 +18,60 @@ import { useRoute, useRouter } from 'vue-router'
 
 export type SwapDirection = 'forward' | 'back'
 
-type ViewSwapQuerySync = {
-  key: string
-  detailValue: () => string
-}
-
 /**
  * Drives a two-pane (list <-> detail) swap inside a single page. Render the list
  * when `view === 'list'` and the detail when `view === 'detail'`, wrapped in the
  * SwapTransition component. `direction` tells that component which way to slide.
  *
- * Pass a query config whose `detailValue` returns a stable resource ID. It is
- * written with router.replace — an in-page state sync, not a navigation, same
- * contract as useSyncedQueryParam. The resource ID lets a refresh restore the
- * exact item. Query mirroring is required for the settings-sidebar
+ * Pass `queryKey` to mirror the detail state into the URL as `?<queryKey>=<value>`
+ * (written with router.replace — an in-page state sync, not a navigation, same
+ * contract as useSyncedQueryParam). The value is whatever the page hands
+ * `openDetail` — pages pass the open resource's stable ID so a refresh can
+ * restore the exact item (the page resolves `queryValue` back to an object
+ * itself; this composable stays ignorant of what the value means). Mirroring
+ * into the query is also required for the settings-sidebar
  * "re-click the tab you're already on" affordance to work: sidebar navigation
  * is a plain `router.push({ name })` with no query. If detail state lives ONLY
  * in a local ref, re-clicking the current tab resolves to the exact same
  * location the router is already at, so Vue Router treats it as a duplicate
  * push and silently drops it — the page never hears about it, so a detail view
- * left open has no way to snap back to its list. Mirroring the state into the
+ * left open has no way to snap back to its list. Mirroring the value into the
  * query makes list-vs-detail part of the resolved location, so leaving detail
  * open changes the URL, and a bare re-push to the tab's un-queried route is a
  * genuinely different destination that the router actually navigates to. Omit
- * the config for swaps that don't need this (e.g. a swap nested inside another
+ * `queryKey` for swaps that don't need this (e.g. a swap nested inside another
  * already-synced tab) — `view` then stays purely local, as before.
+ *
+ * The `queryKey` MUST be unique per settings page. `useRoute()` reads the ONE
+ * global route, and every settings page stays mounted under <KeepAlive>
+ * (settings-section/index.vue) after you navigate away — so a cached page's
+ * watchers keep reading the live URL. If two pages shared a key, the cached
+ * page would read the active page's value off the shared key, fail to resolve
+ * that foreign ID against its own list, and strip the query — snapping the
+ * active page's detail shut. Distinct keys keep each page's URL state its own;
+ * a page only ever sees the key it wrote, so there is nothing to fight over.
  */
-export function useViewSwap(querySync?: ViewSwapQuerySync) {
-  const queryKey = querySync?.key
+export function useViewSwap(queryKey?: string) {
   const route = queryKey ? useRoute() : null
   const router = queryKey ? useRouter() : null
 
+  // The raw query value ('' when absent). Detail is open iff it's non-empty —
+  // the page owns what the value means (a resource ID); we only care presence.
   const queryValue = computed(() => {
     if (!queryKey || !route) return ''
     const value = route.query[queryKey]
     return typeof value === 'string' ? value : ''
   })
-  const queryDetail = computed(() => queryValue.value.length > 0)
+  const queryDetail = computed(() => queryValue.value !== '')
   const view = ref<'list' | 'detail'>(queryDetail.value ? 'detail' : 'list')
   const direction = ref<SwapDirection>('forward')
 
   if (queryKey && route && router) {
-    // Reacts to the query value changing for ANY reason — our own replace()
+    // Reacts to the query flag changing for ANY reason — our own replace()
     // calls below, but also external navigations we don't control: a sidebar
     // re-click that lands on the un-queried route, or the user's own browser
     // back/forward. Whatever the cause, `view` must follow the URL, and losing
-    // the value always reads as "closing", so it always animates as 'back'.
+    // the flag always reads as "closing", so it always animates as 'back'.
     // The equality guard skips the case where openDetail/backToList already
     // applied this exact state locally before writing the query, so the two
     // never fight over `direction` for the same transition.
@@ -74,20 +82,20 @@ export function useViewSwap(querySync?: ViewSwapQuerySync) {
     })
   }
 
-  function openDetail(onSwitched?: () => void) {
+  // `detailValue` is what lands in the URL. Falls back to '1' so an unkeyed or
+  // legacy call still flips the view and keeps the sidebar-re-click affordance
+  // — but keyed pages should always pass the resource ID, or a refresh has
+  // nothing to restore.
+  function openDetail(detailValue?: string) {
     direction.value = 'forward'
-    onSwitched?.()
     view.value = 'detail'
     if (queryKey && route && router) {
-      const detailValue = querySync?.detailValue()
-      if (!detailValue) return
-      void router.replace({ query: { ...route.query, [queryKey]: detailValue } })
+      void router.replace({ query: { ...route.query, [queryKey]: detailValue || '1' } })
     }
   }
 
-  function backToList(onSwitched?: () => void) {
+  function backToList() {
     direction.value = 'back'
-    onSwitched?.()
     view.value = 'list'
     if (queryKey && route && router) {
       const { [queryKey]: _drop, ...rest } = route.query
@@ -96,62 +104,4 @@ export function useViewSwap(querySync?: ViewSwapQuerySync) {
   }
 
   return { view, direction, queryValue, openDetail, backToList }
-}
-
-interface RoutedViewSwapOptions<T> {
-  key: string
-  items: () => readonly T[]
-  selected: () => T | undefined
-  select: (item: T | undefined) => void
-  getRouteValue: (item: T) => string
-  isLoading: (routeValue: string) => boolean
-  isReady: (routeValue: string) => boolean
-}
-
-/**
- * Adds resource resolution to useViewSwap. The URL remains the source of truth,
- * while the selected object is refreshed from the latest query result. A route
- * is rejected only after its relevant data source is ready and no longer
- * loading, because Pinia Colada may expose stale cached items during a refresh.
- */
-export function useRoutedViewSwap<T>(options: RoutedViewSwapOptions<T>) {
-  const swap = useViewSwap({
-    key: options.key,
-    detailValue: () => {
-      const selected = options.selected()
-      return selected ? options.getRouteValue(selected) : ''
-    },
-  })
-
-  function openDetail(item: T) {
-    if (!options.getRouteValue(item)) return
-    swap.openDetail(() => options.select(item))
-  }
-
-  function backToList() {
-    swap.backToList(() => options.select(undefined))
-  }
-
-  watchEffect(() => {
-    const routeValue = swap.queryValue.value
-    if (!routeValue) {
-      options.select(undefined)
-      return
-    }
-
-    const selected = options.items().find(item => options.getRouteValue(item) === routeValue)
-    if (selected) {
-      options.select(selected)
-    } else if (!options.isLoading(routeValue) && options.isReady(routeValue)) {
-      backToList()
-    }
-  })
-
-  return {
-    view: swap.view,
-    direction: swap.direction,
-    queryValue: swap.queryValue,
-    openDetail,
-    backToList,
-  }
 }

--- a/apps/web/src/composables/useViewSwap.ts
+++ b/apps/web/src/composables/useViewSwap.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 // Motion for the in-place list <-> detail swap (a frontend page switch with no
@@ -23,24 +23,19 @@ export type SwapDirection = 'forward' | 'back'
  * when `view === 'list'` and the detail when `view === 'detail'`, wrapped in the
  * SwapTransition component. `direction` tells that component which way to slide.
  *
- * Pass `queryKey` to mirror the detail state into the URL as `?<queryKey>=<value>`
+ * Pass `queryKey` to mirror the open resource into the URL as `?<queryKey>=<value>`
  * (written with router.replace — an in-page state sync, not a navigation, same
- * contract as useSyncedQueryParam). The value is whatever the page hands
- * `openDetail` — pages pass the open resource's stable ID so a refresh can
- * restore the exact item (the page resolves `queryValue` back to an object
- * itself; this composable stays ignorant of what the value means). Mirroring
- * into the query is also required for the settings-sidebar
- * "re-click the tab you're already on" affordance to work: sidebar navigation
- * is a plain `router.push({ name })` with no query. If detail state lives ONLY
- * in a local ref, re-clicking the current tab resolves to the exact same
- * location the router is already at, so Vue Router treats it as a duplicate
- * push and silently drops it — the page never hears about it, so a detail view
- * left open has no way to snap back to its list. Mirroring the value into the
- * query makes list-vs-detail part of the resolved location, so leaving detail
- * open changes the URL, and a bare re-push to the tab's un-queried route is a
- * genuinely different destination that the router actually navigates to. Omit
- * `queryKey` for swaps that don't need this (e.g. a swap nested inside another
- * already-synced tab) — `view` then stays purely local, as before.
+ * contract as useSyncedQueryParam). The value is the open resource's stable ID
+ * (or a page-owned encoding such as `speech:<id>`), so a refresh can restore the
+ * exact item. Query mirroring is also required for the settings-sidebar
+ * "re-click the tab you're already on" affordance: sidebar navigation is a plain
+ * `router.push({ name })` with no query. If detail state lives ONLY in a local
+ * ref, re-clicking the current tab resolves to the exact same location the
+ * router is already at, so Vue Router treats it as a duplicate push and silently
+ * drops it — the page never hears about it. Mirroring the value into the query
+ * makes list-vs-detail part of the resolved location. Omit `queryKey` for swaps
+ * that don't need this (e.g. a swap nested inside another already-synced tab) —
+ * `view` then stays purely local.
  *
  * The `queryKey` MUST be unique per settings page. `useRoute()` reads the ONE
  * global route, and every settings page stays mounted under <KeepAlive>
@@ -48,8 +43,11 @@ export type SwapDirection = 'forward' | 'back'
  * watchers keep reading the live URL. If two pages shared a key, the cached
  * page would read the active page's value off the shared key, fail to resolve
  * that foreign ID against its own list, and strip the query — snapping the
- * active page's detail shut. Distinct keys keep each page's URL state its own;
- * a page only ever sees the key it wrote, so there is nothing to fight over.
+ * active page's detail shut. Distinct keys keep each page's URL state its own.
+ *
+ * For resource resolution (URL → selected object, invalid id → list, loading
+ * gate), use `useRoutedViewSwap` on top of this. This composable only owns
+ * motion + query presence.
  */
 export function useViewSwap(queryKey?: string) {
   const route = queryKey ? useRoute() : null
@@ -67,11 +65,11 @@ export function useViewSwap(queryKey?: string) {
   const direction = ref<SwapDirection>('forward')
 
   if (queryKey && route && router) {
-    // Reacts to the query flag changing for ANY reason — our own replace()
+    // Reacts to the query value changing for ANY reason — our own replace()
     // calls below, but also external navigations we don't control: a sidebar
     // re-click that lands on the un-queried route, or the user's own browser
     // back/forward. Whatever the cause, `view` must follow the URL, and losing
-    // the flag always reads as "closing", so it always animates as 'back'.
+    // the value always reads as "closing", so it always animates as 'back'.
     // The equality guard skips the case where openDetail/backToList already
     // applied this exact state locally before writing the query, so the two
     // never fight over `direction` for the same transition.
@@ -82,16 +80,18 @@ export function useViewSwap(queryKey?: string) {
     })
   }
 
-  // `detailValue` is what lands in the URL. Falls back to '1' so an unkeyed or
-  // legacy call still flips the view and keeps the sidebar-re-click affordance
-  // — but keyed pages should always pass the resource ID, or a refresh has
-  // nothing to restore.
+  // Keyed pages must pass a non-empty resource value — no silent '1' fallback.
+  // Unkeyed swaps ignore the argument (pure local list ↔ detail).
   function openDetail(detailValue?: string) {
+    if (queryKey && route && router) {
+      if (!detailValue) return
+      direction.value = 'forward'
+      view.value = 'detail'
+      void router.replace({ query: { ...route.query, [queryKey]: detailValue } })
+      return
+    }
     direction.value = 'forward'
     view.value = 'detail'
-    if (queryKey && route && router) {
-      void router.replace({ query: { ...route.query, [queryKey]: detailValue || '1' } })
-    }
   }
 
   function backToList() {
@@ -104,4 +104,89 @@ export function useViewSwap(queryKey?: string) {
   }
 
   return { view, direction, queryValue, openDetail, backToList }
+}
+
+export interface RoutedViewSwapOptions<T> {
+  /** Page-owned query key — must be unique under settings KeepAlive. */
+  key: string
+  items: () => readonly T[]
+  selected: () => T | undefined
+  select: (item: T | undefined) => void
+  getRouteValue: (item: T) => string
+  /**
+   * True while the source that would resolve `routeValue` is still fetching.
+   * Used with `isReady` so a missing match during a stale-cache refresh does
+   * not snap the detail shut before fresh data arrives.
+   */
+  isLoading: (routeValue: string) => boolean
+  /**
+   * True once the relevant data source has answered at least once
+   * (`data !== undefined`). Only then is "not in list" treated as deleted.
+   */
+  isReady: (routeValue: string) => boolean
+}
+
+/**
+ * Adds resource resolution to useViewSwap. The URL remains the source of truth;
+ * the selected object is a projection of the latest query result. A route is
+ * rejected only after its relevant data source is ready and no longer loading.
+ *
+ * `isDetailLoading` is true when the URL asks for detail but the object is not
+ * resolved yet — DetailPane can show a skeleton instead of an empty shell.
+ */
+export function useRoutedViewSwap<T>(options: RoutedViewSwapOptions<T>) {
+  const swap = useViewSwap(options.key)
+
+  function openDetail(item: T) {
+    const routeValue = options.getRouteValue(item)
+    if (!routeValue) return
+    options.select(item)
+    swap.openDetail(routeValue)
+  }
+
+  function backToList() {
+    options.select(undefined)
+    swap.backToList()
+  }
+
+  watchEffect(() => {
+    const routeValue = swap.queryValue.value
+    if (!routeValue) {
+      // URL closed detail (sidebar re-click, browser back, etc.) — drop
+      // selection only once view has followed the URL to list. openDetail
+      // selects first, then replace() updates the query; clearing while view is
+      // still 'detail' would wipe that optimistic selection before the route
+      // catches up.
+      if (swap.view.value === 'list' && options.selected() !== undefined) {
+        options.select(undefined)
+      }
+      return
+    }
+
+    const selected = options.items().find(item => options.getRouteValue(item) === routeValue)
+    if (selected) {
+      options.select(selected)
+      return
+    }
+
+    if (!options.isLoading(routeValue) && options.isReady(routeValue)) {
+      backToList()
+    }
+  })
+
+  const isDetailLoading = computed(() => {
+    const routeValue = swap.queryValue.value
+    if (!routeValue) return false
+    if (options.selected() !== undefined) return false
+    return options.isLoading(routeValue) || !options.isReady(routeValue)
+  })
+
+  return {
+    view: swap.view,
+    direction: swap.direction,
+    queryValue: swap.queryValue,
+    isDetailLoading,
+    openDetail,
+    backToList,
+  }
 }

--- a/apps/web/src/composables/useViewSwap.ts
+++ b/apps/web/src/composables/useViewSwap.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 // Motion for the in-place list <-> detail swap (a frontend page switch with no
@@ -18,40 +18,52 @@ import { useRoute, useRouter } from 'vue-router'
 
 export type SwapDirection = 'forward' | 'back'
 
+type ViewSwapQuerySync = {
+  key: string
+  detailValue: () => string
+}
+
 /**
  * Drives a two-pane (list <-> detail) swap inside a single page. Render the list
  * when `view === 'list'` and the detail when `view === 'detail'`, wrapped in the
  * SwapTransition component. `direction` tells that component which way to slide.
  *
- * Pass `queryKey` to mirror the detail state into the URL as `?<queryKey>=1`
- * (written with router.replace — an in-page state sync, not a navigation, same
- * contract as useSyncedQueryParam). This is required for the settings-sidebar
+ * Pass a query config whose `detailValue` returns a stable resource ID. It is
+ * written with router.replace — an in-page state sync, not a navigation, same
+ * contract as useSyncedQueryParam. The resource ID lets a refresh restore the
+ * exact item. Query mirroring is required for the settings-sidebar
  * "re-click the tab you're already on" affordance to work: sidebar navigation
  * is a plain `router.push({ name })` with no query. If detail state lives ONLY
  * in a local ref, re-clicking the current tab resolves to the exact same
  * location the router is already at, so Vue Router treats it as a duplicate
  * push and silently drops it — the page never hears about it, so a detail view
- * left open has no way to snap back to its list. Mirroring the flag into the
+ * left open has no way to snap back to its list. Mirroring the state into the
  * query makes list-vs-detail part of the resolved location, so leaving detail
  * open changes the URL, and a bare re-push to the tab's un-queried route is a
  * genuinely different destination that the router actually navigates to. Omit
- * `queryKey` for swaps that don't need this (e.g. a swap nested inside another
+ * the config for swaps that don't need this (e.g. a swap nested inside another
  * already-synced tab) — `view` then stays purely local, as before.
  */
-export function useViewSwap(queryKey?: string) {
+export function useViewSwap(querySync?: ViewSwapQuerySync) {
+  const queryKey = querySync?.key
   const route = queryKey ? useRoute() : null
   const router = queryKey ? useRouter() : null
 
-  const queryDetail = computed(() => !!queryKey && route!.query[queryKey] === '1')
+  const queryValue = computed(() => {
+    if (!queryKey || !route) return ''
+    const value = route.query[queryKey]
+    return typeof value === 'string' ? value : ''
+  })
+  const queryDetail = computed(() => queryValue.value.length > 0)
   const view = ref<'list' | 'detail'>(queryDetail.value ? 'detail' : 'list')
   const direction = ref<SwapDirection>('forward')
 
   if (queryKey && route && router) {
-    // Reacts to the query flag changing for ANY reason — our own replace()
+    // Reacts to the query value changing for ANY reason — our own replace()
     // calls below, but also external navigations we don't control: a sidebar
     // re-click that lands on the un-queried route, or the user's own browser
     // back/forward. Whatever the cause, `view` must follow the URL, and losing
-    // the flag always reads as "closing", so it always animates as 'back'.
+    // the value always reads as "closing", so it always animates as 'back'.
     // The equality guard skips the case where openDetail/backToList already
     // applied this exact state locally before writing the query, so the two
     // never fight over `direction` for the same transition.
@@ -67,7 +79,9 @@ export function useViewSwap(queryKey?: string) {
     onSwitched?.()
     view.value = 'detail'
     if (queryKey && route && router) {
-      void router.replace({ query: { ...route.query, [queryKey]: '1' } })
+      const detailValue = querySync?.detailValue()
+      if (!detailValue) return
+      void router.replace({ query: { ...route.query, [queryKey]: detailValue } })
     }
   }
 
@@ -81,5 +95,63 @@ export function useViewSwap(queryKey?: string) {
     }
   }
 
-  return { view, direction, openDetail, backToList }
+  return { view, direction, queryValue, openDetail, backToList }
+}
+
+interface RoutedViewSwapOptions<T> {
+  key: string
+  items: () => readonly T[]
+  selected: () => T | undefined
+  select: (item: T | undefined) => void
+  getRouteValue: (item: T) => string
+  isLoading: (routeValue: string) => boolean
+  isReady: (routeValue: string) => boolean
+}
+
+/**
+ * Adds resource resolution to useViewSwap. The URL remains the source of truth,
+ * while the selected object is refreshed from the latest query result. A route
+ * is rejected only after its relevant data source is ready and no longer
+ * loading, because Pinia Colada may expose stale cached items during a refresh.
+ */
+export function useRoutedViewSwap<T>(options: RoutedViewSwapOptions<T>) {
+  const swap = useViewSwap({
+    key: options.key,
+    detailValue: () => {
+      const selected = options.selected()
+      return selected ? options.getRouteValue(selected) : ''
+    },
+  })
+
+  function openDetail(item: T) {
+    if (!options.getRouteValue(item)) return
+    swap.openDetail(() => options.select(item))
+  }
+
+  function backToList() {
+    swap.backToList(() => options.select(undefined))
+  }
+
+  watchEffect(() => {
+    const routeValue = swap.queryValue.value
+    if (!routeValue) {
+      options.select(undefined)
+      return
+    }
+
+    const selected = options.items().find(item => options.getRouteValue(item) === routeValue)
+    if (selected) {
+      options.select(selected)
+    } else if (!options.isLoading(routeValue) && options.isReady(routeValue)) {
+      backToList()
+    }
+  })
+
+  return {
+    view: swap.view,
+    direction: swap.direction,
+    queryValue: swap.queryValue,
+    openDetail,
+    backToList,
+  }
 }

--- a/apps/web/src/pages/email/index.vue
+++ b/apps/web/src/pages/email/index.vue
@@ -20,7 +20,7 @@ import AddEmailProvider from './components/add-email-provider.vue'
 import ProviderSetting from './components/provider-setting.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import EmailProviderIcon from '@/components/email-provider-icon/index.vue'
@@ -28,7 +28,7 @@ import EmailProviderIcon from '@/components/email-provider-icon/index.vue'
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providerData } = useQuery({
+const { data: providerData, isLoading: providersLoading } = useQuery({
   key: () => ['email-providers'],
   query: async () => {
     const { data } = await getEmailProviders({ throwOnError: true })
@@ -39,15 +39,22 @@ const { data: providerData } = useQuery({
 const curProvider = ref<EmailProviderResponse>()
 provide('curEmailProvider', curProvider)
 
-// 'detail' query key: see useViewSwap.ts — makes re-clicking Email in the
-// settings sidebar while a provider's detail is open actually navigate back.
-const { view, direction, openDetail, backToList } = useViewSwap('detail')
 const searchQuery = ref('')
 const openStatus = reactive({ addOpen: false })
 
 const providers = computed<EmailProviderResponse[]>(() =>
   Array.isArray(providerData.value) ? providerData.value : [],
 )
+
+const { view, direction, openDetail: openProvider, backToList: closeProvider } = useRoutedViewSwap({
+  key: 'provider',
+  items: () => providers.value,
+  selected: () => curProvider.value,
+  select: provider => curProvider.value = provider,
+  getRouteValue: provider => provider.id ?? '',
+  isLoading: () => providersLoading.value,
+  isReady: () => providerData.value !== undefined,
+})
 
 const showSearch = computed(() => providers.value.length > 0)
 
@@ -58,25 +65,6 @@ const filteredProviders = computed(() => {
     (p.name ?? '').toLowerCase().includes(keyword)
     || (p.provider ?? '').toLowerCase().includes(keyword),
   )
-})
-
-function openProvider(provider: EmailProviderResponse) {
-  curProvider.value = provider
-  openDetail()
-}
-
-// Keep the open provider synced with refreshed data; if it was deleted while
-// open, fall back to the list.
-watch(providers, (list) => {
-  const currentId = curProvider.value?.id
-  if (!currentId) return
-  const stillExists = list.find(p => p.id === currentId)
-  if (stillExists) {
-    curProvider.value = stillExists
-  }
-  else if (view.value === 'detail') {
-    backToList()
-  }
 })
 
 // A provider may have been created in the add dialog — refresh on close.
@@ -175,7 +163,7 @@ watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
       v-else
       width="narrow"
       :back-label="t('email.title')"
-      @back="backToList()"
+      @back="closeProvider"
     >
       <ProviderSetting v-if="curProvider?.id" />
     </DetailPane>

--- a/apps/web/src/pages/email/index.vue
+++ b/apps/web/src/pages/email/index.vue
@@ -20,7 +20,7 @@ import AddEmailProvider from './components/add-email-provider.vue'
 import ProviderSetting from './components/provider-setting.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import EmailProviderIcon from '@/components/email-provider-icon/index.vue'
@@ -28,7 +28,7 @@ import EmailProviderIcon from '@/components/email-provider-icon/index.vue'
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providerData } = useQuery({
+const { data: providerData, isLoading: providersLoading } = useQuery({
   key: () => ['email-providers'],
   query: async () => {
     const { data } = await getEmailProviders({ throwOnError: true })
@@ -39,17 +39,29 @@ const { data: providerData } = useQuery({
 const curProvider = ref<EmailProviderResponse>()
 provide('curEmailProvider', curProvider)
 
-// 'emailProvider' query key (unique per settings page — see useViewSwap.ts):
-// the open provider's ID lives in the URL, so a refresh restores the exact
-// detail view, and re-clicking Email in the settings sidebar while a detail is
-// open navigates back.
-const { view, direction, queryValue, openDetail, backToList } = useViewSwap('emailProvider')
 const searchQuery = ref('')
 const openStatus = reactive({ addOpen: false })
 
 const providers = computed<EmailProviderResponse[]>(() =>
   Array.isArray(providerData.value) ? providerData.value : [],
 )
+
+// Page-owned query key (unique under settings KeepAlive — see useViewSwap.ts).
+const {
+  view,
+  direction,
+  isDetailLoading,
+  openDetail: openProvider,
+  backToList: closeProvider,
+} = useRoutedViewSwap({
+  key: 'emailProvider',
+  items: () => providers.value,
+  selected: () => curProvider.value,
+  select: provider => curProvider.value = provider,
+  getRouteValue: provider => provider.id ?? '',
+  isLoading: () => providersLoading.value,
+  isReady: () => providerData.value !== undefined,
+})
 
 const showSearch = computed(() => providers.value.length > 0)
 
@@ -61,26 +73,6 @@ const filteredProviders = computed(() => {
     || (p.provider ?? '').toLowerCase().includes(keyword),
   )
 })
-
-function openProvider(provider: EmailProviderResponse) {
-  curProvider.value = provider
-  openDetail(provider.id)
-}
-
-// Resolve the URL's provider ID against the loaded list: restores the open
-// provider on refresh, follows refetched data, and falls back to the list if
-// it was deleted while open. Only treat "not found" as deleted once data has
-// actually arrived — the empty list during the initial fetch proves nothing.
-watch([queryValue, providers], ([id, list]) => {
-  if (!id) return
-  const found = list.find(p => p.id === id)
-  if (found) {
-    curProvider.value = found
-  }
-  else if (providerData.value !== undefined) {
-    backToList()
-  }
-}, { immediate: true })
 
 // A provider may have been created in the add dialog — refresh on close.
 watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
@@ -178,7 +170,8 @@ watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
       v-else
       width="narrow"
       :back-label="t('email.title')"
-      @back="backToList()"
+      :loading="isDetailLoading || !curProvider?.id"
+      @back="closeProvider"
     >
       <ProviderSetting v-if="curProvider?.id" />
     </DetailPane>

--- a/apps/web/src/pages/email/index.vue
+++ b/apps/web/src/pages/email/index.vue
@@ -20,7 +20,7 @@ import AddEmailProvider from './components/add-email-provider.vue'
 import ProviderSetting from './components/provider-setting.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
-import { useRoutedViewSwap } from '@/composables/useViewSwap'
+import { useViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import EmailProviderIcon from '@/components/email-provider-icon/index.vue'
@@ -28,7 +28,7 @@ import EmailProviderIcon from '@/components/email-provider-icon/index.vue'
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providerData, isLoading: providersLoading } = useQuery({
+const { data: providerData } = useQuery({
   key: () => ['email-providers'],
   query: async () => {
     const { data } = await getEmailProviders({ throwOnError: true })
@@ -39,22 +39,17 @@ const { data: providerData, isLoading: providersLoading } = useQuery({
 const curProvider = ref<EmailProviderResponse>()
 provide('curEmailProvider', curProvider)
 
+// 'emailProvider' query key (unique per settings page — see useViewSwap.ts):
+// the open provider's ID lives in the URL, so a refresh restores the exact
+// detail view, and re-clicking Email in the settings sidebar while a detail is
+// open navigates back.
+const { view, direction, queryValue, openDetail, backToList } = useViewSwap('emailProvider')
 const searchQuery = ref('')
 const openStatus = reactive({ addOpen: false })
 
 const providers = computed<EmailProviderResponse[]>(() =>
   Array.isArray(providerData.value) ? providerData.value : [],
 )
-
-const { view, direction, openDetail: openProvider, backToList: closeProvider } = useRoutedViewSwap({
-  key: 'provider',
-  items: () => providers.value,
-  selected: () => curProvider.value,
-  select: provider => curProvider.value = provider,
-  getRouteValue: provider => provider.id ?? '',
-  isLoading: () => providersLoading.value,
-  isReady: () => providerData.value !== undefined,
-})
 
 const showSearch = computed(() => providers.value.length > 0)
 
@@ -66,6 +61,26 @@ const filteredProviders = computed(() => {
     || (p.provider ?? '').toLowerCase().includes(keyword),
   )
 })
+
+function openProvider(provider: EmailProviderResponse) {
+  curProvider.value = provider
+  openDetail(provider.id)
+}
+
+// Resolve the URL's provider ID against the loaded list: restores the open
+// provider on refresh, follows refetched data, and falls back to the list if
+// it was deleted while open. Only treat "not found" as deleted once data has
+// actually arrived — the empty list during the initial fetch proves nothing.
+watch([queryValue, providers], ([id, list]) => {
+  if (!id) return
+  const found = list.find(p => p.id === id)
+  if (found) {
+    curProvider.value = found
+  }
+  else if (providerData.value !== undefined) {
+    backToList()
+  }
+}, { immediate: true })
 
 // A provider may have been created in the add dialog — refresh on close.
 watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
@@ -163,7 +178,7 @@ watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
       v-else
       width="narrow"
       :back-label="t('email.title')"
-      @back="closeProvider"
+      @back="backToList()"
     >
       <ProviderSetting v-if="curProvider?.id" />
     </DetailPane>

--- a/apps/web/src/pages/memory/index.vue
+++ b/apps/web/src/pages/memory/index.vue
@@ -12,12 +12,12 @@ import ProviderSetting from './components/provider-setting.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 
 const { t } = useI18n()
 
-const { data: providerData } = useQuery({
+const { data: providerData, isLoading: providersLoading } = useQuery({
   key: () => ['memory-providers'],
   query: async () => {
     const { data } = await getMemoryProviders({ throwOnError: true })
@@ -35,11 +35,6 @@ const externalProviders = computed(() => providers.value.filter((p) => p.provide
 const curProvider = ref<AdaptersProviderGetResponse | null>(null)
 provide('curMemoryProvider', curProvider)
 
-// 'memoryBackend' query key (unique per settings page — see useViewSwap.ts):
-// the open backend's ID lives in the URL, so a refresh restores the exact
-// detail view, and re-clicking Memory in the settings sidebar while a detail
-// is open navigates back.
-const { view, direction, queryValue, openDetail, backToList } = useViewSwap('memoryBackend')
 const advancedOpen = ref(false)
 const openStatus = reactive({ addOpen: false })
 
@@ -54,27 +49,28 @@ const builtinRef = ref<InstanceType<typeof BuiltinConfig> | null>(null)
 // one-shot so a later manual collapse isn't fought by refreshed data.
 let didAutoOpen = false
 
-function openExternal(provider: AdaptersProviderGetResponse) {
-  curProvider.value = provider
-  openDetail(provider.id)
-}
+// Page-owned query key (unique under settings KeepAlive — see useViewSwap.ts).
+const {
+  view,
+  direction,
+  isDetailLoading,
+  openDetail: openExternal,
+  backToList: closeExternal,
+} = useRoutedViewSwap({
+  key: 'memoryBackend',
+  items: () => externalProviders.value,
+  selected: () => curProvider.value ?? undefined,
+  select: provider => curProvider.value = provider ?? null,
+  getRouteValue: provider => provider.id ?? '',
+  isLoading: () => providersLoading.value,
+  isReady: () => providerData.value !== undefined,
+})
 
 watch(externalProviders, (list) => {
   if (!didAutoOpen && list.length > 0) {
     advancedOpen.value = true
     didAutoOpen = true
   }
-}, { immediate: true })
-
-// Resolve the URL's backend ID against the loaded list: restores the open
-// backend on refresh, follows refetched data, and falls back to the list if
-// it was deleted while open. Only treat "not found" as deleted once data has
-// actually arrived — the empty list during the initial fetch proves nothing.
-watch([queryValue, externalProviders], ([id, list]) => {
-  if (!id) return
-  const found = list.find((p) => p.id === id)
-  if (found) curProvider.value = found
-  else if (providerData.value !== undefined) backToList()
 }, { immediate: true })
 </script>
 
@@ -171,7 +167,8 @@ watch([queryValue, externalProviders], ([id, list]) => {
       v-else
       width="narrow"
       :back-label="t('sidebar.memory')"
-      @back="backToList()"
+      :loading="isDetailLoading || !curProvider?.id"
+      @back="closeExternal"
     >
       <ProviderSetting v-if="curProvider?.id" />
     </DetailPane>

--- a/apps/web/src/pages/memory/index.vue
+++ b/apps/web/src/pages/memory/index.vue
@@ -12,12 +12,12 @@ import ProviderSetting from './components/provider-setting.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
-import { useRoutedViewSwap } from '@/composables/useViewSwap'
+import { useViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 
 const { t } = useI18n()
 
-const { data: providerData, isLoading: providersLoading } = useQuery({
+const { data: providerData } = useQuery({
   key: () => ['memory-providers'],
   query: async () => {
     const { data } = await getMemoryProviders({ throwOnError: true })
@@ -35,6 +35,11 @@ const externalProviders = computed(() => providers.value.filter((p) => p.provide
 const curProvider = ref<AdaptersProviderGetResponse | null>(null)
 provide('curMemoryProvider', curProvider)
 
+// 'memoryBackend' query key (unique per settings page — see useViewSwap.ts):
+// the open backend's ID lives in the URL, so a refresh restores the exact
+// detail view, and re-clicking Memory in the settings sidebar while a detail
+// is open navigates back.
+const { view, direction, queryValue, openDetail, backToList } = useViewSwap('memoryBackend')
 const advancedOpen = ref(false)
 const openStatus = reactive({ addOpen: false })
 
@@ -49,21 +54,27 @@ const builtinRef = ref<InstanceType<typeof BuiltinConfig> | null>(null)
 // one-shot so a later manual collapse isn't fought by refreshed data.
 let didAutoOpen = false
 
-const { view, direction, openDetail: openExternal, backToList: closeExternal } = useRoutedViewSwap({
-  key: 'provider',
-  items: () => externalProviders.value,
-  selected: () => curProvider.value ?? undefined,
-  select: provider => curProvider.value = provider ?? null,
-  getRouteValue: provider => provider.id ?? '',
-  isLoading: () => providersLoading.value,
-  isReady: () => providerData.value !== undefined,
-})
+function openExternal(provider: AdaptersProviderGetResponse) {
+  curProvider.value = provider
+  openDetail(provider.id)
+}
 
 watch(externalProviders, (list) => {
   if (!didAutoOpen && list.length > 0) {
     advancedOpen.value = true
     didAutoOpen = true
   }
+}, { immediate: true })
+
+// Resolve the URL's backend ID against the loaded list: restores the open
+// backend on refresh, follows refetched data, and falls back to the list if
+// it was deleted while open. Only treat "not found" as deleted once data has
+// actually arrived — the empty list during the initial fetch proves nothing.
+watch([queryValue, externalProviders], ([id, list]) => {
+  if (!id) return
+  const found = list.find((p) => p.id === id)
+  if (found) curProvider.value = found
+  else if (providerData.value !== undefined) backToList()
 }, { immediate: true })
 </script>
 
@@ -160,7 +171,7 @@ watch(externalProviders, (list) => {
       v-else
       width="narrow"
       :back-label="t('sidebar.memory')"
-      @back="closeExternal"
+      @back="backToList()"
     >
       <ProviderSetting v-if="curProvider?.id" />
     </DetailPane>

--- a/apps/web/src/pages/memory/index.vue
+++ b/apps/web/src/pages/memory/index.vue
@@ -12,12 +12,12 @@ import ProviderSetting from './components/provider-setting.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 
 const { t } = useI18n()
 
-const { data: providerData } = useQuery({
+const { data: providerData, isLoading: providersLoading } = useQuery({
   key: () => ['memory-providers'],
   query: async () => {
     const { data } = await getMemoryProviders({ throwOnError: true })
@@ -35,10 +35,6 @@ const externalProviders = computed(() => providers.value.filter((p) => p.provide
 const curProvider = ref<AdaptersProviderGetResponse | null>(null)
 provide('curMemoryProvider', curProvider)
 
-// 'detail' query key: mirrors detail-open into the URL so re-clicking Memory
-// in the settings sidebar while a backend's detail is open actually navigates
-// back (see useViewSwap.ts).
-const { view, direction, openDetail, backToList } = useViewSwap('detail')
 const advancedOpen = ref(false)
 const openStatus = reactive({ addOpen: false })
 
@@ -53,23 +49,20 @@ const builtinRef = ref<InstanceType<typeof BuiltinConfig> | null>(null)
 // one-shot so a later manual collapse isn't fought by refreshed data.
 let didAutoOpen = false
 
-function openExternal(provider: AdaptersProviderGetResponse) {
-  curProvider.value = provider
-  openDetail()
-}
+const { view, direction, openDetail: openExternal, backToList: closeExternal } = useRoutedViewSwap({
+  key: 'provider',
+  items: () => externalProviders.value,
+  selected: () => curProvider.value ?? undefined,
+  select: provider => curProvider.value = provider ?? null,
+  getRouteValue: provider => provider.id ?? '',
+  isLoading: () => providersLoading.value,
+  isReady: () => providerData.value !== undefined,
+})
 
 watch(externalProviders, (list) => {
   if (!didAutoOpen && list.length > 0) {
     advancedOpen.value = true
     didAutoOpen = true
-  }
-  const currentId = curProvider.value?.id
-  if (!currentId) return
-  const stillExists = list.find((p) => p.id === currentId)
-  if (stillExists) {
-    curProvider.value = stillExists
-  } else if (view.value === 'detail') {
-    backToList()
   }
 }, { immediate: true })
 </script>
@@ -167,7 +160,7 @@ watch(externalProviders, (list) => {
       v-else
       width="narrow"
       :back-label="t('sidebar.memory')"
-      @back="backToList()"
+      @back="closeExternal"
     >
       <ProviderSetting v-if="curProvider?.id" />
     </DetailPane>

--- a/apps/web/src/pages/providers/index.test.ts
+++ b/apps/web/src/pages/providers/index.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import type { Component, Ref, Slots } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  providerData: undefined as unknown as Ref<Array<Record<string, unknown>> | undefined>,
+  providersLoading: undefined as unknown as Ref<boolean>,
+  modelData: undefined as unknown as Ref<Array<Record<string, unknown>>>,
+  route: { query: {} as Record<string, string> },
+  replace: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
+  useRouter: () => ({ replace: mocks.replace }),
+}))
+
+vi.mock('@pinia/colada', async () => {
+  const { ref } = await import('vue')
+  mocks.providerData = ref()
+  mocks.providersLoading = ref(false)
+  mocks.modelData = ref([])
+  return {
+    useQuery: ({ key }: { key: () => string[] }) => key()[0] === 'providers'
+      ? { data: mocks.providerData, isLoading: mocks.providersLoading }
+      : { data: mocks.modelData, isLoading: ref(false) },
+  }
+})
+
+vi.mock('@memohai/sdk', () => ({
+  getModels: vi.fn(),
+  getProviders: vi.fn(),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('lucide-vue-next', () => ({
+  Boxes: () => h('span'),
+  Box: () => h('span'),
+  ChevronRight: () => h('span'),
+  Plus: () => h('span'),
+  Search: () => h('span'),
+}))
+
+vi.mock('@felinic/ui', () => {
+  const Passthrough = (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.())
+  return {
+    Button: Passthrough,
+    Empty: Passthrough,
+    EmptyContent: Passthrough,
+    EmptyDescription: Passthrough,
+    EmptyHeader: Passthrough,
+    EmptyMedia: Passthrough,
+    EmptyTitle: Passthrough,
+    InputGroup: Passthrough,
+    InputGroupAddon: Passthrough,
+    InputGroupInput: Passthrough,
+  }
+})
+
+vi.mock('@/components/add-provider/index.vue', () => ({ default: () => h('div') }))
+vi.mock('@/components/provider-icon/index.vue', () => ({ default: () => h('span') }))
+vi.mock('@/components/settings/backend-card.vue', () => ({
+  default: {
+    props: ['name'],
+    emits: ['click'],
+    setup(props: { name: string }, { emit }: { emit: (event: 'click') => void }) {
+      return () => h('button', {
+        'data-provider': props.name,
+        'onClick': () => emit('click'),
+      }, props.name)
+    },
+  },
+}))
+vi.mock('@/components/settings/detail-pane.vue', () => ({
+  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.()),
+}))
+vi.mock('@/components/settings/swap-transition.vue', () => ({
+  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.()),
+}))
+vi.mock('@/components/page-shell/index.vue', () => ({
+  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', [slots.actions?.(), slots.default?.()]),
+}))
+vi.mock('./model-setting.vue', () => ({
+  default: {
+    props: ['provider'],
+    setup(props: { provider?: { id?: string, name?: string } }) {
+      return () => h('div', { 'data-testid': 'provider-detail' }, `${props.provider?.id}:${props.provider?.name}`)
+    },
+  },
+}))
+
+let ProviderPage: Component
+
+async function mountPage() {
+  const root = document.createElement('div')
+  document.body.append(root)
+  const app = createApp(ProviderPage)
+  app.mount(root)
+  await nextTick()
+  return { app, root }
+}
+
+describe('provider route state', () => {
+  beforeEach(async () => {
+    ProviderPage = (await import('./index.vue')).default
+    mocks.providerData.value = [
+      { id: 'provider-one', name: 'One', enable: true },
+      { id: 'provider-two', name: 'Two', enable: true },
+    ]
+    mocks.providersLoading.value = false
+    mocks.modelData.value = []
+    mocks.route.query = {}
+    mocks.replace.mockReset()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('waits for a stale provider query to refresh before resolving the URL', async () => {
+    mocks.route.query = { provider: 'provider-two' }
+    mocks.providerData.value = [
+      { id: 'provider-one', name: 'One', enable: true },
+    ]
+    mocks.providersLoading.value = true
+
+    const { app, root } = await mountPage()
+
+    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(root.querySelector('[data-testid="provider-detail"]')).toBeNull()
+
+    mocks.providerData.value = [
+      { id: 'provider-one', name: 'One', enable: true },
+      { id: 'provider-two', name: 'Two', enable: true },
+    ]
+    mocks.providersLoading.value = false
+    await nextTick()
+
+    expect(root.querySelector('[data-testid="provider-detail"]')?.textContent).toBe('provider-two:Two')
+    app.unmount()
+  })
+
+  it('writes the selected provider ID instead of a shared detail flag', async () => {
+    const { app, root } = await mountPage()
+
+    ;(root.querySelector('[data-provider="Two"]') as HTMLButtonElement).click()
+    await nextTick()
+
+    expect(mocks.replace).toHaveBeenCalledWith({ query: { provider: 'provider-two' } })
+    expect(root.querySelector('[data-testid="provider-detail"]')?.textContent).toBe('provider-two:Two')
+    app.unmount()
+  })
+
+  it('returns to the list when the URL references a missing provider', async () => {
+    mocks.route.query = { provider: 'missing', tab: 'kept' }
+
+    const { app, root } = await mountPage()
+
+    expect(mocks.replace).toHaveBeenCalledWith({ query: { tab: 'kept' } })
+    expect(root.querySelector('[data-testid="provider-detail"]')).toBeNull()
+    app.unmount()
+  })
+})

--- a/apps/web/src/pages/providers/index.test.ts
+++ b/apps/web/src/pages/providers/index.test.ts
@@ -5,6 +5,7 @@ import type { Component, Ref, Slots } from 'vue'
 
 const mocks = vi.hoisted(() => ({
   providerData: undefined as unknown as Ref<Array<Record<string, unknown>> | undefined>,
+  providersLoading: undefined as unknown as Ref<boolean>,
   modelData: undefined as unknown as Ref<Array<Record<string, unknown>>>,
   route: { query: {} as Record<string, string> },
   replace: vi.fn(),
@@ -18,11 +19,12 @@ vi.mock('vue-router', () => ({
 vi.mock('@pinia/colada', async () => {
   const { ref } = await import('vue')
   mocks.providerData = ref()
+  mocks.providersLoading = ref(false)
   mocks.modelData = ref([])
   return {
     useQuery: ({ key }: { key: () => string[] }) => key()[0] === 'providers'
-      ? { data: mocks.providerData }
-      : { data: mocks.modelData },
+      ? { data: mocks.providerData, isLoading: mocks.providersLoading }
+      : { data: mocks.modelData, isLoading: ref(false) },
   }
 })
 
@@ -56,6 +58,7 @@ vi.mock('@felinic/ui', () => {
     InputGroup: Passthrough,
     InputGroupAddon: Passthrough,
     InputGroupInput: Passthrough,
+    Skeleton: (props: { class?: string }) => h('div', { 'data-slot': 'skeleton', class: props.class }),
   }
 })
 
@@ -74,7 +77,21 @@ vi.mock('@/components/settings/backend-card.vue', () => ({
   },
 }))
 vi.mock('@/components/settings/detail-pane.vue', () => ({
-  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.()),
+  default: {
+    props: ['backLabel', 'width', 'loading'],
+    emits: ['back'],
+    setup(
+      props: { loading?: boolean },
+      { slots, emit }: { slots: Slots, emit: (event: 'back') => void },
+    ) {
+      return () => h('div', { 'data-testid': 'detail-pane' }, [
+        h('button', { 'data-testid': 'back', onClick: () => emit('back') }, 'back'),
+        props.loading
+          ? h('div', { 'data-testid': 'detail-pane-skeleton' })
+          : slots.default?.(),
+      ])
+    },
+  },
 }))
 vi.mock('@/components/settings/swap-transition.vue', () => ({
   default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.()),
@@ -110,6 +127,7 @@ describe('provider route state', () => {
       { id: 'provider-one', name: 'One', enable: true },
       { id: 'provider-two', name: 'Two', enable: true },
     ]
+    mocks.providersLoading.value = false
     mocks.modelData.value = []
     mocks.route.query = {}
     mocks.replace.mockReset()
@@ -119,21 +137,41 @@ describe('provider route state', () => {
     document.body.innerHTML = ''
   })
 
-  it('restores the detail pane from the provider query after data loads', async () => {
+  it('shows a detail skeleton while the URL provider is still loading', async () => {
     mocks.route.query = { provider: 'provider-two' }
     mocks.providerData.value = undefined
+    mocks.providersLoading.value = true
 
     const { app, root } = await mountPage()
+
+    expect(root.querySelector('[data-testid="detail-pane-skeleton"]')).not.toBeNull()
     expect(root.querySelector('[data-testid="provider-detail"]')).toBeNull()
     expect(mocks.replace).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('waits for a stale provider query to refresh before resolving the URL', async () => {
+    mocks.route.query = { provider: 'provider-two' }
+    mocks.providerData.value = [
+      { id: 'provider-one', name: 'One', enable: true },
+    ]
+    mocks.providersLoading.value = true
+
+    const { app, root } = await mountPage()
+
+    expect(mocks.replace).not.toHaveBeenCalled()
+    expect(root.querySelector('[data-testid="detail-pane-skeleton"]')).not.toBeNull()
+    expect(root.querySelector('[data-testid="provider-detail"]')).toBeNull()
 
     mocks.providerData.value = [
       { id: 'provider-one', name: 'One', enable: true },
       { id: 'provider-two', name: 'Two', enable: true },
     ]
+    mocks.providersLoading.value = false
     await nextTick()
 
     expect(root.querySelector('[data-testid="provider-detail"]')?.textContent).toBe('provider-two:Two')
+    expect(root.querySelector('[data-testid="detail-pane-skeleton"]')).toBeNull()
     app.unmount()
   })
 

--- a/apps/web/src/pages/providers/index.test.ts
+++ b/apps/web/src/pages/providers/index.test.ts
@@ -5,7 +5,6 @@ import type { Component, Ref, Slots } from 'vue'
 
 const mocks = vi.hoisted(() => ({
   providerData: undefined as unknown as Ref<Array<Record<string, unknown>> | undefined>,
-  providersLoading: undefined as unknown as Ref<boolean>,
   modelData: undefined as unknown as Ref<Array<Record<string, unknown>>>,
   route: { query: {} as Record<string, string> },
   replace: vi.fn(),
@@ -19,12 +18,11 @@ vi.mock('vue-router', () => ({
 vi.mock('@pinia/colada', async () => {
   const { ref } = await import('vue')
   mocks.providerData = ref()
-  mocks.providersLoading = ref(false)
   mocks.modelData = ref([])
   return {
     useQuery: ({ key }: { key: () => string[] }) => key()[0] === 'providers'
-      ? { data: mocks.providerData, isLoading: mocks.providersLoading }
-      : { data: mocks.modelData, isLoading: ref(false) },
+      ? { data: mocks.providerData }
+      : { data: mocks.modelData },
   }
 })
 
@@ -106,12 +104,12 @@ async function mountPage() {
 
 describe('provider route state', () => {
   beforeEach(async () => {
+    vi.resetModules()
     ProviderPage = (await import('./index.vue')).default
     mocks.providerData.value = [
       { id: 'provider-one', name: 'One', enable: true },
       { id: 'provider-two', name: 'Two', enable: true },
     ]
-    mocks.providersLoading.value = false
     mocks.modelData.value = []
     mocks.route.query = {}
     mocks.replace.mockReset()
@@ -121,23 +119,18 @@ describe('provider route state', () => {
     document.body.innerHTML = ''
   })
 
-  it('waits for a stale provider query to refresh before resolving the URL', async () => {
+  it('restores the detail pane from the provider query after data loads', async () => {
     mocks.route.query = { provider: 'provider-two' }
-    mocks.providerData.value = [
-      { id: 'provider-one', name: 'One', enable: true },
-    ]
-    mocks.providersLoading.value = true
+    mocks.providerData.value = undefined
 
     const { app, root } = await mountPage()
-
-    expect(mocks.replace).not.toHaveBeenCalled()
     expect(root.querySelector('[data-testid="provider-detail"]')).toBeNull()
+    expect(mocks.replace).not.toHaveBeenCalled()
 
     mocks.providerData.value = [
       { id: 'provider-one', name: 'One', enable: true },
       { id: 'provider-two', name: 'Two', enable: true },
     ]
-    mocks.providersLoading.value = false
     await nextTick()
 
     expect(root.querySelector('[data-testid="provider-detail"]')?.textContent).toBe('provider-two:Two')

--- a/apps/web/src/pages/providers/index.vue
+++ b/apps/web/src/pages/providers/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useQuery } from '@pinia/colada'
 import {
   Button,
@@ -21,7 +21,7 @@ import AddProvider from '@/components/add-provider/index.vue'
 import ProviderIcon from '@/components/provider-icon/index.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
-import { useRoutedViewSwap } from '@/composables/useViewSwap'
+import { useViewSwap } from '@/composables/useViewSwap'
 import { avatarInitials } from '@/composables/useAvatarInitials'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import PageShell from '@/components/page-shell/index.vue'
@@ -29,7 +29,7 @@ import ModelSetting from './model-setting.vue'
 
 const { t } = useI18n()
 
-const { data: providerData, isLoading: providersLoading } = useQuery({
+const { data: providerData } = useQuery({
   key: () => ['providers'],
   query: async () => {
     const { data } = await getProviders({ throwOnError: true })
@@ -47,6 +47,12 @@ const { data: modelData } = useQuery({
 
 const curProvider = ref<ProvidersGetResponse>()
 
+// 'provider' query key (unique per settings page — see useViewSwap.ts): the
+// open provider's ID lives in the URL, so a refresh (or a shared link) restores
+// the exact detail view, and re-clicking Providers in the settings sidebar
+// while a detail is open navigates back to the list instead of being dropped as
+// a duplicate push.
+const { view, direction, queryValue, openDetail, backToList } = useViewSwap('provider')
 const searchQuery = ref('')
 const addOpen = ref(false)
 
@@ -57,16 +63,6 @@ const providers = computed<ProvidersGetResponse[]>(() => {
     const be = b.enable !== false ? 1 : 0
     return be - ae
   })
-})
-
-const { view, direction, openDetail: openProvider, backToList: closeProvider } = useRoutedViewSwap({
-  key: 'provider',
-  items: () => providers.value,
-  selected: () => curProvider.value,
-  select: provider => curProvider.value = provider,
-  getRouteValue: provider => provider.id ?? '',
-  isLoading: () => providersLoading.value,
-  isReady: () => providerData.value !== undefined,
 })
 
 const modelCountByProvider = computed(() => {
@@ -105,6 +101,26 @@ function modelCount(id: string | undefined) {
   return id ? (modelCountByProvider.value[id] ?? 0) : 0
 }
 
+function openProvider(provider: ProvidersGetResponse) {
+  curProvider.value = provider
+  openDetail(provider.id)
+}
+
+// Resolve the URL's provider ID against the loaded list. One watch covers all
+// three cases: a refresh restores the open provider once data arrives, a
+// background refetch swaps in the fresh object, and a provider deleted while
+// open falls back to the gallery. The not-found branch must wait for data to
+// actually arrive — during the initial fetch the list is empty, which is not
+// evidence the provider is gone.
+watch([queryValue, providers], ([id, list]) => {
+  if (!id) return
+  const found = list.find((p) => p.id === id)
+  if (found) {
+    curProvider.value = found
+  } else if (providerData.value !== undefined) {
+    backToList()
+  }
+}, { immediate: true })
 </script>
 
 <template>
@@ -212,7 +228,7 @@ function modelCount(id: string | undefined) {
       v-else
       width="narrow"
       :back-label="t('sidebar.providers')"
-      @back="closeProvider"
+      @back="backToList()"
     >
       <ModelSetting
         v-if="curProvider?.id"

--- a/apps/web/src/pages/providers/index.vue
+++ b/apps/web/src/pages/providers/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useQuery } from '@pinia/colada'
 import {
   Button,
@@ -21,7 +21,7 @@ import AddProvider from '@/components/add-provider/index.vue'
 import ProviderIcon from '@/components/provider-icon/index.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import { avatarInitials } from '@/composables/useAvatarInitials'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import PageShell from '@/components/page-shell/index.vue'
@@ -29,7 +29,7 @@ import ModelSetting from './model-setting.vue'
 
 const { t } = useI18n()
 
-const { data: providerData } = useQuery({
+const { data: providerData, isLoading: providersLoading } = useQuery({
   key: () => ['providers'],
   query: async () => {
     const { data } = await getProviders({ throwOnError: true })
@@ -46,13 +46,6 @@ const { data: modelData } = useQuery({
 })
 
 const curProvider = ref<ProvidersGetResponse>()
-
-// 'provider' query key (unique per settings page — see useViewSwap.ts): the
-// open provider's ID lives in the URL, so a refresh (or a shared link) restores
-// the exact detail view, and re-clicking Providers in the settings sidebar
-// while a detail is open navigates back to the list instead of being dropped as
-// a duplicate push.
-const { view, direction, queryValue, openDetail, backToList } = useViewSwap('provider')
 const searchQuery = ref('')
 const addOpen = ref(false)
 
@@ -63,6 +56,23 @@ const providers = computed<ProvidersGetResponse[]>(() => {
     const be = b.enable !== false ? 1 : 0
     return be - ae
   })
+})
+
+// Page-owned query key (unique under settings KeepAlive — see useViewSwap.ts).
+const {
+  view,
+  direction,
+  isDetailLoading,
+  openDetail: openProvider,
+  backToList: closeProvider,
+} = useRoutedViewSwap({
+  key: 'provider',
+  items: () => providers.value,
+  selected: () => curProvider.value,
+  select: provider => curProvider.value = provider,
+  getRouteValue: provider => provider.id ?? '',
+  isLoading: () => providersLoading.value,
+  isReady: () => providerData.value !== undefined,
 })
 
 const modelCountByProvider = computed(() => {
@@ -100,27 +110,6 @@ function providerSubtitle(provider: ProvidersGetResponse) {
 function modelCount(id: string | undefined) {
   return id ? (modelCountByProvider.value[id] ?? 0) : 0
 }
-
-function openProvider(provider: ProvidersGetResponse) {
-  curProvider.value = provider
-  openDetail(provider.id)
-}
-
-// Resolve the URL's provider ID against the loaded list. One watch covers all
-// three cases: a refresh restores the open provider once data arrives, a
-// background refetch swaps in the fresh object, and a provider deleted while
-// open falls back to the gallery. The not-found branch must wait for data to
-// actually arrive — during the initial fetch the list is empty, which is not
-// evidence the provider is gone.
-watch([queryValue, providers], ([id, list]) => {
-  if (!id) return
-  const found = list.find((p) => p.id === id)
-  if (found) {
-    curProvider.value = found
-  } else if (providerData.value !== undefined) {
-    backToList()
-  }
-}, { immediate: true })
 </script>
 
 <template>
@@ -228,7 +217,8 @@ watch([queryValue, providers], ([id, list]) => {
       v-else
       width="narrow"
       :back-label="t('sidebar.providers')"
-      @back="backToList()"
+      :loading="isDetailLoading || !curProvider?.id"
+      @back="closeProvider"
     >
       <ModelSetting
         v-if="curProvider?.id"

--- a/apps/web/src/pages/providers/index.vue
+++ b/apps/web/src/pages/providers/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useQuery } from '@pinia/colada'
 import {
   Button,
@@ -21,7 +21,7 @@ import AddProvider from '@/components/add-provider/index.vue'
 import ProviderIcon from '@/components/provider-icon/index.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import { avatarInitials } from '@/composables/useAvatarInitials'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import PageShell from '@/components/page-shell/index.vue'
@@ -29,7 +29,7 @@ import ModelSetting from './model-setting.vue'
 
 const { t } = useI18n()
 
-const { data: providerData } = useQuery({
+const { data: providerData, isLoading: providersLoading } = useQuery({
   key: () => ['providers'],
   query: async () => {
     const { data } = await getProviders({ throwOnError: true })
@@ -47,11 +47,6 @@ const { data: modelData } = useQuery({
 
 const curProvider = ref<ProvidersGetResponse>()
 
-// 'detail' query key: mirrors detail-open into the URL so re-clicking Providers
-// in the settings sidebar while a provider's detail is open actually navigates
-// back to the list, instead of being dropped as a duplicate push (see
-// useViewSwap.ts).
-const { view, direction, openDetail, backToList } = useViewSwap('detail')
 const searchQuery = ref('')
 const addOpen = ref(false)
 
@@ -62,6 +57,16 @@ const providers = computed<ProvidersGetResponse[]>(() => {
     const be = b.enable !== false ? 1 : 0
     return be - ae
   })
+})
+
+const { view, direction, openDetail: openProvider, backToList: closeProvider } = useRoutedViewSwap({
+  key: 'provider',
+  items: () => providers.value,
+  selected: () => curProvider.value,
+  select: provider => curProvider.value = provider,
+  getRouteValue: provider => provider.id ?? '',
+  isLoading: () => providersLoading.value,
+  isReady: () => providerData.value !== undefined,
 })
 
 const modelCountByProvider = computed(() => {
@@ -100,23 +105,6 @@ function modelCount(id: string | undefined) {
   return id ? (modelCountByProvider.value[id] ?? 0) : 0
 }
 
-function openProvider(provider: ProvidersGetResponse) {
-  curProvider.value = provider
-  openDetail()
-}
-
-// Sync the open provider with refreshed data; if it was deleted while open,
-// fall back to the gallery.
-watch(providers, (list) => {
-  const currentId = curProvider.value?.id
-  if (!currentId) return
-  const stillExists = list.find((p) => p.id === currentId)
-  if (stillExists) {
-    curProvider.value = stillExists
-  } else if (view.value === 'detail') {
-    backToList()
-  }
-})
 </script>
 
 <template>
@@ -224,7 +212,7 @@ watch(providers, (list) => {
       v-else
       width="narrow"
       :back-label="t('sidebar.providers')"
-      @back="backToList()"
+      @back="closeProvider"
     >
       <ModelSetting
         v-if="curProvider?.id"

--- a/apps/web/src/pages/video/index.vue
+++ b/apps/web/src/pages/video/index.vue
@@ -11,14 +11,14 @@ import ProviderIcon from '@/components/provider-icon/index.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import VideoProviderSetting from './provider-setting.vue'
 
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providersData } = useQuery({
+const { data: providersData, isLoading: providersLoading } = useQuery({
   key: () => ['video-providers'],
   query: async () => {
     const { data } = await getVideoProviders({ throwOnError: true })
@@ -29,9 +29,6 @@ const { data: providersData } = useQuery({
 const curProvider = ref<VideoProviderResponse>()
 provide('curVideoProvider', curProvider)
 
-// 'detail' query key: see useViewSwap.ts — makes re-clicking Video in the
-// settings sidebar while a provider's detail is open actually navigate back.
-const { view, direction, openDetail, backToList } = useViewSwap('detail')
 const openStatus = reactive({ addOpen: false })
 
 const providers = computed<VideoProviderResponse[]>(() => {
@@ -39,16 +36,21 @@ const providers = computed<VideoProviderResponse[]>(() => {
   return [...list].sort((a, b) => Number(b.enable !== false) - Number(a.enable !== false))
 })
 
+const { view, direction, openDetail: openProvider, backToList: closeProvider } = useRoutedViewSwap({
+  key: 'provider',
+  items: () => providers.value,
+  selected: () => curProvider.value,
+  select: provider => curProvider.value = provider,
+  getRouteValue: provider => provider.id ?? '',
+  isLoading: () => providersLoading.value,
+  isReady: () => providersData.value !== undefined,
+})
+
 const addProviderNames = computed(() => providers.value.map((p) => ({ name: p.name })))
 
 function getInitials(name: string | undefined) {
   const label = name?.trim() ?? ''
   return label ? label.slice(0, 2).toUpperCase() : '?'
-}
-
-function openProvider(provider: VideoProviderResponse) {
-  curProvider.value = provider
-  openDetail()
 }
 
 async function importVideoModels(providerId: string) {
@@ -69,13 +71,6 @@ watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
   }
 })
 
-watch(providers, (list) => {
-  const id = curProvider.value?.id
-  if (!id) return
-  const found = list.find((p) => p.id === id)
-  if (found) curProvider.value = found
-  else if (view.value === 'detail') backToList()
-})
 </script>
 
 <template>
@@ -145,7 +140,7 @@ watch(providers, (list) => {
       v-else
       width="narrow"
       :back-label="t('video.title')"
-      @back="backToList()"
+      @back="closeProvider"
     >
       <VideoProviderSetting />
     </DetailPane>

--- a/apps/web/src/pages/video/index.vue
+++ b/apps/web/src/pages/video/index.vue
@@ -11,14 +11,14 @@ import ProviderIcon from '@/components/provider-icon/index.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
-import { useRoutedViewSwap } from '@/composables/useViewSwap'
+import { useViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import VideoProviderSetting from './provider-setting.vue'
 
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providersData, isLoading: providersLoading } = useQuery({
+const { data: providersData } = useQuery({
   key: () => ['video-providers'],
   query: async () => {
     const { data } = await getVideoProviders({ throwOnError: true })
@@ -29,6 +29,11 @@ const { data: providersData, isLoading: providersLoading } = useQuery({
 const curProvider = ref<VideoProviderResponse>()
 provide('curVideoProvider', curProvider)
 
+// 'videoProvider' query key (unique per settings page — see useViewSwap.ts):
+// the open provider's ID lives in the URL, so a refresh restores the exact
+// detail view, and re-clicking Video in the settings sidebar while a detail is
+// open navigates back.
+const { view, direction, queryValue, openDetail, backToList } = useViewSwap('videoProvider')
 const openStatus = reactive({ addOpen: false })
 
 const providers = computed<VideoProviderResponse[]>(() => {
@@ -36,21 +41,16 @@ const providers = computed<VideoProviderResponse[]>(() => {
   return [...list].sort((a, b) => Number(b.enable !== false) - Number(a.enable !== false))
 })
 
-const { view, direction, openDetail: openProvider, backToList: closeProvider } = useRoutedViewSwap({
-  key: 'provider',
-  items: () => providers.value,
-  selected: () => curProvider.value,
-  select: provider => curProvider.value = provider,
-  getRouteValue: provider => provider.id ?? '',
-  isLoading: () => providersLoading.value,
-  isReady: () => providersData.value !== undefined,
-})
-
 const addProviderNames = computed(() => providers.value.map((p) => ({ name: p.name })))
 
 function getInitials(name: string | undefined) {
   const label = name?.trim() ?? ''
   return label ? label.slice(0, 2).toUpperCase() : '?'
+}
+
+function openProvider(provider: VideoProviderResponse) {
+  curProvider.value = provider
+  openDetail(provider.id)
 }
 
 async function importVideoModels(providerId: string) {
@@ -71,6 +71,16 @@ watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
   }
 })
 
+// Resolve the URL's provider ID against the loaded list: restores the open
+// provider on refresh, follows refetched data, and falls back to the list if
+// it was deleted while open. Only treat "not found" as deleted once data has
+// actually arrived — the empty list during the initial fetch proves nothing.
+watch([queryValue, providers], ([id, list]) => {
+  if (!id) return
+  const found = list.find((p) => p.id === id)
+  if (found) curProvider.value = found
+  else if (providersData.value !== undefined) backToList()
+}, { immediate: true })
 </script>
 
 <template>
@@ -140,7 +150,7 @@ watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
       v-else
       width="narrow"
       :back-label="t('video.title')"
-      @back="closeProvider"
+      @back="backToList()"
     >
       <VideoProviderSetting />
     </DetailPane>

--- a/apps/web/src/pages/video/index.vue
+++ b/apps/web/src/pages/video/index.vue
@@ -11,14 +11,14 @@ import ProviderIcon from '@/components/provider-icon/index.vue'
 import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import VideoProviderSetting from './provider-setting.vue'
 
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providersData } = useQuery({
+const { data: providersData, isLoading: providersLoading } = useQuery({
   key: () => ['video-providers'],
   query: async () => {
     const { data } = await getVideoProviders({ throwOnError: true })
@@ -29,11 +29,6 @@ const { data: providersData } = useQuery({
 const curProvider = ref<VideoProviderResponse>()
 provide('curVideoProvider', curProvider)
 
-// 'videoProvider' query key (unique per settings page — see useViewSwap.ts):
-// the open provider's ID lives in the URL, so a refresh restores the exact
-// detail view, and re-clicking Video in the settings sidebar while a detail is
-// open navigates back.
-const { view, direction, queryValue, openDetail, backToList } = useViewSwap('videoProvider')
 const openStatus = reactive({ addOpen: false })
 
 const providers = computed<VideoProviderResponse[]>(() => {
@@ -41,16 +36,28 @@ const providers = computed<VideoProviderResponse[]>(() => {
   return [...list].sort((a, b) => Number(b.enable !== false) - Number(a.enable !== false))
 })
 
+// Page-owned query key (unique under settings KeepAlive — see useViewSwap.ts).
+const {
+  view,
+  direction,
+  isDetailLoading,
+  openDetail: openProvider,
+  backToList: closeProvider,
+} = useRoutedViewSwap({
+  key: 'videoProvider',
+  items: () => providers.value,
+  selected: () => curProvider.value,
+  select: provider => curProvider.value = provider,
+  getRouteValue: provider => provider.id ?? '',
+  isLoading: () => providersLoading.value,
+  isReady: () => providersData.value !== undefined,
+})
+
 const addProviderNames = computed(() => providers.value.map((p) => ({ name: p.name })))
 
 function getInitials(name: string | undefined) {
   const label = name?.trim() ?? ''
   return label ? label.slice(0, 2).toUpperCase() : '?'
-}
-
-function openProvider(provider: VideoProviderResponse) {
-  curProvider.value = provider
-  openDetail(provider.id)
 }
 
 async function importVideoModels(providerId: string) {
@@ -70,17 +77,6 @@ watch(() => openStatus.addOpen, (isOpen, wasOpen) => {
     queryCache.invalidateQueries({ key: ['video-models'] })
   }
 })
-
-// Resolve the URL's provider ID against the loaded list: restores the open
-// provider on refresh, follows refetched data, and falls back to the list if
-// it was deleted while open. Only treat "not found" as deleted once data has
-// actually arrived — the empty list during the initial fetch proves nothing.
-watch([queryValue, providers], ([id, list]) => {
-  if (!id) return
-  const found = list.find((p) => p.id === id)
-  if (found) curProvider.value = found
-  else if (providersData.value !== undefined) backToList()
-}, { immediate: true })
 </script>
 
 <template>
@@ -150,9 +146,10 @@ watch([queryValue, providers], ([id, list]) => {
       v-else
       width="narrow"
       :back-label="t('video.title')"
-      @back="backToList()"
+      :loading="isDetailLoading || !curProvider?.id"
+      @back="closeProvider"
     >
-      <VideoProviderSetting />
+      <VideoProviderSetting v-if="curProvider?.id" />
     </DetailPane>
   </SwapTransition>
 </template>

--- a/apps/web/src/pages/voice/index.vue
+++ b/apps/web/src/pages/voice/index.vue
@@ -12,7 +12,7 @@ import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import SectionGroup from '@/components/section-group/index.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import SpeechSetting from '@/pages/speech/components/provider-setting.vue'
 import TranscriptionSetting from '@/pages/transcription/provider-setting.vue'
@@ -20,14 +20,14 @@ import TranscriptionSetting from '@/pages/transcription/provider-setting.vue'
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: speechData } = useQuery({
+const { data: speechData, isLoading: speechLoading } = useQuery({
   key: () => ['speech-providers'],
   query: async () => {
     const { data } = await getSpeechProviders({ throwOnError: true })
     return data
   },
 })
-const { data: transcriptionData } = useQuery({
+const { data: transcriptionData, isLoading: transcriptionLoading } = useQuery({
   key: () => ['transcription-providers'],
   query: async () => {
     const { data } = await getTranscriptionProviders({ throwOnError: true })
@@ -40,14 +40,9 @@ const curTranscription = ref<AudioSpeechProviderResponse>()
 provide('curTtsProvider', curTts)
 provide('curTranscriptionProvider', curTranscription)
 
-// 'detail' query key: see useViewSwap.ts — makes re-clicking Voice in the
-// settings sidebar while a provider's detail is open actually navigate back.
-// detailKind (which of the two provider kinds) stays a local ref, not mirrored
-// into the query: the only way `view` flips to 'detail' is openSpeech/
-// openTranscription below, which always set detailKind first — there is no
-// path where the query alone drives view into 'detail' with detailKind unset.
-const { view, direction, openDetail, backToList } = useViewSwap('detail')
-const detailKind = ref<'speech' | 'transcription'>('speech')
+type VoiceDetailKind = 'speech' | 'transcription'
+type VoiceDetail = { kind: VoiceDetailKind, provider: AudioSpeechProviderResponse }
+const detailKind = ref<VoiceDetailKind>('speech')
 const openStatus = reactive({ addSpeechOpen: false, addTranscriptionOpen: false })
 
 async function importSpeechModels(providerId: string) {
@@ -83,6 +78,32 @@ const transcriptionProviders = computed<AudioSpeechProviderResponse[]>(() =>
   Array.isArray(transcriptionData.value) ? sortByEnabled(transcriptionData.value) : [],
 )
 
+const { view, direction, openDetail, backToList: closeProvider } = useRoutedViewSwap<VoiceDetail>({
+  key: 'provider',
+  items: () => [
+    ...speechProviders.value.map(provider => ({ kind: 'speech' as const, provider })),
+    ...transcriptionProviders.value.map(provider => ({ kind: 'transcription' as const, provider })),
+  ],
+  selected: () => {
+    const provider = detailKind.value === 'speech' ? curTts.value : curTranscription.value
+    return provider ? { kind: detailKind.value, provider } : undefined
+  },
+  select: (detail) => {
+    detailKind.value = detail?.kind ?? 'speech'
+    curTts.value = detail?.kind === 'speech' ? detail.provider : undefined
+    curTranscription.value = detail?.kind === 'transcription' ? detail.provider : undefined
+  },
+  getRouteValue: detail => `${detail.kind}:${detail.provider.id}`,
+  isLoading: routeValue => routeValue.startsWith('speech:')
+    ? speechLoading.value
+    : routeValue.startsWith('transcription:') && transcriptionLoading.value,
+  isReady: routeValue => routeValue.startsWith('speech:')
+    ? speechData.value !== undefined
+    : routeValue.startsWith('transcription:')
+      ? transcriptionData.value !== undefined
+      : true,
+})
+
 const addProviderNames = computed(() => [
   ...speechProviders.value.map((p) => ({ name: p.name })),
   ...transcriptionProviders.value.map((p) => ({ name: p.name })),
@@ -94,15 +115,11 @@ function getInitials(name: string | undefined) {
 }
 
 function openSpeech(provider: AudioSpeechProviderResponse) {
-  curTts.value = provider
-  detailKind.value = 'speech'
-  openDetail()
+  openDetail({ kind: 'speech', provider })
 }
 
 function openTranscription(provider: AudioSpeechProviderResponse) {
-  curTranscription.value = provider
-  detailKind.value = 'transcription'
-  openDetail()
+  openDetail({ kind: 'transcription', provider })
 }
 
 // Each section adds its own kind of provider, so refresh just that list when
@@ -118,20 +135,6 @@ watch(() => openStatus.addTranscriptionOpen, (isOpen, wasOpen) => {
   }
 })
 
-watch(speechProviders, (list) => {
-  const id = curTts.value?.id
-  if (!id) return
-  const found = list.find((p) => p.id === id)
-  if (found) curTts.value = found
-  else if (view.value === 'detail' && detailKind.value === 'speech') backToList()
-})
-watch(transcriptionProviders, (list) => {
-  const id = curTranscription.value?.id
-  if (!id) return
-  const found = list.find((p) => p.id === id)
-  if (found) curTranscription.value = found
-  else if (view.value === 'detail' && detailKind.value === 'transcription') backToList()
-})
 </script>
 
 <template>
@@ -268,7 +271,7 @@ watch(transcriptionProviders, (list) => {
       v-else
       width="narrow"
       :back-label="t('voice.title')"
-      @back="backToList()"
+      @back="closeProvider"
     >
       <SpeechSetting v-if="detailKind === 'speech' && curTts?.id" />
       <TranscriptionSetting v-else-if="detailKind === 'transcription' && curTranscription?.id" />

--- a/apps/web/src/pages/voice/index.vue
+++ b/apps/web/src/pages/voice/index.vue
@@ -12,7 +12,7 @@ import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import SectionGroup from '@/components/section-group/index.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import SpeechSetting from '@/pages/speech/components/provider-setting.vue'
 import TranscriptionSetting from '@/pages/transcription/provider-setting.vue'
@@ -20,14 +20,14 @@ import TranscriptionSetting from '@/pages/transcription/provider-setting.vue'
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: speechData } = useQuery({
+const { data: speechData, isLoading: speechLoading } = useQuery({
   key: () => ['speech-providers'],
   query: async () => {
     const { data } = await getSpeechProviders({ throwOnError: true })
     return data
   },
 })
-const { data: transcriptionData } = useQuery({
+const { data: transcriptionData, isLoading: transcriptionLoading } = useQuery({
   key: () => ['transcription-providers'],
   query: async () => {
     const { data } = await getTranscriptionProviders({ throwOnError: true })
@@ -40,13 +40,9 @@ const curTranscription = ref<AudioSpeechProviderResponse>()
 provide('curTtsProvider', curTts)
 provide('curTranscriptionProvider', curTranscription)
 
-// 'voiceProvider' query key (unique per settings page — see useViewSwap.ts),
-// valued `<kind>:<id>` — the detail pane can show either a speech or a
-// transcription provider, and both lists hold the same response type, so the
-// URL must carry which list the ID belongs to for a refresh to restore the
-// right pane. Also keeps the sidebar re-click affordance working.
-const { view, direction, queryValue, openDetail, backToList } = useViewSwap('voiceProvider')
-const detailKind = ref<'speech' | 'transcription'>('speech')
+type VoiceDetailKind = 'speech' | 'transcription'
+type VoiceDetail = { kind: VoiceDetailKind, provider: AudioSpeechProviderResponse }
+const detailKind = ref<VoiceDetailKind>('speech')
 const openStatus = reactive({ addSpeechOpen: false, addTranscriptionOpen: false })
 
 async function importSpeechModels(providerId: string) {
@@ -82,6 +78,42 @@ const transcriptionProviders = computed<AudioSpeechProviderResponse[]>(() =>
   Array.isArray(transcriptionData.value) ? sortByEnabled(transcriptionData.value) : [],
 )
 
+// Page-owned query key, valued `kind:id` so refresh restores which pane.
+const {
+  view,
+  direction,
+  isDetailLoading,
+  openDetail,
+  backToList: closeProvider,
+} = useRoutedViewSwap<VoiceDetail>({
+  key: 'voiceProvider',
+  items: () => [
+    ...speechProviders.value.map(provider => ({ kind: 'speech' as const, provider })),
+    ...transcriptionProviders.value.map(provider => ({ kind: 'transcription' as const, provider })),
+  ],
+  selected: () => {
+    const provider = detailKind.value === 'speech' ? curTts.value : curTranscription.value
+    return provider ? { kind: detailKind.value, provider } : undefined
+  },
+  select: (detail) => {
+    detailKind.value = detail?.kind ?? 'speech'
+    curTts.value = detail?.kind === 'speech' ? detail.provider : undefined
+    curTranscription.value = detail?.kind === 'transcription' ? detail.provider : undefined
+  },
+  getRouteValue: detail => `${detail.kind}:${detail.provider.id}`,
+  isLoading: (routeValue) => {
+    if (routeValue.startsWith('speech:')) return speechLoading.value
+    if (routeValue.startsWith('transcription:')) return transcriptionLoading.value
+    return false
+  },
+  isReady: (routeValue) => {
+    if (routeValue.startsWith('speech:')) return speechData.value !== undefined
+    if (routeValue.startsWith('transcription:')) return transcriptionData.value !== undefined
+    // Malformed / unknown kind — ready to reject immediately.
+    return true
+  },
+})
+
 const addProviderNames = computed(() => [
   ...speechProviders.value.map((p) => ({ name: p.name })),
   ...transcriptionProviders.value.map((p) => ({ name: p.name })),
@@ -93,15 +125,11 @@ function getInitials(name: string | undefined) {
 }
 
 function openSpeech(provider: AudioSpeechProviderResponse) {
-  curTts.value = provider
-  detailKind.value = 'speech'
-  openDetail(`speech:${provider.id}`)
+  openDetail({ kind: 'speech', provider })
 }
 
 function openTranscription(provider: AudioSpeechProviderResponse) {
-  curTranscription.value = provider
-  detailKind.value = 'transcription'
-  openDetail(`transcription:${provider.id}`)
+  openDetail({ kind: 'transcription', provider })
 }
 
 // Each section adds its own kind of provider, so refresh just that list when
@@ -116,43 +144,6 @@ watch(() => openStatus.addTranscriptionOpen, (isOpen, wasOpen) => {
     queryCache.invalidateQueries({ key: ['transcription-providers'] })
   }
 })
-
-// Resolve the URL's `<kind>:<id>` against the matching list: restores the open
-// provider (and which pane kind) on refresh, follows refetched data, and falls
-// back to the list if it was deleted while open. Each kind only consults its
-// own list and only treats "not found" as deleted once that list's data has
-// actually arrived — the empty list during the initial fetch proves nothing.
-watch([queryValue, speechProviders, transcriptionProviders], ([raw, speech, transcription]) => {
-  if (!raw) return
-  const sep = raw.indexOf(':')
-  if (sep === -1) {
-    // Malformed value (hand-edited URL) — nothing will ever match it.
-    backToList()
-    return
-  }
-  const kind = raw.slice(0, sep)
-  const id = raw.slice(sep + 1)
-  if (kind === 'speech') {
-    const found = speech.find((p) => p.id === id)
-    if (found) {
-      detailKind.value = 'speech'
-      curTts.value = found
-    } else if (speechData.value !== undefined) {
-      backToList()
-    }
-  } else if (kind === 'transcription') {
-    const found = transcription.find((p) => p.id === id)
-    if (found) {
-      detailKind.value = 'transcription'
-      curTranscription.value = found
-    } else if (transcriptionData.value !== undefined) {
-      backToList()
-    }
-  } else {
-    // Unknown kind — nothing will ever match it.
-    backToList()
-  }
-}, { immediate: true })
 </script>
 
 <template>
@@ -289,7 +280,8 @@ watch([queryValue, speechProviders, transcriptionProviders], ([raw, speech, tran
       v-else
       width="narrow"
       :back-label="t('voice.title')"
-      @back="backToList()"
+      :loading="isDetailLoading || !(detailKind === 'speech' ? curTts?.id : curTranscription?.id)"
+      @back="closeProvider"
     >
       <SpeechSetting v-if="detailKind === 'speech' && curTts?.id" />
       <TranscriptionSetting v-else-if="detailKind === 'transcription' && curTranscription?.id" />

--- a/apps/web/src/pages/voice/index.vue
+++ b/apps/web/src/pages/voice/index.vue
@@ -12,7 +12,7 @@ import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import SectionGroup from '@/components/section-group/index.vue'
-import { useRoutedViewSwap } from '@/composables/useViewSwap'
+import { useViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 import SpeechSetting from '@/pages/speech/components/provider-setting.vue'
 import TranscriptionSetting from '@/pages/transcription/provider-setting.vue'
@@ -20,14 +20,14 @@ import TranscriptionSetting from '@/pages/transcription/provider-setting.vue'
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: speechData, isLoading: speechLoading } = useQuery({
+const { data: speechData } = useQuery({
   key: () => ['speech-providers'],
   query: async () => {
     const { data } = await getSpeechProviders({ throwOnError: true })
     return data
   },
 })
-const { data: transcriptionData, isLoading: transcriptionLoading } = useQuery({
+const { data: transcriptionData } = useQuery({
   key: () => ['transcription-providers'],
   query: async () => {
     const { data } = await getTranscriptionProviders({ throwOnError: true })
@@ -40,9 +40,13 @@ const curTranscription = ref<AudioSpeechProviderResponse>()
 provide('curTtsProvider', curTts)
 provide('curTranscriptionProvider', curTranscription)
 
-type VoiceDetailKind = 'speech' | 'transcription'
-type VoiceDetail = { kind: VoiceDetailKind, provider: AudioSpeechProviderResponse }
-const detailKind = ref<VoiceDetailKind>('speech')
+// 'voiceProvider' query key (unique per settings page — see useViewSwap.ts),
+// valued `<kind>:<id>` — the detail pane can show either a speech or a
+// transcription provider, and both lists hold the same response type, so the
+// URL must carry which list the ID belongs to for a refresh to restore the
+// right pane. Also keeps the sidebar re-click affordance working.
+const { view, direction, queryValue, openDetail, backToList } = useViewSwap('voiceProvider')
+const detailKind = ref<'speech' | 'transcription'>('speech')
 const openStatus = reactive({ addSpeechOpen: false, addTranscriptionOpen: false })
 
 async function importSpeechModels(providerId: string) {
@@ -78,32 +82,6 @@ const transcriptionProviders = computed<AudioSpeechProviderResponse[]>(() =>
   Array.isArray(transcriptionData.value) ? sortByEnabled(transcriptionData.value) : [],
 )
 
-const { view, direction, openDetail, backToList: closeProvider } = useRoutedViewSwap<VoiceDetail>({
-  key: 'provider',
-  items: () => [
-    ...speechProviders.value.map(provider => ({ kind: 'speech' as const, provider })),
-    ...transcriptionProviders.value.map(provider => ({ kind: 'transcription' as const, provider })),
-  ],
-  selected: () => {
-    const provider = detailKind.value === 'speech' ? curTts.value : curTranscription.value
-    return provider ? { kind: detailKind.value, provider } : undefined
-  },
-  select: (detail) => {
-    detailKind.value = detail?.kind ?? 'speech'
-    curTts.value = detail?.kind === 'speech' ? detail.provider : undefined
-    curTranscription.value = detail?.kind === 'transcription' ? detail.provider : undefined
-  },
-  getRouteValue: detail => `${detail.kind}:${detail.provider.id}`,
-  isLoading: routeValue => routeValue.startsWith('speech:')
-    ? speechLoading.value
-    : routeValue.startsWith('transcription:') && transcriptionLoading.value,
-  isReady: routeValue => routeValue.startsWith('speech:')
-    ? speechData.value !== undefined
-    : routeValue.startsWith('transcription:')
-      ? transcriptionData.value !== undefined
-      : true,
-})
-
 const addProviderNames = computed(() => [
   ...speechProviders.value.map((p) => ({ name: p.name })),
   ...transcriptionProviders.value.map((p) => ({ name: p.name })),
@@ -115,11 +93,15 @@ function getInitials(name: string | undefined) {
 }
 
 function openSpeech(provider: AudioSpeechProviderResponse) {
-  openDetail({ kind: 'speech', provider })
+  curTts.value = provider
+  detailKind.value = 'speech'
+  openDetail(`speech:${provider.id}`)
 }
 
 function openTranscription(provider: AudioSpeechProviderResponse) {
-  openDetail({ kind: 'transcription', provider })
+  curTranscription.value = provider
+  detailKind.value = 'transcription'
+  openDetail(`transcription:${provider.id}`)
 }
 
 // Each section adds its own kind of provider, so refresh just that list when
@@ -135,6 +117,42 @@ watch(() => openStatus.addTranscriptionOpen, (isOpen, wasOpen) => {
   }
 })
 
+// Resolve the URL's `<kind>:<id>` against the matching list: restores the open
+// provider (and which pane kind) on refresh, follows refetched data, and falls
+// back to the list if it was deleted while open. Each kind only consults its
+// own list and only treats "not found" as deleted once that list's data has
+// actually arrived — the empty list during the initial fetch proves nothing.
+watch([queryValue, speechProviders, transcriptionProviders], ([raw, speech, transcription]) => {
+  if (!raw) return
+  const sep = raw.indexOf(':')
+  if (sep === -1) {
+    // Malformed value (hand-edited URL) — nothing will ever match it.
+    backToList()
+    return
+  }
+  const kind = raw.slice(0, sep)
+  const id = raw.slice(sep + 1)
+  if (kind === 'speech') {
+    const found = speech.find((p) => p.id === id)
+    if (found) {
+      detailKind.value = 'speech'
+      curTts.value = found
+    } else if (speechData.value !== undefined) {
+      backToList()
+    }
+  } else if (kind === 'transcription') {
+    const found = transcription.find((p) => p.id === id)
+    if (found) {
+      detailKind.value = 'transcription'
+      curTranscription.value = found
+    } else if (transcriptionData.value !== undefined) {
+      backToList()
+    }
+  } else {
+    // Unknown kind — nothing will ever match it.
+    backToList()
+  }
+}, { immediate: true })
 </script>
 
 <template>
@@ -271,7 +289,7 @@ watch(() => openStatus.addTranscriptionOpen, (isOpen, wasOpen) => {
       v-else
       width="narrow"
       :back-label="t('voice.title')"
-      @back="closeProvider"
+      @back="backToList()"
     >
       <SpeechSetting v-if="detailKind === 'speech' && curTts?.id" />
       <TranscriptionSetting v-else-if="detailKind === 'transcription' && curTranscription?.id" />

--- a/apps/web/src/pages/web-search/index.vue
+++ b/apps/web/src/pages/web-search/index.vue
@@ -15,13 +15,13 @@ import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import SectionGroup from '@/components/section-group/index.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providerData } = useQuery({
+const { data: providerData, isLoading: providersLoading } = useQuery({
   key: () => ['search-providers'],
   query: async () => {
     const { data } = await getSearchProviders({ throwOnError: true })
@@ -29,7 +29,7 @@ const { data: providerData } = useQuery({
   },
 })
 
-const { data: fetchProviderData } = useQuery({
+const { data: fetchProviderData, isLoading: fetchProvidersLoading } = useQuery({
   key: () => ['fetch-providers'],
   query: async () => {
     const { data } = await getFetchProviders({ throwOnError: true })
@@ -42,12 +42,11 @@ const curFetchProvider = ref<FetchprovidersGetResponse>()
 provide('curSearchProvider', curProvider)
 provide('curFetchProvider', curFetchProvider)
 
-// 'webProvider' query key (unique per settings page — see useViewSwap.ts),
-// valued `<kind>:<id>` — the detail pane can show either a search or a fetch
-// provider, so the URL must carry which list the ID belongs to for a refresh
-// to restore the right pane. Also keeps the sidebar re-click affordance working.
-const { view, direction, queryValue, openDetail, backToList } = useViewSwap('webProvider')
-const detailKind = ref<'search' | 'fetch'>('search')
+type WebDetailKind = 'search' | 'fetch'
+type WebDetail =
+  | { kind: 'search', provider: SearchprovidersGetResponse }
+  | { kind: 'fetch', provider: FetchprovidersGetResponse }
+const detailKind = ref<WebDetailKind>('search')
 const openStatus = reactive({
   addSearchOpen: false,
   addFetchOpen: false,
@@ -70,16 +69,52 @@ const fetchProviders = computed<FetchprovidersGetResponse[]>(() => {
   })
 })
 
+// Page-owned query key, valued `kind:id` so refresh restores which pane.
+const {
+  view,
+  direction,
+  isDetailLoading,
+  openDetail,
+  backToList: closeProvider,
+} = useRoutedViewSwap<WebDetail>({
+  key: 'webProvider',
+  items: () => [
+    ...providers.value.map(provider => ({ kind: 'search' as const, provider })),
+    ...fetchProviders.value.map(provider => ({ kind: 'fetch' as const, provider })),
+  ],
+  selected: () => {
+    if (detailKind.value === 'search' && curProvider.value) {
+      return { kind: 'search', provider: curProvider.value }
+    }
+    if (detailKind.value === 'fetch' && curFetchProvider.value) {
+      return { kind: 'fetch', provider: curFetchProvider.value }
+    }
+    return undefined
+  },
+  select: (detail) => {
+    detailKind.value = detail?.kind ?? 'search'
+    curProvider.value = detail?.kind === 'search' ? detail.provider : undefined
+    curFetchProvider.value = detail?.kind === 'fetch' ? detail.provider : undefined
+  },
+  getRouteValue: detail => `${detail.kind}:${detail.provider.id}`,
+  isLoading: (routeValue) => {
+    if (routeValue.startsWith('search:')) return providersLoading.value
+    if (routeValue.startsWith('fetch:')) return fetchProvidersLoading.value
+    return false
+  },
+  isReady: (routeValue) => {
+    if (routeValue.startsWith('search:')) return providerData.value !== undefined
+    if (routeValue.startsWith('fetch:')) return fetchProviderData.value !== undefined
+    return true
+  },
+})
+
 function openProvider(provider: SearchprovidersGetResponse) {
-  curProvider.value = provider
-  detailKind.value = 'search'
-  openDetail(`search:${provider.id}`)
+  openDetail({ kind: 'search', provider })
 }
 
 function openFetchProvider(provider: FetchprovidersGetResponse) {
-  curFetchProvider.value = provider
-  detailKind.value = 'fetch'
-  openDetail(`fetch:${provider.id}`)
+  openDetail({ kind: 'fetch', provider })
 }
 
 watch(() => openStatus.addSearchOpen, (isOpen, wasOpen) => {
@@ -93,43 +128,6 @@ watch(() => openStatus.addFetchOpen, (isOpen, wasOpen) => {
     queryCache.invalidateQueries({ key: ['fetch-providers'] })
   }
 })
-
-// Resolve the URL's `<kind>:<id>` against the matching list: restores the open
-// provider (and which pane kind) on refresh, follows refetched data, and falls
-// back to the list if it was deleted while open. Each kind only consults its
-// own list and only treats "not found" as deleted once that list's data has
-// actually arrived — the empty list during the initial fetch proves nothing.
-watch([queryValue, providers, fetchProviders], ([raw, search, fetchList]) => {
-  if (!raw) return
-  const sep = raw.indexOf(':')
-  if (sep === -1) {
-    // Malformed value (hand-edited URL) — nothing will ever match it.
-    backToList()
-    return
-  }
-  const kind = raw.slice(0, sep)
-  const id = raw.slice(sep + 1)
-  if (kind === 'search') {
-    const found = search.find((p) => p.id === id)
-    if (found) {
-      detailKind.value = 'search'
-      curProvider.value = found
-    } else if (providerData.value !== undefined) {
-      backToList()
-    }
-  } else if (kind === 'fetch') {
-    const found = fetchList.find((p) => p.id === id)
-    if (found) {
-      detailKind.value = 'fetch'
-      curFetchProvider.value = found
-    } else if (fetchProviderData.value !== undefined) {
-      backToList()
-    }
-  } else {
-    // Unknown kind — nothing will ever match it.
-    backToList()
-  }
-}, { immediate: true })
 </script>
 
 <template>
@@ -247,7 +245,8 @@ watch([queryValue, providers, fetchProviders], ([raw, search, fetchList]) => {
       v-else
       width="narrow"
       :back-label="t('webSearch.title')"
-      @back="backToList()"
+      :loading="isDetailLoading || !(detailKind === 'search' ? curProvider?.id : curFetchProvider?.id)"
+      @back="closeProvider"
     >
       <ProviderSetting v-if="detailKind === 'search' && curProvider?.id" />
       <FetchProviderSetting v-else-if="detailKind === 'fetch' && curFetchProvider?.id" />

--- a/apps/web/src/pages/web-search/index.vue
+++ b/apps/web/src/pages/web-search/index.vue
@@ -15,13 +15,13 @@ import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import SectionGroup from '@/components/section-group/index.vue'
-import { useViewSwap } from '@/composables/useViewSwap'
+import { useRoutedViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providerData } = useQuery({
+const { data: providerData, isLoading: providersLoading } = useQuery({
   key: () => ['search-providers'],
   query: async () => {
     const { data } = await getSearchProviders({ throwOnError: true })
@@ -29,7 +29,7 @@ const { data: providerData } = useQuery({
   },
 })
 
-const { data: fetchProviderData } = useQuery({
+const { data: fetchProviderData, isLoading: fetchProvidersLoading } = useQuery({
   key: () => ['fetch-providers'],
   query: async () => {
     const { data } = await getFetchProviders({ throwOnError: true })
@@ -42,11 +42,11 @@ const curFetchProvider = ref<FetchprovidersGetResponse>()
 provide('curSearchProvider', curProvider)
 provide('curFetchProvider', curFetchProvider)
 
-// 'detail' query key: see useViewSwap.ts — makes re-clicking Web Search in the
-// settings sidebar while a provider's detail is open actually navigate back.
-// detailKind stays a local ref, not mirrored — same reasoning as voice/index.vue.
-const { view, direction, openDetail, backToList } = useViewSwap('detail')
-const detailKind = ref<'search' | 'fetch'>('search')
+type WebDetailKind = 'search' | 'fetch'
+type WebDetail =
+  | { kind: 'search', provider: SearchprovidersGetResponse }
+  | { kind: 'fetch', provider: FetchprovidersGetResponse }
+const detailKind = ref<WebDetailKind>('search')
 const openStatus = reactive({
   addSearchOpen: false,
   addFetchOpen: false,
@@ -69,16 +69,43 @@ const fetchProviders = computed<FetchprovidersGetResponse[]>(() => {
   })
 })
 
+const { view, direction, openDetail, backToList: closeProvider } = useRoutedViewSwap<WebDetail>({
+  key: 'provider',
+  items: () => [
+    ...providers.value.map(provider => ({ kind: 'search' as const, provider })),
+    ...fetchProviders.value.map(provider => ({ kind: 'fetch' as const, provider })),
+  ],
+  selected: () => {
+    if (detailKind.value === 'search' && curProvider.value) {
+      return { kind: 'search', provider: curProvider.value }
+    }
+    if (detailKind.value === 'fetch' && curFetchProvider.value) {
+      return { kind: 'fetch', provider: curFetchProvider.value }
+    }
+    return undefined
+  },
+  select: (detail) => {
+    detailKind.value = detail?.kind ?? 'search'
+    curProvider.value = detail?.kind === 'search' ? detail.provider : undefined
+    curFetchProvider.value = detail?.kind === 'fetch' ? detail.provider : undefined
+  },
+  getRouteValue: detail => `${detail.kind}:${detail.provider.id}`,
+  isLoading: routeValue => routeValue.startsWith('search:')
+    ? providersLoading.value
+    : routeValue.startsWith('fetch:') && fetchProvidersLoading.value,
+  isReady: routeValue => routeValue.startsWith('search:')
+    ? providerData.value !== undefined
+    : routeValue.startsWith('fetch:')
+      ? fetchProviderData.value !== undefined
+      : true,
+})
+
 function openProvider(provider: SearchprovidersGetResponse) {
-  curProvider.value = provider
-  detailKind.value = 'search'
-  openDetail()
+  openDetail({ kind: 'search', provider })
 }
 
 function openFetchProvider(provider: FetchprovidersGetResponse) {
-  curFetchProvider.value = provider
-  detailKind.value = 'fetch'
-  openDetail()
+  openDetail({ kind: 'fetch', provider })
 }
 
 watch(() => openStatus.addSearchOpen, (isOpen, wasOpen) => {
@@ -93,21 +120,6 @@ watch(() => openStatus.addFetchOpen, (isOpen, wasOpen) => {
   }
 })
 
-watch(providers, (list) => {
-  const id = curProvider.value?.id
-  if (!id) return
-  const found = list.find((p) => p.id === id)
-  if (found) curProvider.value = found
-  else if (view.value === 'detail' && detailKind.value === 'search') backToList()
-})
-
-watch(fetchProviders, (list) => {
-  const id = curFetchProvider.value?.id
-  if (!id) return
-  const found = list.find((p) => p.id === id)
-  if (found) curFetchProvider.value = found
-  else if (view.value === 'detail' && detailKind.value === 'fetch') backToList()
-})
 </script>
 
 <template>
@@ -225,7 +237,7 @@ watch(fetchProviders, (list) => {
       v-else
       width="narrow"
       :back-label="t('webSearch.title')"
-      @back="backToList()"
+      @back="closeProvider"
     >
       <ProviderSetting v-if="detailKind === 'search' && curProvider?.id" />
       <FetchProviderSetting v-else-if="detailKind === 'fetch' && curFetchProvider?.id" />

--- a/apps/web/src/pages/web-search/index.vue
+++ b/apps/web/src/pages/web-search/index.vue
@@ -15,13 +15,13 @@ import BackendCard from '@/components/settings/backend-card.vue'
 import DetailPane from '@/components/settings/detail-pane.vue'
 import PageShell from '@/components/page-shell/index.vue'
 import SectionGroup from '@/components/section-group/index.vue'
-import { useRoutedViewSwap } from '@/composables/useViewSwap'
+import { useViewSwap } from '@/composables/useViewSwap'
 import SwapTransition from '@/components/settings/swap-transition.vue'
 
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-const { data: providerData, isLoading: providersLoading } = useQuery({
+const { data: providerData } = useQuery({
   key: () => ['search-providers'],
   query: async () => {
     const { data } = await getSearchProviders({ throwOnError: true })
@@ -29,7 +29,7 @@ const { data: providerData, isLoading: providersLoading } = useQuery({
   },
 })
 
-const { data: fetchProviderData, isLoading: fetchProvidersLoading } = useQuery({
+const { data: fetchProviderData } = useQuery({
   key: () => ['fetch-providers'],
   query: async () => {
     const { data } = await getFetchProviders({ throwOnError: true })
@@ -42,11 +42,12 @@ const curFetchProvider = ref<FetchprovidersGetResponse>()
 provide('curSearchProvider', curProvider)
 provide('curFetchProvider', curFetchProvider)
 
-type WebDetailKind = 'search' | 'fetch'
-type WebDetail =
-  | { kind: 'search', provider: SearchprovidersGetResponse }
-  | { kind: 'fetch', provider: FetchprovidersGetResponse }
-const detailKind = ref<WebDetailKind>('search')
+// 'webProvider' query key (unique per settings page — see useViewSwap.ts),
+// valued `<kind>:<id>` — the detail pane can show either a search or a fetch
+// provider, so the URL must carry which list the ID belongs to for a refresh
+// to restore the right pane. Also keeps the sidebar re-click affordance working.
+const { view, direction, queryValue, openDetail, backToList } = useViewSwap('webProvider')
+const detailKind = ref<'search' | 'fetch'>('search')
 const openStatus = reactive({
   addSearchOpen: false,
   addFetchOpen: false,
@@ -69,43 +70,16 @@ const fetchProviders = computed<FetchprovidersGetResponse[]>(() => {
   })
 })
 
-const { view, direction, openDetail, backToList: closeProvider } = useRoutedViewSwap<WebDetail>({
-  key: 'provider',
-  items: () => [
-    ...providers.value.map(provider => ({ kind: 'search' as const, provider })),
-    ...fetchProviders.value.map(provider => ({ kind: 'fetch' as const, provider })),
-  ],
-  selected: () => {
-    if (detailKind.value === 'search' && curProvider.value) {
-      return { kind: 'search', provider: curProvider.value }
-    }
-    if (detailKind.value === 'fetch' && curFetchProvider.value) {
-      return { kind: 'fetch', provider: curFetchProvider.value }
-    }
-    return undefined
-  },
-  select: (detail) => {
-    detailKind.value = detail?.kind ?? 'search'
-    curProvider.value = detail?.kind === 'search' ? detail.provider : undefined
-    curFetchProvider.value = detail?.kind === 'fetch' ? detail.provider : undefined
-  },
-  getRouteValue: detail => `${detail.kind}:${detail.provider.id}`,
-  isLoading: routeValue => routeValue.startsWith('search:')
-    ? providersLoading.value
-    : routeValue.startsWith('fetch:') && fetchProvidersLoading.value,
-  isReady: routeValue => routeValue.startsWith('search:')
-    ? providerData.value !== undefined
-    : routeValue.startsWith('fetch:')
-      ? fetchProviderData.value !== undefined
-      : true,
-})
-
 function openProvider(provider: SearchprovidersGetResponse) {
-  openDetail({ kind: 'search', provider })
+  curProvider.value = provider
+  detailKind.value = 'search'
+  openDetail(`search:${provider.id}`)
 }
 
 function openFetchProvider(provider: FetchprovidersGetResponse) {
-  openDetail({ kind: 'fetch', provider })
+  curFetchProvider.value = provider
+  detailKind.value = 'fetch'
+  openDetail(`fetch:${provider.id}`)
 }
 
 watch(() => openStatus.addSearchOpen, (isOpen, wasOpen) => {
@@ -120,6 +94,42 @@ watch(() => openStatus.addFetchOpen, (isOpen, wasOpen) => {
   }
 })
 
+// Resolve the URL's `<kind>:<id>` against the matching list: restores the open
+// provider (and which pane kind) on refresh, follows refetched data, and falls
+// back to the list if it was deleted while open. Each kind only consults its
+// own list and only treats "not found" as deleted once that list's data has
+// actually arrived — the empty list during the initial fetch proves nothing.
+watch([queryValue, providers, fetchProviders], ([raw, search, fetchList]) => {
+  if (!raw) return
+  const sep = raw.indexOf(':')
+  if (sep === -1) {
+    // Malformed value (hand-edited URL) — nothing will ever match it.
+    backToList()
+    return
+  }
+  const kind = raw.slice(0, sep)
+  const id = raw.slice(sep + 1)
+  if (kind === 'search') {
+    const found = search.find((p) => p.id === id)
+    if (found) {
+      detailKind.value = 'search'
+      curProvider.value = found
+    } else if (providerData.value !== undefined) {
+      backToList()
+    }
+  } else if (kind === 'fetch') {
+    const found = fetchList.find((p) => p.id === id)
+    if (found) {
+      detailKind.value = 'fetch'
+      curFetchProvider.value = found
+    } else if (fetchProviderData.value !== undefined) {
+      backToList()
+    }
+  } else {
+    // Unknown kind — nothing will ever match it.
+    backToList()
+  }
+}, { immediate: true })
 </script>
 
 <template>
@@ -237,7 +247,7 @@ watch(() => openStatus.addFetchOpen, (isOpen, wasOpen) => {
       v-else
       width="narrow"
       :back-label="t('webSearch.title')"
-      @back="closeProvider"
+      @back="backToList()"
     >
       <ProviderSetting v-if="detailKind === 'search' && curProvider?.id" />
       <FetchProviderSetting v-else-if="detailKind === 'fetch' && curFetchProvider?.id" />


### PR DESCRIPTION
## Summary

- replace the ambiguous `detail=1` flag with `provider=<id>`
- restore the selected provider from the URL after the provider list loads
- fall back to the provider list when the URL references a missing provider
- cover refresh, provider switching, and invalid IDs with regression tests

## Verification

- `pnpm exec vitest run --project web src/pages/providers/index.test.ts`
- `pnpm exec eslint apps/web/src/composables/useViewSwap.ts apps/web/src/pages/providers/index.vue apps/web/src/pages/providers/index.test.ts`
- `pnpm --filter @memohai/web exec vue-tsc -p tsconfig.json --noEmit`
- `node scripts/check-ui-contract.mjs`
- manually selected the second provider in Chrome Canary and refreshed the detail URL

Fixes #787