### PR TITLE
feat(web): open desktop when GUI tools start

### DIFF
--- a/apps/web/src/pages/home/components/tool-call-registry.ts
+++ b/apps/web/src/pages/home/components/tool-call-registry.ts
@@ -80,6 +80,7 @@ import ToolCallDetailSpawn from './tool-call-detail-spawn.vue'
 import ToolCallDetailWebFetch from './tool-call-detail-web-fetch.vue'
 import ToolCallDetailWebSearch from './tool-call-detail-web-search.vue'
 import ToolCallDetailWrite from './tool-call-detail-write.vue'
+import { isGuiToolName } from '@/utils/gui-tools'
 
 export interface ToolDisplay {
   icon: Component
@@ -130,20 +131,15 @@ export function isReadOnlyTool(toolName: string): boolean {
 // side-effecting "action" calls as one continuous browsing activity. Splitting
 // them on every observe↔action flip would strand each step in its own segment,
 // so they share a single category and stay grouped together.
-const GUI_TOOLS = new Set([
-  'browser_action', 'browser_observe', 'browser_remote_session',
-  'computer_action', 'computer_observe',
-])
-
 export type ToolSegmentCategory = 'explore' | 'action' | 'gui'
 
 export function isGuiTool(toolName: string): boolean {
-  return GUI_TOOLS.has(toolName)
+  return isGuiToolName(toolName)
 }
 
 // Segment category used to group consecutive tool calls in a process run.
 export function toolSegmentCategory(toolName: string): ToolSegmentCategory {
-  if (GUI_TOOLS.has(toolName)) return 'gui'
+  if (isGuiToolName(toolName)) return 'gui'
   return isReadOnlyTool(toolName) ? 'explore' : 'action'
 }
 

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -303,6 +303,76 @@ describe('chat-list store', () => {
     expect(api.fetchSessions).toHaveBeenCalledWith('bot-ready')
   })
 
+  it('requests the Desktop once when each Browser Use or Computer Use call starts', async () => {
+    sendEvents = [
+      { type: 'start' } as UIStreamEvent,
+      {
+        type: 'message',
+        data: {
+          id: 1,
+          type: 'tool',
+          name: 'browser_action',
+          input: { action: 'click' },
+          tool_call_id: 'call-browser',
+          running: true,
+        },
+      } as UIStreamEvent,
+    ]
+    const store = useChatStore()
+    await store.selectBot('bot-1')
+
+    const sending = store.sendMessage('use the browser')
+    await flushPromises()
+    expect(store.guiToolUseRequested).toMatchObject({
+      botId: 'bot-1',
+      sessionId: 'session-1',
+      toolCallId: 'call-browser',
+      toolName: 'browser_action',
+      seq: 1,
+    })
+
+    streamHandler?.({
+      type: 'message',
+      stream_id: lastStreamId,
+      session_id: 'session-1',
+      data: {
+        id: 1,
+        type: 'tool',
+        name: 'browser_action',
+        input: { action: 'click', coordinate: [10, 20] },
+        tool_call_id: 'call-browser',
+        running: true,
+      },
+    } as UIStreamEvent)
+    expect(store.guiToolUseRequested?.seq).toBe(1)
+
+    streamHandler?.({
+      type: 'message',
+      stream_id: lastStreamId,
+      session_id: 'session-1',
+      data: {
+        id: 2,
+        type: 'tool',
+        name: 'computer_observe',
+        input: { observe: 'snapshot' },
+        tool_call_id: 'call-computer',
+        running: true,
+      },
+    } as UIStreamEvent)
+    expect(store.guiToolUseRequested).toMatchObject({
+      toolCallId: 'call-computer',
+      toolName: 'computer_observe',
+      seq: 2,
+    })
+
+    streamHandler?.({
+      type: 'end',
+      stream_id: lastStreamId,
+      session_id: 'session-1',
+    } as UIStreamEvent)
+    await expect(sending).resolves.toMatchObject({ ok: true })
+  })
+
   it('returns startup stream errors to the composer when no assistant output exists', async () => {
     const store = useChatStore()
     const onBeforeTurnAppend = vi.fn()

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -84,6 +84,7 @@ import {
   locateMessageUI,
 } from '@/composables/api/useChat'
 import { ACP_DEFAULT_PROJECT_MODE, ACP_DEFAULT_PROJECT_PATH } from '@/utils/acp'
+import { isGuiToolName } from '@/utils/gui-tools'
 import { getBotsByBotIdSettings } from '@memohai/sdk'
 import type { AcpagentRuntimeStatus } from '@memohai/sdk'
 
@@ -181,6 +182,14 @@ interface StartupSendFailure {
   restoreRequestedSkills?: RequestedSkillSelection[]
 }
 
+interface GuiToolUseRequest {
+  botId: string
+  sessionId: string
+  toolCallId: string
+  toolName: string
+  seq: number
+}
+
 class StreamFailureError extends Error {
   stage: SendMessageStage
 
@@ -229,6 +238,9 @@ export const useChatStore = defineStore('chat', () => {
     rememberBackgroundTask,
     applyPendingBackgroundEventsToTool,
   } = backgroundTasks
+  const guiToolUseRequested = ref<GuiToolUseRequest | null>(null)
+  const seenGuiToolCalls = new Set<string>()
+  let guiToolUseRequestSeq = 0
   const focusedChatViewId = ref('chat')
   let transcriptSnapshotHook: (view: ChatViewEntry, targetSessionId: string | undefined, turns: import('@/composables/api/useChat.types').UITurn[]) => void = () => {}
   let transcriptRefreshAppliedHook: (view: ChatViewEntry, targetSessionId: string, latestTimestamp?: string) => void = () => {}
@@ -1166,6 +1178,20 @@ export const useChatStore = defineStore('chat', () => {
         ensureDiscussStream(streamId, sid, bid)
         break
       case 'message':
+        if (event.data.type === 'tool' && event.data.running && isGuiToolName(event.data.name)) {
+          const toolCallId = event.data.tool_call_id?.trim() ?? ''
+          const dedupeKey = `${bid}:${sid}:${toolCallId || `${streamId}:${event.data.id}:${event.data.name}`}`
+          if (!seenGuiToolCalls.has(dedupeKey)) {
+            seenGuiToolCalls.add(dedupeKey)
+            guiToolUseRequested.value = {
+              botId: bid,
+              sessionId: sid,
+              toolCallId,
+              toolName: event.data.name,
+              seq: ++guiToolUseRequestSeq,
+            }
+          }
+        }
         const messageStream = ensureDiscussStream(streamId, sid, bid)
         if (messageStream) upsertAssistantUIMessage(messageStream.assistantTurn, event.data)
         break
@@ -1246,6 +1272,8 @@ export const useChatStore = defineStore('chat', () => {
     resetApprovalResponses()
     forkingMessages.clear()
     backgroundTasks.clearBackgroundTasks()
+    seenGuiToolCalls.clear()
+    guiToolUseRequested.value = null
   }
 
   async function loadMoreSessions(): Promise<void> {
@@ -2894,6 +2922,7 @@ export const useChatStore = defineStore('chat', () => {
     draftViewRequested,
     applyDraftViewRequest,
     forkedSessionRequested,
+    guiToolUseRequested,
     deletedSession,
     removeSession,
     renameSession,

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -111,6 +111,13 @@ const chatStoreMock = vi.hoisted(() => ({
     wasDraft: boolean
     seq: number
   } | null>>,
+  guiToolUseRequested: undefined as unknown as ReturnType<typeof ref<{
+    botId: string
+    sessionId: string
+    toolCallId: string
+    toolName: string
+    seq: number
+  } | null>>,
   focusChatView: vi.fn(),
   selectSession: vi.fn(async (sessionId: string, options?: { explicitSelection?: boolean }) => {
     useChatSelectionStore().setSession(sessionId, options)
@@ -145,6 +152,9 @@ vi.mock('@/store/chat-list', () => ({
     activeSession: null,
     get userSentInSession() {
       return chatStoreMock.userSentInSession.value
+    },
+    get guiToolUseRequested() {
+      return chatStoreMock.guiToolUseRequested.value
     },
     get pendingACPSessionInput() {
       return chatStoreMock.pendingACPSessionInput.value
@@ -190,6 +200,7 @@ interface FakePanel {
     close: () => void
     setTitle: (title: string) => void
     updateParameters: (params: Record<string, unknown>) => void
+    moveTo: (options: { group?: FakeGroup; position?: 'top' | 'bottom' | 'left' | 'right' | 'center' }) => void
     readonly title: string
   }
 }
@@ -212,6 +223,7 @@ function createFakeDock() {
   const panels: FakePanel[] = []
   const groups: FakeGroup[] = []
   const groupActivePanels = new Map<string, FakePanel | null>()
+  const groupPositions = new Map<string, { referenceGroup: string; direction: string }>()
   const removeListeners: Array<(panel: FakePanel) => void> = []
   // Mirror dockview v7's real onDidActivePanelChange payload: `{ panel, origin }`.
   // The old fake used `{ activePanel }` (the v6 shape); that masked the v6→v7
@@ -312,6 +324,12 @@ function createFakeDock() {
     getPanel(id: string) {
       return panels.find((p) => p.id === id)
     },
+    adjacentGroupInDirection(group: FakeGroup, direction: 'left' | 'right' | 'above' | 'below') {
+      return groups.find((candidate) => {
+        const position = groupPositions.get(candidate.id)
+        return position?.referenceGroup === group.id && position.direction === direction
+      })
+    },
     addPanel(options: {
       id: string
       component: string
@@ -329,6 +347,9 @@ function createFakeDock() {
         : options.position
           ? createGroup()
           : activePanel?.group ?? primaryGroup
+      if (options.position && options.position.direction !== 'within') {
+        groupPositions.set(targetGroup.id, options.position)
+      }
       const panel: FakePanel = {
         id: options.id,
         component: options.component,
@@ -361,6 +382,28 @@ function createFakeDock() {
           updateParameters: (params: Record<string, unknown>) => {
             Object.assign(panel.params, params)
           },
+          moveTo: (options: { group?: FakeGroup; position?: 'top' | 'bottom' | 'left' | 'right' | 'center' }) => {
+            const sourceGroup = panel.group
+            const targetGroup = options.position === 'center'
+              ? options.group ?? sourceGroup
+              : createGroup()
+            if (options.position && options.position !== 'center' && options.group) {
+              groupPositions.set(targetGroup.id, {
+                referenceGroup: options.group.id,
+                direction: options.position,
+              })
+            }
+            panel.group = targetGroup
+            groupActivePanels.set(targetGroup.id, panel)
+            if (sourceGroup && sourceGroup !== primaryGroup && sourceGroup.panels.length === 0) {
+              const groupIndex = groups.indexOf(sourceGroup)
+              if (groupIndex >= 0) groups.splice(groupIndex, 1)
+              groupActivePanels.delete(sourceGroup.id)
+              groupPositions.delete(sourceGroup.id)
+            }
+            setActivePanel(panel)
+            emitLayoutChange()
+          },
           get title() {
             return panel.title
           },
@@ -376,6 +419,7 @@ function createFakeDock() {
       panels.splice(0, panels.length)
       groups.splice(1, groups.length - 1)
       groupActivePanels.clear()
+      groupPositions.clear()
       setActivePanel(null)
       emitLayoutChange()
     },
@@ -515,6 +559,7 @@ describe('workspace layout store', () => {
     chatStoreMock.draftViewRequested = ref(null)
     chatStoreMock.forkedSessionRequested = ref(null)
     chatStoreMock.userSentInSession = ref(null)
+    chatStoreMock.guiToolUseRequested = ref(null)
     chatStoreMock.sessions = reactive([]) as typeof chatStoreMock.sessions
     chatStoreMock.knownSessions = reactive([]) as typeof chatStoreMock.knownSessions
     chatStoreMock.knownSessionSummary.mockImplementation((sessionId: string) =>
@@ -557,6 +602,17 @@ describe('workspace layout store', () => {
     }
   }
 
+  function emitGuiToolUse(toolName = 'browser_action') {
+    const prevSeq = chatStoreMock.guiToolUseRequested.value?.seq ?? 0
+    chatStoreMock.guiToolUseRequested.value = {
+      botId: 'bot-1',
+      sessionId: 'session-1',
+      toolCallId: `call-${prevSeq + 1}`,
+      toolName,
+      seq: prevSeq + 1,
+    }
+  }
+
   it('opens browser panels and updates their address', () => {
     const store = useWorkspaceTabsStore()
     const dock = createFakeDock()
@@ -593,6 +649,67 @@ describe('workspace layout store', () => {
     expect(store.openBrowserAt('localhost:5173/app')).toBe(true)
     expect(dock.panels.filter(p => p.component === 'browser')).toHaveLength(2)
     expect(dock.activePanel?.id).toBe('browser:1')
+  })
+
+  it('opens Desktop in a new right region when a GUI tool starts from a single region', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openDraftChat({ title: 'Session' })
+
+    emitGuiToolUse()
+
+    const display = dock.getPanel('display:1')
+    expect(display?.component).toBe('display')
+    expect(display?.group?.id).not.toBe('group-1')
+    expect(dock.activePanel?.id).toBe('display:1')
+  })
+
+  it('opens Desktop as a tab in the existing right region when a GUI tool starts', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openDraftChat({ title: 'Session' })
+    store.splitGroup('group-1', 'right')
+    const rightGroup = dock.activePanel!.group!
+
+    emitGuiToolUse('computer_observe')
+
+    expect(dock.getPanel('display:1')?.group?.id).toBe(rightGroup.id)
+    expect(dock.groups).toHaveLength(2)
+  })
+
+  it('creates a right Desktop region when the existing second region is below', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openDraftChat({ title: 'Session' })
+    store.splitGroup('group-1', 'below')
+    const belowGroup = dock.activePanel!.group!
+
+    emitGuiToolUse()
+
+    const display = dock.getPanel('display:1')!
+    expect(display.group?.id).not.toBe(belowGroup.id)
+    expect(dock.groups).toHaveLength(3)
+  })
+
+  it('focuses the existing Desktop tab in the right region when a GUI tool starts again', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openDraftChat({ title: 'Session' })
+    store.splitGroup('group-1', 'right')
+    const rightChat = dock.activePanel!
+    emitGuiToolUse()
+    const display = dock.getPanel('display:1')!
+    rightChat.api.setActive()
+    expect(dock.activePanel?.id).toBe(rightChat.id)
+
+    emitGuiToolUse('computer_action')
+
+    expect(dock.activePanel?.id).toBe(display.id)
+    expect(display.group?.id).toBe(rightChat.group?.id)
   })
 
   it('refuses to open a browser tab for a non-local address', () => {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -1498,6 +1498,75 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     })
   }
 
+  // GUI tools should keep the conversation visible on the left and reserve the
+  // first region to its right for the live Desktop. Bottom terminal groups do
+  // not count as editor regions, and a below-only split must not be mistaken for
+  // the requested right-side region.
+  function openDisplayForAgentUse() {
+    if (!hasCurrentPermission('manage')) return
+    const dock = api.value
+    if (!dock) return
+
+    const primaryGroup = dock.groups.find(group => !isTerminalOnlyGroup(group))
+    if (!primaryGroup) {
+      openDisplay()
+      return
+    }
+
+    const adjacentRight = dock.adjacentGroupInDirection(primaryGroup, 'right')
+    const secondaryGroup = adjacentRight && !isTerminalOnlyGroup(adjacentRight)
+      ? adjacentRight
+      : undefined
+    const existingDisplays = dock.panels.filter(panel => panelComponentOf(panel.id) === 'display')
+    const existing = existingDisplays[0]
+    let targetDisplay = existing
+
+    if (secondaryGroup) {
+      const displayInSecondary = secondaryGroup.panels.find(
+        panel => panelComponentOf(panel.id) === 'display',
+      )
+      if (displayInSecondary) {
+        targetDisplay = displayInSecondary
+        focusPanel(displayInSecondary)
+      }
+      else if (existing) {
+        existing.api.moveTo({ group: secondaryGroup, position: 'center' })
+        focusPanel(existing)
+      }
+      else {
+        dock.addPanel({
+          id: DISPLAY_PANEL_ID,
+          component: 'display',
+          title: i18n.global.t('chat.display.title'),
+          renderer: 'always',
+          position: { referenceGroup: secondaryGroup.id, direction: 'within' },
+        })
+      }
+    }
+    else if (existing) {
+      // Desktop is a singleton. When it is still a tab in the only editor
+      // region, move that live panel to a new right split instead of reconnecting
+      // a duplicate viewer.
+      if (existing.group.id !== primaryGroup.id || primaryGroup.panels.length > 1) {
+        existing.api.moveTo({ group: primaryGroup, position: 'right' })
+      }
+      focusPanel(existing)
+    }
+    else {
+      dock.addPanel({
+        id: DISPLAY_PANEL_ID,
+        component: 'display',
+        title: i18n.global.t('chat.display.title'),
+        renderer: 'always',
+        position: { referenceGroup: primaryGroup.id, direction: 'right' },
+      })
+    }
+
+    for (const extra of existingDisplays) {
+      if (extra !== targetDisplay) extra.api.close()
+    }
+  }
+
   function uniqueSplitPanelId(baseId: string): string {
     const dock = api.value
     if (!dock) return baseId
@@ -1952,6 +2021,11 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     pinPanel(panel.id)
     syncChatTitles()
   })
+
+  watch(() => chatStore.guiToolUseRequested, (request) => {
+    if (!request || request.botId !== (currentBotId.value ?? '').trim()) return
+    openDisplayForAgentUse()
+  }, { flush: 'sync' })
 
   // `/new` can finish resolving Agent defaults after focus has moved to a
   // different split. The workspace owns the final Draft panel id because a

--- a/apps/web/src/utils/gui-tools.ts
+++ b/apps/web/src/utils/gui-tools.ts
@@ -1,0 +1,11 @@
+const GUI_TOOL_NAMES = new Set([
+  'browser_action',
+  'browser_observe',
+  'browser_remote_session',
+  'computer_action',
+  'computer_observe',
+])
+
+export function isGuiToolName(toolName: string): boolean {
+  return GUI_TOOL_NAMES.has(toolName)
+}


### PR DESCRIPTION
## Summary

- detect Browser Use and Computer Use tool starts from live chat events
- open Desktop in a newly created right-side region when the layout has only one region
- reuse the existing right-side region, and focus its existing Desktop tab when present
- preserve the Desktop singleton while moving it to the right-side region when necessary

## Why

Users should see the live workspace desktop as soon as an agent starts GUI automation, without manually splitting the layout or locating the Desktop tab.

## Validation

- `pnpm --filter @memohai/web exec vitest run src/store/workspace-tabs.test.ts src/store/chat-list.test.ts` (207 tests passed)
- `pnpm --filter @memohai/web exec vue-tsc --noEmit`
- `pnpm --filter @memohai/web build`
- commit hooks: ESLint, Go lint, and Go tests