### PR TITLE
refactor(web): simplify computer settings layout

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -162,7 +162,6 @@
   },
   "runtimes": {
     "title": "Computers",
-    "description": "Connect computers for Bots to use. Add each computer to a Bot under Connected computers.",
     "connect": "Connect computer",
     "connectOther": "Connect another computer",
     "computers": "Connected computers",
@@ -1886,7 +1885,7 @@
       "network": "Network",
       "memory": "Memory",
       "channels": "Platforms",
-      "remoteRuntime": "Connected computers",
+      "remoteRuntime": "Computers",
       "container": "Workspace",
       "mcp": "MCP",
       "heartbeat": "Heartbeat",
@@ -1902,8 +1901,7 @@
       "settings": "Settings"
     },
     "remoteRuntime": {
-      "title": "Connected computers",
-      "description": "Let this Bot use connected computers in addition to its existing Workspace. This only changes where file and command work runs.",
+      "title": "Computers",
       "workspaceTitle": "Work locations",
       "loading": "Loading work locations...",
       "loadFailed": "Couldn’t load work locations",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -159,7 +159,6 @@
   },
   "runtimes": {
     "title": "コンピューター",
-    "description": "Bot で使うコンピューターを接続し、各 Bot の「接続済みのコンピューター」から追加します。",
     "connect": "コンピューターを接続",
     "connectOther": "別のコンピューターを接続",
     "computers": "接続済みのコンピューター",
@@ -1865,7 +1864,7 @@
       "network": "ネットワーク",
       "memory": "メモリ",
       "channels": "プラットフォーム",
-      "remoteRuntime": "接続済みのコンピューター",
+      "remoteRuntime": "コンピューター",
       "container": "Workspace",
       "mcp": "MCP",
       "heartbeat": "ハートビート",
@@ -1881,8 +1880,7 @@
       "settings": "設定"
     },
     "remoteRuntime": {
-      "title": "接続済みのコンピューター",
-      "description": "この Bot は、既存の Workspace に加えて、接続済みのコンピューターでファイル操作やコマンド実行ができます。",
+      "title": "コンピューター",
       "workspaceTitle": "使用場所",
       "loading": "使用場所を読み込んでいます...",
       "loadFailed": "使用場所を読み込めませんでした",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -162,7 +162,6 @@
   },
   "runtimes": {
     "title": "电脑",
-    "description": "连接可供 Bot 使用的电脑，再到每个 Bot 的“已连接电脑”中添加。",
     "connect": "连接电脑",
     "connectOther": "连接其他电脑",
     "computers": "已连接的电脑",
@@ -1886,7 +1885,7 @@
       "network": "网络",
       "memory": "记忆",
       "channels": "平台",
-      "remoteRuntime": "已连接电脑",
+      "remoteRuntime": "电脑",
       "container": "工作区",
       "mcp": "MCP",
       "heartbeat": "心跳",
@@ -1902,8 +1901,7 @@
       "settings": "设置"
     },
     "remoteRuntime": {
-      "title": "已连接电脑",
-      "description": "让这个 Bot 在原有工作区之外，还可以使用已连接电脑读写文件和执行命令。",
+      "title": "电脑",
       "workspaceTitle": "使用位置",
       "loading": "正在加载使用位置...",
       "loadFailed": "无法加载使用位置",

--- a/apps/web/src/pages/bots/components/bot-remote-runtime.vue
+++ b/apps/web/src/pages/bots/components/bot-remote-runtime.vue
@@ -2,58 +2,28 @@
   <PageShell
     variant="tab"
     :title="t('bots.remoteRuntime.title')"
-    :description="t('bots.remoteRuntime.description')"
   >
-    <template #actions>
-      <Button @click="openAddDialog">
-        <Plus class="size-4" />
-        {{ t('bots.remoteRuntime.addComputer') }}
-      </Button>
-    </template>
-
-    <SettingsSection :title="t('bots.remoteRuntime.workspaceTitle')">
-      <InlineLoadingRow
-        v-if="initialLoading"
-        surface="card-row"
+    <div class="space-y-8">
+      <SettingsSection
+        v-if="!loadFailed"
+        :title="t('bots.remoteRuntime.primary')"
       >
-        {{ t('bots.remoteRuntime.loading') }}
-      </InlineLoadingRow>
-
-      <SettingsRow
-        v-else-if="loadFailed"
-        :label="t('bots.remoteRuntime.loadFailed')"
-        :description="t('bots.remoteRuntime.loadFailedDescription')"
-      >
-        <Button
-          variant="outline"
-          size="sm"
-          @click="retry"
+        <InlineLoadingRow
+          v-if="initialLoading"
+          surface="card-row"
         >
-          {{ t('runtimes.retry') }}
-        </Button>
-      </SettingsRow>
-
-      <template v-else>
-        <SettingsRow
-          v-if="showThisComputerSetup"
-          stack="sm"
-          :label="t('bots.remoteRuntime.thisComputerOff')"
-          :description="t('bots.remoteRuntime.thisComputerOffDescription')"
-        >
-          <Button
-            variant="outline"
-            size="sm"
-            @click="openComputers"
-          >
-            {{ t('bots.remoteRuntime.openComputerSettings') }}
-          </Button>
-        </SettingsRow>
+          {{ t('bots.remoteRuntime.loading') }}
+        </InlineLoadingRow>
 
         <SettingsRow
+          v-else
           stack="sm"
-          :label="t('bots.remoteRuntime.primary')"
-          :description="t('bots.remoteRuntime.primaryDescription')"
         >
+          <template #content>
+            <p class="text-xs text-muted-foreground">
+              {{ t('bots.remoteRuntime.primaryDescription') }}
+            </p>
+          </template>
           <Select
             :model-value="primaryTargetId"
             :disabled="primarySaving"
@@ -74,55 +44,105 @@
             </SelectContent>
           </Select>
         </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection :title="t('bots.remoteRuntime.workspaceTitle')">
+        <template #actions>
+          <Button
+            size="sm"
+            @click="openAddDialog"
+          >
+            <Plus class="size-4" />
+            {{ t('bots.remoteRuntime.addComputer') }}
+          </Button>
+        </template>
+
+        <InlineLoadingRow
+          v-if="initialLoading"
+          surface="card-row"
+        >
+          {{ t('bots.remoteRuntime.loading') }}
+        </InlineLoadingRow>
 
         <SettingsRow
-          v-for="target in validTargets"
-          :key="target.target_id"
-          stack="sm"
-          :label="targetName(target)"
-          :description="targetSummary(target)"
+          v-else-if="loadFailed"
+          :label="t('bots.remoteRuntime.loadFailed')"
+          :description="t('bots.remoteRuntime.loadFailedDescription')"
         >
-          <div class="flex items-center gap-2">
-            <span class="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span
-                class="size-1.5 rounded-full"
-                :class="statusDotClass(targetStatus(target))"
-              />
-              {{ statusLabel(targetStatus(target)) }}
-            </span>
-
-            <DropdownMenu v-if="target.kind === 'remote'">
-              <DropdownMenuTrigger as-child>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  :aria-label="t('common.actions')"
-                >
-                  <MoreHorizontal class="size-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  v-if="canEditTarget(target)"
-                  @select="openEditDialog(target)"
-                >
-                  <Pencil class="size-4" />
-                  {{ t('common.edit') }}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator v-if="canEditTarget(target)" />
-                <DropdownMenuItem
-                  variant="destructive"
-                  @select="pendingDeleteTarget = target"
-                >
-                  <Trash2 class="size-4" />
-                  {{ t('bots.remoteRuntime.removeFromBot') }}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            @click="retry"
+          >
+            {{ t('runtimes.retry') }}
+          </Button>
         </SettingsRow>
-      </template>
-    </SettingsSection>
+
+        <template v-else>
+          <SettingsRow
+            v-if="showThisComputerSetup"
+            stack="sm"
+            :label="t('bots.remoteRuntime.thisComputerOff')"
+            :description="t('bots.remoteRuntime.thisComputerOffDescription')"
+          >
+            <Button
+              variant="outline"
+              size="sm"
+              @click="openComputers"
+            >
+              {{ t('bots.remoteRuntime.openComputerSettings') }}
+            </Button>
+          </SettingsRow>
+
+          <SettingsRow
+            v-for="target in validTargets"
+            :key="target.target_id"
+            stack="sm"
+            :label="targetName(target)"
+            :description="targetSummary(target)"
+          >
+            <div class="flex items-center gap-2">
+              <span class="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <span
+                  class="size-1.5 rounded-full"
+                  :class="statusDotClass(targetStatus(target))"
+                />
+                {{ statusLabel(targetStatus(target)) }}
+              </span>
+
+              <DropdownMenu v-if="target.kind === 'remote'">
+                <DropdownMenuTrigger as-child>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    :aria-label="t('common.actions')"
+                  >
+                    <MoreHorizontal class="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    v-if="canEditTarget(target)"
+                    @select="openEditDialog(target)"
+                  >
+                    <Pencil class="size-4" />
+                    {{ t('common.edit') }}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator v-if="canEditTarget(target)" />
+                  <DropdownMenuItem
+                    variant="destructive"
+                    @select="pendingDeleteTarget = target"
+                  >
+                    <Trash2 class="size-4" />
+                    {{ t('bots.remoteRuntime.removeFromBot') }}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </SettingsRow>
+        </template>
+      </SettingsSection>
+    </div>
   </PageShell>
 
   <Dialog v-model:open="mountDialogOpen">

--- a/apps/web/src/pages/runtimes/index.vue
+++ b/apps/web/src/pages/runtimes/index.vue
@@ -1,18 +1,5 @@
 <template>
-  <PageShell
-    :title="t('runtimes.title')"
-    :description="t('runtimes.description')"
-  >
-    <template #actions>
-      <Button
-        size="sm"
-        @click="connectDialogOpen = true"
-      >
-        <Plus class="size-4" />
-        {{ desktopRuntimeBridge ? t('runtimes.connectOther') : t('runtimes.connect') }}
-      </Button>
-    </template>
-
+  <PageShell :title="t('runtimes.title')">
     <div class="space-y-8">
       <SettingsSection
         v-if="desktopRuntimeBridge"
@@ -64,6 +51,16 @@
       </SettingsSection>
 
       <SettingsSection :title="desktopRuntimeBridge ? t('runtimes.otherComputers') : t('runtimes.computers')">
+        <template #actions>
+          <Button
+            size="sm"
+            @click="connectDialogOpen = true"
+          >
+            <Plus class="size-4" />
+            {{ desktopRuntimeBridge ? t('runtimes.connectOther') : t('runtimes.connect') }}
+          </Button>
+        </template>
+
         <InlineLoadingRow
           v-if="runtimesLoading && runtimes === undefined"
           surface="card-row"
@@ -95,14 +92,6 @@
           <p class="mx-auto mt-1 max-w-md text-xs leading-relaxed text-muted-foreground">
             {{ desktopRuntimeBridge ? t('runtimes.emptyOtherDescription') : t('runtimes.emptyDescription') }}
           </p>
-          <Button
-            class="mt-4"
-            variant="outline"
-            size="sm"
-            @click="connectDialogOpen = true"
-          >
-            {{ desktopRuntimeBridge ? t('runtimes.connectOther') : t('runtimes.connect') }}
-          </Button>
         </div>
 
         <SettingsRow


### PR DESCRIPTION
## What

- simplify the Computers settings page hierarchy and remove redundant descriptions
- move connect actions into section headers
- separate the bot primary computer from available work locations
- remove the duplicate empty-state connect action
- align English, Chinese, and Japanese labels

## Why

The existing page repeated context and actions, making the primary computer and additional work locations harder to scan.

## Impact

This is an independent presentation-only change and does not depend on the execution-target backend work.

## Checks

- pnpm web:build
- node scripts/check-ui-contract.mjs
- eslint on touched files
- git diff --check