### PR TITLE
fix(desktop): append /api to server URL if missing

### DIFF
--- a/apps/desktop/src/shared/server-connection.test.ts
+++ b/apps/desktop/src/shared/server-connection.test.ts
@@ -53,7 +53,7 @@ describe('desktop server connection', () => {
     )
     await expect(probeServerBaseUrl('https://memoh.example.com', success))
       .resolves.toEqual({ ok: true, baseUrl: 'https://memoh.example.com' })
-    expect(success).toHaveBeenCalledWith('https://memoh.example.com/ping', expect.objectContaining({
+    expect(success).toHaveBeenCalledWith('https://memoh.example.com/api/ping', expect.objectContaining({
       headers: { Accept: 'application/json' },
     }))
 

--- a/apps/desktop/src/shared/server-connection.ts
+++ b/apps/desktop/src/shared/server-connection.ts
@@ -39,6 +39,10 @@ export function normalizeBaseUrl(raw: string): string {
   }
   url.hash = ''
   url.search = ''
+  if (!url.pathname.endsWith('/api')) {
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/api`
+  }
+
   return url.toString().replace(/\/$/, '')
 }
 


### PR DESCRIPTION
在desktop中，如果输入的服务器地址不带`/api`后缀，则会返回错误，这似乎不是预期的。

此 PR 不包含 AI 生成的代码。