### PR TITLE
fix(providers): disable template models by default

### DIFF
--- a/db/postgres/queries/models.sql
+++ b/db/postgres/queries/models.sql
@@ -183,8 +183,8 @@ ON CONFLICT (team_id, name) DO UPDATE SET
 RETURNING *;
 
 -- name: UpsertRegistryModel :one
-INSERT INTO models (model_id, name, provider_id, type, config)
-VALUES (sqlc.arg(model_id), sqlc.arg(name), sqlc.arg(provider_id), sqlc.arg(type), sqlc.arg(config))
+INSERT INTO models (model_id, name, provider_id, type, enable, config)
+VALUES (sqlc.arg(model_id), sqlc.arg(name), sqlc.arg(provider_id), sqlc.arg(type), false, sqlc.arg(config))
 ON CONFLICT (team_id, provider_id, model_id) DO UPDATE SET
   name = EXCLUDED.name,
   type = EXCLUDED.type,

--- a/internal/db/postgres/sqlc/models.sql.go
+++ b/internal/db/postgres/sqlc/models.sql.go
@@ -1491,8 +1491,8 @@ func (q *Queries) UpdateProvider(ctx context.Context, arg UpdateProviderParams) 
 }
 
 const upsertRegistryModel = `-- name: UpsertRegistryModel :one
-INSERT INTO models (model_id, name, provider_id, type, config)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO models (model_id, name, provider_id, type, enable, config)
+VALUES ($1, $2, $3, $4, false, $5)
 ON CONFLICT (team_id, provider_id, model_id) DO UPDATE SET
   name = EXCLUDED.name,
   type = EXCLUDED.type,

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -150,7 +150,8 @@ func (f *fakeQueries) UpdateProvider(_ context.Context, arg sqlc.UpdateProviderP
 
 // UpsertRegistryModel mirrors:
 //
-//	INSERT INTO models (model_id, name, provider_id, type, config)
+//	INSERT INTO models (model_id, name, provider_id, type, enable, config)
+//	VALUES (..., false, ...)
 //	ON CONFLICT (provider_id, model_id) DO UPDATE SET
 //	  name = EXCLUDED.name, type = EXCLUDED.type, config = EXCLUDED.config
 func (f *fakeQueries) UpsertRegistryModel(_ context.Context, arg sqlc.UpsertRegistryModelParams) (sqlc.Model, error) {
@@ -173,7 +174,7 @@ func (f *fakeQueries) UpsertRegistryModel(_ context.Context, arg sqlc.UpsertRegi
 		Name:       arg.Name,
 		ProviderID: arg.ProviderID,
 		Type:       arg.Type,
-		Enable:     true,
+		Enable:     false,
 		Config:     append([]byte(nil), arg.Config...),
 	}
 	f.models = append(f.models, m)
@@ -274,12 +275,18 @@ func TestSyncCreatesProvidersAndModels(t *testing.T) {
 	if !ok || chat.Name.String != "GPT Test" || chat.Type != "chat" {
 		t.Fatalf("chat model = %+v, want gpt-test/GPT Test/chat", chat)
 	}
+	if chat.Enable {
+		t.Fatal("chat model enable = true, want new registry models disabled")
+	}
 	if value := jsonMap(t, chat.Config)["context_window"]; value != float64(128000) {
 		t.Fatalf("chat model context_window = %#v, want 128000", value)
 	}
 	embed, ok := byModelID["gpt-embed"]
 	if !ok || embed.Type != "embedding" {
 		t.Fatalf("embedding model = %+v, want gpt-embed/embedding", embed)
+	}
+	if embed.Enable {
+		t.Fatal("embedding model enable = true, want new registry models disabled")
 	}
 }
 
@@ -494,6 +501,9 @@ func TestSyncMatchesLegacyProviderByBaseURL(t *testing.T) {
 	}
 	if models[0].Name.String != "GPT Test" {
 		t.Fatalf("model name = %q, want registry name", models[0].Name.String)
+	}
+	if !models[0].Enable {
+		t.Fatal("model enable = false, want existing user choice preserved")
 	}
 }
 


### PR DESCRIPTION
## Summary

- create registry-provided models with `enable = false`
- preserve the existing enable state when registry models are refreshed
- cover disabled chat and embedding defaults plus preservation of existing user choices

## Why

Provider templates can contain hundreds of models. Enabling every template model floods model selectors and conflicts with the existing bulk-import behavior, which already imports newly discovered models as disabled.

## Impact

New models inserted from provider templates are disabled until the user explicitly enables them. Existing model enable choices are not changed.

## Validation

- `go test ./internal/registry ./internal/audio ./internal/video ./internal/models`
- `go test ./internal/handlers`
- repository pre-commit Go lint and full Go test suite
- `git diff --check`