### PR TITLE
fix(web): make typecheck script actually check app source

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -92,5 +92,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run Vitest
         run: pnpm test --run --testTimeout=15000 apps/web/src/composables/api/useChat.ws.test.ts apps/web/src/store/chat-list.test.ts
+      # Report-only until the pre-existing error backlog (~476 at introduction)
+      # is burned down; then drop continue-on-error to make this a hard gate.
       - name: Typecheck Web
+        continue-on-error: true
         run: pnpm --filter @memohai/web typecheck

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "vue-tsc --noEmit",
+    "typecheck": "vue-tsc --noEmit -p tsconfig.app.json",
     "start": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

`@memohai/web` type checking has never actually run:

- `apps/web/tsconfig.json` is a solution-style file (`"files": []` + project references), so pointing a checker at it type-checks **zero files**.
- Until recently `apps/web/package.json` had **no `typecheck` script at all**. #800 added one — `"typecheck": "vue-tsc --noEmit"` — **and wired it into CI** (`.github/workflows/eslint.yml`, "Typecheck Web" step). But because the script has no `-p` flag, `vue-tsc` resolves the solution-style root `tsconfig.json`, matches zero input files, and **exits 0 while checking nothing**. Verified locally: the script on current `main` passes silently, so the CI step is green while asserting nothing.

Net effect: the entire web frontend has never been type-checked in any automated way, and since #800 there is a green CI step that gives the appearance that it is. (The desktop app has its own working `typecheck:web` script; only the web app itself is unprotected.)

## Change

Two small changes:

1. `apps/web/package.json`:

```diff
- "typecheck": "vue-tsc --noEmit",
+ "typecheck": "vue-tsc --noEmit -p tsconfig.app.json",
```

`tsconfig.app.json` is the project config that actually `include`s `src/**`. This mirrors the existing working pattern in `apps/desktop` (`vue-tsc --noEmit -p tsconfig.web.json`).

2. `.github/workflows/eslint.yml`: the "Typecheck Web" step (added by #800) now runs with `continue-on-error: true`. The step passed until now only because the script was a no-op; once the script really runs it reports ~476 pre-existing errors, and hard-gating on that would block every PR. The step stays in CI so the backlog count remains visible in logs, but it cannot fail the workflow until the backlog is burned down (see follow-ups).

## Measured result (on current `main`, 00a974fc1)

`pnpm --filter @memohai/web typecheck` now really runs and reports **476 pre-existing errors**:

- **219** in `apps/web/src` itself
- **257** in `@felinic/ui` submodule sources (all `TS2307` — the ui package's internal `#/` import alias is not resolvable from the web app's tsconfig; `@felinic/ui`'s `package.json` has no `imports` field)

Representative samples from `apps/web/src`:

```
src/components/bot-select/index.vue(4,53): error TS2345: Argument of type 'AcceptableValue' is not assignable to parameter of type 'string'.
src/components/config-schema-form/index.vue(145,15): error TS2769: No overload matches this call.
src/lib/api-client.test.ts: 12 errors
src/pages/bots/index.vue: 11 errors
src/pages/login/components/dot-matrix-bg.vue: 10 errors
```

## Scope — what this PR deliberately does NOT do

- **Does not fix any of the 476 pre-existing errors.** Making the backlog visible is the point of this PR; cleanup is a separate effort.
- **Does not add any suppression / baseline-file mechanism.**

## Suggested follow-ups (for maintainers to decide)

1. Triage and burn down the 219 errors in `apps/web/src` (many look mechanical: `TS2322`, `TS18048`, `TS2345`, `TS2532`, `TS2353`).
2. Decide how `@felinic/ui`'s `#/` alias should resolve when type-checked from a consuming package (path mapping in the consumer tsconfig, or adding an `imports` field to the ui package — see comment below for measured data).
3. Once the backlog is near zero, remove `continue-on-error` from the "Typecheck Web" step so it becomes a hard gate.
4. Optionally extend coverage to `tsconfig.node.json` (vite config etc.), which is currently unchecked.

## Test plan

- [ ] `pnpm install && pnpm --filter @memohai/web typecheck`
- [ ] Expected: the command runs `vue-tsc` over the app sources and exits non-zero, reporting ~476 errors (the number will drift as `main` moves).
- [ ] Confirm the eslint.yml workflow stays green: the "Typecheck Web" step should show the errors in its log but not fail the job.
