### PR TITLE
fix(memory): decode escaped IDs in item routes

### DIFF
--- a/internal/handlers/memory.go
+++ b/internal/handlers/memory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -684,6 +685,17 @@ func requireMemoryOwnedByBot(botID, memoryID string) error {
 	return nil
 }
 
+func memoryIDFromPath(c echo.Context) string {
+	memoryID := strings.TrimSpace(c.Param("memory_id"))
+	if c.Request().URL.RawPath == "" {
+		return memoryID
+	}
+	if decoded, err := url.PathUnescape(memoryID); err == nil {
+		return strings.TrimSpace(decoded)
+	}
+	return memoryID
+}
+
 // @Summary Delete memories
 // @Description Delete specific memories by IDs, or delete all memories if no IDs are provided
 // @Tags memory
@@ -762,7 +774,7 @@ func (h *MemoryHandler) ChatDeleteOne(c echo.Context) error {
 		return checkErr
 	}
 
-	memoryID := strings.TrimSpace(c.Param("memory_id"))
+	memoryID := memoryIDFromPath(c)
 	if memoryID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "memory_id is required")
 	}
@@ -800,7 +812,7 @@ func (h *MemoryHandler) ChatUpdate(c echo.Context) error {
 	if checkErr != nil {
 		return checkErr
 	}
-	memoryID := strings.TrimSpace(c.Param("memory_id"))
+	memoryID := memoryIDFromPath(c)
 	if memoryID == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "memory_id is required")
 	}

--- a/internal/handlers/memory_authz_test.go
+++ b/internal/handlers/memory_authz_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 
 	"github.com/memohai/memoh/internal/accounts"
@@ -70,6 +71,91 @@ func requireForbidden(t *testing.T, err error) {
 	}
 	if httpErr.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", httpErr.Code)
+	}
+}
+
+func TestMemoryItemRoutesDecodeEscapedMemoryID(t *testing.T) {
+	botID := "11111111-1111-1111-1111-111111111111"
+	userID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	for _, tt := range []struct {
+		name            string
+		method          string
+		escapedMemoryID string
+		memoryID        string
+		body            string
+		decodedPath     bool
+	}{
+		{
+			name:            "update",
+			method:          http.MethodPut,
+			escapedMemoryID: botID + "%3Amem_123",
+			memoryID:        botID + ":mem_123",
+			body:            `{"memory":"updated"}`,
+		},
+		{
+			name:            "delete",
+			method:          http.MethodDelete,
+			escapedMemoryID: botID + "%3Amem_123",
+			memoryID:        botID + ":mem_123",
+		},
+		{
+			name:            "update literal percent triplet",
+			method:          http.MethodPut,
+			escapedMemoryID: botID + "%3Amem%253Afoo",
+			memoryID:        botID + ":mem%3Afoo",
+			body:            `{"memory":"updated"}`,
+		},
+		{
+			name:            "delete literal percent triplet",
+			method:          http.MethodDelete,
+			escapedMemoryID: botID + "%3Amem%253Afoo",
+			memoryID:        botID + ":mem%3Afoo",
+		},
+		{
+			name:            "update decoded literal percent triplet",
+			method:          http.MethodPut,
+			escapedMemoryID: botID + "%3Amem%253Afoo",
+			memoryID:        botID + ":mem%3Afoo",
+			body:            `{"memory":"updated"}`,
+			decodedPath:     true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, provider := newMemoryAuthzHandler(t, botID, userID)
+			e := echo.New()
+			e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+				return func(c echo.Context) error {
+					c.Set("user", &jwt.Token{
+						Valid: true,
+						Claims: jwt.MapClaims{
+							"sub":     userID,
+							"user_id": userID,
+						},
+					})
+					return next(c)
+				}
+			})
+			handler.Register(e)
+
+			req := httptest.NewRequest(tt.method, "/bots/"+botID+"/memory/"+tt.escapedMemoryID, bytes.NewBufferString(tt.body))
+			if tt.decodedPath {
+				req.URL.Path = "/bots/" + botID + "/memory/" + tt.memoryID
+				req.URL.RawPath = ""
+			}
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("%s encoded memory id %q status = %d, want 200; body = %s", tt.method, tt.memoryID, rec.Code, rec.Body.String())
+			}
+			if tt.method == http.MethodPut && (len(provider.updateCalls) != 1 || provider.updateCalls[0] != tt.memoryID) {
+				t.Fatalf("provider.Update calls = %v, want [%s]", provider.updateCalls, tt.memoryID)
+			}
+			if tt.method == http.MethodDelete && (len(provider.deleteCalls) != 1 || provider.deleteCalls[0] != tt.memoryID) {
+				t.Fatalf("provider.Delete calls = %v, want [%s]", provider.deleteCalls, tt.memoryID)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- decode escaped memory item IDs before update/delete ownership checks and provider calls
- preserve already-decoded IDs when the request has no raw escaped path
- cover encoded colons, literal percent triplets, PUT, and DELETE at the registered Echo route boundary

## Root cause

Memory IDs from the builtin provider contain a colon (`<bot-id>:mem_...`). The generated web client correctly sends that route segment with `encodeURIComponent`, so the browser request contains `%3A`. Echo can expose the escaped route parameter while retaining the raw path, and the handlers previously passed that escaped value directly to the ownership check and memory provider. The ID therefore no longer matched the provider's canonical ID.

Decode the route parameter exactly once when `URL.RawPath` shows that the request arrived escaped. Requests that already contain a decoded path remain unchanged, avoiding double-decoding literal percent triplets.

Fixes #783.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- go test ./internal/handlers -count=1`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- golangci-lint run ./internal/handlers`
- local Chromium E2E through the real Vue app, SDK, Vite proxy, backend, and PostgreSQL: UI login and memory creation succeeded; PUT and DELETE both used an item URL containing a single `%3A` and returned 200; hard reload preserved the edit and confirmed the deletion; final memory count was zero with no page errors or target console errors
