### PR TITLE
fix(deploy): stop SSE streams from exhausting browser HTTP/1.1 connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,12 @@ services:
       MEMOH_SERVER_UPSTREAM: ${MEMOH_SERVER_UPSTREAM:-memoh-server:8080}
     ports:
       - "8082:8082"
+      # HTTPS + HTTP/2：h2 多路复用可避免多标签页的 SSE 长连接占满浏览器对单
+      # origin 的 ~6 条 HTTP/1.1 连接、导致页面卡死（#822）。取消下面两处注释
+      # 并放入证书后自动启用（自签 / mkcert / Let's Encrypt 均可）。
+      # - "8443:8443"
+    # volumes:
+    #   - ./certs:/etc/nginx/certs:ro   # 需包含 server.crt 与 server.key
     depends_on:
       - server
     restart: unless-stopped

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -31,11 +31,19 @@ FROM nginx:alpine
 
 COPY --from=builder /build/apps/web/dist /usr/share/nginx/html
 
-ENV MEMOH_SERVER_UPSTREAM=memoh-server:8080
+ENV MEMOH_SERVER_UPSTREAM=memoh-server:8080 \
+    MEMOH_TLS_CERT=/etc/nginx/certs/server.crt \
+    MEMOH_TLS_KEY=/etc/nginx/certs/server.key \
+    MEMOH_WEB_HTTPS_PORT=8443
 
 COPY docker/nginx.conf /etc/nginx/templates/default.conf.template
+COPY docker/nginx-app.conf /etc/nginx/templates/includes/memoh-app.conf.template
+# HTTPS + HTTP/2 入口（#822）：模板放在 templates-available/，仅当挂载了
+# TLS 证书时由 15-memoh-https.sh 启用，避免无证书时 nginx 启动失败。
+COPY docker/nginx-https.conf /etc/nginx/templates-available/https.conf.template
+COPY --chmod=755 docker/nginx-enable-https.sh /docker-entrypoint.d/15-memoh-https.sh
 
-EXPOSE 8082
+EXPOSE 8082 8443
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:8082/health || exit 1

--- a/docker/nginx-app.conf
+++ b/docker/nginx-app.conf
@@ -1,0 +1,77 @@
+# Memoh Web 应用的 server 级共享配置：HTTP(8082) 与可选 HTTPS/h2 入口共同
+# include 本文件，保证两个入口行为一致。经 envsubst 渲染到
+# /etc/nginx/conf.d/includes/memoh-app.conf（conf.d 子目录不会被自动 include）。
+root /usr/share/nginx/html;
+index index.html;
+
+client_max_body_size 50m;
+
+# Gzip 压缩
+gzip on;
+gzip_vary on;
+gzip_min_length 1024;
+gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json application/javascript;
+
+# 前端路由
+location / {
+    try_files $uri $uri/ /index.html;
+}
+
+# Nginx 健康检查
+location = /health {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 "ok\n";
+}
+
+# 统一代理参数
+proxy_http_version 1.1;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Host $host;
+proxy_cache_bypass $http_upgrade;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_connect_timeout 60s;
+proxy_send_timeout 300s;
+proxy_read_timeout 300s;
+
+# Swagger 文档（保留 /api 前缀）
+location ~ ^/api/(docs(?:/.*)?|swagger\.json)$ {
+    proxy_pass http://${MEMOH_SERVER_UPSTREAM};
+}
+
+# SSE 长连接：关闭代理缓冲与 gzip、拉长读超时，保证事件即时下发。
+# 后端所有 SSE 端点同时发送 X-Accel-Buffering: no，对未列入本 location 的
+# 流式端点（如 POST /bots/stream、容器创建流）同样禁用缓冲。
+location ~ ^/api/(bots/[^/]+/sessions(?:/[^/]+/messages)?/events|bots/[^/]+/web/stream)$ {
+    proxy_pass http://${MEMOH_SERVER_UPSTREAM}/$1$is_args$args;
+    proxy_buffering off;
+    proxy_cache off;
+    gzip off;
+    proxy_read_timeout 1h;
+    proxy_send_timeout 1h;
+}
+
+# API 代理（其余 /api/* 去掉 /api 前缀转发）
+location /api/ {
+    proxy_pass http://${MEMOH_SERVER_UPSTREAM}/;
+}
+
+# Channel webhook proxy. Keep the full path intact.
+location ^~ /channels/ {
+    proxy_pass http://${MEMOH_SERVER_UPSTREAM};
+}
+
+# 静态资源缓存
+location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot)$ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+}
+
+# 安全头
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;

--- a/docker/nginx-enable-https.sh
+++ b/docker/nginx-enable-https.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# 检测 TLS 证书，存在则启用 HTTPS + HTTP/2 入口（#822）。
+# 以 15- 前缀在官方 20-envsubst-on-templates.sh 之前执行：把可选模板放入
+# /etc/nginx/templates/，交给官方 envsubst 脚本统一渲染。
+set -e
+
+ME=$(basename "$0")
+
+cert="${MEMOH_TLS_CERT:-/etc/nginx/certs/server.crt}"
+key="${MEMOH_TLS_KEY:-/etc/nginx/certs/server.key}"
+template="/etc/nginx/templates-available/https.conf.template"
+
+if [ -f "$cert" ] && [ -f "$key" ]; then
+    echo "$ME: found TLS certificate, enabling HTTPS + HTTP/2 on port ${MEMOH_WEB_HTTPS_PORT:-8443}"
+    cp "$template" /etc/nginx/templates/https.conf.template
+else
+    echo "$ME: no TLS certificate at $cert / $key, serving plain HTTP only"
+fi

--- a/docker/nginx-https.conf
+++ b/docker/nginx-https.conf
@@ -1,0 +1,18 @@
+# HTTPS + HTTP/2 入口（#822）：h2 多路复用使单条 TCP 连接即可承载全部并发
+# 流（nginx 默认 http2_max_concurrent_streams 128），绕开浏览器对单 origin
+# 约 6 条 HTTP/1.1 连接的限制，多标签页 / 多 SSE 不再互相阻塞。
+# 上游仍走 HTTP/1.1，后端无需改动。
+#
+# 本模板默认不生效：15-memoh-https.sh 检测到 MEMOH_TLS_CERT 与 MEMOH_TLS_KEY
+# 指向的证书文件同时存在时，才会将其纳入 envsubst 渲染。
+server {
+    listen ${MEMOH_WEB_HTTPS_PORT} ssl;
+    listen [::]:${MEMOH_WEB_HTTPS_PORT} ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate     ${MEMOH_TLS_CERT};
+    ssl_certificate_key ${MEMOH_TLS_KEY};
+
+    include /etc/nginx/conf.d/includes/memoh-app.conf;
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,3 +1,10 @@
+# 仅当客户端真正发起协议升级（WebSocket）时才向上游传递 Connection: upgrade；
+# 普通请求（含 SSE）保持标准的 Connection 语义。
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 8082;
     listen [::]:8082;
@@ -7,7 +14,7 @@ server {
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
+    proxy_set_header Connection $connection_upgrade;
     proxy_set_header Host $host;
     proxy_cache_bypass $http_upgrade;
     proxy_set_header X-Real-IP $remote_addr;
@@ -23,70 +30,14 @@ server {
     }
 }
 
+# HTTP 入口。浏览器对同一 origin 的 HTTP/1.1 并发连接上限约 6 条，多标签页 /
+# 多会话的 SSE 长连接可能占满配额导致普通请求排队（#822）。挂载 TLS 证书即可
+# 额外启用 HTTPS + HTTP/2 入口（h2 多路复用彻底绕开该限制），
+# 见 templates-available/https.conf.template 与 15-memoh-https.sh。
 server {
     listen 8082 default_server;
     listen [::]:8082 default_server;
     server_name _;
-    root /usr/share/nginx/html;
-    index index.html;
 
-    client_max_body_size 50m;
-
-    # Gzip 压缩
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 1024;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json application/javascript;
-
-    # 前端路由
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    # Nginx 健康检查
-    location = /health {
-        access_log off;
-        add_header Content-Type text/plain;
-        return 200 "ok\n";
-    }
-
-    # 统一代理参数
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
-    proxy_set_header Host $host;
-    proxy_cache_bypass $http_upgrade;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Host $host;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_connect_timeout 60s;
-    proxy_send_timeout 300s;
-    proxy_read_timeout 300s;
-
-    # Swagger 文档（保留 /api 前缀）
-    location ~ ^/api/(docs(?:/.*)?|swagger\.json)$ {
-        proxy_pass http://${MEMOH_SERVER_UPSTREAM};
-    }
-
-    # API 代理（其余 /api/* 去掉 /api 前缀转发）
-    location /api/ {
-        proxy_pass http://${MEMOH_SERVER_UPSTREAM}/;
-    }
-
-    # Channel webhook proxy. Keep the full path intact.
-    location ^~ /channels/ {
-        proxy_pass http://${MEMOH_SERVER_UPSTREAM};
-    }
-
-    # 静态资源缓存
-    location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    # 安全头
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    include /etc/nginx/conf.d/includes/memoh-app.conf;
 }

--- a/internal/handlers/containerd.go
+++ b/internal/handlers/containerd.go
@@ -374,9 +374,7 @@ func (h *ContainerdHandler) CreateContainer(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "streaming not supported")
 	}
 
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	c.Response().Header().Set(echo.HeaderCacheControl, "no-cache")
-	c.Response().Header().Set(echo.HeaderConnection, "keep-alive")
+	setSSEHeaders(c)
 	c.Response().WriteHeader(http.StatusOK)
 	writer := c.Response().Writer
 

--- a/internal/handlers/display.go
+++ b/internal/handlers/display.go
@@ -276,9 +276,7 @@ func (h *ContainerdHandler) PrepareDisplay(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "streaming not supported")
 	}
 
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	c.Response().Header().Set(echo.HeaderCacheControl, "no-cache")
-	c.Response().Header().Set(echo.HeaderConnection, "keep-alive")
+	setSSEHeaders(c)
 	c.Response().WriteHeader(http.StatusOK)
 	writer := c.Response().Writer
 	send := func(payload displayPrepareStreamEvent) {

--- a/internal/handlers/local_channel.go
+++ b/internal/handlers/local_channel.go
@@ -452,9 +452,7 @@ func (h *LocalChannelHandler) StreamMessages(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "route hub not configured")
 	}
 
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	c.Response().Header().Set(echo.HeaderCacheControl, "no-cache")
-	c.Response().Header().Set(echo.HeaderConnection, "keep-alive")
+	setSSEHeaders(c)
 	c.Response().WriteHeader(http.StatusOK)
 
 	flusher, ok := c.Response().Writer.(http.Flusher)

--- a/internal/handlers/message_stream.go
+++ b/internal/handlers/message_stream.go
@@ -406,10 +406,19 @@ func writeMessageCreated(writer io.Writer, flusher http.Flusher, botID string, m
 	})
 }
 
-func beginSSEResponse(c echo.Context) (io.Writer, http.Flusher, error) {
+// setSSEHeaders applies the response headers shared by every SSE endpoint.
+// X-Accel-Buffering disables per-response proxy buffering in nginx (and
+// compatible reverse proxies) so events reach the browser as soon as the
+// handler flushes them, without requiring proxy-side location tuning.
+func setSSEHeaders(c echo.Context) {
 	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
 	c.Response().Header().Set(echo.HeaderCacheControl, "no-cache")
 	c.Response().Header().Set(echo.HeaderConnection, "keep-alive")
+	c.Response().Header().Set("X-Accel-Buffering", "no")
+}
+
+func beginSSEResponse(c echo.Context) (io.Writer, http.Flusher, error) {
+	setSSEHeaders(c)
 	c.Response().WriteHeader(http.StatusOK)
 	flusher, ok := c.Response().Writer.(http.Flusher)
 	if !ok {

--- a/internal/handlers/sse_headers_test.go
+++ b/internal/handlers/sse_headers_test.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// TestBeginSSEResponseSetsProxyFriendlyHeaders guards the header contract for
+// every SSE endpoint: X-Accel-Buffering tells nginx (and compatible reverse
+// proxies) to disable response buffering so events reach the browser as soon
+// as the handler flushes them. Without it, proxy_buffering (on by default)
+// can hold events back indefinitely.
+func TestBeginSSEResponseSetsProxyFriendlyHeaders(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if _, _, err := beginSSEResponse(c); err != nil {
+		t.Fatalf("beginSSEResponse: %v", err)
+	}
+
+	want := map[string]string{
+		echo.HeaderContentType:  "text/event-stream",
+		echo.HeaderCacheControl: "no-cache",
+		echo.HeaderConnection:   "keep-alive",
+		"X-Accel-Buffering":     "no",
+	}
+	for key, value := range want {
+		if got := rec.Header().Get(key); got != value {
+			t.Fatalf("header %s = %q, want %q", key, got, value)
+		}
+	}
+}

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -552,9 +552,7 @@ func (h *UsersHandler) createBotStream(c echo.Context, ownerID string, ownerFrom
 		return createBotHTTPError(err, ownerFromToken)
 	}
 
-	c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
-	c.Response().Header().Set(echo.HeaderCacheControl, "no-cache")
-	c.Response().Header().Set(echo.HeaderConnection, "keep-alive")
+	setSSEHeaders(c)
 	c.Response().WriteHeader(http.StatusOK)
 	writer := c.Response().Writer
 


### PR DESCRIPTION
Closes #822

## 问题

浏览器对同一 origin 的 HTTP/1.1 并发连接上限约 6 条，每条 SSE 流长期独占一条连接。多开标签页 / 多个 bot 会话页时连接配额被占满，后续 REST 请求排队等待，页面整体卡死。

## 修复内容

### 后端：所有 SSE 端点发送 `X-Accel-Buffering: no`

抽出共享的 `setSSEHeaders` helper，统一覆盖全部 5 处 SSE 端点（session 消息流、bot 活动流、web/stream、bot 创建流、容器创建流、display prepare 流）。nginx 及兼容反代会按响应关闭缓冲，事件即时下发，无需依赖 location 级配置。

### nginx：SSE 反代优化

- `Connection: upgrade` 改为 `map $http_upgrade $connection_upgrade`，仅在真正的协议升级请求上传递（原来对所有请求无条件设置，不规范）；
- 为长连接 SSE 端点（`sessions/*/messages/events`、`sessions/events`、`web/stream`）加专用 location：`proxy_buffering off`、`gzip off`、读超时拉长到 1h。

### nginx：可选 HTTPS + HTTP/2 入口（根治）

- 新增 8443 端口的 TLS + h2 server 模板，由 `docker-entrypoint.d/15-memoh-https.sh` 在检测到证书（默认 `/etc/nginx/certs/server.crt|key`，路径可用 `MEMOH_TLS_CERT` / `MEMOH_TLS_KEY` 覆盖）时自动启用，无证书时保持纯 HTTP，行为完全向后兼容；
- h2 多路复用使单条 TCP 连接承载全部并发流，彻底绕开 6 连接限制；上游仍走 HTTP/1.1，Go 后端无需改动；
- 主 server 的应用配置抽成共享 include（`conf.d/includes/memoh-app.conf`），HTTP 与 HTTPS 两个入口行为保持一致；
- `docker-compose.yml` 中提供注释掉的 `8443` 端口映射与证书挂载示例（自签 / mkcert / Let's Encrypt 均可）。

## 验证

- 新增 `TestBeginSSEResponseSetsProxyFriendlyHeaders` 守护 SSE 头契约（TDD：先红后绿）；`go test ./...` 全量通过，`golangci-lint` 无告警；
- 用 `nginx:alpine` 实际渲染模板双模式验证：无证书 → 仅 HTTP、`nginx -t` 通过；有证书 → HTTPS 入口启用、`curl --http2` 实测返回 `HTTP/2 200`；
- 穿透测试确认路径改写正确：`/api/bots/*/sessions/*/messages/events` → 去掉 `/api` 前缀、查询串保留，普通 `/api/*` 路由不受影响。

## 未包含（issue 中的可选项）

前端 BroadcastChannel / SharedWorker 共享 SSE 流的兜底方案未包含在本 PR——启用 h2 后收益有限，如仍需要建议单开 issue 跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)