### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,29 @@ jobs:
             "${RUNNER_TEMP}/Memoh-${VERSION}-source.zip" \
             --clobber
 
+  # npm publish jobs authenticate via npm trusted publishing (OIDC), not token
+  # secrets: each published package has memohai/Memoh + this release.yml
+  # registered as its trusted publisher on npmjs.com, and pnpm exchanges the
+  # GitHub OIDC token at publish time (requires id-token: write on the job).
+  # The npm-side trusted publisher entry has NO environment name, so these jobs
+  # must NOT declare an `environment:` — npm matches repo + workflow +
+  # environment exactly, and a mismatch fails auth with an opaque 404.
+  # If a package is ever added to the publish allowlist in
+  # scripts/publish-packages.mjs, it must get the same trusted-publisher entry
+  # on npmjs.com first, or its publish will fail. The old NPM_TOKEN /
+  # FELINIC_NPM_TOKEN secrets are retired; scripts/publish-packages.mjs still
+  # supports NODE_AUTH_TOKEN for local manual publishes.
   npm-publish-felinic:
     name: Publish @felinic/ui
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'push'
+    # Also runs on workflow_dispatch so a failed publish of an existing tag can
+    # be retried; scripts/publish-packages.mjs skips already-published versions,
+    # which keeps re-runs idempotent.
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -124,6 +142,18 @@ jobs:
             if (!fs.existsSync(target)) continue;
             const pkg = JSON.parse(fs.readFileSync(target, 'utf8'));
             pkg.version = version;
+            // npm provenance (auto-generated for trusted publishing) requires
+            // repository.url to exactly match the repo the OIDC token is
+            // minted for — always memohai/Memoh here. Stamp it at release time
+            // so a missing/stale field can never fail the publish, and so
+            // packages/ui (a submodule whose own repo is memohai/ui) gets the
+            // Memoh URL, matching where the publish actually runs.
+            const directory = target.replace(/\/package\.json$/, '');
+            pkg.repository = {
+              type: 'git',
+              url: 'git+https://github.com/memohai/Memoh.git',
+              ...(directory === 'package.json' || directory === '' ? {} : { directory }),
+            };
             fs.writeFileSync(target, `${JSON.stringify(pkg, null, 2)}\n`);
           }
           EOF
@@ -137,17 +167,8 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
-      - name: Verify @felinic publish token
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.FELINIC_NPM_TOKEN }}
-        run: |
-          npm whoami
-          npm ping
-          npm access list packages @felinic \
-            || (echo "::error::FELINIC_NPM_TOKEN cannot reach the @felinic scope" && exit 1)
       - name: Publish @felinic/ui
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.FELINIC_NPM_TOKEN }}
           NPM_PUBLISH_SCOPE: "@felinic"
         run: pnpm publish:npm
 
@@ -155,7 +176,11 @@ jobs:
     name: Publish @memohai packages
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'push'
+    # workflow_dispatch allowed for the same retry reason as the felinic job.
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -182,6 +207,18 @@ jobs:
             if (!fs.existsSync(target)) continue;
             const pkg = JSON.parse(fs.readFileSync(target, 'utf8'));
             pkg.version = version;
+            // npm provenance (auto-generated for trusted publishing) requires
+            // repository.url to exactly match the repo the OIDC token is
+            // minted for — always memohai/Memoh here. Stamp it at release time
+            // so a missing/stale field can never fail the publish, and so
+            // packages/ui (a submodule whose own repo is memohai/ui) gets the
+            // Memoh URL, matching where the publish actually runs.
+            const directory = target.replace(/\/package\.json$/, '');
+            pkg.repository = {
+              type: 'git',
+              url: 'git+https://github.com/memohai/Memoh.git',
+              ...(directory === 'package.json' || directory === '' ? {} : { directory }),
+            };
             fs.writeFileSync(target, `${JSON.stringify(pkg, null, 2)}\n`);
           }
           EOF
@@ -195,15 +232,8 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
-      - name: Verify @memohai publish token
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          npm whoami
-          npm ping
       - name: Publish @memohai packages
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_PUBLISH_SCOPE: "@memohai"
         run: pnpm publish:npm
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/memohai/Memoh",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/memohai/Memoh.git"
+    "url": "git+https://github.com/memohai/Memoh.git",
+    "directory": "apps/desktop"
   },
   "main": "./out/main/index.js",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@memohai/web",
   "version": "0.16.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/memohai/Memoh.git",
+    "directory": "apps/web"
+  },
   "type": "module",
   "exports": {
     ".": "./src/main.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@memohai/config",
   "version": "0.16.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/memohai/Memoh.git",
+    "directory": "packages/config"
+  },
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@memohai/icon",
   "version": "0.16.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/memohai/Memoh.git",
+    "directory": "packages/icons"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@memohai/runtime",
   "version": "0.16.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/memohai/Memoh.git",
+    "directory": "packages/runtime"
+  },
   "description": "Embeddable Memoh Remote Runtime SDK and CLI",
   "type": "module",
   "bin": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@memohai/sdk",
   "version": "0.16.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/memohai/Memoh.git",
+    "directory": "packages/sdk"
+  },
   "description": "",
   "exports": {
     ".": "./src/index.ts",

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -31,6 +31,19 @@ const log = {
 const dryRun = process.argv.includes('--dry-run') || process.env.PUBLISH_PACKAGES_DRY_RUN === '1'
 const publishScope = process.env.NPM_PUBLISH_SCOPE?.trim() || null
 
+// Auth model: two modes.
+// - Token mode (local/manual): NODE_AUTH_TOKEN is set and used directly.
+// - OIDC mode (CI trusted publishing): no token; pnpm exchanges the GitHub
+//   Actions OIDC token (ACTIONS_ID_TOKEN_REQUEST_TOKEN, available when the job
+//   has id-token: write) for a short-lived npm credential at publish time.
+//   Every published package must have memohai/Memoh + release.yml registered
+//   as its trusted publisher on npmjs.com, or the exchange is rejected.
+// OIDC mode changes two behaviors below: the token preflight is impossible
+// (npm whoami needs a token), so it is skipped; and --provenance is added,
+// which both requires OIDC and records the build provenance on npm.
+const hasToken = Boolean(process.env.NODE_AUTH_TOKEN?.trim())
+const oidcMode = !hasToken && Boolean(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)
+
 function prereleaseTag(version) {
   const override = process.env.NPM_PUBLISH_TAG?.trim()
   if (override) {
@@ -48,6 +61,9 @@ function prereleaseTag(version) {
 
 function publishOptions(version) {
   const args = ['--access', 'public', '--no-git-checks']
+  if (oidcMode) {
+    args.push('--provenance')
+  }
   const tag = prereleaseTag(version)
   if (tag) {
     args.push('--tag', tag)
@@ -103,12 +119,9 @@ function scopeReachable(scope) {
 // Preflight: before publishing ANY package, verify the token can reach every
 // scope we are about to publish into. Fail closed — if we can't confirm a
 // scope, abort the whole run so npm never ends up with a partial release
-// (e.g. @memohai/* published but @felinic/ui rejected at 403). Skipped in
-// dry-run so local token-free runs keep working.
-//
-// Kept in sync with the publish loop below and the release token step in
-// .github/workflows/release.yml. @felinic/ui in particular is a first-publish
-// into a scope whose org must already exist with the token as a member.
+// (e.g. @memohai/* published but @felinic/ui rejected at 403). Token-mode
+// only: OIDC trusted publishing has no token to check, and dry-run skips it
+// so local token-free runs keep working. See the mode note at the top.
 function preflightScopes(plan) {
   const scopes = [...new Set(plan.map((p) => scopeOf(p.name)).filter(Boolean))]
   if (scopes.length === 0) {
@@ -197,12 +210,19 @@ for (const dir of CANDIDATE_DIRS) {
   plan.push({ dir, name, version })
 }
 
-// Preflight gate. On real runs a scope we can't reach aborts everything before
-// the first publish, so npm is never left with a partial release. Dry-run skips
-// it so token-free local/CI dry runs keep working.
-if (!dryRun && plan.length > 0 && !preflightScopes(plan)) {
-  console.log(`\nSummary: 0 published, ${skipped} skipped, ${plan.length} blocked by preflight`)
-  process.exit(1)
+// Preflight gate. On real token-mode runs a scope we can't reach aborts
+// everything before the first publish, so npm is never left with a partial
+// release. OIDC mode skips it: there is no token to check (whoami/access-list
+// would fail spuriously), and a missing trusted-publisher entry fails that
+// package's publish loudly instead. Dry-run skips it so token-free local/CI
+// dry runs keep working.
+if (!dryRun && plan.length > 0) {
+  if (oidcMode) {
+    log.info('OIDC trusted publishing (no NODE_AUTH_TOKEN): skipping token preflight; auth happens per-package at publish time')
+  } else if (!preflightScopes(plan)) {
+    console.log(`\nSummary: 0 published, ${skipped} skipped, ${plan.length} blocked by preflight`)
+    process.exit(1)
+  }
 }
 
 for (const { dir, name, version } of plan) {


### PR DESCRIPTION
## Summary

Since v0.12.0 every @memohai npm publish has failed with **EOTP**: npm revoked classic tokens (Dec 2025), and the replacement granular token in `NPM_TOKEN` cannot bypass the account's 2FA, so every publish demands an interactive OTP that CI cannot provide. `@felinic/ui` kept publishing only because `FELINIC_NPM_TOKEN` bypasses 2FA. Result: **@memohai/\* v0.12.0–v0.16.0 were never published**.

This PR switches both publish jobs to **npm trusted publishing (OIDC)** — no tokens, no 2FA prompts, automatic provenance.

## Changes

- **`.github/workflows/release.yml`**
  - Both npm jobs get `permissions: { contents: read, id-token: write }` and drop `NODE_AUTH_TOKEN` + the token verify steps (`npm whoami` has no token to check in OIDC mode).
  - Both jobs also run on `workflow_dispatch` so the missed v0.12.0–v0.16.0 @memohai versions can be republished; already-published versions are skipped by the script, keeping re-runs idempotent.
  - Version sync now force-stamps `repository.url` (+ `directory`): auto-generated provenance requires an exact match with the OIDC-minting repo, and `packages/ui` is a submodule whose own repo (memohai/ui) would mismatch the Memoh-minted token — no memohai/ui change needed.
- **`scripts/publish-packages.mjs`**
  - Detects OIDC mode (no `NODE_AUTH_TOKEN` + `ACTIONS_ID_TOKEN_REQUEST_TOKEN`): skips the token preflight there and adds `--provenance`; token path unchanged for local manual publishes.
- **package.json**: add missing `repository` fields (5 packages) + `directory` subfield (desktop).

## Prerequisites (already done on npmjs.com)

All 7 published packages have `memohai/Memoh` + `release.yml` registered as trusted publisher, permission `npm publish`, **no environment name** (the jobs must not declare `environment:` — npm matches repo+workflow+environment exactly).

## Test plan

- [ ] After merge, `workflow_dispatch` a release run to verify both npm jobs go green (felinic skips already-published, memohai publishes under OIDC) and packages show the Provenance badge
- [ ] Optionally first dispatch with `tag_name=v0.17.0-next.0` to exercise the full OIDC path on the `next` dist-tag without touching `latest`
- [ ] Backfill missing @memohai versions (dispatch v0.16.0, or they ship with the next tag)
- [ ] Once green, delete the `NPM_TOKEN` / `FELINIC_NPM_TOKEN` repo secrets