### PR TITLE
fix(web): restore tool approval layout

### DIFF
--- a/apps/web/src/components/settings/row.vue
+++ b/apps/web/src/components/settings/row.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    class="mx-4 flex min-h-[3.75rem] border-b border-border py-3 last:border-b-0"
-    :class="rootClass"
+    class="mx-4 flex min-h-[3.75rem] border-border py-3 last:border-b-0"
+    :class="[rootClass, dividerClass]"
   >
     <!-- Leading media: an icon, avatar, channel mark, or a load skeleton that
          sits before the text. Only renders (and only claims its gap) when a
@@ -65,12 +65,18 @@ const props = withDefaults(defineProps<{
   // field (a full-width Textarea under its label) needs, where the control is
   // never a beside-the-label affordance.
   stack?: 'never' | 'sm' | 'always'
+  // A row can visually continue into the next row (for example, a mode picker
+  // followed by fields owned by that mode) without drawing a divider between them.
+  divider?: boolean
 }>(), {
   label: '',
   description: '',
   align: 'center',
   stack: 'never',
+  divider: true,
 })
+
+const dividerClass = computed(() => (props.divider ? 'border-b' : 'border-b-0'))
 
 const rootClass = computed(() => {
   // Full literal class strings only — Tailwind scans source text, so a runtime
@@ -101,4 +107,3 @@ const trailingClass = computed(() => {
   }
 })
 </script>
-

--- a/apps/web/src/pages/bots/components/bot-tool-approval.vue
+++ b/apps/web/src/pages/bots/components/bot-tool-approval.vue
@@ -46,78 +46,74 @@
         :key="target.target_id"
         :title="targetName(target)"
       >
-        <SettingsRow
-          :label="t('bots.toolApproval.enabled')"
-          :description="targetApprovalDescription(target)"
-        >
+        <template #actions>
           <Switch
             :model-value="draftFor(target).enabled"
             :disabled="isSaving"
+            :aria-label="t('bots.toolApproval.enabled')"
             @update:model-value="(value) => updateEnabled(target, !!value)"
           />
-        </SettingsRow>
+        </template>
 
-        <template v-if="draftFor(target).enabled">
-          <ExpandableSettingsRow
-            v-for="tool in approvalTools"
-            :key="target.target_id + ':' + tool"
-            :open="expandedRows.has(rowKey(target, tool))"
+        <template
+          v-for="tool in approvalTools"
+          :key="target.target_id + ':' + tool"
+        >
+          <SettingsRow
+            stack="sm"
+            :divider="modeFor(target, tool) !== 'ask'"
             :label="t('bots.toolApproval.toolNames.' + tool)"
             :description="t('bots.toolApproval.tools.' + tool)"
-            @update:open="(open) => setExpanded(rowKey(target, tool), open)"
           >
-            <template #trailing>
-              <span class="text-xs text-muted-foreground">
-                {{ t('bots.toolApproval.modes.' + modeFor(target, tool)) }}
-              </span>
-            </template>
+            <SegmentedControl
+              :model-value="modeFor(target, tool)"
+              :items="modeItems"
+              :aria-label="t('bots.toolApproval.toolNames.' + tool)"
+              class="w-full sm:w-fit"
+              @update:model-value="(value) => updateMode(target, tool, value)"
+            />
+          </SettingsRow>
 
-            <template #expanded>
-              <FormStack class="pb-1">
-                <FieldStack :label="t('bots.toolApproval.behavior.label')">
-                  <SegmentedControl
-                    :model-value="modeFor(target, tool)"
-                    :items="modeItems"
-                    :aria-label="t('bots.toolApproval.toolNames.' + tool)"
-                    class="w-full sm:w-fit"
-                    @update:model-value="(value) => updateMode(target, tool, value)"
+          <SettingsRow
+            v-if="modeFor(target, tool) === 'ask'"
+            stack="always"
+          >
+            <template #content>
+              <div class="grid gap-4 sm:grid-cols-2">
+                <FieldStack
+                  :label="t('bots.toolApproval.bypass')"
+                  :for="ruleFieldId(target, tool, 'bypass')"
+                >
+                  <Textarea
+                    :id="ruleFieldId(target, tool, 'bypass')"
+                    :model-value="ruleText(target, tool, 'bypass')"
+                    :placeholder="rulePlaceholder(tool, 'bypass')"
+                    :disabled="isSaving"
+                    rows="4"
+                    class="font-mono text-xs"
+                    spellcheck="false"
+                    @update:model-value="(value) => updateRules(target, tool, 'bypass', String(value ?? ''))"
                   />
                 </FieldStack>
 
-                <template v-if="modeFor(target, tool) === 'ask'">
-                  <FieldStack
-                    :label="t('bots.toolApproval.bypass')"
-                    :help="ruleHelp(tool, 'bypass')"
-                  >
-                    <Textarea
-                      :model-value="ruleText(target, tool, 'bypass')"
-                      :placeholder="rulePlaceholder(tool, 'bypass')"
-                      :disabled="isSaving"
-                      rows="4"
-                      class="font-mono text-xs"
-                      spellcheck="false"
-                      @update:model-value="(value) => updateRules(target, tool, 'bypass', String(value ?? ''))"
-                    />
-                  </FieldStack>
-
-                  <FieldStack
-                    :label="t('bots.toolApproval.mustReview')"
-                    :help="ruleHelp(tool, 'force')"
-                  >
-                    <Textarea
-                      :model-value="ruleText(target, tool, 'force')"
-                      :placeholder="rulePlaceholder(tool, 'force')"
-                      :disabled="isSaving"
-                      rows="4"
-                      class="font-mono text-xs"
-                      spellcheck="false"
-                      @update:model-value="(value) => updateRules(target, tool, 'force', String(value ?? ''))"
-                    />
-                  </FieldStack>
-                </template>
-              </FormStack>
+                <FieldStack
+                  :label="t('bots.toolApproval.mustReview')"
+                  :for="ruleFieldId(target, tool, 'force')"
+                >
+                  <Textarea
+                    :id="ruleFieldId(target, tool, 'force')"
+                    :model-value="ruleText(target, tool, 'force')"
+                    :placeholder="rulePlaceholder(tool, 'force')"
+                    :disabled="isSaving"
+                    rows="4"
+                    class="font-mono text-xs"
+                    spellcheck="false"
+                    @update:model-value="(value) => updateRules(target, tool, 'force', String(value ?? ''))"
+                  />
+                </FieldStack>
+              </div>
             </template>
-          </ExpandableSettingsRow>
+          </SettingsRow>
         </template>
       </SettingsSection>
     </div>
@@ -142,9 +138,7 @@ import {
   toast,
 } from '@felinic/ui'
 import PageShell from '@/components/page-shell/index.vue'
-import ExpandableSettingsRow from '@/components/settings/expandable-row.vue'
 import FieldStack from '@/components/settings/field-stack.vue'
-import FormStack from '@/components/settings/form-stack.vue'
 import SettingsSection from '@/components/settings/section.vue'
 import SettingsRow from '@/components/settings/row.vue'
 import InlineLoadingRow from '@/components/inline-loading-row/index.vue'
@@ -199,7 +193,6 @@ const {
 const targetItems = ref<WorkspaceWorkspaceTarget[]>([])
 const drafts = ref<Record<string, ToolApprovalConfig>>({})
 const savedConfigs = ref<Record<string, ToolApprovalConfig>>({})
-const expandedRows = ref(new Set<string>())
 const isSaving = ref(false)
 
 watch(workspaceTargetsResponse, (response) => {
@@ -276,12 +269,6 @@ function draftFor(target: ValidWorkspaceTarget): ToolApprovalConfig {
   return drafts.value[target.target_id] ?? defaultToolApprovalConfig(targetKind(target))
 }
 
-function targetApprovalDescription(target: ValidWorkspaceTarget): string {
-  return draftFor(target).enabled
-    ? t('bots.toolApproval.enabledDescription')
-    : t('bots.toolApproval.disabledDescription')
-}
-
 function replaceDraft(target: ValidWorkspaceTarget, config: ToolApprovalConfig): void {
   drafts.value = {
     ...drafts.value,
@@ -338,16 +325,6 @@ function updateRules(target: ValidWorkspaceTarget, tool: ApprovalTool, kind: Rul
   replaceDraft(target, config)
 }
 
-function ruleHelp(tool: ApprovalTool, kind: RuleKind): string {
-  const prefix = kind === 'bypass'
-    ? t('bots.toolApproval.bypassHint')
-    : t('bots.toolApproval.mustReviewHint')
-  const syntax = tool === 'exec'
-    ? t('bots.toolApproval.commandSyntaxHint')
-    : t('bots.toolApproval.pathSyntaxHint')
-  return prefix + ' ' + syntax
-}
-
 function rulePlaceholder(tool: ApprovalTool, kind: RuleKind): string {
   if (tool === 'exec') {
     return t(kind === 'bypass'
@@ -359,15 +336,8 @@ function rulePlaceholder(tool: ApprovalTool, kind: RuleKind): string {
     : 'bots.toolApproval.placeholders.fileMustReview')
 }
 
-function rowKey(target: ValidWorkspaceTarget, tool: ApprovalTool): string {
-  return target.target_id + ':' + tool
-}
-
-function setExpanded(key: string, open: boolean): void {
-  const next = new Set(expandedRows.value)
-  if (open) next.add(key)
-  else next.delete(key)
-  expandedRows.value = next
+function ruleFieldId(target: ValidWorkspaceTarget, tool: ApprovalTool, kind: RuleKind): string {
+  return `tool-approval-${target.target_id}-${tool}-${kind}`
 }
 
 async function saveChanges(): Promise<void> {


### PR DESCRIPTION
## Summary

- move each Tool Approval toggle beside its workspace or computer name
- restore the three persistent Allow / Ask / Deny controls without expandable rows
- show Bypass and Must review rules in a compact two-column layout for Ask mode
- visually join each Ask rule editor to its mode row by removing the internal divider

## Why

The recent remote runtime update made each tool row expandable and promoted Tool Approval into a standalone row. That added interaction and visual weight compared with the previous settings layout. This restores the simpler layout while preserving per-target approval configuration and rule editing.

## Validation

- `pnpm exec eslint apps/web/src/components/settings/row.vue apps/web/src/pages/bots/components/bot-tool-approval.vue`
- `pnpm exec vitest run apps/web/src/pages/bots/components/tool-approval-config.test.ts`
- `node scripts/check-ui-contract.mjs`
- `pnpm --filter @memohai/web build`
- pre-commit Go test suite
- browser QA in dark mode at wide and 390px viewports