### PR TITLE
refactor(agent): persist subagent fork context in history

### DIFF
--- a/db/postgres/migrations/0001_init.up.sql
+++ b/db/postgres/migrations/0001_init.up.sql
@@ -668,6 +668,11 @@ CREATE INDEX IF NOT EXISTS idx_bot_history_messages_session_source
   ON bot_history_messages(session_id, source_message_id);
 CREATE INDEX IF NOT EXISTS idx_bot_history_messages_session_reply
   ON bot_history_messages(session_id, source_reply_to_message_id);
+CREATE INDEX IF NOT EXISTS idx_bot_history_messages_subagent_fork_context
+  ON bot_history_messages(session_id, turn_position, turn_message_seq)
+  WHERE turn_visible = false
+    AND session_mode = 'subagent'
+    AND metadata->>'context_scope' = 'subagent_fork';
 
 CREATE OR REPLACE VIEW bot_visible_history_messages AS
 SELECT
@@ -2175,8 +2180,8 @@ SELECT set_config(
     false
 );
 
--- Managed subagents pin their selected model and may retain an invisible
--- snapshot of the parent model context for forked execution.
+-- Managed subagents pin their selected model. Forked model context is stored
+-- as scoped invisible rows in bot_history_messages.
 CREATE TABLE IF NOT EXISTS public.subagent_configs (
     team_id         UUID        NOT NULL DEFAULT public.memoh_current_team_id()
                                 REFERENCES public.teams(id) ON DELETE RESTRICT,
@@ -2185,7 +2190,6 @@ CREATE TABLE IF NOT EXISTS public.subagent_configs (
     model_id        TEXT        NOT NULL,
     provider_name   TEXT        NOT NULL,
     forked          BOOLEAN     NOT NULL DEFAULT false,
-    parent_messages JSONB,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     CONSTRAINT subagent_configs_team_session_key UNIQUE (team_id, session_id),
@@ -2194,11 +2198,7 @@ CREATE TABLE IF NOT EXISTS public.subagent_configs (
         REFERENCES public.bot_sessions(team_id, id) ON DELETE CASCADE,
     CONSTRAINT subagent_configs_model_uuid_fkey
         FOREIGN KEY (team_id, model_uuid)
-        REFERENCES public.models(team_id, id) ON DELETE SET NULL (model_uuid),
-    CONSTRAINT subagent_configs_fork_snapshot_check CHECK (
-        (forked AND parent_messages IS NOT NULL AND jsonb_typeof(parent_messages) = 'array')
-        OR (NOT forked AND parent_messages IS NULL)
-    )
+        REFERENCES public.models(team_id, id) ON DELETE SET NULL (model_uuid)
 );
 
 CREATE INDEX IF NOT EXISTS idx_subagent_configs_team_model

--- a/db/postgres/migrations/0119_subagent_fork_history.down.sql
+++ b/db/postgres/migrations/0119_subagent_fork_history.down.sql
@@ -1,0 +1,18 @@
+-- 0119_subagent_fork_history
+-- Restore the legacy parent-message snapshot column for managed subagents.
+
+DROP INDEX IF EXISTS public.idx_bot_history_messages_subagent_fork_context;
+
+TRUNCATE TABLE public.subagent_configs;
+
+ALTER TABLE public.subagent_configs
+    ADD COLUMN IF NOT EXISTS parent_messages JSONB;
+
+ALTER TABLE public.subagent_configs
+    DROP CONSTRAINT IF EXISTS subagent_configs_fork_snapshot_check;
+
+ALTER TABLE public.subagent_configs
+    ADD CONSTRAINT subagent_configs_fork_snapshot_check CHECK (
+        (forked AND parent_messages IS NOT NULL AND jsonb_typeof(parent_messages) = 'array')
+        OR (NOT forked AND parent_messages IS NULL)
+    );

--- a/db/postgres/migrations/0119_subagent_fork_history.up.sql
+++ b/db/postgres/migrations/0119_subagent_fork_history.up.sql
@@ -1,0 +1,16 @@
+-- 0119_subagent_fork_history
+-- Store forked subagent context as scoped invisible history messages.
+
+TRUNCATE TABLE public.subagent_configs;
+
+ALTER TABLE public.subagent_configs
+    DROP CONSTRAINT IF EXISTS subagent_configs_fork_snapshot_check;
+
+ALTER TABLE public.subagent_configs
+    DROP COLUMN IF EXISTS parent_messages;
+
+CREATE INDEX IF NOT EXISTS idx_bot_history_messages_subagent_fork_context
+    ON public.bot_history_messages (session_id, turn_position, turn_message_seq)
+    WHERE turn_visible = false
+      AND session_mode = 'subagent'
+      AND metadata->>'context_scope' = 'subagent_fork';

--- a/db/postgres/queries/sessions.sql
+++ b/db/postgres/queries/sessions.sql
@@ -462,7 +462,14 @@ SELECT *
 FROM bot_sessions
 WHERE team_id = public.memoh_current_team_id()
   AND parent_session_id = sqlc.arg(parent_session_id)
+  AND type = 'subagent'
   AND deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM subagent_configs config
+    WHERE config.team_id = public.memoh_current_team_id()
+      AND config.session_id = bot_sessions.id
+  )
 ORDER BY created_at DESC;
 
 -- name: SoftDeleteSessionsByBot :exec

--- a/db/postgres/queries/subagents.sql
+++ b/db/postgres/queries/subagents.sql
@@ -4,10 +4,9 @@ INSERT INTO subagent_configs (
   model_uuid,
   model_id,
   provider_name,
-  forked,
-  parent_messages
+  forked
 ) VALUES (
-  $1, $2, $3, $4, $5, $6
+  $1, $2, $3, $4, $5
 )
 RETURNING *;
 
@@ -16,22 +15,151 @@ SELECT *
 FROM subagent_configs
 WHERE session_id = $1;
 
--- name: UpsertSubagentConfig :one
-INSERT INTO subagent_configs (
-  session_id,
-  model_uuid,
-  model_id,
-  provider_name,
-  forked,
-  parent_messages
-) VALUES (
-  $1, $2, $3, $4, $5, $6
+-- name: CreateSubagentForkContext :one
+WITH target_session AS MATERIALIZED (
+  SELECT child.id, child.bot_id, child.team_id
+  FROM bot_sessions child
+  JOIN bot_sessions parent
+    ON parent.team_id = public.memoh_current_team_id()
+   AND parent.id = sqlc.arg(parent_session_id)
+   AND parent.id = child.parent_session_id
+   AND parent.bot_id = child.bot_id
+   AND parent.deleted_at IS NULL
+  WHERE child.team_id = public.memoh_current_team_id()
+    AND child.id = sqlc.arg(session_id)
+    AND child.type = 'subagent'
+    AND child.deleted_at IS NULL
+),
+context_entries AS MATERIALIZED (
+  SELECT entry, ordinality::bigint AS position
+  FROM jsonb_array_elements(sqlc.arg(context_messages)::jsonb)
+       WITH ORDINALITY AS items(entry, ordinality)
+),
+prepared_messages AS MATERIALIZED (
+  SELECT
+    gen_random_uuid() AS id,
+    gen_random_uuid() AS turn_id,
+    entries.position,
+    source.id AS source_id,
+    target.id AS session_id,
+    target.bot_id,
+    source.sender_channel_identity_id,
+    source.sender_account_user_id,
+    source.source_message_id,
+    source.source_reply_to_message_id,
+    COALESCE(source.role, entries.entry->>'role') AS role,
+    COALESCE(source.content, entries.entry->'message') AS content,
+    COALESCE(source.metadata, '{}'::jsonb)
+      || jsonb_build_object(
+        'context_scope', 'subagent_fork',
+        'context_version', 1,
+        'source_session_id', sqlc.arg(parent_session_id)::text
+      )
+      || CASE
+        WHEN source.id IS NULL THEN '{}'::jsonb
+        ELSE jsonb_build_object('source_message_id', source.id::text)
+      END AS metadata,
+    COALESCE(source.runtime_type, 'model') AS runtime_type,
+    source.model_id,
+    source.display_text,
+    COALESCE(source.created_at, now()) AS created_at
+  FROM context_entries entries
+  CROSS JOIN target_session target
+  LEFT JOIN bot_history_messages source
+    ON source.team_id = public.memoh_current_team_id()
+   AND source.id = NULLIF(entries.entry->>'source_message_id', '')::uuid
+   AND source.session_id = sqlc.arg(parent_session_id)
+   AND source.bot_id = target.bot_id
+),
+updated_session AS (
+  UPDATE bot_sessions session
+  SET next_turn_position = (SELECT count(*)::bigint + 1 FROM context_entries)
+  FROM target_session target
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
+  RETURNING session.id
+),
+inserted_messages AS (
+  INSERT INTO bot_history_messages (
+    id,
+    bot_id,
+    session_id,
+    sender_channel_identity_id,
+    sender_account_user_id,
+    source_message_id,
+    source_reply_to_message_id,
+    role,
+    content,
+    metadata,
+    usage,
+    session_mode,
+    runtime_type,
+    model_id,
+    display_text,
+    turn_id,
+    turn_position,
+    turn_message_seq,
+    turn_visible,
+    created_at
+  )
+  SELECT
+    prepared.id,
+    prepared.bot_id,
+    prepared.session_id,
+    prepared.sender_channel_identity_id,
+    prepared.sender_account_user_id,
+    prepared.source_message_id,
+    prepared.source_reply_to_message_id,
+    prepared.role,
+    prepared.content,
+    prepared.metadata,
+    NULL,
+    'subagent',
+    prepared.runtime_type,
+    prepared.model_id,
+    prepared.display_text,
+    prepared.turn_id,
+    prepared.position,
+    1,
+    false,
+    prepared.created_at
+  FROM prepared_messages prepared
+  JOIN updated_session updated ON updated.id = prepared.session_id
+  RETURNING id
+),
+copied_assets AS (
+  INSERT INTO bot_history_message_assets (
+    message_id,
+    role,
+    ordinal,
+    content_hash,
+    name,
+    metadata
+  )
+  SELECT
+    prepared.id,
+    asset.role,
+    asset.ordinal,
+    asset.content_hash,
+    asset.name,
+    asset.metadata
+  FROM prepared_messages prepared
+  JOIN inserted_messages inserted ON inserted.id = prepared.id
+  JOIN bot_history_message_assets asset
+    ON asset.team_id = public.memoh_current_team_id()
+   AND asset.message_id = prepared.source_id
+  RETURNING id
 )
-ON CONFLICT (session_id) DO UPDATE SET
-  model_uuid = EXCLUDED.model_uuid,
-  model_id = EXCLUDED.model_id,
-  provider_name = EXCLUDED.provider_name,
-  forked = EXCLUDED.forked,
-  parent_messages = EXCLUDED.parent_messages,
-  updated_at = now()
-RETURNING *;
+SELECT
+  (SELECT count(*)::bigint FROM inserted_messages) AS inserted_count,
+  (SELECT count(*)::bigint FROM copied_assets) AS copied_asset_count;
+
+-- name: ListSubagentForkContext :many
+SELECT role, content
+FROM bot_history_messages
+WHERE team_id = public.memoh_current_team_id()
+  AND session_id = sqlc.arg(session_id)
+  AND session_mode = 'subagent'
+  AND turn_visible = false
+  AND metadata->>'context_scope' = 'subagent_fork'
+ORDER BY turn_position ASC, turn_message_seq ASC, created_at ASC, id ASC;

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -152,7 +152,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 		sendEvent(ctx, ch, toolStreamEventToAgentEvent(evt))
 	})
 	if cfg.ForkContext == nil {
-		cfg.ForkContext = tools.NewMessageSnapshot(cfg.Messages)
+		cfg.ForkContext = tools.NewMessageSnapshotWithSources(cfg.Messages, cfg.ForkContextSourceMessageIDs)
 	}
 
 	var sdkTools []sdk.Tool
@@ -648,7 +648,7 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 		collected.Add(evt)
 	})
 	if cfg.ForkContext == nil {
-		cfg.ForkContext = tools.NewMessageSnapshot(cfg.Messages)
+		cfg.ForkContext = tools.NewMessageSnapshotWithSources(cfg.Messages, cfg.ForkContextSourceMessageIDs)
 	}
 
 	var sdkTools []sdk.Tool

--- a/internal/agent/tools/message_snapshot_test.go
+++ b/internal/agent/tools/message_snapshot_test.go
@@ -39,3 +39,47 @@ func TestMessageSnapshotIsImmutableAndProviderNeutral(t *testing.T) {
 		t.Fatalf("unexpected provider-neutral tool call: %+v", call)
 	}
 }
+
+func TestMessageSnapshotRetainsSourcesOnlyForUnchangedMessages(t *testing.T) {
+	first := sdk.UserMessage("first")
+	second := sdk.AssistantMessage("second")
+	snapshot := NewMessageSnapshotWithSources(
+		[]sdk.Message{first, second},
+		[]string{"message-1", "message-2"},
+	)
+
+	secondWithProviderState := second
+	secondWithProviderState.Content[0] = sdk.TextPart{
+		Text:         "second",
+		CacheControl: &sdk.CacheControl{Type: "ephemeral"},
+	}
+	if err := snapshot.Store([]sdk.Message{
+		sdk.SystemMessage("runtime-only"),
+		secondWithProviderState,
+		sdk.UserMessage("new tool delta"),
+	}); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	entries, err := snapshot.Entries()
+	if err != nil {
+		t.Fatalf("Entries: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("entries = %d, want 3", len(entries))
+	}
+	if entries[0].SourceMessageID != "" || entries[1].SourceMessageID != "message-2" || entries[2].SourceMessageID != "" {
+		t.Fatalf("unexpected retained sources: %+v", entries)
+	}
+
+	if err := snapshot.Store([]sdk.Message{sdk.AssistantMessage("second changed")}); err != nil {
+		t.Fatalf("Store changed message: %v", err)
+	}
+	entries, err = snapshot.Entries()
+	if err != nil {
+		t.Fatalf("Entries after change: %v", err)
+	}
+	if len(entries) != 1 || entries[0].SourceMessageID != "" {
+		t.Fatalf("changed message retained a source: %+v", entries)
+	}
+}

--- a/internal/agent/tools/subagent.go
+++ b/internal/agent/tools/subagent.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	"github.com/memohai/memoh/internal/agent/background"
@@ -173,7 +172,7 @@ func (w *SubagentWatchdog) run(ctx context.Context) {
 type agentSessionService interface {
 	CreateSubagent(ctx context.Context, input sessionpkg.CreateSubagentInput) (sessionpkg.Session, sessionpkg.SubagentConfig, error)
 	GetSubagentConfig(ctx context.Context, sessionID string) (sessionpkg.SubagentConfig, error)
-	UpsertSubagentConfig(ctx context.Context, config sessionpkg.SubagentConfig) (sessionpkg.SubagentConfig, error)
+	ListSubagentForkContext(ctx context.Context, sessionID string) ([]sessionpkg.SubagentForkContextMessage, error)
 	ListSubagentsByParent(ctx context.Context, parentSessionID string) ([]sessionpkg.Session, error)
 }
 
@@ -520,21 +519,29 @@ func (p *SpawnProvider) execSpawnAgent(ctx context.Context, session SessionConte
 		return nil, fmt.Errorf("resolve subagent model: %w", err)
 	}
 	forked, _, _ := BoolArg(args, "fork")
-	var parentMessages json.RawMessage
+	var forkContext []sessionpkg.SubagentForkContextMessage
 	if forked {
 		if session.ForkContext == nil {
 			return nil, errors.New("fork context is not available for this session")
 		}
-		messages, snapshotErr := session.ForkContext.Messages()
+		entries, snapshotErr := session.ForkContext.Entries()
 		if snapshotErr != nil {
 			return nil, fmt.Errorf("read fork context: %w", snapshotErr)
 		}
-		parentMessages, snapshotErr = json.Marshal(messages)
-		if snapshotErr != nil {
-			return nil, fmt.Errorf("marshal fork context: %w", snapshotErr)
+		forkContext = make([]sessionpkg.SubagentForkContextMessage, 0, len(entries))
+		for i, entry := range entries {
+			content, marshalErr := json.Marshal(entry.Message)
+			if marshalErr != nil {
+				return nil, fmt.Errorf("marshal fork context message %d: %w", i, marshalErr)
+			}
+			forkContext = append(forkContext, sessionpkg.SubagentForkContextMessage{
+				SourceMessageID: strings.TrimSpace(entry.SourceMessageID),
+				Role:            string(entry.Message.Role),
+				Message:         content,
+			})
 		}
 	}
-	rec, config, err := p.createAgentSession(context.WithoutCancel(ctx), session, agentID, task, runtime, forked, parentMessages)
+	rec, config, err := p.createAgentSession(context.WithoutCancel(ctx), session, agentID, task, runtime, forked, forkContext)
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +565,7 @@ func (p *SpawnProvider) execSendMessage(ctx context.Context, session SessionCont
 	if err != nil {
 		return nil, err
 	}
-	config, err := p.loadOrCreateSubagentConfig(context.WithoutCancel(ctx), session, rec)
+	config, err := p.loadSubagentConfig(context.WithoutCancel(ctx), rec)
 	if err != nil {
 		return nil, err
 	}
@@ -847,10 +854,11 @@ func (p *SpawnProvider) runSubagentTask(ctx context.Context, req *agentRequest) 
 	if req.messagePersisted {
 		history = dropLatestMatchingUserMessage(history, req.message)
 	}
-	if req.config.Forked && len(req.config.ParentMessages) > 0 {
-		var parentMessages []sdk.Message
-		if err := json.Unmarshal(req.config.ParentMessages, &parentMessages); err != nil {
-			res.Error = fmt.Sprintf("load fork context: %v", err)
+	if req.config.Forked {
+		parentMessages, loadErr := p.loadAgentForkContext(context.WithoutCancel(ctx), req.agentSessionID)
+		if loadErr != nil {
+			res.Error = fmt.Sprintf("load fork context: %v", loadErr)
+			res.Status = string(background.TaskFailed)
 			return res
 		}
 		combined := make([]sdk.Message, 0, len(parentMessages)+len(history))
@@ -978,7 +986,7 @@ func (p *SpawnProvider) createAgentSession(
 	agentID, task string,
 	runtime resolvedSubagentModel,
 	forked bool,
-	parentMessages json.RawMessage,
+	forkContext []sessionpkg.SubagentForkContextMessage,
 ) (agentRecord, sessionpkg.SubagentConfig, error) {
 	if p.sessionService == nil {
 		return agentRecord{}, sessionpkg.SubagentConfig{}, errors.New("session service not available")
@@ -995,11 +1003,11 @@ func (p *SpawnProvider) createAgentSession(
 				"agent_control_version": agentControlVersion,
 			},
 		},
-		ModelUUID:      runtime.UUID,
-		ModelID:        runtime.ModelID,
-		ProviderName:   runtime.ProviderName,
-		Forked:         forked,
-		ParentMessages: parentMessages,
+		ModelUUID:    runtime.UUID,
+		ModelID:      runtime.ModelID,
+		ProviderName: runtime.ProviderName,
+		Forked:       forked,
+		ForkContext:  forkContext,
 	})
 	if err != nil {
 		return agentRecord{}, sessionpkg.SubagentConfig{}, err
@@ -1013,31 +1021,15 @@ func (p *SpawnProvider) createAgentSession(
 	}, config, nil
 }
 
-func (p *SpawnProvider) loadOrCreateSubagentConfig(ctx context.Context, parent SessionContext, rec agentRecord) (sessionpkg.SubagentConfig, error) {
+func (p *SpawnProvider) loadSubagentConfig(ctx context.Context, rec agentRecord) (sessionpkg.SubagentConfig, error) {
 	if p.sessionService == nil {
 		return sessionpkg.SubagentConfig{}, errors.New("session service not available")
 	}
 	config, err := p.sessionService.GetSubagentConfig(ctx, rec.SessionID)
-	if err == nil {
-		return config, nil
-	}
-	if !errors.Is(err, pgx.ErrNoRows) {
-		return sessionpkg.SubagentConfig{}, err
-	}
-
-	// Sessions created before agent-control v2 have no pinned config. Preserve
-	// their historical behavior once, then pin the resolved model for future
-	// follow-ups.
-	runtime, err := p.modelResolver(ctx, parent, "", "", "")
 	if err != nil {
-		return sessionpkg.SubagentConfig{}, fmt.Errorf("resolve legacy subagent model: %w", err)
+		return sessionpkg.SubagentConfig{}, fmt.Errorf("load subagent config: %w", err)
 	}
-	return p.sessionService.UpsertSubagentConfig(ctx, sessionpkg.SubagentConfig{
-		SessionID:    rec.SessionID,
-		ModelUUID:    runtime.UUID,
-		ModelID:      runtime.ModelID,
-		ProviderName: runtime.ProviderName,
-	})
+	return config, nil
 }
 
 func (p *SpawnProvider) resolveNewAgentID(ctx context.Context, session SessionContext, raw string) (string, error) {
@@ -1103,6 +1095,25 @@ func (p *SpawnProvider) listAgentRecords(ctx context.Context, session SessionCon
 		return records[i].CreatedAt.Before(records[j].CreatedAt)
 	})
 	return records, nil
+}
+
+func (p *SpawnProvider) loadAgentForkContext(ctx context.Context, sessionID string) ([]sdk.Message, error) {
+	if p.sessionService == nil {
+		return nil, errors.New("session service not available")
+	}
+	rows, err := p.sessionService.ListSubagentForkContext(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	messages := make([]sdk.Message, 0, len(rows))
+	for _, row := range rows {
+		converted, ok := sdkMessageFromPersisted(messagepkg.Message{Role: row.Role, Content: row.Message})
+		if !ok {
+			return nil, fmt.Errorf("invalid fork context message role %q", row.Role)
+		}
+		messages = append(messages, converted)
+	}
+	return messages, nil
 }
 
 func (p *SpawnProvider) loadAgentMessages(ctx context.Context, sessionID string) []sdk.Message {

--- a/internal/agent/tools/subagent_bg_test.go
+++ b/internal/agent/tools/subagent_bg_test.go
@@ -79,6 +79,7 @@ type fakeAgentSessionService struct {
 	next     int
 	sessions []sessionpkg.Session
 	configs  map[string]sessionpkg.SubagentConfig
+	contexts map[string][]sessionpkg.SubagentForkContextMessage
 }
 
 func (s *fakeAgentSessionService) Create(_ context.Context, input sessionpkg.CreateInput) (sessionpkg.Session, error) {
@@ -107,20 +108,44 @@ func (s *fakeAgentSessionService) CreateSubagent(ctx context.Context, input sess
 		return sessionpkg.Session{}, sessionpkg.SubagentConfig{}, err
 	}
 	config := sessionpkg.SubagentConfig{
-		SessionID:      sess.ID,
-		ModelUUID:      input.ModelUUID,
-		ModelID:        input.ModelID,
-		ProviderName:   input.ProviderName,
-		Forked:         input.Forked,
-		ParentMessages: append(json.RawMessage(nil), input.ParentMessages...),
+		SessionID:    sess.ID,
+		ModelUUID:    input.ModelUUID,
+		ModelID:      input.ModelID,
+		ProviderName: input.ProviderName,
+		Forked:       input.Forked,
 	}
 	s.mu.Lock()
 	if s.configs == nil {
 		s.configs = make(map[string]sessionpkg.SubagentConfig)
 	}
 	s.configs[sess.ID] = config
+	if s.contexts == nil {
+		s.contexts = make(map[string][]sessionpkg.SubagentForkContextMessage)
+	}
+	for _, message := range input.ForkContext {
+		s.contexts[sess.ID] = append(s.contexts[sess.ID], sessionpkg.SubagentForkContextMessage{
+			SourceMessageID: message.SourceMessageID,
+			Role:            message.Role,
+			Message:         append(json.RawMessage(nil), message.Message...),
+		})
+	}
 	s.mu.Unlock()
 	return sess, config, nil
+}
+
+func (s *fakeAgentSessionService) ListSubagentForkContext(_ context.Context, sessionID string) ([]sessionpkg.SubagentForkContextMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	contextMessages := s.contexts[sessionID]
+	out := make([]sessionpkg.SubagentForkContextMessage, 0, len(contextMessages))
+	for _, message := range contextMessages {
+		out = append(out, sessionpkg.SubagentForkContextMessage{
+			SourceMessageID: message.SourceMessageID,
+			Role:            message.Role,
+			Message:         append(json.RawMessage(nil), message.Message...),
+		})
+	}
+	return out, nil
 }
 
 func (s *fakeAgentSessionService) GetSubagentConfig(_ context.Context, sessionID string) (sessionpkg.SubagentConfig, error) {
@@ -133,22 +158,15 @@ func (s *fakeAgentSessionService) GetSubagentConfig(_ context.Context, sessionID
 	return config, nil
 }
 
-func (s *fakeAgentSessionService) UpsertSubagentConfig(_ context.Context, config sessionpkg.SubagentConfig) (sessionpkg.SubagentConfig, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.configs == nil {
-		s.configs = make(map[string]sessionpkg.SubagentConfig)
-	}
-	s.configs[config.SessionID] = config
-	return config, nil
-}
-
 func (s *fakeAgentSessionService) ListSubagentsByParent(_ context.Context, parentSessionID string) ([]sessionpkg.Session, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var out []sessionpkg.Session
 	for _, sess := range s.sessions {
 		if sess.ParentSessionID == parentSessionID {
+			if _, ok := s.configs[sess.ID]; !ok {
+				continue
+			}
 			out = append(out, sess)
 		}
 	}

--- a/internal/agent/tools/types.go
+++ b/internal/agent/tools/types.go
@@ -81,14 +81,40 @@ type StreamEmitter func(ToolStreamEvent)
 // to the model. Agent steps update the snapshot before each model call; tools
 // can safely read it while sibling tool calls execute concurrently.
 type MessageSnapshot struct {
-	mu  sync.RWMutex
-	raw json.RawMessage
+	mu               sync.RWMutex
+	raw              json.RawMessage
+	sourceMessageIDs []string
 }
 
 func NewMessageSnapshot(messages []sdk.Message) *MessageSnapshot {
+	return NewMessageSnapshotWithSources(messages, nil)
+}
+
+// NewMessageSnapshotWithSources seeds a snapshot with the database message ID
+// backing each message. Runtime-only messages use an empty source ID. Later
+// Store calls preserve IDs only for unchanged messages that remain in order.
+func NewMessageSnapshotWithSources(messages []sdk.Message, sourceMessageIDs []string) *MessageSnapshot {
 	s := &MessageSnapshot{}
-	_ = s.Store(messages)
+	_ = s.storeInitial(messages, sourceMessageIDs)
 	return s
+}
+
+func (s *MessageSnapshot) storeInitial(messages []sdk.Message, sourceMessageIDs []string) error {
+	if messages == nil {
+		messages = []sdk.Message{}
+	}
+	clean := providerNeutralMessages(messages)
+	raw, err := json.Marshal(clean)
+	if err != nil {
+		return err
+	}
+	sources := make([]string, len(clean))
+	copy(sources, sourceMessageIDs)
+	s.mu.Lock()
+	s.raw = append(s.raw[:0], raw...)
+	s.sourceMessageIDs = sources
+	s.mu.Unlock()
+	return nil
 }
 
 func (s *MessageSnapshot) Store(messages []sdk.Message) error {
@@ -98,14 +124,73 @@ func (s *MessageSnapshot) Store(messages []sdk.Message) error {
 	if messages == nil {
 		messages = []sdk.Message{}
 	}
-	raw, err := json.Marshal(providerNeutralMessages(messages))
+	clean := providerNeutralMessages(messages)
+	raw, err := json.Marshal(clean)
 	if err != nil {
 		return err
 	}
 	s.mu.Lock()
+	oldMessages, decodeErr := decodeSnapshotMessages(s.raw)
+	if decodeErr != nil {
+		s.mu.Unlock()
+		return decodeErr
+	}
+	sources := retainSnapshotSources(oldMessages, s.sourceMessageIDs, clean)
 	s.raw = append(s.raw[:0], raw...)
+	s.sourceMessageIDs = sources
 	s.mu.Unlock()
 	return nil
+}
+
+func decodeSnapshotMessages(raw json.RawMessage) ([]sdk.Message, error) {
+	if len(raw) == 0 {
+		return []sdk.Message{}, nil
+	}
+	var messages []sdk.Message
+	if err := json.Unmarshal(raw, &messages); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
+func retainSnapshotSources(oldMessages []sdk.Message, oldSources []string, messages []sdk.Message) []string {
+	sources := make([]string, len(messages))
+	positions := make(map[string][]int, len(oldMessages))
+	for i, message := range oldMessages {
+		key, ok := snapshotMessageKey(message)
+		if ok {
+			positions[key] = append(positions[key], i)
+		}
+	}
+	cursors := make(map[string]int, len(positions))
+	lastMatched := -1
+	for i, message := range messages {
+		key, ok := snapshotMessageKey(message)
+		if !ok {
+			continue
+		}
+		candidates := positions[key]
+		cursor := cursors[key]
+		for cursor < len(candidates) && candidates[cursor] <= lastMatched {
+			cursor++
+		}
+		cursors[key] = cursor
+		if cursor >= len(candidates) {
+			continue
+		}
+		oldIndex := candidates[cursor]
+		cursors[key] = cursor + 1
+		lastMatched = oldIndex
+		if oldIndex < len(oldSources) {
+			sources[i] = oldSources[oldIndex]
+		}
+	}
+	return sources
+}
+
+func snapshotMessageKey(message sdk.Message) (string, bool) {
+	raw, err := json.Marshal(message)
+	return string(raw), err == nil
 }
 
 func providerNeutralMessages(messages []sdk.Message) []sdk.Message {
@@ -177,6 +262,40 @@ func (s *MessageSnapshot) Messages() ([]sdk.Message, error) {
 		messages = []sdk.Message{}
 	}
 	return messages, nil
+}
+
+// Entries returns the provider-neutral messages together with any persisted
+// source message IDs retained from the resolver's initial history snapshot.
+func (s *MessageSnapshot) Entries() ([]MessageSnapshotEntry, error) {
+	if s == nil {
+		return []MessageSnapshotEntry{}, nil
+	}
+	s.mu.RLock()
+	raw := append(json.RawMessage(nil), s.raw...)
+	sources := append([]string(nil), s.sourceMessageIDs...)
+	s.mu.RUnlock()
+	messages, err := decodeSnapshotMessages(raw)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]MessageSnapshotEntry, 0, len(messages))
+	for i, message := range messages {
+		sourceMessageID := ""
+		if i < len(sources) {
+			sourceMessageID = sources[i]
+		}
+		entries = append(entries, MessageSnapshotEntry{
+			Message:         message,
+			SourceMessageID: sourceMessageID,
+		})
+	}
+	return entries, nil
+}
+
+// MessageSnapshotEntry describes one message in a forkable model context.
+type MessageSnapshotEntry struct {
+	Message         sdk.Message
+	SourceMessageID string
 }
 
 // SessionContext carries request-scoped identity for tool execution.

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -77,37 +77,38 @@ type InjectMessage struct {
 
 // RunConfig holds everything needed for a single agent invocation.
 type RunConfig struct {
-	Model                    *sdk.Model
-	CurrentModelUUID         string
-	CurrentModelID           string
-	CurrentModelProvider     string
-	ForkContext              *tools.MessageSnapshot
-	ReasoningEffort          string
-	ReasoningActive          bool
-	ReasoningDisabled        bool
-	ReasoningAdaptive        bool
-	ReasoningOffEffort       string
-	ChatCompletionsCompat    string
-	Messages                 []sdk.Message
-	Query                    string
-	System                   string
-	ContextFrags             []contextfrag.ContextFrag
-	ContextManifest          contextfrag.Manifest
-	ContextScope             contextfrag.Scope
-	ContextQueryMaterialized bool
-	ContextToolUsage         string
-	ContextDynamicMutators   []contextfrag.DynamicMutator
-	SessionType              string
-	LiveToolStream           bool
-	CanRequestUserInput      bool
-	SupportsImageInput       bool
-	SupportsToolCall         bool
-	InlineImages             []sdk.ImagePart
-	Identity                 SessionContext
-	Bot                      BotInfo
-	Skills                   []SkillEntry
-	LoopDetection            LoopDetectionConfig
-	Retry                    RetryConfig
+	Model                       *sdk.Model
+	CurrentModelUUID            string
+	CurrentModelID              string
+	CurrentModelProvider        string
+	ForkContext                 *tools.MessageSnapshot
+	ForkContextSourceMessageIDs []string
+	ReasoningEffort             string
+	ReasoningActive             bool
+	ReasoningDisabled           bool
+	ReasoningAdaptive           bool
+	ReasoningOffEffort          string
+	ChatCompletionsCompat       string
+	Messages                    []sdk.Message
+	Query                       string
+	System                      string
+	ContextFrags                []contextfrag.ContextFrag
+	ContextManifest             contextfrag.Manifest
+	ContextScope                contextfrag.Scope
+	ContextQueryMaterialized    bool
+	ContextToolUsage            string
+	ContextDynamicMutators      []contextfrag.DynamicMutator
+	SessionType                 string
+	LiveToolStream              bool
+	CanRequestUserInput         bool
+	SupportsImageInput          bool
+	SupportsToolCall            bool
+	InlineImages                []sdk.ImagePart
+	Identity                    SessionContext
+	Bot                         BotInfo
+	Skills                      []SkillEntry
+	LoopDetection               LoopDetectionConfig
+	Retry                       RetryConfig
 
 	// PromptCacheTTL controls prompt caching for this run. Empty or
 	// unrecognized values default to 5m. Use "1h" for the long-cache tier

--- a/internal/conversation/flow/resolver.go
+++ b/internal/conversation/flow/resolver.go
@@ -482,7 +482,9 @@ func (r *Resolver) resolve(ctx context.Context, req conversation.ChatRequest) (r
 		headerifiedModelQuery = turnpkg.FormatUserHeader(headerInput, modelQuery)
 	}
 	runCfg.ContextFrags = historyContextFragsForMessages(messages, historyRecords)
-	runCfg.Messages = modelMessagesToSDKMessages(nonNilModelMessages(messages))
+	forkMessages := nonNilModelMessages(messages)
+	runCfg.ForkContextSourceMessageIDs = historySourceMessageIDsForMessages(forkMessages, historyRecords)
+	runCfg.Messages = modelMessagesToSDKMessages(forkMessages)
 	// When using the pipeline the user message is already in the RC;
 	// don't send it to the LLM again. headerifiedQuery is still kept
 	// for storeRound so the user message gets persisted.
@@ -1277,6 +1279,7 @@ func (r *Resolver) prepareRunConfig(ctx context.Context, cfg agentpkg.RunConfig)
 			}
 		}
 		cfg.Messages = append(cfg.Messages, sdk.UserMessage(cfg.Query, extra...))
+		cfg.ForkContextSourceMessageIDs = append(cfg.ForkContextSourceMessageIDs, "")
 		cfg.ContextQueryMaterialized = true
 	} else if len(cfg.InlineImages) > 0 {
 		// Pipeline path: the user query is already embedded in the RC messages,
@@ -1293,12 +1296,16 @@ func (r *Resolver) prepareRunConfig(ctx context.Context, cfg agentpkg.RunConfig)
 			for i := len(cfg.Messages) - 1; i >= 0; i-- {
 				if cfg.Messages[i].Role == sdk.MessageRoleUser {
 					cfg.Messages[i].Content = append(cfg.Messages[i].Content, imageParts...)
+					if i < len(cfg.ForkContextSourceMessageIDs) {
+						cfg.ForkContextSourceMessageIDs[i] = ""
+					}
 					injected = true
 					break
 				}
 			}
 			if !injected {
 				cfg.Messages = append(cfg.Messages, sdk.UserMessage("", imageParts...))
+				cfg.ForkContextSourceMessageIDs = append(cfg.ForkContextSourceMessageIDs, "")
 			}
 			cfg.ContextQueryMaterialized = true
 		}

--- a/internal/conversation/flow/resolver_fork_context_test.go
+++ b/internal/conversation/flow/resolver_fork_context_test.go
@@ -1,0 +1,43 @@
+package flow
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/conversation"
+	"github.com/memohai/memoh/internal/historyfrag"
+)
+
+func TestHistorySourceMessageIDsFollowRetainedDatabaseMessages(t *testing.T) {
+	records := []historyfrag.HistoryRecord{
+		{
+			DBMessageID: "00000000-0000-0000-0000-000000000001",
+			ModelMessage: conversation.ModelMessage{
+				Role:    "user",
+				Content: conversation.NewTextContent("first"),
+			},
+		},
+		{
+			DBMessageID: "00000000-0000-0000-0000-000000000002",
+			ModelMessage: conversation.ModelMessage{
+				Role:    "assistant",
+				Content: conversation.NewTextContent("second"),
+			},
+		},
+	}
+	messages := []conversation.ModelMessage{
+		{Role: "system", Content: conversation.NewTextContent("runtime workspace context")},
+		records[1].ModelMessage,
+		{Role: "user", Content: conversation.NewTextContent("current query")},
+	}
+
+	got := historySourceMessageIDsForMessages(messages, records)
+	want := []string{"", records[1].DBMessageID, ""}
+	if len(got) != len(want) {
+		t.Fatalf("source IDs = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("source ID %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/conversation/flow/resolver_history_compaction.go
+++ b/internal/conversation/flow/resolver_history_compaction.go
@@ -55,6 +55,44 @@ func sameModelMessage(a conversation.ModelMessage, b conversation.ModelMessage) 
 		string(a.Content) == string(b.Content)
 }
 
+func historySourceMessageIDsForMessages(messages []conversation.ModelMessage, records []historyfrag.HistoryRecord) []string {
+	sourceIDs := make([]string, len(messages))
+	if len(messages) == 0 || len(records) == 0 {
+		return sourceIDs
+	}
+	positions := make(map[string][]int, len(records))
+	for i, record := range records {
+		if strings.TrimSpace(record.DBMessageID) == "" {
+			continue
+		}
+		key := modelMessageSourceKey(record.ModelMessage)
+		positions[key] = append(positions[key], i)
+	}
+	cursors := make(map[string]int, len(positions))
+	lastMatched := -1
+	for i, message := range messages {
+		key := modelMessageSourceKey(message)
+		candidates := positions[key]
+		cursor := cursors[key]
+		for cursor < len(candidates) && candidates[cursor] <= lastMatched {
+			cursor++
+		}
+		cursors[key] = cursor
+		if cursor >= len(candidates) {
+			continue
+		}
+		recordIndex := candidates[cursor]
+		cursors[key] = cursor + 1
+		lastMatched = recordIndex
+		sourceIDs[i] = strings.TrimSpace(records[recordIndex].DBMessageID)
+	}
+	return sourceIDs
+}
+
+func modelMessageSourceKey(message conversation.ModelMessage) string {
+	return strings.ToLower(strings.TrimSpace(message.Role)) + "\x00" + string(message.Content)
+}
+
 func stripToolMessagesWhenCompactionSummaryIsActive(messages []conversation.ModelMessage, records []historyfrag.HistoryRecord) []conversation.ModelMessage {
 	for _, record := range records {
 		if record.SourceKind == historyfrag.SourceCompactionLog &&

--- a/internal/db/postgres/sqlc/models.go
+++ b/internal/db/postgres/sqlc/models.go
@@ -691,15 +691,14 @@ type StorageProvider struct {
 }
 
 type SubagentConfig struct {
-	TeamID         pgtype.UUID        `json:"team_id"`
-	SessionID      pgtype.UUID        `json:"session_id"`
-	ModelUuid      pgtype.UUID        `json:"model_uuid"`
-	ModelID        string             `json:"model_id"`
-	ProviderName   string             `json:"provider_name"`
-	Forked         bool               `json:"forked"`
-	ParentMessages []byte             `json:"parent_messages"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	TeamID       pgtype.UUID        `json:"team_id"`
+	SessionID    pgtype.UUID        `json:"session_id"`
+	ModelUuid    pgtype.UUID        `json:"model_uuid"`
+	ModelID      string             `json:"model_id"`
+	ProviderName string             `json:"provider_name"`
+	Forked       bool               `json:"forked"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
 }
 
 type Task struct {

--- a/internal/db/postgres/sqlc/sessions.sql.go
+++ b/internal/db/postgres/sqlc/sessions.sql.go
@@ -938,7 +938,14 @@ SELECT id, bot_id, route_id, channel_type, type, session_mode, runtime_type, run
 FROM bot_sessions
 WHERE team_id = public.memoh_current_team_id()
   AND parent_session_id = $1
+  AND type = 'subagent'
   AND deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM subagent_configs config
+    WHERE config.team_id = public.memoh_current_team_id()
+      AND config.session_id = bot_sessions.id
+  )
 ORDER BY created_at DESC
 `
 

--- a/internal/db/postgres/sqlc/subagents.sql.go
+++ b/internal/db/postgres/sqlc/subagents.sql.go
@@ -17,21 +17,19 @@ INSERT INTO subagent_configs (
   model_uuid,
   model_id,
   provider_name,
-  forked,
-  parent_messages
+  forked
 ) VALUES (
-  $1, $2, $3, $4, $5, $6
+  $1, $2, $3, $4, $5
 )
-RETURNING team_id, session_id, model_uuid, model_id, provider_name, forked, parent_messages, created_at, updated_at
+RETURNING team_id, session_id, model_uuid, model_id, provider_name, forked, created_at, updated_at
 `
 
 type CreateSubagentConfigParams struct {
-	SessionID      pgtype.UUID `json:"session_id"`
-	ModelUuid      pgtype.UUID `json:"model_uuid"`
-	ModelID        string      `json:"model_id"`
-	ProviderName   string      `json:"provider_name"`
-	Forked         bool        `json:"forked"`
-	ParentMessages []byte      `json:"parent_messages"`
+	SessionID    pgtype.UUID `json:"session_id"`
+	ModelUuid    pgtype.UUID `json:"model_uuid"`
+	ModelID      string      `json:"model_id"`
+	ProviderName string      `json:"provider_name"`
+	Forked       bool        `json:"forked"`
 }
 
 func (q *Queries) CreateSubagentConfig(ctx context.Context, arg CreateSubagentConfigParams) (SubagentConfig, error) {
@@ -41,7 +39,6 @@ func (q *Queries) CreateSubagentConfig(ctx context.Context, arg CreateSubagentCo
 		arg.ModelID,
 		arg.ProviderName,
 		arg.Forked,
-		arg.ParentMessages,
 	)
 	var i SubagentConfig
 	err := row.Scan(
@@ -51,15 +48,172 @@ func (q *Queries) CreateSubagentConfig(ctx context.Context, arg CreateSubagentCo
 		&i.ModelID,
 		&i.ProviderName,
 		&i.Forked,
-		&i.ParentMessages,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
 	return i, err
 }
 
+const createSubagentForkContext = `-- name: CreateSubagentForkContext :one
+WITH target_session AS MATERIALIZED (
+  SELECT child.id, child.bot_id, child.team_id
+  FROM bot_sessions child
+  JOIN bot_sessions parent
+    ON parent.team_id = public.memoh_current_team_id()
+   AND parent.id = $1
+   AND parent.id = child.parent_session_id
+   AND parent.bot_id = child.bot_id
+   AND parent.deleted_at IS NULL
+  WHERE child.team_id = public.memoh_current_team_id()
+    AND child.id = $2
+    AND child.type = 'subagent'
+    AND child.deleted_at IS NULL
+),
+context_entries AS MATERIALIZED (
+  SELECT entry, ordinality::bigint AS position
+  FROM jsonb_array_elements($3::jsonb)
+       WITH ORDINALITY AS items(entry, ordinality)
+),
+prepared_messages AS MATERIALIZED (
+  SELECT
+    gen_random_uuid() AS id,
+    gen_random_uuid() AS turn_id,
+    entries.position,
+    source.id AS source_id,
+    target.id AS session_id,
+    target.bot_id,
+    source.sender_channel_identity_id,
+    source.sender_account_user_id,
+    source.source_message_id,
+    source.source_reply_to_message_id,
+    COALESCE(source.role, entries.entry->>'role') AS role,
+    COALESCE(source.content, entries.entry->'message') AS content,
+    COALESCE(source.metadata, '{}'::jsonb)
+      || jsonb_build_object(
+        'context_scope', 'subagent_fork',
+        'context_version', 1,
+        'source_session_id', $1::text
+      )
+      || CASE
+        WHEN source.id IS NULL THEN '{}'::jsonb
+        ELSE jsonb_build_object('source_message_id', source.id::text)
+      END AS metadata,
+    COALESCE(source.runtime_type, 'model') AS runtime_type,
+    source.model_id,
+    source.display_text,
+    COALESCE(source.created_at, now()) AS created_at
+  FROM context_entries entries
+  CROSS JOIN target_session target
+  LEFT JOIN bot_history_messages source
+    ON source.team_id = public.memoh_current_team_id()
+   AND source.id = NULLIF(entries.entry->>'source_message_id', '')::uuid
+   AND source.session_id = $1
+   AND source.bot_id = target.bot_id
+),
+updated_session AS (
+  UPDATE bot_sessions session
+  SET next_turn_position = (SELECT count(*)::bigint + 1 FROM context_entries)
+  FROM target_session target
+  WHERE session.team_id = public.memoh_current_team_id()
+    AND session.id = target.id
+  RETURNING session.id
+),
+inserted_messages AS (
+  INSERT INTO bot_history_messages (
+    id,
+    bot_id,
+    session_id,
+    sender_channel_identity_id,
+    sender_account_user_id,
+    source_message_id,
+    source_reply_to_message_id,
+    role,
+    content,
+    metadata,
+    usage,
+    session_mode,
+    runtime_type,
+    model_id,
+    display_text,
+    turn_id,
+    turn_position,
+    turn_message_seq,
+    turn_visible,
+    created_at
+  )
+  SELECT
+    prepared.id,
+    prepared.bot_id,
+    prepared.session_id,
+    prepared.sender_channel_identity_id,
+    prepared.sender_account_user_id,
+    prepared.source_message_id,
+    prepared.source_reply_to_message_id,
+    prepared.role,
+    prepared.content,
+    prepared.metadata,
+    NULL,
+    'subagent',
+    prepared.runtime_type,
+    prepared.model_id,
+    prepared.display_text,
+    prepared.turn_id,
+    prepared.position,
+    1,
+    false,
+    prepared.created_at
+  FROM prepared_messages prepared
+  JOIN updated_session updated ON updated.id = prepared.session_id
+  RETURNING id
+),
+copied_assets AS (
+  INSERT INTO bot_history_message_assets (
+    message_id,
+    role,
+    ordinal,
+    content_hash,
+    name,
+    metadata
+  )
+  SELECT
+    prepared.id,
+    asset.role,
+    asset.ordinal,
+    asset.content_hash,
+    asset.name,
+    asset.metadata
+  FROM prepared_messages prepared
+  JOIN inserted_messages inserted ON inserted.id = prepared.id
+  JOIN bot_history_message_assets asset
+    ON asset.team_id = public.memoh_current_team_id()
+   AND asset.message_id = prepared.source_id
+  RETURNING id
+)
+SELECT
+  (SELECT count(*)::bigint FROM inserted_messages) AS inserted_count,
+  (SELECT count(*)::bigint FROM copied_assets) AS copied_asset_count
+`
+
+type CreateSubagentForkContextParams struct {
+	ParentSessionID pgtype.UUID `json:"parent_session_id"`
+	SessionID       pgtype.UUID `json:"session_id"`
+	ContextMessages []byte      `json:"context_messages"`
+}
+
+type CreateSubagentForkContextRow struct {
+	InsertedCount    int64 `json:"inserted_count"`
+	CopiedAssetCount int64 `json:"copied_asset_count"`
+}
+
+func (q *Queries) CreateSubagentForkContext(ctx context.Context, arg CreateSubagentForkContextParams) (CreateSubagentForkContextRow, error) {
+	row := q.db.QueryRow(ctx, createSubagentForkContext, arg.ParentSessionID, arg.SessionID, arg.ContextMessages)
+	var i CreateSubagentForkContextRow
+	err := row.Scan(&i.InsertedCount, &i.CopiedAssetCount)
+	return i, err
+}
+
 const getSubagentConfig = `-- name: GetSubagentConfig :one
-SELECT team_id, session_id, model_uuid, model_id, provider_name, forked, parent_messages, created_at, updated_at
+SELECT team_id, session_id, model_uuid, model_id, provider_name, forked, created_at, updated_at
 FROM subagent_configs
 WHERE session_id = $1
 `
@@ -74,63 +228,44 @@ func (q *Queries) GetSubagentConfig(ctx context.Context, sessionID pgtype.UUID) 
 		&i.ModelID,
 		&i.ProviderName,
 		&i.Forked,
-		&i.ParentMessages,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
 	return i, err
 }
 
-const upsertSubagentConfig = `-- name: UpsertSubagentConfig :one
-INSERT INTO subagent_configs (
-  session_id,
-  model_uuid,
-  model_id,
-  provider_name,
-  forked,
-  parent_messages
-) VALUES (
-  $1, $2, $3, $4, $5, $6
-)
-ON CONFLICT (session_id) DO UPDATE SET
-  model_uuid = EXCLUDED.model_uuid,
-  model_id = EXCLUDED.model_id,
-  provider_name = EXCLUDED.provider_name,
-  forked = EXCLUDED.forked,
-  parent_messages = EXCLUDED.parent_messages,
-  updated_at = now()
-RETURNING team_id, session_id, model_uuid, model_id, provider_name, forked, parent_messages, created_at, updated_at
+const listSubagentForkContext = `-- name: ListSubagentForkContext :many
+SELECT role, content
+FROM bot_history_messages
+WHERE team_id = public.memoh_current_team_id()
+  AND session_id = $1
+  AND session_mode = 'subagent'
+  AND turn_visible = false
+  AND metadata->>'context_scope' = 'subagent_fork'
+ORDER BY turn_position ASC, turn_message_seq ASC, created_at ASC, id ASC
 `
 
-type UpsertSubagentConfigParams struct {
-	SessionID      pgtype.UUID `json:"session_id"`
-	ModelUuid      pgtype.UUID `json:"model_uuid"`
-	ModelID        string      `json:"model_id"`
-	ProviderName   string      `json:"provider_name"`
-	Forked         bool        `json:"forked"`
-	ParentMessages []byte      `json:"parent_messages"`
+type ListSubagentForkContextRow struct {
+	Role    string `json:"role"`
+	Content []byte `json:"content"`
 }
 
-func (q *Queries) UpsertSubagentConfig(ctx context.Context, arg UpsertSubagentConfigParams) (SubagentConfig, error) {
-	row := q.db.QueryRow(ctx, upsertSubagentConfig,
-		arg.SessionID,
-		arg.ModelUuid,
-		arg.ModelID,
-		arg.ProviderName,
-		arg.Forked,
-		arg.ParentMessages,
-	)
-	var i SubagentConfig
-	err := row.Scan(
-		&i.TeamID,
-		&i.SessionID,
-		&i.ModelUuid,
-		&i.ModelID,
-		&i.ProviderName,
-		&i.Forked,
-		&i.ParentMessages,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
+func (q *Queries) ListSubagentForkContext(ctx context.Context, sessionID pgtype.UUID) ([]ListSubagentForkContextRow, error) {
+	rows, err := q.db.Query(ctx, listSubagentForkContext, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListSubagentForkContextRow
+	for rows.Next() {
+		var i ListSubagentForkContextRow
+		if err := rows.Scan(&i.Role, &i.Content); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/internal/db/store/queries.go
+++ b/internal/db/store/queries.go
@@ -102,6 +102,7 @@ type Queries interface {
 	CreateSessionEvent(ctx context.Context, arg dbsqlc.CreateSessionEventParams) (pgtype.UUID, error)
 	CreateStorageProvider(ctx context.Context, arg dbsqlc.CreateStorageProviderParams) (dbsqlc.StorageProvider, error)
 	CreateSubagentConfig(ctx context.Context, arg dbsqlc.CreateSubagentConfigParams) (dbsqlc.SubagentConfig, error)
+	CreateSubagentForkContext(ctx context.Context, arg dbsqlc.CreateSubagentForkContextParams) (dbsqlc.CreateSubagentForkContextRow, error)
 	CreateToolApprovalRequest(ctx context.Context, arg dbsqlc.CreateToolApprovalRequestParams) (dbsqlc.ToolApprovalRequest, error)
 	CreateUserInputRequest(ctx context.Context, arg dbsqlc.CreateUserInputRequestParams) (dbsqlc.UserInputRequest, error)
 	CreateUser(ctx context.Context, arg dbsqlc.CreateUserParams) (dbsqlc.CreateUserRow, error)
@@ -293,6 +294,7 @@ type Queries interface {
 	ListMessagesBeforeMessageBySession(ctx context.Context, arg dbsqlc.ListMessagesBeforeMessageBySessionParams) ([]dbsqlc.ListMessagesBeforeMessageBySessionRow, error)
 	ListMessageRefsByCompactID(ctx context.Context, compactID pgtype.UUID) ([]dbsqlc.ListMessageRefsByCompactIDRow, error)
 	ListMessagesBySession(ctx context.Context, sessionID pgtype.UUID) ([]dbsqlc.ListMessagesBySessionRow, error)
+	ListSubagentForkContext(ctx context.Context, sessionID pgtype.UUID) ([]dbsqlc.ListSubagentForkContextRow, error)
 	ListMessagesLatest(ctx context.Context, arg dbsqlc.ListMessagesLatestParams) ([]dbsqlc.ListMessagesLatestRow, error)
 	ListMessagesLatestBySession(ctx context.Context, arg dbsqlc.ListMessagesLatestBySessionParams) ([]dbsqlc.ListMessagesLatestBySessionRow, error)
 	ListMessagesLatestUIBySession(ctx context.Context, arg dbsqlc.ListMessagesLatestUIBySessionParams) ([]dbsqlc.ListMessagesLatestUIBySessionRow, error)
@@ -437,7 +439,6 @@ type Queries interface {
 	UpsertProviderTemplateModel(ctx context.Context, arg dbsqlc.UpsertProviderTemplateModelParams) (dbsqlc.TemplateProviderTemplateModel, error)
 	UpsertSessionDiscussCursor(ctx context.Context, arg dbsqlc.UpsertSessionDiscussCursorParams) (dbsqlc.BotSessionDiscussCursor, error)
 	UpsertSnapshot(ctx context.Context, arg dbsqlc.UpsertSnapshotParams) (dbsqlc.Snapshot, error)
-	UpsertSubagentConfig(ctx context.Context, arg dbsqlc.UpsertSubagentConfigParams) (dbsqlc.SubagentConfig, error)
 	UpsertUserChannelBinding(ctx context.Context, arg dbsqlc.UpsertUserChannelBindingParams) (dbsqlc.UserChannelBinding, error)
 	UpsertUserProviderOAuthToken(ctx context.Context, arg dbsqlc.UpsertUserProviderOAuthTokenParams) (dbsqlc.UserProviderOauthToken, error)
 	WithTx(tx pgx.Tx) Queries

--- a/internal/db/subagent_fork_history_migration_integration_test.go
+++ b/internal/db/subagent_fork_history_migration_integration_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestSubagentForkHistoryMigrationRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	pool := freshMigratedDB(t)
+	dsn := teamMigrationDSN(t)
+
+	assertSubagentForkHistorySchema(t, ctx, pool, false, true)
+	stepDown(t, dsn, 1)
+	assertSubagentForkHistorySchema(t, ctx, pool, true, false)
+	stepUp(t, dsn, 1)
+	assertSubagentForkHistorySchema(t, ctx, pool, false, true)
+}
+
+func assertSubagentForkHistorySchema(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	wantParentMessages bool,
+	wantContextIndex bool,
+) {
+	t.Helper()
+	var hasParentMessages, hasContextIndex bool
+	if err := pool.QueryRow(ctx, `
+		SELECT
+		  EXISTS (
+		    SELECT 1
+		    FROM information_schema.columns
+		    WHERE table_schema = 'public'
+		      AND table_name = 'subagent_configs'
+		      AND column_name = 'parent_messages'
+		  ),
+		  to_regclass('public.idx_bot_history_messages_subagent_fork_context') IS NOT NULL
+	`).Scan(&hasParentMessages, &hasContextIndex); err != nil {
+		t.Fatalf("inspect subagent fork history schema: %v", err)
+	}
+	if hasParentMessages != wantParentMessages || hasContextIndex != wantContextIndex {
+		t.Fatalf(
+			"subagent fork history schema = parent_messages:%t index:%t, want parent_messages:%t index:%t",
+			hasParentMessages,
+			hasContextIndex,
+			wantParentMessages,
+			wantContextIndex,
+		)
+	}
+}

--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -119,25 +119,31 @@ type CreateInput struct {
 }
 
 // SubagentConfig is the persisted runtime selection for a managed subagent.
-// ParentMessages is intentionally separate from visible session history.
 type SubagentConfig struct {
-	SessionID      string          `json:"session_id"`
-	ModelUUID      string          `json:"model_uuid,omitempty"`
-	ModelID        string          `json:"model_id"`
-	ProviderName   string          `json:"provider"`
-	Forked         bool            `json:"fork"`
-	ParentMessages json.RawMessage `json:"-"`
-	CreatedAt      time.Time       `json:"created_at"`
-	UpdatedAt      time.Time       `json:"updated_at"`
+	SessionID    string    `json:"session_id"`
+	ModelUUID    string    `json:"model_uuid,omitempty"`
+	ModelID      string    `json:"model_id"`
+	ProviderName string    `json:"provider"`
+	Forked       bool      `json:"fork"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// SubagentForkContextMessage is one hidden history message copied or
+// materialized into a forked subagent session.
+type SubagentForkContextMessage struct {
+	SourceMessageID string          `json:"source_message_id,omitempty"`
+	Role            string          `json:"role"`
+	Message         json.RawMessage `json:"message"`
 }
 
 type CreateSubagentInput struct {
-	Session        CreateInput
-	ModelUUID      string
-	ModelID        string
-	ProviderName   string
-	Forked         bool
-	ParentMessages json.RawMessage
+	Session      CreateInput
+	ModelUUID    string
+	ModelID      string
+	ProviderName string
+	Forked       bool
+	ForkContext  []SubagentForkContextMessage
 }
 
 type subagentTransactionalQueries interface {
@@ -300,13 +306,29 @@ func (s *Service) CreateSubagent(ctx context.Context, input CreateSubagentInput)
 	if strings.TrimSpace(input.ProviderName) == "" {
 		return Session{}, SubagentConfig{}, errors.New("subagent provider is required")
 	}
-	if input.Forked {
-		var messages []json.RawMessage
-		if len(input.ParentMessages) == 0 || json.Unmarshal(input.ParentMessages, &messages) != nil {
-			return Session{}, SubagentConfig{}, errors.New("forked subagent requires a valid parent message array")
+	if !input.Forked {
+		input.ForkContext = nil
+	} else if input.ForkContext == nil {
+		input.ForkContext = []SubagentForkContextMessage{}
+	}
+	for i, message := range input.ForkContext {
+		switch strings.TrimSpace(message.Role) {
+		case "user", "assistant", "system", "tool":
+		default:
+			return Session{}, SubagentConfig{}, fmt.Errorf("invalid fork context role at index %d", i)
 		}
-	} else {
-		input.ParentMessages = nil
+		if len(message.Message) == 0 || !json.Valid(message.Message) {
+			return Session{}, SubagentConfig{}, fmt.Errorf("invalid fork context message at index %d", i)
+		}
+		if strings.TrimSpace(message.SourceMessageID) != "" {
+			if _, parseErr := dbpkg.ParseUUID(message.SourceMessageID); parseErr != nil {
+				return Session{}, SubagentConfig{}, fmt.Errorf("invalid fork context source message id at index %d: %w", i, parseErr)
+			}
+		}
+	}
+	forkContextJSON, err := json.Marshal(input.ForkContext)
+	if err != nil {
+		return Session{}, SubagentConfig{}, fmt.Errorf("marshal fork context: %w", err)
 	}
 
 	var created Session
@@ -325,15 +347,31 @@ func (s *Service) CreateSubagent(ctx context.Context, input CreateSubagentInput)
 			return createErr
 		}
 		row, createErr := queries.CreateSubagentConfig(ctx, sqlc.CreateSubagentConfigParams{
-			SessionID:      pgSessionID,
-			ModelUuid:      modelUUID,
-			ModelID:        strings.TrimSpace(input.ModelID),
-			ProviderName:   strings.TrimSpace(input.ProviderName),
-			Forked:         input.Forked,
-			ParentMessages: append([]byte(nil), input.ParentMessages...),
+			SessionID:    pgSessionID,
+			ModelUuid:    modelUUID,
+			ModelID:      strings.TrimSpace(input.ModelID),
+			ProviderName: strings.TrimSpace(input.ProviderName),
+			Forked:       input.Forked,
 		})
 		if createErr != nil {
 			return createErr
+		}
+		if input.Forked {
+			parentSessionID, parseErr := dbpkg.ParseUUID(input.Session.ParentSessionID)
+			if parseErr != nil {
+				return fmt.Errorf("invalid parent session id: %w", parseErr)
+			}
+			contextResult, contextErr := queries.CreateSubagentForkContext(ctx, sqlc.CreateSubagentForkContextParams{
+				ParentSessionID: parentSessionID,
+				SessionID:       pgSessionID,
+				ContextMessages: forkContextJSON,
+			})
+			if contextErr != nil {
+				return contextErr
+			}
+			if contextResult.InsertedCount != int64(len(input.ForkContext)) {
+				return fmt.Errorf("persist fork context: inserted %d of %d messages", contextResult.InsertedCount, len(input.ForkContext))
+			}
 		}
 		created = createdSession
 		config = toSubagentConfig(row)
@@ -365,27 +403,25 @@ func (s *Service) GetSubagentConfig(ctx context.Context, sessionID string) (Suba
 	return toSubagentConfig(row), nil
 }
 
-func (s *Service) UpsertSubagentConfig(ctx context.Context, config SubagentConfig) (SubagentConfig, error) {
-	pgSessionID, err := dbpkg.ParseUUID(config.SessionID)
+// ListSubagentForkContext loads only the hidden rows reserved for a forked
+// subagent's inherited model context. Other invisible history rows are ignored.
+func (s *Service) ListSubagentForkContext(ctx context.Context, sessionID string) ([]SubagentForkContextMessage, error) {
+	pgSessionID, err := dbpkg.ParseUUID(sessionID)
 	if err != nil {
-		return SubagentConfig{}, fmt.Errorf("invalid subagent session id: %w", err)
+		return nil, fmt.Errorf("invalid subagent session id: %w", err)
 	}
-	pgModelUUID, err := parseOptionalUUID(config.ModelUUID)
+	rows, err := s.queries.ListSubagentForkContext(ctx, pgSessionID)
 	if err != nil {
-		return SubagentConfig{}, fmt.Errorf("invalid subagent model uuid: %w", err)
+		return nil, err
 	}
-	row, err := s.queries.UpsertSubagentConfig(ctx, sqlc.UpsertSubagentConfigParams{
-		SessionID:      pgSessionID,
-		ModelUuid:      pgModelUUID,
-		ModelID:        strings.TrimSpace(config.ModelID),
-		ProviderName:   strings.TrimSpace(config.ProviderName),
-		Forked:         config.Forked,
-		ParentMessages: append([]byte(nil), config.ParentMessages...),
-	})
-	if err != nil {
-		return SubagentConfig{}, err
+	messages := make([]SubagentForkContextMessage, 0, len(rows))
+	for _, row := range rows {
+		messages = append(messages, SubagentForkContextMessage{
+			Role:    row.Role,
+			Message: append(json.RawMessage(nil), row.Content...),
+		})
 	}
-	return toSubagentConfig(row), nil
+	return messages, nil
 }
 
 // ForkFromAssistantMessage creates a new chat session containing the source
@@ -1093,14 +1129,13 @@ func toSubagentConfig(row sqlc.SubagentConfig) SubagentConfig {
 		modelUUID = row.ModelUuid.String()
 	}
 	return SubagentConfig{
-		SessionID:      row.SessionID.String(),
-		ModelUUID:      modelUUID,
-		ModelID:        row.ModelID,
-		ProviderName:   row.ProviderName,
-		Forked:         row.Forked,
-		ParentMessages: append(json.RawMessage(nil), row.ParentMessages...),
-		CreatedAt:      row.CreatedAt.Time,
-		UpdatedAt:      row.UpdatedAt.Time,
+		SessionID:    row.SessionID.String(),
+		ModelUUID:    modelUUID,
+		ModelID:      row.ModelID,
+		ProviderName: row.ProviderName,
+		Forked:       row.Forked,
+		CreatedAt:    row.CreatedAt.Time,
+		UpdatedAt:    row.UpdatedAt.Time,
 	}
 }
 

--- a/internal/session/service_postgres_integration_test.go
+++ b/internal/session/service_postgres_integration_test.go
@@ -175,6 +175,144 @@ func TestPostgresForkFromAssistantMessageCopiesVisibleTurns(t *testing.T) {
 	}
 }
 
+func TestPostgresCreateSubagentStoresForkContextAsHiddenHistory(t *testing.T) {
+	ctx := context.Background()
+	tx := beginPostgresSessionTestTx(t, ctx)
+	setupPostgresSessionForkFixtures(t, ctx, tx)
+	legacySessionID := "00000000-0000-0000-0000-000000075122"
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO bot_sessions (id, bot_id, type, title, parent_session_id, metadata)
+		VALUES ($1, $2, 'subagent', 'Legacy worker', $3, '{"agent_id":"legacy-worker"}'::jsonb)
+	`, legacySessionID, postgresSessionTestBotID, postgresSessionTestSessionID); err != nil {
+		t.Fatalf("insert configless legacy subagent: %v", err)
+	}
+
+	providerID := "00000000-0000-0000-0000-000000075120"
+	modelID := "00000000-0000-0000-0000-000000075121"
+	name := fmt.Sprintf("postgres-subagent-test-%d", time.Now().UnixNano())
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO providers (id, name, client_type)
+		VALUES ($1, $2, 'openai-completions')
+	`, providerID, name); err != nil {
+		t.Fatalf("insert subagent provider: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO models (id, model_id, provider_id, type)
+		VALUES ($1, 'subagent-test-model', $2, 'chat')
+	`, modelID, providerID); err != nil {
+		t.Fatalf("insert subagent model: %v", err)
+	}
+
+	svc := NewService(nil, postgresstore.NewQueries(dbsqlc.New(tx)), nil)
+	child, config, err := svc.CreateSubagent(ctx, CreateSubagentInput{
+		Session: CreateInput{
+			BotID:           postgresSessionTestBotID,
+			ParentSessionID: postgresSessionTestSessionID,
+			CreatedByUserID: postgresSessionTestUserID,
+			Title:           "Forked worker",
+			Metadata:        map[string]any{"agent_id": "worker"},
+		},
+		ModelUUID:    modelID,
+		ModelID:      "subagent-test-model",
+		ProviderName: name,
+		Forked:       true,
+		ForkContext: []SubagentForkContextMessage{
+			{
+				SourceMessageID: postgresSessionTestAssistant2ID,
+				Role:            "assistant",
+				Message:         []byte(`{"role":"assistant","content":[{"type":"text","text":"second reply"}]}`),
+			},
+			{
+				Role:    "system",
+				Message: []byte(`{"role":"system","content":[{"type":"text","text":"runtime workspace context"}]}`),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create forked subagent: %v", err)
+	}
+	if !config.Forked || config.SessionID != child.ID {
+		t.Fatalf("unexpected subagent config: %+v", config)
+	}
+	listed, err := svc.ListSubagentsByParent(ctx, postgresSessionTestSessionID)
+	if err != nil {
+		t.Fatalf("list managed subagents: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != child.ID {
+		t.Fatalf("configless legacy subagent was not ignored: %+v", listed)
+	}
+
+	contextMessages, err := svc.ListSubagentForkContext(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("list subagent fork context: %v", err)
+	}
+	if len(contextMessages) != 2 || contextMessages[0].Role != "assistant" || contextMessages[1].Role != "system" {
+		t.Fatalf("unexpected fork context: %+v", contextMessages)
+	}
+
+	messageSvc := message.NewService(nil, postgresstore.NewQueries(dbsqlc.New(tx)))
+	visible, err := messageSvc.ListBySession(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("list visible child history: %v", err)
+	}
+	if len(visible) != 0 {
+		t.Fatalf("fork context leaked into visible history: %+v", visible)
+	}
+
+	var hiddenCount, copiedAssetCount int
+	var nextTurnPosition int64
+	if err := tx.QueryRow(ctx, `
+		SELECT count(*)
+		FROM bot_history_messages
+		WHERE session_id = $1
+		  AND turn_visible = false
+		  AND session_mode = 'subagent'
+		  AND metadata->>'context_scope' = 'subagent_fork'
+	`, child.ID).Scan(&hiddenCount); err != nil {
+		t.Fatalf("count hidden fork context: %v", err)
+	}
+	if hiddenCount != 2 {
+		t.Fatalf("hidden fork context count = %d, want 2", hiddenCount)
+	}
+	if err := tx.QueryRow(ctx, `
+		SELECT count(*)
+		FROM bot_history_message_assets asset
+		JOIN bot_history_messages message ON message.id = asset.message_id
+		WHERE message.session_id = $1
+		  AND message.metadata->>'source_message_id' = $2
+		  AND asset.content_hash = 'sha256:postgres-session-test-asset'
+	`, child.ID, postgresSessionTestAssistant2ID).Scan(&copiedAssetCount); err != nil {
+		t.Fatalf("count copied fork assets: %v", err)
+	}
+	if copiedAssetCount != 1 {
+		t.Fatalf("copied fork asset count = %d, want 1", copiedAssetCount)
+	}
+	if err := tx.QueryRow(ctx, `SELECT next_turn_position FROM bot_sessions WHERE id = $1`, child.ID).Scan(&nextTurnPosition); err != nil {
+		t.Fatalf("read child next turn position: %v", err)
+	}
+	if nextTurnPosition != 3 {
+		t.Fatalf("next_turn_position = %d, want 3", nextTurnPosition)
+	}
+
+	firstVisible, err := messageSvc.Persist(ctx, message.PersistInput{
+		BotID:       postgresSessionTestBotID,
+		SessionID:   child.ID,
+		Role:        "user",
+		Content:     []byte(`{"role":"user","content":"child task"}`),
+		SessionMode: TypeSubagent,
+	})
+	if err != nil {
+		t.Fatalf("persist first visible child message: %v", err)
+	}
+	var visiblePosition int64
+	if err := tx.QueryRow(ctx, `SELECT turn_position FROM bot_history_messages WHERE id = $1`, firstVisible.ID).Scan(&visiblePosition); err != nil {
+		t.Fatalf("read first visible child position: %v", err)
+	}
+	if visiblePosition != 3 {
+		t.Fatalf("first visible child position = %d, want 3", visiblePosition)
+	}
+}
+
 func TestPostgresForkFromAssistantMessageRejectsInvalidTargetWithoutSideEffects(t *testing.T) {
 	ctx := context.Background()
 	tx := beginPostgresSessionTestTx(t, ctx)

--- a/internal/session/subagent_config_test.go
+++ b/internal/session/subagent_config_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -19,6 +20,8 @@ type subagentConfigQueries struct {
 	inTx          bool
 	sessionCreate bool
 	configCreate  bool
+	contextCreate bool
+	contextJSON   []byte
 	failConfig    bool
 }
 
@@ -28,6 +31,7 @@ func (q *subagentConfigQueries) InTx(_ context.Context, fn func(dbstore.Queries)
 	if err != nil {
 		q.sessionCreate = false
 		q.configCreate = false
+		q.contextCreate = false
 	}
 	return err
 }
@@ -58,15 +62,24 @@ func (q *subagentConfigQueries) CreateSubagentConfig(_ context.Context, arg sqlc
 	q.configCreate = true
 	now := pgtype.Timestamptz{Time: time.Unix(1, 0).UTC(), Valid: true}
 	return sqlc.SubagentConfig{
-		SessionID:      arg.SessionID,
-		ModelUuid:      arg.ModelUuid,
-		ModelID:        arg.ModelID,
-		ProviderName:   arg.ProviderName,
-		Forked:         arg.Forked,
-		ParentMessages: arg.ParentMessages,
-		CreatedAt:      now,
-		UpdatedAt:      now,
+		SessionID:    arg.SessionID,
+		ModelUuid:    arg.ModelUuid,
+		ModelID:      arg.ModelID,
+		ProviderName: arg.ProviderName,
+		Forked:       arg.Forked,
+		CreatedAt:    now,
+		UpdatedAt:    now,
 	}, nil
+}
+
+func (q *subagentConfigQueries) CreateSubagentForkContext(_ context.Context, arg sqlc.CreateSubagentForkContextParams) (sqlc.CreateSubagentForkContextRow, error) {
+	q.contextCreate = true
+	q.contextJSON = append(q.contextJSON[:0], arg.ContextMessages...)
+	var messages []SubagentForkContextMessage
+	if err := json.Unmarshal(arg.ContextMessages, &messages); err != nil {
+		return sqlc.CreateSubagentForkContextRow{}, err
+	}
+	return sqlc.CreateSubagentForkContextRow{InsertedCount: int64(len(messages))}, nil
 }
 
 func mustSessionUUID(raw string) pgtype.UUID {
@@ -88,20 +101,45 @@ func TestCreateSubagentPersistsSessionAndConfigInOneTransaction(t *testing.T) {
 			Title:           "worker",
 			Metadata:        map[string]any{"agent_id": "worker"},
 		},
-		ModelUUID:      "00000000-0000-0000-0000-000000000505",
-		ModelID:        "worker-model",
-		ProviderName:   "provider-a",
-		Forked:         true,
-		ParentMessages: []byte(`[{"role":"user","content":[{"type":"text","text":"hello"}]}]`),
+		ModelUUID:    "00000000-0000-0000-0000-000000000505",
+		ModelID:      "worker-model",
+		ProviderName: "provider-a",
+		Forked:       true,
+		ForkContext: []SubagentForkContextMessage{{
+			Role:    "user",
+			Message: []byte(`{"role":"user","content":[{"type":"text","text":"hello"}]}`),
+		}},
 	})
 	if err != nil {
 		t.Fatalf("CreateSubagent: %v", err)
 	}
-	if !queries.inTx || !queries.sessionCreate || !queries.configCreate {
+	if !queries.inTx || !queries.sessionCreate || !queries.configCreate || !queries.contextCreate {
 		t.Fatalf("expected transactional session+config creation: %+v", queries)
 	}
 	if session.Type != TypeSubagent || config.ModelID != "worker-model" || config.ProviderName != "provider-a" || !config.Forked {
 		t.Fatalf("unexpected created values: session=%+v config=%+v", session, config)
+	}
+}
+
+func TestCreateSubagentPersistsEmptyForkContextAsJSONArray(t *testing.T) {
+	queries := &subagentConfigQueries{}
+	svc := NewService(nil, queries, nil)
+	_, config, err := svc.CreateSubagent(context.Background(), CreateSubagentInput{
+		Session: CreateInput{
+			BotID:           "00000000-0000-0000-0000-000000000501",
+			ParentSessionID: "00000000-0000-0000-0000-000000000502",
+			Title:           "empty fork",
+		},
+		ModelUUID:    "00000000-0000-0000-0000-000000000505",
+		ModelID:      "worker-model",
+		ProviderName: "provider-a",
+		Forked:       true,
+	})
+	if err != nil {
+		t.Fatalf("CreateSubagent: %v", err)
+	}
+	if !queries.contextCreate || string(queries.contextJSON) != "[]" || !config.Forked {
+		t.Fatalf("empty fork context was not persisted: queries=%+v config=%+v", queries, config)
 	}
 }
 


### PR DESCRIPTION
## Summary\n\n- remove the parent_messages JSONB snapshot from subagent_configs\n- persist forked model context as marker-scoped invisible bot_history_messages rows and copy existing message assets\n- materialize runtime-only context messages in the same history facility\n- load only subagent fork context rows while keeping user-visible session history unchanged\n- intentionally discard existing subagent configs and ignore configless legacy subagent sessions\n\n## Verification\n\n- go test ./...\n- mise run lint:go\n- sqlc generate with sqlc 1.31.1\n- PostgreSQL migration up -> down -> up integration test\n- PostgreSQL hidden-history and asset-copy integration test\n- development migration 119 applied with a healthy server\n- authenticated web message API spawned a forked subagent and returned the expected child response; temporary test data was removed