### PR TITLE
fix(ci): avoid local tags for digest pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -181,7 +181,8 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platform }}
           load: ${{ env.PUSH != 'true' && matrix.image == 'workspace' && matrix.platform == 'linux/amd64' }}
-          tags: memoh-ci-${{ matrix.image }}:${{ matrix.variant != '' && matrix.variant || 'default' }}
+          # A local tag is only needed by the PR smoke-test; digest pushes must not include it.
+          tags: ${{ env.PUSH != 'true' && matrix.image == 'workspace' && matrix.platform == 'linux/amd64' && 'memoh-ci-workspace:debian' || '' }}
           outputs: ${{ env.PUSH == 'true' && format('type=image,"name={0}/{1}/{2}",push-by-digest=true,name-canonical=true,push=true,compression=zstd', env.REGISTRY, github.repository_owner, matrix.image) || '' }}
           build-contexts: ${{ matrix.image == 'server' && format('gomodcache={0}/.go-cache', github.workspace) || '' }}
           build-args: |


### PR DESCRIPTION
## Summary

- scope the local `memoh-ci-workspace:debian` tag to the non-publishing amd64 workspace smoke-test
- keep main and release builds on the existing GHCR digest-only output path
- document why local tags must not be supplied to digest pushes

## Root cause

PR #852 added a local image tag for the workspace smoke-test, but the tag was passed to every matrix build. On main, Buildx therefore received both a GHCR `push-by-digest` output and a tagged `docker.io/library/memoh-ci-*` reference. All six Server, Web, and Workspace architecture jobs failed during export with `can't push tagged ref ... by digest` after their images had built successfully.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -shellcheck= .github/workflows/docker.yml`
- `git diff --check`
- compared the publishing inputs against the last successful main Docker workflow, which did not pass a local tag to digest exports
