### PR TITLE
fix(providers): save templates before OAuth

### DIFF
--- a/apps/web/src/pages/email/components/provider-setting.test.ts
+++ b/apps/web/src/pages/email/components/provider-setting.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, provide, ref } from 'vue'
+import type { Component, Slots } from 'vue'
+import type { EmailProviderResponse } from '@memohai/sdk'
+
+const mocks = vi.hoisted(() => ({
+  authorize: vi.fn(),
+  createProvider: vi.fn(),
+  getOAuthStatus: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+function translate(key: string) {
+  return key
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: translate, te: () => false }),
+}))
+
+vi.mock('vee-validate', async () => {
+  const { reactive } = await import('vue')
+  return {
+    useForm: () => {
+      const values = reactive({ name: '' })
+      return {
+        handleSubmit: (submit: (values: { name: string }) => unknown) => async (event?: Event) => {
+          event?.preventDefault()
+          return submit({ ...values })
+        },
+        setValues: (next: { name: string }) => Object.assign(values, next),
+      }
+    },
+  }
+})
+
+vi.mock('@pinia/colada', async () => {
+  const { ref } = await import('vue')
+  return {
+    useMutation: ({ mutation }: { mutation: (data?: unknown) => Promise<unknown> }) => ({
+      mutateAsync: (data?: unknown) => mutation(data),
+      isLoading: ref(false),
+    }),
+    useQuery: () => ({
+      data: ref([{
+        provider: 'gmail',
+        display_name: 'Gmail',
+        config_schema: { fields: [] },
+      }]),
+    }),
+    useQueryCache: () => ({ invalidateQueries: vi.fn() }),
+  }
+})
+
+vi.mock('@memohai/sdk', () => ({
+  deleteEmailProvidersById: vi.fn(),
+  deleteEmailProvidersByIdOauthToken: vi.fn(),
+  getEmailProvidersByIdOauthAuthorize: mocks.authorize,
+  getEmailProvidersByIdOauthStatus: mocks.getOAuthStatus,
+  getEmailProvidersMeta: vi.fn(),
+  postEmailProviders: mocks.createProvider,
+  putEmailProvidersById: vi.fn(),
+}))
+
+vi.mock('lucide-vue-next', () => ({
+  Eye: () => h('span'),
+  EyeOff: () => h('span'),
+  KeyRound: () => h('span'),
+  Trash2: () => h('span'),
+}))
+
+vi.mock('@felinic/ui', async () => {
+  const { h } = await import('vue')
+  const Passthrough = (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.())
+  const Button = (_props: Record<string, unknown>, { attrs, slots }: { attrs: Record<string, unknown>, slots: Slots }) => h('button', attrs, slots.default?.())
+  const FormField = (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.({
+    componentField: {},
+  }))
+  return {
+    Button,
+    FormControl: Passthrough,
+    FormField,
+    Input: Passthrough,
+    Select: Passthrough,
+    SelectContent: Passthrough,
+    SelectItem: Passthrough,
+    SelectTrigger: Passthrough,
+    SelectValue: Passthrough,
+    Switch: Passthrough,
+    toast: {
+      error: mocks.toastError,
+      success: mocks.toastSuccess,
+    },
+  }
+})
+
+vi.mock('@/components/confirm-popover/index.vue', () => ({
+  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.()),
+}))
+vi.mock('@/components/loading-button/index.vue', () => ({
+  default: (_props: Record<string, unknown>, { attrs, slots }: { attrs: Record<string, unknown>, slots: Slots }) => h('button', attrs, slots.default?.()),
+}))
+vi.mock('@/components/settings-shell/index.vue', () => ({
+  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.()),
+}))
+vi.mock('@/components/settings/section.vue', () => ({
+  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('section', [slots.default?.(), slots.footer?.()]),
+}))
+vi.mock('@/components/settings/row.vue', () => ({
+  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.()),
+}))
+vi.mock('@/components/settings/field-stack.vue', () => ({
+  default: (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.()),
+}))
+vi.mock('@/components/email-provider-icon/index.vue', () => ({ default: () => h('span') }))
+
+let ProviderSetting: Component
+
+describe('Gmail provider OAuth', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ProviderSetting = (await import('./provider-setting.vue')).default
+    mocks.createProvider.mockResolvedValue({
+      data: {
+        id: 'gmail-created',
+        name: 'Gmail',
+        provider: 'gmail',
+        config: {},
+      },
+    })
+    mocks.authorize.mockResolvedValue({
+      data: { auth_url: 'https://accounts.google.com/oauth' },
+    })
+    mocks.getOAuthStatus.mockResolvedValue({
+      data: {
+        configured: true,
+        has_token: true,
+        expired: false,
+        email_address: 'person@gmail.com',
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('creates the template draft before requesting the authorization URL', async () => {
+    const provider = ref<EmailProviderResponse>({
+      name: 'Gmail',
+      provider: 'gmail',
+      config: {},
+    })
+    const popup = {
+      close: vi.fn(),
+      focus: vi.fn(),
+      location: { href: '' },
+    }
+    vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window)
+
+    const Wrapper = defineComponent({
+      setup() {
+        provide('curEmailProvider', provider)
+        return () => h(ProviderSetting)
+      },
+    })
+    const root = document.createElement('div')
+    document.body.append(root)
+    const app = createApp(Wrapper)
+    app.config.globalProperties.$t = translate
+    app.mount(root)
+    await flushPromises()
+
+    const authorizeButton = Array.from(root.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('email.oauth.authorize'))
+    expect(authorizeButton).toBeDefined()
+    authorizeButton!.click()
+    await flushPromises()
+
+    expect(window.open).toHaveBeenCalledWith('', 'email-oauth', 'width=600,height=720')
+    expect(mocks.createProvider).toHaveBeenCalledWith({
+      body: {
+        name: 'Gmail',
+        provider: 'gmail',
+        config: {},
+      },
+      throwOnError: true,
+    })
+    expect(mocks.authorize).toHaveBeenCalledWith({
+      path: { id: 'gmail-created' },
+    })
+    expect(mocks.createProvider.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.authorize.mock.invocationCallOrder[0]!)
+    expect(popup.location.href).toBe('https://accounts.google.com/oauth')
+    expect(popup.focus).toHaveBeenCalledOnce()
+
+    window.dispatchEvent(new MessageEvent('message', {
+      data: {
+        type: 'memoh-email-oauth-callback',
+        providerId: 'gmail-created',
+        status: 'success',
+      },
+    }))
+    await flushPromises()
+
+    expect(provider.value.id).toBe('gmail-created')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('email.oauth.authorizeOpened')
+
+    app.unmount()
+    root.remove()
+  })
+})

--- a/apps/web/src/pages/email/components/provider-setting.vue
+++ b/apps/web/src/pages/email/components/provider-setting.vue
@@ -365,6 +365,19 @@ const { mutateAsync: doDelete, isLoading: deleteLoading } = useMutation({
 })
 
 const handleSave = form.handleSubmit(async (values) => {
+  try {
+    const providerId = await persistProvider(values)
+    if (!providerId) return
+    toast.success(t('provider.saveChanges'))
+    if (isOAuthProvider.value) {
+      await fetchOAuthStatus(providerId)
+    }
+  } catch (e: unknown) {
+    toast.error(e instanceof Error ? e.message : t('common.saveFailed'))
+  }
+})
+
+async function persistProvider(values: { name: string }): Promise<string | null> {
   const missing = orderedFields.value.find((field) => {
     if (!field.required || !field.key) return false
     const value = configData[field.key]
@@ -373,18 +386,16 @@ const handleSave = form.handleSubmit(async (values) => {
   })
   if (missing) {
     toast.error(t('provider.requiredField', { field: fieldLabel(missing) }))
-    return
+    return null
   }
-  try {
-    await submitUpdate({ name: values.name, config: { ...configData } })
-    toast.success(t('provider.saveChanges'))
-    if (isOAuthProvider.value) {
-      await fetchOAuthStatus()
-    }
-  } catch (e: unknown) {
-    toast.error(e instanceof Error ? e.message : t('common.saveFailed'))
-  }
-})
+
+  const provider = await submitUpdate({ name: values.name, config: { ...configData } })
+  const providerId = provider?.id ?? curProviderId.value
+  if (!providerId) throw new Error(t('common.saveFailed'))
+  return providerId
+}
+
+const persistProviderForOAuth = form.handleSubmit(values => persistProvider(values))
 
 async function handleDelete() {
   if (!curProviderId.value) return
@@ -400,27 +411,36 @@ const authorizeLoading = ref(false)
 const hasOAuthToken = computed(() => Boolean(oauthStatus.value?.has_token))
 const oauthTokenExpired = computed(() => Boolean(oauthStatus.value?.has_token && oauthStatus.value?.expired))
 const canAuthorize = computed(() => {
-  if (!isOAuthProvider.value || !curProviderId.value) return false
+  if (!isOAuthProvider.value) return false
   if (oauthStatusLoading.value) return false
   if (oauthStatus.value && !oauthStatus.value.configured) return false
   return true
 })
 
 async function handleAuthorize() {
-  if (!curProviderId.value) return
+  const popup = window.open('', 'email-oauth', 'width=600,height=720')
+  if (!popup) {
+    toast.error(t('email.oauth.authorizeFailed'))
+    return
+  }
+
   authorizeLoading.value = true
   try {
+    const providerId = await persistProviderForOAuth()
+    if (!providerId) {
+      popup.close()
+      return
+    }
+
     const { data, error } = await getEmailProvidersByIdOauthAuthorize({
-      path: { id: curProviderId.value },
+      path: { id: providerId },
     })
     if (error || !data?.auth_url) {
       throw new Error(t('email.oauth.authorizeFailed'))
     }
 
-    const popup = window.open(data.auth_url, 'email-oauth', 'width=600,height=720')
-    if (!popup) {
-      throw new Error(t('email.oauth.authorizeFailed'))
-    }
+    popup.location.href = data.auth_url
+    popup.focus()
 
     await new Promise<void>((resolve, reject) => {
       const cleanup = () => {
@@ -429,12 +449,12 @@ async function handleAuthorize() {
 
       const onMessage = async (event: MessageEvent) => {
         if (event.data?.type !== 'memoh-email-oauth-callback') return
-        if (event.data?.providerId && event.data.providerId !== curProviderId.value) return
+        if (event.data?.providerId && event.data.providerId !== providerId) return
 
         cleanup()
 
         if (event.data?.status === 'success') {
-          await fetchOAuthStatus()
+          await fetchOAuthStatus(providerId)
           toast.success(t('email.oauth.authorizeOpened'))
           resolve()
           return
@@ -446,21 +466,22 @@ async function handleAuthorize() {
       window.addEventListener('message', onMessage)
     })
   } catch (e: unknown) {
+    popup.close()
     toast.error(e instanceof Error ? e.message : t('email.oauth.authorizeFailed'))
   } finally {
     authorizeLoading.value = false
   }
 }
 
-async function fetchOAuthStatus() {
-  if (!isOAuthProvider.value || !curProviderId.value) {
+async function fetchOAuthStatus(providerId = curProviderId.value) {
+  if (!isOAuthProvider.value || !providerId) {
     oauthStatus.value = null
     return
   }
   oauthStatusLoading.value = true
   try {
     const { data, error } = await getEmailProvidersByIdOauthStatus({
-      path: { id: curProviderId.value },
+      path: { id: providerId },
     })
     if (error) {
       throw error

--- a/apps/web/src/pages/providers/components/provider-form.test.ts
+++ b/apps/web/src/pages/providers/components/provider-form.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, h, nextTick } from 'vue'
+import { createApp, defineComponent, h, nextTick, ref } from 'vue'
 import type { Slots } from 'vue'
 
 const mocks = vi.hoisted(() => ({
+  ensureProvider: vi.fn(),
+  getAuthorize: vi.fn(),
   getOAuthStatus: vi.fn(),
   pollOAuth: vi.fn(),
   syncCatalog: vi.fn(),
@@ -28,7 +30,7 @@ vi.mock('vue-i18n', () => ({
 
 vi.mock('@memohai/sdk', () => ({
   deleteProvidersByIdOauthToken: vi.fn(),
-  getProvidersByIdOauthAuthorize: vi.fn(),
+  getProvidersByIdOauthAuthorize: mocks.getAuthorize,
   getProvidersByIdOauthStatus: mocks.getOAuthStatus,
   postProvidersByIdOauthPoll: mocks.pollOAuth,
   postProvidersByIdTest: vi.fn(),
@@ -51,9 +53,10 @@ vi.mock('@felinic/ui', async () => {
     componentField: {},
     errorMessage: '',
   }))
+  const Button = (_props: Record<string, unknown>, { attrs, slots }: { attrs: Record<string, unknown>, slots: Slots }) => h('button', attrs, slots.default?.())
   return {
     AutoHeight: Passthrough,
-    Button: Passthrough,
+    Button,
     FormControl: Passthrough,
     FormField,
     FormItem: Passthrough,
@@ -77,7 +80,7 @@ vi.mock('@felinic/ui', async () => {
 })
 
 vi.mock('@/components/confirm-popover/index.vue', () => ({ default: { template: '<div><slot /></div>' } }))
-vi.mock('@/components/device-code-panel/index.vue', () => ({ default: { template: '<div><slot /></div>' } }))
+vi.mock('@/components/device-code-panel/index.vue', () => ({ default: { template: '<div data-testid="device-code"><slot /></div>' } }))
 vi.mock('@/components/loading-button/index.vue', () => ({ default: { template: '<div><slot /></div>' } }))
 vi.mock('@/components/settings/row.vue', () => ({ default: { template: '<div><slot /></div>' } }))
 vi.mock('@/components/settings/section.vue', () => ({ default: { template: '<div><slot /></div>' } }))
@@ -108,6 +111,24 @@ describe('provider OAuth model sync', () => {
         expired: false,
       },
     })
+    mocks.getAuthorize.mockResolvedValue({
+      data: {
+        mode: 'device',
+        device: {
+          pending: true,
+          user_code: 'ABCD-EFGH',
+          verification_uri: 'https://github.com/login/device',
+          interval_seconds: 1,
+        },
+      },
+    })
+    mocks.ensureProvider.mockResolvedValue({
+      id: 'created-provider-id',
+      name: 'GitHub Copilot',
+      client_type: 'github-copilot',
+      enable: false,
+      config: {},
+    })
     mocks.syncCatalog.mockResolvedValue({ created: 2, updated: 1 })
   })
 
@@ -117,10 +138,11 @@ describe('provider OAuth model sync', () => {
   })
 
   it('syncs the managed catalog when device authorization completes', async () => {
-    const ProviderForm = (await import('./provider-form.vue')).default
+    const providerForm = (await import('./provider-form.vue')).default
     const root = document.createElement('div')
     document.body.append(root)
-    const app = createApp(ProviderForm, {
+    // eslint-disable-next-line vue/one-component-per-file -- The object is root props, not a component definition.
+    const app = createApp(providerForm, {
       provider: {
         id: 'provider-id',
         name: 'GitHub Copilot',
@@ -129,6 +151,7 @@ describe('provider OAuth model sync', () => {
         config: {},
       },
       editLoading: false,
+      ensureProvider: mocks.ensureProvider,
     })
     app.config.globalProperties.$t = translate
     app.mount(root)
@@ -142,6 +165,105 @@ describe('provider OAuth model sync', () => {
     expect(mocks.syncCatalog).toHaveBeenCalledOnce()
     expect(mocks.syncCatalog).toHaveBeenCalledWith('provider-id')
     expect(mocks.toastSuccess).toHaveBeenCalledWith('provider.oauth.authorizeSuccess')
+
+    app.unmount()
+    root.remove()
+  })
+
+  it('materializes a template before starting OAuth authorization', async () => {
+    const providerForm = (await import('./provider-form.vue')).default
+    const root = document.createElement('div')
+    document.body.append(root)
+    // eslint-disable-next-line vue/one-component-per-file -- The object is root props, not a component definition.
+    const app = createApp(providerForm, {
+      provider: {
+        provider_template_id: 'template-copilot',
+        name: 'GitHub Copilot',
+        client_type: 'github-copilot',
+        enable: false,
+        config: {},
+      },
+      editLoading: false,
+      ensureProvider: mocks.ensureProvider,
+    })
+    app.config.globalProperties.$t = translate
+    app.mount(root)
+    await flushPromises()
+
+    ;(root.querySelector('button') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(mocks.ensureProvider).toHaveBeenCalledOnce()
+    expect(mocks.getAuthorize).toHaveBeenCalledWith({
+      path: { id: 'created-provider-id' },
+      throwOnError: true,
+    })
+    expect(mocks.ensureProvider.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.getAuthorize.mock.invocationCallOrder[0]!)
+
+    app.unmount()
+    root.remove()
+  })
+
+  it('keeps the new device code when the pre-authorization status request finishes later', async () => {
+    let resolveStatus!: (value: { data: Record<string, unknown> }) => void
+    mocks.getOAuthStatus.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveStatus = resolve
+    }))
+
+    const providerForm = (await import('./provider-form.vue')).default
+    const provider = ref<Record<string, unknown>>({
+      provider_template_id: 'template-copilot',
+      name: 'GitHub Copilot',
+      client_type: 'github-copilot',
+      enable: false,
+      config: {},
+    })
+    const ensureProvider = vi.fn(async () => {
+      const created = {
+        id: 'created-provider-id',
+        name: 'GitHub Copilot',
+        client_type: 'github-copilot',
+        enable: false,
+        config: {},
+      }
+      provider.value = created
+      await nextTick()
+      return created
+    })
+    // eslint-disable-next-line vue/one-component-per-file -- Test wrapper keeps the provider prop reactive during materialization.
+    const Wrapper = defineComponent({
+      setup() {
+        return () => h(providerForm, {
+          provider: provider.value,
+          editLoading: false,
+          ensureProvider,
+        })
+      },
+    })
+    const root = document.createElement('div')
+    document.body.append(root)
+    const app = createApp(Wrapper)
+    app.config.globalProperties.$t = translate
+    app.mount(root)
+    await flushPromises()
+
+    ;(root.querySelector('button') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(root.querySelector('[data-testid="device-code"]')).not.toBeNull()
+
+    resolveStatus({
+      data: {
+        configured: true,
+        mode: 'device',
+        has_token: false,
+        expired: false,
+      },
+    })
+    await flushPromises()
+
+    expect(root.querySelector('[data-testid="device-code"]')).not.toBeNull()
 
     app.unmount()
     root.remove()

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -270,7 +270,7 @@
               variant="outline"
               size="sm"
               class="shrink-0"
-              :disabled="!props.provider?.id"
+              :disabled="authorizeLoading"
               :loading="authorizeLoading"
               loading-mode="manual"
               @click="devicePending ? cancelDeviceAuthorization() : handleAuthorize()"
@@ -397,6 +397,7 @@ function supportsPromptCache(clientType: string | undefined): boolean {
 const props = defineProps<{
   provider: ProviderWithAuth | undefined
   editLoading: boolean
+  ensureProvider: () => Promise<ProvidersGetResponse>
 }>()
 
 const isDraft = computed(() => !props.provider?.id && !!props.provider?.provider_template_id)
@@ -414,6 +415,7 @@ const oauthStatusLoading = ref(false)
 const authorizeLoading = ref(false)
 const revokeLoading = ref(false)
 const devicePollTimer = ref<number | null>(null)
+let oauthStatusLoadGeneration = 0
 
 const testStatus = computed(() => {
   if (testResult.value?.status === 'ok') return 'ok'
@@ -533,6 +535,8 @@ watch(() => props.provider, (newVal) => {
 
 watch(() => form.values.client_type, (clientType) => {
   if (!isManagedOAuthClientType(clientType)) {
+    oauthStatusLoadGeneration += 1
+    oauthStatusLoading.value = false
     oauthStatus.value = null
   }
   if (clientType === 'openai-codex' && !form.values.base_url) {
@@ -545,6 +549,8 @@ watch(() => form.values.client_type, (clientType) => {
 
 watch(() => [props.provider?.id, form.values.client_type] as const, async ([id, clientType]) => {
   if (!id || !isManagedOAuthClientType(clientType)) {
+    oauthStatusLoadGeneration += 1
+    oauthStatusLoading.value = false
     oauthStatus.value = null
     return
   }
@@ -644,6 +650,7 @@ function clearDevicePollTimer() {
 
 async function fetchOAuthStatus(): Promise<ProvidersOAuthStatus | null> {
   if (!props.provider?.id) return null
+  const generation = ++oauthStatusLoadGeneration
   oauthStatusLoading.value = true
   try {
     const { data } = await getProvidersByIdOauthStatus({
@@ -651,14 +658,18 @@ async function fetchOAuthStatus(): Promise<ProvidersOAuthStatus | null> {
       throwOnError: true,
     })
     const nextStatus = data ?? null
+    if (generation !== oauthStatusLoadGeneration) return null
     oauthStatus.value = nextStatus
     return nextStatus
   } catch (error) {
+    if (generation !== oauthStatusLoadGeneration) return null
     oauthStatus.value = null
     console.error('failed to load provider oauth status', error)
     return null
   } finally {
-    oauthStatusLoading.value = false
+    if (generation === oauthStatusLoadGeneration) {
+      oauthStatusLoading.value = false
+    }
   }
 }
 
@@ -715,11 +726,19 @@ function cancelDeviceAuthorization() {
 }
 
 async function handleAuthorize() {
-  if (!props.provider?.id) return
   authorizeLoading.value = true
   try {
+    let providerId = props.provider?.id
+    if (!providerId) {
+      const provider = await props.ensureProvider()
+      providerId = provider.id
+    }
+    if (!providerId) throw new Error(t('provider.oauth.authorizeFailed'))
+
+    oauthStatusLoadGeneration += 1
+    oauthStatusLoading.value = false
     const { data } = await getProvidersByIdOauthAuthorize({
-      path: { id: props.provider.id },
+      path: { id: providerId },
       throwOnError: true,
     })
     if (!data) throw new Error(t('provider.oauth.authorizeFailed'))

--- a/apps/web/src/pages/providers/model-setting.vue
+++ b/apps/web/src/pages/providers/model-setting.vue
@@ -51,6 +51,7 @@
       <ProviderForm
         :provider="curProvider"
         :edit-loading="editLoading"
+        :ensure-provider="ensureOAuthProvider"
         @submit="changeProvider"
       />
 
@@ -167,7 +168,11 @@ const { mutate: changeProvider, isLoading: editLoading } = useMutation({
   },
 })
 
-async function materializeProvider(data: Record<string, unknown>, enable: boolean) {
+async function materializeProvider(
+  data: Record<string, unknown>,
+  enable: boolean,
+  importModels = true,
+) {
   if (curProvider.value?.id) return curProvider.value
   if (materializePromise) return materializePromise
 
@@ -200,13 +205,15 @@ async function materializeProvider(data: Record<string, unknown>, enable: boolea
     curProvider.value = result
     emit('materialized', result)
 
-    try {
-      await postProvidersByIdImportModels({
-        path: { id: created.id },
-        throwOnError: true,
-      })
-    } catch {
-      toast.error(t('models.importFailed'))
+    if (importModels) {
+      try {
+        await postProvidersByIdImportModels({
+          path: { id: created.id },
+          throwOnError: true,
+        })
+      } catch {
+        toast.error(t('models.importFailed'))
+      }
     }
 
     invalidateProviderQueries()
@@ -219,6 +226,18 @@ async function materializeProvider(data: Record<string, unknown>, enable: boolea
   } finally {
     materializePromise = null
   }
+}
+
+async function ensureOAuthProvider(): Promise<ProvidersGetResponse> {
+  const provider = curProvider.value
+  if (!provider) throw new Error('provider is missing')
+  if (provider.id) return provider
+
+  return materializeProvider({
+    name: provider.name,
+    config: provider.config ?? {},
+    metadata: provider.metadata ?? {},
+  }, provider.enable !== false, false)
 }
 
 async function handleToggleEnable(value: boolean) {


### PR DESCRIPTION
## Summary

- materialize OpenAI Codex and GitHub Copilot templates before starting managed OAuth
- validate and persist Gmail provider drafts before requesting the OAuth URL
- prevent stale OAuth status reads from replacing a newly issued device code

## Why

Provider templates intentionally remain UI-only until configured. OAuth endpoints require a persisted provider ID, so draft templates previously forced users to save or enable them before the Connect action became available.

## Validation

- `pnpm exec vitest run apps/web/src/pages/providers/components/provider-form.test.ts apps/web/src/pages/email/components/provider-setting.test.ts apps/web/src/pages/providers/index.test.ts apps/web/src/pages/email/index.test.ts` (13 tests passed)
- `pnpm exec eslint apps/web/src/pages/email/components/provider-setting.vue apps/web/src/pages/email/components/provider-setting.test.ts apps/web/src/pages/providers/components/provider-form.vue apps/web/src/pages/providers/components/provider-form.test.ts apps/web/src/pages/providers/model-setting.vue`
- `node scripts/check-ui-contract.mjs`
- `pnpm --filter @memohai/web build`
- `git diff --check`

## Notes

- The full Web typecheck remains blocked by unrelated pre-existing repository errors.
- Rendered verification confirmed that the GitHub Copilot template Connect action is enabled. Gmail draft sequencing is covered by the component test because the local environment already had a persisted Gmail instance and no configured Gmail OAuth client.
