### PR TITLE
fix(devenv): pin air to v1.66.0 for Go 1.25 compatibility

### DIFF
--- a/devenv/Dockerfile.server
+++ b/devenv/Dockerfile.server
@@ -7,7 +7,7 @@ FROM golang:1.25-alpine
 
 WORKDIR /workspace
 
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/air-verse/air@v1.66.0
 
 RUN apk add --no-cache \
     bash \


### PR DESCRIPTION
## Problem

The dev server image build fails for everyone since air released v1.67:

```
#9 [3/7] RUN go install github.com/air-verse/air@latest
go: downloading github.com/air-verse/air v1.67.2
go: github.com/air-verse/air@latest: github.com/air-verse/air@v1.67.2 requires go >= 1.26.0 (running go 1.25.12; GOTOOLCHAIN=local)
ERROR: exit code 1
```

`devenv/Dockerfile.server` installs air with `@latest` on a `golang:1.25-alpine` base. air v1.67.0 bumped its Go requirement to 1.26, so the unpinned install now fails on every build, with no change in this repo.

Reproduce: `docker run --rm golang:1.25-alpine go install github.com/air-verse/air@latest`

## Fix

Pin air to v1.66.0 — the last release that targets Go 1.25 (verified via its go.mod). Bumping the base image to Go 1.26 was considered but rejected: the repo toolchain is pinned to Go 1.25 (mise.toml), and the dev image should match it.

Verified: image builds cleanly with the pin; air v1.66.0 hot-reload works in the dev stack.