### PR TITLE
fix(web): keep ask_user composer hidden while pending

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -2056,7 +2056,7 @@ const dockMaskHeight = computed(() => dockEl.value?.maskHeight ?? `${COMPOSER_MA
 const messagesBottomPad = computed(() => `${dockHeight.value + COMPOSER_MASK_BELOW_PX + 24}px`)
 
 // The textarea belongs to the pane, so when the dock hands the input slot
-// back (ask_user resolved or an option picked) it emits and we focus here.
+// back after ask_user is resolved or canceled, it emits and we focus here.
 function handleDockRevealComposer(opts: { focus?: boolean }) {
   if (opts.focus) void nextTick(focusTextarea)
 }

--- a/apps/web/src/pages/home/components/chat-user-input-form.test.ts
+++ b/apps/web/src/pages/home/components/chat-user-input-form.test.ts
@@ -65,7 +65,7 @@ describe('chat-user-input-form', () => {
     return root
   }
 
-  it('hands the composer back (focused) when an option is selected', async () => {
+  it('keeps the composer hidden when an option is selected', async () => {
     const revealComposer = vi.fn()
     const ChatUserInputForm = (await import('./chat-user-input-form.vue')).default
     const el = await mount(ChatUserInputForm, {
@@ -88,9 +88,42 @@ describe('chat-user-input-form', () => {
     await nextTick()
 
     expect(firstOption!.getAttribute('aria-checked')).toBe('true')
-    // Selecting an option reveals the composer (focused, since this is the
-    // lone question) so the user can keep typing; it does not submit yet.
-    expect(revealComposer).toHaveBeenCalledWith({ focus: true })
+    expect(revealComposer).not.toHaveBeenCalled()
     expect(respondUserInput).not.toHaveBeenCalled()
+  })
+
+  it('hands the composer back when the request is canceled', async () => {
+    const revealComposer = vi.fn()
+    const userInput = {
+      user_input_id: 'input-1',
+      status: 'pending',
+      questions: [{
+        id: 'q1',
+        text: 'Choose one',
+        kind: 'single_select',
+        options: [{ id: 'q1.o1', label: 'One' }],
+      }],
+    }
+    const ChatUserInputForm = (await import('./chat-user-input-form.vue')).default
+    const el = await mount(ChatUserInputForm, {
+      userInput,
+      onRevealComposer: revealComposer,
+    })
+
+    const cancel = [...el.querySelectorAll<HTMLButtonElement>('button')]
+      .find(button => button.textContent === 'chat.tools.cancelUserInput')
+    expect(cancel).toBeDefined()
+    cancel!.click()
+    await nextTick()
+
+    expect(revealComposer).toHaveBeenCalledWith({ focus: true })
+    expect(respondUserInput).toHaveBeenCalledWith(userInput, {
+      canceled: true,
+      reason: 'user_canceled',
+    }, {
+      botId: 'bot-1',
+      sessionId: 'session-1',
+      viewId: 'view-1',
+    })
   })
 })

--- a/apps/web/src/pages/home/components/chat-user-input-form.vue
+++ b/apps/web/src/pages/home/components/chat-user-input-form.vue
@@ -107,9 +107,8 @@ import ComposerCapsule from './composer-capsule.vue'
 // while a request is pending (the parent hides the textarea and shows this
 // capsule, styled like the composer, in its place) and is fully
 // self-contained: option rows on top, then a divider, then the free-text
-// input ("tell the bot more") and the Submit / Cancel pair. Cancel resolves
-// the request as canceled, which hands the composer back. Picking an option
-// also reveals the composer again so the user can keep typing.
+// input ("tell the bot more") and the Submit / Cancel pair. The normal
+// composer stays hidden until the request is submitted or canceled.
 // Multi-question requests keep per-question inline inputs, because one footer
 // input cannot answer several text questions at once.
 const props = defineProps<{
@@ -199,8 +198,6 @@ function toggleOption(question: UIUserInputQuestion, optionId: string) {
     draft.customSelected = false
     draft.customText = ''
   }
-  // Picking an option hands the textarea back so the user can keep typing.
-  emit('reveal-composer', { focus: isSingle.value })
 }
 
 function toggleCustom(question: UIUserInputQuestion) {

--- a/apps/web/src/pages/home/components/composer-dock.vue
+++ b/apps/web/src/pages/home/components/composer-dock.vue
@@ -54,8 +54,9 @@
 //   REPLACING the composer is a deliberate product decision, not an accident:
 //   while the agent is asking, answering is the only input that matters, and
 //   the capsule's own free-text field IS the substitute input. That mutex is
-//   a public capability of this dock (the capsule can hand the slot back via
-//   `reveal-composer`) — it must survive any future refactor of the tiers.
+//   a public capability of this dock: selecting an answer never releases it;
+//   the capsule hands the slot back only when the request resolves or the user
+//   explicitly cancels.
 // - STACK tier (ComposerPanel, hugs the box): approvals / command results /
 //   errors — surfaces the user answers with a CLICK, so they must not take
 //   the input slot away.
@@ -107,7 +108,7 @@ const stackVisible = computed(() => Boolean(
 
 // Box-tier mutex: while an ask_user request is pending the capsule owns the
 // slot and the composer hides (v-show so its textarea state survives); the
-// capsule hands the slot back once an option is picked or it resolves.
+// capsule hands the slot back only once the request resolves or is canceled.
 const userInputComposerRevealed = ref(false)
 const composerVisible = computed(() => !props.pendingUserInput || userInputComposerRevealed.value)
 

--- a/apps/web/src/pages/login/index.vue
+++ b/apps/web/src/pages/login/index.vue
@@ -32,6 +32,7 @@
       <!-- 两字段 + Continue 等距 gap-2.5(不学 SaaS 密码步拉开 CTA)。
            placeholder 用 Enter …(P0 label≠placeholder)。 -->
       <form
+        v-if="!loginSucceeded"
         class="flex w-full flex-col gap-2.5"
         @submit.prevent="login"
       >
@@ -61,6 +62,12 @@
           {{ $t('auth.continue') }}
         </LoadingButton>
       </form>
+      <div
+        v-else
+        class="flex w-full flex-col items-center gap-3"
+      >
+        <CircleCheck class="size-12 text-foreground" />
+      </div>
     </section>
   </main>
 </template>
@@ -68,6 +75,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { Input } from '@felinic/ui'
+import { CircleCheck } from 'lucide-vue-next'
 import { useRouter } from 'vue-router'
 import { useUserStore } from '@/store/user'
 import { toast } from '@felinic/ui'
@@ -86,6 +94,7 @@ const { t } = useI18n()
 
 const username = ref('')
 const password = ref('')
+const loginSucceeded = ref(false)
 const exiting = ref(false)
 const shouldAnimateEntry = safeSessionGet(LOGIN_ENTRY_ANIMATION_KEY) === '1'
 if (shouldAnimateEntry) safeSessionRemove(LOGIN_ENTRY_ANIMATION_KEY)
@@ -116,6 +125,8 @@ const login = async () => {
       authenticate: (body) => postAuthLogin({ body }),
       applyLogin: loginHandle,
       navigateHome: async () => {
+        loginSucceeded.value = true
+        await new Promise<void>(resolve => setTimeout(resolve, 700))
         exiting.value = true
         safeSessionSet(ONBOARDING_KEYS.entryAnimation, '1')
         await new Promise<void>(resolve => setTimeout(resolve, 175))


### PR DESCRIPTION
## Summary

- keep the normal chat composer hidden while an `ask_user` request is pending
- treat option selection as draft state only
- restore and focus the composer after explicit cancellation
- add regression coverage for selection and cancellation

## Root cause

The composer dock refactor emitted `reveal-composer` immediately after an option was selected. That released the box-tier mutex before the user submitted or canceled the `ask_user` form, so the normal prompt textarea reappeared alongside the pending decision.

## User impact

The prompt textarea now remains hidden for the full lifetime of the pending `ask_user` interaction and returns only after submission, resolution, or cancellation.

## Validation

- `pnpm test apps/web/src/pages/home/components/chat-user-input-form.test.ts --run`
- focused ESLint for the four changed Vue/Test files
- `node scripts/check-ui-contract.mjs`
- commit hook: Go tests, Go lint, staged ESLint