### PR TITLE
fix(agent): stabilize prompt cache prefixes

### DIFF
--- a/internal/agent/application/acp_context.go
+++ b/internal/agent/application/acp_context.go
@@ -14,7 +14,6 @@ import (
 const acpContextURI = "memoh://context/current-turn"
 
 type acpContextRenderInput struct {
-	Now                       time.Time
 	Timezone                  string
 	BotID                     string
 	ChatID                    string
@@ -67,7 +66,6 @@ func (s *Service) buildACPContextMarkdown(ctx context.Context, req ChatRequest, 
 	}
 
 	return renderACPContextMarkdown(acpContextRenderInput{
-		Now:                       now,
 		Timezone:                  timezoneName,
 		BotID:                     req.BotID,
 		ChatID:                    req.ChatID,
@@ -90,10 +88,6 @@ func (s *Service) buildACPContextMarkdown(ctx context.Context, req ChatRequest, 
 }
 
 func renderACPContextMarkdown(input acpContextRenderInput) string {
-	now := input.Now
-	if now.IsZero() {
-		now = time.Now().UTC()
-	}
 	timezoneName := strings.TrimSpace(input.Timezone)
 	if timezoneName == "" {
 		timezoneName = "UTC"
@@ -104,7 +98,6 @@ func renderACPContextMarkdown(input acpContextRenderInput) string {
 	sb.WriteString("This virtual resource is already embedded in the current ACP prompt. It is not a workspace file and no file lookup is needed. Use it for identity, memory, user preferences, and session background. The user prompt outside this resource is the actual task.\n\n")
 
 	writeACPContextSection(&sb, "Current Runtime", acpContextMetadataLines([][2]string{
-		{"Current time", now.Format(time.RFC3339)},
 		{"Timezone", timezoneName},
 		{"Bot ID", input.BotID},
 		{"Session ID", input.SessionID},

--- a/internal/agent/application/acp_context_test.go
+++ b/internal/agent/application/acp_context_test.go
@@ -3,7 +3,6 @@ package application
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 )
@@ -12,7 +11,6 @@ func TestRenderACPContextMarkdownIncludesDynamicRuntimeAndMemory(t *testing.T) {
 	t.Parallel()
 
 	got := renderACPContextMarkdown(acpContextRenderInput{
-		Now:                     time.Date(2026, 6, 1, 9, 30, 0, 0, time.FixedZone("PDT", -7*3600)),
 		Timezone:                "America/Los_Angeles",
 		BotID:                   "bot-1",
 		SessionID:               "session-1",
@@ -40,7 +38,6 @@ func TestRenderACPContextMarkdownIncludesDynamicRuntimeAndMemory(t *testing.T) {
 
 	for _, want := range []string{
 		"# Memoh ACP Context",
-		"Current time: 2026-06-01T09:30:00-07:00",
 		"Timezone: America/Los_Angeles",
 		"Bot ID: bot-1",
 		"ACP agent: codex",
@@ -68,6 +65,9 @@ func TestRenderACPContextMarkdownIncludesDynamicRuntimeAndMemory(t *testing.T) {
 	if strings.Contains(got, "Do not inject normal tool prompt.") {
 		t.Fatalf("TOOLS.md content should not be injected into ACP context:\n%s", got)
 	}
+	if strings.Contains(got, "Current time:") {
+		t.Fatalf("ACP context must not include a volatile current time:\n%s", got)
+	}
 }
 
 func TestRenderACPContextMarkdownRespectsSystemFilesBudget(t *testing.T) {
@@ -75,7 +75,6 @@ func TestRenderACPContextMarkdownRespectsSystemFilesBudget(t *testing.T) {
 
 	large := "HEAD\n" + strings.Repeat("0123456789", 200) + "\nTAIL"
 	got := renderACPContextMarkdown(acpContextRenderInput{
-		Now:                 time.Date(2026, 6, 1, 9, 30, 0, 0, time.UTC),
 		Timezone:            "UTC",
 		BotID:               "bot-1",
 		SessionID:           "session-1",

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -1238,10 +1238,6 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 		files = fs.LoadSystemFiles(ctx)
 	}
 
-	now := time.Now().UTC()
-	if cfg.Identity.TimezoneLocation != nil {
-		now = now.In(cfg.Identity.TimezoneLocation)
-	}
 	platformIdentitiesSection := ""
 	if s.platformIdentities != nil {
 		identities, err := s.platformIdentities.ListPlatformIdentities(ctx, cfg.Identity.BotID)
@@ -1260,7 +1256,6 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 		Skills:                    cfg.Skills,
 		Files:                     files,
 		MaxFilesBytes:             limits.SystemFilesMaxBytes,
-		Now:                       now,
 		Timezone:                  cfg.Identity.Timezone,
 		PlatformIdentitiesSection: platformIdentitiesSection,
 	})

--- a/internal/agent/application/service_history.go
+++ b/internal/agent/application/service_history.go
@@ -24,16 +24,39 @@ func injectWorkspaceTransitionRecords(records []historyfrag.HistoryRecord) []his
 	var previous *WorkspaceTarget
 	for _, record := range records {
 		if current := workspaceTargetFromMetadata(record.Metadata); current != nil && !sameWorkspaceTarget(previous, current) {
-			text := fmt.Sprintf("[Execution location] Earlier file and command operations from this point belong to %q (target_id=%q).", current.Name, current.TargetID)
-			if previous != nil {
-				text = fmt.Sprintf("[Execution location changed] The default execution location changed from %q (target_id=%q) to %q (target_id=%q). Files, processes, and working-directory state do not transfer between them.", previous.Name, previous.TargetID, current.Name, current.TargetID)
-			}
+			text := renderWorkspaceTransition(previous, current)
 			result = append(result, historyfrag.HistoryRecord{ModelMessage: ModelMessage{Role: "system", Content: newTextContent(text)}})
 			previous = current
 		}
 		result = append(result, record)
 	}
 	return result
+}
+
+func renderWorkspaceTransition(previous, current *WorkspaceTarget) string {
+	if current == nil || strings.TrimSpace(current.TargetID) == "" {
+		return ""
+	}
+	if previous != nil && sameWorkspaceTarget(previous, current) {
+		return ""
+	}
+	if previous == nil {
+		return fmt.Sprintf(
+			"[Execution location] The default Computer is %q (target_id=%q, kind=%q). Workspace tools that omit target_id run there.",
+			current.Name,
+			current.TargetID,
+			current.Kind,
+		)
+	}
+	return fmt.Sprintf(
+		"[Execution location changed] The default Computer changed from %q (target_id=%q, kind=%q) to %q (target_id=%q, kind=%q). Earlier file and command results belong to their recorded Computer. Files, processes, and working-directory state do not transfer between Computers; inspect the new Computer before continuing.",
+		previous.Name,
+		previous.TargetID,
+		previous.Kind,
+		current.Name,
+		current.TargetID,
+		current.Kind,
+	)
 }
 
 func sameWorkspaceTarget(left, right *WorkspaceTarget) bool {
@@ -79,9 +102,9 @@ func (s *Service) currentWorkspaceContextMessage(ctx context.Context, req ChatRe
 			}
 		}
 	}
-	text := fmt.Sprintf("[Current execution location] The default Computer for this request is %q (target_id=%q, kind=%q). Workspace tools that omit target_id run there.", current.Name, current.TargetID, current.Kind)
-	if previous != nil && !sameWorkspaceTarget(previous, current) {
-		text = fmt.Sprintf("[Current execution location changed] The default Computer for this request changed from %q (target_id=%q) to %q (target_id=%q, kind=%q). Earlier file and command results belong to their recorded Computer. Do not assume files, processes, or working-directory state exist on the new Computer; inspect it before continuing.", previous.Name, previous.TargetID, current.Name, current.TargetID, current.Kind)
+	text := renderWorkspaceTransition(previous, current)
+	if text == "" {
+		return nil
 	}
 	message := ModelMessage{Role: "system", Content: newTextContent(text)}
 	return &message

--- a/internal/agent/application/service_workspace_history_test.go
+++ b/internal/agent/application/service_workspace_history_test.go
@@ -7,6 +7,7 @@ import (
 
 	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
 	"github.com/memohai/memoh/internal/bots"
+	sessionpkg "github.com/memohai/memoh/internal/chat/thread"
 	"github.com/memohai/memoh/internal/workspace"
 )
 
@@ -94,6 +95,85 @@ func TestInjectWorkspaceTransitionRecordsIgnoresLegacyStartingFolderChanges(t *t
 	}
 	if strings.Contains(got[0].ModelMessage.TextContent(), "starting_folder") {
 		t.Fatalf("legacy workspace_path leaked into marker: %#v", got[0].ModelMessage)
+	}
+}
+
+func TestWorkspaceTransitionRendererMatchesLiveAndReplay(t *testing.T) {
+	current := &WorkspaceTarget{TargetID: "computer-b", Kind: "remote", Name: "Computer B"}
+	service := &Service{}
+	live := service.currentWorkspaceContextMessage(t.Context(), ChatRequest{WorkspaceTarget: current})
+	if live == nil {
+		t.Fatal("initial live context must include a workspace snapshot")
+	}
+
+	replayed := injectWorkspaceTransitionRecords([]historyfrag.HistoryRecord{
+		workspaceHistoryRecord("user", "first", current.TargetID, current.Kind, current.Name, "/work/b"),
+	})
+	if len(replayed) != 2 {
+		t.Fatalf("replayed records = %d, want marker + message", len(replayed))
+	}
+	if got, want := live.TextContent(), replayed[0].ModelMessage.TextContent(); got != want {
+		t.Fatalf("initial live/replay marker mismatch:\nlive:   %s\nreplay: %s", got, want)
+	}
+}
+
+func TestCurrentWorkspaceContextMessageOmitsUnchangedTarget(t *testing.T) {
+	current := &WorkspaceTarget{TargetID: "computer-b", Kind: "remote", Name: "Computer B"}
+	service := &Service{
+		sessionService: &fakeBackgroundSessionService{
+			getFn: func(context.Context, string) (sessionpkg.Thread, error) {
+				return sessionpkg.Thread{Metadata: map[string]any{
+					"workspace_target": map[string]any{
+						"target_id": current.TargetID,
+						"kind":      current.Kind,
+						"name":      current.Name,
+					},
+				}}, nil
+			},
+		},
+	}
+
+	if got := service.currentWorkspaceContextMessage(t.Context(), ChatRequest{
+		ThreadID:        "session-1",
+		WorkspaceTarget: current,
+	}); got != nil {
+		t.Fatalf("unchanged workspace marker = %q, want nil", got.TextContent())
+	}
+}
+
+func TestWorkspaceTransitionRendererMatchesLiveAndReplayAfterChange(t *testing.T) {
+	previous := &WorkspaceTarget{TargetID: "computer-a", Kind: "remote", Name: "Computer A"}
+	current := &WorkspaceTarget{TargetID: "computer-b", Kind: "remote", Name: "Computer B"}
+	service := &Service{
+		sessionService: &fakeBackgroundSessionService{
+			getFn: func(context.Context, string) (sessionpkg.Thread, error) {
+				return sessionpkg.Thread{Metadata: map[string]any{
+					"workspace_target": map[string]any{
+						"target_id": previous.TargetID,
+						"kind":      previous.Kind,
+						"name":      previous.Name,
+					},
+				}}, nil
+			},
+		},
+	}
+	live := service.currentWorkspaceContextMessage(t.Context(), ChatRequest{
+		ThreadID:        "session-1",
+		WorkspaceTarget: current,
+	})
+	if live == nil {
+		t.Fatal("changed live context must include a workspace transition")
+	}
+
+	replayed := injectWorkspaceTransitionRecords([]historyfrag.HistoryRecord{
+		workspaceHistoryRecord("user", "first", previous.TargetID, previous.Kind, previous.Name, "/work/a"),
+		workspaceHistoryRecord("user", "second", current.TargetID, current.Kind, current.Name, "/work/b"),
+	})
+	if len(replayed) != 4 {
+		t.Fatalf("replayed records = %d, want two markers + two messages", len(replayed))
+	}
+	if got, want := live.TextContent(), replayed[2].ModelMessage.TextContent(); got != want {
+		t.Fatalf("changed live/replay marker mismatch:\nlive:   %s\nreplay: %s", got, want)
 	}
 }
 

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
-	"time"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
@@ -158,7 +157,6 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 		imageParts := s.inlineDiscussImages(ctx, cmd.BotID, refs)
 		injectImagePartsIntoLastUserMessage(runConfig.Messages, imageParts)
 	}
-	runConfig.Messages = append(runConfig.Messages, sdk.UserMessage(buildLateBindingPrompt(cmd.DiscussMentioned)))
 	runConfig = runConfig.RefreshContextFrag()
 
 	eventCh := s.streamDiscussAgent(ctx, runConfig)
@@ -191,7 +189,7 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 }
 
 func (s *Service) pumpDiscussACP(ctx context.Context, cmd turn.StartTurnCommand, h *discussHandle) {
-	prompt := discussACPFullContextPrompt(cmd.DiscussMessages, buildLateBindingPrompt(cmd.DiscussAddressed))
+	prompt := discussACPFullContextPrompt(cmd.DiscussMessages)
 	if strings.TrimSpace(prompt) == "" {
 		// No composable context: end without a skip marker so the caller
 		// does not advance its consumed cursor (pre-port semantics).
@@ -314,25 +312,6 @@ func (s *Service) storeDiscussRound(
 	return s.StoreRound(ctx, botID, sessionID, channelIdentityID, currentPlatform, messages, modelID)
 }
 
-// buildLateBindingPrompt renders the per-turn runtime instructions. The
-// native runtime nudges on explicit mentions; the ACP runtime nudges on
-// the broader addressed condition (mention or direct conversation).
-func buildLateBindingPrompt(nudge bool) string {
-	now := time.Now().Format(time.RFC3339)
-	var sb strings.Builder
-	sb.WriteString("Current time: ")
-	sb.WriteString(now)
-	sb.WriteString("\n\n")
-	sb.WriteString("IMPORTANT: You MUST use the `send` tool to speak. Your text output is invisible to everyone — it is only internal monologue. ")
-	sb.WriteString("If you want to say something, you MUST call the `send` tool. Writing text without a tool call means absolute silence — no one will see it.")
-
-	if nudge {
-		sb.WriteString("\n\nYou are being addressed directly. You should respond by calling the `send` tool now.")
-	}
-
-	return sb.String()
-}
-
 // discussMessagesToSDK converts composed context messages into SDK
 // messages, preserving structured raw content when present.
 func discussMessagesToSDK(messages []turn.DiscussMessage) []sdk.Message {
@@ -388,10 +367,12 @@ func injectImagePartsIntoLastUserMessage(msgs []sdk.Message, parts []sdk.ImagePa
 }
 
 // discussACPFullContextPrompt renders the composed context into the single
-// reset-each-turn prompt used by external ACP runtimes.
-func discussACPFullContextPrompt(messages []turn.DiscussMessage, lateBinding string) string {
+// reset-each-turn prompt used by external ACP runtimes. ACP does not receive
+// native ToolUsage, so its stable preamble owns the send-only output contract.
+func discussACPFullContextPrompt(messages []turn.DiscussMessage) string {
 	var b strings.Builder
 	b.WriteString("You are replying in a discuss-mode conversation. The runtime is reset each turn, so use the complete context below as the source of truth.\n\n")
+	b.WriteString("IMPORTANT: You MUST use the `send` tool to speak in the observed conversation. Ordinary text output is internal and invisible to everyone.\n\n")
 	for _, msg := range messages {
 		role := strings.TrimSpace(msg.Role)
 		if role == "" {
@@ -408,9 +389,5 @@ func discussACPFullContextPrompt(messages []turn.DiscussMessage, lateBinding str
 		b.WriteString("\n\n")
 	}
 	b.WriteString("Reply to the latest user-visible message when a response is appropriate.")
-	if strings.TrimSpace(lateBinding) != "" {
-		b.WriteString("\n\n")
-		b.WriteString(lateBinding)
-	}
 	return b.String()
 }

--- a/internal/agent/application/turn_discuss_test.go
+++ b/internal/agent/application/turn_discuss_test.go
@@ -93,7 +93,6 @@ func discussCommand() turn.StartTurnCommand {
 		DiscussMessages: []turn.DiscussMessage{
 			{Role: "user", Content: `<message id="1">photo</message>`},
 		},
-		DiscussMentioned: true,
 		DiscussAddressed: true,
 	}
 }
@@ -131,8 +130,8 @@ func TestDiscussInlinesImages(t *testing.T) {
 			userMsgs = append(userMsgs, m)
 		}
 	}
-	if len(userMsgs) < 2 {
-		t.Fatalf("expected at least 2 user messages (rc + late binding), got %d", len(userMsgs))
+	if len(userMsgs) != 1 {
+		t.Fatalf("expected only the canonical RC user message, got %d", len(userMsgs))
 	}
 	hasImage := false
 	for _, part := range userMsgs[0].Content {
@@ -225,9 +224,11 @@ func TestDiscussACPUsesChatStreamer(t *testing.T) {
 	if !strings.Contains(req.Query, "please inspect the app") || !strings.Contains(req.Query, "reset each turn") || !strings.Contains(req.Query, "MUST use the `send` tool") {
 		t.Fatalf("runtime query = %q, want full discuss context", req.Query)
 	}
-	// DiscussAddressed=true must render the addressed-directly nudge for ACP.
-	if !strings.Contains(req.Query, "addressed directly") {
-		t.Fatalf("runtime query missing addressed-directly nudge: %q", req.Query)
+	if strings.Contains(req.Query, "Current time:") || strings.Contains(req.Query, "addressed directly") {
+		t.Fatalf("runtime query contains volatile late-binding context: %q", req.Query)
+	}
+	if strings.Index(req.Query, "MUST use the `send` tool") > strings.Index(req.Query, "please inspect the app") {
+		t.Fatalf("ACP send contract must stay in the stable preamble: %q", req.Query)
 	}
 	if !req.UserMessagePersisted {
 		t.Fatal("runtime request should avoid duplicating the full-context prompt as a user history message")
@@ -276,7 +277,7 @@ func TestDiscussACPSkipsWhenNotAddressed(t *testing.T) {
 	}
 }
 
-func TestDiscussRefreshesContextFragAfterLateBinding(t *testing.T) {
+func TestDiscussRefreshesContextFragWithoutLateBindingMessage(t *testing.T) {
 	agent := &fakeAgentStreamer{}
 	resolver := &fakeDiscussService{
 		resolveResult: ResolveRunConfigResult{
@@ -301,8 +302,12 @@ func TestDiscussRefreshesContextFragAfterLateBinding(t *testing.T) {
 	if cfg.ContextManifest.Counts.Messages != len(cfg.Messages) {
 		t.Fatalf("manifest message count = %d, messages = %d", cfg.ContextManifest.Counts.Messages, len(cfg.Messages))
 	}
-	if !lastMessageFragContains(cfg.ContextFrags, "MUST use the `send` tool") {
-		t.Fatalf("context frags do not include late-binding prompt: %#v", cfg.ContextManifest.Items)
+	if len(cfg.Messages) != 1 {
+		t.Fatalf("messages = %d, want only composed discuss context", len(cfg.Messages))
+	}
+	if lastMessageFragContains(cfg.ContextFrags, "Current time:") ||
+		lastMessageFragContains(cfg.ContextFrags, "MUST use the `send` tool") {
+		t.Fatalf("context frags include a volatile late-binding prompt: %#v", cfg.ContextManifest.Items)
 	}
 }
 

--- a/internal/agent/context/fragment/types.go
+++ b/internal/agent/context/fragment/types.go
@@ -282,7 +282,6 @@ const (
 	DynamicMutatorReadMedia           DynamicMutator = "read_media"
 	DynamicMutatorBeforeModelCallHook DynamicMutator = "before_model_call_hook"
 	DynamicMutatorBackgroundSummary   DynamicMutator = "background_summary"
-	DynamicMutatorMidTaskPrune        DynamicMutator = "mid_task_prune"
 )
 
 // ManifestCounts summarizes fragment composition.

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -812,31 +812,10 @@ func (a *Agent) buildGenerateOptions(cfg RunConfig, tools []sdk.Tool, approvalTo
 		opts = append(opts, sdk.WithApprovalHandler(approvalHandler))
 	}
 
-	// Wrap the existing prepareStep (if any) with mid-task context pruning.
-	// When the message array grows large during multi-tool runs, this prunes
-	// older tool results to keep the context window manageable.
-	basePrepare := prepareStep
-	keepSteps := cfg.MidTaskPruneKeepSteps
-	if keepSteps <= 0 {
-		keepSteps = MidTaskPruneKeepStepsDefault
+	prepareStep = wrapPrepareStepWithForkSnapshot(prepareStep, cfg.ForkContext)
+	if prepareStep != nil {
+		opts = append(opts, sdk.WithPrepareStep(prepareStep))
 	}
-	threshold := cfg.MidTaskPruneThreshold
-	if threshold <= 0 {
-		threshold = MidTaskPruneThresholdDefault
-	}
-	midTaskPrune := func(p *sdk.GenerateParams) *sdk.GenerateParams {
-		if basePrepare != nil {
-			if override := basePrepare(p); override != nil {
-				p = override
-			}
-		}
-		p = pruneOldToolResults(p, keepSteps, threshold)
-		if cfg.ForkContext != nil {
-			_ = cfg.ForkContext.Store(p.Messages)
-		}
-		return p
-	}
-	opts = append(opts, sdk.WithPrepareStep(midTaskPrune))
 
 	opts = append(opts, models.BuildReasoningOptions(models.SDKModelConfig{
 		ClientType:            models.ResolveClientType(cfg.Model),
@@ -1221,100 +1200,22 @@ func wrapToolsWithLoopGuard(tools []sdk.Tool, guard *ToolLoopGuard, abortCallIDs
 	return wrapped
 }
 
-const (
-	// MidTaskPruneKeepStepsDefault is the number of recent tool-call steps to keep
-	// intact when pruning older tool results during a multi-step agent run.
-	MidTaskPruneKeepStepsDefault = 4
-	// MidTaskPruneThresholdDefault is the minimum number of messages before pruning activates.
-	MidTaskPruneThresholdDefault = 20
-)
-
-// pruneOldToolResults prunes older tool result messages in the SDK params to
-// keep the context window manageable during long multi-tool agent runs. It
-// keeps the most recent keepSteps tool-call cycles intact and replaces older
-// tool results with size summaries.
-func pruneOldToolResults(p *sdk.GenerateParams, keepSteps, threshold int) *sdk.GenerateParams {
-	msgs := p.Messages
-	if len(msgs) < threshold {
+func wrapPrepareStepWithForkSnapshot(
+	prepareStep func(*sdk.GenerateParams) *sdk.GenerateParams,
+	forkContext *tools.MessageSnapshot,
+) func(*sdk.GenerateParams) *sdk.GenerateParams {
+	if forkContext == nil {
+		return prepareStep
+	}
+	return func(p *sdk.GenerateParams) *sdk.GenerateParams {
+		if prepareStep != nil {
+			if override := prepareStep(p); override != nil {
+				p = override
+			}
+		}
+		_ = forkContext.Store(p.Messages)
 		return p
 	}
-
-	// Count complete tool-call cycles (tool-result pair) from the end to find the cutoff.
-	toolResultCount := 0
-	cutoffIdx := len(msgs)
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Role == sdk.MessageRoleTool {
-			// Check that the preceding assistant message contains the matching tool call
-			// to ensure we count complete cycles, not orphaned results.
-			hasMatchingCall := false
-			for j := i - 1; j >= 0; j-- {
-				if msgs[j].Role == sdk.MessageRoleAssistant {
-					// If there's another tool result between this and the assistant msg,
-					// it means this assistant message belongs to a different cycle.
-					if j+1 < i && msgs[j+1].Role == sdk.MessageRoleTool {
-						break
-					}
-					hasMatchingCall = true
-					break
-				}
-				if msgs[j].Role == sdk.MessageRoleUser {
-					break
-				}
-			}
-			if hasMatchingCall {
-				toolResultCount++
-				if toolResultCount > keepSteps {
-					cutoffIdx = i
-					break
-				}
-			}
-		}
-	}
-	if cutoffIdx >= len(msgs) {
-		return p // not enough tool messages to prune
-	}
-
-	// Build a new slice so the original messages can be GC'd.
-	pruned := make([]sdk.Message, 0, len(msgs))
-	pruned = append(pruned, msgs[:cutoffIdx]...)
-	for i := cutoffIdx; i < len(msgs); i++ {
-		if msgs[i].Role != sdk.MessageRoleTool {
-			pruned = append(pruned, msgs[i])
-			continue
-		}
-		// Measure content size from ToolResultPart entries.
-		contentSize := 0
-		for _, part := range msgs[i].Content {
-			if tr, ok := part.(sdk.ToolResultPart); ok {
-				contentSize += len(fmt.Sprintf("%v", tr.Result))
-			}
-		}
-		if contentSize > 512 { // only prune if content is large enough
-			// Build replacement parts preserving ToolResultPart type so that
-			// provider serializers that validate part types per role stay happy.
-			replacementParts := make([]sdk.MessagePart, 0, len(msgs[i].Content))
-			for _, part := range msgs[i].Content {
-				if tr, ok := part.(sdk.ToolResultPart); ok {
-					replacementParts = append(replacementParts, sdk.ToolResultPart{
-						ToolCallID: tr.ToolCallID,
-						ToolName:   tr.ToolName,
-						Result:     fmt.Sprintf("[tool result pruned: %d bytes]", contentSize),
-					})
-				} else {
-					replacementParts = append(replacementParts, part)
-				}
-			}
-			pruned = append(pruned, sdk.Message{
-				Role:    msgs[i].Role,
-				Content: replacementParts,
-			})
-		} else {
-			pruned = append(pruned, msgs[i])
-		}
-	}
-
-	p.Messages = pruned
-	return p
 }
 
 // runMidStreamRetry attempts to continue the agent stream after a retryable

--- a/internal/agent/runtime/native/context_frag.go
+++ b/internal/agent/runtime/native/context_frag.go
@@ -54,6 +54,5 @@ func (cfg RunConfig) contextDynamicMutators(readMedia bool, beforeModelCallHook 
 	if cfg.BackgroundManager != nil {
 		mutators = append(mutators, contextfrag.DynamicMutatorBackgroundSummary)
 	}
-	mutators = append(mutators, contextfrag.DynamicMutatorMidTaskPrune)
 	return mutators
 }

--- a/internal/agent/runtime/native/context_frag_test.go
+++ b/internal/agent/runtime/native/context_frag_test.go
@@ -137,7 +137,6 @@ func TestRefreshContextFragWithDynamicMutatorsMarksPreProviderBoundary(t *testin
 		contextfrag.DynamicMutatorReadMedia,
 		contextfrag.DynamicMutatorBeforeModelCallHook,
 		contextfrag.DynamicMutatorBackgroundSummary,
-		contextfrag.DynamicMutatorMidTaskPrune,
 	} {
 		if !manifestHasMutator(cfg.ContextManifest, want) {
 			t.Fatalf("manifest dynamic mutators = %#v, want %q", cfg.ContextManifest.DynamicMutators, want)

--- a/internal/agent/runtime/native/prepare_step_test.go
+++ b/internal/agent/runtime/native/prepare_step_test.go
@@ -1,0 +1,62 @@
+package native
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	agenttools "github.com/memohai/memoh/internal/agent/tool"
+)
+
+func TestWrapPrepareStepWithForkSnapshotDoesNotRewriteToolResults(t *testing.T) {
+	t.Parallel()
+
+	messages := []sdk.Message{sdk.UserMessage("inspect the repository")}
+	for i := 0; i < 12; i++ {
+		callID := fmt.Sprintf("call-%02d", i)
+		messages = append(messages, sdk.Message{
+			Role: sdk.MessageRoleAssistant,
+			Content: []sdk.MessagePart{sdk.ToolCallPart{
+				ToolCallID: callID,
+				ToolName:   "exec",
+				Input:      map[string]any{"command": fmt.Sprintf("step-%02d", i)},
+			}},
+		})
+		messages = append(messages, sdk.ToolMessage(sdk.ToolResultPart{
+			ToolCallID: callID,
+			ToolName:   "exec",
+			Result:     strings.Repeat(string(rune('a'+i)), 2048),
+		}))
+	}
+	before, err := json.Marshal(messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := agenttools.NewMessageSnapshot(nil)
+	prepareStep := wrapPrepareStepWithForkSnapshot(nil, snapshot)
+	params := &sdk.GenerateParams{Messages: messages}
+	got := prepareStep(params)
+	if got != params {
+		t.Fatal("prepare step unexpectedly replaced the params")
+	}
+
+	after, err := json.Marshal(got.Messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("prepare step rewrote prior tool results:\nbefore: %s\nafter:  %s", before, after)
+	}
+
+	snapshotMessages, err := snapshot.Messages()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshotMessages) != len(messages) {
+		t.Fatalf("fork snapshot messages = %d, want %d", len(snapshotMessages), len(messages))
+	}
+}

--- a/internal/agent/runtime/native/prompt.go
+++ b/internal/agent/runtime/native/prompt.go
@@ -106,10 +106,6 @@ func selectModeTemplate(sessionType string) string {
 // GenerateSystemPrompt builds the complete system prompt from files, skills, and context.
 func GenerateSystemPrompt(params SystemPromptParams) string {
 	home := "/data"
-	now := params.Now
-	if now.IsZero() {
-		now = TimeNow()
-	}
 	timezoneName := strings.TrimSpace(params.Timezone)
 	if timezoneName == "" {
 		timezoneName = "UTC"
@@ -125,7 +121,6 @@ func GenerateSystemPrompt(params SystemPromptParams) string {
 
 	return render(tmpl, map[string]string{
 		"home":                      home,
-		"currentTime":               now.Format(time.RFC3339),
 		"timezone":                  timezoneName,
 		"botInfoSection":            botInfoSection,
 		"skillsSection":             skillsSection,
@@ -143,7 +138,6 @@ type SystemPromptParams struct {
 	Skills                    []SkillEntry
 	Files                     []SystemFile
 	MaxFilesBytes             int
-	Now                       time.Time
 	Timezone                  string
 	PlatformIdentitiesSection string
 }

--- a/internal/agent/runtime/native/prompt_test.go
+++ b/internal/agent/runtime/native/prompt_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/memohai/memoh/internal/agent/sessionmode"
 	agenttools "github.com/memohai/memoh/internal/agent/tool"
@@ -16,7 +15,6 @@ func TestGenerateSystemPromptIncludesPlatformIdentitiesInChat(t *testing.T) {
 
 	prompt := GenerateSystemPrompt(SystemPromptParams{
 		SessionType:               sessionmode.Chat,
-		Now:                       time.Unix(1, 0).UTC(),
 		Timezone:                  "UTC",
 		PlatformIdentitiesSection: "## Platform Identities\n\n<identity channel=\"telegram\" username=\"@memoh\"/>",
 	})
@@ -26,6 +24,21 @@ func TestGenerateSystemPromptIncludesPlatformIdentitiesInChat(t *testing.T) {
 	}
 	if !strings.Contains(prompt, `<identity channel="telegram" username="@memoh"/>`) {
 		t.Fatalf("expected platform identity XML in prompt")
+	}
+}
+
+func TestGenerateSystemPromptOmitsVolatileCurrentTime(t *testing.T) {
+	t.Parallel()
+
+	prompt := GenerateSystemPrompt(SystemPromptParams{
+		SessionType: sessionmode.Chat,
+		Timezone:    "Asia/Singapore",
+	})
+	if strings.Contains(prompt, "Current time:") || strings.Contains(prompt, "{{currentTime}}") {
+		t.Fatalf("system prompt contains a volatile current time:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Timezone: Asia/Singapore") {
+		t.Fatalf("system prompt must retain the stable timezone:\n%s", prompt)
 	}
 }
 
@@ -84,7 +97,6 @@ func TestGenerateSystemPromptIncludesCommonAndModeContracts(t *testing.T) {
 			t.Parallel()
 			prompt := GenerateSystemPrompt(SystemPromptParams{
 				SessionType: tc.sessionType,
-				Now:         time.Unix(1, 0).UTC(),
 				Timezone:    "UTC",
 			})
 			for _, want := range tc.want {
@@ -107,7 +119,6 @@ func TestGenerateSystemPromptIncludesServiceOwnedBotInfo(t *testing.T) {
 			DisplayName: "Research Bot",
 			Timezone:    "Asia/Shanghai",
 		},
-		Now:      time.Unix(1, 0).UTC(),
 		Timezone: "UTC",
 	})
 
@@ -192,7 +203,6 @@ func TestGenerateSystemPromptOmitsLegacyCoreFiles(t *testing.T) {
 			t.Parallel()
 			prompt := GenerateSystemPrompt(SystemPromptParams{
 				SessionType: sessionType,
-				Now:         time.Unix(1, 0).UTC(),
 				Timezone:    "UTC",
 			})
 			for _, legacy := range []string{"IDENTITY.md", "SOUL.md", "TOOLS.md"} {
@@ -213,7 +223,6 @@ func TestGenerateSystemPromptOmitsToolSpecificMemorySearchGuidance(t *testing.T)
 			t.Parallel()
 			prompt := GenerateSystemPrompt(SystemPromptParams{
 				SessionType: sessionType,
-				Now:         time.Unix(1, 0).UTC(),
 				Timezone:    "UTC",
 			})
 			if strings.Contains(prompt, "`search_memory`") {
@@ -238,7 +247,6 @@ func TestGenerateSystemPromptDoesNotReintroduceStaticToolSections(t *testing.T) 
 			t.Parallel()
 			prompt := GenerateSystemPrompt(SystemPromptParams{
 				SessionType:               sessionType,
-				Now:                       time.Unix(1, 0).UTC(),
 				Timezone:                  "UTC",
 				PlatformIdentitiesSection: "## Platform Identities\n\n<identity channel=\"telegram\" username=\"@memoh\"/>",
 			})
@@ -273,7 +281,6 @@ func TestGenerateSystemPromptDoesNotEnumerateConditionalTools(t *testing.T) {
 			t.Parallel()
 			prompt := GenerateSystemPrompt(SystemPromptParams{
 				SessionType:               sessionType,
-				Now:                       time.Unix(1, 0).UTC(),
 				Timezone:                  "UTC",
 				PlatformIdentitiesSection: "## Platform Identities\n\n<identity channel=\"telegram\" username=\"@memoh\"/>",
 			})
@@ -340,7 +347,6 @@ func TestGenerateSystemPromptIncludesPlatformIdentitiesInDiscuss(t *testing.T) {
 
 	prompt := GenerateSystemPrompt(SystemPromptParams{
 		SessionType:               sessionmode.Discuss,
-		Now:                       time.Unix(1, 0).UTC(),
 		Timezone:                  "UTC",
 		PlatformIdentitiesSection: "## Platform Identities\n\n<identity channel=\"discord\" username=\"@memoh\"/>",
 	})

--- a/internal/agent/runtime/native/prompts/system_common.md
+++ b/internal/agent/runtime/native/prompts/system_common.md
@@ -2,7 +2,6 @@ You are an AI agent running inside a private Memoh workspace.
 
 **`{{home}}` is your HOME** — resolve workspace file paths relative to it. When file tools are available, use them for file operations.
 
-Current time: {{currentTime}}
 Timezone: {{timezone}}
 
 {{botInfoSection}}

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -117,17 +117,6 @@ type RunConfig struct {
 	// Anthropic Messages); for other vendors the value is ignored.
 	PromptCacheTTL string
 
-	// MidTaskPruneThreshold is the minimum number of messages before mid-task
-	// pruning kicks in. When the accumulated message count reaches this
-	// threshold, older tool-result pairs are pruned to keep the context
-	// within budget. Defaults to MidTaskPruneThresholdDefault (20).
-	MidTaskPruneThreshold int
-
-	// MidTaskPruneKeepSteps is the number of recent tool-call cycles to
-	// preserve when mid-task pruning is triggered. Defaults to
-	// MidTaskPruneKeepStepsDefault (4).
-	MidTaskPruneKeepSteps int
-
 	// InjectCh receives user messages to inject between tool rounds.
 	// When non-nil, a PrepareStep hook drains this channel and appends
 	// user messages to the conversation before the next LLM call.
@@ -195,6 +184,3 @@ func mustMarshal(v any) json.RawMessage {
 	}
 	return data
 }
-
-// TimeNow is a hook for testing. Defaults to time.Now.
-var TimeNow = time.Now

--- a/internal/agent/turn/turn.go
+++ b/internal/agent/turn/turn.go
@@ -99,12 +99,10 @@ type StartTurnCommand struct {
 	// image inlining so vision parts land on the last real user message.
 	DiscussMessages  []DiscussMessage
 	DiscussImageRefs []DiscussImageRef
-	// DiscussMentioned reports an explicit @-mention or reply-to in the
-	// new context window; DiscussAddressed additionally covers direct
-	// (1:1) conversations. Expensive external runtimes (ACP) use
-	// DiscussAddressed as a participation gate and skip the run when
-	// false.
-	DiscussMentioned bool
+	// DiscussAddressed covers an explicit @-mention, a reply-to, or a direct
+	// (1:1) conversation. Expensive external runtimes (ACP) use it as a
+	// participation gate and skip the run when false. Mention/reply details
+	// stay attached to their canonical timeline messages.
 	DiscussAddressed bool
 }
 

--- a/internal/agent/turn/turn.go
+++ b/internal/agent/turn/turn.go
@@ -95,8 +95,8 @@ type StartTurnCommand struct {
 
 	// DiscussMessages is the composed conversation context for a discuss
 	// turn (Mode == ModeDiscuss), already rendered by the caller's
-	// projection. The runtime appends its own late-binding prompt after
-	// image inlining so vision parts land on the last real user message.
+	// projection. Image parts are injected into the last real user message
+	// before the runtime starts streaming.
 	DiscussMessages  []DiscussMessage
 	DiscussImageRefs []DiscussImageRef
 	// DiscussAddressed covers an explicit @-mention, a reply-to, or a direct

--- a/internal/channel/discuss/driver_artifacts_test.go
+++ b/internal/channel/discuss/driver_artifacts_test.go
@@ -144,7 +144,7 @@ func TestBuildMentionGatesOnWatermarkNotCoverage(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a composed plan")
 	}
-	if !pending.command.DiscussMentioned {
+	if !pending.command.DiscussAddressed {
 		t.Fatal("a mention the watermark has not consumed must wake the session even when compaction covers it")
 	}
 
@@ -152,7 +152,7 @@ func TestBuildMentionGatesOnWatermarkNotCoverage(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a composed plan past the mention")
 	}
-	if consumed.command.DiscussMentioned {
+	if consumed.command.DiscussAddressed {
 		t.Fatal("a consumed mention must not re-mark the session as mentioned")
 	}
 }

--- a/internal/channel/discuss/driver_test.go
+++ b/internal/channel/discuss/driver_test.go
@@ -80,9 +80,6 @@ func TestHandleReplyWithTurn_PassesContextAndImageRefs(t *testing.T) {
 	if len(cmd.DiscussMessages) == 0 {
 		t.Fatal("expected composed discuss messages")
 	}
-	if cmd.DiscussMentioned {
-		t.Fatal("plain message must not be flagged as mentioned")
-	}
 }
 
 func TestHandleReplyWithTurn_ACPAdvancesCursorOnCleanTerminal(t *testing.T) {
@@ -319,11 +316,6 @@ func TestHandleReplyWithTurn_ACPRepliesInDirectConversation(t *testing.T) {
 	}
 	if sess.lastProcessedMs != 200 {
 		t.Fatalf("lastProcessedMs = %d, want 200 (cursor advanced after direct reply)", sess.lastProcessedMs)
-	}
-	// A direct conversation is "addressed" without being mentioned; the ACP
-	// runtime uses this to render the addressed-directly nudge.
-	if svc.lastCmd.DiscussMentioned {
-		t.Fatal("DM without @-mention must not be flagged as mentioned")
 	}
 }
 

--- a/internal/channel/discuss/trigger.go
+++ b/internal/channel/discuss/trigger.go
@@ -60,7 +60,6 @@ func (discussTriggerBuilder) Build(cfg DiscussSessionConfig, rc timeline.Rendere
 			ToolHTTPURL:             cfg.ToolHTTPURL,
 			DiscussMessages:         msgs,
 			DiscussImageRefs:        imageRefs,
-			DiscussMentioned:        isMentioned,
 			DiscussAddressed:        addressed,
 		},
 		consumedMs:      latestRCReceivedAtMs(rc),

--- a/internal/chat/timeline/rendering.go
+++ b/internal/chat/timeline/rendering.go
@@ -87,6 +87,12 @@ func renderMessage(msg *ICMessage, params RenderParams) RenderedSegment {
 	if isMyself {
 		attrs = append(attrs, `myself="true"`)
 	}
+	if mentionsMe {
+		attrs = append(attrs, `mentions_me="true"`)
+	}
+	if repliesToMe {
+		attrs = append(attrs, `replies_to_me="true"`)
+	}
 	attrs = append(attrs, fmt.Sprintf("t=%q", formatTimestamp(msg.TimestampSec, msg.UTCOffsetMin)))
 
 	if msg.EditedAtSec > 0 {

--- a/internal/chat/timeline/rendering_test.go
+++ b/internal/chat/timeline/rendering_test.go
@@ -1,6 +1,7 @@
 package timeline
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -44,5 +45,32 @@ func TestRenderMessage_NoImageRefs(t *testing.T) {
 
 	if len(seg.ImageRefs) != 0 {
 		t.Fatalf("expected 0 image refs, got %d", len(seg.ImageRefs))
+	}
+}
+
+func TestRenderMessage_PreservesAddressingFlagsInCanonicalContent(t *testing.T) {
+	msg := &ICMessage{
+		MessageID:    "msg-addressed",
+		ReceivedAtMs: 300,
+		TimestampSec: 300,
+		Content:      []ContentNode{{Type: "text", Text: "please inspect this"}},
+		MentionsMe:   true,
+		RepliesToMe:  true,
+		Conversation: ConversationMeta{Channel: "telegram", ConversationType: "group"},
+	}
+
+	seg := renderMessage(msg, RenderParams{})
+	if len(seg.Content) != 1 {
+		t.Fatalf("content pieces = %d, want 1", len(seg.Content))
+	}
+	for _, want := range []string{`mentions_me="true"`, `replies_to_me="true"`} {
+		if !strings.Contains(seg.Content[0].Text, want) {
+			t.Fatalf("canonical content missing %s: %s", want, seg.Content[0].Text)
+		}
+	}
+
+	replayed := renderMessage(msg, RenderParams{})
+	if replayed.Content[0].Text != seg.Content[0].Text {
+		t.Fatalf("canonical addressing content changed across replay:\nfirst: %s\nagain: %s", seg.Content[0].Text, replayed.Content[0].Text)
 	}
 }

--- a/internal/chat/timeline/rendering_test.go
+++ b/internal/chat/timeline/rendering_test.go
@@ -72,6 +72,9 @@ func TestRenderMessage_PreservesAddressingFlagsInCanonicalContent(t *testing.T) 
 	replayed := renderMessage(msg, RenderParams{})
 	if replayed.Content[0].Text != seg.Content[0].Text {
 		t.Fatalf("canonical addressing content changed across replay:\nfirst: %s\nagain: %s", seg.Content[0].Text, replayed.Content[0].Text)
+	}
+}
+
 func TestRenderMessagePopulatesSlotIdentityAndEditTime(t *testing.T) {
 	msg := &ICMessage{
 		MessageID:       "msg-slot",

--- a/internal/handlers/skills_test.go
+++ b/internal/handlers/skills_test.go
@@ -831,7 +831,6 @@ func promptFromLoadedSkills(items []SkillItem) string {
 	return native.GenerateSystemPrompt(native.SystemPromptParams{
 		SessionType: "chat",
 		Skills:      skills,
-		Now:         time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC),
 		Timezone:    "UTC",
 	})
 }


### PR DESCRIPTION
## Summary

- remove volatile current-time text from native and ACP prompt prefixes while retaining the stable timezone
- remove mid-task tool-result rewriting so multi-step histories remain append-only; preserve fork snapshots without changing compaction
- make Discuss addressing durable in canonical timeline content and keep the ACP send contract in a stable preamble
- use one canonical workspace-transition renderer for live and replay paths, and omit unchanged workspace markers

## Root cause

Prompt prefixes were being invalidated by four independent sources of churn: a per-request timestamp, prepare-step rewrites of earlier tool results, ephemeral Discuss tail instructions, and divergent live/replay workspace wording. Together they reduced reusable prefix length even when requests were otherwise closely related.

## Validation

- `go test ./...`
- `mise run lint:go`
- commit hooks: Go lint, Go tests, and staged-file lint
- restarted the development server with `mise run dev:restart -- server`
- `HEAD /health` returned `200`
- `GET /ping` returned `status=ok`
- authenticated read-only checks passed for `GET /users/me`, `GET /bots`, and `GET /bots/:id/sessions`
- confirmed the branch contains no changes under `internal/agent/context/compaction/`

## Local lint caveat

The UI contract portion of `mise run lint` passed. Its repository-wide ESLint step traversed unrelated local `.claude/worktrees/*` directories and reported pre-existing errors from those physical worktrees; the final Go lint and staged-file lint both passed.