### PR TITLE
chore: migrate to stable mise monorepo config

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
-experimental_monorepo_root = true
+min_version = "2026.6.6"
+monorepo_root = true
 
 [monorepo]
 config_roots = ["apps/web", "cmd/agent"]


### PR DESCRIPTION
## 变更内容

- 声明 mise 最低支持版本为 `2026.6.6`
- 将已弃用的 `experimental_monorepo_root` 替换为正式配置 `monorepo_root`

## 背景

mise 从 v2026.6.6 开始将 monorepo 功能转为正式功能。旧配置键目前会产生弃用警告，并计划在 2027.12.0 中移除。

同时声明最低 mise 版本，可以让使用旧版本的开发者获得明确的升级提示，避免隐式改变兼容性要求。

## 验证

- `git diff --check`
- `mise tasks ls`
- 仓库提交钩子（Go lint 和测试）