### PR TITLE
fix(desktop): restore styled DMG installer layout

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -31,6 +31,22 @@ mac:
 dmg:
   icon: build/icon.icns
   sign: true
+  # 双击自安装样式:卷宗名即 Finder 窗口标题;背景图(build/background.png +
+  # background@2x.png,660x440 逻辑)烤入装饰文案与品牌光晕。
+  title: Install Memoh
+  background: build/background.png
+  window:
+    width: 660
+    height: 440
+  iconSize: 128
+  # 只摆 app 一个活图标,居中偏下,对齐背景图光晕。显式给出 contents 后
+  # electron-builder 不再自动追加 /Applications 软链 —— 双击式不需要拖拽目标。
+  # x/y 复刻用户认可的预览 DMG(make-preview-dmg.sh 的 330/254);真机签名
+  # 打包挂载后若图标偏高/偏低,只需微调这里的 y。
+  contents:
+    - x: 330
+      y: 254
+      type: file
 linux:
   category: Utility
   target:


### PR DESCRIPTION
## What

Restores the styled macOS DMG installer layout from #732 (d46c2d6ae, "feat(desktop): styled macOS DMG with double-click self-install").

The dmg section of `apps/desktop/electron-builder.yml` was reset to only `icon` + `sign` in #748 (f79811157, "refactor: remove sqlite and local desktop"), losing the `title` / `background` / `window` / `iconSize` / `contents` layout config. That refactor's commit message noted packaged-resource inspection could not run locally (no actool), so the regression shipped unnoticed.

Result on main today: the built DMG falls back to electron-builder's default two-icon layout (app + /Applications symlink), which contradicts the background image's "Double-click the icon to install" copy — there is nothing to drag onto.

## Fix

Restore the #732 dmg section **verbatim** (verified: zero diff against `git show d46c2d6ae:apps/desktop/electron-builder.yml` for the section). The explicit single-icon `contents` both centers the app icon on the background's glow and suppresses electron-builder's auto-added /Applications symlink. The `build/background*.png` assets were never deleted, so the background was still being picked up — only the layout was broken.

## Verification

Built locally on macOS arm64 (ad-hoc signed, `-c.dmg.sign=false`) and inspected the mounted volume:

- Volume/Finder window title: `Install Memoh` (was `Memoh 0.16.0-arm64`)
- Contents: only `Memoh.app` — no `Applications` symlink
- Window bounds `{660, 440}`, `iconSize => 128`, background picture set
- Icon position parsed from `.DS_Store`: `(330, 254)`, matching the approved preview DMG layout

Visual happy-path QA (double-click install flow) to be confirmed on a signed/CI build.

## Test plan

- [ ] CI desktop build produces a DMG with the single centered icon, no Applications symlink
- [ ] Mount the CI DMG: window title "Install Memoh", background copy matches layout
- [ ] Double-click install flow works end-to-end