### PR TITLE
fix(ci): prefer OIDC for npm publishing

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -15,6 +15,7 @@ on:
       - "packages/**/*.ts"
       - "packages/**/*.tsx"
       - "packages/**/*.vue"
+      - "scripts/**/*.mjs"
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -36,6 +37,7 @@ on:
       - "packages/**/*.ts"
       - "packages/**/*.tsx"
       - "packages/**/*.vue"
+      - "scripts/**/*.mjs"
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -90,6 +92,8 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Test release scripts
+        run: node --test scripts/publish-auth.test.mjs
       - name: Run Vitest
         run: pnpm test --run --testTimeout=15000 apps/web/src/composables/api/useChat.ws.test.ts apps/web/src/store/chat-list.test.ts
       # Report-only until the pre-existing error backlog (~476 at introduction)

--- a/scripts/publish-auth.mjs
+++ b/scripts/publish-auth.mjs
@@ -1,0 +1,19 @@
+export function detectPublishAuthMode(env = process.env) {
+  const hasOidcRequest = Boolean(
+    env.ACTIONS_ID_TOKEN_REQUEST_URL?.trim()
+      && env.ACTIONS_ID_TOKEN_REQUEST_TOKEN?.trim(),
+  )
+
+  // actions/setup-node exports a non-secret NODE_AUTH_TOKEN placeholder when
+  // registry-url is configured. Prefer the complete GitHub OIDC environment so
+  // that placeholder cannot send trusted publishing through token preflight.
+  if (hasOidcRequest) {
+    return 'oidc'
+  }
+
+  if (env.NODE_AUTH_TOKEN?.trim()) {
+    return 'token'
+  }
+
+  return 'none'
+}

--- a/scripts/publish-auth.test.mjs
+++ b/scripts/publish-auth.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { detectPublishAuthMode } from './publish-auth.mjs'
+
+const ROOT_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
+
+test('prefers GitHub OIDC over the setup-node token placeholder', () => {
+  assert.equal(detectPublishAuthMode({
+    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://github.example.test/oidc',
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-oidc-request-token',
+    NODE_AUTH_TOKEN: 'XXXXX-XXXXX-XXXXX-XXXXX',
+  }), 'oidc')
+})
+
+test('prefers GitHub OIDC when a token is also present', () => {
+  assert.equal(detectPublishAuthMode({
+    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://github.example.test/oidc',
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-oidc-request-token',
+    NODE_AUTH_TOKEN: 'manual-publish-token',
+  }), 'oidc')
+})
+
+test('uses token mode outside an OIDC environment', () => {
+  assert.equal(detectPublishAuthMode({
+    NODE_AUTH_TOKEN: 'manual-publish-token',
+  }), 'token')
+})
+
+test('does not accept an incomplete OIDC environment', () => {
+  assert.equal(detectPublishAuthMode({
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-oidc-request-token',
+  }), 'none')
+})
+
+test('publish script skips token preflight when setup-node placeholder and OIDC coexist', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'memoh-publish-auth-'))
+  const fakeBin = join(tempDir, 'bin')
+  const npmLog = join(tempDir, 'npm.log')
+  const pnpmLog = join(tempDir, 'pnpm.log')
+
+  try {
+    mkdirSync(fakeBin)
+
+    const fakeNpm = join(fakeBin, 'npm')
+    writeFileSync(fakeNpm, `#!/bin/sh
+printf '%s\\n' "$*" >> "$PUBLISH_TEST_NPM_LOG"
+[ "$1" = "view" ] && exit 1
+exit 91
+`)
+    chmodSync(fakeNpm, 0o755)
+
+    const fakePnpm = join(fakeBin, 'pnpm')
+    writeFileSync(fakePnpm, `#!/bin/sh
+printf '%s\\n' "$*" >> "$PUBLISH_TEST_PNPM_LOG"
+exit 0
+`)
+    chmodSync(fakePnpm, 0o755)
+
+    const result = spawnSync(process.execPath, ['scripts/publish-packages.mjs'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://github.example.test/oidc',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-oidc-request-token',
+        NODE_AUTH_TOKEN: 'XXXXX-XXXXX-XXXXX-XXXXX',
+        NPM_PUBLISH_SCOPE: '@memohai',
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        PUBLISH_TEST_NPM_LOG: npmLog,
+        PUBLISH_TEST_PNPM_LOG: pnpmLog,
+      },
+    })
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.match(result.stdout, /OIDC trusted publishing: skipping token preflight/)
+
+    const npmCalls = readFileSync(npmLog, 'utf8')
+    assert.doesNotMatch(npmCalls, /^whoami$/m)
+    assert.doesNotMatch(npmCalls, /^access /m)
+
+    const pnpmCalls = readFileSync(pnpmLog, 'utf8')
+    assert.match(pnpmCalls, /publish apps\/desktop --access public --no-git-checks --provenance/)
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+})

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -4,6 +4,8 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { detectPublishAuthMode } from './publish-auth.mjs'
+
 const ROOT_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
 
 // packages/ui is a git submodule, but it intentionally stays in this publish
@@ -33,7 +35,7 @@ const publishScope = process.env.NPM_PUBLISH_SCOPE?.trim() || null
 
 // Auth model: two modes.
 // - Token mode (local/manual): NODE_AUTH_TOKEN is set and used directly.
-// - OIDC mode (CI trusted publishing): no token; pnpm exchanges the GitHub
+// - OIDC mode (CI trusted publishing): pnpm exchanges the GitHub
 //   Actions OIDC token (ACTIONS_ID_TOKEN_REQUEST_TOKEN, available when the job
 //   has id-token: write) for a short-lived npm credential at publish time.
 //   Every published package must have memohai/Memoh + release.yml registered
@@ -41,8 +43,8 @@ const publishScope = process.env.NPM_PUBLISH_SCOPE?.trim() || null
 // OIDC mode changes two behaviors below: the token preflight is impossible
 // (npm whoami needs a token), so it is skipped; and --provenance is added,
 // which both requires OIDC and records the build provenance on npm.
-const hasToken = Boolean(process.env.NODE_AUTH_TOKEN?.trim())
-const oidcMode = !hasToken && Boolean(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)
+const authMode = detectPublishAuthMode()
+const oidcMode = authMode === 'oidc'
 
 function prereleaseTag(version) {
   const override = process.env.NPM_PUBLISH_TAG?.trim()
@@ -218,7 +220,7 @@ for (const dir of CANDIDATE_DIRS) {
 // dry runs keep working.
 if (!dryRun && plan.length > 0) {
   if (oidcMode) {
-    log.info('OIDC trusted publishing (no NODE_AUTH_TOKEN): skipping token preflight; auth happens per-package at publish time')
+    log.info('OIDC trusted publishing: skipping token preflight; auth happens per-package at publish time')
   } else if (!preflightScopes(plan)) {
     console.log(`\nSummary: 0 published, ${skipped} skipped, ${plan.length} blocked by preflight`)
     process.exit(1)
@@ -227,9 +229,6 @@ if (!dryRun && plan.length > 0) {
 
 for (const { dir, name, version } of plan) {
   log.info(`${name}@${version}`)
-  if (name === '@felinic/ui') {
-    log.info('@felinic/ui requires FELINIC_NPM_TOKEN publish rights for the @felinic scope')
-  }
   if (publish(dir, version)) {
     log.ok(`${name}@${version}`)
     published++


### PR DESCRIPTION
## Summary

- prefer the complete GitHub Actions OIDC environment over `NODE_AUTH_TOKEN`
- keep token preflight for local/manual publishing outside OIDC
- remove the stale `FELINIC_NPM_TOKEN` runtime message
- add unit and script-level regression coverage to the ESLint workflow

## Root cause

PR #841 switched the release jobs to npm trusted publishing, but `actions/setup-node` exports `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` when `registry-url` is configured. The publish script treated every non-empty value as a real token and required `!hasToken` before enabling OIDC.

Both npm jobs in the `v0.17.0` release therefore ran `npm whoami` against the setup-node placeholder and exited before the first `pnpm publish`. No package was published and the OIDC exchange was never attempted.

This change detects a complete GitHub OIDC request environment first, matching npm CLI's OIDC-before-token authentication order.

## Verification

- `node --test scripts/publish-auth.test.mjs` (5 passing)
- `pnpm exec eslint scripts/publish-auth.mjs scripts/publish-auth.test.mjs scripts/publish-packages.mjs`
- `pnpm lint`
- workflow YAML parse
- repository pre-commit hook, including full Go test/lint checks

## Release recovery

After merge, dispatch `release.yml` with `tag_name=v0.17.0`. The publish script remains idempotent and skips versions already present in npm.

Fixes the npm publish failures in run https://github.com/memohai/Memoh/actions/runs/30449229707
