### PR TITLE
fix(ci): package dispatched releases from tag

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -23,6 +23,7 @@ on:
       - "tsconfig.json"
       - "vitest.config.ts"
       - ".github/workflows/eslint.yml"
+      - ".github/workflows/release.yml"
   pull_request:
     branches: ["main"]
     paths:
@@ -45,6 +46,7 @@ on:
       - "tsconfig.json"
       - "vitest.config.ts"
       - ".github/workflows/eslint.yml"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          # workflow_dispatch runs the repaired workflow from main, but release
+          # archives must remain reproducible from the requested release tag.
+          ref: ${{ env.RELEASE_TAG }}
       - name: Package repository with submodules
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- make the source-bundle job check out `RELEASE_TAG`
- keep npm recovery jobs on the repaired workflow revision from `main`
- run the existing lint/test workflow when `release.yml` changes

## Context

The `v0.17.0` npm recovery must use `workflow_dispatch` so the publish jobs can run the OIDC fix merged after the tag. Before this change, the source-bundle job also checked out the dispatch ref (`main`) and uploaded those archives to the existing release with `--clobber`.

Pinning only the source-bundle checkout to `RELEASE_TAG` keeps release archives reproducible from the requested tag without moving the npm jobs back to the broken tagged workflow code.

## Verification

- `pnpm lint`
- `node --test scripts/publish-auth.test.mjs` (5 passing)
- parsed `release.yml` and `eslint.yml` with Ruby YAML
- repository pre-commit hook, including Go test/lint checks
