### PR TITLE
fix(runtime): include team context in remote runtime handshake

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -103,6 +103,10 @@ export default defineConfig(async ({ command }) => {
         tailwindcss(),
       ],
       resolve: {
+        // The renderer consumes both @memohai/web and the linked @felinic/ui
+        // workspace package. Keep their injection-based runtimes shared just
+        // like the standalone Web build does.
+        dedupe: ['vue', 'vee-validate'],
         alias: {
           '@renderer': fileURLToPath(new URL('./src/renderer/src', import.meta.url)),
           // match apps/web/vite.config.ts aliases so imported web modules resolve correctly.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -778,7 +778,15 @@ function normalizeDesktopRuntimeConfig(value: unknown): DesktopRuntimeConfig | n
   if (typeof record.runtimeId !== 'string' || typeof record.name !== 'string' || typeof record.key !== 'string') {
     throw new Error('runtime configuration must contain runtimeId, name, and key')
   }
+  if (record.teamId !== undefined && typeof record.teamId !== 'string') {
+    throw new Error('runtime configuration teamId must be a string')
+  }
   const name = record.name.trim()
   if (!name) throw new Error('runtime configuration name is required')
-  return { runtimeId: record.runtimeId, name, key: record.key }
+  return {
+    runtimeId: record.runtimeId,
+    name,
+    key: record.key,
+    teamId: record.teamId,
+  }
 }

--- a/apps/desktop/src/main/remote-runtime.test.ts
+++ b/apps/desktop/src/main/remote-runtime.test.ts
@@ -76,6 +76,30 @@ describe('DesktopRemoteRuntimeManager', () => {
     })
   })
 
+  it('fails closed when a saved team ID is not a string', async () => {
+    const fixture = await createFixture()
+    const encryptedKey = fixture.encryption.encrypt(runtimeKey).toString('base64')
+    await writeFile(fixture.configPath, JSON.stringify({
+      version: 1,
+      runtimeId: runtimeID,
+      serverUrl: 'http://localhost:18080/',
+      teamId: 42,
+      encryptedKey,
+    }))
+    const decrypt = vi.spyOn(fixture.encryption, 'decrypt')
+    const factory = vi.fn<RuntimeSessionFactory>(() => resolvedSession())
+
+    const state = await fixture.manager({ createSession: factory }).restore()
+
+    expect(state).toMatchObject({
+      enabled: true,
+      status: 'error',
+      error: 'This computer\'s saved connection could not be read',
+    })
+    expect(decrypt).not.toHaveBeenCalled()
+    expect(factory).not.toHaveBeenCalled()
+  })
+
   it('fails closed without decrypting when the saved server does not match the current server', async () => {
     const fixture = await createFixture()
     await fixture.manager({ createSession: resolvedSessionFactory() })

--- a/apps/desktop/src/main/remote-runtime.test.ts
+++ b/apps/desktop/src/main/remote-runtime.test.ts
@@ -15,6 +15,7 @@ const runtimeID = '11111111-1111-4111-8111-111111111111'
 const replacementRuntimeID = '22222222-2222-4222-8222-222222222222'
 const runtimeKey = `mrk_${'a'.repeat(64)}`
 const replacementRuntimeKey = `mrk_${'b'.repeat(64)}`
+const runtimeTeamId = '33333333-3333-4333-8333-333333333333'
 const temporaryDirectories: string[] = []
 
 afterEach(async () => {
@@ -25,7 +26,12 @@ describe('DesktopRemoteRuntimeManager', () => {
   it('restores an encrypted runtime configuration using main-process-owned connection values', async () => {
     const fixture = await createFixture()
     const first = fixture.manager({ createSession: resolvedSessionFactory() })
-    await first.configure({ runtimeId: runtimeID, name: 'Studio Mac', key: runtimeKey })
+    await first.configure({
+      runtimeId: runtimeID,
+      name: 'Studio Mac',
+      key: runtimeKey,
+      teamId: runtimeTeamId,
+    })
 
     const restoredFactory = vi.fn<RuntimeSessionFactory>(() => resolvedSession())
     const restored = fixture.manager({ createSession: restoredFactory })
@@ -42,6 +48,7 @@ describe('DesktopRemoteRuntimeManager', () => {
       {
         serverUrl: 'http://localhost:18080/',
         key: runtimeKey,
+        teamId: runtimeTeamId,
         workspaceBase: fixture.workspaceBase,
         insecureLocalhost: true,
       },
@@ -146,7 +153,12 @@ describe('DesktopRemoteRuntimeManager', () => {
     const observed: unknown[] = []
     manager.onStateChanged(state => observed.push(state))
 
-    const configured = await manager.configure({ runtimeId: runtimeID, name: 'Studio Mac', key: runtimeKey })
+    const configured = await manager.configure({
+      runtimeId: runtimeID,
+      name: 'Studio Mac',
+      key: runtimeKey,
+      teamId: runtimeTeamId,
+    })
     reportStatus?.('disconnected', `credential ${runtimeKey} was rejected`)
 
     const serializedState = JSON.stringify([configured, manager.runtimeState(), observed])
@@ -159,6 +171,7 @@ describe('DesktopRemoteRuntimeManager', () => {
       runtimeId: runtimeID,
       runtimeName: 'Studio Mac',
       serverUrl: 'http://localhost:18080/',
+      teamId: runtimeTeamId,
       encryptedKey: expect.any(String),
     }))
 

--- a/apps/desktop/src/main/remote-runtime.ts
+++ b/apps/desktop/src/main/remote-runtime.ts
@@ -3,6 +3,7 @@ import { dirname } from 'node:path'
 
 import {
   RuntimeSession,
+  normalizeRuntimeTeamId,
   normalizeRuntimeServerUrl,
   validateRuntimeKey,
   type RuntimeClientConfig,
@@ -23,6 +24,7 @@ interface StoredRuntimeConfig {
   runtimeId: string
   runtimeName?: string
   serverUrl: string
+  teamId?: string
   encryptedKey: string
 }
 
@@ -149,7 +151,7 @@ export class DesktopRemoteRuntimeManager {
       }
 
       try {
-        this.startSession(stored.runtimeId, currentServerUrl, key)
+        this.startSession(stored.runtimeId, currentServerUrl, key, stored.teamId)
       } catch (error) {
         return this.updateState({
           enabled: true,
@@ -177,16 +179,20 @@ export class DesktopRemoteRuntimeManager {
       const runtimeName = normalizedRuntimeName(input.name)
       const key = input.key.trim()
       validateRuntimeKey(key)
+      const teamId = input.teamId === undefined
+        ? undefined
+        : normalizeRuntimeTeamId(input.teamId)
       if (!this.options.encryption.isAvailable()) {
         throw new Error('secure credential storage is unavailable')
       }
       const serverUrl = normalizeDesktopServerUrl(this.options.currentServerUrl())
-      const prepared = this.prepareSession(runtimeId, serverUrl, key)
+      const prepared = this.prepareSession(runtimeId, serverUrl, key, teamId)
       const stored: StoredRuntimeConfig = {
         version: configVersion,
         runtimeId,
         runtimeName,
         serverUrl,
+        teamId,
         encryptedKey: this.options.encryption.encrypt(key).toString('base64'),
       }
       await writeStoredConfig(this.options.configPath, stored)
@@ -214,7 +220,7 @@ export class DesktopRemoteRuntimeManager {
     })
   }
 
-  private prepareSession(runtimeId: string, serverUrl: string, key: string): {
+  private prepareSession(runtimeId: string, serverUrl: string, key: string, teamId?: string): {
     session: ManagedRuntimeSession
     token: object
   } {
@@ -223,6 +229,7 @@ export class DesktopRemoteRuntimeManager {
       {
         serverUrl,
         key,
+        teamId,
         workspaceBase: this.options.workspaceBase,
         insecureLocalhost: isInsecureLocalhost(serverUrl),
       },
@@ -234,8 +241,8 @@ export class DesktopRemoteRuntimeManager {
     return { session, token }
   }
 
-  private startSession(runtimeId: string, serverUrl: string, key: string): void {
-    this.activateSession(this.prepareSession(runtimeId, serverUrl, key), runtimeId, key)
+  private startSession(runtimeId: string, serverUrl: string, key: string, teamId?: string): void {
+    this.activateSession(this.prepareSession(runtimeId, serverUrl, key, teamId), runtimeId, key)
   }
 
   private activateSession(
@@ -338,6 +345,9 @@ function parseStoredConfig(raw: string): StoredRuntimeConfig {
   if (typeof parsed.encryptedKey !== 'string') {
     throw new Error('desktop runtime credential is missing')
   }
+  const teamId = parsed.teamId === undefined
+    ? undefined
+    : normalizeRuntimeTeamId(parsed.teamId)
   decodeEncryptedKey(parsed.encryptedKey)
   return {
     version: configVersion,
@@ -346,6 +356,7 @@ function parseStoredConfig(raw: string): StoredRuntimeConfig {
       ? normalizedRuntimeName(parsed.runtimeName)
       : undefined,
     serverUrl,
+    teamId,
     encryptedKey: parsed.encryptedKey,
   }
 }

--- a/apps/desktop/src/main/remote-runtime.ts
+++ b/apps/desktop/src/main/remote-runtime.ts
@@ -345,6 +345,9 @@ function parseStoredConfig(raw: string): StoredRuntimeConfig {
   if (typeof parsed.encryptedKey !== 'string') {
     throw new Error('desktop runtime credential is missing')
   }
+  if (parsed.teamId !== undefined && typeof parsed.teamId !== 'string') {
+    throw new Error('desktop runtime team ID is invalid')
+  }
   const teamId = parsed.teamId === undefined
     ? undefined
     : normalizeRuntimeTeamId(parsed.teamId)

--- a/apps/desktop/src/renderer/types/web-stubs.d.ts
+++ b/apps/desktop/src/renderer/types/web-stubs.d.ts
@@ -257,7 +257,7 @@ declare module '@memohai/web/lib/desktop-shell' {
   }
   export interface DesktopRuntimeBridge {
     runtimeState(): Promise<DesktopRuntimeState>
-    configureRuntime(config: { runtimeId: string, name: string, key: string } | null): Promise<DesktopRuntimeState>
+    configureRuntime(config: { runtimeId: string, name: string, key: string, teamId?: string } | null): Promise<DesktopRuntimeState>
     onRuntimeStateChanged(listener: (state: DesktopRuntimeState) => void): () => void
   }
   export const DesktopRuntimeKey: InjectionKey<DesktopRuntimeBridge | undefined>

--- a/apps/desktop/src/shared/remote-runtime.ts
+++ b/apps/desktop/src/shared/remote-runtime.ts
@@ -19,4 +19,5 @@ export interface DesktopRuntimeConfig {
   runtimeId: string
   name: string
   key: string
+  teamId?: string
 }

--- a/apps/web/src/lib/desktop-shell.ts
+++ b/apps/web/src/lib/desktop-shell.ts
@@ -24,7 +24,7 @@ export interface DesktopRuntimeState {
 
 export interface DesktopRuntimeBridge {
   runtimeState(): Promise<DesktopRuntimeState>
-  configureRuntime(config: { runtimeId: string, name: string, key: string } | null): Promise<DesktopRuntimeState>
+  configureRuntime(config: { runtimeId: string, name: string, key: string, teamId?: string } | null): Promise<DesktopRuntimeState>
   onRuntimeStateChanged(listener: (state: DesktopRuntimeState) => void): () => void
 }
 

--- a/apps/web/src/pages/runtimes/command.test.ts
+++ b/apps/web/src/pages/runtimes/command.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildRuntimeConnectCommand } from './command'
+
+const key = `mrk_${'a'.repeat(64)}`
+const teamId = '11111111-1111-4111-8111-111111111111'
+
+describe('buildRuntimeConnectCommand', () => {
+  it('includes the credential team ID required by hosted gateways', () => {
+    expect(buildRuntimeConnectCommand('https://memoh.example/api', {
+      key,
+      team_id: teamId,
+    })).toBe(
+      `npx --yes @memohai/runtime --server https://memoh.example/api --key ${key} --team-id ${teamId}`,
+    )
+  })
+
+  it('keeps credentials from older self-hosted servers usable', () => {
+    expect(buildRuntimeConnectCommand('https://memoh.example/api', { key }))
+      .toBe(`npx --yes @memohai/runtime --server https://memoh.example/api --key ${key}`)
+  })
+
+  it('enables plaintext WebSockets only for loopback development servers', () => {
+    expect(buildRuntimeConnectCommand('http://127.0.0.1:18080', {
+      key,
+      team_id: teamId,
+    })).toBe(
+      `npx --yes @memohai/runtime --server http://127.0.0.1:18080 --key ${key} --team-id ${teamId} --insecure-localhost`,
+    )
+  })
+})

--- a/apps/web/src/pages/runtimes/command.ts
+++ b/apps/web/src/pages/runtimes/command.ts
@@ -1,0 +1,36 @@
+export interface RuntimeCommandCredential {
+  key?: string
+  team_id?: string
+}
+
+export function buildRuntimeConnectCommand(
+  serverUrl: string,
+  credential: RuntimeCommandCredential | null | undefined,
+): string {
+  const key = credential?.key?.trim()
+  if (!key) return ''
+
+  const args = [
+    'npx',
+    '--yes',
+    '@memohai/runtime',
+    '--server',
+    serverUrl,
+    '--key',
+    key,
+  ]
+  const teamId = credential?.team_id?.trim()
+  if (teamId) {
+    args.push('--team-id', teamId)
+  }
+  if (isInsecureLocalhost(serverUrl)) {
+    args.push('--insecure-localhost')
+  }
+  return args.join(' ')
+}
+
+function isInsecureLocalhost(serverUrl: string): boolean {
+  const url = new URL(serverUrl)
+  const hostname = url.hostname.replace(/^\[|\]$/g, '')
+  return url.protocol === 'http:' && ['localhost', '127.0.0.1', '::1'].includes(hostname)
+}

--- a/apps/web/src/pages/runtimes/index.vue
+++ b/apps/web/src/pages/runtimes/index.vue
@@ -345,6 +345,7 @@ import {
 } from '@/lib/desktop-shell'
 import { useClipboard } from '@/composables/useClipboard'
 import { resolveApiErrorMessage } from '@/utils/api-error'
+import { buildRuntimeConnectCommand } from './command'
 
 const { t } = useI18n()
 const { copyText } = useClipboard()
@@ -501,6 +502,7 @@ const enableDesktopRuntime = connectForm.handleSubmit(async (values) => {
       runtimeId: created.id,
       name,
       key: created.key,
+      teamId: created.team_id?.trim() || undefined,
     })
     created = undefined
     desktopRuntimeDialogOpen.value = false
@@ -521,18 +523,16 @@ const enableDesktopRuntime = connectForm.handleSubmit(async (values) => {
   }
 })
 
-function commandForKey(value: string | undefined): string {
-  const key = value?.trim()
-  if (!key) return ''
-  const server = sdkApiBaseUrl()
-  const localFlag = isInsecureLocalhost(server) ? ' --insecure-localhost' : ''
-  return `npx --yes @memohai/runtime --server ${server} --key ${key}${localFlag}`
+function commandForCredential(
+  credential: Pick<UserruntimeRuntime, 'key' | 'team_id'> | null | undefined,
+): string {
+  return buildRuntimeConnectCommand(sdkApiBaseUrl(), credential)
 }
 
-const connectCommand = computed(() => commandForKey(createdCredential.value?.key))
+const connectCommand = computed(() => commandForCredential(createdCredential.value))
 
 function runtimeCommand(runtime: UserruntimeRuntime): string {
-  return commandForKey(runtime.key)
+  return commandForCredential(runtime)
 }
 
 const createRuntimeCredential = connectForm.handleSubmit(async (values) => {
@@ -568,12 +568,6 @@ function runtimeSummary(runtime: UserruntimeRuntime): string {
   if (!runtime.online) return t('runtimes.waitingForConnection')
   const machine = [runtime.hostname, runtime.os, runtime.arch].filter(Boolean).join(' · ')
   return machine || t('runtimes.connected')
-}
-
-function isInsecureLocalhost(server: string): boolean {
-  const url = new URL(server)
-  const hostname = url.hostname.replace(/^\[|\]$/g, '')
-  return url.protocol === 'http:' && ['localhost', '127.0.0.1', '::1'].includes(hostname)
 }
 
 watch(connectDialogOpen, (open) => {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -130,6 +130,11 @@ export default defineConfig(({ command }) => {
       allowedHosts: true,
     },
     resolve: {
+      // @felinic/ui is a linked workspace package and pnpm can resolve its
+      // peer dependencies through a different Vue version than the host app.
+      // Keep singleton/injection-based runtimes shared so useForm() and the
+      // UI package's FormField see the same vee-validate context in builds.
+      dedupe: ['vue', 'vee-validate'],
       alias: {
         '#': fileURLToPath(new URL('../../packages/ui/src', import.meta.url)),
         '@': fileURLToPath(new URL('./src', import.meta.url))

--- a/internal/db/postgres/store/user_runtimes.go
+++ b/internal/db/postgres/store/user_runtimes.go
@@ -61,7 +61,7 @@ func (s *Store) RevokeUserRuntime(ctx context.Context, runtimeID, userID string)
 
 func userRuntimeRecord(row dbsqlc.UserRuntime) dbstore.UserRuntimeRecord {
 	return dbstore.UserRuntimeRecord{
-		ID: row.ID.String(), UserID: row.UserID.String(), Name: row.Name,
+		ID: row.ID.String(), TeamID: row.TeamID.String(), UserID: row.UserID.String(), Name: row.Name,
 		APIToken: row.ApiToken, CreatedAt: db.TimeFromPg(row.CreatedAt),
 	}
 }

--- a/internal/db/store/contracts.go
+++ b/internal/db/store/contracts.go
@@ -21,6 +21,7 @@ type Page struct {
 
 type UserRuntimeRecord struct {
 	ID        string
+	TeamID    string
 	UserID    string
 	Name      string
 	APIToken  string //nolint:gosec // owner-readable Remote Runtime credential by product design

--- a/internal/userruntime/service.go
+++ b/internal/userruntime/service.go
@@ -201,7 +201,7 @@ func canonicalRuntimeUUID(value string) (string, bool) {
 
 func runtimeFromRecord(row dbstore.UserRuntimeRecord, connection *Connection) Runtime {
 	runtime := Runtime{
-		ID: row.ID, Name: row.Name, Key: row.APIToken, CreatedAt: row.CreatedAt,
+		ID: row.ID, TeamID: row.TeamID, Name: row.Name, Key: row.APIToken, CreatedAt: row.CreatedAt,
 	}
 	if connection == nil {
 		return runtime

--- a/internal/userruntime/service_test.go
+++ b/internal/userruntime/service_test.go
@@ -17,7 +17,10 @@ import (
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
-const serviceTestRuntimeID = "11111111-1111-4111-8111-111111111111"
+const (
+	serviceTestRuntimeID = "11111111-1111-4111-8111-111111111111"
+	serviceTestTeamID    = "22222222-2222-4222-8222-222222222222"
+)
 
 type serviceTestStore struct {
 	mu      sync.Mutex
@@ -29,7 +32,7 @@ func (s *serviceTestStore) CreateUserRuntime(_ context.Context, input dbstore.Cr
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.runtime = dbstore.UserRuntimeRecord{
-		ID: serviceTestRuntimeID, UserID: input.UserID, Name: input.Name,
+		ID: serviceTestRuntimeID, TeamID: serviceTestTeamID, UserID: input.UserID, Name: input.Name,
 		APIToken: input.APIToken, CreatedAt: time.Now().UTC(),
 	}
 	s.revoked = false
@@ -93,7 +96,7 @@ func TestServiceRegistrationConnectionAndRevoke(t *testing.T) {
 	if err := ValidateKeyFormat(created.Key); err != nil {
 		t.Fatalf("created key is invalid: %v", err)
 	}
-	if created.ID != serviceTestRuntimeID || created.Online {
+	if created.ID != serviceTestRuntimeID || created.TeamID != serviceTestTeamID || created.Online {
 		t.Fatalf("created Runtime = %#v", created)
 	}
 	store.mu.Lock()
@@ -126,6 +129,9 @@ func TestServiceRegistrationConnectionAndRevoke(t *testing.T) {
 	}
 	if items[0].Key != created.Key {
 		t.Fatal("ListRuntimes() did not return the reusable API token")
+	}
+	if items[0].TeamID != serviceTestTeamID {
+		t.Fatalf("ListRuntimes() team ID = %q, want %q", items[0].TeamID, serviceTestTeamID)
 	}
 
 	if err := service.RevokeRuntime(context.Background(), "user-1", created.ID); err != nil {

--- a/internal/userruntime/types.go
+++ b/internal/userruntime/types.go
@@ -6,6 +6,7 @@ import "time"
 // reverse-RPC connection is online; they are not persisted.
 type Runtime struct {
 	ID            string    `json:"id"`
+	TeamID        string    `json:"team_id"`
 	Name          string    `json:"name"`
 	Key           string    `json:"key"`
 	CreatedAt     time.Time `json:"created_at"`

--- a/packages/runtime/src/cli.ts
+++ b/packages/runtime/src/cli.ts
@@ -13,6 +13,7 @@ async function main(args: string[]): Promise<void> {
   }
   const serverUrl = valueAfter(args, '--server') ?? process.env.MEMOH_RUNTIME_SERVER
   const key = valueAfter(args, '--key') ?? process.env.MEMOH_RUNTIME_KEY
+  const teamId = (valueAfter(args, '--team-id') ?? process.env.MEMOH_RUNTIME_TEAM_ID)?.trim() || undefined
   if (!serverUrl || !key) {
     throw new Error('--server and --key are required (or set MEMOH_RUNTIME_SERVER and MEMOH_RUNTIME_KEY)')
   }
@@ -25,6 +26,7 @@ async function main(args: string[]): Promise<void> {
     const session = new RuntimeSession({
       serverUrl,
       key,
+      teamId,
       workspaceBase,
       insecureLocalhost: args.includes('--insecure-localhost'),
     }, {
@@ -51,7 +53,7 @@ function valueAfter(args: string[], name: string): string | undefined {
 }
 
 function usage(exitCode: number): never {
-  console.error('Usage: memoh-runtime --server <url> --key <key> [--insecure-localhost]')
+  console.error('Usage: memoh-runtime --server <url> --key <key> [--team-id <uuid>] [--insecure-localhost]')
   process.exit(exitCode)
 }
 

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -2,11 +2,23 @@ import { isAbsolute } from 'node:path'
 
 import { validateRuntimeKey } from './key'
 
+const runtimeTeamIdPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export interface RuntimeClientConfig {
   serverUrl: string
   key: string
+  // Optional for direct connections to the upstream single-team server.
+  teamId?: string
   workspaceBase: string
   insecureLocalhost?: boolean
+}
+
+export function normalizeRuntimeTeamId(teamId: string): string {
+  const normalized = teamId.trim().toLowerCase()
+  if (!runtimeTeamIdPattern.test(normalized)) {
+    throw new Error('runtime team ID must be a UUID')
+  }
+  return normalized
 }
 
 export function validateConfig(config: RuntimeClientConfig): void {
@@ -35,4 +47,7 @@ export function validateConfig(config: RuntimeClientConfig): void {
     throw new Error('insecureLocalhost must be a boolean')
   }
   validateRuntimeKey(config.key)
+  if (config.teamId !== undefined) {
+    normalizeRuntimeTeamId(config.teamId)
+  }
 }

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -1,9 +1,10 @@
 import { arch, hostname, platform } from 'node:os'
 import { realpath } from 'node:fs/promises'
+import type { IncomingMessage } from 'node:http'
 
 import WebSocket from 'ws'
 
-import { validateConfig, type RuntimeClientConfig } from './config.js'
+import { normalizeRuntimeTeamId, validateConfig, type RuntimeClientConfig } from './config.js'
 import { bridgeWebSocketToGrpc } from './pipe/grpc-websocket'
 import { grpcMessageLimit, startRuntimeGrpcServer } from './service'
 import { runtimeCapabilities } from './core/guards'
@@ -11,7 +12,12 @@ import { runtimeClientVersion } from './version'
 
 export const runtimeProtocolGrpc = 'memoh.runtime.v1.grpc'
 export const runtimeMetadataHeader = 'X-Memoh-Runtime-Metadata'
+// Hosted gateways consume this tenant-routing header before proxying the
+// WebSocket. The upstream single-team server intentionally does not require it.
+export const runtimeTeamIDHeader = 'X-Team-ID'
 export const runtimeMetadataMaxBytes = 8 * 1024
+const runtimeHandshakeErrorMaxBytes = 8 * 1024
+const runtimeHandshakeErrorReadTimeoutMs = 2_000
 
 export interface RuntimeHandshakeMetadataV1 {
   version: 1
@@ -27,6 +33,7 @@ export interface RuntimeHandshakeHeaders {
   Authorization: string
   'Sec-WebSocket-Protocol': typeof runtimeProtocolGrpc
   'X-Memoh-Runtime-Metadata': string
+  'X-Team-ID'?: string
 }
 
 export interface RuntimeSessionOptions {
@@ -111,11 +118,15 @@ export function handshakeHeaders(
   version = runtimeClientVersion,
   metadata = createHandshakeMetadata(config.workspaceBase, version),
 ): RuntimeHandshakeHeaders {
-  return {
+  const headers: RuntimeHandshakeHeaders = {
     Authorization: `Bearer ${config.key.trim()}`,
     'Sec-WebSocket-Protocol': runtimeProtocolGrpc,
     'X-Memoh-Runtime-Metadata': encodeHandshakeMetadata(metadata),
   }
+  if (config.teamId !== undefined) {
+    headers[runtimeTeamIDHeader] = normalizeRuntimeTeamId(config.teamId)
+  }
+  return headers
 }
 
 export class RuntimeSession {
@@ -198,11 +209,15 @@ export class RuntimeSession {
       })
       const metadata = createHandshakeMetadata(workspaceBase, this.version)
       const headers = handshakeHeaders(this.config, this.version, metadata)
+      const websocketHeaders: Record<string, string> = {
+        Authorization: headers.Authorization,
+        [runtimeMetadataHeader]: headers[runtimeMetadataHeader],
+      }
+      if (headers[runtimeTeamIDHeader]) {
+        websocketHeaders[runtimeTeamIDHeader] = headers[runtimeTeamIDHeader]
+      }
       websocket = new WebSocket(url, runtimeProtocolGrpc, {
-        headers: {
-          Authorization: headers.Authorization,
-          [runtimeMetadataHeader]: headers[runtimeMetadataHeader],
-        },
+        headers: websocketHeaders,
         handshakeTimeout: 15_000,
         maxPayload: grpcMessageLimit,
         perMessageDeflate: false,
@@ -258,15 +273,65 @@ function waitForOpen(websocket: WebSocket): Promise<void> {
       cleanup()
       reject(new Error('runtime WebSocket closed during handshake'))
     }
-    const onUnexpectedResponse = (_request: unknown, response: { statusCode?: number, resume?: () => void }) => {
+    const onUnexpectedResponse = (_request: unknown, response: IncomingMessage) => {
       cleanup()
-      response.resume?.()
-      reject(new Error(`runtime handshake rejected with HTTP ${response.statusCode ?? 'unknown'}`))
+      void readHandshakeError(response).then((detail) => {
+        const suffix = detail ? `: ${detail}` : ''
+        reject(new Error(`runtime handshake rejected with HTTP ${response.statusCode ?? 'unknown'}${suffix}`))
+      })
     }
     websocket.once('open', onOpen)
     websocket.once('error', onError)
     websocket.once('close', onClose)
     websocket.once('unexpected-response', onUnexpectedResponse)
+  })
+}
+
+function readHandshakeError(response: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = []
+    let size = 0
+    let settled = false
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      response.off('data', onData)
+      response.off('end', finish)
+      response.off('error', finish)
+      response.off('aborted', finish)
+      response.off('close', finish)
+    }
+    const finish = () => {
+      if (settled) return
+      settled = true
+      cleanup()
+      response.resume()
+      resolve(
+        Buffer.concat(chunks)
+          .toString('utf8')
+          .replace(/\s+/g, ' ')
+          .trim(),
+      )
+    }
+    const onData = (chunk: Buffer | Uint8Array | string) => {
+      if (size >= runtimeHandshakeErrorMaxBytes) return
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      const remaining = runtimeHandshakeErrorMaxBytes - size
+      const accepted = buffer.subarray(0, remaining)
+      chunks.push(accepted)
+      size += accepted.length
+      if (size >= runtimeHandshakeErrorMaxBytes) {
+        finish()
+      }
+    }
+
+    const timer = setTimeout(finish, runtimeHandshakeErrorReadTimeoutMs)
+    timer.unref()
+    response.on('data', onData)
+    response.once('end', finish)
+    response.once('error', finish)
+    response.once('aborted', finish)
+    response.once('close', finish)
   })
 }
 

--- a/packages/runtime/test/config.test.ts
+++ b/packages/runtime/test/config.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { validateConfig } from '../src/config'
+import { normalizeRuntimeTeamId, validateConfig } from '../src/config'
 
 const key = `mrk_${'a'.repeat(64)}`
+const teamId = '11111111-1111-4111-8111-111111111111'
 
 describe('runtime config', () => {
   it('rejects unsafe URLs and relative workspace roots', () => {
@@ -11,5 +12,21 @@ describe('runtime config', () => {
       .toThrow('credentials')
     expect(() => validateConfig({ serverUrl: 'https://example.test/api', key, workspaceBase: 'relative' }))
       .toThrow('absolute')
+  })
+
+  it('normalizes and validates optional team IDs', () => {
+    expect(normalizeRuntimeTeamId(` ${teamId.toUpperCase()} `)).toBe(teamId)
+    expect(() => validateConfig({
+      serverUrl: 'https://example.test/api',
+      key,
+      teamId,
+      workspaceBase: '/tmp',
+    })).not.toThrow()
+    expect(() => validateConfig({
+      serverUrl: 'https://example.test/api',
+      key,
+      teamId: 'not-a-team-id',
+      workspaceBase: '/tmp',
+    })).toThrow('UUID')
   })
 })

--- a/packages/runtime/test/session.test.ts
+++ b/packages/runtime/test/session.test.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer'
 import { mkdtemp, realpath, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -16,6 +17,7 @@ import {
 } from '../src/session'
 
 const runtimeKey = `mrk_${'a'.repeat(64)}`
+const runtimeTeamId = '11111111-1111-4111-8111-111111111111'
 
 describe('runtime handshake', () => {
   it('preserves an API base path when building the public WebSocket URL', () => {
@@ -37,12 +39,14 @@ describe('runtime handshake', () => {
     const headers = handshakeHeaders({
       serverUrl: 'https://example.test/api',
       key,
+      teamId: runtimeTeamId,
       workspaceBase: metadata.workspace_base,
     }, '1.2.3', metadata)
 
     expect(metadata.capabilities).toContain('host_fs')
     expect(headers['Sec-WebSocket-Protocol']).toBe(runtimeProtocolGrpc)
     expect(headers.Authorization).toBe(`Bearer ${key}`)
+    expect(headers['X-Team-ID']).toBe(runtimeTeamId)
     expect(headers).not.toHaveProperty('X-Memoh-Runtime-Hostname')
     const decoded = JSON.parse(Buffer.from(headers['X-Memoh-Runtime-Metadata'], 'base64url').toString('utf8'))
     expect(decoded).toEqual(metadata)
@@ -94,6 +98,7 @@ describe('runtime handshake', () => {
       const session = new RuntimeSession({
         serverUrl: `http://127.0.0.1:${port}/api`,
         key,
+        teamId: runtimeTeamId,
         workspaceBase: root,
         insecureLocalhost: true,
       }, {
@@ -104,6 +109,7 @@ describe('runtime handshake', () => {
       const request = await requestPromise
       expect(request.url).toBe('/api/runtimes/connect')
       expect(request.headers.authorization).toBe(`Bearer ${key}`)
+      expect(request.headers['x-team-id']).toBe(runtimeTeamId)
       expect(request.headers['sec-websocket-protocol']).toBe(runtimeProtocolGrpc)
       const encoded = request.headers['x-memoh-runtime-metadata']
       expect(typeof encoded).toBe('string')
@@ -125,4 +131,94 @@ describe('runtime handshake', () => {
       await rm(root, { recursive: true, force: true })
     }
   })
+
+  it('includes a bounded server response body in handshake errors', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'memoh-runtime-rejection-'))
+    const controller = new AbortController()
+    let running: Promise<void> | undefined
+    let rejection: string | undefined
+    const server = new WebSocketServer({
+      port: 0,
+      verifyClient: (_info, done) => done(false, 400, 'X-Team-ID is required'),
+    })
+    try {
+      await new Promise<void>(resolve => server.once('listening', resolve))
+      const port = (server.address() as { port: number }).port
+      const session = new RuntimeSession({
+        serverUrl: `http://127.0.0.1:${port}/api`,
+        key: runtimeKey,
+        workspaceBase: root,
+        insecureLocalhost: true,
+      }, {
+        random: () => 0.5,
+        onStatus: (status, error) => {
+          if (status !== 'disconnected' || !error) return
+          rejection = error
+          controller.abort()
+        },
+      })
+
+      running = session.start(controller.signal)
+      await running
+
+      expect(rejection).toBe('runtime handshake rejected with HTTP 400: X-Team-ID is required')
+    } finally {
+      controller.abort()
+      await running?.catch(() => undefined)
+      await new Promise<void>(resolve => server.close(() => resolve()))
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('stops waiting when a handshake error body never ends', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'memoh-runtime-stalled-rejection-'))
+    const controller = new AbortController()
+    let running: Promise<void> | undefined
+    let rejection: string | undefined
+    let responseStartedResolve: (() => void) | undefined
+    const responseStarted = new Promise<void>((resolve) => {
+      responseStartedResolve = resolve
+    })
+    const server = createServer((_request, response) => {
+      response.writeHead(400, {
+        'Content-Length': '100',
+        'Content-Type': 'text/plain',
+      })
+      response.write('partial gateway error')
+      responseStartedResolve?.()
+    })
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
+      })
+      const port = (server.address() as { port: number }).port
+      const session = new RuntimeSession({
+        serverUrl: `http://127.0.0.1:${port}/api`,
+        key: runtimeKey,
+        workspaceBase: root,
+        insecureLocalhost: true,
+      }, {
+        random: () => 0.5,
+        onStatus: (status, error) => {
+          if (status !== 'disconnected' || !error) return
+          rejection = error
+          controller.abort()
+        },
+      })
+
+      running = session.start(controller.signal)
+      await responseStarted
+      await running
+
+      expect(rejection).toBe('runtime handshake rejected with HTTP 400: partial gateway error')
+    } finally {
+      controller.abort()
+      await running?.catch(() => undefined)
+      const closed = new Promise<void>(resolve => server.close(() => resolve()))
+      server.closeAllConnections()
+      await closed
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 10_000)
 })

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -2904,6 +2904,7 @@ export type UserruntimeRuntime = {
     name?: string;
     online?: boolean;
     os?: string;
+    team_id?: string;
     workspace_base?: string;
 };
 

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -21157,6 +21157,9 @@ const docTemplate = `{
                 "os": {
                     "type": "string"
                 },
+                "team_id": {
+                    "type": "string"
+                },
                 "workspace_base": {
                     "type": "string"
                 }

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -21148,6 +21148,9 @@
                 "os": {
                     "type": "string"
                 },
+                "team_id": {
+                    "type": "string"
+                },
                 "workspace_base": {
                     "type": "string"
                 }

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -4933,6 +4933,8 @@ definitions:
         type: boolean
       os:
         type: string
+      team_id:
+        type: string
       workspace_base:
         type: string
     type: object


### PR DESCRIPTION
## 背景

托管网关需要根据 team 路由 Remote Runtime 连接，但现有 runtime 命令和握手没有携带 team ID，因此连接会被网关以 HTTP 400 拒绝。原来的客户端错误也只包含状态码，无法直接看到服务端返回的具体原因。

## 主要改动

- Remote Runtime 凭证的创建和列表接口返回 team_id，并同步更新 Swagger 与 TypeScript SDK。
- Web 端生成的连接命令增加 --team-id；兼容旧服务端未返回 team_id 的情况。
- Desktop 保存、恢复并传递 teamId，同时保持对旧版存储配置的兼容。
- @memohai/runtime 支持 --team-id 和 MEMOH_RUNTIME_TEAM_ID，校验并规范化 UUID，在 WebSocket 握手中发送 X-Team-ID。
- 握手失败时读取并展示服务端响应体，限制最多 8 KiB，并增加 2 秒兜底超时，避免异常响应长期阻塞重连。
- 注释明确 X-Team-ID 由托管网关用于租户路由；上游单团队服务端有意不强制消费该 header。

## 数据库与发布

- 本次没有新增数据库 migration。user_runtimes.team_id 已由现有迁移完成回填并设置为 NOT NULL，本次只补齐 Go 存储层到 API 的字段映射。
- 本 PR 不修改 npm package 版本，也不修改 pnpm-lock.yaml。合并后再通过独立 release 流程发布新版 @memohai/runtime。

## 验证

- @memohai/runtime：8 个测试文件、37 个测试通过，build 和 typecheck 通过。
- Desktop remote-runtime 与 Web 命令相关测试通过，Desktop typecheck 与 Web production build 通过。
- go test ./... 与 Go lint 通过。
- 使用本地 link 后的 runtime CLI 完成端到端验证：创建接口返回有效 team_id、列表结果一致、CLI 成功连接且 runtime 状态变为 online。
