### PR TITLE
fix(runtime): preserve inject channel ownership

### DIFF
--- a/internal/agent/application/turn_inject_ownership_test.go
+++ b/internal/agent/application/turn_inject_ownership_test.go
@@ -1,0 +1,84 @@
+package application
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	"github.com/memohai/memoh/internal/agent/turn"
+)
+
+type injectOwnershipAdmitter struct {
+	input         sessionruntime.AdmitInput
+	finishStarted chan struct{}
+	finishRelease chan struct{}
+}
+
+func newInjectOwnershipAdmitter() *injectOwnershipAdmitter {
+	return &injectOwnershipAdmitter{
+		finishStarted: make(chan struct{}),
+		finishRelease: make(chan struct{}),
+	}
+}
+
+func (a *injectOwnershipAdmitter) Admit(_ context.Context, input sessionruntime.AdmitInput) (sessionruntime.Admission, error) {
+	a.input = input
+	return sessionruntime.Admission{
+		RunID:   "run-inject-ownership",
+		Started: true,
+		Handle: sessionruntime.RunHandle{
+			BotID:        input.BotID,
+			SessionID:    input.SessionID,
+			RunID:        "run-inject-ownership",
+			FencingToken: 1,
+		},
+	}, nil
+}
+
+func (a *injectOwnershipAdmitter) FinishRun(context.Context, sessionruntime.RunHandle, string, string) error {
+	close(a.finishStarted)
+	<-a.finishRelease
+	a.input.Execution.InjectCh <- turn.InjectMessage{Text: "finishing steer"}
+	return nil
+}
+
+func TestRunEndStopsDirectInjectBeforeSessionFinishes(t *testing.T) {
+	runner := &fakeRunner{chunks: []string{`{"type":"done"}`}}
+	admitter := newInjectOwnershipAdmitter()
+	service := &Service{
+		sessionRuntime: admitter,
+		turnHooks: &turnRuntimeHooks{
+			streamChat: runner.StreamChat,
+		},
+	}
+	var releaseOnce sync.Once
+	releaseFinish := func() {
+		releaseOnce.Do(func() { close(admitter.finishRelease) })
+	}
+	t.Cleanup(releaseFinish)
+
+	handle, err := service.StartTurn(context.Background(), turn.StartTurnCommand{TeamID: "t", Mode: turn.ModeChat})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-admitter.finishStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("durable finisher did not start")
+	}
+	if err := handle.Inject(context.Background(), turn.InjectMessage{Text: "late"}); err == nil {
+		t.Error("direct inject succeeded after execution stopped")
+	}
+	releaseFinish()
+	drainHandle(handle)
+	select {
+	case got := <-runner.gotReq.InjectCh:
+		if got.Text != "finishing steer" {
+			t.Fatalf("inject text = %q", got.Text)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session inject did not finish before channel close")
+	}
+}

--- a/internal/agent/application/turn_service.go
+++ b/internal/agent/application/turn_service.go
@@ -111,11 +111,11 @@ type runHandle struct {
 	inject    chan turn.InjectMessage
 	addAssets func([]turn.OutboundAssetRef)
 
-	// injectMu guards inject against send-after-close: the pump closes the
-	// channel when the run ends so the application's forwarding goroutine
-	// (which ranges over it) can exit instead of leaking per turn.
-	injectMu     sync.Mutex
-	injectClosed bool
+	// injectMu lets teardown stop direct injections before the durable finisher
+	// stops the session sender and the channel can be closed safely.
+	injectMu      sync.Mutex
+	injectStopped bool
+	injectClosed  bool
 
 	// failed records that the run ended in an error or cancellation, and
 	// streamErr keeps the error itself when there was one. Both are needed
@@ -135,10 +135,10 @@ func (h *runHandle) Cancel()                   { h.cancel() }
 func (h *runHandle) Inject(ctx context.Context, msg turn.InjectMessage) error {
 	h.injectMu.Lock()
 	defer h.injectMu.Unlock()
-	if h.injectClosed {
-		if err := h.ctx.Err(); err != nil {
-			return err
-		}
+	if err := h.ctx.Err(); err != nil {
+		return err
+	}
+	if h.injectStopped {
 		return errors.New("turn: run already finished")
 	}
 	select {
@@ -151,22 +151,27 @@ func (h *runHandle) Inject(ctx context.Context, msg turn.InjectMessage) error {
 	}
 }
 
-// closeInject closes the inject channel exactly once. Safe against a
-// concurrent Inject: the pump cancels the run context before closing, so
-// any in-flight Inject unblocks via ctx.Done and drops the mutex first.
+func (h *runHandle) stopInject() {
+	h.injectMu.Lock()
+	defer h.injectMu.Unlock()
+	h.injectStopped = true
+}
+
+// closeInject closes the inject channel exactly once after direct and session
+// senders have stopped.
 func (h *runHandle) closeInject() {
 	h.injectMu.Lock()
 	defer h.injectMu.Unlock()
 	if h.injectClosed {
 		return
 	}
+	h.injectStopped = true
 	h.injectClosed = true
 	close(h.inject)
 }
 
-// finish records the run's terminal state and releases the thread's slot. Runs
-// the last thing in the pump's defer stack, so nothing else in the run can still
-// be writing when the record is closed.
+// finish records the run's terminal state and releases the thread's slot after
+// direct injects stop but before the application closes the shared channel.
 //
 // Every outcome is terminal, including failure. A failed run is this invocation's
 // recorded answer, so a platform redelivery of the same external message is a
@@ -215,14 +220,13 @@ func (h *runHandle) AddOutboundAssets(refs []turn.OutboundAssetRef) {
 // pump forwards the application's chunk/error pair into the handle's channels,
 // wrapping each chunk as a turn.Event with a monotonically increasing Seq.
 func (h *runHandle) pump(cmd turn.StartTurnCommand, chunkCh <-chan StreamChunk, errCh <-chan error) {
-	// Deferred order (LIFO): detect external cancellation, cancel, close
-	// inject, release a failed claim, then close the channel pair — so by
-	// the time a consumer observes the closed channels, the idempotency
-	// claim of a failed/canceled run has already been released.
+	// Deferred order (LIFO): detect external cancellation, cancel, stop direct
+	// injects, finish the durable run, close inject, then close the channel pair.
 	defer close(h.events)
 	defer close(h.errs)
-	defer h.finish()
 	defer h.closeInject()
+	defer h.finish()
+	defer h.stopInject()
 	defer func() {
 		// A canceled run may look like a clean completion here: the
 		// application reacts to ctx cancellation by closing both channels.

--- a/internal/agent/runtime/session/admit.go
+++ b/internal/agent/runtime/session/admit.go
@@ -92,7 +92,8 @@ type Execution struct {
 	AbortCh chan<- struct{}
 	Cancel  context.CancelFunc
 	// InjectCh receives steering messages; nil means this caller does not
-	// support steering.
+	// support steering. The caller owns channel closure; the runtime only stops
+	// sending during teardown.
 	InjectCh chan<- turn.InjectMessage
 	// OwnershipCancel revokes the caller's execution context when the lease is
 	// lost, so a superseded owner stops producing output rather than racing the

--- a/internal/agent/runtime/session/control.go
+++ b/internal/agent/runtime/session/control.go
@@ -193,7 +193,7 @@ func (c *runControl) stopCommands() {
 	if c.lifecycleCancel != nil {
 		c.lifecycleCancel()
 	}
-	c.closeInject()
+	c.stopInject()
 }
 
 func (c *runControl) sendInject(ctx context.Context, message turn.InjectMessage) (bool, string) {
@@ -202,7 +202,7 @@ func (c *runControl) sendInject(ctx context.Context, message turn.InjectMessage)
 	}
 	c.injectMu.Lock()
 	defer c.injectMu.Unlock()
-	if c.injectClosed || c.injectCh == nil {
+	if c.injectStopped || c.injectCh == nil {
 		return false, "active runtime is not available"
 	}
 	select {
@@ -215,17 +215,16 @@ func (c *runControl) sendInject(ctx context.Context, message turn.InjectMessage)
 	}
 }
 
-func (c *runControl) closeInject() {
+func (c *runControl) stopInject() {
 	if c == nil {
 		return
 	}
 	c.injectMu.Lock()
 	defer c.injectMu.Unlock()
-	if c.injectClosed || c.injectCh == nil {
+	if c.injectStopped || c.injectCh == nil {
 		return
 	}
-	close(c.injectCh)
-	c.injectClosed = true
+	c.injectStopped = true
 }
 
 func (c *runControl) markReady() {

--- a/internal/agent/runtime/session/inject_ownership_test.go
+++ b/internal/agent/runtime/session/inject_ownership_test.go
@@ -1,0 +1,74 @@
+package sessionruntime
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/memohai/memoh/internal/agent/turn"
+)
+
+func TestFinishRunStopsInjectSendsWithoutClosingBorrowedChannel(t *testing.T) {
+	manager := testRuntimeManager(t, NewMemoryBackend(), "owner-inject-stop")
+
+	for i := range 100 {
+		sessionID := fmt.Sprintf("session-inject-stop-%d", i)
+		runID := fmt.Sprintf("stream-inject-stop-%d", i)
+		injectCh := make(chan turn.InjectMessage, 1)
+		if err := manager.StartRun(context.Background(), testBotID, sessionID, runID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
+			t.Fatalf("start run %d: %v", i, err)
+		}
+		ctrl := manager.localControlForScope(testBotID, sessionID, runID)
+		if ctrl == nil {
+			t.Fatalf("run %d has no local control", i)
+		}
+		start := make(chan struct{})
+		steerDone := make(chan struct{})
+		go func() {
+			<-start
+			_, _ = manager.Steer(context.Background(), testBotID, sessionID, runID, "race teardown")
+			close(steerDone)
+		}()
+		close(start)
+		if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, sessionID, runID), RunStatusCompleted, ""); err != nil {
+			t.Fatalf("finish run %d: %v", i, err)
+		}
+		receiveTestResult(t, "concurrent steer", steerDone)
+		requireInjectStopped(t, ctrl)
+		closeExecutionInjectChannel(t, injectCh)
+	}
+}
+
+func TestFinishRunAcceptsExecutionClosedInjectChannel(t *testing.T) {
+	manager := testRuntimeManager(t, NewMemoryBackend(), "owner-inject-closed")
+	injectCh := make(chan turn.InjectMessage, 1)
+	if err := manager.StartRun(context.Background(), testBotID, "session-inject-closed", "stream-inject-closed", make(chan struct{}, 1), func() {}, injectCh); err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	ctrl := manager.localControlForScope(testBotID, "session-inject-closed", "stream-inject-closed")
+	if ctrl == nil {
+		t.Fatal("run has no local control")
+	}
+	closeExecutionInjectChannel(t, injectCh)
+	if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, "session-inject-closed", "stream-inject-closed"), RunStatusCompleted, ""); err != nil {
+		t.Fatalf("finish run: %v", err)
+	}
+	requireInjectStopped(t, ctrl)
+}
+
+func requireInjectStopped(t *testing.T, ctrl *runControl) {
+	t.Helper()
+	if ok, _ := ctrl.sendInject(context.Background(), turn.InjectMessage{Text: "after teardown"}); ok {
+		t.Fatal("session runtime accepted inject after teardown")
+	}
+}
+
+func closeExecutionInjectChannel(t *testing.T, injectCh chan turn.InjectMessage) {
+	t.Helper()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("session runtime closed execution-owned inject channel: %v", recovered)
+		}
+	}()
+	close(injectCh)
+}

--- a/internal/agent/runtime/session/manager.go
+++ b/internal/agent/runtime/session/manager.go
@@ -97,7 +97,7 @@ type runControl struct {
 	lifecycleCancel   context.CancelFunc
 	injectCh          chan<- turn.InjectMessage
 	injectMu          sync.Mutex
-	injectClosed      bool
+	injectStopped     bool
 	converter         *chatview.UIMessageStreamConverter
 	leaseStop         func()
 	leaseDone         chan struct{}

--- a/internal/agent/runtime/session/manager_test.go
+++ b/internal/agent/runtime/session/manager_test.go
@@ -642,47 +642,6 @@ func TestActiveCommandContextAccountsForBackendTimeLatency(t *testing.T) {
 	}
 }
 
-func TestFinishRunSerializesInjectSendAndClose(t *testing.T) {
-	manager := testRuntimeManager(t, NewMemoryBackend(), "owner-inject-close")
-
-	for i := range 100 {
-		sessionID := fmt.Sprintf("session-inject-close-%d", i)
-		runID := fmt.Sprintf("stream-inject-close-%d", i)
-		injectCh := make(chan turn.InjectMessage, 1)
-		if err := manager.StartRun(context.Background(), testBotID, sessionID, runID, make(chan struct{}, 1), func() {}, injectCh); err != nil {
-			t.Fatalf("start run %d: %v", i, err)
-		}
-		start := make(chan struct{})
-		steerDone := make(chan struct{})
-		go func() {
-			<-start
-			_, _ = manager.Steer(context.Background(), testBotID, sessionID, runID, "race teardown")
-			close(steerDone)
-		}()
-		close(start)
-		if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, sessionID, runID), RunStatusCompleted, ""); err != nil {
-			t.Fatalf("finish run %d: %v", i, err)
-		}
-		receiveTestResult(t, "concurrent steer", steerDone)
-		waitInjectChannelClosed(t, injectCh)
-	}
-}
-
-func waitInjectChannelClosed(t *testing.T, injectCh <-chan turn.InjectMessage) {
-	t.Helper()
-	deadline := time.After(time.Second)
-	for {
-		select {
-		case _, ok := <-injectCh:
-			if !ok {
-				return
-			}
-		case <-deadline:
-			t.Fatal("runtime inject channel was not closed")
-		}
-	}
-}
-
 func waitRuntimeEvent(t *testing.T, events <-chan Event, pred func(Event) bool) Event {
 	t.Helper()
 	deadline := time.After(5 * time.Second)
@@ -2318,7 +2277,7 @@ func runRuntimeManagerCancelsExecutionAfterOwnershipLossContract(t *testing.T, s
 	case <-time.After(time.Second):
 		t.Fatal("ownership loss did not revoke terminal hook authority")
 	}
-	waitInjectChannelClosed(t, injectCh)
+	closeExecutionInjectChannel(t, injectCh)
 }
 
 func runRuntimeManagerKeepsHookAuthorityForUserAbort(t *testing.T, suite distributedRuntimeBackendContractSuite) {
@@ -3375,7 +3334,7 @@ func runRuntimeManagerCancelsActiveResponseOnClose(t *testing.T, suite distribut
 	if !result.handled || !errors.Is(result.err, context.Canceled) {
 		t.Fatalf("dispatch after close = handled:%v err:%v, want handler cancellation", result.handled, result.err)
 	}
-	waitInjectChannelClosed(t, injectCh)
+	closeExecutionInjectChannel(t, injectCh)
 }
 
 func runRuntimeManagerAbortCommandDoesNotRepublishStaleSelfReference(t *testing.T, suite distributedRuntimeBackendContractSuite) {


### PR DESCRIPTION
## Summary

- keep `InjectCh` closure ownership with the application run handle that creates it
- make the session runtime stop new inject sends without closing the borrowed channel
- order teardown as direct-inject stop → durable finish/session-send stop → application channel close
- add focused ownership and concurrent-teardown regressions

## Root cause

The durable finisher wiring merged in #865 brought two pre-existing cleanup paths together. `runHandle.closeInject` and `runControl.closeInject` each had an independent guard but closed the same channel. A completed web-message run closed it in the application pump, then `FinishRun` closed it again through session teardown, causing `panic: close of closed channel` and terminating the server.

The independent guards also left a send-after-close window for a concurrent steer. The revised ordering first rejects new direct injections, lets `FinishRun` serialize and stop the session sender, and only then lets the application owner close the channel.

## Impact

Completing `POST /bots/{id}/web/messages` through the durable finisher no longer double-closes the inject channel. Late direct injections are rejected, while an in-flight session sender can quiesce before physical closure.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- go test ./internal/agent/application ./internal/agent/runtime/session -count=1`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- go test -race ./internal/agent/application ./internal/agent/runtime/session -count=1`
- focused ownership regressions in both packages with `-count=100`
- final Standards, Spec, and adversarial reviews: no remaining confirmed findings