### PR TITLE
fix(web): isolate workspace state per browser tab

### DIFF
--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -6,19 +6,27 @@ export interface AuthSessionClearedDetail {
 
 export const AUTH_SESSION_CLEARED_EVENT = 'memoh:auth-session-cleared'
 
+// Per-Tab focus/layout state now lives in sessionStorage (see
+// utils/tab-scoped-storage.ts), with a localStorage cold-start seed under the
+// SAME key name. So logout must clear BOTH areas for these keys, or the next
+// account on this tab inherits the previous user's session focus / layout.
+// `chat-input-drafts` and `pinned-bot-ids` remain localStorage-only.
 const USER_SCOPED_STORAGE_KEYS = [
   'chat-bot-id',
   'chat-session-id',
+  'chat-explicit-selection',
+  'chat-draft-intent',
   'chat-input-drafts',
   'pinned-bot-ids',
-  'workspace-tabs',
+  // Was 'workspace-tabs' — a long-dead key. The live dockview layout key is
+  // 'workspace-layout'; logout never actually cleared it before this fix.
+  'workspace-layout',
 ]
 
 export function clearPersistedUserScopedState() {
-  if (typeof localStorage === 'undefined') return
-
   for (const key of USER_SCOPED_STORAGE_KEYS) {
-    localStorage.removeItem(key)
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(key)
+    if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(key)
   }
 }
 

--- a/apps/web/src/pages/home/components/chat-workspace.test.ts
+++ b/apps/web/src/pages/home/components/chat-workspace.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { createApp, defineComponent, h, nextTick, onMounted, ref } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const dock = {
+  panels: [
+    { id: 'file:/data/AGENTS.md' },
+    { id: 'preview:/data/AGENTS.md' },
+  ],
+  layout: vi.fn(),
+}
+const api = ref<typeof dock | null>(null)
+const workspaceStore = {
+  api,
+  panelDragging: false,
+  registerApi: vi.fn((nextApi: typeof dock) => {
+    api.value = nextApi
+  }),
+  requestCloseTab: vi.fn(),
+  requestCloseTabs: vi.fn(),
+  releaseApi: vi.fn(),
+  openSessionChat: vi.fn(),
+  openDraftChat: vi.fn(),
+}
+
+vi.mock('dockview-vue', () => ({
+  DockviewVue: defineComponent({
+    emits: ['ready'],
+    setup(_, { emit }) {
+      onMounted(() => emit('ready', { api: dock }))
+      return () => h('div')
+    },
+  }),
+}))
+
+vi.mock('@/store/workspace-tabs', () => ({
+  useWorkspaceTabsStore: () => workspaceStore,
+}))
+
+vi.mock('@/store/chat-list', () => ({
+  useChatStore: () => ({
+    currentBotId: 'bot-1',
+    sessionId: null,
+    hasExplicitSessionSelection: false,
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('./dockview/panel-chat.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/panel-file.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/panel-preview.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/panel-asset.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/panel-terminal.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/panel-browser.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/panel-display.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/panel-schedule.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/workspace-watermark.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/workspace-tab-host.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/terminal-tab.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/group-actions.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/header-add-actions.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/prefix-header-actions.vue', () => ({ default: { render: () => null } }))
+vi.mock('./dockview/tab-close-confirm.vue', () => ({ default: { render: () => null } }))
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+}
+
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  value: ResizeObserverMock,
+  configurable: true,
+})
+
+describe('chat workspace initialization', () => {
+  let root: HTMLElement | null = null
+
+  afterEach(() => {
+    workspaceStore.registerApi.mockClear()
+    workspaceStore.openSessionChat.mockClear()
+    workspaceStore.openDraftChat.mockClear()
+    workspaceStore.releaseApi.mockClear()
+    dock.layout.mockClear()
+    api.value = null
+    root?.remove()
+    root = null
+  })
+
+  it('leaves a restored non-empty workspace unchanged when it has no chat panel', async () => {
+    // The repository's test tsconfig does not load Vue's ambient module shim.
+    // @ts-expect-error Vitest's Vue plugin resolves this SFC at runtime.
+    const ChatWorkspace = (await import('./chat-workspace.vue')).default
+    root = document.createElement('div')
+    Object.defineProperties(root, {
+      clientWidth: { value: 1200 },
+      clientHeight: { value: 800 },
+    })
+    document.body.appendChild(root)
+
+    const app = createApp(ChatWorkspace)
+    app.mount(root)
+    await nextTick()
+
+    expect(workspaceStore.registerApi).toHaveBeenCalledWith(dock)
+    expect(workspaceStore.openSessionChat).not.toHaveBeenCalled()
+    expect(workspaceStore.openDraftChat).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+})

--- a/apps/web/src/pages/home/components/chat-workspace.vue
+++ b/apps/web/src/pages/home/components/chat-workspace.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script setup lang="ts">
-import { inject, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue'
+import { inject, onBeforeUnmount, onMounted, provide, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import {
@@ -40,7 +40,6 @@ import {
 import 'dockview-vue/dist/styles/dockview.css'
 import '@/styles/dockview-theme.css'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
-import { useChatStore } from '@/store/chat-list'
 import { openInFileManagerKey, openAssetPreviewKey } from '../composables/useFileManagerProvider'
 import { DesktopShellKey } from '@/lib/desktop-shell'
 import PanelChat from './dockview/panel-chat.vue'
@@ -62,8 +61,6 @@ import TabCloseConfirm from './dockview/tab-close-confirm.vue'
 const { t } = useI18n()
 const store = useWorkspaceTabsStore()
 const { api } = storeToRefs(store)
-const chatStore = useChatStore()
-const { currentBotId } = storeToRefs(chatStore)
 
 // dockview's own auto-resize is disabled at construction (:disable-auto-resizing);
 // we drive layout from this ResizeObserver instead. The dock is a flex-1 sibling
@@ -177,36 +174,12 @@ function getTabContextMenuItems({ panel, group }: GetTabContextMenuItemsParams):
 }
 
 function onReady(event: DockviewReadyEvent) {
+  // registerApi owns restoration and the only empty-dock fallback. Keeping a
+  // second "no chat panel" fallback here rewrites a valid file/preview-only
+  // workspace by opening New Session into its ephemeral slot.
   store.registerApi(event.api)
   applyLayout()
-  ensureChatPanel()
 }
-
-// Bot ready/switch: the store restores the persisted layout; make sure at least a
-// draft chat tab exists afterwards (all chat tabs may have been closed in a past
-// session). Per-tab titles are kept in sync by the store (syncChatTitles).
-function ensureChatPanel() {
-  const dock = api.value
-  if (!currentBotId.value || !dock) return
-  const hasChat = dock.panels.some(
-    p => p.id === 'chat' || p.id.startsWith('chat:') || p.id.startsWith('chat~'),
-  )
-  if (hasChat) return
-  // Open the active session's tab if one is already selected (e.g. initialize or an
-  // ACP start set it before the dock mounted); otherwise a fresh draft.
-  const sid = (chatStore.sessionId ?? '').trim()
-  if (sid) {
-    store.openSessionChat({
-      sessionId: sid,
-      explicitSelection: chatStore.hasExplicitSessionSelection === true,
-    })
-  }
-  else store.openDraftChat({ title: t('chat.newSession'), explicitSelection: false })
-}
-
-watch(currentBotId, (bid) => {
-  if (bid && api.value) ensureChatPanel()
-})
 
 const FILE_MANAGER_ROOT = '/data'
 

--- a/apps/web/src/store/chat-selection.test.ts
+++ b/apps/web/src/store/chat-selection.test.ts
@@ -3,22 +3,29 @@ import { createPinia, setActivePinia } from 'pinia'
 
 describe('chat-selection store', () => {
   let storage: Map<string, string>
+  let session: Map<string, string>
 
   beforeEach(() => {
     vi.resetModules()
     storage = new Map<string, string>()
-    const localStorageMock = {
-      getItem: (key: string) => storage.get(key) ?? null,
-      setItem: (key: string, value: string) => storage.set(key, value),
-      removeItem: (key: string) => storage.delete(key),
-      clear: () => storage.clear(),
-    }
+    session = new Map<string, string>()
+    const makeMock = (map: Map<string, string>) => ({
+      getItem: (key: string) => map.get(key) ?? null,
+      setItem: (key: string, value: string) => map.set(key, value),
+      removeItem: (key: string) => map.delete(key),
+      clear: () => map.clear(),
+    })
+    const localStorageMock = makeMock(storage)
+    // Per-Tab focus (bot/session) now reads from sessionStorage; seed here.
+    const sessionStorageMock = makeMock(session)
     class StorageMock {}
     vi.stubGlobal('Storage', StorageMock)
     vi.stubGlobal('localStorage', localStorageMock)
+    vi.stubGlobal('sessionStorage', sessionStorageMock)
     vi.stubGlobal('document', {})
     vi.stubGlobal('window', {
       localStorage: localStorageMock,
+      sessionStorage: sessionStorageMock,
       Storage: StorageMock,
       document: {},
       addEventListener: vi.fn(),
@@ -33,7 +40,7 @@ describe('chat-selection store', () => {
 
   it('does not migrate a legacy stored session id into an explicit selection', async () => {
     const { useChatSelectionStore } = await import('./chat-selection')
-    localStorage.setItem('chat-session-id', 'history-session-1')
+    sessionStorage.setItem('chat-session-id', 'history-session-1')
 
     const selection = useChatSelectionStore()
 
@@ -43,8 +50,8 @@ describe('chat-selection store', () => {
 
   it('preserves an existing explicit selection flag', async () => {
     const { useChatSelectionStore } = await import('./chat-selection')
-    localStorage.setItem('chat-session-id', 'manual-session-1')
-    localStorage.setItem('chat-explicit-selection', 'true')
+    sessionStorage.setItem('chat-session-id', 'manual-session-1')
+    sessionStorage.setItem('chat-explicit-selection', 'true')
 
     const selection = useChatSelectionStore()
 

--- a/apps/web/src/store/chat-selection.ts
+++ b/apps/web/src/store/chat-selection.ts
@@ -1,19 +1,24 @@
 import { defineStore } from 'pinia'
-import { useStorage } from '@vueuse/core'
+import { useTabScopedStorage } from '@/utils/tab-scoped-storage'
 
 export const useChatSelectionStore = defineStore('chat-selection', () => {
-  const currentBotId = useStorage<string | null>('chat-bot-id', null)
-  const sessionId = useStorage<string | null>('chat-session-id', null)
+  // Per-Tab: which bot/session THIS browser tab is focused on. Was localStorage,
+  // which broadcast every selection to every other tab (the cross-tab session
+  // hijack). `currentBotId` keeps a cold-start seed so reopening defaults to the
+  // last bot; the session focus is not seeded — it follows the restored layout's
+  // active panel, so a stale seed would fight that restore.
+  const currentBotId = useTabScopedStorage<string | null>('chat-bot-id', null, { seed: true })
+  const sessionId = useTabScopedStorage<string | null>('chat-session-id', null)
   // Persist the user's intent separately from the raw session id. `sessionId`
   // can be written by initialize() when it auto-picks the latest conversation;
   // default ACP startup must be allowed to override that. A manually selected
   // or newly-created session is different and should survive reloads.
-  const explicitSelection = useStorage<boolean>('chat-explicit-selection', false)
+  const explicitSelection = useTabScopedStorage<boolean>('chat-explicit-selection', false)
   // Did the user intentionally sit on the draft "New Session" page (vs. just never
   // having selected anything)? A null sessionId is ambiguous on reload: this flag
   // lets initialize keep the draft instead of force-opening a random session, while
   // a fresh/never-selected load (flag false) still auto-opens the latest session.
-  const draftIntent = useStorage<boolean>('chat-draft-intent', false)
+  const draftIntent = useTabScopedStorage<boolean>('chat-draft-intent', false)
 
   function setBot(botId: string | null) {
     currentBotId.value = (botId ?? '').trim() || null

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -35,14 +35,24 @@ vi.hoisted(() => {
 
   const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>()
   const storage = new MemoryStorage()
+  // Layout/selection now live in sessionStorage (per-Tab), so the store's
+  // restore path reads it, not localStorage. A separate instance mirrors the
+  // real browser split (two distinct areas under the same key names).
+  const session = new MemoryStorage()
   Object.defineProperty(globalThis, 'localStorage', {
     value: storage,
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    value: session,
     configurable: true,
     writable: true,
   })
   Object.defineProperty(globalThis, 'window', {
     value: {
       localStorage: storage,
+      sessionStorage: session,
       addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
         const set = listeners.get(type) ?? new Set<EventListenerOrEventListenerObject>()
         set.add(listener)
@@ -546,6 +556,8 @@ describe('workspace layout store', () => {
   beforeEach(() => {
     localStorage.clear()
     window.localStorage.clear()
+    sessionStorage.clear()
+    window.sessionStorage.clear()
     chatStoreMock.createNewSession.mockClear()
     chatStoreMock.focusChatView.mockClear()
     chatStoreMock.selectSession.mockClear()
@@ -920,6 +932,110 @@ describe('workspace layout store', () => {
     expect(chatStoreMock.selectDraft).not.toHaveBeenCalled()
     expect(chatStoreMock.selectSession).toHaveBeenCalledWith('history-session-1')
     expect(dock.activePanel?.params.sessionId).toBe('history-session-1')
+  })
+
+  it('keeps a restored session chat without adding a draft when selection is empty', async () => {
+    const restoredLayout = persistedLayoutWithPanel(
+      'chat:bot-1:1',
+      'chat',
+      { sessionId: 'session-1', explicitSelection: true },
+      'Session 1',
+    )
+    localStorage.setItem('workspace-layout', JSON.stringify({
+      'bot-1': {
+        layout: restoredLayout,
+        ephemeralIds: [],
+      },
+    }))
+
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    await nextTick()
+
+    expect(dock.panels).toHaveLength(1)
+    expect(dock.activePanel?.params.sessionId).toBe('session-1')
+    expect(dock.panels.some(panel => panel.component === 'chat' && panel.params.sessionId == null)).toBe(false)
+    expect(chatStoreMock.focusChatView).toHaveBeenCalledWith('chat:bot-1:1')
+  })
+
+  it('does not open a chat tab when initialize auto-picks a session over a restored file/preview workspace', async () => {
+    // Cold-start seed: File + Preview only (the user's Tab A layout). A new
+    // browser tab must restore that dock as-is — initialize()'s non-explicit
+    // auto-pick of the latest Untitled Session must NOT punch chat tabs in.
+    localStorage.setItem('workspace-layout', JSON.stringify({
+      'bot-1': {
+        layout: {
+          panels: {
+            'file:/data/AGENTS.md': {
+              id: 'file:/data/AGENTS.md',
+              contentComponent: 'file',
+              title: 'AGENTS.md',
+              params: { filePath: '/data/AGENTS.md' },
+            },
+            'preview:/data/AGENTS.md': {
+              id: 'preview:/data/AGENTS.md',
+              contentComponent: 'preview',
+              title: 'Preview: AGENTS.md',
+              params: { filePath: '/data/AGENTS.md' },
+            },
+          },
+        },
+        ephemeralIds: ['file:/data/AGENTS.md', 'preview:/data/AGENTS.md'],
+      },
+    }))
+
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    await nextTick()
+
+    expect(dock.panels.map(panel => panel.component).sort()).toEqual(['file', 'preview'])
+    expect(dock.panels.some(panel => panel.component === 'chat')).toBe(false)
+
+    // Simulate initialize() finishing: it writes the latest history item into
+    // selection with explicitSelection=false (see bootstrap.ts).
+    chatStoreMock.sessionId = 'untitled-1'
+    chatStoreMock.hasExplicitSessionSelection = false
+    chatStoreMock.loadingChats = false
+    chatStoreMock.sessions.push({ id: 'untitled-1', title: '' })
+    useChatSelectionStore().setSession('untitled-1', { explicitSelection: false })
+    await nextTick()
+    await flushDraftChatFallback()
+
+    expect(dock.panels.map(panel => panel.component).sort()).toEqual(['file', 'preview'])
+    expect(dock.panels.some(panel => panel.component === 'chat')).toBe(false)
+  })
+
+  it('still opens a chat tab on explicit session selection after a file/preview restore', async () => {
+    localStorage.setItem('workspace-layout', JSON.stringify({
+      'bot-1': {
+        layout: {
+          panels: {
+            'file:/data/AGENTS.md': {
+              id: 'file:/data/AGENTS.md',
+              contentComponent: 'file',
+              title: 'AGENTS.md',
+              params: { filePath: '/data/AGENTS.md' },
+            },
+          },
+        },
+        ephemeralIds: [],
+      },
+    }))
+
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    await nextTick()
+
+    chatStoreMock.sessionId = 'picked-1'
+    chatStoreMock.hasExplicitSessionSelection = true
+    chatStoreMock.sessions.push({ id: 'picked-1', title: 'Picked' })
+    useChatSelectionStore().setSession('picked-1', { explicitSelection: true })
+    await nextTick()
+
+    expect(dock.panels.some(panel => panel.component === 'chat' && panel.params.sessionId === 'picked-1')).toBe(true)
   })
 
   it('does not promote a restored auto-selected native session into explicit selection while chats load', async () => {
@@ -1298,6 +1414,93 @@ describe('workspace layout store', () => {
     const chat = dock.panels[0]!
     expect(chat.component).toBe('chat')
     expect(chat.params.sessionId ?? null).toBeNull()
+  })
+
+  it('opens a draft — not an auto-picked Untitled session — after closing a restored file/preview workspace', async () => {
+    // Cold-start tab: layout seeded from localStorage, initialize() wrote a
+    // non-explicit sessionId we refused to open. Closing the last file must
+    // refill New Session, not that stale Untitled pick.
+    localStorage.setItem('workspace-layout', JSON.stringify({
+      'bot-1': {
+        layout: {
+          panels: {
+            'file:/data/AGENTS.md': {
+              id: 'file:/data/AGENTS.md',
+              contentComponent: 'file',
+              title: 'AGENTS.md',
+              params: { filePath: '/data/AGENTS.md' },
+            },
+            'preview:/data/AGENTS.md': {
+              id: 'preview:/data/AGENTS.md',
+              contentComponent: 'preview',
+              title: 'Preview: AGENTS.md',
+              params: { filePath: '/data/AGENTS.md' },
+            },
+          },
+        },
+        ephemeralIds: ['file:/data/AGENTS.md', 'preview:/data/AGENTS.md'],
+      },
+    }))
+
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    await nextTick()
+
+    chatStoreMock.sessionId = 'untitled-stale'
+    chatStoreMock.hasExplicitSessionSelection = false
+    chatStoreMock.sessions.push({ id: 'untitled-stale', title: '' })
+    useChatSelectionStore().setSession('untitled-stale', { explicitSelection: false })
+    await nextTick()
+
+    expect(dock.panels.some(panel => panel.component === 'chat')).toBe(false)
+
+    store.closeTab('preview:/data/AGENTS.md')
+    store.closeTab('file:/data/AGENTS.md')
+    await flushDraftChatFallback()
+
+    expect(dock.panels).toHaveLength(1)
+    const chat = dock.panels[0]!
+    expect(chat.component).toBe('chat')
+    expect(chat.params.sessionId ?? null).toBeNull()
+    expect(chat.title).toBe('New Session')
+  })
+
+  it('refills an explicitly selected session when the last non-chat tab closes', async () => {
+    localStorage.setItem('workspace-layout', JSON.stringify({
+      'bot-1': {
+        layout: {
+          panels: {
+            'file:/data/AGENTS.md': {
+              id: 'file:/data/AGENTS.md',
+              contentComponent: 'file',
+              title: 'AGENTS.md',
+              params: { filePath: '/data/AGENTS.md' },
+            },
+          },
+        },
+        ephemeralIds: [],
+      },
+    }))
+
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    await nextTick()
+
+    // Drive chatStore directly: an already-explicit selection whose chat tab is
+    // not open (e.g. replaced by a file). Closing the file should restore it.
+    chatStoreMock.sessionId = 'explicit-1'
+    chatStoreMock.hasExplicitSessionSelection = true
+    chatStoreMock.sessions.push({ id: 'explicit-1', title: 'Kept Session' })
+    expect(dock.panels.some(panel => panel.component === 'chat')).toBe(false)
+
+    store.closeTab('file:/data/AGENTS.md')
+    await flushDraftChatFallback()
+
+    const chat = dock.panels.find(panel => panel.component === 'chat')
+    expect(chat?.params.sessionId).toBe('explicit-1')
+    expect(chat?.title).toBe('Kept Session')
   })
 
   it('opens a draft chat when switching to a bot without a saved layout', async () => {

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -957,6 +957,49 @@ describe('workspace layout store', () => {
     expect(dock.activePanel?.params.sessionId).toBe('session-1')
     expect(dock.panels.some(panel => panel.component === 'chat' && panel.params.sessionId == null)).toBe(false)
     expect(chatStoreMock.focusChatView).toHaveBeenCalledWith('chat:bot-1:1')
+    // Recents follows chat-session-id — pull it onto the restored panel.
+    expect(chatStoreMock.selectSession).toHaveBeenCalledWith('session-1', { explicitSelection: false })
+    expect(useChatSelectionStore().sessionId).toBe('session-1')
+  })
+
+  it('reconciles an auto-picked session to the restored chat panel without opening another tab', async () => {
+    const restoredLayout = persistedLayoutWithPanel(
+      'chat:bot-1:1',
+      'chat',
+      { sessionId: 'restored-session', explicitSelection: true },
+      'Restored',
+    )
+    localStorage.setItem('workspace-layout', JSON.stringify({
+      'bot-1': {
+        layout: restoredLayout,
+        ephemeralIds: [],
+      },
+    }))
+
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    await nextTick()
+    chatStoreMock.selectSession.mockClear()
+
+    // initialize() auto-picks a newer Untitled while the dock still shows the
+    // restored conversation — selection must snap back to the open panel.
+    chatStoreMock.sessionId = 'untitled-latest'
+    chatStoreMock.hasExplicitSessionSelection = false
+    chatStoreMock.loadingChats = false
+    chatStoreMock.sessions.push(
+      { id: 'untitled-latest', title: '' },
+      { id: 'restored-session', title: 'Restored' },
+    )
+    useChatSelectionStore().setSession('untitled-latest', { explicitSelection: false })
+    await nextTick()
+    await flushDraftChatFallback()
+
+    expect(dock.panels).toHaveLength(1)
+    expect(dock.activePanel?.params.sessionId).toBe('restored-session')
+    expect(chatStoreMock.selectSession).toHaveBeenCalledWith('restored-session', { explicitSelection: false })
+    expect(useChatSelectionStore().sessionId).toBe('restored-session')
+    expect(chatStoreMock.hasExplicitSessionSelection).toBe(false)
   })
 
   it('does not open a chat tab when initialize auto-picks a session over a restored file/preview workspace', async () => {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -1144,8 +1144,13 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
         return
       }
       // Auto-picked / cold-start selection must not add a chat tab on top of a
-      // restored File/Preview (or any non-empty) workspace.
-      if (blockNonExplicitOpen) return
+      // restored File/Preview (or any non-empty) workspace. If the restored
+      // active panel is already a different chat, pull selection onto it so
+      // Recents highlights the conversation on screen — not the auto-pick.
+      if (blockNonExplicitOpen) {
+        adoptActiveRestoredChatSelection(activeSession, active?.id)
+        return
+      }
       openSessionChat({ sessionId: sid, groupId, explicitSelection })
       return
     }
@@ -1162,12 +1167,21 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       // A fresh top-level tab has no separately-seeded chat selection, but its
       // restored workspace can already contain the chat the user was viewing.
       // Keep that panel instead of interpreting the empty selection as a request
-      // for a second draft. Later explicit draft/ACP transitions still use the
-      // normal path below and may replace it deliberately.
-      chatStore.focusChatView(active.id)
+      // for a second draft. Align the global selection to the preserved panel
+      // (non-explicit) so the Recents highlight matches the open conversation.
+      adoptActiveRestoredChatSelection(activeSession, active.id)
       return
     }
     openDraftChat({ groupId, explicitSelection })
+  }
+
+  function adoptActiveRestoredChatSelection(sessionId: string | null, panelId?: string) {
+    if (!sessionId || isDeletedSessionForCurrentBot(sessionId)) return
+    if (panelId) chatStore.focusChatView(panelId)
+    // Already pointing at the preserved panel — leave explicitness alone.
+    if ((chatStore.sessionId ?? '').trim() === sessionId) return
+    // Non-explicit: layout ownership, not a user click.
+    selectChatSession(sessionId, false)
   }
 
   function syncDraftTargetFromState() {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -1,6 +1,7 @@
 import { defineStore, storeToRefs } from 'pinia'
 import { computed, nextTick, ref, shallowRef, watch } from 'vue'
-import { useLocalStorage, useStorage } from '@vueuse/core'
+import { useLocalStorage } from '@vueuse/core'
+import { useTabScopedStorage } from '@/utils/tab-scoped-storage'
 import type { DockviewApi, DockviewGroupPanel, SerializedDockview } from 'dockview-vue'
 import { useChatStore } from '@/store/chat-list'
 import { useChatSelectionStore } from '@/store/chat-selection'
@@ -42,7 +43,6 @@ const DEFAULT_CHAT_TITLE = 'New Session'
 // first splits off below the chat. ~1/3 mirrors VS Code's editor:panel ratio
 // (≈554:269) — enough room to work in without burying the conversation.
 const TERMINAL_PANEL_HEIGHT_RATIO = 1 / 3
-const workspaceLayoutStorage = typeof localStorage !== 'undefined' ? localStorage : undefined
 
 export type WorkspacePanelComponent = 'chat' | 'file' | 'preview' | 'asset' | 'terminal' | 'browser' | 'display' | 'schedule'
 
@@ -128,7 +128,13 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     localStorage.removeItem('workspace-tabs')
     localStorage.removeItem('workspace-panes')
   }
-  const storage = useStorage<WorkspaceLayoutStorage>('workspace-layout', {}, workspaceLayoutStorage)
+  // Per-Tab: the dockview layout is the full structure of THIS browser tab's
+  // panels — two tabs are two windows and must lay out independently. Was
+  // localStorage, which shared one layout across all tabs and broadcast every
+  // change, so tab A's split reflowed tab B. sessionStorage isolates it; the
+  // localStorage cold-start seed (same key) restores "reopen where I left off"
+  // after every tab closes, and migrates an existing localStorage layout for free.
+  const storage = useTabScopedStorage<WorkspaceLayoutStorage>('workspace-layout', {}, { seed: true })
 
   // ---- dockview wiring -----------------------------------------------------
 
@@ -173,6 +179,14 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   // reordered or stacked. Reset on drag end.
   let dragSourceTerminal = false
   let draftChatQueued = false
+  // After restoring a NON-empty dock, ignore initialize()'s auto-picked
+  // sessionId (and other non-explicit selection churn). Otherwise a File /
+  // Preview workspace gets an extra Untitled/New Session tab punched in by
+  // selection watchers — the cold-start hijack this store exists to prevent.
+  // Explicit user actions (sidebar click, New Session, /new) either call the
+  // public open* APIs directly or set hasExplicitSessionSelection, both of
+  // which bypass this guard. Cleared when the dock is empty again.
+  let suppressSelectionDockMutations = false
   const reconcilingDeletedChatPanelIds = new Set<string>()
   const deletedSessionIdsByBot = new Map<string, Set<string>>()
   let suppressReconcileActivation = false
@@ -387,9 +401,14 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       suppressPersist = false
     }
     if (repairedEmptyTitles && !dockEmptyAfterRestore) persistLayout()
+    // Non-empty restore is authoritative for this tab's panels. Empty restore
+    // still needs the draft fallback, and may accept initialize()'s auto-pick
+    // (repointing that draft). Same product rule either way: never invent tabs
+    // on top of a restored workspace.
+    suppressSelectionDockMutations = !dockEmptyAfterRestore
     if (dockEmptyAfterRestore) ensureDraftChatPanel()
     syncDraftChatExplicitSelection()
-    syncRestoredChatSelection()
+    syncRestoredChatSelection({ preserveRestoredChat: true })
   }
 
   function domListener<K extends keyof DocumentEventMap>(
@@ -638,6 +657,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     panelDragging.value = false
     dragSourceTerminal = false
     draftChatQueued = false
+    suppressSelectionDockMutations = false
     reconcilingDeletedChatPanelIds.clear()
     releaseDeletedChatActivationNow()
   }
@@ -1027,6 +1047,9 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     if (!dock) return
     const bid = (currentBotId.value ?? '').trim()
     if (!bid) return
+    // Public entry (sidebar New Session, /new, empty-dock fallback): the user
+    // asked for a draft, so stop shielding the restored layout from mutations.
+    suppressSelectionDockMutations = false
     const draftCandidates = opts?.groupId
       ? dock.getGroup(opts.groupId)?.panels ?? []
       : dock.panels
@@ -1089,11 +1112,16 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     }
   }
 
-  function syncRestoredChatSelection() {
+  function syncRestoredChatSelection(options?: { preserveRestoredChat?: boolean }) {
     const dock = api.value
     const sid = (chatStore.sessionId ?? '').trim()
     if (!dock) return
     const explicitSelection = chatStore.hasExplicitSessionSelection === true
+    // Cold-start guard: non-explicit selection must not invent dock tabs after
+    // a non-empty restore. Explicit clicks bypass it. Separate from
+    // preserveRestoredChat, which only covers the empty-selection + restored
+    // real-session case below.
+    const blockNonExplicitOpen = suppressSelectionDockMutations && !explicitSelection
     const active = dock.activePanel
     const activeIsChat = !!active && panelComponentOf(active.id) === 'chat'
     const activeSession = activeIsChat ? panelSessionId(active) : null
@@ -1109,6 +1137,15 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
         chatStore.focusChatView(active.id)
         return
       }
+      const existing = chatPanelForSession(sid)
+      if (existing) {
+        setNextChatActivationExplicit(existing.id, explicitSelection)
+        focusPanel(existing)
+        return
+      }
+      // Auto-picked / cold-start selection must not add a chat tab on top of a
+      // restored File/Preview (or any non-empty) workspace.
+      if (blockNonExplicitOpen) return
       openSessionChat({ sessionId: sid, groupId, explicitSelection })
       return
     }
@@ -1121,6 +1158,15 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       chatStore.selectDraft({ explicitSelection })
       return
     }
+    if (options?.preserveRestoredChat || blockNonExplicitOpen) {
+      // A fresh top-level tab has no separately-seeded chat selection, but its
+      // restored workspace can already contain the chat the user was viewing.
+      // Keep that panel instead of interpreting the empty selection as a request
+      // for a second draft. Later explicit draft/ACP transitions still use the
+      // normal path below and may replace it deliberately.
+      chatStore.focusChatView(active.id)
+      return
+    }
     openDraftChat({ groupId, explicitSelection })
   }
 
@@ -1129,6 +1175,10 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     if (!dock || suppressPersist) return
     if ((selection.sessionId ?? '').trim()) return
     if (chatStore.hasExplicitSessionSelection !== true && !chatStore.pendingACPSessionInput) return
+    // Explicit empty-composer / ACP draft staging is a real request to show a
+    // draft, even after a non-empty restore — clear the cold-start guard so
+    // syncRestoredChatSelection can open one.
+    if (suppressSelectionDockMutations) suppressSelectionDockMutations = false
     syncRestoredChatSelection()
   }
 
@@ -1223,16 +1273,22 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       const latestDock = api.value
       if (!latestDock || suppressPersist || latestDock.panels.length > 0) return
       if (!(currentBotId.value ?? '').trim()) return
-      // The active session's tab if one is selected, else a fresh draft (its
-      // activation resets the global view via selectDraft).
+      // Dock is empty again — cold-start shielding no longer applies.
+      suppressSelectionDockMutations = false
+      // Only an EXPLICIT selection may refill as that session. initialize()'s
+      // auto-pick leaves a non-explicit sessionId even when we refused to open
+      // its tab over a File/Preview restore; honoring it here would surface a
+      // random Untitled Session the moment the user closes the last file tab.
+      // Live tabs that already selected a session explicitly keep that refill.
       const sid = (chatStore.sessionId ?? '').trim()
-      if (sid && !isDeletedSessionForCurrentBot(sid)) {
+      const explicitSelection = chatStore.hasExplicitSessionSelection === true
+      if (sid && explicitSelection && !isDeletedSessionForCurrentBot(sid)) {
         openSessionChat({
           sessionId: sid,
-          explicitSelection: chatStore.hasExplicitSessionSelection === true,
+          explicitSelection: true,
         })
       } else {
-        openDraftChat({ explicitSelection: chatStore.hasExplicitSessionSelection === true })
+        openDraftChat({ explicitSelection })
       }
     })
   }
@@ -2104,16 +2160,21 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     }
     if (isDeletedSessionForCurrentBot(trimmed)) return
     const existing = chatPanelForSession(trimmed)
+    const explicitSelection = chatStore.hasExplicitSessionSelection === true
     if (existing) {
-      setNextChatActivationExplicit(existing.id, chatStore.hasExplicitSessionSelection === true)
+      setNextChatActivationExplicit(existing.id, explicitSelection)
       focusPanel(existing)
       return
     }
+    // initialize() auto-picks the latest history item with explicitSelection
+    // false. That must not open a chat tab over a restored File/Preview layout.
+    // Sidebar clicks go through openSessionChat directly (or set explicit).
+    if (suppressSelectionDockMutations && !explicitSelection) return
     // No tab yet: open one. If the group's ephemeral slot is a draft, this
     // repoints it in place (no stray draft tab); otherwise it adds a chat tab.
     openSessionChat({
       sessionId: trimmed,
-      explicitSelection: chatStore.hasExplicitSessionSelection === true,
+      explicitSelection,
     })
   })
 
@@ -2149,7 +2210,12 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     () => [chatStore.loadingChats, chatStore.sessions.length, currentBotId.value] as const,
     () => {
       if (chatStore.loadingChats) return
-      syncRestoredChatSelection()
+      // After chats load, reconcile selection ↔ dock. suppressSelectionDockMutations
+      // inside syncRestoredChatSelection still blocks auto-picked opens on a
+      // restored non-empty workspace.
+      syncRestoredChatSelection({
+        preserveRestoredChat: suppressSelectionDockMutations,
+      })
     },
   )
 

--- a/apps/web/src/utils/tab-scoped-storage.test.ts
+++ b/apps/web/src/utils/tab-scoped-storage.test.ts
@@ -58,4 +58,16 @@ describe('useTabScopedStorage', () => {
     const r = useTabScopedStorage<string>('k', 'def')
     expect(r.value).toBe('def')
   })
+
+  it('falls back to defaults when seeding into sessionStorage throws', () => {
+    ls.set('k', 'seed')
+    vi.stubGlobal('sessionStorage', {
+      ...mock(ss),
+      setItem: () => {
+        throw new DOMException('QuotaExceededError')
+      },
+    })
+    const r = useTabScopedStorage<string>('k', 'def', { seed: true })
+    expect(r.value).toBe('def')
+  })
 })

--- a/apps/web/src/utils/tab-scoped-storage.test.ts
+++ b/apps/web/src/utils/tab-scoped-storage.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useTabScopedStorage } from './tab-scoped-storage'
+
+// Verifies the two non-obvious invariants of the seed:
+//   1. cold start (empty sessionStorage) reads the localStorage seed ONCE —
+//      this is the migration path for an existing localStorage value;
+//   2. a live sessionStorage value wins over the seed and later writes mirror
+//      back into localStorage, so no cross-tab listener is ever attached.
+describe('useTabScopedStorage', () => {
+  let ls: Map<string, string>
+  let ss: Map<string, string>
+
+  const mock = (m: Map<string, string>) => ({
+    getItem: (k: string) => m.get(k) ?? null,
+    setItem: (k: string, v: string) => m.set(k, v),
+    removeItem: (k: string) => m.delete(k),
+    clear: () => m.clear(),
+    key: () => null,
+    get length() { return m.size },
+  })
+
+  beforeEach(() => {
+    ls = new Map(); ss = new Map()
+    vi.stubGlobal('localStorage', mock(ls))
+    vi.stubGlobal('sessionStorage', mock(ss))
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('cold start seeds an object from localStorage (migration path)', () => {
+    ls.set('k', JSON.stringify({ a: 1 })) // useStorage stores objects as JSON
+    const r = useTabScopedStorage<{ a: number }>('k', { a: 0 }, { seed: true })
+    expect(r.value).toEqual({ a: 1 })
+  })
+
+  it('cold start seeds a bare string from localStorage (migration path)', () => {
+    ls.set('k', 'legacy') // useStorage stores strings bare — must NOT be JSON.parsed
+    const r = useTabScopedStorage<string>('k', 'def', { seed: true })
+    expect(r.value).toBe('legacy')
+  })
+
+  it('a live sessionStorage value wins over the seed', () => {
+    ls.set('k', 'seed')
+    ss.set('k', 'live')
+    const r = useTabScopedStorage<string>('k', 'def', { seed: true })
+    expect(r.value).toBe('live')
+  })
+
+  it('mirrors writes into the localStorage seed', async () => {
+    const r = useTabScopedStorage<string>('k', 'def', { seed: true })
+    r.value = 'next'
+    await nextTick()
+    expect(ls.get('k')).toBe('next') // raw mirror, byte-identical to sessionStorage
+  })
+
+  it('without seed, ignores localStorage entirely', () => {
+    ls.set('k', 'seed')
+    const r = useTabScopedStorage<string>('k', 'def')
+    expect(r.value).toBe('def')
+  })
+})

--- a/apps/web/src/utils/tab-scoped-storage.ts
+++ b/apps/web/src/utils/tab-scoped-storage.ts
@@ -1,0 +1,72 @@
+import { useStorage } from '@vueuse/core'
+import { watch } from 'vue'
+import type { Ref } from 'vue'
+
+/**
+ * Per-browser-tab state with a cross-session cold-start seed.
+ *
+ * WHY: "which session / which layout am I looking at" is per-Tab state — two
+ * browser tabs are two windows and must not hijack each other. The old design
+ * used `useStorage(key, …, localStorage)`, which (a) shares one value across
+ * every tab and (b) broadcasts changes via the `storage` event, so tab A's
+ * click retargeted tab B's session. sessionStorage is physically per-tab and
+ * fires no cross-tab event, so it cannot cause that hijack.
+ *
+ * The cost of sessionStorage alone: it is wiped when the tab's last copy closes,
+ * losing "reopen where I left off". So (opt-in via `seed`) we keep ONE seed in
+ * localStorage under the SAME key name — a different storage area, so no
+ * collision — read it EXACTLY once when a fresh tab has no sessionStorage value
+ * (true cold start), then mirror later writes into it. Same key name also makes
+ * migration free: an existing `localStorage[key]` from the old design is picked
+ * up as the seed on first load, so no layout/bot selection is lost on deploy.
+ *
+ * The seed is deliberately last-writer-wins across tabs and is NEVER read again
+ * while the tab lives — it is a default, not a live source, so it needs no
+ * cross-tab listener and cannot reintroduce the coupling it replaces. The mirror
+ * write is a plain `setItem` (NOT a second `useStorage`) for the same reason: a
+ * second useStorage would attach a `storage` listener and undo the isolation.
+ *
+ * ponytail: the seed is a single shared slot, so "reopen after closing all tabs"
+ * restores whichever tab wrote last, not a designated primary tab. Tracking a
+ * primary tab isn't worth the complexity; a plausible last state is enough.
+ */
+export function useTabScopedStorage<T>(
+  key: string,
+  defaults: T,
+  opts: { seed?: boolean } = {},
+): Ref<T> {
+  const ss = typeof sessionStorage !== 'undefined' ? sessionStorage : undefined
+  const ls = typeof localStorage !== 'undefined' ? localStorage : undefined
+
+  // Seed at the RAW-string layer, never by re-serializing. useStorage's default
+  // ('any') serializer stores a string bare (`abc`) but an object as JSON — if
+  // we JSON.parse the seed ourselves, the object case works by luck and the
+  // string case throws on the bare value. Copying the raw slot sidesteps that
+  // entirely: vueuse owns (de)serialization on both ends, so the seed — incl. a
+  // value written by the OLD localStorage design — round-trips byte-identically.
+  //
+  // Must run BEFORE useStorage: its constructor writes `defaults` into
+  // sessionStorage, which would erase the "this tab is cold" signal.
+  if (opts.seed && ss && ls && ss.getItem(key) === null) {
+    const seed = ls.getItem(key)
+    if (seed !== null) ss.setItem(key, seed) // useStorage reads it as if native
+  }
+
+  const state = useStorage<T>(key, defaults, ss, { listenToStorageChanges: false })
+
+  // Mirror later writes back into the seed slot, again as raw text: read what
+  // useStorage just serialized into sessionStorage and copy it verbatim. Plain
+  // setItem (NOT a second useStorage) so no `storage` listener is attached —
+  // attaching one would reintroduce the cross-tab coupling this file removes.
+  if (opts.seed && ss && ls) {
+    watch(state, () => {
+      const raw = ss.getItem(key)
+      try {
+        if (raw === null) ls.removeItem(key)
+        else ls.setItem(key, raw)
+      } catch { /* quota — best effort */ }
+    }, { deep: true })
+  }
+
+  return state
+}

--- a/apps/web/src/utils/tab-scoped-storage.ts
+++ b/apps/web/src/utils/tab-scoped-storage.ts
@@ -48,8 +48,12 @@ export function useTabScopedStorage<T>(
   // Must run BEFORE useStorage: its constructor writes `defaults` into
   // sessionStorage, which would erase the "this tab is cold" signal.
   if (opts.seed && ss && ls && ss.getItem(key) === null) {
-    const seed = ls.getItem(key)
-    if (seed !== null) ss.setItem(key, seed) // useStorage reads it as if native
+    try {
+      const seed = ls.getItem(key)
+      // Quota / disabled sessionStorage must not abort store construction —
+      // fall through to `defaults` the same way the mirror write is best-effort.
+      if (seed !== null) ss.setItem(key, seed)
+    } catch { /* seed unavailable — use defaults */ }
   }
 
   const state = useStorage<T>(key, defaults, ss, { listenToStorageChanges: false })


### PR DESCRIPTION
## 摘要
多个浏览器窗口不再互相抢走 Bot、会话和工作区布局。每个窗口独立；重新打开时用「上次最后写下的状态」当默认开局。已经摆好的工作区不会被擅自塞进空会话。

## 产品设计

### 一句话
**一个浏览器窗口 = 一份独立工作台。** 窗口之间不实时同步；关掉再开，用最近一次留下的默认状态开局。

### 两条状态
- **窗口正在用的状态**：只属于这个窗口，改这边不影响那边。
- **重新打开时的默认**：所有窗口共用一份「最后写下的」默认（谁最后改，下次新窗口就跟谁）。窗口开着的时候，不会去听别人改这份默认。

Session 不单独做「重新打开默认」——它跟着工作区里已经打开的 Chat 面板走，避免和布局打架。

### 几条路径（人话）

1. **开两个窗口看同一个 Bot**  
   左边改布局、切会话，右边不受影响。不会出现点一下左边、右边跟着跳走。

2. **窗口 A 摆好了文件 + 预览（没有聊天）→ 再开一个普通新窗口 B**  
   B 按默认把这份工作区原样打开。不会多出一个「新会话 / 未命名会话」标签盖上去。

3. **新窗口恢复后，后台虽然可能自动瞄了一眼最新历史会话**  
   但工作区已经非空时，不会因此再往台上塞聊天页。你看到的还是恢复出来的那份布局。

4. **冷启动恢复的是「文件 + 预览」→ 把这两个都关掉**  
   台上空了，这时才出现 **New Session**（空白可输入页）。  
   不会突然蹦出一个以前自动瞄到的 Untitled Session。

5. **恢复的工作区里本来就有某个聊天页**  
   左侧最近列表的高亮，跟台上正在看的那个聊天对齐，而不是指着另一个「最新历史」。

6. **你在最近列表里主动点某个会话，或点 New Session**  
   这是明确操作，会正常打开 / 聚焦对应面板。上面那些「别乱动」的规则挡的是自动行为，不是你的点击。

7. **关掉所有窗口后再开一个**  
   用「最后一次写下的」Bot + 工作区布局当开局。这是同机默认，不是多设备同步。

8. **登出**  
   这个账号留下的窗口状态和重新打开默认一起清掉，避免下一个账号 inheriting 上一份工作台。

### 刻意不做
- 不在多台设备 / 多浏览器账号之间同步布局。
- 最近列表里出现 Untitled（真实未命名会话）可以接受；禁止的是恢复时往工作区里**白造**空会话标签。
- Session / 文件 / 预览进网址，是另一条能力，不在本 PR。

## 测试计划
- [ ] 开两个窗口：各自改布局 / 会话，互不抢
- [ ] A 只留文件 + 预览 → 新开 B → 原样恢复，不叠新会话
- [ ] 冷启动文件 + 预览 → 依次关掉 → 出现 New Session，不是 Untitled
- [ ] 恢复带聊天页的布局 → 左侧高亮与台上一致
- [ ] 点最近列表 / New Session → 仍正常打开
- [ ] 全部关掉再开 → 回到上次默认 Bot + 布局
- [ ] 登出后再进 → 不会带着上一账号的工作台