### PR TITLE
fix(web): Recents scroll position and phantom sidebar highlight

### DIFF
--- a/apps/web/src/components/sidebar/recents-scroll.test.ts
+++ b/apps/web/src/components/sidebar/recents-scroll.test.ts
@@ -45,7 +45,6 @@ describe('shouldPrefetchToFillViewport', () => {
     expect(shouldPrefetchToFillViewport({
       hasMore: true,
       loading: false,
-      itemCount: 5,
       contentHeight: 180,
       viewportHeight: 400,
     })).toBe(true)
@@ -55,7 +54,6 @@ describe('shouldPrefetchToFillViewport', () => {
     expect(shouldPrefetchToFillViewport({
       hasMore: true,
       loading: false,
-      itemCount: 40,
       contentHeight: 1200,
       viewportHeight: 400,
     })).toBe(false)
@@ -65,23 +63,25 @@ describe('shouldPrefetchToFillViewport', () => {
     expect(shouldPrefetchToFillViewport({
       hasMore: true,
       loading: false,
-      itemCount: 5,
       contentHeight: 180,
       viewportHeight: 0,
     })).toBe(false)
     expect(shouldPrefetchToFillViewport({
       hasMore: true,
       loading: true,
-      itemCount: 5,
       contentHeight: 180,
       viewportHeight: 400,
     })).toBe(false)
+  })
+
+  it('keeps paging when the active filter yields zero visible rows', () => {
+    // Mixed-type API page + Schedule/Agent client filter: spacer stays 0 while
+    // hasMore is still true. Stopping here would strand an empty Recents list.
     expect(shouldPrefetchToFillViewport({
       hasMore: true,
       loading: false,
-      itemCount: 0,
       contentHeight: 0,
       viewportHeight: 400,
-    })).toBe(false)
+    })).toBe(true)
   })
 })

--- a/apps/web/src/components/sidebar/recents-scroll.test.ts
+++ b/apps/web/src/components/sidebar/recents-scroll.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { shouldPrefetchToFillViewport, shouldShowLoadMoreSentinel } from './recents-scroll'
+import {
+  didLoadMoreMakeProgress,
+  shouldPrefetchToFillViewport,
+  shouldShowLoadMoreSentinel,
+} from './recents-scroll'
 
 describe('shouldShowLoadMoreSentinel', () => {
   it('stays off while the virtualizer spacer is still short of the viewport', () => {
@@ -82,6 +86,52 @@ describe('shouldPrefetchToFillViewport', () => {
       loading: false,
       contentHeight: 0,
       viewportHeight: 400,
+    })).toBe(true)
+  })
+})
+
+describe('didLoadMoreMakeProgress', () => {
+  it('stops prefetch after a settled load that did not advance cursor or height', () => {
+    // Failed request (or no-op): loadingMore flipped false with nothing else
+    // changed — tight-looping here would hammer the sessions API.
+    expect(didLoadMoreMakeProgress({
+      wasLoadingMore: true,
+      isLoadingMore: false,
+      previousCursor: 'cursor-2',
+      currentCursor: 'cursor-2',
+      previousContentHeight: 180,
+      currentContentHeight: 180,
+    })).toBe(false)
+  })
+
+  it('continues after cursor advances even when visible height stays zero', () => {
+    // Schedule/Agent filter: a page can add zero visible rows while nextCursor moves.
+    expect(didLoadMoreMakeProgress({
+      wasLoadingMore: true,
+      isLoadingMore: false,
+      previousCursor: 'cursor-2',
+      currentCursor: 'cursor-3',
+      previousContentHeight: 0,
+      currentContentHeight: 0,
+    })).toBe(true)
+  })
+
+  it('continues when content grew or the transition is not a load settle', () => {
+    expect(didLoadMoreMakeProgress({
+      wasLoadingMore: true,
+      isLoadingMore: false,
+      previousCursor: 'cursor-2',
+      currentCursor: 'cursor-2',
+      previousContentHeight: 180,
+      currentContentHeight: 400,
+    })).toBe(true)
+    expect(didLoadMoreMakeProgress({
+      wasLoadingMore: false,
+      isLoadingMore: false,
+      previousCursor: 'cursor-2',
+      currentCursor: 'cursor-2',
+      previousContentHeight: 180,
+      currentContentHeight: 180,
     })).toBe(true)
   })
 })

--- a/apps/web/src/components/sidebar/recents-scroll.test.ts
+++ b/apps/web/src/components/sidebar/recents-scroll.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { shouldPrefetchToFillViewport, shouldShowLoadMoreSentinel } from './recents-scroll'
+
+describe('shouldShowLoadMoreSentinel', () => {
+  it('stays off while the virtualizer spacer is still short of the viewport', () => {
+    expect(shouldShowLoadMoreSentinel({
+      hasMore: true,
+      contentHeight: 0,
+      viewportHeight: 400,
+    })).toBe(false)
+    expect(shouldShowLoadMoreSentinel({
+      hasMore: true,
+      contentHeight: 200,
+      viewportHeight: 400,
+    })).toBe(false)
+  })
+
+  it('turns on only after content overflows a measured viewport', () => {
+    expect(shouldShowLoadMoreSentinel({
+      hasMore: true,
+      contentHeight: 401,
+      viewportHeight: 400,
+    })).toBe(true)
+  })
+
+  it('stays off when the viewport is not measured yet', () => {
+    expect(shouldShowLoadMoreSentinel({
+      hasMore: true,
+      contentHeight: 800,
+      viewportHeight: 0,
+    })).toBe(false)
+  })
+
+  it('stays off when there is no next page', () => {
+    expect(shouldShowLoadMoreSentinel({
+      hasMore: false,
+      contentHeight: 800,
+      viewportHeight: 400,
+    })).toBe(false)
+  })
+})
+
+describe('shouldPrefetchToFillViewport', () => {
+  it('loads the next page while a short list still fits the viewport', () => {
+    expect(shouldPrefetchToFillViewport({
+      hasMore: true,
+      loading: false,
+      itemCount: 5,
+      contentHeight: 180,
+      viewportHeight: 400,
+    })).toBe(true)
+  })
+
+  it('does not prefetch once the list overflows', () => {
+    expect(shouldPrefetchToFillViewport({
+      hasMore: true,
+      loading: false,
+      itemCount: 40,
+      contentHeight: 1200,
+      viewportHeight: 400,
+    })).toBe(false)
+  })
+
+  it('waits for a measured viewport and idle load state', () => {
+    expect(shouldPrefetchToFillViewport({
+      hasMore: true,
+      loading: false,
+      itemCount: 5,
+      contentHeight: 180,
+      viewportHeight: 0,
+    })).toBe(false)
+    expect(shouldPrefetchToFillViewport({
+      hasMore: true,
+      loading: true,
+      itemCount: 5,
+      contentHeight: 180,
+      viewportHeight: 400,
+    })).toBe(false)
+    expect(shouldPrefetchToFillViewport({
+      hasMore: true,
+      loading: false,
+      itemCount: 0,
+      contentHeight: 0,
+      viewportHeight: 400,
+    })).toBe(false)
+  })
+})

--- a/apps/web/src/components/sidebar/recents-scroll.ts
+++ b/apps/web/src/components/sidebar/recents-scroll.ts
@@ -1,0 +1,36 @@
+/**
+ * Sidebar Recents pagination gates.
+ *
+ * The virtualizer's spacer starts at 0 / a small estimate. If the load-more
+ * sentinel is mounted in that window, IntersectionObserver (+ rootMargin)
+ * treats it as already intersecting and fires a page fetch. When the real
+ * spacer then grows above the sentinel, the browser's overflow anchoring
+ * walks scrollTop down with the growth — Recents opens mid-list.
+ *
+ * Only observe the sentinel once content actually overflows the viewport.
+ * While it still fits, prefetch pages until it overflows or the cursor ends.
+ */
+
+export function shouldShowLoadMoreSentinel(opts: {
+  hasMore: boolean
+  contentHeight: number
+  viewportHeight: number
+}): boolean {
+  return (
+    opts.hasMore
+    && opts.viewportHeight > 0
+    && opts.contentHeight > opts.viewportHeight
+  )
+}
+
+export function shouldPrefetchToFillViewport(opts: {
+  hasMore: boolean
+  loading: boolean
+  itemCount: number
+  contentHeight: number
+  viewportHeight: number
+}): boolean {
+  if (!opts.hasMore || opts.loading || opts.itemCount === 0) return false
+  if (opts.viewportHeight <= 0) return false
+  return opts.contentHeight <= opts.viewportHeight
+}

--- a/apps/web/src/components/sidebar/recents-scroll.ts
+++ b/apps/web/src/components/sidebar/recents-scroll.ts
@@ -26,11 +26,13 @@ export function shouldShowLoadMoreSentinel(opts: {
 export function shouldPrefetchToFillViewport(opts: {
   hasMore: boolean
   loading: boolean
-  itemCount: number
   contentHeight: number
   viewportHeight: number
 }): boolean {
-  if (!opts.hasMore || opts.loading || opts.itemCount === 0) return false
+  // Do not gate on visible row count: the API returns mixed session types and
+  // Recents filters client-side (Schedule / Agent). A page can yield zero rows
+  // for the active filter while nextCursor is still set — keep paging.
+  if (!opts.hasMore || opts.loading) return false
   if (opts.viewportHeight <= 0) return false
   return opts.contentHeight <= opts.viewportHeight
 }

--- a/apps/web/src/components/sidebar/recents-scroll.ts
+++ b/apps/web/src/components/sidebar/recents-scroll.ts
@@ -36,3 +36,27 @@ export function shouldPrefetchToFillViewport(opts: {
   if (opts.viewportHeight <= 0) return false
   return opts.contentHeight <= opts.viewportHeight
 }
+
+/**
+ * After loadMoreSessions settles, only continue viewport prefetch when the
+ * attempt made progress. A failed request leaves cursor + contentHeight
+ * unchanged; without this gate the loading flag flipping false retriggers the
+ * watch in a tight retry loop.
+ *
+ * Cursor advance with unchanged height is still progress: Schedule/Agent
+ * client filters can yield an empty page while nextCursor moves.
+ */
+export function didLoadMoreMakeProgress(opts: {
+  wasLoadingMore: boolean
+  isLoadingMore: boolean
+  previousCursor: string | null
+  currentCursor: string | null
+  previousContentHeight: number
+  currentContentHeight: number
+}): boolean {
+  if (!opts.wasLoadingMore || opts.isLoadingMore) return true
+  return (
+    opts.previousCursor !== opts.currentCursor
+    || opts.previousContentHeight !== opts.currentContentHeight
+  )
+}

--- a/apps/web/src/components/sidebar/recents.vue
+++ b/apps/web/src/components/sidebar/recents.vue
@@ -289,13 +289,11 @@ watch(
     loadingMoreSessions,
     totalSize,
     viewportHeight,
-    () => visibleSessions.value.length,
   ],
   () => {
     if (!shouldPrefetchToFillViewport({
       hasMore: hasMoreSessions.value,
       loading: loadingChats.value || loadingMoreSessions.value,
-      itemCount: visibleSessions.value.length,
       contentHeight: totalSize.value,
       viewportHeight: viewportHeight.value,
     })) return

--- a/apps/web/src/components/sidebar/recents.vue
+++ b/apps/web/src/components/sidebar/recents.vue
@@ -173,7 +173,11 @@ import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { isSessionVisibleInSidebarMode, sortByRecency, type SidebarSessionMode } from '@/store/chat-list.utils'
 import type { SessionSummary } from '@/composables/api/useChat'
 import { resolveApiErrorMessage } from '@/utils/api-error'
-import { shouldPrefetchToFillViewport, shouldShowLoadMoreSentinel } from './recents-scroll'
+import {
+  didLoadMoreMakeProgress,
+  shouldPrefetchToFillViewport,
+  shouldShowLoadMoreSentinel,
+} from './recents-scroll'
 import {
   Button,
   TextButton,
@@ -206,6 +210,7 @@ const {
   loadingChats,
   hasMoreSessions,
   loadingMoreSessions,
+  sessionsCursor,
 } = storeToRefs(chatStore)
 
 // The list pivots between human conversations (Recent) and system run streams
@@ -289,14 +294,28 @@ watch(
     loadingMoreSessions,
     totalSize,
     viewportHeight,
+    sessionsCursor,
   ],
-  () => {
+  (curr, prev) => {
     if (!shouldPrefetchToFillViewport({
       hasMore: hasMoreSessions.value,
       loading: loadingChats.value || loadingMoreSessions.value,
       contentHeight: totalSize.value,
       viewportHeight: viewportHeight.value,
     })) return
+    // Failed / no-op loadMore: loading settles with the same cursor and height.
+    // Do not tight-loop; a later viewport/list change can try again.
+    if (
+      prev
+      && !didLoadMoreMakeProgress({
+        wasLoadingMore: prev[2],
+        isLoadingMore: curr[2],
+        previousCursor: prev[5],
+        currentCursor: curr[5],
+        previousContentHeight: prev[3],
+        currentContentHeight: curr[3],
+      })
+    ) return
     void chatStore.loadMoreSessions()
   },
 )

--- a/apps/web/src/components/sidebar/recents.vue
+++ b/apps/web/src/components/sidebar/recents.vue
@@ -75,9 +75,12 @@
                Sits AFTER the virtualizer's height spacer so it lives at the
                natural end of the scroll content; the IntersectionObserver
                below uses scrollEl as its root and triggers the next page
-               200px before the user actually reaches the bottom. -->
+               200px before the user actually reaches the bottom.
+               Mounted only once the list overflows the viewport — see
+               shouldShowLoadMoreSentinel — so a short first paint cannot
+               falsely intersect and kick a page fetch that grows the spacer. -->
           <div
-            v-if="hasMoreSessions"
+            v-if="showLoadMoreSentinel"
             ref="loadMoreSentinel"
             data-testid="load-more-sentinel"
             class="h-px w-full"
@@ -159,7 +162,7 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from 'vue'
 import { Check, ChevronDown } from 'lucide-vue-next'
-import { useLocalStorage } from '@vueuse/core'
+import { useElementSize, useLocalStorage } from '@vueuse/core'
 import { useVirtualizer } from '@tanstack/vue-virtual'
 import { useIntersectionObserver } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
@@ -170,6 +173,7 @@ import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { isSessionVisibleInSidebarMode, sortByRecency, type SidebarSessionMode } from '@/store/chat-list.utils'
 import type { SessionSummary } from '@/composables/api/useChat'
 import { resolveApiErrorMessage } from '@/utils/api-error'
+import { shouldPrefetchToFillViewport, shouldShowLoadMoreSentinel } from './recents-scroll'
 import {
   Button,
   TextButton,
@@ -255,6 +259,12 @@ function measureRow(el: unknown) {
 // scroll content and fires the next page 200px before the user reaches it.
 // The store's loadMoreSessions guards re-entry (loadingMoreSessions / cursor
 // exhaustion), so the observer can fire freely as the user scrolls.
+const { height: viewportHeight } = useElementSize(scrollEl)
+const showLoadMoreSentinel = computed(() => shouldShowLoadMoreSentinel({
+  hasMore: hasMoreSessions.value,
+  contentHeight: totalSize.value,
+  viewportHeight: viewportHeight.value,
+}))
 const loadMoreSentinel = ref<HTMLElement | null>(null)
 useIntersectionObserver(
   loadMoreSentinel,
@@ -266,6 +276,30 @@ useIntersectionObserver(
     root: scrollEl,
     rootMargin: '0px 0px 200px 0px',
     threshold: 0,
+  },
+)
+
+// Short first pages never reach the sentinel gate above — keep paging until
+// the list overflows (or the cursor ends) so empty viewport space is filled
+// without relying on a falsely-intersecting sentinel.
+watch(
+  [
+    hasMoreSessions,
+    loadingChats,
+    loadingMoreSessions,
+    totalSize,
+    viewportHeight,
+    () => visibleSessions.value.length,
+  ],
+  () => {
+    if (!shouldPrefetchToFillViewport({
+      hasMore: hasMoreSessions.value,
+      loading: loadingChats.value || loadingMoreSessions.value,
+      itemCount: visibleSessions.value.length,
+      contentHeight: totalSize.value,
+      viewportHeight: viewportHeight.value,
+    })) return
+    void chatStore.loadMoreSessions()
   },
 )
 

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -111,6 +111,7 @@ const h = {
   sessionsActivityHandler: null as ((event: BotSessionActivityEvent) => void) | null,
   sendUpdates: [] as RuntimeTestUpdate[],
   sentWSMessages: [] as Array<Record<string, unknown>>,
+  runtimeUnsubscribes: [] as string[],
   wsRunIds: [] as string[],
   abortedWSRuns: [] as string[],
   lastRunId: '',
@@ -254,6 +255,7 @@ beforeEach(() => {
     h.wsRunSeq = 0
     h.runtimeBySession = new Map()
     h.sentWSMessages = []
+    h.runtimeUnsubscribes = []
     h.wsRunIds = []
     h.abortedWSRuns = []
     h.sendUpdates = [runtime.started, runtime.failed('model failed')]
@@ -404,7 +406,10 @@ beforeEach(() => {
             if (message.session_id) emitRuntimeSnapshot(onStreamEvent, message.session_id)
             return
           }
-          if (message.type === 'runtime_unsubscribe') return
+          if (message.type === 'runtime_unsubscribe') {
+            if (message.session_id) h.runtimeUnsubscribes.push(message.session_id)
+            return
+          }
           h.sentWSMessages.push(message as Record<string, unknown>)
           h.lastSessionId = message.session_id ?? ''
           if (
@@ -1368,6 +1373,34 @@ describe('chat-list store', () => {
       expect(store.pendingACPSessionMetadata).toBeNull()
       expect(store.hasExplicitSessionSelection).toBe(true)
       expect(api.createACPRuntime).not.toHaveBeenCalled()
+    })
+
+  it('unsubscribes the live session runtime when resetToEmptyComposer clears a selected session', async () => {
+      api.fetchSessions.mockResolvedValueOnce({
+        items: [{
+          id: 'session-live',
+          bot_id: 'bot-1',
+          title: 'Live',
+          type: 'chat',
+        }],
+        nextCursor: null,
+      })
+      const store = useChatStore()
+
+      await store.selectBot('bot-1')
+      await store.selectSession('session-live')
+      await flushPromises()
+      expect(store.sessionId).toBe('session-live')
+
+      h.runtimeUnsubscribes = []
+      store.resetToEmptyComposer({
+        clearPendingACP: false,
+        explicitSelection: false,
+        draftIntent: false,
+      })
+
+      expect(store.sessionId).toBeNull()
+      expect(h.runtimeUnsubscribes).toEqual(['session-live'])
     })
 
   it('keeps a manually staged ACP agent explicit so the default stage cannot reclaim it', async () => {

--- a/apps/web/src/store/chat/acp-staging.ts
+++ b/apps/web/src/store/chat/acp-staging.ts
@@ -207,17 +207,19 @@ export function createACPStaging(deps: ACPStagingDeps) {
     bumpSelectSessionRequest()
     explicitSessionSelection.value = false
     draftIntent.value = false
-    sessionId.value = null
+    // Stop the live session runtime before clearing sessionId — clearTranscriptForDraft
+    // reads the current id to unsubscribe.
     clearTranscriptForDraft()
+    sessionId.value = null
     stageACPSession(input, { explicitSelection: false })
   }
 
   function stageNewACPSession(input: ACPAgentSessionInput) {
     bumpSelectSessionRequest()
     clearPendingACPSession()
-    sessionId.value = null
     draftIntent.value = true
     clearTranscriptForDraft()
+    sessionId.value = null
     stageACPSession(input, { explicitSelection: true })
   }
 
@@ -226,10 +228,13 @@ export function createACPStaging(deps: ACPStagingDeps) {
     if (options.clearPendingACP !== false) {
       clearPendingACPSession()
     }
+    // Must run while sessionId is still set: clearTranscriptForDraft stops the
+    // session runtime by reading the current id. Nulling first leaves an orphan
+    // subscribe (File/Preview restore clearing initialize()'s auto-pick).
+    clearTranscriptForDraft()
     sessionId.value = null
     explicitSessionSelection.value = options.explicitSelection === true
     draftIntent.value = options.draftIntent ?? options.explicitSelection === true
-    clearTranscriptForDraft()
   }
 
   async function ensurePendingACPRuntime(): Promise<AcpagentRuntimeStatus | undefined> {

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -139,6 +139,15 @@ const chatStoreMock = vi.hoisted(() => ({
     chatStoreMock.sessionId = null
     chatStoreMock.hasExplicitSessionSelection = options?.explicitSelection === true
   }),
+  resetToEmptyComposer: vi.fn((options?: {
+    clearPendingACP?: boolean
+    explicitSelection?: boolean
+    draftIntent?: boolean
+  }) => {
+    useChatSelectionStore().setSession(null, { explicitSelection: options?.explicitSelection === true })
+    chatStoreMock.sessionId = null
+    chatStoreMock.hasExplicitSessionSelection = options?.explicitSelection === true
+  }),
   knownSessionSummary: vi.fn((sessionId: string) =>
     chatStoreMock.knownSessions.find(session => session.id === sessionId)
     ?? chatStoreMock.sessions.find(session => session.id === sessionId)
@@ -194,6 +203,7 @@ vi.mock('@/store/chat-list', () => ({
     focusChatView: chatStoreMock.focusChatView,
     selectSession: chatStoreMock.selectSession,
     selectDraft: chatStoreMock.selectDraft,
+    resetToEmptyComposer: chatStoreMock.resetToEmptyComposer,
     applyDraftViewRequest: chatStoreMock.applyDraftViewRequest,
   }),
 }))
@@ -562,6 +572,7 @@ describe('workspace layout store', () => {
     chatStoreMock.focusChatView.mockClear()
     chatStoreMock.selectSession.mockClear()
     chatStoreMock.selectDraft.mockClear()
+    chatStoreMock.resetToEmptyComposer.mockClear()
     chatStoreMock.applyDraftViewRequest.mockClear()
     chatStoreMock.sessionId = null
     chatStoreMock.hasExplicitSessionSelection = false
@@ -588,6 +599,15 @@ describe('workspace layout store', () => {
     })
     chatStoreMock.selectDraft.mockImplementation((options?: { explicitSelection?: boolean }) => {
       useChatSelectionStore().setSession(null, options)
+      chatStoreMock.sessionId = null
+      chatStoreMock.hasExplicitSessionSelection = options?.explicitSelection === true
+    })
+    chatStoreMock.resetToEmptyComposer.mockImplementation((options?: {
+      clearPendingACP?: boolean
+      explicitSelection?: boolean
+      draftIntent?: boolean
+    }) => {
+      useChatSelectionStore().setSession(null, { explicitSelection: options?.explicitSelection === true })
       chatStoreMock.sessionId = null
       chatStoreMock.hasExplicitSessionSelection = options?.explicitSelection === true
     })
@@ -1005,7 +1025,8 @@ describe('workspace layout store', () => {
   it('does not open a chat tab when initialize auto-picks a session over a restored file/preview workspace', async () => {
     // Cold-start seed: File + Preview only (the user's Tab A layout). A new
     // browser tab must restore that dock as-is — initialize()'s non-explicit
-    // auto-pick of the latest Untitled Session must NOT punch chat tabs in.
+    // auto-pick of the latest Untitled Session must NOT punch chat tabs in,
+    // and must not leave Recents highlighting a session that is not on screen.
     localStorage.setItem('workspace-layout', JSON.stringify({
       'bot-1': {
         layout: {
@@ -1048,6 +1069,14 @@ describe('workspace layout store', () => {
 
     expect(dock.panels.map(panel => panel.component).sort()).toEqual(['file', 'preview'])
     expect(dock.panels.some(panel => panel.component === 'chat')).toBe(false)
+    expect(chatStoreMock.resetToEmptyComposer).toHaveBeenCalledWith({
+      clearPendingACP: false,
+      explicitSelection: false,
+      draftIntent: false,
+    })
+    expect(chatStoreMock.sessionId).toBeNull()
+    expect(useChatSelectionStore().sessionId).toBeNull()
+    expect(chatStoreMock.selectDraft).not.toHaveBeenCalled()
   })
 
   it('still opens a chat tab on explicit session selection after a file/preview restore', async () => {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -1175,8 +1175,21 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     openDraftChat({ groupId, explicitSelection })
   }
 
+  // Align global selection to the chat on screen (or to none). Called after a
+  // non-empty restore blocks inventing tabs: if the active panel is a chat,
+  // Recents must highlight that session; if there is no chat to adopt,
+  // drop initialize()'s non-explicit auto-pick so Recents stays unselected.
   function adoptActiveRestoredChatSelection(sessionId: string | null, panelId?: string) {
-    if (!sessionId || isDeletedSessionForCurrentBot(sessionId)) return
+    if (!sessionId || isDeletedSessionForCurrentBot(sessionId)) {
+      if (!chatStore.hasExplicitSessionSelection && (chatStore.sessionId ?? '').trim()) {
+        chatStore.resetToEmptyComposer({
+          clearPendingACP: false,
+          explicitSelection: false,
+          draftIntent: false,
+        })
+      }
+      return
+    }
     if (panelId) chatStore.focusChatView(panelId)
     // Already pointing at the preserved panel — leave explicitness alone.
     if ((chatStore.sessionId ?? '').trim() === sessionId) return

--- a/apps/web/src/styles/sidebar-scroll.css
+++ b/apps/web/src/styles/sidebar-scroll.css
@@ -9,8 +9,14 @@
  * lived in recents' scoped style, which silently did nothing for
  * panel-schedule (scoped selectors only match the defining component's DOM).
  * Import this file from every component that puts `sidebar-scroll` on a
- * scroll container. */
+ * scroll container.
+ *
+ * overflow-anchor is OFF here on purpose. Chat panes keep the browser default
+ * so history prepend stays visually pinned; sidebar lists grow downward from
+ * an empty/short first paint (virtualizer spacer + load-more), and anchoring
+ * would walk scrollTop down with that growth — Recents opening mid-list. */
 .sidebar-scroll {
+  overflow-anchor: none;
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklab, var(--foreground) 18%, transparent) transparent;
 }


### PR DESCRIPTION
## Summary
- Keep Recents from opening mid-list: turn off sidebar `overflow-anchor`, and only mount the load-more sentinel after the virtualized list overflows the viewport (short lists prefetch instead).
- Clear phantom Recents highlight when a restored dock has File/Preview but no Chat: extend `adoptActiveRestoredChatSelection` so a missing active chat drops `initialize()`'s non-explicit auto-pick (no new selection state).

## Why the diff looks additive
Most of the scroll fix is new gating helpers + CSS; the selection fix replaces a bare early-`return` with a clear-then-return inside the existing adopt path. No new persistent IDs/flags.

## Test plan
- [ ] Open Recents with a long session list — first paint should stay at the top, not mid-list
- [ ] Cold-start / new tab with File + Preview only (no Chat) — Recents should not highlight Untitled / latest session
- [ ] Click a Recents row — Chat still opens and highlights correctly
- [ ] Restore a layout that already includes a Chat — Recents highlights that session
- [ ] `pnpm --filter @memohai/web exec vitest run src/components/sidebar/recents-scroll.test.ts src/store/workspace-tabs.test.ts`