### PR TITLE
fix(web): add CJK fallback to code font stacks

### DIFF
--- a/apps/web/src/pages/appearance/index.vue
+++ b/apps/web/src/pages/appearance/index.vue
@@ -382,7 +382,7 @@ import { colorSchemes, type ColorSchemeId, type ColorSchemeOption } from '@/cons
 import { MERMAID_THEMES, type MermaidTheme, useSettingsStore, type ThemePreference } from '@/store/settings'
 import { isMermaidTheme } from '@/store/settings/mermaid'
 import { listBundledShikiThemes } from '@/store/settings/shiki-theme'
-import { cssFontFamilyDeclaration, DEFAULT_CODE_FONT_FAMILY, DEFAULT_CODE_FONT_SIZE_PX, DEFAULT_UI_FONT_SIZE_PX, normalizeCodeFontSizePx } from '@/store/settings/typography'
+import { cssCodeFontFamilyStyleValue, DEFAULT_CODE_FONT_SIZE_PX, DEFAULT_UI_FONT_SIZE_PX, normalizeCodeFontSizePx } from '@/store/settings/typography'
 
 enableMermaid()
 setCustomComponents({ mermaid: ThemedMermaidBlock })
@@ -490,7 +490,7 @@ const codeFontPreviewFallback = `<pre><code>${codeFontPreviewCode}</code></pre>`
 const codeFontPreviewLightHtml = computed(() => codeFontPreviewLight.html.value || codeFontPreviewFallback)
 const codeFontPreviewDarkHtml = computed(() => codeFontPreviewDark.html.value || codeFontPreviewFallback)
 const codeFontPreviewStyle = computed(() => ({
-  '--typography-code-preview-font-family': cssFontFamilyDeclaration(codeFontFamilyDraft.value, DEFAULT_CODE_FONT_FAMILY),
+  '--typography-code-preview-font-family': cssCodeFontFamilyStyleValue(codeFontFamilyDraft.value),
   '--typography-code-preview-font-size': `${normalizeCodeFontSizePx(codeFontSizeDraft.value)}px`,
 }))
 

--- a/apps/web/src/store/settings/index.ts
+++ b/apps/web/src/store/settings/index.ts
@@ -8,6 +8,7 @@ import { isColorSchemeId, type ColorSchemeId } from '@/constants/color-schemes'
 import {
   applyTypographyVariables,
   cssFontFamilyDeclaration,
+  cssCodeFontFamilyStyleValue,
   DEFAULT_CODE_FONT_FAMILY,
   DEFAULT_CODE_FONT_SIZE_PX,
   DEFAULT_UI_FONT_FAMILY,
@@ -55,7 +56,7 @@ export const useSettingsStore = defineStore('settings', () => {
   const shikiThemeDark = useStorage<BundledTheme>('shiki-theme-dark', DEFAULT_SHIKI_THEME_DARK)
   const mermaidTheme = useStorage<MermaidTheme>('mermaid-theme', DEFAULT_MERMAID_THEME)
   const uiFontStack = computed(() => cssFontFamilyDeclaration(uiFontFamily.value, DEFAULT_UI_FONT_FAMILY))
-  const codeFontStack = computed(() => cssFontFamilyDeclaration(codeFontFamily.value, DEFAULT_CODE_FONT_FAMILY))
+  const codeFontStack = computed(() => cssCodeFontFamilyStyleValue(codeFontFamily.value))
   const shikiThemes = computed(() => ({ light: shikiThemeLight.value, dark: shikiThemeDark.value }))
 
   // Expose the resolved active color mode as the single source of truth.

--- a/apps/web/src/store/settings/typography.test.ts
+++ b/apps/web/src/store/settings/typography.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   applyTypographyVariables,
+  cssCodeFontFamilyStyleValue,
   cssFontFamilyDeclaration,
   cssFontFamilyStyleValue,
   cssFontStack,
@@ -16,6 +17,9 @@ import {
 // names get quoted).
 const UI_FALLBACK_SERIALIZED = 'system-ui, sans-serif'
 const CODE_FALLBACK_SERIALIZED = 'ui-monospace, monospace'
+// cssCodeFontFamilyStyleValue appends this CJK tail to every code stack (#851);
+// it ends in generic monospace as the final catch-all.
+const CODE_CJK_TAIL_SERIALIZED = '"MiSans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Noto Sans SC", monospace'
 
 describe('typography settings', () => {
   afterEach(() => {
@@ -62,6 +66,20 @@ describe('typography settings', () => {
     // A stack that already contains a generic family is kept untouched.
     expect(cssFontStack('Inter, sans-serif', DEFAULT_UI_FONT_FAMILY))
       .toBe('Inter, sans-serif')
+  })
+
+  it('appends the CJK fallback tail to every code stack (#851)', () => {
+    // Default stack gets the tail.
+    expect(cssCodeFontFamilyStyleValue(''))
+      .toBe(`${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
+    // Custom stacks get it after the default fallback…
+    expect(cssCodeFontFamilyStyleValue('JetBrains Mono'))
+      .toBe(`"JetBrains Mono", ${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
+    // …and even when the custom stack ends in a generic family (where
+    // cssFontStack appends nothing), so a Latin-only custom font can never
+    // lose the CJK fallback.
+    expect(cssCodeFontFamilyStyleValue('JetBrains Mono, monospace'))
+      .toBe(`"JetBrains Mono", monospace, ${CODE_CJK_TAIL_SERIALIZED}`)
   })
 
   it('normalizes free-text font family input before storing it', () => {
@@ -128,8 +146,8 @@ describe('typography settings', () => {
     expect(properties.get('--memoh-ui-font-family')).toBe(`"A \\"Quoted\\" Font", ${UI_FALLBACK_SERIALIZED}`)
     expect(properties.get('--font-sans')).toBe(`"A \\"Quoted\\" Font", ${UI_FALLBACK_SERIALIZED}`)
     expect(properties.get('--memoh-ui-font-size')).toBe('14px')
-    expect(properties.get('--memoh-code-font-family')).toBe(`"Mono\\\\Font", ${CODE_FALLBACK_SERIALIZED}`)
-    expect(properties.get('--font-mono')).toBe(`"Mono\\\\Font", ${CODE_FALLBACK_SERIALIZED}`)
+    expect(properties.get('--memoh-code-font-family')).toBe(`"Mono\\\\Font", ${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
+    expect(properties.get('--font-mono')).toBe(`"Mono\\\\Font", ${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
     expect(properties.get('--memoh-code-font-size')).toBe('13px')
     expect(properties.has('--memoh-text-xs')).toBe(false)
     expect(properties.has('--chat-markdown-h1-font-size')).toBe(false)
@@ -167,6 +185,6 @@ describe('typography settings', () => {
     expect(properties.has('--font-mono')).toBe(false)
     expect(properties.has('--memoh-ui-font-size')).toBe(false)
     expect(properties.get('--memoh-ui-font-family')).toBe(UI_FALLBACK_SERIALIZED)
-    expect(properties.get('--memoh-code-font-family')).toBe(CODE_FALLBACK_SERIALIZED)
+    expect(properties.get('--memoh-code-font-family')).toBe(`${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
   })
 })

--- a/apps/web/src/store/settings/typography.test.ts
+++ b/apps/web/src/store/settings/typography.test.ts
@@ -16,10 +16,9 @@ import {
 // The default stacks after serialization (generic keywords stay bare, concrete
 // names get quoted).
 const UI_FALLBACK_SERIALIZED = 'system-ui, sans-serif'
-const CODE_FALLBACK_SERIALIZED = 'ui-monospace, monospace'
-// cssCodeFontFamilyStyleValue appends this CJK tail to every code stack (#851);
-// it ends in generic monospace as the final catch-all.
-const CODE_CJK_TAIL_SERIALIZED = '"MiSans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Noto Sans SC", monospace'
+// CJK concrete families sit before the terminal generic monospace catch-all (#851).
+const CODE_CJK_CORE_SERIALIZED = '"MiSans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Noto Sans SC"'
+const CODE_STACK_WITH_CJK = `ui-monospace, ${CODE_CJK_CORE_SERIALIZED}, monospace`
 
 describe('typography settings', () => {
   afterEach(() => {
@@ -68,18 +67,13 @@ describe('typography settings', () => {
       .toBe('Inter, sans-serif')
   })
 
-  it('appends the CJK fallback tail to every code stack (#851)', () => {
-    // Default stack gets the tail.
-    expect(cssCodeFontFamilyStyleValue(''))
-      .toBe(`${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
-    // Custom stacks get it after the default fallback…
+  it('inserts the CJK stack before terminal monospace on every code stack (#851)', () => {
+    expect(cssCodeFontFamilyStyleValue('')).toBe(CODE_STACK_WITH_CJK)
     expect(cssCodeFontFamilyStyleValue('JetBrains Mono'))
-      .toBe(`"JetBrains Mono", ${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
-    // …and even when the custom stack ends in a generic family (where
-    // cssFontStack appends nothing), so a Latin-only custom font can never
-    // lose the CJK fallback.
+      .toBe(`"JetBrains Mono", ${CODE_STACK_WITH_CJK}`)
+    // User stacks ending in generic monospace still get CJK ahead of the catch-all.
     expect(cssCodeFontFamilyStyleValue('JetBrains Mono, monospace'))
-      .toBe(`"JetBrains Mono", monospace, ${CODE_CJK_TAIL_SERIALIZED}`)
+      .toBe(`"JetBrains Mono", ${CODE_CJK_CORE_SERIALIZED}, monospace`)
   })
 
   it('normalizes free-text font family input before storing it', () => {
@@ -146,8 +140,8 @@ describe('typography settings', () => {
     expect(properties.get('--memoh-ui-font-family')).toBe(`"A \\"Quoted\\" Font", ${UI_FALLBACK_SERIALIZED}`)
     expect(properties.get('--font-sans')).toBe(`"A \\"Quoted\\" Font", ${UI_FALLBACK_SERIALIZED}`)
     expect(properties.get('--memoh-ui-font-size')).toBe('14px')
-    expect(properties.get('--memoh-code-font-family')).toBe(`"Mono\\\\Font", ${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
-    expect(properties.get('--font-mono')).toBe(`"Mono\\\\Font", ${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
+    expect(properties.get('--memoh-code-font-family')).toBe(cssCodeFontFamilyStyleValue('Mono\\Font'))
+    expect(properties.get('--font-mono')).toBe(cssCodeFontFamilyStyleValue('Mono\\Font'))
     expect(properties.get('--memoh-code-font-size')).toBe('13px')
     expect(properties.has('--memoh-text-xs')).toBe(false)
     expect(properties.has('--chat-markdown-h1-font-size')).toBe(false)
@@ -185,6 +179,6 @@ describe('typography settings', () => {
     expect(properties.has('--font-mono')).toBe(false)
     expect(properties.has('--memoh-ui-font-size')).toBe(false)
     expect(properties.get('--memoh-ui-font-family')).toBe(UI_FALLBACK_SERIALIZED)
-    expect(properties.get('--memoh-code-font-family')).toBe(`${CODE_FALLBACK_SERIALIZED}, ${CODE_CJK_TAIL_SERIALIZED}`)
+    expect(properties.get('--memoh-code-font-family')).toBe(CODE_STACK_WITH_CJK)
   })
 })

--- a/apps/web/src/store/settings/typography.ts
+++ b/apps/web/src/store/settings/typography.ts
@@ -4,6 +4,19 @@ export const DEFAULT_CODE_FONT_FAMILY = 'ui-monospace, monospace'
 export const DEFAULT_UI_FONT_SIZE_PX = 16
 export const DEFAULT_CODE_FONT_SIZE_PX = 13
 
+// CJK tail appended to EVERY code stack (default or user-custom). The Latin
+// mono families above carry no CJK members, so without this the glyphs fall to
+// whatever per-lang font the OS picks — under <html lang="zh"> the :lang(zh)
+// weight shave (style.css) drops the request to ~315, which lands on PingFang's
+// Light static face and renders visibly thin/blurry at 12–13px (#851). MiSans
+// leads so code CJK matches the rest of the UI; system CJK fonts follow for
+// glyphs outside MiSans' subset ranges. Latin is always claimed earlier by the
+// mono families, and MiSans' unicode-range subsets claim no color-emoji glyphs,
+// so neither Latin nor emoji rendering changes. The CSS fallback lists in
+// style.css (var(--memoh-code-font-family, …)) mirror this tail for the
+// pre-boot frame — keep them in sync.
+export const CODE_FONT_CJK_FALLBACK = 'MiSans, PingFang SC, Hiragino Sans GB, Microsoft YaHei UI, Noto Sans SC'
+
 const MIN_UI_FONT_SIZE_PX = 12
 const MAX_UI_FONT_SIZE_PX = 20
 const MIN_CODE_FONT_SIZE_PX = 11
@@ -115,6 +128,18 @@ export function cssFontFamilyDeclaration(value: unknown, fallback: string): stri
   return cssFontFamilyStyleValue(value, fallback)
 }
 
+// Code stacks only: the effective family list with the CJK tail appended. Goes
+// through cssFontStack first, so the tail lands AFTER the default fallback
+// (keeping it behind every Latin family the user asked for) and is present even
+// when the user stack ends in a generic family (where cssFontStack appends
+// nothing). Consumers: applyTypographyVariables, settings store codeFontStack
+// (monaco / markdown / html-preview), appearance preview.
+export function cssCodeFontFamilyStyleValue(value: unknown): string {
+  const base = cssFontFamilyStyleValue(value, DEFAULT_CODE_FONT_FAMILY)
+  const tail = cssFontFamilyStyleValue(CODE_FONT_CJK_FALLBACK, 'monospace')
+  return `${base}, ${tail}`
+}
+
 export function cssFontFamilyStyleValue(value: unknown, fallback: string): string {
   return splitFontFamilyList(cssFontStack(value, fallback))
     .map((family) => serializeFontFamily(family, fallback))
@@ -211,7 +236,7 @@ export function applyTypographyVariables(options: {
   const style = document.documentElement.style
 
   style.setProperty('--memoh-ui-font-family', cssFontFamilyDeclaration(options.uiFontFamily, DEFAULT_UI_FONT_FAMILY))
-  style.setProperty('--memoh-code-font-family', cssFontFamilyDeclaration(options.codeFontFamily, DEFAULT_CODE_FONT_FAMILY))
+  style.setProperty('--memoh-code-font-family', cssCodeFontFamilyStyleValue(options.codeFontFamily))
 
   // Tailwind's preflight resolves body/code fonts through --font-sans /
   // --font-mono at runtime. Override them only for explicit customizations so
@@ -222,7 +247,7 @@ export function applyTypographyVariables(options: {
     style.removeProperty('--font-sans')
   }
   if (codeFamily) {
-    style.setProperty('--font-mono', cssFontFamilyDeclaration(codeFamily, DEFAULT_CODE_FONT_FAMILY))
+    style.setProperty('--font-mono', cssCodeFontFamilyStyleValue(codeFamily))
   } else {
     style.removeProperty('--font-mono')
   }

--- a/apps/web/src/store/settings/typography.ts
+++ b/apps/web/src/store/settings/typography.ts
@@ -4,17 +4,18 @@ export const DEFAULT_CODE_FONT_FAMILY = 'ui-monospace, monospace'
 export const DEFAULT_UI_FONT_SIZE_PX = 16
 export const DEFAULT_CODE_FONT_SIZE_PX = 13
 
-// CJK tail appended to EVERY code stack (default or user-custom). The Latin
-// mono families above carry no CJK members, so without this the glyphs fall to
-// whatever per-lang font the OS picks — under <html lang="zh"> the :lang(zh)
-// weight shave (style.css) drops the request to ~315, which lands on PingFang's
-// Light static face and renders visibly thin/blurry at 12–13px (#851). MiSans
-// leads so code CJK matches the rest of the UI; system CJK fonts follow for
-// glyphs outside MiSans' subset ranges. Latin is always claimed earlier by the
-// mono families, and MiSans' unicode-range subsets claim no color-emoji glyphs,
-// so neither Latin nor emoji rendering changes. The CSS fallback lists in
-// style.css (var(--memoh-code-font-family, …)) mirror this tail for the
-// pre-boot frame — keep them in sync.
+// CJK concrete families inserted before the terminal generic monospace on EVERY
+// code stack (default or user-custom). The Latin mono families ahead carry no CJK
+// members, so without MiSans the glyphs fall to whatever per-lang font the OS
+// picks — under <html lang="zh"> the :lang(zh) weight shave (style.css) drops
+// the request to ~315, which lands on PingFang's Light static face and renders
+// visibly thin/blurry at 12–13px (#851). MiSans leads the CJK run so code zh
+// matches the rest of the UI; system CJK fonts in this list are only for glyphs
+// outside MiSans' subset ranges. Latin is always claimed earlier by the mono
+// families, and MiSans' unicode-range subsets claim no color-emoji glyphs, so
+// neither Latin nor emoji rendering changes. The CSS fallback lists in
+// style.css (var(--memoh-code-font-family, …)) mirror this ordering — keep
+// them in sync.
 export const CODE_FONT_CJK_FALLBACK = 'MiSans, PingFang SC, Hiragino Sans GB, Microsoft YaHei UI, Noto Sans SC'
 
 const MIN_UI_FONT_SIZE_PX = 12
@@ -128,16 +129,27 @@ export function cssFontFamilyDeclaration(value: unknown, fallback: string): stri
   return cssFontFamilyStyleValue(value, fallback)
 }
 
-// Code stacks only: the effective family list with the CJK tail appended. Goes
-// through cssFontStack first, so the tail lands AFTER the default fallback
-// (keeping it behind every Latin family the user asked for) and is present even
-// when the user stack ends in a generic family (where cssFontStack appends
-// nothing). Consumers: applyTypographyVariables, settings store codeFontStack
-// (monaco / markdown / html-preview), appearance preview.
+// Code stacks only: Latin mono families first, then the CJK concrete stack, then
+// a terminal generic monospace catch-all. CJK is inserted BEFORE that final
+// monospace so browsers don't satisfy zh glyphs via the OS monospace pick
+// (PingFang Light under :lang(zh) weight shave — #851) before MiSans is tried.
+// Goes through cssFontStack first so user/custom Latin families stay ahead of
+// the default ui-monospace fallback, and CJK is still injected when the user
+// stack already ends in a generic family (where cssFontStack appends nothing).
 export function cssCodeFontFamilyStyleValue(value: unknown): string {
-  const base = cssFontFamilyStyleValue(value, DEFAULT_CODE_FONT_FAMILY)
-  const tail = cssFontFamilyStyleValue(CODE_FONT_CJK_FALLBACK, 'monospace')
-  return `${base}, ${tail}`
+  const baseFamilies = splitFontFamilyList(
+    cssFontFamilyStyleValue(value, DEFAULT_CODE_FONT_FAMILY),
+  )
+  if (baseFamilies.length > 0 && baseFamilies.at(-1)!.toLowerCase() === 'monospace') {
+    baseFamilies.pop()
+  }
+  const head = baseFamilies.map((family) =>
+    serializeFontFamily(family, DEFAULT_CODE_FONT_FAMILY),
+  )
+  const cjk = splitFontFamilyList(CODE_FONT_CJK_FALLBACK).map((family) =>
+    serializeFontFamily(family, 'monospace'),
+  )
+  return [...head, ...cjk, 'monospace'].join(', ')
 }
 
 export function cssFontFamilyStyleValue(value: unknown, fallback: string): string {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -367,7 +367,7 @@
   /* Pre-boot default for var(--memoh-code-font-family, …) consumers
    * (markstream code below); once settings apply, the inline variable
    * carries the same tail from typography.ts. */
-  --memoh-code-font-family-default: ui-monospace, monospace, "MiSans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Noto Sans SC";
+  --memoh-code-font-family-default: ui-monospace, "MiSans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Noto Sans SC", monospace;
 }
 
 @layer components {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -351,6 +351,25 @@
   }
 }
 
+:root {
+  /* Code-font CJK coverage (#851). The stock mono stack (used by the
+   * `font-mono` utility: approval cards, inline code, diffs) has no CJK
+   * members, so code CJK fell to the OS per-lang pick — under lang="zh" the
+   * weight shave below then dropped it onto PingFang's Light face and 12px
+   * code Chinese read thin/blurry. Mirror --font-sans' CJK tail (felinic
+   * :root) so code Chinese renders the same MiSans as the rest of the UI,
+   * with system CJK behind it. Latin is always claimed by the mono families
+   * first; MiSans' unicode-range subsets claim no color emoji, so neither
+   * changes. Kept in sync with CODE_FONT_CJK_FALLBACK in
+   * store/settings/typography.ts (the runtime inline override, which wins
+   * over this when the user customizes the code font). */
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", "MiSans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Noto Sans SC", monospace;
+  /* Pre-boot default for var(--memoh-code-font-family, …) consumers
+   * (markstream code below); once settings apply, the inline variable
+   * carries the same tail from typography.ts. */
+  --memoh-code-font-family-default: ui-monospace, monospace, "MiSans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Noto Sans SC";
+}
+
 @layer components {
   [data-chat-content] .prose {
     /* Chat reading body: 16px. This is the container default; the actual glyph
@@ -490,8 +509,8 @@
 
   /* Typography scale */
   --ms-font-sans: var(--memoh-ui-font-family, inherit);
-  --ms-font-mono: var(--memoh-code-font-family, ui-monospace, monospace);
-  --markstream-code-font-family: var(--memoh-code-font-family, ui-monospace, monospace);
+  --ms-font-mono: var(--memoh-code-font-family, var(--memoh-code-font-family-default));
+  --markstream-code-font-family: var(--memoh-code-font-family, var(--memoh-code-font-family-default));
   --ms-text-body: inherit;
   --ms-leading-body: var(--chat-leading);
   /* Heading scale is em-relative (tracks the body) and restrained: headings sit
@@ -679,7 +698,7 @@
   padding: 0.125rem 0.375rem;
   font-size: 0.875em;
   font-weight: 480;
-  font-family: var(--memoh-code-font-family, ui-monospace, monospace);
+  font-family: var(--memoh-code-font-family, var(--memoh-code-font-family-default));
 }
 
 /* Code block container — soft rounded frame */
@@ -687,7 +706,7 @@
   margin: 1rem 0;
   overflow: hidden;
   font-size: var(--memoh-code-font-size, 13px);
-  font-family: var(--memoh-code-font-family, ui-monospace, monospace);
+  font-family: var(--memoh-code-font-family, var(--memoh-code-font-family-default));
 }
 
 /* markstream-vue 1.0.7 renamed .code-block-content to .code-block-shell-content
@@ -695,7 +714,7 @@
  * so the line-height override keeps applying. */
 .markstream-vue .code-block-container .code-block-shell-content {
   font-size: var(--memoh-code-font-size, 13px);
-  font-family: var(--memoh-code-font-family, ui-monospace, monospace);
+  font-family: var(--memoh-code-font-family, var(--memoh-code-font-family-default));
   line-height: 1.5;
 }
 


### PR DESCRIPTION
## Summary
- Append MiSans-led CJK fallback to every code font stack so Chinese in mono contexts (approval cards, chat code blocks, diffs) no longer render thin/blurry under `lang=zh`.
- Unify markstream/monaco/markdown consumers through `cssCodeFontFamilyStyleValue()` and extend Tailwind `--font-mono`.

Closes #851

## Test plan
- [ ] Set UI language to 中文 and open a chat code block / diff with Chinese text — glyphs should look crisp at 12px
- [ ] Verify Latin mono still uses the configured code font first
- [ ] Run `pnpm exec vitest run apps/web/src/store/settings/typography.test.ts`