### PR TITLE
ci(runtime): publish package on version changes

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -24,6 +24,7 @@ on:
       - "vitest.config.ts"
       - ".github/workflows/eslint.yml"
       - ".github/workflows/release.yml"
+      - ".github/workflows/runtime-release.yml"
   pull_request:
     branches: ["main"]
     paths:
@@ -47,6 +48,7 @@ on:
       - "vitest.config.ts"
       - ".github/workflows/eslint.yml"
       - ".github/workflows/release.yml"
+      - ".github/workflows/runtime-release.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,15 +83,15 @@ jobs:
             --clobber
 
   # npm publish jobs authenticate via npm trusted publishing (OIDC), not token
-  # secrets: each published package has memohai/Memoh + this release.yml
-  # registered as its trusted publisher on npmjs.com, and pnpm exchanges the
-  # GitHub OIDC token at publish time (requires id-token: write on the job).
+  # secrets. Packages published here have memohai/Memoh + this release.yml
+  # registered as their trusted publisher on npmjs.com. @memohai/runtime is
+  # intentionally excluded: runtime-release.yml owns that package.
   # The npm-side trusted publisher entry has NO environment name, so these jobs
   # must NOT declare an `environment:` — npm matches repo + workflow +
   # environment exactly, and a mismatch fails auth with an opaque 404.
   # If a package is ever added to the publish allowlist in
-  # scripts/publish-packages.mjs, it must get the same trusted-publisher entry
-  # on npmjs.com first, or its publish will fail. The old NPM_TOKEN /
+  # scripts/publish-packages.mjs, it must register whichever workflow owns its
+  # release on npmjs.com first, or its publish will fail. The old NPM_TOKEN /
   # FELINIC_NPM_TOKEN secrets are retired; scripts/publish-packages.mjs still
   # supports NODE_AUTH_TOKEN for local manual publishes.
   npm-publish-felinic:
@@ -238,4 +238,5 @@ jobs:
       - name: Publish @memohai packages
         env:
           NPM_PUBLISH_SCOPE: "@memohai"
+          NPM_PUBLISH_EXCLUDE: "@memohai/runtime"
         run: pnpm publish:npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,6 @@ jobs:
           const targets = [
             'package.json',
             'packages/sdk/package.json',
-            'packages/runtime/package.json',
             'packages/ui/package.json',
             'packages/icons/package.json',
             'packages/config/package.json',
@@ -200,7 +199,6 @@ jobs:
           const targets = [
             'package.json',
             'packages/sdk/package.json',
-            'packages/runtime/package.json',
             'packages/icons/package.json',
             'packages/config/package.json',
             'apps/web/package.json',

--- a/.github/workflows/runtime-ci.yml
+++ b/.github/workflows/runtime-ci.yml
@@ -11,6 +11,7 @@ on:
       - "pnpm-workspace.yaml"
       - "tsconfig.json"
       - ".github/workflows/runtime-ci.yml"
+      - ".github/workflows/runtime-release.yml"
   pull_request:
     branches: ["main"]
     paths:
@@ -21,6 +22,7 @@ on:
       - "pnpm-workspace.yaml"
       - "tsconfig.json"
       - ".github/workflows/runtime-ci.yml"
+      - ".github/workflows/runtime-release.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/runtime-release.yml
+++ b/.github/workflows/runtime-release.yml
@@ -13,6 +13,7 @@ permissions:
 concurrency:
   group: runtime-release
   cancel-in-progress: false
+  queue: max
 
 jobs:
   detect-version:

--- a/.github/workflows/runtime-release.yml
+++ b/.github/workflows/runtime-release.yml
@@ -1,0 +1,100 @@
+name: Runtime Release
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "packages/runtime/package.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-release
+  cancel-in-progress: false
+
+jobs:
+  detect-version:
+    name: Detect Runtime version change
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.version.outputs.changed }}
+      current: ${{ steps.version.outputs.current }}
+      previous: ${{ steps.version.outputs.previous }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compare package versions
+        id: version
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          current="$(node -p "require('./packages/runtime/package.json').version")"
+          previous=""
+
+          if [[ "$EVENT_NAME" == "push" ]] \
+            && [[ -n "$BEFORE_SHA" ]] \
+            && git cat-file -e "${BEFORE_SHA}:packages/runtime/package.json" 2>/dev/null; then
+            previous="$(
+              git show "${BEFORE_SHA}:packages/runtime/package.json" \
+                | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version"
+            )"
+          fi
+
+          changed=false
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$current" != "$previous" ]]; then
+            changed=true
+          fi
+
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "Runtime version: ${previous:-unknown} -> $current (changed=$changed)"
+
+  publish:
+    name: Publish @memohai/runtime
+    needs: detect-version
+    if: needs.detect-version.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck Runtime
+        run: pnpm --filter @memohai/runtime typecheck
+
+      - name: Test Runtime
+        run: pnpm --filter @memohai/runtime test
+
+      - name: Build Runtime
+        run: pnpm --filter @memohai/runtime build
+
+      - name: Publish Runtime
+        env:
+          NPM_PUBLISH_PACKAGE: "@memohai/runtime"
+        run: pnpm publish:npm

--- a/bump.config.ts
+++ b/bump.config.ts
@@ -4,9 +4,6 @@ export default defineConfig({
   files: [
     'package.json',
     'packages/sdk/package.json',
-    // Full Memoh releases still advance Runtime. Its package publish is owned
-    // separately by runtime-release.yml when this committed version changes.
-    'packages/runtime/package.json',
     'packages/icons/package.json',
     'packages/config/package.json',
     'apps/web/package.json',

--- a/bump.config.ts
+++ b/bump.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   files: [
     'package.json',
     'packages/sdk/package.json',
+    // Full Memoh releases still advance Runtime. Its package publish is owned
+    // separately by runtime-release.yml when this committed version changes.
     'packages/runtime/package.json',
     'packages/icons/package.json',
     'packages/config/package.json',

--- a/scripts/publish-auth.test.mjs
+++ b/scripts/publish-auth.test.mjs
@@ -10,6 +10,45 @@ import { detectPublishAuthMode } from './publish-auth.mjs'
 
 const ROOT_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
 
+function createFakePublishCommands(prefix) {
+  const tempDir = mkdtempSync(join(tmpdir(), prefix))
+  const fakeBin = join(tempDir, 'bin')
+  const npmLog = join(tempDir, 'npm.log')
+  const pnpmLog = join(tempDir, 'pnpm.log')
+
+  mkdirSync(fakeBin)
+
+  const fakeNpm = join(fakeBin, 'npm')
+  writeFileSync(fakeNpm, `#!/bin/sh
+printf '%s\\n' "$*" >> "$PUBLISH_TEST_NPM_LOG"
+[ "$1" = "view" ] && exit 1
+exit 91
+`)
+  chmodSync(fakeNpm, 0o755)
+
+  const fakePnpm = join(fakeBin, 'pnpm')
+  writeFileSync(fakePnpm, `#!/bin/sh
+printf '%s\\n' "$*" >> "$PUBLISH_TEST_PNPM_LOG"
+exit 0
+`)
+  chmodSync(fakePnpm, 0o755)
+
+  return {
+    env: {
+      ...process.env,
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'https://github.example.test/oidc',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-oidc-request-token',
+      NODE_AUTH_TOKEN: 'XXXXX-XXXXX-XXXXX-XXXXX',
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      PUBLISH_TEST_NPM_LOG: npmLog,
+      PUBLISH_TEST_PNPM_LOG: pnpmLog,
+    },
+    npmLog,
+    pnpmLog,
+    cleanup: () => rmSync(tempDir, { recursive: true, force: true }),
+  }
+}
+
 test('prefers GitHub OIDC over the setup-node token placeholder', () => {
   assert.equal(detectPublishAuthMode({
     ACTIONS_ID_TOKEN_REQUEST_URL: 'https://github.example.test/oidc',
@@ -39,54 +78,69 @@ test('does not accept an incomplete OIDC environment', () => {
 })
 
 test('publish script skips token preflight when setup-node placeholder and OIDC coexist', () => {
-  const tempDir = mkdtempSync(join(tmpdir(), 'memoh-publish-auth-'))
-  const fakeBin = join(tempDir, 'bin')
-  const npmLog = join(tempDir, 'npm.log')
-  const pnpmLog = join(tempDir, 'pnpm.log')
+  const fixture = createFakePublishCommands('memoh-publish-auth-')
 
   try {
-    mkdirSync(fakeBin)
-
-    const fakeNpm = join(fakeBin, 'npm')
-    writeFileSync(fakeNpm, `#!/bin/sh
-printf '%s\\n' "$*" >> "$PUBLISH_TEST_NPM_LOG"
-[ "$1" = "view" ] && exit 1
-exit 91
-`)
-    chmodSync(fakeNpm, 0o755)
-
-    const fakePnpm = join(fakeBin, 'pnpm')
-    writeFileSync(fakePnpm, `#!/bin/sh
-printf '%s\\n' "$*" >> "$PUBLISH_TEST_PNPM_LOG"
-exit 0
-`)
-    chmodSync(fakePnpm, 0o755)
-
     const result = spawnSync(process.execPath, ['scripts/publish-packages.mjs'], {
       cwd: ROOT_DIR,
       encoding: 'utf8',
       env: {
-        ...process.env,
-        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://github.example.test/oidc',
-        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-oidc-request-token',
-        NODE_AUTH_TOKEN: 'XXXXX-XXXXX-XXXXX-XXXXX',
+        ...fixture.env,
         NPM_PUBLISH_SCOPE: '@memohai',
-        PATH: `${fakeBin}:${process.env.PATH}`,
-        PUBLISH_TEST_NPM_LOG: npmLog,
-        PUBLISH_TEST_PNPM_LOG: pnpmLog,
+        NPM_PUBLISH_EXCLUDE: '@memohai/runtime',
       },
     })
 
     assert.equal(result.status, 0, result.stderr || result.stdout)
     assert.match(result.stdout, /OIDC trusted publishing: skipping token preflight/)
 
-    const npmCalls = readFileSync(npmLog, 'utf8')
+    const npmCalls = readFileSync(fixture.npmLog, 'utf8')
     assert.doesNotMatch(npmCalls, /^whoami$/m)
     assert.doesNotMatch(npmCalls, /^access /m)
 
-    const pnpmCalls = readFileSync(pnpmLog, 'utf8')
+    const pnpmCalls = readFileSync(fixture.pnpmLog, 'utf8')
     assert.match(pnpmCalls, /publish apps\/desktop --access public --no-git-checks --provenance/)
+    assert.doesNotMatch(pnpmCalls, /publish packages\/runtime /)
   } finally {
-    rmSync(tempDir, { recursive: true, force: true })
+    fixture.cleanup()
   }
+})
+
+test('publish script can select only the Runtime package', () => {
+  const fixture = createFakePublishCommands('memoh-runtime-publish-')
+
+  try {
+    const result = spawnSync(process.execPath, ['scripts/publish-packages.mjs'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf8',
+      env: {
+        ...fixture.env,
+        NPM_PUBLISH_PACKAGE: '@memohai/runtime',
+      },
+    })
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.match(result.stdout, /@memohai\/runtime@/)
+
+    const npmCalls = readFileSync(fixture.npmLog, 'utf8')
+    assert.match(npmCalls, /^view @memohai\/runtime@\S+ version$/m)
+    assert.equal(npmCalls.trim().split('\n').length, 1)
+
+    const pnpmCalls = readFileSync(fixture.pnpmLog, 'utf8')
+    assert.match(pnpmCalls, /^publish packages\/runtime --access public --no-git-checks --provenance$/m)
+    assert.equal(pnpmCalls.trim().split('\n').length, 1)
+  } finally {
+    fixture.cleanup()
+  }
+})
+
+test('Runtime release workflow is version-gated and owns only @memohai/runtime', () => {
+  const workflow = readFileSync(join(ROOT_DIR, '.github/workflows/runtime-release.yml'), 'utf8')
+  const aggregateWorkflow = readFileSync(join(ROOT_DIR, '.github/workflows/release.yml'), 'utf8')
+
+  assert.match(workflow, /paths:\n\s+- "packages\/runtime\/package\.json"/)
+  assert.match(workflow, /git show "\$\{BEFORE_SHA\}:packages\/runtime\/package\.json"/)
+  assert.match(workflow, /if: needs\.detect-version\.outputs\.changed == 'true'/)
+  assert.match(workflow, /NPM_PUBLISH_PACKAGE: "@memohai\/runtime"/)
+  assert.match(aggregateWorkflow, /NPM_PUBLISH_EXCLUDE: "@memohai\/runtime"/)
 })

--- a/scripts/publish-auth.test.mjs
+++ b/scripts/publish-auth.test.mjs
@@ -137,10 +137,14 @@ test('publish script can select only the Runtime package', () => {
 test('Runtime release workflow is version-gated and owns only @memohai/runtime', () => {
   const workflow = readFileSync(join(ROOT_DIR, '.github/workflows/runtime-release.yml'), 'utf8')
   const aggregateWorkflow = readFileSync(join(ROOT_DIR, '.github/workflows/release.yml'), 'utf8')
+  const bumpConfig = readFileSync(join(ROOT_DIR, 'bump.config.ts'), 'utf8')
 
   assert.match(workflow, /paths:\n\s+- "packages\/runtime\/package\.json"/)
   assert.match(workflow, /git show "\$\{BEFORE_SHA\}:packages\/runtime\/package\.json"/)
   assert.match(workflow, /if: needs\.detect-version\.outputs\.changed == 'true'/)
+  assert.match(workflow, /concurrency:\n\s+group: runtime-release\n\s+cancel-in-progress: false\n\s+queue: max/)
   assert.match(workflow, /NPM_PUBLISH_PACKAGE: "@memohai\/runtime"/)
   assert.match(aggregateWorkflow, /NPM_PUBLISH_EXCLUDE: "@memohai\/runtime"/)
+  assert.doesNotMatch(aggregateWorkflow, /'packages\/runtime\/package\.json'/)
+  assert.doesNotMatch(bumpConfig, /'packages\/runtime\/package\.json'/)
 })

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -32,13 +32,20 @@ const log = {
 
 const dryRun = process.argv.includes('--dry-run') || process.env.PUBLISH_PACKAGES_DRY_RUN === '1'
 const publishScope = process.env.NPM_PUBLISH_SCOPE?.trim() || null
+const publishPackage = process.env.NPM_PUBLISH_PACKAGE?.trim() || null
+const excludedPackages = new Set(
+  (process.env.NPM_PUBLISH_EXCLUDE ?? '')
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean),
+)
 
 // Auth model: two modes.
 // - Token mode (local/manual): NODE_AUTH_TOKEN is set and used directly.
 // - OIDC mode (CI trusted publishing): pnpm exchanges the GitHub
 //   Actions OIDC token (ACTIONS_ID_TOKEN_REQUEST_TOKEN, available when the job
 //   has id-token: write) for a short-lived npm credential at publish time.
-//   Every published package must have memohai/Memoh + release.yml registered
+//   Every published package must register the workflow that owns its release
 //   as its trusted publisher on npmjs.com, or the exchange is rejected.
 // OIDC mode changes two behaviors below: the token preflight is impossible
 // (npm whoami needs a token), so it is skipped; and --provenance is added,
@@ -199,6 +206,18 @@ for (const dir of CANDIDATE_DIRS) {
 
   if (publishScope && scopeOf(name) !== publishScope) {
     log.skip(`${name} (outside ${publishScope})`)
+    skipped++
+    continue
+  }
+
+  if (publishPackage && name !== publishPackage) {
+    log.skip(`${name} (not selected)`)
+    skipped++
+    continue
+  }
+
+  if (excludedPackages.has(name)) {
+    log.skip(`${name} (independent release)`)
     skipped++
     continue
   }


### PR DESCRIPTION
## 改动

Runtime 现在使用独立版本，可以脱离 Memoh 整体版本单独发布。

- 新增 `runtime-release.yml`，监听 `main` 上 `packages/runtime/package.json` 的变化
- 比较 push 前后的 `version`，只有版本变化才会发包，普通 metadata 变化不会触发发布
- 发布前执行 Runtime 的 typecheck、测试和构建
- `publish-packages.mjs` 支持按 package 精确选择或排除
- 从全仓 `bumpp` 和整体 release 的版本同步中移除 Runtime；完整 Memoh release 不再修改 Runtime 版本
- 整体 `release.yml` 排除 `@memohai/runtime`，避免两个 workflow 同时发布
- 使用 `queue: max` 串行保留连续版本的发布任务，避免 pending run 被后续版本替换

## 发布方式

需要发布 Runtime 时，在对应代码改动中更新 `packages/runtime/package.json` 的版本。合入 `main` 后，`runtime-release.yml` 会自动完成验证和发布。

完整 Memoh release 不会再提升或发布 Runtime；Desktop 发布时会使用仓库中已经记录的 Runtime 版本。

## 验证

- `node --test scripts/publish-auth.test.mjs`（7 个测试）
- `pnpm --filter @memohai/runtime typecheck`
- `pnpm --filter @memohai/runtime test`（8 files / 37 tests）
- `pnpm --filter @memohai/runtime build`
- ESLint
- 相关 workflow 已使用支持 `queue: max` 的 actionlint 版本校验；该语法由 GitHub Actions 于 2026 年 5 月正式支持

## 合并后的配置

这个 PR 不修改 Runtime 当前的 `0.17.0`，合并后不会立即发包。

在提交 `0.17.1` 版本变更前，需要先把 npm 上 `@memohai/runtime` 的 Trusted Publisher workflow 从 `release.yml` 改为 `runtime-release.yml`，Environment 留空。之后只要 Runtime package version 合入 `main`，就会自动发包。