### PR TITLE
fix(web): keep the composer model picker open after selection

### DIFF
--- a/apps/web/src/pages/home/components/chat-model-picker.vue
+++ b/apps/web/src/pages/home/components/chat-model-picker.vue
@@ -195,10 +195,6 @@ const props = defineProps<{
   }>
 }>()
 
-const emit = defineEmits<{
-  close: []
-}>()
-
 const modelValue = defineModel<string>({ default: '' })
 const reasoningEffort = defineModel<string>('reasoningEffort', { default: '' })
 
@@ -432,17 +428,19 @@ const currentReasoningLabelKey = computed(() =>
   currentReasoningOption.value?.labelKey ?? EFFORT_LABELS[currentReasoningValue.value] ?? 'chat.reasoningOff',
 )
 
-// Picking a model by its name commits the choice and dismisses the menu.
+// Selection applies immediately and the popover STAYS OPEN on purpose (#899):
+// the user can hop between models (and efforts) to compare without reopening
+// the menu. Dismissal is the popover's own business — outside click / Esc.
 function commitModel(value: string) {
   reasoningOpen.value = false
   if (value !== modelValue.value) modelValue.value = value
-  emit('close')
 }
 
 function setEffort(level: string) {
+  // Keep the effort flyout open after a pick (#899): the check mark just
+  // moves. Collapsing on every click made a shaky double-click land on the
+  // backdrop and dismiss the whole popover.
   reasoningEffort.value = level
-  reasoningOpen.value = false
-  emit('close')
 }
 
 watch(() => props.open, (v) => {

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -623,7 +623,6 @@
                         :open="modelPopoverOpen"
                         @update:model-value="onComposerModelValueSelected"
                         @update:reasoning-effort="onComposerReasoningEffortSelected"
-                        @close="modelPopoverOpen = false"
                       />
                     </PopoverContent>
                   </Popover>
@@ -1930,9 +1929,8 @@ async function selectMemohAgent() {
 }
 
 function onModelSelected() {
-  // The picker drives dismissal via @close (so opening a model's reasoning
-  // options can adopt it without collapsing the menu); here we only sanitise
-  // the effort when the new model can't reason.
+  // The popover stays open on selection (#899) — dismissal is outside click /
+  // Esc. Here we only sanitise the effort when the new model can't reason.
   if (!activeModelSupportsReasoning.value) {
     overrideReasoningEffort.value = REASONING_EFFORT_DISABLE
   }


### PR DESCRIPTION
Closes #899.

## What

The composer model picker no longer dismisses itself on selection:

- **Model pick**: the check mark moves, popover stays open — hop between models to compare without reopening.
- **Reasoning effort pick**: the effort flyout also stays open. Previously it collapsed on every click, so a shaky double-click's second click landed on the backdrop and killed the whole popover.

Dismissal is unchanged and entirely the popover's own: outside click / Esc.

## Diff

2 files, +8/−12 — deletes the `close` emit (`commitModel`/`setEffort`) and its single call-site wiring. `ChatModelPicker` has exactly one consumer (the composer), no other surface affected.

## Test plan

- [x] `vue-tsc` / eslint / `chat-model-picker.test.ts` (3 tests) green
- [ ] Manual: open composer model pill → select another model → popover stays, check moves; pick an effort → flyout stays; Esc / outside click closes