### PR TITLE
fix(web): drop the double frame around the Members table

### DIFF
--- a/apps/web/src/pages/people/index.vue
+++ b/apps/web/src/pages/people/index.vue
@@ -19,7 +19,10 @@
         <AlertDescription>{{ loadError }}</AlertDescription>
       </Alert>
 
-      <SettingsSection :title="membersTitle">
+      <section class="space-y-2.5">
+        <h2 class="px-2 text-label font-medium text-muted-foreground">
+          {{ membersTitle }}
+        </h2>
         <Table>
           <TableHeader>
             <TableRow>
@@ -143,7 +146,7 @@
             </TableRow>
           </TableBody>
         </Table>
-      </SettingsSection>
+      </section>
     </div>
 
     <Dialog v-model:open="createDialogOpen">
@@ -274,7 +277,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { ConfirmPopover, FieldStack, FormStack, PageShell, SettingsSection, toast } from '@felinic/ui'
+import { ConfirmPopover, FieldStack, FormStack, PageShell, toast } from '@felinic/ui'
 import { Trash2, UserPlus } from 'lucide-vue-next'
 import {
   Alert,


### PR DESCRIPTION
## What

The Members table was wrapped in `SettingsSection`, but `Table` already self-frames (`rounded-lg border bg-card`) — the nested card drew a second border + second radius, so the table read visibly heavier than every other page.

Switch to the bare `<section>` + `h2` idiom the bot email outbox table already uses. Title typography and inset are unchanged (`text-label`, `px-2`).

1 file, +6/−3.

## Test plan

- [x] `vue-tsc` / eslint green
- [x] Manual: Members page now shows a single table frame, matching the outbox/usage tables