### PR TITLE
chore(web): bump ui submodule, drop deleted sidebar tokens from the dev-wall catalog

### DIFF
--- a/apps/web/src/pages/dev/components/lib/token-catalog.ts
+++ b/apps/web/src/pages/dev/components/lib/token-catalog.ts
@@ -59,9 +59,8 @@ export const tokenGroups: TokenGroup[] = [
     label: 'Sidebar',
     tokens: [
       'sidebar', 'sidebar-foreground',
-      'sidebar-primary', 'sidebar-primary-foreground',
       'sidebar-accent', 'sidebar-accent-foreground',
-      'sidebar-border', 'sidebar-ring',
+      'sidebar-border',
     ],
   },
   {


### PR DESCRIPTION
Follow-up to memohai/ui#13 (merged as `f95e998`), which deleted the dead `--sidebar-primary` / `--sidebar-ring` tokens and synced DESIGN.md.

- `packages/ui` gitlink: `ad14119` → `f95e998`
- dev-wall `token-catalog.ts`: removes the three deleted tokens from the Sidebar family listing (the only host-side reference)

No component in the host referenced these tokens — verified by grep across `apps/web`, `apps/desktop`, and `packages/*`.

## Test plan

- [x] `vue-tsc` green
- [ ] CI