### PR TITLE
fix(web): render completed ask_user as an answers card in the text flow

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -646,6 +646,11 @@
     "panel": {
       "regionLabel": "Pending items"
     },
+    "answers": {
+      "skipped": "Skipped",
+      "cancelled": "Cancelled",
+      "unanswered": "No answer"
+    },
     "tools": {
       "read": "Read",
       "write": "Write",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -615,6 +615,11 @@
     "panel": {
       "regionLabel": "保留中の項目"
     },
+    "answers": {
+      "skipped": "スキップ",
+      "cancelled": "キャンセル",
+      "unanswered": "未回答"
+    },
     "tools": {
       "read": "読む",
       "write": "書く",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -646,6 +646,11 @@
     "panel": {
       "regionLabel": "待处理事项"
     },
+    "answers": {
+      "skipped": "已跳过",
+      "cancelled": "已取消",
+      "unanswered": "未作答"
+    },
     "tools": {
       "read": "读取",
       "write": "写入",

--- a/apps/web/src/pages/home/components/chat-answers-card.vue
+++ b/apps/web/src/pages/home/components/chat-answers-card.vue
@@ -1,0 +1,87 @@
+<template>
+  <!-- Completed ask_user, rendered as a quiet bordered card IN the text flow.
+       The Q&A record is content the conversation refers back to — unlike the
+       muted process capsule, which holds transient tool machinery — so it
+       breaks out of the tool-call group (see renderNodes in message-item)
+       and takes a bordered card, never the capsule. bg-card lifts the card
+       off the page in dark mode (0.21 vs 0.152 surface); in light both are
+       effectively white, so the card stays quiet there. Question muted,
+       answer foreground: the Q→A reading without extra chrome.
+       Width hugs the Q&A content (w-fit) instead of spanning the column —
+       a full-width frame around two short lines reads as scaffolding. -->
+  <div class="w-fit max-w-full rounded-lg border border-border bg-card px-4 py-3">
+    <div class="space-y-2.5">
+      <div
+        v-for="entry in entries"
+        :key="entry.id"
+      >
+        <p class="text-sm text-muted-foreground">
+          {{ entry.question }}
+        </p>
+        <p
+          class="mt-0.5 text-sm"
+          :class="entry.unanswered ? 'text-muted-foreground' : 'text-foreground'"
+        >
+          {{ entry.answer }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { ToolCallBlock } from '@/store/chat-list'
+
+const props = defineProps<{ block: ToolCallBlock }>()
+const { t } = useI18n()
+
+// Shape of one result entry, from the backend's submittedResult: the tool
+// result already carries the question text and human-readable answer, so the
+// card never touches the raw input JSON (that dump was #868).
+type ResultAnswer = {
+  question?: string
+  selected?: { label?: string }[]
+  custom_text?: string
+  text?: string
+  skipped?: boolean
+}
+
+const entries = computed(() => {
+  const result = props.block.result as { status?: string; answers?: ResultAnswer[] } | null
+  if (Array.isArray(result?.answers)) {
+    return result.answers.map((a, i) => ({
+      id: `a${i}`,
+      question: a.question ?? '',
+      answer: answerText(a),
+      unanswered: a.skipped === true,
+    }))
+  }
+  // canceled / expired / failed: no answers recorded — show what was asked
+  // with an unanswered marker (questions from the live request state, or the
+  // tool input for pre-v2 history).
+  const questions = props.block.userInput?.questions?.map(q => q.text)
+    ?? legacyQuestions(props.block.input)
+  const note = result?.status === 'canceled'
+    ? t('chat.answers.cancelled')
+    : t('chat.answers.unanswered')
+  return questions.map((q, i) => ({ id: `q${i}`, question: q, answer: note, unanswered: true }))
+})
+
+function answerText(a: ResultAnswer): string {
+  if (a.skipped) return t('chat.answers.skipped')
+  const parts: string[] = []
+  if (a.selected?.length) parts.push(a.selected.map(s => s.label ?? '').filter(Boolean).join(', '))
+  if (a.custom_text) parts.push(a.custom_text)
+  if (a.text) parts.push(a.text)
+  return parts.filter(Boolean).join(', ')
+}
+
+function legacyQuestions(input: unknown): string[] {
+  const obj = input as { questions?: { text?: string }[]; question?: string } | null
+  if (Array.isArray(obj?.questions)) return obj.questions.map(q => q.text ?? '').filter(Boolean)
+  if (typeof obj?.question === 'string') return [obj.question]
+  return []
+}
+</script>

--- a/apps/web/src/pages/home/components/chat-answers-card.vue
+++ b/apps/web/src/pages/home/components/chat-answers-card.vue
@@ -60,10 +60,12 @@ const entries = computed(() => {
   }
   // canceled / expired / failed: no answers recorded — show what was asked
   // with an unanswered marker (questions from the live request state, or the
-  // tool input for pre-v2 history).
+  // tool input for pre-v2 history). The terminal status can live in either
+  // the result OR userInput.status (a canceled request may end result-less).
   const questions = props.block.userInput?.questions?.map(q => q.text)
     ?? legacyQuestions(props.block.input)
-  const note = result?.status === 'canceled'
+  const status = result?.status ?? props.block.userInput?.status
+  const note = status === 'canceled'
     ? t('chat.answers.cancelled')
     : t('chat.answers.unanswered')
   return questions.map((q, i) => ({ id: `q${i}`, question: q, answer: note, unanswered: true }))

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -298,6 +298,13 @@
               :active="message.streaming && node.lastIndex === message.messages.length - 1"
             />
 
+            <!-- Completed ask_user: the Q&A card, broken out of the process
+                 group so it reads as conversation content, not tool machinery. -->
+            <ChatAnswersCard
+              v-else-if="node.kind === 'answers'"
+              :block="node.block"
+            />
+
             <template v-else>
               <!-- Text block -->
               <!-- Headings split into two spacing groups, not one flat ramp:
@@ -413,6 +420,7 @@ import { Avatar, AvatarImage, AvatarFallback, Button, Textarea } from '@felinic/
 import MarkdownRender, { enableKatex, enableMermaid } from 'markstream-vue'
 import { useSettingsStore } from '@/store/settings'
 import ToolCallGroup from './tool-call-group.vue'
+import ChatAnswersCard from './chat-answers-card.vue'
 import { toolSegmentCategoryForBlock } from './tool-call-registry'
 import type { ToolSegmentCategory } from './tool-call-registry'
 import { finalizeReasoning, markReasoningSeen } from './reasoning-timing'
@@ -821,8 +829,25 @@ function isVisibleAssistantBlock(block: ContentBlock): boolean {
 //  - Every other block type (text / error / attachments) keeps its place.
 // Keyed by stable block id.
 type ProcessNode = { kind: 'process'; key: string; items: ContentBlock[]; cat: ToolSegmentCategory | null; lastIndex: number }
+type AnswersNode = { kind: 'answers'; key: string; block: ContentBlock; index: number }
 type BlockNode = { kind: 'block'; key: string; block: ContentBlock; index: number }
-type RenderNode = ProcessNode | BlockNode
+type RenderNode = ProcessNode | AnswersNode | BlockNode
+
+// A completed ask_user is content, not process: it carries the Q&A record, so
+// it breaks out of the tool group and renders as an answers card in the text
+// flow. A pending one has no result yet and stays in the group (its input
+// form lives elsewhere). Content-based check — works for pre-v2 history too.
+function isCompletedAskUser(block: ContentBlock): boolean {
+  if (block.type !== 'tool') return false
+  const b = block as ToolCallBlockType
+  if (b.toolName !== 'ask_user') return false
+  const r = b.result as { status?: unknown; answers?: unknown } | null
+  if (!r || typeof r !== 'object') return false
+  return Array.isArray(r.answers)
+    || r.status === 'canceled'
+    || r.status === 'expired'
+    || r.status === 'failed'
+}
 
 const renderNodes = computed<RenderNode[]>(() => {
   if (props.message.role !== 'assistant') return []
@@ -830,6 +855,11 @@ const renderNodes = computed<RenderNode[]>(() => {
   let run: ProcessNode | null = null
   props.message.messages.forEach((block, index) => {
     if (!isVisibleAssistantBlock(block)) return
+    if (isCompletedAskUser(block)) {
+      run = null
+      nodes.push({ kind: 'answers', key: `a${block.id}`, block, index })
+      return
+    }
     if (block.type === 'tool' || block.type === 'reasoning') {
       const cat = block.type === 'tool'
         ? toolSegmentCategoryForBlock(block as ToolCallBlockType)

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -836,17 +836,24 @@ type RenderNode = ProcessNode | AnswersNode | BlockNode
 // A completed ask_user is content, not process: it carries the Q&A record, so
 // it breaks out of the tool group and renders as an answers card in the text
 // flow. A pending one has no result yet and stays in the group (its input
-// form lives elsewhere). Content-based check — works for pre-v2 history too.
+// form lives elsewhere). Two completion signals, because a canceled/expired/
+// failed request can end WITHOUT a tool result — the terminal state then
+// lives only in userInput.status (the backend's user_input_request event
+// sets UserInput but never a result). The result path also covers pre-v2
+// history where userInput is absent.
+const ASK_USER_TERMINAL_STATUSES = new Set(['submitted', 'canceled', 'expired', 'failed'])
+
 function isCompletedAskUser(block: ContentBlock): boolean {
   if (block.type !== 'tool') return false
   const b = block as ToolCallBlockType
   if (b.toolName !== 'ask_user') return false
   const r = b.result as { status?: unknown; answers?: unknown } | null
-  if (!r || typeof r !== 'object') return false
-  return Array.isArray(r.answers)
-    || r.status === 'canceled'
-    || r.status === 'expired'
-    || r.status === 'failed'
+  if (r && typeof r === 'object') {
+    if (Array.isArray(r.answers)) return true
+    if (typeof r.status === 'string' && ASK_USER_TERMINAL_STATUSES.has(r.status)) return true
+  }
+  const s = b.userInput?.status
+  return typeof s === 'string' && ASK_USER_TERMINAL_STATUSES.has(s)
 }
 
 const renderNodes = computed<RenderNode[]>(() => {


### PR DESCRIPTION
Closes #868.

## What

A completed `ask_user` was folded into the tool-call group like any other tool — and expanding its row dumped the raw `questions` JSON at the user.

But a finished ask_user is **conversation content** (the Q&A record), not tool machinery. This PR separates it:

- **`renderNodes` (message-item)**: a completed ask_user (result has `answers`, or status `canceled`/`expired`/`failed`) breaks out of the process group and becomes its own node. Pending requests keep the existing group row + input form — untouched.
- **New `chat-answers-card.vue`**: a quiet bordered card composed with the text flow — question muted, answer foreground, width hugging the content (`w-fit`), `bg-card` so it lifts off the page in dark mode while staying effectively white in light mode.
- **Data source**: the tool `result` only (question text + `selected[].label` / `custom_text` / `text` / `skipped` per answer). The raw input JSON path is gone entirely. Canceled/expired/failed requests show the asked questions with an unanswered marker.
- i18n ×3 (skipped / cancelled / unanswered).

## Test plan

- [x] `vue-tsc` / eslint / `check-ui-contract` green
- [x] component + store vitest: failures identical to the pre-existing `chat-list.test.ts` baseline, zero new
- [x] Manual: completed ask_user renders as the card in flow; pending still shows the input form; dark mode card lifts off background