### PR TITLE
fix(web): preserve thinking collapse state while streaming

### DIFF
--- a/apps/web/src/pages/home/components/process-collapse.ts
+++ b/apps/web/src/pages/home/components/process-collapse.ts
@@ -22,6 +22,11 @@ export function setCollapseOpen(key: string, open: boolean): void {
   if (key) openState.set(key, open)
 }
 
+export function migrateCollapseOpen(previousKey: string, key: string, open: boolean): void {
+  if (previousKey && previousKey !== key) openState.delete(previousKey)
+  setCollapseOpen(key, open)
+}
+
 function hash(value: string): string {
   let h = 0
   for (let i = 0; i < value.length; i += 1) {

--- a/apps/web/src/pages/home/components/thinking-block.test.ts
+++ b/apps/web/src/pages/home/components/thinking-block.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { createApp, defineComponent, h, nextTick, shallowRef } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ThinkingBlock as ThinkingBlockType } from '@/store/chat-list'
+import ThinkingBlock from './thinking-block.vue'
+
+interface MountedThinkingBlock {
+  app: ReturnType<typeof createApp>
+  root: HTMLDivElement
+  setContent: (content: string) => void
+}
+
+const mounted: MountedThinkingBlock[] = []
+
+afterEach(() => {
+  for (const item of mounted.splice(0)) {
+    item.app.unmount()
+    item.root.remove()
+  }
+})
+
+function mountThinkingBlock(content: string, streaming = true): MountedThinkingBlock {
+  const block = shallowRef<ThinkingBlockType>({ id: 1, type: 'reasoning', content })
+  const harness = defineComponent({
+    setup() {
+      return () => h(ThinkingBlock, { block: block.value, streaming })
+    },
+  })
+  const root = document.createElement('div')
+  document.body.append(root)
+  const app = createApp(harness)
+  app.use(createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: {
+      en: {
+        chat: {
+          thinkingInProgress: 'Thinking',
+          process: {
+            thoughtBriefly: 'Thought briefly',
+          },
+        },
+      },
+    },
+  }))
+  app.mount(root)
+
+  const result = {
+    app,
+    root,
+    setContent: (nextContent: string) => {
+      block.value = { ...block.value, content: nextContent }
+    },
+  }
+  mounted.push(result)
+  return result
+}
+
+function unmountThinkingBlock(item: MountedThinkingBlock): void {
+  item.app.unmount()
+  item.root.remove()
+  mounted.splice(mounted.indexOf(item), 1)
+}
+
+function disclosureButton(root: HTMLElement): HTMLButtonElement {
+  const button = root.querySelector<HTMLButtonElement>('button')
+  if (!button) throw new Error('Thinking disclosure button was not rendered')
+  return button
+}
+
+function isExpanded(button: HTMLButtonElement): boolean {
+  return button.querySelector('.lucide-chevron-down') !== null
+}
+
+describe('ThinkingBlock', () => {
+  it('keeps a user-expanded block open as streamed content grows', async () => {
+    const thinking = mountThinkingBlock('first thought')
+    const button = disclosureButton(thinking.root)
+
+    button.click()
+    await nextTick()
+    expect(isExpanded(button)).toBe(true)
+
+    thinking.setContent('first thought with another token')
+    await nextTick()
+
+    expect(isExpanded(button)).toBe(true)
+  })
+
+  it('keeps a user-collapsed block closed as streamed content grows', async () => {
+    const thinking = mountThinkingBlock('thought the user will close')
+    const button = disclosureButton(thinking.root)
+
+    button.click()
+    await nextTick()
+    button.click()
+    await nextTick()
+    expect(isExpanded(button)).toBe(false)
+
+    thinking.setContent('thought the user will close with another token')
+    await nextTick()
+
+    expect(isExpanded(button)).toBe(false)
+  })
+
+  it('restores the latest streamed state after the final content remounts', async () => {
+    const finalContent = 'thought that will be re-fetched after streaming'
+    const streaming = mountThinkingBlock('thought that will be re-fetched')
+    const streamingButton = disclosureButton(streaming.root)
+
+    streamingButton.click()
+    await nextTick()
+    streaming.setContent(finalContent)
+    await nextTick()
+    unmountThinkingBlock(streaming)
+
+    const completed = mountThinkingBlock(finalContent, false)
+
+    expect(isExpanded(disclosureButton(completed.root))).toBe(true)
+  })
+
+  it('does not retain collapse state for superseded streamed content', async () => {
+    const initialContent = 'temporary streamed thought'
+    const streaming = mountThinkingBlock(initialContent)
+    const streamingButton = disclosureButton(streaming.root)
+
+    streamingButton.click()
+    await nextTick()
+    streaming.setContent('temporary streamed thought with another token')
+    await nextTick()
+
+    const superseded = mountThinkingBlock(initialContent, false)
+
+    expect(isExpanded(disclosureButton(superseded.root))).toBe(false)
+  })
+})

--- a/apps/web/src/pages/home/components/thinking-block.vue
+++ b/apps/web/src/pages/home/components/thinking-block.vue
@@ -37,7 +37,7 @@ import { useI18n } from 'vue-i18n'
 import type { ThinkingBlock } from '@/store/chat-list'
 import CollapseSection from './collapse-section.vue'
 import { getReasoningDuration } from './reasoning-timing'
-import { getCollapseOpen, reasoningCollapseKey, setCollapseOpen } from './process-collapse'
+import { getCollapseOpen, migrateCollapseOpen, reasoningCollapseKey, setCollapseOpen } from './process-collapse'
 
 const props = defineProps<{
   block: ThinkingBlock
@@ -52,8 +52,8 @@ const { t } = useI18n()
 // Persisted, user-driven toggle (survives the post-turn refetch/remount).
 const collapseKey = computed(() => reasoningCollapseKey(props.block.content ?? ''))
 const open = ref(getCollapseOpen(collapseKey.value))
-watch(collapseKey, (key) => {
-  open.value = getCollapseOpen(key)
+watch(collapseKey, (key, previousKey) => {
+  migrateCollapseOpen(previousKey, key, open.value)
 })
 
 // Trimmed so the expanded body doesn't open with leading blank lines/space.


### PR DESCRIPTION
## Summary

- preserve the user's expanded or collapsed thinking-block state while reasoning content streams
- migrate that state to each new content-derived key and discard the superseded key
- add rendered-component coverage for open, closed, final-remount, and stale-key behavior

## Root cause

The reasoning collapse key hashes the current content. During streaming, every token changes that key, and the watcher previously loaded the new key's missing state as `false`, collapsing a block the user had opened.

## User impact

Users can keep reading an expanded thinking block while the assistant continues streaming. Their last choice also survives the final response refetch/remount without accumulating one Map entry per token.

## Validation

- focused ThinkingBlock and runtime-projection Vitest suites: 2 files, 13 tests passed
- scoped ESLint on the three changed files passed
- `git diff --check` passed

The broader Web typecheck still reports pre-existing unrelated diagnostics; none reference the changed files.

Fixes #866
