### PR TITLE
chore(connectors): upgrade Connect-It to v0.1.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,14 +34,14 @@ mise run dev       # Start the full containerized dev environment
 5. Web frontend with Vite hot reload
 
 The dev stack uses `devenv/app.dev.toml` directly and does not overwrite the repo root `config.toml`.
-Default host ports are shifted away from the production compose stack: Web `18082`, API `18080`, Connect-It `18083`, Postgres `15432`.
+Default host ports are shifted away from the production compose stack: Web `18082`, API `18080`, Connect-It `18421`, Postgres `15432`.
 
 ### Connect-It
 
-The dev Compose files pull the pinned multi-architecture images
-`ghcr.io/memohai/connect-it-server:sha-5aafc1b` and
-`ghcr.io/memohai/connect-it-web:sha-5aafc1b`; no Connect-It source checkout is
-required. Connect-It uses the same `memoh` PostgreSQL database as Memoh, with
+The dev Compose files pull the pinned multi-architecture image
+`ghcr.io/memohai/connect-it:0.1.1`; no Connect-It source checkout is required.
+The image serves the API, MCP endpoint, and admin UI from one container.
+Connect-It uses the same `memoh` PostgreSQL database as Memoh, with
 its independently migrated tables isolated in the `connect_it` schema. The
 schema is owned, created, and migrated by the Connect-It server itself on
 startup; Memoh's migrations never touch it.
@@ -51,7 +51,7 @@ the Connect-It container seeds it as an API token at startup
 (`CONNECT_IT_BOOTSTRAP_API_TOKEN`) and the Memoh server presents it as its
 bearer token. The Connectors tab is therefore available from the first
 startup, with no token minting or caching involved. The admin UI remains
-available at `http://localhost:18083` with the development credentials
+available at `http://localhost:18421` with the development credentials
 `admin` / `admin123`. The Connect-It port binds to loopback only: the token
 is public, so the deployment must not be reachable from the LAN. If the
 bootstrap token was revoked through the admin UI, rotate it once with
@@ -61,8 +61,7 @@ is seeded as a fresh token and the revoked one stays revoked.
 Override the host UI port with `MEMOH_DEV_CONNECT_IT_PORT`, the public OAuth callback
 address with `MEMOH_DEV_CONNECT_IT_BASE_URL`, or point at an external Connect-It
 deployment with `MEMOH_CONNECT_IT_BASE_URL` and `MEMOH_CONNECT_IT_API_TOKEN`. For
-image testing, override `MEMOH_DEV_CONNECT_IT_SERVER_IMAGE` or
-`MEMOH_DEV_CONNECT_IT_WEB_IMAGE`.
+image testing, override `MEMOH_DEV_CONNECT_IT_IMAGE`.
 
 ## Daily Development
 

--- a/devenv/app.dev.toml
+++ b/devenv/app.dev.toml
@@ -80,7 +80,7 @@ providers_dir = "conf/providers"
 base_url = "https://supermarket.memoh.ai"
 
 [connect_it]
-# The Connect-It dev services are available at http://localhost:18083.
+# The Connect-It dev service is available at http://localhost:18421.
 # `mise run dev` shares one fixed bootstrap token between both sides: the
 # Connect-It container seeds it at startup and the Memoh server presents it.
 # If that token was revoked through the Connect-It admin UI, rotate it once:

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -92,7 +92,7 @@ services:
   # Connect-It owns the connect_it schema and creates it on startup; it only
   # needs postgres, never Memoh's migrations.
   connect-it:
-    image: "${MEMOH_DEV_CONNECT_IT_SERVER_IMAGE:-ghcr.io/memohai/connect-it-server:sha-5aafc1b}"
+    image: "${MEMOH_DEV_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.1.1}"
     container_name: memoh-dev-connect-it
     environment:
       DATABASE_URL: "postgres://memoh:memoh123@postgres:5432/memoh?sslmode=disable&search_path=connect_it"
@@ -100,28 +100,19 @@ services:
       CONNECT_IT_SECRET_KEY: "${MEMOH_DEV_CONNECT_IT_SECRET_KEY:-1:1111111111111111111111111111111111111111111111111111111111111111}"
       COOKIE_SECRET: "${MEMOH_DEV_CONNECT_IT_COOKIE_SECRET:-memoh-connect-it-dev-cookie-secret}"
       CONNECT_IT_ADMIN_PASSWORD: "${MEMOH_DEV_CONNECT_IT_ADMIN_PASSWORD:-admin123}"
-      CONNECT_IT_BASE_URL: "${MEMOH_DEV_CONNECT_IT_BASE_URL:-http://localhost:18083}"
-      LISTEN_ADDR: ":8080"
+      CONNECT_IT_BASE_URL: "${MEMOH_DEV_CONNECT_IT_BASE_URL:-http://localhost:18421}"
       HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
       HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
-      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,server,connect-it,connect-it-web,memoh-dev-postgres,memoh-dev-server,memoh-dev-connect-it,memoh-dev-connect-it-web"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,server,connect-it,memoh-dev-postgres,memoh-dev-server,memoh-dev-connect-it"
       http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
       https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
-      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,server,connect-it,connect-it-web,memoh-dev-postgres,memoh-dev-server,memoh-dev-connect-it,memoh-dev-connect-it-web"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    restart: unless-stopped
-
-  connect-it-web:
-    image: "${MEMOH_DEV_CONNECT_IT_WEB_IMAGE:-ghcr.io/memohai/connect-it-web:sha-5aafc1b}"
-    container_name: memoh-dev-connect-it-web
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,server,connect-it,memoh-dev-postgres,memoh-dev-server,memoh-dev-connect-it"
     ports:
       # Loopback only: the dev stack ships a publicly-known bootstrap API
       # token, and real third-party credentials live behind this port.
-      - "127.0.0.1:${MEMOH_DEV_CONNECT_IT_PORT:-18083}:8080"
+      - "127.0.0.1:${MEMOH_DEV_CONNECT_IT_PORT:-18421}:8421"
     depends_on:
-      connect-it:
+      postgres:
         condition: service_healthy
     restart: unless-stopped
 
@@ -146,10 +137,10 @@ services:
       #   HTTP_PROXY=http://host.docker.internal:7890 mise run dev
       HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
       HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
-      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,pgvector,server,web,migrate,deps,connect-it,connect-it-web,webhook-tunnel,memoh-dev-postgres,memoh-dev-pgvector,memoh-dev-server,memoh-dev-web,memoh-dev-migrate,memoh-dev-deps,memoh-dev-connect-it,memoh-dev-connect-it-web,memoh-dev-webhook-tunnel"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,pgvector,server,web,migrate,deps,connect-it,webhook-tunnel,memoh-dev-postgres,memoh-dev-pgvector,memoh-dev-server,memoh-dev-web,memoh-dev-migrate,memoh-dev-deps,memoh-dev-connect-it,memoh-dev-webhook-tunnel"
       http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
       https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
-      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,pgvector,server,web,migrate,deps,connect-it,connect-it-web,webhook-tunnel,memoh-dev-postgres,memoh-dev-pgvector,memoh-dev-server,memoh-dev-web,memoh-dev-migrate,memoh-dev-deps,memoh-dev-connect-it,memoh-dev-connect-it-web,memoh-dev-webhook-tunnel"
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,pgvector,server,web,migrate,deps,connect-it,webhook-tunnel,memoh-dev-postgres,memoh-dev-pgvector,memoh-dev-server,memoh-dev-web,memoh-dev-migrate,memoh-dev-deps,memoh-dev-connect-it,memoh-dev-webhook-tunnel"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MIN: "${MEMOH_DEV_DISPLAY_WEBRTC_UDP_PORT_MIN:-30000}"
       MEMOH_DISPLAY_WEBRTC_UDP_PORT_MAX: "${MEMOH_DEV_DISPLAY_WEBRTC_UDP_PORT_MAX:-30100}"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,10 +68,10 @@ services:
       #   HTTP_PROXY=http://host.docker.internal:7890 docker compose up -d
       HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
       HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
-      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,pgvector,server,channel,web,migrate,webhook-tunnel,connect-it,connect-it-web,memoh-postgres,memoh-pgvector,memoh-server,memoh-channel,memoh-web,memoh-migrate,memoh-webhook-tunnel,memoh-connect-it,memoh-connect-it-web"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,pgvector,server,channel,web,migrate,webhook-tunnel,connect-it,memoh-postgres,memoh-pgvector,memoh-server,memoh-channel,memoh-web,memoh-migrate,memoh-webhook-tunnel,memoh-connect-it"
       http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
       https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
-      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,pgvector,server,channel,web,migrate,webhook-tunnel,connect-it,connect-it-web,memoh-postgres,memoh-pgvector,memoh-server,memoh-channel,memoh-web,memoh-migrate,memoh-webhook-tunnel,memoh-connect-it,memoh-connect-it-web"
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,pgvector,server,channel,web,migrate,webhook-tunnel,connect-it,memoh-postgres,memoh-pgvector,memoh-server,memoh-channel,memoh-web,memoh-migrate,memoh-webhook-tunnel,memoh-connect-it"
       MEMOH_INTERNAL_RPC_SHARED_SECRET: "${MEMOH_INTERNAL_RPC_SHARED_SECRET:?MEMOH_INTERNAL_RPC_SHARED_SECRET is required}"
       MEMOH_INTERNAL_RPC_SERVER_TARGET: "server:9090"
       MEMOH_INTERNAL_RPC_CHANNEL_TARGET: "channel:9091"
@@ -175,7 +175,7 @@ services:
   # Connect-It at startup and presented by the Memoh server as its bearer
   # token — the install script generates and persists all of these values.
   connect-it:
-    image: ghcr.io/memohai/connect-it-server:sha-5aafc1b
+    image: "${MEMOH_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.1.1}"
     container_name: memoh-connect-it
     profiles: [connectors]
     environment:
@@ -184,29 +184,17 @@ services:
       COOKIE_SECRET: "${MEMOH_CONNECT_IT_COOKIE_SECRET:-}"
       CONNECT_IT_ADMIN_PASSWORD: "${MEMOH_CONNECT_IT_ADMIN_PASSWORD:-}"
       CONNECT_IT_BOOTSTRAP_API_TOKEN: "${MEMOH_CONNECT_IT_API_TOKEN:-}"
-      CONNECT_IT_BASE_URL: "${MEMOH_CONNECT_IT_PUBLIC_BASE_URL:-http://localhost:${MEMOH_CONNECT_IT_PORT:-8083}}"
-      LISTEN_ADDR: ":8080"
+      CONNECT_IT_BASE_URL: "${MEMOH_CONNECT_IT_PUBLIC_BASE_URL:-http://localhost:${MEMOH_CONNECT_IT_PORT:-8421}}"
       HTTP_PROXY: "${HTTP_PROXY:-${http_proxy:-}}"
       HTTPS_PROXY: "${HTTPS_PROXY:-${https_proxy:-}}"
-      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,server,connect-it,connect-it-web,memoh-postgres,memoh-server,memoh-connect-it,memoh-connect-it-web"
+      NO_PROXY: "${NO_PROXY:-127.0.0.1,localhost},postgres,server,connect-it,memoh-postgres,memoh-server,memoh-connect-it"
       http_proxy: "${http_proxy:-${HTTP_PROXY:-}}"
       https_proxy: "${https_proxy:-${HTTPS_PROXY:-}}"
-      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,server,connect-it,connect-it-web,memoh-postgres,memoh-server,memoh-connect-it,memoh-connect-it-web"
+      no_proxy: "${no_proxy:-${NO_PROXY:-127.0.0.1,localhost}},postgres,server,connect-it,memoh-postgres,memoh-server,memoh-connect-it"
+    ports:
+      - "${MEMOH_CONNECT_IT_PORT:-8421}:8421"
     depends_on:
       postgres:
-        condition: service_healthy
-    restart: unless-stopped
-    networks:
-      - memoh-network
-
-  connect-it-web:
-    image: ghcr.io/memohai/connect-it-web:sha-5aafc1b
-    container_name: memoh-connect-it-web
-    profiles: [connectors]
-    ports:
-      - "${MEMOH_CONNECT_IT_PORT:-8083}:8080"
-    depends_on:
-      connect-it:
         condition: service_healthy
     restart: unless-stopped
     networks:

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/line/line-bot-sdk-go/v8 v8.20.1
 	github.com/mailgun/mailgun-go/v5 v5.14.0
 	github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7
-	github.com/memohai/connect-it/sdk/go v0.1.0
+	github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6
 	github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978
 	github.com/memohai/twilight-ai v0.4.1-0.20260729090613-198e82782622
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,8 @@ github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRC
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7 h1:beehwOQperqGWj4m4EhcPhnSZKtDiuHK/7ZMoTPaQjw=
 github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7/go.mod h1:OvmxM7JmnXBmwJWWVqtreL3HSHSKuzPbtbhlg5MvBg0=
-github.com/memohai/connect-it/sdk/go v0.1.0 h1:7HBtc7ZOK42j5oW8UEXgdRJ7ApJ56iKkB/0oQ8B4PPM=
-github.com/memohai/connect-it/sdk/go v0.1.0/go.mod h1:8n7yDCRRNju4+wB8JrKOd29xwbKq9luyihK4eBONBVY=
+github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6 h1:izUUiax2VaFHdOynSuDGpqVcTuzbO9azDiuR+OW90co=
+github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6/go.mod h1:8n7yDCRRNju4+wB8JrKOd29xwbKq9luyihK4eBONBVY=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978 h1:6gD8DvZkimGmU0e3PjlusJPyw55SyeoE12CZQoYUa8g=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978/go.mod h1:2LMgK5QYFlTSvrGY+sI/j+jK2WK+YGHv4IMuiW+iPSc=
 github.com/memohai/twilight-ai v0.4.1-0.20260729090613-198e82782622 h1:wzb0lghtHegSrR+JtRgv+cciXSBOfWVbfkszLoEtg8M=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,14 +208,14 @@ func TestLoadAppliesWebhookTunnelEnvOverrides(t *testing.T) {
 }
 
 func TestLoadAppliesConnectItEnvOverrides(t *testing.T) {
-	t.Setenv("MEMOH_CONNECT_IT_BASE_URL", "http://connect-it:8080")
+	t.Setenv("MEMOH_CONNECT_IT_BASE_URL", "http://connect-it:8421")
 	t.Setenv("MEMOH_CONNECT_IT_API_TOKEN", "test-token")
 
 	cfg, err := Load(filepath.Join(t.TempDir(), "missing.toml"))
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	if cfg.ConnectIt.BaseURL != "http://connect-it:8080" || cfg.ConnectIt.APIToken != "test-token" {
+	if cfg.ConnectIt.BaseURL != "http://connect-it:8421" || cfg.ConnectIt.APIToken != "test-token" {
 		t.Fatalf("connect-it config = %#v", cfg.ConnectIt)
 	}
 }
@@ -232,13 +232,13 @@ func TestConnectItConfigValidationRequiresCompletePair(t *testing.T) {
 		{
 			name: "configured",
 			config: ConnectItConfig{
-				BaseURL:  "http://connect-it:8080",
+				BaseURL:  "http://connect-it:8421",
 				APIToken: "cit_test",
 			},
 		},
 		{
 			name:    "missing token",
-			config:  ConnectItConfig{BaseURL: "http://connect-it:8080"},
+			config:  ConnectItConfig{BaseURL: "http://connect-it:8421"},
 			wantErr: true,
 		},
 		{

--- a/scripts/desktop-install.sh
+++ b/scripts/desktop-install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-apt_get() {
+apt_get_once() {
   timeout_seconds="${MEMOH_APT_COMMAND_TIMEOUT:-300}"
   if has_cmd timeout; then
     timeout "$timeout_seconds" apt-get \
@@ -17,6 +17,33 @@ apt_get() {
     -o "Acquire::http::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
     -o "Acquire::https::Timeout=${MEMOH_APT_HTTP_TIMEOUT:-30}" \
     "$@"
+}
+
+apt_get() {
+  max_attempts="${MEMOH_APT_COMMAND_RETRIES:-3}"
+  retry_delay="${MEMOH_APT_RETRY_DELAY:-5}"
+  case "$max_attempts" in
+    ""|*[!0-9]*|0) max_attempts=3 ;;
+  esac
+  case "$retry_delay" in
+    ""|*[!0-9]*) retry_delay=5 ;;
+  esac
+
+  attempt=1
+  while :; do
+    if apt_get_once "$@"; then
+      return 0
+    else
+      status=$?
+    fi
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      return "$status"
+    fi
+    wait_seconds=$((retry_delay * attempt))
+    echo "apt-get failed with exit code $status (attempt $attempt/$max_attempts); retrying in ${wait_seconds}s" >&2
+    sleep "$wait_seconds"
+    attempt=$((attempt + 1))
+  done
 }
 
 run_limited() {

--- a/scripts/dev-compose.sh
+++ b/scripts/dev-compose.sh
@@ -22,7 +22,7 @@ done
 # MEMOH_CONNECT_IT_API_TOKEN to target an external Connect-It deployment.
 dev_bootstrap_token="cit_1111111111111111111111111111111111111111111111111111111111111111"
 
-export MEMOH_CONNECT_IT_BASE_URL="${MEMOH_CONNECT_IT_BASE_URL:-http://connect-it:8080}"
+export MEMOH_CONNECT_IT_BASE_URL="${MEMOH_CONNECT_IT_BASE_URL:-http://connect-it:8421}"
 export MEMOH_CONNECT_IT_API_TOKEN="${MEMOH_CONNECT_IT_API_TOKEN:-${dev_bootstrap_token}}"
 
-exec "${compose[@]}" up --build
+exec "${compose[@]}" up --build --remove-orphans

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,8 @@ else
   CONNECT_IT_MODE_SET=false
 fi
 NETWORK_NAME="${COMPOSE_PROJECT_NAME}_memoh-network"
-PROJECT_CONTAINERS="memoh-postgres memoh-pgvector memoh-migrate memoh-server memoh-channel memoh-web memoh-webhook-tunnel memoh-connect-it memoh-connect-it-web"
+PROJECT_CONTAINERS="memoh-postgres memoh-pgvector memoh-migrate memoh-server memoh-channel memoh-web memoh-webhook-tunnel memoh-connect-it"
+LEGACY_PROJECT_CONTAINERS="memoh-connect-it-web"
 PROJECT_VOLUMES="${COMPOSE_PROJECT_NAME}_postgres_data ${COMPOSE_PROJECT_NAME}_pgvector_data ${COMPOSE_PROJECT_NAME}_containerd_data ${COMPOSE_PROJECT_NAME}_memoh_data ${COMPOSE_PROJECT_NAME}_server_cni_state ${COMPOSE_PROJECT_NAME}_openviking_data"
 
 EXISTING_CONFIG_SOURCE=""
@@ -354,7 +355,7 @@ detect_existing_installation() {
     fi
   done
 
-  for container in $PROJECT_CONTAINERS; do
+  for container in $PROJECT_CONTAINERS $LEGACY_PROJECT_CONTAINERS; do
     if $DOCKER container inspect "$container" >/dev/null 2>&1; then
       EXISTING_DOCKER_STATE=true
       EXISTING_DOCKER_CONTAINERS=true
@@ -462,6 +463,10 @@ load_existing_settings() {
     [ -n "$value" ] && MEMOH_CONNECT_IT_API_TOKEN="${MEMOH_CONNECT_IT_API_TOKEN:-$value}"
     value=$(read_env_file_value "$EXISTING_ENV_SOURCE" "MEMOH_CONNECT_IT_PUBLIC_BASE_URL" || true)
     [ -n "$value" ] && MEMOH_CONNECT_IT_PUBLIC_BASE_URL="${MEMOH_CONNECT_IT_PUBLIC_BASE_URL:-$value}"
+    value=$(read_env_file_value "$EXISTING_ENV_SOURCE" "MEMOH_CONNECT_IT_PORT" || true)
+    [ -n "$value" ] && MEMOH_CONNECT_IT_PORT="${MEMOH_CONNECT_IT_PORT:-$value}"
+    value=$(read_env_file_value "$EXISTING_ENV_SOURCE" "MEMOH_CONNECT_IT_IMAGE" || true)
+    [ -n "$value" ] && MEMOH_CONNECT_IT_IMAGE="${MEMOH_CONNECT_IT_IMAGE:-$value}"
   fi
 }
 
@@ -554,7 +559,7 @@ prompt_install_mode() {
 
 cleanup_existing_installation() {
   echo "${YELLOW}Removing existing Memoh Docker containers, volumes, and network...${NC}"
-  for container in $PROJECT_CONTAINERS; do
+  for container in $PROJECT_CONTAINERS $LEGACY_PROJECT_CONTAINERS; do
     $DOCKER rm -f "$container" >/dev/null 2>&1 || true
   done
   for volume in $PROJECT_VOLUMES; do
@@ -568,7 +573,7 @@ show_failure_logs() {
   echo "${RED}Startup failed. Recent database, migration, server, and channel logs:${NC}"
   log_services="postgres migrate server channel"
   if [ "${CONNECT_IT_MODE:-}" = "embedded" ]; then
-    log_services="$log_services connect-it connect-it-web"
+    log_services="$log_services connect-it"
   fi
   $DOCKER compose $COMPOSE_FILES $COMPOSE_PROFILES logs --no-color --tail=200 $log_services || true
 }
@@ -670,6 +675,8 @@ MEMOH_CONNECT_IT_SECRET_KEY="${MEMOH_CONNECT_IT_SECRET_KEY:-}"
 MEMOH_CONNECT_IT_COOKIE_SECRET="${MEMOH_CONNECT_IT_COOKIE_SECRET:-}"
 MEMOH_CONNECT_IT_API_TOKEN="${MEMOH_CONNECT_IT_API_TOKEN:-}"
 MEMOH_CONNECT_IT_PUBLIC_BASE_URL="${MEMOH_CONNECT_IT_PUBLIC_BASE_URL:-}"
+MEMOH_CONNECT_IT_PORT="${MEMOH_CONNECT_IT_PORT:-8421}"
+MEMOH_CONNECT_IT_IMAGE="${MEMOH_CONNECT_IT_IMAGE:-}"
 PG_PASS="memoh123"
 WORKSPACE="$WORKSPACE_DEFAULT"
 MEMOH_DATA_DIR="$MEMOH_DATA_DIR_DEFAULT"
@@ -919,7 +926,7 @@ export MEMOH_WEBHOOK_TUNNEL_MODE="$WEBHOOK_TUNNEL_MODE"
 export MEMOH_WEBHOOK_TUNNEL_LISTEN_ADDR="${MEMOH_WEBHOOK_TUNNEL_LISTEN_ADDR:-:18734}"
 export MEMOH_WEBHOOK_TUNNEL_METRICS_URL="${MEMOH_WEBHOOK_TUNNEL_METRICS_URL:-http://webhook-tunnel:18735}"
 
-# Connect-It connectors: embedded runs the co-hosted Connect-It containers and
+# Connect-It connectors: embedded runs the co-hosted Connect-It container and
 # wires Memoh to them with generated credentials; disabled leaves the feature
 # off. Credentials are generated once and reused across upgrades, so toggling
 # the mode later keeps existing connections working.
@@ -946,10 +953,10 @@ esac
 [ -n "$MEMOH_CONNECT_IT_API_TOKEN" ] || MEMOH_CONNECT_IT_API_TOKEN="cit_$(gen_hex)"
 if [ "$CONNECT_IT_MODE" = "embedded" ]; then
   COMPOSE_PROFILES="$COMPOSE_PROFILES --profile connectors"
-  MEMOH_CONNECT_IT_BASE_URL="http://connect-it:8080"
+  MEMOH_CONNECT_IT_BASE_URL="http://connect-it:8421"
   echo "${GREEN}✓ Connect-It connectors enabled${NC}"
   if [ -z "$MEMOH_CONNECT_IT_PUBLIC_BASE_URL" ]; then
-    echo "${YELLOW}ℹ Connector OAuth callbacks default to http://localhost:${MEMOH_CONNECT_IT_PORT:-8083}; set MEMOH_CONNECT_IT_PUBLIC_BASE_URL when Memoh is used from other machines${NC}"
+    echo "${YELLOW}ℹ Connector OAuth callbacks default to http://localhost:${MEMOH_CONNECT_IT_PORT}; set MEMOH_CONNECT_IT_PUBLIC_BASE_URL when Memoh is used from other machines${NC}"
   fi
   if [ "$USE_CN_MIRROR" = true ]; then
     echo "${YELLOW}ℹ Connect-It images come from ghcr.io; memoh.cn mirror does not cover them. Set MEMOH_CONNECT_IT_MODE=disabled to skip them${NC}"
@@ -964,6 +971,8 @@ export MEMOH_CONNECT_IT_ADMIN_PASSWORD
 export MEMOH_CONNECT_IT_SECRET_KEY
 export MEMOH_CONNECT_IT_COOKIE_SECRET
 export MEMOH_CONNECT_IT_PUBLIC_BASE_URL
+export MEMOH_CONNECT_IT_PORT
+export MEMOH_CONNECT_IT_IMAGE
 
 : > .env
 write_env_value "POSTGRES_PASSWORD" "$PG_PASS"
@@ -983,6 +992,8 @@ write_env_value "MEMOH_CONNECT_IT_SECRET_KEY" "$MEMOH_CONNECT_IT_SECRET_KEY"
 write_env_value "MEMOH_CONNECT_IT_COOKIE_SECRET" "$MEMOH_CONNECT_IT_COOKIE_SECRET"
 write_env_value "MEMOH_CONNECT_IT_API_TOKEN" "$MEMOH_CONNECT_IT_API_TOKEN"
 write_env_value "MEMOH_CONNECT_IT_PUBLIC_BASE_URL" "$MEMOH_CONNECT_IT_PUBLIC_BASE_URL"
+write_env_value "MEMOH_CONNECT_IT_PORT" "$MEMOH_CONNECT_IT_PORT"
+write_env_value "MEMOH_CONNECT_IT_IMAGE" "$MEMOH_CONNECT_IT_IMAGE"
 echo "${GREEN}✓ Database backend: ${DATABASE_DRIVER}${NC}"
 echo "${GREEN}✓ Workspace backend: ${CONTAINER_BACKEND}${NC}"
 
@@ -996,7 +1007,7 @@ $DOCKER compose $COMPOSE_FILES $COMPOSE_PROFILES pull
 
 echo ""
 echo "${GREEN}Starting services (first startup may take a few minutes)...${NC}"
-if ! $DOCKER compose $COMPOSE_FILES $COMPOSE_PROFILES up -d; then
+if ! $DOCKER compose $COMPOSE_FILES $COMPOSE_PROFILES up -d --remove-orphans; then
   show_failure_logs
   exit 1
 fi
@@ -1027,7 +1038,7 @@ echo ""
 echo "  🔑 Admin login:       ${ADMIN_USER} / ${ADMIN_PASS}"
 echo ""
 if [ "$CONNECT_IT_MODE" = "embedded" ]; then
-  echo "  🔗 Connect-It admin:  ${MEMOH_CONNECT_IT_PUBLIC_BASE_URL:-http://localhost:${MEMOH_CONNECT_IT_PORT:-8083}} (admin / ${MEMOH_CONNECT_IT_ADMIN_PASSWORD})"
+  echo "  🔗 Connect-It admin:  ${MEMOH_CONNECT_IT_PUBLIC_BASE_URL:-http://localhost:${MEMOH_CONNECT_IT_PORT}} (admin / ${MEMOH_CONNECT_IT_ADMIN_PASSWORD})"
   echo ""
 fi
 COMPOSE_CMD="$DOCKER compose $COMPOSE_FILES $COMPOSE_PROFILES"


### PR DESCRIPTION
## Summary

- replace the split Connect-It server and web services with the combined `ghcr.io/memohai/connect-it:0.1.1` image
- move the production service to port `8421` and the development host binding to `18421`
- update the Connect-It Go SDK to the module revision associated with the v0.1.1 release
- update the development and install flows to persist image/port overrides and remove legacy orphan containers
- retry complete `apt-get` commands so transient Debian mirror failures do not abort development workspace image builds
- refresh configuration tests and contributor documentation

## Why

Connect-It v0.1.1 now serves its API, MCP endpoint, and admin UI from one container on port 8421. Memoh still referenced the previous split server/web images and port 8080, so its Compose and install paths needed to migrate together.

Development workspace builds also download a large Debian package set. Per-download retries did not recover when a few archives returned HTTP 502, so the installer now retries the complete command while reusing the apt cache.

## Validation

- commit hook: Go lint
- commit hook: `go test ./...`
- production and development `docker compose config` validation
- shell syntax checks and mocked retry success/exhaustion checks for the development and install scripts
- `pnpm --filter @memohai/web build`
- real `mise run dev:workspace-image` recovery: the first apt command failed on three HTTP 502 responses, the second attempt reused cached archives and completed the image
- full development Compose startup with orphan cleanup: Connect-It, Memoh server, and channel healthy; Memoh Web returned HTTP 200
- development Connect-It smoke test: image `ghcr.io/memohai/connect-it:0.1.1`, `/healthz` succeeded, `/version` returned `0.1.1`, and the bundled web UI responded
- isolated Docker smoke test with PostgreSQL: `/healthz` succeeded, `/version` returned `0.1.1`, and the bundled web UI responded

## Known baseline

`pnpm run test -- --run` still reports existing failures in untouched Desktop and Chat frontend suites.