### PR TITLE
fix(web): connectors-first supermarket tabs, fixed-height market cards

### DIFF
--- a/apps/web/src/pages/supermarket/components/market-item-card.vue
+++ b/apps/web/src/pages/supermarket/components/market-item-card.vue
@@ -2,6 +2,8 @@
   <!-- 超市列表卡的形状 owner:plugin-card / skill-card 原本各手写一份同形结构,
        且 hover 反馈只有 skill 那份有(plugin 卡悬停无任何反馈,是可见 bug)。
        归一后:图标槽(#leading)+ 标题 + 主页外链 + 两行截断描述 + 尾部动作槽(#actions)。
+       卡高固定:描述框恒占两行(min-h-8 = 2 × text-xs 的 1rem 行高),短描述不塌、长描述
+       被 line-clamp-2 省略,所以每张卡的高度都是 p-4 + 标题行 + 两行描述,网格不再参差。
        根是 Card[role=button](两处原本就这么写,天然避开 button 嵌套陷阱),
        整卡点击/回车/空格 → emit('open');#actions 区域和主页外链要同时 stop 掉 click 和
        keydown——根的 keydown.enter.prevent 会吞掉嵌套交互元素的原生回车激活,只 stop click 不够。
@@ -39,7 +41,8 @@
           <ExternalLink class="size-3" />
         </a>
       </div>
-      <p class="mt-1 line-clamp-2 text-xs text-muted-foreground">
+      <!-- overflow-wrap:anywhere:描述里的长 URL / 无空格 token 否则会横向顶破卡片 -->
+      <p class="mt-1 line-clamp-2 min-h-8 break-words text-xs text-muted-foreground [overflow-wrap:anywhere]">
         {{ description }}
       </p>
     </div>

--- a/apps/web/src/pages/supermarket/index.vue
+++ b/apps/web/src/pages/supermarket/index.vue
@@ -27,82 +27,35 @@
         />
       </div>
 
+      <!-- 连接器是首位 tab 且是默认选中项,而它是否存在要等 capabilities 拉回来才知道。
+           在 loaded 之前渲染 tab 条会先画出 [插件][技能]/选中插件,ping 落地后整条重排并
+           改选中——所以这里等 loaded 再渲染,一次画对。已加载过(store 常驻)则无感。 -->
+      <InlineLoadingRow
+        v-if="!capabilitiesStore.loaded"
+        class="justify-center py-8"
+      >
+        {{ $t('common.loading') }}
+      </InlineLoadingRow>
+
       <Tabs
+        v-else
         v-model="activeTab"
         class="w-full"
       >
         <TabsList>
-          <TabsTrigger value="plugins">
-            {{ $t('supermarket.pluginSection') }}
-          </TabsTrigger>
-          <TabsTrigger value="skills">
-            {{ $t('supermarket.skillsSection') }}
-          </TabsTrigger>
           <TabsTrigger
             v-if="capabilitiesStore.connectors"
             value="connectors"
           >
             {{ $t('supermarket.connectorsSection') }}
           </TabsTrigger>
+          <TabsTrigger value="plugins">
+            {{ $t('supermarket.pluginSection') }}
+          </TabsTrigger>
+          <TabsTrigger value="skills">
+            {{ $t('supermarket.skillsSection') }}
+          </TabsTrigger>
         </TabsList>
-
-        <!-- Plugins Tab -->
-        <TabsContent value="plugins">
-          <InlineLoadingRow
-            v-if="pluginsLoading"
-            class="justify-center py-8"
-          >
-            {{ $t('common.loading') }}
-          </InlineLoadingRow>
-
-          <div
-            v-else-if="!plugins.length"
-            class="py-8 text-center text-xs text-muted-foreground"
-          >
-            {{ $t('supermarket.noPluginResults') }}
-          </div>
-
-          <div
-            v-else
-            class="grid grid-cols-1 sm:grid-cols-2 gap-4"
-          >
-            <PluginCard
-              v-for="plugin in plugins"
-              :key="plugin.id"
-              :plugin="plugin"
-              @install="openPluginInstall"
-            />
-          </div>
-        </TabsContent>
-
-        <!-- Skills Tab -->
-        <TabsContent value="skills">
-          <InlineLoadingRow
-            v-if="skillsLoading"
-            class="justify-center py-8"
-          >
-            {{ $t('common.loading') }}
-          </InlineLoadingRow>
-
-          <div
-            v-else-if="!skills.length"
-            class="py-8 text-center text-xs text-muted-foreground"
-          >
-            {{ $t('supermarket.noSkillResults') }}
-          </div>
-
-          <div
-            v-else
-            class="grid grid-cols-1 sm:grid-cols-2 gap-4"
-          >
-            <SkillCard
-              v-for="skill in skills"
-              :key="skill.id"
-              :skill="skill"
-              @install="openSkillInstall"
-            />
-          </div>
-        </TabsContent>
 
         <TabsContent
           v-if="capabilitiesStore.connectors"
@@ -165,6 +118,64 @@
                 </Button>
               </template>
             </MarketItemCard>
+          </div>
+        </TabsContent>
+
+        <!-- Plugins Tab -->
+        <TabsContent value="plugins">
+          <InlineLoadingRow
+            v-if="pluginsLoading"
+            class="justify-center py-8"
+          >
+            {{ $t('common.loading') }}
+          </InlineLoadingRow>
+
+          <div
+            v-else-if="!plugins.length"
+            class="py-8 text-center text-xs text-muted-foreground"
+          >
+            {{ $t('supermarket.noPluginResults') }}
+          </div>
+
+          <div
+            v-else
+            class="grid grid-cols-1 sm:grid-cols-2 gap-4"
+          >
+            <PluginCard
+              v-for="plugin in plugins"
+              :key="plugin.id"
+              :plugin="plugin"
+              @install="openPluginInstall"
+            />
+          </div>
+        </TabsContent>
+
+        <!-- Skills Tab -->
+        <TabsContent value="skills">
+          <InlineLoadingRow
+            v-if="skillsLoading"
+            class="justify-center py-8"
+          >
+            {{ $t('common.loading') }}
+          </InlineLoadingRow>
+
+          <div
+            v-else-if="!skills.length"
+            class="py-8 text-center text-xs text-muted-foreground"
+          >
+            {{ $t('supermarket.noSkillResults') }}
+          </div>
+
+          <div
+            v-else
+            class="grid grid-cols-1 sm:grid-cols-2 gap-4"
+          >
+            <SkillCard
+              v-for="skill in skills"
+              :key="skill.id"
+              :skill="skill"
+              @install="openSkillInstall"
+            />
           </div>
         </TabsContent>
       </Tabs>
@@ -233,17 +244,23 @@ const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const capabilitiesStore = useCapabilitiesStore()
-const tabParam = useSyncedQueryParam('tab', 'plugins')
+// Empty default (not 'plugins'): the landing tab depends on a capability that is
+// only known after ping, so the fallback below owns it instead of the composable —
+// an empty param means "no explicit tab", and nothing gets written into the URL.
+const tabParam = useSyncedQueryParam('tab', '')
 // Settings pages are KeepAlive-cached and share the `tab` query key, so a
 // foreign value (e.g. bot detail's ?tab=memory) can land in the synced param
 // while this page is deactivated. Render anything outside this page's own
-// tabs as 'plugins'; writes go back through the synced param.
+// tabs as the default tab; writes go back through the synced param.
 const activeTab = computed({
   get: () => {
     const valid = capabilitiesStore.connectors
-      ? ['plugins', 'skills', 'connectors']
+      ? ['connectors', 'plugins', 'skills']
       : ['plugins', 'skills']
-    return valid.includes(tabParam.value) ? tabParam.value : 'plugins'
+    // Connectors leads the tab strip, so it is also the default landing tab
+    // wherever the capability exists; otherwise plugins keeps that role.
+    const fallback = capabilitiesStore.connectors ? 'connectors' : 'plugins'
+    return valid.includes(tabParam.value) ? tabParam.value : fallback
   },
   set: (value: string) => {
     tabParam.value = value


### PR DESCRIPTION
## 连接器排到分类首位

超市的 tab 顺序改为 **连接器 → 插件 → 技能**，并且在 connectors capability 存在时，连接器也是默认落地的 tab（capability 关闭时「插件」继续担任这个角色）。

- `tab` 同步参数去掉了 `'plugins'` 默认值：落地 tab 依赖一个要等 ping 才知道的 capability，所以交给 `activeTab` 的 capability-aware fallback 来定，而不是 composable。空参数表示"没有显式 tab"，因此也不会往 URL 里写 `?tab=`。
- tab 条等 `capabilities.loaded` 之后再渲染。否则首屏会先画出 `[插件][技能]`＋选中插件，ping 落地后整条重排并改选中。store 常驻，非冷启动无感知。
- 原有的"URL 显式带 `?tab=connectors` 但服务端没开 connectors → 归一到 plugins"的逻辑保持不变。

## 卡片高度固定，description 截断

超市卡在网格里参差不齐：一行描述的卡比旁边两行描述的矮，行与行对不齐，长描述还会把卡撑高。

- 描述框现在恒占两行（`min-h-8` = 2 × `text-xs` 的 1rem 行高），并保留 `line-clamp-2`。短描述不再让卡片塌下去，长描述用省略号截断而不是把卡撑高。
- 每张卡的高度因此恒定为 `p-4` + 标题行 + 两行描述。没有额外硬写一个根高度，避免"声明的固定高度"和"实际内容高度"两个可能对不上的真值。
- 顺带加了 `break-words [overflow-wrap:anywhere]`（沿用 `bot-skills.vue` 的写法），描述里的长 URL / 无空格 token 不再横向顶破卡片。

> [!NOTE]
> `MarketItemCard` 是**插件卡／技能卡／连接器卡共用**的形状 owner，所以这个高度修复对三种卡都生效——它们本来就有同样的参差问题。

## 验证

- `node scripts/check-ui-contract.mjs` 通过（仅剩 3 条与本改动无关的既有 warning）
- ESLint 通过；`pnpm --filter @memohai/web build` 通过
- pre-commit 全套（golangci-lint、全量 `go test`、lint-staged）通过
- 在构建产物里核对了 `.min-h-8{min-height:calc(var(--spacing) * 8)}` = 2rem，且 `--text-xs--line-height: calc(1/.75)` × 0.75rem = 1rem/行，即恰好两行

🤖 Generated with [Claude Code](https://claude.com/claude-code)