### PR TITLE
feat(desktop): add native translucent sidebar

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import {
   BrowserWindow,
   ipcMain,
   nativeImage,
+  nativeTheme,
   safeStorage,
   Tray,
   screen,
@@ -21,6 +22,7 @@ import trayIconPng from '../../resources/tray-icon.png?asset'
 import { acceleratorForCommand, appKeyboardCommands, type AppKeyboardCommand } from '../shared/keyboard-commands'
 import { dispatchFocusedWindowCommand } from './window-commands'
 import { dispatchRendererNavigate } from './window-navigation'
+import { macWindowChromeOptions } from './window-chrome'
 import { maybeSelfInstallMacOS } from './self-install'
 import { DesktopRemoteRuntimeManager } from './remote-runtime'
 import { isTrustedRendererUrl } from './renderer-trust'
@@ -34,6 +36,7 @@ import {
   type ServerConnectionResult,
 } from '../shared/server-connection'
 import type { DesktopRuntimeConfig } from '../shared/remote-runtime'
+import { normalizeDesktopThemeSource } from '../shared/theme'
 
 const DESKTOP_PRODUCT_NAME = 'Memoh'
 const DEFAULT_BASE_URL = is.dev ? 'http://localhost:18080' : 'http://localhost:8080'
@@ -492,21 +495,10 @@ function createAppTray(): void {
 // output is what wires the IPC bridge into the renderer.
 const PRELOAD_FILE = '../preload/index.mjs'
 
-function macWindowChromeOptions(tabbingIdentifier: string): Partial<Electron.BrowserWindowConstructorOptions> {
-  if (process.platform !== 'darwin') return {}
-  return {
-    titleBarStyle: 'hidden',
-    trafficLightPosition: { x: 14, y: 13 },
-    transparent: true,
-    backgroundColor: '#00000000',
-    tabbingIdentifier,
-  }
-}
-
 function createChatWindow(): BrowserWindow {
   const window = new BrowserWindow({
     ...rememberedWindowOptions('chat', CHAT_DEFAULTS),
-    ...macWindowChromeOptions('memoh-chat'),
+    ...macWindowChromeOptions(process.platform, 'memoh-chat'),
     show: false,
     autoHideMenuBar: true,
     title: DESKTOP_PRODUCT_NAME,
@@ -681,6 +673,10 @@ app.whenReady().then(async () => {
   ipcMain.handle('desktop:api-base-url', (event) => {
     assertTrustedRenderer(event)
     return getDesktopApiBaseUrl()
+  })
+  ipcMain.handle('desktop:set-theme-source', (event, themeSource: unknown) => {
+    assertTrustedRenderer(event)
+    nativeTheme.themeSource = normalizeDesktopThemeSource(themeSource)
   })
   ipcMain.handle('desktop:probe-server', (event) => {
     assertTrustedRenderer(event)

--- a/apps/desktop/src/main/window-chrome.test.ts
+++ b/apps/desktop/src/main/window-chrome.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { macWindowChromeOptions } from './window-chrome'
+
+describe('macWindowChromeOptions', () => {
+  it('uses the native sidebar material on macOS', () => {
+    expect(macWindowChromeOptions('darwin', 'memoh-chat')).toMatchObject({
+      backgroundColor: '#00000000',
+      tabbingIdentifier: 'memoh-chat',
+      titleBarStyle: 'hidden',
+      transparent: true,
+      vibrancy: 'sidebar',
+      visualEffectState: 'followWindow',
+    })
+  })
+
+  it('leaves other platforms on their standard opaque window chrome', () => {
+    expect(macWindowChromeOptions('win32', 'memoh-chat')).toEqual({})
+    expect(macWindowChromeOptions('linux', 'memoh-chat')).toEqual({})
+  })
+})

--- a/apps/desktop/src/main/window-chrome.ts
+++ b/apps/desktop/src/main/window-chrome.ts
@@ -1,0 +1,19 @@
+import type { BrowserWindowConstructorOptions } from 'electron'
+
+export function macWindowChromeOptions(
+  platform: NodeJS.Platform,
+  tabbingIdentifier: string,
+): Partial<BrowserWindowConstructorOptions> {
+  if (platform !== 'darwin') return {}
+  return {
+    titleBarStyle: 'hidden',
+    trafficLightPosition: { x: 14, y: 13 },
+    transparent: true,
+    backgroundColor: '#00000000',
+    // The native material fills the window; opaque renderer surfaces cover the
+    // content pane, leaving only explicitly transparent sidebars visible.
+    vibrancy: 'sidebar',
+    visualEffectState: 'followWindow',
+    tabbingIdentifier,
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -7,6 +7,7 @@ import {
 } from '../shared/keyboard-commands'
 import type { ServerConnectResult, ServerConnectionResult } from '../shared/server-connection'
 import type { DesktopRuntimeConfig, DesktopRuntimeState } from '../shared/remote-runtime'
+import type { DesktopThemeSource } from '../shared/theme'
 import type { DesktopUpdateInfo, DesktopUpdateState } from '../shared/updates'
 
 // Renderer query-cache invalidation payload. Mirrors the subset of
@@ -33,6 +34,8 @@ const api = {
     }> =>
       ipcRenderer.invoke('desktop:server-status'),
     apiBaseUrl: (): Promise<string> => ipcRenderer.invoke('desktop:api-base-url'),
+    setThemeSource: (themeSource: DesktopThemeSource): Promise<void> =>
+      ipcRenderer.invoke('desktop:set-theme-source', themeSource),
     probeServer: (): Promise<ServerConnectionResult> => ipcRenderer.invoke('desktop:probe-server'),
     connectServer: (baseUrl: string): Promise<ServerConnectResult> =>
       ipcRenderer.invoke('desktop:connect-server', baseUrl),

--- a/apps/desktop/src/renderer/src/chat/App.vue
+++ b/apps/desktop/src/renderer/src/chat/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, provide } from 'vue'
+import { computed, onBeforeUnmount, onMounted, provide, watch } from 'vue'
 import { RouterView, useRouter, useRoute } from 'vue-router'
 import { Toaster } from '@felinic/ui'
 import { useSettingsStore } from '@memohai/web/store/settings'
@@ -26,7 +26,13 @@ provide(DesktopUpdatesKey, {
   install: window.api.desktop.updates.install,
   onStateChanged: window.api.desktop.updates.onStateChanged,
 } satisfies DesktopUpdateBridge)
-useSettingsStore()
+const settingsStore = useSettingsStore()
+watch(
+  () => settingsStore.theme,
+  themeSource => void window.api.desktop.setThemeSource(themeSource).catch((error) => {
+    console.warn('failed to synchronize desktop native theme', error)
+  }),
+)
 
 // Mirror apps/web App.vue: keep chat dockview/scroll alive (DOM attached,
 // full-size) while in settings, so returning has no black flash / re-scroll /
@@ -55,7 +61,10 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onDevKey))
 
 <template>
   <section>
-    <MainSection v-if="isAppArea" />
+    <MainSection
+      v-if="isAppArea"
+      :data-native-sidebar-underlay-clear="isSettingsRoute || undefined"
+    />
     <!-- Permanent fixed settings layer (see apps/web App.vue): TRANSPARENT wrapper
          toggled with `visibility` only. settings-section paints its own opaque
          bg, so chat (not black) shows behind its slide/fade. No v-if (avoids

--- a/apps/desktop/src/renderer/src/desktop-shell.css
+++ b/apps/desktop/src/renderer/src/desktop-shell.css
@@ -14,10 +14,13 @@ html {
 
 html[data-native-sidebar-material] {
   /* Keep the sidebar calmer than raw vibrancy while preserving enough of the
-   * macOS material to read as translucent. */
+   * macOS material to read as translucent. A vibrancy material's rendered
+   * color is hostage to whatever sits behind the window (clean over the
+   * default wallpaper, muddy over a dark window) — 70% theme color bounds
+   * that swing to the remaining 30%. */
   --desktop-native-sidebar-tint: color-mix(
     in oklab,
-    var(--sidebar) 46%,
+    var(--sidebar) 70%,
     transparent
   );
 }
@@ -46,6 +49,16 @@ html[data-native-sidebar-material] [data-native-sidebar-tint] {
 /* Opaque sidebar fades would paint over the native material at the footer. */
 html[data-native-sidebar-material] [data-native-sidebar-fade] {
   background-image: none;
+}
+
+/* Sidebar ↔ chat seam: the stroke derives from the family divider color (an
+ * invented or translucent line reads foreign over the glass); the seam's
+ * extra weight comes from a soft shadow spilling left onto the sidebar, so
+ * the chat plane reads as floating above the glass layer. */
+html[data-native-sidebar-material] [data-native-sidebar-seam] {
+  border-right-width: 1px;
+  border-right-color: var(--native-sidebar-seam);
+  box-shadow: inset -10px 0 10px -10px var(--native-sidebar-seam-shadow);
 }
 
 /* Settings stays mounted above the persistent chat workspace. Clear the exact

--- a/apps/desktop/src/renderer/src/desktop-shell.css
+++ b/apps/desktop/src/renderer/src/desktop-shell.css
@@ -7,3 +7,59 @@ body,
   overflow: hidden;
   background: var(--background);
 }
+
+html {
+  --desktop-sidebar-width: 15rem;
+}
+
+html[data-native-sidebar-material] {
+  /* Keep the sidebar calmer than raw vibrancy while preserving enough of the
+   * macOS material to read as translucent. */
+  --desktop-native-sidebar-tint: color-mix(
+    in oklab,
+    var(--sidebar) 46%,
+    transparent
+  );
+}
+
+html.dark[data-native-sidebar-material] {
+  /* Desktop's dark reading plane is intentionally softer than the shared Web
+   * near-black. The literal belongs to this platform token, never a page. */
+  --background: #181818;
+}
+
+/* Electron's native sidebar material sits behind the full renderer. Keep the
+ * document canvas transparent on macOS, then let normal bg-background content
+ * panes cover it. Only the marked sidebar surfaces expose the material. */
+html[data-native-sidebar-material],
+html[data-native-sidebar-material] body,
+html[data-native-sidebar-material] #app,
+html[data-native-sidebar-material] [data-desktop-window-layer],
+html[data-native-sidebar-material] [data-native-sidebar-surface] {
+  background: transparent;
+}
+
+html[data-native-sidebar-material] [data-native-sidebar-tint] {
+  background: var(--desktop-native-sidebar-tint);
+}
+
+/* Opaque sidebar fades would paint over the native material at the footer. */
+html[data-native-sidebar-material] [data-native-sidebar-fade] {
+  background-image: none;
+}
+
+/* Settings stays mounted above the persistent chat workspace. Clear the exact
+ * native-sidebar column from that underlay so the transparent settings sidebar
+ * reaches the OS material instead of revealing opaque chat content beneath it. */
+html[data-native-sidebar-material] [data-native-sidebar-underlay-clear="true"] {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0 var(--desktop-sidebar-width),
+    black var(--desktop-sidebar-width)
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0 var(--desktop-sidebar-width),
+    black var(--desktop-sidebar-width)
+  );
+}

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -18,6 +18,7 @@ import { registerWorkspaceTabCommands } from '@memohai/web/pages/home/commands/w
 import { useWorkspaceTabsStore } from '@memohai/web/store/workspace-tabs'
 import { useKeyboardShortcutsStore } from '@memohai/web/store/keyboard-shortcuts'
 import { useChatStore } from '@memohai/web/store/chat-list'
+import { normalizeDesktopThemeSource } from '../../shared/theme'
 
 import '@fontsource-variable/inter'
 import 'markstream-vue/index.css'
@@ -30,6 +31,13 @@ import router from './chat/router'
 import { setupRendererCacheSync } from './renderer-cache-sync'
 import { handleRendererNavigate } from './renderer-navigation'
 import { isCurrentServerProbe } from './connect/connection-navigation'
+
+// Native sidebar material exists only on macOS. Marking this before Vue mounts
+// lets desktop-shell.css expose the native backdrop without changing Web or the
+// opaque fallback used by Windows and Linux.
+if (navigator.platform.toLowerCase().includes('mac')) {
+  document.documentElement.dataset.nativeSidebarMaterial = ''
+}
 
 // Window-management fallback, intentionally kept separate from the close-tab app
 // command. Cmd/Ctrl+W closes the active workspace tab; when the registry reports
@@ -60,6 +68,17 @@ async function bootstrap() {
   const serverProbe = window.api.desktop.probeServer()
 
   const pinia = createPinia().use(piniaPluginPersistedstate)
+  // NSVisualEffectView follows Electron's nativeTheme rather than the page's
+  // `.dark` class. Seed it before mounting so a persisted manual preference
+  // cannot flash the opposite material; App.vue keeps later changes in sync
+  // from component setup, where the settings store can safely use vue-i18n.
+  try {
+    await window.api.desktop.setThemeSource(
+      normalizeDesktopThemeSource(localStorage.getItem('theme')),
+    )
+  } catch (error) {
+    console.warn('failed to synchronize desktop native theme', error)
+  }
   const keyboardCommands = createKeyboardCommandRegistry()
   registerWorkspaceTabCommands(keyboardCommands, useWorkspaceTabsStore(pinia))
   // Menu-delivered commands arrive over IPC; closing the window when no tab

--- a/apps/desktop/src/renderer/types/web-stubs.d.ts
+++ b/apps/desktop/src/renderer/types/web-stubs.d.ts
@@ -175,9 +175,10 @@ declare module '@memohai/web/pages/home/commands/workspace-tab-commands' {
 }
 
 declare module '@memohai/web/store/settings' {
-  // We don't need the concrete Pinia store type here. Desktop just calls the
-  // composable for its registration side-effect.
-  export function useSettingsStore(): unknown
+  export type ThemePreference = 'light' | 'dark' | 'system'
+  export function useSettingsStore(pinia?: unknown): {
+    theme: ThemePreference
+  }
 }
 
 declare module '@memohai/web/store/workspace-tabs' {

--- a/apps/desktop/src/shared/theme.test.ts
+++ b/apps/desktop/src/shared/theme.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeDesktopThemeSource } from './theme'
+
+describe('normalizeDesktopThemeSource', () => {
+  it.each(['system', 'light', 'dark'] as const)('accepts %s', (source) => {
+    expect(normalizeDesktopThemeSource(source)).toBe(source)
+  })
+
+  it('falls back to the system appearance for invalid renderer input', () => {
+    expect(normalizeDesktopThemeSource('sepia')).toBe('system')
+    expect(normalizeDesktopThemeSource(null)).toBe('system')
+  })
+})

--- a/apps/desktop/src/shared/theme.ts
+++ b/apps/desktop/src/shared/theme.ts
@@ -1,0 +1,9 @@
+export const DESKTOP_THEME_SOURCES = ['system', 'light', 'dark'] as const
+
+export type DesktopThemeSource = typeof DESKTOP_THEME_SOURCES[number]
+
+export function normalizeDesktopThemeSource(value: unknown): DesktopThemeSource {
+  return DESKTOP_THEME_SOURCES.includes(value as DesktopThemeSource)
+    ? value as DesktopThemeSource
+    : 'system'
+}

--- a/apps/web/src/components/master-detail-sidebar-layout/index.vue
+++ b/apps/web/src/components/master-detail-sidebar-layout/index.vue
@@ -9,7 +9,7 @@
          responsive widths; desktop matches SettingsSidebar's fixed 15rem width. -->
     <Sidebar
       class="relative! **:[[role=navigation]]:relative! sidebar-container h-full! border-0! [&_[data-sidebar=sidebar]]:bg-transparent!"
-      :class="desktopShell ? 'w-60!' : 'w-48! lg:w-52! xl:w-60!'"
+      :class="desktopShell ? 'w-(--desktop-sidebar-width)!' : 'w-48! lg:w-52! xl:w-60!'"
     >
       <SidebarContent
         class="overflow-hidden h-full flex flex-col"
@@ -20,6 +20,8 @@
              it goes edge-to-edge with a right divider, matching SettingsSidebar. -->
         <div
           class="flex-1 flex flex-col overflow-hidden min-h-0"
+          :data-native-sidebar-surface="flush || undefined"
+          :data-native-sidebar-tint="flush || undefined"
           :class="flush
             ? 'workspace-divider-r bg-sidebar'
             : 'border border-border-soft bg-muted/10 rounded-lg'"

--- a/apps/web/src/components/settings-sidebar/index.vue
+++ b/apps/web/src/components/settings-sidebar/index.vue
@@ -6,11 +6,13 @@
   <aside
     ref="asideEl"
     class="relative h-full"
-    :style="{ '--sidebar-width': desktopShell ? '15rem' : `${sidebarWidth}px` }"
+    :style="{ '--sidebar-width': desktopShell ? 'var(--desktop-sidebar-width)' : `${sidebarWidth}px` }"
   >
     <Sidebar
       collapsible="none"
       :class="['workspace-divider-r', desktopShell && 'h-dvh']"
+      data-native-sidebar-surface
+      data-native-sidebar-tint
     >
       <div
         v-if="macTrafficReserve"

--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -9,6 +9,7 @@
     class="workspace-divider-r relative flex shrink-0 flex-col bg-sidebar"
     data-native-sidebar-surface
     data-native-sidebar-tint
+    data-native-sidebar-seam
     :style="asideStyle"
     :inert="!workbenchOpen || undefined"
   >

--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -7,6 +7,8 @@
        while closed so focus can't tab into the parked-off-screen rail. -->
   <aside
     class="workspace-divider-r relative flex shrink-0 flex-col bg-sidebar"
+    data-native-sidebar-surface
+    data-native-sidebar-tint
     :style="asideStyle"
     :inert="!workbenchOpen || undefined"
   >
@@ -18,6 +20,7 @@
          full-width (right edge aligns with the search row below). -->
     <header
       class="flex h-11 shrink-0 items-center bg-sidebar pr-2 [-webkit-app-region:drag]"
+      data-native-sidebar-surface
       :class="macTrafficReserve ? 'pl-22' : 'pl-3'"
     >
       <div class="min-w-0 flex-1">
@@ -122,7 +125,10 @@
         v-show="sidebarView === 'schedule'"
         class="h-full"
       />
-      <div class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-sidebar to-transparent" />
+      <div
+        class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-sidebar to-transparent"
+        data-native-sidebar-fade
+      />
     </div>
 
     <!-- Settings, pinned to the bottom. Same action-row owner as New Session /

--- a/apps/web/src/pages/bots/detail.vue
+++ b/apps/web/src/pages/bots/detail.vue
@@ -13,6 +13,7 @@
     <section
       v-if="show"
       class="absolute inset-0 flex flex-col bg-background"
+      data-desktop-window-layer
     >
       <div class="flex-1 relative">
         <MasterDetailSidebarLayout

--- a/apps/web/src/pages/settings-section/index.vue
+++ b/apps/web/src/pages/settings-section/index.vue
@@ -1,9 +1,11 @@
 <template>
-  <!-- Opaque bg-background: this view is rendered into App.vue's transparent
-       fixed overlay, so it must paint its own backdrop to cover the persistent
-       chat behind it. (The overlay wrapper is intentionally transparent so the
-       chat — not a black layer — shows through during this view's slide/fade.) -->
-  <div class="flex h-dvh flex-col overflow-hidden bg-background">
+  <!-- Web keeps an opaque root over the persistent chat. macOS Desktop clears
+       this root in desktop-shell.css: SidebarInset still paints the content pane,
+       while the sidebar exposes the native material behind the renderer. -->
+  <div
+    class="flex h-dvh flex-col overflow-hidden bg-background"
+    data-desktop-window-layer
+  >
     <div class="min-h-0 flex-1">
       <!-- Whole settings view (sidebar + content) slides in from the right on open,
            faster slide-out on leave; navigation is held until the leave plays. -->

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -74,6 +74,17 @@
   --workspace-divider-width: 1.2px;
   --workspace-tab-stroke-width: 1px;
   --workspace-divider-color: rgb(240 239 237);
+
+  /* Desktop native-material sidebar seam (desktop-shell.css consumes these).
+   * Raw --workspace-divider-color washes out over the glass material, and a
+   * color-mix derivation from it reads as the wrong hue — a plain alpha
+   * stroke is what survived tuning. Polarity flips with the mode: the line is
+   * a luminance STEP AWAY from the surface (black over light glass, white
+   * over dark glass), while the shadow stays black in both modes because its
+   * metaphor is occlusion — spilling LEFT onto the sidebar so the chat plane
+   * reads as floating ABOVE the glass layer. */
+  --native-sidebar-seam: oklch(0 0 0 / 0.06);
+  --native-sidebar-seam-shadow: oklch(0 0 0 / 0.04);
   --workspace-tab-strip-color: color-mix(
     in oklab,
     var(--workspace-divider-color) 75%,
@@ -132,6 +143,8 @@
   --surface-chrome: var(--sidebar);
   --surface-composer: var(--card);
   --workspace-divider-color: var(--border);
+  --native-sidebar-seam: oklch(1 0 0 / 0.07);
+  --native-sidebar-seam-shadow: oklch(0 0 0 / 0.12);
   --composer-edge-rest: oklch(0.255 0 0);
   /* Dark = a solid deep purple ≈ rgb(83,45,141) with pure-white ink (a filled
    * "sent" bubble); same relative recipe, just a darker L and near-full C. */


### PR DESCRIPTION
## Summary

- use Electron's native macOS sidebar material instead of a CSS-only blur
- expose the material only through Desktop-specific surface hooks while keeping Web, Windows, and Linux opaque
- synchronize the renderer theme preference with Electron `nativeTheme`
- keep the dark reading surface at `#181818` and apply a 46% semantic sidebar tint so the native material remains visible
- prevent the persistent chat workspace from bleeding through the settings sidebar

## User impact

Memoh Desktop now has a calmer, Codex-like translucent sidebar on macOS. The native material follows the active window and system appearance, including when the window is moved between displays. Other platforms and the browser UI retain their existing appearance.

## Validation

- `pnpm --filter @memohai/desktop typecheck`
- `pnpm exec vitest run apps/desktop/src/main/window-chrome.test.ts apps/desktop/src/shared/theme.test.ts` (6 tests)
- focused ESLint on all changed TypeScript and Vue files
- `node scripts/check-ui-contract.mjs` (passed; 3 pre-existing warnings)
- `pnpm --filter @memohai/desktop build:dir`
- repository pre-commit Go lint/test and staged-file ESLint checks
- manually verified light and dark rendering on a macOS secondary display
