### PR TITLE
fix(channel): isolate inbound worker context

### DIFF
--- a/internal/channel/inbound.go
+++ b/internal/channel/inbound.go
@@ -26,7 +26,7 @@ func (m *Manager) HandleInbound(ctx context.Context, cfg ChannelConfig, msg Inbo
 	if m.processor == nil {
 		return errors.New("inbound processor not configured")
 	}
-	m.startInboundWorkers(ctx)
+	m.startInboundWorkers()
 	if m.inboundCtx != nil && m.inboundCtx.Err() != nil {
 		return errors.New("inbound dispatcher stopped")
 	}
@@ -56,10 +56,11 @@ func (m *Manager) handleInbound(ctx context.Context, cfg ChannelConfig, msg Inbo
 	return nil
 }
 
-func (m *Manager) startInboundWorkers(ctx context.Context) {
+func (m *Manager) startInboundWorkers() {
 	m.inboundOnce.Do(func() {
-		workerCtx := context.WithoutCancel(ctx)
-		inboundCtx, inboundCancel := context.WithCancel(workerCtx)
+		// The pool is shared by every inbound request, so it must not retain
+		// values from whichever request happened to initialize it first.
+		inboundCtx, inboundCancel := context.WithCancel(context.Background())
 		m.inboundCtx, m.inboundCancel = inboundCtx, inboundCancel
 		for i := 0; i < m.inboundWorkers; i++ {
 			go m.runInboundWorker(inboundCtx)

--- a/internal/channel/inbound.go
+++ b/internal/channel/inbound.go
@@ -22,11 +22,11 @@ type inboundTask struct {
 }
 
 // HandleInbound enqueues an inbound message for asynchronous processing by the worker pool.
-func (m *Manager) HandleInbound(ctx context.Context, cfg ChannelConfig, msg InboundMessage) error {
+func (m *Manager) HandleInbound(_ context.Context, cfg ChannelConfig, msg InboundMessage) error {
 	if m.processor == nil {
 		return errors.New("inbound processor not configured")
 	}
-	m.startInboundWorkers()
+	m.startInboundWorkers() //nolint:contextcheck // The shared pool intentionally owns a request-independent lifecycle context.
 	if m.inboundCtx != nil && m.inboundCtx.Err() != nil {
 		return errors.New("inbound dispatcher stopped")
 	}

--- a/internal/channel/inbound_test.go
+++ b/internal/channel/inbound_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 )
 
 // mockAdapter is used for inbound handleInbound tests.
@@ -102,6 +103,37 @@ func (*fakeInboundStreamProcessor) HandleInbound(ctx context.Context, _ ChannelC
 		return err
 	}
 	return stream.Close(ctx)
+}
+
+type inboundRequestContextKey struct{}
+
+type contextCapturingInboundProcessor struct {
+	contexts chan context.Context
+}
+
+func (p *contextCapturingInboundProcessor) HandleInbound(ctx context.Context, _ ChannelConfig, _ InboundMessage, _ StreamReplySender) error {
+	p.contexts <- ctx
+	return nil
+}
+
+func TestManagerInboundWorkersDoNotInheritFirstRequestContext(t *testing.T) {
+	processor := &contextCapturingInboundProcessor{contexts: make(chan context.Context, 1)}
+	m := NewManager(slog.New(slog.DiscardHandler), NewRegistry(), &fakeConfigStore{}, processor)
+	t.Cleanup(func() { _ = m.Shutdown(context.Background()) })
+
+	requestCtx := context.WithValue(context.Background(), inboundRequestContextKey{}, "first-request")
+	if err := m.HandleInbound(requestCtx, ChannelConfig{ID: "cfg-1"}, InboundMessage{}); err != nil {
+		t.Fatalf("HandleInbound: %v", err)
+	}
+
+	select {
+	case workerCtx := <-processor.contexts:
+		if got := workerCtx.Value(inboundRequestContextKey{}); got != nil {
+			t.Fatalf("worker inherited first request context value: %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for inbound worker")
+	}
 }
 
 func TestManager_handleInbound(t *testing.T) {

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -209,7 +209,7 @@ func (m *Manager) Start(ctx context.Context) {
 	if m.logger != nil {
 		m.logger.Info("manager start")
 	}
-	m.startInboundWorkers()
+	m.startInboundWorkers() //nolint:contextcheck // The shared pool intentionally owns a request-independent lifecycle context.
 	go func() {
 		m.refresh(ctx)
 		ticker := time.NewTicker(m.refreshInterval)

--- a/internal/channel/manager.go
+++ b/internal/channel/manager.go
@@ -209,7 +209,7 @@ func (m *Manager) Start(ctx context.Context) {
 	if m.logger != nil {
 		m.logger.Info("manager start")
 	}
-	m.startInboundWorkers(ctx)
+	m.startInboundWorkers()
 	go func() {
 		m.refresh(ctx)
 		ticker := time.NewTicker(m.refreshInterval)


### PR DESCRIPTION
## Root cause

The shared inbound worker pool was initialized with `context.WithoutCancel(ctx)` from the first request that reached it. Cancellation was removed, but every request-scoped value remained attached to the pool and was reused for all later inbound messages.

## Fix

- Root the shared worker pool in a neutral background context.
- Keep its lifecycle owned by the manager's existing shutdown cancellation.
- Add a regression test proving that values from the first request are not visible to worker processing.

This is intentionally a small OSS-only lifecycle fix; hosted Team/RLS reconciliation and control-plane wiring are out of scope.

## Verification

- `go test -race ./internal/channel`