### PR TITLE
docs: disclose human QA status in PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,17 @@ docker compose up -d        # Start all services
 Production deploy services are `postgres`, `pgvector`, `migrate`, `server`, `channel`, and `web`.
 Optional profile: `webhook-tunnel` (cloudflared for channels behind NAT). Desktop connects to Memoh Cloud or this hosted server instead of running its own server.
 
+### Pull Request QA Status
+
+Most PR descriptions in this repository are written by AI agents, and an agent must never silently stand in for human verification. Every PR body must disclose its QA state:
+
+- **Opening a PR** — if no human has verified the change yet (nobody has walked the happy path), end the description with this exact line:
+
+  > ⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
+
+- **After human confirmation** — when a human explicitly confirms QA (in chat, review, or a PR comment), remove the line from the description (e.g. via `gh pr edit`). Green CI, passing tests, typechecks, and the agent's own runs or screenshots never count as human QA; only an explicit human confirmation clears the line.
+- **Updating the description later** — keep the line until a human confirms. If commits land after confirmation, judge whether they could break the verified happy path (typos, rebases, and comment/docs touch-ups cannot); if they could, restore the line until a human verifies the new head. The goal is disclosing the current QA state, not re-QA of every commit.
+
 ## Key Development Rules
 
 ### Database, sqlc & Migrations


### PR DESCRIPTION
## Summary

Most PR descriptions in this repo are written by AI agents, and an agent must never silently stand in for human verification. Too many autopilot PRs land without any human walking the happy path. This PR adds a **Pull Request QA Status** convention to `AGENTS.md` (Development Guide) that makes every PR's QA state visible in its body:

- **Opening a PR** with changes no human has verified → the description must end with this exact line:

  > ⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

- **After a human explicitly confirms QA** (chat, review, or PR comment) → the line must be removed from the description. Green CI, passing tests, typechecks, and agent-run screenshots never count as human QA.
- **Later body edits** — keep the line until human confirmation. If post-confirmation commits could break the verified happy path (typos, rebases, comment/docs touch-ups cannot), restore the line until a human verifies the new head. Safe changes don't require re-QA — the goal is disclosing the current QA state, not re-testing every commit.

## Why this shape

- **Convention, not CI**: no bot edits anyone's PR; the rule binds any agent working in a checkout of this repo — including forks, which CI could not reach.
- **Fixed string**: greppable for audits — `gh search prs "No human QA" --repo memohai/Memoh --state open`.
- **Self-describing line**: the trailing instruction tells contributors who never read `AGENTS.md` how to clear it.

Companion PR: memohai/Memoh-Cloud#125 (same convention for the private repo).

## Test plan

- [x] Docs-only change; no code paths affected
- [x] Markdown renders correctly (blockquote line)
- [ ] Team acknowledgement of the convention

This PR is itself docs-only; its content was reviewed by a human in conversation before submission.

Revision: the third rule was changed from "never re-add once removed" to a judgment-based rule after review feedback — post-confirmation commits that could break the verified happy path restore the line, but the consequence is honest disclosure, not mandatory re-QA of every commit.
