### PR TITLE
fix(web): prevent chat hydration consistency races

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -829,7 +829,7 @@ const paneTarget = computed(() => ({
 }))
 provideChatViewTarget(paneTarget)
 const paneView = computed(() => chatStore.chatView(paneTarget.value))
-const messages = computed(() => paneView.value.transcript.messages)
+const messages = computed(() => paneView.value.transcript.visibleMessages.value)
 const loadingMessages = computed(() => paneView.value.transcript.loadingMessages.value)
 const loadingOlder = computed(() => paneView.value.transcript.loadingOlder.value)
 const hasMoreOlder = computed(() => paneView.value.transcript.hasMoreOlder.value)

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createPinia, setActivePinia } from 'pinia'
+import { createPinia, disposePinia, setActivePinia, type Pinia } from 'pinia'
 import type {
   BotSessionActivityEvent,
   RuntimeCurrentRunView,
@@ -8,6 +8,7 @@ import type {
   UIMessage,
   UIStreamEvent,
   UIStreamEventHandler,
+  UITurn,
   UIUserTurn,
 } from '@/composables/api/useChat'
 import { REASONING_EFFORT_DISABLE } from '@/pages/bots/components/reasoning-effort'
@@ -48,15 +49,17 @@ const sdk = vi.hoisted(() => ({
 }))
 
 vi.hoisted(() => {
-  Object.defineProperty(globalThis, 'localStorage', {
-    configurable: true,
-    value: {
-      getItem: () => null,
-      setItem: () => {},
-      removeItem: () => {},
-      clear: () => {},
-    },
-  })
+  for (const name of ['localStorage', 'sessionStorage']) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      value: {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+        clear: () => {},
+      },
+    })
+  }
 })
 
 vi.mock('@/composables/api/useChat', () => api)
@@ -124,6 +127,8 @@ const h = {
     publishedRunId: string
   }>(),
 }
+
+let pinia: Pinia
 
 function testRuntime(sessionId: string) {
   let runtime = h.runtimeBySession.get(sessionId)
@@ -247,7 +252,8 @@ function wsRunId(index = 0): string {
 }
 
 beforeEach(() => {
-    setActivePinia(createPinia())
+    pinia = createPinia()
+    setActivePinia(pinia)
     h.streamHandler = null
     h.sessionsActivityHandler = null
     h.lastRunId = ''
@@ -557,6 +563,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  disposePinia(pinia)
   vi.unstubAllGlobals()
 })
 
@@ -1988,6 +1995,43 @@ describe('chat-list store', () => {
 
       expect(store.knownSessionSummary('session-subagent')?.title).toBe('Updated subagent title')
       expect(store.knownSessions.find(session => session.id === 'session-subagent')?.title).toBe('Updated subagent title')
+    })
+
+  it('does not let an older REST snapshot overwrite a newer SSE title', async () => {
+      api.fetchSessions.mockResolvedValueOnce({ items: [
+        { id: 'session-1', bot_id: 'bot-1', title: 'Original', type: 'chat' },
+      ], nextCursor: null })
+      const staleRefresh = deferred<{
+        items: Array<{ id: string, bot_id: string, title: string, type: string }>
+        nextCursor: null
+      }>()
+      const store = useChatStore()
+      await store.selectBot('bot-1')
+      api.fetchSessions
+        .mockReturnValueOnce(staleRefresh.promise)
+        .mockResolvedValueOnce({ items: [
+          { id: 'session-1', bot_id: 'bot-1', title: 'New title', type: 'chat' },
+        ], nextCursor: null })
+
+      h.sessionsActivityHandler?.({
+        type: 'session_created',
+        session_id: 'unknown-session',
+        session_type: 'chat',
+      })
+      await flushPromises()
+      h.sessionsActivityHandler?.({
+        type: 'session_title_changed',
+        session_id: 'session-1',
+        title: 'New title',
+      })
+      staleRefresh.resolve({ items: [
+        { id: 'session-1', bot_id: 'bot-1', title: 'Original', type: 'chat' },
+      ], nextCursor: null })
+      await flushPromises()
+      await flushPromises()
+
+      expect(api.fetchSessions).toHaveBeenCalledTimes(3)
+      expect(store.sessions[0]?.title).toBe('New title')
     })
 
   it('keeps remembered hidden session title updates after the visible session list refreshes', async () => {
@@ -3976,6 +4020,39 @@ describe('chat-list store', () => {
       expect(store.messages).toHaveLength(0)
     })
 
+  it('clears the previous bot sessions before the next bot snapshot arrives', async () => {
+      api.fetchBots.mockResolvedValue([
+        { id: 'bot-1', status: 'active', name: 'Bot 1' },
+        { id: 'bot-2', status: 'active', name: 'Bot 2' },
+      ])
+      const botTwoSessions = deferred<{
+        items: Array<{ id: string, bot_id: string, title: string, type: string }>
+        nextCursor: null
+      }>()
+      api.fetchSessions
+        .mockResolvedValueOnce({
+          items: [{ id: 'session-old', bot_id: 'bot-1', title: 'Old', type: 'chat' }],
+          nextCursor: null,
+        })
+        .mockReturnValueOnce(botTwoSessions.promise)
+      const store = useChatStore()
+
+      await store.selectBot('bot-1')
+      const switching = store.selectBot('bot-2')
+
+      expect(store.currentBotId).toBe('bot-2')
+      expect(store.loadingChats).toBe(true)
+      expect(store.sessions).toEqual([])
+
+      botTwoSessions.resolve({
+        items: [{ id: 'session-new', bot_id: 'bot-2', title: 'New', type: 'chat' }],
+        nextCursor: null,
+      })
+      await switching
+
+      expect(store.sessions.map(session => session.id)).toEqual(['session-new'])
+    })
+
   it('reattaches an active stream even when return hydration fails', async () => {
       h.sendUpdates = []
       api.fetchSessions.mockResolvedValueOnce({ items: [
@@ -4009,6 +4086,52 @@ describe('chat-list store', () => {
       returningToSessionA = false
       emitRuntime(runtime.completed, 'session-a', runId)
       await sending
+    })
+
+  it('does not expose a cached Session transcript while it rehydrates', async () => {
+      api.fetchSessions.mockResolvedValueOnce({ items: [
+        { id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' },
+        { id: 'session-b', bot_id: 'bot-1', title: 'B', type: 'chat' },
+      ], nextCursor: null })
+      const freshSessionA = deferred<UITurn[]>()
+      api.fetchMessagesUI
+        .mockResolvedValueOnce([{
+          id: 'cached-a',
+          turn_id: 'cached-a',
+          role: 'user',
+          text: 'cached',
+          attachments: [],
+          timestamp: '2026-01-01T00:00:00.000Z',
+        }])
+        .mockResolvedValueOnce([])
+        .mockReturnValueOnce(freshSessionA.promise)
+      const store = useChatStore()
+
+      await store.selectBot('bot-1')
+      await flushPromises()
+      await store.selectSession('session-b')
+      await flushPromises()
+      await store.selectSession('session-a')
+
+      expect(store.chatView({
+        botId: 'bot-1',
+        sessionId: 'session-a',
+        viewId: 'chat',
+      }).transcript.messages.map(turn => turn.id)).toEqual(['cached-a'])
+      expect(store.loadingMessages).toBe(true)
+      expect(store.messages).toEqual([])
+
+      freshSessionA.resolve([{
+        id: 'fresh-a',
+        turn_id: 'fresh-a',
+        role: 'user',
+        text: 'fresh',
+        attachments: [],
+        timestamp: '2026-01-02T00:00:00.000Z',
+      }])
+      await flushPromises()
+
+      expect(store.messages.map(turn => turn.id)).toEqual(['fresh-a'])
     })
 
   it('hydrates hidden subagent session summaries after selecting them', async () => {
@@ -4161,6 +4284,48 @@ describe('chat-list store', () => {
       // Further load attempts are a no-op once the cursor is exhausted.
       await store.loadMoreSessions()
       expect(api.fetchSessions).toHaveBeenCalledTimes(2)
+    })
+
+  it('drops a pagination page when a newer full refresh replaces its cursor', async () => {
+      const oldPage = deferred<{
+        items: Array<{ id: string, bot_id: string, title: string, type: string }>
+        nextCursor: null
+      }>()
+      api.fetchSessions
+        .mockResolvedValueOnce({
+          items: [{ id: 'session-1', bot_id: 'bot-1', title: 'A', type: 'chat' }],
+          nextCursor: 'cursor-old',
+        })
+        .mockReturnValueOnce(oldPage.promise)
+        .mockResolvedValueOnce({
+          items: [{ id: 'session-new', bot_id: 'bot-1', title: 'New', type: 'chat' }],
+          nextCursor: 'cursor-new',
+        })
+      const store = useChatStore()
+
+      await store.selectBot('bot-1')
+      const loadingPage = store.loadMoreSessions()
+      await flushPromises()
+
+      h.sessionsActivityHandler?.({
+        type: 'session_created',
+        session_id: 'session-new',
+        session_type: 'chat',
+        title: 'New',
+      })
+      await flushPromises()
+      expect(store.sessions.map(session => session.id)).toEqual(['session-new'])
+      expect(store.sessionsCursor).toBe('cursor-new')
+
+      oldPage.resolve({
+        items: [{ id: 'session-stale-page', bot_id: 'bot-1', title: 'Stale', type: 'chat' }],
+        nextCursor: null,
+      })
+      await loadingPage
+
+      expect(store.sessions.map(session => session.id)).toEqual(['session-new'])
+      expect(store.sessionsCursor).toBe('cursor-new')
+      expect(store.hasMoreSessions).toBe(true)
     })
 
   it('resets hasLoadedOlder on initialize so a fresh bot does not inherit the previous scroll-back flag', async () => {
@@ -4532,6 +4697,13 @@ describe('chat-list store', () => {
       api.fetchSessions.mockImplementationOnce(() => new Promise((resolve) => {
         resolveRefresh = resolve
       }))
+      api.fetchSessions.mockResolvedValueOnce({
+        items: [
+          { id: 'session-1', bot_id: 'bot-1', title: 'A', type: 'chat' },
+          { id: 'session-3', bot_id: 'bot-1', title: 'C', type: 'chat' },
+        ],
+        nextCursor: null,
+      })
       h.sessionsActivityHandler?.({
         type: 'session_created',
         session_id: 'session-3',

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -1,5 +1,5 @@
 import { defineStore, storeToRefs } from 'pinia'
-import { computed, ref, watch } from 'vue'
+import { computed, onScopeDispose, ref, watch } from 'vue'
 import { toast } from '@felinic/ui'
 import { useChatSelectionStore } from '@/store/chat-selection'
 import { onAuthSessionCleared } from '@/lib/auth-session'
@@ -98,7 +98,7 @@ export const useChatStore = defineStore('chat', () => {
     chatView, transcriptForTarget, sessionTranscript, transcriptForTurn,
     messages, loadingMessages, loadingOlder, hasMoreOlder, hasLoadedOlder,
     clearHistoryView, prepareForInitialization, markHistoryEmpty,
-    refreshCurrentSession, loadInitialMessages, fetchSessionWindow,
+    refreshCurrentSession, resyncRuntimeTranscript, loadInitialMessages, fetchSessionWindow,
     loadOlderMessages, findMessageIdByExternalId, locateMessageByExternalId,
     isSessionStreaming, streamingSessionId, streaming, isChatViewStreaming,
     workspaceTargetSelectionFor, setWorkspaceTargetSelection,
@@ -132,6 +132,7 @@ export const useChatStore = defineStore('chat', () => {
   const {
     sessions, sessionsCursor, hasMoreSessions, loadingMoreSessions,
     activeSession, knownSessions, activeChatReadOnly, activeChatCanFork,
+    currentSessionListRevision,
     updateForkAnchorForReplacedMessage,
     replaceSessions, appendSessions, upsertSession, rememberSession,
     knownSessionSummary, hasListedSession, patchSessionInList,
@@ -142,6 +143,7 @@ export const useChatStore = defineStore('chat', () => {
   const refreshCoordinator = createChatRefreshCoordinator({
     currentBotId,
     fetchSessions,
+    currentSessionListRevision,
     applySessionsSnapshot: (response) => {
       replaceSessions(response.items)
       sessionsCursor.value = response.nextCursor
@@ -157,6 +159,7 @@ export const useChatStore = defineStore('chat', () => {
     currentBotId,
     sessionId,
     userScopeGeneration: () => userScopeGeneration,
+    currentSessionListRevision,
     currentSelectRequest: () => selectSessionRequestId,
     knownSession: knownSessionSummary,
     rememberSession,
@@ -238,6 +241,7 @@ export const useChatStore = defineStore('chat', () => {
     hasVisibleAssistantBlocks,
     finalizeStreamFailure,
     refreshCurrentSession,
+    resyncRuntimeTranscript,
     releaseHiddenSessionView: (botId, targetSessionId) => {
       releaseHiddenSessionView(chatViews.getSession(botId, targetSessionId) ?? null)
     },
@@ -415,6 +419,7 @@ export const useChatStore = defineStore('chat', () => {
     currentSelectSessionRequest: () => selectSessionRequestId,
     prepareForInitialization,
     resetRefreshCoordinator,
+    resetSessionActivity,
     stopStreams,
     stopWebSocket,
     ensureBot,
@@ -492,7 +497,14 @@ export const useChatStore = defineStore('chat', () => {
     else resetUserScopedState()
   }, { immediate: true })
 
-  onAuthSessionCleared(() => resetUserScopedState({ clearSelection: true }))
+  const stopAuthSessionListener = onAuthSessionCleared(() => {
+    resetUserScopedState({ clearSelection: true })
+  })
+  onScopeDispose(() => {
+    stopAuthSessionListener()
+    stopStreams()
+    stopWebSocket()
+  })
 
   const {
     handleWebNewCommand,

--- a/apps/web/src/store/chat/acp-controller.ts
+++ b/apps/web/src/store/chat/acp-controller.ts
@@ -89,6 +89,7 @@ export function createACPController(deps: {
     currentBotId: deps.currentBotId,
     sessionId: deps.sessionId,
     explicitSessionSelection: deps.explicitSessionSelection,
+    userScopeGeneration: deps.userScopeGeneration,
     currentSelectRequest: deps.currentSelectSessionRequest,
     rememberDefault: staging.rememberDefaultACPInput,
     cachedDefault: staging.cachedDefaultACPInput,
@@ -200,6 +201,7 @@ export function createACPController(deps: {
 
   function reset() {
     staging.clearPendingACPSession()
+    staging.clearDefaultACPInputs()
     orchestration.reset()
     runtimeRegistry.resetACPRuntimeRegistry()
     draftViewRequested.value = null

--- a/apps/web/src/store/chat/acp-defaults.test.ts
+++ b/apps/web/src/store/chat/acp-defaults.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createACPDefaults } from './acp-defaults'
+
+const sdk = vi.hoisted(() => ({
+  getBotsByBotIdSettings: vi.fn(),
+}))
+
+vi.mock('@memohai/sdk', () => ({
+  getBotsByBotIdSettings: sdk.getBotsByBotIdSettings,
+}))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('ACP defaults', () => {
+  it('does not cache settings that resolve after the auth scope changes', async () => {
+    const response = deferred<{ data: Record<string, unknown> }>()
+    sdk.getBotsByBotIdSettings.mockReturnValueOnce(response.promise)
+    let generation = 0
+    const rememberDefault = vi.fn()
+    const defaults = createACPDefaults({
+      currentBotId: ref('bot-1'),
+      sessionId: ref(null),
+      explicitSessionSelection: ref(false),
+      userScopeGeneration: () => generation,
+      currentSelectRequest: () => 0,
+      rememberDefault,
+      cachedDefault: () => ({ loaded: false, input: null }),
+      pendingMatches: () => false,
+      stageDefault: vi.fn(),
+    })
+
+    const loading = defaults.defaultRuntimeIsACP('bot-1')
+    generation += 1
+    response.resolve({
+      data: {
+        chat_runtime: 'acp_agent',
+        chat_acp_agent_id: 'codex',
+      },
+    })
+
+    await expect(loading).resolves.toBe(false)
+    expect(rememberDefault).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/store/chat/acp-defaults.ts
+++ b/apps/web/src/store/chat/acp-defaults.ts
@@ -24,6 +24,7 @@ export function createACPDefaults(deps: {
   currentBotId: Ref<string | null>
   sessionId: Ref<string | null>
   explicitSessionSelection: Ref<boolean>
+  userScopeGeneration: () => number
   currentSelectRequest: () => number
   rememberDefault: (botId: string, input: ACPAgentSessionInput | null) => void
   cachedDefault: (botId: string) => {
@@ -55,8 +56,10 @@ export function createACPDefaults(deps: {
   async function inputFromSettings(botId: string): Promise<ACPAgentSessionInput | null> {
     const bid = botId.trim()
     if (!bid) return null
+    const generation = deps.userScopeGeneration()
     try {
       const settings = await fetchACPSettings(bid)
+      if (generation !== deps.userScopeGeneration()) return null
       if (settings?.chat_runtime !== 'acp_agent') {
         deps.rememberDefault(bid, null)
         return null

--- a/apps/web/src/store/chat/acp-staging.ts
+++ b/apps/web/src/store/chat/acp-staging.ts
@@ -119,6 +119,10 @@ export function createACPStaging(deps: ACPStagingDeps) {
     return { loaded: true, input: input ? cloneACPInput(input) : null }
   }
 
+  function clearDefaultACPInputs() {
+    defaultACPInputsByBot.clear()
+  }
+
   function cacheDefaultACPSession(input: ACPAgentSessionInput | null) {
     rememberDefaultACPInput(currentBotId.value ?? '', input)
   }
@@ -425,6 +429,7 @@ export function createACPStaging(deps: ACPStagingDeps) {
     pendingACPRuntimeEnsuring,
     rememberDefaultACPInput,
     cachedDefaultACPInput,
+    clearDefaultACPInputs,
     cacheDefaultACPSession,
     stageACPSession,
     stageDefaultACPSession,

--- a/apps/web/src/store/chat/bootstrap.ts
+++ b/apps/web/src/store/chat/bootstrap.ts
@@ -12,6 +12,7 @@ export interface ChatBootstrapDeps {
   currentSelectSessionRequest: () => number
   prepareForInitialization: () => void
   resetRefreshCoordinator: () => void
+  resetSessionActivity: () => void
   stopStreams: () => void
   stopWebSocket: () => void
   ensureBot: () => Promise<string | null>
@@ -75,6 +76,7 @@ export function createChatBootstrap(deps: ChatBootstrapDeps) {
           initializingBotId = (deps.currentBotId.value ?? '').trim() || null
           deps.prepareForInitialization()
           deps.resetRefreshCoordinator()
+          deps.resetSessionActivity()
           deps.stopStreams()
           deps.stopWebSocket()
 
@@ -205,6 +207,10 @@ export function createChatBootstrap(deps: ChatBootstrapDeps) {
     deps.abortAllAssistantStreams()
     deps.clearPendingACPSession()
     deps.clearFsForBotSwitch()
+    deps.resetSessionActivity()
+    deps.replaceSessions([])
+    deps.sessionsCursor.value = null
+    deps.hasMoreSessions.value = false
     deps.currentBotId.value = targetBotId
     deps.sessionId.value = null
     deps.clearRememberedSessions()

--- a/apps/web/src/store/chat/realtime.test.ts
+++ b/apps/web/src/store/chat/realtime.test.ts
@@ -57,7 +57,9 @@ function makeController() {
   const activityHandlers: Array<(event: BotSessionActivityEvent) => void> = []
   const callbacks: ChatRealtimeCallbacks = {
     onWebSocketEvent: vi.fn(),
-    prepareSessionRuntime: vi.fn().mockResolvedValue(undefined),
+    prepareSessionRuntime: vi.fn(async (_botId, _sessionId, commitInitialHistory) => {
+      await commitInitialHistory(() => {})
+    }),
     onRuntimeProjection: vi.fn(),
     onBotSessionsActivityEvent: vi.fn(),
   }
@@ -192,6 +194,7 @@ describe('chat realtime controller', () => {
         updated_at: '2026-07-27T08:00:00.000Z',
       },
     })
+    await flushPromises()
 
     expect(callbacks.onRuntimeProjection).toHaveBeenCalledOnce()
     expect(controller.runtimeProjection('session-1')).toMatchObject({
@@ -200,15 +203,51 @@ describe('chat realtime controller', () => {
     })
   })
 
-  it('lets history apply buffered runtime state before hydration completes', async () => {
+  it('holds fetched history until the initial runtime snapshot is ready', async () => {
     const { controller, callbacks, sockets } = makeController()
-    let applyBufferedProjections: (() => void) | undefined
-    let finishPreparation: (() => void) | undefined
-    callbacks.prepareSessionRuntime = vi.fn((_botId, _sessionId, applyBuffered) => {
-      applyBufferedProjections = applyBuffered
-      return new Promise<void>((resolve) => {
-        finishPreparation = resolve
-      })
+    const phases: string[] = []
+    callbacks.onRuntimeProjection = vi.fn(() => phases.push('runtime'))
+    callbacks.prepareSessionRuntime = vi.fn(async (_botId, _sessionId, commitInitialHistory) => {
+      phases.push('history-fetched')
+      await commitInitialHistory(() => phases.push('history'))
+      phases.push('prepared')
+    })
+    controller.startWebSocket('bot-1')
+    controller.startSessionRuntime('bot-1', 'session-1')
+    await flushPromises()
+
+    expect(phases).toEqual(['history-fetched'])
+    expect(callbacks.onRuntimeProjection).not.toHaveBeenCalled()
+
+    sockets[0]!.handler({
+      type: 'runtime_snapshot',
+      session_id: 'session-1',
+      epoch: 'epoch-1',
+      seq: 1,
+      snapshot: {
+        bot_id: 'bot-1',
+        session_id: 'session-1',
+        epoch: 'epoch-1',
+        seq: 1,
+        updated_at: '2026-07-27T08:00:00.000Z',
+      },
+    })
+    await flushPromises()
+
+    expect(phases).toEqual(['history-fetched', 'history', 'runtime', 'prepared'])
+  })
+
+  it('holds the initial runtime snapshot until fetched history can commit', async () => {
+    const { controller, callbacks, sockets } = makeController()
+    const phases: string[] = []
+    let finishHistoryFetch!: () => void
+    const historyFetched = new Promise<void>((resolve) => {
+      finishHistoryFetch = resolve
+    })
+    callbacks.onRuntimeProjection = vi.fn(() => phases.push('runtime'))
+    callbacks.prepareSessionRuntime = vi.fn(async (_botId, _sessionId, commitInitialHistory) => {
+      await historyFetched
+      await commitInitialHistory(() => phases.push('history'))
     })
     controller.startWebSocket('bot-1')
     controller.startSessionRuntime('bot-1', 'session-1')
@@ -226,13 +265,32 @@ describe('chat realtime controller', () => {
         updated_at: '2026-07-27T08:00:00.000Z',
       },
     })
+    await flushPromises()
+
+    expect(phases).toEqual([])
     expect(callbacks.onRuntimeProjection).not.toHaveBeenCalled()
 
-    applyBufferedProjections?.()
-    expect(callbacks.onRuntimeProjection).toHaveBeenCalledOnce()
-
-    finishPreparation?.()
+    finishHistoryFetch()
     await flushPromises()
+
+    expect(phases).toEqual(['history', 'runtime'])
+  })
+
+  it('releases a pending hydration when its runtime subscription stops', async () => {
+    const { controller, callbacks } = makeController()
+    const prepared = vi.fn()
+    callbacks.prepareSessionRuntime = vi.fn(async (_botId, _sessionId, commitInitialHistory) => {
+      await commitInitialHistory(() => {})
+      prepared()
+    })
+    controller.startWebSocket('bot-1')
+    controller.startSessionRuntime('bot-1', 'session-1')
+
+    controller.stopSessionRuntime('bot-1', 'session-1')
+    await flushPromises()
+
+    expect(prepared).toHaveBeenCalledOnce()
+    expect(callbacks.onRuntimeProjection).not.toHaveBeenCalled()
   })
 
   it('unsubscribes a hidden session without stopping another session', async () => {

--- a/apps/web/src/store/chat/realtime.ts
+++ b/apps/web/src/store/chat/realtime.ts
@@ -21,6 +21,8 @@ interface RetryingStream {
 interface SessionRuntimeConnection {
   prepared: boolean
   pending: RuntimeProjectionChange[]
+  initialSnapshotReady: Promise<void>
+  resolveInitialSnapshot: (() => void) | null
 }
 
 export interface ChatRealtimeCallbacks {
@@ -28,7 +30,7 @@ export interface ChatRealtimeCallbacks {
   prepareSessionRuntime: (
     botId: string,
     sessionId: string,
-    applyBufferedProjections: () => void,
+    commitInitialHistory: (applyHistory: () => void) => Promise<void>,
   ) => Promise<void>
   onRuntimeProjection: (
     botId: string,
@@ -78,6 +80,10 @@ export function createChatRealtimeController(
       if (!botId || !connection) return
       if (!connection.prepared) {
         connection.pending.push(change)
+        if (change.event.type === 'runtime_snapshot') {
+          connection.resolveInitialSnapshot?.()
+          connection.resolveInitialSnapshot = null
+        }
         return
       }
       callbacks.onRuntimeProjection(botId, sessionId, change)
@@ -160,8 +166,9 @@ export function createChatRealtimeController(
 
   function stopSessionRuntime(botId?: string, sessionId?: string) {
     if (botId === undefined && sessionId === undefined) {
-      for (const key of sessionRuntimeConnections.keys()) {
+      for (const [key, connection] of sessionRuntimeConnections) {
         const [, sid = ''] = key.split('\u0000')
+        connection.resolveInitialSnapshot?.()
         runtimeClient.unsubscribe(sid)
       }
       sessionRuntimeConnections.clear()
@@ -172,7 +179,10 @@ export function createChatRealtimeController(
     const sid = (sessionId ?? '').trim()
     if (!bid || !sid) return
     const key = sessionRuntimeKey(bid, sid)
-    if (!sessionRuntimeConnections.delete(key)) return
+    const connection = sessionRuntimeConnections.get(key)
+    if (!connection) return
+    sessionRuntimeConnections.delete(key)
+    connection.resolveInitialSnapshot?.()
     runtimeClient.unsubscribe(sid)
   }
 
@@ -182,9 +192,15 @@ export function createChatRealtimeController(
     if (!bid || !sid) return
     const key = sessionRuntimeKey(bid, sid)
     if (sessionRuntimeConnections.has(key)) return
+    let resolveInitialSnapshot!: () => void
+    const initialSnapshotReady = new Promise<void>((resolve) => {
+      resolveInitialSnapshot = resolve
+    })
     const connection: SessionRuntimeConnection = {
       prepared: false,
       pending: [],
+      initialSnapshotReady,
+      resolveInitialSnapshot,
     }
     sessionRuntimeConnections.set(key, connection)
     runtimeClient.subscribe(sid)
@@ -195,7 +211,16 @@ export function createChatRealtimeController(
         callbacks.onRuntimeProjection(bid, sid, change)
       }
     }
-    void callbacks.prepareSessionRuntime(bid, sid, applyBufferedProjections)
+    const commitInitialHistory = async (applyHistory: () => void) => {
+      await connection.initialSnapshotReady
+      if (sessionRuntimeConnections.get(key) !== connection) return
+      // The database can still expose the pre-edit tail while Runtime already
+      // owns its replacement. Commit both projections without yielding so Vue
+      // never renders the database-only intermediate state.
+      applyHistory()
+      applyBufferedProjections()
+    }
+    void callbacks.prepareSessionRuntime(bid, sid, commitInitialHistory)
       .catch(error => console.error('Failed to load session messages:', error))
       .finally(() => {
         if (sessionRuntimeConnections.get(key) !== connection) return

--- a/apps/web/src/store/chat/refresh-coordinator.test.ts
+++ b/apps/web/src/store/chat/refresh-coordinator.test.ts
@@ -22,31 +22,68 @@ function makeCoordinator() {
   const currentBotId = ref<string | null>('bot-1')
   const fetchSessions = vi.fn<(_botId: string) => Promise<FetchSessionsResult>>()
   const applySessionsSnapshot = vi.fn()
+  let revision = 0
   return {
     currentBotId,
     fetchSessions,
     applySessionsSnapshot,
+    bumpRevision: () => { revision += 1 },
     coordinator: createChatRefreshCoordinator({
       currentBotId,
       fetchSessions,
+      currentSessionListRevision: () => revision,
       applySessionsSnapshot,
     }),
   }
 }
 
 describe('chat refresh coordinator', () => {
-  it('deduplicates session-list refreshes for the same bot', async () => {
+  it('coalesces an in-flight signal into one trailing refresh', async () => {
     const { coordinator, fetchSessions, applySessionsSnapshot } = makeCoordinator()
-    const request = deferred<FetchSessionsResult>()
-    fetchSessions.mockReturnValue(request.promise)
+    const firstRequest = deferred<FetchSessionsResult>()
+    const trailingRequest = deferred<FetchSessionsResult>()
+    fetchSessions
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(trailingRequest.promise)
 
     const first = coordinator.refreshSessionsList('bot-1')
     const second = coordinator.refreshSessionsList('bot-1')
     expect(fetchSessions).toHaveBeenCalledOnce()
 
-    request.resolve(page('session-current'))
+    firstRequest.resolve(page('session-stale'))
+    await Promise.resolve()
+    expect(applySessionsSnapshot).not.toHaveBeenCalled()
+    expect(fetchSessions).toHaveBeenCalledTimes(2)
+
+    trailingRequest.resolve(page('session-current'))
     await Promise.all([first, second])
     expect(applySessionsSnapshot).toHaveBeenCalledOnce()
+    expect(applySessionsSnapshot).toHaveBeenCalledWith(page('session-current'))
+  })
+
+  it('reruns when an SSE mutation advances the list revision', async () => {
+    const {
+      coordinator,
+      fetchSessions,
+      applySessionsSnapshot,
+      bumpRevision,
+    } = makeCoordinator()
+    const firstRequest = deferred<FetchSessionsResult>()
+    const trailingRequest = deferred<FetchSessionsResult>()
+    fetchSessions
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(trailingRequest.promise)
+
+    const refresh = coordinator.refreshSessionsList('bot-1')
+    bumpRevision()
+    firstRequest.resolve(page('session-stale'))
+    await Promise.resolve()
+    expect(applySessionsSnapshot).not.toHaveBeenCalled()
+
+    trailingRequest.resolve(page('session-current'))
+    await refresh
+    expect(applySessionsSnapshot).toHaveBeenCalledOnce()
+    expect(applySessionsSnapshot).toHaveBeenCalledWith(page('session-current'))
   })
 
   it('invalidates old responses and lets a new scope request win', async () => {

--- a/apps/web/src/store/chat/refresh-coordinator.ts
+++ b/apps/web/src/store/chat/refresh-coordinator.ts
@@ -4,40 +4,69 @@ import type { FetchSessionsResult } from '@/composables/api/useChat'
 interface ChatRefreshCoordinatorDeps {
   currentBotId: Ref<string | null>
   fetchSessions: (botId: string) => Promise<FetchSessionsResult>
+  currentSessionListRevision: () => number
   applySessionsSnapshot: (response: FetchSessionsResult) => void
+}
+
+interface SessionListRefresh {
+  dirty: boolean
+  promise: Promise<void>
 }
 
 export function createChatRefreshCoordinator({
   currentBotId,
   fetchSessions,
+  currentSessionListRevision,
   applySessionsSnapshot,
 }: ChatRefreshCoordinatorDeps) {
-  const sessionListRequests = new Map<string, Promise<void>>()
+  const sessionListRequests = new Map<string, SessionListRefresh>()
   let scopeGeneration = 0
 
   function refreshSessionsList(botId: string): Promise<void> {
     const bid = botId.trim()
     if (!bid) return Promise.resolve()
     const existing = sessionListRequests.get(bid)
-    if (existing) return existing
+    if (existing) {
+      // A second signal means the snapshot already in flight may have started
+      // before the server-side mutation. Skip it and coalesce all signals into
+      // one trailing refresh.
+      existing.dirty = true
+      return existing.promise
+    }
 
     const generation = scopeGeneration
-    const promise = fetchSessions(bid)
-      .then((response) => {
-        if (generation !== scopeGeneration) return
-        if (sessionListRequests.get(bid) !== promise) return
-        if ((currentBotId.value ?? '').trim() !== bid) return
+    const request: SessionListRefresh = {
+      dirty: false,
+      promise: Promise.resolve(),
+    }
+    request.promise = (async () => {
+      do {
+        request.dirty = false
+        const revision = currentSessionListRevision()
+        let response: FetchSessionsResult
+        try {
+          response = await fetchSessions(bid)
+        } catch (error) {
+          console.error('Failed to refresh sessions:', error)
+          return
+        }
+        if (
+          generation !== scopeGeneration
+          || sessionListRequests.get(bid) !== request
+          || (currentBotId.value ?? '').trim() !== bid
+        ) return
+        if (request.dirty || currentSessionListRevision() !== revision) {
+          request.dirty = true
+          continue
+        }
         applySessionsSnapshot(response)
-      })
-      .catch((error) => {
-        console.error('Failed to refresh sessions:', error)
-      })
-      .finally(() => {
-        if (sessionListRequests.get(bid) === promise) sessionListRequests.delete(bid)
-      })
+      } while (request.dirty)
+    })().finally(() => {
+      if (sessionListRequests.get(bid) === request) sessionListRequests.delete(bid)
+    })
 
-    sessionListRequests.set(bid, promise)
-    return promise
+    sessionListRequests.set(bid, request)
+    return request.promise
   }
 
   function resetRefreshCoordinator() {

--- a/apps/web/src/store/chat/runtime-integration.ts
+++ b/apps/web/src/store/chat/runtime-integration.ts
@@ -81,7 +81,7 @@ export interface RuntimeIntegrationDeps {
   loadInitialMessages: (
     botId: string,
     sessionId: string,
-    afterApply?: () => void,
+    commitInitialHistory: (applyHistory: () => void) => Promise<void>,
   ) => Promise<void>
   reattachTurnToSession: (
     botId: string,
@@ -401,7 +401,7 @@ export function createRuntimeIntegration(deps: RuntimeIntegrationDeps) {
   async function prepareSessionRuntime(
     botId: string,
     sessionId: string,
-    applyBufferedProjections: () => void,
+    commitInitialHistory: (applyHistory: () => void) => Promise<void>,
   ) {
     const normalizedBotId = botId.trim()
     const normalizedSessionId = sessionId.trim()
@@ -410,7 +410,7 @@ export function createRuntimeIntegration(deps: RuntimeIntegrationDeps) {
       await deps.loadInitialMessages(
         normalizedBotId,
         normalizedSessionId,
-        applyBufferedProjections,
+        commitInitialHistory,
       )
     } finally {
       for (const stream of deps.assistantStreams.assistantStreamsForSession(

--- a/apps/web/src/store/chat/runtime-integration.ts
+++ b/apps/web/src/store/chat/runtime-integration.ts
@@ -77,6 +77,11 @@ export interface RuntimeIntegrationDeps {
     error: Error,
   ) => void
   refreshCurrentSession: (botId: string, sessionId: string) => Promise<void>
+  resyncRuntimeTranscript: (
+    botId: string,
+    sessionId: string,
+    transcript: RuntimeProjectionChange['current']['transcript'],
+  ) => Promise<void>
   releaseHiddenSessionView: (botId: string, sessionId: string) => void
   loadInitialMessages: (
     botId: string,
@@ -305,11 +310,11 @@ export function createRuntimeIntegration(deps: RuntimeIntegrationDeps) {
     const needsHistoryResync = Boolean(
       view && !view.transcript.applyRuntimeTranscript(change.current.transcript),
     )
-    const resyncTranscript = () => deps.refreshCurrentSession(botId, sessionId)
-      .then(() => {
-        deps.chatViews.getSession(botId, sessionId)
-          ?.transcript.applyRuntimeTranscript(change.current.transcript)
-      })
+    const resyncTranscript = () => deps.resyncRuntimeTranscript(
+      botId,
+      sessionId,
+      change.current.transcript,
+    )
 
     if (needsHistoryResync && currentRun && isRuntimeRunActive(currentRun.status)) {
       void resyncTranscript()

--- a/apps/web/src/store/chat/runtime-layer.ts
+++ b/apps/web/src/store/chat/runtime-layer.ts
@@ -34,13 +34,13 @@ export function createChatRuntimeLayer(deps: ChatRuntimeLayerDeps) {
   let forwardPrepareSessionRuntime: (
     botId: string,
     sessionId: string,
-    applyBufferedProjections: () => void,
+    commitInitialHistory: (applyHistory: () => void) => Promise<void>,
   ) => Promise<void> = async () => {}
 
   const realtime = createChatRealtimeController({
     onWebSocketEvent: (botId, event) => forwardWebSocketEvent(botId, event),
-    prepareSessionRuntime: (botId, sessionId, applyBufferedProjections) =>
-      forwardPrepareSessionRuntime(botId, sessionId, applyBufferedProjections),
+    prepareSessionRuntime: (botId, sessionId, commitInitialHistory) =>
+      forwardPrepareSessionRuntime(botId, sessionId, commitInitialHistory),
     onRuntimeProjection: (botId, sessionId, change) =>
       forwardRuntimeProjection(botId, sessionId, change),
     onBotSessionsActivityEvent: deps.onBotSessionsActivityEvent,

--- a/apps/web/src/store/chat/runtime-projection.test.ts
+++ b/apps/web/src/store/chat/runtime-projection.test.ts
@@ -89,6 +89,17 @@ describe('runtime projection', () => {
     ])
   })
 
+  it('treats a null message list from an idle runtime snapshot as empty', () => {
+    const state = reduceRuntimeProjection(createEmptyRuntimeProjection(), snapshot(runView({
+      status: 'completed',
+      messages: null as unknown as RuntimeCurrentRunView['messages'],
+      request_user_turn: undefined,
+    })))
+
+    expect(state.currentRunView?.messages).toEqual([])
+    expect(state.transcript.streaming).toBe(false)
+  })
+
   it('projects an edit replacement as the authoritative user and assistant pair', () => {
     const state = reduceRuntimeProjection(createEmptyRuntimeProjection(), snapshot(runView({
       request_user_turn: undefined,

--- a/apps/web/src/store/chat/runtime-projection.ts
+++ b/apps/web/src/store/chat/runtime-projection.ts
@@ -69,9 +69,10 @@ function cloneUIMessage(message: UIMessage): UIMessage {
 }
 
 function cloneRunView(run: RuntimeCurrentRunView): RuntimeCurrentRunView {
+  const messages = run.messages ?? []
   return {
     ...run,
-    messages: run.messages.map(cloneUIMessage),
+    messages: messages.map(cloneUIMessage),
     request_user_turn: run.request_user_turn
       ? {
           ...run.request_user_turn,

--- a/apps/web/src/store/chat/session-activity.ts
+++ b/apps/web/src/store/chat/session-activity.ts
@@ -10,6 +10,7 @@ export function createSessionActivity(deps: {
   currentBotId: Ref<string | null>
   sessionId: Ref<string | null>
   userScopeGeneration: () => number
+  currentSessionListRevision: () => number
   currentSelectRequest: () => number
   knownSession: (sessionId: string) => SessionSummary | null | undefined
   rememberSession: (session: SessionSummary) => void
@@ -26,6 +27,7 @@ export function createSessionActivity(deps: {
   refreshSessionsList: (botId: string) => Promise<void>
 }) {
   const visibleSummaryRequests = new Map<string, Promise<SessionSummary | null>>()
+  let loadMoreRequestVersion = 0
 
   async function ensureSessionSummary(
     botId: string,
@@ -95,17 +97,28 @@ export function createSessionActivity(deps: {
     const botId = (deps.currentBotId.value ?? '').trim()
     const cursor = deps.sessionsCursor.value
     if (!botId || !cursor) return
+    const userGeneration = deps.userScopeGeneration()
+    const listRevision = deps.currentSessionListRevision()
+    const requestVersion = ++loadMoreRequestVersion
     deps.loadingMoreSessions.value = true
     try {
       const response = await fetchSessions(botId, { cursor })
-      if ((deps.currentBotId.value ?? '').trim() !== botId) return
+      if (
+        requestVersion !== loadMoreRequestVersion
+        || userGeneration !== deps.userScopeGeneration()
+        || (deps.currentBotId.value ?? '').trim() !== botId
+        || deps.sessionsCursor.value !== cursor
+        || deps.currentSessionListRevision() !== listRevision
+      ) return
       deps.appendSessions(response.items)
       deps.sessionsCursor.value = response.nextCursor
       deps.hasMoreSessions.value = response.nextCursor !== null
     } catch (error) {
       console.error('Failed to load more sessions:', error)
     } finally {
-      deps.loadingMoreSessions.value = false
+      if (requestVersion === loadMoreRequestVersion) {
+        deps.loadingMoreSessions.value = false
+      }
     }
   }
 
@@ -144,6 +157,10 @@ export function createSessionActivity(deps: {
     ensureVisibleSessionSummary,
     loadMoreSessions,
     handleActivity,
-    reset: () => { visibleSummaryRequests.clear() },
+    reset: () => {
+      visibleSummaryRequests.clear()
+      loadMoreRequestVersion += 1
+      deps.loadingMoreSessions.value = false
+    },
   }
 }

--- a/apps/web/src/store/chat/session-list.ts
+++ b/apps/web/src/store/chat/session-list.ts
@@ -71,6 +71,10 @@ export function createSessionList({ currentBotId, sessionId, messages }: Session
     return sessionLookupRevision.value
   }
 
+  function currentSessionListRevision() {
+    return sessionLookupRevision.value
+  }
+
   // --- Fork-anchor tracking -------------------------------------------------
   // The anchor is stored as metadata.forked_from.fork_message_id on the
   // SessionSummary; there is no dedicated state beyond the session records.
@@ -334,16 +338,22 @@ export function createSessionList({ currentBotId, sessionId, messages }: Session
     const sid = targetSessionId.trim()
     if (!bid || !sid) return
     const deletedIds = deletedSessionIdsByBot.get(bid) ?? new Set<string>()
+    if (deletedIds.has(sid)) return
     deletedIds.add(sid)
     deletedSessionIdsByBot.set(bid, deletedIds)
+    markSessionLookupChanged()
   }
 
   function clearDeletedSessionIds() {
+    if (deletedSessionIdsByBot.size === 0) return
     deletedSessionIdsByBot.clear()
+    markSessionLookupChanged()
   }
 
   function clearRememberedSessions() {
+    if (Object.keys(rememberedSessions.value).length === 0) return
     rememberedSessions.value = {}
+    markSessionLookupChanged()
   }
 
   return {
@@ -357,6 +367,7 @@ export function createSessionList({ currentBotId, sessionId, messages }: Session
     knownSessions,
     activeChatReadOnly,
     activeChatCanFork,
+    currentSessionListRevision,
     updateForkAnchorForReplacedMessage,
     // mutations
     replaceSessions,

--- a/apps/web/src/store/chat/transcript-queries.ts
+++ b/apps/web/src/store/chat/transcript-queries.ts
@@ -1,0 +1,48 @@
+import { serverMessageId } from '../chat-list.normalize'
+import type { ChatAssistantTurn, ChatMessage, ChatUserTurn } from './types'
+
+export function createTranscriptQueries(messages: ChatMessage[]) {
+  function latestOptimisticUserText(): string {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index]
+      if (message?.role === 'user') return message.text.trim()
+    }
+    return ''
+  }
+
+  function findTurnByServerId(messageId: string): ChatMessage | null {
+    const id = messageId.trim()
+    if (!id) return null
+    return messages.find(turn => serverMessageId(turn) === id) ?? null
+  }
+
+  function latestVisibleTurn(role: 'user'): ChatUserTurn | null
+  function latestVisibleTurn(role: 'assistant'): ChatAssistantTurn | null
+  function latestVisibleTurn(role: ChatMessage['role']): ChatUserTurn | ChatAssistantTurn | null {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const turn = messages[index]
+      if (turn && turn.role !== 'system' && turn.role === role && !turn.__optimistic) return turn
+    }
+    return null
+  }
+
+  function isLatestVisibleUserTurn(turn: ChatMessage): turn is ChatUserTurn {
+    if (turn.role !== 'user') return false
+    const latest = latestVisibleTurn('user')
+    return Boolean(latest && serverMessageId(latest) === serverMessageId(turn))
+  }
+
+  function isLatestVisibleAssistantTurn(turn: ChatMessage): turn is ChatAssistantTurn {
+    if (turn.role !== 'assistant') return false
+    const latest = latestVisibleTurn('assistant')
+    return Boolean(latest && serverMessageId(latest) === serverMessageId(turn))
+  }
+
+  return {
+    latestOptimisticUserText,
+    hasTurn: (turn: ChatMessage) => messages.includes(turn),
+    findTurnByServerId,
+    isLatestVisibleUserTurn,
+    isLatestVisibleAssistantTurn,
+  }
+}

--- a/apps/web/src/store/chat/transcript.test.ts
+++ b/apps/web/src/store/chat/transcript.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { ref, toRaw } from 'vue'
+import { nextTick, ref, toRaw, watch } from 'vue'
 import type { UIMessage, UITurn } from '@/composables/api/useChat.types'
 import { createBackgroundTaskTracker } from './background-tasks'
 import { createTranscriptController } from './transcript'
@@ -329,6 +329,27 @@ describe('chat transcript controller', () => {
     })
   })
 
+  it('masks a cached transcript until rehydration commits', async () => {
+    const { transcript, fetchMessages } = makeTranscript()
+    transcript.replaceMessages([rawUser('cached-user', 'stale')], 'session-1')
+    const pending = deferred<UITurn[]>()
+    fetchMessages.mockReturnValueOnce(pending.promise)
+
+    const hydration = transcript.loadInitialMessages(
+      'bot-1',
+      'session-1',
+      async applyHistory => applyHistory(),
+    )
+
+    expect(transcript.messages.map(turn => turn.id)).toEqual(['cached-user'])
+    expect(transcript.visibleMessages.value).toEqual([])
+
+    pending.resolve([rawUser('fresh-user', 'fresh')])
+    await hydration
+
+    expect(transcript.visibleMessages.value.map(turn => turn.id)).toEqual(['fresh-user'])
+  })
+
   it('replaces staged database history with an active edit projection', async () => {
     const { transcript, fetchMessages } = makeTranscript()
     fetchMessages.mockResolvedValueOnce([
@@ -419,6 +440,41 @@ describe('chat transcript controller', () => {
 
     expect(applied).toBe(false)
     expect(transcript.messages.map(turn => turn.id)).toEqual(['user-old'])
+  })
+
+  it('commits resynced history and its replacement projection in one render', async () => {
+    const { transcript, fetchMessages } = makeTranscript()
+    transcript.replaceMessages([rawUser('cached-user', 'stale')], 'session-1')
+    fetchMessages.mockResolvedValueOnce([
+      rawUser('server-user', 'original'),
+      rawAssistant('server-assistant', [{ id: 0, type: 'text', content: 'old' }]),
+    ])
+    const renders: string[] = []
+    const stop = watch(
+      () => transcript.messages.map(turn => turn.id).join(','),
+      value => renders.push(value),
+    )
+
+    await transcript.refreshCurrentSession('bot-1', 'session-1', () => {
+      transcript.applyRuntimeTranscript({
+        runId: 'run-edit',
+        turnId: 'turn-edit',
+        status: 'running',
+        operation: {
+          kind: 'edit',
+          replace_from_message_id: 'server-user',
+        },
+        streaming: true,
+        turns: [
+          rawUser('runtime-user', 'edited'),
+          rawAssistant('runtime-assistant'),
+        ],
+      })
+    })
+    await nextTick()
+    stop()
+
+    expect(renders).toEqual(['runtime-user,runtime-assistant'])
   })
 
   it('owns refresh state and reports the latest applied timestamp', async () => {

--- a/apps/web/src/store/chat/transcript.test.ts
+++ b/apps/web/src/store/chat/transcript.test.ts
@@ -297,7 +297,10 @@ describe('chat transcript controller', () => {
     fetchMessages.mockResolvedValueOnce([historyUser, historyAssistant])
     const phases: string[] = []
 
-    await transcript.loadInitialMessages('bot-1', 'session-1', () => {
+    await transcript.loadInitialMessages('bot-1', 'session-1', async (applyHistory) => {
+      expect(transcript.messages).toHaveLength(0)
+      applyHistory()
+      phases.push('history')
       phases.push('runtime')
       transcript.applyRuntimeTranscript({
         runId: 'run-1',
@@ -316,7 +319,7 @@ describe('chat transcript controller', () => {
     })
     phases.push('loaded')
 
-    expect(phases).toEqual(['runtime', 'loaded'])
+    expect(phases).toEqual(['history', 'runtime', 'loaded'])
     expect(transcript.messages).toHaveLength(2)
     expect(transcript.messages.map(turn => turn.id)).toEqual(['server-user', 'server-assistant'])
     expect(transcript.messages[1]).toMatchObject({
@@ -324,6 +327,39 @@ describe('chat transcript controller', () => {
       streaming: true,
       messages: [{ type: 'text', content: 'streaming' }],
     })
+  })
+
+  it('replaces staged database history with an active edit projection', async () => {
+    const { transcript, fetchMessages } = makeTranscript()
+    fetchMessages.mockResolvedValueOnce([
+      rawUser('server-user', 'original'),
+      rawAssistant('server-assistant', [{ id: 0, type: 'text', content: 'old answer' }]),
+    ])
+
+    await transcript.loadInitialMessages('bot-1', 'session-1', async (applyHistory) => {
+      expect(transcript.messages).toHaveLength(0)
+      applyHistory()
+      transcript.applyRuntimeTranscript({
+        runId: 'run-edit',
+        turnId: 'turn-edit',
+        status: 'running',
+        operation: {
+          kind: 'edit',
+          replace_from_message_id: 'server-user',
+        },
+        streaming: true,
+        turns: [
+          rawUser('runtime-user', 'edited'),
+          rawAssistant('runtime-assistant'),
+        ],
+      })
+    })
+
+    expect(transcript.messages.map(turn => turn.id)).toEqual([
+      'runtime-user',
+      'runtime-assistant',
+    ])
+    expect(transcript.messages[0]).toMatchObject({ role: 'user', text: 'edited' })
   })
 
   it('applies a replacement operation that arrives after the admitting projection', () => {
@@ -394,7 +430,9 @@ describe('chat transcript controller', () => {
       rawAssistant('assistant-1', [], '2026-01-01T00:00:02.000Z'),
     ])
 
-    await transcript.loadInitialMessages('bot-1', 'session-1')
+    await transcript.loadInitialMessages('bot-1', 'session-1', async (applyHistory) => {
+      applyHistory()
+    })
 
     expect(transcript.loadingMessages.value).toBe(false)
     expect(transcript.hasMoreOlder.value).toBe(true)

--- a/apps/web/src/store/chat/transcript.ts
+++ b/apps/web/src/store/chat/transcript.ts
@@ -1,4 +1,4 @@
-import { reactive, ref, type Ref } from 'vue'
+import { computed, reactive, ref, type Ref } from 'vue'
 import type {
   ChatAttachment,
   FetchMessagesOptions,
@@ -21,6 +21,7 @@ import type {
 import type { RuntimeTranscriptSlice } from './runtime-projection'
 import { createTranscriptHistory } from './transcript-history'
 import { createTranscriptDecisions } from './transcript-decisions'
+import { createTranscriptQueries } from './transcript-queries'
 
 export interface TranscriptDeps {
   currentBotId: Ref<string | null>
@@ -34,6 +35,7 @@ export interface TranscriptDeps {
 
 type RefreshAppliedHook = (targetSessionId: string, latestTimestamp?: string) => void
 type CommitInitialHistory = (applyHistory: () => void) => Promise<void>
+type AfterHistoryCommit = () => void
 
 export interface LocateMessageResult {
   items: UITurn[]
@@ -55,6 +57,10 @@ export function createTranscriptController({
 }: TranscriptDeps) {
   const messages = reactive<ChatMessage[]>([])
   const loadingMessages = ref(false)
+  // Cached Session views retain raw turns so optimistic/runtime object
+  // identity survives a round trip. Mask that cache while fresh database and
+  // Runtime projections are being committed.
+  const visibleMessages = computed(() => loadingMessages.value ? [] : messages)
   const loadingOlder = ref(false)
   const hasMoreOlder = ref(true)
   const hasLoadedOlder = ref(false)
@@ -62,6 +68,7 @@ export function createTranscriptController({
   let refreshPromise: {
     key: string
     promise: Promise<void>
+    afterHistory: Set<AfterHistoryCommit>
   } | null = null
   let historyGeneration = 0
   let loadingMessagesVersion = 0
@@ -93,6 +100,7 @@ export function createTranscriptController({
     markToolApprovalDecision,
     markUserInputDecision,
   } = createTranscriptDecisions(messages)
+  const transcriptQueries = createTranscriptQueries(messages)
 
   const PAGE_SIZE = 30
 
@@ -153,6 +161,7 @@ export function createTranscriptController({
   async function refreshCurrentSession(
     targetBotId?: string,
     targetSessionId?: string,
+    afterHistory?: AfterHistoryCommit,
   ) {
     const bid = (targetBotId ?? currentBotId.value ?? '').trim()
     const sid = (targetSessionId ?? sessionId.value ?? '').trim()
@@ -162,19 +171,26 @@ export function createTranscriptController({
 
     if (refreshPromise) {
       if (refreshPromise.key === key) {
+        if (afterHistory) refreshPromise.afterHistory.add(afterHistory)
         await refreshPromise.promise
         return
       }
       await refreshPromise.promise
     }
 
+    const afterHistoryCallbacks = new Set<AfterHistoryCommit>()
+    if (afterHistory) afterHistoryCallbacks.add(afterHistory)
     const promise = (async () => {
       const turns = await fetchMessages(bid, sid, { limit: PAGE_SIZE })
+      if (!isCurrentHistoryContext(bid, sid, generation)) return
       applyFetchedHistory(bid, sid, generation, turns)
+      // Keep a replacement Runtime projection in the same synchronous commit
+      // as the refreshed anchor so Vue cannot paint the database-only state.
+      for (const apply of afterHistoryCallbacks) apply()
     })().finally(() => {
       if (refreshPromise?.promise === promise) refreshPromise = null
     })
-    refreshPromise = { key, promise }
+    refreshPromise = { key, promise, afterHistory: afterHistoryCallbacks }
     await promise
   }
 
@@ -561,57 +577,13 @@ export function createTranscriptController({
     }
   }
 
-  function latestOptimisticUserText(): string {
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      const message = messages[i]
-      if (message?.role === 'user') return message.text.trim()
-    }
-    return ''
-  }
-
-  function hasTurn(turn: ChatMessage): boolean {
-    return messages.includes(turn)
-  }
-
-  function findTurnByServerId(messageId: string): ChatMessage | null {
-    const id = messageId.trim()
-    if (!id) return null
-    return messages.find(turn => serverMessageId(turn) === id) ?? null
-  }
-
-  function latestVisibleTurn(role: 'user'): ChatUserTurn | null
-  function latestVisibleTurn(role: 'assistant'): ChatAssistantTurn | null
-  function latestVisibleTurn(role: ChatMessage['role']): ChatUserTurn | ChatAssistantTurn | null {
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-      const turn = messages[index]
-      if (
-        turn
-        && turn.role !== 'system'
-        && turn.role === role
-        && !turn.__optimistic
-      ) return turn
-    }
-    return null
-  }
-
-  function isLatestVisibleUserTurn(turn: ChatMessage): turn is ChatUserTurn {
-    if (turn.role !== 'user') return false
-    const latest = latestVisibleTurn('user')
-    return Boolean(latest && serverMessageId(latest) === serverMessageId(turn))
-  }
-
-  function isLatestVisibleAssistantTurn(turn: ChatMessage): turn is ChatAssistantTurn {
-    if (turn.role !== 'assistant') return false
-    const latest = latestVisibleTurn('assistant')
-    return Boolean(latest && serverMessageId(latest) === serverMessageId(turn))
-  }
-
   function resetUserScope() {
     clearHistoryView({ hasMoreOlder: true })
   }
 
   return {
     messages,
+    visibleMessages,
     loadingMessages,
     loadingOlder,
     hasMoreOlder,
@@ -656,11 +628,7 @@ export function createTranscriptController({
     restoreUserInputStates,
     finalizeStreamFailure,
     removeRuntimeTurn,
-    latestOptimisticUserText,
-    hasTurn,
-    findTurnByServerId,
-    isLatestVisibleUserTurn,
-    isLatestVisibleAssistantTurn,
+    ...transcriptQueries,
     markToolApprovalDecision,
     markUserInputDecision,
     resetUserScope,

--- a/apps/web/src/store/chat/transcript.ts
+++ b/apps/web/src/store/chat/transcript.ts
@@ -33,7 +33,7 @@ export interface TranscriptDeps {
 }
 
 type RefreshAppliedHook = (targetSessionId: string, latestTimestamp?: string) => void
-type AfterHistoryApply = () => void
+type CommitInitialHistory = (applyHistory: () => void) => Promise<void>
 
 export interface LocateMessageResult {
   items: UITurn[]
@@ -62,7 +62,6 @@ export function createTranscriptController({
   let refreshPromise: {
     key: string
     promise: Promise<void>
-    afterApply: AfterHistoryApply[]
   } | null = null
   let historyGeneration = 0
   let loadingMessagesVersion = 0
@@ -138,10 +137,22 @@ export function createTranscriptController({
     loadingOlder.value = false
   }
 
+  function applyFetchedHistory(botId: string, targetSessionId: string, generation: number, turns: UITurn[]) {
+    if (!isCurrentHistoryContext(botId, targetSessionId, generation)) return
+    if (hasLoadedOlder.value) {
+      mergeMessages(turns, targetSessionId)
+    } else {
+      replaceMessages(turns, targetSessionId)
+      // The API pages raw DB rows but returns merged UI turns, so a short
+      // page is not proof that history ended. Only pagination can settle it.
+      hasMoreOlder.value = true
+    }
+    onRefreshApplied(targetSessionId, messages[messages.length - 1]?.timestamp)
+  }
+
   async function refreshCurrentSession(
     targetBotId?: string,
     targetSessionId?: string,
-    afterApply?: AfterHistoryApply,
   ) {
     const bid = (targetBotId ?? currentBotId.value ?? '').trim()
     const sid = (targetSessionId ?? sessionId.value ?? '').trim()
@@ -151,46 +162,39 @@ export function createTranscriptController({
 
     if (refreshPromise) {
       if (refreshPromise.key === key) {
-        if (afterApply) refreshPromise.afterApply.push(afterApply)
         await refreshPromise.promise
         return
       }
       await refreshPromise.promise
     }
 
-    const afterApplyCallbacks = afterApply ? [afterApply] : []
     const promise = (async () => {
       const turns = await fetchMessages(bid, sid, { limit: PAGE_SIZE })
-      if (!isCurrentHistoryContext(bid, sid, generation)) return
-      if (hasLoadedOlder.value) {
-        mergeMessages(turns, sid)
-      } else {
-        replaceMessages(turns, sid)
-        // The API pages raw DB rows but returns merged UI turns, so a short
-        // page is not proof that history ended. Only pagination can settle it.
-        hasMoreOlder.value = true
-      }
-      for (const callback of afterApplyCallbacks.splice(0)) callback()
-      onRefreshApplied(sid, messages[messages.length - 1]?.timestamp)
+      applyFetchedHistory(bid, sid, generation, turns)
     })().finally(() => {
       if (refreshPromise?.promise === promise) refreshPromise = null
     })
-    refreshPromise = { key, promise, afterApply: afterApplyCallbacks }
+    refreshPromise = { key, promise }
     await promise
   }
 
   async function loadInitialMessages(
     botId: string,
     targetSessionId: string,
-    afterApply?: AfterHistoryApply,
+    commitInitialHistory: CommitInitialHistory,
   ) {
     const bid = botId.trim()
     const sid = targetSessionId.trim()
     if (!bid || !sid) return
     loadingMessages.value = true
     const version = ++loadingMessagesVersion
+    const generation = historyGeneration
     try {
-      await refreshCurrentSession(bid, sid, afterApply)
+      const turns = await fetchMessages(bid, sid, { limit: PAGE_SIZE })
+      if (!isCurrentHistoryContext(bid, sid, generation)) return
+      await commitInitialHistory(() => {
+        applyFetchedHistory(bid, sid, generation, turns)
+      })
     } finally {
       if (version === loadingMessagesVersion) loadingMessages.value = false
     }

--- a/apps/web/src/store/chat/views.ts
+++ b/apps/web/src/store/chat/views.ts
@@ -140,14 +140,14 @@ export function createChatViews(deps: ChatViewsDeps) {
   async function loadInitialMessages(
     botId: string,
     sessionId: string,
-    afterApply?: () => void,
+    commitInitialHistory: (applyHistory: () => void) => Promise<void>,
   ) {
     const view = chatViews.getOrCreate({
       botId,
       sessionId,
       viewId: focusedViewId.value,
     })
-    await view.transcript.loadInitialMessages(botId, sessionId, afterApply)
+    await view.transcript.loadInitialMessages(botId, sessionId, commitInitialHistory)
     view.initialized = true
   }
   const fetchSessionWindow = (botId: string, sessionId: string) =>

--- a/apps/web/src/store/chat/views.ts
+++ b/apps/web/src/store/chat/views.ts
@@ -117,7 +117,7 @@ export function createChatViews(deps: ChatViewsDeps) {
       ?.transcript ?? null
   }
 
-  const messages = computed(() => transcriptForTarget().messages)
+  const messages = computed(() => transcriptForTarget().visibleMessages.value)
   const loadingMessages = computed(() => transcriptForTarget().loadingMessages.value)
   const loadingOlder = computed(() => transcriptForTarget().loadingOlder.value)
   const hasMoreOlder = computed(() => transcriptForTarget().hasMoreOlder.value)
@@ -136,6 +136,17 @@ export function createChatViews(deps: ChatViewsDeps) {
     if (!resolvedBotId || !resolvedSessionId) return
     await sessionTranscript(resolvedBotId, resolvedSessionId)
       .refreshCurrentSession(resolvedBotId, resolvedSessionId)
+  }
+  async function resyncRuntimeTranscript(
+    botId: string,
+    sessionId: string,
+    runtimeTranscript: Parameters<Transcript['applyRuntimeTranscript']>[0],
+  ) {
+    const view = chatViews.getSession(botId, sessionId)
+    if (!view) return
+    await view.transcript.refreshCurrentSession(botId, sessionId, () => {
+      view.transcript.applyRuntimeTranscript(runtimeTranscript)
+    })
   }
   async function loadInitialMessages(
     botId: string,
@@ -374,6 +385,7 @@ export function createChatViews(deps: ChatViewsDeps) {
     prepareForInitialization,
     markHistoryEmpty,
     refreshCurrentSession,
+    resyncRuntimeTranscript,
     loadInitialMessages,
     fetchSessionWindow,
     loadOlderMessages,


### PR DESCRIPTION
## What

- hide a cached transcript while the selected Session is rehydrating, and commit refreshed history with its replacement Runtime projection in one update
- make session-list refreshes revision-aware, coalesce concurrent signals into one trailing refresh, and reject stale pagination or previous-Bot results
- keep ACP defaults and auth listeners inside the current user and Pinia scope

## Why

The chat UI had three variants of the same frontend consistency problem:

1. persisted history and the Session Runtime snapshot could be rendered in separate frames
2. older list or pagination responses could overwrite newer SSE mutations and navigation state
3. late user-scoped responses and listeners could survive a logout or disposed store

Together these races could briefly show an old edited turn, restore a stale title or deleted Session, expose rows from the previous Bot, or reuse ACP defaults from the previous user.

This PR fixes those frontend ownership boundaries without changing persistence, Session Runtime, or product behavior.

## Validation

- 168 focused chat, transcript, runtime, refresh, session-list, and ACP tests passed
- full ESLint passed
- UI contract guard passed
- commit hooks passed, including Go tests
- Docker Desktop dev stack healthy; real browser Session switching and reload restored the correct list and transcript with no console warnings or errors
- `git diff --check`

Fixes #931
