### PR TITLE
feat(session): persist interrupted inference checkpoints

### DIFF
--- a/db/postgres/queries/session_runs.sql
+++ b/db/postgres/queries/session_runs.sql
@@ -204,6 +204,22 @@ WHERE team_id = public.memoh_current_team_id()
   AND abort_requested_at IS NULL
 FOR UPDATE;
 
+-- name: LockSessionRunForInterruptedAgentStepCommit :one
+-- An interrupted text/reasoning snapshot is writable only after abort intent
+-- is durable and before this owner finalizes the run. It deliberately uses a
+-- separate predicate from complete-step commits so tool steps keep their
+-- existing abort race semantics.
+SELECT run_id
+FROM session_runs
+WHERE team_id = public.memoh_current_team_id()
+  AND run_id = sqlc.arg(run_id)
+  AND bot_id = sqlc.arg(bot_id)
+  AND session_id = sqlc.arg(session_id)
+  AND fencing_token = sqlc.arg(fencing_token)
+  AND state IN ('running', 'waiting_decision')
+  AND abort_requested_at IS NOT NULL
+FOR UPDATE;
+
 -- name: ListStaleGenerationSessionRuns :many
 -- Fail-closed recovery sweep. Matching on "not the current generation" rather
 -- than one specific old value means a backend lost twice in quick succession

--- a/db/postgres/queries/session_runs.sql
+++ b/db/postgres/queries/session_runs.sql
@@ -190,9 +190,8 @@ WHERE team_id = public.memoh_current_team_id()
 RETURNING *;
 
 -- name: LockSessionRunForAgentStepCommit :one
--- Linearize a complete-step commit against abort and terminal transitions.
--- RequestSessionRunAbort updates the same row, so either the step locks first
--- and commits, or the abort becomes visible here and the step is refused.
+-- Complete steps must precede abort intent; interrupted checkpoints only need
+-- the same active owner because some cancellation paths do not record intent.
 SELECT run_id
 FROM session_runs
 WHERE team_id = public.memoh_current_team_id()
@@ -201,23 +200,7 @@ WHERE team_id = public.memoh_current_team_id()
   AND session_id = sqlc.arg(session_id)
   AND fencing_token = sqlc.arg(fencing_token)
   AND state IN ('running', 'waiting_decision')
-  AND abort_requested_at IS NULL
-FOR UPDATE;
-
--- name: LockSessionRunForInterruptedAgentStepCommit :one
--- An interrupted text/reasoning snapshot is writable only after abort intent
--- is durable and before this owner finalizes the run. It deliberately uses a
--- separate predicate from complete-step commits so tool steps keep their
--- existing abort race semantics.
-SELECT run_id
-FROM session_runs
-WHERE team_id = public.memoh_current_team_id()
-  AND run_id = sqlc.arg(run_id)
-  AND bot_id = sqlc.arg(bot_id)
-  AND session_id = sqlc.arg(session_id)
-  AND fencing_token = sqlc.arg(fencing_token)
-  AND state IN ('running', 'waiting_decision')
-  AND abort_requested_at IS NOT NULL
+  AND (sqlc.arg(interrupted)::boolean OR abort_requested_at IS NULL)
 FOR UPDATE;
 
 -- name: ListStaleGenerationSessionRuns :many

--- a/internal/agent/application/service_continuation.go
+++ b/internal/agent/application/service_continuation.go
@@ -24,6 +24,7 @@ func (s *Service) prepareContinuationRunConfig(
 	if err != nil {
 		return native.RunConfig{}, err
 	}
+	loaded = projectInterruptedHistoryReasoning(loaded)
 	messages, retained, _ := trimMessagesAndRecordsByTokens(s.logger, loaded, 0)
 	messages = sanitizeMessages(messages)
 

--- a/internal/agent/application/service_history_messages.go
+++ b/internal/agent/application/service_history_messages.go
@@ -131,15 +131,7 @@ func (s *Service) loadTurnResponses(ctx context.Context, sessionID string) []tim
 		s.logger.Warn("load TRs failed", slog.String("session_id", sessionID), slog.Any("error", err))
 		return nil
 	}
-	var trs []timeline.TurnResponseEntry
-	for _, m := range msgs {
-		entry, ok := timeline.DecodeTurnResponseEntry(m)
-		if !ok {
-			continue
-		}
-		trs = append(trs, entry)
-	}
-	return trs
+	return timeline.DecodeTurnResponseEntries(msgs)
 }
 
 // stripToolMessages removes bulky tool interactions from the context while

--- a/internal/agent/application/service_history_messages_test.go
+++ b/internal/agent/application/service_history_messages_test.go
@@ -41,6 +41,30 @@ func TestProjectInterruptedHistoryReasoning(t *testing.T) {
 	}
 }
 
+func TestProjectInterruptedHistoryReasoningSkipsSupersededCheckpoint(t *testing.T) {
+	checkpoint := historyfrag.HistoryRecord{
+		ModelMessage: sdkMessagesToModelMessages([]sdk.Message{{
+			Role:    sdk.MessageRoleAssistant,
+			Content: []sdk.MessagePart{sdk.ReasoningPart{Text: "partial reasoning"}},
+		}})[0],
+		Metadata: map[string]any{messagepkg.AgentStepInterruptedMetadataKey: true},
+	}
+	answer := historyfrag.HistoryRecord{
+		ModelMessage: sdkMessagesToModelMessages([]sdk.Message{{
+			Role:    sdk.MessageRoleAssistant,
+			Content: []sdk.MessagePart{sdk.TextPart{Text: "the answer"}},
+		}})[0],
+	}
+	projected := projectInterruptedHistoryReasoning([]historyfrag.HistoryRecord{checkpoint, answer})
+	got := modelMessageToSDKMessage(projected[0].ModelMessage)
+	if len(got.Content) != 1 {
+		t.Fatalf("projected content = %#v, want the reasoning part untouched", got.Content)
+	}
+	if _, ok := got.Content[0].(sdk.ReasoningPart); !ok {
+		t.Fatalf("superseded checkpoint was projected into prompt text: %#v", got.Content[0])
+	}
+}
+
 const (
 	pipelineTestBotID     = "11111111-1111-1111-1111-111111111111"
 	pipelineTestSessionID = "22222222-2222-2222-2222-222222222222"

--- a/internal/agent/application/service_history_messages_test.go
+++ b/internal/agent/application/service_history_messages_test.go
@@ -9,14 +9,37 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	sdk "github.com/memohai/twilight-ai/sdk"
 
 	compaction "github.com/memohai/memoh/internal/agent/context/compaction"
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
+	messagepkg "github.com/memohai/memoh/internal/chat/message"
 	"github.com/memohai/memoh/internal/chat/timeline"
 	dbpkg "github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 )
+
+func TestProjectInterruptedHistoryReasoning(t *testing.T) {
+	records := []historyfrag.HistoryRecord{{
+		ModelMessage: sdkMessagesToModelMessages([]sdk.Message{{
+			Role: sdk.MessageRoleAssistant,
+			Content: []sdk.MessagePart{
+				sdk.ReasoningPart{Text: "partial reasoning"}, sdk.TextPart{Text: "partial text"},
+			},
+		}})[0],
+		Metadata: map[string]any{messagepkg.AgentStepInterruptedMetadataKey: true},
+	}}
+	got := modelMessageToSDKMessage(projectInterruptedHistoryReasoning(records)[0].ModelMessage)
+	if len(got.Content) != 1 || got.Content[0].(sdk.TextPart).Text !=
+		messagepkg.AgentStepInterruptedReasoningPrefix+"partial reasoning\n\npartial text" {
+		t.Fatalf("projected content = %#v", got.Content)
+	}
+	if len(modelMessageToSDKMessage(records[0].ModelMessage).Content) != 2 {
+		t.Fatal("input records were mutated")
+	}
+}
 
 const (
 	pipelineTestBotID     = "11111111-1111-1111-1111-111111111111"

--- a/internal/agent/application/service_history_prepare.go
+++ b/internal/agent/application/service_history_prepare.go
@@ -2,8 +2,12 @@ package application
 
 import (
 	"context"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
 
 	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
+	messagepkg "github.com/memohai/memoh/internal/chat/message"
 )
 
 type preparedHistoryContext struct {
@@ -41,6 +45,7 @@ func (s *Service) prepareHistoryContext(
 	if err != nil {
 		return preparedHistoryContext{}, err
 	}
+	loaded = projectInterruptedHistoryReasoning(loaded)
 	compactableTokens := totalCompactableHistoryTokens(loaded)
 	messages, records, estimatedTokens := trimMessagesAndRecordsByTokens(s.logger, loaded, contextTokenBudget)
 	return preparedHistoryContext{
@@ -49,4 +54,67 @@ func (s *Service) prepareHistoryContext(
 		estimatedTokens:   estimatedTokens,
 		compactableTokens: compactableTokens,
 	}, nil
+}
+
+// projectInterruptedHistoryReasoning turns only explicitly interrupted
+// reasoning into assistant text for the next model call. Durable history keeps
+// the typed reasoning part; this projection covers the non-DCP fallback and
+// providers that ignore reasoning_content in prior messages.
+func projectInterruptedHistoryReasoning(records []historyfrag.HistoryRecord) []historyfrag.HistoryRecord {
+	var projected []historyfrag.HistoryRecord
+	for i, record := range records {
+		if !strings.EqualFold(strings.TrimSpace(record.ModelMessage.Role), "assistant") ||
+			record.Metadata[messagepkg.AgentStepInterruptedMetadataKey] != true {
+			continue
+		}
+		message := modelMessageToSDKMessage(record.ModelMessage)
+		var reasoning strings.Builder
+		parts := make([]sdk.MessagePart, 0, len(message.Content))
+		for _, part := range message.Content {
+			switch p := part.(type) {
+			case sdk.ReasoningPart:
+				reasoning.WriteString(p.Text)
+			case *sdk.ReasoningPart:
+				reasoning.WriteString(p.Text)
+			default:
+				parts = append(parts, part)
+			}
+		}
+		if strings.TrimSpace(reasoning.String()) == "" {
+			continue
+		}
+		checkpoint := messagepkg.AgentStepInterruptedReasoningPrefix + reasoning.String()
+		merged := false
+		for j, part := range parts {
+			switch p := part.(type) {
+			case sdk.TextPart:
+				p.Text = checkpoint + "\n\n" + p.Text
+				parts[j], merged = p, true
+			case *sdk.TextPart:
+				clone := *p
+				clone.Text = checkpoint + "\n\n" + clone.Text
+				parts[j], merged = clone, true
+			}
+			if merged {
+				break
+			}
+		}
+		if !merged {
+			parts = append([]sdk.MessagePart{sdk.TextPart{Text: checkpoint}}, parts...)
+		}
+		message.Content = parts
+		converted := sdkMessagesToModelMessages([]sdk.Message{message})[0]
+		converted.Usage = record.ModelMessage.Usage
+		converted.ToolCalls = record.ModelMessage.ToolCalls
+		converted.ToolCallID = record.ModelMessage.ToolCallID
+		converted.Name = record.ModelMessage.Name
+		if projected == nil {
+			projected = append([]historyfrag.HistoryRecord(nil), records...)
+		}
+		projected[i].ModelMessage = converted
+	}
+	if projected != nil {
+		return projected
+	}
+	return records
 }

--- a/internal/agent/application/service_history_prepare.go
+++ b/internal/agent/application/service_history_prepare.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"strings"
 
-	sdk "github.com/memohai/twilight-ai/sdk"
-
 	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
+	"github.com/memohai/memoh/internal/chat/timeline"
 )
 
 type preparedHistoryContext struct {
@@ -56,65 +55,20 @@ func (s *Service) prepareHistoryContext(
 	}, nil
 }
 
-// projectInterruptedHistoryReasoning turns only explicitly interrupted
-// reasoning into assistant text for the next model call. Durable history keeps
-// the typed reasoning part; this projection covers the non-DCP fallback and
-// providers that ignore reasoning_content in prior messages.
+// projectInterruptedHistoryReasoning turns still-live interrupted reasoning
+// into assistant text for the next model call. Durable history keeps the typed
+// reasoning part; this projection covers the non-DCP fallback and providers that
+// ignore reasoning_content in prior messages. Checkpoints a completed answer
+// already superseded stay hidden, same as on the DCP path.
 func projectInterruptedHistoryReasoning(records []historyfrag.HistoryRecord) []historyfrag.HistoryRecord {
-	var projected []historyfrag.HistoryRecord
-	for i, record := range records {
-		if !strings.EqualFold(strings.TrimSpace(record.ModelMessage.Role), "assistant") ||
-			record.Metadata[messagepkg.AgentStepInterruptedMetadataKey] != true {
-			continue
-		}
-		message := modelMessageToSDKMessage(record.ModelMessage)
-		var reasoning strings.Builder
-		parts := make([]sdk.MessagePart, 0, len(message.Content))
-		for _, part := range message.Content {
-			switch p := part.(type) {
-			case sdk.ReasoningPart:
-				reasoning.WriteString(p.Text)
-			case *sdk.ReasoningPart:
-				reasoning.WriteString(p.Text)
-			default:
-				parts = append(parts, part)
-			}
-		}
-		if strings.TrimSpace(reasoning.String()) == "" {
-			continue
-		}
-		checkpoint := messagepkg.AgentStepInterruptedReasoningPrefix + reasoning.String()
-		merged := false
-		for j, part := range parts {
-			switch p := part.(type) {
-			case sdk.TextPart:
-				p.Text = checkpoint + "\n\n" + p.Text
-				parts[j], merged = p, true
-			case *sdk.TextPart:
-				clone := *p
-				clone.Text = checkpoint + "\n\n" + clone.Text
-				parts[j], merged = clone, true
-			}
-			if merged {
-				break
-			}
-		}
-		if !merged {
-			parts = append([]sdk.MessagePart{sdk.TextPart{Text: checkpoint}}, parts...)
-		}
-		message.Content = parts
-		converted := sdkMessagesToModelMessages([]sdk.Message{message})[0]
-		converted.Usage = record.ModelMessage.Usage
-		converted.ToolCalls = record.ModelMessage.ToolCalls
-		converted.ToolCallID = record.ModelMessage.ToolCallID
-		converted.Name = record.ModelMessage.Name
-		if projected == nil {
-			projected = append([]historyfrag.HistoryRecord(nil), records...)
-		}
-		projected[i].ModelMessage = converted
+	checkpoint := messagepkg.LatestInterruptedCheckpoint(len(records), func(i int) (bool, bool) {
+		return strings.EqualFold(strings.TrimSpace(records[i].ModelMessage.Role), "assistant"),
+			records[i].Metadata[messagepkg.AgentStepInterruptedMetadataKey] == true
+	})
+	if checkpoint < 0 {
+		return records
 	}
-	if projected != nil {
-		return projected
-	}
-	return records
+	projected := append([]historyfrag.HistoryRecord(nil), records...)
+	projected[checkpoint].ModelMessage = timeline.ProjectInterruptedReasoning(records[checkpoint].ModelMessage)
+	return projected
 }

--- a/internal/agent/application/service_stream.go
+++ b/internal/agent/application/service_stream.go
@@ -156,6 +156,7 @@ func (s *Service) StreamChat(ctx context.Context, req ChatRequest) (<-chan Strea
 		stepCommitter := s.newAgentStepCommitter(streamCtx, streamReq, rc)
 		if stepCommitter != nil {
 			cfg.OnStepCommitted = stepCommitter.commit
+			cfg.OnStepInterrupted = stepCommitter.interrupt
 		}
 		cfg = s.prepareRunConfig(streamCtx, cfg)
 
@@ -394,6 +395,7 @@ func (s *Service) streamChatWSResultWithHooks(
 	stepCommitter := s.newAgentStepCommitter(streamCtx, req, rc)
 	if stepCommitter != nil {
 		cfg.OnStepCommitted = stepCommitter.commit
+		cfg.OnStepInterrupted = stepCommitter.interrupt
 	}
 	cfg = s.prepareRunConfig(streamCtx, cfg)
 

--- a/internal/agent/application/step_commit.go
+++ b/internal/agent/application/step_commit.go
@@ -75,10 +75,17 @@ func (c *agentStepCommitter) persist(ctx context.Context, stepIndex int, step *s
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if stepIndex != c.nextStep {
-		err := fmt.Errorf("unexpected agent step %d, want %d", stepIndex, c.nextStep)
-		c.commitErr = err
+	// A failed interrupted checkpoint is reported to its caller but never
+	// recorded as a commit failure: the turn is already ending, and losing an
+	// unfinished snapshot must not turn an abort into a turn error.
+	fail := func(err error) error {
+		if !interrupted {
+			c.commitErr = err
+		}
 		return err
+	}
+	if stepIndex != c.nextStep {
+		return fail(fmt.Errorf("unexpected agent step %d, want %d", stepIndex, c.nextStep))
 	}
 	if !hasPersistableAssistantOutput(messages) {
 		c.nextStep++
@@ -102,8 +109,7 @@ func (c *agentStepCommitter) persist(ctx context.Context, stepIndex int, step *s
 	}
 	inputs, err := c.service.buildPersistInputs(context.WithoutCancel(ctx), storeReq, messages, c.rc.model.ID, opts)
 	if err != nil {
-		c.commitErr = err
-		return err
+		return fail(err)
 	}
 	for i := range inputs {
 		inputs[i].TurnRequestMessageID = c.turnRequestMessageID
@@ -112,8 +118,7 @@ func (c *agentStepCommitter) persist(ctx context.Context, stepIndex int, step *s
 		RunID: c.req.RunID, Messages: inputs, Interrupted: interrupted,
 	})
 	if err != nil {
-		c.commitErr = err
-		return err
+		return fail(err)
 	}
 	c.nextStep++
 	for _, message := range persisted {

--- a/internal/agent/application/step_commit.go
+++ b/internal/agent/application/step_commit.go
@@ -60,8 +60,16 @@ func (s *Service) newAgentStepCommitter(ctx context.Context, req ChatRequest, rc
 }
 
 func (c *agentStepCommitter) commit(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
+	return c.persist(ctx, stepIndex, step, false)
+}
+
+func (c *agentStepCommitter) interrupt(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
+	return c.persist(ctx, stepIndex, step, true)
+}
+
+func (c *agentStepCommitter) persist(ctx context.Context, stepIndex int, step *sdk.StepResult, interrupted bool) error {
 	if c == nil || step == nil {
-		return errors.New("complete agent step is missing")
+		return errors.New("agent step is missing")
 	}
 	messages := sdkMessagesToModelMessages(step.Messages)
 
@@ -83,9 +91,16 @@ func (c *agentStepCommitter) commit(ctx context.Context, stepIndex int, step *sd
 	// Outbound assets are linked once after the stream closes; including the
 	// collector in every step would attach the same accumulated assets again.
 	storeReq.OutboundAssetCollector = nil
-	inputs, err := c.service.buildPersistInputs(context.WithoutCancel(ctx), storeReq, messages, c.rc.model.ID, storeRoundOptions{
-		AllowPendingToolCalls: step.DeferredToolApproval != nil,
-	})
+	opts := storeRoundOptions{AllowPendingToolCalls: step.DeferredToolApproval != nil}
+	if interrupted {
+		opts.MessageMetadataByIndex = make(map[int]map[string]any)
+		for i, message := range messages {
+			if strings.EqualFold(strings.TrimSpace(message.Role), "assistant") {
+				opts.MessageMetadataByIndex[i] = map[string]any{messagepkg.AgentStepInterruptedMetadataKey: true}
+			}
+		}
+	}
+	inputs, err := c.service.buildPersistInputs(context.WithoutCancel(ctx), storeReq, messages, c.rc.model.ID, opts)
 	if err != nil {
 		c.commitErr = err
 		return err
@@ -94,7 +109,7 @@ func (c *agentStepCommitter) commit(ctx context.Context, stepIndex int, step *sd
 		inputs[i].TurnRequestMessageID = c.turnRequestMessageID
 	}
 	persisted, err := c.persister.PersistAgentStep(context.WithoutCancel(ctx), messagepkg.AgentStep{
-		RunID: c.req.RunID, Messages: inputs,
+		RunID: c.req.RunID, Messages: inputs, Interrupted: interrupted,
 	})
 	if err != nil {
 		c.commitErr = err
@@ -107,7 +122,11 @@ func (c *agentStepCommitter) commit(ctx context.Context, stepIndex int, step *sd
 		}
 	}
 	c.persisted = append(c.persisted, persisted...)
-	c.messages = append(c.messages, messages...)
+	if !interrupted {
+		// Unfinished reasoning/text is history context, not a fact source for
+		// asynchronous long-term memory extraction.
+		c.messages = append(c.messages, messages...)
+	}
 	return nil
 }
 

--- a/internal/agent/application/step_commit_test.go
+++ b/internal/agent/application/step_commit_test.go
@@ -42,10 +42,20 @@ func TestAgentStepCommitterPersistsOnlyStepDelta(t *testing.T) {
 			t.Fatalf("commit step %d: %v", i, err)
 		}
 	}
-	if len(store.steps) != 2 || len(store.steps[0].Messages) != 2 || len(store.steps[1].Messages) != 1 {
-		t.Fatalf("step message counts = %#v, want [user+assistant, assistant]", store.steps)
+	partial := sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.ReasoningPart{Text: "partial reasoning"}}}
+	if err := committer.interrupt(ctx, 2, &sdk.StepResult{Messages: []sdk.Message{partial}}); err != nil {
+		t.Fatalf("persist interrupted step: %v", err)
+	}
+	if len(store.steps) != 3 || len(store.steps[0].Messages) != 2 || len(store.steps[1].Messages) != 1 || !store.steps[2].Interrupted {
+		t.Fatalf("persisted steps = %#v, want two complete plus one interrupted", store.steps)
+	}
+	if store.steps[2].Messages[0].Metadata[messagepkg.AgentStepInterruptedMetadataKey] != true {
+		t.Fatalf("interrupted metadata = %#v", store.steps[2].Messages[0].Metadata)
 	}
 	if got := store.steps[1].Messages[0].TurnRequestMessageID; got != "committed" {
 		t.Fatalf("second step request message = %q, want first committed user", got)
+	}
+	if len(committer.messages) != 3 {
+		t.Fatalf("memory messages = %d, want interrupted output excluded", len(committer.messages))
 	}
 }

--- a/internal/agent/application/turn_service.go
+++ b/internal/agent/application/turn_service.go
@@ -244,14 +244,23 @@ func (h *runHandle) pump(cmd turn.StartTurnCommand, chunkCh <-chan StreamChunk, 
 	}()
 
 	var seq int64
+	clientGone := false
+	ctxDone := h.ctx.Done()
 	for chunkCh != nil || errCh != nil {
 		select {
+		case <-ctxDone:
+			h.failed.Store(true)
+			clientGone = true
+			ctxDone = nil
 		case chunk, ok := <-chunkCh:
 			if !ok {
 				chunkCh = nil
 				continue
 			}
 			seq++
+			if clientGone {
+				continue
+			}
 			select {
 			case h.events <- turn.Event{
 				RunID:    h.id,
@@ -263,7 +272,8 @@ func (h *runHandle) pump(cmd turn.StartTurnCommand, chunkCh <-chan StreamChunk, 
 			}:
 			case <-h.ctx.Done():
 				h.failed.Store(true)
-				return
+				clientGone = true
+				ctxDone = nil
 			}
 		case err, ok := <-errCh:
 			if !ok {
@@ -275,10 +285,13 @@ func (h *runHandle) pump(cmd turn.StartTurnCommand, chunkCh <-chan StreamChunk, 
 				if h.streamErr == nil {
 					h.streamErr = err
 				}
-				select {
-				case h.errs <- err:
-				case <-h.ctx.Done():
-					return
+				if !clientGone {
+					select {
+					case h.errs <- err:
+					case <-h.ctx.Done():
+						clientGone = true
+						ctxDone = nil
+					}
 				}
 			}
 		}

--- a/internal/agent/application/turn_service_test.go
+++ b/internal/agent/application/turn_service_test.go
@@ -25,6 +25,12 @@ type testChatStreamer interface {
 	StreamChat(context.Context, ChatRequest) (<-chan StreamChunk, <-chan error)
 }
 
+type testChatStreamerFunc func(context.Context, ChatRequest) (<-chan StreamChunk, <-chan error)
+
+func (f testChatStreamerFunc) StreamChat(ctx context.Context, req ChatRequest) (<-chan StreamChunk, <-chan error) {
+	return f(ctx, req)
+}
+
 // scriptedAdmitter stands in for the session runtime so these tests can exercise
 // what this package owns: the translation of an admission answer into the turn
 // port's vocabulary, and the terminal write a finished run must produce. The
@@ -263,6 +269,40 @@ func TestCancelClosesEvents(t *testing.T) {
 		case <-deadline:
 			t.Fatal("events channel not closed after cancel")
 		}
+	}
+}
+
+func TestCancelWaitsForStreamCleanupBeforeFinalizingRun(t *testing.T) {
+	cancelObserved, release := make(chan struct{}), make(chan struct{})
+	streamer := testChatStreamerFunc(func(ctx context.Context, _ ChatRequest) (<-chan StreamChunk, <-chan error) {
+		chunks, errs := make(chan StreamChunk), make(chan error)
+		go func() {
+			<-ctx.Done()
+			close(cancelObserved)
+			<-release
+			close(chunks)
+			close(errs)
+		}()
+		return chunks, errs
+	})
+	service, admitter := newAdmittedTurnTestService(streamer)
+	h, err := service.StartTurn(context.Background(), turn.StartTurnCommand{TeamID: "t", Mode: turn.ModeChat})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.Cancel()
+	<-cancelObserved
+	admitter.mu.Lock()
+	finishedEarly := len(admitter.finishes) != 0
+	admitter.mu.Unlock()
+	if finishedEarly {
+		t.Fatal("run finalized before interrupted-step persistence could finish")
+	}
+	close(release)
+	for range h.Events() {
+	}
+	if got := admitter.awaitFinish(t).status; got != sessionruntime.RunStatusAborted {
+		t.Fatalf("finish status = %q, want aborted", got)
 	}
 }
 

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -286,10 +287,15 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 		modelStepIndex++
 		return nil
 	}))
+	var nextDurableStep atomic.Int64
 	var onStepCommitted func(context.Context, int, *sdk.StepResult) error
 	if cfg.OnStepCommitted != nil {
 		onStepCommitted = func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
-			return cfg.OnStepCommitted(ctx, stepIndex, committedStepMessages.decorate(stepIndex, step, toolExecutionMetadata))
+			if err := cfg.OnStepCommitted(ctx, stepIndex, committedStepMessages.decorate(stepIndex, step, toolExecutionMetadata)); err != nil {
+				return err
+			}
+			nextDurableStep.Store(int64(stepIndex + 1))
+			return nil
 		}
 		opts = append(opts, sdk.WithOnStepCommitted(onStepCommitted))
 	}
@@ -342,6 +348,8 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 	sendEvent(ctx, ch, StreamEvent{Type: EventAgentStart})
 
 	var allText strings.Builder
+	var interruptedStep interruptedStepCapture
+	var interruptedMessages []sdk.Message
 	stepNumber := 0
 
 	streamClosed := false
@@ -358,6 +366,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 			}
 			part = next
 		}
+		interruptedStep.observe(part)
 
 		switch p := part.(type) {
 		case *sdk.StartPart:
@@ -570,6 +579,23 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 			break
 		}
 	}
+	if ctx.Err() != nil {
+		aborted = true
+	}
+
+	// Only external cancellation can represent a user/session abort. Provider
+	// errors and loop guards keep their existing failure semantics.
+	if aborted && ctx.Err() != nil && cfg.OnStepInterrupted != nil {
+		if step := interruptedStep.snapshot(); step != nil {
+			stepIndex := int(nextDurableStep.Load())
+			step = committedStepMessages.decorate(stepIndex, step, toolExecutionMetadata)
+			if err := cfg.OnStepInterrupted(context.WithoutCancel(streamCtx), stepIndex, step); err != nil {
+				a.logger.Error("persist interrupted model step failed", slog.Any("error", err))
+			} else {
+				interruptedMessages = step.Messages
+			}
+		}
+	}
 
 	if aborted && !streamClosed {
 		// A provider is expected to close its stream when the context is
@@ -608,6 +634,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 			totalUsage.OutputTokenDetails.ReasoningTokens += step.Usage.OutputTokenDetails.ReasoningTokens
 		}
 	}
+	finalMessages = append(finalMessages, interruptedMessages...)
 	usageJSON, _ := json.Marshal(totalUsage)
 
 	termEvent := StreamEvent{

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -287,14 +286,14 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 		modelStepIndex++
 		return nil
 	}))
-	var nextDurableStep atomic.Int64
+	var nextDurableStep int
 	var onStepCommitted func(context.Context, int, *sdk.StepResult) error
 	if cfg.OnStepCommitted != nil {
 		onStepCommitted = func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
 			if err := cfg.OnStepCommitted(ctx, stepIndex, committedStepMessages.decorate(stepIndex, step, toolExecutionMetadata)); err != nil {
 				return err
 			}
-			nextDurableStep.Store(int64(stepIndex + 1))
+			nextDurableStep = stepIndex + 1
 			return nil
 		}
 		opts = append(opts, sdk.WithOnStepCommitted(onStepCommitted))
@@ -559,7 +558,8 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 				streamResult, aborted = a.runMidStreamRetry(
 					ctx, streamCtx, cancel, toolLoopAbortCallIDs,
 					ch, cfg, sdkTools, approvalTools, prepareStep, streamResult,
-					committedStepMessages, onStepCommitted, stepNumber, errMsg, &allText, textLoopProbeBuffer,
+					committedStepMessages, onStepCommitted, &interruptedStep,
+					stepNumber, errMsg, &allText, textLoopProbeBuffer,
 				)
 				if !aborted {
 					turnError = ""
@@ -583,27 +583,37 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 		aborted = true
 	}
 
-	// Only external cancellation can represent a user/session abort. Provider
-	// errors and loop guards keep their existing failure semantics.
-	if aborted && ctx.Err() != nil && cfg.OnStepInterrupted != nil {
-		if step := interruptedStep.snapshot(); step != nil {
-			stepIndex := int(nextDurableStep.Load())
-			step = committedStepMessages.decorate(stepIndex, step, toolExecutionMetadata)
-			if err := cfg.OnStepInterrupted(context.WithoutCancel(streamCtx), stepIndex, step); err != nil {
-				a.logger.Error("persist interrupted model step failed", slog.Any("error", err))
-			} else {
-				interruptedMessages = step.Messages
-			}
-		}
-	}
-
 	if aborted && !streamClosed {
 		// A provider is expected to close its stream when the context is
 		// cancelled, but run termination must not depend on that cooperation.
 		// Preserve the final snapshot when it arrives promptly, then stop
 		// waiting so the caller can fence and finalize the run as aborted.
 		cancel(context.Canceled)
-		streamClosed = drainStreamUntilClosed(streamResult.Stream, streamCancelDrainGrace)
+		streamClosed = drainStreamUntilClosed(streamResult.Stream, streamCancelDrainGrace, interruptedStep.observe)
+	}
+
+	// Only external cancellation can represent a user/session abort. Provider
+	// errors and loop guards keep their existing failure semantics.
+	//
+	// A closed stream is what makes this write safe, so it is required rather
+	// than merely convenient. It means the SDK's step goroutine has returned:
+	// no further complete step can commit after this checkpoint, and the
+	// prepared-message capture read below is published by that goroutine's exit
+	// instead of racing its next PrepareStep. When a provider refuses to close
+	// within the drain grace, the checkpoint is dropped rather than risk
+	// duplicating an answer the SDK is still about to commit.
+	if aborted && streamClosed && ctx.Err() != nil && cfg.OnStepInterrupted != nil {
+		stepIndex := nextDurableStep
+		if step := interruptedStep.snapshot(stepIndex); step != nil {
+			step = committedStepMessages.decorate(stepIndex, step, toolExecutionMetadata)
+			if err := cfg.OnStepInterrupted(context.WithoutCancel(streamCtx), stepIndex, step); err != nil {
+				// An owner that lost its lease, or a run another writer already
+				// finalized, is an expected outcome of racing an abort.
+				a.logger.Warn("persist interrupted model step failed", slog.Any("error", err))
+			} else {
+				interruptedMessages = step.Messages
+			}
+		}
 	}
 
 	if textLoopProbeBuffer != nil {
@@ -680,7 +690,12 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 	sendEvent(deliveryCtx, ch, termEvent)
 }
 
-func drainStreamUntilClosed(stream <-chan sdk.StreamPart, grace time.Duration) bool {
+// drainStreamUntilClosed consumes what the provider still has buffered after
+// cancellation. observe sees those parts too: a finish-step or tool call left in
+// the buffer is state this run reached, so an interrupted checkpoint must be
+// judged against it rather than against the prefix the event loop happened to
+// read before the abort.
+func drainStreamUntilClosed(stream <-chan sdk.StreamPart, grace time.Duration, observe func(sdk.StreamPart)) bool {
 	if stream == nil {
 		return true
 	}
@@ -688,9 +703,12 @@ func drainStreamUntilClosed(stream <-chan sdk.StreamPart, grace time.Duration) b
 	defer timer.Stop()
 	for {
 		select {
-		case _, ok := <-stream:
+		case part, ok := <-stream:
 			if !ok {
 				return true
+			}
+			if observe != nil {
+				observe(part)
 			}
 		case <-timer.C:
 			return false
@@ -1331,6 +1349,7 @@ func (a *Agent) runMidStreamRetry(
 	prevResult *sdk.StreamResult,
 	committedStepMessages *stepMessageCapture,
 	onStepCommitted func(context.Context, int, *sdk.StepResult) error,
+	interruptedStep *interruptedStepCapture,
 	stepNumber int,
 	errMsg string,
 	allText *strings.Builder,
@@ -1343,6 +1362,10 @@ func (a *Agent) runMidStreamRetry(
 		}
 	}
 	stepOffset := len(prevResult.Steps)
+	// The failed attempt's partial output is regenerated from the last
+	// committed boundary, so it must not survive as a checkpoint. Retried
+	// steps are numbered from the offset the commit barrier already uses.
+	interruptedStep.rebase(stepOffset)
 
 	retryCfg := DefaultRetryConfig()
 	for attempt := 0; attempt < retryCfg.MaxAttempts; attempt++ {
@@ -1399,6 +1422,7 @@ func (a *Agent) runMidStreamRetry(
 				aborted = true
 				break
 			}
+			interruptedStep.observe(retryPart)
 			switch rp := retryPart.(type) {
 			case *sdk.TextStartPart:
 				if !sendEvent(sendCtx, ch, StreamEvent{Type: EventTextStart}) {
@@ -1503,7 +1527,8 @@ func (a *Agent) runMidStreamRetry(
 			}
 		}
 		if aborted {
-			for range retryResult.Stream {
+			for retryPart := range retryResult.Stream {
+				interruptedStep.observe(retryPart)
 			}
 		}
 		// Merge prev messages into retryResult so the caller sees the full

--- a/internal/agent/runtime/native/generate_loop_test.go
+++ b/internal/agent/runtime/native/generate_loop_test.go
@@ -431,6 +431,7 @@ func TestRunMidStreamRetryMarksTextLoopCancellationAsAborted(t *testing.T) {
 		&sdk.StreamResult{Messages: []sdk.Message{sdk.UserMessage("previous step")}},
 		&stepMessageCapture{},
 		nil,
+		&interruptedStepCapture{},
 		0,
 		"api error 500",
 		&strings.Builder{},

--- a/internal/agent/runtime/native/interrupted_step.go
+++ b/internal/agent/runtime/native/interrupted_step.go
@@ -1,0 +1,78 @@
+package native
+
+import (
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// interruptedStepCapture retains only the current model call's text and
+// reasoning. Tool activity and finish-step both disqualify the snapshot: those
+// paths keep using Twilight's complete-step barrier.
+type interruptedStepCapture struct {
+	text, reasoning strings.Builder
+	reasoningMeta   map[string]any
+	toolActivity    bool
+	finished        bool
+}
+
+func (c *interruptedStepCapture) reset() {
+	c.text.Reset()
+	c.reasoning.Reset()
+	c.reasoningMeta = nil
+	c.toolActivity = false
+	c.finished = false
+}
+
+func (c *interruptedStepCapture) reopenIfFinished() {
+	if c.finished {
+		c.reset()
+	}
+}
+
+func (c *interruptedStepCapture) observe(part sdk.StreamPart) {
+	switch p := part.(type) {
+	case *sdk.StartStepPart:
+		c.reset()
+	case *sdk.TextStartPart, *sdk.ReasoningStartPart:
+		c.reopenIfFinished()
+	case *sdk.TextDeltaPart:
+		c.reopenIfFinished()
+		c.text.WriteString(p.Text)
+	case *sdk.ReasoningDeltaPart:
+		c.reopenIfFinished()
+		c.reasoning.WriteString(p.Text)
+		if p.ProviderMetadata != nil {
+			c.reasoningMeta = p.ProviderMetadata
+		}
+	case *sdk.ReasoningEndPart:
+		if p.ProviderMetadata != nil {
+			c.reasoningMeta = p.ProviderMetadata
+		}
+	case *sdk.ToolInputStartPart, *sdk.ToolInputDeltaPart, *sdk.ToolInputEndPart,
+		*sdk.StreamToolCallPart, *sdk.StreamToolResultPart, *sdk.StreamToolErrorPart,
+		*sdk.ToolOutputDeniedPart, *sdk.ToolApprovalRequestPart, *sdk.ToolProgressPart:
+		c.toolActivity = true
+	case *sdk.FinishStepPart:
+		c.finished = true
+	}
+}
+
+func (c *interruptedStepCapture) snapshot() *sdk.StepResult {
+	text, reasoning := c.text.String(), c.reasoning.String()
+	if c.finished || c.toolActivity ||
+		(strings.TrimSpace(text) == "" && strings.TrimSpace(reasoning) == "") {
+		return nil
+	}
+	parts := make([]sdk.MessagePart, 0, 2)
+	if reasoning != "" {
+		parts = append(parts, sdk.ReasoningPart{Text: reasoning, ProviderMetadata: c.reasoningMeta})
+	}
+	if text != "" {
+		parts = append(parts, sdk.TextPart{Text: text})
+	}
+	return &sdk.StepResult{
+		Text: text, Reasoning: reasoning,
+		Messages: []sdk.Message{{Role: sdk.MessageRoleAssistant, Content: parts}},
+	}
+}

--- a/internal/agent/runtime/native/interrupted_step.go
+++ b/internal/agent/runtime/native/interrupted_step.go
@@ -7,16 +7,18 @@ import (
 )
 
 // interruptedStepCapture retains only the current model call's text and
-// reasoning. Tool activity and finish-step both disqualify the snapshot: those
-// paths keep using Twilight's complete-step barrier.
+// reasoning. Tool activity stays on Twilight's complete-step path. stepIndex
+// distinguishes an unfinished frontier from a step already committed while its
+// finish event was still buffered for this consumer.
 type interruptedStepCapture struct {
 	text, reasoning strings.Builder
 	reasoningMeta   map[string]any
 	toolActivity    bool
 	finished        bool
+	stepIndex       int
 }
 
-func (c *interruptedStepCapture) reset() {
+func (c *interruptedStepCapture) resetContent() {
 	c.text.Reset()
 	c.reasoning.Reset()
 	c.reasoningMeta = nil
@@ -24,16 +26,35 @@ func (c *interruptedStepCapture) reset() {
 	c.finished = false
 }
 
+// rebase restarts capture at an absolute step index. A mid-stream retry
+// abandons the failed attempt's partial output — the model regenerates it from
+// the last committed boundary — so that content must not survive as a
+// checkpoint.
+func (c *interruptedStepCapture) rebase(stepIndex int) {
+	c.resetContent()
+	c.stepIndex = stepIndex
+}
+
+// advance opens the capture window for whichever step is starting. Only a step
+// that already finished moves the index: the first step of a stream starts at
+// the index rebase left behind.
+func (c *interruptedStepCapture) advance() {
+	if c.finished {
+		c.stepIndex++
+	}
+	c.resetContent()
+}
+
 func (c *interruptedStepCapture) reopenIfFinished() {
 	if c.finished {
-		c.reset()
+		c.advance()
 	}
 }
 
 func (c *interruptedStepCapture) observe(part sdk.StreamPart) {
 	switch p := part.(type) {
 	case *sdk.StartStepPart:
-		c.reset()
+		c.advance()
 	case *sdk.TextStartPart, *sdk.ReasoningStartPart:
 		c.reopenIfFinished()
 	case *sdk.TextDeltaPart:
@@ -58,9 +79,12 @@ func (c *interruptedStepCapture) observe(part sdk.StreamPart) {
 	}
 }
 
-func (c *interruptedStepCapture) snapshot() *sdk.StepResult {
+// snapshot returns retained output only at the uncommitted frontier. A finished
+// step is still eligible when its complete commit lost the abort race; a
+// successful complete commit advances nextDurableStep and rejects it here.
+func (c *interruptedStepCapture) snapshot(nextDurableStep int) *sdk.StepResult {
 	text, reasoning := c.text.String(), c.reasoning.String()
-	if c.finished || c.toolActivity ||
+	if c.toolActivity || c.stepIndex != nextDurableStep ||
 		(strings.TrimSpace(text) == "" && strings.TrimSpace(reasoning) == "") {
 		return nil
 	}

--- a/internal/agent/runtime/native/interrupted_step_test.go
+++ b/internal/agent/runtime/native/interrupted_step_test.go
@@ -1,0 +1,87 @@
+package native
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	agenttools "github.com/memohai/memoh/internal/agent/tool"
+)
+
+// agentStepBoundaryToolProvider exposes one trivially executable tool so the SDK
+// advances past step 0 and runs PrepareStep for the next step.
+type agentStepBoundaryToolProvider struct{}
+
+func (*agentStepBoundaryToolProvider) Tools(context.Context, agenttools.SessionContext) ([]sdk.Tool, error) {
+	return []sdk.Tool{{
+		Name:        "probe",
+		Description: "probe",
+		Execute:     func(*sdk.ToolExecContext, any) (any, error) { return "ok", nil },
+	}}, nil
+}
+
+// TestAgentStreamCheckpointWaitsForStepGoroutineToExit covers the case where the
+// SDK has run a whole step ahead of the event loop through the stream's buffer.
+// Only the loop's own prefix looks unfinished; the run has in fact committed
+// step 0 and is preparing step 1. Checkpointing that prefix would duplicate a
+// durable answer, and reading the prepared-message capture while PrepareStep is
+// still writing it is a data race — so this test is meaningful under -race.
+func TestAgentStreamCheckpointWaitsForStepGoroutineToExit(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	injectCh := make(chan InjectMessage, 1)
+	injectCh <- InjectMessage{Text: "steering", HeaderifiedText: "steering"}
+
+	agent := New(Deps{})
+	agent.SetToolProviders([]agenttools.ToolProvider{&agentStepBoundaryToolProvider{}})
+	var calls atomic.Int32
+	provider := agentStreamTestProvider(func(ctx context.Context, _ sdk.GenerateParams) (*sdk.StreamResult, error) {
+		if calls.Add(1) == 1 {
+			return closedAgentTestStream(
+				&sdk.StartStepPart{},
+				&sdk.TextDeltaPart{ID: "text", Text: "working"},
+				&sdk.StreamToolCallPart{ToolCallID: "call-1", ToolName: "probe", Input: map[string]any{}},
+				&sdk.FinishStepPart{FinishReason: sdk.FinishReasonToolCalls},
+			), nil
+		}
+		ch := make(chan sdk.StreamPart)
+		go func() { <-ctx.Done(); close(ch) }()
+		return &sdk.StreamResult{Stream: ch}, nil
+	})
+
+	interrupted := make(chan *sdk.StepResult, 4)
+	events := agent.Stream(ctx, RunConfig{
+		Model:            &sdk.Model{ID: "mock-model", Provider: provider},
+		Messages:         []sdk.Message{sdk.UserMessage("hi")},
+		Identity:         SessionContext{BotID: "bot-1"},
+		SupportsToolCall: true,
+		InjectCh:         injectCh,
+		OnStepCommitted:  func(context.Context, int, *sdk.StepResult) error { return nil },
+		OnStepInterrupted: func(_ context.Context, _ int, step *sdk.StepResult) error {
+			interrupted <- step
+			return nil
+		},
+	})
+
+	if first, ok := <-events; !ok || first.Type != EventAgentStart {
+		t.Fatalf("first event = %#v", first)
+	}
+	// Deliberately not synchronized with the SDK goroutine: a signal from it
+	// would order the two sides and hide exactly the race under test.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	for range events {
+	}
+
+	select {
+	case step := <-interrupted:
+		t.Fatalf("checkpointed a committed step: text=%q messages=%d", step.Text, len(step.Messages))
+	default:
+	}
+}

--- a/internal/agent/runtime/native/stream_test.go
+++ b/internal/agent/runtime/native/stream_test.go
@@ -3,6 +3,7 @@ package native
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -10,97 +11,46 @@ import (
 	sdk "github.com/memohai/twilight-ai/sdk"
 )
 
-type agentToolPlaceholderProvider struct{}
+type agentStreamTestProvider func(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error)
 
-func (*agentToolPlaceholderProvider) Name() string { return "tool-placeholder-mock" }
-
-func (*agentToolPlaceholderProvider) ListModels(context.Context) ([]sdk.Model, error) {
+func (agentStreamTestProvider) Name() string { return "stream-mock" }
+func (agentStreamTestProvider) ListModels(context.Context) ([]sdk.Model, error) {
 	return nil, nil
 }
 
-type agentNonClosingStreamProvider struct{}
-
-type agentInterruptedStreamProvider struct{}
-
-func (*agentNonClosingStreamProvider) Name() string { return "non-closing-stream-mock" }
-
-func (*agentNonClosingStreamProvider) ListModels(context.Context) ([]sdk.Model, error) {
-	return nil, nil
-}
-
-func (*agentNonClosingStreamProvider) Test(context.Context) *sdk.ProviderTestResult {
+func (agentStreamTestProvider) Test(context.Context) *sdk.ProviderTestResult {
 	return &sdk.ProviderTestResult{Status: sdk.ProviderStatusOK, Message: "ok"}
 }
 
-func (*agentNonClosingStreamProvider) TestModel(context.Context, string) (*sdk.ModelTestResult, error) {
+func (agentStreamTestProvider) TestModel(context.Context, string) (*sdk.ModelTestResult, error) {
 	return &sdk.ModelTestResult{Supported: true, Message: "supported"}, nil
 }
 
-func (*agentNonClosingStreamProvider) DoGenerate(context.Context, sdk.GenerateParams) (*sdk.GenerateResult, error) {
+func (agentStreamTestProvider) DoGenerate(context.Context, sdk.GenerateParams) (*sdk.GenerateResult, error) {
 	return &sdk.GenerateResult{FinishReason: sdk.FinishReasonStop}, nil
 }
 
-func (*agentNonClosingStreamProvider) DoStream(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {
-	return &sdk.StreamResult{Stream: make(chan sdk.StreamPart)}, nil
+func (p agentStreamTestProvider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sdk.StreamResult, error) {
+	return p(ctx, params)
 }
 
-func (*agentInterruptedStreamProvider) Name() string { return "interrupted-stream-mock" }
-func (*agentInterruptedStreamProvider) ListModels(context.Context) ([]sdk.Model, error) {
-	return nil, nil
+func closedAgentTestStream(parts ...sdk.StreamPart) *sdk.StreamResult {
+	ch := make(chan sdk.StreamPart, len(parts))
+	for _, part := range parts {
+		ch <- part
+	}
+	close(ch)
+	return &sdk.StreamResult{Stream: ch}
 }
 
-func (*agentInterruptedStreamProvider) Test(context.Context) *sdk.ProviderTestResult {
-	return &sdk.ProviderTestResult{Status: sdk.ProviderStatusOK, Message: "ok"}
-}
-
-func (*agentInterruptedStreamProvider) TestModel(context.Context, string) (*sdk.ModelTestResult, error) {
-	return &sdk.ModelTestResult{Supported: true}, nil
-}
-
-func (*agentInterruptedStreamProvider) DoGenerate(context.Context, sdk.GenerateParams) (*sdk.GenerateResult, error) {
-	return &sdk.GenerateResult{}, nil
-}
-
-func (*agentInterruptedStreamProvider) DoStream(ctx context.Context, _ sdk.GenerateParams) (*sdk.StreamResult, error) {
-	ch := make(chan sdk.StreamPart, 4)
-	ch <- &sdk.StartStepPart{}
-	ch <- &sdk.ReasoningDeltaPart{ID: "reasoning", Text: "thinking"}
-	ch <- &sdk.TextDeltaPart{ID: "text", Text: "partial"}
-	go func() {
-		<-ctx.Done()
-		close(ch)
-	}()
-	return &sdk.StreamResult{Stream: ch}, nil
-}
-
-func (*agentToolPlaceholderProvider) Test(context.Context) *sdk.ProviderTestResult {
-	return &sdk.ProviderTestResult{Status: sdk.ProviderStatusOK, Message: "ok"}
-}
-
-func (*agentToolPlaceholderProvider) TestModel(context.Context, string) (*sdk.ModelTestResult, error) {
-	return &sdk.ModelTestResult{Supported: true, Message: "supported"}, nil
-}
-
-func (*agentToolPlaceholderProvider) DoGenerate(context.Context, sdk.GenerateParams) (*sdk.GenerateResult, error) {
-	return &sdk.GenerateResult{FinishReason: sdk.FinishReasonStop}, nil
-}
-
-func (*agentToolPlaceholderProvider) DoStream(_ context.Context, _ sdk.GenerateParams) (*sdk.StreamResult, error) {
-	ch := make(chan sdk.StreamPart, 8)
-	go func() {
-		defer close(ch)
-		ch <- &sdk.StartPart{}
-		ch <- &sdk.StartStepPart{}
-		ch <- &sdk.ToolInputStartPart{ID: "call-1", ToolName: "write"}
-		ch <- &sdk.StreamToolCallPart{
-			ToolCallID: "call-1",
-			ToolName:   "write",
-			Input:      map[string]any{"path": "/tmp/long.txt"},
-		}
-		ch <- &sdk.FinishStepPart{FinishReason: sdk.FinishReasonStop}
-		ch <- &sdk.FinishPart{FinishReason: sdk.FinishReasonStop}
-	}()
-	return &sdk.StreamResult{Stream: ch}, nil
+func finishedTextTestProvider(text string) agentStreamTestProvider {
+	return func(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {
+		return closedAgentTestStream(
+			&sdk.StartStepPart{},
+			&sdk.TextDeltaPart{ID: "text", Text: text},
+			&sdk.FinishStepPart{FinishReason: sdk.FinishReasonStop},
+		), nil
+	}
 }
 
 // TestAgentStreamEmitsToolCallInputStartThenStart asserts that a tool call
@@ -114,14 +64,20 @@ func TestAgentStreamEmitsToolCallInputStartThenStart(t *testing.T) {
 	t.Parallel()
 
 	a := New(Deps{})
+	provider := agentStreamTestProvider(func(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {
+		return closedAgentTestStream(
+			&sdk.StartPart{}, &sdk.StartStepPart{},
+			&sdk.ToolInputStartPart{ID: "call-1", ToolName: "write"},
+			&sdk.StreamToolCallPart{ToolCallID: "call-1", ToolName: "write", Input: map[string]any{"path": "/tmp/long.txt"}},
+			&sdk.FinishStepPart{FinishReason: sdk.FinishReasonStop},
+			&sdk.FinishPart{FinishReason: sdk.FinishReasonStop},
+		), nil
+	})
 
 	var events []StreamEvent
 	commits := 0
 	for event := range a.Stream(context.Background(), RunConfig{
-		Model: &sdk.Model{
-			ID:       "mock-model",
-			Provider: &agentToolPlaceholderProvider{},
-		},
+		Model:            &sdk.Model{ID: "mock-model", Provider: provider},
 		Messages:         []sdk.Message{sdk.UserMessage("write a long file")},
 		SupportsToolCall: false,
 		Identity:         SessionContext{BotID: "bot-1"},
@@ -164,11 +120,11 @@ func TestAgentStreamCancellationDoesNotWaitForProviderToClose(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	provider := agentStreamTestProvider(func(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {
+		return &sdk.StreamResult{Stream: make(chan sdk.StreamPart)}, nil
+	})
 	events := New(Deps{}).Stream(ctx, RunConfig{
-		Model: &sdk.Model{
-			ID:       "mock-model",
-			Provider: &agentNonClosingStreamProvider{},
-		},
+		Model:    &sdk.Model{ID: "mock-model", Provider: provider},
 		Messages: []sdk.Message{sdk.UserMessage("keep streaming")},
 		Identity: SessionContext{BotID: "bot-1"},
 	})
@@ -205,9 +161,17 @@ func TestAgentStreamPersistsInterruptedInferenceStep(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	provider := agentStreamTestProvider(func(ctx context.Context, _ sdk.GenerateParams) (*sdk.StreamResult, error) {
+		ch := make(chan sdk.StreamPart, 3)
+		ch <- &sdk.StartStepPart{}
+		ch <- &sdk.ReasoningDeltaPart{ID: "reasoning", Text: "thinking"}
+		ch <- &sdk.TextDeltaPart{ID: "text", Text: "partial"}
+		go func() { <-ctx.Done(); close(ch) }()
+		return &sdk.StreamResult{Stream: ch}, nil
+	})
 	var interrupted *sdk.StepResult
 	events := New(Deps{}).Stream(ctx, RunConfig{
-		Model:    &sdk.Model{ID: "mock-model", Provider: &agentInterruptedStreamProvider{}},
+		Model:    &sdk.Model{ID: "mock-model", Provider: provider},
 		Messages: []sdk.Message{sdk.UserMessage("keep streaming")},
 		Identity: SessionContext{BotID: "bot-1"},
 		OnStepInterrupted: func(callbackCtx context.Context, stepIndex int, step *sdk.StepResult) error {
@@ -236,16 +200,109 @@ func TestAgentStreamPersistsInterruptedInferenceStep(t *testing.T) {
 	}
 }
 
-func TestInterruptedStepCaptureRejectsToolAndFinishedSteps(t *testing.T) {
-	for _, disqualify := range []sdk.StreamPart{
-		&sdk.ToolInputStartPart{ID: "call", ToolName: "exec"},
-		&sdk.FinishStepPart{FinishReason: sdk.FinishReasonStop},
-	} {
-		var capture interruptedStepCapture
-		capture.observe(&sdk.TextDeltaPart{Text: "partial"})
-		capture.observe(disqualify)
-		if step := capture.snapshot(); step != nil {
-			t.Fatalf("snapshot after %T = %#v, want nil", disqualify, step)
+func TestInterruptedStepCaptureRejectsToolStep(t *testing.T) {
+	var capture interruptedStepCapture
+	capture.observe(&sdk.TextDeltaPart{Text: "partial"})
+	capture.observe(&sdk.ToolInputStartPart{ID: "call", ToolName: "exec"})
+	if step := capture.snapshot(0); step != nil {
+		t.Fatalf("snapshot after tool activity = %#v, want nil", step)
+	}
+}
+
+func TestInterruptedStepCaptureRejectsAlreadyCommittedStep(t *testing.T) {
+	var capture interruptedStepCapture
+	capture.observe(&sdk.StartStepPart{})
+	capture.observe(&sdk.TextDeltaPart{Text: "partial"})
+	if step := capture.snapshot(1); step != nil {
+		t.Fatalf("snapshot of a step the SDK already committed = %#v, want nil", step)
+	}
+	if step := capture.snapshot(0); step == nil {
+		t.Fatal("snapshot of the uncommitted frontier = nil, want the partial text")
+	}
+	capture.observe(&sdk.FinishStepPart{FinishReason: sdk.FinishReasonStop})
+	if step := capture.snapshot(0); step == nil {
+		t.Fatal("finished step whose complete commit failed = nil, want interrupted fallback")
+	}
+}
+
+func TestAgentStreamDoesNotCheckpointAnAlreadyCommittedStep(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	committed := make(chan string, 4)
+	interrupted := make(chan string, 4)
+	events := New(Deps{}).Stream(ctx, RunConfig{
+		Model:    &sdk.Model{ID: "mock-model", Provider: finishedTextTestProvider("final answer")},
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+		Identity: SessionContext{BotID: "bot-1"},
+		OnStepCommitted: func(_ context.Context, _ int, step *sdk.StepResult) error {
+			committed <- step.Text
+			return nil
+		},
+		OnStepInterrupted: func(_ context.Context, _ int, step *sdk.StepResult) error {
+			interrupted <- step.Text
+			return nil
+		},
+	})
+
+	// Take only agent_start so the event loop parks on the text delta it has
+	// already observed, leaving the finish-step part unread.
+	if first, ok := <-events; !ok || first.Type != EventAgentStart {
+		t.Fatalf("first event = %#v", first)
+	}
+	select {
+	case <-committed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("step was never committed")
+	}
+
+	cancel()
+	for range events {
+	}
+
+	select {
+	case text := <-interrupted:
+		t.Fatalf("checkpointed %q, which the complete-step barrier already made durable", text)
+	default:
+	}
+}
+
+func TestAgentStreamCheckpointsWhenCompleteCommitLosesAbortRace(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	commitStarted := make(chan struct{})
+	interrupted := make(chan string, 1)
+	events := New(Deps{}).Stream(ctx, RunConfig{
+		Model:    &sdk.Model{ID: "mock-model", Provider: finishedTextTestProvider("final answer")},
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+		Identity: SessionContext{BotID: "bot-1"},
+		OnStepCommitted: func(context.Context, int, *sdk.StepResult) error {
+			close(commitStarted)
+			<-ctx.Done()
+			return errors.New("abort won")
+		},
+		OnStepInterrupted: func(_ context.Context, _ int, step *sdk.StepResult) error {
+			interrupted <- step.Text
+			return nil
+		},
+	})
+
+	if first := <-events; first.Type != EventAgentStart {
+		t.Fatalf("first event = %#v", first)
+	}
+	<-commitStarted
+	cancel()
+	for range events {
+	}
+	select {
+	case text := <-interrupted:
+		if text != "final answer" {
+			t.Fatalf("interrupted text = %q", text)
 		}
+	default:
+		t.Fatal("complete step rejected by abort was not checkpointed")
 	}
 }

--- a/internal/agent/runtime/native/stream_test.go
+++ b/internal/agent/runtime/native/stream_test.go
@@ -2,6 +2,7 @@ package native
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -18,6 +19,8 @@ func (*agentToolPlaceholderProvider) ListModels(context.Context) ([]sdk.Model, e
 }
 
 type agentNonClosingStreamProvider struct{}
+
+type agentInterruptedStreamProvider struct{}
 
 func (*agentNonClosingStreamProvider) Name() string { return "non-closing-stream-mock" }
 
@@ -39,6 +42,35 @@ func (*agentNonClosingStreamProvider) DoGenerate(context.Context, sdk.GeneratePa
 
 func (*agentNonClosingStreamProvider) DoStream(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {
 	return &sdk.StreamResult{Stream: make(chan sdk.StreamPart)}, nil
+}
+
+func (*agentInterruptedStreamProvider) Name() string { return "interrupted-stream-mock" }
+func (*agentInterruptedStreamProvider) ListModels(context.Context) ([]sdk.Model, error) {
+	return nil, nil
+}
+
+func (*agentInterruptedStreamProvider) Test(context.Context) *sdk.ProviderTestResult {
+	return &sdk.ProviderTestResult{Status: sdk.ProviderStatusOK, Message: "ok"}
+}
+
+func (*agentInterruptedStreamProvider) TestModel(context.Context, string) (*sdk.ModelTestResult, error) {
+	return &sdk.ModelTestResult{Supported: true}, nil
+}
+
+func (*agentInterruptedStreamProvider) DoGenerate(context.Context, sdk.GenerateParams) (*sdk.GenerateResult, error) {
+	return &sdk.GenerateResult{}, nil
+}
+
+func (*agentInterruptedStreamProvider) DoStream(ctx context.Context, _ sdk.GenerateParams) (*sdk.StreamResult, error) {
+	ch := make(chan sdk.StreamPart, 4)
+	ch <- &sdk.StartStepPart{}
+	ch <- &sdk.ReasoningDeltaPart{ID: "reasoning", Text: "thinking"}
+	ch <- &sdk.TextDeltaPart{ID: "text", Text: "partial"}
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return &sdk.StreamResult{Stream: ch}, nil
 }
 
 func (*agentToolPlaceholderProvider) Test(context.Context) *sdk.ProviderTestResult {
@@ -165,5 +197,55 @@ func TestAgentStreamCancellationDoesNotWaitForProviderToClose(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("stream did not close after its terminal abort")
+	}
+}
+
+func TestAgentStreamPersistsInterruptedInferenceStep(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var interrupted *sdk.StepResult
+	events := New(Deps{}).Stream(ctx, RunConfig{
+		Model:    &sdk.Model{ID: "mock-model", Provider: &agentInterruptedStreamProvider{}},
+		Messages: []sdk.Message{sdk.UserMessage("keep streaming")},
+		Identity: SessionContext{BotID: "bot-1"},
+		OnStepInterrupted: func(callbackCtx context.Context, stepIndex int, step *sdk.StepResult) error {
+			if callbackCtx.Err() != nil || stepIndex != 0 {
+				t.Errorf("callback context/index = %v/%d", callbackCtx.Err(), stepIndex)
+			}
+			interrupted = step
+			return nil
+		},
+	})
+	var terminal StreamEvent
+	for event := range events {
+		if event.Type == EventTextDelta {
+			cancel()
+		}
+		if event.IsTerminal() {
+			terminal = event
+		}
+	}
+	if interrupted == nil || interrupted.Reasoning != "thinking" || interrupted.Text != "partial" {
+		t.Fatalf("interrupted step = %#v", interrupted)
+	}
+	var messages []sdk.Message
+	if terminal.Type != EventAgentAbort || json.Unmarshal(terminal.Messages, &messages) != nil || len(messages) != 1 {
+		t.Fatalf("terminal event/messages = %#v / %#v", terminal, messages)
+	}
+}
+
+func TestInterruptedStepCaptureRejectsToolAndFinishedSteps(t *testing.T) {
+	for _, disqualify := range []sdk.StreamPart{
+		&sdk.ToolInputStartPart{ID: "call", ToolName: "exec"},
+		&sdk.FinishStepPart{FinishReason: sdk.FinishReasonStop},
+	} {
+		var capture interruptedStepCapture
+		capture.observe(&sdk.TextDeltaPart{Text: "partial"})
+		capture.observe(disqualify)
+		if step := capture.snapshot(); step != nil {
+			t.Fatalf("snapshot after %T = %#v, want nil", disqualify, step)
+		}
 	}
 }

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -133,6 +133,11 @@ type RunConfig struct {
 	// before it, with persistence-only tool metadata already attached.
 	OnStepCommitted func(ctx context.Context, stepIndex int, step *sdk.StepResult) error
 
+	// OnStepInterrupted persists text/reasoning emitted by the current model
+	// call when cancellation arrives before finish-step. Tool-call steps never
+	// use this path.
+	OnStepInterrupted func(ctx context.Context, stepIndex int, step *sdk.StepResult) error
+
 	// BackgroundManager provides access to the background task system.
 	// When non-nil, the agent loop refreshes running task summaries at step
 	// boundaries while tools handle waiting and result inspection.

--- a/internal/channel/discuss/history.go
+++ b/internal/channel/discuss/history.go
@@ -26,12 +26,5 @@ func (r discussHistoryReader) Load(ctx context.Context, sessionID string) []time
 		return nil
 	}
 
-	var responses []timeline.TurnResponseEntry
-	for _, message := range messages {
-		entry, ok := timeline.DecodeTurnResponseEntry(message)
-		if ok {
-			responses = append(responses, entry)
-		}
-	}
-	return responses
+	return timeline.DecodeTurnResponseEntries(messages)
 }

--- a/internal/chat/message/runtime_fence_postgres_integration_test.go
+++ b/internal/chat/message/runtime_fence_postgres_integration_test.go
@@ -179,7 +179,8 @@ func TestPostgresRuntimeFenceRejectsStaleRoundAndReplacement(t *testing.T) {
 	}
 }
 
-func TestPostgresAgentStepCommitFencesCompleteAndInterruptedWrites(t *testing.T) {
+// Named for the ^TestPostgresRuntimeFence filter the durable-fencing CI job runs.
+func TestPostgresRuntimeFenceAgentStepCompleteAndInterruptedWrites(t *testing.T) {
 	ctx := context.Background()
 	pool := openRuntimeFencePostgresPool(t, ctx)
 	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
@@ -201,19 +202,24 @@ func TestPostgresAgentStepCommitFencesCompleteAndInterruptedWrites(t *testing.T)
 	}}
 	service := NewService(nil, postgresstore.NewQueriesWithPool(pool, queries))
 	owner := runtimefence.WithContext(ctx, runtimefence.Fence{BotID: botID.String(), SessionID: sessionID.String(), Token: token})
-	step.Interrupted = true
-	if _, err := service.PersistAgentStep(owner, step); !errors.Is(err, ErrAgentStepNotWritable) {
-		t.Fatalf("pre-abort interrupted step error = %v, want ErrAgentStepNotWritable", err)
-	}
-	step.Interrupted = false
 	persisted, err := service.PersistAgentStep(owner, step)
 	if err != nil || len(persisted) != 2 {
 		t.Fatalf("first step commit = (%d, %v), want (2, nil)", len(persisted), err)
+	}
+	// Cancellation without recorded abort intent — an idle timeout, a channel
+	// /stop that only cancels locally, a client that disconnected — must still
+	// checkpoint. Requiring intent would limit the feature to the Web stop
+	// button, which is the one path that records it.
+	step.Interrupted = true
+	step.Messages = []PersistInput{interruptedCheckpointInput(botID, sessionID, runID, persisted[0].ID, "cut short")}
+	if checkpoint, err := service.PersistAgentStep(owner, step); err != nil || len(checkpoint) != 1 {
+		t.Fatalf("interrupted commit without abort intent = (%d, %v), want (1, nil)", len(checkpoint), err)
 	}
 	pgRunID, _ := dbpkg.ParseUUID(runID.String())
 	if _, err := queries.RequestSessionRunAbort(ctx, pgRunID); err != nil {
 		t.Fatalf("request abort: %v", err)
 	}
+	step.Interrupted = false
 	step.Messages = []PersistInput{{
 		BotID: botID.String(), SessionID: sessionID.String(), RunID: runID.String(), Role: "assistant",
 		Content: []byte(`{"role":"assistant","content":"too late"}`), TurnRequestMessageID: persisted[0].ID,
@@ -222,13 +228,14 @@ func TestPostgresAgentStepCommitFencesCompleteAndInterruptedWrites(t *testing.T)
 		t.Fatalf("post-abort step error = %v, want ErrAgentStepNotWritable", err)
 	}
 	step.Interrupted = true
-	step.Messages[0].Metadata = map[string]any{AgentStepInterruptedMetadataKey: true}
+	step.Messages = []PersistInput{interruptedCheckpointInput(botID, sessionID, runID, persisted[0].ID, "stopped")}
 	if interrupted, err := service.PersistAgentStep(owner, step); err != nil || len(interrupted) != 1 {
 		t.Fatalf("interrupted step commit = (%d, %v), want (1, nil)", len(interrupted), err)
 	}
 	history, err := service.ListBySession(ctx, sessionID.String())
-	if err != nil || len(history) != 3 || history[0].Role != "user" || history[1].Role != "assistant" ||
-		history[2].Role != "assistant" || history[2].Metadata[AgentStepInterruptedMetadataKey] != true {
+	if err != nil || len(history) != 4 || history[0].Role != "user" ||
+		history[2].Metadata[AgentStepInterruptedMetadataKey] != true ||
+		history[3].Metadata[AgentStepInterruptedMetadataKey] != true {
 		t.Fatalf("history after interrupt = %#v, %v", history, err)
 	}
 	if _, err := pool.Exec(ctx, "UPDATE session_runs SET state = 'aborted' WHERE run_id = $1", runID); err != nil {
@@ -236,6 +243,15 @@ func TestPostgresAgentStepCommitFencesCompleteAndInterruptedWrites(t *testing.T)
 	}
 	if _, err := service.PersistAgentStep(owner, step); !errors.Is(err, ErrAgentStepNotWritable) {
 		t.Fatalf("post-finalize interrupted step error = %v, want ErrAgentStepNotWritable", err)
+	}
+}
+
+func interruptedCheckpointInput(botID, sessionID pgtype.UUID, runID uuid.UUID, requestMessageID, text string) PersistInput {
+	return PersistInput{
+		BotID: botID.String(), SessionID: sessionID.String(), RunID: runID.String(), Role: "assistant",
+		Content:              []byte(`{"role":"assistant","content":"` + text + `"}`),
+		TurnRequestMessageID: requestMessageID,
+		Metadata:             map[string]any{AgentStepInterruptedMetadataKey: true},
 	}
 }
 

--- a/internal/chat/message/runtime_fence_postgres_integration_test.go
+++ b/internal/chat/message/runtime_fence_postgres_integration_test.go
@@ -179,7 +179,7 @@ func TestPostgresRuntimeFenceRejectsStaleRoundAndReplacement(t *testing.T) {
 	}
 }
 
-func TestPostgresAgentStepCommitStopsAfterAbort(t *testing.T) {
+func TestPostgresAgentStepCommitFencesCompleteAndInterruptedWrites(t *testing.T) {
 	ctx := context.Background()
 	pool := openRuntimeFencePostgresPool(t, ctx)
 	botID, sessionID := createRuntimeFenceFixtures(t, ctx, pool)
@@ -201,6 +201,11 @@ func TestPostgresAgentStepCommitStopsAfterAbort(t *testing.T) {
 	}}
 	service := NewService(nil, postgresstore.NewQueriesWithPool(pool, queries))
 	owner := runtimefence.WithContext(ctx, runtimefence.Fence{BotID: botID.String(), SessionID: sessionID.String(), Token: token})
+	step.Interrupted = true
+	if _, err := service.PersistAgentStep(owner, step); !errors.Is(err, ErrAgentStepNotWritable) {
+		t.Fatalf("pre-abort interrupted step error = %v, want ErrAgentStepNotWritable", err)
+	}
+	step.Interrupted = false
 	persisted, err := service.PersistAgentStep(owner, step)
 	if err != nil || len(persisted) != 2 {
 		t.Fatalf("first step commit = (%d, %v), want (2, nil)", len(persisted), err)
@@ -215,6 +220,22 @@ func TestPostgresAgentStepCommitStopsAfterAbort(t *testing.T) {
 	}}
 	if _, err := service.PersistAgentStep(owner, step); !errors.Is(err, ErrAgentStepNotWritable) {
 		t.Fatalf("post-abort step error = %v, want ErrAgentStepNotWritable", err)
+	}
+	step.Interrupted = true
+	step.Messages[0].Metadata = map[string]any{AgentStepInterruptedMetadataKey: true}
+	if interrupted, err := service.PersistAgentStep(owner, step); err != nil || len(interrupted) != 1 {
+		t.Fatalf("interrupted step commit = (%d, %v), want (1, nil)", len(interrupted), err)
+	}
+	history, err := service.ListBySession(ctx, sessionID.String())
+	if err != nil || len(history) != 3 || history[0].Role != "user" || history[1].Role != "assistant" ||
+		history[2].Role != "assistant" || history[2].Metadata[AgentStepInterruptedMetadataKey] != true {
+		t.Fatalf("history after interrupt = %#v, %v", history, err)
+	}
+	if _, err := pool.Exec(ctx, "UPDATE session_runs SET state = 'aborted' WHERE run_id = $1", runID); err != nil {
+		t.Fatalf("finalize aborted run: %v", err)
+	}
+	if _, err := service.PersistAgentStep(owner, step); !errors.Is(err, ErrAgentStepNotWritable) {
+		t.Fatalf("post-finalize interrupted step error = %v, want ErrAgentStepNotWritable", err)
 	}
 }
 

--- a/internal/chat/message/step_commit.go
+++ b/internal/chat/message/step_commit.go
@@ -19,11 +19,12 @@ var ErrAgentStepNotWritable = errors.New("agent step is no longer writable")
 
 type agentStepQueries interface {
 	LockSessionRunForAgentStepCommit(context.Context, sqlc.LockSessionRunForAgentStepCommitParams) (pgtype.UUID, error)
+	LockSessionRunForInterruptedAgentStepCommit(context.Context, sqlc.LockSessionRunForInterruptedAgentStepCommitParams) (pgtype.UUID, error)
 }
 
-// PersistAgentStep appends a complete SDK step in one runtime-fenced
-// transaction. Locking the run row linearizes the commit against abort; the
-// caller must not replay a step after this method returns.
+// PersistAgentStep appends one SDK step in a runtime-fenced transaction.
+// Complete steps lock before abort; interrupted text/reasoning snapshots lock
+// after abort intent but before terminal finalization.
 func (s *DBService) PersistAgentStep(ctx context.Context, step AgentStep) ([]Message, error) {
 	if s == nil || s.queries == nil {
 		return nil, errors.New("message service is not configured")
@@ -66,12 +67,19 @@ func (s *DBService) PersistAgentStep(ctx context.Context, step AgentStep) ([]Mes
 		if !ok {
 			return errors.New("persistence store does not support agent step writes")
 		}
-		if _, err := writer.LockSessionRunForAgentStepCommit(ctx, sqlc.LockSessionRunForAgentStepCommitParams{
+		params := sqlc.LockSessionRunForAgentStepCommitParams{
 			RunID: pgRunID, BotID: pgBotID, SessionID: pgSessionID, FencingToken: fence.Token,
-		}); errors.Is(err, pgx.ErrNoRows) {
+		}
+		var lockErr error
+		if step.Interrupted {
+			_, lockErr = writer.LockSessionRunForInterruptedAgentStepCommit(ctx, sqlc.LockSessionRunForInterruptedAgentStepCommitParams(params))
+		} else {
+			_, lockErr = writer.LockSessionRunForAgentStepCommit(ctx, params)
+		}
+		if errors.Is(lockErr, pgx.ErrNoRows) {
 			return ErrAgentStepNotWritable
-		} else if err != nil {
-			return fmt.Errorf("lock session run for agent step: %w", err)
+		} else if lockErr != nil {
+			return fmt.Errorf("lock session run for agent step: %w", lockErr)
 		}
 
 		txService := *s

--- a/internal/chat/message/step_commit.go
+++ b/internal/chat/message/step_commit.go
@@ -19,12 +19,11 @@ var ErrAgentStepNotWritable = errors.New("agent step is no longer writable")
 
 type agentStepQueries interface {
 	LockSessionRunForAgentStepCommit(context.Context, sqlc.LockSessionRunForAgentStepCommitParams) (pgtype.UUID, error)
-	LockSessionRunForInterruptedAgentStepCommit(context.Context, sqlc.LockSessionRunForInterruptedAgentStepCommitParams) (pgtype.UUID, error)
 }
 
 // PersistAgentStep appends one SDK step in a runtime-fenced transaction.
-// Complete steps lock before abort; interrupted text/reasoning snapshots lock
-// after abort intent but before terminal finalization.
+// Complete steps precede abort intent; interrupted checkpoints remain writable
+// until terminal finalization for cancellation paths without recorded intent.
 func (s *DBService) PersistAgentStep(ctx context.Context, step AgentStep) ([]Message, error) {
 	if s == nil || s.queries == nil {
 		return nil, errors.New("message service is not configured")
@@ -68,14 +67,10 @@ func (s *DBService) PersistAgentStep(ctx context.Context, step AgentStep) ([]Mes
 			return errors.New("persistence store does not support agent step writes")
 		}
 		params := sqlc.LockSessionRunForAgentStepCommitParams{
-			RunID: pgRunID, BotID: pgBotID, SessionID: pgSessionID, FencingToken: fence.Token,
+			RunID: pgRunID, BotID: pgBotID, SessionID: pgSessionID,
+			FencingToken: fence.Token, Interrupted: step.Interrupted,
 		}
-		var lockErr error
-		if step.Interrupted {
-			_, lockErr = writer.LockSessionRunForInterruptedAgentStepCommit(ctx, sqlc.LockSessionRunForInterruptedAgentStepCommitParams(params))
-		} else {
-			_, lockErr = writer.LockSessionRunForAgentStepCommit(ctx, params)
-		}
+		_, lockErr := writer.LockSessionRunForAgentStepCommit(ctx, params)
 		if errors.Is(lockErr, pgx.ErrNoRows) {
 			return ErrAgentStepNotWritable
 		} else if lockErr != nil {

--- a/internal/chat/message/types.go
+++ b/internal/chat/message/types.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+const (
+	AgentStepInterruptedMetadataKey     = "agent_step_interrupted"
+	AgentStepInterruptedReasoningPrefix = "[Previous assistant response was interrupted during reasoning. Continue from this checkpoint:]\n"
+)
+
 // MessageAsset carries media asset metadata attached to a message.
 // ContentHash is the content-addressed identifier for the media file.
 type MessageAsset struct {
@@ -144,10 +149,12 @@ type AtomicRoundPersister interface {
 	PersistRound(ctx context.Context, inputs []PersistInput, options RoundPersistenceOptions) ([]Message, bool, error)
 }
 
-// AgentStep is one complete native-agent step persisted atomically.
+// AgentStep is one native-agent step persisted atomically. Interrupted is set
+// only for a text/reasoning snapshot captured after the run's abort intent.
 type AgentStep struct {
-	RunID    string
-	Messages []PersistInput
+	RunID       string
+	Messages    []PersistInput
+	Interrupted bool
 }
 
 type AgentStepPersister interface {

--- a/internal/chat/message/types.go
+++ b/internal/chat/message/types.go
@@ -11,6 +11,24 @@ const (
 	AgentStepInterruptedReasoningPrefix = "[Previous assistant response was interrupted during reasoning. Continue from this checkpoint:]\n"
 )
 
+// LatestInterruptedCheckpoint returns the last assistant entry only when it is
+// an interrupted checkpoint. Earlier checkpoints are ordinary history.
+func LatestInterruptedCheckpoint(n int, classify func(int) (assistant, interrupted bool)) int {
+	if n <= 0 || classify == nil {
+		return -1
+	}
+	for i := n - 1; i >= 0; i-- {
+		assistant, interrupted := classify(i)
+		if assistant {
+			if interrupted {
+				return i
+			}
+			return -1
+		}
+	}
+	return -1
+}
+
 // MessageAsset carries media asset metadata attached to a message.
 // ContentHash is the content-addressed identifier for the media file.
 type MessageAsset struct {
@@ -149,8 +167,9 @@ type AtomicRoundPersister interface {
 	PersistRound(ctx context.Context, inputs []PersistInput, options RoundPersistenceOptions) ([]Message, bool, error)
 }
 
-// AgentStep is one native-agent step persisted atomically. Interrupted is set
-// only for a text/reasoning snapshot captured after the run's abort intent.
+// AgentStep is one native-agent step persisted atomically. Interrupted marks a
+// text/reasoning snapshot of a step the model never finished, which takes a
+// different writability predicate than a complete step.
 type AgentStep struct {
 	RunID       string
 	Messages    []PersistInput

--- a/internal/chat/timeline/turn_response.go
+++ b/internal/chat/timeline/turn_response.go
@@ -4,17 +4,45 @@ import (
 	"encoding/json"
 	"strings"
 
+	sdk "github.com/memohai/twilight-ai/sdk"
+
 	"github.com/memohai/memoh/internal/agent/turn"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
+	"github.com/memohai/memoh/internal/messageconv"
 )
 
-// DecodeTurnResponseEntry converts a persisted bot message into a TR entry for
-// pipeline context composition.
+// DecodeTurnResponseEntries converts a chronological run of persisted bot
+// messages into TR entries for pipeline context composition.
 //
+// Decoding the run as a whole is what lets an interrupted checkpoint's
+// reasoning be projected only while it is still the unfinished frontier; a
+// single message cannot tell whether a completed answer already followed it.
+func DecodeTurnResponseEntries(msgs []messagepkg.Message) []TurnResponseEntry {
+	checkpoint := messagepkg.LatestInterruptedCheckpoint(len(msgs), func(i int) (bool, bool) {
+		return strings.TrimSpace(msgs[i].Role) == "assistant",
+			msgs[i].Metadata[messagepkg.AgentStepInterruptedMetadataKey] == true
+	})
+	entries := make([]TurnResponseEntry, 0, len(msgs))
+	for i, msg := range msgs {
+		if entry, ok := decodeTurnResponseEntry(msg, i == checkpoint); ok {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+// DecodeTurnResponseEntry converts a single persisted bot message into a TR
+// entry. Reasoning is always dropped: an interrupted checkpoint's reasoning
+// needs the surrounding history to know whether it is still live, so callers
+// composing context use DecodeTurnResponseEntries instead.
+func DecodeTurnResponseEntry(msg messagepkg.Message) (TurnResponseEntry, bool) {
+	return decodeTurnResponseEntry(msg, false)
+}
+
 // Tool calls and tool results are preserved as native structured content
 // parts. They must not be rendered as assistant-visible pseudo-protocol text:
 // models may imitate that text instead of emitting real provider tool calls.
-func DecodeTurnResponseEntry(msg messagepkg.Message) (TurnResponseEntry, bool) {
+func decodeTurnResponseEntry(msg messagepkg.Message, liveCheckpoint bool) (TurnResponseEntry, bool) {
 	role := strings.TrimSpace(msg.Role)
 	if role != "assistant" && role != "tool" {
 		return TurnResponseEntry{}, false
@@ -30,7 +58,10 @@ func DecodeTurnResponseEntry(msg messagepkg.Message) (TurnResponseEntry, bool) {
 	case "tool":
 		rawContent = nativeToolRoleContent(modelMsg)
 	default:
-		rawContent = nativeAssistantContent(modelMsg, msg.Metadata[messagepkg.AgentStepInterruptedMetadataKey] == true)
+		if liveCheckpoint {
+			modelMsg = ProjectInterruptedReasoning(modelMsg)
+		}
+		rawContent = nativeAssistantContent(modelMsg)
 	}
 
 	if len(rawContent) == 0 || strings.TrimSpace(string(rawContent)) == "" {
@@ -44,6 +75,54 @@ func DecodeTurnResponseEntry(msg messagepkg.Message) (TurnResponseEntry, bool) {
 		RawContent:      rawContent,
 		SourceMessageID: msg.ID,
 	}, true
+}
+
+// ProjectInterruptedReasoning exposes an unfinished reasoning part as text so
+// every provider can continue it on the next turn. Other message fields and
+// content parts remain unchanged.
+func ProjectInterruptedReasoning(modelMsg turn.ModelMessage) turn.ModelMessage {
+	message := messageconv.ModelMessageToSDKMessage(modelMsg)
+	var reasoning strings.Builder
+	parts := make([]sdk.MessagePart, 0, len(message.Content))
+	for _, part := range message.Content {
+		switch p := part.(type) {
+		case sdk.ReasoningPart:
+			reasoning.WriteString(p.Text)
+		case *sdk.ReasoningPart:
+			reasoning.WriteString(p.Text)
+		default:
+			parts = append(parts, part)
+		}
+	}
+	if strings.TrimSpace(reasoning.String()) == "" {
+		return modelMsg
+	}
+
+	checkpoint := messagepkg.AgentStepInterruptedReasoningPrefix + reasoning.String()
+	for i, part := range parts {
+		switch p := part.(type) {
+		case sdk.TextPart:
+			p.Text = checkpoint + "\n\n" + p.Text
+			parts[i], checkpoint = p, ""
+		case *sdk.TextPart:
+			clone := *p
+			clone.Text = checkpoint + "\n\n" + clone.Text
+			parts[i], checkpoint = clone, ""
+		}
+		if checkpoint == "" {
+			break
+		}
+	}
+	if checkpoint != "" {
+		parts = append([]sdk.MessagePart{sdk.TextPart{Text: checkpoint}}, parts...)
+	}
+	message.Content = parts
+	projected := messageconv.SDKMessagesToModelMessages([]sdk.Message{message})[0]
+	projected.Usage = modelMsg.Usage
+	projected.ToolCalls = modelMsg.ToolCalls
+	projected.ToolCallID = modelMsg.ToolCallID
+	projected.Name = modelMsg.Name
+	return projected
 }
 
 // turnResponsePart is a permissive view of a persisted content part. It
@@ -60,9 +139,8 @@ type turnResponsePart struct {
 	ProviderMetadata json.RawMessage `json:"providerMetadata,omitempty"`
 }
 
-func nativeAssistantContent(msg turn.ModelMessage, includeReasoning bool) json.RawMessage {
+func nativeAssistantContent(msg turn.ModelMessage) json.RawMessage {
 	var out []map[string]any
-	var interruptedReasoning strings.Builder
 	// 1) Plain-string content (legacy format).
 	if len(msg.Content) > 0 {
 		var plain string
@@ -95,10 +173,7 @@ func nativeAssistantContent(msg turn.ModelMessage, includeReasoning bool) json.R
 				"text": text,
 			})
 		case "reasoning":
-			if !includeReasoning || strings.TrimSpace(p.Text) == "" {
-				continue
-			}
-			interruptedReasoning.WriteString(p.Text)
+			continue
 		case "tool-call":
 			out = append(out, nativeToolCallPart(p.ToolCallID, p.ToolName, p.Input, p.ProviderMetadata))
 		case "tool-result":
@@ -109,21 +184,6 @@ func nativeAssistantContent(msg turn.ModelMessage, includeReasoning bool) json.R
 			out = append(out, nativeToolResultPart(p.ToolCallID, p.ToolName, payload))
 		}
 	}
-	if interruptedReasoning.Len() > 0 {
-		checkpoint := messagepkg.AgentStepInterruptedReasoningPrefix + interruptedReasoning.String()
-		merged := false
-		for _, part := range out {
-			if part["type"] == "text" {
-				part["text"] = checkpoint + "\n\n" + part["text"].(string)
-				merged = true
-				break
-			}
-		}
-		if !merged {
-			out = append([]map[string]any{{"type": "text", "text": checkpoint}}, out...)
-		}
-	}
-
 	// 3) Top-level ToolCalls field (older OpenAI-style wire format).
 	for _, call := range msg.ToolCalls {
 		id := strings.TrimSpace(call.ID)

--- a/internal/chat/timeline/turn_response.go
+++ b/internal/chat/timeline/turn_response.go
@@ -19,7 +19,7 @@ import (
 // single message cannot tell whether a completed answer already followed it.
 func DecodeTurnResponseEntries(msgs []messagepkg.Message) []TurnResponseEntry {
 	checkpoint := messagepkg.LatestInterruptedCheckpoint(len(msgs), func(i int) (bool, bool) {
-		return strings.TrimSpace(msgs[i].Role) == "assistant",
+		return strings.EqualFold(strings.TrimSpace(msgs[i].Role), "assistant"),
 			msgs[i].Metadata[messagepkg.AgentStepInterruptedMetadataKey] == true
 	})
 	entries := make([]TurnResponseEntry, 0, len(msgs))
@@ -43,7 +43,7 @@ func DecodeTurnResponseEntry(msg messagepkg.Message) (TurnResponseEntry, bool) {
 // parts. They must not be rendered as assistant-visible pseudo-protocol text:
 // models may imitate that text instead of emitting real provider tool calls.
 func decodeTurnResponseEntry(msg messagepkg.Message, liveCheckpoint bool) (TurnResponseEntry, bool) {
-	role := strings.TrimSpace(msg.Role)
+	role := strings.ToLower(strings.TrimSpace(msg.Role))
 	if role != "assistant" && role != "tool" {
 		return TurnResponseEntry{}, false
 	}

--- a/internal/chat/timeline/turn_response.go
+++ b/internal/chat/timeline/turn_response.go
@@ -30,7 +30,7 @@ func DecodeTurnResponseEntry(msg messagepkg.Message) (TurnResponseEntry, bool) {
 	case "tool":
 		rawContent = nativeToolRoleContent(modelMsg)
 	default:
-		rawContent = nativeAssistantContent(modelMsg)
+		rawContent = nativeAssistantContent(modelMsg, msg.Metadata[messagepkg.AgentStepInterruptedMetadataKey] == true)
 	}
 
 	if len(rawContent) == 0 || strings.TrimSpace(string(rawContent)) == "" {
@@ -60,8 +60,9 @@ type turnResponsePart struct {
 	ProviderMetadata json.RawMessage `json:"providerMetadata,omitempty"`
 }
 
-func nativeAssistantContent(msg turn.ModelMessage) json.RawMessage {
+func nativeAssistantContent(msg turn.ModelMessage, includeReasoning bool) json.RawMessage {
 	var out []map[string]any
+	var interruptedReasoning strings.Builder
 	// 1) Plain-string content (legacy format).
 	if len(msg.Content) > 0 {
 		var plain string
@@ -94,9 +95,10 @@ func nativeAssistantContent(msg turn.ModelMessage) json.RawMessage {
 				"text": text,
 			})
 		case "reasoning":
-			// Intentionally omitted: reasoning is model-internal and must not
-			// leak back into subsequent prompts verbatim.
-			continue
+			if !includeReasoning || strings.TrimSpace(p.Text) == "" {
+				continue
+			}
+			interruptedReasoning.WriteString(p.Text)
 		case "tool-call":
 			out = append(out, nativeToolCallPart(p.ToolCallID, p.ToolName, p.Input, p.ProviderMetadata))
 		case "tool-result":
@@ -105,6 +107,20 @@ func nativeAssistantContent(msg turn.ModelMessage) json.RawMessage {
 				payload = p.Result
 			}
 			out = append(out, nativeToolResultPart(p.ToolCallID, p.ToolName, payload))
+		}
+	}
+	if interruptedReasoning.Len() > 0 {
+		checkpoint := messagepkg.AgentStepInterruptedReasoningPrefix + interruptedReasoning.String()
+		merged := false
+		for _, part := range out {
+			if part["type"] == "text" {
+				part["text"] = checkpoint + "\n\n" + part["text"].(string)
+				merged = true
+				break
+			}
+		}
+		if !merged {
+			out = append([]map[string]any{{"type": "text", "text": checkpoint}}, out...)
 		}
 	}
 

--- a/internal/chat/timeline/turn_response_test.go
+++ b/internal/chat/timeline/turn_response_test.go
@@ -260,13 +260,13 @@ func TestDecodeTurnResponseEntryKeepsOnlyInterruptedReasoning(t *testing.T) {
 		t.Fatalf("marshal model message: %v", err)
 	}
 	if _, ok := DecodeTurnResponseEntry(messagepkg.Message{
-		Role:    "assistant",
+		Role:    " Assistant ",
 		Content: modelMessage,
 	}); ok {
 		t.Fatal("expected reasoning-only message to be skipped")
 	}
 	interrupted := messagepkg.Message{
-		Role: "assistant", Content: modelMessage,
+		Role: " Assistant ", Content: modelMessage,
 		Metadata: map[string]any{messagepkg.AgentStepInterruptedMetadataKey: true},
 	}
 	entries := DecodeTurnResponseEntries([]messagepkg.Message{interrupted, interrupted})

--- a/internal/chat/timeline/turn_response_test.go
+++ b/internal/chat/timeline/turn_response_test.go
@@ -40,7 +40,7 @@ func TestDecodeTurnResponseEntryUsesVisibleText(t *testing.T) {
 	if entry.Content != "任务完成" {
 		t.Fatalf("content = %q, want %q", entry.Content, "任务完成")
 	}
-	// Reasoning must never leak into TRs to avoid re-injection into prompts.
+	// Completed reasoning must not be re-injected into later prompts.
 	if strings.Contains(entry.Content, "thinking") {
 		t.Fatalf("reasoning leaked into TR: %q", entry.Content)
 	}
@@ -241,10 +241,11 @@ func TestDecodeTurnResponseEntryToolRoleLegacyEnvelope(t *testing.T) {
 	}
 }
 
-func TestDecodeTurnResponseEntrySkipsEmpty(t *testing.T) {
+func TestDecodeTurnResponseEntryKeepsOnlyInterruptedReasoning(t *testing.T) {
 	t.Parallel()
 
-	// Only reasoning → nothing to expose to future prompts → skip.
+	// Completed reasoning remains hidden, while an interrupted checkpoint is
+	// continuation state and must survive into the next prompt.
 	content, err := json.Marshal([]map[string]any{
 		{"type": "reasoning", "text": "thinking out loud"},
 	})
@@ -264,6 +265,14 @@ func TestDecodeTurnResponseEntrySkipsEmpty(t *testing.T) {
 	}); ok {
 		t.Fatal("expected reasoning-only message to be skipped")
 	}
+	entry, ok := DecodeTurnResponseEntry(messagepkg.Message{
+		Role: "assistant", Content: modelMessage,
+		Metadata: map[string]any{messagepkg.AgentStepInterruptedMetadataKey: true},
+	})
+	if !ok {
+		t.Fatal("expected interrupted reasoning to remain in continuation context")
+	}
+	assertRawPart(t, entry.RawContent, "text", messagepkg.AgentStepInterruptedReasoningPrefix+"thinking out loud", "")
 }
 
 func TestDecodeTurnResponseEntryLegacyToolCallsField(t *testing.T) {
@@ -313,7 +322,7 @@ func assertRawPart(t *testing.T, raw json.RawMessage, partType, nameOrText, call
 			continue
 		}
 		switch partType {
-		case "text":
+		case "text", "reasoning":
 			if part["text"] == nameOrText {
 				return part
 			}

--- a/internal/chat/timeline/turn_response_test.go
+++ b/internal/chat/timeline/turn_response_test.go
@@ -265,14 +265,51 @@ func TestDecodeTurnResponseEntryKeepsOnlyInterruptedReasoning(t *testing.T) {
 	}); ok {
 		t.Fatal("expected reasoning-only message to be skipped")
 	}
-	entry, ok := DecodeTurnResponseEntry(messagepkg.Message{
+	interrupted := messagepkg.Message{
 		Role: "assistant", Content: modelMessage,
 		Metadata: map[string]any{messagepkg.AgentStepInterruptedMetadataKey: true},
-	})
-	if !ok {
-		t.Fatal("expected interrupted reasoning to remain in continuation context")
 	}
-	assertRawPart(t, entry.RawContent, "text", messagepkg.AgentStepInterruptedReasoningPrefix+"thinking out loud", "")
+	entries := DecodeTurnResponseEntries([]messagepkg.Message{interrupted, interrupted})
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want only the latest interrupted checkpoint", len(entries))
+	}
+	assertRawPart(t, entries[0].RawContent, "text", messagepkg.AgentStepInterruptedReasoningPrefix+"thinking out loud", "")
+}
+
+func TestDecodeTurnResponseEntriesDropSupersededCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	// Once a completed answer follows the checkpoint, its reasoning is history:
+	// re-injecting the continuation instruction would ask the model to resume an
+	// answer it already delivered, on every later turn.
+	reasoning, err := json.Marshal([]map[string]any{{"type": "reasoning", "text": "thinking out loud"}})
+	if err != nil {
+		t.Fatalf("marshal reasoning content: %v", err)
+	}
+	interruptedMessage, err := json.Marshal(turn.ModelMessage{Role: "assistant", Content: reasoning})
+	if err != nil {
+		t.Fatalf("marshal interrupted message: %v", err)
+	}
+	answer, err := json.Marshal([]map[string]any{{"type": "text", "text": "done"}})
+	if err != nil {
+		t.Fatalf("marshal answer content: %v", err)
+	}
+	answerMessage, err := json.Marshal(turn.ModelMessage{Role: "assistant", Content: answer})
+	if err != nil {
+		t.Fatalf("marshal answer message: %v", err)
+	}
+
+	entries := DecodeTurnResponseEntries([]messagepkg.Message{
+		{
+			Role: "assistant", Content: interruptedMessage,
+			Metadata: map[string]any{messagepkg.AgentStepInterruptedMetadataKey: true},
+		},
+		{Role: "assistant", Content: answerMessage},
+	})
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want only the completed answer", len(entries))
+	}
+	assertRawPart(t, entries[0].RawContent, "text", "done", "")
 }
 
 func TestDecodeTurnResponseEntryLegacyToolCallsField(t *testing.T) {

--- a/internal/db/postgres/sqlc/session_runs.sql.go
+++ b/internal/db/postgres/sqlc/session_runs.sql.go
@@ -570,6 +570,42 @@ func (q *Queries) LockSessionRunForAgentStepCommit(ctx context.Context, arg Lock
 	return run_id, err
 }
 
+const lockSessionRunForInterruptedAgentStepCommit = `-- name: LockSessionRunForInterruptedAgentStepCommit :one
+SELECT run_id
+FROM session_runs
+WHERE team_id = public.memoh_current_team_id()
+  AND run_id = $1
+  AND bot_id = $2
+  AND session_id = $3
+  AND fencing_token = $4
+  AND state IN ('running', 'waiting_decision')
+  AND abort_requested_at IS NOT NULL
+FOR UPDATE
+`
+
+type LockSessionRunForInterruptedAgentStepCommitParams struct {
+	RunID        pgtype.UUID `json:"run_id"`
+	BotID        pgtype.UUID `json:"bot_id"`
+	SessionID    pgtype.UUID `json:"session_id"`
+	FencingToken int64       `json:"fencing_token"`
+}
+
+// An interrupted text/reasoning snapshot is writable only after abort intent
+// is durable and before this owner finalizes the run. It deliberately uses a
+// separate predicate from complete-step commits so tool steps keep their
+// existing abort race semantics.
+func (q *Queries) LockSessionRunForInterruptedAgentStepCommit(ctx context.Context, arg LockSessionRunForInterruptedAgentStepCommitParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, lockSessionRunForInterruptedAgentStepCommit,
+		arg.RunID,
+		arg.BotID,
+		arg.SessionID,
+		arg.FencingToken,
+	)
+	var run_id pgtype.UUID
+	err := row.Scan(&run_id)
+	return run_id, err
+}
+
 const nextSessionRunFencingToken = `-- name: NextSessionRunFencingToken :one
 SELECT nextval('session_runtime_fencing_token_seq')::bigint AS token
 `

--- a/internal/db/postgres/sqlc/session_runs.sql.go
+++ b/internal/db/postgres/sqlc/session_runs.sql.go
@@ -544,7 +544,7 @@ WHERE team_id = public.memoh_current_team_id()
   AND session_id = $3
   AND fencing_token = $4
   AND state IN ('running', 'waiting_decision')
-  AND abort_requested_at IS NULL
+  AND ($5::boolean OR abort_requested_at IS NULL)
 FOR UPDATE
 `
 
@@ -553,53 +553,18 @@ type LockSessionRunForAgentStepCommitParams struct {
 	BotID        pgtype.UUID `json:"bot_id"`
 	SessionID    pgtype.UUID `json:"session_id"`
 	FencingToken int64       `json:"fencing_token"`
+	Interrupted  bool        `json:"interrupted"`
 }
 
-// Linearize a complete-step commit against abort and terminal transitions.
-// RequestSessionRunAbort updates the same row, so either the step locks first
-// and commits, or the abort becomes visible here and the step is refused.
+// Complete steps must precede abort intent; interrupted checkpoints only need
+// the same active owner because some cancellation paths do not record intent.
 func (q *Queries) LockSessionRunForAgentStepCommit(ctx context.Context, arg LockSessionRunForAgentStepCommitParams) (pgtype.UUID, error) {
 	row := q.db.QueryRow(ctx, lockSessionRunForAgentStepCommit,
 		arg.RunID,
 		arg.BotID,
 		arg.SessionID,
 		arg.FencingToken,
-	)
-	var run_id pgtype.UUID
-	err := row.Scan(&run_id)
-	return run_id, err
-}
-
-const lockSessionRunForInterruptedAgentStepCommit = `-- name: LockSessionRunForInterruptedAgentStepCommit :one
-SELECT run_id
-FROM session_runs
-WHERE team_id = public.memoh_current_team_id()
-  AND run_id = $1
-  AND bot_id = $2
-  AND session_id = $3
-  AND fencing_token = $4
-  AND state IN ('running', 'waiting_decision')
-  AND abort_requested_at IS NOT NULL
-FOR UPDATE
-`
-
-type LockSessionRunForInterruptedAgentStepCommitParams struct {
-	RunID        pgtype.UUID `json:"run_id"`
-	BotID        pgtype.UUID `json:"bot_id"`
-	SessionID    pgtype.UUID `json:"session_id"`
-	FencingToken int64       `json:"fencing_token"`
-}
-
-// An interrupted text/reasoning snapshot is writable only after abort intent
-// is durable and before this owner finalizes the run. It deliberately uses a
-// separate predicate from complete-step commits so tool steps keep their
-// existing abort race semantics.
-func (q *Queries) LockSessionRunForInterruptedAgentStepCommit(ctx context.Context, arg LockSessionRunForInterruptedAgentStepCommitParams) (pgtype.UUID, error) {
-	row := q.db.QueryRow(ctx, lockSessionRunForInterruptedAgentStepCommit,
-		arg.RunID,
-		arg.BotID,
-		arg.SessionID,
-		arg.FencingToken,
+		arg.Interrupted,
 	)
 	var run_id pgtype.UUID
 	err := row.Scan(&run_id)


### PR DESCRIPTION
## Summary

- extend #934 so a user abort during an unfinished native-model reasoning/text step persists the emitted prefix as an interrupted assistant checkpoint
- keep tool-call, tool-result, approval, and completed-step persistence on the existing Twilight `OnStepCommitted` path
- reuse the existing `session_runs` state and fencing token; complete writes remain ordered against abort intent while interrupted writes also cover cancellation paths without durable intent; no table, column, or migration is added
- tag interrupted history messages in existing JSONB metadata and exclude unfinished output from long-term memory extraction
- project interrupted reasoning into provider-neutral assistant text on the next turn, including the PostgreSQL cold-start fallback after a server restart
- drain application streams after client cancellation so the checkpoint transaction completes before terminal run finalization

## Why

#934 made every complete native-agent step durable before Twilight advanced the tool/model loop. A remaining gap existed when the user aborted while the model was still reasoning or streaming its answer: there was no complete step callback, so the current progress disappeared and the next user turn resumed from the previous complete boundary.

This change captures only the current model call's text/reasoning stream. Any tool activity disqualifies the snapshot so tool behavior and its existing complete-step barrier remain unchanged.

## Database ordering

Complete and interrupted writes share the existing atomic history-message transaction and lock the owning `session_runs` row:

- complete steps require `abort_requested_at IS NULL`
- interrupted checkpoints do not require abort intent because channel `/stop`, idle timeout, and client disconnect can cancel locally
- both require the active state, exact run/bot/session identity, and current fencing token
- terminal finalization remains ordered after stream cleanup

The row lock and fencing predicate serialize complete-step commit, interrupted checkpoint commit, and terminal transition without introducing a separate checkpoint table.

## Compatibility

The continuation is provider-neutral: durable history retains typed reasoning/text parts, while only interrupted reasoning is projected to ordinary assistant text for the next request. This avoids relying on historical `reasoning_content`, Anthropic/Gemini signatures, or provider-side response state.

This is semantic continuation, not resumption of the provider's original sampling/KV state. Providers that do not stream visible reasoning can still preserve partial text, but cannot expose hidden reasoning for checkpointing.

## Validation

- `mise run sqlc-generate`
- `go test ./internal/agent/... ./internal/chat/...`
- `go test -race ./internal/agent/runtime/native ./internal/agent/application ./internal/chat/timeline`
- `mise run lint:go`
- PostgreSQL integration: complete-before-abort accepted, complete-after-abort rejected, interrupted checkpoints accepted with or without abort intent while the run is active, and post-terminal writes rejected
- Twilight provider packages: OpenAI Completions, OpenAI Responses, OpenAI Codex, Anthropic Messages, Google Generative AI, and GitHub Copilot
- `git diff --check`

## Dev environment validation

Ran against the dev environment with a real OpenAI-compatible reasoning model:

- aborted during partial inference, then recovered the emitted checkpoint on the next user turn
- aborted during reasoning-only output, restarted the server to clear in-memory state, then recovered the checkpoint from PostgreSQL on the next turn
- confirmed history ordering as user → interrupted assistant → next user → completed assistant

This was agent-executed backend validation; it does not count as human QA.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.