### PR TITLE
fix(web): keep bot-switcher click from being eaten by drag jitter

### DIFF
--- a/apps/web/src/components/sidebar/bot-switcher.vue
+++ b/apps/web/src/components/sidebar/bot-switcher.vue
@@ -66,8 +66,9 @@
            the live rows slide to make room (animation) and the source slot shows
            as an empty gap (.bot-row-ghost). The WHOLE row is the drag target (no
            `handle`), so you can grab it anywhere the cursor reads as interactive,
-           not just the avatar; a short move starts a drag, a plain click still
-           selects. The grip that swaps in on hover is a pure affordance (no
+           not just the avatar; a move past the 5px `fallbackTolerance` starts a
+           drag, a plain click (even with slight hand jitter) still selects.
+           The grip that swaps in on hover is a pure affordance (no
            separate cursor, so moving across the row never flickers grab↔pointer).
            While a drag runs we (a) freeze the rendered list off `displayBots` so
            an unrelated query refetch can't re-render mid-drag and yank the row,
@@ -321,6 +322,19 @@ watch(menuOpen, async (open) => {
         forceFallback: true,
         fallbackOnBody: true,
         fallbackClass: 'bot-row-drag',
+        // A drag only arms after the pointer travels 5px from pointerdown
+        // (default 0 = the FIRST pointermove of any distance starts one).
+        // Sortable swallows the next click in capture phase once a drag has
+        // started (its #1184 fix), so with zero tolerance a sub-pixel jitter
+        // during a click — constant on a Magic Mouse — silently eats the
+        // select click: the menu stays open and nothing happens. 5px matches
+        // the native OS drag threshold; the clone tracks the cursor 1:1, so a
+        // real drag still feels instant, and the post-drop click stays
+        // suppressed (drop ≠ select) — aside from a rare pre-existing upstream
+        // race where a >50ms drag whose emulation tick lands on a sibling row
+        // releases the suppression early (sortablejs #1184 handling in
+        // _onDragOver); this tolerance changes nothing about that either way.
+        fallbackTolerance: 5,
         ghostClass: 'bot-row-ghost',
         onStart: () => {
           isDragging = true


### PR DESCRIPTION
## Summary

- **Root cause** (traced in vendored sortablejs 1.15.7 source): with `forceFallback: true`, `fallbackTolerance` defaults to 0, so the first pointermove of *any* distance after pointerdown starts a drag — and once a drag starts, sortablejs swallows the next click via a capture-phase listener (its own #1184 fix). Every Magic Mouse click carries 1-3px of micro-jitter, so the select click was silently eaten: the menu stayed open and the bot never switched.
- **Fix**: `fallbackTolerance: 5` on the bot-switcher's Sortable config (5px ≈ the native OS drag threshold). Below the threshold no drag starts and the click reaches the row unchanged; the clone tracks the cursor 1:1, so real drags still feel instant, and the post-drop click stays suppressed (drop ≠ select).
- **Verified**: mechanism traced end-to-end against the vendored source — all pointer/touch/mouse paths converge on the single tolerance gate; displacement is measured cumulatively from pointerdown; nothing preventDefaults or swallows the click when no drag starts. Human QA'd on local dev.

Refs memohai/Memoh-Cloud#62 — reported against Cloud, but the component lives here and ships to Cloud via the web package, so Cloud picks the fix up on its next `@memohai/web` bump.

## Known residuals (pre-existing upstream sortablejs behavior, unchanged by this fix)

- A >50ms drag whose emulation tick lands on a sibling row can release the click suppression early (`_onDragOver` resets the flag) — in that rare corner the dropped row may also get selected.
- If the pointer is canceled mid-drag (no click follows), the suppression flag leaks once and eats the next click anywhere, then self-heals.
- Any distance threshold inherently judges a >5px "click" as a drag; the row visibly lifts when that happens, so it fails loud rather than silent.

Touch drags now get the same 5px tolerance as mouse (previously a touch drag armed on first move).

## Test plan

- [x] Human QA on local dev: click-with-jitter selects and closes the menu; real drag reorders; drop does not select
- [ ] CI