### PR TITLE
feat(web): persist whitelisted query cache across reloads

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,6 +37,7 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@fontsource-variable/inter": "^5.2.8",
     "@memohai/runtime": "workspace:*",
+    "@pinia/colada-plugin-cache-persister": "0.1.3",
     "electron-updater": "^6.6.2"
   },
   "devDependencies": {

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -5,6 +5,7 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import { PiniaColada, useQueryCache } from '@pinia/colada'
+import { PiniaColadaCachePersister, isCacheReady } from '@pinia/colada-plugin-cache-persister'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 
 import { watchEffect } from 'vue'
@@ -18,6 +19,7 @@ import { registerWorkspaceTabCommands } from '@memohai/web/pages/home/commands/w
 import { useWorkspaceTabsStore } from '@memohai/web/store/workspace-tabs'
 import { useKeyboardShortcutsStore } from '@memohai/web/store/keyboard-shortcuts'
 import { useChatStore } from '@memohai/web/store/chat-list'
+import { QUERY_CACHE_STORAGE_KEY, queryCachePersistFilter } from '@memohai/web/lib/query-cache-persistence'
 import { normalizeDesktopThemeSource } from '../../shared/theme'
 
 import '@fontsource-variable/inter'
@@ -121,7 +123,16 @@ async function bootstrap() {
 
   const app = createApp(App)
     .use(pinia)
-    .use(PiniaColada)
+    .use(PiniaColada, {
+      plugins: [
+        // Same cross-reload snapshot as the web app (see
+        // @memohai/web/lib/query-cache-persistence.ts).
+        PiniaColadaCachePersister({
+          key: QUERY_CACHE_STORAGE_KEY,
+          filter: queryCachePersistFilter,
+        }),
+      ],
+    })
     .use(router)
     .use(i18n)
     .provide(KEYBOARD_REGISTRY, keyboardCommands)
@@ -167,6 +178,9 @@ async function bootstrap() {
     })
   })
 
+  // Mount only after the snapshot is hydrated so the first render already
+  // has the last-known values (storage is sync, so this resolves fast).
+  await isCacheReady()
   app.mount('#app')
 
   // The first frame stays optimistic: render the normal auth/app route while

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -133,15 +133,20 @@ async function bootstrap() {
   // The composer reads its agent list from the chat store's one-shot bot
   // snapshot, not the Colada cache, so the sync above can't refresh it. When the
   // settings window mutates bot config — enabling an ACP agent, renaming,
-  // switching model — it invalidates ['bots'] / ['bot', <id>]; mirror that into a
-  // store re-pull so the chat window's agent menu updates without a manual
-  // reload. (Web does this via its route watcher when leaving the settings
-  // overlay; desktop's chat window route never enters settings.)
+  // switching model — it invalidates the bots list / ['bot', <id>]; mirror that
+  // into a store re-pull so the chat window's agent menu updates without a
+  // manual reload. (Web does this via its route watcher when leaving the
+  // settings overlay; desktop's chat window route never enters settings.)
   const chatStore = useChatStore(pinia)
   window.api.desktop.onInvalidate((payload) => {
     const key = payload?.filters?.key
-    const head = Array.isArray(key) ? key[0] : undefined
-    if (head === 'bots' || head === 'bot') {
+    const head: unknown = Array.isArray(key) ? key[0] : undefined
+    // The bots list entry lives under the SDK-generated object key
+    // ([{ _id: 'getBots', … }]); accept the legacy string head 'bots' too so
+    // an older settings window's broadcast still lands.
+    const isBotsList = typeof head === 'object' && head !== null
+      && (head as { _id?: unknown })._id === 'getBots'
+    if (head === 'bots' || head === 'bot' || isBotsList) {
       void chatStore.refreshBots()
     }
   })

--- a/apps/desktop/src/renderer/types/web-stubs.d.ts
+++ b/apps/desktop/src/renderer/types/web-stubs.d.ts
@@ -299,6 +299,12 @@ declare module '@memohai/web/lib/auth-session' {
   export function notifyAuthSessionCleared(reason: AuthSessionClearReason): void
 }
 
+declare module '@memohai/web/lib/query-cache-persistence' {
+  import type { UseQueryEntryFilter } from '@pinia/colada'
+  export const QUERY_CACHE_STORAGE_KEY: string
+  export const queryCachePersistFilter: UseQueryEntryFilter
+}
+
 declare module '@memohai/web/pages/login/transition' {
   export const LOGIN_ENTRY_ANIMATION_KEY: string
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "@memohai/icon": "workspace:*",
     "@memohai/sdk": "workspace:*",
     "@pinia/colada": "^0.21.2",
+    "@pinia/colada-plugin-cache-persister": "0.1.3",
     "@shikijs/transformers": "^4.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/vue-table": "^8.21.3",

--- a/apps/web/src/components/sidebar/panel-schedule.vue
+++ b/apps/web/src/components/sidebar/panel-schedule.vue
@@ -107,7 +107,6 @@ import { useI18n } from 'vue-i18n'
 import { storeToRefs } from 'pinia'
 import { Plus } from 'lucide-vue-next'
 import { ConfirmDeleteDialog, toast } from '@felinic/ui'
-import { useQueryCache } from '@pinia/colada'
 import {
   Button, Spinner,
 } from '@felinic/ui'
@@ -129,7 +128,6 @@ const chatStore = useChatStore()
 const { currentBotId } = storeToRefs(chatStore)
 const workspaceTabs = useWorkspaceTabsStore()
 const { sidebarView } = storeToRefs(workspaceTabs)
-const queryCache = useQueryCache()
 
 const isLoading = ref(false)
 const schedules = ref<ScheduleSchedule[]>([])
@@ -246,18 +244,6 @@ watch(sidebarView, (view) => {
   if (view === 'schedule') void fetchSchedules()
 })
 
-// Refresh when bot-schedule.vue invalidates the cache (after create/edit/delete)
-watch(
-  () => {
-    const entries = queryCache.getEntries({ key: ['bot-schedule', currentBotId.value ?? ''] })
-    return entries[0]?.state.value.data
-  },
-  (next, prev) => {
-    if (!currentBotId.value || next === prev) return
-    void fetchSchedules()
-  },
-)
-
 // Refresh when active bot changes
 watch(currentBotId, () => void fetchSchedules())
 
@@ -292,7 +278,6 @@ async function handleToggleEnabled(item: ScheduleSchedule, enabled: boolean) {
       throwOnError: true,
     })
     await fetchSchedules()
-    queryCache.invalidateQueries({ key: ['bot-schedule', botId] })
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.schedule.saveFailed')))
   } finally {

--- a/apps/web/src/composables/useProviderModelCatalog.test.ts
+++ b/apps/web/src/composables/useProviderModelCatalog.test.ts
@@ -34,7 +34,6 @@ describe('useProviderModelCatalog', () => {
     expect(mocks.invalidateQueries.mock.calls).toEqual([
       [{ key: ['provider-models'] }],
       [{ key: ['models'] }],
-      [{ key: ['all-models'] }],
     ])
   })
 })

--- a/apps/web/src/composables/useProviderModelCatalog.ts
+++ b/apps/web/src/composables/useProviderModelCatalog.ts
@@ -1,7 +1,7 @@
 import { useQueryCache } from '@pinia/colada'
 import { postProvidersByIdImportModels } from '@memohai/sdk'
 
-const MODEL_QUERY_KEYS = ['provider-models', 'models', 'all-models'] as const
+const MODEL_QUERY_KEYS = ['provider-models', 'models'] as const
 
 export function useProviderModelCatalog() {
   const queryCache = useQueryCache()

--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -1,3 +1,5 @@
+import { QUERY_CACHE_STORAGE_KEY } from './query-cache-persistence'
+
 export type AuthSessionClearReason = 'login' | 'logout' | 'token-cleared' | 'unauthorized'
 
 export interface AuthSessionClearedDetail {
@@ -21,6 +23,9 @@ const USER_SCOPED_STORAGE_KEYS = [
   // Was 'workspace-tabs' — a long-dead key. The live dockview layout key is
   // 'workspace-layout'; logout never actually cleared it before this fix.
   'workspace-layout',
+  // Cross-reload query-cache snapshot (lib/query-cache-persistence.ts) —
+  // without this the next account would see the previous one's catalog data.
+  QUERY_CACHE_STORAGE_KEY,
 ]
 
 export function clearPersistedUserScopedState() {

--- a/apps/web/src/lib/query-cache-persistence.test.ts
+++ b/apps/web/src/lib/query-cache-persistence.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import type { UseQueryEntry } from '@pinia/colada'
+import { QUERY_CACHE_STORAGE_KEY, queryCachePersistFilter } from './query-cache-persistence'
+
+// The predicate only reads entry.key[0] and entry.state.value.status, so a
+// minimal stub beats constructing a full UseQueryEntry.
+function entryWith(key: readonly unknown[], status: 'success' | 'pending' | 'error' = 'success') {
+  return { key, state: { value: { status } } } as unknown as UseQueryEntry
+}
+
+const { predicate } = queryCachePersistFilter as {
+  predicate: (entry: UseQueryEntry) => boolean
+}
+
+describe('queryCachePersistFilter', () => {
+  it('persists whitelisted catalog and config namespaces', () => {
+    const allowed = [
+      ['models'],
+      ['providers'],
+      ['provider-models', 'provider-1'],
+      ['memory-providers'],
+      ['search-providers-meta'],
+      ['speech-provider-models', 'sp-1'],
+      ['transcription-providers'],
+      ['video-provider-detail', 'vp-1'],
+      ['acp-profiles'],
+      ['channels'],
+      ['connectors-catalog'],
+      ['remote-runtimes'],
+      ['platform'],
+      ['bot', 'bot-1'],
+      ['bot-settings', 'bot-1'],
+    ]
+    for (const key of allowed) {
+      expect(predicate(entryWith(key)), `expected ${key[0]} to persist`).toBe(true)
+    }
+  })
+
+  it('persists the SDK-object bots list key', () => {
+    expect(predicate(entryWith([{ _id: 'getBots', baseUrl: 'http://x' }]))).toBe(true)
+  })
+
+  it('rejects volatile and unknown namespaces', () => {
+    const rejected = [
+      ['session-status', 'b', 's'],
+      ['session-subagents', 'b', 's'],
+      ['token-usage', 'b'],
+      ['bot-email-outbox', 'b'],
+      ['bot-container-overview', 'b'],
+      ['bot-display-info', 'b'],
+      ['bot-network-status', 'b'],
+      ['bot-memory-status', 'b'],
+      ['my-channel-identities'],
+      ['user-has-im-bot'],
+      ['something-new'],
+    ]
+    for (const key of rejected) {
+      expect(predicate(entryWith(key)), `expected ${key[0]} to be excluded`).toBe(false)
+    }
+  })
+
+  it('rejects object keys with other operations', () => {
+    expect(predicate(entryWith([{ _id: 'getBotsByBotIdSessions', baseUrl: 'http://x' }]))).toBe(false)
+  })
+
+  it('rejects non-success entries even for whitelisted keys', () => {
+    expect(predicate(entryWith(['models'], 'pending'))).toBe(false)
+    expect(predicate(entryWith(['models'], 'error'))).toBe(false)
+  })
+})
+
+describe('QUERY_CACHE_STORAGE_KEY', () => {
+  it('is the contract auth-session.ts clears on auth changes', () => {
+    expect(QUERY_CACHE_STORAGE_KEY).toBe('memoh:query-cache')
+  })
+})

--- a/apps/web/src/lib/query-cache-persistence.ts
+++ b/apps/web/src/lib/query-cache-persistence.ts
@@ -1,0 +1,96 @@
+import type { UseQueryEntryFilter } from '@pinia/colada'
+
+/**
+ * Cross-reload persistence for the Pinia Colada query cache.
+ *
+ * The cache is memory-only by default, so a hard refresh cold-starts every
+ * useQuery and settings pages render placeholders for at least one RTT
+ * (visible against any remote server, and on every desktop app launch).
+ * The persister plugin snapshots WHITELISTED entries to localStorage and
+ * rehydrates them on boot. Hydrated entries are always older than the
+ * default 5s staleTime, so colada revalidates them in the background on
+ * mount (SWR) — the snapshot only owes the first paint; correctness always
+ * comes from the network.
+ *
+ * Whitelist, never blacklist: a query is only persisted when named here, so
+ * newly added queries default to safe. Only semi-static catalog/config data
+ * qualifies — its writes flow through this app's mutations (which re-persist
+ * via the plugin), and out-of-band writes (channel slash commands, other
+ * devices) converge on the next mount revalidation. Volatile data (sessions,
+ * usage, container/status, outbox) stays out: freshness matters more than
+ * first paint there, and its invalidation surface is much larger.
+ */
+
+/**
+ * localStorage key shared by the web app and the desktop renderer. Cleared
+ * with the other user-scoped keys on login/logout/token-cleared/unauthorized
+ * — see USER_SCOPED_STORAGE_KEYS in lib/auth-session.ts.
+ */
+export const QUERY_CACHE_STORAGE_KEY = 'memoh:query-cache'
+
+/**
+ * First key segment (the string namespace) of every query allowed to
+ * persist. Keep in sync with the real call sites: a name no query uses is a
+ * harmless no-op, a missing name means that query never persists.
+ */
+const PERSISTED_QUERY_KEY_HEADS: ReadonlySet<string> = new Set([
+  // Global catalogs
+  'models',
+  'providers',
+  'provider-models',
+  'provider-templates',
+  'provider-template-models',
+  'memory-providers',
+  'memory-providers-meta',
+  'email-providers',
+  'email-providers-meta',
+  'search-providers',
+  'search-providers-meta',
+  'fetch-providers',
+  'fetch-providers-meta',
+  'speech-providers',
+  'speech-providers-meta',
+  'speech-provider-detail',
+  'speech-provider-models',
+  'transcription-providers',
+  'transcription-providers-meta',
+  'transcription-provider-detail',
+  'transcription-provider-models',
+  'video-providers',
+  'video-providers-meta',
+  'video-provider-detail',
+  'video-provider-models',
+  'acp-profiles',
+  'channels',
+  'connectors-catalog',
+  'network-providers-meta',
+  'remote-runtimes',
+  'platform',
+  // Per-bot identity + settings — the Bot Settings cold-start flash reads
+  // its model UUID from 'bot-settings' and the display name from 'models'.
+  'bot',
+  'bot-settings',
+])
+
+/**
+ * The bots list is the one query keyed by the SDK-generated object form
+ * ([{ _id: 'getBots', baseUrl, … }]) instead of a string namespace.
+ */
+function isBotsListKeyHead(head: unknown): boolean {
+  return typeof head === 'object' && head !== null
+    && (head as { _id?: unknown })._id === 'getBots'
+}
+
+/**
+ * Persistence filter for PiniaColadaCachePersister: which entries are
+ * written to and restored from the snapshot. Error/pending entries are
+ * excluded so a transient failure never gets frozen into the snapshot.
+ */
+export const queryCachePersistFilter: UseQueryEntryFilter = {
+  predicate: (entry) => {
+    if (entry.state.value.status !== 'success') return false
+    const head = entry.key[0]
+    if (typeof head === 'string') return PERSISTED_QUERY_KEY_HEADS.has(head)
+    return isBotsListKeyHead(head)
+  },
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -19,7 +19,9 @@ import { useKeyboardShortcutsStore } from './store/keyboard-shortcuts'
 import { createPinia } from 'pinia'
 import i18n from './i18n'
 import { PiniaColada } from '@pinia/colada'
+import { PiniaColadaCachePersister, isCacheReady } from '@pinia/colada-plugin-cache-persister'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
+import { QUERY_CACHE_STORAGE_KEY, queryCachePersistFilter } from './lib/query-cache-persistence'
 import 'katex/dist/katex.min.css'
 
 setupApiClient({
@@ -57,7 +59,16 @@ const forceDesktopShell =
 
 const app = createApp(App)
   .use(pinia)
-  .use(PiniaColada)
+  .use(PiniaColada, {
+    plugins: [
+      // Persist whitelisted catalog/config queries across reloads; hydrated
+      // entries revalidate on mount (see lib/query-cache-persistence.ts).
+      PiniaColadaCachePersister({
+        key: QUERY_CACHE_STORAGE_KEY,
+        filter: queryCachePersistFilter,
+      }),
+    ],
+  })
   .use(router)
   .use(i18n)
   .provide(KEYBOARD_REGISTRY, keyboardCommands)
@@ -66,4 +77,6 @@ if (forceDesktopShell) {
   app.provide(DesktopShellKey, true)
 }
 
-app.mount('#app')
+// Mount only after the snapshot is hydrated so the first render already has
+// the last-known values (storage is sync, so this resolves in a microtask).
+void isCacheReady().then(() => app.mount('#app'))

--- a/apps/web/src/pages/bots/components/bot-acp.vue
+++ b/apps/web/src/pages/bots/components/bot-acp.vue
@@ -137,6 +137,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 import { useMutation, useQuery, useQueryCache } from '@pinia/colada'
 import { getAcpProfiles, getBotsById, putBotsById } from '@memohai/sdk'
+import { getBotsQueryKey } from '@memohai/sdk/colada'
 import type { AcpprofilePublicProfile, BotsUpdateBotRequest } from '@memohai/sdk'
 import type { Ref } from 'vue'
 import SettingsAcpDetail from './settings-acp-detail.vue'
@@ -213,7 +214,7 @@ const { mutateAsync: updateBot } = useMutation({
   },
   onSettled: () => {
     queryCache.invalidateQueries({ key: ['bot', botIdRef.value] })
-    queryCache.invalidateQueries({ key: ['bots'] })
+    queryCache.invalidateQueries({ key: getBotsQueryKey() })
     void chatStore.refreshBots().catch(() => {})
   },
 })

--- a/apps/web/src/pages/bots/components/bot-schedule.vue
+++ b/apps/web/src/pages/bots/components/bot-schedule.vue
@@ -140,7 +140,6 @@ import {
 import { ref, computed, onMounted, reactive, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { InlineLoadingRow, PageShell, toast } from '@felinic/ui'
-import { useQueryCache } from '@pinia/colada'
 import {
   Button,
   Dialog, DialogContent, DialogScrollContent, DialogHeader, DialogTitle, DialogFooter,
@@ -223,7 +222,6 @@ async function confirmDelete() {
     toast.success(t('bots.schedule.deleteSuccess'))
     deleteTarget.value = null
     await fetchSchedules()
-    invalidateSidebarSchedule()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.schedule.deleteFailed')))
   } finally {
@@ -247,11 +245,6 @@ function describeItem(pattern: string | undefined): string | undefined {
 }
 
 // --- API ---
-const queryCache = useQueryCache()
-function invalidateSidebarSchedule() {
-  queryCache.invalidateQueries({ key: ['bot-schedule', props.botId] })
-}
-
 async function fetchSchedules() {
   if (!props.botId) return
   isLoading.value = true
@@ -308,7 +301,6 @@ async function handleEditorSaved() {
   formVisible.value = false
   editingSchedule.value = null
   await fetchSchedules()
-  invalidateSidebarSchedule()
 }
 
 async function handleToggleEnabled(item: ScheduleSchedule, enabled: boolean) {
@@ -318,7 +310,6 @@ async function handleToggleEnabled(item: ScheduleSchedule, enabled: boolean) {
   try {
     await putBotsByBotIdScheduleById({ path: { bot_id: props.botId, id }, body: { enabled }, throwOnError: true })
     await fetchSchedules()
-    invalidateSidebarSchedule()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.schedule.saveFailed')))
   } finally {
@@ -330,17 +321,6 @@ onMounted(() => {
   fetchSchedules()
   fetchBotSettings()
 })
-
-watch(
-  () => {
-    const entries = queryCache.getEntries({ key: ['bot-schedule', props.botId] })
-    return entries[0]?.state.value.data
-  },
-  (next, prev) => {
-    if (!props.botId || next === prev) return
-    void fetchSchedules()
-  },
-)
 
 watch(
   () => props.initialScheduleId,

--- a/apps/web/src/pages/bots/components/bot-settings.vue
+++ b/apps/web/src/pages/bots/components/bot-settings.vue
@@ -103,6 +103,7 @@ import {
   Input,
 } from '@felinic/ui'
 import { Check, X, LoaderCircle } from 'lucide-vue-next'
+import { getBotsQueryKey } from '@memohai/sdk/colada'
 import { reactive, ref, computed, watch, onMounted, onActivated, nextTick } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { useRouter, useRoute } from 'vue-router'
@@ -180,7 +181,7 @@ const { data: bot } = useQuery({
 })
 
 const { data: modelData } = useQuery({
-  key: ['all-models'],
+  key: ['models'],
   query: async () => {
     const { data } = await getModels({ throwOnError: true })
     return data
@@ -188,7 +189,7 @@ const { data: modelData } = useQuery({
 })
 
 const { data: providerData } = useQuery({
-  key: ['all-providers'],
+  key: ['providers'],
   query: async () => {
     const { data } = await getProviders({ throwOnError: true })
     return data
@@ -204,7 +205,7 @@ const { data: acpProfileData } = useQuery({
 })
 
 const { data: searchProviderData } = useQuery({
-  key: ['all-search-providers'],
+  key: ['search-providers'],
   query: async () => {
     const { data } = await getSearchProviders({ throwOnError: true })
     return data
@@ -212,7 +213,7 @@ const { data: searchProviderData } = useQuery({
 })
 
 const { data: fetchProviderData } = useQuery({
-  key: ['all-fetch-providers'],
+  key: ['fetch-providers'],
   query: async () => {
     const { data } = await getFetchProviders({ throwOnError: true })
     return data
@@ -220,7 +221,7 @@ const { data: fetchProviderData } = useQuery({
 })
 
 const { data: memoryProviderData } = useQuery({
-  key: ['all-memory-providers'],
+  key: ['memory-providers'],
   query: async () => {
     const { data } = await getMemoryProviders({ throwOnError: true })
     return data
@@ -280,7 +281,7 @@ const { mutateAsync: deleteBot, isLoading: deleteLoading } = useMutation({
     await deleteBotsById({ path: { id: botIdRef.value }, throwOnError: true })
   },
   onSettled: () => {
-    queryCache.invalidateQueries({ key: ['bots'] })
+    queryCache.invalidateQueries({ key: getBotsQueryKey() })
     queryCache.invalidateQueries({ key: ['bot'] })
   },
 })
@@ -556,7 +557,7 @@ function onDrained(savedKeys: Set<keyof SettingsForm>) {
   // The sidebar lists bots by name; nothing else on this page is visible
   // there, so the expensive full-list refetch only fires for renames.
   if (savedKeys.has('name')) {
-    queryCache.invalidateQueries({ key: ['bots'] })
+    queryCache.invalidateQueries({ key: getBotsQueryKey() })
     void chatStore.refreshBots().catch(() => {})
   }
 }
@@ -578,7 +579,7 @@ function isNameConflict(error: unknown): boolean {
 }
 
 function handleBackupImported(botId: string) {
-  queryCache.invalidateQueries({ key: ['bots'] })
+  queryCache.invalidateQueries({ key: getBotsQueryKey() })
   if (botId && botId !== props.botId) {
     router.push({ name: 'bot-detail', params: { botId } })
     return

--- a/apps/web/src/pages/bots/components/bot-skills.vue
+++ b/apps/web/src/pages/bots/components/bot-skills.vue
@@ -386,10 +386,6 @@ const props = defineProps<{
 const { t } = useI18n()
 const queryCache = useQueryCache()
 
-function invalidateSidebarSkills() {
-  queryCache.invalidateQueries({ key: ['bot-skills-catalog', props.botId] })
-}
-
 const MANAGED_SKILL_PATH = '/data/skills'
 const DEFAULT_DISCOVERY_ROOTS = ['/data/.agents/skills', '/root/.agents/skills']
 const RESERVED_DISCOVERY_ROOTS = new Set(['/data/skills', '/data/.skills'])
@@ -661,7 +657,6 @@ async function handleSkillAction(action: 'adopt' | 'disable' | 'enable', skill: 
           : t('bots.skills.enableSuccess'),
     )
     await fetchSkills()
-    invalidateSidebarSkills()
   } catch (error) {
     toast.error(resolveApiErrorMessage(
       error,
@@ -692,7 +687,6 @@ async function handleSave() {
     toast.success(t('bots.skills.saveSuccess'))
     isDialogOpen.value = false
     await fetchSkills()
-    invalidateSidebarSkills()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.skills.saveFailed')))
   } finally {
@@ -749,7 +743,6 @@ async function handleDelete(name?: string) {
     })
     toast.success(t('bots.skills.deleteSuccess'))
     await fetchSkills()
-    invalidateSidebarSkills()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.skills.deleteFailed')))
   } finally {
@@ -764,19 +757,6 @@ watch(() => props.botId, () => {
   syncDiscoveryRoots(DEFAULT_DISCOVERY_ROOTS)
   void fetchSkills()
 }, { immediate: true })
-
-// Refresh local skills list when chat-sidebar invalidates the shared catalog cache.
-watch(
-  () => {
-    const entries = queryCache.getEntries({ key: ['bot-skills-catalog', props.botId] })
-    return entries[0]?.state.value.data
-  },
-  (next, prev) => {
-    if (!props.botId) return
-    if (next === prev) return
-    void fetchSkills()
-  },
-)
 
 watch(bot, (value) => {
   if (!value) return

--- a/apps/web/src/pages/bots/components/memory-advanced-actions.vue
+++ b/apps/web/src/pages/bots/components/memory-advanced-actions.vue
@@ -105,7 +105,7 @@ const { data: settings } = useQuery({
 })
 
 const { data: memoryProviderData } = useQuery({
-  key: ['all-memory-providers'],
+  key: ['memory-providers'],
   query: async () => {
     const { data } = await getMemoryProviders({ throwOnError: true })
     return data

--- a/apps/web/src/pages/bots/components/settings-acp-detail.vue
+++ b/apps/web/src/pages/bots/components/settings-acp-detail.vue
@@ -298,6 +298,7 @@ import {
   type AcpprofilePublicProfile,
 } from '@memohai/sdk'
 import { useACPOAuth } from '@/composables/useACPOAuth'
+import { getBotsQueryKey } from '@memohai/sdk/colada'
 import {
   HERMES_CUSTOM_MODEL_VALUE,
   HERMES_PROVIDER_PRESETS,
@@ -582,7 +583,7 @@ function claudeOAuthTextClass(): string {
 
 function invalidateOAuthQueries() {
   void queryCache.invalidateQueries({ key: ['bot', props.botId] })
-  void queryCache.invalidateQueries({ key: ['bots'] })
+  void queryCache.invalidateQueries({ key: getBotsQueryKey() })
 }
 
 function markCodexOAuthAuthorized() {

--- a/apps/web/src/pages/home/components/dockview/panel-schedule.vue
+++ b/apps/web/src/pages/home/components/dockview/panel-schedule.vue
@@ -52,7 +52,6 @@ import { onBeforeUnmount, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { ConfirmDeleteDialog, InlineLoadingRow, toast } from '@felinic/ui'
-import { useQueryCache } from '@pinia/colada'
 import {
   deleteBotsByBotIdScheduleById,
   getBotsByBotIdScheduleById,
@@ -74,7 +73,6 @@ const props = defineProps<{
 const { t } = useI18n()
 const chatStore = useChatStore()
 const { currentBotId } = storeToRefs(chatStore)
-const queryCache = useQueryCache()
 
 const scheduleId = ref(typeof props.params.params.scheduleId === 'string' ? props.params.params.scheduleId : undefined)
 const schedule = ref<ScheduleSchedule | null>(null)
@@ -112,15 +110,8 @@ async function fetchSchedule() {
   }
 }
 
-function invalidateScheduleList() {
-  const botId = currentBotId.value
-  if (!botId) return
-  queryCache.invalidateQueries({ key: ['bot-schedule', botId] })
-}
-
 async function handleSaved() {
   toast.success(t('bots.schedule.saveSuccess'))
-  invalidateScheduleList()
   await fetchSchedule()
 }
 
@@ -139,7 +130,6 @@ async function confirmDelete() {
       throwOnError: true,
     })
     toast.success(t('bots.schedule.deleteSuccess'))
-    invalidateScheduleList()
     props.params.api.close()
   } catch (error) {
     toast.error(resolveApiErrorMessage(error, t('bots.schedule.deleteFailed')))

--- a/apps/web/src/pages/onboarding/steps/useProviderSetup.ts
+++ b/apps/web/src/pages/onboarding/steps/useProviderSetup.ts
@@ -291,7 +291,6 @@ export function useProviderSetup(options: {
       })
       queryCache.invalidateQueries({ key: ['provider-models'] })
       queryCache.invalidateQueries({ key: ['models'] })
-      queryCache.invalidateQueries({ key: ['all-models'] })
     } catch {
       // Non-fatal: the user will still see the model list and can enable
       // models manually if the auto-activate failed.

--- a/apps/web/src/pages/profile/index.vue
+++ b/apps/web/src/pages/profile/index.vue
@@ -158,7 +158,7 @@ const canSignOut = true
 const account = ref<UserAccount | null>(null)
 
 const { data: modelData } = useQuery({
-  key: ['all-models'],
+  key: ['models'],
   query: async () => {
     const { data } = await getModels({ throwOnError: true })
     return data
@@ -166,7 +166,7 @@ const { data: modelData } = useQuery({
 })
 
 const { data: providerData } = useQuery({
-  key: ['all-providers'],
+  key: ['providers'],
   query: async () => {
     const { data } = await getProviders({ throwOnError: true })
     return data

--- a/apps/web/src/pages/providers/components/model-item.vue
+++ b/apps/web/src/pages/providers/components/model-item.vue
@@ -226,11 +226,10 @@ async function handleToggleEnable(value: boolean) {
     }
     await putModelsById({ path: { id: props.model.id }, body, throwOnError: true })
     queryCache.invalidateQueries({ key: ['provider-models'] })
+    // The bot model picker shares this entry (bot-settings kept a separate
+    // ['all-models'] key until the two were unified), so one invalidation
+    // covers both pickers.
     queryCache.invalidateQueries({ key: ['models'] })
-    // bot-settings caches the full model list under ['all-models']; without
-    // this, the bot picker keeps a disabled model visible until the route
-    // remounts because the tab is kept alive.
-    queryCache.invalidateQueries({ key: ['all-models'] })
   } catch {
     enableOverride.value = prev
     toast.error(t('models.toggleFailed'))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@memohai/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
+      '@pinia/colada-plugin-cache-persister':
+        specifier: 0.1.3
+        version: 0.1.3(@pinia/colada@0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)))
       electron-updater:
         specifier: ^6.6.2
         version: 6.8.9
@@ -207,6 +210,9 @@ importers:
       '@pinia/colada':
         specifier: ^0.21.2
         version: 0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+      '@pinia/colada-plugin-cache-persister':
+        specifier: 0.1.3
+        version: 0.1.3(@pinia/colada@0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)))
       '@shikijs/transformers':
         specifier: ^4.0.1
         version: 4.0.1
@@ -1657,6 +1663,11 @@ packages:
   '@peculiar/webcrypto@1.7.1':
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
+
+  '@pinia/colada-plugin-cache-persister@0.1.3':
+    resolution: {integrity: sha512-26feFaIernj0OgC7V3xKlkpmGtnuep19gVJQO7Vt0yBv3wV+gMKa27JavlaXasfbSPMDBzHwSZyrR4ii4y6SQw==}
+    peerDependencies:
+      '@pinia/colada': '>=0.21.1'
 
   '@pinia/colada@0.21.2':
     resolution: {integrity: sha512-k2epk1jed5cTmNA7l00UtsFRyqw9HfyU6WO4cV0BMUT3sSE4CMLCilprbLAL5h2bxD76WSiglciI/6o+Uh7Vzw==}
@@ -6684,6 +6695,10 @@ snapshots:
       '@peculiar/utils': 2.0.3
       tslib: 2.8.1
       webcrypto-core: 1.9.2
+
+  '@pinia/colada-plugin-cache-persister@0.1.3(@pinia/colada@0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)))':
+    dependencies:
+      '@pinia/colada': 0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
 
   '@pinia/colada@0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
     dependencies:


### PR DESCRIPTION
## Summary

Closes #936. On a hard refresh, every `useQuery` cold-started (memory-only cache), so settings pages rendered placeholders for at least one RTT — e.g. Bot Settings → General flashed "Select Model" → raw UUID → real name. Invisible on localhost; obvious on a remote deployment (100–300 ms RTT) and on **every desktop app launch**.

While mapping the query layer for this, two latent problems surfaced that persistence would have amplified (a missed invalidation today costs ~5s of staleness; with a persisted snapshot it would survive restarts), so the PR fixes the foundation first:

1. **`fix(web)` — unify duplicated catalog query keys.** The models/providers/memory/search/fetch catalogs were each cached under two keys (`['models']` vs `['all-models']`, …) for the same zero-param endpoint. One namespace could go stale while the other refreshed: Providers-page edits never reached the KeepAlive'd Bot Settings page. Also repairs five invalidations that used the string key `['bots']`, which never matches the bots list entry (it lives under the SDK-generated object key `[{ _id: 'getBots', … }]`); the desktop invalidation listener is updated to recognize the object form so the tray/composer agent list keeps refreshing.
2. **`chore(web)` — remove never-fired cross-panel refresh signals.** No `useQuery` ever registered `['bot-schedule', id]` or `['bot-skills-catalog', id]`: the invalidate calls matched zero entries and the `getEntries` watchers never fired once. The panels already fetch on mount/switch and after their own mutations, so **no observable behavior is removed** — the "cross-panel refresh" these calls imply has never existed. (Flagging explicitly: this is dead-code deletion, not a behavior change.)
3. **`feat(web)` — persist whitelisted query cache across reloads.** Registers `@pinia/colada-plugin-cache-persister` with a **whitelist** filter (semi-static catalog/config queries only: catalogs, provider metas, `bot`, `bot-settings`, the bots list). Hydrated entries are always past the default 5s `staleTime`, so colada revalidates them in the background on mount — the snapshot owes the first paint, correctness still comes from the network. Sessions/messages/usage/status queries are deliberately excluded. The snapshot key joins `USER_SCOPED_STORAGE_KEYS`, so login/logout/token-cleared/unauthorized all clear it (no cross-account leakage). Registered in both the web app and the desktop renderer.

## New dependency justification

`@pinia/colada-plugin-cache-persister`, pinned to exactly **0.1.3**:

- Official plugin by the Pinia Colada author (posva/pinia-colada repo), MIT, **zero runtime dependencies**, ~150 LoC.
- Version pin must not float: 0.1.4+ requires colada ≥1.0 while we run 0.21.2; 0.1.3 is the newest compatible release. Upgrade path: move to 1.1.0 together with the deferred colada 1.x bump.
- Hand-rolling was the alternative (colada exports `hydrateQueryCache`), but it relies on underscored internals; the official plugin is smaller than the code we'd own.

## Test plan

- [x] `pnpm vitest run` (apps/web): 106 files / 1007 tests green, including a new `query-cache-persistence.test.ts` covering the whitelist predicate
- [x] ESLint clean on all changed files
- [x] `vue-tsc` for desktop (`typecheck:web`) green
- [x] `vite build` (apps/web) green
- [ ] **Human QA (happy path):**
  1. Against a remote server, hard-refresh Bot Settings → General: the chat model label renders its last-known value immediately (no "Select Model" / raw-UUID flash), and a background revalidation request fires
  2. Edit a model on the Providers page → Bot Settings reflects it (unified key, no stale second namespace)
  3. Log out → log in as a different account: no previous account's catalog data flashes
  4. Desktop: cold start shows the same instant render; renaming a bot still refreshes the tray/composer agent menu (listener regression check)

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
