### PR TITLE
fix(bridge): delegate PID 1 reaping to tini

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -201,7 +201,7 @@ jobs:
         if: steps.should-build.outputs.skip != 'true' && env.PUSH != 'true' && matrix.image == 'workspace' && matrix.platform == 'linux/amd64'
         run: |
           docker run --rm memoh-ci-workspace:debian sh -eux -c '
-            grep -q "\"contract_version\": 1" /opt/memoh/workspace-contract.json
+            grep -q "\"contract_version\": 2" /opt/memoh/workspace-contract.json
             ldd --version >/dev/null
             node --version
             python3 --version

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"os"
@@ -25,6 +26,10 @@ const (
 )
 
 func main() {
+	os.Exit(runBridge())
+}
+
+func runBridge() int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -36,25 +41,12 @@ func main() {
 	startDisplaySupervisor(ctx)
 	startACPToolsProxy(ctx, reverseHTTP)
 
-	// PID 1 zombie reaping: when bridge runs as PID 1 inside a container,
-	// orphaned child processes become zombies unless reaped.
-	// On Linux 5.3+, Go's os/exec uses pidfd_open which avoids races between
-	// this reaper and cmd.Wait(). Kernels below 5.3 may see rare ECHILD errors.
-	go func() {
-		var status syscall.WaitStatus
-		for {
-			if _, err := syscall.Wait4(-1, &status, 0, nil); err != nil {
-				time.Sleep(time.Second)
-			}
-		}
-	}()
-
 	network := "unix"
 	address := os.Getenv("BRIDGE_SOCKET_PATH")
 	if tcpAddr := os.Getenv("BRIDGE_TCP_ADDR"); tcpAddr != "" {
 		if !isBridgeTCPListenAddrAllowed(tcpAddr) {
 			logger.Error("BRIDGE_TCP_ADDR must be loopback or use :port bind shorthand; explicit non-loopback TCP exposes bridge gRPC without TLS/auth", slog.String("addr", tcpAddr))
-			return
+			return 1
 		}
 		network = "tcp"
 		address = tcpAddr
@@ -70,7 +62,7 @@ func main() {
 	lis, err := (&net.ListenConfig{}).Listen(ctx, network, address)
 	if err != nil {
 		logger.Error("failed to listen", slog.String("network", network), slog.String("address", address), slog.Any("error", err))
-		return
+		return 1
 	}
 
 	serverOpts := []grpc.ServerOption{
@@ -94,7 +86,7 @@ func main() {
 		creds, err := bridgeServerCredentials()
 		if err != nil {
 			logger.Error("bridge TLS configuration invalid", slog.Any("error", err))
-			return
+			return 1
 		}
 		if creds != nil {
 			serverOpts = append(serverOpts, grpc.Creds(creds))
@@ -110,17 +102,38 @@ func main() {
 	}))
 	reflection.Register(srv)
 
+	shutdownDone := make(chan struct{})
 	go func() {
-		<-ctx.Done()
-		logger.FromContext(ctx).Info("shutting down gRPC server")
-		srv.GracefulStop()
+		stopBridgeGRPCServer(ctx, srv)
+		close(shutdownDone)
 	}()
 
 	logger.Info("bridge gRPC server listening", slog.String("network", network), slog.String("address", address))
-	if err := srv.Serve(lis); err != nil {
-		logger.Error("gRPC server failed", slog.Any("error", err))
-		return
+	serveErr := srv.Serve(lis)
+	unexpectedServeErr := serveErr != nil && !errors.Is(serveErr, grpc.ErrServerStopped)
+	if unexpectedServeErr {
+		stop()
 	}
+	if ctx.Err() != nil {
+		<-shutdownDone
+	}
+	if unexpectedServeErr {
+		logger.Error("gRPC server failed", slog.Any("error", serveErr))
+		return 1
+	}
+	return 0
+}
+
+func stopBridgeGRPCServer(ctx context.Context, srv *grpc.Server) {
+	<-ctx.Done()
+	logger.FromContext(ctx).Info("shutting down gRPC server")
+	// Bridge Exec streams can legitimately live for the lifetime of an ACP
+	// process, so graceful draining has no useful upper bound here. Calling
+	// GracefulStop and Stop concurrently can also deadlock inside grpc-go when
+	// an active handler ignores cancellation. Stop closes transports and
+	// returns without waiting for those handlers, allowing the container's init
+	// process to complete shutdown.
+	srv.Stop()
 }
 
 func isBridgeTCPListenAddrAllowed(addr string) bool {

--- a/cmd/bridge/main_test.go
+++ b/cmd/bridge/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	pb "github.com/memohai/memoh/internal/workspace/bridgepb"
+)
+
+type blockingExecBridgeServer struct {
+	pb.UnimplementedContainerServiceServer
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingExecBridgeServer) Exec(pb.ContainerService_ExecServer) error {
+	close(s.started)
+	// Deliberately ignore stream cancellation. Positive-timeout bridge Exec
+	// handlers can do the same while their child process is still running.
+	<-s.release
+	return nil
+}
+
+func TestBridgeGRPCShutdownStopsActiveStreams(t *testing.T) {
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	service := &blockingExecBridgeServer{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	defer close(service.release)
+	server := grpc.NewServer()
+	pb.RegisterContainerServiceServer(server, service)
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- server.Serve(listener) }()
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		server.Stop()
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	streamCtx, streamCancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer streamCancel()
+	stream, err := pb.NewContainerServiceClient(conn).Exec(streamCtx)
+	if err != nil {
+		server.Stop()
+		t.Fatalf("open exec stream: %v", err)
+	}
+	if err := stream.Send(&pb.ExecInput{Command: "sleep forever"}); err != nil {
+		server.Stop()
+		t.Fatalf("start exec stream: %v", err)
+	}
+	select {
+	case <-service.started:
+	case <-time.After(time.Second):
+		server.Stop()
+		t.Fatal("exec stream did not start")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	shutdownDone := make(chan struct{})
+	go func() {
+		stopBridgeGRPCServer(ctx, server)
+		close(shutdownDone)
+	}()
+	cancel()
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		server.Stop()
+		t.Fatal("bridge shutdown did not finish")
+	}
+	if _, err := stream.Recv(); err == nil {
+		t.Fatal("active exec stream survived forced bridge shutdown")
+	}
+	select {
+	case err := <-serveDone:
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Fatalf("serve returned %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gRPC Serve did not return after shutdown")
+	}
+}

--- a/docker/Dockerfile.workspace
+++ b/docker/Dockerfile.workspace
@@ -81,6 +81,7 @@ COPY --from=toolkit-builder /opt/memoh/toolkit /opt/memoh/toolkit
 COPY scripts/desktop-style.sh scripts/display-apply-style.sh scripts/display-prepare.sh /opt/memoh/scripts/
 COPY docker/workspace-contract.json /opt/memoh/workspace-contract.json
 RUN chmod 0755 /opt/memoh/scripts/*.sh \
+  && test -x /usr/bin/tini \
   && test -x /opt/memoh/toolkit/bin/node \
   && test -x /opt/memoh/toolkit/bin/python3 \
   && test -x /opt/memoh/toolkit/bin/uv \
@@ -91,7 +92,7 @@ FROM workspace AS toolkit-acp-bridge-live
 COPY --from=bridge-builder /out/bridge /usr/local/bin/bridge
 ENV BRIDGE_TCP_ADDR=:1455
 EXPOSE 1455
-ENTRYPOINT ["/usr/local/bin/bridge"]
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/bridge"]
 
 # Keep the default build output equal to the production workspace target.
 FROM workspace AS final

--- a/docker/workspace-contract.json
+++ b/docker/workspace-contract.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": 1,
+  "contract_version": 2,
   "platform": {
     "os": "linux",
     "libc": "glibc"

--- a/internal/container/docker/service.go
+++ b/internal/container/docker/service.go
@@ -135,7 +135,6 @@ func (s *Service) CreateContainer(ctx context.Context, req containerapi.CreateCo
 	hostCfg := &container.HostConfig{
 		Mounts: toDockerMounts(req.Spec.Mounts),
 		DNS:    req.Spec.DNS,
-		Init:   boolPtr(true),
 		PortBindings: nat.PortMap{
 			nat.Port(bridgeTCPPort + "/tcp"): []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: ""}},
 		},
@@ -538,8 +537,6 @@ func hasReadonlyOption(options []string) bool {
 	}
 	return false
 }
-
-func boolPtr(v bool) *bool { return &v }
 
 func cloneLabels(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))

--- a/internal/workspace/contract.go
+++ b/internal/workspace/contract.go
@@ -13,9 +13,11 @@ import (
 
 const (
 	WorkspaceContractPath           = "/opt/memoh/workspace-contract.json"
-	CurrentWorkspaceContractVersion = 1
+	CurrentWorkspaceContractVersion = 2
 	WorkspaceToolkitDir             = "/opt/memoh/toolkit"
 	WorkspaceScriptsDir             = "/opt/memoh/scripts"
+	WorkspaceInitPath               = "/usr/bin/tini"
+	WorkspaceBridgePath             = "/opt/memoh/bridge"
 )
 
 var ErrWorkspaceImageIncompatible = errors.New("workspace image is incompatible")
@@ -37,6 +39,7 @@ type WorkspaceContractPaths struct {
 }
 
 var requiredWorkspaceExecutables = []string{
+	WorkspaceInitPath,
 	WorkspaceToolkitDir + "/bin/node",
 	WorkspaceToolkitDir + "/bin/python3",
 	WorkspaceToolkitDir + "/bin/uv",

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -548,7 +548,7 @@ func (m *Manager) buildWorkspaceContainerSpec(ctx context.Context, botID string,
 			Options:     []string{"rbind", "ro"},
 		},
 		{
-			Destination: "/opt/memoh/bridge",
+			Destination: WorkspaceBridgePath,
 			Type:        "bind",
 			Source:      bridgePath,
 			Options:     []string{"bind", "ro"},
@@ -594,7 +594,7 @@ func (m *Manager) buildWorkspaceContainerSpec(ctx context.Context, botID string,
 	env = append(env, skillEnv...)
 
 	return ctr.ContainerSpec{
-		Cmd:        []string{"/opt/memoh/bridge"},
+		Cmd:        []string{WorkspaceInitPath, "-g", "--", WorkspaceBridgePath},
 		Mounts:     mounts,
 		Env:        env,
 		CDIDevices: normalizeWorkspaceGPUDevices(gpu.Devices),

--- a/internal/workspace/manager_legacy_test.go
+++ b/internal/workspace/manager_legacy_test.go
@@ -237,10 +237,13 @@ func TestBuildWorkspaceContainerSpecInjectsBridgeTLSMaterial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build spec: %v", err)
 	}
+	if got, want := strings.Join(spec.Cmd, " "), WorkspaceInitPath+" -g -- "+WorkspaceBridgePath; got != want {
+		t.Fatalf("workspace command = %q, want %q", got, want)
+	}
 
 	var foundMount, foundBridgeMount bool
 	for _, mount := range spec.Mounts {
-		if mount.Destination == "/opt/memoh/bridge" {
+		if mount.Destination == WorkspaceBridgePath {
 			foundBridgeMount = true
 			if mount.Source != bridgePath {
 				t.Fatalf("bridge mount source = %q, want %q", mount.Source, bridgePath)

--- a/scripts/desktop-install.sh
+++ b/scripts/desktop-install.sh
@@ -257,7 +257,7 @@ install_debian() {
     apt_get install -y --no-install-recommends apt-utils
   fi
   progress 42 installing "Installing VNC, desktop, accessibility, and CJK fonts"
-  apt_get install -y --no-install-recommends ca-certificates curl gnupg dbus-x11 x11-xserver-utils xterm xfce4 xfce4-terminal tigervnc-standalone-server fontconfig fonts-dejavu fonts-noto-cjk fonts-noto-color-emoji procps at-spi2-core
+  apt_get install -y --no-install-recommends ca-certificates curl gnupg dbus-x11 x11-xserver-utils xterm xfce4 xfce4-terminal tigervnc-standalone-server fontconfig fonts-dejavu fonts-noto-cjk fonts-noto-color-emoji procps at-spi2-core tini
   install_debian_style_extras
   if ! find_browser >/dev/null 2>&1; then
     progress 66 browser "Installing browser"


### PR DESCRIPTION
## 背景

Linux workspace 中，bridge 原先无条件调用 `wait4(-1)` 回收子进程，同时业务命令由 `os/exec.Cmd.Wait` 等待退出。两者会争抢同一个退出状态；竞争命中时命令收到 `ECHILD`，表现为首次 ACP runtime 启动失败、重试后恢复。

## 修复

- 删除 bridge 内部的全局 reaper，让业务命令继续由 `os/exec` 独占等待
- 所有 workspace 后端统一通过 `tini -g -- /opt/memoh/bridge` 启动，由成熟的 init 负责孤儿进程回收与信号转发
- 移除 Docker 后端重复的 `HostConfig.Init`，避免双层 init
- workspace contract 升级到 v2，并要求镜像提供 `/usr/bin/tini`；标准 workspace 镜像已安装
- bridge gRPC 关闭使用同步 `Stop()`，避免长期 Exec stream 令 `GracefulStop()` 卡住

## 升级说明

现有 contract v1 workspace 需要重建一次以使用包含 `tini` 的新镜像；持久化的 `/data` 不受影响。

## 验证

- `go test -race ./cmd/bridge/...`
- `go test ./...`
- `golangci-lint run ./cmd/bridge/... ./internal/workspace/... ./internal/container/docker/...`
- `docker buildx build --check --file docker/Dockerfile.workspace .`
- 人工完成 contract v1 → v2 workspace 保留数据重建，重建后 `/data` 和 ACP 配置均正常
- 人工验证 Codex、Claude Code、Hermes 均可正常启动和执行命令

Fixes #945
