### PR TITLE
feat(web): elevate ACP agent choice to bot creation and onboarding

### DIFF
--- a/apps/web/src/composables/useAcpSetupModeItems.ts
+++ b/apps/web/src/composables/useAcpSetupModeItems.ts
@@ -1,0 +1,18 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { SegmentedItem } from '@felinic/ui'
+import type { AcpprofilePublicProfile } from '@memohai/sdk'
+import { acpSetupModeLabel, acpSetupModes } from '@/utils/acp/setup-fields'
+
+export function useAcpSetupModeItems(profile: MaybeRefOrGetter<AcpprofilePublicProfile>) {
+  const { t } = useI18n()
+
+  const setupModeItems = computed<SegmentedItem<string>[]>(() =>
+    acpSetupModes(toValue(profile)).map(mode => ({
+      value: mode,
+      label: acpSetupModeLabel(toValue(profile), mode, t),
+    })),
+  )
+
+  return { setupModeItems, setupModes: () => acpSetupModes(toValue(profile)) }
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1747,10 +1747,17 @@
       "securityDesc": "Access control",
       "model": "Model",
       "modelDesc": "Choose a chat model (optional)",
+      "agent": "Agent",
+      "agentDesc": "The hosted agent brings its own model.",
       "memory": "Memory",
       "memoryDesc": "Memory provider (optional)",
       "settings": "Settings",
       "settingsDesc": "Timezone and more"
+    },
+    "agentCreate": {
+      "typeAriaLabel": "Agent type",
+      "oauthSettingsHint": "Authorization happens after creation — finish it anytime in the bot's settings.",
+      "requiredError": "Please fill in \"{field}\""
     },
     "createBotLocalHint": "Local bots use a folder on this computer and are not sandboxed.",
     "create": {
@@ -3358,17 +3365,6 @@
         "manualAddBtn": "Add",
         "manualAddedCount": "{count} model(s) added",
         "removeModel": "Remove"
-      },
-      "acp": {
-        "setupMode": "Setup method",
-        "modeApiKey": "API key",
-        "modeChatGPT": "Sign in with ChatGPT",
-        "modeClaude": "Sign in with Claude",
-        "modeOAuth": "OAuth",
-        "modeSelf": "Local config",
-        "oauthDeferredHint": "Authorization happens in the next step, after the bot and its workspace are ready.",
-        "selfHint": "Reuses the agent already configured in the workspace.",
-        "requiredError": "Please fill in \"{field}\""
       }
     },
     "bot": {
@@ -3380,7 +3376,7 @@
         "hint": "Pick the model your bot replies with. Recommended, but you can change it anytime in settings."
       },
       "acp": {
-        "banner": "This bot will use {agent} as its primary agent",
+        "deferredHint": "Authorization happens in the next step, after the bot and its workspace are ready.",
         "oauthTitle": "Authorize {agent}",
         "oauthAuthorized": "Authorized",
         "oauthNotAuthorized": "Not authorized yet",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1736,10 +1736,17 @@
       "securityDesc": "アクセス制御",
       "model": "Model",
       "modelDesc": "チャット Modelを選択します (オプション)",
+      "agent": "エージェント",
+      "agentDesc": "ホステッドエージェントは独自のモデルを使用します。",
       "memory": "Memory",
       "memoryDesc": "MemoryProvider (オプション)",
       "settings": "設定",
       "settingsDesc": "タイムゾーンなど"
+    },
+    "agentCreate": {
+      "typeAriaLabel": "エージェントの種類",
+      "oauthSettingsHint": "認可は作成後に行います。Bot の設定でいつでも完了できます。",
+      "requiredError": "「{field}」を入力してください"
     },
     "createBotLocalHint": "ローカル Botはこのコンピューター上のフォルダーを使用し、サンドボックス化されていません。",
     "create": {
@@ -3335,17 +3342,6 @@
         "manualAddBtn": "追加",
         "manualAddedCount": "{count}件のモデルを追加しました",
         "removeModel": "削除"
-      },
-      "acp": {
-        "setupMode": "設定方法",
-        "modeApiKey": "APIキー",
-        "modeChatGPT": "ChatGPT でサインインする",
-        "modeClaude": "クロードでサインイン",
-        "modeOAuth": "OAuth",
-        "modeSelf": "ローカル構成",
-        "oauthDeferredHint": "認可は、Bot とワークスペースの準備ができた後の次のステップで行われます。",
-        "selfHint": "ワークスペースですでに設定されているエージェントを再利用します。",
-        "requiredError": "「{field}」と入力してください"
       }
     },
     "bot": {
@@ -3357,7 +3353,7 @@
         "hint": "Bot が応答に使用するモデルを選択します。推奨項目ですが、設定でいつでも変更できます。"
       },
       "acp": {
-        "banner": "このBotはプライマリ エージェントとして {agent} を使用します",
+        "deferredHint": "認可は、Bot とワークスペースの準備ができた後の次のステップで行われます。",
         "oauthTitle": "{agent}を承認する",
         "oauthAuthorized": "認可された",
         "oauthNotAuthorized": "まだ認可されていません",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1747,10 +1747,17 @@
       "securityDesc": "访问控制",
       "model": "模型",
       "modelDesc": "选择聊天模型（可选）",
+      "agent": "Agent",
+      "agentDesc": "托管 Agent 自带模型。",
       "memory": "记忆",
       "memoryDesc": "记忆提供者（可选）",
       "settings": "设置",
       "settingsDesc": "时区等"
+    },
+    "agentCreate": {
+      "typeAriaLabel": "Agent 类型",
+      "oauthSettingsHint": "授权在创建后进行，可随时在 Bot 设置中完成。",
+      "requiredError": "请填写「{field}」"
     },
     "createBotLocalHint": "Local Bot 会使用这台电脑上的文件夹，且不提供沙箱隔离。",
     "create": {
@@ -3358,17 +3365,6 @@
         "manualAddBtn": "添加",
         "manualAddedCount": "已添加 {count} 个模型",
         "removeModel": "移除"
-      },
-      "acp": {
-        "setupMode": "接入方式",
-        "modeApiKey": "API 密钥",
-        "modeChatGPT": "使用 ChatGPT 登录",
-        "modeClaude": "使用 Claude 登录",
-        "modeOAuth": "OAuth 授权",
-        "modeSelf": "使用本地配置",
-        "oauthDeferredHint": "授权将在下一步创建 Bot 并准备好工作区后进行。",
-        "selfHint": "沿用工作区中已配置好的 Agent。",
-        "requiredError": "请填写「{field}」"
       }
     },
     "bot": {
@@ -3380,7 +3376,7 @@
         "hint": "选择 Bot 回复时使用的模型。建议现在选择，之后也可随时在设置中更改。"
       },
       "acp": {
-        "banner": "该 Bot 将以 {agent} 作为主要智能体",
+        "deferredHint": "授权将在下一步创建 Bot 并准备好工作区后进行。",
         "oauthTitle": "授权 {agent}",
         "oauthAuthorized": "已授权",
         "oauthNotAuthorized": "尚未授权",

--- a/apps/web/src/pages/bots/components/acp-managed-fields.vue
+++ b/apps/web/src/pages/bots/components/acp-managed-fields.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+/* eslint-disable vue/no-mutating-props -- Parents pass a reactive managed map; field edits mutate in place like settings-acp-detail. */
+// Shared managed-field stack for ACP setup (create + settings). Parents own
+// setup_mode / OAuth; this component only renders the schema-driven fields.
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  FieldStack,
+  FormStack,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@felinic/ui'
+import type { AcpprofileManagedField, AcpprofilePublicProfile } from '@memohai/sdk'
+import {
+  HERMES_CUSTOM_MODEL_VALUE,
+  HERMES_PROVIDER_PRESETS,
+  hermesDefaultModel,
+  hermesModelPresets,
+  hermesModelSelectValue,
+  hermesProviderValue,
+  isHermesCustomProvider,
+  isHermesPresetModel,
+  normalizeACPAgentID,
+} from '@/utils/acp'
+import {
+  acpInputType,
+  acpManagedFieldAutocomplete,
+  acpManagedFieldHelp,
+  acpManagedFieldName,
+  acpManagedPlaceholder,
+} from '@/utils/acp/setup-fields'
+
+const props = withDefaults(defineProps<{
+  profile: AcpprofilePublicProfile
+  managed: Record<string, string>
+  fields: AcpprofileManagedField[]
+  fieldGap?: 'card' | 'bare'
+  /** Settings inputs get stable names and emit fieldCommit on native change. */
+  settingsMode?: boolean
+}>(), {
+  fieldGap: 'card',
+  settingsMode: false,
+})
+
+const emit = defineEmits<{
+  fieldChange: []
+  fieldCommit: []
+}>()
+
+const { t } = useI18n()
+
+const isHermes = computed(() => normalizeACPAgentID(props.profile.id) === 'hermes')
+const hermesProvider = computed(() => hermesProviderValue(props.managed.provider))
+const hermesModelOptions = computed(() => hermesModelPresets(hermesProvider.value))
+const hermesModelSelect = computed(() => hermesModelSelectValue(hermesProvider.value, props.managed.model))
+const hermesUsingCustomModel = computed(() => hermesModelSelect.value === HERMES_CUSTOM_MODEL_VALUE)
+
+function isHermesProviderField(field: AcpprofileManagedField): boolean {
+  return isHermes.value && normalizeACPAgentID(field.id) === 'provider'
+}
+
+function isHermesModelField(field: AcpprofileManagedField): boolean {
+  return isHermes.value && normalizeACPAgentID(field.id) === 'model'
+}
+
+function setManagedField(fieldID: string | undefined, value: string) {
+  const id = normalizeACPAgentID(fieldID)
+  if (!id) return
+  props.managed[id] = value
+  emit('fieldChange')
+}
+
+function setHermesProvider(value: string) {
+  const provider = hermesProviderValue(value)
+  props.managed.provider = provider
+  props.managed.model = hermesDefaultModel(provider)
+  if (!isHermesCustomProvider(provider)) props.managed.base_url = ''
+  emit('fieldChange')
+  if (props.settingsMode) emit('fieldCommit')
+}
+
+function setHermesModel(value: string) {
+  if (value === HERMES_CUSTOM_MODEL_VALUE) {
+    if (isHermesPresetModel(hermesProvider.value, props.managed.model)) {
+      props.managed.model = ''
+    }
+  } else {
+    props.managed.model = value
+  }
+  emit('fieldChange')
+  if (props.settingsMode) emit('fieldCommit')
+}
+
+function handleFieldInput(field: AcpprofileManagedField, value: string) {
+  setManagedField(field.id, value)
+}
+
+function handleFieldCommit() {
+  emit('fieldCommit')
+}
+</script>
+
+<template>
+  <FormStack>
+    <FieldStack
+      v-for="field in fields"
+      :key="field.id"
+      :label="field.label || field.id"
+      :help="acpManagedFieldHelp(profile, field)"
+      :gap="fieldGap"
+    >
+      <Select
+        v-if="isHermesProviderField(field)"
+        :model-value="hermesProvider"
+        @update:model-value="(value) => setHermesProvider(String(value))"
+      >
+        <SelectTrigger class="w-full">
+          <SelectValue :placeholder="t('bots.settings.acpHermesProviderPlaceholder')" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            v-for="provider in HERMES_PROVIDER_PRESETS"
+            :key="provider.value"
+            :value="provider.value"
+          >
+            {{ t(provider.labelKey) }}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+      <template v-else-if="isHermesModelField(field)">
+        <Select
+          :model-value="hermesModelSelect"
+          @update:model-value="(value) => setHermesModel(String(value))"
+        >
+          <SelectTrigger class="w-full">
+            <SelectValue :placeholder="t('bots.settings.acpHermesModelPlaceholder')" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="model in hermesModelOptions"
+              :key="model.value"
+              :value="model.value"
+            >
+              {{ model.label }}
+            </SelectItem>
+            <SelectItem :value="HERMES_CUSTOM_MODEL_VALUE">
+              {{ t('bots.settings.acpHermesCustomModel') }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <Input
+          v-if="hermesUsingCustomModel"
+          class="mt-2"
+          :model-value="managed.model || ''"
+          :name="settingsMode ? acpManagedFieldName(profile, field) : undefined"
+          autocomplete="off"
+          autocapitalize="off"
+          autocorrect="off"
+          spellcheck="false"
+          :placeholder="t('bots.settings.acpHermesCustomModelPlaceholder')"
+          @update:model-value="(val) => handleFieldInput(field, String(val ?? ''))"
+          @change="handleFieldCommit"
+        />
+      </template>
+      <Input
+        v-else
+        :model-value="managed[field.id || ''] || ''"
+        :type="acpInputType(field.type)"
+        :name="settingsMode ? acpManagedFieldName(profile, field) : undefined"
+        :autocomplete="settingsMode ? acpManagedFieldAutocomplete(field) : 'off'"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false"
+        :placeholder="acpManagedPlaceholder(profile, field, hermesProvider)"
+        @update:model-value="(val) => handleFieldInput(field, String(val ?? ''))"
+        @change="handleFieldCommit"
+      />
+    </FieldStack>
+  </FormStack>
+</template>

--- a/apps/web/src/pages/bots/components/acp-setup-panel.vue
+++ b/apps/web/src/pages/bots/components/acp-setup-panel.vue
@@ -5,41 +5,20 @@
 // interactive OAuth flows (device code, code exchange) deliberately stay out:
 // a bot must exist before authorization can run.
 //
-// State lives inside the panel; parents pull a snapshot via the exposed
-// `selection()` at submit and gate on `missingRequiredField()` — the same
-// pull-at-submit contract the onboarding step used before the extraction.
+// Managed fields render via acp-managed-fields.vue (shared with settings).
 import { computed, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import {
-  FieldStack,
-  FormStack,
-  Input,
-  SegmentedControl,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  type SegmentedItem,
-} from '@felinic/ui'
+import { FieldStack, FormStack, SegmentedControl } from '@felinic/ui'
 import type { AcpprofileManagedField, AcpprofilePublicProfile } from '@memohai/sdk'
+import { useAcpSetupModeItems } from '@/composables/useAcpSetupModeItems'
 import {
-  HERMES_CUSTOM_MODEL_VALUE,
-  HERMES_PROVIDER_PRESETS,
   defaultSetupMode,
   ensureHermesManagedDefaults,
   findMissingRequiredManagedField,
-  hermesAPIKeyPlaceholder,
-  hermesDefaultModel,
-  hermesModelPresets,
-  hermesModelSelectValue,
-  hermesProviderValue,
-  isClaudeCodeAgent,
-  isCodexAgent,
-  isHermesCustomProvider,
-  isHermesPresetModel,
   normalizeACPAgentID,
 } from '@/utils/acp'
+import { filterCreateVisibleManagedFields } from '@/utils/acp/setup-fields'
+import AcpManagedFields from './acp-managed-fields.vue'
 
 export interface AcpSetupSelection {
   agentId: string
@@ -47,28 +26,52 @@ export interface AcpSetupSelection {
   managed: Record<string, string>
 }
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   profile: AcpprofilePublicProfile
-  // Where OAuth authorization will happen, in the caller's words (it differs
-  // per surface: onboarding runs a post-create step, the new-bot page defers
-  // to bot settings). Caller i18n, no fallback — same contract as ConfirmPopover.
   oauthHint: string
-}>()
+  fieldGap?: 'card' | 'bare'
+  initialSelection?: AcpSetupSelection | null
+}>(), {
+  fieldGap: 'card',
+  initialSelection: null,
+})
 
-// Set by the parent after a rejected submit; cleared on any edit. v-model so
-// the panel renders the message in one consistent spot instead of every
-// surface hand-rolling its own error line.
 const errorMessage = defineModel<string>('errorMessage', { default: '' })
 
 const { t } = useI18n()
+const { setupModeItems, setupModes } = useAcpSetupModeItems(() => props.profile)
 
 const setupMode = ref('api_key')
 const managed = reactive<Record<string, string>>({})
 
 const isHermes = computed(() => normalizeACPAgentID(props.profile.id) === 'hermes')
 
-// (Re)initialize whenever a different agent is picked: seed one empty slot per
-// managed field and prefer the profile's default setup mode.
+const visibleManagedFields = computed(() =>
+  filterCreateVisibleManagedFields(props.profile, managed, setupMode.value),
+)
+
+const selfModeHint = computed(() => isHermes.value
+  ? t('bots.settings.acpHermesSelfModeHint')
+  : t('bots.settings.acpSelfModeHint'))
+
+function applyInitialSelection(profile: AcpprofilePublicProfile) {
+  const seed = props.initialSelection
+  if (!seed) return
+  if (normalizeACPAgentID(seed.agentId) !== normalizeACPAgentID(profile.id)) return
+  const modes = setupModes()
+  if (modes.includes(seed.setupMode)) {
+    setupMode.value = seed.setupMode
+  }
+  if (setupMode.value !== 'api_key') return
+  for (const [key, value] of Object.entries(seed.managed)) {
+    const id = normalizeACPAgentID(key)
+    if (id && id in managed) managed[id] = value
+  }
+  if (isHermes.value) {
+    ensureHermesManagedDefaults(managed)
+  }
+}
+
 watch(() => props.profile, (profile) => {
   for (const key of Object.keys(managed)) delete managed[key]
   for (const field of profile.managed_fields ?? []) {
@@ -81,28 +84,9 @@ watch(() => props.profile, (profile) => {
   if (isHermes.value && setupMode.value === 'api_key') {
     ensureHermesManagedDefaults(managed)
   }
+  applyInitialSelection(profile)
   errorMessage.value = ''
 }, { immediate: true })
-
-function setupModes(): string[] {
-  const modes = (props.profile.setup_modes ?? []).filter(Boolean)
-  return modes.length > 0 ? modes : ['api_key']
-}
-
-function setupModeLabel(mode: string): string {
-  if (mode === 'api_key') return t('bots.settings.acpSetupApiKey')
-  if (mode === 'oauth') {
-    if (isCodexAgent(props.profile.id)) return t('bots.settings.acpSetupChatGPT')
-    if (isClaudeCodeAgent(props.profile.id)) return t('bots.settings.acpSetupClaude')
-    return t('bots.settings.acpSetupOAuth')
-  }
-  if (mode === 'self') return t('bots.settings.acpSetupSelf')
-  return mode
-}
-
-const setupModeItems = computed<SegmentedItem<string>[]>(() =>
-  setupModes().map(mode => ({ value: mode, label: setupModeLabel(mode) })),
-)
 
 function setSetupMode(mode: string) {
   setupMode.value = mode
@@ -112,94 +96,10 @@ function setSetupMode(mode: string) {
   errorMessage.value = ''
 }
 
-// Creation shows managed fields for api_key mode only — oauth defers to a
-// later authorization step, self reuses the workspace's own config, so neither
-// has anything to fill in here.
-const visibleManagedFields = computed<AcpprofileManagedField[]>(() => {
-  if (setupMode.value !== 'api_key') return []
-  return (props.profile.managed_fields ?? []).filter((field) => {
-    const id = normalizeACPAgentID(field.id)
-    if (!id || id === 'provider_id' || id === 'oauth_token') return false
-    if (isHermes.value && id === 'base_url') return isHermesCustomProvider(hermesProvider.value)
-    return true
-  })
-})
-
-// Hermes provider/model fields render their own preset selects and never carry
-// help text; every other managed field surfaces its schema-provided help.
-function managedFieldHelp(field: AcpprofileManagedField): string {
-  const id = normalizeACPAgentID(field.id)
-  if (isHermes.value && (id === 'provider' || id === 'model')) return ''
-  return field.help || ''
-}
-
-function inputType(type: string | undefined): string {
-  if (type === 'password') return 'password'
-  if (type === 'url') return 'url'
-  return 'text'
-}
-
-function managedPlaceholder(field: AcpprofileManagedField): string | undefined {
-  if (isHermes.value && normalizeACPAgentID(field.id) === 'api_key') {
-    return hermesAPIKeyPlaceholder(hermesProvider.value, field.placeholder)
-  }
-  return field.placeholder
-}
-
-function setManagedField(fieldID: string | undefined, value: string) {
-  const id = normalizeACPAgentID(fieldID)
-  if (!id) return
-  managed[id] = value
+function clearErrorMessage() {
   errorMessage.value = ''
 }
 
-// --- Hermes preset handling (provider → model presets, custom endpoint) ---
-
-const hermesProvider = computed(() => hermesProviderValue(managed.provider))
-
-function isHermesProviderField(field: AcpprofileManagedField): boolean {
-  return isHermes.value && normalizeACPAgentID(field.id) === 'provider'
-}
-
-function isHermesModelField(field: AcpprofileManagedField): boolean {
-  return isHermes.value && normalizeACPAgentID(field.id) === 'model'
-}
-
-function hermesModelOptions() {
-  return hermesModelPresets(hermesProvider.value)
-}
-
-function hermesModelSelect(): string {
-  return hermesModelSelectValue(hermesProvider.value, managed.model)
-}
-
-const hermesUsingCustomModel = computed(() => hermesModelSelect() === HERMES_CUSTOM_MODEL_VALUE)
-
-function setHermesProvider(value: string) {
-  const provider = hermesProviderValue(value)
-  managed.provider = provider
-  managed.model = hermesDefaultModel(provider)
-  if (!isHermesCustomProvider(provider)) managed.base_url = ''
-  errorMessage.value = ''
-}
-
-function setHermesModel(value: string) {
-  if (value === HERMES_CUSTOM_MODEL_VALUE) {
-    if (isHermesPresetModel(hermesProvider.value, managed.model)) {
-      managed.model = ''
-    }
-  } else {
-    managed.model = value
-  }
-  errorMessage.value = ''
-}
-
-const selfModeHint = computed(() => isHermes.value
-  ? t('bots.settings.acpHermesSelfModeHint')
-  : t('bots.settings.acpSelfModeHint'))
-
-// selection snapshots the parent's create payload: api_key collects only the
-// visible fields (trimmed, non-empty); other modes carry no managed values.
 function selection(): AcpSetupSelection {
   const managedSnapshot: Record<string, string> = {}
   if (setupMode.value === 'api_key') {
@@ -216,8 +116,6 @@ function selection(): AcpSetupSelection {
   }
 }
 
-// missingRequiredField is the submit-time gate: the first required api_key
-// field left empty, or null when the selection is submittable.
 function missingRequiredField(): AcpprofileManagedField | null {
   if (setupMode.value !== 'api_key') return null
   return findMissingRequiredManagedField(props.profile, managed, setupMode.value)
@@ -228,7 +126,10 @@ defineExpose({ selection, missingRequiredField })
 
 <template>
   <FormStack>
-    <FieldStack :label="t('bots.settings.acpSetupMode')">
+    <FieldStack
+      :label="t('bots.settings.acpSetupMode')"
+      :gap="fieldGap"
+    >
       <SegmentedControl
         :model-value="setupMode"
         :items="setupModeItems"
@@ -238,77 +139,14 @@ defineExpose({ selection, missingRequiredField })
       />
     </FieldStack>
 
-    <template v-if="setupMode === 'api_key'">
-      <FieldStack
-        v-for="field in visibleManagedFields"
-        :key="field.id"
-        :label="field.label || field.id"
-        :help="managedFieldHelp(field)"
-      >
-        <Select
-          v-if="isHermesProviderField(field)"
-          :model-value="hermesProvider"
-          @update:model-value="(value) => setHermesProvider(String(value))"
-        >
-          <SelectTrigger class="w-full">
-            <SelectValue :placeholder="t('bots.settings.acpHermesProviderPlaceholder')" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem
-              v-for="provider in HERMES_PROVIDER_PRESETS"
-              :key="provider.value"
-              :value="provider.value"
-            >
-              {{ t(provider.labelKey) }}
-            </SelectItem>
-          </SelectContent>
-        </Select>
-        <template v-else-if="isHermesModelField(field)">
-          <Select
-            :model-value="hermesModelSelect()"
-            @update:model-value="(value) => setHermesModel(String(value))"
-          >
-            <SelectTrigger class="w-full">
-              <SelectValue :placeholder="t('bots.settings.acpHermesModelPlaceholder')" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem
-                v-for="model in hermesModelOptions()"
-                :key="model.value"
-                :value="model.value"
-              >
-                {{ model.label }}
-              </SelectItem>
-              <SelectItem :value="HERMES_CUSTOM_MODEL_VALUE">
-                {{ t('bots.settings.acpHermesCustomModel') }}
-              </SelectItem>
-            </SelectContent>
-          </Select>
-          <Input
-            v-if="hermesUsingCustomModel"
-            class="mt-2"
-            :model-value="managed.model || ''"
-            autocomplete="off"
-            autocapitalize="off"
-            autocorrect="off"
-            spellcheck="false"
-            :placeholder="t('bots.settings.acpHermesCustomModelPlaceholder')"
-            @update:model-value="(val) => setManagedField(field.id, String(val ?? ''))"
-          />
-        </template>
-        <Input
-          v-else
-          :model-value="managed[field.id || ''] || ''"
-          :type="inputType(field.type)"
-          autocomplete="off"
-          autocapitalize="off"
-          autocorrect="off"
-          spellcheck="false"
-          :placeholder="managedPlaceholder(field)"
-          @update:model-value="(val) => setManagedField(field.id, String(val ?? ''))"
-        />
-      </FieldStack>
-    </template>
+    <AcpManagedFields
+      v-if="setupMode === 'api_key'"
+      :profile="profile"
+      :managed="managed"
+      :fields="visibleManagedFields"
+      :field-gap="fieldGap"
+      @field-change="clearErrorMessage"
+    />
 
     <p
       v-else-if="setupMode === 'oauth'"

--- a/apps/web/src/pages/bots/components/acp-setup-panel.vue
+++ b/apps/web/src/pages/bots/components/acp-setup-panel.vue
@@ -1,0 +1,333 @@
+<script setup lang="ts">
+// Creation-time setup panel for one hosted ACP agent: setup-mode chooser +
+// managed fields (api_key mode) / deferral hints (oauth, self). Shared by the
+// new-bot page and onboarding — it owns only the *pre-create* slice, so the
+// interactive OAuth flows (device code, code exchange) deliberately stay out:
+// a bot must exist before authorization can run.
+//
+// State lives inside the panel; parents pull a snapshot via the exposed
+// `selection()` at submit and gate on `missingRequiredField()` — the same
+// pull-at-submit contract the onboarding step used before the extraction.
+import { computed, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  FieldStack,
+  FormStack,
+  Input,
+  SegmentedControl,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  type SegmentedItem,
+} from '@felinic/ui'
+import type { AcpprofileManagedField, AcpprofilePublicProfile } from '@memohai/sdk'
+import {
+  HERMES_CUSTOM_MODEL_VALUE,
+  HERMES_PROVIDER_PRESETS,
+  defaultSetupMode,
+  ensureHermesManagedDefaults,
+  findMissingRequiredManagedField,
+  hermesAPIKeyPlaceholder,
+  hermesDefaultModel,
+  hermesModelPresets,
+  hermesModelSelectValue,
+  hermesProviderValue,
+  isClaudeCodeAgent,
+  isCodexAgent,
+  isHermesCustomProvider,
+  isHermesPresetModel,
+  normalizeACPAgentID,
+} from '@/utils/acp'
+
+export interface AcpSetupSelection {
+  agentId: string
+  setupMode: string
+  managed: Record<string, string>
+}
+
+const props = defineProps<{
+  profile: AcpprofilePublicProfile
+  // Where OAuth authorization will happen, in the caller's words (it differs
+  // per surface: onboarding runs a post-create step, the new-bot page defers
+  // to bot settings). Caller i18n, no fallback — same contract as ConfirmPopover.
+  oauthHint: string
+}>()
+
+// Set by the parent after a rejected submit; cleared on any edit. v-model so
+// the panel renders the message in one consistent spot instead of every
+// surface hand-rolling its own error line.
+const errorMessage = defineModel<string>('errorMessage', { default: '' })
+
+const { t } = useI18n()
+
+const setupMode = ref('api_key')
+const managed = reactive<Record<string, string>>({})
+
+const isHermes = computed(() => normalizeACPAgentID(props.profile.id) === 'hermes')
+
+// (Re)initialize whenever a different agent is picked: seed one empty slot per
+// managed field and prefer the profile's default setup mode.
+watch(() => props.profile, (profile) => {
+  for (const key of Object.keys(managed)) delete managed[key]
+  for (const field of profile.managed_fields ?? []) {
+    const id = normalizeACPAgentID(field.id)
+    if (id) managed[id] = ''
+  }
+  const modes = setupModes()
+  const preferred = defaultSetupMode(profile)
+  setupMode.value = modes.includes(preferred) ? preferred : (modes[0] ?? defaultSetupMode(profile))
+  if (isHermes.value && setupMode.value === 'api_key') {
+    ensureHermesManagedDefaults(managed)
+  }
+  errorMessage.value = ''
+}, { immediate: true })
+
+function setupModes(): string[] {
+  const modes = (props.profile.setup_modes ?? []).filter(Boolean)
+  return modes.length > 0 ? modes : ['api_key']
+}
+
+function setupModeLabel(mode: string): string {
+  if (mode === 'api_key') return t('bots.settings.acpSetupApiKey')
+  if (mode === 'oauth') {
+    if (isCodexAgent(props.profile.id)) return t('bots.settings.acpSetupChatGPT')
+    if (isClaudeCodeAgent(props.profile.id)) return t('bots.settings.acpSetupClaude')
+    return t('bots.settings.acpSetupOAuth')
+  }
+  if (mode === 'self') return t('bots.settings.acpSetupSelf')
+  return mode
+}
+
+const setupModeItems = computed<SegmentedItem<string>[]>(() =>
+  setupModes().map(mode => ({ value: mode, label: setupModeLabel(mode) })),
+)
+
+function setSetupMode(mode: string) {
+  setupMode.value = mode
+  if (isHermes.value && mode === 'api_key') {
+    ensureHermesManagedDefaults(managed)
+  }
+  errorMessage.value = ''
+}
+
+// Creation shows managed fields for api_key mode only — oauth defers to a
+// later authorization step, self reuses the workspace's own config, so neither
+// has anything to fill in here.
+const visibleManagedFields = computed<AcpprofileManagedField[]>(() => {
+  if (setupMode.value !== 'api_key') return []
+  return (props.profile.managed_fields ?? []).filter((field) => {
+    const id = normalizeACPAgentID(field.id)
+    if (!id || id === 'provider_id' || id === 'oauth_token') return false
+    if (isHermes.value && id === 'base_url') return isHermesCustomProvider(hermesProvider.value)
+    return true
+  })
+})
+
+// Hermes provider/model fields render their own preset selects and never carry
+// help text; every other managed field surfaces its schema-provided help.
+function managedFieldHelp(field: AcpprofileManagedField): string {
+  const id = normalizeACPAgentID(field.id)
+  if (isHermes.value && (id === 'provider' || id === 'model')) return ''
+  return field.help || ''
+}
+
+function inputType(type: string | undefined): string {
+  if (type === 'password') return 'password'
+  if (type === 'url') return 'url'
+  return 'text'
+}
+
+function managedPlaceholder(field: AcpprofileManagedField): string | undefined {
+  if (isHermes.value && normalizeACPAgentID(field.id) === 'api_key') {
+    return hermesAPIKeyPlaceholder(hermesProvider.value, field.placeholder)
+  }
+  return field.placeholder
+}
+
+function setManagedField(fieldID: string | undefined, value: string) {
+  const id = normalizeACPAgentID(fieldID)
+  if (!id) return
+  managed[id] = value
+  errorMessage.value = ''
+}
+
+// --- Hermes preset handling (provider → model presets, custom endpoint) ---
+
+const hermesProvider = computed(() => hermesProviderValue(managed.provider))
+
+function isHermesProviderField(field: AcpprofileManagedField): boolean {
+  return isHermes.value && normalizeACPAgentID(field.id) === 'provider'
+}
+
+function isHermesModelField(field: AcpprofileManagedField): boolean {
+  return isHermes.value && normalizeACPAgentID(field.id) === 'model'
+}
+
+function hermesModelOptions() {
+  return hermesModelPresets(hermesProvider.value)
+}
+
+function hermesModelSelect(): string {
+  return hermesModelSelectValue(hermesProvider.value, managed.model)
+}
+
+const hermesUsingCustomModel = computed(() => hermesModelSelect() === HERMES_CUSTOM_MODEL_VALUE)
+
+function setHermesProvider(value: string) {
+  const provider = hermesProviderValue(value)
+  managed.provider = provider
+  managed.model = hermesDefaultModel(provider)
+  if (!isHermesCustomProvider(provider)) managed.base_url = ''
+  errorMessage.value = ''
+}
+
+function setHermesModel(value: string) {
+  if (value === HERMES_CUSTOM_MODEL_VALUE) {
+    if (isHermesPresetModel(hermesProvider.value, managed.model)) {
+      managed.model = ''
+    }
+  } else {
+    managed.model = value
+  }
+  errorMessage.value = ''
+}
+
+const selfModeHint = computed(() => isHermes.value
+  ? t('bots.settings.acpHermesSelfModeHint')
+  : t('bots.settings.acpSelfModeHint'))
+
+// selection snapshots the parent's create payload: api_key collects only the
+// visible fields (trimmed, non-empty); other modes carry no managed values.
+function selection(): AcpSetupSelection {
+  const managedSnapshot: Record<string, string> = {}
+  if (setupMode.value === 'api_key') {
+    for (const field of visibleManagedFields.value) {
+      const id = normalizeACPAgentID(field.id)
+      const value = (managed[id ?? ''] ?? '').trim()
+      if (value) managedSnapshot[id] = value
+    }
+  }
+  return {
+    agentId: normalizeACPAgentID(props.profile.id),
+    setupMode: setupMode.value,
+    managed: managedSnapshot,
+  }
+}
+
+// missingRequiredField is the submit-time gate: the first required api_key
+// field left empty, or null when the selection is submittable.
+function missingRequiredField(): AcpprofileManagedField | null {
+  if (setupMode.value !== 'api_key') return null
+  return findMissingRequiredManagedField(props.profile, managed, setupMode.value)
+}
+
+defineExpose({ selection, missingRequiredField })
+</script>
+
+<template>
+  <FormStack>
+    <FieldStack :label="t('bots.settings.acpSetupMode')">
+      <SegmentedControl
+        :model-value="setupMode"
+        :items="setupModeItems"
+        :aria-label="t('bots.settings.acpSetupMode')"
+        class="w-full sm:w-fit"
+        @update:model-value="setSetupMode"
+      />
+    </FieldStack>
+
+    <template v-if="setupMode === 'api_key'">
+      <FieldStack
+        v-for="field in visibleManagedFields"
+        :key="field.id"
+        :label="field.label || field.id"
+        :help="managedFieldHelp(field)"
+      >
+        <Select
+          v-if="isHermesProviderField(field)"
+          :model-value="hermesProvider"
+          @update:model-value="(value) => setHermesProvider(String(value))"
+        >
+          <SelectTrigger class="w-full">
+            <SelectValue :placeholder="t('bots.settings.acpHermesProviderPlaceholder')" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem
+              v-for="provider in HERMES_PROVIDER_PRESETS"
+              :key="provider.value"
+              :value="provider.value"
+            >
+              {{ t(provider.labelKey) }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <template v-else-if="isHermesModelField(field)">
+          <Select
+            :model-value="hermesModelSelect()"
+            @update:model-value="(value) => setHermesModel(String(value))"
+          >
+            <SelectTrigger class="w-full">
+              <SelectValue :placeholder="t('bots.settings.acpHermesModelPlaceholder')" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem
+                v-for="model in hermesModelOptions()"
+                :key="model.value"
+                :value="model.value"
+              >
+                {{ model.label }}
+              </SelectItem>
+              <SelectItem :value="HERMES_CUSTOM_MODEL_VALUE">
+                {{ t('bots.settings.acpHermesCustomModel') }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            v-if="hermesUsingCustomModel"
+            class="mt-2"
+            :model-value="managed.model || ''"
+            autocomplete="off"
+            autocapitalize="off"
+            autocorrect="off"
+            spellcheck="false"
+            :placeholder="t('bots.settings.acpHermesCustomModelPlaceholder')"
+            @update:model-value="(val) => setManagedField(field.id, String(val ?? ''))"
+          />
+        </template>
+        <Input
+          v-else
+          :model-value="managed[field.id || ''] || ''"
+          :type="inputType(field.type)"
+          autocomplete="off"
+          autocapitalize="off"
+          autocorrect="off"
+          spellcheck="false"
+          :placeholder="managedPlaceholder(field)"
+          @update:model-value="(val) => setManagedField(field.id, String(val ?? ''))"
+        />
+      </FieldStack>
+    </template>
+
+    <p
+      v-else-if="setupMode === 'oauth'"
+      class="text-sm text-muted-foreground"
+    >
+      {{ oauthHint }}
+    </p>
+    <p
+      v-else-if="setupMode === 'self'"
+      class="text-sm text-muted-foreground"
+    >
+      {{ selfModeHint }}
+    </p>
+
+    <p
+      v-if="errorMessage"
+      class="text-xs text-destructive"
+    >
+      {{ errorMessage }}
+    </p>
+  </FormStack>
+</template>

--- a/apps/web/src/pages/bots/components/agent-type-pill.vue
+++ b/apps/web/src/pages/bots/components/agent-type-pill.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+// Agent-kind chooser for bot-creation surfaces: built-in Memoh agent vs a
+// hosted ACP agent (Claude Code / Codex / …). Data-driven from getAcpProfiles —
+// when the server publishes no ACP profiles the pill renders nothing, so the
+// surface behaves exactly as before the chooser existed (fail-closed).
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { SegmentedControl } from '@felinic/ui'
+import type { AcpprofilePublicProfile } from '@memohai/sdk'
+import { acpAgentIcon } from '@/utils/acp'
+import { MEMOH_AGENT_VALUE, agentTypeItems } from './agent-type'
+
+const props = defineProps<{
+  profiles: AcpprofilePublicProfile[]
+}>()
+
+const modelValue = defineModel<string>({ default: MEMOH_AGENT_VALUE })
+
+const { t } = useI18n()
+
+const items = computed(() => agentTypeItems(props.profiles))
+</script>
+
+<template>
+  <SegmentedControl
+    v-if="items.length > 1"
+    v-model="modelValue"
+    :items="items"
+    :aria-label="t('bots.agentCreate.typeAriaLabel')"
+    class="w-full sm:w-fit"
+  >
+    <template #item="{ item }">
+      <span class="inline-flex min-w-0 items-center justify-center gap-1.5">
+        <img
+          v-if="item.value === MEMOH_AGENT_VALUE"
+          src="/logo.svg"
+          alt=""
+          class="size-4 shrink-0"
+        >
+        <component
+          :is="acpAgentIcon(item.value, true)"
+          v-else
+          class="size-4 shrink-0"
+        />
+        <span class="truncate">{{ item.label }}</span>
+      </span>
+    </template>
+  </SegmentedControl>
+</template>

--- a/apps/web/src/pages/bots/components/agent-type.test.ts
+++ b/apps/web/src/pages/bots/components/agent-type.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { AcpprofilePublicProfile } from '@memohai/sdk'
+import { MEMOH_AGENT_VALUE, agentTypeItems } from './agent-type'
+
+function profile(id: string, displayName = ''): AcpprofilePublicProfile {
+  return { id, display_name: displayName } as AcpprofilePublicProfile
+}
+
+describe('agentTypeItems', () => {
+  it('always puts the built-in Memoh agent first', () => {
+    const items = agentTypeItems([profile('codex'), profile('claude-code')])
+    expect(items[0]).toEqual({ value: MEMOH_AGENT_VALUE, label: 'Memoh' })
+    expect(items.map(item => item.value)).toEqual([MEMOH_AGENT_VALUE, 'codex', 'claude-code'])
+  })
+
+  // Known agents get their brand name even without a server display_name —
+  // the picker never shows a raw slug like "claude-code".
+  it('falls back to the brand display name for known agents', () => {
+    const items = agentTypeItems([profile('claude-code')])
+    expect(items[1]?.label).toBe('Claude Code')
+  })
+
+  it('prefers the server-provided display name', () => {
+    const items = agentTypeItems([profile('codex', 'Codex (managed)')])
+    expect(items[1]?.label).toBe('Codex (managed)')
+  })
+
+  it('normalizes profile ids the same way ACP metadata does', () => {
+    const items = agentTypeItems([profile('  Claude-Code ')])
+    expect(items.map(item => item.value)).toContain('claude-code')
+  })
+
+  // A profile that normalizes to the reserved built-in value would replace the
+  // Memoh segment's identity — it must be skipped, never rendered.
+  it('skips profiles that collide with the reserved Memoh segment', () => {
+    const items = agentTypeItems([profile('Memoh')])
+    expect(items).toHaveLength(1)
+  })
+
+  // Fail-closed: no published profiles → a single (hidden by the pill)
+  // built-in segment, so surfaces behave as if the chooser didn't exist.
+  it('returns only the built-in segment when no profiles are published', () => {
+    expect(agentTypeItems([])).toEqual([{ value: MEMOH_AGENT_VALUE, label: 'Memoh' }])
+  })
+})

--- a/apps/web/src/pages/bots/components/agent-type.ts
+++ b/apps/web/src/pages/bots/components/agent-type.ts
@@ -1,0 +1,23 @@
+import type { SegmentedItem } from '@felinic/ui'
+import type { AcpprofilePublicProfile } from '@memohai/sdk'
+import { acpAgentDisplayName, normalizeACPAgentID } from '@/utils/acp'
+
+// MEMOH_AGENT_VALUE is the built-in-agent segment's value in agent-type-pill.
+// It is NOT an agent id — a reserved marker so the chooser can never collide
+// with a normalized ACP profile id.
+export const MEMOH_AGENT_VALUE = 'memoh'
+
+// agentTypeItems builds the pill's segments: the built-in Memoh agent always
+// first, then one segment per ACP profile the server publishes. Callers hide
+// the pill entirely when this returns a single segment (no hosted agents on
+// this server), so the surface behaves exactly as if the chooser didn't exist.
+export function agentTypeItems(profiles: AcpprofilePublicProfile[]): SegmentedItem<string>[] {
+  const agents = profiles.flatMap((profile) => {
+    const agentId = normalizeACPAgentID(profile.id)
+    // Skip entries that fail normalization or would collide with the reserved
+    // built-in segment value.
+    if (!agentId || agentId === MEMOH_AGENT_VALUE) return []
+    return [{ value: agentId, label: profile.display_name || acpAgentDisplayName(agentId, agentId) }]
+  })
+  return [{ value: MEMOH_AGENT_VALUE, label: 'Memoh' }, ...agents]
+}

--- a/apps/web/src/pages/bots/components/settings-acp-detail.vue
+++ b/apps/web/src/pages/bots/components/settings-acp-detail.vue
@@ -1,9 +1,6 @@
 <!-- eslint-disable vue/no-mutating-props -->
 <template>
   <div class="space-y-8">
-    <!-- Identity card: which agent this is. The brand mark is signal (which
-         agent), not decoration. Mirrors the provider detail header so every
-         backend reads the same way. -->
     <section class="flex items-center gap-3 rounded-[var(--radius-menu-shell)] border border-border bg-card px-4 py-3">
       <span class="flex size-9 shrink-0 items-center justify-center">
         <component
@@ -180,81 +177,13 @@
             </div>
           </div>
 
-          <FormStack>
-            <FieldStack
-              v-for="field in visibleManagedFields"
-              :key="field.id"
-              :label="field.label || field.id"
-              :help="managedFieldHelp(field)"
-            >
-              <Select
-                v-if="isHermesProviderField(field)"
-                :model-value="hermesProvider"
-                @update:model-value="(value) => setHermesProvider(String(value))"
-              >
-                <SelectTrigger class="w-full">
-                  <SelectValue :placeholder="$t('bots.settings.acpHermesProviderPlaceholder')" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem
-                    v-for="provider in HERMES_PROVIDER_PRESETS"
-                    :key="provider.value"
-                    :value="provider.value"
-                  >
-                    {{ $t(provider.labelKey) }}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              <template v-else-if="isHermesModelField(field)">
-                <Select
-                  :model-value="hermesModelSelect"
-                  @update:model-value="(value) => setHermesModel(String(value))"
-                >
-                  <SelectTrigger class="w-full">
-                    <SelectValue :placeholder="$t('bots.settings.acpHermesModelPlaceholder')" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem
-                      v-for="model in hermesModelOptions"
-                      :key="model.value"
-                      :value="model.value"
-                    >
-                      {{ model.label }}
-                    </SelectItem>
-                    <SelectItem :value="HERMES_CUSTOM_MODEL_VALUE">
-                      {{ $t('bots.settings.acpHermesCustomModel') }}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <Input
-                  v-if="hermesUsingCustomModel"
-                  class="mt-2"
-                  :model-value="agent.managed.model || ''"
-                  :name="managedFieldName(field)"
-                  autocomplete="off"
-                  autocapitalize="off"
-                  autocorrect="off"
-                  spellcheck="false"
-                  :placeholder="$t('bots.settings.acpHermesCustomModelPlaceholder')"
-                  @update:model-value="(val) => setManagedField(field.id, String(val ?? ''))"
-                  @change="commitForm"
-                />
-              </template>
-              <Input
-                v-else
-                :model-value="agent.managed[field.id || ''] || ''"
-                :type="inputType(field.type)"
-                :name="managedFieldName(field)"
-                :autocomplete="managedFieldAutocomplete(field)"
-                autocapitalize="off"
-                autocorrect="off"
-                spellcheck="false"
-                :placeholder="managedFieldPlaceholder(field)"
-                @update:model-value="(val) => setManagedField(field.id, String(val ?? ''))"
-                @change="commitForm"
-              />
-            </FieldStack>
-          </FormStack>
+          <AcpManagedFields
+            :profile="profile"
+            :managed="agent.managed"
+            :fields="visibleManagedFields"
+            settings-mode
+            @field-commit="commitForm"
+          />
         </template>
 
         <p
@@ -279,47 +208,34 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { FieldStack, FormStack, InlineLoadingRow, SettingsSection, toast, useClipboard } from '@felinic/ui'
+import { InlineLoadingRow, SettingsSection, toast, useClipboard } from '@felinic/ui'
 import { useQueryCache } from '@pinia/colada'
 import {
   Button,
   Input,
   SegmentedControl,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  type SegmentedItem,
 } from '@felinic/ui'
 import { Copy } from 'lucide-vue-next'
 import {
-  type AcpprofileManagedField,
   type AcpprofilePublicProfile,
 } from '@memohai/sdk'
 import { useACPOAuth } from '@/composables/useACPOAuth'
+import { useAcpSetupModeItems } from '@/composables/useAcpSetupModeItems'
 import { getBotsQueryKey } from '@memohai/sdk/colada'
 import {
-  HERMES_CUSTOM_MODEL_VALUE,
-  HERMES_PROVIDER_PRESETS,
   acpAgentIcon,
   ensureACPAgentForm,
   ensureHermesManagedDefaults,
   findMissingRequiredManagedField,
-  hermesAPIKeyPlaceholder,
-  hermesDefaultModel,
-  hermesModelPresets,
-  hermesModelSelectValue,
-  hermesProviderValue,
   isClaudeCodeAgent,
   isCodexAgent,
-  isHermesCustomProvider,
-  isHermesPresetModel,
   normalizeACPAgentID,
   type ACPAgentForm,
   type ACPForm,
 } from '@/utils/acp'
+import { filterSettingsVisibleManagedFields } from '@/utils/acp/setup-fields'
 import { oauthStatusTextKey } from '@/utils/oauth/status-text'
+import AcpManagedFields from './acp-managed-fields.vue'
 
 const props = defineProps<{
   botId: string
@@ -340,6 +256,7 @@ const { t } = useI18n()
 const queryCache = useQueryCache()
 const { copyText } = useClipboard()
 const claudeOAuthCode = ref('')
+const { setupModeItems } = useAcpSetupModeItems(() => props.profile)
 const {
   codexStatus: codexOAuthStatus,
   codexStatusLoading: codexOAuthStatusLoading,
@@ -369,10 +286,6 @@ const agent = computed<ACPAgentForm>(() => ensureACPAgentForm(props.form, props.
 const isCodex = computed(() => isCodexAgent(props.profile.id))
 const isClaude = computed(() => isClaudeCodeAgent(props.profile.id))
 const isHermes = computed(() => normalizeACPAgentID(props.profile.id) === 'hermes')
-const hermesProvider = computed(() => hermesProviderValue(agent.value.managed.provider))
-const hermesModelOptions = computed(() => hermesModelPresets(hermesProvider.value))
-const hermesModelSelect = computed(() => hermesModelSelectValue(hermesProvider.value, agent.value.managed.model))
-const hermesUsingCustomModel = computed(() => hermesModelSelect.value === HERMES_CUSTOM_MODEL_VALUE)
 const isHermesSelfConfirmVisible = computed(() =>
   isHermes.value && props.pendingSelfConfirm === true && agent.value.enabled && agent.value.setup_mode === 'self',
 )
@@ -380,27 +293,8 @@ const selfModeHint = computed(() => isHermes.value
   ? t('bots.settings.acpHermesSelfModeHint')
   : t('bots.settings.acpSelfModeHint'))
 
-function setupModes(): string[] {
-  const modes = props.profile.setup_modes?.filter(Boolean) ?? []
-  return modes.length > 0 ? modes : ['api_key']
-}
-
-function setupModeLabel(mode: string): string {
-  if (mode === 'api_key') return t('bots.settings.acpSetupApiKey')
-  if (mode === 'oauth') {
-    if (isCodex.value) return t('bots.settings.acpSetupChatGPT')
-    if (isClaude.value) return t('bots.settings.acpSetupClaude')
-    return t('bots.settings.acpSetupOAuth')
-  }
-  if (mode === 'self') return t('bots.settings.acpSetupSelf')
-  return mode
-}
-
-const setupModeItems = computed<SegmentedItem<string>[]>(() =>
-  setupModes().map(mode => ({
-    value: mode,
-    label: setupModeLabel(mode),
-  })),
+const visibleManagedFields = computed(() =>
+  filterSettingsVisibleManagedFields(props.profile, agent.value.managed, agent.value.setup_mode),
 )
 
 function commitForm() {
@@ -424,82 +318,6 @@ function setSetupMode(mode: string) {
   commitForm()
 }
 
-function inputType(type: string | undefined): string {
-  if (type === 'password') return 'password'
-  if (type === 'url') return 'url'
-  return 'text'
-}
-
-function managedFieldName(field: AcpprofileManagedField): string {
-  return `acp-${normalizeACPAgentID(props.profile.id) || 'agent'}-${normalizeACPAgentID(field.id) || 'field'}`
-}
-
-function managedFieldAutocomplete(field: AcpprofileManagedField): string {
-  return field.type === 'password' ? 'new-password' : 'off'
-}
-
-function managedFieldPlaceholder(field: AcpprofileManagedField): string | undefined {
-  if (isHermes.value && normalizeACPAgentID(field.id) === 'api_key') {
-    return hermesAPIKeyPlaceholder(hermesProvider.value, field.placeholder)
-  }
-  return field.placeholder
-}
-
-// Hermes provider/model fields render their own preset selects and never carry
-// help text; every other managed field surfaces its schema-provided help.
-function managedFieldHelp(field: AcpprofileManagedField): string {
-  if (isHermesProviderField(field) || isHermesModelField(field)) return ''
-  return field.help || ''
-}
-
-function setManagedField(fieldID: string | undefined, value: string) {
-  const id = normalizeACPAgentID(fieldID)
-  if (!id) return
-  agent.value.managed[id] = value
-}
-
-function isHermesProviderField(field: AcpprofileManagedField): boolean {
-  return isHermes.value && normalizeACPAgentID(field.id) === 'provider'
-}
-
-function isHermesModelField(field: AcpprofileManagedField): boolean {
-  return isHermes.value && normalizeACPAgentID(field.id) === 'model'
-}
-
-function setHermesProvider(value: string) {
-  const provider = hermesProviderValue(value)
-  agent.value.managed.provider = provider
-  agent.value.managed.model = hermesDefaultModel(provider)
-  if (!isHermesCustomProvider(provider)) agent.value.managed.base_url = ''
-  commitForm()
-}
-
-function setHermesModel(value: string) {
-  if (value === HERMES_CUSTOM_MODEL_VALUE) {
-    if (isHermesPresetModel(hermesProvider.value, agent.value.managed.model)) {
-      agent.value.managed.model = ''
-    }
-  } else {
-    agent.value.managed.model = value
-  }
-  commitForm()
-}
-
-const visibleManagedFields = computed<AcpprofileManagedField[]>(() => {
-  const mode = agent.value.setup_mode
-  return (props.profile.managed_fields ?? []).filter((field) => {
-    const id = normalizeACPAgentID(field.id)
-    if (id === 'provider_id') return false
-    if (isHermes.value && id === 'base_url') return isHermesCustomProvider(hermesProvider.value)
-    if (isCodex.value && mode === 'oauth') return false
-    if (isClaude.value) {
-      if (id === 'api_key') return mode === 'api_key'
-      if (id === 'oauth_token') return false
-    }
-    return true
-  })
-})
-
 const codexOAuthActive = computed(() => isCodex.value && !!agent.value.enabled && agent.value.setup_mode === 'oauth')
 const claudeOAuthActive = computed(() => isClaude.value && !!agent.value.enabled && agent.value.setup_mode === 'oauth')
 const currentCodexDeviceSession = computed(() => {
@@ -518,8 +336,6 @@ const claudeOAuthPending = computed(() => {
   return Boolean(claudeOAuthSessionId.value && !claudeOAuthStatus.value?.has_token)
 })
 
-// Codex/Claude in OAuth mode need their live token status the moment the detail
-// opens (or the mode flips), so the status line and authorize button reflect reality.
 watch([() => props.botId, () => props.profile.id, () => agent.value.setup_mode], () => {
   if (isHermes.value && agent.value.setup_mode === 'api_key') ensureHermesManagedDefaults(agent.value.managed)
   if (codexOAuthActive.value || (isCodex.value && agent.value.setup_mode === 'oauth')) void loadOAuthStatus()

--- a/apps/web/src/pages/bots/new.vue
+++ b/apps/web/src/pages/bots/new.vue
@@ -170,23 +170,40 @@
 
       <Separator class="my-6" />
 
-      <!-- Model -->
+      <!-- Model / Agent -->
       <div>
         <h3 class="text-sm font-medium mb-4">
-          {{ $t('bots.steps.model') }}
+          {{ selectedAcpProfile ? $t('bots.steps.agent') : $t('bots.steps.model') }}
         </h3>
         <p class="text-xs text-muted-foreground mb-3">
-          {{ $t('bots.steps.modelDesc') }}
+          {{ selectedAcpProfile ? $t('bots.steps.agentDesc') : $t('bots.steps.modelDesc') }}
         </p>
-        <Label class="mb-2">{{ $t('bots.settings.chatModel') }}</Label>
-        <ModelSelect
-          v-model="form.chat_model_id"
-          v-model:reasoning-effort="form.reasoning_effort"
-          :models="models"
-          :providers="providers"
-          model-type="chat"
-          :placeholder="$t('common.none')"
-          show-reasoning
+        <!-- Agent-kind chooser (ACP 提权): hides itself when the server
+             publishes no hosted agents — the form then matches the pre-chooser
+             behavior exactly. -->
+        <AgentTypePill
+          v-model="agentType"
+          :profiles="acpProfiles"
+          class="mb-3"
+        />
+        <template v-if="!selectedAcpProfile">
+          <Label class="mb-2">{{ $t('bots.settings.chatModel') }}</Label>
+          <ModelSelect
+            v-model="form.chat_model_id"
+            v-model:reasoning-effort="form.reasoning_effort"
+            :models="models"
+            :providers="providers"
+            model-type="chat"
+            :placeholder="$t('common.none')"
+            show-reasoning
+          />
+        </template>
+        <AcpSetupPanel
+          v-else
+          ref="acpSetupPanelRef"
+          v-model:error-message="acpError"
+          :profile="selectedAcpProfile"
+          :oauth-hint="$t('bots.agentCreate.oauthSettingsHint')"
         />
       </div>
 
@@ -287,14 +304,18 @@ import { useDebounceFn } from '@vueuse/core'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useQuery } from '@pinia/colada'
-import { getModels, getProviders, getMemoryProviders, getBotsNameAvailability } from '@memohai/sdk'
-import type { BotsCreateBotRequest } from '@memohai/sdk'
+import { getModels, getProviders, getMemoryProviders, getBotsNameAvailability, getAcpProfiles } from '@memohai/sdk'
+import type { BotsCreateBotRequest, AcpprofilePublicProfile } from '@memohai/sdk'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
 import { aclPresetOptions, defaultAclPreset } from '@/constants/acl-presets'
 import { emptyTimezoneValue } from '@/utils/timezones'
+import { normalizeACPAgentID, withACPMetadata, type ACPForm } from '@/utils/acp'
 import TimezoneSelect from '@/components/timezone-select/index.vue'
 import { useBotCreateProgressStore } from '@/store/bot-create-progress'
 import ModelSelect from './components/model-select.vue'
+import AgentTypePill from './components/agent-type-pill.vue'
+import AcpSetupPanel from './components/acp-setup-panel.vue'
+import { MEMOH_AGENT_VALUE } from './components/agent-type'
 import MemoryProviderSelect from './components/memory-provider-select.vue'
 import AvatarEditDialog from './components/avatar-edit-dialog.vue'
 import BotImportPanel from './components/bot-import-panel.vue'
@@ -427,6 +448,27 @@ watch(memoryProviders, (list) => {
   }
 }, { immediate: true })
 
+const { data: acpProfileData } = useQuery({
+  key: ['acp-profiles'],
+  query: async () => {
+    const { data } = await getAcpProfiles({ throwOnError: true })
+    return data
+  },
+})
+
+const acpProfiles = computed(() => acpProfileData.value?.items ?? [])
+
+const agentType = ref(MEMOH_AGENT_VALUE)
+const acpError = ref('')
+const acpSetupPanelRef = ref<InstanceType<typeof AcpSetupPanel> | null>(null)
+
+// Null for the built-in agent; the panel + metadata only exist when a hosted
+// agent is picked.
+const selectedAcpProfile = computed<AcpprofilePublicProfile | null>(() => {
+  if (agentType.value === MEMOH_AGENT_VALUE) return null
+  return acpProfiles.value.find(profile => normalizeACPAgentID(profile.id) === agentType.value) ?? null
+})
+
 // ACL description
 const aclDescription = computed(() => {
   const opt = aclPresetOptions.find(o => o.value === form.acl_preset)
@@ -454,6 +496,24 @@ function handleImported(botId: string) {
   }
 }
 
+// A hosted agent travels as bot metadata (same shape the onboarding bot step
+// builds); the built-in Memoh agent carries none.
+function buildAcpMetadata(): Record<string, unknown> | undefined {
+  const panel = acpSetupPanelRef.value
+  if (!selectedAcpProfile.value || !panel) return undefined
+  const selection = panel.selection()
+  const acpForm: ACPForm = {
+    agents: {
+      [selection.agentId]: {
+        enabled: true,
+        setup_mode: selection.setupMode,
+        managed: selection.setupMode === 'api_key' ? selection.managed : {},
+      },
+    },
+  }
+  return withACPMetadata({}, acpForm, acpProfiles.value)
+}
+
 function buildCreatePayload(): BotsCreateBotRequest {
   const tz = form.timezone === emptyTimezoneValue ? undefined : form.timezone || undefined
 
@@ -464,6 +524,7 @@ function buildCreatePayload(): BotsCreateBotRequest {
     timezone: tz,
     is_active: true,
     acl_preset: form.acl_preset,
+    metadata: buildAcpMetadata(),
     wait_for_ready: true,
   }
 }
@@ -487,6 +548,15 @@ function createStartOptions() {
 
 async function handleSubmit() {
   if (!canSubmit.value || isCreateFlowBlocked.value) return
+
+  // Submit-time validation, not on-blur: the first empty required field is
+  // named inline inside the panel and nothing nags while typing.
+  const missing = selectedAcpProfile.value ? acpSetupPanelRef.value?.missingRequiredField() : null
+  if (missing) {
+    acpError.value = t('bots.agentCreate.requiredError', { field: missing.label || missing.id || '' })
+    return
+  }
+
   submitLoading.value = true
 
   const payload = buildCreatePayload()

--- a/apps/web/src/pages/onboarding/steps/Step3Provider.vue
+++ b/apps/web/src/pages/onboarding/steps/Step3Provider.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   Input,
@@ -12,7 +12,6 @@ import {
   Spinner,
 } from '@felinic/ui'
 import { ArrowLeft, Plus, AlertCircle } from 'lucide-vue-next'
-import { getAcpProfiles, type AcpprofileManagedField, type AcpprofilePublicProfile } from '@memohai/sdk'
 import { FieldStack, FormStack } from '@felinic/ui'
 import { useOnboarding } from '@/composables/useOnboarding'
 import ProviderIcon from '@/components/provider-icon/index.vue'
@@ -21,48 +20,23 @@ import ModelItem from '@/pages/providers/components/model-item.vue'
 import ChoiceTile from '../components/choice-tile.vue'
 import StepFrame from '../components/step-frame.vue'
 import StepExitShell from '../components/step-exit-shell.vue'
-import HintBox from '../components/hint-box.vue'
 import FooterNav from '../components/footer-nav.vue'
 import { onboardingProviderPresets as providerPresets, type ProviderPreset } from '@/constants/provider-presets'
-import {
-  HERMES_CUSTOM_MODEL_VALUE,
-  HERMES_PROVIDER_PRESETS,
-  acpAgentIcon,
-  defaultSetupMode,
-  ensureHermesManagedDefaults,
-  findMissingRequiredManagedField,
-  hermesAPIKeyPlaceholder,
-  hermesDefaultModel,
-  hermesModelPresets,
-  hermesModelSelectValue,
-  hermesProviderValue,
-  isHermesCustomProvider,
-  isHermesPresetModel,
-  normalizeACPAgentID,
-} from '@/utils/acp'
 import { useStepTransition, nextFrame } from '../useStepTransition'
 import { safeSessionGet, safeSessionSet } from '@/utils/safe-storage'
 import { ONBOARDING_KEYS } from '../constants'
 import { useProviderSetup } from './useProviderSetup'
-import { writeACPSelection, clearACPSelection } from './useACPSetup'
 
 const { t } = useI18n()
 const { nextStep, prevStep } = useOnboarding()
 const { visible, exiting, leave } = useStepTransition()
 const listVisible = ref(false)
 const gridVisible = ref(false)
-const mode = ref<'list' | 'form' | 'acp'>('list')
+const mode = ref<'list' | 'form'>('list')
 const formVisible = ref(false)
 const formContentVisible = ref(false)
 const selectedPreset = ref<ProviderPreset | null>(null)
 const addedCount = ref(0)
-
-const acpProfiles = ref<AcpprofilePublicProfile[]>([])
-const selectedAcpProfile = ref<AcpprofilePublicProfile | null>(null)
-const acpSetupMode = ref('api_key')
-const acpManaged = reactive<Record<string, string>>({})
-const acpError = ref('')
-const acpSubmitting = ref(false)
 
 function advanceWithCount() {
   addedCount.value++
@@ -88,8 +62,6 @@ const {
 const ctaLabel = computed(() => addedCount.value > 0 ? t('onboarding.next') : t('onboarding.skip'))
 
 function openForm(preset: ProviderPreset | null) {
-  // Choosing a regular provider supersedes any earlier ACP pick.
-  clearACPSelection()
   selectedPreset.value = preset
   initFormValues(preset)
   listVisible.value = false
@@ -111,7 +83,6 @@ function backToList() {
   setTimeout(() => {
     mode.value = 'list'
     selectedPreset.value = null
-    selectedAcpProfile.value = null
     resetFormState()
     listVisible.value = false
     visible.value = false
@@ -123,9 +94,6 @@ function backToList() {
 }
 
 function onSkipStep() {
-  // Skipping (or finishing with a regular provider) means this is not an ACP
-  // bot, so drop any stale ACP selection from an earlier visit to this step.
-  clearACPSelection()
   if (createdProviderId.value) {
     advanceWithCount()
   } else {
@@ -133,181 +101,15 @@ function onSkipStep() {
   }
 }
 
-async function openAcpForm(profile: AcpprofilePublicProfile) {
-  selectedAcpProfile.value = profile
-  acpError.value = ''
-  acpSubmitting.value = false
-  for (const key of Object.keys(acpManaged)) delete acpManaged[key]
-  for (const field of profile.managed_fields ?? []) {
-    const id = normalizeACPAgentID(field.id)
-    if (id) acpManaged[id] = ''
-  }
-  const modes = acpSetupModes(profile)
-  const preferred = defaultSetupMode(profile)
-  acpSetupMode.value = modes.includes(preferred) ? preferred : (modes[0] ?? defaultSetupMode(profile))
-  if (isAcpHermesProfile(profile) && acpSetupMode.value === 'api_key') {
-    ensureHermesManagedDefaults(acpManaged)
-  }
-  listVisible.value = false
-  setTimeout(() => {
-    mode.value = 'acp'
-    formVisible.value = false
-    formContentVisible.value = false
-    nextFrame(() => {
-      formVisible.value = true
-      formContentVisible.value = true
-    })
-  }, 175)
-}
-
-function acpSetupModes(profile: AcpprofilePublicProfile): string[] {
-  const modes = (profile.setup_modes ?? []).filter(Boolean)
-  return modes.length > 0 ? modes : ['api_key']
-}
-
-function acpSetupModeLabel(modeValue: string, profile: AcpprofilePublicProfile): string {
-  if (modeValue === 'api_key') return t('onboarding.provider.acp.modeApiKey')
-  if (modeValue === 'oauth') {
-    if (normalizeACPAgentID(profile.id) === 'codex') return t('onboarding.provider.acp.modeChatGPT')
-    if (normalizeACPAgentID(profile.id) === 'claude-code') return t('onboarding.provider.acp.modeClaude')
-    return t('onboarding.provider.acp.modeOAuth')
-  }
-  if (modeValue === 'self') return t('onboarding.provider.acp.modeSelf')
-  return modeValue
-}
-
-function setAcpSetupMode(modeValue: string) {
-  acpSetupMode.value = modeValue
-  if (selectedAcpProfile.value && isAcpHermesProfile(selectedAcpProfile.value) && modeValue === 'api_key') {
-    ensureHermesManagedDefaults(acpManaged)
-  }
-}
-
-function acpVisibleFields(profile: AcpprofilePublicProfile): AcpprofileManagedField[] {
-  if (acpSetupMode.value !== 'api_key') return []
-  return (profile.managed_fields ?? []).filter((field) => {
-    const id = normalizeACPAgentID(field.id)
-    if (!id || id === 'provider_id' || id === 'oauth_token') return false
-    if (isAcpHermesProfile(profile) && id === 'base_url') return isHermesCustomProvider(acpManaged.provider)
-    return true
-  })
-}
-
-function acpInputType(type: string | undefined): string {
-  if (type === 'password') return 'password'
-  if (type === 'url') return 'url'
-  return 'text'
-}
-
-function acpManagedPlaceholder(field: AcpprofileManagedField): string | undefined {
-  if (isAcpHermesProfile(selectedAcpProfile.value) && normalizeACPAgentID(field.id) === 'api_key') {
-    return hermesAPIKeyPlaceholder(acpHermesProvider(), field.placeholder)
-  }
-  return field.placeholder
-}
-
-function setAcpManaged(fieldID: string | undefined, value: string) {
-  const id = normalizeACPAgentID(fieldID)
-  if (!id) return
-  acpManaged[id] = value
-}
-
-function isAcpHermesProfile(profile: AcpprofilePublicProfile | null | undefined): boolean {
-  return normalizeACPAgentID(profile?.id) === 'hermes'
-}
-
-function isAcpHermesProviderField(field: AcpprofileManagedField): boolean {
-  return isAcpHermesProfile(selectedAcpProfile.value) && normalizeACPAgentID(field.id) === 'provider'
-}
-
-function isAcpHermesModelField(field: AcpprofileManagedField): boolean {
-  return isAcpHermesProfile(selectedAcpProfile.value) && normalizeACPAgentID(field.id) === 'model'
-}
-
-function acpHermesProvider(): string {
-  return hermesProviderValue(acpManaged.provider)
-}
-
-function acpHermesModelOptions() {
-  return hermesModelPresets(acpHermesProvider())
-}
-
-function acpHermesModelSelect(): string {
-  return hermesModelSelectValue(acpHermesProvider(), acpManaged.model)
-}
-
-function acpHermesUsingCustomModel(): boolean {
-  return acpHermesModelSelect() === HERMES_CUSTOM_MODEL_VALUE
-}
-
-function setAcpHermesProvider(value: string) {
-  const provider = hermesProviderValue(value)
-  acpManaged.provider = provider
-  acpManaged.model = hermesDefaultModel(provider)
-  if (!isHermesCustomProvider(provider)) acpManaged.base_url = ''
-}
-
-function setAcpHermesModel(value: string) {
-  if (value === HERMES_CUSTOM_MODEL_VALUE) {
-    if (isHermesPresetModel(acpHermesProvider(), acpManaged.model)) {
-      acpManaged.model = ''
-    }
-  } else {
-    acpManaged.model = value
-  }
-}
-
-function saveAcpAndNext() {
-  const profile = selectedAcpProfile.value
-  if (!profile || acpSubmitting.value) return
-  acpError.value = ''
-  if (acpSetupMode.value === 'api_key') {
-    const missing = findMissingRequiredManagedField(profile, acpManaged, acpSetupMode.value)
-    if (missing) {
-      acpError.value = t('onboarding.provider.acp.requiredError', { field: missing.label || missing.id || '' })
-      return
-    }
-  }
-  const agentId = normalizeACPAgentID(profile.id)
-  if (!agentId) return
-  const managed: Record<string, string> = {}
-  if (acpSetupMode.value === 'api_key') {
-    for (const field of acpVisibleFields(profile)) {
-      const id = normalizeACPAgentID(field.id)
-      const value = (acpManaged[id] ?? '').trim()
-      if (value) managed[id] = value
-    }
-  }
-  writeACPSelection({ agentId, setupMode: acpSetupMode.value, managed })
-  acpSubmitting.value = true
-  leave(nextStep)
-}
-
 onMounted(() => {
-  // Drop any ACP selection left over from an abandoned run; it is (re)written
-  // only when the user actually picks an agent on this step.
-  clearACPSelection()
-
   const stored = safeSessionGet(ONBOARDING_KEYS.providerAddedCount)
   if (stored !== null) {
     const parsed = Number.parseInt(stored, 10)
     if (Number.isFinite(parsed) && parsed >= 0) addedCount.value = parsed
   }
 
-  void (async () => {
-    try {
-      const { data } = await getAcpProfiles({ throwOnError: true })
-      acpProfiles.value = data?.items ?? []
-    } catch {
-      acpProfiles.value = []
-    } finally {
-      nextFrame(() => {
-        gridVisible.value = true
-      })
-    }
-  })()
-
   nextFrame(() => {
+    gridVisible.value = true
     listVisible.value = true
   })
 
@@ -347,7 +149,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <!-- 三个模式变体共用一个退出壳,所以壳在 StepFrame 之上而非各 frame 自带 -->
+  <!-- 两个模式变体共用一个退出壳,所以壳在 StepFrame 之上而非各 frame 自带 -->
   <StepExitShell :exiting="exiting">
     <StepFrame
       v-if="mode === 'list'"
@@ -390,19 +192,6 @@ onMounted(() => {
               />
             </template>
           </ChoiceTile>
-          <ChoiceTile
-            v-for="profile in acpProfiles"
-            :key="`acp-${profile.id}`"
-            :label="profile.display_name || profile.id"
-            @click="openAcpForm(profile)"
-          >
-            <template #icon>
-              <component
-                :is="acpAgentIcon(profile.id, true)"
-                class="size-[22px] shrink-0"
-              />
-            </template>
-          </ChoiceTile>
         </div>
       </div>
 
@@ -421,7 +210,7 @@ onMounted(() => {
       :visible="visible"
       :body-class="['pt-16 transition-all duration-[175ms] ease-out', formVisible ? 'scale-100 opacity-100' : 'scale-[0.96] opacity-0']"
     >
-      <!-- form/acp 模式有返回箭头+图标+标题的头行,而非纯 h2,走 #header slot -->
+      <!-- form 模式有返回箭头+图标+标题的头行,而非纯 h2,走 #header slot -->
       <template #header>
         <div
           class="mb-8 flex items-center gap-3 transition-all duration-[200ms] ease-out"
@@ -694,185 +483,6 @@ onMounted(() => {
                 {{ formCtaLabel }}
               </span>
             </Transition>
-          </button>
-        </template>
-      </FooterNav>
-    </StepFrame>
-
-    <StepFrame
-      v-else-if="mode === 'acp' && selectedAcpProfile"
-      :visible="visible"
-      :body-class="['pt-16 transition-all duration-[175ms] ease-out', formVisible ? 'scale-100 opacity-100' : 'scale-[0.96] opacity-0']"
-    >
-      <template #header>
-        <div
-          class="mb-8 flex items-center gap-3 transition-all duration-[200ms] ease-out"
-          :class="formContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
-        >
-          <button
-            type="button"
-            class="-ml-1.5 inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            :disabled="acpSubmitting"
-            :aria-label="t('onboarding.prev')"
-            @click="backToList"
-          >
-            <ArrowLeft class="size-4" />
-          </button>
-          <component
-            :is="acpAgentIcon(selectedAcpProfile.id, true)"
-            class="size-7 shrink-0"
-          />
-          <h2 class="text-2xl font-semibold">
-            {{ selectedAcpProfile.display_name || selectedAcpProfile.id }}
-          </h2>
-        </div>
-      </template>
-
-      <div class="min-h-0 flex-1 overflow-y-auto -mx-2 px-2 -my-1 py-1">
-        <FormStack>
-          <div
-            class="transition-all duration-[200ms] ease-out delay-[20ms]"
-            :class="formContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
-          >
-            <FieldStack>
-              <template #label>
-                <Label class="text-sm font-medium">
-                  {{ t('onboarding.provider.acp.setupMode') }}
-                </Label>
-              </template>
-              <div class="grid grid-cols-3 gap-2">
-                <button
-                  v-for="m in acpSetupModes(selectedAcpProfile)"
-                  :key="m"
-                  type="button"
-                  class="min-h-10 rounded-lg border px-3 py-2 text-sm font-medium leading-tight transition-colors"
-                  :class="acpSetupMode === m ? 'border-foreground bg-foreground text-background' : 'border-border bg-background text-foreground hover:bg-accent/40'"
-                  @click="setAcpSetupMode(m)"
-                >
-                  {{ acpSetupModeLabel(m, selectedAcpProfile) }}
-                </button>
-              </div>
-            </FieldStack>
-          </div>
-
-          <div
-            v-for="(field, index) in acpVisibleFields(selectedAcpProfile)"
-            :key="field.id || index"
-            class="transition-all duration-[200ms] ease-out"
-            :style="{ transitionDelay: `${40 + index * 20}ms` }"
-            :class="formContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
-          >
-            <FieldStack>
-              <template #label>
-                <Label class="text-sm font-medium">
-                  {{ field.label || field.id }}
-                </Label>
-              </template>
-              <Select
-                v-if="isAcpHermesProviderField(field)"
-                :model-value="acpHermesProvider()"
-                @update:model-value="(value) => setAcpHermesProvider(String(value))"
-              >
-                <SelectTrigger class="w-full">
-                  <SelectValue :placeholder="t('bots.settings.acpHermesProviderPlaceholder')" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem
-                    v-for="provider in HERMES_PROVIDER_PRESETS"
-                    :key="provider.value"
-                    :value="provider.value"
-                  >
-                    {{ t(provider.labelKey) }}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              <template v-else-if="isAcpHermesModelField(field)">
-                <Select
-                  :model-value="acpHermesModelSelect()"
-                  @update:model-value="(value) => setAcpHermesModel(String(value))"
-                >
-                  <SelectTrigger class="w-full">
-                    <SelectValue :placeholder="t('bots.settings.acpHermesModelPlaceholder')" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem
-                      v-for="model in acpHermesModelOptions()"
-                      :key="model.value"
-                      :value="model.value"
-                    >
-                      {{ model.label }}
-                    </SelectItem>
-                    <SelectItem :value="HERMES_CUSTOM_MODEL_VALUE">
-                      {{ t('bots.settings.acpHermesCustomModel') }}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <Input
-                  v-if="acpHermesUsingCustomModel()"
-                  class="mt-2"
-                  :model-value="acpManaged.model || ''"
-                  autocomplete="off"
-                  autocapitalize="off"
-                  autocorrect="off"
-                  spellcheck="false"
-                  :placeholder="t('bots.settings.acpHermesCustomModelPlaceholder')"
-                  @update:model-value="(val) => setAcpManaged(field.id, String(val ?? ''))"
-                />
-              </template>
-              <Input
-                v-else
-                :model-value="acpManaged[field.id || ''] || ''"
-                :type="acpInputType(field.type)"
-                autocomplete="off"
-                autocapitalize="off"
-                autocorrect="off"
-                spellcheck="false"
-                :placeholder="acpManagedPlaceholder(field)"
-                @update:model-value="(val) => setAcpManaged(field.id, String(val ?? ''))"
-              />
-            </FieldStack>
-          </div>
-
-          <HintBox
-            v-if="acpSetupMode === 'oauth'"
-            class="transition-all duration-[200ms] ease-out delay-[40ms]"
-            :class="formContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
-          >
-            {{ t('onboarding.provider.acp.oauthDeferredHint') }}
-          </HintBox>
-
-          <HintBox
-            v-else-if="acpSetupMode === 'self'"
-            class="transition-all duration-[200ms] ease-out delay-[40ms]"
-            :class="formContentVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
-          >
-            {{ isAcpHermesProfile(selectedAcpProfile) ? t('bots.settings.acpHermesSelfModeHint') : t('onboarding.provider.acp.selfHint') }}
-          </HintBox>
-        </FormStack>
-
-        <p
-          v-if="acpError"
-          class="mt-3 text-xs text-destructive"
-        >
-          {{ acpError }}
-        </p>
-      </div>
-
-      <FooterNav
-        class="delay-[80ms]"
-        :visible="formContentVisible"
-        :next-label="t('onboarding.next')"
-        :next-disabled="acpSubmitting"
-        @next="saveAcpAndNext"
-      >
-        <template #prev>
-          <button
-            type="button"
-            class="inline-flex h-[2.625rem] items-center justify-center rounded-lg px-4 text-sm font-normal text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
-            :disabled="acpSubmitting"
-            @click="backToList"
-          >
-            {{ t('onboarding.provider.form.cancel') }}
           </button>
         </template>
       </FooterNav>

--- a/apps/web/src/pages/onboarding/steps/Step4Bot.vue
+++ b/apps/web/src/pages/onboarding/steps/Step4Bot.vue
@@ -18,7 +18,7 @@ import { ref, reactive, computed, watch, onMounted } from 'vue'
 import { FieldStack, InlineLoadingRow, toast, useClipboard } from '@felinic/ui'
 import { useI18n } from 'vue-i18n'
 import { useQuery, useQueryCache } from '@pinia/colada'
-import { getModels, getProviders, getMemoryProviders, getAcpProfiles, type AcpprofilePublicProfile } from '@memohai/sdk'
+import { getModels, getProviders, getMemoryProviders, getAcpProfiles } from '@memohai/sdk'
 import { getBotsQueryKey } from '@memohai/sdk/colada'
 import { storeToRefs } from 'pinia'
 import { useOnboarding } from '@/composables/useOnboarding'
@@ -26,14 +26,17 @@ import { useACPOAuth } from '@/composables/useACPOAuth'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
 import { defaultAclPreset } from '@/constants/acl-presets'
 import { safeSessionSet } from '@/utils/safe-storage'
-import { acpAgentDisplayName, acpAgentIcon, isClaudeCodeAgent, isCodexAgent, withACPMetadata, type ACPForm } from '@/utils/acp'
+import { acpAgentDisplayName, acpAgentIcon, isClaudeCodeAgent, isCodexAgent, normalizeACPAgentID, withACPMetadata, type ACPForm } from '@/utils/acp'
 import { useBotCreateProgressStore } from '@/store/bot-create-progress'
 import AvatarEditDialog from '@/pages/bots/components/avatar-edit-dialog.vue'
 import BotCreateTerminal from '@/pages/bots/components/bot-create-terminal.vue'
 import ModelSelect from '@/pages/bots/components/model-select.vue'
+import AgentTypePill from '@/pages/bots/components/agent-type-pill.vue'
+import AcpSetupPanel from '@/pages/bots/components/acp-setup-panel.vue'
+import { MEMOH_AGENT_VALUE } from '@/pages/bots/components/agent-type'
 import { useStepTransition, nextFrame } from '../useStepTransition'
 import { ONBOARDING_KEYS } from '../constants'
-import { clearACPSelection, readACPSelection, type OnboardingACPSelection } from './useACPSetup'
+import { clearACPSelection, writeACPSelection, type OnboardingACPSelection } from './useACPSetup'
 import StepFrame from '../components/step-frame.vue'
 import StepExitShell from '../components/step-exit-shell.vue'
 import HintBox from '../components/hint-box.vue'
@@ -50,10 +53,30 @@ const submitting = ref(false)
 const store = useBotCreateProgressStore()
 const { lines: terminalLines, status: createStatus } = storeToRefs(store)
 
-const acpSelection = ref<OnboardingACPSelection | null>(null)
-const acpProfiles = ref<AcpprofilePublicProfile[]>([])
+const agentType = ref(MEMOH_AGENT_VALUE)
+const acpError = ref('')
+const acpSetupPanelRef = ref<InstanceType<typeof AcpSetupPanel> | null>(null)
 
-const isACPSelected = computed(() => !!acpSelection.value)
+const { data: acpProfileData } = useQuery({
+  key: ['acp-profiles'],
+  query: async () => {
+    const { data } = await getAcpProfiles({ throwOnError: true })
+    return data
+  },
+})
+const acpProfiles = computed(() => acpProfileData.value?.items ?? [])
+
+// Null while the built-in Memoh agent is picked — model select stays, no ACP
+// setup, no metadata.
+const selectedAcpProfile = computed(() => {
+  if (agentType.value === MEMOH_AGENT_VALUE) return null
+  return acpProfiles.value.find(profile => normalizeACPAgentID(profile.id) === agentType.value) ?? null
+})
+
+// Snapshot pulled from the setup panel at submit — drives the create metadata,
+// the sessionStorage selection Step5 reads, and the post-create OAuth phase.
+// The pill (agentType) is the choice; this is the committed form of it.
+const acpSelection = ref<OnboardingACPSelection | null>(null)
 const acpAgentId = computed(() => acpSelection.value?.agentId ?? '')
 const acpAgentName = computed(() => acpAgentDisplayName(acpAgentId.value))
 
@@ -86,17 +109,9 @@ const {
 } = useACPOAuth(() => oauthBotId.value)
 
 onMounted(() => {
-  acpSelection.value = readACPSelection()
-  if (acpSelection.value) {
-    void (async () => {
-      try {
-        const { data } = await getAcpProfiles({ throwOnError: true })
-        acpProfiles.value = data?.items ?? []
-      } catch {
-        acpProfiles.value = []
-      }
-    })()
-  }
+  // A selection is only (re)written at submit on this step — drop any stale
+  // one from an abandoned run so Step5's hasProvider can't pick it up.
+  clearACPSelection()
 })
 
 const form = reactive({
@@ -179,6 +194,23 @@ function buildMetadata(): Record<string, unknown> | undefined {
 
 async function handleSubmit() {
   if (!canSubmit.value || submitting.value) return
+
+  // Submit-time validation, not on-blur: the first empty required field is
+  // named inline inside the panel and nothing nags while typing.
+  if (selectedAcpProfile.value) {
+    const panel = acpSetupPanelRef.value
+    const missing = panel?.missingRequiredField()
+    if (missing) {
+      acpError.value = t('bots.agentCreate.requiredError', { field: missing.label || missing.id || '' })
+      return
+    }
+    const sel = panel?.selection()
+    // The panel renders together with the selection, so a missing ref means
+    // "not mounted yet" — there is nothing valid to submit against.
+    if (!sel) return
+    acpSelection.value = sel
+  }
+
   submitting.value = true
 
   // The store drives the inline terminal reactively while we await completion.
@@ -212,6 +244,11 @@ async function handleSubmit() {
   const botId = store.bot?.id
   if (botId) {
     safeSessionSet(ONBOARDING_KEYS.createdBotId, botId)
+  }
+  // Step5 reads this for its hasProvider gate and the ?acp= completion
+  // redirect; skipping OAuth below clears it again on purpose.
+  if (acpSelection.value) {
+    writeACPSelection(acpSelection.value)
   }
   if (store.setupError) {
     toast.error(store.setupError)
@@ -420,50 +457,50 @@ function skipOAuth() {
               <Separator class="my-6" />
             </div>
 
-            <!-- ACP 身份横幅:带品牌图标的 text-sm 状态行,不是 HintBox 那种
-                 text-xs 表单提示 —— 关系不同,留在本地。 -->
             <div
-              v-if="isACPSelected"
-              class="flex items-center gap-3 rounded-lg border border-border bg-muted-soft px-3 py-2.5 transition-all duration-[350ms] ease-out delay-[120ms]"
-              :class="visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
-            >
-              <component
-                :is="acpAgentIcon(acpAgentId, true)"
-                class="size-5 shrink-0"
-              />
-              <p class="text-sm text-muted-foreground">
-                {{ t('onboarding.bot.acp.banner', { agent: acpAgentName }) }}
-              </p>
-            </div>
-            <div
-              v-else
               class="transition-all duration-[350ms] ease-out delay-[120ms]"
               :class="visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-3'"
             >
-              <div class="mb-2 flex items-center gap-2">
-                <Label>{{ $t('bots.settings.chatModel') }}</Label>
-                <Tooltip>
-                  <TooltipTrigger as-child>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      class="size-5 text-muted-foreground hover:text-foreground"
-                    >
-                      <CircleHelp class="size-3.5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent class="max-w-80 text-left leading-relaxed">
-                    {{ $t('onboarding.bot.model.hint') }}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-              <ModelSelect
-                v-model="form.chat_model_id"
-                :models="models"
-                :providers="providers"
-                model-type="chat"
-                :placeholder="$t('onboarding.bot.model.selectPlaceholder')"
+              <!-- The chooser hides itself on servers with no hosted agents —
+                   the step then matches the pre-chooser behavior exactly. -->
+              <AgentTypePill
+                v-model="agentType"
+                :profiles="acpProfiles"
+                class="mb-3"
+              />
+              <template v-if="!selectedAcpProfile">
+                <div class="mb-2 flex items-center gap-2">
+                  <Label>{{ $t('bots.settings.chatModel') }}</Label>
+                  <Tooltip>
+                    <TooltipTrigger as-child>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        class="size-5 text-muted-foreground hover:text-foreground"
+                      >
+                        <CircleHelp class="size-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent class="max-w-80 text-left leading-relaxed">
+                      {{ $t('onboarding.bot.model.hint') }}
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <ModelSelect
+                  v-model="form.chat_model_id"
+                  :models="models"
+                  :providers="providers"
+                  model-type="chat"
+                  :placeholder="$t('onboarding.bot.model.selectPlaceholder')"
+                />
+              </template>
+              <AcpSetupPanel
+                v-else
+                ref="acpSetupPanelRef"
+                v-model:error-message="acpError"
+                :profile="selectedAcpProfile"
+                :oauth-hint="t('onboarding.bot.acp.deferredHint')"
               />
             </div>
 

--- a/apps/web/src/utils/acp/index.ts
+++ b/apps/web/src/utils/acp/index.ts
@@ -1,3 +1,4 @@
 export { acpAgentDisplayName, acpAgentIcon, isClaudeCodeAgent, isCodexAgent } from './agent-icon'
 export * from './hermes'
 export * from './metadata'
+export * from './setup-fields'

--- a/apps/web/src/utils/acp/setup-fields.test.ts
+++ b/apps/web/src/utils/acp/setup-fields.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import type { AcpprofilePublicProfile } from '@memohai/sdk'
+import {
+  acpSetupModeLabel,
+  acpSetupModes,
+  filterCreateVisibleManagedFields,
+  filterSettingsVisibleManagedFields,
+} from './setup-fields'
+
+const t = (key: string) => key
+
+function profile(overrides: Partial<AcpprofilePublicProfile> = {}): AcpprofilePublicProfile {
+  return {
+    id: 'codex',
+    display_name: 'Codex',
+    setup_modes: ['api_key', 'oauth', 'self'],
+    managed_fields: [
+      { id: 'api_key', label: 'API Key', required: true },
+      { id: 'provider_id', label: 'Provider' },
+      { id: 'oauth_token', label: 'OAuth' },
+    ],
+    ...overrides,
+  }
+}
+
+describe('acpSetupModes', () => {
+  it('falls back to api_key when setup_modes is empty', () => {
+    expect(acpSetupModes(profile({ setup_modes: [] }))).toEqual(['api_key'])
+  })
+})
+
+describe('acpSetupModeLabel', () => {
+  it('labels codex oauth mode', () => {
+    expect(acpSetupModeLabel(profile(), 'oauth', t)).toBe('bots.settings.acpSetupChatGPT')
+  })
+})
+
+describe('filterCreateVisibleManagedFields', () => {
+  it('returns no fields outside api_key mode', () => {
+    expect(filterCreateVisibleManagedFields(profile(), {}, 'oauth')).toEqual([])
+  })
+
+  it('drops provider_id and oauth_token in api_key mode', () => {
+    const fields = filterCreateVisibleManagedFields(profile(), {}, 'api_key')
+    expect(fields.map(f => f.id)).toEqual(['api_key'])
+  })
+})
+
+describe('filterSettingsVisibleManagedFields', () => {
+  it('hides managed fields for codex oauth mode', () => {
+    expect(filterSettingsVisibleManagedFields(profile(), {}, 'oauth')).toEqual([])
+  })
+
+  it('shows api_key field for claude in api_key mode only', () => {
+    const claude = profile({ id: 'claude-code' })
+    expect(filterSettingsVisibleManagedFields(claude, {}, 'api_key').map(f => f.id)).toEqual(['api_key'])
+    expect(filterSettingsVisibleManagedFields(claude, {}, 'oauth').map(f => f.id)).toEqual([])
+  })
+})

--- a/apps/web/src/utils/acp/setup-fields.ts
+++ b/apps/web/src/utils/acp/setup-fields.ts
@@ -1,0 +1,106 @@
+import type { AcpprofileManagedField, AcpprofilePublicProfile } from '@memohai/sdk'
+import { isClaudeCodeAgent, isCodexAgent } from './agent-icon'
+import { hermesAPIKeyPlaceholder, isHermesCustomProvider, hermesProviderValue } from './hermes'
+import { normalizeACPAgentID } from './metadata'
+
+export type AcpSetupModeLabelTranslate = (key: string) => string
+
+export function acpSetupModes(profile: AcpprofilePublicProfile): string[] {
+  const modes = (profile.setup_modes ?? []).filter(Boolean)
+  return modes.length > 0 ? modes : ['api_key']
+}
+
+export function acpSetupModeLabel(
+  profile: AcpprofilePublicProfile,
+  mode: string,
+  t: AcpSetupModeLabelTranslate,
+): string {
+  if (mode === 'api_key') return t('bots.settings.acpSetupApiKey')
+  if (mode === 'oauth') {
+    if (isCodexAgent(profile.id)) return t('bots.settings.acpSetupChatGPT')
+    if (isClaudeCodeAgent(profile.id)) return t('bots.settings.acpSetupClaude')
+    return t('bots.settings.acpSetupOAuth')
+  }
+  if (mode === 'self') return t('bots.settings.acpSetupSelf')
+  return mode
+}
+
+export function acpInputType(type: string | undefined): string {
+  if (type === 'password') return 'password'
+  if (type === 'url') return 'url'
+  return 'text'
+}
+
+export function acpManagedFieldHelp(
+  profile: AcpprofilePublicProfile,
+  field: AcpprofileManagedField,
+): string {
+  const isHermes = normalizeACPAgentID(profile.id) === 'hermes'
+  const id = normalizeACPAgentID(field.id)
+  if (isHermes && (id === 'provider' || id === 'model')) return ''
+  return field.help || ''
+}
+
+export function acpManagedPlaceholder(
+  profile: AcpprofilePublicProfile,
+  field: AcpprofileManagedField,
+  hermesProvider: string,
+): string | undefined {
+  const isHermes = normalizeACPAgentID(profile.id) === 'hermes'
+  if (isHermes && normalizeACPAgentID(field.id) === 'api_key') {
+    return hermesAPIKeyPlaceholder(hermesProvider, field.placeholder)
+  }
+  return field.placeholder
+}
+
+export function acpManagedFieldName(profile: AcpprofilePublicProfile, field: AcpprofileManagedField): string {
+  return `acp-${normalizeACPAgentID(profile.id) || 'agent'}-${normalizeACPAgentID(field.id) || 'field'}`
+}
+
+export function acpManagedFieldAutocomplete(field: AcpprofileManagedField): string {
+  return field.type === 'password' ? 'new-password' : 'off'
+}
+
+function isHermesProfile(profile: AcpprofilePublicProfile): boolean {
+  return normalizeACPAgentID(profile.id) === 'hermes'
+}
+
+/** Fields shown on create surfaces (new bot + onboarding) in api_key mode only. */
+export function filterCreateVisibleManagedFields(
+  profile: AcpprofilePublicProfile,
+  managed: Record<string, string>,
+  setupMode: string,
+): AcpprofileManagedField[] {
+  if (setupMode !== 'api_key') return []
+  const isHermes = isHermesProfile(profile)
+  const hermesProvider = hermesProviderValue(managed.provider)
+  return (profile.managed_fields ?? []).filter((field) => {
+    const id = normalizeACPAgentID(field.id)
+    if (!id || id === 'provider_id' || id === 'oauth_token') return false
+    if (isHermes && id === 'base_url') return isHermesCustomProvider(hermesProvider)
+    return true
+  })
+}
+
+/** Fields shown in bot settings for the active setup mode (includes OAuth-aware filtering). */
+export function filterSettingsVisibleManagedFields(
+  profile: AcpprofilePublicProfile,
+  managed: Record<string, string>,
+  setupMode: string,
+): AcpprofileManagedField[] {
+  const isHermes = isHermesProfile(profile)
+  const isCodex = isCodexAgent(profile.id)
+  const isClaude = isClaudeCodeAgent(profile.id)
+  const hermesProvider = hermesProviderValue(managed.provider)
+  return (profile.managed_fields ?? []).filter((field) => {
+    const id = normalizeACPAgentID(field.id)
+    if (id === 'provider_id') return false
+    if (isHermes && id === 'base_url') return isHermesCustomProvider(hermesProvider)
+    if (isCodex && setupMode === 'oauth') return false
+    if (isClaude) {
+      if (id === 'api_key') return setupMode === 'api_key'
+      if (id === 'oauth_token') return false
+    }
+    return true
+  })
+}


### PR DESCRIPTION
## Summary
Elevates hosted ACP agents (Claude Code / Codex) to equal footing with the built-in Memoh agent across bot creation surfaces in `@memohai/web`.

- **Bot Creation (`bots/new.vue`)**: Adds `AgentTypePill` + `AcpSetupPanel` for setup-mode configuration and required managed credentials. Encodes selection into bot `metadata` via `withACPMetadata`.
- **Onboarding (`Step4Bot.vue`)**: Replaces static ACP banner with `AgentTypePill` above ModelSelect. Hosted agent selection hides ModelSelect and shows setup panel inline.
- **Onboarding (`Step3Provider.vue`)**: Removes ACP profile tiles from provider grid — agent choice unified on Step 4.
- **Shared layer** (ported from Cloud QA): `acp-managed-fields.vue`, `setup-fields.ts`, `useAcpSetupModeItems` — reused by create surfaces and `settings-acp-detail.vue`.

## OSS vs Cloud
Onboarding shell differs between OSS and Cloud fork; this PR targets OSS `main` structure. Cloud-specific wizard polish (draft persistence, catalog prefetch) lives on `submodule/memoh` only.

## Test Plan
- [x] Unit: `agent-type.test.ts`, `setup-fields.test.ts` (12/12 pass)
- [x] Pre-commit: Go test + ESLint
- [ ] Human QA: onboarding Step 4 agent pill + `/bots/new` + settings ACP tab

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.