### PR TITLE
feat(context): fragments-first authoritative context compiler

### DIFF
--- a/cmd/internal/core/providers.go
+++ b/cmd/internal/core/providers.go
@@ -53,6 +53,7 @@ import (
 	"github.com/memohai/memoh/internal/connectors"
 	ctr "github.com/memohai/memoh/internal/container"
 	containerprovider "github.com/memohai/memoh/internal/container/provider"
+	"github.com/memohai/memoh/internal/contextview"
 	"github.com/memohai/memoh/internal/db"
 	pgvectordb "github.com/memohai/memoh/internal/db/pgvector"
 	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
@@ -431,10 +432,11 @@ func provideScheduleSessionCreator(sessionService *sessionpkg.Service) schedule.
 
 func provideAgent(log *slog.Logger, provider bridge.Provider, hookService *hookspkg.Service, cfg config.Config) *native.Agent {
 	return native.New(native.Deps{
-		BridgeProvider: provider,
-		HookService:    hookService,
-		Logger:         log,
-		Limits:         agentLimitsFromConfig(cfg.Agent),
+		BridgeProvider:     provider,
+		HookService:        hookService,
+		Logger:             log,
+		Limits:             agentLimitsFromConfig(cfg.Agent),
+		ContextViewApplier: contextview.ProviderRunConfigApplier(log),
 	})
 }
 

--- a/internal/agent/application/context_frag.go
+++ b/internal/agent/application/context_frag.go
@@ -1,13 +1,34 @@
 package application
 
 import (
+	"context"
 	"strings"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 	"github.com/memohai/memoh/internal/agent/sessionmode"
 	"github.com/memohai/memoh/internal/agent/turn"
+	"github.com/memohai/memoh/internal/contextview"
 )
+
+func buildProviderSourceFrags(
+	ctx context.Context,
+	cfg native.RunConfig,
+	sections []native.SystemSection,
+	promptHookTexts []string,
+) []contextfrag.ContextFrag {
+	frags := native.SystemSectionFrags(sections, cfg.ContextScope)
+	if hookText := strings.Join(promptHookTexts, "\n\n"); hookText != "" {
+		hookFrags, err := (&contextview.HookContextCollector{}).Collect(ctx, contextview.CollectRequest{
+			Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider,
+			Config: contextview.HookContextConfig{Text: hookText},
+		})
+		if err == nil {
+			frags = append(frags, hookFrags...)
+		}
+	}
+	return append(frags, contextview.CollectNonSystemProviderSourceFrags(ctx, cfg)...)
+}
 
 func buildContextFragScope(req ChatRequest, displayName string, identity native.SessionContext) contextfrag.Scope {
 	channelIdentityID := firstNonEmpty(req.SourceChannelIdentityID, identity.ChannelIdentityID)

--- a/internal/agent/application/context_frag_test.go
+++ b/internal/agent/application/context_frag_test.go
@@ -2,13 +2,17 @@ package application
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
 	"github.com/memohai/memoh/internal/agent/turn"
+	"github.com/memohai/memoh/internal/contextview"
+	"github.com/memohai/memoh/internal/hooks"
 )
 
 func TestBuildContextFragScopePreservesIMTopology(t *testing.T) {
@@ -106,6 +110,46 @@ func TestPrepareRunConfigDoesNotDoubleCountPipelineInlineImages(t *testing.T) {
 	}
 	if !messagesContainImage(got.Messages) {
 		t.Fatalf("prepared messages do not contain injected image: %#v", got.Messages)
+	}
+	if got.ContextCurrentUserMessageIndex == nil || *got.ContextCurrentUserMessageIndex != 0 {
+		t.Fatalf("current user index = %#v, want image recipient 0", got.ContextCurrentUserMessageIndex)
+	}
+	if len(got.ContextSourceFrags) == 0 {
+		t.Fatal("prepared config did not build authoritative source fragments")
+	}
+}
+
+func TestBuildProviderSourceFragsPreservesLegacyPromptHookAndMemoryBytes(t *testing.T) {
+	t.Parallel()
+	params := native.SystemPromptParams{SessionType: sessionmode.Chat, Timezone: "UTC"}
+	hookTexts := []string{
+		formatServiceHookContext(hooks.EventBeforePromptBuild, "before bytes"),
+		formatServiceHookContext(hooks.EventAfterPromptBuild, "after bytes"),
+	}
+	system := native.GenerateSystemPrompt(params) + "\n\n" + hookTexts[0] + "\n\n" + hookTexts[1]
+	messages := []sdk.Message{
+		sdk.UserMessage("raw memory recall\n\n[Hook Context: AfterMemorySearch]\nraw memory hook"),
+		sdk.UserMessage("  current request  "),
+	}
+	index := 1
+	cfg := native.RunConfig{
+		System: system, Messages: messages, ContextCurrentUserMessageIndex: &index,
+		ContextQueryMaterialized: true, ContextScope: contextfrag.Scope{BotID: "bot-1"},
+	}
+	cfg.ContextSourceFrags = buildProviderSourceFrags(context.Background(), cfg, native.GenerateSystemSections(params), hookTexts)
+
+	hookCount := 0
+	for _, frag := range cfg.ContextSourceFrags {
+		if frag.Kind == contextfrag.KindHookContext {
+			hookCount++
+		}
+	}
+	if hookCount != 1 {
+		t.Fatalf("hook fragment count = %d, want one combined system tail", hookCount)
+	}
+	got := contextview.ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if got.System != system || !reflect.DeepEqual(got.Messages, messages) {
+		t.Fatalf("provider bytes changed: system=%q messages=%#v", got.System, got.Messages)
 	}
 }
 

--- a/internal/agent/application/context_frag_test.go
+++ b/internal/agent/application/context_frag_test.go
@@ -94,9 +94,16 @@ func TestPrepareRunConfigDoesNotDoubleCountPipelineInlineImages(t *testing.T) {
 
 	image := sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"}
 	resolver := &Service{}
+	currentIndex := 0
+	memoryIndex := 1
 	cfg := native.RunConfig{
-		Messages:     []sdk.Message{sdk.UserMessage("pipeline current user")},
-		InlineImages: []sdk.ImagePart{image},
+		Messages: []sdk.Message{
+			sdk.UserMessage("pipeline current user"),
+			sdk.UserMessage("memory recall"),
+		},
+		InlineImages:                   []sdk.ImagePart{image},
+		ContextCurrentUserMessageIndex: &currentIndex,
+		ContextMemoryMessageIndex:      &memoryIndex,
 	}
 
 	got := resolver.prepareRunConfig(context.Background(), cfg)
@@ -112,10 +119,122 @@ func TestPrepareRunConfigDoesNotDoubleCountPipelineInlineImages(t *testing.T) {
 		t.Fatalf("prepared messages do not contain injected image: %#v", got.Messages)
 	}
 	if got.ContextCurrentUserMessageIndex == nil || *got.ContextCurrentUserMessageIndex != 0 {
-		t.Fatalf("current user index = %#v, want image recipient 0", got.ContextCurrentUserMessageIndex)
+		t.Fatalf("current user index = %#v, want pipeline current 0", got.ContextCurrentUserMessageIndex)
+	}
+	if got.ContextMemoryMessageIndex == nil || *got.ContextMemoryMessageIndex != 1 {
+		t.Fatalf("memory index = %#v, want 1", got.ContextMemoryMessageIndex)
+	}
+	wantMessages := []sdk.Message{
+		sdk.UserMessage("pipeline current user"),
+		sdk.UserMessage("memory recall", image),
+	}
+	if !reflect.DeepEqual(got.Messages, wantMessages) {
+		t.Fatalf("provider messages changed: got %#v want %#v", got.Messages, wantMessages)
 	}
 	if len(got.ContextSourceFrags) == 0 {
 		t.Fatal("prepared config did not build authoritative source fragments")
+	}
+}
+
+func TestPrepareRunConfigPreservesPipelineFileAttachmentBytes(t *testing.T) {
+	t.Parallel()
+
+	file := sdk.FilePart{
+		Data:      "JVBERi0xLjQ=",
+		MediaType: "application/pdf",
+		Filename:  "report.pdf",
+	}
+	currentIndex := 0
+	cfg := native.RunConfig{
+		Messages:                       []sdk.Message{sdk.UserMessage("pipeline current user")},
+		InlineAttachments:              []sdk.MessagePart{file},
+		ContextCurrentUserMessageIndex: &currentIndex,
+	}
+
+	prepared := (&Service{}).prepareRunConfig(context.Background(), cfg)
+	got := contextview.ApplyProviderRunConfig(context.Background(), nil, prepared)
+	want := []sdk.Message{sdk.UserMessage("pipeline current user", file)}
+
+	if !reflect.DeepEqual(got.Messages, want) {
+		t.Fatalf("provider messages changed: got %#v want %#v", got.Messages, want)
+	}
+}
+
+func TestNormalizeContextMessagesRemapsCurrentAndMemory(t *testing.T) {
+	t.Parallel()
+
+	webCall := sdkMessagesToModelMessages([]sdk.Message{{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{sdk.ToolCallPart{
+			ToolCallID: "web-call", ToolName: "web_fetch",
+		}},
+	}})[0]
+	webResult := sdkMessagesToModelMessages([]sdk.Message{sdk.ToolMessage(sdk.ToolResultPart{
+		ToolCallID: "web-call", ToolName: "web_fetch", Result: "discarded",
+	})})[0]
+	askCall := sdkMessagesToModelMessages([]sdk.Message{{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{sdk.ToolCallPart{
+			ToolCallID: "ask-call", ToolName: "ask_user",
+		}},
+	}})[0]
+	messages := []ModelMessage{
+		{Content: newTextContent("missing role")},
+		{Role: "user", Content: newTextContent("history 0")},
+		{Role: "assistant", Content: newTextContent("answer 0")},
+		{Role: "user", Content: newTextContent("history 1")},
+		webCall,
+		webResult,
+		{Role: "assistant", Content: newTextContent("answer 1")},
+		{Role: "user", Content: newTextContent("history 2")},
+		{Role: "assistant", Content: newTextContent("answer 2")},
+		{Role: "user", Content: newTextContent("history 3")},
+		askCall,
+		{Role: "user", Content: newTextContent("pipeline current")},
+		{Role: "user", Content: newTextContent("memory recall")},
+	}
+	currentIndex := 11
+	memoryIndex := 12
+
+	want := sanitizeMessages(messages)
+	if len(want) <= 10 {
+		t.Fatalf("fixture did not activate tool stripping: %d messages", len(want))
+	}
+	want = stripToolMessages(want)
+	want = repairToolCallClosures(want, syntheticToolClosureError)
+	got, gotCurrent, gotMemory := normalizeContextMessages(messages, &currentIndex, &memoryIndex)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized messages changed: got %#v want %#v", got, want)
+	}
+	if gotCurrent == nil || *gotCurrent != 9 || got[*gotCurrent].TextContent() != "pipeline current" {
+		t.Fatalf("current index = %#v in %#v, want pipeline current at 9", gotCurrent, got)
+	}
+	if gotMemory == nil || *gotMemory != 10 || got[*gotMemory].TextContent() != "memory recall" {
+		t.Fatalf("memory index = %#v in %#v, want memory recall at 10", gotMemory, got)
+	}
+}
+
+func TestPrependContextMessagesShiftsTrackedCurrentUser(t *testing.T) {
+	t.Parallel()
+
+	prefix := []ModelMessage{
+		{Role: "user", Content: newTextContent("parent fork context")},
+		{Role: "assistant", Content: newTextContent("parent answer")},
+	}
+	messages := []ModelMessage{
+		{Role: "assistant", Content: newTextContent("thread history")},
+		{Role: "user", Content: newTextContent("pipeline current")},
+	}
+	currentIndex := 1
+
+	got, gotCurrent := prependContextMessages(prefix, messages, &currentIndex)
+
+	if gotCurrent == nil || *gotCurrent != 3 {
+		t.Fatalf("current index = %#v, want shifted index 3", gotCurrent)
+	}
+	if got[*gotCurrent].TextContent() != "pipeline current" {
+		t.Fatalf("tracked message = %q, want pipeline current", got[*gotCurrent].TextContent())
 	}
 }
 

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -397,8 +397,10 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 	var estimatedTokens int
 	var compactableTokens int
 	var compactableTokensKnown bool
+	var currentMessageIndex *int
 	if usePipeline {
 		messages = s.buildMessagesFromPipeline(ctx, req, contextTokenBudget)
+		currentMessageIndex = latestModelUserMessageIndex(messages)
 	} else {
 		historyFallback := historyScopeFallbackFromChatRequest(req)
 		prepared, loadErr := s.prepareHistoryContext(ctx, req, historyFallback, contextTokenBudget)
@@ -455,13 +457,15 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 	if forkContext := s.subagentForkContextModelMessages(ctx, req); len(forkContext) > 0 {
 		// The inherited parent snapshot precedes the thread's own transcript,
 		// exactly as parent-driven subagent tasks assemble it.
-		messages = append(forkContext, messages...)
+		messages, currentMessageIndex = prependContextMessages(forkContext, messages, currentMessageIndex)
 	}
 	if notice := s.currentWorkspaceContextMessage(ctx, req); notice != nil {
 		messages = append(messages, *notice)
 	}
+	var memoryMessageIndex *int
 	if memoryMsg != nil {
 		messages = append(messages, *memoryMsg)
+		memoryMessageIndex = intPointer(len(messages) - 1)
 	}
 	if requestedSkillMsg := buildRequestedSkillContextMessage(req.RequestedSkills); requestedSkillMsg != nil {
 		messages = append(messages, *requestedSkillMsg)
@@ -469,14 +473,11 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 	if !usePipeline && !req.ReusePersistedUserMessage {
 		messages = append(messages, reqMessages...)
 	}
-	messages = sanitizeMessages(messages)
-	// Strip tool messages and tool-call-only assistant messages from context.
-	// Tool outputs are large and waste tokens; the LLM doesn't need raw tool
-	// results when summaries and memory tools are available for lookup.
-	if len(messages) > 10 {
-		messages = stripToolMessages(messages)
-	}
-	messages = repairToolCallClosures(messages, syntheticToolClosureError)
+	messages, currentMessageIndex, memoryMessageIndex = normalizeContextMessages(
+		messages,
+		currentMessageIndex,
+		memoryMessageIndex,
+	)
 
 	displayName := s.resolveDisplayName(ctx, req)
 	mergedAttachments := s.routeAndMergeAttachments(ctx, chatModel, req)
@@ -509,8 +510,9 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 	forkMessages := nonNilModelMessages(messages)
 	runCfg.ForkContextSourceMessageIDs = historySourceMessageIDsForMessages(forkMessages, historyRecords)
 	runCfg.Messages = modelMessagesToSDKMessages(forkMessages)
+	runCfg.ContextMemoryMessageIndex = memoryMessageIndex
 	if usePipeline {
-		runCfg.ContextCurrentUserMessageIndex = latestUserMessageIndex(runCfg.Messages)
+		runCfg.ContextCurrentUserMessageIndex = currentMessageIndex
 	}
 	// When using the pipeline the user message is already in the RC;
 	// don't send it to the LLM again. headerifiedQuery is still kept
@@ -1354,6 +1356,11 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 		}
 		imageParts = append(imageParts, cfg.InlineAttachments...)
 		if len(imageParts) > 0 {
+			currentIndex := validCurrentUserMessageIndex(
+				cfg.Messages,
+				cfg.ContextCurrentUserMessageIndex,
+				cfg.ContextMemoryMessageIndex,
+			)
 			injected := false
 			for i := len(cfg.Messages) - 1; i >= 0; i-- {
 				if cfg.Messages[i].Role == sdk.MessageRoleUser {
@@ -1361,8 +1368,6 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 					if i < len(cfg.ForkContextSourceMessageIDs) {
 						cfg.ForkContextSourceMessageIDs[i] = ""
 					}
-					index := i
-					cfg.ContextCurrentUserMessageIndex = &index
 					injected = true
 					break
 				}
@@ -1371,8 +1376,9 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 				cfg.Messages = append(cfg.Messages, sdk.UserMessage("", imageParts...))
 				cfg.ForkContextSourceMessageIDs = append(cfg.ForkContextSourceMessageIDs, "")
 				index := len(cfg.Messages) - 1
-				cfg.ContextCurrentUserMessageIndex = &index
+				currentIndex = &index
 			}
+			cfg.ContextCurrentUserMessageIndex = currentIndex
 			cfg.ContextQueryMaterialized = true
 		}
 	}
@@ -1381,15 +1387,92 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 	return cfg.RefreshContextFrag()
 }
 
-func latestUserMessageIndex(messages []sdk.Message) *int {
+func normalizeContextMessages(messages []ModelMessage, currentIndex, memoryIndex *int) ([]ModelMessage, *int, *int) {
+	cleaned := sanitizeMessages(messages)
+	stripTools := len(cleaned) > 10
+	if stripTools {
+		// Tool outputs are large and waste tokens; the LLM doesn't need raw
+		// tool results when summaries and memory tools are available for lookup.
+		cleaned = stripToolMessages(cleaned)
+	}
+	cleaned = repairToolCallClosures(cleaned, syntheticToolClosureError)
+	return cleaned,
+		remapContextMessageIndex(messages, currentIndex, stripTools),
+		remapContextMessageIndex(messages, memoryIndex, stripTools)
+}
+
+func prependContextMessages(prefix, messages []ModelMessage, trackedIndex *int) ([]ModelMessage, *int) {
+	if len(prefix) == 0 {
+		return messages, trackedIndex
+	}
+	if trackedIndex != nil {
+		if *trackedIndex < 0 || *trackedIndex >= len(messages) {
+			trackedIndex = nil
+		} else {
+			trackedIndex = intPointer(*trackedIndex + len(prefix))
+		}
+	}
+	return append(prefix, messages...), trackedIndex
+}
+
+func remapContextMessageIndex(messages []ModelMessage, index *int, stripTools bool) *int {
+	if index == nil || *index < 0 || *index >= len(messages) || !strings.EqualFold(strings.TrimSpace(messages[*index].Role), "user") {
+		return nil
+	}
+	prefix := sanitizeMessages(messages[:*index+1])
+	if stripTools {
+		prefix = stripToolMessages(prefix)
+	}
+	prefix = repairToolCallClosures(prefix, syntheticToolClosureError)
+	if len(prefix) == 0 || !strings.EqualFold(strings.TrimSpace(prefix[len(prefix)-1].Role), "user") {
+		return nil
+	}
+	return intPointer(len(prefix) - 1)
+}
+
+func latestModelUserMessageIndex(messages []ModelMessage) *int {
 	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == sdk.MessageRoleUser {
-			index := i
-			return &index
+		if strings.EqualFold(strings.TrimSpace(messages[i].Role), "user") {
+			return intPointer(i)
 		}
 	}
 	return nil
 }
+
+func validCurrentUserMessageIndex(messages []sdk.Message, currentIndex, memoryIndex *int) *int {
+	if currentIndex != nil && *currentIndex >= 0 && *currentIndex < len(messages) &&
+		messages[*currentIndex].Role == sdk.MessageRoleUser && (memoryIndex == nil || *currentIndex != *memoryIndex) {
+		return intPointer(*currentIndex)
+	}
+	return latestUserMessageIndex(messages, optionalIndex(memoryIndex)...)
+}
+
+func latestUserMessageIndex(messages []sdk.Message, excluded ...int) *int {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == sdk.MessageRoleUser && !containsIndex(excluded, i) {
+			return intPointer(i)
+		}
+	}
+	return nil
+}
+
+func optionalIndex(index *int) []int {
+	if index == nil {
+		return nil
+	}
+	return []int{*index}
+}
+
+func containsIndex(indexes []int, target int) bool {
+	for _, index := range indexes {
+		if index == target {
+			return true
+		}
+	}
+	return false
+}
+
+func intPointer(value int) *int { return &value }
 
 func normalizeGatewaySkill(entry SkillEntry) (native.SkillEntry, bool) {
 	name := strings.TrimSpace(entry.Name)

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -509,6 +509,9 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 	forkMessages := nonNilModelMessages(messages)
 	runCfg.ForkContextSourceMessageIDs = historySourceMessageIDsForMessages(forkMessages, historyRecords)
 	runCfg.Messages = modelMessagesToSDKMessages(forkMessages)
+	if usePipeline {
+		runCfg.ContextCurrentUserMessageIndex = latestUserMessageIndex(runCfg.Messages)
+	}
 	// When using the pipeline the user message is already in the RC;
 	// don't send it to the LLM again. headerifiedQuery is still kept
 	// for storeRound so the user message gets persisted.
@@ -1296,7 +1299,7 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 			platformIdentitiesSection = buildPlatformIdentitiesSection(identities)
 		}
 	}
-	cfg.System = native.GenerateSystemPrompt(native.SystemPromptParams{
+	systemParams := native.SystemPromptParams{
 		SessionType:               cfg.SessionType,
 		Bot:                       cfg.Bot,
 		Skills:                    cfg.Skills,
@@ -1304,9 +1307,13 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 		MaxFilesBytes:             limits.SystemFilesMaxBytes,
 		Timezone:                  cfg.Identity.Timezone,
 		PlatformIdentitiesSection: platformIdentitiesSection,
-	})
+	}
+	cfg.System = native.GenerateSystemPrompt(systemParams)
+	var promptHookTexts []string
 	if beforePromptContext != "" {
-		cfg.System += "\n\n" + formatServiceHookContext(hooks.EventBeforePromptBuild, beforePromptContext)
+		text := formatServiceHookContext(hooks.EventBeforePromptBuild, beforePromptContext)
+		cfg.System += "\n\n" + text
+		promptHookTexts = append(promptHookTexts, text)
 	}
 	afterPromptContext := s.runPromptHook(ctx, agentRunConfigView{
 		BotID:        cfg.Identity.BotID,
@@ -1317,7 +1324,9 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 		SystemBytes:  len(cfg.System),
 	}, hooks.EventAfterPromptBuild)
 	if afterPromptContext != "" {
-		cfg.System += "\n\n" + formatServiceHookContext(hooks.EventAfterPromptBuild, afterPromptContext)
+		text := formatServiceHookContext(hooks.EventAfterPromptBuild, afterPromptContext)
+		cfg.System += "\n\n" + text
+		promptHookTexts = append(promptHookTexts, text)
 	}
 
 	if cfg.Query != "" {
@@ -1330,6 +1339,8 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 		extra = append(extra, cfg.InlineAttachments...)
 		cfg.Messages = append(cfg.Messages, sdk.UserMessage(cfg.Query, extra...))
 		cfg.ForkContextSourceMessageIDs = append(cfg.ForkContextSourceMessageIDs, "")
+		index := len(cfg.Messages) - 1
+		cfg.ContextCurrentUserMessageIndex = &index
 		cfg.ContextQueryMaterialized = true
 	} else if len(cfg.InlineImages) > 0 || len(cfg.InlineAttachments) > 0 {
 		// Pipeline path: the user query is already embedded in the RC messages,
@@ -1350,6 +1361,8 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 					if i < len(cfg.ForkContextSourceMessageIDs) {
 						cfg.ForkContextSourceMessageIDs[i] = ""
 					}
+					index := i
+					cfg.ContextCurrentUserMessageIndex = &index
 					injected = true
 					break
 				}
@@ -1357,12 +1370,25 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 			if !injected {
 				cfg.Messages = append(cfg.Messages, sdk.UserMessage("", imageParts...))
 				cfg.ForkContextSourceMessageIDs = append(cfg.ForkContextSourceMessageIDs, "")
+				index := len(cfg.Messages) - 1
+				cfg.ContextCurrentUserMessageIndex = &index
 			}
 			cfg.ContextQueryMaterialized = true
 		}
 	}
 
+	cfg.ContextSourceFrags = buildProviderSourceFrags(ctx, cfg, native.GenerateSystemSections(systemParams), promptHookTexts)
 	return cfg.RefreshContextFrag()
+}
+
+func latestUserMessageIndex(messages []sdk.Message) *int {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == sdk.MessageRoleUser {
+			index := i
+			return &index
+		}
+	}
+	return nil
 }
 
 func normalizeGatewaySkill(entry SkillEntry) (native.SkillEntry, bool) {

--- a/internal/agent/application/service_continuation.go
+++ b/internal/agent/application/service_continuation.go
@@ -37,6 +37,7 @@ func (s *Service) prepareContinuationRunConfig(
 	// provider-valid. Applies to every continuation path that resumes after a
 	// deferred tool call.
 	base.Messages = modelMessagesToSDKMessages(repairToolCallClosures(nonNilModelMessages(messages), syntheticToolClosureError))
+	base.ContextCurrentUserMessageIndex = nil
 	base.Query = ""
 	base.LiveToolStream = eventCh != nil
 	base.CanRequestUserInput = s.canDeliverUserInputWS(eventCh)

--- a/internal/agent/application/service_continuation.go
+++ b/internal/agent/application/service_continuation.go
@@ -38,6 +38,7 @@ func (s *Service) prepareContinuationRunConfig(
 	// deferred tool call.
 	base.Messages = modelMessagesToSDKMessages(repairToolCallClosures(nonNilModelMessages(messages), syntheticToolClosureError))
 	base.ContextCurrentUserMessageIndex = nil
+	base.ContextMemoryMessageIndex = nil
 	base.Query = ""
 	base.LiveToolStream = eventCh != nil
 	base.CanRequestUserInput = s.canDeliverUserInputWS(eventCh)

--- a/internal/agent/application/service_continuation_test.go
+++ b/internal/agent/application/service_continuation_test.go
@@ -18,9 +18,15 @@ func TestPrepareContinuationRunConfigReplacesStaleContextAndSetsCapabilities(t *
 
 	resolver := &Service{userInput: &userinput.Service{}}
 	eventCh := make(chan WSStreamEvent)
+	staleIndex := 0
 	base := native.RunConfig{
-		Query:    "stale query",
-		Messages: []sdk.Message{sdk.UserMessage("stale context")},
+		Query:                          "stale query",
+		Messages:                       []sdk.Message{sdk.UserMessage("stale context")},
+		ContextCurrentUserMessageIndex: &staleIndex,
+		ContextSourceFrags: []contextfrag.ContextFrag{{
+			ID:   "stale-source-fragment",
+			Kind: contextfrag.KindConversationEvent,
+		}},
 		ContextFrags: []contextfrag.ContextFrag{{
 			ID:   "stale-fragment",
 			Kind: contextfrag.KindConversationEvent,
@@ -43,6 +49,14 @@ func TestPrepareContinuationRunConfigReplacesStaleContextAndSetsCapabilities(t *
 	for _, frag := range got.ContextFrags {
 		if frag.ID == "stale-fragment" {
 			t.Fatalf("continuation retained stale fragment: %#v", frag)
+		}
+	}
+	if got.ContextCurrentUserMessageIndex != nil {
+		t.Fatalf("continuation retained stale current-user index: %#v", got.ContextCurrentUserMessageIndex)
+	}
+	for _, frag := range got.ContextSourceFrags {
+		if frag.ID == "stale-source-fragment" {
+			t.Fatalf("continuation retained stale source fragment: %#v", frag)
 		}
 	}
 	if !got.LiveToolStream || !got.CanRequestUserInput {

--- a/internal/agent/application/service_continuation_test.go
+++ b/internal/agent/application/service_continuation_test.go
@@ -19,10 +19,12 @@ func TestPrepareContinuationRunConfigReplacesStaleContextAndSetsCapabilities(t *
 	resolver := &Service{userInput: &userinput.Service{}}
 	eventCh := make(chan WSStreamEvent)
 	staleIndex := 0
+	staleMemoryIndex := 0
 	base := native.RunConfig{
 		Query:                          "stale query",
 		Messages:                       []sdk.Message{sdk.UserMessage("stale context")},
 		ContextCurrentUserMessageIndex: &staleIndex,
+		ContextMemoryMessageIndex:      &staleMemoryIndex,
 		ContextSourceFrags: []contextfrag.ContextFrag{{
 			ID:   "stale-source-fragment",
 			Kind: contextfrag.KindConversationEvent,
@@ -53,6 +55,9 @@ func TestPrepareContinuationRunConfigReplacesStaleContextAndSetsCapabilities(t *
 	}
 	if got.ContextCurrentUserMessageIndex != nil {
 		t.Fatalf("continuation retained stale current-user index: %#v", got.ContextCurrentUserMessageIndex)
+	}
+	if got.ContextMemoryMessageIndex != nil {
+		t.Fatalf("continuation retained stale memory index: %#v", got.ContextMemoryMessageIndex)
 	}
 	for _, frag := range got.ContextSourceFrags {
 		if frag.ID == "stale-source-fragment" {

--- a/internal/agent/application/service_history_records_test.go
+++ b/internal/agent/application/service_history_records_test.go
@@ -16,6 +16,7 @@ import (
 	userinput "github.com/memohai/memoh/internal/agent/decision/input"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
+	"github.com/memohai/memoh/internal/contextview"
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -243,6 +244,30 @@ func TestHistoryContextFragsForMessagesCarriesActiveSummaryCoverage(t *testing.T
 	}
 	if summaryItems != 1 {
 		t.Fatalf("run config manifest summary items = %d, want 1: %#v", summaryItems, cfg.ContextManifest.Items)
+	}
+
+	cfg.ContextQueryMaterialized = true
+	cfg.ContextSourceFrags = buildProviderSourceFrags(context.Background(), cfg, nil, nil)
+	providerCfg := contextview.ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if !reflect.DeepEqual(providerCfg.Messages, cfg.Messages) {
+		t.Fatalf("provider messages changed: got %#v want %#v", providerCfg.Messages, cfg.Messages)
+	}
+	if len(providerCfg.ContextManifest.CoverageTrace) != 1 {
+		t.Fatalf("provider manifest lost summary coverage: %#v", providerCfg.ContextManifest)
+	}
+	providerSummaryItems := 0
+	for _, item := range providerCfg.ContextManifest.Items {
+		if item.Kind == contextfrag.KindConversationSummary {
+			providerSummaryItems++
+			if item.Ref.Namespace != summary.Ref.Namespace || item.Ref.ID != summary.Ref.ID ||
+				item.Ref.Version != summary.Ref.Version || item.Ref.Durability != contextfrag.RefDurable ||
+				item.Ref.ContentHash == "" {
+				t.Fatalf("provider summary ref lost durable identity: got %#v source %#v", item.Ref, summary.Ref)
+			}
+		}
+	}
+	if providerSummaryItems != 1 {
+		t.Fatalf("provider manifest summary items = %d, want 1: %#v", providerSummaryItems, providerCfg.ContextManifest.Items)
 	}
 }
 

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -154,6 +154,8 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 	runConfig.Messages = discussMessagesToSDK(cmd.DiscussMessages)
 	runConfig.SessionType = sessionpkg.TypeDiscuss
 	runConfig.Query = ""
+	runConfig.ContextCurrentUserMessageIndex = nil
+	runConfig.ContextSourceFrags = nil
 
 	// Inline image attachments from new RC segments so the model receives
 	// them as native vision input (ImagePart) on the first encounter.

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -155,6 +155,7 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 	runConfig.SessionType = sessionpkg.TypeDiscuss
 	runConfig.Query = ""
 	runConfig.ContextCurrentUserMessageIndex = nil
+	runConfig.ContextMemoryMessageIndex = nil
 	runConfig.ContextSourceFrags = nil
 
 	// Inline image attachments from new RC segments so the model receives

--- a/internal/agent/application/turn_discuss_test.go
+++ b/internal/agent/application/turn_discuss_test.go
@@ -281,8 +281,13 @@ func TestDiscussRefreshesContextFragWithoutLateBindingMessage(t *testing.T) {
 	agent := &fakeAgentStreamer{}
 	resolver := &fakeDiscussService{
 		resolveResult: ResolveRunConfigResult{
-			RunConfig: native.RunConfig{System: "base system"},
-			ModelID:   "model-1",
+			RunConfig: native.RunConfig{
+				System: "base system",
+				ContextSourceFrags: []contextfrag.ContextFrag{{
+					ID: "stale-system-only-source", Slot: contextfrag.SlotSystem,
+				}},
+			},
+			ModelID: "model-1",
 		},
 	}
 	a := newDiscussTestService(&fakeRunner{}, agent, resolver)
@@ -304,6 +309,9 @@ func TestDiscussRefreshesContextFragWithoutLateBindingMessage(t *testing.T) {
 	}
 	if len(cfg.Messages) != 1 {
 		t.Fatalf("messages = %d, want only composed discuss context", len(cfg.Messages))
+	}
+	if cfg.ContextSourceFrags != nil {
+		t.Fatalf("discuss retained stale authoritative source: %#v", cfg.ContextSourceFrags)
 	}
 	if lastMessageFragContains(cfg.ContextFrags, "Current time:") ||
 		lastMessageFragContains(cfg.ContextFrags, "MUST use the `send` tool") {

--- a/internal/agent/application/turn_discuss_test.go
+++ b/internal/agent/application/turn_discuss_test.go
@@ -279,10 +279,14 @@ func TestDiscussACPSkipsWhenNotAddressed(t *testing.T) {
 
 func TestDiscussRefreshesContextFragWithoutLateBindingMessage(t *testing.T) {
 	agent := &fakeAgentStreamer{}
+	staleIndex := 0
+	staleMemoryIndex := 0
 	resolver := &fakeDiscussService{
 		resolveResult: ResolveRunConfigResult{
 			RunConfig: native.RunConfig{
-				System: "base system",
+				System:                         "base system",
+				ContextCurrentUserMessageIndex: &staleIndex,
+				ContextMemoryMessageIndex:      &staleMemoryIndex,
 				ContextSourceFrags: []contextfrag.ContextFrag{{
 					ID: "stale-system-only-source", Slot: contextfrag.SlotSystem,
 				}},
@@ -312,6 +316,9 @@ func TestDiscussRefreshesContextFragWithoutLateBindingMessage(t *testing.T) {
 	}
 	if cfg.ContextSourceFrags != nil {
 		t.Fatalf("discuss retained stale authoritative source: %#v", cfg.ContextSourceFrags)
+	}
+	if cfg.ContextCurrentUserMessageIndex != nil || cfg.ContextMemoryMessageIndex != nil {
+		t.Fatalf("discuss retained stale message markers: current=%#v memory=%#v", cfg.ContextCurrentUserMessageIndex, cfg.ContextMemoryMessageIndex)
 	}
 	if lastMessageFragContains(cfg.ContextFrags, "Current time:") ||
 		lastMessageFragContains(cfg.ContextFrags, "MUST use the `send` tool") {

--- a/internal/agent/context/fragment/compile.go
+++ b/internal/agent/context/fragment/compile.go
@@ -15,21 +15,27 @@ const (
 
 // CompileInput contains the legacy RunConfig fields used as phase-1 sources.
 type CompileInput struct {
-	Source          string
-	Scope           Scope
-	System          string
-	Messages        []sdk.Message
-	Query           string
-	InlineImages    []sdk.ImagePart
-	ToolUsage       string
-	View            ManifestView
-	DynamicMutators []DynamicMutator
-	Existing        []ContextFrag
+	Source   string
+	Scope    Scope
+	System   string
+	Messages []sdk.Message
+	// CurrentUserMessageIndex identifies a current request already carried in
+	// Messages so legacy manifests retain its typed slot.
+	CurrentUserMessageIndex *int
+	Query                   string
+	InlineImages            []sdk.ImagePart
+	ToolUsage               string
+	View                    ManifestView
+	DynamicMutators         []DynamicMutator
+	Existing                []ContextFrag
 }
 
-// Compile builds typed fragments from the current SDK-shaped fields, preserving
-// explicit non-derived fragments such as tool usage.
-func Compile(input CompileInput) AssembledContext {
+// CompileFrags builds the typed fragment list from the current SDK-shaped
+// fields, preserving explicit non-derived fragments such as tool usage — the
+// same fragment-construction `Compile` does, without also rendering the
+// legacy System/Messages view or building the provenance manifest. For
+// callers that only need the fragments themselves.
+func CompileFrags(input CompileInput) []ContextFrag {
 	source := strings.TrimSpace(input.Source)
 	if source == "" {
 		source = SourceRunConfig
@@ -61,18 +67,32 @@ func Compile(input CompileInput) AssembledContext {
 			frags = append(frags, frag)
 			continue
 		}
+		kind := kindForMessage(msg)
+		slot := SlotHistory
+		cacheClass := cacheForMessage(msg)
+		trust := trustForMessage(msg)
+		budget := BudgetPolicy{}
+		messageScope := scope
+		if isCurrentUserMessage(input.CurrentUserMessageIndex, i, msg) {
+			kind = KindCurrentUserMessage
+			slot = SlotCurrentUser
+			cacheClass = CacheNever
+			trust = TrustUser
+			budget.Overflow = OverflowKeep
+		}
 		frags = append(frags, MessageFrag(MessageFragInput{
 			ID:         id,
 			Message:    msg,
-			Kind:       kindForMessage(msg),
-			Slot:       SlotHistory,
+			Kind:       kind,
+			Slot:       slot,
 			Priority:   PriorityForMessage(msg),
-			CacheClass: cacheForMessage(msg),
-			Trust:      trustForMessage(msg),
-			Scope:      scope,
+			CacheClass: cacheClass,
+			Trust:      trust,
+			Scope:      messageScope,
 			Source:     source,
 			Collector:  CollectorRunConfigFields,
 			Index:      i,
+			Budget:     budget,
 		}))
 	}
 	if strings.TrimSpace(input.Query) != "" {
@@ -98,7 +118,17 @@ func Compile(input CompileInput) AssembledContext {
 		}
 	}
 
-	frags = normalizeContextRefs(frags)
+	return normalizeContextRefs(frags)
+}
+
+func isCurrentUserMessage(index *int, candidate int, msg sdk.Message) bool {
+	return index != nil && *index == candidate && msg.Role == sdk.MessageRoleUser
+}
+
+// Compile builds typed fragments from the current SDK-shaped fields, preserving
+// explicit non-derived fragments such as tool usage.
+func Compile(input CompileInput) AssembledContext {
+	frags := CompileFrags(input)
 	assembled := Render(frags)
 	assembled.Frags = frags
 	assembled.Manifest = BuildManifest(frags)
@@ -166,36 +196,38 @@ func systemTextFrag(id string, kind Kind, text string, priority int, cacheClass 
 
 // TextFragInput describes a text fragment to construct.
 type TextFragInput struct {
-	ID         string
-	Kind       Kind
-	Role       sdk.MessageRole
-	Slot       Slot
-	Text       string
-	Priority   int
-	CacheClass CacheClass
-	Trust      TrustLevel
-	Scope      Scope
-	Source     string
-	SourceID   string
-	Collector  string
-	Index      int
-	Render     RenderPolicy
-	Budget     BudgetPolicy
+	ID          string
+	Kind        Kind
+	Role        sdk.MessageRole
+	Slot        Slot
+	Text        string
+	Priority    int
+	CacheClass  CacheClass
+	Trust       TrustLevel
+	Scope       Scope
+	Source      string
+	SourceID    string
+	Collector   string
+	Index       int
+	Render      RenderPolicy
+	Budget      BudgetPolicy
+	ConflictKey string
 }
 
 // TextFrag creates a text-backed fragment.
 func TextFrag(input TextFragInput) ContextFrag {
 	return ContextFrag{
-		ID:         strings.TrimSpace(input.ID),
-		Kind:       input.Kind,
-		Role:       input.Role,
-		Slot:       input.Slot,
-		Priority:   input.Priority,
-		CacheClass: input.CacheClass,
-		Trust:      input.Trust,
-		Scope:      normalizeScope(input.Scope),
-		Budget:     input.Budget,
-		Render:     input.Render,
+		ID:          strings.TrimSpace(input.ID),
+		Kind:        input.Kind,
+		Role:        input.Role,
+		Slot:        input.Slot,
+		Priority:    input.Priority,
+		CacheClass:  input.CacheClass,
+		Trust:       input.Trust,
+		Scope:       normalizeScope(input.Scope),
+		Budget:      input.Budget,
+		Render:      input.Render,
+		ConflictKey: input.ConflictKey,
 		Provenance: Provenance{
 			Source:    strings.TrimSpace(input.Source),
 			SourceID:  strings.TrimSpace(input.SourceID),
@@ -211,33 +243,37 @@ func TextFrag(input TextFragInput) ContextFrag {
 
 // MessageFragInput describes an SDK message fragment.
 type MessageFragInput struct {
-	ID         string
-	Message    sdk.Message
-	Kind       Kind
-	Slot       Slot
-	Priority   int
-	CacheClass CacheClass
-	Trust      TrustLevel
-	Scope      Scope
-	Source     string
-	SourceID   string
-	Collector  string
-	Index      int
+	ID            string
+	Message       sdk.Message
+	Kind          Kind
+	Slot          Slot
+	Priority      int
+	CacheClass    CacheClass
+	Trust         TrustLevel
+	Scope         Scope
+	Source        string
+	SourceID      string
+	Collector     string
+	Index         int
+	TokenEstimate int
+	Budget        BudgetPolicy
 }
 
 // MessageFrag creates a message-backed fragment.
 func MessageFrag(input MessageFragInput) ContextFrag {
 	msg := cloneMessage(input.Message)
 	return ContextFrag{
-		ID:         strings.TrimSpace(input.ID),
-		Kind:       input.Kind,
-		Role:       input.Message.Role,
-		Slot:       input.Slot,
-		Priority:   input.Priority,
-		CacheClass: input.CacheClass,
-		Trust:      input.Trust,
-		Scope:      normalizeScope(input.Scope),
-		Render:     RenderPolicy{Format: RenderSDKMessage},
+		TokenEstimate: input.TokenEstimate,
+		Budget:        input.Budget,
+		ID:            strings.TrimSpace(input.ID),
+		Kind:          input.Kind,
+		Role:          input.Message.Role,
+		Slot:          input.Slot,
+		Priority:      input.Priority,
+		CacheClass:    input.CacheClass,
+		Trust:         input.Trust,
+		Scope:         normalizeScope(input.Scope),
+		Render:        RenderPolicy{Format: RenderSDKMessage},
 		Provenance: Provenance{
 			Source:    strings.TrimSpace(input.Source),
 			SourceID:  strings.TrimSpace(input.SourceID),
@@ -372,7 +408,7 @@ func cacheForMessage(msg sdk.Message) CacheClass {
 	case sdk.MessageRoleSystem:
 		return CacheDynamic
 	case sdk.MessageRoleUser, sdk.MessageRoleAssistant, sdk.MessageRoleTool:
-		return CacheNever
+		return CacheStable
 	default:
 		return CacheNever
 	}

--- a/internal/agent/context/fragment/compile.go
+++ b/internal/agent/context/fragment/compile.go
@@ -22,12 +22,15 @@ type CompileInput struct {
 	// CurrentUserMessageIndex identifies a current request already carried in
 	// Messages so legacy manifests retain its typed slot.
 	CurrentUserMessageIndex *int
-	Query                   string
-	InlineImages            []sdk.ImagePart
-	ToolUsage               string
-	View                    ManifestView
-	DynamicMutators         []DynamicMutator
-	Existing                []ContextFrag
+	// MemoryMessageIndex identifies materialized memory recall that remains in
+	// Messages for byte-equivalent provider ordering.
+	MemoryMessageIndex *int
+	Query              string
+	InlineImages       []sdk.ImagePart
+	ToolUsage          string
+	View               ManifestView
+	DynamicMutators    []DynamicMutator
+	Existing           []ContextFrag
 }
 
 // CompileFrags builds the typed fragment list from the current SDK-shaped
@@ -73,6 +76,11 @@ func CompileFrags(input CompileInput) []ContextFrag {
 		trust := trustForMessage(msg)
 		budget := BudgetPolicy{}
 		messageScope := scope
+		if isMemoryMessage(input.MemoryMessageIndex, i, msg) {
+			kind = KindMemoryRecall
+			cacheClass = CacheNever
+			trust = TrustWorkspace
+		}
 		if isCurrentUserMessage(input.CurrentUserMessageIndex, i, msg) {
 			kind = KindCurrentUserMessage
 			slot = SlotCurrentUser
@@ -122,6 +130,10 @@ func CompileFrags(input CompileInput) []ContextFrag {
 }
 
 func isCurrentUserMessage(index *int, candidate int, msg sdk.Message) bool {
+	return index != nil && *index == candidate && msg.Role == sdk.MessageRoleUser
+}
+
+func isMemoryMessage(index *int, candidate int, msg sdk.Message) bool {
 	return index != nil && *index == candidate && msg.Role == sdk.MessageRoleUser
 }
 

--- a/internal/agent/context/fragment/compile_test.go
+++ b/internal/agent/context/fragment/compile_test.go
@@ -1,6 +1,7 @@
 package contextfrag
 
 import (
+	"reflect"
 	"testing"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -84,6 +85,22 @@ func TestCompileDoesNotInferToolUsageFromPlainSystemText(t *testing.T) {
 	}
 }
 
+func TestCompileFragsMatchesCompileFrags(t *testing.T) {
+	input := CompileInput{
+		Scope:    Scope{BotID: "bot-1"},
+		System:   "system prompt",
+		Messages: []sdk.Message{sdk.UserMessage("hi"), sdk.AssistantMessage("hello")},
+		Query:    "current question",
+	}
+
+	got := CompileFrags(input)
+	want := Compile(input).Frags
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CompileFrags(...) diverges from Compile(...).Frags:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
 func manifestHasKind(manifest Manifest, kind Kind) bool {
 	for _, item := range manifest.Items {
 		if item.Kind == kind {
@@ -91,4 +108,30 @@ func manifestHasKind(manifest Manifest, kind Kind) bool {
 		}
 	}
 	return false
+}
+
+// TestCacheForMessageMatchesHistoryCollectorMapping is the P5 RED test.
+// cacheForMessage backs the legacy/fallback compile path (contextfrag.Compile,
+// used by agent.RefreshContextFrag); contextview's history collector
+// (cacheForSDKMessage in internal/contextview/collector_history.go) backs the
+// newer contextview path. Both classify the same message roles, so they must
+// agree: history messages (user/assistant/tool) are CacheStable, matching
+// the view-side rule, instead of the legacy path's CacheNever.
+func TestCacheForMessageMatchesHistoryCollectorMapping(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		role sdk.MessageRole
+		want CacheClass
+	}{
+		{sdk.MessageRoleSystem, CacheDynamic},
+		{sdk.MessageRoleUser, CacheStable},
+		{sdk.MessageRoleAssistant, CacheStable},
+		{sdk.MessageRoleTool, CacheStable},
+	}
+	for _, tc := range cases {
+		if got := cacheForMessage(sdk.Message{Role: tc.role}); got != tc.want {
+			t.Errorf("cacheForMessage(role=%s) = %q, want %q", tc.role, got, tc.want)
+		}
+	}
 }

--- a/internal/agent/context/fragment/manifest_breakdown_test.go
+++ b/internal/agent/context/fragment/manifest_breakdown_test.go
@@ -1,0 +1,111 @@
+package contextfrag
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func breakdownFixtureFrags() []ContextFrag {
+	sysA := TextFrag(TextFragInput{
+		ID: "system.prompt", Kind: KindSystemPrompt, Slot: SlotSystem,
+		Text: strings.Repeat("a", 40),
+	})
+	sysB := TextFrag(TextFragInput{
+		ID: "system.prompt.tail", Kind: KindSystemPrompt, Slot: SlotSystem,
+		Text: strings.Repeat("b", 20),
+	})
+	hist := MessageFrag(MessageFragInput{
+		ID:      "history.db_message.m1",
+		Message: sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "hi"}}},
+		Kind:    KindConversationEvent,
+		Slot:    SlotHistory,
+	})
+	hist.TokenEstimate = 123
+	img := ImageFrag("current_user.images", []sdk.ImagePart{{Image: "data:image/png;base64,AAAA", MediaType: "image/png"}}, Scope{}, "run_config")
+	return []ContextFrag{sysA, sysB, hist, img}
+}
+
+func TestBuildManifestItemsCarryTokenEstimates(t *testing.T) {
+	t.Parallel()
+
+	manifest := BuildManifest(breakdownFixtureFrags())
+	if len(manifest.Items) != 4 {
+		t.Fatalf("items = %d, want 4", len(manifest.Items))
+	}
+	wantByID := map[string]int{
+		"system.prompt":         10,
+		"system.prompt.tail":    5,
+		"history.db_message.m1": 123,
+		"current_user.images":   EstimateImageTokens,
+	}
+	for _, item := range manifest.Items {
+		if want, ok := wantByID[item.ID]; ok && item.TokenEstimate != want {
+			t.Fatalf("item %s token estimate = %d, want %d", item.ID, item.TokenEstimate, want)
+		}
+	}
+	if want := 10 + 5 + 123 + EstimateImageTokens; manifest.Counts.TokenEstimate != want {
+		t.Fatalf("counts token estimate = %d, want %d", manifest.Counts.TokenEstimate, want)
+	}
+}
+
+func TestBuildManifestBreakdownAggregatesByKind(t *testing.T) {
+	t.Parallel()
+
+	manifest := BuildManifest(breakdownFixtureFrags())
+	want := []KindBreakdown{
+		{Kind: KindNativeImage, Fragments: 1, TokenEstimate: EstimateImageTokens, Images: 1},
+		{Kind: KindConversationEvent, Fragments: 1, TokenEstimate: 123, TextBytes: 2},
+		{Kind: KindSystemPrompt, Fragments: 2, TokenEstimate: 15, TextBytes: 60},
+	}
+	if len(manifest.Breakdown) != len(want) {
+		t.Fatalf("breakdown = %+v, want %+v", manifest.Breakdown, want)
+	}
+	for i, entry := range want {
+		if manifest.Breakdown[i] != entry {
+			t.Fatalf("breakdown[%d] = %+v, want %+v", i, manifest.Breakdown[i], entry)
+		}
+	}
+}
+
+func TestBuildManifestBreakdownOrderIsDeterministicOnTies(t *testing.T) {
+	t.Parallel()
+
+	a := TextFrag(TextFragInput{ID: "a", Kind: KindToolUsage, Slot: SlotSystem, Text: strings.Repeat("x", 40)})
+	b := TextFrag(TextFragInput{ID: "b", Kind: KindBotIdentity, Slot: SlotSystem, Text: strings.Repeat("y", 40)})
+	manifest := BuildManifest([]ContextFrag{a, b})
+	if manifest.Breakdown[0].Kind != KindBotIdentity || manifest.Breakdown[1].Kind != KindToolUsage {
+		t.Fatalf("tie order = %+v, want bot_identity before tool_usage", manifest.Breakdown)
+	}
+}
+
+func TestBuildManifestTrustBreakdownMeasuresExposure(t *testing.T) {
+	t.Parallel()
+
+	frags := []ContextFrag{
+		TextFrag(TextFragInput{ID: "system.prompt", Kind: KindSystemPrompt, Slot: SlotSystem, Trust: TrustSystem, Text: strings.Repeat("s", 40)}),
+		MessageFrag(MessageFragInput{
+			ID: "history.db_message.m1", Kind: KindConversationEvent, Slot: SlotHistory, Trust: TrustExternal,
+			Message: sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: strings.Repeat("e", 80)}}},
+		}),
+		MessageFrag(MessageFragInput{
+			ID: "history.db_message.m2", Kind: KindConversationEvent, Slot: SlotHistory, Trust: TrustWorkspace,
+			Message: sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.TextPart{Text: strings.Repeat("w", 40)}}},
+		}),
+	}
+	manifest := BuildManifest(frags)
+	want := []TrustBreakdown{
+		{Trust: TrustExternal, Fragments: 1, TokenEstimate: 20, TextBytes: 80},
+		{Trust: TrustSystem, Fragments: 1, TokenEstimate: 10, TextBytes: 40},
+		{Trust: TrustWorkspace, Fragments: 1, TokenEstimate: 10, TextBytes: 40},
+	}
+	if len(manifest.TrustBreakdown) != len(want) {
+		t.Fatalf("trust breakdown = %+v, want %+v", manifest.TrustBreakdown, want)
+	}
+	for i := range want {
+		if manifest.TrustBreakdown[i] != want[i] {
+			t.Fatalf("trust breakdown[%d] = %+v, want %+v", i, manifest.TrustBreakdown[i], want[i])
+		}
+	}
+}

--- a/internal/agent/context/fragment/mutation.go
+++ b/internal/agent/context/fragment/mutation.go
@@ -105,7 +105,11 @@ func nilIfEmptyValue(value any) any {
 	}
 	rv := reflect.ValueOf(value)
 	switch rv.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+	case reflect.Map, reflect.Slice:
+		if rv.IsNil() || rv.Len() == 0 {
+			return nil
+		}
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Pointer:
 		if rv.IsNil() {
 			return nil
 		}

--- a/internal/agent/context/fragment/mutation.go
+++ b/internal/agent/context/fragment/mutation.go
@@ -1,0 +1,124 @@
+package contextfrag
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"reflect"
+	"sync"
+)
+
+// MutationKind identifies a post-render context mutator: code that changes
+// the provider payload after the context view rendered it.
+type MutationKind string
+
+const (
+	MutationBeforeModelCallHook MutationKind = "before_model_call_hook"
+	MutationBackgroundSummary   MutationKind = "background_summary"
+	MutationMidTaskPrune        MutationKind = "mid_task_prune"
+	MutationInjectedMessage     MutationKind = "injected_message"
+	MutationContextViewFallback MutationKind = "context_view_fallback"
+	MutationReadMedia           MutationKind = "read_media"
+)
+
+// MutationRecord is one ledger entry describing a post-render mutation.
+type MutationRecord struct {
+	Kind   MutationKind `json:"kind"`
+	Detail string       `json:"detail,omitempty"`
+}
+
+// MutationLedger records post-render changes and the final provider input
+// hash. It intentionally carries no provider-attempt or step state.
+type MutationLedger struct {
+	mu             sync.Mutex
+	records        []MutationRecord
+	finalInputHash string
+}
+
+func NewMutationLedger() *MutationLedger {
+	return &MutationLedger{}
+}
+
+func (l *MutationLedger) Record(kind MutationKind, detail string) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.records = append(l.records, MutationRecord{Kind: kind, Detail: detail})
+}
+
+func (l *MutationLedger) Records() []MutationRecord {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]MutationRecord, len(l.records))
+	copy(out, l.records)
+	return out
+}
+
+func (l *MutationLedger) SetFinalInputHash(hash string) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.finalInputHash = hash
+}
+
+func (l *MutationLedger) FinalInputHash() string {
+	if l == nil {
+		return ""
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.finalInputHash
+}
+
+// ProviderInputHash hashes the assembled provider payload deterministically.
+func ProviderInputHash(system string, messages any) string {
+	hash, _ := ProviderPayloadHashAndBytes(system, messages, nil)
+	return hash
+}
+
+// ProviderPayloadHashAndBytes includes tool definitions when supplied while
+// preserving the legacy hash shape when tools are empty.
+func ProviderPayloadHashAndBytes(system string, messages any, tools any) (string, int) {
+	tools = nilIfEmptyValue(tools)
+	raw, err := json.Marshal(struct {
+		System   string `json:"system"`
+		Messages any    `json:"messages"`
+		Tools    any    `json:"tools,omitempty"`
+	}{System: system, Messages: messages, Tools: tools})
+	if err != nil {
+		return "", 0
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), len(raw)
+}
+
+func nilIfEmptyValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		if rv.IsNil() {
+			return nil
+		}
+	}
+	return value
+}
+
+func (l *MutationLedger) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Records        []MutationRecord `json:"records,omitempty"`
+		FinalInputHash string           `json:"final_input_hash,omitempty"`
+	}{
+		Records:        l.Records(),
+		FinalInputHash: l.FinalInputHash(),
+	})
+}

--- a/internal/agent/context/fragment/mutation_test.go
+++ b/internal/agent/context/fragment/mutation_test.go
@@ -51,8 +51,10 @@ func TestProviderPayloadHashTracksTools(t *testing.T) {
 
 	withoutTools, withoutToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, nil)
 	withEmptyTools, withEmptyToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, []string(nil))
+	withAllocatedEmptyTools, withAllocatedEmptyToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, []string{})
 	withTools, withToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, []string{"tool"})
-	if withoutTools != withEmptyTools || withoutToolsBytes != withEmptyToolsBytes {
+	if withoutTools != withEmptyTools || withoutToolsBytes != withEmptyToolsBytes ||
+		withoutTools != withAllocatedEmptyTools || withoutToolsBytes != withAllocatedEmptyToolsBytes {
 		t.Fatal("empty tools must preserve the legacy payload identity")
 	}
 	if withTools == withoutTools || withToolsBytes <= withoutToolsBytes {

--- a/internal/agent/context/fragment/mutation_test.go
+++ b/internal/agent/context/fragment/mutation_test.go
@@ -1,0 +1,61 @@
+package contextfrag
+
+import "testing"
+
+func TestMutationLedgerNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var ledger *MutationLedger
+	ledger.Record(MutationBackgroundSummary, "bytes=10")
+	ledger.SetFinalInputHash("abc")
+	if ledger.Records() != nil || ledger.FinalInputHash() != "" {
+		t.Fatal("nil ledger must be inert")
+	}
+}
+
+func TestMutationLedgerRecordsInOrder(t *testing.T) {
+	t.Parallel()
+
+	ledger := NewMutationLedger()
+	ledger.Record(MutationBackgroundSummary, "bytes=10")
+	ledger.Record(MutationMidTaskPrune, "pruned=3")
+	ledger.SetFinalInputHash("hash-1")
+
+	records := ledger.Records()
+	if len(records) != 2 ||
+		records[0].Kind != MutationBackgroundSummary ||
+		records[1].Kind != MutationMidTaskPrune {
+		t.Fatalf("records = %#v", records)
+	}
+	if ledger.FinalInputHash() != "hash-1" {
+		t.Fatalf("final hash = %q", ledger.FinalInputHash())
+	}
+}
+
+func TestProviderInputHashDeterministic(t *testing.T) {
+	t.Parallel()
+
+	first := ProviderInputHash("system", []string{"a", "b"})
+	second := ProviderInputHash("system", []string{"a", "b"})
+	changed := ProviderInputHash("system", []string{"a", "c"})
+	if first == "" || first != second {
+		t.Fatal("hash must be deterministic and non-empty")
+	}
+	if first == changed {
+		t.Fatal("hash must track payload changes")
+	}
+}
+
+func TestProviderPayloadHashTracksTools(t *testing.T) {
+	t.Parallel()
+
+	withoutTools, withoutToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, nil)
+	withEmptyTools, withEmptyToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, []string(nil))
+	withTools, withToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, []string{"tool"})
+	if withoutTools != withEmptyTools || withoutToolsBytes != withEmptyToolsBytes {
+		t.Fatal("empty tools must preserve the legacy payload identity")
+	}
+	if withTools == withoutTools || withToolsBytes <= withoutToolsBytes {
+		t.Fatal("tool definitions must participate in provider payload identity")
+	}
+}

--- a/internal/agent/context/fragment/precedence.go
+++ b/internal/agent/context/fragment/precedence.go
@@ -1,0 +1,34 @@
+package contextfrag
+
+// TrustRank orders trust levels for adjudication: external content is the
+// least privileged, system-authored content the most. Unknown levels rank as
+// external so unlabelled sources never gain authority by omission.
+func TrustRank(trust TrustLevel) int {
+	switch trust {
+	case TrustSystem:
+		return 3
+	case TrustWorkspace:
+		return 2
+	case TrustUser:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// SpecificityRank scores how narrowly a scope binds, for closest-wins
+// precedence: a session-scoped claim supersedes a chat-scoped one, which
+// supersedes a bot-wide one, which supersedes a global one.
+func (s Scope) SpecificityRank() int {
+	rank := 0
+	if s.BotID != "" {
+		rank++
+	}
+	if s.ChatID != "" {
+		rank += 2
+	}
+	if s.SessionID != "" {
+		rank += 4
+	}
+	return rank
+}

--- a/internal/agent/context/fragment/precedence_test.go
+++ b/internal/agent/context/fragment/precedence_test.go
@@ -1,0 +1,37 @@
+package contextfrag
+
+import "testing"
+
+func TestTrustRankOrdering(t *testing.T) {
+	t.Parallel()
+
+	if TrustRank(TrustExternal) >= TrustRank(TrustUser) ||
+		TrustRank(TrustUser) >= TrustRank(TrustWorkspace) ||
+		TrustRank(TrustWorkspace) >= TrustRank(TrustSystem) {
+		t.Fatal("trust must rank external < user < workspace < system")
+	}
+	if TrustRank("") != TrustRank(TrustExternal) {
+		t.Fatal("unknown trust ranks as external (least privileged)")
+	}
+}
+
+func TestScopeSpecificityClosestWins(t *testing.T) {
+	t.Parallel()
+
+	global := Scope{}
+	bot := Scope{BotID: "b"}
+	chat := Scope{BotID: "b", ChatID: "c"}
+	session := Scope{BotID: "b", ChatID: "c", SessionID: "s"}
+
+	ranks := []int{
+		global.SpecificityRank(),
+		bot.SpecificityRank(),
+		chat.SpecificityRank(),
+		session.SpecificityRank(),
+	}
+	for i := 1; i < len(ranks); i++ {
+		if ranks[i] <= ranks[i-1] {
+			t.Fatalf("specificity must strictly increase global<bot<chat<session: %v", ranks)
+		}
+	}
+}

--- a/internal/agent/context/fragment/render.go
+++ b/internal/agent/context/fragment/render.go
@@ -1,6 +1,7 @@
 package contextfrag
 
 import (
+	"sort"
 	"strings"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -21,18 +22,19 @@ func BuildManifest(frags []ContextFrag) Manifest {
 		}
 		manifest.ValidationWarnings = append(manifest.ValidationWarnings, ContextRefWarnings(ref)...)
 		item := ManifestItem{
-			ID:         frag.ID,
-			Ref:        ref,
-			Kind:       frag.Kind,
-			Slot:       frag.Slot,
-			Role:       frag.Role,
-			Priority:   frag.Priority,
-			CacheClass: frag.CacheClass,
-			Trust:      frag.Trust,
-			Source:     frag.Provenance.Source,
-			SourceID:   frag.Provenance.SourceID,
-			Collector:  frag.Provenance.Collector,
-			Scope:      frag.Scope,
+			ID:          frag.ID,
+			Ref:         ref,
+			Kind:        frag.Kind,
+			Slot:        frag.Slot,
+			Role:        frag.Role,
+			Priority:    frag.Priority,
+			CacheClass:  frag.CacheClass,
+			Trust:       frag.Trust,
+			Source:      frag.Provenance.Source,
+			SourceID:    frag.Provenance.SourceID,
+			Collector:   frag.Provenance.Collector,
+			ConflictKey: frag.ConflictKey,
+			Scope:       frag.Scope,
 		}
 		for _, part := range frag.Parts {
 			item.PartTypes = append(item.PartTypes, part.Type)
@@ -47,16 +49,82 @@ func BuildManifest(frags []ContextFrag) Manifest {
 				item.ImageCount++
 			}
 		}
+		item.TokenEstimate = ResolveFragTokens(frag)
 		manifest.Counts.TextBytes += item.TextBytes
 		manifest.Counts.Images += item.ImageCount
+		manifest.Counts.TokenEstimate += item.TokenEstimate
 		if frag.Coverage != nil {
 			manifest.CoverageTrace = append(manifest.CoverageTrace, *frag.Coverage)
 		}
 		manifest.Items = append(manifest.Items, item)
 	}
 	manifest.Counts.Fragments = len(frags)
+	manifest.Breakdown = breakdownFromItems(manifest.Items)
+	manifest.TrustBreakdown = trustBreakdownFromItems(manifest.Items)
 	manifest.RenderedOutputs = renderedOutputRefs(frags)
 	return manifest
+}
+
+// trustBreakdownFromItems rolls manifest items up by TrustLevel, ordered by
+// descending token estimate with Trust as the tie-breaker.
+func trustBreakdownFromItems(items []ManifestItem) []TrustBreakdown {
+	if len(items) == 0 {
+		return nil
+	}
+	byTrust := make(map[TrustLevel]*TrustBreakdown, 4)
+	for _, item := range items {
+		entry, ok := byTrust[item.Trust]
+		if !ok {
+			entry = &TrustBreakdown{Trust: item.Trust}
+			byTrust[item.Trust] = entry
+		}
+		entry.Fragments++
+		entry.TokenEstimate += item.TokenEstimate
+		entry.TextBytes += item.TextBytes
+		entry.Images += item.ImageCount
+	}
+	out := make([]TrustBreakdown, 0, len(byTrust))
+	for _, entry := range byTrust {
+		out = append(out, *entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].TokenEstimate != out[j].TokenEstimate {
+			return out[i].TokenEstimate > out[j].TokenEstimate
+		}
+		return out[i].Trust < out[j].Trust
+	})
+	return out
+}
+
+// breakdownFromItems rolls manifest items up by Kind, ordered by descending
+// token estimate with Kind as the tie-breaker so the output is deterministic.
+func breakdownFromItems(items []ManifestItem) []KindBreakdown {
+	if len(items) == 0 {
+		return nil
+	}
+	byKind := make(map[Kind]*KindBreakdown, len(items))
+	for _, item := range items {
+		entry, ok := byKind[item.Kind]
+		if !ok {
+			entry = &KindBreakdown{Kind: item.Kind}
+			byKind[item.Kind] = entry
+		}
+		entry.Fragments++
+		entry.TokenEstimate += item.TokenEstimate
+		entry.TextBytes += item.TextBytes
+		entry.Images += item.ImageCount
+	}
+	out := make([]KindBreakdown, 0, len(byKind))
+	for _, entry := range byKind {
+		out = append(out, *entry)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].TokenEstimate != out[j].TokenEstimate {
+			return out[i].TokenEstimate > out[j].TokenEstimate
+		}
+		return out[i].Kind < out[j].Kind
+	})
+	return out
 }
 
 // Render builds the legacy SDK-shaped view from fragments.

--- a/internal/agent/context/fragment/repair.go
+++ b/internal/agent/context/fragment/repair.go
@@ -139,20 +139,20 @@ func FragMessage(frag ContextFrag) *sdk.Message {
 }
 
 func RebuildFragMessage(frag ContextFrag, msg sdk.Message) ContextFrag {
-	return MessageFrag(MessageFragInput{
-		ID:            frag.ID,
-		Message:       msg,
-		Kind:          frag.Kind,
-		Slot:          frag.Slot,
-		Priority:      frag.Priority,
-		CacheClass:    frag.CacheClass,
-		Trust:         frag.Trust,
-		Scope:         frag.Scope,
-		Source:        frag.Provenance.Source,
-		SourceID:      frag.Provenance.SourceID,
-		Collector:     frag.Provenance.Collector,
-		Index:         frag.Provenance.Index,
-		Budget:        frag.Budget,
-		TokenEstimate: frag.TokenEstimate,
-	})
+	rebuilt := frag
+	cloned := cloneMessage(msg)
+	rebuilt.Role = cloned.Role
+	rebuilt.Parts = []Part{{
+		Type:       PartSDKMessage,
+		Message:    &cloned,
+		SDKMessage: &cloned,
+	}}
+	rebuilt.TokenEstimate = 0
+
+	ref := rebuilt.Ref
+	ref.HashAlgo = ""
+	ref.HashScope = ""
+	ref.ContentHash = ""
+	rebuilt.Ref = ContextRef{}
+	return WithContextRef(rebuilt, ref)
 }

--- a/internal/agent/context/fragment/repair.go
+++ b/internal/agent/context/fragment/repair.go
@@ -1,0 +1,158 @@
+package contextfrag
+
+import (
+	"fmt"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+const (
+	// SourceToolClosureRepair attributes a synthetic tool-closure fragment to
+	// the repair pass rather than to whatever collected the surrounding
+	// history.
+	SourceToolClosureRepair = "context_repair"
+	// ToolClosureRepairText mirrors the legacy resolver repair wording so the
+	// model sees the same interruption notice regardless of caller.
+	ToolClosureRepairText = "tool execution interrupted before a response was recorded"
+)
+
+// RepairToolClosureFrags walks history message fragments and enforces tool
+// closure integrity: every assistant tool call is answered before the next
+// non-tool message (synthesizing an interrupted-result when missing) and tool
+// results without a pending call are removed. Synthetic closure fragments are
+// attributed to collector, so callers outside contextview (which has no
+// per-request Collect() name to reuse) can still tag them consistently with
+// the surrounding history fragments.
+func RepairToolClosureFrags(frags []ContextFrag, scope Scope, collector string) []ContextFrag {
+	repaired := make([]ContextFrag, 0, len(frags))
+	pendingOrder := make([]string, 0, 2)
+	pendingNames := make(map[string]string, 2)
+	syntheticIndex := 0
+
+	flush := func() {
+		for _, callID := range pendingOrder {
+			repaired = append(repaired, syntheticToolClosureFrag(callID, pendingNames[callID], syntheticIndex, scope, collector))
+			syntheticIndex++
+			delete(pendingNames, callID)
+		}
+		pendingOrder = pendingOrder[:0]
+	}
+
+	for _, frag := range frags {
+		msg := FragMessage(frag)
+		if msg == nil {
+			flush()
+			repaired = append(repaired, frag)
+			continue
+		}
+		switch msg.Role {
+		case sdk.MessageRoleAssistant:
+			flush()
+			repaired = append(repaired, frag)
+			for _, part := range msg.Content {
+				call, ok := part.(sdk.ToolCallPart)
+				if !ok {
+					continue
+				}
+				callID := strings.TrimSpace(call.ToolCallID)
+				if callID == "" {
+					continue
+				}
+				if _, exists := pendingNames[callID]; exists {
+					continue
+				}
+				pendingNames[callID] = strings.TrimSpace(call.ToolName)
+				pendingOrder = append(pendingOrder, callID)
+			}
+		case sdk.MessageRoleTool:
+			kept := make([]sdk.MessagePart, 0, len(msg.Content))
+			for _, part := range msg.Content {
+				result, ok := part.(sdk.ToolResultPart)
+				if !ok {
+					continue
+				}
+				callID := strings.TrimSpace(result.ToolCallID)
+				if _, pending := pendingNames[callID]; !pending {
+					continue
+				}
+				kept = append(kept, result)
+				delete(pendingNames, callID)
+				for i, id := range pendingOrder {
+					if id == callID {
+						pendingOrder = append(pendingOrder[:i], pendingOrder[i+1:]...)
+						break
+					}
+				}
+			}
+			if len(kept) == 0 {
+				continue
+			}
+			if len(kept) != len(msg.Content) {
+				frag = RebuildFragMessage(frag, sdk.Message{Role: sdk.MessageRoleTool, Content: kept})
+			}
+			repaired = append(repaired, frag)
+		default:
+			flush()
+			repaired = append(repaired, frag)
+		}
+	}
+	flush()
+	return repaired
+}
+
+func syntheticToolClosureFrag(callID, toolName string, index int, scope Scope, collector string) ContextFrag {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleTool,
+		Content: []sdk.MessagePart{sdk.ToolResultPart{
+			ToolCallID: callID,
+			ToolName:   toolName,
+			Result:     ToolClosureRepairText,
+			IsError:    true,
+		}},
+	}
+	return MessageFrag(MessageFragInput{
+		ID:         fmt.Sprintf("history.tool_closure.%03d", index),
+		Message:    msg,
+		Kind:       KindConversationEvent,
+		Slot:       SlotHistory,
+		Priority:   PriorityForMessage(msg),
+		CacheClass: CacheNever,
+		Trust:      TrustWorkspace,
+		Scope:      scope,
+		Source:     SourceToolClosureRepair,
+		SourceID:   "tool_closure." + callID,
+		Collector:  collector,
+		Index:      index,
+	})
+}
+
+// FragMessage returns the first SDK message carried by frag's parts, or nil
+// if frag does not wrap a message (e.g. a text or image fragment).
+func FragMessage(frag ContextFrag) *sdk.Message {
+	for _, part := range frag.Parts {
+		if msg := partMessage(part); msg != nil {
+			return msg
+		}
+	}
+	return nil
+}
+
+func RebuildFragMessage(frag ContextFrag, msg sdk.Message) ContextFrag {
+	return MessageFrag(MessageFragInput{
+		ID:            frag.ID,
+		Message:       msg,
+		Kind:          frag.Kind,
+		Slot:          frag.Slot,
+		Priority:      frag.Priority,
+		CacheClass:    frag.CacheClass,
+		Trust:         frag.Trust,
+		Scope:         frag.Scope,
+		Source:        frag.Provenance.Source,
+		SourceID:      frag.Provenance.SourceID,
+		Collector:     frag.Provenance.Collector,
+		Index:         frag.Provenance.Index,
+		Budget:        frag.Budget,
+		TokenEstimate: frag.TokenEstimate,
+	})
+}

--- a/internal/agent/context/fragment/repair_test.go
+++ b/internal/agent/context/fragment/repair_test.go
@@ -1,0 +1,78 @@
+package contextfrag
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestRepairToolClosureFragsRefreshesRebuiltMessageAccounting(t *testing.T) {
+	t.Parallel()
+
+	assistant := MessageFrag(MessageFragInput{
+		ID: "history.assistant",
+		Message: sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.ToolCallPart{
+			ToolCallID: "call-valid",
+			ToolName:   "search",
+		}}},
+		Kind: KindConversationEvent,
+		Slot: SlotHistory,
+	})
+	result := MessageFrag(MessageFragInput{
+		ID: "history.result",
+		Message: sdk.Message{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{
+			sdk.ToolResultPart{ToolCallID: "call-orphan", ToolName: "search", Result: "orphan"},
+			sdk.ToolResultPart{ToolCallID: "call-valid", ToolName: "search", Result: "kept"},
+		}},
+		Kind:          KindConversationEvent,
+		Slot:          SlotHistory,
+		TokenEstimate: 999,
+	})
+	result.ConflictKey = "history.tool-result"
+	result = WithContextRef(result, ContextRef{
+		Namespace:   "history",
+		ID:          "result-row",
+		Version:     3,
+		HashAlgo:    HashAlgoSHA256,
+		HashScope:   HashScopeSourcePayload,
+		ContentHash: "stale-source-hash",
+		Schema:      SchemaContextRef,
+		Durability:  RefDurable,
+	})
+
+	repaired := RepairToolClosureFrags([]ContextFrag{assistant, result}, Scope{}, "test")
+	if len(repaired) != 2 {
+		t.Fatalf("repaired fragments = %d, want 2", len(repaired))
+	}
+	got := repaired[1]
+	msg := FragMessage(got)
+	if msg == nil || len(msg.Content) != 1 {
+		t.Fatalf("rebuilt tool result = %#v, want one valid result", msg)
+	}
+	kept, ok := msg.Content[0].(sdk.ToolResultPart)
+	if !ok || kept.ToolCallID != "call-valid" {
+		t.Fatalf("rebuilt tool result content = %#v, want call-valid", msg.Content[0])
+	}
+	if got.TokenEstimate != 0 {
+		t.Fatalf("rebuilt token estimate = %d, want stale estimate cleared", got.TokenEstimate)
+	}
+	if resolved, estimated := ResolveFragTokens(got), EstimateFragTokens(got); resolved != estimated || resolved == 999 {
+		t.Fatalf("rebuilt token accounting = %d, estimated = %d, stale = 999", resolved, estimated)
+	}
+	if !got.Ref.EqualIdentity(result.Ref) {
+		t.Fatalf("rebuilt ref identity = %#v, want %#v", got.Ref, result.Ref)
+	}
+	if got.Ref.HashScope != HashScopeCanonicalFragment || got.Ref.ContentHash == "" || got.Ref.ContentHash == result.Ref.ContentHash {
+		t.Fatalf("rebuilt ref hash was not refreshed: got %#v, original %#v", got.Ref, result.Ref)
+	}
+	expected, err := CanonicalFragmentHash(got)
+	if err != nil {
+		t.Fatalf("hash rebuilt fragment: %v", err)
+	}
+	if got.Ref.ContentHash != expected.Value {
+		t.Fatalf("rebuilt ref hash = %q, want canonical %q", got.Ref.ContentHash, expected.Value)
+	}
+	if got.ConflictKey != result.ConflictKey {
+		t.Fatalf("rebuilt conflict key = %q, want %q", got.ConflictKey, result.ConflictKey)
+	}
+}

--- a/internal/agent/context/fragment/tokens.go
+++ b/internal/agent/context/fragment/tokens.go
@@ -1,0 +1,104 @@
+package contextfrag
+
+import (
+	"encoding/json"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// EstimateBytesPerToken is the byte-per-token heuristic shared by every
+// context ledger (selection budgets, compaction triggers, manifest
+// accounting), and the single swap point for a real tokenizer.
+const EstimateBytesPerToken = 4
+
+// EstimateImageTokens is the flat per-image estimate. Real image cost is
+// resolution-dependent and provider-capped at roughly 1.1–1.6K tokens, so a
+// ceiling-magnitude flat figure keeps image-heavy history visible to budget
+// pressure without counting base64 payload bytes as text.
+const EstimateImageTokens = 1500
+
+// TokensFromBytes converts a byte count to the shared token estimate.
+func TokensFromBytes(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	return n / EstimateBytesPerToken
+}
+
+// EstimateSDKMessageTokens estimates tokens for one SDK message additively
+// across all parts: text and reasoning count their raw bytes, tool calls and
+// tool results count their serialized payload, and each image counts the
+// flat EstimateImageTokens instead of its base64 payload.
+func EstimateSDKMessageTokens(msg sdk.Message) int {
+	bytes, images := sdkMessageEstimate(msg)
+	return TokensFromBytes(bytes) + images*EstimateImageTokens
+}
+
+func sdkMessageEstimate(msg sdk.Message) (bytes, images int) {
+	for _, part := range msg.Content {
+		switch p := part.(type) {
+		case sdk.TextPart:
+			bytes += len(p.Text)
+		case sdk.ReasoningPart:
+			bytes += len(p.Text)
+		case sdk.ImagePart:
+			images++
+		default:
+			if data, err := json.Marshal(part); err == nil {
+				bytes += len(data)
+			}
+		}
+	}
+	return bytes, images
+}
+
+// EstimateFragTokens computes the token estimate from the fragment's parts,
+// ignoring any preset TokenEstimate.
+func EstimateFragTokens(frag ContextFrag) int {
+	bytes, images := fragEstimate(frag)
+	return TokensFromBytes(bytes) + images*EstimateImageTokens
+}
+
+func fragEstimate(frag ContextFrag) (bytes, images int) {
+	for _, part := range frag.Parts {
+		switch part.Type {
+		case PartText:
+			bytes += len(part.Text)
+		case PartSDKMessage:
+			if msg := partMessage(part); msg != nil {
+				msgBytes, msgImages := sdkMessageEstimate(*msg)
+				bytes += msgBytes
+				images += msgImages
+			}
+		case PartImage:
+			images++
+		}
+	}
+	return bytes, images
+}
+
+// ResolveFragTokens returns the fragment's authoritative token estimate:
+// the collector-provided TokenEstimate when set (which may carry real
+// provider usage), otherwise the computed part estimate.
+func ResolveFragTokens(frag ContextFrag) int {
+	if frag.TokenEstimate > 0 {
+		return frag.TokenEstimate
+	}
+	return EstimateFragTokens(frag)
+}
+
+// ToolDefAccountingFor measures one tool definition as the provider will
+// receive it (name, description, parameter schema). A definition that fails
+// to serialize falls back to its visible prose size.
+func ToolDefAccountingFor(provider string, tool sdk.Tool) ToolDefAccounting {
+	size := len(tool.Name) + len(tool.Description)
+	if data, err := json.Marshal(tool); err == nil {
+		size = len(data)
+	}
+	return ToolDefAccounting{
+		Provider:      provider,
+		Name:          tool.Name,
+		Bytes:         size,
+		TokenEstimate: TokensFromBytes(size),
+	}
+}

--- a/internal/agent/context/fragment/tokens_test.go
+++ b/internal/agent/context/fragment/tokens_test.go
@@ -1,0 +1,211 @@
+package contextfrag
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestTokensFromBytes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{name: "zero", in: 0, want: 0},
+		{name: "negative", in: -8, want: 0},
+		{name: "below one token", in: 3, want: 0},
+		{name: "exact", in: 8, want: 2},
+		{name: "floor", in: 7, want: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := TokensFromBytes(tc.in); got != tc.want {
+				t.Fatalf("TokensFromBytes(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEstimateSDKMessageTokensTextOnly(t *testing.T) {
+	t.Parallel()
+
+	text := "hello world, this is a test!"
+	msg := sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: text}}}
+	if got, want := EstimateSDKMessageTokens(msg), len(text)/4; got != want {
+		t.Fatalf("EstimateSDKMessageTokens = %d, want %d", got, want)
+	}
+}
+
+func TestEstimateSDKMessageTokensEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := EstimateSDKMessageTokens(sdk.Message{Role: sdk.MessageRoleUser}); got != 0 {
+		t.Fatalf("EstimateSDKMessageTokens(empty) = %d, want 0", got)
+	}
+}
+
+func TestEstimateSDKMessageTokensCountsUnicodeBytes(t *testing.T) {
+	t.Parallel()
+
+	msg := sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "你好世界"}}}
+	if got := EstimateSDKMessageTokens(msg); got != 3 {
+		t.Fatalf("EstimateSDKMessageTokens(CJK 12 bytes) = %d, want 3", got)
+	}
+}
+
+// The estimate must be additive across parts: an assistant message carrying
+// both text and a tool call counts the tool call payload too, instead of
+// discarding it because text is present.
+func TestEstimateSDKMessageTokensAddsToolCallToText(t *testing.T) {
+	t.Parallel()
+
+	text := "Let me check that file now."
+	call := sdk.ToolCallPart{
+		ToolCallID: "call-1",
+		ToolName:   "read_file",
+		Input:      map[string]any{"path": "/data/projects/memoh/internal/agent/runtime/native/agent.go"},
+	}
+	msg := sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.TextPart{Text: text}, call}}
+
+	callBytes, err := json.Marshal(call)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := (len(text) + len(callBytes)) / 4
+	got := EstimateSDKMessageTokens(msg)
+	if got != want {
+		t.Fatalf("EstimateSDKMessageTokens = %d, want %d", got, want)
+	}
+	if textOnly := len(text) / 4; got <= textOnly {
+		t.Fatalf("EstimateSDKMessageTokens = %d, must exceed text-only estimate %d", got, textOnly)
+	}
+}
+
+func TestEstimateSDKMessageTokensCountsToolResult(t *testing.T) {
+	t.Parallel()
+
+	result := sdk.ToolResultPart{
+		ToolCallID: "call-1",
+		ToolName:   "read_file",
+		Result:     map[string]any{"content": "package native\n\nfunc main() {}\n"},
+	}
+	msg := sdk.Message{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{result}}
+
+	resultBytes, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := EstimateSDKMessageTokens(msg), len(resultBytes)/4; got != want || got == 0 {
+		t.Fatalf("EstimateSDKMessageTokens = %d, want %d (nonzero)", got, want)
+	}
+}
+
+func TestEstimateSDKMessageTokensCountsReasoning(t *testing.T) {
+	t.Parallel()
+
+	reasoning := "The user wants a summary of the diff, so read it first."
+	msg := sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.ReasoningPart{Text: reasoning}}}
+	if got, want := EstimateSDKMessageTokens(msg), len(reasoning)/4; got != want {
+		t.Fatalf("EstimateSDKMessageTokens = %d, want %d", got, want)
+	}
+}
+
+// Byte totals are summed first and divided once, so multi-part messages do
+// not lose up to three bytes of remainder per part.
+func TestEstimateSDKMessageTokensSumsBeforeDividing(t *testing.T) {
+	t.Parallel()
+
+	msg := sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{
+		sdk.TextPart{Text: "abcdef"},
+		sdk.TextPart{Text: "ghijkl"},
+	}}
+	if got := EstimateSDKMessageTokens(msg); got != 3 {
+		t.Fatalf("EstimateSDKMessageTokens(6+6 bytes) = %d, want 3", got)
+	}
+}
+
+func TestEstimateFragTokensTextPart(t *testing.T) {
+	t.Parallel()
+
+	frag := TextFrag(TextFragInput{
+		ID:   "system.prompt",
+		Kind: KindSystemPrompt,
+		Slot: SlotSystem,
+		Text: "You are an AI agent running inside a private Memoh workspace.",
+	})
+	if got, want := EstimateFragTokens(frag), len(frag.Parts[0].Text)/4; got != want {
+		t.Fatalf("EstimateFragTokens = %d, want %d", got, want)
+	}
+}
+
+func TestEstimateFragTokensSDKMessagePart(t *testing.T) {
+	t.Parallel()
+
+	text := "What changed in the last release?"
+	frag := MessageFrag(MessageFragInput{
+		ID:      "message.000",
+		Message: sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: text}}},
+		Kind:    KindConversationEvent,
+		Slot:    SlotHistory,
+	})
+	if got, want := EstimateFragTokens(frag), len(text)/4; got != want {
+		t.Fatalf("EstimateFragTokens = %d, want %d", got, want)
+	}
+}
+
+// Images carry a flat estimate: never their base64 payload bytes (which
+// overstate provider cost by orders of magnitude) and never zero (which
+// would make image-heavy history invisible to budget pressure).
+func TestEstimateFragTokensFlatImageEstimate(t *testing.T) {
+	t.Parallel()
+
+	bulky := strings.Repeat("A", 40000)
+	frag := ImageFrag("current_user.images", []sdk.ImagePart{{Image: "data:image/png;base64," + bulky, MediaType: "image/png"}}, Scope{}, "run_config")
+	if got := EstimateFragTokens(frag); got != EstimateImageTokens {
+		t.Fatalf("EstimateFragTokens(image) = %d, want %d", got, EstimateImageTokens)
+	}
+}
+
+func TestEstimateSDKMessageTokensFlatImageEstimate(t *testing.T) {
+	t.Parallel()
+
+	bulky := strings.Repeat("A", 40000)
+	msg := sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{
+		sdk.TextPart{Text: "abcdefgh"},
+		sdk.ImagePart{Image: "data:image/png;base64," + bulky, MediaType: "image/png"},
+		sdk.ImagePart{Image: "data:image/png;base64," + bulky, MediaType: "image/png"},
+	}}
+	if got, want := EstimateSDKMessageTokens(msg), 2+2*EstimateImageTokens; got != want {
+		t.Fatalf("EstimateSDKMessageTokens = %d, want %d", got, want)
+	}
+}
+
+func TestEstimateFragTokensIgnoresPresetEstimate(t *testing.T) {
+	t.Parallel()
+
+	frag := TextFrag(TextFragInput{ID: "f", Kind: KindSystemPrompt, Slot: SlotSystem, Text: "abcdefgh"})
+	frag.TokenEstimate = 999
+	if got := EstimateFragTokens(frag); got != 2 {
+		t.Fatalf("EstimateFragTokens = %d, want 2 (computed from parts)", got)
+	}
+}
+
+func TestResolveFragTokensPrefersPresetEstimate(t *testing.T) {
+	t.Parallel()
+
+	frag := TextFrag(TextFragInput{ID: "f", Kind: KindSystemPrompt, Slot: SlotSystem, Text: "abcdefgh"})
+	frag.TokenEstimate = 999
+	if got := ResolveFragTokens(frag); got != 999 {
+		t.Fatalf("ResolveFragTokens = %d, want 999", got)
+	}
+	frag.TokenEstimate = 0
+	if got := ResolveFragTokens(frag); got != 2 {
+		t.Fatalf("ResolveFragTokens = %d, want 2 (fallback to computed)", got)
+	}
+}

--- a/internal/agent/context/fragment/tooldefs_test.go
+++ b/internal/agent/context/fragment/tooldefs_test.go
@@ -1,0 +1,36 @@
+package contextfrag
+
+import (
+	"encoding/json"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestToolDefAccountingForMeasuresSerializedDefinition(t *testing.T) {
+	t.Parallel()
+
+	tool := sdk.Tool{
+		Name:        "send_message",
+		Description: "Send a message to the current conversation.",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string"}}},
+	}
+	got := ToolDefAccountingFor("native", tool)
+
+	data, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ToolDefAccounting{
+		Provider:      "native",
+		Name:          "send_message",
+		Bytes:         len(data),
+		TokenEstimate: TokensFromBytes(len(data)),
+	}
+	if got != want {
+		t.Fatalf("ToolDefAccountingFor = %+v, want %+v", got, want)
+	}
+	if got.TokenEstimate == 0 {
+		t.Fatal("tool definition estimate must be nonzero")
+	}
+}

--- a/internal/agent/context/fragment/types.go
+++ b/internal/agent/context/fragment/types.go
@@ -18,6 +18,7 @@ const (
 	KindCurrentUserMessage   Kind = "current_user_message"
 	KindAttachmentRef        Kind = "attachment_ref"
 	KindNativeImage          Kind = "native_image"
+	KindSkillsCatalog        Kind = "skills_catalog"
 	KindHookContext          Kind = "hook_context"
 	KindBackgroundSummary    Kind = "background_summary"
 	KindACPContext           Kind = "acp_context"
@@ -27,6 +28,13 @@ const (
 	KindMemoryRecall        Kind = "memory_recall"
 	KindConversationSummary Kind = "conversation_summary"
 )
+
+// WorkspaceInstructionAnchor is the heading that marks where the workspace
+// instruction section begins in a flattened system prompt string; it must
+// stay byte-identical to the heading system_common.md renders. Reverse-parse
+// paths (the discuss pipeline and the legacy-fields fallback) search for it
+// to splice tool usage before it or split it into its own fragment.
+const WorkspaceInstructionAnchor = "\n## Workspace instruction files"
 
 // v1 keeps all context schema versions in lockstep; future migrations can
 // split this into per-schema supported ranges without changing manifest shape.
@@ -125,8 +133,9 @@ const (
 	OverflowDrop      OverflowAction = "drop"
 )
 
-// BudgetPolicy captures the planned budget behavior for a fragment. Phase 1
-// records policy only; enforcement remains in the existing trimming paths.
+// BudgetPolicy captures the budget behavior for a fragment: the selector
+// enforces MaxTokens/MaxChars via Trim or Drop, Summarize is not implemented
+// (deferred to compaction), and Keep marks the fragment as must-keep.
 type BudgetPolicy struct {
 	MaxTokens int            `json:"max_tokens,omitempty"`
 	MaxChars  int            `json:"max_chars,omitempty"`
@@ -176,6 +185,8 @@ type Scope struct {
 	BotID                     string            `json:"bot_id,omitempty"`
 	ChatID                    string            `json:"chat_id,omitempty"`
 	SessionID                 string            `json:"session_id,omitempty"`
+	SessionMode               string            `json:"session_mode,omitempty"`
+	RuntimeType               string            `json:"runtime_type,omitempty"`
 	ChannelIdentityID         string            `json:"channel_identity_id,omitempty"`
 	DisplayName               string            `json:"display_name,omitempty"`
 	Platform                  string            `json:"platform,omitempty"`
@@ -224,20 +235,25 @@ type Part struct {
 
 // ContextFrag is the typed context fragment abstraction.
 type ContextFrag struct {
-	ID         string           `json:"id"`
-	Ref        ContextRef       `json:"ref,omitempty"`
-	Kind       Kind             `json:"kind"`
-	Role       sdk.MessageRole  `json:"role,omitempty"`
-	Slot       Slot             `json:"slot"`
-	Priority   int              `json:"priority,omitempty"`
-	CacheClass CacheClass       `json:"cache_class,omitempty"`
-	Trust      TrustLevel       `json:"trust,omitempty"`
-	Scope      Scope            `json:"scope,omitempty"`
-	Budget     BudgetPolicy     `json:"budget,omitempty"`
-	Render     RenderPolicy     `json:"render,omitempty"`
-	Provenance Provenance       `json:"provenance,omitempty"`
-	Coverage   *SummaryCoverage `json:"coverage,omitempty"`
-	Parts      []Part           `json:"parts,omitempty"`
+	ID            string          `json:"id"`
+	Ref           ContextRef      `json:"ref,omitempty"`
+	Kind          Kind            `json:"kind"`
+	Role          sdk.MessageRole `json:"role,omitempty"`
+	Slot          Slot            `json:"slot"`
+	Priority      int             `json:"priority,omitempty"`
+	CacheClass    CacheClass      `json:"cache_class,omitempty"`
+	Trust         TrustLevel      `json:"trust,omitempty"`
+	Scope         Scope           `json:"scope,omitempty"`
+	Budget        BudgetPolicy    `json:"budget,omitempty"`
+	Render        RenderPolicy    `json:"render,omitempty"`
+	Provenance    Provenance      `json:"provenance,omitempty"`
+	TokenEstimate int             `json:"token_estimate,omitempty"`
+	// ConflictKey groups fragments that are alternatives of one another: the
+	// selector keeps only the highest-precedence member (closest scope, then
+	// trust, then latest collected) and drops the rest.
+	ConflictKey string           `json:"conflict_key,omitempty"`
+	Coverage    *SummaryCoverage `json:"coverage,omitempty"`
+	Parts       []Part           `json:"parts,omitempty"`
 }
 
 // AssembledContext is the compiled view produced from fragments.
@@ -262,7 +278,13 @@ type Manifest struct {
 	ContinuityGroups   []ContinuityGroup   `json:"continuity_groups,omitempty"`
 	ValidationWarnings []ValidationWarning `json:"validation_warnings,omitempty"`
 	Counts             ManifestCounts      `json:"counts"`
+	Breakdown          []KindBreakdown     `json:"breakdown,omitempty"`
+	TrustBreakdown     []TrustBreakdown    `json:"trust_breakdown,omitempty"`
+	ToolDefs           []ToolDefAccounting `json:"tool_defs,omitempty"`
 	Items              []ManifestItem      `json:"items,omitempty"`
+	Selection          *SelectionTrace     `json:"selection,omitempty"`
+	CachePlan          *CachePlan          `json:"cache_plan,omitempty"`
+	Mutations          *MutationLedger     `json:"mutations,omitempty"`
 }
 
 // ManifestView names the exact view represented by a manifest.
@@ -286,29 +308,69 @@ const (
 
 // ManifestCounts summarizes fragment composition.
 type ManifestCounts struct {
-	Fragments int `json:"fragments"`
-	Messages  int `json:"messages"`
-	Images    int `json:"images"`
-	TextBytes int `json:"text_bytes"`
+	Fragments     int `json:"fragments"`
+	Messages      int `json:"messages"`
+	Images        int `json:"images"`
+	TextBytes     int `json:"text_bytes"`
+	TokenEstimate int `json:"token_estimate"`
+}
+
+// KindBreakdown aggregates manifest items of one Kind so consumers can show
+// where the context window went without walking every item.
+type KindBreakdown struct {
+	Kind          Kind `json:"kind"`
+	Fragments     int  `json:"fragments"`
+	TokenEstimate int  `json:"token_estimate"`
+	TextBytes     int  `json:"text_bytes,omitempty"`
+	Images        int  `json:"images,omitempty"`
+}
+
+// TrustBreakdown aggregates manifest items of one TrustLevel so consumers
+// can measure how much of the context window is attacker-influenceable
+// (external) versus Memoh-controlled, per turn.
+type TrustBreakdown struct {
+	Trust         TrustLevel `json:"trust"`
+	Fragments     int        `json:"fragments"`
+	TokenEstimate int        `json:"token_estimate"`
+	TextBytes     int        `json:"text_bytes,omitempty"`
+	Images        int        `json:"images,omitempty"`
+}
+
+// ToolDefAccounting records the serialized size of one tool definition sent
+// to the provider. Tool schemas never render as fragments, so without this
+// entry the manifest understates the real prompt by the whole tool roster.
+type ToolDefAccounting struct {
+	Provider      string `json:"provider"`
+	Name          string `json:"name"`
+	Bytes         int    `json:"bytes"`
+	TokenEstimate int    `json:"token_estimate"`
+}
+
+type SelectionTrace struct {
+	Selected    int            `json:"selected"`
+	Dropped     int            `json:"dropped"`
+	DropReasons map[string]int `json:"drop_reasons,omitempty"`
 }
 
 // ManifestItem is one non-sensitive fragment entry.
 type ManifestItem struct {
-	ID         string          `json:"id"`
-	Ref        ContextRef      `json:"ref,omitempty"`
-	Kind       Kind            `json:"kind"`
-	Slot       Slot            `json:"slot"`
-	Role       sdk.MessageRole `json:"role,omitempty"`
-	Priority   int             `json:"priority,omitempty"`
-	CacheClass CacheClass      `json:"cache_class,omitempty"`
-	Trust      TrustLevel      `json:"trust,omitempty"`
-	Source     string          `json:"source,omitempty"`
-	SourceID   string          `json:"source_id,omitempty"`
-	Collector  string          `json:"collector,omitempty"`
-	PartTypes  []PartType      `json:"part_types,omitempty"`
-	TextBytes  int             `json:"text_bytes,omitempty"`
-	ImageCount int             `json:"image_count,omitempty"`
-	Scope      Scope           `json:"scope,omitempty"`
+	ID            string          `json:"id"`
+	Ref           ContextRef      `json:"ref,omitempty"`
+	Kind          Kind            `json:"kind"`
+	Slot          Slot            `json:"slot"`
+	Role          sdk.MessageRole `json:"role,omitempty"`
+	Priority      int             `json:"priority,omitempty"`
+	CacheClass    CacheClass      `json:"cache_class,omitempty"`
+	Trust         TrustLevel      `json:"trust,omitempty"`
+	Source        string          `json:"source,omitempty"`
+	SourceID      string          `json:"source_id,omitempty"`
+	Collector     string          `json:"collector,omitempty"`
+	ConflictKey   string          `json:"conflict_key,omitempty"`
+	PartTypes     []PartType      `json:"part_types,omitempty"`
+	TextBytes     int             `json:"text_bytes,omitempty"`
+	ImageCount    int             `json:"image_count,omitempty"`
+	TokenEstimate int             `json:"token_estimate,omitempty"`
+	Scope         Scope           `json:"scope,omitempty"`
 }
 
 type SlotRenderPolicy struct {
@@ -398,4 +460,23 @@ type ContextConflict struct {
 	Key      string       `json:"key,omitempty"`
 	Expected string       `json:"expected,omitempty"`
 	Actual   string       `json:"actual,omitempty"`
+}
+
+// ToolExchangePolicy asks the selector to strip bulky tool interactions from
+// history: tool results and non-conversational tool calls are removed while
+// ask_user exchanges survive because the question and answer are part of the
+// visible conversation. MinMessages gates the policy: it applies only when
+// the history holds more message fragments than the threshold (zero applies
+// it unconditionally).
+type ToolExchangePolicy struct {
+	MinMessages int
+}
+
+const defaultToolExchangeMinMessages = 10
+
+// DefaultToolExchangePolicy returns the package's shared default
+// tool-exchange stripping policy. Returns a fresh pointer on every call so
+// callers never share (and risk mutating) the same underlying struct.
+func DefaultToolExchangePolicy() *ToolExchangePolicy {
+	return &ToolExchangePolicy{MinMessages: defaultToolExchangeMinMessages}
 }

--- a/internal/agent/context/fragment/types.go
+++ b/internal/agent/context/fragment/types.go
@@ -185,8 +185,6 @@ type Scope struct {
 	BotID                     string            `json:"bot_id,omitempty"`
 	ChatID                    string            `json:"chat_id,omitempty"`
 	SessionID                 string            `json:"session_id,omitempty"`
-	SessionMode               string            `json:"session_mode,omitempty"`
-	RuntimeType               string            `json:"runtime_type,omitempty"`
 	ChannelIdentityID         string            `json:"channel_identity_id,omitempty"`
 	DisplayName               string            `json:"display_name,omitempty"`
 	Platform                  string            `json:"platform,omitempty"`

--- a/internal/agent/context/fragment/types_json_test.go
+++ b/internal/agent/context/fragment/types_json_test.go
@@ -1,0 +1,27 @@
+package contextfrag
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestContextFragJSONFieldNames(t *testing.T) {
+	frag := ContextFrag{ID: "f1", TokenEstimate: 42, ConflictKey: "group.a"}
+	data, err := json.Marshal(frag)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, ok := decoded["token_estimate"].(float64); !ok || got != 42 {
+		t.Fatalf("token_estimate = %v, want 42", decoded["token_estimate"])
+	}
+	if got, ok := decoded["conflict_key"].(string); !ok || got != "group.a" {
+		t.Fatalf("conflict_key = %v, want %q", decoded["conflict_key"], "group.a")
+	}
+	if _, ok := decoded["TokenEstimate"]; ok {
+		t.Fatal("TokenEstimate leaked under Go field name")
+	}
+}

--- a/internal/agent/context/fragment/types_test.go
+++ b/internal/agent/context/fragment/types_test.go
@@ -1,0 +1,18 @@
+package contextfrag
+
+import "testing"
+
+func TestDefaultToolExchangePolicy(t *testing.T) {
+	t.Parallel()
+
+	got := DefaultToolExchangePolicy()
+	if got.MinMessages != 10 {
+		t.Fatalf("MinMessages = %d, want 10", got.MinMessages)
+	}
+
+	other := DefaultToolExchangePolicy()
+	other.MinMessages = 99
+	if got.MinMessages == other.MinMessages {
+		t.Fatal("DefaultToolExchangePolicy must return a fresh pointer per call, not a shared one")
+	}
+}

--- a/internal/agent/context/fragment/view.go
+++ b/internal/agent/context/fragment/view.go
@@ -1,0 +1,28 @@
+package contextfrag
+
+// Intent names why a context is being built; RenderTarget names what it is
+// rendered into. One intent may fan out to several render targets.
+type Intent string
+
+const IntentRunConfigPreProvider Intent = "run_config_pre_provider"
+
+func (i Intent) ManifestView() ManifestView {
+	return ManifestView(i)
+}
+
+type RenderTarget string
+
+const RenderSDKMessages RenderTarget = "sdk_messages"
+
+// NormalizeContextRefs fills durable refs and canonical hashes for fragments
+// coming from collectors, mirroring what Compile does for legacy inputs.
+func NormalizeContextRefs(frags []ContextFrag) []ContextFrag {
+	return normalizeContextRefs(frags)
+}
+
+// CachePlan records the stable prefix selected for provider prompt caching.
+type CachePlan struct {
+	StablePrefixHash          string `json:"stable_prefix_hash,omitempty"`
+	StableMessageCount        int    `json:"stable_message_count,omitempty"`
+	StablePrefixTokenEstimate int    `json:"stable_prefix_token_estimate,omitempty"`
+}

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -13,6 +13,7 @@ import (
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	"github.com/memohai/memoh/internal/agent/background"
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	userinput "github.com/memohai/memoh/internal/agent/decision/input"
 	tools "github.com/memohai/memoh/internal/agent/tool"
 	"github.com/memohai/memoh/internal/hooks"
@@ -81,7 +82,7 @@ func (a *Agent) Generate(ctx context.Context, cfg RunConfig) (*GenerateResult, e
 }
 
 func (a *Agent) ExecuteTool(ctx context.Context, cfg RunConfig, call sdk.ToolCall) (sdk.ToolResultPart, error) {
-	sdkTools, _, err := a.assembleTools(ctx, cfg, nil, false)
+	sdkTools, _, _, err := a.assembleTools(ctx, cfg, nil, false)
 	if err != nil {
 		return sdk.ToolResultPart{}, fmt.Errorf("assemble tools: %w", err)
 	}
@@ -160,13 +161,15 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 	var sdkTools []sdk.Tool
 	if cfg.SupportsToolCall {
 		var toolUsage string
+		var toolDefs []contextfrag.ToolDefAccounting
 		var err error
-		sdkTools, toolUsage, err = a.assembleTools(streamCtx, cfg, streamEmitter, cfg.LiveToolStream)
+		sdkTools, toolUsage, toolDefs, err = a.assembleTools(streamCtx, cfg, streamEmitter, cfg.LiveToolStream)
 		if err != nil {
 			turnError = fmt.Sprintf("assemble tools: %v", err)
 			sendEvent(ctx, ch, StreamEvent{Type: EventError, Error: turnError})
 			return
 		}
+		cfg.ContextToolDefs = toolDefs
 		if toolUsage != "" {
 			// Must run before buildGenerateOptions so prompt caching and
 			// background task summaries see the usage-augmented text.
@@ -743,11 +746,13 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 	var sdkTools []sdk.Tool
 	if cfg.SupportsToolCall {
 		var toolUsage string
+		var toolDefs []contextfrag.ToolDefAccounting
 		var err error
-		sdkTools, toolUsage, err = a.assembleTools(genCtx, cfg, collectEmitter, false)
+		sdkTools, toolUsage, toolDefs, err = a.assembleTools(genCtx, cfg, collectEmitter, false)
 		if err != nil {
 			return nil, fmt.Errorf("assemble tools: %w", err)
 		}
+		cfg.ContextToolDefs = toolDefs
 		if toolUsage != "" {
 			// Must run before buildGenerateOptions so prompt caching and
 			// background task summaries see the usage-augmented text.
@@ -933,9 +938,9 @@ func (a *Agent) buildGenerateOptions(cfg RunConfig, tools []sdk.Tool, approvalTo
 // (see tools.ToolUsage). emitter is injected into the session context so that
 // tools targeting the current conversation can push side-effect events
 // (attachments, reactions, speech) directly into the agent stream.
-func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.StreamEmitter, liveStream bool) ([]sdk.Tool, string, error) {
+func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.StreamEmitter, liveStream bool) ([]sdk.Tool, string, []contextfrag.ToolDefAccounting, error) {
 	if len(a.toolProviders) == 0 {
-		return nil, "", nil
+		return nil, "", nil, nil
 	}
 	skillsMap := make(map[string]tools.SkillDetail, len(cfg.Skills))
 	for _, s := range cfg.Skills {
@@ -975,6 +980,7 @@ func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.
 	}
 
 	var allTools []sdk.Tool
+	var toolDefs []contextfrag.ToolDefAccounting
 	type usageRegistration struct {
 		provider tools.ToolUsage
 	}
@@ -1008,6 +1014,13 @@ func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.
 		if len(providerTools) == 0 {
 			continue
 		}
+		label := "native"
+		if labeler, ok := provider.(tools.ProviderLabeler); ok {
+			label = labeler.ProviderLabel()
+		}
+		for _, tool := range providerTools {
+			toolDefs = append(toolDefs, contextfrag.ToolDefAccountingFor(label, tool))
+		}
 		allTools = append(allTools, providerTools...)
 		// Collect group-level usage guidance only from providers that actually
 		// contributed tools this session, so guidance and registration share
@@ -1029,7 +1042,7 @@ func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.
 	if len(usageSections) > 0 {
 		usage = "## Tool usage\n\n" + strings.Join(usageSections, "\n\n")
 	}
-	return allTools, usage, nil
+	return allTools, usage, toolDefs, nil
 }
 
 func appendToolUsageToSystem(system, toolUsage string) string {

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -927,6 +927,7 @@ func (a *Agent) buildGenerateOptions(cfg RunConfig, tools []sdk.Tool, approvalTo
 	}
 
 	prepareStep = wrapPrepareStepWithForkSnapshot(prepareStep, cfg.ForkContext)
+	prepareStep = wrapPrepareStepWithFinalInputHash(prepareStep, cfg.ContextMutations)
 	if prepareStep != nil {
 		opts = append(opts, sdk.WithPrepareStep(prepareStep))
 	}
@@ -1030,7 +1031,9 @@ func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.
 		}
 		label := "native"
 		if labeler, ok := provider.(tools.ProviderLabeler); ok {
-			label = labeler.ProviderLabel()
+			if providerLabel := strings.TrimSpace(labeler.ProviderLabel()); providerLabel != "" {
+				label = providerLabel
+			}
 		}
 		for _, tool := range providerTools {
 			toolDefs = append(toolDefs, contextfrag.ToolDefAccountingFor(label, tool))
@@ -1355,6 +1358,29 @@ func wrapPrepareStepWithForkSnapshot(
 		}
 		_ = forkContext.Store(p.Messages)
 		return p
+	}
+}
+
+func wrapPrepareStepWithFinalInputHash(
+	prepareStep func(*sdk.GenerateParams) *sdk.GenerateParams,
+	ledger *contextfrag.MutationLedger,
+) func(*sdk.GenerateParams) *sdk.GenerateParams {
+	if ledger == nil {
+		return prepareStep
+	}
+	return func(p *sdk.GenerateParams) *sdk.GenerateParams {
+		var override *sdk.GenerateParams
+		if prepareStep != nil {
+			override = prepareStep(p)
+			if override != nil {
+				p = override
+			}
+		}
+		if p != nil {
+			hash, _ := contextfrag.ProviderPayloadHashAndBytes(p.System, p.Messages, p.Tools)
+			ledger.SetFinalInputHash(hash)
+		}
+		return override
 	}
 }
 

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -23,12 +23,13 @@ import (
 
 // Agent is the core agent that handles LLM interactions.
 type Agent struct {
-	client         *sdk.Client
-	toolProviders  []tools.ToolProvider
-	bridgeProvider bridge.Provider
-	hookService    *hooks.Service
-	logger         *slog.Logger
-	limits         Limits
+	client             *sdk.Client
+	toolProviders      []tools.ToolProvider
+	bridgeProvider     bridge.Provider
+	hookService        *hooks.Service
+	logger             *slog.Logger
+	limits             Limits
+	contextViewApplier ContextViewApplier
 }
 
 const streamCancelDrainGrace = 250 * time.Millisecond
@@ -40,12 +41,23 @@ func New(deps Deps) *Agent {
 		logger = slog.Default()
 	}
 	return &Agent{
-		client:         sdk.NewClient(),
-		bridgeProvider: deps.BridgeProvider,
-		hookService:    deps.HookService,
-		logger:         logger.With(slog.String("service", "agent/runtime/native")),
-		limits:         deps.Limits.Normalize(),
+		client:             sdk.NewClient(),
+		bridgeProvider:     deps.BridgeProvider,
+		hookService:        deps.HookService,
+		logger:             logger.With(slog.String("service", "agent/runtime/native")),
+		limits:             deps.Limits.Normalize(),
+		contextViewApplier: deps.ContextViewApplier,
 	}
+}
+
+// applyContextView compiles the provider-facing fields from authoritative
+// fragments when the application installed the PR1 compiler. Direct Agent
+// users retain the legacy refresh path.
+func (a *Agent) applyContextView(ctx context.Context, cfg RunConfig) RunConfig {
+	if a != nil && a.contextViewApplier != nil {
+		return a.contextViewApplier(ctx, cfg)
+	}
+	return cfg.RefreshContextFrag()
 }
 
 // BridgeProvider returns the underlying bridge provider (workspace manager).
@@ -179,7 +191,8 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 	}
 	limit := a.Limits().ToolOutputLimit()
 	sdkTools, readMediaState := decorateReadMediaTools(cfg.Model, sdkTools)
-	cfg = cfg.RefreshContextFragWithDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, true)
+	cfg.ContextDynamicMutators = cfg.contextDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, true)
+	cfg = a.applyContextView(streamCtx, cfg)
 	sdkTools = tools.WrapToolOutputLimits(sdkTools, limit)
 	approvalTools := append([]sdk.Tool(nil), sdkTools...)
 	sdkTools = a.wrapToolsWithHooks(ctx, cfg, sdkTools)
@@ -281,7 +294,6 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 		sendEvent(ctx, ch, StreamEvent{Type: EventError, Error: turnError})
 		return
 	}
-	cfg = cfg.RefreshContextFragWithDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, true)
 	opts := a.buildGenerateOptions(cfg, sdkTools, approvalTools, prepareStep)
 	modelStepIndex := 0
 	opts = append(opts, sdk.WithOnStep(func(step *sdk.StepResult) *sdk.GenerateParams {
@@ -762,7 +774,8 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 	}
 	limit := a.Limits().ToolOutputLimit()
 	sdkTools, readMediaState := decorateReadMediaTools(cfg.Model, sdkTools)
-	cfg = cfg.RefreshContextFragWithDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, false)
+	cfg.ContextDynamicMutators = cfg.contextDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, false)
+	cfg = a.applyContextView(genCtx, cfg)
 	sdkTools = tools.WrapToolOutputLimits(sdkTools, limit)
 	approvalTools := append([]sdk.Tool(nil), sdkTools...)
 	sdkTools = a.wrapToolsWithHooks(ctx, cfg, sdkTools)
@@ -793,7 +806,6 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 	if err != nil {
 		return nil, err
 	}
-	cfg = cfg.RefreshContextFragWithDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, false)
 	opts := a.buildGenerateOptions(cfg, sdkTools, approvalTools, prepareStep)
 	modelStepIndex := 0
 	opts = append(opts,
@@ -876,6 +888,8 @@ func (a *Agent) buildGenerateOptions(cfg RunConfig, tools []sdk.Tool, approvalTo
 	system, messages, tools := models.ApplyPromptCache(
 		cfg.Model, cfg.PromptCacheTTL, cfg.System, cfg.Messages, tools,
 	)
+	finalHash, _ := contextfrag.ProviderPayloadHashAndBytes(system, messages, tools)
+	cfg.ContextMutations.SetFinalInputHash(finalHash)
 	if cfg.ForkContext != nil {
 		_ = cfg.ForkContext.Store(messages)
 	}

--- a/internal/agent/runtime/native/config.go
+++ b/internal/agent/runtime/native/config.go
@@ -1,12 +1,17 @@
 package native
 
 import (
+	"context"
 	"log/slog"
 
 	agenttools "github.com/memohai/memoh/internal/agent/tool"
 	"github.com/memohai/memoh/internal/hooks"
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
+
+// ContextViewApplier rebuilds provider-facing fields from the authoritative
+// context fragments immediately before generate options are assembled.
+type ContextViewApplier func(context.Context, RunConfig) RunConfig
 
 const (
 	DefaultToolOutputMaxBytes  = 64 * 1024
@@ -22,10 +27,11 @@ type Limits struct {
 
 // Deps holds all service dependencies for the Agent.
 type Deps struct {
-	BridgeProvider bridge.Provider
-	HookService    *hooks.Service
-	Logger         *slog.Logger
-	Limits         Limits
+	BridgeProvider     bridge.Provider
+	HookService        *hooks.Service
+	Logger             *slog.Logger
+	Limits             Limits
+	ContextViewApplier ContextViewApplier
 }
 
 func DefaultLimits() Limits {

--- a/internal/agent/runtime/native/context_frag.go
+++ b/internal/agent/runtime/native/context_frag.go
@@ -20,6 +20,7 @@ func (cfg RunConfig) RefreshContextFrag() RunConfig {
 		System:                  cfg.System,
 		Messages:                cfg.Messages,
 		CurrentUserMessageIndex: cfg.ContextCurrentUserMessageIndex,
+		MemoryMessageIndex:      cfg.ContextMemoryMessageIndex,
 		Query:                   query,
 		InlineImages:            inlineImages,
 		ToolUsage:               cfg.ContextToolUsage,

--- a/internal/agent/runtime/native/context_frag.go
+++ b/internal/agent/runtime/native/context_frag.go
@@ -15,18 +15,28 @@ func (cfg RunConfig) RefreshContextFrag() RunConfig {
 		inlineImages = nil
 	}
 	assembled := contextfrag.Compile(contextfrag.CompileInput{
-		Source:          contextfrag.SourceRunConfig,
-		Scope:           cfg.ContextScope,
-		System:          cfg.System,
-		Messages:        cfg.Messages,
-		Query:           query,
-		InlineImages:    inlineImages,
-		ToolUsage:       cfg.ContextToolUsage,
-		DynamicMutators: cfg.ContextDynamicMutators,
-		Existing:        cfg.ContextFrags,
+		Source:                  contextfrag.SourceRunConfig,
+		Scope:                   cfg.ContextScope,
+		System:                  cfg.System,
+		Messages:                cfg.Messages,
+		CurrentUserMessageIndex: cfg.ContextCurrentUserMessageIndex,
+		Query:                   query,
+		InlineImages:            inlineImages,
+		ToolUsage:               cfg.ContextToolUsage,
+		DynamicMutators:         cfg.ContextDynamicMutators,
+		Existing:                cfg.ContextFrags,
 	})
 	cfg.ContextFrags = assembled.Frags
-	cfg.ContextManifest = assembled.Manifest
+	manifest := assembled.Manifest
+	manifest.ToolDefs = cfg.ContextToolDefs
+	if cfg.ContextManifest.CachePlan != nil && manifest.CachePlan == nil {
+		plan := *cfg.ContextManifest.CachePlan
+		manifest.CachePlan = &plan
+	}
+	if cfg.ContextManifest.Mutations != nil && manifest.Mutations == nil {
+		manifest.Mutations = cfg.ContextManifest.Mutations
+	}
+	cfg.ContextManifest = manifest
 	return cfg
 }
 

--- a/internal/agent/runtime/native/context_frag_test.go
+++ b/internal/agent/runtime/native/context_frag_test.go
@@ -141,8 +141,8 @@ func TestSpawnRunConfigCarriesContextScopeAndMaterializedQuery(t *testing.T) {
 		t.Fatal("spawn query should be marked materialized because it is appended to Messages")
 	}
 	rc = rc.RefreshContextFrag()
-	if manifestHasAgentKind(rc.ContextManifest, contextfrag.KindCurrentUserMessage) {
-		t.Fatalf("manifest should not include duplicate pending current user query: %#v", rc.ContextManifest.Items)
+	if !manifestHasAgentKind(rc.ContextManifest, contextfrag.KindCurrentUserMessage) {
+		t.Fatalf("manifest should classify the materialized query as current user: %#v", rc.ContextManifest.Items)
 	}
 	if rc.ContextManifest.Counts.Messages != 2 {
 		t.Fatalf("manifest message count = %d, want history + materialized query", rc.ContextManifest.Counts.Messages)

--- a/internal/agent/runtime/native/context_frag_test.go
+++ b/internal/agent/runtime/native/context_frag_test.go
@@ -71,6 +71,26 @@ func TestRefreshContextFragMarksMaterializedCurrentMessage(t *testing.T) {
 	}
 }
 
+func TestRefreshContextFragKeepsMemoryDistinctFromCurrentMessage(t *testing.T) {
+	t.Parallel()
+	currentIndex := 0
+	memoryIndex := 1
+	cfg := RunConfig{
+		Messages:                       []sdk.Message{sdk.UserMessage("current"), sdk.UserMessage("memory recall")},
+		ContextCurrentUserMessageIndex: &currentIndex,
+		ContextMemoryMessageIndex:      &memoryIndex,
+		ContextQueryMaterialized:       true,
+	}
+
+	cfg = cfg.RefreshContextFrag()
+	if cfg.ContextFrags[currentIndex].Kind != contextfrag.KindCurrentUserMessage || cfg.ContextFrags[currentIndex].Slot != contextfrag.SlotCurrentUser {
+		t.Fatalf("current fragment = %#v", cfg.ContextFrags[currentIndex])
+	}
+	if cfg.ContextFrags[memoryIndex].Kind != contextfrag.KindMemoryRecall || cfg.ContextFrags[memoryIndex].Slot != contextfrag.SlotHistory || cfg.ContextFrags[memoryIndex].CacheClass != contextfrag.CacheNever {
+		t.Fatalf("memory fragment = %#v", cfg.ContextFrags[memoryIndex])
+	}
+}
+
 func TestRefreshContextFragPreservesProviderAccounting(t *testing.T) {
 	t.Parallel()
 	ledger := contextfrag.NewMutationLedger()

--- a/internal/agent/runtime/native/context_frag_test.go
+++ b/internal/agent/runtime/native/context_frag_test.go
@@ -53,6 +53,43 @@ func TestRefreshContextFragOmitsMaterializedInlineImages(t *testing.T) {
 	}
 }
 
+func TestRefreshContextFragMarksMaterializedCurrentMessage(t *testing.T) {
+	t.Parallel()
+	index := 1
+	cfg := RunConfig{
+		System:                         "base system",
+		Messages:                       []sdk.Message{sdk.AssistantMessage("history"), sdk.UserMessage("current")},
+		ContextCurrentUserMessageIndex: &index,
+		ContextQueryMaterialized:       true,
+	}
+	cfg = cfg.RefreshContextFrag()
+	if !manifestHasAgentKind(cfg.ContextManifest, contextfrag.KindCurrentUserMessage) {
+		t.Fatalf("manifest items = %#v", cfg.ContextManifest.Items)
+	}
+	if cfg.ContextFrags[index+1].Slot != contextfrag.SlotCurrentUser {
+		t.Fatalf("current fragment = %#v", cfg.ContextFrags[index+1])
+	}
+}
+
+func TestRefreshContextFragPreservesProviderAccounting(t *testing.T) {
+	t.Parallel()
+	ledger := contextfrag.NewMutationLedger()
+	plan := contextfrag.CachePlan{StablePrefixHash: "prefix", StableMessageCount: 2}
+	cfg := RunConfig{
+		System:          "base system",
+		Messages:        []sdk.Message{sdk.UserMessage("hi")},
+		ContextToolDefs: []contextfrag.ToolDefAccounting{{Provider: "native", Name: "read", Bytes: 40, TokenEstimate: 10}},
+		ContextManifest: contextfrag.Manifest{CachePlan: &plan, Mutations: ledger},
+	}
+	cfg = cfg.RefreshContextFrag()
+	if cfg.ContextManifest.CachePlan == nil || cfg.ContextManifest.CachePlan.StablePrefixHash != "prefix" || cfg.ContextManifest.Mutations != ledger {
+		t.Fatalf("manifest accounting = %#v", cfg.ContextManifest)
+	}
+	if len(cfg.ContextManifest.ToolDefs) != 1 || cfg.ContextManifest.ToolDefs[0].Name != "read" {
+		t.Fatalf("tool definitions = %#v", cfg.ContextManifest.ToolDefs)
+	}
+}
+
 func TestRefreshContextFragMarksToolUsageBeforeWorkspaceInstructions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/runtime/native/context_view_applier_test.go
+++ b/internal/agent/runtime/native/context_view_applier_test.go
@@ -1,0 +1,110 @@
+package native
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	tools "github.com/memohai/memoh/internal/agent/tool"
+)
+
+func TestGenerateAppliesContextViewBeforeProviderOptions(t *testing.T) {
+	t.Parallel()
+	modelProvider := &usageRecordingProvider{}
+	ledger := contextfrag.NewMutationLedger()
+	called := 0
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) RunConfig {
+		called++
+		if !strings.Contains(cfg.ContextToolUsage, usageMarker) {
+			t.Fatalf("applier tool usage = %q, want marker", cfg.ContextToolUsage)
+		}
+		if len(cfg.ContextToolDefs) != 1 || cfg.ContextToolDefs[0].Name != "fake_tool" {
+			t.Fatalf("applier tool definitions = %#v", cfg.ContextToolDefs)
+		}
+		cfg.System = "compiled system"
+		cfg.Messages = []sdk.Message{sdk.UserMessage("compiled message")}
+		cfg.ContextMutations = ledger
+		return cfg
+	}})
+	a.SetToolProviders([]tools.ToolProvider{&usageTestProvider{emitTool: true, usage: usageMarker}})
+
+	if _, err := a.Generate(context.Background(), RunConfig{
+		Model:  &sdk.Model{ID: "view-model", Provider: modelProvider, Type: sdk.ModelTypeChat},
+		System: "legacy system", Messages: []sdk.Message{sdk.UserMessage("legacy message")}, SupportsToolCall: true,
+	}); err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("applier calls = %d, want 1", called)
+	}
+	params := modelProvider.lastParams()
+	if params.System != "compiled system" || !reflect.DeepEqual(params.Messages, []sdk.Message{sdk.UserMessage("compiled message")}) {
+		t.Fatalf("provider payload = system %q messages %#v", params.System, params.Messages)
+	}
+	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(params.System, params.Messages, params.Tools)
+	if ledger.FinalInputHash() != wantHash {
+		t.Fatalf("final input hash = %q, want %q", ledger.FinalInputHash(), wantHash)
+	}
+}
+
+func TestStreamAppliesContextViewOnce(t *testing.T) {
+	t.Parallel()
+	modelProvider := &usageStreamRecordingProvider{}
+	called := make(chan RunConfig, 1)
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) RunConfig {
+		called <- cfg
+		cfg.System = "compiled stream system"
+		cfg.Messages = []sdk.Message{sdk.UserMessage("compiled stream message")}
+		cfg.ContextMutations = contextfrag.NewMutationLedger()
+		return cfg
+	}})
+
+	for range a.Stream(context.Background(), RunConfig{
+		Model:  &sdk.Model{ID: "view-stream-model", Provider: modelProvider, Type: sdk.ModelTypeChat},
+		System: "legacy stream system", Messages: []sdk.Message{sdk.UserMessage("legacy stream message")},
+	}) {
+	}
+	select {
+	case <-called:
+	default:
+		t.Fatal("context view applier was not called")
+	}
+	select {
+	case <-called:
+		t.Fatal("context view applier was called more than once")
+	default:
+	}
+	params := modelProvider.lastParams()
+	if params.System != "compiled stream system" || !reflect.DeepEqual(params.Messages, []sdk.Message{sdk.UserMessage("compiled stream message")}) {
+		t.Fatalf("provider payload = system %q messages %#v", params.System, params.Messages)
+	}
+}
+
+func TestApplyContextViewFallsBackToLegacyRefresh(t *testing.T) {
+	t.Parallel()
+	cfg := RunConfig{System: "system", Messages: []sdk.Message{sdk.UserMessage("history")}}
+	got := New(Deps{}).applyContextView(context.Background(), cfg)
+	if len(got.ContextFrags) == 0 || got.ContextManifest.Counts.Messages != 1 {
+		t.Fatalf("legacy context refresh = %#v", got.ContextManifest)
+	}
+}
+
+func TestBeforeModelCallAppendRecordsPostViewMutation(t *testing.T) {
+	t.Parallel()
+	ledger := contextfrag.NewMutationLedger()
+	source := []contextfrag.ContextFrag{{ID: "authoritative"}}
+	cfg := RunConfig{Messages: []sdk.Message{sdk.UserMessage("before")}, ContextSourceFrags: source, ContextMutations: ledger}
+
+	got := applyBeforeModelCallAppendContext(cfg, "hook bytes")
+	if len(got.Messages) != 2 || !reflect.DeepEqual(got.ContextSourceFrags, source) {
+		t.Fatalf("hook append changed authoritative source: %#v", got)
+	}
+	records := ledger.Records()
+	if len(records) != 1 || records[0].Kind != contextfrag.MutationBeforeModelCallHook {
+		t.Fatalf("mutation records = %#v", records)
+	}
+}

--- a/internal/agent/runtime/native/context_view_applier_test.go
+++ b/internal/agent/runtime/native/context_view_applier_test.go
@@ -51,6 +51,43 @@ func TestGenerateAppliesContextViewBeforeProviderOptions(t *testing.T) {
 	}
 }
 
+func TestGenerateFinalInputHashTracksLastProviderStep(t *testing.T) {
+	t.Parallel()
+	ledger := contextfrag.NewMutationLedger()
+	var lastParams sdk.GenerateParams
+	modelProvider := &atomicMockProvider{handler: func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		if call == 1 {
+			return &sdk.GenerateResult{
+				FinishReason: sdk.FinishReasonToolCalls,
+				ToolCalls:    []sdk.ToolCall{{ToolCallID: "hash-call", ToolName: "hash_tool"}},
+			}, nil
+		}
+		lastParams = params
+		return &sdk.GenerateResult{Text: "done", FinishReason: sdk.FinishReasonStop}, nil
+	}}
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) RunConfig {
+		cfg.ContextMutations = ledger
+		return cfg
+	}})
+	a.SetToolProviders([]tools.ToolProvider{staticToolProvider{tools: []sdk.Tool{{
+		Name: "hash_tool",
+		Execute: func(*sdk.ToolExecContext, any) (any, error) {
+			return "ok", nil
+		},
+	}}}})
+
+	if _, err := a.Generate(context.Background(), RunConfig{
+		Model:    &sdk.Model{ID: "hash-model", Provider: modelProvider, Type: sdk.ModelTypeChat},
+		Messages: []sdk.Message{sdk.UserMessage("run the tool")}, SupportsToolCall: true,
+	}); err != nil {
+		t.Fatalf("Generate error: %v", err)
+	}
+	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(lastParams.System, lastParams.Messages, lastParams.Tools)
+	if ledger.FinalInputHash() != wantHash {
+		t.Fatalf("final input hash = %q, want last provider step %q", ledger.FinalInputHash(), wantHash)
+	}
+}
+
 func TestStreamAppliesContextViewOnce(t *testing.T) {
 	t.Parallel()
 	modelProvider := &usageStreamRecordingProvider{}

--- a/internal/agent/runtime/native/hooks.go
+++ b/internal/agent/runtime/native/hooks.go
@@ -207,7 +207,7 @@ func (a *Agent) applyBeforeModelCallHook(ctx context.Context, cfg RunConfig, ste
 	}
 	if strings.TrimSpace(res.AppendContext) != "" {
 		cfg = applyBeforeModelCallAppendContext(cfg, res.AppendContext)
-		if a == nil || a.contextViewApplier == nil {
+		if a.contextViewApplier == nil {
 			cfg = cfg.RefreshContextFrag()
 		}
 	}

--- a/internal/agent/runtime/native/hooks.go
+++ b/internal/agent/runtime/native/hooks.go
@@ -9,6 +9,7 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	contextlimit "github.com/memohai/memoh/internal/agent/context/limit"
 	"github.com/memohai/memoh/internal/hooks"
 	"github.com/memohai/memoh/internal/workspace/bridge"
@@ -205,10 +206,21 @@ func (a *Agent) applyBeforeModelCallHook(ctx context.Context, cfg RunConfig, ste
 		return cfg, fmt.Errorf("before model call hook failed: %w", err)
 	}
 	if strings.TrimSpace(res.AppendContext) != "" {
-		cfg.Messages = append(cfg.Messages, sdk.UserMessage(formatHookContext(hooks.EventBeforeModelCall, res.AppendContext)))
-		cfg = cfg.RefreshContextFrag()
+		cfg = applyBeforeModelCallAppendContext(cfg, res.AppendContext)
+		if a == nil || a.contextViewApplier == nil {
+			cfg = cfg.RefreshContextFrag()
+		}
 	}
 	return cfg, nil
+}
+
+func applyBeforeModelCallAppendContext(cfg RunConfig, appendContext string) RunConfig {
+	if strings.TrimSpace(appendContext) == "" {
+		return cfg
+	}
+	cfg.Messages = append(cfg.Messages, sdk.UserMessage(formatHookContext(hooks.EventBeforeModelCall, appendContext)))
+	cfg.ContextMutations.Record(contextfrag.MutationBeforeModelCallHook, fmt.Sprintf("append_bytes=%d", len(appendContext)))
+	return cfg
 }
 
 func (a *Agent) wrapPrepareStepWithModelHook(ctx context.Context, cfg RunConfig, base func(*sdk.GenerateParams) *sdk.GenerateParams) func(*sdk.GenerateParams) *sdk.GenerateParams {

--- a/internal/agent/runtime/native/prompt.go
+++ b/internal/agent/runtime/native/prompt.go
@@ -105,30 +105,7 @@ func selectModeTemplate(sessionType string) string {
 
 // GenerateSystemPrompt builds the complete system prompt from files, skills, and context.
 func GenerateSystemPrompt(params SystemPromptParams) string {
-	home := "/data"
-	timezoneName := strings.TrimSpace(params.Timezone)
-	if timezoneName == "" {
-		timezoneName = "UTC"
-	}
-
-	botInfoSection := buildBotInfoSection(params.Bot)
-
-	skillsSection := buildSkillsSection(params.Skills)
-
-	fileSections := buildFileSections(params.Files, params.MaxFilesBytes)
-
-	tmpl := strings.TrimSpace(systemCommonTmpl + "\n\n" + selectModeTemplate(params.SessionType))
-
-	return render(tmpl, map[string]string{
-		"home":                      home,
-		"timezone":                  timezoneName,
-		"botInfoSection":            botInfoSection,
-		"skillsSection":             skillsSection,
-		"platformIdentitiesSection": strings.TrimSpace(params.PlatformIdentitiesSection),
-		"mainAgentSections":         buildMainAgentSections(strings.TrimSpace(params.PlatformIdentitiesSection), skillsSection, fileSections),
-		"subagentSections":          buildSubagentSections(strings.TrimSpace(params.PlatformIdentitiesSection)),
-		"fileSections":              fileSections,
-	})
+	return renderSystemSections(GenerateSystemSections(params))
 }
 
 // SystemPromptParams holds all inputs for system prompt generation.
@@ -299,40 +276,6 @@ func splitHeadTail(maxBytes int) (int, int) {
 		return maxBytes, 0
 	}
 	return headBytes, tailBytes
-}
-
-func buildMainAgentSections(platformIdentitiesSection string, skillsSection, fileSections string) string {
-	identitiesSection := render(includes["_identities"], map[string]string{
-		"platformIdentitiesSection": platformIdentitiesSection,
-	})
-	sections := []string{
-		includes["_memory"],
-		identitiesSection,
-		skillsSection,
-		fileSections,
-	}
-	return joinPromptSections(sections...)
-}
-
-func buildSubagentSections(platformIdentitiesSection string) string {
-	return strings.TrimSpace(render(includes["_identities"], map[string]string{
-		"platformIdentitiesSection": platformIdentitiesSection,
-	}))
-}
-
-func joinPromptSections(sections ...string) string {
-	var sb strings.Builder
-	for _, section := range sections {
-		section = strings.TrimSpace(section)
-		if section == "" {
-			continue
-		}
-		if sb.Len() > 0 {
-			sb.WriteString("\n\n")
-		}
-		sb.WriteString(section)
-	}
-	return sb.String()
 }
 
 func formatSystemFile(file SystemFile) string {

--- a/internal/agent/runtime/native/prompt_sections.go
+++ b/internal/agent/runtime/native/prompt_sections.go
@@ -1,0 +1,239 @@
+package native
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
+)
+
+// SystemSection is one typed, priority-ordered piece of the system prompt.
+type SystemSection struct {
+	ID       string
+	Kind     contextfrag.Kind
+	Priority int
+	Text     string
+}
+
+const (
+	sectionIDIntro                 = "system.prompt.intro"
+	sectionIDBotIdentity           = "system.bot_identity"
+	sectionIDBody                  = "system.prompt.body"
+	sectionIDTail                  = "system.prompt.tail"
+	sectionIDPlatformIdentity      = "system.platform_identity"
+	sectionIDSkills                = "system.skills"
+	sectionIDWorkspaceInstructions = "system.workspace_instructions"
+	sectionIDFallback              = "system.prompt.fallback"
+)
+
+const (
+	priorityIntro                 = 10
+	priorityBotIdentity           = 20
+	priorityBody                  = 30
+	priorityTail                  = 50
+	priorityPlatformIdentity      = 60
+	prioritySkills                = 65
+	priorityWorkspaceInstructions = 70
+)
+
+const (
+	botInfoPlaceholder = "{{botInfoSection}}"
+	workspaceHeading   = "## Workspace instruction files"
+)
+
+// GenerateSystemSections builds the typed system prompt sections that
+// renderSystemSections joins into the same string GenerateSystemPrompt used
+// to build directly. Two sections (intro, bot identity) sit inside a single
+// template's own placeholder gaps: they are always returned, even with empty
+// Text, so the uniform join below reproduces that template's literal
+// spacing. Sections folding in dynamic, possibly-absent content (platform
+// identity, skills, workspace files) are omitted entirely when empty.
+func GenerateSystemSections(params SystemPromptParams) []SystemSection {
+	home := "/data"
+	timezone := strings.TrimSpace(params.Timezone)
+	if timezone == "" {
+		timezone = "UTC"
+	}
+
+	intro, body, tailBoilerplate, err := splitSystemCommonTmpl(systemCommonTmpl)
+	if err != nil {
+		return degradedSystemSections(params, home, timezone, err)
+	}
+	isSubagent := params.SessionType == sessionmode.Subagent
+
+	tail, err := buildSystemPromptTail(tailBoilerplate, params.SessionType, isSubagent)
+	if err != nil {
+		return degradedSystemSections(params, home, timezone, err)
+	}
+
+	sections := []SystemSection{
+		{
+			ID: sectionIDIntro, Kind: contextfrag.KindSystemPrompt, Priority: priorityIntro,
+			Text: render(intro, map[string]string{"home": home, "timezone": timezone}),
+		},
+		{
+			ID: sectionIDBotIdentity, Kind: contextfrag.KindBotIdentity, Priority: priorityBotIdentity,
+			Text: buildBotInfoSection(params.Bot),
+		},
+		{ID: sectionIDBody, Kind: contextfrag.KindSystemPrompt, Priority: priorityBody, Text: body},
+		{ID: sectionIDTail, Kind: contextfrag.KindSystemPrompt, Priority: priorityTail, Text: tail},
+	}
+
+	if text := strings.TrimSpace(params.PlatformIdentitiesSection); text != "" {
+		sections = append(sections, SystemSection{
+			ID: sectionIDPlatformIdentity, Kind: contextfrag.KindPlatformIdentity, Priority: priorityPlatformIdentity, Text: text,
+		})
+	}
+
+	if isSubagent {
+		return sections
+	}
+
+	if text := strings.TrimSpace(buildSkillsSection(params.Skills)); text != "" {
+		sections = append(sections, SystemSection{
+			ID: sectionIDSkills, Kind: contextfrag.KindSkillsCatalog, Priority: prioritySkills, Text: text,
+		})
+	}
+	if text := strings.TrimSpace(buildFileSections(params.Files, params.MaxFilesBytes)); text != "" {
+		sections = append(sections, SystemSection{
+			ID: sectionIDWorkspaceInstructions, Kind: contextfrag.KindWorkspaceInstruction, Priority: priorityWorkspaceInstructions, Text: text,
+		})
+	}
+
+	return sections
+}
+
+// degradedSystemSections is the panic-free fallback for when the embedded
+// prompt templates are missing an anchor GenerateSystemSections needs to
+// split them into typed sections. It logs the failure and returns the
+// complete, unsplit template text as a single KindSystemPrompt section
+// instead of crashing Agent.Stream's un-recovered goroutine.
+//
+// It still runs the whole system_common+mode template through the same
+// render() substitution the healthy path applies (per section), so a
+// missing anchor degrades to an unsplit prompt instead of one that leaks a
+// literal {{placeholder}} or drops the bot identity.
+func degradedSystemSections(params SystemPromptParams, home, timezone string, cause error) []SystemSection {
+	slog.Default().Error("agent: system prompt template missing expected anchor; falling back to an unsplit system prompt", slog.Any("error", cause))
+	tmpl := strings.TrimSpace(systemCommonTmpl + "\n\n" + selectModeTemplate(params.SessionType))
+	text := render(tmpl, map[string]string{
+		"home":              home,
+		"timezone":          timezone,
+		"botInfoSection":    buildBotInfoSection(params.Bot),
+		"mainAgentSections": "",
+		"subagentSections":  "",
+	})
+	if params.SessionType != sessionmode.Subagent {
+		text += "\n\n" + strings.TrimSpace(includes["_memory"])
+	}
+	return []SystemSection{{
+		ID:       sectionIDFallback,
+		Kind:     contextfrag.KindSystemPrompt,
+		Priority: priorityBody,
+		Text:     text,
+	}}
+}
+
+// SystemSectionFrags converts typed system prompt sections into context
+// fragments, mirroring contextview.ToolUsageFrag's construction so a caller
+// building ContextSourceFrags directly from GenerateSystemSections produces
+// fragments indistinguishable in shape from the rest of the pipeline.
+func SystemSectionFrags(sections []SystemSection, scope contextfrag.Scope) []contextfrag.ContextFrag {
+	frags := make([]contextfrag.ContextFrag, 0, len(sections))
+	for _, section := range sections {
+		frags = append(frags, contextfrag.TextFrag(contextfrag.TextFragInput{
+			ID:         section.ID,
+			Kind:       section.Kind,
+			Role:       sdk.MessageRoleSystem,
+			Slot:       contextfrag.SlotSystem,
+			Text:       section.Text,
+			Priority:   section.Priority,
+			CacheClass: contextfrag.CacheStable,
+			Trust:      contextfrag.TrustSystem,
+			Scope:      scope,
+			Source:     contextfrag.SourceRunConfig,
+			Collector:  "system_sections",
+			Render:     contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+		}))
+	}
+	return frags
+}
+
+// renderSystemSections sorts sections by Priority ascending and joins them
+// with a blank line between every consecutive pair. Emptiness is already
+// resolved at construction time (which section a piece is, and whether it
+// was appended at all), so the join never special-cases an empty Text.
+func renderSystemSections(sections []SystemSection) string {
+	sorted := slices.Clone(sections)
+	slices.SortFunc(sorted, func(a, b SystemSection) int {
+		return a.Priority - b.Priority
+	})
+	var sb strings.Builder
+	for i, s := range sorted {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(s.Text)
+	}
+	return sb.String()
+}
+
+// splitSystemCommonTmpl cuts the raw system_common.md template at the two
+// anchors that also matter downstream (the bot-identity placeholder and the
+// workspace-instructions heading), so the pieces can become independent
+// sections instead of being reverse-parsed from the rendered output later.
+// It returns an error instead of panicking when either anchor is missing.
+func splitSystemCommonTmpl(tmpl string) (intro, body, tailBoilerplate string, err error) {
+	idxBotInfo := strings.Index(tmpl, botInfoPlaceholder)
+	idxWorkspace := strings.Index(tmpl, workspaceHeading)
+	if idxBotInfo < 0 || idxWorkspace < 0 {
+		return "", "", "", errors.New("agent: system_common.md is missing an expected section anchor")
+	}
+	intro = tmpl[:idxBotInfo]
+	body = strings.TrimSpace(tmpl[idxBotInfo+len(botInfoPlaceholder) : idxWorkspace])
+	tailBoilerplate = tmpl[idxWorkspace:]
+	return intro, body, tailBoilerplate, nil
+}
+
+// buildSystemPromptTail fuses the static workspace-instructions/attachments
+// boilerplate with the mode contract and, for main-agent modes, the memory
+// section — mirroring the "\n\n" joins GenerateSystemPrompt used to produce
+// via raw template concatenation and joinPromptSections.
+func buildSystemPromptTail(tailBoilerplate, sessionType string, isSubagent bool) (string, error) {
+	contract, err := modeContractTmpl(sessionType)
+	if err != nil {
+		return "", err
+	}
+	tail := tailBoilerplate + "\n\n" + contract
+	if isSubagent {
+		return tail, nil
+	}
+	return tail + "\n\n" + strings.TrimSpace(includes["_memory"]), nil
+}
+
+// modeContractTmpl returns the mode-specific contract text with its trailing
+// mainAgentSections/subagentSections placeholder cut off and trimmed.
+func modeContractTmpl(sessionType string) (string, error) {
+	tmpl := selectModeTemplate(sessionType)
+	placeholder := "{{mainAgentSections}}"
+	if sessionType == sessionmode.Subagent {
+		placeholder = "{{subagentSections}}"
+	}
+	return cutModeContractTmpl(tmpl, placeholder)
+}
+
+// cutModeContractTmpl cuts tmpl at placeholder, returning the trimmed prefix.
+// It returns an error instead of panicking when placeholder is not present.
+func cutModeContractTmpl(tmpl, placeholder string) (string, error) {
+	idx := strings.Index(tmpl, placeholder)
+	if idx < 0 {
+		return "", fmt.Errorf("agent: mode template is missing expected placeholder %s", placeholder)
+	}
+	return strings.TrimSpace(tmpl[:idx]), nil
+}

--- a/internal/agent/runtime/native/prompt_sections_test.go
+++ b/internal/agent/runtime/native/prompt_sections_test.go
@@ -1,0 +1,203 @@
+package native
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
+)
+
+func TestGenerateSystemPromptMatchesLegacyAssemblyBytes(t *testing.T) {
+	t.Parallel()
+	full := SystemPromptParams{
+		Timezone: "UTC",
+		Bot:      BotInfo{ID: "bot-1", Name: "research-bot", DisplayName: "Research Bot", Timezone: "Asia/Shanghai"},
+		Skills: []SkillEntry{
+			{Name: "foo-skill", Description: "does foo things"},
+			{Name: "bar-skill", Description: "does bar things"},
+		},
+		Files: []SystemFile{
+			{Filename: "AGENTS.md", Content: "# Agent notes\n\nBe nice."},
+			{Filename: "PROFILES.md", Content: "# People\n\n- Alice"},
+		},
+		PlatformIdentitiesSection: "## Platform Identities\n\n<identity channel=\"telegram\" username=\"@memoh\"/>",
+	}
+	for _, mode := range []string{sessionmode.Chat, sessionmode.Discuss, sessionmode.Heartbeat, sessionmode.Schedule, sessionmode.Subagent} {
+		mode := mode
+		t.Run(mode+"_full", func(t *testing.T) {
+			t.Parallel()
+			params := full
+			params.SessionType = mode
+			assertSystemPromptLegacyEquivalent(t, params)
+		})
+		t.Run(mode+"_empty", func(t *testing.T) {
+			t.Parallel()
+			assertSystemPromptLegacyEquivalent(t, SystemPromptParams{SessionType: mode, Timezone: "UTC"})
+		})
+	}
+	mixed := []SystemPromptParams{
+		{SessionType: sessionmode.Chat, Timezone: "UTC", Bot: full.Bot, Files: full.Files},
+		{SessionType: sessionmode.Chat, Timezone: "UTC", Skills: full.Skills, PlatformIdentitiesSection: full.PlatformIdentitiesSection},
+	}
+	for _, params := range mixed {
+		assertSystemPromptLegacyEquivalent(t, params)
+	}
+}
+
+func assertSystemPromptLegacyEquivalent(t *testing.T, params SystemPromptParams) {
+	t.Helper()
+	want := legacyGenerateSystemPrompt(params)
+	if got := GenerateSystemPrompt(params); got != want {
+		t.Fatalf("GenerateSystemPrompt mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+	if got := renderSystemSections(GenerateSystemSections(params)); got != want {
+		t.Fatalf("section render mismatch\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func legacyGenerateSystemPrompt(params SystemPromptParams) string {
+	home := "/data"
+	timezone := strings.TrimSpace(params.Timezone)
+	if timezone == "" {
+		timezone = "UTC"
+	}
+	skills := buildSkillsSection(params.Skills)
+	files := buildFileSections(params.Files, params.MaxFilesBytes)
+	platform := strings.TrimSpace(params.PlatformIdentitiesSection)
+	tmpl := strings.TrimSpace(systemCommonTmpl + "\n\n" + selectModeTemplate(params.SessionType))
+	return render(tmpl, map[string]string{
+		"home":                      home,
+		"timezone":                  timezone,
+		"botInfoSection":            buildBotInfoSection(params.Bot),
+		"skillsSection":             skills,
+		"platformIdentitiesSection": platform,
+		"mainAgentSections":         legacyMainAgentSections(platform, skills, files),
+		"subagentSections":          legacySubagentSections(platform),
+		"fileSections":              files,
+	})
+}
+
+func legacyMainAgentSections(platform, skills, files string) string {
+	identities := render(includes["_identities"], map[string]string{"platformIdentitiesSection": platform})
+	return legacyJoinPromptSections(includes["_memory"], identities, skills, files)
+}
+
+func legacySubagentSections(platform string) string {
+	return strings.TrimSpace(render(includes["_identities"], map[string]string{"platformIdentitiesSection": platform}))
+}
+
+func legacyJoinPromptSections(sections ...string) string {
+	var kept []string
+	for _, section := range sections {
+		if section = strings.TrimSpace(section); section != "" {
+			kept = append(kept, section)
+		}
+	}
+	return strings.Join(kept, "\n\n")
+}
+
+func TestGenerateSystemSectionsShape(t *testing.T) {
+	t.Parallel()
+	sections := GenerateSystemSections(SystemPromptParams{
+		SessionType:               sessionmode.Chat,
+		Timezone:                  "UTC",
+		Bot:                       BotInfo{ID: "bot-1", Name: "research-bot"},
+		Skills:                    []SkillEntry{{Name: "foo", Description: "does foo"}},
+		Files:                     []SystemFile{{Filename: "AGENTS.md", Content: "Be nice."}},
+		PlatformIdentitiesSection: "platform identity",
+	})
+	want := []struct {
+		id       string
+		kind     contextfrag.Kind
+		priority int
+	}{
+		{sectionIDIntro, contextfrag.KindSystemPrompt, priorityIntro},
+		{sectionIDBotIdentity, contextfrag.KindBotIdentity, priorityBotIdentity},
+		{sectionIDBody, contextfrag.KindSystemPrompt, priorityBody},
+		{sectionIDTail, contextfrag.KindSystemPrompt, priorityTail},
+		{sectionIDPlatformIdentity, contextfrag.KindPlatformIdentity, priorityPlatformIdentity},
+		{sectionIDSkills, contextfrag.KindSkillsCatalog, prioritySkills},
+		{sectionIDWorkspaceInstructions, contextfrag.KindWorkspaceInstruction, priorityWorkspaceInstructions},
+	}
+	if len(sections) != len(want) {
+		t.Fatalf("sections = %#v", sections)
+	}
+	for i := range want {
+		if sections[i].ID != want[i].id || sections[i].Kind != want[i].kind || sections[i].Priority != want[i].priority {
+			t.Fatalf("section[%d] = %#v, want %#v", i, sections[i], want[i])
+		}
+	}
+}
+
+func TestGenerateSystemSectionsKeepsOnlyStructuralEmptySection(t *testing.T) {
+	t.Parallel()
+	sections := GenerateSystemSections(SystemPromptParams{SessionType: sessionmode.Chat, Timezone: "UTC"})
+	foundBot := false
+	for _, section := range sections {
+		switch section.Kind {
+		case contextfrag.KindBotIdentity:
+			foundBot = true
+			if section.Text != "" {
+				t.Fatalf("bot identity text = %q", section.Text)
+			}
+		case contextfrag.KindPlatformIdentity, contextfrag.KindSkillsCatalog, contextfrag.KindWorkspaceInstruction:
+			t.Fatalf("empty optional section survived: %#v", section)
+		}
+	}
+	if !foundBot {
+		t.Fatal("missing structural bot identity section")
+	}
+}
+
+func TestSystemSectionFragsPreserveTypedShape(t *testing.T) {
+	t.Parallel()
+	sections := []SystemSection{{ID: "a", Kind: contextfrag.KindSystemPrompt, Priority: 10, Text: " first "}, {ID: "b", Kind: contextfrag.KindBotIdentity, Priority: 20}}
+	frags := SystemSectionFrags(sections, contextfrag.Scope{BotID: "bot-1"})
+	if len(frags) != 2 {
+		t.Fatalf("frags = %#v", frags)
+	}
+	for i, frag := range frags {
+		if frag.ID != sections[i].ID || frag.Kind != sections[i].Kind || frag.Priority != sections[i].Priority ||
+			frag.Role != sdk.MessageRoleSystem || frag.Slot != contextfrag.SlotSystem || frag.Scope.BotID != "bot-1" ||
+			frag.Parts[0].Text != strings.TrimSpace(sections[i].Text) {
+			t.Fatalf("frag[%d] = %#v", i, frag)
+		}
+	}
+}
+
+func TestGenerateSystemSectionsDegradesWhenAnchorsAreMissing(t *testing.T) {
+	t.Run("system template", func(t *testing.T) {
+		original := systemCommonTmpl
+		systemCommonTmpl = strings.Replace(original, workspaceHeading, "## renamed", 1)
+		t.Cleanup(func() { systemCommonTmpl = original })
+		sections := GenerateSystemSections(SystemPromptParams{SessionType: sessionmode.Chat, Bot: BotInfo{Name: "research-bot"}})
+		assertDegradedSection(t, sections)
+	})
+	t.Run("mode template", func(t *testing.T) {
+		original := modeChatTmpl
+		modeChatTmpl = strings.Replace(original, "{{mainAgentSections}}", "", 1)
+		t.Cleanup(func() { modeChatTmpl = original })
+		sections := GenerateSystemSections(SystemPromptParams{SessionType: sessionmode.Chat, Bot: BotInfo{Name: "research-bot"}})
+		assertDegradedSection(t, sections)
+	})
+}
+
+func assertDegradedSection(t *testing.T, sections []SystemSection) {
+	t.Helper()
+	if len(sections) != 1 || sections[0].Kind != contextfrag.KindSystemPrompt || strings.Contains(sections[0].Text, "{{") || !strings.Contains(sections[0].Text, "research-bot") {
+		t.Fatalf("sections = %#v", sections)
+	}
+}
+
+func TestSectionSplitHelpersRejectMissingAnchors(t *testing.T) {
+	t.Parallel()
+	if _, _, _, err := splitSystemCommonTmpl("no anchors"); err == nil {
+		t.Fatal("expected splitSystemCommonTmpl error")
+	}
+	if _, err := cutModeContractTmpl("no placeholder", "{{missing}}"); err == nil {
+		t.Fatal("expected cutModeContractTmpl error")
+	}
+}

--- a/internal/agent/runtime/native/spawn_adapter.go
+++ b/internal/agent/runtime/native/spawn_adapter.go
@@ -81,11 +81,14 @@ func (s *SpawnAdapter) Generate(ctx context.Context, cfg tools.SpawnRunConfig) (
 
 func runConfigFromSpawnRunConfig(cfg tools.SpawnRunConfig) RunConfig {
 	messages := cfg.Messages
+	var currentUserMessageIndex *int
 	if cfg.Query != "" {
 		messages = append(messages, sdk.Message{
 			Role:    sdk.MessageRoleUser,
 			Content: []sdk.MessagePart{sdk.TextPart{Text: cfg.Query}},
 		})
+		index := len(messages) - 1
+		currentUserMessageIndex = &index
 	}
 
 	identity := SessionContext{
@@ -114,25 +117,26 @@ func runConfigFromSpawnRunConfig(cfg tools.SpawnRunConfig) RunConfig {
 			Path:        skill.Path,
 		})
 	}
-	return RunConfig{
-		Model:                    cfg.Model,
-		CurrentModelUUID:         cfg.ModelUUID,
-		CurrentModelID:           cfg.ModelID,
-		CurrentModelProvider:     cfg.ModelProvider,
-		System:                   cfg.System,
-		Query:                    cfg.Query,
-		ContextQueryMaterialized: cfg.Query != "",
-		SessionType:              cfg.SessionType,
-		Messages:                 messages,
-		ReasoningEffort:          cfg.ReasoningEffort,
-		PromptCacheTTL:           cfg.PromptCacheTTL,
-		ChatCompletionsCompat:    cfg.ChatCompletionsCompat,
-		SupportsImageInput:       cfg.SupportsImageInput,
-		SupportsFileInput:        cfg.SupportsFileInput,
-		SupportsToolCall:         cfg.SupportsToolCall,
-		Identity:                 identity,
-		Skills:                   skills,
-		BackgroundManager:        cfg.BackgroundManager,
+	rc := RunConfig{
+		Model:                          cfg.Model,
+		CurrentModelUUID:               cfg.ModelUUID,
+		CurrentModelID:                 cfg.ModelID,
+		CurrentModelProvider:           cfg.ModelProvider,
+		System:                         cfg.System,
+		Query:                          cfg.Query,
+		ContextQueryMaterialized:       cfg.Query != "",
+		ContextCurrentUserMessageIndex: currentUserMessageIndex,
+		SessionType:                    cfg.SessionType,
+		Messages:                       messages,
+		ReasoningEffort:                cfg.ReasoningEffort,
+		PromptCacheTTL:                 cfg.PromptCacheTTL,
+		ChatCompletionsCompat:          cfg.ChatCompletionsCompat,
+		SupportsImageInput:             cfg.SupportsImageInput,
+		SupportsFileInput:              cfg.SupportsFileInput,
+		SupportsToolCall:               cfg.SupportsToolCall,
+		Identity:                       identity,
+		Skills:                         skills,
+		BackgroundManager:              cfg.BackgroundManager,
 		ContextScope: contextfrag.Scope{
 			BotID:             identity.BotID,
 			ChatID:            identity.ChatID,
@@ -144,6 +148,30 @@ func runConfigFromSpawnRunConfig(cfg tools.SpawnRunConfig) RunConfig {
 			Enabled: cfg.LoopDetection.Enabled,
 		},
 	}
+	rc.ContextSourceFrags = SpawnContextSourceFrags(rc)
+	return rc
+}
+
+// SpawnContextSourceFrags uses typed system sections only when they reproduce
+// the caller-supplied System exactly. Custom spawn prompts deliberately stay
+// on the legacy collector fallback so PR1 cannot replace or normalize them.
+func SpawnContextSourceFrags(rc RunConfig) []contextfrag.ContextFrag {
+	sections := GenerateSystemSections(SystemPromptParams{SessionType: rc.SessionType})
+	if renderSystemSections(sections) != rc.System {
+		return nil
+	}
+	query := rc.Query
+	if rc.ContextQueryMaterialized {
+		query = ""
+	}
+	messages := contextfrag.CompileFrags(contextfrag.CompileInput{
+		Scope:                   rc.ContextScope,
+		Messages:                rc.Messages,
+		CurrentUserMessageIndex: rc.ContextCurrentUserMessageIndex,
+		Query:                   query,
+	})
+	frags := SystemSectionFrags(sections, rc.ContextScope)
+	return append(frags, messages...)
 }
 
 // GenerateWithWatchdog runs the agent in streaming mode, touching the

--- a/internal/agent/runtime/native/spawn_adapter_test.go
+++ b/internal/agent/runtime/native/spawn_adapter_test.go
@@ -1,0 +1,47 @@
+package native
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
+	tools "github.com/memohai/memoh/internal/agent/tool"
+)
+
+func TestSpawnRunConfigClassifiesRawQueryAsCurrentUser(t *testing.T) {
+	t.Parallel()
+	const query = "  keep raw query bytes  "
+	rc := runConfigFromSpawnRunConfig(tools.SpawnRunConfig{
+		System: SpawnSystemPrompt(sessionmode.Subagent), Query: query, SessionType: sessionmode.Subagent,
+		Messages: []sdk.Message{sdk.UserMessage("history")},
+	})
+
+	if rc.ContextCurrentUserMessageIndex == nil || *rc.ContextCurrentUserMessageIndex != 1 {
+		t.Fatalf("current user index = %#v, want 1", rc.ContextCurrentUserMessageIndex)
+	}
+	if text, _ := rc.Messages[1].Content[0].(sdk.TextPart); text.Text != query {
+		t.Fatalf("spawn query = %q, want byte-exact %q", text.Text, query)
+	}
+	current := 0
+	for _, frag := range rc.ContextSourceFrags {
+		if frag.Slot == contextfrag.SlotCurrentUser {
+			current++
+			if frag.Kind != contextfrag.KindCurrentUserMessage {
+				t.Fatalf("current fragment kind = %q", frag.Kind)
+			}
+		}
+	}
+	if current != 1 {
+		t.Fatalf("current fragment count = %d, want 1", current)
+	}
+}
+
+func TestSpawnContextSourceFragsDefersCustomSystemToFallback(t *testing.T) {
+	t.Parallel()
+	rc := RunConfig{System: "  custom spawn system\n", SessionType: sessionmode.Subagent}
+	if got := SpawnContextSourceFrags(rc); got != nil {
+		t.Fatalf("custom system source fragments = %#v, want legacy fallback", got)
+	}
+}

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -80,34 +80,40 @@ type InjectMessage struct {
 
 // RunConfig holds everything needed for a single agent invocation.
 type RunConfig struct {
-	Model                       *sdk.Model
-	CurrentModelUUID            string
-	CurrentModelID              string
-	CurrentModelProvider        string
-	ForkContext                 *tools.MessageSnapshot
-	ForkContextSourceMessageIDs []string
-	ReasoningEffort             string
-	ReasoningActive             bool
-	ReasoningDisabled           bool
-	ReasoningAdaptive           bool
-	ReasoningOffEffort          string
-	ChatCompletionsCompat       string
-	Messages                    []sdk.Message
-	Query                       string
-	System                      string
-	ContextFrags                []contextfrag.ContextFrag
-	ContextManifest             contextfrag.Manifest
-	ContextScope                contextfrag.Scope
-	ContextQueryMaterialized    bool
-	ContextToolUsage            string
-	ContextDynamicMutators      []contextfrag.DynamicMutator
-	SessionType                 string
-	LiveToolStream              bool
-	CanRequestUserInput         bool
-	SupportsImageInput          bool
-	SupportsFileInput           bool
-	SupportsToolCall            bool
-	InlineImages                []sdk.ImagePart
+	Model                          *sdk.Model
+	CurrentModelUUID               string
+	CurrentModelID                 string
+	CurrentModelProvider           string
+	ForkContext                    *tools.MessageSnapshot
+	ForkContextSourceMessageIDs    []string
+	ReasoningEffort                string
+	ReasoningActive                bool
+	ReasoningDisabled              bool
+	ReasoningAdaptive              bool
+	ReasoningOffEffort             string
+	ChatCompletionsCompat          string
+	Messages                       []sdk.Message
+	Query                          string
+	System                         string
+	ContextFrags                   []contextfrag.ContextFrag
+	ContextSourceFrags             []contextfrag.ContextFrag
+	ContextManifest                contextfrag.Manifest
+	ContextScope                   contextfrag.Scope
+	ContextCurrentUserMessageIndex *int
+	ContextQueryMaterialized       bool
+	ContextToolUsage               string
+	ContextToolDefs                []contextfrag.ToolDefAccounting
+	ContextToolExchangePolicy      *contextfrag.ToolExchangePolicy
+	ContextCachePlan               contextfrag.CachePlan
+	ContextMutations               *contextfrag.MutationLedger
+	ContextDynamicMutators         []contextfrag.DynamicMutator
+	SessionType                    string
+	LiveToolStream                 bool
+	CanRequestUserInput            bool
+	SupportsImageInput             bool
+	SupportsFileInput              bool
+	SupportsToolCall               bool
+	InlineImages                   []sdk.ImagePart
 	// InlineAttachments carries non-image native attachment parts (documents
 	// as sdk.FilePart, small text files as wrapped sdk.TextPart) appended to
 	// the current user message. Images stay in InlineImages, which also feeds

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -100,6 +100,7 @@ type RunConfig struct {
 	ContextManifest                contextfrag.Manifest
 	ContextScope                   contextfrag.Scope
 	ContextCurrentUserMessageIndex *int
+	ContextMemoryMessageIndex      *int
 	ContextQueryMaterialized       bool
 	ContextToolUsage               string
 	ContextToolDefs                []contextfrag.ToolDefAccounting

--- a/internal/agent/runtime/native/usage_injection_test.go
+++ b/internal/agent/runtime/native/usage_injection_test.go
@@ -50,6 +50,14 @@ func (plainTestProvider) Tools(_ context.Context, _ tools.SessionContext) ([]sdk
 	return []sdk.Tool{{Name: tools.ToolRead().String(), Description: "plain"}}, nil
 }
 
+type labeledTestProvider struct{ label string }
+
+func (p labeledTestProvider) ProviderLabel() string { return p.label }
+
+func (labeledTestProvider) Tools(_ context.Context, _ tools.SessionContext) ([]sdk.Tool, error) {
+	return []sdk.Tool{{Name: "remote_tool", Description: "remote"}}, nil
+}
+
 func newTestAgent(providers ...tools.ToolProvider) *Agent {
 	a := New(Deps{})
 	a.SetToolProviders(providers)
@@ -276,12 +284,15 @@ func TestAssembleToolsInjectsUsageWhenProviderEmitsTools(t *testing.T) {
 	t.Parallel()
 	a := newTestAgent(&usageTestProvider{emitTool: true, usage: usageMarker})
 
-	gotTools, usage, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, toolDefs, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}
 	if len(gotTools) != 1 {
 		t.Fatalf("expected 1 tool, got %d", len(gotTools))
+	}
+	if len(toolDefs) != 1 || toolDefs[0].Provider != "native" || toolDefs[0].Name != "fake_tool" {
+		t.Fatalf("tool definitions = %#v, want native fake_tool", toolDefs)
 	}
 	if !strings.Contains(usage, usageMarker) {
 		t.Fatalf("expected usage to contain %q, got %q", usageMarker, usage)
@@ -295,7 +306,7 @@ func TestAssembleToolsOmitsUsageWhenProviderEmitsNoTools(t *testing.T) {
 	t.Parallel()
 	a := newTestAgent(&usageTestProvider{emitTool: false, usage: usageMarker})
 
-	gotTools, usage, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}
@@ -307,11 +318,24 @@ func TestAssembleToolsOmitsUsageWhenProviderEmitsNoTools(t *testing.T) {
 	}
 }
 
+func TestAssembleToolsUsesProviderAccountingLabel(t *testing.T) {
+	t.Parallel()
+	a := newTestAgent(labeledTestProvider{label: "mcp"})
+
+	_, _, toolDefs, err := a.assembleTools(context.Background(), RunConfig{}, nil, false)
+	if err != nil {
+		t.Fatalf("assembleTools error: %v", err)
+	}
+	if len(toolDefs) != 1 || toolDefs[0].Provider != "mcp" || toolDefs[0].Name != "remote_tool" {
+		t.Fatalf("tool definitions = %#v, want mcp remote_tool", toolDefs)
+	}
+}
+
 func TestAssembleToolsDoesNotExposeAskUserWithoutCapability(t *testing.T) {
 	t.Parallel()
 	a := newTestAgent(&tools.AskUserProvider{})
 
-	gotTools, usage, err := a.assembleTools(context.Background(), RunConfig{
+	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{
 		SessionType: sessionmode.Chat,
 	}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
@@ -324,7 +348,7 @@ func TestAssembleToolsDoesNotExposeAskUserWithoutCapability(t *testing.T) {
 		t.Fatalf("expected no ask_user usage without user input capability, got %q", usage)
 	}
 
-	gotTools, usage, err = a.assembleTools(context.Background(), RunConfig{
+	gotTools, usage, _, err = a.assembleTools(context.Background(), RunConfig{
 		SessionType:         sessionmode.Chat,
 		CanRequestUserInput: true,
 	}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
@@ -343,7 +367,7 @@ func TestAssembleToolsIgnoresProvidersWithoutUsage(t *testing.T) {
 	t.Parallel()
 	a := newTestAgent(plainTestProvider{})
 
-	gotTools, usage, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}
@@ -371,7 +395,7 @@ func TestAssembleToolsGatesUsagePerProvider(t *testing.T) {
 		plainTestProvider{},
 	)
 
-	gotTools, usage, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}
@@ -397,7 +421,7 @@ func TestAssembleToolsKeepsFirstDuplicateToolAndItsUsage(t *testing.T) {
 		&usageTestProvider{emitTool: true, usage: secondUsage},
 	)
 
-	gotTools, usage, err := a.assembleTools(
+	gotTools, usage, toolDefs, err := a.assembleTools(
 		context.Background(),
 		RunConfig{},
 		tools.StreamEmitter(func(tools.ToolStreamEvent) {}),
@@ -408,6 +432,9 @@ func TestAssembleToolsKeepsFirstDuplicateToolAndItsUsage(t *testing.T) {
 	}
 	if len(gotTools) != 1 || gotTools[0].Name != "fake_tool" {
 		t.Fatalf("expected only the first duplicate tool, got %#v", gotTools)
+	}
+	if len(toolDefs) != 1 || toolDefs[0].Provider != "native" || toolDefs[0].Name != "fake_tool" {
+		t.Fatalf("tool definitions = %#v, want only the retained native fake_tool", toolDefs)
 	}
 	if !strings.Contains(usage, firstUsage) {
 		t.Fatalf("expected usage from the retained provider, got %q", usage)
@@ -433,7 +460,7 @@ func TestAssembleToolsPassesCompleteAvailableToolSetToUsage(t *testing.T) {
 		plainTestProvider{},
 	)
 
-	gotTools, usage, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}

--- a/internal/agent/runtime/native/usage_injection_test.go
+++ b/internal/agent/runtime/native/usage_injection_test.go
@@ -320,14 +320,18 @@ func TestAssembleToolsOmitsUsageWhenProviderEmitsNoTools(t *testing.T) {
 
 func TestAssembleToolsUsesProviderAccountingLabel(t *testing.T) {
 	t.Parallel()
-	a := newTestAgent(labeledTestProvider{label: "mcp"})
-
-	_, _, toolDefs, err := a.assembleTools(context.Background(), RunConfig{}, nil, false)
-	if err != nil {
-		t.Fatalf("assembleTools error: %v", err)
-	}
-	if len(toolDefs) != 1 || toolDefs[0].Provider != "mcp" || toolDefs[0].Name != "remote_tool" {
-		t.Fatalf("tool definitions = %#v, want mcp remote_tool", toolDefs)
+	for _, tc := range []struct{ label, want string }{
+		{label: " mcp ", want: "mcp"},
+		{label: " ", want: "native"},
+	} {
+		a := newTestAgent(labeledTestProvider{label: tc.label})
+		_, _, toolDefs, err := a.assembleTools(context.Background(), RunConfig{}, nil, false)
+		if err != nil {
+			t.Fatalf("assembleTools error: %v", err)
+		}
+		if len(toolDefs) != 1 || toolDefs[0].Provider != tc.want || toolDefs[0].Name != "remote_tool" {
+			t.Fatalf("tool definitions = %#v, want %s remote_tool", toolDefs, tc.want)
+		}
 	}
 }
 

--- a/internal/agent/tool/federation.go
+++ b/internal/agent/tool/federation.go
@@ -29,6 +29,8 @@ func NewFederationProvider(log *slog.Logger, source mcp.ToolSource) *FederationP
 	}
 }
 
+func (*FederationProvider) ProviderLabel() string { return "mcp" }
+
 func (f *FederationProvider) Tools(ctx context.Context, session SessionContext) ([]sdk.Tool, error) {
 	if f.source == nil {
 		return nil, nil

--- a/internal/agent/tool/types.go
+++ b/internal/agent/tool/types.go
@@ -392,6 +392,12 @@ func (s SessionContext) FormatTime(t time.Time) string {
 	return t.Format(time.RFC3339)
 }
 
+// ProviderLabeler optionally names the accounting bucket a provider's tool
+// definitions belong to. Providers without it count as native tools.
+type ProviderLabeler interface {
+	ProviderLabel() string
+}
+
 // ToolProvider supplies a set of tools for the agent.
 // Tools() is called per-request; implementations may return different
 // tool sets based on session context (e.g. subagent restrictions, bot settings).

--- a/internal/contextview/builder.go
+++ b/internal/contextview/builder.go
@@ -1,0 +1,193 @@
+package contextview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+type Builder struct {
+	collectors CollectorRegistry
+	selector   Selector
+	placer     Placer
+	renderers  RendererRegistry
+}
+
+func NewBuilder(collectors CollectorRegistry, selector Selector, placer Placer, renderers RendererRegistry) *Builder {
+	return &Builder{
+		collectors: collectors,
+		selector:   selector,
+		placer:     placer,
+		renderers:  renderers,
+	}
+}
+
+func (b *Builder) Build(ctx context.Context, input BuildInput) (*ContextView, error) {
+	if b.collectors == nil {
+		return nil, errors.New("collector registry is required")
+	}
+	if b.selector == nil {
+		return nil, errors.New("selector is required")
+	}
+	if b.placer == nil {
+		return nil, errors.New("placer is required")
+	}
+
+	trace := BuildTrace{
+		CollectDurations: make(map[string]int64, len(input.Sources)),
+		RenderSummaries:  make(map[contextfrag.RenderTarget]RenderSummary, len(input.Targets)),
+	}
+	sourceFrags := make([]contextfrag.ContextFrag, 0)
+	for _, spec := range input.Sources {
+		collector, ok := b.collectors.Get(spec.Name)
+		if !ok {
+			return nil, fmt.Errorf("unknown collector %q", spec.Name)
+		}
+
+		start := time.Now()
+		frags, err := collector.Collect(ctx, CollectRequest{
+			Scope:  input.Scope,
+			Intent: input.Intent,
+			Config: spec.Config,
+		})
+		trace.CollectDurations[spec.Name] = time.Since(start).Microseconds()
+		if err != nil {
+			return nil, fmt.Errorf("collector %q: %w", spec.Name, err)
+		}
+		sourceFrags = append(sourceFrags, frags...)
+	}
+	sourceFrags = contextfrag.NormalizeContextRefs(sourceFrags)
+
+	profile := b.selector.ProfileFor(input.Intent)
+	result := b.selector.Select(sourceFrags, profile, input.Budget)
+	trace.SelectionSummary = result.Summary
+
+	placement := b.placer.Place(result.Selected, input.Intent)
+	trace.PlacementSummary = summarizePlacement(placement)
+
+	manifest := contextfrag.BuildManifest(result.Selected)
+	manifest.View = input.Intent.ManifestView()
+	manifest.DynamicMutators = normalizeDynamicMutators(input.DynamicMutators)
+	manifest.Selection = selectionTrace(result.Summary)
+	manifest.EditTrace = append(manifest.EditTrace, selectionEditTrace(result.Dropped)...)
+	manifest.EditTrace = append(manifest.EditTrace, result.Edited...)
+	manifest.ValidationWarnings = append(manifest.ValidationWarnings, result.Warnings...)
+	trace.Warnings = append(trace.Warnings, manifest.ValidationWarnings...)
+
+	view := &ContextView{
+		Intent:      input.Intent,
+		SourceFrags: sourceFrags,
+		Selected:    result.Selected,
+		Placement:   placement,
+		Manifest:    manifest,
+		Rendered:    make(map[contextfrag.RenderTarget]RenderedPayload, len(input.Targets)),
+		Trace:       trace,
+	}
+
+	if input.Options.DryRun {
+		return view, nil
+	}
+
+	for _, target := range input.Targets {
+		if b.renderers == nil {
+			return nil, fmt.Errorf("unknown renderer %q", target)
+		}
+		renderer, ok := b.renderers.Get(target)
+		if !ok {
+			return nil, fmt.Errorf("unknown renderer %q", target)
+		}
+		payload, err := renderer.Render(ctx, RenderInput{
+			Intent:    input.Intent,
+			Selected:  result.Selected,
+			Placement: placement,
+			Manifest:  &manifest,
+			Scope:     input.Scope,
+			Target:    target,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("renderer %q: %w", target, err)
+		}
+		if payload.Target == "" {
+			payload.Target = target
+		}
+		view.Rendered[target] = payload
+		view.Trace.RenderSummaries[target] = RenderSummary{
+			Target:      payload.Target,
+			ContentHash: payload.ContentHash,
+			ItemCount:   len(placement.Items),
+		}
+	}
+
+	return view, nil
+}
+
+func summarizePlacement(placement PlacementPlan) PlacementSummary {
+	stable := placement.FirstVolatileIndex
+	if stable < 0 || stable > len(placement.Items) {
+		stable = len(placement.Items)
+	}
+	return PlacementSummary{
+		StablePrefixFrags: stable,
+		DynamicFrags:      len(placement.Items) - stable,
+	}
+}
+
+func normalizeDynamicMutators(mutators []contextfrag.DynamicMutator) []contextfrag.DynamicMutator {
+	if len(mutators) == 0 {
+		return nil
+	}
+	out := make([]contextfrag.DynamicMutator, 0, len(mutators))
+	seen := make(map[contextfrag.DynamicMutator]bool, len(mutators))
+	for _, mutator := range mutators {
+		if mutator == "" || seen[mutator] {
+			continue
+		}
+		seen[mutator] = true
+		out = append(out, mutator)
+	}
+	return out
+}
+
+func selectionTrace(summary SelectionSummary) *contextfrag.SelectionTrace {
+	if summary.TotalCollected == 0 && summary.TotalSelected == 0 && summary.TotalDropped == 0 && len(summary.DropReasons) == 0 {
+		return nil
+	}
+	trace := &contextfrag.SelectionTrace{
+		Selected: summary.TotalSelected,
+		Dropped:  summary.TotalDropped,
+	}
+	if len(summary.DropReasons) > 0 {
+		trace.DropReasons = make(map[string]int, len(summary.DropReasons))
+		for _, record := range summary.DropReasons {
+			reason := record.Reason
+			if reason == "" {
+				reason = "unknown"
+			}
+			trace.DropReasons[reason]++
+		}
+	}
+	return trace
+}
+
+func selectionEditTrace(dropped []contextfrag.ContextFrag) []contextfrag.ContextEditTrace {
+	if len(dropped) == 0 {
+		return nil
+	}
+	out := make([]contextfrag.ContextEditTrace, 0, len(dropped))
+	for _, frag := range dropped {
+		ref := frag.Ref
+		if err := contextfrag.ValidateContextRef(ref); err != nil {
+			ref = contextfrag.WithContextRef(frag, ref).Ref
+		}
+		out = append(out, contextfrag.ContextEditTrace{
+			EditID: "selection.drop." + frag.ID,
+			Op:     contextfrag.EditRemove,
+			Slot:   frag.Slot,
+			Refs:   []contextfrag.ContextRef{ref},
+		})
+	}
+	return out
+}

--- a/internal/contextview/builder.go
+++ b/internal/contextview/builder.go
@@ -59,6 +59,11 @@ func (b *Builder) Build(ctx context.Context, input BuildInput) (*ContextView, er
 		}
 		sourceFrags = append(sourceFrags, frags...)
 	}
+	// Provider system fragments render into one leading system field even when
+	// a late collector (for example tool usage) supplied them after message
+	// fragments. Canonicalize that order before selection and placement so the
+	// cache plan describes the same prefix the renderer emits.
+	sourceFrags = sortSystemFragsByPriority(sourceFrags)
 	sourceFrags = contextfrag.NormalizeContextRefs(sourceFrags)
 
 	profile := b.selector.ProfileFor(input.Intent)

--- a/internal/contextview/builder_test.go
+++ b/internal/contextview/builder_test.go
@@ -151,6 +151,40 @@ func TestBuildRecordsDroppedFragmentEditTrace(t *testing.T) {
 	}
 }
 
+func TestBuilderPlacesLateSystemFragmentInRenderedPrefixOrder(t *testing.T) {
+	t.Parallel()
+
+	history := messageFrag("history", sdk.UserMessage("hello"))
+	workspace := textFrag("workspace", contextfrag.SlotSystem, contextfrag.KindWorkspaceInstruction, sdk.MessageRoleSystem, "workspace")
+	workspace.Priority = 50
+	toolUsage := textFrag("tool-usage", contextfrag.SlotSystem, contextfrag.KindToolUsage, sdk.MessageRoleSystem, "tools")
+	toolUsage.Priority = 45
+	registry := NewMapCollectorRegistry(StaticCollector{
+		CollectorName: "late-system",
+		Frags:         []contextfrag.ContextFrag{workspace, history, toolUsage},
+	})
+	builder := NewBuilder(registry, PassthroughSelector{}, StablePrefixPlacer{}, NewMapRendererRegistry(&SDKMessagesRenderer{}))
+
+	view, err := builder.Build(context.Background(), BuildInput{
+		Intent:  contextfrag.IntentRunConfigPreProvider,
+		Sources: []SourceSpec{{Name: "late-system"}},
+		Targets: []contextfrag.RenderTarget{contextfrag.RenderSDKMessages},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"tool-usage", "workspace", "history"}
+	for i, id := range want {
+		if view.Selected[i].ID != id || view.Placement.Items[i].FragID != id {
+			t.Fatalf("selected = %#v, placement = %#v", view.Selected, view.Placement.Items)
+		}
+	}
+	payload := view.Rendered[contextfrag.RenderSDKMessages].Data.(*SDKRenderedPayload)
+	if payload.System != "tools\n\nworkspace" {
+		t.Fatalf("system = %q", payload.System)
+	}
+}
+
 func testFrags() []contextfrag.ContextFrag {
 	return []contextfrag.ContextFrag{
 		textFrag("system.prompt", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "System guidance"),

--- a/internal/contextview/builder_test.go
+++ b/internal/contextview/builder_test.go
@@ -1,0 +1,178 @@
+package contextview
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestBuildEndToEndPassthrough(t *testing.T) {
+	t.Parallel()
+
+	frags := testFrags()
+	builder := NewBuilder(
+		NewMapCollectorRegistry(StaticCollector{CollectorName: "static", Frags: frags}),
+		PassthroughSelector{},
+		IdentityPlacer{},
+		NewMapRendererRegistry(NoopRenderer{TargetName: contextfrag.RenderSDKMessages}),
+	)
+
+	got, err := builder.Build(context.Background(), BuildInput{
+		Scope:   contextfrag.Scope{BotID: "bot-1", SessionID: "session-1"},
+		Intent:  contextfrag.IntentRunConfigPreProvider,
+		Sources: []SourceSpec{{Name: "static"}},
+		Targets: []contextfrag.RenderTarget{contextfrag.RenderSDKMessages},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if len(got.SourceFrags) != 3 || len(got.Selected) != 3 || got.Manifest.Counts.Fragments != 3 {
+		t.Fatalf("unexpected view counts: source=%d selected=%d manifest=%d", len(got.SourceFrags), len(got.Selected), got.Manifest.Counts.Fragments)
+	}
+	if got.Manifest.View != contextfrag.ViewRunConfigPreProvider {
+		t.Fatalf("manifest view = %q", got.Manifest.View)
+	}
+	if _, ok := got.Rendered[contextfrag.RenderSDKMessages]; !ok {
+		t.Fatal("SDK render target missing")
+	}
+	if got.Trace.SelectionSummary.TotalCollected != 3 || got.Trace.SelectionSummary.TotalSelected != 3 {
+		t.Fatalf("selection trace = %#v", got.Trace.SelectionSummary)
+	}
+}
+
+func TestBuildDryRunSkipsRender(t *testing.T) {
+	t.Parallel()
+
+	builder := NewBuilder(
+		NewMapCollectorRegistry(StaticCollector{CollectorName: "static", Frags: testFrags()[:1]}),
+		PassthroughSelector{},
+		IdentityPlacer{},
+		NewMapRendererRegistry(),
+	)
+	got, err := builder.Build(context.Background(), BuildInput{
+		Intent:  contextfrag.IntentRunConfigPreProvider,
+		Sources: []SourceSpec{{Name: "static"}},
+		Targets: []contextfrag.RenderTarget{contextfrag.RenderSDKMessages},
+		Options: BuildOptions{DryRun: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Rendered) != 0 || len(got.Trace.RenderSummaries) != 0 {
+		t.Fatalf("dry run rendered output: %#v", got.Rendered)
+	}
+}
+
+func TestBuildRejectsUnknownCollectorAndRenderer(t *testing.T) {
+	t.Parallel()
+
+	builder := NewBuilder(NewMapCollectorRegistry(), PassthroughSelector{}, IdentityPlacer{}, NewMapRendererRegistry())
+	_, err := builder.Build(context.Background(), BuildInput{
+		Intent: contextfrag.IntentRunConfigPreProvider, Sources: []SourceSpec{{Name: "missing"}}, Options: BuildOptions{DryRun: true},
+	})
+	if err == nil || !strings.Contains(err.Error(), `unknown collector "missing"`) {
+		t.Fatalf("collector error = %v", err)
+	}
+
+	builder = NewBuilder(
+		NewMapCollectorRegistry(StaticCollector{CollectorName: "static", Frags: testFrags()[:1]}),
+		PassthroughSelector{}, IdentityPlacer{}, NewMapRendererRegistry(),
+	)
+	_, err = builder.Build(context.Background(), BuildInput{
+		Intent: contextfrag.IntentRunConfigPreProvider, Sources: []SourceSpec{{Name: "static"}}, Targets: []contextfrag.RenderTarget{contextfrag.RenderSDKMessages},
+	})
+	if err == nil || !strings.Contains(err.Error(), `unknown renderer "sdk_messages"`) {
+		t.Fatalf("renderer error = %v", err)
+	}
+}
+
+func TestBuildNormalizesCollectedContextRefs(t *testing.T) {
+	t.Parallel()
+
+	frag := textFrag("system.prompt", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "system prompt")
+	builder := NewBuilder(
+		NewMapCollectorRegistry(StaticCollector{CollectorName: "static", Frags: []contextfrag.ContextFrag{frag}}),
+		PassthroughSelector{}, IdentityPlacer{}, NewMapRendererRegistry(),
+	)
+	view, err := builder.Build(context.Background(), BuildInput{
+		Intent: contextfrag.IntentRunConfigPreProvider, Sources: []SourceSpec{{Name: "static"}}, Options: BuildOptions{DryRun: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.SourceFrags[0].Ref.ID == "" || view.Selected[0].Ref.ContentHash == "" {
+		t.Fatalf("refs were not normalized: %#v", view.Selected[0].Ref)
+	}
+	if view.Placement.Items[0].Ref.Schema != contextfrag.SchemaContextRef {
+		t.Fatalf("placement ref = %#v", view.Placement.Items[0].Ref)
+	}
+}
+
+type droppingSelector struct{}
+
+func (droppingSelector) ProfileFor(intent contextfrag.Intent) IntentProfile {
+	return IntentProfile{Intent: intent}
+}
+
+func (droppingSelector) Select(frags []contextfrag.ContextFrag, _ IntentProfile, _ BudgetEnvelope) SelectionResult {
+	return SelectionResult{
+		Selected: frags[1:],
+		Dropped:  frags[:1],
+		Summary: SelectionSummary{
+			TotalCollected: len(frags), TotalSelected: len(frags) - 1, TotalDropped: 1,
+			DropReasons: []DropRecord{{FragID: frags[0].ID, Ref: frags[0].Ref, Reason: "fixture"}},
+		},
+	}
+}
+
+func TestBuildRecordsDroppedFragmentEditTrace(t *testing.T) {
+	t.Parallel()
+
+	frags := testFrags()
+	builder := NewBuilder(
+		NewMapCollectorRegistry(StaticCollector{CollectorName: "static", Frags: frags}),
+		droppingSelector{}, IdentityPlacer{}, NewMapRendererRegistry(),
+	)
+	got, err := builder.Build(context.Background(), BuildInput{
+		Intent: contextfrag.IntentRunConfigPreProvider, Sources: []SourceSpec{{Name: "static"}}, Options: BuildOptions{DryRun: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Manifest.EditTrace) != 1 || got.Manifest.EditTrace[0].Op != contextfrag.EditRemove {
+		t.Fatalf("edit trace = %#v", got.Manifest.EditTrace)
+	}
+	if len(got.Manifest.Items) != len(frags)-1 {
+		t.Fatalf("manifest items = %d, want %d", len(got.Manifest.Items), len(frags)-1)
+	}
+}
+
+func testFrags() []contextfrag.ContextFrag {
+	return []contextfrag.ContextFrag{
+		textFrag("system.prompt", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "System guidance"),
+		messageFrag("history.001", sdk.UserMessage("previous user turn")),
+		textFrag("current.message", contextfrag.SlotCurrentUser, contextfrag.KindCurrentUserMessage, sdk.MessageRoleUser, "current request"),
+	}
+}
+
+func textFrag(id string, slot contextfrag.Slot, kind contextfrag.Kind, role sdk.MessageRole, text string) contextfrag.ContextFrag {
+	cacheClass := contextfrag.CacheStable
+	if slot == contextfrag.SlotCurrentUser {
+		cacheClass = contextfrag.CacheNever
+	}
+	return contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: id, Kind: kind, Role: role, Slot: slot, Text: text, Priority: 10,
+		CacheClass: cacheClass, Trust: contextfrag.TrustSystem, Source: "static", Collector: "static",
+	})
+}
+
+func messageFrag(id string, msg sdk.Message) contextfrag.ContextFrag {
+	return contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: id, Message: msg, Kind: contextfrag.KindConversationEvent, Slot: contextfrag.SlotHistory,
+		CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustExternal, Source: "static", Collector: "static",
+	})
+}

--- a/internal/contextview/cache_estimate_test.go
+++ b/internal/contextview/cache_estimate_test.go
@@ -1,0 +1,31 @@
+package contextview
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestStablePrefixTokenEstimateCoversToolDefsAndPlacedPrefix(t *testing.T) {
+	t.Parallel()
+	frags := []contextfrag.ContextFrag{
+		systemTextFrag("system", "system", contextfrag.KindSystemPrompt, 20),
+		stableHistoryMessageFrag("history", sdk.UserMessage("history")),
+		currentMessageFrag("current", "current"),
+	}
+	placement := StablePrefixPlacer{}.Place(frags, contextfrag.IntentRunConfigPreProvider)
+	defs := []contextfrag.ToolDefAccounting{{TokenEstimate: 11}, {TokenEstimate: 7}}
+	want := 18 + contextfrag.ResolveFragTokens(frags[0]) + contextfrag.ResolveFragTokens(frags[1])
+	if got := stablePrefixTokenEstimate(placement, frags, defs); got != want {
+		t.Fatalf("estimate = %d, want %d", got, want)
+	}
+}
+
+func TestStablePrefixTokenEstimateEmptyPlacementCountsTools(t *testing.T) {
+	t.Parallel()
+	if got := stablePrefixTokenEstimate(PlacementPlan{}, nil, []contextfrag.ToolDefAccounting{{TokenEstimate: 9}}); got != 9 {
+		t.Fatalf("estimate = %d", got)
+	}
+}

--- a/internal/contextview/collector_config.go
+++ b/internal/contextview/collector_config.go
@@ -1,0 +1,24 @@
+package contextview
+
+import "errors"
+
+// collectorConfig unwraps a collector's CollectRequest.Config into its
+// concrete type T, accepting a nil config, a direct value, or a pointer
+// (nil or populated), and rejecting anything else with errMsg.
+func collectorConfig[T any](config any, errMsg string) (T, error) {
+	var zero T
+	if config == nil {
+		return zero, nil
+	}
+	switch cfg := config.(type) {
+	case *T:
+		if cfg == nil {
+			return zero, nil
+		}
+		return *cfg, nil
+	case T:
+		return cfg, nil
+	default:
+		return zero, errors.New(errMsg)
+	}
+}

--- a/internal/contextview/collector_config_test.go
+++ b/internal/contextview/collector_config_test.go
@@ -1,0 +1,70 @@
+package contextview
+
+import "testing"
+
+type collectorConfigTestType struct {
+	Value string
+}
+
+func TestCollectorConfigNilConfigReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	got, err := collectorConfig[collectorConfigTestType](nil, "bad config")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got != (collectorConfigTestType{}) {
+		t.Fatalf("got = %#v, want zero value", got)
+	}
+}
+
+func TestCollectorConfigDirectValue(t *testing.T) {
+	t.Parallel()
+
+	want := collectorConfigTestType{Value: "direct"}
+	got, err := collectorConfig[collectorConfigTestType](want, "bad config")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got != want {
+		t.Fatalf("got = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectorConfigPointerValue(t *testing.T) {
+	t.Parallel()
+
+	want := collectorConfigTestType{Value: "pointer"}
+	got, err := collectorConfig[collectorConfigTestType](&want, "bad config")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got != want {
+		t.Fatalf("got = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectorConfigNilPointerReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	var nilPtr *collectorConfigTestType
+	got, err := collectorConfig[collectorConfigTestType](nilPtr, "bad config")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got != (collectorConfigTestType{}) {
+		t.Fatalf("got = %#v, want zero value", got)
+	}
+}
+
+func TestCollectorConfigWrongTypeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	got, err := collectorConfig[collectorConfigTestType](42, "bad config")
+	if err == nil || err.Error() != "bad config" {
+		t.Fatalf("err = %v, want %q", err, "bad config")
+	}
+	if got != (collectorConfigTestType{}) {
+		t.Fatalf("got = %#v, want zero value", got)
+	}
+}

--- a/internal/contextview/collector_current_user.go
+++ b/internal/contextview/collector_current_user.go
@@ -1,0 +1,49 @@
+package contextview
+
+import (
+	"context"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+const currentUserCollectorName = "current_user"
+
+type CurrentUserConfig struct {
+	Query string
+}
+
+type CurrentUserCollector struct{}
+
+func (*CurrentUserCollector) Name() string {
+	return currentUserCollectorName
+}
+
+func (*CurrentUserCollector) Collect(_ context.Context, req CollectRequest) ([]contextfrag.ContextFrag, error) {
+	cfg, err := currentUserConfig(req.Config)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Query == "" {
+		return nil, nil
+	}
+	msg := sdk.UserMessage(cfg.Query)
+	return []contextfrag.ContextFrag{contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID:         "current_user.message",
+		Message:    msg,
+		Kind:       contextfrag.KindCurrentUserMessage,
+		Slot:       contextfrag.SlotCurrentUser,
+		Priority:   90,
+		CacheClass: contextfrag.CacheNever,
+		Trust:      contextfrag.TrustUser,
+		Scope:      req.Scope,
+		Source:     contextfrag.SourceRunConfig,
+		Collector:  currentUserCollectorName,
+		Budget:     contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep},
+	})}, nil
+}
+
+func currentUserConfig(config any) (CurrentUserConfig, error) {
+	return collectorConfig[CurrentUserConfig](config, "current_user config must be CurrentUserConfig")
+}

--- a/internal/contextview/collector_history.go
+++ b/internal/contextview/collector_history.go
@@ -1,0 +1,150 @@
+package contextview
+
+import (
+	"context"
+	"fmt"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+const (
+	historyMessagesCollectorName         = "history_messages"
+	materializedCurrentUserCollectorName = "materialized_current_user"
+)
+
+type HistoryMessagesConfig struct {
+	Messages []sdk.Message
+	// CurrentUserMessageIndex identifies a current request already carried in
+	// Messages. The history collector omits it and the current-user collector
+	// retains it in the current-user slot.
+	CurrentUserMessageIndex *int
+	// RepairToolClosures applies the shared repair when a caller has not
+	// already repaired its materialized message stream.
+	RepairToolClosures bool
+}
+
+type HistoryMessagesCollector struct{}
+
+func (*HistoryMessagesCollector) Name() string {
+	return historyMessagesCollectorName
+}
+
+func (*HistoryMessagesCollector) Collect(_ context.Context, req CollectRequest) ([]contextfrag.ContextFrag, error) {
+	cfg, err := historyMessagesConfig(req.Config)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.Messages) == 0 {
+		return nil, nil
+	}
+
+	historyScope := req.Scope
+	historyScope.Attention = nil
+	currentUserIndex, hasCurrentUser := markedCurrentUserMessageIndex(cfg.Messages, cfg.CurrentUserMessageIndex)
+	frags := make([]contextfrag.ContextFrag, 0, len(cfg.Messages))
+	for i, msg := range cfg.Messages {
+		if hasCurrentUser && i == currentUserIndex {
+			continue
+		}
+		frags = append(frags, contextfrag.MessageFrag(contextfrag.MessageFragInput{
+			ID:         fmt.Sprintf("message.%03d", i),
+			Message:    msg,
+			Kind:       kindForSDKMessage(msg),
+			Slot:       contextfrag.SlotHistory,
+			Priority:   contextfrag.PriorityForMessage(msg),
+			CacheClass: cacheForSDKMessage(msg),
+			Trust:      trustForSDKMessage(msg),
+			Scope:      historyScope,
+			Source:     contextfrag.SourceRunConfig,
+			Collector:  historyMessagesCollectorName,
+			Index:      i,
+		}))
+	}
+	if cfg.RepairToolClosures {
+		frags = contextfrag.RepairToolClosureFrags(frags, historyScope, historyMessagesCollectorName)
+	}
+	return frags, nil
+}
+
+type materializedCurrentUserCollector struct{}
+
+func (*materializedCurrentUserCollector) Name() string {
+	return materializedCurrentUserCollectorName
+}
+
+func (*materializedCurrentUserCollector) Collect(_ context.Context, req CollectRequest) ([]contextfrag.ContextFrag, error) {
+	cfg, err := historyMessagesConfig(req.Config)
+	if err != nil {
+		return nil, err
+	}
+	index, ok := markedCurrentUserMessageIndex(cfg.Messages, cfg.CurrentUserMessageIndex)
+	if !ok {
+		return nil, nil
+	}
+	msg := cfg.Messages[index]
+	return []contextfrag.ContextFrag{contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID:         fmt.Sprintf("message.%03d", index),
+		Message:    msg,
+		Kind:       contextfrag.KindCurrentUserMessage,
+		Slot:       contextfrag.SlotCurrentUser,
+		Priority:   contextfrag.PriorityForMessage(msg),
+		CacheClass: contextfrag.CacheNever,
+		Trust:      contextfrag.TrustUser,
+		Scope:      req.Scope,
+		Source:     contextfrag.SourceRunConfig,
+		Collector:  materializedCurrentUserCollectorName,
+		Index:      index,
+		Budget:     contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep},
+	})}, nil
+}
+
+func markedCurrentUserMessageIndex(messages []sdk.Message, index *int) (int, bool) {
+	if index == nil {
+		return 0, false
+	}
+	if *index >= 0 && *index < len(messages) && messages[*index].Role == sdk.MessageRoleUser {
+		return *index, true
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == sdk.MessageRoleUser {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func historyMessagesConfig(config any) (HistoryMessagesConfig, error) {
+	return collectorConfig[HistoryMessagesConfig](config, "history_messages config must be HistoryMessagesConfig")
+}
+
+func kindForSDKMessage(msg sdk.Message) contextfrag.Kind {
+	if msg.Role == sdk.MessageRoleSystem {
+		return contextfrag.KindSystemPolicy
+	}
+	return contextfrag.KindConversationEvent
+}
+
+func cacheForSDKMessage(msg sdk.Message) contextfrag.CacheClass {
+	if msg.Role == sdk.MessageRoleSystem {
+		return contextfrag.CacheDynamic
+	}
+	switch msg.Role {
+	case sdk.MessageRoleUser, sdk.MessageRoleAssistant, sdk.MessageRoleTool:
+		return contextfrag.CacheStable
+	default:
+		return contextfrag.CacheNever
+	}
+}
+
+func trustForSDKMessage(msg sdk.Message) contextfrag.TrustLevel {
+	switch msg.Role {
+	case sdk.MessageRoleSystem:
+		return contextfrag.TrustSystem
+	case sdk.MessageRoleAssistant, sdk.MessageRoleTool:
+		return contextfrag.TrustWorkspace
+	default:
+		return contextfrag.TrustExternal
+	}
+}

--- a/internal/contextview/collector_history.go
+++ b/internal/contextview/collector_history.go
@@ -20,6 +20,9 @@ type HistoryMessagesConfig struct {
 	// Messages. The history collector omits it and the current-user collector
 	// retains it in the current-user slot.
 	CurrentUserMessageIndex *int
+	// MemoryMessageIndex identifies materialized memory recall that must be
+	// collected separately without changing its provider message position.
+	MemoryMessageIndex *int
 	// RepairToolClosures applies the shared repair when a caller has not
 	// already repaired its materialized message stream.
 	RepairToolClosures bool
@@ -42,10 +45,11 @@ func (*HistoryMessagesCollector) Collect(_ context.Context, req CollectRequest) 
 
 	historyScope := req.Scope
 	historyScope.Attention = nil
-	currentUserIndex, hasCurrentUser := markedCurrentUserMessageIndex(cfg.Messages, cfg.CurrentUserMessageIndex)
+	memoryIndex, hasMemory := markedMemoryMessageIndex(cfg.Messages, cfg.MemoryMessageIndex)
+	currentUserIndex, hasCurrentUser := markedCurrentUserMessageIndex(cfg.Messages, cfg.CurrentUserMessageIndex, optionalIndex(memoryIndex, hasMemory)...)
 	frags := make([]contextfrag.ContextFrag, 0, len(cfg.Messages))
 	for i, msg := range cfg.Messages {
-		if hasCurrentUser && i == currentUserIndex {
+		if hasCurrentUser && i == currentUserIndex || hasMemory && i == memoryIndex {
 			continue
 		}
 		frags = append(frags, contextfrag.MessageFrag(contextfrag.MessageFragInput{
@@ -79,7 +83,8 @@ func (*materializedCurrentUserCollector) Collect(_ context.Context, req CollectR
 	if err != nil {
 		return nil, err
 	}
-	index, ok := markedCurrentUserMessageIndex(cfg.Messages, cfg.CurrentUserMessageIndex)
+	memoryIndex, hasMemory := markedMemoryMessageIndex(cfg.Messages, cfg.MemoryMessageIndex)
+	index, ok := markedCurrentUserMessageIndex(cfg.Messages, cfg.CurrentUserMessageIndex, optionalIndex(memoryIndex, hasMemory)...)
 	if !ok {
 		return nil, nil
 	}
@@ -100,19 +105,42 @@ func (*materializedCurrentUserCollector) Collect(_ context.Context, req CollectR
 	})}, nil
 }
 
-func markedCurrentUserMessageIndex(messages []sdk.Message, index *int) (int, bool) {
+func markedCurrentUserMessageIndex(messages []sdk.Message, index *int, excluded ...int) (int, bool) {
 	if index == nil {
 		return 0, false
 	}
-	if *index >= 0 && *index < len(messages) && messages[*index].Role == sdk.MessageRoleUser {
+	if *index >= 0 && *index < len(messages) && messages[*index].Role == sdk.MessageRoleUser && !containsIndex(excluded, *index) {
 		return *index, true
 	}
 	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == sdk.MessageRoleUser {
+		if messages[i].Role == sdk.MessageRoleUser && !containsIndex(excluded, i) {
 			return i, true
 		}
 	}
 	return 0, false
+}
+
+func markedMemoryMessageIndex(messages []sdk.Message, index *int) (int, bool) {
+	if index == nil || *index < 0 || *index >= len(messages) || messages[*index].Role != sdk.MessageRoleUser {
+		return 0, false
+	}
+	return *index, true
+}
+
+func optionalIndex(index int, ok bool) []int {
+	if !ok {
+		return nil
+	}
+	return []int{index}
+}
+
+func containsIndex(indexes []int, target int) bool {
+	for _, index := range indexes {
+		if index == target {
+			return true
+		}
+	}
+	return false
 }
 
 func historyMessagesConfig(config any) (HistoryMessagesConfig, error) {

--- a/internal/contextview/collector_history_repair_test.go
+++ b/internal/contextview/collector_history_repair_test.go
@@ -1,0 +1,90 @@
+package contextview
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestHistoryCollectorRepairsDanglingToolCalls(t *testing.T) {
+	t.Parallel()
+
+	messages := []sdk.Message{
+		sdk.UserMessage("question"),
+		assistantToolCallMessage("call-lost", "web_search", ""),
+		sdk.UserMessage("next question"),
+	}
+	frags, err := (&HistoryMessagesCollector{}).Collect(context.Background(), CollectRequest{
+		Scope:  contextfrag.Scope{BotID: "bot-1"},
+		Intent: contextfrag.IntentRunConfigPreProvider,
+		Config: HistoryMessagesConfig{Messages: messages, RepairToolClosures: true},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+	if len(frags) != 4 {
+		t.Fatalf("frags = %d, want synthetic closure inserted", len(frags))
+	}
+	synthetic := frags[2]
+	msg := discussFragMessage(synthetic)
+	if msg == nil || msg.Role != sdk.MessageRoleTool {
+		t.Fatalf("frag after dangling call must be a synthetic tool result: %#v", synthetic)
+	}
+	result, ok := msg.Content[0].(sdk.ToolResultPart)
+	if !ok || result.ToolCallID != "call-lost" {
+		t.Fatalf("synthetic result must close the dangling call: %#v", msg.Content[0])
+	}
+	if !strings.Contains(synthetic.Provenance.Source, "repair") {
+		t.Fatalf("synthetic closure must be attributed to the repair policy: %+v", synthetic.Provenance)
+	}
+}
+
+func TestHistoryCollectorDropsOrphanToolResults(t *testing.T) {
+	t.Parallel()
+
+	messages := []sdk.Message{
+		toolResultMessage("call-unknown", "web_search", "orphan"),
+		sdk.UserMessage("question"),
+	}
+	frags, err := (&HistoryMessagesCollector{}).Collect(context.Background(), CollectRequest{
+		Scope:  contextfrag.Scope{BotID: "bot-1"},
+		Intent: contextfrag.IntentRunConfigPreProvider,
+		Config: HistoryMessagesConfig{Messages: messages, RepairToolClosures: true},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+	for _, frag := range frags {
+		msg := discussFragMessage(frag)
+		if msg != nil && msg.Role == sdk.MessageRoleTool {
+			t.Fatalf("orphan tool result must not survive repair: %#v", frag)
+		}
+	}
+}
+
+func assistantToolCallMessage(callID, toolName, text string) sdk.Message {
+	parts := make([]sdk.MessagePart, 0, 2)
+	if text != "" {
+		parts = append(parts, sdk.TextPart{Text: text})
+	}
+	parts = append(parts, sdk.ToolCallPart{
+		ToolCallID: callID,
+		ToolName:   toolName,
+		Input:      map[string]any{},
+	})
+	return sdk.Message{Role: sdk.MessageRoleAssistant, Content: parts}
+}
+
+func toolResultMessage(callID, toolName, value string) sdk.Message {
+	return sdk.Message{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{
+		sdk.ToolResultPart{ToolCallID: callID, ToolName: toolName, Result: value},
+	}}
+}
+
+func discussFragMessage(frag contextfrag.ContextFrag) *sdk.Message {
+	return contextfrag.FragMessage(frag)
+}

--- a/internal/contextview/collector_history_test.go
+++ b/internal/contextview/collector_history_test.go
@@ -1,0 +1,64 @@
+package contextview
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestHistoryCollectorPreservesMessagesAndSeparatesCurrent(t *testing.T) {
+	t.Parallel()
+
+	messages := []sdk.Message{sdk.UserMessage("history"), sdk.AssistantMessage("answer"), sdk.UserMessage("  current \n")}
+	current := 2
+	cfg := HistoryMessagesConfig{Messages: messages, CurrentUserMessageIndex: &current}
+	history, err := (&HistoryMessagesCollector{}).Collect(context.Background(), CollectRequest{Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentFrags, err := (&materializedCurrentUserCollector{}).Collect(context.Background(), CollectRequest{Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 2 || len(currentFrags) != 1 || currentFrags[0].Slot != contextfrag.SlotCurrentUser {
+		t.Fatalf("history/current = %#v / %#v", history, currentFrags)
+	}
+	msg := contextfrag.FragMessage(currentFrags[0])
+	text := msg.Content[0].(sdk.TextPart)
+	if text.Text != "  current \n" {
+		t.Fatalf("current text = %q", text.Text)
+	}
+}
+
+func TestHistoryCollectorDoesNotInheritCurrentAttention(t *testing.T) {
+	t.Parallel()
+
+	frags, err := (&HistoryMessagesCollector{}).Collect(context.Background(), CollectRequest{
+		Scope:  contextfrag.Scope{Attention: []contextfrag.AttentionReason{contextfrag.AttentionDirect}},
+		Config: HistoryMessagesConfig{Messages: []sdk.Message{sdk.UserMessage("old")}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frags[0].Scope.Attention) != 0 {
+		t.Fatalf("history attention = %#v", frags[0].Scope.Attention)
+	}
+}
+
+func TestMaterializedCurrentIndexFallsBackToLatestUser(t *testing.T) {
+	t.Parallel()
+
+	stale := 99
+	frags, err := (&materializedCurrentUserCollector{}).Collect(context.Background(), CollectRequest{
+		Config: HistoryMessagesConfig{Messages: []sdk.Message{sdk.UserMessage("first"), sdk.AssistantMessage("answer"), sdk.UserMessage("latest")}, CurrentUserMessageIndex: &stale},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frags) != 1 || frags[0].ID != "message.002" {
+		t.Fatalf("frags = %#v", frags)
+	}
+}

--- a/internal/contextview/collector_hook.go
+++ b/internal/contextview/collector_hook.go
@@ -1,0 +1,38 @@
+package contextview
+
+import (
+	"context"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+const hookContextCollectorName = "hook_context"
+
+type HookContextConfig struct {
+	Text string
+}
+
+type HookContextCollector struct{}
+
+func (*HookContextCollector) Name() string {
+	return hookContextCollectorName
+}
+
+func (*HookContextCollector) Collect(_ context.Context, req CollectRequest) ([]contextfrag.ContextFrag, error) {
+	cfg, err := collectorConfig[HookContextConfig](req.Config, "hook_context config must be HookContextConfig")
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Text == "" {
+		return nil, nil
+	}
+	return []contextfrag.ContextFrag{{
+		ID: "system.hook_context", Kind: contextfrag.KindHookContext, Role: sdk.MessageRoleSystem, Slot: contextfrag.SlotSystem,
+		Priority: 80, CacheClass: contextfrag.CacheNever, Trust: contextfrag.TrustSystem, Scope: req.Scope,
+		Render:     contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+		Provenance: contextfrag.Provenance{Source: "hook_context", Collector: hookContextCollectorName},
+		Parts:      []contextfrag.Part{{Type: contextfrag.PartText, Text: cfg.Text}},
+	}}, nil
+}

--- a/internal/contextview/collector_hook_test.go
+++ b/internal/contextview/collector_hook_test.go
@@ -1,0 +1,29 @@
+package contextview
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestHookCollectorPreservesLegacySystemAuthorityAndBytes(t *testing.T) {
+	t.Parallel()
+
+	raw := "[Hook Context: BeforePromptBuild]\n  exact hook text \n"
+	frags, err := (&HookContextCollector{}).Collect(context.Background(), CollectRequest{Config: HookContextConfig{Text: raw}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frags) != 1 || frags[0].Role != sdk.MessageRoleSystem || frags[0].Slot != contextfrag.SlotSystem {
+		t.Fatalf("hook frag = %#v", frags)
+	}
+	if frags[0].Priority <= 70 || frags[0].CacheClass != contextfrag.CacheNever || frags[0].Trust != contextfrag.TrustSystem {
+		t.Fatalf("hook metadata = %#v", frags[0])
+	}
+	if len(frags[0].Parts) != 1 || frags[0].Parts[0].Text != raw {
+		t.Fatalf("hook parts = %#v", frags[0].Parts)
+	}
+}

--- a/internal/contextview/collector_inline_images.go
+++ b/internal/contextview/collector_inline_images.go
@@ -1,0 +1,41 @@
+package contextview
+
+import (
+	"context"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+const inlineImagesCollectorName = "inline_images"
+
+type InlineImageConfig struct {
+	Images []sdk.ImagePart
+}
+
+type InlineImageCollector struct{}
+
+func (*InlineImageCollector) Name() string {
+	return inlineImagesCollectorName
+}
+
+func (*InlineImageCollector) Collect(_ context.Context, req CollectRequest) ([]contextfrag.ContextFrag, error) {
+	cfg, err := inlineImageConfig(req.Config)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.Images) == 0 {
+		return nil, nil
+	}
+	frag := contextfrag.ImageFrag("current_user.images", cfg.Images, req.Scope, contextfrag.SourceRunConfig)
+	if len(frag.Parts) == 0 {
+		return nil, nil
+	}
+	frag.Provenance.Collector = inlineImagesCollectorName
+	return []contextfrag.ContextFrag{frag}, nil
+}
+
+func inlineImageConfig(config any) (InlineImageConfig, error) {
+	return collectorConfig[InlineImageConfig](config, "inline_images config must be InlineImageConfig")
+}

--- a/internal/contextview/collector_memory.go
+++ b/internal/contextview/collector_memory.go
@@ -11,7 +11,9 @@ import (
 const memoryContextCollectorName = "memory_context"
 
 type MemoryContextConfig struct {
-	Text string
+	Text    string
+	Message *sdk.Message
+	Index   int
 }
 
 type MemoryContextCollector struct{}
@@ -25,13 +27,18 @@ func (*MemoryContextCollector) Collect(_ context.Context, req CollectRequest) ([
 	if err != nil {
 		return nil, err
 	}
-	if cfg.Text == "" {
-		return nil, nil
+	var msg sdk.Message
+	if cfg.Message != nil {
+		msg = *cfg.Message
+	} else {
+		if cfg.Text == "" {
+			return nil, nil
+		}
+		msg = sdk.UserMessage(cfg.Text)
 	}
-	msg := sdk.UserMessage(cfg.Text)
 	return []contextfrag.ContextFrag{contextfrag.MessageFrag(contextfrag.MessageFragInput{
 		ID: "memory.recall", Message: msg, Kind: contextfrag.KindMemoryRecall, Slot: contextfrag.SlotHistory,
 		Priority: 60, CacheClass: contextfrag.CacheNever, Trust: contextfrag.TrustWorkspace,
-		Scope: req.Scope, Source: "memory_context", Collector: memoryContextCollectorName,
+		Scope: req.Scope, Source: "memory_context", Collector: memoryContextCollectorName, Index: cfg.Index,
 	})}, nil
 }

--- a/internal/contextview/collector_memory.go
+++ b/internal/contextview/collector_memory.go
@@ -1,0 +1,37 @@
+package contextview
+
+import (
+	"context"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+const memoryContextCollectorName = "memory_context"
+
+type MemoryContextConfig struct {
+	Text string
+}
+
+type MemoryContextCollector struct{}
+
+func (*MemoryContextCollector) Name() string {
+	return memoryContextCollectorName
+}
+
+func (*MemoryContextCollector) Collect(_ context.Context, req CollectRequest) ([]contextfrag.ContextFrag, error) {
+	cfg, err := collectorConfig[MemoryContextConfig](req.Config, "memory_context config must be MemoryContextConfig")
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Text == "" {
+		return nil, nil
+	}
+	msg := sdk.UserMessage(cfg.Text)
+	return []contextfrag.ContextFrag{contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: "memory.recall", Message: msg, Kind: contextfrag.KindMemoryRecall, Slot: contextfrag.SlotHistory,
+		Priority: 60, CacheClass: contextfrag.CacheNever, Trust: contextfrag.TrustWorkspace,
+		Scope: req.Scope, Source: "memory_context", Collector: memoryContextCollectorName,
+	})}, nil
+}

--- a/internal/contextview/collector_memory_test.go
+++ b/internal/contextview/collector_memory_test.go
@@ -1,0 +1,28 @@
+package contextview
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestMemoryCollectorPreservesLegacyMessageBytes(t *testing.T) {
+	t.Parallel()
+
+	raw := "  raw <memory> & hook text \n"
+	frags, err := (&MemoryContextCollector{}).Collect(context.Background(), CollectRequest{Config: MemoryContextConfig{Text: raw}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frags) != 1 || frags[0].Kind != contextfrag.KindMemoryRecall {
+		t.Fatalf("frags = %#v", frags)
+	}
+	msg := contextfrag.FragMessage(frags[0])
+	text, ok := msg.Content[0].(sdk.TextPart)
+	if !ok || text.Text != raw {
+		t.Fatalf("memory text = %#v, want %q", msg.Content[0], raw)
+	}
+}

--- a/internal/contextview/collector_system.go
+++ b/internal/contextview/collector_system.go
@@ -1,0 +1,136 @@
+package contextview
+
+import (
+	"context"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+const systemPromptCollectorName = "system_prompt"
+
+type SystemPromptConfig struct {
+	System    string
+	ToolUsage string
+	// SplitWorkspace splits the workspace instruction section into its own
+	// fragment even without embedded tool usage, so an agent-side tool usage
+	// fragment can sort between prompt and workspace instructions.
+	SplitWorkspace bool
+}
+
+// SystemPromptCollector reverse-parses a flat system prompt string for callers
+// that do not already provide typed source fragments.
+type SystemPromptCollector struct{}
+
+func (*SystemPromptCollector) Name() string {
+	return systemPromptCollectorName
+}
+
+func (*SystemPromptCollector) Collect(_ context.Context, req CollectRequest) ([]contextfrag.ContextFrag, error) {
+	cfg, err := systemPromptConfig(req.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	rawSystem := cfg.System
+	if rawSystem == "" {
+		return nil, nil
+	}
+	system := strings.TrimSpace(rawSystem)
+	if system == "" {
+		return preserveSystemBytes(rawSystem, nil, req.Scope), nil
+	}
+
+	toolUsage := strings.TrimSpace(cfg.ToolUsage)
+	toolStart := -1
+	if toolUsage != "" {
+		toolStart = strings.Index(system, toolUsage)
+	}
+	if toolStart < 0 {
+		if cfg.SplitWorkspace {
+			if idx := strings.Index(system, contextfrag.WorkspaceInstructionAnchor); idx >= 0 {
+				frags := make([]contextfrag.ContextFrag, 0, 2)
+				if prompt := strings.TrimSpace(system[:idx]); prompt != "" {
+					frags = append(frags, systemPromptTextFrag(req.Scope, "system.prompt", contextfrag.KindSystemPrompt, prompt, 20, contextfrag.SourceRunConfig, 0))
+				}
+				frags = append(frags, systemPromptTextFrag(req.Scope, "system.workspace_instructions", contextfrag.KindWorkspaceInstruction, strings.TrimSpace(system[idx:]), 50, contextfrag.SourceRunConfig, 1))
+				return preserveSystemBytes(rawSystem, frags, req.Scope), nil
+			}
+		}
+		return preserveSystemBytes(rawSystem, []contextfrag.ContextFrag{
+			systemPromptTextFrag(req.Scope, "system.prompt", contextfrag.KindSystemPrompt, system, 20, contextfrag.SourceRunConfig, 0),
+		}, req.Scope), nil
+	}
+
+	frags := make([]contextfrag.ContextFrag, 0, 3)
+	if prefix := strings.TrimSpace(system[:toolStart]); prefix != "" {
+		frags = append(frags, systemPromptTextFrag(req.Scope, "system.prompt", contextfrag.KindSystemPrompt, prefix, 20, contextfrag.SourceRunConfig, 0))
+	}
+
+	rest := strings.TrimSpace(system[toolStart:])
+	toolEnd := len(toolUsage)
+	if toolUsageText := strings.TrimSpace(rest[:toolEnd]); toolUsageText != "" {
+		frags = append(frags, systemPromptTextFrag(req.Scope, "system.tool_usage", contextfrag.KindToolUsage, toolUsageText, 45, contextfrag.SourceAgentToolUsage, 1))
+	}
+	if suffix := strings.TrimSpace(rest[toolEnd:]); suffix != "" {
+		kind := contextfrag.KindSystemPrompt
+		id := "system.prompt.tail"
+		if strings.HasPrefix(suffix, "## Workspace instruction files") {
+			kind = contextfrag.KindWorkspaceInstruction
+			id = "system.workspace_instructions"
+		}
+		frags = append(frags, systemPromptTextFrag(req.Scope, id, kind, suffix, 50, contextfrag.SourceRunConfig, 2))
+	}
+	return preserveSystemBytes(rawSystem, frags, req.Scope), nil
+}
+
+func preserveSystemBytes(raw string, frags []contextfrag.ContextFrag, scope contextfrag.Scope) []contextfrag.ContextFrag {
+	var parts []string
+	for _, frag := range frags {
+		for _, part := range frag.Parts {
+			if part.Type == contextfrag.PartText {
+				parts = append(parts, part.Text)
+			}
+		}
+	}
+	if strings.Join(parts, "\n\n") == raw {
+		return frags
+	}
+	return []contextfrag.ContextFrag{{
+		ID:         "system.prompt",
+		Kind:       contextfrag.KindSystemPrompt,
+		Role:       sdk.MessageRoleSystem,
+		Slot:       contextfrag.SlotSystem,
+		Priority:   20,
+		CacheClass: contextfrag.CacheStable,
+		Trust:      contextfrag.TrustSystem,
+		Scope:      scope,
+		Render:     contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+		Provenance: contextfrag.Provenance{Source: contextfrag.SourceRunConfig, Collector: systemPromptCollectorName},
+		Parts:      []contextfrag.Part{{Type: contextfrag.PartText, Text: raw}},
+	}}
+}
+
+func systemPromptConfig(config any) (SystemPromptConfig, error) {
+	return collectorConfig[SystemPromptConfig](config, "system_prompt config must be SystemPromptConfig")
+}
+
+func systemPromptTextFrag(scope contextfrag.Scope, id string, kind contextfrag.Kind, text string, priority int, source string, index int) contextfrag.ContextFrag {
+	return contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID:         id,
+		Kind:       kind,
+		Role:       sdk.MessageRoleSystem,
+		Slot:       contextfrag.SlotSystem,
+		Text:       text,
+		Priority:   priority,
+		CacheClass: contextfrag.CacheStable,
+		Trust:      contextfrag.TrustSystem,
+		Scope:      scope,
+		Source:     source,
+		Collector:  systemPromptCollectorName,
+		Index:      index,
+		Render:     contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+	})
+}

--- a/internal/contextview/collector_test.go
+++ b/internal/contextview/collector_test.go
@@ -1,0 +1,125 @@
+package contextview
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestSystemPromptCollectorSplitsCanonicalToolUsage(t *testing.T) {
+	t.Parallel()
+
+	toolUsage := "## Tool usage\nUse tools carefully."
+	system := "Base system.\n\n" + toolUsage + "\n\n## Workspace instruction files\nAGENTS.md"
+	frags, err := (&SystemPromptCollector{}).Collect(context.Background(), CollectRequest{
+		Scope:  contextfrag.Scope{BotID: "bot-1"},
+		Config: SystemPromptConfig{System: system, ToolUsage: toolUsage},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := []contextfrag.Kind{frags[0].Kind, frags[1].Kind, frags[2].Kind}; !reflect.DeepEqual(got, []contextfrag.Kind{
+		contextfrag.KindSystemPrompt, contextfrag.KindToolUsage, contextfrag.KindWorkspaceInstruction,
+	}) {
+		t.Fatalf("kinds = %v", got)
+	}
+	if got := collectedSystemText(frags); got != system {
+		t.Fatalf("system bytes = %q, want %q", got, system)
+	}
+}
+
+func TestSystemPromptCollectorPreservesNoncanonicalBytes(t *testing.T) {
+	t.Parallel()
+
+	for _, system := range []string{"  system with outer space\n", "   "} {
+		frags, err := (&SystemPromptCollector{}).Collect(context.Background(), CollectRequest{Config: SystemPromptConfig{System: system}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(frags) != 1 || collectedSystemText(frags) != system {
+			t.Fatalf("frags = %#v, want exact system %q", frags, system)
+		}
+	}
+}
+
+func TestSystemPromptCollectorEmptySystem(t *testing.T) {
+	t.Parallel()
+
+	frags, err := (&SystemPromptCollector{}).Collect(context.Background(), CollectRequest{})
+	if err != nil || len(frags) != 0 {
+		t.Fatalf("frags = %#v, err = %v", frags, err)
+	}
+}
+
+func TestCurrentUserCollectorPreservesQueryBytes(t *testing.T) {
+	t.Parallel()
+
+	query := "  keep leading and trailing space \n"
+	frags, err := (&CurrentUserCollector{}).Collect(context.Background(), CollectRequest{
+		Config: CurrentUserConfig{Query: query},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frags) != 1 || frags[0].Slot != contextfrag.SlotCurrentUser {
+		t.Fatalf("frags = %#v", frags)
+	}
+	msg := contextfrag.FragMessage(frags[0])
+	if msg == nil || len(msg.Content) != 1 {
+		t.Fatalf("message = %#v", msg)
+	}
+	text, ok := msg.Content[0].(sdk.TextPart)
+	if !ok || text.Text != query {
+		t.Fatalf("text = %#v, want %q", msg.Content[0], query)
+	}
+}
+
+func TestCurrentUserCollectorOnlyOmitsEmptyString(t *testing.T) {
+	t.Parallel()
+
+	empty, err := (&CurrentUserCollector{}).Collect(context.Background(), CollectRequest{Config: CurrentUserConfig{Query: ""}})
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("empty frags = %#v, err = %v", empty, err)
+	}
+	spaces, err := (&CurrentUserCollector{}).Collect(context.Background(), CollectRequest{Config: CurrentUserConfig{Query: "  "}})
+	if err != nil || len(spaces) != 1 {
+		t.Fatalf("space frags = %#v, err = %v", spaces, err)
+	}
+}
+
+func TestInlineImageCollectorFiltersEmptyImages(t *testing.T) {
+	t.Parallel()
+
+	images := []sdk.ImagePart{
+		{Image: "data:image/png;base64,abc", MediaType: "image/png"},
+		{Image: "", MediaType: "image/png"},
+		{Image: "data:image/jpeg;base64,def", MediaType: "image/jpeg"},
+	}
+	frags, err := (&InlineImageCollector{}).Collect(context.Background(), CollectRequest{Config: InlineImageConfig{Images: images}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frags) != 1 || len(frags[0].Parts) != 2 {
+		t.Fatalf("frags = %#v", frags)
+	}
+	if frags[0].Kind != contextfrag.KindNativeImage || frags[0].Slot != contextfrag.SlotCurrentUser {
+		t.Fatalf("image frag metadata = %#v", frags[0])
+	}
+}
+
+func collectedSystemText(frags []contextfrag.ContextFrag) string {
+	var parts []string
+	for _, frag := range frags {
+		for _, part := range frag.Parts {
+			if part.Type == contextfrag.PartText {
+				parts = append(parts, part.Text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}

--- a/internal/contextview/equivalence_test.go
+++ b/internal/contextview/equivalence_test.go
@@ -1,0 +1,96 @@
+package contextview
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+type legacyInput struct {
+	system    string
+	messages  []sdk.Message
+	query     string
+	images    []sdk.ImagePart
+	toolUsage string
+}
+
+func TestContextViewMatchesLegacyProviderBytes(t *testing.T) {
+	t.Parallel()
+	toolUsage := "## Tool usage\nUse tools carefully."
+	image := sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"}
+	cases := map[string]legacyInput{
+		"basic":                      {system: "You are helpful.", messages: []sdk.Message{sdk.UserMessage("hello"), sdk.AssistantMessage("hi")}, query: "What is 2+2?"},
+		"system whitespace":          {system: "  preserve outer system bytes\n", messages: []sdk.Message{sdk.UserMessage("hello")}},
+		"tool usage and workspace":   {system: "Base.\n\n" + toolUsage + "\n\n## Workspace instruction files\nAGENTS.md", toolUsage: toolUsage, query: "continue"},
+		"query whitespace and image": {system: "vision", query: "  inspect this \n", images: []sdk.ImagePart{image}},
+		"image only pipeline":        {system: "vision", messages: []sdk.Message{sdk.UserMessage("embedded query"), sdk.AssistantMessage("working")}, images: []sdk.ImagePart{image}},
+		"memory bytes":               {system: "system", messages: []sdk.Message{sdk.UserMessage("<memory>raw & unescaped</memory>"), sdk.UserMessage("current")}},
+		"hook bytes":                 {system: "system\n\n[Hook Context: BeforePromptBuild]\n  exact hook output \n"},
+	}
+	for name, input := range cases {
+		name, input := name, input
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assertContextViewEquivalent(t, input)
+		})
+	}
+}
+
+func assertContextViewEquivalent(t *testing.T, input legacyInput) {
+	t.Helper()
+	want := legacyProviderMessages(input.messages, input.query, input.images)
+	builder := NewBuilder(
+		NewMapCollectorRegistry(&SystemPromptCollector{}, &HistoryMessagesCollector{}, &CurrentUserCollector{}, &InlineImageCollector{}),
+		&FragmentSelector{}, StablePrefixPlacer{}, NewMapRendererRegistry(&SDKMessagesRenderer{}),
+	)
+	view, err := builder.Build(context.Background(), BuildInput{
+		Intent: contextfrag.IntentRunConfigPreProvider,
+		Sources: []SourceSpec{
+			{Name: systemPromptCollectorName, Config: SystemPromptConfig{System: input.system, ToolUsage: input.toolUsage}},
+			{Name: historyMessagesCollectorName, Config: HistoryMessagesConfig{Messages: input.messages}},
+			{Name: currentUserCollectorName, Config: CurrentUserConfig{Query: input.query}},
+			{Name: inlineImagesCollectorName, Config: InlineImageConfig{Images: input.images}},
+		},
+		Targets: []contextfrag.RenderTarget{contextfrag.RenderSDKMessages},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := view.Rendered[contextfrag.RenderSDKMessages].Data.(*SDKRenderedPayload)
+	if payload.System != input.system {
+		t.Fatalf("system = %q, want %q", payload.System, input.system)
+	}
+	assertMessagesEqual(t, payload.Messages, want)
+}
+
+func legacyProviderMessages(messages []sdk.Message, query string, images []sdk.ImagePart) []sdk.Message {
+	var out []sdk.Message
+	if messages != nil {
+		out = make([]sdk.Message, len(messages))
+		for i, message := range messages {
+			out[i] = cloneSDKMessage(message)
+		}
+	}
+	parts := make([]sdk.MessagePart, 0, len(images))
+	for _, image := range images {
+		if image.Image != "" {
+			parts = append(parts, image)
+		}
+	}
+	if query != "" {
+		return append(out, sdk.UserMessage(query, parts...))
+	}
+	if len(parts) == 0 {
+		return out
+	}
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i].Role == sdk.MessageRoleUser {
+			out[i].Content = append(out[i].Content, parts...)
+			return out
+		}
+	}
+	return append(out, sdk.UserMessage("", parts...))
+}

--- a/internal/contextview/interfaces.go
+++ b/internal/contextview/interfaces.go
@@ -1,0 +1,65 @@
+package contextview
+
+import (
+	"context"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+type CollectRequest struct {
+	Scope  contextfrag.Scope
+	Intent contextfrag.Intent
+	Config any
+}
+
+type RenderInput struct {
+	Intent    contextfrag.Intent
+	Selected  []contextfrag.ContextFrag
+	Placement PlacementPlan
+	Manifest  *contextfrag.Manifest
+	Scope     contextfrag.Scope
+	Target    contextfrag.RenderTarget
+}
+
+type Collector interface {
+	Name() string
+	Collect(context.Context, CollectRequest) ([]contextfrag.ContextFrag, error)
+}
+
+type CollectorRegistry interface {
+	Get(name string) (Collector, bool)
+	Names() []string
+}
+
+type Selector interface {
+	ProfileFor(contextfrag.Intent) IntentProfile
+	Select([]contextfrag.ContextFrag, IntentProfile, BudgetEnvelope) SelectionResult
+}
+
+type SelectionResult struct {
+	Selected []contextfrag.ContextFrag
+	Dropped  []contextfrag.ContextFrag
+	Edited   []contextfrag.ContextEditTrace
+	Warnings []contextfrag.ValidationWarning
+	Summary  SelectionSummary
+}
+
+type IntentProfile struct {
+	Intent        contextfrag.Intent
+	MustKeepSlots []contextfrag.Slot
+	// SlotTrustFloors declares the minimum trust level per slot.
+	SlotTrustFloors map[contextfrag.Slot]contextfrag.TrustLevel
+}
+
+type Placer interface {
+	Place([]contextfrag.ContextFrag, contextfrag.Intent) PlacementPlan
+}
+
+type Renderer interface {
+	Target() contextfrag.RenderTarget
+	Render(context.Context, RenderInput) (RenderedPayload, error)
+}
+
+type RendererRegistry interface {
+	Get(contextfrag.RenderTarget) (Renderer, bool)
+}

--- a/internal/contextview/passthrough.go
+++ b/internal/contextview/passthrough.go
@@ -1,0 +1,137 @@
+package contextview
+
+import (
+	"context"
+	"sort"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+type PassthroughSelector struct{}
+
+func (PassthroughSelector) ProfileFor(intent contextfrag.Intent) IntentProfile {
+	return IntentProfile{Intent: intent}
+}
+
+func (PassthroughSelector) Select(frags []contextfrag.ContextFrag, _ IntentProfile, _ BudgetEnvelope) SelectionResult {
+	selected := append([]contextfrag.ContextFrag(nil), frags...)
+	return SelectionResult{
+		Selected: selected,
+		Summary: SelectionSummary{
+			TotalCollected: len(frags),
+			TotalSelected:  len(selected),
+		},
+	}
+}
+
+type IdentityPlacer struct{}
+
+func (IdentityPlacer) Place(selected []contextfrag.ContextFrag, _ contextfrag.Intent) PlacementPlan {
+	items := make([]PlacementItem, 0, len(selected))
+	for i, frag := range selected {
+		items = append(items, PlacementItem{
+			FragID:    frag.ID,
+			Slot:      frag.Slot,
+			Position:  i,
+			CacheHint: frag.CacheClass,
+			Ref:       frag.Ref,
+		})
+	}
+	return PlacementPlan{
+		FirstVolatileIndex: len(items),
+		Items:              items,
+	}
+}
+
+type NoopRenderer struct {
+	TargetName contextfrag.RenderTarget
+}
+
+func (r NoopRenderer) Target() contextfrag.RenderTarget {
+	return r.TargetName
+}
+
+func (r NoopRenderer) Render(_ context.Context, input RenderInput) (RenderedPayload, error) {
+	target := r.TargetName
+	if target == "" {
+		target = input.Target
+	}
+	return RenderedPayload{Target: target}, nil
+}
+
+type MapCollectorRegistry struct {
+	collectors map[string]Collector
+}
+
+func NewMapCollectorRegistry(collectors ...Collector) *MapCollectorRegistry {
+	registry := &MapCollectorRegistry{collectors: make(map[string]Collector, len(collectors))}
+	for _, collector := range collectors {
+		if collector == nil {
+			continue
+		}
+		registry.collectors[collector.Name()] = collector
+	}
+	return registry
+}
+
+func (r *MapCollectorRegistry) Get(name string) (Collector, bool) {
+	if r == nil {
+		return nil, false
+	}
+	collector, ok := r.collectors[name]
+	if !ok || collector == nil {
+		return nil, false
+	}
+	return collector, true
+}
+
+func (r *MapCollectorRegistry) Names() []string {
+	if r == nil {
+		return nil
+	}
+	names := make([]string, 0, len(r.collectors))
+	for name := range r.collectors {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+type MapRendererRegistry struct {
+	renderers map[contextfrag.RenderTarget]Renderer
+}
+
+func NewMapRendererRegistry(renderers ...Renderer) *MapRendererRegistry {
+	registry := &MapRendererRegistry{renderers: make(map[contextfrag.RenderTarget]Renderer, len(renderers))}
+	for _, renderer := range renderers {
+		if renderer == nil {
+			continue
+		}
+		registry.renderers[renderer.Target()] = renderer
+	}
+	return registry
+}
+
+func (r *MapRendererRegistry) Get(target contextfrag.RenderTarget) (Renderer, bool) {
+	if r == nil {
+		return nil, false
+	}
+	renderer, ok := r.renderers[target]
+	if !ok || renderer == nil {
+		return nil, false
+	}
+	return renderer, true
+}
+
+type StaticCollector struct {
+	CollectorName string
+	Frags         []contextfrag.ContextFrag
+}
+
+func (c StaticCollector) Name() string {
+	return c.CollectorName
+}
+
+func (c StaticCollector) Collect(_ context.Context, _ CollectRequest) ([]contextfrag.ContextFrag, error) {
+	return append([]contextfrag.ContextFrag(nil), c.Frags...), nil
+}

--- a/internal/contextview/placement.go
+++ b/internal/contextview/placement.go
@@ -1,6 +1,9 @@
 package contextview
 
 import (
+	"reflect"
+	"strings"
+
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 )
 
@@ -22,11 +25,52 @@ func (StablePrefixPlacer) Place(selected []contextfrag.ContextFrag, _ contextfra
 			firstVolatile = i
 		}
 	}
+	firstVolatile = renderedStablePrefixEnd(selected, firstVolatile)
 	return PlacementPlan{
 		StablePrefixHash:   stablePrefixHash(selected[:firstVolatile]),
 		FirstVolatileIndex: firstVolatile,
 		Items:              items,
 	}
+}
+
+func renderedStablePrefixEnd(frags []contextfrag.ContextFrag, end int) int {
+	if end <= 0 || end >= len(frags) {
+		return end
+	}
+	stable := renderSDKPayloadFromFrags(frags[:end])
+	full := renderSDKPayloadFromFrags(frags)
+	if stable.System != "" && full.System != stable.System && !strings.HasPrefix(full.System, stable.System+"\n\n") {
+		return 0
+	}
+	if len(stable.Messages) > len(full.Messages) {
+		return 0
+	}
+	for i, message := range stable.Messages {
+		if reflect.DeepEqual(message, full.Messages[i]) {
+			continue
+		}
+		return fragmentIndexForRenderedMessage(frags[:end], i)
+	}
+	return end
+}
+
+func fragmentIndexForRenderedMessage(frags []contextfrag.ContextFrag, target int) int {
+	messageIndex := 0
+	for i, frag := range frags {
+		if frag.Slot == contextfrag.SlotSystem {
+			continue
+		}
+		for _, part := range frag.Parts {
+			if part.Type != contextfrag.PartSDKMessage || sdkMessagePart(part) == nil {
+				continue
+			}
+			if messageIndex == target {
+				return i
+			}
+			messageIndex++
+		}
+	}
+	return 0
 }
 
 func placementRef(frag contextfrag.ContextFrag) contextfrag.ContextRef {

--- a/internal/contextview/placement.go
+++ b/internal/contextview/placement.go
@@ -1,0 +1,69 @@
+package contextview
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+type StablePrefixPlacer struct{}
+
+func (StablePrefixPlacer) Place(selected []contextfrag.ContextFrag, _ contextfrag.Intent) PlacementPlan {
+	items := make([]PlacementItem, 0, len(selected))
+	firstVolatile := len(selected)
+	for i, frag := range selected {
+		ref := placementRef(frag)
+		items = append(items, PlacementItem{
+			FragID:    frag.ID,
+			Slot:      frag.Slot,
+			Position:  i,
+			CacheHint: frag.CacheClass,
+			Ref:       ref,
+		})
+		if firstVolatile == len(selected) && frag.CacheClass != contextfrag.CacheStable {
+			firstVolatile = i
+		}
+	}
+	return PlacementPlan{
+		StablePrefixHash:   stablePrefixHash(selected[:firstVolatile]),
+		FirstVolatileIndex: firstVolatile,
+		Items:              items,
+	}
+}
+
+func placementRef(frag contextfrag.ContextFrag) contextfrag.ContextRef {
+	if err := contextfrag.ValidateContextRef(frag.Ref); err == nil {
+		return frag.Ref
+	}
+	return contextfrag.WithContextRef(frag, frag.Ref).Ref
+}
+
+func stablePrefixHash(frags []contextfrag.ContextFrag) string {
+	if len(frags) == 0 {
+		return ""
+	}
+	items := make([]stablePrefixHashItem, 0, len(frags))
+	for _, frag := range frags {
+		items = append(items, stablePrefixHashItem{
+			ID:         frag.ID,
+			Ref:        placementRef(frag),
+			Slot:       frag.Slot,
+			CacheClass: frag.CacheClass,
+		})
+	}
+	raw, err := json.Marshal(items)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+type stablePrefixHashItem struct {
+	ID         string                 `json:"id"`
+	Ref        contextfrag.ContextRef `json:"ref"`
+	Slot       contextfrag.Slot       `json:"slot"`
+	CacheClass contextfrag.CacheClass `json:"cache_class"`
+}

--- a/internal/contextview/placement.go
+++ b/internal/contextview/placement.go
@@ -1,10 +1,6 @@
 package contextview
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 )
 
@@ -44,26 +40,9 @@ func stablePrefixHash(frags []contextfrag.ContextFrag) string {
 	if len(frags) == 0 {
 		return ""
 	}
-	items := make([]stablePrefixHashItem, 0, len(frags))
-	for _, frag := range frags {
-		items = append(items, stablePrefixHashItem{
-			ID:         frag.ID,
-			Ref:        placementRef(frag),
-			Slot:       frag.Slot,
-			CacheClass: frag.CacheClass,
-		})
-	}
-	raw, err := json.Marshal(items)
+	hash, err := sdkRenderedPayloadHash(renderSDKPayloadFromFrags(frags))
 	if err != nil {
 		return ""
 	}
-	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:])
-}
-
-type stablePrefixHashItem struct {
-	ID         string                 `json:"id"`
-	Ref        contextfrag.ContextRef `json:"ref"`
-	Slot       contextfrag.Slot       `json:"slot"`
-	CacheClass contextfrag.CacheClass `json:"cache_class"`
+	return hash
 }

--- a/internal/contextview/placement_test.go
+++ b/internal/contextview/placement_test.go
@@ -1,0 +1,65 @@
+package contextview
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestStablePrefixPlacerMarksContiguousStablePrefix(t *testing.T) {
+	t.Parallel()
+
+	dynamic := textFrag("dynamic", contextfrag.SlotSystem, contextfrag.KindToolUsage, sdk.MessageRoleSystem, "runtime tools")
+	dynamic.CacheClass = contextfrag.CacheDynamic
+	frags := contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{
+		textFrag("system", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "system"),
+		textFrag("identity", contextfrag.SlotSystem, contextfrag.KindBotIdentity, sdk.MessageRoleSystem, "identity"),
+		dynamic,
+		messageFrag("latest", sdk.UserMessage("latest")),
+	})
+
+	plan := StablePrefixPlacer{}.Place(frags, contextfrag.IntentRunConfigPreProvider)
+
+	if plan.FirstVolatileIndex != 2 {
+		t.Fatalf("FirstVolatileIndex = %d, want 2", plan.FirstVolatileIndex)
+	}
+	if plan.StablePrefixHash == "" {
+		t.Fatal("StablePrefixHash should be set for stable prefix")
+	}
+	if len(plan.Items) != len(frags) {
+		t.Fatalf("items = %d, want %d", len(plan.Items), len(frags))
+	}
+	for i, item := range plan.Items {
+		if item.Position != i || item.FragID != frags[i].ID || item.CacheHint != frags[i].CacheClass {
+			t.Fatalf("item %d = %#v, want position/id/cache from frag %#v", i, item, frags[i])
+		}
+	}
+}
+
+func TestStablePrefixPlacerHashIgnoresVolatileSuffix(t *testing.T) {
+	t.Parallel()
+
+	stable := textFrag("system", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "system")
+	firstVolatile := messageFrag("latest", sdk.UserMessage("latest"))
+	changedVolatile := messageFrag("latest", sdk.UserMessage("changed"))
+	firstVolatile.CacheClass = contextfrag.CacheNever
+	changedVolatile.CacheClass = contextfrag.CacheNever
+
+	first := StablePrefixPlacer{}.Place(contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{stable, firstVolatile}), contextfrag.IntentRunConfigPreProvider)
+	second := StablePrefixPlacer{}.Place(contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{stable, changedVolatile}), contextfrag.IntentRunConfigPreProvider)
+
+	if first.StablePrefixHash == "" {
+		t.Fatal("StablePrefixHash should be set")
+	}
+	if first.StablePrefixHash != second.StablePrefixHash {
+		t.Fatalf("StablePrefixHash changed after volatile suffix edit: first=%q second=%q", first.StablePrefixHash, second.StablePrefixHash)
+	}
+
+	changedStable := textFrag("system", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "changed system")
+	third := StablePrefixPlacer{}.Place(contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{changedStable, firstVolatile}), contextfrag.IntentRunConfigPreProvider)
+	if first.StablePrefixHash == third.StablePrefixHash {
+		t.Fatalf("StablePrefixHash did not change after stable prefix edit: %q", first.StablePrefixHash)
+	}
+}

--- a/internal/contextview/prefix_stability_test.go
+++ b/internal/contextview/prefix_stability_test.go
@@ -1,0 +1,83 @@
+package contextview
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+func prefixSystemFrags() []contextfrag.ContextFrag {
+	return []contextfrag.ContextFrag{
+		systemTextFrag("system.prompt", "base", contextfrag.KindSystemPrompt, 20),
+		systemTextFrag("system.workspace", "workspace", contextfrag.KindWorkspaceInstruction, 50),
+	}
+}
+
+func TestApplyProviderRunConfigCrossTurnPrefixStable(t *testing.T) {
+	t.Parallel()
+	turn1Frags := append(prefixSystemFrags(), stableHistoryMessageFrag("message.000", sdk.UserMessage("history")), currentMessageFrag("message.001", "q1"))
+	turn2Frags := append(prefixSystemFrags(),
+		stableHistoryMessageFrag("message.000", sdk.UserMessage("history")),
+		stableHistoryMessageFrag("message.001", sdk.UserMessage("q1")),
+		stableHistoryMessageFrag("message.002", sdk.AssistantMessage("a1")),
+		currentMessageFrag("message.003", "q2"),
+	)
+	turn1 := ApplyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{ContextSourceFrags: turn1Frags})
+	turn2 := ApplyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{ContextSourceFrags: turn2Frags})
+	if turn1.System != turn2.System || !reflect.DeepEqual(turn1.Messages, turn2.Messages[:len(turn1.Messages)]) {
+		t.Fatalf("turn1 = %#v, turn2 = %#v", turn1, turn2)
+	}
+}
+
+func TestApplyProviderRunConfigMemoryAndHookIsolation(t *testing.T) {
+	t.Parallel()
+	build := func(memory, hook string) agentpkg.RunConfig {
+		frags := prefixSystemFrags()
+		if hook != "" {
+			hookFrags, err := (&HookContextCollector{}).Collect(context.Background(), CollectRequest{Config: HookContextConfig{Text: hook}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			frags = append(frags, hookFrags...)
+		}
+		frags = append(frags, stableHistoryMessageFrag("history", sdk.UserMessage("history")))
+		if memory != "" {
+			memoryFrags, err := (&MemoryContextCollector{}).Collect(context.Background(), CollectRequest{Config: MemoryContextConfig{Text: memory}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			frags = append(frags, memoryFrags...)
+		}
+		frags = append(frags, currentMessageFrag("current", "question"))
+		return agentpkg.RunConfig{ContextSourceFrags: frags}
+	}
+	first := ApplyProviderRunConfig(context.Background(), nil, build("memory one", "hook one"))
+	second := ApplyProviderRunConfig(context.Background(), nil, build("memory two", "hook two"))
+	if first.ContextCachePlan.StablePrefixHash != second.ContextCachePlan.StablePrefixHash {
+		t.Fatalf("stable hashes = %q, %q", first.ContextCachePlan.StablePrefixHash, second.ContextCachePlan.StablePrefixHash)
+	}
+	if first.System == second.System {
+		t.Fatal("legacy prompt hook bytes must remain in System")
+	}
+	if first.Messages[1].Content[0].(sdk.TextPart).Text != "memory one" || second.Messages[1].Content[0].(sdk.TextPart).Text != "memory two" {
+		t.Fatalf("messages = %#v / %#v", first.Messages, second.Messages)
+	}
+	if first.ContextCachePlan.StableMessageCount != 0 {
+		t.Fatalf("stable message count = %d, want volatile hook to end prefix", first.ContextCachePlan.StableMessageCount)
+	}
+}
+
+func TestApplyProviderRunConfigSameTurnIdempotent(t *testing.T) {
+	t.Parallel()
+	cfg := fragsFirstFixture()
+	first := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	second := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if first.System != second.System || !reflect.DeepEqual(first.Messages, second.Messages) || !reflect.DeepEqual(first.ContextManifest.Items, second.ContextManifest.Items) {
+		t.Fatalf("first = %#v, second = %#v", first, second)
+	}
+}

--- a/internal/contextview/prefix_stability_test.go
+++ b/internal/contextview/prefix_stability_test.go
@@ -34,6 +34,51 @@ func TestApplyProviderRunConfigCrossTurnPrefixStable(t *testing.T) {
 	}
 }
 
+func TestApplyProviderRunConfigStablePrefixIgnoresTurnLocalScope(t *testing.T) {
+	t.Parallel()
+	sections := []agentpkg.SystemSection{{
+		ID: "system.prompt", Kind: contextfrag.KindSystemPrompt, Priority: 20, Text: "same system",
+	}}
+	messages := []sdk.Message{sdk.UserMessage("same history"), sdk.UserMessage("same current")}
+	currentIndex := 1
+	build := func(scope contextfrag.Scope) agentpkg.RunConfig {
+		cfg := agentpkg.RunConfig{
+			Messages: messages, ContextCurrentUserMessageIndex: &currentIndex, ContextQueryMaterialized: true,
+			ContextScope: scope, ContextToolUsage: "same tool usage",
+		}
+		cfg.ContextSourceFrags = agentpkg.SystemSectionFrags(sections, scope)
+		cfg.ContextSourceFrags = append(cfg.ContextSourceFrags, CollectNonSystemProviderSourceFrags(context.Background(), cfg)...)
+		return ApplyProviderRunConfig(context.Background(), nil, cfg)
+	}
+	firstScope := contextfrag.Scope{
+		BotID: "bot-1", ChatID: "chat-1", SessionID: "session-1",
+		CurrentMessageID: "telegram-msg-1001", EventID: "event-001",
+	}
+	secondScope := contextfrag.Scope{
+		BotID: "bot-1", ChatID: "chat-1", SessionID: "session-1",
+		CurrentMessageID: "telegram-msg-1002", EventID: "event-002",
+	}
+	first := build(firstScope)
+	second := build(secondScope)
+
+	if first.System != second.System || !reflect.DeepEqual(first.Messages, second.Messages) {
+		t.Fatalf("provider bytes differ: first system %q messages %#v, second system %q messages %#v", first.System, first.Messages, second.System, second.Messages)
+	}
+	if first.ContextCachePlan.StablePrefixHash == "" || first.ContextCachePlan.StablePrefixHash != second.ContextCachePlan.StablePrefixHash {
+		t.Fatalf("stable prefix hashes = %q and %q", first.ContextCachePlan.StablePrefixHash, second.ContextCachePlan.StablePrefixHash)
+	}
+	for _, item := range first.ContextManifest.Items {
+		if item.Scope.CurrentMessageID != firstScope.CurrentMessageID || item.Scope.EventID != firstScope.EventID {
+			t.Fatalf("first manifest lost turn scope: %#v", item.Scope)
+		}
+	}
+	for _, item := range second.ContextManifest.Items {
+		if item.Scope.CurrentMessageID != secondScope.CurrentMessageID || item.Scope.EventID != secondScope.EventID {
+			t.Fatalf("second manifest lost turn scope: %#v", item.Scope)
+		}
+	}
+}
+
 func TestApplyProviderRunConfigMemoryAndHookIsolation(t *testing.T) {
 	t.Parallel()
 	build := func(memory, hook string) agentpkg.RunConfig {

--- a/internal/contextview/prefix_stability_test.go
+++ b/internal/contextview/prefix_stability_test.go
@@ -79,6 +79,33 @@ func TestApplyProviderRunConfigStablePrefixIgnoresTurnLocalScope(t *testing.T) {
 	}
 }
 
+func TestApplyProviderRunConfigImageOnlyCurrentMovesStableMessageBoundary(t *testing.T) {
+	t.Parallel()
+	system := systemTextFrag("system.prompt", "stable system", contextfrag.KindSystemPrompt, 20)
+	history := stableHistoryMessageFrag("message.000", sdk.UserMessage("history"))
+	build := func(imageData string) agentpkg.RunConfig {
+		image := contextfrag.ImageFrag("current_user.images", []sdk.ImagePart{{
+			Image: imageData, MediaType: "image/png",
+		}}, contextfrag.Scope{}, contextfrag.SourceRunConfig)
+		return ApplyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{
+			ContextSourceFrags: []contextfrag.ContextFrag{system, history, image},
+		})
+	}
+	first := build("data:image/png;base64,first")
+	second := build("data:image/png;base64,second")
+
+	if reflect.DeepEqual(first.Messages, second.Messages) {
+		t.Fatalf("image-only current input did not change provider messages: %#v", first.Messages)
+	}
+	if first.ContextCachePlan.StableMessageCount != 0 || second.ContextCachePlan.StableMessageCount != 0 {
+		t.Fatalf("stable message counts = %d and %d, want image target excluded", first.ContextCachePlan.StableMessageCount, second.ContextCachePlan.StableMessageCount)
+	}
+	wantHash := stablePrefixHash([]contextfrag.ContextFrag{system})
+	if wantHash == "" || first.ContextCachePlan.StablePrefixHash != wantHash || second.ContextCachePlan.StablePrefixHash != wantHash {
+		t.Fatalf("stable hashes = %q and %q, want system-only %q", first.ContextCachePlan.StablePrefixHash, second.ContextCachePlan.StablePrefixHash, wantHash)
+	}
+}
+
 func TestApplyProviderRunConfigMemoryAndHookIsolation(t *testing.T) {
 	t.Parallel()
 	build := func(memory, hook string) agentpkg.RunConfig {

--- a/internal/contextview/provider_fallback_test.go
+++ b/internal/contextview/provider_fallback_test.go
@@ -41,7 +41,10 @@ func TestLegacyMaterializeQuerySplicesToolUsageBeforeWorkspace(t *testing.T) {
 		ContextToolUsage: "## Tool usage\n\nUSE_TOOLS",
 	}
 	got := legacyMaterializeQuery(cfg)
-	if strings.Index(got.System, "## Tool usage") < 0 || strings.Index(got.System, "## Tool usage") > strings.Index(got.System, "## Workspace instruction files") {
+	if !strings.Contains(got.System, "## Tool usage") {
+		t.Fatalf("system = %q, want tool usage", got.System)
+	}
+	if strings.Index(got.System, "## Tool usage") > strings.Index(got.System, "## Workspace instruction files") {
 		t.Fatalf("system = %q", got.System)
 	}
 }

--- a/internal/contextview/provider_fallback_test.go
+++ b/internal/contextview/provider_fallback_test.go
@@ -1,0 +1,55 @@
+package contextview
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+func TestProviderViewFallbackKeepsLegacyBytesAndAudit(t *testing.T) {
+	t.Parallel()
+	duplicate := systemTextFrag("duplicate", "source ignored", contextfrag.KindSystemPrompt, 20)
+	image := sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"}
+	cfg := agentpkg.RunConfig{
+		System: "  legacy system \n", Messages: []sdk.Message{sdk.AssistantMessage("history")},
+		Query: "  current \n", InlineImages: []sdk.ImagePart{image},
+		ContextSourceFrags: []contextfrag.ContextFrag{duplicate, duplicate},
+	}
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if got.System != cfg.System {
+		t.Fatalf("system = %q, want %q", got.System, cfg.System)
+	}
+	assertMessagesEqual(t, got.Messages, []sdk.Message{sdk.AssistantMessage("history"), sdk.UserMessage(cfg.Query, image)})
+	if got.ContextManifest.CachePlan == nil || got.ContextManifest.Mutations == nil || got.ContextMutations == nil {
+		t.Fatalf("manifest = %#v", got.ContextManifest)
+	}
+	records := got.ContextMutations.Records()
+	if len(records) != 1 || records[0].Kind != contextfrag.MutationContextViewFallback {
+		t.Fatalf("records = %#v", records)
+	}
+}
+
+func TestLegacyMaterializeQuerySplicesToolUsageBeforeWorkspace(t *testing.T) {
+	t.Parallel()
+	cfg := agentpkg.RunConfig{
+		System:           "base\n\n## Workspace instruction files\n\nworkspace",
+		ContextToolUsage: "## Tool usage\n\nUSE_TOOLS",
+	}
+	got := legacyMaterializeQuery(cfg)
+	if strings.Index(got.System, "## Tool usage") < 0 || strings.Index(got.System, "## Tool usage") > strings.Index(got.System, "## Workspace instruction files") {
+		t.Fatalf("system = %q", got.System)
+	}
+}
+
+func TestLegacyMaterializeQueryPreservesRawMemoryBeforeCurrent(t *testing.T) {
+	t.Parallel()
+	memory := sdk.UserMessage("<memory>raw & unescaped</memory>")
+	cfg := agentpkg.RunConfig{Messages: []sdk.Message{memory}, Query: "current"}
+	got := legacyMaterializeQuery(cfg)
+	assertMessagesEqual(t, got.Messages, []sdk.Message{memory, sdk.UserMessage("current")})
+}

--- a/internal/contextview/provider_fallback_test.go
+++ b/internal/contextview/provider_fallback_test.go
@@ -2,6 +2,7 @@ package contextview
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -31,6 +32,50 @@ func TestProviderViewFallbackKeepsLegacyBytesAndAudit(t *testing.T) {
 	records := got.ContextMutations.Records()
 	if len(records) != 1 || records[0].Kind != contextfrag.MutationContextViewFallback {
 		t.Fatalf("records = %#v", records)
+	}
+}
+
+func TestProviderViewFallbackDropsStaleFragmentOverridesFromAudit(t *testing.T) {
+	t.Parallel()
+	duplicate := systemTextFrag("duplicate", "source ignored", contextfrag.KindSystemPrompt, 20)
+	stale := contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: "message.000", Message: sdk.UserMessage("stale override"), Kind: contextfrag.KindConversationSummary,
+		Slot: contextfrag.SlotHistory, CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustExternal,
+		Source: "compaction_log", Collector: "history_records",
+	})
+	coverage := contextfrag.NewSummaryCoverage(
+		contextfrag.ContextRef{Namespace: "compaction_summary", ID: "summary-1", Schema: contextfrag.SchemaContextRef, Durability: contextfrag.RefDurable},
+		[]contextfrag.ContextRef{{Namespace: "bot_history_message", ID: "row-1", Schema: contextfrag.SchemaContextRef, Durability: contextfrag.RefDurable}},
+	)
+	stale.Coverage = &coverage
+	cfg := agentpkg.RunConfig{
+		System:             "legacy system",
+		Messages:           []sdk.Message{sdk.AssistantMessage("actual history")},
+		ContextFrags:       []contextfrag.ContextFrag{stale},
+		ContextSourceFrags: []contextfrag.ContextFrag{duplicate, duplicate},
+	}
+
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	rendered := contextfrag.Render(got.ContextFrags)
+	if !reflect.DeepEqual(rendered.Messages, got.Messages) {
+		t.Fatalf("fallback audit messages = %#v, emitted messages = %#v", rendered.Messages, got.Messages)
+	}
+	if len(got.ContextManifest.CoverageTrace) != 0 {
+		t.Fatalf("fallback audit retained stale coverage: %#v", got.ContextManifest.CoverageTrace)
+	}
+}
+
+func TestApplyProviderRunConfigAcceptsEmptyProviderInput(t *testing.T) {
+	t.Parallel()
+	got := ApplyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{})
+	if got.System != "" || len(got.Messages) != 0 {
+		t.Fatalf("empty provider bytes changed: system %q messages %#v", got.System, got.Messages)
+	}
+	if got.ContextMutations == nil {
+		t.Fatal("empty provider input did not install a mutation ledger")
+	}
+	if records := got.ContextMutations.Records(); len(records) != 0 {
+		t.Fatalf("empty provider input was classified as fallback: %#v", records)
 	}
 }
 

--- a/internal/contextview/provider_frags_first_test.go
+++ b/internal/contextview/provider_frags_first_test.go
@@ -1,0 +1,126 @@
+package contextview
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+func systemTextFrag(id, text string, kind contextfrag.Kind, priority int) contextfrag.ContextFrag {
+	return contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: id, Text: text, Kind: kind, Role: sdk.MessageRoleSystem, Slot: contextfrag.SlotSystem,
+		Priority: priority, CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustSystem,
+		Source: contextfrag.SourceRunConfig, Collector: "system_sections",
+	})
+}
+
+func currentMessageFrag(id, text string) contextfrag.ContextFrag {
+	return contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: id, Message: sdk.UserMessage(text), Kind: contextfrag.KindCurrentUserMessage,
+		Slot: contextfrag.SlotCurrentUser, Priority: 90, CacheClass: contextfrag.CacheNever,
+		Trust: contextfrag.TrustUser, Source: contextfrag.SourceRunConfig, Collector: currentUserCollectorName,
+		Budget: contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep},
+	})
+}
+
+func stableHistoryMessageFrag(id string, message sdk.Message) contextfrag.ContextFrag {
+	frag := historyMessageFrag(id, message)
+	frag.CacheClass = contextfrag.CacheStable
+	return frag
+}
+
+func fragsFirstFixture() agentpkg.RunConfig {
+	return agentpkg.RunConfig{
+		System: "LEGACY_SYSTEM_IGNORED", Messages: []sdk.Message{sdk.UserMessage("LEGACY_MESSAGE_IGNORED")},
+		ContextSourceFrags: []contextfrag.ContextFrag{
+			systemTextFrag("system.prompt", "base system", contextfrag.KindSystemPrompt, 20),
+			systemTextFrag("system.workspace", "## Workspace instruction files\n\nworkspace", contextfrag.KindWorkspaceInstruction, 50),
+			stableHistoryMessageFrag("message.000", sdk.UserMessage("history")),
+			currentMessageFrag("message.001", "current"),
+		},
+		ContextToolUsage: "## Tool usage\n\nUSE_TOOLS",
+		ContextToolDefs:  []contextfrag.ToolDefAccounting{{Provider: "native", Name: "read", TokenEstimate: 5}},
+	}
+}
+
+func TestApplyProviderRunConfigFragsFirst(t *testing.T) {
+	t.Parallel()
+	got := ApplyProviderRunConfig(context.Background(), nil, fragsFirstFixture())
+	wantSystem := "base system\n\n## Tool usage\n\nUSE_TOOLS\n\n## Workspace instruction files\n\nworkspace"
+	if got.System != wantSystem || strings.Contains(got.System, "LEGACY") {
+		t.Fatalf("system = %q", got.System)
+	}
+	assertMessagesEqual(t, got.Messages, []sdk.Message{sdk.UserMessage("history"), sdk.UserMessage("current")})
+	if len(got.ContextFrags) != 5 {
+		t.Fatalf("frags = %#v", got.ContextFrags)
+	}
+	wantOrder := []string{"system.prompt", "system.tool_usage", "system.workspace", "message.000", "message.001"}
+	for i, id := range wantOrder {
+		if got.ContextFrags[i].ID != id {
+			t.Fatalf("frag order = %#v", got.ContextFrags)
+		}
+	}
+	wantEstimate := 5
+	for _, frag := range got.ContextFrags[:4] {
+		wantEstimate += contextfrag.ResolveFragTokens(frag)
+	}
+	if got.ContextCachePlan.StablePrefixTokenEstimate != wantEstimate || got.ContextCachePlan.StableMessageCount != 1 {
+		t.Fatalf("cache plan = %#v, want estimate %d", got.ContextCachePlan, wantEstimate)
+	}
+}
+
+func TestApplyProviderRunConfigDedupesToolUsage(t *testing.T) {
+	t.Parallel()
+	cfg := fragsFirstFixture()
+	cfg.ContextSourceFrags = append(cfg.ContextSourceFrags, ToolUsageFrag("stale usage", cfg.ContextScope))
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if strings.Contains(got.System, "stale usage") || strings.Count(got.System, "## Tool usage") != 1 {
+		t.Fatalf("system = %q", got.System)
+	}
+}
+
+func TestCollectProviderSourceFragsSplitsWorkspaceAndPreservesMessageOrder(t *testing.T) {
+	t.Parallel()
+	index := 1
+	cfg := agentpkg.RunConfig{
+		System:                         "base\n\n## Workspace instruction files\n\nworkspace",
+		Messages:                       []sdk.Message{sdk.AssistantMessage("before"), sdk.UserMessage("current"), sdk.AssistantMessage("after")},
+		ContextCurrentUserMessageIndex: &index, ContextQueryMaterialized: true,
+	}
+	frags := CollectProviderSourceFrags(context.Background(), cfg)
+	wantIDs := []string{"system.prompt", "system.workspace_instructions", "message.000", "message.001", "message.002"}
+	if len(frags) != len(wantIDs) {
+		t.Fatalf("frags = %#v", frags)
+	}
+	for i, id := range wantIDs {
+		if frags[i].ID != id {
+			t.Fatalf("frag ids = %#v", frags)
+		}
+	}
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if !reflect.DeepEqual(got.Messages, cfg.Messages) {
+		t.Fatalf("messages = %#v, want %#v", got.Messages, cfg.Messages)
+	}
+}
+
+func TestCollectNonSystemProviderSourceFragsExcludesSystem(t *testing.T) {
+	t.Parallel()
+	frags := CollectNonSystemProviderSourceFrags(context.Background(), agentpkg.RunConfig{
+		System: "ignored", Messages: []sdk.Message{sdk.UserMessage("history")}, Query: "  current \n",
+		InlineImages: []sdk.ImagePart{{Image: "data:image/png;base64,abc", MediaType: "image/png"}},
+	})
+	for _, frag := range frags {
+		if frag.Slot == contextfrag.SlotSystem {
+			t.Fatalf("system frag = %#v", frag)
+		}
+	}
+	if len(frags) != 3 || frags[1].ID != "current_user.message" || frags[2].ID != "current_user.images" {
+		t.Fatalf("frags = %#v", frags)
+	}
+}

--- a/internal/contextview/provider_frags_first_test.go
+++ b/internal/contextview/provider_frags_first_test.go
@@ -126,6 +126,86 @@ func TestCollectNonSystemProviderSourceFragsExcludesSystem(t *testing.T) {
 	}
 }
 
+func TestCollectNonSystemProviderSourceFragsSeparatesMemoryFromCurrent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		messages    []sdk.Message
+		current     int
+		memory      int
+		wantFragIDs []string
+	}{
+		{
+			name:        "pipeline current before memory",
+			messages:    []sdk.Message{sdk.UserMessage("current"), sdk.UserMessage("memory recall")},
+			current:     0,
+			memory:      1,
+			wantFragIDs: []string{"message.000", "memory.recall"},
+		},
+		{
+			name:        "legacy memory before materialized current",
+			messages:    []sdk.Message{sdk.AssistantMessage("history"), sdk.UserMessage("memory recall"), sdk.UserMessage("current")},
+			current:     2,
+			memory:      1,
+			wantFragIDs: []string{"message.000", "memory.recall", "message.002"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := agentpkg.RunConfig{
+				Messages:                       tt.messages,
+				ContextCurrentUserMessageIndex: &tt.current,
+				ContextMemoryMessageIndex:      &tt.memory,
+				ContextQueryMaterialized:       true,
+			}
+			cfg.ContextSourceFrags = CollectNonSystemProviderSourceFrags(context.Background(), cfg)
+			if len(cfg.ContextSourceFrags) != len(tt.wantFragIDs) {
+				t.Fatalf("source fragments = %#v", cfg.ContextSourceFrags)
+			}
+			for i, wantID := range tt.wantFragIDs {
+				if cfg.ContextSourceFrags[i].ID != wantID {
+					t.Fatalf("source fragment ids = %#v", cfg.ContextSourceFrags)
+				}
+			}
+
+			currentFrag := cfg.ContextSourceFrags[indexOfFragID(t, cfg.ContextSourceFrags, fmt.Sprintf("message.%03d", tt.current))]
+			if currentFrag.Kind != contextfrag.KindCurrentUserMessage || currentFrag.Slot != contextfrag.SlotCurrentUser || currentFrag.CacheClass != contextfrag.CacheNever {
+				t.Fatalf("current fragment = %#v", currentFrag)
+			}
+			memoryFrag := cfg.ContextSourceFrags[indexOfFragID(t, cfg.ContextSourceFrags, "memory.recall")]
+			if memoryFrag.Kind != contextfrag.KindMemoryRecall || memoryFrag.Slot != contextfrag.SlotHistory || memoryFrag.CacheClass != contextfrag.CacheNever || memoryFrag.Trust != contextfrag.TrustWorkspace {
+				t.Fatalf("memory fragment = %#v", memoryFrag)
+			}
+
+			got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+			if !reflect.DeepEqual(got.Messages, tt.messages) {
+				t.Fatalf("provider messages changed: got %#v want %#v", got.Messages, tt.messages)
+			}
+			if got.ContextCurrentUserMessageIndex == nil || *got.ContextCurrentUserMessageIndex != tt.current {
+				t.Fatalf("current message index = %#v, want %d", got.ContextCurrentUserMessageIndex, tt.current)
+			}
+			if got.ContextMemoryMessageIndex == nil || *got.ContextMemoryMessageIndex != tt.memory {
+				t.Fatalf("memory message index = %#v, want %d", got.ContextMemoryMessageIndex, tt.memory)
+			}
+		})
+	}
+}
+
+func indexOfFragID(t *testing.T, frags []contextfrag.ContextFrag, id string) int {
+	t.Helper()
+	for i, frag := range frags {
+		if frag.ID == id {
+			return i
+		}
+	}
+	t.Fatalf("fragment %q not found in %#v", id, frags)
+	return -1
+}
+
 func TestApplyProviderRunConfigDoesNotAddImplicitToolStripping(t *testing.T) {
 	t.Parallel()
 	for _, messageCount := range []int{10, 11} {

--- a/internal/contextview/provider_frags_first_test.go
+++ b/internal/contextview/provider_frags_first_test.go
@@ -2,6 +2,7 @@ package contextview
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -122,5 +123,30 @@ func TestCollectNonSystemProviderSourceFragsExcludesSystem(t *testing.T) {
 	}
 	if len(frags) != 3 || frags[1].ID != "current_user.message" || frags[2].ID != "current_user.images" {
 		t.Fatalf("frags = %#v", frags)
+	}
+}
+
+func TestApplyProviderRunConfigDoesNotAddImplicitToolStripping(t *testing.T) {
+	t.Parallel()
+	for _, messageCount := range []int{10, 11} {
+		messageCount := messageCount
+		t.Run(fmt.Sprintf("messages_%d", messageCount), func(t *testing.T) {
+			t.Parallel()
+			messages := make([]sdk.Message, 0, messageCount)
+			for i := 0; i < messageCount-2; i++ {
+				messages = append(messages, sdk.UserMessage(fmt.Sprintf("history-%d", i)))
+			}
+			messages = append(messages,
+				assistantToolCallMessage("call-1", "read", "checking"),
+				toolResultMessage("call-1", "read", "exact tool result"),
+			)
+			cfg := agentpkg.RunConfig{System: "system", Messages: messages, ContextQueryMaterialized: true}
+			cfg.ContextSourceFrags = CollectProviderSourceFrags(context.Background(), cfg)
+
+			got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+			if !reflect.DeepEqual(got.Messages, messages) {
+				t.Fatalf("nil tool policy changed %d messages: %#v", messageCount, got.Messages)
+			}
+		})
 	}
 }

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -1,0 +1,307 @@
+package contextview
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+const (
+	sourceFragsCollectorName = "source_frags"
+	toolUsageConflictKey     = "system.tool_usage"
+)
+
+func ProviderRunConfigApplier(logger *slog.Logger) agentpkg.ContextViewApplier {
+	return func(ctx context.Context, cfg agentpkg.RunConfig) agentpkg.RunConfig {
+		return ApplyProviderRunConfig(ctx, logger, cfg)
+	}
+}
+
+// CollectProviderSourceFrags derives typed fragments from already-materialized
+// provider fields. It is the legacy fallback; application code normally
+// supplies typed system sections directly.
+func CollectProviderSourceFrags(ctx context.Context, cfg agentpkg.RunConfig) []contextfrag.ContextFrag {
+	system, err := (&SystemPromptCollector{}).Collect(ctx, CollectRequest{
+		Scope:  cfg.ContextScope,
+		Intent: contextfrag.IntentRunConfigPreProvider,
+		Config: SystemPromptConfig{System: cfg.System, ToolUsage: cfg.ContextToolUsage, SplitWorkspace: true},
+	})
+	if err != nil {
+		return nil
+	}
+	nonSystem := CollectNonSystemProviderSourceFrags(ctx, cfg)
+	if nonSystem == nil {
+		return nil
+	}
+	return append(system, nonSystem...)
+}
+
+// CollectNonSystemProviderSourceFrags preserves the exact SDK message order.
+// A marked current message keeps its original index even though it receives a
+// current-user slot, and raw Query/InlineImages are collected only when the
+// caller has not materialized them yet.
+func CollectNonSystemProviderSourceFrags(ctx context.Context, cfg agentpkg.RunConfig) []contextfrag.ContextFrag {
+	historyConfig := HistoryMessagesConfig{
+		Messages:                cfg.Messages,
+		CurrentUserMessageIndex: cfg.ContextCurrentUserMessageIndex,
+	}
+	history, err := (&HistoryMessagesCollector{}).Collect(ctx, CollectRequest{
+		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider, Config: historyConfig,
+	})
+	if err != nil {
+		return nil
+	}
+	current, err := (&materializedCurrentUserCollector{}).Collect(ctx, CollectRequest{
+		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider, Config: historyConfig,
+	})
+	if err != nil {
+		return nil
+	}
+	messages := append(history, current...)
+	sort.SliceStable(messages, func(i, j int) bool {
+		return messages[i].Provenance.Index < messages[j].Provenance.Index
+	})
+
+	if cfg.ContextQueryMaterialized {
+		return messages
+	}
+	rawCurrent, err := (&CurrentUserCollector{}).Collect(ctx, CollectRequest{
+		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider, Config: CurrentUserConfig{Query: cfg.Query},
+	})
+	if err != nil {
+		return nil
+	}
+	images, err := (&InlineImageCollector{}).Collect(ctx, CollectRequest{
+		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider, Config: InlineImageConfig{Images: cfg.InlineImages},
+	})
+	if err != nil {
+		return nil
+	}
+	messages = append(messages, rawCurrent...)
+	messages = append(messages, images...)
+	return messages
+}
+
+func ToolUsageFrag(usage string, scope contextfrag.Scope) contextfrag.ContextFrag {
+	return contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "system.tool_usage", Kind: contextfrag.KindToolUsage, Role: sdk.MessageRoleSystem,
+		Slot: contextfrag.SlotSystem, Text: usage, Priority: 45, CacheClass: contextfrag.CacheStable,
+		Trust: contextfrag.TrustSystem, Scope: scope, Source: contextfrag.SourceAgentToolUsage,
+		Collector: sourceFragsCollectorName, Render: contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+		ConflictKey: toolUsageConflictKey,
+	})
+}
+
+func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentpkg.RunConfig) agentpkg.RunConfig {
+	ledger := cfg.ContextMutations
+	if ledger == nil {
+		ledger = contextfrag.NewMutationLedger()
+	}
+
+	var frags []contextfrag.ContextFrag
+	if len(cfg.ContextSourceFrags) > 0 {
+		frags = append([]contextfrag.ContextFrag(nil), cfg.ContextSourceFrags...)
+		if usage := strings.TrimSpace(cfg.ContextToolUsage); usage != "" {
+			frags = append(frags, ToolUsageFrag(usage, cfg.ContextScope))
+		}
+	} else {
+		cfg = legacyMaterializeQuery(cfg)
+		frags = CollectProviderSourceFrags(ctx, cfg)
+		if frags == nil {
+			return providerViewFallback(logger, cfg, ledger, "collect_error", "context view collection failed", nil)
+		}
+	}
+
+	registry := NewMapCollectorRegistry(StaticCollector{CollectorName: sourceFragsCollectorName, Frags: frags})
+	builder := NewBuilder(registry, &FragmentSelector{}, StablePrefixPlacer{}, NewMapRendererRegistry(&SDKMessagesRenderer{}))
+	view, err := builder.Build(ctx, BuildInput{
+		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider,
+		Sources:         []SourceSpec{{Name: sourceFragsCollectorName}},
+		Targets:         []contextfrag.RenderTarget{contextfrag.RenderSDKMessages},
+		Budget:          BudgetEnvelope{ToolExchange: cfg.ContextToolExchangePolicy},
+		DynamicMutators: cfg.ContextDynamicMutators,
+	})
+	if err != nil {
+		return providerViewFallback(logger, cfg, ledger, "build_error", "context view build failed", err)
+	}
+	payload, ok := view.Rendered[contextfrag.RenderSDKMessages].Data.(*SDKRenderedPayload)
+	if !ok {
+		return providerViewFallback(logger, cfg, ledger, "unexpected_payload", "context view rendered unexpected payload", nil)
+	}
+
+	plan := cachePlanFromPlacement(view.Placement)
+	plan.StablePrefixTokenEstimate = stablePrefixTokenEstimate(view.Placement, view.Selected, cfg.ContextToolDefs)
+	manifest := view.Manifest
+	manifest.CachePlan = &plan
+	manifest.Mutations = ledger
+	manifest.ToolDefs = append([]contextfrag.ToolDefAccounting(nil), cfg.ContextToolDefs...)
+
+	cfg.System = payload.System
+	cfg.Messages = payload.Messages
+	if hasCurrentUserFrag(view.Selected) {
+		cfg.ContextCurrentUserMessageIndex = latestUserMessageIndex(cfg.Messages)
+	}
+	cfg.ContextQueryMaterialized = true
+	cfg.ContextFrags = view.Selected
+	cfg.ContextManifest = manifest
+	cfg.ContextCachePlan = plan
+	cfg.ContextMutations = ledger
+	return cfg
+}
+
+func providerViewFallback(logger *slog.Logger, cfg agentpkg.RunConfig, ledger *contextfrag.MutationLedger, reason, message string, err error) agentpkg.RunConfig {
+	warnProviderContextView(logger, cfg, message, err)
+	cfg = legacyMaterializeQuery(cfg)
+	cfg = cfg.RefreshContextFrag()
+	ledger.Record(contextfrag.MutationContextViewFallback, reason)
+	plan := contextfrag.CachePlan{}
+	manifest := cfg.ContextManifest
+	manifest.CachePlan = &plan
+	manifest.Mutations = ledger
+	manifest.ToolDefs = append([]contextfrag.ToolDefAccounting(nil), cfg.ContextToolDefs...)
+	cfg.ContextManifest = manifest
+	cfg.ContextCachePlan = plan
+	cfg.ContextMutations = ledger
+	return cfg
+}
+
+func legacyMaterializeQuery(cfg agentpkg.RunConfig) agentpkg.RunConfig {
+	if usage := strings.TrimSpace(cfg.ContextToolUsage); usage != "" && !strings.Contains(cfg.System, usage) {
+		cfg.System = appendToolUsageLegacy(cfg.System, usage)
+	}
+	if cfg.ContextQueryMaterialized {
+		return cfg
+	}
+	cfg.Messages = cloneMessages(cfg.Messages)
+	cfg.ForkContextSourceMessageIDs = append([]string(nil), cfg.ForkContextSourceMessageIDs...)
+	imageParts := make([]sdk.MessagePart, 0, len(cfg.InlineImages))
+	for _, image := range cfg.InlineImages {
+		if strings.TrimSpace(image.Image) != "" {
+			imageParts = append(imageParts, image)
+		}
+	}
+	if cfg.Query != "" {
+		cfg.Messages = append(cfg.Messages, sdk.UserMessage(cfg.Query, imageParts...))
+		cfg.ForkContextSourceMessageIDs = append(cfg.ForkContextSourceMessageIDs, "")
+		index := len(cfg.Messages) - 1
+		cfg.ContextCurrentUserMessageIndex = &index
+		cfg.ContextQueryMaterialized = true
+		return cfg
+	}
+	if len(imageParts) == 0 {
+		return cfg
+	}
+	for i := len(cfg.Messages) - 1; i >= 0; i-- {
+		if cfg.Messages[i].Role != sdk.MessageRoleUser {
+			continue
+		}
+		cfg.Messages[i].Content = append(cfg.Messages[i].Content, imageParts...)
+		if i < len(cfg.ForkContextSourceMessageIDs) {
+			cfg.ForkContextSourceMessageIDs[i] = ""
+		}
+		cfg.ContextCurrentUserMessageIndex = intPointer(i)
+		cfg.ContextQueryMaterialized = true
+		return cfg
+	}
+	cfg.Messages = append(cfg.Messages, sdk.UserMessage("", imageParts...))
+	cfg.ForkContextSourceMessageIDs = append(cfg.ForkContextSourceMessageIDs, "")
+	cfg.ContextCurrentUserMessageIndex = intPointer(len(cfg.Messages) - 1)
+	cfg.ContextQueryMaterialized = true
+	return cfg
+}
+
+func appendToolUsageLegacy(system, usage string) string {
+	system = strings.TrimSpace(system)
+	usage = strings.TrimSpace(usage)
+	if usage == "" {
+		return system
+	}
+	if system == "" {
+		return usage
+	}
+	if index := strings.Index(system, contextfrag.WorkspaceInstructionAnchor); index >= 0 {
+		return strings.TrimSpace(system[:index]) + "\n\n" + usage + "\n" + system[index:]
+	}
+	return strings.TrimSpace(system + "\n\n" + usage)
+}
+
+func cloneMessages(messages []sdk.Message) []sdk.Message {
+	if messages == nil {
+		return nil
+	}
+	out := make([]sdk.Message, len(messages))
+	for i, message := range messages {
+		out[i] = cloneSDKMessage(message)
+	}
+	return out
+}
+
+func cachePlanFromPlacement(placement PlacementPlan) contextfrag.CachePlan {
+	stableMessages := 0
+	for i, item := range placement.Items {
+		if i >= placement.FirstVolatileIndex {
+			break
+		}
+		if item.Slot != contextfrag.SlotSystem {
+			stableMessages++
+		}
+	}
+	return contextfrag.CachePlan{StablePrefixHash: placement.StablePrefixHash, StableMessageCount: stableMessages}
+}
+
+func stablePrefixTokenEstimate(placement PlacementPlan, selected []contextfrag.ContextFrag, toolDefs []contextfrag.ToolDefAccounting) int {
+	total := 0
+	for _, definition := range toolDefs {
+		total += definition.TokenEstimate
+	}
+	byID := make(map[string]contextfrag.ContextFrag, len(selected))
+	for _, frag := range selected {
+		byID[frag.ID] = frag
+	}
+	for i, item := range placement.Items {
+		if i >= placement.FirstVolatileIndex {
+			break
+		}
+		if frag, ok := byID[item.FragID]; ok {
+			total += contextfrag.ResolveFragTokens(frag)
+		}
+	}
+	return total
+}
+
+func latestUserMessageIndex(messages []sdk.Message) *int {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == sdk.MessageRoleUser {
+			return intPointer(i)
+		}
+	}
+	return nil
+}
+
+func hasCurrentUserFrag(frags []contextfrag.ContextFrag) bool {
+	for _, frag := range frags {
+		if frag.Slot == contextfrag.SlotCurrentUser {
+			return true
+		}
+	}
+	return false
+}
+
+func intPointer(value int) *int { return &value }
+
+func warnProviderContextView(logger *slog.Logger, cfg agentpkg.RunConfig, message string, err error) {
+	if logger == nil {
+		return
+	}
+	attrs := []any{slog.String("bot_id", cfg.Identity.BotID), slog.String("session_id", cfg.Identity.SessionID)}
+	if err != nil {
+		attrs = append(attrs, slog.Any("error", err))
+	}
+	logger.Warn(message, attrs...) //nolint:sloglint // message names the exact fallback stage
+}

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -125,7 +125,13 @@ func preserveExplicitHistoryMetadata(collected []contextfrag.ContextFrag, cfg ag
 	for i, frag := range collected {
 		index := frag.Provenance.Index
 		if candidate, ok := overrides[index]; ok && frag.ID == messageFragmentID(index) {
-			collected[i] = candidate
+			frag.Kind = contextfrag.KindConversationSummary
+			frag.Ref = candidate.Ref
+			frag.Coverage = candidate.Coverage
+			frag.Provenance.Source = candidate.Provenance.Source
+			frag.Provenance.SourceID = candidate.Provenance.SourceID
+			frag.Provenance.Collector = candidate.Provenance.Collector
+			collected[i] = frag
 		}
 	}
 	return collected
@@ -136,13 +142,7 @@ func messageFragmentID(index int) string {
 }
 
 func hasExplicitHistoryMetadata(frag contextfrag.ContextFrag) bool {
-	if frag.Coverage != nil || frag.Ref.Durability == contextfrag.RefDurable {
-		return true
-	}
-	source := strings.TrimSpace(frag.Provenance.Source)
-	collector := strings.TrimSpace(frag.Provenance.Collector)
-	return (source != "" && source != contextfrag.SourceRunConfig) ||
-		(collector != "" && collector != contextfrag.CollectorRunConfigFields && collector != historyMessagesCollectorName)
+	return frag.Kind == contextfrag.KindConversationSummary && frag.Coverage != nil && frag.Ref.Durability == contextfrag.RefDurable
 }
 
 func singleSDKMessage(frag contextfrag.ContextFrag) (sdk.Message, bool) {

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -63,7 +63,8 @@ func CollectNonSystemProviderSourceFrags(ctx context.Context, cfg agentpkg.RunCo
 	if err != nil {
 		return nil
 	}
-	messages := append(history, current...)
+	messages := append([]contextfrag.ContextFrag(nil), history...)
+	messages = append(messages, current...)
 	sort.SliceStable(messages, func(i, j int) bool {
 		return messages[i].Provenance.Index < messages[j].Provenance.Index
 	})

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -2,7 +2,9 @@ package contextview
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -39,7 +41,10 @@ func CollectProviderSourceFrags(ctx context.Context, cfg agentpkg.RunConfig) []c
 	if nonSystem == nil {
 		return nil
 	}
-	return append(system, nonSystem...)
+	frags := make([]contextfrag.ContextFrag, 0, len(system)+len(nonSystem))
+	frags = append(frags, system...)
+	frags = append(frags, nonSystem...)
+	return frags
 }
 
 // CollectNonSystemProviderSourceFrags preserves the exact SDK message order.
@@ -63,8 +68,10 @@ func CollectNonSystemProviderSourceFrags(ctx context.Context, cfg agentpkg.RunCo
 	if err != nil {
 		return nil
 	}
-	messages := append([]contextfrag.ContextFrag(nil), history...)
+	messages := make([]contextfrag.ContextFrag, 0, len(history)+len(current))
+	messages = append(messages, history...)
 	messages = append(messages, current...)
+	messages = preserveExplicitHistoryMetadata(messages, cfg)
 	sort.SliceStable(messages, func(i, j int) bool {
 		return messages[i].Provenance.Index < messages[j].Provenance.Index
 	})
@@ -87,6 +94,76 @@ func CollectNonSystemProviderSourceFrags(ctx context.Context, cfg agentpkg.RunCo
 	messages = append(messages, rawCurrent...)
 	messages = append(messages, images...)
 	return messages
+}
+
+func preserveExplicitHistoryMetadata(collected []contextfrag.ContextFrag, cfg agentpkg.RunConfig) []contextfrag.ContextFrag {
+	if len(collected) == 0 || len(cfg.ContextFrags) == 0 || len(cfg.Messages) == 0 {
+		return collected
+	}
+	currentIndex, hasCurrent := markedCurrentUserMessageIndex(cfg.Messages, cfg.ContextCurrentUserMessageIndex)
+	overrides := make(map[int]contextfrag.ContextFrag)
+	for _, candidate := range cfg.ContextFrags {
+		index := candidate.Provenance.Index
+		if candidate.Slot != contextfrag.SlotHistory || index < 0 || index >= len(cfg.Messages) {
+			continue
+		}
+		if hasCurrent && index == currentIndex {
+			continue
+		}
+		if candidate.ID != messageFragmentID(index) || !hasExplicitHistoryMetadata(candidate) {
+			continue
+		}
+		message, ok := singleSDKMessage(candidate)
+		if !ok || !reflect.DeepEqual(message, cfg.Messages[index]) {
+			continue
+		}
+		overrides[index] = candidate
+	}
+	if len(overrides) == 0 {
+		return collected
+	}
+	for i, frag := range collected {
+		index := frag.Provenance.Index
+		if candidate, ok := overrides[index]; ok && frag.ID == messageFragmentID(index) {
+			collected[i] = candidate
+		}
+	}
+	return collected
+}
+
+func messageFragmentID(index int) string {
+	return fmt.Sprintf("message.%03d", index)
+}
+
+func hasExplicitHistoryMetadata(frag contextfrag.ContextFrag) bool {
+	if frag.Coverage != nil || frag.Ref.Durability == contextfrag.RefDurable {
+		return true
+	}
+	source := strings.TrimSpace(frag.Provenance.Source)
+	collector := strings.TrimSpace(frag.Provenance.Collector)
+	return (source != "" && source != contextfrag.SourceRunConfig) ||
+		(collector != "" && collector != contextfrag.CollectorRunConfigFields && collector != historyMessagesCollectorName)
+}
+
+func singleSDKMessage(frag contextfrag.ContextFrag) (sdk.Message, bool) {
+	var message *sdk.Message
+	for _, part := range frag.Parts {
+		if part.Type != contextfrag.PartSDKMessage {
+			continue
+		}
+		candidate := part.SDKMessage
+		if candidate == nil {
+			candidate = part.Message
+		}
+		if candidate == nil || message != nil {
+			return sdk.Message{}, false
+		}
+		message = candidate
+	}
+	if message == nil {
+		return sdk.Message{}, false
+	}
+	return *message, true
 }
 
 func ToolUsageFrag(usage string, scope contextfrag.Scope) contextfrag.ContextFrag {
@@ -159,6 +236,8 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 func providerViewFallback(logger *slog.Logger, cfg agentpkg.RunConfig, ledger *contextfrag.MutationLedger, reason, message string, err error) agentpkg.RunConfig {
 	warnProviderContextView(logger, cfg, message, err)
 	cfg = legacyMaterializeQuery(cfg)
+	cfg.ContextFrags = nil
+	cfg.ContextSourceFrags = nil
 	cfg = cfg.RefreshContextFrag()
 	ledger.Record(contextfrag.MutationContextViewFallback, reason)
 	plan := contextfrag.CachePlan{}

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -55,6 +55,7 @@ func CollectNonSystemProviderSourceFrags(ctx context.Context, cfg agentpkg.RunCo
 	historyConfig := HistoryMessagesConfig{
 		Messages:                cfg.Messages,
 		CurrentUserMessageIndex: cfg.ContextCurrentUserMessageIndex,
+		MemoryMessageIndex:      cfg.ContextMemoryMessageIndex,
 	}
 	history, err := (&HistoryMessagesCollector{}).Collect(ctx, CollectRequest{
 		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider, Config: historyConfig,
@@ -68,8 +69,20 @@ func CollectNonSystemProviderSourceFrags(ctx context.Context, cfg agentpkg.RunCo
 	if err != nil {
 		return nil
 	}
-	messages := make([]contextfrag.ContextFrag, 0, len(history)+len(current))
+	var memory []contextfrag.ContextFrag
+	if index, ok := markedMemoryMessageIndex(cfg.Messages, cfg.ContextMemoryMessageIndex); ok {
+		message := cfg.Messages[index]
+		memory, err = (&MemoryContextCollector{}).Collect(ctx, CollectRequest{
+			Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider,
+			Config: MemoryContextConfig{Message: &message, Index: index},
+		})
+		if err != nil {
+			return nil
+		}
+	}
+	messages := make([]contextfrag.ContextFrag, 0, len(history)+len(memory)+len(current))
 	messages = append(messages, history...)
+	messages = append(messages, memory...)
 	messages = append(messages, current...)
 	messages = preserveExplicitHistoryMetadata(messages, cfg)
 	sort.SliceStable(messages, func(i, j int) bool {
@@ -100,7 +113,8 @@ func preserveExplicitHistoryMetadata(collected []contextfrag.ContextFrag, cfg ag
 	if len(collected) == 0 || len(cfg.ContextFrags) == 0 || len(cfg.Messages) == 0 {
 		return collected
 	}
-	currentIndex, hasCurrent := markedCurrentUserMessageIndex(cfg.Messages, cfg.ContextCurrentUserMessageIndex)
+	memoryIndex, hasMemory := markedMemoryMessageIndex(cfg.Messages, cfg.ContextMemoryMessageIndex)
+	currentIndex, hasCurrent := markedCurrentUserMessageIndex(cfg.Messages, cfg.ContextCurrentUserMessageIndex, optionalIndex(memoryIndex, hasMemory)...)
 	overrides := make(map[int]contextfrag.ContextFrag)
 	for _, candidate := range cfg.ContextFrags {
 		index := candidate.Provenance.Index
@@ -222,8 +236,19 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 
 	cfg.System = payload.System
 	cfg.Messages = payload.Messages
-	if hasCurrentUserFrag(view.Selected) {
-		cfg.ContextCurrentUserMessageIndex = latestUserMessageIndex(cfg.Messages)
+	ordered, err := orderedSelectedFrags(view.Selected, view.Placement)
+	if err != nil {
+		return providerViewFallback(logger, cfg, ledger, "placement_error", "context view placement invalid after render", err)
+	}
+	currentIndex, memoryIndex := renderedSpecialMessageIndexes(ordered)
+	cfg.ContextMemoryMessageIndex = memoryIndex
+	switch {
+	case currentIndex != nil:
+		cfg.ContextCurrentUserMessageIndex = currentIndex
+	case hasCurrentUserFrag(view.Selected):
+		cfg.ContextCurrentUserMessageIndex = latestUserMessageIndex(cfg.Messages, optionalPointerValue(memoryIndex)...)
+	default:
+		cfg.ContextCurrentUserMessageIndex = nil
 	}
 	cfg.ContextQueryMaterialized = true
 	cfg.ContextFrags = view.Selected
@@ -355,13 +380,42 @@ func stablePrefixTokenEstimate(placement PlacementPlan, selected []contextfrag.C
 	return total
 }
 
-func latestUserMessageIndex(messages []sdk.Message) *int {
+func latestUserMessageIndex(messages []sdk.Message, excluded ...int) *int {
 	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role == sdk.MessageRoleUser {
+		if messages[i].Role == sdk.MessageRoleUser && !containsIndex(excluded, i) {
 			return intPointer(i)
 		}
 	}
 	return nil
+}
+
+func renderedSpecialMessageIndexes(frags []contextfrag.ContextFrag) (current, memory *int) {
+	messageIndex := 0
+	for _, frag := range frags {
+		if frag.Slot == contextfrag.SlotSystem {
+			continue
+		}
+		for _, part := range frag.Parts {
+			if part.Type != contextfrag.PartSDKMessage || sdkMessagePart(part) == nil {
+				continue
+			}
+			switch {
+			case frag.Kind == contextfrag.KindMemoryRecall:
+				memory = intPointer(messageIndex)
+			case frag.Kind == contextfrag.KindCurrentUserMessage || frag.Slot == contextfrag.SlotCurrentUser:
+				current = intPointer(messageIndex)
+			}
+			messageIndex++
+		}
+	}
+	return current, memory
+}
+
+func optionalPointerValue(value *int) []int {
+	if value == nil {
+		return nil
+	}
+	return []int{*value}
 }
 
 func hasCurrentUserFrag(frags []contextfrag.ContextFrag) bool {

--- a/internal/contextview/provider_run_config_test.go
+++ b/internal/contextview/provider_run_config_test.go
@@ -41,6 +41,50 @@ func TestApplyProviderRunConfigProducesManifestLedgerAndCachePlan(t *testing.T) 
 	}
 }
 
+func TestApplyProviderRunConfigMergesOnlyMatchingHistoryAuditMetadata(t *testing.T) {
+	t.Parallel()
+	message := sdk.UserMessage("summary bytes")
+	ref := contextfrag.ContextRef{
+		Namespace: "compaction_log", ID: "compact-1", Version: 1,
+		Schema: contextfrag.SchemaContextRef, Durability: contextfrag.RefDurable,
+	}
+	coverage := contextfrag.NewSummaryCoverage(ref, []contextfrag.ContextRef{{
+		Namespace: "bot_history_message", ID: "row-1", Schema: contextfrag.SchemaContextRef, Durability: contextfrag.RefDurable,
+	}})
+	shadow := contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: "message.000", Message: message, Kind: contextfrag.KindConversationSummary,
+		Slot: contextfrag.SlotHistory, CacheClass: contextfrag.CacheNever, Trust: contextfrag.TrustSystem,
+		Scope: contextfrag.Scope{CurrentMessageID: "stale"}, Source: "compaction_log", SourceID: "compact-1",
+		Collector: "history_records", Budget: contextfrag.BudgetPolicy{MaxChars: 1, Overflow: contextfrag.OverflowDrop},
+	})
+	shadow.Ref = ref
+	shadow.Coverage = &coverage
+	shadow.ConflictKey = "stale-policy"
+	shadow.Parts = append(shadow.Parts, contextfrag.Part{Type: contextfrag.PartText, Text: "untrusted extra part"})
+	scope := contextfrag.Scope{BotID: "bot-1", CurrentMessageID: "current"}
+	cfg := agentpkg.RunConfig{
+		Messages: []sdk.Message{message}, ContextFrags: []contextfrag.ContextFrag{shadow},
+		ContextScope: scope, ContextQueryMaterialized: true,
+	}
+	cfg.ContextSourceFrags = CollectNonSystemProviderSourceFrags(context.Background(), cfg)
+
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if !reflect.DeepEqual(got.Messages, cfg.Messages) {
+		t.Fatalf("shadow policy changed provider messages: got %#v want %#v", got.Messages, cfg.Messages)
+	}
+	if len(got.ContextFrags) != 1 {
+		t.Fatalf("provider fragments = %#v, want one history fragment", got.ContextFrags)
+	}
+	merged := got.ContextFrags[0]
+	if merged.Kind != contextfrag.KindConversationSummary || merged.Coverage == nil || merged.Ref.ID != ref.ID {
+		t.Fatalf("matching audit metadata was not preserved: %#v", merged)
+	}
+	if merged.Budget != (contextfrag.BudgetPolicy{}) || merged.ConflictKey != "" || merged.CacheClass != contextfrag.CacheStable ||
+		merged.Trust != contextfrag.TrustExternal || merged.Scope.CurrentMessageID != scope.CurrentMessageID || len(merged.Parts) != 1 {
+		t.Fatalf("shadow selection/render policy leaked into authoritative fragment: %#v", merged)
+	}
+}
+
 func TestProviderRunConfigApplierUsesInjectedLoggerShape(t *testing.T) {
 	t.Parallel()
 	applier := ProviderRunConfigApplier(nil)

--- a/internal/contextview/provider_run_config_test.go
+++ b/internal/contextview/provider_run_config_test.go
@@ -1,0 +1,51 @@
+package contextview
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+func TestApplyProviderRunConfigProducesManifestLedgerAndCachePlan(t *testing.T) {
+	t.Parallel()
+	ledger := contextfrag.NewMutationLedger()
+	cfg := agentpkg.RunConfig{
+		System: "system", Messages: []sdk.Message{sdk.UserMessage("history")}, Query: "current",
+		ContextMutations:       ledger,
+		ContextToolDefs:        []contextfrag.ToolDefAccounting{{Provider: "native", Name: "read", TokenEstimate: 7}},
+		ContextDynamicMutators: []contextfrag.DynamicMutator{contextfrag.DynamicMutatorPromptCache},
+	}
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if got.ContextMutations != ledger || got.ContextManifest.Mutations != ledger {
+		t.Fatal("mutation ledger pointer was not preserved")
+	}
+	if got.ContextManifest.CachePlan == nil || *got.ContextManifest.CachePlan != got.ContextCachePlan {
+		t.Fatalf("cache plan = %#v, field = %#v", got.ContextManifest.CachePlan, got.ContextCachePlan)
+	}
+	if len(got.ContextManifest.ToolDefs) != 1 || got.ContextManifest.ToolDefs[0].Name != "read" {
+		t.Fatalf("tool definitions = %#v", got.ContextManifest.ToolDefs)
+	}
+	if !reflect.DeepEqual(got.ContextManifest.DynamicMutators, cfg.ContextDynamicMutators) {
+		t.Fatalf("dynamic mutators = %#v", got.ContextManifest.DynamicMutators)
+	}
+	if got.ContextCachePlan.StableMessageCount != 1 {
+		t.Fatalf("stable messages = %d, want history only", got.ContextCachePlan.StableMessageCount)
+	}
+	if got.ContextCachePlan.StablePrefixTokenEstimate <= 7 {
+		t.Fatalf("stable prefix estimate = %d, want tool defs plus fragments", got.ContextCachePlan.StablePrefixTokenEstimate)
+	}
+}
+
+func TestProviderRunConfigApplierUsesInjectedLoggerShape(t *testing.T) {
+	t.Parallel()
+	applier := ProviderRunConfigApplier(nil)
+	got := applier(context.Background(), agentpkg.RunConfig{System: "system", Query: "query"})
+	if got.System != "system" || len(got.Messages) != 1 {
+		t.Fatalf("got = %#v", got)
+	}
+}

--- a/internal/contextview/render_sdk.go
+++ b/internal/contextview/render_sdk.go
@@ -1,0 +1,204 @@
+package contextview
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+type SDKRenderedPayload struct {
+	System       string
+	Messages     []sdk.Message
+	Query        string
+	InlineImages []sdk.ImagePart
+}
+
+type SDKMessagesRenderer struct{}
+
+func (*SDKMessagesRenderer) Target() contextfrag.RenderTarget {
+	return contextfrag.RenderSDKMessages
+}
+
+func (*SDKMessagesRenderer) Render(_ context.Context, input RenderInput) (RenderedPayload, error) {
+	ordered, err := orderedSelectedFrags(input.Selected, input.Placement)
+	if err != nil {
+		return RenderedPayload{}, err
+	}
+	payload := &SDKRenderedPayload{}
+	firstSystem := true
+	for _, frag := range sortSystemFragsByPriority(ordered) {
+		switch frag.Slot {
+		case contextfrag.SlotSystem:
+			if !firstSystem {
+				payload.System += "\n\n"
+			}
+			firstSystem = false
+			for _, part := range frag.Parts {
+				if part.Type == contextfrag.PartText {
+					payload.System += part.Text
+				}
+			}
+		case contextfrag.SlotCurrentUser:
+			renderCurrentUserFrag(payload, frag)
+		default:
+			renderMessageFrag(payload, frag)
+		}
+	}
+	materializeRenderedCurrent(payload)
+	hash, err := sdkRenderedPayloadHash(payload)
+	if err != nil {
+		return RenderedPayload{}, err
+	}
+	return RenderedPayload{Target: contextfrag.RenderSDKMessages, ContentHash: hash, Data: payload}, nil
+}
+
+func orderedSelectedFrags(selected []contextfrag.ContextFrag, placement PlacementPlan) ([]contextfrag.ContextFrag, error) {
+	if len(placement.Items) == 0 {
+		if len(selected) != 0 {
+			return nil, fmt.Errorf("placement is empty for %d selected fragments", len(selected))
+		}
+		return nil, nil
+	}
+	if len(placement.Items) != len(selected) {
+		return nil, fmt.Errorf("placement item count %d does not match selected fragment count %d", len(placement.Items), len(selected))
+	}
+	byID := make(map[string]contextfrag.ContextFrag, len(selected))
+	for _, frag := range selected {
+		if _, exists := byID[frag.ID]; exists {
+			return nil, fmt.Errorf("selected fragments contain duplicate id %q", frag.ID)
+		}
+		byID[frag.ID] = frag
+	}
+	ordered := make([]contextfrag.ContextFrag, 0, len(selected))
+	seen := make(map[string]bool, len(selected))
+	for _, item := range placement.Items {
+		if seen[item.FragID] {
+			return nil, fmt.Errorf("placement contains duplicate fragment %q", item.FragID)
+		}
+		seen[item.FragID] = true
+		frag, ok := byID[item.FragID]
+		if !ok {
+			return nil, fmt.Errorf("placement references unknown fragment %q", item.FragID)
+		}
+		ordered = append(ordered, frag)
+	}
+	return ordered, nil
+}
+
+func renderCurrentUserFrag(payload *SDKRenderedPayload, frag contextfrag.ContextFrag) {
+	for _, part := range frag.Parts {
+		switch part.Type {
+		case contextfrag.PartText:
+			payload.Query = part.Text
+		case contextfrag.PartImage:
+			if image := sdkImagePart(part); image != nil && strings.TrimSpace(image.Image) != "" {
+				payload.InlineImages = append(payload.InlineImages, *image)
+			}
+		case contextfrag.PartSDKMessage:
+			if msg := sdkMessagePart(part); msg != nil {
+				payload.Messages = append(payload.Messages, cloneSDKMessage(*msg))
+			}
+		}
+	}
+}
+
+func renderMessageFrag(payload *SDKRenderedPayload, frag contextfrag.ContextFrag) {
+	for _, part := range frag.Parts {
+		if part.Type == contextfrag.PartSDKMessage {
+			if msg := sdkMessagePart(part); msg != nil {
+				payload.Messages = append(payload.Messages, cloneSDKMessage(*msg))
+			}
+		}
+	}
+}
+
+func materializeRenderedCurrent(payload *SDKRenderedPayload) {
+	images := make([]sdk.MessagePart, 0, len(payload.InlineImages))
+	for _, image := range payload.InlineImages {
+		if strings.TrimSpace(image.Image) != "" {
+			images = append(images, image)
+		}
+	}
+	if payload.Query != "" {
+		payload.Messages = append(payload.Messages, sdk.UserMessage(payload.Query, images...))
+		payload.Query = ""
+		payload.InlineImages = nil
+		return
+	}
+	if len(images) == 0 {
+		return
+	}
+	for i := len(payload.Messages) - 1; i >= 0; i-- {
+		if payload.Messages[i].Role == sdk.MessageRoleUser {
+			payload.Messages[i].Content = append(payload.Messages[i].Content, images...)
+			payload.InlineImages = nil
+			return
+		}
+	}
+	payload.Messages = append(payload.Messages, sdk.UserMessage("", images...))
+	payload.InlineImages = nil
+}
+
+func sdkMessagePart(part contextfrag.Part) *sdk.Message {
+	if part.SDKMessage != nil {
+		return part.SDKMessage
+	}
+	return part.Message
+}
+
+func sdkImagePart(part contextfrag.Part) *sdk.ImagePart {
+	if part.SDKImage != nil {
+		return part.SDKImage
+	}
+	return part.ImagePart
+}
+
+func cloneSDKMessage(msg sdk.Message) sdk.Message {
+	out := msg
+	out.Content = append([]sdk.MessagePart(nil), msg.Content...)
+	return out
+}
+
+func sdkRenderedPayloadHash(payload *SDKRenderedPayload) (string, error) {
+	raw, err := json.Marshal(struct {
+		System       string          `json:"system"`
+		Messages     []sdk.Message   `json:"messages"`
+		Query        string          `json:"query"`
+		InlineImages []sdk.ImagePart `json:"inline_images"`
+	}{payload.System, payload.Messages, payload.Query, payload.InlineImages})
+	if err != nil {
+		return "", fmt.Errorf("marshal sdk rendered payload: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func sortSystemFragsByPriority(ordered []contextfrag.ContextFrag) []contextfrag.ContextFrag {
+	systemFrags := make([]contextfrag.ContextFrag, 0, 4)
+	nonSystemFrags := make([]contextfrag.ContextFrag, 0, len(ordered))
+	for _, frag := range ordered {
+		if frag.Slot == contextfrag.SlotSystem {
+			systemFrags = append(systemFrags, frag)
+		} else {
+			nonSystemFrags = append(nonSystemFrags, frag)
+		}
+	}
+	if len(systemFrags) == 0 {
+		return ordered
+	}
+	sort.SliceStable(systemFrags, func(i, j int) bool {
+		return systemFrags[i].Priority < systemFrags[j].Priority
+	})
+	out := make([]contextfrag.ContextFrag, 0, len(ordered))
+	out = append(out, systemFrags...)
+	out = append(out, nonSystemFrags...)
+	return out
+}

--- a/internal/contextview/render_sdk.go
+++ b/internal/contextview/render_sdk.go
@@ -32,6 +32,15 @@ func (*SDKMessagesRenderer) Render(_ context.Context, input RenderInput) (Render
 	if err != nil {
 		return RenderedPayload{}, err
 	}
+	payload := renderSDKPayloadFromFrags(ordered)
+	hash, err := sdkRenderedPayloadHash(payload)
+	if err != nil {
+		return RenderedPayload{}, err
+	}
+	return RenderedPayload{Target: contextfrag.RenderSDKMessages, ContentHash: hash, Data: payload}, nil
+}
+
+func renderSDKPayloadFromFrags(ordered []contextfrag.ContextFrag) *SDKRenderedPayload {
 	payload := &SDKRenderedPayload{}
 	firstSystem := true
 	for _, frag := range ordered {
@@ -53,11 +62,7 @@ func (*SDKMessagesRenderer) Render(_ context.Context, input RenderInput) (Render
 		}
 	}
 	materializeRenderedCurrent(payload)
-	hash, err := sdkRenderedPayloadHash(payload)
-	if err != nil {
-		return RenderedPayload{}, err
-	}
-	return RenderedPayload{Target: contextfrag.RenderSDKMessages, ContentHash: hash, Data: payload}, nil
+	return payload
 }
 
 func orderedSelectedFrags(selected []contextfrag.ContextFrag, placement PlacementPlan) ([]contextfrag.ContextFrag, error) {

--- a/internal/contextview/render_sdk.go
+++ b/internal/contextview/render_sdk.go
@@ -34,7 +34,7 @@ func (*SDKMessagesRenderer) Render(_ context.Context, input RenderInput) (Render
 	}
 	payload := &SDKRenderedPayload{}
 	firstSystem := true
-	for _, frag := range sortSystemFragsByPriority(ordered) {
+	for _, frag := range ordered {
 		switch frag.Slot {
 		case contextfrag.SlotSystem:
 			if !firstSystem {

--- a/internal/contextview/render_sdk_test.go
+++ b/internal/contextview/render_sdk_test.go
@@ -1,0 +1,121 @@
+package contextview
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestSDKRendererPreservesSystemSectionBytes(t *testing.T) {
+	t.Parallel()
+	frags := []contextfrag.ContextFrag{
+		{
+			ID: "sys.1", Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem,
+			Slot: contextfrag.SlotSystem, Priority: 20, Trust: contextfrag.TrustSystem,
+			Parts: []contextfrag.Part{{Type: contextfrag.PartText, Text: "  first\n"}},
+		},
+		{
+			ID: "sys.2", Kind: contextfrag.KindBotIdentity, Role: sdk.MessageRoleSystem,
+			Slot: contextfrag.SlotSystem, Priority: 40, Trust: contextfrag.TrustSystem,
+			Parts: []contextfrag.Part{{Type: contextfrag.PartText, Text: ""}},
+		},
+		{
+			ID: "sys.3", Kind: contextfrag.KindHookContext, Role: sdk.MessageRoleSystem,
+			Slot: contextfrag.SlotSystem, Priority: 80, Trust: contextfrag.TrustSystem,
+			Parts: []contextfrag.Part{{Type: contextfrag.PartText, Text: " hook tail "}},
+		},
+	}
+	payload, _ := renderSDKPayload(t, frags, placementFor(frags))
+	if payload.System != "  first\n\n\n\n\n hook tail " {
+		t.Fatalf("system = %q", payload.System)
+	}
+}
+
+func TestSDKRendererPreservesMessagesAndMaterializesRawCurrentInput(t *testing.T) {
+	t.Parallel()
+	query := "  current request \n"
+	images := []sdk.ImagePart{{Image: "data:image/png;base64,abc", MediaType: "image/png"}}
+	frags := []contextfrag.ContextFrag{
+		messageFrag("history", sdk.AssistantMessage("answer")),
+		contextfrag.MessageFrag(contextfrag.MessageFragInput{ID: "current", Message: sdk.UserMessage(query), Kind: contextfrag.KindCurrentUserMessage, Slot: contextfrag.SlotCurrentUser}),
+		contextfrag.ImageFrag("images", images, contextfrag.Scope{}, contextfrag.SourceRunConfig),
+	}
+	payload, _ := renderSDKPayload(t, frags, placementFor(frags))
+	want := []sdk.Message{sdk.AssistantMessage("answer"), sdk.UserMessage(query, images[0])}
+	assertMessagesEqual(t, payload.Messages, want)
+	if payload.Query != "" || len(payload.InlineImages) != 0 {
+		t.Fatalf("unmaterialized current input: %#v", payload)
+	}
+}
+
+func TestSDKRendererImageOnlyInputInjectsLatestUser(t *testing.T) {
+	t.Parallel()
+	image := sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"}
+	frags := []contextfrag.ContextFrag{
+		messageFrag("user", sdk.UserMessage("pipeline query")),
+		messageFrag("assistant", sdk.AssistantMessage("working")),
+		contextfrag.ImageFrag("images", []sdk.ImagePart{image}, contextfrag.Scope{}, contextfrag.SourceRunConfig),
+	}
+	payload, _ := renderSDKPayload(t, frags, placementFor(frags))
+	assertMessagesEqual(t, payload.Messages, []sdk.Message{
+		sdk.UserMessage("pipeline query", image),
+		sdk.AssistantMessage("working"),
+	})
+}
+
+func TestSDKRendererValidatesPlacementAndHashesDeterministically(t *testing.T) {
+	t.Parallel()
+	frag := textFrag("system", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "system")
+	first, firstHash := renderSDKPayload(t, []contextfrag.ContextFrag{frag}, placementFor([]contextfrag.ContextFrag{frag}))
+	second, secondHash := renderSDKPayload(t, []contextfrag.ContextFrag{frag}, placementFor([]contextfrag.ContextFrag{frag}))
+	if firstHash == "" || firstHash != secondHash || !reflect.DeepEqual(first, second) {
+		t.Fatalf("first = %#v (%q), second = %#v (%q)", first, firstHash, second, secondHash)
+	}
+	_, err := (&SDKMessagesRenderer{}).Render(context.Background(), RenderInput{Selected: []contextfrag.ContextFrag{frag}})
+	if err == nil {
+		t.Fatal("expected missing placement error")
+	}
+}
+
+func renderSDKPayload(t *testing.T, frags []contextfrag.ContextFrag, placement PlacementPlan) (*SDKRenderedPayload, string) {
+	t.Helper()
+	rendered, err := (&SDKMessagesRenderer{}).Render(context.Background(), RenderInput{
+		Intent: contextfrag.IntentRunConfigPreProvider, Selected: frags, Placement: placement, Target: contextfrag.RenderSDKMessages,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, ok := rendered.Data.(*SDKRenderedPayload)
+	if !ok {
+		t.Fatalf("payload type = %T", rendered.Data)
+	}
+	return payload, rendered.ContentHash
+}
+
+func placementFor(frags []contextfrag.ContextFrag) PlacementPlan {
+	items := make([]PlacementItem, len(frags))
+	for i, frag := range frags {
+		items[i] = PlacementItem{FragID: frag.ID, Slot: frag.Slot, Position: i, CacheHint: frag.CacheClass, Ref: frag.Ref}
+	}
+	return PlacementPlan{Items: items, FirstVolatileIndex: len(items)}
+}
+
+func assertMessagesEqual(t *testing.T, got, want []sdk.Message) {
+	t.Helper()
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotJSON) != string(wantJSON) {
+		t.Fatalf("messages = %s, want %s", gotJSON, wantJSON)
+	}
+}

--- a/internal/contextview/selector.go
+++ b/internal/contextview/selector.go
@@ -1,0 +1,127 @@
+package contextview
+
+import contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+
+type FragmentSelector struct{}
+
+func (*FragmentSelector) ProfileFor(intent contextfrag.Intent) IntentProfile {
+	if intent != contextfrag.IntentRunConfigPreProvider {
+		return IntentProfile{Intent: intent}
+	}
+	return IntentProfile{
+		Intent:          intent,
+		MustKeepSlots:   []contextfrag.Slot{contextfrag.SlotSystem, contextfrag.SlotCurrentUser},
+		SlotTrustFloors: map[contextfrag.Slot]contextfrag.TrustLevel{contextfrag.SlotSystem: contextfrag.TrustWorkspace},
+	}
+}
+
+func (*FragmentSelector) Select(frags []contextfrag.ContextFrag, profile IntentProfile, budget BudgetEnvelope) SelectionResult {
+	collected := len(frags)
+	selected, gated := applyTrustGate(frags, profile)
+	selected, superseded := resolveConflictGroups(selected)
+	selected, budgetDropped, edits, warnings := enforceFragBudgets(selected, profile)
+	selected, exchangeDropped, exchangeEdits := applyToolExchangePolicy(selected, budget.ToolExchange)
+
+	result := SelectionResult{
+		Selected: selected,
+		Edited:   append(edits, exchangeEdits...),
+		Warnings: warnings,
+		Summary: SelectionSummary{
+			TotalCollected: collected,
+			TotalSelected:  len(selected),
+		},
+	}
+	for _, frag := range gated {
+		result.recordDrop(frag, "trust_gate:"+string(frag.Slot)+"_requires_"+string(profile.SlotTrustFloors[frag.Slot]))
+	}
+	for _, loser := range superseded {
+		result.recordDrop(loser.frag, "precedence:superseded_by_"+loser.winnerID)
+	}
+	for _, dropped := range budgetDropped {
+		result.recordDrop(dropped.frag, dropped.reason)
+	}
+	for _, frag := range exchangeDropped {
+		result.recordDrop(frag, toolExchangeDropReason)
+	}
+	result.Summary.TotalDropped = len(result.Dropped)
+	return result
+}
+
+func (r *SelectionResult) recordDrop(frag contextfrag.ContextFrag, reason string) {
+	r.Dropped = append(r.Dropped, frag)
+	r.Summary.DropReasons = append(r.Summary.DropReasons, DropRecord{
+		FragID: frag.ID,
+		Ref:    frag.Ref,
+		Reason: reason,
+	})
+}
+
+func applyTrustGate(frags []contextfrag.ContextFrag, profile IntentProfile) ([]contextfrag.ContextFrag, []contextfrag.ContextFrag) {
+	if len(profile.SlotTrustFloors) == 0 {
+		return frags, nil
+	}
+	kept := make([]contextfrag.ContextFrag, 0, len(frags))
+	var dropped []contextfrag.ContextFrag
+	for _, frag := range frags {
+		floor, ok := profile.SlotTrustFloors[frag.Slot]
+		if ok && contextfrag.TrustRank(frag.Trust) < contextfrag.TrustRank(floor) {
+			dropped = append(dropped, frag)
+			continue
+		}
+		kept = append(kept, frag)
+	}
+	return kept, dropped
+}
+
+type conflictLoser struct {
+	frag     contextfrag.ContextFrag
+	winnerID string
+}
+
+func resolveConflictGroups(frags []contextfrag.ContextFrag) ([]contextfrag.ContextFrag, []conflictLoser) {
+	winners := make(map[string]int)
+	for i, frag := range frags {
+		if frag.ConflictKey == "" {
+			continue
+		}
+		current, ok := winners[frag.ConflictKey]
+		if !ok || conflictBeats(frag, frags[current]) {
+			winners[frag.ConflictKey] = i
+		}
+	}
+	if len(winners) == 0 {
+		return frags, nil
+	}
+	kept := make([]contextfrag.ContextFrag, 0, len(frags))
+	var losers []conflictLoser
+	for i, frag := range frags {
+		if frag.ConflictKey != "" && winners[frag.ConflictKey] != i {
+			losers = append(losers, conflictLoser{frag: frag, winnerID: frags[winners[frag.ConflictKey]].ID})
+			continue
+		}
+		kept = append(kept, frag)
+	}
+	return kept, losers
+}
+
+func conflictBeats(challenger, incumbent contextfrag.ContextFrag) bool {
+	if challengerScope, incumbentScope := challenger.Scope.SpecificityRank(), incumbent.Scope.SpecificityRank(); challengerScope != incumbentScope {
+		return challengerScope > incumbentScope
+	}
+	if challengerTrust, incumbentTrust := contextfrag.TrustRank(challenger.Trust), contextfrag.TrustRank(incumbent.Trust); challengerTrust != incumbentTrust {
+		return challengerTrust > incumbentTrust
+	}
+	return true
+}
+
+func isMustKeepFrag(frag contextfrag.ContextFrag, profile IntentProfile) bool {
+	if frag.Budget.Overflow == contextfrag.OverflowKeep {
+		return true
+	}
+	for _, slot := range profile.MustKeepSlots {
+		if frag.Slot == slot {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/contextview/selector_frag_budget.go
+++ b/internal/contextview/selector_frag_budget.go
@@ -1,0 +1,203 @@
+package contextview
+
+import (
+	"encoding/json"
+	"fmt"
+	"unicode/utf8"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/textutil"
+)
+
+const fragBudgetTokenByteFactor = contextfrag.EstimateBytesPerToken
+
+type fragBudgetDrop struct {
+	frag   contextfrag.ContextFrag
+	reason string
+}
+
+func enforceFragBudgets(frags []contextfrag.ContextFrag, profile IntentProfile) (kept []contextfrag.ContextFrag, dropped []fragBudgetDrop, edits []contextfrag.ContextEditTrace, warnings []contextfrag.ValidationWarning) {
+	kept = make([]contextfrag.ContextFrag, 0, len(frags))
+	for _, frag := range frags {
+		reason, exceeded := fragBudgetExceeded(frag)
+		if !exceeded || frag.Budget.Overflow == contextfrag.OverflowKeep {
+			kept = append(kept, frag)
+			continue
+		}
+		switch frag.Budget.Overflow {
+		case contextfrag.OverflowDrop:
+			switch {
+			case isToolExchangeFrag(frag):
+				kept = append(kept, frag)
+				warnings = append(warnings, contextfrag.ValidationWarning{Code: "frag_budget_drop_blocked_tool_closure", Ref: frag.Ref})
+			case isMustKeepFrag(frag, profile):
+				kept = append(kept, frag)
+				warnings = append(warnings, contextfrag.ValidationWarning{Code: "frag_budget_drop_blocked_must_keep", Ref: frag.Ref})
+			default:
+				dropped = append(dropped, fragBudgetDrop{frag: frag, reason: reason})
+			}
+		case contextfrag.OverflowTrim:
+			trimmed, ok := trimFragText(frag)
+			if !ok {
+				kept = append(kept, frag)
+				warnings = append(warnings, contextfrag.ValidationWarning{Code: "overflow_trim_unsupported", Ref: frag.Ref})
+				continue
+			}
+			kept = append(kept, trimmed)
+			edits = append(edits, fragBudgetTrimEdit(trimmed))
+		case contextfrag.OverflowSummarize:
+			kept = append(kept, frag)
+			warnings = append(warnings, contextfrag.ValidationWarning{Code: "overflow_summarize_unsupported", Ref: frag.Ref})
+		default:
+			kept = append(kept, frag)
+		}
+	}
+	return kept, dropped, edits, warnings
+}
+
+func fragBudgetExceeded(frag contextfrag.ContextFrag) (string, bool) {
+	if frag.Budget.MaxTokens > 0 && contextfrag.ResolveFragTokens(frag) > frag.Budget.MaxTokens {
+		return "frag_budget:max_tokens", true
+	}
+	if frag.Budget.MaxChars > 0 && fragCharCount(frag) > frag.Budget.MaxChars {
+		return "frag_budget:max_chars", true
+	}
+	return "", false
+}
+
+func fragCharCount(frag contextfrag.ContextFrag) int {
+	total := 0
+	for _, part := range frag.Parts {
+		switch part.Type {
+		case contextfrag.PartText:
+			total += utf8.RuneCountInString(part.Text)
+		case contextfrag.PartSDKMessage:
+			msg := contextfrag.FragMessage(contextfrag.ContextFrag{Parts: []contextfrag.Part{part}})
+			if msg == nil {
+				continue
+			}
+			for _, messagePart := range msg.Content {
+				switch typed := messagePart.(type) {
+				case sdk.TextPart:
+					total += utf8.RuneCountInString(typed.Text)
+				case sdk.ReasoningPart:
+					total += utf8.RuneCountInString(typed.Text)
+				case sdk.ImagePart:
+				default:
+					if data, err := json.Marshal(messagePart); err == nil {
+						total += utf8.RuneCountInString(string(data))
+					}
+				}
+			}
+		}
+	}
+	return total
+}
+
+func trimFragText(frag contextfrag.ContextFrag) (contextfrag.ContextFrag, bool) {
+	if len(frag.Parts) == 0 {
+		return frag, false
+	}
+	for _, part := range frag.Parts {
+		if part.Type != contextfrag.PartText {
+			return frag, false
+		}
+	}
+	charLimit, tokenByteLimit := fragTrimLimit(frag.Budget)
+	parts := frag.Parts
+	changed := false
+	if charLimit > 0 {
+		if next, ok := trimPartsToLimit(parts, charLimit, false); ok {
+			parts, changed = next, true
+		}
+	}
+	if tokenByteLimit > 0 {
+		if next, ok := trimPartsToLimit(parts, tokenByteLimit, true); ok {
+			parts, changed = next, true
+		}
+	}
+	if !changed {
+		return frag, false
+	}
+	frag.Parts = parts
+	frag.TokenEstimate = 0
+	frag.Ref.HashAlgo = ""
+	frag.Ref.HashScope = ""
+	frag.Ref.ContentHash = ""
+	return contextfrag.WithContextRef(frag, frag.Ref), true
+}
+
+func fragTrimLimit(budget contextfrag.BudgetPolicy) (charLimit, tokenByteLimit int) {
+	if budget.MaxChars > 0 {
+		charLimit = budget.MaxChars
+	}
+	if budget.MaxTokens > 0 {
+		tokenByteLimit = budget.MaxTokens * fragBudgetTokenByteFactor
+	}
+	return charLimit, tokenByteLimit
+}
+
+func trimPartsToLimit(parts []contextfrag.Part, limit int, byBytes bool) ([]contextfrag.Part, bool) {
+	originalBytes := 0
+	for _, part := range parts {
+		originalBytes += len(part.Text)
+	}
+	marker := fmt.Sprintf("[trimmed from %d bytes]", originalBytes)
+	contentLimit := limit
+	appendMarker := limit > len(marker)
+	if appendMarker {
+		contentLimit -= len(marker)
+	}
+	next := append([]contextfrag.Part(nil), parts...)
+	remaining := contentLimit
+	changed := false
+	lastChanged := -1
+	for i, part := range next {
+		kept := textutil.TruncateRunes(part.Text, remaining)
+		if byBytes {
+			kept = safeUTF8BytePrefix(part.Text, remaining)
+		}
+		if kept != part.Text {
+			changed = true
+			lastChanged = i
+		}
+		if byBytes {
+			remaining -= len(kept)
+		} else {
+			remaining -= utf8.RuneCountInString(kept)
+		}
+		next[i].Text = kept
+	}
+	if !changed {
+		return parts, false
+	}
+	if appendMarker {
+		next[lastChanged].Text += marker
+	}
+	return next, true
+}
+
+func fragBudgetTrimEdit(frag contextfrag.ContextFrag) contextfrag.ContextEditTrace {
+	return contextfrag.ContextEditTrace{
+		EditID: "frag_budget.trim." + frag.ID,
+		Op:     contextfrag.EditReplace,
+		Slot:   frag.Slot,
+		Refs:   []contextfrag.ContextRef{frag.Ref},
+	}
+}
+
+func safeUTF8BytePrefix(value string, maxBytes int) string {
+	if maxBytes <= 0 || value == "" {
+		return ""
+	}
+	if maxBytes >= len(value) {
+		return value
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return value[:cut]
+}

--- a/internal/contextview/selector_frag_budget_test.go
+++ b/internal/contextview/selector_frag_budget_test.go
@@ -3,20 +3,39 @@ package contextview
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 )
 
-func TestFragBudgetDropsOversizedDroppableFragment(t *testing.T) {
+func TestFragBudgetDropsOversizedFragEvenWithoutEnvelopeBudget(t *testing.T) {
 	t.Parallel()
 	selector := &FragmentSelector{}
-	frag := textFrag("oversized", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, strings.Repeat("x", 40))
-	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 5, Overflow: contextfrag.OverflowDrop}
-	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
-	if len(result.Selected) != 0 || len(result.Dropped) != 1 || result.Summary.DropReasons[0].Reason != "frag_budget:max_chars" {
+	oversized := messageFrag("oversized", sdk.AssistantMessage(strings.Repeat("x", 400)))
+	oversized.Budget = contextfrag.BudgetPolicy{MaxTokens: 1, Overflow: contextfrag.OverflowDrop}
+	result := selector.Select([]contextfrag.ContextFrag{
+		messageFrag("plain", sdk.AssistantMessage("plain content")),
+		oversized,
+	}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 || result.Selected[0].ID != "plain" || len(result.Dropped) != 1 || result.Summary.DropReasons[0].Reason != "frag_budget:max_tokens" {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestFragBudgetTrimsPureTextFragOverMaxChars(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frag := textFrag("long", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, strings.Repeat("a", 50))
+	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 30, Overflow: contextfrag.OverflowTrim}
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 || len(result.Edited) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	text := result.Selected[0].Parts[0].Text
+	if !strings.HasPrefix(text, strings.Repeat("a", 7)) || !strings.Contains(text, "[trimmed from 50 bytes]") || utf8.RuneCountInString(text) > frag.Budget.MaxChars {
+		t.Fatalf("trimmed text = %q", text)
 	}
 }
 
@@ -51,6 +70,112 @@ func TestFragBudgetKeepsMustKeepSlotAndWarns(t *testing.T) {
 	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 1, Overflow: contextfrag.OverflowDrop}
 	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
 	if len(result.Selected) != 1 || len(result.Warnings) != 1 || result.Warnings[0].Code != "frag_budget_drop_blocked_must_keep" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestFragBudgetTrimRespectsMaxTokensIncludingMarker(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frag := textFrag("long", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, strings.Repeat("z", 200))
+	frag.Budget = contextfrag.BudgetPolicy{MaxTokens: 10, Overflow: contextfrag.OverflowTrim}
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 {
+		t.Fatalf("selected = %d", len(result.Selected))
+	}
+	text := result.Selected[0].Parts[0].Text
+	if !strings.Contains(text, "[trimmed from 200 bytes]") || len(text) > frag.Budget.MaxTokens*fragBudgetTokenByteFactor {
+		t.Fatalf("trimmed text = %q", text)
+	}
+}
+
+func TestFragBudgetSummarizeKeepsAndWarns(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frag := textFrag("summary", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, strings.Repeat("s", 50))
+	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 5, Overflow: contextfrag.OverflowSummarize}
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 || result.Selected[0].Parts[0].Text != strings.Repeat("s", 50) ||
+		len(result.Warnings) != 1 || result.Warnings[0].Code != "overflow_summarize_unsupported" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestFragBudgetUnderLimitIsNoop(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	within := textFrag("within", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, "short")
+	within.Budget = contextfrag.BudgetPolicy{MaxChars: 100, Overflow: contextfrag.OverflowDrop}
+	noLimit := textFrag("no-limit", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, strings.Repeat("n", 500))
+	result := selector.Select([]contextfrag.ContextFrag{within, noLimit}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 2 || len(result.Dropped) != 0 || len(result.Edited) != 0 || len(result.Warnings) != 0 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestFragBudgetDropProtectsToolClosure(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	resultFrag := historyMessageFrag("result", toolResultMessage("call-1", "calc", strings.Repeat("r", 400)))
+	resultFrag.Budget = contextfrag.BudgetPolicy{MaxTokens: 1, Overflow: contextfrag.OverflowDrop}
+	result := selector.Select([]contextfrag.ContextFrag{
+		historyMessageFrag("call", assistantToolCallMessage("call-1", "calc", "")),
+		resultFrag,
+	}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 2 || len(result.Warnings) != 1 || result.Warnings[0].Code != "frag_budget_drop_blocked_tool_closure" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestFragBudgetCountsNonTextToolResultForMaxChars(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	resultFrag := historyMessageFrag("result", toolResultMessage("call-1", "calc", strings.Repeat("r", 400)))
+	resultFrag.Budget = contextfrag.BudgetPolicy{MaxChars: 5, Overflow: contextfrag.OverflowDrop}
+	result := selector.Select([]contextfrag.ContextFrag{
+		historyMessageFrag("call", assistantToolCallMessage("call-1", "calc", "")),
+		resultFrag,
+	}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Warnings) != 1 || result.Warnings[0].Code != "frag_budget_drop_blocked_tool_closure" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestFragBudgetUnsupportedMessageTrimKeepsAndWarns(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frag := messageFrag("message", sdk.AssistantMessage(strings.Repeat("m", 50)))
+	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 5, Overflow: contextfrag.OverflowTrim}
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 || len(result.Warnings) != 1 || result.Warnings[0].Code != "overflow_trim_unsupported" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestFragBudgetEnforcesBothCharacterAndTokenDimensions(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	original := strings.Repeat("m", 100)
+	frag := textFrag("both", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, original)
+	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 1000, MaxTokens: 10, Overflow: contextfrag.OverflowTrim}
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	text := result.Selected[0].Parts[0].Text
+	if len(text) > frag.Budget.MaxTokens*fragBudgetTokenByteFactor || utf8.RuneCountInString(text) > frag.Budget.MaxChars {
+		t.Fatalf("trimmed text = %q", text)
+	}
+	if text == original {
+		t.Fatal("MaxTokens did not trim while MaxChars remained under limit")
+	}
+}
+
+func TestFragBudgetOverflowKeepIgnoresConfiguredLimits(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	want := strings.Repeat("k", 50)
+	frag := textFrag("pinned", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, want)
+	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 1, MaxTokens: 1, Overflow: contextfrag.OverflowKeep}
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 || result.Selected[0].Parts[0].Text != want || len(result.Warnings) != 0 || len(result.Edited) != 0 {
 		t.Fatalf("result = %#v", result)
 	}
 }

--- a/internal/contextview/selector_frag_budget_test.go
+++ b/internal/contextview/selector_frag_budget_test.go
@@ -1,0 +1,56 @@
+package contextview
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestFragBudgetDropsOversizedDroppableFragment(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frag := textFrag("oversized", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, strings.Repeat("x", 40))
+	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 5, Overflow: contextfrag.OverflowDrop}
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 0 || len(result.Dropped) != 1 || result.Summary.DropReasons[0].Reason != "frag_budget:max_chars" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestFragBudgetTrimRefreshesAccountingAndHash(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frag := textFrag("trimmed", contextfrag.SlotHistory, contextfrag.KindConversationEvent, sdk.MessageRoleAssistant, strings.Repeat("z", 80))
+	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 30, Overflow: contextfrag.OverflowTrim}
+	frag.TokenEstimate = 999
+	frag = contextfrag.WithContextRef(frag, frag.Ref)
+	originalHash := frag.Ref.ContentHash
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 || len(result.Edited) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	trimmed := result.Selected[0]
+	if trimmed.TokenEstimate != 0 {
+		t.Fatalf("token estimate = %d, want recomputation", trimmed.TokenEstimate)
+	}
+	if trimmed.Ref.ContentHash == "" || trimmed.Ref.ContentHash == originalHash {
+		t.Fatalf("content hash = %q, original = %q", trimmed.Ref.ContentHash, originalHash)
+	}
+	if len(trimmed.Parts[0].Text) > frag.Budget.MaxChars {
+		t.Fatalf("trimmed text = %q", trimmed.Parts[0].Text)
+	}
+}
+
+func TestFragBudgetKeepsMustKeepSlotAndWarns(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frag := textFrag("current", contextfrag.SlotCurrentUser, contextfrag.KindCurrentUserMessage, sdk.MessageRoleUser, strings.Repeat("u", 40))
+	frag.Budget = contextfrag.BudgetPolicy{MaxChars: 1, Overflow: contextfrag.OverflowDrop}
+	result := selector.Select([]contextfrag.ContextFrag{frag}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 || len(result.Warnings) != 1 || result.Warnings[0].Code != "frag_budget_drop_blocked_must_keep" {
+		t.Fatalf("result = %#v", result)
+	}
+}

--- a/internal/contextview/selector_precedence_test.go
+++ b/internal/contextview/selector_precedence_test.go
@@ -1,0 +1,56 @@
+package contextview
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func conflictFrag(id, key string, trust contextfrag.TrustLevel, scope contextfrag.Scope) contextfrag.ContextFrag {
+	return contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID:          id,
+		Kind:        contextfrag.KindSystemPolicy,
+		Role:        sdk.MessageRoleSystem,
+		Slot:        contextfrag.SlotSystem,
+		Text:        id,
+		Trust:       trust,
+		Scope:       scope,
+		Source:      "test",
+		Collector:   "test",
+		ConflictKey: key,
+	})
+}
+
+func TestConflictGroupClosestScopeWins(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frags := []contextfrag.ContextFrag{
+		conflictFrag("policy.bot", "policy", contextfrag.TrustSystem, contextfrag.Scope{BotID: "b"}),
+		conflictFrag("policy.session", "policy", contextfrag.TrustSystem, contextfrag.Scope{BotID: "b", ChatID: "c", SessionID: "s"}),
+		conflictFrag("other", "", contextfrag.TrustSystem, contextfrag.Scope{BotID: "b"}),
+	}
+	result := selector.Select(frags, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 2 || result.Selected[0].ID != "policy.session" || result.Selected[1].ID != "other" {
+		t.Fatalf("selected = %#v", result.Selected)
+	}
+	if len(result.Summary.DropReasons) != 1 || !strings.HasPrefix(result.Summary.DropReasons[0].Reason, "precedence:") {
+		t.Fatalf("drop reasons = %#v", result.Summary.DropReasons)
+	}
+}
+
+func TestConflictGroupTrustThenCollectionBreakTies(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	scope := contextfrag.Scope{BotID: "b", SessionID: "s"}
+	result := selector.Select([]contextfrag.ContextFrag{
+		conflictFrag("workspace", "identity", contextfrag.TrustWorkspace, scope),
+		conflictFrag("system.old", "identity", contextfrag.TrustSystem, scope),
+		conflictFrag("system.new", "identity", contextfrag.TrustSystem, scope),
+	}, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 1 || result.Selected[0].ID != "system.new" {
+		t.Fatalf("selected = %#v", result.Selected)
+	}
+}

--- a/internal/contextview/selector_tool_exchange.go
+++ b/internal/contextview/selector_tool_exchange.go
@@ -1,0 +1,139 @@
+package contextview
+
+import (
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	userinput "github.com/memohai/memoh/internal/agent/decision/input"
+)
+
+const toolExchangeDropReason = "tool_exchange:stripped"
+
+func applyToolExchangePolicy(frags []contextfrag.ContextFrag, policy *contextfrag.ToolExchangePolicy) (kept, dropped []contextfrag.ContextFrag, edits []contextfrag.ContextEditTrace) {
+	if policy == nil || policy.MinMessages > 0 && countMessageFrags(frags) <= policy.MinMessages {
+		return frags, nil, nil
+	}
+	kept = make([]contextfrag.ContextFrag, 0, len(frags))
+	for _, frag := range frags {
+		msg := contextfrag.FragMessage(frag)
+		if msg == nil || frag.Slot != contextfrag.SlotHistory {
+			kept = append(kept, frag)
+			continue
+		}
+		switch msg.Role {
+		case sdk.MessageRoleTool:
+			results := askUserToolResults(msg.Content)
+			if len(results) == 0 {
+				dropped = append(dropped, frag)
+				continue
+			}
+			if len(results) != len(msg.Content) {
+				frag = rebuildMessageFrag(frag, sdk.Message{Role: sdk.MessageRoleTool, Content: results})
+				edits = append(edits, toolExchangeEdit(frag))
+			}
+			kept = append(kept, frag)
+		case sdk.MessageRoleAssistant:
+			parts, changed := stripAssistantToolParts(msg.Content)
+			if !changed {
+				kept = append(kept, frag)
+				continue
+			}
+			if len(parts) == 0 {
+				dropped = append(dropped, frag)
+				continue
+			}
+			frag = rebuildMessageFrag(frag, sdk.Message{Role: sdk.MessageRoleAssistant, Content: parts})
+			edits = append(edits, toolExchangeEdit(frag))
+			kept = append(kept, frag)
+		default:
+			kept = append(kept, frag)
+		}
+	}
+	return kept, dropped, edits
+}
+
+func countMessageFrags(frags []contextfrag.ContextFrag) int {
+	count := 0
+	for _, frag := range frags {
+		if contextfrag.FragMessage(frag) != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func askUserToolResults(parts []sdk.MessagePart) []sdk.MessagePart {
+	kept := make([]sdk.MessagePart, 0, len(parts))
+	for _, part := range parts {
+		result, ok := part.(sdk.ToolResultPart)
+		if ok && strings.EqualFold(strings.TrimSpace(result.ToolName), userinput.ToolNameAskUser) {
+			kept = append(kept, result)
+		}
+	}
+	return kept
+}
+
+func stripAssistantToolParts(parts []sdk.MessagePart) ([]sdk.MessagePart, bool) {
+	kept := make([]sdk.MessagePart, 0, len(parts))
+	changed := false
+	for _, part := range parts {
+		switch typed := part.(type) {
+		case sdk.ToolCallPart:
+			if strings.EqualFold(strings.TrimSpace(typed.ToolName), userinput.ToolNameAskUser) {
+				kept = append(kept, typed)
+			} else {
+				changed = true
+			}
+		case sdk.ToolResultPart, sdk.ReasoningPart:
+			changed = true
+		case sdk.TextPart:
+			if strings.TrimSpace(typed.Text) == "" {
+				changed = true
+			} else {
+				kept = append(kept, typed)
+			}
+		default:
+			kept = append(kept, part)
+		}
+	}
+	return kept, changed
+}
+
+func rebuildMessageFrag(frag contextfrag.ContextFrag, msg sdk.Message) contextfrag.ContextFrag {
+	conflictKey := frag.ConflictKey
+	frag = contextfrag.RebuildFragMessage(frag, msg)
+	frag.ConflictKey = conflictKey
+	frag.TokenEstimate = 0
+	frag.Ref.HashAlgo = ""
+	frag.Ref.HashScope = ""
+	frag.Ref.ContentHash = ""
+	return contextfrag.WithContextRef(frag, frag.Ref)
+}
+
+func toolExchangeEdit(frag contextfrag.ContextFrag) contextfrag.ContextEditTrace {
+	return contextfrag.ContextEditTrace{
+		EditID: "tool_exchange.strip." + frag.ID,
+		Op:     contextfrag.EditReplace,
+		Slot:   frag.Slot,
+		Refs:   []contextfrag.ContextRef{frag.Ref},
+	}
+}
+
+func isToolExchangeFrag(frag contextfrag.ContextFrag) bool {
+	msg := contextfrag.FragMessage(frag)
+	if msg == nil {
+		return false
+	}
+	if msg.Role == sdk.MessageRoleTool {
+		return true
+	}
+	for _, part := range msg.Content {
+		switch part.(type) {
+		case sdk.ToolCallPart, sdk.ToolResultPart:
+			return true
+		}
+	}
+	return false
+}

--- a/internal/contextview/selector_tool_exchange_test.go
+++ b/internal/contextview/selector_tool_exchange_test.go
@@ -1,0 +1,64 @@
+package contextview
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	userinput "github.com/memohai/memoh/internal/agent/decision/input"
+)
+
+func historyMessageFrag(id string, msg sdk.Message) contextfrag.ContextFrag {
+	return contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: id, Message: msg, Kind: contextfrag.KindConversationEvent, Slot: contextfrag.SlotHistory,
+		Scope: contextfrag.Scope{BotID: "bot-1"}, Source: "run_config_fields", Collector: "history_messages",
+	})
+}
+
+func toolExchangeFixture() []contextfrag.ContextFrag {
+	return []contextfrag.ContextFrag{
+		historyMessageFrag("h0", sdk.UserMessage("question")),
+		historyMessageFrag("h1", assistantToolCallMessage("call-1", "web_search", "let me look")),
+		historyMessageFrag("h2", toolResultMessage("call-1", "web_search", "bulky result")),
+		historyMessageFrag("h3", assistantToolCallMessage("ask-1", userinput.ToolNameAskUser, "")),
+		historyMessageFrag("h4", toolResultMessage("ask-1", userinput.ToolNameAskUser, "user picked B")),
+		historyMessageFrag("h5", sdk.AssistantMessage("final answer")),
+	}
+}
+
+func TestToolExchangePolicyStripsBulkyExchangesAndKeepsAskUser(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	result := selector.Select(toolExchangeFixture(), selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{ToolExchange: &contextfrag.ToolExchangePolicy{}})
+	ids := make(map[string]bool)
+	for _, frag := range result.Selected {
+		ids[frag.ID] = true
+		if frag.ID == "h1" {
+			for _, part := range contextfrag.FragMessage(frag).Content {
+				if call, ok := part.(sdk.ToolCallPart); ok && !strings.EqualFold(call.ToolName, userinput.ToolNameAskUser) {
+					t.Fatalf("tool call survived: %#v", call)
+				}
+			}
+		}
+	}
+	if ids["h2"] || !ids["h3"] || !ids["h4"] || !ids["h0"] || !ids["h5"] {
+		t.Fatalf("selected ids = %#v", ids)
+	}
+	if len(result.Edited) == 0 || len(result.Dropped) != 1 || result.Summary.DropReasons[0].Reason != toolExchangeDropReason {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestToolExchangePolicyThresholdAndNilPreserveEverything(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+	for _, budget := range []BudgetEnvelope{{}, {ToolExchange: &contextfrag.ToolExchangePolicy{MinMessages: 10}}} {
+		result := selector.Select(toolExchangeFixture(), profile, budget)
+		if len(result.Selected) != 6 || len(result.Dropped) != 0 || len(result.Edited) != 0 {
+			t.Fatalf("budget = %#v, result = %#v", budget, result)
+		}
+	}
+}

--- a/internal/contextview/spawn_frags_first_test.go
+++ b/internal/contextview/spawn_frags_first_test.go
@@ -1,0 +1,44 @@
+package contextview_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
+	"github.com/memohai/memoh/internal/contextview"
+)
+
+func TestSpawnFragmentsRenderLegacyProviderBytes(t *testing.T) {
+	t.Parallel()
+	index := 1
+	rc := agentpkg.RunConfig{
+		System: agentpkg.SpawnSystemPrompt(sessionmode.Subagent), SessionType: sessionmode.Subagent,
+		Messages:                       []sdk.Message{sdk.UserMessage("history"), sdk.UserMessage("  current  ")},
+		ContextCurrentUserMessageIndex: &index, ContextQueryMaterialized: true,
+	}
+	rc.ContextSourceFrags = agentpkg.SpawnContextSourceFrags(rc)
+	wantSystem := rc.System
+	wantMessages := rc.Messages
+
+	got := contextview.ApplyProviderRunConfig(context.Background(), nil, rc)
+	if got.System != wantSystem || !reflect.DeepEqual(got.Messages, wantMessages) {
+		t.Fatalf("spawn provider bytes changed: system %q messages %#v", got.System, got.Messages)
+	}
+}
+
+func TestSpawnCustomSystemFallbackPreservesExactBytes(t *testing.T) {
+	t.Parallel()
+	rc := agentpkg.RunConfig{
+		System: "  custom spawn system\n", SessionType: sessionmode.Subagent,
+		Messages: []sdk.Message{sdk.UserMessage("history")}, ContextQueryMaterialized: true,
+	}
+	rc.ContextSourceFrags = agentpkg.SpawnContextSourceFrags(rc)
+	got := contextview.ApplyProviderRunConfig(context.Background(), nil, rc)
+	if got.System != rc.System || !reflect.DeepEqual(got.Messages, rc.Messages) {
+		t.Fatalf("custom spawn fallback changed bytes: system %q messages %#v", got.System, got.Messages)
+	}
+}

--- a/internal/contextview/trust_gate_test.go
+++ b/internal/contextview/trust_gate_test.go
@@ -1,0 +1,27 @@
+package contextview
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestTrustGateRejectsExternalSystemAuthority(t *testing.T) {
+	t.Parallel()
+	selector := &FragmentSelector{}
+	frags := []contextfrag.ContextFrag{
+		contextfrag.TextFrag(contextfrag.TextFragInput{ID: "system", Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem, Slot: contextfrag.SlotSystem, Text: "system", Trust: contextfrag.TrustSystem}),
+		contextfrag.TextFrag(contextfrag.TextFragInput{ID: "injected", Kind: contextfrag.KindSystemPolicy, Role: sdk.MessageRoleSystem, Slot: contextfrag.SlotSystem, Text: "injected", Trust: contextfrag.TrustExternal}),
+		contextfrag.MessageFrag(contextfrag.MessageFragInput{ID: "history", Message: sdk.UserMessage("history"), Kind: contextfrag.KindConversationEvent, Slot: contextfrag.SlotHistory, Trust: contextfrag.TrustExternal}),
+	}
+	result := selector.Select(frags, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{})
+	if len(result.Selected) != 2 || result.Selected[0].ID != "system" || result.Selected[1].ID != "history" {
+		t.Fatalf("selected = %#v", result.Selected)
+	}
+	if len(result.Summary.DropReasons) != 1 || !strings.HasPrefix(result.Summary.DropReasons[0].Reason, "trust_gate:") {
+		t.Fatalf("drop reasons = %#v", result.Summary.DropReasons)
+	}
+}

--- a/internal/contextview/types.go
+++ b/internal/contextview/types.go
@@ -1,0 +1,90 @@
+package contextview
+
+import contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+
+type BuildInput struct {
+	Scope           contextfrag.Scope
+	Intent          contextfrag.Intent
+	Sources         []SourceSpec
+	Targets         []contextfrag.RenderTarget
+	Budget          BudgetEnvelope
+	DynamicMutators []contextfrag.DynamicMutator
+	Options         BuildOptions
+}
+
+type SourceSpec struct {
+	Name   string
+	Config any
+}
+
+// BudgetEnvelope carries independently configured fragment policies. The
+// caller remains responsible for the already-materialized history window.
+type BudgetEnvelope struct {
+	ToolExchange *contextfrag.ToolExchangePolicy
+}
+
+type BuildOptions struct {
+	DryRun bool
+}
+
+type ContextView struct {
+	Intent      contextfrag.Intent
+	SourceFrags []contextfrag.ContextFrag
+	Selected    []contextfrag.ContextFrag
+	Placement   PlacementPlan
+	Manifest    contextfrag.Manifest
+	Rendered    map[contextfrag.RenderTarget]RenderedPayload
+	Trace       BuildTrace
+}
+
+type RenderedPayload struct {
+	Target      contextfrag.RenderTarget
+	ContentHash string
+	Data        any
+}
+
+type PlacementPlan struct {
+	StablePrefixHash   string
+	FirstVolatileIndex int
+	Items              []PlacementItem
+}
+
+type PlacementItem struct {
+	FragID    string
+	Slot      contextfrag.Slot
+	Position  int
+	CacheHint contextfrag.CacheClass
+	Ref       contextfrag.ContextRef
+}
+
+type BuildTrace struct {
+	CollectDurations map[string]int64
+	SelectionSummary SelectionSummary
+	PlacementSummary PlacementSummary
+	RenderSummaries  map[contextfrag.RenderTarget]RenderSummary
+	Warnings         []contextfrag.ValidationWarning
+}
+
+type SelectionSummary struct {
+	TotalCollected int
+	TotalSelected  int
+	TotalDropped   int
+	DropReasons    []DropRecord
+}
+
+type DropRecord struct {
+	FragID string
+	Ref    contextfrag.ContextRef
+	Reason string
+}
+
+type PlacementSummary struct {
+	StablePrefixFrags int
+	DynamicFrags      int
+}
+
+type RenderSummary struct {
+	Target      contextfrag.RenderTarget
+	ContentHash string
+	ItemCount   int
+}


### PR DESCRIPTION

## What changes

Typed context fragments are now the authoritative input to the normal native provider path. The application builds source fragments once, the context view selects and renders them, and the native runtime uses that rendered `System` and `Messages` payload.

This is a provider-visible zero-behavior-change refactor. The rendered payload is byte-identical to the legacy assembly at restack base `0265158c5`. Focused equivalence tests cover system prompts, history, memory, hook text, tool usage, images, PDF file parts, fallback behavior, and stable cache prefixes.

## Scope

This PR contains the fragment IR, native provider compiler, collectors, rendering, audit metadata, and thin application/runtime wiring. It does not add context budget allocation, retention/drop policy, capability gating, typed discuss or ACP transport, provider-attempt reselection, or lifecycle persistence.

This is part 1 of the landing stack motivated by #890. It establishes the typed compiler that later PRs use, but does not close #890.

## Restack notes

The restack keeps newer upstream behavior: first-wins duplicate-tool registration, live-subagent persistence and observation, immutable workdirs, interrupted-step checkpoints, file-input routing, injection ownership, and the model-relative compaction controller. Restack-specific regressions verify that prepended subagent fork context cannot steal the current-user marker and that PDF `FilePart` payloads survive the typed render unchanged.

## Verification

The following checks passed on `cbfc18336`:

- `go build ./...`
- `go test -count=1 ./...`
- `golangci-lint run` on all touched Go packages
- Focused fragment, provider-view, native-runtime, application, tool, and core suites
- Provider byte-equivalence and system-prompt parity suites, including all five session modes
- `git diff --check 0265158c5..HEAD`

## Landing stack

| PR | Scope |
| --- | --- |
| PR1 | Fragments-first authoritative compiler with byte-equivalent provider output |
| PR2 | System-section retention, drop policy, grouped rendering, and capability gating |
| PR3 | Unified `ContextBudgetPlan` and budget-aware behavior for all five modes |
| PR4 | Hook authority split and provider-attempt preflight |
| PR5 | Runtime decision correctness and fencing for #865 |
| PR6 | Run-keyed lifecycle persistence and read ownership |
| PR7 | Prompt shrink, baselines, and repository-level gates |
| PR8 | Cross-stack lifecycle, budget, fallback, and tool-roster integration seams |