### PR TITLE
fix(runtime): durable decision parking and terminal outcome correctness

### DIFF
--- a/internal/agent/application/runtime_decision.go
+++ b/internal/agent/application/runtime_decision.go
@@ -243,8 +243,11 @@ func (s *Service) handleRuntimeDecisionCommand(ctx context.Context, command sess
 		})
 		go func() {
 			defer runCancel()
-			s.continueRuntimeDecision(runCtx, command, func(eventCh chan<- WSStreamEvent) error {
-				return s.ContinueCommittedUserInputResponse(runCtx, committed, eventCh)
+			s.continueRuntimeDecision(runCtx, command, func(
+				continuationCtx context.Context,
+				eventCh chan<- WSStreamEvent,
+			) error {
+				return s.ContinueCommittedUserInputResponse(continuationCtx, committed, eventCh)
 			})
 		}()
 		return nil
@@ -282,8 +285,11 @@ func (s *Service) handleRuntimeDecisionCommand(ctx context.Context, command sess
 		})
 		go func() {
 			defer runCancel()
-			s.continueRuntimeDecision(runCtx, command, func(eventCh chan<- WSStreamEvent) error {
-				return s.ContinueCommittedToolApprovalResponse(runCtx, committed, eventCh)
+			s.continueRuntimeDecision(runCtx, command, func(
+				continuationCtx context.Context,
+				eventCh chan<- WSStreamEvent,
+			) error {
+				return s.ContinueCommittedToolApprovalResponse(continuationCtx, committed, eventCh)
 			})
 		}()
 		return nil
@@ -317,7 +323,11 @@ func (s *Service) publishCommittedRuntimeDecision(ctx context.Context, command s
 	}
 }
 
-func (s *Service) continueRuntimeDecision(ctx context.Context, command sessionruntime.Command, continueRun func(chan<- WSStreamEvent) error) {
+func (s *Service) continueRuntimeDecision(
+	ctx context.Context,
+	command sessionruntime.Command,
+	continueRun func(context.Context, chan<- WSStreamEvent) error,
+) {
 	handle := sessionruntime.RunHandle{
 		BotID:      command.BotID,
 		SessionID:  command.SessionID,
@@ -333,7 +343,7 @@ func (s *Service) continueRuntimeDecision(ctx context.Context, command sessionru
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go func() {
-		runDone <- continueRun(eventCh)
+		runDone <- continueRun(runCtx, eventCh)
 		close(eventCh)
 	}()
 

--- a/internal/agent/application/runtime_decision.go
+++ b/internal/agent/application/runtime_decision.go
@@ -16,6 +16,7 @@ import (
 	userinput "github.com/memohai/memoh/internal/agent/decision/input"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	"github.com/memohai/memoh/internal/apperror"
 	"github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
 )
@@ -324,7 +325,7 @@ func (s *Service) continueRuntimeDecision(ctx context.Context, command sessionru
 		Generation: command.Generation,
 	}
 	if err := s.decisionRuntime.WaitDecisionContinuationReady(ctx, command); err != nil {
-		_ = s.decisionRuntime.FinishRun(context.WithoutCancel(ctx), handle, sessionruntime.RunStatusErrored, err.Error())
+		s.finishRuntimeDecision(ctx, handle, err)
 		return
 	}
 	eventCh := make(chan WSStreamEvent, 64)
@@ -354,8 +355,20 @@ func (s *Service) continueRuntimeDecision(ctx context.Context, command sessionru
 	}
 	finishCtx := context.WithoutCancel(ctx)
 	if runErr != nil {
-		_ = s.decisionRuntime.FinishRun(finishCtx, handle, sessionruntime.RunStatusErrored, runErr.Error())
+		s.finishRuntimeDecision(finishCtx, handle, runErr)
 		return
 	}
 	_ = s.decisionRuntime.FinishRun(finishCtx, handle, "", "")
+}
+
+func (s *Service) finishRuntimeDecision(ctx context.Context, handle sessionruntime.RunHandle, cause error) {
+	status, message := runtimeDecisionTerminal(cause)
+	_ = s.decisionRuntime.FinishRun(context.WithoutCancel(ctx), handle, status, message)
+}
+
+func runtimeDecisionTerminal(cause error) (string, string) {
+	if cause != nil && !errors.Is(cause, context.Canceled) {
+		return sessionruntime.RunStatusErrored, string(apperror.CodeOf(cause))
+	}
+	return "", ""
 }

--- a/internal/agent/application/runtime_decision.go
+++ b/internal/agent/application/runtime_decision.go
@@ -353,21 +353,23 @@ func (s *Service) continueRuntimeDecision(ctx context.Context, command sessionru
 	if publishErr != nil {
 		runErr = publishErr
 	}
-	finishCtx := context.WithoutCancel(ctx)
 	if runErr != nil {
-		s.finishRuntimeDecision(finishCtx, handle, runErr)
+		s.finishRuntimeDecision(ctx, handle, runErr)
 		return
 	}
-	_ = s.decisionRuntime.FinishRun(finishCtx, handle, "", "")
+	_ = s.decisionRuntime.FinishRun(context.WithoutCancel(ctx), handle, "", "")
 }
 
 func (s *Service) finishRuntimeDecision(ctx context.Context, handle sessionruntime.RunHandle, cause error) {
-	status, message := runtimeDecisionTerminal(cause)
+	status, message := runtimeDecisionTerminal(ctx, cause)
 	_ = s.decisionRuntime.FinishRun(context.WithoutCancel(ctx), handle, status, message)
 }
 
-func runtimeDecisionTerminal(cause error) (string, string) {
-	if cause != nil && !errors.Is(cause, context.Canceled) {
+func runtimeDecisionTerminal(ctx context.Context, cause error) (string, string) {
+	explicitlyCanceled := ctx != nil &&
+		errors.Is(cause, context.Canceled) &&
+		errors.Is(context.Cause(ctx), context.Canceled)
+	if cause != nil && !explicitlyCanceled {
 		return sessionruntime.RunStatusErrored, string(apperror.CodeOf(cause))
 	}
 	return "", ""

--- a/internal/agent/application/runtime_decision_test.go
+++ b/internal/agent/application/runtime_decision_test.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,6 +12,23 @@ import (
 	"github.com/memohai/memoh/internal/agent/turn"
 	"github.com/memohai/memoh/internal/apperror"
 )
+
+type failNextRuntimeDecisionBackend struct {
+	sessionruntime.Backend
+	failNext atomic.Bool
+	err      error
+}
+
+func (b *failNextRuntimeDecisionBackend) Update(
+	ctx context.Context,
+	key sessionruntime.Key,
+	update sessionruntime.SnapshotUpdate,
+) (sessionruntime.Snapshot, bool, error) {
+	if b.failNext.CompareAndSwap(true, false) {
+		return sessionruntime.Snapshot{}, false, b.err
+	}
+	return b.Backend.Update(ctx, key, update)
+}
 
 func TestRuntimeDecisionTerminalDoesNotExposePrivateErrors(t *testing.T) {
 	tests := []struct {
@@ -110,7 +128,7 @@ func TestContinueRuntimeDecisionDoesNotParkProviderCancellation(t *testing.T) {
 		SessionID:  sessionID,
 		RunID:      runID,
 		Generation: handle.Generation,
-	}, func(chan<- WSStreamEvent) error {
+	}, func(context.Context, chan<- WSStreamEvent) error {
 		return context.Canceled
 	})
 
@@ -120,5 +138,103 @@ func TestContinueRuntimeDecisionDoesNotParkProviderCancellation(t *testing.T) {
 	}
 	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != sessionruntime.RunStatusErrored {
 		t.Fatalf("terminal run = %#v, want errored instead of parked", snapshot.CurrentRunView)
+	}
+}
+
+func TestContinueRuntimeDecisionCancelsContinuationAfterPublicationFailure(t *testing.T) {
+	const (
+		botID     = "bot-publish-failure"
+		sessionID = "session-publish-failure"
+		runID     = "run-publish-failure"
+	)
+	publishErr := errors.New("private runtime publication failure")
+	backend := &failNextRuntimeDecisionBackend{
+		Backend: sessionruntime.NewMemoryBackend(),
+		err:     publishErr,
+	}
+	manager := sessionruntime.NewManager(backend, sessionruntime.Options{
+		OwnerID:       "owner-publish-failure",
+		StateTTL:      time.Minute,
+		OwnerLeaseTTL: time.Second,
+		CommandAckTTL: time.Second,
+	})
+	t.Cleanup(func() { _ = manager.Close() })
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start runtime manager: %v", err)
+	}
+	handle, err := manager.StartRunHandle(
+		context.Background(),
+		botID,
+		sessionID,
+		runID,
+		make(chan struct{}, 1),
+		func() {},
+		make(chan turn.InjectMessage, 1),
+	)
+	if err != nil {
+		t.Fatalf("start runtime run: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), handle, native.StreamEvent{
+		Type:        native.EventUserInputRequest,
+		UserInputID: "input-publish-failure",
+		Status:      "pending",
+	}); err != nil {
+		t.Fatalf("park runtime decision: %v", err)
+	}
+	if err := manager.FinishRun(context.Background(), handle, "", ""); err != nil {
+		t.Fatalf("mark deferred producer ready: %v", err)
+	}
+
+	command := sessionruntime.Command{
+		BotID:      botID,
+		SessionID:  sessionID,
+		RunID:      runID,
+		Generation: handle.Generation,
+	}
+	service := &Service{decisionRuntime: manager}
+	continuationCause := make(chan error, 1)
+	continuationDone := make(chan struct{})
+	go func() {
+		defer close(continuationDone)
+		service.continueRuntimeDecision(context.Background(), command, func(
+			continuationCtx context.Context,
+			eventCh chan<- WSStreamEvent,
+		) error {
+			backend.failNext.Store(true)
+			select {
+			case eventCh <- WSStreamEvent(`{"type":"text_delta","delta":"late"}`):
+			case <-continuationCtx.Done():
+				continuationCause <- context.Cause(continuationCtx)
+				return context.Cause(continuationCtx)
+			}
+			<-continuationCtx.Done()
+			continuationCause <- context.Cause(continuationCtx)
+			return context.Cause(continuationCtx)
+		})
+	}()
+
+	select {
+	case <-continuationDone:
+	case <-time.After(time.Second):
+		t.Fatal("runtime decision continuation hung after publication failure")
+	}
+	select {
+	case cause := <-continuationCause:
+		if !errors.Is(cause, context.Canceled) {
+			t.Fatalf("continuation cause = %v, want context canceled", cause)
+		}
+	default:
+		t.Fatal("continuation did not observe cancellation")
+	}
+
+	snapshot, err := manager.Snapshot(context.Background(), botID, sessionID)
+	if err != nil {
+		t.Fatalf("load terminal snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != sessionruntime.RunStatusErrored {
+		t.Fatalf("terminal run = %#v, want errored", snapshot.CurrentRunView)
+	}
+	if snapshot.CurrentRunView.Error != "" {
+		t.Fatalf("terminal run error = %q, want no private publication detail", snapshot.CurrentRunView.Error)
 	}
 }

--- a/internal/agent/application/runtime_decision_test.go
+++ b/internal/agent/application/runtime_decision_test.go
@@ -1,0 +1,41 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	"github.com/memohai/memoh/internal/apperror"
+)
+
+func TestRuntimeDecisionTerminalDoesNotExposePrivateErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		cause   error
+		status  string
+		message string
+	}{
+		{name: "success"},
+		{name: "canceled", cause: context.Canceled},
+		{
+			name:   "private provider error",
+			cause:  errors.New("private provider detail"),
+			status: sessionruntime.RunStatusErrored,
+		},
+		{
+			name:    "stable application error",
+			cause:   apperror.New(apperror.CodeSessionHistoryInconsistent, nil),
+			status:  sessionruntime.RunStatusErrored,
+			message: string(apperror.CodeSessionHistoryInconsistent),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, message := runtimeDecisionTerminal(tt.cause)
+			if status != tt.status || message != tt.message {
+				t.Fatalf("runtimeDecisionTerminal() = (%q, %q), want (%q, %q)", status, message, tt.status, tt.message)
+			}
+		})
+	}
+}

--- a/internal/agent/application/runtime_decision_test.go
+++ b/internal/agent/application/runtime_decision_test.go
@@ -4,20 +4,39 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	"github.com/memohai/memoh/internal/agent/turn"
 	"github.com/memohai/memoh/internal/apperror"
 )
 
 func TestRuntimeDecisionTerminalDoesNotExposePrivateErrors(t *testing.T) {
 	tests := []struct {
-		name    string
-		cause   error
-		status  string
-		message string
+		name         string
+		contextCause error
+		cause        error
+		status       string
+		message      string
 	}{
 		{name: "success"},
-		{name: "canceled", cause: context.Canceled},
+		{
+			name:         "explicit cancellation",
+			contextCause: context.Canceled,
+			cause:        context.Canceled,
+		},
+		{
+			name:   "provider cancellation with active context",
+			cause:  context.Canceled,
+			status: sessionruntime.RunStatusErrored,
+		},
+		{
+			name:         "ownership loss",
+			contextCause: sessionruntime.ErrRunOwnershipLost,
+			cause:        context.Canceled,
+			status:       sessionruntime.RunStatusErrored,
+		},
 		{
 			name:   "private provider error",
 			cause:  errors.New("private provider detail"),
@@ -32,10 +51,74 @@ func TestRuntimeDecisionTerminalDoesNotExposePrivateErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status, message := runtimeDecisionTerminal(tt.cause)
+			ctx := context.Background()
+			if tt.contextCause != nil {
+				var cancel context.CancelCauseFunc
+				ctx, cancel = context.WithCancelCause(ctx)
+				cancel(tt.contextCause)
+			}
+			status, message := runtimeDecisionTerminal(ctx, tt.cause)
 			if status != tt.status || message != tt.message {
 				t.Fatalf("runtimeDecisionTerminal() = (%q, %q), want (%q, %q)", status, message, tt.status, tt.message)
 			}
 		})
+	}
+}
+
+func TestContinueRuntimeDecisionDoesNotParkProviderCancellation(t *testing.T) {
+	const (
+		botID     = "bot-provider-cancel"
+		sessionID = "session-provider-cancel"
+		runID     = "run-provider-cancel"
+	)
+	manager := sessionruntime.NewManager(sessionruntime.NewMemoryBackend(), sessionruntime.Options{
+		OwnerID:       "owner-provider-cancel",
+		StateTTL:      time.Minute,
+		OwnerLeaseTTL: time.Second,
+		CommandAckTTL: time.Second,
+	})
+	t.Cleanup(func() { _ = manager.Close() })
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start runtime manager: %v", err)
+	}
+	handle, err := manager.StartRunHandle(
+		context.Background(),
+		botID,
+		sessionID,
+		runID,
+		make(chan struct{}, 1),
+		func() {},
+		make(chan turn.InjectMessage, 1),
+	)
+	if err != nil {
+		t.Fatalf("start runtime run: %v", err)
+	}
+	if _, err := manager.HandleAgentEvent(context.Background(), handle, native.StreamEvent{
+		Type:        native.EventUserInputRequest,
+		UserInputID: "input-provider-cancel",
+		Status:      "pending",
+	}); err != nil {
+		t.Fatalf("park runtime decision: %v", err)
+	}
+	if err := manager.FinishRun(context.Background(), handle, "", ""); err != nil {
+		t.Fatalf("mark deferred producer ready: %v", err)
+	}
+
+	service := &Service{decisionRuntime: manager}
+	service.continueRuntimeDecision(context.Background(), sessionruntime.Command{
+		BotID:      botID,
+		SessionID:  sessionID,
+		RunID:      runID,
+		Generation: handle.Generation,
+	}, func(chan<- WSStreamEvent) error {
+		return context.Canceled
+	})
+
+	snapshot, err := manager.Snapshot(context.Background(), botID, sessionID)
+	if err != nil {
+		t.Fatalf("load terminal snapshot: %v", err)
+	}
+	if snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Status != sessionruntime.RunStatusErrored {
+		t.Fatalf("terminal run = %#v, want errored instead of parked", snapshot.CurrentRunView)
 	}
 }

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -139,6 +139,7 @@ type Service struct {
 	allowedTeam         string
 	sessionRuntime      turnAdmitter
 	decisionRuntime     *sessionruntime.Manager
+	publishTurnEvent    func(context.Context, sessionruntime.RunHandle, native.StreamEvent) error
 	turnHooks           *turnRuntimeHooks
 }
 

--- a/internal/agent/application/service_tool_approval.go
+++ b/internal/agent/application/service_tool_approval.go
@@ -382,6 +382,9 @@ func (s *Service) continueToolApprovalSession(ctx context.Context, approval tool
 			}
 		}
 	}
+	if ctx.Err() != nil {
+		return context.Cause(ctx)
+	}
 	return nil
 }
 

--- a/internal/agent/application/service_user_input.go
+++ b/internal/agent/application/service_user_input.go
@@ -395,6 +395,9 @@ func (s *Service) continueUserInputSession(ctx context.Context, req userinput.Re
 			}
 		}
 	}
+	if ctx.Err() != nil {
+		return context.Cause(ctx)
+	}
 	return nil
 }
 

--- a/internal/agent/application/turn_admission.go
+++ b/internal/agent/application/turn_admission.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	tools "github.com/memohai/memoh/internal/agent/tool"
 	"github.com/memohai/memoh/internal/agent/turn"
@@ -41,6 +42,10 @@ func (s *Service) SetSessionRuntime(manager *sessionruntime.Manager) {
 	}
 	s.sessionRuntime = manager
 	s.decisionRuntime = manager
+	s.publishTurnEvent = func(ctx context.Context, handle sessionruntime.RunHandle, event native.StreamEvent) error {
+		_, err := manager.HandleAgentEvent(ctx, handle, event)
+		return err
+	}
 	manager.SetDecisionStore(s)
 	manager.SetCommandHandler(s.handleRuntimeDecisionCommand)
 }

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -40,6 +40,7 @@ func (s *Service) startDiscussTurn(runCtx context.Context, cmd turn.StartTurnCom
 		return nil, errors.New("turn: discuss runtime not configured")
 	}
 	h := newDiscussHandle(runCtx, cmd, cancel, admission.RunID, s.turnRunFinisher(runCtx, admission))
+	h.publishAgentEvent = s.turnAgentEventPublisher(admission.Handle)
 	go s.pumpDiscuss(runCtx, cmd, h)
 	return h, nil
 }
@@ -171,6 +172,12 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 
 	var finalMessages json.RawMessage
 	for event := range eventCh {
+		if h.publishAgentEvent != nil {
+			if publishErr := h.publishAgentEvent(ctx, event); publishErr != nil {
+				h.emitErr(publishErr)
+				return
+			}
+		}
 		if event.Type == native.EventAgentEnd || event.Type == native.EventAgentAbort {
 			finalMessages = event.Messages
 		}

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -97,14 +97,11 @@ func (h *discussHandle) emit(kind string, payload []byte) bool {
 	}
 }
 
-// emitErr mirrors emit for the error channel. Any reported error marks the
-// run failed so finish releases the idempotency claim.
+// emitErr mirrors emit for the error channel. Any reported error marks the run
+// failed; recordStreamFailure preserves explicit cancellation as an abort.
 func (h *discussHandle) emitErr(err error) bool {
-	h.failed.Store(true)
-	if h.streamErr == nil {
-		// Keep the first error: without it the terminal record cannot tell a
-		// discuss turn that broke from one that was stopped.
-		h.streamErr = err
+	if !h.recordStreamFailure(err) {
+		return false
 	}
 	select {
 	case h.errs <- err:
@@ -171,15 +168,23 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 	eventCh := s.streamDiscussAgent(ctx, runConfig)
 
 	var finalMessages json.RawMessage
+	var terminalEvent native.StreamEvent
+	var terminalPayload []byte
+	var hasTerminalEvent bool
 	for event := range eventCh {
+		terminal := event.Type == native.EventAgentEnd || event.Type == native.EventAgentAbort
+		if terminal {
+			finalMessages = event.Messages
+			terminalEvent = event
+			terminalPayload, _ = json.Marshal(event)
+			hasTerminalEvent = true
+			continue
+		}
 		if h.publishAgentEvent != nil {
 			if publishErr := h.publishAgentEvent(ctx, event); publishErr != nil {
 				h.emitErr(publishErr)
 				return
 			}
-		}
-		if event.Type == native.EventAgentEnd || event.Type == native.EventAgentAbort {
-			finalMessages = event.Messages
 		}
 		payload, marshalErr := json.Marshal(event)
 		if marshalErr != nil {
@@ -197,9 +202,20 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 				cmd.BotID, cmd.ThreadID, cmd.SourceChannelIdentityID, cmd.CurrentChannel,
 				sdkMsgs, resolved.ModelID,
 			); storeErr != nil {
-				h.emitErr(storeErr)
+				h.emitErr(runtimeHistoryError(storeErr))
+				return
 			}
 		}
+	}
+	if hasTerminalEvent && h.publishAgentEvent != nil {
+		if publishErr := h.publishAgentEvent(ctx, terminalEvent); publishErr != nil {
+			h.emitErr(publishErr)
+			return
+		}
+		h.terminalPublished = true
+	}
+	if len(terminalPayload) > 0 && !h.emit(string(terminalEvent.Type), terminalPayload) {
+		return
 	}
 
 	// Compute pressure on this goroutine so the detached trigger holds a few

--- a/internal/agent/application/turn_discuss_terminal_test.go
+++ b/internal/agent/application/turn_discuss_terminal_test.go
@@ -1,0 +1,287 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/memohai/memoh/internal/agent/runtime/native"
+	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	"github.com/memohai/memoh/internal/agent/turn"
+	"github.com/memohai/memoh/internal/apperror"
+)
+
+type canceledDiscussTerminalReporter struct {
+	started chan struct{}
+}
+
+func (f *canceledDiscussTerminalReporter) Stream(ctx context.Context, _ native.RunConfig) <-chan native.StreamEvent {
+	ch := make(chan native.StreamEvent, 1)
+	close(f.started)
+	go func() {
+		defer close(ch)
+		<-ctx.Done()
+		ch <- native.StreamEvent{Type: native.EventAgentAbort}
+	}()
+	return ch
+}
+
+type decisionDiscussAgentStreamer struct{}
+
+func (*decisionDiscussAgentStreamer) Stream(context.Context, native.RunConfig) <-chan native.StreamEvent {
+	ch := make(chan native.StreamEvent, 2)
+	ch <- native.StreamEvent{
+		Type:       native.EventToolApprovalRequest,
+		ApprovalID: "approval-1",
+		Status:     "pending",
+	}
+	ch <- native.StreamEvent{
+		Type:       native.EventAgentEnd,
+		ApprovalID: "approval-1",
+		Status:     "pending",
+		Messages:   json.RawMessage(`[{"role":"assistant","content":"done"}]`),
+	}
+	close(ch)
+	return ch
+}
+
+type fullBufferTerminalDiscussStreamer struct{}
+
+func (*fullBufferTerminalDiscussStreamer) Stream(context.Context, native.RunConfig) <-chan native.StreamEvent {
+	ch := make(chan native.StreamEvent, 16)
+	for range 15 {
+		ch <- native.StreamEvent{Type: native.EventTextDelta, Delta: "x"}
+	}
+	ch <- native.StreamEvent{
+		Type:     native.EventAgentEnd,
+		Messages: json.RawMessage(`[{"role":"assistant","content":"done"}]`),
+	}
+	close(ch)
+	return ch
+}
+
+func TestDiscussCancellationWithDetachedTerminalEventFinishesAborted(t *testing.T) {
+	agent := &canceledDiscussTerminalReporter{started: make(chan struct{})}
+	resolver := &fakeDiscussService{
+		resolveResult: ResolveRunConfigResult{ModelID: "model-1"},
+	}
+	a := newDiscussTestService(&fakeRunner{}, agent, resolver)
+	admitter := a.sessionRuntime.(*scriptedAdmitter)
+	a.publishTurnEvent = func(
+		ctx context.Context,
+		handle sessionruntime.RunHandle,
+		event native.StreamEvent,
+	) error {
+		if ctx.Err() != nil {
+			return context.Cause(ctx)
+		}
+		return admitter.PublishAgentEvent(ctx, handle, event)
+	}
+	h, err := a.StartTurn(context.Background(), discussCommand())
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-agent.started:
+	case <-time.After(time.Second):
+		t.Fatal("discuss turn did not reach native streaming")
+	}
+	h.Cancel()
+	for range h.Events() {
+	}
+	for streamErr := range h.Errs() {
+		t.Fatalf("canceled discuss run exposed stream error: %v", streamErr)
+	}
+
+	if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusAborted {
+		t.Fatalf("status = %q, want %q", got.status, sessionruntime.RunStatusAborted)
+	}
+}
+
+func TestDiscussPublishesDecisionTerminalAfterStoreSucceeds(t *testing.T) {
+	agent := &decisionDiscussAgentStreamer{}
+	resolver := &fakeDiscussService{
+		resolveResult: ResolveRunConfigResult{ModelID: "model-1"},
+	}
+	a := newDiscussTestService(&fakeRunner{}, agent, resolver)
+	admitter := a.sessionRuntime.(*scriptedAdmitter)
+	storeStarted := make(chan struct{})
+	releaseStore := make(chan struct{})
+	storeFinished := make(chan struct{})
+	resolver.storeFn = func() error {
+		close(storeStarted)
+		<-releaseStore
+		admitter.mu.Lock()
+		defer admitter.mu.Unlock()
+		for _, event := range admitter.published {
+			if event.Type == native.EventAgentEnd || event.Type == native.EventAgentAbort {
+				return errors.New("terminal event published before StoreRound")
+			}
+		}
+		close(storeFinished)
+		return nil
+	}
+
+	h, err := a.StartTurn(context.Background(), discussCommand())
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-storeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("StoreRound was not called")
+	}
+	var events []turn.Event
+	for len(events) < 2 {
+		select {
+		case event := <-h.Events():
+			events = append(events, event)
+		case <-time.After(time.Second):
+			t.Fatal("non-terminal discuss events were not emitted before StoreRound")
+		}
+	}
+	for _, event := range events {
+		if event.Kind == string(native.EventAgentEnd) || event.Kind == string(native.EventAgentAbort) {
+			t.Fatalf("terminal event emitted before StoreRound completed: %#v", event)
+		}
+	}
+	select {
+	case event := <-h.Events():
+		t.Fatalf("event emitted while StoreRound was blocked: %#v", event)
+	default:
+	}
+	close(releaseStore)
+	events = append(events, drainDiscuss(t, h)...)
+
+	admitter.mu.Lock()
+	published := append([]native.StreamEvent(nil), admitter.published...)
+	admitter.mu.Unlock()
+	if len(published) != 2 ||
+		published[0].Type != native.EventToolApprovalRequest ||
+		published[1].Type != native.EventAgentEnd {
+		t.Fatalf("published events = %#v, want approval request then agent end", published)
+	}
+	if got := admitter.awaitFinish(t); got.status != "" {
+		t.Fatalf("finish status = %q, want unnamed runtime-derived status", got.status)
+	}
+	foundTerminal := false
+	for _, event := range events {
+		if event.Kind != string(native.EventAgentEnd) && event.Kind != string(native.EventAgentAbort) {
+			continue
+		}
+		foundTerminal = true
+		select {
+		case <-storeFinished:
+		default:
+			t.Fatal("terminal event emitted before StoreRound returned")
+		}
+	}
+	if !foundTerminal {
+		t.Fatal("terminal event was not emitted after StoreRound succeeded")
+	}
+}
+
+func TestDiscussWithholdsTerminalPublicationWhenStoreFails(t *testing.T) {
+	storeErr := errors.New("store failed")
+	resolver := &fakeDiscussService{
+		resolveResult: ResolveRunConfigResult{ModelID: "model-1"},
+		storeErr:      storeErr,
+	}
+	a := newDiscussTestService(&fakeRunner{}, &fakeAgentStreamer{}, resolver)
+	admitter := a.sessionRuntime.(*scriptedAdmitter)
+
+	h, err := a.StartTurn(context.Background(), discussCommand())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var events []turn.Event
+	for event := range h.Events() {
+		events = append(events, event)
+	}
+	var publicErr error
+	for streamErr := range h.Errs() {
+		publicErr = streamErr
+	}
+
+	admitter.mu.Lock()
+	published := append([]native.StreamEvent(nil), admitter.published...)
+	admitter.mu.Unlock()
+	for _, event := range published {
+		if event.Type == native.EventAgentEnd || event.Type == native.EventAgentAbort {
+			t.Fatalf("published terminal event before failed StoreRound: %#v", event)
+		}
+	}
+	for _, event := range events {
+		if event.Kind == string(native.EventAgentEnd) || event.Kind == string(native.EventAgentAbort) {
+			t.Fatalf("emitted terminal event before failed StoreRound: %#v", event)
+		}
+	}
+	got := admitter.awaitFinish(t)
+	if got.status != sessionruntime.RunStatusErrored {
+		t.Fatalf("finish status = %q, want %q", got.status, sessionruntime.RunStatusErrored)
+	}
+	if got.message != string(apperror.CodeSessionHistoryInconsistent) {
+		t.Fatalf("finish message = %q, want %q", got.message, apperror.CodeSessionHistoryInconsistent)
+	}
+	if code := apperror.CodeOf(publicErr); code != apperror.CodeSessionHistoryInconsistent {
+		t.Fatalf("public store error code = %q, want %q", code, apperror.CodeSessionHistoryInconsistent)
+	}
+	if cause := apperror.CauseOf(publicErr); !errors.Is(cause, storeErr) {
+		t.Fatalf("private store cause = %v, want %v", cause, storeErr)
+	}
+}
+
+func TestDiscussPublishedTerminalWinsOverLateConsumerCancellation(t *testing.T) {
+	resolver := &fakeDiscussService{
+		resolveResult: ResolveRunConfigResult{ModelID: "model-1"},
+	}
+	a := newDiscussTestService(&fakeRunner{}, &fullBufferTerminalDiscussStreamer{}, resolver)
+	admitter := a.sessionRuntime.(*scriptedAdmitter)
+	terminalPublished := make(chan struct{})
+	a.publishTurnEvent = func(
+		ctx context.Context,
+		handle sessionruntime.RunHandle,
+		event native.StreamEvent,
+	) error {
+		if err := admitter.PublishAgentEvent(ctx, handle, event); err != nil {
+			return err
+		}
+		if event.Type == native.EventAgentEnd || event.Type == native.EventAgentAbort {
+			close(terminalPublished)
+		}
+		return nil
+	}
+
+	h, err := a.StartTurn(context.Background(), discussCommand())
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-terminalPublished:
+	case <-time.After(time.Second):
+		t.Fatal("terminal event was not published to the runtime")
+	}
+	h.Cancel()
+	select {
+	case streamErr, ok := <-h.Errs():
+		if ok {
+			t.Fatalf("late consumer cancellation exposed stream error: %v", streamErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("discuss pump did not observe late consumer cancellation")
+	}
+	var events []turn.Event
+	for event := range h.Events() {
+		events = append(events, event)
+	}
+	for _, event := range events {
+		if event.Kind == string(native.EventAgentEnd) || event.Kind == string(native.EventAgentAbort) {
+			t.Fatalf("blocked terminal event unexpectedly reached the consumer: %#v", event)
+		}
+	}
+	if got := admitter.awaitFinish(t); got.status != "" {
+		t.Fatalf("finish status = %q, want runtime-derived terminal outcome", got.status)
+	}
+}

--- a/internal/agent/application/turn_discuss_test.go
+++ b/internal/agent/application/turn_discuss_test.go
@@ -36,6 +36,8 @@ type fakeDiscussService struct {
 	resolveResult ResolveRunConfigResult
 	inlineFn      func(ctx context.Context, botID string, refs []timeline.ImageAttachmentRef) []sdk.ImagePart
 	storeCalls    int
+	storeErr      error
+	storeFn       func() error
 }
 
 func (f *fakeDiscussService) ResolveRunConfig(_ context.Context, _, _, _, _, _, _, _ string) (ResolveRunConfigResult, error) {
@@ -51,7 +53,10 @@ func (f *fakeDiscussService) InlineImageAttachments(ctx context.Context, botID s
 
 func (f *fakeDiscussService) StoreRound(_ context.Context, _, _, _, _ string, _ []sdk.Message, _ string) error {
 	f.storeCalls++
-	return nil
+	if f.storeFn != nil {
+		return f.storeFn()
+	}
+	return f.storeErr
 }
 
 type testAgentStreamer interface {

--- a/internal/agent/application/turn_discuss_test.go
+++ b/internal/agent/application/turn_discuss_test.go
@@ -11,6 +11,7 @@ import (
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
+	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	"github.com/memohai/memoh/internal/agent/turn"
 	sessionpkg "github.com/memohai/memoh/internal/chat/thread"
 	"github.com/memohai/memoh/internal/chat/timeline"
@@ -377,6 +378,7 @@ func TestDiscussCancelUnblocksFullEventBuffer(t *testing.T) {
 		resolveResult: ResolveRunConfigResult{ModelID: "model-1"},
 	}
 	a := newDiscussTestService(&fakeRunner{}, agent, resolver)
+	admitter := a.sessionRuntime.(*scriptedAdmitter)
 	h, err := a.StartTurn(context.Background(), discussCommand())
 	if err != nil {
 		t.Fatal(err)
@@ -389,6 +391,9 @@ func TestDiscussCancelUnblocksFullEventBuffer(t *testing.T) {
 		case _, ok := <-h.Events():
 			if !ok {
 				for range h.Errs() {
+				}
+				if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusAborted {
+					t.Fatalf("status = %q, want %q", got.status, sessionruntime.RunStatusAborted)
 				}
 				return
 			}

--- a/internal/agent/application/turn_service.go
+++ b/internal/agent/application/turn_service.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	"github.com/memohai/memoh/internal/agent/turn"
 	"github.com/memohai/memoh/internal/runtimefence"
@@ -95,7 +96,8 @@ func (s *Service) StartTurn(ctx context.Context, cmd turn.StartTurnCommand) (tur
 			defer assetMu.Unlock()
 			assets = append(assets, refs...)
 		},
-		finishRun: s.turnRunFinisher(runCtx, admission),
+		finishRun:         s.turnRunFinisher(runCtx, admission),
+		publishAgentEvent: s.turnAgentEventPublisher(admission.Handle),
 	}
 	go h.pump(cmd, chunkCh, errCh)
 	return h, nil
@@ -128,9 +130,10 @@ type runHandle struct {
 	// because the terminal record distinguishes a run someone stopped from a run
 	// that broke, and cancellation alone cannot tell them apart. Only the pump
 	// goroutine writes either, and it reads them in its own defer.
-	failed    atomic.Bool
-	streamErr error
-	finishRun func(status string, cause error)
+	failed            atomic.Bool
+	streamErr         error
+	finishRun         func(status string, cause error)
+	publishAgentEvent func(context.Context, native.StreamEvent) error
 }
 
 func (h *runHandle) RunID() string             { return h.id }
@@ -198,7 +201,30 @@ func (h *runHandle) finish() {
 		h.finishRun(sessionruntime.RunStatusAborted, nil)
 		return
 	}
-	h.finishRun(sessionruntime.RunStatusCompleted, nil)
+	// An unnamed clean end lets the runtime preserve waiting_decision or derive
+	// completed from its event projection. Naming completion here would collapse
+	// a deferred decision into a terminal run.
+	h.finishRun("", nil)
+}
+
+func (s *Service) turnAgentEventPublisher(handle sessionruntime.RunHandle) func(context.Context, native.StreamEvent) error {
+	if s == nil || s.publishTurnEvent == nil {
+		return nil
+	}
+	return func(ctx context.Context, event native.StreamEvent) error {
+		return s.publishTurnEvent(ctx, handle, event)
+	}
+}
+
+func (h *runHandle) publishChunk(chunk StreamChunk) error {
+	if h.publishAgentEvent == nil {
+		return nil
+	}
+	var event native.StreamEvent
+	if err := json.Unmarshal(chunk, &event); err != nil || event.Type == "" {
+		return nil
+	}
+	return h.publishAgentEvent(h.ctx, event)
 }
 
 // RespondToolApproval resumes a turn deferred on tool approval.
@@ -256,6 +282,15 @@ func (h *runHandle) pump(cmd turn.StartTurnCommand, chunkCh <-chan StreamChunk, 
 			if !ok {
 				chunkCh = nil
 				continue
+			}
+			if err := h.publishChunk(chunk); err != nil {
+				h.failed.Store(true)
+				h.streamErr = err
+				select {
+				case h.errs <- err:
+				case <-h.ctx.Done():
+				}
+				return
 			}
 			seq++
 			if clientGone {

--- a/internal/agent/application/turn_service.go
+++ b/internal/agent/application/turn_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	"github.com/memohai/memoh/internal/agent/turn"
+	"github.com/memohai/memoh/internal/apperror"
 	"github.com/memohai/memoh/internal/runtimefence"
 )
 
@@ -132,6 +133,7 @@ type runHandle struct {
 	// goroutine writes either, and it reads them in its own defer.
 	failed            atomic.Bool
 	streamErr         error
+	terminalPublished bool
 	finishRun         func(status string, cause error)
 	publishAgentEvent func(context.Context, native.StreamEvent) error
 }
@@ -195,6 +197,13 @@ func (h *runHandle) finish() {
 		h.finishRun(sessionruntime.RunStatusErrored, h.streamErr)
 		return
 	}
+	// Once the terminal event is in the runtime projection, that projection is
+	// authoritative. A consumer disconnect while forwarding the same terminal
+	// event must not rewrite a completed, aborted, or parked run as aborted.
+	if h.terminalPublished {
+		h.finishRun("", nil)
+		return
+	}
 	// Canceled with nothing on the error channel means someone stopped this run
 	// — /stop, a routed abort, or a lost owner lease — rather than it breaking.
 	if h.failed.Load() {
@@ -207,12 +216,43 @@ func (h *runHandle) finish() {
 	h.finishRun("", nil)
 }
 
+func (h *runHandle) recordStreamFailure(err error) bool {
+	h.failed.Store(true)
+	if err == nil {
+		return false
+	}
+	// Native and ACP streams may report context.Canceled after the run was
+	// explicitly stopped. That terminal signal still means aborted; a provider
+	// cancellation while the run context is active remains an error.
+	failureCause := err
+	if privateCause := apperror.CauseOf(err); privateCause != nil {
+		failureCause = privateCause
+	}
+	explicitlyCanceled := h.ctx != nil &&
+		errors.Is(failureCause, context.Canceled) &&
+		errors.Is(context.Cause(h.ctx), context.Canceled)
+	if explicitlyCanceled {
+		return false
+	}
+	if h.streamErr == nil {
+		h.streamErr = err
+	}
+	return true
+}
+
+func runtimeHistoryError(err error) error {
+	if err == nil || apperror.CodeOf(err) != "" {
+		return err
+	}
+	return apperror.Wrap(apperror.CodeSessionHistoryInconsistent, err, nil)
+}
+
 func (s *Service) turnAgentEventPublisher(handle sessionruntime.RunHandle) func(context.Context, native.StreamEvent) error {
 	if s == nil || s.publishTurnEvent == nil {
 		return nil
 	}
 	return func(ctx context.Context, event native.StreamEvent) error {
-		return s.publishTurnEvent(ctx, handle, event)
+		return runtimeHistoryError(s.publishTurnEvent(ctx, handle, event))
 	}
 }
 
@@ -224,7 +264,11 @@ func (h *runHandle) publishChunk(chunk StreamChunk) error {
 	if err := json.Unmarshal(chunk, &event); err != nil || event.Type == "" {
 		return nil
 	}
-	return h.publishAgentEvent(h.ctx, event)
+	err := h.publishAgentEvent(h.ctx, event)
+	if err == nil && (event.Type == native.EventAgentEnd || event.Type == native.EventAgentAbort) {
+		h.terminalPublished = true
+	}
+	return err
 }
 
 // RespondToolApproval resumes a turn deferred on tool approval.
@@ -283,14 +327,24 @@ func (h *runHandle) pump(cmd turn.StartTurnCommand, chunkCh <-chan StreamChunk, 
 				chunkCh = nil
 				continue
 			}
-			if err := h.publishChunk(chunk); err != nil {
+			if h.ctx.Err() != nil {
 				h.failed.Store(true)
-				h.streamErr = err
-				select {
-				case h.errs <- err:
-				case <-h.ctx.Done():
+				clientGone = true
+				ctxDone = nil
+			}
+			if !clientGone {
+				if err := h.publishChunk(chunk); err != nil {
+					if h.recordStreamFailure(err) {
+						select {
+						case h.errs <- err:
+						case <-h.ctx.Done():
+						}
+					}
+					h.cancel()
+					clientGone = true
+					ctxDone = nil
+					continue
 				}
-				return
 			}
 			seq++
 			if clientGone {
@@ -316,14 +370,10 @@ func (h *runHandle) pump(cmd turn.StartTurnCommand, chunkCh <-chan StreamChunk, 
 				continue
 			}
 			if err != nil {
-				h.failed.Store(true)
-				// StreamChat reports its terminal context cause. When the run
-				// was explicitly canceled, that context.Canceled value names a
-				// stopped run rather than a provider failure.
-				canceledRun := errors.Is(err, context.Canceled) &&
-					errors.Is(context.Cause(h.ctx), context.Canceled)
-				if h.streamErr == nil && !canceledRun {
-					h.streamErr = err
+				if !h.recordStreamFailure(err) {
+					clientGone = true
+					ctxDone = nil
+					continue
 				}
 				if !clientGone {
 					select {

--- a/internal/agent/application/turn_service.go
+++ b/internal/agent/application/turn_service.go
@@ -317,7 +317,12 @@ func (h *runHandle) pump(cmd turn.StartTurnCommand, chunkCh <-chan StreamChunk, 
 			}
 			if err != nil {
 				h.failed.Store(true)
-				if h.streamErr == nil {
+				// StreamChat reports its terminal context cause. When the run
+				// was explicitly canceled, that context.Canceled value names a
+				// stopped run rather than a provider failure.
+				canceledRun := errors.Is(err, context.Canceled) &&
+					errors.Is(context.Cause(h.ctx), context.Canceled)
+				if h.streamErr == nil && !canceledRun {
 					h.streamErr = err
 				}
 				if !clientGone {

--- a/internal/agent/application/turn_service_test.go
+++ b/internal/agent/application/turn_service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	"github.com/memohai/memoh/internal/agent/turn"
+	"github.com/memohai/memoh/internal/apperror"
 )
 
 type fakeRunner struct {
@@ -263,20 +264,60 @@ func TestStartTurnPublishesNativeEventsBeforeCleanFinish(t *testing.T) {
 }
 
 func TestStartTurnFailsWhenRuntimeEventPublicationFails(t *testing.T) {
-	a, admitter := newAdmittedTurnTestService(&fakeRunner{chunks: []string{
-		`{"type":"text_delta","delta":"hello"}`,
-	}})
-	admitter.publishErr = errors.New("runtime publication failed")
+	cancelObserved := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseCleanup) }) }
+	t.Cleanup(release)
+	streamer := testChatStreamerFunc(func(ctx context.Context, _ ChatRequest) (<-chan StreamChunk, <-chan error) {
+		chunks := make(chan StreamChunk, 1)
+		errs := make(chan error)
+		chunks <- StreamChunk(`{"type":"text_delta","delta":"hello"}`)
+		go func() {
+			<-ctx.Done()
+			close(cancelObserved)
+			<-releaseCleanup
+			close(chunks)
+			close(errs)
+		}()
+		return chunks, errs
+	})
+	a, admitter := newAdmittedTurnTestService(streamer)
+	publishErr := errors.New("private runtime publication failure")
+	admitter.publishErr = publishErr
 	h, err := a.StartTurn(context.Background(), turn.StartTurnCommand{
 		TeamID: "t", Mode: turn.ModeChat, BotID: "b", ThreadID: "s",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	drainHandle(h)
+	select {
+	case <-cancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("publication failure did not cancel the stream")
+	}
+	admitter.mu.Lock()
+	finishedEarly := len(admitter.finishes) != 0
+	admitter.mu.Unlock()
+	if finishedEarly {
+		t.Fatal("run finalized before publication-failure cleanup completed")
+	}
+	release()
+	for range h.Events() {
+	}
+	var publicErr error
+	for streamErr := range h.Errs() {
+		publicErr = streamErr
+	}
 
 	if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusErrored {
 		t.Fatalf("publication failure status = %q, want %q", got.status, sessionruntime.RunStatusErrored)
+	}
+	if got := apperror.CodeOf(publicErr); got != apperror.CodeSessionHistoryInconsistent {
+		t.Fatalf("publication failure code = %q, want %q", got, apperror.CodeSessionHistoryInconsistent)
+	}
+	if got := apperror.CauseOf(publicErr); !errors.Is(got, publishErr) {
+		t.Fatalf("private publication cause = %v, want %v", got, publishErr)
 	}
 }
 
@@ -690,6 +731,20 @@ func (*canceledRunReporter) StreamChat(ctx context.Context, _ ChatRequest) (<-ch
 	return ch, errCh
 }
 
+type canceledRunTerminalReporter struct{}
+
+func (*canceledRunTerminalReporter) StreamChat(ctx context.Context, _ ChatRequest) (<-chan StreamChunk, <-chan error) {
+	ch := make(chan StreamChunk, 1)
+	errCh := make(chan error)
+	go func() {
+		defer close(ch)
+		defer close(errCh)
+		<-ctx.Done()
+		ch <- StreamChunk(`{"type":"agent_abort"}`)
+	}()
+	return ch, errCh
+}
+
 func drainHandle(h turn.RunHandle) {
 	for range h.Events() {
 	}
@@ -776,7 +831,38 @@ func TestRunEndRecordsTerminalState(t *testing.T) {
 			t.Fatal(err)
 		}
 		h.Cancel()
-		drainHandle(h)
+		for range h.Events() {
+		}
+		for streamErr := range h.Errs() {
+			t.Fatalf("canceled run exposed stream error: %v", streamErr)
+		}
+		if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusAborted {
+			t.Fatalf("status = %q, want %q", got.status, sessionruntime.RunStatusAborted)
+		}
+	})
+
+	t.Run("cancellation reported by detached terminal event", func(t *testing.T) {
+		a, admitter := newAdmittedTurnTestService(&canceledRunTerminalReporter{})
+		a.publishTurnEvent = func(
+			ctx context.Context,
+			handle sessionruntime.RunHandle,
+			event native.StreamEvent,
+		) error {
+			if ctx.Err() != nil {
+				return context.Cause(ctx)
+			}
+			return admitter.PublishAgentEvent(ctx, handle, event)
+		}
+		h, err := a.StartTurn(context.Background(), cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.Cancel()
+		for range h.Events() {
+		}
+		for streamErr := range h.Errs() {
+			t.Fatalf("canceled run exposed stream error: %v", streamErr)
+		}
 		if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusAborted {
 			t.Fatalf("status = %q, want %q", got.status, sessionruntime.RunStatusAborted)
 		}
@@ -797,6 +883,68 @@ func TestRunEndRecordsTerminalState(t *testing.T) {
 			t.Fatal("terminal write carried no fencing token: a superseded owner could close this run")
 		}
 	})
+}
+
+func TestRecordStreamFailureClassifiesOnlyExplicitCancellationAsAborted(t *testing.T) {
+	providerErr := errors.New("provider failed")
+	tests := []struct {
+		name         string
+		contextCause error
+		err          error
+		wantStored   bool
+	}{
+		{
+			name:         "explicit cancellation",
+			contextCause: context.Canceled,
+			err:          context.Canceled,
+		},
+		{
+			name:         "wrapped explicit cancellation",
+			contextCause: context.Canceled,
+			err:          runtimeHistoryError(context.Canceled),
+		},
+		{
+			name:       "provider cancellation with active context",
+			err:        context.Canceled,
+			wantStored: true,
+		},
+		{
+			name:         "ownership loss",
+			contextCause: sessionruntime.ErrRunOwnershipLost,
+			err:          context.Canceled,
+			wantStored:   true,
+		},
+		{
+			name:       "provider failure",
+			err:        providerErr,
+			wantStored: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.contextCause != nil {
+				var cancel context.CancelCauseFunc
+				ctx, cancel = context.WithCancelCause(ctx)
+				cancel(tt.contextCause)
+			}
+			h := &runHandle{ctx: ctx}
+			reported := h.recordStreamFailure(tt.err)
+
+			if !h.failed.Load() {
+				t.Fatal("stream failure did not mark the run failed")
+			}
+			if tt.wantStored && !errors.Is(h.streamErr, tt.err) {
+				t.Fatalf("stored error = %v, want %v", h.streamErr, tt.err)
+			}
+			if !tt.wantStored && h.streamErr != nil {
+				t.Fatalf("stored error = %v, want explicit cancellation suppressed", h.streamErr)
+			}
+			if reported != tt.wantStored {
+				t.Fatalf("reported = %v, want %v", reported, tt.wantStored)
+			}
+		})
+	}
 }
 
 // TestDiscussInjectFailsFast: discuss handles have no inject reader, so

--- a/internal/agent/application/turn_service_test.go
+++ b/internal/agent/application/turn_service_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	userinput "github.com/memohai/memoh/internal/agent/decision/input"
+	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	"github.com/memohai/memoh/internal/agent/turn"
 )
@@ -45,8 +46,10 @@ type scriptedAdmitter struct {
 	// replay of a run owned elsewhere or already finished.
 	started bool
 
-	inputs   []sessionruntime.AdmitInput
-	finishes []recordedFinish
+	inputs     []sessionruntime.AdmitInput
+	finishes   []recordedFinish
+	published  []native.StreamEvent
+	publishErr error
 }
 
 type recordedFinish struct {
@@ -91,6 +94,17 @@ func (a *scriptedAdmitter) FinishRun(_ context.Context, handle sessionruntime.Ru
 	return nil
 }
 
+func (a *scriptedAdmitter) PublishAgentEvent(
+	_ context.Context,
+	_ sessionruntime.RunHandle,
+	event native.StreamEvent,
+) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.published = append(a.published, event)
+	return a.publishErr
+}
+
 func (a *scriptedAdmitter) admitted() []sessionruntime.AdmitInput {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -124,7 +138,8 @@ func newTurnTestService(streamer testChatStreamer) *Service {
 func newAdmittedTurnTestService(streamer testChatStreamer) (*Service, *scriptedAdmitter) {
 	admitter := newScriptedAdmitter()
 	return &Service{
-		sessionRuntime: admitter,
+		sessionRuntime:   admitter,
+		publishTurnEvent: admitter.PublishAgentEvent,
 		turnHooks: &turnRuntimeHooks{
 			streamChat: streamer.StreamChat,
 		},
@@ -218,6 +233,50 @@ func TestStartTurnStreamsEvents(t *testing.T) {
 		t.Fatalf("ChatRequest not translated: %+v", r.gotReq)
 	}
 	for range h.Errs() {
+	}
+}
+
+func TestStartTurnPublishesNativeEventsBeforeCleanFinish(t *testing.T) {
+	a, admitter := newAdmittedTurnTestService(&fakeRunner{chunks: []string{
+		`{"type":"tool_approval_request","approval_id":"approval-1","status":"pending"}`,
+		`{"type":"agent_end","approval_id":"approval-1","status":"pending"}`,
+	}})
+	h, err := a.StartTurn(context.Background(), turn.StartTurnCommand{
+		TeamID: "t", Mode: turn.ModeChat, BotID: "b", ThreadID: "s",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainHandle(h)
+
+	admitter.mu.Lock()
+	published := append([]native.StreamEvent(nil), admitter.published...)
+	admitter.mu.Unlock()
+	if len(published) != 2 ||
+		published[0].Type != native.EventToolApprovalRequest ||
+		published[1].Type != native.EventAgentEnd {
+		t.Fatalf("published events = %#v, want approval request then agent end", published)
+	}
+	if got := admitter.awaitFinish(t); got.status != "" {
+		t.Fatalf("clean deferred finish status = %q, want unnamed runtime-derived status", got.status)
+	}
+}
+
+func TestStartTurnFailsWhenRuntimeEventPublicationFails(t *testing.T) {
+	a, admitter := newAdmittedTurnTestService(&fakeRunner{chunks: []string{
+		`{"type":"text_delta","delta":"hello"}`,
+	}})
+	admitter.publishErr = errors.New("runtime publication failed")
+	h, err := a.StartTurn(context.Background(), turn.StartTurnCommand{
+		TeamID: "t", Mode: turn.ModeChat, BotID: "b", ThreadID: "s",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainHandle(h)
+
+	if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusErrored {
+		t.Fatalf("publication failure status = %q, want %q", got.status, sessionruntime.RunStatusErrored)
 	}
 }
 
@@ -692,8 +751,8 @@ func TestRunEndRecordsTerminalState(t *testing.T) {
 		}
 		drainHandle(h)
 		got := admitter.awaitFinish(t)
-		if got.status != sessionruntime.RunStatusCompleted {
-			t.Fatalf("status = %q, want %q", got.status, sessionruntime.RunStatusCompleted)
+		if got.status != "" {
+			t.Fatalf("status = %q, want unnamed runtime-derived completion", got.status)
 		}
 		if got.handle.FencingToken == 0 {
 			t.Fatal("terminal write carried no fencing token: a superseded owner could close this run")

--- a/internal/agent/application/turn_service_test.go
+++ b/internal/agent/application/turn_service_test.go
@@ -676,6 +676,20 @@ func (f *errRunner) StreamChat(ctx context.Context, _ ChatRequest) (<-chan Strea
 	return ch, errCh
 }
 
+type canceledRunReporter struct{}
+
+func (*canceledRunReporter) StreamChat(ctx context.Context, _ ChatRequest) (<-chan StreamChunk, <-chan error) {
+	ch := make(chan StreamChunk)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(ch)
+		defer close(errCh)
+		<-ctx.Done()
+		errCh <- context.Cause(ctx)
+	}()
+	return ch, errCh
+}
+
 func drainHandle(h turn.RunHandle) {
 	for range h.Events() {
 	}
@@ -725,6 +739,18 @@ func TestRunEndRecordsTerminalState(t *testing.T) {
 		}
 	})
 
+	t.Run("unsolicited context cancellation", func(t *testing.T) {
+		a, admitter := newAdmittedTurnTestService(&errRunner{err: context.Canceled})
+		h, err := a.StartTurn(context.Background(), cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		drainHandle(h)
+		if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusErrored {
+			t.Fatalf("status = %q, want %q", got.status, sessionruntime.RunStatusErrored)
+		}
+	})
+
 	t.Run("cancellation", func(t *testing.T) {
 		a, admitter := newAdmittedTurnTestService(&fakeRunner{
 			chunks: []string{`{"type":"done"}`},
@@ -738,6 +764,19 @@ func TestRunEndRecordsTerminalState(t *testing.T) {
 		drainHandle(h)
 		// A canceled run reaches the pump as two closed channels, exactly like a
 		// clean finish; only the run context tells them apart.
+		if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusAborted {
+			t.Fatalf("status = %q, want %q", got.status, sessionruntime.RunStatusAborted)
+		}
+	})
+
+	t.Run("cancellation reported by stream", func(t *testing.T) {
+		a, admitter := newAdmittedTurnTestService(&canceledRunReporter{})
+		h, err := a.StartTurn(context.Background(), cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.Cancel()
+		drainHandle(h)
 		if got := admitter.awaitFinish(t); got.status != sessionruntime.RunStatusAborted {
 			t.Fatalf("status = %q, want %q", got.status, sessionruntime.RunStatusAborted)
 		}

--- a/internal/agent/runtime/session/control.go
+++ b/internal/agent/runtime/session/control.go
@@ -171,11 +171,18 @@ func (c *runControl) commandContext(parent context.Context) (context.Context, co
 			parent = runtimefence.WithContext(parent, fence)
 		}
 	}
-	ctx, cancel := context.WithCancel(parent)
+	ctx, cancelCause := context.WithCancelCause(parent)
+	cancel := func() { cancelCause(context.Canceled) }
 	if c == nil || c.lifecycleCtx == nil {
 		return ctx, cancel
 	}
-	stop := context.AfterFunc(c.lifecycleCtx, cancel)
+	stop := context.AfterFunc(c.lifecycleCtx, func() {
+		if c.ownershipWasLost() {
+			cancelCause(ErrRunOwnershipLost)
+			return
+		}
+		cancelCause(context.Canceled)
+	})
 	return ctx, func() {
 		stop()
 		cancel()

--- a/internal/agent/runtime/session/decision_route_test.go
+++ b/internal/agent/runtime/session/decision_route_test.go
@@ -3,6 +3,7 @@ package sessionruntime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -11,6 +12,24 @@ import (
 	"github.com/memohai/memoh/internal/agent/runtime/session/ledger"
 	chatview "github.com/memohai/memoh/internal/agent/view"
 )
+
+func TestRunControlCommandContextPreservesOwnershipLossCause(t *testing.T) {
+	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
+	ctrl := &runControl{
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
+	}
+	ctx, cancel := ctrl.commandContext(context.Background())
+	defer cancel()
+
+	ctrl.revokeOwnership(ErrRunOwnershipLost)
+	ctrl.stopCommands()
+
+	<-ctx.Done()
+	if cause := context.Cause(ctx); !errors.Is(cause, ErrRunOwnershipLost) {
+		t.Fatalf("command context cause = %v, want %v", cause, ErrRunOwnershipLost)
+	}
+}
 
 type fakeDecisionStore struct {
 	mu     sync.Mutex


### PR DESCRIPTION
### Summary

This standalone PR fixes five correctness failures at the Agent application / Session Runtime boundary:

- A run that emitted a pending tool approval or user-input request could be finalized as `completed`, collapsing `waiting_decision` before the user responded. `TestStartTurnPublishesNativeEventsBeforeCleanFinish` reproduces the pending-decision event followed by a clean provider end and requires an unnamed, runtime-derived finish.
- Explicit cancellation could be reported as a provider error, while an unsolicited provider `context.Canceled` could be mistaken for a user abort. `TestRunEndRecordsTerminalState`, `TestRecordStreamFailureClassifiesOnlyExplicitCancellationAsAborted`, and `TestRuntimeDecisionTerminalDoesNotExposePrivateErrors` require both the returned error and the run-context cause to be `context.Canceled` before classifying the outcome as an abort.
- Decision continuations lost `ErrRunOwnershipLost` when their lifecycle context was canceled. `TestRunControlCommandContextPreservesOwnershipLossCause` requires command contexts to preserve the cancellation cause.
- A late consumer cancellation could overwrite a terminal outcome already accepted by Session Runtime, and native discuss could publish its terminal before `StoreRound` succeeded. `TestDiscussPublishesDecisionTerminalAfterStoreSucceeds`, `TestDiscussWithholdsTerminalPublicationWhenStoreFails`, and `TestDiscussPublishedTerminalWinsOverLateConsumerCancellation` require persistence-before-publication and runtime-authoritative terminal outcomes. Publication/storage failures expose only `session_runtime.history_inconsistent`; their private causes remain available through `apperror.CauseOf` and never become the recorded public message.
- A resumed decision continuation could hang after live-event publication failed because cancellation stopped the consumer but never reached the producer. `TestContinueRuntimeDecisionCancelsContinuationAfterPublicationFailure` requires the child cancellation context to reach the continuation and for canceled stream closures to return `context.Cause(ctx)`.

The PR has no stack dependency.

### Upstream overlap audit

The slice was audited fix-by-fix against #944 (`e828a7fe1`, interrupted inference checkpoints) and #941 (`e97c11c69`, live subagent sessions) before restacking onto `0265158c5`.

| PR5 target | Classification | Upstream evidence and disposition |
| --- | --- | --- |
| Decision parking via unnamed clean finish | Still needed | #944 checkpoints only interrupted/canceled inference; ordinary `StartTurn` still did not project native decision events and still named clean completion. #941's observer is subagent-only. Ported on top of the new turn fields and kept runtime projection authoritative. |
| Abort classification requires both cancellation signals | Needs reshape | #944 intentionally drains stream channels after cancellation, so ACP's returned `context.Canceled` is now reliably observed. Integrated the two-signal classifier into that drain loop instead of restoring the old early-return behavior. |
| Preserve ownership-loss cause | Still needed | `runControl.commandContext` still used `context.WithCancel` and flattened ownership loss. Ported with `context.WithCancelCause`; #944/#941 did not make this obsolete. |
| Protect accepted terminal outcomes and persistence ordering | Needs reshape | Kept #944's interrupted-checkpoint drain, added terminal authority without touching #941's log-only subagent observer, and staged native discuss terminal publication until `StoreRound` succeeds. Publication failure now cancels the producer but waits for its cleanup before finalizing. |
| Cancel resumed producer after publication failure | Still needed | The target created a child context but the continuation callback still captured the outer context, so `<-runDone` could hang. Ported the context-taking callback and canceled-stream cause propagation. |

No PR5 fix was already complete upstream or dropped as obsolete.

### Verification

All commands passed from `/workspaces/Memoh-land-pr5` at `eb1f95258e170e479df2a11d366ee98ad229159b`:

- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- go build ./...`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- go test -count=1 ./...`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- golangci-lint run ./internal/agent/application/... ./internal/agent/runtime/session/...`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- go test -race -count=1 ./internal/agent/application ./internal/agent/runtime/session`
- Required application state-machine set at `-count=100`, including #944's `TestCancelWaitsForStreamCleanupBeforeFinalizingRun`
- Required Session Runtime fencing set at `-count=100`
- Publication-failure/checkpoint-cleanup composition at `-count=100`
- Late terminal / consumer-cancellation race at `-count=1000`