### PR TITLE
refactor(models): give "off" one name across declarations and settings

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -898,7 +898,6 @@
     "reasoningEffort": "Reasoning",
     "reasoningOff": "Off",
     "reasoningAdaptive": "Adaptive",
-    "reasoningNone": "None",
     "reasoningMinimal": "Minimal",
     "reasoningLow": "Low",
     "reasoningMedium": "Medium",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -869,7 +869,6 @@
     "reasoningEffort": "推論",
     "reasoningOff": "オフ",
     "reasoningAdaptive": "アダプティブ",
-    "reasoningNone": "なし",
     "reasoningMinimal": "最小限",
     "reasoningLow": "低い",
     "reasoningMedium": "中くらい",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -898,7 +898,6 @@
     "reasoningEffort": "推理",
     "reasoningOff": "关闭",
     "reasoningAdaptive": "自适应",
-    "reasoningNone": "无",
     "reasoningMinimal": "极简",
     "reasoningLow": "低",
     "reasoningMedium": "中",

--- a/apps/web/src/pages/bots/components/model-options.vue
+++ b/apps/web/src/pages/bots/components/model-options.vue
@@ -460,6 +460,7 @@ const nativeAvailableEfforts = computed(() => {
   return availableEffortsForMode(
     resolveThinkingMode(activeModel.value.config),
     resolveEffortLevels(activeModel.value.config, activeClientType.value),
+    activeClientType.value,
   )
 })
 

--- a/apps/web/src/pages/bots/components/reasoning-effort.test.ts
+++ b/apps/web/src/pages/bots/components/reasoning-effort.test.ts
@@ -8,10 +8,18 @@ describe('resolveEffortLevels', () => {
     }, 'openai-completions')).toEqual([REASONING_EFFORT_DISABLE, 'low', 'medium', 'high'])
   })
 
-  it('drops none, which is a provider wire value rather than a declaration', () => {
+  it('rewrites the legacy off spelling instead of dropping it', () => {
+    // A config still advertising "none" describes a model that can be turned off.
+    // Dropping it would hide Off from a model that supports it.
     expect(resolveEffortLevels({
       reasoning_efforts: ['none', 'low', 'medium', 'high'],
-    }, 'openai-completions')).toEqual(['low', 'medium', 'high'])
+    }, 'openai-completions')).toEqual([REASONING_EFFORT_DISABLE, 'low', 'medium', 'high'])
+  })
+
+  it('collapses both spellings of off into one entry', () => {
+    expect(resolveEffortLevels({
+      reasoning_efforts: ['none', REASONING_EFFORT_DISABLE, 'low', 'high'],
+    }, 'openai-completions')).toEqual([REASONING_EFFORT_DISABLE, 'low', 'high'])
   })
 
   it('preserves max for Codex and filters client-only efforts', () => {

--- a/apps/web/src/pages/bots/components/reasoning-effort.test.ts
+++ b/apps/web/src/pages/bots/components/reasoning-effort.test.ts
@@ -52,6 +52,26 @@ describe('availableEffortsForMode', () => {
     expect(selectable).toEqual(['low', 'medium', 'high'])
   })
 
+  it('offers off on the Anthropic wire, where off needs no declared token', () => {
+    // Claude never advertises the token, but a toggle model is off whenever the
+    // thinking field is absent — which is what the adaptor sends when disabled.
+    const selectable = availableEffortsForMode('toggle', resolveEffortLevels({
+      thinking_mode: 'toggle',
+      reasoning_efforts: ['low', 'medium', 'high'],
+    }, 'anthropic-messages'), 'anthropic-messages')
+    expect(selectable).toEqual([REASONING_EFFORT_DISABLE, 'low', 'medium', 'high'])
+  })
+
+  it('offers no off for adaptive Anthropic models, where omission is not off', () => {
+    // Adaptive models think on their own, so omitting the field leaves that
+    // default in charge instead of turning thinking off.
+    const selectable = availableEffortsForMode('adaptive', resolveEffortLevels({
+      thinking_mode: 'adaptive',
+      reasoning_efforts: ['low', 'medium', 'high', 'max'],
+    }, 'anthropic-messages'), 'anthropic-messages')
+    expect(selectable).toEqual(['low', 'medium', 'high', 'max'])
+  })
+
   it('offers nothing for a model with no thinking concept', () => {
     expect(availableEffortsForMode('none', ['low', 'medium'])).toEqual([])
   })

--- a/apps/web/src/pages/bots/components/reasoning-effort.test.ts
+++ b/apps/web/src/pages/bots/components/reasoning-effort.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from 'vitest'
 import { REASONING_EFFORT_DISABLE, availableEffortsForMode, nearestEffortToMedium, resolveEffortLevels } from './reasoning-effort'
 
 describe('resolveEffortLevels', () => {
+  it('keeps disable, which declares that off is achievable', () => {
+    expect(resolveEffortLevels({
+      reasoning_efforts: [REASONING_EFFORT_DISABLE, 'low', 'medium', 'high'],
+    }, 'openai-completions')).toEqual([REASONING_EFFORT_DISABLE, 'low', 'medium', 'high'])
+  })
+
+  it('drops none, which is a provider wire value rather than a declaration', () => {
+    expect(resolveEffortLevels({
+      reasoning_efforts: ['none', 'low', 'medium', 'high'],
+    }, 'openai-completions')).toEqual(['low', 'medium', 'high'])
+  })
+
   it('preserves max for Codex and filters client-only efforts', () => {
     expect(resolveEffortLevels({
       reasoning_efforts: ['low', 'xhigh', 'max', 'ultra'],
@@ -12,6 +24,28 @@ describe('resolveEffortLevels', () => {
     expect(resolveEffortLevels({
       reasoning_efforts: ['low', 'xhigh', 'max'],
     }, 'openai-responses')).toEqual(['low', 'xhigh'])
+  })
+})
+
+describe('availableEffortsForMode', () => {
+  it('offers off once, at the front, when the model advertises it', () => {
+    const selectable = availableEffortsForMode('adaptive', resolveEffortLevels({
+      reasoning_efforts: ['low', REASONING_EFFORT_DISABLE, 'medium', 'high'],
+    }, 'openai-completions'))
+    expect(selectable).toEqual([REASONING_EFFORT_DISABLE, 'low', 'medium', 'high'])
+  })
+
+  it('offers no off for a model that cannot be turned off', () => {
+    // A model that never declared it can be turned off has no off shape to send,
+    // so showing Off there is a control that does nothing.
+    const selectable = availableEffortsForMode('adaptive', resolveEffortLevels({
+      reasoning_efforts: ['low', 'medium', 'high'],
+    }, 'openai-completions'))
+    expect(selectable).toEqual(['low', 'medium', 'high'])
+  })
+
+  it('offers nothing for a model with no thinking concept', () => {
+    expect(availableEffortsForMode('none', ['low', 'medium'])).toEqual([])
   })
 })
 
@@ -33,10 +67,10 @@ describe('nearestEffortToMedium', () => {
     expect(nearestEffortToMedium(['max', 'high', 'low', 'none'])).toBe('low')
   })
 
-  it('never returns the disable sentinel that availableEffortsForMode prepends', () => {
-    // The old fallback took efforts[0], which is always "disable" — silently
+  it('never returns off, so an active config cannot resolve to disabled', () => {
+    // The old fallback took efforts[0], which was always "disable" — silently
     // turning reasoning off whenever a model lacked the selected tier.
-    const selectable = availableEffortsForMode('toggle', ['low', 'high'])
+    const selectable = availableEffortsForMode('toggle', [REASONING_EFFORT_DISABLE, 'low', 'high'])
     expect(selectable[0]).toBe(REASONING_EFFORT_DISABLE)
     expect(nearestEffortToMedium(selectable)).toBe('low')
   })

--- a/apps/web/src/pages/bots/components/reasoning-effort.ts
+++ b/apps/web/src/pages/bots/components/reasoning-effort.ts
@@ -6,8 +6,19 @@ export const REASONING_EFFORT_ADAPTIVE = 'adaptive'
 
 export type ThinkingMode = 'toggle' | 'adaptive' | 'only_adaptive' | 'none'
 
-// Effort tiers the UI understands, ordered weakest → strongest.
-export const KNOWN_EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const
+// Active effort tiers the UI understands, ordered weakest → strongest. "off" is
+// REASONING_EFFORT_DISABLE and deliberately absent: it is not a tier, and keeping
+// it out is what stops the nearest-tier fallback from resolving to "off".
+//
+// Keep in sync with orderedReasoningEfforts in internal/models/types.go.
+export const KNOWN_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const
+
+// Values a model may advertise: the active tiers plus the disable token, which
+// declares that the model can be turned off. OpenAI's wire spelling of off
+// ("none") is not declarable — provider adaptors translate into it.
+//
+// Keep in sync with validReasoningEfforts in internal/models/types.go.
+const DECLARABLE_EFFORTS: readonly string[] = [REASONING_EFFORT_DISABLE, ...KNOWN_EFFORTS]
 
 // Keep in sync with normalizesMaxReasoningEffort in internal/conversation/flow/resolver.go.
 // Generic OpenAI-format clients retain the existing max-to-xhigh compatibility
@@ -17,7 +28,9 @@ const MAX_NORMALIZED_CLIENT_TYPES = new Set(['openai-completions', 'openai-respo
 export const EFFORT_LABELS: Record<string, string> = {
   [REASONING_EFFORT_DISABLE]: 'chat.reasoningOff',
   [REASONING_EFFORT_ADAPTIVE]: 'chat.reasoningAdaptive',
-  none: 'chat.reasoningNone',
+  // Legacy spelling of off, kept so values stored before the two tokens were
+  // unified still render — under the same label, not a second one.
+  none: 'chat.reasoningOff',
   minimal: 'chat.reasoningMinimal',
   low: 'chat.reasoningLow',
   medium: 'chat.reasoningMedium',
@@ -29,7 +42,7 @@ export const EFFORT_LABELS: Record<string, string> = {
 export const EFFORT_OPACITY: Record<string, number> = {
   [REASONING_EFFORT_DISABLE]: 0.1,
   [REASONING_EFFORT_ADAPTIVE]: 0.25,
-  none: 0.15,
+  none: 0.1,
   minimal: 0.25,
   low: 0.4,
   medium: 0.6,
@@ -56,14 +69,16 @@ export function resolveThinkingMode(config?: ModelConfigLike | null): ThinkingMo
   return config?.compatibilities?.includes('reasoning') ? 'toggle' : 'none'
 }
 
-// resolveEffortLevels returns the model's supported effort tiers (filtered to
-// known ones), falling back to the common low/medium/high subset. Generic
-// OpenAI-format clients use xhigh as the highest effort tier, while Codex can
-// expose max directly.
+// resolveEffortLevels returns what the model advertises — its active tiers, plus
+// the disable token when the model can be turned off — falling back to the common
+// low/medium/high subset when nothing is advertised. Generic OpenAI-format clients
+// use xhigh as the highest effort tier, while Codex can expose max directly.
+//
+// The disable token stays in the result because that is how the picker learns
+// whether "off" is achievable at all. It is dropped from the tier ordering
+// instead (see KNOWN_EFFORTS), so it can never be chosen as an active effort.
 export function resolveEffortLevels(config?: ModelConfigLike | null, clientType?: string | null): string[] {
-  const efforts = (config?.reasoning_efforts ?? []).filter((e) =>
-    (KNOWN_EFFORTS as readonly string[]).includes(e),
-  )
+  const efforts = (config?.reasoning_efforts ?? []).filter((e) => DECLARABLE_EFFORTS.includes(e))
   const levels = efforts.length > 0 ? efforts : ['low', 'medium', 'high']
   if (MAX_NORMALIZED_CLIENT_TYPES.has(clientType ?? '')) {
     return levels.filter((e) => e !== 'max')
@@ -74,9 +89,9 @@ export function resolveEffortLevels(config?: ModelConfigLike | null, clientType?
 // nearestEffortToMedium picks the tier closest to medium from levels, breaking
 // ties toward the weaker tier. It is the fallback when a model does not
 // advertise medium: [minimal, low] -> low, [high, max] -> high, [low, high] -> low.
-// Values outside KNOWN_EFFORTS (including the "disable" sentinel that
-// availableEffortsForMode prepends) are ignored, so passing a selectable list
-// straight in never yields "off"; returns '' when no usable tier is present.
+// Values outside KNOWN_EFFORTS — including the disable token, which a model may
+// advertise — are ignored, so passing a selectable list straight in never yields
+// "off"; returns '' when no usable tier is present.
 //
 // Keep in sync with NearestEffortToMedium in internal/models/types.go.
 export function nearestEffortToMedium(levels: string[]): string {
@@ -101,10 +116,18 @@ export function nearestEffortToMedium(levels: string[]): string {
   return best
 }
 
-// availableEffortsForMode builds the selectable list for a thinking mode:
-//   - none:          nothing
-//   - adaptive/toggle: an explicit "off" plus the effort tiers
+// availableEffortsForMode builds the selectable list for a thinking mode. A model
+// with no thinking concept offers nothing; otherwise the options are exactly what
+// the model advertises, with "off" hoisted to the front when it is among them.
+//
+// Nothing is prepended unconditionally any more. Doing so offered "off" on models
+// that never declared they can be turned off, where picking it has no defined
+// effect: the provider adaptor has no off shape to send, so it omits the field and
+// the model's default thinking behavior stands.
 export function availableEffortsForMode(mode: ThinkingMode, levels: string[]): string[] {
   if (mode === 'none') return []
-  return [REASONING_EFFORT_DISABLE, ...levels]
+  const tiers = levels.filter((e) => e !== REASONING_EFFORT_DISABLE)
+  return levels.includes(REASONING_EFFORT_DISABLE)
+    ? [REASONING_EFFORT_DISABLE, ...tiers]
+    : tiers
 }

--- a/apps/web/src/pages/bots/components/reasoning-effort.ts
+++ b/apps/web/src/pages/bots/components/reasoning-effort.ts
@@ -20,6 +20,12 @@ export const KNOWN_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'
 // Keep in sync with validReasoningEfforts in internal/models/types.go.
 const DECLARABLE_EFFORTS: readonly string[] = [REASONING_EFFORT_DISABLE, ...KNOWN_EFFORTS]
 
+// How "off" was spelled in declarations before the two tokens were unified.
+// Configs written under the old spelling are rewritten on read, not discarded.
+//
+// Keep in sync with normalizeAdvertisedEfforts in internal/models/types.go.
+const LEGACY_OFF_EFFORT = 'none'
+
 // Keep in sync with normalizesMaxReasoningEffort in internal/conversation/flow/resolver.go.
 // Generic OpenAI-format clients retain the existing max-to-xhigh compatibility
 // behavior; Codex uses the effort levels advertised by its catalog directly.
@@ -77,8 +83,14 @@ export function resolveThinkingMode(config?: ModelConfigLike | null): ThinkingMo
 // The disable token stays in the result because that is how the picker learns
 // whether "off" is achievable at all. It is dropped from the tier ordering
 // instead (see KNOWN_EFFORTS), so it can never be chosen as an active effort.
+//
+// The legacy spelling is rewritten rather than filtered out. A config that still
+// advertises "none" describes a model that can be turned off, so dropping it would
+// hide Off from a model that supports it — for as long as that row goes unwritten.
 export function resolveEffortLevels(config?: ModelConfigLike | null, clientType?: string | null): string[] {
-  const efforts = (config?.reasoning_efforts ?? []).filter((e) => DECLARABLE_EFFORTS.includes(e))
+  const advertised = (config?.reasoning_efforts ?? [])
+    .map(e => (e === LEGACY_OFF_EFFORT ? REASONING_EFFORT_DISABLE : e))
+  const efforts = advertised.filter((e, i) => DECLARABLE_EFFORTS.includes(e) && advertised.indexOf(e) === i)
   const levels = efforts.length > 0 ? efforts : ['low', 'medium', 'high']
   if (MAX_NORMALIZED_CLIENT_TYPES.has(clientType ?? '')) {
     return levels.filter((e) => e !== 'max')

--- a/apps/web/src/pages/bots/components/reasoning-effort.ts
+++ b/apps/web/src/pages/bots/components/reasoning-effort.ts
@@ -31,6 +31,14 @@ const LEGACY_OFF_EFFORT = 'none'
 // behavior; Codex uses the effort levels advertised by its catalog directly.
 const MAX_NORMALIZED_CLIENT_TYPES = new Set(['openai-completions', 'openai-responses'])
 
+// Clients whose wire format expresses "off" by omission rather than by a value.
+// Anthropic's Messages API has no off token: thinking is off when the field is
+// absent, which is exactly what the adaptor sends for a disabled toggle model.
+// No catalog advertises the disable token for Claude either — the capability
+// registry never marks an Anthropic entry as supporting the off effort — so
+// gating on the declaration alone would hide a control that works.
+const IMPLICIT_OFF_CLIENT_TYPES = new Set(['anthropic-messages'])
+
 export const EFFORT_LABELS: Record<string, string> = {
   [REASONING_EFFORT_DISABLE]: 'chat.reasoningOff',
   [REASONING_EFFORT_ADAPTIVE]: 'chat.reasoningAdaptive',
@@ -129,17 +137,25 @@ export function nearestEffortToMedium(levels: string[]): string {
 }
 
 // availableEffortsForMode builds the selectable list for a thinking mode. A model
-// with no thinking concept offers nothing; otherwise the options are exactly what
-// the model advertises, with "off" hoisted to the front when it is among them.
+// with no thinking concept offers nothing; otherwise the options are the model's
+// active tiers, with "off" hoisted to the front when off is actually reachable.
 //
-// Nothing is prepended unconditionally any more. Doing so offered "off" on models
-// that never declared they can be turned off, where picking it has no defined
-// effect: the provider adaptor has no off shape to send, so it omits the field and
-// the model's default thinking behavior stands.
-export function availableEffortsForMode(mode: ThinkingMode, levels: string[]): string[] {
+// Off is no longer prepended unconditionally. Doing so offered it on models that
+// cannot be turned off, where picking it has no defined effect: the adaptor has no
+// off shape to send, so it omits the field and the model's default thinking stands.
+export function availableEffortsForMode(mode: ThinkingMode, levels: string[], clientType?: string | null): string[] {
   if (mode === 'none') return []
   const tiers = levels.filter((e) => e !== REASONING_EFFORT_DISABLE)
-  return levels.includes(REASONING_EFFORT_DISABLE)
-    ? [REASONING_EFFORT_DISABLE, ...tiers]
-    : tiers
+  return canTurnOff(mode, levels, clientType) ? [REASONING_EFFORT_DISABLE, ...tiers] : tiers
+}
+
+// canTurnOff reports whether picking "off" reaches the model: either the model
+// advertises the token, or its client expresses off by omitting the field.
+//
+// The omission rule is limited to toggle models, where thinking only happens when
+// asked for. Under adaptive thinking the model decides on its own, so omitting the
+// field leaves that default in charge rather than turning thinking off.
+function canTurnOff(mode: ThinkingMode, levels: string[], clientType?: string | null): boolean {
+  if (levels.includes(REASONING_EFFORT_DISABLE)) return true
+  return mode === 'toggle' && IMPLICIT_OFF_CLIENT_TYPES.has(clientType ?? '')
 }

--- a/cmd/synccaps/main.go
+++ b/cmd/synccaps/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -183,6 +184,15 @@ func applyToModel(model *yaml.Node, mode string, efforts []string) bool {
 	wantEfforts := efforts
 	if len(wantEfforts) == 0 {
 		wantEfforts = []string{"low", "medium", "high"}
+	}
+	// A hand-maintained disable token is preserved, not overwritten. LiteLLM's
+	// only off signal is the OpenAI-wire supports_none_reasoning_effort flag, so
+	// for providers whose off travels another way (DeepSeek/MiniMax toggle via
+	// chat_completions_compat) the token can only ever come from the template.
+	// Registry silence must not strip what the registry cannot know about.
+	if existing := mapValue(cfg, "reasoning_efforts"); seqContains(existing, "disable") &&
+		!slices.Contains(wantEfforts, "disable") {
+		wantEfforts = append([]string{"disable"}, wantEfforts...)
 	}
 
 	changed := false

--- a/cmd/synccaps/main_test.go
+++ b/cmd/synccaps/main_test.go
@@ -146,3 +146,44 @@ models:
 		t.Fatalf("output missing enrichment:\n%s", got)
 	}
 }
+
+func TestEnrichFilePreservesHandMaintainedDisableToken(t *testing.T) {
+	t.Parallel()
+
+	// LiteLLM's only off signal is the OpenAI-wire supports_none_reasoning_effort
+	// flag; for DeepSeek/MiniMax-style toggle-off (via chat_completions_compat)
+	// the registry is structurally silent. A hand-placed disable token must
+	// survive re-sync rather than being clobbered by the derived tier list.
+	resolver, err := capabilities.NewResolver([]byte(`{
+		"toggle-model": {"mode": "chat", "supports_reasoning": true}
+	}`))
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "provider.yaml")
+	fixture := `name: Test
+client_type: openai-completions
+models:
+  - model_id: toggle-model
+    name: Toggle
+    type: chat
+    config:
+      compatibilities: [reasoning, tool-call]
+      thinking_mode: toggle
+      reasoning_efforts: [disable, low, medium, high]
+`
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	changed, err := enrichFile(path, resolver, false)
+	if err != nil {
+		t.Fatalf("enrichFile: %v", err)
+	}
+	if changed != 0 {
+		gotBytes, _ := os.ReadFile(path) //nolint:gosec // test reads its own temp fixture
+		t.Fatalf("changed = %d, want 0 (disable token should be preserved):\n%s", changed, gotBytes)
+	}
+}

--- a/conf/providers/azure-openai.yaml
+++ b/conf/providers/azure-openai.yaml
@@ -293,7 +293,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 272000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high]
+      reasoning_efforts: [disable, minimal, low, medium, high]
   - model_id: "gpt-5.1-2025-11-13"
     name: "GPT 5.1 2025 11 13"
     type: chat
@@ -301,7 +301,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 272000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high]
+      reasoning_efforts: [disable, minimal, low, medium, high]
   - model_id: "gpt-5.1-chat"
     name: "GPT 5.1 Chat"
     type: chat
@@ -309,7 +309,7 @@ models:
       compatibilities: [vision, tool-call, reasoning]
       context_window: 128000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high]
+      reasoning_efforts: [disable, low, medium, high]
   - model_id: "gpt-5.1-chat-2025-11-13"
     name: "GPT 5.1 Chat 2025 11 13"
     type: chat
@@ -317,7 +317,7 @@ models:
       compatibilities: [vision, reasoning]
       context_window: 128000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high]
+      reasoning_efforts: [disable, low, medium, high]
   - model_id: "gpt-5.2"
     name: "GPT 5.2"
     type: chat
@@ -325,7 +325,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 272000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high, xhigh]
+      reasoning_efforts: [disable, minimal, low, medium, high, xhigh]
   - model_id: "gpt-5.2-2025-12-11"
     name: "GPT 5.2 2025 12 11"
     type: chat
@@ -333,7 +333,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 272000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high, xhigh]
+      reasoning_efforts: [disable, minimal, low, medium, high, xhigh]
   - model_id: "gpt-5.2-chat"
     name: "GPT 5.2 Chat"
     type: chat
@@ -365,7 +365,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high, xhigh]
+      reasoning_efforts: [disable, minimal, low, medium, high, xhigh]
   - model_id: "gpt-5.4-2026-03-05"
     name: "GPT 5.4 2026 03 05"
     type: chat
@@ -381,7 +381,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "gpt-5.4-mini-2026-03-17"
     name: "GPT 5.4 Mini 2026 03 17"
     type: chat
@@ -389,7 +389,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "gpt-5.4-nano"
     name: "GPT 5.4 Nano"
     type: chat
@@ -397,7 +397,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "gpt-5.4-nano-2026-03-17"
     name: "GPT 5.4 Nano 2026 03 17"
     type: chat
@@ -405,7 +405,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "gpt-5.5"
     name: "GPT 5.5"
     type: chat
@@ -413,7 +413,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "gpt-5.5-2026-04-23"
     name: "GPT 5.5 2026 04 23"
     type: chat
@@ -421,7 +421,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "gpt-audio-1.5-2026-02-23"
     name: "GPT Audio 1.5 2026 02 23"
     type: chat

--- a/conf/providers/deepseek.yaml
+++ b/conf/providers/deepseek.yaml
@@ -13,7 +13,10 @@ models:
       compatibilities: [tool-call, reasoning]
       context_window: 1000000
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      # disable is hand-maintained: LiteLLM has no off signal for DeepSeek, but the
+      # chat_completions_compat layer maps a disabled toggle onto thinking-off
+      # (models.dev and OpenRouter both confirm V4 can be turned off).
+      reasoning_efforts: [disable, low, medium, high]
 
   - model_id: deepseek-v4-pro
     name: DeepSeek V4 Pro
@@ -22,7 +25,7 @@ models:
       compatibilities: [tool-call, reasoning]
       context_window: 1000000
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      reasoning_efforts: [disable, low, medium, high]
 
   - model_id: deepseek-chat
     name: DeepSeek V4 Flash (legacy non-thinking)

--- a/conf/providers/github-copilot.yaml
+++ b/conf/providers/github-copilot.yaml
@@ -56,7 +56,7 @@ models:
     config:
       context_window: 400000
       compatibilities: [vision, tool-call, reasoning]
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
 
   - model_id: gpt-5.4
     name: GPT-5.4
@@ -94,7 +94,7 @@ models:
     config:
       context_window: 264000
       compatibilities: [vision, tool-call, reasoning]
-      reasoning_efforts: [none, low, medium, high]
+      reasoning_efforts: [disable, low, medium, high]
 
   - model_id: text-embedding-3-small
     name: Embedding V3 small

--- a/conf/providers/openai.yaml
+++ b/conf/providers/openai.yaml
@@ -12,7 +12,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high, xhigh]
+      reasoning_efforts: [disable, minimal, low, medium, high, xhigh]
 
   - model_id: gpt-5.4-pro
     name: GPT-5.4 Pro
@@ -30,7 +30,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 400000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
 
   - model_id: gpt-5.4-nano
     name: GPT-5.4 nano
@@ -39,7 +39,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 400000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
 
   - model_id: gpt-5.3-chat-latest
     name: GPT-5.3 Chat
@@ -66,7 +66,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 400000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high, xhigh]
+      reasoning_efforts: [disable, minimal, low, medium, high, xhigh]
 
   - model_id: gpt-5.2-codex
     name: GPT-5.2 Codex
@@ -102,7 +102,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 400000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high]
+      reasoning_efforts: [disable, minimal, low, medium, high]
 
   - model_id: gpt-5.1-chat-latest
     name: GPT-5.1 Chat
@@ -111,7 +111,7 @@ models:
       compatibilities: [vision, file-input, tool-call]
       context_window: 128000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high]
+      reasoning_efforts: [disable, minimal, low, medium, high]
 
   - model_id: gpt-5.1-codex-max
     name: GPT-5.1 Codex Max

--- a/conf/providers/openrouter.yaml
+++ b/conf/providers/openrouter.yaml
@@ -1313,7 +1313,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 400000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high]
+      reasoning_efforts: [disable, minimal, low, medium, high]
   - model_id: "openai/gpt-5.1-chat"
     name: "OpenAI: GPT-5.1 Chat"
     type: chat
@@ -1351,7 +1351,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 400000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high, xhigh]
+      reasoning_efforts: [disable, minimal, low, medium, high, xhigh]
   - model_id: "openai/gpt-5.2-chat"
     name: "OpenAI: GPT-5.2 Chat"
     type: chat
@@ -1395,7 +1395,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, minimal, low, medium, high, xhigh]
+      reasoning_efforts: [disable, minimal, low, medium, high, xhigh]
   - model_id: "openai/gpt-5.4-image-2"
     name: "OpenAI: GPT-5.4 Image 2"
     type: chat
@@ -1409,7 +1409,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 400000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "openai/gpt-5.4-nano"
     name: "OpenAI: GPT-5.4 Nano"
     type: chat
@@ -1417,7 +1417,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 400000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "openai/gpt-5.4-pro"
     name: "OpenAI: GPT-5.4 Pro"
     type: chat
@@ -1433,7 +1433,7 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1050000
       thinking_mode: toggle
-      reasoning_efforts: [none, low, medium, high, xhigh]
+      reasoning_efforts: [disable, low, medium, high, xhigh]
   - model_id: "openai/gpt-5.5-pro"
     name: "OpenAI: GPT-5.5 Pro"
     type: chat

--- a/docs/superpowers/specs/2026-08-10-reasoning-capability-architecture-proposal.md
+++ b/docs/superpowers/specs/2026-08-10-reasoning-capability-architecture-proposal.md
@@ -1,0 +1,233 @@
+# Reasoning 能力元数据:别再打补丁了,聊聊怎么根治
+
+> 状态:**提案,等团队讨论**。同意了才动手。
+> 起因:review PR #966 时发现的结构性问题。相关上下文:#563、#926、#966。
+> 日期:2026-08-10
+
+## TL;DR
+
+"这个模型的 thinking 能不能关、有哪些档位"这个问题,我们现在有**三个地方各答各的**(Web picker、`/reasoning` 命令、后端 resolver),而唯一真正知道答案的 adaptor 层没有被任何一方问过。再加上"能否关闭"被塞在 `reasoning_efforts` 字符串列表里当哨兵值,导致每次改动都在漏水——#966 一个 PR 里就自己堵了三次洞,而且现在 DeepSeek/MiniMax 还漏着。
+
+提案分三步:**① 后端算好下发,前端只渲染;② catalog schema 把"能力"和"档位"拆开;③ 数据源主力换成 models.dev,LiteLLM 降级为价格源。** 三步独立,可以分开做,第一步收益最大。
+
+---
+
+## 一、起因:#966 是怎么把我们带到这里的
+
+### 这条 PR 链的故事
+
+先快速回放一下历史,不然看不懂问题在哪:
+
+- **#563** 引入了 capability 驱动的 thinking 元数据:`thinking_mode` + `reasoning_efforts`,数据从 LiteLLM registry 同步(synccaps)。当时 picker 的"关闭"选项(`disable`)是无条件排在最前面的,同时 `none` 是模型可声明的档位。
+- **#926** 干掉了 `reasoning_enabled` 布尔,让 `reasoning_effort` 一个字段同时承担开关和档位:存 `disable` 就是关,存别的就是档位。
+- **#966**(还没合)发现 `disable` 和 `none` 是同一个状态的两个名字,俩都出现在 picker 里,于是统一成 `disable`。
+
+#966 的方向没问题,但看它自己的 commit 演化,味道就不对了:
+
+1. **Commit 1**:统一 token,`disable` 变成可声明的。
+2. **Commit 2**:糟糕,`disable` 进了 effort 列表之后,`pickEffort` 直读 stored setting 会把它当成活跃档位发上 wire(没有任何厂商认识 "disable" 这个词)→ 加守卫。
+3. **Commit 3**:review 指出存量数据和没再生成的 registry 还在说 `none` → 在 ModelConfig 读写两侧加 normalize,Go 和 TS 各写一份。
+4. **Commit 4**:Copilot review 指出 Claude 全系的 Off 没了(Anthropic 的 wire 上"关"是靠省略字段表达的,catalog 永远不会声明 `disable`)→ 前端硬编码一个 `IMPLICIT_OFF_CLIENT_TYPES = {'anthropic-messages'}` 名单救回来;顺带还得把 `disable` 从 `anthropicEffortEra` 的判断信号里摘出去,因为往列表里塞 token 干扰了一个不相干的世代推断。
+
+一个 PR,四个 commit,后三个都在堵前面开的洞。这不是作者水平问题——是**每个补丁都逻辑自洽,但补丁越打越说明位置不对**。
+
+### 我们还能立刻找到下一个洞
+
+Commit 4 修了 Claude,但**同型的问题在 DeepSeek 上还在**(一度以为 MiniMax 也是,后来发现更有意思,见下):
+
+- DeepSeek 的 YAML 是 `client_type: openai-completions` + `thinking_mode: toggle`,`reasoning_efforts` 里没有 `disable`;
+- 后端 `sdk.go` 的 compat 分支**明确支持关闭**——`rc.Disabled` 时发 `reasoning_effort: "none"`,SDK compat 层翻译成 thinking-off;
+- 但前端 `canTurnOff` 一看:没有 `disable` token,client type 也不在 Anthropic 名单里 → **Web 端 Off 被藏掉了**。而 `/reasoning off` 命令照常提供,而且真的生效。
+
+(→ 已修:本 PR 给 deepseek-v4-flash/pro 的 YAML 补了 `disable` token,synccaps 改为保留手维护的 disable 不被 re-sync 冲掉。)
+
+**MiniMax 则是一个反转,而且反转本身更能说明问题**:我们本以为它和 DeepSeek 一样漏了 Off(后端 compat 同样支持翻译),但交叉核对 models.dev(`reasoning_options = []`,always-on)和 OpenRouter(`mandatory: true`)后发现,**M2.x 全系根本关不掉**——反倒是我们 YAML 里 M2.5/M2.1-Lightning 标着 `thinking_mode: toggle` + 三档 efforts 这份数据本身可疑。也就是说,同一份残缺元数据,在 DeepSeek 上表现为"藏了一个能用的控件",在 MiniMax 上表现为"差点给一个假控件正名"。单源数据两头都能骗到你,这正是后文"多源交叉校验"的现实论据。MiniMax 的数据修正留给后续(需要探针或官方文档确认 Lightning 变体的真实行为)。
+
+这不是碰巧漏掉,是结构性必然:"能不能关"的真相只存在于 adaptor 层(Anthropic 靠省略、DeepSeek/MiniMax 靠 compat 翻译、Google 目前压根什么都不发),但决策却让前端拿 `(mode, levels, clientType)` 这个残缺投影去猜。前端连 `chat_completions_compat` 都看不到,它不可能答对。
+
+顺带一提 Gemini 是同一问题的另一面:picker 提供 low/medium/high,但 `BuildReasoningOptions` 对 Google 永远返回 nil——选了也白选。这坑 #966 之前就有。
+
+### 病根到底是什么
+
+两句话:
+
+**1. 能力布尔值伪装成了 tier 哨兵。**"这个模型能被关掉"是个 capability boolean,却被塞进 `reasoning_efforts` 字符串列表里当成员。于是每个读这个列表的人都得记得把它滤掉:`orderedReasoningEfforts` 排除它、`NearestEffortToMedium` 忽略它、`KNOWN_EFFORTS` 不含它、`pickEffort` 加守卫、`availableEffortsForMode` 拆开重排、`anthropicEffortEra` 还得专门声明"这个 token 不算信号"。一个列表被四种消费者读出四种含义,commit 2 和 commit 4 的洞都是这个重载的直接产物。
+
+有人可能问:那把 bool 反过来存("不能关"名单)行不行?不行,这条链已经把两个极性都试过了:#966 之前是"默认都能关"(gpt-5.0 关不掉也摆着 Off,点了没效果);#966 之后是"默认都不能关"(Claude 全系立刻丢 Off,得打名单补丁)。**两个全局默认值各错一半**,因为"能否关闭"根本不是一个能有统一默认的逐模型事实,它按 provider 家族分叉——这只能由知道家族语义的那一层来回答。
+
+**2. "什么可选"这个策略有三份独立实现。** Web picker(TS 推导)、`/reasoning` 命令(硬编码 off+low~xhigh,完全不看模型)、后端 resolver(Go),三份逻辑,7 处 "keep in sync" 注释横跨两种语言。每处都是一条会断的手动同步链,Commit 4 的 `IMPLICIT_OFF_CLIENT_TYPES` 本质上是把 adaptor 知识手抄一份到前端——抄漏了 DeepSeek/MiniMax 就是证明。
+
+### LiteLLM 也帮不了我们
+
+有人会想:是不是 LiteLLM 数据再全一点就好了?我们实测拉了 registry(2988 条)做了普查:
+
+- 整个 registry 里跟"关闭"沾边的字段只有一个 `supports_none_reasoning_effort`,82 条,**全部是 OpenAI wire 的模型**。173 条 Claude 里零个。
+- 这很合理:这个 flag 描述的是"模型接受 `reasoning_effort: 'none'` 这个枚举值"这个 **OpenAI wire 专属事实**,不是"可关闭"这个抽象能力。Anthropic wire 上不存在这个值,LiteLLM 永远不会给 Claude 标它。
+- 翻了近期 PR/issue,没有修这个缺口的计划,反而有 issue 抱怨它把 DeepSeek 的映射搞错了。
+
+所以 `discover.go` 里 `supports_none_reasoning_effort → disable token` 这条映射,是把一个单一 wire 的事实当成了中立能力写进 catalog。对 OpenAI 系恰好成立,对其他家族系统性缺失。
+
+---
+
+## 二、经过:我们调研了业界怎么解决这个问题
+
+派了两路调查:一路实测各候选数据源,一路翻同类开源项目的源码。结论出奇地一致。
+
+### 数据源:models.dev 已经解决了语义表达问题
+
+**models.dev**(sst/models.dev,MIT,6.3k stars,小时级自动 sync):182 个 provider / 6,247 个模型,我们要的 provider 全命中(包括 LiteLLM 没有的 GitHub Copilot、MiniMax 国内外双站)。关键是它的 `reasoning_options` 结构,业界已经收敛到这个语义模型:
+
+```toml
+# DeepSeek V4 Pro 的真实数据
+[[reasoning_options]]
+type = "toggle"            # 有独立开关,可关闭
+[[reasoning_options]]
+type = "effort"
+values = ["high", "max"]   # 档位枚举
+```
+
+三种 option 类型,可关闭性有精确三态:
+
+- `effort` 的 values 含 `none` → 用 effort=none 关(OpenAI 系);
+- 独立 `toggle` 条目 → 有单独的 on/off wire 字段(DeepSeek/MiniMax/旧 Claude);
+- `reasoning_options = []` → 会推理但调用方不可控(deepseek-reasoner 这种 always-on)。
+
+而且有成熟的编辑规范和贡献者审核流程约束数据质量。
+
+**OpenRouter `/api/v1/models`** 是可关闭性最干净的真值源:2026 年新增的顶层 `reasoning` 对象带 `mandatory`(true = 拒绝关闭)和 `default_enabled`——"能否关" = `!mandatory`,一个字段答完。免鉴权实时 API,适合交叉校验,但没有 Azure/Copilot 条目,当不了主源。
+
+**Anthropic 官方 `/v1/models`** 2026 版直接返回 `capabilities.thinking.types.{enabled,adaptive}.supported`——这是 adaptive 世代的权威源。
+
+**LiteLLM** 的价格粒度是全场最全的(cache 分时、分层计价、Azure/Bedrock 区域条目)——但查了 synccaps 的实际消费面,我们一个价格字段都没读过,只用能力 flag 和 `max_input_tokens`。这两样 models.dev 都有,所以 LiteLLM 可以直接退役(详见第三步)。
+
+### 同类项目:头部玩家全部走向"后端解析、前端渲染"
+
+看了 OpenCode、Cherry Studio、LobeChat、Open WebUI、aider、Cline、Roo Code、Vercel AI SDK。模式非常清晰地分成两组:
+
+**做对的**:
+
+- **Cline**(和我们架构最同构的参照):同样 build-time 从上游 JSON 生成目录,源是 models.dev,schema 原样采纳 `reasoning_options`。可关闭性派生就一行:`supportsOff = toggle ∨ effort.has("none")`。**不需要任何前端 client-type 名单。** 数据缺失时的 Claude 世代 fallback 也有成熟规则:"目录里有 effort control ⇒ adaptive 世代;未知 Claude id 默认按最新世代"(向前兼容,新模型发布当天不至于坏)。
+- **OpenCode**:把 reasoning_options 编译成 `variants` map,UI 只循环 key,对 reasoning 语义零知识。
+- **Cherry Studio**:main 进程投影出 `selectableEfforts` 给 renderer,文档明文写着 "UI helpers do not inspect model IDs"。Anthropic 世代方言显式建模为 `wireDialect` 字段。
+
+**做错的(也就是我们现在的样子)**:
+
+- **aider**:LiteLLM(价格)+ 804 条手工 YAML(行为)+ 60 行正则兜底,Anthropic 4.7 的 adaptive 问题靠 `"4.7" not in model` 这种**硬编码负名单**处理——和我们的 `IMPLICIT_OFF_CLIENT_TYPES` 如出一辙。LiteLLM 的 registry 缺口在它那边也是长期 issue 源。
+- **Roo Code**:集中式手工布尔字段(`supportsReasoningBudget/Binary/Effort`),表达力不足后被迫扩成数组,per-model-id 修正补丁堆积。
+- **LobeChat**:每个厂商每一代模型加一个专属枚举值 + 专属控件组件(`gpt5_1ReasoningEffort`、`opus47Effort`……约 40 个),维护成本全场最高。
+
+对照很残酷:**我们现在走的路,尽头就是 aider 的 804 条 YAML 和 LobeChat 的 40 个控件组件。** 而正确的路已经有三个项目验证过了。
+
+### 两条路走到最后,账单长什么样
+
+上面的定性判断值得展开成可以横向比的账目。先说清楚:两条路的分界不是代码质量,是**知识存放的形态**——补丁路线把"哪个模型有什么怪癖"存成一条条例外(正则、名单、专属枚举),抽象路线把它存成一个语义 schema 加一层派生。例外之间互相不复用,所以边际成本恒定甚至递增;schema 摊销一次,新模型只是多一行数据。
+
+**补丁路线的实测账单**(都是当前 main 分支数出来的,不是估算):
+
+| 项目 | 存量 | 新出一代模型要干什么 | 症状案例 |
+|---|---|---|---|
+| aider | 804 条手工 YAML + 60+ 行子串匹配链 | 加 YAML 条目;有 wire 怪癖就改通用正则 | Claude 4.7 不收 budget → 硬编码 `"4.7" not in model`,openrouter/ 前缀还得再抄一遍 |
+| LobeChat | ~40 个 reasoning 控件组件,每厂商每代一个专属枚举 | 加枚举值 + 加组件 + runtime 硬编码规则 | `gpt5_1ReasoningEffort` 和 `gpt5_2ReasoningEffort` 是两个字段——相邻两代都不能复用 |
+| Roo Code | 多布尔字段被迫扩成数组 + OpenRouter fetcher 里 per-model-id 修正堆 | 改字段定义或加 per-id 修正 | "disable" vs "none" 双语义是踩坑后补的,注释专门解释两者 UI 同显示但行为不同 |
+
+**抽象路线的实测账单**:
+
+| 项目 | 存量 | 新出一代模型要干什么 |
+|---|---|---|
+| Cline | 一个 `reasoning_options` schema + `supportsOff` 一行派生 + 一个 era fallback 函数 | 等 models.dev 数据同步(小时级);未知 Claude 默认最新世代,发布当天不坏 |
+| OpenCode | 数据编译成 variants map,UI 零知识 | 同上;fallback 正则族只在数据缺失时兜底 |
+| Cherry Studio | 生成式 registry + `wireDialect` 显式字段,renderer 禁看 model id | creator 规则 2-3 天一改,但改动面集中、CI 防漂移 |
+
+**再对我们自己算一遍。** 现状(补丁路线上的 t+1 时刻):策略逻辑 3 份(Web picker TS / `/reasoning` 命令 / 后端 resolver),跨 Go/TS 的 "keep in sync" 注释 7 处,client-type 特判名单 1 个(刚打的,Claude),已知未修的同型 bug 2 个(DeepSeek/MiniMax 的 Off、Gemini 的假档位)。照此外推,每接一个新 provider 家族,三份拷贝各有一次漏的机会,名单再长一条;aider 的 804 条就是这个循环跑了五年的样子。
+
+改造后(提案三步走完):后端 1 个解析函数是唯一出口,前端 0 份能力逻辑、0 个名单,"keep in sync" 0 处;新 provider 家族的接入成本 = 在解析函数里加一个 case(这个 case 反正要写——adaptor 的 wire 编码躲不掉,区别只是写一处还是抄三处);新模型的接入成本 ≈ 0(数据同步 + 向前兼容默认)。
+
+一次性实现成本当然是抽象路线更高——第一步要动 API、删重写前端,第二步要迁 schema。但这笔钱三个项目已经替我们验证过值得花,而且我们的删除量可观:TS 侧 `KNOWN_EFFORTS`/`canTurnOff`/`nearestEffortToMedium` 镜像和名单全部退役,净代码量大概率是负的。
+
+---
+
+## 三、结果:提案的三步走
+
+三步互相独立,可以分开成 PR、分开排期。第一步不依赖换源,收益最大,建议先做。
+
+### 第一步:后端解析,前端渲染(架构收敛)
+
+后端加一个单一出口,按 `client_type + compat + catalog` 算出每个模型的:
+
+```json
+{
+  "supports_off": true,
+  "selectable_efforts": ["low", "medium", "high"],
+  "default_effort": "medium"
+}
+```
+
+通过 models API / SDK 下发。这些知识现在已经全在后端了(`offEffortFor`、`BuildReasoningOptions` 的 compat 分支、adaptor 语义),只是散着、没有一个出口。
+
+然后:
+
+- Web picker 和 `/reasoning` 命令降级为纯渲染;
+- 删掉 TS 侧的 `KNOWN_EFFORTS`、`canTurnOff`、`nearestEffortToMedium` 镜像、`IMPLICIT_OFF_CLIENT_TYPES` 名单;
+- 7 处 "keep in sync" 注释全部退役;
+- **DeepSeek/MiniMax 的 Off 缺失顺手就修了**——后端 compat 层本来就知道它们能关。
+
+### 第二步:catalog schema 把能力和档位拆开
+
+provider YAML 从:
+
+```yaml
+reasoning_efforts: [disable, minimal, low, medium, high]
+```
+
+迁到 models.dev 同构的结构(具体字段名可以讨论,语义对齐就行):
+
+```yaml
+reasoning:
+  toggle: true                # 或者由 effort 含 none 表达,二选一
+  efforts: [minimal, low, medium, high]
+  wire: adaptive              # Anthropic 世代显式化,不再从档位列表猜
+```
+
+这样:
+
+- `disable` 哨兵从档位列表退役,`pickEffort` 的守卫、`orderedReasoningEfforts` 的排除注释这些防御性代码都可以删;
+- `anthropicEffortEra`(从档位内容猜 wire 世代)换成显式字段 + Cline 式 fallback("未知 Claude 默认最新世代");
+- #966 commit 3 的双语言永久 normalize 退化为一次性数据迁移。
+
+### 第三步:数据源换血
+
+- synccaps 主源切 **models.dev**(建议直接消费它 GitHub 仓库的 TOML,api.json 域名从国内访问偶发超时);
+- **OpenRouter** `/api/v1/models` 的 `reasoning.mandatory` 做定期交叉校验,OpenRouter 渠道的模型直接用它;
+- **Anthropic 官方 API** 按需补 adaptive 世代权威值;
+- **LiteLLM 直接退役**。查了一下 synccaps 的实际消费面:我们从 LiteLLM 只读能力 flag 和 `max_input_tokens`,**一个价格字段都没碰**(开源仓库也不需要计价)。models.dev 的 `limit.context`/`limit.output` 覆盖 context window,能力语义又强一截,所以 LiteLLM 没有留下的理由——顶多在 synccaps 里留个交叉校验开关。
+
+### 那 #966 怎么办:合,但为什么不一步到位?
+
+**建议合。** 单一 token、picker 诚实化、`none` 降回 wire 拼写,都是净改进,而且它的 normalize 边界处理为第二步的迁移铺了路。
+
+"为什么不干脆撤了 #966,直接一步到位做终态"——这个问题值得正面回答,因为答案不是"懒",是三个实际约束:
+
+1. **一步到位 = 一个巨型 PR。** 终态横跨 API schema(加字段)、DB 迁移(存量 `reasoning_efforts` 数据)、synccaps 重写(换源)、前端删重写、`/reasoning` 命令改造——一次做完就是又一个 #563 规模的 PR(50 个文件起步),review 质量和回滚粒度都会崩。而这三步天然有依赖顺序:第一步(下发解析结果)不动数据格式,先把消费端收敛;第二步(schema)才动数据;第三步(换源)只动 synccaps。每步单独可测、单独可回滚。
+2. **#966 修的 bug 是现行的,终态是需要团队排期的。** "picker 里 Off/None 并列"、"Off 出现在关不掉的模型上"是用户现在就能踩到的问题,#966 已经写完、测完、review 过一轮。让一个已完成的修复排队等一个还没开工的架构改造,等于把已知 bug 多养一个季度。
+3. **#966 的产出物不会被终态浪费。** 单一 token 约定、`IsReasoningDisabled` 的 legacy 兼容、normalize 的边界位置(写前/读后),这些在第二步里都直接复用——迁移脚本就是把 normalize 逻辑跑一次固化。真正会被替换的只有前端 `canTurnOff` 那一小片,而那片本来就是几十行。
+
+唯一的合入前置条件:**把 DeepSeek/MiniMax 的 Off 补上**(最小改法:在它们的 YAML/discovery 里声明可关闭;或者干脆等第一步一起修,但要在 #966 里留注释和 issue 链接,别让这个已知洞变成无主的)。同时把本文档的三步开成 issue 挂在 #966 上,明确 commit 4 的 Claude 特判是过渡态,不是先例。
+
+---
+
+## 常见问题
+
+**Q: 为什么不直接换数据源就完事?**
+因为就算数据再完美,Google adaptor 没接 effort、DeepSeek 靠 compat 翻译这些 **adaptor 层事实**还是只有后端知道。换源解决"原料缺语义",架构收敛解决"三个 surface 各自猜"。两个问题,两味药。
+
+**Q: models.dev 数据质量靠谱吗?**
+比 LiteLLM 在 reasoning 语义上强得多(LiteLLM 压根表达不了),而且 Cline、OpenCode、Vercel AI Gateway、Cherry Studio 四个头部项目在生产使用。有编辑规范 + 人审 PR + 小时级自动 sync。当然任何外部源都会有错漏,所以才要 OpenRouter 交叉校验 + 我们自己的 synccaps 人审流程兜底(这套流程 #563 就建好了,继续用)。
+
+**Q: 工作量多大?**
+第一步是主体:后端一个解析函数 + API 字段 + 前端删代码(删的比加的多);第二步是 schema 迁移 + synccaps 改造;第三步主要是 synccaps 的数据源适配。三步都有现成参照(Cline 的实现几乎可以照着看)。具体排期等团队同意方向后再拆。
+
+**Q: 换掉 LiteLLM 后 context window 从哪来?**
+models.dev 自带:`limit.context` / `limit.output` 是每个模型条目的标准字段(实测 claude-opus-4-6 → context 1,000,000,和 LiteLLM 的 `max_input_tokens` 一致)。我们从 LiteLLM 实际只消费能力 flag 和 `max_input_tokens` 两类信息,models.dev 都有替代,不存在换源后缺数据的问题。
+
+**Q: 不做会怎样?**
+每接一个新 provider、每出一代新模型,三份策略拷贝就有机会漏一次。#966 四个 commit 的演化和 DeepSeek/MiniMax 的现行 bug 已经演示过了;aider 和 LobeChat 演示了五年后的样子。

--- a/docs/superpowers/specs/2026-08-10-reasoning-consolidation-workplan.md
+++ b/docs/superpowers/specs/2026-08-10-reasoning-consolidation-workplan.md
@@ -1,0 +1,152 @@
+# Reasoning 收敛工程:工作文档
+
+> 状态:**待团队确认后实施**。
+> 前置阅读:[提案文档](./2026-08-10-reasoning-capability-architecture-proposal.md)(起因经过结果)。本文档是它的实施篇:精确的现状地图、目标结构、符号去向、分 PR 顺序。
+> 现状地图来自两次全库普查(后端 Go / 前端 TS 各一次,2026-08-10,基于 PR #966 分支 + DeepSeek 前置修复)。
+
+## 0. 一句话目标
+
+把散在 **6 个后端位置 + 1 个前端文件** 的 reasoning 能力逻辑收敛为:**一个后端包做决策,一条 API 下发结果,前端只渲染**。同时清掉普查发现的 4 份词表拷贝、2 份重复实现、2 处死代码、若干现行 bug。
+
+## 1. 现状地图(浓缩版)
+
+完整地图很长,这里只放"决定架构"的部分。
+
+### 1.1 逻辑散布在哪
+
+| 位置 | 装了什么 | 问题 |
+|---|---|---|
+| `internal/models/types.go` | effort 词表、ThinkingMode、校验、NearestEffortToMedium、normalize | 定义层,基本合理,但和下面几处互相抄 |
+| `internal/models/sdk.go` | ReasoningConfig 类型、wire 编码(BuildReasoningOptions 等) | wire 层,合理;但 `openAIWireEffort` 和 service.go 的 `normalizesMaxReasoningEffort` 是同一逻辑两份 |
+| `internal/agent/application/service.go` | **全部调用时决策**:resolveReasoningConfig / pickEffort / offEffortFor / effectiveReasoningEfforts / anthropicEffortEra 等 7 个函数 | 住在一个 1594 行的编排文件里,但它们是纯函数,只依赖 models + 一个 settings 字符串——**放错了地方** |
+| `internal/capabilities/` + `cmd/synccaps/` | build-time 能力发现(LiteLLM → YAML) | 自己维护了第三份 effort 顺序表 `effortOrder` |
+| `internal/command/reasoning.go` | `/reasoning` 命令 | 自己维护第四份词表 `reasoningChoices`(用字面 `"off"`,少 minimal/max),完全不看模型 |
+| `internal/settings/` | 存储层 | `isValidReasoningEffort` 与 models 包**同名不同义**(一个只拒空,一个严格词表) |
+| `apps/web/.../reasoning-effort.ts` | 前端自己推导 mode/档位/off 可达性/迁移策略 | 两个 client-type 特判集合;desktop 复用 web,没有第三份 |
+
+### 1.2 重复与平行实现(全部清单)
+
+1. **effort 词表 4 份**:`models.validReasoningEfforts` / `capabilities.effortOrder` / `command.reasoningChoices`+`validEffort` / 前端 `KNOWN_EFFORTS`+`DECLARABLE_EFFORTS`。另有 i18n usage 文本硬编码词表(还写着已经不可选的 `none`,见 §5 bug 清单)。
+2. **max→xhigh 归一化 2 份**:`service.go:normalizesMaxReasoningEffort`(列表过滤)与 `sdk.go:openAIWireEffort`(wire 兜底),注释自称 defence-in-depth,且两者都要求与前端 `MAX_NORMALIZED_CLIENT_TYPES` 同步——同一知识三处。
+3. **ReasoningConfig 类型 2 个**:`models.ReasoningConfig`(现役 5 字段)与 `native/types.go:191-198` 的 `ReasoningConfig{Enabled,Effort}`——后者**全仓库无引用,是死代码**。
+4. **`Model.SupportsReasoning`**(types.go:328)非测试代码已无调用方,被 `ResolveThinkingMode` 取代——平行 API 残留。
+5. **legacy "off" 拼写桥 3 处**:`IsReasoningDisabled` 收 "none"、`normalizeAdvertisedEfforts` 重写声明、`botbackup/settings_compat` 收 `reasoning_enabled:false`。(这 3 处各管一个边界,保留,但要在同一个包里挨着放。)
+6. **"Keep in sync" 注释后端 3 处 + 前端 5 处**,其中前端 1 处指向**已不存在的文件**(`internal/conversation/flow/resolver.go`)。
+
+### 1.3 普查顺手发现的 bug(独立于重构,都要修)
+
+| # | 位置 | 问题 | 严重度 |
+|---|---|---|---|
+| B1 | `native/spawn_adapter.go:127` | subagent spawn 链路只传 `ReasoningEffort` 一个字段,`Active/Disabled/Adaptive/OffEffort` 全丢——子代理的 reasoning 决策在传输中降级 | **高,先验证再修**(可能被下游重算掩盖) |
+| B2 | `chat-pane.vue:1753` | 调 `availableEffortsForMode` 漏传第三参 clientType → 聊天页 Anthropic 的 Off 不显示,和 bots 设置页行为不一致 | 中(重构后此代码整体消失,若 PR B 排期近可不单修) |
+| B3 | `internal/i18n/locales/*:cmd.reasoning.setUsage` | 提示词表写着 `off\|none\|low\|...`,但 `none` 实际已不可选 | 低 |
+| B4 | 前端 `reasoning-effort.ts:29` | keep-in-sync 注释指向已删除的文件路径 | 低(重构后消失) |
+| B5 | `apps/web` i18n | `bots.settings.reasoning*`、`bots.overview.reasoningBadge` 等死 key | 低,顺手清 |
+| B6 | `conf/providers/minimax.yaml` | M2.5/M2.1-Lightning 标 `thinking_mode: toggle`+三档,但 models.dev/OpenRouter 双源说 M2.x always-on——存量数据可疑 | 中,需探针或官方文档确认后修数据 |
+
+## 2. 目标结构
+
+### 2.1 新包:`internal/reasoning`
+
+决策逻辑收敛到一个**叶子包**(不 import models,函数收纯 string/slice,models 反过来 import 它做校验,避免环):
+
+```
+internal/reasoning/
+├── vocabulary.go   # effort 常量、有序 tier 表、IsDisabled、IsValidDeclarable、
+│                   # NearestToMedium、NormalizeAdvertised(自 models/types.go 迁入)
+├── mode.go         # ThinkingMode 常量 + ResolveMode(mode, compats)(自 models/types.go 迁入)
+├── resolve.go      # 调用时决策(自 agent/application/service.go 迁入):
+│                   # ResolveConfig(mode, advertised, stored, requested, clientType) → *Config
+│                   # 内含 pickEffort / effectiveEfforts / offEffortFor / anthropicEffortEra
+├── options.go      # ★新增,第一步的核心:
+│                   # OptionsFor(mode, advertised, clientType) → Options{
+│                   #   Supported, CanDisable, Efforts []string, DefaultEffort }
+│                   # 给 API 下发用;/reasoning 命令与 Web picker 的唯一数据源
+├── wire.go         # Config 类型 + wire 编码(自 models/sdk.go 迁入 BuildReasoningOptions、
+│                   # openAIEffortOptions、openAIWireEffort、anthropicLegacyBudget)
+│                   # max→xhigh 归一收敛为一份,住在这里
+└── *_test.go       # 各来源的测试跟随迁入合并
+```
+
+要点:
+
+- **`options.go` 和 `resolve.go` 共享内部函数**——"picker 里能选什么"和"调用时怎么解析"从此在物理上不可能分叉,这是整个工程的核心保证。
+- `models` 包保留 `ModelConfig` 存储结构和 `NewSDKChatModel`(provider 构造),校验改调 `reasoning.IsValidDeclarable`;老常量名(`models.ReasoningEffortDisable` 等)保留为**别名转发**,存量调用方不用一次性全改,后续 PR 渐进迁移。
+- `capabilities.effortOrder`、`command.reasoningChoices`/`validEffort` 删除,改从 `reasoning` 包取。
+- `settings.isValidReasoningEffort` 改名(比如 `hasReasoningEffortValue`)消除同名不同义。
+- ACP 面(`acp/client/reasoning.go`)**不动**:它的 effort id 是 agent 自报的词表,和 models tier 本来就解耦,现状正确。
+
+### 2.2 API:对齐 ACP 已有形态
+
+普查的关键发现:**ACP 侧已经是终态形态**——`AcpclientReasoningState{available_efforts, current_effort, supported}`,前端消费路径也已存在。Native 模型对齐它:
+
+models 相关响应(list/get)的每个 chat model 附带解析结果:
+
+```json
+"reasoning": {
+  "supported": true,
+  "can_disable": true,
+  "efforts": ["low", "medium", "high"],
+  "default_effort": "medium"
+}
+```
+
+由 handler 调 `reasoning.OptionsFor(...)` 计算(client_type 服务端从 provider 拿,不再需要前端 join)。`efforts` 不含 disable token——可关闭性走 `can_disable` 布尔,哨兵值从 API 面消失。
+
+### 2.3 前端:删推导,留渲染
+
+| 现有符号(reasoning-effort.ts) | 去向 |
+|---|---|
+| `resolveThinkingMode` / `resolveEffortLevels` / `availableEffortsForMode` / `canTurnOff` / `nearestEffortToMedium` / `KNOWN_EFFORTS` / `DECLARABLE_EFFORTS` / `LEGACY_OFF_EFFORT` / `MAX_NORMALIZED_CLIENT_TYPES` / `IMPLICIT_OFF_CLIENT_TYPES` | **删除**,改读 API 的 `reasoning` 对象 |
+| `EFFORT_LABELS` / `EFFORT_OPACITY` / `REASONING_EFFORT_DISABLE` | 保留(纯渲染映射 + 写库 token) |
+| 换模型迁移策略(settings-interaction-card / chat-pane 两处 watch) | 简化为:选中值不在 `efforts` 里 → 取 `default_effort`(off 且 `can_disable` 则保留) |
+| 三处 `activeClientType` computed(providers join) | 删除,不再需要 |
+
+### 2.4 符号去向总表(后端)
+
+| 现在 | 去向 | 动作 |
+|---|---|---|
+| `models/types.go` effort/mode 常量、词表、Nearest、normalize | `reasoning/vocabulary.go`、`mode.go` | 迁移+别名转发 |
+| `models/sdk.go` `ReasoningConfig`、`BuildReasoningOptions`、`openAIEffortOptions`、`openAIWireEffort`、`anthropicLegacyBudget*` | `reasoning/wire.go` | 迁移(`NewSDKChatModel` 留在 models,import reasoning.Config) |
+| `service.go` `resolveReasoningConfig`/`pickEffort`/`offEffortFor`/`effectiveReasoningEfforts`/`anthropicEffortEra`/`normalizesMaxReasoningEffort`/`hasEffort`/`reasoningEffortDisabled`/`offEffortOrEmpty` | `reasoning/resolve.go` | 迁移;service.go 只留一行调用 |
+| `capabilities.effortOrder` | 删除 | 改用 reasoning 包的有序表(+disable 领头逻辑内联) |
+| `command.reasoningChoices` / `validEffort` | 删除 | `/reasoning` 改调 `reasoning.OptionsFor`(顺带修复:它从此**按模型**给选项,而不是无条件 off+low~xhigh) |
+| `native/types.go:191-198` 死 `ReasoningConfig` | 删除 | — |
+| `Model.SupportsReasoning` | 删除 | 无调用方 |
+| `native.RunConfig` 5 个扁平字段 + spawn_adapter | 改为直接携带 `*reasoning.Config` | 消除拆装往返,B1 一并修复 |
+
+## 3. 分 PR 实施
+
+### PR A:后端收敛(纯重构,行为不变)
+
+1. 建 `internal/reasoning`,按 §2.4 迁移,测试跟随。
+2. 删两处死代码、合并 max→xhigh、settings 改名、`RunConfig` 改携带 `*reasoning.Config`(先写 B1 的复现测试,确认现状是否真丢行为)。
+3. `/reasoning` 命令接 `OptionsFor`(这一步有行为变化:选项按模型走,单独 commit,方便 review 时讨论)。
+
+验收:`go build ./...`、全量 `go test`;`resolveReasoningConfig` 的表驱动测试**一个不改全绿**(纯函数搬家的最硬证据);`synccaps -check` 干净。
+
+### PR B:API 下发 + 前端删推导
+
+1. handler 给 models 响应加 `reasoning` 对象,swagger/SDK 重新生成。
+2. 前端按 §2.3 删推导、改消费,B2/B4/B5 随之消失或顺手清。
+3. i18n 死 key 清理 + B3 修正。
+
+验收:vitest 全绿(推导类测试删除,渲染类保留改造);手工核对三个 surface(Web picker、chat composer、`/reasoning`)对同一批模型给出一致选项——拿 DeepSeek V4(可关)、MiniMax M2.5(不可关)、Claude 4.5(隐式可关)、Claude 4.6+(不可关)、Gemini(现状假档位,见开放问题 Q2)五个代表验。
+
+### PR C / PR D:schema 升级、换源 models.dev
+
+对应提案第二、三步,依赖 A/B 落地后开工,细节在提案文档里,届时再出各自的工作文档。
+
+## 4. 开放问题(团队拍板)
+
+1. **包名**:`internal/reasoning` vs `internal/models/reasoning`?本文按前者写(它是被 models import 的叶子包,平级更诚实),不强持。
+2. **Gemini 怎么办**:查证结论——Gemini 官方支持调节(2.5 世代 `thinkingConfig.thinkingBudget` 预算制,3.x 世代 `thinking_level` 档位制),models.dev 数据也齐全(3.5-flash 给 `[minimal,low,medium,high]`,2.5-pro 给 `budget_tokens`);缺口在**我们自己的 Twilight AI Google provider**:它只处理 reasoning 输出流,请求侧完全不消费 `ReasoningEffort`,所以 `BuildReasoningOptions` 对 Google 返回 nil,picker 的三档是假控件。处置:(a) 给 Twilight AI 补 Gemini thinking 支持列为独立工作项(修根,工作量可估:3.x 映射 thinking_level,2.5 映射 effort→budget,参照 anthropicLegacyBudget 的模式);(b) 落地前 `OptionsFor` 对 Google 如实返回 `supported:false`——消失的是从未生效过的控件,用户实际损失为零。需要团队确认的只是 (a) 的排期。
+3. **别名转发的清退节奏**:`models.ReasoningEffort*` 别名保留到什么时候?建议 PR C 时一并清,存量 import 改为直接用 reasoning 包。
+4. **B1 的严重度**:spawn 链路丢字段如果确认影响子代理行为,是否要先出独立 hotfix 而不等 PR A?待复现测试给答案。
+
+## 5. 不做什么(明确排除)
+
+- 不动 ACP reasoning 面(已是正确形态)。
+- 不动 DB schema 和存储语义(`reasoning_effort` 列、disable token 的存储形式,留给 PR C)。
+- 不在这轮换数据源(留给 PR D)。
+- 不动事件/展示层(ReasoningStart/Delta/End 流渲染,与能力解析无关)。

--- a/docs/superpowers/specs/2026-08-10-twilight-reasoning-sdk-design.md
+++ b/docs/superpowers/specs/2026-08-10-twilight-reasoning-sdk-design.md
@@ -1,0 +1,270 @@
+# Twilight SDK 的 reasoning 抽象:设计决策
+
+> 状态:**提案,等团队讨论**。同意了才动手。
+> 关联文档:[能力元数据架构提案](./2026-08-10-reasoning-capability-architecture-proposal.md)(为什么)、[收敛工程工作文档](./2026-08-10-reasoning-consolidation-workplan.md)(Memoh 侧怎么做)。本文档管 **Twilight SDK 侧**的 API 设计。
+> 依据:三份独立调研(官方 SDK 源码实测、产品 UX 实测、Go 类型设计论证),2026-08-10。
+
+## TL;DR
+
+Gemini 的 thinking 完全不可控——不是模型不支持,也不是数据缺失,是**我们自己的 Google provider 请求侧没接**。修它顺带触发了一个更大的问题:SDK 的 reasoning 抽象该长什么样。
+
+调研结论有点反直觉:**不要在通用层加 budget 字段,不要做客户端校验,不要抽象跨 provider 的统一 reasoning 模型**。官方 SDK 一致的做法是"通用层薄 + provider 私有层忠实镜像 + 误用交给服务端 400"。我们现状已经天然接近这个模式,需要的是补齐 Google、把 Anthropic 的扁平 struct 改成 union、删掉一个自作聪明的归一化函数。
+
+用户可见的控件**保持纯档位**,不暴露 token 预算——业界已经收敛,而且 budget 正在从各家 API 里消失。
+
+---
+
+## 一、问题从哪来
+
+排查"为什么 Gemini 的 reasoning 控件是假的"时,逐层验证的结果:
+
+| 层 | 状况 |
+|---|---|
+| Gemini 官方 | **支持**。2.5 世代 `thinkingConfig.thinkingBudget`(预算制),3.x 世代 `thinkingConfig.thinkingLevel`(档位制) |
+| models.dev 数据 | **齐全**。3.5-flash 给 `effort:[minimal,low,medium,high]`,2.5-pro 给 `budget_tokens{128,32768}`,连两代机制不同都表达了 |
+| **我们的 Twilight Google provider** | **断在这里**。`generationConfig` 结构体没有 `thinkingConfig` 字段,`buildRequest` 不读 `params.ReasoningEffort`,也没有 `WithThinking` 这类 Option |
+
+所以 picker 里 Gemini 的三档从第一天起就是安慰剂:选了什么都不会发出去。
+
+### 现状抽象:两层,但不齐
+
+Twilight 的 reasoning 分两层:
+
+1. **通用请求层**:`sdk.GenerateParams.ReasoningEffort *string` + `sdk.WithReasoningEffort(string)`。表达力 = "一个档位字符串或 nil"。**没有 ProviderOptions 之类的逃生舱。**
+2. **provider 私有构造层**:各 provider 自己的 Option,如 `provider/anthropic/messages.WithThinking(ThinkingConfig{Type, BudgetTokens})`,构造 Model 时注入。
+
+Anthropic 之所以能工作,是因为它两层都用:budget/adaptive 这种私有形状走第二层(Memoh 在 `NewSDKChatModel` 里按世代注入),档位走第一层。OpenAI 只用第一层。**Google 一层都没接**——这才是它断掉的确切原因,不是抽象逼它做了什么错事。
+
+---
+
+## 二、调研发现(三份互相印证也互相修正)
+
+### 2.1 官方 SDK 的一致惯例
+
+实测六个 SDK 的源码(不是文档转述),结论出乎意料地一致:
+
+| SDK | 新老机制关系 | 冲突处理 | model id 嗅探 | effort→budget 表 |
+|---|---|---|---|---|
+| **Anthropic**(py/ts/go) | **一个字段多态**(3 元 union) | 类型系统即排他,无法同时设 | 无 | 无 |
+| **OpenAI**(py/node/go) | 单一 effort 字段(开放 enum) | 无冲突可能 | 无 | 无 |
+| **Google GenAI** | 两个并列字段(同一 struct) | **完全透传,零校验** | 无 | 无 |
+| **Vercel AI SDK** | provider 私有选项 | 各 provider 内部 union | 无 | 无 |
+| LangChain(第三方) | 两个并列 + 客户端校验 | **抛 ValueError** | **有(`startswith`)** | 无 |
+| LiteLLM(网关) | 翻译层 | 后者覆盖 + 自动降级 | **有(能力表)** | **有硬编码** |
+
+三条最关键的:
+
+**① 官方 SDK 一律不做客户端语义校验,不做 model 嗅探,纯透传。** Anthropic Go SDK 全线零校验(`BudgetTokens` 只出现在 struct 定义、构造函数和 getter 里,没有一个 `if`);Google 连"budget 和 level 同时设"这种明显冲突都不查。做嗅探的两个都是第三方封装,且都因此背上持续维护模型知识库的负担。
+
+**② 新老机制并存时,官方首选 union,不选并列字段。** Anthropic 面对的问题和我们**完全一样**(老世代 budget、新世代 adaptive、4.7+ 拒绝 budget),它的选择是 3 元 discriminated union,关键在于 `ThinkingConfigAdaptiveParam` 里**根本没有 `budget_tokens` 字段**——非法组合在类型层不可表达,于是不需要任何冲突处理逻辑。Go SDK 用指针 + `MarshalUnion` 实现:
+
+```go
+// anthropic-sdk-go/message.go:6637
+// Only one field can be non-zero.
+type ThinkingConfigParamUnion struct {
+	OfEnabled  *ThinkingConfigEnabledParam  `json:",omitzero,inline"`
+	OfDisabled *ThinkingConfigDisabledParam `json:",omitzero,inline"`
+	OfAdaptive *ThinkingConfigAdaptiveParam `json:",omitzero,inline"`
+	paramUnion
+}
+```
+
+唯一的"并列字段"先例是 Google,而那是被上游 protobuf 形状绑住的历史包袱(`thinking_budget` 和 `thinking_level` 是同一个扁平 struct 上两个 Optional 字段),它的应对方式是**干脆不管**。
+
+**③ 跨 provider 抽象层倾向于不抽象 reasoning。** Vercel AI SDK 通用层的 reasoning 参数数量是 **0**——`LanguageModelV3CallOptions` 里只有 maxOutputTokens/temperature/topP/topK,全部 thinking 下沉到 `providerOptions`,并且**忠实镜像各家原生形状**:Anthropic 是 union 就做 union,Google 是两字段并列就两字段并列。
+
+**④ 不加 deprecation 标记。** Anthropic 官方在 `budget_tokens` 已被 4.7+ 移除的情况下,源码里**仍未加任何 deprecation 标记**——因为老模型上它依然完全合法,加标记会误伤。世代差异写在 doc comment 里(Vercel 的做法:`/** for models before Opus 4.6 */`)。
+
+### 2.2 产品 UX:档位制已是 API 层现实
+
+调研了 Claude Code、Cursor、Windsurf、Copilot Chat、Cherry Studio、LobeChat、Open WebUI、Cline、Roo Code、三家第一方 playground。
+
+**最锋利的一句:我们正在为一个正在消失的参数形态考虑是否要暴露它。**
+
+- `budget_tokens` 在 Claude 4.7+ 是 400 错误
+- `thinkingBudget` 在 Gemini 3 上"仅为向后兼容而接受",和 `thinkingLevel` 同时发会 400
+- OpenAI 从未有过数字预算
+
+**用户反馈方向和我们的担心相反。** 所有仓库里检索的结论:**没有任何一个 issue 要求"我想精确控制 budget 数字"**。抱怨全是三类——档位不够用、档位藏得太深、档位不透明导致失控成本。
+
+反过来,**数字预算被证实是 bug 源头**:Cline #4503(Gemini 上设的 52k budget,切到 Bedrock Claude 时数字被带过去了)、#7260(1024 硬下限触发 Gemini 免费额度 429)、#7735/#7957(给 2.5 Pro 发 0、给 gemini-3 同时发两个字段)、Open WebUI 一串自由文本输入导致 500。
+
+**最强的演进证据:Cline 把数字滑块删了。** PR #12716(2026-07-30)`deleted file mode ThinkingBudgetSlider.tsx`,-175 行,改成纯档位下拉。它前一个 PR #12542 的动机陈述几乎是对我们现状的逐字描述:
+
+> "Previously, Cline reduced model reasoning support to a Boolean and reconstructed provider behavior using duplicated effort types, regexes, version lists, and hard-coded model matrices. That could collapse max/xhigh, drop native OpenAI effort, combine unsupported Gemini controls, choose the wrong Anthropic thinking mode."
+
+(顺带:那个老滑块是 `step={1}`,一个 token 一格——这本身就是"暴露数字"的实现陷阱。)
+
+**混合模式确实存在,但形态是"档位在主界面 + 数字在设置层",不是并排。** 三个范本按推荐度:Copilot(档位进 model picker、数字降级为 settings.json 键、adaptive 模型上数字直接忽略)、Vertex AI Studio(下拉默认 Auto → 选 Manual 才展开 slider,渐进披露)、Claude Code(UI 纯档位,数字仅存于 `MAX_THINKING_TOKENS` 环境变量逃生阀)。
+
+**不推荐 LobeChat 的并排 slider+InputNumber**:代价是同目录约 25 个按模型族定制的控件 + 18 套档位词表,对多 provider 平台是维护灾难。
+
+**三家第一方都刻意拒绝公布档位→token 映射**,两家在文档里明说档位"是相对配额而非严格的 token 保证"。任何第三方映射都是自己发明的。
+
+### 2.3 被修正的两个前提(记录下来,避免重犯)
+
+调研过程推翻了我在讨论中提出的两个判断,值得留档:
+
+**① "可序列化性是 SDK 的硬约束"——错。** 全仓搜索确认 `sdk.GenerateParams` **从未被 Marshal**,那些 json tag 是遗留装饰(结构体里 `Model *Model` 持有 `Provider` interface 含 `*http.Client`、`ToolChoice any`,本来就不可能往返)。真正需要序列化的是 **Memoh 自己的 `native.RunConfig`**(要过 server↔channel 的 gRPC),那是我们的 DTO 约束。
+
+推论:`service.go:751-755` 把 `ReasoningConfig` 拆成 5 个扁平字段穿过 RunConfig 是**过度反应**——直接放一个带 json tag 的 `*ReasoningConfig` 就行。这顺手解释了普查发现的 B1(spawn 路径只搬 `ReasoningEffort`、丢掉另外 4 个字段):**字段拆得越散,漏传的机会越多。**
+
+**② "那张 16000 的表该搬进 SDK"——不采纳。** 设计论证提议把 effort→budget 表搬进 SDK(带 `TierBudgets` 覆盖点),理由是"legacy Claude 只吃 budget"属于 wire 知识不该外泄。但实测显示:**官方 SDK 无一有换算表**;唯一有的 LiteLLM 是**网关角色**——它必须把一种输入形状翻译成 N 家形状。而在我们的架构里,**Memoh 才是那个网关角色**,Twilight 是 provider SDK。所以表留在 Memoh 是对的,只是形态要改(见 §3.7)。
+
+---
+
+## 三、设计决策
+
+### SDK 侧(Twilight)
+
+**3.1 通用层 `ReasoningEffort *string` 不动,不加 budget 字段。**
+
+理由:Vercel 通用层 reasoning 参数为 0,我们已天然接近这个模式;`*string` 而非自定义 enum 也是对的——对齐 OpenAI 的开放 enum 策略(它的 Go SDK 就是 `type ReasoningEffort string` + 具名常量,注释明说 "Not all reasoning models support every value"),服务端先发新档位时我们不用改版本。
+
+可以补一组具名常量方便调用方,但**不在 SDK 里校验取值合法性**。
+
+**3.2 Anthropic 的 `ThinkingConfig` 从扁平 struct 改成 union。**
+
+现状(`provider/anthropic/messages/messages.go:36`):
+
+```go
+type ThinkingConfig struct {
+	Type         string // "enabled", "adaptive", or "disabled"
+	BudgetTokens int    // required when Type is "enabled"
+}
+```
+
+这允许 `{Type:"adaptive", BudgetTokens:8000}` 被构造出来,只能靠服务端拦。照官方形状改造后,调用方拿不到非法组合:
+
+```go
+func WithThinkingEnabled(budgetTokens int) Option  // 老世代(<=4.5)
+func WithThinkingAdaptive() Option                  // 4.6+
+func WithThinkingDisabled() Option
+```
+
+**3.3 Google provider 补 thinking,如实镜像上游两字段并列。**
+
+```go
+type thinkingConfig struct {
+	ThinkingBudget  *int   `json:"thinkingBudget,omitempty"`   // 2.5 世代
+	ThinkingLevel   string `json:"thinkingLevel,omitempty"`    // 3.x 世代
+	IncludeThoughts *bool  `json:"includeThoughts,omitempty"`
+}
+```
+
+挂到 `generationConfig` 上,`buildRequest` 消费。**不校验两者互斥**——Google 官方和 Vercel 都是这么做的,忠实镜像的可预测性高于自创归一化。
+
+**这里可以超越官方一点**:google-genai 三语言都把 `-1`/`0` 留成裸 magic number(只写在字段 description 里),我们给具名常量:
+
+```go
+const (
+	ThinkingBudgetDynamic  = -1 // AUTOMATIC
+	ThinkingBudgetDisabled = 0  // DISABLED,仅 Flash/Lite 合法
+)
+```
+
+仍然透传、仍不校验,只是让调用点可读。
+
+**3.4 删掉 `NormalizeReasoningEffort`。**
+
+`provider/openai/reasoning.go` 那个 max→xhigh 的映射,注释自称 defence-in-depth,实际是 defence-against-the-future:它基于 SDK 对"OpenAI 会接受什么"的**猜测**,哪天 OpenAI 支持了 `max`,它会静默降级用户请求且没人记得它存在。官方 SDK 无一有 tier 白名单。
+
+判据(建议写进 Twilight 的贡献文档):**SDK 可以执行调用方的声明,不可以执行自己的猜测。**
+
+它是 exported 函数,但 Memoh 侧没有直接调用(我们有自己的 `openAIWireEffort`),实际影响为零。建议先留空壳一个版本再删。
+
+**3.5 不做 model id 嗅探。**
+
+三份调研一致。做了的两个——LangChain 的 `startswith("claude-opus-5")`、LiteLLM 的能力表——都是第三方封装,都因此要持续维护模型知识库。**这条要写进 Twilight 的 AGENTS.md。**
+
+**3.6 不加 deprecation 标记,世代差异写 doc comment。**
+
+理由见 §2.1 ④。真要标记,等目标模型全部退役再说。
+
+**3.7 唯一需要我们自己定的冲突点:通用 `ReasoningEffort` 与 provider 私有 thinking 同时设置时谁胜。**
+
+建议 **provider 私有选项胜出**(表达力更强、意图更明确),**并写进 doc comment**——LangChain 靠 Pydantic alias 优先级隐式决定、只在 docstring 里补说明,是可避免的坑。
+
+### Memoh 侧
+
+**3.8 换算表留在 Memoh,但从硬编码改成比例式。**
+
+这是三份调研里唯一**两个独立项目收敛出同一答案**的点:
+
+```go
+// Cline: sdk/packages/shared/src/llms/reasoning-effort.ts
+ratio = {max:1, xhigh:0.95, high:0.8, medium:0.5, low:0.2, minimal:0.1, none:0}
+
+// Cherry Studio: src/shared/ai/reasoning.ts —— 注意是 min↔max 的 lerp,不是 max × ratio
+budget = max(1024, floor((limit.max - limit.min) * ratio + limit.min))
+```
+
+我们现状(`internal/models/sdk.go:271`)是硬编码 `low:5000 / medium:16000 / high:50000`。改成比例式的收益:
+
+- **不需要为每个模型维护一行**,自动落在各模型的合法区间内
+- **限制表必须按模型族分,不能扁平**:Gemini 是 `pro={128,32768}` / `flash={0,24576}` / `flash-lite={512,24576}`;Claude 各代 max_tokens 也不同(Sonnet 4.5 = 64000、3.7 = 32000)。理想是从 models.dev 拉,而非自己维护矩阵
+- 顺带解释了一个 wire 事实:**2.5 Pro 下限是 128 所以关不掉,Flash 下限是 0 所以能关**——这正好对应 catalog 里 `reasoning_efforts` 该不该含 `disable`
+
+⚠️ 一个需要澄清的点:现有的 `50000` 在 **Anthropic 路径上不越界**——`resolveMaxTokens` 会把 budget 加到 max_tokens 上(`4096 + 50000`)。它只在"把这张表用到 Gemini 2.5(上限 32768)"时才越界,而我们目前没有这条路径。所以这不是现行 bug,是**换比例式要防的坑**。
+
+**3.9 档位保持为唯一用户可见控件,不暴露 budget。**
+
+多 provider + agent 是档位制收益最大的象限:agent 场景下 thinking 只是总消耗的一部分(tool call 也吃 token),而 `effort` 影响**全部输出**、`budget_tokens` 只影响 thinking——**档位在 agent 场景下语义更正确**。
+
+**3.10 加 `auto` 档位,并按模型能力隐藏不支持的档位。**
+
+- `auto`:Gemini 发 `-1`,Claude 发 adaptive
+- `off`:Gemini 发 `0`(仅 Flash/Lite)、Claude 省略 thinking、OpenAI 发 `none`
+- 区分"省略参数"和"发送 none 值"(参考 Roo Code 的 `disable` vs `none`,源于它的 issue #8624)
+- **2.5 Pro 不能关 thinking,UI 就不该给 off**;切模型时把不支持的档位 fallback 到最近可用档(Claude Code 的做法),而不是报错
+
+**3.11 对失控成本做防御。**
+
+这是纯档位制**唯一的真实缺陷**:claude-code#64153——"Opus 4.8 **medium** effort 在一个简单编码轮次上花掉 46,433 output tokens",UI 显示思考 22 分 43 秒。但解法不是暴露 budget:
+
+- 事后显示实际 thinking token 消耗(Anthropic 给了 `usage.output_tokens_details.thinking_tokens`)
+- 用独立的输出/成本上限兜底,而不是靠 thinking budget 控成本
+- 参考 Claude Code:让最高档**只在当前会话有效、不持久化**(防止用户忘记关掉烧钱)
+
+---
+
+## 四、还成立但需要单独处理的:生命周期错配
+
+设计论证里有个发现独立于上面所有决策,而且**在 union 方案下依然存在**:
+
+Anthropic 的 thinking 形状被钉在 **provider 构造期**(`WithThinking` 是 Model Option,构造一次),而档位在**请求期**(每次调用)。于是同一个逻辑决策("用户选了 high")被劈成两半:budget 在 `NewSDKChatModel`,effort 在 `BuildReasoningOptions`。这就是 `SDKModelConfig.ReasoningConfig` 要被消费两次的根源。
+
+**建议:把 provider thinking 选项从构造期移到请求期**,作为独立工作项。它不阻塞 Gemini 修复,但会让 Memoh 侧的 reasoning 决策收敛成真正的单点(和收敛工程工作文档的目标一致)。
+
+---
+
+## 五、落地顺序
+
+每步独立可发布,**第 1 步就交付了最痛的问题**:
+
+| 步 | 内容 | 仓库 | Breaking |
+|---|---|---|---|
+| 1 | Google provider 补 `thinkingConfig` 字段 + Option + `buildRequest` 消费;`-1`/`0` 具名常量 | Twilight | 否(纯新增) |
+| 2 | Memoh 侧填 Gemini 的方言声明,`BuildReasoningOptions` 接上 Google 分支 | Memoh | 否 → **Gemini 端到端打通** |
+| 3 | Anthropic `ThinkingConfig` 改 union;`NormalizeReasoningEffort` 留空壳标废弃 | Twilight | 否 |
+| 4 | 换算表改比例式 + 限制表按模型族分(理想:从 models.dev 拉) | Memoh | 否 |
+| 5 | `auto` 档位 + 按能力隐藏档位 + 失控成本可观测性 | Memoh | UI 可见变化 |
+| 6 | thinking 选项从构造期移到请求期(§4) | 两边 | 需协调版本 |
+| 7 | 删 `NormalizeReasoningEffort` 空壳 | Twilight | 是(exported,但无调用方) |
+
+第 4/5 步与 Memoh 侧收敛工程(工作文档的 PR A/B)有重叠,实施时合并进那两个 PR 更省事。
+
+## 六、开放问题
+
+1. **Gemini 修复的排期**:第 1-2 步能独立交付,是否插队到收敛工程之前?(Gemini 用户现在的控件是假的,但这个假控件已经存在很久了)
+2. **比例值取谁的**:Cline 的 `{high:0.8, medium:0.5, low:0.2}` 还是 Cherry 的 lerp 公式?两者对 Gemini 2.5 Pro(128–32768)算出的结果不同。建议 Cherry 的 lerp(尊重下限)+ Cline 的比例值。
+3. **`auto` 档位的 UI 位置**:是和 low/medium/high 并列,还是像 Vertex AI Studio 那样作为默认值单独呈现?
+4. **Twilight 的 AGENTS.md 是否要新增"禁止 model id 嗅探"条款**?建议要,并附本文档链接。
+
+## 七、明确不做
+
+- 不在通用层加 budget 字段(§3.1)
+- 不做客户端语义校验(方言不匹配、tier 白名单、budget 越界都交给 provider 400)
+- 不做 model id 嗅探(§3.5)
+- 不给用户暴露 token 预算输入(§3.9)
+- 不抽象跨 provider 的统一 reasoning 模型(Vercel 验证过:忠实镜像比自创归一更可预测)

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -909,7 +909,12 @@ func pickEffort(requested string, botSettings settings.Settings, effortLevels []
 			return e
 		}
 	}
-	if e := strings.TrimSpace(botSettings.ReasoningEffort); e != "" && hasEffort(effortLevels, e) {
+	// The stored effort is skipped when it means "off". pickEffort only runs once
+	// reasoning is on, and "off" is advertisable now, so without this guard a bot
+	// parked on off would hand the disable token back as an active tier and send it
+	// upstream, where no provider knows the word.
+	if e := strings.TrimSpace(botSettings.ReasoningEffort); e != "" &&
+		!models.IsReasoningDisabled(e) && hasEffort(effortLevels, e) {
 		return e
 	}
 	if hasEffort(effortLevels, models.ReasoningEffortMedium) {

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -884,15 +884,18 @@ func resolveReasoningConfig(chatModel models.GetResponse, botSettings settings.S
 // anthropicEffortEra reports whether an Anthropic model uses the 4.6+
 // effort/adaptive thinking mechanism rather than the legacy
 // thinking{type:"enabled", budget_tokens:N} path. Pre-4.6 Claude advertises only
-// the implicit low/medium/high base; 4.6+ adds at least one of disable (spelled
-// "none" on the OpenAI wire) / minimal / xhigh / max. Detecting any of those
-// catches the cloud-provider variants that the registry leaves without
-// supports_adaptive_thinking.
+// the implicit low/medium/high base; 4.6+ adds at least one of minimal/xhigh/max.
+// Detecting any of those catches the cloud-provider variants that the registry
+// leaves without supports_adaptive_thinking.
+//
+// The disable token is deliberately not a signal. It declares that a model can be
+// turned off, which every Claude generation can do, so reading it as "4.6+" would
+// put a legacy model on the adaptive wire that it rejects.
 func anthropicEffortEra(effortLevels []string) bool {
 	for _, e := range effortLevels {
 		switch e {
-		case models.ReasoningEffortDisable, models.ReasoningEffortMinimal,
-			models.ReasoningEffortXHigh, models.ReasoningEffortMax:
+		case models.ReasoningEffortMinimal, models.ReasoningEffortXHigh,
+			models.ReasoningEffortMax:
 			return true
 		}
 	}

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -884,13 +884,14 @@ func resolveReasoningConfig(chatModel models.GetResponse, botSettings settings.S
 // anthropicEffortEra reports whether an Anthropic model uses the 4.6+
 // effort/adaptive thinking mechanism rather than the legacy
 // thinking{type:"enabled", budget_tokens:N} path. Pre-4.6 Claude advertises only
-// the implicit low/medium/high base; 4.6+ adds at least one of none/minimal/
-// xhigh/max. Detecting any of those tiers catches the cloud-provider variants
-// that the registry leaves without supports_adaptive_thinking.
+// the implicit low/medium/high base; 4.6+ adds at least one of disable (spelled
+// "none" on the OpenAI wire) / minimal / xhigh / max. Detecting any of those
+// catches the cloud-provider variants that the registry leaves without
+// supports_adaptive_thinking.
 func anthropicEffortEra(effortLevels []string) bool {
 	for _, e := range effortLevels {
 		switch e {
-		case models.ReasoningEffortNone, models.ReasoningEffortMinimal,
+		case models.ReasoningEffortDisable, models.ReasoningEffortMinimal,
 			models.ReasoningEffortXHigh, models.ReasoningEffortMax:
 			return true
 		}
@@ -966,21 +967,21 @@ func hasEffort(effortLevels []string, effort string) bool {
 	return false
 }
 
-// offEffortFor picks the effort an OpenAI-style provider should send to
-// approximate "off": "none" when advertised, else "minimal" when advertised,
-// else "" meaning the caller must omit reasoning_effort entirely. Returning a
-// real tier (low/medium/high) here would *enable* thinking instead of disabling
-// it — e.g. OpenRouter translates reasoning_effort:"low" into Anthropic extended
-// thinking, so a toggle model that advertises only low/medium/high would keep
-// reasoning on when the user selected Off. Omitting the field instead lets the
-// provider default (thinking off for toggle/Anthropic-compat models) take over
-// and also avoids sending an unsupported tier. effortLevels is ordered low→high.
+// offEffortFor translates "off" into the effort value an OpenAI-format provider
+// needs, or "" when the model cannot be turned off and the caller must omit
+// reasoning_effort entirely. A model that advertises ReasoningEffortDisable can be
+// switched off, and OpenAI spells that state "none".
+//
+// It deliberately never falls back to a real tier. "minimal" used to serve as a
+// second-best "off", but it enables reasoning rather than disabling it, so Off
+// would have resolved to the same request as the Minimal tier — one state, two
+// selectable options. The two are also mutually exclusive upstream: minimal is
+// gpt-5.0's weakest tier and gpt-5.1 replaced it with none, so "advertises minimal
+// but not none" describes a model that genuinely cannot be turned off. Omitting
+// the field is the honest answer there, and it lets the provider default stand.
 func offEffortFor(effortLevels []string) string {
-	if hasEffort(effortLevels, models.ReasoningEffortNone) {
+	if hasEffort(effortLevels, models.ReasoningEffortDisable) {
 		return models.ReasoningEffortNone
-	}
-	if hasEffort(effortLevels, models.ReasoningEffortMinimal) {
-		return models.ReasoningEffortMinimal
 	}
 	return ""
 }

--- a/internal/agent/application/service_model_selection_test.go
+++ b/internal/agent/application/service_model_selection_test.go
@@ -214,6 +214,17 @@ func TestResolveReasoningConfig(t *testing.T) {
 			},
 		},
 	}
+	// Legacy Anthropic that also declares it can be turned off. Being turn-off
+	// capable says nothing about which thinking wire the model speaks, so this one
+	// must stay on the budget path.
+	disablableLegacyAnthropicModel := models.GetResponse{
+		Model: models.Model{
+			Config: models.ModelConfig{
+				ThinkingMode:     models.ThinkingModeToggle,
+				ReasoningEfforts: []string{models.ReasoningEffortDisable, "low", "medium", "high"},
+			},
+		},
+	}
 	// Cloud-variant Claude 4.6+: the registry left it toggle (no
 	// supports_adaptive_thinking) but it advertises 4.6+ effort tiers, so the
 	// Anthropic wire promotes it to adaptive to stay off the legacy budget path.
@@ -346,6 +357,13 @@ func TestResolveReasoningConfig(t *testing.T) {
 		{
 			name:        "legacy anthropic stays non-adaptive for budget path",
 			model:       legacyAnthropicModel,
+			botSettings: settings.Settings{ReasoningEffort: models.ReasoningEffortHigh},
+			clientType:  string(models.ClientTypeAnthropicMessages),
+			want:        &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortHigh},
+		},
+		{
+			name:        "declaring off does not promote a legacy anthropic model to adaptive",
+			model:       disablableLegacyAnthropicModel,
 			botSettings: settings.Settings{ReasoningEffort: models.ReasoningEffortHigh},
 			clientType:  string(models.ClientTypeAnthropicMessages),
 			want:        &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortHigh},

--- a/internal/agent/application/service_model_selection_test.go
+++ b/internal/agent/application/service_model_selection_test.go
@@ -23,8 +23,20 @@ func TestOffEffortFor(t *testing.T) {
 		levels []string
 		want   string
 	}{
-		{"none wins", []string{models.ReasoningEffortNone, "low", "medium"}, models.ReasoningEffortNone},
-		{"minimal when no none", []string{models.ReasoningEffortMinimal, "low", "medium"}, models.ReasoningEffortMinimal},
+		{
+			"declaring disable yields the OpenAI wire spelling of off",
+			[]string{models.ReasoningEffortDisable, "low", "medium"},
+			models.ReasoningEffortNone,
+		},
+		{
+			// minimal reduces reasoning, it does not stop it, so standing in for off
+			// would make Off and the Minimal tier the same request. Upstream also
+			// never ships both: minimal is gpt-5.0's weakest tier and gpt-5.1
+			// replaced it with none.
+			"minimal is a tier, not a stand-in for off",
+			[]string{models.ReasoningEffortMinimal, "low", "medium"},
+			"",
+		},
 		{"empty when only real tiers (omit, do not enable)", []string{"medium", "high", "xhigh"}, ""},
 		{"legacy base yields empty (omit reasoning_effort)", []string{"low", "medium", "high"}, ""},
 		{"empty levels yield empty", nil, ""},
@@ -182,11 +194,12 @@ func TestResolveReasoningConfig(t *testing.T) {
 		},
 	}
 
-	noneEffortModel := models.GetResponse{
+	// A model that advertises it can be turned off, alongside its active tiers.
+	disablableModel := models.GetResponse{
 		Model: models.Model{
 			Config: models.ModelConfig{
 				ThinkingMode:     models.ThinkingModeToggle,
-				ReasoningEfforts: []string{"none", "minimal", "low", "medium", "high"},
+				ReasoningEfforts: []string{models.ReasoningEffortDisable, "minimal", "low", "medium", "high"},
 			},
 		},
 	}
@@ -236,18 +249,27 @@ func TestResolveReasoningConfig(t *testing.T) {
 			want:          &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortMedium},
 		},
 		{
-			name:          "unsupported none effort falls back to bot default",
+			// A requested "none" is an off request, not an active tier. Treating it as
+			// a tier produced Active with Effort "none" — enabled at no strength —
+			// which wires to the same request as off.
+			name:          "requested none reads as off even when the model cannot be turned off",
 			model:         toggleModel,
 			botSettings:   settings.Settings{ReasoningEffort: models.ReasoningEffortHigh},
 			requestEffort: models.ReasoningEffortNone,
-			want:          &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortHigh},
+			want:          &models.ReasoningConfig{Disabled: true},
 		},
 		{
-			name:          "explicit none effort is preserved when model supports it",
-			model:         noneEffortModel,
+			name:          "requested none reads as off, and a disablable model carries the wire value",
+			model:         disablableModel,
 			botSettings:   settings.Settings{ReasoningEffort: models.ReasoningEffortHigh},
 			requestEffort: models.ReasoningEffortNone,
-			want:          &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortNone},
+			want:          &models.ReasoningConfig{Disabled: true, OffEffort: models.ReasoningEffortNone},
+		},
+		{
+			name:          "explicit disable reads as off",
+			model:         disablableModel,
+			requestEffort: models.ReasoningEffortDisable,
+			want:          &models.ReasoningConfig{Disabled: true, OffEffort: models.ReasoningEffortNone},
 		},
 		{
 			name:          "explicit effort is trimmed",

--- a/internal/agent/application/service_model_selection_test.go
+++ b/internal/agent/application/service_model_selection_test.go
@@ -272,6 +272,21 @@ func TestResolveReasoningConfig(t *testing.T) {
 			want:          &models.ReasoningConfig{Disabled: true, OffEffort: models.ReasoningEffortNone},
 		},
 		{
+			// A bot parked on off, overridden for one message with a tier the model
+			// does not advertise. The stored value must not be picked up as the active
+			// tier: "disable" is advertisable now, so it would otherwise reach the
+			// provider wire, where no vendor knows the word.
+			name:          "a stored off never becomes the active tier",
+			model:         disablableModel,
+			botSettings:   settings.Settings{ReasoningEffort: models.ReasoningEffortDisable},
+			requestEffort: models.ReasoningEffortXHigh,
+			want: &models.ReasoningConfig{
+				Active:    true,
+				Effort:    models.ReasoningEffortMedium,
+				OffEffort: models.ReasoningEffortNone,
+			},
+		},
+		{
 			name:          "explicit effort is trimmed",
 			model:         toggleModel,
 			requestEffort: " low ",

--- a/internal/capabilities/discover.go
+++ b/internal/capabilities/discover.go
@@ -43,8 +43,10 @@ type Capabilities struct {
 }
 
 // effortOrder is the canonical low→high ordering used to render effort lists.
+// "off" leads because it is the weakest thing a user can ask for, even though it
+// is not a tier.
 var effortOrder = []string{
-	models.ReasoningEffortNone,
+	models.ReasoningEffortDisable,
 	models.ReasoningEffortMinimal,
 	models.ReasoningEffortLow,
 	models.ReasoningEffortMedium,
@@ -103,8 +105,10 @@ func deriveEffortLevels(e litellmEntry) []string {
 	if e.SupportsLowReasoningEffort == nil || *e.SupportsLowReasoningEffort {
 		present[models.ReasoningEffortLow] = true
 	}
+	// The registry flag is named after OpenAI's wire value, but what it tells us is
+	// that the model can be turned off, so it lands on our neutral token.
 	if boolVal(e.SupportsNoneReasoningEffort) {
-		present[models.ReasoningEffortNone] = true
+		present[models.ReasoningEffortDisable] = true
 	}
 	if boolVal(e.SupportsMinimalReasoningEffort) {
 		present[models.ReasoningEffortMinimal] = true

--- a/internal/command/reasoning.go
+++ b/internal/command/reasoning.go
@@ -10,19 +10,21 @@ import (
 )
 
 // reasoningChoices are the selectable reasoning levels. "off" disables thinking;
-// the rest enable it at that effort.
+// the rest enable it at that effort. Only "off" represents the disabled state —
+// listing "none" here too offered the same state under a second name.
 var reasoningChoices = []string{
 	"off",
-	models.ReasoningEffortNone,
 	models.ReasoningEffortLow,
 	models.ReasoningEffortMedium,
 	models.ReasoningEffortHigh,
 	models.ReasoningEffortXHigh,
 }
 
+// validEffort accepts the tiers that turn reasoning on. The disabled state is
+// handled by its own branch before this is consulted.
 func validEffort(v string) bool {
 	switch v {
-	case models.ReasoningEffortNone, models.ReasoningEffortLow, models.ReasoningEffortMedium, models.ReasoningEffortHigh, models.ReasoningEffortXHigh:
+	case models.ReasoningEffortLow, models.ReasoningEffortMedium, models.ReasoningEffortHigh, models.ReasoningEffortXHigh:
 		return true
 	}
 	return false

--- a/internal/command/reasoning_test.go
+++ b/internal/command/reasoning_test.go
@@ -45,10 +45,15 @@ func TestReasoningChoicesIncludeFullBackendEffortLadder(t *testing.T) {
 	for _, c := range res.Interactive.Choices.Choices {
 		labels[c.Label] = true
 	}
-	for _, want := range []string{"off", "none", "low", "medium", "high", "xhigh"} {
+	for _, want := range []string{"off", "low", "medium", "high", "xhigh"} {
 		if !labels[want] {
 			t.Errorf("reasoning choices missing %q", want)
 		}
+	}
+	// "off" is the only disabled choice. Listing "none" alongside it offered the
+	// same state twice, and picking either stored a value that reads as off.
+	if labels[models.ReasoningEffortNone] {
+		t.Error("reasoning choices still offer none, a second name for off")
 	}
 }
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -438,6 +438,8 @@ func (s *Service) convertToGetResponse(dbModel sqlc.Model) GetResponse {
 		if err := json.Unmarshal(dbModel.Config, &resp.Config); err != nil {
 			s.logger.Warn("failed to unmarshal model config", slog.String("model_id", dbModel.ModelID), slog.Any("error", err))
 		}
+		// Rows written before "off" was unified still advertise the legacy spelling.
+		resp.Config = normalizeModelConfig(resp.Config)
 	}
 
 	return resp

--- a/internal/models/reasoning_effort_test.go
+++ b/internal/models/reasoning_effort_test.go
@@ -1,6 +1,9 @@
 package models
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestNearestEffortToMedium(t *testing.T) {
 	t.Parallel()
@@ -75,6 +78,62 @@ func TestIsValidReasoningEffortVocabulary(t *testing.T) {
 	}
 	if IsValidReasoningEffort(ReasoningEffortNone) {
 		t.Error("IsValidReasoningEffort accepted none, which is a provider wire value")
+	}
+}
+
+// Declarations written before off was unified, and provider registries that have
+// not been regenerated, still advertise the legacy spelling. Normalizing on both
+// boundaries of ModelConfig is what keeps those models readable as turn-off
+// capable — dropping the value instead would hide Off from a model that supports
+// it, and would make every consumer that looks for the disable token misread it.
+func TestNormalizeModelConfigRewritesLegacyOff(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "legacy spelling becomes the declarable token",
+			in:   []string{ReasoningEffortNone, "low", "medium", "high"},
+			want: []string{ReasoningEffortDisable, "low", "medium", "high"},
+		},
+		{
+			name: "both spellings collapse to one entry",
+			in:   []string{ReasoningEffortNone, ReasoningEffortDisable, "low"},
+			want: []string{ReasoningEffortDisable, "low"},
+		},
+		{
+			name: "active tiers are untouched",
+			in:   []string{"minimal", "low", "high"},
+			want: []string{"minimal", "low", "high"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeModelConfig(ModelConfig{ReasoningEfforts: tt.in}).ReasoningEfforts
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("ReasoningEfforts = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Normalizing before validation is what lets a legacy declaration be stored at all:
+// the vocabulary no longer accepts "none", so a config carrying it would otherwise
+// be rejected on write.
+func TestLegacyOffDeclarationSurvivesValidation(t *testing.T) {
+	t.Parallel()
+
+	m := Model{
+		ModelID:    "m",
+		ProviderID: "11111111-1111-1111-1111-111111111111",
+		Type:       ModelTypeChat,
+		Config:     normalizeModelConfig(ModelConfig{ReasoningEfforts: []string{ReasoningEffortNone, "high"}}),
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want a legacy declaration to normalize and pass", err)
 	}
 }
 

--- a/internal/models/reasoning_effort_test.go
+++ b/internal/models/reasoning_effort_test.go
@@ -52,8 +52,11 @@ func TestIsReasoningDisabled(t *testing.T) {
 	}{
 		{effort: ReasoningEffortDisable, want: true},
 		{effort: "  disable  ", want: true},
-		{effort: ReasoningEffortNone, want: false},
+		// Legacy spelling: "none" was declarable and storable before off was
+		// unified onto the disable token, so stored values must still read as off.
+		{effort: ReasoningEffortNone, want: true},
 		{effort: "", want: false},
+		{effort: ReasoningEffortMinimal, want: false},
 	} {
 		if got := IsReasoningDisabled(tt.effort); got != tt.want {
 			t.Errorf("IsReasoningDisabled(%q) = %v, want %v", tt.effort, got, tt.want)
@@ -61,12 +64,29 @@ func TestIsReasoningDisabled(t *testing.T) {
 	}
 }
 
-func TestIsValidReasoningEffortRejectsDisable(t *testing.T) {
+// A model declares whether it can be turned off, and "disable" is how it says so.
+// The OpenAI wire spelling of that state is not declarable — adaptors translate
+// into it — so accepting both would give one state two selectable tokens again.
+func TestIsValidReasoningEffortVocabulary(t *testing.T) {
 	t.Parallel()
 
-	// ModelConfig stores wire tiers only; "disable" is a settings-level value and
-	// must never be persisted as a model capability.
-	if IsValidReasoningEffort(ReasoningEffortDisable) {
-		t.Fatal("IsValidReasoningEffort accepted the disable sentinel")
+	if !IsValidReasoningEffort(ReasoningEffortDisable) {
+		t.Error("IsValidReasoningEffort rejected disable, which a model must be able to advertise")
+	}
+	if IsValidReasoningEffort(ReasoningEffortNone) {
+		t.Error("IsValidReasoningEffort accepted none, which is a provider wire value")
+	}
+}
+
+// The nearest-tier fallback must never resolve an active reasoning config to off,
+// which is why the disable token is kept out of the tier ordering.
+func TestNearestEffortToMediumNeverReturnsOff(t *testing.T) {
+	t.Parallel()
+
+	if got := NearestEffortToMedium([]string{ReasoningEffortDisable}); got != "" {
+		t.Errorf("NearestEffortToMedium([disable]) = %q, want empty", got)
+	}
+	if got := NearestEffortToMedium([]string{ReasoningEffortDisable, ReasoningEffortHigh}); got != ReasoningEffortHigh {
+		t.Errorf("NearestEffortToMedium([disable high]) = %q, want high", got)
 	}
 }

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -49,10 +49,10 @@ type ReasoningConfig struct {
 	Adaptive bool
 	// Effort is the effort tier to send when active ("" lets the SDK default).
 	Effort string
-	// OffEffort is the effort an OpenAI-style provider should send when disabled:
-	// "none" when supported, else "minimal" when supported, else "" meaning the
-	// reasoning_effort field is omitted entirely. It is never a real tier
-	// (low/medium/high) because those enable thinking instead of disabling it.
+	// OffEffort is the effort an OpenAI-format provider should send when disabled:
+	// "none" when the model advertised that it can be turned off, else "" meaning
+	// the reasoning_effort field is omitted entirely. It is never a real tier
+	// (minimal/low/medium/high) because those enable thinking instead of disabling it.
 	OffEffort string
 }
 
@@ -228,8 +228,8 @@ func BuildReasoningOptions(cfg SDKModelConfig) []sdk.GenerateOption {
 }
 
 // openAIEffortOptions maps a reasoning decision to OpenAI-style reasoning.effort.
-// OpenAI models have no real on/off switch, so "off" is approximated by the
-// lowest effort the model supports (none when available, otherwise minimal).
+// OpenAI expresses "off" as a member of the same enum ("none" from gpt-5.1 on),
+// so the off state travels in the very field that carries the tiers.
 func openAIEffortOptions(clientType ClientType, rc *ReasoningConfig) []sdk.GenerateOption {
 	switch {
 	case rc.Active:
@@ -239,12 +239,11 @@ func openAIEffortOptions(clientType ClientType, rc *ReasoningConfig) []sdk.Gener
 		}
 		return []sdk.GenerateOption{sdk.WithReasoningEffort(effort)}
 	case rc.Disabled:
-		// Approximate "off". Only "none"/"minimal" actually reduce/disable
-		// thinking; a real tier (low/medium/high) would turn thinking ON (e.g.
-		// OpenRouter maps reasoning_effort:"low" to Anthropic extended thinking).
-		// When the model advertises no such off-ish tier, OffEffort is empty and
-		// we omit reasoning_effort entirely so the provider default (no thinking
-		// for toggle/Anthropic-compat models) applies.
+		// OffEffort is "none" when the model advertised that it can be turned off,
+		// and "" when it cannot. Omitting the field in the latter case lets the
+		// provider default stand; sending a real tier instead would turn thinking
+		// ON (OpenRouter, for instance, maps reasoning_effort:"low" onto Anthropic
+		// extended thinking), which is the opposite of what the user asked for.
 		off := openAIWireEffort(clientType, rc.OffEffort)
 		if off == "" {
 			return nil

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -235,7 +236,34 @@ func normalizeModelConfig(config ModelConfig) ModelConfig {
 		description := strings.TrimSpace(*config.Description)
 		config.Description = &description
 	}
+	config.ReasoningEfforts = normalizeAdvertisedEfforts(config.ReasoningEfforts)
 	return config
+}
+
+// normalizeAdvertisedEfforts rewrites the legacy spelling of "off" to the token a
+// model declares today. It runs on both boundaries of ModelConfig — before a write
+// is validated and after a row is read back — so nothing downstream has to know
+// that "none" was ever declarable.
+//
+// Without it the vocabulary change would only apply to freshly written configs:
+// rows persisted earlier, and provider registries that have not been regenerated,
+// would keep advertising "none", and every consumer that now looks for the disable
+// token would read those models as "cannot be turned off" — silently dropping Off
+// from the picker and misreading which thinking mechanism the model wants.
+func normalizeAdvertisedEfforts(efforts []string) []string {
+	if len(efforts) == 0 {
+		return efforts
+	}
+	out := make([]string, 0, len(efforts))
+	for _, effort := range efforts {
+		if strings.TrimSpace(effort) == ReasoningEffortNone {
+			effort = ReasoningEffortDisable
+		}
+		if !slices.Contains(out, effort) {
+			out = append(out, effort)
+		}
+	}
+	return out
 }
 
 type Model struct {

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -236,21 +236,21 @@ func normalizeModelConfig(config ModelConfig) ModelConfig {
 		description := strings.TrimSpace(*config.Description)
 		config.Description = &description
 	}
-	config.ReasoningEfforts = normalizeAdvertisedEfforts(config.ReasoningEfforts)
+	config.ReasoningEfforts = NormalizeAdvertisedEfforts(config.ReasoningEfforts)
 	return config
 }
 
-// normalizeAdvertisedEfforts rewrites the legacy spelling of "off" to the token a
+// NormalizeAdvertisedEfforts rewrites the legacy spelling of "off" to the token a
 // model declares today. It runs on both boundaries of ModelConfig — before a write
-// is validated and after a row is read back — so nothing downstream has to know
-// that "none" was ever declarable.
+// is validated and after a row is read back — and at external catalog boundaries,
+// so nothing downstream has to know that "none" was ever declarable.
 //
 // Without it the vocabulary change would only apply to freshly written configs:
 // rows persisted earlier, and provider registries that have not been regenerated,
 // would keep advertising "none", and every consumer that now looks for the disable
 // token would read those models as "cannot be turned off" — silently dropping Off
 // from the picker and misreading which thinking mechanism the model wants.
-func normalizeAdvertisedEfforts(efforts []string) []string {
+func NormalizeAdvertisedEfforts(efforts []string) []string {
 	if len(efforts) == 0 {
 		return efforts
 	}

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -58,8 +58,9 @@ const (
 	CompatFileInput = "file-input"
 )
 
+// Active effort tiers, weakest to strongest. These are the values that turn
+// reasoning on; "off" is ReasoningEffortDisable and deliberately not among them.
 const (
-	ReasoningEffortNone    = "none"
 	ReasoningEffortMinimal = "minimal"
 	ReasoningEffortLow     = "low"
 	ReasoningEffortMedium  = "medium"
@@ -68,16 +69,27 @@ const (
 	ReasoningEffortMax     = "max"
 )
 
-// ReasoningEffortDisable turns reasoning off. It is not a wire tier a model can
-// advertise — it is the settings/override value that says "send no reasoning at
-// all", which is why IsValidReasoningEffort rejects it. Since bots dropped the
-// separate reasoning_enabled flag, this is the only representation of "off".
+// ReasoningEffortDisable is the single representation of "no reasoning". It is
+// both what a user picks and what a model advertises: a model listing it in
+// reasoning_efforts can be turned off, whatever wire shape that takes on its
+// provider. Since bots dropped the separate reasoning_enabled flag, it is also
+// the only stored form of "off".
 const ReasoningEffortDisable = "disable"
 
-// orderedReasoningEfforts lists the real tiers weakest to strongest. Order is
-// what NearestEffortToMedium walks, so it must stay monotonic.
+// ReasoningEffortNone is OpenAI's wire spelling of "no reasoning" (gpt-5.1
+// introduced it and dropped minimal; gpt-5.0 has minimal and no none). It is
+// never declared by a model nor stored in settings — provider adaptors translate
+// ReasoningEffortDisable into it, exactly as the Anthropic path translates the
+// same intent into thinking{type:"disabled"}. Giving "off" one name on our side
+// and letting each provider spell it its own way is what keeps a single state
+// from acquiring two selectable tokens.
+const ReasoningEffortNone = "none"
+
+// orderedReasoningEfforts lists the active tiers weakest to strongest. Order is
+// what NearestEffortToMedium walks, so it must stay monotonic. ReasoningEffortDisable
+// is absent on purpose: it is not a tier, and including it would let the nearest-tier
+// fallback resolve an *active* reasoning config to "off".
 var orderedReasoningEfforts = []string{
-	ReasoningEffortNone,
 	ReasoningEffortMinimal,
 	ReasoningEffortLow,
 	ReasoningEffortMedium,
@@ -87,8 +99,14 @@ var orderedReasoningEfforts = []string{
 }
 
 // IsReasoningDisabled reports whether an effort value means "no reasoning".
+// ReasoningEffortNone is accepted as the legacy spelling: it was declarable and
+// storable before "off" was unified onto ReasoningEffortDisable.
 func IsReasoningDisabled(effort string) bool {
-	return strings.TrimSpace(effort) == ReasoningEffortDisable
+	switch strings.TrimSpace(effort) {
+	case ReasoningEffortDisable, ReasoningEffortNone:
+		return true
+	}
+	return false
 }
 
 // NearestEffortToMedium picks the tier closest to medium from levels, breaking
@@ -169,8 +187,12 @@ func ValidateCompatibilities(compatibilities []string) error {
 	return nil
 }
 
+// validReasoningEfforts is the vocabulary a model may advertise: the active tiers
+// plus ReasoningEffortDisable, which declares that the model can be turned off.
+// ReasoningEffortNone is absent because it is a provider wire value, not something
+// a model declares — see the constant.
 var validReasoningEfforts = map[string]struct{}{
-	ReasoningEffortNone:    {},
+	ReasoningEffortDisable: {},
 	ReasoningEffortMinimal: {},
 	ReasoningEffortLow:     {},
 	ReasoningEffortMedium:  {},

--- a/internal/providers/codex_models.go
+++ b/internal/providers/codex_models.go
@@ -112,9 +112,12 @@ func (s *Service) listCodexRemoteModels(ctx context.Context, baseURL string, cre
 		if containsFold(model.InputModalities, "image") {
 			compatibilities = append(compatibilities, models.CompatVision)
 		}
-		reasoningEfforts := make([]string, 0, len(model.SupportedReasoningLevels))
+		advertisedEfforts := make([]string, 0, len(model.SupportedReasoningLevels))
 		for _, level := range model.SupportedReasoningLevels {
-			effort := strings.TrimSpace(level.Effort)
+			advertisedEfforts = append(advertisedEfforts, strings.ToLower(strings.TrimSpace(level.Effort)))
+		}
+		reasoningEfforts := make([]string, 0, len(advertisedEfforts))
+		for _, effort := range models.NormalizeAdvertisedEfforts(advertisedEfforts) {
 			if models.IsValidReasoningEffort(effort) && !containsFold(reasoningEfforts, effort) {
 				reasoningEfforts = append(reasoningEfforts, effort)
 			}

--- a/internal/providers/copilot_models.go
+++ b/internal/providers/copilot_models.go
@@ -142,9 +142,12 @@ func (s *Service) listGitHubCopilotRemoteModels(ctx context.Context, baseURL, gi
 		if model.Capabilities.Supports.Vision {
 			compatibilities = append(compatibilities, models.CompatVision)
 		}
-		reasoningEfforts := make([]string, 0, len(model.Capabilities.Supports.ReasoningEffort))
+		advertisedEfforts := make([]string, 0, len(model.Capabilities.Supports.ReasoningEffort))
 		for _, effort := range model.Capabilities.Supports.ReasoningEffort {
-			effort = strings.ToLower(strings.TrimSpace(effort))
+			advertisedEfforts = append(advertisedEfforts, strings.ToLower(strings.TrimSpace(effort)))
+		}
+		reasoningEfforts := make([]string, 0, len(advertisedEfforts))
+		for _, effort := range models.NormalizeAdvertisedEfforts(advertisedEfforts) {
 			if models.IsValidReasoningEffort(effort) && !containsFold(reasoningEfforts, effort) {
 				reasoningEfforts = append(reasoningEfforts, effort)
 			}

--- a/internal/providers/copilot_models_test.go
+++ b/internal/providers/copilot_models_test.go
@@ -42,7 +42,19 @@ func TestListGitHubCopilotRemoteModels(t *testing.T) {
 							"supports": map[string]any{
 								"tool_calls":       true,
 								"vision":           true,
-								"reasoning_effort": []string{"low", "max", "ultra", "low"},
+								"reasoning_effort": []string{" none ", "low", "max", "ultra", "none", "low"},
+							},
+						},
+					},
+					{
+						"id":                   "off-only-model",
+						"name":                 "Off-only Model",
+						"model_picker_enabled": true,
+						"supported_endpoints":  []string{"/chat/completions"},
+						"capabilities": map[string]any{
+							"type": "chat",
+							"supports": map[string]any{
+								"reasoning_effort": []string{"none"},
 							},
 						},
 					},
@@ -74,8 +86,8 @@ func TestListGitHubCopilotRemoteModels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("list GitHub Copilot models: %v", err)
 		}
-		if len(remoteModels) != 1 {
-			t.Fatalf("models = %d, want 1: %#v", len(remoteModels), remoteModels)
+		if len(remoteModels) != 2 {
+			t.Fatalf("models = %d, want 2: %#v", len(remoteModels), remoteModels)
 		}
 		model := remoteModels[0]
 		if model.ID != "reasoning-model" || model.Name != "Reasoning Model" || model.OwnedBy != "Example" {
@@ -84,7 +96,7 @@ func TestListGitHubCopilotRemoteModels(t *testing.T) {
 		if got := strings.Join(model.Compatibilities, ","); got != "tool-call,vision,reasoning" {
 			t.Fatalf("compatibilities = %q", got)
 		}
-		if got := strings.Join(model.ReasoningEfforts, ","); got != "low,max" {
+		if got := strings.Join(model.ReasoningEfforts, ","); got != "disable,low,max" {
 			t.Fatalf("reasoning efforts = %q", got)
 		}
 		if model.ThinkingMode != models.ThinkingModeToggle {
@@ -95,6 +107,16 @@ func TestListGitHubCopilotRemoteModels(t *testing.T) {
 		}
 		if !model.CapabilitiesKnown {
 			t.Fatal("Copilot catalog capabilities should be authoritative")
+		}
+		offOnlyModel := remoteModels[1]
+		if got := strings.Join(offOnlyModel.ReasoningEfforts, ","); got != "disable" {
+			t.Fatalf("off-only reasoning efforts = %q", got)
+		}
+		if got := strings.Join(offOnlyModel.Compatibilities, ","); got != "reasoning" {
+			t.Fatalf("off-only compatibilities = %q", got)
+		}
+		if offOnlyModel.ThinkingMode != models.ThinkingModeToggle {
+			t.Fatalf("off-only thinking mode = %q", offOnlyModel.ThinkingMode)
 		}
 	})
 

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -127,6 +127,7 @@ func TestListCodexRemoteModels(t *testing.T) {
 					"display_name": "GPT-5.6-Sol",
 					"visibility":   "list",
 					"supported_reasoning_levels": []map[string]any{
+						{"effort": " NONE "},
 						{"effort": "low"},
 						{"effort": "medium"},
 						{"effort": "high"},
@@ -134,6 +135,7 @@ func TestListCodexRemoteModels(t *testing.T) {
 						{"effort": "xhigh"},
 						{"effort": "max"},
 						{"effort": "ultra"},
+						{"effort": "none"},
 					},
 					"context_window":   372000,
 					"input_modalities": []string{"text", "image"},
@@ -186,7 +188,7 @@ func TestListCodexRemoteModels(t *testing.T) {
 	if got := strings.Join(model.Compatibilities, ","); got != "tool-call,vision,reasoning" {
 		t.Fatalf("compatibilities = %q", got)
 	}
-	if got := strings.Join(model.ReasoningEfforts, ","); got != "low,medium,high,xhigh,max" {
+	if got := strings.Join(model.ReasoningEfforts, ","); got != "disable,low,medium,high,xhigh,max" {
 		t.Fatalf("reasoning efforts = %q", got)
 	}
 	if model.ThinkingMode != models.ThinkingModeToggle {


### PR DESCRIPTION
## Problem

"Off" has two names. `disable` is what a user picks and what a bot stores; `none` is what a model may advertise in `reasoning_efforts`. Both survive into the picker, so a model advertising `none` renders two options — different labels, identical request.

The split is deliberate today. #563 introduced `REASONING_EFFORT_DISABLE` as the picker's off token — prepended unconditionally — and in the same change made `none` declarable. #926 then dropped the `reasoning_enabled` flag and promoted `ReasoningEffortDisable` into `internal/models` as "the settings/override value that says send no reasoning at all, which is why IsValidReasoningEffort rejects it", keeping `none` as the declarable spelling.

This PR argues that split costs more than it buys:

- **One state, two selectable options.** `KNOWN_EFFORTS` contains `none` and `availableEffortsForMode` prepends `disable` unconditionally, so a model advertising `none` offers both. Picking either produces the same request.
- **`none` sits in the tier ordering.** `orderedReasoningEfforts` lists it as the weakest tier, so `NearestEffortToMedium` can return it — an *active* reasoning config resolving to "no reasoning". #926 added a test guarding exactly this hazard for the `disable` sentinel; `none` walks through the same door because it is spelled like a tier.
- **Off is offered where it cannot be delivered.** The unconditional prepend shows the control on models that never declared they can be turned off, where the adaptor has no off shape to send and the model's default thinking behavior stands regardless.

Keeping two names is what makes all three possible: as long as off is spelled one way in settings and another way in declarations, nothing stops the declaration spelling from being treated as a tier.

## Change

`disable` becomes the single name for off on our side — both what a user picks and what a model advertises. `none` steps back to what it actually is: OpenAI's wire spelling, produced by the provider adaptor, exactly as the Anthropic path produces `thinking:{type:"disabled"}` for the same intent.

| Area | Change |
|---|---|
| `internal/models/types.go` | `validReasoningEfforts` accepts `disable`, drops `none`; `IsReasoningDisabled` still accepts `none` so values stored under the old spelling keep working |
| `internal/capabilities/discover.go` | LiteLLM's `supports_none_reasoning_effort` now lands on `disable` — the flag is named after OpenAI's wire value, but what it reports is that the model can be turned off |
| `internal/models/sdk.go`, `internal/agent/application/service.go` | off is translated to `none` at the OpenAI wire, and to nothing at all when the model cannot be turned off |
| `internal/command/reasoning.go` | `/reasoning` offers `off` instead of the `none` tier |
| `apps/web/.../reasoning-effort.ts` | `KNOWN_EFFORTS` holds only active tiers; declarable values are those plus `disable`; off is hoisted to the front only when the model advertises it |
| `conf/providers/*.yaml` | regenerated (`go run ./cmd/synccaps`) — 27 entries across 4 templates |

Why `disable` rather than `none` as the canonical value: `none` is OpenAI's vocabulary, and OpenAI has already changed it once — `minimal` was gpt-5.0's weakest tier and gpt-5.1 replaced it with `none`. Making it the neutral value binds the model layer to one vendor's naming. It also keeps the tier ordering honest: `disable` is not a tier, so it stays out of `KNOWN_EFFORTS` and the nearest-tier fallback can never resolve an *active* config to off.

## Behavior change worth calling out

Off is no longer offered on a model that does not advertise it. Previously the option appeared everywhere and, when picked on such a model, resolved to omitting `reasoning_effort` entirely — so the model's default thinking behavior stood and the control silently did nothing. Removing it makes the picker reflect what the model can actually do.

Existing bots whose stored effort is the legacy `none` keep working: `IsReasoningDisabled` still reads it as off.

## A hazard the change itself introduces

Advertising "off" puts the disable token into the effort level list, and `pickEffort` reads the bot's stored effort directly rather than through the tier ordering that deliberately excludes it. A bot parked on off, overridden for one message with a tier the model does not advertise, would hand `disable` back as the *active* tier and send it upstream, where no vendor knows the word. The requested effort was already guarded against exactly this; the second commit extends the same rule to the stored one.

This is the same hazard `orderedReasoningEfforts` and `NearestEffortToMedium` are shaped to avoid — worth noting that `pickEffort` bypasses both by reading settings straight.

## Verification

- `go build ./...`; `go test` on `internal/models`, `internal/capabilities`, `internal/agent/application`, `internal/command`
- `go run ./cmd/synccaps -check` clean; it correctly reports `templates are stale` if a `none` entry is put back, so the templates and the discovery mapping stay in agreement
- `vitest run src/pages/bots/components/reasoning-effort.test.ts` — 13 passing

New assertions cover the parts that carry the intent: `disable` is declarable and `none` is not, the picker offers off exactly once and only when advertised, and the nearest-tier fallback never returns off.

