### PR TITLE
feat(context): system section retention policy and capability gating

### DIFF
--- a/internal/agent/application/platform_identity.go
+++ b/internal/agent/application/platform_identity.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	native "github.com/memohai/memoh/internal/agent/runtime/native"
 )
 
 const platformIdentitiesIntro = "## Platform Identities\n\nThese XML tags describe your own known account identities across connected platforms.\n"
@@ -18,16 +20,32 @@ type identityAttr struct {
 }
 
 func buildPlatformIdentitiesSection(configs []PlatformIdentity) string {
-	xmlBlock := buildPlatformIdentitiesXML(configs)
-	if xmlBlock == "" {
+	return buildPlatformIdentitiesSectionFromItems(buildPlatformIdentityPromptItems(configs))
+}
+
+func buildPlatformIdentitiesSectionFromItems(items []native.SystemPromptItem) string {
+	if len(items) == 0 {
 		return ""
 	}
-	return platformIdentitiesIntro + "\n" + xmlBlock
+	lines := make([]string, 0, len(items))
+	for _, item := range items {
+		lines = append(lines, item.Text)
+	}
+	return platformIdentitiesIntro + "\n" + strings.Join(lines, "\n")
 }
 
 func buildPlatformIdentitiesXML(configs []PlatformIdentity) string {
+	items := buildPlatformIdentityPromptItems(configs)
+	lines := make([]string, 0, len(items))
+	for _, item := range items {
+		lines = append(lines, item.Text)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func buildPlatformIdentityPromptItems(configs []PlatformIdentity) []native.SystemPromptItem {
 	if len(configs) == 0 {
-		return ""
+		return nil
 	}
 	sorted := make([]PlatformIdentity, len(configs))
 	copy(sorted, configs)
@@ -43,15 +61,15 @@ func buildPlatformIdentitiesXML(configs []PlatformIdentity) string {
 		return strings.Compare(left.ID, right.ID) < 0
 	})
 
-	lines := make([]string, 0, len(sorted))
+	items := make([]native.SystemPromptItem, 0, len(sorted))
 	for _, cfg := range sorted {
 		line := buildPlatformIdentityLine(cfg)
 		if line == "" {
 			continue
 		}
-		lines = append(lines, line)
+		items = append(items, native.SystemPromptItem{ID: strings.TrimSpace(cfg.ID), Text: line})
 	}
-	return strings.Join(lines, "\n")
+	return items
 }
 
 func buildPlatformIdentityLine(cfg PlatformIdentity) string {

--- a/internal/agent/application/platform_identity_test.go
+++ b/internal/agent/application/platform_identity_test.go
@@ -39,6 +39,39 @@ func TestBuildPlatformIdentitiesXML(t *testing.T) {
 	}
 }
 
+func TestBuildPlatformIdentityPromptItemsPreserveSortedIDs(t *testing.T) {
+	t.Parallel()
+
+	items := buildPlatformIdentityPromptItems([]PlatformIdentity{
+		{
+			ID:               "telegram-2",
+			Platform:         "telegram",
+			ExternalIdentity: "2",
+			SelfIdentity:     map[string]any{"username": "second"},
+		},
+		{
+			ID:               "discord-1",
+			Platform:         "discord",
+			ExternalIdentity: "1",
+			SelfIdentity:     map[string]any{"username": "first"},
+		},
+	})
+
+	if len(items) != 2 {
+		t.Fatalf("items = %#v, want 2", items)
+	}
+	if items[0].ID != "discord-1" || !strings.Contains(items[0].Text, `channel="discord"`) {
+		t.Fatalf("first item = %#v, want sorted discord identity with stable ID", items[0])
+	}
+	if items[1].ID != "telegram-2" || !strings.Contains(items[1].Text, `channel="telegram"`) {
+		t.Fatalf("second item = %#v, want sorted telegram identity with stable ID", items[1])
+	}
+	wantSection := platformIdentitiesIntro + "\n" + items[0].Text + "\n" + items[1].Text
+	if got := buildPlatformIdentitiesSectionFromItems(items); got != wantSection {
+		t.Fatalf("section = %q, want byte-equivalent %q", got, wantSection)
+	}
+}
+
 func TestBuildPlatformIdentityLineNormalizesAttrs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -1291,6 +1291,7 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 	}
 
 	platformIdentitiesSection := ""
+	var platformIdentityItems []native.SystemPromptItem
 	if s.platformIdentities != nil {
 		identities, err := s.platformIdentities.ListPlatformIdentities(ctx, cfg.Identity.BotID)
 		if err != nil {
@@ -1299,7 +1300,8 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 				slog.Any("error", err),
 			)
 		} else {
-			platformIdentitiesSection = buildPlatformIdentitiesSection(identities)
+			platformIdentityItems = buildPlatformIdentityPromptItems(identities)
+			platformIdentitiesSection = buildPlatformIdentitiesSectionFromItems(platformIdentityItems)
 		}
 	}
 	systemParams := native.SystemPromptParams{
@@ -1310,6 +1312,7 @@ func (s *Service) prepareRunConfig(ctx context.Context, cfg native.RunConfig) na
 		MaxFilesBytes:             limits.SystemFilesMaxBytes,
 		Timezone:                  cfg.Identity.Timezone,
 		PlatformIdentitiesSection: platformIdentitiesSection,
+		PlatformIdentities:        platformIdentityItems,
 	}
 	cfg.System = native.GenerateSystemPrompt(systemParams)
 	var promptHookTexts []string

--- a/internal/agent/context/fragment/compile.go
+++ b/internal/agent/context/fragment/compile.go
@@ -190,56 +190,63 @@ func systemFrags(system string, toolUsage string, scope Scope, source string) []
 
 func systemTextFrag(id string, kind Kind, text string, priority int, cacheClass CacheClass, scope Scope, source string, index int) ContextFrag {
 	return TextFrag(TextFragInput{
-		ID:         id,
-		Kind:       kind,
-		Role:       sdk.MessageRoleSystem,
-		Slot:       SlotSystem,
-		Text:       text,
-		Priority:   priority,
-		CacheClass: cacheClass,
-		Trust:      TrustSystem,
-		Scope:      scope,
-		Source:     source,
-		Collector:  CollectorRunConfigFields,
-		Index:      index,
-		Render:     RenderPolicy{Format: RenderMarkdown},
+		ID:            id,
+		Kind:          kind,
+		Role:          sdk.MessageRoleSystem,
+		Slot:          SlotSystem,
+		Text:          text,
+		Priority:      priority,
+		RetentionTier: RetentionRequired,
+		CacheClass:    cacheClass,
+		Trust:         TrustSystem,
+		Scope:         scope,
+		Source:        source,
+		Collector:     CollectorRunConfigFields,
+		Index:         index,
+		Render:        RenderPolicy{Format: RenderMarkdown},
 	})
 }
 
 // TextFragInput describes a text fragment to construct.
 type TextFragInput struct {
-	ID          string
-	Kind        Kind
-	Role        sdk.MessageRole
-	Slot        Slot
-	Text        string
-	Priority    int
-	CacheClass  CacheClass
-	Trust       TrustLevel
-	Scope       Scope
-	Source      string
-	SourceID    string
-	Collector   string
-	Index       int
-	Render      RenderPolicy
-	Budget      BudgetPolicy
-	ConflictKey string
+	ID                 string
+	Kind               Kind
+	Role               sdk.MessageRole
+	Slot               Slot
+	Text               string
+	Priority           int
+	RetentionTier      RetentionTier
+	DropPriority       DropPriority
+	RequiredCapability string
+	CacheClass         CacheClass
+	Trust              TrustLevel
+	Scope              Scope
+	Source             string
+	SourceID           string
+	Collector          string
+	Index              int
+	Render             RenderPolicy
+	Budget             BudgetPolicy
+	ConflictKey        string
 }
 
 // TextFrag creates a text-backed fragment.
 func TextFrag(input TextFragInput) ContextFrag {
 	return ContextFrag{
-		ID:          strings.TrimSpace(input.ID),
-		Kind:        input.Kind,
-		Role:        input.Role,
-		Slot:        input.Slot,
-		Priority:    input.Priority,
-		CacheClass:  input.CacheClass,
-		Trust:       input.Trust,
-		Scope:       normalizeScope(input.Scope),
-		Budget:      input.Budget,
-		Render:      input.Render,
-		ConflictKey: input.ConflictKey,
+		ID:                 strings.TrimSpace(input.ID),
+		Kind:               input.Kind,
+		Role:               input.Role,
+		Slot:               input.Slot,
+		Priority:           input.Priority,
+		RetentionTier:      input.RetentionTier,
+		DropPriority:       input.DropPriority,
+		RequiredCapability: strings.TrimSpace(input.RequiredCapability),
+		CacheClass:         input.CacheClass,
+		Trust:              input.Trust,
+		Scope:              normalizeScope(input.Scope),
+		Budget:             input.Budget,
+		Render:             input.Render,
+		ConflictKey:        input.ConflictKey,
 		Provenance: Provenance{
 			Source:    strings.TrimSpace(input.Source),
 			SourceID:  strings.TrimSpace(input.SourceID),
@@ -248,44 +255,55 @@ func TextFrag(input TextFragInput) ContextFrag {
 		},
 		Parts: []Part{{
 			Type: PartText,
-			Text: strings.TrimSpace(input.Text),
+			Text: RenderText(input.Text, input.Render),
 		}},
 	}
 }
 
 // MessageFragInput describes an SDK message fragment.
 type MessageFragInput struct {
-	ID            string
-	Message       sdk.Message
-	Kind          Kind
-	Slot          Slot
-	Priority      int
-	CacheClass    CacheClass
-	Trust         TrustLevel
-	Scope         Scope
-	Source        string
-	SourceID      string
-	Collector     string
-	Index         int
-	TokenEstimate int
-	Budget        BudgetPolicy
+	ID                 string
+	Message            sdk.Message
+	Kind               Kind
+	Slot               Slot
+	Priority           int
+	RetentionTier      RetentionTier
+	DropPriority       DropPriority
+	RequiredCapability string
+	CacheClass         CacheClass
+	Trust              TrustLevel
+	Scope              Scope
+	Source             string
+	SourceID           string
+	Collector          string
+	Index              int
+	TokenEstimate      int
+	Budget             BudgetPolicy
+	Render             RenderPolicy
 }
 
 // MessageFrag creates a message-backed fragment.
 func MessageFrag(input MessageFragInput) ContextFrag {
 	msg := cloneMessage(input.Message)
+	renderPolicy := input.Render
+	if renderPolicy.Format == "" {
+		renderPolicy.Format = RenderSDKMessage
+	}
 	return ContextFrag{
-		TokenEstimate: input.TokenEstimate,
-		Budget:        input.Budget,
-		ID:            strings.TrimSpace(input.ID),
-		Kind:          input.Kind,
-		Role:          input.Message.Role,
-		Slot:          input.Slot,
-		Priority:      input.Priority,
-		CacheClass:    input.CacheClass,
-		Trust:         input.Trust,
-		Scope:         normalizeScope(input.Scope),
-		Render:        RenderPolicy{Format: RenderSDKMessage},
+		TokenEstimate:      input.TokenEstimate,
+		Budget:             input.Budget,
+		ID:                 strings.TrimSpace(input.ID),
+		Kind:               input.Kind,
+		Role:               input.Message.Role,
+		Slot:               input.Slot,
+		Priority:           input.Priority,
+		RetentionTier:      input.RetentionTier,
+		DropPriority:       input.DropPriority,
+		RequiredCapability: strings.TrimSpace(input.RequiredCapability),
+		CacheClass:         input.CacheClass,
+		Trust:              input.Trust,
+		Scope:              normalizeScope(input.Scope),
+		Render:             renderPolicy,
 		Provenance: Provenance{
 			Source:    strings.TrimSpace(input.Source),
 			SourceID:  strings.TrimSpace(input.SourceID),

--- a/internal/agent/context/fragment/contract_test.go
+++ b/internal/agent/context/fragment/contract_test.go
@@ -99,6 +99,89 @@ func TestCanonicalFragmentHashIsStableAndIgnoresDebugID(t *testing.T) {
 	}
 }
 
+func TestCanonicalFragmentHashIncludesSectionPolicy(t *testing.T) {
+	t.Parallel()
+
+	base := TextFrag(TextFragInput{
+		ID:                 "system.skills",
+		Kind:               KindSkillsCatalog,
+		Role:               sdk.MessageRoleSystem,
+		Slot:               SlotSystem,
+		Text:               "skills",
+		RetentionTier:      RetentionRequired,
+		DropPriority:       10,
+		RequiredCapability: "use_skill",
+		Render: RenderPolicy{
+			Format:      RenderMarkdown,
+			GroupID:     "system.skills",
+			GroupJoiner: "\n",
+		},
+	})
+
+	baseHash, err := CanonicalFragmentHash(base)
+	if err != nil {
+		t.Fatalf("canonical base hash: %v", err)
+	}
+	mutations := []struct {
+		name   string
+		mutate func(*ContextFrag)
+	}{
+		{name: "retention tier", mutate: func(frag *ContextFrag) { frag.RetentionTier = RetentionPreferred }},
+		{name: "drop priority", mutate: func(frag *ContextFrag) { frag.DropPriority = 20 }},
+		{name: "required capability", mutate: func(frag *ContextFrag) { frag.RequiredCapability = "other_tool" }},
+		{name: "render group", mutate: func(frag *ContextFrag) { frag.Render.GroupID = "other.group" }},
+		{name: "render joiner", mutate: func(frag *ContextFrag) { frag.Render.GroupJoiner = "\n\n" }},
+	}
+	for _, mutation := range mutations {
+		mutation := mutation
+		t.Run(mutation.name, func(t *testing.T) {
+			t.Parallel()
+			changed := base
+			mutation.mutate(&changed)
+			changedHash, err := CanonicalFragmentHash(changed)
+			if err != nil {
+				t.Fatalf("canonical changed hash: %v", err)
+			}
+			if changedHash.Value == baseHash.Value {
+				t.Fatalf("canonical hash must change with %s", mutation.name)
+			}
+		})
+	}
+}
+
+func TestDropPriorityHigherValuesDropFirst(t *testing.T) {
+	t.Parallel()
+
+	if !DropPriority(20).DropsBefore(10) {
+		t.Fatal("higher drop priority must drop before a lower value")
+	}
+	if DropPriority(10).DropsBefore(20) {
+		t.Fatal("lower drop priority must survive longer than a higher value")
+	}
+}
+
+func TestMessageFragAndRepairPreserveSectionPolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := RenderPolicy{Format: RenderSDKMessage, GroupID: "messages", GroupJoiner: "\n"}
+	frag := MessageFrag(MessageFragInput{
+		ID:                 "message.001",
+		Message:            sdk.UserMessage("before"),
+		Kind:               KindConversationEvent,
+		Slot:               SlotHistory,
+		RetentionTier:      RetentionPreferred,
+		DropPriority:       25,
+		RequiredCapability: "read",
+		Render:             policy,
+	})
+	rebuilt := RebuildFragMessage(frag, sdk.AssistantMessage("after"))
+
+	if rebuilt.RetentionTier != frag.RetentionTier || rebuilt.DropPriority != frag.DropPriority ||
+		rebuilt.RequiredCapability != frag.RequiredCapability || rebuilt.Render != policy {
+		t.Fatalf("rebuilt policy = %#v, want %#v", rebuilt, frag)
+	}
+}
+
 func TestCanonicalFragmentHashGoldenValue(t *testing.T) {
 	t.Parallel()
 
@@ -122,6 +205,32 @@ func TestCanonicalFragmentHashGoldenValue(t *testing.T) {
 	const want = "a33139d731966124ebcadf9eb4f2ce815b63650e866794086fc587c504193764"
 	if hash.Value != want {
 		t.Fatalf("golden hash drifted: got %q, want %q — if the canonical struct shape changed intentionally, update this value", hash.Value, want)
+	}
+}
+
+func TestBuildManifestItemCarriesSectionPolicy(t *testing.T) {
+	t.Parallel()
+
+	render := RenderPolicy{Format: RenderMarkdown, GroupID: "system.skills", GroupJoiner: "\n"}
+	frag := TextFrag(TextFragInput{
+		ID:                 "system.skill.alpha",
+		Kind:               KindSkillsCatalog,
+		Slot:               SlotSystem,
+		Text:               "alpha",
+		RetentionTier:      RetentionOptional,
+		DropPriority:       30,
+		RequiredCapability: "use_skill",
+		Render:             render,
+	})
+	manifest := BuildManifest([]ContextFrag{frag})
+
+	if len(manifest.Items) != 1 {
+		t.Fatalf("manifest items = %d, want 1", len(manifest.Items))
+	}
+	item := manifest.Items[0]
+	if item.RetentionTier != RetentionOptional || item.DropPriority != 30 ||
+		item.RequiredCapability != "use_skill" || item.Render != render {
+		t.Fatalf("manifest section policy = %#v", item)
 	}
 }
 

--- a/internal/agent/context/fragment/hash.go
+++ b/internal/agent/context/fragment/hash.go
@@ -12,15 +12,18 @@ func CanonicalFragmentHash(frag ContextFrag) (FragmentHash, error) {
 		return FragmentHash{}, err
 	}
 	canonical := canonicalFragment{
-		Kind:       frag.Kind,
-		Role:       string(frag.Role),
-		Slot:       frag.Slot,
-		Priority:   frag.Priority,
-		CacheClass: frag.CacheClass,
-		Trust:      frag.Trust,
-		Scope:      frag.Scope,
-		Budget:     frag.Budget,
-		Render:     frag.Render,
+		Kind:               frag.Kind,
+		Role:               string(frag.Role),
+		Slot:               frag.Slot,
+		Priority:           frag.Priority,
+		RetentionTier:      frag.RetentionTier,
+		DropPriority:       frag.DropPriority,
+		RequiredCapability: frag.RequiredCapability,
+		CacheClass:         frag.CacheClass,
+		Trust:              frag.Trust,
+		Scope:              frag.Scope,
+		Budget:             frag.Budget,
+		Render:             frag.Render,
 		Provenance: canonicalProvenance{
 			Source:    frag.Provenance.Source,
 			SourceID:  frag.Provenance.SourceID,
@@ -41,17 +44,20 @@ func CanonicalFragmentHash(frag ContextFrag) (FragmentHash, error) {
 }
 
 type canonicalFragment struct {
-	Kind       Kind                `json:"kind"`
-	Role       string              `json:"role,omitempty"`
-	Slot       Slot                `json:"slot"`
-	Priority   int                 `json:"priority,omitempty"`
-	CacheClass CacheClass          `json:"cache_class,omitempty"`
-	Trust      TrustLevel          `json:"trust,omitempty"`
-	Scope      Scope               `json:"scope,omitempty"`
-	Budget     BudgetPolicy        `json:"budget,omitempty"`
-	Render     RenderPolicy        `json:"render,omitempty"`
-	Provenance canonicalProvenance `json:"provenance,omitempty"`
-	Parts      []canonicalPart     `json:"parts,omitempty"`
+	Kind               Kind                `json:"kind"`
+	Role               string              `json:"role,omitempty"`
+	Slot               Slot                `json:"slot"`
+	Priority           int                 `json:"priority,omitempty"`
+	RetentionTier      RetentionTier       `json:"retention_tier,omitempty"`
+	DropPriority       DropPriority        `json:"drop_priority,omitempty"`
+	RequiredCapability string              `json:"required_capability,omitempty"`
+	CacheClass         CacheClass          `json:"cache_class,omitempty"`
+	Trust              TrustLevel          `json:"trust,omitempty"`
+	Scope              Scope               `json:"scope,omitempty"`
+	Budget             BudgetPolicy        `json:"budget,omitempty"`
+	Render             RenderPolicy        `json:"render,omitempty"`
+	Provenance         canonicalProvenance `json:"provenance,omitempty"`
+	Parts              []canonicalPart     `json:"parts,omitempty"`
 }
 
 type canonicalProvenance struct {

--- a/internal/agent/context/fragment/mutation.go
+++ b/internal/agent/context/fragment/mutation.go
@@ -18,6 +18,7 @@ const (
 	MutationMidTaskPrune        MutationKind = "mid_task_prune"
 	MutationInjectedMessage     MutationKind = "injected_message"
 	MutationContextViewFallback MutationKind = "context_view_fallback"
+	MutationCapabilityGate      MutationKind = "capability_gate"
 	MutationReadMedia           MutationKind = "read_media"
 )
 

--- a/internal/agent/context/fragment/render.go
+++ b/internal/agent/context/fragment/render.go
@@ -22,19 +22,23 @@ func BuildManifest(frags []ContextFrag) Manifest {
 		}
 		manifest.ValidationWarnings = append(manifest.ValidationWarnings, ContextRefWarnings(ref)...)
 		item := ManifestItem{
-			ID:          frag.ID,
-			Ref:         ref,
-			Kind:        frag.Kind,
-			Slot:        frag.Slot,
-			Role:        frag.Role,
-			Priority:    frag.Priority,
-			CacheClass:  frag.CacheClass,
-			Trust:       frag.Trust,
-			Source:      frag.Provenance.Source,
-			SourceID:    frag.Provenance.SourceID,
-			Collector:   frag.Provenance.Collector,
-			ConflictKey: frag.ConflictKey,
-			Scope:       frag.Scope,
+			ID:                 frag.ID,
+			Ref:                ref,
+			Kind:               frag.Kind,
+			Slot:               frag.Slot,
+			Role:               frag.Role,
+			Priority:           frag.Priority,
+			RetentionTier:      frag.RetentionTier,
+			DropPriority:       frag.DropPriority,
+			RequiredCapability: frag.RequiredCapability,
+			CacheClass:         frag.CacheClass,
+			Trust:              frag.Trust,
+			Source:             frag.Provenance.Source,
+			SourceID:           frag.Provenance.SourceID,
+			Collector:          frag.Provenance.Collector,
+			ConflictKey:        frag.ConflictKey,
+			Render:             frag.Render,
+			Scope:              frag.Scope,
 		}
 		for _, part := range frag.Parts {
 			item.PartTypes = append(item.PartTypes, part.Type)
@@ -130,17 +134,21 @@ func breakdownFromItems(items []ManifestItem) []KindBreakdown {
 // Render builds the legacy SDK-shaped view from fragments.
 func Render(frags []ContextFrag) AssembledContext {
 	var out AssembledContext
+	var previousSystemRender RenderPolicy
+	hasRenderedSystem := false
 	for _, frag := range frags {
 		switch frag.Slot {
 		case SlotSystem:
 			for _, part := range frag.Parts {
-				if part.Type != PartText || strings.TrimSpace(part.Text) == "" {
+				if part.Type != PartText || RenderText(part.Text, frag.Render) == "" {
 					continue
 				}
-				if out.System != "" {
-					out.System += "\n\n"
+				if hasRenderedSystem {
+					out.System += RenderSeparator(previousSystemRender, frag.Render)
 				}
-				out.System += strings.TrimSpace(part.Text)
+				out.System += RenderText(part.Text, frag.Render)
+				previousSystemRender = frag.Render
+				hasRenderedSystem = true
 			}
 		case SlotCurrentUser:
 			for _, part := range frag.Parts {

--- a/internal/agent/context/fragment/types.go
+++ b/internal/agent/context/fragment/types.go
@@ -328,6 +328,7 @@ type Manifest struct {
 	TrustBreakdown     []TrustBreakdown    `json:"trust_breakdown,omitempty"`
 	ToolDefs           []ToolDefAccounting `json:"tool_defs,omitempty"`
 	Items              []ManifestItem      `json:"items,omitempty"`
+	SelectionDecisions []SelectionDecision `json:"selection_decisions,omitempty"`
 	Selection          *SelectionTrace     `json:"selection,omitempty"`
 	CachePlan          *CachePlan          `json:"cache_plan,omitempty"`
 	Mutations          *MutationLedger     `json:"mutations,omitempty"`
@@ -396,6 +397,31 @@ type SelectionTrace struct {
 	Selected    int            `json:"selected"`
 	Dropped     int            `json:"dropped"`
 	DropReasons map[string]int `json:"drop_reasons,omitempty"`
+}
+
+type SelectionDecisionKind string
+
+const (
+	DecisionSelected SelectionDecisionKind = "selected"
+	DecisionTrimmed  SelectionDecisionKind = "trimmed"
+	DecisionDropped  SelectionDecisionKind = "dropped"
+)
+
+// SelectionDecision is the content-light per-fragment audit trail for
+// selection. It identifies sources and costs without retaining prompt text.
+type SelectionDecision struct {
+	ID            string                `json:"id"`
+	Ref           ContextRef            `json:"ref,omitempty"`
+	Slot          Slot                  `json:"slot"`
+	Source        string                `json:"source,omitempty"`
+	SourceID      string                `json:"source_id,omitempty"`
+	Decision      SelectionDecisionKind `json:"decision"`
+	Reason        string                `json:"reason,omitempty"`
+	TokenEstimate int                   `json:"token_estimate,omitempty"`
+	TextBytes     int                   `json:"text_bytes,omitempty"`
+	ImageCount    int                   `json:"image_count,omitempty"`
+	CacheClass    CacheClass            `json:"cache_class,omitempty"`
+	RetentionTier RetentionTier         `json:"retention_tier,omitempty"`
 }
 
 // ManifestItem is one non-sensitive fragment entry.

--- a/internal/agent/context/fragment/types.go
+++ b/internal/agent/context/fragment/types.go
@@ -2,7 +2,11 @@
 // describe context before it is rendered into provider-specific SDK inputs.
 package contextfrag
 
-import sdk "github.com/memohai/twilight-ai/sdk"
+import (
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
 
 // Kind identifies the semantic source and intent of a context fragment.
 type Kind string
@@ -133,6 +137,25 @@ const (
 	OverflowDrop      OverflowAction = "drop"
 )
 
+// RetentionTier groups fragments by how strongly a policy pass must retain
+// them. The zero value leaves the policy unspecified.
+type RetentionTier string
+
+const (
+	RetentionUnspecified RetentionTier = ""
+	RetentionRequired    RetentionTier = "required"
+	RetentionPreferred   RetentionTier = "preferred"
+	RetentionOptional    RetentionTier = "optional"
+)
+
+// DropPriority orders fragments within one retention tier. Higher values drop
+// before lower values, so lower values survive longer under policy pressure.
+type DropPriority int
+
+func (p DropPriority) DropsBefore(other DropPriority) bool {
+	return p > other
+}
+
 // BudgetPolicy captures the budget behavior for a fragment: the selector
 // enforces MaxTokens/MaxChars via Trim or Drop, Summarize is not implemented
 // (deferred to compaction), and Keep marks the fragment as must-keep.
@@ -155,8 +178,30 @@ const (
 // RenderPolicy stores rendering hints. Anchor is used for sections such as
 // tool usage that must land before a known heading.
 type RenderPolicy struct {
-	Format RenderFormat `json:"format,omitempty"`
-	Anchor string       `json:"anchor,omitempty"`
+	Format      RenderFormat `json:"format,omitempty"`
+	Anchor      string       `json:"anchor,omitempty"`
+	GroupID     string       `json:"group_id,omitempty"`
+	GroupJoiner string       `json:"group_joiner,omitempty"`
+}
+
+func RenderText(text string, policy RenderPolicy) string {
+	if policy.GroupID != "" {
+		return strings.Trim(text, " \t\r")
+	}
+	return strings.TrimSpace(text)
+}
+
+func RenderSeparator(previous, current RenderPolicy) string {
+	if previous.GroupID == "" || previous.GroupID != current.GroupID {
+		return "\n\n"
+	}
+	if current.GroupJoiner != "" {
+		return current.GroupJoiner
+	}
+	if previous.GroupJoiner != "" {
+		return previous.GroupJoiner
+	}
+	return "\n\n"
 }
 
 // Provenance identifies where a fragment came from.
@@ -233,19 +278,22 @@ type Part struct {
 
 // ContextFrag is the typed context fragment abstraction.
 type ContextFrag struct {
-	ID            string          `json:"id"`
-	Ref           ContextRef      `json:"ref,omitempty"`
-	Kind          Kind            `json:"kind"`
-	Role          sdk.MessageRole `json:"role,omitempty"`
-	Slot          Slot            `json:"slot"`
-	Priority      int             `json:"priority,omitempty"`
-	CacheClass    CacheClass      `json:"cache_class,omitempty"`
-	Trust         TrustLevel      `json:"trust,omitempty"`
-	Scope         Scope           `json:"scope,omitempty"`
-	Budget        BudgetPolicy    `json:"budget,omitempty"`
-	Render        RenderPolicy    `json:"render,omitempty"`
-	Provenance    Provenance      `json:"provenance,omitempty"`
-	TokenEstimate int             `json:"token_estimate,omitempty"`
+	ID                 string          `json:"id"`
+	Ref                ContextRef      `json:"ref,omitempty"`
+	Kind               Kind            `json:"kind"`
+	Role               sdk.MessageRole `json:"role,omitempty"`
+	Slot               Slot            `json:"slot"`
+	Priority           int             `json:"priority,omitempty"`
+	RetentionTier      RetentionTier   `json:"retention_tier,omitempty"`
+	DropPriority       DropPriority    `json:"drop_priority,omitempty"`
+	RequiredCapability string          `json:"required_capability,omitempty"`
+	CacheClass         CacheClass      `json:"cache_class,omitempty"`
+	Trust              TrustLevel      `json:"trust,omitempty"`
+	Scope              Scope           `json:"scope,omitempty"`
+	Budget             BudgetPolicy    `json:"budget,omitempty"`
+	Render             RenderPolicy    `json:"render,omitempty"`
+	Provenance         Provenance      `json:"provenance,omitempty"`
+	TokenEstimate      int             `json:"token_estimate,omitempty"`
 	// ConflictKey groups fragments that are alternatives of one another: the
 	// selector keeps only the highest-precedence member (closest scope, then
 	// trust, then latest collected) and drops the rest.
@@ -352,23 +400,27 @@ type SelectionTrace struct {
 
 // ManifestItem is one non-sensitive fragment entry.
 type ManifestItem struct {
-	ID            string          `json:"id"`
-	Ref           ContextRef      `json:"ref,omitempty"`
-	Kind          Kind            `json:"kind"`
-	Slot          Slot            `json:"slot"`
-	Role          sdk.MessageRole `json:"role,omitempty"`
-	Priority      int             `json:"priority,omitempty"`
-	CacheClass    CacheClass      `json:"cache_class,omitempty"`
-	Trust         TrustLevel      `json:"trust,omitempty"`
-	Source        string          `json:"source,omitempty"`
-	SourceID      string          `json:"source_id,omitempty"`
-	Collector     string          `json:"collector,omitempty"`
-	ConflictKey   string          `json:"conflict_key,omitempty"`
-	PartTypes     []PartType      `json:"part_types,omitempty"`
-	TextBytes     int             `json:"text_bytes,omitempty"`
-	ImageCount    int             `json:"image_count,omitempty"`
-	TokenEstimate int             `json:"token_estimate,omitempty"`
-	Scope         Scope           `json:"scope,omitempty"`
+	ID                 string          `json:"id"`
+	Ref                ContextRef      `json:"ref,omitempty"`
+	Kind               Kind            `json:"kind"`
+	Slot               Slot            `json:"slot"`
+	Role               sdk.MessageRole `json:"role,omitempty"`
+	Priority           int             `json:"priority,omitempty"`
+	RetentionTier      RetentionTier   `json:"retention_tier,omitempty"`
+	DropPriority       DropPriority    `json:"drop_priority,omitempty"`
+	RequiredCapability string          `json:"required_capability,omitempty"`
+	CacheClass         CacheClass      `json:"cache_class,omitempty"`
+	Trust              TrustLevel      `json:"trust,omitempty"`
+	Source             string          `json:"source,omitempty"`
+	SourceID           string          `json:"source_id,omitempty"`
+	Collector          string          `json:"collector,omitempty"`
+	ConflictKey        string          `json:"conflict_key,omitempty"`
+	Render             RenderPolicy    `json:"render,omitempty"`
+	PartTypes          []PartType      `json:"part_types,omitempty"`
+	TextBytes          int             `json:"text_bytes,omitempty"`
+	ImageCount         int             `json:"image_count,omitempty"`
+	TokenEstimate      int             `json:"token_estimate,omitempty"`
+	Scope              Scope           `json:"scope,omitempty"`
 }
 
 type SlotRenderPolicy struct {

--- a/internal/agent/context/fragment/types_json_test.go
+++ b/internal/agent/context/fragment/types_json_test.go
@@ -6,7 +6,18 @@ import (
 )
 
 func TestContextFragJSONFieldNames(t *testing.T) {
-	frag := ContextFrag{ID: "f1", TokenEstimate: 42, ConflictKey: "group.a"}
+	frag := ContextFrag{
+		ID:                 "f1",
+		TokenEstimate:      42,
+		ConflictKey:        "group.a",
+		RetentionTier:      RetentionPreferred,
+		DropPriority:       12,
+		RequiredCapability: "read",
+		Render: RenderPolicy{
+			GroupID:     "system.tools",
+			GroupJoiner: "\n\n",
+		},
+	}
 	data, err := json.Marshal(frag)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -20,6 +31,19 @@ func TestContextFragJSONFieldNames(t *testing.T) {
 	}
 	if got, ok := decoded["conflict_key"].(string); !ok || got != "group.a" {
 		t.Fatalf("conflict_key = %v, want %q", decoded["conflict_key"], "group.a")
+	}
+	if got, ok := decoded["retention_tier"].(string); !ok || got != string(RetentionPreferred) {
+		t.Fatalf("retention_tier = %v, want %q", decoded["retention_tier"], RetentionPreferred)
+	}
+	if got, ok := decoded["drop_priority"].(float64); !ok || got != 12 {
+		t.Fatalf("drop_priority = %v, want 12", decoded["drop_priority"])
+	}
+	if got, ok := decoded["required_capability"].(string); !ok || got != "read" {
+		t.Fatalf("required_capability = %v, want read", decoded["required_capability"])
+	}
+	render, ok := decoded["render"].(map[string]any)
+	if !ok || render["group_id"] != "system.tools" || render["group_joiner"] != "\n\n" {
+		t.Fatalf("render = %#v, want grouped render policy", decoded["render"])
 	}
 	if _, ok := decoded["TokenEstimate"]; ok {
 		t.Fatal("TokenEstimate leaked under Go field name")

--- a/internal/agent/context/fragment/view.go
+++ b/internal/agent/context/fragment/view.go
@@ -4,7 +4,10 @@ package contextfrag
 // rendered into. One intent may fan out to several render targets.
 type Intent string
 
-const IntentRunConfigPreProvider Intent = "run_config_pre_provider"
+const (
+	IntentRunConfigPreProvider Intent = "run_config_pre_provider"
+	IntentDiscussReply         Intent = "discuss_reply"
+)
 
 func (i Intent) ManifestView() ManifestView {
 	return ManifestView(i)

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -171,6 +171,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 	}
 
 	var sdkTools []sdk.Tool
+	cfg.ContextToolDefsResolved = true
 	if cfg.SupportsToolCall {
 		var toolUsage string
 		var toolUsageFrags []contextfrag.ContextFrag
@@ -758,6 +759,7 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 	}
 
 	var sdkTools []sdk.Tool
+	cfg.ContextToolDefsResolved = true
 	if cfg.SupportsToolCall {
 		var toolUsage string
 		var toolUsageFrags []contextfrag.ContextFrag

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -94,7 +94,7 @@ func (a *Agent) Generate(ctx context.Context, cfg RunConfig) (*GenerateResult, e
 }
 
 func (a *Agent) ExecuteTool(ctx context.Context, cfg RunConfig, call sdk.ToolCall) (sdk.ToolResultPart, error) {
-	sdkTools, _, _, err := a.assembleTools(ctx, cfg, nil, false)
+	sdkTools, _, _, _, err := a.assembleTools(ctx, cfg, nil, false)
 	if err != nil {
 		return sdk.ToolResultPart{}, fmt.Errorf("assemble tools: %w", err)
 	}
@@ -173,9 +173,10 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 	var sdkTools []sdk.Tool
 	if cfg.SupportsToolCall {
 		var toolUsage string
+		var toolUsageFrags []contextfrag.ContextFrag
 		var toolDefs []contextfrag.ToolDefAccounting
 		var err error
-		sdkTools, toolUsage, toolDefs, err = a.assembleTools(streamCtx, cfg, streamEmitter, cfg.LiveToolStream)
+		sdkTools, toolUsage, toolUsageFrags, toolDefs, err = a.assembleTools(streamCtx, cfg, streamEmitter, cfg.LiveToolStream)
 		if err != nil {
 			turnError = fmt.Sprintf("assemble tools: %v", err)
 			sendEvent(ctx, ch, StreamEvent{Type: EventError, Error: turnError})
@@ -187,6 +188,7 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 			// background task summaries see the usage-augmented text.
 			cfg.System = appendToolUsageToSystem(cfg.System, toolUsage)
 			cfg.ContextToolUsage = toolUsage
+			cfg.ContextToolUsageFrags = toolUsageFrags
 		}
 	}
 	limit := a.Limits().ToolOutputLimit()
@@ -758,9 +760,10 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 	var sdkTools []sdk.Tool
 	if cfg.SupportsToolCall {
 		var toolUsage string
+		var toolUsageFrags []contextfrag.ContextFrag
 		var toolDefs []contextfrag.ToolDefAccounting
 		var err error
-		sdkTools, toolUsage, toolDefs, err = a.assembleTools(genCtx, cfg, collectEmitter, false)
+		sdkTools, toolUsage, toolUsageFrags, toolDefs, err = a.assembleTools(genCtx, cfg, collectEmitter, false)
 		if err != nil {
 			return nil, fmt.Errorf("assemble tools: %w", err)
 		}
@@ -770,6 +773,7 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 			// background task summaries see the usage-augmented text.
 			cfg.System = appendToolUsageToSystem(cfg.System, toolUsage)
 			cfg.ContextToolUsage = toolUsage
+			cfg.ContextToolUsageFrags = toolUsageFrags
 		}
 	}
 	limit := a.Limits().ToolOutputLimit()
@@ -953,9 +957,14 @@ func (a *Agent) buildGenerateOptions(cfg RunConfig, tools []sdk.Tool, approvalTo
 // (see tools.ToolUsage). emitter is injected into the session context so that
 // tools targeting the current conversation can push side-effect events
 // (attachments, reactions, speech) directly into the agent stream.
-func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.StreamEmitter, liveStream bool) ([]sdk.Tool, string, []contextfrag.ToolDefAccounting, error) {
+func (a *Agent) assembleTools(
+	ctx context.Context,
+	cfg RunConfig,
+	emitter tools.StreamEmitter,
+	liveStream bool,
+) ([]sdk.Tool, string, []contextfrag.ContextFrag, []contextfrag.ToolDefAccounting, error) {
 	if len(a.toolProviders) == 0 {
-		return nil, "", nil, nil
+		return nil, "", nil, nil, nil
 	}
 	skillsMap := make(map[string]tools.SkillDetail, len(cfg.Skills))
 	for _, s := range cfg.Skills {
@@ -997,10 +1006,10 @@ func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.
 	var allTools []sdk.Tool
 	var toolDefs []contextfrag.ToolDefAccounting
 	type usageRegistration struct {
-		provider tools.ToolUsage
+		provider   tools.ToolUsage
+		capability string
 	}
 	var usageRegistrations []usageRegistration
-	var usageSections []string
 	seenToolNames := make(map[string]struct{})
 	for _, provider := range a.toolProviders {
 		providerTools, err := provider.Tools(ctx, session)
@@ -1043,23 +1052,34 @@ func (a *Agent) assembleTools(ctx context.Context, cfg RunConfig, emitter tools.
 		// contributed tools this session, so guidance and registration share
 		// one gating decision and cannot drift apart.
 		if usageProvider, ok := provider.(tools.ToolUsage); ok {
-			usageRegistrations = append(usageRegistrations, usageRegistration{provider: usageProvider})
+			usageRegistrations = append(usageRegistrations, usageRegistration{
+				provider:   usageProvider,
+				capability: firstToolName(providerTools),
+			})
 		}
 	}
 	if cfg.ToolApprovalHandler != nil || a.hookService != nil {
 		allTools = markApprovalTools(allTools)
 	}
 	availableTools := tools.NewAvailableTools(allTools)
+	var usageSections []toolUsageSection
 	for _, registration := range usageRegistrations {
 		if text := strings.TrimSpace(registration.provider.Usage(ctx, session, availableTools)); text != "" {
-			usageSections = append(usageSections, text)
+			usageSections = append(usageSections, toolUsageSection{
+				capability: registration.capability,
+				text:       text,
+			})
 		}
 	}
 	usage := ""
 	if len(usageSections) > 0 {
-		usage = "## Tool usage\n\n" + strings.Join(usageSections, "\n\n")
+		texts := make([]string, 0, len(usageSections))
+		for _, section := range usageSections {
+			texts = append(texts, section.text)
+		}
+		usage = "## Tool usage\n\n" + strings.Join(texts, "\n\n")
 	}
-	return allTools, usage, toolDefs, nil
+	return allTools, usage, structuredToolUsage(usageSections, cfg.ContextScope), toolDefs, nil
 }
 
 func appendToolUsageToSystem(system, toolUsage string) string {

--- a/internal/agent/runtime/native/context_view_applier_test.go
+++ b/internal/agent/runtime/native/context_view_applier_test.go
@@ -30,6 +30,9 @@ func TestGenerateAppliesContextViewBeforeProviderOptions(t *testing.T) {
 			cfg.ContextToolUsageFrags[1].ID != "system.tool_usage.fake_tool" {
 			t.Fatalf("applier structured tool usage = %#v, want header and provider item", cfg.ContextToolUsageFrags)
 		}
+		if !cfg.ContextToolDefsResolved {
+			t.Fatal("applier must see an authoritative tool capability roster")
+		}
 		cfg.System = "compiled system"
 		cfg.Messages = []sdk.Message{sdk.UserMessage("compiled message")}
 		cfg.ContextMutations = ledger

--- a/internal/agent/runtime/native/context_view_applier_test.go
+++ b/internal/agent/runtime/native/context_view_applier_test.go
@@ -25,6 +25,11 @@ func TestGenerateAppliesContextViewBeforeProviderOptions(t *testing.T) {
 		if len(cfg.ContextToolDefs) != 1 || cfg.ContextToolDefs[0].Name != "fake_tool" {
 			t.Fatalf("applier tool definitions = %#v", cfg.ContextToolDefs)
 		}
+		if len(cfg.ContextToolUsageFrags) != 2 ||
+			cfg.ContextToolUsageFrags[0].ID != "system.tool_usage.header" ||
+			cfg.ContextToolUsageFrags[1].ID != "system.tool_usage.fake_tool" {
+			t.Fatalf("applier structured tool usage = %#v, want header and provider item", cfg.ContextToolUsageFrags)
+		}
 		cfg.System = "compiled system"
 		cfg.Messages = []sdk.Message{sdk.UserMessage("compiled message")}
 		cfg.ContextMutations = ledger

--- a/internal/agent/runtime/native/prompt.go
+++ b/internal/agent/runtime/native/prompt.go
@@ -117,6 +117,12 @@ type SystemPromptParams struct {
 	MaxFilesBytes             int
 	Timezone                  string
 	PlatformIdentitiesSection string
+	PlatformIdentities        []SystemPromptItem
+}
+
+type SystemPromptItem struct {
+	ID   string
+	Text string
 }
 
 func buildBotInfoSection(bot BotInfo) string {
@@ -168,31 +174,60 @@ func GenerateHeartbeatPrompt(interval int, checklist string, now time.Time, last
 }
 
 func buildSkillsSection(skills []SkillEntry) string {
-	if len(skills) == 0 {
+	items := buildSkillPromptItems(skills)
+	if len(items) == 0 {
 		return ""
 	}
+	var sb strings.Builder
+	sb.WriteString(buildSkillsHeader(len(items)))
+	for _, item := range items {
+		sb.WriteByte('\n')
+		sb.WriteString(item.Text)
+	}
+	return sb.String()
+}
+
+func buildSkillPromptItems(skills []SkillEntry) []SystemPromptItem {
 	sorted := make([]SkillEntry, len(skills))
 	copy(sorted, skills)
 	slices.SortFunc(sorted, func(a, b SkillEntry) int {
 		return strings.Compare(a.Name, b.Name)
 	})
+	items := make([]SystemPromptItem, 0, len(sorted))
+	for _, skill := range sorted {
+		items = append(items, SystemPromptItem{
+			ID:   skill.Name,
+			Text: "- **" + skill.Name + "**: " + skill.Description,
+		})
+	}
+	return items
+}
+
+func buildSkillsHeader(count int) string {
 	var sb strings.Builder
 	sb.WriteString("## Skills\n\n")
 	sb.WriteString("Memoh-managed skills are stored in `" + skillset.ManagedDir() + "/`. ")
 	sb.WriteString("Compatible external skill directories inside the bot workspace may also be discovered automatically. ")
 	sb.WriteString("Each skill is a `SKILL.md` file inside a named subdirectory. ")
 	sb.WriteString("Only activate a skill when it is relevant to the current task and a skill-loading capability is available.\n\n")
-	sb.WriteString(strconv.Itoa(len(sorted)))
-	sb.WriteString(" skill(s) available:\n")
-	for _, s := range sorted {
-		sb.WriteString("- **" + s.Name + "**: " + s.Description + "\n")
-	}
+	sb.WriteString(strconv.Itoa(count))
+	sb.WriteString(" skill(s) available:")
 	return sb.String()
 }
 
 func buildFileSections(files []SystemFile, maxBytes int) string {
+	items := buildFilePromptItems(files, maxBytes)
+	texts := make([]string, 0, len(items))
+	for _, item := range items {
+		texts = append(texts, item.Text)
+	}
+	return strings.Join(texts, "\n\n")
+}
+
+func buildFilePromptItems(files []SystemFile, maxBytes int) []SystemPromptItem {
 	maxBytes = normalizeSystemFilesMaxBytes(maxBytes)
-	var sb strings.Builder
+	var items []SystemPromptItem
+	totalBytes := 0
 	lineCount := 0
 	for _, f := range files {
 		if f.Content == "" {
@@ -200,11 +235,11 @@ func buildFileSections(files []SystemFile, maxBytes int) string {
 		}
 		separator := ""
 		separatorLines := 0
-		if sb.Len() > 0 {
+		if len(items) > 0 {
 			separator = "\n\n"
 			separatorLines = 2
 		}
-		remaining := maxBytes - sb.Len() - len(separator)
+		remaining := maxBytes - totalBytes - len(separator)
 		remainingLines := textprune.DefaultMaxLines - lineCount - separatorLines
 		if remaining <= 0 || remainingLines <= 0 {
 			break
@@ -217,16 +252,14 @@ func buildFileSections(files []SystemFile, maxBytes int) string {
 			}
 			section = truncated
 		}
-		if separator != "" {
-			sb.WriteString(separator)
-		}
-		sb.WriteString(section)
+		items = append(items, SystemPromptItem{ID: f.Filename, Text: section})
+		totalBytes += len(separator) + len(section)
 		lineCount += separatorLines + textprune.CountLines(section)
 		if len(section) == remaining {
 			break
 		}
 	}
-	return sb.String()
+	return items
 }
 
 func normalizeSystemFilesMaxBytes(maxBytes int) int {

--- a/internal/agent/runtime/native/prompt_sections.go
+++ b/internal/agent/runtime/native/prompt_sections.go
@@ -28,14 +28,15 @@ type SystemSection struct {
 }
 
 const (
-	sectionIDIntro                 = "system.prompt.intro"
-	sectionIDBotIdentity           = "system.bot_identity"
-	sectionIDBody                  = "system.prompt.body"
-	sectionIDTail                  = "system.prompt.tail"
-	sectionIDPlatformIdentity      = "system.platform_identity"
-	sectionIDSkills                = "system.skills"
-	sectionIDWorkspaceInstructions = "system.workspace_instructions"
-	sectionIDFallback              = "system.prompt.fallback"
+	sectionIDIntro            = "system.prompt.intro"
+	sectionIDBotIdentity      = "system.bot_identity"
+	sectionIDBody             = "system.prompt.body"
+	sectionIDTail             = "system.prompt.tail"
+	sectionIDPlatformIdentity = "system.platform_identity"
+	sectionIDSkills           = "system.skills"
+	sectionIDSkill            = "system.skill"
+	sectionIDWorkspaceFile    = "system.workspace_file"
+	sectionIDFallback         = "system.prompt.fallback"
 )
 
 var skillRequiredCapability = tools.ToolUseSkill().String()
@@ -93,31 +94,81 @@ func GenerateSystemSections(params SystemPromptParams) []SystemSection {
 		{ID: sectionIDTail, Kind: contextfrag.KindSystemPrompt, Priority: priorityTail, RetentionTier: contextfrag.RetentionRequired, Text: tail},
 	}
 
-	if text := strings.TrimSpace(params.PlatformIdentitiesSection); text != "" {
-		sections = append(sections, SystemSection{
-			ID: sectionIDPlatformIdentity, Kind: contextfrag.KindPlatformIdentity, Priority: priorityPlatformIdentity,
-			RetentionTier: contextfrag.RetentionPreferred, Text: text,
-		})
-	}
+	sections = append(sections, buildPlatformIdentitySections(params)...)
 
 	if isSubagent {
 		return sections
 	}
 
-	if text := strings.TrimSpace(buildSkillsSection(params.Skills)); text != "" {
+	if items := buildSkillPromptItems(params.Skills); len(items) > 0 {
 		sections = append(sections, SystemSection{
-			ID: sectionIDSkills, Kind: contextfrag.KindSkillsCatalog, Priority: prioritySkills,
-			RetentionTier: contextfrag.RetentionOptional, RequiredCapability: skillRequiredCapability, Text: text,
+			ID: sectionIDSkills + ".header", Kind: contextfrag.KindSkillsCatalog, Priority: prioritySkills,
+			RetentionTier: contextfrag.RetentionOptional, RequiredCapability: skillRequiredCapability,
+			Text: buildSkillsHeader(len(items)), Render: groupedSystemRender(sectionIDSkills, "\n"),
 		})
+		for _, item := range items {
+			sections = append(sections, SystemSection{
+				ID: sectionIDSkill + "." + item.ID, Kind: contextfrag.KindSkillsCatalog, Priority: prioritySkills,
+				RetentionTier: contextfrag.RetentionOptional, RequiredCapability: skillRequiredCapability,
+				Text: item.Text, Render: groupedSystemRender(sectionIDSkills, "\n"),
+			})
+		}
 	}
-	if text := strings.TrimSpace(buildFileSections(params.Files, params.MaxFilesBytes)); text != "" {
+	for _, item := range buildFilePromptItems(params.Files, params.MaxFilesBytes) {
 		sections = append(sections, SystemSection{
-			ID: sectionIDWorkspaceInstructions, Kind: contextfrag.KindWorkspaceInstruction, Priority: priorityWorkspaceInstructions,
-			RetentionTier: contextfrag.RetentionPreferred, Text: text,
+			ID: sectionIDWorkspaceFile + "." + item.ID, Kind: contextfrag.KindWorkspaceInstruction,
+			Priority: priorityWorkspaceInstructions, RetentionTier: contextfrag.RetentionPreferred, Text: item.Text,
 		})
 	}
 
 	return sections
+}
+
+func buildPlatformIdentitySections(params SystemPromptParams) []SystemSection {
+	text := strings.TrimSpace(params.PlatformIdentitiesSection)
+	if text == "" {
+		return nil
+	}
+	items := make([]SystemPromptItem, 0, len(params.PlatformIdentities))
+	itemTexts := make([]string, 0, len(params.PlatformIdentities))
+	for _, item := range params.PlatformIdentities {
+		item.ID = strings.TrimSpace(item.ID)
+		item.Text = strings.TrimSpace(item.Text)
+		if item.ID == "" || item.Text == "" {
+			continue
+		}
+		items = append(items, item)
+		itemTexts = append(itemTexts, item.Text)
+	}
+	itemBlock := strings.Join(itemTexts, "\n")
+	if len(items) == 0 || !strings.HasSuffix(text, itemBlock) {
+		return []SystemSection{{
+			ID: sectionIDPlatformIdentity, Kind: contextfrag.KindPlatformIdentity, Priority: priorityPlatformIdentity,
+			RetentionTier: contextfrag.RetentionPreferred, Text: text,
+		}}
+	}
+	header := strings.TrimSuffix(strings.TrimSuffix(text, itemBlock), "\n")
+	sections := []SystemSection{{
+		ID: sectionIDPlatformIdentity + ".header", Kind: contextfrag.KindPlatformIdentity, Priority: priorityPlatformIdentity,
+		RetentionTier: contextfrag.RetentionPreferred, Text: header,
+		Render: groupedSystemRender(sectionIDPlatformIdentity, "\n"),
+	}}
+	for _, item := range items {
+		sections = append(sections, SystemSection{
+			ID: sectionIDPlatformIdentity + "." + item.ID, Kind: contextfrag.KindPlatformIdentity,
+			Priority: priorityPlatformIdentity, RetentionTier: contextfrag.RetentionPreferred, Text: item.Text,
+			Render: groupedSystemRender(sectionIDPlatformIdentity, "\n"),
+		})
+	}
+	return sections
+}
+
+func groupedSystemRender(groupID, joiner string) contextfrag.RenderPolicy {
+	return contextfrag.RenderPolicy{
+		Format:      contextfrag.RenderMarkdown,
+		GroupID:     groupID,
+		GroupJoiner: joiner,
+	}
 }
 
 // degradedSystemSections is the panic-free fallback for when the embedded

--- a/internal/agent/runtime/native/prompt_sections.go
+++ b/internal/agent/runtime/native/prompt_sections.go
@@ -11,14 +11,20 @@ import (
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/sessionmode"
+	tools "github.com/memohai/memoh/internal/agent/tool"
 )
 
 // SystemSection is one typed, priority-ordered piece of the system prompt.
 type SystemSection struct {
-	ID       string
-	Kind     contextfrag.Kind
-	Priority int
-	Text     string
+	ID                 string
+	Kind               contextfrag.Kind
+	Priority           int
+	RetentionTier      contextfrag.RetentionTier
+	DropPriority       contextfrag.DropPriority
+	RequiredCapability string
+	Budget             contextfrag.BudgetPolicy
+	Render             contextfrag.RenderPolicy
+	Text               string
 }
 
 const (
@@ -31,6 +37,8 @@ const (
 	sectionIDWorkspaceInstructions = "system.workspace_instructions"
 	sectionIDFallback              = "system.prompt.fallback"
 )
+
+var skillRequiredCapability = tools.ToolUseSkill().String()
 
 const (
 	priorityIntro                 = 10
@@ -74,20 +82,21 @@ func GenerateSystemSections(params SystemPromptParams) []SystemSection {
 
 	sections := []SystemSection{
 		{
-			ID: sectionIDIntro, Kind: contextfrag.KindSystemPrompt, Priority: priorityIntro,
+			ID: sectionIDIntro, Kind: contextfrag.KindSystemPrompt, Priority: priorityIntro, RetentionTier: contextfrag.RetentionRequired,
 			Text: render(intro, map[string]string{"home": home, "timezone": timezone}),
 		},
 		{
-			ID: sectionIDBotIdentity, Kind: contextfrag.KindBotIdentity, Priority: priorityBotIdentity,
+			ID: sectionIDBotIdentity, Kind: contextfrag.KindBotIdentity, Priority: priorityBotIdentity, RetentionTier: contextfrag.RetentionPreferred,
 			Text: buildBotInfoSection(params.Bot),
 		},
-		{ID: sectionIDBody, Kind: contextfrag.KindSystemPrompt, Priority: priorityBody, Text: body},
-		{ID: sectionIDTail, Kind: contextfrag.KindSystemPrompt, Priority: priorityTail, Text: tail},
+		{ID: sectionIDBody, Kind: contextfrag.KindSystemPrompt, Priority: priorityBody, RetentionTier: contextfrag.RetentionRequired, Text: body},
+		{ID: sectionIDTail, Kind: contextfrag.KindSystemPrompt, Priority: priorityTail, RetentionTier: contextfrag.RetentionRequired, Text: tail},
 	}
 
 	if text := strings.TrimSpace(params.PlatformIdentitiesSection); text != "" {
 		sections = append(sections, SystemSection{
-			ID: sectionIDPlatformIdentity, Kind: contextfrag.KindPlatformIdentity, Priority: priorityPlatformIdentity, Text: text,
+			ID: sectionIDPlatformIdentity, Kind: contextfrag.KindPlatformIdentity, Priority: priorityPlatformIdentity,
+			RetentionTier: contextfrag.RetentionPreferred, Text: text,
 		})
 	}
 
@@ -97,12 +106,14 @@ func GenerateSystemSections(params SystemPromptParams) []SystemSection {
 
 	if text := strings.TrimSpace(buildSkillsSection(params.Skills)); text != "" {
 		sections = append(sections, SystemSection{
-			ID: sectionIDSkills, Kind: contextfrag.KindSkillsCatalog, Priority: prioritySkills, Text: text,
+			ID: sectionIDSkills, Kind: contextfrag.KindSkillsCatalog, Priority: prioritySkills,
+			RetentionTier: contextfrag.RetentionOptional, RequiredCapability: skillRequiredCapability, Text: text,
 		})
 	}
 	if text := strings.TrimSpace(buildFileSections(params.Files, params.MaxFilesBytes)); text != "" {
 		sections = append(sections, SystemSection{
-			ID: sectionIDWorkspaceInstructions, Kind: contextfrag.KindWorkspaceInstruction, Priority: priorityWorkspaceInstructions, Text: text,
+			ID: sectionIDWorkspaceInstructions, Kind: contextfrag.KindWorkspaceInstruction, Priority: priorityWorkspaceInstructions,
+			RetentionTier: contextfrag.RetentionPreferred, Text: text,
 		})
 	}
 
@@ -133,10 +144,11 @@ func degradedSystemSections(params SystemPromptParams, home, timezone string, ca
 		text += "\n\n" + strings.TrimSpace(includes["_memory"])
 	}
 	return []SystemSection{{
-		ID:       sectionIDFallback,
-		Kind:     contextfrag.KindSystemPrompt,
-		Priority: priorityBody,
-		Text:     text,
+		ID:            sectionIDFallback,
+		Kind:          contextfrag.KindSystemPrompt,
+		Priority:      priorityBody,
+		RetentionTier: contextfrag.RetentionRequired,
+		Text:          text,
 	}}
 }
 
@@ -147,19 +159,27 @@ func degradedSystemSections(params SystemPromptParams, home, timezone string, ca
 func SystemSectionFrags(sections []SystemSection, scope contextfrag.Scope) []contextfrag.ContextFrag {
 	frags := make([]contextfrag.ContextFrag, 0, len(sections))
 	for _, section := range sections {
+		renderPolicy := section.Render
+		if renderPolicy.Format == "" {
+			renderPolicy.Format = contextfrag.RenderMarkdown
+		}
 		frags = append(frags, contextfrag.TextFrag(contextfrag.TextFragInput{
-			ID:         section.ID,
-			Kind:       section.Kind,
-			Role:       sdk.MessageRoleSystem,
-			Slot:       contextfrag.SlotSystem,
-			Text:       section.Text,
-			Priority:   section.Priority,
-			CacheClass: contextfrag.CacheStable,
-			Trust:      contextfrag.TrustSystem,
-			Scope:      scope,
-			Source:     contextfrag.SourceRunConfig,
-			Collector:  "system_sections",
-			Render:     contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+			ID:                 section.ID,
+			Kind:               section.Kind,
+			Role:               sdk.MessageRoleSystem,
+			Slot:               contextfrag.SlotSystem,
+			Text:               section.Text,
+			Priority:           section.Priority,
+			RetentionTier:      section.RetentionTier,
+			DropPriority:       section.DropPriority,
+			RequiredCapability: section.RequiredCapability,
+			CacheClass:         contextfrag.CacheStable,
+			Trust:              contextfrag.TrustSystem,
+			Scope:              scope,
+			Source:             contextfrag.SourceRunConfig,
+			Collector:          "system_sections",
+			Render:             renderPolicy,
+			Budget:             section.Budget,
 		}))
 	}
 	return frags
@@ -171,15 +191,15 @@ func SystemSectionFrags(sections []SystemSection, scope contextfrag.Scope) []con
 // was appended at all), so the join never special-cases an empty Text.
 func renderSystemSections(sections []SystemSection) string {
 	sorted := slices.Clone(sections)
-	slices.SortFunc(sorted, func(a, b SystemSection) int {
+	slices.SortStableFunc(sorted, func(a, b SystemSection) int {
 		return a.Priority - b.Priority
 	})
 	var sb strings.Builder
 	for i, s := range sorted {
 		if i > 0 {
-			sb.WriteString("\n\n")
+			sb.WriteString(contextfrag.RenderSeparator(sorted[i-1].Render, s.Render))
 		}
-		sb.WriteString(s.Text)
+		sb.WriteString(contextfrag.RenderText(s.Text, s.Render))
 	}
 	return sb.String()
 }

--- a/internal/agent/runtime/native/prompt_sections.go
+++ b/internal/agent/runtime/native/prompt_sections.go
@@ -22,7 +22,6 @@ type SystemSection struct {
 	RetentionTier      contextfrag.RetentionTier
 	DropPriority       contextfrag.DropPriority
 	RequiredCapability string
-	Budget             contextfrag.BudgetPolicy
 	Render             contextfrag.RenderPolicy
 	Text               string
 }
@@ -230,7 +229,6 @@ func SystemSectionFrags(sections []SystemSection, scope contextfrag.Scope) []con
 			Source:             contextfrag.SourceRunConfig,
 			Collector:          "system_sections",
 			Render:             renderPolicy,
-			Budget:             section.Budget,
 		}))
 	}
 	return frags

--- a/internal/agent/runtime/native/prompt_sections_test.go
+++ b/internal/agent/runtime/native/prompt_sections_test.go
@@ -245,7 +245,6 @@ func TestSystemSectionFragsPreserveTypedShape(t *testing.T) {
 		{
 			ID: "a", Kind: contextfrag.KindSystemPrompt, Priority: 10, Text: " first ",
 			RetentionTier: contextfrag.RetentionPreferred, DropPriority: 40, RequiredCapability: "read",
-			Budget: contextfrag.BudgetPolicy{MaxChars: 128, Overflow: contextfrag.OverflowTrim},
 			Render: contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown, GroupID: "group", GroupJoiner: "\n"},
 		},
 		{ID: "b", Kind: contextfrag.KindBotIdentity, Priority: 20},
@@ -259,7 +258,7 @@ func TestSystemSectionFragsPreserveTypedShape(t *testing.T) {
 			frag.Role != sdk.MessageRoleSystem || frag.Slot != contextfrag.SlotSystem || frag.Scope.BotID != "bot-1" ||
 			frag.Parts[0].Text != contextfrag.RenderText(sections[i].Text, sections[i].Render) ||
 			frag.RetentionTier != sections[i].RetentionTier || frag.DropPriority != sections[i].DropPriority ||
-			frag.RequiredCapability != sections[i].RequiredCapability || frag.Budget != sections[i].Budget {
+			frag.RequiredCapability != sections[i].RequiredCapability {
 			t.Fatalf("frag[%d] = %#v", i, frag)
 		}
 		wantRender := sections[i].Render

--- a/internal/agent/runtime/native/prompt_sections_test.go
+++ b/internal/agent/runtime/native/prompt_sections_test.go
@@ -107,7 +107,8 @@ func TestGenerateSystemSectionsShape(t *testing.T) {
 		Bot:                       BotInfo{ID: "bot-1", Name: "research-bot"},
 		Skills:                    []SkillEntry{{Name: "foo", Description: "does foo"}},
 		Files:                     []SystemFile{{Filename: "AGENTS.md", Content: "Be nice."}},
-		PlatformIdentitiesSection: "platform identity",
+		PlatformIdentitiesSection: "platform header\nplatform identity",
+		PlatformIdentities:        []SystemPromptItem{{ID: "telegram-1", Text: "platform identity"}},
 	})
 	want := []struct {
 		id                 string
@@ -120,9 +121,11 @@ func TestGenerateSystemSectionsShape(t *testing.T) {
 		{sectionIDBotIdentity, contextfrag.KindBotIdentity, priorityBotIdentity, contextfrag.RetentionPreferred, ""},
 		{sectionIDBody, contextfrag.KindSystemPrompt, priorityBody, contextfrag.RetentionRequired, ""},
 		{sectionIDTail, contextfrag.KindSystemPrompt, priorityTail, contextfrag.RetentionRequired, ""},
-		{sectionIDPlatformIdentity, contextfrag.KindPlatformIdentity, priorityPlatformIdentity, contextfrag.RetentionPreferred, ""},
-		{sectionIDSkills, contextfrag.KindSkillsCatalog, prioritySkills, contextfrag.RetentionOptional, "use_skill"},
-		{sectionIDWorkspaceInstructions, contextfrag.KindWorkspaceInstruction, priorityWorkspaceInstructions, contextfrag.RetentionPreferred, ""},
+		{sectionIDPlatformIdentity + ".header", contextfrag.KindPlatformIdentity, priorityPlatformIdentity, contextfrag.RetentionPreferred, ""},
+		{sectionIDPlatformIdentity + ".telegram-1", contextfrag.KindPlatformIdentity, priorityPlatformIdentity, contextfrag.RetentionPreferred, ""},
+		{sectionIDSkills + ".header", contextfrag.KindSkillsCatalog, prioritySkills, contextfrag.RetentionOptional, "use_skill"},
+		{sectionIDSkill + ".foo", contextfrag.KindSkillsCatalog, prioritySkills, contextfrag.RetentionOptional, "use_skill"},
+		{sectionIDWorkspaceFile + ".AGENTS.md", contextfrag.KindWorkspaceInstruction, priorityWorkspaceInstructions, contextfrag.RetentionPreferred, ""},
 	}
 	if len(sections) != len(want) {
 		t.Fatalf("sections = %#v", sections)
@@ -132,6 +135,87 @@ func TestGenerateSystemSectionsShape(t *testing.T) {
 			sections[i].RetentionTier != want[i].retention || sections[i].RequiredCapability != want[i].requiredCapability {
 			t.Fatalf("section[%d] = %#v, want %#v", i, sections[i], want[i])
 		}
+	}
+}
+
+func TestGenerateSystemSectionsGranularDynamicItemsRemainByteEquivalent(t *testing.T) {
+	t.Parallel()
+
+	platformItems := []SystemPromptItem{
+		{ID: "telegram-1", Text: `<identity channel="telegram" username="@memoh"/>`},
+		{ID: "微信-2", Text: `<identity channel="weixin" username="小明"/>`},
+	}
+	platformSection := "## Platform Identities\n\nKnown identities.\n\n" +
+		platformItems[0].Text + "\n" + platformItems[1].Text
+	skills := []SkillEntry{
+		{Name: "技能", Description: "第二"},
+		{Name: "alpha", Description: "first"},
+	}
+	files := []SystemFile{
+		{Filename: "ZETA.md", Content: "zeta"},
+		{Filename: "AGENTS.md", Content: "agents"},
+		{Filename: "MEMORY.md", Content: "still included on the accepted PR1 path"},
+	}
+	params := SystemPromptParams{
+		SessionType:               sessionmode.Chat,
+		Timezone:                  "UTC",
+		Skills:                    skills,
+		Files:                     files,
+		PlatformIdentitiesSection: platformSection,
+		PlatformIdentities:        platformItems,
+	}
+
+	sections := GenerateSystemSections(params)
+	wantIDs := []string{
+		"system.prompt.intro",
+		"system.bot_identity",
+		"system.prompt.body",
+		"system.prompt.tail",
+		"system.platform_identity.header",
+		"system.platform_identity.telegram-1",
+		"system.platform_identity.微信-2",
+		"system.skills.header",
+		"system.skill.alpha",
+		"system.skill.技能",
+		"system.workspace_file.ZETA.md",
+		"system.workspace_file.AGENTS.md",
+		"system.workspace_file.MEMORY.md",
+	}
+	gotIDs := make([]string, 0, len(sections))
+	for _, section := range sections {
+		gotIDs = append(gotIDs, section.ID)
+	}
+	if strings.Join(gotIDs, "\n") != strings.Join(wantIDs, "\n") {
+		t.Fatalf("section IDs = %v, want %v", gotIDs, wantIDs)
+	}
+
+	wantSuffix := platformSection + "\n\n" +
+		buildSkillsSection(skills) + "\n\n" +
+		buildFileSections(files, DefaultSystemFilesMaxBytes)
+	if got := GenerateSystemPrompt(params); !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("granular prompt suffix mismatch\ngot:  %q\nwant suffix: %q", got, wantSuffix)
+	}
+}
+
+func TestGenerateSystemSectionsSkillsRequireUseSkillCapability(t *testing.T) {
+	t.Parallel()
+
+	sections := GenerateSystemSections(SystemPromptParams{
+		SessionType: sessionmode.Chat,
+		Skills:      []SkillEntry{{Name: "alpha", Description: "first"}},
+	})
+	found := 0
+	for _, section := range sections {
+		if section.Kind != contextfrag.KindSkillsCatalog {
+			continue
+		}
+		found++
+		if section.RequiredCapability != skillRequiredCapability {
+			t.Fatalf("%s required capability = %q, want %q", section.ID, section.RequiredCapability, skillRequiredCapability)
+		}
+	}
+	if found != 2 {
+		t.Fatalf("skill sections = %d, want header plus item", found)
 	}
 }
 

--- a/internal/agent/runtime/native/prompt_sections_test.go
+++ b/internal/agent/runtime/native/prompt_sections_test.go
@@ -110,23 +110,26 @@ func TestGenerateSystemSectionsShape(t *testing.T) {
 		PlatformIdentitiesSection: "platform identity",
 	})
 	want := []struct {
-		id       string
-		kind     contextfrag.Kind
-		priority int
+		id                 string
+		kind               contextfrag.Kind
+		priority           int
+		retention          contextfrag.RetentionTier
+		requiredCapability string
 	}{
-		{sectionIDIntro, contextfrag.KindSystemPrompt, priorityIntro},
-		{sectionIDBotIdentity, contextfrag.KindBotIdentity, priorityBotIdentity},
-		{sectionIDBody, contextfrag.KindSystemPrompt, priorityBody},
-		{sectionIDTail, contextfrag.KindSystemPrompt, priorityTail},
-		{sectionIDPlatformIdentity, contextfrag.KindPlatformIdentity, priorityPlatformIdentity},
-		{sectionIDSkills, contextfrag.KindSkillsCatalog, prioritySkills},
-		{sectionIDWorkspaceInstructions, contextfrag.KindWorkspaceInstruction, priorityWorkspaceInstructions},
+		{sectionIDIntro, contextfrag.KindSystemPrompt, priorityIntro, contextfrag.RetentionRequired, ""},
+		{sectionIDBotIdentity, contextfrag.KindBotIdentity, priorityBotIdentity, contextfrag.RetentionPreferred, ""},
+		{sectionIDBody, contextfrag.KindSystemPrompt, priorityBody, contextfrag.RetentionRequired, ""},
+		{sectionIDTail, contextfrag.KindSystemPrompt, priorityTail, contextfrag.RetentionRequired, ""},
+		{sectionIDPlatformIdentity, contextfrag.KindPlatformIdentity, priorityPlatformIdentity, contextfrag.RetentionPreferred, ""},
+		{sectionIDSkills, contextfrag.KindSkillsCatalog, prioritySkills, contextfrag.RetentionOptional, "use_skill"},
+		{sectionIDWorkspaceInstructions, contextfrag.KindWorkspaceInstruction, priorityWorkspaceInstructions, contextfrag.RetentionPreferred, ""},
 	}
 	if len(sections) != len(want) {
 		t.Fatalf("sections = %#v", sections)
 	}
 	for i := range want {
-		if sections[i].ID != want[i].id || sections[i].Kind != want[i].kind || sections[i].Priority != want[i].priority {
+		if sections[i].ID != want[i].id || sections[i].Kind != want[i].kind || sections[i].Priority != want[i].priority ||
+			sections[i].RetentionTier != want[i].retention || sections[i].RequiredCapability != want[i].requiredCapability {
 			t.Fatalf("section[%d] = %#v, want %#v", i, sections[i], want[i])
 		}
 	}
@@ -154,7 +157,15 @@ func TestGenerateSystemSectionsKeepsOnlyStructuralEmptySection(t *testing.T) {
 
 func TestSystemSectionFragsPreserveTypedShape(t *testing.T) {
 	t.Parallel()
-	sections := []SystemSection{{ID: "a", Kind: contextfrag.KindSystemPrompt, Priority: 10, Text: " first "}, {ID: "b", Kind: contextfrag.KindBotIdentity, Priority: 20}}
+	sections := []SystemSection{
+		{
+			ID: "a", Kind: contextfrag.KindSystemPrompt, Priority: 10, Text: " first ",
+			RetentionTier: contextfrag.RetentionPreferred, DropPriority: 40, RequiredCapability: "read",
+			Budget: contextfrag.BudgetPolicy{MaxChars: 128, Overflow: contextfrag.OverflowTrim},
+			Render: contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown, GroupID: "group", GroupJoiner: "\n"},
+		},
+		{ID: "b", Kind: contextfrag.KindBotIdentity, Priority: 20},
+	}
 	frags := SystemSectionFrags(sections, contextfrag.Scope{BotID: "bot-1"})
 	if len(frags) != 2 {
 		t.Fatalf("frags = %#v", frags)
@@ -162,8 +173,17 @@ func TestSystemSectionFragsPreserveTypedShape(t *testing.T) {
 	for i, frag := range frags {
 		if frag.ID != sections[i].ID || frag.Kind != sections[i].Kind || frag.Priority != sections[i].Priority ||
 			frag.Role != sdk.MessageRoleSystem || frag.Slot != contextfrag.SlotSystem || frag.Scope.BotID != "bot-1" ||
-			frag.Parts[0].Text != strings.TrimSpace(sections[i].Text) {
+			frag.Parts[0].Text != contextfrag.RenderText(sections[i].Text, sections[i].Render) ||
+			frag.RetentionTier != sections[i].RetentionTier || frag.DropPriority != sections[i].DropPriority ||
+			frag.RequiredCapability != sections[i].RequiredCapability || frag.Budget != sections[i].Budget {
 			t.Fatalf("frag[%d] = %#v", i, frag)
+		}
+		wantRender := sections[i].Render
+		if wantRender.Format == "" {
+			wantRender.Format = contextfrag.RenderMarkdown
+		}
+		if frag.Render != wantRender {
+			t.Fatalf("frag[%d] render policy = %#v, want %#v", i, frag.Render, wantRender)
 		}
 	}
 }
@@ -187,7 +207,9 @@ func TestGenerateSystemSectionsDegradesWhenAnchorsAreMissing(t *testing.T) {
 
 func assertDegradedSection(t *testing.T, sections []SystemSection) {
 	t.Helper()
-	if len(sections) != 1 || sections[0].Kind != contextfrag.KindSystemPrompt || strings.Contains(sections[0].Text, "{{") || !strings.Contains(sections[0].Text, "research-bot") {
+	if len(sections) != 1 || sections[0].Kind != contextfrag.KindSystemPrompt ||
+		sections[0].RetentionTier != contextfrag.RetentionRequired ||
+		strings.Contains(sections[0].Text, "{{") || !strings.Contains(sections[0].Text, "research-bot") {
 		t.Fatalf("sections = %#v", sections)
 	}
 }

--- a/internal/agent/runtime/native/tool_usage_fragments.go
+++ b/internal/agent/runtime/native/tool_usage_fragments.go
@@ -1,0 +1,75 @@
+package native
+
+import (
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+const toolUsageGroupID = "system.tool_usage"
+
+type toolUsageSection struct {
+	capability string
+	text       string
+}
+
+func firstToolName(providerTools []sdk.Tool) string {
+	first := ""
+	for _, tool := range providerTools {
+		name := strings.TrimSpace(tool.Name)
+		if name != "" && (first == "" || name < first) {
+			first = name
+		}
+	}
+	return first
+}
+
+func structuredToolUsage(sections []toolUsageSection, scope contextfrag.Scope) []contextfrag.ContextFrag {
+	if len(sections) == 0 {
+		return nil
+	}
+	render := contextfrag.RenderPolicy{
+		Format:      contextfrag.RenderMarkdown,
+		GroupID:     toolUsageGroupID,
+		GroupJoiner: "\n\n",
+	}
+	frag := func(id, text, capability string, index int) contextfrag.ContextFrag {
+		return contextfrag.TextFrag(contextfrag.TextFragInput{
+			ID:                 id,
+			Kind:               contextfrag.KindToolUsage,
+			Role:               sdk.MessageRoleSystem,
+			Slot:               contextfrag.SlotSystem,
+			Text:               text,
+			Priority:           45,
+			RetentionTier:      contextfrag.RetentionPreferred,
+			RequiredCapability: capability,
+			CacheClass:         contextfrag.CacheStable,
+			Trust:              contextfrag.TrustSystem,
+			Scope:              scope,
+			Source:             contextfrag.SourceAgentToolUsage,
+			SourceID:           capability,
+			Collector:          "assemble_tools",
+			Index:              index,
+			Render:             render,
+		})
+	}
+
+	frags := make([]contextfrag.ContextFrag, 0, len(sections)+1)
+	frags = append(frags, frag(
+		toolUsageGroupID+".header",
+		"## Tool usage",
+		sections[0].capability,
+		0,
+	))
+	for i, section := range sections {
+		frags = append(frags, frag(
+			toolUsageGroupID+"."+section.capability,
+			section.text,
+			section.capability,
+			i+1,
+		))
+	}
+	return frags
+}

--- a/internal/agent/runtime/native/tool_usage_fragments_test.go
+++ b/internal/agent/runtime/native/tool_usage_fragments_test.go
@@ -1,0 +1,62 @@
+package native
+
+import (
+	"context"
+	"testing"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	tools "github.com/memohai/memoh/internal/agent/tool"
+)
+
+func TestAssembleToolsReturnsStructuredUsageFragments(t *testing.T) {
+	t.Parallel()
+
+	a := newTestAgent(
+		&usageTestProvider{emitTool: true, toolName: "zeta_tool", usage: "Zeta usage"},
+		&usageTestProvider{emitTool: true, toolName: "alpha_tool", usage: "Alpha 用法"},
+	)
+
+	_, flat, frags, _, err := a.assembleTools(
+		context.Background(),
+		RunConfig{},
+		tools.StreamEmitter(func(tools.ToolStreamEvent) {}),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("assembleTools error: %v", err)
+	}
+
+	wantFlat := "## Tool usage\n\nZeta usage\n\nAlpha 用法"
+	if flat != wantFlat {
+		t.Fatalf("flat usage = %q, want %q", flat, wantFlat)
+	}
+	if got := contextfrag.Render(frags).System; got != wantFlat {
+		t.Fatalf("structured usage renders %q, want byte-identical %q", got, wantFlat)
+	}
+
+	wantIDs := []string{
+		"system.tool_usage.header",
+		"system.tool_usage.zeta_tool",
+		"system.tool_usage.alpha_tool",
+	}
+	wantCapabilities := []string{"zeta_tool", "zeta_tool", "alpha_tool"}
+	if len(frags) != len(wantIDs) {
+		t.Fatalf("structured usage fragments = %d, want %d", len(frags), len(wantIDs))
+	}
+	for i := range frags {
+		if frags[i].ID != wantIDs[i] {
+			t.Errorf("fragment %d ID = %q, want %q", i, frags[i].ID, wantIDs[i])
+		}
+		if frags[i].RequiredCapability != wantCapabilities[i] {
+			t.Errorf(
+				"fragment %d required capability = %q, want %q",
+				i,
+				frags[i].RequiredCapability,
+				wantCapabilities[i],
+			)
+		}
+		if frags[i].Render.GroupID != toolUsageGroupID || frags[i].Render.GroupJoiner != "\n\n" {
+			t.Errorf("fragment %d render policy = %+v, want tool-usage group with blank-line join", i, frags[i].Render)
+		}
+	}
+}

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -105,6 +105,7 @@ type RunConfig struct {
 	ContextToolUsage               string
 	ContextToolUsageFrags          []contextfrag.ContextFrag
 	ContextToolDefs                []contextfrag.ToolDefAccounting
+	ContextToolDefsResolved        bool
 	ContextToolExchangePolicy      *contextfrag.ToolExchangePolicy
 	ContextCachePlan               contextfrag.CachePlan
 	ContextMutations               *contextfrag.MutationLedger

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -103,6 +103,7 @@ type RunConfig struct {
 	ContextMemoryMessageIndex      *int
 	ContextQueryMaterialized       bool
 	ContextToolUsage               string
+	ContextToolUsageFrags          []contextfrag.ContextFrag
 	ContextToolDefs                []contextfrag.ToolDefAccounting
 	ContextToolExchangePolicy      *contextfrag.ToolExchangePolicy
 	ContextCachePlan               contextfrag.CachePlan

--- a/internal/agent/runtime/native/usage_injection_test.go
+++ b/internal/agent/runtime/native/usage_injection_test.go
@@ -17,6 +17,7 @@ import (
 // letting us assert that usage guidance is gated by tool registration.
 type usageTestProvider struct {
 	emitTool      bool
+	toolName      string
 	usage         string
 	requireTool   tools.ToolName
 	missingMarker string
@@ -30,7 +31,11 @@ func (p *usageTestProvider) Tools(_ context.Context, session tools.SessionContex
 	if !p.emitTool {
 		return nil, nil
 	}
-	return []sdk.Tool{{Name: "fake_tool", Description: "fake"}}, nil
+	name := p.toolName
+	if name == "" {
+		name = "fake_tool"
+	}
+	return []sdk.Tool{{Name: name, Description: "fake"}}, nil
 }
 
 func (p *usageTestProvider) Usage(_ context.Context, _ tools.SessionContext, available tools.AvailableTools) string {
@@ -284,7 +289,7 @@ func TestAssembleToolsInjectsUsageWhenProviderEmitsTools(t *testing.T) {
 	t.Parallel()
 	a := newTestAgent(&usageTestProvider{emitTool: true, usage: usageMarker})
 
-	gotTools, usage, toolDefs, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, toolDefs, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}
@@ -306,7 +311,7 @@ func TestAssembleToolsOmitsUsageWhenProviderEmitsNoTools(t *testing.T) {
 	t.Parallel()
 	a := newTestAgent(&usageTestProvider{emitTool: false, usage: usageMarker})
 
-	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}
@@ -325,7 +330,7 @@ func TestAssembleToolsUsesProviderAccountingLabel(t *testing.T) {
 		{label: " ", want: "native"},
 	} {
 		a := newTestAgent(labeledTestProvider{label: tc.label})
-		_, _, toolDefs, err := a.assembleTools(context.Background(), RunConfig{}, nil, false)
+		_, _, _, toolDefs, err := a.assembleTools(context.Background(), RunConfig{}, nil, false)
 		if err != nil {
 			t.Fatalf("assembleTools error: %v", err)
 		}
@@ -339,7 +344,7 @@ func TestAssembleToolsDoesNotExposeAskUserWithoutCapability(t *testing.T) {
 	t.Parallel()
 	a := newTestAgent(&tools.AskUserProvider{})
 
-	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{
+	gotTools, usage, _, _, err := a.assembleTools(context.Background(), RunConfig{
 		SessionType: sessionmode.Chat,
 	}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
@@ -352,7 +357,7 @@ func TestAssembleToolsDoesNotExposeAskUserWithoutCapability(t *testing.T) {
 		t.Fatalf("expected no ask_user usage without user input capability, got %q", usage)
 	}
 
-	gotTools, usage, _, err = a.assembleTools(context.Background(), RunConfig{
+	gotTools, usage, _, _, err = a.assembleTools(context.Background(), RunConfig{
 		SessionType:         sessionmode.Chat,
 		CanRequestUserInput: true,
 	}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
@@ -371,7 +376,7 @@ func TestAssembleToolsIgnoresProvidersWithoutUsage(t *testing.T) {
 	t.Parallel()
 	a := newTestAgent(plainTestProvider{})
 
-	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}
@@ -399,7 +404,7 @@ func TestAssembleToolsGatesUsagePerProvider(t *testing.T) {
 		plainTestProvider{},
 	)
 
-	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}
@@ -425,7 +430,7 @@ func TestAssembleToolsKeepsFirstDuplicateToolAndItsUsage(t *testing.T) {
 		&usageTestProvider{emitTool: true, usage: secondUsage},
 	)
 
-	gotTools, usage, toolDefs, err := a.assembleTools(
+	gotTools, usage, _, toolDefs, err := a.assembleTools(
 		context.Background(),
 		RunConfig{},
 		tools.StreamEmitter(func(tools.ToolStreamEvent) {}),
@@ -464,7 +469,7 @@ func TestAssembleToolsPassesCompleteAvailableToolSetToUsage(t *testing.T) {
 		plainTestProvider{},
 	)
 
-	gotTools, usage, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
+	gotTools, usage, _, _, err := a.assembleTools(context.Background(), RunConfig{}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true)
 	if err != nil {
 		t.Fatalf("assembleTools error: %v", err)
 	}

--- a/internal/contextview/builder.go
+++ b/internal/contextview/builder.go
@@ -77,6 +77,7 @@ func (b *Builder) Build(ctx context.Context, input BuildInput) (*ContextView, er
 	manifest.View = input.Intent.ManifestView()
 	manifest.DynamicMutators = normalizeDynamicMutators(input.DynamicMutators)
 	manifest.Selection = selectionTrace(result.Summary)
+	manifest.SelectionDecisions = selectionDecisions(sourceFrags, result)
 	manifest.EditTrace = append(manifest.EditTrace, selectionEditTrace(result.Dropped)...)
 	manifest.EditTrace = append(manifest.EditTrace, result.Edited...)
 	manifest.ValidationWarnings = append(manifest.ValidationWarnings, result.Warnings...)
@@ -127,6 +128,74 @@ func (b *Builder) Build(ctx context.Context, input BuildInput) (*ContextView, er
 	}
 
 	return view, nil
+}
+
+func selectionDecisions(sourceFrags []contextfrag.ContextFrag, result SelectionResult) []contextfrag.SelectionDecision {
+	dropReasons := make(map[string][]string, len(result.Summary.DropReasons))
+	for _, record := range result.Summary.DropReasons {
+		dropReasons[record.FragID] = append(dropReasons[record.FragID], record.Reason)
+	}
+	selectedByID := make(map[string][]contextfrag.ContextFrag, len(result.Selected))
+	for _, frag := range result.Selected {
+		selectedByID[frag.ID] = append(selectedByID[frag.ID], frag)
+	}
+
+	decisions := make([]contextfrag.SelectionDecision, 0, len(sourceFrags)+2)
+	sourceCounts := make(map[string]int, len(sourceFrags))
+	for _, source := range sourceFrags {
+		sourceCounts[source.ID]++
+		if reasons := dropReasons[source.ID]; len(reasons) > 0 {
+			decisions = append(decisions, selectionDecisionForFrag(source, contextfrag.DecisionDropped, reasons[0]))
+			dropReasons[source.ID] = reasons[1:]
+			continue
+		}
+		selected := selectedByID[source.ID]
+		if len(selected) == 0 {
+			decisions = append(decisions, selectionDecisionForFrag(source, contextfrag.DecisionDropped, "unknown"))
+			continue
+		}
+		decision := contextfrag.DecisionSelected
+		if source.Ref.ContentHash != selected[0].Ref.ContentHash ||
+			contextfrag.ResolveFragTokens(source) != contextfrag.ResolveFragTokens(selected[0]) {
+			decision = contextfrag.DecisionTrimmed
+		}
+		decisions = append(decisions, selectionDecisionForFrag(selected[0], decision, ""))
+		selectedByID[source.ID] = selected[1:]
+	}
+	for _, selected := range result.Selected {
+		if sourceCounts[selected.ID] > 0 {
+			sourceCounts[selected.ID]--
+			continue
+		}
+		decisions = append(decisions, selectionDecisionForFrag(selected, contextfrag.DecisionSelected, ""))
+	}
+	return decisions
+}
+
+func selectionDecisionForFrag(
+	frag contextfrag.ContextFrag,
+	decision contextfrag.SelectionDecisionKind,
+	reason string,
+) contextfrag.SelectionDecision {
+	itemManifest := contextfrag.BuildManifest([]contextfrag.ContextFrag{frag})
+	item := contextfrag.ManifestItem{}
+	if len(itemManifest.Items) > 0 {
+		item = itemManifest.Items[0]
+	}
+	return contextfrag.SelectionDecision{
+		ID:            frag.ID,
+		Ref:           item.Ref,
+		Slot:          frag.Slot,
+		Source:        frag.Provenance.Source,
+		SourceID:      frag.Provenance.SourceID,
+		Decision:      decision,
+		Reason:        reason,
+		TokenEstimate: item.TokenEstimate,
+		TextBytes:     item.TextBytes,
+		ImageCount:    item.ImageCount,
+		CacheClass:    frag.CacheClass,
+		RetentionTier: frag.RetentionTier,
+	}
 }
 
 func summarizePlacement(placement PlacementPlan) PlacementSummary {

--- a/internal/contextview/builder.go
+++ b/internal/contextview/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
@@ -131,45 +132,167 @@ func (b *Builder) Build(ctx context.Context, input BuildInput) (*ContextView, er
 }
 
 func selectionDecisions(sourceFrags []contextfrag.ContextFrag, result SelectionResult) []contextfrag.SelectionDecision {
-	dropReasons := make(map[string][]string, len(result.Summary.DropReasons))
+	dropReasonsByRef := make(map[selectionRefKey][]string, len(result.Summary.DropReasons))
+	legacyDropReasonsByID := make(map[string][]string)
 	for _, record := range result.Summary.DropReasons {
-		dropReasons[record.FragID] = append(dropReasons[record.FragID], record.Reason)
+		if key, ok := newSelectionRefKey(record.Ref); ok {
+			dropReasonsByRef[key] = append(dropReasonsByRef[key], record.Reason)
+			continue
+		}
+		legacyDropReasonsByID[record.FragID] = append(legacyDropReasonsByID[record.FragID], record.Reason)
 	}
-	selectedByID := make(map[string][]contextfrag.ContextFrag, len(result.Selected))
-	for _, frag := range result.Selected {
-		selectedByID[frag.ID] = append(selectedByID[frag.ID], frag)
+	selectedByRef := make(map[selectionRefKey][]int, len(result.Selected))
+	for i, frag := range result.Selected {
+		if key, ok := newSelectionRefKey(frag.Ref); ok {
+			selectedByRef[key] = append(selectedByRef[key], i)
+		}
 	}
 
-	decisions := make([]contextfrag.SelectionDecision, 0, len(sourceFrags)+2)
-	sourceCounts := make(map[string]int, len(sourceFrags))
-	for _, source := range sourceFrags {
-		sourceCounts[source.ID]++
-		if reasons := dropReasons[source.ID]; len(reasons) > 0 {
-			decisions = append(decisions, selectionDecisionForFrag(source, contextfrag.DecisionDropped, reasons[0]))
-			dropReasons[source.ID] = reasons[1:]
+	decisions := make([]contextfrag.SelectionDecision, len(sourceFrags))
+	decided := make([]bool, len(sourceFrags))
+	selectedUsed := make([]bool, len(result.Selected))
+
+	// DropRecord.Ref identifies the exact source candidate that was rejected.
+	// Resolve those records before any selected-fragment matching so two
+	// candidates sharing a debug ID cannot exchange their audit outcomes.
+	for i, source := range sourceFrags {
+		key, ok := newSelectionRefKey(source.Ref)
+		if !ok {
 			continue
 		}
-		selected := selectedByID[source.ID]
-		if len(selected) == 0 {
-			decisions = append(decisions, selectionDecisionForFrag(source, contextfrag.DecisionDropped, "unknown"))
+		reasons := dropReasonsByRef[key]
+		if len(reasons) == 0 {
 			continue
 		}
-		decision := contextfrag.DecisionSelected
-		if source.Ref.ContentHash != selected[0].Ref.ContentHash ||
-			contextfrag.ResolveFragTokens(source) != contextfrag.ResolveFragTokens(selected[0]) {
-			decision = contextfrag.DecisionTrimmed
-		}
-		decisions = append(decisions, selectionDecisionForFrag(selected[0], decision, ""))
-		selectedByID[source.ID] = selected[1:]
+		decisions[i] = selectionDecisionForFrag(source, contextfrag.DecisionDropped, reasons[0])
+		decided[i] = true
+		dropReasonsByRef[key] = reasons[1:]
 	}
-	for _, selected := range result.Selected {
-		if sourceCounts[selected.ID] > 0 {
-			sourceCounts[selected.ID]--
+
+	// Match unchanged selections by the complete ContextRef, including the
+	// content hash, before considering trim identity or legacy IDs.
+	for i, source := range sourceFrags {
+		if decided[i] {
 			continue
 		}
-		decisions = append(decisions, selectionDecisionForFrag(selected, contextfrag.DecisionSelected, ""))
+		key, ok := newSelectionRefKey(source.Ref)
+		if !ok {
+			continue
+		}
+		indexes := selectedByRef[key]
+		for len(indexes) > 0 && selectedUsed[indexes[0]] {
+			indexes = indexes[1:]
+		}
+		selectedByRef[key] = indexes
+		if len(indexes) == 0 {
+			continue
+		}
+		selectedIndex := indexes[0]
+		decisions[i] = selectionDecisionForSelection(source, result.Selected[selectedIndex])
+		decided[i] = true
+		selectedUsed[selectedIndex] = true
+		selectedByRef[key] = indexes[1:]
+	}
+
+	// A trim keeps the ContextRef identity but refreshes its content hash.
+	// Exact matches above must run first because multiple revisions of one
+	// durable identity can legitimately appear in the same source set.
+	for i, source := range sourceFrags {
+		if decided[i] {
+			continue
+		}
+		for selectedIndex, selected := range result.Selected {
+			if selectedUsed[selectedIndex] || !source.Ref.EqualIdentity(selected.Ref) {
+				continue
+			}
+			decisions[i] = selectionDecisionForSelection(source, selected)
+			decided[i] = true
+			selectedUsed[selectedIndex] = true
+			break
+		}
+	}
+
+	// Keep ID-only drop records for legacy selectors that did not provide a Ref.
+	for i, source := range sourceFrags {
+		if decided[i] {
+			continue
+		}
+		if reasons := legacyDropReasonsByID[source.ID]; len(reasons) > 0 {
+			decisions[i] = selectionDecisionForFrag(source, contextfrag.DecisionDropped, reasons[0])
+			decided[i] = true
+			legacyDropReasonsByID[source.ID] = reasons[1:]
+		}
+	}
+
+	// Preserve the former ID fallback for trim/replacement selectors only when
+	// one source and one selected fragment remain for that ID. Multiple
+	// candidates are ambiguous and must never be paired by their debug ID.
+	unresolvedSourcesByID := make(map[string]int)
+	unusedSelectedByID := make(map[string]int)
+	for i, source := range sourceFrags {
+		if !decided[i] {
+			unresolvedSourcesByID[source.ID]++
+		}
+	}
+	for i, selected := range result.Selected {
+		if !selectedUsed[i] {
+			unusedSelectedByID[selected.ID]++
+		}
+	}
+	for i, source := range sourceFrags {
+		if decided[i] || unresolvedSourcesByID[source.ID] != 1 || unusedSelectedByID[source.ID] != 1 {
+			continue
+		}
+		for selectedIndex, selected := range result.Selected {
+			if selectedUsed[selectedIndex] || selected.ID != source.ID {
+				continue
+			}
+			decisions[i] = selectionDecisionForSelection(source, selected)
+			decided[i] = true
+			selectedUsed[selectedIndex] = true
+			break
+		}
+	}
+
+	for i, source := range sourceFrags {
+		if !decided[i] {
+			decisions[i] = selectionDecisionForFrag(source, contextfrag.DecisionDropped, "unknown")
+		}
+	}
+	for i, selected := range result.Selected {
+		if !selectedUsed[i] {
+			decisions = append(decisions, selectionDecisionForFrag(selected, contextfrag.DecisionSelected, ""))
+		}
 	}
 	return decisions
+}
+
+type selectionRefKey struct {
+	identity    string
+	hashAlgo    string
+	hashScope   string
+	contentHash string
+}
+
+func newSelectionRefKey(ref contextfrag.ContextRef) (selectionRefKey, bool) {
+	if strings.TrimSpace(ref.Namespace) == "" || strings.TrimSpace(ref.ID) == "" {
+		return selectionRefKey{}, false
+	}
+	return selectionRefKey{
+		identity:    ref.StableKey(),
+		hashAlgo:    strings.TrimSpace(ref.HashAlgo),
+		hashScope:   strings.TrimSpace(ref.HashScope),
+		contentHash: strings.TrimSpace(ref.ContentHash),
+	}, true
+}
+
+func selectionDecisionForSelection(source, selected contextfrag.ContextFrag) contextfrag.SelectionDecision {
+	decision := contextfrag.DecisionSelected
+	if source.Ref.ContentHash != selected.Ref.ContentHash ||
+		contextfrag.ResolveFragTokens(source) != contextfrag.ResolveFragTokens(selected) {
+		decision = contextfrag.DecisionTrimmed
+	}
+	return selectionDecisionForFrag(selected, decision, "")
 }
 
 func selectionDecisionForFrag(

--- a/internal/contextview/builder_selection_ref_test.go
+++ b/internal/contextview/builder_selection_ref_test.go
@@ -1,0 +1,54 @@
+package contextview
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestSelectionDecisionsUsesContextRefWhenIDsCollide(t *testing.T) {
+	first := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "same-id", Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem,
+		Slot: contextfrag.SlotSystem, Text: "winner", Priority: 10,
+		CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustSystem,
+		Source: "selection-test", Collector: "selection-test", ConflictKey: "same-conflict",
+	})
+	second := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "same-id", Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem,
+		Slot: contextfrag.SlotSystem, Text: "loser", Priority: 10,
+		CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustWorkspace,
+		Source: "selection-test", Collector: "selection-test", ConflictKey: "same-conflict",
+	})
+	sources := contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{first, second})
+	builder := NewBuilder(
+		NewMapCollectorRegistry(StaticCollector{CollectorName: "selection-test", Frags: sources}),
+		&FragmentSelector{},
+		IdentityPlacer{},
+		NewMapRendererRegistry(),
+	)
+	view, err := builder.Build(context.Background(), BuildInput{
+		Intent:  contextfrag.IntentRunConfigPreProvider,
+		Sources: []SourceSpec{{Name: "selection-test"}},
+		Options: BuildOptions{DryRun: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(view.Selected) != 1 || view.Selected[0].Ref.ContentHash != sources[0].Ref.ContentHash {
+		t.Fatalf("selector winner = %#v, want first ContextRef", view.Selected)
+	}
+	if len(view.Manifest.SelectionDecisions) != 2 {
+		t.Fatalf("selection decisions = %#v, want two source decisions", view.Manifest.SelectionDecisions)
+	}
+	firstDecision := view.Manifest.SelectionDecisions[0]
+	secondDecision := view.Manifest.SelectionDecisions[1]
+	if firstDecision.Decision != contextfrag.DecisionSelected || firstDecision.Ref.ContentHash != sources[0].Ref.ContentHash {
+		t.Fatalf("winner decision = %#v, want selected first ContextRef", firstDecision)
+	}
+	if secondDecision.Decision != contextfrag.DecisionDropped || secondDecision.Ref.ContentHash != sources[1].Ref.ContentHash {
+		t.Fatalf("loser decision = %#v, want dropped second ContextRef", secondDecision)
+	}
+}

--- a/internal/contextview/builder_test.go
+++ b/internal/contextview/builder_test.go
@@ -149,6 +149,49 @@ func TestBuildRecordsDroppedFragmentEditTrace(t *testing.T) {
 	if len(got.Manifest.Items) != len(frags)-1 {
 		t.Fatalf("manifest items = %d, want %d", len(got.Manifest.Items), len(frags)-1)
 	}
+	if len(got.Manifest.SelectionDecisions) != len(frags) {
+		t.Fatalf("selection decisions = %#v", got.Manifest.SelectionDecisions)
+	}
+	for i, decision := range got.Manifest.SelectionDecisions {
+		if decision.ID != frags[i].ID || decision.Ref.ID == "" {
+			t.Fatalf("selection decision %d = %#v", i, decision)
+		}
+		wantDecision := contextfrag.DecisionSelected
+		wantReason := ""
+		if i == 0 {
+			wantDecision = contextfrag.DecisionDropped
+			wantReason = "fixture"
+		}
+		if decision.Decision != wantDecision || decision.Reason != wantReason {
+			t.Fatalf("selection decision %d = %#v, want %q/%q", i, decision, wantDecision, wantReason)
+		}
+	}
+}
+
+func TestSelectionDecisionsMarksChangedSelectionTrimmed(t *testing.T) {
+	t.Parallel()
+
+	source := textFrag("same", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "changed")
+	selected := textFrag("same", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "change")
+	frags := contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{source, selected})
+	source, selected = frags[0], frags[1]
+	if contextfrag.ResolveFragTokens(source) != contextfrag.ResolveFragTokens(selected) {
+		t.Fatal("fixture must keep the same token estimate")
+	}
+
+	decisions := selectionDecisions([]contextfrag.ContextFrag{source}, SelectionResult{
+		Selected: []contextfrag.ContextFrag{selected},
+		Summary:  SelectionSummary{TotalCollected: 1, TotalSelected: 1},
+	})
+	if len(decisions) != 1 || decisions[0].Decision != contextfrag.DecisionTrimmed {
+		t.Fatalf("selection decisions = %#v", decisions)
+	}
+	if decisions[0].Ref.ContentHash != selected.Ref.ContentHash || decisions[0].Ref.ContentHash == source.Ref.ContentHash {
+		t.Fatalf("decision ref = %#v, source = %#v, selected = %#v", decisions[0].Ref, source.Ref, selected.Ref)
+	}
+	if decisions[0].TextBytes != len("change") || decisions[0].TokenEstimate != contextfrag.ResolveFragTokens(selected) {
+		t.Fatalf("decision accounting = %#v", decisions[0])
+	}
 }
 
 func TestBuilderPlacesLateSystemFragmentInRenderedPrefixOrder(t *testing.T) {

--- a/internal/contextview/capability_gate.go
+++ b/internal/contextview/capability_gate.go
@@ -1,0 +1,178 @@
+package contextview
+
+import (
+	"strings"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+const capabilityGateDropReason = "capability_gated"
+
+type capabilityGateSelector struct {
+	delegate  Selector
+	available map[string]struct{}
+}
+
+func newCapabilityGateSelector(
+	delegate Selector,
+	defs []contextfrag.ToolDefAccounting,
+) *capabilityGateSelector {
+	available := make(map[string]struct{}, len(defs))
+	for _, def := range defs {
+		if name := strings.TrimSpace(def.Name); name != "" {
+			available[name] = struct{}{}
+		}
+	}
+	return &capabilityGateSelector{delegate: delegate, available: available}
+}
+
+func (s *capabilityGateSelector) ProfileFor(intent contextfrag.Intent) IntentProfile {
+	return s.delegate.ProfileFor(intent)
+}
+
+func (s *capabilityGateSelector) Select(
+	frags []contextfrag.ContextFrag,
+	profile IntentProfile,
+	budget BudgetEnvelope,
+) SelectionResult {
+	kept, gated := filterUnavailableCapabilities(frags, s.available)
+	result := s.delegate.Select(kept, profile, budget)
+	return appendCapabilityGateDrops(result, gated)
+}
+
+func filterUnavailableCapabilities(
+	frags []contextfrag.ContextFrag,
+	available map[string]struct{},
+) ([]contextfrag.ContextFrag, []contextfrag.ContextFrag) {
+	if len(frags) == 0 {
+		return nil, nil
+	}
+
+	dropped := make([]bool, len(frags))
+	groupItems := make(map[string]int)
+	keptGroupItems := make(map[string]int)
+	for i, frag := range frags {
+		groupID := frag.Render.GroupID
+		if groupID != "" && !isRenderGroupHeader(frag) {
+			groupItems[groupID]++
+		}
+		if isRenderGroupHeader(frag) {
+			continue
+		}
+		if requiresUnavailableCapability(frag, available) {
+			dropped[i] = true
+			continue
+		}
+		if groupID != "" {
+			keptGroupItems[groupID]++
+		}
+	}
+	for i, frag := range frags {
+		if !isRenderGroupHeader(frag) {
+			continue
+		}
+		groupID := frag.Render.GroupID
+		if groupItems[groupID] > 0 {
+			dropped[i] = keptGroupItems[groupID] == 0
+			continue
+		}
+		dropped[i] = requiresUnavailableCapability(frag, available)
+	}
+
+	kept := make([]contextfrag.ContextFrag, 0, len(frags))
+	var gated []contextfrag.ContextFrag
+	for i, frag := range frags {
+		if dropped[i] {
+			gated = append(gated, frag)
+			continue
+		}
+		kept = append(kept, frag)
+	}
+	return kept, gated
+}
+
+func isRenderGroupHeader(frag contextfrag.ContextFrag) bool {
+	return frag.Render.GroupID != "" && frag.ID == frag.Render.GroupID+".header"
+}
+
+func requiresUnavailableCapability(
+	frag contextfrag.ContextFrag,
+	available map[string]struct{},
+) bool {
+	capability := strings.TrimSpace(frag.RequiredCapability)
+	if frag.Slot != contextfrag.SlotSystem || capability == "" {
+		return false
+	}
+	_, ok := available[capability]
+	return !ok
+}
+
+func appendCapabilityGateDrops(
+	result SelectionResult,
+	gated []contextfrag.ContextFrag,
+) SelectionResult {
+	for _, frag := range gated {
+		result.Dropped = append(result.Dropped, frag)
+		result.Summary.DropReasons = append(result.Summary.DropReasons, DropRecord{
+			FragID: frag.ID,
+			Ref:    frag.Ref,
+			Reason: capabilityGateDropReason,
+		})
+	}
+	result.Summary.TotalCollected += len(gated)
+	result.Summary.TotalDropped += len(gated)
+	return result
+}
+
+func capabilitySafeFallbackConfig(
+	cfg agentpkg.RunConfig,
+	sourceFrags []contextfrag.ContextFrag,
+	available map[string]struct{},
+) agentpkg.RunConfig {
+	normalized := contextfrag.NormalizeContextRefs(sourceFrags)
+	kept, gated := filterUnavailableCapabilities(normalized, available)
+	cfg.System = renderSystemOnly(kept)
+	cfg.ContextToolUsage = ""
+	cfg.ContextToolUsageFrags = nil
+	cfg.ContextFrags = nonSystemFrags(cfg.ContextFrags)
+	result := appendCapabilityGateDrops(SelectionResult{}, gated)
+	cfg.ContextManifest.Selection = selectionTrace(result.Summary)
+	cfg.ContextManifest.SelectionDecisions = make(
+		[]contextfrag.SelectionDecision,
+		0,
+		len(gated),
+	)
+	for _, frag := range gated {
+		cfg.ContextManifest.SelectionDecisions = append(
+			cfg.ContextManifest.SelectionDecisions,
+			selectionDecisionForFrag(frag, contextfrag.DecisionDropped, capabilityGateDropReason),
+		)
+	}
+	return cfg
+}
+
+func renderSystemOnly(frags []contextfrag.ContextFrag) string {
+	payload := &SDKRenderedPayload{}
+	var previous contextfrag.RenderPolicy
+	hasPrevious := false
+	for _, frag := range sortSystemFragsByPriority(frags) {
+		if frag.Slot != contextfrag.SlotSystem {
+			continue
+		}
+		renderSystemFrag(payload, frag, previous, hasPrevious)
+		previous = frag.Render
+		hasPrevious = true
+	}
+	return payload.System
+}
+
+func nonSystemFrags(frags []contextfrag.ContextFrag) []contextfrag.ContextFrag {
+	out := make([]contextfrag.ContextFrag, 0, len(frags))
+	for _, frag := range frags {
+		if frag.Slot != contextfrag.SlotSystem {
+			out = append(out, frag)
+		}
+	}
+	return out
+}

--- a/internal/contextview/capability_gate_test.go
+++ b/internal/contextview/capability_gate_test.go
@@ -1,0 +1,294 @@
+package contextview
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	tools "github.com/memohai/memoh/internal/agent/tool"
+)
+
+func TestApplyProviderRunConfigGatesUnavailableSkillGuidance(t *testing.T) {
+	t.Parallel()
+
+	cfg := capabilityGateFixture()
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+
+	if got.System != "base system" {
+		t.Fatalf("system = %q, want unavailable skill guidance removed", got.System)
+	}
+	if strings.Contains(got.System, "[System Notice]") {
+		t.Fatalf("capability gating must not render an omission marker: %q", got.System)
+	}
+	for _, id := range []string{"system.skills.header", "system.skill.alpha"} {
+		decision, ok := decisionByID(got.ContextManifest.SelectionDecisions, id)
+		if !ok || decision.Decision != contextfrag.DecisionDropped || decision.Reason != capabilityGateDropReason {
+			t.Errorf("decision for %q = %#v, want dropped/%s", id, decision, capabilityGateDropReason)
+		}
+	}
+	if got.ContextManifest.Selection == nil ||
+		got.ContextManifest.Selection.DropReasons[capabilityGateDropReason] != 2 {
+		t.Fatalf("selection = %#v, want two capability-gated drops", got.ContextManifest.Selection)
+	}
+	records := got.ContextMutations.Records()
+	if len(records) != 1 ||
+		records[0].Kind != contextfrag.MutationCapabilityGate ||
+		records[0].Detail != "dropped=2" {
+		t.Fatalf("mutations = %+v, want one count-only capability gate record", records)
+	}
+}
+
+func TestApplyProviderRunConfigKeepsAvailableSkillGuidanceByteIdentical(t *testing.T) {
+	t.Parallel()
+
+	cfg := capabilityGateFixture()
+	cfg.ContextToolDefs = []contextfrag.ToolDefAccounting{{Name: tools.ToolUseSkill().String()}}
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+
+	if got.System != cfg.System {
+		t.Fatalf("system = %q, want byte-identical %q", got.System, cfg.System)
+	}
+	if got.ContextManifest.Selection != nil &&
+		got.ContextManifest.Selection.DropReasons[capabilityGateDropReason] != 0 {
+		t.Fatalf("selection = %#v, want no capability gate", got.ContextManifest.Selection)
+	}
+	if records := got.ContextMutations.Records(); len(records) != 0 {
+		t.Fatalf("mutations = %+v, want none", records)
+	}
+}
+
+func TestApplyProviderRunConfigLeavesUnknownCapabilityRosterUngated(t *testing.T) {
+	t.Parallel()
+
+	cfg := capabilityGateFixture()
+	cfg.ContextToolDefsResolved = false
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+
+	if got.System != cfg.System {
+		t.Fatalf("system = %q, want unknown roster to preserve %q", got.System, cfg.System)
+	}
+	if records := got.ContextMutations.Records(); len(records) != 0 {
+		t.Fatalf("mutations = %+v, want unknown roster ungated", records)
+	}
+}
+
+func TestApplyProviderRunConfigCapabilityGateKeepsHeaderForRemainingToolUsage(t *testing.T) {
+	t.Parallel()
+
+	base := capabilitySystemFrag(
+		"system.prompt",
+		"base system",
+		contextfrag.KindSystemPrompt,
+		20,
+		"",
+		contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+	)
+	cfg := agentpkg.RunConfig{
+		System:             "base system\n\n## Tool usage\n\nZeta usage\n\nAlpha 用法",
+		ContextSourceFrags: []contextfrag.ContextFrag{base},
+		ContextToolUsage:   "## Tool usage\n\nZeta usage\n\nAlpha 用法",
+		ContextToolUsageFrags: []contextfrag.ContextFrag{
+			toolUsageTestFrag("system.tool_usage.header", "## Tool usage", "zeta_tool", 0),
+			toolUsageTestFrag("system.tool_usage.zeta_tool", "Zeta usage", "zeta_tool", 1),
+			toolUsageTestFrag("system.tool_usage.alpha_tool", "Alpha 用法", "alpha_tool", 2),
+		},
+		ContextToolDefs:         []contextfrag.ToolDefAccounting{{Name: "alpha_tool"}},
+		ContextToolDefsResolved: true,
+	}
+
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	want := "base system\n\n## Tool usage\n\nAlpha 用法"
+	if got.System != want {
+		t.Fatalf("system = %q, want remaining provider usage %q", got.System, want)
+	}
+	if !hasFragID(got.ContextFrags, "system.tool_usage.header") ||
+		hasFragID(got.ContextFrags, "system.tool_usage.zeta_tool") {
+		t.Fatalf("selected fragments = %v, want header plus only available provider", fragIDs(got.ContextFrags))
+	}
+	if decision, ok := decisionByID(
+		got.ContextManifest.SelectionDecisions,
+		"system.tool_usage.zeta_tool",
+	); !ok || decision.Reason != capabilityGateDropReason {
+		t.Fatalf("zeta decision = %#v, want capability-gated", decision)
+	}
+}
+
+func TestApplyProviderRunConfigLeavesLegacySystemUngated(t *testing.T) {
+	t.Parallel()
+
+	cfg := capabilityGateFixture()
+	cfg.ContextSourceFrags = nil
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if got.System != cfg.System {
+		t.Fatalf("legacy system = %q, want unchanged %q", got.System, cfg.System)
+	}
+}
+
+func TestApplyProviderRunConfigFallbackCannotRestoreGatedGuidance(t *testing.T) {
+	t.Parallel()
+
+	cfg := capabilityGateFixture()
+	cfg.Messages = []sdk.Message{sdk.UserMessage("legacy message")}
+	cfg.ContextSourceFrags = append(
+		cfg.ContextSourceFrags,
+		contextfrag.MessageFrag(contextfrag.MessageFragInput{
+			ID:        "duplicate",
+			Message:   sdk.UserMessage("first"),
+			Kind:      contextfrag.KindConversationEvent,
+			Slot:      contextfrag.SlotHistory,
+			Source:    contextfrag.SourceRunConfig,
+			Collector: sourceFragsCollectorName,
+		}),
+		contextfrag.MessageFrag(contextfrag.MessageFragInput{
+			ID:        "duplicate",
+			Message:   sdk.AssistantMessage("second"),
+			Kind:      contextfrag.KindConversationEvent,
+			Slot:      contextfrag.SlotHistory,
+			Source:    contextfrag.SourceRunConfig,
+			Collector: sourceFragsCollectorName,
+		}),
+	)
+
+	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
+	if got.System != "base system" || strings.Contains(got.System, "alpha") {
+		t.Fatalf("fallback system = %q, want capability-filtered base system", got.System)
+	}
+	if len(got.Messages) != 1 || messageText(t, got.Messages[0]) != "legacy message" {
+		t.Fatalf("fallback messages = %#v, want legacy message", got.Messages)
+	}
+	records := got.ContextMutations.Records()
+	if len(records) != 2 ||
+		records[0].Kind != contextfrag.MutationCapabilityGate ||
+		records[1].Kind != contextfrag.MutationContextViewFallback {
+		t.Fatalf("fallback mutations = %+v, want capability gate then context-view fallback", records)
+	}
+	if got.ContextManifest.Selection == nil ||
+		got.ContextManifest.Selection.DropReasons[capabilityGateDropReason] != 2 {
+		t.Fatalf("fallback selection = %#v, want two capability-gated drops", got.ContextManifest.Selection)
+	}
+	for _, id := range []string{"system.skills.header", "system.skill.alpha"} {
+		decision, ok := decisionByID(got.ContextManifest.SelectionDecisions, id)
+		if !ok || decision.Decision != contextfrag.DecisionDropped || decision.Reason != capabilityGateDropReason {
+			t.Errorf("fallback decision for %q = %#v, want dropped/%s", id, decision, capabilityGateDropReason)
+		}
+	}
+	if decision, ok := decisionByID(got.ContextManifest.SelectionDecisions, "duplicate"); ok {
+		t.Fatalf("fallback recorded unsent source history as selected: %#v", decision)
+	}
+	if got.ContextManifest.Selection.Selected != len(got.ContextFrags) {
+		t.Fatalf(
+			"fallback selected count = %d, want actual rendered fragment count %d",
+			got.ContextManifest.Selection.Selected,
+			len(got.ContextFrags),
+		)
+	}
+}
+
+func capabilityGateFixture() agentpkg.RunConfig {
+	capability := tools.ToolUseSkill().String()
+	render := contextfrag.RenderPolicy{
+		Format:      contextfrag.RenderMarkdown,
+		GroupID:     "system.skills",
+		GroupJoiner: "\n",
+	}
+	frags := []contextfrag.ContextFrag{
+		capabilitySystemFrag(
+			"system.prompt",
+			"base system",
+			contextfrag.KindSystemPrompt,
+			20,
+			"",
+			contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+		),
+		capabilitySystemFrag(
+			"system.skills.header",
+			"## Skills\n\n1 skill(s) available:",
+			contextfrag.KindSkillsCatalog,
+			40,
+			capability,
+			render,
+		),
+		capabilitySystemFrag(
+			"system.skill.alpha",
+			"- **alpha**: Alpha 用法",
+			contextfrag.KindSkillsCatalog,
+			40,
+			capability,
+			render,
+		),
+	}
+	return agentpkg.RunConfig{
+		System:                  contextfrag.Render(frags).System,
+		ContextSourceFrags:      frags,
+		ContextToolDefsResolved: true,
+	}
+}
+
+func capabilitySystemFrag(
+	id, text string,
+	kind contextfrag.Kind,
+	priority int,
+	requiredCapability string,
+	render contextfrag.RenderPolicy,
+) contextfrag.ContextFrag {
+	return contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID:                 id,
+		Kind:               kind,
+		Role:               sdk.MessageRoleSystem,
+		Slot:               contextfrag.SlotSystem,
+		Text:               text,
+		Priority:           priority,
+		RetentionTier:      contextfrag.RetentionPreferred,
+		RequiredCapability: requiredCapability,
+		CacheClass:         contextfrag.CacheStable,
+		Trust:              contextfrag.TrustSystem,
+		Source:             contextfrag.SourceRunConfig,
+		Collector:          sourceFragsCollectorName,
+		Render:             render,
+	})
+}
+
+func decisionByID(
+	decisions []contextfrag.SelectionDecision,
+	id string,
+) (contextfrag.SelectionDecision, bool) {
+	for _, decision := range decisions {
+		if decision.ID == id {
+			return decision, true
+		}
+	}
+	return contextfrag.SelectionDecision{}, false
+}
+
+func hasFragID(frags []contextfrag.ContextFrag, id string) bool {
+	for _, frag := range frags {
+		if frag.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func fragIDs(frags []contextfrag.ContextFrag) []string {
+	ids := make([]string, 0, len(frags))
+	for _, frag := range frags {
+		ids = append(ids, frag.ID)
+	}
+	return ids
+}
+
+func messageText(t *testing.T, message sdk.Message) string {
+	t.Helper()
+	if len(message.Content) != 1 {
+		t.Fatalf("message content = %#v", message.Content)
+	}
+	part, ok := message.Content[0].(sdk.TextPart)
+	if !ok {
+		t.Fatalf("message part = %#v, want text", message.Content[0])
+	}
+	return part.Text
+}

--- a/internal/contextview/collector_system.go
+++ b/internal/contextview/collector_system.go
@@ -99,17 +99,18 @@ func preserveSystemBytes(raw string, frags []contextfrag.ContextFrag, scope cont
 		return frags
 	}
 	return []contextfrag.ContextFrag{{
-		ID:         "system.prompt",
-		Kind:       contextfrag.KindSystemPrompt,
-		Role:       sdk.MessageRoleSystem,
-		Slot:       contextfrag.SlotSystem,
-		Priority:   20,
-		CacheClass: contextfrag.CacheStable,
-		Trust:      contextfrag.TrustSystem,
-		Scope:      scope,
-		Render:     contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
-		Provenance: contextfrag.Provenance{Source: contextfrag.SourceRunConfig, Collector: systemPromptCollectorName},
-		Parts:      []contextfrag.Part{{Type: contextfrag.PartText, Text: raw}},
+		ID:            "system.prompt",
+		Kind:          contextfrag.KindSystemPrompt,
+		Role:          sdk.MessageRoleSystem,
+		Slot:          contextfrag.SlotSystem,
+		Priority:      20,
+		RetentionTier: contextfrag.RetentionRequired,
+		CacheClass:    contextfrag.CacheStable,
+		Trust:         contextfrag.TrustSystem,
+		Scope:         scope,
+		Render:        contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+		Provenance:    contextfrag.Provenance{Source: contextfrag.SourceRunConfig, Collector: systemPromptCollectorName},
+		Parts:         []contextfrag.Part{{Type: contextfrag.PartText, Text: raw}},
 	}}
 }
 
@@ -119,18 +120,19 @@ func systemPromptConfig(config any) (SystemPromptConfig, error) {
 
 func systemPromptTextFrag(scope contextfrag.Scope, id string, kind contextfrag.Kind, text string, priority int, source string, index int) contextfrag.ContextFrag {
 	return contextfrag.TextFrag(contextfrag.TextFragInput{
-		ID:         id,
-		Kind:       kind,
-		Role:       sdk.MessageRoleSystem,
-		Slot:       contextfrag.SlotSystem,
-		Text:       text,
-		Priority:   priority,
-		CacheClass: contextfrag.CacheStable,
-		Trust:      contextfrag.TrustSystem,
-		Scope:      scope,
-		Source:     source,
-		Collector:  systemPromptCollectorName,
-		Index:      index,
-		Render:     contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+		ID:            id,
+		Kind:          kind,
+		Role:          sdk.MessageRoleSystem,
+		Slot:          contextfrag.SlotSystem,
+		Text:          text,
+		Priority:      priority,
+		RetentionTier: contextfrag.RetentionRequired,
+		CacheClass:    contextfrag.CacheStable,
+		Trust:         contextfrag.TrustSystem,
+		Scope:         scope,
+		Source:        source,
+		Collector:     systemPromptCollectorName,
+		Index:         index,
+		Render:        contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
 	})
 }

--- a/internal/contextview/interfaces.go
+++ b/internal/contextview/interfaces.go
@@ -47,6 +47,9 @@ type SelectionResult struct {
 type IntentProfile struct {
 	Intent        contextfrag.Intent
 	MustKeepSlots []contextfrag.Slot
+	// MustKeepFrag evaluates retention that depends on fragment policy rather
+	// than provider placement alone.
+	MustKeepFrag func(contextfrag.ContextFrag) bool
 	// SlotTrustFloors declares the minimum trust level per slot.
 	SlotTrustFloors map[contextfrag.Slot]contextfrag.TrustLevel
 }

--- a/internal/contextview/provider_frags_first_test.go
+++ b/internal/contextview/provider_frags_first_test.go
@@ -55,6 +55,7 @@ func fragsFirstFixture() agentpkg.RunConfig {
 			{Provider: "native", Name: "zeta_tool", TokenEstimate: 5},
 			{Provider: "native", Name: "alpha_tool"},
 		},
+		ContextToolDefsResolved: true,
 	}
 }
 

--- a/internal/contextview/provider_frags_first_test.go
+++ b/internal/contextview/provider_frags_first_test.go
@@ -45,30 +45,70 @@ func fragsFirstFixture() agentpkg.RunConfig {
 			stableHistoryMessageFrag("message.000", sdk.UserMessage("history")),
 			currentMessageFrag("message.001", "current"),
 		},
-		ContextToolUsage: "## Tool usage\n\nUSE_TOOLS",
-		ContextToolDefs:  []contextfrag.ToolDefAccounting{{Provider: "native", Name: "read", TokenEstimate: 5}},
+		ContextToolUsage: "## Tool usage\n\nUSE_TOOLS\n\nUNICODE 用法",
+		ContextToolUsageFrags: []contextfrag.ContextFrag{
+			toolUsageTestFrag("system.tool_usage.header", "## Tool usage", "zeta_tool", 0),
+			toolUsageTestFrag("system.tool_usage.zeta_tool", "USE_TOOLS", "zeta_tool", 1),
+			toolUsageTestFrag("system.tool_usage.alpha_tool", "UNICODE 用法", "alpha_tool", 2),
+		},
+		ContextToolDefs: []contextfrag.ToolDefAccounting{
+			{Provider: "native", Name: "zeta_tool", TokenEstimate: 5},
+			{Provider: "native", Name: "alpha_tool"},
+		},
 	}
+}
+
+func toolUsageTestFrag(id, text, capability string, index int) contextfrag.ContextFrag {
+	return contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID:                 id,
+		Kind:               contextfrag.KindToolUsage,
+		Role:               sdk.MessageRoleSystem,
+		Slot:               contextfrag.SlotSystem,
+		Text:               text,
+		Priority:           45,
+		RetentionTier:      contextfrag.RetentionPreferred,
+		RequiredCapability: capability,
+		CacheClass:         contextfrag.CacheStable,
+		Trust:              contextfrag.TrustSystem,
+		Scope:              contextfrag.Scope{BotID: "bot-1"},
+		Source:             contextfrag.SourceAgentToolUsage,
+		Collector:          "assemble_tools",
+		Index:              index,
+		Render: contextfrag.RenderPolicy{
+			Format:      contextfrag.RenderMarkdown,
+			GroupID:     "system.tool_usage",
+			GroupJoiner: "\n\n",
+		},
+	})
 }
 
 func TestApplyProviderRunConfigFragsFirst(t *testing.T) {
 	t.Parallel()
 	got := ApplyProviderRunConfig(context.Background(), nil, fragsFirstFixture())
-	wantSystem := "base system\n\n## Tool usage\n\nUSE_TOOLS\n\n## Workspace instruction files\n\nworkspace"
+	wantSystem := "base system\n\n## Tool usage\n\nUSE_TOOLS\n\nUNICODE 用法\n\n## Workspace instruction files\n\nworkspace"
 	if got.System != wantSystem || strings.Contains(got.System, "LEGACY") {
 		t.Fatalf("system = %q", got.System)
 	}
 	assertMessagesEqual(t, got.Messages, []sdk.Message{sdk.UserMessage("history"), sdk.UserMessage("current")})
-	if len(got.ContextFrags) != 5 {
+	if len(got.ContextFrags) != 7 {
 		t.Fatalf("frags = %#v", got.ContextFrags)
 	}
-	wantOrder := []string{"system.prompt", "system.tool_usage", "system.workspace", "message.000", "message.001"}
+	wantOrder := []string{
+		"system.prompt",
+		"system.tool_usage.header",
+		"system.tool_usage.zeta_tool",
+		"system.tool_usage.alpha_tool",
+		"system.workspace",
+		"message.000",
+		"message.001",
+	}
 	for i, id := range wantOrder {
 		if got.ContextFrags[i].ID != id {
 			t.Fatalf("frag order = %#v", got.ContextFrags)
 		}
 	}
 	wantEstimate := 5
-	for _, frag := range got.ContextFrags[:4] {
+	for _, frag := range got.ContextFrags[:6] {
 		wantEstimate += contextfrag.ResolveFragTokens(frag)
 	}
 	if got.ContextCachePlan.StablePrefixTokenEstimate != wantEstimate || got.ContextCachePlan.StableMessageCount != 1 {
@@ -83,6 +123,15 @@ func TestApplyProviderRunConfigDedupesToolUsage(t *testing.T) {
 	got := ApplyProviderRunConfig(context.Background(), nil, cfg)
 	if strings.Contains(got.System, "stale usage") || strings.Count(got.System, "## Tool usage") != 1 {
 		t.Fatalf("system = %q", got.System)
+	}
+	usageFrags := 0
+	for _, frag := range got.ContextFrags {
+		if frag.Kind == contextfrag.KindToolUsage {
+			usageFrags++
+		}
+	}
+	if usageFrags != len(cfg.ContextToolUsageFrags) {
+		t.Fatalf("tool usage frags = %d, want %d structured fragments", usageFrags, len(cfg.ContextToolUsageFrags))
 	}
 }
 

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -183,8 +183,8 @@ func singleSDKMessage(frag contextfrag.ContextFrag) (sdk.Message, bool) {
 func ToolUsageFrag(usage string, scope contextfrag.Scope) contextfrag.ContextFrag {
 	return contextfrag.TextFrag(contextfrag.TextFragInput{
 		ID: "system.tool_usage", Kind: contextfrag.KindToolUsage, Role: sdk.MessageRoleSystem,
-		Slot: contextfrag.SlotSystem, Text: usage, Priority: 45, CacheClass: contextfrag.CacheStable,
-		Trust: contextfrag.TrustSystem, Scope: scope, Source: contextfrag.SourceAgentToolUsage,
+		Slot: contextfrag.SlotSystem, Text: usage, Priority: 45, RetentionTier: contextfrag.RetentionPreferred,
+		CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustSystem, Scope: scope, Source: contextfrag.SourceAgentToolUsage,
 		Collector: sourceFragsCollectorName, Render: contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
 		ConflictKey: toolUsageConflictKey,
 	})

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -199,7 +199,15 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 	var frags []contextfrag.ContextFrag
 	if len(cfg.ContextSourceFrags) > 0 {
 		frags = append([]contextfrag.ContextFrag(nil), cfg.ContextSourceFrags...)
-		if usage := strings.TrimSpace(cfg.ContextToolUsage); usage != "" {
+		if len(cfg.ContextToolUsageFrags) > 0 {
+			filtered := frags[:0]
+			for _, frag := range frags {
+				if frag.Kind != contextfrag.KindToolUsage {
+					filtered = append(filtered, frag)
+				}
+			}
+			frags = append(filtered, cfg.ContextToolUsageFrags...)
+		} else if usage := strings.TrimSpace(cfg.ContextToolUsage); usage != "" {
 			frags = append(frags, ToolUsageFrag(usage, cfg.ContextScope))
 		}
 	} else {

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -196,8 +196,10 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 		ledger = contextfrag.NewMutationLedger()
 	}
 
+	fragsFirst := len(cfg.ContextSourceFrags) > 0
+	var providerSourceFrags []contextfrag.ContextFrag
 	var frags []contextfrag.ContextFrag
-	if len(cfg.ContextSourceFrags) > 0 {
+	if fragsFirst {
 		frags = append([]contextfrag.ContextFrag(nil), cfg.ContextSourceFrags...)
 		if len(cfg.ContextToolUsageFrags) > 0 {
 			filtered := frags[:0]
@@ -210,6 +212,7 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 		} else if usage := strings.TrimSpace(cfg.ContextToolUsage); usage != "" {
 			frags = append(frags, ToolUsageFrag(usage, cfg.ContextScope))
 		}
+		providerSourceFrags = frags
 	} else {
 		cfg = legacyMaterializeQuery(cfg)
 		frags = CollectProviderSourceFrags(ctx, cfg)
@@ -218,8 +221,20 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 		}
 	}
 
+	selector := Selector(&FragmentSelector{})
+	fallbackCfg := cfg
+	if fragsFirst && cfg.ContextToolDefsResolved {
+		gate := newCapabilityGateSelector(selector, cfg.ContextToolDefs)
+		_, gated := filterUnavailableCapabilities(providerSourceFrags, gate.available)
+		if len(gated) > 0 {
+			ledger.Record(contextfrag.MutationCapabilityGate, fmt.Sprintf("dropped=%d", len(gated)))
+			fallbackCfg = capabilitySafeFallbackConfig(cfg, providerSourceFrags, gate.available)
+		}
+		selector = gate
+	}
+
 	registry := NewMapCollectorRegistry(StaticCollector{CollectorName: sourceFragsCollectorName, Frags: frags})
-	builder := NewBuilder(registry, &FragmentSelector{}, StablePrefixPlacer{}, NewMapRendererRegistry(&SDKMessagesRenderer{}))
+	builder := NewBuilder(registry, selector, StablePrefixPlacer{}, NewMapRendererRegistry(&SDKMessagesRenderer{}))
 	view, err := builder.Build(ctx, BuildInput{
 		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider,
 		Sources:         []SourceSpec{{Name: sourceFragsCollectorName}},
@@ -228,11 +243,11 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 		DynamicMutators: cfg.ContextDynamicMutators,
 	})
 	if err != nil {
-		return providerViewFallback(logger, cfg, ledger, "build_error", "context view build failed", err)
+		return providerViewFallback(logger, fallbackCfg, ledger, "build_error", "context view build failed", err)
 	}
 	payload, ok := view.Rendered[contextfrag.RenderSDKMessages].Data.(*SDKRenderedPayload)
 	if !ok {
-		return providerViewFallback(logger, cfg, ledger, "unexpected_payload", "context view rendered unexpected payload", nil)
+		return providerViewFallback(logger, fallbackCfg, ledger, "unexpected_payload", "context view rendered unexpected payload", nil)
 	}
 
 	plan := cachePlanFromPlacement(view.Placement)
@@ -246,7 +261,7 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 	cfg.Messages = payload.Messages
 	ordered, err := orderedSelectedFrags(view.Selected, view.Placement)
 	if err != nil {
-		return providerViewFallback(logger, cfg, ledger, "placement_error", "context view placement invalid after render", err)
+		return providerViewFallback(logger, fallbackCfg, ledger, "placement_error", "context view placement invalid after render", err)
 	}
 	currentIndex, memoryIndex := renderedSpecialMessageIndexes(ordered)
 	cfg.ContextMemoryMessageIndex = memoryIndex
@@ -268,10 +283,12 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 
 func providerViewFallback(logger *slog.Logger, cfg agentpkg.RunConfig, ledger *contextfrag.MutationLedger, reason, message string, err error) agentpkg.RunConfig {
 	warnProviderContextView(logger, cfg, message, err)
+	priorManifest := cfg.ContextManifest
 	cfg = legacyMaterializeQuery(cfg)
 	cfg.ContextFrags = nil
 	cfg.ContextSourceFrags = nil
 	cfg = cfg.RefreshContextFrag()
+	mergeCapabilityFallbackAudit(&cfg, priorManifest)
 	ledger.Record(contextfrag.MutationContextViewFallback, reason)
 	plan := contextfrag.CachePlan{}
 	manifest := cfg.ContextManifest
@@ -282,6 +299,36 @@ func providerViewFallback(logger *slog.Logger, cfg agentpkg.RunConfig, ledger *c
 	cfg.ContextCachePlan = plan
 	cfg.ContextMutations = ledger
 	return cfg
+}
+
+func mergeCapabilityFallbackAudit(out *agentpkg.RunConfig, prior contextfrag.Manifest) {
+	if out == nil || prior.Selection == nil ||
+		prior.Selection.DropReasons[capabilityGateDropReason] == 0 {
+		return
+	}
+	gated := make([]contextfrag.SelectionDecision, 0, prior.Selection.Dropped)
+	for _, decision := range prior.SelectionDecisions {
+		if decision.Decision == contextfrag.DecisionDropped &&
+			decision.Reason == capabilityGateDropReason {
+			gated = append(gated, decision)
+		}
+	}
+	if len(gated) == 0 {
+		return
+	}
+	decisions := make([]contextfrag.SelectionDecision, 0, len(out.ContextFrags)+len(gated))
+	for _, frag := range out.ContextFrags {
+		decisions = append(decisions, selectionDecisionForFrag(frag, contextfrag.DecisionSelected, ""))
+	}
+	decisions = append(decisions, gated...)
+	out.ContextManifest.Selection = &contextfrag.SelectionTrace{
+		Selected: len(out.ContextFrags),
+		Dropped:  len(gated),
+		DropReasons: map[string]int{
+			capabilityGateDropReason: len(gated),
+		},
+	}
+	out.ContextManifest.SelectionDecisions = decisions
 }
 
 func legacyMaterializeQuery(cfg agentpkg.RunConfig) agentpkg.RunConfig {

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -208,7 +208,8 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 					filtered = append(filtered, frag)
 				}
 			}
-			frags = append(filtered, cfg.ContextToolUsageFrags...)
+			filtered = append(filtered, cfg.ContextToolUsageFrags...)
+			frags = filtered
 		} else if usage := strings.TrimSpace(cfg.ContextToolUsage); usage != "" {
 			frags = append(frags, ToolUsageFrag(usage, cfg.ContextScope))
 		}

--- a/internal/contextview/render_sdk.go
+++ b/internal/contextview/render_sdk.go
@@ -42,19 +42,14 @@ func (*SDKMessagesRenderer) Render(_ context.Context, input RenderInput) (Render
 
 func renderSDKPayloadFromFrags(ordered []contextfrag.ContextFrag) *SDKRenderedPayload {
 	payload := &SDKRenderedPayload{}
-	firstSystem := true
+	var previousSystemRender contextfrag.RenderPolicy
+	hasSystemFrag := false
 	for _, frag := range ordered {
 		switch frag.Slot {
 		case contextfrag.SlotSystem:
-			if !firstSystem {
-				payload.System += "\n\n"
-			}
-			firstSystem = false
-			for _, part := range frag.Parts {
-				if part.Type == contextfrag.PartText {
-					payload.System += part.Text
-				}
-			}
+			renderSystemFrag(payload, frag, previousSystemRender, hasSystemFrag)
+			previousSystemRender = frag.Render
+			hasSystemFrag = true
 		case contextfrag.SlotCurrentUser:
 			renderCurrentUserFrag(payload, frag)
 		default:
@@ -63,6 +58,22 @@ func renderSDKPayloadFromFrags(ordered []contextfrag.ContextFrag) *SDKRenderedPa
 	}
 	materializeRenderedCurrent(payload)
 	return payload
+}
+
+func renderSystemFrag(
+	payload *SDKRenderedPayload,
+	frag contextfrag.ContextFrag,
+	previous contextfrag.RenderPolicy,
+	hasPrevious bool,
+) {
+	if hasPrevious {
+		payload.System += contextfrag.RenderSeparator(previous, frag.Render)
+	}
+	for _, part := range frag.Parts {
+		if part.Type == contextfrag.PartText {
+			payload.System += part.Text
+		}
+	}
 }
 
 func orderedSelectedFrags(selected []contextfrag.ContextFrag, placement PlacementPlan) ([]contextfrag.ContextFrag, error) {

--- a/internal/contextview/render_sdk_test.go
+++ b/internal/contextview/render_sdk_test.go
@@ -36,6 +36,60 @@ func TestSDKRendererPreservesSystemSectionBytes(t *testing.T) {
 	}
 }
 
+func TestSDKRendererSystemRenderGroupsUseDeclaredJoiners(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		textFrag("system.prompt", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "prompt"),
+		groupedSystemTextFrag(
+			"system.platform_identity.header",
+			"system.platform_identity",
+			"\n",
+			"## Platform Identities\n\nKnown identities.\n",
+		),
+		groupedSystemTextFrag(
+			"system.platform_identity.telegram",
+			"system.platform_identity",
+			"\n",
+			`<identity channel="telegram" username="@memoh"/>`,
+		),
+		groupedSystemTextFrag(
+			"system.platform_identity.微信",
+			"system.platform_identity",
+			"\n",
+			`<identity channel="weixin" username="小明"/>`,
+		),
+		groupedSystemTextFrag(
+			"system.skills.header",
+			"system.skills",
+			"\n",
+			"## Skills\n\n2 skill(s) available:",
+		),
+		groupedSystemTextFrag("system.skill.alpha", "system.skills", "\n", "- **alpha**: first"),
+		groupedSystemTextFrag("system.skill.技能", "system.skills", "\n", "- **技能**: 第二"),
+		textFrag(
+			"system.workspace_file.AGENTS.md",
+			contextfrag.SlotSystem,
+			contextfrag.KindWorkspaceInstruction,
+			sdk.MessageRoleSystem,
+			"## AGENTS.md\n\ninstructions",
+		),
+	}
+
+	payload, _ := renderSDKPayload(t, frags, placementFor(frags))
+	want := "prompt\n\n" +
+		"## Platform Identities\n\nKnown identities.\n\n" +
+		"<identity channel=\"telegram\" username=\"@memoh\"/>\n" +
+		"<identity channel=\"weixin\" username=\"小明\"/>\n\n" +
+		"## Skills\n\n2 skill(s) available:\n" +
+		"- **alpha**: first\n" +
+		"- **技能**: 第二\n\n" +
+		"## AGENTS.md\n\ninstructions"
+	if payload.System != want {
+		t.Fatalf("system = %q, want grouped system bytes %q", payload.System, want)
+	}
+}
+
 func TestSDKRendererPreservesMessagesAndMaterializesRawCurrentInput(t *testing.T) {
 	t.Parallel()
 	query := "  current request \n"
@@ -118,4 +172,18 @@ func assertMessagesEqual(t *testing.T, got, want []sdk.Message) {
 	if string(gotJSON) != string(wantJSON) {
 		t.Fatalf("messages = %s, want %s", gotJSON, wantJSON)
 	}
+}
+
+func groupedSystemTextFrag(id, groupID, joiner, text string) contextfrag.ContextFrag {
+	return contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: id, Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem,
+		Slot: contextfrag.SlotSystem, Text: text, Priority: 20,
+		CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustSystem,
+		Source: "test", Collector: "test",
+		Render: contextfrag.RenderPolicy{
+			Format:      contextfrag.RenderMarkdown,
+			GroupID:     groupID,
+			GroupJoiner: joiner,
+		},
+	})
 }

--- a/internal/contextview/selector.go
+++ b/internal/contextview/selector.go
@@ -5,14 +5,25 @@ import contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 type FragmentSelector struct{}
 
 func (*FragmentSelector) ProfileFor(intent contextfrag.Intent) IntentProfile {
-	if intent != contextfrag.IntentRunConfigPreProvider {
+	switch intent {
+	case contextfrag.IntentRunConfigPreProvider, contextfrag.IntentDiscussReply:
+		return IntentProfile{
+			Intent:          intent,
+			MustKeepSlots:   []contextfrag.Slot{contextfrag.SlotCurrentUser},
+			MustKeepFrag:    mustKeepProviderSystemFrag,
+			SlotTrustFloors: map[contextfrag.Slot]contextfrag.TrustLevel{contextfrag.SlotSystem: contextfrag.TrustWorkspace},
+		}
+	default:
 		return IntentProfile{Intent: intent}
 	}
-	return IntentProfile{
-		Intent:          intent,
-		MustKeepSlots:   []contextfrag.Slot{contextfrag.SlotSystem, contextfrag.SlotCurrentUser},
-		SlotTrustFloors: map[contextfrag.Slot]contextfrag.TrustLevel{contextfrag.SlotSystem: contextfrag.TrustWorkspace},
-	}
+}
+
+// mustKeepProviderSystemFrag keeps history-budget selection from claiming
+// authority over system fragments. A later system-budget pass may apply the
+// retention tier, but every system fragment surviving that pass remains
+// protected here.
+func mustKeepProviderSystemFrag(frag contextfrag.ContextFrag) bool {
+	return frag.Slot == contextfrag.SlotSystem
 }
 
 func (*FragmentSelector) Select(frags []contextfrag.ContextFrag, profile IntentProfile, budget BudgetEnvelope) SelectionResult {
@@ -116,6 +127,9 @@ func conflictBeats(challenger, incumbent contextfrag.ContextFrag) bool {
 
 func isMustKeepFrag(frag contextfrag.ContextFrag, profile IntentProfile) bool {
 	if frag.Budget.Overflow == contextfrag.OverflowKeep {
+		return true
+	}
+	if profile.MustKeepFrag != nil && profile.MustKeepFrag(frag) {
 		return true
 	}
 	for _, slot := range profile.MustKeepSlots {

--- a/internal/contextview/selector_policy_test.go
+++ b/internal/contextview/selector_policy_test.go
@@ -1,0 +1,150 @@
+package contextview
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestProviderSystemMustKeepUsesPerFragmentPolicy(t *testing.T) {
+	t.Parallel()
+
+	intents := []contextfrag.Intent{
+		contextfrag.IntentRunConfigPreProvider,
+		contextfrag.IntentDiscussReply,
+	}
+	tiers := []contextfrag.RetentionTier{
+		contextfrag.RetentionUnspecified,
+		contextfrag.RetentionRequired,
+		contextfrag.RetentionPreferred,
+		contextfrag.RetentionOptional,
+	}
+	selector := &FragmentSelector{}
+	for _, intent := range intents {
+		profile := selector.ProfileFor(intent)
+		if slotInMustKeepSlots(profile, contextfrag.SlotSystem) {
+			t.Fatalf("%s MustKeepSlots = %#v, system must use the per-fragment seam", intent, profile.MustKeepSlots)
+		}
+		if !slotInMustKeepSlots(profile, contextfrag.SlotCurrentUser) {
+			t.Fatalf("%s MustKeepSlots = %#v, want current_user", intent, profile.MustKeepSlots)
+		}
+		for _, tier := range tiers {
+			frag := contextfrag.ContextFrag{Slot: contextfrag.SlotSystem, RetentionTier: tier}
+			if !isMustKeepFrag(frag, profile) {
+				t.Fatalf("%s system retention %q must remain kept before the system-budget pass exists", intent, tier)
+			}
+		}
+	}
+}
+
+func TestProviderHistoryBudgetNeverDropsSystemFragments(t *testing.T) {
+	t.Parallel()
+
+	intents := []contextfrag.Intent{
+		contextfrag.IntentRunConfigPreProvider,
+		contextfrag.IntentDiscussReply,
+	}
+	tiers := []contextfrag.RetentionTier{
+		contextfrag.RetentionUnspecified,
+		contextfrag.RetentionRequired,
+		contextfrag.RetentionPreferred,
+		contextfrag.RetentionOptional,
+	}
+	selector := &FragmentSelector{}
+	for _, intent := range intents {
+		for _, tier := range tiers {
+			system := contextfrag.TextFrag(contextfrag.TextFragInput{
+				ID: "system", Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem,
+				Slot: contextfrag.SlotSystem, Text: "oversized system", RetentionTier: tier,
+				Trust:  contextfrag.TrustSystem,
+				Budget: contextfrag.BudgetPolicy{MaxChars: 1, Overflow: contextfrag.OverflowDrop},
+			})
+			history := contextfrag.TextFrag(contextfrag.TextFragInput{
+				ID: "history", Kind: contextfrag.KindConversationEvent, Role: sdk.MessageRoleUser,
+				Slot: contextfrag.SlotHistory, Text: "oversized history", Trust: contextfrag.TrustExternal,
+				Budget: contextfrag.BudgetPolicy{MaxChars: 1, Overflow: contextfrag.OverflowDrop},
+			})
+			result := selector.Select(
+				[]contextfrag.ContextFrag{system, history},
+				selector.ProfileFor(intent),
+				BudgetEnvelope{},
+			)
+
+			if !containsFragID(result.Selected, "system") {
+				t.Fatalf("%s system retention %q was dropped: %#v", intent, tier, result.Dropped)
+			}
+			if !containsFragID(result.Dropped, "history") {
+				t.Fatalf("%s retention %q did not exercise droppable history: %#v", intent, tier, result)
+			}
+		}
+	}
+}
+
+func TestLegacySystemReverseParsersStampRequired(t *testing.T) {
+	t.Parallel()
+
+	const toolUsage = "## Tool usage\nUse tools carefully."
+	const system = "Base system prompt.\n\n" + toolUsage + "\n\nTail guidance."
+	collected, err := (&SystemPromptCollector{}).Collect(context.Background(), CollectRequest{
+		Intent: contextfrag.IntentRunConfigPreProvider,
+		Config: SystemPromptConfig{System: system, ToolUsage: toolUsage},
+	})
+	if err != nil {
+		t.Fatalf("collect system prompt: %v", err)
+	}
+	compiled := contextfrag.CompileFrags(contextfrag.CompileInput{System: system, ToolUsage: toolUsage})
+	for name, frags := range map[string][]contextfrag.ContextFrag{
+		"collector": collected,
+		"compiler":  compiled,
+	} {
+		if len(frags) != 3 {
+			t.Fatalf("%s fragments = %d, want 3", name, len(frags))
+		}
+		for _, frag := range frags {
+			if frag.RetentionTier != contextfrag.RetentionRequired {
+				t.Fatalf("%s fragment %s retention = %q, want required", name, frag.ID, frag.RetentionTier)
+			}
+		}
+	}
+
+	raw, err := (&SystemPromptCollector{}).Collect(context.Background(), CollectRequest{
+		Intent: contextfrag.IntentRunConfigPreProvider,
+		Config: SystemPromptConfig{System: "  byte-exact system \n"},
+	})
+	if err != nil {
+		t.Fatalf("collect byte-exact system prompt: %v", err)
+	}
+	if len(raw) != 1 || raw[0].RetentionTier != contextfrag.RetentionRequired {
+		t.Fatalf("byte-exact fallback fragments = %#v, want one required fragment", raw)
+	}
+}
+
+func TestToolUsageFragIsPreferred(t *testing.T) {
+	t.Parallel()
+
+	frag := ToolUsageFrag("use tools", contextfrag.Scope{})
+	if frag.RetentionTier != contextfrag.RetentionPreferred {
+		t.Fatalf("tool usage retention = %q, want preferred", frag.RetentionTier)
+	}
+}
+
+func slotInMustKeepSlots(profile IntentProfile, slot contextfrag.Slot) bool {
+	for _, candidate := range profile.MustKeepSlots {
+		if candidate == slot {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFragID(frags []contextfrag.ContextFrag, id string) bool {
+	for _, frag := range frags {
+		if frag.ID == id {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION

## What changes

Typed context fragments now carry system-section retention, drop priority, required capability, and grouped-render metadata. Provider and discuss selection keep system fragments individually, while skills, platform identities, workspace files, and tool guidance render as stable per-item sections without changing their established order or separators.

Provider preflight gates guidance only when the fragments-first tool roster is authoritative. Unknown rosters and legacy input remain ungated. When a capability is unavailable, the gate removes its guidance without adding provider-visible markers, keeps group headers only while a member survives, and records content-light selection and mutation audit data. The fallback path cannot restore gated text.

With every capability available, the provider payload remains byte-identical to upstream main, including all five prompt modes and Unicode dynamic content.

## Scope

This PR contains the fragment policy vocabulary, per-fragment system retention, grouped SDK rendering, structured platform identities and tool guidance, resolved-roster tracking, capability gating, and fallback audit behavior.

It does not add context budgeting, estimators, markers, typed discuss transport, hook or provider-attempt state, lifecycle persistence, prompt text changes, or ACP and compaction policy changes.

This is part 2 of the landing work motivated by #890. It builds on the compiler merged in #959 but does not close #890.

## Verification

The following checks passed on `5b685c979`:

- `go build ./...`
- `go test -count=1 ./...`
- `golangci-lint run` on all touched Go packages
- Full tests for `internal/agent/context/fragment`, `internal/contextview`, `internal/agent/runtime/native`, and `internal/agent/application`
- The focused PR2 policy, grouped-rendering, capability-gating, fallback-audit, and provider byte-equivalence suite
- `git diff --check upstream-main-snapshot..HEAD`
- `git range-diff 10a350d12..5f455048e upstream-main-snapshot..HEAD`

## Landing stack

| PR | Scope |
| --- | --- |
| PR1 (merged #959) | Fragments-first authoritative compiler with byte-equivalent provider output |
| PR2 (this PR) | System-section retention, drop policy, grouped rendering, and capability gating |
| PR3 | Unified `ContextBudgetPlan` and budget-aware behavior for all five modes |
| PR4 | Hook authority split and provider-attempt preflight |
| PR5 (merged #960) | Runtime decision correctness and fencing for #865 |
| PR6 | Run-keyed lifecycle persistence and read ownership |
| PR7 | Prompt shrink, baselines, and repository-level gates |
| PR8 | Cross-stack lifecycle, budget, fallback, and tool-roster integration seams |