### PR TITLE
fix(web): persist full query cache with recursive secret strip

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,6 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@fontsource-variable/inter": "^5.2.8",
     "@memohai/runtime": "workspace:*",
-    "@pinia/colada-plugin-cache-persister": "0.1.3",
     "electron-updater": "^6.6.2"
   },
   "devDependencies": {

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -5,7 +5,7 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import { PiniaColada, useQueryCache } from '@pinia/colada'
-import { PiniaColadaCachePersister, isCacheReady } from '@pinia/colada-plugin-cache-persister'
+import { createQueryCachePersistencePlugin, whenQueryCacheRestored } from '@memohai/web/lib/query-cache-persistence'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 
 import { watchEffect } from 'vue'
@@ -19,7 +19,6 @@ import { registerWorkspaceTabCommands } from '@memohai/web/pages/home/commands/w
 import { useWorkspaceTabsStore } from '@memohai/web/store/workspace-tabs'
 import { useKeyboardShortcutsStore } from '@memohai/web/store/keyboard-shortcuts'
 import { useChatStore } from '@memohai/web/store/chat-list'
-import { QUERY_CACHE_STORAGE_KEY, queryCachePersistFilter } from '@memohai/web/lib/query-cache-persistence'
 import { normalizeDesktopThemeSource } from '../../shared/theme'
 
 import '@fontsource-variable/inter'
@@ -127,10 +126,7 @@ async function bootstrap() {
       plugins: [
         // Same cross-reload snapshot as the web app (see
         // @memohai/web/lib/query-cache-persistence.ts).
-        PiniaColadaCachePersister({
-          key: QUERY_CACHE_STORAGE_KEY,
-          filter: queryCachePersistFilter,
-        }),
+        createQueryCachePersistencePlugin(),
       ],
     })
     .use(router)
@@ -180,7 +176,7 @@ async function bootstrap() {
 
   // Mount only after the snapshot is hydrated so the first render already
   // has the last-known values (storage is sync, so this resolves fast).
-  await isCacheReady()
+  await whenQueryCacheRestored()
   app.mount('#app')
 
   // The first frame stays optimistic: render the normal auth/app route while

--- a/apps/desktop/src/renderer/types/web-stubs.d.ts
+++ b/apps/desktop/src/renderer/types/web-stubs.d.ts
@@ -300,9 +300,18 @@ declare module '@memohai/web/lib/auth-session' {
 }
 
 declare module '@memohai/web/lib/query-cache-persistence' {
-  import type { UseQueryEntryFilter } from '@pinia/colada'
+  import type { PiniaColadaPlugin, QueryCache, UseQueryEntryFilter } from '@pinia/colada'
   export const QUERY_CACHE_STORAGE_KEY: string
-  export const queryCachePersistFilter: UseQueryEntryFilter
+  export const persistableQueryFilter: UseQueryEntryFilter
+  export function createQueryCachePersistencePlugin(options?: {
+    key?: string
+    storage?: Storage
+    debounce?: number
+  }): PiniaColadaPlugin
+  export function whenQueryCacheRestored(): Promise<void>
+  export function saveQueryCacheToDiskNow(queryCache: QueryCache, storage?: Storage): void
+  export function removeQueryCacheFromDisk(storage?: Storage): void
+  export function cancelPendingQueryCacheSave(): void
 }
 
 declare module '@memohai/web/pages/login/transition' {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,6 @@
     "@memohai/icon": "workspace:*",
     "@memohai/sdk": "workspace:*",
     "@pinia/colada": "^0.21.2",
-    "@pinia/colada-plugin-cache-persister": "0.1.3",
     "@shikijs/transformers": "^4.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@tanstack/vue-table": "^8.21.3",

--- a/apps/web/src/lib/query-cache-persistence.test.ts
+++ b/apps/web/src/lib/query-cache-persistence.test.ts
@@ -1,69 +1,65 @@
-import { describe, expect, it } from 'vitest'
-import type { UseQueryEntry } from '@pinia/colada'
-import { QUERY_CACHE_STORAGE_KEY, queryCachePersistFilter } from './query-cache-persistence'
+import { describe, expect, it, vi } from 'vitest'
+import type { QueryCache, UseQueryEntry } from '@pinia/colada'
+import {
+  QUERY_CACHE_STORAGE_KEY,
+  cancelPendingQueryCacheSave,
+  persistableQueryFilter,
+  removeQueryCacheFromDisk,
+  saveQueryCacheToDiskNow,
+} from './query-cache-persistence'
 
-// The predicate only reads entry.key[0] and entry.state.value.status, so a
-// minimal stub beats constructing a full UseQueryEntry.
-function entryWith(key: readonly unknown[], status: 'success' | 'pending' | 'error' = 'success') {
-  return { key, state: { value: { status } } } as unknown as UseQueryEntry
+function entryWith(
+  key: readonly unknown[],
+  status: 'success' | 'pending' | 'error' = 'success',
+  data: unknown = { id: 'x' },
+) {
+  return { key, keyHash: JSON.stringify(key), state: { value: { status, data } } } as unknown as UseQueryEntry
 }
 
-const { predicate } = queryCachePersistFilter as {
+function memoryStorage(initial?: Record<string, string>) {
+  return {
+    data: new Map<string, string>(Object.entries(initial ?? {})),
+    setItem(k: string, v: string) { this.data.set(k, v) },
+    removeItem(k: string) { this.data.delete(k) },
+    getItem(k: string) { return this.data.get(k) ?? null },
+  } as unknown as Storage
+}
+
+function cacheWith(entries: UseQueryEntry[]) {
+  return { getEntries: vi.fn(() => entries) } as unknown as QueryCache
+}
+
+const { predicate } = persistableQueryFilter as {
   predicate: (entry: UseQueryEntry) => boolean
 }
 
-describe('queryCachePersistFilter', () => {
-  it('persists whitelisted catalog and config namespaces', () => {
-    const allowed = [
+describe('persistableQueryFilter', () => {
+  it('persists every successful query by default, catalogs and providers included', () => {
+    const persisted = [
       ['models'],
       ['providers'],
-      ['provider-models', 'provider-1'],
-      ['memory-providers'],
-      ['search-providers-meta'],
-      ['speech-provider-models', 'sp-1'],
-      ['transcription-providers'],
-      ['video-provider-detail', 'vp-1'],
-      ['acp-profiles'],
-      ['channels'],
-      ['connectors-catalog'],
-      ['remote-runtimes'],
-      ['platform'],
-      ['bot', 'bot-1'],
       ['bot-settings', 'bot-1'],
-    ]
-    for (const key of allowed) {
-      expect(predicate(entryWith(key)), `expected ${key[0]} to persist`).toBe(true)
-    }
-  })
-
-  it('persists the SDK-object bots list key', () => {
-    expect(predicate(entryWith([{ _id: 'getBots', baseUrl: 'http://x' }]))).toBe(true)
-  })
-
-  it('rejects volatile and unknown namespaces', () => {
-    const rejected = [
-      ['session-status', 'b', 's'],
-      ['session-subagents', 'b', 's'],
-      ['token-usage', 'b'],
-      ['bot-email-outbox', 'b'],
-      ['bot-container-overview', 'b'],
-      ['bot-display-info', 'b'],
-      ['bot-network-status', 'b'],
-      ['bot-memory-status', 'b'],
-      ['my-channel-identities'],
-      ['user-has-im-bot'],
+      ['bot', 'qf-2'],
+      ['fetch-providers'],
+      ['memory-providers'],
+      ['search-providers'],
+      ['speech-providers'],
+      ['video-providers'],
+      [{ _id: 'getBots', baseUrl: 'http://x' }],
       ['something-new'],
     ]
-    for (const key of rejected) {
-      expect(predicate(entryWith(key)), `expected ${key[0]} to be excluded`).toBe(false)
+    for (const key of persisted) {
+      expect(predicate(entryWith(key)), `expected ${String(key[0])} to persist`).toBe(true)
     }
   })
 
-  it('rejects object keys with other operations', () => {
-    expect(predicate(entryWith([{ _id: 'getBotsByBotIdSessions', baseUrl: 'http://x' }]))).toBe(false)
+  it('excludes whole-payload secrets and volatile state', () => {
+    for (const key of [['remote-runtimes'], ['session-status', 'b', 's']]) {
+      expect(predicate(entryWith(key)), `expected ${String(key[0])} to be excluded`).toBe(false)
+    }
   })
 
-  it('rejects non-success entries even for whitelisted keys', () => {
+  it('rejects non-success entries', () => {
     expect(predicate(entryWith(['models'], 'pending'))).toBe(false)
     expect(predicate(entryWith(['models'], 'error'))).toBe(false)
   })
@@ -72,5 +68,111 @@ describe('queryCachePersistFilter', () => {
 describe('QUERY_CACHE_STORAGE_KEY', () => {
   it('is the contract auth-session.ts clears on auth changes', () => {
     expect(QUERY_CACHE_STORAGE_KEY).toBe('memoh:query-cache')
+  })
+})
+
+describe('saveQueryCacheToDiskNow', () => {
+  it('persists provider lists and strips secrets recursively', () => {
+    const storage = memoryStorage()
+    const fetchProviders = entryWith(['fetch-providers'], 'success', [
+      { id: 'p1', name: 'WeakReference', provider: 'native', config: { api_key: 'sk-1', timeout: 30 } },
+    ])
+    const memoryProviders = entryWith(['memory-providers'], 'success', [
+      { id: 'm1', name: 'MemoryProvider', provider: 'builtin', config: { memory_mode: 'graph', token: 't-1' } },
+    ])
+
+    saveQueryCacheToDiskNow(cacheWith([fetchProviders, memoryProviders]), storage)
+    const raw = storage.getItem(QUERY_CACHE_STORAGE_KEY)
+    expect(raw).toBeTruthy()
+    // Display fields survive…
+    expect(raw).toContain('WeakReference')
+    expect(raw).toContain('MemoryProvider')
+    expect(raw).toContain('memory_mode')
+    expect(raw).toContain('timeout')
+    // …secrets do not.
+    expect(raw).not.toContain('sk-1')
+    expect(raw).not.toContain('t-1')
+    expect(raw).not.toContain('api_key')
+    expect(raw).not.toContain('token')
+  })
+
+  it('strips nested bot metadata secrets but keeps display fields', () => {
+    const storage = memoryStorage()
+    const bot = entryWith(['bot', 'qf-2'], 'success', {
+      id: 'bot-uuid',
+      name: 'qf-2',
+      metadata: { acp: { api_key: 'secret', agent: 'claude' } },
+    })
+
+    saveQueryCacheToDiskNow(cacheWith([bot]), storage)
+    const raw = storage.getItem(QUERY_CACHE_STORAGE_KEY)
+    expect(raw).toContain('bot-uuid')
+    expect(raw).toContain('qf-2')
+    expect(raw).toContain('agent')
+    expect(raw).not.toContain('secret')
+    expect(raw).not.toContain('api_key')
+  })
+
+  it('never strips look-alike display fields (author, oauth_provider)', () => {
+    const storage = memoryStorage()
+    const entry = entryWith(['models'], 'success', [
+      { id: 'm1', name: 'gpt', author: 'openai', oauth_provider: 'github' },
+    ])
+
+    saveQueryCacheToDiskNow(cacheWith([entry]), storage)
+    const raw = storage.getItem(QUERY_CACHE_STORAGE_KEY)
+    expect(raw).toContain('author')
+    expect(raw).toContain('oauth_provider')
+  })
+
+  it('strips real-world secret variants (bot_token, appSecret, secret_key, OPENAI_API_KEY)', () => {
+    const storage = memoryStorage()
+    const entry = entryWith(['channels'], 'success', {
+      credentials: { bot_token: 'tg-1', appSecret: 'wx-1', secret_key: 'tx-1' },
+      env: { OPENAI_API_KEY: 'sk-1' },
+      usage: { token_count: 12, total_tokens: 30 },
+      client_id: 'public-id',
+    })
+
+    saveQueryCacheToDiskNow(cacheWith([entry]), storage)
+    const raw = storage.getItem(QUERY_CACHE_STORAGE_KEY)
+    for (const leaked of ['tg-1', 'wx-1', 'tx-1', 'sk-1', 'bot_token', 'appSecret', 'secret_key', 'OPENAI_API_KEY']) {
+      expect(raw).not.toContain(leaked)
+    }
+    // Token *statistics* and public identifiers are display data, not secrets.
+    expect(raw).toContain('token_count')
+    expect(raw).toContain('total_tokens')
+    expect(raw).toContain('client_id')
+  })
+
+  it('does not persist excluded keys', () => {
+    const storage = memoryStorage()
+    const entries = [
+      entryWith(['remote-runtimes'], 'success', { key: 'runtime-key' }),
+      entryWith(['session-status', 'b', 's']),
+    ]
+
+    saveQueryCacheToDiskNow(cacheWith(entries), storage)
+    expect(storage.getItem(QUERY_CACHE_STORAGE_KEY)).toBeNull()
+  })
+
+  it('removes the storage key when nothing qualifies', () => {
+    const storage = memoryStorage({ [QUERY_CACHE_STORAGE_KEY]: '{}' })
+    saveQueryCacheToDiskNow(cacheWith([entryWith(['remote-runtimes'])]), storage)
+    expect(storage.getItem(QUERY_CACHE_STORAGE_KEY)).toBeNull()
+  })
+})
+
+describe('removeQueryCacheFromDisk', () => {
+  it('drops the on-disk copy', () => {
+    const storage = memoryStorage({ [QUERY_CACHE_STORAGE_KEY]: '{}' })
+    removeQueryCacheFromDisk(storage)
+    expect(storage.getItem(QUERY_CACHE_STORAGE_KEY)).toBeNull()
+  })
+})
+
+describe('cancelPendingQueryCacheSave', () => {
+  it('is callable without throwing', () => {
+    expect(() => cancelPendingQueryCacheSave()).not.toThrow()
   })
 })

--- a/apps/web/src/lib/query-cache-persistence.test.ts
+++ b/apps/web/src/lib/query-cache-persistence.test.ts
@@ -53,8 +53,8 @@ describe('persistableQueryFilter', () => {
     }
   })
 
-  it('excludes whole-payload secrets and volatile state', () => {
-    for (const key of [['remote-runtimes'], ['session-status', 'b', 's']]) {
+  it('excludes whole-payload secrets, volatile state, and opaque workspace files', () => {
+    for (const key of [['remote-runtimes'], ['session-status', 'b', 's'], ['bot-hooks-config', 'bot-1']]) {
       expect(predicate(entryWith(key)), `expected ${String(key[0])} to be excluded`).toBe(false)
     }
   })
@@ -150,6 +150,7 @@ describe('saveQueryCacheToDiskNow', () => {
     const entries = [
       entryWith(['remote-runtimes'], 'success', { key: 'runtime-key' }),
       entryWith(['session-status', 'b', 's']),
+      entryWith(['bot-hooks-config', 'bot-1'], 'success', '{"env":{"OPENAI_API_KEY":"sk-1"}}'),
     ]
 
     saveQueryCacheToDiskNow(cacheWith(entries), storage)

--- a/apps/web/src/lib/query-cache-persistence.ts
+++ b/apps/web/src/lib/query-cache-persistence.ts
@@ -1,96 +1,198 @@
-import type { UseQueryEntryFilter } from '@pinia/colada'
+import {
+  _queryEntry_toJSON as queryEntryToJSON,
+  hydrateQueryCache,
+  type PiniaColadaPlugin,
+  type QueryCache,
+  type UseQueryEntryFilter,
+} from '@pinia/colada'
 
 /**
- * Cross-reload persistence for the Pinia Colada query cache.
+ * Persist Pinia Colada query results to localStorage across reloads (#936 / #950).
  *
- * The cache is memory-only by default, so a hard refresh cold-starts every
- * useQuery and settings pages render placeholders for at least one RTT
- * (visible against any remote server, and on every desktop app launch).
- * The persister plugin snapshots WHITELISTED entries to localStorage and
- * rehydrates them on boot. Hydrated entries are always older than the
- * default 5s staleTime, so colada revalidates them in the background on
- * mount (SWR) — the snapshot only owes the first paint; correctness always
- * comes from the network.
+ * Three layers to keep in mind:
+ * 1. In-memory query cache — live API results inside the SPA session.
+ * 2. localStorage (`memoh:query-cache`) — display-safe copy that survives Cmd+R.
+ * 3. Server — source of truth; Colada revalidates stale entries in the background.
  *
- * Whitelist, never blacklist: a query is only persisted when named here, so
- * newly added queries default to safe. Only semi-static catalog/config data
- * qualifies — its writes flow through this app's mutations (which re-persist
- * via the plugin), and out-of-band writes (channel slash commands, other
- * devices) converge on the next mount revalidation. Volatile data (sessions,
- * usage, container/status, outbox) stays out: freshness matters more than
- * first paint there, and its invalidation surface is much larger.
+ * Every successful query persists by default; on write, `deepStripSecrets`
+ * recursively removes secret-bearing fields (api_key, token, …) so provider
+ * configs and bot metadata never reach disk, while display fields (id, name,
+ * provider, memory_mode, …) survive and hydrate the first paint. Only keys on
+ * EXCLUDED_QUERY_KEY_HEADS (entire-payload secrets, volatile state) skip disk.
+ *
+ * After a successful save in-app, call `saveQueryCacheToDiskNow()` so a quick
+ * reload does not show a pre-save value (see bot-settings autosave).
  */
 
-/**
- * localStorage key shared by the web app and the desktop renderer. Cleared
- * with the other user-scoped keys on login/logout/token-cleared/unauthorized
- * — see USER_SCOPED_STORAGE_KEYS in lib/auth-session.ts.
- */
 export const QUERY_CACHE_STORAGE_KEY = 'memoh:query-cache'
 
+const SAVE_TO_DISK_DEBOUNCE_MS = 1000
+
 /**
- * First key segment (the string namespace) of every query allowed to
- * persist. Keep in sync with the real call sites: a name no query uses is a
- * harmless no-op, a missing name means that query never persists.
+ * Keys that never touch disk: either the whole payload is a credential
+ * (remote-runtimes) or the data is volatile session state, not display data.
  */
-const PERSISTED_QUERY_KEY_HEADS: ReadonlySet<string> = new Set([
-  // Global catalogs
-  'models',
-  'providers',
-  'provider-models',
-  'provider-templates',
-  'provider-template-models',
-  'memory-providers',
-  'memory-providers-meta',
-  'email-providers',
-  'email-providers-meta',
-  'search-providers',
-  'search-providers-meta',
-  'fetch-providers',
-  'fetch-providers-meta',
-  'speech-providers',
-  'speech-providers-meta',
-  'speech-provider-detail',
-  'speech-provider-models',
-  'transcription-providers',
-  'transcription-providers-meta',
-  'transcription-provider-detail',
-  'transcription-provider-models',
-  'video-providers',
-  'video-providers-meta',
-  'video-provider-detail',
-  'video-provider-models',
-  'acp-profiles',
-  'channels',
-  'connectors-catalog',
-  'network-providers-meta',
+const EXCLUDED_QUERY_KEY_HEADS: ReadonlySet<string> = new Set([
   'remote-runtimes',
-  'platform',
-  // Per-bot identity + settings — the Bot Settings cold-start flash reads
-  // its model UUID from 'bot-settings' and the display name from 'models'.
-  'bot',
-  'bot-settings',
+  'session-status',
 ])
 
 /**
- * The bots list is the one query keyed by the SDK-generated object form
- * ([{ _id: 'getBots', baseUrl, … }]) instead of a string namespace.
+ * Suffix/segment match on the normalized (snake_case, lowercase) key, so
+ * real-world variants — bot_token, app_secret, secret_key, OPENAI_API_KEY,
+ * appSecret — all strip, while display fields like `author`, `oauth_provider`,
+ * `token_count`, `total_tokens`, `public_key` survive untouched.
  */
-function isBotsListKeyHead(head: unknown): boolean {
-  return typeof head === 'object' && head !== null
-    && (head as { _id?: unknown })._id === 'getBots'
+const SECRET_FIELD_PATTERN = /(^|_)(api_?key|apikey|token|password|passwd|private_?key|credentials?|authorization|auth_?token|bearer)$|^secret(_|$)|_secret(_|$)/
+
+function isSecretField(key: string): boolean {
+  const normalized = key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+  return SECRET_FIELD_PATTERN.test(normalized)
 }
 
-/**
- * Persistence filter for PiniaColadaCachePersister: which entries are
- * written to and restored from the snapshot. Error/pending entries are
- * excluded so a transient failure never gets frozen into the snapshot.
- */
-export const queryCachePersistFilter: UseQueryEntryFilter = {
+function deepStripSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(deepStripSecrets)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => !isSecretField(key))
+        .map(([key, val]) => [key, deepStripSecrets(val)]),
+    )
+  }
+  return value
+}
+
+export const persistableQueryFilter: UseQueryEntryFilter = {
   predicate: (entry) => {
     if (entry.state.value.status !== 'success') return false
     const head = entry.key[0]
-    if (typeof head === 'string') return PERSISTED_QUERY_KEY_HEADS.has(head)
-    return isBotsListKeyHead(head)
+    // SDK object keys ({ _id: 'getBots', … }) persist like everything else;
+    // their secrets are stripped on write, not filtered here.
+    if (typeof head !== 'string') return true
+    return !EXCLUDED_QUERY_KEY_HEADS.has(head)
   },
+}
+
+function serializeEntryForDisk(entry: { key: readonly unknown[]; keyHash: string; state: { value: { status: string } } }): [string, unknown] {
+  const json = queryEntryToJSON(entry as Parameters<typeof queryEntryToJSON>[0]) as unknown[]
+  if (json.length === 0) return [entry.keyHash, json]
+  return [entry.keyHash, [deepStripSecrets(json[0]), ...json.slice(1)]]
+}
+
+function serializePersistableEntries(queryCache: QueryCache): Record<string, unknown> {
+  const entries = queryCache.getEntries({ status: 'success' })
+  const { predicate } = persistableQueryFilter as { predicate?: (entry: (typeof entries)[number]) => boolean }
+  const persistable = predicate ? entries.filter(predicate) : entries
+  return Object.fromEntries(
+    persistable.map((entry) => serializeEntryForDisk(entry)),
+  )
+}
+
+/** Write the in-memory cache (secrets stripped) to localStorage immediately, skipping debounce. */
+export function saveQueryCacheToDiskNow(
+  queryCache: QueryCache,
+  storage: Storage | undefined = typeof localStorage !== 'undefined' ? localStorage : undefined,
+) {
+  if (!storage) return
+  const serialized = serializePersistableEntries(queryCache)
+  if (Object.keys(serialized).length === 0) {
+    storage.removeItem(QUERY_CACHE_STORAGE_KEY)
+    return
+  }
+  storage.setItem(QUERY_CACHE_STORAGE_KEY, JSON.stringify(serialized))
+}
+
+/** Remove the on-disk copy; in-memory query cache is untouched. */
+export function removeQueryCacheFromDisk(
+  storage: Storage | undefined = typeof localStorage !== 'undefined' ? localStorage : undefined,
+) {
+  storage?.removeItem(QUERY_CACHE_STORAGE_KEY)
+}
+
+let restoreResolve: (() => void) | undefined
+let restorePromise: Promise<void> = new Promise((resolve) => {
+  restoreResolve = resolve
+})
+
+/** Resolves after localStorage has been read into the in-memory query cache. */
+export function whenQueryCacheRestored(): Promise<void> {
+  return restorePromise
+}
+
+/** @internal Vitest-only reset for whenQueryCacheRestored(). */
+export function resetQueryCacheRestoreForTests() {
+  restorePromise = new Promise((resolve) => {
+    restoreResolve = resolve
+  })
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | undefined
+let saveAgainAfterCurrent = false
+let activeStorage: Storage | undefined
+let activeQueryCache: QueryCache | undefined
+
+function scheduleDebouncedSaveToDisk() {
+  if (!activeStorage || !activeQueryCache) return
+  if (saveTimer) {
+    saveAgainAfterCurrent = true
+    return
+  }
+  saveTimer = setTimeout(() => {
+    saveQueryCacheToDiskNow(activeQueryCache!, activeStorage)
+    saveTimer = undefined
+    if (saveAgainAfterCurrent) {
+      saveAgainAfterCurrent = false
+      scheduleDebouncedSaveToDisk()
+    }
+  }, SAVE_TO_DISK_DEBOUNCE_MS)
+}
+
+/** Cancel a pending debounced save (call before logout clears disk). */
+export function cancelPendingQueryCacheSave() {
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+    saveTimer = undefined
+  }
+  saveAgainAfterCurrent = false
+}
+
+/**
+ * Pinia Colada plugin: restore from localStorage on boot, debounce-save on change.
+ * Inlined from @pinia/colada-plugin-cache-persister so we can flush/cancel on demand.
+ */
+export function createQueryCachePersistencePlugin(options?: {
+  key?: string
+  storage?: Storage
+  debounce?: number
+}): PiniaColadaPlugin {
+  const key = options?.key ?? QUERY_CACHE_STORAGE_KEY
+  const storage = options?.storage ?? (typeof localStorage !== 'undefined' ? localStorage : undefined)
+  void options?.debounce // fixed at SAVE_TO_DISK_DEBOUNCE_MS; kept for API compat
+
+  return ({ queryCache }) => {
+    activeStorage = storage
+    activeQueryCache = queryCache
+
+    async function restoreFromDisk() {
+      if (!storage) {
+        restoreResolve?.()
+        return
+      }
+      try {
+        const stored = storage.getItem(key)
+        if (stored) hydrateQueryCache(queryCache, JSON.parse(stored))
+      } catch {
+        // Corrupt on-disk copy — cold start.
+      }
+      restoreResolve?.()
+    }
+
+    void restoreFromDisk()
+
+    queryCache.$onAction(({ name, after }) => {
+      if (name === 'setEntryState' || name === 'setQueryData' || name === 'remove') {
+        after(() => scheduleDebouncedSaveToDisk())
+      }
+    })
+  }
 }

--- a/apps/web/src/lib/query-cache-persistence.ts
+++ b/apps/web/src/lib/query-cache-persistence.ts
@@ -18,7 +18,8 @@ import {
  * recursively removes secret-bearing fields (api_key, token, …) so provider
  * configs and bot metadata never reach disk, while display fields (id, name,
  * provider, memory_mode, …) survive and hydrate the first paint. Only keys on
- * EXCLUDED_QUERY_KEY_HEADS (entire-payload secrets, volatile state) skip disk.
+ * EXCLUDED_QUERY_KEY_HEADS (entire-payload credentials, volatile state,
+ * opaque workspace file reads such as bot-hooks-config) skip disk.
  *
  * After a successful save in-app, call `saveQueryCacheToDiskNow()` so a quick
  * reload does not show a pre-save value (see bot-settings autosave).
@@ -35,6 +36,9 @@ const SAVE_TO_DISK_DEBOUNCE_MS = 1000
 const EXCLUDED_QUERY_KEY_HEADS: ReadonlySet<string> = new Set([
   'remote-runtimes',
   'session-status',
+  // Raw workspace file text (hooks.json env map may contain API keys); deepStripSecrets
+  // only walks objects/arrays and cannot redact secrets inside an opaque string.
+  'bot-hooks-config',
 ])
 
 /**

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -19,9 +19,8 @@ import { useKeyboardShortcutsStore } from './store/keyboard-shortcuts'
 import { createPinia } from 'pinia'
 import i18n from './i18n'
 import { PiniaColada } from '@pinia/colada'
-import { PiniaColadaCachePersister, isCacheReady } from '@pinia/colada-plugin-cache-persister'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
-import { QUERY_CACHE_STORAGE_KEY, queryCachePersistFilter } from './lib/query-cache-persistence'
+import { createQueryCachePersistencePlugin, whenQueryCacheRestored } from './lib/query-cache-persistence'
 import 'katex/dist/katex.min.css'
 
 setupApiClient({
@@ -63,10 +62,7 @@ const app = createApp(App)
     plugins: [
       // Persist whitelisted catalog/config queries across reloads; hydrated
       // entries revalidate on mount (see lib/query-cache-persistence.ts).
-      PiniaColadaCachePersister({
-        key: QUERY_CACHE_STORAGE_KEY,
-        filter: queryCachePersistFilter,
-      }),
+      createQueryCachePersistencePlugin(),
     ],
   })
   .use(router)
@@ -79,4 +75,4 @@ if (forceDesktopShell) {
 
 // Mount only after the snapshot is hydrated so the first render already has
 // the last-known values (storage is sync, so this resolves in a microtask).
-void isCacheReady().then(() => app.mount('#app'))
+void whenQueryCacheRestored().then(() => app.mount('#app'))

--- a/apps/web/src/pages/bots/components/bot-settings.vue
+++ b/apps/web/src/pages/bots/components/bot-settings.vue
@@ -123,6 +123,7 @@ import type { Ref } from 'vue'
 import { apiErrorStatus, parseMemohError, resolveApiErrorMessage } from '@/utils/api-error'
 import { useChatStore } from '@/store/chat-list'
 import { useAutosaveQueue, type AutosaveJob } from '@/composables/use-autosave-queue'
+import { saveQueryCacheToDiskNow } from '@/lib/query-cache-persistence'
 
 const props = defineProps<{
   botId: string
@@ -547,10 +548,28 @@ function buildJobs(changed: (keyof SettingsForm)[]): AutosaveJob<SettingsForm>[]
   return jobs
 }
 
+function patchFromAutosavedFields(savedKeys: Set<keyof SettingsForm>): SettingsSettings {
+  const patch: SettingsSettings = {}
+  for (const key of SETTINGS_FIELD_KEYS) {
+    if (savedKeys.has(key)) {
+      ;(patch as Record<string, unknown>)[key] = synced[key]
+    }
+  }
+  return patch
+}
+
 function onDrained(savedKeys: Set<keyof SettingsForm>) {
   const saved = [...savedKeys]
   if (saved.some((key) => key !== 'name' && key !== 'timezone')) {
-    queryCache.invalidateQueries({ key: ['bot-settings', botIdRef.value] })
+    const patch = patchFromAutosavedFields(savedKeys)
+    if (Object.keys(patch).length > 0) {
+      queryCache.setQueryData(['bot-settings', botIdRef.value], (current) => ({
+        ...(current ?? {}),
+        ...patch,
+      }))
+      saveQueryCacheToDiskNow(queryCache)
+    }
+    void queryCache.invalidateQueries({ key: ['bot-settings', botIdRef.value] })
   }
   if (savedKeys.has('name') || savedKeys.has('timezone')) {
     queryCache.invalidateQueries({ key: ['bot', botIdRef.value] })

--- a/apps/web/src/store/user.ts
+++ b/apps/web/src/store/user.ts
@@ -5,6 +5,7 @@ import { useRouter } from 'vue-router'
 import { useQueryCache } from '@pinia/colada'
 import { getUsersMe } from '@memohai/sdk'
 import { notifyAuthSessionCleared, onAuthSessionCleared, type AuthSessionClearReason } from '@/lib/auth-session'
+import { cancelPendingQueryCacheSave, removeQueryCacheFromDisk } from '@/lib/query-cache-persistence'
 import { resetOnboardingState } from '@/composables/useOnboarding'
 import { ONBOARDING_KEYS } from '@/pages/onboarding/constants'
 import { safeLocalRemove, safeSessionRemove } from '@/utils/safe-storage'
@@ -87,8 +88,10 @@ export const useUserStore = defineStore(
     }
 
     const clearFrontendSessionState = (reason: AuthSessionClearReason) => {
+      cancelPendingQueryCacheSave()
       clearQueryCache()
       notifyAuthSessionCleared(reason)
+      removeQueryCacheFromDisk()
     }
 
     const login = (userData: UserInfo, token: string) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       '@memohai/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
-      '@pinia/colada-plugin-cache-persister':
-        specifier: 0.1.3
-        version: 0.1.3(@pinia/colada@0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)))
       electron-updater:
         specifier: ^6.6.2
         version: 6.8.9
@@ -210,9 +207,6 @@ importers:
       '@pinia/colada':
         specifier: ^0.21.2
         version: 0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
-      '@pinia/colada-plugin-cache-persister':
-        specifier: 0.1.3
-        version: 0.1.3(@pinia/colada@0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)))
       '@shikijs/transformers':
         specifier: ^4.0.1
         version: 4.0.1
@@ -1663,11 +1657,6 @@ packages:
   '@peculiar/webcrypto@1.7.1':
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
-
-  '@pinia/colada-plugin-cache-persister@0.1.3':
-    resolution: {integrity: sha512-26feFaIernj0OgC7V3xKlkpmGtnuep19gVJQO7Vt0yBv3wV+gMKa27JavlaXasfbSPMDBzHwSZyrR4ii4y6SQw==}
-    peerDependencies:
-      '@pinia/colada': '>=0.21.1'
 
   '@pinia/colada@0.21.2':
     resolution: {integrity: sha512-k2epk1jed5cTmNA7l00UtsFRyqw9HfyU6WO4cV0BMUT3sSE4CMLCilprbLAL5h2bxD76WSiglciI/6o+Uh7Vzw==}
@@ -6695,10 +6684,6 @@ snapshots:
       '@peculiar/utils': 2.0.3
       tslib: 2.8.1
       webcrypto-core: 1.9.2
-
-  '@pinia/colada-plugin-cache-persister@0.1.3(@pinia/colada@0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)))':
-    dependencies:
-      '@pinia/colada': 0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
 
   '@pinia/colada@0.21.2(pinia@3.0.4(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
     dependencies:


### PR DESCRIPTION
## Summary

Follow-up to #950, closing the remaining gaps with #936:

- **Invert whitelist → persist-all + strip**: every successful query persists to `localStorage` by default; a single `deepStripSecrets` pass recursively removes secret-bearing fields on write (covers `api_key`, `bot_token`, `app_secret`/`appSecret`, `secret_key`, `OPENAI_API_KEY` variants), while display fields (`author`, `token_count`, `client_id`, `memory_mode`) survive. Only `remote-runtimes` (whole payload is a credential) and `session-status` (volatile) stay excluded.
- **Fixes remaining flashes**: General tab dropdowns backed by `fetch-providers` / `memory-providers` / `search-providers` / `speech-providers` / `video-providers` now hydrate on first paint, and slug URLs (`/bots/qf-2`) resolve `botId` from the persisted `bot` entry — no more one-frame placeholder.
- **Autosave → immediate reload consistency**: `bot-settings` calls `setQueryData` + `saveQueryCacheToDiskNow()` after a successful save, so a quick Cmd+R shows the just-saved value instead of the pre-save snapshot.
- **Logout hygiene**: cancel the pending debounced save before clearing, so `memoh:query-cache` is actually removed instead of being rewritten as `{}`.
- Inline the persister plugin (drop `@pinia/colada-plugin-cache-persister` dependency) to gain flush/cancel control.

## Test plan

- [x] Unit: 12 tests covering default-persist, exclusion list, recursive secret strip (nested/array/camelCase), look-alike display-field survival, logout helpers
- [x] Hard refresh on Bot Settings → General: Chat Model / Web Fetch / Memory Provider render first frame (30-frame rAF sampling, zero placeholder frames)
- [x] Tab switching across bot detail tabs (regression check for KeepAlive)
- [x] Logout: `memoh:query-cache` removed from localStorage
- [x] Disk snapshot contains no real credentials (only schema metadata like ACP `managed_fields`)