### PR TITLE
refactor(reasoning): give the capability layer one home

### DIFF
--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/memohai/memoh/internal/models"
 	"github.com/memohai/memoh/internal/oauthctx"
 	"github.com/memohai/memoh/internal/providers"
+	"github.com/memohai/memoh/internal/reasoning"
 	"github.com/memohai/memoh/internal/settings"
 	"github.com/memohai/memoh/internal/workspace"
 )
@@ -710,10 +711,6 @@ func (s *Service) buildBaseRunConfig(ctx context.Context, p baseRunConfigParams)
 	)
 
 	reasoningConfig := resolveReasoningConfig(chatModel, botSettings, p.ReasoningEffort, provider.ClientType)
-	reasoningEffort := ""
-	if reasoningConfig != nil && reasoningConfig.Active {
-		reasoningEffort = reasoningConfig.Effort
-	}
 
 	sdkModel := models.NewSDKChatModel(models.SDKModelConfig{
 		ModelID:               chatModel.ModelID,
@@ -748,11 +745,7 @@ func (s *Service) buildBaseRunConfig(ctx context.Context, p baseRunConfigParams)
 		CurrentModelUUID:      chatModel.ID,
 		CurrentModelID:        chatModel.ModelID,
 		CurrentModelProvider:  provider.Name,
-		ReasoningEffort:       reasoningEffort,
-		ReasoningActive:       reasoningConfig != nil && reasoningConfig.Active,
-		ReasoningDisabled:     reasoningConfig != nil && reasoningConfig.Disabled,
-		ReasoningAdaptive:     reasoningConfig != nil && reasoningConfig.Adaptive,
-		ReasoningOffEffort:    offEffortOrEmpty(reasoningConfig),
+		ReasoningConfig:       reasoningConfig,
 		ChatCompletionsCompat: chatCompletionsCompat,
 		PromptCacheTTL:        providers.ProviderConfigString(provider, "prompt_cache_ttl"),
 		SessionType:           p.SessionType,
@@ -826,177 +819,18 @@ func supportsFileInputForModel(m models.GetResponse) bool {
 	return m.HasCompatibility(models.CompatFileInput)
 }
 
-const (
-	reasoningEffortAdaptive = "adaptive"
-	reasoningEffortDisable  = models.ReasoningEffortDisable
-)
-
-// resolveReasoningConfig makes the single reasoning decision for a call, driven
-// by the model's discovered thinking mode plus the user's settings/override.
-//
-//   - none:     no thinking; returns nil.
-//   - adaptive: on/off; when active, Anthropic-style providers use adaptive
-//     thinking plus the selected effort.
-//   - toggle:   on/off, with per-message override taking precedence over the
-//     bot's default.
+// resolveReasoningConfig makes the single reasoning decision for a call. The
+// decision itself lives in internal/reasoning, which also answers what a picker
+// may offer — the two share internals so the options a user sees and the value a
+// call sends cannot disagree.
 func resolveReasoningConfig(chatModel models.GetResponse, botSettings settings.Settings, requestedEffort, clientType string) *models.ReasoningConfig {
-	mode := chatModel.ResolveThinkingMode()
-	if mode == models.ThinkingModeNone {
-		return nil
-	}
-
-	effortLevels := effectiveReasoningEfforts(chatModel.Config.ReasoningEfforts, clientType)
-	offEffort := offEffortFor(effortLevels)
-	requested := strings.TrimSpace(requestedEffort)
-	adaptive := mode == models.ThinkingModeAdaptive
-	// Anthropic 4.6+ uses the effort/adaptive wire (no budget_tokens). Cloud
-	// variants (bedrock/vertex/azure/openrouter) are missing
-	// supports_adaptive_thinking in the LiteLLM registry but still advertise the
-	// 4.6+ effort tiers, so promote them to adaptive here. This keeps them off the
-	// legacy budget path, where budget_tokens is rejected with 400 on 4.7+.
-	if !adaptive && clientType == string(models.ClientTypeAnthropicMessages) && anthropicEffortEra(effortLevels) {
-		adaptive = true
-	}
-
-	switch {
-	case reasoningEffortDisabled(requested):
-		return &models.ReasoningConfig{Disabled: true, OffEffort: offEffort}
-	case requested == reasoningEffortAdaptive:
-		// Legacy "adaptive" override on a toggle model: treat as on (toggle has no
-		// adaptive concept; send a normal effort).
-		return &models.ReasoningConfig{Active: true, Adaptive: adaptive, Effort: pickEffort("", botSettings, effortLevels), OffEffort: offEffort}
-	case requested != "":
-		return &models.ReasoningConfig{Active: true, Adaptive: adaptive, Effort: pickEffort(requested, botSettings, effortLevels), OffEffort: offEffort}
-	case reasoningEffortDisabled(botSettings.ReasoningEffort):
-		// The bot's stored effort is the only on/off source; "disable" is off.
-		return &models.ReasoningConfig{Disabled: true, OffEffort: offEffort}
-	default:
-		return &models.ReasoningConfig{Active: true, Adaptive: adaptive, Effort: pickEffort("", botSettings, effortLevels), OffEffort: offEffort}
-	}
-}
-
-// anthropicEffortEra reports whether an Anthropic model uses the 4.6+
-// effort/adaptive thinking mechanism rather than the legacy
-// thinking{type:"enabled", budget_tokens:N} path. Pre-4.6 Claude advertises only
-// the implicit low/medium/high base; 4.6+ adds at least one of minimal/xhigh/max.
-// Detecting any of those catches the cloud-provider variants that the registry
-// leaves without supports_adaptive_thinking.
-//
-// The disable token is deliberately not a signal. It declares that a model can be
-// turned off, which every Claude generation can do, so reading it as "4.6+" would
-// put a legacy model on the adaptive wire that it rejects.
-func anthropicEffortEra(effortLevels []string) bool {
-	for _, e := range effortLevels {
-		switch e {
-		case models.ReasoningEffortMinimal, models.ReasoningEffortXHigh,
-			models.ReasoningEffortMax:
-			return true
-		}
-	}
-	return false
-}
-
-// pickEffort resolves the effort to send when thinking is active: the
-// per-message override (if a concrete tier) wins, then the bot default, then
-// medium. Values outside the effective model+wire effort list are ignored so
-// stale settings or command/API overrides cannot send a known-invalid wire value.
-func pickEffort(requested string, botSettings settings.Settings, effortLevels []string) string {
-	if e := strings.TrimSpace(requested); e != "" && e != reasoningEffortAdaptive && e != reasoningEffortDisable {
-		if hasEffort(effortLevels, e) {
-			return e
-		}
-	}
-	// The stored effort is skipped when it means "off". pickEffort only runs once
-	// reasoning is on, and "off" is advertisable now, so without this guard a bot
-	// parked on off would hand the disable token back as an active tier and send it
-	// upstream, where no provider knows the word.
-	if e := strings.TrimSpace(botSettings.ReasoningEffort); e != "" &&
-		!models.IsReasoningDisabled(e) && hasEffort(effortLevels, e) {
-		return e
-	}
-	if hasEffort(effortLevels, models.ReasoningEffortMedium) {
-		return models.ReasoningEffortMedium
-	}
-	// No medium: land on the tier closest to it rather than on effortLevels[0],
-	// which is whatever the registry listed first (usually the weakest tier).
-	if nearest := models.NearestEffortToMedium(effortLevels); nearest != "" {
-		return nearest
-	}
-	return models.ReasoningEffortMedium
-}
-
-// effectiveReasoningEfforts intersects the model's advertised effort levels
-// with the selected client's current wire policy. Generic OpenAI-format clients
-// retain the existing max-to-xhigh compatibility behavior, while Codex uses its
-// catalog levels directly. openAIWireEffort in models/sdk.go is defence-in-depth.
-// Keep normalizesMaxReasoningEffort in sync with the frontend
-// MAX_NORMALIZED_CLIENT_TYPES.
-func effectiveReasoningEfforts(effortLevels []string, clientType string) []string {
-	levels := effortLevels
-	if len(levels) == 0 {
-		levels = []string{models.ReasoningEffortLow, models.ReasoningEffortMedium, models.ReasoningEffortHigh}
-	}
-	out := make([]string, 0, len(levels))
-	for _, e := range levels {
-		if normalizesMaxReasoningEffort(clientType) && e == models.ReasoningEffortMax {
-			continue
-		}
-		if !hasEffort(out, e) {
-			out = append(out, e)
-		}
-	}
-	return out
-}
-
-// normalizesMaxReasoningEffort reports whether the current compatibility policy
-// maps "max" to "xhigh". Keep in sync with MAX_NORMALIZED_CLIENT_TYPES in
-// reasoning-effort.ts.
-func normalizesMaxReasoningEffort(clientType string) bool {
-	switch models.ClientType(clientType) {
-	case models.ClientTypeOpenAICompletions, models.ClientTypeOpenAIResponses:
-		return true
-	default:
-		return false
-	}
-}
-
-func hasEffort(effortLevels []string, effort string) bool {
-	for _, e := range effortLevels {
-		if e == effort {
-			return true
-		}
-	}
-	return false
-}
-
-// offEffortFor translates "off" into the effort value an OpenAI-format provider
-// needs, or "" when the model cannot be turned off and the caller must omit
-// reasoning_effort entirely. A model that advertises ReasoningEffortDisable can be
-// switched off, and OpenAI spells that state "none".
-//
-// It deliberately never falls back to a real tier. "minimal" used to serve as a
-// second-best "off", but it enables reasoning rather than disabling it, so Off
-// would have resolved to the same request as the Minimal tier — one state, two
-// selectable options. The two are also mutually exclusive upstream: minimal is
-// gpt-5.0's weakest tier and gpt-5.1 replaced it with none, so "advertises minimal
-// but not none" describes a model that genuinely cannot be turned off. Omitting
-// the field is the honest answer there, and it lets the provider default stand.
-func offEffortFor(effortLevels []string) string {
-	if hasEffort(effortLevels, models.ReasoningEffortDisable) {
-		return models.ReasoningEffortNone
-	}
-	return ""
-}
-
-func reasoningEffortDisabled(effort string) bool {
-	return models.IsReasoningDisabled(effort)
-}
-
-func offEffortOrEmpty(rc *models.ReasoningConfig) string {
-	if rc == nil {
-		return ""
-	}
-	return rc.OffEffort
+	return reasoning.ResolveConfig(
+		chatModel.ResolveThinkingMode(),
+		chatModel.Config.ReasoningEfforts,
+		botSettings.ReasoningEffort,
+		requestedEffort,
+		clientType,
+	)
 }
 
 func (s *Service) buildToolApprovalHandler(p baseRunConfigParams) func(context.Context, sdk.ToolCall) (sdk.ToolApprovalResult, error) {

--- a/internal/agent/application/service_model_selection_test.go
+++ b/internal/agent/application/service_model_selection_test.go
@@ -13,42 +13,9 @@ import (
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
 	"github.com/memohai/memoh/internal/settings"
 )
-
-func TestOffEffortFor(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name   string
-		levels []string
-		want   string
-	}{
-		{
-			"declaring disable yields the OpenAI wire spelling of off",
-			[]string{models.ReasoningEffortDisable, "low", "medium"},
-			models.ReasoningEffortNone,
-		},
-		{
-			// minimal reduces reasoning, it does not stop it, so standing in for off
-			// would make Off and the Minimal tier the same request. Upstream also
-			// never ships both: minimal is gpt-5.0's weakest tier and gpt-5.1
-			// replaced it with none.
-			"minimal is a tier, not a stand-in for off",
-			[]string{models.ReasoningEffortMinimal, "low", "medium"},
-			"",
-		},
-		{"empty when only real tiers (omit, do not enable)", []string{"medium", "high", "xhigh"}, ""},
-		{"legacy base yields empty (omit reasoning_effort)", []string{"low", "medium", "high"}, ""},
-		{"empty levels yield empty", nil, ""},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := offEffortFor(tt.levels); got != tt.want {
-				t.Fatalf("offEffortFor(%v) = %q, want %q", tt.levels, got, tt.want)
-			}
-		})
-	}
-}
 
 func TestMatchesModelReference_ModelID(t *testing.T) {
 	t.Parallel()
@@ -250,13 +217,13 @@ func TestResolveReasoningConfig(t *testing.T) {
 			name:          "disable overrides bot default",
 			model:         toggleModel,
 			botSettings:   settings.Settings{ReasoningEffort: models.ReasoningEffortHigh},
-			requestEffort: reasoningEffortDisable,
+			requestEffort: models.ReasoningEffortDisable,
 			want:          &models.ReasoningConfig{Disabled: true},
 		},
 		{
 			name:          "legacy adaptive request enables toggle with default effort",
 			model:         toggleModel,
-			requestEffort: reasoningEffortAdaptive,
+			requestEffort: reasoning.EffortAdaptive,
 			want:          &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortMedium},
 		},
 		{
@@ -324,7 +291,7 @@ func TestResolveReasoningConfig(t *testing.T) {
 		{
 			name:          "adaptive model can still be disabled",
 			model:         adaptiveModel,
-			requestEffort: reasoningEffortDisable,
+			requestEffort: models.ReasoningEffortDisable,
 			want:          &models.ReasoningConfig{Disabled: true},
 		},
 		{

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -915,13 +915,7 @@ func (a *Agent) buildGenerateOptions(cfg RunConfig, tools []sdk.Tool, approvalTo
 	opts = append(opts, models.BuildReasoningOptions(models.SDKModelConfig{
 		ClientType:            models.ResolveClientType(cfg.Model),
 		ChatCompletionsCompat: cfg.ChatCompletionsCompat,
-		ReasoningConfig: &models.ReasoningConfig{
-			Active:    cfg.ReasoningActive,
-			Disabled:  cfg.ReasoningDisabled,
-			Adaptive:  cfg.ReasoningAdaptive,
-			Effort:    cfg.ReasoningEffort,
-			OffEffort: cfg.ReasoningOffEffort,
-		},
+		ReasoningConfig:       cfg.ReasoningConfig,
 	})...)
 	return opts
 }

--- a/internal/agent/runtime/native/agent_reasoning_test.go
+++ b/internal/agent/runtime/native/agent_reasoning_test.go
@@ -57,7 +57,7 @@ func TestBuildGenerateOptionsPreservesDeepSeekReasoningDisabled(t *testing.T) {
 			Provider: provider,
 			Type:     sdk.ModelTypeChat,
 		},
-		ReasoningDisabled:     true,
+		ReasoningConfig:       &models.ReasoningConfig{Disabled: true},
 		ChatCompletionsCompat: models.ChatCompletionsCompatDeepSeek,
 	}
 

--- a/internal/agent/runtime/native/spawn_adapter.go
+++ b/internal/agent/runtime/native/spawn_adapter.go
@@ -124,7 +124,7 @@ func runConfigFromSpawnRunConfig(cfg tools.SpawnRunConfig) RunConfig {
 		ContextQueryMaterialized: cfg.Query != "",
 		SessionType:              cfg.SessionType,
 		Messages:                 messages,
-		ReasoningEffort:          cfg.ReasoningEffort,
+		ReasoningConfig:          cfg.ReasoningConfig,
 		PromptCacheTTL:           cfg.PromptCacheTTL,
 		ChatCompletionsCompat:    cfg.ChatCompletionsCompat,
 		SupportsImageInput:       cfg.SupportsImageInput,

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -3,7 +3,6 @@ package native
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 	"time"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -12,6 +11,7 @@ import (
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/event"
 	tools "github.com/memohai/memoh/internal/agent/tool"
+	"github.com/memohai/memoh/internal/models"
 )
 
 // SessionContext carries request-scoped identity and routing information.
@@ -86,28 +86,27 @@ type RunConfig struct {
 	CurrentModelProvider        string
 	ForkContext                 *tools.MessageSnapshot
 	ForkContextSourceMessageIDs []string
-	ReasoningEffort             string
-	ReasoningActive             bool
-	ReasoningDisabled           bool
-	ReasoningAdaptive           bool
-	ReasoningOffEffort          string
-	ChatCompletionsCompat       string
-	Messages                    []sdk.Message
-	Query                       string
-	System                      string
-	ContextFrags                []contextfrag.ContextFrag
-	ContextManifest             contextfrag.Manifest
-	ContextScope                contextfrag.Scope
-	ContextQueryMaterialized    bool
-	ContextToolUsage            string
-	ContextDynamicMutators      []contextfrag.DynamicMutator
-	SessionType                 string
-	LiveToolStream              bool
-	CanRequestUserInput         bool
-	SupportsImageInput          bool
-	SupportsFileInput           bool
-	SupportsToolCall            bool
-	InlineImages                []sdk.ImagePart
+	// ReasoningConfig is the resolved thinking decision, carried whole. It was
+	// once five flat fields, which is how the subagent spawn path came to carry
+	// one of them and silently drop the rest.
+	ReasoningConfig          *models.ReasoningConfig
+	ChatCompletionsCompat    string
+	Messages                 []sdk.Message
+	Query                    string
+	System                   string
+	ContextFrags             []contextfrag.ContextFrag
+	ContextManifest          contextfrag.Manifest
+	ContextScope             contextfrag.Scope
+	ContextQueryMaterialized bool
+	ContextToolUsage         string
+	ContextDynamicMutators   []contextfrag.DynamicMutator
+	SessionType              string
+	LiveToolStream           bool
+	CanRequestUserInput      bool
+	SupportsImageInput       bool
+	SupportsFileInput        bool
+	SupportsToolCall         bool
+	InlineImages             []sdk.ImagePart
 	// InlineAttachments carries non-image native attachment parts (documents
 	// as sdk.FilePart, small text files as wrapped sdk.TextPart) appended to
 	// the current user message. Images stay in InlineImages, which also feeds
@@ -178,23 +177,6 @@ type (
 type SystemFile struct {
 	Filename string
 	Content  string
-}
-
-// ModelConfig holds provider and model information resolved from DB.
-type ModelConfig struct {
-	ModelID         string
-	ClientType      string
-	APIKey          string //nolint:gosec // carries provider credential material at runtime
-	CodexAccountID  string
-	BaseURL         string
-	HTTPClient      *http.Client
-	ReasoningConfig *ReasoningConfig
-}
-
-// ReasoningConfig controls extended thinking/reasoning behavior.
-type ReasoningConfig struct {
-	Enabled bool
-	Effort  string
 }
 
 func mustMarshal(v any) json.RawMessage {

--- a/internal/agent/tool/subagent.go
+++ b/internal/agent/tool/subagent.go
@@ -37,17 +37,20 @@ type SpawnAgent interface {
 
 // SpawnRunConfig mirrors agent.RunConfig fields needed by subagent controls.
 type SpawnRunConfig struct {
-	Model                 *sdk.Model
-	ModelUUID             string
-	ModelID               string
-	ModelProvider         string
-	System                string
-	Query                 string
-	SessionType           string
-	Identity              SpawnIdentity
-	LoopDetection         SpawnLoopConfig
-	Messages              []sdk.Message
-	ReasoningEffort       string
+	Model         *sdk.Model
+	ModelUUID     string
+	ModelID       string
+	ModelProvider string
+	System        string
+	Query         string
+	SessionType   string
+	Identity      SpawnIdentity
+	LoopDetection SpawnLoopConfig
+	Messages      []sdk.Message
+	// ReasoningConfig is the thinking decision resolved for the subagent's own
+	// model. It replaces a lone effort string that was never assigned, which is
+	// how subagents came to run with no reasoning configuration at all (#983).
+	ReasoningConfig       *models.ReasoningConfig
 	PromptCacheTTL        string
 	ChatCompletionsCompat string
 	SupportsImageInput    bool

--- a/internal/capabilities/discover.go
+++ b/internal/capabilities/discover.go
@@ -1,6 +1,9 @@
 package capabilities
 
-import "github.com/memohai/memoh/internal/models"
+import (
+	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
+)
 
 // litellmEntry is the subset of a LiteLLM registry record we consume. All
 // capability fields are pointers so we can distinguish "registry is silent"
@@ -44,16 +47,12 @@ type Capabilities struct {
 
 // effortOrder is the canonical low→high ordering used to render effort lists.
 // "off" leads because it is the weakest thing a user can ask for, even though it
-// is not a tier.
-var effortOrder = []string{
-	models.ReasoningEffortDisable,
-	models.ReasoningEffortMinimal,
-	models.ReasoningEffortLow,
-	models.ReasoningEffortMedium,
-	models.ReasoningEffortHigh,
-	models.ReasoningEffortXHigh,
-	models.ReasoningEffortMax,
-}
+// is not a tier — which is why it is prepended here rather than living in the
+// reasoning package's tier ordering.
+var effortOrder = append(
+	[]string{reasoning.EffortDisable},
+	reasoning.OrderedEfforts()...,
+)
 
 func boolVal(p *bool) bool { return p != nil && *p }
 

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -12,6 +12,7 @@ import (
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	memohcopilot "github.com/memohai/memoh/internal/copilot"
+	"github.com/memohai/memoh/internal/reasoning"
 )
 
 // SDKModelConfig holds provider and model information resolved from DB,
@@ -29,32 +30,13 @@ type SDKModelConfig struct {
 	ReasoningConfig       *ReasoningConfig
 }
 
-// ReasoningConfig is the resolved extended-thinking decision for one call. The
-// resolver makes a single decision (based on the model's thinking mode and the
-// user's settings); the SDK layer mechanically translates it per provider.
-// Anthropic 4.6+ (Adaptive) sends thinking{type:"adaptive"} plus an effort
+// ReasoningConfig is the resolved extended-thinking decision for one call,
+// produced by internal/reasoning and translated here into each provider's wire
+// shape. Anthropic 4.6+ (Adaptive) sends thinking{type:"adaptive"} plus an effort
 // string and never a token budget; legacy Anthropic (<=4.5, non-adaptive) sends
 // thinking{type:"enabled", budget_tokens:N} derived from the effort. OpenAI-style
 // providers only ever receive an effort string.
-type ReasoningConfig struct {
-	// Active means thinking is on for this call.
-	Active bool
-	// Disabled means thinking was explicitly turned off (toggle=off). For
-	// OpenAI-style providers without a real off switch, OffEffort approximates it.
-	Disabled bool
-	// Adaptive means the provider's thinking is adaptive (Anthropic 4.6+), wired
-	// as thinking{type:"adaptive"} with no budget. When false on an active
-	// Anthropic call, the model is treated as legacy (<=4.5) and wired as
-	// thinking{type:"enabled", budget_tokens:N}.
-	Adaptive bool
-	// Effort is the effort tier to send when active ("" lets the SDK default).
-	Effort string
-	// OffEffort is the effort an OpenAI-format provider should send when disabled:
-	// "none" when the model advertised that it can be turned off, else "" meaning
-	// the reasoning_effort field is omitted entirely. It is never a real tier
-	// (minimal/low/medium/high) because those enable thinking instead of disabling it.
-	OffEffort string
-}
+type ReasoningConfig = reasoning.Config
 
 // NewSDKChatModel builds a Twilight AI SDK Model from the resolved model config.
 func NewSDKChatModel(cfg SDKModelConfig) *sdk.Model {
@@ -256,9 +238,13 @@ func openAIEffortOptions(clientType ClientType, rc *ReasoningConfig) []sdk.Gener
 
 // openAIWireEffort retains the generic OpenAI clients' existing max-to-xhigh
 // compatibility behavior. Codex accepts the catalog-advertised max value.
+//
+// The resolver already filters "max" out of the selectable tiers for these
+// clients, so this only fires for values that bypassed it — a stale stored effort,
+// or a caller that built a ReasoningConfig by hand.
 func openAIWireEffort(clientType ClientType, effort string) string {
-	if clientType != ClientTypeOpenAICodex && effort == ReasoningEffortMax {
-		return ReasoningEffortXHigh
+	if clientType != ClientTypeOpenAICodex && effort == reasoning.EffortMax {
+		return reasoning.EffortXHigh
 	}
 	return effort
 }

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -2,10 +2,11 @@ package models
 
 import (
 	"errors"
-	"slices"
 	"strings"
 
 	"github.com/google/uuid"
+
+	"github.com/memohai/memoh/internal/reasoning"
 )
 
 type ModelType string
@@ -59,117 +60,42 @@ const (
 	CompatFileInput = "file-input"
 )
 
-// Active effort tiers, weakest to strongest. These are the values that turn
-// reasoning on; "off" is ReasoningEffortDisable and deliberately not among them.
+// Reasoning effort tokens. The vocabulary lives in internal/reasoning; these are
+// forwarding aliases so existing call sites keep compiling while they migrate.
 const (
-	ReasoningEffortMinimal = "minimal"
-	ReasoningEffortLow     = "low"
-	ReasoningEffortMedium  = "medium"
-	ReasoningEffortHigh    = "high"
-	ReasoningEffortXHigh   = "xhigh"
-	ReasoningEffortMax     = "max"
+	ReasoningEffortMinimal = reasoning.EffortMinimal
+	ReasoningEffortLow     = reasoning.EffortLow
+	ReasoningEffortMedium  = reasoning.EffortMedium
+	ReasoningEffortHigh    = reasoning.EffortHigh
+	ReasoningEffortXHigh   = reasoning.EffortXHigh
+	ReasoningEffortMax     = reasoning.EffortMax
+
+	// ReasoningEffortDisable is the single representation of "no reasoning" —
+	// both what a user picks and what a model advertises.
+	ReasoningEffortDisable = reasoning.EffortDisable
+	// ReasoningEffortNone is OpenAI's wire spelling of the same state, produced
+	// by adaptors and never declared or stored.
+	ReasoningEffortNone = reasoning.EffortNone
 )
 
-// ReasoningEffortDisable is the single representation of "no reasoning". It is
-// both what a user picks and what a model advertises: a model listing it in
-// reasoning_efforts can be turned off, whatever wire shape that takes on its
-// provider. Since bots dropped the separate reasoning_enabled flag, it is also
-// the only stored form of "off".
-const ReasoningEffortDisable = "disable"
-
-// ReasoningEffortNone is OpenAI's wire spelling of "no reasoning" (gpt-5.1
-// introduced it and dropped minimal; gpt-5.0 has minimal and no none). It is
-// never declared by a model nor stored in settings — provider adaptors translate
-// ReasoningEffortDisable into it, exactly as the Anthropic path translates the
-// same intent into thinking{type:"disabled"}. Giving "off" one name on our side
-// and letting each provider spell it its own way is what keeps a single state
-// from acquiring two selectable tokens.
-const ReasoningEffortNone = "none"
-
-// orderedReasoningEfforts lists the active tiers weakest to strongest. Order is
-// what NearestEffortToMedium walks, so it must stay monotonic. ReasoningEffortDisable
-// is absent on purpose: it is not a tier, and including it would let the nearest-tier
-// fallback resolve an *active* reasoning config to "off".
-var orderedReasoningEfforts = []string{
-	ReasoningEffortMinimal,
-	ReasoningEffortLow,
-	ReasoningEffortMedium,
-	ReasoningEffortHigh,
-	ReasoningEffortXHigh,
-	ReasoningEffortMax,
-}
-
 // IsReasoningDisabled reports whether an effort value means "no reasoning".
-// ReasoningEffortNone is accepted as the legacy spelling: it was declarable and
-// storable before "off" was unified onto ReasoningEffortDisable.
 func IsReasoningDisabled(effort string) bool {
-	switch strings.TrimSpace(effort) {
-	case ReasoningEffortDisable, ReasoningEffortNone:
-		return true
-	}
-	return false
+	return reasoning.IsDisabled(effort)
 }
 
 // NearestEffortToMedium picks the tier closest to medium from levels, breaking
-// ties toward the weaker tier. It is the fallback when a model does not
-// advertise medium: [minimal low] -> low, [high max] -> high, [low high] -> low.
-// Ignores values outside the known tier list (including "disable"), and returns
-// "" when levels has no usable tier.
-//
-// Keep in sync with nearestEffortToMedium in
-// apps/web/src/pages/bots/components/reasoning-effort.ts.
+// ties toward the weaker tier.
 func NearestEffortToMedium(levels []string) string {
-	mediumIdx := -1
-	for i, e := range orderedReasoningEfforts {
-		if e == ReasoningEffortMedium {
-			mediumIdx = i
-			break
-		}
-	}
-
-	best, bestIdx, bestDistance := "", 0, 0
-	for _, level := range levels {
-		idx := -1
-		for i, e := range orderedReasoningEfforts {
-			if e == level {
-				idx = i
-				break
-			}
-		}
-		if idx < 0 {
-			continue
-		}
-		distance := idx - mediumIdx
-		if distance < 0 {
-			distance = -distance
-		}
-		// Ties break toward the weaker tier (smaller index) rather than toward
-		// whichever came first, because levels arrives in registry order and is
-		// not guaranteed to be sorted.
-		if best == "" || distance < bestDistance || (distance == bestDistance && idx < bestIdx) {
-			best, bestIdx, bestDistance = level, idx, distance
-		}
-	}
-	return best
+	return reasoning.NearestToMedium(levels)
 }
 
-// ThinkingMode describes how a model's extended-thinking control behaves. It is
-// the capability-discovery output that the UI and wire layer key off of.
-//
-//   - toggle:        user can turn thinking on/off (most reasoning/hybrid models,
-//     incl. OpenAI). "off" wire behavior is provider-specific (see adapter).
-//   - adaptive:      user can turn thinking on/off; when on, the provider uses
-//     adaptive thinking (Claude 4.6+/4.7/4.8).
-//   - only_adaptive: legacy alias for adaptive retained for branch-local imports.
-//   - none:          model has no thinking concept.
-//
-// An empty value means "unknown" and is treated as a transitional state that
-// falls back to the legacy CompatReasoning flag (see Model.SupportsReasoning).
+// Thinking mode tokens. Semantics live in internal/reasoning; these are
+// forwarding aliases so existing call sites keep compiling while they migrate.
 const (
-	ThinkingModeAdaptive     = "adaptive"
-	ThinkingModeToggle       = "toggle"
-	ThinkingModeOnlyAdaptive = "only_adaptive"
-	ThinkingModeNone         = "none"
+	ThinkingModeAdaptive     = reasoning.ModeAdaptive
+	ThinkingModeToggle       = reasoning.ModeToggle
+	ThinkingModeOnlyAdaptive = reasoning.ModeOnlyAdaptive
+	ThinkingModeNone         = reasoning.ModeNone
 )
 
 // validCompatibilities enumerates accepted compatibility tokens.
@@ -178,31 +104,9 @@ var validCompatibilities = map[string]struct{}{
 	CompatFileInput: {},
 }
 
-// validReasoningEfforts is the vocabulary a model may advertise: the active tiers
-// plus ReasoningEffortDisable, which declares that the model can be turned off.
-// ReasoningEffortNone is absent because it is a provider wire value, not something
-// a model declares — see the constant.
-var validReasoningEfforts = map[string]struct{}{
-	ReasoningEffortDisable: {},
-	ReasoningEffortMinimal: {},
-	ReasoningEffortLow:     {},
-	ReasoningEffortMedium:  {},
-	ReasoningEffortHigh:    {},
-	ReasoningEffortXHigh:   {},
-	ReasoningEffortMax:     {},
-}
-
 // IsValidReasoningEffort reports whether effort can be stored in ModelConfig.
 func IsValidReasoningEffort(effort string) bool {
-	_, ok := validReasoningEfforts[effort]
-	return ok
-}
-
-var validThinkingModes = map[string]struct{}{
-	ThinkingModeAdaptive:     {},
-	ThinkingModeToggle:       {},
-	ThinkingModeOnlyAdaptive: {},
-	ThinkingModeNone:         {},
+	return reasoning.IsDeclarable(effort)
 }
 
 // ModelConfig holds the JSONB config stored per model.
@@ -226,34 +130,11 @@ func normalizeModelConfig(config ModelConfig) ModelConfig {
 		description := strings.TrimSpace(*config.Description)
 		config.Description = &description
 	}
-	config.ReasoningEfforts = normalizeAdvertisedEfforts(config.ReasoningEfforts)
+	// Rewrites the legacy "none" spelling of off on both ModelConfig boundaries —
+	// before a write is validated and after a row is read back — so nothing
+	// downstream has to know that "none" was ever declarable.
+	config.ReasoningEfforts = reasoning.NormalizeAdvertised(config.ReasoningEfforts)
 	return config
-}
-
-// normalizeAdvertisedEfforts rewrites the legacy spelling of "off" to the token a
-// model declares today. It runs on both boundaries of ModelConfig — before a write
-// is validated and after a row is read back — so nothing downstream has to know
-// that "none" was ever declarable.
-//
-// Without it the vocabulary change would only apply to freshly written configs:
-// rows persisted earlier, and provider registries that have not been regenerated,
-// would keep advertising "none", and every consumer that now looks for the disable
-// token would read those models as "cannot be turned off" — silently dropping Off
-// from the picker and misreading which thinking mechanism the model wants.
-func normalizeAdvertisedEfforts(efforts []string) []string {
-	if len(efforts) == 0 {
-		return efforts
-	}
-	out := make([]string, 0, len(efforts))
-	for _, effort := range efforts {
-		if strings.TrimSpace(effort) == ReasoningEffortNone {
-			effort = ReasoningEffortDisable
-		}
-		if !slices.Contains(out, effort) {
-			out = append(out, effort)
-		}
-	}
-	return out
 }
 
 type Model struct {
@@ -303,10 +184,8 @@ func (m *Model) Validate() error {
 			return errors.New("invalid reasoning effort: " + effort)
 		}
 	}
-	if m.Config.ThinkingMode != "" {
-		if _, ok := validThinkingModes[m.Config.ThinkingMode]; !ok {
-			return errors.New("invalid thinking mode: " + m.Config.ThinkingMode)
-		}
+	if m.Config.ThinkingMode != "" && !reasoning.IsValidMode(m.Config.ThinkingMode) {
+		return errors.New("invalid thinking mode: " + m.Config.ThinkingMode)
 	}
 	return nil
 }
@@ -321,35 +200,18 @@ func (m *Model) HasCompatibility(c string) bool {
 	return false
 }
 
-// SupportsReasoning reports whether the model supports extended thinking. It
-// prefers the new ThinkingMode field and falls back to the legacy
-// CompatReasoning flag for models discovered before the thinking-mode schema
-// existed (transitional; resolved naturally on next model re-fetch).
-func (m *Model) SupportsReasoning() bool {
-	switch m.Config.ThinkingMode {
-	case ThinkingModeToggle, ThinkingModeAdaptive, ThinkingModeOnlyAdaptive:
-		return true
-	case ThinkingModeNone:
-		return false
-	default: // unknown / empty → legacy bridge
-		return m.HasCompatibility(CompatReasoning)
-	}
-}
-
 // ResolveThinkingMode returns the effective ThinkingMode, bridging legacy data:
 // unknown + reasoning compat → toggle; unknown without it → none.
 func (m *Model) ResolveThinkingMode() string {
-	switch m.Config.ThinkingMode {
-	case ThinkingModeToggle, ThinkingModeAdaptive, ThinkingModeNone:
-		return m.Config.ThinkingMode
-	case ThinkingModeOnlyAdaptive:
-		return ThinkingModeAdaptive
-	default:
-		if m.HasCompatibility(CompatReasoning) {
-			return ThinkingModeToggle
-		}
-		return ThinkingModeNone
-	}
+	return reasoning.ResolveMode(m.Config.ThinkingMode, m.HasCompatibility(CompatReasoning))
+}
+
+// ReasoningOptions reports what a caller may select for this model on the given
+// client type: the selectable tiers, whether off is reachable, and the default.
+// It is the single source every surface reads — the web picker, /reasoning, and
+// the API all render this rather than deriving their own answer.
+func (m *Model) ReasoningOptions(clientType string) reasoning.Options {
+	return reasoning.OptionsFor(m.ResolveThinkingMode(), m.Config.ReasoningEfforts, clientType)
 }
 
 // AddRequest is the payload for creating a new model. Enable is a pointer so

--- a/internal/reasoning/mode.go
+++ b/internal/reasoning/mode.go
@@ -1,0 +1,57 @@
+package reasoning
+
+// ThinkingMode describes how a model's extended-thinking control behaves. It is
+// the capability-discovery output that the UI and wire layer key off of.
+//
+//   - toggle:        user can turn thinking on/off (most reasoning/hybrid models,
+//     incl. OpenAI). "off" wire behavior is provider-specific (see adaptor).
+//   - adaptive:      user can turn thinking on/off; when on, the provider uses
+//     adaptive thinking (Claude 4.6+/4.7/4.8).
+//   - only_adaptive: legacy alias for adaptive retained for branch-local imports.
+//   - none:          model has no thinking concept.
+//
+// An empty value means "unknown" and is treated as a transitional state that falls
+// back to the legacy reasoning compatibility flag (see ResolveMode).
+const (
+	ModeAdaptive     = "adaptive"
+	ModeToggle       = "toggle"
+	ModeOnlyAdaptive = "only_adaptive"
+	ModeNone         = "none"
+)
+
+var validModes = map[string]struct{}{
+	ModeAdaptive:     {},
+	ModeToggle:       {},
+	ModeOnlyAdaptive: {},
+	ModeNone:         {},
+}
+
+// IsValidMode reports whether mode can be stored in a model config.
+func IsValidMode(mode string) bool {
+	_, ok := validModes[mode]
+	return ok
+}
+
+// ResolveMode returns the effective thinking mode, bridging legacy data. The
+// declared mode wins when it is known; only_adaptive collapses onto adaptive.
+// When the mode is empty — a model imported before the thinking-mode schema
+// existed — hasReasoningCompat decides: the old "reasoning" compatibility flag
+// means toggle, its absence means none.
+func ResolveMode(declared string, hasReasoningCompat bool) string {
+	switch declared {
+	case ModeToggle, ModeAdaptive, ModeNone:
+		return declared
+	case ModeOnlyAdaptive:
+		return ModeAdaptive
+	default:
+		if hasReasoningCompat {
+			return ModeToggle
+		}
+		return ModeNone
+	}
+}
+
+// Supported reports whether a resolved mode allows any thinking at all.
+func Supported(mode string) bool {
+	return mode != ModeNone && mode != ""
+}

--- a/internal/reasoning/off_effort_test.go
+++ b/internal/reasoning/off_effort_test.go
@@ -1,0 +1,40 @@
+package reasoning
+
+import "testing"
+
+// Moved verbatim from internal/agent/application when the resolver became a leaf
+// package; the assertions are unchanged.
+
+func TestOffEffortFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		levels []string
+		want   string
+	}{
+		{
+			"declaring disable yields the OpenAI wire spelling of off",
+			[]string{EffortDisable, "low", "medium"},
+			EffortNone,
+		},
+		{
+			// minimal reduces reasoning, it does not stop it, so standing in for off
+			// would make Off and the Minimal tier the same request. Upstream also
+			// never ships both: minimal is gpt-5.0's weakest tier and gpt-5.1
+			// replaced it with none.
+			"minimal is a tier, not a stand-in for off",
+			[]string{EffortMinimal, "low", "medium"},
+			"",
+		},
+		{"empty when only real tiers (omit, do not enable)", []string{"medium", "high", "xhigh"}, ""},
+		{"legacy base yields empty (omit reasoning_effort)", []string{"low", "medium", "high"}, ""},
+		{"empty levels yield empty", nil, ""},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := offEffortFor(tt.levels); got != tt.want {
+				t.Fatalf("offEffortFor(%v) = %q, want %q", tt.levels, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reasoning/options.go
+++ b/internal/reasoning/options.go
@@ -1,0 +1,98 @@
+package reasoning
+
+// Options is what a caller may select for a model: the answer every surface needs
+// before it can render a picker, a slash-command choice list, or an API response.
+//
+// Efforts holds active tiers only — the disable token never appears in it. Whether
+// off is reachable is CanDisable, a field of its own, so no consumer has to
+// remember to filter a sentinel out of a tier list. That sentinel was how a
+// capability boolean travelled through the effort list before this package
+// existed, and forgetting to filter it is what let an *active* config resolve to
+// "off" in two separate places.
+type Options struct {
+	// Supported is false when the model has no thinking concept; the other fields
+	// are then empty and no control should be rendered at all.
+	Supported bool
+	// CanDisable reports whether picking "off" actually reaches the model.
+	CanDisable bool
+	// Efforts are the selectable active tiers, weakest to strongest as advertised.
+	Efforts []string
+	// DefaultEffort is the tier to use when nothing is stored, and the tier to fall
+	// back to when a stored value is no longer offered by the model.
+	DefaultEffort string
+}
+
+// Client types whose wire expresses "off" by omitting the field rather than by
+// sending a value. Anthropic's Messages API has no off token: thinking is off when
+// the field is absent, which is exactly what the adaptor sends for a disabled
+// toggle model. No catalog advertises the disable token for Claude either — the
+// capability registry never marks an Anthropic entry as supporting the off effort
+// — so gating on the declaration alone would hide a control that works.
+func expressesOffByOmission(clientType string) bool {
+	return clientType == ClientTypeAnthropicMessages
+}
+
+// OptionsFor reports what a caller may select for a model.
+//
+// It shares effectiveEfforts and pickEffort with ResolveConfig on purpose: the
+// options a user is offered and the value a call actually sends are then two
+// readings of one computation, and cannot disagree. Every past bug in this area
+// was a disagreement between those two answers.
+func OptionsFor(mode string, advertised []string, clientType string) Options {
+	if !Supported(mode) {
+		return Options{}
+	}
+
+	levels := effectiveEfforts(advertised, clientType)
+	tiers := make([]string, 0, len(levels))
+	for _, e := range levels {
+		if e == EffortDisable {
+			continue
+		}
+		tiers = append(tiers, e)
+	}
+
+	return Options{
+		Supported:     true,
+		CanDisable:    canDisable(mode, levels, clientType),
+		Efforts:       tiers,
+		DefaultEffort: pickEffort("", "", levels),
+	}
+}
+
+// canDisable reports whether picking "off" reaches the model: either the model
+// advertises the token, or its client expresses off by omitting the field.
+//
+// The omission rule is limited to toggle models, where thinking only happens when
+// asked for. Under adaptive thinking the model decides on its own, so omitting the
+// field leaves that default in charge rather than turning thinking off.
+func canDisable(mode string, levels []string, clientType string) bool {
+	if hasEffort(levels, EffortDisable) {
+		return true
+	}
+	return mode == ModeToggle && expressesOffByOmission(clientType)
+}
+
+// ReconcileStored returns the effort a caller should hold after the model changed.
+// A stored value the model still offers survives; "off" survives when off is still
+// reachable; anything else lands on the model's default tier. It returns "" when
+// the model has no thinking concept, meaning the caller should clear the value.
+//
+// This is the one policy the frontend used to implement twice — once in the bot
+// settings page and once in the chat composer, with the two disagreeing about
+// whether Claude could be turned off.
+func ReconcileStored(stored string, opts Options) string {
+	if !opts.Supported {
+		return ""
+	}
+	if IsDisabled(stored) {
+		if opts.CanDisable {
+			return EffortDisable
+		}
+		return opts.DefaultEffort
+	}
+	if hasEffort(opts.Efforts, stored) {
+		return stored
+	}
+	return opts.DefaultEffort
+}

--- a/internal/reasoning/options_test.go
+++ b/internal/reasoning/options_test.go
@@ -1,0 +1,180 @@
+package reasoning
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestOptionsForNeverOffersTheDisableTokenAsATier(t *testing.T) {
+	t.Parallel()
+
+	// The disable token travels in the advertised list because that is how a model
+	// declares it can be turned off. It must not come back out as something a user
+	// can pick as an *effort* — that confusion is what let an active config
+	// resolve to "off" before this package existed.
+	opts := OptionsFor(ModeToggle, []string{EffortDisable, EffortLow, EffortHigh}, "openai-completions")
+
+	if !opts.CanDisable {
+		t.Fatal("advertised disable token should report CanDisable")
+	}
+	if slices.Contains(opts.Efforts, EffortDisable) {
+		t.Fatalf("disable leaked into the tier list: %v", opts.Efforts)
+	}
+	if slices.Contains(opts.Efforts, EffortNone) {
+		t.Fatalf("the wire spelling of off leaked into the tier list: %v", opts.Efforts)
+	}
+}
+
+func TestOptionsForOffReachability(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		mode       string
+		advertised []string
+		clientType string
+		canDisable bool
+	}{
+		{
+			// DeepSeek V4: off travels through the compat layer, and the catalog
+			// says so. This is the case that was silently missing from the picker.
+			name:       "declared disable is reachable",
+			mode:       ModeToggle,
+			advertised: []string{EffortDisable, EffortLow, EffortHigh},
+			clientType: "openai-completions",
+			canDisable: true,
+		},
+		{
+			// Claude <=4.5: no catalog ever advertises the token for Anthropic
+			// because the wire has no off value — absence of the field is off.
+			name:       "anthropic toggle is off by omission",
+			mode:       ModeToggle,
+			advertised: []string{EffortLow, EffortMedium, EffortHigh},
+			clientType: ClientTypeAnthropicMessages,
+			canDisable: true,
+		},
+		{
+			// Claude 4.6+: omitting the field leaves adaptive thinking in charge,
+			// which still thinks. Off is not reachable by omission here.
+			name:       "anthropic adaptive cannot be turned off by omission",
+			mode:       ModeAdaptive,
+			advertised: []string{EffortLow, EffortHigh, EffortMax},
+			clientType: ClientTypeAnthropicMessages,
+			canDisable: false,
+		},
+		{
+			// gpt-5.0 advertises minimal but not none: it genuinely cannot be
+			// turned off, and offering the control would be a dead switch.
+			name:       "openai without the token cannot be turned off",
+			mode:       ModeToggle,
+			advertised: []string{EffortMinimal, EffortLow, EffortMedium},
+			clientType: "openai-completions",
+			canDisable: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := OptionsFor(tt.mode, tt.advertised, tt.clientType).CanDisable; got != tt.canDisable {
+				t.Fatalf("CanDisable = %v, want %v", got, tt.canDisable)
+			}
+		})
+	}
+}
+
+func TestOptionsForUnsupportedModelOffersNothing(t *testing.T) {
+	t.Parallel()
+
+	opts := OptionsFor(ModeNone, []string{EffortLow}, "openai-completions")
+	if opts.Supported || opts.CanDisable || len(opts.Efforts) > 0 || opts.DefaultEffort != "" {
+		t.Fatalf("a model with no thinking concept should offer nothing, got %+v", opts)
+	}
+}
+
+func TestOptionsForAppliesTheSameWirePolicyAsResolve(t *testing.T) {
+	t.Parallel()
+
+	// Generic OpenAI clients take xhigh as the ceiling. If the picker offered max
+	// while the resolver filtered it, a user could select a tier that silently
+	// became something else — the class of drift this package prevents.
+	const advertisedMax = EffortMax
+	advertised := []string{EffortLow, EffortHigh, advertisedMax}
+
+	opts := OptionsFor(ModeToggle, advertised, "openai-completions")
+	if slices.Contains(opts.Efforts, advertisedMax) {
+		t.Fatalf("max should be filtered for generic OpenAI clients: %v", opts.Efforts)
+	}
+
+	cfg := ResolveConfig(ModeToggle, advertised, advertisedMax, "", "openai-completions")
+	if cfg == nil || cfg.Effort == advertisedMax {
+		t.Fatalf("resolver should not send a filtered tier, got %+v", cfg)
+	}
+
+	// Codex keeps max, and both answers must agree about that too.
+	codexOpts := OptionsFor(ModeToggle, advertised, "openai-codex")
+	if !slices.Contains(codexOpts.Efforts, advertisedMax) {
+		t.Fatalf("codex should keep max: %v", codexOpts.Efforts)
+	}
+	codexCfg := ResolveConfig(ModeToggle, advertised, advertisedMax, "", "openai-codex")
+	if codexCfg == nil || codexCfg.Effort != advertisedMax {
+		t.Fatalf("codex resolver should send max, got %+v", codexCfg)
+	}
+}
+
+func TestOptionsDefaultEffortMatchesWhatResolveWouldSend(t *testing.T) {
+	t.Parallel()
+
+	// The default a picker shows and the effort an unconfigured call sends are one
+	// computation read twice. Any divergence here is the bug class this package
+	// was built to make impossible.
+	for _, advertised := range [][]string{
+		{EffortLow, EffortMedium, EffortHigh},
+		{EffortMinimal, EffortLow},
+		{EffortHigh, EffortMax},
+		{EffortDisable, EffortHigh, EffortXHigh},
+		nil,
+	} {
+		opts := OptionsFor(ModeToggle, advertised, "openai-codex")
+		cfg := ResolveConfig(ModeToggle, advertised, "", "", "openai-codex")
+		if cfg == nil {
+			t.Fatalf("advertised %v: resolver returned nil for a toggle model", advertised)
+		}
+		if opts.DefaultEffort != cfg.Effort {
+			t.Fatalf("advertised %v: picker default %q != resolved effort %q",
+				advertised, opts.DefaultEffort, cfg.Effort)
+		}
+	}
+}
+
+func TestReconcileStored(t *testing.T) {
+	t.Parallel()
+
+	canDisable := OptionsFor(ModeToggle, []string{EffortDisable, EffortLow, EffortHigh}, "openai-codex")
+	cannotDisable := OptionsFor(ModeToggle, []string{EffortLow, EffortHigh}, "openai-codex")
+	unsupported := OptionsFor(ModeNone, nil, "openai-codex")
+
+	cases := []struct {
+		name   string
+		stored string
+		opts   Options
+		want   string
+	}{
+		{"a tier the model still offers survives", EffortHigh, canDisable, EffortHigh},
+		{"off survives when off is reachable", EffortDisable, canDisable, EffortDisable},
+		{"legacy off spelling survives as the current one", EffortNone, canDisable, EffortDisable},
+		{"off falls back when off is not reachable", EffortDisable, cannotDisable, cannotDisable.DefaultEffort},
+		{"a tier the model dropped falls back", EffortMinimal, cannotDisable, cannotDisable.DefaultEffort},
+		{"an unset value takes the default", "", cannotDisable, cannotDisable.DefaultEffort},
+		{"a model without thinking clears the value", EffortHigh, unsupported, ""},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ReconcileStored(tt.stored, tt.opts); got != tt.want {
+				t.Fatalf("ReconcileStored(%q) = %q, want %q", tt.stored, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/reasoning/resolve.go
+++ b/internal/reasoning/resolve.go
@@ -1,0 +1,184 @@
+package reasoning
+
+import "strings"
+
+// Config is the resolved reasoning decision for one call.
+//
+// Active and Disabled are the two on/off states; both false means the model has
+// no thinking concept and the caller sends nothing. Effort is the tier to send
+// when Active. Adaptive selects the Anthropic 4.6+ wire. OffEffort is the value an
+// OpenAI-format provider needs to express "off", or "" when the model cannot be
+// turned off and the field must be omitted entirely.
+type Config struct {
+	Active    bool
+	Disabled  bool
+	Adaptive  bool
+	Effort    string
+	OffEffort string
+}
+
+// ClientTypeAnthropicMessages is the one client type this package must recognise
+// by name, because the Anthropic wire changed shape between model generations and
+// the era has to be inferred from the advertised tiers. Callers pass their own
+// client-type string; this constant is what it is compared against.
+const ClientTypeAnthropicMessages = "anthropic-messages"
+
+// Client types whose wire policy maps "max" onto "xhigh". Codex uses its catalog
+// levels directly and is deliberately absent.
+const (
+	clientTypeOpenAICompletions = "openai-completions"
+	clientTypeOpenAIResponses   = "openai-responses"
+)
+
+// ResolveConfig makes the single reasoning decision for a call.
+//
+// It takes plain values rather than a settings struct so that every caller can
+// use it — turn orchestration reads stored from bot settings, the subagent spawn
+// path resolves against the subagent's own model, and a command may pass neither.
+//
+//	mode:       the model's resolved thinking mode (see ResolveMode)
+//	advertised: the model's declared effort list, "" entries and all
+//	stored:     the bot's persisted effort ("" when unset, "disable" for off)
+//	requested:  this message's override ("" when absent)
+//	clientType: the provider's client type, for wire policy
+//
+// Returns nil when the model has no thinking concept at all.
+func ResolveConfig(mode string, advertised []string, stored, requested, clientType string) *Config {
+	if !Supported(mode) {
+		return nil
+	}
+
+	levels := effectiveEfforts(advertised, clientType)
+	offEffort := offEffortFor(levels)
+	req := strings.TrimSpace(requested)
+	adaptive := isAdaptiveWire(mode, levels, clientType)
+
+	switch {
+	case IsDisabled(req):
+		return &Config{Disabled: true, OffEffort: offEffort}
+	case req == EffortAdaptive:
+		// Legacy "adaptive" override on a toggle model: treat as on (toggle has no
+		// adaptive concept; send a normal effort).
+		return &Config{Active: true, Adaptive: adaptive, Effort: pickEffort("", stored, levels), OffEffort: offEffort}
+	case req != "":
+		return &Config{Active: true, Adaptive: adaptive, Effort: pickEffort(req, stored, levels), OffEffort: offEffort}
+	case IsDisabled(stored):
+		// The stored effort is the only on/off source; "disable" is off.
+		return &Config{Disabled: true, OffEffort: offEffort}
+	default:
+		return &Config{Active: true, Adaptive: adaptive, Effort: pickEffort("", stored, levels), OffEffort: offEffort}
+	}
+}
+
+// isAdaptiveWire reports whether a call should use the Anthropic adaptive wire.
+//
+// A declared adaptive mode says so directly. Beyond that, Anthropic 4.6+ uses the
+// effort/adaptive wire (no budget_tokens), and cloud variants
+// (bedrock/vertex/azure/openrouter) are missing supports_adaptive_thinking in the
+// LiteLLM registry while still advertising the 4.6+ effort tiers — so promote them
+// here. This keeps them off the legacy budget path, where budget_tokens is
+// rejected with 400 on 4.7+.
+func isAdaptiveWire(mode string, levels []string, clientType string) bool {
+	if mode == ModeAdaptive {
+		return true
+	}
+	return clientType == ClientTypeAnthropicMessages && anthropicEffortEra(levels)
+}
+
+// anthropicEffortEra reports whether an Anthropic model uses the 4.6+
+// effort/adaptive thinking mechanism rather than the legacy
+// thinking{type:"enabled", budget_tokens:N} path. Pre-4.6 Claude advertises only
+// the implicit low/medium/high base; 4.6+ adds at least one of minimal/xhigh/max.
+// Detecting any of those catches the cloud-provider variants that the registry
+// leaves without supports_adaptive_thinking.
+//
+// The disable token is deliberately not a signal. It declares that a model can be
+// turned off, which every Claude generation can do, so reading it as "4.6+" would
+// put a legacy model on the adaptive wire that it rejects.
+func anthropicEffortEra(levels []string) bool {
+	for _, e := range levels {
+		switch e {
+		case EffortMinimal, EffortXHigh, EffortMax:
+			return true
+		}
+	}
+	return false
+}
+
+// pickEffort resolves the effort to send when thinking is active: the per-message
+// override (if a concrete tier) wins, then the stored default, then medium. Values
+// outside the effective model+wire effort list are ignored so stale settings or
+// command/API overrides cannot send a known-invalid wire value.
+func pickEffort(requested, stored string, levels []string) string {
+	if e := strings.TrimSpace(requested); e != "" && e != EffortAdaptive && e != EffortDisable {
+		if hasEffort(levels, e) {
+			return e
+		}
+	}
+	// The stored effort is skipped when it means "off". pickEffort only runs once
+	// reasoning is on, and "off" is advertisable, so without this guard a bot
+	// parked on off would hand the disable token back as an active tier and send it
+	// upstream, where no provider knows the word.
+	if e := strings.TrimSpace(stored); e != "" && !IsDisabled(e) && hasEffort(levels, e) {
+		return e
+	}
+	if hasEffort(levels, EffortMedium) {
+		return EffortMedium
+	}
+	// No medium: land on the tier closest to it rather than on levels[0], which is
+	// whatever the registry listed first (usually the weakest tier).
+	if nearest := NearestToMedium(levels); nearest != "" {
+		return nearest
+	}
+	return EffortMedium
+}
+
+// effectiveEfforts intersects the model's advertised effort levels with the
+// selected client's wire policy, and supplies the common base when a model
+// advertises nothing. Generic OpenAI-format clients drop "max" (they take xhigh as
+// the ceiling); Codex uses its catalog levels directly.
+func effectiveEfforts(advertised []string, clientType string) []string {
+	levels := advertised
+	if len(levels) == 0 {
+		levels = []string{EffortLow, EffortMedium, EffortHigh}
+	}
+	out := make([]string, 0, len(levels))
+	for _, e := range levels {
+		if normalizesMax(clientType) && e == EffortMax {
+			continue
+		}
+		if !hasEffort(out, e) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// normalizesMax reports whether the client's wire policy maps "max" to "xhigh".
+func normalizesMax(clientType string) bool {
+	switch clientType {
+	case clientTypeOpenAICompletions, clientTypeOpenAIResponses:
+		return true
+	default:
+		return false
+	}
+}
+
+// offEffortFor translates "off" into the effort value an OpenAI-format provider
+// needs, or "" when the model cannot be turned off and the caller must omit
+// reasoning_effort entirely. A model that advertises EffortDisable can be switched
+// off, and OpenAI spells that state "none".
+//
+// It deliberately never falls back to a real tier. "minimal" used to serve as a
+// second-best "off", but it enables reasoning rather than disabling it, so Off
+// would have resolved to the same request as the Minimal tier — one state, two
+// selectable options. The two are also mutually exclusive upstream: minimal is
+// gpt-5.0's weakest tier and gpt-5.1 replaced it with none, so "advertises minimal
+// but not none" describes a model that genuinely cannot be turned off. Omitting
+// the field is the honest answer there, and it lets the provider default stand.
+func offEffortFor(levels []string) string {
+	if hasEffort(levels, EffortDisable) {
+		return EffortNone
+	}
+	return ""
+}

--- a/internal/reasoning/vocabulary.go
+++ b/internal/reasoning/vocabulary.go
@@ -1,0 +1,159 @@
+// Package reasoning owns every decision about extended thinking: what a user may
+// select for a model, and what a call actually sends upstream. Both answers come
+// from this package and share the same internals, so "what the picker offers" and
+// "what the wire receives" cannot drift apart — the drift that produced a web
+// picker showing Off on models that could not be turned off, and hiding it on
+// models that could.
+//
+// It is a leaf package on purpose. Everything it needs arrives as plain strings
+// and slices, so any caller can use it: turn orchestration, the subagent spawn
+// path, slash commands, HTTP handlers. Nothing here imports another Memoh package.
+package reasoning
+
+import (
+	"slices"
+	"strings"
+)
+
+// Active effort tiers, weakest to strongest. These are the values that turn
+// reasoning on; "off" is EffortDisable and deliberately not among them.
+const (
+	EffortMinimal = "minimal"
+	EffortLow     = "low"
+	EffortMedium  = "medium"
+	EffortHigh    = "high"
+	EffortXHigh   = "xhigh"
+	EffortMax     = "max"
+)
+
+// EffortDisable is the single representation of "no reasoning". It is both what a
+// user picks and what a model advertises: a model listing it in reasoning_efforts
+// can be turned off, whatever wire shape that takes on its provider. Since bots
+// dropped the separate reasoning_enabled flag, it is also the only stored form of
+// "off".
+const EffortDisable = "disable"
+
+// EffortNone is OpenAI's wire spelling of "no reasoning" (gpt-5.1 introduced it
+// and dropped minimal; gpt-5.0 has minimal and no none). It is never declared by a
+// model nor stored in settings — provider adaptors translate EffortDisable into
+// it, exactly as the Anthropic path translates the same intent into
+// thinking{type:"disabled"}. Giving "off" one name on our side and letting each
+// provider spell it its own way is what keeps a single state from acquiring two
+// selectable tokens.
+const EffortNone = "none"
+
+// EffortAdaptive is a legacy per-message override value. Adaptive is a thinking
+// mode resolved from the model, not a tier a caller selects, but settings written
+// before that distinction existed still carry it, so ResolveConfig accepts it as
+// "on, at the default tier".
+const EffortAdaptive = "adaptive"
+
+// orderedEfforts lists the active tiers weakest to strongest. Order is what
+// NearestToMedium walks, so it must stay monotonic. EffortDisable is absent on
+// purpose: it is not a tier, and including it would let the nearest-tier fallback
+// resolve an *active* reasoning config to "off".
+var orderedEfforts = []string{
+	EffortMinimal,
+	EffortLow,
+	EffortMedium,
+	EffortHigh,
+	EffortXHigh,
+	EffortMax,
+}
+
+// declarableEfforts is the vocabulary a model may advertise: the active tiers plus
+// EffortDisable, which declares that the model can be turned off. EffortNone is
+// absent because it is a provider wire value, not something a model declares.
+var declarableEfforts = map[string]struct{}{
+	EffortDisable: {},
+	EffortMinimal: {},
+	EffortLow:     {},
+	EffortMedium:  {},
+	EffortHigh:    {},
+	EffortXHigh:   {},
+	EffortMax:     {},
+}
+
+// IsDisabled reports whether an effort value means "no reasoning". EffortNone is
+// accepted as the legacy spelling: it was declarable and storable before "off" was
+// unified onto EffortDisable.
+func IsDisabled(effort string) bool {
+	switch strings.TrimSpace(effort) {
+	case EffortDisable, EffortNone:
+		return true
+	}
+	return false
+}
+
+// IsDeclarable reports whether effort can be stored in a model's advertised
+// effort list.
+func IsDeclarable(effort string) bool {
+	_, ok := declarableEfforts[effort]
+	return ok
+}
+
+// NormalizeAdvertised rewrites the legacy spelling of "off" to the token a model
+// declares today, and drops duplicates. It runs on both boundaries of a stored
+// model config — before a write is validated and after a row is read back — so
+// nothing downstream has to know that "none" was ever declarable.
+//
+// Without it the vocabulary change would only apply to freshly written configs:
+// rows persisted earlier, and provider registries that have not been regenerated,
+// would keep advertising "none", and every consumer that now looks for the disable
+// token would read those models as "cannot be turned off" — silently dropping Off
+// from the picker and misreading which thinking mechanism the model wants.
+func NormalizeAdvertised(efforts []string) []string {
+	if len(efforts) == 0 {
+		return efforts
+	}
+	out := make([]string, 0, len(efforts))
+	for _, effort := range efforts {
+		if strings.TrimSpace(effort) == EffortNone {
+			effort = EffortDisable
+		}
+		if !slices.Contains(out, effort) {
+			out = append(out, effort)
+		}
+	}
+	return out
+}
+
+// NearestToMedium picks the tier closest to medium from levels, breaking ties
+// toward the weaker tier. It is the fallback when a model does not advertise
+// medium: [minimal low] -> low, [high max] -> high, [low high] -> low. Ignores
+// values outside the known tier list (including "disable"), and returns "" when
+// levels has no usable tier.
+func NearestToMedium(levels []string) string {
+	mediumIdx := slices.Index(orderedEfforts, EffortMedium)
+
+	best, bestIdx, bestDistance := "", 0, 0
+	for _, level := range levels {
+		idx := slices.Index(orderedEfforts, level)
+		if idx < 0 {
+			continue
+		}
+		distance := idx - mediumIdx
+		if distance < 0 {
+			distance = -distance
+		}
+		// Ties break toward the weaker tier (smaller index) rather than toward
+		// whichever came first, because levels arrives in registry order and is
+		// not guaranteed to be sorted.
+		if best == "" || distance < bestDistance || (distance == bestDistance && idx < bestIdx) {
+			best, bestIdx, bestDistance = level, idx, distance
+		}
+	}
+	return best
+}
+
+// hasEffort reports whether levels contains effort.
+func hasEffort(levels []string, effort string) bool {
+	return slices.Contains(levels, effort)
+}
+
+// OrderedEfforts returns the active tiers weakest to strongest. Callers that need
+// a rendering order with "off" at the front prepend EffortDisable themselves — it
+// is not a tier and stays out of this list.
+func OrderedEfforts() []string {
+	return slices.Clone(orderedEfforts)
+}

--- a/internal/settings/service.go
+++ b/internal/settings/service.go
@@ -141,7 +141,7 @@ func (s *Service) UpsertBot(ctx context.Context, botID string, req UpsertRequest
 	if effect := strings.TrimSpace(req.AclDefaultEffect); effect != "" {
 		current.AclDefaultEffect = effect
 	}
-	if req.ReasoningEffort != nil && isValidReasoningEffort(*req.ReasoningEffort) {
+	if req.ReasoningEffort != nil && hasReasoningEffortValue(*req.ReasoningEffort) {
 		current.ReasoningEffort = *req.ReasoningEffort
 	}
 	if req.HeartbeatEnabled != nil {
@@ -473,7 +473,7 @@ func normalizeBotSetting(language string, commandUILanguage string, aclDefaultEf
 	if settings.AclDefaultEffect == "" {
 		settings.AclDefaultEffect = "allow"
 	}
-	if !isValidReasoningEffort(settings.ReasoningEffort) {
+	if !hasReasoningEffortValue(settings.ReasoningEffort) {
 		settings.ReasoningEffort = DefaultReasoningEffort
 	}
 	if settings.HeartbeatInterval <= 0 {
@@ -518,7 +518,7 @@ func nullableCompactionTargetPercent(value *int) pgtype.Int4 {
 // free-form tier string (models expose their own supported levels via capability
 // discovery), so we only reject empty/whitespace values here; the specific tiers
 // a given model accepts are enforced upstream, not by this generic setting.
-func isValidReasoningEffort(effort string) bool {
+func hasReasoningEffortValue(effort string) bool {
 	return strings.TrimSpace(effort) != ""
 }
 

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -285,8 +285,8 @@ func TestReasoningEffortAllowsFullModelLadder(t *testing.T) {
 	t.Parallel()
 
 	for _, effort := range []string{"none", "low", "medium", "high", "xhigh"} {
-		if !isValidReasoningEffort(effort) {
-			t.Fatalf("isValidReasoningEffort(%q) = false, want true", effort)
+		if !hasReasoningEffortValue(effort) {
+			t.Fatalf("hasReasoningEffortValue(%q) = false, want true", effort)
 		}
 		got := normalizeBotSetting("en", "auto", "allow", effort, false, 60, false, 0, pgtype.Int4{})
 		if got.ReasoningEffort != effort {


### PR DESCRIPTION
Stacked on #966. First step of #982.

## What this does

Moves every reasoning capability decision into `internal/reasoning`, a leaf
package that imports nothing else in the tree. Behaviour is unchanged — this is a
move, not a rewrite.

The property worth reviewing for is that `OptionsFor` (what a picker may offer)
and `ResolveConfig` (what a call sends) share their internals. They were separate
answers before, in separate languages, and every bug in this area was a
disagreement between them. `TestOptionsDefaultEffortMatchesWhatResolveWouldSend`
asserts they agree across five catalogs.

Off-ness also stops being a sentinel inside the tier list. It is
`Options.CanDisable` now, so no consumer has to remember to filter `disable` out
of a list of efforts — the omission that let an *active* config resolve to "off"
twice in #966.

## The evidence that behaviour did not change

The resolver's table-driven tests in `internal/agent/application` pass with
**their assertions untouched**; only symbol names moved. `TestOffEffortFor` moved
to the leaf package verbatim.

## Also removed

| Before | After |
|---|---|
| 4 copies of the effort vocabulary | one, in `internal/reasoning` |
| `native.ModelConfig`, `native.ReasoningConfig` | deleted — both unreferenced |
| `settings.isValidReasoningEffort` | `hasReasoningEffortValue` — it only checked for a non-blank value, while the identically named function in `models` enforced the real vocabulary |
| `RunConfig`'s five flat reasoning fields | one `*models.ReasoningConfig` |

`internal/models` keeps forwarding aliases (`models.ReasoningEffortDisable` etc.)
so existing call sites migrate on their own schedule rather than in one sweep.

## Why the flat fields mattered

They were split for a serialization constraint that does not exist —
`sdk.GenerateParams` is never marshalled — and splitting them is how the subagent
spawn path came to carry one field and silently drop four (#983). Carrying the
config whole makes that class of loss unrepresentable. The spawn path still needs
its own resolution against the subagent's own model; that lands next, now that
`internal/agent/tool` can import a leaf package.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` all green; `gofmt` clean.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.