### PR TITLE
refactor(command): let /reasoning read the model instead of a fixed list

### DIFF
--- a/internal/command/reasoning.go
+++ b/internal/command/reasoning.go
@@ -2,32 +2,41 @@ package command
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/memohai/memoh/internal/i18n"
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
 	"github.com/memohai/memoh/internal/settings"
 )
 
-// reasoningChoices are the selectable reasoning levels. "off" disables thinking;
-// the rest enable it at that effort. Only "off" represents the disabled state —
-// listing "none" here too offered the same state under a second name.
-var reasoningChoices = []string{
-	"off",
-	models.ReasoningEffortLow,
-	models.ReasoningEffortMedium,
-	models.ReasoningEffortHigh,
-	models.ReasoningEffortXHigh,
-}
+// offChoice is the user-facing token for the disabled state. Storage represents
+// it as ReasoningEffortDisable; "off" is what a person types and taps.
+const offChoice = "off"
 
-// validEffort accepts the tiers that turn reasoning on. The disabled state is
-// handled by its own branch before this is consulted.
-func validEffort(v string) bool {
-	switch v {
-	case models.ReasoningEffortLow, models.ReasoningEffortMedium, models.ReasoningEffortHigh, models.ReasoningEffortXHigh:
-		return true
+// reasoningOptions reports what the bot's current chat model can actually do.
+// It replaces a hardcoded list that offered the same five levels on every model —
+// including Off on models that cannot be turned off, and never xhigh's neighbours
+// on models that advertise them.
+//
+// A model that cannot be resolved yields a zero Options, and the caller falls
+// back to accepting any declarable tier rather than blocking the command.
+func (h *Handler) reasoningOptions(cc CommandContext, modelID string) reasoning.Options {
+	if modelID == "" || h.modelsService == nil {
+		return reasoning.Options{}
 	}
-	return false
+	m, err := h.modelsService.GetByID(cc.Ctx, modelID)
+	if err != nil {
+		return reasoning.Options{}
+	}
+	clientType := ""
+	if h.providersService != nil {
+		if p, provErr := h.providersService.Get(cc.Ctx, m.ProviderID); provErr == nil {
+			clientType = p.ClientType
+		}
+	}
+	return m.ReasoningOptions(clientType)
 }
 
 // buildReasoningGroup registers /reasoning — a first-class sibling of /model.
@@ -45,7 +54,7 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			if err != nil {
 				return nil, err
 			}
-			return reasoningResult(cc.L, s.ReasoningEffort), nil
+			return reasoningResult(cc.L, s.ReasoningEffort, h.reasoningOptions(cc, s.ChatModelID)), nil
 		},
 	})
 	g.Register(SubCommand{
@@ -60,14 +69,20 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			if h.settingsService == nil {
 				return &Result{Text: cc.T("cmd.reasoning.unavailable")}, nil
 			}
+			current, err := h.getBotSettings(cc)
+			if err != nil {
+				return nil, err
+			}
+			opts := h.reasoningOptions(cc, current.ChatModelID)
+
 			req := settings.UpsertRequest{}
 			switch {
-			case level == "off":
+			case level == offChoice:
 				// "off" is the user-facing token; storage represents it as the
 				// "disable" effort now that bots have no separate on/off flag.
 				disable := models.ReasoningEffortDisable
 				req.ReasoningEffort = &disable
-			case validEffort(level):
+			case acceptsEffort(level, opts):
 				req.ReasoningEffort = &level
 			default:
 				return &Result{Text: cc.T("cmd.reasoning.unknownLevel", map[string]any{"level": fmt.Sprintf("%q", cc.Args[0])})}, nil
@@ -79,7 +94,7 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			if err != nil {
 				return nil, err
 			}
-			return reasoningResult(cc.L, s.ReasoningEffort), nil
+			return reasoningResult(cc.L, s.ReasoningEffort, opts), nil
 		},
 	})
 	return g
@@ -94,7 +109,7 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 // time (IsWrite), so a non-owner tap returns a clear "owner only" message rather
 // than the buttons being hidden — hiding them also hid them from owners whose
 // Telegram identity isn't resolved as owner, killing the feature.
-func reasoningResult(t *i18n.Localizer, effort string) *Result {
+func reasoningResult(t *i18n.Localizer, effort string, opts reasoning.Options) *Result {
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	disabled := models.IsReasoningDisabled(effort)
 	current := effort
@@ -105,10 +120,10 @@ func reasoningResult(t *i18n.Localizer, effort string) *Result {
 		current = t.T("cmd.common.on")
 	}
 	header := MdBold(t.T("cmd.reasoning.header")) + "\n" + t.T("cmd.reasoning.current", map[string]any{"level": current})
-	choices := make([]ListItem, 0, len(reasoningChoices))
-	for _, lvl := range reasoningChoices {
+	choices := make([]ListItem, 0, len(opts.Efforts)+1)
+	for _, lvl := range reasoningChoicesFor(opts) {
 		selected := false
-		if lvl == "off" {
+		if lvl == offChoice {
 			selected = disabled
 		} else {
 			selected = !disabled && lvl == effort
@@ -133,4 +148,35 @@ func reasoningResult(t *i18n.Localizer, effort string) *Result {
 			Choices: &ChoicesView{Title: body, Choices: choices},
 		},
 	}
+}
+
+// reasoningChoicesFor renders the levels this model actually offers, with "off"
+// leading when off is reachable. When the model cannot be resolved it falls back
+// to the tiers every reasoning model has, so the command still works rather than
+// showing an empty picker.
+func reasoningChoicesFor(opts reasoning.Options) []string {
+	tiers := opts.Efforts
+	if !opts.Supported {
+		return []string{
+			offChoice,
+			reasoning.EffortLow,
+			reasoning.EffortMedium,
+			reasoning.EffortHigh,
+		}
+	}
+	out := make([]string, 0, len(tiers)+1)
+	if opts.CanDisable {
+		out = append(out, offChoice)
+	}
+	return append(out, tiers...)
+}
+
+// acceptsEffort reports whether a typed tier can be stored. An unresolvable model
+// accepts any declarable tier rather than rejecting everything, since the
+// resolver filters unusable values at call time anyway.
+func acceptsEffort(level string, opts reasoning.Options) bool {
+	if !opts.Supported {
+		return reasoning.IsDeclarable(level) && !reasoning.IsDisabled(level)
+	}
+	return slices.Contains(opts.Efforts, level)
 }

--- a/internal/command/reasoning_test.go
+++ b/internal/command/reasoning_test.go
@@ -1,11 +1,13 @@
 package command
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/memohai/memoh/internal/i18n"
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
 )
 
 func TestReasoningRegisteredWithAliases(t *testing.T) {
@@ -24,9 +26,25 @@ func TestReasoningRegisteredWithAliases(t *testing.T) {
 	}
 }
 
+// fullLadderOptions is a model that can be turned off and advertises the whole
+// ladder — what the command used to assume of every model unconditionally.
+func fullLadderOptions() reasoning.Options {
+	return reasoning.OptionsFor(
+		reasoning.ModeToggle,
+		[]string{
+			reasoning.EffortDisable,
+			reasoning.EffortLow,
+			reasoning.EffortMedium,
+			reasoning.EffortHigh,
+			reasoning.EffortXHigh,
+		},
+		"openai-codex",
+	)
+}
+
 func TestReasoningResultMarksCurrent(t *testing.T) {
 	t.Parallel()
-	res := reasoningResult(i18n.New("en"), "medium")
+	res := reasoningResult(i18n.New("en"), "medium", fullLadderOptions())
 	if res.Interactive == nil || res.Interactive.Kind != InteractiveChoices || res.Interactive.Choices == nil {
 		t.Fatalf("expected a choices interactive, got %+v", res.Interactive)
 	}
@@ -34,12 +52,12 @@ func TestReasoningResultMarksCurrent(t *testing.T) {
 	if !strings.Contains(res.Text, "Current: medium") {
 		t.Errorf("missing current line: %s", res.Text)
 	}
-	assertReasoningMarked(t, reasoningResult(i18n.New("en"), models.ReasoningEffortDisable), "off")
+	assertReasoningMarked(t, reasoningResult(i18n.New("en"), models.ReasoningEffortDisable, fullLadderOptions()), "off")
 }
 
 func TestReasoningChoicesIncludeFullBackendEffortLadder(t *testing.T) {
 	t.Parallel()
-	res := reasoningResult(i18n.New("en"), "xhigh")
+	res := reasoningResult(i18n.New("en"), "xhigh", fullLadderOptions())
 	assertReasoningMarked(t, res, "xhigh")
 	labels := make(map[string]bool)
 	for _, c := range res.Interactive.Choices.Choices {
@@ -77,7 +95,7 @@ func assertReasoningMarked(t *testing.T, res *Result, want string) {
 // button must re-parse to "/reasoning set <level>" so the tap actually applies.
 func TestReasoningChoiceCallbackRoundTrip(t *testing.T) {
 	t.Parallel()
-	for _, lvl := range reasoningChoices {
+	for _, lvl := range reasoningChoicesFor(fullLadderOptions()) {
 		data := EncodeListCallback("reasoning", "set", []string{lvl}, 0)
 		if len(data) > telegramCallbackLimit {
 			t.Fatalf("callback %q exceeds limit", data)
@@ -117,5 +135,75 @@ func TestUnknownCommandHandling(t *testing.T) {
 		if !h.IsCommand(c) {
 			t.Errorf("%s should be a known command", c)
 		}
+	}
+}
+
+// TestReasoningChoicesFollowTheModel is the behaviour change: the picker used to
+// offer the same five levels on every model, including Off on models that cannot
+// be turned off and never the tiers a model actually advertises.
+func TestReasoningChoicesFollowTheModel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		opts   reasoning.Options
+		want   []string
+		absent []string
+	}{
+		{
+			name: "a model that can be turned off leads with off",
+			opts: reasoning.OptionsFor(reasoning.ModeToggle,
+				[]string{reasoning.EffortDisable, reasoning.EffortLow, reasoning.EffortHigh},
+				"openai-codex"),
+			want: []string{"off", "low", "high"},
+		},
+		{
+			name: "a model that cannot be turned off does not offer it",
+			opts: reasoning.OptionsFor(reasoning.ModeToggle,
+				[]string{reasoning.EffortMinimal, reasoning.EffortLow, reasoning.EffortMedium},
+				"openai-codex"),
+			want:   []string{"minimal", "low", "medium"},
+			absent: []string{"off"},
+		},
+		{
+			name: "an unresolvable model keeps the command usable",
+			opts: reasoning.Options{},
+			want: []string{"off", "low", "medium", "high"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := reasoningChoicesFor(tt.opts)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("choices = %v, want %v", got, tt.want)
+			}
+			for _, absent := range tt.absent {
+				if slices.Contains(got, absent) {
+					t.Fatalf("choices unexpectedly offer %q: %v", absent, got)
+				}
+			}
+		})
+	}
+}
+
+// TestAcceptsEffortRejectsTiersTheModelDoesNotOffer keeps a typed level from
+// storing a value the model will never accept — the /reasoning half of the same
+// guarantee the picker gives by only rendering reachable options.
+func TestAcceptsEffortRejectsTiersTheModelDoesNotOffer(t *testing.T) {
+	t.Parallel()
+
+	opts := reasoning.OptionsFor(reasoning.ModeToggle,
+		[]string{reasoning.EffortLow, reasoning.EffortMedium}, "openai-codex")
+
+	if !acceptsEffort(reasoning.EffortLow, opts) {
+		t.Error("an advertised tier should be accepted")
+	}
+	if acceptsEffort(reasoning.EffortXHigh, opts) {
+		t.Error("a tier the model does not advertise should be rejected")
+	}
+	if acceptsEffort(reasoning.EffortDisable, opts) {
+		t.Error("the disable token is not a tier and has its own branch")
 	}
 }

--- a/internal/command/settings_i18n_test.go
+++ b/internal/command/settings_i18n_test.go
@@ -13,7 +13,7 @@ import (
 // but the level button labels and their dispatched Args stay canonical tokens.
 func TestReasoningResultZhLocalizesProseNotTokens(t *testing.T) {
 	t.Parallel()
-	res := reasoningResult(i18n.New("zh"), "xhigh")
+	res := reasoningResult(i18n.New("zh"), "xhigh", fullLadderOptions())
 	title := res.Interactive.Choices.Title
 	if !strings.Contains(title, "🧠 推理") {
 		t.Errorf("zh header missing, title=%q", title)

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -311,7 +311,7 @@
       "unknownOption": "Unknown option: {option}\n\n{usage}",
       "unknownLanguage": "Unknown language {value}. Choose auto, en, zh, or ja.",
       "unavailable": "Settings aren't available right now.",
-      "updateUsage": "Usage: /settings update [options]\n\nOptions:\n- --language <value>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|none|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <minutes>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n(Command UI language: /settings language <auto|en|zh|ja>)",
+      "updateUsage": "Usage: /settings update [options]\n\nOptions:\n- --language <value>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <minutes>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n(Command UI language: /settings language <auto|en|zh|ja>)",
       "langJa": "日本語"
     },
     "language": {
@@ -509,7 +509,7 @@
       "header": "🧠 Reasoning",
       "current": "Current: {level}",
       "choosePrompt": "Higher effort means more careful thinking, but slower replies. Choose a level:",
-      "setUsage": "Usage: /reasoning set <off|none|low|medium|high|xhigh>",
+      "setUsage": "Usage: /reasoning set <off|low|medium|high|xhigh>",
       "unavailable": "Reasoning isn't available right now.",
       "unknownLevel": "Unknown level {level} — choose off, none, low, medium, high, or xhigh."
     },

--- a/internal/i18n/locales/ja.json
+++ b/internal/i18n/locales/ja.json
@@ -311,7 +311,7 @@
       "unknownOption": "不明なオプション: {option}\n\n{usage}",
       "unknownLanguage": "不明な言語 {value}。auto、en、zh、ja から選んでください。",
       "unavailable": "現在設定は利用できません。",
-      "updateUsage": "使い方: /settings update [options]\n\nOptions:\n- --language <value>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|none|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <minutes>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n(Command UI language: /settings language <auto|en|zh|ja>)",
+      "updateUsage": "使い方: /settings update [options]\n\nOptions:\n- --language <value>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <minutes>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n(Command UI language: /settings language <auto|en|zh|ja>)",
       "langJa": "日本語"
     },
     "language": {
@@ -509,7 +509,7 @@
       "header": "🧠 推論",
       "current": "現在: {level}",
       "choosePrompt": "努力が増えると、より慎重に考えることになりますが、応答は遅くなります。レベルを選択してください:",
-      "setUsage": "使い方: /reasoning set<off|none|low|medium|high|xhigh>",
+      "setUsage": "使い方: /reasoning set<off|low|medium|high|xhigh>",
       "unavailable": "推論は現在利用できません。",
       "unknownLevel": "不明レベル {level} — off、none、low、medium、high、または xhigh を選択します。"
     },

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -311,7 +311,7 @@
       "unknownOption": "未知选项：{option}\n\n{usage}",
       "unknownLanguage": "未知语言 {value}。请选择 auto、en、zh 或 ja。",
       "unavailable": "设置暂不可用。",
-      "updateUsage": "用法：/settings update [选项]\n\n选项：\n- --language <值>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|none|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <分钟>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n（命令界面语言：/settings language <auto|en|zh|ja>）",
+      "updateUsage": "用法：/settings update [选项]\n\n选项：\n- --language <值>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <分钟>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n（命令界面语言：/settings language <auto|en|zh|ja>）",
       "langJa": "日本語"
     },
     "language": {
@@ -509,7 +509,7 @@
       "header": "🧠 推理",
       "current": "当前：{level}",
       "choosePrompt": "强度越高思考越深入，但回复更慢。选择级别：",
-      "setUsage": "用法：/reasoning set <off|none|low|medium|high|xhigh>",
+      "setUsage": "用法：/reasoning set <off|low|medium|high|xhigh>",
       "unavailable": "推理功能暂不可用。",
       "unknownLevel": "未知级别 {level}，请选择 off、none、low、medium、high 或 xhigh。"
     },


### PR DESCRIPTION
Stacked on #985. Part of #982.

## The change

`/reasoning` offered `off, low, medium, high, xhigh` on every model, having never
consulted one. Wrong in both directions:

- **Off appeared on models that cannot be turned off**, where picking it does
  nothing the provider honours
- **`minimal` and `max` never appeared** on the models that advertise them

It was also the fourth copy of the effort vocabulary in the tree, and the one
furthest from the resolver that decides what actually gets sent.

The command now asks the bot's current chat model through the same `OptionsFor`
the picker and the resolver share (#984). A typed level is validated the same
way, so a tier the model does not offer is refused at the command rather than
stored and quietly ignored at call time.

## Fallback

A model that cannot be resolved — no chat model set, or the lookup fails — falls
back to the common `off/low/medium/high` ladder rather than rendering an empty
picker. Breaking the command because a model row is missing is a worse answer
than offering the tiers every reasoning model has.

## Also

The usage strings in all three locales still advertised `none`, which stopped
being selectable when #966 gave off a single name.

## Tests

`TestReasoningChoicesFollowTheModel` covers the three cases that used to be one:
a model that can be turned off, one that cannot, and an unresolvable one.
`TestAcceptsEffortRejectsTiersTheModelDoesNotOffer` covers the typed-level half.

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt` clean.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.