### PR TITLE
feat(api): ship resolved reasoning options with every chat model

### DIFF
--- a/internal/handlers/models.go
+++ b/internal/handlers/models.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -13,18 +14,57 @@ import (
 	"github.com/memohai/memoh/internal/auth"
 	"github.com/memohai/memoh/internal/models"
 	"github.com/memohai/memoh/internal/oauthctx"
+	"github.com/memohai/memoh/internal/providers"
 )
 
 type ModelsHandler struct {
-	service *models.Service
-	logger  *slog.Logger
+	service   *models.Service
+	providers *providers.Service
+	logger    *slog.Logger
 }
 
-func NewModelsHandler(log *slog.Logger, service *models.Service) *ModelsHandler {
+func NewModelsHandler(log *slog.Logger, service *models.Service, providerSvc *providers.Service) *ModelsHandler {
 	return &ModelsHandler{
-		service: service,
-		logger:  log.With(slog.String("handler", "models")),
+		service:   service,
+		providers: providerSvc,
+		logger:    log.With(slog.String("handler", "models")),
 	}
+}
+
+// withReasoning fills each model's resolved reasoning options. It is computed
+// here rather than stored because it depends on the provider's client type,
+// which lives one join away from the model row — and because it is a projection
+// of the catalog, not a fact about it.
+//
+// A provider that cannot be read yields options resolved with an empty client
+// type: the model's own tiers still come through, only the wire policy is
+// missing. That is strictly better than omitting the field and sending the
+// frontend back to deriving it.
+func (h *ModelsHandler) withReasoning(ctx context.Context, list []models.GetResponse) []models.GetResponse {
+	clientTypes := make(map[string]string, 4)
+	for i := range list {
+		if list[i].Type != models.ModelTypeChat {
+			continue
+		}
+		providerID := list[i].ProviderID
+		clientType, cached := clientTypes[providerID]
+		if !cached {
+			if h.providers != nil {
+				if p, err := h.providers.Get(ctx, providerID); err == nil {
+					clientType = p.ClientType
+				}
+			}
+			clientTypes[providerID] = clientType
+		}
+		opts := list[i].ReasoningOptions(clientType)
+		list[i].Reasoning = &opts
+	}
+	return list
+}
+
+// withReasoningOne is withReasoning for a single model.
+func (h *ModelsHandler) withReasoningOne(ctx context.Context, m models.GetResponse) models.GetResponse {
+	return h.withReasoning(ctx, []models.GetResponse{m})[0]
 }
 
 func (h *ModelsHandler) Register(e *echo.Echo) {
@@ -99,7 +139,7 @@ func (h *ModelsHandler) List(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, resp)
+	return c.JSON(http.StatusOK, h.withReasoning(c.Request().Context(), resp))
 }
 
 // GetByID godoc
@@ -122,7 +162,7 @@ func (h *ModelsHandler) GetByID(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
-	return c.JSON(http.StatusOK, resp)
+	return c.JSON(http.StatusOK, h.withReasoningOne(c.Request().Context(), resp))
 }
 
 // GetByModelID godoc
@@ -156,7 +196,7 @@ func (h *ModelsHandler) GetByModelID(c echo.Context) error {
 		}
 		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
-	return c.JSON(http.StatusOK, resp)
+	return c.JSON(http.StatusOK, h.withReasoningOne(c.Request().Context(), resp))
 }
 
 // UpdateByID godoc

--- a/internal/handlers/models_reasoning_test.go
+++ b/internal/handlers/models_reasoning_test.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/models"
+)
+
+// A handler with no providers service stands in for the case where a provider
+// row cannot be read: the model's own tiers still resolve, only the wire policy
+// is missing. Omitting the field there would send clients back to deriving it.
+func newReasoningTestHandler() *ModelsHandler {
+	return &ModelsHandler{logger: slog.Default()}
+}
+
+func chatModel(cfg models.ModelConfig) models.GetResponse {
+	return models.GetResponse{
+		ID:      "00000000-0000-0000-0000-000000000001",
+		ModelID: "test-model",
+		Model: models.Model{
+			ModelID: "test-model",
+			Type:    models.ModelTypeChat,
+			Config:  cfg,
+		},
+	}
+}
+
+func TestWithReasoningFillsResolvedOptions(t *testing.T) {
+	t.Parallel()
+
+	list := newReasoningTestHandler().withReasoning(context.Background(), []models.GetResponse{
+		chatModel(models.ModelConfig{
+			ThinkingMode:     models.ThinkingModeToggle,
+			ReasoningEfforts: []string{models.ReasoningEffortDisable, models.ReasoningEffortLow, models.ReasoningEffortHigh},
+		}),
+	})
+
+	got := list[0].Reasoning
+	if got == nil {
+		t.Fatal("chat model should carry resolved reasoning options")
+	}
+	if !got.Supported || !got.CanDisable {
+		t.Fatalf("expected a supported, disableable model: %+v", got)
+	}
+	// The disable token declares a capability; it must not come back as a tier.
+	for _, e := range got.Efforts {
+		if e == models.ReasoningEffortDisable {
+			t.Fatalf("disable leaked into the tier list: %v", got.Efforts)
+		}
+	}
+	if got.DefaultEffort == "" {
+		t.Fatal("a supported model should carry a default effort")
+	}
+}
+
+func TestWithReasoningMarksModelsThatCannotThink(t *testing.T) {
+	t.Parallel()
+
+	list := newReasoningTestHandler().withReasoning(context.Background(), []models.GetResponse{
+		chatModel(models.ModelConfig{ThinkingMode: models.ThinkingModeNone}),
+	})
+
+	got := list[0].Reasoning
+	if got == nil {
+		t.Fatal("the field should be present and honest, not omitted")
+	}
+	if got.Supported || got.CanDisable || len(got.Efforts) > 0 {
+		t.Fatalf("a model with no thinking concept should offer nothing: %+v", got)
+	}
+}
+
+func TestWithReasoningSkipsNonChatModels(t *testing.T) {
+	t.Parallel()
+
+	embedding := chatModel(models.ModelConfig{})
+	embedding.Type = models.ModelTypeEmbedding
+
+	list := newReasoningTestHandler().withReasoning(context.Background(), []models.GetResponse{embedding})
+	if list[0].Reasoning != nil {
+		t.Fatalf("embedding models have no reasoning control: %+v", list[0].Reasoning)
+	}
+}
+
+// The wire contract clients read. Field names are snake_case like the rest of the
+// API, and a model that cannot think still sends the object so a client can tell
+// "no thinking" from "the server did not say".
+func TestReasoningOptionsSerializeAsSnakeCase(t *testing.T) {
+	t.Parallel()
+
+	list := newReasoningTestHandler().withReasoning(context.Background(), []models.GetResponse{
+		chatModel(models.ModelConfig{
+			ThinkingMode:     models.ThinkingModeToggle,
+			ReasoningEfforts: []string{models.ReasoningEffortLow, models.ReasoningEffortHigh},
+		}),
+	})
+
+	encoded, err := json.Marshal(list[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{`"reasoning"`, `"supported"`, `"can_disable"`, `"efforts"`, `"default_effort"`} {
+		if !strings.Contains(string(encoded), want) {
+			t.Fatalf("payload missing %s: %s", want, encoded)
+		}
+	}
+}

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -238,6 +238,11 @@ type GetResponse struct {
 	ID      string `json:"id"`
 	ModelID string `json:"model_id"`
 	Model
+	// Reasoning is the model's resolved thinking options, filled by the API layer
+	// (it depends on the provider's client type). Clients render this rather than
+	// deriving their own answer from ThinkingMode and ReasoningEfforts — the
+	// duplication that let the web picker and the wire disagree.
+	Reasoning *reasoning.Options `json:"reasoning,omitempty"`
 }
 
 // UpdateRequest is the payload for updating an existing model. Enable is a

--- a/internal/reasoning/options.go
+++ b/internal/reasoning/options.go
@@ -12,14 +12,14 @@ package reasoning
 type Options struct {
 	// Supported is false when the model has no thinking concept; the other fields
 	// are then empty and no control should be rendered at all.
-	Supported bool
+	Supported bool `json:"supported"`
 	// CanDisable reports whether picking "off" actually reaches the model.
-	CanDisable bool
+	CanDisable bool `json:"can_disable"`
 	// Efforts are the selectable active tiers, weakest to strongest as advertised.
-	Efforts []string
+	Efforts []string `json:"efforts,omitempty"`
 	// DefaultEffort is the tier to use when nothing is stored, and the tier to fall
 	// back to when a stored value is no longer offered by the model.
-	DefaultEffort string
+	DefaultEffort string `json:"default_effort,omitempty"`
 }
 
 // Client types whose wire expresses "off" by omitting the field rather than by

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -20572,6 +20572,14 @@ const docTemplate = `{
                 "provider_id": {
                     "type": "string"
                 },
+                "reasoning": {
+                    "description": "Reasoning is the model's resolved thinking options, filled by the API layer\n(it depends on the provider's client type). Clients render this rather than\nderiving their own answer from ThinkingMode and ReasoningEfforts — the\nduplication that let the web picker and the wire disagree.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/reasoning.Options"
+                        }
+                    ]
+                },
                 "type": {
                     "$ref": "#/definitions/models.ModelType"
                 }
@@ -21368,6 +21376,30 @@ const docTemplate = `{
                 },
                 "type": {
                     "type": "string"
+                }
+            }
+        },
+        "reasoning.Options": {
+            "type": "object",
+            "properties": {
+                "can_disable": {
+                    "description": "CanDisable reports whether picking \"off\" actually reaches the model.",
+                    "type": "boolean"
+                },
+                "default_effort": {
+                    "description": "DefaultEffort is the tier to use when nothing is stored, and the tier to fall\nback to when a stored value is no longer offered by the model.",
+                    "type": "string"
+                },
+                "efforts": {
+                    "description": "Efforts are the selectable active tiers, weakest to strongest as advertised.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "supported": {
+                    "description": "Supported is false when the model has no thinking concept; the other fields\nare then empty and no control should be rendered at all.",
+                    "type": "boolean"
                 }
             }
         },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -20563,6 +20563,14 @@
                 "provider_id": {
                     "type": "string"
                 },
+                "reasoning": {
+                    "description": "Reasoning is the model's resolved thinking options, filled by the API layer\n(it depends on the provider's client type). Clients render this rather than\nderiving their own answer from ThinkingMode and ReasoningEfforts — the\nduplication that let the web picker and the wire disagree.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/reasoning.Options"
+                        }
+                    ]
+                },
                 "type": {
                     "$ref": "#/definitions/models.ModelType"
                 }
@@ -21359,6 +21367,30 @@
                 },
                 "type": {
                     "type": "string"
+                }
+            }
+        },
+        "reasoning.Options": {
+            "type": "object",
+            "properties": {
+                "can_disable": {
+                    "description": "CanDisable reports whether picking \"off\" actually reaches the model.",
+                    "type": "boolean"
+                },
+                "default_effort": {
+                    "description": "DefaultEffort is the tier to use when nothing is stored, and the tier to fall\nback to when a stored value is no longer offered by the model.",
+                    "type": "string"
+                },
+                "efforts": {
+                    "description": "Efforts are the selectable active tiers, weakest to strongest as advertised.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "supported": {
+                    "description": "Supported is false when the model has no thinking concept; the other fields\nare then empty and no control should be rendered at all.",
+                    "type": "boolean"
                 }
             }
         },

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -4031,6 +4031,14 @@ definitions:
         type: string
       provider_id:
         type: string
+      reasoning:
+        allOf:
+        - $ref: '#/definitions/reasoning.Options'
+        description: |-
+          Reasoning is the model's resolved thinking options, filled by the API layer
+          (it depends on the provider's client type). Clients render this rather than
+          deriving their own answer from ThinkingMode and ReasoningEfforts — the
+          duplication that let the web picker and the wire disagree.
       type:
         $ref: '#/definitions/models.ModelType'
     type: object
@@ -4565,6 +4573,29 @@ definitions:
         type: integer
       type:
         type: string
+    type: object
+  reasoning.Options:
+    properties:
+      can_disable:
+        description: CanDisable reports whether picking "off" actually reaches the
+          model.
+        type: boolean
+      default_effort:
+        description: |-
+          DefaultEffort is the tier to use when nothing is stored, and the tier to fall
+          back to when a stored value is no longer offered by the model.
+        type: string
+      efforts:
+        description: Efforts are the selectable active tiers, weakest to strongest
+          as advertised.
+        items:
+          type: string
+        type: array
+      supported:
+        description: |-
+          Supported is false when the model has no thinking concept; the other fields
+          are then empty and no control should be rendered at all.
+        type: boolean
     type: object
   schedule.CreateRequest:
     properties:


### PR DESCRIPTION
Stacked on #986. Part of #982.

## What ships

Every chat model in the API now carries the resolved answer instead of the raw
ingredients:

```json
"reasoning": {
  "supported": true,
  "can_disable": true,
  "efforts": ["low", "medium", "high"],
  "default_effort": "medium"
}
```

It comes from the same `OptionsFor` the resolver and `/reasoning` already read
(#984), so what a client renders and what the wire receives are one computation.

## Why the frontend could not get this right

The web picker derived capability from `thinking_mode` + `reasoning_efforts` +
`client_type`, in TypeScript, from a projection that **did not include everything
the answer depends on** — it cannot see `chat_completions_compat` at all, which
is why DeepSeek's Off went missing. It also joined providers itself in three
separate places to learn a client type, and [one of them forgot the
argument](https://github.com/memohai/Memoh/blob/main/apps/web/src/pages/home/components/chat-pane.vue#L1753),
so the chat composer and the settings page disagreed about Claude.

## Design notes

- **The shape follows ACP's existing `ReasoningState`** (`available_efforts` /
  `current_effort` / `supported`) rather than inventing a second pattern for
  native models.
- **Computed in the handler, not stored** — it depends on the provider's client
  type, one join away from the model row, and it is a projection of the catalog
  rather than a fact about it.
- **A provider that cannot be read** still yields the model's own tiers with the
  wire policy missing. That beats omitting the field and sending clients back to
  deriving it.
- **A model with no thinking concept sends `{"supported": false}`** rather than
  nothing, so a client can tell "cannot think" from "the server did not say".

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt` clean.
`mise run swagger-generate` run; `reasoning.Options` is in the spec with
snake_case fields.

The TypeScript SDK regeneration lands with the frontend change that consumes it.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.