### PR TITLE
feat(models): make Gemini's thinking control real

### DIFF
--- a/cmd/synccaps/main.go
+++ b/cmd/synccaps/main.go
@@ -185,14 +185,20 @@ func applyToModel(model *yaml.Node, mode string, efforts []string) bool {
 	if len(wantEfforts) == 0 {
 		wantEfforts = []string{"low", "medium", "high"}
 	}
-	// A hand-maintained disable token is preserved, not overwritten. LiteLLM's
-	// only off signal is the OpenAI-wire supports_none_reasoning_effort flag, so
-	// for providers whose off travels another way (DeepSeek/MiniMax toggle via
-	// chat_completions_compat) the token can only ever come from the template.
-	// Registry silence must not strip what the registry cannot know about.
-	if existing := mapValue(cfg, "reasoning_efforts"); seqContains(existing, "disable") &&
-		!slices.Contains(wantEfforts, "disable") {
-		wantEfforts = append([]string{"disable"}, wantEfforts...)
+	// Hand-maintained tokens the registry cannot know about are preserved rather
+	// than overwritten. LiteLLM's only off signal is the OpenAI-wire
+	// supports_none_reasoning_effort flag, so where off travels another way
+	// (DeepSeek/MiniMax toggle via chat_completions_compat, Gemini 2.5 Flash via a
+	// zero budget) the token can only come from the template. The same holds for
+	// minimal, which the registry reports for exactly one model family while
+	// Gemini 3.x accepts it as its floor. Registry silence is not evidence of
+	// absence.
+	if existing := mapValue(cfg, "reasoning_efforts"); existing != nil {
+		for _, token := range []string{"disable", "minimal"} {
+			if seqContains(existing, token) && !slices.Contains(wantEfforts, token) {
+				wantEfforts = append([]string{token}, wantEfforts...)
+			}
+		}
 	}
 
 	changed := false

--- a/cmd/synccaps/main.go
+++ b/cmd/synccaps/main.go
@@ -194,10 +194,16 @@ func applyToModel(model *yaml.Node, mode string, efforts []string) bool {
 	// Gemini 3.x accepts it as its floor. Registry silence is not evidence of
 	// absence.
 	if existing := mapValue(cfg, "reasoning_efforts"); existing != nil {
+		// Collected in canonical order and prepended once, so the list stays
+		// weakest-to-strongest instead of reversing with each insertion.
+		var carried []string
 		for _, token := range []string{"disable", "minimal"} {
 			if seqContains(existing, token) && !slices.Contains(wantEfforts, token) {
-				wantEfforts = append([]string{token}, wantEfforts...)
+				carried = append(carried, token)
 			}
+		}
+		if len(carried) > 0 {
+			wantEfforts = append(carried, wantEfforts...)
 		}
 	}
 

--- a/cmd/synccaps/main_test.go
+++ b/cmd/synccaps/main_test.go
@@ -147,6 +147,48 @@ models:
 	}
 }
 
+func TestEnrichFilePreservesHandMaintainedMinimalToken(t *testing.T) {
+	t.Parallel()
+
+	// LiteLLM reports supports_minimal for one model family only, while Gemini 3.x
+	// takes minimal as its floor. A template that declares it must survive re-sync
+	// for the same reason the disable token does: registry silence is not evidence
+	// of absence.
+	resolver, err := capabilities.NewResolver([]byte(`{
+		"tier-model": {"mode": "chat", "supports_reasoning": true}
+	}`))
+	if err != nil {
+		t.Fatalf("NewResolver: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "provider.yaml")
+	fixture := `name: Test
+client_type: google-generative-ai
+models:
+  - model_id: tier-model
+    name: Tier
+    type: chat
+    config:
+      compatibilities: [reasoning, tool-call]
+      thinking_mode: toggle
+      reasoning_dialect: tier
+      reasoning_efforts: [minimal, low, medium, high]
+`
+	if err := os.WriteFile(path, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	changed, err := enrichFile(path, resolver, false)
+	if err != nil {
+		t.Fatalf("enrichFile: %v", err)
+	}
+	if changed != 0 {
+		got, _ := os.ReadFile(path) //nolint:gosec // test reads its own temp fixture
+		t.Fatalf("changed = %d, want 0 (minimal and the dialect should survive):\n%s", changed, got)
+	}
+}
+
 func TestEnrichFilePreservesHandMaintainedDisableToken(t *testing.T) {
 	t.Parallel()
 

--- a/conf/providers/anthropic.yaml
+++ b/conf/providers/anthropic.yaml
@@ -11,6 +11,10 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1000000
       thinking_mode: adaptive
+      # 4.6 defaults to thinking off and accepts thinking{type:"disabled"}, per
+      # Anthropic's per-model table. Declared because nothing about the mode or the
+      # tier list distinguishes it from Fable 5, which rejects the same shape.
+      reasoning_off_support: accepted
       reasoning_efforts: [low, medium, high, max]
 
   - model_id: claude-sonnet-4-6
@@ -20,6 +24,10 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1000000
       thinking_mode: adaptive
+      # 4.6 defaults to thinking off and accepts thinking{type:"disabled"}, per
+      # Anthropic's per-model table. Declared because nothing about the mode or the
+      # tier list distinguishes it from Fable 5, which rejects the same shape.
+      reasoning_off_support: accepted
       reasoning_efforts: [low, medium, high, max]
 
   - model_id: claude-opus-4-5-20251101

--- a/conf/providers/google.yaml
+++ b/conf/providers/google.yaml
@@ -11,7 +11,9 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      # The latest aliases resolve to 3.x today, which takes a named level.
+      reasoning_dialect: tier
+      reasoning_efforts: [minimal, low, medium, high]
 
   - model_id: gemini-flash-latest
     name: Gemini Flash Latest
@@ -20,7 +22,9 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      # The latest aliases resolve to 3.x today, which takes a named level.
+      reasoning_dialect: tier
+      reasoning_efforts: [minimal, low, medium, high]
 
   - model_id: gemini-flash-lite-latest
     name: Gemini Flash-Lite Latest
@@ -29,7 +33,9 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      # The latest aliases resolve to 3.x today, which takes a named level.
+      reasoning_dialect: tier
+      reasoning_efforts: [minimal, low, medium, high]
 
   - model_id: gemini-3.1-flash-image-preview
     name: Nano Banana 2
@@ -45,7 +51,9 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      # 3.x takes a named level; minimal is the floor, so there is no off.
+      reasoning_dialect: tier
+      reasoning_efforts: [minimal, low, medium, high]
 
   - model_id: gemini-3.1-flash-lite-preview
     name: Gemini 3.1 Flash-Lite Preview
@@ -54,7 +62,9 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      # 3.x takes a named level; minimal is the floor, so there is no off.
+      reasoning_dialect: tier
+      reasoning_efforts: [minimal, low, medium, high]
 
   - model_id: gemini-3-flash-preview
     name: Gemini 3 Flash Preview
@@ -63,7 +73,9 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      # 3.x takes a named level; minimal is the floor, so there is no off.
+      reasoning_dialect: tier
+      reasoning_efforts: [minimal, low, medium, high]
 
   - model_id: gemini-3-pro-image-preview
     name: Nano Banana Pro
@@ -79,6 +91,11 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
+      # 2.5 controls thinking with a token budget; its floor is positive, so this
+      # model cannot be turned off and does not advertise the disable token.
+      reasoning_dialect: budget
+      thinking_budget_min: 128
+      thinking_budget_max: 32768
       reasoning_efforts: [low, medium, high]
 
   - model_id: gemini-2.5-pro-preview-06-05
@@ -102,7 +119,11 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
-      reasoning_efforts: [low, medium, high]
+      # Flash allows a zero budget, so off is reachable here where it is not on Pro.
+      reasoning_dialect: budget
+      thinking_budget_min: 0
+      thinking_budget_max: 24576
+      reasoning_efforts: [disable, low, medium, high]
 
   - model_id: gemini-2.5-flash-image
     name: Nano Banana
@@ -118,6 +139,9 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
+      reasoning_dialect: budget
+      thinking_budget_min: 512
+      thinking_budget_max: 24576
       reasoning_efforts: [low, medium, high]
 
   - model_id: gemini-2.5-flash-lite-preview-09-2025
@@ -127,6 +151,9 @@ models:
       compatibilities: [vision, file-input, tool-call, reasoning]
       context_window: 1114112
       thinking_mode: toggle
+      reasoning_dialect: budget
+      thinking_budget_min: 512
+      thinking_budget_max: 24576
       reasoning_efforts: [low, medium, high]
 
   - model_id: gemini-2.0-flash

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7
 	github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6
 	github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978
-	github.com/memohai/twilight-ai v0.4.1-0.20260805161855-932415603f21
+	github.com/memohai/twilight-ai v0.4.1-0.20260811053034-702921454f2b
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,8 @@ github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978 h1:
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978/go.mod h1:2LMgK5QYFlTSvrGY+sI/j+jK2WK+YGHv4IMuiW+iPSc=
 github.com/memohai/twilight-ai v0.4.1-0.20260805161855-932415603f21 h1:vfTgct8VppUgwi3HcUymbP2iBrF4U2t3URCsY3AkfLA=
 github.com/memohai/twilight-ai v0.4.1-0.20260805161855-932415603f21/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
+github.com/memohai/twilight-ai v0.4.1-0.20260811053034-702921454f2b h1:jrRyJobfPNp/KQFkXDoRekfowivRyc7XE8sIOnll9r0=
+github.com/memohai/twilight-ai v0.4.1-0.20260811053034-702921454f2b/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -722,6 +722,7 @@ func (s *Service) buildBaseRunConfig(ctx context.Context, p baseRunConfigParams)
 		HTTPClient:            s.streamHTTPClient,
 		ReasoningConfig:       reasoningConfig,
 		ReasoningDialect:      chatModel.Config.ReasoningDialect,
+		ReasoningOffSupport:   chatModel.Config.ReasoningOffSupport,
 		ThinkingBudgetMin:     chatModel.Config.ThinkingBudgetMin,
 		ThinkingBudgetMax:     chatModel.Config.ThinkingBudgetMax,
 	})

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -721,6 +721,9 @@ func (s *Service) buildBaseRunConfig(ctx context.Context, p baseRunConfigParams)
 		ChatCompletionsCompat: chatCompletionsCompat,
 		HTTPClient:            s.streamHTTPClient,
 		ReasoningConfig:       reasoningConfig,
+		ReasoningDialect:      chatModel.Config.ReasoningDialect,
+		ThinkingBudgetMin:     chatModel.Config.ThinkingBudgetMin,
+		ThinkingBudgetMax:     chatModel.Config.ThinkingBudgetMax,
 	})
 
 	var agentSkills []native.SkillEntry

--- a/internal/agent/tool/subagent.go
+++ b/internal/agent/tool/subagent.go
@@ -1641,6 +1641,9 @@ func (p *SpawnProvider) resolveModel(
 		BaseURL:               baseURL,
 		ChatCompletionsCompat: chatCompletionsCompat,
 		ReasoningConfig:       reasoningConfig,
+		ReasoningDialect:      modelInfo.Config.ReasoningDialect,
+		ThinkingBudgetMin:     modelInfo.Config.ThinkingBudgetMin,
+		ThinkingBudgetMax:     modelInfo.Config.ThinkingBudgetMax,
 	})
 	return resolvedSubagentModel{
 		Model:                 sdkModel,

--- a/internal/agent/tool/subagent.go
+++ b/internal/agent/tool/subagent.go
@@ -1642,6 +1642,7 @@ func (p *SpawnProvider) resolveModel(
 		ChatCompletionsCompat: chatCompletionsCompat,
 		ReasoningConfig:       reasoningConfig,
 		ReasoningDialect:      modelInfo.Config.ReasoningDialect,
+		ReasoningOffSupport:   modelInfo.Config.ReasoningOffSupport,
 		ThinkingBudgetMin:     modelInfo.Config.ThinkingBudgetMin,
 		ThinkingBudgetMax:     modelInfo.Config.ThinkingBudgetMax,
 	})

--- a/internal/command/reasoning_test.go
+++ b/internal/command/reasoning_test.go
@@ -39,6 +39,7 @@ func fullLadderOptions() reasoning.Options {
 			reasoning.EffortXHigh,
 		},
 		"openai-codex",
+		"",
 	)
 }
 
@@ -152,16 +153,12 @@ func TestReasoningChoicesFollowTheModel(t *testing.T) {
 	}{
 		{
 			name: "a model that can be turned off leads with off",
-			opts: reasoning.OptionsFor(reasoning.ModeToggle,
-				[]string{reasoning.EffortDisable, reasoning.EffortLow, reasoning.EffortHigh},
-				"openai-codex"),
+			opts: reasoning.OptionsFor(reasoning.ModeToggle, []string{reasoning.EffortDisable, reasoning.EffortLow, reasoning.EffortHigh}, "openai-codex", ""),
 			want: []string{"off", "low", "high"},
 		},
 		{
-			name: "a model that cannot be turned off does not offer it",
-			opts: reasoning.OptionsFor(reasoning.ModeToggle,
-				[]string{reasoning.EffortMinimal, reasoning.EffortLow, reasoning.EffortMedium},
-				"openai-codex"),
+			name:   "a model that cannot be turned off does not offer it",
+			opts:   reasoning.OptionsFor(reasoning.ModeToggle, []string{reasoning.EffortMinimal, reasoning.EffortLow, reasoning.EffortMedium}, "openai-codex", ""),
 			want:   []string{"minimal", "low", "medium"},
 			absent: []string{"off"},
 		},
@@ -194,8 +191,7 @@ func TestReasoningChoicesFollowTheModel(t *testing.T) {
 func TestAcceptsEffortRejectsTiersTheModelDoesNotOffer(t *testing.T) {
 	t.Parallel()
 
-	opts := reasoning.OptionsFor(reasoning.ModeToggle,
-		[]string{reasoning.EffortLow, reasoning.EffortMedium}, "openai-codex")
+	opts := reasoning.OptionsFor(reasoning.ModeToggle, []string{reasoning.EffortLow, reasoning.EffortMedium}, "openai-codex", "")
 
 	if !acceptsEffort(reasoning.EffortLow, opts) {
 		t.Error("an advertised tier should be accepted")

--- a/internal/handlers/models.go
+++ b/internal/handlers/models.go
@@ -228,7 +228,7 @@ func (h *ModelsHandler) UpdateByID(c echo.Context) error {
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, resp)
+	return c.JSON(http.StatusOK, h.withReasoningOne(c.Request().Context(), resp))
 }
 
 // UpdateByModelID godoc
@@ -271,7 +271,7 @@ func (h *ModelsHandler) UpdateByModelID(c echo.Context) error {
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
-	return c.JSON(http.StatusOK, resp)
+	return c.JSON(http.StatusOK, h.withReasoningOne(c.Request().Context(), resp))
 }
 
 // DeleteByID godoc

--- a/internal/handlers/models_reasoning_test.go
+++ b/internal/handlers/models_reasoning_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/providers"
+	"github.com/memohai/memoh/internal/reasoning"
 )
 
 // A handler with no providers service stands in for the case where a provider
@@ -106,5 +108,52 @@ func TestReasoningOptionsSerializeAsSnakeCase(t *testing.T) {
 		if !strings.Contains(string(encoded), want) {
 			t.Fatalf("payload missing %s: %s", want, encoded)
 		}
+	}
+}
+
+// The registry guard covers YAML templates, which is where the dialect is written
+// — but not where it is read from at call time. A model reaches the wire through
+// the import path, and a dialect lost anywhere along it means a Gemini 2.5 row
+// resolved as 3.x: thinkingLevel on a wire that wants thinkingBudget, i.e. a 400
+// on every request. That gap is exactly how the field came to be missing from
+// RemoteModel in the first place.
+func TestImportedModelConfigCarriesTheWireDeclarations(t *testing.T) {
+	t.Parallel()
+
+	budgetMin, budgetMax := 128, 32768
+	remote := providers.RemoteModel{
+		ID:                  "gemini-2.5-pro",
+		Type:                string(models.ModelTypeChat),
+		ReasoningEfforts:    []string{models.ReasoningEffortLow, models.ReasoningEffortHigh},
+		ThinkingMode:        models.ThinkingModeToggle,
+		ReasoningDialect:    reasoning.DialectBudget,
+		ReasoningOffSupport: reasoning.OffSupportRejected,
+		ThinkingBudgetMin:   &budgetMin,
+		ThinkingBudgetMax:   &budgetMax,
+	}
+
+	// The real assembly ImportModels uses. Mirroring it here instead would pass
+	// even if the production path dropped a field, which is the mistake this test
+	// exists to catch.
+	cfg := modelConfigFromRemote(remote, []string{models.CompatReasoning})
+
+	if cfg.ReasoningDialect != reasoning.DialectBudget {
+		t.Errorf("dialect = %q, want %q", cfg.ReasoningDialect, reasoning.DialectBudget)
+	}
+	if cfg.ReasoningOffSupport != reasoning.OffSupportRejected {
+		t.Errorf("off support = %q, want %q", cfg.ReasoningOffSupport, reasoning.OffSupportRejected)
+	}
+	if cfg.ThinkingBudgetMin == nil || *cfg.ThinkingBudgetMin != budgetMin {
+		t.Errorf("budget min = %v, want %d", cfg.ThinkingBudgetMin, budgetMin)
+	}
+	if cfg.ThinkingBudgetMax == nil || *cfg.ThinkingBudgetMax != budgetMax {
+		t.Errorf("budget max = %v, want %d", cfg.ThinkingBudgetMax, budgetMax)
+	}
+
+	// A declared rejection must survive into what a client is offered, or the
+	// picker would show an off switch the wire answers with a 400.
+	m := models.Model{Type: models.ModelTypeChat, Config: cfg}
+	if opts := m.ReasoningOptions("google-generative-ai"); opts.CanDisable {
+		t.Error("a model declaring it rejects an explicit off must not offer one")
 	}
 }

--- a/internal/handlers/providers.go
+++ b/internal/handlers/providers.go
@@ -386,14 +386,7 @@ func (h *ProvidersHandler) ImportModels(c echo.Context) error {
 		if name == "" {
 			name = m.ID
 		}
-		cfg := models.ModelConfig{
-			Description:      m.Description,
-			Compatibilities:  compatibilities,
-			ReasoningEfforts: m.ReasoningEfforts,
-			ThinkingMode:     m.ThinkingMode,
-			ContextWindow:    m.ContextWindow,
-			Dimensions:       m.Dimensions,
-		}
+		cfg := modelConfigFromRemote(m, compatibilities)
 		if managedCatalog {
 			available := true
 			cfg.CatalogAvailable = &available
@@ -495,14 +488,56 @@ func (h *ProvidersHandler) fillExistingModel(ctx context.Context, providerID, mo
 	return true
 }
 
+// preserveDeclaredCapabilities lets discovery refresh the tier list while keeping
+// capability tokens it structurally cannot know about.
+//
+// The disable token declares that a model can be turned off. For providers whose
+// off travels outside the effort field — DeepSeek and MiniMax through
+// chat_completions_compat, Gemini 2.5 Flash through a zero budget — no upstream
+// catalog reports it, so it can only ever come from a hand-maintained template.
+// Replacing the list wholesale on each refresh silently revoked the capability
+// and dropped Off from the picker, which is worse than a stale tier list.
+//
+// Only tokens absent from discovery are carried over, so a genuine upstream change
+// still lands.
+// modelConfigFromRemote builds the stored config for an imported model. It exists
+// as a named function so a test can assert that every wire declaration survives
+// the import path: a dialect or off-support token lost here is lost for every row
+// this path creates, and the resulting model resolves onto the wrong wire — which
+// is how these fields came to be missing from RemoteModel in the first place.
+func modelConfigFromRemote(m providers.RemoteModel, compatibilities []string) models.ModelConfig {
+	return models.ModelConfig{
+		Description:         m.Description,
+		Compatibilities:     compatibilities,
+		ReasoningEfforts:    m.ReasoningEfforts,
+		ThinkingMode:        m.ThinkingMode,
+		ReasoningDialect:    m.ReasoningDialect,
+		ReasoningOffSupport: m.ReasoningOffSupport,
+		ThinkingBudgetMin:   m.ThinkingBudgetMin,
+		ThinkingBudgetMax:   m.ThinkingBudgetMax,
+		ContextWindow:       m.ContextWindow,
+		Dimensions:          m.Dimensions,
+	}
+}
+
+func preserveDeclaredCapabilities(stored, discovered []string) []string {
+	out := append([]string(nil), discovered...)
+	for _, token := range []string{models.ReasoningEffortDisable} {
+		if slices.Contains(stored, token) && !slices.Contains(out, token) {
+			out = append([]string{token}, out...)
+		}
+	}
+	return out
+}
+
 func mergeManagedDiscoveredConfig(existing, discovered models.ModelConfig) (models.ModelConfig, bool) {
 	out, changed := mergeDiscoveredConfig(existing, discovered)
 	if !slices.Equal(out.Compatibilities, discovered.Compatibilities) {
 		out.Compatibilities = append([]string(nil), discovered.Compatibilities...)
 		changed = true
 	}
-	if !slices.Equal(out.ReasoningEfforts, discovered.ReasoningEfforts) {
-		out.ReasoningEfforts = append([]string(nil), discovered.ReasoningEfforts...)
+	if wanted := preserveDeclaredCapabilities(out.ReasoningEfforts, discovered.ReasoningEfforts); !slices.Equal(out.ReasoningEfforts, wanted) {
+		out.ReasoningEfforts = wanted
 		changed = true
 	}
 	if discovered.ThinkingMode != "" && out.ThinkingMode != discovered.ThinkingMode {
@@ -529,9 +564,11 @@ func mergeDiscoveredConfig(existing, discovered models.ModelConfig) (models.Mode
 		out.ThinkingMode = discovered.ThinkingMode
 		changed = true
 	}
-	if len(discovered.ReasoningEfforts) > 0 && !slices.Equal(discovered.ReasoningEfforts, out.ReasoningEfforts) {
-		out.ReasoningEfforts = append([]string(nil), discovered.ReasoningEfforts...)
-		changed = true
+	if len(discovered.ReasoningEfforts) > 0 {
+		if wanted := preserveDeclaredCapabilities(out.ReasoningEfforts, discovered.ReasoningEfforts); !slices.Equal(wanted, out.ReasoningEfforts) {
+			out.ReasoningEfforts = wanted
+			changed = true
+		}
 	}
 	if discovered.ContextWindow != nil && (out.ContextWindow == nil || *discovered.ContextWindow != *out.ContextWindow) {
 		out.ContextWindow = discovered.ContextWindow

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -511,7 +511,7 @@
       "choosePrompt": "Higher effort means more careful thinking, but slower replies. Choose a level:",
       "setUsage": "Usage: /reasoning set <off|low|medium|high|xhigh>",
       "unavailable": "Reasoning isn't available right now.",
-      "unknownLevel": "Unknown level {level} — choose off, none, low, medium, high, or xhigh."
+      "unknownLevel": "Unknown level {level} — pick one of the levels shown above."
     },
     "error": {
       "unknownCommand": "Unknown command {command}. Run {help} to see what's available, or resend without the leading slash to send it as a regular message.",

--- a/internal/i18n/locales/ja.json
+++ b/internal/i18n/locales/ja.json
@@ -511,7 +511,7 @@
       "choosePrompt": "努力が増えると、より慎重に考えることになりますが、応答は遅くなります。レベルを選択してください:",
       "setUsage": "使い方: /reasoning set<off|low|medium|high|xhigh>",
       "unavailable": "推論は現在利用できません。",
-      "unknownLevel": "不明レベル {level} — off、none、low、medium、high、または xhigh を選択します。"
+      "unknownLevel": "不明なレベル {level} —— 上に表示されているレベルから選んでください。"
     },
     "error": {
       "unknownCommand": "不明なコマンド {command}。 {help} を実行して利用可能なものを確認するか、先頭のスラッシュを付けずに再送信して通常のメッセージとして送信します。",

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -511,7 +511,7 @@
       "choosePrompt": "强度越高思考越深入，但回复更慢。选择级别：",
       "setUsage": "用法：/reasoning set <off|low|medium|high|xhigh>",
       "unavailable": "推理功能暂不可用。",
-      "unknownLevel": "未知级别 {level}，请选择 off、none、low、medium、high 或 xhigh。"
+      "unknownLevel": "未知级别 {level} —— 请从上面显示的级别中选择。"
     },
     "error": {
       "unknownCommand": "未知命令 {command}，用 {help} 查看可用命令。也可去掉斜杠作为普通消息发送。",

--- a/internal/models/anthropic_thinking_test.go
+++ b/internal/models/anthropic_thinking_test.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/reasoning"
+)
+
+// Omission is not a way to turn thinking off from Opus 5 on: those models think by
+// default, so an omitted field leaves thinking running — billed as output tokens
+// and counted against max_tokens — while the user believes it is off. Where the
+// model accepts it, the adaptor must say so explicitly.
+func TestAnthropicExplicitOffIsSentWhereAccepted(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		offSupport string
+		want       bool
+	}{
+		{"a model that accepts an explicit disable gets one", reasoning.OffSupportAccepted, true},
+		{"so does one that accepts it below xhigh", reasoning.OffSupportLowEffortOnly, true},
+		{"a model that rejects it gets an omitted field instead", reasoning.OffSupportRejected, false},
+		{"an undeclared model keeps the omission behaviour", "", false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := anthropicAcceptsExplicitOff(tt.offSupport); got != tt.want {
+				t.Fatalf("acceptsExplicitOff(%q) = %v, want %v", tt.offSupport, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/models/google_thinking_test.go
+++ b/internal/models/google_thinking_test.go
@@ -1,0 +1,185 @@
+package models
+
+import (
+	"testing"
+
+	googlegenerative "github.com/memohai/twilight-ai/provider/google/generativeai"
+
+	"github.com/memohai/memoh/internal/reasoning"
+)
+
+func intPtr(v int) *int { return &v }
+
+// The two Gemini generations take mutually exclusive fields, and sending both is
+// a 400. Which one applies comes from the model's declared dialect — never from
+// its id — so these cases are the contract between the catalog and the wire.
+func TestGoogleThinkingFollowsTheDeclaredDialect(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		cfg        SDKModelConfig
+		wantSend   bool
+		wantLevel  string
+		wantBudget *int
+	}{
+		{
+			name: "3.x sends a named level",
+			cfg: SDKModelConfig{
+				ReasoningDialect: reasoning.DialectTier,
+				ReasoningConfig:  &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh},
+			},
+			wantSend:  true,
+			wantLevel: ReasoningEffortHigh,
+		},
+		{
+			name: "2.5 sends a budget inside its own range",
+			cfg: SDKModelConfig{
+				ReasoningDialect:  reasoning.DialectBudget,
+				ThinkingBudgetMin: intPtr(128),
+				ThinkingBudgetMax: intPtr(32768),
+				ReasoningConfig:   &ReasoningConfig{Active: true, Effort: ReasoningEffortMedium},
+			},
+			wantSend: true,
+			// medium sits halfway: 128 + 0.5*(32768-128)
+			wantBudget: intPtr(16448),
+		},
+		{
+			name: "a 2.5 model whose floor is zero can be turned off",
+			cfg: SDKModelConfig{
+				ReasoningDialect:  reasoning.DialectBudget,
+				ThinkingBudgetMin: intPtr(0),
+				ThinkingBudgetMax: intPtr(24576),
+				ReasoningConfig:   &ReasoningConfig{Disabled: true},
+			},
+			wantSend:   true,
+			wantBudget: intPtr(googlegenerative.ThinkingBudgetDisabled),
+		},
+		{
+			// 2.5 Pro's floor is 128, so thinking cannot be switched off at all.
+			// Omitting the field is honest; sending 0 would be a 400.
+			name: "a 2.5 model with a positive floor cannot be turned off",
+			cfg: SDKModelConfig{
+				ReasoningDialect:  reasoning.DialectBudget,
+				ThinkingBudgetMin: intPtr(128),
+				ThinkingBudgetMax: intPtr(32768),
+				ReasoningConfig:   &ReasoningConfig{Disabled: true},
+			},
+			wantSend: false,
+		},
+		{
+			// The tier wire has no off value — minimal is the floor — so a stale
+			// stored "off" sends nothing rather than a bogus level.
+			name: "3.x disabled sends nothing",
+			cfg: SDKModelConfig{
+				ReasoningDialect: reasoning.DialectTier,
+				ReasoningConfig:  &ReasoningConfig{Disabled: true},
+			},
+			wantSend: false,
+		},
+		{
+			name: "active without a tier asks the model to choose",
+			cfg: SDKModelConfig{
+				ReasoningDialect:  reasoning.DialectBudget,
+				ThinkingBudgetMin: intPtr(128),
+				ThinkingBudgetMax: intPtr(32768),
+				ReasoningConfig:   &ReasoningConfig{Active: true},
+			},
+			wantSend:   true,
+			wantBudget: intPtr(googlegenerative.ThinkingBudgetDynamic),
+		},
+		{
+			name:     "no decision sends nothing",
+			cfg:      SDKModelConfig{ReasoningDialect: reasoning.DialectTier},
+			wantSend: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := googleThinkingFor(tt.cfg)
+			if ok != tt.wantSend {
+				t.Fatalf("send = %v, want %v (got %+v)", ok, tt.wantSend, got)
+			}
+			if !tt.wantSend {
+				return
+			}
+			if got.ThinkingLevel != tt.wantLevel {
+				t.Errorf("level = %q, want %q", got.ThinkingLevel, tt.wantLevel)
+			}
+			switch {
+			case tt.wantBudget == nil && got.ThinkingBudget != nil:
+				t.Errorf("budget = %d, want unset", *got.ThinkingBudget)
+			case tt.wantBudget != nil && got.ThinkingBudget == nil:
+				t.Errorf("budget unset, want %d", *tt.wantBudget)
+			case tt.wantBudget != nil && *got.ThinkingBudget != *tt.wantBudget:
+				t.Errorf("budget = %d, want %d", *got.ThinkingBudget, *tt.wantBudget)
+			}
+			// Never both: the API rejects a request carrying budget and level.
+			if got.ThinkingBudget != nil && got.ThinkingLevel != "" {
+				t.Errorf("sent both budget and level: %+v", got)
+			}
+		})
+	}
+}
+
+// Without includeThoughts the API emits no thought parts, so the reasoning stream
+// stays empty even though thinking ran and was billed.
+func TestGoogleThinkingRequestsThoughtsWheneverThinkingIsOn(t *testing.T) {
+	t.Parallel()
+
+	on, ok := googleThinkingFor(SDKModelConfig{
+		ReasoningDialect: reasoning.DialectTier,
+		ReasoningConfig:  &ReasoningConfig{Active: true, Effort: ReasoningEffortLow},
+	})
+	if !ok || on.IncludeThoughts == nil || !*on.IncludeThoughts {
+		t.Fatalf("thinking on should request thoughts: %+v", on)
+	}
+
+	off, ok := googleThinkingFor(SDKModelConfig{
+		ReasoningDialect:  reasoning.DialectBudget,
+		ThinkingBudgetMin: intPtr(0),
+		ThinkingBudgetMax: intPtr(24576),
+		ReasoningConfig:   &ReasoningConfig{Disabled: true},
+	})
+	if !ok {
+		t.Fatal("a zero-floor model should send an explicit off budget")
+	}
+	if off.IncludeThoughts != nil {
+		t.Errorf("thinking off should not ask for thoughts: %+v", off)
+	}
+}
+
+// A budget tier scales with the model's own ceiling rather than a fixed table,
+// because two Gemini models with different ranges cannot share token counts.
+func TestGoogleBudgetScalesWithTheModelRange(t *testing.T) {
+	t.Parallel()
+
+	narrow, _ := googleThinkingFor(SDKModelConfig{
+		ReasoningDialect:  reasoning.DialectBudget,
+		ThinkingBudgetMin: intPtr(512),
+		ThinkingBudgetMax: intPtr(24576),
+		ReasoningConfig:   &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh},
+	})
+	wide, _ := googleThinkingFor(SDKModelConfig{
+		ReasoningDialect:  reasoning.DialectBudget,
+		ThinkingBudgetMin: intPtr(128),
+		ThinkingBudgetMax: intPtr(32768),
+		ReasoningConfig:   &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh},
+	})
+
+	if narrow.ThinkingBudget == nil || wide.ThinkingBudget == nil {
+		t.Fatal("both should carry a budget")
+	}
+	if *narrow.ThinkingBudget >= *wide.ThinkingBudget {
+		t.Errorf("high on a narrower range (%d) should be below high on a wider one (%d)",
+			*narrow.ThinkingBudget, *wide.ThinkingBudget)
+	}
+	// Both must land inside their own bounds; a fixed table would overshoot the
+	// narrower model.
+	if *narrow.ThinkingBudget > 24576 || *wide.ThinkingBudget > 32768 {
+		t.Errorf("budget escaped its range: narrow=%d wide=%d",
+			*narrow.ThinkingBudget, *wide.ThinkingBudget)
+	}
+}

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -34,6 +34,9 @@ type SDKModelConfig struct {
 	ReasoningDialect  string
 	ThinkingBudgetMin *int
 	ThinkingBudgetMax *int
+	// ReasoningOffSupport declares whether this model accepts an explicit
+	// thinking{type:"disabled"}. See anthropicAcceptsExplicitOff.
+	ReasoningOffSupport string
 }
 
 // ReasoningConfig is the resolved extended-thinking decision for one call,
@@ -106,15 +109,26 @@ func NewSDKChatModel(cfg SDKModelConfig) *sdk.Model {
 		//     does not turn it on. The resolver flags every effort-era model as
 		//     Adaptive (including cloud variants missing supports_adaptive_thinking),
 		//     so a non-adaptive active config here is a legacy model.
-		if rc := cfg.ReasoningConfig; rc != nil && rc.Active {
-			if rc.Adaptive {
+		//   - off: an explicit thinking{type:"disabled"} rather than an omitted
+		//     field. Omission means "off" only up to 4.8; from Opus 5 and Sonnet 5
+		//     on, thinking is the default and an omitted field leaves it running —
+		//     billed, counted against max_tokens, and invisible to a user who
+		//     believes they turned it off. Sending the explicit shape is only safe
+		//     where the model accepts it, which the catalog declares.
+		if rc := cfg.ReasoningConfig; rc != nil {
+			switch {
+			case rc.Active && rc.Adaptive:
 				opts = append(opts, anthropicmessages.WithThinking(anthropicmessages.ThinkingConfig{
 					Type: "adaptive",
 				}))
-			} else {
+			case rc.Active:
 				opts = append(opts, anthropicmessages.WithThinking(anthropicmessages.ThinkingConfig{
 					Type:         "enabled",
 					BudgetTokens: legacyAnthropicBudgetFor(rc.Effort),
+				}))
+			case rc.Disabled && anthropicAcceptsExplicitOff(cfg.ReasoningOffSupport):
+				opts = append(opts, anthropicmessages.WithThinking(anthropicmessages.ThinkingConfig{
+					Type: "disabled",
 				}))
 			}
 		}
@@ -383,3 +397,24 @@ func googleBudgetFor(rc *ReasoningConfig, minBudget, maxBudget *int) (int, bool)
 }
 
 func boolPtr(v bool) *bool { return &v }
+
+// anthropicAcceptsExplicitOff reports whether a model takes
+// thinking{type:"disabled"} on the wire.
+//
+// Omitting the field is not a substitute. It reads as "off" only through Opus 4.8;
+// Opus 5, Sonnet 5, Fable 5 and Mythos 5 think by default, so an omitted field
+// leaves thinking running — billed as output tokens and counted against
+// max_tokens, while the user believes it is off. Fable 5 and Mythos 5 also reject
+// the explicit shape with a 400, so it cannot be sent unconditionally either.
+//
+// Only a catalog declaration can tell these apart: the models share a thinking
+// mode and an identical tier list. An undeclared model gets the omission
+// behaviour, which is correct for every generation we currently ship.
+func anthropicAcceptsExplicitOff(offSupport string) bool {
+	switch offSupport {
+	case reasoning.OffSupportAccepted, reasoning.OffSupportLowEffortOnly:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -28,6 +28,12 @@ type SDKModelConfig struct {
 	ChatCompletionsCompat string
 	HTTPClient            *http.Client
 	ReasoningConfig       *ReasoningConfig
+	// ReasoningDialect and the budget bounds come from the model's catalog entry.
+	// They say how this model spells its thinking control, which is not derivable
+	// from the tiers it advertises.
+	ReasoningDialect  string
+	ThinkingBudgetMin *int
+	ThinkingBudgetMax *int
 }
 
 // ReasoningConfig is the resolved extended-thinking decision for one call,
@@ -123,6 +129,9 @@ func NewSDKChatModel(cfg SDKModelConfig) *sdk.Model {
 		if cfg.BaseURL != "" {
 			opts = append(opts, googlegenerative.WithBaseURL(cfg.BaseURL))
 		}
+		if thinking, ok := googleThinkingFor(cfg); ok {
+			opts = append(opts, googlegenerative.WithThinking(thinking))
+		}
 		p := googlegenerative.New(opts...)
 		return p.ChatModel(cfg.ModelID)
 
@@ -198,7 +207,9 @@ func BuildReasoningOptions(cfg SDKModelConfig) []sdk.GenerateOption {
 		return nil
 
 	case ClientTypeGoogleGenerativeAI:
-		// Google thinking is out of scope for the effort wire; leave untouched.
+		// Google's thinking control rides on the provider (see googleThinkingFor),
+		// because budget and level are mutually exclusive and which one applies is
+		// a property of the model, not of the request.
 		return nil
 
 	case ClientTypeOpenAIResponses, ClientTypeOpenAICodex, ClientTypeOpenAICompletions:
@@ -291,3 +302,84 @@ func ResolveClientType(model *sdk.Model) string {
 		return string(ClientTypeOpenAICompletions)
 	}
 }
+
+// googleThinkingFor translates a resolved reasoning decision into Gemini's
+// thinking config. Which field to send is the model's declared dialect, never
+// guessed from its id: 2.5 takes thinkingBudget, 3.x takes thinkingLevel, and
+// sending both is a 400.
+//
+// The budget dialect maps a tier proportionally across the model's own range
+// rather than through fixed token counts. A fixed table cannot be right for two
+// models with different ceilings — 2.5 Pro allows 128..32768 while Flash allows
+// 0..24576 — and the vendors deliberately publish no tier-to-token mapping,
+// describing tiers as relative allowances rather than guarantees.
+//
+// IncludeThoughts is set whenever thinking is on, because the API emits no
+// thought parts without it and the reasoning stream would stay empty.
+func googleThinkingFor(cfg SDKModelConfig) (googlegenerative.ThinkingConfig, bool) {
+	rc := cfg.ReasoningConfig
+	if rc == nil {
+		return googlegenerative.ThinkingConfig{}, false
+	}
+
+	if cfg.ReasoningDialect == reasoning.DialectBudget {
+		budget, ok := googleBudgetFor(rc, cfg.ThinkingBudgetMin, cfg.ThinkingBudgetMax)
+		if !ok {
+			return googlegenerative.ThinkingConfig{}, false
+		}
+		thinking := googlegenerative.ThinkingConfig{ThinkingBudget: &budget}
+		if budget != googlegenerative.ThinkingBudgetDisabled {
+			thinking.IncludeThoughts = boolPtr(true)
+		}
+		return thinking, true
+	}
+
+	// Tier dialect (Gemini 3.x). There is no off value on this wire — minimal is
+	// the floor — so a disabled model sends nothing and lets the provider default
+	// stand. OptionsFor keeps Off out of the picker for such models, so reaching
+	// here with Disabled means a stale stored setting rather than a user choice.
+	if !rc.Active || rc.Effort == "" {
+		return googlegenerative.ThinkingConfig{}, false
+	}
+	return googlegenerative.ThinkingConfig{
+		ThinkingLevel:   rc.Effort,
+		IncludeThoughts: boolPtr(true),
+	}, true
+}
+
+// googleBudgetFor resolves a tier into a token budget within the model's range,
+// or the dynamic/disabled sentinels. It reports false when nothing should be sent.
+func googleBudgetFor(rc *ReasoningConfig, minBudget, maxBudget *int) (int, bool) {
+	switch {
+	case rc.Disabled:
+		// 0 is only legal where the range allows it (Flash/Lite); on a model with a
+		// positive floor, such as 2.5 Pro, thinking cannot be turned off at all and
+		// omitting the field is the honest answer.
+		if minBudget != nil && *minBudget > 0 {
+			return 0, false
+		}
+		return googlegenerative.ThinkingBudgetDisabled, true
+	case !rc.Active:
+		return 0, false
+	case rc.Effort == "":
+		return googlegenerative.ThinkingBudgetDynamic, true
+	}
+
+	ratio, ok := reasoning.BudgetRatio(rc.Effort)
+	if !ok {
+		return googlegenerative.ThinkingBudgetDynamic, true
+	}
+	lo, hi := 0, 0
+	if minBudget != nil {
+		lo = *minBudget
+	}
+	if maxBudget != nil {
+		hi = *maxBudget
+	}
+	if hi <= lo {
+		return googlegenerative.ThinkingBudgetDynamic, true
+	}
+	return lo + int(ratio*float64(hi-lo)), true
+}
+
+func boolPtr(v bool) *bool { return &v }

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -130,6 +130,11 @@ type ModelConfig struct {
 	// sniffing the model id, and an id is not a capability. Empty means the
 	// provider's modern default.
 	ReasoningDialect string `json:"reasoning_dialect,omitempty"`
+	// ReasoningOffSupport declares how the model answers an explicit request to
+	// stop thinking. Anthropic's per-model table splits models that share a
+	// thinking mode and an identical tier list, so this cannot be derived — see the
+	// reasoning package's OffSupport constants.
+	ReasoningOffSupport string `json:"reasoning_off_support,omitempty"`
 	// ThinkingBudgetMin/Max bound the budget dialect. The range is per model
 	// family, not per vendor: Gemini 2.5 Pro is 128..32768 and cannot be turned
 	// off, while Flash starts at 0 and can.
@@ -202,6 +207,9 @@ func (m *Model) Validate() error {
 	if !reasoning.IsValidDialect(m.Config.ReasoningDialect) {
 		return errors.New("invalid reasoning dialect: " + m.Config.ReasoningDialect)
 	}
+	if !reasoning.IsValidOffSupport(m.Config.ReasoningOffSupport) {
+		return errors.New("invalid reasoning off support: " + m.Config.ReasoningOffSupport)
+	}
 	return nil
 }
 
@@ -226,7 +234,12 @@ func (m *Model) ResolveThinkingMode() string {
 // It is the single source every surface reads — the web picker, /reasoning, and
 // the API all render this rather than deriving their own answer.
 func (m *Model) ReasoningOptions(clientType string) reasoning.Options {
-	return reasoning.OptionsFor(m.ResolveThinkingMode(), m.Config.ReasoningEfforts, clientType)
+	return reasoning.OptionsFor(
+		m.ResolveThinkingMode(),
+		m.Config.ReasoningEfforts,
+		clientType,
+		m.Config.ReasoningOffSupport,
+	)
 }
 
 // AddRequest is the payload for creating a new model. Enable is a pointer so

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -123,6 +123,18 @@ type ModelConfig struct {
 	ReasoningEfforts []string `json:"reasoning_efforts,omitempty"`
 	ThinkingMode     string   `json:"thinking_mode,omitempty"`
 	CatalogAvailable *bool    `json:"catalog_available,omitempty"`
+	// ReasoningDialect declares the wire shape of this model's thinking control,
+	// which cannot be inferred from the tiers it advertises: Gemini 2.5 takes a
+	// token budget while 3.x takes a named level, and the two are mutually
+	// exclusive on the same request. Declared per model because the alternative is
+	// sniffing the model id, and an id is not a capability. Empty means the
+	// provider's modern default.
+	ReasoningDialect string `json:"reasoning_dialect,omitempty"`
+	// ThinkingBudgetMin/Max bound the budget dialect. The range is per model
+	// family, not per vendor: Gemini 2.5 Pro is 128..32768 and cannot be turned
+	// off, while Flash starts at 0 and can.
+	ThinkingBudgetMin *int `json:"thinking_budget_min,omitempty"`
+	ThinkingBudgetMax *int `json:"thinking_budget_max,omitempty"`
 }
 
 func normalizeModelConfig(config ModelConfig) ModelConfig {
@@ -186,6 +198,9 @@ func (m *Model) Validate() error {
 	}
 	if m.Config.ThinkingMode != "" && !reasoning.IsValidMode(m.Config.ThinkingMode) {
 		return errors.New("invalid thinking mode: " + m.Config.ThinkingMode)
+	}
+	if !reasoning.IsValidDialect(m.Config.ReasoningDialect) {
+		return errors.New("invalid reasoning dialect: " + m.Config.ReasoningDialect)
 	}
 	return nil
 }

--- a/internal/providers/codex_models.go
+++ b/internal/providers/codex_models.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
 )
 
 const (
@@ -112,9 +113,15 @@ func (s *Service) listCodexRemoteModels(ctx context.Context, baseURL string, cre
 		if containsFold(model.InputModalities, "image") {
 			compatibilities = append(compatibilities, models.CompatVision)
 		}
-		reasoningEfforts := make([]string, 0, len(model.SupportedReasoningLevels))
+		// Upstream spells off "none"; normalize rather than filter so a model that
+		// can be turned off keeps saying so. See copilot_models.go for the same
+		// reasoning.
+		advertised := make([]string, 0, len(model.SupportedReasoningLevels))
 		for _, level := range model.SupportedReasoningLevels {
-			effort := strings.TrimSpace(level.Effort)
+			advertised = append(advertised, strings.TrimSpace(level.Effort))
+		}
+		reasoningEfforts := make([]string, 0, len(advertised))
+		for _, effort := range reasoning.NormalizeAdvertised(advertised) {
 			if models.IsValidReasoningEffort(effort) && !containsFold(reasoningEfforts, effort) {
 				reasoningEfforts = append(reasoningEfforts, effort)
 			}

--- a/internal/providers/copilot_models.go
+++ b/internal/providers/copilot_models.go
@@ -12,6 +12,7 @@ import (
 	memohcopilot "github.com/memohai/memoh/internal/copilot"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
 )
 
 const (
@@ -142,9 +143,16 @@ func (s *Service) listGitHubCopilotRemoteModels(ctx context.Context, baseURL, gi
 		if model.Capabilities.Supports.Vision {
 			compatibilities = append(compatibilities, models.CompatVision)
 		}
-		reasoningEfforts := make([]string, 0, len(model.Capabilities.Supports.ReasoningEffort))
+		// Upstream spells off its own way ("none" on the OpenAI wire). Normalizing
+		// rather than filtering is what keeps a model that can be turned off from
+		// silently losing the capability — dropping the value would read as "this
+		// model cannot be turned off" everywhere downstream.
+		advertised := make([]string, 0, len(model.Capabilities.Supports.ReasoningEffort))
 		for _, effort := range model.Capabilities.Supports.ReasoningEffort {
-			effort = strings.ToLower(strings.TrimSpace(effort))
+			advertised = append(advertised, strings.ToLower(strings.TrimSpace(effort)))
+		}
+		reasoningEfforts := make([]string, 0, len(advertised))
+		for _, effort := range reasoning.NormalizeAdvertised(advertised) {
 			if models.IsValidReasoningEffort(effort) && !containsFold(reasoningEfforts, effort) {
 				reasoningEfforts = append(reasoningEfforts, effort)
 			}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -439,15 +439,19 @@ func remoteModelsFromCatalog(items []sqlc.TemplateProviderTemplateModel) []Remot
 	for _, model := range items {
 		cfg := providerConfig(model.Config)
 		out = append(out, RemoteModel{
-			ID:               model.ModelID,
-			Name:             model.Name,
-			Description:      configStringPtr(cfg, "description"),
-			Type:             model.Type,
-			Compatibilities:  configStringSlice(cfg, "compatibilities"),
-			ReasoningEfforts: configStringSlice(cfg, "reasoning_efforts"),
-			ThinkingMode:     configString(cfg, "thinking_mode"),
-			ContextWindow:    configIntPtr(cfg, "context_window"),
-			Dimensions:       configIntPtr(cfg, "dimensions"),
+			ID:                  model.ModelID,
+			Name:                model.Name,
+			Description:         configStringPtr(cfg, "description"),
+			Type:                model.Type,
+			Compatibilities:     configStringSlice(cfg, "compatibilities"),
+			ReasoningEfforts:    configStringSlice(cfg, "reasoning_efforts"),
+			ThinkingMode:        configString(cfg, "thinking_mode"),
+			ReasoningDialect:    configString(cfg, "reasoning_dialect"),
+			ReasoningOffSupport: configString(cfg, "reasoning_off_support"),
+			ThinkingBudgetMin:   configIntPtr(cfg, "thinking_budget_min"),
+			ThinkingBudgetMax:   configIntPtr(cfg, "thinking_budget_max"),
+			ContextWindow:       configIntPtr(cfg, "context_window"),
+			Dimensions:          configIntPtr(cfg, "dimensions"),
 		})
 	}
 	return out
@@ -462,15 +466,19 @@ func remoteModelsFromTemplate(def registry.ProviderDefinition) []RemoteModel {
 		}
 		cfg := model.Config
 		out = append(out, RemoteModel{
-			ID:               model.ModelID,
-			Name:             model.Name,
-			Description:      configStringPtr(cfg, "description"),
-			Type:             modelType,
-			Compatibilities:  configStringSlice(cfg, "compatibilities"),
-			ReasoningEfforts: configStringSlice(cfg, "reasoning_efforts"),
-			ThinkingMode:     configString(cfg, "thinking_mode"),
-			ContextWindow:    configIntPtr(cfg, "context_window"),
-			Dimensions:       configIntPtr(cfg, "dimensions"),
+			ID:                  model.ModelID,
+			Name:                model.Name,
+			Description:         configStringPtr(cfg, "description"),
+			Type:                modelType,
+			Compatibilities:     configStringSlice(cfg, "compatibilities"),
+			ReasoningEfforts:    configStringSlice(cfg, "reasoning_efforts"),
+			ThinkingMode:        configString(cfg, "thinking_mode"),
+			ReasoningDialect:    configString(cfg, "reasoning_dialect"),
+			ReasoningOffSupport: configString(cfg, "reasoning_off_support"),
+			ThinkingBudgetMin:   configIntPtr(cfg, "thinking_budget_min"),
+			ThinkingBudgetMax:   configIntPtr(cfg, "thinking_budget_max"),
+			ContextWindow:       configIntPtr(cfg, "context_window"),
+			Dimensions:          configIntPtr(cfg, "dimensions"),
 		})
 	}
 	return out

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -112,20 +112,28 @@ type OAuthAuthorizeResponse struct {
 
 // RemoteModel represents a model returned by the provider's /v1/models endpoint.
 type RemoteModel struct {
-	ID                string   `json:"id"`
-	Description       *string  `json:"description,omitempty"`
-	Object            string   `json:"object"`
-	Created           int64    `json:"created"`
-	OwnedBy           string   `json:"owned_by"`
-	Name              string   `json:"name,omitempty"`
-	DisplayName       string   `json:"display_name,omitempty"`
-	Type              string   `json:"type,omitempty"`
-	Compatibilities   []string `json:"compatibilities,omitempty"`
-	ReasoningEfforts  []string `json:"reasoning_efforts,omitempty"`
-	ThinkingMode      string   `json:"thinking_mode,omitempty"`
-	ContextWindow     *int     `json:"context_window,omitempty"`
-	Dimensions        *int     `json:"dimensions,omitempty"`
-	CapabilitiesKnown bool     `json:"-"`
+	ID               string   `json:"id"`
+	Description      *string  `json:"description,omitempty"`
+	Object           string   `json:"object"`
+	Created          int64    `json:"created"`
+	OwnedBy          string   `json:"owned_by"`
+	Name             string   `json:"name,omitempty"`
+	DisplayName      string   `json:"display_name,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	Compatibilities  []string `json:"compatibilities,omitempty"`
+	ReasoningEfforts []string `json:"reasoning_efforts,omitempty"`
+	ThinkingMode     string   `json:"thinking_mode,omitempty"`
+	// ReasoningDialect and the budget bounds must survive the import path, not
+	// just live in the template: an imported Gemini 2.5 row without a dialect
+	// falls back to the tier wire and every request is a 400.
+	ReasoningDialect string `json:"reasoning_dialect,omitempty"`
+	// ReasoningOffSupport declares how the model answers an explicit disable.
+	ReasoningOffSupport string `json:"reasoning_off_support,omitempty"`
+	ThinkingBudgetMin   *int   `json:"thinking_budget_min,omitempty"`
+	ThinkingBudgetMax   *int   `json:"thinking_budget_max,omitempty"`
+	ContextWindow       *int   `json:"context_window,omitempty"`
+	Dimensions          *int   `json:"dimensions,omitempty"`
+	CapabilitiesKnown   bool   `json:"-"`
 }
 
 // ImportModelsResponse represents the response for importing models.

--- a/internal/reasoning/options.go
+++ b/internal/reasoning/options.go
@@ -20,6 +20,10 @@ type Options struct {
 	// DefaultEffort is the tier to use when nothing is stored, and the tier to fall
 	// back to when a stored value is no longer offered by the model.
 	DefaultEffort string `json:"default_effort,omitempty"`
+	// EffortsWithoutOff are tiers that cannot be combined with off on this model.
+	// Opus 5 accepts an explicit disable only at effort high or below, so a client
+	// that lets a user hold both must know which tiers conflict.
+	EffortsWithoutOff []string `json:"efforts_without_off,omitempty"`
 }
 
 // Client types whose wire expresses "off" by omitting the field rather than by
@@ -38,7 +42,10 @@ func expressesOffByOmission(clientType string) bool {
 // options a user is offered and the value a call actually sends are then two
 // readings of one computation, and cannot disagree. Every past bug in this area
 // was a disagreement between those two answers.
-func OptionsFor(mode string, advertised []string, clientType string) Options {
+//
+// offSupport is the model's declared response to an explicit disable (see the
+// OffSupport constants). Empty falls back to the mode-based rule.
+func OptionsFor(mode string, advertised []string, clientType, offSupport string) Options {
 	if !Supported(mode) {
 		return Options{}
 	}
@@ -52,21 +59,53 @@ func OptionsFor(mode string, advertised []string, clientType string) Options {
 		tiers = append(tiers, e)
 	}
 
+	var conflicting []string
+	if offSupport == OffSupportLowEffortOnly {
+		for _, e := range tiers {
+			if effortExceedsHigh(e) {
+				conflicting = append(conflicting, e)
+			}
+		}
+	}
+
+	// A model advertising only the off token has no tier to fall back to. Reporting
+	// one it does not offer would invite a caller to send it, so the default stays
+	// empty and ReconcileStored keeps such a model on off.
+	defaultEffort := ""
+	if len(tiers) > 0 {
+		defaultEffort = pickEffort("", "", levels)
+	}
+
 	return Options{
-		Supported:     true,
-		CanDisable:    canDisable(mode, levels, clientType),
-		Efforts:       tiers,
-		DefaultEffort: pickEffort("", "", levels),
+		Supported:         true,
+		CanDisable:        canDisable(mode, levels, clientType, offSupport),
+		Efforts:           tiers,
+		DefaultEffort:     defaultEffort,
+		EffortsWithoutOff: conflicting,
 	}
 }
 
-// canDisable reports whether picking "off" reaches the model: either the model
-// advertises the token, or its client expresses off by omitting the field.
+// canDisable reports whether picking "off" reaches the model.
 //
-// The omission rule is limited to toggle models, where thinking only happens when
-// asked for. Under adaptive thinking the model decides on its own, so omitting the
-// field leaves that default in charge rather than turning thinking off.
-func canDisable(mode string, levels []string, clientType string) bool {
+// A declared off-support answer wins, because it is the only thing that can be
+// right: Anthropic's per-model table splits models that share a thinking mode and
+// an identical tier list. Opus 4.6-4.8 accept an explicit disable, Fable 5 rejects
+// it with a 400, and nothing about the mode or the tiers distinguishes them.
+//
+// Without a declaration, the fallbacks are an advertised disable token, then the
+// omission rule — limited to toggle models, where thinking only happens when asked
+// for. Under adaptive thinking the model may think by default, so omitting the
+// field can leave that default in charge rather than turning thinking off. That
+// fallback is deliberately conservative: it under-offers on adaptive models that
+// would accept a disable, which costs a control, rather than over-offering on a
+// model that rejects one, which costs a failed request.
+func canDisable(mode string, levels []string, clientType, offSupport string) bool {
+	switch offSupport {
+	case OffSupportAccepted, OffSupportLowEffortOnly:
+		return true
+	case OffSupportRejected:
+		return false
+	}
 	if hasEffort(levels, EffortDisable) {
 		return true
 	}

--- a/internal/reasoning/options_test.go
+++ b/internal/reasoning/options_test.go
@@ -12,7 +12,7 @@ func TestOptionsForNeverOffersTheDisableTokenAsATier(t *testing.T) {
 	// declares it can be turned off. It must not come back out as something a user
 	// can pick as an *effort* — that confusion is what let an active config
 	// resolve to "off" before this package existed.
-	opts := OptionsFor(ModeToggle, []string{EffortDisable, EffortLow, EffortHigh}, "openai-completions")
+	opts := OptionsFor(ModeToggle, []string{EffortDisable, EffortLow, EffortHigh}, "openai-completions", "")
 
 	if !opts.CanDisable {
 		t.Fatal("advertised disable token should report CanDisable")
@@ -33,6 +33,7 @@ func TestOptionsForOffReachability(t *testing.T) {
 		mode       string
 		advertised []string
 		clientType string
+		offSupport string
 		canDisable bool
 	}{
 		{
@@ -54,12 +55,43 @@ func TestOptionsForOffReachability(t *testing.T) {
 			canDisable: true,
 		},
 		{
-			// Claude 4.6+: omitting the field leaves adaptive thinking in charge,
-			// which still thinks. Off is not reachable by omission here.
-			name:       "anthropic adaptive cannot be turned off by omission",
+			// An undeclared adaptive model: omission may leave the model's own
+			// default in charge, so the conservative answer is no off switch. Under-
+			// offering costs a control; over-offering costs a failed request.
+			name:       "undeclared anthropic adaptive is conservative",
 			mode:       ModeAdaptive,
 			advertised: []string{EffortLow, EffortHigh, EffortMax},
 			clientType: ClientTypeAnthropicMessages,
+			canDisable: false,
+		},
+		{
+			// Opus 4.6-4.8 accept thinking{type:"disabled"} even though they are
+			// adaptive. Only the declaration can say so — the mode and the tier list
+			// are identical to Fable 5's, which rejects the same shape.
+			name:       "a declared accepted model can be turned off",
+			mode:       ModeAdaptive,
+			advertised: []string{EffortLow, EffortHigh, EffortMax},
+			clientType: ClientTypeAnthropicMessages,
+			offSupport: OffSupportAccepted,
+			canDisable: true,
+		},
+		{
+			// Fable 5 / Mythos 5 always think and 400 on an explicit disable.
+			name:       "a declared rejecting model cannot",
+			mode:       ModeAdaptive,
+			advertised: []string{EffortLow, EffortHigh, EffortMax},
+			clientType: ClientTypeAnthropicMessages,
+			offSupport: OffSupportRejected,
+			canDisable: false,
+		},
+		{
+			// A declaration also overrides an advertised token, since the wire has
+			// the final say over the catalog's tier list.
+			name:       "a rejection wins over an advertised disable token",
+			mode:       ModeToggle,
+			advertised: []string{EffortDisable, EffortLow},
+			clientType: "openai-completions",
+			offSupport: OffSupportRejected,
 			canDisable: false,
 		},
 		{
@@ -76,7 +108,7 @@ func TestOptionsForOffReachability(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := OptionsFor(tt.mode, tt.advertised, tt.clientType).CanDisable; got != tt.canDisable {
+			if got := OptionsFor(tt.mode, tt.advertised, tt.clientType, tt.offSupport).CanDisable; got != tt.canDisable {
 				t.Fatalf("CanDisable = %v, want %v", got, tt.canDisable)
 			}
 		})
@@ -86,7 +118,7 @@ func TestOptionsForOffReachability(t *testing.T) {
 func TestOptionsForUnsupportedModelOffersNothing(t *testing.T) {
 	t.Parallel()
 
-	opts := OptionsFor(ModeNone, []string{EffortLow}, "openai-completions")
+	opts := OptionsFor(ModeNone, []string{EffortLow}, "openai-completions", "")
 	if opts.Supported || opts.CanDisable || len(opts.Efforts) > 0 || opts.DefaultEffort != "" {
 		t.Fatalf("a model with no thinking concept should offer nothing, got %+v", opts)
 	}
@@ -101,7 +133,7 @@ func TestOptionsForAppliesTheSameWirePolicyAsResolve(t *testing.T) {
 	const advertisedMax = EffortMax
 	advertised := []string{EffortLow, EffortHigh, advertisedMax}
 
-	opts := OptionsFor(ModeToggle, advertised, "openai-completions")
+	opts := OptionsFor(ModeToggle, advertised, "openai-completions", "")
 	if slices.Contains(opts.Efforts, advertisedMax) {
 		t.Fatalf("max should be filtered for generic OpenAI clients: %v", opts.Efforts)
 	}
@@ -112,7 +144,7 @@ func TestOptionsForAppliesTheSameWirePolicyAsResolve(t *testing.T) {
 	}
 
 	// Codex keeps max, and both answers must agree about that too.
-	codexOpts := OptionsFor(ModeToggle, advertised, "openai-codex")
+	codexOpts := OptionsFor(ModeToggle, advertised, "openai-codex", "")
 	if !slices.Contains(codexOpts.Efforts, advertisedMax) {
 		t.Fatalf("codex should keep max: %v", codexOpts.Efforts)
 	}
@@ -135,7 +167,7 @@ func TestOptionsDefaultEffortMatchesWhatResolveWouldSend(t *testing.T) {
 		{EffortDisable, EffortHigh, EffortXHigh},
 		nil,
 	} {
-		opts := OptionsFor(ModeToggle, advertised, "openai-codex")
+		opts := OptionsFor(ModeToggle, advertised, "openai-codex", "")
 		cfg := ResolveConfig(ModeToggle, advertised, "", "", "openai-codex")
 		if cfg == nil {
 			t.Fatalf("advertised %v: resolver returned nil for a toggle model", advertised)
@@ -150,9 +182,9 @@ func TestOptionsDefaultEffortMatchesWhatResolveWouldSend(t *testing.T) {
 func TestReconcileStored(t *testing.T) {
 	t.Parallel()
 
-	canDisable := OptionsFor(ModeToggle, []string{EffortDisable, EffortLow, EffortHigh}, "openai-codex")
-	cannotDisable := OptionsFor(ModeToggle, []string{EffortLow, EffortHigh}, "openai-codex")
-	unsupported := OptionsFor(ModeNone, nil, "openai-codex")
+	canDisable := OptionsFor(ModeToggle, []string{EffortDisable, EffortLow, EffortHigh}, "openai-codex", "")
+	cannotDisable := OptionsFor(ModeToggle, []string{EffortLow, EffortHigh}, "openai-codex", "")
+	unsupported := OptionsFor(ModeNone, nil, "openai-codex", "")
 
 	cases := []struct {
 		name   string
@@ -176,5 +208,55 @@ func TestReconcileStored(t *testing.T) {
 				t.Fatalf("ReconcileStored(%q) = %q, want %q", tt.stored, got, tt.want)
 			}
 		})
+	}
+}
+
+// Opus 5 accepts an explicit disable only at effort high or below; pairing it with
+// xhigh or max is a 400. A client that lets a user hold both a tier and an off
+// switch needs to know which tiers conflict, so Options names them.
+func TestOptionsNamesTiersThatConflictWithOff(t *testing.T) {
+	t.Parallel()
+
+	advertised := []string{EffortLow, EffortHigh, EffortXHigh, EffortMax}
+
+	conditional := OptionsFor(ModeAdaptive, advertised, ClientTypeAnthropicMessages, OffSupportLowEffortOnly)
+	if !conditional.CanDisable {
+		t.Fatal("a conditionally-accepting model can still be turned off")
+	}
+	if !slices.Equal(conditional.EffortsWithoutOff, []string{EffortXHigh, EffortMax}) {
+		t.Fatalf("conflicting tiers = %v, want [xhigh max]", conditional.EffortsWithoutOff)
+	}
+	// The conflicting tiers stay selectable; they just cannot be combined with off.
+	for _, want := range []string{EffortXHigh, EffortMax} {
+		if !slices.Contains(conditional.Efforts, want) {
+			t.Errorf("%q should remain selectable: %v", want, conditional.Efforts)
+		}
+	}
+
+	// Unconditional acceptance has no conflicts to report.
+	plain := OptionsFor(ModeAdaptive, advertised, ClientTypeAnthropicMessages, OffSupportAccepted)
+	if len(plain.EffortsWithoutOff) != 0 {
+		t.Errorf("an unconditionally-accepting model has no conflicts: %v", plain.EffortsWithoutOff)
+	}
+}
+
+// A model that advertises only the off token has no tier to fall back to.
+// Reporting one it does not offer would invite a caller to send it.
+func TestOptionsForOffOnlyModelHasNoDefaultTier(t *testing.T) {
+	t.Parallel()
+
+	opts := OptionsFor(ModeToggle, []string{EffortDisable}, "openai-codex", "")
+	if !opts.CanDisable {
+		t.Fatal("an off-only model can be turned off")
+	}
+	if len(opts.Efforts) != 0 {
+		t.Fatalf("no tiers should be offered: %v", opts.Efforts)
+	}
+	if opts.DefaultEffort != "" {
+		t.Fatalf("default = %q, want empty: the model offers no tier to default to", opts.DefaultEffort)
+	}
+	// Such a model stays on off rather than being moved to a tier it lacks.
+	if got := ReconcileStored(EffortDisable, opts); got != EffortDisable {
+		t.Fatalf("ReconcileStored = %q, want %q", got, EffortDisable)
 	}
 }

--- a/internal/reasoning/vocabulary.go
+++ b/internal/reasoning/vocabulary.go
@@ -157,3 +157,52 @@ func hasEffort(levels []string, effort string) bool {
 func OrderedEfforts() []string {
 	return slices.Clone(orderedEfforts)
 }
+
+// Reasoning wire dialects. A dialect is how a provider spells the thinking
+// control on the request, which is not derivable from the tiers a model
+// advertises — Gemini 2.5 takes a token budget while 3.x takes a named level, and
+// sending both is a 400. It is declared per model rather than sniffed from an id.
+const (
+	// DialectTier sends a named tier: OpenAI reasoning.effort, Anthropic
+	// output_config.effort, Gemini 3.x thinkingLevel.
+	DialectTier = "tier"
+	// DialectBudget sends a token budget: Anthropic <=4.5 budget_tokens, Gemini
+	// 2.5 thinkingBudget.
+	DialectBudget = "budget"
+)
+
+var validDialects = map[string]struct{}{
+	DialectTier:   {},
+	DialectBudget: {},
+}
+
+// IsValidDialect reports whether a dialect token can be stored. An empty dialect
+// is valid and means "the provider's modern default".
+func IsValidDialect(dialect string) bool {
+	if dialect == "" {
+		return true
+	}
+	_, ok := validDialects[dialect]
+	return ok
+}
+
+// budgetRatios place each tier proportionally within a model's own budget range.
+// Fixed token counts cannot be right across models with different ceilings, and
+// the vendors publish no tier-to-token mapping — they describe tiers as relative
+// allowances rather than guarantees. Two independent clients (Cline, Cherry
+// Studio) converged on this same proportional approach.
+var budgetRatios = map[string]float64{
+	EffortMinimal: 0.1,
+	EffortLow:     0.2,
+	EffortMedium:  0.5,
+	EffortHigh:    0.8,
+	EffortXHigh:   0.95,
+	EffortMax:     1,
+}
+
+// BudgetRatio returns where a tier sits within a budget range, as a fraction.
+// It reports false for values that are not active tiers, including the off token.
+func BudgetRatio(effort string) (float64, bool) {
+	ratio, ok := budgetRatios[strings.TrimSpace(effort)]
+	return ratio, ok
+}

--- a/internal/reasoning/vocabulary.go
+++ b/internal/reasoning/vocabulary.go
@@ -206,3 +206,49 @@ func BudgetRatio(effort string) (float64, bool) {
 	ratio, ok := budgetRatios[strings.TrimSpace(effort)]
 	return ratio, ok
 }
+
+// How a model responds to an explicit request to stop thinking. This cannot be
+// derived from the thinking mode or the advertised tiers: Anthropic's own
+// per-model table splits models that share both. Opus 4.6 through 4.8 default to
+// thinking off and accept thinking{type:"disabled"}; Sonnet 5 defaults to on and
+// still accepts it; Opus 5 accepts it only at effort high or below; Fable 5 and
+// Mythos 5 reject it outright. Guessing from a model id is what this field exists
+// to avoid.
+const (
+	// OffSupportUnset means the catalog has not said. Callers fall back to the
+	// mode-based rule, which is right for the toggle generation and conservative
+	// for the rest.
+	OffSupportUnset = ""
+	// OffSupportAccepted means the model accepts an explicit disable at any effort.
+	OffSupportAccepted = "accepted"
+	// OffSupportLowEffortOnly means the model accepts an explicit disable, but only
+	// at effort high or below — pairing it with xhigh or max is a 400 (Opus 5).
+	OffSupportLowEffortOnly = "low_effort_only"
+	// OffSupportRejected means the model always thinks and rejects an explicit
+	// disable (Fable 5, Mythos 5). Offering an off switch would be a dead control
+	// that also costs a round trip.
+	OffSupportRejected = "rejected"
+)
+
+var validOffSupport = map[string]struct{}{
+	OffSupportUnset:         {},
+	OffSupportAccepted:      {},
+	OffSupportLowEffortOnly: {},
+	OffSupportRejected:      {},
+}
+
+// IsValidOffSupport reports whether an off-support token can be stored.
+func IsValidOffSupport(support string) bool {
+	_, ok := validOffSupport[support]
+	return ok
+}
+
+// effortsAboveHigh are the tiers Opus 5 refuses to combine with an explicit
+// disable. They are the tiers stronger than high in the ordering.
+func effortExceedsHigh(effort string) bool {
+	switch strings.TrimSpace(effort) {
+	case EffortXHigh, EffortMax:
+		return true
+	}
+	return false
+}

--- a/internal/registry/reasoning_dialect_test.go
+++ b/internal/registry/reasoning_dialect_test.go
@@ -1,0 +1,109 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Declaring a wire dialect per model is what lets the code avoid sniffing model
+// ids, but it moves a cost: a new model added without one silently falls back to
+// the provider's modern default. For Google that fallback is wrong half the time
+// — a 2.5 model treated as 3.x gets thinkingLevel, which the API rejects.
+//
+// This test is the tripwire. It is scoped to providers whose generations actually
+// disagree about the wire shape; elsewhere an empty dialect is correct and
+// requiring one would be noise.
+func TestGoogleReasoningModelsDeclareAWireDialect(t *testing.T) {
+	t.Parallel()
+
+	const dir = "../../conf/providers"
+	raw, err := os.ReadFile(filepath.Join(dir, "google.yaml")) //nolint:gosec // repo-local template
+	if err != nil {
+		t.Fatalf("read google.yaml: %v", err)
+	}
+
+	var doc struct {
+		Models []struct {
+			ModelID string         `yaml:"model_id"`
+			Config  map[string]any `yaml:"config"`
+		} `yaml:"models"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse google.yaml: %v", err)
+	}
+	if len(doc.Models) == 0 {
+		t.Fatal("no models parsed; the fixture path or schema changed")
+	}
+
+	for _, m := range doc.Models {
+		mode, _ := m.Config["thinking_mode"].(string)
+		if mode == "" || mode == "none" {
+			continue
+		}
+		dialect, _ := m.Config["reasoning_dialect"].(string)
+		if dialect == "" {
+			t.Errorf("%s declares thinking_mode %q but no reasoning_dialect: "+
+				"2.5 needs \"budget\", 3.x needs \"tier\", and guessing from the id is "+
+				"what this field exists to avoid", m.ModelID, mode)
+			continue
+		}
+		if dialect != "budget" && dialect != "tier" {
+			t.Errorf("%s has unknown reasoning_dialect %q", m.ModelID, dialect)
+		}
+		// A budget dialect without bounds would scale tiers across a zero range and
+		// collapse every tier onto the dynamic sentinel.
+		if dialect == "budget" {
+			if _, ok := m.Config["thinking_budget_max"]; !ok {
+				t.Errorf("%s uses the budget dialect but declares no thinking_budget_max", m.ModelID)
+			}
+		}
+	}
+}
+
+// Off-ability on the budget dialect is not a matter of taste: a zero budget is
+// legal only where the model's floor is zero. Flash allows it, Pro does not, and
+// the catalog has to say the same thing the wire will.
+func TestGoogleBudgetModelsAdvertiseOffOnlyWhenTheFloorIsZero(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile("../../conf/providers/google.yaml") //nolint:gosec // repo-local template
+	if err != nil {
+		t.Fatalf("read google.yaml: %v", err)
+	}
+	var doc struct {
+		Models []struct {
+			ModelID string         `yaml:"model_id"`
+			Config  map[string]any `yaml:"config"`
+		} `yaml:"models"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse google.yaml: %v", err)
+	}
+
+	for _, m := range doc.Models {
+		if dialect, _ := m.Config["reasoning_dialect"].(string); dialect != "budget" {
+			continue
+		}
+		minBudget, hasMin := m.Config["thinking_budget_min"].(int)
+		efforts, _ := m.Config["reasoning_efforts"].([]any)
+		advertisesOff := false
+		for _, e := range efforts {
+			if s, ok := e.(string); ok && strings.TrimSpace(s) == "disable" {
+				advertisesOff = true
+			}
+		}
+
+		switch {
+		case hasMin && minBudget == 0 && !advertisesOff:
+			t.Errorf("%s allows a zero budget but does not advertise off; the control "+
+				"would be hidden from a model that supports it", m.ModelID)
+		case hasMin && minBudget > 0 && advertisesOff:
+			t.Errorf("%s advertises off but its floor is %d, so a zero budget is a 400; "+
+				"the picker would offer a switch the wire rejects", m.ModelID, minBudget)
+		}
+	}
+}

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -20616,6 +20616,10 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "reasoning_off_support": {
+                    "description": "ReasoningOffSupport declares how the model answers an explicit request to\nstop thinking. Anthropic's per-model table splits models that share a\nthinking mode and an identical tier list, so this cannot be derived — see the\nreasoning package's OffSupport constants.",
+                    "type": "string"
+                },
                 "thinking_budget_max": {
                     "type": "integer"
                 },
@@ -21403,6 +21407,13 @@ const docTemplate = `{
                 },
                 "efforts": {
                     "description": "Efforts are the selectable active tiers, weakest to strongest as advertised.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "efforts_without_off": {
+                    "description": "EffortsWithoutOff are tiers that cannot be combined with off on this model.\nOpus 5 accepts an explicit disable only at effort high or below, so a client\nthat lets a user hold both must know which tiers conflict.",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -20606,11 +20606,22 @@ const docTemplate = `{
                 "dimensions": {
                     "type": "integer"
                 },
+                "reasoning_dialect": {
+                    "description": "ReasoningDialect declares the wire shape of this model's thinking control,\nwhich cannot be inferred from the tiers it advertises: Gemini 2.5 takes a\ntoken budget while 3.x takes a named level, and the two are mutually\nexclusive on the same request. Declared per model because the alternative is\nsniffing the model id, and an id is not a capability. Empty means the\nprovider's modern default.",
+                    "type": "string"
+                },
                 "reasoning_efforts": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "thinking_budget_max": {
+                    "type": "integer"
+                },
+                "thinking_budget_min": {
+                    "description": "ThinkingBudgetMin/Max bound the budget dialect. The range is per model\nfamily, not per vendor: Gemini 2.5 Pro is 128..32768 and cannot be turned\noff, while Flash starts at 0 and can.",
+                    "type": "integer"
                 },
                 "thinking_mode": {
                     "type": "string"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -20607,6 +20607,10 @@
                         "type": "string"
                     }
                 },
+                "reasoning_off_support": {
+                    "description": "ReasoningOffSupport declares how the model answers an explicit request to\nstop thinking. Anthropic's per-model table splits models that share a\nthinking mode and an identical tier list, so this cannot be derived — see the\nreasoning package's OffSupport constants.",
+                    "type": "string"
+                },
                 "thinking_budget_max": {
                     "type": "integer"
                 },
@@ -21394,6 +21398,13 @@
                 },
                 "efforts": {
                     "description": "Efforts are the selectable active tiers, weakest to strongest as advertised.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "efforts_without_off": {
+                    "description": "EffortsWithoutOff are tiers that cannot be combined with off on this model.\nOpus 5 accepts an explicit disable only at effort high or below, so a client\nthat lets a user hold both must know which tiers conflict.",
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -20597,11 +20597,22 @@
                 "dimensions": {
                     "type": "integer"
                 },
+                "reasoning_dialect": {
+                    "description": "ReasoningDialect declares the wire shape of this model's thinking control,\nwhich cannot be inferred from the tiers it advertises: Gemini 2.5 takes a\ntoken budget while 3.x takes a named level, and the two are mutually\nexclusive on the same request. Declared per model because the alternative is\nsniffing the model id, and an id is not a capability. Empty means the\nprovider's modern default.",
+                    "type": "string"
+                },
                 "reasoning_efforts": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "thinking_budget_max": {
+                    "type": "integer"
+                },
+                "thinking_budget_min": {
+                    "description": "ThinkingBudgetMin/Max bound the budget dialect. The range is per model\nfamily, not per vendor: Gemini 2.5 Pro is 128..32768 and cannot be turned\noff, while Flash starts at 0 and can.",
+                    "type": "integer"
                 },
                 "thinking_mode": {
                     "type": "string"

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -4069,6 +4069,13 @@ definitions:
         items:
           type: string
         type: array
+      reasoning_off_support:
+        description: |-
+          ReasoningOffSupport declares how the model answers an explicit request to
+          stop thinking. Anthropic's per-model table splits models that share a
+          thinking mode and an identical tier list, so this cannot be derived — see the
+          reasoning package's OffSupport constants.
+        type: string
       thinking_budget_max:
         type: integer
       thinking_budget_min:
@@ -4605,6 +4612,14 @@ definitions:
       efforts:
         description: Efforts are the selectable active tiers, weakest to strongest
           as advertised.
+        items:
+          type: string
+        type: array
+      efforts_without_off:
+        description: |-
+          EffortsWithoutOff are tiers that cannot be combined with off on this model.
+          Opus 5 accepts an explicit disable only at effort high or below, so a client
+          that lets a user hold both must know which tiers conflict.
         items:
           type: string
         type: array

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -4056,10 +4056,27 @@ definitions:
         type: string
       dimensions:
         type: integer
+      reasoning_dialect:
+        description: |-
+          ReasoningDialect declares the wire shape of this model's thinking control,
+          which cannot be inferred from the tiers it advertises: Gemini 2.5 takes a
+          token budget while 3.x takes a named level, and the two are mutually
+          exclusive on the same request. Declared per model because the alternative is
+          sniffing the model id, and an id is not a capability. Empty means the
+          provider's modern default.
+        type: string
       reasoning_efforts:
         items:
           type: string
         type: array
+      thinking_budget_max:
+        type: integer
+      thinking_budget_min:
+        description: |-
+          ThinkingBudgetMin/Max bound the budget dialect. The range is per model
+          family, not per vendor: Gemini 2.5 Pro is 128..32768 and cannot be turned
+          off, while Flash starts at 0 and can.
+        type: integer
       thinking_mode:
         type: string
     type: object


### PR DESCRIPTION
Stacked on #988. Closes the Gemini half of #982 / memohai/twilight-ai#41.

## The control was never connected

The picker has offered Gemini three tiers since the day it was added, and none of
them ever left the building: the Google provider had no thinking field on its
request, so `BuildReasoningOptions` returned nil and the selection was a placebo.
memohai/twilight-ai#42 added the wire; this connects it.

Requires the dependency bump included here (`twilight-ai@70292145`).

## Why the catalog has to declare the dialect

Gemini 2.5 takes `thinkingConfig.thinkingBudget`; 3.x takes
`thinkingConfig.thinkingLevel`; **sending both is a 400**. The tiers look
identical from the outside, so the wire shape is not inferable from what a model
advertises — and the alternative to declaring it is sniffing the model id, which
is the practice this whole effort exists to remove.

So the catalog says it: `reasoning_dialect` plus the budget bounds, per model.

## Proportional budgets, not a fixed table

A tier maps across each model's **own** range:

| model | range | `high` |
|---|---|---|
| 2.5 Pro | 128–32768 | 26240 |
| 2.5 Flash | 0–24576 | 19660 |
| 2.5 Flash-Lite | 512–24576 | 19763 |

A fixed table cannot be right for models with different ceilings, and the vendors
publish no tier-to-token mapping at all — they describe tiers as *relative
allowances rather than guarantees*. Cline and Cherry Studio independently landed
on the same proportional approach.

## Off-ability falls out of the bounds

A zero budget is legal exactly where the floor is zero:

- **2.5 Flash** (floor 0) can be turned off, and now advertises it
- **2.5 Pro** (floor 128) cannot; asking it to would earn a 400
- **3.x** has no off value at all — `minimal` is the floor — so a disabled model
  sends nothing and lets the provider default stand

## `includeThoughts`

Set whenever thinking is on. Without it the API runs and **bills** the thinking
but emits no thought parts, so the reasoning stream stays empty for a user who
can see they are paying for it.

## Guards

This design trades sniffing for a declaration, and declarations rot. Two template
tests:

1. A Google model declaring a thinking mode without a dialect fails.
2. A budget model whose advertised off-ability disagrees with its floor fails.

Both were confirmed to fail against a deliberately broken catalog before being
kept — a guard that has never failed is not known to work.

## synccaps

It was stripping the `minimal` tier: LiteLLM reports `supports_minimal` for one
model family while Gemini 3.x takes it as the floor. Same shape of gap as the
`disable` token, same treatment — registry silence is not evidence of absence.
`go run ./cmd/synccaps -check` is clean.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt` clean; swagger
regenerated.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.