### PR TITLE
refactor(command): let /reasoning read the model instead of a fixed list

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -120,6 +120,10 @@
     "compaction": {
       "model_unavailable": "The compaction model is unavailable. Pick an enabled chat model with a declared context window."
     },
+    "settings": {
+      "reasoning_effort_invalid": "Reasoning level \"{effort}\" is not supported by the selected chat model.",
+      "reasoning_options_unavailable": "The chat model's reasoning options could not be resolved. Please try again."
+    },
     "profile": {
       "request_invalid": "The profile update request is invalid.",
       "title_model_invalid": "The selected title model is unavailable or is not a chat model.",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -117,6 +117,10 @@
     "compaction": {
       "model_unavailable": "圧縮Modelを利用できません。有効でコンテキストウィンドウが宣言されたチャットModelを選択してください。"
     },
+    "settings": {
+      "reasoning_effort_invalid": "選択したチャットModelは推論レベル「{effort}」に対応していません。",
+      "reasoning_options_unavailable": "チャットModelの推論オプションを確認できませんでした。しばらくしてからもう一度お試しください。"
+    },
     "profile": {
       "request_invalid": "プロフィール更新リクエストが無効です。",
       "title_model_invalid": "選択したタイトルModelは利用できないか、チャットModelではありません。",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -120,6 +120,10 @@
     "compaction": {
       "model_unavailable": "压缩模型不可用。请选择一个已启用、且声明了上下文窗口的对话模型。"
     },
+    "settings": {
+      "reasoning_effort_invalid": "所选对话模型不支持推理级别“{effort}”。",
+      "reasoning_options_unavailable": "暂时无法解析对话模型的推理选项，请稍后重试。"
+    },
     "profile": {
       "request_invalid": "个人资料更新请求无效。",
       "title_model_invalid": "所选标题模型不可用或不是聊天模型。",

--- a/cmd/internal/core/module.go
+++ b/cmd/internal/core/module.go
@@ -23,7 +23,6 @@ import (
 	"github.com/memohai/memoh/internal/providertemplates"
 	"github.com/memohai/memoh/internal/schedule"
 	"github.com/memohai/memoh/internal/searchproviders"
-	"github.com/memohai/memoh/internal/settings"
 	"github.com/memohai/memoh/internal/userruntime"
 	videopkg "github.com/memohai/memoh/internal/video"
 	"github.com/memohai/memoh/internal/workdir"
@@ -66,7 +65,7 @@ func ServerModule() fx.Option {
 			provideOverlayProviderRegistry,
 			provideNetworkService,
 			provideNetworkController,
-			settings.NewService,
+			provideSettingsService,
 			provideToolApprovalService,
 			providePGVectorStore,
 			provideUserRuntimeStore,

--- a/cmd/internal/core/providers.go
+++ b/cmd/internal/core/providers.go
@@ -231,6 +231,18 @@ func provideAccountService(log *slog.Logger, accountStore dbstore.AccountStore) 
 	return accounts.NewService(log, accountStore)
 }
 
+func provideSettingsService(
+	log *slog.Logger,
+	queries dbstore.Queries,
+	aclService *acl.Service,
+	networkService *netctl.Service,
+	modelsService *models.Service,
+) *settings.Service {
+	service := settings.NewService(log, queries, aclService, networkService)
+	service.SetReasoningOptionsResolver(modelsService)
+	return service
+}
+
 // provideWikiStore wires the PostgreSQL memory wiki store. Returns a pointer
 // so FX can inject nil-safe into providers that may run without a wiki store.
 func provideWikiStore(postgresStore *postgresstore.Store) (*wikistore.Store, error) {

--- a/internal/apperror/error.go
+++ b/internal/apperror/error.go
@@ -14,6 +14,8 @@ const (
 	CodeBotNameTaken                     Code = "bot.name_taken"
 	CodeChannelRuntimeUnavailable        Code = "channel.runtime_unavailable"
 	CodeCompactionModelUnavailable       Code = "compaction.model_unavailable"
+	CodeSettingsReasoningEffortInvalid   Code = "settings.reasoning_effort_invalid"
+	CodeSettingsReasoningUnavailable     Code = "settings.reasoning_options_unavailable"
 	CodeWorkspaceUnreachable             Code = "workspace.unreachable"
 	CodeWorkspaceImageIncompatible       Code = "workspace.image_incompatible"
 	CodeWorkspaceTemplateBootstrapFailed Code = "workspace.template_bootstrap_failed"
@@ -97,6 +99,15 @@ var catalog = map[Code]Definition{
 		HTTPStatus:  http.StatusBadRequest,
 		Detail:      "The compaction model is unavailable.",
 		AllowedArgs: []string{"reason"},
+	},
+	CodeSettingsReasoningEffortInvalid: {
+		HTTPStatus:  http.StatusBadRequest,
+		Detail:      "The selected reasoning level is not supported by the chat model.",
+		AllowedArgs: []string{"effort"},
+	},
+	CodeSettingsReasoningUnavailable: {
+		HTTPStatus: http.StatusServiceUnavailable,
+		Detail:     "The chat model's reasoning options could not be resolved. Please try again.",
 	},
 	CodeWorkspaceUnreachable: {
 		HTTPStatus: http.StatusServiceUnavailable,

--- a/internal/command/handler.go
+++ b/internal/command/handler.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -522,6 +523,16 @@ func (h *Handler) ExecuteResult(ctx context.Context, input ExecuteInput) (res *R
 func (h *Handler) friendlyCommandError(t *i18n.Localizer, resource string, err error) string {
 	if err == nil {
 		return ""
+	}
+	var invalidReasoning *settings.InvalidReasoningEffortError
+	if errors.As(err, &invalidReasoning) {
+		return t.T("cmd.reasoning.unknownLevel", map[string]any{
+			"level":  fmt.Sprintf("%q", invalidReasoning.Effort),
+			"levels": strings.Join(reasoningChoicesFor(invalidReasoning.Options), ", "),
+		})
+	}
+	if errors.Is(err, settings.ErrReasoningOptionsUnavailable) {
+		return t.T("cmd.reasoning.unavailable")
 	}
 	msg := strings.TrimSpace(err.Error())
 	res := strings.TrimSpace(resource)

--- a/internal/command/reasoning.go
+++ b/internal/command/reasoning.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -20,23 +21,39 @@ const offChoice = "off"
 // including Off on models that cannot be turned off, and never xhigh's neighbours
 // on models that advertise them.
 //
-// A model that cannot be resolved yields a zero Options, and the caller falls
-// back to accepting any declarable tier rather than blocking the command.
-func (h *Handler) reasoningOptions(cc CommandContext, modelID string) reasoning.Options {
-	if modelID == "" || h.modelsService == nil {
-		return reasoning.Options{}
+// The bool reports whether both the model and its provider were resolved. It is
+// deliberately separate from Options.Supported: a resolved model may genuinely
+// have no reasoning capability, while a lookup failure leaves the capability
+// unknown. Neither case is safe to treat as a generic reasoning model.
+func (h *Handler) reasoningOptions(cc CommandContext, modelID string) (reasoning.Options, bool) {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" || h.modelsService == nil || h.providersService == nil {
+		return reasoning.Options{}, false
 	}
 	m, err := h.modelsService.GetByID(cc.Ctx, modelID)
 	if err != nil {
-		return reasoning.Options{}
-	}
-	clientType := ""
-	if h.providersService != nil {
-		if p, provErr := h.providersService.Get(cc.Ctx, m.ProviderID); provErr == nil {
-			clientType = p.ClientType
+		if h.logger != nil {
+			h.logger.Warn("reasoning model lookup failed",
+				slog.String("bot_id", cc.BotID),
+				slog.String("model_id", modelID),
+				slog.Any("error", err),
+			)
 		}
+		return reasoning.Options{}, false
 	}
-	return m.ReasoningOptions(clientType)
+	p, err := h.providersService.Get(cc.Ctx, m.ProviderID)
+	if err != nil || strings.TrimSpace(p.ClientType) == "" {
+		if h.logger != nil {
+			h.logger.Warn("reasoning provider lookup failed",
+				slog.String("bot_id", cc.BotID),
+				slog.String("model_id", modelID),
+				slog.String("provider_id", m.ProviderID),
+				slog.Any("error", err),
+			)
+		}
+		return reasoning.Options{}, false
+	}
+	return m.ReasoningOptions(p.ClientType), true
 }
 
 // buildReasoningGroup registers /reasoning — a first-class sibling of /model.
@@ -54,18 +71,21 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			if err != nil {
 				return nil, err
 			}
-			return reasoningResult(cc.L, s.ReasoningEffort, h.reasoningOptions(cc, s.ChatModelID)), nil
+			opts, resolved := h.reasoningOptions(cc, s.ChatModelID)
+			if !resolved {
+				return &Result{Text: cc.T("cmd.reasoning.unavailable")}, nil
+			}
+			if !opts.Supported {
+				return &Result{Text: cc.T("cmd.reasoning.unsupported")}, nil
+			}
+			return reasoningResult(cc.L, s.ReasoningEffort, opts), nil
 		},
 	})
 	g.Register(SubCommand{
 		Name:    "set",
-		Usage:   "set <off|none|low|medium|high|xhigh> - Set the reasoning level",
+		Usage:   "set <off|minimal|low|medium|high|xhigh|max> - Set the reasoning level",
 		IsWrite: true,
 		ResultHandler: func(cc CommandContext) (*Result, error) {
-			if len(cc.Args) < 1 {
-				return &Result{Text: cc.T("cmd.reasoning.setUsage")}, nil
-			}
-			level := strings.ToLower(strings.TrimSpace(cc.Args[0]))
 			if h.settingsService == nil {
 				return &Result{Text: cc.T("cmd.reasoning.unavailable")}, nil
 			}
@@ -73,11 +93,24 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			if err != nil {
 				return nil, err
 			}
-			opts := h.reasoningOptions(cc, current.ChatModelID)
+			opts, resolved := h.reasoningOptions(cc, current.ChatModelID)
+			if !resolved {
+				return &Result{Text: cc.T("cmd.reasoning.unavailable")}, nil
+			}
+			if !opts.Supported {
+				return &Result{Text: cc.T("cmd.reasoning.unsupported")}, nil
+			}
+			choices := reasoningChoicesFor(opts)
+			if len(cc.Args) < 1 {
+				return &Result{Text: cc.T("cmd.reasoning.setUsage", map[string]any{
+					"levels": strings.Join(choices, "|"),
+				})}, nil
+			}
+			level := strings.ToLower(strings.TrimSpace(cc.Args[0]))
 
 			req := settings.UpsertRequest{}
 			switch {
-			case level == offChoice:
+			case level == offChoice && acceptsEffort(level, opts):
 				// "off" is the user-facing token; storage represents it as the
 				// "disable" effort now that bots have no separate on/off flag.
 				disable := models.ReasoningEffortDisable
@@ -85,7 +118,10 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			case acceptsEffort(level, opts):
 				req.ReasoningEffort = &level
 			default:
-				return &Result{Text: cc.T("cmd.reasoning.unknownLevel", map[string]any{"level": fmt.Sprintf("%q", cc.Args[0])})}, nil
+				return &Result{Text: cc.T("cmd.reasoning.unknownLevel", map[string]any{
+					"level":  fmt.Sprintf("%q", cc.Args[0]),
+					"levels": strings.Join(choices, ", "),
+				})}, nil
 			}
 			if _, err := h.settingsService.UpsertBot(cc.Ctx, cc.BotID, req); err != nil {
 				return nil, err
@@ -102,7 +138,7 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 
 // reasoningResult builds the picker: a header with the current level plus one
 // button per level (current marked ✓). Tapping re-dispatches "/reasoning set X"
-// which edits the message in place. Level tokens (off/none/low/…) are canonical
+// which edits the message in place. Level tokens (off/low/…) are canonical
 // args and stay untranslated; only the surrounding prose is localized via t.
 //
 // Buttons render for everyone; the owner-only gate is enforced at execution
@@ -151,18 +187,13 @@ func reasoningResult(t *i18n.Localizer, effort string, opts reasoning.Options) *
 }
 
 // reasoningChoicesFor renders the levels this model actually offers, with "off"
-// leading when off is reachable. When the model cannot be resolved it falls back
-// to the tiers every reasoning model has, so the command still works rather than
-// showing an empty picker.
+// leading when off is reachable. Callers handle unresolved and unsupported models
+// before reaching this function; inventing a fallback would make those two states
+// look like a real model capability.
 func reasoningChoicesFor(opts reasoning.Options) []string {
 	tiers := opts.Efforts
 	if !opts.Supported {
-		return []string{
-			offChoice,
-			reasoning.EffortLow,
-			reasoning.EffortMedium,
-			reasoning.EffortHigh,
-		}
+		return nil
 	}
 	out := make([]string, 0, len(tiers)+1)
 	if opts.CanDisable {
@@ -171,12 +202,15 @@ func reasoningChoicesFor(opts reasoning.Options) []string {
 	return append(out, tiers...)
 }
 
-// acceptsEffort reports whether a typed tier can be stored. An unresolvable model
-// accepts any declarable tier rather than rejecting everything, since the
-// resolver filters unusable values at call time anyway.
+// acceptsEffort reports whether a typed selection can be stored. Off follows the
+// same capability gate as active tiers; hiding it from the picker is insufficient
+// because users can type `/reasoning set off` directly.
 func acceptsEffort(level string, opts reasoning.Options) bool {
 	if !opts.Supported {
-		return reasoning.IsDeclarable(level) && !reasoning.IsDisabled(level)
+		return false
+	}
+	if level == offChoice {
+		return opts.CanDisable
 	}
 	return slices.Contains(opts.Efforts, level)
 }

--- a/internal/command/reasoning.go
+++ b/internal/command/reasoning.go
@@ -2,32 +2,41 @@ package command
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/memohai/memoh/internal/i18n"
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
 	"github.com/memohai/memoh/internal/settings"
 )
 
-// reasoningChoices are the selectable reasoning levels. "off" disables thinking;
-// the rest enable it at that effort. Only "off" represents the disabled state —
-// listing "none" here too offered the same state under a second name.
-var reasoningChoices = []string{
-	"off",
-	models.ReasoningEffortLow,
-	models.ReasoningEffortMedium,
-	models.ReasoningEffortHigh,
-	models.ReasoningEffortXHigh,
-}
+// offChoice is the user-facing token for the disabled state. Storage represents
+// it as ReasoningEffortDisable; "off" is what a person types and taps.
+const offChoice = "off"
 
-// validEffort accepts the tiers that turn reasoning on. The disabled state is
-// handled by its own branch before this is consulted.
-func validEffort(v string) bool {
-	switch v {
-	case models.ReasoningEffortLow, models.ReasoningEffortMedium, models.ReasoningEffortHigh, models.ReasoningEffortXHigh:
-		return true
+// reasoningOptions reports what the bot's current chat model can actually do.
+// It replaces a hardcoded list that offered the same five levels on every model —
+// including Off on models that cannot be turned off, and never xhigh's neighbours
+// on models that advertise them.
+//
+// A model that cannot be resolved yields a zero Options, and the caller falls
+// back to accepting any declarable tier rather than blocking the command.
+func (h *Handler) reasoningOptions(cc CommandContext, modelID string) reasoning.Options {
+	if modelID == "" || h.modelsService == nil {
+		return reasoning.Options{}
 	}
-	return false
+	m, err := h.modelsService.GetByID(cc.Ctx, modelID)
+	if err != nil {
+		return reasoning.Options{}
+	}
+	clientType := ""
+	if h.providersService != nil {
+		if p, provErr := h.providersService.Get(cc.Ctx, m.ProviderID); provErr == nil {
+			clientType = p.ClientType
+		}
+	}
+	return m.ReasoningOptions(clientType)
 }
 
 // buildReasoningGroup registers /reasoning — a first-class sibling of /model.
@@ -45,7 +54,7 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			if err != nil {
 				return nil, err
 			}
-			return reasoningResult(cc.L, s.ReasoningEffort), nil
+			return reasoningResult(cc.L, s.ReasoningEffort, h.reasoningOptions(cc, s.ChatModelID)), nil
 		},
 	})
 	g.Register(SubCommand{
@@ -60,14 +69,20 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			if h.settingsService == nil {
 				return &Result{Text: cc.T("cmd.reasoning.unavailable")}, nil
 			}
+			current, err := h.getBotSettings(cc)
+			if err != nil {
+				return nil, err
+			}
+			opts := h.reasoningOptions(cc, current.ChatModelID)
+
 			req := settings.UpsertRequest{}
 			switch {
-			case level == "off":
+			case level == offChoice:
 				// "off" is the user-facing token; storage represents it as the
 				// "disable" effort now that bots have no separate on/off flag.
 				disable := models.ReasoningEffortDisable
 				req.ReasoningEffort = &disable
-			case validEffort(level):
+			case acceptsEffort(level, opts):
 				req.ReasoningEffort = &level
 			default:
 				return &Result{Text: cc.T("cmd.reasoning.unknownLevel", map[string]any{"level": fmt.Sprintf("%q", cc.Args[0])})}, nil
@@ -79,7 +94,7 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 			if err != nil {
 				return nil, err
 			}
-			return reasoningResult(cc.L, s.ReasoningEffort), nil
+			return reasoningResult(cc.L, s.ReasoningEffort, opts), nil
 		},
 	})
 	return g
@@ -94,7 +109,7 @@ func (h *Handler) buildReasoningGroup() *CommandGroup {
 // time (IsWrite), so a non-owner tap returns a clear "owner only" message rather
 // than the buttons being hidden — hiding them also hid them from owners whose
 // Telegram identity isn't resolved as owner, killing the feature.
-func reasoningResult(t *i18n.Localizer, effort string) *Result {
+func reasoningResult(t *i18n.Localizer, effort string, opts reasoning.Options) *Result {
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	disabled := models.IsReasoningDisabled(effort)
 	current := effort
@@ -105,10 +120,10 @@ func reasoningResult(t *i18n.Localizer, effort string) *Result {
 		current = t.T("cmd.common.on")
 	}
 	header := MdBold(t.T("cmd.reasoning.header")) + "\n" + t.T("cmd.reasoning.current", map[string]any{"level": current})
-	choices := make([]ListItem, 0, len(reasoningChoices))
-	for _, lvl := range reasoningChoices {
+	choices := make([]ListItem, 0, len(opts.Efforts)+1)
+	for _, lvl := range reasoningChoicesFor(opts) {
 		selected := false
-		if lvl == "off" {
+		if lvl == offChoice {
 			selected = disabled
 		} else {
 			selected = !disabled && lvl == effort
@@ -133,4 +148,35 @@ func reasoningResult(t *i18n.Localizer, effort string) *Result {
 			Choices: &ChoicesView{Title: body, Choices: choices},
 		},
 	}
+}
+
+// reasoningChoicesFor renders the levels this model actually offers, with "off"
+// leading when off is reachable. When the model cannot be resolved it falls back
+// to the tiers every reasoning model has, so the command still works rather than
+// showing an empty picker.
+func reasoningChoicesFor(opts reasoning.Options) []string {
+	tiers := opts.Efforts
+	if !opts.Supported {
+		return []string{
+			offChoice,
+			reasoning.EffortLow,
+			reasoning.EffortMedium,
+			reasoning.EffortHigh,
+		}
+	}
+	out := make([]string, 0, len(tiers)+1)
+	if opts.CanDisable {
+		out = append(out, offChoice)
+	}
+	return append(out, tiers...)
+}
+
+// acceptsEffort reports whether a typed tier can be stored. An unresolvable model
+// accepts any declarable tier rather than rejecting everything, since the
+// resolver filters unusable values at call time anyway.
+func acceptsEffort(level string, opts reasoning.Options) bool {
+	if !opts.Supported {
+		return reasoning.IsDeclarable(level) && !reasoning.IsDisabled(level)
+	}
+	return slices.Contains(opts.Efforts, level)
 }

--- a/internal/command/reasoning.go
+++ b/internal/command/reasoning.go
@@ -27,10 +27,10 @@ const offChoice = "off"
 // unknown. Neither case is safe to treat as a generic reasoning model.
 func (h *Handler) reasoningOptions(cc CommandContext, modelID string) (reasoning.Options, bool) {
 	modelID = strings.TrimSpace(modelID)
-	if modelID == "" || h.modelsService == nil || h.providersService == nil {
+	if modelID == "" || h.modelsService == nil {
 		return reasoning.Options{}, false
 	}
-	m, err := h.modelsService.GetByID(cc.Ctx, modelID)
+	opts, err := h.modelsService.ResolveReasoningOptions(cc.Ctx, modelID)
 	if err != nil {
 		if h.logger != nil {
 			h.logger.Warn("reasoning model lookup failed",
@@ -41,19 +41,7 @@ func (h *Handler) reasoningOptions(cc CommandContext, modelID string) (reasoning
 		}
 		return reasoning.Options{}, false
 	}
-	p, err := h.providersService.Get(cc.Ctx, m.ProviderID)
-	if err != nil || strings.TrimSpace(p.ClientType) == "" {
-		if h.logger != nil {
-			h.logger.Warn("reasoning provider lookup failed",
-				slog.String("bot_id", cc.BotID),
-				slog.String("model_id", modelID),
-				slog.String("provider_id", m.ProviderID),
-				slog.Any("error", err),
-			)
-		}
-		return reasoning.Options{}, false
-	}
-	return m.ReasoningOptions(p.ClientType), true
+	return opts, true
 }
 
 // buildReasoningGroup registers /reasoning — a first-class sibling of /model.

--- a/internal/command/reasoning_error_test.go
+++ b/internal/command/reasoning_error_test.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/i18n"
+	"github.com/memohai/memoh/internal/reasoning"
+	"github.com/memohai/memoh/internal/settings"
+)
+
+func TestFriendlyCommandErrorLocalizesReasoningPolicyErrors(t *testing.T) {
+	t.Parallel()
+
+	handler := &Handler{}
+	invalid := &settings.InvalidReasoningEffortError{
+		Effort: reasoning.EffortXHigh,
+		Options: reasoning.Options{
+			Supported:     true,
+			CanDisable:    true,
+			Efforts:       []string{reasoning.EffortLow, reasoning.EffortHigh},
+			DefaultEffort: reasoning.EffortLow,
+		},
+	}
+	if got, want := handler.friendlyCommandError(i18n.New("en"), "settings", invalid),
+		`Unknown level "xhigh" — available levels: off, low, high.`; got != want {
+		t.Fatalf("invalid effort message = %q, want %q", got, want)
+	}
+
+	unavailable := errors.Join(settings.ErrReasoningOptionsUnavailable, errors.New("SECRET provider diagnostic"))
+	got := handler.friendlyCommandError(i18n.New("en"), "settings", unavailable)
+	if want := "Reasoning isn't available right now."; got != want {
+		t.Fatalf("unavailable message = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "SECRET") {
+		t.Fatalf("unavailable message leaked private diagnostic: %q", got)
+	}
+}

--- a/internal/command/reasoning_handler_test.go
+++ b/internal/command/reasoning_handler_test.go
@@ -1,0 +1,211 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/providers"
+	"github.com/memohai/memoh/internal/settings"
+)
+
+type reasoningCommandQueries struct {
+	dbstore.Queries
+	model          sqlc.Model
+	provider       sqlc.Provider
+	modelErr       error
+	providerErr    error
+	upsertAttempts int
+}
+
+func (q *reasoningCommandQueries) GetSettingsByBotID(context.Context, pgtype.UUID) (sqlc.GetSettingsByBotIDRow, error) {
+	return sqlc.GetSettingsByBotIDRow{
+		Language:           settings.DefaultLanguage,
+		CommandUiLanguage:  settings.DefaultCommandUILanguage,
+		ReasoningEffort:    settings.DefaultReasoningEffort,
+		HeartbeatInterval:  settings.DefaultHeartbeatInterval,
+		ChatModelID:        q.model.ID,
+		ChatRuntime:        settings.ChatRuntimeModel,
+		ChatAcpProjectPath: settings.DefaultACPProjectPath,
+		ChatAcpProjectMode: settings.DefaultACPProjectMode,
+	}, nil
+}
+
+func (q *reasoningCommandQueries) GetModelByID(context.Context, pgtype.UUID) (sqlc.Model, error) {
+	if q.modelErr != nil {
+		return sqlc.Model{}, q.modelErr
+	}
+	return q.model, nil
+}
+
+func (q *reasoningCommandQueries) GetProviderByID(context.Context, pgtype.UUID) (sqlc.Provider, error) {
+	if q.providerErr != nil {
+		return sqlc.Provider{}, q.providerErr
+	}
+	return q.provider, nil
+}
+
+// GetBotByID is the first query UpsertBot performs. Rejection tests use the call
+// count as a persistence-boundary assertion: invalid selections must stop before
+// any write path is entered.
+func (q *reasoningCommandQueries) GetBotByID(context.Context, pgtype.UUID) (sqlc.GetBotByIDRow, error) {
+	q.upsertAttempts++
+	return sqlc.GetBotByIDRow{}, errors.New("unexpected settings upsert")
+}
+
+func newReasoningCommandHarness(
+	t *testing.T,
+	modelConfig string,
+	modelErr error,
+	providerErr error,
+) (*Handler, *reasoningCommandQueries, string) {
+	t.Helper()
+
+	botID := "00000000-0000-0000-0000-000000000610"
+	modelID := pgtype.UUID{Bytes: uuid.MustParse("00000000-0000-0000-0000-000000000611"), Valid: true}
+	providerID := pgtype.UUID{Bytes: uuid.MustParse("00000000-0000-0000-0000-000000000612"), Valid: true}
+	queries := &reasoningCommandQueries{
+		model: sqlc.Model{
+			ID:         modelID,
+			ModelID:    "reasoning-test-model",
+			ProviderID: providerID,
+			Type:       string(models.ModelTypeChat),
+			Enable:     true,
+			Config:     []byte(modelConfig),
+		},
+		provider: sqlc.Provider{
+			ID:         providerID,
+			Name:       "reasoning-test-provider",
+			ClientType: string(models.ClientTypeOpenAICodex),
+			Enable:     true,
+		},
+		modelErr:    modelErr,
+		providerErr: providerErr,
+	}
+	logger := slog.New(slog.DiscardHandler)
+	settingsService := settings.NewService(logger, queries, nil, nil)
+	handler := NewHandler(
+		logger,
+		&fakeRoleResolver{role: "owner"},
+		nil,
+		settingsService,
+		nil,
+		models.NewService(logger, queries),
+		providers.NewService(logger, queries, ""),
+		nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	return handler, queries, botID
+}
+
+func executeReasoningCommand(t *testing.T, handler *Handler, botID, text string) *Result {
+	t.Helper()
+	result, err := handler.ExecuteResult(context.Background(), ExecuteInput{
+		BotID:             botID,
+		ChannelIdentityID: "owner-channel-identity",
+		Text:              text,
+		Locale:            "en",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteResult(%q): %v", text, err)
+	}
+	if result == nil {
+		t.Fatalf("ExecuteResult(%q) returned nil", text)
+	}
+	return result
+}
+
+func TestReasoningSetOffRequiresDisableCapability(t *testing.T) {
+	t.Parallel()
+
+	handler, queries, botID := newReasoningCommandHarness(t,
+		`{"compatibilities":["reasoning"],"thinking_mode":"toggle","reasoning_efforts":["minimal","low","max"]}`,
+		nil, nil,
+	)
+	result := executeReasoningCommand(t, handler, botID, "/reasoning set off")
+
+	if got, want := result.Text, `Unknown level "off" — available levels: minimal, low, max.`; got != want {
+		t.Fatalf("response = %q, want %q", got, want)
+	}
+	if queries.upsertAttempts != 0 {
+		t.Fatalf("invalid off selection entered persistence path %d time(s)", queries.upsertAttempts)
+	}
+}
+
+func TestReasoningResolvedUnsupportedDoesNotUseFallback(t *testing.T) {
+	t.Parallel()
+
+	handler, queries, botID := newReasoningCommandHarness(t,
+		`{"thinking_mode":"none"}`,
+		nil, nil,
+	)
+	for _, command := range []string{"/reasoning", "/reasoning set high"} {
+		result := executeReasoningCommand(t, handler, botID, command)
+		if got, want := result.Text, "The current model doesn't support reasoning."; got != want {
+			t.Fatalf("%s response = %q, want %q", command, got, want)
+		}
+		if result.Interactive != nil {
+			t.Fatalf("%s returned invented choices: %+v", command, result.Interactive)
+		}
+	}
+	if queries.upsertAttempts != 0 {
+		t.Fatalf("unsupported model entered persistence path %d time(s)", queries.upsertAttempts)
+	}
+}
+
+func TestReasoningLookupFailuresFailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		modelErr    error
+		providerErr error
+	}{
+		{name: "model lookup", modelErr: errors.New("SECRET model diagnostic")},
+		{name: "provider lookup", providerErr: errors.New("SECRET provider diagnostic")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, queries, botID := newReasoningCommandHarness(t,
+				`{"compatibilities":["reasoning"],"thinking_mode":"toggle","reasoning_efforts":["disable","low","high"]}`,
+				tt.modelErr, tt.providerErr,
+			)
+			result := executeReasoningCommand(t, handler, botID, "/reasoning set high")
+
+			if got, want := result.Text, "Reasoning isn't available right now."; got != want {
+				t.Fatalf("response = %q, want %q", got, want)
+			}
+			if strings.Contains(result.Text, "SECRET") {
+				t.Fatalf("response leaked lookup diagnostic: %q", result.Text)
+			}
+			if queries.upsertAttempts != 0 {
+				t.Fatalf("lookup failure entered persistence path %d time(s)", queries.upsertAttempts)
+			}
+		})
+	}
+}
+
+func TestReasoningSetUsageFollowsResolvedModel(t *testing.T) {
+	t.Parallel()
+
+	handler, queries, botID := newReasoningCommandHarness(t,
+		`{"compatibilities":["reasoning"],"thinking_mode":"toggle","reasoning_efforts":["minimal","low","max"]}`,
+		nil, nil,
+	)
+	result := executeReasoningCommand(t, handler, botID, "/reasoning set")
+
+	if got, want := result.Text, "Usage: /reasoning set <minimal|low|max>"; got != want {
+		t.Fatalf("response = %q, want %q", got, want)
+	}
+	if queries.upsertAttempts != 0 {
+		t.Fatalf("usage request entered persistence path %d time(s)", queries.upsertAttempts)
+	}
+}

--- a/internal/command/reasoning_test.go
+++ b/internal/command/reasoning_test.go
@@ -1,11 +1,13 @@
 package command
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/memohai/memoh/internal/i18n"
 	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
 )
 
 func TestReasoningRegisteredWithAliases(t *testing.T) {
@@ -24,9 +26,25 @@ func TestReasoningRegisteredWithAliases(t *testing.T) {
 	}
 }
 
+// fullLadderOptions is a model that can be turned off and advertises the whole
+// ladder — what the command used to assume of every model unconditionally.
+func fullLadderOptions() reasoning.Options {
+	return reasoning.OptionsFor(
+		reasoning.ModeToggle,
+		[]string{
+			reasoning.EffortDisable,
+			reasoning.EffortLow,
+			reasoning.EffortMedium,
+			reasoning.EffortHigh,
+			reasoning.EffortXHigh,
+		},
+		"openai-codex",
+	)
+}
+
 func TestReasoningResultMarksCurrent(t *testing.T) {
 	t.Parallel()
-	res := reasoningResult(i18n.New("en"), "medium")
+	res := reasoningResult(i18n.New("en"), "medium", fullLadderOptions())
 	if res.Interactive == nil || res.Interactive.Kind != InteractiveChoices || res.Interactive.Choices == nil {
 		t.Fatalf("expected a choices interactive, got %+v", res.Interactive)
 	}
@@ -34,12 +52,12 @@ func TestReasoningResultMarksCurrent(t *testing.T) {
 	if !strings.Contains(res.Text, "Current: medium") {
 		t.Errorf("missing current line: %s", res.Text)
 	}
-	assertReasoningMarked(t, reasoningResult(i18n.New("en"), models.ReasoningEffortDisable), "off")
+	assertReasoningMarked(t, reasoningResult(i18n.New("en"), models.ReasoningEffortDisable, fullLadderOptions()), "off")
 }
 
 func TestReasoningChoicesIncludeFullBackendEffortLadder(t *testing.T) {
 	t.Parallel()
-	res := reasoningResult(i18n.New("en"), "xhigh")
+	res := reasoningResult(i18n.New("en"), "xhigh", fullLadderOptions())
 	assertReasoningMarked(t, res, "xhigh")
 	labels := make(map[string]bool)
 	for _, c := range res.Interactive.Choices.Choices {
@@ -77,7 +95,7 @@ func assertReasoningMarked(t *testing.T, res *Result, want string) {
 // button must re-parse to "/reasoning set <level>" so the tap actually applies.
 func TestReasoningChoiceCallbackRoundTrip(t *testing.T) {
 	t.Parallel()
-	for _, lvl := range reasoningChoices {
+	for _, lvl := range reasoningChoicesFor(fullLadderOptions()) {
 		data := EncodeListCallback("reasoning", "set", []string{lvl}, 0)
 		if len(data) > telegramCallbackLimit {
 			t.Fatalf("callback %q exceeds limit", data)
@@ -117,5 +135,75 @@ func TestUnknownCommandHandling(t *testing.T) {
 		if !h.IsCommand(c) {
 			t.Errorf("%s should be a known command", c)
 		}
+	}
+}
+
+// TestReasoningChoicesFollowTheModel is the behaviour change: the picker used to
+// offer the same five levels on every model, including Off on models that cannot
+// be turned off and never the tiers a model actually advertises.
+func TestReasoningChoicesFollowTheModel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		opts   reasoning.Options
+		want   []string
+		absent []string
+	}{
+		{
+			name: "a model that can be turned off leads with off",
+			opts: reasoning.OptionsFor(reasoning.ModeToggle,
+				[]string{reasoning.EffortDisable, reasoning.EffortLow, reasoning.EffortHigh},
+				"openai-codex"),
+			want: []string{"off", "low", "high"},
+		},
+		{
+			name: "a model that cannot be turned off does not offer it",
+			opts: reasoning.OptionsFor(reasoning.ModeToggle,
+				[]string{reasoning.EffortMinimal, reasoning.EffortLow, reasoning.EffortMedium},
+				"openai-codex"),
+			want:   []string{"minimal", "low", "medium"},
+			absent: []string{"off"},
+		},
+		{
+			name: "an unresolvable model keeps the command usable",
+			opts: reasoning.Options{},
+			want: []string{"off", "low", "medium", "high"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := reasoningChoicesFor(tt.opts)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("choices = %v, want %v", got, tt.want)
+			}
+			for _, absent := range tt.absent {
+				if slices.Contains(got, absent) {
+					t.Fatalf("choices unexpectedly offer %q: %v", absent, got)
+				}
+			}
+		})
+	}
+}
+
+// TestAcceptsEffortRejectsTiersTheModelDoesNotOffer keeps a typed level from
+// storing a value the model will never accept — the /reasoning half of the same
+// guarantee the picker gives by only rendering reachable options.
+func TestAcceptsEffortRejectsTiersTheModelDoesNotOffer(t *testing.T) {
+	t.Parallel()
+
+	opts := reasoning.OptionsFor(reasoning.ModeToggle,
+		[]string{reasoning.EffortLow, reasoning.EffortMedium}, "openai-codex")
+
+	if !acceptsEffort(reasoning.EffortLow, opts) {
+		t.Error("an advertised tier should be accepted")
+	}
+	if acceptsEffort(reasoning.EffortXHigh, opts) {
+		t.Error("a tier the model does not advertise should be rejected")
+	}
+	if acceptsEffort(reasoning.EffortDisable, opts) {
+		t.Error("the disable token is not a tier and has its own branch")
 	}
 }

--- a/internal/command/reasoning_test.go
+++ b/internal/command/reasoning_test.go
@@ -166,9 +166,9 @@ func TestReasoningChoicesFollowTheModel(t *testing.T) {
 			absent: []string{"off"},
 		},
 		{
-			name: "an unresolvable model keeps the command usable",
+			name: "a model without reasoning offers no invented fallback",
 			opts: reasoning.Options{},
-			want: []string{"off", "low", "medium", "high"},
+			want: []string{},
 		},
 	}
 
@@ -194,16 +194,23 @@ func TestReasoningChoicesFollowTheModel(t *testing.T) {
 func TestAcceptsEffortRejectsTiersTheModelDoesNotOffer(t *testing.T) {
 	t.Parallel()
 
-	opts := reasoning.OptionsFor(reasoning.ModeToggle,
+	cannotDisable := reasoning.OptionsFor(reasoning.ModeToggle,
 		[]string{reasoning.EffortLow, reasoning.EffortMedium}, "openai-codex")
+	canDisable := fullLadderOptions()
 
-	if !acceptsEffort(reasoning.EffortLow, opts) {
+	if !acceptsEffort(reasoning.EffortLow, cannotDisable) {
 		t.Error("an advertised tier should be accepted")
 	}
-	if acceptsEffort(reasoning.EffortXHigh, opts) {
+	if acceptsEffort(reasoning.EffortXHigh, cannotDisable) {
 		t.Error("a tier the model does not advertise should be rejected")
 	}
-	if acceptsEffort(reasoning.EffortDisable, opts) {
-		t.Error("the disable token is not a tier and has its own branch")
+	if acceptsEffort(offChoice, cannotDisable) {
+		t.Error("off should be rejected when the model cannot disable reasoning")
+	}
+	if !acceptsEffort(offChoice, canDisable) {
+		t.Error("off should be accepted when the model can disable reasoning")
+	}
+	if acceptsEffort(reasoning.EffortLow, reasoning.Options{}) {
+		t.Error("an unsupported or unresolved model must not accept a fallback tier")
 	}
 }

--- a/internal/command/settings_i18n_test.go
+++ b/internal/command/settings_i18n_test.go
@@ -13,7 +13,7 @@ import (
 // but the level button labels and their dispatched Args stay canonical tokens.
 func TestReasoningResultZhLocalizesProseNotTokens(t *testing.T) {
 	t.Parallel()
-	res := reasoningResult(i18n.New("zh"), "xhigh")
+	res := reasoningResult(i18n.New("zh"), "xhigh", fullLadderOptions())
 	title := res.Interactive.Choices.Title
 	if !strings.Contains(title, "🧠 推理") {
 		t.Errorf("zh header missing, title=%q", title)

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/memohai/memoh/internal/accounts"
+	"github.com/memohai/memoh/internal/apperror"
 	"github.com/memohai/memoh/internal/bots"
 	"github.com/memohai/memoh/internal/heartbeat"
 	"github.com/memohai/memoh/internal/settings"
@@ -78,7 +79,8 @@ func (h *SettingsHandler) Get(c echo.Context) error {
 // @Param bot_id path string true "Bot ID"
 // @Param payload body settings.UpsertRequest true "Settings payload"
 // @Success 200 {object} settings.Settings
-// @Failure 400 {object} ErrorResponse
+// @Failure 400 {object} apperror.Problem
+// @Failure 503 {object} apperror.Problem
 // @Failure 500 {object} ErrorResponse
 // @Router /bots/{bot_id}/settings [put]
 // @Router /bots/{bot_id}/settings [post].
@@ -100,6 +102,9 @@ func (h *SettingsHandler) Upsert(c echo.Context) error {
 	}
 	resp, err := h.service.UpsertBot(c.Request().Context(), botID, req)
 	if err != nil {
+		if reasoningErr := settingsReasoningHTTPError(err); reasoningErr != nil {
+			return reasoningErr
+		}
 		if feedbackErr := acpFeedbackHTTPError(err); feedbackErr != nil {
 			return feedbackErr
 		}
@@ -119,6 +124,19 @@ func (h *SettingsHandler) Upsert(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, resp)
+}
+
+func settingsReasoningHTTPError(err error) error {
+	var invalid *settings.InvalidReasoningEffortError
+	if errors.As(err, &invalid) {
+		return apperror.New(apperror.CodeSettingsReasoningEffortInvalid, map[string]string{
+			"effort": invalid.Effort,
+		})
+	}
+	if errors.Is(err, settings.ErrReasoningOptionsUnavailable) {
+		return apperror.Wrap(apperror.CodeSettingsReasoningUnavailable, err, nil)
+	}
+	return nil
 }
 
 // Delete godoc

--- a/internal/handlers/settings_reasoning_error_test.go
+++ b/internal/handlers/settings_reasoning_error_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/apperror"
+	"github.com/memohai/memoh/internal/reasoning"
+	"github.com/memohai/memoh/internal/settings"
+)
+
+func TestSettingsReasoningHTTPError(t *testing.T) {
+	t.Parallel()
+
+	invalid := &settings.InvalidReasoningEffortError{
+		Effort: reasoning.EffortXHigh,
+		Options: reasoning.Options{
+			Supported: true,
+			Efforts:   []string{reasoning.EffortLow, reasoning.EffortHigh},
+		},
+	}
+	mapped := settingsReasoningHTTPError(invalid)
+	if got := apperror.CodeOf(mapped); got != apperror.CodeSettingsReasoningEffortInvalid {
+		t.Fatalf("invalid effort code = %q, want %q", got, apperror.CodeSettingsReasoningEffortInvalid)
+	}
+	problem, ok := apperror.ProblemFrom(mapped, "request-reasoning")
+	if !ok {
+		t.Fatal("invalid effort did not map to Problem Details")
+	}
+	if problem.Status != 400 || problem.Args["effort"] != reasoning.EffortXHigh {
+		t.Fatalf("invalid effort problem = %#v", problem)
+	}
+
+	private := errors.New("SECRET provider diagnostic")
+	unavailable := settingsReasoningHTTPError(errors.Join(settings.ErrReasoningOptionsUnavailable, private))
+	if got := apperror.CodeOf(unavailable); got != apperror.CodeSettingsReasoningUnavailable {
+		t.Fatalf("unavailable code = %q, want %q", got, apperror.CodeSettingsReasoningUnavailable)
+	}
+	problem, ok = apperror.ProblemFrom(unavailable, "request-reasoning")
+	if !ok || problem.Status != 503 {
+		t.Fatalf("unavailable problem = %#v, ok = %t", problem, ok)
+	}
+	if strings.Contains(problem.Detail, "SECRET") {
+		t.Fatalf("Problem Details leaked private diagnostic: %#v", problem)
+	}
+	if !errors.Is(apperror.CauseOf(unavailable), private) {
+		t.Fatalf("private cause was not retained for logging: %v", apperror.CauseOf(unavailable))
+	}
+}

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -311,7 +311,7 @@
       "unknownOption": "Unknown option: {option}\n\n{usage}",
       "unknownLanguage": "Unknown language {value}. Choose auto, en, zh, or ja.",
       "unavailable": "Settings aren't available right now.",
-      "updateUsage": "Usage: /settings update [options]\n\nOptions:\n- --language <value>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|none|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <minutes>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n(Command UI language: /settings language <auto|en|zh|ja>)",
+      "updateUsage": "Usage: /settings update [options]\n\nOptions:\n- --language <value>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <minutes>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n(Command UI language: /settings language <auto|en|zh|ja>)",
       "langJa": "日本語"
     },
     "language": {
@@ -509,7 +509,7 @@
       "header": "🧠 Reasoning",
       "current": "Current: {level}",
       "choosePrompt": "Higher effort means more careful thinking, but slower replies. Choose a level:",
-      "setUsage": "Usage: /reasoning set <off|none|low|medium|high|xhigh>",
+      "setUsage": "Usage: /reasoning set <off|low|medium|high|xhigh>",
       "unavailable": "Reasoning isn't available right now.",
       "unknownLevel": "Unknown level {level} — choose off, none, low, medium, high, or xhigh."
     },

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -509,9 +509,10 @@
       "header": "🧠 Reasoning",
       "current": "Current: {level}",
       "choosePrompt": "Higher effort means more careful thinking, but slower replies. Choose a level:",
-      "setUsage": "Usage: /reasoning set <off|low|medium|high|xhigh>",
+      "setUsage": "Usage: /reasoning set <{levels}>",
       "unavailable": "Reasoning isn't available right now.",
-      "unknownLevel": "Unknown level {level} — choose off, none, low, medium, high, or xhigh."
+      "unsupported": "The current model doesn't support reasoning.",
+      "unknownLevel": "Unknown level {level} — available levels: {levels}."
     },
     "error": {
       "unknownCommand": "Unknown command {command}. Run {help} to see what's available, or resend without the leading slash to send it as a regular message.",

--- a/internal/i18n/locales/ja.json
+++ b/internal/i18n/locales/ja.json
@@ -311,7 +311,7 @@
       "unknownOption": "不明なオプション: {option}\n\n{usage}",
       "unknownLanguage": "不明な言語 {value}。auto、en、zh、ja から選んでください。",
       "unavailable": "現在設定は利用できません。",
-      "updateUsage": "使い方: /settings update [options]\n\nOptions:\n- --language <value>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|none|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <minutes>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n(Command UI language: /settings language <auto|en|zh|ja>)",
+      "updateUsage": "使い方: /settings update [options]\n\nOptions:\n- --language <value>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <minutes>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n(Command UI language: /settings language <auto|en|zh|ja>)",
       "langJa": "日本語"
     },
     "language": {
@@ -509,7 +509,7 @@
       "header": "🧠 推論",
       "current": "現在: {level}",
       "choosePrompt": "努力が増えると、より慎重に考えることになりますが、応答は遅くなります。レベルを選択してください:",
-      "setUsage": "使い方: /reasoning set<off|none|low|medium|high|xhigh>",
+      "setUsage": "使い方: /reasoning set<off|low|medium|high|xhigh>",
       "unavailable": "推論は現在利用できません。",
       "unknownLevel": "不明レベル {level} — off、none、low、medium、high、または xhigh を選択します。"
     },

--- a/internal/i18n/locales/ja.json
+++ b/internal/i18n/locales/ja.json
@@ -509,9 +509,10 @@
       "header": "🧠 推論",
       "current": "現在: {level}",
       "choosePrompt": "努力が増えると、より慎重に考えることになりますが、応答は遅くなります。レベルを選択してください:",
-      "setUsage": "使い方: /reasoning set<off|low|medium|high|xhigh>",
+      "setUsage": "使い方: /reasoning set <{levels}>",
       "unavailable": "推論は現在利用できません。",
-      "unknownLevel": "不明レベル {level} — off、none、low、medium、high、または xhigh を選択します。"
+      "unsupported": "現在のモデルは推論に対応していません。",
+      "unknownLevel": "不明なレベル {level} — 利用可能なレベル: {levels}。"
     },
     "error": {
       "unknownCommand": "不明なコマンド {command}。 {help} を実行して利用可能なものを確認するか、先頭のスラッシュを付けずに再送信して通常のメッセージとして送信します。",

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -509,9 +509,10 @@
       "header": "🧠 推理",
       "current": "当前：{level}",
       "choosePrompt": "强度越高思考越深入，但回复更慢。选择级别：",
-      "setUsage": "用法：/reasoning set <off|low|medium|high|xhigh>",
+      "setUsage": "用法：/reasoning set <{levels}>",
       "unavailable": "推理功能暂不可用。",
-      "unknownLevel": "未知级别 {level}，请选择 off、none、low、medium、high 或 xhigh。"
+      "unsupported": "当前模型不支持推理。",
+      "unknownLevel": "未知级别 {level}，可用级别：{levels}。"
     },
     "error": {
       "unknownCommand": "未知命令 {command}，用 {help} 查看可用命令。也可去掉斜杠作为普通消息发送。",

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -311,7 +311,7 @@
       "unknownOption": "未知选项：{option}\n\n{usage}",
       "unknownLanguage": "未知语言 {value}。请选择 auto、en、zh 或 ja。",
       "unavailable": "设置暂不可用。",
-      "updateUsage": "用法：/settings update [选项]\n\n选项：\n- --language <值>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|none|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <分钟>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n（命令界面语言：/settings language <auto|en|zh|ja>）",
+      "updateUsage": "用法：/settings update [选项]\n\n选项：\n- --language <值>\n- --acl_default_effect <allow|deny>\n- --reasoning_effort <disable|low|medium|high|xhigh>\n- --heartbeat_enabled <true|false>\n- --heartbeat_interval <分钟>\n- --chat_model_id <id>\n- --heartbeat_model_id <id>\n\n（命令界面语言：/settings language <auto|en|zh|ja>）",
       "langJa": "日本語"
     },
     "language": {
@@ -509,7 +509,7 @@
       "header": "🧠 推理",
       "current": "当前：{level}",
       "choosePrompt": "强度越高思考越深入，但回复更慢。选择级别：",
-      "setUsage": "用法：/reasoning set <off|none|low|medium|high|xhigh>",
+      "setUsage": "用法：/reasoning set <off|low|medium|high|xhigh>",
       "unavailable": "推理功能暂不可用。",
       "unknownLevel": "未知级别 {level}，请选择 off、none、low、medium、high 或 xhigh。"
     },

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -15,6 +15,7 @@ import (
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/reasoning"
 	"github.com/memohai/memoh/internal/redact"
 )
 
@@ -103,6 +104,29 @@ func (s *Service) GetByID(ctx context.Context, id string) (GetResponse, error) {
 	}
 
 	return s.convertToGetResponse(dbModel), nil
+}
+
+// ResolveReasoningOptions returns the selectable reasoning contract for a model
+// using the client type of its persisted provider. Keeping provider lookup here
+// gives commands and settings writes the same capability answer.
+func (s *Service) ResolveReasoningOptions(ctx context.Context, id string) (reasoning.Options, error) {
+	model, err := s.GetByID(ctx, id)
+	if err != nil {
+		return reasoning.Options{}, err
+	}
+	providerID, err := db.ParseUUID(model.ProviderID)
+	if err != nil {
+		return reasoning.Options{}, fmt.Errorf("invalid provider ID: %w", err)
+	}
+	provider, err := s.queries.GetProviderByID(ctx, providerID)
+	if err != nil {
+		return reasoning.Options{}, fmt.Errorf("failed to get provider: %w", err)
+	}
+	clientType := strings.TrimSpace(provider.ClientType)
+	if clientType == "" {
+		return reasoning.Options{}, errors.New("provider client type is required")
+	}
+	return model.ReasoningOptions(clientType), nil
 }
 
 // GetByModelID retrieves a model by its model_id field.

--- a/internal/reasoning/selection.go
+++ b/internal/reasoning/selection.go
@@ -1,0 +1,26 @@
+package reasoning
+
+import (
+	"slices"
+	"strings"
+)
+
+// NormalizeSelection validates a user-facing reasoning choice against the
+// resolved options for one model and returns the canonical stored value.
+// "off" and the legacy wire spelling "none" both store as EffortDisable.
+func NormalizeSelection(selection string, opts Options) (string, bool) {
+	selection = strings.ToLower(strings.TrimSpace(selection))
+	if !opts.Supported || selection == "" {
+		return "", false
+	}
+	if selection == "off" || IsDisabled(selection) {
+		if opts.CanDisable {
+			return EffortDisable, true
+		}
+		return "", false
+	}
+	if slices.Contains(opts.Efforts, selection) {
+		return selection, true
+	}
+	return "", false
+}

--- a/internal/reasoning/selection_test.go
+++ b/internal/reasoning/selection_test.go
@@ -1,0 +1,43 @@
+package reasoning
+
+import "testing"
+
+func TestNormalizeSelection(t *testing.T) {
+	t.Parallel()
+
+	canDisable := Options{
+		Supported:     true,
+		CanDisable:    true,
+		Efforts:       []string{EffortLow, EffortHigh},
+		DefaultEffort: EffortLow,
+	}
+	cannotDisable := canDisable
+	cannotDisable.CanDisable = false
+
+	tests := []struct {
+		name      string
+		selection string
+		opts      Options
+		want      string
+		wantOK    bool
+	}{
+		{name: "active tier", selection: " HIGH ", opts: canDisable, want: EffortHigh, wantOK: true},
+		{name: "off label", selection: "off", opts: canDisable, want: EffortDisable, wantOK: true},
+		{name: "canonical off", selection: EffortDisable, opts: canDisable, want: EffortDisable, wantOK: true},
+		{name: "legacy off", selection: EffortNone, opts: canDisable, want: EffortDisable, wantOK: true},
+		{name: "off unavailable", selection: "off", opts: cannotDisable},
+		{name: "unadvertised tier", selection: EffortXHigh, opts: canDisable},
+		{name: "unsupported model", selection: EffortLow, opts: Options{}},
+		{name: "blank", selection: "  ", opts: canDisable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := NormalizeSelection(tt.selection, tt.opts)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("NormalizeSelection(%q) = (%q, %t), want (%q, %t)", tt.selection, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/settings/service.go
+++ b/internal/settings/service.go
@@ -19,20 +19,36 @@ import (
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	netctl "github.com/memohai/memoh/internal/network"
+	"github.com/memohai/memoh/internal/reasoning"
 	tzutil "github.com/memohai/memoh/internal/timezone"
 )
 
+type ReasoningOptionsResolver interface {
+	ResolveReasoningOptions(context.Context, string) (reasoning.Options, error)
+}
+
 type Service struct {
-	queries dbstore.Queries
-	acl     *acl.Service
-	network *netctl.Service
-	logger  *slog.Logger
+	queries           dbstore.Queries
+	acl               *acl.Service
+	network           *netctl.Service
+	reasoningResolver ReasoningOptionsResolver
+	logger            *slog.Logger
 }
 
 var (
-	ErrModelIDAmbiguous = errors.New("model_id is ambiguous across providers")
-	ErrInvalidModelRef  = errors.New("invalid model reference")
+	ErrModelIDAmbiguous            = errors.New("model_id is ambiguous across providers")
+	ErrInvalidModelRef             = errors.New("invalid model reference")
+	ErrReasoningOptionsUnavailable = errors.New("reasoning options unavailable")
 )
+
+type InvalidReasoningEffortError struct {
+	Effort  string
+	Options reasoning.Options
+}
+
+func (e *InvalidReasoningEffortError) Error() string {
+	return fmt.Sprintf("reasoning effort %q is not supported by the chat model", e.Effort)
+}
 
 func NewService(log *slog.Logger, queries dbstore.Queries, aclService *acl.Service, networkService *netctl.Service) *Service {
 	return &Service{
@@ -41,6 +57,10 @@ func NewService(log *slog.Logger, queries dbstore.Queries, aclService *acl.Servi
 		network: networkService,
 		logger:  log.With(slog.String("service", "settings")),
 	}
+}
+
+func (s *Service) SetReasoningOptionsResolver(resolver ReasoningOptionsResolver) {
+	s.reasoningResolver = resolver
 }
 
 func (s *Service) GetBot(ctx context.Context, botID string) (Settings, error) {
@@ -141,9 +161,6 @@ func (s *Service) UpsertBot(ctx context.Context, botID string, req UpsertRequest
 	if effect := strings.TrimSpace(req.AclDefaultEffect); effect != "" {
 		current.AclDefaultEffect = effect
 	}
-	if req.ReasoningEffort != nil && hasReasoningEffortValue(*req.ReasoningEffort) {
-		current.ReasoningEffort = *req.ReasoningEffort
-	}
 	if req.HeartbeatEnabled != nil {
 		current.HeartbeatEnabled = *req.HeartbeatEnabled
 	}
@@ -237,6 +254,9 @@ func (s *Service) UpsertBot(ctx context.Context, botID string, req UpsertRequest
 		} else {
 			current.ChatModelID = ""
 		}
+	}
+	if err := s.applyReasoningPolicy(ctx, &current, req); err != nil {
+		return Settings{}, err
 	}
 	heartbeatModelUUID := pgtype.UUID{}
 	heartbeatModelIDSet := req.HeartbeatModelID != nil
@@ -520,6 +540,68 @@ func nullableCompactionTargetPercent(value *int) pgtype.Int4 {
 // a given model accepts are enforced upstream, not by this generic setting.
 func hasReasoningEffortValue(effort string) bool {
 	return strings.TrimSpace(effort) != ""
+}
+
+func (s *Service) applyReasoningPolicy(ctx context.Context, current *Settings, req UpsertRequest) error {
+	requestedSet := req.ReasoningEffort != nil && hasReasoningEffortValue(*req.ReasoningEffort)
+	if !requestedSet && req.ChatModelID == nil {
+		return nil
+	}
+
+	requested := ""
+	if requestedSet {
+		requested = normalizeDormantReasoningEffort(*req.ReasoningEffort)
+	}
+	if strings.TrimSpace(current.ChatModelID) == "" {
+		if requestedSet {
+			current.ReasoningEffort = requested
+		}
+		return nil
+	}
+	if s.reasoningResolver == nil {
+		return fmt.Errorf("%w: resolver not configured", ErrReasoningOptionsUnavailable)
+	}
+
+	opts, err := s.reasoningResolver.ResolveReasoningOptions(ctx, current.ChatModelID)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrReasoningOptionsUnavailable, err)
+	}
+	// A model without a reasoning concept keeps the dormant preference. This
+	// preserves import/create behavior and lets a later switch back to a reasoning
+	// model reconcile the value against that model's real options.
+	if !opts.Supported {
+		if requestedSet {
+			current.ReasoningEffort = requested
+		}
+		return nil
+	}
+	if requestedSet {
+		normalized, ok := reasoning.NormalizeSelection(requested, opts)
+		if !ok {
+			// Full model-setting payloads (create/import and the web model picker)
+			// may carry a preference from the previous model. Reconcile that stale
+			// value in the same write; effort-only requests are explicit choices and
+			// receive a validation error instead.
+			if req.ChatModelID != nil {
+				current.ReasoningEffort = reasoning.ReconcileStored(requested, opts)
+				return nil
+			}
+			return &InvalidReasoningEffortError{Effort: requested, Options: opts}
+		}
+		current.ReasoningEffort = normalized
+		return nil
+	}
+
+	current.ReasoningEffort = reasoning.ReconcileStored(current.ReasoningEffort, opts)
+	return nil
+}
+
+func normalizeDormantReasoningEffort(effort string) string {
+	effort = strings.ToLower(strings.TrimSpace(effort))
+	if effort == "off" || reasoning.IsDisabled(effort) {
+		return reasoning.EffortDisable
+	}
+	return effort
 }
 
 func normalizeBotSettingsReadRow(row sqlc.GetSettingsByBotIDRow) Settings {

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -1,15 +1,274 @@
 package settings
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	acpfeedback "github.com/memohai/memoh/internal/agent/decision/feedback"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/reasoning"
 )
+
+type stubReasoningOptionsResolver struct {
+	opts    reasoning.Options
+	err     error
+	calls   int
+	modelID string
+}
+
+func (r *stubReasoningOptionsResolver) ResolveReasoningOptions(_ context.Context, modelID string) (reasoning.Options, error) {
+	r.calls++
+	r.modelID = modelID
+	return r.opts, r.err
+}
+
+func TestApplyReasoningPolicy(t *testing.T) {
+	t.Parallel()
+
+	modelID := "00000000-0000-0000-0000-000000000701"
+	supported := reasoning.Options{
+		Supported:     true,
+		CanDisable:    false,
+		Efforts:       []string{reasoning.EffortLow, reasoning.EffortMedium, reasoning.EffortHigh},
+		DefaultEffort: reasoning.EffortMedium,
+	}
+
+	t.Run("explicit advertised tier is canonicalized", func(t *testing.T) {
+		resolver := &stubReasoningOptionsResolver{opts: supported}
+		service := &Service{reasoningResolver: resolver}
+		current := Settings{ChatModelID: modelID, ReasoningEffort: reasoning.EffortLow}
+		requested := " HIGH "
+		if err := service.applyReasoningPolicy(context.Background(), &current, UpsertRequest{ReasoningEffort: &requested}); err != nil {
+			t.Fatal(err)
+		}
+		if current.ReasoningEffort != reasoning.EffortHigh {
+			t.Fatalf("reasoning effort = %q, want high", current.ReasoningEffort)
+		}
+	})
+
+	t.Run("explicit off is rejected for always-on model", func(t *testing.T) {
+		resolver := &stubReasoningOptionsResolver{opts: supported}
+		service := &Service{reasoningResolver: resolver}
+		current := Settings{ChatModelID: modelID, ReasoningEffort: reasoning.EffortHigh}
+		requested := "off"
+		err := service.applyReasoningPolicy(context.Background(), &current, UpsertRequest{ReasoningEffort: &requested})
+		var invalid *InvalidReasoningEffortError
+		if !errors.As(err, &invalid) || invalid.Effort != reasoning.EffortDisable {
+			t.Fatalf("error = %#v, want canonical invalid disable error", err)
+		}
+		if current.ReasoningEffort != reasoning.EffortHigh {
+			t.Fatalf("rejected write changed effort to %q", current.ReasoningEffort)
+		}
+	})
+
+	t.Run("model switch reconciles stale tier", func(t *testing.T) {
+		resolver := &stubReasoningOptionsResolver{opts: supported}
+		service := &Service{reasoningResolver: resolver}
+		current := Settings{ChatModelID: modelID, ReasoningEffort: reasoning.EffortXHigh}
+		newModelID := modelID
+		if err := service.applyReasoningPolicy(context.Background(), &current, UpsertRequest{ChatModelID: &newModelID}); err != nil {
+			t.Fatal(err)
+		}
+		if current.ReasoningEffort != reasoning.EffortMedium {
+			t.Fatalf("reasoning effort = %q, want model default medium", current.ReasoningEffort)
+		}
+	})
+
+	t.Run("combined model payload reconciles stale explicit tier", func(t *testing.T) {
+		resolver := &stubReasoningOptionsResolver{opts: supported}
+		service := &Service{reasoningResolver: resolver}
+		current := Settings{ChatModelID: modelID, ReasoningEffort: reasoning.EffortLow}
+		newModelID := modelID
+		requested := reasoning.EffortXHigh
+		if err := service.applyReasoningPolicy(context.Background(), &current, UpsertRequest{
+			ChatModelID:     &newModelID,
+			ReasoningEffort: &requested,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if current.ReasoningEffort != reasoning.EffortMedium {
+			t.Fatalf("reasoning effort = %q, want model default medium", current.ReasoningEffort)
+		}
+	})
+
+	t.Run("unsupported model preserves dormant preference", func(t *testing.T) {
+		resolver := &stubReasoningOptionsResolver{}
+		service := &Service{reasoningResolver: resolver}
+		current := Settings{ChatModelID: modelID, ReasoningEffort: reasoning.EffortXHigh}
+		newModelID := modelID
+		if err := service.applyReasoningPolicy(context.Background(), &current, UpsertRequest{ChatModelID: &newModelID}); err != nil {
+			t.Fatal(err)
+		}
+		if current.ReasoningEffort != reasoning.EffortXHigh {
+			t.Fatalf("dormant preference = %q, want xhigh", current.ReasoningEffort)
+		}
+	})
+
+	t.Run("lookup failure fails closed", func(t *testing.T) {
+		resolver := &stubReasoningOptionsResolver{err: errors.New("SECRET provider failure")}
+		service := &Service{reasoningResolver: resolver}
+		current := Settings{ChatModelID: modelID, ReasoningEffort: reasoning.EffortLow}
+		requested := reasoning.EffortHigh
+		err := service.applyReasoningPolicy(context.Background(), &current, UpsertRequest{ReasoningEffort: &requested})
+		if !errors.Is(err, ErrReasoningOptionsUnavailable) {
+			t.Fatalf("error = %v, want ErrReasoningOptionsUnavailable", err)
+		}
+	})
+
+	t.Run("unrelated write skips capability lookup", func(t *testing.T) {
+		resolver := &stubReasoningOptionsResolver{err: errors.New("must not be called")}
+		service := &Service{reasoningResolver: resolver}
+		current := Settings{ChatModelID: modelID, ReasoningEffort: reasoning.EffortLow}
+		language := "zh"
+		if err := service.applyReasoningPolicy(context.Background(), &current, UpsertRequest{Language: &language}); err != nil {
+			t.Fatal(err)
+		}
+		if resolver.calls != 0 {
+			t.Fatalf("resolver called %d time(s)", resolver.calls)
+		}
+	})
+}
+
+type reasoningPolicyQueries struct {
+	dbstore.Queries
+	botID          pgtype.UUID
+	currentModelID pgtype.UUID
+	storedEffort   string
+	upsertCalls    int
+	lastUpsert     sqlc.UpsertBotSettingsParams
+}
+
+func (q *reasoningPolicyQueries) GetBotByID(context.Context, pgtype.UUID) (sqlc.GetBotByIDRow, error) {
+	return sqlc.GetBotByIDRow{
+		ID:                q.botID,
+		Language:          DefaultLanguage,
+		ReasoningEffort:   q.storedEffort,
+		ChatModelID:       q.currentModelID,
+		HeartbeatInterval: DefaultHeartbeatInterval,
+	}, nil
+}
+
+func (*reasoningPolicyQueries) GetBotOverlayConfig(context.Context, pgtype.UUID) (sqlc.GetBotOverlayConfigRow, error) {
+	return sqlc.GetBotOverlayConfigRow{}, nil
+}
+
+func (q *reasoningPolicyQueries) GetSettingsByBotID(context.Context, pgtype.UUID) (sqlc.GetSettingsByBotIDRow, error) {
+	return sqlc.GetSettingsByBotIDRow{
+		BotID:                  q.botID,
+		Language:               DefaultLanguage,
+		CommandUiLanguage:      DefaultCommandUILanguage,
+		ReasoningEffort:        q.storedEffort,
+		HeartbeatInterval:      DefaultHeartbeatInterval,
+		ChatModelID:            q.currentModelID,
+		ChatRuntime:            ChatRuntimeModel,
+		ChatAcpProjectPath:     DefaultACPProjectPath,
+		ChatAcpProjectMode:     DefaultACPProjectMode,
+		ToolApprovalConfig:     []byte(`{}`),
+		CompactionThreshold:    0,
+		CompactionEnabled:      false,
+		PersistFullToolResults: false,
+	}, nil
+}
+
+func (*reasoningPolicyQueries) GetModelByID(_ context.Context, id pgtype.UUID) (sqlc.Model, error) {
+	return sqlc.Model{ID: id}, nil
+}
+
+func (q *reasoningPolicyQueries) UpsertBotSettings(_ context.Context, arg sqlc.UpsertBotSettingsParams) (sqlc.UpsertBotSettingsRow, error) {
+	q.upsertCalls++
+	q.lastUpsert = arg
+	modelID := q.currentModelID
+	if arg.ChatModelIDSet {
+		modelID = arg.ChatModelID
+	}
+	return sqlc.UpsertBotSettingsRow{
+		BotID:               q.botID,
+		Language:            arg.Language,
+		CommandUiLanguage:   arg.CommandUiLanguage,
+		ReasoningEffort:     arg.ReasoningEffort,
+		HeartbeatEnabled:    arg.HeartbeatEnabled,
+		HeartbeatInterval:   arg.HeartbeatInterval,
+		CompactionEnabled:   arg.CompactionEnabled,
+		CompactionThreshold: arg.CompactionThreshold,
+		ChatModelID:         modelID,
+		ChatRuntime:         arg.ChatRuntime,
+		ChatAcpAgentID:      arg.ChatAcpAgentID,
+		ChatAcpProjectPath:  arg.ChatAcpProjectPath,
+		ChatAcpProjectMode:  arg.ChatAcpProjectMode,
+		ToolApprovalConfig:  arg.ToolApprovalConfig,
+		OverlayConfig:       arg.OverlayConfig,
+	}, nil
+}
+
+func TestUpsertBotReconcilesReasoningOnModelChange(t *testing.T) {
+	t.Parallel()
+
+	botID := pgtype.UUID{Bytes: uuid.MustParse("00000000-0000-0000-0000-000000000710"), Valid: true}
+	oldModelID := pgtype.UUID{Bytes: uuid.MustParse("00000000-0000-0000-0000-000000000711"), Valid: true}
+	newModelID := uuid.MustParse("00000000-0000-0000-0000-000000000712")
+	queries := &reasoningPolicyQueries{
+		botID:          botID,
+		currentModelID: oldModelID,
+		storedEffort:   reasoning.EffortXHigh,
+	}
+	resolver := &stubReasoningOptionsResolver{opts: reasoning.Options{
+		Supported:     true,
+		Efforts:       []string{reasoning.EffortLow, reasoning.EffortMedium, reasoning.EffortHigh},
+		DefaultEffort: reasoning.EffortMedium,
+	}}
+	service := NewService(slog.Default(), queries, nil, nil)
+	service.SetReasoningOptionsResolver(resolver)
+	newModelIDString := newModelID.String()
+
+	if _, err := service.UpsertBot(context.Background(), uuid.UUID(botID.Bytes).String(), UpsertRequest{ChatModelID: &newModelIDString}); err != nil {
+		t.Fatal(err)
+	}
+	if queries.upsertCalls != 1 {
+		t.Fatalf("UpsertBotSettings calls = %d, want 1", queries.upsertCalls)
+	}
+	if queries.lastUpsert.ReasoningEffort != reasoning.EffortMedium {
+		t.Fatalf("persisted reasoning effort = %q, want medium", queries.lastUpsert.ReasoningEffort)
+	}
+	if resolver.modelID != newModelIDString {
+		t.Fatalf("resolved model = %q, want %q", resolver.modelID, newModelIDString)
+	}
+}
+
+func TestUpsertBotRejectsInvalidReasoningBeforePersistence(t *testing.T) {
+	t.Parallel()
+
+	botID := pgtype.UUID{Bytes: uuid.MustParse("00000000-0000-0000-0000-000000000720"), Valid: true}
+	modelID := pgtype.UUID{Bytes: uuid.MustParse("00000000-0000-0000-0000-000000000721"), Valid: true}
+	queries := &reasoningPolicyQueries{
+		botID:          botID,
+		currentModelID: modelID,
+		storedEffort:   reasoning.EffortHigh,
+	}
+	service := NewService(slog.Default(), queries, nil, nil)
+	service.SetReasoningOptionsResolver(&stubReasoningOptionsResolver{opts: reasoning.Options{
+		Supported:     true,
+		CanDisable:    false,
+		Efforts:       []string{reasoning.EffortLow, reasoning.EffortHigh},
+		DefaultEffort: reasoning.EffortLow,
+	}})
+	requested := "off"
+
+	_, err := service.UpsertBot(context.Background(), uuid.UUID(botID.Bytes).String(), UpsertRequest{ReasoningEffort: &requested})
+	var invalid *InvalidReasoningEffortError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("error = %v, want InvalidReasoningEffortError", err)
+	}
+	if queries.upsertCalls != 0 {
+		t.Fatalf("invalid effort reached persistence %d time(s)", queries.upsertCalls)
+	}
+}
 
 func TestNormalizeBotSettingsReadRow_ShowToolCallsInIMDefault(t *testing.T) {
 	t.Parallel()

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -9925,11 +9925,15 @@ export type PostBotsByBotIdSettingsErrors = {
     /**
      * Bad Request
      */
-    400: HandlersErrorResponse;
+    400: ApperrorProblem;
     /**
      * Internal Server Error
      */
     500: HandlersErrorResponse;
+    /**
+     * Service Unavailable
+     */
+    503: ApperrorProblem;
 };
 
 export type PostBotsByBotIdSettingsError = PostBotsByBotIdSettingsErrors[keyof PostBotsByBotIdSettingsErrors];
@@ -9962,11 +9966,15 @@ export type PutBotsByBotIdSettingsErrors = {
     /**
      * Bad Request
      */
-    400: HandlersErrorResponse;
+    400: ApperrorProblem;
     /**
      * Internal Server Error
      */
     500: HandlersErrorResponse;
+    /**
+     * Service Unavailable
+     */
+    503: ApperrorProblem;
 };
 
 export type PutBotsByBotIdSettingsError = PutBotsByBotIdSettingsErrors[keyof PutBotsByBotIdSettingsErrors];

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -8092,13 +8092,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/apperror.Problem"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Problem"
                         }
                     }
                 }
@@ -8137,13 +8143,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/apperror.Problem"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Problem"
                         }
                     }
                 }

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -8083,13 +8083,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/apperror.Problem"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Problem"
                         }
                     }
                 }
@@ -8128,13 +8134,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/handlers.ErrorResponse"
+                            "$ref": "#/definitions/apperror.Problem"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/handlers.ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Problem"
                         }
                     }
                 }

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -10900,11 +10900,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/apperror.Problem'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/apperror.Problem'
       summary: Update user settings
       tags:
       - settings
@@ -10930,11 +10934,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/handlers.ErrorResponse'
+            $ref: '#/definitions/apperror.Problem'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/handlers.ErrorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/apperror.Problem'
       summary: Update user settings
       tags:
       - settings


### PR DESCRIPTION
Second of three. Stacked on #991. Part of #982. Replaces #986.

Kept separate from its neighbours because it is the only one of the three with a
**user-visible behaviour change**, and that deserves its own review surface.

## The change

`/reasoning` offered `off, low, medium, high, xhigh` on every model, having never
consulted one. Wrong in both directions:

- **Off appeared on models that cannot be turned off**, where picking it does
  nothing the provider honours
- **`minimal` and `max` never appeared** on the models that advertise them

It was also the fourth copy of the effort vocabulary, and the one furthest from the
resolver that decides what actually gets sent.

The command asks the bot's current chat model now, through the same `OptionsFor`
the picker and the resolver share (#991). A typed level is validated the same way,
so a tier the model does not offer is refused at the command rather than stored and
quietly ignored at call time.

## Fallback

A model that cannot be resolved — no chat model set, or the lookup fails — falls
back to the common `off/low/medium/high` ladder rather than rendering an empty
picker. Breaking the command because a model row is missing is a worse answer than
offering the tiers every reasoning model has.

## Also

All three locales still advertised `none` in the usage strings, which stopped being
selectable when #966 gave off a single name.

## Tests

`TestReasoningChoicesFollowTheModel` covers the three cases that used to be one: a
model that can be turned off, one that cannot, and an unresolvable one.
`TestAcceptsEffortRejectsTiersTheModelDoesNotOffer` covers the typed-level half.

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt` clean.

---

## Human QA

Walked on a local dev stack with a bot on `gemini-3.6-flash`.

`/reasoning set xhigh` was **refused**, which is the behaviour change in one line:
`xhigh` is in the ladder this command used to hardcode, so before this PR it would
have been accepted, stored, and then silently ignored at call time because the
model does not advertise it.

The walk also surfaced a flaw in my own wording, fixed here in `14665f26`: the
rejection said "pick one of the levels shown above", but a typed
`/reasoning set <level>` has no picker above it, and the levels differ per model
now — so the message could not point at a list. It names them instead:
`available levels: minimal, low, high`.

Note on scope: `/reasoning` is an IM-channel command, so the interactive picker
half (tapping a level, and the option list changing between a Gemini bot and a
Claude one) was not exercised — the web composer does not route slash commands.
That half is covered by `TestReasoningChoicesFollowTheModel`, which asserts the
three cases that used to be one: a model that can be turned off, one that cannot,
and one that cannot be resolved.
