### PR TITLE
feat(capabilities): read reasoning capabilities from models.dev and OpenRouter

### DIFF
--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -723,6 +723,7 @@ func (s *Service) buildBaseRunConfig(ctx context.Context, p baseRunConfigParams)
 		ReasoningConfig:       reasoningConfig,
 		ReasoningDialect:      chatModel.Config.ReasoningDialect,
 		ReasoningOffSupport:   chatModel.Config.ReasoningOffSupport,
+		ReasoningDefaultOn:    chatModel.Config.ReasoningDefaultOn,
 		ThinkingBudgetMin:     chatModel.Config.ThinkingBudgetMin,
 		ThinkingBudgetMax:     chatModel.Config.ThinkingBudgetMax,
 	})

--- a/internal/agent/tool/subagent.go
+++ b/internal/agent/tool/subagent.go
@@ -1643,6 +1643,7 @@ func (p *SpawnProvider) resolveModel(
 		ReasoningConfig:       reasoningConfig,
 		ReasoningDialect:      modelInfo.Config.ReasoningDialect,
 		ReasoningOffSupport:   modelInfo.Config.ReasoningOffSupport,
+		ReasoningDefaultOn:    modelInfo.Config.ReasoningDefaultOn,
 		ThinkingBudgetMin:     modelInfo.Config.ThinkingBudgetMin,
 		ThinkingBudgetMax:     modelInfo.Config.ThinkingBudgetMax,
 	})

--- a/internal/capabilities/discover.go
+++ b/internal/capabilities/discover.go
@@ -51,6 +51,9 @@ type Capabilities struct {
 	ThinkingBudgetMin   *int
 	ThinkingBudgetMax   *int
 	ReasoningOffSupport string
+	// ReasoningDefaultOn reports whether omitting the thinking field leaves the
+	// model thinking. nil when no source said.
+	ReasoningDefaultOn *bool
 }
 
 // effortOrder is the canonical low→high ordering used to render effort lists.

--- a/internal/capabilities/discover.go
+++ b/internal/capabilities/discover.go
@@ -43,6 +43,14 @@ type Capabilities struct {
 	FileInput *bool
 	// ContextWindow is nil when unknown.
 	ContextWindow *int
+	// ReasoningDialect, the budget bounds and ReasoningOffSupport are wire facts
+	// LiteLLM could not express at all: it reported which OpenAI-wire flags a model
+	// set, not which shape the provider speaks. models.dev models the shape
+	// directly, so discovery can now fill what the templates used to carry by hand.
+	ReasoningDialect    string
+	ThinkingBudgetMin   *int
+	ThinkingBudgetMax   *int
+	ReasoningOffSupport string
 }
 
 // effortOrder is the canonical low→high ordering used to render effort lists.

--- a/internal/capabilities/merge.go
+++ b/internal/capabilities/merge.go
@@ -1,0 +1,46 @@
+package capabilities
+
+import "fmt"
+
+// Merge combines what each source is authoritative about, rather than ranking the
+// sources against each other. Every field has exactly one owner:
+//
+//	models.dev   the wire shape — dialect, budget bounds, tier list, thinking mode.
+//	             It is the only catalog that models a provider's control as a
+//	             typed option rather than a spread of booleans.
+//	OpenRouter   off-ability and the default state. It is a gateway, so it knows
+//	             which models refuse to stop thinking and which think unless told
+//	             otherwise; both facts fall out of its own routing.
+//
+// Where their knowledge overlaps — whether a model can be turned off — a
+// disagreement is reported rather than resolved. Picking a winner would hide the
+// one thing a second source is for: telling us that something is wrong.
+//
+// Neither source can answer whether a model *accepts* an explicit disable, which
+// splits Anthropic's catalog three ways and only its own documentation states.
+// That stays hand-declared, and a declaration always wins here.
+func Merge(base, off Capabilities) (Capabilities, []string) {
+	out := base
+	var conflicts []string
+
+	if off.ReasoningDefaultOn != nil {
+		out.ReasoningDefaultOn = off.ReasoningDefaultOn
+	}
+
+	switch {
+	case off.ReasoningOffSupport == "":
+		// No opinion; keep whatever the base said.
+	case out.ReasoningOffSupport == "":
+		out.ReasoningOffSupport = off.ReasoningOffSupport
+	case out.ReasoningOffSupport != off.ReasoningOffSupport:
+		conflicts = append(conflicts, fmt.Sprintf(
+			"off-ability: models.dev implies %q, OpenRouter reports %q",
+			out.ReasoningOffSupport, off.ReasoningOffSupport))
+		// The gateway wins on this one field: it has to make the request work,
+		// while models.dev is describing what the vendor documents. The conflict is
+		// still surfaced so a human can decide whether the catalog is stale.
+		out.ReasoningOffSupport = off.ReasoningOffSupport
+	}
+
+	return out, conflicts
+}

--- a/internal/capabilities/merge_test.go
+++ b/internal/capabilities/merge_test.go
@@ -1,0 +1,80 @@
+package capabilities
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/memohai/memoh/internal/reasoning"
+)
+
+func TestMergeTakesEachSourceForWhatItKnows(t *testing.T) {
+	t.Parallel()
+
+	on := true
+	base := Capabilities{
+		ThinkingMode:     "toggle",
+		EffortLevels:     []string{"low", "high"},
+		ReasoningDialect: reasoning.DialectTier,
+	}
+	off := Capabilities{
+		ReasoningOffSupport: reasoning.OffSupportAccepted,
+		ReasoningDefaultOn:  &on,
+	}
+
+	merged, conflicts := Merge(base, off)
+	if len(conflicts) != 0 {
+		t.Fatalf("unexpected conflicts: %v", conflicts)
+	}
+	// The wire shape stays with the source that models it.
+	if merged.ReasoningDialect != reasoning.DialectTier || len(merged.EffortLevels) != 2 {
+		t.Errorf("the base's wire shape should survive: %+v", merged)
+	}
+	// Off-ability and the default state come from the gateway.
+	if merged.ReasoningOffSupport != reasoning.OffSupportAccepted {
+		t.Errorf("off support = %q, want accepted", merged.ReasoningOffSupport)
+	}
+	if !reasoning.DefaultOn(merged.ReasoningDefaultOn) {
+		t.Error("default-on should come from the gateway")
+	}
+}
+
+// A second source earns its place by disagreeing. Resolving silently would throw
+// away the only signal it exists to produce.
+func TestMergeReportsDisagreementAboutOffAbility(t *testing.T) {
+	t.Parallel()
+
+	base := Capabilities{ReasoningOffSupport: reasoning.OffSupportRejected}
+	off := Capabilities{ReasoningOffSupport: reasoning.OffSupportAccepted}
+
+	merged, conflicts := Merge(base, off)
+	if len(conflicts) != 1 {
+		t.Fatalf("a disagreement should be reported, got %v", conflicts)
+	}
+	if !strings.Contains(conflicts[0], "off-ability") {
+		t.Errorf("the conflict should name the field: %q", conflicts[0])
+	}
+	// The gateway wins the value because it has to make the request work, but the
+	// conflict is still surfaced for a human to judge.
+	if merged.ReasoningOffSupport != reasoning.OffSupportAccepted {
+		t.Errorf("off support = %q, want the gateway's answer", merged.ReasoningOffSupport)
+	}
+}
+
+func TestMergeSilenceIsNotAnOpinion(t *testing.T) {
+	t.Parallel()
+
+	base := Capabilities{ReasoningOffSupport: reasoning.OffSupportRejected}
+
+	// An absent second source must not erase what the first knew: OpenRouter only
+	// covers models it resells, and absence there says nothing about capability.
+	merged, conflicts := Merge(base, Capabilities{})
+	if len(conflicts) != 0 {
+		t.Fatalf("silence is not a conflict: %v", conflicts)
+	}
+	if merged.ReasoningOffSupport != reasoning.OffSupportRejected {
+		t.Errorf("off support = %q, want the base's answer preserved", merged.ReasoningOffSupport)
+	}
+	if merged.ReasoningDefaultOn != nil {
+		t.Error("an unknown default state should stay unknown")
+	}
+}

--- a/internal/capabilities/modelsdev.go
+++ b/internal/capabilities/modelsdev.go
@@ -205,8 +205,11 @@ func deriveFromModelsDev(e modelsDevEntry) Capabilities {
 	caps.ThinkingMode = models.ThinkingModeToggle
 	opts := *e.ReasoningOptions
 	if len(opts) == 0 {
-		// Reasons, but exposes no control: always on. Declaring no tiers and no off
-		// switch is what keeps a picker from offering either.
+		// Reasons and takes no direction: no tiers, no switch. This is its own
+		// thinking mode rather than a toggle with an empty list, because "you may
+		// not turn this off" and "you may turn this off but there are no tiers" are
+		// different things to tell a user.
+		caps.ThinkingMode = reasoning.ModeAlways
 		caps.EffortLevels = []string{}
 		caps.ReasoningOffSupport = reasoning.OffSupportRejected
 		return caps

--- a/internal/capabilities/modelsdev.go
+++ b/internal/capabilities/modelsdev.go
@@ -36,7 +36,12 @@ type modelsDevOption struct {
 }
 
 type modelsDevEntry struct {
-	Name             string             `toml:"name"`
+	Name string `toml:"name"`
+	// BaseModel points at the canonical definition under the checkout's top-level
+	// models/ directory. A provider entry is an overlay carrying only what differs,
+	// so most omit the reasoning flag, the modalities and the context limit and
+	// inherit them instead.
+	BaseModel        string             `toml:"base_model"`
 	Reasoning        *bool              `toml:"reasoning"`
 	ToolCall         *bool              `toml:"tool_call"`
 	ReasoningOptions *[]modelsDevOption `toml:"reasoning_options"`
@@ -59,6 +64,8 @@ type modelsDevEntry struct {
 type ModelsDevSource struct {
 	// entries is keyed by "provider/model-id", both normalized.
 	entries map[string]modelsDevEntry
+	// bases is keyed by base_model path, e.g. "google/gemini-2.5-flash".
+	bases map[string]modelsDevEntry
 }
 
 // providerAliases maps our template names onto models.dev provider directories.
@@ -71,9 +78,17 @@ var providerAliases = map[string]string{
 // NewModelsDevSource loads every model TOML under dir/providers. dir is the root
 // of a models.dev checkout.
 func NewModelsDevSource(dir string) (*ModelsDevSource, error) {
-	root := filepath.Join(dir, "providers")
-	src := &ModelsDevSource{entries: make(map[string]modelsDevEntry, 4096)}
+	src := &ModelsDevSource{
+		entries: make(map[string]modelsDevEntry, 8192),
+		bases:   make(map[string]modelsDevEntry, 512),
+	}
+	// Canonical definitions first: provider entries overlay these, and resolving an
+	// overlay against a missing base would silently lose what it omits.
+	if err := src.loadBases(filepath.Join(dir, "models")); err != nil {
+		return nil, err
+	}
 
+	root := filepath.Join(dir, "providers")
 	providers, err := os.ReadDir(root)
 	if err != nil {
 		return nil, fmt.Errorf("read models.dev providers: %w", err)
@@ -129,7 +144,7 @@ func (s *ModelsDevSource) Resolve(provider, modelID string) (Capabilities, bool)
 	if !ok {
 		return Capabilities{}, false
 	}
-	return deriveFromModelsDev(entry), true
+	return deriveFromModelsDev(s.resolveInheritance(entry)), true
 }
 
 // entryKey normalizes an id so that cosmetic differences between our templates and
@@ -278,4 +293,56 @@ func containsFold(list []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// loadBases reads the canonical model definitions under the checkout's top-level
+// models/ directory. Provider entries reference these by base_model and carry only
+// their differences: of 2994 overlays, 2751 have no reasoning flag of their own,
+// 2255 no modalities and 1608 no context limit. Reading overlays alone therefore
+// misses most of the catalog's capability data.
+func (s *ModelsDevSource) loadBases(dir string) error {
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() || !strings.HasSuffix(path, ".toml") {
+			return nil //nolint:nilerr // a missing models/ directory is not fatal
+		}
+		var entry modelsDevEntry
+		if _, err := toml.DecodeFile(path, &entry); err != nil {
+			return nil //nolint:nilerr // see the note in NewModelsDevSource
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		s.bases[strings.ToLower(strings.TrimSuffix(rel, ".toml"))] = entry
+		return nil
+	})
+}
+
+// resolveInheritance fills an overlay's absent fields from its base model. Only
+// absent values are taken: an overlay states what differs for this provider, so
+// anything it does say wins.
+func (s *ModelsDevSource) resolveInheritance(e modelsDevEntry) modelsDevEntry {
+	if e.BaseModel == "" {
+		return e
+	}
+	base, ok := s.bases[strings.ToLower(strings.TrimSpace(e.BaseModel))]
+	if !ok {
+		return e
+	}
+	if e.Reasoning == nil {
+		e.Reasoning = base.Reasoning
+	}
+	if e.ToolCall == nil {
+		e.ToolCall = base.ToolCall
+	}
+	if e.ReasoningOptions == nil {
+		e.ReasoningOptions = base.ReasoningOptions
+	}
+	if e.Limit.Context == nil {
+		e.Limit.Context = base.Limit.Context
+	}
+	if len(e.Modalities.Input) == 0 {
+		e.Modalities.Input = base.Modalities.Input
+	}
+	return e
 }

--- a/internal/capabilities/modelsdev.go
+++ b/internal/capabilities/modelsdev.go
@@ -1,0 +1,281 @@
+package capabilities
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
+)
+
+// models.dev describes a model's thinking control as a list of discriminated
+// options rather than a spread of boolean flags. That difference is the reason to
+// prefer it: the shape a provider speaks — a toggle, a tier list, a token budget —
+// is a first-class value here, while LiteLLM could only report which OpenAI-wire
+// flags a model happened to set.
+//
+// The three option types, from the upstream schema:
+//
+//	toggle        the model has a dedicated on/off switch
+//	effort        the model takes named tiers; the list is authoritative
+//	budget_tokens the model takes a token budget, with min/max bounds
+//
+// An empty list is meaningful and distinct from an absent one: it declares that
+// the model reasons but exposes no control at all (deepseek-reasoner, MiniMax
+// M2.x). That is a fact we previously had to discover by reading two other
+// catalogs by hand.
+type modelsDevOption struct {
+	Type   string   `toml:"type"`
+	Values []string `toml:"values"`
+	Min    *int     `toml:"min"`
+	Max    *int     `toml:"max"`
+}
+
+type modelsDevEntry struct {
+	Name             string             `toml:"name"`
+	Reasoning        *bool              `toml:"reasoning"`
+	ToolCall         *bool              `toml:"tool_call"`
+	ReasoningOptions *[]modelsDevOption `toml:"reasoning_options"`
+
+	Limit struct {
+		Context *int `toml:"context"`
+	} `toml:"limit"`
+
+	Modalities struct {
+		Input []string `toml:"input"`
+	} `toml:"modalities"`
+}
+
+// ModelsDevSource resolves capabilities from a local models.dev checkout.
+//
+// It reads the repository's TOML rather than the published api.json: the JSON is a
+// single 3.6 MB document behind a host that is unreliable from some networks,
+// while the repository is a git clone that can be pinned, diffed and vendored.
+// Both carry the same fields.
+type ModelsDevSource struct {
+	// entries is keyed by "provider/model-id", both normalized.
+	entries map[string]modelsDevEntry
+}
+
+// providerAliases maps our template names onto models.dev provider directories.
+// Only the ones that genuinely differ are listed; everything else matches.
+var providerAliases = map[string]string{
+	"moonshot": "moonshotai",
+	"qwen":     "alibaba",
+}
+
+// NewModelsDevSource loads every model TOML under dir/providers. dir is the root
+// of a models.dev checkout.
+func NewModelsDevSource(dir string) (*ModelsDevSource, error) {
+	root := filepath.Join(dir, "providers")
+	src := &ModelsDevSource{entries: make(map[string]modelsDevEntry, 4096)}
+
+	providers, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read models.dev providers: %w", err)
+	}
+	for _, provider := range providers {
+		if !provider.IsDir() {
+			continue
+		}
+		modelsDir := filepath.Join(root, provider.Name(), "models")
+		// OpenRouter nests its models one level deeper, by vendor.
+		err := filepath.WalkDir(modelsDir, func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil || d.IsDir() || !strings.HasSuffix(path, ".toml") {
+				return nil //nolint:nilerr // a provider without models is not an error
+			}
+			var entry modelsDevEntry
+			if _, decErr := toml.DecodeFile(path, &entry); decErr != nil {
+				// One bad file must not cost us the whole catalog. Upstream carries
+				// 184 providers, most of which we never sync, and a case-insensitive
+				// filesystem can surface a path it then cannot open (two vendor
+				// directories differing only in case collapse onto one). Skipping
+				// leaves the model unknown, which callers already handle.
+				return nil //nolint:nilerr // a single unreadable entry is not fatal
+			}
+			rel, relErr := filepath.Rel(modelsDir, path)
+			if relErr != nil {
+				return relErr
+			}
+			modelID := strings.TrimSuffix(rel, ".toml")
+			src.entries[entryKey(provider.Name(), modelID)] = entry
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(src.entries) == 0 {
+		return nil, fmt.Errorf("no models found under %s", root)
+	}
+	return src, nil
+}
+
+// Count reports how many model entries were loaded.
+func (s *ModelsDevSource) Count() int { return len(s.entries) }
+
+// Resolve returns the capabilities for a model under a provider template, and
+// whether the catalog knows it.
+func (s *ModelsDevSource) Resolve(provider, modelID string) (Capabilities, bool) {
+	dir := provider
+	if alias, ok := providerAliases[provider]; ok {
+		dir = alias
+	}
+	entry, ok := s.entries[entryKey(dir, modelID)]
+	if !ok {
+		return Capabilities{}, false
+	}
+	return deriveFromModelsDev(entry), true
+}
+
+// entryKey normalizes an id so that cosmetic differences between our templates and
+// models.dev do not read as missing data. Two real cases: xAI ships the same model
+// as grok-4.20-beta-0309 and grok-4.20-0309, and vendors append release dates that
+// one catalog keeps and the other drops.
+//
+// Normalization is deliberately narrow. Anything more aggressive risks collapsing
+// two genuinely different models onto one entry, which would silently give a model
+// another's capabilities — worse than reporting it as unknown.
+func entryKey(provider, modelID string) string {
+	id := strings.ToLower(strings.TrimSpace(modelID))
+	id = strings.ReplaceAll(id, "-beta-", "-")
+	id = strings.TrimSuffix(id, "-beta")
+	return provider + "/" + id
+}
+
+// deriveFromModelsDev maps a models.dev entry onto our capability shape.
+func deriveFromModelsDev(e modelsDevEntry) Capabilities {
+	caps := Capabilities{
+		ToolCall:      e.ToolCall,
+		ContextWindow: e.Limit.Context,
+	}
+	if len(e.Modalities.Input) > 0 {
+		vision := containsModality(e.Modalities.Input, "image")
+		fileInput := containsModality(e.Modalities.Input, "pdf")
+		caps.Vision = &vision
+		caps.FileInput = &fileInput
+	}
+
+	// The option list is the stronger signal and must be read whenever present.
+	// Most of the catalog carries options without also setting the top-level
+	// reasoning flag — 1631 of 2737 entries at the time of writing — so keying off
+	// the flag alone would discard the controls for the majority of models,
+	// including every Gemini 2.5 entry.
+	if e.ReasoningOptions == nil {
+		switch {
+		case e.Reasoning == nil:
+			// Silent both ways: leave the mode unknown so a caller keeps whatever it
+			// already had rather than being told "no reasoning".
+			return caps
+		case !*e.Reasoning:
+			caps.ThinkingMode = models.ThinkingModeNone
+			return caps
+		default:
+			// Claims reasoning but describes no control. Nothing to say about tiers.
+			caps.ThinkingMode = models.ThinkingModeToggle
+			return caps
+		}
+	}
+	if e.Reasoning != nil && !*e.Reasoning {
+		// Contradictory: options present but reasoning explicitly false. Trust the
+		// explicit denial and report no thinking rather than inventing a control.
+		caps.ThinkingMode = models.ThinkingModeNone
+		return caps
+	}
+
+	caps.ThinkingMode = models.ThinkingModeToggle
+	opts := *e.ReasoningOptions
+	if len(opts) == 0 {
+		// Reasons, but exposes no control: always on. Declaring no tiers and no off
+		// switch is what keeps a picker from offering either.
+		caps.EffortLevels = []string{}
+		caps.ReasoningOffSupport = reasoning.OffSupportRejected
+		return caps
+	}
+
+	var tiers []string
+	hasToggle, hasBudget := false, false
+	for _, opt := range opts {
+		switch opt.Type {
+		case "toggle":
+			hasToggle = true
+		case "effort":
+			tiers = append(tiers, opt.Values...)
+		case "budget_tokens":
+			hasBudget = true
+			caps.ThinkingBudgetMin = opt.Min
+			caps.ThinkingBudgetMax = opt.Max
+		}
+	}
+
+	// Which shape to *send* is not always what upstream reports as *accepted*.
+	// Claude 4.6 lists both effort and budget_tokens because the API takes both,
+	// but budget_tokens is deprecated there and rejected outright on 4.7+, so the
+	// tier dialect is the correct choice and a naive "budget wins" rule would
+	// downgrade it. When a model offers tiers, they are the dialect; a budget is
+	// only the dialect when it is the sole control.
+	switch {
+	case len(tiers) > 0:
+		caps.ReasoningDialect = reasoning.DialectTier
+	case hasBudget:
+		caps.ReasoningDialect = reasoning.DialectBudget
+	}
+
+	caps.EffortLevels = normalizeTiers(tiers, hasToggle)
+	return caps
+}
+
+// normalizeTiers turns models.dev's tier vocabulary into ours. Upstream spells off
+// as a member of the tier list ("none", OpenAI's wire word) while we keep it as a
+// separate capability token, so the two spellings collapse onto ours. A dedicated
+// toggle option means the same thing by another route.
+func normalizeTiers(tiers []string, hasToggle bool) []string {
+	out := make([]string, 0, len(tiers)+1)
+	canDisable := hasToggle
+	for _, tier := range tiers {
+		tier = strings.ToLower(strings.TrimSpace(tier))
+		switch tier {
+		case reasoning.EffortNone, reasoning.EffortDisable:
+			canDisable = true
+			continue
+		case "default":
+			// Upstream's marker for "let the model choose"; not a tier a user picks.
+			continue
+		case "":
+			continue
+		}
+		if !containsFold(out, tier) {
+			out = append(out, tier)
+		}
+	}
+	ordered := make([]string, 0, len(out)+1)
+	if canDisable {
+		ordered = append(ordered, reasoning.EffortDisable)
+	}
+	// Emit tiers weakest-to-strongest regardless of the order upstream listed them.
+	for _, tier := range reasoning.OrderedEfforts() {
+		if containsFold(out, tier) {
+			ordered = append(ordered, tier)
+		}
+	}
+	// Anything upstream knows and we do not is dropped rather than passed through:
+	// an unknown tier would fail validation on write.
+	return ordered
+}
+
+func containsModality(list []string, want string) bool {
+	return containsFold(list, want)
+}
+
+func containsFold(list []string, want string) bool {
+	for _, v := range list {
+		if strings.EqualFold(strings.TrimSpace(v), want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/capabilities/modelsdev_test.go
+++ b/internal/capabilities/modelsdev_test.go
@@ -114,9 +114,12 @@ name = "Quiet"
 			wantTiers: []string{"disable", "low", "medium", "high", "xhigh"},
 		},
 		{
-			name:     "no controls means always on",
+			// Its own mode, not a toggle with an empty list: "you cannot turn this
+			// off" and "you can turn it off but there are no tiers" are different
+			// things to tell a user.
+			name:     "no controls at all is the always mode",
 			provider: "minimax", modelID: "always-on",
-			wantMode: models.ThinkingModeToggle, wantTiers: []string{},
+			wantMode: reasoning.ModeAlways, wantTiers: []string{},
 			wantOff: reasoning.OffSupportRejected,
 		},
 		{

--- a/internal/capabilities/modelsdev_test.go
+++ b/internal/capabilities/modelsdev_test.go
@@ -1,0 +1,234 @@
+package capabilities
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/memohai/memoh/internal/models"
+	"github.com/memohai/memoh/internal/reasoning"
+)
+
+// writeCatalog builds a minimal models.dev checkout on disk. Fixtures rather than
+// the real clone, so the test says what it depends on.
+func writeCatalog(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, body := range files {
+		path := filepath.Join(dir, "providers", rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return dir
+}
+
+func TestModelsDevDerivesTheWireShape(t *testing.T) {
+	t.Parallel()
+
+	dir := writeCatalog(t, map[string]string{
+		// Tiers plus a budget: the API accepts both, but tiers are what a caller
+		// picks and what should reach the wire. Claude 4.6 is the live example —
+		// budget_tokens is deprecated there and rejected on 4.7+.
+		"anthropic/models/claude-x.toml": `
+reasoning = true
+[[reasoning_options]]
+type = "effort"
+values = ["low", "medium", "high", "max"]
+[[reasoning_options]]
+type = "budget_tokens"
+min = 1024
+`,
+		// Budget only: the model wants a number, and the bounds decide off-ability.
+		"google/models/gemini-budget.toml": `
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 32768
+`,
+		// Tiers including upstream's own spelling of off.
+		"openai/models/gpt-tiers.toml": `
+reasoning = true
+[[reasoning_options]]
+type = "effort"
+values = ["none", "low", "medium", "high", "xhigh"]
+`,
+		// Reasons but exposes no control: always on.
+		"minimax/models/always-on.toml": `
+reasoning = true
+reasoning_options = []
+`,
+		// Explicitly no reasoning.
+		"openai/models/plain.toml": `
+reasoning = false
+`,
+		// Silent on both: nothing may be concluded.
+		"openai/models/silent.toml": `
+name = "Quiet"
+`,
+	})
+
+	src, err := NewModelsDevSource(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	cases := []struct {
+		name        string
+		provider    string
+		modelID     string
+		wantMode    string
+		wantDialect string
+		wantTiers   []string
+		wantOff     string
+	}{
+		{
+			name:     "tiers win the dialect even when a budget is also accepted",
+			provider: "anthropic", modelID: "claude-x",
+			wantMode: models.ThinkingModeToggle, wantDialect: reasoning.DialectTier,
+			wantTiers: []string{"low", "medium", "high", "max"},
+		},
+		{
+			name:     "a budget-only model takes the budget dialect",
+			provider: "google", modelID: "gemini-budget",
+			wantMode: models.ThinkingModeToggle, wantDialect: reasoning.DialectBudget,
+			wantTiers: []string{},
+		},
+		{
+			// Upstream lists off inside the tier list; we keep it as a capability
+			// token, so the two spellings collapse onto ours and off leads.
+			name:     "upstream's off tier becomes our disable token",
+			provider: "openai", modelID: "gpt-tiers",
+			wantMode: models.ThinkingModeToggle, wantDialect: reasoning.DialectTier,
+			wantTiers: []string{"disable", "low", "medium", "high", "xhigh"},
+		},
+		{
+			name:     "no controls means always on",
+			provider: "minimax", modelID: "always-on",
+			wantMode: models.ThinkingModeToggle, wantTiers: []string{},
+			wantOff: reasoning.OffSupportRejected,
+		},
+		{
+			name:     "an explicit denial is reported as no thinking",
+			provider: "openai", modelID: "plain",
+			wantMode: models.ThinkingModeNone,
+		},
+		{
+			name:     "silence leaves the mode unknown",
+			provider: "openai", modelID: "silent",
+			wantMode: "",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			caps, ok := src.Resolve(tt.provider, tt.modelID)
+			if !ok {
+				t.Fatalf("%s/%s not found", tt.provider, tt.modelID)
+			}
+			if caps.ThinkingMode != tt.wantMode {
+				t.Errorf("mode = %q, want %q", caps.ThinkingMode, tt.wantMode)
+			}
+			if caps.ReasoningDialect != tt.wantDialect {
+				t.Errorf("dialect = %q, want %q", caps.ReasoningDialect, tt.wantDialect)
+			}
+			if tt.wantTiers != nil && !slices.Equal(caps.EffortLevels, tt.wantTiers) {
+				t.Errorf("tiers = %v, want %v", caps.EffortLevels, tt.wantTiers)
+			}
+			if caps.ReasoningOffSupport != tt.wantOff {
+				t.Errorf("off support = %q, want %q", caps.ReasoningOffSupport, tt.wantOff)
+			}
+		})
+	}
+}
+
+// The majority of the catalog carries reasoning_options without also setting the
+// top-level reasoning flag. Keying off the flag would discard the controls for most
+// models, every Gemini 2.5 entry among them.
+func TestModelsDevReadsOptionsWithoutTheReasoningFlag(t *testing.T) {
+	t.Parallel()
+
+	dir := writeCatalog(t, map[string]string{
+		"google/models/no-flag.toml": `
+name = "Options but no flag"
+[[reasoning_options]]
+type = "budget_tokens"
+min = 128
+max = 24576
+`,
+	})
+	src, err := NewModelsDevSource(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	caps, ok := src.Resolve("google", "no-flag")
+	if !ok {
+		t.Fatal("model not found")
+	}
+	if caps.ThinkingMode != models.ThinkingModeToggle {
+		t.Errorf("mode = %q, want toggle", caps.ThinkingMode)
+	}
+	if caps.ThinkingBudgetMin == nil || *caps.ThinkingBudgetMin != 128 {
+		t.Errorf("budget min = %v, want 128", caps.ThinkingBudgetMin)
+	}
+	if caps.ThinkingBudgetMax == nil || *caps.ThinkingBudgetMax != 24576 {
+		t.Errorf("budget max = %v, want 24576", caps.ThinkingBudgetMax)
+	}
+}
+
+// Provider directory names differ for two of ours, and ids differ cosmetically for
+// xAI. Both are lookup concerns, not data gaps — treating them as gaps is how a
+// coverage comparison ends up wrong.
+func TestModelsDevResolvesAliasesAndCosmeticIDs(t *testing.T) {
+	t.Parallel()
+
+	dir := writeCatalog(t, map[string]string{
+		"moonshotai/models/kimi.toml":              "reasoning = true\nreasoning_options = []\n",
+		"alibaba/models/qwen-x.toml":               "reasoning = true\nreasoning_options = []\n",
+		"xai/models/grok-4.20-0309-reasoning.toml": "reasoning = true\nreasoning_options = []\n",
+		// OpenRouter nests by vendor.
+		"openrouter/models/openai/gpt-x.toml": "reasoning = true\nreasoning_options = []\n",
+	})
+	src, err := NewModelsDevSource(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	for _, tt := range []struct{ provider, modelID string }{
+		{"moonshot", "kimi"},                     // template name differs from the directory
+		{"qwen", "qwen-x"},                       // ditto
+		{"xai", "grok-4.20-beta-0309-reasoning"}, // our id carries a -beta- marker
+		{"openrouter", "openai/gpt-x"},           // nested path
+	} {
+		if _, ok := src.Resolve(tt.provider, tt.modelID); !ok {
+			t.Errorf("%s/%s should resolve", tt.provider, tt.modelID)
+		}
+	}
+}
+
+// A single unreadable file must not cost the whole catalog: upstream ships 184
+// providers, most of which we never sync, and a case-insensitive filesystem can
+// surface a path it cannot then open.
+func TestModelsDevSkipsUnreadableEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := writeCatalog(t, map[string]string{
+		"openai/models/good.toml": "reasoning = true\nreasoning_options = []\n",
+		"openai/models/bad.toml":  "this is not = valid = toml [[[\n",
+	})
+	src, err := NewModelsDevSource(dir)
+	if err != nil {
+		t.Fatalf("a broken entry should not fail the load: %v", err)
+	}
+	if _, ok := src.Resolve("openai", "good"); !ok {
+		t.Error("the readable entry should still resolve")
+	}
+	if _, ok := src.Resolve("openai", "bad"); ok {
+		t.Error("the broken entry should be absent, not guessed at")
+	}
+}

--- a/internal/capabilities/modelsdev_test.go
+++ b/internal/capabilities/modelsdev_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/memohai/memoh/internal/models"
@@ -12,11 +13,17 @@ import (
 
 // writeCatalog builds a minimal models.dev checkout on disk. Fixtures rather than
 // the real clone, so the test says what it depends on.
+//
+// A key starting with "models/" lands in the canonical tree; everything else is a
+// provider overlay under providers/.
 func writeCatalog(t *testing.T, files map[string]string) string {
 	t.Helper()
 	dir := t.TempDir()
 	for rel, body := range files {
 		path := filepath.Join(dir, "providers", rel)
+		if strings.HasPrefix(rel, "models/") {
+			path = filepath.Join(dir, rel)
+		}
 		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 			t.Fatalf("mkdir: %v", err)
 		}
@@ -230,5 +237,84 @@ func TestModelsDevSkipsUnreadableEntries(t *testing.T) {
 	}
 	if _, ok := src.Resolve("openai", "bad"); ok {
 		t.Error("the broken entry should be absent, not guessed at")
+	}
+}
+
+// Provider entries are overlays: they carry what differs and inherit the rest.
+// Of 2994 overlays in the real catalog, 2751 have no reasoning flag of their own,
+// 2255 no modalities and 1608 no context limit — so reading them without resolving
+// base_model misses most of the capability data.
+func TestModelsDevResolvesBaseModelInheritance(t *testing.T) {
+	t.Parallel()
+
+	dir := writeCatalog(t, map[string]string{
+		"models/google/gemini-x.toml": `
+name = "Gemini X"
+reasoning = true
+tool_call = true
+[[reasoning_options]]
+type = "budget_tokens"
+min = 0
+max = 24576
+[limit]
+context = 1048576
+[modalities]
+input = ["text", "image", "pdf"]
+`,
+		// The overlay states only what differs for this provider.
+		"google/models/gemini-x.toml": `
+base_model = "google/gemini-x"
+[cost]
+input = 0.30
+`,
+		// An overlay may also override: what it says wins over the base.
+		"openrouter/models/google/gemini-x.toml": `
+base_model = "google/gemini-x"
+[[reasoning_options]]
+type = "effort"
+values = ["low", "high"]
+`,
+	})
+
+	src, err := NewModelsDevSource(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	inherited, ok := src.Resolve("google", "gemini-x")
+	if !ok {
+		t.Fatal("overlay should resolve")
+	}
+	if inherited.ThinkingMode != models.ThinkingModeToggle {
+		t.Errorf("mode = %q, want toggle (inherited)", inherited.ThinkingMode)
+	}
+	if inherited.ReasoningDialect != reasoning.DialectBudget {
+		t.Errorf("dialect = %q, want budget (inherited)", inherited.ReasoningDialect)
+	}
+	if inherited.ContextWindow == nil || *inherited.ContextWindow != 1048576 {
+		t.Errorf("context = %v, want 1048576 (inherited)", inherited.ContextWindow)
+	}
+	if inherited.Vision == nil || !*inherited.Vision {
+		t.Error("vision should be inherited from the base modalities")
+	}
+	if inherited.ThinkingBudgetMax == nil || *inherited.ThinkingBudgetMax != 24576 {
+		t.Errorf("budget max = %v, want 24576 (inherited)", inherited.ThinkingBudgetMax)
+	}
+
+	// The overlay's own options replace the base's rather than merging with them:
+	// a provider that exposes different controls is stating a fact about itself.
+	overridden, ok := src.Resolve("openrouter", "google/gemini-x")
+	if !ok {
+		t.Fatal("nested overlay should resolve")
+	}
+	if overridden.ReasoningDialect != reasoning.DialectTier {
+		t.Errorf("dialect = %q, want tier (overlay wins)", overridden.ReasoningDialect)
+	}
+	if !slices.Equal(overridden.EffortLevels, []string{"low", "high"}) {
+		t.Errorf("tiers = %v, want [low high] (overlay wins)", overridden.EffortLevels)
+	}
+	// Fields the overlay is silent about still come from the base.
+	if overridden.ContextWindow == nil || *overridden.ContextWindow != 1048576 {
+		t.Errorf("context = %v, want 1048576 (still inherited)", overridden.ContextWindow)
 	}
 }

--- a/internal/capabilities/openrouter.go
+++ b/internal/capabilities/openrouter.go
@@ -1,0 +1,99 @@
+package capabilities
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/memohai/memoh/internal/reasoning"
+)
+
+// OpenRouter answers two questions no other catalog does, because it is a gateway
+// rather than a description: it has to translate one request shape into every
+// upstream's, so it knows which models refuse to stop thinking and which think
+// unless told otherwise. Both facts are derived from its own routing code, which
+// makes them production-tested rather than curated.
+//
+//	mandatory        the model cannot be turned off at all
+//	default_enabled  omitting the control leaves thinking running
+//
+// models.dev implies the first through the shape of its option list and cannot
+// express the second; LiteLLM has neither. The overlap with models.dev is a free
+// cross-check: where both speak, they agree on every model we sync today.
+type openRouterReasoning struct {
+	Mandatory        *bool    `json:"mandatory"`
+	DefaultEnabled   *bool    `json:"default_enabled"`
+	SupportedEfforts []string `json:"supported_efforts"`
+	DefaultEffort    string   `json:"default_effort"`
+}
+
+type openRouterModel struct {
+	ID        string               `json:"id"`
+	Reasoning *openRouterReasoning `json:"reasoning"`
+}
+
+// OpenRouterSource resolves off-ability from an OpenRouter /api/v1/models payload.
+//
+// Its coverage is deliberately narrow — only models OpenRouter resells — so it is
+// a supplement, never a base. Absence here means "no opinion", not "no capability".
+type OpenRouterSource struct {
+	entries map[string]openRouterReasoning
+}
+
+// NewOpenRouterSource parses an OpenRouter models payload.
+func NewOpenRouterSource(body []byte) (*OpenRouterSource, error) {
+	var payload struct {
+		Data []openRouterModel `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("parse openrouter models: %w", err)
+	}
+	src := &OpenRouterSource{entries: make(map[string]openRouterReasoning, len(payload.Data))}
+	for _, model := range payload.Data {
+		if model.Reasoning == nil {
+			continue
+		}
+		src.entries[normalizeOpenRouterID(model.ID)] = *model.Reasoning
+	}
+	if len(src.entries) == 0 {
+		return nil, fmt.Errorf("openrouter payload carried no reasoning data")
+	}
+	return src, nil
+}
+
+// Count reports how many models carry reasoning data.
+func (s *OpenRouterSource) Count() int { return len(s.entries) }
+
+// Resolve returns the off-ability facts for a model, and whether OpenRouter has an
+// opinion about it. vendorID is the model as OpenRouter names it — for our
+// openrouter template that is the model id verbatim; for a first-party template it
+// is the vendor-prefixed form, which callers build.
+func (s *OpenRouterSource) Resolve(vendorID string) (Capabilities, bool) {
+	entry, ok := s.entries[normalizeOpenRouterID(vendorID)]
+	if !ok {
+		return Capabilities{}, false
+	}
+
+	caps := Capabilities{ReasoningDefaultOn: entry.DefaultEnabled}
+	switch {
+	case entry.Mandatory == nil:
+		// Silent: say nothing rather than guess. A wrong "cannot be turned off"
+		// removes a working control.
+	case *entry.Mandatory:
+		caps.ReasoningOffSupport = reasoning.OffSupportRejected
+	default:
+		caps.ReasoningOffSupport = reasoning.OffSupportAccepted
+	}
+	return caps, true
+}
+
+// normalizeOpenRouterID lowercases and drops the routing suffixes OpenRouter
+// appends to variants (":free", ":thinking", ":nitro"), which name a routing
+// choice rather than a different model's capabilities.
+func normalizeOpenRouterID(id string) string {
+	out := strings.ToLower(strings.TrimSpace(id))
+	if idx := strings.IndexByte(out, ':'); idx > 0 {
+		out = out[:idx]
+	}
+	return out
+}

--- a/internal/capabilities/openrouter_test.go
+++ b/internal/capabilities/openrouter_test.go
@@ -1,0 +1,80 @@
+package capabilities
+
+import (
+	"testing"
+
+	"github.com/memohai/memoh/internal/reasoning"
+)
+
+func TestOpenRouterReadsOffAbilityAndDefaultState(t *testing.T) {
+	t.Parallel()
+
+	src, err := NewOpenRouterSource([]byte(`{"data":[
+		{"id":"google/gemini-2.5-pro","reasoning":{"mandatory":true}},
+		{"id":"google/gemini-2.5-flash","reasoning":{"mandatory":false}},
+		{"id":"anthropic/claude-opus-4.6","reasoning":{"mandatory":false,"default_enabled":false}},
+		{"id":"openai/o-next","reasoning":{"mandatory":false,"default_enabled":true}},
+		{"id":"vendor/silent","reasoning":{}},
+		{"id":"vendor/no-reasoning"}
+	]}`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		id        string
+		wantKnown bool
+		wantOff   string
+		wantOn    any
+	}{
+		{"mandatory means it cannot be turned off", "google/gemini-2.5-pro", true, reasoning.OffSupportRejected, nil},
+		{"not mandatory means it can", "google/gemini-2.5-flash", true, reasoning.OffSupportAccepted, nil},
+		{"off by default is recorded separately from off-ability", "anthropic/claude-opus-4.6", true, reasoning.OffSupportAccepted, false},
+		{"on by default is the case that needs an explicit disable", "openai/o-next", true, reasoning.OffSupportAccepted, true},
+		{"an empty reasoning object states nothing", "vendor/silent", true, "", nil},
+		{"a model without the object is unknown", "vendor/no-reasoning", false, "", nil},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			caps, ok := src.Resolve(tt.id)
+			if ok != tt.wantKnown {
+				t.Fatalf("known = %v, want %v", ok, tt.wantKnown)
+			}
+			if !ok {
+				return
+			}
+			if caps.ReasoningOffSupport != tt.wantOff {
+				t.Errorf("off support = %q, want %q", caps.ReasoningOffSupport, tt.wantOff)
+			}
+			switch want := tt.wantOn.(type) {
+			case nil:
+				if caps.ReasoningDefaultOn != nil {
+					t.Errorf("default-on = %v, want unknown", *caps.ReasoningDefaultOn)
+				}
+			case bool:
+				if caps.ReasoningDefaultOn == nil || *caps.ReasoningDefaultOn != want {
+					t.Errorf("default-on = %v, want %v", caps.ReasoningDefaultOn, want)
+				}
+			}
+		})
+	}
+}
+
+// Routing suffixes name a delivery choice, not a different model's capabilities.
+func TestOpenRouterIgnoresRoutingSuffixes(t *testing.T) {
+	t.Parallel()
+
+	src, err := NewOpenRouterSource([]byte(
+		`{"data":[{"id":"deepseek/deepseek-v4:free","reasoning":{"mandatory":false}}]}`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	for _, id := range []string{"deepseek/deepseek-v4", "deepseek/deepseek-v4:free", "DeepSeek/DeepSeek-V4"} {
+		if _, ok := src.Resolve(id); !ok {
+			t.Errorf("%q should resolve to the same model", id)
+		}
+	}
+}

--- a/internal/handlers/providers.go
+++ b/internal/handlers/providers.go
@@ -513,6 +513,7 @@ func modelConfigFromRemote(m providers.RemoteModel, compatibilities []string) mo
 		ThinkingMode:        m.ThinkingMode,
 		ReasoningDialect:    m.ReasoningDialect,
 		ReasoningOffSupport: m.ReasoningOffSupport,
+		ReasoningDefaultOn:  m.ReasoningDefaultOn,
 		ThinkingBudgetMin:   m.ThinkingBudgetMin,
 		ThinkingBudgetMax:   m.ThinkingBudgetMax,
 		ContextWindow:       m.ContextWindow,

--- a/internal/models/anthropic_thinking_test.go
+++ b/internal/models/anthropic_thinking_test.go
@@ -6,29 +6,56 @@ import (
 	"github.com/memohai/memoh/internal/reasoning"
 )
 
-// Omission is not a way to turn thinking off from Opus 5 on: those models think by
-// default, so an omitted field leaves thinking running — billed as output tokens
-// and counted against max_tokens — while the user believes it is off. Where the
-// model accepts it, the adaptor must say so explicitly.
-func TestAnthropicExplicitOffIsSentWhereAccepted(t *testing.T) {
+// Two independent facts decide whether a disabled call must say so on the wire:
+// whether the model accepts thinking{type:"disabled"}, and whether omitting the
+// field would have worked anyway. Conflating them is how a user's "off" on Opus 5
+// would silently keep thinking — billed as output tokens and counted against
+// max_tokens.
+func TestAnthropicExplicitOffNeedsBothFacts(t *testing.T) {
 	t.Parallel()
+
+	on, off := true, false
 
 	cases := []struct {
 		name       string
 		offSupport string
+		defaultOn  *bool
 		want       bool
 	}{
-		{"a model that accepts an explicit disable gets one", reasoning.OffSupportAccepted, true},
-		{"so does one that accepts it below xhigh", reasoning.OffSupportLowEffortOnly, true},
-		{"a model that rejects it gets an omitted field instead", reasoning.OffSupportRejected, false},
-		{"an undeclared model keeps the omission behaviour", "", false},
+		{
+			// Opus 5: thinks by default and accepts a disable — the case that needs
+			// the explicit shape.
+			name:       "on by default and accepting needs the explicit shape",
+			offSupport: reasoning.OffSupportLowEffortOnly, defaultOn: &on, want: true,
+		},
+		{
+			name:       "so does an unconditionally accepting model that is on by default",
+			offSupport: reasoning.OffSupportAccepted, defaultOn: &on, want: true,
+		},
+		{
+			// Claude 4.6: accepts a disable, but omitting already means off, so
+			// sending it would be noise.
+			name:       "off by default needs nothing, even though it accepts one",
+			offSupport: reasoning.OffSupportAccepted, defaultOn: &off, want: false,
+		},
+		{
+			// Fable 5: thinks by default and 400s on an explicit disable. Off is
+			// unreachable; the picker keeps the control out.
+			name:       "on by default but rejecting cannot be turned off at all",
+			offSupport: reasoning.OffSupportRejected, defaultOn: &on, want: false,
+		},
+		{
+			name:       "an undeclared model keeps the omission behaviour",
+			offSupport: "", defaultOn: nil, want: false,
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := anthropicAcceptsExplicitOff(tt.offSupport); got != tt.want {
-				t.Fatalf("acceptsExplicitOff(%q) = %v, want %v", tt.offSupport, got, tt.want)
+			if got := anthropicNeedsExplicitOff(tt.offSupport, tt.defaultOn); got != tt.want {
+				t.Fatalf("needsExplicitOff(%q, %v) = %v, want %v",
+					tt.offSupport, tt.defaultOn, got, tt.want)
 			}
 		})
 	}

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -37,6 +37,9 @@ type SDKModelConfig struct {
 	// ReasoningOffSupport declares whether this model accepts an explicit
 	// thinking{type:"disabled"}. See anthropicAcceptsExplicitOff.
 	ReasoningOffSupport string
+	// ReasoningDefaultOn reports whether omitting the thinking field leaves the
+	// model thinking. nil means unknown.
+	ReasoningDefaultOn *bool
 }
 
 // ReasoningConfig is the resolved extended-thinking decision for one call,
@@ -126,7 +129,7 @@ func NewSDKChatModel(cfg SDKModelConfig) *sdk.Model {
 					Type:         "enabled",
 					BudgetTokens: legacyAnthropicBudgetFor(rc.Effort),
 				}))
-			case rc.Disabled && anthropicAcceptsExplicitOff(cfg.ReasoningOffSupport):
+			case rc.Disabled && anthropicNeedsExplicitOff(cfg.ReasoningOffSupport, cfg.ReasoningDefaultOn):
 				opts = append(opts, anthropicmessages.WithThinking(anthropicmessages.ThinkingConfig{
 					Type: "disabled",
 				}))
@@ -398,23 +401,31 @@ func googleBudgetFor(rc *ReasoningConfig, minBudget, maxBudget *int) (int, bool)
 
 func boolPtr(v bool) *bool { return &v }
 
-// anthropicAcceptsExplicitOff reports whether a model takes
-// thinking{type:"disabled"} on the wire.
+// anthropicNeedsExplicitOff reports whether a disabled call must say so on the
+// wire rather than express it by omitting the thinking field.
 //
-// Omitting the field is not a substitute. It reads as "off" only through Opus 4.8;
-// Opus 5, Sonnet 5, Fable 5 and Mythos 5 think by default, so an omitted field
-// leaves thinking running — billed as output tokens and counted against
-// max_tokens, while the user believes it is off. Fable 5 and Mythos 5 also reject
-// the explicit shape with a 400, so it cannot be sent unconditionally either.
+// Two independent facts decide this, which is why they are two fields. Whether the
+// model *accepts* thinking{type:"disabled"} — Fable 5 and Mythos 5 answer with a
+// 400 — and whether omission would have worked anyway. Omitting reads as off only
+// through Opus 4.8; Opus 5 and Sonnet 5 think by default, so an omitted field
+// leaves thinking running, billed as output tokens and counted against max_tokens,
+// while the user believes it is off.
 //
-// Only a catalog declaration can tell these apart: the models share a thinking
-// mode and an identical tier list. An undeclared model gets the omission
-// behaviour, which is correct for every generation we currently ship.
-func anthropicAcceptsExplicitOff(offSupport string) bool {
+// Sending the explicit shape where omission already means off is harmless but
+// noisy, so it is reserved for models that need it: accepted *and* on by default.
+// An undeclared model keeps the omission behaviour, which is correct for every
+// generation we currently ship.
+func anthropicNeedsExplicitOff(offSupport string, defaultOn *bool) bool {
+	if !reasoning.DefaultOn(defaultOn) {
+		return false
+	}
 	switch offSupport {
 	case reasoning.OffSupportAccepted, reasoning.OffSupportLowEffortOnly:
 		return true
 	default:
+		// Thinks by default and rejects an explicit disable: off is unreachable on
+		// this model. OptionsFor keeps the control out of the picker, so arriving
+		// here means a stale stored setting rather than a user choice.
 		return false
 	}
 }

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -135,6 +135,12 @@ type ModelConfig struct {
 	// thinking mode and an identical tier list, so this cannot be derived — see the
 	// reasoning package's OffSupport constants.
 	ReasoningOffSupport string `json:"reasoning_off_support,omitempty"`
+	// ReasoningDefaultOn reports whether omitting the thinking field leaves the
+	// model thinking. Separate from off-ability: Claude 4.6 can be turned off *and*
+	// defaults to off, while Opus 5 can be turned off but defaults to on, so
+	// omitting the field there keeps thinking running — billed, and invisible to a
+	// user who believes they turned it off. nil means unknown.
+	ReasoningDefaultOn *bool `json:"reasoning_default_on,omitempty"`
 	// ThinkingBudgetMin/Max bound the budget dialect. The range is per model
 	// family, not per vendor: Gemini 2.5 Pro is 128..32768 and cannot be turned
 	// off, while Flash starts at 0 and can.

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -448,6 +448,7 @@ func remoteModelsFromCatalog(items []sqlc.TemplateProviderTemplateModel) []Remot
 			ThinkingMode:        configString(cfg, "thinking_mode"),
 			ReasoningDialect:    configString(cfg, "reasoning_dialect"),
 			ReasoningOffSupport: configString(cfg, "reasoning_off_support"),
+			ReasoningDefaultOn:  configBoolPtr(cfg, "reasoning_default_on"),
 			ThinkingBudgetMin:   configIntPtr(cfg, "thinking_budget_min"),
 			ThinkingBudgetMax:   configIntPtr(cfg, "thinking_budget_max"),
 			ContextWindow:       configIntPtr(cfg, "context_window"),
@@ -788,4 +789,17 @@ func metadataSectionSource(metadata map[string]any, section string) string {
 		return ""
 	}
 	return strings.TrimSpace(stringValue(nested, metadataSourceKey))
+}
+
+// configBoolPtr reads an optional boolean, distinguishing "absent" from "false".
+// reasoning_default_on needs that distinction: unknown means the adaptor keeps its
+// conservative behaviour, while an explicit false is a fact about the model.
+func configBoolPtr(cfg map[string]any, key string) *bool {
+	if cfg == nil {
+		return nil
+	}
+	if value, ok := cfg[key].(bool); ok {
+		return &value
+	}
+	return nil
 }

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -129,6 +129,7 @@ type RemoteModel struct {
 	ReasoningDialect string `json:"reasoning_dialect,omitempty"`
 	// ReasoningOffSupport declares how the model answers an explicit disable.
 	ReasoningOffSupport string `json:"reasoning_off_support,omitempty"`
+	ReasoningDefaultOn  *bool  `json:"reasoning_default_on,omitempty"`
 	ThinkingBudgetMin   *int   `json:"thinking_budget_min,omitempty"`
 	ThinkingBudgetMax   *int   `json:"thinking_budget_max,omitempty"`
 	ContextWindow       *int   `json:"context_window,omitempty"`

--- a/internal/reasoning/mode.go
+++ b/internal/reasoning/mode.go
@@ -7,6 +7,10 @@ package reasoning
 //     incl. OpenAI). "off" wire behavior is provider-specific (see adaptor).
 //   - adaptive:      user can turn thinking on/off; when on, the provider uses
 //     adaptive thinking (Claude 4.6+/4.7/4.8).
+//   - always:        the model reasons and exposes no control at all — no tiers,
+//     no off switch (deepseek-reasoner, MiniMax M2.x). Distinct from toggle: a
+//     toggle model with an empty tier list can still be turned off, while this
+//     one cannot be influenced in any way.
 //   - only_adaptive: legacy alias for adaptive retained for branch-local imports.
 //   - none:          model has no thinking concept.
 //
@@ -15,6 +19,7 @@ package reasoning
 const (
 	ModeAdaptive     = "adaptive"
 	ModeToggle       = "toggle"
+	ModeAlways       = "always"
 	ModeOnlyAdaptive = "only_adaptive"
 	ModeNone         = "none"
 )
@@ -22,6 +27,7 @@ const (
 var validModes = map[string]struct{}{
 	ModeAdaptive:     {},
 	ModeToggle:       {},
+	ModeAlways:       {},
 	ModeOnlyAdaptive: {},
 	ModeNone:         {},
 }
@@ -39,7 +45,7 @@ func IsValidMode(mode string) bool {
 // means toggle, its absence means none.
 func ResolveMode(declared string, hasReasoningCompat bool) string {
 	switch declared {
-	case ModeToggle, ModeAdaptive, ModeNone:
+	case ModeToggle, ModeAdaptive, ModeAlways, ModeNone:
 		return declared
 	case ModeOnlyAdaptive:
 		return ModeAdaptive

--- a/internal/reasoning/options.go
+++ b/internal/reasoning/options.go
@@ -49,6 +49,12 @@ func OptionsFor(mode string, advertised []string, clientType, offSupport string)
 	if !Supported(mode) {
 		return Options{}
 	}
+	if mode == ModeAlways {
+		// The model reasons and takes no direction: no tiers to pick, no switch to
+		// flip. Reporting it as supported-but-uncontrollable is what lets a client
+		// say so, rather than rendering a control that cannot reach the model.
+		return Options{Supported: true}
+	}
 
 	levels := effectiveEfforts(advertised, clientType)
 	tiers := make([]string, 0, len(levels))
@@ -100,6 +106,9 @@ func OptionsFor(mode string, advertised []string, clientType, offSupport string)
 // would accept a disable, which costs a control, rather than over-offering on a
 // model that rejects one, which costs a failed request.
 func canDisable(mode string, levels []string, clientType, offSupport string) bool {
+	if mode == ModeAlways {
+		return false
+	}
 	switch offSupport {
 	case OffSupportAccepted, OffSupportLowEffortOnly:
 		return true

--- a/internal/reasoning/vocabulary.go
+++ b/internal/reasoning/vocabulary.go
@@ -243,6 +243,21 @@ func IsValidOffSupport(support string) bool {
 	return ok
 }
 
+// DefaultOn reports whether omitting the thinking field leaves the model thinking.
+//
+// This is a different question from whether a model can be turned off, and the two
+// were briefly conflated. "Can it be turned off" decides whether a picker offers
+// the control; "does omission mean off" decides what the adaptor must send to
+// honour that choice. Claude 4.6 answers no to the second (omitting is off) while
+// Opus 5 answers yes (omitting keeps thinking, billed and counted against
+// max_tokens, while the user believes it is off).
+//
+// nil means unknown, which callers treat as the conservative "omission is not a
+// reliable way to turn thinking off".
+func DefaultOn(defaultOn *bool) bool {
+	return defaultOn != nil && *defaultOn
+}
+
 // effortsAboveHigh are the tiers Opus 5 refuses to combine with an explicit
 // disable. They are the tiers stronger than high in the ordering.
 func effortExceedsHigh(effort string) bool {

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -20606,6 +20606,10 @@ const docTemplate = `{
                 "dimensions": {
                     "type": "integer"
                 },
+                "reasoning_default_on": {
+                    "description": "ReasoningDefaultOn reports whether omitting the thinking field leaves the\nmodel thinking. Separate from off-ability: Claude 4.6 can be turned off *and*\ndefaults to off, while Opus 5 can be turned off but defaults to on, so\nomitting the field there keeps thinking running — billed, and invisible to a\nuser who believes they turned it off. nil means unknown.",
+                    "type": "boolean"
+                },
                 "reasoning_dialect": {
                     "description": "ReasoningDialect declares the wire shape of this model's thinking control,\nwhich cannot be inferred from the tiers it advertises: Gemini 2.5 takes a\ntoken budget while 3.x takes a named level, and the two are mutually\nexclusive on the same request. Declared per model because the alternative is\nsniffing the model id, and an id is not a capability. Empty means the\nprovider's modern default.",
                     "type": "string"

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -20597,6 +20597,10 @@
                 "dimensions": {
                     "type": "integer"
                 },
+                "reasoning_default_on": {
+                    "description": "ReasoningDefaultOn reports whether omitting the thinking field leaves the\nmodel thinking. Separate from off-ability: Claude 4.6 can be turned off *and*\ndefaults to off, while Opus 5 can be turned off but defaults to on, so\nomitting the field there keeps thinking running — billed, and invisible to a\nuser who believes they turned it off. nil means unknown.",
+                    "type": "boolean"
+                },
                 "reasoning_dialect": {
                     "description": "ReasoningDialect declares the wire shape of this model's thinking control,\nwhich cannot be inferred from the tiers it advertises: Gemini 2.5 takes a\ntoken budget while 3.x takes a named level, and the two are mutually\nexclusive on the same request. Declared per model because the alternative is\nsniffing the model id, and an id is not a capability. Empty means the\nprovider's modern default.",
                     "type": "string"

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -4056,6 +4056,14 @@ definitions:
         type: string
       dimensions:
         type: integer
+      reasoning_default_on:
+        description: |-
+          ReasoningDefaultOn reports whether omitting the thinking field leaves the
+          model thinking. Separate from off-ability: Claude 4.6 can be turned off *and*
+          defaults to off, while Opus 5 can be turned off but defaults to on, so
+          omitting the field there keeps thinking running — billed, and invisible to a
+          user who believes they turned it off. nil means unknown.
+        type: boolean
       reasoning_dialect:
         description: |-
           ReasoningDialect declares the wire shape of this model's thinking control,


### PR DESCRIPTION
Stacked on #993. The data-source half of #982's third step.

Adds the sources and the merge. Wiring synccaps to them is deliberately separate —
this PR can be reviewed on whether the data is read correctly, without also
arguing about how much of the catalog discovery should own.

## Why LiteLLM cannot answer our question

It is a pricing table. It reports which OpenAI-wire flags a model happens to set
(`supports_reasoning`, `supports_xhigh_reasoning_effort`) and has no vocabulary
for the shape a provider actually speaks. That is why the templates carry
`reasoning_dialect`, the budget bounds and the disable token by hand, and why
synccaps needs two rules to stop itself erasing them.

**A correction to my own earlier claim:** I first compared coverage across all 603
models and concluded LiteLLM covered Anthropic, OpenAI and xAI better. Everything
in that margin was an old non-reasoning model — `claude-3-haiku`,
`gpt-3.5-turbo-0125`, `gpt-4-0613` — which LiteLLM keeps because it prices them
and models.dev curates away because it describes capabilities. Measured against
the 167 models our templates mark as reasoning, models.dev knows 125 and is ahead
everywhere the two overlap.

## What each source is for

| | models.dev | OpenRouter |
|---|---|---|
| wire dialect (tier vs budget) | ✅ only source | — |
| budget bounds | ✅ only source | — |
| tier list | ✅ authoritative | ✅ |
| **can it be turned off** | implied by option shape | ✅ `mandatory`, direct |
| **does omission mean off** | ✗ cannot express | ✅ `default_enabled` |

OpenRouter is a gateway rather than a description, so it *has* to know which
models refuse to stop thinking and which think unless told otherwise — both fall
out of its own routing code rather than from curation.

`Merge` takes each source for what it alone knows rather than ranking them. Where
they overlap, **a disagreement is reported rather than resolved silently** —
telling us something is wrong is the main thing a second source is for.

Checked against both live catalogs on six models spanning every case: they agree
everywhere, zero conflicts, and `claude-opus-4-6` picks up `default_enabled:false`
matching Anthropic's own per-model table.

## Three things the real catalog taught

Each is now a test, and each was a bug first:

1. **Provider entries are overlays.** They carry only what differs and inherit the
   rest via `base_model` from a top-level `models/` tree I had not read. Of 2994
   overlays, 2751 have no reasoning flag of their own, 2255 no modalities, 1608 no
   context limit — so gpt-5.2, claude-sonnet-4-5 and every Gemini 2.5 resolved as
   unknown while the data sat one file away.
2. **The option list must be read even without the reasoning flag** — 1631 of 2737
   entries carry options and no flag.
3. **Accepted is not preferred.** Claude 4.6 lists both `effort` and
   `budget_tokens` because the API takes both, but budget is deprecated there and
   rejected on 4.7+. A "budget wins" rule would have downgraded a correct
   hand-written dialect, so tiers take precedence when present.

## Data model gaps this closed

- **`always` is its own thinking mode.** A model that reasons and takes no
  direction was stored as a toggle with an empty tier list and off support
  "rejected" — which reads as "switchable, but refuses to switch".
- **`reasoning_default_on` is separate from off-ability.** Claude 4.6 can be turned
  off *and* omitting the field means off; Opus 5 can be turned off but thinks by
  default, so omitting leaves thinking running — billed, and invisible to a user
  who believes it is off. The adaptor now sends an explicit `disabled` only where
  both facts call for it.

Whether a model *accepts* an explicit disable — which splits Anthropic's catalog
three ways and only its documentation states — stays hand-declared and still wins
over both sources.

`go build ./...`, `go vet ./...`, `go test ./...` green; `gofmt` clean.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.