### PR TITLE
refactor(web): schedule page follows the settings page language; shared session picker

### DIFF
--- a/apps/web/src/components/session-select/index.vue
+++ b/apps/web/src/components/session-select/index.vue
@@ -1,0 +1,179 @@
+<template>
+  <SearchableSelectPopover
+    v-model="selected"
+    :options="options"
+    :placeholder="resolvedPlaceholder"
+    :aria-label="resolvedPlaceholder"
+    :search-placeholder="t('chat.searchSessionPlaceholder')"
+    :search-aria-label="t('chat.searchSessions')"
+    :empty-text="emptyText"
+    popover-class="w-[var(--reka-popover-trigger-width)]"
+  >
+    <!-- Custom trigger: the default one is text-only, and the selected
+         session's mark (schedule clock / agent) has to survive collapse —
+         otherwise the kind is visible only while the menu is open. -->
+    <template #trigger="{ open }">
+      <button
+        data-slot="select-trigger"
+        data-size="default"
+        :data-placeholder="triggerLabel ? undefined : ''"
+        type="button"
+        :aria-expanded="open"
+        :aria-label="resolvedPlaceholder"
+        :class="[selectTriggerClass, 'w-full']"
+      >
+        <span class="flex min-w-0 items-center gap-2">
+          <SessionKindIcon
+            v-if="selectedMark"
+            :kind="selectedMark.kind"
+            :agent-id="selectedMark.agentId"
+            :label="selectedMark.label"
+          />
+          <span class="line-clamp-1">{{ triggerLabel || resolvedPlaceholder }}</span>
+        </span>
+        <ChevronsUpDown class="opacity-50" />
+      </button>
+    </template>
+
+    <template #option-icon="{ option }">
+      <SessionKindIcon
+        :kind="markOf(option).kind"
+        :agent-id="markOf(option).agentId"
+        :label="markOf(option).label"
+        reserve-space
+      />
+    </template>
+  </SearchableSelectPopover>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ChevronsUpDown } from 'lucide-vue-next'
+import { selectTriggerClass } from '@felinic/ui'
+import { getBotsByBotIdSessions } from '@memohai/sdk'
+import type { SessionSession } from '@memohai/sdk'
+import SearchableSelectPopover from '@/components/searchable-select-popover/index.vue'
+import type { SearchableSelectOption } from '@/components/searchable-select-popover/index.vue'
+import { useWorkdirsStore } from '@/store/workdirs'
+import { normalizedSessionMode } from '@/store/chat-list.utils'
+import SessionKindIcon from './session-kind-icon.vue'
+import {
+  buildSessionOptions,
+  sessionMark,
+  sessionTitle,
+  NO_MARK,
+  type SessionMark,
+  type SessionSelectLabels,
+} from './options'
+
+// A bot's sessions as a picker: the same three things the sidebar list gives
+// you — folder grouping, search, and a per-kind mark — in one field-sized
+// control, so every surface that has to name an existing session reads the
+// same way.
+const props = withDefaults(defineProps<{
+  botId: string
+  placeholder?: string
+  // Restrict the list to these session modes (chat | discuss | schedule | …).
+  // Empty means every mode the API returns.
+  modes?: string[]
+  limit?: number
+}>(), {
+  placeholder: '',
+  modes: () => [],
+  limit: 200,
+})
+
+const emit = defineEmits<{
+  // The resolved row behind the selected id, so callers don't refetch the list
+  // just to read the target's runtime.
+  'update:session': [SessionSession | null]
+}>()
+
+const { t } = useI18n()
+const workdirsStore = useWorkdirsStore()
+
+const selected = defineModel<string>({ default: '' })
+
+const sessions = ref<SessionSession[]>([])
+const loading = ref(false)
+const loaded = ref(false)
+
+const labels = computed<SessionSelectLabels>(() => ({
+  untitled: t('chat.untitledSession'),
+  recents: t('chat.recents'),
+  unavailableFolder: t('chat.folderUnavailable'),
+  schedule: t('chat.sessionTypeSchedule'),
+  agent: t('chat.sessionTypeACPAgent'),
+}))
+
+const resolvedPlaceholder = computed(() => props.placeholder || t('chat.selectSession'))
+
+const emptyText = computed(() =>
+  loading.value ? t('common.loading') : t('chat.noSearchResults'),
+)
+
+const listedSessions = computed(() => {
+  const modes = props.modes
+  if (modes.length === 0) return sessions.value
+  return sessions.value.filter(session => modes.includes(normalizedSessionMode(session)))
+})
+
+const options = computed<SearchableSelectOption[]>(() =>
+  buildSessionOptions(listedSessions.value, workdirsStore.workdirsFor(props.botId), labels.value),
+)
+
+function markOf(option: SearchableSelectOption): SessionMark {
+  return (option.meta as SessionMark | undefined) ?? NO_MARK
+}
+
+const selectedSession = computed(() =>
+  sessions.value.find(session => session.id === selected.value) ?? null,
+)
+
+const selectedMark = computed(() =>
+  selectedSession.value ? sessionMark(selectedSession.value, labels.value) : null,
+)
+
+// Until the list lands, a hydrated id has no title to show; the raw uuid the
+// popover would fall back to is noise, so the field reads as loading instead.
+const triggerLabel = computed(() => {
+  if (selectedSession.value) return sessionTitle(selectedSession.value, labels.value)
+  if (selected.value && !loaded.value) return t('common.loading')
+  return ''
+})
+
+async function fetchSessions(botId: string) {
+  if (!botId) {
+    sessions.value = []
+    loaded.value = false
+    return
+  }
+  loading.value = true
+  try {
+    const { data } = await getBotsByBotIdSessions({
+      path: { bot_id: botId },
+      query: { limit: props.limit },
+      throwOnError: true,
+    })
+    sessions.value = data.items ?? []
+  } catch {
+    sessions.value = []
+  } finally {
+    loading.value = false
+    loaded.value = true
+  }
+}
+
+watch(() => props.botId, (botId) => {
+  loaded.value = false
+  void workdirsStore.ensureWorkdirs(botId)
+  void fetchSessions(botId)
+}, { immediate: true })
+
+watch([selectedSession, loaded], () => {
+  emit('update:session', selectedSession.value)
+}, { immediate: true })
+
+defineExpose({ refresh: () => fetchSessions(props.botId) })
+</script>

--- a/apps/web/src/components/session-select/options.test.ts
+++ b/apps/web/src/components/session-select/options.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionSession } from '@memohai/sdk'
+import type { BotWorkdir } from '@/composables/api/useWorkdirs'
+import { buildSessionOptions, sessionMark, type SessionSelectLabels } from './options'
+
+const labels: SessionSelectLabels = {
+  untitled: 'Untitled Session',
+  recents: 'Recents',
+  unavailableFolder: 'Unavailable folder',
+  schedule: 'Scheduled Task',
+  agent: 'Agent',
+}
+
+function session(id: string, overrides: Partial<SessionSession> = {}): SessionSession {
+  return { id, bot_id: 'bot-1', title: `Session ${id}`, type: 'chat', session_mode: 'chat', ...overrides }
+}
+
+function workdir(id: string, name: string, overrides: Partial<BotWorkdir> = {}): BotWorkdir {
+  return { id, name, path: `/data/${name}`, ...overrides }
+}
+
+describe('buildSessionOptions', () => {
+  it('lists unfiled sessions without a header when there are no folders', () => {
+    const options = buildSessionOptions([session('a'), session('b')], [], labels)
+
+    expect(options.map(o => o.value)).toEqual(['a', 'b'])
+    expect(options.every(o => o.group === '' && o.groupLabel === '')).toBe(true)
+  })
+
+  it('puts unfiled sessions first under Recents once a folder has sessions', () => {
+    const options = buildSessionOptions(
+      [session('filed', { workdir_id: 'wd-1' }), session('loose')],
+      [workdir('wd-1', 'Docs')],
+      labels,
+    )
+
+    expect(options.map(o => [o.value, o.groupLabel])).toEqual([
+      ['loose', 'Recents'],
+      ['filed', 'Docs'],
+    ])
+  })
+
+  it('keeps folder order and drops folders with no sessions', () => {
+    const options = buildSessionOptions(
+      [session('b', { workdir_id: 'wd-2' }), session('a', { workdir_id: 'wd-1' })],
+      [workdir('wd-1', 'First'), workdir('wd-empty', 'Empty'), workdir('wd-2', 'Second')],
+      labels,
+    )
+
+    expect(options.map(o => o.groupLabel)).toEqual(['First', 'Second'])
+  })
+
+  it('keeps a session bound to a vanished folder in its own group', () => {
+    const options = buildSessionOptions([session('a', { workdir_id: 'gone' })], [], labels)
+
+    expect(options[0]?.group).toBe('gone')
+    expect(options[0]?.groupLabel).toBe('Unavailable folder')
+  })
+
+  it('skips archived folders but still names the sessions still bound to them', () => {
+    const options = buildSessionOptions(
+      [session('a', { workdir_id: 'wd-1' })],
+      [workdir('wd-1', 'Archived', { archived: true })],
+      labels,
+    )
+
+    expect(options.map(o => o.groupLabel)).toEqual(['Archived'])
+  })
+
+  it('falls back to the untitled label and searches on title, folder and id', () => {
+    const options = buildSessionOptions(
+      [session('a', { title: '  ', workdir_id: 'wd-1' })],
+      [workdir('wd-1', 'Docs')],
+      labels,
+    )
+
+    expect(options[0]?.label).toBe('Untitled Session')
+    expect(options[0]?.keywords).toEqual(['Untitled Session', 'Docs', 'a'])
+  })
+})
+
+describe('sessionMark', () => {
+  it('marks schedule sessions with the clock, even when they run an agent', () => {
+    const mark = sessionMark(
+      session('a', { session_mode: 'schedule', runtime_type: 'acp_agent', metadata: { acp_agent_id: 'codex' } }),
+      labels,
+    )
+
+    expect(mark).toEqual({ kind: 'schedule', agentId: 'codex', label: 'Scheduled Task' })
+  })
+
+  it('marks ACP chats with the agent that runs them', () => {
+    const mark = sessionMark(
+      session('a', { runtime_type: 'acp_agent', runtime_metadata: { acp_agent_id: 'claude-code' } }),
+      labels,
+    )
+
+    expect(mark.kind).toBe('acp')
+    expect(mark.agentId).toBe('claude-code')
+  })
+
+  it('resolves the legacy acp_agent type with no runtime_type', () => {
+    expect(sessionMark(session('a', { type: 'acp_agent', session_mode: '' }), labels).kind).toBe('acp')
+  })
+
+  it('leaves plain model chats unmarked', () => {
+    expect(sessionMark(session('a'), labels).kind).toBe('chat')
+  })
+})

--- a/apps/web/src/components/session-select/options.ts
+++ b/apps/web/src/components/session-select/options.ts
@@ -1,0 +1,90 @@
+import type { SessionSession } from '@memohai/sdk'
+import type { SearchableSelectOption } from '@/components/searchable-select-popover/index.vue'
+import type { BotWorkdir } from '@/composables/api/useWorkdirs'
+import type { SessionKind } from './session-kind-icon.vue'
+import { acpAgentDisplayName, normalizeACPAgentID } from '@/utils/acp'
+import { normalizedRuntimeType, normalizedSessionMode } from '@/store/chat-list.utils'
+
+// The per-row mark the picker paints beside a session title.
+export interface SessionMark {
+  kind: SessionKind
+  agentId: string
+  label: string
+}
+
+// Copy the picker needs but cannot look up itself — kept as data so the
+// grouping stays a pure function.
+export interface SessionSelectLabels {
+  untitled: string
+  recents: string
+  unavailableFolder: string
+  schedule: string
+  agent: string
+}
+
+export const NO_MARK: SessionMark = { kind: 'chat', agentId: '', label: '' }
+
+export function sessionTitle(session: SessionSession, labels: SessionSelectLabels): string {
+  return (session.title ?? '').trim() || labels.untitled
+}
+
+export function sessionMark(session: SessionSession, labels: SessionSelectLabels): SessionMark {
+  const agentId = normalizeACPAgentID(
+    session.runtime_metadata?.acp_agent_id ?? session.metadata?.acp_agent_id,
+  )
+  // Schedule wins over the ACP mark here, unlike the sidebar row: this picker
+  // exists to tell schedule-owned sessions apart from ordinary chats, and a
+  // schedule session that happens to run an agent is still a schedule session.
+  if (normalizedSessionMode(session) === 'schedule') {
+    return { kind: 'schedule', agentId, label: labels.schedule }
+  }
+  if (normalizedRuntimeType(session) === 'acp_agent') {
+    return { kind: 'acp', agentId, label: acpAgentDisplayName(agentId, labels.agent) }
+  }
+  return NO_MARK
+}
+
+// buildSessionOptions groups a bot's sessions the way the sidebar lists them:
+// unfiled sessions first — headerless while there is nothing to contrast them
+// with — then one group per live folder, in the folder list's own order. A
+// session bound to a folder that is gone (archived, deleted) keeps its own
+// group rather than silently joining the unfiled bucket.
+export function buildSessionOptions(
+  sessions: SessionSession[],
+  workdirs: BotWorkdir[],
+  labels: SessionSelectLabels,
+): SearchableSelectOption[] {
+  const nameById = new Map(workdirs.flatMap(wd => (wd.id ? [[wd.id, wd.name ?? '']] : [])))
+  const buckets = new Map<string, SessionSession[]>([['', []]])
+  for (const workdir of workdirs) {
+    if (workdir.id && !workdir.archived) buckets.set(workdir.id, [])
+  }
+  for (const session of sessions) {
+    const key = (session.workdir_id ?? '').trim()
+    const bucket = buckets.get(key)
+    if (bucket) bucket.push(session)
+    else buckets.set(key, [session])
+  }
+
+  const groups = [...buckets].filter(([, items]) => items.length > 0)
+  const hasFolders = groups.some(([key]) => key !== '')
+
+  const options: SearchableSelectOption[] = []
+  for (const [key, items] of groups) {
+    const groupLabel = key === ''
+      ? (hasFolders ? labels.recents : '')
+      : (nameById.get(key) || labels.unavailableFolder)
+    for (const session of items) {
+      const label = sessionTitle(session, labels)
+      options.push({
+        value: session.id ?? '',
+        label,
+        group: key,
+        groupLabel,
+        keywords: [label, groupLabel, session.id ?? ''],
+        meta: sessionMark(session, labels),
+      })
+    }
+  }
+  return options
+}

--- a/apps/web/src/components/session-select/session-kind-icon.vue
+++ b/apps/web/src/components/session-select/session-kind-icon.vue
@@ -1,0 +1,53 @@
+<template>
+  <!-- Same vocabulary as the sidebar's session rows (session-item.vue): plain
+       model chats stay text-only, ACP chats carry the agent mark, and schedule
+       runs carry a yellow clock. `reserveSpace` keeps the label column aligned
+       in list contexts where only some rows have a mark. -->
+  <span
+    v-if="kind === 'schedule'"
+    class="flex size-4 shrink-0 items-center justify-center"
+    role="img"
+    :aria-label="label"
+  >
+    <!-- Status icons stay state-constant on the accent ramp. -->
+    <Clock
+      class="size-4 text-[color:var(--accent-yellow)]"
+      aria-hidden="true"
+    />
+  </span>
+  <span
+    v-else-if="kind === 'acp'"
+    class="flex size-4 shrink-0 items-center justify-center text-muted-foreground"
+    role="img"
+    :aria-label="label"
+  >
+    <component
+      :is="acpAgentIcon(agentId, true)"
+      class="size-4"
+      aria-hidden="true"
+    />
+  </span>
+  <span
+    v-else-if="reserveSpace"
+    class="size-4 shrink-0"
+    aria-hidden="true"
+  />
+</template>
+
+<script setup lang="ts">
+import { Clock } from 'lucide-vue-next'
+import { acpAgentIcon } from '@/utils/acp'
+
+export type SessionKind = 'chat' | 'acp' | 'schedule'
+
+withDefaults(defineProps<{
+  kind: SessionKind
+  agentId?: string
+  label?: string
+  reserveSpace?: boolean
+}>(), {
+  agentId: '',
+  label: '',
+  reserveSpace: false,
+})
+</script>

--- a/apps/web/src/components/sidebar/panel-schedule.vue
+++ b/apps/web/src/components/sidebar/panel-schedule.vue
@@ -69,11 +69,10 @@
 
           <!-- Cards in group -->
           <div class="px-2 pb-1 space-y-1.5">
-            <ScheduleListItem
+            <ScheduleItem
               v-for="item in group.tasks"
               :key="item.id"
               :item="item"
-              variant="sidebar"
               :description="item.description?.trim() || describeItem(item.pattern) || item.pattern || ''"
               :time-label="nextRunTimeLabel(item)"
               :busy="busyIds.has(item.id ?? '')"
@@ -116,7 +115,7 @@ import { useChatStore } from '@/store/chat-list'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import { describeCron, nextRuns } from '@/utils/cron-pattern'
-import ScheduleListItem from '@/pages/bots/components/schedule-list-item.vue'
+import ScheduleItem from './schedule-item.vue'
 import SidebarPanelHeader from './panel-header.vue'
 // The narrow native scrollbar this template's `sidebar-scroll` class relies on.
 // Without this import the class was silently inert (it used to be defined only

--- a/apps/web/src/components/sidebar/schedule-item.vue
+++ b/apps/web/src/components/sidebar/schedule-item.vue
@@ -1,22 +1,19 @@
 <template>
+  <!-- The sidebar's schedule card. Deliberately NOT a SettingsRow: the panel is
+       its own dense surface (compact card, two tight lines, hover-revealed
+       actions), a different spatial relationship from the settings list this
+       used to share code with. -->
   <div
-    class="group/card relative flex cursor-pointer items-center gap-3 rounded-[var(--radius-menu-shell)] border border-border bg-card transition-colors hover:bg-accent/30 dark:hover:bg-accent focus-visible:outline-none"
-    :class="variant === 'sidebar' ? '' : 'px-4 py-3.5'"
+    :class="cardClass"
     role="button"
     tabindex="0"
     @click="$emit('open')"
     @keydown.enter="$emit('open')"
     @keydown.space.prevent="$emit('open')"
   >
-    <div
-      class="min-w-0 flex-1"
-      :class="variant === 'sidebar' ? 'px-3 py-2.5' : ''"
-    >
+    <div class="min-w-0 flex-1 px-3 py-2.5">
       <div class="flex min-w-0 items-center gap-2">
-        <p
-          class="truncate text-foreground"
-          :class="variant === 'sidebar' ? 'text-control font-normal leading-snug' : 'text-sm font-medium'"
-        >
+        <p class="truncate text-control font-normal leading-snug text-foreground">
           {{ item.name }}
         </p>
         <span
@@ -26,30 +23,21 @@
           {{ timeLabel }}
         </span>
       </div>
-      <p
-        class="truncate text-muted-foreground"
-        :class="variant === 'sidebar' ? 'mt-0.5 text-caption leading-snug' : 'text-xs'"
-      >
+      <p class="mt-0.5 truncate text-caption leading-snug text-muted-foreground">
         {{ description }}
       </p>
     </div>
 
-    <div
-      class="flex shrink-0 items-center gap-2"
-      :class="variant === 'sidebar' ? 'pr-1.5' : ''"
-    >
+    <div class="flex shrink-0 items-center gap-2 pr-1.5">
       <DropdownMenu
         @update:open="(open: boolean) => { menuOpen = open }"
       >
         <DropdownMenuTrigger as-child>
           <Button
             variant="ghost"
-            :size="variant === 'sidebar' ? 'icon-sm' : 'icon'"
-            class="transition-opacity"
-            :class="[
-              variant === 'sidebar' ? 'size-6' : 'size-7',
-              menuOpen ? 'opacity-100' : 'opacity-0 group-hover/card:opacity-100',
-            ]"
+            size="icon-sm"
+            class="size-6 transition-opacity"
+            :class="menuOpen ? 'opacity-100' : 'opacity-0 group-hover/card:opacity-100'"
             :aria-label="t('common.actions')"
             @click.stop
           >
@@ -57,20 +45,16 @@
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            class="gap-2"
-            @select="$emit('edit')"
-          >
-            <Pencil class="size-3.5" />
+          <DropdownMenuItem @select="$emit('edit')">
+            <Pencil />
             {{ t('bots.schedule.edit') }}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             variant="destructive"
-            class="gap-2"
             @select="$emit('delete')"
           >
-            <Trash2 class="size-3.5" />
+            <Trash2 />
             {{ t('bots.schedule.delete') }}
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -107,11 +91,9 @@ withDefaults(defineProps<{
   description: string
   timeLabel?: string
   busy?: boolean
-  variant?: 'card' | 'sidebar'
 }>(), {
   timeLabel: '',
   busy: false,
-  variant: 'card',
 })
 
 defineEmits<{
@@ -120,6 +102,11 @@ defineEmits<{
   delete: []
   toggle: [enabled: boolean]
 }>()
+
+// The sidebar is a deliberately local row system (see ui-owners), so this card
+// carries its own hover — on the sidebar's own rung of the overlay ladder, the
+// same token session-item.vue and folders-section.vue use, never a baked tint.
+const cardClass = 'group/card relative flex cursor-pointer items-center gap-3 rounded-[var(--radius-menu-shell)] border border-border bg-card transition-colors hover:bg-[color:var(--sidebar-hover)] focus-visible:outline-none' /* ui-allow-style: sidebar rows are a local row system (see ui-owners) — same hover token as session-item.vue */
 
 const { t } = useI18n()
 const menuOpen = ref(false)

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -3030,6 +3030,7 @@
       "title": "Schedule",
       "loadFailed": "Load failed",
       "empty": "No tasks scheduled",
+      "emptyDescription": "Give this bot a prompt to run on its own, on a schedule you set.",
       "name": "Name",
       "pattern": "Pattern",
       "enabled": "Enabled",
@@ -3054,6 +3055,7 @@
       "sortName": "By name",
       "sortStatus": "By status",
       "sortNextRun": "By next run",
+      "nextRun": "Next run {time}",
       "picker": {
         "every": "Every",
         "minutes": "minutes",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -529,6 +529,7 @@
     "license": "AGPLv3 · © 2026 MemohAI"
   },
   "chat": {
+    "selectSession": "Select a session",
     "welcome": {
       "folder": "What can I do in {name}?",
       "g1": "Where should we begin?",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -3007,6 +3007,7 @@
       "title": "スケジュール",
       "loadFailed": "ロードに失敗しました",
       "empty": "スケジュールされたタスクはありません",
+      "emptyDescription": "設定した時刻に Bot が自分でプロンプトを実行します。",
       "name": "名前",
       "pattern": "パターン",
       "enabled": "有効",
@@ -3031,6 +3032,7 @@
       "sortName": "名前で",
       "sortStatus": "ステータス別",
       "sortNextRun": "次回の実行までに",
+      "nextRun": "次回実行 {time}",
       "picker": {
         "every": "毎",
         "minutes": "分",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -526,6 +526,7 @@
     "license": "AGPLv3 · © 2026 MemohAI"
   },
   "chat": {
+    "selectSession": "セッションを選択",
     "welcome": {
       "folder": "{name} で何をしましょうか？"
     },

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -3030,6 +3030,7 @@
       "title": "定时任务",
       "loadFailed": "加载失败",
       "empty": "暂无定时任务",
+      "emptyDescription": "让这个 Bot 按你设定的时间自动执行一段指令。",
       "name": "名称",
       "pattern": "表达式",
       "enabled": "启用",
@@ -3054,6 +3055,7 @@
       "sortName": "按名称",
       "sortStatus": "按状态",
       "sortNextRun": "按下次触发",
+      "nextRun": "下次运行 {time}",
       "picker": {
         "every": "每",
         "minutes": "分钟",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -529,6 +529,7 @@
     "license": "AGPLv3 · © 2026 MemohAI"
   },
   "chat": {
+    "selectSession": "选择会话",
     "welcome": {
       "folder": "要在 {name} 里做点什么？",
       "g1": "我们从哪里开始？",

--- a/apps/web/src/pages/bots/components/bot-schedule.vue
+++ b/apps/web/src/pages/bots/components/bot-schedule.vue
@@ -6,11 +6,8 @@
     <template #actions>
       <DropdownMenu v-if="schedules.length > 1">
         <DropdownMenuTrigger as-child>
-          <Button
-            variant="ghost"
-            class="text-muted-foreground"
-          >
-            <ArrowUpDown class="size-3.5" />
+          <Button variant="ghost">
+            <ArrowUpDown />
             {{ currentSortLabel }}
           </Button>
         </DropdownMenuTrigger>
@@ -22,64 +19,88 @@
             @select="sortKey = opt.key"
           >
             {{ $t(opt.labelKey) }}
-            <Check
-              class="size-3.5 shrink-0"
-              :class="sortKey === opt.key ? 'opacity-100' : 'opacity-0'"
-            />
+            <Check :class="sortKey === opt.key ? 'opacity-100' : 'opacity-0'" />
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <Button @click="handleNew">
-        <Plus class="size-4" />
+        <Plus />
         {{ $t('bots.schedule.create') }}
       </Button>
     </template>
 
-    <!-- Loading -->
-    <InlineLoadingRow
-      v-if="isLoading && schedules.length === 0"
-      class="px-2"
-    >
-      {{ $t('common.loading') }}
-    </InlineLoadingRow>
-
-    <!-- Empty -->
-    <div
-      v-else-if="schedules.length === 0"
-      class="flex flex-col items-center justify-center rounded-[var(--radius-menu-shell)] border border-dashed border-border py-16 text-center"
-    >
-      <Calendar class="mb-3 size-8 text-muted-foreground/40" />
-      <p class="text-sm font-medium text-foreground">
-        {{ $t('bots.schedule.empty') }}
-      </p>
-      <Button
-        variant="outline"
-        size="sm"
-        class="mt-4"
-        @click="handleNew"
+    <!-- One titleless card: the page title already names the concern, so a
+         section label here would say "tasks" a second time. -->
+    <SettingsSection>
+      <InlineLoadingRow
+        v-if="isLoading && schedules.length === 0"
+        surface="card-row"
       >
-        <Plus class="size-4" />
-        {{ $t('bots.schedule.create') }}
-      </Button>
-    </div>
+        {{ $t('common.loading') }}
+      </InlineLoadingRow>
 
-    <!-- Card Grid -->
-    <div
-      v-else
-      class="grid grid-cols-1 gap-3 sm:grid-cols-2"
-    >
-      <ScheduleListItem
-        v-for="item in sortedSchedules"
-        :key="item.id"
-        :item="item"
-        :description="item.description?.trim() || describeItem(item.pattern) || item.pattern || ''"
-        :busy="busyIds.has(item.id || '')"
-        @open="handleEdit(item)"
-        @edit="handleEdit(item)"
-        @delete="deleteTarget = item"
-        @toggle="(enabled) => handleToggleEnabled(item, enabled)"
-      />
-    </div>
+      <Empty
+        v-else-if="schedules.length === 0"
+        class="py-12"
+      >
+        <EmptyHeader>
+          <EmptyTitle>{{ $t('bots.schedule.empty') }}</EmptyTitle>
+          <EmptyDescription>{{ $t('bots.schedule.emptyDescription') }}</EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <Button
+            variant="outline"
+            @click="handleNew"
+          >
+            <Plus />
+            {{ $t('bots.schedule.create') }}
+          </Button>
+        </EmptyContent>
+      </Empty>
+
+      <SettingsRow
+        v-for="row in rows"
+        v-else
+        :key="row.item.id"
+        :label="row.item.name || ''"
+        :description="row.description"
+      >
+        <div class="flex items-center gap-2">
+          <Switch
+            :model-value="!!row.item.enabled"
+            :disabled="busyIds.has(row.item.id || '')"
+            :aria-label="$t('bots.schedule.form.enabled')"
+            @update:model-value="(value: boolean) => handleToggleEnabled(row.item, !!value)"
+          />
+
+          <DropdownMenu>
+            <DropdownMenuTrigger as-child>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                :aria-label="$t('common.actions')"
+              >
+                <MoreHorizontal />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem @select="handleEdit(row.item)">
+                <Pencil />
+                {{ $t('bots.schedule.edit') }}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                @select="deleteTarget = row.item"
+              >
+                <Trash2 />
+                {{ $t('bots.schedule.delete') }}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </SettingsRow>
+    </SettingsSection>
 
     <!-- Create / Edit Dialog -->
     <Dialog v-model:open="formVisible">
@@ -101,49 +122,32 @@
       </DialogScrollContent>
     </Dialog>
 
-    <!-- Delete confirmation dialog -->
-    <Dialog
+    <ConfirmDeleteDialog
       :open="!!deleteTarget"
-      @update:open="(v) => { if (!v) deleteTarget = null }"
-    >
-      <DialogContent class="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>{{ $t('bots.schedule.deleteTitle') }}</DialogTitle>
-        </DialogHeader>
-        <p class="text-sm text-muted-foreground">
-          {{ $t('bots.schedule.deleteConfirm', { name: deleteTarget?.name ?? '' }) }}
-        </p>
-        <DialogFooter class="gap-2">
-          <Button
-            variant="outline"
-            @click="deleteTarget = null"
-          >
-            {{ $t('common.cancel') }}
-          </Button>
-          <Button
-            variant="destructive"
-            :loading="isDeleting"
-            @click="confirmDelete"
-          >
-            {{ $t('bots.schedule.delete') }}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      :title="$t('bots.schedule.deleteTitle')"
+      :description="$t('bots.schedule.deleteConfirm', { name: deleteTarget?.name ?? '' })"
+      :cancel-label="$t('common.cancel')"
+      :confirm-label="$t('bots.schedule.delete')"
+      :loading="isDeleting"
+      @update:open="(v: boolean) => { if (!v) deleteTarget = null }"
+      @confirm="confirmDelete"
+    />
   </PageShell>
 </template>
 
 <script setup lang="ts">
 import {
-  ArrowUpDown, Calendar, Check, Plus,
+  ArrowUpDown, Check, MoreHorizontal, Pencil, Plus, Trash2,
 } from 'lucide-vue-next'
 import { ref, computed, onMounted, reactive, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { InlineLoadingRow, PageShell, toast } from '@felinic/ui'
 import {
   Button,
-  Dialog, DialogContent, DialogScrollContent, DialogHeader, DialogTitle, DialogFooter,
-  DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, DropdownMenuItem,
+  ConfirmDeleteDialog,
+  Dialog, DialogScrollContent, DialogHeader, DialogTitle,
+  DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, DropdownMenuItem, DropdownMenuSeparator,
+  Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyTitle,
+  InlineLoadingRow, PageShell, SettingsRow, SettingsSection, Switch, toast,
 } from '@felinic/ui'
 import {
   deleteBotsByBotIdScheduleById,
@@ -153,9 +157,9 @@ import {
 } from '@memohai/sdk'
 import type { ScheduleSchedule } from '@memohai/sdk'
 import { resolveApiErrorMessage } from '@/utils/api-error'
+import { formatCalendarTime } from '@/utils/date-time'
 import { describeCron, nextRuns } from '@/utils/cron-pattern'
 import ScheduleEditor from './schedule-editor.vue'
-import ScheduleListItem from './schedule-list-item.vue'
 
 const props = defineProps<{
   botId: string
@@ -183,6 +187,9 @@ const currentSortLabel = computed(
   () => t(SORT_OPTIONS.find((o) => o.key === sortKey.value)?.labelKey ?? 'bots.schedule.sortName'),
 )
 
+const cronLocale = computed<'en' | 'zh' | 'ja'>(() => (locale.value.startsWith('zh') ? 'zh' : locale.value.startsWith('ja') ? 'ja' : 'en'))
+const uiLocale = computed(() => locale.value.startsWith('zh') ? 'zh-CN' : locale.value.startsWith('ja') ? 'ja-JP' : 'en-US')
+
 const effectiveTimezone = computed(() => {
   const tz = botTimezone.value?.trim()
   if (tz) return tz
@@ -198,14 +205,36 @@ const sortedSchedules = computed(() => {
     return list.sort((a, b) => Number(b.enabled ?? false) - Number(a.enabled ?? false))
   }
   if (sortKey.value === 'next-run') {
-    return list.sort((a, b) => {
-      const aTime = a.pattern ? (nextRuns(a.pattern, effectiveTimezone.value, 1)[0]?.getTime() ?? Infinity) : Infinity
-      const bTime = b.pattern ? (nextRuns(b.pattern, effectiveTimezone.value, 1)[0]?.getTime() ?? Infinity) : Infinity
-      return aTime - bTime
-    })
+    return list.sort((a, b) => (nextRunAt(a)?.getTime() ?? Infinity) - (nextRunAt(b)?.getTime() ?? Infinity))
   }
   return list
 })
+
+function nextRunAt(item: ScheduleSchedule): Date | null {
+  if (!item.pattern) return null
+  return nextRuns(item.pattern, effectiveTimezone.value, 1)[0] ?? null
+}
+
+// One line per task carrying the three things this page is asked for: what the
+// user called it, when it fires, and when that next happens. A disabled task
+// promises no next run, so the clause simply drops.
+function rowDescription(item: ScheduleSchedule): string {
+  const parts = [item.description?.trim() || '']
+  parts.push((item.pattern ? describeCron(item.pattern, cronLocale.value) : '') || item.pattern || '')
+  if (item.enabled) {
+    const next = nextRunAt(item)
+    if (next) {
+      parts.push(t('bots.schedule.nextRun', {
+        time: formatCalendarTime(next.toISOString(), { locale: uiLocale.value }),
+      }))
+    }
+  }
+  return parts.filter(Boolean).join(' · ')
+}
+
+const rows = computed(() =>
+  sortedSchedules.value.map(item => ({ item, description: rowDescription(item) })),
+)
 
 // --- Delete via card menu ---
 const deleteTarget = ref<ScheduleSchedule | null>(null)
@@ -235,14 +264,6 @@ const formVisible = ref(false)
 const formMode = ref<'create' | 'edit'>('create')
 const editingSchedule = ref<ScheduleSchedule | null>(null)
 const consumedInitialScheduleId = ref<string | undefined>(undefined)
-
-const cronLocale = computed<'en' | 'zh' | 'ja'>(() => (locale.value.startsWith('zh') ? 'zh' : locale.value.startsWith('ja') ? 'ja' : 'en'))
-
-// --- Card helpers ---
-function describeItem(pattern: string | undefined): string | undefined {
-  if (!pattern) return undefined
-  return describeCron(pattern, cronLocale.value)
-}
 
 // --- API ---
 async function fetchSchedules() {

--- a/apps/web/src/pages/bots/components/model-select.vue
+++ b/apps/web/src/pages/bots/components/model-select.vue
@@ -34,6 +34,7 @@
           :open="open"
           :none-label="noneLabel"
           :show-reasoning="showReasoning"
+          :reasoning-options="reasoningOptions"
         />
       </div>
     </PopoverContent>
@@ -56,6 +57,14 @@ const props = defineProps<{
   placeholder?: string
   noneLabel?: string
   showReasoning?: boolean
+  // Runtime-supplied tiers, forwarded to ModelOptions. Callers whose efforts do
+  // not come from the model's own capabilities (ACP agents report their own)
+  // pass them here instead of letting the menu derive them.
+  reasoningOptions?: Array<{
+    value: string
+    label: string
+    description?: string
+  }>
 }>()
 
 const selected = defineModel<string>({ default: '' })
@@ -83,6 +92,10 @@ const displayLabel = computed(() => {
   if (!props.showReasoning || !modelLabel.value) return modelLabel.value
   const effort = reasoningEffort.value
   if (!effort || effort === REASONING_EFFORT_DISABLE) return modelLabel.value
+  if (props.reasoningOptions) {
+    const option = props.reasoningOptions.find(o => o.value === effort)
+    return option ? `${modelLabel.value} · ${option.label}` : modelLabel.value
+  }
   const key = EFFORT_LABELS[effort]
   return `${modelLabel.value} · ${key ? t(key) : effort}`
 })

--- a/apps/web/src/pages/bots/components/schedule-editor.vue
+++ b/apps/web/src/pages/bots/components/schedule-editor.vue
@@ -203,21 +203,25 @@
         :class="showMore ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'"
       >
         <div class="min-h-0">
-          <div class="mt-3">
-            <div class="flex items-center justify-between gap-3">
-              <Label class="text-muted-foreground">
-                {{ t('bots.schedule.form.maxCalls') }}
-              </Label>
+          <!-- The disclosed zone is one continuous form column with the fields
+               above it, so it keeps the same label-over-control rhythm rather
+               than switching to a side-by-side row halfway down the dialog.
+               The placeholder carries the empty-value meaning, so no help line
+               repeats it. -->
+          <FormStack class="mt-3">
+            <FieldStack
+              :label="t('bots.schedule.form.maxCalls')"
+              for="sched-max-calls"
+            >
               <Input
+                id="sched-max-calls"
                 v-model="runLimitModel"
                 type="text"
                 inputmode="numeric"
-                size="sm"
-                :placeholder="'∞'"
-                class="w-24 text-center"
+                :placeholder="t('bots.schedule.unlimited')"
               />
-            </div>
-          </div>
+            </FieldStack>
+          </FormStack>
         </div>
       </div>
     </div>
@@ -276,6 +280,8 @@ import { ChevronRight, Trash2 } from 'lucide-vue-next'
 import {
   Button,
   DialogFooter,
+  FieldStack,
+  FormStack,
   Input,
   Label,
   Select,
@@ -293,7 +299,6 @@ import {
   putBotsByBotIdScheduleById,
 } from '@memohai/sdk'
 import type { ScheduleCreateRequest, ScheduleSchedule, ScheduleUpdateRequest } from '@memohai/sdk'
-import { FieldStack } from '@felinic/ui'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import {
   describeCron,


### PR DESCRIPTION
## Summary

The schedule tab's task list was the last schedule surface still off the design contract. This brings it onto the settings page language and fixes two information gaps in the rows.

Diagnosed against `packages/ui/skills/web/SKILL.md` + its dirty→clean table; rebuilt by mirroring `bot-connectors.vue`, the clean same-shape sibling in the same directory.

## What was off-contract

| Dirty | Rule |
|---|---|
| `border-dashed` empty state | dashed is reserved for the "+ Add another" tile beside real items; an empty surface keeps the populated frame |
| `<Calendar>` glyph stacked in that box, `text-muted-foreground/40` | decorative icon in a card + hand-mixed alpha |
| hand-rolled empty state | the `Empty` owner exists |
| two-column grid of hand-rolled clickable cards | a list of manageable rows is `SettingsSection` + `SettingsRow`, not an object-picker grid |
| `hover:bg-accent/30 dark:hover:bg-accent` | hand-mixed alpha + a `dark:` override — the tell of starting from a raw color; the overlay ladder is scheme-agnostic |
| hand-rolled `Dialog` + two buttons for delete | `ConfirmDeleteDialog` owner |
| `class="text-muted-foreground"` injected onto a `<Button>` | the className red line |

## What changed

**List** — one titleless `SettingsSection` (the page title already names the concern) of `SettingsRow`s, each with a `Switch` and an `icon-sm` row menu. `Empty` inside that card (borderless, no icon tile, title + description + one guiding action), `InlineLoadingRow surface="card-row"` for loading, `ConfirmDeleteDialog` for delete. Box count drops from N cards to one card of rows.

**Rows carry the schedule facts.** The cron description used to disappear whenever a task had its own description — on a page whose subject is *when things run*. And the next fire time was only ever visible in the sidebar. Both now ride the row's single line (`description · every day at 09:00 · Next run Tomorrow 9:00 AM`), using the shared locale-aware `formatCalendarTime`. A disabled task promises no next run, so that clause drops.

**Sidebar card split out.** `schedule-list-item.vue` served both the sidebar panel and the settings tab through a `variant` prop — the same-shape-different-relationship fork that pulled the settings tab off-language. It becomes `components/sidebar/schedule-item.vue`, stating one shape, with its hover on the sidebar's rung of the neutral overlay ladder (the token `session-item.vue` and `folders-section.vue` already use). No visual change to the sidebar.

**Editor** — Run Limit joins the form column it lives in as a `FieldStack` instead of a squat `sm` side-by-side row; the placeholder carries the empty-value meaning so no help line repeats it.

## Deliberately dropped

Whole-row click-to-edit on the settings tab. Keeping it beside the row's `Switch` needs either a hand-rolled row (guard-flagged) or a new `SettingsRow` variant in the `packages/ui` submodule; Edit is the first item of the row menu. Say the word and I'll add it back via the stay-local stretched-overlay pattern `ui-owners` sanctions for exactly this shape.

## Shared session picker (commit 2)

`components/session-select/` composes the existing `SearchableSelectPopover` into the three things the sidebar list already gives you, so surfaces that must name an existing session stop hand-rolling their own list:

- **Folder groups** — unfiled sessions first, headerless until a folder exists (a bot with no folders reads as one plain list), then one group per live folder in the sidebar's order. A session bound to a folder that is gone keeps its own group rather than silently joining the unfiled bucket.
- **Search** over title, folder name and id.
- **Per-kind marks** — a yellow clock for schedule sessions, the agent mark for ACP, nothing for a plain model chat, with a reserved slot so labels stay aligned. Schedule wins over the ACP mark here, unlike the sidebar row: a picker that exists to separate schedule-owned sessions from ordinary chats should say so even when that session runs an agent.

The grouping is a pure function in `options.ts`, so those rules are covered by 10 unit tests instead of asserted by eye. A `modes` prop lets a caller list only the session modes it can accept.

`ModelSelect` also gains a `reasoningOptions` passthrough to `ModelOptions`, for callers whose effort tiers come from a runtime rather than the model's own capabilities.

> **Both land ahead of their first consumer.** They were written for the schedule editor's execution parameters, which are not on `main` — `main`'s `schedule` table has no `run_target`/`model_id`/`reasoning_effort` columns and `ScheduleSchedule` has no such fields. The picker rewrite that consumes them (`schedule-execution-fields.vue`) and the backend change that accepts an explicit "Off" effort (`internal/schedule/execution.go`) have no file to modify here; they are held back until that feature reaches `main`.

## Testing

- `pnpm build`, ESLint, `node scripts/check-ui-contract.mjs` — no new violations from these files (the guard's `recents.vue` px failure is pre-existing on `main`, from #976).
- `vitest`: 1063 pass (including 10 new `session-select` grouping tests). Three pre-existing failures on clean `main`, verified by re-running them with this branch stashed: `useMediaGallery.test.ts` (`localStorage.getItem is not a function`), `panel-preview.test.ts` (vue-i18n mock missing `createI18n`), and a flaky 15s timeout in `model-list-row.test.ts` that passes standalone.
- Raw-color / `dark:` / inline-style grep clean across the touched files; the two new i18n keys are in en, zh **and** ja.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
