### PR TITLE
perf(dev): rebuild and re-import the workspace image only when it changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,8 @@ Bot persona templates (not developer guides):
 | `mise run lint:fix` | Run all linters with auto-fix |
 | `mise run release` | Release new version (bumpp) |
 | `mise run install-socktainer` | Install socktainer (macOS container backend) |
-| `mise run dev:workspace-image` | Build and export the canonical workspace image for development |
+| `mise run dev:workspace-image` | Build and export the canonical workspace image for development (skipped when its inputs are unchanged) |
+| `mise run dev:workspace-image:rebuild` | Force a rebuild of the dev workspace image (new base image, refreshed apt packages) |
 
 ### Dev Component Wall & UI Contract Guard
 

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -131,6 +131,9 @@ services:
       CONFIG_PATH: /workspace/devenv/app.dev.toml
       GOFLAGS: -buildvcs=false
       TZ: "${MEMOH_DEV_TZ:-UTC}"
+      # Entrypoint only: which ref the workspace archive carries, so it can tell
+      # whether containerd already holds it and skip the ~1GB re-import.
+      MEMOH_DEV_WORKSPACE_IMAGE: "${MEMOH_DEV_WORKSPACE_IMAGE:-memohai/workspace:debian}"
       MEMOH_CONNECT_IT_BASE_URL: "${MEMOH_CONNECT_IT_BASE_URL:-}"
       MEMOH_CONNECT_IT_API_TOKEN: "${MEMOH_CONNECT_IT_API_TOKEN:-}"
       # Proxy: use host.docker.internal for localhost proxies, e.g.

--- a/devenv/server-entrypoint.sh
+++ b/devenv/server-entrypoint.sh
@@ -56,8 +56,30 @@ if [ ! -r "$workspace_image_archive" ]; then
   exit 1
 fi
 
-echo "Importing development workspace image..."
-ctr --namespace "${MEMOH_CONTAINERD_NAMESPACE:-default}" images import "$workspace_image_archive"
+containerd_namespace="${MEMOH_CONTAINERD_NAMESPACE:-default}"
+workspace_image_ref="${MEMOH_DEV_WORKSPACE_IMAGE:-memohai/workspace:debian}"
+# Importing the ~1GB archive takes far longer than the rest of this entrypoint,
+# and it happens on every container start. The stamp records which archive the
+# store already holds; it lives inside /var/lib/containerd so it is wiped by the
+# same `docker compose down -v` that wipes the image store it vouches for.
+workspace_image_stamp=/var/lib/containerd/.memoh-dev-workspace-image
+workspace_archive_key="$(stat -c '%s:%Y' "$workspace_image_archive")"
+
+workspace_image_present() {
+  ctr --namespace "$containerd_namespace" images ls -q 2>/dev/null | grep -Fqx \
+    -e "$workspace_image_ref" \
+    -e "docker.io/$workspace_image_ref" \
+    -e "docker.io/library/$workspace_image_ref"
+}
+
+if [ "$(cat "$workspace_image_stamp" 2>/dev/null || true)" = "$workspace_archive_key" ] \
+  && workspace_image_present; then
+  echo "Development workspace image is already imported (archive unchanged)."
+else
+  echo "Importing development workspace image..."
+  ctr --namespace "$containerd_namespace" images import "$workspace_image_archive"
+  printf '%s\n' "$workspace_archive_key" > "$workspace_image_stamp"
+fi
 echo "Development workspace image is ready."
 
 # Build bridge binary into runtime directory (first boot)

--- a/internal/agent/runtime/session/acceptance/testdata/compose.override.yml
+++ b/internal/agent/runtime/session/acceptance/testdata/compose.override.yml
@@ -41,6 +41,7 @@ services:
       CONFIG_PATH: /workspace/devenv/app.dev.toml
       GOFLAGS: -buildvcs=false
       TZ: "${MEMOH_DEV_TZ:-UTC}"
+      MEMOH_DEV_WORKSPACE_IMAGE: "${MEMOH_DEV_WORKSPACE_IMAGE:-memohai/workspace:debian}"
       NO_PROXY: "127.0.0.1,localhost,host.docker.internal,postgres,pgvector,server,server_b"
       no_proxy: "127.0.0.1,localhost,host.docker.internal,postgres,pgvector,server,server_b"
     volumes:

--- a/mise.toml
+++ b/mise.toml
@@ -318,7 +318,12 @@ description = "Build the canonical Debian workspace image"
 run = "docker build --target workspace -f docker/Dockerfile.workspace -t memohai/workspace:debian ."
 
 [tasks."dev:workspace-image"]
-description = "Build and export the canonical workspace image for nested dev containerd"
+description = "Build and export the canonical workspace image for nested dev containerd (skipped when its inputs are unchanged)"
+run = "scripts/prepare-dev-workspace-image.sh"
+
+[tasks."dev:workspace-image:rebuild"]
+description = "Force a rebuild of the dev workspace image (new base image, refreshed apt packages, ...)"
+env = { MEMOH_DEV_WORKSPACE_IMAGE_FORCE = "1" }
 run = "scripts/prepare-dev-workspace-image.sh"
 
 [tasks.lint]

--- a/scripts/prepare-dev-workspace-image.sh
+++ b/scripts/prepare-dev-workspace-image.sh
@@ -1,12 +1,112 @@
 #!/bin/sh
 set -eu
 
+# Builds the canonical workspace image and exports it as a tar the dev server's
+# nested containerd imports at boot.
+#
+# Both steps are expensive (the export alone writes ~1GB), and `mise run dev`
+# depends on this script, so it fingerprints everything the `workspace` target
+# of docker/Dockerfile.workspace actually reads and skips the whole thing when
+# that fingerprint still matches the exported archive. Set
+# MEMOH_DEV_WORKSPACE_IMAGE_FORCE=1 to rebuild anyway — needed when the change
+# is outside the fingerprint, e.g. a new debian:bookworm-slim base or newer
+# upstream packages pulled by apt.
+
 repo_root="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 image="${MEMOH_DEV_WORKSPACE_IMAGE:-memohai/workspace:debian}"
 cache_dir="${MEMOH_DEV_WORKSPACE_CACHE_DIR:-$repo_root/.cache/memoh}"
 archive="$cache_dir/workspace-debian.tar"
+stamp="$cache_dir/workspace-debian.stamp"
+tmp_dir="$cache_dir/tmp"
+force="${MEMOH_DEV_WORKSPACE_IMAGE_FORCE:-0}"
+
+# Build inputs of the `workspace` target, relative to the repo root. The
+# `bridge-builder` stage copies the whole repo but only feeds
+# `toolkit-acp-bridge-live`, so BuildKit never runs it for this target and the
+# Go sources are deliberately absent here.
+inputs="
+scripts/prepare-dev-workspace-image.sh
+docker/Dockerfile.workspace
+docker/workspace-contract.json
+docker/toolkit
+scripts/desktop-install.sh
+scripts/desktop-style.sh
+scripts/display-apply-style.sh
+scripts/display-prepare.sh
+Cargo.toml
+Cargo.lock
+crates
+"
+
+sha256_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | cut -d' ' -f1
+  else
+    openssl dgst -sha256 | sed 's/.*[= ]//'
+  fi
+}
+
+compute_fingerprint() {
+  cd "$repo_root"
+
+  for input in $inputs; do
+    if [ ! -e "$input" ]; then
+      echo "ERROR: build input is missing: $input" >&2
+      echo "       Update the input list in scripts/prepare-dev-workspace-image.sh." >&2
+      exit 1
+    fi
+  done
+
+  {
+    # Bump the schema when the hashed stream changes shape, so existing stamps
+    # are treated as stale instead of accidentally matching.
+    printf 'schema=1\nimage=%s\ntarget=workspace\n' "$image"
+
+    # shellcheck disable=SC2086 # $inputs is an intentional word-split path list.
+    find $inputs -type f ! -name '.DS_Store' -print | LC_ALL=C sort | while IFS= read -r file; do
+      if [ -x "$file" ]; then
+        printf 'file %s mode=x\n' "$file"
+      else
+        printf 'file %s mode=-\n' "$file"
+      fi
+      cat "$file"
+      printf '\n'
+    done
+  } | sha256_stdin
+}
+
+fingerprint="$(compute_fingerprint)"
+
+if [ "$force" = "0" ] &&
+  [ -s "$archive" ] &&
+  [ -f "$stamp" ] &&
+  [ "$(cat "$stamp")" = "$fingerprint" ]; then
+  echo "Development workspace image is up to date: $archive"
+  echo "  (set MEMOH_DEV_WORKSPACE_IMAGE_FORCE=1 to rebuild anyway)"
+  exit 0
+fi
 
 mkdir -p "$cache_dir"
+
+# Drop the stamp first: a build that dies halfway must not leave a stamp
+# vouching for the previous archive.
+rm -f "$stamp"
+
+# Temp files live in their own directory so a run interrupted mid-export
+# (docker save writes a ~1GB temp of its own next to the output) cannot leave
+# gigabytes of orphans in the cache directory.
+rm -rf "$tmp_dir"
+mkdir -p "$tmp_dir"
+# Orphans left by earlier revisions of this script, which exported through a
+# mktemp sibling of the archive.
+rm -f "$cache_dir"/workspace-debian.tar.?????? "$cache_dir"/.tmp-workspace-debian.tar.*
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
 
 echo "Building development workspace image: $image"
 docker build \
@@ -16,13 +116,10 @@ docker build \
   --tag "$image" \
   "$repo_root"
 
-archive_tmp="$(mktemp "$cache_dir/workspace-debian.tar.XXXXXX")"
-cleanup() {
-  rm -f "$archive_tmp"
-}
-trap cleanup EXIT INT TERM
+archive_tmp="$tmp_dir/workspace-debian.tar"
 
 echo "Exporting development workspace image: $archive"
 docker save --output "$archive_tmp" "$image"
 mv "$archive_tmp" "$archive"
-trap - EXIT INT TERM
+
+printf '%s\n' "$fingerprint" > "$stamp"


### PR DESCRIPTION
## Problem

`mise run dev` paid for the workspace image twice on every start, and both charges were unconditional:

1. **Host** — `scripts/prepare-dev-workspace-image.sh` always ran `docker build` plus a ~1GB `docker save` export, even when no build input had changed.
2. **Container** — `devenv/server-entrypoint.sh` always ran `ctr images import` on that archive, even when the dev server's nested containerd already held it.

The second one is the more expensive of the two and had gone unnoticed.

## Change

Both steps are now content-gated.

**Host: fingerprint the real build inputs.** The script hashes exactly what the `workspace` target of `docker/Dockerfile.workspace` reads — the Dockerfile, `docker/toolkit/`, `docker/workspace-contract.json`, the desktop/display scripts, `Cargo.toml`/`Cargo.lock`/`crates/`, plus the script itself and the image name — and stores it beside the archive. A matching fingerprint skips both the build and the export.

The `bridge-builder` stage does `COPY . .`, but it only feeds `toolkit-acp-bridge-live`, so BuildKit never runs it for this target. The Go sources are therefore deliberately *outside* the fingerprint, and editing them no longer triggers a workspace image rebuild.

**Container: stamp the import.** The entrypoint keys the import on the archive's `size:mtime` and stores that key under `/var/lib/containerd`, so the stamp and the image store it vouches for are wiped by the same `docker compose down -v` — no window where the stamp outlives the image. It additionally verifies the ref is really in the store before skipping, so a manual `ctr images rm` still re-imports. `MEMOH_DEV_WORKSPACE_IMAGE` is now passed into the server service so an overridden ref is matched correctly.

**Temp file hygiene.** Exports go through a dedicated `tmp/` subdirectory. `docker save` writes a ~1GB temp of its own next to its output, so an interrupted run previously left both that and the mktemp archive sitting in the cache directory (found ~875MB of orphans locally). Leftovers from the old layout are cleaned on the next build.

## Escape hatch

The fingerprint only covers repository content, so it cannot see a new `debian:bookworm-slim` base or newer upstream apt packages. For those:

```
mise run dev:workspace-image:rebuild     # or MEMOH_DEV_WORKSPACE_IMAGE_FORCE=1
```

Anyone adding a `COPY` source to the `workspace` target needs to add it to the `inputs` list in the script. A path that is renamed or deleted fails the script loudly rather than silently under-fingerprinting.

## Results

Measured locally with a warm Docker layer cache:

| | before | after |
|---|---|---|
| host `dev:workspace-image` | 20s | 0.075s |
| in-container `ctr images import` | 43s | 0s |

## Testing

- Host script: cold build, warm skip, input-touched rebuild, and forced rebuild, verified with both a stubbed and a real `docker`; missing-input path exits non-zero with a clear message.
- Entrypoint import block: run against a real containerd inside `memoh-dev-server`, covering four paths — cold store (imports), warm (skips), image removed by hand with the stamp intact (re-imports), and a stamp naming a different archive (re-imports).
- `docker compose config` validates for both the base dev stack and the Session Runtime acceptance overlay.

The full `mise run dev` stack was not brought up end to end; the entrypoint change was exercised in isolation against `memoh-dev-server` as described above.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
