### PR TITLE
feat(memory): carry message source refs through formation and search

### DIFF
--- a/cmd/internal/core/providers.go
+++ b/cmd/internal/core/providers.go
@@ -696,6 +696,7 @@ func provideToolProviders(log *slog.Logger, channelRuntime channel.Runtime, regi
 		assetResolver = &mediaAssetResolverAdapter{media: mediaService}
 	}
 	channelMessaging := channelmessagingadapter.New(channelRuntime, registry, assetResolver)
+	historySessions := channelthreadadapter.NewLister(sessionService, routeService)
 	fedSource := mcpfederation.NewSource(log, fedGateway, mcpConnService, mcpfederation.WithReservedToolName(agenttools.IsBuiltInToolName))
 	return []agenttools.ToolProvider{
 		agenttools.NewAskUserProvider(log),
@@ -704,7 +705,7 @@ func provideToolProviders(log *slog.Logger, channelRuntime channel.Runtime, regi
 		agenttools.NewScheduleProvider(log, scheduleService),
 		agenttools.NewWorkdirProvider(log, workdirService),
 		agenttools.NewACPAgentsProvider(log, &acpRuntimePoolAdapter{pool: acpPool}, queries),
-		agenttools.NewMemoryProvider(log, memoryRegistry, settingsService),
+		agenttools.NewMemoryProvider(log, memoryRegistry, settingsService, historySessions),
 		agenttools.NewWebProvider(log, settingsService, searchProviderService),
 		agenttools.NewContainerProvider(log, manager, bgManager, config.DefaultDataMount, hookService),
 		agenttools.NewBackgroundProvider(log, bgManager),
@@ -719,7 +720,7 @@ func provideToolProviders(log *slog.Logger, channelRuntime channel.Runtime, regi
 		agenttools.NewVideoGenProvider(log, settingsService, videoService, bgManager, manager, config.DefaultDataMount),
 		agenttools.NewFederationProvider(log, connectorSource),
 		agenttools.NewFederationProvider(log, fedSource),
-		agenttools.NewHistoryProvider(log, channelthreadadapter.NewLister(sessionService, routeService), messageService, queries),
+		agenttools.NewHistoryProvider(log, historySessions, messageService, queries),
 	}
 }
 

--- a/db/postgres/queries/memory_wiki.sql
+++ b/db/postgres/queries/memory_wiki.sql
@@ -12,7 +12,17 @@ ON CONFLICT (team_id, id) DO UPDATE SET
   subject = EXCLUDED.subject,
   confidence = EXCLUDED.confidence,
   metadata = EXCLUDED.metadata,
-  source_message_ids = EXCLUDED.source_message_ids,
+  source_message_ids = (
+    SELECT COALESCE(jsonb_agg(ref.value ORDER BY ref.first_seen), '[]'::jsonb)
+    FROM (
+      SELECT value, min(ordinality) AS first_seen
+      FROM jsonb_array_elements(
+        COALESCE(memory_nodes.source_message_ids, '[]'::jsonb)
+        || COALESCE(EXCLUDED.source_message_ids, '[]'::jsonb)
+      ) WITH ORDINALITY AS combined(value, ordinality)
+      GROUP BY value
+    ) AS ref
+  ),
   profile_ref = EXCLUDED.profile_ref,
   topic = EXCLUDED.topic,
   expires_at = EXCLUDED.expires_at,

--- a/db/postgres/queries/messages.sql
+++ b/db/postgres/queries/messages.sql
@@ -2580,6 +2580,7 @@ LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.t
 LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
 WHERE m.team_id = public.memoh_current_team_id()
   AND m.bot_id = sqlc.arg(bot_id)
+  AND m.session_id = ANY(sqlc.arg(session_ids)::uuid[])
   AND (sqlc.narg(session_id)::uuid IS NULL OR m.session_id = sqlc.narg(session_id)::uuid)
   AND (sqlc.narg(contact_id)::uuid IS NULL OR m.sender_channel_identity_id = sqlc.narg(contact_id)::uuid)
   AND (sqlc.narg(start_time)::timestamptz IS NULL OR m.created_at >= sqlc.narg(start_time)::timestamptz)

--- a/internal/agent/application/service_acp.go
+++ b/internal/agent/application/service_acp.go
@@ -820,14 +820,14 @@ func (s *Service) persistACPRound(ctx context.Context, req ChatRequest, agentID,
 		}
 	}
 	skipMemory := promptErr != nil || req.UserMessagePersisted || req.SkipMemoryExtraction
-	err := s.storeRoundWithOptions(ctx, req, round, "", storeRoundOptions{
+	persisted, err := s.storeRoundWithOptionsResult(ctx, req, round, "", storeRoundOptions{
 		SkipMemory:              skipMemory,
 		AllowEmptyAssistantText: true,
 		MessageMetadataByIndex:  metadataByIndex,
 		RequireCompletePersist:  true,
 	})
 	if err == nil && promptErr == nil && req.UserMessagePersisted && !req.SkipMemoryExtraction {
-		go s.storeMemory(context.WithoutCancel(ctx), req, round)
+		go s.storeMemory(context.WithoutCancel(ctx), req, round, roundSourceRefs(req, persisted))
 	}
 	return err
 }

--- a/internal/agent/application/service_memory.go
+++ b/internal/agent/application/service_memory.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	messagepkg "github.com/memohai/memoh/internal/chat/message"
 	"github.com/memohai/memoh/internal/hooks"
 	memprovider "github.com/memohai/memoh/internal/memory/adapters"
 )
@@ -213,7 +214,7 @@ func (s *Service) effectiveMemorySearchTimeout() time.Duration {
 	return s.memorySearchTimeout
 }
 
-func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []ModelMessage) {
+func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []ModelMessage, sourceRefs []string) {
 	botID := strings.TrimSpace(req.BotID)
 	if botID == "" {
 		return
@@ -247,6 +248,7 @@ func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []M
 		ChannelIdentityID: strings.TrimSpace(req.SourceChannelIdentityID),
 		DisplayName:       s.resolveDisplayName(ctx, req),
 		TimezoneLocation:  tzLoc,
+		SourceMessageIDs:  sourceRefs,
 	}); err != nil {
 		s.logger.Warn("memory provider OnAfterChat failed", slog.String("bot_id", botID), slog.Any("error", err))
 		return
@@ -265,6 +267,25 @@ func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []M
 	}); err != nil {
 		s.logHookWarn(hooks.EventAfterMemoryWrite, botID, req.ThreadID, err)
 	}
+}
+
+func roundSourceRefs(req ChatRequest, persisted []messagepkg.Message) []string {
+	refs := make([]string, 0, len(persisted)+1)
+	if req.UserMessagePersisted || req.ReusePersistedUserMessage {
+		if ref := memprovider.EncodeSourceRef(req.ThreadID, req.PersistedUserMessageID); ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+	for _, msg := range persisted {
+		sessionID := msg.SessionID
+		if strings.TrimSpace(sessionID) == "" {
+			sessionID = req.ThreadID
+		}
+		if ref := memprovider.EncodeSourceRef(sessionID, msg.ID); ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
 }
 
 func toProviderMessages(messages []ModelMessage) []memprovider.Message {

--- a/internal/agent/application/service_store.go
+++ b/internal/agent/application/service_store.go
@@ -72,7 +72,7 @@ func (s *Service) storeRoundWithOptionsResult(ctx context.Context, req ChatReque
 		return persisted, fmt.Errorf("persisted %d of %d messages", len(persisted), len(filtered))
 	}
 	if !opts.SkipMemory && !req.SkipMemoryExtraction {
-		go s.storeMemory(context.WithoutCancel(ctx), req, filtered)
+		go s.storeMemory(context.WithoutCancel(ctx), req, filtered, roundSourceRefs(req, persisted))
 	}
 
 	return persisted, nil

--- a/internal/agent/application/service_store_refs_test.go
+++ b/internal/agent/application/service_store_refs_test.go
@@ -1,0 +1,95 @@
+package application
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	messagepkg "github.com/memohai/memoh/internal/chat/message"
+	memprovider "github.com/memohai/memoh/internal/memory/adapters"
+	"github.com/memohai/memoh/internal/settings"
+)
+
+func TestRoundSourceRefs(t *testing.T) {
+	t.Parallel()
+
+	persisted := []messagepkg.Message{
+		{ID: "msg-a", SessionID: "sess-1"},
+		{ID: "msg-b"},
+		{ID: ""},
+	}
+
+	got := roundSourceRefs(ChatRequest{
+		ThreadID:               "sess-1",
+		UserMessagePersisted:   true,
+		PersistedUserMessageID: "msg-user",
+	}, persisted)
+	want := []string{"sess-1/msg-user", "sess-1/msg-a", "sess-1/msg-b"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("roundSourceRefs = %v, want %v", got, want)
+	}
+
+	got = roundSourceRefs(ChatRequest{ThreadID: "sess-1"}, persisted[:1])
+	want = []string{"sess-1/msg-a"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("roundSourceRefs without persisted user message = %v, want %v", got, want)
+	}
+
+	if got := roundSourceRefs(ChatRequest{ThreadID: "sess-1"}, nil); len(got) != 0 {
+		t.Fatalf("roundSourceRefs with no messages = %v, want empty", got)
+	}
+}
+
+type refsRecordingMessageService struct {
+	recordingMessageService
+	persistCount int
+}
+
+func (s *refsRecordingMessageService) Persist(ctx context.Context, input messagepkg.PersistInput) (messagepkg.Message, error) {
+	msg, err := s.recordingMessageService.Persist(ctx, input)
+	if err != nil {
+		return msg, err
+	}
+	s.persistCount++
+	msg.ID = fmt.Sprintf("msg-%d", s.persistCount)
+	return msg, nil
+}
+
+func TestStoreRoundPassesSourceRefsToMemory(t *testing.T) {
+	t.Parallel()
+
+	messages := &refsRecordingMessageService{}
+	memory := &storeRoundMemoryProvider{afterChat: make(chan memprovider.AfterChatRequest, 1)}
+	registry := memprovider.NewRegistry(slog.New(slog.DiscardHandler))
+	registry.Register(storeRoundMemoryProviderID, memory)
+	resolver := &Service{
+		messageService:  messages,
+		memoryRegistry:  registry,
+		settingsService: settings.NewService(slog.New(slog.DiscardHandler), &storeRoundSettingsQueries{}, nil, nil),
+		logger:          slog.New(slog.DiscardHandler),
+	}
+
+	if err := resolver.storeRound(context.Background(), ChatRequest{
+		BotID:    storeRoundBotID,
+		ThreadID: "session-1",
+		Query:    "hello",
+	}, []ModelMessage{
+		{Role: "user", Content: newTextContent("hello")},
+		{Role: "assistant", Content: newTextContent("hi there")},
+	}, "model-1"); err != nil {
+		t.Fatalf("storeRound error: %v", err)
+	}
+
+	select {
+	case got := <-memory.afterChat:
+		want := []string{"session-1/msg-1", "session-1/msg-2"}
+		if !slices.Equal(got.SourceMessageIDs, want) {
+			t.Fatalf("AfterChatRequest.SourceMessageIDs = %v, want %v", got.SourceMessageIDs, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("memory provider was not called")
+	}
+}

--- a/internal/agent/application/step_commit.go
+++ b/internal/agent/application/step_commit.go
@@ -168,7 +168,7 @@ func (c *agentStepCommitter) finish(ctx context.Context, inputTokens int) error 
 		c.service.LinkOutboundAssets(ctx, c.req.BotID, c.req.ThreadID, outboundAssetRefsToMessageRefs(c.req.OutboundAssetCollector()))
 	}
 	if !c.req.SkipMemoryExtraction {
-		go c.service.storeMemory(ctx, c.req, messages)
+		go c.service.storeMemory(ctx, c.req, messages, roundSourceRefs(c.req, persisted))
 	}
 	if inputTokens > 0 {
 		go c.service.maybeCompact(ctx, c.req, c.rc, inputTokens)

--- a/internal/agent/tool/history.go
+++ b/internal/agent/tool/history.go
@@ -28,8 +28,6 @@ type SessionLister interface {
 
 // HistoryMessageReader is the minimal interface for reading persisted messages.
 type HistoryMessageReader interface {
-	ListLatest(ctx context.Context, botID string, limit int32) ([]messagepkg.Message, error)
-	ListBefore(ctx context.Context, botID string, before time.Time, limit int32) ([]messagepkg.Message, error)
 	ListLatestBySession(ctx context.Context, sessionID string, limit int32) ([]messagepkg.Message, error)
 	ListBeforeBySession(ctx context.Context, sessionID string, before time.Time, limit int32) ([]messagepkg.Message, error)
 }
@@ -59,7 +57,7 @@ func (*HistoryProvider) Usage(_ context.Context, _ SessionContext, available Ava
 	listSessionsRef := ""
 	if ref, ok := available.Ref(ToolListSessions()); ok {
 		listSessionsRef = ref
-		parts = append(parts, ref+": List all chat sessions with their bound contact/route info. Filter by `type` (chat/heartbeat/schedule) or `platform`.")
+		parts = append(parts, ref+": List accessible chat sessions with their bound contact/route info. Filter by `type` (chat/heartbeat/schedule) or `platform`.")
 	}
 	if ref, ok := available.Ref(ToolGetMessages()); ok {
 		parts = append(parts, ref+": Get recent messages from the current or selected session.")
@@ -83,7 +81,7 @@ func (p *HistoryProvider) Tools(_ context.Context, sess SessionContext) ([]sdk.T
 		s := sess
 		tools = append(tools, sdk.Tool{
 			Name:        ToolListSessions().String(),
-			Description: "List all chat sessions for the current bot with their bound contact/route information.",
+			Description: "List chat sessions accessible from the current user or channel route, with their bound contact/route information.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -142,7 +140,7 @@ func (p *HistoryProvider) Tools(_ context.Context, sess SessionContext) ([]sdk.T
 		s := sess
 		tools = append(tools, sdk.Tool{
 			Name:        ToolSearchMessages().String(),
-			Description: "Search message history across all sessions. Supports filtering by time range, keyword, session, contact, and role. All parameters are optional. If start_time is not provided, only the last 7 days are searched.",
+			Description: "Search message history across sessions accessible from the current user or channel route. Supports filtering by time range, keyword, session, contact, and role. All parameters are optional. If start_time is not provided, only the last 7 days are searched.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -197,7 +195,7 @@ func (p *HistoryProvider) execListSessions(ctx context.Context, sess SessionCont
 		return nil, errors.New("bot_id is required")
 	}
 
-	sessions, err := p.sessions.ListByBot(ctx, botID)
+	sessions, _, err := visibleHistorySessions(ctx, p.sessions, sess)
 	if err != nil {
 		return nil, err
 	}
@@ -280,8 +278,11 @@ func (p *HistoryProvider) execGetMessages(ctx context.Context, sess SessionConte
 	if sessionID == "" {
 		sessionID = strings.TrimSpace(sess.SessionID)
 	}
+	if sessionID == "" {
+		return nil, errors.New("session_id is required when there is no current session")
+	}
 	if sessionID != "" && sessionID != strings.TrimSpace(sess.SessionID) {
-		if err := p.ensureSessionBelongsToBot(ctx, botID, sessionID); err != nil {
+		if err := p.ensureSessionVisible(ctx, sess, sessionID); err != nil {
 			return nil, err
 		}
 	}
@@ -296,16 +297,9 @@ func (p *HistoryProvider) execGetMessages(ctx context.Context, sess SessionConte
 		if err != nil {
 			return nil, err
 		}
-		if sessionID != "" {
-			messages, err = p.messages.ListBeforeBySession(ctx, sessionID, before, limit)
-		} else {
-			messages, err = p.messages.ListBefore(ctx, botID, before, limit)
-		}
-	} else if sessionID != "" {
-		messages, err = p.messages.ListLatestBySession(ctx, sessionID, limit)
-		reverseHistoryMessages(messages)
+		messages, err = p.messages.ListBeforeBySession(ctx, sessionID, before, limit)
 	} else {
-		messages, err = p.messages.ListLatest(ctx, botID, limit)
+		messages, err = p.messages.ListLatestBySession(ctx, sessionID, limit)
 		reverseHistoryMessages(messages)
 	}
 	if err != nil {
@@ -323,29 +317,22 @@ func (p *HistoryProvider) execGetMessages(ctx context.Context, sess SessionConte
 		"count":    len(results),
 		"messages": results,
 	}
-	if sessionID != "" {
-		out["session_id"] = sessionID
-	}
+	out["session_id"] = sessionID
 	if !before.IsZero() {
 		out["before"] = sess.FormatTime(before)
 	}
 	return out, nil
 }
 
-func (p *HistoryProvider) ensureSessionBelongsToBot(ctx context.Context, botID, sessionID string) error {
-	if p.sessions == nil {
-		return errors.New("session lookup is not configured")
-	}
-	sessions, err := p.sessions.ListByBot(ctx, botID)
+func (p *HistoryProvider) ensureSessionVisible(ctx context.Context, sess SessionContext, sessionID string) error {
+	_, allowed, err := visibleHistorySessions(ctx, p.sessions, sess)
 	if err != nil {
 		return err
 	}
-	for _, item := range sessions {
-		if item.ID == sessionID {
-			return nil
-		}
+	if historySessionVisible(allowed, sessionID) {
+		return nil
 	}
-	return errors.New("session_id does not belong to the current bot")
+	return errors.New("session_id is not accessible from the current context")
 }
 
 // ---------------------------------------------------------------------------
@@ -368,13 +355,38 @@ func (p *HistoryProvider) execSearchMessages(ctx context.Context, sess SessionCo
 		limit = int32(v) //nolint:gosec // bounds-checked above
 	}
 
+	_, allowed, err := visibleHistorySessions(ctx, p.sessions, sess)
+	if err != nil {
+		return nil, err
+	}
+	allowedSessionIDs := make([]pgtype.UUID, 0, len(allowed))
+	for sessionID := range allowed {
+		parsed, parseErr := dbpkg.ParseUUID(sessionID)
+		if parseErr == nil {
+			allowedSessionIDs = append(allowedSessionIDs, parsed)
+		}
+	}
+	if len(allowedSessionIDs) == 0 {
+		return map[string]any{
+			"ok": true, "bot_id": botID, "count": 0, "messages": []map[string]any{},
+		}, nil
+	}
+
 	params := sqlc.SearchMessagesParams{
-		BotID:    pgBotID,
-		MaxCount: limit,
+		BotID:      pgBotID,
+		SessionIds: allowedSessionIDs,
+		MaxCount:   limit,
 	}
 
 	if v := StringArg(args, "session_id"); v != "" {
-		params.SessionID = dbpkg.ParseUUIDOrEmpty(v)
+		if !historySessionVisible(allowed, v) {
+			return nil, errors.New("session_id is not accessible from the current context")
+		}
+		parsed, parseErr := dbpkg.ParseUUID(v)
+		if parseErr != nil {
+			return nil, errors.New("invalid session_id")
+		}
+		params.SessionID = parsed
 	}
 	if v := StringArg(args, "contact_id"); v != "" {
 		params.ContactID = dbpkg.ParseUUIDOrEmpty(v)

--- a/internal/agent/tool/history_test.go
+++ b/internal/agent/tool/history_test.go
@@ -27,15 +27,6 @@ type fakeHistoryMessageReader struct {
 	beforeMessages  []messagepkg.Message
 }
 
-func (f *fakeHistoryMessageReader) ListLatest(_ context.Context, _ string, _ int32) ([]messagepkg.Message, error) {
-	return f.latestMessages, nil
-}
-
-func (f *fakeHistoryMessageReader) ListBefore(_ context.Context, _ string, before time.Time, _ int32) ([]messagepkg.Message, error) {
-	f.before = before
-	return f.beforeMessages, nil
-}
-
 func (f *fakeHistoryMessageReader) ListLatestBySession(_ context.Context, sessionID string, _ int32) ([]messagepkg.Message, error) {
 	f.latestSessionID = sessionID
 	return f.latestMessages, nil
@@ -79,6 +70,16 @@ func TestHistoryProviderGetMessagesDefaultsToCurrentSession(t *testing.T) {
 	}
 }
 
+func TestHistoryProviderGetMessagesRejectsMissingSessionScope(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeHistoryMessageReader{}
+	provider := NewHistoryProvider(nil, nil, reader, nil)
+	if _, err := provider.execGetMessages(context.Background(), SessionContext{BotID: "bot-1"}, nil); err == nil {
+		t.Fatal("execGetMessages() error = nil, want missing session scope error")
+	}
+}
+
 func TestHistoryProviderGetMessagesBeforeUsesRequestedSession(t *testing.T) {
 	t.Parallel()
 
@@ -88,12 +89,13 @@ func TestHistoryProviderGetMessagesBeforeUsesRequestedSession(t *testing.T) {
 		},
 	}
 	provider := NewHistoryProvider(nil, fakeHistorySessionLister{
-		sessions: []session.Thread{{ID: "session-other", BotID: "bot-1"}},
+		sessions: []session.Thread{{ID: "session-other", BotID: "bot-1", CreatedByUserID: "user-1"}},
 	}, reader, nil)
 
 	got, err := provider.execGetMessages(context.Background(), SessionContext{
 		BotID:     "bot-1",
 		SessionID: "session-current",
+		UserID:    "user-1",
 	}, map[string]any{
 		"session_id": "session-other",
 		"before":     "2026-06-14T09:00:00Z",
@@ -118,12 +120,15 @@ func TestHistoryProviderGetMessagesBeforeUsesRequestedSession(t *testing.T) {
 	}
 }
 
-func TestHistoryProviderGetMessagesRejectsSessionOutsideBot(t *testing.T) {
+func TestHistoryProviderGetMessagesRejectsInaccessibleSessionOnSameBot(t *testing.T) {
 	t.Parallel()
 
 	reader := &fakeHistoryMessageReader{}
 	provider := NewHistoryProvider(nil, fakeHistorySessionLister{
-		sessions: []session.Thread{{ID: "session-current", BotID: "bot-1"}},
+		sessions: []session.Thread{
+			{ID: "session-current", BotID: "bot-1", RouteID: "route-alice"},
+			{ID: "session-other", BotID: "bot-1", RouteID: "route-bob"},
+		},
 	}, reader, nil)
 
 	_, err := provider.execGetMessages(context.Background(), SessionContext{
@@ -133,7 +138,78 @@ func TestHistoryProviderGetMessagesRejectsSessionOutsideBot(t *testing.T) {
 		"session_id": "session-other",
 	})
 	if err == nil {
-		t.Fatal("execGetMessages() error = nil, want session ownership error")
+		t.Fatal("execGetMessages() error = nil, want session visibility error")
+	}
+}
+
+func TestHistoryProviderGetMessagesAllowsSessionOnSameRoute(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeHistoryMessageReader{}
+	provider := NewHistoryProvider(nil, fakeHistorySessionLister{
+		sessions: []session.Thread{
+			{ID: "session-current", BotID: "bot-1", RouteID: "route-private"},
+			{ID: "session-previous", BotID: "bot-1", RouteID: "route-private"},
+		},
+	}, reader, nil)
+
+	if _, err := provider.execGetMessages(context.Background(), SessionContext{
+		BotID: "bot-1", SessionID: "session-current",
+	}, map[string]any{"session_id": "session-previous"}); err != nil {
+		t.Fatalf("execGetMessages() error = %v, want same-route session to be visible", err)
+	}
+	if reader.latestSessionID != "session-previous" {
+		t.Fatalf("latest session id = %q, want session-previous", reader.latestSessionID)
+	}
+}
+
+func TestHistoryProviderListSessionsFiltersOtherUsersAndRoutes(t *testing.T) {
+	t.Parallel()
+
+	provider := NewHistoryProvider(nil, fakeHistorySessionLister{
+		sessions: []session.Thread{
+			{ID: "session-current", BotID: "bot-1", RouteID: "route-current"},
+			{ID: "session-same-route", BotID: "bot-1", RouteID: "route-current"},
+			{ID: "session-same-user", BotID: "bot-1", CreatedByUserID: "user-1"},
+			{ID: "session-bob", BotID: "bot-1", RouteID: "route-bob", CreatedByUserID: "user-2"},
+		},
+	}, nil, nil)
+
+	got, err := provider.execListSessions(context.Background(), SessionContext{
+		BotID: "bot-1", SessionID: "session-current", UserID: "user-1",
+	}, nil)
+	if err != nil {
+		t.Fatalf("execListSessions() error = %v", err)
+	}
+	items := got.(map[string]any)["sessions"].([]map[string]any)
+	if len(items) != 3 {
+		t.Fatalf("visible sessions = %v, want current, same route, and same user", items)
+	}
+	for _, item := range items {
+		if item["session_id"] == "session-bob" {
+			t.Fatalf("inaccessible session leaked: %v", item)
+		}
+	}
+}
+
+func TestHistoryVisibilityUsesPersistedCurrentSessionOwner(t *testing.T) {
+	t.Parallel()
+
+	_, allowed, err := visibleHistorySessions(context.Background(), fakeHistorySessionLister{
+		sessions: []session.Thread{
+			{ID: "session-current", BotID: "bot-1", CreatedByUserID: "user-owner"},
+			{ID: "session-owner", BotID: "bot-1", CreatedByUserID: "user-owner"},
+			{ID: "session-context", BotID: "bot-1", CreatedByUserID: "user-context"},
+		},
+	}, SessionContext{BotID: "bot-1", SessionID: "session-current", UserID: "user-context"})
+	if err != nil {
+		t.Fatalf("visibleHistorySessions() error = %v", err)
+	}
+	if !historySessionVisible(allowed, "session-owner") {
+		t.Fatal("persisted current-session owner should define the user scope")
+	}
+	if historySessionVisible(allowed, "session-context") {
+		t.Fatal("request context must not override the persisted current-session owner")
 	}
 }
 

--- a/internal/agent/tool/history_visibility.go
+++ b/internal/agent/tool/history_visibility.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"context"
+	"strings"
+
+	session "github.com/memohai/memoh/internal/chat/thread"
+)
+
+// visibleHistorySessions resolves the history scope of one tool invocation.
+// Memory facts are bot-shared, but the transcripts that produced them are not:
+// a caller may read its current session, another thread on the same external
+// route, or another thread created by the same authenticated user.
+func visibleHistorySessions(ctx context.Context, lister SessionLister, sess SessionContext) ([]session.Thread, map[string]struct{}, error) {
+	allowed := make(map[string]struct{})
+	currentSessionID := strings.TrimSpace(sess.SessionID)
+	if currentSessionID != "" {
+		allowed[currentSessionID] = struct{}{}
+	}
+	if lister == nil {
+		return nil, allowed, nil
+	}
+
+	threads, err := lister.ListByBot(ctx, strings.TrimSpace(sess.BotID))
+	if err != nil {
+		return nil, allowed, err
+	}
+
+	currentRouteID := ""
+	currentUserID := strings.TrimSpace(sess.UserID)
+	for _, thread := range threads {
+		if thread.ID == currentSessionID {
+			currentRouteID = strings.TrimSpace(thread.RouteID)
+			if persistedUserID := strings.TrimSpace(thread.CreatedByUserID); persistedUserID != "" {
+				currentUserID = persistedUserID
+			}
+			break
+		}
+	}
+	visible := make([]session.Thread, 0, len(threads))
+	for _, thread := range threads {
+		threadID := strings.TrimSpace(thread.ID)
+		if threadID == "" {
+			continue
+		}
+		sameSession := threadID == currentSessionID
+		sameRoute := currentRouteID != "" && strings.TrimSpace(thread.RouteID) == currentRouteID
+		sameUser := currentUserID != "" && strings.TrimSpace(thread.CreatedByUserID) == currentUserID
+		if !sameSession && !sameRoute && !sameUser {
+			continue
+		}
+		visible = append(visible, thread)
+		allowed[threadID] = struct{}{}
+	}
+	return visible, allowed, nil
+}
+
+func historySessionVisible(allowed map[string]struct{}, sessionID string) bool {
+	_, ok := allowed[strings.TrimSpace(sessionID)]
+	return ok
+}

--- a/internal/agent/tool/memory.go
+++ b/internal/agent/tool/memory.go
@@ -21,16 +21,18 @@ type MemorySettingsReader interface {
 type MemoryProvider struct {
 	registry *memprovider.Registry
 	settings MemorySettingsReader
+	sessions SessionLister
 	logger   *slog.Logger
 }
 
-func NewMemoryProvider(log *slog.Logger, registry *memprovider.Registry, settingsSvc MemorySettingsReader) *MemoryProvider {
+func NewMemoryProvider(log *slog.Logger, registry *memprovider.Registry, settingsSvc MemorySettingsReader, sessions SessionLister) *MemoryProvider {
 	if log == nil {
 		log = slog.Default()
 	}
 	return &MemoryProvider{
 		registry: registry,
 		settings: settingsSvc,
+		sessions: sessions,
 		logger:   log.With(slog.String("tool", "memory")),
 	}
 }
@@ -71,11 +73,78 @@ func (p *MemoryProvider) Tools(ctx context.Context, session SessionContext) ([]s
 				if err != nil {
 					return nil, err
 				}
-				return normalizeToolResult(result), nil
+				output := normalizeToolResult(result)
+				if desc.Name == ToolSearchMemory().String() {
+					output = p.filterSourceRefs(ctx.Context, session, output)
+				}
+				return output, nil
 			},
 		})
 	}
 	return tools, nil
+}
+
+func (p *MemoryProvider) filterSourceRefs(ctx context.Context, session SessionContext, output any) any {
+	_, allowed, err := visibleHistorySessions(ctx, p.sessions, session)
+	if err != nil {
+		p.logger.Warn("memory source ref scope lookup failed", slog.Any("error", err))
+	}
+	return filterSourceRefsValue(output, allowed)
+}
+
+func filterSourceRefsValue(value any, allowed map[string]struct{}) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, item := range typed {
+			if key == "source_refs" {
+				if filtered := visibleSourceRefs(item, allowed); len(filtered) > 0 {
+					typed[key] = filtered
+				} else {
+					delete(typed, key)
+				}
+				continue
+			}
+			typed[key] = filterSourceRefsValue(item, allowed)
+		}
+		return typed
+	case []map[string]any:
+		for i := range typed {
+			typed[i] = filterSourceRefsValue(typed[i], allowed).(map[string]any)
+		}
+		return typed
+	case []any:
+		for i := range typed {
+			typed[i] = filterSourceRefsValue(typed[i], allowed)
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func visibleSourceRefs(value any, allowed map[string]struct{}) []map[string]any {
+	var refs []map[string]any
+	switch typed := value.(type) {
+	case []map[string]any:
+		refs = typed
+	case []any:
+		refs = make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			if ref, ok := item.(map[string]any); ok {
+				refs = append(refs, ref)
+			}
+		}
+	default:
+		return nil
+	}
+	filtered := make([]map[string]any, 0, len(refs))
+	for _, ref := range refs {
+		sessionID, _ := ref["session_id"].(string)
+		if historySessionVisible(allowed, sessionID) {
+			filtered = append(filtered, ref)
+		}
+	}
+	return filtered
 }
 
 func (p *MemoryProvider) resolveProvider(ctx context.Context, botID string) memprovider.Provider {

--- a/internal/agent/tool/memory_source_refs_test.go
+++ b/internal/agent/tool/memory_source_refs_test.go
@@ -1,0 +1,89 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	session "github.com/memohai/memoh/internal/chat/thread"
+)
+
+func TestMemoryProviderFiltersSourceRefsByHistoryVisibility(t *testing.T) {
+	t.Parallel()
+
+	provider := NewMemoryProvider(nil, nil, nil, fakeHistorySessionLister{
+		sessions: []session.Thread{
+			{ID: "session-current", BotID: "bot-1", RouteID: "route-current"},
+			{ID: "session-same-route", BotID: "bot-1", RouteID: "route-current"},
+			{ID: "session-same-user", BotID: "bot-1", CreatedByUserID: "user-1"},
+			{ID: "session-bob", BotID: "bot-1", RouteID: "route-bob", CreatedByUserID: "user-2"},
+		},
+	})
+	output := map[string]any{
+		"results": []map[string]any{{
+			"memory": "shared fact",
+			"source_refs": []map[string]any{
+				{"session_id": "session-current", "message_id": "message-current"},
+				{"session_id": "session-same-route", "message_id": "message-route"},
+				{"session_id": "session-same-user", "message_id": "message-user"},
+				{"session_id": "session-bob", "message_id": "message-bob"},
+				{"message_id": "legacy-unscoped"},
+			},
+		}},
+	}
+
+	filtered := provider.filterSourceRefs(context.Background(), SessionContext{
+		BotID: "bot-1", SessionID: "session-current", UserID: "user-1",
+	}, output).(map[string]any)
+	refs := filtered["results"].([]map[string]any)[0]["source_refs"].([]map[string]any)
+	if len(refs) != 3 {
+		t.Fatalf("source refs = %v, want only current, same-route, and same-user refs", refs)
+	}
+	for _, ref := range refs {
+		if ref["session_id"] == "session-bob" || ref["message_id"] == "legacy-unscoped" {
+			t.Fatalf("inaccessible source ref leaked: %v", ref)
+		}
+	}
+}
+
+func TestMemoryProviderOmitsSourceRefsWithoutScopeLister(t *testing.T) {
+	t.Parallel()
+
+	provider := NewMemoryProvider(nil, nil, nil, nil)
+	output := map[string]any{
+		"results": []map[string]any{{
+			"memory":      "shared fact",
+			"source_refs": []map[string]any{{"session_id": "session-other", "message_id": "message-other"}},
+		}},
+	}
+
+	filtered := provider.filterSourceRefs(context.Background(), SessionContext{
+		BotID: "bot-1", SessionID: "session-current",
+	}, output).(map[string]any)
+	if _, ok := filtered["results"].([]map[string]any)[0]["source_refs"]; ok {
+		t.Fatalf("unverified source refs must be omitted: %v", filtered)
+	}
+}
+
+func TestMemoryProviderFiltersJSONDecodedSourceRefs(t *testing.T) {
+	t.Parallel()
+
+	provider := NewMemoryProvider(nil, nil, nil, nil)
+	output := map[string]any{
+		"results": []any{map[string]any{
+			"memory": "shared fact",
+			"source_refs": []any{
+				map[string]any{"session_id": "session-current", "message_id": "message-current"},
+				map[string]any{"session_id": "session-other", "message_id": "message-other"},
+			},
+		}},
+	}
+
+	filtered := provider.filterSourceRefs(context.Background(), SessionContext{
+		BotID: "bot-1", SessionID: "session-current",
+	}, output).(map[string]any)
+	result := filtered["results"].([]any)[0].(map[string]any)
+	refs := result["source_refs"].([]map[string]any)
+	if len(refs) != 1 || refs[0]["message_id"] != "message-current" {
+		t.Fatalf("JSON-decoded source refs were not scoped: %v", refs)
+	}
+}

--- a/internal/agent/tool/usage_test.go
+++ b/internal/agent/tool/usage_test.go
@@ -728,7 +728,7 @@ func TestSpeakToolPromptMetadataGatesCurrentConversationTarget(t *testing.T) {
 func TestMemoryProviderUsageGatesSearchMemory(t *testing.T) {
 	t.Parallel()
 
-	provider := NewMemoryProvider(nil, nil, nil)
+	provider := NewMemoryProvider(nil, nil, nil, nil)
 	if got := provider.Usage(context.Background(), SessionContext{}, AvailableTools{}); got != "" {
 		t.Fatalf("Usage without search_memory = %q, want empty", got)
 	}

--- a/internal/db/postgres/sqlc/memory_wiki.sql.go
+++ b/internal/db/postgres/sqlc/memory_wiki.sql.go
@@ -436,7 +436,17 @@ ON CONFLICT (team_id, id) DO UPDATE SET
   subject = EXCLUDED.subject,
   confidence = EXCLUDED.confidence,
   metadata = EXCLUDED.metadata,
-  source_message_ids = EXCLUDED.source_message_ids,
+  source_message_ids = (
+    SELECT COALESCE(jsonb_agg(ref.value ORDER BY ref.first_seen), '[]'::jsonb)
+    FROM (
+      SELECT value, min(ordinality) AS first_seen
+      FROM jsonb_array_elements(
+        COALESCE(memory_nodes.source_message_ids, '[]'::jsonb)
+        || COALESCE(EXCLUDED.source_message_ids, '[]'::jsonb)
+      ) WITH ORDINALITY AS combined(value, ordinality)
+      GROUP BY value
+    ) AS ref
+  ),
   profile_ref = EXCLUDED.profile_ref,
   topic = EXCLUDED.topic,
   expires_at = EXCLUDED.expires_at,

--- a/internal/db/postgres/sqlc/messages.sql.go
+++ b/internal/db/postgres/sqlc/messages.sql.go
@@ -5682,12 +5682,13 @@ LEFT JOIN channel_identities ci ON ci.id = m.sender_channel_identity_id AND ci.t
 LEFT JOIN bot_sessions s ON s.id = m.session_id AND s.team_id = public.memoh_current_team_id()
 WHERE m.team_id = public.memoh_current_team_id()
   AND m.bot_id = $1
-  AND ($2::uuid IS NULL OR m.session_id = $2::uuid)
-  AND ($3::uuid IS NULL OR m.sender_channel_identity_id = $3::uuid)
-  AND ($4::timestamptz IS NULL OR m.created_at >= $4::timestamptz)
-  AND ($5::timestamptz IS NULL OR m.created_at <= $5::timestamptz)
-  AND ($6::text IS NULL OR m.role = $6::text)
-  AND ($7::text IS NULL OR (
+  AND m.session_id = ANY($2::uuid[])
+  AND ($3::uuid IS NULL OR m.session_id = $3::uuid)
+  AND ($4::uuid IS NULL OR m.sender_channel_identity_id = $4::uuid)
+  AND ($5::timestamptz IS NULL OR m.created_at >= $5::timestamptz)
+  AND ($6::timestamptz IS NULL OR m.created_at <= $6::timestamptz)
+  AND ($7::text IS NULL OR m.role = $7::text)
+  AND ($8::text IS NULL OR (
     CASE
       WHEN jsonb_typeof(m.content->'content') = 'string'
         THEN m.content->>'content'
@@ -5697,20 +5698,21 @@ WHERE m.team_id = public.memoh_current_team_id()
               WHERE elem->>'type' = 'text')
       ELSE ''
     END
-  ) ILIKE '%' || $7::text || '%')
+  ) ILIKE '%' || $8::text || '%')
 ORDER BY m.created_at DESC, m.id DESC
-LIMIT $8
+LIMIT $9
 `
 
 type SearchMessagesParams struct {
-	BotID     pgtype.UUID        `json:"bot_id"`
-	SessionID pgtype.UUID        `json:"session_id"`
-	ContactID pgtype.UUID        `json:"contact_id"`
-	StartTime pgtype.Timestamptz `json:"start_time"`
-	EndTime   pgtype.Timestamptz `json:"end_time"`
-	Role      pgtype.Text        `json:"role"`
-	Keyword   pgtype.Text        `json:"keyword"`
-	MaxCount  int32              `json:"max_count"`
+	BotID      pgtype.UUID        `json:"bot_id"`
+	SessionIds []pgtype.UUID      `json:"session_ids"`
+	SessionID  pgtype.UUID        `json:"session_id"`
+	ContactID  pgtype.UUID        `json:"contact_id"`
+	StartTime  pgtype.Timestamptz `json:"start_time"`
+	EndTime    pgtype.Timestamptz `json:"end_time"`
+	Role       pgtype.Text        `json:"role"`
+	Keyword    pgtype.Text        `json:"keyword"`
+	MaxCount   int32              `json:"max_count"`
 }
 
 type SearchMessagesRow struct {
@@ -5728,6 +5730,7 @@ type SearchMessagesRow struct {
 func (q *Queries) SearchMessages(ctx context.Context, arg SearchMessagesParams) ([]SearchMessagesRow, error) {
 	rows, err := q.db.Query(ctx, searchMessages,
 		arg.BotID,
+		arg.SessionIds,
 		arg.SessionID,
 		arg.ContactID,
 		arg.StartTime,

--- a/internal/memory/adapters/builtin/builtin.go
+++ b/internal/memory/adapters/builtin/builtin.go
@@ -18,7 +18,29 @@ const (
 
 	defaultMemoryToolLimit = 8
 	maxMemoryToolLimit     = 50
+	maxSourceRefsPerResult = 8
 )
+
+// sourceRefsPayload renders the most recent source refs of a memory item as
+// tool-facing {session_id, message_id} objects.
+func sourceRefsPayload(refs []string) []map[string]any {
+	if len(refs) > maxSourceRefsPerResult {
+		refs = refs[len(refs)-maxSourceRefsPerResult:]
+	}
+	out := make([]map[string]any, 0, len(refs))
+	for _, ref := range refs {
+		sessionID, messageID := adapters.ParseSourceRef(ref)
+		if messageID == "" {
+			continue
+		}
+		entry := map[string]any{"message_id": messageID}
+		if sessionID != "" {
+			entry["session_id"] = sessionID
+		}
+		out = append(out, entry)
+	}
+	return out
+}
 
 // BuiltinProvider wraps the existing Service as a Provider.
 type BuiltinProvider struct {
@@ -280,10 +302,11 @@ func (p *BuiltinProvider) OnAfterChat(ctx context.Context, req adapters.AfterCha
 	}
 	metadata := adapters.BuildProfileMetadata(req.UserID, req.ChannelIdentityID, req.DisplayName)
 	if _, err := p.service.Add(ctx, adapters.AddRequest{
-		Messages: req.Messages,
-		BotID:    botID,
-		Metadata: metadata,
-		Filters:  filters,
+		Messages:         req.Messages,
+		BotID:            botID,
+		Metadata:         metadata,
+		Filters:          filters,
+		SourceMessageIDs: req.SourceMessageIDs,
 	}); err != nil {
 		p.logger.Warn("store memory failed", slog.String("bot_id", botID), slog.Any("error", err))
 	}
@@ -372,11 +395,15 @@ func (p *BuiltinProvider) CallTool(ctx context.Context, session mcp.ToolSessionC
 
 	results := make([]map[string]any, 0, len(allResults))
 	for _, item := range allResults {
-		results = append(results, map[string]any{
+		entry := map[string]any{
 			"id":     item.ID,
 			"memory": item.Memory,
 			"score":  item.Score,
-		})
+		}
+		if refs := sourceRefsPayload(item.SourceMessageIDs); len(refs) > 0 {
+			entry["source_refs"] = refs
+		}
+		results = append(results, entry)
 	}
 
 	return mcp.BuildToolSuccessResult(map[string]any{

--- a/internal/memory/adapters/builtin/formation.go
+++ b/internal/memory/adapters/builtin/formation.go
@@ -72,7 +72,7 @@ func runFormation(ctx context.Context, logger *slog.Logger, llm adapters.LLM, ru
 	}
 	metadata := adapters.BuildProfileMetadata(req.UserID, req.ChannelIdentityID, req.DisplayName)
 
-	applyActions(ctx, logger, runtime, botID, decided.Actions, filters, metadata, &result)
+	applyActions(ctx, logger, runtime, botID, decided.Actions, filters, metadata, req.SourceMessageIDs, &result)
 	return result
 }
 
@@ -157,7 +157,7 @@ func gatherCandidates(ctx context.Context, logger *slog.Logger, runtime Runtime,
 }
 
 // applyActions executes the decided CRUD actions against the runtime.
-func applyActions(ctx context.Context, logger *slog.Logger, runtime Runtime, botID string, actions []adapters.DecisionAction, filters map[string]any, metadata map[string]any, result *formationResult) {
+func applyActions(ctx context.Context, logger *slog.Logger, runtime Runtime, botID string, actions []adapters.DecisionAction, filters map[string]any, metadata map[string]any, sourceMessageIDs []string, result *formationResult) {
 	deleted := make(map[string]struct{})
 	updated := make(map[string]struct{})
 
@@ -172,10 +172,11 @@ func applyActions(ctx context.Context, logger *slog.Logger, runtime Runtime, bot
 				continue
 			}
 			if _, err := runtime.Add(ctx, adapters.AddRequest{
-				Message:  text,
-				BotID:    botID,
-				Metadata: metadata,
-				Filters:  filters,
+				Message:          text,
+				BotID:            botID,
+				Metadata:         metadata,
+				Filters:          filters,
+				SourceMessageIDs: sourceMessageIDs,
 			}); err != nil {
 				logger.Warn("memory formation: ADD failed", slog.String("bot_id", botID), slog.Any("error", err))
 			} else {
@@ -195,8 +196,9 @@ func applyActions(ctx context.Context, logger *slog.Logger, runtime Runtime, bot
 				continue
 			}
 			if _, err := runtime.Update(ctx, adapters.UpdateRequest{
-				MemoryID: id,
-				Memory:   text,
+				MemoryID:         id,
+				Memory:           text,
+				SourceMessageIDs: sourceMessageIDs,
 			}); err != nil {
 				logger.Warn("memory formation: UPDATE failed", slog.String("bot_id", botID), slog.String("memory_id", id), slog.Any("error", err))
 			} else {

--- a/internal/memory/adapters/builtin/graph_runtime.go
+++ b/internal/memory/adapters/builtin/graph_runtime.go
@@ -135,12 +135,13 @@ func (r *graphRuntime) Add(ctx context.Context, req adapters.AddRequest) (adapte
 	}
 	now := time.Now().UTC()
 	spec := memoryItemToNodeSpec(adapters.MemoryItem{
-		ID:        runtimeMemoryID(botID, now),
-		Memory:    text,
-		Hash:      runtimeHash(text),
-		CreatedAt: now.Format(time.RFC3339),
-		UpdatedAt: now.Format(time.RFC3339),
-		Metadata:  req.Metadata,
+		ID:               runtimeMemoryID(botID, now),
+		Memory:           text,
+		Hash:             runtimeHash(text),
+		CreatedAt:        now.Format(time.RFC3339),
+		UpdatedAt:        now.Format(time.RFC3339),
+		Metadata:         req.Metadata,
+		SourceMessageIDs: unionStrings(nil, req.SourceMessageIDs),
 	}, botID)
 
 	saved, err := r.store.UpsertNode(ctx, spec)
@@ -378,6 +379,7 @@ func (r *graphRuntime) Update(ctx context.Context, req adapters.UpdateRequest) (
 	existing.ID = memoryID
 	existing.Body = text
 	existing.Hash = runtimeHash(text)
+	existing.SourceMessageIDs = unionStrings(existing.SourceMessageIDs, req.SourceMessageIDs)
 	saved, err := r.store.UpsertNode(ctx, existing)
 	if err != nil {
 		return adapters.MemoryItem{}, fmt.Errorf("graph runtime: update node: %w", err)
@@ -625,18 +627,41 @@ func memoryItemToNodeSpec(item adapters.MemoryItem, botID string) migrate.NodeSp
 		profileRef = metadataStringVal(item.Metadata, "profile_user_id")
 	}
 	return migrate.NodeSpec{
-		ID:         strings.TrimSpace(item.ID),
-		BotID:      botID,
-		Body:       body,
-		Hash:       strings.TrimSpace(item.Hash),
-		Layer:      layer,
-		Subject:    metadataStringVal(item.Metadata, "subject"),
-		Confidence: metadataFloatVal(item.Metadata, "confidence", 0.5),
-		Metadata:   item.Metadata,
-		ProfileRef: profileRef,
-		Topic:      metadataStringVal(item.Metadata, "topic"),
-		CapturedAt: parseGraphTime(item.CreatedAt),
+		ID:               strings.TrimSpace(item.ID),
+		BotID:            botID,
+		Body:             body,
+		Hash:             strings.TrimSpace(item.Hash),
+		Layer:            layer,
+		Subject:          metadataStringVal(item.Metadata, "subject"),
+		Confidence:       metadataFloatVal(item.Metadata, "confidence", 0.5),
+		Metadata:         item.Metadata,
+		SourceMessageIDs: item.SourceMessageIDs,
+		ProfileRef:       profileRef,
+		Topic:            metadataStringVal(item.Metadata, "topic"),
+		CapturedAt:       parseGraphTime(item.CreatedAt),
 	}
+}
+
+func unionStrings(existing, extra []string) []string {
+	if len(extra) == 0 {
+		return existing
+	}
+	out := make([]string, 0, len(existing)+len(extra))
+	seen := make(map[string]struct{}, len(existing)+len(extra))
+	for _, list := range [][]string{existing, extra} {
+		for _, value := range list {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			out = append(out, value)
+		}
+	}
+	return out
 }
 
 func metadataStringVal(m map[string]any, key string) string {

--- a/internal/memory/adapters/builtin/graph_sync.go
+++ b/internal/memory/adapters/builtin/graph_sync.go
@@ -151,13 +151,14 @@ func formatNodeTime(t time.Time) string {
 // shape used by the Runtime interface and search responses.
 func nodeSpecToMemoryItem(n migrate.NodeSpec) adapters.MemoryItem {
 	return adapters.MemoryItem{
-		ID:        n.ID,
-		Memory:    n.Body,
-		Hash:      n.Hash,
-		CreatedAt: formatNodeTime(n.CapturedAt),
-		UpdatedAt: formatNodeTime(n.CapturedAt),
-		Score:     0,
-		Metadata:  buildNodeMetadata(n),
-		BotID:     n.BotID,
+		ID:               n.ID,
+		Memory:           n.Body,
+		Hash:             n.Hash,
+		CreatedAt:        formatNodeTime(n.CapturedAt),
+		UpdatedAt:        formatNodeTime(n.CapturedAt),
+		Score:            0,
+		Metadata:         buildNodeMetadata(n),
+		BotID:            n.BotID,
+		SourceMessageIDs: n.SourceMessageIDs,
 	}
 }

--- a/internal/memory/adapters/builtin/source_refs_test.go
+++ b/internal/memory/adapters/builtin/source_refs_test.go
@@ -1,0 +1,235 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"testing"
+
+	"github.com/memohai/memoh/internal/mcp"
+	adapters "github.com/memohai/memoh/internal/memory/adapters"
+)
+
+func TestGraphRuntimeAddPersistsSourceMessageIDs(t *testing.T) {
+	t.Parallel()
+	store := newFakeWikiStore()
+	rt := NewGraphRuntime(nil, store, newFakeStore())
+
+	resp, err := rt.Add(context.Background(), adapters.AddRequest{
+		Message:          "User prefers oolong tea",
+		BotID:            "bot-1",
+		SourceMessageIDs: []string{"sess-1/msg-1", "sess-1/msg-1", "sess-1/msg-2"},
+	})
+	if err != nil {
+		t.Fatalf("Add error: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(resp.Results))
+	}
+	want := []string{"sess-1/msg-1", "sess-1/msg-2"}
+	node, ok := store.nodes[resp.Results[0].ID]
+	if !ok {
+		t.Fatalf("node %q not found in store", resp.Results[0].ID)
+	}
+	if !slices.Equal(node.SourceMessageIDs, want) {
+		t.Fatalf("stored SourceMessageIDs = %v, want %v", node.SourceMessageIDs, want)
+	}
+	if !slices.Equal(resp.Results[0].SourceMessageIDs, want) {
+		t.Fatalf("returned SourceMessageIDs = %v, want %v", resp.Results[0].SourceMessageIDs, want)
+	}
+}
+
+func TestGraphRuntimeUpdateUnionsSourceMessageIDs(t *testing.T) {
+	t.Parallel()
+	store := newFakeWikiStore()
+	rt := NewGraphRuntime(nil, store, newFakeStore())
+
+	added, err := rt.Add(context.Background(), adapters.AddRequest{
+		Message:          "User prefers oolong tea",
+		BotID:            "bot-1",
+		SourceMessageIDs: []string{"sess-1/msg-1", "sess-1/msg-2"},
+	})
+	if err != nil {
+		t.Fatalf("Add error: %v", err)
+	}
+	memoryID := added.Results[0].ID
+
+	updated, err := rt.Update(context.Background(), adapters.UpdateRequest{
+		MemoryID:         memoryID,
+		Memory:           "User prefers strong oolong tea",
+		SourceMessageIDs: []string{"sess-1/msg-2", "sess-2/msg-3"},
+	})
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	want := []string{"sess-1/msg-1", "sess-1/msg-2", "sess-2/msg-3"}
+	if !slices.Equal(updated.SourceMessageIDs, want) {
+		t.Fatalf("updated SourceMessageIDs = %v, want %v", updated.SourceMessageIDs, want)
+	}
+	node := store.nodes[memoryID]
+	if !slices.Equal(node.SourceMessageIDs, want) {
+		t.Fatalf("stored SourceMessageIDs = %v, want %v", node.SourceMessageIDs, want)
+	}
+}
+
+type capturingRuntime struct {
+	Runtime
+	addReqs    []adapters.AddRequest
+	updateReqs []adapters.UpdateRequest
+}
+
+func (c *capturingRuntime) Add(_ context.Context, req adapters.AddRequest) (adapters.SearchResponse, error) {
+	c.addReqs = append(c.addReqs, req)
+	return adapters.SearchResponse{}, nil
+}
+
+func (c *capturingRuntime) Update(_ context.Context, req adapters.UpdateRequest) (adapters.MemoryItem, error) {
+	c.updateReqs = append(c.updateReqs, req)
+	return adapters.MemoryItem{}, nil
+}
+
+func (*capturingRuntime) Search(_ context.Context, _ adapters.SearchRequest) (adapters.SearchResponse, error) {
+	return adapters.SearchResponse{}, nil
+}
+
+func (*capturingRuntime) GetAll(_ context.Context, _ adapters.GetAllRequest) (adapters.SearchResponse, error) {
+	return adapters.SearchResponse{}, nil
+}
+
+func TestFormationCarriesSourceMessageIDs(t *testing.T) {
+	t.Parallel()
+	runtime := &capturingRuntime{}
+	llm := &fakeLLM{
+		extractFacts: []string{"User likes oolong tea"},
+		decideActions: []adapters.DecisionAction{
+			{Event: "ADD", Text: "User likes oolong tea"},
+			{Event: "UPDATE", ID: "bot-1:mem_existing", Text: "User likes strong oolong tea"},
+		},
+	}
+	refs := []string{"sess-1/msg-1", "sess-1/msg-2"}
+
+	runFormation(context.Background(), slog.Default(), llm, runtime, adapters.AfterChatRequest{
+		BotID:            "bot-1",
+		Messages:         []adapters.Message{{Role: "user", Content: "I like oolong tea"}},
+		SourceMessageIDs: refs,
+	})
+
+	if len(runtime.addReqs) != 1 {
+		t.Fatalf("expected 1 add request, got %d", len(runtime.addReqs))
+	}
+	if !slices.Equal(runtime.addReqs[0].SourceMessageIDs, refs) {
+		t.Fatalf("ADD SourceMessageIDs = %v, want %v", runtime.addReqs[0].SourceMessageIDs, refs)
+	}
+	if len(runtime.updateReqs) != 1 {
+		t.Fatalf("expected 1 update request, got %d", len(runtime.updateReqs))
+	}
+	if !slices.Equal(runtime.updateReqs[0].SourceMessageIDs, refs) {
+		t.Fatalf("UPDATE SourceMessageIDs = %v, want %v", runtime.updateReqs[0].SourceMessageIDs, refs)
+	}
+}
+
+func callSearchMemory(t *testing.T, p *BuiltinProvider, query string) []map[string]any {
+	t.Helper()
+	result, err := p.CallTool(context.Background(), mcp.ToolSessionContext{BotID: "bot-1"}, adapters.ToolSearchMemory, map[string]any{
+		"query": query,
+	})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	structured, ok := result["structuredContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing structuredContent in %v", result)
+	}
+	rawResults, ok := structured["results"].([]map[string]any)
+	if !ok {
+		t.Fatalf("unexpected results shape: %T", structured["results"])
+	}
+	return rawResults
+}
+
+func TestCallToolSearchMemoryReturnsSourceRefs(t *testing.T) {
+	t.Parallel()
+	p := NewBuiltinProvider(slog.Default(), NewGraphRuntime(nil, newFakeWikiStore(), newFakeStore()))
+
+	if _, err := p.Add(context.Background(), adapters.AddRequest{
+		Message:          "User prefers oolong tea",
+		BotID:            "bot-1",
+		SourceMessageIDs: []string{"sess-1/msg-1", "msg-2"},
+	}); err != nil {
+		t.Fatalf("Add error: %v", err)
+	}
+
+	results := callSearchMemory(t, p, "oolong tea")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	refs, ok := results[0]["source_refs"].([]map[string]any)
+	if !ok {
+		t.Fatalf("unexpected source_refs shape: %T", results[0]["source_refs"])
+	}
+	want := []map[string]any{
+		{"session_id": "sess-1", "message_id": "msg-1"},
+		{"message_id": "msg-2"},
+	}
+	if len(refs) != len(want) {
+		t.Fatalf("source_refs = %v, want %v", refs, want)
+	}
+	for i := range want {
+		if fmt.Sprint(refs[i]) != fmt.Sprint(want[i]) {
+			t.Fatalf("source_refs[%d] = %v, want %v", i, refs[i], want[i])
+		}
+	}
+}
+
+func TestCallToolSearchMemoryCapsSourceRefs(t *testing.T) {
+	t.Parallel()
+	p := NewBuiltinProvider(slog.Default(), NewGraphRuntime(nil, newFakeWikiStore(), newFakeStore()))
+
+	refs := make([]string, 0, 10)
+	for i := 1; i <= 10; i++ {
+		refs = append(refs, fmt.Sprintf("sess-1/msg-%02d", i))
+	}
+	if _, err := p.Add(context.Background(), adapters.AddRequest{
+		Message:          "User prefers oolong tea",
+		BotID:            "bot-1",
+		SourceMessageIDs: refs,
+	}); err != nil {
+		t.Fatalf("Add error: %v", err)
+	}
+
+	results := callSearchMemory(t, p, "oolong tea")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	got, ok := results[0]["source_refs"].([]map[string]any)
+	if !ok {
+		t.Fatalf("unexpected source_refs shape: %T", results[0]["source_refs"])
+	}
+	if len(got) != 8 {
+		t.Fatalf("expected 8 source_refs, got %d", len(got))
+	}
+	if got[0]["message_id"] != "msg-03" || got[7]["message_id"] != "msg-10" {
+		t.Fatalf("expected most recent 8 refs, got first=%v last=%v", got[0], got[7])
+	}
+}
+
+func TestCallToolSearchMemoryOmitsEmptySourceRefs(t *testing.T) {
+	t.Parallel()
+	p := NewBuiltinProvider(slog.Default(), NewGraphRuntime(nil, newFakeWikiStore(), newFakeStore()))
+
+	if _, err := p.Add(context.Background(), adapters.AddRequest{
+		Message: "User prefers oolong tea",
+		BotID:   "bot-1",
+	}); err != nil {
+		t.Fatalf("Add error: %v", err)
+	}
+
+	results := callSearchMemory(t, p, "oolong tea")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if _, present := results[0]["source_refs"]; present {
+		t.Fatalf("expected source_refs to be omitted, got %v", results[0]["source_refs"])
+	}
+}

--- a/internal/memory/adapters/sourceref.go
+++ b/internal/memory/adapters/sourceref.go
@@ -1,0 +1,33 @@
+package adapters
+
+import "strings"
+
+const sourceRefSeparator = "/"
+
+// EncodeSourceRef builds a "<sessionID>/<messageID>" source ref. The session
+// part is optional so bare message IDs stay valid refs.
+func EncodeSourceRef(sessionID, messageID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return ""
+	}
+	if sessionID == "" {
+		return messageID
+	}
+	return sessionID + sourceRefSeparator + messageID
+}
+
+// ParseSourceRef splits a source ref into its session and message parts. A ref
+// without a separator is treated as a bare message ID.
+func ParseSourceRef(ref string) (sessionID, messageID string) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", ""
+	}
+	session, message, found := strings.Cut(ref, sourceRefSeparator)
+	if !found {
+		return "", ref
+	}
+	return strings.TrimSpace(session), strings.TrimSpace(message)
+}

--- a/internal/memory/adapters/sourceref_test.go
+++ b/internal/memory/adapters/sourceref_test.go
@@ -1,0 +1,61 @@
+package adapters
+
+import "testing"
+
+func TestEncodeSourceRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		sessionID string
+		messageID string
+		want      string
+	}{
+		{"session and message", "sess-1", "msg-1", "sess-1/msg-1"},
+		{"bare message", "", "msg-1", "msg-1"},
+		{"trims whitespace", " sess-1 ", " msg-1 ", "sess-1/msg-1"},
+		{"empty message", "sess-1", "", ""},
+		{"empty both", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := EncodeSourceRef(tc.sessionID, tc.messageID); got != tc.want {
+				t.Fatalf("EncodeSourceRef(%q, %q) = %q, want %q", tc.sessionID, tc.messageID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseSourceRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		ref         string
+		wantSession string
+		wantMessage string
+	}{
+		{"composite", "sess-1/msg-1", "sess-1", "msg-1"},
+		{"bare message id", "msg-1", "", "msg-1"},
+		{"trims whitespace", " sess-1/msg-1 ", "sess-1", "msg-1"},
+		{"empty", "", "", ""},
+		{"only separator", "/", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotSession, gotMessage := ParseSourceRef(tc.ref)
+			if gotSession != tc.wantSession || gotMessage != tc.wantMessage {
+				t.Fatalf("ParseSourceRef(%q) = (%q, %q), want (%q, %q)", tc.ref, gotSession, gotMessage, tc.wantSession, tc.wantMessage)
+			}
+		})
+	}
+}
+
+func TestEncodeParseSourceRefRoundTrip(t *testing.T) {
+	t.Parallel()
+	ref := EncodeSourceRef("0d9c1a2b-3e4f-4a5b-8c6d-7e8f9a0b1c2d", "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d")
+	session, message := ParseSourceRef(ref)
+	if session != "0d9c1a2b-3e4f-4a5b-8c6d-7e8f9a0b1c2d" || message != "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d" {
+		t.Fatalf("round trip failed: got (%q, %q)", session, message)
+	}
+}

--- a/internal/memory/adapters/types.go
+++ b/internal/memory/adapters/types.go
@@ -27,6 +27,7 @@ type AfterChatRequest struct {
 	ChannelIdentityID string
 	DisplayName       string
 	TimezoneLocation  *time.Location
+	SourceMessageIDs  []string
 }
 
 // LLM is the interface for LLM operations needed by memory service.
@@ -51,6 +52,7 @@ type AddRequest struct {
 	Filters          map[string]any `json:"filters,omitempty"`
 	Infer            *bool          `json:"infer,omitempty"`
 	EmbeddingEnabled *bool          `json:"embedding_enabled,omitempty"`
+	SourceMessageIDs []string       `json:"source_message_ids,omitempty"`
 }
 
 type SearchRequest struct {
@@ -66,9 +68,10 @@ type SearchRequest struct {
 }
 
 type UpdateRequest struct {
-	MemoryID         string `json:"memory_id"`
-	Memory           string `json:"memory"`
-	EmbeddingEnabled *bool  `json:"embedding_enabled,omitempty"`
+	MemoryID         string   `json:"memory_id"`
+	Memory           string   `json:"memory"`
+	EmbeddingEnabled *bool    `json:"embedding_enabled,omitempty"`
+	SourceMessageIDs []string `json:"source_message_ids,omitempty"`
 }
 
 type GetAllRequest struct {
@@ -88,16 +91,17 @@ type DeleteAllRequest struct {
 }
 
 type MemoryItem struct {
-	ID        string         `json:"id"`
-	Memory    string         `json:"memory"`
-	Hash      string         `json:"hash,omitempty"`
-	CreatedAt string         `json:"created_at,omitempty"`
-	UpdatedAt string         `json:"updated_at,omitempty"`
-	Score     float64        `json:"score,omitempty"`
-	Metadata  map[string]any `json:"metadata,omitempty"`
-	BotID     string         `json:"bot_id,omitempty"`
-	AgentID   string         `json:"agent_id,omitempty"`
-	RunID     string         `json:"run_id,omitempty"`
+	ID               string         `json:"id"`
+	Memory           string         `json:"memory"`
+	Hash             string         `json:"hash,omitempty"`
+	CreatedAt        string         `json:"created_at,omitempty"`
+	UpdatedAt        string         `json:"updated_at,omitempty"`
+	Score            float64        `json:"score,omitempty"`
+	Metadata         map[string]any `json:"metadata,omitempty"`
+	BotID            string         `json:"bot_id,omitempty"`
+	AgentID          string         `json:"agent_id,omitempty"`
+	RunID            string         `json:"run_id,omitempty"`
+	SourceMessageIDs []string       `json:"source_message_ids,omitempty"`
 }
 
 type SearchResponse struct {

--- a/internal/memory/adapters/types.go
+++ b/internal/memory/adapters/types.go
@@ -91,17 +91,20 @@ type DeleteAllRequest struct {
 }
 
 type MemoryItem struct {
-	ID               string         `json:"id"`
-	Memory           string         `json:"memory"`
-	Hash             string         `json:"hash,omitempty"`
-	CreatedAt        string         `json:"created_at,omitempty"`
-	UpdatedAt        string         `json:"updated_at,omitempty"`
-	Score            float64        `json:"score,omitempty"`
-	Metadata         map[string]any `json:"metadata,omitempty"`
-	BotID            string         `json:"bot_id,omitempty"`
-	AgentID          string         `json:"agent_id,omitempty"`
-	RunID            string         `json:"run_id,omitempty"`
-	SourceMessageIDs []string       `json:"source_message_ids,omitempty"`
+	ID        string         `json:"id"`
+	Memory    string         `json:"memory"`
+	Hash      string         `json:"hash,omitempty"`
+	CreatedAt string         `json:"created_at,omitempty"`
+	UpdatedAt string         `json:"updated_at,omitempty"`
+	Score     float64        `json:"score,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+	BotID     string         `json:"bot_id,omitempty"`
+	AgentID   string         `json:"agent_id,omitempty"`
+	RunID     string         `json:"run_id,omitempty"`
+	// SourceMessageIDs is internal provenance. Public HTTP responses must not
+	// expose raw session/message locators; tool projections authorize and render
+	// them explicitly at the request boundary.
+	SourceMessageIDs []string `json:"-"`
 }
 
 type SearchResponse struct {

--- a/internal/memory/adapters/types_test.go
+++ b/internal/memory/adapters/types_test.go
@@ -39,3 +39,17 @@ func TestMemoryStatusIncludesConfiguredPgvectorHealth(t *testing.T) {
 		t.Fatalf("configured pgvector health should be present, got %s", payload)
 	}
 }
+
+func TestMemoryItemJSONOmitsInternalSourceMessageIDs(t *testing.T) {
+	raw, err := json.Marshal(MemoryItem{
+		ID:               "memory-1",
+		Memory:           "shared fact",
+		SourceMessageIDs: []string{"session-private/message-private"},
+	})
+	if err != nil {
+		t.Fatalf("marshal memory item: %v", err)
+	}
+	if strings.Contains(string(raw), "source_message_ids") || strings.Contains(string(raw), "session-private") {
+		t.Fatalf("public memory JSON leaked internal provenance: %s", raw)
+	}
+}

--- a/internal/memory/wikistore/postgres_integration_test.go
+++ b/internal/memory/wikistore/postgres_integration_test.go
@@ -1,0 +1,107 @@
+package wikistore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	dbpkg "github.com/memohai/memoh/internal/db"
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	"github.com/memohai/memoh/internal/memory/migrate"
+)
+
+func TestPostgresUpsertNodeConcurrentlyUnionsSourceRefs(t *testing.T) {
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("TEST_POSTGRES_DSN is not set")
+	}
+	ctx := context.Background()
+	pool, err := dbpkg.OpenPostgresDSN(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	const teamID = "00000000-0000-0000-0000-000000000001"
+	suffix := time.Now().UnixNano()
+	uuidTail := suffix % 1_000_000_000_000
+	userID := fmt.Sprintf("00000000-0000-0000-0000-%012d", uuidTail)
+	botID := fmt.Sprintf("10000000-0000-0000-0000-%012d", uuidTail)
+	username := fmt.Sprintf("pr1003-%d", uuidTail)
+	email := username + "@example.test"
+	botName := fmt.Sprintf("pr1003-%d", uuidTail)
+	fixtureStatements := []struct {
+		query string
+		args  []any
+	}{
+		{`INSERT INTO users (id, username, email) VALUES ($1, $2, $3)`, []any{userID, username, email}},
+		{`INSERT INTO team_members (team_id, user_id, role) VALUES ($1, $2, 'member')`, []any{teamID, userID}},
+		{`INSERT INTO bots (team_id, id, owner_user_id, type, name) VALUES ($1, $2, $3, 'personal', $4)`, []any{teamID, botID, userID, botName}},
+	}
+	for _, statement := range fixtureStatements {
+		if _, err := pool.Exec(ctx, statement.query, statement.args...); err != nil {
+			t.Fatalf("create postgres fixtures: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM bots WHERE team_id = $1 AND id = $2", teamID, botID)
+		_, _ = pool.Exec(context.Background(), "DELETE FROM team_members WHERE team_id = $1 AND user_id = $2", teamID, userID)
+		_, _ = pool.Exec(context.Background(), "DELETE FROM users WHERE id = $1", userID)
+	})
+	nodeID := fmt.Sprintf("pr1003-concurrent-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM memory_nodes WHERE bot_id = $1 AND id = $2", botID, nodeID)
+	})
+
+	store := NewPostgres(dbsqlc.New(pool))
+	base := migrate.NodeSpec{
+		ID: nodeID, BotID: botID, Body: "shared fact", Hash: "hash", Layer: migrate.LayerNote,
+		SourceMessageIDs: []string{"session/base"}, CapturedAt: time.Now().UTC(),
+	}
+	if _, err := store.UpsertNode(ctx, base); err != nil {
+		t.Fatalf("insert base node: %v", err)
+	}
+
+	const writers = 24
+	start := make(chan struct{})
+	errCh := make(chan error, writers)
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			node := base
+			node.SourceMessageIDs = []string{fmt.Sprintf("session/message-%02d", i)}
+			_, writeErr := store.UpsertNode(ctx, node)
+			errCh <- writeErr
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+	for writeErr := range errCh {
+		if writeErr != nil {
+			t.Fatalf("concurrent upsert: %v", writeErr)
+		}
+	}
+
+	got, err := store.GetNode(ctx, botID, nodeID)
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	sort.Strings(got.SourceMessageIDs)
+	want := make([]string, 0, writers+1)
+	want = append(want, "session/base")
+	for i := range writers {
+		want = append(want, fmt.Sprintf("session/message-%02d", i))
+	}
+	sort.Strings(want)
+	if fmt.Sprint(got.SourceMessageIDs) != fmt.Sprint(want) {
+		t.Fatalf("source refs = %v, want %v", got.SourceMessageIDs, want)
+	}
+}


### PR DESCRIPTION
## What this delivers

First step of the cross-session retrieval fallback chain: memory hits become addressable. `memory_nodes.source_message_ids` has existed in the schema all along, but nothing ever wrote or read it — the pipeline stripped message identity before memory saw it (`toProviderMessages` reduced messages to `{role, content}`), the formation path never filled the column, and `search_memory` returned only `{id, memory, score}`. A memory hit was a dead end: no pointer back to the session and messages that produced it.

This PR energizes that dormant column end to end, with zero migrations:

- **Ref codec** (`internal/memory/adapters/sourceref.go`): refs are `"<session_id>/<message_id>"` composite strings; bare message IDs stay valid. Session is denormalized into the ref at write time — messages never move between sessions and forks copy rows under new IDs, so the pair is stable — and the memory domain stays ignorant of chat semantics.
- **Write path**: `roundSourceRefs(req, persisted)` builds refs from the just-persisted round rows (plus the channel-persisted user message when the round reuses it); both `storeMemory` call sites pass them, with the ACP path switched to `storeRoundWithOptionsResult` so it shares the same persisted-row refs as chat. Formation ADD/UPDATE and the no-LLM fallback forward the refs into the runtime; the graph runtime persists them on Add and **append-unions on Update**, so provenance accumulates across node rewrites instead of being overwritten.
- **Read path**: `search_memory` results now carry `source_refs: [{session_id, message_id}]`, capped at the 8 most recent per item. The `<memory-context>` auto-injection builder is untouched — refs are tool-result-only, so injected prompt bytes do not change.

## Why

Memory is the coarse first tier of recall. When it can only give the gist, the model needs a pointer to drill back into the originating session for detail. With refs in place, `search_memory` → `get_messages(session_id, …)` closes that loop today at message granularity. A follow-up PR adds a session-context window tool (with channel-scope filtering) for composed-context drill-down.

## Testing

- Nine new tests, written first: codec table tests; graph runtime Add persistence and Update union; formation carry-through via a capturing runtime; `search_memory` refs shape, recency cap, and omission when empty; `roundSourceRefs`; and a storeRound → provider end-to-end assertion through the existing recording fixtures.
- `go test ./internal/memory/... ./internal/agent/application/` green; `golangci-lint run` clean on the touched packages.

Notes: mem0/openviking no-op providers are unaffected; the file-fallback runtime ignores refs (degraded mode).
