### PR TITLE
fix(agent): cap replayed reasoning at the newest assistant turn

### DIFF
--- a/internal/agent/application/service_history_compaction.go
+++ b/internal/agent/application/service_history_compaction.go
@@ -64,8 +64,9 @@ func historySourceMessageIDsForMessages(messages []ModelMessage, records []histo
 		if strings.TrimSpace(record.DBMessageID) == "" {
 			continue
 		}
-		key := modelMessageSourceKey(record.ModelMessage)
-		positions[key] = append(positions[key], i)
+		for _, key := range modelMessageSourceKeys(record.ModelMessage) {
+			positions[key] = append(positions[key], i)
+		}
 	}
 	cursors := make(map[string]int, len(positions))
 	lastMatched := -1
@@ -90,6 +91,22 @@ func historySourceMessageIDsForMessages(messages []ModelMessage, records []histo
 
 func modelMessageSourceKey(message ModelMessage) string {
 	return strings.ToLower(strings.TrimSpace(message.Role)) + "\x00" + string(message.Content)
+}
+
+// modelMessageSourceKeys returns every key a record's message can be recognised
+// by. Context assembly caps replayed reasoning, so a durable assistant turn
+// reaches the model with its reasoning dropped or projected to text; indexing
+// the record under that shape as well keeps the message resolvable to its DB row
+// instead of silently losing provenance for fork sources and context accounting.
+func modelMessageSourceKeys(message ModelMessage) []string {
+	keys := []string{modelMessageSourceKey(message)}
+	if !strings.EqualFold(strings.TrimSpace(message.Role), "assistant") {
+		return keys
+	}
+	if stripped := dropReasoning(message); string(stripped.Content) != string(message.Content) {
+		keys = append(keys, modelMessageSourceKey(stripped))
+	}
+	return keys
 }
 
 func stripToolMessagesWhenCompactionSummaryIsActive(messages []ModelMessage, records []historyfrag.HistoryRecord) []ModelMessage {

--- a/internal/agent/application/service_history_messages.go
+++ b/internal/agent/application/service_history_messages.go
@@ -138,11 +138,13 @@ func (s *Service) loadTurnResponses(ctx context.Context, sessionID string) []tim
 // keeping ask_user calls and results. ask_user is conversation-visible: the
 // question and the user's answer are part of the chat semantics, not tool noise.
 //
-// Reasoning in the most recent assistant message is preserved. Providers verify
-// the thinking blocks of the latest assistant turn and reject a sequence they
-// did not produce, while older turns are filtered server-side and need no
-// pruning here. Keeping only the newest turn satisfies that check without
-// letting encrypted reasoning accumulate across a long conversation.
+// It also caps how much reasoning goes back: only the most recent assistant
+// message keeps its reasoning blocks. Replayed reasoning otherwise grows without
+// bound — every turn carries every earlier turn's blocks, and encrypted ones are
+// several hundred bytes each — until the request is large enough to blow the
+// provider request timeout. Providers verify the thinking blocks of the latest
+// assistant message and filter older turns server-side, so the newest turn is
+// the only one that has to survive.
 func stripToolMessages(messages []ModelMessage) []ModelMessage {
 	latestAssistant := lastAssistantIndex(messages)
 	filtered := make([]ModelMessage, 0, len(messages))
@@ -154,19 +156,48 @@ func stripToolMessages(messages []ModelMessage) []ModelMessage {
 			}
 			continue
 		}
-		// Remove assistant messages that only contain tool calls / reasoning with
-		// no visible text. Tool-call metadata may live either in ToolCalls or in
-		// structured content parts.
-		if strings.EqualFold(role, "assistant") && hasToolCallContent(m) {
-			stripped, ok := stripNonAskUserToolCalls(m, i == latestAssistant)
-			if !ok {
-				continue
+		if strings.EqualFold(role, "assistant") {
+			// Remove assistant messages that only contain tool calls / reasoning
+			// with no visible text. Tool-call metadata may live either in
+			// ToolCalls or in structured content parts.
+			if hasToolCallContent(m) {
+				stripped, ok := stripNonAskUserToolCalls(m, i == latestAssistant)
+				if !ok {
+					continue
+				}
+				m = stripped
+			} else if i != latestAssistant {
+				// A plain conversational turn has no tool call to strip, but its
+				// reasoning still accumulates, so drop it here as well.
+				m = dropReasoning(m)
 			}
-			m = stripped
 		}
 		filtered = append(filtered, m)
 	}
 	return filtered
+}
+
+// dropReasoning removes an assistant message's reasoning parts, leaving the rest
+// of its content untouched. A message left with nothing but reasoning keeps its
+// original form rather than becoming empty, since a contentless assistant turn
+// is not something a provider accepts.
+func dropReasoning(message ModelMessage) ModelMessage {
+	parts := modelMessageToSDKMessage(message).Content
+	kept := make([]sdk.MessagePart, 0, len(parts))
+	dropped := false
+	for _, part := range parts {
+		if _, ok := part.(sdk.ReasoningPart); ok {
+			dropped = true
+			continue
+		}
+		kept = append(kept, part)
+	}
+	if !dropped || len(kept) == 0 {
+		return message
+	}
+	stripped := modelMessageFromSDKParts(sdk.MessageRoleAssistant, kept, message.Usage)
+	stripped.ToolCalls = message.ToolCalls
+	return stripped
 }
 
 // lastAssistantIndex reports the index of the most recent assistant message, or

--- a/internal/agent/application/service_history_messages.go
+++ b/internal/agent/application/service_history_messages.go
@@ -137,9 +137,16 @@ func (s *Service) loadTurnResponses(ctx context.Context, sessionID string) []tim
 // stripToolMessages removes bulky tool interactions from the context while
 // keeping ask_user calls and results. ask_user is conversation-visible: the
 // question and the user's answer are part of the chat semantics, not tool noise.
+//
+// Reasoning in the most recent assistant message is preserved. Providers verify
+// the thinking blocks of the latest assistant turn and reject a sequence they
+// did not produce, while older turns are filtered server-side and need no
+// pruning here. Keeping only the newest turn satisfies that check without
+// letting encrypted reasoning accumulate across a long conversation.
 func stripToolMessages(messages []ModelMessage) []ModelMessage {
+	latestAssistant := lastAssistantIndex(messages)
 	filtered := make([]ModelMessage, 0, len(messages))
-	for _, m := range messages {
+	for i, m := range messages {
 		role := strings.TrimSpace(m.Role)
 		if strings.EqualFold(role, "tool") {
 			if kept := keepAskUserToolResultMessage(m); kept != nil {
@@ -151,7 +158,7 @@ func stripToolMessages(messages []ModelMessage) []ModelMessage {
 		// no visible text. Tool-call metadata may live either in ToolCalls or in
 		// structured content parts.
 		if strings.EqualFold(role, "assistant") && hasToolCallContent(m) {
-			stripped, ok := stripNonAskUserToolCalls(m)
+			stripped, ok := stripNonAskUserToolCalls(m, i == latestAssistant)
 			if !ok {
 				continue
 			}
@@ -160,6 +167,17 @@ func stripToolMessages(messages []ModelMessage) []ModelMessage {
 		filtered = append(filtered, m)
 	}
 	return filtered
+}
+
+// lastAssistantIndex reports the index of the most recent assistant message, or
+// -1 when there is none.
+func lastAssistantIndex(messages []ModelMessage) int {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if strings.EqualFold(strings.TrimSpace(messages[i].Role), "assistant") {
+			return i
+		}
+	}
+	return -1
 }
 
 func hasToolCallContent(message ModelMessage) bool {
@@ -174,11 +192,11 @@ func hasToolCallContent(message ModelMessage) bool {
 	return false
 }
 
-func stripNonAskUserToolCalls(message ModelMessage) (ModelMessage, bool) {
+func stripNonAskUserToolCalls(message ModelMessage, keepReasoning bool) (ModelMessage, bool) {
 	legacyToolCalls := keepAskUserLegacyToolCalls(message.ToolCalls)
 	text := strings.TrimSpace(message.TextContent())
 
-	keptParts := filterAssistantContextParts(modelMessageToSDKMessage(message).Content)
+	keptParts := filterAssistantContextParts(modelMessageToSDKMessage(message).Content, keepReasoning)
 	if len(keptParts) > 0 {
 		message = modelMessageFromSDKParts(sdk.MessageRoleAssistant, keptParts, message.Usage)
 		message.ToolCalls = legacyToolCalls
@@ -224,7 +242,11 @@ func keepAskUserLegacyToolCalls(calls []ToolCall) []ToolCall {
 	return kept
 }
 
-func filterAssistantContextParts(parts []sdk.MessagePart) []sdk.MessagePart {
+// filterAssistantContextParts drops tool noise from an assistant message.
+// keepReasoning preserves the message's reasoning parts, which the caller sets
+// for the latest assistant turn: its thinking blocks are the ones a provider
+// verifies, and they have to be replayed whole, empty-text blocks included.
+func filterAssistantContextParts(parts []sdk.MessagePart, keepReasoning bool) []sdk.MessagePart {
 	if len(parts) == 0 {
 		return nil
 	}
@@ -235,7 +257,11 @@ func filterAssistantContextParts(parts []sdk.MessagePart) []sdk.MessagePart {
 			if strings.EqualFold(strings.TrimSpace(typed.ToolName), userinput.ToolNameAskUser) {
 				kept = append(kept, typed)
 			}
-		case sdk.ToolResultPart, sdk.ReasoningPart:
+		case sdk.ReasoningPart:
+			if keepReasoning {
+				kept = append(kept, typed)
+			}
+		case sdk.ToolResultPart:
 			continue
 		case sdk.TextPart:
 			if strings.TrimSpace(typed.Text) != "" {

--- a/internal/agent/application/service_history_messages.go
+++ b/internal/agent/application/service_history_messages.go
@@ -141,17 +141,29 @@ func (s *Service) loadTurnResponses(ctx context.Context, sessionID string) []tim
 // It also caps how much reasoning goes back: only the most recent assistant
 // message keeps its reasoning blocks. Replayed reasoning otherwise grows without
 // bound — every turn carries every earlier turn's blocks, and encrypted ones are
-// several hundred bytes each — until the request is large enough to blow the
-// provider request timeout. Providers verify the thinking blocks of the latest
+// several hundred bytes each — until long conversations pay for reasoning they
+// will never use again. Providers verify the thinking blocks of the latest
 // assistant message and filter older turns server-side, so the newest turn is
 // the only one that has to survive.
+//
+// The newest turn keeps its tool calls along with its reasoning. A thinking
+// block explains the call it was issued with; replaying it while dropping the
+// call shows the model its own decision to use a tool with no record that the
+// call happened. The results those calls produced are kept for the same reason.
 func stripToolMessages(messages []ModelMessage) []ModelMessage {
 	latestAssistant := lastAssistantIndex(messages)
+	keptToolCallIDs := map[string]struct{}{}
+	// Only a latest turn that actually replays reasoning needs its calls kept:
+	// with no thinking block there is nothing whose explanation would dangle,
+	// and the tool noise is worth dropping as before.
+	if latestAssistant >= 0 && hasReasoningContent(messages[latestAssistant]) {
+		keptToolCallIDs = toolCallIDsOf(messages[latestAssistant])
+	}
 	filtered := make([]ModelMessage, 0, len(messages))
 	for i, m := range messages {
 		role := strings.TrimSpace(m.Role)
 		if strings.EqualFold(role, "tool") {
-			if kept := keepAskUserToolResultMessage(m); kept != nil {
+			if kept := keepAskUserToolResultMessage(m, keptToolCallIDs); kept != nil {
 				filtered = append(filtered, *kept)
 			}
 			continue
@@ -161,7 +173,8 @@ func stripToolMessages(messages []ModelMessage) []ModelMessage {
 			// with no visible text. Tool-call metadata may live either in
 			// ToolCalls or in structured content parts.
 			if hasToolCallContent(m) {
-				stripped, ok := stripNonAskUserToolCalls(m, i == latestAssistant)
+				keepLatestTurn := i == latestAssistant && hasReasoningContent(m)
+				stripped, ok := stripNonAskUserToolCalls(m, keepLatestTurn)
 				if !ok {
 					continue
 				}
@@ -177,23 +190,72 @@ func stripToolMessages(messages []ModelMessage) []ModelMessage {
 	return filtered
 }
 
+// hasReasoningContent reports whether an assistant message carries a reasoning
+// part, including an empty-text redacted one whose payload is all metadata.
+func hasReasoningContent(message ModelMessage) bool {
+	for _, part := range modelMessageToSDKMessage(message).Content {
+		if _, ok := part.(sdk.ReasoningPart); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// toolCallIDsOf reports the tool call IDs an assistant message issued, across
+// both the structured content parts and the legacy top-level ToolCalls field.
+// It is only consulted for a message whose calls are being kept, so that the
+// results pairing with them can be kept too.
+func toolCallIDsOf(message ModelMessage) map[string]struct{} {
+	ids := map[string]struct{}{}
+	for _, part := range modelMessageToSDKMessage(message).Content {
+		if call, ok := part.(sdk.ToolCallPart); ok {
+			if id := strings.TrimSpace(call.ToolCallID); id != "" {
+				ids[id] = struct{}{}
+			}
+		}
+	}
+	for _, call := range message.ToolCalls {
+		if id := strings.TrimSpace(call.ID); id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	return ids
+}
+
 // dropReasoning removes an assistant message's reasoning parts, leaving the rest
-// of its content untouched. A message left with nothing but reasoning keeps its
-// original form rather than becoming empty, since a contentless assistant turn
-// is not something a provider accepts.
+// of its content untouched.
+//
+// A message whose only content is reasoning cannot simply lose it: an emptied
+// assistant message is dropped by sanitizeMessages and rejected by providers.
+// Keeping the opaque block instead would exempt exactly the shape an
+// interruption mid-thinking leaves behind — reasoning with no answer text is
+// still checkpointed — and that shape recurs, so the cap would not hold. The
+// thinking is projected to text instead: the turn stays alive and readable
+// while the block itself stops being replayed.
 func dropReasoning(message ModelMessage) ModelMessage {
 	parts := modelMessageToSDKMessage(message).Content
 	kept := make([]sdk.MessagePart, 0, len(parts))
+	var reasoning strings.Builder
 	dropped := false
 	for _, part := range parts {
-		if _, ok := part.(sdk.ReasoningPart); ok {
+		if reasoningPart, ok := part.(sdk.ReasoningPart); ok {
 			dropped = true
+			reasoning.WriteString(reasoningPart.Text)
 			continue
 		}
 		kept = append(kept, part)
 	}
-	if !dropped || len(kept) == 0 {
+	if !dropped {
 		return message
+	}
+	if len(kept) == 0 {
+		// Nothing but reasoning: an empty-text block (a redacted one carries its
+		// payload in metadata) leaves no text to project, so the message has to
+		// keep its original form rather than vanish.
+		if strings.TrimSpace(reasoning.String()) == "" {
+			return message
+		}
+		kept = append(kept, sdk.TextPart{Text: reasoning.String()})
 	}
 	stripped := modelMessageFromSDKParts(sdk.MessageRoleAssistant, kept, message.Usage)
 	stripped.ToolCalls = message.ToolCalls
@@ -223,11 +285,14 @@ func hasToolCallContent(message ModelMessage) bool {
 	return false
 }
 
-func stripNonAskUserToolCalls(message ModelMessage, keepReasoning bool) (ModelMessage, bool) {
-	legacyToolCalls := keepAskUserLegacyToolCalls(message.ToolCalls)
+func stripNonAskUserToolCalls(message ModelMessage, keepLatestTurn bool) (ModelMessage, bool) {
+	legacyToolCalls := message.ToolCalls
+	if !keepLatestTurn {
+		legacyToolCalls = keepAskUserLegacyToolCalls(message.ToolCalls)
+	}
 	text := strings.TrimSpace(message.TextContent())
 
-	keptParts := filterAssistantContextParts(modelMessageToSDKMessage(message).Content, keepReasoning)
+	keptParts := filterAssistantContextParts(modelMessageToSDKMessage(message).Content, keepLatestTurn)
 	if len(keptParts) > 0 {
 		message = modelMessageFromSDKParts(sdk.MessageRoleAssistant, keptParts, message.Usage)
 		message.ToolCalls = legacyToolCalls
@@ -248,11 +313,18 @@ func stripNonAskUserToolCalls(message ModelMessage, keepReasoning bool) (ModelMe
 	return message, true
 }
 
-func keepAskUserToolResultMessage(message ModelMessage) *ModelMessage {
+// keepAskUserToolResultMessage keeps a tool message when it carries an ask_user
+// answer, or a result pairing with a tool call that survived stripping. The
+// latter keeps the newest turn's tool exchange whole: the call is replayed, so
+// the result it produced has to be there too.
+func keepAskUserToolResultMessage(message ModelMessage, keptToolCallIDs map[string]struct{}) *ModelMessage {
 	if strings.EqualFold(strings.TrimSpace(message.Name), userinput.ToolNameAskUser) {
 		return &message
 	}
-	results := filterAskUserToolResults(modelMessageToSDKMessage(message).Content)
+	if _, ok := keptToolCallIDs[strings.TrimSpace(message.ToolCallID)]; ok && strings.TrimSpace(message.ToolCallID) != "" {
+		return &message
+	}
+	results := filterAskUserToolResults(modelMessageToSDKMessage(message).Content, keptToolCallIDs)
 	if len(results) == 0 {
 		return nil
 	}
@@ -274,10 +346,12 @@ func keepAskUserLegacyToolCalls(calls []ToolCall) []ToolCall {
 }
 
 // filterAssistantContextParts drops tool noise from an assistant message.
-// keepReasoning preserves the message's reasoning parts, which the caller sets
-// for the latest assistant turn: its thinking blocks are the ones a provider
-// verifies, and they have to be replayed whole, empty-text blocks included.
-func filterAssistantContextParts(parts []sdk.MessagePart, keepReasoning bool) []sdk.MessagePart {
+// keepLatestTurn preserves the message's reasoning parts and the tool calls they
+// were issued with, which the caller sets for the latest assistant turn: its
+// thinking blocks are the ones a provider verifies, and they have to be replayed
+// whole, empty-text blocks included. The calls travel with them, since a
+// thinking block explains a call that must still be there to explain.
+func filterAssistantContextParts(parts []sdk.MessagePart, keepLatestTurn bool) []sdk.MessagePart {
 	if len(parts) == 0 {
 		return nil
 	}
@@ -285,11 +359,11 @@ func filterAssistantContextParts(parts []sdk.MessagePart, keepReasoning bool) []
 	for _, part := range parts {
 		switch typed := part.(type) {
 		case sdk.ToolCallPart:
-			if strings.EqualFold(strings.TrimSpace(typed.ToolName), userinput.ToolNameAskUser) {
+			if keepLatestTurn || strings.EqualFold(strings.TrimSpace(typed.ToolName), userinput.ToolNameAskUser) {
 				kept = append(kept, typed)
 			}
 		case sdk.ReasoningPart:
-			if keepReasoning {
+			if keepLatestTurn {
 				kept = append(kept, typed)
 			}
 		case sdk.ToolResultPart:
@@ -305,7 +379,9 @@ func filterAssistantContextParts(parts []sdk.MessagePart, keepReasoning bool) []
 	return kept
 }
 
-func filterAskUserToolResults(parts []sdk.MessagePart) []sdk.MessagePart {
+// filterAskUserToolResults keeps ask_user results, plus results pairing with a
+// tool call that survived stripping so the newest turn's exchange stays whole.
+func filterAskUserToolResults(parts []sdk.MessagePart, keptToolCallIDs map[string]struct{}) []sdk.MessagePart {
 	if len(parts) == 0 {
 		return nil
 	}
@@ -317,6 +393,12 @@ func filterAskUserToolResults(parts []sdk.MessagePart) []sdk.MessagePart {
 		}
 		if strings.EqualFold(strings.TrimSpace(result.ToolName), userinput.ToolNameAskUser) {
 			kept = append(kept, result)
+			continue
+		}
+		if id := strings.TrimSpace(result.ToolCallID); id != "" {
+			if _, pairs := keptToolCallIDs[id]; pairs {
+				kept = append(kept, result)
+			}
 		}
 	}
 	return kept

--- a/internal/agent/application/service_history_provenance_test.go
+++ b/internal/agent/application/service_history_provenance_test.go
@@ -1,0 +1,52 @@
+package application
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
+)
+
+// Capping replayed reasoning rewrites an assistant message's content, and
+// provenance is resolved by matching that content against durable rows. Without
+// recognising the capped shape the row is silently lost, which drops fork
+// context sources and context accounting for exactly the turns the cap touches.
+func TestHistorySourceMessageIDsSurviveReasoningCap(t *testing.T) {
+	durable := modelMessageFromSDKParts(sdk.MessageRoleAssistant, []sdk.MessagePart{
+		reasoningPart("thinking", "SIG"),
+		sdk.TextPart{Text: "answer"},
+	}, nil)
+
+	records := []historyfrag.HistoryRecord{
+		{DBMessageID: "msg-1", ModelMessage: durable},
+	}
+
+	capped := dropReasoning(durable)
+	if string(capped.Content) == string(durable.Content) {
+		t.Fatalf("precondition: dropReasoning did not rewrite the content")
+	}
+
+	ids := historySourceMessageIDsForMessages([]ModelMessage{capped}, records)
+	if len(ids) != 1 || ids[0] != "msg-1" {
+		t.Fatalf("source ids for the capped message: got %v, want [msg-1]", ids)
+	}
+}
+
+// A reasoning-only turn is projected to text rather than emptied, so its
+// provenance has to survive that projection too.
+func TestHistorySourceMessageIDsSurviveReasoningOnlyProjection(t *testing.T) {
+	durable := modelMessageFromSDKParts(sdk.MessageRoleAssistant, []sdk.MessagePart{
+		reasoningPart("only thinking", "SIG"),
+	}, nil)
+
+	records := []historyfrag.HistoryRecord{
+		{DBMessageID: "msg-2", ModelMessage: durable},
+	}
+
+	projected := dropReasoning(durable)
+	ids := historySourceMessageIDsForMessages([]ModelMessage{projected}, records)
+	if len(ids) != 1 || ids[0] != "msg-2" {
+		t.Fatalf("source ids for the projected message: got %v, want [msg-2]", ids)
+	}
+}

--- a/internal/agent/application/service_history_reasoning_test.go
+++ b/internal/agent/application/service_history_reasoning_test.go
@@ -15,8 +15,7 @@ import (
 
 func reasoningPart(text, signature string) sdk.ReasoningPart {
 	return sdk.ReasoningPart{
-		Text:   text,
-		Format: sdk.ReasoningFormatAnthropic,
+		Text: text,
 		ProviderMetadata: map[string]any{
 			"anthropic": map[string]any{"signature": signature},
 		},
@@ -97,7 +96,6 @@ func TestStripToolMessagesKeepsLatestTurnEmptyReasoning(t *testing.T) {
 		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "hi"}}},
 		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
 			sdk.ReasoningPart{
-				Format: sdk.ReasoningFormatAnthropic,
 				ProviderMetadata: map[string]any{
 					"anthropic": map[string]any{"redactedData": "BLOB"},
 				},
@@ -225,9 +223,9 @@ func TestStripToolMessagesBoundsReplayedReasoning(t *testing.T) {
 			sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "q"}}},
 			sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
 				// Several redacted blocks per turn, as a real response returns.
-				sdk.ReasoningPart{Format: sdk.ReasoningFormatAnthropic, ProviderMetadata: map[string]any{
+				sdk.ReasoningPart{ProviderMetadata: map[string]any{
 					"anthropic": map[string]any{"redactedData": "BLOB_A"}}},
-				sdk.ReasoningPart{Format: sdk.ReasoningFormatAnthropic, ProviderMetadata: map[string]any{
+				sdk.ReasoningPart{ProviderMetadata: map[string]any{
 					"anthropic": map[string]any{"redactedData": "BLOB_B"}}},
 				sdk.TextPart{Text: "a"},
 			}},

--- a/internal/agent/application/service_history_reasoning_test.go
+++ b/internal/agent/application/service_history_reasoning_test.go
@@ -224,9 +224,11 @@ func TestStripToolMessagesBoundsReplayedReasoning(t *testing.T) {
 			sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
 				// Several redacted blocks per turn, as a real response returns.
 				sdk.ReasoningPart{ProviderMetadata: map[string]any{
-					"anthropic": map[string]any{"redactedData": "BLOB_A"}}},
+					"anthropic": map[string]any{"redactedData": "BLOB_A"},
+				}},
 				sdk.ReasoningPart{ProviderMetadata: map[string]any{
-					"anthropic": map[string]any{"redactedData": "BLOB_B"}}},
+					"anthropic": map[string]any{"redactedData": "BLOB_B"},
+				}},
 				sdk.TextPart{Text: "a"},
 			}},
 		)

--- a/internal/agent/application/service_history_reasoning_test.go
+++ b/internal/agent/application/service_history_reasoning_test.go
@@ -1,0 +1,178 @@
+package application
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// Providers verify the thinking blocks of the latest assistant message and
+// reject a sequence they did not produce, so that turn's reasoning has to
+// survive context stripping. Older turns are filtered server-side, and dropping
+// them here is what keeps encrypted reasoning from accumulating across a long
+// conversation.
+
+func reasoningPart(text, signature string) sdk.ReasoningPart {
+	return sdk.ReasoningPart{
+		Text:   text,
+		Format: sdk.ReasoningFormatAnthropic,
+		ProviderMetadata: map[string]any{
+			"anthropic": map[string]any{"signature": signature},
+		},
+	}
+}
+
+func signatureOf(t *testing.T, part sdk.MessagePart) string {
+	t.Helper()
+	rp, ok := part.(sdk.ReasoningPart)
+	if !ok {
+		return ""
+	}
+	am, _ := rp.ProviderMetadata["anthropic"].(map[string]any)
+	sig, _ := am["signature"].(string)
+	return sig
+}
+
+func reasoningPartsIn(t *testing.T, msg ModelMessage) []sdk.MessagePart {
+	t.Helper()
+	var out []sdk.MessagePart
+	for _, part := range modelMessageToSDKMessage(msg).Content {
+		if _, ok := part.(sdk.ReasoningPart); ok {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// A conversation where an older assistant turn and the newest one both carry
+// reasoning alongside a tool call.
+func conversationWithTwoReasoningTurns() []ModelMessage {
+	return sdkMessagesToModelMessages([]sdk.Message{
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "first"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			reasoningPart("old thinking", "SIG_OLD"),
+			sdk.TextPart{Text: "old answer"},
+			sdk.ToolCallPart{ToolCallID: "c1", ToolName: "read_file", Input: map[string]any{}},
+		}},
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "second"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			reasoningPart("new thinking", "SIG_NEW"),
+			sdk.TextPart{Text: "new answer"},
+			sdk.ToolCallPart{ToolCallID: "c2", ToolName: "read_file", Input: map[string]any{}},
+		}},
+	})
+}
+
+func TestStripToolMessagesKeepsLatestTurnReasoning(t *testing.T) {
+	stripped := stripToolMessages(conversationWithTwoReasoningTurns())
+
+	var assistants []ModelMessage
+	for _, m := range stripped {
+		if m.Role == string(sdk.MessageRoleAssistant) {
+			assistants = append(assistants, m)
+		}
+	}
+	if len(assistants) != 2 {
+		t.Fatalf("assistant messages: got %d, want 2", len(assistants))
+	}
+
+	if got := reasoningPartsIn(t, assistants[0]); len(got) != 0 {
+		t.Errorf("older turn kept %d reasoning part(s); it should be stripped", len(got))
+	}
+
+	latest := reasoningPartsIn(t, assistants[1])
+	if len(latest) != 1 {
+		t.Fatalf("latest turn reasoning parts: got %d, want 1 — its signature is the one the provider verifies", len(latest))
+	}
+	if sig := signatureOf(t, latest[0]); sig != "SIG_NEW" {
+		t.Errorf("latest turn signature: got %q, want SIG_NEW", sig)
+	}
+}
+
+// A redacted thinking block carries its whole payload in metadata, so an
+// empty-text part in the latest turn must not be mistaken for nothing.
+func TestStripToolMessagesKeepsLatestTurnEmptyReasoning(t *testing.T) {
+	messages := sdkMessagesToModelMessages([]sdk.Message{
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "hi"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Format: sdk.ReasoningFormatAnthropic,
+				ProviderMetadata: map[string]any{
+					"anthropic": map[string]any{"redactedData": "BLOB"},
+				},
+			},
+			sdk.TextPart{Text: "answer"},
+			sdk.ToolCallPart{ToolCallID: "c1", ToolName: "read_file", Input: map[string]any{}},
+		}},
+	})
+
+	stripped := stripToolMessages(messages)
+	var latest ModelMessage
+	for _, m := range stripped {
+		if m.Role == string(sdk.MessageRoleAssistant) {
+			latest = m
+		}
+	}
+
+	parts := reasoningPartsIn(t, latest)
+	if len(parts) != 1 {
+		t.Fatalf("reasoning parts: got %d, want 1 — an empty-text redacted block was dropped", len(parts))
+	}
+	rp := parts[0].(sdk.ReasoningPart)
+	am, _ := rp.ProviderMetadata["anthropic"].(map[string]any)
+	if data, _ := am["redactedData"].(string); data != "BLOB" {
+		t.Errorf("redactedData: got %q, want BLOB", data)
+	}
+}
+
+// Several reasoning blocks in the latest turn all belong to the sequence the
+// provider checks, so none of them may be dropped or reordered.
+func TestStripToolMessagesKeepsEveryBlockOfLatestTurn(t *testing.T) {
+	messages := sdkMessagesToModelMessages([]sdk.Message{
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "hi"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			reasoningPart("first", "SIG_1"),
+			reasoningPart("second", "SIG_2"),
+			reasoningPart("third", "SIG_3"),
+			sdk.ToolCallPart{ToolCallID: "c1", ToolName: "read_file", Input: map[string]any{}},
+		}},
+	})
+
+	stripped := stripToolMessages(messages)
+	var latest ModelMessage
+	for _, m := range stripped {
+		if m.Role == string(sdk.MessageRoleAssistant) {
+			latest = m
+		}
+	}
+
+	parts := reasoningPartsIn(t, latest)
+	if len(parts) != 3 {
+		t.Fatalf("reasoning parts: got %d, want 3", len(parts))
+	}
+	for i, want := range []string{"SIG_1", "SIG_2", "SIG_3"} {
+		if sig := signatureOf(t, parts[i]); sig != want {
+			t.Errorf("part %d signature: got %q, want %q (order must hold)", i, sig, want)
+		}
+	}
+}
+
+// Stripping must not resurrect reasoning in a turn that has no tool call to
+// strip — that path leaves the message untouched either way.
+func TestStripToolMessagesLeavesPlainAssistantTurnsAlone(t *testing.T) {
+	messages := sdkMessagesToModelMessages([]sdk.Message{
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "hi"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			reasoningPart("thinking", "SIG"),
+			sdk.TextPart{Text: "answer"},
+		}},
+	})
+
+	stripped := stripToolMessages(messages)
+	if len(stripped) != 2 {
+		t.Fatalf("messages: got %d, want 2", len(stripped))
+	}
+	if got := reasoningPartsIn(t, stripped[1]); len(got) != 1 {
+		t.Errorf("reasoning parts: got %d, want 1", len(got))
+	}
+}

--- a/internal/agent/application/service_history_reasoning_test.go
+++ b/internal/agent/application/service_history_reasoning_test.go
@@ -244,9 +244,12 @@ func TestStripToolMessagesBoundsReplayedReasoning(t *testing.T) {
 	}
 }
 
-// An assistant turn whose only content is reasoning must not be emptied out —
-// a contentless assistant message is not something a provider accepts.
-func TestStripToolMessagesKeepsReasoningOnlyTurnIntact(t *testing.T) {
+// An assistant turn whose only content is reasoning cannot simply lose it: an
+// emptied assistant message is dropped by sanitizeMessages and rejected by
+// providers. Projecting the thinking to text keeps the turn alive without
+// replaying an opaque block the cap is supposed to have removed — the same
+// projection durable history already applies to a live interrupted checkpoint.
+func TestStripToolMessagesProjectsOlderReasoningOnlyTurn(t *testing.T) {
 	messages := sdkMessagesToModelMessages([]sdk.Message{
 		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "q"}}},
 		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
@@ -260,7 +263,91 @@ func TestStripToolMessagesKeepsReasoningOnlyTurnIntact(t *testing.T) {
 	if len(stripped) != 4 {
 		t.Fatalf("messages: got %d, want 4", len(stripped))
 	}
-	if got := reasoningPartsIn(t, stripped[1]); len(got) != 1 {
-		t.Errorf("reasoning-only turn: got %d part(s), want it left intact", len(got))
+	if got := reasoningPartsIn(t, stripped[1]); len(got) != 0 {
+		t.Errorf("older reasoning-only turn: got %d reasoning part(s), want 0 — the cap has to reach it too", len(got))
+	}
+	if text := stripped[1].TextContent(); !strings.Contains(text, "only thinking") {
+		t.Errorf("older reasoning-only turn text: got %q, want the thinking projected into it", text)
+	}
+}
+
+// The cap is only a cap if it holds for the shape an interruption mid-thinking
+// leaves behind: assistant messages carrying reasoning and nothing else. Those
+// cannot be emptied, so a bounds check that only covers turns with answer text
+// misses the case that accumulates in practice.
+func TestStripToolMessagesBoundsReasoningOnlyTurns(t *testing.T) {
+	var messages []sdk.Message
+	for turn := 0; turn < 6; turn++ {
+		messages = append(messages,
+			sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "q"}}},
+			sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+				reasoningPart("thinking", "SIG"),
+			}},
+		)
+	}
+	messages = append(messages,
+		sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "last"}}},
+		sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.TextPart{Text: "answer"}}},
+	)
+
+	stripped := stripToolMessages(sdkMessagesToModelMessages(messages))
+	total := 0
+	for _, m := range stripped {
+		total += len(reasoningPartsIn(t, m))
+	}
+	// The latest assistant turn carries no reasoning, so nothing may be replayed.
+	if total != 0 {
+		t.Fatalf("replayed reasoning parts across 6 reasoning-only turns: got %d, want 0", total)
+	}
+}
+
+// Keeping the latest turn's thinking while dropping the tool_use it was issued
+// with leaves a reasoning block that no longer explains anything: the model is
+// shown its own decision to call a tool with no record of the call. Reasoning
+// and the call it belongs to travel together or not at all.
+func TestStripToolMessagesKeepsLatestTurnToolCallWithReasoning(t *testing.T) {
+	messages := sdkMessagesToModelMessages([]sdk.Message{
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "search"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			reasoningPart("I should search", "SIG_LATEST"),
+			sdk.ToolCallPart{ToolCallID: "c1", ToolName: "web_search", Input: map[string]any{}},
+		}},
+		{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{
+			sdk.ToolResultPart{ToolCallID: "c1", ToolName: "web_search", Result: "results"},
+		}},
+	})
+
+	stripped := stripToolMessages(messages)
+
+	var latest ModelMessage
+	for _, m := range stripped {
+		if strings.EqualFold(strings.TrimSpace(m.Role), "assistant") {
+			latest = m
+		}
+	}
+	if got := len(reasoningPartsIn(t, latest)); got != 1 {
+		t.Fatalf("latest turn reasoning parts: got %d, want 1", got)
+	}
+
+	var toolCalls int
+	for _, part := range modelMessageToSDKMessage(latest).Content {
+		if _, ok := part.(sdk.ToolCallPart); ok {
+			toolCalls++
+		}
+	}
+	if toolCalls != 1 {
+		t.Errorf("latest turn tool calls: got %d, want 1 — reasoning was kept without the call it belongs to", toolCalls)
+	}
+
+	var toolResults int
+	for _, m := range stripped {
+		for _, part := range modelMessageToSDKMessage(m).Content {
+			if _, ok := part.(sdk.ToolResultPart); ok {
+				toolResults++
+			}
+		}
+	}
+	if toolResults != 1 {
+		t.Errorf("tool results paired with the kept call: got %d, want 1", toolResults)
 	}
 }

--- a/internal/agent/application/service_history_reasoning_test.go
+++ b/internal/agent/application/service_history_reasoning_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"strings"
 	"testing"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -157,9 +158,8 @@ func TestStripToolMessagesKeepsEveryBlockOfLatestTurn(t *testing.T) {
 	}
 }
 
-// Stripping must not resurrect reasoning in a turn that has no tool call to
-// strip — that path leaves the message untouched either way.
-func TestStripToolMessagesLeavesPlainAssistantTurnsAlone(t *testing.T) {
+// The newest turn keeps its reasoning even with no tool call to strip.
+func TestStripToolMessagesKeepsLatestPlainTurnReasoning(t *testing.T) {
 	messages := sdkMessagesToModelMessages([]sdk.Message{
 		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "hi"}}},
 		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
@@ -174,5 +174,93 @@ func TestStripToolMessagesLeavesPlainAssistantTurnsAlone(t *testing.T) {
 	}
 	if got := reasoningPartsIn(t, stripped[1]); len(got) != 1 {
 		t.Errorf("reasoning parts: got %d, want 1", len(got))
+	}
+}
+
+// A plain conversational turn carries no tool call, so it never reached the
+// tool-stripping path — and its reasoning accumulated forever. Only the newest
+// turn's blocks go back now.
+func TestStripToolMessagesDropsReasoningFromPlainOlderTurns(t *testing.T) {
+	messages := sdkMessagesToModelMessages([]sdk.Message{
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "first"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			reasoningPart("old thinking", "SIG_OLD"),
+			sdk.TextPart{Text: "old answer"},
+		}},
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "second"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			reasoningPart("new thinking", "SIG_NEW"),
+			sdk.TextPart{Text: "new answer"},
+		}},
+	})
+
+	stripped := stripToolMessages(messages)
+	if len(stripped) != 4 {
+		t.Fatalf("messages: got %d, want 4 — nothing should be removed outright", len(stripped))
+	}
+
+	if got := reasoningPartsIn(t, stripped[1]); len(got) != 0 {
+		t.Errorf("older plain turn kept %d reasoning part(s); it should be dropped", len(got))
+	}
+	// The answer text has to stay: only reasoning is dropped.
+	if text := strings.TrimSpace(stripped[1].TextContent()); text != "old answer" {
+		t.Errorf("older turn text: got %q, want %q", text, "old answer")
+	}
+
+	latest := reasoningPartsIn(t, stripped[3])
+	if len(latest) != 1 {
+		t.Fatalf("latest turn reasoning: got %d, want 1", len(latest))
+	}
+	if sig := signatureOf(t, latest[0]); sig != "SIG_NEW" {
+		t.Errorf("latest turn signature: got %q, want SIG_NEW", sig)
+	}
+}
+
+// The replayed block count has to stop growing as a conversation goes on. That
+// unbounded growth is what pushed requests past the provider timeout.
+func TestStripToolMessagesBoundsReplayedReasoning(t *testing.T) {
+	var messages []sdk.Message
+	for turn := 0; turn < 8; turn++ {
+		messages = append(messages,
+			sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "q"}}},
+			sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+				// Several redacted blocks per turn, as a real response returns.
+				sdk.ReasoningPart{Format: sdk.ReasoningFormatAnthropic, ProviderMetadata: map[string]any{
+					"anthropic": map[string]any{"redactedData": "BLOB_A"}}},
+				sdk.ReasoningPart{Format: sdk.ReasoningFormatAnthropic, ProviderMetadata: map[string]any{
+					"anthropic": map[string]any{"redactedData": "BLOB_B"}}},
+				sdk.TextPart{Text: "a"},
+			}},
+		)
+	}
+
+	stripped := stripToolMessages(sdkMessagesToModelMessages(messages))
+	total := 0
+	for _, m := range stripped {
+		total += len(reasoningPartsIn(t, m))
+	}
+	if total != 2 {
+		t.Fatalf("replayed reasoning parts across 8 turns: got %d, want 2 (the newest turn only)", total)
+	}
+}
+
+// An assistant turn whose only content is reasoning must not be emptied out —
+// a contentless assistant message is not something a provider accepts.
+func TestStripToolMessagesKeepsReasoningOnlyTurnIntact(t *testing.T) {
+	messages := sdkMessagesToModelMessages([]sdk.Message{
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "q"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			reasoningPart("only thinking", "SIG"),
+		}},
+		{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{sdk.TextPart{Text: "q2"}}},
+		{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.TextPart{Text: "answer"}}},
+	})
+
+	stripped := stripToolMessages(messages)
+	if len(stripped) != 4 {
+		t.Fatalf("messages: got %d, want 4", len(stripped))
+	}
+	if got := reasoningPartsIn(t, stripped[1]); len(got) != 1 {
+		t.Errorf("reasoning-only turn: got %d part(s), want it left intact", len(got))
 	}
 }


### PR DESCRIPTION
Closes #1008

Replayed reasoning had no ceiling. Every turn sent back every earlier turn's blocks, so a conversation kept growing its own request:

```
messages=17  replayed 13 blocks
messages=23  replayed 26 blocks
messages=25  replayed 33 blocks
```

And none of it is cached — `prompt_cache.go` only breakpoints the system prompt and the last tool definition, nothing in the messages array — so all 14 KB of ciphertext measured on that conversation was re-billed at full price every turn.

The accumulation is old; what changed is the volume. `redacted_thinking` blocks used to be dropped on parse, so they never entered history. twilight-ai#45 fixed that and now they're 87% of the total (35 redacted vs 5 signed). Not a regression, then — a missing ceiling that a correctness fix made impossible to ignore. Reverting isn't on the table: dropping redacted blocks is the documented top cause of `thinking or redacted_thinking blocks in the latest assistant message cannot be modified`.

Anthropic tells us where to draw the line — it verifies the latest assistant message's thinking sequence and filters older turns server-side ("You don't need to prune old thinking yourself"). So the newest turn keeps its blocks in full, empty-text redacted ones included, and everything older loses them.

The catch, and why this took two commits: `stripToolMessages` only rewrites an assistant message when `hasToolCallContent(m)` is true. A plain conversational turn never enters that path, so the first commit capped nothing for most messages — a probe over two plain turns showed both keeping their reasoning. The second drops reasoning from every older assistant message regardless of tool calls. A turn whose only content is reasoning keeps its original shape, since emptying it would leave a contentless assistant message that providers reject.

## Verified live

Ran it against a live Claude 4.6 through a logging proxy. Replayed block counts went from climbing (13 → 19 → 26 → 33) to tracking just the newest turn (6 → 2 → 2), with one turn replaying nothing at all because its latest assistant message had no reasoning. At `messages=24` that's 2 blocks where the old behaviour sent 33. No 400s.

Seven guards, including one asserting the count stops growing across eight turns. I reverted the widening to watch it fail (`got 16, want 2`) — a dropped signature is silent until a provider rejects the next request, so a guard that has never failed isn't worth much here.

## One correction

An earlier version of this description blamed the growing request for the 2-minute provider timeouts we were seeing, because they showed up together. That was wrong: after this change the requests carry 2 blocks instead of 33 and the timeouts happen just the same. Filed separately as #1010.

twilight-ai#45 fixed per-block replay upstream; the two are independent and can merge in either order.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
