### PR TITLE
fix(memory): make source provenance bounded and resolvable

### DIFF
--- a/db/postgres/queries/memory_wiki.sql
+++ b/db/postgres/queries/memory_wiki.sql
@@ -15,12 +15,20 @@ ON CONFLICT (team_id, id) DO UPDATE SET
   source_message_ids = (
     SELECT COALESCE(jsonb_agg(ref.value ORDER BY ref.first_seen), '[]'::jsonb)
     FROM (
-      SELECT value, min(ordinality) AS first_seen
-      FROM jsonb_array_elements(
-        COALESCE(memory_nodes.source_message_ids, '[]'::jsonb)
-        || COALESCE(EXCLUDED.source_message_ids, '[]'::jsonb)
-      ) WITH ORDINALITY AS combined(value, ordinality)
-      GROUP BY value
+      SELECT deduplicated.value, deduplicated.first_seen
+      FROM (
+        SELECT value, min(ordinality) AS first_seen
+        FROM jsonb_array_elements(
+          COALESCE(memory_nodes.source_message_ids, '[]'::jsonb)
+          || COALESCE(EXCLUDED.source_message_ids, '[]'::jsonb)
+        ) WITH ORDINALITY AS combined(value, ordinality)
+        WHERE jsonb_typeof(value) = 'string'
+          AND (value #>> '{}') ~ '^[^/]+/[^/]+$'
+        GROUP BY value
+      ) AS deduplicated
+      ORDER BY deduplicated.first_seen DESC
+      -- Keep in sync with adapters.MaxSourceRefsPerMemory.
+      LIMIT 64
     ) AS ref
   ),
   profile_ref = EXCLUDED.profile_ref,

--- a/internal/agent/application/service_acp.go
+++ b/internal/agent/application/service_acp.go
@@ -876,7 +876,7 @@ func (s *Service) persistACPRound(
 		err = errors.New("ACP assistant output was not persisted")
 	}
 	if err == nil && promptErr == nil && req.UserMessagePersisted && !req.SkipMemoryExtraction {
-		go s.storeMemory(context.WithoutCancel(ctx), req, output, persisted)
+		go s.storeMemory(context.WithoutCancel(ctx), req, persisted)
 	}
 	return err
 }

--- a/internal/agent/application/service_acp.go
+++ b/internal/agent/application/service_acp.go
@@ -876,7 +876,7 @@ func (s *Service) persistACPRound(
 		err = errors.New("ACP assistant output was not persisted")
 	}
 	if err == nil && promptErr == nil && req.UserMessagePersisted && !req.SkipMemoryExtraction {
-		go s.storeMemory(context.WithoutCancel(ctx), req, round, roundSourceRefs(req, persisted))
+		go s.storeMemory(context.WithoutCancel(ctx), req, output, persisted)
 	}
 	return err
 }

--- a/internal/agent/application/service_memory.go
+++ b/internal/agent/application/service_memory.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"strings"
@@ -214,12 +215,24 @@ func (s *Service) effectiveMemorySearchTimeout() time.Duration {
 	return s.memorySearchTimeout
 }
 
-func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []ModelMessage, persisted []messagepkg.Message) {
+func (s *Service) storeMemory(ctx context.Context, req ChatRequest, persisted []messagepkg.Message) {
 	botID := strings.TrimSpace(req.BotID)
 	if botID == "" {
 		return
 	}
-	memMsgs := toProviderMessages(req, messages, persisted)
+	if req.UserMessagePersisted || req.ReusePersistedUserMessage {
+		userMessage, err := s.messageService.GetByIDBySession(ctx, req.ThreadID, req.PersistedUserMessageID)
+		if err != nil {
+			s.logger.Warn("load persisted user message for memory failed",
+				slog.String("session_id", req.ThreadID),
+				slog.String("message_id", req.PersistedUserMessageID),
+				slog.Any("error", err),
+			)
+		} else {
+			persisted = append([]messagepkg.Message{userMessage}, persisted...)
+		}
+	}
+	memMsgs := toProviderMessages(persisted)
 	if len(memMsgs) == 0 {
 		return
 	}
@@ -268,40 +281,25 @@ func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []M
 	}
 }
 
-func toProviderMessages(req ChatRequest, messages []ModelMessage, persisted []messagepkg.Message) []memprovider.Message {
-	out := make([]memprovider.Message, 0, len(messages)+1)
-	if req.UserMessagePersisted || req.ReusePersistedUserMessage {
-		if ref := memprovider.EncodeSourceRef(req.ThreadID, req.PersistedUserMessageID); ref != "" {
-			if _, _, ok := memprovider.ParseScopedSourceRef(ref); !ok {
-				ref = ""
-			}
-			if content := strings.TrimSpace(req.Query); content != "" {
-				if ref != "" {
-					out = append(out, memprovider.Message{Role: "user", Content: content, SourceMessageID: ref})
-				}
-			}
-		}
-	}
-	for i, msg := range messages {
-		if i >= len(persisted) {
-			break
+func toProviderMessages(persisted []messagepkg.Message) []memprovider.Message {
+	out := make([]memprovider.Message, 0, len(persisted))
+	for _, stored := range persisted {
+		var msg ModelMessage
+		if err := json.Unmarshal(stored.Content, &msg); err != nil {
+			continue
 		}
 		text := strings.TrimSpace(msg.TextContent())
 		if text == "" {
 			continue
 		}
-		stored := persisted[i]
 		sessionID := strings.TrimSpace(stored.SessionID)
-		if sessionID == "" {
-			sessionID = strings.TrimSpace(req.ThreadID)
-		}
 		ref := memprovider.EncodeSourceRef(sessionID, stored.ID)
 		if _, _, ok := memprovider.ParseScopedSourceRef(ref); !ok {
 			continue
 		}
-		role := strings.TrimSpace(msg.Role)
+		role := strings.TrimSpace(stored.Role)
 		if role == "" {
-			role = "assistant"
+			role = strings.TrimSpace(msg.Role)
 		}
 		out = append(out, memprovider.Message{Role: role, Content: text, SourceMessageID: ref})
 	}

--- a/internal/agent/application/service_memory.go
+++ b/internal/agent/application/service_memory.go
@@ -214,12 +214,12 @@ func (s *Service) effectiveMemorySearchTimeout() time.Duration {
 	return s.memorySearchTimeout
 }
 
-func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []ModelMessage, sourceRefs []string) {
+func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []ModelMessage, persisted []messagepkg.Message) {
 	botID := strings.TrimSpace(req.BotID)
 	if botID == "" {
 		return
 	}
-	memMsgs := toProviderMessages(messages)
+	memMsgs := toProviderMessages(req, messages, persisted)
 	if len(memMsgs) == 0 {
 		return
 	}
@@ -248,7 +248,6 @@ func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []M
 		ChannelIdentityID: strings.TrimSpace(req.SourceChannelIdentityID),
 		DisplayName:       s.resolveDisplayName(ctx, req),
 		TimezoneLocation:  tzLoc,
-		SourceMessageIDs:  sourceRefs,
 	}); err != nil {
 		s.logger.Warn("memory provider OnAfterChat failed", slog.String("bot_id", botID), slog.Any("error", err))
 		return
@@ -269,37 +268,42 @@ func (s *Service) storeMemory(ctx context.Context, req ChatRequest, messages []M
 	}
 }
 
-func roundSourceRefs(req ChatRequest, persisted []messagepkg.Message) []string {
-	refs := make([]string, 0, len(persisted)+1)
+func toProviderMessages(req ChatRequest, messages []ModelMessage, persisted []messagepkg.Message) []memprovider.Message {
+	out := make([]memprovider.Message, 0, len(messages)+1)
 	if req.UserMessagePersisted || req.ReusePersistedUserMessage {
 		if ref := memprovider.EncodeSourceRef(req.ThreadID, req.PersistedUserMessageID); ref != "" {
-			refs = append(refs, ref)
+			if _, _, ok := memprovider.ParseScopedSourceRef(ref); !ok {
+				ref = ""
+			}
+			if content := strings.TrimSpace(req.Query); content != "" {
+				if ref != "" {
+					out = append(out, memprovider.Message{Role: "user", Content: content, SourceMessageID: ref})
+				}
+			}
 		}
 	}
-	for _, msg := range persisted {
-		sessionID := msg.SessionID
-		if strings.TrimSpace(sessionID) == "" {
-			sessionID = req.ThreadID
+	for i, msg := range messages {
+		if i >= len(persisted) {
+			break
 		}
-		if ref := memprovider.EncodeSourceRef(sessionID, msg.ID); ref != "" {
-			refs = append(refs, ref)
-		}
-	}
-	return refs
-}
-
-func toProviderMessages(messages []ModelMessage) []memprovider.Message {
-	out := make([]memprovider.Message, 0, len(messages))
-	for _, msg := range messages {
 		text := strings.TrimSpace(msg.TextContent())
 		if text == "" {
+			continue
+		}
+		stored := persisted[i]
+		sessionID := strings.TrimSpace(stored.SessionID)
+		if sessionID == "" {
+			sessionID = strings.TrimSpace(req.ThreadID)
+		}
+		ref := memprovider.EncodeSourceRef(sessionID, stored.ID)
+		if _, _, ok := memprovider.ParseScopedSourceRef(ref); !ok {
 			continue
 		}
 		role := strings.TrimSpace(msg.Role)
 		if role == "" {
 			role = "assistant"
 		}
-		out = append(out, memprovider.Message{Role: role, Content: text})
+		out = append(out, memprovider.Message{Role: role, Content: text, SourceMessageID: ref})
 	}
 	return out
 }

--- a/internal/agent/application/service_store.go
+++ b/internal/agent/application/service_store.go
@@ -84,7 +84,7 @@ func (s *Service) storeRoundWithOptionsResult(ctx context.Context, req ChatReque
 		return persisted, nil
 	}
 	if !opts.SkipMemory && !req.SkipMemoryExtraction {
-		go s.storeMemory(context.WithoutCancel(ctx), req, filtered, persisted)
+		go s.storeMemory(context.WithoutCancel(ctx), req, persisted)
 	}
 
 	return persisted, nil

--- a/internal/agent/application/service_store.go
+++ b/internal/agent/application/service_store.go
@@ -72,11 +72,19 @@ func (s *Service) storeRoundWithOptionsResult(ctx context.Context, req ChatReque
 
 	persisted := s.storeMessages(ctx, req, filtered, modelID, opts)
 	opts.ContextLifecycle.SetAssistantMessageID(lastPersistedAssistantMessageID(persisted))
-	if opts.RequireCompletePersist && len(persisted) != len(filtered) {
-		return persisted, fmt.Errorf("persisted %d of %d messages", len(persisted), len(filtered))
+	if len(persisted) != len(filtered) {
+		if opts.RequireCompletePersist {
+			return persisted, fmt.Errorf("persisted %d of %d messages", len(persisted), len(filtered))
+		}
+		s.logger.Warn("skipping memory extraction for partially persisted round",
+			slog.String("bot_id", req.BotID),
+			slog.Int("persisted", len(persisted)),
+			slog.Int("expected", len(filtered)),
+		)
+		return persisted, nil
 	}
 	if !opts.SkipMemory && !req.SkipMemoryExtraction {
-		go s.storeMemory(context.WithoutCancel(ctx), req, filtered, roundSourceRefs(req, persisted))
+		go s.storeMemory(context.WithoutCancel(ctx), req, filtered, persisted)
 	}
 
 	return persisted, nil

--- a/internal/agent/application/service_store_refs_test.go
+++ b/internal/agent/application/service_store_refs_test.go
@@ -2,10 +2,12 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,33 +16,51 @@ import (
 	"github.com/memohai/memoh/internal/settings"
 )
 
-func TestToProviderMessagesKeepsContentAndPersistedSourceAligned(t *testing.T) {
+func TestToProviderMessagesKeepsPersistedContentAndSourceAligned(t *testing.T) {
 	t.Parallel()
 
 	persisted := []messagepkg.Message{
-		{ID: "msg-a", SessionID: "sess-1"},
-		{ID: "msg-b"},
+		storedMemoryTestMessage(t, "msg-a", "sess-1", "assistant", "first stored answer"),
+		storedMemoryTestMessage(t, "msg-b", "sess-1", "assistant", "second stored answer"),
 	}
-	got := toProviderMessages(ChatRequest{
-		ThreadID:               "sess-1",
-		Query:                  "original user question",
-		UserMessagePersisted:   true,
-		PersistedUserMessageID: "msg-user",
-	}, []ModelMessage{
-		{Role: "assistant", Content: newTextContent("first answer")},
-		{Role: "assistant", Content: newTextContent("second answer")},
-	}, persisted)
-	if len(got) != 3 {
-		t.Fatalf("provider messages = %v, want reused user plus two persisted messages", got)
+	got := toProviderMessages(persisted)
+	if len(got) != 2 {
+		t.Fatalf("provider messages = %v, want two persisted messages", got)
 	}
-	wantRefs := []string{"sess-1/msg-user", "sess-1/msg-a", "sess-1/msg-b"}
+	wantRefs := []string{"sess-1/msg-a", "sess-1/msg-b"}
 	for i, want := range wantRefs {
 		if got[i].SourceMessageID != want {
 			t.Fatalf("provider message %d source = %q, want %q", i, got[i].SourceMessageID, want)
 		}
 	}
-	if got[0].Content != "original user question" || got[1].Content != "first answer" || got[2].Content != "second answer" {
+	if got[0].Content != "first stored answer" || got[1].Content != "second stored answer" {
 		t.Fatalf("provider message content is misaligned: %v", got)
+	}
+}
+
+func TestToProviderMessagesUsesPrunedPersistedContent(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{
+		settingsService: settings.NewService(slog.New(slog.DiscardHandler), &storeRoundSettingsQueries{}, nil, nil),
+		logger:          slog.New(slog.DiscardHandler),
+	}
+	unit := "large tool result "
+	huge := strings.Repeat(unit, gatewayToolPayloadMaxBytes/len(unit)+2)
+	inputs, err := service.buildPersistInputs(context.Background(), ChatRequest{
+		BotID: storeRoundBotID, ThreadID: "session-1",
+	}, []ModelMessage{{Role: "tool", Content: newTextContent(huge)}}, "", storeRoundOptions{})
+	if err != nil {
+		t.Fatalf("buildPersistInputs() error = %v", err)
+	}
+	got := toProviderMessages([]messagepkg.Message{{
+		ID: "msg-tool", SessionID: "session-1", Role: "tool", Content: inputs[0].Content,
+	}})
+	if len(got) != 1 {
+		t.Fatalf("provider messages = %v, want one persisted tool message", got)
+	}
+	if got[0].Content == huge || !strings.Contains(got[0].Content, gatewayToolPayloadPrunedMarker) {
+		t.Fatalf("provider message did not use pruned persisted content: %.120q", got[0].Content)
 	}
 }
 
@@ -111,6 +131,43 @@ func TestStoreRoundPassesSourceRefsToMemory(t *testing.T) {
 	}
 }
 
+func TestStoreMemoryUsesPersistedUserContent(t *testing.T) {
+	t.Parallel()
+
+	user := storedMemoryTestMessage(t, "msg-user", "session-1", "user", "persisted user question")
+	messages := &recordingMessageService{persisted: []messagepkg.PersistInput{{
+		SessionID: user.SessionID, Role: user.Role, Content: user.Content,
+	}}}
+	memory := &storeRoundMemoryProvider{afterChat: make(chan memprovider.AfterChatRequest, 1)}
+	registry := memprovider.NewRegistry(slog.New(slog.DiscardHandler))
+	registry.Register(storeRoundMemoryProviderID, memory)
+	service := &Service{
+		messageService:  messages,
+		memoryRegistry:  registry,
+		settingsService: settings.NewService(slog.New(slog.DiscardHandler), &storeRoundSettingsQueries{}, nil, nil),
+		logger:          slog.New(slog.DiscardHandler),
+	}
+
+	service.storeMemory(context.Background(), ChatRequest{
+		BotID: storeRoundBotID, ThreadID: "session-1",
+		Query:                "runtime query with generated headers",
+		UserMessagePersisted: true, PersistedUserMessageID: "msg-user",
+	}, []messagepkg.Message{
+		storedMemoryTestMessage(t, "msg-assistant", "session-1", "assistant", "stored answer"),
+	})
+
+	got := <-memory.afterChat
+	if len(got.Messages) != 2 {
+		t.Fatalf("memory messages = %v, want persisted user and assistant", got.Messages)
+	}
+	if got.Messages[0].Content != "persisted user question" || got.Messages[0].SourceMessageID != "session-1/msg-user" {
+		t.Fatalf("persisted user message = %#v", got.Messages[0])
+	}
+	if got.Messages[1].Content != "stored answer" || got.Messages[1].SourceMessageID != "session-1/msg-assistant" {
+		t.Fatalf("persisted assistant message = %#v", got.Messages[1])
+	}
+}
+
 func TestStoreRoundSkipsMemoryWhenPersistenceIsPartial(t *testing.T) {
 	t.Parallel()
 
@@ -139,4 +196,13 @@ func TestStoreRoundSkipsMemoryWhenPersistenceIsPartial(t *testing.T) {
 		t.Fatalf("memory extraction ran for partial persistence: %+v", got)
 	case <-time.After(100 * time.Millisecond):
 	}
+}
+
+func storedMemoryTestMessage(t *testing.T, id, sessionID, role, text string) messagepkg.Message {
+	t.Helper()
+	content, err := json.Marshal(ModelMessage{Role: role, Content: newTextContent(text)})
+	if err != nil {
+		t.Fatalf("marshal stored message: %v", err)
+	}
+	return messagepkg.Message{ID: id, SessionID: sessionID, Role: role, Content: content}
 }

--- a/internal/agent/application/service_store_refs_test.go
+++ b/internal/agent/application/service_store_refs_test.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -13,39 +14,51 @@ import (
 	"github.com/memohai/memoh/internal/settings"
 )
 
-func TestRoundSourceRefs(t *testing.T) {
+func TestToProviderMessagesKeepsContentAndPersistedSourceAligned(t *testing.T) {
 	t.Parallel()
 
 	persisted := []messagepkg.Message{
 		{ID: "msg-a", SessionID: "sess-1"},
 		{ID: "msg-b"},
-		{ID: ""},
 	}
-
-	got := roundSourceRefs(ChatRequest{
+	got := toProviderMessages(ChatRequest{
 		ThreadID:               "sess-1",
+		Query:                  "original user question",
 		UserMessagePersisted:   true,
 		PersistedUserMessageID: "msg-user",
+	}, []ModelMessage{
+		{Role: "assistant", Content: newTextContent("first answer")},
+		{Role: "assistant", Content: newTextContent("second answer")},
 	}, persisted)
-	want := []string{"sess-1/msg-user", "sess-1/msg-a", "sess-1/msg-b"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("roundSourceRefs = %v, want %v", got, want)
+	if len(got) != 3 {
+		t.Fatalf("provider messages = %v, want reused user plus two persisted messages", got)
 	}
-
-	got = roundSourceRefs(ChatRequest{ThreadID: "sess-1"}, persisted[:1])
-	want = []string{"sess-1/msg-a"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("roundSourceRefs without persisted user message = %v, want %v", got, want)
+	wantRefs := []string{"sess-1/msg-user", "sess-1/msg-a", "sess-1/msg-b"}
+	for i, want := range wantRefs {
+		if got[i].SourceMessageID != want {
+			t.Fatalf("provider message %d source = %q, want %q", i, got[i].SourceMessageID, want)
+		}
 	}
-
-	if got := roundSourceRefs(ChatRequest{ThreadID: "sess-1"}, nil); len(got) != 0 {
-		t.Fatalf("roundSourceRefs with no messages = %v, want empty", got)
+	if got[0].Content != "original user question" || got[1].Content != "first answer" || got[2].Content != "second answer" {
+		t.Fatalf("provider message content is misaligned: %v", got)
 	}
 }
 
 type refsRecordingMessageService struct {
 	recordingMessageService
 	persistCount int
+}
+
+type partialRefsMessageService struct {
+	refsRecordingMessageService
+}
+
+func (s *partialRefsMessageService) Persist(ctx context.Context, input messagepkg.PersistInput) (messagepkg.Message, error) {
+	if s.persistCount == 1 {
+		s.persistCount++
+		return messagepkg.Message{}, errors.New("injected second-message failure")
+	}
+	return s.refsRecordingMessageService.Persist(ctx, input)
 }
 
 func (s *refsRecordingMessageService) Persist(ctx context.Context, input messagepkg.PersistInput) (messagepkg.Message, error) {
@@ -86,10 +99,44 @@ func TestStoreRoundPassesSourceRefsToMemory(t *testing.T) {
 	select {
 	case got := <-memory.afterChat:
 		want := []string{"session-1/msg-1", "session-1/msg-2"}
-		if !slices.Equal(got.SourceMessageIDs, want) {
-			t.Fatalf("AfterChatRequest.SourceMessageIDs = %v, want %v", got.SourceMessageIDs, want)
+		refs := make([]string, 0, len(got.Messages))
+		for _, message := range got.Messages {
+			refs = append(refs, message.SourceMessageID)
+		}
+		if !slices.Equal(refs, want) {
+			t.Fatalf("AfterChatRequest message sources = %v, want %v", refs, want)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("memory provider was not called")
+	}
+}
+
+func TestStoreRoundSkipsMemoryWhenPersistenceIsPartial(t *testing.T) {
+	t.Parallel()
+
+	messages := &partialRefsMessageService{}
+	memory := &storeRoundMemoryProvider{afterChat: make(chan memprovider.AfterChatRequest, 1)}
+	registry := memprovider.NewRegistry(slog.New(slog.DiscardHandler))
+	registry.Register(storeRoundMemoryProviderID, memory)
+	resolver := &Service{
+		messageService:  messages,
+		memoryRegistry:  registry,
+		settingsService: settings.NewService(slog.New(slog.DiscardHandler), &storeRoundSettingsQueries{}, nil, nil),
+		logger:          slog.New(slog.DiscardHandler),
+	}
+
+	if err := resolver.storeRound(context.Background(), ChatRequest{
+		BotID: storeRoundBotID, ThreadID: "session-1", Query: "hello",
+	}, []ModelMessage{
+		{Role: "user", Content: newTextContent("hello")},
+		{Role: "assistant", Content: newTextContent("hi there")},
+	}, "model-1"); err != nil {
+		t.Fatalf("storeRound error: %v", err)
+	}
+
+	select {
+	case got := <-memory.afterChat:
+		t.Fatalf("memory extraction ran for partial persistence: %+v", got)
+	case <-time.After(100 * time.Millisecond):
 	}
 }

--- a/internal/agent/application/service_stream_test.go
+++ b/internal/agent/application/service_stream_test.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -76,8 +77,16 @@ func (*recordingMessageService) LocateByExternalIDBySession(context.Context, str
 	return messagepkg.LocateResult{}, nil
 }
 
-func (*recordingMessageService) GetByIDBySession(context.Context, string, string) (messagepkg.Message, error) {
-	return messagepkg.Message{}, nil
+func (s *recordingMessageService) GetByIDBySession(_ context.Context, sessionID, messageID string) (messagepkg.Message, error) {
+	for _, input := range s.persisted {
+		if input.SessionID == sessionID && input.Role == "user" {
+			return messagepkg.Message{
+				ID: messageID, SessionID: sessionID, Role: input.Role,
+				Content: input.Content, DisplayContent: input.DisplayText,
+			}, nil
+		}
+	}
+	return messagepkg.Message{}, errors.New("message not found")
 }
 
 func (*recordingMessageService) ListVisibleFromBySession(context.Context, string, string) ([]messagepkg.Message, error) {

--- a/internal/agent/application/step_commit.go
+++ b/internal/agent/application/step_commit.go
@@ -176,7 +176,7 @@ func (c *agentStepCommitter) finish(ctx context.Context, inputTokens int) error 
 		c.service.LinkOutboundAssets(ctx, c.req.BotID, c.req.ThreadID, outboundAssetRefsToMessageRefs(c.req.OutboundAssetCollector()))
 	}
 	if !c.req.SkipMemoryExtraction && len(memoryPersisted) == len(messages) && len(memoryPersisted) > 0 {
-		go c.service.storeMemory(ctx, c.req, messages, memoryPersisted)
+		go c.service.storeMemory(ctx, c.req, memoryPersisted)
 	}
 	if inputTokens > 0 {
 		go c.service.maybeCompact(ctx, c.req, c.rc, inputTokens)

--- a/internal/agent/application/step_commit.go
+++ b/internal/agent/application/step_commit.go
@@ -25,6 +25,7 @@ type agentStepCommitter struct {
 	mu                   sync.Mutex
 	turnRequestMessageID string
 	persisted            []messagepkg.Message
+	memoryPersisted      []messagepkg.Message
 	messages             []ModelMessage
 	nextStep             int // In-process ordering guard, not a durable replay cursor.
 	commitErr            error
@@ -135,6 +136,7 @@ func (c *agentStepCommitter) persist(ctx context.Context, stepIndex int, step *s
 	if !interrupted {
 		// Unfinished reasoning/text is history context, not a fact source for
 		// asynchronous long-term memory extraction.
+		c.memoryPersisted = append(c.memoryPersisted, persisted...)
 		c.messages = append(c.messages, messages...)
 	}
 	return nil
@@ -160,6 +162,7 @@ func (c *agentStepCommitter) finish(ctx context.Context, inputTokens int) error 
 	}
 	c.finalized = true
 	persisted := append([]messagepkg.Message(nil), c.persisted...)
+	memoryPersisted := append([]messagepkg.Message(nil), c.memoryPersisted...)
 	messages := append([]ModelMessage(nil), c.messages...)
 	c.mu.Unlock()
 	if len(persisted) == 0 {
@@ -172,8 +175,8 @@ func (c *agentStepCommitter) finish(ctx context.Context, inputTokens int) error 
 	if c.req.OutboundAssetCollector != nil {
 		c.service.LinkOutboundAssets(ctx, c.req.BotID, c.req.ThreadID, outboundAssetRefsToMessageRefs(c.req.OutboundAssetCollector()))
 	}
-	if !c.req.SkipMemoryExtraction {
-		go c.service.storeMemory(ctx, c.req, messages, roundSourceRefs(c.req, persisted))
+	if !c.req.SkipMemoryExtraction && len(memoryPersisted) == len(messages) && len(memoryPersisted) > 0 {
+		go c.service.storeMemory(ctx, c.req, messages, memoryPersisted)
 	}
 	if inputTokens > 0 {
 		go c.service.maybeCompact(ctx, c.req, c.rc, inputTokens)

--- a/internal/agent/tool/history.go
+++ b/internal/agent/tool/history.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	sdk "github.com/memohai/twilight-ai/sdk"
 
@@ -30,6 +31,7 @@ type SessionLister interface {
 type HistoryMessageReader interface {
 	ListLatestBySession(ctx context.Context, sessionID string, limit int32) ([]messagepkg.Message, error)
 	ListBeforeBySession(ctx context.Context, sessionID string, before time.Time, limit int32) ([]messagepkg.Message, error)
+	GetByIDBySession(ctx context.Context, sessionID string, messageID string) (messagepkg.Message, error)
 }
 
 // HistoryProvider exposes list_sessions, get_messages, and search_messages tools.
@@ -60,7 +62,7 @@ func (*HistoryProvider) Usage(_ context.Context, _ SessionContext, available Ava
 		parts = append(parts, ref+": List accessible chat sessions with their bound contact/route info. Filter by `type` (chat/heartbeat/schedule) or `platform`.")
 	}
 	if ref, ok := available.Ref(ToolGetMessages()); ok {
-		parts = append(parts, ref+": Get recent messages from the current or selected session.")
+		parts = append(parts, ref+": Get recent messages from the current or selected session, or resolve one exact `message_id`.")
 		if listSessionsRef != "" {
 			parts = append(parts, "Use session IDs from "+listSessionsRef+" as `session_id` for "+ref+" when reading a specific conversation.")
 		}
@@ -111,13 +113,17 @@ func (p *HistoryProvider) Tools(_ context.Context, sess SessionContext) ([]sdk.T
 		s := sess
 		tools = append(tools, sdk.Tool{
 			Name:        ToolGetMessages().String(),
-			Description: "Get recent messages from a chat session. Defaults to the current session. Results are returned oldest-first.",
+			Description: "Get recent messages from a chat session, or resolve one exact message ID. Defaults to the current session. Results are returned oldest-first.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"session_id": map[string]any{
 						"type":        "string",
 						"description": "Session ID to read. Defaults to the current session when omitted.",
+					},
+					"message_id": map[string]any{
+						"type":        "string",
+						"description": "Exact persisted message ID to resolve, such as a message_id returned in search_memory source_refs.",
 					},
 					"before": map[string]any{
 						"type":        "string",
@@ -286,13 +292,27 @@ func (p *HistoryProvider) execGetMessages(ctx context.Context, sess SessionConte
 			return nil, err
 		}
 	}
+	messageID := strings.TrimSpace(StringArg(args, "message_id"))
+	if messageID != "" && strings.TrimSpace(StringArg(args, "before")) != "" {
+		return nil, errors.New("message_id and before cannot be used together")
+	}
 
 	var (
 		messages []messagepkg.Message
 		err      error
 		before   time.Time
 	)
-	if rawBefore := StringArg(args, "before"); rawBefore != "" {
+	if messageID != "" {
+		message, loadErr := p.messages.GetByIDBySession(ctx, sessionID, messageID)
+		switch {
+		case errors.Is(loadErr, pgx.ErrNoRows):
+			messages = []messagepkg.Message{}
+		case loadErr != nil:
+			return nil, loadErr
+		default:
+			messages = []messagepkg.Message{message}
+		}
+	} else if rawBefore := StringArg(args, "before"); rawBefore != "" {
 		before, err = parseFlexibleTime(rawBefore)
 		if err != nil {
 			return nil, err
@@ -318,6 +338,9 @@ func (p *HistoryProvider) execGetMessages(ctx context.Context, sess SessionConte
 		"messages": results,
 	}
 	out["session_id"] = sessionID
+	if messageID != "" {
+		out["message_id"] = messageID
+	}
 	if !before.IsZero() {
 		out["before"] = sess.FormatTime(before)
 	}

--- a/internal/agent/tool/history_test.go
+++ b/internal/agent/tool/history_test.go
@@ -22,9 +22,13 @@ func (f fakeHistorySessionLister) ListByBot(_ context.Context, _ string) ([]sess
 type fakeHistoryMessageReader struct {
 	latestSessionID string
 	beforeSessionID string
+	exactSessionID  string
+	exactMessageID  string
 	before          time.Time
 	latestMessages  []messagepkg.Message
 	beforeMessages  []messagepkg.Message
+	exactMessage    messagepkg.Message
+	exactErr        error
 }
 
 func (f *fakeHistoryMessageReader) ListLatestBySession(_ context.Context, sessionID string, _ int32) ([]messagepkg.Message, error) {
@@ -36,6 +40,12 @@ func (f *fakeHistoryMessageReader) ListBeforeBySession(_ context.Context, sessio
 	f.beforeSessionID = sessionID
 	f.before = before
 	return f.beforeMessages, nil
+}
+
+func (f *fakeHistoryMessageReader) GetByIDBySession(_ context.Context, sessionID string, messageID string) (messagepkg.Message, error) {
+	f.exactSessionID = sessionID
+	f.exactMessageID = messageID
+	return f.exactMessage, f.exactErr
 }
 
 func TestHistoryProviderGetMessagesDefaultsToCurrentSession(t *testing.T) {
@@ -117,6 +127,39 @@ func TestHistoryProviderGetMessagesBeforeUsesRequestedSession(t *testing.T) {
 	messages := out["messages"].([]map[string]any)
 	if messages[0]["text"] != "before cursor" {
 		t.Fatalf("message text = %v, want before cursor", messages[0]["text"])
+	}
+}
+
+func TestHistoryProviderGetMessagesResolvesExactSourceRef(t *testing.T) {
+	t.Parallel()
+
+	reader := &fakeHistoryMessageReader{exactMessage: historyTestMessage(
+		t, "msg-source", "session-current", "user", "supporting detail", time.Date(2026, 6, 14, 8, 0, 0, 0, time.UTC),
+	)}
+	provider := NewHistoryProvider(nil, nil, reader, nil)
+	got, err := provider.execGetMessages(context.Background(), SessionContext{
+		BotID: "bot-1", SessionID: "session-current",
+	}, map[string]any{"session_id": "session-current", "message_id": "msg-source"})
+	if err != nil {
+		t.Fatalf("execGetMessages() error = %v", err)
+	}
+	if reader.exactSessionID != "session-current" || reader.exactMessageID != "msg-source" {
+		t.Fatalf("exact lookup = (%q, %q)", reader.exactSessionID, reader.exactMessageID)
+	}
+	messages := got.(map[string]any)["messages"].([]map[string]any)
+	if len(messages) != 1 || messages[0]["text"] != "supporting detail" {
+		t.Fatalf("exact messages = %v", messages)
+	}
+}
+
+func TestHistoryProviderGetMessagesRejectsExactLookupWithBefore(t *testing.T) {
+	t.Parallel()
+	provider := NewHistoryProvider(nil, nil, &fakeHistoryMessageReader{}, nil)
+	_, err := provider.execGetMessages(context.Background(), SessionContext{
+		BotID: "bot-1", SessionID: "session-current",
+	}, map[string]any{"message_id": "msg-source", "before": "2026-06-14T09:00:00Z"})
+	if err == nil {
+		t.Fatal("execGetMessages() error = nil, want ambiguous argument error")
 	}
 }
 

--- a/internal/agent/tool/memory.go
+++ b/internal/agent/tool/memory.go
@@ -13,6 +13,8 @@ import (
 	"github.com/memohai/memoh/internal/settings"
 )
 
+const maxVisibleMemorySourceRefs = memprovider.MaxSourceRefsPerToolResult
+
 // MemorySettingsReader returns bot settings for memory provider resolution.
 type MemorySettingsReader interface {
 	GetBot(ctx context.Context, botID string) (settings.Settings, error)
@@ -42,10 +44,14 @@ func (*MemoryProvider) Usage(_ context.Context, _ SessionContext, available Avai
 	if !ok {
 		return ""
 	}
-	return usageSection("Long-term memory", []string{
+	parts := []string{
 		"Use " + ref + " to recall durable user preferences, prior conversations, project context, and other long-term facts beyond the current context window.",
 		"When retrieved memory conflicts with the latest user message or visible context, treat the latest user message and current context as authoritative.",
-	})
+	}
+	if historyRef, historyOK := available.Ref(ToolGetMessages()); historyOK {
+		parts = append(parts, "When "+ref+" returns `source_refs`, verify exact supporting messages with "+historyRef+" by passing both `session_id` and `message_id` from a ref.")
+	}
+	return usageSection("Long-term memory", parts)
 }
 
 func (p *MemoryProvider) Tools(ctx context.Context, session SessionContext) ([]sdk.Tool, error) {
@@ -138,11 +144,24 @@ func visibleSourceRefs(value any, allowed map[string]struct{}) []map[string]any 
 		return nil
 	}
 	filtered := make([]map[string]any, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
 	for _, ref := range refs {
 		sessionID, _ := ref["session_id"].(string)
-		if historySessionVisible(allowed, sessionID) {
-			filtered = append(filtered, ref)
+		messageID, _ := ref["message_id"].(string)
+		sessionID = strings.TrimSpace(sessionID)
+		messageID = strings.TrimSpace(messageID)
+		if !historySessionVisible(allowed, sessionID) || messageID == "" {
+			continue
 		}
+		key := memprovider.EncodeSourceRef(sessionID, messageID)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		filtered = append(filtered, map[string]any{"session_id": sessionID, "message_id": messageID})
+	}
+	if len(filtered) > maxVisibleMemorySourceRefs {
+		filtered = filtered[len(filtered)-maxVisibleMemorySourceRefs:]
 	}
 	return filtered
 }

--- a/internal/agent/tool/memory_source_refs_test.go
+++ b/internal/agent/tool/memory_source_refs_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	session "github.com/memohai/memoh/internal/chat/thread"
@@ -42,6 +43,30 @@ func TestMemoryProviderFiltersSourceRefsByHistoryVisibility(t *testing.T) {
 		if ref["session_id"] == "session-bob" || ref["message_id"] == "legacy-unscoped" {
 			t.Fatalf("inaccessible source ref leaked: %v", ref)
 		}
+	}
+}
+
+func TestVisibleSourceRefsValidatesBeforeCapping(t *testing.T) {
+	t.Parallel()
+	refs := make([]map[string]any, 0, maxVisibleMemorySourceRefs+2)
+	for i := 0; i < maxVisibleMemorySourceRefs; i++ {
+		refs = append(refs, map[string]any{
+			"session_id": "session-current", "message_id": fmt.Sprintf("message-%02d", i), "private": "drop-me",
+		})
+	}
+	refs = append(refs,
+		map[string]any{"session_id": "session-current", "message_id": ""},
+		map[string]any{"session_id": "session-current"},
+	)
+	got := visibleSourceRefs(refs, map[string]struct{}{"session-current": {}})
+	if len(got) != maxVisibleMemorySourceRefs {
+		t.Fatalf("visibleSourceRefs() length = %d, want %d: %v", len(got), maxVisibleMemorySourceRefs, got)
+	}
+	if got[0]["message_id"] != "message-00" || got[len(got)-1]["message_id"] != "message-07" {
+		t.Fatalf("visibleSourceRefs() = %v, want all valid refs", got)
+	}
+	if _, leaked := got[0]["private"]; leaked {
+		t.Fatalf("visibleSourceRefs() leaked provider-controlled fields: %v", got[0])
 	}
 }
 

--- a/internal/agent/tool/usage_test.go
+++ b/internal/agent/tool/usage_test.go
@@ -739,6 +739,12 @@ func TestMemoryProviderUsageGatesSearchMemory(t *testing.T) {
 			t.Fatalf("Usage with search_memory should mention %q, got:\n%s", want, got)
 		}
 	}
+	got = provider.Usage(context.Background(), SessionContext{}, availableToolsForTest(ToolSearchMemory(), ToolGetMessages()))
+	for _, want := range []string{"`source_refs`", "`get_messages`", "`session_id`", "`message_id`"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Usage with memory/history drill-down should mention %q, got:\n%s", want, got)
+		}
+	}
 }
 
 func TestSkillProviderUsageGatesUseSkill(t *testing.T) {

--- a/internal/db/postgres/sqlc/memory_wiki.sql.go
+++ b/internal/db/postgres/sqlc/memory_wiki.sql.go
@@ -439,12 +439,20 @@ ON CONFLICT (team_id, id) DO UPDATE SET
   source_message_ids = (
     SELECT COALESCE(jsonb_agg(ref.value ORDER BY ref.first_seen), '[]'::jsonb)
     FROM (
-      SELECT value, min(ordinality) AS first_seen
-      FROM jsonb_array_elements(
-        COALESCE(memory_nodes.source_message_ids, '[]'::jsonb)
-        || COALESCE(EXCLUDED.source_message_ids, '[]'::jsonb)
-      ) WITH ORDINALITY AS combined(value, ordinality)
-      GROUP BY value
+      SELECT deduplicated.value, deduplicated.first_seen
+      FROM (
+        SELECT value, min(ordinality) AS first_seen
+        FROM jsonb_array_elements(
+          COALESCE(memory_nodes.source_message_ids, '[]'::jsonb)
+          || COALESCE(EXCLUDED.source_message_ids, '[]'::jsonb)
+        ) WITH ORDINALITY AS combined(value, ordinality)
+        WHERE jsonb_typeof(value) = 'string'
+          AND (value #>> '{}') ~ '^[^/]+/[^/]+$'
+        GROUP BY value
+      ) AS deduplicated
+      ORDER BY deduplicated.first_seen DESC
+      -- Keep in sync with adapters.MaxSourceRefsPerMemory.
+      LIMIT 64
     ) AS ref
   ),
   profile_ref = EXCLUDED.profile_ref,

--- a/internal/memory/adapters/builtin/builtin.go
+++ b/internal/memory/adapters/builtin/builtin.go
@@ -18,26 +18,21 @@ const (
 
 	defaultMemoryToolLimit = 8
 	maxMemoryToolLimit     = 50
-	maxSourceRefsPerResult = 8
+	maxSourceRefsPerResult = adapters.MaxSourceRefsPerToolResult
 )
 
-// sourceRefsPayload renders the most recent source refs of a memory item as
-// tool-facing {session_id, message_id} objects.
+// sourceRefsPayload renders a bounded set of retained, scoped source refs as
+// tool-facing {session_id, message_id} objects. Validation happens before the
+// projection cap so malformed tail entries cannot crowd out valid refs.
 func sourceRefsPayload(refs []string) []map[string]any {
-	if len(refs) > maxSourceRefsPerResult {
-		refs = refs[len(refs)-maxSourceRefsPerResult:]
-	}
+	refs = adapters.RetainSourceRefs(refs, maxSourceRefsPerResult)
 	out := make([]map[string]any, 0, len(refs))
 	for _, ref := range refs {
-		sessionID, messageID := adapters.ParseSourceRef(ref)
-		if messageID == "" {
+		sessionID, messageID, ok := adapters.ParseScopedSourceRef(ref)
+		if !ok {
 			continue
 		}
-		entry := map[string]any{"message_id": messageID}
-		if sessionID != "" {
-			entry["session_id"] = sessionID
-		}
-		out = append(out, entry)
+		out = append(out, map[string]any{"session_id": sessionID, "message_id": messageID})
 	}
 	return out
 }
@@ -306,7 +301,7 @@ func (p *BuiltinProvider) OnAfterChat(ctx context.Context, req adapters.AfterCha
 		BotID:            botID,
 		Metadata:         metadata,
 		Filters:          filters,
-		SourceMessageIDs: req.SourceMessageIDs,
+		SourceMessageIDs: sourceMessageIDsFromMessages(req.Messages),
 	}); err != nil {
 		p.logger.Warn("store memory failed", slog.String("bot_id", botID), slog.Any("error", err))
 	}

--- a/internal/memory/adapters/builtin/compact.go
+++ b/internal/memory/adapters/builtin/compact.go
@@ -466,11 +466,18 @@ func completeCompactNode(node migrate.NodeSpec, sources []migrate.NodeSpec) migr
 }
 
 func mergeCompactSourceMessageIDs(nodes []migrate.NodeSpec) []string {
+	ordered := append([]migrate.NodeSpec(nil), nodes...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if !ordered[i].CapturedAt.Equal(ordered[j].CapturedAt) {
+			return ordered[i].CapturedAt.Before(ordered[j].CapturedAt)
+		}
+		return ordered[i].ID < ordered[j].ID
+	})
 	values := make([]string, 0)
-	for _, node := range nodes {
+	for _, node := range ordered {
 		values = append(values, node.SourceMessageIDs...)
 	}
-	return uniqueCompactStrings(values)
+	return adapters.NormalizeSourceRefs(values)
 }
 
 func cloneCompactMetadata(metadata map[string]any) map[string]any {

--- a/internal/memory/adapters/builtin/formation.go
+++ b/internal/memory/adapters/builtin/formation.go
@@ -47,7 +47,7 @@ func runFormation(ctx context.Context, logger *slog.Logger, llm adapters.LLM, ru
 		logger.Warn("memory formation: extract failed", slog.String("bot_id", botID), slog.Any("error", err))
 		return result
 	}
-	facts := filterNonEmpty(extracted.Facts)
+	facts, factSourceMessageIDs := normalizeExtractedFacts(extracted)
 	if len(facts) == 0 {
 		return result
 	}
@@ -72,7 +72,7 @@ func runFormation(ctx context.Context, logger *slog.Logger, llm adapters.LLM, ru
 	}
 	metadata := adapters.BuildProfileMetadata(req.UserID, req.ChannelIdentityID, req.DisplayName)
 
-	applyActions(ctx, logger, runtime, botID, decided.Actions, filters, metadata, req.SourceMessageIDs, &result)
+	applyActions(ctx, logger, runtime, botID, decided.Actions, facts, factSourceMessageIDs, filters, metadata, &result)
 	return result
 }
 
@@ -157,12 +157,13 @@ func gatherCandidates(ctx context.Context, logger *slog.Logger, runtime Runtime,
 }
 
 // applyActions executes the decided CRUD actions against the runtime.
-func applyActions(ctx context.Context, logger *slog.Logger, runtime Runtime, botID string, actions []adapters.DecisionAction, filters map[string]any, metadata map[string]any, sourceMessageIDs []string, result *formationResult) {
+func applyActions(ctx context.Context, logger *slog.Logger, runtime Runtime, botID string, actions []adapters.DecisionAction, facts []string, factSourceMessageIDs [][]string, filters map[string]any, metadata map[string]any, result *formationResult) {
 	deleted := make(map[string]struct{})
 	updated := make(map[string]struct{})
 
 	for _, action := range actions {
 		event := strings.ToUpper(strings.TrimSpace(action.Event))
+		sourceMessageIDs := sourceRefsForAction(action, facts, factSourceMessageIDs)
 		switch event {
 		case actionADD:
 			text := strings.TrimSpace(action.Text)
@@ -234,13 +235,55 @@ func applyActions(ctx context.Context, logger *slog.Logger, runtime Runtime, bot
 	}
 }
 
-func filterNonEmpty(ss []string) []string {
-	out := make([]string, 0, len(ss))
-	for _, s := range ss {
-		s = strings.TrimSpace(s)
-		if s != "" {
-			out = append(out, s)
+func normalizeExtractedFacts(resp adapters.ExtractResponse) ([]string, [][]string) {
+	facts := make([]string, 0, len(resp.Facts))
+	sources := make([][]string, 0, len(resp.Facts))
+	for i, fact := range resp.Facts {
+		fact = strings.TrimSpace(fact)
+		if fact == "" {
+			continue
+		}
+		var refs []string
+		if i < len(resp.FactSourceMessageIDs) {
+			refs = adapters.NormalizeSourceRefs(resp.FactSourceMessageIDs[i])
+		}
+		facts = append(facts, fact)
+		sources = append(sources, refs)
+	}
+	return facts, sources
+}
+
+func sourceRefsForAction(action adapters.DecisionAction, facts []string, sources [][]string) []string {
+	indices := action.SourceFactIndices
+	if len(indices) == 0 {
+		// Backward-compatible models sometimes omit the new index field. Only an
+		// exact fact/action match is safe to infer; ambiguous rewrites stay
+		// uncited instead of inheriting the whole round.
+		text := normalizeActionFact(action.Text)
+		for i, fact := range facts {
+			if normalizeActionFact(fact) == text && text != "" {
+				indices = append(indices, i)
+			}
 		}
 	}
-	return out
+	refs := make([]string, 0)
+	for _, index := range indices {
+		if index < 0 || index >= len(sources) {
+			continue
+		}
+		refs = append(refs, sources[index]...)
+	}
+	return adapters.NormalizeSourceRefs(refs)
+}
+
+func normalizeActionFact(value string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(value))), " ")
+}
+
+func sourceMessageIDsFromMessages(messages []adapters.Message) []string {
+	refs := make([]string, 0, len(messages))
+	for _, message := range messages {
+		refs = append(refs, message.SourceMessageID)
+	}
+	return adapters.NormalizeSourceRefs(refs)
 }

--- a/internal/memory/adapters/builtin/formation_test.go
+++ b/internal/memory/adapters/builtin/formation_test.go
@@ -11,22 +11,23 @@ import (
 
 // fakeLLM implements adapters.LLM for testing the formation pipeline.
 type fakeLLM struct {
-	extractFacts  []string
-	extractErr    error
-	decideActions []adapters.DecisionAction
-	decideErr     error
-	compactFacts  []string
-	compactErr    error
-	compactFunc   func(adapters.CompactRequest) adapters.CompactResponse
-	extractCalls  int
-	decideCalls   int
-	compactCalls  int
-	compactReqs   []adapters.CompactRequest
+	extractFacts       []string
+	extractFactSources [][]string
+	extractErr         error
+	decideActions      []adapters.DecisionAction
+	decideErr          error
+	compactFacts       []string
+	compactErr         error
+	compactFunc        func(adapters.CompactRequest) adapters.CompactResponse
+	extractCalls       int
+	decideCalls        int
+	compactCalls       int
+	compactReqs        []adapters.CompactRequest
 }
 
 func (f *fakeLLM) Extract(_ context.Context, _ adapters.ExtractRequest) (adapters.ExtractResponse, error) {
 	f.extractCalls++
-	return adapters.ExtractResponse{Facts: f.extractFacts}, f.extractErr
+	return adapters.ExtractResponse{Facts: f.extractFacts, FactSourceMessageIDs: f.extractFactSources}, f.extractErr
 }
 
 func (f *fakeLLM) Decide(_ context.Context, _ adapters.DecideRequest) (adapters.DecideResponse, error) {

--- a/internal/memory/adapters/builtin/graph_runtime.go
+++ b/internal/memory/adapters/builtin/graph_runtime.go
@@ -141,7 +141,7 @@ func (r *graphRuntime) Add(ctx context.Context, req adapters.AddRequest) (adapte
 		CreatedAt:        now.Format(time.RFC3339),
 		UpdatedAt:        now.Format(time.RFC3339),
 		Metadata:         req.Metadata,
-		SourceMessageIDs: unionStrings(nil, req.SourceMessageIDs),
+		SourceMessageIDs: adapters.NormalizeSourceRefs(req.SourceMessageIDs),
 	}, botID)
 
 	saved, err := r.store.UpsertNode(ctx, spec)
@@ -379,7 +379,7 @@ func (r *graphRuntime) Update(ctx context.Context, req adapters.UpdateRequest) (
 	existing.ID = memoryID
 	existing.Body = text
 	existing.Hash = runtimeHash(text)
-	existing.SourceMessageIDs = unionStrings(existing.SourceMessageIDs, req.SourceMessageIDs)
+	existing.SourceMessageIDs = adapters.MergeSourceRefs(existing.SourceMessageIDs, req.SourceMessageIDs)
 	saved, err := r.store.UpsertNode(ctx, existing)
 	if err != nil {
 		return adapters.MemoryItem{}, fmt.Errorf("graph runtime: update node: %w", err)
@@ -635,33 +635,11 @@ func memoryItemToNodeSpec(item adapters.MemoryItem, botID string) migrate.NodeSp
 		Subject:          metadataStringVal(item.Metadata, "subject"),
 		Confidence:       metadataFloatVal(item.Metadata, "confidence", 0.5),
 		Metadata:         item.Metadata,
-		SourceMessageIDs: item.SourceMessageIDs,
+		SourceMessageIDs: adapters.NormalizeSourceRefs(item.SourceMessageIDs),
 		ProfileRef:       profileRef,
 		Topic:            metadataStringVal(item.Metadata, "topic"),
 		CapturedAt:       parseGraphTime(item.CreatedAt),
 	}
-}
-
-func unionStrings(existing, extra []string) []string {
-	if len(extra) == 0 {
-		return existing
-	}
-	out := make([]string, 0, len(existing)+len(extra))
-	seen := make(map[string]struct{}, len(existing)+len(extra))
-	for _, list := range [][]string{existing, extra} {
-		for _, value := range list {
-			value = strings.TrimSpace(value)
-			if value == "" {
-				continue
-			}
-			if _, ok := seen[value]; ok {
-				continue
-			}
-			seen[value] = struct{}{}
-			out = append(out, value)
-		}
-	}
-	return out
 }
 
 func metadataStringVal(m map[string]any, key string) string {

--- a/internal/memory/adapters/builtin/graph_sync.go
+++ b/internal/memory/adapters/builtin/graph_sync.go
@@ -159,6 +159,6 @@ func nodeSpecToMemoryItem(n migrate.NodeSpec) adapters.MemoryItem {
 		Score:            0,
 		Metadata:         buildNodeMetadata(n),
 		BotID:            n.BotID,
-		SourceMessageIDs: n.SourceMessageIDs,
+		SourceMessageIDs: adapters.NormalizeSourceRefs(n.SourceMessageIDs),
 	}
 }

--- a/internal/memory/adapters/builtin/source_refs_test.go
+++ b/internal/memory/adapters/builtin/source_refs_test.go
@@ -6,9 +6,11 @@ import (
 	"log/slog"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/memohai/memoh/internal/mcp"
 	adapters "github.com/memohai/memoh/internal/memory/adapters"
+	"github.com/memohai/memoh/internal/memory/migrate"
 )
 
 func TestGraphRuntimeAddPersistsSourceMessageIDs(t *testing.T) {
@@ -73,6 +75,42 @@ func TestGraphRuntimeUpdateUnionsSourceMessageIDs(t *testing.T) {
 	}
 }
 
+func TestGraphRuntimeBoundsSourceMessageIDs(t *testing.T) {
+	t.Parallel()
+	store := newFakeWikiStore()
+	rt := NewGraphRuntime(nil, store, newFakeStore())
+	refs := make([]string, 0, adapters.MaxSourceRefsPerMemory+2)
+	for i := 0; i < adapters.MaxSourceRefsPerMemory+2; i++ {
+		refs = append(refs, fmt.Sprintf("sess-1/msg-%03d", i))
+	}
+	resp, err := rt.Add(context.Background(), adapters.AddRequest{
+		Message: "bounded provenance", BotID: "bot-1", SourceMessageIDs: refs,
+	})
+	if err != nil {
+		t.Fatalf("Add error: %v", err)
+	}
+	got := resp.Results[0].SourceMessageIDs
+	if len(got) != adapters.MaxSourceRefsPerMemory {
+		t.Fatalf("stored refs = %d, want %d", len(got), adapters.MaxSourceRefsPerMemory)
+	}
+	if got[0] != "sess-1/msg-002" || got[len(got)-1] != "sess-1/msg-065" {
+		t.Fatalf("stored refs retained range = %q...%q", got[0], got[len(got)-1])
+	}
+}
+
+func TestMergeCompactSourceMessageIDsUsesCaptureOrder(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	got := mergeCompactSourceMessageIDs([]migrate.NodeSpec{
+		{ID: "newer", CapturedAt: base.Add(time.Hour), SourceMessageIDs: []string{"sess-1/msg-new"}},
+		{ID: "older", CapturedAt: base, SourceMessageIDs: []string{"sess-1/msg-old"}},
+	})
+	want := []string{"sess-1/msg-old", "sess-1/msg-new"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("mergeCompactSourceMessageIDs() = %v, want %v", got, want)
+	}
+}
+
 type capturingRuntime struct {
 	Runtime
 	addReqs    []adapters.AddRequest
@@ -101,31 +139,33 @@ func TestFormationCarriesSourceMessageIDs(t *testing.T) {
 	t.Parallel()
 	runtime := &capturingRuntime{}
 	llm := &fakeLLM{
-		extractFacts: []string{"User likes oolong tea"},
+		extractFacts:       []string{"User likes oolong tea", "User moved to Berlin"},
+		extractFactSources: [][]string{{"sess-1/msg-1"}, {"sess-1/msg-2"}},
 		decideActions: []adapters.DecisionAction{
-			{Event: "ADD", Text: "User likes oolong tea"},
-			{Event: "UPDATE", ID: "bot-1:mem_existing", Text: "User likes strong oolong tea"},
+			{Event: "ADD", Text: "User likes oolong tea", SourceFactIndices: []int{0}},
+			{Event: "UPDATE", ID: "bot-1:mem_existing", Text: "User lives in Berlin", SourceFactIndices: []int{1}},
 		},
 	}
-	refs := []string{"sess-1/msg-1", "sess-1/msg-2"}
 
 	runFormation(context.Background(), slog.Default(), llm, runtime, adapters.AfterChatRequest{
-		BotID:            "bot-1",
-		Messages:         []adapters.Message{{Role: "user", Content: "I like oolong tea"}},
-		SourceMessageIDs: refs,
+		BotID: "bot-1",
+		Messages: []adapters.Message{
+			{Role: "user", Content: "I like oolong tea", SourceMessageID: "sess-1/msg-1"},
+			{Role: "user", Content: "I moved to Berlin", SourceMessageID: "sess-1/msg-2"},
+		},
 	})
 
 	if len(runtime.addReqs) != 1 {
 		t.Fatalf("expected 1 add request, got %d", len(runtime.addReqs))
 	}
-	if !slices.Equal(runtime.addReqs[0].SourceMessageIDs, refs) {
-		t.Fatalf("ADD SourceMessageIDs = %v, want %v", runtime.addReqs[0].SourceMessageIDs, refs)
+	if want := []string{"sess-1/msg-1"}; !slices.Equal(runtime.addReqs[0].SourceMessageIDs, want) {
+		t.Fatalf("ADD SourceMessageIDs = %v, want %v", runtime.addReqs[0].SourceMessageIDs, want)
 	}
 	if len(runtime.updateReqs) != 1 {
 		t.Fatalf("expected 1 update request, got %d", len(runtime.updateReqs))
 	}
-	if !slices.Equal(runtime.updateReqs[0].SourceMessageIDs, refs) {
-		t.Fatalf("UPDATE SourceMessageIDs = %v, want %v", runtime.updateReqs[0].SourceMessageIDs, refs)
+	if want := []string{"sess-1/msg-2"}; !slices.Equal(runtime.updateReqs[0].SourceMessageIDs, want) {
+		t.Fatalf("UPDATE SourceMessageIDs = %v, want %v", runtime.updateReqs[0].SourceMessageIDs, want)
 	}
 }
 
@@ -170,7 +210,6 @@ func TestCallToolSearchMemoryReturnsSourceRefs(t *testing.T) {
 	}
 	want := []map[string]any{
 		{"session_id": "sess-1", "message_id": "msg-1"},
-		{"message_id": "msg-2"},
 	}
 	if len(refs) != len(want) {
 		t.Fatalf("source_refs = %v, want %v", refs, want)
@@ -210,7 +249,23 @@ func TestCallToolSearchMemoryCapsSourceRefs(t *testing.T) {
 		t.Fatalf("expected 8 source_refs, got %d", len(got))
 	}
 	if got[0]["message_id"] != "msg-03" || got[7]["message_id"] != "msg-10" {
-		t.Fatalf("expected most recent 8 refs, got first=%v last=%v", got[0], got[7])
+		t.Fatalf("expected retained tail of 8 refs, got first=%v last=%v", got[0], got[7])
+	}
+}
+
+func TestCallToolSearchMemoryValidatesBeforeCappingSourceRefs(t *testing.T) {
+	t.Parallel()
+	refs := make([]string, 0, 10)
+	for i := 1; i <= 8; i++ {
+		refs = append(refs, fmt.Sprintf("sess-1/msg-%02d", i))
+	}
+	refs = append(refs, "bare-message", "broken/")
+	got := sourceRefsPayload(refs)
+	if len(got) != 8 {
+		t.Fatalf("sourceRefsPayload() length = %d, want 8 valid refs: %v", len(got), got)
+	}
+	if got[0]["message_id"] != "msg-01" || got[7]["message_id"] != "msg-08" {
+		t.Fatalf("sourceRefsPayload() = %v, want all valid refs", got)
 	}
 }
 

--- a/internal/memory/adapters/sourceref.go
+++ b/internal/memory/adapters/sourceref.go
@@ -2,7 +2,17 @@ package adapters
 
 import "strings"
 
-const sourceRefSeparator = "/"
+const (
+	sourceRefSeparator = "/"
+
+	// MaxSourceRefsPerMemory bounds durable provenance growth for one memory.
+	// The PostgreSQL upsert enforces the same limit atomically.
+	MaxSourceRefsPerMemory = 64
+
+	// MaxSourceRefsPerToolResult bounds source locators exposed for one memory
+	// hit after validation and authorization.
+	MaxSourceRefsPerToolResult = 8
+)
 
 // EncodeSourceRef builds a "<sessionID>/<messageID>" source ref. The session
 // part is optional so bare message IDs stay valid refs.
@@ -30,4 +40,61 @@ func ParseSourceRef(ref string) (sessionID, messageID string) {
 		return "", ref
 	}
 	return strings.TrimSpace(session), strings.TrimSpace(message)
+}
+
+// ParseScopedSourceRef accepts only the durable ref shape emitted by the chat
+// persistence path. Bare legacy message IDs cannot be authorized across
+// sessions and malformed multi-segment refs are rejected.
+func ParseScopedSourceRef(ref string) (sessionID, messageID string, ok bool) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || strings.Count(ref, sourceRefSeparator) != 1 {
+		return "", "", false
+	}
+	sessionID, messageID = ParseSourceRef(ref)
+	if sessionID == "" || messageID == "" {
+		return "", "", false
+	}
+	return sessionID, messageID, true
+}
+
+// NormalizeSourceRefs validates, de-duplicates, and retains the newest
+// associations up to the durable per-memory limit. Input order is association
+// order; retained output keeps that order.
+func NormalizeSourceRefs(refs []string) []string {
+	return RetainSourceRefs(refs, MaxSourceRefsPerMemory)
+}
+
+// MergeSourceRefs appends new associations to existing provenance and applies
+// the same canonical validation and bound used at storage boundaries.
+func MergeSourceRefs(existing, extra []string) []string {
+	combined := make([]string, 0, len(existing)+len(extra))
+	combined = append(combined, existing...)
+	combined = append(combined, extra...)
+	return NormalizeSourceRefs(combined)
+}
+
+// RetainSourceRefs validates before applying the limit, so malformed tail
+// entries cannot crowd out older valid provenance.
+func RetainSourceRefs(refs []string, limit int) []string {
+	if limit <= 0 || len(refs) == 0 {
+		return nil
+	}
+	valid := make([]string, 0, min(len(refs), limit))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		sessionID, messageID, ok := ParseScopedSourceRef(ref)
+		if !ok {
+			continue
+		}
+		canonical := EncodeSourceRef(sessionID, messageID)
+		if _, exists := seen[canonical]; exists {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		valid = append(valid, canonical)
+	}
+	if len(valid) > limit {
+		valid = valid[len(valid)-limit:]
+	}
+	return append([]string(nil), valid...)
 }

--- a/internal/memory/adapters/sourceref_test.go
+++ b/internal/memory/adapters/sourceref_test.go
@@ -1,6 +1,10 @@
 package adapters
 
-import "testing"
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
 
 func TestEncodeSourceRef(t *testing.T) {
 	t.Parallel()
@@ -57,5 +61,41 @@ func TestEncodeParseSourceRefRoundTrip(t *testing.T) {
 	session, message := ParseSourceRef(ref)
 	if session != "0d9c1a2b-3e4f-4a5b-8c6d-7e8f9a0b1c2d" || message != "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d" {
 		t.Fatalf("round trip failed: got (%q, %q)", session, message)
+	}
+}
+
+func TestParseScopedSourceRefRejectsUnscopedAndMalformedRefs(t *testing.T) {
+	t.Parallel()
+	for _, ref := range []string{"", "msg-1", "/msg-1", "sess-1/", "sess-1/msg-1/extra"} {
+		if sessionID, messageID, ok := ParseScopedSourceRef(ref); ok {
+			t.Fatalf("ParseScopedSourceRef(%q) = (%q, %q, true), want rejected", ref, sessionID, messageID)
+		}
+	}
+	if sessionID, messageID, ok := ParseScopedSourceRef(" sess-1/msg-1 "); !ok || sessionID != "sess-1" || messageID != "msg-1" {
+		t.Fatalf("ParseScopedSourceRef(valid) = (%q, %q, %v)", sessionID, messageID, ok)
+	}
+}
+
+func TestRetainSourceRefsValidatesBeforeCapping(t *testing.T) {
+	t.Parallel()
+	refs := []string{"sess-1/msg-1", "sess-1/msg-2", "bare", "broken/", "also/broken/tail"}
+	want := []string{"sess-1/msg-1", "sess-1/msg-2"}
+	if got := RetainSourceRefs(refs, 2); !slices.Equal(got, want) {
+		t.Fatalf("RetainSourceRefs() = %v, want %v", got, want)
+	}
+}
+
+func TestMergeSourceRefsBoundsDurableProvenance(t *testing.T) {
+	t.Parallel()
+	existing := make([]string, 0, MaxSourceRefsPerMemory)
+	for i := 0; i < MaxSourceRefsPerMemory; i++ {
+		existing = append(existing, fmt.Sprintf("sess-1/msg-%03d", i))
+	}
+	got := MergeSourceRefs(existing, []string{"sess-1/msg-010", "unscoped", "sess-1/msg-new"})
+	if len(got) != MaxSourceRefsPerMemory {
+		t.Fatalf("MergeSourceRefs() length = %d, want %d", len(got), MaxSourceRefsPerMemory)
+	}
+	if got[0] != "sess-1/msg-001" || got[len(got)-1] != "sess-1/msg-new" {
+		t.Fatalf("MergeSourceRefs() retained range = %q...%q", got[0], got[len(got)-1])
 	}
 }

--- a/internal/memory/adapters/types.go
+++ b/internal/memory/adapters/types.go
@@ -27,7 +27,6 @@ type AfterChatRequest struct {
 	ChannelIdentityID string
 	DisplayName       string
 	TimezoneLocation  *time.Location
-	SourceMessageIDs  []string
 }
 
 // LLM is the interface for LLM operations needed by memory service.
@@ -38,8 +37,9 @@ type LLM interface {
 }
 
 type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role            string `json:"role"`
+	Content         string `json:"content"`
+	SourceMessageID string `json:"-"`
 }
 
 type AddRequest struct {
@@ -127,7 +127,8 @@ type ExtractRequest struct {
 }
 
 type ExtractResponse struct {
-	Facts []string `json:"facts"`
+	Facts                []string   `json:"facts"`
+	FactSourceMessageIDs [][]string `json:"-"`
 }
 
 type CandidateMemory struct {
@@ -146,10 +147,11 @@ type DecideRequest struct {
 }
 
 type DecisionAction struct {
-	Event     string `json:"event"`
-	ID        string `json:"id,omitempty"`
-	Text      string `json:"text"`
-	OldMemory string `json:"old_memory,omitempty"`
+	Event             string `json:"event"`
+	ID                string `json:"id,omitempty"`
+	Text              string `json:"text"`
+	OldMemory         string `json:"old_memory,omitempty"`
+	SourceFactIndices []int  `json:"source_fact_indices,omitempty"`
 }
 
 type DecideResponse struct {

--- a/internal/memory/memllm/client.go
+++ b/internal/memory/memllm/client.go
@@ -62,7 +62,7 @@ func (c *Client) Extract(ctx context.Context, req adapters.ExtractRequest) (adap
 	defer cancel()
 
 	var sb strings.Builder
-	for _, m := range req.Messages {
+	for i, m := range req.Messages {
 		content := strings.TrimSpace(m.Content)
 		if content == "" {
 			continue
@@ -71,6 +71,7 @@ func (c *Client) Extract(ctx context.Context, req adapters.ExtractRequest) (adap
 		if role == "" {
 			role = "user"
 		}
+		fmt.Fprintf(&sb, "[message_index=%d] ", i)
 		sb.WriteString(strings.ToUpper(role[:1]) + role[1:])
 		sb.WriteString(": ")
 		sb.WriteString(content)
@@ -101,11 +102,24 @@ func (c *Client) Extract(ctx context.Context, req adapters.ExtractRequest) (adap
 		return adapters.ExtractResponse{}, fmt.Errorf("extract: %w", err)
 	}
 
-	facts := parseExtractResponse(result.Text)
-	if len(facts) > maxExtractFacts {
-		facts = facts[:maxExtractFacts]
+	extracted := parseExtractResponseWithSources(result.Text)
+	if len(extracted) > maxExtractFacts {
+		extracted = extracted[:maxExtractFacts]
 	}
-	return adapters.ExtractResponse{Facts: facts}, nil
+	facts := make([]string, 0, len(extracted))
+	sources := make([][]string, 0, len(extracted))
+	for _, fact := range extracted {
+		refs := make([]string, 0, len(fact.MessageIndices))
+		for _, index := range fact.MessageIndices {
+			if index < 0 || index >= len(req.Messages) {
+				continue
+			}
+			refs = append(refs, req.Messages[index].SourceMessageID)
+		}
+		facts = append(facts, fact.Text)
+		sources = append(sources, adapters.NormalizeSourceRefs(refs))
+	}
+	return adapters.ExtractResponse{Facts: facts, FactSourceMessageIDs: sources}, nil
 }
 
 func (c *Client) Decide(ctx context.Context, req adapters.DecideRequest) (adapters.DecideResponse, error) {
@@ -193,7 +207,11 @@ func buildUpdateUserMessage(candidates []adapters.CandidateMemory, facts []strin
 	}
 
 	sb.WriteString("The new retrieved facts are mentioned in the triple backticks. You have to analyze the new retrieved facts and determine whether these facts should be added, updated, or deleted in the memory.\n\n```\n")
-	factsJSON, _ := json.Marshal(facts)
+	indexedFacts := make([]map[string]any, 0, len(facts))
+	for i, fact := range facts {
+		indexedFacts = append(indexedFacts, map[string]any{"index": i, "text": fact})
+	}
+	factsJSON, _ := json.Marshal(indexedFacts)
 	sb.Write(factsJSON)
 	sb.WriteString("\n```\n\n")
 
@@ -205,7 +223,8 @@ func buildUpdateUserMessage(candidates []adapters.CandidateMemory, facts []strin
       "id" : " ",
       "text" : " ",
       "event" : " ",
-      "old_memory" : " "
+      "old_memory" : " ",
+      "source_fact_indices" : [0]
     }
   ]
 }
@@ -217,6 +236,7 @@ Follow the instruction mentioned below:
 - If there is an addition, generate a new key and add the new memory corresponding to it.
 - If there is a deletion, the memory key-value pair should be removed from the memory.
 - If there is an update, the ID key should remain the same and only the value needs to be updated.
+- Every ADD or UPDATE must include source_fact_indices containing the zero-based indices of the retrieved facts that support the resulting memory. Never invent an index.
 
 Do not return anything except the JSON format.
 `)
@@ -225,18 +245,65 @@ Do not return anything except the JSON format.
 
 // --- JSON parsing helpers ---
 
-// parseExtractResponse parses the {"facts": [...]} response from Extract.
-func parseExtractResponse(text string) []string {
+type extractedFactEntry struct {
+	Text           string `json:"text"`
+	MessageIndices []int  `json:"message_indices"`
+}
+
+// parseExtractResponseWithSources parses the provenance-aware extraction
+// shape and remains compatible with legacy arrays of strings.
+func parseExtractResponseWithSources(text string) []extractedFactEntry {
 	text = extractJSONBlock(text)
 
-	var wrapper struct {
-		Facts []string `json:"facts"`
+	var objectWrapper struct {
+		Facts []extractedFactEntry `json:"facts"`
 	}
-	if json.Unmarshal([]byte(text), &wrapper) == nil && len(wrapper.Facts) > 0 {
-		return filterNonEmpty(wrapper.Facts)
+	if json.Unmarshal([]byte(text), &objectWrapper) == nil && len(objectWrapper.Facts) > 0 {
+		return filterExtractedFactEntries(objectWrapper.Facts)
+	}
+	var objectArray []extractedFactEntry
+	if json.Unmarshal([]byte(text), &objectArray) == nil && len(objectArray) > 0 {
+		return filterExtractedFactEntries(objectArray)
 	}
 
-	return parseJSONStringArray(text)
+	var legacyWrapper struct {
+		Facts []string `json:"facts"`
+	}
+	legacy := []string(nil)
+	if json.Unmarshal([]byte(text), &legacyWrapper) == nil {
+		legacy = filterNonEmpty(legacyWrapper.Facts)
+	}
+	if len(legacy) == 0 {
+		legacy = parseJSONStringArray(text)
+	}
+	entries := make([]extractedFactEntry, 0, len(legacy))
+	for _, fact := range legacy {
+		entries = append(entries, extractedFactEntry{Text: fact})
+	}
+	return entries
+}
+
+// parseExtractResponse is retained for parser compatibility tests and callers
+// that only need fact text.
+func parseExtractResponse(text string) []string {
+	entries := parseExtractResponseWithSources(text)
+	facts := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		facts = append(facts, entry.Text)
+	}
+	return facts
+}
+
+func filterExtractedFactEntries(entries []extractedFactEntry) []extractedFactEntry {
+	out := make([]extractedFactEntry, 0, len(entries))
+	for _, entry := range entries {
+		entry.Text = strings.TrimSpace(entry.Text)
+		if entry.Text == "" {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 func parseJSONStringArray(text string) []string {
@@ -250,10 +317,11 @@ func parseJSONStringArray(text string) []string {
 
 // updateResponseEntry mirrors a single item in Mem0's {"memory": [...]} response.
 type updateResponseEntry struct {
-	ID        string `json:"id"`
-	Text      string `json:"text"`
-	Event     string `json:"event"`
-	OldMemory string `json:"old_memory"`
+	ID                string `json:"id"`
+	Text              string `json:"text"`
+	Event             string `json:"event"`
+	OldMemory         string `json:"old_memory"`
+	SourceFactIndices []int  `json:"source_fact_indices"`
 }
 
 // parseUpdateResponse parses the {"memory": [...]} response from Decide.
@@ -271,10 +339,11 @@ func parseUpdateResponse(text string) []adapters.DecisionAction {
 				event = "NOOP"
 			}
 			actions = append(actions, adapters.DecisionAction{
-				Event:     event,
-				ID:        strings.TrimSpace(entry.ID),
-				Text:      strings.TrimSpace(entry.Text),
-				OldMemory: strings.TrimSpace(entry.OldMemory),
+				Event:             event,
+				ID:                strings.TrimSpace(entry.ID),
+				Text:              strings.TrimSpace(entry.Text),
+				OldMemory:         strings.TrimSpace(entry.OldMemory),
+				SourceFactIndices: entry.SourceFactIndices,
 			})
 		}
 		return actions

--- a/internal/memory/memllm/client_test.go
+++ b/internal/memory/memllm/client_test.go
@@ -106,11 +106,25 @@ func TestParseExtractResponse_EmptyFacts(t *testing.T) {
 	}
 }
 
+func TestParseExtractResponseWithSources(t *testing.T) {
+	t.Parallel()
+	result := parseExtractResponseWithSources(`{"facts":[
+		{"text":"Likes tea","message_indices":[0,2]},
+		{"text":"Lives in Berlin","message_indices":[1]}
+	]}`)
+	if len(result) != 2 || result[0].Text != "Likes tea" {
+		t.Fatalf("unexpected extracted facts: %+v", result)
+	}
+	if len(result[0].MessageIndices) != 2 || result[0].MessageIndices[1] != 2 {
+		t.Fatalf("unexpected source indices: %+v", result[0].MessageIndices)
+	}
+}
+
 func TestParseUpdateResponse_Mem0Format(t *testing.T) {
 	t.Parallel()
 	input := `{"memory": [
 		{"id": "0", "text": "User is a software engineer", "event": "NONE"},
-		{"id": "1", "text": "Name is John", "event": "ADD"},
+		{"id": "1", "text": "Name is John", "event": "ADD", "source_fact_indices":[0]},
 		{"id": "2", "text": "Loves cheese pizza", "event": "DELETE"},
 		{"id": "3", "text": "Moved to Berlin", "event": "UPDATE", "old_memory": "Lives in Tokyo"}
 	]}`
@@ -123,6 +137,9 @@ func TestParseUpdateResponse_Mem0Format(t *testing.T) {
 	}
 	if result[1].Event != "ADD" || result[1].Text != "Name is John" {
 		t.Fatalf("unexpected ADD action: %+v", result[1])
+	}
+	if len(result[1].SourceFactIndices) != 1 || result[1].SourceFactIndices[0] != 0 {
+		t.Fatalf("unexpected ADD provenance: %+v", result[1].SourceFactIndices)
 	}
 	if result[2].Event != "DELETE" || result[2].ID != "2" {
 		t.Fatalf("unexpected DELETE action: %+v", result[2])

--- a/internal/memory/memllm/prompts/memory_extract.md
+++ b/internal/memory/memllm/prompts/memory_extract.md
@@ -19,16 +19,16 @@ Input: There are branches in trees.
 Output: {"facts" : []}
 
 Input: Hi, I am looking for a restaurant in San Francisco.
-Output: {"facts" : ["Looking for a restaurant in San Francisco"]}
+Output: {"facts" : [{"text":"Looking for a restaurant in San Francisco","message_indices":[0]}]}
 
 Input: Yesterday, I had a meeting with John at 3pm. We discussed the new project.
-Output: {"facts" : ["Had a meeting with John at 3pm", "Discussed the new project"]}
+Output: {"facts" : [{"text":"Had a meeting with John at 3pm","message_indices":[0]}, {"text":"Discussed the new project","message_indices":[0]}]}
 
 Input: Hi, my name is John. I am a software engineer.
-Output: {"facts" : ["Name is John", "Is a Software engineer"]}
+Output: {"facts" : [{"text":"Name is John","message_indices":[0]}, {"text":"Is a Software engineer","message_indices":[0]}]}
 
 Input: Me favourite movies are Inception and Interstellar.
-Output: {"facts" : ["Favourite movies are Inception and Interstellar"]}
+Output: {"facts" : [{"text":"Favourite movies are Inception and Interstellar","message_indices":[0]}]}
 
 Return the facts and preferences in a json format as shown above.
 
@@ -37,7 +37,8 @@ Remember the following:
 - Do not return anything from the custom few shot example prompts provided above.
 - If you do not find anything relevant in the below conversation, you can return an empty list corresponding to the "facts" key.
 - Create the facts based on the user and assistant messages only. Do not pick anything from the system messages.
-- Make sure to return the response in the format mentioned in the examples. The response should be in json with a key as "facts" and corresponding value will be a list of strings.
+- Input transcript lines are prefixed with `[message_index=N]`. Every fact must include the zero-based `message_indices` that directly support it. Never cite a message that does not support the fact.
+- Return JSON with a `facts` list of objects shaped as `{ "text": "...", "message_indices": [0] }`.
 - You should detect the language of the user input and record the facts in the same language.
 
 Following is a conversation between the user and the assistant. You have to extract the relevant facts and preferences about the user, if any, from the conversation and return them in the json format as shown above.

--- a/internal/memory/memllm/prompts_test.go
+++ b/internal/memory/memllm/prompts_test.go
@@ -10,6 +10,11 @@ func TestEmbeddedExtractPromptHasTodayPlaceholder(t *testing.T) {
 	if !strings.Contains(memoryExtractPrompt, "{{today}}") {
 		t.Fatal("extract prompt must contain the {{today}} placeholder")
 	}
+	for _, want := range []string{"message_index", "message_indices", `"text"`} {
+		if !strings.Contains(memoryExtractPrompt, want) {
+			t.Fatalf("extract prompt must contain provenance contract %q", want)
+		}
+	}
 }
 
 func TestEmbeddedUpdatePromptNotEmpty(t *testing.T) {

--- a/internal/memory/wikistore/conv.go
+++ b/internal/memory/wikistore/conv.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	adapters "github.com/memohai/memoh/internal/memory/adapters"
 	"github.com/memohai/memoh/internal/memory/migrate"
 )
 
@@ -23,7 +24,7 @@ func nodeToRecord(n migrate.NodeSpec) record {
 		Subject:          n.Subject,
 		Confidence:       clampConfidence(n.Confidence),
 		Metadata:         n.Metadata,
-		SourceMessageIDs: n.SourceMessageIDs,
+		SourceMessageIDs: adapters.NormalizeSourceRefs(n.SourceMessageIDs),
 		ProfileRef:       n.ProfileRef,
 		Topic:            n.Topic,
 		CapturedAt:       n.CapturedAt,
@@ -42,7 +43,7 @@ func recordToNode(r record) migrate.NodeSpec {
 		Subject:          r.Subject,
 		Confidence:       r.Confidence,
 		Metadata:         r.Metadata,
-		SourceMessageIDs: r.SourceMessageIDs,
+		SourceMessageIDs: adapters.NormalizeSourceRefs(r.SourceMessageIDs),
 		ProfileRef:       r.ProfileRef,
 		Topic:            r.Topic,
 		CapturedAt:       r.CapturedAt,

--- a/internal/memory/wikistore/postgres_integration_test.go
+++ b/internal/memory/wikistore/postgres_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	dbpkg "github.com/memohai/memoh/internal/db"
 	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	adapters "github.com/memohai/memoh/internal/memory/adapters"
 	"github.com/memohai/memoh/internal/memory/migrate"
 )
 
@@ -103,5 +104,23 @@ func TestPostgresUpsertNodeConcurrentlyUnionsSourceRefs(t *testing.T) {
 	sort.Strings(want)
 	if fmt.Sprint(got.SourceMessageIDs) != fmt.Sprint(want) {
 		t.Fatalf("source refs = %v, want %v", got.SourceMessageIDs, want)
+	}
+
+	for i := 0; i < adapters.MaxSourceRefsPerMemory+20; i++ {
+		node := base
+		node.SourceMessageIDs = []string{fmt.Sprintf("session/capped-%03d", i)}
+		if _, err := store.UpsertNode(ctx, node); err != nil {
+			t.Fatalf("bounded upsert %d: %v", i, err)
+		}
+	}
+	got, err = store.GetNode(ctx, botID, nodeID)
+	if err != nil {
+		t.Fatalf("get bounded node: %v", err)
+	}
+	if len(got.SourceMessageIDs) != adapters.MaxSourceRefsPerMemory {
+		t.Fatalf("bounded source refs = %d, want %d", len(got.SourceMessageIDs), adapters.MaxSourceRefsPerMemory)
+	}
+	if got.SourceMessageIDs[0] != "session/capped-020" || got.SourceMessageIDs[len(got.SourceMessageIDs)-1] != "session/capped-083" {
+		t.Fatalf("bounded refs retained range = %q...%q", got.SourceMessageIDs[0], got.SourceMessageIDs[len(got.SourceMessageIDs)-1])
 	}
 }

--- a/internal/memory/wikistore/postgres_integration_test.go
+++ b/internal/memory/wikistore/postgres_integration_test.go
@@ -41,7 +41,7 @@ func TestPostgresUpsertNodeConcurrentlyUnionsSourceRefs(t *testing.T) {
 	}{
 		{`INSERT INTO users (id, username, email) VALUES ($1, $2, $3)`, []any{userID, username, email}},
 		{`INSERT INTO team_members (team_id, user_id, role) VALUES ($1, $2, 'member')`, []any{teamID, userID}},
-		{`INSERT INTO bots (team_id, id, owner_user_id, type, name) VALUES ($1, $2, $3, 'personal', $4)`, []any{teamID, botID, userID, botName}},
+		{`INSERT INTO bots (team_id, id, owner_user_id, name) VALUES ($1, $2, $3, $4)`, []any{teamID, botID, userID, botName}},
 	}
 	for _, statement := range fixtureStatements {
 		if _, err := pool.Exec(ctx, statement.query, statement.args...); err != nil {


### PR DESCRIPTION
## Summary

This is a stacked follow-up to #1003. Its base branch points at the current #1003 head and should be retargeted to `main` after #1003 merges.

- centralize source-ref validation, deduplication, ordering, and retention limits (64 per memory, 8 per tool result)
- keep content and provenance aligned per persisted message through extraction and memory decisions
- require fact-to-message mapping before assigning refs, with only exact-text fallback for legacy model output
- skip memory extraction after partial persistence instead of attaching refs to the wrong content
- make `search_memory` refs actionable through exact `get_messages(session_id, message_id)` lookup
- enforce the same bounded union in PostgreSQL and cover it with a real concurrent integration test

## Root causes addressed

1. Source refs had no single lifecycle invariant: producers, SQL upserts, compaction, and tool projection each applied different rules.
2. Message content and source identity traveled as parallel collections, so reused user messages and partial writes could become misaligned.
3. Extraction and decision contracts did not preserve fact-to-message provenance, causing actions to inherit an entire round's refs.
4. Search returned message locators, but the history tool could not resolve one locator exactly.

## Historical data and fallback behavior

- No heuristic backfill is performed. Historical memories without a provable message mapping remain without refs.
- Existing refs are normalized at storage/runtime boundaries and bounded when memories are updated.
- The file fallback remains ref-less by design: persisting protected message locators in agent-readable Markdown would cross the authorization boundary.

## Validation

- `mise run sqlc-generate`
- `go test ./internal/agent/application ./internal/agent/tool ./internal/memory/...`
- `go test -race ./internal/agent/application ./internal/agent/tool ./internal/memory/...`
- real PostgreSQL migration plus concurrent source-ref union/retention integration test
- `go test ./...`
- `mise run lint:go`
- `git diff --check`

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
