### PR TITLE
refactor(toolcontext): extract shared tool session context and bind to run context

### DIFF
--- a/internal/agent/runtime/acp/client/client.go
+++ b/internal/agent/runtime/acp/client/client.go
@@ -25,6 +25,7 @@ import (
 	acpprofile "github.com/memohai/memoh/internal/agent/runtime/acp/profile"
 	"github.com/memohai/memoh/internal/mcp"
 	"github.com/memohai/memoh/internal/runtimefence"
+	"github.com/memohai/memoh/internal/toolcontext"
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
@@ -448,7 +449,7 @@ func (c *clientCallbacks) updateAvailableCommands(sessionID acp.SessionId, comma
 
 func (c *clientCallbacks) ReadTextFile(ctx context.Context, p acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
 	session := c.currentToolSession()
-	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	ctx, cancel := toolcontext.Bind(ctx, session)
 	defer cancel()
 
 	toolID := "read-" + uuid.NewString()
@@ -491,7 +492,7 @@ func (c *clientCallbacks) ReadTextFile(ctx context.Context, p acp.ReadTextFileRe
 	if p.Limit != nil && *p.Limit > 0 {
 		limit = boundedPositiveInt32(*p.Limit)
 	}
-	if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
+	if err := toolcontext.ValidateRuntimeGuard(ctx, session); err != nil {
 		toolErr = err
 		return acp.ReadTextFileResponse{}, err
 	}
@@ -533,7 +534,7 @@ func (c *clientCallbacks) limitedApprovalRejectionMessage(toolName string, appro
 
 func (c *clientCallbacks) WriteTextFile(ctx context.Context, p acp.WriteTextFileRequest) (acp.WriteTextFileResponse, error) {
 	session := c.currentToolSession()
-	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	ctx, cancel := toolcontext.Bind(ctx, session)
 	defer cancel()
 
 	toolID := "write-" + uuid.NewString()
@@ -562,7 +563,7 @@ func (c *clientCallbacks) WriteTextFile(ctx context.Context, p acp.WriteTextFile
 		toolErr = err
 		return acp.WriteTextFileResponse{}, err
 	}
-	if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
+	if err := toolcontext.ValidateRuntimeGuard(ctx, session); err != nil {
 		toolErr = err
 		return acp.WriteTextFileResponse{}, err
 	}
@@ -686,14 +687,14 @@ func (c *clientCallbacks) RequestPermission(ctx context.Context, p acp.RequestPe
 		}
 	}
 	session := c.currentToolSession()
-	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	ctx, cancel := toolcontext.Bind(ctx, session)
 	defer cancel()
 	allowWithGuard := func() (acp.RequestPermissionResponse, error) {
 		resp := allowOncePermission(p)
 		if resp.Outcome.Cancelled != nil {
 			return resp, nil
 		}
-		if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
+		if err := toolcontext.ValidateRuntimeGuard(ctx, session); err != nil {
 			return acp.RequestPermissionResponse{}, err
 		}
 		return resp, nil
@@ -834,7 +835,7 @@ func (c *clientCallbacks) RequestPermission(ctx context.Context, p acp.RequestPe
 		}
 		return resp, nil
 	}
-	if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
+	if err := toolcontext.ValidateRuntimeGuard(ctx, session); err != nil {
 		return acp.RequestPermissionResponse{}, err
 	}
 	if native {
@@ -1091,7 +1092,7 @@ func (c *clientCallbacks) currentToolSession() ToolSessionContext {
 	base := c.baseSession
 	prompt := c.promptSession
 	c.mu.RUnlock()
-	return mcp.MergeToolSessionContext(base, prompt)
+	return toolcontext.Merge(base, prompt)
 }
 
 func permissionNativeToolState(state *acpToolState, quirks acpprofile.ToolQuirks) (toolCallID, toolName string, input map[string]any, ok bool) {
@@ -1548,7 +1549,7 @@ func (c *clientCallbacks) SessionUpdate(_ context.Context, p acp.SessionNotifica
 
 func (c *clientCallbacks) CreateTerminal(ctx context.Context, p acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
 	session := c.currentToolSession()
-	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	ctx, cancel := toolcontext.Bind(ctx, session)
 	defer cancel()
 	return c.terminals.CreateTerminal(ctx, p, func(toolCallID string, input map[string]any) (terminalApprovalResult, error) {
 		id, approval, err := c.approveCallbackTool(ctx, toolCallID, "exec", input)
@@ -1559,7 +1560,7 @@ func (c *clientCallbacks) CreateTerminal(ctx context.Context, p acp.CreateTermin
 		}, err
 	}, terminalRuntimeScope{
 		validate: func(guardCtx context.Context) error {
-			return mcp.ValidateRuntimeGuard(guardCtx, session)
+			return toolcontext.ValidateRuntimeGuard(guardCtx, session)
 		},
 		runContext: session.RunContext,
 	})

--- a/internal/agent/runtime/acp/client/elicitation.go
+++ b/internal/agent/runtime/acp/client/elicitation.go
@@ -13,7 +13,7 @@ import (
 
 	userinput "github.com/memohai/memoh/internal/agent/decision/input"
 	"github.com/memohai/memoh/internal/agent/event"
-	"github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/toolcontext"
 )
 
 // createElicitationRequest accepts the v0.13.5 form shape plus the optional
@@ -104,7 +104,7 @@ func (c *clientCallbacks) CreateElicitation(ctx context.Context, request createE
 	// reconnects. The blocked JSON-RPC callback and its field mapping are
 	// process-local; cancellation, timeout, or runtime teardown invalidates the
 	// waiter rather than pretending the form can resume after a process restart.
-	ctx, cancel := mcp.BindRuntimeContext(ctx, session)
+	ctx, cancel := toolcontext.Bind(ctx, session)
 	defer cancel()
 	providerMetadata := map[string]any{
 		"source":     userinput.ProviderSourceACPElicitation,

--- a/internal/agent/runtime/acp/client/session.go
+++ b/internal/agent/runtime/acp/client/session.go
@@ -20,10 +20,11 @@ import (
 	"github.com/memohai/memoh/internal/agent/event"
 	acpprofile "github.com/memohai/memoh/internal/agent/runtime/acp/profile"
 	"github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/toolcontext"
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
-type ToolSessionContext = mcp.ToolSessionContext
+type ToolSessionContext = toolcontext.Session
 
 type StartRequest struct {
 	AgentID     string

--- a/internal/agent/runtime/acp/session_pool.go
+++ b/internal/agent/runtime/acp/session_pool.go
@@ -1889,7 +1889,7 @@ func (p *SessionPool) toolHTTPHandler(h *runtimeHandle) http.Handler {
 		return nil
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		mcp.ServeToolMCPHTTPWithoutContextMerge(w, req, p.logger, p.tools, p.contexts, h.toolContext())
+		mcp.ServeToolMCPHTTP(w, req, p.logger, p.tools, p.contexts, h.toolContext())
 	})
 }
 

--- a/internal/agent/runtime/acp/sessionpool_test.go
+++ b/internal/agent/runtime/acp/sessionpool_test.go
@@ -2426,11 +2426,6 @@ func TestSessionPoolBakesOnlyStableRuntimeIdentity(t *testing.T) {
 	if baked.SessionID != "" || baked.RunID != "" || baked.SessionToken != "" || baked.ReplyTarget != "" || baked.RouteID != "" || baked.ChannelIdentityID != "" {
 		t.Fatalf("baked identity leaks per-prompt fields: %#v", baked)
 	}
-	// The pool no longer publishes ACP contexts into the shared store.
-	merged := contexts.Merge(mcp.ToolSessionContext{BotID: "bot-1", SessionID: "session-1"})
-	if merged.RunID != "" || merged.ConversationType != "" {
-		t.Fatalf("ACP context leaked into the shared store: %#v", merged)
-	}
 }
 
 func TestSessionPoolUsesWorkspaceACPToolsEndpointForContainer(t *testing.T) {

--- a/internal/agent/tool/native_source.go
+++ b/internal/agent/tool/native_source.go
@@ -14,6 +14,7 @@ import (
 	toolapproval "github.com/memohai/memoh/internal/agent/decision/approval"
 	userinput "github.com/memohai/memoh/internal/agent/decision/input"
 	"github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/toolcontext"
 )
 
 type NativeToolSourceOptions struct {
@@ -181,7 +182,7 @@ func (s *NativeToolSource) CallTool(ctx context.Context, session mcp.ToolSession
 		if !approval.approved {
 			return s.limitMCPResult(toolName, mcp.BuildToolErrorResult(approval.message)), nil
 		}
-		if err := mcp.ValidateRuntimeGuard(ctx, session); err != nil {
+		if err := toolcontext.ValidateRuntimeGuard(ctx, session); err != nil {
 			return nil, err
 		}
 		result, err := tool.Execute(&sdk.ToolExecContext{

--- a/internal/connectors/source.go
+++ b/internal/connectors/source.go
@@ -15,6 +15,7 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	mcpgw "github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/toolcontext"
 )
 
 const (
@@ -159,7 +160,7 @@ func (s *Source) CallTool(
 	}
 	callCtx, cancel := context.WithTimeout(ctx, connectorCallTimeout)
 	defer cancel()
-	if err := mcpgw.ValidateRuntimeGuard(callCtx, session); err != nil {
+	if err := toolcontext.ValidateRuntimeGuard(callCtx, session); err != nil {
 		return nil, err
 	}
 	clientSession, ok, err := s.connect(callCtx, strings.TrimSpace(session.BotID))

--- a/internal/handlers/mcp_tools.go
+++ b/internal/handlers/mcp_tools.go
@@ -79,11 +79,11 @@ func (h *ContainerdHandler) handleMCPToolsWithBotID(c echo.Context, botID string
 		if !ok {
 			return echo.NewHTTPError(http.StatusNotFound, "runtime not found")
 		}
-		mcpgw.ServeToolMCPHTTPWithoutContextMerge(c.Response().Writer, c.Request(), h.logger, h.toolGateway, h.toolContexts, session)
+		mcpgw.ServeToolMCPHTTP(c.Response().Writer, c.Request(), h.logger, h.toolGateway, h.toolContexts, session)
 		return nil
 	}
 	session := h.buildToolSessionContext(c, botID)
-	mcpgw.ServeToolMCPHTTPWithoutContextMerge(c.Response().Writer, c.Request(), h.logger, h.toolGateway, h.toolContexts, session)
+	mcpgw.ServeToolMCPHTTP(c.Response().Writer, c.Request(), h.logger, h.toolGateway, h.toolContexts, session)
 	return nil
 }
 

--- a/internal/handlers/mcp_tools_test.go
+++ b/internal/handlers/mcp_tools_test.go
@@ -364,27 +364,3 @@ func TestBuildToolSessionContextUsesAuthenticatedIdentity(t *testing.T) {
 		t.Fatalf("channel identity = %q, want authenticated user", session.ChannelIdentityID)
 	}
 }
-
-func TestBuildToolSessionContextDoesNotMergeStoredACPContextForPublicEndpoint(t *testing.T) {
-	store := mcpgw.NewToolSessionContextStore()
-	store.Put(mcpgw.ToolSessionContext{
-		BotID:            "bot-1",
-		SessionID:        "session-1",
-		RunID:            "run-latest",
-		CurrentPlatform:  "web",
-		ReplyTarget:      "reply-latest",
-		ConversationType: "private",
-	})
-
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/bots/bot-1/tools", nil)
-	req.Header.Set(headerBotID, "bot-1")
-	req.Header.Set(headerSessionID, "session-1")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-
-	session := (&ContainerdHandler{toolContexts: store}).buildToolSessionContext(c, "bot-1")
-	if session.RunID != "" || session.CurrentPlatform != "" || session.ReplyTarget != "" || session.ConversationType != "" {
-		t.Fatalf("public endpoint merged ACP context: %#v", session)
-	}
-}

--- a/internal/mcp/http_tools.go
+++ b/internal/mcp/http_tools.go
@@ -73,25 +73,15 @@ func firstNonEmptyHTTPHeader(req *http.Request, names ...string) string {
 	return ""
 }
 
+// ServeToolMCPHTTP serves a tool MCP request using the request-carried
+// session context. Callers that own richer per-run context (the ACP session
+// pool) overlay it onto the session before calling.
 func ServeToolMCPHTTP(w http.ResponseWriter, req *http.Request, log *slog.Logger, gateway *ToolGatewayService, contexts *ToolSessionContextStore, session ToolSessionContext) {
-	serveToolMCPHTTP(w, req, log, gateway, contexts, session, true)
-}
-
-// ServeToolMCPHTTPWithoutContextMerge serves a tool MCP request using the
-// request-carried session context without merging long-lived ACP session state.
-func ServeToolMCPHTTPWithoutContextMerge(w http.ResponseWriter, req *http.Request, log *slog.Logger, gateway *ToolGatewayService, contexts *ToolSessionContextStore, session ToolSessionContext) {
-	serveToolMCPHTTP(w, req, log, gateway, contexts, session, false)
-}
-
-func serveToolMCPHTTP(w http.ResponseWriter, req *http.Request, log *slog.Logger, gateway *ToolGatewayService, contexts *ToolSessionContextStore, session ToolSessionContext, mergeContext bool) {
 	if gateway == nil {
 		http.Error(w, "tool gateway not configured", http.StatusServiceUnavailable)
 		return
 	}
 	EnsureStreamableAcceptHeader(req)
-	if contexts != nil && mergeContext {
-		session = contexts.Merge(session)
-	}
 	handler := sdkmcp.NewStreamableHTTPHandler(
 		func(*http.Request) *sdkmcp.Server {
 			return BuildToolMCPServer(gateway, contexts, session)

--- a/internal/mcp/http_tools_test.go
+++ b/internal/mcp/http_tools_test.go
@@ -62,30 +62,6 @@ func TestToolGatewayMiddlewareStopsWhenOwningRunIsCanceled(t *testing.T) {
 	}
 }
 
-func TestValidateRuntimeGuardRejectsCancellationDuringGuard(t *testing.T) {
-	runCtx, cancelRun := context.WithCancel(context.Background())
-	session := ToolSessionContext{RunContext: runCtx}
-	bound, cancelBound := BindRuntimeContext(context.Background(), session)
-	defer cancelBound()
-	started := make(chan struct{})
-	release := make(chan struct{})
-	done := make(chan error, 1)
-	go func() {
-		session.RuntimeGuard = func(context.Context) error {
-			close(started)
-			<-release
-			return nil
-		}
-		done <- ValidateRuntimeGuard(bound, session)
-	}()
-	<-started
-	cancelRun()
-	close(release)
-	if err := <-done; !errors.Is(err, context.Canceled) {
-		t.Fatalf("runtime guard error = %v, want context.Canceled", err)
-	}
-}
-
 func TestToolGatewayMiddlewareScopesRuntimeToolCallsToActivePrompts(t *testing.T) {
 	provider := &gatewayTestProvider{
 		tools:      []ToolDescriptor{{Name: "echo_tool", InputSchema: map[string]any{"type": "object"}}},

--- a/internal/mcp/sources/federation/source.go
+++ b/internal/mcp/sources/federation/source.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	mcpgw "github.com/memohai/memoh/internal/mcp"
+	"github.com/memohai/memoh/internal/toolcontext"
 )
 
 const cacheTTL = 5 * time.Second
@@ -125,7 +126,7 @@ func (s *Source) CallTool(ctx context.Context, session mcpgw.ToolSessionContext,
 
 	callCtx, callCancel := context.WithTimeout(ctx, mcpCallTimeout)
 	defer callCancel()
-	if err := mcpgw.ValidateRuntimeGuard(callCtx, session); err != nil {
+	if err := toolcontext.ValidateRuntimeGuard(callCtx, session); err != nil {
 		return nil, err
 	}
 

--- a/internal/mcp/tool_gateway_service.go
+++ b/internal/mcp/tool_gateway_service.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/memohai/memoh/internal/toolcontext"
 )
 
 const (
@@ -93,7 +95,7 @@ func (s *ToolGatewayService) LookupTool(ctx context.Context, session ToolSession
 }
 
 func (s *ToolGatewayService) CallTool(ctx context.Context, session ToolSessionContext, payload ToolCallPayload) (map[string]any, error) {
-	ctx, cancel := BindRuntimeContext(ctx, session)
+	ctx, cancel := toolcontext.Bind(ctx, session)
 	defer cancel()
 
 	toolName := strings.TrimSpace(payload.Name)
@@ -121,7 +123,7 @@ func (s *ToolGatewayService) CallTool(ctx context.Context, session ToolSessionCo
 	if arguments == nil {
 		arguments = map[string]any{}
 	}
-	if err := ValidateRuntimeGuard(ctx, session); err != nil {
+	if err := toolcontext.ValidateRuntimeGuard(ctx, session); err != nil {
 		return nil, err
 	}
 	result, err := source.CallTool(ctx, session, toolName, arguments)

--- a/internal/mcp/tool_session_store.go
+++ b/internal/mcp/tool_session_store.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/memohai/memoh/internal/agent/event"
+	"github.com/memohai/memoh/internal/toolcontext"
 )
 
 // ToolSessionContextStore keeps the latest per-prompt context for long-lived
@@ -121,7 +122,7 @@ func (s *ToolSessionContextStore) Put(session ToolSessionContext) {
 	}
 	s.mu.Lock()
 	if existing, ok := s.sessions[key]; ok {
-		session = MergeToolSessionContext(existing, session)
+		session = toolcontext.Merge(existing, session)
 	}
 	s.sessions[key] = session
 	s.mu.Unlock()
@@ -141,7 +142,7 @@ func (s *ToolSessionContextStore) Merge(session ToolSessionContext) ToolSessionC
 	if !ok {
 		return session
 	}
-	return MergeToolSessionContext(session, latest)
+	return toolcontext.Merge(session, latest)
 }
 
 func (s *ToolSessionContextStore) CloseSession(sessionID string) {
@@ -241,76 +242,4 @@ func toolSessionKeyHasSessionID(key, sessionID string) bool {
 func toolStreamEventKeyHasSessionID(key, sessionID string) bool {
 	parts := strings.Split(key, "\x00")
 	return len(parts) == 3 && parts[1] == sessionID
-}
-
-// MergeToolSessionContext overlays every non-empty field of latest onto base
-// (bools are sticky-true). It is the single merge for ToolSessionContext -
-// used by the tool-context store and the ACP client callbacks - so a new
-// field only needs to be wired up here.
-func MergeToolSessionContext(base, latest ToolSessionContext) ToolSessionContext {
-	merged := base
-	if value := strings.TrimSpace(latest.BotID); value != "" {
-		merged.BotID = value
-	}
-	if value := strings.TrimSpace(latest.ChatID); value != "" {
-		merged.ChatID = value
-	}
-	if value := strings.TrimSpace(latest.RuntimeID); value != "" {
-		merged.RuntimeID = value
-	}
-	if value := strings.TrimSpace(latest.RuntimeToken); value != "" {
-		merged.RuntimeToken = value
-	}
-	if value := strings.TrimSpace(latest.SessionID); value != "" {
-		merged.SessionID = value
-	}
-	if value := strings.TrimSpace(latest.RunID); value != "" {
-		merged.RunID = value
-	}
-	if value := strings.TrimSpace(latest.SessionType); value != "" {
-		merged.SessionType = value
-	}
-	if value := strings.TrimSpace(latest.RouteID); value != "" {
-		merged.RouteID = value
-	}
-	if value := strings.TrimSpace(latest.ChannelIdentityID); value != "" {
-		merged.ChannelIdentityID = value
-	}
-	if value := strings.TrimSpace(latest.SessionToken); value != "" {
-		merged.SessionToken = value
-	}
-	if value := strings.TrimSpace(latest.CurrentPlatform); value != "" {
-		merged.CurrentPlatform = value
-	}
-	if value := strings.TrimSpace(latest.ReplyTarget); value != "" {
-		merged.ReplyTarget = value
-	}
-	if value := strings.TrimSpace(latest.ConversationType); value != "" {
-		merged.ConversationType = value
-	}
-	if latest.CanRequestUserInput {
-		merged.CanRequestUserInput = true
-	}
-	if latest.CanListUserInput {
-		merged.CanListUserInput = true
-	}
-	if latest.IsSubagent {
-		merged.IsSubagent = true
-	}
-	if latest.RuntimeActive {
-		merged.RuntimeActive = true
-	}
-	if latest.SupportsImageInput {
-		merged.SupportsImageInput = true
-	}
-	if latest.RuntimeFence.Valid() {
-		merged.RuntimeFence = latest.RuntimeFence
-	}
-	if latest.RunContext != nil {
-		merged.RunContext = latest.RunContext
-	}
-	if latest.RuntimeGuard != nil {
-		merged.RuntimeGuard = latest.RuntimeGuard
-	}
-	return merged
 }

--- a/internal/mcp/tool_session_store.go
+++ b/internal/mcp/tool_session_store.go
@@ -5,15 +5,15 @@ import (
 	"sync"
 
 	"github.com/memohai/memoh/internal/agent/event"
-	"github.com/memohai/memoh/internal/toolcontext"
 )
 
-// ToolSessionContextStore keeps the latest per-prompt context for long-lived
-// ACP MCP sessions whose HTTP headers are fixed when the agent process starts.
+// ToolSessionContextStore registers per-run tool event sinks so gateway HTTP
+// tool calls can stream lifecycle events back to the owning prompt. Session
+// context itself travels with each request (ACP runtimes overlay it from the
+// live runtime handle), so the store holds no session state.
 type ToolSessionContextStore struct {
-	mu       sync.RWMutex
-	sessions map[string]ToolSessionContext
-	sinks    map[string]*toolEventSinkEntry
+	mu    sync.RWMutex
+	sinks map[string]*toolEventSinkEntry
 }
 
 type toolEventSinkEntry struct {
@@ -45,8 +45,7 @@ func (e *toolEventSinkEntry) close() {
 
 func NewToolSessionContextStore() *ToolSessionContextStore {
 	return &ToolSessionContextStore{
-		sessions: map[string]ToolSessionContext{},
-		sinks:    map[string]*toolEventSinkEntry{},
+		sinks: map[string]*toolEventSinkEntry{},
 	}
 }
 
@@ -110,68 +109,6 @@ func (e ToolStreamEvent) ToAgentStreamEvent() (event.StreamEvent, bool) {
 	}
 }
 
-func (s *ToolSessionContextStore) Put(session ToolSessionContext) {
-	if s == nil {
-		return
-	}
-	session.BotID = strings.TrimSpace(session.BotID)
-	session.SessionID = strings.TrimSpace(session.SessionID)
-	key := toolSessionContextKey(session.BotID, session.SessionID)
-	if key == "" {
-		return
-	}
-	s.mu.Lock()
-	if existing, ok := s.sessions[key]; ok {
-		session = toolcontext.Merge(existing, session)
-	}
-	s.sessions[key] = session
-	s.mu.Unlock()
-}
-
-func (s *ToolSessionContextStore) Merge(session ToolSessionContext) ToolSessionContext {
-	if s == nil {
-		return session
-	}
-	key := toolSessionContextKey(session.BotID, session.SessionID)
-	if key == "" {
-		return session
-	}
-	s.mu.RLock()
-	latest, ok := s.sessions[key]
-	s.mu.RUnlock()
-	if !ok {
-		return session
-	}
-	return toolcontext.Merge(session, latest)
-}
-
-func (s *ToolSessionContextStore) CloseSession(sessionID string) {
-	if s == nil {
-		return
-	}
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return
-	}
-	removedSinks := make([]*toolEventSinkEntry, 0)
-	s.mu.Lock()
-	for key := range s.sessions {
-		if toolSessionKeyHasSessionID(key, sessionID) {
-			delete(s.sessions, key)
-		}
-	}
-	for key := range s.sinks {
-		if toolStreamEventKeyHasSessionID(key, sessionID) {
-			removedSinks = append(removedSinks, s.sinks[key])
-			delete(s.sinks, key)
-		}
-	}
-	s.mu.Unlock()
-	for _, entry := range removedSinks {
-		entry.close()
-	}
-}
-
 func (s *ToolSessionContextStore) AppendToolEvent(session ToolSessionContext, event ToolStreamEvent) bool {
 	if s == nil {
 		return false
@@ -216,30 +153,12 @@ func (s *ToolSessionContextStore) RegisterToolEventSink(session ToolSessionConte
 	}
 }
 
-func toolSessionContextKey(botID, sessionID string) string {
+func toolRunEventKey(botID, sessionID, runID string) string {
 	botID = strings.TrimSpace(botID)
 	sessionID = strings.TrimSpace(sessionID)
-	if botID == "" || sessionID == "" {
-		return ""
-	}
-	return botID + "\x00" + sessionID
-}
-
-func toolRunEventKey(botID, sessionID, runID string) string {
-	sessionKey := toolSessionContextKey(botID, sessionID)
 	runID = strings.TrimSpace(runID)
-	if sessionKey == "" || runID == "" {
+	if botID == "" || sessionID == "" || runID == "" {
 		return ""
 	}
-	return sessionKey + "\x00" + runID
-}
-
-func toolSessionKeyHasSessionID(key, sessionID string) bool {
-	parts := strings.Split(key, "\x00")
-	return len(parts) == 2 && parts[1] == sessionID
-}
-
-func toolStreamEventKeyHasSessionID(key, sessionID string) bool {
-	parts := strings.Split(key, "\x00")
-	return len(parts) == 3 && parts[1] == sessionID
+	return botID + "\x00" + sessionID + "\x00" + runID
 }

--- a/internal/mcp/tool_session_store_test.go
+++ b/internal/mcp/tool_session_store_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"context"
 	"testing"
 )
 
@@ -26,33 +25,6 @@ func TestToolSessionContextStoreMergesLatestPromptContext(t *testing.T) {
 	}
 	if merged.SessionToken != "header-token" {
 		t.Fatalf("SessionToken = %q, want header fallback", merged.SessionToken)
-	}
-}
-
-func TestToolSessionContextMergePreservesSupportsImageInput(t *testing.T) {
-	base := ToolSessionContext{BotID: "bot-1"}
-	merged := MergeToolSessionContext(base, ToolSessionContext{SupportsImageInput: true})
-	if !merged.SupportsImageInput {
-		t.Fatalf("SupportsImageInput = false, want true")
-	}
-}
-
-func TestToolSessionContextMergePreservesUserInputCapability(t *testing.T) {
-	base := ToolSessionContext{BotID: "bot-1"}
-	merged := MergeToolSessionContext(base, ToolSessionContext{CanRequestUserInput: true})
-	if !merged.CanRequestUserInput {
-		t.Fatalf("CanRequestUserInput = false, want true")
-	}
-}
-
-func TestToolSessionContextMergePreservesRuntimeLifecycle(t *testing.T) {
-	runCtx := context.Background()
-	guard := func(context.Context) error { return nil }
-	merged := MergeToolSessionContext(ToolSessionContext{BotID: "bot-1"}, ToolSessionContext{
-		RunContext: runCtx, RuntimeGuard: guard,
-	})
-	if merged.RunContext != runCtx || merged.RuntimeGuard == nil {
-		t.Fatalf("runtime lifecycle = context:%v guard:%v", merged.RunContext, merged.RuntimeGuard != nil)
 	}
 }
 

--- a/internal/mcp/tool_session_store_test.go
+++ b/internal/mcp/tool_session_store_test.go
@@ -4,59 +4,19 @@ import (
 	"testing"
 )
 
-func TestToolSessionContextStoreMergesLatestPromptContext(t *testing.T) {
-	store := NewToolSessionContextStore()
-	store.Put(ToolSessionContext{
-		BotID:            "bot-1",
-		SessionID:        "session-1",
-		RunID:            "run-1",
-		CurrentPlatform:  "web",
-		ReplyTarget:      "reply-1",
-		ConversationType: "private",
-	})
-
-	merged := store.Merge(ToolSessionContext{
-		BotID:        "bot-1",
-		SessionID:    "session-1",
-		SessionToken: "header-token",
-	})
-	if merged.RunID != "run-1" || merged.CurrentPlatform != "web" || merged.ReplyTarget != "reply-1" || merged.ConversationType != "private" {
-		t.Fatalf("merged context = %#v", merged)
-	}
-	if merged.SessionToken != "header-token" {
-		t.Fatalf("SessionToken = %q, want header fallback", merged.SessionToken)
-	}
-}
-
-func TestToolSessionContextStorePutPreservesExistingNonEmptyFields(t *testing.T) {
-	store := NewToolSessionContextStore()
-	store.Put(ToolSessionContext{BotID: "bot-1", SessionID: "session-1", RunID: "run-1"})
-	store.Put(ToolSessionContext{BotID: "bot-1", SessionID: "session-1", CurrentPlatform: "web"})
-
-	merged := store.Merge(ToolSessionContext{BotID: "bot-1", SessionID: "session-1"})
-	if merged.RunID != "run-1" || merged.CurrentPlatform != "web" {
-		t.Fatalf("merged context = %#v", merged)
-	}
-}
-
-func TestToolSessionContextStoreCloseSessionClearsContextAndSinks(t *testing.T) {
+func TestToolSessionContextStoreUnregisterStopsToolEvents(t *testing.T) {
 	store := NewToolSessionContextStore()
 	session := ToolSessionContext{BotID: "bot-1", SessionID: "session-1", RunID: "run-1"}
-	store.Put(ToolSessionContext{BotID: "bot-1", SessionID: "session-1", CurrentPlatform: "web"})
-	store.RegisterToolEventSink(session, func(ToolStreamEvent) {})
+	unregister := store.RegisterToolEventSink(session, func(ToolStreamEvent) {})
 
-	store.CloseSession("session-1")
+	unregister()
 
-	merged := store.Merge(ToolSessionContext{BotID: "bot-1", SessionID: "session-1"})
-	if merged.CurrentPlatform != "" {
-		t.Fatalf("stored context was not cleared: %#v", merged)
-	}
 	if delivered := store.AppendToolEvent(session, ToolStreamEvent{
 		Type:       "tool_call_start",
 		ToolCallID: "call-1",
 		ToolName:   "schedule_list",
 	}); delivered {
-		t.Fatal("AppendToolEvent delivered=true after CloseSession")
+		t.Fatal("AppendToolEvent delivered=true after unregister")
 	}
 }
 

--- a/internal/mcp/tool_types.go
+++ b/internal/mcp/tool_types.go
@@ -7,91 +7,13 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"time"
 
-	"github.com/memohai/memoh/internal/runtimefence"
+	"github.com/memohai/memoh/internal/toolcontext"
 )
 
-// ToolSessionContext carries request-scoped identity for tool execution.
-type ToolSessionContext struct {
-	BotID               string
-	ChatID              string
-	RuntimeID           string
-	RuntimeToken        string `json:"-"`
-	SessionID           string
-	RunID               string
-	ToolCallID          string
-	SessionType         string
-	RouteID             string
-	ChannelIdentityID   string
-	SessionToken        string `json:"-"`
-	CurrentPlatform     string
-	ReplyTarget         string
-	ConversationType    string
-	CanRequestUserInput bool
-	CanListUserInput    bool
-	IsSubagent          bool
-	RuntimeActive       bool
-	SupportsImageInput  bool
-	SupportsFileInput   bool
-	RuntimeFence        runtimefence.Fence          `json:"-"`
-	RunContext          context.Context             `json:"-"`
-	RuntimeGuard        func(context.Context) error `json:"-"`
-}
-
-const runtimeGuardTimeout = 5 * time.Second
-
-// BindRuntimeContext makes a tool request stop when its owning run stops.
-// Runtime-only values remain process-local and are never serialized.
-func BindRuntimeContext(ctx context.Context, session ToolSessionContext) (context.Context, context.CancelFunc) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	ctx = runtimefence.WithContext(ctx, session.RuntimeFence)
-	if session.RunContext == nil {
-		return ctx, func() {}
-	}
-	bound, cancel := context.WithCancel(ctx)
-	stop := context.AfterFunc(session.RunContext, cancel)
-	if session.RunContext.Err() != nil {
-		cancel()
-	}
-	return bound, func() {
-		stop()
-		cancel()
-	}
-}
-
-// ValidateRuntimeGuard performs the last ownership check immediately before
-// a tool effect. The check remains bound to both the request and owning run.
-func ValidateRuntimeGuard(ctx context.Context, session ToolSessionContext) error {
-	if ctx == nil {
-		return errors.New("runtime guard context is required")
-	}
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if session.RunContext != nil {
-		if err := session.RunContext.Err(); err != nil {
-			return err
-		}
-	}
-	if session.RuntimeGuard == nil {
-		return nil
-	}
-	guardCtx, cancel := context.WithTimeout(ctx, runtimeGuardTimeout)
-	defer cancel()
-	guardCtx = runtimefence.WithContext(guardCtx, session.RuntimeFence)
-	if err := session.RuntimeGuard(guardCtx); err != nil {
-		return err
-	}
-	if session.RunContext != nil {
-		if err := session.RunContext.Err(); err != nil {
-			return err
-		}
-	}
-	return guardCtx.Err()
-}
+// ToolSessionContext is the MCP gateway's compatibility name for the shared
+// tool execution context. The canonical type is owned by internal/toolcontext.
+type ToolSessionContext = toolcontext.Session
 
 // ToolDescriptor is the MCP tools/list item shape used by the gateway.
 type ToolDescriptor struct {

--- a/internal/toolcontext/context.go
+++ b/internal/toolcontext/context.go
@@ -1,0 +1,172 @@
+// Package toolcontext owns the request-scoped identity and lifecycle shared by
+// every Memoh tool transport. It is independent of MCP, ACP, and native tool
+// protocols so those adapters can all bind work to the same agent run.
+package toolcontext
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/memohai/memoh/internal/runtimefence"
+)
+
+// Session carries request-scoped identity and runtime ownership for tool
+// execution. Runtime-only fields remain process-local and are never serialized.
+type Session struct {
+	BotID               string
+	ChatID              string
+	RuntimeID           string
+	RuntimeToken        string `json:"-"`
+	SessionID           string
+	RunID               string
+	ToolCallID          string
+	SessionType         string
+	RouteID             string
+	ChannelIdentityID   string
+	SessionToken        string `json:"-"`
+	CurrentPlatform     string
+	ReplyTarget         string
+	ConversationType    string
+	CanRequestUserInput bool
+	CanListUserInput    bool
+	IsSubagent          bool
+	RuntimeActive       bool
+	SupportsImageInput  bool
+	SupportsFileInput   bool
+	RuntimeFence        runtimefence.Fence          `json:"-"`
+	RunContext          context.Context             `json:"-"`
+	RuntimeGuard        func(context.Context) error `json:"-"`
+}
+
+const runtimeGuardTimeout = 5 * time.Second
+
+// Bind gives a tool callback the owning run's request-scoped values and makes
+// it stop when either the callback or the run stops. The run context is the
+// authoritative source of tenant, identity, trace, and other turn values;
+// transport callback contexts contribute their independent cancellation.
+func Bind(callbackCtx context.Context, session Session) (context.Context, context.CancelFunc) {
+	if callbackCtx == nil {
+		callbackCtx = context.Background()
+	}
+	if session.RunContext == nil {
+		return runtimefence.WithContext(callbackCtx, session.RuntimeFence), func() {}
+	}
+
+	base := runtimefence.WithContext(session.RunContext, session.RuntimeFence)
+	bound, cancel := context.WithCancel(base)
+	stop := context.AfterFunc(callbackCtx, cancel)
+	if callbackCtx.Err() != nil {
+		cancel()
+	}
+	return bound, func() {
+		stop()
+		cancel()
+	}
+}
+
+// ValidateRuntimeGuard performs the last ownership check immediately before a
+// tool effect. The check remains bound to both the request and owning run.
+func ValidateRuntimeGuard(ctx context.Context, session Session) error {
+	if ctx == nil {
+		return errors.New("runtime guard context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if session.RunContext != nil {
+		if err := session.RunContext.Err(); err != nil {
+			return err
+		}
+	}
+	if session.RuntimeGuard == nil {
+		return nil
+	}
+	guardCtx, cancel := context.WithTimeout(ctx, runtimeGuardTimeout)
+	defer cancel()
+	guardCtx = runtimefence.WithContext(guardCtx, session.RuntimeFence)
+	if err := session.RuntimeGuard(guardCtx); err != nil {
+		return err
+	}
+	if session.RunContext != nil {
+		if err := session.RunContext.Err(); err != nil {
+			return err
+		}
+	}
+	return guardCtx.Err()
+}
+
+// Merge overlays every non-empty field of latest onto base; boolean
+// capabilities are sticky-true. ToolCallID is excluded on purpose: it is
+// per-call and assigned by the caller after merging.
+func Merge(base, latest Session) Session {
+	merged := base
+	if value := strings.TrimSpace(latest.BotID); value != "" {
+		merged.BotID = value
+	}
+	if value := strings.TrimSpace(latest.ChatID); value != "" {
+		merged.ChatID = value
+	}
+	if value := strings.TrimSpace(latest.RuntimeID); value != "" {
+		merged.RuntimeID = value
+	}
+	if value := strings.TrimSpace(latest.RuntimeToken); value != "" {
+		merged.RuntimeToken = value
+	}
+	if value := strings.TrimSpace(latest.SessionID); value != "" {
+		merged.SessionID = value
+	}
+	if value := strings.TrimSpace(latest.RunID); value != "" {
+		merged.RunID = value
+	}
+	if value := strings.TrimSpace(latest.SessionType); value != "" {
+		merged.SessionType = value
+	}
+	if value := strings.TrimSpace(latest.RouteID); value != "" {
+		merged.RouteID = value
+	}
+	if value := strings.TrimSpace(latest.ChannelIdentityID); value != "" {
+		merged.ChannelIdentityID = value
+	}
+	if value := strings.TrimSpace(latest.SessionToken); value != "" {
+		merged.SessionToken = value
+	}
+	if value := strings.TrimSpace(latest.CurrentPlatform); value != "" {
+		merged.CurrentPlatform = value
+	}
+	if value := strings.TrimSpace(latest.ReplyTarget); value != "" {
+		merged.ReplyTarget = value
+	}
+	if value := strings.TrimSpace(latest.ConversationType); value != "" {
+		merged.ConversationType = value
+	}
+	if latest.CanRequestUserInput {
+		merged.CanRequestUserInput = true
+	}
+	if latest.CanListUserInput {
+		merged.CanListUserInput = true
+	}
+	if latest.IsSubagent {
+		merged.IsSubagent = true
+	}
+	if latest.RuntimeActive {
+		merged.RuntimeActive = true
+	}
+	if latest.SupportsImageInput {
+		merged.SupportsImageInput = true
+	}
+	if latest.SupportsFileInput {
+		merged.SupportsFileInput = true
+	}
+	if latest.RuntimeFence.Valid() {
+		merged.RuntimeFence = latest.RuntimeFence
+	}
+	if latest.RunContext != nil {
+		merged.RunContext = latest.RunContext
+	}
+	if latest.RuntimeGuard != nil {
+		merged.RuntimeGuard = latest.RuntimeGuard
+	}
+	return merged
+}

--- a/internal/toolcontext/context_test.go
+++ b/internal/toolcontext/context_test.go
@@ -1,0 +1,113 @@
+package toolcontext
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type ctxKey string
+
+func TestBindUsesRunContextAsValueAuthority(t *testing.T) {
+	key := ctxKey("tenant")
+	runCtx := context.WithValue(context.Background(), key, "team-1")
+	callbackCtx := context.WithValue(context.Background(), key, "transport-only")
+
+	bound, cancel := Bind(callbackCtx, Session{RunContext: runCtx})
+	defer cancel()
+
+	if got := bound.Value(key); got != "team-1" {
+		t.Fatalf("bound value = %v, want run context value", got)
+	}
+}
+
+func TestBindStopsWhenCallbackContextIsCanceled(t *testing.T) {
+	callbackCtx, cancelCallback := context.WithCancel(context.Background())
+	bound, cancel := Bind(callbackCtx, Session{RunContext: context.Background()})
+	defer cancel()
+
+	cancelCallback()
+	select {
+	case <-bound.Done():
+	case <-time.After(time.Second):
+		t.Fatal("bound context was not canceled after callback cancellation")
+	}
+}
+
+func TestBindStopsWhenOwningRunIsCanceled(t *testing.T) {
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	bound, cancel := Bind(context.Background(), Session{RunContext: runCtx})
+	defer cancel()
+
+	cancelRun()
+	select {
+	case <-bound.Done():
+	case <-time.After(time.Second):
+		t.Fatal("bound context was not canceled after run cancellation")
+	}
+}
+
+func TestBindWithAlreadyCanceledCallbackContext(t *testing.T) {
+	callbackCtx, cancelCallback := context.WithCancel(context.Background())
+	cancelCallback()
+	bound, cancel := Bind(callbackCtx, Session{RunContext: context.Background()})
+	defer cancel()
+
+	if bound.Err() == nil {
+		t.Fatal("bound context should already be canceled")
+	}
+}
+
+func TestValidateRuntimeGuardRejectsCancellationDuringGuard(t *testing.T) {
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	session := Session{RunContext: runCtx}
+	bound, cancelBound := Bind(context.Background(), session)
+	defer cancelBound()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		session.RuntimeGuard = func(context.Context) error {
+			close(started)
+			<-release
+			return nil
+		}
+		done <- ValidateRuntimeGuard(bound, session)
+	}()
+	<-started
+	cancelRun()
+	close(release)
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("runtime guard error = %v, want context.Canceled", err)
+	}
+}
+
+func TestMergePreservesStickyCapabilities(t *testing.T) {
+	base := Session{BotID: "bot-1"}
+	merged := Merge(base, Session{
+		SupportsImageInput:  true,
+		SupportsFileInput:   true,
+		CanRequestUserInput: true,
+	})
+	if !merged.SupportsImageInput {
+		t.Fatalf("SupportsImageInput = false, want true")
+	}
+	if !merged.SupportsFileInput {
+		t.Fatalf("SupportsFileInput = false, want true")
+	}
+	if !merged.CanRequestUserInput {
+		t.Fatalf("CanRequestUserInput = false, want true")
+	}
+}
+
+func TestMergePreservesRuntimeLifecycle(t *testing.T) {
+	runCtx := context.Background()
+	guard := func(context.Context) error { return nil }
+	merged := Merge(Session{BotID: "bot-1"}, Session{
+		RunContext: runCtx, RuntimeGuard: guard,
+	})
+	if merged.RunContext != runCtx || merged.RuntimeGuard == nil {
+		t.Fatalf("runtime lifecycle = context:%v guard:%v", merged.RunContext, merged.RuntimeGuard != nil)
+	}
+}


### PR DESCRIPTION
## 改了什么

1. 把 `ToolSessionContext` 和它的 `Bind` / `ValidateRuntimeGuard` / `Merge` 从 `internal/mcp` 抽到新包 `internal/toolcontext`。这套东西是所有工具传输(ACP、MCP gateway、native、connector)共用的,不该住在 MCP 包里逼着别人 import gateway。`internal/mcp` 留了类型别名,调用方不用改。

2. 翻转 `Bind` 的方向:绑定后的 ctx 以 run context 为基底,回调 ctx 只贡献取消信号。之前反过来——工具审批、elicitation 跑在传输层回调的 ctx 上,而那个 ctx 上没有本轮 turn 的任何请求级值(租户、身份、trace)。开源版没人读这些值所以没事;从 ctx 解析租户的部署会因此 fail-closed:审批落库失败,turn 直接停,用户根本没收到申请。

3. 顺手修了 `Merge` 漏掉的 `SupportsFileInput`,并给新包补了行为测试(value 来源、双向取消)。

## 兼容性

无 API、DB、配置变化。开源版行为不变(run context 上本来就没有额外的值)。

4. 清掉 `ToolSessionContextStore` 的死状态:它的 session map(`Put` / `Merge` / `CloseSession`)自从 ACP 池改为从活跃 runtime handle 直接取每轮上下文(#567)后就没有生产调用方了,只有 sink 注册还在用。删掉这部分,`ServeToolMCPHTTPWithoutContextMerge` 收敛回 `ServeToolMCPHTTP`,store 只保留它真正的职责:per-run 工具事件 sink 注册表。
