### PR TITLE
fix(web): Continue-on 控件单元素形变 + composer 移动端比例

### DIFF
--- a/apps/web/src/pages/bots/components/model-options.vue
+++ b/apps/web/src/pages/bots/components/model-options.vue
@@ -2,10 +2,13 @@
   <!-- The Popover root is renderless (reka's PopoverRoot only provides context),
        so wrapping unconditionally costs nothing when the reasoning footer is off. -->
   <Popover v-model:open="reasoningOpen">
-    <div
-      :class="menuSearchHeaderClass"
-      @pointerenter="reasoningOpen = false"
-    >
+    <!-- No pointerenter closers on the search header or the listbox: with the
+         flyout collision-shifted up beside the list (short windows), every
+         diagonal path from the footer trigger to the flyout crossed one of
+         those zones and the menu died mid-flight. The flyout now closes only
+         on explicit actions — model pick, list scroll, typing, outside click
+         / Esc (see commitModel / scroll listener / searchTerm watcher). -->
+    <div :class="menuSearchHeaderClass">
       <input
         v-model="searchTerm"
         role="combobox"
@@ -24,7 +27,6 @@
       ref="scrollEl"
       :class="virtualListboxClass"
       role="listbox"
-      @pointerenter="reasoningOpen = false"
     >
       <div
         v-if="rows.length === 0"
@@ -90,13 +92,18 @@
       <div :class="menuSeparatorClass" />
       <div class="p-1.5 pt-0">
         <PopoverAnchor as-child>
+          <!-- menuItemClass highlights only via [data-highlighted] (the reka
+               Menu contract); these plain buttons must drive it themselves,
+               same as the list rows do via activeIndex. -->
           <button
             type="button"
             :aria-label="$t('chat.reasoningEffort')"
             :class="menuItemClass"
             :data-disabled="canSelectReasoning ? undefined : ''"
+            :data-highlighted="reasoningTriggerHover ? '' : undefined"
             :disabled="!canSelectReasoning"
-            @pointerenter="reasoningOpen = true"
+            @pointerenter="reasoningTriggerHover = true; reasoningOpen = true"
+            @pointerleave="reasoningTriggerHover = false"
             @click="reasoningOpen = true"
           >
             <Lightbulb :style="{ opacity: EFFORT_OPACITY[currentReasoningValue] ?? 0.5 }" />
@@ -119,7 +126,10 @@
       class="w-44"
       @open-auto-focus.prevent
     >
-      <div :class="menuChromeClass">
+      <div
+        :class="menuChromeClass"
+        @pointerleave="reasoningHoverValue = null"
+      >
         <div
           ref="reasoningScrollEl"
           :class="virtualListboxClass"
@@ -135,6 +145,8 @@
               <button
                 type="button"
                 :class="menuItemClass"
+                :data-highlighted="reasoningHoverValue === option.value ? '' : undefined"
+                @pointermove="reasoningHoverValue = option.value"
                 @click="setEffort(option.value)"
               >
                 <Lightbulb :style="{ opacity: EFFORT_OPACITY[option.value] ?? 0.5 }" />
@@ -257,6 +269,13 @@ const searchTerm = ref('')
 const scrollEl = ref<HTMLElement | null>(null)
 const reasoningScrollEl = ref<HTMLElement | null>(null)
 const reasoningOpen = ref(false)
+// Pointer-driven highlight state for the effort trigger and the flyout rows.
+// Both are plain buttons wearing menuItemClass, whose highlight only renders
+// through [data-highlighted]; nothing reka-side sets it here (unlike the list
+// rows, which are driven by the keyboard composable's activeIndex). Reset when
+// the flyout closes so a stale row never stays lit into the next open.
+const reasoningTriggerHover = ref(false)
+const reasoningHoverValue = ref<string | null>(null)
 const openDescriptionTooltipKey = ref<string | null>(null)
 // Sort order is captured when the picker opens. Changing models inside the same
 // open menu must not make the list jump under the pointer.
@@ -506,6 +525,13 @@ function setEffort(level: string) {
   // backdrop and dismiss the whole popover.
   reasoningEffort.value = level
 }
+
+watch(reasoningOpen, (open) => {
+  if (!open) {
+    reasoningTriggerHover.value = false
+    reasoningHoverValue.value = null
+  }
+})
 
 watch(() => props.open, (v) => {
   if (v) {

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -654,73 +654,80 @@
                         </span>
                       </Button>
                     </PopoverTrigger>
+                    <!-- `menu` makes this host transparent: the inner
+                         menuChromeClass div already owns the border/shadow/
+                         radius, so a chromed host would draw a doubled edge
+                         (same pattern as model-select.vue). -->
                     <PopoverContent
+                      menu
                       class="w-80 max-w-[calc(100vw-2rem)] overflow-hidden p-0"
                       align="end"
                       side="top"
                       :side-offset="4"
                     >
-                      <InlineLoadingRow
-                        v-if="composerModelsLoading"
-                        class="px-2 py-3"
-                      >
-                        {{ $t('common.loading') }}
-                      </InlineLoadingRow>
-                      <div
-                        v-else
-                        :class="menuChromeClass"
-                      >
-                        <div
-                          v-if="activeUsesACPComposer && !activeIsPendingACP && acpModes.length"
-                          class="border-b border-border p-3"
+                      <!-- The chrome wrapper covers BOTH branches: with the
+                           host transparent (`menu`), a bare loading row would
+                           float on the chat UI with no surface at all. -->
+                      <div :class="menuChromeClass">
+                        <InlineLoadingRow
+                          v-if="composerModelsLoading"
+                          class="px-2 py-3"
                         >
-                          <div class="mb-2 text-label text-foreground">
-                            {{ $t('chat.sessionMode') }}
-                          </div>
-                          <Select
-                            :model-value="currentACPModeId"
-                            :disabled="activeChatReadOnly || streaming || acpConfigChanging"
-                            @update:model-value="onACPModeSelected"
+                          {{ $t('common.loading') }}
+                        </InlineLoadingRow>
+                        <template v-else>
+                          <div
+                            v-if="activeUsesACPComposer && !activeIsPendingACP && acpModes.length"
+                            class="border-b border-border p-3"
                           >
-                            <SelectTrigger class="w-full">
-                              <SelectValue :placeholder="$t('chat.sessionModePlaceholder')" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem
-                                v-for="mode in acpModes"
-                                :key="mode.id"
-                                :value="mode.id"
-                              >
-                                <div class="min-w-0">
-                                  <div class="truncate">
-                                    {{ mode.name?.trim() || mode.id }}
+                            <div class="mb-2 text-label text-foreground">
+                              {{ $t('chat.sessionMode') }}
+                            </div>
+                            <Select
+                              :model-value="currentACPModeId"
+                              :disabled="activeChatReadOnly || streaming || acpConfigChanging"
+                              @update:model-value="onACPModeSelected"
+                            >
+                              <SelectTrigger class="w-full">
+                                <SelectValue :placeholder="$t('chat.sessionModePlaceholder')" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem
+                                  v-for="mode in acpModes"
+                                  :key="mode.id"
+                                  :value="mode.id"
+                                >
+                                  <div class="min-w-0">
+                                    <div class="truncate">
+                                      {{ mode.name?.trim() || mode.id }}
+                                    </div>
+                                    <div
+                                      v-if="mode.description?.trim()"
+                                      class="text-caption text-muted-foreground"
+                                    >
+                                      {{ mode.description }}
+                                    </div>
                                   </div>
-                                  <div
-                                    v-if="mode.description?.trim()"
-                                    class="text-caption text-muted-foreground"
-                                  >
-                                    {{ mode.description }}
-                                  </div>
-                                </div>
-                              </SelectItem>
-                            </SelectContent>
-                          </Select>
-                          <p class="mt-2 rounded-md border border-warning-border bg-warning-soft p-2 text-caption text-warning-foreground">
-                            {{ $t('chat.sessionModeCaution') }}
-                          </p>
-                        </div>
-                        <ModelOptions
-                          :model-value="overrideModelId"
-                          :reasoning-effort="overrideReasoningEffort"
-                          :reasoning-options="composerReasoningOptions"
-                          :models="composerModels"
-                          :providers="composerModelProviders"
-                          model-type="chat"
-                          :open="modelPopoverOpen"
-                          show-reasoning
-                          @update:model-value="onComposerModelValueSelected"
-                          @update:reasoning-effort="onComposerReasoningEffortSelected"
-                        />
+                                </SelectItem>
+                              </SelectContent>
+                            </Select>
+                            <p class="mt-2 rounded-md border border-warning-border bg-warning-soft p-2 text-caption text-warning-foreground">
+                              {{ $t('chat.sessionModeCaution') }}
+                            </p>
+                          </div>
+                          <ModelOptions
+                            :model-value="overrideModelId"
+                            :reasoning-effort="overrideReasoningEffort"
+                            :reasoning-options="composerReasoningOptions"
+                            :models="composerModels"
+                            :providers="composerModelProviders"
+                            model-type="chat"
+                            :open="modelPopoverOpen"
+                            show-reasoning
+                            @update:model-value="onComposerModelValueSelected"
+                            @update:reasoning-effort="onComposerReasoningEffortSelected"
+                          />
+                        </template>
                       </div>
                     </PopoverContent>
                   </Popover>

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -873,6 +873,7 @@ import { commandResultPresentation, isCommandResultItemVisible, resolveCommandRe
 import { captureChatPaneSendContext, composerHasNoModel as hasNoComposerModel, matchesChatPaneSendContext, pinnedSubagentModelId as resolvePinnedSubagentModelId, shouldRefreshACPComposerConfig } from './chat-pane-send'
 import { onAuthSessionCleared } from '@/lib/auth-session'
 import { useACPRuntime } from '@/composables/useACPRuntime'
+import { useIsMobile } from '@/composables/useIsMobile'
 import { useVirtualKeyboard } from '@/composables/useVirtualKeyboard'
 import { ACP_DEFAULT_PROJECT_MODE, ACP_DEFAULT_PROJECT_PATH, acpAgentIcon, findMissingRequiredManagedField, isACPAgentEnabled, normalizeACPAgentID, readACPAgentConfig } from '@/utils/acp'
 import { resolveApiErrorMessage } from '@/utils/api-error'
@@ -2395,8 +2396,11 @@ watch(inputText, (text) => {
 // Same rule as ComposerContinueOn's isDefaultTarget (only the native cloud
 // workspace collapses to the circle; a missing/ghost selection resolves to
 // null here exactly like the child's selectedTarget) — the layout reservation
-// must track which of the two widths the control is actually rendering.
-const continueOnExpanded = computed(() => selectedWorkspaceTarget.value?.kind !== 'native')
+// must track which of the two widths the control is actually rendering. On
+// mobile the trigger never expands (see the child's header comment), so it
+// always reserves the circle.
+const isMobileShell = useIsMobile()
+const continueOnExpanded = computed(() => selectedWorkspaceTarget.value?.kind !== 'native' && !isMobileShell.value)
 
 const {
   textareaEl,

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -621,7 +621,7 @@
                         size="sm"
                         shape="circle"
                         :disabled="!currentBotId || activeChatReadOnly || composerConfigPending"
-                        class="composer-pill-press min-w-0 max-md:h-11"
+                        class="composer-pill-press min-w-0 shrink max-md:h-11"
                         :style="{ maxWidth: `${modelTriggerMaxWidth}px` }"
                       >
                         <!-- One transformable wrapper for the press squish —
@@ -2392,6 +2392,12 @@ watch(inputText, (text) => {
   if (!prefix || text === prefix || text.startsWith(`${prefix} `)) return
   slashPanelSuppressedPrefix.value = ''
 })
+// Same rule as ComposerContinueOn's isDefaultTarget (only the native cloud
+// workspace collapses to the circle; a missing/ghost selection resolves to
+// null here exactly like the child's selectedTarget) — the layout reservation
+// must track which of the two widths the control is actually rendering.
+const continueOnExpanded = computed(() => selectedWorkspaceTarget.value?.kind !== 'native')
+
 const {
   textareaEl,
   composerEl,
@@ -2399,6 +2405,7 @@ const {
   modelTriggerMaxWidth,
 } = useComposerLayout({
   continueOnVisible: showComputersMenu,
+  continueOnExpanded,
 })
 
 const showSend = computed(() => Boolean(inputText.value.trim()) || pendingFiles.value.length > 0 || requestedSkills.value.length > 0)

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -378,12 +378,22 @@
               <!-- The composer is ALWAYS a two-row card (textarea on top,
                    controls below) — no pill↔multiline morph: a fixed rounded-2xl
                    box with a minimum height, so its shape never depends on the
-                   content and nothing animates mid-typing. -->
+                   content and nothing animates mid-typing.
+                   Docked (non-welcome) state compresses and quiets: min-h-24
+                   pulls the textarea row toward the controls row, and
+                   .chat-composer-docked (style.css) softens the edge to
+                   --border-soft — the centered welcome card keeps the full
+                   presence; docked it sits under the conversation and should
+                   read lighter.
+                   Mobile radius is DERIVED, not eyeballed: concentric with the
+                   44px control circles — control radius 22 + padding 10
+                   (p-2.5) = 32 = rounded-4xl. -->
               <div
                 ref="composerEl"
                 data-slot="input-group"
                 role="group"
-                class="chat-composer-edge relative flex min-h-28 w-full flex-wrap content-between items-end gap-1 rounded-2xl bg-surface-composer p-3 cursor-text max-md:rounded-xl max-md:p-2.5"
+                class="chat-composer-edge relative flex w-full flex-wrap content-between items-end gap-1 rounded-2xl bg-surface-composer p-3 cursor-text max-md:rounded-4xl max-md:p-2.5"
+                :class="isWelcome ? 'min-h-28' : 'min-h-24 chat-composer-docked'"
                 @click="handleComposerClick"
               >
                 <!-- The attachment row reveals via a grid 0fr↔1fr track so a card

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -383,7 +383,7 @@
                 ref="composerEl"
                 data-slot="input-group"
                 role="group"
-                class="chat-composer-edge relative flex min-h-28 w-full flex-wrap content-between items-end gap-1 rounded-2xl bg-surface-composer p-3 cursor-text"
+                class="chat-composer-edge relative flex min-h-28 w-full flex-wrap content-between items-end gap-1 rounded-2xl bg-surface-composer p-3 cursor-text max-md:rounded-xl max-md:p-2.5"
                 @click="handleComposerClick"
               >
                 <!-- The attachment row reveals via a grid 0fr↔1fr track so a card
@@ -491,12 +491,12 @@
                     >
                       <Spinner
                         v-if="agentChanging"
-                        class="size-4"
+                        class="size-4 max-md:size-5"
                       />
                       <Plus
                         v-else
                         :stroke-width="1.5"
-                        class="size-4"
+                        class="size-4 max-md:size-5"
                       />
                     </Button>
                   </DropdownMenuTrigger>
@@ -735,7 +735,7 @@
                     >
                       <Spinner
                         v-if="voiceInputState === 'transcribing'"
-                        class="size-4"
+                        class="size-4 max-md:size-5"
                       />
                       <svg
                         v-else
@@ -744,7 +744,7 @@
                         stroke="currentColor"
                         stroke-width="2.5"
                         stroke-linecap="round"
-                        class="size-4.5"
+                        class="size-4.5 max-md:size-5"
                         :class="voiceInputState === 'recording' ? 'motion-safe:animate-pulse' : undefined"
                         aria-hidden="true"
                       >
@@ -775,7 +775,7 @@
                       @click="streaming ? chatStore.abort(paneTarget) : handleSend()"
                     >
                       <span
-                        class="grid size-[18px] shrink-0 place-items-center"
+                        class="grid size-[18px] max-md:size-5 shrink-0 place-items-center"
                         aria-hidden="true"
                       >
                         <svg
@@ -785,7 +785,7 @@
                           stroke-width="2.75"
                           stroke-linecap="round"
                           stroke-linejoin="round"
-                          class="col-start-1 row-start-1 size-[18px] transition-opacity duration-200 ease-out motion-reduce:transition-none"
+                          class="col-start-1 row-start-1 size-[18px] max-md:size-5 transition-opacity duration-200 ease-out motion-reduce:transition-none"
                           :class="streaming ? 'opacity-0' : 'opacity-100'"
                         >
                           <path d="M12 19.5 V5" />
@@ -794,7 +794,7 @@
                         <svg
                           viewBox="0 0 24 24"
                           fill="currentColor"
-                          class="col-start-1 row-start-1 size-4 transition-opacity duration-200 ease-out motion-reduce:transition-none"
+                          class="col-start-1 row-start-1 size-4 max-md:size-4.5 transition-opacity duration-200 ease-out motion-reduce:transition-none"
                           :class="streaming ? 'opacity-100' : 'opacity-0'"
                         >
                           <rect

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -176,9 +176,12 @@
       <div
         v-if="!activeChatReadOnly"
         class="pointer-events-none absolute z-(--z-panel)"
-        :class="isWelcome
-          ? 'inset-0 flex flex-col items-center justify-start pt-[28dvh]'
-          : 'inset-x-0 bottom-0 pt-2 pb-7'"
+        :class="[
+          isWelcome
+            ? 'inset-0 flex flex-col items-center justify-start pt-[28dvh]'
+            : 'inset-x-0 bottom-0 pt-2 pb-7',
+          { invisible: composerPlacementPending },
+        ]"
         :style="composerLiftPx > 0 ? { bottom: `${composerLiftPx}px` } : undefined"
       >
         <!-- Opaque backdrop, bottom-anchored, rising only to the box's widest point
@@ -1008,6 +1011,17 @@ const isWelcome = computed(() =>
   && !loadingChats.value
   && messages.value.length === 0,
 )
+
+// During boot, "a draft that stays a draft" and "a draft about to be
+// repointed to the most recent session" are indistinguishable until
+// fetchSessions returns (bootstrap auto-picks at the END of the load).
+// isWelcome waits out that window via !loadingChats — but rendering the
+// docked posture meanwhile made a hard refresh of the welcome page flash
+// bottom → center. While placement is undecidable, hide the composer
+// instead: `invisible` keeps layout and the dock measurements alive,
+// where v-if would unmount them. A session panel carries its sessionId
+// from the first frame, so this gate never engages on session routes.
+const composerPlacementPending = computed(() => loadingChats.value && !hasRenderedSession.value)
 
 // Rotate the greeting per fresh chat so the entry point feels alive rather than
 // a fixed banner; the pick stays stable while a single welcome screen is shown

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -219,9 +219,10 @@
                the column math is centered, but the eye reads the composer a hair
                right of the message column (the scroll rail eats the right edge),
                so the whole dock unit shifts left a touch to sit where it looks
-               centered. -->
+               centered. Desktop only — mobile has no scroll rail, so there the
+               nudge would just push the composer off centre. -->
           <div
-            class="pointer-events-auto relative mx-auto w-full -translate-x-0.5 px-4 sm:px-6 lg:px-10"
+            class="pointer-events-auto relative mx-auto w-full px-4 sm:px-6 lg:px-10 md:-translate-x-0.5"
             :class="isWelcome ? 'max-w-[44rem]' : 'max-w-[840px]'"
           >
             <Transition
@@ -377,23 +378,26 @@
             >
               <!-- The composer is ALWAYS a two-row card (textarea on top,
                    controls below) — no pill↔multiline morph: a fixed rounded-2xl
-                   box with a minimum height, so its shape never depends on the
-                   content and nothing animates mid-typing.
-                   Docked (non-welcome) state compresses and quiets: min-h-24
-                   pulls the textarea row toward the controls row, and
-                   .chat-composer-docked (style.css) softens the edge to
-                   --border-soft — the centered welcome card keeps the full
-                   presence; docked it sits under the conversation and should
-                   read lighter.
-                   Mobile radius is DERIVED, not eyeballed: concentric with the
-                   44px control circles — control radius 22 + padding 10
-                   (p-2.5) = 32 = rounded-4xl. -->
+                   box, so its shape never depends on the content and nothing
+                   animates mid-typing.
+                   Docked (non-welcome) state compresses and quiets: no min
+                   height + tighter padding (p-2.5) + a shorter textarea row
+                   (min-h-10) pull the two rows together — the centered welcome
+                   card keeps the full presence (min-h-28, p-3); docked it sits
+                   under the conversation and should read lighter, with the edge
+                   softened to --border-soft (.chat-composer-docked, style.css).
+                   Mobile radius is DERIVED from the control circles inside:
+                   radius tracks the control radius — 44px controls → 22, i.e.
+                   rounded-3xl (24, nearest rung); the same rule on desktop
+                   (32px controls → 16) is exactly the rounded-2xl the card
+                   already wears. (The concentric alternative, control radius +
+                   padding = 32, read as too round in QA.) -->
               <div
                 ref="composerEl"
                 data-slot="input-group"
                 role="group"
-                class="chat-composer-edge relative flex w-full flex-wrap content-between items-end gap-1 rounded-2xl bg-surface-composer p-3 cursor-text max-md:rounded-4xl max-md:p-2.5"
-                :class="isWelcome ? 'min-h-28' : 'min-h-24 chat-composer-docked'"
+                class="chat-composer-edge relative flex w-full flex-wrap content-between items-end gap-1 rounded-2xl bg-surface-composer cursor-text max-md:rounded-3xl max-md:p-2.5"
+                :class="isWelcome ? 'min-h-28 p-3' : 'p-2.5 chat-composer-docked'"
                 @click="handleComposerClick"
               >
                 <!-- The attachment row reveals via a grid 0fr↔1fr track so a card
@@ -478,7 +482,8 @@
                   rows="1"
                   :placeholder="activeChatReadOnly ? $t('chat.readonlyHint') : $t('chat.inputPlaceholder')"
                   :disabled="!currentBotId || activeChatReadOnly || loadingMessages || voiceInputState !== 'idle'"
-                  class="order-none min-h-12 max-h-52 w-full basis-full field-sizing-content resize-none break-words bg-transparent pl-2 pr-1 pt-2 pb-1.5 text-base leading-[var(--chat-leading)] text-foreground outline-none placeholder:text-[var(--field-placeholder)] disabled:cursor-not-allowed"
+                  class="order-none max-h-52 w-full basis-full field-sizing-content resize-none break-words bg-transparent pl-2 pr-1 pt-2 pb-1.5 text-base leading-[var(--chat-leading)] text-foreground outline-none placeholder:text-[var(--field-placeholder)] disabled:cursor-not-allowed"
+                  :class="isWelcome ? 'min-h-12' : 'min-h-10'"
                   @keydown="handleComposerKeydown"
                   @paste="handlePaste"
                 />

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -2408,14 +2408,18 @@ watch(inputText, (text) => {
   if (!prefix || text === prefix || text.startsWith(`${prefix} `)) return
   slashPanelSuppressedPrefix.value = ''
 })
-// Same rule as ComposerContinueOn's isDefaultTarget (only the native cloud
-// workspace collapses to the circle; a missing/ghost selection resolves to
-// null here exactly like the child's selectedTarget) — the layout reservation
-// must track which of the two widths the control is actually rendering. On
-// mobile the trigger never expands (see the child's header comment), so it
-// always reserves the circle.
+// Mirror of ComposerContinueOn's pill rule: only an explicit non-default
+// selection expands the trigger (unset — including the pre-load window —
+// renders the collapsed default circle; a missing/ghost selection resolves to
+// null here exactly like the child's selectedTarget). The reservation must
+// track which width the control is actually rendering, and on mobile the
+// trigger never expands (see the child's header comment).
 const isMobileShell = useIsMobile()
-const continueOnExpanded = computed(() => selectedWorkspaceTarget.value?.kind !== 'native' && !isMobileShell.value)
+const continueOnExpanded = computed(() => (
+  !!selectedWorkspaceTargetId.value
+  && selectedWorkspaceTarget.value?.kind !== 'native'
+  && !isMobileShell.value
+))
 
 const {
   textareaEl,

--- a/apps/web/src/pages/home/components/composer-continue-on.vue
+++ b/apps/web/src/pages/home/components/composer-continue-on.vue
@@ -27,9 +27,9 @@
         :title="isDefaultTarget ? currentName : t('chat.continueOn.label')"
         :aria-label="t('chat.continueOn.label')"
         class="order-2 min-w-0 max-w-48 self-end max-md:h-11 duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
-        :class="isDefaultTarget
-          ? 'composer-circle-press px-2 max-md:px-3'
-          : 'composer-pill-press shrink'"
+        :class="rendersAsPill
+          ? 'composer-pill-press shrink'
+          : 'composer-circle-press px-2 max-md:px-3'"
       >
         <span class="composer-pill-content inline-flex min-w-0 items-center">
           <Laptop
@@ -38,12 +38,11 @@
           />
           <!-- Spacing lives on the slot's children (ml-2), not the slot itself:
                a gap/padding on the collapsing container would survive the
-               collapse and the circle could never converge to 32px. The
-               expansion is gated to md+ — see the header comment. -->
+               collapse and the circle could never converge to 32px. -->
           <span
             class="inline-flex min-w-0 items-center overflow-hidden transition-[max-width,opacity] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
-            :class="isDefaultTarget ? 'max-w-0 opacity-0' : 'max-w-0 opacity-0 md:max-w-38 md:opacity-100'"
-            :aria-hidden="isDefaultTarget"
+            :class="rendersAsPill ? 'max-w-38 opacity-100' : 'max-w-0 opacity-0'"
+            :aria-hidden="!rendersAsPill"
           >
             <span class="ml-2 min-w-0 truncate text-label text-composer-control-label">{{ currentName }}</span>
             <ChevronDown
@@ -188,6 +187,7 @@ import {
   DesktopRuntimeKey,
   type DesktopRuntimeState,
 } from '@/lib/desktop-shell'
+import { useIsMobile } from '@/composables/useIsMobile'
 import {
   workspaceTargetAvailable,
   workspaceTargetName,
@@ -267,6 +267,13 @@ const isDefaultTarget = computed(() => (
     ? selectedTarget.value.kind === 'native'
     : !props.selectedTargetId
 ))
+
+// The pill form only exists on md+; on mobile the trigger always renders the
+// circle (see the header comment), so it must also PRESS and read like the
+// circle — same composer-circle-press, collapsed slot, hidden from SRs. This
+// is the single source of truth for which form is on screen.
+const isMobileShell = useIsMobile()
+const rendersAsPill = computed(() => !isDefaultTarget.value && !isMobileShell.value)
 
 function goToRuntimes(): void {
   void router.push({ name: 'runtimes' })

--- a/apps/web/src/pages/home/components/composer-continue-on.vue
+++ b/apps/web/src/pages/home/components/composer-continue-on.vue
@@ -253,13 +253,20 @@ function displayName(target: WorkspaceWorkspaceTarget): string {
 const currentName = computed(() => {
   if (selectedTarget.value) return displayName(selectedTarget.value)
   if (props.selectedMissing) return props.selectedSnapshotName || t('chat.computerUnavailable')
-  return t('chat.continueOn.label')
+  // A selection whose targets haven't loaded yet still wears its snapshot
+  // name — the pill is announcing THAT computer, not the generic label.
+  return props.selectedSnapshotName || t('chat.continueOn.label')
 })
 
-// The native cloud workspace IS the default destination; only it gets the
-// collapsed icon trigger. Any real machine (or a non-default/ghost selection)
-// gets the labeled pill.
-const isDefaultTarget = computed(() => selectedTarget.value?.kind === 'native')
+// Only an explicit non-default selection earns the pill. No selection at all —
+// including the window before the targets query lands — renders the collapsed
+// default circle: otherwise every fresh welcome page flashes a "Continue on"
+// pill that collapses the moment the default target resolves.
+const isDefaultTarget = computed(() => (
+  selectedTarget.value
+    ? selectedTarget.value.kind === 'native'
+    : !props.selectedTargetId
+))
 
 function goToRuntimes(): void {
   void router.push({ name: 'runtimes' })

--- a/apps/web/src/pages/home/components/composer-continue-on.vue
+++ b/apps/web/src/pages/home/components/composer-continue-on.vue
@@ -2,17 +2,22 @@
   <DropdownMenu @update:open="onMenuOpen">
     <DropdownMenuTrigger as-child>
       <!-- Icon-only for the default destination (the native cloud workspace):
-           a quiet peer of the ＋ button. The moment the session is pinned to a
-           real machine — or holds any non-default selection — the trigger
-           grows into the labeled pill: a non-default target is worth reading
-           at a glance.
+           a quiet peer of the ＋ button. On md+, the moment the session is
+           pinned to a real machine — or holds any non-default selection — the
+           trigger grows into the labeled pill: a non-default target is worth
+           reading at a glance. On mobile it NEVER expands: the pill and the
+           model trigger would squeeze each other into uselessness on a narrow
+           row, so the collapsed circle carries it and the selection is read
+           in the menu instead.
            The two forms are ONE element morphing, never two nodes swapping:
            a single Laptop glyph, a collapsing label slot (max-width/opacity),
            and a padding transition converge the circle to exactly 32×32
            (44×44 on mobile). Splitting the forms across v-if/v-else nodes
            reads as two different controls mid-switch. The <button> itself
            still never transforms (reka anchors the open menu to its rendered
-           rect); the pill's press squish lives on .composer-pill-content. -->
+           rect); press squish lives on .composer-pill-content in BOTH forms
+           (composer-pill-press / composer-circle-press, style.css) so press
+           feedback is identical either way. -->
       <Button
         type="button"
         variant="ghost"
@@ -23,7 +28,7 @@
         :aria-label="t('chat.continueOn.label')"
         class="order-2 min-w-0 max-w-48 self-end max-md:h-11 duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
         :class="isDefaultTarget
-          ? 'px-2 max-md:px-3'
+          ? 'composer-circle-press px-2 max-md:px-3'
           : 'composer-pill-press shrink'"
       >
         <span class="composer-pill-content inline-flex min-w-0 items-center">
@@ -33,10 +38,11 @@
           />
           <!-- Spacing lives on the slot's children (ml-2), not the slot itself:
                a gap/padding on the collapsing container would survive the
-               collapse and the circle could never converge to 32px. -->
+               collapse and the circle could never converge to 32px. The
+               expansion is gated to md+ — see the header comment. -->
           <span
             class="inline-flex min-w-0 items-center overflow-hidden transition-[max-width,opacity] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
-            :class="isDefaultTarget ? 'max-w-0 opacity-0' : 'max-w-38 opacity-100'"
+            :class="isDefaultTarget ? 'max-w-0 opacity-0' : 'max-w-0 opacity-0 md:max-w-38 md:opacity-100'"
             :aria-hidden="isDefaultTarget"
           >
             <span class="ml-2 min-w-0 truncate text-label text-composer-control-label">{{ currentName }}</span>

--- a/apps/web/src/pages/home/components/composer-continue-on.vue
+++ b/apps/web/src/pages/home/components/composer-continue-on.vue
@@ -1,43 +1,50 @@
 <template>
   <DropdownMenu @update:open="onMenuOpen">
     <DropdownMenuTrigger as-child>
-      <!-- Icon-only ONLY for the default destination (the native cloud
-           workspace): a quiet peer of the ＋ button. The moment the session is
-           pinned to a real machine — or holds any non-default selection — the
-           trigger expands to the labeled pill: a non-default target is worth
-           reading at a glance. The <button> itself never transforms (reka
-           anchors the open menu to its rendered rect); the pill's press
-           squish lives on .composer-pill-content. -->
+      <!-- Icon-only for the default destination (the native cloud workspace):
+           a quiet peer of the ＋ button. The moment the session is pinned to a
+           real machine — or holds any non-default selection — the trigger
+           grows into the labeled pill: a non-default target is worth reading
+           at a glance.
+           The two forms are ONE element morphing, never two nodes swapping:
+           a single Laptop glyph, a collapsing label slot (max-width/opacity),
+           and a padding transition converge the circle to exactly 32×32
+           (44×44 on mobile). Splitting the forms across v-if/v-else nodes
+           reads as two different controls mid-switch. The <button> itself
+           still never transforms (reka anchors the open menu to its rendered
+           rect); the pill's press squish lives on .composer-pill-content. -->
       <Button
         type="button"
         variant="ghost"
-        :size="isDefaultTarget ? 'icon-sm' : 'sm'"
+        size="sm"
         shape="circle"
         :disabled="locked"
         :title="isDefaultTarget ? currentName : t('chat.continueOn.label')"
         :aria-label="t('chat.continueOn.label')"
+        class="order-2 min-w-0 max-w-48 self-end max-md:h-11 duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
         :class="isDefaultTarget
-          ? 'order-2 self-end text-muted-foreground max-md:size-11'
-          : 'composer-pill-press order-2 min-w-0 max-w-48 self-end max-md:h-11'"
+          ? 'px-2 max-md:px-3'
+          : 'composer-pill-press shrink'"
       >
-        <Laptop
-          v-if="isDefaultTarget"
-          class="size-4"
-          :stroke-width="1.5"
-        />
-        <span
-          v-else
-          class="composer-pill-content inline-flex min-w-0 items-center gap-2"
-        >
+        <span class="composer-pill-content inline-flex min-w-0 items-center">
           <Laptop
-            class="size-3.5 shrink-0 text-muted-foreground"
+            class="size-4 max-md:size-5 shrink-0 text-muted-foreground"
             :stroke-width="1.5"
           />
-          <span class="min-w-0 truncate text-label text-composer-control-label">{{ currentName }}</span>
-          <ChevronDown
-            class="size-3.5 shrink-0 text-muted-foreground"
-            :stroke-width="1.5"
-          />
+          <!-- Spacing lives on the slot's children (ml-2), not the slot itself:
+               a gap/padding on the collapsing container would survive the
+               collapse and the circle could never converge to 32px. -->
+          <span
+            class="inline-flex min-w-0 items-center overflow-hidden transition-[max-width,opacity] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
+            :class="isDefaultTarget ? 'max-w-0 opacity-0' : 'max-w-38 opacity-100'"
+            :aria-hidden="isDefaultTarget"
+          >
+            <span class="ml-2 min-w-0 truncate text-label text-composer-control-label">{{ currentName }}</span>
+            <ChevronDown
+              class="ml-2 size-3.5 shrink-0 text-muted-foreground"
+              :stroke-width="1.5"
+            />
+          </span>
         </span>
       </Button>
     </DropdownMenuTrigger>

--- a/apps/web/src/pages/home/composables/useComposerLayout.ts
+++ b/apps/web/src/pages/home/composables/useComposerLayout.ts
@@ -7,9 +7,10 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, type Comput
 // The composer is a fixed two-row card now (textarea on its own row, controls
 // below), so there is no pill↔multiline reflow to detect and no height morph
 // to drive — the card simply grows with the textarea's field-sizing. What
-// remains genuinely dynamic is the model trigger's max-width: the trigger
-// inherits the Button's shrink-0, so without a hard clamp a long model name
-// would push past the box instead of ellipsising.
+// remains genuinely dynamic is the model trigger's max-width: the clamp
+// reserves space for the sibling controls so the row never overflows, and
+// floors at 72px — below that the trigger's own `shrink` lets it truncate
+// rather than push past the box.
 
 // The strip beneath the bottom box (pb-8). Shared with the dock so the mask
 // can apply the same half-height rule to whatever box replaces the composer.
@@ -24,9 +25,11 @@ export interface ComposerLayoutDeps {
 }
 
 const MODEL_TRIGGER_MAX = 240 // max-w-60
-// Reservations use the max-md worst case (44px touch-floor controls). On
-// desktop this over-reserves ~24px — invisible at desktop widths; on mobile it
-// errs toward clamping the model name instead of letting the row overflow.
+// Reservations use the max-md worst case (44px touch-floor controls): exact on
+// mobile, while desktop over-reserves ~12px per 32px control (24–36px total
+// depending on the Continue-on form) — invisible at desktop widths, and the
+// error direction is clamping the model name rather than letting the row
+// overflow.
 const PLUS_SLOT = 48 // ＋ circle at its largest (max-md size-11 = 44) + gap-1
 const SEND_SLOT = 44 // mic/send circle at its largest (max-md size-11)
 const CONTINUE_ON_PILL = 196 // labeled pill cap (max-w-48 = 192) + gap-1

--- a/apps/web/src/pages/home/composables/useComposerLayout.ts
+++ b/apps/web/src/pages/home/composables/useComposerLayout.ts
@@ -16,18 +16,25 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, type Comput
 export const COMPOSER_MASK_BELOW_PX = 32
 
 export interface ComposerLayoutDeps {
-  // Whether the Continue-on destination pill is in the row; it reserves space.
+  // Whether the Continue-on destination control is in the row; it reserves space.
   continueOnVisible: ComputedRef<boolean>
+  // Whether that control is the labeled pill (vs. the collapsed default-target
+  // circle) — the two forms differ by ~148px and must reserve differently.
+  continueOnExpanded: ComputedRef<boolean>
 }
 
 const MODEL_TRIGGER_MAX = 240 // max-w-60
-const PLUS_SLOT = 40 // ＋ button (32) + gap
-const CONTINUE_ON_SLOT = 168 // destination pill cap (max-w-40) + gap
-const SEND_SLOT = 36 // mic/send circle size-8
+// Reservations use the max-md worst case (44px touch-floor controls). On
+// desktop this over-reserves ~24px — invisible at desktop widths; on mobile it
+// errs toward clamping the model name instead of letting the row overflow.
+const PLUS_SLOT = 48 // ＋ circle at its largest (max-md size-11 = 44) + gap-1
+const SEND_SLOT = 44 // mic/send circle at its largest (max-md size-11)
+const CONTINUE_ON_PILL = 196 // labeled pill cap (max-w-48 = 192) + gap-1
+const CONTINUE_ON_CIRCLE = 48 // collapsed circle (max-md 44) + gap-1
 const CLUSTER_GAP = 8 // gap-2 between controls-row children
 
 export function useComposerLayout(deps: ComposerLayoutDeps) {
-  const { continueOnVisible } = deps
+  const { continueOnVisible, continueOnExpanded } = deps
 
   const textareaEl = ref<HTMLTextAreaElement | null>(null)
   const composerEl = ref<HTMLElement | null>(null)
@@ -49,14 +56,15 @@ export function useComposerLayout(deps: ComposerLayoutDeps) {
   }
 
   // Sized to whatever the controls row can spare after the ＋, the Continue-on
-  // pill, and the mic/send circle. Only bites when space is tight; otherwise
-  // it rests at the 240px cap and hugs a short name.
+  // control (pill or collapsed circle — they differ by ~148px), and the
+  // mic/send circle. Only bites when space is tight; otherwise it rests at the
+  // 240px cap and hugs a short name.
   const modelTriggerMaxWidth = computed(() => {
     const inner = composerInnerWidth.value
     if (inner <= 1) return MODEL_TRIGGER_MAX
     let reserved = PLUS_SLOT + CLUSTER_GAP + SEND_SLOT
     if (continueOnVisible.value) {
-      reserved += CONTINUE_ON_SLOT
+      reserved += continueOnExpanded.value ? CONTINUE_ON_PILL : CONTINUE_ON_CIRCLE
     }
     return Math.max(72, Math.min(MODEL_TRIGGER_MAX, inner - reserved))
   })

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -207,6 +207,12 @@
 [data-slot="input-group"].chat-composer-edge:not(:has([aria-invalid="true"])) {
   --field-edge: var(--field-edge-rest);
 }
+/* Docked (non-welcome) the composer sits under the conversation and should
+ * read lighter than the centered welcome card: soften the edge to
+ * --border-soft. Ordered before :focus-within so focus still wins. */
+[data-slot="input-group"].chat-composer-edge.chat-composer-docked:not(:has([aria-invalid="true"])) {
+  --field-edge: var(--border-soft);
+}
 [data-slot="input-group"].chat-composer-edge:focus-within:not(:has([aria-invalid="true"])) {
   --field-edge: var(--composer-edge-focus);
 }

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -250,6 +250,18 @@
   background-color: var(--ui-hover);
 }
 
+/* The collapsed circle form presses with the SAME content squish as the pill
+ * (0.97 / 150ms easeOutExpo on .composer-pill-content): press parity — the
+ * glyph must shrink in both forms or the two states stop reading as one
+ * control. The chip is deliberately NOT re-tinted here: the circle keeps the
+ * shared ghost chip so its hover stays a quiet peer of the ＋ button. */
+[data-button][data-variant="ghost"].composer-circle-press .composer-pill-content {
+  transition: scale 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-button][data-variant="ghost"].composer-circle-press:active .composer-pill-content {
+  scale: 0.97;
+}
+
 /* Inter-script spacing (W3C CLREQ / CSS Text 4): insert the standard ~1/8em gap
  * between CJK (Han/kana) and adjacent Latin letters or numerals, so mixed runs
  * like "Chat查看文件" stop colliding into one dense blob. The property is


### PR DESCRIPTION
## 背景

#1005 合并后的 composer QA 迭代合集(9 个 commit)。起点是三个问题:Continue-on 控件 circle⇄pill 切换不连贯、移动端比例失调、model 名宽度钳制的预留常量失真;QA 途中陆续又暴露:按压反馈不一致、移动端 pill 互挤、docked 高度压不下来、手机端不居中、welcome 页 pill 闪现、刷新时位置跳动、model picker 双描边 + reasoning 区无 hover(修复曾只落在 Cloud fork,从未回流 OSS)。

## 改动

**Continue-on 控件**(composer-continue-on.vue)
- `f8e200c5` circle⇄pill 单元素连续形变:固定 `size="sm"`,单一 Laptop 节点 + 可折叠 label 槽(max-width/opacity)+ padding 过渡,circle 恰好收敛 32×32(移动端 44×44);`composer-pill-press` 只在 pill 态挂载。
- `a90e3c1e` 按压一致性:circle 态补内容收缩(`composer-circle-press`,与 pill 同参数,chip 保持与＋一致的共享 ghost);移动端永不展开 pill(窄屏 pill 与 model trigger 互挤得不偿失),选择进菜单看勾。
- `f0e85020` welcome 页 pill 闪现:未选择状态(含 targets 加载窗口)渲染默认 circle,pill 只跟随明确的非默认选择;选择已存在但列表未加载时显示 snapshot 名而非通用 label。

**布局与压缩**(useComposerLayout.ts / chat-pane.vue / style.css)
- `8971a83f` 预留常量失真:`CONTINUE_ON_SLOT=168` 与真实 pill 上限 `max-w-48`(192)不符,且按桌面 32px 控件算 → 统一取 max-md 最坏值(44px)并按 pill(196)/circle(48)分档,由 `continueOnExpanded` 驱动;model pill 加 `shrink`,72px 下限从硬溢出点降级为软目标。**行为变化:桌面 clamp 提前 ~24px 收紧,桌面宽度下不可见。**
- `62c7485e` 移动端比例:保留 44px 触摸底线,glyph 放大一档(16→20,比例 0.36→0.45),卡片 `max-md:p-2.5`。
- `9f50f0bf` + `0d1ea8d8` docked 收紧与安静化:此前 `min-h-24` 低于内容下限从未生效——改为 docked 态去掉 min-height、`p-2.5`、textarea 行 `min-h-12→min-h-10`(docked ≈96px,原 ~108),描边软化为 `--border-soft`;welcome 居中态保持 `min-h-28 + p-3` 不变。移动端圆角按"卡片圆角 ≈ 控件圆半径"的规则取 `rounded-3xl`(24;同心公式 32 经 QA 判定过圆);PC 的 2px 光学偏移(补桌面滚动轨道)加 `md:` 门控,手机端真正居中。
- `e11b7377` 硬刷新位置跳动:bootstrap 在加载末尾才 auto-pick 最近会话,启动窗口内"draft 还是恢复会话"不可判定——窗口期隐藏 composer(`invisible`,保留布局与 dock 测量),落定后一次性以正确位置出现;session 路由首帧带 sessionId,不受影响。

**model picker**(移植自 Cloud fork #126,`e2a88442`)
- `13165c23` bug 出生于 OSS #926,修复却只进过 Cloud fork。`model-options.vue` 字节级移植:reasoning 触发行/选项行本地驱动 `data-highlighted`(menuItemClass 的高亮只认这个属性);删除搜索框/列表的 pointerenter 关闭器(斜向移动杀菜单)。`chat-pane.vue` 适配移植:弹层宿主加 `menu`(内层 chrome 已有 border/shadow,宿主再画一份即双描边),chrome 包裹覆盖 loading 分支;适配点:保留 OSS 的 `max-w-[calc(100vw-2rem)]`,OSS 独有的 ACP mode 块与 ModelOptions 一起包进 `template v-else`。

## 验证

- `pnpm --filter @memohai/web typecheck`:零新增错误(baseline 的 packages/ui `#/` alias 环境问题与个别 pre-existing 仍在);eslint 改动文件 clean;CI 全绿(12 pass + 1 预期 skip)。
- 人工 QA 已由作者在**手机真机 + 桌面**完成:docked 高度与描边、移动端居中、圆角、形变连续性、按压一致性、welcome 无闪现、picker 单描边 + reasoning hover。

## 风险

- tailwind-merge 后者胜是隐式契约(同 monorepo 可接受);
- Continue-on 图标移动端 20px 是无先例配比,若嫌粗:图标撤 `max-md:size-5`、circle 态改 `max-md:px-3.5`(14+16+14=44),一行回退;
- 手机端选中电脑后 trigger 不再显示机器名(进菜单看),这是 QA 中明确的取舍。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.