### PR TITLE
fix(web): render ```text code fences instead of dropping them

### DIFF
--- a/apps/web/src/components/markdown/index.test.ts
+++ b/apps/web/src/components/markdown/index.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import { createPinia } from 'pinia'
+
+// Regression: markstream resolves a code fence's component by its LANGUAGE
+// name before the `code_block` key, in the same namespace as node-type
+// overrides — so a ```text fence used to hit the prose `text` component and
+// render nothing (no `content` on code_block nodes). The registered text
+// router must send code_block nodes to the surface's code block component
+// while plain prose keeps the per-script span split.
+
+const storage = new Map<string, string>()
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (k: string) => storage.get(k) ?? null,
+    setItem: (k: string, v: string) => void storage.set(k, String(v)),
+    removeItem: (k: string) => void storage.delete(k),
+    clear: () => storage.clear(),
+    key: (i: number) => [...storage.keys()][i] ?? null,
+    get length() { return storage.size },
+  },
+  configurable: true,
+})
+
+async function renderChatMarkdown(content: string): Promise<HTMLElement> {
+  const { default: MarkdownRender } = await import('markstream-vue')
+  const { registerSharedMarkdownComponents } = await import('@/components/markdown')
+  const { default: ChatCodeBlock } = await import('@/pages/home/components/chat-code-block.vue')
+  const { createI18n } = await import('vue-i18n')
+  registerSharedMarkdownComponents('chat-msg', { code_block: ChatCodeBlock, shell: ChatCodeBlock })
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const app = createApp({
+    render() {
+      return h(MarkdownRender, {
+        content,
+        isDark: false,
+        smoothStreaming: false,
+        typewriter: false,
+        fade: false,
+        showTooltips: false,
+        customId: 'chat-msg',
+      })
+    },
+  })
+  app.use(createI18n({ legacy: false, locale: 'en', messages: { en: {} } }))
+  app.use(createPinia())
+  app.mount(host)
+  await nextTick()
+  await new Promise((r) => setTimeout(r, 300))
+  await nextTick()
+  return host
+}
+
+describe('registerSharedMarkdownComponents', () => {
+  it('renders a ```text fence through the code block component', async () => {
+    const host = await renderChatMarkdown('不是空白,输出的是:\n\n```text\n192.0.2.1\n```\n')
+    expect(host.textContent ?? '').toContain('192.0.2.1')
+    expect(host.querySelector('.chat-code-block')).not.toBeNull()
+  })
+
+  it('keeps prose text on the per-script span split', async () => {
+    const host = await renderChatMarkdown('中文 mixed with Latin')
+    expect(host.querySelector('.chat-cjk')?.textContent).toContain('中文')
+    expect(host.querySelector('.chat-latin')?.textContent).toContain('Latin')
+  })
+})

--- a/apps/web/src/components/markdown/index.ts
+++ b/apps/web/src/components/markdown/index.ts
@@ -1,4 +1,4 @@
-import type { Component } from 'vue'
+import { defineComponent, h, type Component } from 'vue'
 import { setCustomComponents } from 'markstream-vue'
 import MdCheckbox from './md-checkbox.vue'
 import MdFootnoteReference from './md-footnote-reference.vue'
@@ -25,6 +25,28 @@ const sharedComponents: Record<string, Component> = {
 
 const registered = new Set<string>()
 
+// markstream resolves a code fence's component by its LANGUAGE name before
+// falling back to the `code_block` key, and that lookup shares one namespace
+// with node-type overrides. A ```text fence therefore resolves to the `text`
+// mapping — our prose text node, which reads `node.content` (absent on
+// code_block nodes) and renders nothing. Route by node type so the fence
+// reaches the surface's code block component instead.
+function textNodeRouter(codeBlock: Component | undefined): Component {
+  if (!codeBlock) return MdText
+  return defineComponent({
+    name: 'MdTextRouter',
+    inheritAttrs: false,
+    props: { node: { type: Object, required: true } },
+    setup(props, { attrs }) {
+      return () =>
+        h(
+          (props.node as { type?: string }).type === 'code_block' ? codeBlock : MdText,
+          { ...attrs, node: props.node },
+        )
+    },
+  })
+}
+
 // Register the shared components (plus any surface-specific extras, e.g. the
 // chat code block) in ONE call per `customId`, so the result is correct
 // regardless of whether markstream merges or replaces a scope's mapping.
@@ -34,5 +56,7 @@ export function registerSharedMarkdownComponents(
 ): void {
   if (registered.has(customId)) return
   registered.add(customId)
-  setCustomComponents(customId, { ...sharedComponents, ...extra })
+  const merged = { ...sharedComponents, ...extra }
+  merged.text = textNodeRouter(extra?.code_block)
+  setCustomComponents(customId, merged)
 }


### PR DESCRIPTION
## 改了什么

修复聊天里 ```` ```text ```` 代码围栏整块消失的问题。

markstream-vue 给代码围栏选组件时,会**先按围栏的语言名**查自定义组件表,查不到才回落到 `code_block` 键——而这张表和节点类型覆盖共用一个命名空间。于是语言名为 `text` 的围栏命中了我们为**文本节点**注册的 `text` 组件(MdText);MdText 读 `node.content`,code_block 节点上没有这个字段,整块渲染为空。模型很爱用 ```` ```text ```` 输出命令结果,所以这类消息看起来就是"话说了一半,内容没了"。

修法:注册进 markstream 的 `text` 组件换成一个按节点类型分发的小路由——`code_block` 节点转交给该 surface 注册的代码块组件(聊天和文件预览都是 ChatCodeBlock),其余照旧走 MdText 的中西文分段渲染。附带一个挂载真实 MarkdownRender 的回归测试,覆盖 ```` ```text ```` 围栏可见和 prose 分段两条路径。
