### PR TITLE
fix(agent): adopt twilight v0.5.0 per-block reasoning in the interrupted-step checkpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7
 	github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6
 	github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978
-	github.com/memohai/twilight-ai v0.4.1-0.20260811053034-702921454f2b
+	github.com/memohai/twilight-ai v0.5.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -521,10 +521,8 @@ github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6 h1:izU
 github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6/go.mod h1:8n7yDCRRNju4+wB8JrKOd29xwbKq9luyihK4eBONBVY=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978 h1:6gD8DvZkimGmU0e3PjlusJPyw55SyeoE12CZQoYUa8g=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978/go.mod h1:2LMgK5QYFlTSvrGY+sI/j+jK2WK+YGHv4IMuiW+iPSc=
-github.com/memohai/twilight-ai v0.4.1-0.20260805161855-932415603f21 h1:vfTgct8VppUgwi3HcUymbP2iBrF4U2t3URCsY3AkfLA=
-github.com/memohai/twilight-ai v0.4.1-0.20260805161855-932415603f21/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
-github.com/memohai/twilight-ai v0.4.1-0.20260811053034-702921454f2b h1:jrRyJobfPNp/KQFkXDoRekfowivRyc7XE8sIOnll9r0=
-github.com/memohai/twilight-ai v0.4.1-0.20260811053034-702921454f2b/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
+github.com/memohai/twilight-ai v0.5.0 h1:zkQkmUhasQooHP8/6aZM/+Ogv5a12zlCFfxQ4XJ+uRU=
+github.com/memohai/twilight-ai v0.5.0/go.mod h1:s5s03jeYgK56SaHH9oVHua73xCmiSG4uyfCZKi9fCHk=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=

--- a/internal/agent/application/service_history_messages_test.go
+++ b/internal/agent/application/service_history_messages_test.go
@@ -41,6 +41,40 @@ func TestProjectInterruptedHistoryReasoning(t *testing.T) {
 	}
 }
 
+func TestProjectInterruptedHistoryReasoningKeepsOpaqueBlock(t *testing.T) {
+	checkpoint := historyfrag.HistoryRecord{
+		ModelMessage: sdkMessagesToModelMessages([]sdk.Message{{
+			Role: sdk.MessageRoleAssistant,
+			Content: []sdk.MessagePart{sdk.ReasoningPart{
+				ID:     "r1",
+				Format: sdk.ReasoningFormatAnthropic,
+				Model:  "claude-sonnet-4-20250514",
+				ProviderMetadata: map[string]any{
+					"anthropic": map[string]any{"redactedData": "BLOB"},
+				},
+			}},
+		}})[0],
+		Metadata: map[string]any{messagepkg.AgentStepInterruptedMetadataKey: true},
+	}
+
+	got := modelMessageToSDKMessage(projectInterruptedHistoryReasoning([]historyfrag.HistoryRecord{checkpoint})[0].ModelMessage)
+	if len(got.Content) != 1 {
+		t.Fatalf("projected content = %#v, want one opaque reasoning block", got.Content)
+	}
+	part, ok := got.Content[0].(sdk.ReasoningPart)
+	if !ok {
+		t.Fatalf("content[0] = %T, want ReasoningPart", got.Content[0])
+	}
+	if part.ID != "r1" || part.Format != sdk.ReasoningFormatAnthropic ||
+		part.Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("reasoning provenance was not preserved: %#v", part)
+	}
+	meta, _ := part.ProviderMetadata["anthropic"].(map[string]any)
+	if data, _ := meta["redactedData"].(string); data != "BLOB" {
+		t.Fatalf("redactedData = %q, want BLOB", data)
+	}
+}
+
 func TestProjectInterruptedHistoryReasoningSkipsSupersededCheckpoint(t *testing.T) {
 	checkpoint := historyfrag.HistoryRecord{
 		ModelMessage: sdkMessagesToModelMessages([]sdk.Message{{

--- a/internal/agent/runtime/native/interrupted_step.go
+++ b/internal/agent/runtime/native/interrupted_step.go
@@ -11,11 +11,12 @@ import (
 // distinguishes an unfinished frontier from a step already committed while its
 // finish event was still buffered for this consumer.
 type interruptedStepCapture struct {
-	text            strings.Builder
-	reasoningBlocks reasoningBlockCapture
-	toolActivity    bool
-	finished        bool
-	stepIndex       int
+	text                 strings.Builder
+	textProviderMetadata map[string]any
+	reasoningBlocks      reasoningBlockCapture
+	toolActivity         bool
+	finished             bool
+	stepIndex            int
 }
 
 // reasoningBlockCapture folds streamed reasoning into ordered blocks, keeping
@@ -108,6 +109,7 @@ func (c *reasoningBlockCapture) empty() bool {
 
 func (c *interruptedStepCapture) resetContent() {
 	c.text.Reset()
+	c.textProviderMetadata = nil
 	c.reasoningBlocks.reset()
 	c.toolActivity = false
 	c.finished = false
@@ -147,6 +149,10 @@ func (c *interruptedStepCapture) observe(part sdk.StreamPart) {
 	case *sdk.TextDeltaPart:
 		c.reopenIfFinished()
 		c.text.WriteString(p.Text)
+	case *sdk.TextEndPart:
+		if p.ProviderMetadata != nil {
+			c.textProviderMetadata = p.ProviderMetadata
+		}
 	case *sdk.ReasoningStartPart:
 		c.reopenIfFinished()
 		c.reasoningBlocks.observe(p.ID, "", p.Format, p.Model, p.ProviderMetadata)
@@ -177,7 +183,10 @@ func (c *interruptedStepCapture) snapshot(nextDurableStep int) *sdk.StepResult {
 	// thinking-first ordering and reject a modified block sequence.
 	parts := c.reasoningBlocks.messageParts()
 	if text != "" {
-		parts = append(parts, sdk.TextPart{Text: text})
+		parts = append(parts, sdk.TextPart{
+			Text:             text,
+			ProviderMetadata: c.textProviderMetadata,
+		})
 	}
 	return &sdk.StepResult{
 		Text:           text,

--- a/internal/agent/runtime/native/interrupted_step.go
+++ b/internal/agent/runtime/native/interrupted_step.go
@@ -54,14 +54,21 @@ func (c *reasoningBlockCapture) at(id string) int {
 	return idx
 }
 
-// observe applies one stream part. Text concatenates; the dialect and opaque
-// token replace, because a provider sends the token once as a whole at the end
-// of a block and the later value is authoritative.
-func (c *reasoningBlockCapture) observe(id, text string, format sdk.ReasoningFormat, meta map[string]any) {
+// observe applies one stream part. Text concatenates; the dialect, model, and
+// opaque token replace when present because the later value is authoritative.
+func (c *reasoningBlockCapture) observe(
+	id, text string,
+	format sdk.ReasoningFormat,
+	model string,
+	meta map[string]any,
+) {
 	idx := c.at(id)
 	c.parts[idx].Text += text
 	if format != sdk.ReasoningFormatUnknown {
 		c.parts[idx].Format = format
+	}
+	if model != "" {
+		c.parts[idx].Model = model
 	}
 	if len(meta) == 0 {
 		return
@@ -86,11 +93,17 @@ func (c *reasoningBlockCapture) text() string {
 	return sdk.ReasoningText(c.parts)
 }
 
-// empty reports whether anything was captured at all. A block with no text is
-// not empty: a redacted thinking block carries its whole payload in metadata,
-// and dropping it breaks the replay the provider requires.
+// empty reports whether any replayable reasoning was captured. IDs, dialects,
+// and model names merely describe a block; text or provider metadata is the
+// payload. A redacted thinking block has no text but is meaningful because its
+// encrypted payload lives in metadata.
 func (c *reasoningBlockCapture) empty() bool {
-	return len(c.parts) == 0
+	for i := range c.parts {
+		if strings.TrimSpace(c.parts[i].Text) != "" || len(c.parts[i].ProviderMetadata) > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *interruptedStepCapture) resetContent() {
@@ -136,12 +149,12 @@ func (c *interruptedStepCapture) observe(part sdk.StreamPart) {
 		c.text.WriteString(p.Text)
 	case *sdk.ReasoningStartPart:
 		c.reopenIfFinished()
-		c.reasoningBlocks.observe(p.ID, "", p.Format, p.ProviderMetadata)
+		c.reasoningBlocks.observe(p.ID, "", p.Format, p.Model, p.ProviderMetadata)
 	case *sdk.ReasoningDeltaPart:
 		c.reopenIfFinished()
-		c.reasoningBlocks.observe(p.ID, p.Text, p.Format, p.ProviderMetadata)
+		c.reasoningBlocks.observe(p.ID, p.Text, p.Format, p.Model, p.ProviderMetadata)
 	case *sdk.ReasoningEndPart:
-		c.reasoningBlocks.observe(p.ID, "", p.Format, p.ProviderMetadata)
+		c.reasoningBlocks.observe(p.ID, "", p.Format, p.Model, p.ProviderMetadata)
 	case *sdk.ToolInputStartPart, *sdk.ToolInputDeltaPart, *sdk.ToolInputEndPart,
 		*sdk.StreamToolCallPart, *sdk.StreamToolResultPart, *sdk.StreamToolErrorPart,
 		*sdk.ToolOutputDeniedPart, *sdk.ToolApprovalRequestPart, *sdk.ToolProgressPart:

--- a/internal/agent/runtime/native/interrupted_step.go
+++ b/internal/agent/runtime/native/interrupted_step.go
@@ -11,17 +11,91 @@ import (
 // distinguishes an unfinished frontier from a step already committed while its
 // finish event was still buffered for this consumer.
 type interruptedStepCapture struct {
-	text, reasoning strings.Builder
-	reasoningMeta   map[string]any
+	text            strings.Builder
+	reasoningBlocks reasoningBlockCapture
 	toolActivity    bool
 	finished        bool
 	stepIndex       int
 }
 
+// reasoningBlockCapture folds streamed reasoning into ordered blocks, keeping
+// each block's own dialect and opaque token. Providers verify the block sequence
+// on replay, so merging blocks or dropping their tokens makes the checkpoint
+// unreplayable.
+type reasoningBlockCapture struct {
+	parts []sdk.ReasoningPart
+	byID  map[string]int
+}
+
+func (c *reasoningBlockCapture) reset() {
+	c.parts = nil
+	c.byID = nil
+}
+
+// at returns the block a stream part belongs to, creating it when the provider
+// announces a new ID. A part with no ID joins the most recent block, which is
+// what providers that omit block IDs imply.
+func (c *reasoningBlockCapture) at(id string) int {
+	if id != "" {
+		if idx, ok := c.byID[id]; ok {
+			return idx
+		}
+	} else if len(c.parts) > 0 {
+		return len(c.parts) - 1
+	}
+	c.parts = append(c.parts, sdk.ReasoningPart{ID: id})
+	idx := len(c.parts) - 1
+	if id != "" {
+		if c.byID == nil {
+			c.byID = make(map[string]int)
+		}
+		c.byID[id] = idx
+	}
+	return idx
+}
+
+// observe applies one stream part. Text concatenates; the dialect and opaque
+// token replace, because a provider sends the token once as a whole at the end
+// of a block and the later value is authoritative.
+func (c *reasoningBlockCapture) observe(id, text string, format sdk.ReasoningFormat, meta map[string]any) {
+	idx := c.at(id)
+	c.parts[idx].Text += text
+	if format != sdk.ReasoningFormatUnknown {
+		c.parts[idx].Format = format
+	}
+	if len(meta) == 0 {
+		return
+	}
+	if c.parts[idx].ProviderMetadata == nil {
+		c.parts[idx].ProviderMetadata = make(map[string]any, len(meta))
+	}
+	for key, value := range meta {
+		c.parts[idx].ProviderMetadata[key] = value
+	}
+}
+
+func (c *reasoningBlockCapture) messageParts() []sdk.MessagePart {
+	parts := make([]sdk.MessagePart, 0, len(c.parts))
+	for i := range c.parts {
+		parts = append(parts, c.parts[i])
+	}
+	return parts
+}
+
+func (c *reasoningBlockCapture) text() string {
+	return sdk.ReasoningText(c.parts)
+}
+
+// empty reports whether anything was captured at all. A block with no text is
+// not empty: a redacted thinking block carries its whole payload in metadata,
+// and dropping it breaks the replay the provider requires.
+func (c *reasoningBlockCapture) empty() bool {
+	return len(c.parts) == 0
+}
+
 func (c *interruptedStepCapture) resetContent() {
 	c.text.Reset()
-	c.reasoning.Reset()
-	c.reasoningMeta = nil
+	c.reasoningBlocks.reset()
 	c.toolActivity = false
 	c.finished = false
 }
@@ -55,21 +129,19 @@ func (c *interruptedStepCapture) observe(part sdk.StreamPart) {
 	switch p := part.(type) {
 	case *sdk.StartStepPart:
 		c.advance()
-	case *sdk.TextStartPart, *sdk.ReasoningStartPart:
+	case *sdk.TextStartPart:
 		c.reopenIfFinished()
 	case *sdk.TextDeltaPart:
 		c.reopenIfFinished()
 		c.text.WriteString(p.Text)
+	case *sdk.ReasoningStartPart:
+		c.reopenIfFinished()
+		c.reasoningBlocks.observe(p.ID, "", p.Format, p.ProviderMetadata)
 	case *sdk.ReasoningDeltaPart:
 		c.reopenIfFinished()
-		c.reasoning.WriteString(p.Text)
-		if p.ProviderMetadata != nil {
-			c.reasoningMeta = p.ProviderMetadata
-		}
+		c.reasoningBlocks.observe(p.ID, p.Text, p.Format, p.ProviderMetadata)
 	case *sdk.ReasoningEndPart:
-		if p.ProviderMetadata != nil {
-			c.reasoningMeta = p.ProviderMetadata
-		}
+		c.reasoningBlocks.observe(p.ID, "", p.Format, p.ProviderMetadata)
 	case *sdk.ToolInputStartPart, *sdk.ToolInputDeltaPart, *sdk.ToolInputEndPart,
 		*sdk.StreamToolCallPart, *sdk.StreamToolResultPart, *sdk.StreamToolErrorPart,
 		*sdk.ToolOutputDeniedPart, *sdk.ToolApprovalRequestPart, *sdk.ToolProgressPart:
@@ -83,20 +155,21 @@ func (c *interruptedStepCapture) observe(part sdk.StreamPart) {
 // step is still eligible when its complete commit lost the abort race; a
 // successful complete commit advances nextDurableStep and rejects it here.
 func (c *interruptedStepCapture) snapshot(nextDurableStep int) *sdk.StepResult {
-	text, reasoning := c.text.String(), c.reasoning.String()
+	text := c.text.String()
 	if c.toolActivity || c.stepIndex != nextDurableStep ||
-		(strings.TrimSpace(text) == "" && strings.TrimSpace(reasoning) == "") {
+		(strings.TrimSpace(text) == "" && c.reasoningBlocks.empty()) {
 		return nil
 	}
-	parts := make([]sdk.MessagePart, 0, 2)
-	if reasoning != "" {
-		parts = append(parts, sdk.ReasoningPart{Text: reasoning, ProviderMetadata: c.reasoningMeta})
-	}
+	// Reasoning leads the message, one part per block: providers enforce
+	// thinking-first ordering and reject a modified block sequence.
+	parts := c.reasoningBlocks.messageParts()
 	if text != "" {
 		parts = append(parts, sdk.TextPart{Text: text})
 	}
 	return &sdk.StepResult{
-		Text: text, Reasoning: reasoning,
-		Messages: []sdk.Message{{Role: sdk.MessageRoleAssistant, Content: parts}},
+		Text:           text,
+		Reasoning:      c.reasoningBlocks.text(),
+		ReasoningParts: c.reasoningBlocks.parts,
+		Messages:       []sdk.Message{{Role: sdk.MessageRoleAssistant, Content: parts}},
 	}
 }

--- a/internal/agent/runtime/native/interrupted_step_reasoning_test.go
+++ b/internal/agent/runtime/native/interrupted_step_reasoning_test.go
@@ -1,0 +1,150 @@
+package native
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// An interrupted step is persisted as a checkpoint and replayed on the next
+// turn, so it has to preserve reasoning the way a completed step does: one part
+// per block, each keeping its own dialect and opaque token. Flattening the
+// blocks here would leave the checkpoint unreplayable even though the provider
+// side is correct — and nothing would fail to compile.
+
+func reasoningPartsOf(t *testing.T, step *sdk.StepResult) []sdk.ReasoningPart {
+	t.Helper()
+	if step == nil {
+		t.Fatal("no snapshot produced")
+	}
+	var parts []sdk.ReasoningPart
+	for _, part := range step.Messages[0].Content {
+		if rp, ok := part.(sdk.ReasoningPart); ok {
+			parts = append(parts, rp)
+		}
+	}
+	return parts
+}
+
+func anthropicMeta(key, value string) map[string]any {
+	return map[string]any{"anthropic": map[string]any{key: value}}
+}
+
+func TestInterruptedStepKeepsEveryReasoningBlockToken(t *testing.T) {
+	var capture interruptedStepCapture
+	for _, part := range []sdk.StreamPart{
+		&sdk.ReasoningStartPart{ID: "b1", Format: sdk.ReasoningFormatAnthropic},
+		&sdk.ReasoningDeltaPart{ID: "b1", Text: "AAA", Format: sdk.ReasoningFormatAnthropic},
+		&sdk.ReasoningEndPart{ID: "b1", Format: sdk.ReasoningFormatAnthropic,
+			ProviderMetadata: anthropicMeta("signature", "SIG_A")},
+		&sdk.ReasoningStartPart{ID: "b2", Format: sdk.ReasoningFormatAnthropic},
+		&sdk.ReasoningDeltaPart{ID: "b2", Text: "BBB", Format: sdk.ReasoningFormatAnthropic},
+		&sdk.ReasoningEndPart{ID: "b2", Format: sdk.ReasoningFormatAnthropic,
+			ProviderMetadata: anthropicMeta("signature", "SIG_B")},
+		&sdk.TextDeltaPart{Text: "answer"},
+	} {
+		capture.observe(part)
+	}
+
+	parts := reasoningPartsOf(t, capture.snapshot(0))
+	if len(parts) != 2 {
+		t.Fatalf("reasoning parts: got %d, want 2 — blocks were merged", len(parts))
+	}
+	for i, want := range []struct{ text, sig string }{{"AAA", "SIG_A"}, {"BBB", "SIG_B"}} {
+		if parts[i].Text != want.text {
+			t.Errorf("part %d text: got %q, want %q", i, parts[i].Text, want.text)
+		}
+		if parts[i].Format != sdk.ReasoningFormatAnthropic {
+			t.Errorf("part %d format: got %q, want %q", i, parts[i].Format, sdk.ReasoningFormatAnthropic)
+		}
+		am, _ := parts[i].ProviderMetadata["anthropic"].(map[string]any)
+		if sig, _ := am["signature"].(string); sig != want.sig {
+			t.Errorf("part %d signature: got %q, want %q", i, sig, want.sig)
+		}
+	}
+}
+
+// A redacted thinking block has no text at all. Its payload lives entirely in
+// metadata and must still reach the checkpoint.
+func TestInterruptedStepKeepsEmptyTextReasoningBlock(t *testing.T) {
+	var capture interruptedStepCapture
+	for _, part := range []sdk.StreamPart{
+		&sdk.ReasoningStartPart{ID: "r1", Format: sdk.ReasoningFormatAnthropic},
+		&sdk.ReasoningEndPart{ID: "r1", Format: sdk.ReasoningFormatAnthropic,
+			ProviderMetadata: anthropicMeta("redactedData", "BLOB")},
+		&sdk.TextDeltaPart{Text: "answer"},
+	} {
+		capture.observe(part)
+	}
+
+	parts := reasoningPartsOf(t, capture.snapshot(0))
+	if len(parts) != 1 {
+		t.Fatalf("reasoning parts: got %d, want 1 — empty-text block was dropped", len(parts))
+	}
+	am, _ := parts[0].ProviderMetadata["anthropic"].(map[string]any)
+	if data, _ := am["redactedData"].(string); data != "BLOB" {
+		t.Errorf("redactedData: got %q, want BLOB", data)
+	}
+}
+
+// Reasoning alone, with no answer text yet, is still worth checkpointing: it is
+// exactly what an interruption mid-thinking leaves behind.
+func TestInterruptedStepSnapshotsReasoningWithoutText(t *testing.T) {
+	var capture interruptedStepCapture
+	capture.observe(&sdk.ReasoningStartPart{ID: "b1", Format: sdk.ReasoningFormatAnthropic})
+	capture.observe(&sdk.ReasoningEndPart{ID: "b1", Format: sdk.ReasoningFormatAnthropic,
+		ProviderMetadata: anthropicMeta("redactedData", "BLOB")})
+
+	step := capture.snapshot(0)
+	if step == nil {
+		t.Fatal("reasoning-only interruption produced no snapshot")
+	}
+	if len(step.ReasoningParts) != 1 {
+		t.Fatalf("ReasoningParts: got %d, want 1", len(step.ReasoningParts))
+	}
+}
+
+// Reasoning leads the assistant message: providers enforce thinking-first
+// ordering, and a trailing reasoning item is rejected outright by OpenAI.
+func TestInterruptedStepPutsReasoningBeforeText(t *testing.T) {
+	var capture interruptedStepCapture
+	capture.observe(&sdk.ReasoningDeltaPart{ID: "b1", Text: "thought", Format: sdk.ReasoningFormatAnthropic})
+	capture.observe(&sdk.TextDeltaPart{Text: "answer"})
+
+	step := capture.snapshot(0)
+	if step == nil {
+		t.Fatal("no snapshot produced")
+	}
+	if _, ok := step.Messages[0].Content[0].(sdk.ReasoningPart); !ok {
+		t.Errorf("content[0] = %T, want ReasoningPart to lead", step.Messages[0].Content[0])
+	}
+}
+
+// The flat Reasoning field stays available for display, derived from the blocks.
+func TestInterruptedStepFlatReasoningJoinsBlocks(t *testing.T) {
+	var capture interruptedStepCapture
+	capture.observe(&sdk.ReasoningDeltaPart{ID: "b1", Text: "AAA", Format: sdk.ReasoningFormatAnthropic})
+	capture.observe(&sdk.ReasoningDeltaPart{ID: "b2", Text: "BBB", Format: sdk.ReasoningFormatAnthropic})
+
+	step := capture.snapshot(0)
+	if step == nil {
+		t.Fatal("no snapshot produced")
+	}
+	if step.Reasoning != "AAABBB" {
+		t.Errorf("Reasoning: got %q, want %q", step.Reasoning, "AAABBB")
+	}
+}
+
+// Retained content must not leak across step boundaries.
+func TestInterruptedStepResetsReasoningBetweenSteps(t *testing.T) {
+	var capture interruptedStepCapture
+	capture.observe(&sdk.ReasoningDeltaPart{ID: "b1", Text: "first", Format: sdk.ReasoningFormatAnthropic})
+	capture.observe(&sdk.FinishStepPart{})
+	capture.observe(&sdk.StartStepPart{})
+	capture.observe(&sdk.ReasoningDeltaPart{ID: "b2", Text: "second", Format: sdk.ReasoningFormatAnthropic})
+
+	parts := reasoningPartsOf(t, capture.snapshot(1))
+	if len(parts) != 1 || parts[0].Text != "second" {
+		t.Fatalf("parts: %+v, want only the second step's block", parts)
+	}
+}

--- a/internal/agent/runtime/native/interrupted_step_reasoning_test.go
+++ b/internal/agent/runtime/native/interrupted_step_reasoning_test.go
@@ -35,12 +35,16 @@ func TestInterruptedStepKeepsEveryReasoningBlockToken(t *testing.T) {
 	for _, part := range []sdk.StreamPart{
 		&sdk.ReasoningStartPart{ID: "b1", Format: sdk.ReasoningFormatAnthropic},
 		&sdk.ReasoningDeltaPart{ID: "b1", Text: "AAA", Format: sdk.ReasoningFormatAnthropic},
-		&sdk.ReasoningEndPart{ID: "b1", Format: sdk.ReasoningFormatAnthropic,
-			ProviderMetadata: anthropicMeta("signature", "SIG_A")},
+		&sdk.ReasoningEndPart{
+			ID: "b1", Format: sdk.ReasoningFormatAnthropic,
+			ProviderMetadata: anthropicMeta("signature", "SIG_A"),
+		},
 		&sdk.ReasoningStartPart{ID: "b2", Format: sdk.ReasoningFormatAnthropic},
 		&sdk.ReasoningDeltaPart{ID: "b2", Text: "BBB", Format: sdk.ReasoningFormatAnthropic},
-		&sdk.ReasoningEndPart{ID: "b2", Format: sdk.ReasoningFormatAnthropic,
-			ProviderMetadata: anthropicMeta("signature", "SIG_B")},
+		&sdk.ReasoningEndPart{
+			ID: "b2", Format: sdk.ReasoningFormatAnthropic,
+			ProviderMetadata: anthropicMeta("signature", "SIG_B"),
+		},
 		&sdk.TextDeltaPart{Text: "answer"},
 	} {
 		capture.observe(part)
@@ -70,8 +74,10 @@ func TestInterruptedStepKeepsEmptyTextReasoningBlock(t *testing.T) {
 	var capture interruptedStepCapture
 	for _, part := range []sdk.StreamPart{
 		&sdk.ReasoningStartPart{ID: "r1", Format: sdk.ReasoningFormatAnthropic},
-		&sdk.ReasoningEndPart{ID: "r1", Format: sdk.ReasoningFormatAnthropic,
-			ProviderMetadata: anthropicMeta("redactedData", "BLOB")},
+		&sdk.ReasoningEndPart{
+			ID: "r1", Format: sdk.ReasoningFormatAnthropic,
+			ProviderMetadata: anthropicMeta("redactedData", "BLOB"),
+		},
 		&sdk.TextDeltaPart{Text: "answer"},
 	} {
 		capture.observe(part)
@@ -92,8 +98,10 @@ func TestInterruptedStepKeepsEmptyTextReasoningBlock(t *testing.T) {
 func TestInterruptedStepSnapshotsReasoningWithoutText(t *testing.T) {
 	var capture interruptedStepCapture
 	capture.observe(&sdk.ReasoningStartPart{ID: "b1", Format: sdk.ReasoningFormatAnthropic})
-	capture.observe(&sdk.ReasoningEndPart{ID: "b1", Format: sdk.ReasoningFormatAnthropic,
-		ProviderMetadata: anthropicMeta("redactedData", "BLOB")})
+	capture.observe(&sdk.ReasoningEndPart{
+		ID: "b1", Format: sdk.ReasoningFormatAnthropic,
+		ProviderMetadata: anthropicMeta("redactedData", "BLOB"),
+	})
 
 	step := capture.snapshot(0)
 	if step == nil {

--- a/internal/agent/runtime/native/interrupted_step_reasoning_test.go
+++ b/internal/agent/runtime/native/interrupted_step_reasoning_test.go
@@ -68,6 +68,60 @@ func TestInterruptedStepKeepsEveryReasoningBlockToken(t *testing.T) {
 	}
 }
 
+// A reasoning block's opaque token is bound to the model that produced it.
+// Stream parts may report that model at different points, so later non-empty
+// values replace earlier aliases while omitted values must not erase it.
+func TestInterruptedStepKeepsReasoningBlockModel(t *testing.T) {
+	var capture interruptedStepCapture
+	capture.observe(&sdk.ReasoningStartPart{
+		ID: "b1", Model: "claude-sonnet-4", Format: sdk.ReasoningFormatAnthropic,
+	})
+	capture.observe(&sdk.ReasoningDeltaPart{
+		ID: "b1", Text: "thought", Format: sdk.ReasoningFormatAnthropic,
+	})
+	if got := capture.reasoningBlocks.parts[0].Model; got != "claude-sonnet-4" {
+		t.Fatalf("empty delta model erased start model: got %q", got)
+	}
+	capture.observe(&sdk.ReasoningDeltaPart{
+		ID: "b1", Model: "anthropic/claude-sonnet-4", Format: sdk.ReasoningFormatAnthropic,
+	})
+	if got := capture.reasoningBlocks.parts[0].Model; got != "anthropic/claude-sonnet-4" {
+		t.Fatalf("delta model was not merged: got %q", got)
+	}
+	capture.observe(&sdk.ReasoningEndPart{
+		ID: "b1", Model: "claude-sonnet-4-20250514", Format: sdk.ReasoningFormatAnthropic,
+		ProviderMetadata: anthropicMeta("signature", "SIG"),
+	})
+
+	step := capture.snapshot(0)
+	if step == nil {
+		t.Fatal("no snapshot produced")
+	}
+	if got := step.ReasoningParts[0].Model; got != "claude-sonnet-4-20250514" {
+		t.Errorf("ReasoningParts[0].Model: got %q, want response model", got)
+	}
+	parts := reasoningPartsOf(t, step)
+	if got := parts[0].Model; got != "claude-sonnet-4-20250514" {
+		t.Errorf("message reasoning model: got %q, want response model", got)
+	}
+}
+
+// A start marker only announces a block; without text or provider metadata it
+// contains nothing that can be replayed and should not create a checkpoint.
+func TestInterruptedStepDropsEmptyReasoningStart(t *testing.T) {
+	var capture interruptedStepCapture
+	capture.observe(&sdk.ReasoningStartPart{
+		ID: "b1", Model: "claude-sonnet-4-20250514", Format: sdk.ReasoningFormatAnthropic,
+	})
+	capture.observe(&sdk.ReasoningDeltaPart{
+		ID: "b1", Text: "   ", Format: sdk.ReasoningFormatAnthropic,
+	})
+
+	if step := capture.snapshot(0); step != nil {
+		t.Fatalf("empty reasoning start produced a snapshot: %+v", step)
+	}
+}
+
 // A redacted thinking block has no text at all. Its payload lives entirely in
 // metadata and must still reach the checkpoint.
 func TestInterruptedStepKeepsEmptyTextReasoningBlock(t *testing.T) {

--- a/internal/agent/runtime/native/interrupted_step_reasoning_test.go
+++ b/internal/agent/runtime/native/interrupted_step_reasoning_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
+
+	"github.com/memohai/memoh/internal/messageconv"
 )
 
 // An interrupted step is persisted as a checkpoint and replayed on the next
@@ -28,6 +30,42 @@ func reasoningPartsOf(t *testing.T, step *sdk.StepResult) []sdk.ReasoningPart {
 
 func anthropicMeta(key, value string) map[string]any {
 	return map[string]any{"anthropic": map[string]any{key: value}}
+}
+
+func googleMeta(key, value string) map[string]any {
+	return map[string]any{"google": map[string]any{key: value}}
+}
+
+func TestInterruptedStepKeepsTextProviderMetadata(t *testing.T) {
+	var capture interruptedStepCapture
+	for _, part := range []sdk.StreamPart{
+		&sdk.TextStartPart{ID: "t1"},
+		&sdk.TextDeltaPart{ID: "t1", Text: "answer"},
+		&sdk.TextEndPart{
+			ID:               "t1",
+			ProviderMetadata: googleMeta("thoughtSignature", "SIG_TEXT"),
+		},
+	} {
+		capture.observe(part)
+	}
+
+	step := capture.snapshot(0)
+	if step == nil {
+		t.Fatal("no snapshot produced")
+	}
+	persisted := messageconv.SDKMessagesToModelMessages(step.Messages)
+	if len(persisted) != 1 {
+		t.Fatalf("persisted messages: got %d, want 1", len(persisted))
+	}
+	replayed := messageconv.ModelMessageToSDKMessage(persisted[0])
+	text, ok := replayed.Content[0].(sdk.TextPart)
+	if !ok {
+		t.Fatalf("content[0] = %T, want TextPart", replayed.Content[0])
+	}
+	gm, _ := text.ProviderMetadata["google"].(map[string]any)
+	if sig, _ := gm["thoughtSignature"].(string); sig != "SIG_TEXT" {
+		t.Errorf("thought signature: got %q, want SIG_TEXT", sig)
+	}
 }
 
 func TestInterruptedStepKeepsEveryReasoningBlockToken(t *testing.T) {

--- a/internal/chat/timeline/turn_response.go
+++ b/internal/chat/timeline/turn_response.go
@@ -61,7 +61,7 @@ func decodeTurnResponseEntry(msg messagepkg.Message, liveCheckpoint bool) (TurnR
 		if liveCheckpoint {
 			modelMsg = ProjectInterruptedReasoning(modelMsg)
 		}
-		rawContent = nativeAssistantContent(modelMsg)
+		rawContent = nativeAssistantContent(modelMsg, liveCheckpoint)
 	}
 
 	if len(rawContent) == 0 || strings.TrimSpace(string(rawContent)) == "" {
@@ -130,7 +130,10 @@ func ProjectInterruptedReasoning(modelMsg turn.ModelMessage) turn.ModelMessage {
 // structure while keeping the type declaration local to this package.
 type turnResponsePart struct {
 	Type             string          `json:"type"`
+	ID               string          `json:"id,omitempty"`
 	Text             string          `json:"text,omitempty"`
+	Format           string          `json:"format,omitempty"`
+	Model            string          `json:"model,omitempty"`
 	ToolCallID       string          `json:"toolCallId,omitempty"`
 	ToolName         string          `json:"toolName,omitempty"`
 	Input            json.RawMessage `json:"input,omitempty"`
@@ -139,7 +142,7 @@ type turnResponsePart struct {
 	ProviderMetadata json.RawMessage `json:"providerMetadata,omitempty"`
 }
 
-func nativeAssistantContent(msg turn.ModelMessage) json.RawMessage {
+func nativeAssistantContent(msg turn.ModelMessage, liveCheckpoint bool) json.RawMessage {
 	var out []map[string]any
 	// 1) Plain-string content (legacy format).
 	if len(msg.Content) > 0 {
@@ -164,16 +167,45 @@ func nativeAssistantContent(msg turn.ModelMessage) json.RawMessage {
 	for _, p := range parts {
 		switch strings.ToLower(strings.TrimSpace(p.Type)) {
 		case "text":
+			hasMetadata := hasJSONPayload(p.ProviderMetadata)
 			text := strings.TrimSpace(p.Text)
-			if text == "" {
+			if text == "" && !hasMetadata {
 				continue
 			}
-			out = append(out, map[string]any{
+			if hasMetadata {
+				// Provider metadata can be bound to the exact text block. Keep
+				// its whitespace unchanged when carrying that metadata forward.
+				text = p.Text
+			}
+			textPart := map[string]any{
 				"type": "text",
 				"text": text,
-			})
+			}
+			if hasMetadata {
+				textPart["providerMetadata"] = p.ProviderMetadata
+			}
+			out = append(out, textPart)
 		case "reasoning":
-			continue
+			if !liveCheckpoint || !hasReplayableReasoningPayload(p) {
+				continue
+			}
+			reasoning := map[string]any{
+				"type": "reasoning",
+				"text": p.Text,
+			}
+			if strings.TrimSpace(p.ID) != "" {
+				reasoning["id"] = p.ID
+			}
+			if strings.TrimSpace(p.Format) != "" {
+				reasoning["format"] = p.Format
+			}
+			if strings.TrimSpace(p.Model) != "" {
+				reasoning["model"] = p.Model
+			}
+			if hasJSONPayload(p.ProviderMetadata) {
+				reasoning["providerMetadata"] = p.ProviderMetadata
+			}
+			out = append(out, reasoning)
 		case "tool-call":
 			out = append(out, nativeToolCallPart(p.ToolCallID, p.ToolName, p.Input, p.ProviderMetadata))
 		case "tool-result":
@@ -204,6 +236,19 @@ func nativeAssistantContent(msg turn.ModelMessage) json.RawMessage {
 	}
 
 	return marshalParts(out)
+}
+
+func hasReplayableReasoningPayload(part turnResponsePart) bool {
+	return strings.TrimSpace(part.Text) != "" || hasJSONPayload(part.ProviderMetadata)
+}
+
+func hasJSONPayload(raw json.RawMessage) bool {
+	switch strings.TrimSpace(string(raw)) {
+	case "", "null", "{}":
+		return false
+	default:
+		return true
+	}
 }
 
 func nativeToolRoleContent(msg turn.ModelMessage) json.RawMessage {

--- a/internal/chat/timeline/turn_response_test.go
+++ b/internal/chat/timeline/turn_response_test.go
@@ -134,6 +134,42 @@ func TestDecodeTurnResponseEntryPreservesToolCallProviderMetadata(t *testing.T) 
 	}
 }
 
+func TestDecodeTurnResponseEntryPreservesTextProviderMetadata(t *testing.T) {
+	t.Parallel()
+
+	content, err := json.Marshal([]map[string]any{{
+		"type": "text",
+		"text": " the answer ",
+		"providerMetadata": map[string]any{
+			"google": map[string]any{"thoughtSignature": "SIG_TEXT"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("marshal content: %v", err)
+	}
+	modelMessage, err := json.Marshal(turn.ModelMessage{Role: "assistant", Content: content})
+	if err != nil {
+		t.Fatalf("marshal model message: %v", err)
+	}
+
+	entry, ok := DecodeTurnResponseEntry(messagepkg.Message{
+		Role:    "assistant",
+		Content: modelMessage,
+	})
+	if !ok {
+		t.Fatal("expected turn response entry")
+	}
+	part := assertRawPart(t, entry.RawContent, "text", " the answer ", "")
+	meta, ok := part["providerMetadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("providerMetadata = %#v, want map", part["providerMetadata"])
+	}
+	google, ok := meta["google"].(map[string]any)
+	if !ok || google["thoughtSignature"] != "SIG_TEXT" {
+		t.Fatalf("google metadata = %#v, want thought signature", meta["google"])
+	}
+}
+
 func TestDecodeTurnResponseEntryRendersTextAndToolCall(t *testing.T) {
 	t.Parallel()
 
@@ -274,6 +310,57 @@ func TestDecodeTurnResponseEntryKeepsOnlyInterruptedReasoning(t *testing.T) {
 		t.Fatalf("entries = %d, want only the latest interrupted checkpoint", len(entries))
 	}
 	assertRawPart(t, entries[0].RawContent, "text", messagepkg.AgentStepInterruptedReasoningPrefix+"thinking out loud", "")
+}
+
+func TestDecodeTurnResponseEntriesKeepsOpaqueInterruptedReasoning(t *testing.T) {
+	t.Parallel()
+
+	content, err := json.Marshal([]map[string]any{{
+		"type":   "reasoning",
+		"id":     "r1",
+		"text":   "",
+		"format": "anthropic-v1",
+		"model":  "claude-sonnet-4-20250514",
+		"providerMetadata": map[string]any{
+			"anthropic": map[string]any{"redactedData": "BLOB"},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("marshal content: %v", err)
+	}
+	modelMessage, err := json.Marshal(turn.ModelMessage{Role: "assistant", Content: content})
+	if err != nil {
+		t.Fatalf("marshal model message: %v", err)
+	}
+	checkpoint := messagepkg.Message{
+		Role:    "assistant",
+		Content: modelMessage,
+		Metadata: map[string]any{
+			messagepkg.AgentStepInterruptedMetadataKey: true,
+		},
+	}
+
+	entries := DecodeTurnResponseEntries([]messagepkg.Message{checkpoint})
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want opaque interrupted checkpoint", len(entries))
+	}
+	part := assertRawPart(t, entries[0].RawContent, "reasoning", "", "")
+	if part["id"] != "r1" || part["format"] != "anthropic-v1" ||
+		part["model"] != "claude-sonnet-4-20250514" {
+		t.Fatalf("reasoning provenance was not preserved: %#v", part)
+	}
+	meta, ok := part["providerMetadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("providerMetadata = %#v, want map", part["providerMetadata"])
+	}
+	anthropic, ok := meta["anthropic"].(map[string]any)
+	if !ok || anthropic["redactedData"] != "BLOB" {
+		t.Fatalf("anthropic metadata = %#v, want redactedData", meta["anthropic"])
+	}
+
+	if _, ok := DecodeTurnResponseEntry(checkpoint); ok {
+		t.Fatal("completed-history decoder retained opaque reasoning")
+	}
 }
 
 func TestDecodeTurnResponseEntriesDropSupersededCheckpoint(t *testing.T) {


### PR DESCRIPTION
Stacked on #993. Two commits: the twilight v0.5.0 bump (the reasoning round-trip release, twilight-ai#45), and the one Memoh-side adoption it still needed.

## Why this exists

twilight-ai#45 rebuilt reasoning replay around per-block parts — each block keeps its own dialect, producing model and opaque token, because providers verify that sequence and reject anything modified (Anthropic: hard 400, reproduced live several times over in that PR's history).

Memoh compiles against the new SDK unchanged. But compiling isn't the point — the interrupted-step capture (`internal/agent/runtime/native/interrupted_step.go`) builds reasoning parts *itself* rather than taking the SDK's, and it had the exact defect the SDK just fixed: one string builder plus one metadata bag, last token wins, empty-text blocks filtered out. A checkpoint of a turn with several thinking blocks came out as concatenated text under the last block's signature, which is precisely the shape Anthropic rejects.

The mirror is what makes it worth calling out: nothing fails to compile, every existing test stays green, and the path silently keeps corrupting checkpoints after the SDK is correct. Shadow implementations don't get fixed by upstream fixes.

## What changed

The capture accumulates ordered blocks keyed by the stream's block ID. Text concatenates; the dialect, model and token replace, since a provider sends the token once, whole, at the block's end. Blocks lead the assistant message (providers enforce thinking-first ordering), a block is never judged empty by its text alone (redacted blocks carry everything in metadata), and reasoning with no answer text still checkpoints — that's exactly what an interruption mid-thinking leaves behind.

Six guards. I reverted the block-merging fix to watch its guard fail (`got 1, want 2 — blocks were merged`) before keeping it; a dropped token is silent until a provider rejects the next request, so a guard that has never failed proves nothing.

## Verified

Unit-level only. The live path needs an interruption during pure thinking — no tool activity, before any answer text — which is a narrow window to hit by hand; the round-trip mechanics this feeds were verified live in twilight-ai#45 (five redacted blocks replayed byte-intact, signatures paired across six turns, zero 400s).
