### PR TITLE
fix(web): derive terminal tab titles

### DIFF
--- a/apps/web/src/pages/home/components/terminal-pane.vue
+++ b/apps/web/src/pages/home/components/terminal-pane.vue
@@ -97,6 +97,7 @@ let ws: WebSocket | null = null
 let resizeObserver: ResizeObserver | null = null
 let fitTimer: ReturnType<typeof setTimeout> | null = null
 let disposables: Array<{ dispose(): void }> = []
+let connectionDisposables: Array<{ dispose(): void }> = []
 
 function currentCacheKey(): string {
   return terminalCacheKey(props.botId, props.tabId)
@@ -138,6 +139,9 @@ function connectWs() {
   if (!terminal) return
   closeWs()
 
+  for (const d of connectionDisposables) d.dispose()
+  connectionDisposables = []
+
   fitTerminal()
 
   const cols = terminal.cols
@@ -174,10 +178,7 @@ function connectWs() {
     status.value = 'disconnected'
   }
 
-  for (const d of disposables) d.dispose()
-  disposables = []
-
-  disposables.push(
+  connectionDisposables.push(
     terminal.onData((data) => {
       if (ws && ws.readyState === WebSocket.OPEN) {
         ws.send(new TextEncoder().encode(data))
@@ -257,6 +258,13 @@ onMounted(() => {
   fitAddon = fa
   serializeAddon = sa
 
+  disposables.push(
+    // xterm reports OSC 0/2 application titles, not foreground-process identity.
+    term.onTitleChange((title) => {
+      tabsStore.updateTerminalTitle(props.tabId, title)
+    }),
+  )
+
   const snapshot = readTerminalSnapshot(currentCacheKey())
   if (snapshot) {
     term.write(snapshot)
@@ -318,6 +326,8 @@ onBeforeUnmount(() => {
   closeWs()
   for (const d of disposables) d.dispose()
   disposables = []
+  for (const d of connectionDisposables) d.dispose()
+  connectionDisposables = []
   terminal?.dispose()
   terminal = null
   fitAddon = null

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -35,6 +35,9 @@ vi.hoisted(() => {
 
   const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>()
   const storage = new MemoryStorage()
+  // Keep real i18n active so terminal-title assertions catch missing or
+  // misspelled keys, while making the expected English fallback deterministic.
+  storage.setItem('language', 'en')
   // Layout/selection now live in sessionStorage (per-Tab), so the store's
   // restore path reads it, not localStorage. A separate instance mirrors the
   // real browser split (two distinct areas under the same key names).
@@ -113,18 +116,6 @@ const mobileBreakpoint = vi.hoisted(() => {
     },
   }
 })
-
-// workspace-tabs imports @/i18n to localize the desktop panel title; that
-// module reads localStorage at load to pick the initial locale, which isn't
-// polyfilled in this test's environment. Mock it so the import stays
-// side-effect free here.
-vi.mock('@/i18n', () => ({
-  default: {
-    global: {
-      t: (key: string) => key === 'chat.terminal.defaultTabLabel' ? 'Terminal' : key,
-    },
-  },
-}))
 
 const chatStoreMock = vi.hoisted(() => ({
   sessionId: null as string | null,

--- a/apps/web/src/store/workspace-tabs.test.ts
+++ b/apps/web/src/store/workspace-tabs.test.ts
@@ -119,7 +119,11 @@ const mobileBreakpoint = vi.hoisted(() => {
 // polyfilled in this test's environment. Mock it so the import stays
 // side-effect free here.
 vi.mock('@/i18n', () => ({
-  default: { global: { t: (key: string) => key } },
+  default: {
+    global: {
+      t: (key: string) => key === 'chat.terminal.defaultTabLabel' ? 'Terminal' : key,
+    },
+  },
 }))
 
 const chatStoreMock = vi.hoisted(() => ({
@@ -844,13 +848,85 @@ describe('workspace layout store', () => {
     store.registerApi(dock as never)
 
     store.openTerminal()
+    expect(dock.getPanel('terminal:1')?.title).toBe('Terminal 1')
     store.openTerminal()
+    expect(dock.getPanel('terminal:2')?.title).toBe('Terminal 2')
     store.closeTab('terminal:1')
     store.openTerminal()
 
     expect(dock.getPanel('terminal:1')).toBeUndefined()
     expect(dock.getPanel('terminal:2')).toBeTruthy()
     expect(dock.getPanel('terminal:3')).toBeTruthy()
+  })
+
+  it('repairs legacy terminal titles when restoring a layout', async () => {
+    localStorage.setItem('workspace-layout', JSON.stringify({
+      'bot-1': {
+        layout: {
+          panels: {
+            'terminal:1': {
+              id: 'terminal:1',
+              contentComponent: 'terminal',
+              title: 'zsh',
+            },
+            'terminal:2': {
+              id: 'terminal:2',
+              contentComponent: 'terminal',
+              title: '',
+            },
+          },
+        },
+        terminalCounter: 2,
+        ephemeralIds: [],
+      },
+    }))
+
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    await nextTick()
+
+    expect(dock.getPanel('terminal:1')?.title).toBe('Terminal 1')
+    expect(dock.getPanel('terminal:2')?.title).toBe('Terminal 2')
+  })
+
+  it('updates only the intended terminal title and ignores invalid or repeated events', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openTerminal()
+    store.openTerminal()
+
+    const first = dock.getPanel('terminal:1')!
+    const second = dock.getPanel('terminal:2')!
+    const setTitle = vi.spyOn(first.api, 'setTitle')
+
+    store.updateTerminalTitle(first.id, '  python  ')
+
+    expect(first.title).toBe('python')
+    expect(second.title).toBe('Terminal 2')
+    expect(setTitle).toHaveBeenCalledTimes(1)
+
+    store.updateTerminalTitle(first.id, 'python')
+    store.updateTerminalTitle(first.id, '   ')
+    store.updateTerminalTitle(first.id, null)
+
+    expect(first.title).toBe('python')
+    expect(setTitle).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts a split terminal with its own fallback title', () => {
+    const store = useWorkspaceTabsStore()
+    const dock = createFakeDock()
+    store.registerApi(dock as never)
+    store.openTerminal()
+
+    const first = dock.getPanel('terminal:1')!
+    store.updateTerminalTitle(first.id, 'node')
+    store.splitGroup(first.group!.id, 'right')
+
+    expect(first.title).toBe('node')
+    expect(dock.getPanel('terminal:2')?.title).toBe('Terminal 2')
   })
 
   it('duplicates the active file into a split pane with a unique panel id', () => {

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -342,7 +342,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   }
 
   function terminalTitleFallback(id: string): string {
-    const prefix = i18n.global.t('chat.terminal.defaultTabLabel').trim() || DEFAULT_TERMINAL_TITLE
+    const prefix = i18n.global.t('bots.terminal.defaultTabLabel').trim() || DEFAULT_TERMINAL_TITLE
     return numberedFallbackTitle(prefix, id)
   }
 

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -39,6 +39,10 @@ export const TERMINAL_TAB_COMPONENT = 'terminalTab'
 
 const DEFAULT_BROWSER_ADDRESS = 'localhost:5173/'
 const DEFAULT_CHAT_TITLE = 'New Session'
+const DEFAULT_TERMINAL_TITLE = 'Terminal'
+// Persisted layouts from older releases used this value as the terminal title.
+// It is only recognized for migration; it is never used as a new title.
+const LEGACY_TERMINAL_TITLE = 'zsh'
 
 // Default share of the editor height the bottom terminal panel claims when it
 // first splits off below the chat. ~1/3 mirrors VS Code's editor:panel ratio
@@ -337,6 +341,11 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     return suffix ? `${prefix} ${suffix}` : prefix
   }
 
+  function terminalTitleFallback(id: string): string {
+    const prefix = i18n.global.t('chat.terminal.defaultTabLabel').trim() || DEFAULT_TERMINAL_TITLE
+    return numberedFallbackTitle(prefix, id)
+  }
+
   // Per-session chat title fallback (English; the sidebar callers pass localized
   // strings, and syncChatTitles overlays the server title once known).
   function chatTitleFallbackFor(sid: string | null): string {
@@ -359,7 +368,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
         return typeof name === 'string' && name.trim() ? name.trim() : 'file'
       }
       case 'terminal':
-        return 'zsh'
+        return terminalTitleFallback(panel.id)
       case 'browser': {
         const address = params.address
         return typeof address === 'string' && address.trim()
@@ -380,11 +389,24 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     if (!dock) return false
     let repaired = false
     for (const panel of dock.panels) {
-      if ((panel.api.title ?? '').trim()) continue
+      const title = (panel.api.title ?? '').trim()
+      const isLegacyTerminalTitle = panelComponentOf(panel.id) === 'terminal'
+        && title.toLowerCase() === LEGACY_TERMINAL_TITLE
+      if (title && !isLegacyTerminalTitle) continue
       panel.api.setTitle(panelTitleFallback(panel))
       repaired = true
     }
     return repaired
+  }
+
+  function updateTerminalTitle(panelId: string, title: unknown) {
+    const dock = api.value
+    if (!dock || panelComponentOf(panelId) !== 'terminal' || typeof title !== 'string') return
+    const panel = dock.getPanel(panelId)
+    const normalized = title.trim()
+    if (!panel || !normalized || panel.api.title === normalized) return
+    panel.api.setTitle(normalized)
+    persistLayout()
   }
 
   function restoreLayout(botId: string) {
@@ -1679,9 +1701,10 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     // straight through would wrongly merge the terminal into that editor group.
     const initiating = groupId ? dock.getGroup(groupId) : undefined
     const joinTerminalGroup = !!initiating && isTerminalOnlyGroup(initiating)
+    const id = `terminal:${next}`
     addTerminalPanel({
-      id: `terminal:${next}`,
-      title: 'zsh',
+      id,
+      title: terminalTitleFallback(id),
       groupId: joinTerminalGroup ? groupId : undefined,
       position: joinTerminalGroup ? undefined : defaultTerminalPosition(dock, groupId),
     })
@@ -1914,9 +1937,10 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
         if (!state) return
         const next = state.terminalCounter + 1
         patchBotLayout(bid, { terminalCounter: next })
+        const id = `terminal:${next}`
         addTerminalPanel({
-          id: `terminal:${next}`,
-          title: title || 'zsh',
+          id,
+          title: terminalTitleFallback(id),
           position,
         })
         break
@@ -2548,6 +2572,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
     registerFileSaveHandler,
     unregisterFileSaveHandler,
     updateBrowserAddress,
+    updateTerminalTitle,
     resetBot,
     resetAll,
   }


### PR DESCRIPTION
## Summary
- Replace hard-coded `zsh` terminal fallbacks with localized neutral terminal titles and migrate legacy persisted titles.
- Propagate xterm OSC 0/2 application titles to the owning Dockview terminal tab.
- Preserve reconnect disposal behavior and add workspace-tabs regression coverage.

## Validation
- `pnpm exec vitest run apps/web/src/store/workspace-tabs.test.ts`: 72 passed.
- `pnpm lint`: passed.
- `pnpm --filter @memohai/web build`: passed.
- `git diff --check` and `git diff --cached --check`: passed.
- Unchanged pre-commit hook in WSL: Go lint, `go test ./...`, and lint-staged ESLint all passed.
- The initial Windows hook failure was limited to unrelated Windows baseline/environment issues; no unrelated code was changed.

