### PR TITLE
feat(heartbeat): support ACP runtime execution

### DIFF
--- a/cmd/internal/core/providers.go
+++ b/cmd/internal/core/providers.go
@@ -410,6 +410,7 @@ func provideHeartbeatTriggerer(service *application.Service) heartbeat.Triggerer
 type sessionCreatorAdapter struct {
 	svc      *sessionpkg.Service
 	workdirs *workdir.Service
+	settings *settings.Service
 }
 
 func (a *sessionCreatorAdapter) CreateSession(ctx context.Context, botID, sessionType string) (string, error) {
@@ -421,6 +422,43 @@ func (a *sessionCreatorAdapter) CreateSession(ctx context.Context, botID, sessio
 		return "", err
 	}
 	return sess.ID, nil
+}
+
+func (a *sessionCreatorAdapter) CreateHeartbeatSession(ctx context.Context, botID, ownerUserID string) (string, error) {
+	if a.settings == nil {
+		return "", errors.New("settings service not configured")
+	}
+	botSettings, err := a.settings.GetBot(ctx, botID)
+	if err != nil {
+		return "", fmt.Errorf("load heartbeat bot settings: %w", err)
+	}
+
+	input := heartbeatSessionCreateInput(botID, ownerUserID, botSettings)
+
+	sess, err := a.svc.Create(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	return sess.ID, nil
+}
+
+func heartbeatSessionCreateInput(botID, ownerUserID string, botSettings settings.Settings) sessionpkg.CreateInput {
+	input := sessionpkg.CreateInput{
+		BotID:       botID,
+		Type:        sessionpkg.TypeHeartbeat,
+		SessionMode: sessionpkg.TypeHeartbeat,
+	}
+	if botSettings.ChatRuntime != settings.ChatRuntimeACPAgent {
+		return input
+	}
+	input.RuntimeType = sessionpkg.RuntimeACPAgent
+	input.CreatedByUserID = ownerUserID
+	input.Metadata = map[string]any{
+		"acp_agent_id":     botSettings.ChatACPAgentID,
+		"project_path":     botSettings.ChatACPProjectPath,
+		"acp_project_mode": botSettings.ChatACPProjectMode,
+	}
+	return input
 }
 
 // CreateScheduleSession creates the user-visible session one schedule fire
@@ -463,8 +501,8 @@ func (a *sessionCreatorAdapter) CreateScheduleSession(ctx context.Context, spec 
 	return sess.ID, nil
 }
 
-func provideHeartbeatSessionCreator(sessionService *sessionpkg.Service) heartbeat.SessionCreator {
-	return &sessionCreatorAdapter{svc: sessionService}
+func provideHeartbeatSessionCreator(sessionService *sessionpkg.Service, settingsService *settings.Service) heartbeat.SessionCreator {
+	return &sessionCreatorAdapter{svc: sessionService, settings: settingsService}
 }
 
 func provideScheduleSessionCreator(sessionService *sessionpkg.Service, workdirService *workdir.Service) schedule.SessionCreator {

--- a/cmd/internal/core/providers_test.go
+++ b/cmd/internal/core/providers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	agenttools "github.com/memohai/memoh/internal/agent/tool"
+	sessionpkg "github.com/memohai/memoh/internal/chat/thread"
 	"github.com/memohai/memoh/internal/config"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -50,6 +51,32 @@ func TestAgentLimitsFromConfigUsesCustomValues(t *testing.T) {
 		got.ToolOutputMaxLines != 56 ||
 		got.SystemFilesMaxBytes != 7890 {
 		t.Fatalf("agent limits = %#v", got)
+	}
+}
+
+func TestHeartbeatSessionCreateInputUsesACPDefaultsOnlyForACPRuntime(t *testing.T) {
+	acpInput := heartbeatSessionCreateInput("bot-1", "owner-1", settings.Settings{
+		ChatRuntime:        settings.ChatRuntimeACPAgent,
+		ChatACPAgentID:     "codex",
+		ChatACPProjectPath: "/data/project",
+		ChatACPProjectMode: "project",
+	})
+	if acpInput.Type != sessionpkg.TypeHeartbeat || acpInput.SessionMode != sessionpkg.TypeHeartbeat || acpInput.RuntimeType != sessionpkg.RuntimeACPAgent {
+		t.Fatalf("ACP heartbeat descriptor = %#v, want heartbeat/acp_agent", acpInput)
+	}
+	if acpInput.CreatedByUserID != "owner-1" {
+		t.Fatalf("ACP heartbeat owner = %q, want owner-1", acpInput.CreatedByUserID)
+	}
+	if acpInput.Metadata["acp_agent_id"] != "codex" || acpInput.Metadata["project_path"] != "/data/project" || acpInput.Metadata["acp_project_mode"] != "project" {
+		t.Fatalf("ACP heartbeat metadata = %#v", acpInput.Metadata)
+	}
+
+	nativeInput := heartbeatSessionCreateInput("bot-1", "owner-1", settings.Settings{ChatRuntime: settings.ChatRuntimeModel})
+	if nativeInput.Type != sessionpkg.TypeHeartbeat || nativeInput.SessionMode != sessionpkg.TypeHeartbeat || nativeInput.RuntimeType != "" {
+		t.Fatalf("native heartbeat descriptor = %#v, want heartbeat with derived model runtime", nativeInput)
+	}
+	if nativeInput.CreatedByUserID != "" || nativeInput.Metadata != nil {
+		t.Fatalf("native heartbeat input changed ACP-only fields: %#v", nativeInput)
 	}
 }
 

--- a/internal/agent/application/service_acp.go
+++ b/internal/agent/application/service_acp.go
@@ -34,6 +34,10 @@ type acpPrompter interface {
 	Prompt(ctx context.Context, input acpagent.PromptInput) (acpclient.PromptResult, error)
 }
 
+type acpSessionCloser interface {
+	CloseSession(sessionID string) error
+}
+
 type acpPreparedAttachments struct {
 	Images                   []acpclient.PromptImage
 	Context                  []ChatAttachment

--- a/internal/agent/application/service_acp_test.go
+++ b/internal/agent/application/service_acp_test.go
@@ -1825,13 +1825,14 @@ func TestShouldGenerateSessionTitleAllowsACPPlaceholderTitle(t *testing.T) {
 }
 
 type recordingACPPrompter struct {
-	calls        int
-	input        acpagent.PromptInput
-	result       acpclient.PromptResult
-	err          error
-	onPrompt     func()
-	streamEvents []event.StreamEvent
-	afterEvents  func()
+	calls         int
+	input         acpagent.PromptInput
+	result        acpclient.PromptResult
+	err           error
+	closedSession string
+	onPrompt      func()
+	streamEvents  []event.StreamEvent
+	afterEvents   func()
 }
 
 type storeRoundMemoryProvider struct {
@@ -1890,6 +1891,11 @@ func (p *recordingACPPrompter) Prompt(_ context.Context, input acpagent.PromptIn
 		p.afterEvents()
 	}
 	return p.result, p.err
+}
+
+func (p *recordingACPPrompter) CloseSession(sessionID string) error {
+	p.closedSession = sessionID
+	return nil
 }
 
 type fakeBotPermissionChecker struct {

--- a/internal/agent/application/service_heartbeat_test.go
+++ b/internal/agent/application/service_heartbeat_test.go
@@ -1,0 +1,170 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	acpclient "github.com/memohai/memoh/internal/agent/runtime/acp/client"
+	session "github.com/memohai/memoh/internal/chat/thread"
+	"github.com/memohai/memoh/internal/heartbeat"
+)
+
+func TestTriggerHeartbeatACPUsesHeartbeatPromptWithoutNativeModel(t *testing.T) {
+	pool := &recordingACPPrompter{result: acpclientPromptResult("HEARTBEAT_OK\nall clear")}
+	messages := &recordingMessageService{}
+	service, admitter := newHeartbeatACPTestService(pool, messages)
+
+	result, err := service.TriggerHeartbeat(context.Background(), "bot-1", heartbeat.TriggerPayload{
+		Interval:        15,
+		OwnerUserID:     "owner-1",
+		SessionID:       "session-1",
+		LastHeartbeatAt: "2026-08-15T12:00:00Z",
+	}, "Bearer heartbeat-token")
+	if err != nil {
+		t.Fatalf("TriggerHeartbeat() error = %v", err)
+	}
+	if result.Status != "ok" || result.Text != "HEARTBEAT_OK\nall clear" {
+		t.Fatalf("heartbeat result = %#v, want ok result", result)
+	}
+	if result.ModelID != "" || result.SessionID != "session-1" {
+		t.Fatalf("heartbeat result model/session = %q/%q, want empty model and session-1", result.ModelID, result.SessionID)
+	}
+	if pool.calls != 1 {
+		t.Fatalf("ACP prompt calls = %d, want 1", pool.calls)
+	}
+	if pool.input.ModelID != "" {
+		t.Fatalf("ACP heartbeat model id = %q, want empty", pool.input.ModelID)
+	}
+	if pool.input.SessionType != "heartbeat" || pool.input.CanRequestUserInput {
+		t.Fatalf("ACP heartbeat controls = type %q can_request_user_input=%v", pool.input.SessionType, pool.input.CanRequestUserInput)
+	}
+	if pool.input.RuntimeOwnerAccountID != "owner-1" || pool.input.SessionToken != "Bearer heartbeat-token" {
+		t.Fatalf("ACP heartbeat owner/token = %q/%q", pool.input.RuntimeOwnerAccountID, pool.input.SessionToken)
+	}
+	if pool.input.Prompt == "heartbeat" || !strings.Contains(pool.input.Prompt, "15") || !strings.Contains(pool.input.Prompt, "2026-08-15T12:00:00Z") {
+		t.Fatalf("ACP heartbeat prompt = %q, want generated heartbeat details", pool.input.Prompt)
+	}
+	if pool.input.Sink == nil || !strings.Contains(pool.input.ContextMarkdown, "Current Runtime") {
+		t.Fatalf("ACP heartbeat prompt context/sink not configured: sink=%v context=%q", pool.input.Sink != nil, pool.input.ContextMarkdown)
+	}
+	if pool.closedSession != "session-1" {
+		t.Fatalf("closed ACP heartbeat session = %q, want session-1", pool.closedSession)
+	}
+	if len(messages.persisted) != 2 {
+		t.Fatalf("persisted messages = %d, want leading user and assistant", len(messages.persisted))
+	}
+	if got := persistedText(t, messages.persisted[0].Content); got != pool.input.Prompt {
+		t.Fatalf("persisted heartbeat prompt = %q, want ACP prompt", got)
+	}
+	if messages.persisted[0].Role != "user" || messages.persisted[1].Role != "assistant" {
+		t.Fatalf("persisted roles = %q/%q, want user/assistant", messages.persisted[0].Role, messages.persisted[1].Role)
+	}
+	finish := admitter.awaitFinish(t)
+	if finish.status != "completed" {
+		t.Fatalf("admitted heartbeat finish status = %q, want completed", finish.status)
+	}
+}
+
+func TestTriggerHeartbeatACPPersistsSanitizedFailure(t *testing.T) {
+	promptErr := errors.New("adapter crashed in /private/auth.json")
+	pool := &recordingACPPrompter{
+		result: acpclientPromptResult("partial heartbeat output"),
+		err:    promptErr,
+	}
+	messages := &recordingMessageService{}
+	service, admitter := newHeartbeatACPTestService(pool, messages)
+
+	_, err := service.TriggerHeartbeat(context.Background(), "bot-1", heartbeat.TriggerPayload{
+		Interval:    30,
+		OwnerUserID: "owner-1",
+		SessionID:   "session-1",
+	}, "Bearer heartbeat-token")
+	if !errors.Is(err, promptErr) {
+		t.Fatalf("TriggerHeartbeat() error = %v, want prompt error", err)
+	}
+	if strings.Contains(err.Error(), "/private/auth.json") {
+		t.Fatalf("TriggerHeartbeat() leaked adapter path: %v", err)
+	}
+	if len(messages.persisted) != 2 {
+		t.Fatalf("persisted messages = %d, want leading user and failed assistant", len(messages.persisted))
+	}
+	if got := persistedText(t, messages.persisted[1].Content); !strings.Contains(got, "ACP agent failed to complete the turn") {
+		t.Fatalf("persisted failure text = %q, want sanitized ACP failure", got)
+	}
+	if got := messages.persisted[1].Metadata["error_code"]; got != "acp_runtime_prompt_failed" {
+		t.Fatalf("persisted failure code = %#v, want acp_runtime_prompt_failed", got)
+	}
+	if strings.Contains(persistedText(t, messages.persisted[1].Content), "/private/auth.json") {
+		t.Fatal("persisted failure leaked adapter path")
+	}
+	finish := admitter.awaitFinish(t)
+	if finish.status != "errored" {
+		t.Fatalf("admitted heartbeat finish status = %q, want errored", finish.status)
+	}
+	if pool.closedSession != "session-1" {
+		t.Fatalf("closed ACP heartbeat session = %q, want session-1", pool.closedSession)
+	}
+}
+
+func TestTriggerHeartbeatACPReportsRoundPersistenceFailure(t *testing.T) {
+	persistErr := errors.New("history database unavailable")
+	pool := &recordingACPPrompter{result: acpclientPromptResult("HEARTBEAT_OK")}
+	service, admitter := newHeartbeatACPTestService(pool, &recordingMessageService{persistErr: persistErr})
+
+	_, err := service.TriggerHeartbeat(context.Background(), "bot-1", heartbeat.TriggerPayload{
+		Interval:    30,
+		OwnerUserID: "owner-1",
+		SessionID:   "session-1",
+	}, "Bearer heartbeat-token")
+	if err == nil || !strings.Contains(err.Error(), "persist ACP heartbeat round") {
+		t.Fatalf("TriggerHeartbeat() error = %v, want persistence failure", err)
+	}
+	if pool.closedSession != "session-1" {
+		t.Fatalf("closed ACP heartbeat session = %q, want session-1", pool.closedSession)
+	}
+	if finish := admitter.awaitFinish(t); finish.status != "errored" {
+		t.Fatalf("admitted heartbeat finish status = %q, want errored", finish.status)
+	}
+}
+
+func newHeartbeatACPTestService(pool *recordingACPPrompter, messages *recordingMessageService) (*Service, *scriptedAdmitter) {
+	admitter := newScriptedAdmitter()
+	service := &Service{
+		messageService: messages,
+		acpPool:        pool,
+		sessionRuntime: admitter,
+		sessionService: &fakeBackgroundSessionService{
+			getFn: func(_ context.Context, sessionID string) (session.Thread, error) {
+				return session.Thread{
+					ID:              sessionID,
+					BotID:           "bot-1",
+					Type:            session.TypeHeartbeat,
+					SessionMode:     session.TypeHeartbeat,
+					RuntimeType:     session.RuntimeACPAgent,
+					CreatedByUserID: "owner-1",
+					RuntimeMetadata: map[string]any{
+						"acp_agent_id":             "codex",
+						"project_path":             "/data",
+						"runtime_owner_account_id": "owner-1",
+					},
+				}, nil
+			},
+		},
+		botPermissions: allowWorkspaceExecForBot("bot-1", "owner-1"),
+		logger:         slog.New(slog.DiscardHandler),
+	}
+	return service, admitter
+}
+
+func acpclientPromptResult(text string) acpclient.PromptResult {
+	return acpclient.PromptResult{
+		Text:       text,
+		StopReason: "end_turn",
+		Usage:      &sdk.Usage{InputTokens: 3, OutputTokens: 5, TotalTokens: 8},
+	}
+}

--- a/internal/agent/application/service_stream_test.go
+++ b/internal/agent/application/service_stream_test.go
@@ -17,6 +17,7 @@ import (
 
 type recordingMessageService struct {
 	persisted               []messagepkg.PersistInput
+	persistErr              error
 	replaced                int
 	replacementTurnID       string
 	replacementTurnPosition *int64
@@ -24,6 +25,9 @@ type recordingMessageService struct {
 }
 
 func (s *recordingMessageService) Persist(_ context.Context, input messagepkg.PersistInput) (messagepkg.Message, error) {
+	if s.persistErr != nil {
+		return messagepkg.Message{}, s.persistErr
+	}
 	s.persisted = append(s.persisted, input)
 	return messagepkg.Message{ID: "message-id", SessionID: input.SessionID, Role: input.Role, Content: input.Content, DisplayContent: input.DisplayText}, nil
 }

--- a/internal/agent/application/service_trigger.go
+++ b/internal/agent/application/service_trigger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ import (
 	acpclient "github.com/memohai/memoh/internal/agent/runtime/acp/client"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 	"github.com/memohai/memoh/internal/agent/sessionmode"
+	session "github.com/memohai/memoh/internal/chat/thread"
 	"github.com/memohai/memoh/internal/heartbeat"
 	"github.com/memohai/memoh/internal/schedule"
 )
@@ -221,6 +223,14 @@ func (s *Service) TriggerHeartbeat(ctx context.Context, botID string, payload he
 	defer func() { finish(err) }()
 	ctx = runCtx
 
+	acpInfo, err := s.ACPSessionExecutionInfo(ctx, payload.SessionID)
+	if err != nil {
+		return heartbeat.TriggerResult{}, err
+	}
+	if acpInfo.IsACP {
+		return s.triggerHeartbeatACP(ctx, botID, payload, token, admission.RunID, acpInfo)
+	}
+
 	var heartbeatModel string
 	if botSettings, err := s.loadBotSettings(ctx, botID); err == nil {
 		heartbeatModel = strings.TrimSpace(botSettings.HeartbeatModelID)
@@ -247,20 +257,7 @@ func (s *Service) TriggerHeartbeat(ctx context.Context, botID string, payload he
 	cfg.Identity.ChannelIdentityID = strings.TrimSpace(payload.OwnerUserID)
 	cfg.ContextScope.ChannelIdentityID = strings.TrimSpace(payload.OwnerUserID)
 
-	var checklist string
-	if s.agent != nil {
-		nowFn := time.Now
-		if cfg.Identity.TimezoneLocation != nil {
-			nowFn = func() time.Time { return time.Now().In(cfg.Identity.TimezoneLocation) }
-		}
-		fs := native.NewFSClient(s.agent.BridgeProvider(), botID, nowFn)
-		checklist = fs.ReadTextSafe(ctx, "/data/HEARTBEAT.md")
-	}
-	now := time.Now().UTC()
-	if cfg.Identity.TimezoneLocation != nil {
-		now = now.In(cfg.Identity.TimezoneLocation)
-	}
-	heartbeatPrompt := native.GenerateHeartbeatPrompt(payload.Interval, checklist, now, payload.LastHeartbeatAt)
+	heartbeatPrompt := s.generateHeartbeatPrompt(ctx, botID, payload.Interval, payload.LastHeartbeatAt, cfg.Identity.TimezoneLocation)
 	cfg.Messages = append(cfg.Messages, sdk.UserMessage(heartbeatPrompt))
 	cfg = s.prepareRunConfig(ctx, cfg)
 
@@ -288,6 +285,141 @@ func (s *Service) TriggerHeartbeat(ctx context.Context, botID string, payload he
 		ModelID:    rc.model.ID,
 		SessionID:  payload.SessionID,
 	}, nil
+}
+
+// triggerHeartbeatACP runs one internal heartbeat through the ACP session pool.
+// It deliberately does not resolve a native model: an ACP-default bot may not
+// have chat_model_id or heartbeat_model_id configured at all.
+func (s *Service) triggerHeartbeatACP(ctx context.Context, botID string, payload heartbeat.TriggerPayload, token, runID string, info ACPSessionExecutionInfo) (heartbeat.TriggerResult, error) {
+	if strings.TrimSpace(info.Type) != session.TypeHeartbeat {
+		return heartbeat.TriggerResult{}, errors.New("heartbeat requires an ACP heartbeat session")
+	}
+	if s.acpPool == nil {
+		return heartbeat.TriggerResult{}, errors.New("ACP session pool is not configured")
+	}
+	runtimeOwner := strings.TrimSpace(info.RuntimeOwnerAccountID)
+	if runtimeOwner == "" {
+		return heartbeat.TriggerResult{}, errors.New("ACP runtime owner is missing; recreate the heartbeat session")
+	}
+	if err := s.requireACPRuntimeOwnerWorkspaceExec(ctx, botID, runtimeOwner); err != nil {
+		return heartbeat.TriggerResult{}, err
+	}
+	if closer, ok := s.acpPool.(acpSessionCloser); ok {
+		defer func() {
+			if err := closer.CloseSession(payload.SessionID); err != nil {
+				s.logger.Warn("close ACP heartbeat runtime failed", slog.Any("error", err), slog.String("session_id", payload.SessionID))
+			}
+		}()
+	}
+
+	_, timezoneLocation := s.resolveTimezone(ctx, botID, payload.OwnerUserID)
+	heartbeatPrompt := s.generateHeartbeatPrompt(ctx, botID, payload.Interval, payload.LastHeartbeatAt, timezoneLocation)
+	req := ChatRequest{
+		BotID:       botID,
+		ChatID:      botID,
+		ThreadID:    payload.SessionID,
+		RunID:       runID,
+		Query:       heartbeatPrompt,
+		RawQuery:    heartbeatPrompt,
+		UserID:      payload.OwnerUserID,
+		Token:       token,
+		SessionType: sessionmode.Heartbeat,
+		RuntimeType: session.RuntimeACPAgent,
+	}
+	contextMarkdown := s.buildACPContextMarkdown(ctx, req, info.AgentID, info.ProjectPath)
+
+	req, _ = s.persistACPLeadingUserMessage(context.WithoutCancel(ctx), req)
+	result, promptErr := s.acpPool.Prompt(ctx, acpagent.PromptInput{
+		BotID:                 botID,
+		ChatID:                botID,
+		SessionID:             payload.SessionID,
+		RunID:                 runID,
+		SessionType:           sessionmode.Heartbeat,
+		AgentID:               info.AgentID,
+		ProjectPath:           info.ProjectPath,
+		Prompt:                heartbeatPrompt,
+		ChannelIdentityID:     strings.TrimSpace(payload.OwnerUserID),
+		SessionToken:          token,
+		CanRequestUserInput:   false,
+		SupportsImageInput:    false,
+		ToolOutputLimit:       s.toolOutputLimit(),
+		ContextURI:            acpContextURI,
+		ContextMarkdown:       contextMarkdown,
+		RuntimeOwnerAccountID: runtimeOwner,
+		Sink:                  acpclient.EventSinkFunc(func(event.StreamEvent) {}),
+	})
+	if promptErr != nil {
+		s.cancelPendingACPApprovals(context.WithoutCancel(ctx), req, "tool approval cancelled: the heartbeat ended before a decision arrived")
+		failedResult, _ := acpFailureResult(ensureACPPromptOutput(result), promptErr)
+		if err := s.persistACPRound(context.WithoutCancel(ctx), req, info.AgentID, info.ProjectPath, failedResult, promptErr); err != nil {
+			s.logger.Error("ACP heartbeat failure persist failed", slog.Any("error", err), slog.String("session_id", payload.SessionID))
+		}
+		return heartbeat.TriggerResult{}, publicACPTriggerError(promptErr)
+	}
+
+	result = ensureACPPromptOutput(result)
+	if err := s.persistACPRound(context.WithoutCancel(ctx), req, info.AgentID, info.ProjectPath, result, nil); err != nil {
+		s.logger.Error("ACP heartbeat persist failed", slog.Any("error", err), slog.String("session_id", payload.SessionID))
+		return heartbeat.TriggerResult{}, fmt.Errorf("persist ACP heartbeat round: %w", err)
+	}
+
+	status := "alert"
+	text := strings.TrimSpace(result.Text)
+	if isHeartbeatOK(text) {
+		status = "ok"
+	}
+	var usageJSON []byte
+	if result.Usage != nil {
+		usageJSON, _ = json.Marshal(result.Usage)
+	}
+	return heartbeat.TriggerResult{
+		Status:     status,
+		Text:       text,
+		Usage:      usageJSON,
+		UsageBytes: usageJSON,
+		SessionID:  payload.SessionID,
+	}, nil
+}
+
+type acpTriggerError struct {
+	message string
+	cause   error
+}
+
+func (e *acpTriggerError) Error() string {
+	return e.message
+}
+
+func (e *acpTriggerError) Unwrap() error {
+	return e.cause
+}
+
+func publicACPTriggerError(err error) error {
+	if err == nil {
+		return nil
+	}
+	message := acpUserFacingFailureMessage(err)
+	if message == "" {
+		return err
+	}
+	return &acpTriggerError{message: message, cause: err}
+}
+
+func (s *Service) generateHeartbeatPrompt(ctx context.Context, botID string, interval int, lastHeartbeatAt string, timezoneLocation *time.Location) string {
+	var checklist string
+	if s.agent != nil {
+		nowFn := time.Now
+		if timezoneLocation != nil {
+			nowFn = func() time.Time { return time.Now().In(timezoneLocation) }
+		}
+		fs := native.NewFSClient(s.agent.BridgeProvider(), botID, nowFn)
+		checklist = fs.ReadTextSafe(ctx, "/data/HEARTBEAT.md")
+	}
+	now := time.Now().UTC()
+	if timezoneLocation != nil {
+		now = now.In(timezoneLocation)
+	}
+	return native.GenerateHeartbeatPrompt(interval, checklist, now, lastHeartbeatAt)
 }
 
 // scheduleSubmission and heartbeatSubmission are the canonical fingerprint

--- a/internal/botbackup/backup_flow_test.go
+++ b/internal/botbackup/backup_flow_test.go
@@ -209,19 +209,14 @@ func TestImportStateItemErr(t *testing.T) {
 	}
 }
 
-func TestRestoredSessionDescriptorRejectsSystemACPRuntime(t *testing.T) {
-	// Schedule sessions may run through an ACP agent, so schedule/acp_agent
-	// restores cleanly; heartbeat remains a pure internal loop and still
-	// rejects the ACP runtime.
+func TestRestoredSessionDescriptorAcceptsInternalACPRuntime(t *testing.T) {
+	// Schedule and heartbeat sessions may run through an ACP agent while keeping
+	// their internal session modes.
 	if _, _, _, err := restoredSessionDescriptor("schedule", "schedule", "acp_agent"); err != nil {
 		t.Fatalf("restoredSessionDescriptor(schedule/acp_agent) error = %v, want nil", err)
 	}
-	_, _, _, err := restoredSessionDescriptor("heartbeat", "heartbeat", "acp_agent")
-	if err == nil {
-		t.Fatal("restoredSessionDescriptor(heartbeat/acp_agent) = nil error, want unsupported combination")
-	}
-	if !strings.Contains(err.Error(), "only supported") {
-		t.Fatalf("error = %v, want unsupported runtime/mode message", err)
+	if _, _, _, err := restoredSessionDescriptor("heartbeat", "heartbeat", "acp_agent"); err != nil {
+		t.Fatalf("restoredSessionDescriptor(heartbeat/acp_agent) error = %v, want nil", err)
 	}
 }
 

--- a/internal/chat/thread/service.go
+++ b/internal/chat/thread/service.go
@@ -1380,11 +1380,11 @@ func normalizeDescriptor(legacyType, sessionMode, runtimeType string, metadata, 
 	if !IsKnownRuntimeType(runtimeType) {
 		return descriptor{}, fmt.Errorf("unknown runtime type %q", runtimeType)
 	}
-	// Schedule mode joined the ACP-capable modes when schedules gained an
-	// ACP runtime option: a schedule-created session keeps its schedule
-	// mode for prompt/tool gating while an ACP agent executes the turns.
-	if runtimeType == RuntimeACPAgent && sessionMode != TypeChat && sessionMode != TypeDiscuss && sessionMode != TypeSchedule {
-		return descriptor{}, fmt.Errorf("runtime type %q is only supported for %s, %s, or %s session modes", RuntimeACPAgent, TypeChat, TypeDiscuss, TypeSchedule)
+	// Schedule and heartbeat modes can keep their internal loop semantics while
+	// an ACP agent executes the turn. Public session creation still rejects both
+	// system modes in the handler layer.
+	if runtimeType == RuntimeACPAgent && sessionMode != TypeChat && sessionMode != TypeDiscuss && sessionMode != TypeSchedule && sessionMode != TypeHeartbeat {
+		return descriptor{}, fmt.Errorf("runtime type %q is only supported for %s, %s, %s, or %s session modes", RuntimeACPAgent, TypeChat, TypeDiscuss, TypeSchedule, TypeHeartbeat)
 	}
 	out := descriptor{
 		LegacyType:      legacyTypeForDescriptor(sessionMode, runtimeType),

--- a/internal/chat/thread/service_test.go
+++ b/internal/chat/thread/service_test.go
@@ -66,12 +66,10 @@ func TestResolveDescriptorRejectsConflictingACPRuntime(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "conflicts with runtime_type") {
 		t.Fatalf("error = %v, want a 'conflicts with runtime_type' message", err)
 	}
-	// Schedule mode supports the ACP runtime (schedules can run through an
-	// ACP agent), but internal loop modes like heartbeat still reject it.
-	if _, _, _, err := ResolveDescriptor(TypeHeartbeat, "", RuntimeACPAgent); err == nil {
-		t.Fatal("ResolveDescriptor(heartbeat, acp_agent) = nil error, want an unsupported combination error")
-	} else if !strings.Contains(err.Error(), "only supported") {
-		t.Fatalf("error = %v, want an 'only supported' message", err)
+	// Schedule and heartbeat modes keep their internal loop semantics while
+	// executing through ACP.
+	if _, mode, runtime, err := ResolveDescriptor(TypeHeartbeat, "", RuntimeACPAgent); err != nil || mode != TypeHeartbeat || runtime != RuntimeACPAgent {
+		t.Fatalf("ResolveDescriptor(heartbeat, acp_agent) = (%q, %q, %v), want heartbeat/acp_agent", mode, runtime, err)
 	}
 
 	// Legitimate combinations must still resolve cleanly.
@@ -85,6 +83,7 @@ func TestResolveDescriptorRejectsConflictingACPRuntime(t *testing.T) {
 		{"chat + acp_agent -> chat ACP", TypeChat, "", RuntimeACPAgent, TypeACPAgent, TypeChat, RuntimeACPAgent},
 		{"discuss + acp_agent -> discuss ACP", TypeDiscuss, "", RuntimeACPAgent, TypeDiscuss, TypeDiscuss, RuntimeACPAgent},
 		{"schedule + acp_agent -> schedule ACP", TypeSchedule, "", RuntimeACPAgent, TypeSchedule, TypeSchedule, RuntimeACPAgent},
+		{"heartbeat + acp_agent -> heartbeat ACP", TypeHeartbeat, "", RuntimeACPAgent, TypeHeartbeat, TypeHeartbeat, RuntimeACPAgent},
 		{"plain chat", TypeChat, "", "", TypeChat, TypeChat, RuntimeModel},
 	}
 	for _, c := range cases {
@@ -312,6 +311,42 @@ func TestCreateACPAgentSessionDefaultsProjectPath(t *testing.T) {
 	}
 	if created.Metadata["acp_project_mode"] != DefaultACPProjectMode {
 		t.Fatalf("created metadata acp_project_mode = %#v, want %q", created.Metadata["acp_project_mode"], DefaultACPProjectMode)
+	}
+}
+
+func TestCreateHeartbeatACPSessionKeepsInternalModeAndOwner(t *testing.T) {
+	botID := "00000000-0000-0000-0000-000000000001"
+	queries := &createACPQueries{
+		bot: sqlc.GetBotByIDRow{
+			ID: mustPGUUID(botID),
+			Metadata: mustSessionJSON(map[string]any{
+				"acp": map[string]any{
+					"agents": map[string]any{
+						"codex": map[string]any{"enabled": true, "setup_mode": "self"},
+					},
+				},
+			}),
+		},
+	}
+	created, err := newACPTestService(queries).Create(context.Background(), CreateInput{
+		BotID:           botID,
+		Type:            TypeHeartbeat,
+		SessionMode:     TypeHeartbeat,
+		RuntimeType:     RuntimeACPAgent,
+		CreatedByUserID: "00000000-0000-0000-0000-000000000003",
+		Metadata:        map[string]any{"acp_agent_id": "codex"},
+	})
+	if err != nil {
+		t.Fatalf("Create(heartbeat ACP) error = %v", err)
+	}
+	if queries.createParams.Type != TypeHeartbeat || queries.createParams.SessionMode != TypeHeartbeat || queries.createParams.RuntimeType != RuntimeACPAgent {
+		t.Fatalf("heartbeat ACP descriptor = %q/%q/%q, want heartbeat/heartbeat/acp_agent", queries.createParams.Type, queries.createParams.SessionMode, queries.createParams.RuntimeType)
+	}
+	if created.Visibility != VisibilityInternal {
+		t.Fatalf("heartbeat ACP visibility = %q, want internal", created.Visibility)
+	}
+	if got := created.RuntimeMetadata["runtime_owner_account_id"]; got != "00000000-0000-0000-0000-000000000003" {
+		t.Fatalf("heartbeat ACP runtime owner = %#v, want creator", got)
 	}
 }
 

--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -411,9 +411,9 @@ const (
 // parent filter. That default filters by stored visibility rather than by a
 // type list, so schedule-created sessions marked user-visible surface too.
 // rejectSystemACPRuntime keeps system-managed session modes out of the HTTP
-// session API's ACP surface. The thread domain itself allows
-// schedule+acp_agent — the schedule trigger path creates those sessions —
-// but interactive session creation stays limited to chat and discuss.
+// session API's ACP surface. The thread domain itself allows schedule+acp_agent
+// and heartbeat+acp_agent — their trigger paths create those sessions — but
+// interactive session creation stays limited to chat and discuss.
 func rejectSystemACPRuntime(mode, runtimeType string) error {
 	if runtimeType != session.RuntimeACPAgent {
 		return nil

--- a/internal/handlers/session_create_test.go
+++ b/internal/handlers/session_create_test.go
@@ -156,33 +156,37 @@ func TestCreateSessionAcceptsACPAgentType(t *testing.T) {
 }
 
 func TestCreateSessionRejectsSystemACPRuntime(t *testing.T) {
-	botID := "11111111-1111-1111-1111-111111111111"
-	queries := &sessionCreateQueries{
-		bot: testBotRow(botID, map[string]any{
-			acpprofile.MetadataKeyACP: map[string]any{
-				"agents": map[string]any{
-					acpprofile.AgentCodexID: map[string]any{"enabled": true, "setup_mode": "self"},
-				},
-			},
-		}),
-		permissions: []byte(`["workspace_exec"]`),
-	}
-	handler := NewSessionHandler(
-		slog.Default(),
-		newThreadServiceForTest(queries),
-		nil,
-		bots.NewService(nil, queries),
-		newTestAdminAccountService("user"),
-	)
+	for _, sessionType := range []string{session.TypeSchedule, session.TypeHeartbeat} {
+		t.Run(sessionType, func(t *testing.T) {
+			botID := "11111111-1111-1111-1111-111111111111"
+			queries := &sessionCreateQueries{
+				bot: testBotRow(botID, map[string]any{
+					acpprofile.MetadataKeyACP: map[string]any{
+						"agents": map[string]any{
+							acpprofile.AgentCodexID: map[string]any{"enabled": true, "setup_mode": "self"},
+						},
+					},
+				}),
+				permissions: []byte(`["workspace_exec"]`),
+			}
+			handler := NewSessionHandler(
+				slog.Default(),
+				newThreadServiceForTest(queries),
+				nil,
+				bots.NewService(nil, queries),
+				newTestAdminAccountService("user"),
+			)
 
-	body := `{"type":"schedule","runtime_type":"acp_agent","metadata":{"acp_agent_id":"codex"}}`
-	err := callCreateSession(handler, botID, body)
-	var httpErr *echo.HTTPError
-	if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest {
-		t.Fatalf("CreateSession() error = %v, want HTTP 400", err)
-	}
-	if queries.createCalled {
-		t.Fatal("CreateSession should not insert system ACP sessions")
+			body := `{"type":"` + sessionType + `","runtime_type":"acp_agent","metadata":{"acp_agent_id":"codex"}}`
+			err := callCreateSession(handler, botID, body)
+			var httpErr *echo.HTTPError
+			if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest {
+				t.Fatalf("CreateSession() error = %v, want HTTP 400", err)
+			}
+			if queries.createCalled {
+				t.Fatal("CreateSession should not insert system ACP sessions")
+			}
+		})
 	}
 }
 

--- a/internal/heartbeat/service.go
+++ b/internal/heartbeat/service.go
@@ -30,7 +30,7 @@ const defaultHeartbeatIntervalMinutes = 1440
 
 // SessionCreator creates sessions for heartbeat runs.
 type SessionCreator interface {
-	CreateSession(ctx context.Context, botID, sessionType string) (string, error)
+	CreateHeartbeatSession(ctx context.Context, botID, ownerUserID string) (string, error)
 }
 
 type Service struct {
@@ -120,11 +120,17 @@ func (s *Service) runHeartbeat(ctx context.Context, cfg Config) {
 		s.logger.Error("invalid bot id", slog.String("bot_id", cfg.BotID), slog.Any("error", err))
 		return
 	}
+	ownerUserID := strings.TrimSpace(cfg.OwnerUserID)
+	if bot, ownerErr := s.queries.GetBotByID(ctx, pgBotID); ownerErr != nil {
+		s.logger.Warn("refresh heartbeat owner failed; using scheduled owner", slog.String("bot_id", cfg.BotID), slog.Any("error", ownerErr))
+	} else if bot.OwnerUserID.Valid {
+		ownerUserID = bot.OwnerUserID.String()
+	}
 
 	var sessionID string
 	var pgSessionID pgtype.UUID
 	if s.sessionCreator != nil {
-		sid, err := s.sessionCreator.CreateSession(ctx, cfg.BotID, "heartbeat")
+		sid, err := s.sessionCreator.CreateHeartbeatSession(ctx, cfg.BotID, ownerUserID)
 		if err != nil {
 			s.logger.Error("create heartbeat session failed", slog.String("bot_id", cfg.BotID), slog.Any("error", err))
 		} else {
@@ -150,7 +156,7 @@ func (s *Service) runHeartbeat(ctx context.Context, cfg Config) {
 		return
 	}
 
-	token, err := s.generateTriggerToken(cfg.OwnerUserID)
+	token, err := s.generateTriggerToken(ownerUserID)
 	if err != nil {
 		s.completeLog(ctx, logRow.ID, "error", "", err.Error(), nil, pgtype.UUID{})
 		s.logger.Error("generate trigger token failed", slog.String("bot_id", cfg.BotID), slog.Any("error", err))
@@ -160,7 +166,7 @@ func (s *Service) runHeartbeat(ctx context.Context, cfg Config) {
 	result, err := s.triggerer.TriggerHeartbeat(ctx, cfg.BotID, TriggerPayload{
 		BotID:           cfg.BotID,
 		Interval:        cfg.Interval,
-		OwnerUserID:     cfg.OwnerUserID,
+		OwnerUserID:     ownerUserID,
 		SessionID:       sessionID,
 		LastHeartbeatAt: lastHeartbeatAt,
 	}, token)


### PR DESCRIPTION
Closes #975

## Summary

- Create each heartbeat session from the bot's current chat runtime settings, including ACP agent/project metadata and the actual bot owner.
- Allow internal heartbeat sessions to persist with the ACP runtime while keeping them invisible and rejecting manual HTTP system-session creation.
- Route ACP heartbeats through the session pool without native model resolution, preserving the generated heartbeat prompt, HEARTBEAT.md checklist, HEARTBEAT_OK classification, admission identity, round persistence, authorization, and non-interactive behavior.
- Keep heartbeat_model_id native-only; close fresh ACP runtimes after each fire and refresh ownership before execution.

## Scope

Native heartbeat behavior and the merged schedule ACP path are otherwise unchanged. No UI, schema, notification, or schedule redesign changes are included.

## Verification

- go test -count=1 ./...
- go test -race -count=1 ./internal/agent/application
- go test -race -count=1 ./internal/chat/thread ./internal/heartbeat
- go test -race -count=1 ./cmd/internal/core ./internal/handlers ./internal/botbackup
- go build ./...
- go vet ./...
- Scoped golangci-lint run for all touched Go packages
- Exact .husky/pre-commit hook, including full Go tests/lint and backend-only web check
- git diff --check

## Human QA

No human QA yet. A configured ACP agent and local runtime/workspace are required for the live heartbeat smoke test.