### PR TITLE
refactor(media): consolidate sandbox artifacts under .memoh

### DIFF
--- a/internal/agent/application/service_test.go
+++ b/internal/agent/application/service_test.go
@@ -170,7 +170,7 @@ func TestRouteAndMergeAttachments_ImagePathOnlyFallsBackToFile(t *testing.T) {
 		Attachments: []ChatAttachment{
 			{
 				Type: "image",
-				Path: "/data/media/image/demo.png",
+				Path: "/data/.memoh/media/image/demo.png",
 			},
 		},
 	}
@@ -189,7 +189,7 @@ func TestRouteAndMergeAttachments_ImagePathOnlyFallsBackToFile(t *testing.T) {
 	if item.Transport != gatewayTransportToolFileRef {
 		t.Fatalf("expected tool_file_ref transport, got %q", item.Transport)
 	}
-	if item.Payload != "/data/media/image/demo.png" {
+	if item.Payload != "/data/.memoh/media/image/demo.png" {
 		t.Fatalf("unexpected fallback payload: %q", item.Payload)
 	}
 }
@@ -224,7 +224,7 @@ func TestPrepareGatewayAttachments_ResolvesStoredFileAccessPath(t *testing.T) {
 				if botID != "bot-1" || contentHash != "asset-pdf" {
 					t.Fatalf("unexpected asset lookup: bot=%q hash=%q", botID, contentHash)
 				}
-				return "/data/media/aa/asset.pdf", nil
+				return "/data/.memoh/media/aa/asset.pdf", nil
 			},
 		},
 	}
@@ -238,7 +238,7 @@ func TestPrepareGatewayAttachments_ResolvesStoredFileAccessPath(t *testing.T) {
 	}
 
 	prepared := resolver.prepareGatewayAttachments(context.Background(), req)
-	if len(prepared) != 1 || prepared[0].FallbackPath != "/data/media/aa/asset.pdf" {
+	if len(prepared) != 1 || prepared[0].FallbackPath != "/data/.memoh/media/aa/asset.pdf" {
 		t.Fatalf("prepared attachments = %#v, want reachable PDF path", prepared)
 	}
 	merged := resolver.routeAndMergeAttachments(context.Background(), models.GetResponse{}, req)
@@ -246,7 +246,7 @@ func TestPrepareGatewayAttachments_ResolvesStoredFileAccessPath(t *testing.T) {
 		t.Fatalf("routeAndMergeAttachments() length = %d, want 1", len(merged))
 	}
 	item, ok := merged[0].(gatewayAttachment)
-	if !ok || item.Transport != gatewayTransportToolFileRef || item.Payload != "/data/media/aa/asset.pdf" {
+	if !ok || item.Transport != gatewayTransportToolFileRef || item.Payload != "/data/.memoh/media/aa/asset.pdf" {
 		t.Fatalf("merged attachment = %#v, want tool file reference", merged[0])
 	}
 }
@@ -261,7 +261,7 @@ func TestPrepareACPAttachments_UsesFileAndReplyReferences(t *testing.T) {
 				if contentHash != "asset-pdf" {
 					t.Fatalf("unexpected content hash: %s", contentHash)
 				}
-				return "/data/media/aa/asset.pdf", nil
+				return "/data/.memoh/media/aa/asset.pdf", nil
 			},
 		},
 	}
@@ -285,7 +285,7 @@ func TestPrepareACPAttachments_UsesFileAndReplyReferences(t *testing.T) {
 	if len(prepared.Images) != 0 || len(prepared.Context) != 2 || len(prepared.References) != 2 {
 		t.Fatalf("prepared attachments = %#v, want two file references", prepared)
 	}
-	if prepared.Context[0].Path != "/data/media/aa/asset.pdf" || prepared.Context[1].URL != "https://example.com/old.png" {
+	if prepared.Context[0].Path != "/data/.memoh/media/aa/asset.pdf" || prepared.Context[1].URL != "https://example.com/old.png" {
 		t.Fatalf("context attachments = %#v, want PDF path and reply URL", prepared.Context)
 	}
 }
@@ -300,7 +300,7 @@ func TestPrepareACPAttachments_PreservesLongPasteFile(t *testing.T) {
 				if contentHash != "pasted-text-hash" {
 					t.Fatalf("unexpected content hash: %s", contentHash)
 				}
-				return "/data/media/aa/pasted-text.txt", nil
+				return "/data/.memoh/media/aa/pasted-text.txt", nil
 			},
 		},
 	}
@@ -316,7 +316,7 @@ func TestPrepareACPAttachments_PreservesLongPasteFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareACPAttachments() error = %v", err)
 	}
-	if len(prepared.References) != 1 || prepared.Context[0].Path != "/data/media/aa/pasted-text.txt" {
+	if len(prepared.References) != 1 || prepared.Context[0].Path != "/data/.memoh/media/aa/pasted-text.txt" {
 		t.Fatalf("prepared attachments = %#v, want pasted text path", prepared)
 	}
 }
@@ -331,7 +331,7 @@ func TestPrepareACPAttachments_FallsBackWhenStoredImageCannotInline(t *testing.T
 				return nil, "", errors.New("asset too large")
 			},
 			accessPathFn: func(context.Context, string, string) (string, error) {
-				return "/data/media/aa/large.png", nil
+				return "/data/.memoh/media/aa/large.png", nil
 			},
 		},
 	}
@@ -346,7 +346,7 @@ func TestPrepareACPAttachments_FallsBackWhenStoredImageCannotInline(t *testing.T
 	if err != nil {
 		t.Fatalf("prepareACPAttachments() error = %v", err)
 	}
-	if len(prepared.Images) != 0 || len(prepared.References) != 1 || prepared.Context[0].Path != "/data/media/aa/large.png" {
+	if len(prepared.Images) != 0 || len(prepared.References) != 1 || prepared.Context[0].Path != "/data/.memoh/media/aa/large.png" {
 		t.Fatalf("prepared attachments = %#v, want image file fallback", prepared)
 	}
 }

--- a/internal/agent/runtime/acp/sessionpool_test.go
+++ b/internal/agent/runtime/acp/sessionpool_test.go
@@ -254,10 +254,10 @@ func TestSessionPoolPromptFallsBackToAttachmentReferenceWhenImageUnsupported(t *
 		ProjectPath:              "/data/project",
 		Prompt:                   "inspect the image",
 		Images:                   []client.PromptImage{{Data: "aW1hZ2U=", MimeType: "image/png"}},
-		AttachmentReferences:     []string{"/data/media/aa/image.png"},
+		AttachmentReferences:     []string{"/data/.memoh/media/aa/image.png"},
 		CanFallbackImagesToFiles: true,
 		ContextURI:               "memoh://context/current-turn",
-		ContextMarkdown:          "Attachment path: /data/media/aa/image.png",
+		ContextMarkdown:          "Attachment path: /data/.memoh/media/aa/image.png",
 		RuntimeOwnerAccountID:    "user-1",
 	})
 	if err != nil {
@@ -276,9 +276,9 @@ func TestSessionPoolPromptSupportsAttachmentOnly(t *testing.T) {
 		SessionID:             "session-1",
 		AgentID:               acpprofile.AgentCodexID,
 		ProjectPath:           "/data/project",
-		AttachmentReferences:  []string{"/data/media/aa/pasted-text.txt"},
+		AttachmentReferences:  []string{"/data/.memoh/media/aa/pasted-text.txt"},
 		ContextURI:            "memoh://context/current-turn",
-		ContextMarkdown:       "Attachment path: /data/media/aa/pasted-text.txt",
+		ContextMarkdown:       "Attachment path: /data/.memoh/media/aa/pasted-text.txt",
 		RuntimeOwnerAccountID: "user-1",
 	})
 	if err != nil {

--- a/internal/agent/tool/browser.go
+++ b/internal/agent/tool/browser.go
@@ -31,8 +31,7 @@ const (
 	browserToolTimeout                  = 45 * time.Second
 	browserStartupTimeout               = 12 * time.Second
 	computerDisplayStartupTimeout int32 = 1200
-	browserScreenshotSubdir             = "browser-screenshots"
-	computerScreenshotSubdir            = "computer-screenshots"
+	screenshotSubdir                    = ".memoh/screenshots"
 	defaultComputerWidth                = 1280
 	defaultComputerHeight               = 800
 	rfbButtonLeft                 byte  = 1
@@ -360,7 +359,7 @@ func (p *BrowserProvider) execComputerScreenshot(ctx context.Context, session Se
 	if err != nil {
 		return nil, err
 	}
-	return p.buildScreenshotBytesResult(ctx, botID, img, mime, p.screenshotDir(computerScreenshotSubdir), nil), nil
+	return p.buildScreenshotBytesResult(ctx, botID, img, mime, p.screenshotDir(), nil), nil
 }
 
 func (p *BrowserProvider) execComputerSnapshot(ctx context.Context, session SessionContext) (any, error) {
@@ -1428,7 +1427,7 @@ func (p *BrowserProvider) runCDPTabAction(ctx context.Context, client *bridge.Cl
 
 func (p *BrowserProvider) browserActionResult(ctx context.Context, botID string, data map[string]any) any {
 	if b64, ok := data["screenshot"].(string); ok && b64 != "" {
-		return p.buildScreenshotResult(ctx, botID, b64, p.screenshotDir(browserScreenshotSubdir), data)
+		return p.buildScreenshotResult(ctx, botID, b64, p.screenshotDir(), data)
 	}
 	return data
 }
@@ -1975,12 +1974,12 @@ func (p *BrowserProvider) buildScreenshotBytesResult(ctx context.Context, botID 
 	return result
 }
 
-func (p *BrowserProvider) screenshotDir(name string) string {
+func (p *BrowserProvider) screenshotDir() string {
 	root := strings.TrimRight(strings.TrimSpace(p.dataRoot), "/")
 	if root == "" {
 		root = "/data"
 	}
-	return root + "/" + strings.TrimLeft(name, "/")
+	return root + "/" + screenshotSubdir
 }
 
 func (p *BrowserProvider) saveBytes(ctx context.Context, botID, path string, data []byte) error {

--- a/internal/agent/tool/browser_test.go
+++ b/internal/agent/tool/browser_test.go
@@ -201,7 +201,7 @@ func TestBrowserSchemasAreStrict(t *testing.T) {
 
 func TestBuildScreenshotResultDropsShareMetadata(t *testing.T) {
 	p := &BrowserProvider{dataRoot: "/data"}
-	result := p.buildScreenshotBytesResult(t.Context(), "", []byte("png-bytes"), "image/png", "/data/computer-screenshots", nil)
+	result := p.buildScreenshotBytesResult(t.Context(), "", []byte("png-bytes"), "image/png", "/data/.memoh/screenshots", nil)
 	asMap, ok := result.(map[string]any)
 	if !ok {
 		t.Fatalf("expected map result, got %T", result)
@@ -216,6 +216,28 @@ func TestBuildScreenshotResultDropsShareMetadata(t *testing.T) {
 	text, _ := content[0]["text"].(string)
 	if !strings.HasPrefix(text, "Screenshot saved to ") && !strings.HasPrefix(text, "Screenshot captured") {
 		t.Fatalf("unexpected screenshot text: %q", text)
+	}
+}
+
+func TestScreenshotDirUsesSharedMemohDirectory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		dataRoot string
+		want     string
+	}{
+		{name: "default", want: "/data/.memoh/screenshots"},
+		{name: "configured", dataRoot: "/workspace/data/", want: "/workspace/data/.memoh/screenshots"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &BrowserProvider{dataRoot: tt.dataRoot}
+			if got := provider.screenshotDir(); got != tt.want {
+				t.Fatalf("screenshotDir() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/agent/tool/message_test.go
+++ b/internal/agent/tool/message_test.go
@@ -137,7 +137,7 @@ func (messageTestAssetResolver) Ingest(context.Context, media.IngestInput) (medi
 }
 
 func (messageTestAssetResolver) AccessPath(_ context.Context, asset media.Asset) string {
-	return "/data/media/" + asset.ContentHash
+	return "/data/.memoh/media/" + asset.ContentHash
 }
 
 func (messageTestAssetResolver) IngestContainerFile(context.Context, string, string) (media.Asset, error) {

--- a/internal/agent/tool/transcribe.go
+++ b/internal/agent/tool/transcribe.go
@@ -16,12 +16,11 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	"github.com/memohai/memoh/internal/attachment"
 	audiopkg "github.com/memohai/memoh/internal/audio"
 	"github.com/memohai/memoh/internal/media"
 	"github.com/memohai/memoh/internal/settings"
 )
-
-const mediaDataPrefix = "/data/.memoh/media/"
 
 type TranscriptionProvider struct {
 	logger   *slog.Logger
@@ -169,8 +168,8 @@ func (p *TranscriptionProvider) loadAudio(ctx context.Context, botID, pathValue,
 }
 
 func (p *TranscriptionProvider) loadAudioFromPath(ctx context.Context, botID, pathValue, contentTypeOverride string) ([]byte, string, string, error) {
-	storageKey := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(pathValue), mediaDataPrefix))
-	if storageKey == "" || storageKey == strings.TrimSpace(pathValue) {
+	storageKey := attachment.ExtractStorageKey(pathValue)
+	if storageKey == "" {
 		return nil, "", "", fmt.Errorf("unsupported media path: %s", pathValue)
 	}
 	asset, err := p.media.GetByStorageKey(ctx, botID, storageKey)

--- a/internal/agent/tool/transcribe.go
+++ b/internal/agent/tool/transcribe.go
@@ -21,7 +21,7 @@ import (
 	"github.com/memohai/memoh/internal/settings"
 )
 
-const mediaDataPrefix = "/data/media/"
+const mediaDataPrefix = "/data/.memoh/media/"
 
 type TranscriptionProvider struct {
 	logger   *slog.Logger
@@ -70,11 +70,11 @@ func (p *TranscriptionProvider) Tools(ctx context.Context, session SessionContex
 	sess := session
 	return []sdk.Tool{{
 		Name:        ToolTranscribeAudio().String(),
-		Description: "Transcribe an audio or voice message into text. Use this when the user sent a voice message and you need to understand its contents. Accepts a bot media path such as /data/media/... or a direct URL.",
+		Description: "Transcribe an audio or voice message into text. Use this when the user sent a voice message and you need to understand its contents. Accepts a bot media path such as /data/.memoh/media/... or a direct URL.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"path":        map[string]any{"type": "string", "description": "Audio file path from the message context, usually under /data/media/..."},
+				"path":        map[string]any{"type": "string", "description": "Audio file path from the message context, usually under /data/.memoh/media/..."},
 				"url":         map[string]any{"type": "string", "description": "Direct audio URL when a path is unavailable"},
 				"language":    map[string]any{"type": "string", "description": "Optional language hint"},
 				"prompt":      map[string]any{"type": "string", "description": "Optional transcription prompt"},

--- a/internal/agent/view/uimessage_test.go
+++ b/internal/agent/view/uimessage_test.go
@@ -574,7 +574,7 @@ func TestConvertMessagesToUITurnsStripsUserXMLEnvelopeFallback(t *testing.T) {
 		Content: mustUIMessageJSON(t, turn.ModelMessage{
 			Role: "user",
 			Content: mustUIRawJSON(t, `<message id="msg-image-only" sender="Test User (@test_user)" t="2026-05-08T19:08:58Z" channel="telegram" conversation="Test Group" type="group" target="test-group">
-<attachment path="/data/media/test/test-image.webp"/>
+<attachment path="/data/.memoh/media/test/test-image.webp"/>
 
 </message>`),
 		}),

--- a/internal/attachment/bundle.go
+++ b/internal/attachment/bundle.go
@@ -40,7 +40,8 @@ const (
 	MetadataKeySourcePath = "source_path"
 	MetadataKeySourceURL  = "source_url"
 
-	containerMediaSubdir = ".memoh/media"
+	containerMediaSubdir       = ".memoh/media"
+	legacyContainerMediaSubdir = "media"
 )
 
 // Normalize canonicalizes transport fields and fills lightweight derived data
@@ -380,15 +381,29 @@ func IsDataPath(raw string) bool {
 	return ok
 }
 
-// ExtractStorageKey derives the media storage key from a consumer-facing
-// `/data/.memoh/media/...` access path.
+// ExtractStorageKey derives the media storage key from a consumer-facing media
+// path. The legacy /data/media root remains readable during the transition.
 func ExtractStorageKey(accessPath string) string {
-	marker := strings.TrimRight(MediaAccessPath(""), "/") + "/"
-	idx := strings.Index(strings.TrimSpace(accessPath), marker)
-	if idx < 0 {
-		return ""
+	raw := strings.TrimSpace(accessPath)
+	for _, root := range mediaAccessRoots() {
+		marker := strings.TrimRight(root, "/") + "/"
+		if idx := strings.Index(raw, marker); idx >= 0 {
+			return raw[idx+len(marker):]
+		}
 	}
-	return accessPath[idx+len(marker):]
+	return ""
+}
+
+// IsMediaAccessPath reports whether raw is under the current or legacy media
+// root. Both roots are managed media during the transition.
+func IsMediaAccessPath(raw string) bool {
+	cleaned := path.Clean("/" + strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/"))
+	for _, root := range mediaAccessRoots() {
+		if cleaned == root || strings.HasPrefix(cleaned, strings.TrimRight(root, "/")+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // DataMountPath joins a relative path under the canonical container data mount.
@@ -402,11 +417,22 @@ func DataMountPath(raw string) string {
 
 // MediaAccessPath returns the consumer-facing media access path for a storage key.
 func MediaAccessPath(storageKey string) string {
+	return mediaAccessPath(containerMediaSubdir, storageKey)
+}
+
+func mediaAccessRoots() [2]string {
+	return [2]string{
+		mediaAccessPath(containerMediaSubdir, ""),
+		mediaAccessPath(legacyContainerMediaSubdir, ""),
+	}
+}
+
+func mediaAccessPath(subdir, storageKey string) string {
 	storageKey = strings.TrimSpace(storageKey)
 	if storageKey == "" {
-		return path.Join(config.DefaultDataMount, containerMediaSubdir)
+		return path.Join(config.DefaultDataMount, subdir)
 	}
-	return path.Join(config.DefaultDataMount, containerMediaSubdir, storageKey)
+	return path.Join(config.DefaultDataMount, subdir, storageKey)
 }
 
 // DataSubpath strips the canonical /data/ prefix and returns the container-relative path.

--- a/internal/attachment/bundle.go
+++ b/internal/attachment/bundle.go
@@ -40,7 +40,7 @@ const (
 	MetadataKeySourcePath = "source_path"
 	MetadataKeySourceURL  = "source_url"
 
-	containerMediaSubdir = "media"
+	containerMediaSubdir = ".memoh/media"
 )
 
 // Normalize canonicalizes transport fields and fills lightweight derived data
@@ -381,7 +381,7 @@ func IsDataPath(raw string) bool {
 }
 
 // ExtractStorageKey derives the media storage key from a consumer-facing
-// `/data/media/...` access path.
+// `/data/.memoh/media/...` access path.
 func ExtractStorageKey(accessPath string) string {
 	marker := strings.TrimRight(MediaAccessPath(""), "/") + "/"
 	idx := strings.Index(strings.TrimSpace(accessPath), marker)

--- a/internal/attachment/bundle_test.go
+++ b/internal/attachment/bundle_test.go
@@ -182,11 +182,39 @@ func TestBundleWithAssetAccess(t *testing.T) {
 func TestExtractStorageKey(t *testing.T) {
 	t.Parallel()
 
-	if got := ExtractStorageKey("/data/.memoh/media/aa/demo.png"); got != "aa/demo.png" {
-		t.Fatalf("unexpected storage key: %q", got)
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "current", path: "/data/.memoh/media/aa/demo.png", want: "aa/demo.png"},
+		{name: "legacy", path: "/data/media/aa/demo.png", want: "aa/demo.png"},
+		{name: "other", path: "/tmp/demo.png", want: ""},
 	}
-	if got := ExtractStorageKey("/tmp/demo.png"); got != "" {
-		t.Fatalf("expected empty storage key for non-media path, got %q", got)
+	for _, tt := range tests {
+		if got := ExtractStorageKey(tt.path); got != tt.want {
+			t.Errorf("%s: ExtractStorageKey(%q) = %q, want %q", tt.name, tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestIsMediaAccessPath(t *testing.T) {
+	t.Parallel()
+
+	for _, mediaPath := range []string{
+		"/data/.memoh/media",
+		"/data/.memoh/media/aa/demo.png",
+		"/data/media",
+		"data/media/aa/demo.png",
+	} {
+		if !IsMediaAccessPath(mediaPath) {
+			t.Errorf("IsMediaAccessPath(%q) = false, want true", mediaPath)
+		}
+	}
+	for _, otherPath := range []string{"/data/mediakit/demo.png", "/data/.memoh/mediakit/demo.png", "/tmp/demo.png"} {
+		if IsMediaAccessPath(otherPath) {
+			t.Errorf("IsMediaAccessPath(%q) = true, want false", otherPath)
+		}
 	}
 }
 

--- a/internal/attachment/bundle_test.go
+++ b/internal/attachment/bundle_test.go
@@ -169,9 +169,9 @@ func TestBundleWithAssetAccess(t *testing.T) {
 		Mime:        "text/plain",
 		SizeBytes:   7,
 		StorageKey:  "bb/asset-2.txt",
-	}, "/data/media/bb/asset-2.txt")
+	}, "/data/.memoh/media/bb/asset-2.txt")
 
-	if bundle.Path != "/data/media/bb/asset-2.txt" {
+	if bundle.Path != "/data/.memoh/media/bb/asset-2.txt" {
 		t.Fatalf("expected access path preserved, got %q", bundle.Path)
 	}
 	if MetadataString(bundle.Metadata, MetadataKeySourcePath) != "/data/work/demo.txt" {
@@ -182,7 +182,7 @@ func TestBundleWithAssetAccess(t *testing.T) {
 func TestExtractStorageKey(t *testing.T) {
 	t.Parallel()
 
-	if got := ExtractStorageKey("/data/media/aa/demo.png"); got != "aa/demo.png" {
+	if got := ExtractStorageKey("/data/.memoh/media/aa/demo.png"); got != "aa/demo.png" {
 		t.Fatalf("unexpected storage key: %q", got)
 	}
 	if got := ExtractStorageKey("/tmp/demo.png"); got != "" {
@@ -193,10 +193,10 @@ func TestExtractStorageKey(t *testing.T) {
 func TestMediaAccessPath(t *testing.T) {
 	t.Parallel()
 
-	if got := MediaAccessPath("aa/demo.png"); got != "/data/media/aa/demo.png" {
+	if got := MediaAccessPath("aa/demo.png"); got != "/data/.memoh/media/aa/demo.png" {
 		t.Fatalf("unexpected media access path: %q", got)
 	}
-	if got := MediaAccessPath(""); got != "/data/media" {
+	if got := MediaAccessPath(""); got != "/data/.memoh/media" {
 		t.Fatalf("unexpected media root path: %q", got)
 	}
 }

--- a/internal/channel/channeltest/store.go
+++ b/internal/channel/channeltest/store.go
@@ -97,7 +97,7 @@ func (s *MemoryAttachmentStore) GetByStorageKey(_ context.Context, botID, storag
 }
 
 func (*MemoryAttachmentStore) AccessPath(_ context.Context, asset media.Asset) string {
-	return "/data/media/" + strings.TrimSpace(asset.StorageKey)
+	return "/data/.memoh/media/" + strings.TrimSpace(asset.StorageKey)
 }
 
 func (s *MemoryAttachmentStore) IngestContainerFile(_ context.Context, botID, containerPath string) (media.Asset, error) {

--- a/internal/channel/inbound/adapt_test.go
+++ b/internal/channel/inbound/adapt_test.go
@@ -27,7 +27,7 @@ func TestAdaptInbound_FallsBackToText_WhenPartsEmpty(t *testing.T) {
 
 func TestAdaptAttachments_ContentHash(t *testing.T) {
 	atts := []channel.Attachment{
-		{Type: channel.AttachmentImage, ContentHash: "abc123", URL: "/data/media/bot/ab/abc123.jpg", Mime: "image/jpeg"},
+		{Type: channel.AttachmentImage, ContentHash: "abc123", URL: "/data/.memoh/media/bot/ab/abc123.jpg", Mime: "image/jpeg"},
 		{Type: channel.AttachmentFile, URL: "https://example.com/doc.pdf", Mime: "application/pdf"},
 	}
 	got := adaptAttachments(atts)
@@ -37,7 +37,7 @@ func TestAdaptAttachments_ContentHash(t *testing.T) {
 	if got[0].ContentHash != "abc123" || got[0].MimeType != "image/jpeg" {
 		t.Fatalf("unexpected first attachment: %+v", got[0])
 	}
-	if got[0].FilePath != "/data/media/bot/ab/abc123.jpg" {
+	if got[0].FilePath != "/data/.memoh/media/bot/ab/abc123.jpg" {
 		t.Fatalf("expected FilePath from URL, got %q", got[0].FilePath)
 	}
 	if got[1].Type != "file" || got[1].MimeType != "application/pdf" {

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -3083,7 +3083,7 @@ func isHTTPURL(raw string) bool {
 }
 
 // extractStorageKey derives the media storage key from a container-internal
-// access path. The expected path format is /data/media/<storage_key>.
+// access path. The expected path format is /data/.memoh/media/<storage_key>.
 func extractStorageKey(accessPath string, _ string) string {
 	return attachment.ExtractStorageKey(accessPath)
 }

--- a/internal/channel/inbound/channel_test.go
+++ b/internal/channel/inbound/channel_test.go
@@ -546,7 +546,7 @@ func (*fakeMediaIngestor) IngestContainerFile(_ context.Context, _, _ string) (m
 }
 
 func (*fakeMediaIngestor) AccessPath(_ context.Context, asset media.Asset) string {
-	return "/data/media/" + asset.StorageKey
+	return "/data/.memoh/media/" + asset.StorageKey
 }
 
 type fakeStorageProvider struct {
@@ -579,7 +579,7 @@ func (f *fakeStorageProvider) Delete(_ context.Context, key string) error {
 }
 
 func (*fakeStorageProvider) AccessPath(_ context.Context, key string) string {
-	return "/data/media/" + key
+	return "/data/.memoh/media/" + key
 }
 
 type fakeAttachmentResolverAdapter struct {
@@ -2727,8 +2727,8 @@ func TestChannelInboundProcessorIngestsBase64Attachment(t *testing.T) {
 	if gotAttachment.Base64 != "" {
 		t.Fatalf("expected base64 to be cleared after ingest, got %q", gotAttachment.Base64)
 	}
-	if !strings.HasPrefix(gotAttachment.Path, "/data/media/") {
-		t.Fatalf("expected attachment path under /data/media/, got %q", gotAttachment.Path)
+	if !strings.HasPrefix(gotAttachment.Path, "/data/.memoh/media/") {
+		t.Fatalf("expected attachment path under /data/.memoh/media/, got %q", gotAttachment.Path)
 	}
 	if len(chatSvc.persistedIn) != 0 {
 		t.Fatalf("user message persistence is deferred to storeRound; expected 0 persisted, got %d", len(chatSvc.persistedIn))
@@ -2868,7 +2868,7 @@ func TestChannelInboundProcessorPipelineUsesResolvedAttachments(t *testing.T) {
 	if len(atts) != 1 {
 		t.Fatalf("expected one pipeline attachment, got %d", len(atts))
 	}
-	if got := atts[0].FilePath; got != "/data/media/test/asset-pipeline-photo" {
+	if got := atts[0].FilePath; got != "/data/.memoh/media/test/asset-pipeline-photo" {
 		t.Fatalf("expected pipeline attachment path to use media store, got %q", got)
 	}
 	if strings.Contains(atts[0].FilePath, "api.telegram.org") {
@@ -3567,7 +3567,7 @@ func TestIngestOutboundAttachments_NonDataURL(t *testing.T) {
 	p := &ChannelInboundProcessor{}
 	attachments := []channel.Attachment{
 		{Type: channel.AttachmentImage, URL: "https://example.com/img.png"},
-		{Type: channel.AttachmentImage, ContentHash: "existing-asset", URL: "/data/media/img.png"},
+		{Type: channel.AttachmentImage, ContentHash: "existing-asset", URL: "/data/.memoh/media/img.png"},
 	}
 	result := p.ingestOutboundAttachments(context.Background(), "bot-1", channel.ChannelType("telegram"), attachments)
 	if len(result) != 2 {
@@ -3611,7 +3611,7 @@ func TestIsDataURL(t *testing.T) {
 		{"data:image/png;base64,abc", true},
 		{"DATA:text/plain;base64,abc", true},
 		{"https://example.com", false},
-		{"/data/media/img.png", false},
+		{"/data/.memoh/media/img.png", false},
 		{"", false},
 	}
 	for _, tt := range tests {
@@ -3628,8 +3628,8 @@ func TestExtractStorageKey(t *testing.T) {
 		botID      string
 		want       string
 	}{
-		{"/data/media/26da/26da0cc7.jpg", "bot-1", "26da/26da0cc7.jpg"},
-		{"/data/media/abcd/abcd1234.pdf", "bot-2", "abcd/abcd1234.pdf"},
+		{"/data/.memoh/media/26da/26da0cc7.jpg", "bot-1", "26da/26da0cc7.jpg"},
+		{"/data/.memoh/media/abcd/abcd1234.pdf", "bot-2", "abcd/abcd1234.pdf"},
 		{"https://example.com/img.png", "bot-1", ""},
 		{"", "bot-1", ""},
 	}
@@ -3650,7 +3650,7 @@ func TestIsHTTPURL(t *testing.T) {
 		{"https://example.com/img.png", true},
 		{"http://localhost:8080/test", true},
 		{"HTTP://EXAMPLE.COM", true},
-		{"/data/media/img.png", false},
+		{"/data/.memoh/media/img.png", false},
 		{"data:image/png;base64,abc", false},
 		{"", false},
 	}
@@ -3669,7 +3669,7 @@ func TestIngestOutboundAttachments_ContainerPath(t *testing.T) {
 	}
 	p := &ChannelInboundProcessor{mediaService: ms}
 	attachments := []channel.Attachment{
-		{Type: channel.AttachmentImage, Path: "/data/media/26da/26da0cc7.jpg"},
+		{Type: channel.AttachmentImage, Path: "/data/.memoh/media/26da/26da0cc7.jpg"},
 	}
 	result := p.ingestOutboundAttachments(context.Background(), "bot-1", channel.ChannelType("telegram"), attachments)
 	if len(result) != 1 {
@@ -3691,13 +3691,13 @@ func TestIngestOutboundAttachments_ContainerPathNotFound(t *testing.T) {
 	}
 	p := &ChannelInboundProcessor{mediaService: ms}
 	attachments := []channel.Attachment{
-		{Type: channel.AttachmentImage, Path: "/data/media/26da/missing.jpg"},
+		{Type: channel.AttachmentImage, Path: "/data/.memoh/media/26da/missing.jpg"},
 	}
 	result := p.ingestOutboundAttachments(context.Background(), "bot-1", channel.ChannelType("telegram"), attachments)
 	if len(result) != 1 {
 		t.Fatalf("expected unresolved container attachment to remain unchanged, got %d", len(result))
 	}
-	if result[0].Path != "/data/media/26da/missing.jpg" {
+	if result[0].Path != "/data/.memoh/media/26da/missing.jpg" {
 		t.Fatalf("expected original path preserved, got %q", result[0].Path)
 	}
 	if result[0].ContentHash != "" {
@@ -3712,7 +3712,7 @@ func TestMapChannelToChatAttachments(t *testing.T) {
 		{
 			Type:        channel.AttachmentImage,
 			ContentHash: "asset-1",
-			Path:        "/data/media/ab/c.png",
+			Path:        "/data/.memoh/media/ab/c.png",
 			Base64:      "AAAA",
 			Mime:        "image/png",
 		},
@@ -3727,7 +3727,7 @@ func TestMapChannelToChatAttachments(t *testing.T) {
 	if len(mapped) != 2 {
 		t.Fatalf("expected 2 mapped attachments, got %d", len(mapped))
 	}
-	if mapped[0].Path != "/data/media/ab/c.png" {
+	if mapped[0].Path != "/data/.memoh/media/ab/c.png" {
 		t.Fatalf("expected asset attachment path, got %q", mapped[0].Path)
 	}
 	if !strings.HasPrefix(mapped[0].Base64, "data:image/png;base64,") {

--- a/internal/channel/outbound_prepare_test.go
+++ b/internal/channel/outbound_prepare_test.go
@@ -17,7 +17,7 @@ func TestPrepareOutboundMessage_ContainerPathFallsBackToIngestContainerFile(t *t
 	t.Parallel()
 
 	store := channeltest.NewMemoryAttachmentStore()
-	const sourcePath = "/data/media/26da/missing.png"
+	const sourcePath = "/data/.memoh/media/26da/missing.png"
 	store.SeedContainerFile("bot-1", sourcePath, []byte("image-bytes"), "image/png", "missing.png")
 
 	prepared, err := PrepareOutboundMessage(context.Background(), store, ChannelConfig{
@@ -612,10 +612,10 @@ func TestExtractPreparedStorageKey(t *testing.T) {
 		path string
 		want string
 	}{
-		{"/data/media/ab/abcdef.png", "ab/abcdef.png"},
+		{"/data/.memoh/media/ab/abcdef.png", "ab/abcdef.png"},
 		{"/other/media/ab/abcdef.png", ""},
-		{"/data/media/", ""},
-		{"/data/media", ""},
+		{"/data/.memoh/media/", ""},
+		{"/data/.memoh/media", ""},
 		{"ab/abcdef.png", ""},
 	}
 	for _, tc := range cases {
@@ -655,7 +655,7 @@ func TestIsHTTPURL(t *testing.T) {
 	if IsHTTPURL("data:image/png;base64,abc") {
 		t.Error("expected false for data: URL")
 	}
-	if IsHTTPURL("/data/media/file.png") {
+	if IsHTTPURL("/data/.memoh/media/file.png") {
 		t.Error("expected false for local path")
 	}
 }
@@ -663,7 +663,7 @@ func TestIsHTTPURL(t *testing.T) {
 func TestIsDataPath(t *testing.T) {
 	t.Parallel()
 
-	if !IsDataPath("/data/media/file.png") {
+	if !IsDataPath("/data/.memoh/media/file.png") {
 		t.Error("expected true for /data/ path")
 	}
 	if IsDataPath("/tmp/file.png") {

--- a/internal/chat/timeline/rendering_test.go
+++ b/internal/chat/timeline/rendering_test.go
@@ -12,8 +12,8 @@ func TestRenderMessage_ImageRefsPopulated(t *testing.T) {
 		TimestampSec: 100,
 		Content:      []ContentNode{{Type: "text", Text: "photo"}},
 		Attachments: []Attachment{
-			{Type: "image", ContentHash: "hash-1", MimeType: "image/jpeg", FilePath: "/data/media/bot/ab/hash-1.jpg"},
-			{Type: "file", ContentHash: "hash-2", MimeType: "application/pdf", FilePath: "/data/media/bot/cd/hash-2.pdf"},
+			{Type: "image", ContentHash: "hash-1", MimeType: "image/jpeg", FilePath: "/data/.memoh/media/bot/ab/hash-1.jpg"},
+			{Type: "file", ContentHash: "hash-2", MimeType: "application/pdf", FilePath: "/data/.memoh/media/bot/cd/hash-2.pdf"},
 			{Type: "image", MimeType: "image/png"},
 		},
 		Conversation: ConversationMeta{Channel: "telegram", ConversationType: "private"},

--- a/internal/handlers/filemanager.go
+++ b/internal/handlers/filemanager.go
@@ -18,11 +18,10 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/memohai/memoh/internal/apperror"
+	"github.com/memohai/memoh/internal/attachment"
 	"github.com/memohai/memoh/internal/bots"
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
-
-const mediaContainerRoot = "/data/.memoh/media"
 
 // ---------- request / response types ----------
 
@@ -112,8 +111,7 @@ func resolveContainerPath(rawPath string) (string, error) {
 }
 
 func isContainerMediaPath(containerPath string) bool {
-	cleaned := path.Clean("/" + strings.ReplaceAll(strings.TrimSpace(containerPath), "\\", "/"))
-	return cleaned == mediaContainerRoot || strings.HasPrefix(cleaned, mediaContainerRoot+"/")
+	return attachment.IsMediaAccessPath(containerPath)
 }
 
 func isPathWithin(parentPath, childPath string) bool {

--- a/internal/handlers/filemanager.go
+++ b/internal/handlers/filemanager.go
@@ -22,7 +22,7 @@ import (
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
-const mediaContainerRoot = "/data/media"
+const mediaContainerRoot = "/data/.memoh/media"
 
 // ---------- request / response types ----------
 

--- a/internal/handlers/filemanager_test.go
+++ b/internal/handlers/filemanager_test.go
@@ -61,6 +61,10 @@ func TestIsContainerMediaPath(t *testing.T) {
 		{path: "/data/.memoh/media/0f/demo.jpg", want: true},
 		{path: "data/.memoh/media/0f/demo.jpg", want: true},
 		{path: "/data/.memoh/mediakit/demo.jpg", want: false},
+		{path: "/data/media", want: true},
+		{path: "/data/media/0f/demo.jpg", want: true},
+		{path: "data/media/0f/demo.jpg", want: true},
+		{path: "/data/mediakit/demo.jpg", want: false},
 		{path: "/etc/passwd", want: false},
 	}
 

--- a/internal/handlers/filemanager_test.go
+++ b/internal/handlers/filemanager_test.go
@@ -57,10 +57,10 @@ func TestIsContainerMediaPath(t *testing.T) {
 		path string
 		want bool
 	}{
-		{path: "/data/media", want: true},
-		{path: "/data/media/0f/demo.jpg", want: true},
-		{path: "data/media/0f/demo.jpg", want: true},
-		{path: "/data/mediakit/demo.jpg", want: false},
+		{path: "/data/.memoh/media", want: true},
+		{path: "/data/.memoh/media/0f/demo.jpg", want: true},
+		{path: "data/.memoh/media/0f/demo.jpg", want: true},
+		{path: "/data/.memoh/mediakit/demo.jpg", want: false},
 		{path: "/etc/passwd", want: false},
 	}
 

--- a/internal/handlers/local_channel_test.go
+++ b/internal/handlers/local_channel_test.go
@@ -1666,9 +1666,9 @@ func (*localChannelMemoryProvider) Delete(context.Context, string) error { retur
 func (*localChannelMemoryProvider) AccessPath(_ context.Context, key string) string {
 	parts := strings.SplitN(key, "/", 2)
 	if len(parts) != 2 {
-		return "/data/media/" + key
+		return "/data/.memoh/media/" + key
 	}
-	return "/data/media/" + parts[1]
+	return "/data/.memoh/media/" + parts[1]
 }
 
 func (p *localChannelMemoryProvider) OpenContainerFile(ctx context.Context, botID, containerPath string) (io.ReadCloser, error) {

--- a/internal/media/service_access_test.go
+++ b/internal/media/service_access_test.go
@@ -33,7 +33,7 @@ func (p *accessPathEnsuringProvider) EnsureAccessPath(_ context.Context, key str
 func TestServiceEnsureAccessPathUsesMaterializingProvider(t *testing.T) {
 	t.Parallel()
 
-	provider := &accessPathEnsuringProvider{path: " /data/media/aa/asset.pdf "}
+	provider := &accessPathEnsuringProvider{path: " /data/.memoh/media/aa/asset.pdf "}
 	service := NewService(nil, provider)
 	got, err := service.EnsureAccessPath(context.Background(), Asset{
 		BotID:      "bot-1",
@@ -42,7 +42,7 @@ func TestServiceEnsureAccessPathUsesMaterializingProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnsureAccessPath() error = %v", err)
 	}
-	if got != "/data/media/aa/asset.pdf" {
+	if got != "/data/.memoh/media/aa/asset.pdf" {
 		t.Fatalf("EnsureAccessPath() = %q", got)
 	}
 	if provider.ensuredKey != "bot-1/aa/asset.pdf" {

--- a/internal/storage/providers/containerfs/provider.go
+++ b/internal/storage/providers/containerfs/provider.go
@@ -15,7 +15,10 @@ import (
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
-const containerMediaRoot = ".memoh/media"
+const (
+	containerMediaRoot       = ".memoh/media"
+	legacyContainerMediaRoot = "media"
+)
 
 // Provider stores media assets inside bot containers via gRPC.
 type Provider struct {
@@ -54,11 +57,15 @@ func (p *Provider) Open(ctx context.Context, key string) (io.ReadCloser, error) 
 	if err != nil {
 		return nil, fmt.Errorf("get client: %w", err)
 	}
-	containerPath := filepath.Join(containerMediaRoot, sub)
-	return client.ReadRaw(ctx, containerPath)
+	paths := mediaContainerPaths(sub)
+	reader, err := client.ReadRaw(ctx, paths[0])
+	if err == nil || !errors.Is(err, bridge.ErrNotFound) {
+		return reader, err
+	}
+	return client.ReadRaw(ctx, paths[1])
 }
 
-// Delete removes a file from the bot container.
+// Delete removes both current and legacy copies during the transition.
 func (p *Provider) Delete(ctx context.Context, key string) error {
 	botID, sub, err := parseRoutingKey(key)
 	if err != nil {
@@ -68,14 +75,37 @@ func (p *Provider) Delete(ctx context.Context, key string) error {
 	if err != nil {
 		return fmt.Errorf("get client: %w", err)
 	}
-	containerPath := filepath.Join(containerMediaRoot, sub)
-	return client.DeleteFile(ctx, containerPath, false)
+	var errs []error
+	for _, containerPath := range mediaContainerPaths(sub) {
+		if err := client.DeleteFile(ctx, containerPath, false); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
-// AccessPath returns the stable path in the workspace filesystem namespace.
-func (*Provider) AccessPath(_ context.Context, key string) string {
-	_, sub := splitRoutingKey(key)
-	return attachmentpkg.MediaAccessPath(sub)
+// AccessPath returns a reachable current or legacy workspace path.
+func (p *Provider) AccessPath(ctx context.Context, key string) string {
+	botID, sub, err := parseRoutingKey(key)
+	if err != nil {
+		return ""
+	}
+	paths := mediaContainerPaths(sub)
+	if p == nil || p.clients == nil {
+		return attachmentpkg.DataMountPath(paths[0])
+	}
+	client, err := p.clients.MCPClient(ctx, botID)
+	if err != nil {
+		return ""
+	}
+	for _, containerPath := range paths {
+		if _, err := client.Stat(ctx, containerPath); err == nil {
+			return attachmentpkg.DataMountPath(containerPath)
+		} else if !errors.Is(err, bridge.ErrNotFound) {
+			return ""
+		}
+	}
+	return ""
 }
 
 // OpenContainerFile opens a file from a bot's /data/ directory.
@@ -111,24 +141,38 @@ func (p *Provider) ListPrefix(ctx context.Context, prefix string) ([]string, err
 	if err != nil {
 		return nil, nil
 	}
-	dir := filepath.Dir(filepath.Join(containerMediaRoot, sub))
 	base := filepath.Base(sub)
-	entries, err := client.ListDirAll(ctx, dir, false)
-	if err != nil {
-		return nil, nil
-	}
 	var keys []string
-	for _, e := range entries {
-		if e.GetIsDir() {
+	seen := make(map[string]struct{})
+	for _, containerPath := range mediaContainerPaths(sub) {
+		entries, err := client.ListDirAll(ctx, filepath.Dir(containerPath), false)
+		if err != nil {
 			continue
 		}
-		name := e.GetPath()
-		if strings.HasPrefix(name, base) {
-			storageKey := filepath.Join(filepath.Dir(sub), name)
-			keys = append(keys, filepath.Join(botID, storageKey))
+		for _, e := range entries {
+			if e.GetIsDir() {
+				continue
+			}
+			name := e.GetPath()
+			if !strings.HasPrefix(name, base) {
+				continue
+			}
+			key := filepath.Join(botID, filepath.Dir(sub), name)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			keys = append(keys, key)
 		}
 	}
 	return keys, nil
+}
+
+func mediaContainerPaths(sub string) [2]string {
+	return [2]string{
+		filepath.Join(containerMediaRoot, sub),
+		filepath.Join(legacyContainerMediaRoot, sub),
+	}
 }
 
 func parseRoutingKey(key string) (botID, storageKey string, err error) {

--- a/internal/storage/providers/containerfs/provider.go
+++ b/internal/storage/providers/containerfs/provider.go
@@ -1,6 +1,6 @@
 // Package containerfs implements storage.Provider for bot containers
 // backed by gRPC calls to the in-container MCP service. Files are stored
-// inside the container's writable layer at /data/media/<subpath>.
+// inside the container's writable layer at /data/.memoh/media/<subpath>.
 package containerfs
 
 import (
@@ -15,7 +15,7 @@ import (
 	"github.com/memohai/memoh/internal/workspace/bridge"
 )
 
-const containerMediaRoot = "media"
+const containerMediaRoot = ".memoh/media"
 
 // Provider stores media assets inside bot containers via gRPC.
 type Provider struct {

--- a/internal/storage/providers/containerfs/provider_legacy_test.go
+++ b/internal/storage/providers/containerfs/provider_legacy_test.go
@@ -1,0 +1,142 @@
+package containerfs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/memohai/memoh/internal/workspace/bridge"
+	pb "github.com/memohai/memoh/internal/workspace/bridgepb"
+	"github.com/memohai/memoh/internal/workspace/bridgesvc"
+)
+
+type legacyTestClientProvider struct{ client *bridge.Client }
+
+func (p legacyTestClientProvider) MCPClient(context.Context, string) (*bridge.Client, error) {
+	return p.client, nil
+}
+
+func newLegacyTestProvider(t *testing.T, root string) *Provider {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 20)
+	server := grpc.NewServer()
+	pb.RegisterContainerServiceServer(server, bridgesvc.New(bridgesvc.Options{
+		DefaultWorkDir: root,
+		WorkspaceRoot:  root,
+		DataMount:      "/data",
+	}))
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = server.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		server.Stop()
+		<-done
+	})
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return New(legacyTestClientProvider{client: bridge.NewClientFromConn(conn)})
+}
+
+func writeLegacyTestFile(t *testing.T, filePath, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(filePath), err)
+	}
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", filePath, err)
+	}
+}
+
+func TestProvider_LegacyMediaTransition(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	provider := newLegacyTestProvider(t, root)
+	ctx := context.Background()
+	const key = "bot-1/aa/asset.png"
+	legacyPath := filepath.Join(root, "media", "aa", "asset.png")
+	currentPath := filepath.Join(root, ".memoh", "media", "aa", "asset.png")
+	writeLegacyTestFile(t, legacyPath, "legacy")
+
+	reader, err := provider.Open(ctx, key)
+	if err != nil {
+		t.Fatalf("Open legacy media: %v", err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read legacy media: %v", err)
+	}
+	_ = reader.Close()
+	if got := string(data); got != "legacy" {
+		t.Fatalf("legacy media content = %q, want legacy", got)
+	}
+	if got := provider.AccessPath(ctx, key); got != "/data/media/aa/asset.png" {
+		t.Fatalf("legacy AccessPath = %q, want /data/media/aa/asset.png", got)
+	}
+	keys, err := provider.ListPrefix(ctx, "bot-1/aa/asset")
+	if err != nil || len(keys) != 1 || keys[0] != key {
+		t.Fatalf("legacy ListPrefix = %v, %v; want [%s]", keys, err, key)
+	}
+
+	writeLegacyTestFile(t, currentPath, "current")
+	reader, err = provider.Open(ctx, key)
+	if err != nil {
+		t.Fatalf("Open current media: %v", err)
+	}
+	data, err = io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read current media: %v", err)
+	}
+	_ = reader.Close()
+	if got := string(data); got != "current" {
+		t.Fatalf("current media content = %q, want current", got)
+	}
+	if got := provider.AccessPath(ctx, key); got != "/data/.memoh/media/aa/asset.png" {
+		t.Fatalf("current AccessPath = %q, want /data/.memoh/media/aa/asset.png", got)
+	}
+	keys, err = provider.ListPrefix(ctx, "bot-1/aa/asset")
+	if err != nil || len(keys) != 1 || keys[0] != key {
+		t.Fatalf("deduplicated ListPrefix = %v, %v; want [%s]", keys, err, key)
+	}
+
+	if err := provider.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete current and legacy media: %v", err)
+	}
+	for _, deletedPath := range []string{currentPath, legacyPath} {
+		if _, err := os.Stat(deletedPath); !os.IsNotExist(err) {
+			t.Fatalf("deleted media %s still exists or stat failed: %v", deletedPath, err)
+		}
+	}
+
+	const newKey = "bot-1/bb/new.png"
+	if err := provider.Put(ctx, newKey, bytes.NewBufferString("new")); err != nil {
+		t.Fatalf("Put new media: %v", err)
+	}
+	currentNewPath := filepath.Join(root, ".memoh", "media", "bb", "new.png")
+	if data, err := os.ReadFile(currentNewPath); err != nil || string(data) != "new" { //nolint:gosec // G304: path is under t.TempDir.
+		t.Fatalf("current media write = %q, %v; want new", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "media", "bb", "new.png")); !os.IsNotExist(err) {
+		t.Fatalf("new media unexpectedly written to legacy root: %v", err)
+	}
+}

--- a/internal/storage/providers/containerfs/provider_test.go
+++ b/internal/storage/providers/containerfs/provider_test.go
@@ -37,8 +37,8 @@ func TestProvider_AccessPath(t *testing.T) {
 		key  string
 		want string
 	}{
-		{key: "bot-1/image/ab12/ab12cd.png", want: "/data/media/image/ab12/ab12cd.png"},
-		{key: "bot-1/file/xx/doc.pdf", want: "/data/media/file/xx/doc.pdf"},
+		{key: "bot-1/image/ab12/ab12cd.png", want: "/data/.memoh/media/image/ab12/ab12cd.png"},
+		{key: "bot-1/file/xx/doc.pdf", want: "/data/.memoh/media/file/xx/doc.pdf"},
 	}
 	for _, tt := range tests {
 		got := p.AccessPath(context.Background(), tt.key)

--- a/internal/storage/providers/fallback/provider_test.go
+++ b/internal/storage/providers/fallback/provider_test.go
@@ -60,7 +60,7 @@ func TestProviderEnsureAccessPathPromotesSecondaryToPrimary(t *testing.T) {
 	t.Parallel()
 
 	const key = "bot-1/aa/asset.pdf"
-	primary := newMemoryProvider("/data/media")
+	primary := newMemoryProvider("/data/.memoh/media")
 	primary.putErr = errors.New("workspace unavailable")
 	secondary := newMemoryProvider("/host/media")
 	provider := New(primary, secondary)
@@ -73,7 +73,7 @@ func TestProviderEnsureAccessPathPromotesSecondaryToPrimary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnsureAccessPath() error = %v", err)
 	}
-	if want := "/data/media/" + key; got != want {
+	if want := "/data/.memoh/media/" + key; got != want {
 		t.Fatalf("EnsureAccessPath() = %q, want %q", got, want)
 	}
 	if got := string(primary.values[key]); got != "pdf" {
@@ -88,13 +88,13 @@ func TestProviderAccessPathPrefersReachablePrimary(t *testing.T) {
 	t.Parallel()
 
 	const key = "bot-1/aa/asset.png"
-	primary := newMemoryProvider("/data/media")
+	primary := newMemoryProvider("/data/.memoh/media")
 	secondary := newMemoryProvider("/host/media")
 	primary.values[key] = []byte("primary")
 	secondary.values[key] = []byte("secondary")
 	provider := New(primary, secondary)
 
-	if got, want := provider.AccessPath(context.Background(), key), "/data/media/"+key; got != want {
+	if got, want := provider.AccessPath(context.Background(), key), "/data/.memoh/media/"+key; got != want {
 		t.Fatalf("AccessPath() = %q, want %q", got, want)
 	}
 }
@@ -103,7 +103,7 @@ func TestProviderAccessPathReturnsEmptyWithoutReachablePath(t *testing.T) {
 	t.Parallel()
 
 	const key = "bot-1/aa/missing.txt"
-	primary := newMemoryProvider("/data/media")
+	primary := newMemoryProvider("/data/.memoh/media")
 	secondary := newMemoryProvider("/host/media")
 	provider := New(primary, secondary)
 
@@ -126,7 +126,7 @@ func TestProviderAccessPathDoesNotExposeSecondaryWhenPromotionFails(t *testing.T
 	t.Parallel()
 
 	const key = "bot-1/aa/asset.pdf"
-	primary := newMemoryProvider("/data/media")
+	primary := newMemoryProvider("/data/.memoh/media")
 	primary.putErr = errors.New("workspace unavailable")
 	secondary := newMemoryProvider("/host/media")
 	secondary.values[key] = []byte("pdf")
@@ -144,7 +144,7 @@ func TestProviderDeleteCleansBothStores(t *testing.T) {
 	t.Parallel()
 
 	const key = "bot-1/aa/asset.pdf"
-	primary := newMemoryProvider("/data/media")
+	primary := newMemoryProvider("/data/.memoh/media")
 	secondary := newMemoryProvider("/host/media")
 	primary.values[key] = []byte("primary")
 	secondary.values[key] = []byte("secondary")

--- a/internal/workspace/bridge/client_test.go
+++ b/internal/workspace/bridge/client_test.go
@@ -182,7 +182,7 @@ func TestClientReadRawMissingFileReturnsNotFoundImmediately(t *testing.T) {
 	t.Parallel()
 
 	client := newTestReadRawClient(t, map[string][]byte{})
-	_, err := client.ReadRaw(context.Background(), "/data/media/missing.jpg")
+	_, err := client.ReadRaw(context.Background(), "/data/.memoh/media/missing.jpg")
 	if err == nil {
 		t.Fatal("expected read raw to fail for missing file")
 	}
@@ -195,9 +195,9 @@ func TestClientReadRawPreservesFirstChunk(t *testing.T) {
 	t.Parallel()
 
 	client := newTestReadRawClient(t, map[string][]byte{
-		"/data/media/existing.jpg": []byte("hello"),
+		"/data/.memoh/media/existing.jpg": []byte("hello"),
 	})
-	reader, err := client.ReadRaw(context.Background(), "/data/media/existing.jpg")
+	reader, err := client.ReadRaw(context.Background(), "/data/.memoh/media/existing.jpg")
 	if err != nil {
 		t.Fatalf("ReadRaw returned error: %v", err)
 	}
@@ -216,9 +216,9 @@ func TestClientReadRawSupportsEmptyFile(t *testing.T) {
 	t.Parallel()
 
 	client := newTestReadRawClient(t, map[string][]byte{
-		"/data/media/empty.txt": {},
+		"/data/.memoh/media/empty.txt": {},
 	})
-	reader, err := client.ReadRaw(context.Background(), "/data/media/empty.txt")
+	reader, err := client.ReadRaw(context.Background(), "/data/.memoh/media/empty.txt")
 	if err != nil {
 		t.Fatalf("ReadRaw returned error: %v", err)
 	}
@@ -242,10 +242,10 @@ func TestClientWriteRawSupportsEmptyFile(t *testing.T) {
 		WorkspaceRoot:  root,
 		DataMount:      "/data",
 	}))
-	if _, err := client.WriteRaw(context.Background(), "/data/media/empty.txt", bytes.NewReader(nil)); err != nil {
+	if _, err := client.WriteRaw(context.Background(), "/data/.memoh/media/empty.txt", bytes.NewReader(nil)); err != nil {
 		t.Fatalf("WriteRaw() error = %v", err)
 	}
-	info, err := os.Stat(filepath.Join(root, "media", "empty.txt"))
+	info, err := os.Stat(filepath.Join(root, ".memoh", "media", "empty.txt"))
 	if err != nil {
 		t.Fatalf("stat empty file: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestClientWriteRawDoesNotReplaceTargetOnReaderFailure(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	target := filepath.Join(root, "media", "asset.txt")
+	target := filepath.Join(root, ".memoh", "media", "asset.txt")
 	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
 		t.Fatalf("mkdir target: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestClientWriteRawDoesNotReplaceTargetOnReaderFailure(t *testing.T) {
 		WorkspaceRoot:  root,
 		DataMount:      "/data",
 	}))
-	if _, err := client.WriteRaw(context.Background(), "/data/media/asset.txt", &failAfterDataReader{}); err == nil {
+	if _, err := client.WriteRaw(context.Background(), "/data/.memoh/media/asset.txt", &failAfterDataReader{}); err == nil {
 		t.Fatal("WriteRaw() error = nil, want reader failure")
 	}
 


### PR DESCRIPTION
## Summary

- move content-addressed sandbox media from `/data/media` to `/data/.memoh/media`
- store Browser Use and Computer Use screenshots together under `/data/.memoh/screenshots`
- update attachment resolution, transcription paths, media download access, bridge coverage, and related tests

## Why

Memoh-managed sandbox artifacts should live under the hidden `.memoh` namespace instead of being spread across top-level workspace directories.

## Impact

New Channel media and screenshot writes use the consolidated paths. Host spill storage under `${workspace.data_root}/media` remains unchanged. Files already stored in the former sandbox directories are not migrated automatically.

## Validation

- `go test ./internal/attachment ./internal/media ./internal/storage/providers/containerfs ./internal/storage/providers/fallback ./internal/agent/tool ./internal/agent/application ./internal/agent/runtime/acp ./internal/agent/view ./internal/channel/inbound ./internal/channel ./internal/chat/timeline ./internal/handlers ./internal/workspace/bridge`
- pre-commit repository-wide Go tests
- pre-commit Go lint
- `git diff --check`
- verified no remaining `data/media`, `browser-screenshots`, or `computer-screenshots` path references

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.