### PR TITLE
fix(agent): gate vision routing by supported image MIME

### DIFF
--- a/internal/agent/application/capability_policy.go
+++ b/internal/agent/application/capability_policy.go
@@ -3,6 +3,7 @@ package application
 import (
 	"strings"
 
+	attachmentpkg "github.com/memohai/memoh/internal/attachment"
 	"github.com/memohai/memoh/internal/models"
 )
 
@@ -77,7 +78,7 @@ func routeAttachmentsByCapability(compatibilities []string, attachments []gatewa
 
 		native := false
 		switch {
-		case att.Type == "image" && hasVision:
+		case att.Type == "image" && hasVision && isNativeImageAttachment(att):
 			native = isGatewayNativeAttachment(att)
 		case att.Type == "file" && isNativeDocumentMime(att.Mime) && hasFileInput:
 			native = isGatewayNativeAttachment(att)
@@ -139,6 +140,31 @@ func isNativeDocumentMime(mime string) bool {
 		mime = strings.TrimSpace(mime[:idx])
 	}
 	return mime == "application/pdf"
+}
+
+// isNativeImageMime is the common raster set accepted by the native provider
+// adapters. UI type=image is only a presentation hint; it must not admit SVG,
+// BMP, HEIC, or arbitrary image/* bytes into a provider ImagePart.
+func isNativeImageMime(mime string) bool {
+	switch strings.ToLower(strings.TrimSpace(strings.SplitN(mime, ";", 2)[0])) {
+	case "image/png", "image/jpeg", "image/gif", "image/webp":
+		return true
+	default:
+		return false
+	}
+}
+
+func isNativeImageAttachment(att gatewayAttachment) bool {
+	mime := attachmentpkg.NormalizeMime(att.Mime)
+	if mime == "" && strings.EqualFold(strings.TrimSpace(att.Transport), gatewayTransportInlineDataURL) {
+		mime = attachmentpkg.MimeFromDataURL(att.Payload)
+	}
+	// Preserve URL-only image input: its bytes are remote and cannot be sniffed
+	// here. A supplied MIME still has to pass the common-raster allowlist.
+	if mime == "" && strings.EqualFold(strings.TrimSpace(att.Transport), gatewayTransportPublicURL) {
+		return true
+	}
+	return isNativeImageMime(mime)
 }
 
 // isInlineTextMime reports whether the attachment is plain text that can be

--- a/internal/agent/application/capability_policy_test.go
+++ b/internal/agent/application/capability_policy_test.go
@@ -19,6 +19,20 @@ func TestRouteAttachmentsByCapability_VisionSupported(t *testing.T) {
 	assert.Equal(t, "audio", result.Fallback[0].Type)
 }
 
+func TestRouteAttachmentsByCapability_SVGFallsBack(t *testing.T) {
+	attachments := []gatewayAttachment{{
+		Type:         "image",
+		Mime:         "image/svg+xml",
+		Transport:    gatewayTransportInlineDataURL,
+		Payload:      "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+		FallbackPath: "/data/media/logo.svg",
+	}}
+
+	result := routeAttachmentsByCapability([]string{"vision"}, attachments)
+	assert.Empty(t, result.Native)
+	assert.Equal(t, attachments, result.Fallback)
+}
+
 func TestRouteAttachmentsByCapability_NoVision(t *testing.T) {
 	compatibilities := []string{"tool-call"}
 	attachments := []gatewayAttachment{


### PR DESCRIPTION
## 概述

修复附件的展示类型与模型输入类型混用的问题。

前端的 `type=image` 只是附件展示分类，不能直接代表该附件可以作为模型的 `ImagePart` 发送。此前 native runtime 只检查 `type=image` 和模型是否支持 vision，导致 SVG 等非通用图片格式被错误发送到 provider，最终触发 `invalid_image_format`。

## 本次修改

- native vision 路由增加图片 MIME 类型检查。
- 仅允许以下格式进入 `ImagePart`：
  - `image/png`
  - `image/jpeg`
  - `image/gif`
  - `image/webp`
- SVG、BMP、HEIC/HEIF 及其他不在允许列表中的格式不再进入 native vision 路由，继续使用现有 fallback。
- 保留没有明确 MIME 的 URL-only 图片兼容行为。
- 增加 SVG 降级路由的回归测试。

## 验证

```text
go test -count=1 ./internal/agent/application ./internal/attachment
go test -run '^$' ./...
go vet ./internal/attachment ./internal/agent/application
git diff --check
```

人工 QA 已确认：PNG/JPEG vision、SVG fallback、PNG 与 SVG 混合附件以及纯文本消息均可正常工作。
