### PR TITLE
feat(web): mark connector tool calls with their connector's logo

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -893,6 +893,7 @@ import { ATTACHMENT_ANIM_MS, attachmentToFile, fileToAttachment, useComposerAtta
 import { useComposerDrafts } from '../composables/useComposerDrafts'
 import { COMPOSER_MASK_BELOW_PX, useComposerLayout } from '../composables/useComposerLayout'
 import { provideChatViewTarget } from '../composables/useChatViewContext'
+import { provideConnectorLogos } from '../composables/useConnectorLogos'
 import { fetchSafeSkillCatalog, fetchSession, type ChatAttachment, type CommandActionError, type CommandActionListItem, type RequestedSkillSelection, type UIUserInput } from '@/composables/api/useChat'
 import { commandResultPresentation, isCommandResultItemVisible, resolveCommandResultSelection } from './slash-command-result'
 import { captureChatPaneSendContext, composerHasNoModel as hasNoComposerModel, matchesChatPaneSendContext, pinnedSubagentModelId as resolvePinnedSubagentModelId, shouldRefreshACPComposerConfig } from './chat-pane-send'
@@ -973,6 +974,9 @@ const paneTarget = computed(() => ({
   viewId: props.tabId.trim() || 'chat',
 }))
 provideChatViewTarget(paneTarget)
+// Resolved once per pane so every tool row below can mark a Connect-It call
+// with its connector's logo without each row running its own lookup.
+provideConnectorLogos(paneTarget)
 const paneView = computed(() => chatStore.chatView(paneTarget.value))
 const messages = computed(() => paneView.value.transcript.visibleMessages.value)
 const loadingMessages = computed(() => paneView.value.transcript.loadingMessages.value)

--- a/apps/web/src/pages/home/components/tool-call-group.vue
+++ b/apps/web/src/pages/home/components/tool-call-group.vue
@@ -19,6 +19,19 @@
       :open="open"
       @toggle="toggle"
     >
+      <!-- Every connector this run touched, not just the first: the collapsed
+           header is the only place a reader sees which external systems the
+           whole segment reached. -->
+      <div
+        v-if="connectors.length"
+        class="flex items-center gap-1 shrink-0"
+      >
+        <ConnectorLogo
+          v-for="item in connectors"
+          :key="item.alias"
+          :connector="item"
+        />
+      </div>
       <span
         class="min-w-0 truncate tracking-[0.01em]"
         :class="running ? 'tool-shimmer-text' : ''"
@@ -75,6 +88,8 @@ import { getCollapseOpen, groupCollapseKey, setCollapseOpen } from './process-co
 import HeaderRow from './tool-detail/header-row.vue'
 import ExpandChevron from './tool-detail/expand-chevron.vue'
 import Capsule from './tool-detail/capsule.vue'
+import ConnectorLogo from './tool-detail/connector-logo.vue'
+import { useConnectorLogos, type ConnectorIdentity } from '../composables/useConnectorLogos'
 
 const props = defineProps<{
   // Ordered run of tool + reasoning blocks belonging to one process segment.
@@ -87,6 +102,19 @@ const { t } = useI18n()
 
 const single = computed(() => props.items[0])
 const toolItems = computed(() => props.items.filter((b): b is ToolCallBlockType => b.type === 'tool'))
+
+// Distinct connectors used by this run, in order of first call. Keyed by alias
+// so two bindings of the same connector type stay two marks.
+const connectorLookup = useConnectorLogos()
+const connectors = computed(() => {
+  const lookup = connectorLookup.value
+  const seen = new Map<string, ConnectorIdentity>()
+  for (const tool of toolItems.value) {
+    const identity = lookup(tool.toolName)
+    if (identity && !seen.has(identity.alias)) seen.set(identity.alias, identity)
+  }
+  return [...seen.values()]
+})
 
 // Open state is purely user-driven and persisted across the post-turn refetch:
 // a process is collapsed until the user opens it, then stays as they left it

--- a/apps/web/src/pages/home/components/tool-call-inline.vue
+++ b/apps/web/src/pages/home/components/tool-call-inline.vue
@@ -10,6 +10,10 @@
       :tone="display.isError ? 'error' : 'cop'"
       @toggle="toggleOpen"
     >
+      <ConnectorLogo
+        v-if="connector"
+        :connector="connector"
+      />
       <span
         v-if="showActionLabel"
         class="shrink-0"
@@ -66,6 +70,10 @@
       class="flex items-center gap-1.5 w-full py-px"
       :class="rowClass"
     >
+      <ConnectorLogo
+        v-if="connector"
+        :connector="connector"
+      />
       <span
         v-if="showActionLabel"
         class="shrink-0"
@@ -175,11 +183,13 @@ import { computed, inject, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ToolCallBlock } from '@/store/chat-list'
 import { openInFileManagerKey } from '../composables/useFileManagerProvider'
+import { useConnectorLogos } from '../composables/useConnectorLogos'
 import {
   getToolDisplay,
   isDirPathTool,
   isFilePathTool,
 } from './tool-call-registry'
+import ConnectorLogo from './tool-detail/connector-logo.vue'
 import ToolCallDetailGeneric from './tool-call-detail-generic.vue'
 import CollapseSection from './collapse-section.vue'
 import { getCollapseOpen, setCollapseOpen, toolCollapseKey } from './process-collapse'
@@ -193,6 +203,11 @@ const { t } = useI18n()
 const openInFileManager = inject(openInFileManagerKey, undefined)
 
 const display = computed(() => getToolDisplay(props.block))
+
+// A Connect-It tool carries its binding's alias in the tool name; when that
+// alias resolves to one of the bot's connectors the row leads with its logo.
+const connectorLookup = useConnectorLogos()
+const connector = computed(() => connectorLookup.value(props.block.toolName))
 const executionLocationLabel = computed(() => {
   const location = props.block.execution_location
   if (!location) return ''

--- a/apps/web/src/pages/home/components/tool-detail/connector-logo.vue
+++ b/apps/web/src/pages/home/components/tool-detail/connector-logo.vue
@@ -1,0 +1,25 @@
+<template>
+  <!--
+    Provenance mark for a tool call that came from a Connector. Drawn at 1em so
+    it tracks the row's own font size (the tool rows sit at two different type
+    scales — root level and inside a process capsule — and a fixed size would
+    read as oversized in one of them). A connector the catalog has no artwork
+    for still gets the generic plug, so the row never silently loses the "this
+    came from a connector" signal.
+  -->
+  <ProviderIcon
+    :icon="connector.iconUrl"
+    :title="connector.name"
+    class="size-[1em] shrink-0 object-contain"
+  >
+    <Plug class="size-[1em] shrink-0" />
+  </ProviderIcon>
+</template>
+
+<script setup lang="ts">
+import { Plug } from 'lucide-vue-next'
+import ProviderIcon from '@/components/provider-icon/index.vue'
+import type { ConnectorIdentity } from '../../composables/useConnectorLogos'
+
+defineProps<{ connector: ConnectorIdentity }>()
+</script>

--- a/apps/web/src/pages/home/composables/useConnectorLogos.test.ts
+++ b/apps/web/src/pages/home/composables/useConnectorLogos.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { connectorAliasOf } from './useConnectorLogos'
+
+describe('connectorAliasOf', () => {
+  it('reads the alias Connect-It puts in front of a connector tool', () => {
+    expect(connectorAliasOf('notion__notion-search')).toBe('notion')
+    expect(connectorAliasOf('github-2__search_repositories')).toBe('github-2')
+  })
+
+  it('splits on the first separator so a tool name may keep its own', () => {
+    expect(connectorAliasOf('notion__notion__fetch')).toBe('notion')
+  })
+
+  it('claims nothing from a native tool name', () => {
+    expect(connectorAliasOf('web_search')).toBe('')
+    expect(connectorAliasOf('')).toBe('')
+  })
+
+  it('rejects a leading separator rather than reading an empty alias', () => {
+    expect(connectorAliasOf('__orphan')).toBe('')
+  })
+})

--- a/apps/web/src/pages/home/composables/useConnectorLogos.ts
+++ b/apps/web/src/pages/home/composables/useConnectorLogos.ts
@@ -1,0 +1,122 @@
+import {
+  computed,
+  hasInjectionContext,
+  inject,
+  provide,
+  type ComputedRef,
+  type InjectionKey,
+  type Ref,
+} from 'vue'
+import { useQuery } from '@pinia/colada'
+import { getBotsByBotIdConnectors, getConnectorsCatalog } from '@memohai/sdk'
+import { useCapabilitiesStore } from '@/store/capabilities'
+import type { ChatViewTarget } from '@/store/chat-list'
+
+// What a connector tool row needs to identify where the call came from.
+export interface ConnectorIdentity {
+  // The binding's durable tool namespace — also the map key, so a bot with two
+  // bindings of the same connector type ("notion", "notion-2") stays distinct.
+  alias: string
+  // Catalog display name ("Notion"), used as the logo's tooltip.
+  name: string
+  // Catalog artwork URL; empty when the catalog carries no icon for the type.
+  iconUrl: string
+}
+
+export type ConnectorLookup = (toolName: string) => ConnectorIdentity | null
+
+const connectorLookupKey: InjectionKey<ComputedRef<ConnectorLookup>> = Symbol('connector-lookup')
+
+// Connect-It namespaces every connector tool as `<alias>__<tool>` (the Go SDK's
+// MCPSessionConfig documents "github" exposing "github__search_repositories"),
+// so the alias is what a tool name carries — not the connector type. Splitting
+// on the FIRST separator keeps tool names that contain their own "__" intact.
+const ALIAS_SEPARATOR = '__'
+
+export function connectorAliasOf(toolName: string): string {
+  const index = toolName.indexOf(ALIAS_SEPARATOR)
+  if (index <= 0) return ''
+  return toolName.slice(0, index)
+}
+
+const emptyLookup: ConnectorLookup = () => null
+
+/**
+ * Resolve the current bot's connector bindings once per chat pane, so the tool
+ * rows below can mark a call with its connector's logo. The two queries share
+ * their keys with the bot Connectors page, so the pane usually renders from
+ * cache (and from the persisted cache on a cold reload) rather than refetching.
+ */
+export function provideConnectorLogos(
+  target: Ref<ChatViewTarget> | ComputedRef<ChatViewTarget>,
+): ComputedRef<ConnectorLookup> {
+  const capabilities = useCapabilitiesStore()
+  void capabilities.load()
+
+  const botId = computed(() => target.value.botId.trim())
+  // Connectors are a server capability: without it these endpoints do not
+  // answer, so nothing is asked of them.
+  const enabled = () => capabilities.connectors && botId.value !== ''
+
+  const catalogQuery = useQuery({
+    key: ['connectors-catalog'],
+    query: async () => {
+      const { data } = await getConnectorsCatalog({ throwOnError: true })
+      return data
+    },
+    enabled,
+  })
+
+  const bindingsQuery = useQuery({
+    key: () => ['bot-connectors', botId.value],
+    query: async () => {
+      const { data } = await getBotsByBotIdConnectors({
+        path: { bot_id: botId.value },
+        throwOnError: true,
+      })
+      return data.items ?? []
+    },
+    enabled,
+  })
+
+  const byAlias = computed(() => {
+    const catalog = new Map(
+      (catalogQuery.data.value ?? []).map(item => [item.type ?? '', item]),
+    )
+    const out = new Map<string, ConnectorIdentity>()
+    for (const binding of bindingsQuery.data.value ?? []) {
+      const alias = binding.alias?.trim() ?? ''
+      if (!alias) continue
+      const type = binding.connector_type?.trim() ?? ''
+      const metadata = type ? catalog.get(type) : undefined
+      out.set(alias, {
+        alias,
+        name: metadata?.name?.trim() || type || alias,
+        iconUrl: metadata?.icon_url?.trim() ?? '',
+      })
+    }
+    return out
+  })
+
+  const lookup = computed<ConnectorLookup>(() => {
+    const map = byAlias.value
+    if (map.size === 0) return emptyLookup
+    return (toolName: string) => {
+      const alias = connectorAliasOf(toolName.trim())
+      if (!alias) return null
+      return map.get(alias) ?? null
+    }
+  })
+
+  provide(connectorLookupKey, lookup)
+  return lookup
+}
+
+/**
+ * Tool rows rendered outside a chat pane (or before the bindings resolve) get a
+ * lookup that finds nothing, so they simply draw no logo.
+ */
+export function useConnectorLogos(): ComputedRef<ConnectorLookup> {
+  const provided = hasInjectionContext() ? inject(connectorLookupKey, null) : null
+  return provided ?? computed(() => emptyLookup)
+}


### PR DESCRIPTION
## 问题

Connector（Connect-It）的工具调用在聊天里只是一串 `notion__notion-search`——工具名前缀是唯一的来源线索，而流程收起后的概览（「5 步」）连这点线索都没有，恰恰那里才是读者唯一能看到「这一段够到了哪些外部系统」的地方。

## 做法

Connect-It 把每个 connector 工具命名为 `<alias>__<tool>`（其 Go SDK 明确写了 `github` 暴露为 `github__search_repositories`），所以工具名里带的是**绑定的 alias**，不是 connector type。

- 按**第一个** `__` 切出 alias → 匹配该 bot 的 connector 绑定 → 取 catalog 里对应 type 的 `icon_url`。前缀匹配不到任何绑定就什么都不画，所以原生工具和用单下划线的 MCP 联邦工具不会误命中。
- 用 alias（而非 type）做键，同一类型的两个绑定（`notion` / `notion-2`）保持为两个独立标记。
- **单条工具行**：logo 放在动作文字左边。
- **收起后的概览行**：显示这一段用到的**全部**去重 connector，按首次调用顺序排列。

解析在 chat pane 里做一次后 provide 下去，而不是几百条工具行各查一次。两个查询复用 Bot 设置页 Connectors 的 query key，所以通常直接命中缓存——冷刷新时命中持久化缓存。

logo 尺寸取 `1em`，跟随所在行字号：工具行有两级字号（顶层与 process capsule 内），写死尺寸会在其中一级显得过大。catalog 没有配图的 connector 退化为通用 plug 图标，行不会静默丢掉「这来自 Connector」这个信号。

## 验证

- `connectorAliasOf` 单测 4 条：正常 alias、`notion__notion__fetch` 只切首个分隔符、原生工具名不误判、`__orphan` 不产生空 alias。
- ESLint / vue-tsc / `scripts/check-ui-contract.mjs` 对本次改动文件均无新增告警。
- 用运行中的 dev Vite 确认 6 个文件全部编译通过。
- 顺带核对了本地 Connect-It catalog（112 项）：图标是 simpleicons / iconify 的 SVG，单色品牌被钉成浅灰（Notion 为 `.../notion/_/e5e5e5`），彩色品牌保留原色——深色主题下显示正常。浅色主题下这类浅灰图标会偏淡，但这是 catalog 侧取色，Bot 设置的 Connectors 页早已是同样表现，本 PR 未引入新问题。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
