### PR TITLE
fix(desktop): preserve native material behind settings footer

### DIFF
--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -132,9 +132,13 @@
       />
     </div>
 
-    <!-- Settings, pinned below the scrollable panel. Solid bg + z-index so a
-         short viewport never paints list rows over the footer. -->
-    <div class="relative z-1 shrink-0 bg-sidebar px-2 pt-1 pb-2">
+    <!-- Settings, pinned below the scrollable panel. Solid bg + z-index keep
+         list rows behind the footer on Web; the native-surface hook lets macOS
+         Desktop expose the same sidebar material as the surrounding rail. -->
+    <div
+      class="relative z-1 shrink-0 bg-sidebar px-2 pt-1 pb-2"
+      data-native-sidebar-surface
+    >
       <SidebarNavButton
         :active="isSettingsActive"
         :aria-label="t('sidebar.settings')"


### PR DESCRIPTION
## Summary

- keep the Settings footer's solid Web background and stacking behavior
- mark the footer as a native sidebar surface so macOS Desktop exposes the surrounding vibrancy material
- leave Web, Windows, and Linux rendering unchanged because the hook is consumed only by Desktop's macOS-specific stylesheet

## Root cause

The sidebar pagination refactor added an opaque `bg-sidebar` to prevent short viewports from painting session rows over the Settings footer. That was correct for Web, but it bypassed the native sidebar surface contract on macOS Desktop, making the footer render as a separate dark rectangle over the translucent rail.

## Validation

- `pnpm exec eslint apps/web/src/components/sidebar/index.vue`
- `pnpm --filter @memohai/desktop typecheck`
- `pnpm --filter @memohai/desktop build:dir`
- repository pre-commit Go lint and Go test hooks
- `git diff --check`
- `pnpm --filter @memohai/web typecheck` still fails on unrelated existing errors elsewhere in Web and the UI submodule; it reports no error in the changed file
