### PR TITLE
fix(storage): read workspace files by absolute path in containerfs

### DIFF
--- a/internal/storage/providers/containerfs/provider.go
+++ b/internal/storage/providers/containerfs/provider.go
@@ -98,7 +98,12 @@ func (p *Provider) OpenContainerFile(ctx context.Context, botID, containerPath s
 	if err != nil {
 		return nil, fmt.Errorf("get client: %w", err)
 	}
-	return client.ReadRaw(ctx, subPath)
+	// Read with the absolute container path, not the stripped subPath: workspace
+	// clients resolve relative paths against different bases (the in-container
+	// bridge joins its /data workdir, but the runtime-worker chain resolves
+	// against the sandbox home), so a relative subPath reads the wrong file
+	// anywhere off the bridge. Absolute paths resolve consistently everywhere.
+	return client.ReadRaw(ctx, filepath.Clean(containerPath))
 }
 
 // ListPrefix returns all keys under the given routing prefix.

--- a/internal/storage/providers/containerfs/provider_test.go
+++ b/internal/storage/providers/containerfs/provider_test.go
@@ -2,7 +2,16 @@ package containerfs
 
 import (
 	"context"
+	"io"
+	"net"
 	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/memohai/memoh/internal/workspace/bridge"
+	pb "github.com/memohai/memoh/internal/workspace/bridgepb"
 )
 
 func TestParseRoutingKey(t *testing.T) {
@@ -74,5 +83,86 @@ func TestSplitRoutingKey(t *testing.T) {
 	botID2, sub2 := splitRoutingKey("nosubpath")
 	if botID2 != "" || sub2 != "nosubpath" {
 		t.Errorf("splitRoutingKey single: got (%q, %q)", botID2, sub2)
+	}
+}
+
+// recordingReadServer captures the exact path the client sends over the wire.
+type recordingReadServer struct {
+	pb.UnimplementedContainerServiceServer
+	path string
+	data []byte
+}
+
+func (s *recordingReadServer) ReadRaw(req *pb.ReadRawRequest, stream pb.ContainerService_ReadRawServer) error {
+	s.path = req.GetPath()
+	if len(s.data) > 0 {
+		return stream.Send(&pb.DataChunk{Data: s.data})
+	}
+	return nil
+}
+
+type staticClientProvider struct{ client *bridge.Client }
+
+func (p staticClientProvider) MCPClient(context.Context, string) (*bridge.Client, error) {
+	return p.client, nil
+}
+
+func newRecordingClient(t *testing.T, server pb.ContainerServiceServer) *bridge.Client {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	pb.RegisterContainerServiceServer(srv, server)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		srv.Stop()
+		<-done
+	})
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return bridge.NewClientFromConn(conn)
+}
+
+// OpenContainerFile must send the absolute container path to the workspace
+// client. Clients resolve relative paths against different bases (the bridge
+// joins its /data workdir; the runtime-worker chain resolves against the
+// sandbox home), so stripping /data and sending a relative subPath reads the
+// wrong file anywhere off the bridge — this regressed outbound attachment
+// ingestion for runtime-worker workspaces.
+func TestProvider_OpenContainerFileSendsAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	server := &recordingReadServer{data: []byte("png-bytes")}
+	p := New(staticClientProvider{client: newRecordingClient(t, server)})
+
+	rc, err := p.OpenContainerFile(context.Background(), "bot-1", "/data/repro935-big.png")
+	if err != nil {
+		t.Fatalf("OpenContainerFile: %v", err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if string(got) != "png-bytes" {
+		t.Errorf("content = %q, want %q", got, "png-bytes")
+	}
+	if server.path != "/data/repro935-big.png" {
+		t.Errorf("client received path %q, want absolute %q", server.path, "/data/repro935-big.png")
 	}
 }


### PR DESCRIPTION
## Problem

Outbound attachments (image/file sent by a bot via the `send` tool) lost their preview and the card silently vanished at settle — reported in #935 on Cloud (Cloud Computer / e2b workspaces).

Root cause: `containerfs.OpenContainerFile` stripped the `/data` prefix and passed a **relative** subPath to `ReadRaw`. Workspace clients resolve relative paths against different bases:

- the in-container **bridge** joins its `/data` workdir → OSS deployments happened to read the right file;
- the **runtime-worker chain** (Cloud Computer / e2b) resolves against the sandbox **home** → read `/home/user/<name>` instead of `/data/<name>`, failed, and the failure was swallowed warn-only (`ws ingest container file failed`). The attachment event then carried no `content_hash`, so asset extraction silently dropped it and the settled history had no attachment record.

Reproduced end-to-end on a local Cloud dev stack (memoh + runtime-worker + e2b) with the exact production symptom; server log confirmed the wrong path:

```
WARN ws ingest container file failed path=/data/repro935-big.png
  error="open workspace file: primary provider: path '/home/user/repro935-big.png' does not exist"
```

## Fix

One line: after the existing validation (must live under `/data`, no `..`), pass the **absolute** container path to `ReadRaw` instead of the stripped relative subPath. Every client resolves absolute paths consistently (bridge maps via `dataMount`, e2b reads absolute directly). The non-`/data` branch of the same function already passed absolute paths — this makes the `/data` branch consistent with it.

Also adds a bufconn-level regression test asserting the exact path sent over the wire is absolute (verified red → green).

## Verification

- Regression test fails on the old code (`client received path "repro935-big.png"`) and passes with the fix.
- `go test ./...` green.
- End-to-end on the local Cloud stack with the fix: ingestion log flips to `ws attachment_delta: ingested attachments count=1`, the WS frame carries `content_hash`, `bot_history_message_assets` links the asset with the correct `tool_call_id` anchor, and the image preview renders and survives settle (page reload).

## Test plan

- [x] `go test ./internal/storage/providers/containerfs/`
- [x] `go test ./...` (pre-commit)
- [x] Human QA: image preview happy path confirmed on local Cloud dev stack (e2b workspace) with this change
- [ ] Human QA on production after Cloud picks up this change

Human QA note: the happy path (bot sends workspace image → preview renders and persists after reload) was confirmed by a human on the local Cloud dev stack with this exact one-line change applied to the Cloud submodule. This PR head carries the same change against OSS main (method name `MCPClient` vs `WorkspaceClient` in the Cloud fork) plus the regression test.