### PR TITLE
fix(web): keep settled history when idle runtime snapshots carry no content

### DIFF
--- a/apps/web/src/store/chat/runtime-projection.test.ts
+++ b/apps/web/src/store/chat/runtime-projection.test.ts
@@ -267,3 +267,33 @@ describe('runtime projection', () => {
     expect(isRuntimeRunActive('lost')).toBe(false)
   })
 })
+
+describe('idle settled run projection', () => {
+  it('emits no assistant turn for a settled run without streamed content', () => {
+    const state = reduceRuntimeProjection(createEmptyRuntimeProjection(), snapshot(runView({
+      status: 'completed',
+      messages: null as unknown as RuntimeCurrentRunView['messages'],
+    })))
+
+    expect(state.transcript.turns.map(turn => turn.role)).toEqual(['user'])
+  })
+
+  it('emits an empty slice when the settled run also lacks a user turn', () => {
+    const state = reduceRuntimeProjection(createEmptyRuntimeProjection(), snapshot(runView({
+      status: 'completed',
+      messages: null as unknown as RuntimeCurrentRunView['messages'],
+      request_user_turn: undefined,
+    })))
+
+    expect(state.transcript.turns).toEqual([])
+  })
+
+  it('still projects the assistant turn for an active run without content yet', () => {
+    const state = reduceRuntimeProjection(createEmptyRuntimeProjection(), snapshot(runView({
+      status: 'running',
+      messages: [],
+    })))
+
+    expect(state.transcript.turns.map(turn => turn.role)).toEqual(['user', 'assistant'])
+  })
+})

--- a/apps/web/src/store/chat/runtime-projection.ts
+++ b/apps/web/src/store/chat/runtime-projection.ts
@@ -121,21 +121,30 @@ function transcriptForRun(run: RuntimeCurrentRunView | null): RuntimeTranscriptS
       id: `runtime:${turnId}:user`,
     })
   }
-  turns.push({
-    turn_id: turnId,
-    role: 'assistant',
-    id: `runtime:${turnId}:assistant`,
-    timestamp: run.started_at,
-    messages: run.messages.map(cloneUIMessage),
-  })
-  if (run.error && !run.messages.some(message => message.type === 'error')) {
-    turns[turns.length - 1] = {
-      ...turns[turns.length - 1]!,
+  // A settled run with no streamed content has nothing to project. Emitting the
+  // assistant shell here would let applyRuntimeTranscript's merge overwrite the
+  // settled database turn's blocks with this empty list: once the run ends the
+  // database history is authoritative, and idle snapshots arrive with
+  // messages:null (e.g. after a backend restart, whose ledger view carries no
+  // streamed blocks).
+  const projectsAssistantContent = isRuntimeRunActive(run.status) || run.messages.length > 0 || Boolean(run.error)
+  if (projectsAssistantContent) {
+    turns.push({
+      turn_id: turnId,
       role: 'assistant',
-      messages: [
-        ...run.messages.map(cloneUIMessage),
-        { id: nextMessageId(run.messages), type: 'error', content: run.error },
-      ],
+      id: `runtime:${turnId}:assistant`,
+      timestamp: run.started_at,
+      messages: run.messages.map(cloneUIMessage),
+    })
+    if (run.error && !run.messages.some(message => message.type === 'error')) {
+      turns[turns.length - 1] = {
+        ...turns[turns.length - 1]!,
+        role: 'assistant',
+        messages: [
+          ...run.messages.map(cloneUIMessage),
+          { id: nextMessageId(run.messages), type: 'error', content: run.error },
+        ],
+      }
     }
   }
   return {

--- a/apps/web/src/store/chat/transcript.test.ts
+++ b/apps/web/src/store/chat/transcript.test.ts
@@ -572,3 +572,38 @@ describe('chat transcript controller', () => {
     expect(transcript.hasLoadedOlder.value).toBe(false)
   })
 })
+
+describe('idle runtime snapshot reconciliation', () => {
+  // Regression: an idle snapshot (settled run, no streamed content — the shape
+  // every runtime_snapshot takes after a backend restart) must not erase the
+  // settled database turn's blocks. The projection emits no assistant turn for
+  // such runs, so the merge keeps the settled twin intact.
+  it('keeps settled blocks when the idle slice carries only the user turn', () => {
+    const { transcript } = makeTranscript()
+    transcript.replaceMessages([
+      rawUser('user-1'),
+      rawAssistant('assistant-1', [
+        { id: 0, type: 'reasoning', content: 'thinking' },
+        { id: 1, type: 'text', content: 'answer' },
+      ]),
+    ], 'session-1')
+
+    transcript.applyRuntimeTranscript({
+      runId: 'run-1',
+      turnId: 'turn-user-1',
+      status: 'completed',
+      operation: null,
+      turns: [{
+        id: 'runtime:turn-user-1:user',
+        turn_id: 'turn-user-1',
+        role: 'user',
+        text: 'hello',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      }],
+      streaming: false,
+    })
+
+    const assistant = transcript.messages.find(turn => turn.role === 'assistant') as ChatAssistantTurn
+    expect(assistant.messages.map(block => block.type)).toEqual(['reasoning', 'text'])
+  })
+})


### PR DESCRIPTION
## Problem

Switching between chat sessions could blank the assistant half of a transcript: the user prompt kept rendering while every assistant block (reasoning, tool calls, text, attachments) vanished — until a full page reload. Reproduced on production (app.memoh.net) with the same fingerprint: happens only after switching sessions back and forth, only the assistant half disappears, and Cmd+R always heals it.

Root cause chain:

1. When the live session-runtime backend no longer holds a session's state (backend restart, or the 24h `session_runtime.state_ttl` expiring for an old session), `hydrateSnapshotFromLedger` rebuilds the `runtime_snapshot` from the PostgreSQL ledger — identity and status only, by design: `status: completed` with `messages: null` (`null` means "content not held", as opposed to `[]` meaning "content empty").
2. `transcriptForRun` projected that into a slice containing an assistant turn with an **empty** message list.
3. `applyRuntimeTranscript`'s merge does `Object.assign(current, next, { id: renderId })`, so the empty shell overwrote the settled database turn — blocks wiped.
4. Why only revisits break, and why they never self-heal: on a **first** subscription the snapshot arrives with `previousRun = null`, so `handleProjection` falls through to `refreshCurrentSession` and the database page repairs the wipe. On a **revisit**, `runtime-client` keeps the projection cache across unsubscribe, so the re-subscribe snapshot carries the same settled run as `previousRun` and hits the `previousRun.run_id === currentRun.run_id && !wasActive` short-circuit — returning before any refresh, after the destructive `applyRuntimeTranscript` already ran. Wiped, and nothing comes to repair it. A full reload clears the cache and walks the first-subscription (self-healing) path again, which is why Cmd+R always "fixes" it.

Reproduced deterministically on the Cloud dev stack: open session A (renders fully), switch to B (renders fully), switch back to A → only the user prompt renders; store dump shows the assistant turn present with `messages: []` while the REST response for the same fetch returns all blocks.

## Why the fix is frontend-only

The backend side was investigated before settling on this fix. Emitting identity-only snapshots for runs the live backend no longer holds is **intentional and spec-mandated** (SR-OBS-001 in `docs/design/session-runtime-requirements.md`): a reconnecting client must learn the run's identity, status, pending decisions, and `lost` state from any server instance. `hydrateSnapshotFromLedger`'s own comment rules out re-seeding content ("the snapshot would stop being a report and start being a claim"), and suppressing the snapshot would break `lost` reporting and cross-device consistency (SR-OBS-003). The producer is honest; the bug is that the consumer treated a status report as a content claim. Making the consumer respect the protocol's semantics — settled content is owned by the database; runtime frames only carry content while a run is live — is the correct fix on both sides of the contract.

## Fix

One guard in `transcriptForRun`: a settled run with no streamed content and no error has nothing to project, so no assistant turn is emitted for it. The database history is authoritative for settled runs; the runtime slice keeps its twin semantics for active runs (shells preserved), and runs with an error still project the error block. Because the guard sits at the projection's single minting point, it covers every consumer path — first subscription, revisit, and buffered replay — including the no-heal short-circuit above.

## Verification

- New regression tests: slice shape (no assistant turn for idle settled runs; empty slice when no user turn either; active runs keep shells) + merge behavior (settled blocks survive an idle user-only slice). Verified red → green.
- Full `apps/web` vitest suite green (33/33 in the touched files).
- End-to-end on the Cloud dev stack (e2b workspace, backend restarted so all snapshots are idle): before the fix, A→B→A wiped the second session's assistant turn (store-verified 0 blocks); after the fix, A→B→A keeps both transcripts intact (11 and 9 blocks), and the previously-lost attachment preview renders.
- Human QA passed: the reporter reproduced the original wipe on production, then walked the same multi-tab session-switching flow on a local stack serving this fix (verified serving the patched file) — assistant messages persist.

## Follow-ups (not in this PR)

- The `messages: null` vs `messages: []` distinction is the contract hinge, but on the Go side it rests only on the zero value of `CurrentRunView.Messages` in `hydrateSnapshotFromLedger`. A backend test pinning "hydrated snapshots carry null messages" would keep it from being silently flattened later.
- Narrow uncovered case (never observed): a hydrated `errored` run carries `error` but no messages; the guard lets it project an error-only shell, which could still overwrite a fuller settled turn.

## Test plan

- [x] `vitest run src/store/chat/runtime-projection.test.ts src/store/chat/transcript.test.ts` (red → green)
- [x] End-to-end A→B→A session switching on the local Cloud dev stack, store state + visual check
- [x] Human QA on the fixed stack (multi-tab session switching, the production repro flow)
