### PR TITLE
fix(desktop): preserve translucent sidebar footer

### DIFF
--- a/apps/web/src/components/sidebar/index.vue
+++ b/apps/web/src/components/sidebar/index.vue
@@ -132,9 +132,13 @@
       />
     </div>
 
-    <!-- Settings, pinned below the scrollable panel. Solid bg + z-index so a
-         short viewport never paints list rows over the footer. -->
-    <div class="relative z-1 shrink-0 bg-sidebar px-2 pt-1 pb-2">
+    <!-- Settings, pinned below the scrollable panel. Web keeps an opaque bg +
+         z-index so a short viewport never paints list rows over the footer;
+         macOS clears that fill to expose the native sidebar material. -->
+    <div
+      class="relative z-1 shrink-0 bg-sidebar px-2 pt-1 pb-2"
+      data-native-sidebar-surface
+    >
       <SidebarNavButton
         :active="isSettingsActive"
         :aria-label="t('sidebar.settings')"


### PR DESCRIPTION
## Summary

- Mark the pinned Settings footer as a native sidebar surface on macOS.
- Preserve the existing opaque `bg-sidebar` fallback for Web, Windows, and Linux.

## Root cause

The main sidebar and header opted into the macOS native material contract, but the pinned Settings footer retained its own opaque `bg-sidebar` fill. That child fill covered the translucent parent and rendered as a dark block.

## Impact

The Settings row now exposes the same native material as the rest of the sidebar on macOS without changing non-macOS rendering or interaction behavior.

## Validation

- `pnpm exec eslint apps/web/src/components/sidebar/index.vue`
- `pnpm --filter @memohai/desktop typecheck:web`
- `pnpm --filter @memohai/desktop exec electron-vite build`
- Repository pre-commit hooks, including Go tests and staged ESLint
- `git diff --check`

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.