### PR TITLE
feat(context): unified context budget plan across all five modes

### DIFF
--- a/apps/web/src/composables/api/useChat.types.ts
+++ b/apps/web/src/composables/api/useChat.types.ts
@@ -354,6 +354,7 @@ export interface UIStreamErrorEvent {
   run_id?: string
   invocation_id?: string
   session_id?: string
+  code?: string
   message: string
   feedback?: unknown
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -124,6 +124,10 @@
       "reasoning_effort_invalid": "Reasoning level \"{effort}\" is not supported by the selected chat model.",
       "reasoning_options_unavailable": "The chat model's reasoning options could not be resolved. Please try again."
     },
+    "context": {
+      "budget_unsatisfied": "The model context window is too small for this request.",
+      "protected_overflow": "Required context exceeds the model context budget."
+    },
     "profile": {
       "request_invalid": "The profile update request is invalid.",
       "title_model_invalid": "The selected title model is unavailable or is not a chat model.",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -121,6 +121,10 @@
       "reasoning_effort_invalid": "選択したチャットModelは推論レベル「{effort}」に対応していません。",
       "reasoning_options_unavailable": "チャットModelの推論オプションを確認できませんでした。しばらくしてからもう一度お試しください。"
     },
+    "context": {
+      "budget_unsatisfied": "モデルのコンテキストウィンドウが不足しているため、このリクエストを処理できません。",
+      "protected_overflow": "必須コンテキストがモデルのコンテキスト予算を超えています。"
+    },
     "profile": {
       "request_invalid": "プロフィール更新リクエストが無効です。",
       "title_model_invalid": "選択したタイトルModelは利用できないか、チャットModelではありません。",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -124,6 +124,10 @@
       "reasoning_effort_invalid": "所选对话模型不支持推理级别“{effort}”。",
       "reasoning_options_unavailable": "暂时无法解析对话模型的推理选项，请稍后重试。"
     },
+    "context": {
+      "budget_unsatisfied": "模型上下文窗口不足，无法处理当前请求。",
+      "protected_overflow": "必要的上下文内容超出了模型上下文预算。"
+    },
     "profile": {
       "request_invalid": "个人资料更新请求无效。",
       "title_model_invalid": "所选标题模型不可用或不是聊天模型。",

--- a/apps/web/src/utils/api-error.test.ts
+++ b/apps/web/src/utils/api-error.test.ts
@@ -164,6 +164,23 @@ describe('resolveApiErrorMessage', () => {
     }, 'fallback')).toBe(expected)
   })
 
+  it.each([
+    ['context.budget_unsatisfied', 'en', 'The model context window is too small for this request.'],
+    ['context.budget_unsatisfied', 'zh', '模型上下文窗口不足，无法处理当前请求。'],
+    ['context.budget_unsatisfied', 'ja', 'モデルのコンテキストウィンドウが不足しているため、このリクエストを処理できません。'],
+    ['context.protected_overflow', 'en', 'Required context exceeds the model context budget.'],
+    ['context.protected_overflow', 'zh', '必要的上下文内容超出了模型上下文预算。'],
+    ['context.protected_overflow', 'ja', '必須コンテキストがモデルのコンテキスト予算を超えています。'],
+  ])('localizes %s for %s', (code, language, expected) => {
+    locale = language
+
+    expect(resolveApiErrorMessage({
+      type: 'error',
+      code,
+      message: 'backend English fallback',
+    }, 'fallback')).toBe(expected)
+  })
+
   it('keeps unknown codes as open strings and uses their safe fallback', () => {
     const error = {
       code: 'future.new_condition',

--- a/internal/agent/application/resolve_result.go
+++ b/internal/agent/application/resolve_result.go
@@ -7,7 +7,8 @@ import "github.com/memohai/memoh/internal/agent/runtime/native"
 // Produced by application.Service.ResolveRunConfig and consumed by the turn
 // runtime adapters.
 type ResolveRunConfigResult struct {
-	RunConfig   native.RunConfig
-	ModelID     string // database UUID of the selected model
-	RuntimeType string
+	RunConfig              native.RunConfig
+	ModelID                string // database UUID of the selected model
+	RuntimeType            string
+	ContextBudgetMaxTokens int
 }

--- a/internal/agent/application/resolver_trigger_test.go
+++ b/internal/agent/application/resolver_trigger_test.go
@@ -1,0 +1,186 @@
+package application
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
+	turnpkg "github.com/memohai/memoh/internal/agent/turn"
+	"github.com/memohai/memoh/internal/contextview"
+)
+
+const triggerTestContextWindow = 128000
+
+type triggerCaptureProvider struct {
+	mu     sync.Mutex
+	params sdk.GenerateParams
+}
+
+func (*triggerCaptureProvider) Name() string { return "trigger-capture" }
+
+func (*triggerCaptureProvider) ListModels(context.Context) ([]sdk.Model, error) { return nil, nil }
+
+func (*triggerCaptureProvider) Test(context.Context) *sdk.ProviderTestResult {
+	return &sdk.ProviderTestResult{Status: sdk.ProviderStatusOK}
+}
+
+func (*triggerCaptureProvider) TestModel(context.Context, string) (*sdk.ModelTestResult, error) {
+	return &sdk.ModelTestResult{Supported: true}, nil
+}
+
+func (p *triggerCaptureProvider) DoGenerate(_ context.Context, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+	p.mu.Lock()
+	p.params = params
+	p.mu.Unlock()
+	return &sdk.GenerateResult{Text: "done", FinishReason: sdk.FinishReasonStop}, nil
+}
+
+func (p *triggerCaptureProvider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sdk.StreamResult, error) {
+	result, err := p.DoGenerate(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	ch := make(chan sdk.StreamPart, 4)
+	go func() {
+		defer close(ch)
+		ch <- &sdk.StartPart{}
+		ch <- &sdk.StartStepPart{}
+		ch <- &sdk.FinishStepPart{FinishReason: result.FinishReason}
+		ch <- &sdk.FinishPart{FinishReason: result.FinishReason}
+	}()
+	return &sdk.StreamResult{Stream: ch}, nil
+}
+
+func (p *triggerCaptureProvider) lastParams() sdk.GenerateParams {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.params
+}
+
+type triggerViewRecorder struct {
+	mu  sync.Mutex
+	out agentpkg.RunConfig
+}
+
+func (v *triggerViewRecorder) apply(ctx context.Context, cfg agentpkg.RunConfig) (agentpkg.RunConfig, error) {
+	out, err := contextview.ProviderRunConfigApplier(slog.Default())(ctx, cfg)
+	v.mu.Lock()
+	v.out = out
+	v.mu.Unlock()
+	return out, err
+}
+
+func (v *triggerViewRecorder) snapshot() agentpkg.RunConfig {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.out
+}
+
+func triggerResolvedRunConfig(provider sdk.Provider, rawQuery string, now time.Time, sessionType string) agentpkg.RunConfig {
+	headerified := turnpkg.FormatUserHeader(turnpkg.UserMessageHeaderInput{
+		DisplayName: "User",
+		Time:        now,
+	}, rawQuery)
+	return agentpkg.RunConfig{
+		Model:                     &sdk.Model{ID: "trigger-model", Provider: provider, Type: sdk.ModelTypeChat},
+		Query:                     headerified,
+		ContextScope:              contextfrag.Scope{BotID: "bot-1", ChatID: "bot-1"},
+		ContextToolExchangePolicy: &contextfrag.ToolExchangePolicy{MinMessages: 10},
+		ContextLifecycle:          contextfrag.NewLifecycleHolder(),
+		ContextBudgetMaxTokens:    triggerTestContextWindow,
+		SessionType:               sessionType,
+	}
+}
+
+func runTriggerPromptPipeline(t *testing.T, cfg agentpkg.RunConfig, provider *triggerCaptureProvider) (agentpkg.RunConfig, sdk.GenerateParams) {
+	t.Helper()
+	ctx := context.Background()
+	service := &Service{logger: slog.Default()}
+	cfg = service.prepareRunConfig(ctx, cfg)
+
+	recorder := &triggerViewRecorder{}
+	agent := agentpkg.New(agentpkg.Deps{ContextViewApplier: recorder.apply})
+	if _, err := agent.Generate(ctx, cfg); err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	return recorder.snapshot(), provider.lastParams()
+}
+
+func triggerMessageText(message sdk.Message) string {
+	for _, part := range message.Content {
+		if text, ok := part.(sdk.TextPart); ok {
+			return text.Text
+		}
+	}
+	return ""
+}
+
+func assertTriggerCurrentRequest(t *testing.T, seen agentpkg.RunConfig, params sdk.GenerateParams, prompt string) {
+	t.Helper()
+
+	current := 0
+	for _, frag := range seen.ContextFrags {
+		if frag.Kind == contextfrag.KindCurrentUserMessage {
+			current++
+		}
+		if frag.Slot == contextfrag.SlotHistory {
+			t.Fatalf("trigger prompt became history: %#v", frag)
+		}
+	}
+	if current != 1 {
+		t.Fatalf("current fragments = %d, want exactly one: %#v", current, seen.ContextFrags)
+	}
+
+	if len(seen.Messages) != 1 || seen.Messages[0].Role != sdk.MessageRoleUser || triggerMessageText(seen.Messages[0]) != prompt {
+		t.Fatalf("rendered messages = %#v, want exactly the rich trigger prompt", seen.Messages)
+	}
+	if len(params.Messages) != 1 || params.Messages[0].Role != sdk.MessageRoleUser || triggerMessageText(params.Messages[0]) != prompt {
+		t.Fatalf("provider messages = %#v, want exactly the rich trigger prompt", params.Messages)
+	}
+
+	plan := seen.ContextManifest.BudgetPlan
+	if plan == nil || plan.Window != triggerTestContextWindow {
+		t.Fatalf("budget plan = %#v, want active %d-token window", plan, triggerTestContextWindow)
+	}
+	wantCurrentCost := contextfrag.ProviderBudgetTokensFromBytes(len(prompt))
+	if plan.CurrentRequestCost != wantCurrentCost {
+		t.Fatalf("CurrentRequestCost = %d, want conservative prompt cost %d", plan.CurrentRequestCost, wantCurrentCost)
+	}
+}
+
+func TestTriggerScheduleAttachesPromptAsCurrentUserMessage(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 5, 9, 0, 0, 0, time.UTC)
+	schedulePrompt := agentpkg.GenerateSchedulePrompt(agentpkg.Schedule{
+		ID:      "sched-1",
+		Name:    "daily digest",
+		Command: "summarize inbox",
+	})
+
+	provider := &triggerCaptureProvider{}
+	cfg := triggerResolvedRunConfig(provider, "summarize inbox", now, sessionmode.Schedule)
+	cfg = attachCurrentTurnPrompt(cfg, schedulePrompt)
+
+	seen, params := runTriggerPromptPipeline(t, cfg, provider)
+	assertTriggerCurrentRequest(t, seen, params, schedulePrompt)
+}
+
+func TestTriggerHeartbeatAttachesPromptAsCurrentUserMessage(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 5, 9, 0, 0, 0, time.UTC)
+	heartbeatPrompt := agentpkg.GenerateHeartbeatPrompt(30, "", now, "")
+
+	provider := &triggerCaptureProvider{}
+	cfg := triggerResolvedRunConfig(provider, "heartbeat", now, sessionmode.Heartbeat)
+	cfg = attachCurrentTurnPrompt(cfg, heartbeatPrompt)
+
+	seen, params := runTriggerPromptPipeline(t, cfg, provider)
+	assertTriggerCurrentRequest(t, seen, params, heartbeatPrompt)
+}

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -331,6 +331,35 @@ func runIDForChatRequest(admittedRunID string) string {
 	return uuid.NewString()
 }
 
+func contextBudgetFromChatModel(chatModel models.GetResponse) int {
+	return chatModel.Config.ContextBudgetMaxTokens()
+}
+
+func markRequiredHistoryMessageCurrent(cfg *native.RunConfig, requiredMessageID string) {
+	if cfg == nil {
+		return
+	}
+	cfg.ContextCurrentUserMessageIndex = nil
+	requiredMessageID = strings.TrimSpace(requiredMessageID)
+	if requiredMessageID == "" {
+		return
+	}
+	for index, sourceMessageID := range cfg.ForkContextSourceMessageIDs {
+		if strings.TrimSpace(sourceMessageID) != requiredMessageID {
+			continue
+		}
+		if index >= len(cfg.Messages) || cfg.Messages[index].Role != sdk.MessageRoleUser {
+			return
+		}
+		cfg.ContextCurrentUserMessageIndex = intPointer(index)
+		return
+	}
+}
+
+func defaultToolExchangePolicy() *contextfrag.ToolExchangePolicy {
+	return contextfrag.DefaultToolExchangePolicy()
+}
+
 // resolve builds the run context for one turn and returns the effective
 // request alongside it. Resolution fills in defaults the caller's copy does not
 // have — a direct turn on a subagent thread learns its session type, pinned
@@ -405,10 +434,8 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 		}
 	}
 
-	contextTokenBudget := 0
-	if chatModel.Config.ContextWindow != nil && *chatModel.Config.ContextWindow > 0 {
-		contextTokenBudget = *chatModel.Config.ContextWindow
-	}
+	contextTokenBudget := contextBudgetFromChatModel(chatModel)
+	runCfg.ContextBudgetMaxTokens = contextTokenBudget
 
 	var messages []ModelMessage
 	var historyRecords []historyfrag.HistoryRecord
@@ -477,6 +504,7 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 		// exactly as parent-driven subagent tasks assemble it.
 		messages, currentMessageIndex = prependContextMessages(forkContext, messages, currentMessageIndex)
 	}
+	historyMessageCount := len(messages)
 	if notice := s.currentWorkspaceContextMessage(ctx, req); notice != nil {
 		messages = append(messages, *notice)
 	}
@@ -491,11 +519,20 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 	if !usePipeline && !req.ReusePersistedUserMessage {
 		messages = append(messages, reqMessages...)
 	}
+	trimmableMessages := normalizedContextPrefixLength(messages, historyMessageCount)
 	messages, currentMessageIndex, memoryMessageIndex = normalizeContextMessages(
 		messages,
 		currentMessageIndex,
 		memoryMessageIndex,
 	)
+	runCfg.ContextHistoryTokenEstimates = make([]int, len(messages))
+	for index := range messages {
+		runCfg.ContextHistoryTokenEstimates[index] = estimateMessageTokens(messages[index])
+	}
+	runCfg.ContextTrimmableMessages = min(trimmableMessages, len(messages))
+	if runCfg.ContextToolExchangePolicy == nil {
+		runCfg.ContextToolExchangePolicy = defaultToolExchangePolicy()
+	}
 
 	displayName := s.resolveDisplayName(ctx, req)
 	mergedAttachments := s.routeAndMergeAttachments(ctx, chatModel, req)
@@ -531,6 +568,8 @@ func (s *Service) resolve(ctx context.Context, req ChatRequest) (resolvedContext
 	runCfg.ContextMemoryMessageIndex = memoryMessageIndex
 	if usePipeline {
 		runCfg.ContextCurrentUserMessageIndex = currentMessageIndex
+	} else if req.ReusePersistedUserMessage {
+		markRequiredHistoryMessageCurrent(&runCfg, req.RequiredHistoryMessageID)
 	}
 	// When using the pipeline the user message is already in the RC;
 	// don't send it to the LLM again. headerifiedQuery is still kept
@@ -1142,11 +1181,14 @@ func (s *Service) ResolveRunConfig(ctx context.Context, botID, sessionID, channe
 		return ResolveRunConfigResult{}, err
 	}
 
+	contextBudget := contextBudgetFromChatModel(chatModel)
+	cfg.ContextBudgetMaxTokens = contextBudget
 	cfg = s.prepareRunConfig(ctx, cfg)
 	return ResolveRunConfigResult{
-		RunConfig:   cfg,
-		ModelID:     chatModel.ID,
-		RuntimeType: runtimeType,
+		RunConfig:              cfg,
+		ModelID:                chatModel.ID,
+		RuntimeType:            runtimeType,
+		ContextBudgetMaxTokens: contextBudget,
 	}, nil
 }
 
@@ -1298,6 +1340,20 @@ func prependContextMessages(prefix, messages []ModelMessage, trackedIndex *int) 
 		}
 	}
 	return append(prefix, messages...), trackedIndex
+}
+
+func normalizedContextPrefixLength(messages []ModelMessage, rawPrefixLength int) int {
+	if rawPrefixLength <= 0 || len(messages) == 0 {
+		return 0
+	}
+	rawPrefixLength = min(rawPrefixLength, len(messages))
+	stripTools := len(sanitizeMessages(messages)) > 10
+	prefix := sanitizeMessages(messages[:rawPrefixLength])
+	if stripTools {
+		prefix = stripToolMessages(prefix)
+	}
+	prefix = repairToolCallClosures(prefix, syntheticToolClosureError)
+	return len(prefix)
 }
 
 func remapContextMessageIndex(messages []ModelMessage, index *int, stripTools bool) *int {

--- a/internal/agent/application/service_continuation.go
+++ b/internal/agent/application/service_continuation.go
@@ -27,6 +27,12 @@ func (s *Service) prepareContinuationRunConfig(
 	loaded = projectInterruptedHistoryReasoning(loaded)
 	messages, retained, _ := trimMessagesAndRecordsByTokens(s.logger, loaded, 0)
 	messages = sanitizeMessages(messages)
+	historyEstimates := make([]int, len(messages))
+	for i := range messages {
+		historyEstimates[i] = estimateMessageTokens(messages[i])
+	}
+	base.ContextHistoryTokenEstimates = historyEstimates
+	base.ContextTrimmableMessages = len(messages)
 
 	base.ContextFrags = historyContextFragsForMessages(messages, retained)
 	// Close any tool call left open by an interrupted turn before the transcript
@@ -39,6 +45,9 @@ func (s *Service) prepareContinuationRunConfig(
 	base.Messages = modelMessagesToSDKMessages(repairToolCallClosures(nonNilModelMessages(messages), syntheticToolClosureError))
 	base.ContextCurrentUserMessageIndex = nil
 	base.ContextMemoryMessageIndex = nil
+	if base.ContextToolExchangePolicy == nil {
+		base.ContextToolExchangePolicy = defaultToolExchangePolicy()
+	}
 	base.Query = ""
 	base.LiveToolStream = eventCh != nil
 	base.CanRequestUserInput = s.canDeliverUserInputWS(eventCh)

--- a/internal/agent/application/service_continuation_test.go
+++ b/internal/agent/application/service_continuation_test.go
@@ -59,6 +59,10 @@ func TestPrepareContinuationRunConfigReplacesStaleContextAndSetsCapabilities(t *
 	if got.ContextMemoryMessageIndex != nil {
 		t.Fatalf("continuation retained stale memory index: %#v", got.ContextMemoryMessageIndex)
 	}
+	if got.ContextTrimmableMessages != len(got.Messages) || len(got.ContextHistoryTokenEstimates) != len(got.Messages) {
+		t.Fatalf("budget signals = trimmable:%d estimates:%d messages:%d",
+			got.ContextTrimmableMessages, len(got.ContextHistoryTokenEstimates), len(got.Messages))
+	}
 	for _, frag := range got.ContextSourceFrags {
 		if frag.ID == "stale-source-fragment" {
 			t.Fatalf("continuation retained stale source fragment: %#v", frag)

--- a/internal/agent/application/service_history_test.go
+++ b/internal/agent/application/service_history_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 	"time"
 
+	sdk "github.com/memohai/twilight-ai/sdk"
+
 	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
+	"github.com/memohai/memoh/internal/agent/runtime/native"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
 )
 
@@ -75,6 +78,55 @@ func TestFilterMessagesBeforeIDFailsClosedWhenCutoffIsMissing(t *testing.T) {
 	}
 	if got := filterMessagesBeforeID(records, "missing-cutoff"); len(got) != 0 {
 		t.Fatalf("missing cutoff retained history: %#v", got)
+	}
+}
+
+func TestMarkRequiredHistoryMessageCurrentUsesExactPersistedID(t *testing.T) {
+	t.Parallel()
+
+	cfg := native.RunConfig{
+		Messages: []sdk.Message{
+			sdk.UserMessage("retry request"),
+			sdk.AssistantMessage("old answer"),
+			sdk.UserMessage("newer unrelated user"),
+		},
+		ForkContextSourceMessageIDs: []string{"retry-user", "old-answer", "newer-user"},
+	}
+	markRequiredHistoryMessageCurrent(&cfg, "retry-user")
+	if cfg.ContextCurrentUserMessageIndex == nil || *cfg.ContextCurrentUserMessageIndex != 0 {
+		t.Fatalf("current index = %#v, want exact persisted request at 0", cfg.ContextCurrentUserMessageIndex)
+	}
+}
+
+func TestMarkRequiredHistoryMessageCurrentRejectsNonUserAndMissingIDs(t *testing.T) {
+	t.Parallel()
+
+	stale := 2
+	cfg := native.RunConfig{
+		Messages:                       []sdk.Message{sdk.AssistantMessage("not a request"), sdk.UserMessage("actual user")},
+		ForkContextSourceMessageIDs:    []string{"required", "other"},
+		ContextCurrentUserMessageIndex: &stale,
+	}
+	markRequiredHistoryMessageCurrent(&cfg, "required")
+	if cfg.ContextCurrentUserMessageIndex != nil {
+		t.Fatalf("non-user source ID marked current: %#v", cfg.ContextCurrentUserMessageIndex)
+	}
+	markRequiredHistoryMessageCurrent(&cfg, "missing")
+	if cfg.ContextCurrentUserMessageIndex != nil {
+		t.Fatalf("missing source ID marked current: %#v", cfg.ContextCurrentUserMessageIndex)
+	}
+}
+
+func TestNormalizedContextPrefixLengthTracksSanitizedHistory(t *testing.T) {
+	t.Parallel()
+
+	messages := []ModelMessage{
+		{Content: newTextContent("invalid history")},
+		{Role: "user", Content: newTextContent("valid history")},
+		{Role: "user", Content: newTextContent("pinned tail")},
+	}
+	if got := normalizedContextPrefixLength(messages, 2); got != 1 {
+		t.Fatalf("normalized prefix = %d, want 1", got)
 	}
 }
 

--- a/internal/agent/application/service_stream.go
+++ b/internal/agent/application/service_stream.go
@@ -55,6 +55,11 @@ func agentStreamEventError(event native.StreamEvent) error {
 	if event.Type != native.EventError {
 		return nil
 	}
+	if code := apperror.Code(strings.TrimSpace(event.Code)); code != "" {
+		if _, ok := apperror.Lookup(code); ok {
+			return apperror.New(code, nil)
+		}
+	}
 	detail := strings.TrimSpace(event.Error)
 	if detail == "" {
 		detail = "agent stream failed"
@@ -202,6 +207,7 @@ func (s *Service) StreamChat(ctx context.Context, req ChatRequest) (<-chan Strea
 		var toolCallCount int
 		var hasVisibleOutput bool
 		var terminalEventSeen bool
+		var agentStreamErr error
 		for event := range eventCh {
 			idleCancel.Reset() // each event resets the idle timer
 
@@ -215,10 +221,14 @@ func (s *Service) StreamChat(ctx context.Context, req ChatRequest) (<-chan Strea
 				if lifecycleCause == nil {
 					lifecycleCause = eventErr
 				}
+				if agentStreamErr == nil {
+					agentStreamErr = eventErr
+				}
 				s.logger.Error("agent stream error",
 					slog.String("bot_id", streamReq.BotID),
 					slog.String("chat_id", streamReq.ChatID),
 					slog.String("model_id", rc.model.ID),
+					slog.String("code", event.Code),
 					slog.String("error", event.Error),
 				)
 			}
@@ -356,6 +366,9 @@ func (s *Service) StreamChat(ctx context.Context, req ChatRequest) (<-chan Strea
 					}
 				}
 			}
+		}
+		if agentStreamErr != nil {
+			errCh <- agentStreamErr
 		}
 	}()
 	return chunkCh, errCh

--- a/internal/agent/application/service_stream_test.go
+++ b/internal/agent/application/service_stream_test.go
@@ -16,6 +16,41 @@ import (
 	"github.com/memohai/memoh/internal/settings"
 )
 
+func TestAgentStreamEventErrorConversion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-error event", func(t *testing.T) {
+		if err := agentStreamEventError(native.StreamEvent{Type: native.EventTextDelta}); err != nil {
+			t.Fatalf("agentStreamEventError() = %v, want nil", err)
+		}
+	})
+	t.Run("stable application code", func(t *testing.T) {
+		event := native.StreamEvent{
+			Type: native.EventError, Code: string(apperror.CodeContextBudgetUnsatisfied),
+			Error: "untrusted backend fallback",
+		}
+		err := agentStreamEventError(event)
+		if got := apperror.CodeOf(err); got != apperror.CodeContextBudgetUnsatisfied {
+			t.Fatalf("error code = %q, want %q", got, apperror.CodeContextBudgetUnsatisfied)
+		}
+		if err.Error() != string(apperror.CodeContextBudgetUnsatisfied) {
+			t.Fatalf("coded stream identity = %q", err)
+		}
+	})
+	t.Run("legacy detail", func(t *testing.T) {
+		err := agentStreamEventError(native.StreamEvent{Type: native.EventError, Error: " provider stopped "})
+		if err == nil || err.Error() != "provider stopped" {
+			t.Fatalf("agentStreamEventError() = %v", err)
+		}
+	})
+	t.Run("empty legacy detail", func(t *testing.T) {
+		err := agentStreamEventError(native.StreamEvent{Type: native.EventError})
+		if err == nil || err.Error() != "agent stream failed" {
+			t.Fatalf("agentStreamEventError() = %v", err)
+		}
+	})
+}
+
 type recordingMessageService struct {
 	persisted               []messagepkg.PersistInput
 	persistErr              error

--- a/internal/agent/application/service_terminal_lifecycle_test.go
+++ b/internal/agent/application/service_terminal_lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -318,7 +319,7 @@ func assertLifecycleSnapshot(t *testing.T, raw []byte, want contextfrag.Lifecycl
 	if err := json.Unmarshal(raw, &got); err != nil {
 		t.Fatal(err)
 	}
-	if got != want {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("lifecycle snapshot = %#v, want %#v", got, want)
 	}
 }

--- a/internal/agent/application/service_trigger.go
+++ b/internal/agent/application/service_trigger.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	sdk "github.com/memohai/twilight-ai/sdk"
-
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/event"
 	acpagent "github.com/memohai/memoh/internal/agent/runtime/acp"
@@ -20,6 +18,13 @@ import (
 	"github.com/memohai/memoh/internal/heartbeat"
 	"github.com/memohai/memoh/internal/schedule"
 )
+
+// attachCurrentTurnPrompt routes a trigger's rich prompt through Query so the
+// context view classifies it as the live current request rather than history.
+func attachCurrentTurnPrompt(cfg native.RunConfig, prompt string) native.RunConfig {
+	cfg.Query = prompt
+	return cfg
+}
 
 // TriggerSchedule executes a scheduled command via the internal agent.
 func (s *Service) TriggerSchedule(ctx context.Context, botID string, payload schedule.TriggerPayload, token string) (triggerResult schedule.TriggerResult, err error) {
@@ -89,7 +94,7 @@ func (s *Service) TriggerSchedule(ctx context.Context, botID string, payload sch
 		MaxCalls:    payload.MaxCalls,
 		Command:     payload.Command,
 	})
-	cfg.Messages = append(cfg.Messages, sdk.UserMessage(schedulePrompt))
+	cfg = attachCurrentTurnPrompt(cfg, schedulePrompt)
 	cfg = s.prepareRunConfig(ctx, cfg)
 	terminal := s.contextLifecycleTerminal(ctx, cfg)
 	var lifecycleCause error
@@ -297,7 +302,7 @@ func (s *Service) TriggerHeartbeat(ctx context.Context, botID string, payload he
 		now = now.In(cfg.Identity.TimezoneLocation)
 	}
 	heartbeatPrompt := native.GenerateHeartbeatPrompt(payload.Interval, checklist, now, payload.LastHeartbeatAt)
-	cfg.Messages = append(cfg.Messages, sdk.UserMessage(heartbeatPrompt))
+	cfg = attachCurrentTurnPrompt(cfg, heartbeatPrompt)
 	cfg = s.prepareRunConfig(ctx, cfg)
 	terminal := s.contextLifecycleTerminal(ctx, cfg)
 	var lifecycleCause error

--- a/internal/agent/application/turn_discuss.go
+++ b/internal/agent/application/turn_discuss.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -14,6 +15,7 @@ import (
 	"github.com/memohai/memoh/internal/agent/turn"
 	sessionpkg "github.com/memohai/memoh/internal/chat/thread"
 	"github.com/memohai/memoh/internal/chat/timeline"
+	"github.com/memohai/memoh/internal/contextview"
 	"github.com/memohai/memoh/internal/models"
 )
 
@@ -164,21 +166,26 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 	runConfig.Query = ""
 	runConfig.ContextCurrentUserMessageIndex = nil
 	runConfig.ContextMemoryMessageIndex = nil
-	runConfig.ContextSourceFrags = nil
 	if runConfig.ContextLifecycle == nil {
 		runConfig.ContextLifecycle = contextfrag.NewLifecycleHolder()
+	}
+	runConfig.ContextBudgetMaxTokens = resolved.ContextBudgetMaxTokens
+	if runConfig.ContextToolExchangePolicy == nil {
+		runConfig.ContextToolExchangePolicy = defaultToolExchangePolicy()
 	}
 
 	// Inline image attachments from new RC segments so the model receives
 	// them as native vision input (ImagePart) on the first encounter.
+	var imageParts []sdk.ImagePart
 	if runConfig.SupportsImageInput && len(cmd.DiscussImageRefs) > 0 {
 		refs := make([]timeline.ImageAttachmentRef, len(cmd.DiscussImageRefs))
 		for i, r := range cmd.DiscussImageRefs {
 			refs[i] = timeline.ImageAttachmentRef{ContentHash: r.ContentHash, Mime: r.Mime}
 		}
-		imageParts := s.inlineDiscussImages(ctx, cmd.BotID, refs)
+		imageParts = s.inlineDiscussImages(ctx, cmd.BotID, refs)
 		injectImagePartsIntoLastUserMessage(runConfig.Messages, imageParts)
 	}
+	runConfig.ContextSourceFrags = s.collectDiscussSourceFrags(ctx, runConfig, cmd.DiscussMessages, imageParts)
 	runConfig = runConfig.RefreshContextFrag()
 	terminal := s.contextLifecycleTerminal(ctx, runConfig)
 	var lifecycleCause error
@@ -291,6 +298,41 @@ func (s *Service) pumpDiscussNative(ctx context.Context, cmd turn.StartTurnComma
 	if compactable := discussCompactableTokens(cmd.DiscussMessages); compactable > 0 && s.compactionService != nil && s.settingsService != nil {
 		go s.maybeCompactDiscuss(context.WithoutCancel(ctx), cmd.BotID, cmd.ThreadID, resolved.ModelID, compactable)
 	}
+}
+
+func (s *Service) collectDiscussSourceFrags(
+	ctx context.Context,
+	runConfig native.RunConfig,
+	messages []turn.DiscussMessage,
+	inlineImages []sdk.ImagePart,
+) []contextfrag.ContextFrag {
+	var systemFrags []contextfrag.ContextFrag
+	var appendedFrags []contextfrag.ContextFrag
+	for _, frag := range runConfig.ContextSourceFrags {
+		switch {
+		case frag.Slot == contextfrag.SlotSystem:
+			systemFrags = append(systemFrags, frag)
+		case frag.Kind == contextfrag.KindMemoryRecall || frag.Kind == contextfrag.KindHookContext:
+			appendedFrags = append(appendedFrags, frag)
+		}
+	}
+	frags, err := (&contextview.DiscussSDKContextBuilder{}).CollectDiscussSourceFrags(
+		ctx,
+		runConfig.ContextScope,
+		runConfig.System,
+		contextview.DiscussContextInput{
+			ComposedMessages: discussMessagesToTimeline(messages),
+			InlineImages:     inlineImages,
+			SystemFrags:      systemFrags,
+		},
+	)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("collect typed discuss context failed", slog.Any("error", err))
+		}
+		return nil
+	}
+	return append(frags, appendedFrags...)
 }
 
 // maybeCompactDiscuss re-evaluates compaction pressure after a native discuss
@@ -500,6 +542,19 @@ func discussMessagesToSDK(messages []turn.DiscussMessage) []sdk.Message {
 			result = append(result, sdk.AssistantMessage(m.Content))
 		default:
 			result = append(result, sdk.UserMessage(m.Content))
+		}
+	}
+	return result
+}
+
+func discussMessagesToTimeline(messages []turn.DiscussMessage) []timeline.ContextMessage {
+	result := make([]timeline.ContextMessage, len(messages))
+	for i, message := range messages {
+		result[i] = timeline.ContextMessage{
+			Role:                 message.Role,
+			Content:              message.Content,
+			RawContent:           message.RawContent,
+			CompactionArtifactID: message.CompactionArtifactID,
 		}
 	}
 	return result

--- a/internal/agent/application/turn_discuss_test.go
+++ b/internal/agent/application/turn_discuss_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/memohai/memoh/internal/apperror"
 	sessionpkg "github.com/memohai/memoh/internal/chat/thread"
 	"github.com/memohai/memoh/internal/chat/timeline"
+	"github.com/memohai/memoh/internal/contextview"
 )
 
 type fakeAgentStreamer struct {
@@ -116,6 +117,21 @@ func drainDiscuss(t *testing.T, h turn.RunHandle) []turn.Event {
 	for range h.Errs() {
 	}
 	return events
+}
+
+func assertSDKMessagesEqual(t *testing.T, got, want []sdk.Message) {
+	t.Helper()
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal got messages: %v", err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal wanted messages: %v", err)
+	}
+	if string(gotJSON) != string(wantJSON) {
+		t.Fatalf("messages = %s, want %s", gotJSON, wantJSON)
+	}
 }
 
 func discussCommand() turn.StartTurnCommand {
@@ -465,28 +481,18 @@ func TestDiscussACPSkipsWhenNotAddressed(t *testing.T) {
 	}
 }
 
-func TestDiscussRefreshesContextFragWithoutLateBindingMessage(t *testing.T) {
+func TestDiscussPropagatesContextBudgetAndToolExchangePolicy(t *testing.T) {
 	agent := &fakeAgentStreamer{}
-	staleIndex := 0
-	staleMemoryIndex := 0
 	resolver := &fakeDiscussService{
 		resolveResult: ResolveRunConfigResult{
-			RunConfig: native.RunConfig{
-				System:                         "base system",
-				ContextCurrentUserMessageIndex: &staleIndex,
-				ContextMemoryMessageIndex:      &staleMemoryIndex,
-				ContextSourceFrags: []contextfrag.ContextFrag{{
-					ID: "stale-system-only-source", Slot: contextfrag.SlotSystem,
-				}},
-			},
-			ModelID: "model-1",
+			RunConfig:              native.RunConfig{},
+			ModelID:                "model-1",
+			ContextBudgetMaxTokens: 128000,
 		},
 	}
 	a := newDiscussTestService(&fakeRunner{}, agent, resolver)
-	cmd := discussCommand()
-	cmd.DiscussMessages = []turn.DiscussMessage{{Role: "user", Content: `<message id="x">hello</message>`}}
 
-	h, err := a.StartTurn(context.Background(), cmd)
+	h, err := a.StartTurn(context.Background(), discussCommand())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -495,16 +501,84 @@ func TestDiscussRefreshesContextFragWithoutLateBindingMessage(t *testing.T) {
 	if agent.lastConfig == nil {
 		t.Fatal("expected agent to be invoked")
 	}
+	if agent.lastConfig.ContextBudgetMaxTokens != 128000 {
+		t.Fatalf("ContextBudgetMaxTokens = %d, want 128000", agent.lastConfig.ContextBudgetMaxTokens)
+	}
+	if agent.lastConfig.ContextToolExchangePolicy == nil {
+		t.Fatal("expected a default ContextToolExchangePolicy for the discuss path")
+	}
+}
+
+func TestDiscussCarriesComposedMessagesThroughTypedFragments(t *testing.T) {
+	agent := &fakeAgentStreamer{}
+	staleIndex := 0
+	staleMemoryIndex := 0
+	baseConfig := native.RunConfig{
+		System:                         "base system",
+		SupportsImageInput:             true,
+		ContextScope:                   contextfrag.Scope{BotID: "bot-1", SessionID: "sess-1"},
+		ContextCurrentUserMessageIndex: &staleIndex,
+		ContextMemoryMessageIndex:      &staleMemoryIndex,
+	}
+	baseConfig.ContextSourceFrags = contextview.CollectProviderSourceFrags(context.Background(), baseConfig)
+	hookFrags, err := (&contextview.HookContextCollector{}).Collect(context.Background(), contextview.CollectRequest{
+		Scope:  baseConfig.ContextScope,
+		Config: contextview.HookContextConfig{Text: "hook system"},
+	})
+	if err != nil {
+		t.Fatalf("collect hook context: %v", err)
+	}
+	baseConfig.ContextSourceFrags = append(baseConfig.ContextSourceFrags, hookFrags...)
+	baseConfig.ContextSourceFrags = append(baseConfig.ContextSourceFrags,
+		contextfrag.MessageFrag(contextfrag.MessageFragInput{
+			ID: "memory.recall", Message: sdk.UserMessage("remember this"), Kind: contextfrag.KindMemoryRecall,
+			Slot: contextfrag.SlotHistory, CacheClass: contextfrag.CacheNever, Trust: contextfrag.TrustWorkspace,
+		}),
+		contextfrag.MessageFrag(contextfrag.MessageFragInput{
+			ID: "stale.message", Message: sdk.UserMessage("must not survive"), Kind: contextfrag.KindConversationEvent,
+			Slot: contextfrag.SlotHistory, CacheClass: contextfrag.CacheNever, Trust: contextfrag.TrustExternal,
+		}),
+	)
+	resolver := &fakeDiscussService{
+		resolveResult: ResolveRunConfigResult{
+			RunConfig:              baseConfig,
+			ModelID:                "model-1",
+			ContextBudgetMaxTokens: 128000,
+		},
+		inlineFn: func(_ context.Context, _ string, _ []timeline.ImageAttachmentRef) []sdk.ImagePart {
+			return []sdk.ImagePart{{Image: "data:image/png;base64,abc", MediaType: "image/png"}}
+		},
+	}
+	a := newDiscussTestService(&fakeRunner{}, agent, resolver)
+	cmd := discussCommand()
+	cmd.DiscussMessages = []turn.DiscussMessage{
+		{Role: "user", Content: "first user"},
+		{Role: "user", Content: "second user"},
+		{Role: "user", Content: "<summary>covered history</summary>", CompactionArtifactID: "artifact-1"},
+		{
+			Role:       "assistant",
+			Content:    "tool call fallback",
+			RawContent: json.RawMessage(`[{"type":"tool-call","toolCallId":"call-1","toolName":"lookup","input":{"query":"answer"}}]`),
+		},
+		{
+			Role:       "tool",
+			Content:    "debug fallback",
+			RawContent: json.RawMessage(`[{"type":"tool-result","toolCallId":"call-1","toolName":"lookup","result":{"answer":42}}]`),
+		},
+		{Role: "user", Content: "latest user"},
+	}
+	cmd.DiscussImageRefs = []turn.DiscussImageRef{{ContentHash: "image-1", Mime: "image/png"}}
+
+	h, err := a.StartTurn(context.Background(), cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drainDiscuss(t, h)
+
+	if agent.lastConfig == nil {
+		t.Fatal("expected agent to be called")
+	}
 	cfg := agent.lastConfig
-	if cfg.ContextManifest.Counts.Messages != len(cfg.Messages) {
-		t.Fatalf("manifest message count = %d, messages = %d", cfg.ContextManifest.Counts.Messages, len(cfg.Messages))
-	}
-	if len(cfg.Messages) != 1 {
-		t.Fatalf("messages = %d, want only composed discuss context", len(cfg.Messages))
-	}
-	if cfg.ContextSourceFrags != nil {
-		t.Fatalf("discuss retained stale authoritative source: %#v", cfg.ContextSourceFrags)
-	}
 	if cfg.ContextCurrentUserMessageIndex != nil || cfg.ContextMemoryMessageIndex != nil {
 		t.Fatalf("discuss retained stale message markers: current=%#v memory=%#v", cfg.ContextCurrentUserMessageIndex, cfg.ContextMemoryMessageIndex)
 	}
@@ -512,6 +586,67 @@ func TestDiscussRefreshesContextFragWithoutLateBindingMessage(t *testing.T) {
 		lastMessageFragContains(cfg.ContextFrags, "MUST use the `send` tool") {
 		t.Fatalf("context frags include a volatile late-binding prompt: %#v", cfg.ContextManifest.Items)
 	}
+	frags := cfg.ContextSourceFrags
+	if len(frags) != len(cmd.DiscussMessages)+3 {
+		t.Fatalf("ContextSourceFrags = %d, want system + hook + %d discuss + memory", len(frags), len(cmd.DiscussMessages))
+	}
+	wantIDs := []string{
+		"discuss.message.000",
+		"discuss.message.001",
+		"discuss.message.002",
+		"discuss.message.003",
+		"discuss.message.004",
+		"discuss.message.005",
+	}
+	for _, wantID := range wantIDs {
+		if !hasContextFragID(frags, wantID) {
+			t.Fatalf("ContextSourceFrags missing %q: %#v", wantID, frags)
+		}
+	}
+	for _, wantID := range []string{"system.hook_context", "memory.recall"} {
+		if !hasContextFragID(frags, wantID) {
+			t.Fatalf("ContextSourceFrags missing preserved %q: %#v", wantID, frags)
+		}
+	}
+	if hasContextFragID(frags, "stale.message") {
+		t.Fatalf("pre-compose history fragment survived the authoritative discuss carrier: %#v", frags)
+	}
+	current := contextFragByID(frags, "discuss.message.005")
+	if current == nil || current.Kind != contextfrag.KindCurrentUserMessage || current.Slot != contextfrag.SlotHistory ||
+		current.Trust != contextfrag.TrustUser || current.Budget.Overflow != contextfrag.OverflowKeep {
+		t.Fatalf("current discuss fragment = %#v", current)
+	}
+	currentMessage := contextfrag.FragMessage(*current)
+	if currentMessage == nil || len(currentMessage.Content) != 2 {
+		t.Fatalf("current discuss message = %#v, want text plus one image", currentMessage)
+	}
+
+	rendered, err := contextview.ProviderRunConfigApplier(slog.New(slog.DiscardHandler))(context.Background(), *cfg)
+	if err != nil {
+		t.Fatalf("ApplyProviderRunConfig() error = %v", err)
+	}
+	if rendered.System != "base system\n\nhook system" {
+		t.Fatalf("System = %q, want preserved base and hook system fragments", rendered.System)
+	}
+	if rendered.ContextManifest.BudgetPlan == nil || rendered.ContextManifest.BudgetPlan.CurrentRequestCost <= 0 {
+		t.Fatalf("budget plan = %#v, want an active discuss current-request reserve", rendered.ContextManifest.BudgetPlan)
+	}
+	wantMessages := append([]sdk.Message(nil), cfg.Messages...)
+	wantMessages = append(wantMessages, sdk.UserMessage("remember this"))
+	assertSDKMessagesEqual(t, rendered.Messages, wantMessages)
+}
+
+func hasContextFragID(frags []contextfrag.ContextFrag, id string) bool {
+	return contextFragByID(frags, id) != nil
+}
+
+func contextFragByID(frags []contextfrag.ContextFrag, id string) *contextfrag.ContextFrag {
+	for i := range frags {
+		if frags[i].ID == id {
+			return &frags[i]
+		}
+	}
+	return nil
 }
 
 func TestInjectImagePartsIntoLastUserMessage(t *testing.T) {

--- a/internal/agent/context/fragment/lifecycle.go
+++ b/internal/agent/context/fragment/lifecycle.go
@@ -7,20 +7,26 @@ import (
 
 const MetadataContextLifecycleKey = "context_lifecycle"
 
-// LifecycleSnapshot is the durable, content-light description of the context
-// view used by a run. It intentionally excludes manifest items and payloads.
+// LifecycleSnapshot is the durable, content-light audit for one provider
+// context build. It intentionally excludes manifest items and payloads.
 type LifecycleSnapshot struct {
-	Version            int            `json:"version"`
-	View               ManifestView   `json:"view,omitempty"`
-	Counts             ManifestCounts `json:"counts"`
-	AssistantMessageID string         `json:"assistant_message_id,omitempty"`
+	Version            int                 `json:"version"`
+	View               ManifestView        `json:"view,omitempty"`
+	Counts             ManifestCounts      `json:"counts"`
+	AssistantMessageID string              `json:"assistant_message_id,omitempty"`
+	SelectionDecisions []SelectionDecision `json:"selection_decisions,omitempty"`
+	Selection          SelectionTrace      `json:"selection"`
+	BudgetPlan         *ContextBudgetPlan  `json:"budget_plan,omitempty"`
+	CachePlan          *CachePlan          `json:"cache_plan,omitempty"`
+	Mutations          []MutationRecord    `json:"mutations,omitempty"`
+	FinalInputHash     string              `json:"final_input_hash,omitempty"`
 }
 
-// LifecycleHolder keeps the latest context snapshot shared by the copied
-// RunConfig values that participate in one run.
+// LifecycleHolder shares the latest audit across copied RunConfig values.
 type LifecycleHolder struct {
 	mu       sync.RWMutex
 	snapshot LifecycleSnapshot
+	ledger   *MutationLedger
 	set      bool
 }
 
@@ -36,6 +42,7 @@ func (h *LifecycleHolder) SetManifest(manifest Manifest) {
 	h.mu.Lock()
 	next.AssistantMessageID = h.snapshot.AssistantMessageID
 	h.snapshot = next
+	h.ledger = manifest.Mutations
 	h.set = true
 	h.mu.Unlock()
 }
@@ -58,19 +65,67 @@ func (h *LifecycleHolder) Snapshot() (LifecycleSnapshot, bool) {
 		return LifecycleSnapshot{}, false
 	}
 	h.mu.RLock()
-	snapshot := h.snapshot
+	snapshot := cloneLifecycleSnapshot(h.snapshot)
+	ledger := h.ledger
 	ok := h.set
 	h.mu.RUnlock()
 	if !ok {
 		return LifecycleSnapshot{}, false
 	}
+	if ledger != nil {
+		snapshot.Mutations = ledger.Records()
+		snapshot.FinalInputHash = ledger.FinalInputHash()
+	}
 	return snapshot, true
 }
 
 func BuildLifecycleSnapshot(manifest Manifest) LifecycleSnapshot {
-	return LifecycleSnapshot{
-		Version: 1,
-		View:    manifest.View,
-		Counts:  manifest.Counts,
+	snapshot := LifecycleSnapshot{
+		Version:            1,
+		View:               manifest.View,
+		Counts:             manifest.Counts,
+		SelectionDecisions: append([]SelectionDecision(nil), manifest.SelectionDecisions...),
 	}
+	if manifest.Selection != nil {
+		snapshot.Selection = cloneSelectionTrace(*manifest.Selection)
+	}
+	if manifest.BudgetPlan != nil {
+		plan := *manifest.BudgetPlan
+		snapshot.BudgetPlan = &plan
+	}
+	if manifest.CachePlan != nil {
+		plan := *manifest.CachePlan
+		snapshot.CachePlan = &plan
+	}
+	if manifest.Mutations != nil {
+		snapshot.Mutations = manifest.Mutations.Records()
+		snapshot.FinalInputHash = manifest.Mutations.FinalInputHash()
+	}
+	return snapshot
+}
+
+func cloneLifecycleSnapshot(snapshot LifecycleSnapshot) LifecycleSnapshot {
+	snapshot.SelectionDecisions = append([]SelectionDecision(nil), snapshot.SelectionDecisions...)
+	snapshot.Selection = cloneSelectionTrace(snapshot.Selection)
+	snapshot.Mutations = append([]MutationRecord(nil), snapshot.Mutations...)
+	if snapshot.BudgetPlan != nil {
+		plan := *snapshot.BudgetPlan
+		snapshot.BudgetPlan = &plan
+	}
+	if snapshot.CachePlan != nil {
+		plan := *snapshot.CachePlan
+		snapshot.CachePlan = &plan
+	}
+	return snapshot
+}
+
+func cloneSelectionTrace(selection SelectionTrace) SelectionTrace {
+	if len(selection.DropReasons) > 0 {
+		reasons := make(map[string]int, len(selection.DropReasons))
+		for reason, count := range selection.DropReasons {
+			reasons[reason] = count
+		}
+		selection.DropReasons = reasons
+	}
+	return selection
 }

--- a/internal/agent/context/fragment/lifecycle_test.go
+++ b/internal/agent/context/fragment/lifecycle_test.go
@@ -11,45 +11,54 @@ import (
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 )
 
-func TestLifecycleHolderSnapshotIsContentLight(t *testing.T) {
+func TestLifecycleHolderKeepsDurableContentLightBudgetAudit(t *testing.T) {
 	t.Parallel()
 
 	holder := contextfrag.NewLifecycleHolder()
 	if _, ok := holder.Snapshot(); ok {
 		t.Fatal("empty holder unexpectedly exposed a snapshot")
 	}
+	ledger := contextfrag.NewMutationLedger()
+	ledger.Record(contextfrag.MutationContextBudgetFailure, "protected_context_overflow")
+	plan := contextfrag.ContextBudgetPlan{Window: 1024, SystemBudget: 256, ActualSystemCost: 930}
 	holder.SetManifest(contextfrag.Manifest{
-		View: contextfrag.ViewRunConfigPreProvider,
-		Counts: contextfrag.ManifestCounts{
-			Fragments: 4,
-			Messages:  2,
-			Images:    1,
-			TextBytes: 512,
-		},
-		Items: []contextfrag.ManifestItem{{ID: "private-content-marker"}},
+		View:               contextfrag.ViewRunConfigPreProvider,
+		Counts:             contextfrag.ManifestCounts{Fragments: 2, Messages: 1, TextBytes: 2048},
+		Items:              []contextfrag.ManifestItem{{ID: "private-content-marker"}},
+		Selection:          &contextfrag.SelectionTrace{Selected: 1, Dropped: 1, DropReasons: map[string]int{"system_budget": 1}},
+		SelectionDecisions: []contextfrag.SelectionDecision{{ID: "system.optional", Decision: contextfrag.DecisionDropped, Reason: "system_budget"}},
+		BudgetPlan:         &plan,
+		Mutations:          ledger,
 	})
 	holder.SetAssistantMessageID(" assistant-message-1 ")
 
 	snapshot, ok := holder.Snapshot()
-	if !ok {
-		t.Fatal("expected snapshot after SetManifest")
-	}
-	if snapshot.Version != 1 || snapshot.View != contextfrag.ViewRunConfigPreProvider {
-		t.Fatalf("snapshot identity = (%d, %q), want (1, %q)", snapshot.Version, snapshot.View, contextfrag.ViewRunConfigPreProvider)
-	}
-	if snapshot.Counts != (contextfrag.ManifestCounts{Fragments: 4, Messages: 2, Images: 1, TextBytes: 512}) {
-		t.Fatalf("snapshot counts = %#v", snapshot.Counts)
+	if !ok || snapshot.BudgetPlan == nil || snapshot.BudgetPlan.ActualSystemCost != 930 {
+		t.Fatalf("snapshot = %#v, ok = %v", snapshot, ok)
 	}
 	if snapshot.AssistantMessageID != "assistant-message-1" {
-		t.Fatalf("assistant message ID = %q, want trimmed association", snapshot.AssistantMessageID)
+		t.Fatalf("assistant message ID = %q", snapshot.AssistantMessageID)
 	}
-
+	if snapshot.Selection.DropReasons["system_budget"] != 1 || len(snapshot.SelectionDecisions) != 1 {
+		t.Fatalf("selection audit = %#v / %#v", snapshot.Selection, snapshot.SelectionDecisions)
+	}
 	raw, err := json.Marshal(snapshot)
 	if err != nil {
-		t.Fatalf("marshal snapshot: %v", err)
+		t.Fatal(err)
 	}
 	if strings.Contains(string(raw), "private-content-marker") || strings.Contains(string(raw), `"items"`) {
 		t.Fatalf("content-light snapshot leaked manifest items: %s", raw)
+	}
+
+	ledger.SetFinalInputHash("final-hash")
+	refreshed, _ := holder.Snapshot()
+	if refreshed.FinalInputHash != "final-hash" {
+		t.Fatalf("live final hash = %q", refreshed.FinalInputHash)
+	}
+	refreshed.Selection.DropReasons["system_budget"] = 99
+	again, _ := holder.Snapshot()
+	if again.Selection.DropReasons["system_budget"] != 1 {
+		t.Fatal("Snapshot exposed mutable holder state")
 	}
 }
 

--- a/internal/agent/context/fragment/mutation.go
+++ b/internal/agent/context/fragment/mutation.go
@@ -8,18 +8,20 @@ import (
 	"sync"
 )
 
-// MutationKind identifies a post-render context mutator: code that changes
-// the provider payload after the context view rendered it.
+// MutationKind identifies an observable provider-context decision or a
+// post-render mutation that changes the provider payload.
 type MutationKind string
 
 const (
-	MutationBeforeModelCallHook MutationKind = "before_model_call_hook"
-	MutationBackgroundSummary   MutationKind = "background_summary"
-	MutationMidTaskPrune        MutationKind = "mid_task_prune"
-	MutationInjectedMessage     MutationKind = "injected_message"
-	MutationContextViewFallback MutationKind = "context_view_fallback"
-	MutationCapabilityGate      MutationKind = "capability_gate"
-	MutationReadMedia           MutationKind = "read_media"
+	MutationBeforeModelCallHook   MutationKind = "before_model_call_hook"
+	MutationBackgroundSummary     MutationKind = "background_summary"
+	MutationMidTaskPrune          MutationKind = "mid_task_prune"
+	MutationInjectedMessage       MutationKind = "injected_message"
+	MutationContextViewFallback   MutationKind = "context_view_fallback"
+	MutationContextBudgetFailure  MutationKind = "context_budget_failure"
+	MutationContextBudgetDisabled MutationKind = "context_budget_disabled"
+	MutationCapabilityGate        MutationKind = "capability_gate"
+	MutationReadMedia             MutationKind = "read_media"
 )
 
 // MutationRecord is one ledger entry describing a post-render mutation.

--- a/internal/agent/context/fragment/tokens.go
+++ b/internal/agent/context/fragment/tokens.go
@@ -11,6 +11,16 @@ import (
 // accounting), and the single swap point for a real tokenizer.
 const EstimateBytesPerToken = 4
 
+const (
+	// ProviderBudgetEstimator identifies the conservative estimator used only
+	// for provider-envelope decisions.
+	ProviderBudgetEstimator = "bytes_ceil_div4_margin_v1"
+	// ProviderBudgetSafetyFactorPercent adds 25 percent headroom after byte
+	// ceiling. The midpoint of the accepted 15–30 percent range covers common
+	// multilingual and JSON density without changing legacy ledger estimates.
+	ProviderBudgetSafetyFactorPercent = 125
+)
+
 // EstimateImageTokens is the flat per-image estimate. Real image cost is
 // resolution-dependent and provider-capped at roughly 1.1–1.6K tokens, so a
 // ceiling-magnitude flat figure keeps image-heavy history visible to budget
@@ -23,6 +33,20 @@ func TokensFromBytes(n int) int {
 		return 0
 	}
 	return n / EstimateBytesPerToken
+}
+
+// ProviderBudgetTokensFromBytes converts bytes for provider-envelope decisions
+// only. Selection, compaction, cache metrics, and other ledger consumers keep
+// the legacy floor-based TokensFromBytes contract.
+func ProviderBudgetTokensFromBytes(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	ceiling := n / EstimateBytesPerToken
+	if n%EstimateBytesPerToken != 0 {
+		ceiling++
+	}
+	return ceiling * ProviderBudgetSafetyFactorPercent / 100
 }
 
 // EstimateSDKMessageTokens estimates tokens for one SDK message additively
@@ -85,6 +109,17 @@ func ResolveFragTokens(frag ContextFrag) int {
 		return frag.TokenEstimate
 	}
 	return EstimateFragTokens(frag)
+}
+
+// ResolveProviderBudgetFragTokens keeps an authoritative fragment estimate when
+// it is larger, otherwise it uses the conservative provider byte estimate.
+func ResolveProviderBudgetFragTokens(frag ContextFrag) int {
+	bytes, images := fragEstimate(frag)
+	estimated := ProviderBudgetTokensFromBytes(bytes) + images*EstimateImageTokens
+	if frag.TokenEstimate > estimated {
+		return frag.TokenEstimate
+	}
+	return estimated
 }
 
 // ToolDefAccountingFor measures one tool definition as the provider will

--- a/internal/agent/context/fragment/tokens_test.go
+++ b/internal/agent/context/fragment/tokens_test.go
@@ -32,6 +32,54 @@ func TestTokensFromBytes(t *testing.T) {
 	}
 }
 
+func TestProviderBudgetTokensFromBytesUsesCeilingAndSafetyMargin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{in: -1, want: 0},
+		{in: 0, want: 0},
+		{in: 1, want: 1},
+		{in: 3, want: 1},
+		{in: 4, want: 1},
+		{in: 7, want: 2},
+		{in: 8, want: 2},
+		{in: 16, want: 5},
+		{in: 4096, want: 1280},
+	}
+	for _, tc := range cases {
+		if got := ProviderBudgetTokensFromBytes(tc.in); got != tc.want {
+			t.Fatalf("ProviderBudgetTokensFromBytes(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+
+	if got := TokensFromBytes(3); got != 0 {
+		t.Fatalf("TokensFromBytes(3) = %d, want legacy floor estimate 0", got)
+	}
+}
+
+func TestResolveProviderBudgetFragTokensKeepsGreaterEstimate(t *testing.T) {
+	t.Parallel()
+
+	frag := TextFrag(TextFragInput{
+		ID:   "current",
+		Kind: KindCurrentUserMessage,
+		Slot: SlotCurrentUser,
+		Text: "abcdefghijklmnop",
+	})
+	frag.TokenEstimate = 1
+	if got := ResolveProviderBudgetFragTokens(frag); got != 5 {
+		t.Fatalf("ResolveProviderBudgetFragTokens(16 bytes) = %d, want conservative byte estimate 5", got)
+	}
+
+	frag.TokenEstimate = 99
+	if got := ResolveProviderBudgetFragTokens(frag); got != 99 {
+		t.Fatalf("ResolveProviderBudgetFragTokens(authoritative) = %d, want 99", got)
+	}
+}
+
 func TestEstimateSDKMessageTokensTextOnly(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/context/fragment/types.go
+++ b/internal/agent/context/fragment/types.go
@@ -3,6 +3,7 @@
 package contextfrag
 
 import (
+	"errors"
 	"strings"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -146,6 +147,11 @@ const (
 	RetentionRequired    RetentionTier = "required"
 	RetentionPreferred   RetentionTier = "preferred"
 	RetentionOptional    RetentionTier = "optional"
+)
+
+var (
+	ErrProtectedContextOverflow = errors.New("protected context exceeds its budget")
+	ErrBudgetUnsatisfied        = errors.New("context budget reserves exceed the available window")
 )
 
 // DropPriority orders fragments within one retention tier. Higher values drop
@@ -330,6 +336,7 @@ type Manifest struct {
 	Items              []ManifestItem      `json:"items,omitempty"`
 	SelectionDecisions []SelectionDecision `json:"selection_decisions,omitempty"`
 	Selection          *SelectionTrace     `json:"selection,omitempty"`
+	BudgetPlan         *ContextBudgetPlan  `json:"budget_plan,omitempty"`
 	CachePlan          *CachePlan          `json:"cache_plan,omitempty"`
 	Mutations          *MutationLedger     `json:"mutations,omitempty"`
 }
@@ -391,6 +398,20 @@ type ToolDefAccounting struct {
 	Name          string `json:"name"`
 	Bytes         int    `json:"bytes"`
 	TokenEstimate int    `json:"token_estimate"`
+}
+
+// ContextBudgetPlan records the numeric input-envelope allocation used for one
+// provider-bound turn. Raw prompt content never enters this accounting view.
+type ContextBudgetPlan struct {
+	Estimator                    string `json:"estimator"`
+	EstimatorSafetyFactorPercent int    `json:"estimator_safety_factor_percent"`
+	Window                       int    `json:"window"`
+	OutputReserve                int    `json:"output_reserve"`
+	ToolDefsCost                 int    `json:"tool_defs_cost"`
+	CurrentRequestCost           int    `json:"current_request_cost"`
+	SystemBudget                 int    `json:"system_budget"`
+	ActualSystemCost             int    `json:"actual_system_cost"`
+	HistoryBudget                int    `json:"history_budget"`
 }
 
 type SelectionTrace struct {

--- a/internal/agent/event/event.go
+++ b/internal/agent/event/event.go
@@ -53,6 +53,7 @@ type StreamEvent struct {
 	Messages       json.RawMessage  `json:"messages,omitempty"`
 	Usage          json.RawMessage  `json:"usage,omitempty"`
 	Reasoning      []string         `json:"reasoning,omitempty"`
+	Code           string           `json:"code,omitempty"`
 	Error          string           `json:"error,omitempty"`
 	Attempt        int              `json:"attempt,omitempty"`
 	MaxAttempt     int              `json:"maxAttempt,omitempty"`

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -16,6 +16,7 @@ import (
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	userinput "github.com/memohai/memoh/internal/agent/decision/input"
 	tools "github.com/memohai/memoh/internal/agent/tool"
+	"github.com/memohai/memoh/internal/apperror"
 	"github.com/memohai/memoh/internal/hooks"
 	"github.com/memohai/memoh/internal/models"
 	"github.com/memohai/memoh/internal/workspace/bridge"
@@ -53,11 +54,30 @@ func New(deps Deps) *Agent {
 // applyContextView compiles the provider-facing fields from authoritative
 // fragments when the application installed the PR1 compiler. Direct Agent
 // users retain the legacy refresh path.
-func (a *Agent) applyContextView(ctx context.Context, cfg RunConfig) RunConfig {
+func (a *Agent) applyContextView(ctx context.Context, cfg RunConfig) (RunConfig, error) {
 	if a != nil && a.contextViewApplier != nil {
 		return a.contextViewApplier(ctx, cfg)
 	}
-	return cfg.RefreshContextFrag()
+	return cfg.RefreshContextFrag(), nil
+}
+
+const publicContextPreparationError = "The model context could not be prepared."
+
+func contextViewStreamError(err error) StreamEvent {
+	var code apperror.Code
+	switch {
+	case errors.Is(err, contextfrag.ErrProtectedContextOverflow):
+		code = apperror.CodeContextProtectedOverflow
+	case errors.Is(err, contextfrag.ErrBudgetUnsatisfied):
+		code = apperror.CodeContextBudgetUnsatisfied
+	default:
+		return StreamEvent{Type: EventError, Error: publicContextPreparationError}
+	}
+	public, ok := apperror.PublicFrom(apperror.New(code, nil), "")
+	if !ok {
+		return StreamEvent{Type: EventError, Error: publicContextPreparationError}
+	}
+	return StreamEvent{Type: EventError, Code: string(public.Code), Error: public.Detail}
 }
 
 // BridgeProvider returns the underlying bridge provider (workspace manager).
@@ -145,6 +165,9 @@ func sendEvent(ctx context.Context, ch chan<- StreamEvent, evt StreamEvent) bool
 }
 
 func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEvent) {
+	if cfg.ContextLifecycle == nil {
+		cfg.ContextLifecycle = contextfrag.NewLifecycleHolder()
+	}
 	streamCtx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 	aborted := false
@@ -195,7 +218,15 @@ func (a *Agent) runStream(ctx context.Context, cfg RunConfig, ch chan<- StreamEv
 	limit := a.Limits().ToolOutputLimit()
 	sdkTools, readMediaState := decorateReadMediaTools(cfg.Model, sdkTools)
 	cfg.ContextDynamicMutators = cfg.contextDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, true)
-	cfg = a.applyContextView(streamCtx, cfg)
+	var contextViewErr error
+	cfg, contextViewErr = a.applyContextView(streamCtx, cfg)
+	if contextViewErr != nil {
+		publicError := contextViewStreamError(contextViewErr)
+		turnError = publicError.Error
+		a.logger.Warn("context view preflight failed", slog.Any("error", contextViewErr))
+		sendEvent(ctx, ch, publicError)
+		return
+	}
 	sdkTools = tools.WrapToolOutputLimits(sdkTools, limit)
 	approvalTools := append([]sdk.Tool(nil), sdkTools...)
 	sdkTools = a.wrapToolsWithHooks(ctx, cfg, sdkTools)
@@ -735,6 +766,9 @@ func drainStreamUntilClosed(stream <-chan sdk.StreamPart, grace time.Duration, o
 }
 
 func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *GenerateResult, retErr error) {
+	if cfg.ContextLifecycle == nil {
+		cfg.ContextLifecycle = contextfrag.NewLifecycleHolder()
+	}
 	genCtx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 	defer func() {
@@ -781,7 +815,11 @@ func (a *Agent) runGenerate(ctx context.Context, cfg RunConfig) (result *Generat
 	limit := a.Limits().ToolOutputLimit()
 	sdkTools, readMediaState := decorateReadMediaTools(cfg.Model, sdkTools)
 	cfg.ContextDynamicMutators = cfg.contextDynamicMutators(readMediaState != nil, a != nil && a.hookService != nil, false)
-	cfg = a.applyContextView(genCtx, cfg)
+	var contextViewErr error
+	cfg, contextViewErr = a.applyContextView(genCtx, cfg)
+	if contextViewErr != nil {
+		return nil, contextViewErr
+	}
 	sdkTools = tools.WrapToolOutputLimits(sdkTools, limit)
 	approvalTools := append([]sdk.Tool(nil), sdkTools...)
 	sdkTools = a.wrapToolsWithHooks(ctx, cfg, sdkTools)
@@ -971,34 +1009,36 @@ func (a *Agent) assembleTools(
 		}
 	}
 	session := tools.SessionContext{
-		BotID:                    cfg.Identity.BotID,
-		ChatID:                   cfg.Identity.ChatID,
-		SessionID:                cfg.Identity.SessionID,
-		SessionType:              cfg.SessionType,
-		UserID:                   cfg.Identity.UserID,
-		ChannelIdentityID:        cfg.Identity.ChannelIdentityID,
-		SessionToken:             cfg.Identity.SessionToken,
-		WorkspaceTargetID:        cfg.Identity.WorkspaceTargetID,
-		WorkspaceTargetKind:      cfg.Identity.WorkspaceTargetKind,
-		WorkspaceTargetName:      cfg.Identity.WorkspaceTargetName,
-		WorkdirPath:              cfg.Identity.WorkdirPath,
-		CurrentPlatform:          cfg.Identity.CurrentPlatform,
-		ReplyTarget:              cfg.Identity.ReplyTarget,
-		ConversationType:         cfg.Identity.ConversationType,
-		CanRequestUserInput:      cfg.CanRequestUserInput,
-		SupportsImageInput:       cfg.SupportsImageInput,
-		SupportsFileInput:        cfg.SupportsFileInput,
-		IsSubagent:               cfg.Identity.IsSubagent,
-		CurrentModelUUID:         cfg.CurrentModelUUID,
-		CurrentModelID:           cfg.CurrentModelID,
-		CurrentModelProvider:     cfg.CurrentModelProvider,
-		ReasoningStoredEffort:    cfg.ReasoningStoredEffort,
-		ReasoningRequestedEffort: cfg.ReasoningRequestedEffort,
-		ForkContext:              cfg.ForkContext,
-		Skills:                   skillsMap,
-		TimezoneLocation:         cfg.Identity.TimezoneLocation,
-		Emitter:                  emitter,
-		LiveStream:               liveStream,
+		BotID:                     cfg.Identity.BotID,
+		ChatID:                    cfg.Identity.ChatID,
+		SessionID:                 cfg.Identity.SessionID,
+		SessionType:               cfg.SessionType,
+		UserID:                    cfg.Identity.UserID,
+		ChannelIdentityID:         cfg.Identity.ChannelIdentityID,
+		SessionToken:              cfg.Identity.SessionToken,
+		WorkspaceTargetID:         cfg.Identity.WorkspaceTargetID,
+		WorkspaceTargetKind:       cfg.Identity.WorkspaceTargetKind,
+		WorkspaceTargetName:       cfg.Identity.WorkspaceTargetName,
+		WorkdirPath:               cfg.Identity.WorkdirPath,
+		CurrentPlatform:           cfg.Identity.CurrentPlatform,
+		ReplyTarget:               cfg.Identity.ReplyTarget,
+		ConversationType:          cfg.Identity.ConversationType,
+		CanRequestUserInput:       cfg.CanRequestUserInput,
+		SupportsImageInput:        cfg.SupportsImageInput,
+		SupportsFileInput:         cfg.SupportsFileInput,
+		IsSubagent:                cfg.Identity.IsSubagent,
+		CurrentModelUUID:          cfg.CurrentModelUUID,
+		CurrentModelID:            cfg.CurrentModelID,
+		CurrentModelProvider:      cfg.CurrentModelProvider,
+		ReasoningStoredEffort:     cfg.ReasoningStoredEffort,
+		ReasoningRequestedEffort:  cfg.ReasoningRequestedEffort,
+		ForkContext:               cfg.ForkContext,
+		Skills:                    skillsMap,
+		TimezoneLocation:          cfg.Identity.TimezoneLocation,
+		Emitter:                   emitter,
+		LiveStream:                liveStream,
+		ContextBudgetMaxTokens:    cfg.ContextBudgetMaxTokens,
+		ContextToolExchangePolicy: cfg.ContextToolExchangePolicy,
 	}
 
 	var allTools []sdk.Tool

--- a/internal/agent/runtime/native/config.go
+++ b/internal/agent/runtime/native/config.go
@@ -11,7 +11,7 @@ import (
 
 // ContextViewApplier rebuilds provider-facing fields from the authoritative
 // context fragments immediately before generate options are assembled.
-type ContextViewApplier func(context.Context, RunConfig) RunConfig
+type ContextViewApplier func(context.Context, RunConfig) (RunConfig, error)
 
 const (
 	DefaultToolOutputMaxBytes  = 64 * 1024

--- a/internal/agent/runtime/native/context_frag.go
+++ b/internal/agent/runtime/native/context_frag.go
@@ -30,16 +30,40 @@ func (cfg RunConfig) RefreshContextFrag() RunConfig {
 	cfg.ContextFrags = assembled.Frags
 	manifest := assembled.Manifest
 	manifest.ToolDefs = cfg.ContextToolDefs
-	if cfg.ContextManifest.CachePlan != nil && manifest.CachePlan == nil {
-		plan := *cfg.ContextManifest.CachePlan
-		manifest.CachePlan = &plan
-	}
-	if cfg.ContextManifest.Mutations != nil && manifest.Mutations == nil {
-		manifest.Mutations = cfg.ContextManifest.Mutations
-	}
+	manifest = preserveProviderAccounting(cfg.ContextManifest, manifest)
 	cfg.ContextManifest = manifest
-	cfg.ContextLifecycle.SetManifest(manifest)
+	if cfg.ContextLifecycle != nil {
+		cfg.ContextLifecycle.SetManifest(manifest)
+	}
 	return cfg
+}
+
+func preserveProviderAccounting(previous, next contextfrag.Manifest) contextfrag.Manifest {
+	if previous.CachePlan != nil && next.CachePlan == nil {
+		plan := *previous.CachePlan
+		next.CachePlan = &plan
+	}
+	if previous.Mutations != nil && next.Mutations == nil {
+		next.Mutations = previous.Mutations
+	}
+	if previous.Selection != nil && next.Selection == nil {
+		selection := *previous.Selection
+		if len(previous.Selection.DropReasons) > 0 {
+			selection.DropReasons = make(map[string]int, len(previous.Selection.DropReasons))
+			for reason, count := range previous.Selection.DropReasons {
+				selection.DropReasons[reason] = count
+			}
+		}
+		next.Selection = &selection
+	}
+	if previous.BudgetPlan != nil && next.BudgetPlan == nil {
+		plan := *previous.BudgetPlan
+		next.BudgetPlan = &plan
+	}
+	if len(previous.SelectionDecisions) > 0 && len(next.SelectionDecisions) == 0 {
+		next.SelectionDecisions = append([]contextfrag.SelectionDecision(nil), previous.SelectionDecisions...)
+	}
+	return next
 }
 
 func (cfg RunConfig) RefreshContextFragWithDynamicMutators(readMedia bool, beforeModelCallHook bool, injectCh bool) RunConfig {

--- a/internal/agent/runtime/native/context_frag_test.go
+++ b/internal/agent/runtime/native/context_frag_test.go
@@ -94,12 +94,23 @@ func TestRefreshContextFragKeepsMemoryDistinctFromCurrentMessage(t *testing.T) {
 func TestRefreshContextFragPreservesProviderAccounting(t *testing.T) {
 	t.Parallel()
 	ledger := contextfrag.NewMutationLedger()
+	holder := contextfrag.NewLifecycleHolder()
 	plan := contextfrag.CachePlan{StablePrefixHash: "prefix", StableMessageCount: 2}
+	budgetPlan := contextfrag.ContextBudgetPlan{Window: 1000, HistoryBudget: 400}
+	selection := contextfrag.SelectionTrace{Selected: 1, Dropped: 1, DropReasons: map[string]int{"history_budget": 1}}
+	decisions := []contextfrag.SelectionDecision{{ID: "old", Decision: contextfrag.DecisionDropped, Reason: "history_budget"}}
 	cfg := RunConfig{
 		System:          "base system",
 		Messages:        []sdk.Message{sdk.UserMessage("hi")},
 		ContextToolDefs: []contextfrag.ToolDefAccounting{{Provider: "native", Name: "read", Bytes: 40, TokenEstimate: 10}},
-		ContextManifest: contextfrag.Manifest{CachePlan: &plan, Mutations: ledger},
+		ContextManifest: contextfrag.Manifest{
+			CachePlan:          &plan,
+			Mutations:          ledger,
+			BudgetPlan:         &budgetPlan,
+			Selection:          &selection,
+			SelectionDecisions: decisions,
+		},
+		ContextLifecycle: holder,
 	}
 	cfg = cfg.RefreshContextFrag()
 	if cfg.ContextManifest.CachePlan == nil || cfg.ContextManifest.CachePlan.StablePrefixHash != "prefix" || cfg.ContextManifest.Mutations != ledger {
@@ -107,6 +118,19 @@ func TestRefreshContextFragPreservesProviderAccounting(t *testing.T) {
 	}
 	if len(cfg.ContextManifest.ToolDefs) != 1 || cfg.ContextManifest.ToolDefs[0].Name != "read" {
 		t.Fatalf("tool definitions = %#v", cfg.ContextManifest.ToolDefs)
+	}
+	if cfg.ContextManifest.BudgetPlan == nil || cfg.ContextManifest.BudgetPlan.HistoryBudget != 400 {
+		t.Fatalf("budget plan = %#v", cfg.ContextManifest.BudgetPlan)
+	}
+	if cfg.ContextManifest.Selection == nil || cfg.ContextManifest.Selection.DropReasons["history_budget"] != 1 {
+		t.Fatalf("selection = %#v", cfg.ContextManifest.Selection)
+	}
+	if len(cfg.ContextManifest.SelectionDecisions) != 1 || cfg.ContextManifest.SelectionDecisions[0].ID != "old" {
+		t.Fatalf("selection decisions = %#v", cfg.ContextManifest.SelectionDecisions)
+	}
+	snapshot, ok := holder.Snapshot()
+	if !ok || snapshot.BudgetPlan == nil || snapshot.Selection.DropReasons["history_budget"] != 1 {
+		t.Fatalf("lifecycle snapshot = %#v, %v", snapshot, ok)
 	}
 }
 

--- a/internal/agent/runtime/native/context_view_applier_test.go
+++ b/internal/agent/runtime/native/context_view_applier_test.go
@@ -2,8 +2,11 @@ package native
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -17,7 +20,7 @@ func TestGenerateAppliesContextViewBeforeProviderOptions(t *testing.T) {
 	modelProvider := &usageRecordingProvider{}
 	ledger := contextfrag.NewMutationLedger()
 	called := 0
-	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) RunConfig {
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
 		called++
 		if !strings.Contains(cfg.ContextToolUsage, usageMarker) {
 			t.Fatalf("applier tool usage = %q, want marker", cfg.ContextToolUsage)
@@ -36,7 +39,7 @@ func TestGenerateAppliesContextViewBeforeProviderOptions(t *testing.T) {
 		cfg.System = "compiled system"
 		cfg.Messages = []sdk.Message{sdk.UserMessage("compiled message")}
 		cfg.ContextMutations = ledger
-		return cfg
+		return cfg, nil
 	}})
 	a.SetToolProviders([]tools.ToolProvider{&usageTestProvider{emitTool: true, usage: usageMarker}})
 
@@ -73,9 +76,9 @@ func TestGenerateFinalInputHashTracksLastProviderStep(t *testing.T) {
 		lastParams = params
 		return &sdk.GenerateResult{Text: "done", FinishReason: sdk.FinishReasonStop}, nil
 	}}
-	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) RunConfig {
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
 		cfg.ContextMutations = ledger
-		return cfg
+		return cfg, nil
 	}})
 	a.SetToolProviders([]tools.ToolProvider{staticToolProvider{tools: []sdk.Tool{{
 		Name: "hash_tool",
@@ -100,12 +103,12 @@ func TestStreamAppliesContextViewOnce(t *testing.T) {
 	t.Parallel()
 	modelProvider := &usageStreamRecordingProvider{}
 	called := make(chan RunConfig, 1)
-	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) RunConfig {
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
 		called <- cfg
 		cfg.System = "compiled stream system"
 		cfg.Messages = []sdk.Message{sdk.UserMessage("compiled stream message")}
 		cfg.ContextMutations = contextfrag.NewMutationLedger()
-		return cfg
+		return cfg, nil
 	}})
 
 	for range a.Stream(context.Background(), RunConfig{
@@ -132,9 +135,131 @@ func TestStreamAppliesContextViewOnce(t *testing.T) {
 func TestApplyContextViewFallsBackToLegacyRefresh(t *testing.T) {
 	t.Parallel()
 	cfg := RunConfig{System: "system", Messages: []sdk.Message{sdk.UserMessage("history")}}
-	got := New(Deps{}).applyContextView(context.Background(), cfg)
+	got, err := New(Deps{}).applyContextView(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("applyContextView error = %v", err)
+	}
 	if len(got.ContextFrags) == 0 || got.ContextManifest.Counts.Messages != 1 {
 		t.Fatalf("legacy context refresh = %#v", got.ContextManifest)
+	}
+}
+
+type preflightCountingProvider struct {
+	mu            sync.Mutex
+	generateCalls int
+	streamCalls   int
+}
+
+func (*preflightCountingProvider) Name() string { return "preflight-counting" }
+
+func (*preflightCountingProvider) ListModels(context.Context) ([]sdk.Model, error) { return nil, nil }
+
+func (*preflightCountingProvider) Test(context.Context) *sdk.ProviderTestResult {
+	return &sdk.ProviderTestResult{Status: sdk.ProviderStatusOK}
+}
+
+func (*preflightCountingProvider) TestModel(context.Context, string) (*sdk.ModelTestResult, error) {
+	return &sdk.ModelTestResult{Supported: true}, nil
+}
+
+func (p *preflightCountingProvider) DoGenerate(context.Context, sdk.GenerateParams) (*sdk.GenerateResult, error) {
+	p.mu.Lock()
+	p.generateCalls++
+	p.mu.Unlock()
+	return &sdk.GenerateResult{Text: "unexpected", FinishReason: sdk.FinishReasonStop}, nil
+}
+
+func (p *preflightCountingProvider) DoStream(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {
+	p.mu.Lock()
+	p.streamCalls++
+	p.mu.Unlock()
+	return nil, errors.New("unexpected provider stream call")
+}
+
+func (p *preflightCountingProvider) calls() (int, int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.generateCalls, p.streamCalls
+}
+
+func budgetErrorApplier(err error) ContextViewApplier {
+	return func(_ context.Context, cfg RunConfig) (RunConfig, error) { return cfg, err }
+}
+
+func TestContextViewStreamErrorUsesStablePublicContract(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		err      error
+		wantCode string
+		wantText string
+	}{
+		{fmt.Errorf("%w: private cost", contextfrag.ErrProtectedContextOverflow), "context.protected_overflow", "Required context exceeds the model context budget."},
+		{fmt.Errorf("%w: private math", contextfrag.ErrBudgetUnsatisfied), "context.budget_unsatisfied", "The model context window is too small for this request."},
+		{errors.New("private collector failure"), "", publicContextPreparationError},
+	} {
+		event := contextViewStreamError(tt.err)
+		if event.Type != EventError || event.Code != tt.wantCode || event.Error != tt.wantText {
+			t.Fatalf("contextViewStreamError(%v) = %#v", tt.err, event)
+		}
+		if strings.Contains(event.Error, tt.err.Error()) {
+			t.Fatalf("public event leaked private error: %#v", event)
+		}
+	}
+}
+
+func TestAgentInstallsLifecycleHolderBeforeContextPreflight(t *testing.T) {
+	t.Parallel()
+
+	seen := make(chan *contextfrag.LifecycleHolder, 1)
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
+		seen <- cfg.ContextLifecycle
+		return cfg, contextfrag.ErrBudgetUnsatisfied
+	}})
+	_, _ = a.Generate(context.Background(), RunConfig{})
+	if holder := <-seen; holder == nil {
+		t.Fatal("context preflight received a nil lifecycle holder")
+	}
+}
+
+func TestGenerateContextBudgetErrorStopsBeforeProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := &preflightCountingProvider{}
+	wantErr := fmt.Errorf("%w: private cost", contextfrag.ErrProtectedContextOverflow)
+	result, err := New(Deps{ContextViewApplier: budgetErrorApplier(wantErr)}).Generate(context.Background(), RunConfig{
+		Model: &sdk.Model{ID: "budget-generate", Provider: provider, Type: sdk.ModelTypeChat},
+	})
+	if result != nil || !errors.Is(err, wantErr) || !errors.Is(err, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("result/error = %#v/%v", result, err)
+	}
+	if generate, stream := provider.calls(); generate != 0 || stream != 0 {
+		t.Fatalf("provider calls = %d/%d, want zero", generate, stream)
+	}
+}
+
+func TestStreamContextBudgetErrorIsPublicAndStopsBeforeProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := &preflightCountingProvider{}
+	wantErr := fmt.Errorf("%w: window=31 private", contextfrag.ErrBudgetUnsatisfied)
+	var events []StreamEvent
+	for event := range New(Deps{ContextViewApplier: budgetErrorApplier(wantErr)}).Stream(context.Background(), RunConfig{
+		Model: &sdk.Model{ID: "budget-stream", Provider: provider, Type: sdk.ModelTypeChat},
+	}) {
+		if event.Type == EventError {
+			events = append(events, event)
+		}
+	}
+	if len(events) != 1 || events[0].Code != "context.budget_unsatisfied" ||
+		events[0].Error != "The model context window is too small for this request." {
+		t.Fatalf("error events = %#v", events)
+	}
+	if strings.Contains(events[0].Error, "window=31") {
+		t.Fatalf("public event leaked private error: %#v", events[0])
+	}
+	if generate, stream := provider.calls(); generate != 0 || stream != 0 {
+		t.Fatalf("provider calls = %d/%d, want zero", generate, stream)
 	}
 }
 

--- a/internal/agent/runtime/native/spawn_adapter.go
+++ b/internal/agent/runtime/native/spawn_adapter.go
@@ -180,6 +180,8 @@ func runConfigFromSpawnRunConfig(cfg tools.SpawnRunConfig) RunConfig {
 		Identity:                       identity,
 		Skills:                         skills,
 		BackgroundManager:              cfg.BackgroundManager,
+		ContextBudgetMaxTokens:         cfg.ContextBudgetMaxTokens,
+		ContextToolExchangePolicy:      cfg.ContextToolExchangePolicy,
 		ContextScope: contextfrag.Scope{
 			BotID:             identity.BotID,
 			ChatID:            identity.ChatID,

--- a/internal/agent/runtime/native/spawn_adapter_test.go
+++ b/internal/agent/runtime/native/spawn_adapter_test.go
@@ -1,6 +1,7 @@
 package native
 
 import (
+	"context"
 	"testing"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -35,6 +36,50 @@ func TestSpawnRunConfigClassifiesRawQueryAsCurrentUser(t *testing.T) {
 	}
 	if current != 1 {
 		t.Fatalf("current fragment count = %d, want 1", current)
+	}
+}
+
+func TestSpawnRunConfigCarriesContextBudgetAndToolExchangePolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := &contextfrag.ToolExchangePolicy{MinMessages: 10}
+	rc := runConfigFromSpawnRunConfig(tools.SpawnRunConfig{
+		ContextBudgetMaxTokens:    128000,
+		ContextToolExchangePolicy: policy,
+	})
+
+	if rc.ContextBudgetMaxTokens != 128000 {
+		t.Fatalf("ContextBudgetMaxTokens = %d, want 128000", rc.ContextBudgetMaxTokens)
+	}
+	if rc.ContextToolExchangePolicy != policy {
+		t.Fatalf("ContextToolExchangePolicy = %p, want same pointer %p", rc.ContextToolExchangePolicy, policy)
+	}
+}
+
+func TestSpawnAdapterGenerateWithWatchdogFailsOnStreamError(t *testing.T) {
+	t.Parallel()
+
+	a := New(Deps{
+		ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
+			return cfg, contextfrag.ErrBudgetUnsatisfied
+		},
+	})
+	adapter := NewSpawnAdapter(a)
+
+	result, err := adapter.GenerateWithWatchdog(context.Background(), tools.SpawnRunConfig{
+		Model: &sdk.Model{
+			ID:       "spawn-preflight-error",
+			Provider: &preflightCountingProvider{},
+			Type:     sdk.ModelTypeChat,
+		},
+		Query: "do the task",
+	}, func() {})
+
+	if result != nil {
+		t.Fatalf("GenerateWithWatchdog result = %#v, want nil", result)
+	}
+	if err == nil || err.Error() != "The model context window is too small for this request." {
+		t.Fatalf("GenerateWithWatchdog error = %v, want public context-budget failure", err)
 	}
 }
 

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -116,6 +116,10 @@ type RunConfig struct {
 	ContextToolDefs                []contextfrag.ToolDefAccounting
 	ContextToolDefsResolved        bool
 	ContextToolExchangePolicy      *contextfrag.ToolExchangePolicy
+	ContextBudgetMaxTokens         int
+	ContextRecentProtectTokens     *int
+	ContextHistoryTokenEstimates   []int
+	ContextTrimmableMessages       int
 	ContextCachePlan               contextfrag.CachePlan
 	ContextMutations               *contextfrag.MutationLedger
 	ContextDynamicMutators         []contextfrag.DynamicMutator

--- a/internal/agent/runtime/native/usage_injection_test.go
+++ b/internal/agent/runtime/native/usage_injection_test.go
@@ -8,6 +8,7 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/sessionmode"
 	tools "github.com/memohai/memoh/internal/agent/tool"
 )
@@ -322,6 +323,27 @@ func TestAssembleToolsInjectsUsageWhenProviderEmitsTools(t *testing.T) {
 	}
 	if !strings.Contains(usage, "## Tool usage") {
 		t.Fatalf("expected usage to carry the section header, got %q", usage)
+	}
+}
+
+func TestAssembleToolsPassesContextBudgetAndToolExchangePolicyToSession(t *testing.T) {
+	t.Parallel()
+	var captured tools.SessionContext
+	a := newTestAgent(&usageTestProvider{emitTool: true, sessionSeen: &captured})
+	policy := &contextfrag.ToolExchangePolicy{MinMessages: 10}
+
+	if _, _, _, _, err := a.assembleTools(context.Background(), RunConfig{
+		ContextBudgetMaxTokens:    128000,
+		ContextToolExchangePolicy: policy,
+	}, tools.StreamEmitter(func(tools.ToolStreamEvent) {}), true); err != nil {
+		t.Fatalf("assembleTools error: %v", err)
+	}
+
+	if captured.ContextBudgetMaxTokens != 128000 {
+		t.Fatalf("ContextBudgetMaxTokens = %d, want 128000", captured.ContextBudgetMaxTokens)
+	}
+	if captured.ContextToolExchangePolicy != policy {
+		t.Fatalf("ContextToolExchangePolicy = %p, want same pointer %p", captured.ContextToolExchangePolicy, policy)
 	}
 }
 

--- a/internal/agent/tool/subagent.go
+++ b/internal/agent/tool/subagent.go
@@ -68,15 +68,17 @@ type SpawnRunConfig struct {
 	ReasoningConfig *models.ReasoningConfig
 	// Keep the unresolved parent-turn inputs as well, so a nested subagent can
 	// resolve the same override against its own selected model.
-	ReasoningStoredEffort    string
-	ReasoningRequestedEffort string
-	PromptCacheTTL           string
-	ChatCompletionsCompat    string
-	SupportsImageInput       bool
-	SupportsFileInput        bool
-	SupportsToolCall         bool
-	Skills                   map[string]SkillDetail
-	BackgroundManager        *background.Manager
+	ReasoningStoredEffort     string
+	ReasoningRequestedEffort  string
+	PromptCacheTTL            string
+	ChatCompletionsCompat     string
+	SupportsImageInput        bool
+	SupportsFileInput         bool
+	SupportsToolCall          bool
+	Skills                    map[string]SkillDetail
+	BackgroundManager         *background.Manager
+	ContextBudgetMaxTokens    int
+	ContextToolExchangePolicy *contextfrag.ToolExchangePolicy
 	// TurnRequestMessageID is the persisted task user message this run's
 	// assistant and tool rows bind to, so incremental step persistence files
 	// them into the same history turn the runtime view names.
@@ -237,12 +239,13 @@ type resolvedSubagentModel struct {
 	// parent: a subagent may run a different model, whose advertised tiers and
 	// off-ability differ. Before #983 it was neither inherited nor resolved, so
 	// subagents ran with no thinking configuration at all.
-	ReasoningConfig       *models.ReasoningConfig
-	PromptCacheTTL        string
-	ChatCompletionsCompat string
-	SupportsImageInput    bool
-	SupportsFileInput     bool
-	SupportsToolCall      bool
+	ReasoningConfig        *models.ReasoningConfig
+	PromptCacheTTL         string
+	ChatCompletionsCompat  string
+	SupportsImageInput     bool
+	SupportsFileInput      bool
+	SupportsToolCall       bool
+	ContextBudgetMaxTokens int
 }
 
 type subagentModelCatalogItem struct {
@@ -998,27 +1001,33 @@ func (p *SpawnProvider) runSubagentTask(ctx context.Context, req *agentRequest) 
 		combined = append(combined, history...)
 		history = combined
 	}
+	contextBudgetMaxTokens := req.runtime.ContextBudgetMaxTokens
+	if contextBudgetMaxTokens <= 0 {
+		contextBudgetMaxTokens = req.parentSession.ContextBudgetMaxTokens
+	}
 	cfg := SpawnRunConfig{
-		RunID:                    strings.TrimSpace(req.admission.RunID),
-		Model:                    req.runtime.Model,
-		ModelUUID:                req.runtime.UUID,
-		ModelID:                  req.runtime.ModelID,
-		ModelProvider:            req.runtime.ProviderName,
-		ReasoningConfig:          req.runtime.ReasoningConfig,
-		ReasoningStoredEffort:    req.parentSession.ReasoningStoredEffort,
-		ReasoningRequestedEffort: req.parentSession.ReasoningRequestedEffort,
-		System:                   req.systemPrompt,
-		Query:                    req.message,
-		SessionType:              sessionpkg.TypeSubagent,
-		PromptCacheTTL:           req.runtime.PromptCacheTTL,
-		ChatCompletionsCompat:    req.runtime.ChatCompletionsCompat,
-		SupportsImageInput:       req.runtime.SupportsImageInput,
-		SupportsFileInput:        req.runtime.SupportsFileInput,
-		SupportsToolCall:         req.runtime.SupportsToolCall,
-		Messages:                 history,
-		Skills:                   req.parentSession.Skills,
-		BackgroundManager:        p.bgManager,
-		TurnRequestMessageID:     req.requestMessageID,
+		RunID:                     strings.TrimSpace(req.admission.RunID),
+		Model:                     req.runtime.Model,
+		ModelUUID:                 req.runtime.UUID,
+		ModelID:                   req.runtime.ModelID,
+		ModelProvider:             req.runtime.ProviderName,
+		ReasoningConfig:           req.runtime.ReasoningConfig,
+		ReasoningStoredEffort:     req.parentSession.ReasoningStoredEffort,
+		ReasoningRequestedEffort:  req.parentSession.ReasoningRequestedEffort,
+		System:                    req.systemPrompt,
+		Query:                     req.message,
+		SessionType:               sessionpkg.TypeSubagent,
+		PromptCacheTTL:            req.runtime.PromptCacheTTL,
+		ChatCompletionsCompat:     req.runtime.ChatCompletionsCompat,
+		SupportsImageInput:        req.runtime.SupportsImageInput,
+		SupportsFileInput:         req.runtime.SupportsFileInput,
+		SupportsToolCall:          req.runtime.SupportsToolCall,
+		Messages:                  history,
+		Skills:                    req.parentSession.Skills,
+		BackgroundManager:         p.bgManager,
+		ContextBudgetMaxTokens:    contextBudgetMaxTokens,
+		ContextToolExchangePolicy: req.parentSession.ContextToolExchangePolicy,
+		TurnRequestMessageID:      req.requestMessageID,
 		Identity: SpawnIdentity{
 			BotID:               req.parentSession.BotID,
 			ChatID:              req.parentSession.ChatID,
@@ -1846,15 +1855,16 @@ func (p *SpawnProvider) resolveModel(
 		ThinkingBudgetMax:     modelInfo.Config.ThinkingBudgetMax,
 	})
 	return resolvedSubagentModel{
-		Model:                 sdkModel,
-		ReasoningConfig:       reasoningConfig,
-		UUID:                  modelInfo.ID,
-		ModelID:               modelInfo.ModelID,
-		ProviderName:          provider.Name,
-		PromptCacheTTL:        providers.ProviderConfigString(provider, "prompt_cache_ttl"),
-		ChatCompletionsCompat: chatCompletionsCompat,
-		SupportsImageInput:    modelInfo.HasCompatibility(models.CompatVision),
-		SupportsToolCall:      modelInfo.HasCompatibility(models.CompatToolCall),
+		Model:                  sdkModel,
+		ReasoningConfig:        reasoningConfig,
+		UUID:                   modelInfo.ID,
+		ModelID:                modelInfo.ModelID,
+		ProviderName:           provider.Name,
+		PromptCacheTTL:         providers.ProviderConfigString(provider, "prompt_cache_ttl"),
+		ChatCompletionsCompat:  chatCompletionsCompat,
+		SupportsImageInput:     modelInfo.HasCompatibility(models.CompatVision),
+		SupportsToolCall:       modelInfo.HasCompatibility(models.CompatToolCall),
+		ContextBudgetMaxTokens: modelInfo.Config.ContextBudgetMaxTokens(),
 	}, nil
 }
 

--- a/internal/agent/tool/subagent_bg_test.go
+++ b/internal/agent/tool/subagent_bg_test.go
@@ -480,6 +480,54 @@ func TestSpawnAgentSessionInheritsParentUserIdentity(t *testing.T) {
 	}
 }
 
+func TestSpawnAgentPropagatesContextBudgetAndToolExchangePolicy(t *testing.T) {
+	agent := &fakeSpawnAgent{}
+	p, _, _, _ := newAgentControlProvider(t, agent)
+	policy := &contextfrag.ToolExchangePolicy{MinMessages: 10}
+	session := SessionContext{
+		BotID:                     "bot1",
+		SessionID:                 "parent1",
+		ContextBudgetMaxTokens:    128000,
+		ContextToolExchangePolicy: policy,
+	}
+
+	mustExecuteAgentTool(t, p, session, "spawn_agent", map[string]any{"task": "alpha"})
+
+	call, ok := agent.callAt(0)
+	if !ok {
+		t.Fatal("expected spawn_agent call")
+	}
+	if call.ContextBudgetMaxTokens != 128000 {
+		t.Fatalf("ContextBudgetMaxTokens = %d, want 128000", call.ContextBudgetMaxTokens)
+	}
+	if call.ContextToolExchangePolicy != policy {
+		t.Fatalf("ContextToolExchangePolicy = %p, want same pointer %p", call.ContextToolExchangePolicy, policy)
+	}
+}
+
+func TestSpawnAgentUsesResolvedModelContextBudgetOverParent(t *testing.T) {
+	agent := &fakeSpawnAgent{}
+	p, _, _, _ := newAgentControlProvider(t, agent)
+	p.modelResolver = func(context.Context, SessionContext, string, string, string) (resolvedSubagentModel, error) {
+		return resolvedSubagentModel{Model: &sdk.Model{}, ModelID: "model-2", ContextBudgetMaxTokens: 64000}, nil
+	}
+	session := SessionContext{
+		BotID:                  "bot1",
+		SessionID:              "parent1",
+		ContextBudgetMaxTokens: 128000,
+	}
+
+	mustExecuteAgentTool(t, p, session, "spawn_agent", map[string]any{"task": "alpha"})
+
+	call, ok := agent.callAt(0)
+	if !ok {
+		t.Fatal("expected spawn_agent call")
+	}
+	if call.ContextBudgetMaxTokens != 64000 {
+		t.Fatalf("ContextBudgetMaxTokens = %d, want 64000 (the resolved subagent model's own context window, not the parent's 128000)", call.ContextBudgetMaxTokens)
+	}
+}
+
 func TestSpawnAgentIDsAndDuplicateValidation(t *testing.T) {
 	p, _, _, _ := newAgentControlProvider(t, &fakeSpawnAgent{})
 	session := SessionContext{BotID: "bot1", SessionID: "parent1"}
@@ -707,6 +755,66 @@ func TestBusyAgentQueuesAndRunsFIFO(t *testing.T) {
 	}
 	if snap.Status != background.TaskCompleted {
 		t.Fatalf("expected third task completed, got %+v", snap)
+	}
+}
+
+func TestQueuedSpawnAgentUsesExecutionModelContextBudget(t *testing.T) {
+	block := make(chan struct{})
+	agent := &fakeSpawnAgent{block: block}
+	p, _, _, _ := newAgentControlProvider(t, agent)
+	var resolverMu sync.Mutex
+	resolverBudgets := []int{128000, 128000, 128000, 64000, 32000}
+	resolverCall := 0
+	p.modelResolver = func(context.Context, SessionContext, string, string, string) (resolvedSubagentModel, error) {
+		resolverMu.Lock()
+		defer resolverMu.Unlock()
+		if resolverCall >= len(resolverBudgets) {
+			return resolvedSubagentModel{}, errors.New("unexpected model resolution")
+		}
+		budget := resolverBudgets[resolverCall]
+		resolverCall++
+		return resolvedSubagentModel{
+			Model:                  &sdk.Model{},
+			ModelID:                "model-2",
+			ProviderName:           "provider-2",
+			ContextBudgetMaxTokens: budget,
+		}, nil
+	}
+	session := SessionContext{
+		BotID:                  "bot1",
+		SessionID:              "parent1",
+		ContextBudgetMaxTokens: 256000,
+	}
+
+	mustExecuteAgentTool(t, p, session, "spawn_agent", map[string]any{
+		"id":                "worker",
+		"task":              "first",
+		"run_in_background": true,
+	})
+	waitUntil(t, 2*time.Second, func() bool {
+		return reflect.DeepEqual(agent.queries(), []string{"first"})
+	})
+	queued := asMap(t, mustExecuteAgentTool(t, p, session, "send_message", map[string]any{
+		"id":      "worker",
+		"message": "second",
+	}))
+	if queued["status"] != string(background.TaskQueued) {
+		t.Fatalf("expected second request queued, got %v", queued)
+	}
+
+	close(block)
+	waitUntil(t, 2*time.Second, func() bool {
+		return reflect.DeepEqual(agent.queries(), []string{"first", "second"})
+	})
+	secondCall, ok := agent.callAt(1)
+	if !ok {
+		t.Fatal("expected queued request to execute")
+	}
+	if secondCall.ContextBudgetMaxTokens != 32000 {
+		t.Fatalf(
+			"queued ContextBudgetMaxTokens = %d, want latest execution resolution 32000",
+			secondCall.ContextBudgetMaxTokens,
+		)
 	}
 }
 

--- a/internal/agent/tool/types.go
+++ b/internal/agent/tool/types.go
@@ -11,6 +11,7 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/sessionmode"
 	"github.com/memohai/memoh/internal/agent/tool/internal/toolset"
 )
@@ -331,11 +332,13 @@ type SessionContext struct {
 	WorkspaceTargetName string
 	// WorkdirPath is the session's immutable working directory. When set,
 	// relative tool paths resolve under it and exec defaults its cwd to it.
-	WorkdirPath      string
-	Skills           map[string]SkillDetail
-	TimezoneLocation *time.Location
-	Emitter          StreamEmitter
-	LiveStream       bool
+	WorkdirPath               string
+	Skills                    map[string]SkillDetail
+	TimezoneLocation          *time.Location
+	Emitter                   StreamEmitter
+	LiveStream                bool
+	ContextBudgetMaxTokens    int
+	ContextToolExchangePolicy *contextfrag.ToolExchangePolicy
 }
 
 // CanAskUser reports whether ask_user can be both shown to the model and

--- a/internal/apperror/error.go
+++ b/internal/apperror/error.go
@@ -16,6 +16,8 @@ const (
 	CodeCompactionModelUnavailable       Code = "compaction.model_unavailable"
 	CodeSettingsReasoningEffortInvalid   Code = "settings.reasoning_effort_invalid"
 	CodeSettingsReasoningUnavailable     Code = "settings.reasoning_options_unavailable"
+	CodeContextBudgetUnsatisfied         Code = "context.budget_unsatisfied"
+	CodeContextProtectedOverflow         Code = "context.protected_overflow"
 	CodeWorkspaceUnreachable             Code = "workspace.unreachable"
 	CodeWorkspaceImageIncompatible       Code = "workspace.image_incompatible"
 	CodeWorkspaceTemplateBootstrapFailed Code = "workspace.template_bootstrap_failed"
@@ -115,6 +117,14 @@ var catalog = map[Code]Definition{
 	CodeSettingsReasoningUnavailable: {
 		HTTPStatus: http.StatusServiceUnavailable,
 		Detail:     "The chat model's reasoning options could not be resolved. Please try again.",
+	},
+	CodeContextBudgetUnsatisfied: {
+		HTTPStatus: http.StatusUnprocessableEntity,
+		Detail:     "The model context window is too small for this request.",
+	},
+	CodeContextProtectedOverflow: {
+		HTTPStatus: http.StatusUnprocessableEntity,
+		Detail:     "Required context exceeds the model context budget.",
 	},
 	CodeWorkspaceUnreachable: {
 		HTTPStatus: http.StatusServiceUnavailable,

--- a/internal/apperror/error_test.go
+++ b/internal/apperror/error_test.go
@@ -209,3 +209,23 @@ func TestRegistryPackageInstallFailedUsesPrivateServerErrorContract(t *testing.T
 		t.Fatal("registry.package_install_failed has empty fallback detail")
 	}
 }
+
+func TestContextBudgetErrorsHaveStableCatalogContracts(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		code   Code
+		detail string
+	}{
+		{CodeContextBudgetUnsatisfied, "The model context window is too small for this request."},
+		{CodeContextProtectedOverflow, "Required context exceeds the model context budget."},
+	} {
+		definition, ok := Lookup(tt.code)
+		if !ok {
+			t.Fatalf("catalog missing %q", tt.code)
+		}
+		if definition.HTTPStatus != http.StatusUnprocessableEntity || definition.Detail != tt.detail {
+			t.Fatalf("catalog[%q] = %#v", tt.code, definition)
+		}
+	}
+}

--- a/internal/contextview/builder.go
+++ b/internal/contextview/builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -70,6 +71,14 @@ func (b *Builder) Build(ctx context.Context, input BuildInput) (*ContextView, er
 	profile := b.selector.ProfileFor(input.Intent)
 	result := b.selector.Select(sourceFrags, profile, input.Budget)
 	trace.SelectionSummary = result.Summary
+	if result.TrimNotice && result.TrimNoticeIndex >= 0 && result.TrimNoticeIndex <= len(result.Selected) {
+		notice := contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{TrimNoticeFrag(input.Scope)})[0]
+		selected := make([]contextfrag.ContextFrag, 0, len(result.Selected)+1)
+		selected = append(selected, result.Selected[:result.TrimNoticeIndex]...)
+		selected = append(selected, notice)
+		selected = append(selected, result.Selected[result.TrimNoticeIndex:]...)
+		result.Selected = selected
+	}
 
 	placement := b.placer.Place(result.Selected, input.Intent)
 	trace.PlacementSummary = summarizePlacement(placement)
@@ -79,6 +88,10 @@ func (b *Builder) Build(ctx context.Context, input BuildInput) (*ContextView, er
 	manifest.DynamicMutators = normalizeDynamicMutators(input.DynamicMutators)
 	manifest.Selection = selectionTrace(result.Summary)
 	manifest.SelectionDecisions = selectionDecisions(sourceFrags, result)
+	if input.Budget.Plan != nil {
+		plan := *input.Budget.Plan
+		manifest.BudgetPlan = &plan
+	}
 	manifest.EditTrace = append(manifest.EditTrace, selectionEditTrace(result.Dropped)...)
 	manifest.EditTrace = append(manifest.EditTrace, result.Edited...)
 	manifest.ValidationWarnings = append(manifest.ValidationWarnings, result.Warnings...)
@@ -94,6 +107,9 @@ func (b *Builder) Build(ctx context.Context, input BuildInput) (*ContextView, er
 		Trace:       trace,
 	}
 
+	if result.FatalError != nil {
+		return view, result.FatalError
+	}
 	if input.Options.DryRun {
 		return view, nil
 	}
@@ -188,7 +204,7 @@ func selectionDecisions(sourceFrags []contextfrag.ContextFrag, result SelectionR
 			continue
 		}
 		selectedIndex := indexes[0]
-		decisions[i] = selectionDecisionForSelection(source, result.Selected[selectedIndex])
+		decisions[i] = selectionDecisionForSelection(source, result.Selected[selectedIndex], result.EditReasons[source.ID])
 		decided[i] = true
 		selectedUsed[selectedIndex] = true
 		selectedByRef[key] = indexes[1:]
@@ -205,11 +221,42 @@ func selectionDecisions(sourceFrags []contextfrag.ContextFrag, result SelectionR
 			if selectedUsed[selectedIndex] || !source.Ref.EqualIdentity(selected.Ref) {
 				continue
 			}
-			decisions[i] = selectionDecisionForSelection(source, selected)
+			decisions[i] = selectionDecisionForSelection(source, selected, result.EditReasons[source.ID])
 			decided[i] = true
 			selectedUsed[selectedIndex] = true
 			break
 		}
+	}
+
+	// A budget edit can refresh a fragment's content hash before a later stage
+	// drops it, so its drop record no longer carries the source's exact ref.
+	// Match those records by ContextRef identity once selected matching is
+	// done, consuming deterministically among the remaining hashes.
+	for i, source := range sourceFrags {
+		if decided[i] {
+			continue
+		}
+		sourceKey, ok := newSelectionRefKey(source.Ref)
+		if !ok {
+			continue
+		}
+		candidateKeys := make([]selectionRefKey, 0, 1)
+		for key, reasons := range dropReasonsByRef {
+			if len(reasons) > 0 && key.identity == sourceKey.identity {
+				candidateKeys = append(candidateKeys, key)
+			}
+		}
+		if len(candidateKeys) == 0 {
+			continue
+		}
+		sort.Slice(candidateKeys, func(a, b int) bool {
+			return candidateKeys[a].contentHash < candidateKeys[b].contentHash
+		})
+		key := candidateKeys[0]
+		reasons := dropReasonsByRef[key]
+		decisions[i] = selectionDecisionForFrag(source, contextfrag.DecisionDropped, reasons[0])
+		decided[i] = true
+		dropReasonsByRef[key] = reasons[1:]
 	}
 
 	// Keep ID-only drop records for legacy selectors that did not provide a Ref.
@@ -247,7 +294,7 @@ func selectionDecisions(sourceFrags []contextfrag.ContextFrag, result SelectionR
 			if selectedUsed[selectedIndex] || selected.ID != source.ID {
 				continue
 			}
-			decisions[i] = selectionDecisionForSelection(source, selected)
+			decisions[i] = selectionDecisionForSelection(source, selected, result.EditReasons[source.ID])
 			decided[i] = true
 			selectedUsed[selectedIndex] = true
 			break
@@ -261,7 +308,11 @@ func selectionDecisions(sourceFrags []contextfrag.ContextFrag, result SelectionR
 	}
 	for i, selected := range result.Selected {
 		if !selectedUsed[i] {
-			decisions = append(decisions, selectionDecisionForFrag(selected, contextfrag.DecisionSelected, ""))
+			reason := ""
+			if selected.ID == systemBudgetMarkerID {
+				reason = "system_budget_marker"
+			}
+			decisions = append(decisions, selectionDecisionForFrag(selected, contextfrag.DecisionSelected, reason))
 		}
 	}
 	return decisions
@@ -286,13 +337,13 @@ func newSelectionRefKey(ref contextfrag.ContextRef) (selectionRefKey, bool) {
 	}, true
 }
 
-func selectionDecisionForSelection(source, selected contextfrag.ContextFrag) contextfrag.SelectionDecision {
+func selectionDecisionForSelection(source, selected contextfrag.ContextFrag, reason string) contextfrag.SelectionDecision {
 	decision := contextfrag.DecisionSelected
 	if source.Ref.ContentHash != selected.Ref.ContentHash ||
 		contextfrag.ResolveFragTokens(source) != contextfrag.ResolveFragTokens(selected) {
 		decision = contextfrag.DecisionTrimmed
 	}
-	return selectionDecisionForFrag(selected, decision, "")
+	return selectionDecisionForFrag(selected, decision, reason)
 }
 
 func selectionDecisionForFrag(

--- a/internal/contextview/builder_selection_ref_test.go
+++ b/internal/contextview/builder_selection_ref_test.go
@@ -2,6 +2,7 @@ package contextview
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	sdk "github.com/memohai/twilight-ai/sdk"
@@ -50,5 +51,60 @@ func TestSelectionDecisionsUsesContextRefWhenIDsCollide(t *testing.T) {
 	}
 	if secondDecision.Decision != contextfrag.DecisionDropped || secondDecision.Ref.ContentHash != sources[1].Ref.ContentHash {
 		t.Fatalf("loser decision = %#v, want dropped second ContextRef", secondDecision)
+	}
+}
+
+func TestSelectionDecisionsAttributeTrimmedThenDroppedFragByID(t *testing.T) {
+	required := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "required", Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem,
+		Slot: contextfrag.SlotSystem, Text: "required", Priority: 10,
+		CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustSystem,
+		Source: "selection-test", Collector: "selection-test",
+		RetentionTier: contextfrag.RetentionRequired,
+	})
+	oversized := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "oversized-optional", Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem,
+		Slot: contextfrag.SlotSystem, Text: strings.Repeat("budget pressure ", 200), Priority: 9,
+		CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustSystem,
+		Source: "selection-test", Collector: "selection-test",
+		RetentionTier: contextfrag.RetentionOptional,
+	})
+	oversized.Budget = contextfrag.BudgetPolicy{MaxTokens: 500, Overflow: contextfrag.OverflowTrim}
+	sources := contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{required, oversized})
+	marker := systemBudgetMarkerFrag([]string{oversized.ID}, contextfrag.Scope{})
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: systemFragCost([]contextfrag.ContextFrag{sources[0], marker}),
+	}
+	builder := NewBuilder(
+		NewMapCollectorRegistry(StaticCollector{CollectorName: "selection-test", Frags: sources}),
+		&FragmentSelector{},
+		IdentityPlacer{},
+		NewMapRendererRegistry(),
+	)
+	view, err := builder.Build(context.Background(), BuildInput{
+		Intent:  contextfrag.IntentRunConfigPreProvider,
+		Sources: []SourceSpec{{Name: "selection-test"}},
+		Budget:  BudgetEnvelope{Plan: plan},
+		Options: BuildOptions{DryRun: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dropped *contextfrag.SelectionDecision
+	for i := range view.Manifest.SelectionDecisions {
+		if view.Manifest.SelectionDecisions[i].ID == oversized.ID {
+			dropped = &view.Manifest.SelectionDecisions[i]
+			break
+		}
+	}
+	if dropped == nil {
+		t.Fatalf("selection decisions = %#v, want an entry for %s", view.Manifest.SelectionDecisions, oversized.ID)
+	}
+	if dropped.Decision != contextfrag.DecisionDropped || dropped.Reason != systemBudgetDropReason {
+		t.Fatalf("decision for %s = %#v, want dropped/%s", oversized.ID, dropped, systemBudgetDropReason)
+	}
+	if dropped.Ref.ContentHash != sources[1].Ref.ContentHash {
+		t.Fatalf("dropped ref hash = %q, want source hash %q", dropped.Ref.ContentHash, sources[1].Ref.ContentHash)
 	}
 }

--- a/internal/contextview/capability_gate_test.go
+++ b/internal/contextview/capability_gate_test.go
@@ -35,10 +35,11 @@ func TestApplyProviderRunConfigGatesUnavailableSkillGuidance(t *testing.T) {
 		t.Fatalf("selection = %#v, want two capability-gated drops", got.ContextManifest.Selection)
 	}
 	records := got.ContextMutations.Records()
-	if len(records) != 1 ||
-		records[0].Kind != contextfrag.MutationCapabilityGate ||
-		records[0].Detail != "dropped=2" {
-		t.Fatalf("mutations = %+v, want one count-only capability gate record", records)
+	if len(records) != 2 ||
+		records[0].Kind != contextfrag.MutationContextBudgetDisabled ||
+		records[1].Kind != contextfrag.MutationCapabilityGate ||
+		records[1].Detail != "dropped=2" {
+		t.Fatalf("mutations = %+v, want disabled-budget audit then count-only capability gate", records)
 	}
 }
 
@@ -56,8 +57,8 @@ func TestApplyProviderRunConfigKeepsAvailableSkillGuidanceByteIdentical(t *testi
 		got.ContextManifest.Selection.DropReasons[capabilityGateDropReason] != 0 {
 		t.Fatalf("selection = %#v, want no capability gate", got.ContextManifest.Selection)
 	}
-	if records := got.ContextMutations.Records(); len(records) != 0 {
-		t.Fatalf("mutations = %+v, want none", records)
+	if records := got.ContextMutations.Records(); len(records) != 1 || records[0].Kind != contextfrag.MutationContextBudgetDisabled {
+		t.Fatalf("mutations = %+v, want only missing-window audit", records)
 	}
 }
 
@@ -71,8 +72,8 @@ func TestApplyProviderRunConfigLeavesUnknownCapabilityRosterUngated(t *testing.T
 	if got.System != cfg.System {
 		t.Fatalf("system = %q, want unknown roster to preserve %q", got.System, cfg.System)
 	}
-	if records := got.ContextMutations.Records(); len(records) != 0 {
-		t.Fatalf("mutations = %+v, want unknown roster ungated", records)
+	if records := got.ContextMutations.Records(); len(records) != 1 || records[0].Kind != contextfrag.MutationContextBudgetDisabled {
+		t.Fatalf("mutations = %+v, want unknown roster ungated plus missing-window audit", records)
 	}
 }
 
@@ -161,10 +162,11 @@ func TestApplyProviderRunConfigFallbackCannotRestoreGatedGuidance(t *testing.T) 
 		t.Fatalf("fallback messages = %#v, want legacy message", got.Messages)
 	}
 	records := got.ContextMutations.Records()
-	if len(records) != 2 ||
-		records[0].Kind != contextfrag.MutationCapabilityGate ||
-		records[1].Kind != contextfrag.MutationContextViewFallback {
-		t.Fatalf("fallback mutations = %+v, want capability gate then context-view fallback", records)
+	if len(records) != 3 ||
+		records[0].Kind != contextfrag.MutationContextBudgetDisabled ||
+		records[1].Kind != contextfrag.MutationCapabilityGate ||
+		records[2].Kind != contextfrag.MutationContextViewFallback {
+		t.Fatalf("fallback mutations = %+v, want disabled budget, capability gate, then context-view fallback", records)
 	}
 	if got.ContextManifest.Selection == nil ||
 		got.ContextManifest.Selection.DropReasons[capabilityGateDropReason] != 2 {

--- a/internal/contextview/collector_discuss.go
+++ b/internal/contextview/collector_discuss.go
@@ -1,0 +1,156 @@
+package contextview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+const (
+	discussContextCollectorName = "discuss_context"
+	discussContextSource        = "pipeline_discuss"
+)
+
+type DiscussContextConfig struct {
+	// ComposedMessages is the authoritative output of timeline composition
+	// when non-nil.
+	ComposedMessages []timeline.ContextMessage
+	// InlineImages are freshly surfaced attachments delivered as native vision
+	// input on the latest user message.
+	InlineImages []sdk.ImagePart
+}
+
+type DiscussContextCollector struct{}
+
+func (*DiscussContextCollector) Name() string {
+	return discussContextCollectorName
+}
+
+func (*DiscussContextCollector) Collect(_ context.Context, req CollectRequest) ([]contextfrag.ContextFrag, error) {
+	cfg, err := discussContextConfig(req.Config)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.ComposedMessages == nil {
+		return nil, nil
+	}
+
+	frags := make([]contextfrag.ContextFrag, 0, len(cfg.ComposedMessages))
+	currentUserIndex := latestComposedUserMessageIndex(cfg.ComposedMessages)
+	for i, message := range cfg.ComposedMessages {
+		frags = append(frags, discussComposedMessageFrag(message, i, i == currentUserIndex, req.Scope))
+	}
+	if req.Intent == contextfrag.IntentRunConfigPreProvider {
+		frags = contextfrag.RepairToolClosureFrags(frags, req.Scope, discussContextCollectorName)
+	}
+	return injectDiscussImages(frags, cfg.InlineImages), nil
+}
+
+func latestComposedUserMessageIndex(messages []timeline.ContextMessage) int {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].CompactionArtifactID == "" &&
+			discussContextMessageToSDK(messages[i]).Role == sdk.MessageRoleUser {
+			return i
+		}
+	}
+	return -1
+}
+
+func discussComposedMessageFrag(message timeline.ContextMessage, index int, currentUser bool, scope contextfrag.Scope) contextfrag.ContextFrag {
+	msg := discussContextMessageToSDK(message)
+	input := contextfrag.MessageFragInput{
+		ID:         fmt.Sprintf("discuss.message.%03d", index),
+		Message:    msg,
+		Kind:       contextfrag.KindConversationEvent,
+		Slot:       contextfrag.SlotHistory,
+		Priority:   contextfrag.PriorityForMessage(msg),
+		CacheClass: contextfrag.CacheNever,
+		Trust:      trustForDiscussRole(message.Role),
+		Scope:      scope,
+		Source:     discussContextSource,
+		SourceID:   fmt.Sprintf("message.%03d", index),
+		Collector:  discussContextCollectorName,
+		Index:      index,
+	}
+	if message.CompactionArtifactID != "" {
+		input.Kind = contextfrag.KindConversationSummary
+		input.Slot = contextfrag.SlotBeforeHistory
+		input.Priority = 10
+		input.CacheClass = contextfrag.CacheDynamic
+		input.Trust = contextfrag.TrustSystem
+		input.Budget = contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep}
+	} else if currentUser {
+		// Keep the history slot so rendering preserves the authoritative
+		// composed order; kind and overflow carry current-request semantics.
+		input.Kind = contextfrag.KindCurrentUserMessage
+		input.Trust = contextfrag.TrustUser
+		input.Budget = contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep}
+	}
+	return contextfrag.MessageFrag(input)
+}
+
+// injectDiscussImages mirrors the legacy inject-into-last-user-message
+// behavior at fragment granularity.
+func injectDiscussImages(frags []contextfrag.ContextFrag, images []sdk.ImagePart) []contextfrag.ContextFrag {
+	extra := make([]sdk.MessagePart, 0, len(images))
+	for _, img := range images {
+		if strings.TrimSpace(img.Image) != "" {
+			extra = append(extra, img)
+		}
+	}
+	if len(extra) == 0 {
+		return frags
+	}
+	for i := len(frags) - 1; i >= 0; i-- {
+		msg := contextfrag.FragMessage(frags[i])
+		if msg == nil || msg.Role != sdk.MessageRoleUser {
+			continue
+		}
+		enriched := *msg
+		enriched.Content = append(append([]sdk.MessagePart(nil), msg.Content...), extra...)
+		frags[i] = contextfrag.RebuildFragMessage(frags[i], enriched)
+		return frags
+	}
+	return frags
+}
+
+func discussContextConfig(config any) (DiscussContextConfig, error) {
+	return collectorConfig[DiscussContextConfig](config, "discuss_context config must be DiscussContextConfig")
+}
+
+func discussContextMessageToSDK(message timeline.ContextMessage) sdk.Message {
+	if len(message.RawContent) > 0 {
+		raw, err := json.Marshal(struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		}{
+			Role:    message.Role,
+			Content: message.RawContent,
+		})
+		if err == nil {
+			var msg sdk.Message
+			if json.Unmarshal(raw, &msg) == nil {
+				return msg
+			}
+		}
+	}
+	if message.Role == "assistant" {
+		return sdk.AssistantMessage(message.Content)
+	}
+	return sdk.UserMessage(message.Content)
+}
+
+func trustForDiscussRole(role string) contextfrag.TrustLevel {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "assistant", "tool":
+		return contextfrag.TrustWorkspace
+	default:
+		return contextfrag.TrustExternal
+	}
+}

--- a/internal/contextview/collector_discuss_provider_repair_test.go
+++ b/internal/contextview/collector_discuss_provider_repair_test.go
@@ -1,0 +1,83 @@
+package contextview
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+func TestDiscussCollectorProviderIntentRepairsDanglingToolCalls(t *testing.T) {
+	t.Parallel()
+
+	frags := collectDiscussProviderContext(t, []timeline.ContextMessage{
+		{
+			Role:       "assistant",
+			Content:    "calling lookup",
+			RawContent: json.RawMessage(`[{"type":"tool-call","toolCallId":"call-1","toolName":"lookup","input":{"query":"answer"}}]`),
+		},
+		{Role: "user", Content: "next question"},
+	})
+
+	if len(frags) != 3 {
+		t.Fatalf("frags = %d, want assistant call, synthetic result, and current user", len(frags))
+	}
+	synthetic := frags[1]
+	msg := discussFragMessage(synthetic)
+	if msg == nil || msg.Role != sdk.MessageRoleTool || len(msg.Content) != 1 {
+		t.Fatalf("synthetic closure message = %#v, want one tool result", msg)
+	}
+	result, ok := msg.Content[0].(sdk.ToolResultPart)
+	if !ok ||
+		result.ToolCallID != "call-1" ||
+		result.ToolName != "lookup" ||
+		result.Result != contextfrag.ToolClosureRepairText ||
+		!result.IsError {
+		t.Fatalf("synthetic closure result = %#v, want interrupted call-1 lookup result", msg.Content[0])
+	}
+	if synthetic.Provenance.Source != contextfrag.SourceToolClosureRepair ||
+		synthetic.Provenance.Collector != discussContextCollectorName {
+		t.Fatalf("synthetic closure provenance = %+v, want discuss repair attribution", synthetic.Provenance)
+	}
+}
+
+func TestDiscussCollectorProviderIntentDropsOrphanToolResults(t *testing.T) {
+	t.Parallel()
+
+	frags := collectDiscussProviderContext(t, []timeline.ContextMessage{
+		{
+			Role:       "tool",
+			Content:    "debug fallback",
+			RawContent: json.RawMessage(`[{"type":"tool-result","toolCallId":"call-1","toolName":"lookup","result":{"answer":42}}]`),
+		},
+		{Role: "user", Content: "next question"},
+	})
+
+	if len(frags) != 1 {
+		t.Fatalf("frags = %d, want only the current user after orphan repair", len(frags))
+	}
+	msg := discussFragMessage(frags[0])
+	if msg == nil {
+		t.Fatal("remaining current-user fragment has no SDK message")
+	}
+	assertMessagesEqual(t, []sdk.Message{*msg}, []sdk.Message{sdk.UserMessage("next question")})
+}
+
+func collectDiscussProviderContext(t *testing.T, messages []timeline.ContextMessage) []contextfrag.ContextFrag {
+	t.Helper()
+	frags, err := (&DiscussContextCollector{}).Collect(context.Background(), CollectRequest{
+		Scope:  contextfrag.Scope{BotID: "bot-1", SessionID: "s1"},
+		Intent: contextfrag.IntentRunConfigPreProvider,
+		Config: DiscussContextConfig{
+			ComposedMessages: messages,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	return frags
+}

--- a/internal/contextview/collector_discuss_test.go
+++ b/internal/contextview/collector_discuss_test.go
@@ -1,0 +1,128 @@
+package contextview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+func TestDiscussCollector_ComposedMessagesAreAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	composed := []timeline.ContextMessage{
+		{Role: "user", Content: "first user"},
+		{Role: "assistant", Content: "assistant reply"},
+		{
+			Role:                 "user",
+			Content:              "<summary>covered history</summary>",
+			CompactionArtifactID: "artifact-1",
+		},
+		{
+			Role:       "tool",
+			Content:    "debug fallback",
+			RawContent: json.RawMessage(`[{"type":"tool-result","toolCallId":"call-1","toolName":"lookup","result":{"answer":42}}]`),
+		},
+		{Role: "user", Content: "latest user"},
+	}
+	image := sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"}
+	frags := collectDiscussContext(t, DiscussContextConfig{
+		ComposedMessages: composed,
+		InlineImages:     []sdk.ImagePart{image},
+	})
+
+	assertDiscussIDs(t, frags, []string{
+		"discuss.message.000",
+		"discuss.message.001",
+		"discuss.message.002",
+		"discuss.message.003",
+		"discuss.message.004",
+	})
+	for i, frag := range frags {
+		if frag.Provenance.Source != discussContextSource ||
+			frag.Provenance.SourceID != fmt.Sprintf("message.%03d", i) ||
+			frag.Provenance.Collector != discussContextCollectorName ||
+			frag.Provenance.Index != i {
+			t.Fatalf("frag %d provenance = %+v", i, frag.Provenance)
+		}
+	}
+
+	summary := frags[2]
+	if summary.Kind != contextfrag.KindConversationSummary ||
+		summary.Slot != contextfrag.SlotBeforeHistory ||
+		summary.CacheClass != contextfrag.CacheDynamic ||
+		summary.Trust != contextfrag.TrustSystem ||
+		summary.Budget.Overflow != contextfrag.OverflowKeep {
+		t.Fatalf("summary policy = kind %q slot %q cache %q trust %q overflow %q",
+			summary.Kind, summary.Slot, summary.CacheClass, summary.Trust, summary.Budget.Overflow)
+	}
+
+	current := frags[len(frags)-1]
+	if current.Kind != contextfrag.KindCurrentUserMessage ||
+		current.Slot != contextfrag.SlotHistory ||
+		current.Trust != contextfrag.TrustUser ||
+		current.Budget.Overflow != contextfrag.OverflowKeep {
+		t.Fatalf("current request policy = kind %q slot %q trust %q overflow %q",
+			current.Kind, current.Slot, current.Trust, current.Budget.Overflow)
+	}
+	currentMessage := contextfrag.FragMessage(current)
+	if currentMessage == nil || len(currentMessage.Content) != 2 {
+		t.Fatalf("current message = %#v, want text plus image", currentMessage)
+	}
+	if got, ok := currentMessage.Content[1].(sdk.ImagePart); !ok || got.Image != image.Image {
+		t.Fatalf("current image = %#v, want %#v", currentMessage.Content[1], image)
+	}
+	if frags[0].Kind == contextfrag.KindCurrentUserMessage || frags[2].Kind == contextfrag.KindCurrentUserMessage {
+		t.Fatalf("only the latest non-artifact user may be current: %#v", frags)
+	}
+
+	toolMessage := contextfrag.FragMessage(frags[3])
+	if toolMessage == nil || toolMessage.Role != sdk.MessageRoleTool || len(toolMessage.Content) != 1 {
+		t.Fatalf("structured tool message = %#v", toolMessage)
+	}
+}
+
+func TestDiscussCollector_NonNilEmptyComposedMessagesAreAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	frags := collectDiscussContext(t, DiscussContextConfig{
+		ComposedMessages: []timeline.ContextMessage{},
+		InlineImages: []sdk.ImagePart{{
+			Image:     "data:image/png;base64,ignored-without-user",
+			MediaType: "image/png",
+		}},
+	})
+	if frags == nil || len(frags) != 0 {
+		t.Fatalf("frags = %#v, want authoritative non-nil empty result", frags)
+	}
+}
+
+func collectDiscussContext(t *testing.T, cfg DiscussContextConfig) []contextfrag.ContextFrag {
+	t.Helper()
+	frags, err := (&DiscussContextCollector{}).Collect(context.Background(), CollectRequest{
+		Scope:  contextfrag.Scope{BotID: "bot-1", SessionID: "s1"},
+		Intent: contextfrag.IntentDiscussReply,
+		Config: cfg,
+	})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	return frags
+}
+
+func assertDiscussIDs(t *testing.T, frags []contextfrag.ContextFrag, want []string) {
+	t.Helper()
+	if len(frags) != len(want) {
+		t.Fatalf("frag count = %d, want %d", len(frags), len(want))
+	}
+	for i, id := range want {
+		if frags[i].ID != id {
+			t.Fatalf("frag %d ID = %q, want %q", i, frags[i].ID, id)
+		}
+	}
+}

--- a/internal/contextview/collector_history.go
+++ b/internal/contextview/collector_history.go
@@ -23,6 +23,12 @@ type HistoryMessagesConfig struct {
 	// MemoryMessageIndex identifies materialized memory recall that must be
 	// collected separately without changing its provider message position.
 	MemoryMessageIndex *int
+	// TokenEstimates carries per-message token estimates computed at the
+	// source. Missing entries fall back to fragment-side estimation.
+	TokenEstimates []int
+	// TrimmablePrefix marks the leading message count that may be dropped.
+	// Messages at or after the boundary are protected.
+	TrimmablePrefix int
 	// RepairToolClosures applies the shared repair when a caller has not
 	// already repaired its materialized message stream.
 	RepairToolClosures bool
@@ -52,18 +58,28 @@ func (*HistoryMessagesCollector) Collect(_ context.Context, req CollectRequest) 
 		if hasCurrentUser && i == currentUserIndex || hasMemory && i == memoryIndex {
 			continue
 		}
+		estimate := 0
+		if i < len(cfg.TokenEstimates) {
+			estimate = cfg.TokenEstimates[i]
+		}
+		budget := contextfrag.BudgetPolicy{}
+		if i >= cfg.TrimmablePrefix {
+			budget.Overflow = contextfrag.OverflowKeep
+		}
 		frags = append(frags, contextfrag.MessageFrag(contextfrag.MessageFragInput{
-			ID:         fmt.Sprintf("message.%03d", i),
-			Message:    msg,
-			Kind:       kindForSDKMessage(msg),
-			Slot:       contextfrag.SlotHistory,
-			Priority:   contextfrag.PriorityForMessage(msg),
-			CacheClass: cacheForSDKMessage(msg),
-			Trust:      trustForSDKMessage(msg),
-			Scope:      historyScope,
-			Source:     contextfrag.SourceRunConfig,
-			Collector:  historyMessagesCollectorName,
-			Index:      i,
+			ID:            fmt.Sprintf("message.%03d", i),
+			Message:       msg,
+			Kind:          kindForSDKMessage(msg),
+			Slot:          contextfrag.SlotHistory,
+			Priority:      contextfrag.PriorityForMessage(msg),
+			CacheClass:    cacheForSDKMessage(msg),
+			Trust:         trustForSDKMessage(msg),
+			Scope:         historyScope,
+			Source:        contextfrag.SourceRunConfig,
+			Collector:     historyMessagesCollectorName,
+			Index:         i,
+			Budget:        budget,
+			TokenEstimate: estimate,
 		}))
 	}
 	if cfg.RepairToolClosures {
@@ -88,20 +104,25 @@ func (*materializedCurrentUserCollector) Collect(_ context.Context, req CollectR
 	if !ok {
 		return nil, nil
 	}
+	estimate := 0
+	if index < len(cfg.TokenEstimates) {
+		estimate = cfg.TokenEstimates[index]
+	}
 	msg := cfg.Messages[index]
 	return []contextfrag.ContextFrag{contextfrag.MessageFrag(contextfrag.MessageFragInput{
-		ID:         fmt.Sprintf("message.%03d", index),
-		Message:    msg,
-		Kind:       contextfrag.KindCurrentUserMessage,
-		Slot:       contextfrag.SlotCurrentUser,
-		Priority:   contextfrag.PriorityForMessage(msg),
-		CacheClass: contextfrag.CacheNever,
-		Trust:      contextfrag.TrustUser,
-		Scope:      req.Scope,
-		Source:     contextfrag.SourceRunConfig,
-		Collector:  materializedCurrentUserCollectorName,
-		Index:      index,
-		Budget:     contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep},
+		ID:            fmt.Sprintf("message.%03d", index),
+		Message:       msg,
+		Kind:          contextfrag.KindCurrentUserMessage,
+		Slot:          contextfrag.SlotCurrentUser,
+		Priority:      contextfrag.PriorityForMessage(msg),
+		CacheClass:    contextfrag.CacheNever,
+		Trust:         contextfrag.TrustUser,
+		Scope:         req.Scope,
+		Source:        contextfrag.SourceRunConfig,
+		Collector:     materializedCurrentUserCollectorName,
+		Index:         index,
+		Budget:        contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep},
+		TokenEstimate: estimate,
 	})}, nil
 }
 

--- a/internal/contextview/collector_history_test.go
+++ b/internal/contextview/collector_history_test.go
@@ -62,3 +62,72 @@ func TestMaterializedCurrentIndexFallsBackToLatestUser(t *testing.T) {
 		t.Fatalf("frags = %#v", frags)
 	}
 }
+
+func TestHistoryCollectorsCarryBudgetInputsAndPinTheTail(t *testing.T) {
+	t.Parallel()
+
+	current := 2
+	memory := 1
+	cfg := HistoryMessagesConfig{
+		Messages: []sdk.Message{
+			sdk.AssistantMessage("droppable history"),
+			sdk.UserMessage("memory recall"),
+			sdk.UserMessage("current request"),
+		},
+		CurrentUserMessageIndex: &current,
+		MemoryMessageIndex:      &memory,
+		TokenEstimates:          []int{11, 22, 33},
+		TrimmablePrefix:         1,
+	}
+
+	history, err := (&HistoryMessagesCollector{}).Collect(context.Background(), CollectRequest{Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("history = %#v, want only the ordinary history message", history)
+	}
+	if history[0].TokenEstimate != 11 || history[0].Budget.Overflow != "" {
+		t.Fatalf("history budget fields = %#v, want estimate 11 and droppable overflow", history[0])
+	}
+
+	currentFrags, err := (&materializedCurrentUserCollector{}).Collect(context.Background(), CollectRequest{Config: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(currentFrags) != 1 || currentFrags[0].TokenEstimate != 33 ||
+		currentFrags[0].Budget.Overflow != contextfrag.OverflowKeep {
+		t.Fatalf("current fragment = %#v, want estimate 33 and OverflowKeep", currentFrags)
+	}
+}
+
+func TestHistoryCollectorPinsMessagesAtTrimmableBoundary(t *testing.T) {
+	t.Parallel()
+
+	frags, err := (&HistoryMessagesCollector{}).Collect(context.Background(), CollectRequest{
+		Config: HistoryMessagesConfig{
+			Messages:        []sdk.Message{sdk.UserMessage("old"), sdk.AssistantMessage("tail")},
+			TokenEstimates:  []int{7},
+			TrimmablePrefix: 1,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frags) != 2 || frags[0].TokenEstimate != 7 || frags[1].TokenEstimate != 0 {
+		t.Fatalf("token estimates = %#v, want 7 then renderer fallback", frags)
+	}
+	if frags[0].Budget.Overflow != "" || frags[1].Budget.Overflow != contextfrag.OverflowKeep {
+		t.Fatalf("overflow policies = %#v / %#v", frags[0].Budget, frags[1].Budget)
+	}
+
+	pinned, err := (&HistoryMessagesCollector{}).Collect(context.Background(), CollectRequest{
+		Config: HistoryMessagesConfig{Messages: []sdk.Message{sdk.UserMessage("all pinned")}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pinned) != 1 || pinned[0].Budget.Overflow != contextfrag.OverflowKeep {
+		t.Fatalf("zero-prefix history = %#v, want all messages pinned", pinned)
+	}
+}

--- a/internal/contextview/discuss_builder.go
+++ b/internal/contextview/discuss_builder.go
@@ -1,0 +1,44 @@
+package contextview
+
+import (
+	"context"
+	"slices"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+// DiscussSDKContextBuilder assembles typed source fragments for a discuss
+// turn without reverse-parsing a system prompt that is already structured.
+type DiscussSDKContextBuilder struct{}
+
+func (*DiscussSDKContextBuilder) CollectDiscussSourceFrags(
+	ctx context.Context,
+	scope contextfrag.Scope,
+	system string,
+	input DiscussContextInput,
+) ([]contextfrag.ContextFrag, error) {
+	systemFrags := input.SystemFrags
+	if len(systemFrags) == 0 {
+		collected, err := (&SystemPromptCollector{}).Collect(ctx, CollectRequest{
+			Scope:  scope,
+			Intent: contextfrag.IntentRunConfigPreProvider,
+			Config: SystemPromptConfig{System: system, SplitWorkspace: true},
+		})
+		if err != nil {
+			return nil, err
+		}
+		systemFrags = collected
+	}
+	discussFrags, err := (&DiscussContextCollector{}).Collect(ctx, CollectRequest{
+		Scope:  scope,
+		Intent: contextfrag.IntentRunConfigPreProvider,
+		Config: DiscussContextConfig{
+			ComposedMessages: input.ComposedMessages,
+			InlineImages:     input.InlineImages,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return slices.Concat(systemFrags, discussFrags), nil
+}

--- a/internal/contextview/discuss_context_types.go
+++ b/internal/contextview/discuss_context_types.go
@@ -1,0 +1,16 @@
+package contextview
+
+import (
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+// DiscussContextInput carries the authoritative timeline composition and
+// already-typed system fragments for one discuss turn.
+type DiscussContextInput struct {
+	ComposedMessages []timeline.ContextMessage
+	InlineImages     []sdk.ImagePart
+	SystemFrags      []contextfrag.ContextFrag
+}

--- a/internal/contextview/discuss_equivalence_test.go
+++ b/internal/contextview/discuss_equivalence_test.go
@@ -1,0 +1,270 @@
+package contextview
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+func TestDiscussEquivalence_BasicRCAndTR(t *testing.T) {
+	t.Parallel()
+
+	assertDiscussEquivalent(t, discussLegacyInput{
+		system: "Discuss system prompt.",
+		rc: timeline.RenderedContext{
+			renderedTextSegment(100, "first rc"),
+			renderedTextSegment(300, "second rc"),
+		},
+		trs: []timeline.TurnResponseEntry{{
+			RequestedAtMs: 200,
+			Role:          "assistant",
+			Content:       "assistant turn",
+		}},
+	})
+}
+
+func TestDiscussEquivalence_ConsecutiveRCMerged(t *testing.T) {
+	t.Parallel()
+
+	assertDiscussEquivalent(t, discussLegacyInput{
+		rc: timeline.RenderedContext{
+			renderedTextSegment(100, "one"),
+			renderedTextSegment(200, "two"),
+			renderedTextSegment(300, "three"),
+		},
+	})
+}
+
+func TestDiscussEquivalence_CompactSummaryPrepended(t *testing.T) {
+	t.Parallel()
+
+	assertDiscussEquivalent(t, discussLegacyInput{
+		summary: "older context summary",
+		rc:      timeline.RenderedContext{renderedTextSegment(100, "live context")},
+	})
+}
+
+func TestDiscussEquivalence_TRWithRawContent(t *testing.T) {
+	t.Parallel()
+
+	assertDiscussEquivalent(t, discussLegacyInput{
+		rc: timeline.RenderedContext{renderedTextSegment(200, "next question")},
+		trs: []timeline.TurnResponseEntry{{
+			RequestedAtMs: 100,
+			Role:          "tool",
+			Content:       "debug text",
+			RawContent:    json.RawMessage(`[{"type":"tool-result","toolCallId":"call-1","toolName":"lookup","result":{"answer":42}}]`),
+		}},
+	})
+}
+
+func TestDiscussEquivalence_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	assertDiscussEquivalent(t, discussLegacyInput{})
+}
+
+func TestDiscussEquivalence_RCBeforeTROnEqualTimestamp(t *testing.T) {
+	t.Parallel()
+
+	assertDiscussEquivalent(t, discussLegacyInput{
+		rc: timeline.RenderedContext{
+			renderedTextSegment(100, "same-time rc"),
+		},
+		trs: []timeline.TurnResponseEntry{{
+			RequestedAtMs: 100,
+			Role:          "assistant",
+			Content:       "same-time tr",
+		}},
+	})
+}
+
+func TestDiscussSelector_ProfileMustKeepSystemAndCurrentUser(t *testing.T) {
+	t.Parallel()
+
+	profile := (&FragmentSelector{}).ProfileFor(contextfrag.IntentDiscussReply)
+
+	if profile.Intent != contextfrag.IntentDiscussReply {
+		t.Fatalf("Intent = %q, want %q", profile.Intent, contextfrag.IntentDiscussReply)
+	}
+	if !slotInProfile(profile, contextfrag.SlotSystem) {
+		t.Fatalf("MustKeepSlots = %#v, want system", profile.MustKeepSlots)
+	}
+	if !slotInProfile(profile, contextfrag.SlotCurrentUser) {
+		t.Fatalf("MustKeepSlots = %#v, want current_user", profile.MustKeepSlots)
+	}
+}
+
+func TestDiscussSelector_BudgetedSelectionDropsCanDropHistory(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		messageFrag("old-user", sdk.UserMessage("old question")),
+		messageFrag("old-assistant", sdk.AssistantMessage("old answer")),
+		messageFrag("latest", sdk.UserMessage("latest question")),
+	}
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentDiscussReply)
+
+	result := selector.Select(frags, profile, BudgetEnvelope{MaxTokens: 1})
+
+	assertSelectedIDs(t, result, []string{"latest"})
+	assertDroppedReason(t, result, "old-user", budgetDropReasonUntiered)
+	assertDroppedReason(t, result, "old-assistant", budgetDropReasonUntiered)
+}
+
+func TestDiscussSelector_BudgetedSelectionKeepsAllWhenWithinBudget(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		messageFrag("old-user", sdk.UserMessage("old question")),
+		messageFrag("old-assistant", sdk.AssistantMessage("old answer")),
+		messageFrag("latest", sdk.UserMessage("latest question")),
+	}
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentDiscussReply)
+
+	result := selector.Select(frags, profile, BudgetEnvelope{MaxTokens: 1000})
+
+	assertSelectedIDs(t, result, []string{"old-user", "old-assistant", "latest"})
+	if len(result.Dropped) != 0 {
+		t.Fatalf("dropped = %#v, want none", fragIDs(result.Dropped))
+	}
+}
+
+func TestSelector_ProviderBudgetedIntentDropsCanDropHistory(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		messageFrag("old-user", sdk.UserMessage("old question")),
+		messageFrag("old-assistant", sdk.AssistantMessage("old answer")),
+		messageFrag("latest", sdk.UserMessage("latest question")),
+	}
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	result := selector.Select(frags, profile, BudgetEnvelope{MaxTokens: 1})
+
+	assertSelectedIDs(t, result, []string{"latest"})
+	assertDroppedReason(t, result, "old-user", budgetDropReasonUntiered)
+	assertDroppedReason(t, result, "old-assistant", budgetDropReasonUntiered)
+}
+
+type discussLegacyInput struct {
+	system  string
+	rc      timeline.RenderedContext
+	trs     []timeline.TurnResponseEntry
+	summary string
+}
+
+func assertDiscussEquivalent(t *testing.T, input discussLegacyInput) {
+	t.Helper()
+	scope := contextfrag.Scope{BotID: "bot-1", SessionID: "s1"}
+	composedMessages := composeDiscussMessages(input.rc, input.trs, input.summary)
+	flatMessages := legacyContextMessagesToSDK(composedMessages)
+	legacyRendered, err := applyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{
+		System:                   input.system,
+		Messages:                 flatMessages,
+		ContextQueryMaterialized: true,
+		ContextScope:             scope,
+	})
+	if err != nil {
+		t.Fatalf("legacy applyProviderRunConfig() error: %v", err)
+	}
+	typedFrags, err := (&DiscussSDKContextBuilder{}).CollectDiscussSourceFrags(
+		context.Background(),
+		scope,
+		input.system,
+		DiscussContextInput{ComposedMessages: composedMessages},
+	)
+	if err != nil {
+		t.Fatalf("CollectDiscussSourceFrags() error: %v", err)
+	}
+	typedRendered, err := applyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{
+		System:                   input.system,
+		Messages:                 flatMessages,
+		ContextSourceFrags:       typedFrags,
+		ContextQueryMaterialized: true,
+		ContextScope:             scope,
+	})
+	if err != nil {
+		t.Fatalf("typed applyProviderRunConfig() error: %v", err)
+	}
+	for _, mutation := range typedRendered.ContextManifest.Mutations.Records() {
+		if mutation.Kind == contextfrag.MutationContextViewFallback {
+			t.Fatalf("typed provider path fell back to the flat oracle: %+v", mutation)
+		}
+	}
+
+	if typedRendered.System != legacyRendered.System {
+		t.Fatalf("typed System = %q, want legacy %q", typedRendered.System, legacyRendered.System)
+	}
+	assertMessagesEqual(t, typedRendered.Messages, legacyRendered.Messages)
+}
+
+func composeDiscussMessages(rc timeline.RenderedContext, trs []timeline.TurnResponseEntry, summary string) []timeline.ContextMessage {
+	var artifacts []timeline.CompactionArtifact
+	if strings.TrimSpace(summary) != "" {
+		artifacts = []timeline.CompactionArtifact{{ID: "equivalence-artifact", Summary: summary}}
+	}
+	composed := timeline.ComposeContextWithArtifacts(rc, trs, artifacts)
+	if composed == nil {
+		return make([]timeline.ContextMessage, 0)
+	}
+	return composed.Messages
+}
+
+func legacyContextMessagesToSDK(messages []timeline.ContextMessage) []sdk.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	result := make([]sdk.Message, 0, len(messages))
+	for _, message := range messages {
+		if len(message.RawContent) > 0 {
+			raw, err := json.Marshal(struct {
+				Role    string          `json:"role"`
+				Content json.RawMessage `json:"content"`
+			}{
+				Role:    message.Role,
+				Content: message.RawContent,
+			})
+			if err == nil {
+				var msg sdk.Message
+				if json.Unmarshal(raw, &msg) == nil {
+					result = append(result, msg)
+					continue
+				}
+			}
+		}
+		switch message.Role {
+		case "assistant":
+			result = append(result, sdk.AssistantMessage(message.Content))
+		case "user", "tool":
+			result = append(result, sdk.UserMessage(message.Content))
+		default:
+			result = append(result, sdk.UserMessage(message.Content))
+		}
+	}
+	return result
+}
+
+func renderedTextSegment(atMs int64, text string) timeline.RenderedSegment {
+	return timeline.RenderedSegment{
+		ReceivedAtMs: atMs,
+		Content:      []timeline.RenderedContentPiece{{Type: "text", Text: text}},
+	}
+}
+
+func slotInProfile(profile IntentProfile, slot contextfrag.Slot) bool {
+	if slotInMustKeepSlots(profile, slot) {
+		return true
+	}
+	return profile.MustKeepFrag != nil && profile.MustKeepFrag(contextfrag.ContextFrag{Slot: slot})
+}

--- a/internal/contextview/discuss_sections_test.go
+++ b/internal/contextview/discuss_sections_test.go
@@ -1,0 +1,192 @@
+package contextview
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
+	"github.com/memohai/memoh/internal/chat/timeline"
+)
+
+func discussSectionsInputFixture() DiscussContextInput {
+	rc := timeline.RenderedContext{
+		renderedTextSegment(100, "first rc"),
+		renderedTextSegment(300, "second rc"),
+	}
+	trs := []timeline.TurnResponseEntry{{
+		RequestedAtMs: 200,
+		Role:          "assistant",
+		Content:       "assistant turn",
+	}}
+	composed := timeline.ComposeContextWithArtifacts(rc, trs, []timeline.CompactionArtifact{{
+		ID:      "fixture-artifact",
+		Summary: "older summary",
+	}})
+	return DiscussContextInput{
+		ComposedMessages: composed.Messages,
+	}
+}
+
+func TestCollectDiscussSourceFragsUsesProvidedSystemFrags(t *testing.T) {
+	t.Parallel()
+
+	scope := contextfrag.Scope{BotID: "bot-1", SessionID: "s1"}
+	params := agentpkg.SystemPromptParams{
+		SessionType: sessionmode.Discuss,
+		Bot:         agentpkg.BotInfo{ID: "bot-1", Name: "research-bot"},
+	}
+	input := discussSectionsInputFixture()
+	input.SystemFrags = agentpkg.SystemSectionFrags(agentpkg.GenerateSystemSections(params), scope)
+
+	frags, err := (&DiscussSDKContextBuilder{}).CollectDiscussSourceFrags(
+		context.Background(), scope, "REVERSE_PARSE_MUST_NOT_RUN", input)
+	if err != nil {
+		t.Fatalf("CollectDiscussSourceFrags error: %v", err)
+	}
+	if len(frags) <= len(input.SystemFrags) {
+		t.Fatalf("frags = %d, want provided system frags followed by discuss frags", len(frags))
+	}
+	if !reflect.DeepEqual(frags[:len(input.SystemFrags)], input.SystemFrags) {
+		t.Fatalf("leading frags = %#v, want the provided system frags verbatim", frags[:len(input.SystemFrags)])
+	}
+	kinds := make(map[contextfrag.Kind]bool, len(frags))
+	for _, frag := range frags {
+		kinds[frag.Kind] = true
+		for _, part := range frag.Parts {
+			if strings.Contains(part.Text, "REVERSE_PARSE_MUST_NOT_RUN") {
+				t.Fatalf("flat system string must not be reverse-parsed when SystemFrags are provided: %#v", frag)
+			}
+		}
+	}
+	if !kinds[contextfrag.KindBotIdentity] {
+		t.Fatalf("system frags must keep the typed bot identity kind, kinds = %#v", kinds)
+	}
+}
+
+func TestCollectDiscussSourceFragsDoesNotAliasProvidedSystemFrags(t *testing.T) {
+	t.Parallel()
+
+	scope := contextfrag.Scope{BotID: "bot-1", SessionID: "s1"}
+	params := agentpkg.SystemPromptParams{
+		SessionType: sessionmode.Discuss,
+		Bot:         agentpkg.BotInfo{ID: "bot-1", Name: "research-bot"},
+	}
+	provided := agentpkg.SystemSectionFrags(agentpkg.GenerateSystemSections(params), scope)
+	withSpareCap := make([]contextfrag.ContextFrag, len(provided), len(provided)+8)
+	copy(withSpareCap, provided)
+	input := discussSectionsInputFixture()
+	input.SystemFrags = withSpareCap
+
+	frags, err := (&DiscussSDKContextBuilder{}).CollectDiscussSourceFrags(
+		context.Background(), scope, "", input)
+	if err != nil {
+		t.Fatalf("CollectDiscussSourceFrags error: %v", err)
+	}
+	if len(frags) <= len(withSpareCap) {
+		t.Fatalf("frags = %d, want discuss frags after the system frags", len(frags))
+	}
+	firstDiscussID := frags[len(withSpareCap)].ID
+
+	_ = append(withSpareCap, contextfrag.ContextFrag{ID: "caller-sentinel"})
+
+	if got := frags[len(withSpareCap)].ID; got != firstDiscussID {
+		t.Fatalf("returned frags share the caller's backing array: frag ID = %q, want %q", got, firstDiscussID)
+	}
+}
+
+func TestCollectDiscussSourceFragsSectionsMatchReverseParseRender(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		params agentpkg.SystemPromptParams
+	}{
+		{
+			name:   "minimal",
+			params: agentpkg.SystemPromptParams{SessionType: sessionmode.Discuss},
+		},
+		{
+			name: "full",
+			params: agentpkg.SystemPromptParams{
+				SessionType:               sessionmode.Discuss,
+				Bot:                       agentpkg.BotInfo{ID: "bot-1", Name: "research-bot", DisplayName: "Research Bot", Timezone: "Asia/Shanghai"},
+				Skills:                    []agentpkg.SkillEntry{{Name: "foo-skill", Description: "does foo things"}},
+				Files:                     []agentpkg.SystemFile{{Filename: "AGENTS.md", Content: "workspace rules"}},
+				Timezone:                  "Asia/Shanghai",
+				PlatformIdentitiesSection: "## Platform identities\n\n- telegram: `12345`",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scope := contextfrag.Scope{BotID: "bot-1", SessionID: "s1"}
+			system := agentpkg.GenerateSystemPrompt(tc.params)
+			builder := &DiscussSDKContextBuilder{}
+
+			legacyInput := discussSectionsInputFixture()
+			legacyFrags, err := builder.CollectDiscussSourceFrags(context.Background(), scope, system, legacyInput)
+			if err != nil {
+				t.Fatalf("legacy CollectDiscussSourceFrags error: %v", err)
+			}
+			sectionsInput := discussSectionsInputFixture()
+			sectionsInput.SystemFrags = agentpkg.SystemSectionFrags(agentpkg.GenerateSystemSections(tc.params), scope)
+			sectionsFrags, err := builder.CollectDiscussSourceFrags(context.Background(), scope, system, sectionsInput)
+			if err != nil {
+				t.Fatalf("sections CollectDiscussSourceFrags error: %v", err)
+			}
+
+			const toolUsage = "## Tool usage\n\nuse tools wisely"
+			legacyRendered, err := applyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{
+				ContextSourceFrags: legacyFrags,
+				ContextScope:       scope,
+				ContextToolUsage:   toolUsage,
+			})
+			if err != nil {
+				t.Fatalf("legacy applyProviderRunConfig error: %v", err)
+			}
+			sectionsRendered, err := applyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{
+				ContextSourceFrags: sectionsFrags,
+				ContextScope:       scope,
+				ContextToolUsage:   toolUsage,
+			})
+			if err != nil {
+				t.Fatalf("sections applyProviderRunConfig error: %v", err)
+			}
+			if sectionsRendered.System != legacyRendered.System {
+				t.Fatalf("sections System diverges from reverse-parse System:\ngot:  %q\nwant: %q",
+					sectionsRendered.System, legacyRendered.System)
+			}
+			if !reflect.DeepEqual(sectionsRendered.Messages, legacyRendered.Messages) {
+				t.Fatalf("sections messages diverge:\ngot:  %#v\nwant: %#v",
+					sectionsRendered.Messages, legacyRendered.Messages)
+			}
+
+			budgetedSectionsRendered, err := applyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{
+				SessionType:            sessionmode.Discuss,
+				ContextSourceFrags:     sectionsFrags,
+				ContextScope:           scope,
+				ContextToolUsage:       toolUsage,
+				ContextBudgetMaxTokens: 128000,
+			})
+			if err != nil {
+				t.Fatalf("budgeted sections applyProviderRunConfig error: %v", err)
+			}
+			if budgetedSectionsRendered.ContextManifest.BudgetPlan == nil {
+				t.Fatal("budgeted discuss sections did not produce an active plan")
+			}
+			if budgetedSectionsRendered.System != legacyRendered.System {
+				t.Fatalf("budgeted sections System diverges from legacy System:\ngot:  %q\nwant: %q",
+					budgetedSectionsRendered.System, legacyRendered.System)
+			}
+			if !reflect.DeepEqual(budgetedSectionsRendered.Messages, legacyRendered.Messages) {
+				t.Fatalf("budgeted sections messages diverge:\ngot:  %#v\nwant: %#v",
+					budgetedSectionsRendered.Messages, legacyRendered.Messages)
+			}
+		})
+	}
+}

--- a/internal/contextview/interfaces.go
+++ b/internal/contextview/interfaces.go
@@ -39,9 +39,18 @@ type Selector interface {
 type SelectionResult struct {
 	Selected []contextfrag.ContextFrag
 	Dropped  []contextfrag.ContextFrag
-	Edited   []contextfrag.ContextEditTrace
-	Warnings []contextfrag.ValidationWarning
-	Summary  SelectionSummary
+	// FatalError stops rendering while allowing Builder to return the partial,
+	// content-light selection audit accumulated before the failure.
+	FatalError error
+	// TrimNotice reports that budget trimming dropped history and the builder
+	// must splice the trim notice into Selected at TrimNoticeIndex.
+	TrimNotice      bool
+	TrimNoticeIndex int
+	Edited          []contextfrag.ContextEditTrace
+	// EditReasons maps an edited fragment ID to its stable selection reason.
+	EditReasons map[string]string
+	Warnings    []contextfrag.ValidationWarning
+	Summary     SelectionSummary
 }
 
 type IntentProfile struct {

--- a/internal/contextview/provider_budget_plan_test.go
+++ b/internal/contextview/provider_budget_plan_test.go
@@ -1,0 +1,505 @@
+package contextview
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+func contextWindowForDefaultOutputReserve(inputBudget int) int {
+	if inputBudget <= 0 {
+		return 0
+	}
+	window := inputBudget
+	for {
+		resolved := inputBudget + min(DefaultOutputReserveTokens, window/4)
+		if resolved == window {
+			return window
+		}
+		window = resolved
+	}
+}
+
+func TestProviderContextBudgetPlanAccountsForCurrentRequestAndTools(t *testing.T) {
+	t.Parallel()
+
+	current := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "current", Kind: contextfrag.KindCurrentUserMessage, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotCurrentUser, Text: "current request", Trust: contextfrag.TrustUser,
+	})
+	current.TokenEstimate = 120
+	image := contextfrag.ImageFrag("image", []sdk.ImagePart{{Image: "data:image/png;base64,abc", MediaType: "image/png"}}, contextfrag.Scope{}, contextfrag.SourceRunConfig)
+	history := contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: "history", Message: sdk.UserMessage("old"), Kind: contextfrag.KindConversationEvent,
+		Slot: contextfrag.SlotHistory, TokenEstimate: 900,
+	})
+	plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{
+		ContextBudgetMaxTokens: 20000,
+		ContextSourceFrags:     []contextfrag.ContextFrag{history, current, image},
+		ContextToolDefs: []contextfrag.ToolDefAccounting{
+			{Name: "one", TokenEstimate: 100},
+			{Name: "two", TokenEstimate: 200},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan == nil || plan.Window != 20000 || plan.OutputReserve != 5000 || plan.ToolDefsCost != 300 ||
+		plan.CurrentRequestCost != 120+contextfrag.EstimateImageTokens {
+		t.Fatalf("plan = %#v", plan)
+	}
+	if plan.Estimator != contextfrag.ProviderBudgetEstimator ||
+		plan.EstimatorSafetyFactorPercent != contextfrag.ProviderBudgetSafetyFactorPercent {
+		t.Fatalf("estimator contract = %q/%d", plan.Estimator, plan.EstimatorSafetyFactorPercent)
+	}
+}
+
+func TestProviderContextBudgetPlanUsesConservativeByteCosts(t *testing.T) {
+	t.Parallel()
+
+	current := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "current", Kind: contextfrag.KindCurrentUserMessage, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotCurrentUser, Text: "abcdefghijklmnop",
+	})
+	current.TokenEstimate = 1
+	plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{
+		ContextBudgetMaxTokens: 10000,
+		ContextSourceFrags:     []contextfrag.ContextFrag{current},
+		ContextToolDefs:        []contextfrag.ToolDefAccounting{{Name: "short", Bytes: 16, TokenEstimate: 1}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.ToolDefsCost != 5 || plan.CurrentRequestCost != 5 {
+		t.Fatalf("provider costs = tools %d current %d, want 5/5", plan.ToolDefsCost, plan.CurrentRequestCost)
+	}
+}
+
+func TestProviderContextBudgetPlanCountsSemanticCurrentInHistorySlot(t *testing.T) {
+	t.Parallel()
+
+	current := contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: "discuss.current", Message: sdk.UserMessage("current"), Kind: contextfrag.KindCurrentUserMessage,
+		Slot: contextfrag.SlotHistory, TokenEstimate: 123, Budget: contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep},
+	})
+	plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{
+		ContextBudgetMaxTokens: 10000,
+		ContextSourceFrags:     []contextfrag.ContextFrag{current},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.CurrentRequestCost != 123 {
+		t.Fatalf("CurrentRequestCost = %d, want 123", plan.CurrentRequestCost)
+	}
+}
+
+func TestProviderContextBudgetPlanOutputReserveCrossover(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		window int
+		want   int
+	}{{32767, 8191}, {32768, 8192}, {32769, 8192}} {
+		plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{ContextBudgetMaxTokens: tt.window})
+		if err != nil {
+			t.Fatalf("window %d: %v", tt.window, err)
+		}
+		if plan == nil || plan.OutputReserve != tt.want {
+			t.Fatalf("window %d plan = %#v, want reserve %d", tt.window, plan, tt.want)
+		}
+	}
+}
+
+func TestProviderContextBudgetPlanRejectsImpossibleWindow(t *testing.T) {
+	t.Parallel()
+
+	current := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "current", Kind: contextfrag.KindCurrentUserMessage, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotCurrentUser, Text: "oversized", Trust: contextfrag.TrustUser,
+	})
+	current.TokenEstimate = 6000
+	plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{
+		ContextBudgetMaxTokens: 8192,
+		ContextSourceFrags:     []contextfrag.ContextFrag{current},
+		ContextToolDefs:        []contextfrag.ToolDefAccounting{{Name: "tool", TokenEstimate: 100}},
+	})
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("error = %v, want ErrBudgetUnsatisfied", err)
+	}
+	if plan == nil || plan.OutputReserve != 2048 || plan.SystemBudget != MinimumSystemBudgetTokens {
+		t.Fatalf("plan = %#v", plan)
+	}
+}
+
+func TestProviderContextBudgetPlanUsesMaterializedRequestEstimate(t *testing.T) {
+	t.Parallel()
+
+	current := 1
+	plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{
+		Messages: []sdk.Message{sdk.AssistantMessage("old"), sdk.UserMessage("materialized")},
+		Query:    "do not count twice", InlineImages: []sdk.ImagePart{{Image: "data:image/png;base64,ignored"}},
+		ContextQueryMaterialized: true, ContextCurrentUserMessageIndex: &current,
+		ContextHistoryTokenEstimates: []int{77, 222}, ContextBudgetMaxTokens: 10000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.CurrentRequestCost != 222 {
+		t.Fatalf("CurrentRequestCost = %d, want 222", plan.CurrentRequestCost)
+	}
+}
+
+func TestProviderContextBudgetPlanDisabledWithoutWindow(t *testing.T) {
+	t.Parallel()
+
+	plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{})
+	if err != nil || plan != nil {
+		t.Fatalf("plan/error = %#v/%v, want nil/nil", plan, err)
+	}
+}
+
+func TestProviderContextBudgetPlanRejectsNegativeWindow(t *testing.T) {
+	t.Parallel()
+
+	plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{ContextBudgetMaxTokens: -1})
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) || plan == nil {
+		t.Fatalf("plan/error = %#v/%v, want plan and ErrBudgetUnsatisfied", plan, err)
+	}
+}
+
+func TestResolveRecentProtectTokens(t *testing.T) {
+	t.Parallel()
+
+	zero := 0
+	negative := -1
+	if got := resolveRecentProtectTokens(nil); got != DefaultRecentProtectTokens {
+		t.Fatalf("default = %d", got)
+	}
+	if got := resolveRecentProtectTokens(&zero); got != 0 {
+		t.Fatalf("zero override = %d", got)
+	}
+	if got := resolveRecentProtectTokens(&negative); got != 0 {
+		t.Fatalf("negative override = %d", got)
+	}
+}
+
+func TestProviderBudgetPlanIsAppliedAndRetained(t *testing.T) {
+	t.Parallel()
+
+	holder := contextfrag.NewLifecycleHolder()
+	current := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "current", Kind: contextfrag.KindCurrentUserMessage, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotCurrentUser, Text: "current", Trust: contextfrag.TrustUser,
+	})
+	current.TokenEstimate = 120
+	out, err := applyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{
+		ContextSourceFrags: []contextfrag.ContextFrag{current}, ContextBudgetMaxTokens: 8192,
+		ContextLifecycle: holder,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := out.ContextManifest.BudgetPlan
+	if plan == nil || plan.OutputReserve != 2048 || plan.CurrentRequestCost != 120 || plan.SystemBudget != 6024 {
+		t.Fatalf("budget plan = %#v", plan)
+	}
+	snapshot, ok := holder.Snapshot()
+	if !ok || snapshot.BudgetPlan == nil || snapshot.BudgetPlan.SystemBudget != 6024 {
+		t.Fatalf("holder snapshot = %#v, %v", snapshot, ok)
+	}
+}
+
+func TestApplyProviderRunConfigSemanticCurrentIsNotDoubleCharged(t *testing.T) {
+	t.Parallel()
+
+	requiredSystem := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID:            "system.required",
+		Kind:          contextfrag.KindSystemPrompt,
+		Role:          sdk.MessageRoleSystem,
+		Slot:          contextfrag.SlotSystem,
+		Text:          "required system",
+		RetentionTier: contextfrag.RetentionRequired,
+		Trust:         contextfrag.TrustSystem,
+	})
+	requiredSystem.TokenEstimate = 200
+	semanticCurrent := contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID:            "discuss.current",
+		Message:       sdk.UserMessage("current discuss request"),
+		Kind:          contextfrag.KindCurrentUserMessage,
+		Slot:          contextfrag.SlotHistory,
+		TokenEstimate: 100,
+		Trust:         contextfrag.TrustUser,
+		Budget:        contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep},
+	})
+	cfg := agentpkg.RunConfig{
+		ContextSourceFrags:     []contextfrag.ContextFrag{requiredSystem, semanticCurrent},
+		ContextBudgetMaxTokens: contextWindowForDefaultOutputReserve(356),
+	}
+
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ApplyProviderRunConfig() error = %v, want payload that fits its provider envelope", err)
+	}
+	plan := out.ContextManifest.BudgetPlan
+	if plan == nil ||
+		plan.CurrentRequestCost != 100 ||
+		plan.SystemBudget != 256 ||
+		plan.ActualSystemCost != 200 ||
+		plan.HistoryBudget != 56 {
+		t.Fatalf("budget plan = %#v, want current/system/actual/history = 100/256/200/56", plan)
+	}
+	assertMessagesEqual(t, out.Messages, []sdk.Message{sdk.UserMessage("current discuss request")})
+}
+
+func TestProviderBudgetFailureBypassesLegacyFallbackAndKeepsAudit(t *testing.T) {
+	t.Parallel()
+
+	holder := contextfrag.NewLifecycleHolder()
+	required := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "system.required", Kind: contextfrag.KindSystemPrompt, Role: sdk.MessageRoleSystem,
+		Slot: contextfrag.SlotSystem, Text: "required", Trust: contextfrag.TrustSystem,
+		RetentionTier: contextfrag.RetentionRequired,
+	})
+	required.TokenEstimate = 930
+	current := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "current", Kind: contextfrag.KindCurrentUserMessage, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotCurrentUser, Text: "current", Trust: contextfrag.TrustUser,
+	})
+	current.TokenEstimate = 10
+	out, err := applyProviderRunConfig(context.Background(), nil, agentpkg.RunConfig{
+		System: "legacy must not be selected", Messages: []sdk.Message{sdk.UserMessage("legacy")},
+		ContextSourceFrags: []contextfrag.ContextFrag{required, current}, ContextBudgetMaxTokens: 400,
+		ContextLifecycle: holder,
+	})
+	if !errors.Is(err, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("error = %v, want ErrProtectedContextOverflow", err)
+	}
+	if out.ContextManifest.BudgetPlan == nil || out.ContextManifest.Selection == nil {
+		t.Fatalf("failure manifest = %#v", out.ContextManifest)
+	}
+	records := out.ContextMutations.Records()
+	if len(records) != 1 || records[0].Kind != contextfrag.MutationContextBudgetFailure {
+		t.Fatalf("mutations = %#v", records)
+	}
+	for _, record := range records {
+		if record.Kind == contextfrag.MutationContextViewFallback {
+			t.Fatalf("budget failure used legacy fallback: %#v", records)
+		}
+	}
+	snapshot, ok := holder.Snapshot()
+	if !ok || snapshot.BudgetPlan == nil || len(snapshot.Mutations) != 1 {
+		t.Fatalf("failure snapshot = %#v, %v", snapshot, ok)
+	}
+}
+
+func TestMissingContextWindowIsAuditedWithoutChangingProviderBytes(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	holder := contextfrag.NewLifecycleHolder()
+	cfg := agentpkg.RunConfig{
+		System: "legacy system", Messages: []sdk.Message{sdk.AssistantMessage("legacy")}, Query: "current",
+		CurrentModelID: "model-1", ContextScope: contextfrag.Scope{BotID: "bot-1", SessionID: "session-1"},
+		ContextLifecycle: holder,
+	}
+	out, err := applyProviderRunConfig(context.Background(), slog.New(slog.NewJSONHandler(&logs, nil)), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.System != cfg.System || !reflect.DeepEqual(out.Messages, []sdk.Message{sdk.AssistantMessage("legacy"), sdk.UserMessage("current")}) {
+		t.Fatalf("provider bytes changed: system=%q messages=%#v", out.System, out.Messages)
+	}
+	records := out.ContextMutations.Records()
+	if len(records) != 1 || records[0] != (contextfrag.MutationRecord{Kind: contextfrag.MutationContextBudgetDisabled, Detail: "missing_context_window"}) {
+		t.Fatalf("mutations = %#v", records)
+	}
+	if out.ContextManifest.BudgetPlan != nil {
+		t.Fatalf("disabled plan = %#v", out.ContextManifest.BudgetPlan)
+	}
+	for _, want := range []string{"missing_context_window", "bot-1", "session-1", "model-1"} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("warning %q missing %q", logs.String(), want)
+		}
+	}
+	snapshot, ok := holder.Snapshot()
+	if !ok || len(snapshot.Mutations) != 1 || snapshot.Mutations[0].Kind != contextfrag.MutationContextBudgetDisabled {
+		t.Fatalf("disabled snapshot = %#v, %v", snapshot, ok)
+	}
+}
+
+func TestApplyProviderRunConfigStoresActivePlanWithoutNoPressureMutation(t *testing.T) {
+	t.Parallel()
+
+	history := contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID:            "history",
+		Message:       sdk.UserMessage("old context"),
+		Kind:          contextfrag.KindConversationEvent,
+		Slot:          contextfrag.SlotHistory,
+		TokenEstimate: 100,
+	})
+	current := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID:    "current",
+		Kind:  contextfrag.KindCurrentUserMessage,
+		Role:  sdk.MessageRoleUser,
+		Slot:  contextfrag.SlotCurrentUser,
+		Text:  "current request",
+		Trust: contextfrag.TrustUser,
+	})
+	current.TokenEstimate = 120
+	cfg := agentpkg.RunConfig{
+		ContextSourceFrags: []contextfrag.ContextFrag{history, current},
+		ContextToolDefs: []contextfrag.ToolDefAccounting{
+			{Name: "tool", TokenEstimate: 80},
+		},
+		ContextBudgetMaxTokens: contextWindowForDefaultOutputReserve(80 + 120 + 500),
+	}
+
+	disabled := cfg
+	disabled.ContextBudgetMaxTokens = 0
+	legacyOut, err := ProviderRunConfigApplier(nil)(context.Background(), disabled)
+	if err != nil {
+		t.Fatalf("plan-disabled ApplyProviderRunConfig() error = %v", err)
+	}
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ApplyProviderRunConfig() error = %v", err)
+	}
+	plan := out.ContextManifest.BudgetPlan
+	if plan == nil {
+		t.Fatal("successful active run lost its budget plan")
+	}
+	if plan.SystemBudget != 500 || plan.ActualSystemCost != 0 || plan.HistoryBudget != 500 {
+		t.Fatalf("budget plan = %#v, want system/actual/history = 500/0/500", plan)
+	}
+	if out.ContextMutations == nil || len(out.ContextMutations.Records()) != 0 {
+		t.Fatalf("no-pressure mutations = %#v, want zero", out.ContextMutations)
+	}
+	if len(out.Messages) != 2 {
+		t.Fatalf("messages = %#v, want history and current request", out.Messages)
+	}
+	if out.System != legacyOut.System ||
+		out.Query != legacyOut.Query ||
+		!reflect.DeepEqual(out.Messages, legacyOut.Messages) ||
+		!reflect.DeepEqual(out.InlineImages, legacyOut.InlineImages) {
+		t.Fatalf("active no-pressure payload diverged:\nactive=%#v\nlegacy=%#v", out, legacyOut)
+	}
+}
+
+func TestApplyProviderRunConfigBudgetErrorKeepsAuditWhenRenderFails(t *testing.T) {
+	t.Parallel()
+
+	first := attentionMessageFrag("duplicate", sdk.UserMessage("first"), 10)
+	second := attentionMessageFrag("duplicate", sdk.AssistantMessage("second"), 10)
+	holder := contextfrag.NewLifecycleHolder()
+	cfg := agentpkg.RunConfig{
+		System:                 "legacy system",
+		Messages:               []sdk.Message{sdk.UserMessage("legacy message")},
+		ContextSourceFrags:     []contextfrag.ContextFrag{first, second},
+		ContextBudgetMaxTokens: 100,
+		ContextLifecycle:       holder,
+	}
+
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), cfg)
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("ApplyProviderRunConfig() error = %v, want %v", err, contextfrag.ErrBudgetUnsatisfied)
+	}
+	if out.System != cfg.System || !reflect.DeepEqual(out.Messages, cfg.Messages) {
+		t.Fatalf("budget failure changed provider payload: system=%q messages=%#v", out.System, out.Messages)
+	}
+	plan := out.ContextManifest.BudgetPlan
+	if plan == nil || plan.Window != 100 {
+		t.Fatalf("budget plan = %#v, want retained 100-token window", plan)
+	}
+	records := out.ContextManifest.Mutations.Records()
+	if len(records) != 1 ||
+		records[0].Kind != contextfrag.MutationContextBudgetFailure ||
+		records[0].Detail != "budget_unsatisfied" {
+		t.Fatalf("budget failure mutations = %#v, want one stable failure record", records)
+	}
+	if out.ContextMutations == nil {
+		t.Fatal("budget failure lost the run-config mutation ledger")
+	}
+	snapshot, ok := holder.Snapshot()
+	if !ok || snapshot.BudgetPlan == nil || snapshot.BudgetPlan.Window != 100 {
+		t.Fatalf("lifecycle snapshot = %#v, %v; want retained plan", snapshot, ok)
+	}
+	if len(snapshot.Mutations) != 1 ||
+		snapshot.Mutations[0].Kind != contextfrag.MutationContextBudgetFailure {
+		t.Fatalf("lifecycle mutations = %#v, want budget failure", snapshot.Mutations)
+	}
+}
+
+func TestProviderSelectorReservesHistoryTrimNoticeWithinPlan(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("old-1", sdk.UserMessage("old one"), 100),
+		attentionMessageFrag("old-2", sdk.AssistantMessage("old two"), 100),
+		contextfrag.TextFrag(contextfrag.TextFragInput{
+			ID:    "current",
+			Kind:  contextfrag.KindCurrentUserMessage,
+			Role:  sdk.MessageRoleUser,
+			Slot:  contextfrag.SlotCurrentUser,
+			Text:  "current",
+			Trust: contextfrag.TrustUser,
+		}),
+	}
+	plan := &contextfrag.ContextBudgetPlan{SystemBudget: 120}
+
+	result := (&FragmentSelector{}).Select(
+		frags,
+		(&FragmentSelector{}).ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan},
+	)
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() error = %v", result.FatalError)
+	}
+	if !result.TrimNotice {
+		t.Fatal("history pressure must retain its notice")
+	}
+	if len(result.Dropped) != 2 {
+		t.Fatalf("dropped = %#v, want both 100-token history fragments so the notice fits", result.Dropped)
+	}
+	noticeCost := contextfrag.ResolveFragTokens(TrimNoticeFrag(contextfrag.Scope{}))
+	if noticeCost > plan.HistoryBudget {
+		t.Fatalf("notice cost %d exceeds history budget %d", noticeCost, plan.HistoryBudget)
+	}
+}
+
+func TestApplyProviderRunConfigInternalBuildErrorStillFallsBack(t *testing.T) {
+	t.Parallel()
+
+	first := attentionMessageFrag("duplicate", sdk.UserMessage("first"), 10)
+	second := attentionMessageFrag("duplicate", sdk.AssistantMessage("second"), 10)
+	cfg := agentpkg.RunConfig{
+		System:                 "legacy system",
+		Messages:               []sdk.Message{sdk.UserMessage("legacy message")},
+		ContextSourceFrags:     []contextfrag.ContextFrag{first, second},
+		ContextBudgetMaxTokens: 100000,
+	}
+
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ApplyProviderRunConfig() error = %v, want ordinary build fallback", err)
+	}
+	if out.System != cfg.System || !reflect.DeepEqual(out.Messages, cfg.Messages) {
+		t.Fatalf("fallback payload = system %q messages %#v, want legacy payload", out.System, out.Messages)
+	}
+	records := out.ContextMutations.Records()
+	if len(records) != 1 ||
+		records[0].Kind != contextfrag.MutationContextViewFallback ||
+		records[0].Detail != "build_error" {
+		t.Fatalf("fallback records = %#v, want one build_error context fallback", records)
+	}
+}

--- a/internal/contextview/provider_envelope_budget.go
+++ b/internal/contextview/provider_envelope_budget.go
@@ -1,0 +1,54 @@
+package contextview
+
+import (
+	"fmt"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func providerToolDefsCost(definitions []contextfrag.ToolDefAccounting) int {
+	total := 0
+	for _, definition := range definitions {
+		total += max(
+			definition.TokenEstimate,
+			contextfrag.ProviderBudgetTokensFromBytes(definition.Bytes),
+		)
+	}
+	return total
+}
+
+func providerRenderedEnvelopeTokens(
+	payload *SDKRenderedPayload,
+	toolDefs []contextfrag.ToolDefAccounting,
+) int {
+	if payload == nil {
+		return 0
+	}
+	total := contextfrag.ProviderBudgetTokensFromBytes(len(payload.System))
+	for _, message := range payload.Messages {
+		frag := contextfrag.MessageFrag(contextfrag.MessageFragInput{Message: message})
+		total += contextfrag.ResolveProviderBudgetFragTokens(frag)
+	}
+	return total + providerToolDefsCost(toolDefs)
+}
+
+func validateProviderRenderedEnvelope(
+	payload *SDKRenderedPayload,
+	toolDefs []contextfrag.ToolDefAccounting,
+	plan *contextfrag.ContextBudgetPlan,
+) error {
+	if plan == nil {
+		return nil
+	}
+	inputTokens := providerRenderedEnvelopeTokens(payload, toolDefs)
+	if inputTokens+plan.OutputReserve <= plan.Window {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: rendered_input=%d output_reserve=%d window=%d",
+		contextfrag.ErrBudgetUnsatisfied,
+		inputTokens,
+		plan.OutputReserve,
+		plan.Window,
+	)
+}

--- a/internal/contextview/provider_envelope_budget_regression_test.go
+++ b/internal/contextview/provider_envelope_budget_regression_test.go
@@ -1,0 +1,307 @@
+package contextview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"slices"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+const contextbenchFixtureSeed int64 = 0x434f4e54455854
+
+type contextbench16KFixture struct {
+	sourceFrags  []contextfrag.ContextFrag
+	toolDefs     []contextfrag.ToolDefAccounting
+	systemCount  int
+	messageCount int
+}
+
+func TestApplyProviderRunConfigContextbench16KRenderedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	fixture := buildContextbench16KFixture()
+	if fixture.systemCount != 71 || fixture.messageCount != 31 || len(fixture.toolDefs) != 12 {
+		t.Fatalf("fixture shape = system:%d messages:%d tools:%d, want 71/31/12",
+			fixture.systemCount, fixture.messageCount, len(fixture.toolDefs))
+	}
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), agentpkg.RunConfig{
+		ContextSourceFrags:       slices.Clone(fixture.sourceFrags),
+		ContextScope:             contextfrag.Scope{BotID: "contextbench"},
+		ContextQueryMaterialized: true,
+		ContextToolDefs:          slices.Clone(fixture.toolDefs),
+		ContextToolDefsResolved:  true,
+		ContextBudgetMaxTokens:   16_000,
+	})
+	if err != nil {
+		t.Fatalf("contextbench 16k preflight error = %v, want conservative selection to fit", err)
+	}
+
+	inputTokens := testRenderedProviderEnvelopeTokens(out.System, out.Messages, out.ContextToolDefs)
+	reserve := min(DefaultOutputReserveTokens, out.ContextBudgetMaxTokens/4)
+	if envelope := inputTokens + reserve; envelope > out.ContextBudgetMaxTokens {
+		t.Fatalf("provider call allowed with rendered envelope %d > window %d (input=%d reserve=%d)",
+			envelope, out.ContextBudgetMaxTokens, inputTokens, reserve)
+	}
+}
+
+func TestProviderSelectorReservesConservativeHistoryTrimNotice(t *testing.T) {
+	t.Parallel()
+
+	notice := TrimNoticeFrag(contextfrag.Scope{})
+	legacyCost := contextfrag.ResolveFragTokens(notice)
+	providerCost := contextfrag.ResolveProviderBudgetFragTokens(notice)
+	if legacyCost != 55 || providerCost != 68 || providerCost-legacyCost != 13 {
+		t.Fatalf("trim notice costs = legacy:%d provider:%d, want 55/68 (13-token drift)", legacyCost, providerCost)
+	}
+
+	frags := []contextfrag.ContextFrag{
+		testBudgetMessageFrag("old-1", sdk.UserMessage(strings.Repeat("a", 320)), contextfrag.SlotHistory, 100),
+		testBudgetMessageFrag("old-2", sdk.AssistantMessage(strings.Repeat("b", 320)), contextfrag.SlotHistory, 100),
+		testBudgetMessageFrag("current", sdk.UserMessage("current"), contextfrag.SlotCurrentUser, 10),
+	}
+	frags[2].Kind = contextfrag.KindCurrentUserMessage
+	frags[2].Trust = contextfrag.TrustUser
+	frags[2].Budget.Overflow = contextfrag.OverflowKeep
+	plan := &contextfrag.ContextBudgetPlan{SystemBudget: 167}
+	selector := &FragmentSelector{}
+	result := selector.Select(
+		frags,
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan, RecentProtectTokens: 0},
+	)
+	if result.FatalError != nil {
+		t.Fatalf("selector error = %v", result.FatalError)
+	}
+	if !result.TrimNotice || len(result.Dropped) != 2 {
+		t.Fatalf("trim result = notice:%v dropped:%d, want conservative notice and both history messages dropped",
+			result.TrimNotice, len(result.Dropped))
+	}
+}
+
+func TestApplyProviderRunConfigFailsClosedOnRenderedEnvelopeOverflow(t *testing.T) {
+	t.Parallel()
+
+	history := testBudgetMessageFrag(
+		"history-undercharged",
+		sdk.UserMessage(strings.Repeat("x", 4_000)),
+		contextfrag.SlotHistory,
+		1,
+	)
+	current := testBudgetMessageFrag("current", sdk.UserMessage("current"), contextfrag.SlotCurrentUser, 3)
+	current.Kind = contextfrag.KindCurrentUserMessage
+	current.Trust = contextfrag.TrustUser
+	current.Budget.Overflow = contextfrag.OverflowKeep
+
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), agentpkg.RunConfig{
+		ContextSourceFrags:     []contextfrag.ContextFrag{history, current},
+		ContextBudgetMaxTokens: 1_000,
+	})
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("preflight error = %v, want rendered-envelope ErrBudgetUnsatisfied", err)
+	}
+	if out.ContextMutations == nil {
+		t.Fatal("rendered-envelope failure lost mutation audit")
+	}
+	records := out.ContextMutations.Records()
+	if len(records) != 1 || records[0] != (contextfrag.MutationRecord{
+		Kind: contextfrag.MutationContextBudgetFailure, Detail: "budget_unsatisfied",
+	}) {
+		t.Fatalf("rendered-envelope mutations = %#v, want one budget_unsatisfied record", records)
+	}
+}
+
+func buildContextbench16KFixture() contextbench16KFixture {
+	rng := rand.New(rand.NewSource(contextbenchFixtureSeed)) //nolint:gosec // fixed seed is the regression contract
+	sections := []agentpkg.SystemSection{
+		contextbenchSection("system.prompt.intro", contextfrag.KindSystemPrompt, 10, contextfrag.RetentionRequired, 0, contextbenchSeededText(rng, 900, false)),
+		contextbenchSection("system.bot_identity", contextfrag.KindBotIdentity, 20, contextfrag.RetentionPreferred, 0, contextbenchSeededText(rng, 420, true)),
+		contextbenchSection("system.prompt.body", contextfrag.KindSystemPrompt, 30, contextfrag.RetentionRequired, 0, contextbenchSeededText(rng, 2_600, false)),
+		contextbenchSection("system.prompt.tail", contextfrag.KindSystemPrompt, 50, contextfrag.RetentionRequired, 0, contextbenchSeededText(rng, 1_400, false)),
+	}
+	toolRender := contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown, GroupID: "system.tool_usage", GroupJoiner: "\n\n"}
+	sections = append(sections, agentpkg.SystemSection{
+		ID: "system.tool_usage.header", Kind: contextfrag.KindToolUsage, Priority: 45,
+		RetentionTier: contextfrag.RetentionPreferred, Text: "## Tool usage", Render: toolRender,
+	})
+	for i := range 10 {
+		sections = append(sections, agentpkg.SystemSection{
+			ID: fmt.Sprintf("system.tool_usage.provider-%02d", i), Kind: contextfrag.KindToolUsage, Priority: 45,
+			RetentionTier: contextfrag.RetentionPreferred, DropPriority: contextfrag.DropPriority(rng.Intn(3)),
+			Text: contextbenchSeededText(rng, 260+rng.Intn(641), i%3 == 0), Render: toolRender,
+		})
+	}
+	identityRender := contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown, GroupID: "system.platform_identity", GroupJoiner: "\n"}
+	sections = append(sections, agentpkg.SystemSection{
+		ID: "system.platform_identity.header", Kind: contextfrag.KindPlatformIdentity, Priority: 60,
+		RetentionTier: contextfrag.RetentionPreferred, Text: "## Connected identities", Render: identityRender,
+	})
+	for i := range 8 {
+		sections = append(sections, agentpkg.SystemSection{
+			ID: fmt.Sprintf("system.platform_identity.identity-%02d", i), Kind: contextfrag.KindPlatformIdentity, Priority: 60,
+			RetentionTier: contextfrag.RetentionPreferred, DropPriority: contextfrag.DropPriority(rng.Intn(3)),
+			Text: contextbenchSeededText(rng, 180+rng.Intn(421), i%3 == 1), Render: identityRender,
+		})
+	}
+	skillRender := contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown, GroupID: "system.skills", GroupJoiner: "\n"}
+	sections = append(sections, agentpkg.SystemSection{
+		ID: "system.skills.header", Kind: contextfrag.KindSkillsCatalog, Priority: 65,
+		RetentionTier: contextfrag.RetentionOptional, RequiredCapability: "use_skill",
+		Text: "## Available skills (40)", Render: skillRender,
+	})
+	for i := range 40 {
+		sections = append(sections, agentpkg.SystemSection{
+			ID: fmt.Sprintf("system.skill.skill-%02d", i), Kind: contextfrag.KindSkillsCatalog, Priority: 65,
+			RetentionTier: contextfrag.RetentionOptional, DropPriority: contextfrag.DropPriority(rng.Intn(5)),
+			RequiredCapability: "use_skill", Text: contextbenchSeededText(rng, 50+rng.Intn(1_951), i < 12 || i%7 == 0),
+			Render: skillRender,
+		})
+	}
+	for i := range 6 {
+		sections = append(sections, agentpkg.SystemSection{
+			ID: fmt.Sprintf("system.workspace_file.file-%02d", i), Kind: contextfrag.KindWorkspaceInstruction, Priority: 70,
+			RetentionTier: contextfrag.RetentionPreferred, DropPriority: contextfrag.DropPriority(rng.Intn(4)),
+			Text: contextbenchSeededText(rng, 1_024+rng.Intn(19*1_024+1), i%2 == 0),
+		})
+	}
+
+	systemFrags := agentpkg.SystemSectionFrags(sections, contextfrag.Scope{BotID: "contextbench"})
+	messageFrags := make([]contextfrag.ContextFrag, 0, 31)
+	for i := range 30 {
+		text := contextbenchSeededText(rng, 180+rng.Intn(921), i%5 == 0)
+		message := sdk.UserMessage(text)
+		trust := contextfrag.TrustExternal
+		if i%2 == 1 {
+			message = sdk.AssistantMessage(text)
+			trust = contextfrag.TrustWorkspace
+		}
+		messageFrags = append(messageFrags, contextbenchMessageFrag(
+			fmt.Sprintf("message.%03d", i), message, contextfrag.KindConversationEvent, contextfrag.SlotHistory, trust, i,
+		))
+	}
+	current := contextbenchMessageFrag(
+		"message.current",
+		sdk.UserMessage("Compare the retained context precisely and explain any omitted material."),
+		contextfrag.KindCurrentUserMessage,
+		contextfrag.SlotCurrentUser,
+		contextfrag.TrustUser,
+		30,
+	)
+	current.CacheClass = contextfrag.CacheNever
+	current.Budget.Overflow = contextfrag.OverflowKeep
+	messageFrags = append(messageFrags, current)
+
+	tools := contextbenchTools()
+	toolDefs := make([]contextfrag.ToolDefAccounting, 0, len(tools))
+	for _, tool := range tools {
+		toolDefs = append(toolDefs, contextfrag.ToolDefAccountingFor("contextbench", tool))
+	}
+	return contextbench16KFixture{
+		sourceFrags: append(slices.Clone(systemFrags), messageFrags...),
+		toolDefs:    toolDefs, systemCount: len(systemFrags), messageCount: len(messageFrags),
+	}
+}
+
+func contextbenchSection(
+	id string,
+	kind contextfrag.Kind,
+	priority int,
+	retention contextfrag.RetentionTier,
+	drop contextfrag.DropPriority,
+	text string,
+) agentpkg.SystemSection {
+	return agentpkg.SystemSection{
+		ID: id, Kind: kind, Priority: priority, RetentionTier: retention, DropPriority: drop, Text: text,
+	}
+}
+
+func contextbenchMessageFrag(
+	id string,
+	message sdk.Message,
+	kind contextfrag.Kind,
+	slot contextfrag.Slot,
+	trust contextfrag.TrustLevel,
+	index int,
+) contextfrag.ContextFrag {
+	frag := contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: id, Message: message, Kind: kind, Slot: slot, Priority: contextfrag.PriorityForMessage(message),
+		CacheClass: contextfrag.CacheStable, Trust: trust, Scope: contextfrag.Scope{BotID: "contextbench"},
+		Source: "contextbench", Collector: "contextbench", Index: index,
+	})
+	frag.TokenEstimate = contextfrag.ResolveProviderBudgetFragTokens(frag)
+	return frag
+}
+
+func testBudgetMessageFrag(
+	id string,
+	message sdk.Message,
+	slot contextfrag.Slot,
+	tokens int,
+) contextfrag.ContextFrag {
+	return contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: id, Message: message, Kind: contextfrag.KindConversationEvent, Slot: slot,
+		TokenEstimate: tokens, CacheClass: contextfrag.CacheStable, Trust: contextfrag.TrustWorkspace,
+	})
+}
+
+func contextbenchTools() []sdk.Tool {
+	names := []string{
+		"use_skill", "read", "write", "apply_patch", "exec", "search_memory", "web_search",
+		"browser_action", "computer_action", "ask_user", "spawn_agent", "read_media",
+	}
+	tools := make([]sdk.Tool, 0, len(names))
+	for i, name := range names {
+		tools = append(tools, sdk.Tool{
+			Name: name, Description: "Contextbench tool " + name + " with bounded, production-shaped usage guidance.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"query": map[string]any{"type": "string", "description": "request text"},
+					"limit": map[string]any{"type": "integer", "minimum": 1, "maximum": 100 + i},
+				},
+				"required": []string{"query"},
+			},
+		})
+	}
+	return tools
+}
+
+func contextbenchSeededText(rng *rand.Rand, size int, multilingual bool) string {
+	pattern := "context orchestration fixture data "
+	if multilingual {
+		pattern = "上下文编排🙂稳定性数据 "
+	}
+	var out strings.Builder
+	out.Grow(size)
+	for out.Len()+len(pattern) <= size {
+		out.WriteString(pattern)
+	}
+	const alphabet = "abcdefghijklmnopqrstuvwxyz"
+	for out.Len() < size {
+		out.WriteByte(alphabet[rng.Intn(len(alphabet))])
+	}
+	return out.String()
+}
+
+func testRenderedProviderEnvelopeTokens(
+	system string,
+	messages []sdk.Message,
+	toolDefs []contextfrag.ToolDefAccounting,
+) int {
+	total := contextfrag.ProviderBudgetTokensFromBytes(len(system))
+	for _, message := range messages {
+		frag := contextfrag.MessageFrag(contextfrag.MessageFragInput{Message: message})
+		total += contextfrag.ResolveProviderBudgetFragTokens(frag)
+	}
+	for _, definition := range toolDefs {
+		total += max(definition.TokenEstimate, contextfrag.ProviderBudgetTokensFromBytes(definition.Bytes))
+	}
+	return total
+}

--- a/internal/contextview/provider_fallback_test.go
+++ b/internal/contextview/provider_fallback_test.go
@@ -30,7 +30,8 @@ func TestProviderViewFallbackKeepsLegacyBytesAndAudit(t *testing.T) {
 		t.Fatalf("manifest = %#v", got.ContextManifest)
 	}
 	records := got.ContextMutations.Records()
-	if len(records) != 1 || records[0].Kind != contextfrag.MutationContextViewFallback {
+	if len(records) != 2 || records[0].Kind != contextfrag.MutationContextBudgetDisabled ||
+		records[1].Kind != contextfrag.MutationContextViewFallback {
 		t.Fatalf("records = %#v", records)
 	}
 }
@@ -74,8 +75,9 @@ func TestApplyProviderRunConfigAcceptsEmptyProviderInput(t *testing.T) {
 	if got.ContextMutations == nil {
 		t.Fatal("empty provider input did not install a mutation ledger")
 	}
-	if records := got.ContextMutations.Records(); len(records) != 0 {
-		t.Fatalf("empty provider input was classified as fallback: %#v", records)
+	if records := got.ContextMutations.Records(); len(records) != 1 ||
+		records[0].Kind != contextfrag.MutationContextBudgetDisabled {
+		t.Fatalf("empty provider input audit = %#v, want only missing-window classification", records)
 	}
 }
 

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -2,6 +2,7 @@ package contextview
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -20,8 +21,8 @@ const (
 )
 
 func ProviderRunConfigApplier(logger *slog.Logger) agentpkg.ContextViewApplier {
-	return func(ctx context.Context, cfg agentpkg.RunConfig) agentpkg.RunConfig {
-		return ApplyProviderRunConfig(ctx, logger, cfg)
+	return func(ctx context.Context, cfg agentpkg.RunConfig) (agentpkg.RunConfig, error) {
+		return applyProviderRunConfig(ctx, logger, cfg)
 	}
 }
 
@@ -56,6 +57,9 @@ func CollectNonSystemProviderSourceFrags(ctx context.Context, cfg agentpkg.RunCo
 		Messages:                cfg.Messages,
 		CurrentUserMessageIndex: cfg.ContextCurrentUserMessageIndex,
 		MemoryMessageIndex:      cfg.ContextMemoryMessageIndex,
+		TokenEstimates:          cfg.ContextHistoryTokenEstimates,
+		TrimmablePrefix:         cfg.ContextTrimmableMessages,
+		RepairToolClosures:      true,
 	}
 	history, err := (&HistoryMessagesCollector{}).Collect(ctx, CollectRequest{
 		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider, Config: historyConfig,
@@ -190,7 +194,90 @@ func ToolUsageFrag(usage string, scope contextfrag.Scope) contextfrag.ContextFra
 	})
 }
 
+const DefaultRecentProtectTokens = 20000
+
+func resolveRecentProtectTokens(override *int) int {
+	if override == nil {
+		return DefaultRecentProtectTokens
+	}
+	if *override < 0 {
+		return 0
+	}
+	return *override
+}
+
+func providerContextBudgetPlan(ctx context.Context, cfg agentpkg.RunConfig) (*contextfrag.ContextBudgetPlan, error) {
+	if cfg.ContextBudgetMaxTokens == 0 {
+		return nil, nil
+	}
+	currentRequestCost, err := providerCurrentRequestCost(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return ComputeContextBudgetPlan(
+		cfg.ContextBudgetMaxTokens,
+		min(DefaultOutputReserveTokens, cfg.ContextBudgetMaxTokens/4),
+		providerToolDefsCost(cfg.ContextToolDefs),
+		currentRequestCost,
+	)
+}
+
+func providerCurrentRequestCost(ctx context.Context, cfg agentpkg.RunConfig) (int, error) {
+	if len(cfg.ContextSourceFrags) > 0 {
+		return currentRequestFragCost(cfg.ContextSourceFrags), nil
+	}
+	query := cfg.Query
+	inlineImages := cfg.InlineImages
+	if cfg.ContextQueryMaterialized {
+		query = ""
+		inlineImages = nil
+	}
+	historyConfig := HistoryMessagesConfig{
+		Messages:                cfg.Messages,
+		CurrentUserMessageIndex: cfg.ContextCurrentUserMessageIndex,
+		MemoryMessageIndex:      cfg.ContextMemoryMessageIndex,
+		TokenEstimates:          cfg.ContextHistoryTokenEstimates,
+	}
+	specs := []struct {
+		collector Collector
+		config    any
+	}{
+		{&materializedCurrentUserCollector{}, historyConfig},
+		{&CurrentUserCollector{}, CurrentUserConfig{Query: query}},
+		{&InlineImageCollector{}, InlineImageConfig{Images: inlineImages}},
+	}
+	var frags []contextfrag.ContextFrag
+	for _, spec := range specs {
+		collected, err := spec.collector.Collect(ctx, CollectRequest{
+			Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider, Config: spec.config,
+		})
+		if err != nil {
+			return 0, err
+		}
+		frags = append(frags, collected...)
+	}
+	return currentRequestFragCost(frags), nil
+}
+
+func currentRequestFragCost(frags []contextfrag.ContextFrag) int {
+	total := 0
+	for _, frag := range frags {
+		if frag.Slot == contextfrag.SlotCurrentUser || frag.Kind == contextfrag.KindCurrentUserMessage {
+			total += contextfrag.ResolveProviderBudgetFragTokens(frag)
+		}
+	}
+	return total
+}
+
+// ApplyProviderRunConfig keeps the direct compiler helper source-compatible.
+// Native execution uses ProviderRunConfigApplier so typed budget failures are
+// returned to the runtime and fail closed before any provider call.
 func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentpkg.RunConfig) agentpkg.RunConfig {
+	out, _ := applyProviderRunConfig(ctx, logger, cfg)
+	return out
+}
+
+func applyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentpkg.RunConfig) (agentpkg.RunConfig, error) {
 	ledger := cfg.ContextMutations
 	if ledger == nil {
 		ledger = contextfrag.NewMutationLedger()
@@ -218,8 +305,13 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 		cfg = legacyMaterializeQuery(cfg)
 		frags = CollectProviderSourceFrags(ctx, cfg)
 		if frags == nil {
-			return providerViewFallback(logger, cfg, ledger, "collect_error", "context view collection failed", nil)
+			return providerViewFallback(logger, cfg, ledger, "collect_error", "context view collection failed", nil), nil
 		}
+	}
+	budgetPlan, budgetErr := providerContextBudgetPlan(ctx, cfg)
+	if cfg.ContextBudgetMaxTokens == 0 {
+		recordMutationOnce(ledger, contextfrag.MutationContextBudgetDisabled, "missing_context_window")
+		warnMissingContextWindow(ctx, logger, cfg)
 	}
 
 	selector := Selector(&FragmentSelector{})
@@ -233,22 +325,42 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 		}
 		selector = gate
 	}
+	if budgetErr != nil && !isContextBudgetError(budgetErr) {
+		return providerViewFallback(logger, fallbackCfg, ledger, "budget_plan_error", "context budget plan failed", budgetErr), nil
+	}
 
 	registry := NewMapCollectorRegistry(StaticCollector{CollectorName: sourceFragsCollectorName, Frags: frags})
 	builder := NewBuilder(registry, selector, StablePrefixPlacer{}, NewMapRendererRegistry(&SDKMessagesRenderer{}))
 	view, err := builder.Build(ctx, BuildInput{
 		Scope: cfg.ContextScope, Intent: contextfrag.IntentRunConfigPreProvider,
-		Sources:         []SourceSpec{{Name: sourceFragsCollectorName}},
-		Targets:         []contextfrag.RenderTarget{contextfrag.RenderSDKMessages},
-		Budget:          BudgetEnvelope{ToolExchange: cfg.ContextToolExchangePolicy},
+		Sources: []SourceSpec{{Name: sourceFragsCollectorName}},
+		Targets: []contextfrag.RenderTarget{contextfrag.RenderSDKMessages},
+		Budget: BudgetEnvelope{
+			MaxTokens:           cfg.ContextBudgetMaxTokens,
+			Plan:                budgetPlan,
+			RecentProtectTokens: resolveRecentProtectTokens(cfg.ContextRecentProtectTokens),
+			ToolExchange:        cfg.ContextToolExchangePolicy,
+		},
 		DynamicMutators: cfg.ContextDynamicMutators,
 	})
+	if budgetErr != nil {
+		recordContextBudgetFailure(ledger, budgetErr)
+		return providerBudgetAuditConfig(cfg, view, ledger, budgetPlan), budgetErr
+	}
 	if err != nil {
-		return providerViewFallback(logger, fallbackCfg, ledger, "build_error", "context view build failed", err)
+		if isContextBudgetError(err) {
+			recordContextBudgetFailure(ledger, err)
+			return providerBudgetAuditConfig(cfg, view, ledger, budgetPlan), err
+		}
+		return providerViewFallback(logger, fallbackCfg, ledger, "build_error", "context view build failed", err), nil
 	}
 	payload, ok := view.Rendered[contextfrag.RenderSDKMessages].Data.(*SDKRenderedPayload)
 	if !ok {
-		return providerViewFallback(logger, fallbackCfg, ledger, "unexpected_payload", "context view rendered unexpected payload", nil)
+		return providerViewFallback(logger, fallbackCfg, ledger, "unexpected_payload", "context view rendered unexpected payload", nil), nil
+	}
+	if err := validateProviderRenderedEnvelope(payload, cfg.ContextToolDefs, budgetPlan); err != nil {
+		recordContextBudgetFailure(ledger, err)
+		return providerBudgetAuditConfig(cfg, view, ledger, budgetPlan), err
 	}
 
 	plan := cachePlanFromPlacement(view.Placement)
@@ -262,7 +374,7 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 	cfg.Messages = payload.Messages
 	ordered, err := orderedSelectedFrags(view.Selected, view.Placement)
 	if err != nil {
-		return providerViewFallback(logger, fallbackCfg, ledger, "placement_error", "context view placement invalid after render", err)
+		return providerViewFallback(logger, fallbackCfg, ledger, "placement_error", "context view placement invalid after render", err), nil
 	}
 	currentIndex, memoryIndex := renderedSpecialMessageIndexes(ordered)
 	cfg.ContextMemoryMessageIndex = memoryIndex
@@ -279,6 +391,70 @@ func ApplyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 	cfg.ContextManifest = manifest
 	cfg.ContextCachePlan = plan
 	cfg.ContextMutations = ledger
+	if cfg.ContextLifecycle != nil {
+		cfg.ContextLifecycle.SetManifest(manifest)
+	}
+	return cfg, nil
+}
+
+func isContextBudgetError(err error) bool {
+	return errors.Is(err, contextfrag.ErrProtectedContextOverflow) ||
+		errors.Is(err, contextfrag.ErrBudgetUnsatisfied)
+}
+
+func recordContextBudgetFailure(ledger *contextfrag.MutationLedger, err error) {
+	reason := "budget_unsatisfied"
+	if errors.Is(err, contextfrag.ErrProtectedContextOverflow) {
+		reason = "protected_context_overflow"
+	}
+	recordMutationOnce(ledger, contextfrag.MutationContextBudgetFailure, reason)
+}
+
+func recordMutationOnce(ledger *contextfrag.MutationLedger, kind contextfrag.MutationKind, detail string) {
+	for _, record := range ledger.Records() {
+		if record.Kind == kind && record.Detail == detail {
+			return
+		}
+	}
+	ledger.Record(kind, detail)
+}
+
+func providerBudgetAuditConfig(
+	cfg agentpkg.RunConfig,
+	view *ContextView,
+	ledger *contextfrag.MutationLedger,
+	budgetPlan *contextfrag.ContextBudgetPlan,
+) agentpkg.RunConfig {
+	if view == nil {
+		manifest := contextfrag.BuildManifest(nil)
+		manifest.View = contextfrag.ViewRunConfigPreProvider
+		manifest.DynamicMutators = normalizeDynamicMutators(cfg.ContextDynamicMutators)
+		if budgetPlan != nil {
+			plan := *budgetPlan
+			manifest.BudgetPlan = &plan
+		}
+		manifest.Mutations = ledger
+		cfg.ContextManifest = manifest
+		cfg.ContextMutations = ledger
+		if cfg.ContextLifecycle != nil {
+			cfg.ContextLifecycle.SetManifest(manifest)
+		}
+		return cfg
+	}
+	cachePlan := cachePlanFromPlacement(view.Placement)
+	cachePlan.StablePrefixTokenEstimate = stablePrefixTokenEstimate(view.Placement, view.Selected, cfg.ContextToolDefs)
+	manifest := view.Manifest
+	manifest.CachePlan = &cachePlan
+	manifest.Mutations = ledger
+	manifest.ToolDefs = append([]contextfrag.ToolDefAccounting(nil), cfg.ContextToolDefs...)
+
+	cfg.ContextFrags = view.Selected
+	cfg.ContextManifest = manifest
+	cfg.ContextCachePlan = cachePlan
+	cfg.ContextMutations = ledger
+	if cfg.ContextLifecycle != nil {
+		cfg.ContextLifecycle.SetManifest(manifest)
+	}
 	return cfg
 }
 
@@ -299,6 +475,9 @@ func providerViewFallback(logger *slog.Logger, cfg agentpkg.RunConfig, ledger *c
 	cfg.ContextManifest = manifest
 	cfg.ContextCachePlan = plan
 	cfg.ContextMutations = ledger
+	if cfg.ContextLifecycle != nil {
+		cfg.ContextLifecycle.SetManifest(manifest)
+	}
 	return cfg
 }
 
@@ -476,7 +655,7 @@ func optionalPointerValue(value *int) []int {
 
 func hasCurrentUserFrag(frags []contextfrag.ContextFrag) bool {
 	for _, frag := range frags {
-		if frag.Slot == contextfrag.SlotCurrentUser {
+		if frag.Slot == contextfrag.SlotCurrentUser || frag.Kind == contextfrag.KindCurrentUserMessage {
 			return true
 		}
 	}
@@ -494,4 +673,16 @@ func warnProviderContextView(logger *slog.Logger, cfg agentpkg.RunConfig, messag
 		attrs = append(attrs, slog.Any("error", err))
 	}
 	logger.Warn(message, attrs...) //nolint:sloglint // message names the exact fallback stage
+}
+
+func warnMissingContextWindow(ctx context.Context, logger *slog.Logger, cfg agentpkg.RunConfig) {
+	if logger == nil {
+		return
+	}
+	logger.WarnContext(ctx, "context budget disabled: missing model context window",
+		slog.String("reason", "missing_context_window"),
+		slog.String("bot_id", cfg.ContextScope.BotID),
+		slog.String("session_id", cfg.ContextScope.SessionID),
+		slog.String("model_id", cfg.CurrentModelID),
+	)
 }

--- a/internal/contextview/provider_run_config_test.go
+++ b/internal/contextview/provider_run_config_test.go
@@ -64,7 +64,7 @@ func TestApplyProviderRunConfigMergesOnlyMatchingHistoryAuditMetadata(t *testing
 	scope := contextfrag.Scope{BotID: "bot-1", CurrentMessageID: "current"}
 	cfg := agentpkg.RunConfig{
 		Messages: []sdk.Message{message}, ContextFrags: []contextfrag.ContextFrag{shadow},
-		ContextScope: scope, ContextQueryMaterialized: true,
+		ContextScope: scope, ContextQueryMaterialized: true, ContextTrimmableMessages: 1,
 	}
 	cfg.ContextSourceFrags = CollectNonSystemProviderSourceFrags(context.Background(), cfg)
 
@@ -88,7 +88,10 @@ func TestApplyProviderRunConfigMergesOnlyMatchingHistoryAuditMetadata(t *testing
 func TestProviderRunConfigApplierUsesInjectedLoggerShape(t *testing.T) {
 	t.Parallel()
 	applier := ProviderRunConfigApplier(nil)
-	got := applier(context.Background(), agentpkg.RunConfig{System: "system", Query: "query"})
+	got, err := applier(context.Background(), agentpkg.RunConfig{System: "system", Query: "query"})
+	if err != nil {
+		t.Fatalf("applier error = %v", err)
+	}
 	if got.System != "system" || len(got.Messages) != 1 {
 		t.Fatalf("got = %#v", got)
 	}

--- a/internal/contextview/provider_run_config_view_test.go
+++ b/internal/contextview/provider_run_config_view_test.go
@@ -1,0 +1,79 @@
+package contextview
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+func TestApplyProviderContextViewKeepsMaterializedCurrentUserUnderBudgetPressure(t *testing.T) {
+	t.Parallel()
+
+	currentUserIndex := 3
+	memoryIndex := 1
+	zero := 0
+	cfg := agentpkg.RunConfig{
+		Messages: []sdk.Message{
+			sdk.AssistantMessage("old answer"),
+			sdk.UserMessage("remembered fact"),
+			sdk.UserMessage("workspace hook guidance"),
+			sdk.UserMessage("pipeline current question"),
+		},
+		ContextCurrentUserMessageIndex: &currentUserIndex,
+		ContextMemoryMessageIndex:      &memoryIndex,
+		ContextHistoryTokenEstimates:   []int{200, 20, 20, 100},
+		ContextTrimmableMessages:       1,
+		ContextRecentProtectTokens:     &zero,
+	}
+	activateHistoryBudget(&cfg, 100)
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ApplyProviderRunConfig() error = %v", err)
+	}
+
+	if len(out.Messages) == 0 || messageText(t, out.Messages[len(out.Messages)-1]) != "pipeline current question" {
+		t.Fatalf("messages = %#v, materialized current user must survive as the trailing request", out.Messages)
+	}
+}
+
+func activateHistoryBudget(cfg *agentpkg.RunConfig, legacyBudget int) {
+	inputBudget, scale := activeHistoryInputBudget(legacyBudget)
+	for i := range cfg.ContextHistoryTokenEstimates {
+		cfg.ContextHistoryTokenEstimates[i] *= scale
+	}
+	for i := range cfg.ContextSourceFrags {
+		cfg.ContextSourceFrags[i].TokenEstimate *= scale
+	}
+	frags := cfg.ContextSourceFrags
+	if len(frags) == 0 {
+		frags = CollectNonSystemProviderSourceFrags(context.Background(), *cfg)
+	}
+	tagged := tagFragments(frags, (&FragmentSelector{}).ProfileFor(contextfrag.IntentRunConfigPreProvider))
+	inputBudget += protectedHistoryTokenCost(tagged)
+	currentRequestCost, err := providerCurrentRequestCost(context.Background(), *cfg)
+	if err != nil {
+		panic(err)
+	}
+	toolDefsCost := 0
+	for _, def := range cfg.ContextToolDefs {
+		toolDefsCost += def.TokenEstimate
+	}
+	inputBudget += currentRequestCost + toolDefsCost
+	cfg.ContextBudgetMaxTokens = contextWindowForDefaultOutputReserve(inputBudget)
+}
+
+func activeHistoryInputBudget(legacyBudget int) (inputBudget, scale int) {
+	if legacyBudget <= 0 {
+		return 0, 1
+	}
+	scale = 2
+	if scaled := legacyBudget * scale; scaled < MinimumSystemBudgetTokens {
+		scale = (MinimumSystemBudgetTokens + legacyBudget - 1) / legacyBudget
+	}
+	noticeCost := contextfrag.ResolveFragTokens(TrimNoticeFrag(contextfrag.Scope{}))
+	return legacyBudget*scale + noticeCost, scale
+}

--- a/internal/contextview/round6_acceptance_test.go
+++ b/internal/contextview/round6_acceptance_test.go
@@ -1,0 +1,197 @@
+package contextview
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/agent/sessionmode"
+)
+
+var round6NativeModes = []string{
+	sessionmode.Chat,
+	sessionmode.Discuss,
+	sessionmode.Heartbeat,
+	sessionmode.Schedule,
+	sessionmode.Subagent,
+}
+
+func TestNativeModeSystemBudgetPressure(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range round6NativeModes {
+		mode := mode
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+
+			scope := contextfrag.Scope{BotID: "bot-1", SessionID: "session-1"}
+			base := round6StaticSystemFrags(mode, scope)
+			usage := strings.Repeat("registered tool guidance 猫😺 ", 400)
+			marker := systemBudgetMarkerFrag([]string{"system.tool_usage"}, scope)
+			window := contextWindowForDefaultOutputReserve(systemFragCost(appendClone(base, marker)))
+
+			cfg := agentpkg.RunConfig{
+				SessionType:            mode,
+				ContextScope:           scope,
+				ContextSourceFrags:     base,
+				ContextToolUsage:       usage,
+				ContextBudgetMaxTokens: window,
+			}
+			out, err := ProviderRunConfigApplier(nil)(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("ApplyProviderRunConfig() error = %v", err)
+			}
+
+			plan := out.ContextManifest.BudgetPlan
+			if plan == nil || plan.ActualSystemCost > plan.SystemBudget {
+				t.Fatalf("active mode budget plan = %#v", plan)
+			}
+			usageDecision, ok := decisionByID(out.ContextManifest.SelectionDecisions, "system.tool_usage")
+			if !ok ||
+				usageDecision.Decision != contextfrag.DecisionDropped ||
+				usageDecision.Reason != systemBudgetDropReason {
+				t.Fatalf("tool usage decision = %#v, %v; want dropped/system_budget", usageDecision, ok)
+			}
+			if !hasFragID(out.ContextFrags, systemBudgetMarkerID) ||
+				!strings.Contains(out.System, "[System Notice]") {
+				t.Fatalf("selected IDs/system = %v/%q, want explicit omission marker", fragIDs(out.ContextFrags), out.System)
+			}
+			for _, id := range []string{"system.prompt.intro", "system.prompt.body", "system.prompt.tail"} {
+				decision, found := decisionByID(out.ContextManifest.SelectionDecisions, id)
+				if !found || decision.Decision != contextfrag.DecisionSelected {
+					t.Fatalf("required section %s decision = %#v, %v", id, decision, found)
+				}
+			}
+		})
+	}
+}
+
+func TestNativeModeProtectedOverflowFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	window := contextWindowForDefaultOutputReserve(MinimumSystemBudgetTokens)
+	for _, mode := range round6NativeModes {
+		mode := mode
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := ProviderRunConfigApplier(nil)(context.Background(), agentpkg.RunConfig{
+				SessionType:            mode,
+				ContextSourceFrags:     round6ProtectedOverflowSourceFrags(mode),
+				ContextBudgetMaxTokens: window,
+			})
+
+			if !errors.Is(err, contextfrag.ErrProtectedContextOverflow) {
+				t.Fatalf("ApplyProviderRunConfig() error = %v, want ErrProtectedContextOverflow", err)
+			}
+			records := out.ContextManifest.Mutations.Records()
+			if len(records) != 1 ||
+				records[0].Kind != contextfrag.MutationContextBudgetFailure ||
+				records[0].Detail != "protected_context_overflow" {
+				t.Fatalf("budget failure mutations = %#v", records)
+			}
+			for _, record := range records {
+				if record.Kind == contextfrag.MutationContextViewFallback {
+					t.Fatalf("protected overflow triggered legacy fallback: %#v", records)
+				}
+			}
+		})
+	}
+}
+
+func TestProviderUsesByteEstimatorForStaticSystemFragsWithoutTokenizer(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range round6NativeModes {
+		mode := mode
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+
+			params := agentpkg.SystemPromptParams{SessionType: mode, Timezone: "UTC"}
+			frags := agentpkg.SystemSectionFrags(
+				agentpkg.GenerateSystemSections(params),
+				contextfrag.Scope{},
+			)
+			resolvedCost := 0
+			expectedTokens := make(map[string]int, len(frags))
+			for _, frag := range frags {
+				if frag.TokenEstimate != 0 {
+					t.Fatalf("static fragment %s has preset token estimate %d", frag.ID, frag.TokenEstimate)
+				}
+				textBytes := 0
+				for _, part := range frag.Parts {
+					if part.Type != contextfrag.PartText {
+						t.Fatalf("static fragment %s has non-text part %s", frag.ID, part.Type)
+					}
+					textBytes += len(part.Text)
+				}
+				expectedTokens[frag.ID] = contextfrag.TokensFromBytes(textBytes)
+				resolvedCost += expectedTokens[frag.ID]
+			}
+			if len(frags) > 1 {
+				resolvedCost += len(frags) - 1
+			}
+			renderedPrompt := agentpkg.GenerateSystemPrompt(params)
+			renderedCost := ((len(renderedPrompt) + contextfrag.EstimateBytesPerToken - 1) /
+				contextfrag.EstimateBytesPerToken) * contextfrag.ProviderBudgetSafetyFactorPercent / 100
+			wantCost := max(resolvedCost, renderedCost)
+
+			out, err := ProviderRunConfigApplier(nil)(context.Background(), agentpkg.RunConfig{
+				SessionType:            mode,
+				ContextSourceFrags:     frags,
+				ContextBudgetMaxTokens: contextWindowForDefaultOutputReserve(wantCost + 128),
+			})
+			if err != nil {
+				t.Fatalf("ApplyProviderRunConfig() error = %v", err)
+			}
+			if out.System != renderedPrompt {
+				t.Fatalf("provider system prompt changed without pressure")
+			}
+			if plan := out.ContextManifest.BudgetPlan; plan == nil || plan.ActualSystemCost != wantCost {
+				t.Fatalf("provider budget plan = %#v, want byte-estimated system cost %d", plan, wantCost)
+			}
+			for _, frag := range frags {
+				item := manifestItemByID(out.ContextManifest.Items, frag.ID)
+				if item == nil {
+					t.Fatalf("manifest missing static fragment %s", frag.ID)
+				}
+				if want := expectedTokens[frag.ID]; item.TokenEstimate != want {
+					t.Fatalf(
+						"manifest token estimate for %s = %d, want byte estimate %d",
+						frag.ID,
+						item.TokenEstimate,
+						want,
+					)
+				}
+			}
+		})
+	}
+}
+
+func round6StaticSystemFrags(mode string, scope contextfrag.Scope) []contextfrag.ContextFrag {
+	return agentpkg.SystemSectionFrags(agentpkg.GenerateSystemSections(agentpkg.SystemPromptParams{
+		SessionType: mode,
+		Timezone:    "UTC",
+	}), scope)
+}
+
+func round6ProtectedOverflowSourceFrags(mode string) []contextfrag.ContextFrag {
+	return round6StaticSystemFrags(mode, contextfrag.Scope{})
+}
+
+func appendClone(frags []contextfrag.ContextFrag, extra contextfrag.ContextFrag) []contextfrag.ContextFrag {
+	out := append([]contextfrag.ContextFrag(nil), frags...)
+	return append(out, extra)
+}
+
+func manifestItemByID(items []contextfrag.ManifestItem, id string) *contextfrag.ManifestItem {
+	for i := range items {
+		if items[i].ID == id {
+			return &items[i]
+		}
+	}
+	return nil
+}

--- a/internal/contextview/selection_tag.go
+++ b/internal/contextview/selection_tag.go
@@ -1,0 +1,229 @@
+package contextview
+
+import (
+	"encoding/json"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+type SelectionTag string
+
+const (
+	TagMustKeep            SelectionTag = "must_keep"
+	TagPreserveRecent      SelectionTag = "preserve_recent"
+	TagPreserveToolClosure SelectionTag = "preserve_tool_closure"
+	TagCanDrop             SelectionTag = "can_drop"
+)
+
+type TaggedFrag struct {
+	Frag contextfrag.ContextFrag
+	Tags []SelectionTag
+}
+
+func (t TaggedFrag) HasTag(tag SelectionTag) bool {
+	return hasSelectionTag(t.Tags, tag)
+}
+
+func tagFragments(frags []contextfrag.ContextFrag, profile IntentProfile) []TaggedFrag {
+	tagged := make([]TaggedFrag, 0, len(frags))
+	for _, frag := range frags {
+		next := TaggedFrag{Frag: frag}
+		if isMustKeepFrag(frag, profile) {
+			next.Tags = appendSelectionTag(next.Tags, TagMustKeep)
+		}
+		if isToolExchangeFrag(frag) {
+			next.Tags = appendSelectionTag(next.Tags, TagPreserveToolClosure)
+		}
+		if hasAskUserTool(frag) {
+			next.Tags = appendSelectionTag(next.Tags, TagMustKeep)
+			next.Tags = appendSelectionTag(next.Tags, TagPreserveToolClosure)
+		}
+		tagged = append(tagged, next)
+	}
+	markRecentAndDropTags(tagged)
+	return tagged
+}
+
+func markRecentAndDropTags(tagged []TaggedFrag) {
+	if len(tagged) == 0 {
+		return
+	}
+	if latestUser := latestUserIndex(tagged); latestUser == 0 && len(tagged) > 1 {
+		tailStart := recentTailProtectedStart(tagged, 1)
+		for i := range tagged {
+			if i == 0 || i >= tailStart || tagged[i].HasTag(TagMustKeep) {
+				tagged[i].Tags = appendSelectionTag(tagged[i].Tags, TagPreserveRecent)
+				continue
+			}
+			tagged[i].Tags = appendSelectionTag(tagged[i].Tags, TagCanDrop)
+		}
+		return
+	}
+
+	start := recentProtectedStart(tagged)
+	for i := range tagged {
+		if tagged[i].HasTag(TagMustKeep) {
+			tagged[i].Tags = appendSelectionTag(tagged[i].Tags, TagPreserveRecent)
+			continue
+		}
+		if i < start {
+			tagged[i].Tags = appendSelectionTag(tagged[i].Tags, TagCanDrop)
+			continue
+		}
+		tagged[i].Tags = appendSelectionTag(tagged[i].Tags, TagPreserveRecent)
+	}
+}
+
+func isMustKeepFrag(frag contextfrag.ContextFrag, profile IntentProfile) bool {
+	if frag.Budget.Overflow == contextfrag.OverflowKeep {
+		return true
+	}
+	if profile.MustKeepFrag != nil && profile.MustKeepFrag(frag) {
+		return true
+	}
+	for _, slot := range profile.MustKeepSlots {
+		if frag.Slot == slot {
+			return true
+		}
+	}
+	return false
+}
+
+func latestUserIndex(tagged []TaggedFrag) int {
+	for i := len(tagged) - 1; i >= 0; i-- {
+		// Background summaries are per-step status notices, not conversation
+		// turns: they must not anchor the recent-protection window.
+		if tagged[i].Frag.Kind == contextfrag.KindBackgroundSummary {
+			continue
+		}
+		if isRole(tagged[i].Frag.Role, sdk.MessageRoleUser) {
+			return i
+		}
+		for _, part := range tagged[i].Frag.Parts {
+			if msg := sdkMessagePart(part); msg != nil && isRole(msg.Role, sdk.MessageRoleUser) {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func recentProtectedStart(tagged []TaggedFrag) int {
+	if len(tagged) == 0 {
+		return 0
+	}
+	if latestUser := latestUserIndex(tagged); latestUser >= 0 {
+		return latestUser
+	}
+	return recentTailProtectedStart(tagged, 0)
+}
+
+func recentTailProtectedStart(tagged []TaggedFrag, minStart int) int {
+	start := len(tagged) - 1
+	for start > minStart && isToolClosureResult(tagged[start]) {
+		start--
+	}
+	return start
+}
+
+func isToolClosureResult(tagged TaggedFrag) bool {
+	return tagged.HasTag(TagPreserveToolClosure) && isToolResultFrag(tagged.Frag)
+}
+
+func isToolResultFrag(frag contextfrag.ContextFrag) bool {
+	if isRole(frag.Role, sdk.MessageRoleTool) {
+		return true
+	}
+	for _, part := range frag.Parts {
+		if msg := sdkMessagePart(part); msg != nil && isRole(msg.Role, sdk.MessageRoleTool) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAskUserTool(frag contextfrag.ContextFrag) bool {
+	for _, part := range frag.Parts {
+		if msg := sdkMessagePart(part); msg != nil && messageHasToolName(*msg, "ask_user") {
+			return true
+		}
+	}
+	return false
+}
+
+func messageHasToolName(msg sdk.Message, name string) bool {
+	for _, part := range msg.Content {
+		switch p := part.(type) {
+		case sdk.ToolCallPart:
+			if equalToolName(p.ToolName, name) {
+				return true
+			}
+		case sdk.ToolResultPart:
+			if equalToolName(p.ToolName, name) {
+				return true
+			}
+		default:
+			if equalToolName(rawToolName(part), name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func equalToolName(got, want string) bool {
+	return strings.EqualFold(strings.TrimSpace(got), strings.TrimSpace(want))
+}
+
+func isRole(got, want sdk.MessageRole) bool {
+	return strings.EqualFold(strings.TrimSpace(string(got)), string(want))
+}
+
+func rawToolName(value any) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	var envelope struct {
+		ToolName string `json:"toolName"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(envelope.ToolName)
+}
+
+func appendSelectionTag(tags []SelectionTag, tag SelectionTag) []SelectionTag {
+	if hasSelectionTag(tags, tag) {
+		return tags
+	}
+	return append(tags, tag)
+}
+
+func hasSelectionTag(tags []SelectionTag, tag SelectionTag) bool {
+	for _, existing := range tags {
+		if existing == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// selectionDropReason reports the mutually exclusive retention state first
+// (must_keep / preserve_recent / can_drop) so a droppable tool-exchange
+// fragment reads as can_drop instead of the misleading closure tag; the
+// closure tag only surfaces when it is the sole marker.
+func selectionDropReason(tagged TaggedFrag) string {
+	for _, tag := range []SelectionTag{TagMustKeep, TagPreserveRecent, TagCanDrop, TagPreserveToolClosure} {
+		if tagged.HasTag(tag) {
+			return string(tag)
+		}
+	}
+	if tagged.Frag.ID != "" {
+		return "not_selected"
+	}
+	return string(TagCanDrop)
+}

--- a/internal/contextview/selector.go
+++ b/internal/contextview/selector.go
@@ -27,33 +27,160 @@ func mustKeepProviderSystemFrag(frag contextfrag.ContextFrag) bool {
 }
 
 func (*FragmentSelector) Select(frags []contextfrag.ContextFrag, profile IntentProfile, budget BudgetEnvelope) SelectionResult {
-	collected := len(frags)
-	selected, gated := applyTrustGate(frags, profile)
-	selected, superseded := resolveConflictGroups(selected)
-	selected, budgetDropped, edits, warnings := enforceFragBudgets(selected, profile)
-	selected, exchangeDropped, exchangeEdits := applyToolExchangePolicy(selected, budget.ToolExchange)
-
-	result := SelectionResult{
-		Selected: selected,
-		Edited:   append(edits, exchangeEdits...),
-		Warnings: warnings,
-		Summary: SelectionSummary{
-			TotalCollected: collected,
-			TotalSelected:  len(selected),
-		},
+	frags, gated := applyTrustGate(frags, profile)
+	frags, superseded := resolveConflictGroups(frags)
+	frags, fragBudgetDropped, fragBudgetEdits, fragBudgetWarnings := enforceFragBudgets(
+		frags,
+		profile,
+		systemBudgetPlanActive(profile, budget.Plan),
+	)
+	frags, systemBudgetDropped, fatalError := enforceSystemBudget(frags, profile, budget.Plan, fragBudgetDropped)
+	if fatalError != nil {
+		tagged := tagFragments(frags, profile)
+		result := selectionResultFromTaggedReasons(tagged, allSelectedIndexes(tagged), nil)
+		result.FatalError = fatalError
+		return finalizeSelection(
+			result,
+			profile,
+			gated,
+			superseded,
+			fragBudgetDropped,
+			fragBudgetEdits,
+			fragBudgetWarnings,
+			systemBudgetDropped,
+			nil,
+			nil,
+		)
 	}
+	if budget.Plan != nil {
+		budget.MaxTokens = budget.Plan.HistoryBudget
+	}
+
+	var exchangeDropped []contextfrag.ContextFrag
+	var exchangeEdits []contextfrag.ContextEditTrace
+	frags, exchangeDropped, exchangeEdits = applyToolExchangePolicy(frags, budget.ToolExchange)
+	tagged := tagFragments(frags, profile)
+	historyBudget := budget.MaxTokens
+	trimDrops := budgetTrimDrops
+	if budget.Plan != nil {
+		protectedCost := protectedHistoryTokenCost(tagged)
+		if protectedCost > historyBudget {
+			result := selectionResultFromTaggedReasons(tagged, allSelectedIndexes(tagged), nil)
+			result.FatalError = contextfrag.ErrProtectedContextOverflow
+			return finalizeSelection(
+				result,
+				profile,
+				gated,
+				superseded,
+				fragBudgetDropped,
+				fragBudgetEdits,
+				fragBudgetWarnings,
+				systemBudgetDropped,
+				exchangeDropped,
+				exchangeEdits,
+			)
+		}
+		historyBudget -= protectedCost
+		trimDrops = budgetTrimDropsEnabled
+	}
+
+	if drops, dropReasons := trimDrops(tagged, historyBudget, budget.RecentProtectTokens); len(drops) > 0 {
+		if budget.Plan != nil && hasSpatialBudgetDrop(dropReasons) {
+			noticeCost := contextfrag.ResolveProviderBudgetFragTokens(TrimNoticeFrag(contextfrag.Scope{}))
+			if noticeCost > historyBudget {
+				result := selectionResultFromTaggedReasons(tagged, keptIndexes(tagged, drops), dropReasons)
+				result.FatalError = contextfrag.ErrProtectedContextOverflow
+				return finalizeSelection(
+					result,
+					profile,
+					gated,
+					superseded,
+					fragBudgetDropped,
+					fragBudgetEdits,
+					fragBudgetWarnings,
+					systemBudgetDropped,
+					exchangeDropped,
+					exchangeEdits,
+				)
+			}
+			drops, dropReasons = budgetTrimDropsEnabled(
+				tagged,
+				historyBudget-noticeCost,
+				budget.RecentProtectTokens,
+			)
+		}
+		result := selectionResultFromTaggedReasons(tagged, keptIndexes(tagged, drops), dropReasons)
+		if hasSpatialBudgetDrop(dropReasons) {
+			result.TrimNotice = true
+			result.TrimNoticeIndex = trimNoticeIndex(tagged, drops)
+		}
+		return finalizeSelection(
+			result,
+			profile,
+			gated,
+			superseded,
+			fragBudgetDropped,
+			fragBudgetEdits,
+			fragBudgetWarnings,
+			systemBudgetDropped,
+			exchangeDropped,
+			exchangeEdits,
+		)
+	}
+
+	result := selectionResultFromTaggedReasons(tagged, allSelectedIndexes(tagged), nil)
+	return finalizeSelection(
+		result,
+		profile,
+		gated,
+		superseded,
+		fragBudgetDropped,
+		fragBudgetEdits,
+		fragBudgetWarnings,
+		systemBudgetDropped,
+		exchangeDropped,
+		exchangeEdits,
+	)
+}
+
+func finalizeSelection(
+	result SelectionResult,
+	profile IntentProfile,
+	gated []contextfrag.ContextFrag,
+	superseded []conflictLoser,
+	fragBudgetDropped []fragBudgetDrop,
+	fragBudgetEdits []fragBudgetEdit,
+	fragBudgetWarnings []contextfrag.ValidationWarning,
+	systemBudgetDropped []contextfrag.ContextFrag,
+	exchangeDropped []contextfrag.ContextFrag,
+	exchangeEdits []contextfrag.ContextEditTrace,
+) SelectionResult {
+	result.Edited = append(result.Edited, exchangeEdits...)
+	for _, edit := range fragBudgetEdits {
+		result.Edited = append(result.Edited, edit.trace)
+		if result.EditReasons == nil {
+			result.EditReasons = make(map[string]string, len(fragBudgetEdits))
+		}
+		result.EditReasons[edit.fragID] = edit.reason
+	}
+	result.Warnings = append(result.Warnings, fragBudgetWarnings...)
 	for _, frag := range gated {
 		result.recordDrop(frag, "trust_gate:"+string(frag.Slot)+"_requires_"+string(profile.SlotTrustFloors[frag.Slot]))
 	}
 	for _, loser := range superseded {
 		result.recordDrop(loser.frag, "precedence:superseded_by_"+loser.winnerID)
 	}
-	for _, dropped := range budgetDropped {
+	for _, dropped := range fragBudgetDropped {
 		result.recordDrop(dropped.frag, dropped.reason)
+	}
+	for _, frag := range systemBudgetDropped {
+		result.recordDrop(frag, systemBudgetDropReason)
 	}
 	for _, frag := range exchangeDropped {
 		result.recordDrop(frag, toolExchangeDropReason)
 	}
+	result.Summary.TotalCollected = len(result.Selected) + len(result.Dropped)
+	result.Summary.TotalSelected = len(result.Selected)
 	result.Summary.TotalDropped = len(result.Dropped)
 	return result
 }
@@ -65,6 +192,118 @@ func (r *SelectionResult) recordDrop(frag contextfrag.ContextFrag, reason string
 		Ref:    frag.Ref,
 		Reason: reason,
 	})
+}
+
+func selectionResultFromTaggedReasons(
+	tagged []TaggedFrag,
+	selectedIndexes map[int]bool,
+	reasonOverrides map[int]string,
+) SelectionResult {
+	selected := make([]contextfrag.ContextFrag, 0, len(selectedIndexes))
+	dropped := make([]contextfrag.ContextFrag, 0, len(tagged)-len(selectedIndexes))
+	dropRecords := make([]DropRecord, 0, len(tagged)-len(selectedIndexes))
+	for i, taggedFrag := range tagged {
+		if selectedIndexes[i] {
+			selected = append(selected, taggedFrag.Frag)
+			continue
+		}
+		reason := reasonOverrides[i]
+		if reason == "" {
+			reason = selectionDropReason(taggedFrag)
+		}
+		dropped = append(dropped, taggedFrag.Frag)
+		dropRecords = append(dropRecords, DropRecord{
+			FragID: taggedFrag.Frag.ID,
+			Ref:    taggedFrag.Frag.Ref,
+			Reason: reason,
+		})
+	}
+	return SelectionResult{
+		Selected: selected,
+		Dropped:  dropped,
+		Summary: SelectionSummary{
+			TotalCollected: len(tagged),
+			TotalSelected:  len(selected),
+			TotalDropped:   len(dropped),
+			DropReasons:    dropRecords,
+		},
+	}
+}
+
+func keptIndexes(tagged []TaggedFrag, drops map[int]bool) map[int]bool {
+	kept := make(map[int]bool, len(tagged)-len(drops))
+	for i := range tagged {
+		if !drops[i] {
+			kept[i] = true
+		}
+	}
+	return kept
+}
+
+// trimNoticeIndex returns the closure-safe position nearest to the first kept
+// fragment that follows the last dropped fragment.
+func trimNoticeIndex(tagged []TaggedFrag, drops map[int]bool) int {
+	lastDropped := -1
+	for i := range tagged {
+		if drops[i] {
+			lastDropped = i
+		}
+	}
+	if lastDropped < 0 {
+		return -1
+	}
+	kept := make([]contextfrag.ContextFrag, 0, len(tagged)-len(drops))
+	base := -1
+	for i := range tagged {
+		if drops[i] {
+			continue
+		}
+		if base < 0 && i > lastDropped {
+			base = len(kept)
+		}
+		kept = append(kept, tagged[i].Frag)
+	}
+	if base < 0 {
+		base = len(kept)
+	}
+	return closureSafeNoticeIndex(kept, base)
+}
+
+func closureSafeNoticeIndex(kept []contextfrag.ContextFrag, base int) int {
+	open := make(map[string]int)
+	fallback := 0
+	for pos := 0; pos <= len(kept); pos++ {
+		if len(open) == 0 {
+			if pos >= base {
+				return pos
+			}
+			fallback = pos
+		}
+		if pos == len(kept) {
+			break
+		}
+		for _, id := range fragToolCallIDs(kept[pos]) {
+			open[id]++
+		}
+		for _, id := range fragToolResultCallIDs(kept[pos]) {
+			if count, ok := open[id]; ok {
+				if count <= 1 {
+					delete(open, id)
+				} else {
+					open[id] = count - 1
+				}
+			}
+		}
+	}
+	return fallback
+}
+
+func allSelectedIndexes(tagged []TaggedFrag) map[int]bool {
+	selected := make(map[int]bool, len(tagged))
+	for i := range tagged {
+		selected[i] = true
+	}
+	return selected
 }
 
 func applyTrustGate(frags []contextfrag.ContextFrag, profile IntentProfile) ([]contextfrag.ContextFrag, []contextfrag.ContextFrag) {
@@ -123,19 +362,4 @@ func conflictBeats(challenger, incumbent contextfrag.ContextFrag) bool {
 		return challengerTrust > incumbentTrust
 	}
 	return true
-}
-
-func isMustKeepFrag(frag contextfrag.ContextFrag, profile IntentProfile) bool {
-	if frag.Budget.Overflow == contextfrag.OverflowKeep {
-		return true
-	}
-	if profile.MustKeepFrag != nil && profile.MustKeepFrag(frag) {
-		return true
-	}
-	for _, slot := range profile.MustKeepSlots {
-		if frag.Slot == slot {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/contextview/selector_budget.go
+++ b/internal/contextview/selector_budget.go
@@ -1,0 +1,396 @@
+package contextview
+
+import (
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+// HistoryTrimNotice tells the model that budget pressure removed messages.
+// Tiered drops can leave holes mid-history, not only at the head, so the
+// wording stays honest about that. The text is model-visible; change it only
+// deliberately.
+const HistoryTrimNotice = "[System Notice] Some earlier and intervening messages were trimmed to fit the context window. " +
+	"If you need information from the trimmed messages, use the available tools " +
+	"(such as memory_read or web search) to retrieve it."
+
+// Budget drop reasons name the attention band a fragment fell out of, so the
+// lifecycle drop_reasons histogram explains what budget pressure removed.
+const (
+	budgetDropReasonPassive        = "budget:passive"
+	budgetDropReasonUntiered       = "budget:untiered"
+	budgetDropReasonDirected       = "budget:directed"
+	budgetDropReasonRecentWindow   = "budget:recent_window"
+	budgetDropReasonOrphanExchange = "budget:orphan_tool_exchange"
+)
+
+// Attention tiers order budget drops: passive group traffic goes first,
+// fragments without attention data stay time-neutral in the middle, and
+// directed traffic (mention/reply/direct/command/schedule/heartbeat) goes
+// last.
+const (
+	attentionTierPassive = iota
+	attentionTierUntiered
+	attentionTierDirected
+)
+
+func fragAttentionTier(frag contextfrag.ContextFrag) int {
+	reasons := frag.Scope.Attention
+	if len(reasons) == 0 {
+		return attentionTierUntiered
+	}
+	for _, reason := range reasons {
+		if reason != contextfrag.AttentionPassive {
+			return attentionTierDirected
+		}
+	}
+	return attentionTierPassive
+}
+
+func budgetDropReasonForTier(tier int) string {
+	switch tier {
+	case attentionTierPassive:
+		return budgetDropReasonPassive
+	case attentionTierDirected:
+		return budgetDropReasonDirected
+	default:
+		return budgetDropReasonUntiered
+	}
+}
+
+// budgetUnit is the atomic drop unit: a lone fragment, or an assistant
+// tool-call fragment grouped with its tool-result fragments so budget drops
+// never break a tool closure. Units span the whole tagged set: when any
+// member is protected the entire unit is (mixed droppability would orphan
+// half a closure), and the tier comes from attention-bearing members only so
+// data-less tool results never promote a passive exchange.
+type budgetUnit struct {
+	indexes       []int
+	tokens        int
+	attentionTier int
+	hasAttention  bool
+	droppable     bool
+	hasCall       bool
+	hasResult     bool
+}
+
+func (u *budgetUnit) tier() int {
+	if u.hasAttention {
+		return u.attentionTier
+	}
+	return attentionTierUntiered
+}
+
+// orphanToolExchange reports a unit that carries only one side of a tool
+// exchange: a call nothing ever answers, or a result answering a call that
+// is not (or no longer) in the set. Either shape is a guaranteed provider
+// 400 if it reaches the wire, so both drop unconditionally.
+func (u *budgetUnit) orphanToolExchange() bool {
+	return u.hasCall != u.hasResult
+}
+
+// buildBudgetUnits pairs tool calls with their results in a single forward
+// pass keyed by tool_call_id and scoped to appearance order, not id identity
+// alone: a call opens its id, the next result seen for that id closes it,
+// and the id is then free for a later call to reopen. Backends that emit
+// deterministic per-turn ids (llama.cpp/vLLM style "call_0") reuse the same
+// id across unrelated exchanges; scoping by the currently-open call keeps
+// each exchange its own drop unit instead of collapsing every reuse of an id
+// into one atomic (and possibly permanently undroppable) unit.
+//
+// A call whose id is already open when a new call for that id arrives does
+// not close the earlier one: the earlier call stays open — and therefore
+// orphaned, since nothing will ever close it — while the new call starts its
+// own unit. A result whose id has no open call is likewise an orphan. This
+// symmetric treatment also covers a result observed before its matching
+// call: the result finds no open call (orphan), and the call that follows
+// then opens a unit nothing ever closes (orphan too) — both drop, instead of
+// the old union-find behavior that paired them regardless of order.
+func buildBudgetUnits(tagged []TaggedFrag) []budgetUnit {
+	units := make([]budgetUnit, 0, len(tagged))
+	open := make(map[string]int)
+
+	for i, taggedFrag := range tagged {
+		frag := taggedFrag.Frag
+		callIDs := fragToolCallIDs(frag)
+		resultIDs := fragToolResultCallIDs(frag)
+
+		home := -1
+		for _, id := range resultIDs {
+			idx, ok := open[id]
+			if !ok {
+				continue
+			}
+			delete(open, id)
+			if home == -1 {
+				home = idx
+				continue
+			}
+			if home != idx {
+				mergeBudgetUnits(units, home, idx, open)
+			}
+		}
+		if home == -1 {
+			units = append(units, budgetUnit{droppable: true})
+			home = len(units) - 1
+		}
+
+		addFragToBudgetUnit(&units[home], i, frag, taggedFrag, len(callIDs) > 0, len(resultIDs) > 0)
+
+		for _, id := range callIDs {
+			open[id] = home
+		}
+	}
+	return units
+}
+
+// mergeBudgetUnits folds src into dest when a single fragment's result parts
+// close calls that opened two different (still-open) units — a batched
+// multi-result tool message answering more than one pending call. It also
+// redirects any other ids still pointing at src, in case src had further
+// calls open elsewhere.
+func mergeBudgetUnits(units []budgetUnit, dest, src int, open map[string]int) {
+	from := units[src]
+	to := &units[dest]
+	to.indexes = append(to.indexes, from.indexes...)
+	to.tokens += from.tokens
+	if from.hasAttention && (!to.hasAttention || from.attentionTier > to.attentionTier) {
+		to.attentionTier = from.attentionTier
+	}
+	to.hasAttention = to.hasAttention || from.hasAttention
+	to.droppable = to.droppable && from.droppable
+	to.hasCall = to.hasCall || from.hasCall
+	to.hasResult = to.hasResult || from.hasResult
+	units[src] = budgetUnit{}
+	for id, idx := range open {
+		if idx == src {
+			open[id] = dest
+		}
+	}
+}
+
+func addFragToBudgetUnit(unit *budgetUnit, index int, frag contextfrag.ContextFrag, taggedFrag TaggedFrag, hasCall, hasResult bool) {
+	unit.indexes = append(unit.indexes, index)
+	unit.tokens += fragTokenEstimate(frag)
+	if !taggedFrag.HasTag(TagCanDrop) {
+		unit.droppable = false
+	}
+	if len(frag.Scope.Attention) > 0 {
+		if tier := fragAttentionTier(frag); !unit.hasAttention || tier > unit.attentionTier {
+			unit.attentionTier = tier
+		}
+		unit.hasAttention = true
+	}
+	if hasCall {
+		unit.hasCall = true
+	}
+	if hasResult {
+		unit.hasResult = true
+	}
+}
+
+func fragToolCallIDs(frag contextfrag.ContextFrag) []string {
+	var ids []string
+	for _, part := range frag.Parts {
+		msg := sdkMessagePart(part)
+		if msg == nil {
+			continue
+		}
+		for _, mp := range msg.Content {
+			if call, ok := mp.(sdk.ToolCallPart); ok {
+				if id := strings.TrimSpace(call.ToolCallID); id != "" {
+					ids = append(ids, id)
+				}
+			}
+		}
+	}
+	return ids
+}
+
+func fragToolResultCallIDs(frag contextfrag.ContextFrag) []string {
+	var ids []string
+	for _, part := range frag.Parts {
+		msg := sdkMessagePart(part)
+		if msg == nil {
+			continue
+		}
+		for _, mp := range msg.Content {
+			if result, ok := mp.(sdk.ToolResultPart); ok {
+				if id := strings.TrimSpace(result.ToolCallID); id != "" {
+					ids = append(ids, id)
+				}
+			}
+		}
+	}
+	return ids
+}
+
+// budgetTrimDrops decides which droppable fragments leave the context under
+// budget pressure. The drop order is a fixed total order that depends only on
+// the fragments and the recent-protect window, never on the budget:
+//
+//  1. Droppable orphan tool-call/tool-result units (the other half of the
+//     exchange is missing anywhere in the set) drop unconditionally: left in
+//     place they are a guaranteed provider 400.
+//  2. The remaining units drop tier by tier — passive, then untiered, then
+//     directed — so a directed unit never drops before a passive or
+//     untiered one, regardless of where either sits.
+//  3. Within a tier, units outside the recent-protect window drop before
+//     units inside it (reported as budget:recent_window), oldest first in
+//     both halves. The window is a tie-break within a shared tier, not a
+//     competing band: it can never buy a passive unit survival over a
+//     directed one.
+//
+// Each spatial drop happens only while the droppable total still exceeds its
+// allowance — the fit check is the sole budget-dependent point. A larger
+// allowance stops earlier along the same sequence, so it always keeps a superset of
+// what a smaller budget keeps, and dropping the whole sequence always reaches
+// the budget because only droppable tokens are counted.
+//
+// Priority never enters retention: it only orders rendering. The budget
+// passed here is the allowance left for droppable tokens. The legacy path
+// passes its whole history budget, preserving trimMessagesByTokens accounting.
+// An active unified plan first deducts protected history and the required trim
+// notice. When the droppable total fits, nothing drops and the output is
+// byte-identical to the unbudgeted path.
+func budgetTrimDrops(tagged []TaggedFrag, maxTokens, recentProtectTokens int) (map[int]bool, map[int]string) {
+	if maxTokens <= 0 {
+		return nil, nil
+	}
+	return budgetTrimDropsEnabled(tagged, maxTokens, recentProtectTokens)
+}
+
+// budgetTrimDropsEnabled applies an active budget even when no tokens remain
+// for droppable history. The legacy zero value still disables budgeting via
+// budgetTrimDrops.
+func budgetTrimDropsEnabled(tagged []TaggedFrag, maxTokens, recentProtectTokens int) (map[int]bool, map[int]string) {
+	if maxTokens < 0 {
+		maxTokens = 0
+	}
+	units := buildBudgetUnits(tagged)
+
+	drops := make(map[int]bool)
+	reasons := make(map[int]string)
+	dropUnit := func(unit *budgetUnit, reason string) {
+		for _, idx := range unit.indexes {
+			drops[idx] = true
+			reasons[idx] = reason
+		}
+	}
+
+	pool := make([]int, 0, len(units))
+	total := 0
+	for i := range units {
+		unit := &units[i]
+		if !unit.droppable {
+			continue
+		}
+		if unit.orphanToolExchange() {
+			dropUnit(unit, budgetDropReasonOrphanExchange)
+			continue
+		}
+		pool = append(pool, i)
+		total += unit.tokens
+	}
+	if total <= maxTokens {
+		if len(drops) == 0 {
+			return nil, nil
+		}
+		return drops, reasons
+	}
+
+	protectedStart := len(pool)
+	acc := 0
+	for protectedStart > 0 && acc+units[pool[protectedStart-1]].tokens <= recentProtectTokens {
+		acc += units[pool[protectedStart-1]].tokens
+		protectedStart--
+	}
+
+	outside, inside := pool[:protectedStart], pool[protectedStart:]
+	dropTier := func(band []int, tier int, reason string) {
+		for _, unitIdx := range band {
+			if total <= maxTokens {
+				return
+			}
+			unit := &units[unitIdx]
+			if unit.tier() != tier {
+				continue
+			}
+			dropUnit(unit, reason)
+			total -= unit.tokens
+		}
+	}
+	for tier := attentionTierPassive; tier <= attentionTierDirected && total > maxTokens; tier++ {
+		dropTier(outside, tier, budgetDropReasonForTier(tier))
+		dropTier(inside, tier, budgetDropReasonRecentWindow)
+	}
+	return drops, reasons
+}
+
+// protectedHistoryTokenCost charges every protected non-system/non-current
+// fragment to the unified history budget. Current requests may intentionally
+// retain the history slot to preserve composed order, so kind is authoritative
+// alongside slot. Unit protection is atomic: when a protected tool-call/result
+// member makes the whole closure non-droppable, every history member of that
+// closure is charged.
+func protectedHistoryTokenCost(tagged []TaggedFrag) int {
+	units := buildBudgetUnits(tagged)
+	total := 0
+	for i := range units {
+		unit := &units[i]
+		if unit.droppable {
+			continue
+		}
+		for _, idx := range unit.indexes {
+			frag := tagged[idx].Frag
+			if frag.Slot == contextfrag.SlotSystem ||
+				frag.Slot == contextfrag.SlotCurrentUser ||
+				frag.Kind == contextfrag.KindCurrentUserMessage {
+				continue
+			}
+			total += fragTokenEstimate(frag)
+		}
+	}
+	return total
+}
+
+// hasSpatialBudgetDrop reports whether any drop reason came from budget
+// pressure rather than the unconditional orphan cut, so the trim notice
+// (which promises the model earlier or intervening messages were trimmed to
+// fit) is never raised over an orphan-only drop that would have fit as-is.
+func hasSpatialBudgetDrop(reasons map[int]string) bool {
+	for _, reason := range reasons {
+		if reason != budgetDropReasonOrphanExchange {
+			return true
+		}
+	}
+	return false
+}
+
+func fragTokenEstimate(frag contextfrag.ContextFrag) int {
+	return contextfrag.ResolveFragTokens(frag)
+}
+
+// TrimNoticeFrag is the synthetic fragment the builder splices in when budget
+// trimming dropped history, mirroring the legacy resolver notice message.
+func TrimNoticeFrag(scope contextfrag.Scope) contextfrag.ContextFrag {
+	msg := sdk.Message{
+		Role:    sdk.MessageRoleSystem,
+		Content: []sdk.MessagePart{sdk.TextPart{Text: HistoryTrimNotice}},
+	}
+	return contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID:         "history.trim_notice",
+		Message:    msg,
+		Kind:       contextfrag.KindSystemPolicy,
+		Slot:       contextfrag.SlotHistory,
+		Priority:   30,
+		CacheClass: contextfrag.CacheNever,
+		Trust:      contextfrag.TrustSystem,
+		Scope:      scope,
+		Source:     "context_select",
+		SourceID:   "history.trim_notice",
+		Collector:  "budget_trim",
+	})
+}

--- a/internal/contextview/selector_budget_attention_test.go
+++ b/internal/contextview/selector_budget_attention_test.go
@@ -1,0 +1,552 @@
+package contextview
+
+import (
+	"reflect"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func attentionMessageFrag(id string, msg sdk.Message, tokens int, reasons ...contextfrag.AttentionReason) contextfrag.ContextFrag {
+	frag := messageFrag(id, msg)
+	frag.TokenEstimate = tokens
+	frag.Scope.Attention = reasons
+	return frag
+}
+
+func selectProviderFrags(frags []contextfrag.ContextFrag, budget BudgetEnvelope) SelectionResult {
+	selector := &FragmentSelector{}
+	return selector.Select(frags, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), budget)
+}
+
+func TestBudgetAttention_NoPressureKeepsEverything(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("passive-old", sdk.UserMessage("group chatter"), 100, contextfrag.AttentionPassive),
+		attentionMessageFrag("directed-old", sdk.UserMessage("@bot do it"), 100, contextfrag.AttentionMention),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 1000, RecentProtectTokens: 50})
+
+	assertSelectedIDs(t, result, []string{"passive-old", "directed-old", "latest"})
+	if result.TrimNotice {
+		t.Fatal("no budget pressure must not raise a trim notice")
+	}
+}
+
+func TestBudgetAttention_PassiveDropsBeforeDirected(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("directed-1", sdk.UserMessage("@bot summarize"), 100, contextfrag.AttentionMention),
+		attentionMessageFrag("passive-1", sdk.UserMessage("group chatter one"), 100, contextfrag.AttentionPassive),
+		attentionMessageFrag("directed-2", sdk.UserMessage("replying to bot"), 100, contextfrag.AttentionReply),
+		attentionMessageFrag("passive-2", sdk.UserMessage("group chatter two"), 100, contextfrag.AttentionPassive),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 200})
+
+	assertSelectedIDs(t, result, []string{"directed-1", "directed-2", "latest"})
+	assertDroppedReason(t, result, "passive-1", budgetDropReasonPassive)
+	assertDroppedReason(t, result, "passive-2", budgetDropReasonPassive)
+}
+
+func TestBudgetAttention_UntieredDropsAfterPassiveBeforeDirected(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("directed-1", sdk.UserMessage("@bot look"), 100, contextfrag.AttentionMention),
+		attentionMessageFrag("untiered-1", sdk.UserMessage("plain chat history"), 100),
+		attentionMessageFrag("passive-1", sdk.UserMessage("group chatter"), 100, contextfrag.AttentionPassive),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 100})
+
+	assertSelectedIDs(t, result, []string{"directed-1", "latest"})
+	assertDroppedReason(t, result, "passive-1", budgetDropReasonPassive)
+	assertDroppedReason(t, result, "untiered-1", budgetDropReasonUntiered)
+}
+
+func TestBudgetAttention_UntieredOnlyKeepsOldestFirstOrder(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("untiered-1", sdk.UserMessage("first"), 100),
+		attentionMessageFrag("untiered-2", sdk.UserMessage("second"), 100),
+		attentionMessageFrag("untiered-3", sdk.UserMessage("third"), 100),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 200})
+
+	assertSelectedIDs(t, result, []string{"untiered-2", "untiered-3", "latest"})
+	assertDroppedReason(t, result, "untiered-1", budgetDropReasonUntiered)
+}
+
+// The recent-protect window scopes protection to units sharing a tier, not
+// across tiers: attention is the primary key and window membership only
+// breaks ties within a shared tier. A directed unit sitting outside the
+// window must never drop before a passive unit sitting inside it — that
+// cross-tier case is exactly where a fixed window-as-primary-band ordering
+// used to drop a directed message 21K tokens back to protect in-window
+// passive chatter.
+func TestBudgetAttention_DirectedOutsideWindowNeverDropsBeforePassiveInsideWindow(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("directed-old", sdk.UserMessage("@bot old ask"), 150, contextfrag.AttentionMention),
+		attentionMessageFrag("passive-recent", sdk.UserMessage("recent group chatter"), 100, contextfrag.AttentionPassive),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 200, RecentProtectTokens: 100})
+
+	assertSelectedIDs(t, result, []string{"directed-old", "latest"})
+	assertDroppedReason(t, result, "passive-recent", budgetDropReasonRecentWindow)
+}
+
+// When the budget is too small to hold the recent-protect window, the window
+// yields in the same tier order (passive first) instead of shielding recent
+// passives at the expense of older directed traffic, and the drops honestly
+// read budget:recent_window.
+func TestBudgetAttention_WindowYieldsTierOrderedUnderSmallBudget(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("directed-old", sdk.UserMessage("@bot old ask"), 100, contextfrag.AttentionMention),
+		attentionMessageFrag("passive-new", sdk.UserMessage("recent group chatter"), 100, contextfrag.AttentionPassive),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 150, RecentProtectTokens: 1000})
+
+	assertSelectedIDs(t, result, []string{"directed-old", "latest"})
+	assertDroppedReason(t, result, "passive-new", budgetDropReasonRecentWindow)
+}
+
+// The whole span sits inside the window here, so drops walk the in-window
+// band tier by tier (passive, then directed, oldest first) under the
+// budget:recent_window reason; raising the budget stops earlier along the
+// same order and monotonically keeps more.
+func TestBudgetAttention_MoreBudgetNeverDropsMore(t *testing.T) {
+	t.Parallel()
+
+	buildFrags := func() []contextfrag.ContextFrag {
+		return []contextfrag.ContextFrag{
+			attentionMessageFrag("window-1", sdk.UserMessage("one"), 100, contextfrag.AttentionMention),
+			attentionMessageFrag("window-2", sdk.UserMessage("two"), 100, contextfrag.AttentionPassive),
+			attentionMessageFrag("window-3", sdk.UserMessage("three"), 100, contextfrag.AttentionMention),
+			attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+		}
+	}
+
+	tight := selectProviderFrags(buildFrags(), BudgetEnvelope{MaxTokens: 150, RecentProtectTokens: 1000})
+	assertSelectedIDs(t, tight, []string{"window-3", "latest"})
+	assertDroppedReason(t, tight, "window-2", budgetDropReasonRecentWindow)
+	assertDroppedReason(t, tight, "window-1", budgetDropReasonRecentWindow)
+
+	mid := selectProviderFrags(buildFrags(), BudgetEnvelope{MaxTokens: 250, RecentProtectTokens: 1000})
+	assertSelectedIDs(t, mid, []string{"window-1", "window-3", "latest"})
+	assertDroppedReason(t, mid, "window-2", budgetDropReasonRecentWindow)
+
+	loose := selectProviderFrags(buildFrags(), BudgetEnvelope{MaxTokens: 400, RecentProtectTokens: 1000})
+	assertSelectedIDs(t, loose, []string{"window-1", "window-2", "window-3", "latest"})
+}
+
+func keptIDSet(result SelectionResult) map[string]bool {
+	kept := make(map[string]bool, len(result.Selected))
+	for _, frag := range result.Selected {
+		kept[frag.ID] = true
+	}
+	return kept
+}
+
+// windowShiftFrags is the review scenario where a budget-scaled window broke
+// cross-budget monotonicity: the larger budget widened the window, protected
+// more recent passives out of the passive band, and pushed pressure into the
+// older untiered band — dropping the 95-token message the smaller budget kept.
+func windowShiftFrags() []contextfrag.ContextFrag {
+	return []contextfrag.ContextFrag{
+		attentionMessageFrag("untiered-old", sdk.UserMessage("plain history"), 95),
+		attentionMessageFrag("passive-a", sdk.UserMessage("chatter a"), 20, contextfrag.AttentionPassive),
+		attentionMessageFrag("passive-b", sdk.UserMessage("chatter b"), 30, contextfrag.AttentionPassive),
+		attentionMessageFrag("passive-c", sdk.UserMessage("chatter c"), 60, contextfrag.AttentionPassive),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 50, contextfrag.AttentionDirect),
+	}
+}
+
+// Kept sets nest monotonically across any increasing budget ladder: shared
+// banding (fixed recent-protect window, tier order, oldest-first) makes every
+// larger budget stop earlier along the same drop sequence.
+func TestBudgetAttention_KeptSetsNestAcrossBudgets(t *testing.T) {
+	t.Parallel()
+
+	budgets := []int{60, 100, 140, 180, 205}
+	prev := selectProviderFrags(windowShiftFrags(), BudgetEnvelope{MaxTokens: budgets[0], RecentProtectTokens: 100})
+	for _, budget := range budgets[1:] {
+		next := selectProviderFrags(windowShiftFrags(), BudgetEnvelope{MaxTokens: budget, RecentProtectTokens: 100})
+		nextKept := keptIDSet(next)
+		for _, frag := range prev.Selected {
+			if !nextKept[frag.ID] {
+				t.Fatalf("budget %d dropped %q kept at a smaller budget", budget, frag.ID)
+			}
+		}
+		prev = next
+	}
+}
+
+// The trim notice may never split a kept tool closure. When the natural
+// insertion point (after the last dropped fragment) falls between a kept
+// call and its result, it slides to the closure's end.
+func TestBudgetAttention_NoticeNeverSplitsKeptClosure(t *testing.T) {
+	t.Parallel()
+
+	call := toolCallFrag("directed-call", "search", "call-1")
+	call.TokenEstimate = 50
+	call.Scope.Attention = []contextfrag.AttentionReason{contextfrag.AttentionMention}
+	callResult := toolResultFrag("directed-result", "search", "call-1", "found")
+	callResult.TokenEstimate = 50
+
+	frags := []contextfrag.ContextFrag{
+		call,
+		attentionMessageFrag("passive-mid", sdk.UserMessage("group chatter"), 100, contextfrag.AttentionPassive),
+		callResult,
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 150})
+
+	assertSelectedIDs(t, result, []string{"directed-call", "directed-result", "latest"})
+	assertDroppedReason(t, result, "passive-mid", budgetDropReasonPassive)
+	if !result.TrimNotice {
+		t.Fatal("budget drop must raise a trim notice")
+	}
+	if result.TrimNoticeIndex != 2 {
+		t.Fatalf("TrimNoticeIndex = %d, want 2 (after the kept closure)", result.TrimNoticeIndex)
+	}
+}
+
+// The notice wording is honest about scattered trimming — holes can be
+// mid-history, not only at the head. Model-visible change locked here.
+func TestHistoryTrimNoticeWordingHonestAboutHoles(t *testing.T) {
+	t.Parallel()
+
+	want := "[System Notice] Some earlier and intervening messages were trimmed to fit the context window. " +
+		"If you need information from the trimmed messages, use the available tools " +
+		"(such as memory_read or web search) to retrieve it."
+	if HistoryTrimNotice != want {
+		t.Fatalf("HistoryTrimNotice = %q, want %q", HistoryTrimNotice, want)
+	}
+}
+
+func TestBudgetAttention_ToolClosureDropsAtomically(t *testing.T) {
+	t.Parallel()
+
+	call := toolCallFrag("passive-call", "search", "call-1")
+	call.TokenEstimate = 50
+	call.Scope.Attention = []contextfrag.AttentionReason{contextfrag.AttentionPassive}
+	callResult := toolResultFrag("passive-result", "search", "call-1", "found")
+	callResult.TokenEstimate = 100
+	callResult.Scope.Attention = []contextfrag.AttentionReason{contextfrag.AttentionPassive}
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("directed-1", sdk.UserMessage("@bot keep this"), 100, contextfrag.AttentionMention),
+		call,
+		callResult,
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 100})
+
+	assertSelectedIDs(t, result, []string{"directed-1", "latest"})
+	assertDroppedReason(t, result, "passive-call", budgetDropReasonPassive)
+	assertDroppedReason(t, result, "passive-result", budgetDropReasonPassive)
+}
+
+// A tool closure with mixed droppability (one member pinned, the other
+// droppable) must be kept whole; dropping only the droppable half leaves an
+// orphan tool_use or tool_result the provider rejects with a 400.
+func TestBudgetAttention_MixedDroppabilityClosureKeptWhole(t *testing.T) {
+	t.Parallel()
+
+	pinnedCall := toolCallFrag("pinned-call", "search", "call-1")
+	pinnedCall.TokenEstimate = 50
+	pinnedCall.Budget.Overflow = contextfrag.OverflowKeep
+	droppableResult := toolResultFrag("droppable-result", "search", "call-1", "found")
+	droppableResult.TokenEstimate = 200
+
+	droppableCall := toolCallFrag("droppable-call", "search", "call-2")
+	droppableCall.TokenEstimate = 200
+	pinnedResult := toolResultFrag("pinned-result", "search", "call-2", "found")
+	pinnedResult.TokenEstimate = 50
+	pinnedResult.Budget.Overflow = contextfrag.OverflowKeep
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("filler-old", sdk.UserMessage("old filler"), 100),
+		pinnedCall,
+		droppableResult,
+		droppableCall,
+		pinnedResult,
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 50})
+
+	assertSelectedIDs(t, result, []string{"pinned-call", "droppable-result", "droppable-call", "pinned-result", "latest"})
+	assertDroppedReason(t, result, "filler-old", budgetDropReasonUntiered)
+}
+
+// A closure's tier comes from its attention-bearing members only. A passive
+// call whose tool result carries no attention data stays in the passive band
+// instead of being promoted to untiered.
+func TestBudgetAttention_ClosureTierIgnoresAttentionlessMembers(t *testing.T) {
+	t.Parallel()
+
+	call := toolCallFrag("passive-call", "search", "call-1")
+	call.TokenEstimate = 50
+	call.Scope.Attention = []contextfrag.AttentionReason{contextfrag.AttentionPassive}
+	callResult := toolResultFrag("plain-result", "search", "call-1", "found")
+	callResult.TokenEstimate = 50
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("untiered-old", sdk.UserMessage("plain history"), 100),
+		call,
+		callResult,
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 150})
+
+	assertSelectedIDs(t, result, []string{"untiered-old", "latest"})
+	assertDroppedReason(t, result, "passive-call", budgetDropReasonPassive)
+	assertDroppedReason(t, result, "plain-result", budgetDropReasonPassive)
+}
+
+// A droppable tool result whose call is absent from the set is a guaranteed
+// provider 400; with a budget in force it drops unconditionally, restoring
+// the legacy leading-orphan cut even when everything fits.
+//
+// An orphan drop is not a space trim: with nothing else under pressure, it
+// must not raise the trim notice either.
+func TestBudgetAttention_OrphanToolResultDroppedEvenUnderBudget(t *testing.T) {
+	t.Parallel()
+
+	orphan := toolResultFrag("orphan-result", "search", "call-gone", "stale")
+	orphan.TokenEstimate = 10
+
+	frags := []contextfrag.ContextFrag{
+		orphan,
+		attentionMessageFrag("plain-old", sdk.UserMessage("plain history"), 100),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 1000})
+
+	assertSelectedIDs(t, result, []string{"plain-old", "latest"})
+	assertDroppedReason(t, result, "orphan-result", budgetDropReasonOrphanExchange)
+	if result.TrimNotice {
+		t.Fatal("an orphan-only drop is not a space trim and must not raise a trim notice")
+	}
+}
+
+// A genuine space trim alongside an orphan drop must still raise the notice:
+// only the orphan-only case is silent.
+func TestBudgetAttention_OrphanPlusSpatialDropRaisesTrimNotice(t *testing.T) {
+	t.Parallel()
+
+	orphan := toolResultFrag("orphan-result", "search", "call-gone", "stale")
+	orphan.TokenEstimate = 10
+
+	frags := []contextfrag.ContextFrag{
+		orphan,
+		attentionMessageFrag("passive-old", sdk.UserMessage("chatter"), 100, contextfrag.AttentionPassive),
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 50})
+
+	assertSelectedIDs(t, result, []string{"latest"})
+	assertDroppedReason(t, result, "orphan-result", budgetDropReasonOrphanExchange)
+	assertDroppedReason(t, result, "passive-old", budgetDropReasonPassive)
+	if !result.TrimNotice {
+		t.Fatal("a genuine space trim alongside an orphan drop must still raise the trim notice")
+	}
+}
+
+// buildBudgetUnits scopes tool-call pairing to appearance order: a call
+// opens its tool_call_id, the next result seen for that id closes it, and
+// the id is then free for a later call to reopen. Backends that emit
+// deterministic per-turn ids (llama.cpp/vLLM style "call_0") reuse the same
+// id across unrelated exchanges; without appearance-order scoping, reusing
+// an id collapses two independent exchanges into one atomic drop unit. Here
+// the budget only needs the older exchange gone — the newer, smaller reuse
+// of the same id must survive on its own instead of being dragged along.
+func TestBudgetAttention_ReusedToolCallIDKeepsExchangesIndependent(t *testing.T) {
+	t.Parallel()
+
+	oldCall := toolCallFrag("old-call", "search", "call_0")
+	oldCall.TokenEstimate = 50
+	oldCall.Scope.Attention = []contextfrag.AttentionReason{contextfrag.AttentionPassive}
+	oldResult := toolResultFrag("old-result", "search", "call_0", "found")
+	oldResult.TokenEstimate = 50
+
+	newCall := toolCallFrag("new-call", "search", "call_0")
+	newCall.TokenEstimate = 25
+	newCall.Scope.Attention = []contextfrag.AttentionReason{contextfrag.AttentionPassive}
+	newResult := toolResultFrag("new-result", "search", "call_0", "found")
+	newResult.TokenEstimate = 25
+
+	frags := []contextfrag.ContextFrag{
+		oldCall,
+		oldResult,
+		newCall,
+		newResult,
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 50})
+
+	assertSelectedIDs(t, result, []string{"new-call", "new-result", "latest"})
+	assertDroppedReason(t, result, "old-call", budgetDropReasonPassive)
+	assertDroppedReason(t, result, "old-result", budgetDropReasonPassive)
+}
+
+// A must-keep marker on a newer reused-id exchange must not contaminate an
+// unrelated older exchange sharing the same tool_call_id: id-keyed merging
+// (rather than appearance-order scoping) would fold both into one unit,
+// have the must-keep tag make the whole thing undroppable, and blow through
+// the budget with the older exchange still attached — a guaranteed 400 that
+// nothing in the older exchange itself justifies.
+func TestBudgetAttention_ReusedToolCallIDOldExchangeDropsDespiteNewMustKeep(t *testing.T) {
+	t.Parallel()
+
+	oldCall := toolCallFrag("old-call", "search", "call_0")
+	oldCall.TokenEstimate = 5000
+	oldCall.Scope.Attention = []contextfrag.AttentionReason{contextfrag.AttentionPassive}
+	oldResult := toolResultFrag("old-result", "search", "call_0", "found")
+	oldResult.TokenEstimate = 5000
+
+	newCall := toolCallFrag("new-call", "search", "call_0")
+	newCall.TokenEstimate = 50
+	newCall.Budget.Overflow = contextfrag.OverflowKeep
+	newResult := toolResultFrag("new-result", "search", "call_0", "found")
+	newResult.TokenEstimate = 50
+
+	frags := []contextfrag.ContextFrag{
+		oldCall,
+		oldResult,
+		newCall,
+		newResult,
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 200})
+
+	assertSelectedIDs(t, result, []string{"new-call", "new-result", "latest"})
+	assertDroppedReason(t, result, "old-call", budgetDropReasonPassive)
+	assertDroppedReason(t, result, "old-result", budgetDropReasonPassive)
+}
+
+// A result observed before any call for its id has no open unit to close —
+// it is itself an orphan — and the call that later opens the same id is
+// never closed by anything after it, so it is an orphan too. Appearance-
+// order scoping drops both unconditionally instead of the old union-find
+// behavior that paired them regardless of order: result-before-call for the
+// same id is not a shape real backends produce (ids are reused strictly
+// call-then-result), so pairing it was solving a problem this design
+// doesn't have, at the cost of ever dropping a genuine orphan wrong.
+func TestBudgetAttention_ResultBeforeCallBothOrphan(t *testing.T) {
+	t.Parallel()
+
+	early := toolResultFrag("early-result", "search", "call-1", "found")
+	early.TokenEstimate = 40
+	later := toolCallFrag("later-call", "search", "call-1")
+	later.TokenEstimate = 40
+	later.Scope.Attention = []contextfrag.AttentionReason{contextfrag.AttentionPassive}
+
+	frags := []contextfrag.ContextFrag{
+		attentionMessageFrag("directed-old", sdk.UserMessage("@bot keep this"), 100, contextfrag.AttentionMention),
+		early,
+		later,
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 1000})
+
+	assertSelectedIDs(t, result, []string{"directed-old", "latest"})
+	assertDroppedReason(t, result, "early-result", budgetDropReasonOrphanExchange)
+	assertDroppedReason(t, result, "later-call", budgetDropReasonOrphanExchange)
+	if result.TrimNotice {
+		t.Fatal("orphan-only drops must not raise the trim notice")
+	}
+}
+
+// Drops within a tier are contiguous oldest-first; priority no longer
+// reorders them, so a newer zero-estimate unit is not sacrificed for zero
+// gain before an older unit that actually frees tokens.
+func TestBudgetAttention_OldestFirstWithinTierNoZeroGainScatter(t *testing.T) {
+	t.Parallel()
+
+	heavy := attentionMessageFrag("passive-heavy-old", sdk.UserMessage("very long chatter"), 100, contextfrag.AttentionPassive)
+	heavy.Priority = 70
+	zero := attentionMessageFrag("passive-zero-new", sdk.UserMessage("hi"), 0, contextfrag.AttentionPassive)
+	zero.Priority = 10
+
+	frags := []contextfrag.ContextFrag{
+		heavy,
+		zero,
+		attentionMessageFrag("latest", sdk.UserMessage("latest"), 100, contextfrag.AttentionDirect),
+	}
+
+	result := selectProviderFrags(frags, BudgetEnvelope{MaxTokens: 50})
+
+	assertSelectedIDs(t, result, []string{"passive-zero-new", "latest"})
+	assertDroppedReason(t, result, "passive-heavy-old", budgetDropReasonPassive)
+}
+
+func assertSelectedIDs(t *testing.T, result SelectionResult, want []string) {
+	t.Helper()
+	got := fragIDs(result.Selected)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected ids = %#v, want %#v; dropped=%#v", got, want, fragIDs(result.Dropped))
+	}
+	if result.Summary.TotalSelected != len(want) {
+		t.Fatalf("TotalSelected = %d, want %d", result.Summary.TotalSelected, len(want))
+	}
+}
+
+func assertDroppedReason(t *testing.T, result SelectionResult, fragID, reason string) {
+	t.Helper()
+	for _, record := range result.Summary.DropReasons {
+		if record.FragID == fragID {
+			if record.Reason != reason {
+				t.Fatalf("drop reason for %s = %q, want %q", fragID, record.Reason, reason)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing drop record for %s; records=%#v", fragID, result.Summary.DropReasons)
+}
+
+func toolCallFrag(id, name, callID string) contextfrag.ContextFrag {
+	return messageFrag(id, sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ToolCallPart{ToolCallID: callID, ToolName: name, Input: map[string]any{}},
+		},
+	})
+}
+
+func toolResultFrag(id, name, callID, result string) contextfrag.ContextFrag {
+	return messageFrag(id, sdk.ToolMessage(sdk.ToolResultPart{
+		ToolCallID: callID,
+		ToolName:   name,
+		Result:     result,
+	}))
+}

--- a/internal/contextview/selector_frag_budget.go
+++ b/internal/contextview/selector_frag_budget.go
@@ -18,7 +18,17 @@ type fragBudgetDrop struct {
 	reason string
 }
 
-func enforceFragBudgets(frags []contextfrag.ContextFrag, profile IntentProfile) (kept []contextfrag.ContextFrag, dropped []fragBudgetDrop, edits []contextfrag.ContextEditTrace, warnings []contextfrag.ValidationWarning) {
+type fragBudgetEdit struct {
+	trace  contextfrag.ContextEditTrace
+	fragID string
+	reason string
+}
+
+func enforceFragBudgets(
+	frags []contextfrag.ContextFrag,
+	profile IntentProfile,
+	systemPlanActive bool,
+) (kept []contextfrag.ContextFrag, dropped []fragBudgetDrop, edits []fragBudgetEdit, warnings []contextfrag.ValidationWarning) {
 	kept = make([]contextfrag.ContextFrag, 0, len(frags))
 	for _, frag := range frags {
 		reason, exceeded := fragBudgetExceeded(frag)
@@ -32,7 +42,7 @@ func enforceFragBudgets(frags []contextfrag.ContextFrag, profile IntentProfile) 
 			case isToolExchangeFrag(frag):
 				kept = append(kept, frag)
 				warnings = append(warnings, contextfrag.ValidationWarning{Code: "frag_budget_drop_blocked_tool_closure", Ref: frag.Ref})
-			case isMustKeepFrag(frag, profile):
+			case isMustKeepFrag(frag, profile) && (!systemPlanActive || !droppableSystemBudgetFrag(frag)):
 				kept = append(kept, frag)
 				warnings = append(warnings, contextfrag.ValidationWarning{Code: "frag_budget_drop_blocked_must_keep", Ref: frag.Ref})
 			default:
@@ -46,7 +56,11 @@ func enforceFragBudgets(frags []contextfrag.ContextFrag, profile IntentProfile) 
 				continue
 			}
 			kept = append(kept, trimmed)
-			edits = append(edits, fragBudgetTrimEdit(trimmed))
+			edits = append(edits, fragBudgetEdit{
+				trace:  fragBudgetTrimEdit(trimmed),
+				fragID: frag.ID,
+				reason: reason,
+			})
 		case contextfrag.OverflowSummarize:
 			kept = append(kept, frag)
 			warnings = append(warnings, contextfrag.ValidationWarning{Code: "overflow_summarize_unsupported", Ref: frag.Ref})
@@ -55,6 +69,12 @@ func enforceFragBudgets(frags []contextfrag.ContextFrag, profile IntentProfile) 
 		}
 	}
 	return kept, dropped, edits, warnings
+}
+
+func droppableSystemBudgetFrag(frag contextfrag.ContextFrag) bool {
+	return frag.Slot == contextfrag.SlotSystem &&
+		(frag.RetentionTier == contextfrag.RetentionOptional ||
+			frag.RetentionTier == contextfrag.RetentionPreferred)
 }
 
 func fragBudgetExceeded(frag contextfrag.ContextFrag) (string, bool) {

--- a/internal/contextview/selector_frag_budget_test.go
+++ b/internal/contextview/selector_frag_budget_test.go
@@ -1,6 +1,7 @@
 package contextview
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -165,6 +166,75 @@ func TestFragBudgetEnforcesBothCharacterAndTokenDimensions(t *testing.T) {
 	}
 	if text == original {
 		t.Fatal("MaxTokens did not trim while MaxChars remained under limit")
+	}
+}
+
+func TestFragBudgetDropsOptionalSystemBeforeTierPass(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	optional := textFrag(
+		"system.optional",
+		contextfrag.SlotSystem,
+		contextfrag.KindSystemPrompt,
+		sdk.MessageRoleSystem,
+		"oversized optional section",
+	)
+	optional.Trust = contextfrag.TrustSystem
+	optional.RetentionTier = contextfrag.RetentionOptional
+	optional.Budget = contextfrag.BudgetPolicy{MaxTokens: 1, Overflow: contextfrag.OverflowDrop}
+	plan := &contextfrag.ContextBudgetPlan{SystemBudget: 500}
+
+	result := selector.Select(
+		[]contextfrag.ContextFrag{optional},
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan},
+	)
+
+	if got := fragIDs(result.Selected); !reflect.DeepEqual(got, []string{systemBudgetMarkerID}) {
+		t.Fatalf("selected = %v, want exactly one budget-accounted system omission marker", got)
+	}
+	if len(result.Dropped) != 1 {
+		t.Fatalf("dropped = %#v, want optional oversized system fragment dropped", result.Dropped)
+	}
+	if len(result.Summary.DropReasons) != 1 ||
+		result.Summary.DropReasons[0].Reason != "frag_budget:max_tokens" {
+		t.Fatalf("drop reasons = %#v, want per-fragment budget reason", result.Summary.DropReasons)
+	}
+	if plan.ActualSystemCost != systemFragCost(result.Selected) {
+		t.Fatalf("actual system cost = %d, want rendered marker cost %d", plan.ActualSystemCost, systemFragCost(result.Selected))
+	}
+}
+
+func TestFragBudgetPlanDisabledKeepsOptionalSystemByteEquivalent(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	optional := textFrag(
+		"system.optional",
+		contextfrag.SlotSystem,
+		contextfrag.KindSystemPrompt,
+		sdk.MessageRoleSystem,
+		"oversized optional section",
+	)
+	optional.Trust = contextfrag.TrustSystem
+	optional.RetentionTier = contextfrag.RetentionOptional
+	optional.Budget = contextfrag.BudgetPolicy{MaxTokens: 1, Overflow: contextfrag.OverflowDrop}
+
+	result := selector.Select(
+		[]contextfrag.ContextFrag{optional},
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{},
+	)
+
+	if got := fragIDs(result.Selected); !reflect.DeepEqual(got, []string{"system.optional"}) {
+		t.Fatalf("selected = %v, want the original system fragment when the plan is disabled", got)
+	}
+	if len(result.Dropped) != 0 {
+		t.Fatalf("dropped = %#v, want no plan-disabled system drop", result.Dropped)
+	}
+	if len(result.Warnings) != 1 || result.Warnings[0].Code != "frag_budget_drop_blocked_must_keep" {
+		t.Fatalf("warnings = %#v, want one must-keep warning", result.Warnings)
 	}
 }
 

--- a/internal/contextview/selector_tokens_test.go
+++ b/internal/contextview/selector_tokens_test.go
@@ -1,0 +1,51 @@
+package contextview
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func toolCallMessageFrag(text string) contextfrag.ContextFrag {
+	call := sdk.ToolCallPart{
+		ToolCallID: "call-1",
+		ToolName:   "web_search",
+		Input:      map[string]any{"query": "memoh context usage panel design"},
+	}
+	return contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID:      "message.000",
+		Message: sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.TextPart{Text: text}, call}},
+		Kind:    contextfrag.KindConversationEvent,
+		Slot:    contextfrag.SlotHistory,
+	})
+}
+
+func TestFragTokenEstimateAddsToolPayloadToText(t *testing.T) {
+	t.Parallel()
+
+	text := "Running the search now."
+	frag := toolCallMessageFrag(text)
+
+	got := fragTokenEstimate(frag)
+	if want := contextfrag.ResolveFragTokens(frag); got != want {
+		t.Fatalf("fragTokenEstimate = %d, want shared estimator value %d", got, want)
+	}
+	if textOnly := len(text) / 4; got <= textOnly {
+		t.Fatalf("fragTokenEstimate = %d, must exceed text-only estimate %d", got, textOnly)
+	}
+}
+
+func TestFragCharCountAddsToolPayloadToText(t *testing.T) {
+	t.Parallel()
+
+	text := "Running the search now."
+	frag := toolCallMessageFrag(text)
+
+	got := fragCharCount(frag)
+	if textOnly := utf8.RuneCountInString(text); got <= textOnly {
+		t.Fatalf("fragCharCount = %d, must exceed text-only count %d", got, textOnly)
+	}
+}

--- a/internal/contextview/system_budget.go
+++ b/internal/contextview/system_budget.go
@@ -1,0 +1,369 @@
+package contextview
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+const (
+	// DefaultOutputReserveTokens is the conservative large-window completion
+	// allowance ceiling used until model configuration exposes an explicit
+	// maximum output size. Default plans reserve the smaller of this ceiling
+	// and one quarter of the model context window.
+	DefaultOutputReserveTokens = 8192
+	// MinimumSystemBudgetTokens prevents an active plan from treating a tiny
+	// positive remainder as a usable system envelope.
+	MinimumSystemBudgetTokens = 256
+
+	systemBudgetDropReason = "system_budget"
+	systemBudgetMarkerID   = "system.budget_notice"
+
+	systemBudgetMarkerMaxBytes   = 512
+	systemBudgetMarkerIDMaxBytes = 80
+)
+
+// ComputeContextBudgetPlan allocates the fixed reserves named by the provider
+// envelope contract. Passing outputReserve explicitly leaves the source seam
+// ready for a future model-level maximum without inventing one on RunConfig.
+func ComputeContextBudgetPlan(window, outputReserve, toolDefsCost, currentRequestCost int) (*contextfrag.ContextBudgetPlan, error) {
+	if window == 0 {
+		return nil, nil
+	}
+	plan := &contextfrag.ContextBudgetPlan{
+		Estimator:                    contextfrag.ProviderBudgetEstimator,
+		EstimatorSafetyFactorPercent: contextfrag.ProviderBudgetSafetyFactorPercent,
+		Window:                       window,
+		OutputReserve:                outputReserve,
+		ToolDefsCost:                 toolDefsCost,
+		CurrentRequestCost:           currentRequestCost,
+	}
+	remaining := window - outputReserve - toolDefsCost - currentRequestCost
+	if window < 0 || outputReserve < 0 || toolDefsCost < 0 || currentRequestCost < 0 ||
+		remaining < MinimumSystemBudgetTokens {
+		plan.SystemBudget = MinimumSystemBudgetTokens
+		return plan, contextfrag.ErrBudgetUnsatisfied
+	}
+	plan.SystemBudget = remaining
+	return plan, nil
+}
+
+type systemBudgetCandidate struct {
+	index int
+	frag  contextfrag.ContextFrag
+}
+
+func enforceSystemBudget(
+	frags []contextfrag.ContextFrag,
+	profile IntentProfile,
+	plan *contextfrag.ContextBudgetPlan,
+	fragBudgetDropped []fragBudgetDrop,
+) ([]contextfrag.ContextFrag, []contextfrag.ContextFrag, error) {
+	if !systemBudgetPlanActive(profile, plan) {
+		return frags, nil, nil
+	}
+
+	droppedIDs := make([]string, 0, len(fragBudgetDropped))
+	scope := firstSystemScope(frags)
+	hasScope := false
+	for _, frag := range frags {
+		if frag.Slot == contextfrag.SlotSystem {
+			hasScope = true
+			break
+		}
+	}
+	for _, drop := range fragBudgetDropped {
+		if drop.frag.Slot != contextfrag.SlotSystem {
+			continue
+		}
+		droppedIDs = append(droppedIDs, drop.frag.ID)
+		if !hasScope {
+			scope = drop.frag.Scope
+			hasScope = true
+		}
+	}
+	droppedIndexes := make(map[int]bool)
+	dropped := make([]contextfrag.ContextFrag, 0)
+	for _, header := range sweepEmptySystemGroupHeaders(frags, droppedIndexes) {
+		droppedIndexes[header.index] = true
+		dropped = append(dropped, header.frag)
+		droppedIDs = append(droppedIDs, header.frag.ID)
+	}
+	var marker contextfrag.ContextFrag
+	if len(droppedIDs) > 0 {
+		marker = systemBudgetMarkerFrag(droppedIDs, scope)
+	}
+	selected := systemBudgetSelection(frags, droppedIndexes, marker)
+	total := systemFragCost(selected)
+	if total <= plan.SystemBudget {
+		finishSystemBudgetPlan(plan, total)
+		return selected, dropped, nil
+	}
+
+	candidates := make([]systemBudgetCandidate, 0)
+	for i, frag := range frags {
+		if frag.Slot != contextfrag.SlotSystem ||
+			isRenderGroupHeader(frag) ||
+			frag.Budget.Overflow == contextfrag.OverflowKeep ||
+			(frag.RetentionTier != contextfrag.RetentionOptional && frag.RetentionTier != contextfrag.RetentionPreferred) {
+			continue
+		}
+		candidates = append(candidates, systemBudgetCandidate{index: i, frag: frag})
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		left, right := candidates[i].frag, candidates[j].frag
+		if left.RetentionTier != right.RetentionTier {
+			return left.RetentionTier == contextfrag.RetentionOptional
+		}
+		if left.DropPriority != right.DropPriority {
+			return left.DropPriority.DropsBefore(right.DropPriority)
+		}
+		if left.Priority != right.Priority {
+			return left.Priority > right.Priority
+		}
+		return left.ID < right.ID
+	})
+
+	for _, candidate := range candidates {
+		if droppedIndexes[candidate.index] {
+			continue
+		}
+		droppedIndexes[candidate.index] = true
+		dropped = append(dropped, candidate.frag)
+		droppedIDs = append(droppedIDs, candidate.frag.ID)
+		for _, header := range sweepEmptySystemGroupHeaders(frags, droppedIndexes) {
+			droppedIndexes[header.index] = true
+			dropped = append(dropped, header.frag)
+			droppedIDs = append(droppedIDs, header.frag.ID)
+		}
+		marker = systemBudgetMarkerFrag(droppedIDs, scope)
+		selected = systemBudgetSelection(frags, droppedIndexes, marker)
+		actual := systemFragCost(selected)
+		if actual <= plan.SystemBudget {
+			finishSystemBudgetPlan(plan, actual)
+			return selected, dropped, nil
+		}
+	}
+
+	if len(droppedIDs) > 0 {
+		marker = systemBudgetMarkerFrag(droppedIDs, scope)
+	}
+	selected = systemBudgetSelection(frags, droppedIndexes, marker)
+	actual := systemFragCost(selected)
+	finishSystemBudgetPlan(plan, actual)
+	return selected, dropped, contextfrag.ErrProtectedContextOverflow
+}
+
+func systemBudgetPlanActive(profile IntentProfile, plan *contextfrag.ContextBudgetPlan) bool {
+	return plan != nil &&
+		(profile.Intent == contextfrag.IntentRunConfigPreProvider || profile.Intent == contextfrag.IntentDiscussReply)
+}
+
+func finishSystemBudgetPlan(plan *contextfrag.ContextBudgetPlan, actual int) {
+	plan.ActualSystemCost = actual
+	plan.HistoryBudget = plan.SystemBudget - actual
+	if plan.HistoryBudget < 1 {
+		plan.HistoryBudget = 1
+	}
+}
+
+func systemFragCost(frags []contextfrag.ContextFrag) int {
+	frags = sortSystemFragsByPriority(frags)
+	resolved := 0
+	renderedBytes := 0
+	count := 0
+	var previousRender contextfrag.RenderPolicy
+	for _, frag := range frags {
+		if frag.Slot != contextfrag.SlotSystem {
+			continue
+		}
+		if count > 0 {
+			renderedBytes += len(contextfrag.RenderSeparator(previousRender, frag.Render))
+		}
+		for _, part := range frag.Parts {
+			if part.Type == contextfrag.PartText {
+				renderedBytes += len(contextfrag.RenderText(part.Text, frag.Render))
+			}
+		}
+		resolved += contextfrag.ResolveFragTokens(frag)
+		previousRender = frag.Render
+		count++
+	}
+	// Preserve authoritative per-fragment estimates while also measuring the
+	// exact rendered byte stream. The latter closes integer-flooring gaps
+	// across short sections and their "\n\n" boundaries.
+	conservative := resolved
+	if count > 1 {
+		conservative += count - 1
+	}
+	if rendered := contextfrag.ProviderBudgetTokensFromBytes(renderedBytes); rendered > conservative {
+		return rendered
+	}
+	return conservative
+}
+
+func sweepEmptySystemGroupHeaders(
+	frags []contextfrag.ContextFrag,
+	droppedIndexes map[int]bool,
+) []systemBudgetCandidate {
+	itemCounts := make(map[string]int)
+	headers := make(map[string]systemBudgetCandidate)
+	for i, frag := range frags {
+		if droppedIndexes[i] ||
+			frag.Slot != contextfrag.SlotSystem ||
+			frag.Render.GroupID == "" {
+			continue
+		}
+		if isRenderGroupHeader(frag) {
+			headers[frag.Render.GroupID] = systemBudgetCandidate{index: i, frag: frag}
+			continue
+		}
+		itemCounts[frag.Render.GroupID]++
+	}
+	var swept []systemBudgetCandidate
+	for groupID, header := range headers {
+		if itemCounts[groupID] == 0 {
+			swept = append(swept, header)
+		}
+	}
+	sort.Slice(swept, func(i, j int) bool {
+		return swept[i].frag.ID < swept[j].frag.ID
+	})
+	return swept
+}
+
+func firstSystemScope(frags []contextfrag.ContextFrag) contextfrag.Scope {
+	for _, frag := range frags {
+		if frag.Slot == contextfrag.SlotSystem {
+			return frag.Scope
+		}
+	}
+	return contextfrag.Scope{}
+}
+
+func systemBudgetSelection(
+	frags []contextfrag.ContextFrag,
+	droppedIndexes map[int]bool,
+	marker contextfrag.ContextFrag,
+) []contextfrag.ContextFrag {
+	kept := make([]contextfrag.ContextFrag, 0, len(frags)-len(droppedIndexes)+1)
+	lastSystem := -1
+	for i, frag := range frags {
+		if droppedIndexes[i] {
+			continue
+		}
+		kept = append(kept, frag)
+		if frag.Slot == contextfrag.SlotSystem {
+			lastSystem = len(kept) - 1
+		}
+	}
+	if marker.ID == "" {
+		return kept
+	}
+	insertAt := lastSystem + 1
+	kept = append(kept, contextfrag.ContextFrag{})
+	copy(kept[insertAt+1:], kept[insertAt:])
+	kept[insertAt] = marker
+	return kept
+}
+
+func systemBudgetMarkerFrag(droppedIDs []string, scope contextfrag.Scope) contextfrag.ContextFrag {
+	frag := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID:            systemBudgetMarkerID,
+		Kind:          contextfrag.KindSystemPolicy,
+		Role:          sdk.MessageRoleSystem,
+		Slot:          contextfrag.SlotSystem,
+		Text:          systemBudgetMarkerText(droppedIDs),
+		Priority:      int(^uint(0) >> 1),
+		RetentionTier: contextfrag.RetentionRequired,
+		CacheClass:    contextfrag.CacheDynamic,
+		Trust:         contextfrag.TrustSystem,
+		Scope:         scope,
+		Source:        contextfrag.SourceRunConfig,
+		Collector:     "system_budget",
+		Render:        contextfrag.RenderPolicy{Format: contextfrag.RenderMarkdown},
+		Budget:        contextfrag.BudgetPolicy{Overflow: contextfrag.OverflowKeep},
+	})
+	return contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{frag})[0]
+}
+
+func systemBudgetMarkerText(droppedIDs []string) string {
+	const prefix = "[System Notice] Some system sections were omitted to fit the context window: "
+	if len(droppedIDs) == 0 {
+		return prefix + "details unavailable."
+	}
+	var listed []string
+	for i, id := range droppedIDs {
+		displayID := systemBudgetMarkerDisplayID(id)
+		candidateIDs := displayID
+		if len(listed) > 0 {
+			candidateIDs = strings.Join(listed, ", ") + ", " + displayID
+		}
+		candidate := prefix + candidateIDs + systemBudgetMarkerTail(len(droppedIDs)-i-1)
+		if len(candidate) > systemBudgetMarkerMaxBytes {
+			break
+		}
+		listed = append(listed, displayID)
+	}
+	if len(listed) == 0 {
+		return prefix + strconv.Itoa(len(droppedIDs)) + " section IDs not shown."
+	}
+	return prefix + strings.Join(listed, ", ") + systemBudgetMarkerTail(len(droppedIDs)-len(listed))
+}
+
+func systemBudgetMarkerTail(omitted int) string {
+	if omitted <= 0 {
+		return "."
+	}
+	return ", ... (+" + strconv.Itoa(omitted) + " more)."
+}
+
+func systemBudgetMarkerDisplayID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "unnamed"
+	}
+	var token strings.Builder
+	token.Grow(min(len(raw), systemBudgetMarkerIDMaxBytes))
+	changed := false
+	for i := 0; i < len(raw); i++ {
+		value := raw[i]
+		if !systemBudgetMarkerIDByte(value) {
+			value = '-'
+			changed = true
+		}
+		if token.Len() < systemBudgetMarkerIDMaxBytes {
+			token.WriteByte(value)
+		} else {
+			changed = true
+		}
+	}
+	value := token.String()
+	if !changed {
+		return value
+	}
+	sum := sha256.Sum256([]byte(raw))
+	suffix := hex.EncodeToString(sum[:4])
+	prefixLimit := systemBudgetMarkerIDMaxBytes - len(suffix) - 1
+	if len(value) > prefixLimit {
+		value = value[:prefixLimit]
+	}
+	value = strings.TrimRight(value, "-._:")
+	if value == "" {
+		value = "section"
+	}
+	return value + "-" + suffix
+}
+
+func systemBudgetMarkerIDByte(value byte) bool {
+	return (value >= 'a' && value <= 'z') ||
+		(value >= 'A' && value <= 'Z') ||
+		(value >= '0' && value <= '9') ||
+		value == '-' || value == '_' || value == '.' || value == ':'
+}

--- a/internal/contextview/system_budget_marker_test.go
+++ b/internal/contextview/system_budget_marker_test.go
@@ -1,0 +1,35 @@
+package contextview
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestSystemBudgetMarkerBoundsManyAuditIDs(t *testing.T) {
+	t.Parallel()
+
+	ids := make([]string, 64)
+	for i := range ids {
+		ids[i] = "system.hook.policy." + strings.Repeat("x", 120) + strconv.Itoa(i)
+	}
+	ids[0] += "\n\n<ignore-prior-instructions>"
+
+	first := systemBudgetMarkerFrag(ids, contextfrag.Scope{})
+	second := systemBudgetMarkerFrag(ids, contextfrag.Scope{})
+	text := first.Parts[0].Text
+	if len(text) > systemBudgetMarkerMaxBytes {
+		t.Fatalf("marker bytes = %d, want <= %d: %q", len(text), systemBudgetMarkerMaxBytes, text)
+	}
+	if text != second.Parts[0].Text {
+		t.Fatalf("marker changed across builds: %q != %q", text, second.Parts[0].Text)
+	}
+	if strings.ContainsAny(text, "\r\n<>") {
+		t.Fatalf("marker contains instruction-shaped ID bytes: %q", text)
+	}
+	if !strings.Contains(text, " more)") {
+		t.Fatalf("marker = %q, want bounded omitted-count summary", text)
+	}
+}

--- a/internal/contextview/system_budget_test.go
+++ b/internal/contextview/system_budget_test.go
@@ -1,0 +1,520 @@
+package contextview
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+)
+
+func TestComputeContextBudgetPlan(t *testing.T) {
+	t.Parallel()
+
+	disabled, err := ComputeContextBudgetPlan(0, 200, 100, 50)
+	if err != nil {
+		t.Fatalf("disabled plan error = %v", err)
+	}
+	if disabled != nil {
+		t.Fatalf("disabled plan = %#v, want nil", disabled)
+	}
+
+	plan, err := ComputeContextBudgetPlan(1000, 200, 100, 50)
+	if err != nil {
+		t.Fatalf("ComputeContextBudgetPlan() error = %v", err)
+	}
+	want := &contextfrag.ContextBudgetPlan{
+		Estimator:                    contextfrag.ProviderBudgetEstimator,
+		EstimatorSafetyFactorPercent: contextfrag.ProviderBudgetSafetyFactorPercent,
+		Window:                       1000,
+		OutputReserve:                200,
+		ToolDefsCost:                 100,
+		CurrentRequestCost:           50,
+		SystemBudget:                 650,
+	}
+	if !reflect.DeepEqual(plan, want) {
+		t.Fatalf("plan = %#v, want %#v", plan, want)
+	}
+
+	unsatisfied, err := ComputeContextBudgetPlan(300, 200, 100, 50)
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("reserves error = %v, want ErrBudgetUnsatisfied", err)
+	}
+	if unsatisfied == nil || unsatisfied.SystemBudget != MinimumSystemBudgetTokens {
+		t.Fatalf("unsatisfied plan = %#v, want minimum system budget recorded", unsatisfied)
+	}
+}
+
+func TestSystemBudgetNoPressurePreservesSelection(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		systemBudgetTestFrag("required", contextfrag.RetentionRequired, 10, 10, 0, contextfrag.OverflowKeep),
+		systemBudgetTestFrag("optional", contextfrag.RetentionOptional, 20, 20, 0, ""),
+		historyBudgetTestFrag("history", 30),
+	}
+	plan := &contextfrag.ContextBudgetPlan{Window: 1000, SystemBudget: 100}
+	selector := &FragmentSelector{}
+	result := selector.Select(frags, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{
+		MaxTokens: 1000,
+		Plan:      plan,
+	})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() error = %v", result.FatalError)
+	}
+	if !reflect.DeepEqual(result.Selected, frags) {
+		t.Fatalf("selected = %#v, want byte-equivalent passthrough", result.Selected)
+	}
+	if len(result.Dropped) != 0 {
+		t.Fatalf("dropped = %#v, want none", result.Dropped)
+	}
+	if plan.ActualSystemCost != 31 || plan.HistoryBudget != 69 {
+		t.Fatalf("plan after selection = %#v, want actual=31 history=69", plan)
+	}
+	if hasFragID(result.Selected, systemBudgetMarkerID) {
+		t.Fatal("no-pressure selection must not add a marker")
+	}
+}
+
+func TestSystemBudgetDropsOptionalBeforePreferredInDeterministicOrder(t *testing.T) {
+	t.Parallel()
+
+	required := systemBudgetTestFrag("required", contextfrag.RetentionRequired, 10, 10, 0, contextfrag.OverflowKeep)
+	frags := []contextfrag.ContextFrag{
+		required,
+		systemBudgetTestFrag("optional-high-drop", contextfrag.RetentionOptional, 100, 10, 2, ""),
+		systemBudgetTestFrag("optional-high-render", contextfrag.RetentionOptional, 100, 90, 1, ""),
+		systemBudgetTestFrag("optional-lex-b", contextfrag.RetentionOptional, 100, 80, 1, ""),
+		systemBudgetTestFrag("optional-lex-a", contextfrag.RetentionOptional, 100, 80, 1, ""),
+		systemBudgetTestFrag("preferred", contextfrag.RetentionPreferred, 100, 99, 99, ""),
+	}
+	wantDropped := []string{
+		"optional-high-drop",
+		"optional-high-render",
+		"optional-lex-a",
+		"optional-lex-b",
+		"preferred",
+	}
+	marker := systemBudgetMarkerFrag(wantDropped, contextfrag.Scope{})
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: systemFragCost([]contextfrag.ContextFrag{required, marker}),
+	}
+	selector := &FragmentSelector{}
+	result := selector.Select(frags, selector.ProfileFor(contextfrag.IntentRunConfigPreProvider), BudgetEnvelope{Plan: plan})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() error = %v", result.FatalError)
+	}
+	if got := droppedIDsForReason(result.Summary.DropReasons, systemBudgetDropReason); !reflect.DeepEqual(got, wantDropped) {
+		t.Fatalf("system-budget drop order = %v, want %v", got, wantDropped)
+	}
+	if got := fragIDs(result.Selected); !reflect.DeepEqual(got, []string{"required", systemBudgetMarkerID}) {
+		t.Fatalf("selected IDs = %v, want required + one marker", got)
+	}
+	if plan.ActualSystemCost != plan.SystemBudget {
+		t.Fatalf("actual system cost = %d, want budget-accounted %d", plan.ActualSystemCost, plan.SystemBudget)
+	}
+	if plan.HistoryBudget != 1 {
+		t.Fatalf("history budget = %d, want floor 1", plan.HistoryBudget)
+	}
+}
+
+func TestSystemBudgetDropsGroupedItemsIndividually(t *testing.T) {
+	t.Parallel()
+
+	required := systemBudgetTestFrag("required", contextfrag.RetentionRequired, 10, 10, 0, contextfrag.OverflowKeep)
+	header := systemBudgetGroupFrag("system.skills.header", "system.skills", "skills header", 10)
+	alpha := systemBudgetGroupFrag("system.skill.alpha", "system.skills", "alpha", 100)
+	unicode := systemBudgetGroupFrag("system.skill.技能", "system.skills", "技能", 100)
+	marker := systemBudgetMarkerFrag([]string{alpha.ID}, contextfrag.Scope{})
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: systemFragCost([]contextfrag.ContextFrag{required, header, unicode, marker}),
+	}
+	selector := &FragmentSelector{}
+	result := selector.Select(
+		[]contextfrag.ContextFrag{required, header, alpha, unicode},
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan},
+	)
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() error = %v", result.FatalError)
+	}
+	if got := droppedIDsForReason(result.Summary.DropReasons, systemBudgetDropReason); !reflect.DeepEqual(got, []string{alpha.ID}) {
+		t.Fatalf("system-budget drops = %v, want only %s", got, alpha.ID)
+	}
+	if got := fragIDs(result.Selected); !reflect.DeepEqual(got, []string{
+		required.ID,
+		header.ID,
+		unicode.ID,
+		systemBudgetMarkerID,
+	}) {
+		t.Fatalf("selected IDs = %v, want header and remaining skill item", got)
+	}
+	payload, _ := renderSDKPayload(t, result.Selected, placementFor(result.Selected))
+	want := "required\n\nskills header\n技能\n\n" + marker.Parts[0].Text
+	if payload.System != want {
+		t.Fatalf("rendered system = %q, want %q", payload.System, want)
+	}
+}
+
+func TestSystemBudgetSweepsGroupHeaderAfterLastItemDrops(t *testing.T) {
+	t.Parallel()
+
+	required := systemBudgetTestFrag("required", contextfrag.RetentionRequired, 10, 10, 0, contextfrag.OverflowKeep)
+	header := systemBudgetGroupFrag("system.skills.header", "system.skills", "skills header", 10)
+	alpha := systemBudgetGroupFrag("system.skill.alpha", "system.skills", "alpha", 100)
+	unicode := systemBudgetGroupFrag("system.skill.技能", "system.skills", "技能", 100)
+	wantDropped := []string{alpha.ID, unicode.ID, header.ID}
+	marker := systemBudgetMarkerFrag(wantDropped, contextfrag.Scope{})
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: systemFragCost([]contextfrag.ContextFrag{required, marker}),
+	}
+	selector := &FragmentSelector{}
+	result := selector.Select(
+		[]contextfrag.ContextFrag{required, header, alpha, unicode},
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan},
+	)
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() error = %v", result.FatalError)
+	}
+	if got := droppedIDsForReason(result.Summary.DropReasons, systemBudgetDropReason); !reflect.DeepEqual(got, wantDropped) {
+		t.Fatalf("system-budget drops = %v, want items followed by swept header %v", got, wantDropped)
+	}
+	if got := fragIDs(result.Selected); !reflect.DeepEqual(got, []string{required.ID, systemBudgetMarkerID}) {
+		t.Fatalf("selected IDs = %v, want required + marker", got)
+	}
+	if got := result.Selected[1].Parts[0].Text; got != marker.Parts[0].Text {
+		t.Fatalf("marker = %q, want exactly dropped IDs in %q", got, marker.Parts[0].Text)
+	}
+}
+
+func TestSystemBudgetProtectedOverflowReturnsFatalError(t *testing.T) {
+	t.Parallel()
+
+	required := systemBudgetTestFrag("required", contextfrag.RetentionRequired, 100, 10, 0, "")
+	kept := systemBudgetTestFrag("preferred-keep", contextfrag.RetentionPreferred, 100, 20, 0, contextfrag.OverflowKeep)
+	selector := &FragmentSelector{}
+	plan := &contextfrag.ContextBudgetPlan{Window: 1000, SystemBudget: 50}
+	result := selector.Select(
+		[]contextfrag.ContextFrag{required, kept},
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan},
+	)
+
+	if !errors.Is(result.FatalError, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("Select() error = %v, want ErrProtectedContextOverflow", result.FatalError)
+	}
+	if len(result.Dropped) != 0 || hasFragID(result.Selected, systemBudgetMarkerID) {
+		t.Fatalf("protected overflow selected=%v dropped=%v, want no drop and no marker", fragIDs(result.Selected), fragIDs(result.Dropped))
+	}
+	if plan.ActualSystemCost != 201 {
+		t.Fatalf("actual protected cost = %d, want 201", plan.ActualSystemCost)
+	}
+}
+
+func TestSystemBudgetCostIncludesEveryRenderedFragmentBoundary(t *testing.T) {
+	t.Parallel()
+
+	required := systemBudgetTestFrag("required", contextfrag.RetentionRequired, 0, 10, 0, contextfrag.OverflowKeep)
+	required.Parts[0].Text = strings.Repeat("x", 1023)
+	optional := systemBudgetTestFrag("optional", contextfrag.RetentionOptional, 0, 20, 0, "")
+	optional.Parts[0].Text = "four"
+
+	if got := contextfrag.ResolveFragTokens(required) + contextfrag.ResolveFragTokens(optional); got != 256 {
+		t.Fatalf("per-fragment cost = %d, want floor-rounded 256", got)
+	}
+	if got := systemFragCost([]contextfrag.ContextFrag{required, optional}); got != 322 {
+		t.Fatalf("rendered system cost = %d, want conservative provider cost 322", got)
+	}
+}
+
+func TestSystemBudgetCostMatchesRenderedShortSections(t *testing.T) {
+	t.Parallel()
+
+	first := systemBudgetTestFrag("first", contextfrag.RetentionRequired, 0, 10, 0, contextfrag.OverflowKeep)
+	first.Parts[0].Text = "aaa"
+	second := systemBudgetTestFrag("second", contextfrag.RetentionRequired, 0, 20, 0, contextfrag.OverflowKeep)
+	second.Parts[0].Text = "bbb"
+
+	rendered := "aaa\n\nbbb"
+	const want = 2
+	if got := systemFragCost([]contextfrag.ContextFrag{first, second}); got != want {
+		t.Fatalf("rendered system cost = %d, want %d for %q", got, want, rendered)
+	}
+}
+
+func TestSystemBudgetCostUsesRendererPriorityOrderForGroups(t *testing.T) {
+	t.Parallel()
+
+	grouped := func(id string) contextfrag.ContextFrag {
+		frag := systemBudgetGroupFrag(id, "system.skills", "xxx", 0)
+		frag.Priority = 60
+		return frag
+	}
+	ungrouped := func(id string) contextfrag.ContextFrag {
+		frag := systemBudgetTestFrag(id, contextfrag.RetentionRequired, 0, 50, 0, contextfrag.OverflowKeep)
+		frag.Parts[0].Text = "xxx"
+		return frag
+	}
+	frags := []contextfrag.ContextFrag{
+		grouped("system.skills.header"),
+		ungrouped("unrelated.1"),
+		grouped("system.skill.1"),
+		ungrouped("unrelated.2"),
+		grouped("system.skill.2"),
+		ungrouped("unrelated.3"),
+		grouped("system.skill.3"),
+		grouped("system.skill.4"),
+	}
+
+	renderedFrags := sortSystemFragsByPriority(frags)
+	payload, _ := renderSDKPayload(t, renderedFrags, placementFor(renderedFrags))
+	const want = 11
+	if len(payload.System) != 34 {
+		t.Fatalf("fixture rendered bytes = %d, want 34", len(payload.System))
+	}
+	if got := systemFragCost(frags); got != want {
+		t.Fatalf("system cost = %d, want renderer-ordered cost %d for %q", got, want, payload.System)
+	}
+}
+
+func TestSystemBudgetRecomputesCostAfterEveryDrop(t *testing.T) {
+	t.Parallel()
+
+	required := systemBudgetTestFrag("required", contextfrag.RetentionRequired, 10, 10, 0, contextfrag.OverflowKeep)
+	optionalFirst := systemBudgetTestFrag("optional-first", contextfrag.RetentionOptional, 100, 20, 2, "")
+	optionalSecond := systemBudgetTestFrag("optional-second", contextfrag.RetentionOptional, 100, 20, 1, "")
+	marker := systemBudgetMarkerFrag([]string{"optional-first", "optional-second"}, contextfrag.Scope{})
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: systemFragCost([]contextfrag.ContextFrag{required, marker}),
+	}
+	selector := &FragmentSelector{}
+	result := selector.Select(
+		[]contextfrag.ContextFrag{required, optionalFirst, optionalSecond},
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan},
+	)
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() error = %v", result.FatalError)
+	}
+	if got := droppedIDsForReason(result.Summary.DropReasons, systemBudgetDropReason); !reflect.DeepEqual(got, []string{"optional-first", "optional-second"}) {
+		t.Fatalf("system-budget drop order = %v, want both optional sections", got)
+	}
+	if plan.ActualSystemCost != plan.SystemBudget {
+		t.Fatalf("actual system cost = %d, want exact-fit budget %d", plan.ActualSystemCost, plan.SystemBudget)
+	}
+}
+
+func TestSystemBudgetRequiredMarkerOverflowIsProtected(t *testing.T) {
+	t.Parallel()
+
+	required := systemBudgetTestFrag("required", contextfrag.RetentionRequired, 10, 10, 0, contextfrag.OverflowKeep)
+	optional := systemBudgetTestFrag("optional", contextfrag.RetentionOptional, 100, 20, 0, "")
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: systemFragCost([]contextfrag.ContextFrag{required}),
+	}
+	selector := &FragmentSelector{}
+	result := selector.Select(
+		[]contextfrag.ContextFrag{required, optional},
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan},
+	)
+
+	if !errors.Is(result.FatalError, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("Select() error = %v, want ErrProtectedContextOverflow", result.FatalError)
+	}
+	if got := fragIDs(result.Dropped); !reflect.DeepEqual(got, []string{"optional"}) {
+		t.Fatalf("dropped = %v, want optional section", got)
+	}
+	if got := fragIDs(result.Selected); !reflect.DeepEqual(got, []string{"required", systemBudgetMarkerID}) {
+		t.Fatalf("selected = %v, want required section and required marker", got)
+	}
+	if plan.ActualSystemCost <= plan.SystemBudget {
+		t.Fatalf("actual system cost = %d, want marker overflow above budget %d", plan.ActualSystemCost, plan.SystemBudget)
+	}
+}
+
+func TestSystemBudgetActualCostShrinksHistoryBudgetAndChargesProtectedHistory(t *testing.T) {
+	t.Parallel()
+
+	frags := []contextfrag.ContextFrag{
+		systemBudgetTestFrag("system", contextfrag.RetentionRequired, 150, 10, 0, contextfrag.OverflowKeep),
+		historyBudgetTestFrag("old", 70),
+		historyBudgetTestFrag("new", 40),
+	}
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	withoutPlan := selector.Select(frags, profile, BudgetEnvelope{MaxTokens: 200})
+	if len(withoutPlan.Dropped) != 0 {
+		t.Fatalf("plan-disabled selection dropped %v, want none", fragIDs(withoutPlan.Dropped))
+	}
+
+	noticeCost := contextfrag.ResolveProviderBudgetFragTokens(TrimNoticeFrag(contextfrag.Scope{}))
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: 150 + 40 + noticeCost + 1,
+	}
+	withPlan := selector.Select(frags, profile, BudgetEnvelope{
+		MaxTokens:           200,
+		RecentProtectTokens: 0,
+		Plan:                plan,
+	})
+	if withPlan.FatalError != nil {
+		t.Fatalf("Select() error = %v", withPlan.FatalError)
+	}
+	if got := fragIDs(withPlan.Dropped); !reflect.DeepEqual(got, []string{"old"}) {
+		t.Fatalf("dropped = %v, want old history after protected history and notice consume the allowance", got)
+	}
+	if plan.HistoryBudget != 40+noticeCost+1 {
+		t.Fatalf("history budget = %d, want protected history plus notice and one token %d", plan.HistoryBudget, 40+noticeCost+1)
+	}
+}
+
+func TestHistoryBudgetProtectedOverflowReturnsFatalError(t *testing.T) {
+	t.Parallel()
+
+	protected := historyBudgetTestFrag("latest", 40)
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: 39,
+	}
+	selector := &FragmentSelector{}
+	result := selector.Select(
+		[]contextfrag.ContextFrag{protected},
+		selector.ProfileFor(contextfrag.IntentRunConfigPreProvider),
+		BudgetEnvelope{Plan: plan},
+	)
+
+	if !errors.Is(result.FatalError, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("Select() error = %v, want ErrProtectedContextOverflow", result.FatalError)
+	}
+	if got := fragIDs(result.Selected); !reflect.DeepEqual(got, []string{"latest"}) {
+		t.Fatalf("selected = %v, want protected history retained for audit", got)
+	}
+	if len(result.Dropped) != 0 {
+		t.Fatalf("dropped = %v, want no protected history drop", fragIDs(result.Dropped))
+	}
+}
+
+func TestBuilderReturnsBudgetErrorWithContentLightAudit(t *testing.T) {
+	t.Parallel()
+
+	required := systemBudgetTestFrag("required", contextfrag.RetentionRequired, 10, 10, 0, contextfrag.OverflowKeep)
+	optional := systemBudgetTestFrag("optional", contextfrag.RetentionOptional, 100, 20, 0, "")
+	marker := systemBudgetMarkerFrag([]string{"optional"}, contextfrag.Scope{})
+	plan := &contextfrag.ContextBudgetPlan{
+		Window:       1000,
+		SystemBudget: systemFragCost([]contextfrag.ContextFrag{required, marker}),
+	}
+	builder := NewBuilder(
+		NewMapCollectorRegistry(StaticCollector{CollectorName: sourceFragsCollectorName, Frags: []contextfrag.ContextFrag{required, optional}}),
+		&FragmentSelector{},
+		IdentityPlacer{},
+		nil,
+	)
+	view, err := builder.Build(context.Background(), BuildInput{
+		Intent:  contextfrag.IntentRunConfigPreProvider,
+		Sources: []SourceSpec{{Name: sourceFragsCollectorName}},
+		Budget:  BudgetEnvelope{Plan: plan},
+		Options: BuildOptions{DryRun: true},
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if view.Manifest.BudgetPlan == nil || view.Manifest.BudgetPlan.ActualSystemCost != plan.SystemBudget {
+		t.Fatalf("manifest plan = %#v, want actual system cost %d", view.Manifest.BudgetPlan, plan.SystemBudget)
+	}
+	optionalDecision, ok := decisionByID(view.Manifest.SelectionDecisions, "optional")
+	if !ok || optionalDecision.Decision != contextfrag.DecisionDropped || optionalDecision.Reason != systemBudgetDropReason {
+		t.Fatalf("optional decision = %#v, want dropped/system_budget", optionalDecision)
+	}
+	markerDecision, ok := decisionByID(view.Manifest.SelectionDecisions, systemBudgetMarkerID)
+	if !ok || markerDecision.Decision != contextfrag.DecisionSelected {
+		t.Fatalf("marker decision = %#v, want selected", markerDecision)
+	}
+
+	overflowPlan := &contextfrag.ContextBudgetPlan{Window: 1000, SystemBudget: 1}
+	overflowView, err := builder.Build(context.Background(), BuildInput{
+		Intent:  contextfrag.IntentRunConfigPreProvider,
+		Sources: []SourceSpec{{Name: sourceFragsCollectorName}},
+		Budget:  BudgetEnvelope{Plan: overflowPlan},
+		Options: BuildOptions{DryRun: true},
+	})
+	if !errors.Is(err, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("Build() error = %v, want ErrProtectedContextOverflow", err)
+	}
+	if overflowView == nil || overflowView.Manifest.BudgetPlan == nil {
+		t.Fatalf("overflow view = %#v, want partial audit view", overflowView)
+	}
+}
+
+func systemBudgetTestFrag(
+	id string,
+	tier contextfrag.RetentionTier,
+	tokens, priority int,
+	dropPriority contextfrag.DropPriority,
+	overflow contextfrag.OverflowAction,
+) contextfrag.ContextFrag {
+	return contextfrag.ContextFrag{
+		ID:            id,
+		Kind:          contextfrag.KindSystemPrompt,
+		Role:          sdk.MessageRoleSystem,
+		Slot:          contextfrag.SlotSystem,
+		Priority:      priority,
+		RetentionTier: tier,
+		DropPriority:  dropPriority,
+		CacheClass:    contextfrag.CacheStable,
+		Trust:         contextfrag.TrustSystem,
+		Budget:        contextfrag.BudgetPolicy{Overflow: overflow},
+		TokenEstimate: tokens,
+		Parts:         []contextfrag.Part{{Type: contextfrag.PartText, Text: id}},
+	}
+}
+
+func systemBudgetGroupFrag(id, groupID, text string, tokens int) contextfrag.ContextFrag {
+	frag := systemBudgetTestFrag(id, contextfrag.RetentionOptional, tokens, 65, 0, "")
+	frag.Parts[0].Text = text
+	frag.Render = contextfrag.RenderPolicy{
+		Format:      contextfrag.RenderMarkdown,
+		GroupID:     groupID,
+		GroupJoiner: "\n",
+	}
+	return frag
+}
+
+func historyBudgetTestFrag(id string, tokens int) contextfrag.ContextFrag {
+	msg := sdk.UserMessage(id)
+	return contextfrag.ContextFrag{
+		ID:            id,
+		Kind:          contextfrag.KindConversationEvent,
+		Role:          sdk.MessageRoleUser,
+		Slot:          contextfrag.SlotHistory,
+		TokenEstimate: tokens,
+		Parts:         []contextfrag.Part{{Type: contextfrag.PartSDKMessage, Message: &msg, SDKMessage: &msg}},
+	}
+}
+
+func droppedIDsForReason(records []DropRecord, reason string) []string {
+	var ids []string
+	for _, record := range records {
+		if record.Reason == reason {
+			ids = append(ids, record.FragID)
+		}
+	}
+	return ids
+}

--- a/internal/contextview/types.go
+++ b/internal/contextview/types.go
@@ -17,10 +17,15 @@ type SourceSpec struct {
 	Config any
 }
 
-// BudgetEnvelope carries independently configured fragment policies. The
-// caller remains responsible for the already-materialized history window.
 type BudgetEnvelope struct {
-	ToolExchange *contextfrag.ToolExchangePolicy
+	MaxTokens int
+	// Plan activates unified provider-envelope budgeting. Nil preserves the
+	// legacy unbudgeted provider selection path.
+	Plan *contextfrag.ContextBudgetPlan
+	// RecentProtectTokens bands the newest droppable history within this many
+	// estimated tokens to drop last. Zero disables the window.
+	RecentProtectTokens int
+	ToolExchange        *contextfrag.ToolExchangePolicy
 }
 
 type BuildOptions struct {

--- a/internal/handlers/local_channel.go
+++ b/internal/handlers/local_channel.go
@@ -1184,6 +1184,16 @@ func sendWSError(writer *wsWriter, ref wsTurnRef, message string) {
 	writer.SendJSON(event)
 }
 
+func sendWSAgentError(writer *wsWriter, ref wsTurnRef, streamEvent native.StreamEvent) {
+	event := ref.event("error")
+	event.Code = strings.TrimSpace(streamEvent.Code)
+	event.Message = strings.TrimSpace(streamEvent.Error)
+	if event.Message == "" {
+		event.Message = "stream error"
+	}
+	writer.SendJSON(event)
+}
+
 // wsRunAcceptance is what a client needs beyond the run id to reconcile the turn
 // it rendered optimistically with the authoritative one: which turn the run
 // executes, and where in the session's stream it became observable.
@@ -1348,11 +1358,7 @@ func (h *LocalChannelHandler) forwardWSStreamEvents(ctx, assetCtx context.Contex
 			// its own: it names the run as failed but not what to tell this
 			// caller, which is still waiting on the send it made.
 			if streamEvent.Type == native.EventError {
-				message := strings.TrimSpace(streamEvent.Error)
-				if message == "" {
-					message = "stream error"
-				}
-				sendWSError(writer, ref, message)
+				sendWSAgentError(writer, ref, streamEvent)
 			}
 		}
 	}

--- a/internal/handlers/local_channel_runtime_contract_test.go
+++ b/internal/handlers/local_channel_runtime_contract_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/memohai/memoh/internal/agent/application"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	"github.com/memohai/memoh/internal/apperror"
 )
 
 const (
@@ -200,14 +201,21 @@ func TestLocalChannelRuntimeContractSendsOnlyErrorsToTheInitiatingSocket(t *test
 
 	script := append(
 		richActiveRunWSContractScript(t),
-		rawRuntimeContractEvent(t, native.StreamEvent{Type: native.EventError, Error: "runtime interrupted"}),
+		rawRuntimeContractEvent(t, native.StreamEvent{
+			Type:  native.EventError,
+			Code:  string(apperror.CodeContextBudgetUnsatisfied),
+			Error: "The model context window is too small for this request.",
+		}),
 	)
 	events := collectRuntimeContractWSEvents(t, script, "error")
 	if len(events) != 1 {
 		t.Fatalf("events = %#v, want the error alone", events)
 	}
-	if events[0]["message"] != "runtime interrupted" {
+	if events[0]["message"] != "The model context window is too small for this request." {
 		t.Fatalf("error event = %#v", events[0])
+	}
+	if events[0]["code"] != string(apperror.CodeContextBudgetUnsatisfied) {
+		t.Fatalf("error code = %#v, want %q", events[0]["code"], apperror.CodeContextBudgetUnsatisfied)
 	}
 	// The frame names the run, and only the run: a subscriber that never sent
 	// the submission still has to recognise which turn failed.

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -144,6 +144,30 @@ func TestModel_HasCompatibility(t *testing.T) {
 	assert.False(t, m.HasCompatibility("image-output"))
 }
 
+func TestModelConfigContextBudgetMaxTokens(t *testing.T) {
+	t.Parallel()
+
+	zero := 0
+	positive := 128000
+	for _, tt := range []struct {
+		name   string
+		config models.ModelConfig
+		want   int
+	}{
+		{name: "missing", config: models.ModelConfig{}, want: 0},
+		{name: "zero", config: models.ModelConfig{ContextWindow: &zero}, want: 0},
+		{name: "positive", config: models.ModelConfig{ContextWindow: &positive}, want: positive},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.config.ContextBudgetMaxTokens(); got != tt.want {
+				t.Fatalf("ContextBudgetMaxTokens() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestModelTypes(t *testing.T) {
 	t.Run("ModelType constants", func(t *testing.T) {
 		assert.Equal(t, models.ModelTypeChat, models.ModelType("chat"))

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -178,6 +178,15 @@ func NormalizeAdvertisedEfforts(efforts []string) []string {
 	return reasoning.NormalizeAdvertised(efforts)
 }
 
+// ContextBudgetMaxTokens returns the configured model context window, or zero
+// when budget enforcement is unavailable for this model.
+func (c ModelConfig) ContextBudgetMaxTokens() int {
+	if c.ContextWindow != nil && *c.ContextWindow > 0 {
+		return *c.ContextWindow
+	}
+	return 0
+}
+
 type Model struct {
 	ModelID    string      `json:"model_id"`
 	Name       string      `json:"name"`


### PR DESCRIPTION
## What changes

This is the `main` landing of #1012. The original PR was squash-merged into the temporary `stack/pr1020-session-context-window` branch, so its changes never entered `main`.

It lands the unified `ContextBudgetPlan` across all five native modes:

- typed context budget construction and system/history/provider enforcement
- stable budget audit reasons and lifecycle snapshots
- fail-closed provider preflight with coded stream errors
- typed discuss-context collection with rendered equivalence
- budget propagation through continuations, schedules, heartbeats, and spawned subagents
- Web localization for `context.budget_unsatisfied` and `context.protected_overflow`

## Landing boundary

The squash diff from #1012 was replayed onto the current `main`. It intentionally excludes #1020 and its session-context-window feature.

The only replay conflict was in `internal/apperror/error_test.go`; the resolution retains both current-`main` Skill/Registry catalog tests and #1012's context-budget catalog tests. No business implementation was changed during conflict resolution.

## Verification

Passed before the final conflict-free rebase, whose range-diff is identical; focused Go and frontend tests were rerun on final head `65e313ca1`:

- `go build ./...`
- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/agent/application ./internal/agent/runtime/native ./internal/agent/tool ./internal/contextview`
- `golangci-lint run` over all nine touched Go packages
- `vitest run src/utils/api-error.test.ts src/composables/api/sse-error.test.ts` (48 tests)
- ESLint over the touched TypeScript files
- `node scripts/check-ui-contract.mjs` (passes with three pre-existing warnings)
- `pnpm --filter @memohai/web build`
- `git diff --check`

`pnpm --filter @memohai/web typecheck` remains baseline-noisy with existing repository-wide errors; none are reported in the changed `useChat.types.ts` file.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.