### PR TITLE
fix(bridge): tolerate exec streams closed before stdin lands

### DIFF
--- a/internal/workspace/bridge/client.go
+++ b/internal/workspace/bridge/client.go
@@ -279,7 +279,10 @@ func (c *Client) ExecWithOptions(ctx context.Context, command, workDir string, t
 		return nil, mapError(err)
 	}
 
-	// Send config message first
+	// A command may exit without consuming its stdin; the server then closes
+	// the stream while these sends are still in flight, and gRPC reports the
+	// close as io.EOF. The receive loop below carries the authoritative
+	// result or status, so half-closed sends fall through to it.
 	err = stream.Send(&pb.ExecInput{
 		Command:        command,
 		WorkDir:        workDir,
@@ -288,15 +291,15 @@ func (c *Client) ExecWithOptions(ctx context.Context, command, workDir string, t
 		CleanEnv:       opts.CleanEnv,
 		UnsetEnv:       opts.UnsetEnv,
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
-	if len(stdinData) > 0 {
-		if err := stream.Send(&pb.ExecInput{StdinData: stdinData}); err != nil {
+	if err == nil && len(stdinData) > 0 {
+		if err := stream.Send(&pb.ExecInput{StdinData: stdinData}); err != nil && !errors.Is(err, io.EOF) {
 			return nil, err
 		}
 	}
-	if err := stream.CloseSend(); err != nil {
+	if err := stream.CloseSend(); err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 

--- a/internal/workspace/bridge/client_test.go
+++ b/internal/workspace/bridge/client_test.go
@@ -619,3 +619,31 @@ func assertMetadataValue(t *testing.T, md metadata.MD, key, want string) {
 		t.Fatalf("metadata %s = %v, want %q", key, values, want)
 	}
 }
+
+type execEarlyCloseTestServer struct {
+	pb.UnimplementedContainerServiceServer
+}
+
+func (*execEarlyCloseTestServer) Exec(stream pb.ContainerService_ExecServer) error {
+	if _, err := stream.Recv(); err != nil {
+		return err
+	}
+	if err := stream.Send(&pb.ExecOutput{Stream: pb.ExecOutput_STDOUT, Data: []byte("done")}); err != nil {
+		return err
+	}
+	return stream.Send(&pb.ExecOutput{Stream: pb.ExecOutput_EXIT, ExitCode: 0})
+}
+
+func TestClientExecReturnsResultWhenServerClosesBeforeStdinLands(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, &execEarlyCloseTestServer{})
+	stdin := bytes.Repeat([]byte("x"), 8<<20)
+	result, err := client.ExecWithStdin(context.Background(), "hook", "", 5, stdin)
+	if err != nil {
+		t.Fatalf("ExecWithStdin returned error: %v", err)
+	}
+	if result.Stdout != "done" || result.ExitCode != 0 {
+		t.Fatalf("exec result = %q/%d, want %q/0", result.Stdout, result.ExitCode, "done")
+	}
+}


### PR DESCRIPTION
## Problem

`Client.ExecWithOptions` returns any error from the config `Send`, stdin `Send`, or `CloseSend` as-is. When the executed command exits without consuming its stdin, the bridge server handler returns and closes the stream while those sends are still in flight, and gRPC reports the half-closed stream as a bare `io.EOF`. The exec actually succeeded, but the client reports it as a failure.

Per the gRPC streaming contract, `io.EOF` from `SendMsg` means "stream closed by the peer — call `RecvMsg` for the authoritative status". The receive loop below already carries the real result, so the fix tolerates `io.EOF` on the three sends and falls through to it.

## Impact on main

This is a pre-existing bug, not specific to any feature branch. On main the stdin-bearing path is `internal/hooks/service.go` (`ExecWithStdinEnv`): bot lifecycle hooks pipe their JSON payload via stdin, so a hook command that exits without draining stdin can have a successful run reported as an `EOF` error — for `PreToolUse` that wrongly blocks the tool call. The window is timing-dependent, which is why it only shows up on slow runners (reproduced consistently on 2-core CI, never locally).

## Regression test

The test makes the race deterministic instead of timing-dependent: the server responds and returns after the config message without draining stdin, and the client sends an 8MB stdin payload. HTTP/2 flow control (64KB window, no application reads means no window updates) guarantees the stdin `Send` is still blocked when the server closes the stream, so the send observes `io.EOF` on every run.

## Relation to #1041

Extracted from #1041 (commit e8dfa60ef there), where the new before-model-call hook path made the race show up on every CI run. Landing this first keeps that CI green; #1041 will be rebased afterwards so its bridge diff disappears.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
