### PR TITLE
docs: restore broken Star History chart with a working provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for custom configuration and production setup
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=memohai/Memoh&type=date&legend=top-left)](https://www.star-history.com/#memohai/Memoh&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=memohai/Memoh&type=date&legend=top-left)](https://star-history.dera.page/#memohai/Memoh&type=date&legend=top-left)
 
 ## Contributors
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -113,7 +113,7 @@ submodule，setup 也会为后续 pull 启用递归更新。如果从未安装�
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=memohai/Memoh&type=date&legend=top-left)](https://www.star-history.com/#memohai/Memoh&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=memohai/Memoh&type=date&legend=top-left)](https://star-history.dera.page/#memohai/Memoh&type=date&legend=top-left)
 
 ## 贡献者
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -116,7 +116,7 @@ GitHub が自動生成する「Source code」
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=memohai/Memoh&type=date&legend=top-left)](https://www.star-history.com/#memohai/Memoh&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=memohai/Memoh&type=date&legend=top-left)](https://star-history.dera.page/#memohai/Memoh&type=date&legend=top-left)
 
 ## Contributors
 


### PR DESCRIPTION
The Star History chart in our READMEs no longer renders because the upstream service is limited by the GitHub stargazer API. This change points the chart image and its link to star-history.dera.page, a working alternative that requires no API token and serves the same domain for the chart endpoint and the site.

The update applies to all three README versions (English, Chinese, and Japanese) and keeps the existing query parameters intact.