### PR TITLE
fix(chat): never persist the user header envelope as display text

### DIFF
--- a/internal/agent/application/service_store.go
+++ b/internal/agent/application/service_store.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	turnpkg "github.com/memohai/memoh/internal/agent/turn"
 	attachmentpkg "github.com/memohai/memoh/internal/attachment"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
 )
@@ -342,6 +343,12 @@ func (s *Service) buildPersistInputs(ctx context.Context, req ChatRequest, messa
 				default:
 					displayText = strings.TrimSpace(req.Query)
 				}
+				// req.Query is the headerified <message> envelope by the time a
+				// round is stored, and retry copies that envelope into RawQuery.
+				// An attachment-only message (no caption) has no raw text to fall
+				// back on, so without this the wrapper itself became the user
+				// bubble. Real user text is left untouched.
+				displayText = strings.TrimSpace(turnpkg.UnwrapUserMessageEnvelope(displayText))
 				assets = chatAttachmentsToAssetRefs(req.Attachments)
 				persistMeta = mergeMetadata(meta, buildInteractionMetadata(req))
 			} else {

--- a/internal/agent/application/service_store_test.go
+++ b/internal/agent/application/service_store_test.go
@@ -7,9 +7,12 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	turnpkg "github.com/memohai/memoh/internal/agent/turn"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
+	"github.com/memohai/memoh/internal/settings"
 )
 
 func TestBuildInteractionMetadataIncludesForwardConversation(t *testing.T) {
@@ -202,6 +205,45 @@ func TestStoreMessagesUsesToolTailBatch(t *testing.T) {
 	}
 	if len(persisted) != 4 {
 		t.Fatalf("persisted messages = %d, want 4", len(persisted))
+	}
+}
+
+func TestBuildPersistInputsKeepsAttachmentOnlyUserDisplayTextEmpty(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{
+		settingsService: settings.NewService(slog.New(slog.DiscardHandler), &storeRoundSettingsQueries{}, nil, nil),
+		logger:          slog.New(slog.DiscardHandler),
+	}
+	// resolve() replaces ChatRequest.Query with the headerified envelope before
+	// the round is stored; an image with no caption leaves RawQuery empty.
+	headerified := turnpkg.FormatUserHeader(turnpkg.UserMessageHeaderInput{
+		DisplayName:      "User",
+		Channel:          "web",
+		ConversationType: "private",
+		AttachmentPaths:  []string{"/data/.memoh/media/b2/b2edf40e.png"},
+		Time:             time.Date(2026, 8, 20, 17, 37, 14, 0, time.UTC),
+	}, "")
+
+	inputs, err := service.buildPersistInputs(context.Background(), ChatRequest{
+		BotID:    storeRoundBotID,
+		ThreadID: "33333333-3333-3333-3333-333333333333",
+		Query:    headerified,
+	}, []ModelMessage{
+		{Role: "user", Content: newTextContent(headerified)},
+		{Role: "assistant", Content: newTextContent("nice picture")},
+	}, "", storeRoundOptions{})
+	if err != nil {
+		t.Fatalf("buildPersistInputs() error = %v", err)
+	}
+	if len(inputs) != 2 {
+		t.Fatalf("persist inputs = %d, want 2", len(inputs))
+	}
+	if got := inputs[0].DisplayText; got != "" {
+		t.Fatalf("attachment-only user display text = %q, want empty", got)
+	}
+	if !bytes.Contains(inputs[0].Content, []byte("attachment path=")) {
+		t.Fatalf("model-facing content lost its envelope: %s", inputs[0].Content)
 	}
 }
 

--- a/internal/agent/turn/user_header.go
+++ b/internal/agent/turn/user_header.go
@@ -152,6 +152,55 @@ func FormatUserHeaderFromMeta(meta UserMessageMeta, query string) string {
 	return sb.String()
 }
 
+// UnwrapUserMessageEnvelope is the inverse of FormatUserHeaderFromMeta: it
+// returns the text the user actually wrote, with the model-facing <message>
+// wrapper and its structural children (<attachment>, <in-reply-to>) removed.
+// Input that is not a complete envelope is returned unchanged, so callers can
+// apply it defensively to any query string. An attachment-only message unwraps
+// to the empty string — the envelope is the only content it ever had.
+func UnwrapUserMessageEnvelope(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasPrefix(trimmed, "<message") {
+		return text
+	}
+
+	openEnd := strings.IndexByte(trimmed, '>')
+	if openEnd < 0 {
+		return text
+	}
+	if strings.HasSuffix(strings.TrimSpace(trimmed[:openEnd+1]), "/>") {
+		return ""
+	}
+
+	body := strings.TrimSpace(trimmed[openEnd+1:])
+	if !strings.HasSuffix(body, "</message>") {
+		return text
+	}
+	body = strings.TrimSpace(strings.TrimSuffix(body, "</message>"))
+
+	lines := strings.Split(body, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if isUserEnvelopeStructuralLine(strings.TrimSpace(line)) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+// isUserEnvelopeStructuralLine reports whether a line inside a <message>
+// envelope is machine-generated context rather than user-written text.
+func isUserEnvelopeStructuralLine(line string) bool {
+	if line == "" {
+		return false
+	}
+	if strings.HasPrefix(line, "<attachment ") && strings.HasSuffix(line, "/>") {
+		return true
+	}
+	return strings.HasPrefix(line, "<in-reply-to ") && strings.HasSuffix(line, "</in-reply-to>")
+}
+
 // escapeXMLAttr escapes a string for use inside an XML attribute value.
 func escapeXMLAttr(s string) string {
 	r := strings.NewReplacer(

--- a/internal/agent/turn/user_header_test.go
+++ b/internal/agent/turn/user_header_test.go
@@ -43,3 +43,37 @@ func TestFormatUserHeaderWithoutAttachmentsUsesEmptyList(t *testing.T) {
 		t.Fatalf("expected no attachment tag in header: %s", header)
 	}
 }
+
+func TestUnwrapUserMessageEnvelope(t *testing.T) {
+	t.Parallel()
+
+	input := UserMessageHeaderInput{
+		DisplayName:      "User",
+		Channel:          "web",
+		ConversationType: "private",
+		Target:           "115e7013-dc2a-4437-8e21-b49fbb21dfef",
+		AttachmentPaths:  []string{"/data/.memoh/media/b2/b2edf40e.png"},
+		Time:             time.Date(2026, 8, 20, 17, 37, 14, 0, time.UTC),
+	}
+
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"attachment only", FormatUserHeader(input, ""), ""},
+		{"attachment with caption", FormatUserHeader(input, "look at this"), "look at this"},
+		{"self closing", `<message sender="User" t="now"/>`, ""},
+		{"plain text passthrough", "hello world", "hello world"},
+		{"unterminated envelope passthrough", `<message sender="User">hello`, `<message sender="User">hello`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := UnwrapUserMessageEnvelope(tc.text); got != tc.want {
+				t.Fatalf("UnwrapUserMessageEnvelope(%q) = %q, want %q", tc.text, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/agent/view/uimessage_convert.go
+++ b/internal/agent/view/uimessage_convert.go
@@ -498,7 +498,10 @@ func extractPersistedMessageText(raw messagepkg.Message, message *uiDecodedModel
 			return ""
 		}
 		if text := strings.TrimSpace(raw.DisplayContent); text != "" {
-			return text
+			// Rows written before attachment-only messages stopped persisting
+			// the headerified query keep the <message> wrapper as their display
+			// content; unwrap it so history never renders the model-facing XML.
+			return strings.TrimSpace(turn.UnwrapUserMessageEnvelope(text))
 		}
 	}
 

--- a/internal/agent/view/uimessage_test.go
+++ b/internal/agent/view/uimessage_test.go
@@ -598,6 +598,44 @@ func TestConvertMessagesToUITurnsStripsUserXMLEnvelopeFallback(t *testing.T) {
 	}
 }
 
+// Attachment-only turns persisted before the display-text fix stored the
+// headerified envelope as display content. History must not render it.
+func TestConvertMessagesToUITurnsStripsUserXMLEnvelopeFromDisplayContent(t *testing.T) {
+	now := time.Now().UTC()
+	envelope := `<message sender="User" t="2026-08-20T17:37:14+08:00" channel="web" type="private" target="115e7013-dc2a-4437-8e21-b49fbb21dfef">
+<attachment path="/data/.memoh/media/b2/b2edf40e.png"/>
+
+</message>`
+	turns := convertTestMessagesToUITurns([]messagepkg.Message{{
+		ID:             "user-1",
+		BotID:          "bot-1",
+		SessionID:      "session-1",
+		Role:           "user",
+		DisplayContent: envelope,
+		Content: mustUIMessageJSON(t, turn.ModelMessage{
+			Role:    "user",
+			Content: mustUIRawJSON(t, envelope),
+		}),
+		Assets: []messagepkg.MessageAsset{{
+			ContentHash: "test-image-hash",
+			Mime:        "image/png",
+			StorageKey:  "media/b2/b2edf40e.png",
+			Name:        "image.png",
+		}},
+		CreatedAt: now,
+	}})
+
+	if len(turns) != 1 {
+		t.Fatalf("expected 1 turn, got %d", len(turns))
+	}
+	if turns[0].Text != "" {
+		t.Fatalf("expected display content envelope to be stripped, got %q", turns[0].Text)
+	}
+	if len(turns[0].Attachments) != 1 || turns[0].Attachments[0].Type != "image" {
+		t.Fatalf("expected image attachment to remain, got %#v", turns[0].Attachments)
+	}
+}
+
 // Reasoning that streams before the answer text must keep a smaller block ID
 // than the text block: the frontend sorts blocks by ID, so an eagerly created
 // text block would pin the answer above the thinking that preceded it.


### PR DESCRIPTION
## Problem

Sending an image with no caption rendered the model-facing message envelope as the user's chat bubble:

```
<message sender="User" t="2026-08-20T17:37:14+08:00" channel="web" type="private" target="115e7013-…">
<attachment path="/data/.memoh/media/b2/b2edf40e…png"/>

</message>
```

The image itself displayed correctly above it — only the bubble text was wrong.

## Root cause

`resolve()` replaces `ChatRequest.Query` with the headerified `<message>` envelope (`service.go:668`, `service_stream.go:175`/`:465`), so by the time a round is stored `Query` is a model-facing carrier, not user text.

`buildPersistInputs` picks display text as `UserVisibleText` → `RawQuery` → `Query`. An attachment-only message has no caption, so the first two are empty and the fallback wrote the entire envelope into `display_content`. The history projection returns a non-empty `DisplayContent` verbatim (`uimessage_convert.go:500`) — only the `content` path had envelope stripping — so the UI printed the raw XML.

Two more entry points reach the same state: retry copies the envelope into `RawQuery` (`service_retry_edit.go:78`), and editing a message down to attachments-only leaves both text fields empty.

## Fix

- `turn.UnwrapUserMessageEnvelope` — the inverse of `FormatUserHeaderFromMeta`. Strips the `<message>` wrapper and its machine-generated children (`<attachment>`, `<in-reply-to>`); returns input unchanged when it is not a complete envelope, so it is a no-op on real user text.
- Applied to the resolved display text on persist, after the branch selection rather than only in the fallback, so the retry and edit paths are covered too.
- Applied when reading `DisplayContent` in the history projection, which repairs rows already written this way — no migration needed.

`visibleMessageText` (retry) still passes the envelope through as `Query`: `resolve()` enforces `query or attachments is required` and retry does not re-supply attachments, so unwrapping it there would break retry on attachment-only turns. It stays an internal placeholder and is unwrapped at the persistence boundary.

## Tests

- `turn`: table-driven coverage for `UnwrapUserMessageEnvelope` (attachment-only, caption, self-closing, passthrough cases).
- `application`: `buildPersistInputs` keeps display text empty for an attachment-only turn while the model-facing content keeps its envelope. Verified to reproduce the reported XML when the fix is reverted.
- `view`: a history row whose `display_content` holds the envelope projects to empty text with the image attachment intact.

`go test ./internal/...` and `golangci-lint` on the touched packages pass.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
