### PR TITLE
refactor: separate history persistence codec

### DIFF
--- a/docs/superpowers/specs/2026-08-20-agent-context-message-flow-refactor.md
+++ b/docs/superpowers/specs/2026-08-20-agent-context-message-flow-refactor.md
@@ -312,7 +312,11 @@ Native、ACP 和附件分别验证 SDK 序列、provider payload、ACP session�
 
 ### PR 3：持久化解耦并清理重复入口
 
-兼容 reader 继续读取旧 JSON，新 envelope 使用独立版本号。数据库写入和 runtime input 分开维护，旧 writer 继续可用。
+把历史 JSON 的读写兼容集中到 `internal/agent/context/history`。codec 继续读旧
+envelope、bare content、raw fallback 和 legacy tool 字段，写入时保持当前
+`bot_history_messages.content` 的字段和结构。数据库字段与 runtime input 仍然分开维护。
+
+新 envelope 和版本号等数据库格式升级放到后续迁移，先用 codec 把边界固定下来。
 
 完成旧 writer/reader 的兼容测试后，再删除已经由 adapter 取代的重复转换和附件组装。
 

--- a/internal/agent/application/service_acp.go
+++ b/internal/agent/application/service_acp.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
 	acpfeedback "github.com/memohai/memoh/internal/agent/decision/feedback"
 	"github.com/memohai/memoh/internal/agent/event"
 	acpagent "github.com/memohai/memoh/internal/agent/runtime/acp"
@@ -1039,7 +1040,7 @@ func (s *Service) persistACPLeadingUserMessage(ctx context.Context, req ChatRequ
 	if contentText == "" {
 		contentText = displayText
 	}
-	content, err := json.Marshal(ModelMessage{
+	content, err := historyfrag.MarshalStoredModelMessage(ModelMessage{
 		Role:    "user",
 		Content: newTextContent(contentText),
 	})
@@ -1109,7 +1110,7 @@ func (s *Service) persistACPDecisionProjection(ctx context.Context, req ChatRequ
 		if msg.Role != "assistant" {
 			continue
 		}
-		content, err := json.Marshal(msg)
+		content, err := historyfrag.MarshalStoredModelMessage(msg)
 		if err != nil {
 			s.logger.Warn("persist ACP decision projection: marshal failed",
 				slog.String("tool_call_id", ev.ToolCallID),

--- a/internal/agent/application/service_messages.go
+++ b/internal/agent/application/service_messages.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/memohai/twilight-ai/sdk"
 
+	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
 	"github.com/memohai/memoh/internal/messageconv"
 )
 
@@ -13,7 +14,7 @@ import (
 // redacted to text placeholders first — document bytes never enter
 // bot_history_messages (see redactFilePartsForStorage).
 func sdkMessagesToModelMessages(msgs []sdk.Message) []ModelMessage {
-	return messageconv.SDKMessagesToModelMessages(redactFilePartsForStorage(msgs))
+	return historyfrag.ToStoredModelMessages(msgs)
 }
 
 // redactFilePartsForStorage replaces FileParts with text placeholders before
@@ -23,45 +24,7 @@ func sdkMessagesToModelMessages(msgs []sdk.Message) []ModelMessage {
 // file itself stays in the workspace: follow-up turns re-read it via the read
 // tool, which re-injects it for whatever model is current.
 func redactFilePartsForStorage(msgs []sdk.Message) []sdk.Message {
-	out := msgs
-	copied := false
-	for i, msg := range msgs {
-		hasFile := false
-		for _, part := range msg.Content {
-			if _, ok := part.(sdk.FilePart); ok {
-				hasFile = true
-				break
-			}
-		}
-		if !hasFile {
-			continue
-		}
-		if !copied {
-			out = append([]sdk.Message(nil), msgs...)
-			copied = true
-		}
-		kept := make([]sdk.MessagePart, 0, len(msg.Content))
-		for _, part := range msg.Content {
-			fp, ok := part.(sdk.FilePart)
-			if !ok {
-				kept = append(kept, part)
-				continue
-			}
-			name := strings.TrimSpace(fp.Filename)
-			if name == "" {
-				name = "attachment"
-			}
-			mime := strings.TrimSpace(fp.MediaType)
-			if mime == "" {
-				mime = "application/pdf"
-			}
-			kept = append(kept, sdk.TextPart{
-				Text: "[attachment " + name + " (" + mime + ") was shown to the model this turn; its bytes are not persisted — use the read tool to view it again]",
-			})
-		}
-		out[i].Content = kept
-	}
-	return out
+	return historyfrag.RedactFileParts(msgs)
 }
 
 // modelMessageToSDKMessage converts a persistence format message to SDK message

--- a/internal/agent/application/service_store.go
+++ b/internal/agent/application/service_store.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
 	attachmentpkg "github.com/memohai/memoh/internal/attachment"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
 )
@@ -286,7 +287,7 @@ func (s *Service) buildPersistInputs(ctx context.Context, req ChatRequest, messa
 			}
 		}
 
-		content, err := json.Marshal(msg)
+		content, err := historyfrag.MarshalStoredModelMessage(msg)
 		if err != nil {
 			return nil, fmt.Errorf("marshal message %d: %w", i, err)
 		}

--- a/internal/agent/application/service_user_persist.go
+++ b/internal/agent/application/service_user_persist.go
@@ -2,10 +2,10 @@ package application
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"strings"
 
+	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
 )
 
@@ -53,7 +53,7 @@ func (s *Service) persistUserTurn(ctx context.Context, req ChatRequest) (message
 		Content: newTextContent(persistedUserTurnText(req)),
 	}
 	modelMessage = normalizeUserMessageContent(modelMessage)
-	content, err := json.Marshal(modelMessage)
+	content, err := historyfrag.MarshalStoredModelMessage(modelMessage)
 	if err != nil {
 		return messagepkg.Message{}, err
 	}

--- a/internal/agent/application/subagent_step_commit.go
+++ b/internal/agent/application/subagent_step_commit.go
@@ -13,6 +13,7 @@ import (
 	sdk "github.com/memohai/twilight-ai/sdk"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	tools "github.com/memohai/memoh/internal/agent/tool"
@@ -123,7 +124,7 @@ func (c *subagentStepCommitter) persist(ctx context.Context, stepIndex int, step
 		if msg.Role == sdk.MessageRoleUser {
 			continue
 		}
-		content, err := json.Marshal(msg)
+		content, err := historyfrag.MarshalStoredSDKMessage(msg)
 		if err != nil {
 			continue
 		}

--- a/internal/agent/context/history/db_message.go
+++ b/internal/agent/context/history/db_message.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
-	"github.com/memohai/memoh/internal/agent/turn"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
 )
 
@@ -34,7 +33,7 @@ func FromDBMessageWithLogger(log *slog.Logger, msg messagepkg.Message, fallback 
 	}
 	rowID := ref.ID
 
-	modelMessage := modelMessageFromDBMessage(log, msg)
+	modelMessage := DecodeStoredModelMessage(log, msg.ID, msg.Role, msg.Content)
 	inputTokens, outputTokens := parseUsage(msg.Usage)
 	ref.HashAlgo = contextfrag.HashAlgoSHA256
 	ref.HashScope = contextfrag.HashScopeSourcePayload
@@ -146,51 +145,6 @@ type dbMessageSourceHashPayload struct {
 	Assets                  []MediaRef     `json:"assets,omitempty"`
 }
 
-func modelMessageFromDBMessage(log *slog.Logger, msg messagepkg.Message) turn.ModelMessage {
-	var modelMessage turn.ModelMessage
-	if err := json.Unmarshal(msg.Content, &modelMessage); err != nil {
-		if log != nil {
-			log.Warn("historyfrag: content unmarshal failed, treating as raw text",
-				slog.String("message_id", msg.ID),
-				slog.String("role", msg.Role),
-				slog.Any("error", err),
-			)
-		}
-		modelMessage = turn.ModelMessage{
-			Role:    strings.TrimSpace(msg.Role),
-			Content: cloneRawMessage(msg.Content),
-		}
-		return modelMessage
-	}
-
-	// A bare content-part object (e.g. {"type":"text","text":"hello"}) has no
-	// role/content/tool_calls keys, so it unmarshals successfully into an empty
-	// ModelMessage instead of erroring — unknown JSON fields are ignored. Detect
-	// that shape before the row's Role column gets stamped below, and normalize
-	// it into a one-element parts array so TextContent/ContentParts still see it.
-	if modelMessage.Role == "" && !modelMessage.HasContent() {
-		if wrapped, ok := bareContentPartArray(msg.Content); ok {
-			modelMessage.Content = wrapped
-		}
-	}
-
-	modelMessage.Role = strings.TrimSpace(msg.Role)
-	return modelMessage
-}
-
-// bareContentPartArray wraps a raw JSON object into a single-element parts
-// array, e.g. {"type":"text","text":"hello"} -> [{"type":"text","text":"hello"}].
-// Only a non-empty object is wrapped: `{}` carries no content to recover, and
-// unmarshal already guarantees non-object payloads (arrays/strings/scalars)
-// took the error branch above.
-func bareContentPartArray(raw json.RawMessage) (json.RawMessage, bool) {
-	trimmed := strings.TrimSpace(string(raw))
-	if trimmed == "" || trimmed[0] != '{' || trimmed == "{}" {
-		return nil, false
-	}
-	return json.RawMessage("[" + trimmed + "]"), true
-}
-
 func parseUsage(raw json.RawMessage) (*int, *int) {
 	if len(raw) == 0 {
 		return nil, nil
@@ -259,11 +213,4 @@ func cloneMetadata(metadata map[string]any) map[string]any {
 		return nil
 	}
 	return out
-}
-
-func cloneRawMessage(raw json.RawMessage) json.RawMessage {
-	if len(raw) == 0 {
-		return nil
-	}
-	return append(json.RawMessage(nil), raw...)
 }

--- a/internal/agent/context/history/persistence.go
+++ b/internal/agent/context/history/persistence.go
@@ -1,0 +1,167 @@
+package historyfrag
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	"github.com/memohai/memoh/internal/agent/turn"
+	"github.com/memohai/memoh/internal/messageconv"
+)
+
+// MarshalStoredModelMessage encodes the existing turn message payload used by
+// bot_history_messages. Keeping this codec in the history boundary makes the
+// database format explicit without changing that format.
+func MarshalStoredModelMessage(message turn.ModelMessage) (json.RawMessage, error) {
+	return json.Marshal(storedModelMessageV0FromTurn(message))
+}
+
+// MarshalStoredSDKMessage converts one Agent message to the existing history
+// payload after removing file bytes. Usage remains in the message table's
+// separate usage column, as it did before this codec was introduced.
+func MarshalStoredSDKMessage(message sdk.Message) (json.RawMessage, error) {
+	if _, err := json.Marshal(message); err != nil {
+		return nil, err
+	}
+	converted := ToStoredModelMessages([]sdk.Message{message})
+	if len(converted) != 1 {
+		return nil, errors.New("message conversion produced no stored message")
+	}
+	return MarshalStoredModelMessage(converted[0])
+}
+
+// DecodeStoredModelMessage reads both the current turn envelope and the
+// legacy content shapes found in existing history rows.
+func DecodeStoredModelMessage(log *slog.Logger, messageID, role string, raw json.RawMessage) turn.ModelMessage {
+	var stored storedModelMessageV0
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		if log != nil {
+			log.Warn("historyfrag: content unmarshal failed, treating as raw text",
+				slog.String("message_id", messageID),
+				slog.String("role", role),
+				slog.Any("error", err),
+			)
+		}
+		return turn.ModelMessage{
+			Role:    strings.TrimSpace(role),
+			Content: cloneRawMessage(raw),
+		}
+	}
+
+	// Older rows may contain one content part directly, without the role and
+	// content envelope. Unmarshal accepts those unknown fields and produces an
+	// empty ModelMessage, so recover the part before applying the row role.
+	message := stored.turnMessage()
+	if message.Role == "" && !message.HasContent() {
+		if wrapped, ok := bareContentPartArray(raw); ok {
+			message.Content = wrapped
+		}
+	}
+
+	message.Role = strings.TrimSpace(role)
+	return message
+}
+
+// storedModelMessageV0 is the JSON shape already present in
+// bot_history_messages.content. It deliberately remains private: callers use
+// turn.ModelMessage while this package owns the durable representation.
+type storedModelMessageV0 struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content,omitempty"`
+	ToolCalls  []turn.ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+	Name       string          `json:"name,omitempty"`
+}
+
+func storedModelMessageV0FromTurn(message turn.ModelMessage) storedModelMessageV0 {
+	return storedModelMessageV0{
+		Role:       message.Role,
+		Content:    message.Content,
+		ToolCalls:  message.ToolCalls,
+		ToolCallID: message.ToolCallID,
+		Name:       message.Name,
+	}
+}
+
+func (message storedModelMessageV0) turnMessage() turn.ModelMessage {
+	return turn.ModelMessage{
+		Role:       message.Role,
+		Content:    message.Content,
+		ToolCalls:  message.ToolCalls,
+		ToolCallID: message.ToolCallID,
+		Name:       message.Name,
+	}
+}
+
+// bareContentPartArray wraps a raw JSON object into a single-element parts
+// array, e.g. {"type":"text","text":"hello"} -> [{"type":"text","text":"hello"}].
+// Only a non-empty object is wrapped because `{}` carries no content to recover.
+func bareContentPartArray(raw json.RawMessage) (json.RawMessage, bool) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed[0] != '{' || trimmed == "{}" {
+		return nil, false
+	}
+	return json.RawMessage("[" + trimmed + "]"), true
+}
+
+func cloneRawMessage(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+// ToStoredModelMessages converts Agent messages into the existing history
+// message shape. File bytes are replaced with a readable placeholder before
+// conversion; the media store remains the source of the attachment itself.
+func ToStoredModelMessages(messages []sdk.Message) []turn.ModelMessage {
+	return messageconv.SDKMessagesToModelMessages(RedactFileParts(messages))
+}
+
+// RedactFileParts returns a copy only when a message contains a FilePart.
+// History rows must never contain document bytes, while unrelated message
+// parts keep their original order and values.
+func RedactFileParts(messages []sdk.Message) []sdk.Message {
+	out := messages
+	copied := false
+	for i, message := range messages {
+		hasFile := false
+		for _, part := range message.Content {
+			if _, ok := part.(sdk.FilePart); ok {
+				hasFile = true
+				break
+			}
+		}
+		if !hasFile {
+			continue
+		}
+		if !copied {
+			out = append([]sdk.Message(nil), messages...)
+			copied = true
+		}
+		kept := make([]sdk.MessagePart, 0, len(message.Content))
+		for _, part := range message.Content {
+			file, ok := part.(sdk.FilePart)
+			if !ok {
+				kept = append(kept, part)
+				continue
+			}
+			name := strings.TrimSpace(file.Filename)
+			if name == "" {
+				name = "attachment"
+			}
+			mime := strings.TrimSpace(file.MediaType)
+			if mime == "" {
+				mime = "application/pdf"
+			}
+			kept = append(kept, sdk.TextPart{
+				Text: "[attachment " + name + " (" + mime + ") was shown to the model this turn; its bytes are not persisted — use the read tool to view it again]",
+			})
+		}
+		out[i].Content = kept
+	}
+	return out
+}

--- a/internal/agent/context/history/persistence_test.go
+++ b/internal/agent/context/history/persistence_test.go
@@ -1,0 +1,164 @@
+package historyfrag
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	"github.com/memohai/memoh/internal/agent/turn"
+)
+
+func TestStoredModelMessageCodecPreservesEnvelopeAndStructuredContent(t *testing.T) {
+	t.Parallel()
+
+	want := turn.ModelMessage{
+		Role:       "assistant",
+		Content:    json.RawMessage(`[{"type":"reasoning","text":"thinking"},{"type":"text","text":"done"}]`),
+		Usage:      json.RawMessage(`{"inputTokens":9}`),
+		ToolCallID: "legacy-call",
+		Name:       "lookup",
+		ToolCalls: []turn.ToolCall{{
+			ID:   "call-1",
+			Type: "function",
+			Function: turn.ToolCallFunction{
+				Name:      "lookup",
+				Arguments: `{"q":"memoh"}`,
+			},
+		}},
+	}
+
+	raw, err := MarshalStoredModelMessage(want)
+	if err != nil {
+		t.Fatalf("MarshalStoredModelMessage: %v", err)
+	}
+	legacyRaw := mustPersistenceJSON(t, want)
+	if string(raw) != string(legacyRaw) {
+		t.Fatalf("stored JSON changed:\ngot  %s\nwant %s", raw, legacyRaw)
+	}
+	got := DecodeStoredModelMessage(nil, "row-1", "assistant", raw)
+	want.Usage = nil // Usage is stored in its own database column.
+	if string(mustPersistenceJSON(t, got)) != string(mustPersistenceJSON(t, want)) {
+		t.Fatalf("decoded message = %s, want %s", mustPersistenceJSON(t, got), mustPersistenceJSON(t, want))
+	}
+}
+
+func TestDecodeStoredModelMessageKeepsInvalidRawContent(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`not-json`)
+	got := DecodeStoredModelMessage(nil, "row-raw", " assistant ", raw)
+	if got.Role != "assistant" {
+		t.Fatalf("role = %q, want assistant", got.Role)
+	}
+	if string(got.Content) != string(raw) {
+		t.Fatalf("content = %s, want raw fallback %s", got.Content, raw)
+	}
+	got.Content[0] = 'N'
+	if string(raw) != "not-json" {
+		t.Fatalf("raw input was mutated: %s", raw)
+	}
+}
+
+func TestDecodeStoredModelMessageSupportsLegacyShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		raw        string
+		role       string
+		wantText   string
+		wantCallID string
+	}{
+		{name: "bare content part", raw: `{"type":"text","text":"hello"}`, role: "user", wantText: "hello"},
+		{name: "legacy tool envelope", raw: `{"role":"tool","tool_call_id":"call-1","content":"ok"}`, role: "tool", wantText: "ok", wantCallID: "call-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DecodeStoredModelMessage(nil, "row-legacy", tt.role, json.RawMessage(tt.raw))
+			if got.TextContent() != tt.wantText {
+				t.Fatalf("TextContent() = %q, want %q", got.TextContent(), tt.wantText)
+			}
+			if got.ToolCallID != tt.wantCallID {
+				t.Fatalf("ToolCallID = %q, want %q", got.ToolCallID, tt.wantCallID)
+			}
+		})
+	}
+}
+
+func TestRedactFilePartsPreservesOrderAndDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	input := []sdk.Message{sdk.UserMessage("look", sdk.FilePart{
+		Data:      "secret-file-bytes",
+		Filename:  "report.pdf",
+		MediaType: "application/pdf",
+	}, sdk.ImagePart{Image: "data:image/png;base64,abc", MediaType: "image/png"})}
+
+	redacted := RedactFileParts(input)
+	if len(redacted) != 1 || len(redacted[0].Content) != 3 {
+		t.Fatalf("redacted content = %#v, want three ordered parts", redacted)
+	}
+	if _, ok := redacted[0].Content[0].(sdk.TextPart); !ok {
+		t.Fatalf("part 0 = %T, want TextPart", redacted[0].Content[0])
+	}
+	placeholder, ok := redacted[0].Content[1].(sdk.TextPart)
+	if !ok || placeholder.Text == "" || strings.Contains(placeholder.Text, "secret-file-bytes") {
+		t.Fatalf("file placeholder = %#v, want readable text without bytes", redacted[0].Content[1])
+	}
+	if _, ok := redacted[0].Content[2].(sdk.ImagePart); !ok {
+		t.Fatalf("part 2 = %T, want ImagePart", redacted[0].Content[2])
+	}
+	if file, ok := input[0].Content[1].(sdk.FilePart); !ok || file.Data != "secret-file-bytes" {
+		t.Fatalf("input file part was mutated: %#v", input[0].Content[1])
+	}
+}
+
+func TestToStoredModelMessagesNeverIncludesFileBytes(t *testing.T) {
+	t.Parallel()
+
+	stored := ToStoredModelMessages([]sdk.Message{sdk.UserMessage("attach", sdk.FilePart{
+		Data:      "secret-file-bytes",
+		Filename:  "notes.txt",
+		MediaType: "text/plain",
+	})})
+	if len(stored) != 1 {
+		t.Fatalf("stored messages = %#v, want one message", stored)
+	}
+	if text := stored[0].TextContent(); strings.Contains(text, "secret-file-bytes") {
+		t.Fatalf("stored content contains file bytes: %q", text)
+	}
+	if text := stored[0].TextContent(); !strings.Contains(text, "notes.txt") {
+		t.Fatalf("stored content lost file placeholder: %q", text)
+	}
+}
+
+func TestMarshalStoredSDKMessageRedactsFileBytes(t *testing.T) {
+	t.Parallel()
+
+	message := sdk.UserMessage("inspect", sdk.FilePart{
+		Data:      "secret-bytes",
+		Filename:  "report.pdf",
+		MediaType: "application/pdf",
+	})
+	raw, err := MarshalStoredSDKMessage(message)
+	if err != nil {
+		t.Fatalf("MarshalStoredSDKMessage: %v", err)
+	}
+	if strings.Contains(string(raw), "secret-bytes") {
+		t.Fatalf("stored payload contains file bytes: %s", raw)
+	}
+	if !strings.Contains(string(raw), "report.pdf") {
+		t.Fatalf("stored payload lost attachment placeholder: %s", raw)
+	}
+}
+
+func mustPersistenceJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal %T: %v", value, err)
+	}
+	return raw
+}

--- a/internal/agent/tool/subagent.go
+++ b/internal/agent/tool/subagent.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/memohai/memoh/internal/agent/background"
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	historyfrag "github.com/memohai/memoh/internal/agent/context/history"
 	messagepkg "github.com/memohai/memoh/internal/chat/message"
 	sessionpkg "github.com/memohai/memoh/internal/chat/thread"
 	dbstore "github.com/memohai/memoh/internal/db/store"
@@ -1610,7 +1611,7 @@ func (p *SpawnProvider) persistMessages(
 		if msg.Role == sdk.MessageRoleUser {
 			continue
 		}
-		content, err := json.Marshal(msg)
+		content, err := historyfrag.MarshalStoredSDKMessage(msg)
 		if err != nil {
 			continue
 		}
@@ -1655,10 +1656,7 @@ func (p *SpawnProvider) persistUserMessage(ctx context.Context, req *agentReques
 	if p.messageService == nil || strings.TrimSpace(req.agentSessionID) == "" {
 		return "", false
 	}
-	userContent, _ := json.Marshal(map[string]any{
-		"role":    "user",
-		"content": req.message,
-	})
+	userContent, _ := historyfrag.MarshalStoredSDKMessage(sdk.UserMessage(req.message))
 	input := messagepkg.PersistInput{
 		BotID:     req.parentSession.BotID,
 		SessionID: req.agentSessionID,


### PR DESCRIPTION
## Summary
Centralize history JSON compatibility in internal/agent/context/history. Existing database content is preserved: normal envelopes, bare content parts, raw fallback, legacy tool fields, and separate usage data remain readable. Application, ACP, and subagent persistence writers now use the history codec while Channel keeps its agent/turn boundary.

## Verification
- go test ./internal/agent/context/history ./internal/agent/application ./internal/agent/tool ./internal/chat/timeline -count=1
- go test ./internal/arch -count=1
- go test ./internal/agent/... -count=1 (one existing flaky native retry-budget test remains nondeterministic)

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.