### PR TITLE
feat(web): instant stream catch-up on tab return (+ markstream-vue 2.0.0)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,7 +50,7 @@
     "echarts": "^6.1.0",
     "katex": "^0.18.1",
     "lucide-vue-next": "^0.562.0",
-    "markstream-vue": "1.0.7",
+    "markstream-vue": "2.0.0",
     "mermaid": "^11.16.0",
     "misans-vf": "1.0.0",
     "monaco-editor": "^0.52.2",

--- a/apps/web/src/components/markdown/md-link.vue
+++ b/apps/web/src/components/markdown/md-link.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, useAttrs } from 'vue'
-import { LinkNode } from 'markstream-vue'
+import { LinkNode, type LinkNodeProps } from 'markstream-vue'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { tryParseLocalhostHref } from '@/utils/localhost-link'
 
@@ -13,14 +13,8 @@ import { tryParseLocalhostHref } from '@/utils/localhost-link'
 defineOptions({ inheritAttrs: false })
 
 const props = defineProps<{
-  node: {
-    type: 'link'
-    href: string
-    title: string | null
-    text: string
-    children?: unknown[]
-    raw: string
-  }
+  node: LinkNodeProps['node']
+  indexKey: LinkNodeProps['indexKey']
 }>()
 
 const attrs = useAttrs()
@@ -46,6 +40,7 @@ function onClickCapture(event: MouseEvent) {
 <template>
   <span @click.capture="onClickCapture"><LinkNode
     :node="node"
+    :index-key="indexKey"
     v-bind="attrs"
   /></span>
 </template>

--- a/apps/web/src/components/themed-mermaid-block/index.vue
+++ b/apps/web/src/components/themed-mermaid-block/index.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
 import { computed, inject, type Ref } from 'vue'
-import { MermaidBlockNode, type CodeBlockNode } from 'markstream-vue'
+import { MermaidBlockNode, type CodeBlockNodeProps } from 'markstream-vue'
 import { useSettingsStore } from '@/store/settings'
 import { applyMermaidThemeToSource, resolveMermaidIsDark } from '@/store/settings/mermaid'
+
+// 2.0's own `CodeBlockNode` export is the block component (value), which shadows
+// the parser's node type of the same name; the node type rides on the props.
+type CodeBlockNode = CodeBlockNodeProps['node']
 
 defineOptions({ inheritAttrs: false })
 

--- a/apps/web/src/pages/about/index.vue
+++ b/apps/web/src/pages/about/index.vue
@@ -251,6 +251,8 @@ import {
 import MarkdownRender from 'markstream-vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
+import ChatCodeBlock from '@/pages/home/components/chat-code-block.vue'
+import { registerSharedMarkdownComponents } from '@/components/markdown'
 import {
   DesktopShellKey,
   DesktopUpdatesKey,
@@ -263,6 +265,14 @@ import { useSettingsStore } from '@/store/settings'
 import { useUpdateStore } from '@/store/update'
 
 const GITHUB_REPO = 'memohai/memoh'
+
+// Release notes are arbitrary upstream markdown and can contain fenced code
+// blocks. markstream 2.0's built-in code block needs the optional stream-diffs
+// peer (not installed) and otherwise falls back to a plain <pre>, so give this
+// scope the same design-system code block chat and file preview already use.
+// Idempotent-guarded by the registry; the appearance mermaid scopes need no
+// registration — their content is mermaid-only, served by the global override.
+registerSharedMarkdownComponents('release-notes', { code_block: ChatCodeBlock, shell: ChatCodeBlock })
 
 interface ResourceLink {
   icon: Component

--- a/apps/web/src/pages/about/index.vue
+++ b/apps/web/src/pages/about/index.vue
@@ -181,7 +181,8 @@
             :typewriter="false"
             :fade="false"
             :show-tooltips="false"
-            :theme="codeBlockTheme"
+            :code-block-dark-theme="codeBlockTheme.dark"
+            :code-block-light-theme="codeBlockTheme.light"
             custom-id="release-notes"
           />
         </div>

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -235,12 +235,13 @@
                 <MarkdownRender
                   :content="node.block.content"
                   :is-dark="isDark"
-                  :smooth-streaming="isAssistantBlockStreaming(node.index)"
-                  :typewriter="isAssistantBlockStreaming(node.index)"
-                  :fade="isAssistantBlockStreaming(node.index)"
+                  :smooth-streaming="isBlockStreaming(node.index)"
+                  :typewriter="isBlockStreaming(node.index)"
+                  :fade="isBlockStreaming(node.index)"
                   :show-tooltips="false"
                   :mermaid-props="{ showTooltips: false }"
-                  :theme="codeBlockTheme"
+                  :code-block-dark-theme="codeBlockTheme.dark"
+                  :code-block-light-theme="codeBlockTheme.light"
                   custom-id="chat-msg"
                 />
               </div>
@@ -325,6 +326,30 @@ registerSharedMarkdownComponents('chat-msg', { code_block: ChatCodeBlock, shell:
 // markstream default (which only follows the host renderer's isDark flag). One
 // registration covers chat + file preview + any future MarkdownRender call site.
 setCustomComponents({ mermaid: ThemedMermaidBlock })
+
+// One-shot smooth-streaming catch-up gate. markstream's controller reveals
+// queued chars only from a rAF loop, and rAF freezes while the tab is hidden —
+// incoming tokens keep accumulating, so a long background stretch becomes a
+// backlog the renderer then "types out" for tens of seconds after returning
+// (re-parsing and reflowing every frame). The library exposes no visibility
+// hook, so on return-to-visible we flip the streaming props off for exactly one
+// tick: the component's own content watch treats smooth=off as a static render
+// and resets straight to the full received text (respecting its
+// unclosed-code-fence hold-back), then we flip back on — a no-op once caught
+// up, so later tokens keep typewriter-streaming. While hidden nothing changes:
+// rendering stays frozen at zero cost. This rides the library's internal
+// reset-on-smooth-off branch — if that behavior changes, revisit this gate.
+// One module-level listener serves every message block.
+const streamRevealPulse = ref(false)
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState !== 'visible') return
+    streamRevealPulse.value = true
+    nextTick(() => {
+      streamRevealPulse.value = false
+    })
+  })
+}
 </script>
 
 <script setup lang="ts">
@@ -706,6 +731,13 @@ function hasLaterAssistantMessage(index: number): boolean {
 
 function isAssistantBlockStreaming(index: number): boolean {
   return props.message.role === 'assistant' && props.message.streaming && !hasLaterAssistantMessage(index)
+}
+
+// Read the module-scope pulse inside a function (called during render) so the
+// ref access is tracked; a bare template binding would not reliably unwrap a
+// module-scope ref.
+function isBlockStreaming(index: number): boolean {
+  return isAssistantBlockStreaming(index) && !streamRevealPulse.value
 }
 
 const hasVisibleAssistantBlocks = computed(() =>

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -232,12 +232,18 @@
                 :lang="contentLang(node.block.content)"
                 class="prose prose-sm dark:prose-invert max-w-none [&_p]:my-0! [&_p+p]:mt-2! [&_ul]:my-1.5! [&_ol]:my-1.5! [&_li]:my-0.5! [&_:is(h1,h2,h3)]:mt-5! [&_:is(h1,h2,h3)]:mb-2! [&_:is(h4,h5,h6)]:mt-3! [&_:is(h4,h5,h6)]:mb-1! [&>*:first-child]:mt-0! [&>*:last-child]:mb-0!"
               >
+                <!-- mode="chat" selects the upstream chat profile (32/48/6ms
+                     batches, no live-node virtualization cap) instead of the
+                     default docs profile — it is tuned for message streams,
+                     not long documents. -->
                 <MarkdownRender
                   :content="node.block.content"
                   :is-dark="isDark"
+                  mode="chat"
                   :smooth-streaming="isBlockStreaming(node.index)"
                   :typewriter="isBlockStreaming(node.index)"
                   :fade="isBlockStreaming(node.index)"
+                  :batch-rendering="blockBatchRendering(node.index)"
                   :show-tooltips="false"
                   :mermaid-props="{ showTooltips: false }"
                   :code-block-dark-theme="codeBlockTheme.dark"
@@ -738,6 +744,15 @@ function isAssistantBlockStreaming(index: number): boolean {
 // module-scope ref.
 function isBlockStreaming(index: number): boolean {
   return isAssistantBlockStreaming(index) && !streamRevealPulse.value
+}
+
+// Second layer of the same catch-up problem: the renderer mounts nodes in
+// delayed batches (docs profile defaults: 40, then 80 per 16ms tick), so even
+// with the text fully revealed the DOM fills in chunk by chunk. During the
+// pulse, force batch rendering off for the streaming block so its visible
+// window mounts in one pass; undefined elsewhere keeps the profile default.
+function blockBatchRendering(index: number): boolean | undefined {
+  return isAssistantBlockStreaming(index) && streamRevealPulse.value ? false : undefined
 }
 
 const hasVisibleAssistantBlocks = computed(() =>

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -255,6 +255,12 @@ function wsRunId(index = 0): string {
 beforeEach(() => {
     pinia = createPinia()
     setActivePinia(pinia)
+    // The runtime client coalesces delta projections to one per animation
+    // frame; run frames synchronously so existing per-event assertions hold.
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    })
     h.streamHandler = null
     h.sessionsActivityHandler = null
     h.lastRunId = ''

--- a/apps/web/src/store/chat/runtime-client.test.ts
+++ b/apps/web/src/store/chat/runtime-client.test.ts
@@ -39,6 +39,8 @@ function createHarness() {
   const client = createRuntimeClient({
     send: message => sent.push(message),
     onProjection,
+    // Keep delivery synchronous so the existing per-event assertions hold.
+    scheduleFrame: callback => callback(),
   })
   return { client, sent, onProjection }
 }
@@ -162,5 +164,44 @@ describe('runtime client', () => {
 
     expect(sent.at(-1)).toEqual({ type: 'runtime_unsubscribe', session_id: 'session-1' })
     expect(onProjection).not.toHaveBeenCalled()
+  })
+
+  it('coalesces a burst of deltas into one notification per frame', () => {
+    const sent: WSClientMessage[] = []
+    const onProjection = vi.fn()
+    const frames: Array<() => void> = []
+    const client = createRuntimeClient({
+      send: message => sent.push(message),
+      onProjection,
+      scheduleFrame: (callback) => {
+        frames.push(callback)
+      },
+    })
+    client.subscribe('session-1')
+    client.onConnected()
+    client.handleEvent(snapshot())
+    expect(onProjection).toHaveBeenCalledTimes(1)
+
+    // snapshot() lands at seq 3; the burst chains off it.
+    client.handleEvent(delta(4))
+    client.handleEvent(delta(5))
+    client.handleEvent(delta(6))
+    // Nothing is delivered until the frame runs — the burst accumulates.
+    expect(onProjection).toHaveBeenCalledTimes(1)
+    expect(frames).toHaveLength(1)
+
+    frames[0]!()
+    expect(onProjection).toHaveBeenCalledTimes(2)
+    const change = onProjection.mock.calls[1]![1]
+    expect(change.event.type).toBe('runtime_delta')
+    expect(change.previous.seq).toBe(3)
+    expect(change.current.seq).toBe(6)
+    expect(client.projection('session-1')?.seq).toBe(6)
+
+    // A later delta starts a fresh batch and schedules exactly one new frame.
+    client.handleEvent(delta(7))
+    expect(frames).toHaveLength(2)
+    frames[1]!()
+    expect(onProjection).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/web/src/store/chat/runtime-client.ts
+++ b/apps/web/src/store/chat/runtime-client.ts
@@ -1,11 +1,15 @@
 import type {
   RuntimeCursor,
+  RuntimeCurrentRunView,
+  UIRuntimeDeltaEvent,
   UIRuntimeEvent,
   UIRuntimeSnapshotEvent,
   WSClientMessage,
 } from '@/composables/api/useChat'
 import {
+  applyRuntimeRunPatch,
   createEmptyRuntimeProjection,
+  projectRuntimeTranscript,
   reduceRuntimeProjection,
   type RuntimeProjectionState,
 } from './runtime-projection'
@@ -19,9 +23,21 @@ export interface RuntimeProjectionChange {
 export interface RuntimeClientDeps {
   send: (message: WSClientMessage) => void
   onProjection: (sessionId: string, change: RuntimeProjectionChange) => void
+  // Test hook: production coalesces delta notifications to one per animation
+  // frame (see the batch below); tests inject a synchronous scheduler.
+  scheduleFrame?: (callback: () => void) => void
 }
 
-export function createRuntimeClient({ send, onProjection }: RuntimeClientDeps) {
+const defaultScheduleFrame = (callback: () => void) => {
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => callback())
+    return
+  }
+  setTimeout(callback, 16)
+}
+
+export function createRuntimeClient({ send, onProjection, scheduleFrame }: RuntimeClientDeps) {
+  const schedule = scheduleFrame ?? defaultScheduleFrame
   const subscriptions = new Set<string>()
   const projections = new Map<string, RuntimeProjectionState>()
   const awaitingSnapshots = new Set<string>()
@@ -59,6 +75,7 @@ export function createRuntimeClient({ send, onProjection }: RuntimeClientDeps) {
     const sid = sessionId.trim()
     if (!sid || !subscriptions.delete(sid)) return
     awaitingSnapshots.delete(sid)
+    pendingDeltaBatches.delete(sid)
     if (connected) {
       try {
         send({ type: 'runtime_unsubscribe', session_id: sid })
@@ -70,8 +87,56 @@ export function createRuntimeClient({ send, onProjection }: RuntimeClientDeps) {
 
   function recoverFromSnapshot(sessionId: string) {
     if (!subscriptions.has(sessionId) || awaitingSnapshots.has(sessionId)) return
+    pendingDeltaBatches.delete(sessionId)
     awaitingSnapshots.add(sessionId)
     sendSubscribe(sessionId)
+  }
+
+  // Delta batching. Every delta used to trigger a full projection rebuild AND
+  // a downstream transcript merge + reactive notification, so a burst of N
+  // deltas (normal streaming, or a backgrounded tab replaying its backlog on
+  // return) cost N x O(content) and could pin the main thread for tens of
+  // seconds. Deltas are now accumulated per session and flushed once per
+  // animation frame: seq/epoch integrity is still checked per event, but the
+  // transcript build + notification happen once per frame. A hidden tab has no
+  // rAF, so background streaming costs ZERO projection work; on return the
+  // whole backlog lands in a single frame and the terminal run status flips in
+  // that same frame instead of trailing the content queue.
+  interface PendingDeltaBatch {
+    base: RuntimeProjectionState
+    currentRunView: RuntimeCurrentRunView | null
+    epoch: string
+    seq: number
+    lastEvent: UIRuntimeDeltaEvent
+  }
+  const pendingDeltaBatches = new Map<string, PendingDeltaBatch>()
+  let flushScheduled = false
+
+  function flushDeltaBatches() {
+    const batches = [...pendingDeltaBatches.entries()]
+    pendingDeltaBatches.clear()
+    for (const [sid, batch] of batches) {
+      if (!subscriptions.has(sid)) continue
+      const current: RuntimeProjectionState = {
+        ...batch.base,
+        sessionId: sid,
+        epoch: batch.epoch,
+        seq: batch.seq,
+        currentRunView: batch.currentRunView,
+        transcript: projectRuntimeTranscript(batch.currentRunView),
+      }
+      projections.set(sid, current)
+      onProjection(sid, { previous: batch.base, current, event: batch.lastEvent })
+    }
+  }
+
+  function scheduleDeltaFlush() {
+    if (flushScheduled) return
+    flushScheduled = true
+    schedule(() => {
+      flushScheduled = false
+      flushDeltaBatches()
+    })
   }
 
   function handleSnapshot(event: UIRuntimeSnapshotEvent) {
@@ -80,6 +145,7 @@ export function createRuntimeClient({ send, onProjection }: RuntimeClientDeps) {
     const previous = projections.get(sid) ?? createEmptyRuntimeProjection(sid)
     const recovering = awaitingSnapshots.delete(sid)
     if (!recovering && previous.epoch === event.epoch && event.seq <= previous.seq) return
+    pendingDeltaBatches.delete(sid)
     const current = reduceRuntimeProjection(previous, event)
     projections.set(sid, current)
     onProjection(sid, { previous, current, event })
@@ -98,19 +164,30 @@ export function createRuntimeClient({ send, onProjection }: RuntimeClientDeps) {
     }
 
     if (awaitingSnapshots.has(sid)) return
-    const previous = projections.get(sid)
-    if (!previous || !previous.epoch || event.epoch !== previous.epoch) {
+    const delivered = projections.get(sid)
+    if (!delivered || !delivered.epoch || event.epoch !== delivered.epoch) {
       recoverFromSnapshot(sid)
       return
     }
-    if (event.seq <= previous.seq) return
-    if (event.seq !== previous.seq + 1) {
+    const pending = pendingDeltaBatches.get(sid)
+    const latestSeq = pending?.seq ?? delivered.seq
+    if (event.seq <= latestSeq) return
+    if (event.seq !== latestSeq + 1) {
       recoverFromSnapshot(sid)
       return
     }
-    const current = reduceRuntimeProjection(previous, event)
-    projections.set(sid, current)
-    onProjection(sid, { previous, current, event })
+    const currentRunView = applyRuntimeRunPatch(
+      pending?.currentRunView ?? delivered.currentRunView,
+      event.delta,
+    )
+    pendingDeltaBatches.set(sid, {
+      base: pending?.base ?? delivered,
+      currentRunView,
+      epoch: event.epoch,
+      seq: event.seq,
+      lastEvent: event,
+    })
+    scheduleDeltaFlush()
   }
 
   function onConnected() {
@@ -133,6 +210,8 @@ export function createRuntimeClient({ send, onProjection }: RuntimeClientDeps) {
     subscriptions.clear()
     projections.clear()
     awaitingSnapshots.clear()
+    pendingDeltaBatches.clear()
+    flushScheduled = false
     connected = false
   }
 

--- a/apps/web/src/store/chat/runtime-projection.ts
+++ b/apps/web/src/store/chat/runtime-projection.ts
@@ -134,14 +134,17 @@ function transcriptForRun(run: RuntimeCurrentRunView | null): RuntimeTranscriptS
       role: 'assistant',
       id: `runtime:${turnId}:assistant`,
       timestamp: run.started_at,
-      messages: run.messages.map(cloneUIMessage),
+      // Share message identity with the run view: consumers normalize into
+      // their own view blocks without mutating UIMessage input, so re-cloning
+      // every message per projection was pure O(all-content) waste.
+      messages: [...run.messages],
     })
     if (run.error && !run.messages.some(message => message.type === 'error')) {
       turns[turns.length - 1] = {
         ...turns[turns.length - 1]!,
         role: 'assistant',
         messages: [
-          ...run.messages.map(cloneUIMessage),
+          ...run.messages,
           { id: nextMessageId(run.messages), type: 'error', content: run.error },
         ],
       }
@@ -166,10 +169,17 @@ function applyRunPatch(
   run: RuntimeCurrentRunView | null,
   delta: RuntimeDelta,
 ): RuntimeCurrentRunView | null {
+  // Hot path (delta without a full view): shallow-copy the run and start from a
+  // fresh messages array — the patch loops below copy-on-write the specific
+  // messages they touch, so unchanged messages keep object identity and a text
+  // append costs O(delta) instead of O(all content). The previous per-delta
+  // cloneRunView made a stream of N deltas cost O(N x content), which is what
+  // melted the main thread when a backgrounded tab replayed its backlog.
+  // Full-view carriers still clone: that payload may be reused by the caller.
   let next = delta.current_run_view
     ? cloneRunView(delta.current_run_view)
     : run
-      ? cloneRunView(run)
+      ? { ...run, messages: [...(run.messages ?? [])] }
       : null
   if (!next) return null
   const patch = delta.run
@@ -186,7 +196,7 @@ function applyRunPatch(
     }
   }
 
-  const messages = delta.reset_messages ? [] : next.messages.map(cloneUIMessage)
+  const messages = delta.reset_messages ? [] : next.messages
   for (const append of delta.message_appends ?? []) {
     const index = messages.findIndex(message => message.id === append.id && message.type === append.type)
     if (index < 0) {
@@ -224,6 +234,19 @@ function applyRunPatch(
   }
   messages.sort((left, right) => left.id - right.id)
   return { ...next, messages }
+}
+
+// Delta-only patch step, exported for the batching runtime client: accumulate
+// many deltas onto a run view cheaply, then build the transcript once.
+export function applyRuntimeRunPatch(
+  run: RuntimeCurrentRunView | null,
+  delta: RuntimeDelta,
+): RuntimeCurrentRunView | null {
+  return applyRunPatch(run, delta)
+}
+
+export function projectRuntimeTranscript(run: RuntimeCurrentRunView | null): RuntimeTranscriptSlice {
+  return transcriptForRun(run)
 }
 
 export function createEmptyRuntimeProjection(sessionId = ''): RuntimeProjectionState {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,8 +259,8 @@ importers:
         specifier: ^0.562.0
         version: 0.562.0(vue@3.5.40(typescript@6.0.3))
       markstream-vue:
-        specifier: 1.0.7
-        version: 1.0.7(katex@0.18.1)(mermaid@11.16.0)(stream-markdown@0.0.16(react@19.2.7)(shiki@3.23.0)(vue@3.5.40(typescript@6.0.3)))(stream-monaco@0.0.49(monaco-editor@0.52.2))(vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        specifier: 2.0.0
+        version: 2.0.0(katex@0.18.1)(mermaid@11.16.0)(vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
@@ -3444,6 +3444,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -4086,6 +4090,9 @@ packages:
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
+  linkify-it@6.1.0:
+    resolution: {integrity: sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==}
+
   lint-staged@17.2.0:
     resolution: {integrity: sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==}
     engines: {node: '>=22.22.1'}
@@ -4182,6 +4189,10 @@ packages:
   markdown-it-task-checkbox@1.0.6:
     resolution: {integrity: sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw==}
 
+  markdown-it-ts@1.0.10:
+    resolution: {integrity: sha512-8FIKgiTAewMr67TMwikpwMj2u3dVSBLMJ9RZOG4HdqjE0Q+g0o3wDT1LFOXSddQr+RAr6ZT4PFiICU4kRX1l5Q==}
+    engines: {node: '>=20.19'}
+
   markdown-it-ts@1.0.5:
     resolution: {integrity: sha512-vD3lIbUDHE0eorCuPdku4ikNFcIJC1ZzyAQA0d/2zjMg+8etvfC10uV8GOlzQBHQc7/NUh7H0VtW72gLjXANCw==}
     engines: {node: '>=18'}
@@ -4193,6 +4204,9 @@ packages:
 
   markstream-core@1.0.3:
     resolution: {integrity: sha512-QXn+yERo1q+RD6YlGDW61zc/af65uhkQEH3K8YvEKkprHbgRJ/JIeBeEQjELCTyBnPoxqtKQ7I565rylY+PePg==}
+
+  markstream-core@2.0.0:
+    resolution: {integrity: sha512-9SXYsUiZfV7CUC41c6hEkxFD6VbQKMk+RjGOvfr6iKTAtv/aPAnA2IuQYrpwkvbrrZUgYVjgL1I30yg6y/mtIw==}
 
   markstream-vue@1.0.7:
     resolution: {integrity: sha512-88UVoAH34jh/BXGUVYtK8t+Tw9JETbHhRVF2DwBAIE8r8W6MO27xRADotHpz1Qn34Mas6XRW6NmqvzwwjtvciQ==}
@@ -4224,6 +4238,30 @@ packages:
       vue-i18n:
         optional: true
 
+  markstream-vue@2.0.0:
+    resolution: {integrity: sha512-zeD92NhzuJyT1jnNPXRbZ63CIFUK4j6JyYJON9OYYzL2VaClWnwf3k8Ws3cMpgiacBqu1R5D3wHMWUvwcWe1Ag==}
+    peerDependencies:
+      '@antv/infographic': ^0.2.3
+      '@terrastruct/d2': '>=0.1.33'
+      katex: '>=0.16.22'
+      mermaid: '>=11'
+      stream-diffs: '>=0.0.2'
+      vue: '>=3.0.0'
+      vue-i18n: '>=9'
+    peerDependenciesMeta:
+      '@antv/infographic':
+        optional: true
+      '@terrastruct/d2':
+        optional: true
+      katex:
+        optional: true
+      mermaid:
+        optional: true
+      stream-diffs:
+        optional: true
+      vue-i18n:
+        optional: true
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -4240,6 +4278,9 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -4911,6 +4952,9 @@ packages:
   stream-markdown-parser@1.1.4:
     resolution: {integrity: sha512-fjkHUh7uIOH5Yp/kt26l2td+q/4sRusMFO4iB0d+GcWj40ZZuH+HxxiLxGeSD1oo8YdyapokzHOfchDIYFnNgg==}
 
+  stream-markdown-parser@1.2.8:
+    resolution: {integrity: sha512-9owCFbTxBLWMWh0cXEkYq1OS2EsYpUX7WFCcZ4RRmevWDHxLJvCeI8glU0aw70GtFhGuNgNjL9cUkoleVcIzfg==}
+
   stream-markdown@0.0.16:
     resolution: {integrity: sha512-2WoOxlpc3N5RLc3zGuW+g/w76z6ketWBY0N1YzDYbXds1qw7zrUBv5PTQ3DOtpqgCjLuF3P2iCfjJTEqWGv0NQ==}
     peerDependencies:
@@ -5122,6 +5166,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uc.micro@3.0.0:
+    resolution: {integrity: sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==}
 
   ufo@1.6.2:
     resolution: {integrity: sha512-heMioaxBcG9+Znsda5Q8sQbWnLJSl98AFDXTO80wELWEzX3hordXsTdxrIfMQoO9IY1MEnoGoPjpoKpMj+Yx0Q==}
@@ -8747,6 +8794,8 @@ snapshots:
 
   entities@7.0.1: {}
 
+  entities@8.0.0: {}
+
   env-paths@2.2.1: {}
 
   env-paths@3.0.0: {}
@@ -9463,6 +9512,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  linkify-it@6.1.0:
+    dependencies:
+      uc.micro: 3.0.0
+
   lint-staged@17.2.0:
     dependencies:
       picomatch: 4.0.5
@@ -9550,6 +9603,13 @@ snapshots:
 
   markdown-it-task-checkbox@1.0.6: {}
 
+  markdown-it-ts@1.0.10:
+    dependencies:
+      entities: 8.0.0
+      linkify-it: 6.1.0
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+
   markdown-it-ts@1.0.5:
     dependencies:
       '@types/linkify-it': 5.0.0
@@ -9564,6 +9624,8 @@ snapshots:
 
   markstream-core@1.0.3: {}
 
+  markstream-core@2.0.0: {}
+
   markstream-vue@1.0.7(katex@0.18.1)(mermaid@11.16.0)(stream-markdown@0.0.16(react@19.2.7)(shiki@3.23.0)(vue@3.5.40(typescript@6.0.3)))(stream-monaco@0.0.49(monaco-editor@0.52.2))(vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)):
     dependencies:
       '@chenglou/pretext': 0.0.8
@@ -9576,6 +9638,18 @@ snapshots:
       mermaid: 11.16.0
       stream-markdown: 0.0.16(react@19.2.7)(shiki@3.23.0)(vue@3.5.40(typescript@6.0.3))
       stream-monaco: 0.0.49(monaco-editor@0.52.2)
+      vue-i18n: 11.4.8(vue@3.5.40(typescript@6.0.3))
+
+  markstream-vue@2.0.0(katex@0.18.1)(mermaid@11.16.0)(vue-i18n@11.4.8(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)):
+    dependencies:
+      '@chenglou/pretext': 0.0.8
+      '@floating-ui/dom': 1.8.0
+      markstream-core: 2.0.0
+      stream-markdown-parser: 1.2.8
+      vue: 3.5.40(typescript@6.0.3)
+    optionalDependencies:
+      katex: 0.18.1
+      mermaid: 11.16.0
       vue-i18n: 11.4.8(vue@3.5.40(typescript@6.0.3))
 
   matcher@3.0.0:
@@ -9601,6 +9675,8 @@ snapshots:
     optional: true
 
   mdurl@2.0.0: {}
+
+  mdurl@2.1.0: {}
 
   memorystream@0.3.1: {}
 
@@ -10340,6 +10416,16 @@ snapshots:
       markdown-it-task-checkbox: 1.0.6
       markdown-it-ts: 1.0.5
 
+  stream-markdown-parser@1.2.8:
+    dependencies:
+      markdown-it-container: 4.0.0
+      markdown-it-footnote: 4.0.0
+      markdown-it-ins: 4.0.0
+      markdown-it-mark: 4.0.0
+      markdown-it-sup: 2.0.0
+      markdown-it-task-checkbox: 1.0.6
+      markdown-it-ts: 1.0.10
+
   stream-markdown@0.0.16(react@19.2.7)(shiki@3.23.0)(vue@3.5.40(typescript@6.0.3)):
     dependencies:
       shiki: 3.23.0
@@ -10537,6 +10623,8 @@ snapshots:
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
+
+  uc.micro@3.0.0: {}
 
   ufo@1.6.2: {}
 


### PR DESCRIPTION
## Summary

Returning to a backgrounded tab during streaming used to replay the backlog
frame by frame: the smooth-stream typewriter caught up at its chars/sec
ceiling, the node renderer mounted nodes in delayed batches, and — the
dominant cost — the runtime store re-projected every queued WS delta with
full deep clones (QA trace: a single message handler running 20.6s at 99%
CPU). Content landed in slow chunks and the composer's run state trailed
reality, because the run's terminal status travels in the same event
stream that was stuck behind the backlog.

This PR fixes all three layers of the catch-up path:

1. **Visibility pulse (typewriter layer).** The smooth-stream controller
   only reveals chars from rAF, which freezes in background tabs while
   `source` keeps growing. On `visibilitychange → visible` we flip the
   streaming props off for one tick: the component's own watch treats
   smooth=off as a static render and resets to the full received text
   (respecting its unclosed-fence hold-back), then flips back on — a no-op
   once caught up, so later tokens keep typewriter-streaming. Upstream has
   no visibility hook (checked 1.0.7 / 1.1.5 / 2.0.0 dist).
2. **One-pass mount (renderer layer).** During the pulse,
   `batch-rendering` is forced off for the streaming block so its visible
   window mounts in a single pass instead of docs-profile batches
   (40 nodes, then 80/16ms). The chat surface also switches to the
   upstream `mode="chat"` profile (32/48/6ms batches, no live-node
   virtualization cap) — the docs profile's 220-node cap made long
   messages mount in scroll-driven chunks.
3. **Ingestion layer (the big one).**
   - Reducer now uses structural sharing: a delta without a full run view
     shallow-copies the run and the patch loops copy-on-write only the
     messages they touch — an append costs O(delta) instead of O(all
     content). Transcript turns share message identity with the run view
     (consumers never mutate `UIMessage` input).
   - Deltas are coalesced to one transcript build + one notification per
     animation frame (seq/epoch integrity still checked per event;
     snapshots and `runtime_dropped` stay immediate). A hidden tab pays
     **zero** projection cost; on return the whole backlog lands in one
     frame and the terminal run status flips in that same frame — the
     send/Enter button no longer shows "running" after the model finished.

## markstream-vue 1.0.7 → 2.0.0 (dependency change)

Justification for the major bump: 2.0.0 is the new official stable
(2026-08-19). It removes the Monaco and `stream-markdown` code-block
runtimes entirely (smaller footprint; Monaco was never installed here but
`stream-markdown@0.0.16` was). Migration work:

- `theme` prop removed → `code-block-dark-theme` / `code-block-light-theme`
  (chat + about).
- `CodeBlockNode` now names the default block component and shadows the
  parser node type → themed-mermaid-block reads the node type from
  `CodeBlockNodeProps['node']`.
- `LinkNodeProps.indexKey` is now required → md-link forwards it and uses
  the exported `LinkNodeProps['node']` instead of a hand-copied literal.
- New transitive deps: `markstream-core@2.0.0`, `stream-markdown-parser@1.2.8`,
  `@chenglou/pretext@0.0.8`.
- **`stream-diffs` (optional peer) is deliberately NOT installed.** Without
  it, the *default* code block renders fenced code as plain `<pre>`. Chat
  and file preview already use our custom `ChatCodeBlock`; the only scope
  that could hit the fallback is about-page release notes (arbitrary
  upstream markdown that may contain fences), and this PR also registers
  `ChatCodeBlock` for that scope — chosen over adding a dependency whose
  toolbar chrome we previously removed from chat on purpose. The appearance mermaid scopes
  need no registration: their content is mermaid-only, served by the
  global mermaid override.

## Behavior changes

- Runtime delta delivery is now per-frame instead of per-event (≤16ms
  added latency for status updates in foreground; approvals unaffected).
- While the tab is hidden, session runtime projection pauses (sidebar
  metadata comes over the separate bot-activity SSE and is unaffected).
- Long backlog on return = one heavy mount frame (can be seconds for very
  large backlogs) instead of tens of seconds of catch-up rendering.
- Semantic change from per-frame coalescing: the GUI-tool affordance
  (`guiToolUseRequested`) now fires only for GUI tools still running at
  flush time. A tool that starts and finishes within one frame no longer
  prompts, and a tool that completes while the tab is hidden no longer
  leaves a stale prompt on return. We consider this strictly more correct
  (the old per-delta delivery could surface affordances for tools that had
  already finished), but it is a behavior change beyond rendering.

## Test plan

- [x] `vitest` chat store suites: 343 passed, incl. a new test proving
      burst coalescing (one notification per frame, latest seq/status)
- [x] Full web suite: 1122 passed (2 collection failures verified
      pre-existing: localStorage / vue-i18n mock setup, unrelated)
- [x] ESLint + vue-tsc on all touched files (no new errors vs baseline)
- [x] Human QA on the happy path: long-background tab during streaming →
      return reveals the full backlog in one step, typewriter resumes for
      new tokens, run state flips immediately
- [x] Human QA on 2.0.0 rendering: mermaid in chat (full block chrome) and
      in the appearance preview dialog, KaTeX inline + block, code blocks
      with highlighting — all render correctly
- [x] Human QA: about-page release notes render correctly. Note: v0.18.0
      notes contain no fenced code, so the pre-fallback path was not
      exercised in the wild; the `ChatCodeBlock` registration above closes
      that gap permanently.

## Out of scope (seen in traces, filed for later)

- `invalid before_message_id` 400 on a focus refetch (pre-existing
  pagination issue), `query-cache-persistence` 1.5s timer on focus,
  dockview `blur` handler ~3s on tab switch.

