### PR TITLE
fix(models): append /v1 to anthropic base URLs at all SDK construction sites

### DIFF
--- a/internal/models/anthropic_baseurl_test.go
+++ b/internal/models/anthropic_baseurl_test.go
@@ -1,0 +1,88 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+func TestNewSDKChatModelAnthropicMessagesBaseURLGainsV1(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		baseURL func(serverURL string) string
+	}{
+		{name: "bare origin", baseURL: func(u string) string { return u }},
+		{name: "bare origin with trailing slash", baseURL: func(u string) string { return u + "/" }},
+		{name: "versioned root", baseURL: func(u string) string { return u + "/v1" }},
+		{name: "versioned root with trailing slash", baseURL: func(u string) string { return u + "/v1/" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":          "msg_test",
+					"type":        "message",
+					"role":        "assistant",
+					"model":       "claude-opus-5",
+					"content":     []map[string]any{{"type": "text", "text": "ok"}},
+					"stop_reason": "end_turn",
+					"usage":       map[string]any{"input_tokens": 1, "output_tokens": 1},
+				})
+			}))
+			defer srv.Close()
+
+			model := NewSDKChatModel(SDKModelConfig{
+				ModelID:    "claude-opus-5",
+				ClientType: string(ClientTypeAnthropicMessages),
+				BaseURL:    tt.baseURL(srv.URL),
+				APIKey:     "test-key",
+			})
+
+			if _, err := sdk.GenerateTextResult(
+				context.Background(),
+				sdk.WithModel(model),
+				sdk.WithMessages([]sdk.Message{sdk.UserMessage("hi")}),
+			); err != nil {
+				t.Fatalf("generate text: %v", err)
+			}
+
+			if gotPath != "/v1/messages" {
+				t.Fatalf("request path: got %q, want %q", gotPath, "/v1/messages")
+			}
+		})
+	}
+}
+
+func TestNewSDKProviderAnthropicMessagesBaseURLGainsV1(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"id": "claude-opus-5", "display_name": "Claude Opus 5"}},
+		})
+	}))
+	defer srv.Close()
+
+	provider := NewSDKProvider(srv.URL, "test-key", "", ClientTypeAnthropicMessages, time.Second, nil)
+	if _, err := provider.ListModels(context.Background()); err != nil {
+		t.Fatalf("list models: %v", err)
+	}
+	if gotPath != "/v1/models" {
+		t.Fatalf("request path: got %q, want %q", gotPath, "/v1/models")
+	}
+}

--- a/internal/models/probe.go
+++ b/internal/models/probe.go
@@ -168,7 +168,7 @@ func NewSDKProvider(baseURL, apiKey, codexAccountID string, clientType ClientTyp
 			anthropicmessages.WithAPIKey(apiKey),
 			anthropicmessages.WithHTTPClient(httpClient),
 		}
-		if baseURL != "" {
+		if baseURL := anthropicMessagesBaseURL(baseURL); baseURL != "" {
 			opts = append(opts, anthropicmessages.WithBaseURL(baseURL))
 		}
 		return anthropicmessages.New(opts...)

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -99,8 +99,8 @@ func NewSDKChatModel(cfg SDKModelConfig) *sdk.Model {
 			anthropicmessages.WithAPIKey(cfg.APIKey),
 		}
 		opts = append(opts, anthropicmessages.WithHTTPClient(cfg.HTTPClient))
-		if cfg.BaseURL != "" {
-			opts = append(opts, anthropicmessages.WithBaseURL(cfg.BaseURL))
+		if baseURL := anthropicMessagesBaseURL(cfg.BaseURL); baseURL != "" {
+			opts = append(opts, anthropicmessages.WithBaseURL(baseURL))
 		}
 		// Anthropic extended thinking has two wire shapes by model generation:
 		//   - 4.6+ (Adaptive): thinking{type:"adaptive"}; effort is carried
@@ -296,6 +296,21 @@ func legacyAnthropicBudgetFor(effort string) int {
 		return b
 	}
 	return anthropicLegacyBudget[ReasoningEffortMedium]
+}
+
+// anthropicMessagesBaseURL normalizes a configured Anthropic base URL to the
+// versioned API root the SDK joins /messages onto. Provider configs follow the
+// template convention of a bare origin (https://api.anthropic.com), which
+// model import already bridged by appending /v1; every other construction
+// site passed the origin through verbatim, sending requests to
+// {origin}/messages and failing on any endpoint. Normalizing here covers
+// them all.
+func anthropicMessagesBaseURL(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if baseURL == "" || strings.HasSuffix(baseURL, "/v1") {
+		return baseURL
+	}
+	return baseURL + "/v1"
 }
 
 // ResolveClientType infers the client type string from an SDK Model's provider name.


### PR DESCRIPTION
## Problem

An `anthropic-messages` provider with a configured `base_url` fails on every LLM call path — chat, title generation, subagent, image gen, compaction, memory LLM, provider test, model probe — while **model import works**, which makes the configuration look valid and the failure look like a protocol bug.

Root cause: provider configs follow the template convention of a bare origin (`https://api.anthropic.com` in `conf/providers/anthropic.yaml`, prefilled by the add-provider form), while the Twilight AI anthropic client expects the versioned API root and joins `/messages` onto it. Only `fetchRemoteModelsViaSDK` bridged the mismatch by appending `/v1` (#420); every other construction site passed the stored value through verbatim, so requests hit `{origin}/messages`:

- `api.anthropic.com/messages` → 404
- new-api style relays → 200 `text/html` (SPA fallback), which `FetchSSE` parses as zero events → silent empty turns

Switching the same relay to `openai-responses` works because the OpenAI-style convention already carries `/v1` in `base_url` — that asymmetry is what got reported as "the anthropic messages protocol is broken".

## Fix

Normalize at the two SDK construction chokepoints — `NewSDKChatModel` and `NewSDKProvider`, the only `anthropicmessages.New` call sites in the repo — via an idempotent `anthropicMessagesBaseURL` helper: trim trailing `/`, append `/v1` unless already suffixed. Every call path is covered; the existing model-import normalization stays and composes idempotently.

## Testing

- New httptest-driven tests assert bare origin / trailing slash / already-versioned inputs all reach `/v1/messages` (chat) and `/v1/models` (provider listing).
- `go test ./internal/models/ ./internal/providers/` and the full pre-commit suite pass.
- Verified on the wire against a live new-api relay: with `/v1` the full Memoh request shape (adaptive thinking + `output_config.effort` + `cache_control` + streaming) succeeds; without it the relay returns 200 HTML.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
