### PR TITLE
test(agent): fix step budget retry cancellation race

### DIFF
--- a/internal/agent/runtime/native/provider_retry_budget_error_test.go
+++ b/internal/agent/runtime/native/provider_retry_budget_error_test.go
@@ -12,18 +12,23 @@ import (
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 )
 
-// hiddenErrContext models cancellation becoming visible after the retry
-// loop's ctx.Err check but before it handles the provider's ErrorPart. Cause
-// still reaches the embedded cancel-cause context, as it does in the race.
-type hiddenErrContext struct {
+// delayedErrContext models cancellation becoming visible after the retry
+// loop's ctx.Err check but before it handles the provider's ErrorPart. The
+// first Err call is the retry preflight and the second is the loop guard;
+// the third call is the ErrorPart budget check.
+type delayedErrContext struct {
 	context.Context
+	errCalls atomic.Int32
 }
 
-func (hiddenErrContext) Err() error {
-	return nil
+func (c *delayedErrContext) Err() error {
+	if c.errCalls.Add(1) <= 2 {
+		return nil
+	}
+	return c.Context.Err()
 }
 
-func (hiddenErrContext) Done() <-chan struct{} {
+func (*delayedErrContext) Done() <-chan struct{} {
 	return nil
 }
 
@@ -31,7 +36,7 @@ func TestRunMidStreamRetrySuppressesRawErrorAfterStepBudgetCancellation(t *testi
 	t.Parallel()
 
 	baseCtx, cancel := context.WithCancelCause(context.Background())
-	streamCtx := hiddenErrContext{Context: baseCtx}
+	streamCtx := &delayedErrContext{Context: baseCtx}
 	var providerCalls atomic.Int32
 	provider := &atomicMockProvider{
 		stream: func(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {


### PR DESCRIPTION
## Summary

- Fix the mid-stream retry cancellation test context double.
- Model cancellation becoming visible between the stream loop guard and ErrorPart handling.
- Ensure raw provider cancellation errors remain suppressed.

## Validation

- `go test ./internal/agent/runtime/native -run '^TestRunMidStreamRetrySuppressesRawErrorAfterStepBudgetCancellation$' -count=100 -race`
- `go test ./internal/agent/runtime/native`