### PR TITLE
fix(web): unify sidebar folders and recents into one scrollport

### DIFF
--- a/apps/web/src/components/sidebar/folder-sessions-list.vue
+++ b/apps/web/src/components/sidebar/folder-sessions-list.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      v-for="session in sessions"
+      v-for="session in visibleSessions"
       :key="session.id"
       class="pb-0.5 pl-4"
     >
@@ -17,32 +17,43 @@
     </div>
 
     <div
-      v-if="showSentinel"
-      ref="loadMoreSentinel"
-      class="h-px w-full pl-4"
-      :data-testid="`folder-load-more-${workdirId}`"
-    />
-
-    <div
       v-if="paging.loading"
       class="flex justify-center py-2 pl-4"
     >
       <Spinner class="size-4" />
     </div>
 
-    <!-- Auto-prefetch stops after a failed page (it made no progress) and a
-         folder short of its viewport has no sentinel to kick it again — this
-         row is the only way forward. -->
+    <!-- A failed page also leaves the Show more button below, but this row is
+         the one that says the last attempt failed rather than "there is more". -->
     <div
       v-else-if="paging.error"
       class="pb-0.5 pl-4"
     >
       <TextButton
-        class="text-xs"
+        :class="footerActionClass"
         :data-testid="`folder-load-retry-${workdirId}`"
         @click="retryLoad"
       >
-        {{ t('chat.retry') }}
+        {{ t('chat.actions.retry') }}
+      </TextButton>
+    </div>
+
+    <!-- Explicit Show more, NOT infinite scroll: folders now flow inside the
+         sessions panel's single scroll container, so a folder that grew
+         whenever its tail neared the viewport would keep pushing Recents (and
+         every folder below it) out of reach. Each click reveals one more page
+         of rows and only touches the network when the revealed window runs
+         past what has been fetched. -->
+    <div
+      v-else-if="canShowMore"
+      class="pb-0.5 pl-4"
+    >
+      <TextButton
+        :class="footerActionClass"
+        :data-testid="`folder-show-more-${workdirId}`"
+        @click="showMore"
+      >
+        {{ t('chat.showMoreSessions') }}
       </TextButton>
     </div>
 
@@ -56,18 +67,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRef } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { Spinner, TextButton } from '@felinic/ui'
 import { useChatStore } from '@/store/chat-list'
 import type { SessionSummary } from '@/composables/api/useChat'
 import SessionItem from './session-item.vue'
-import { useSidebarInfiniteScroll } from './use-sidebar-infinite-scroll'
 
 const props = defineProps<{
   workdirId: string
-  scrollEl: HTMLElement | null
 }>()
 
 const emit = defineEmits<{
@@ -84,18 +93,33 @@ const { sessionId, currentBotId } = storeToRefs(chatStore)
 const sessions = computed(() => chatStore.workdirSessionsFor(props.workdirId))
 const paging = computed(() => chatStore.workdirSessionsState(props.workdirId))
 
-const scrollElRef = toRef(props, 'scrollEl')
+// Show more / Retry sit under the folder's rows and read as list footers, so
+// their labels line up with the session titles above them.
+const footerActionClass = 'ml-[5px] text-xs' /* ui-allow-px: 5px + the text button's own 6px inset = the 11px sidebar row gutter, so the label lands on the session titles' x */
 
-const { loadMoreSentinel, showSentinel } = useSidebarInfiniteScroll({
-  scrollEl: scrollElRef,
-  hasMore: computed(() => paging.value.hasMore),
-  loading: computed(() => paging.value.loading),
-  loadMore: () => chatStore.loadMoreWorkdirSessions(props.workdirId),
-  // A permission-filtered page can return zero rows with an advanced cursor —
-  // count/height alone would read that as "no progress" and stall paging.
-  progressCursor: computed(() => paging.value.cursor),
-  itemCount: computed(() => sessions.value.length),
+/** Rows an expanded folder shows before it asks. One folder must never be able
+ *  to bury the folders under it — or Recents — under its own history. */
+const FOLDER_VISIBLE_STEP = 8
+
+const visibleCount = ref(FOLDER_VISIBLE_STEP)
+watch(() => props.workdirId, () => {
+  visibleCount.value = FOLDER_VISIBLE_STEP
 })
+
+const visibleSessions = computed(() => sessions.value.slice(0, visibleCount.value))
+
+// A fetched page is much larger than the reveal step, so "more" usually means
+// rows already in the store; hasMore only matters once the window catches up.
+const canShowMore = computed(() => (
+  sessions.value.length > visibleCount.value || paging.value.hasMore
+))
+
+function showMore() {
+  visibleCount.value += FOLDER_VISIBLE_STEP
+  if (sessions.value.length < visibleCount.value && paging.value.hasMore) {
+    void chatStore.loadMoreWorkdirSessions(props.workdirId)
+  }
+}
 
 function retryLoad() {
   if (paging.value.loaded) void chatStore.loadMoreWorkdirSessions(props.workdirId)

--- a/apps/web/src/components/sidebar/folders-section.vue
+++ b/apps/web/src/components/sidebar/folders-section.vue
@@ -1,13 +1,16 @@
 <template>
   <!-- Folders — a sidebar section that is a SIBLING of Recents, never a
        group inside it: folders organize workdir-bound chats, Recents keeps
-       the ungrouped timeline. Bounded height so a long folder list can never
-       squeeze the Recents list out of the panel. -->
+       the ungrouped timeline. This section does NOT scroll and has no height
+       cap: it flows in the sessions panel's single scroll container so every
+       folder is a peer of Recents on one continuous list. What keeps a long
+       folder from burying the ones below it is the per-folder Show more page
+       (see folder-sessions-list.vue), not a scrollbar. -->
   <div
     v-if="currentBotId"
-    class="flex min-h-0 max-h-[min(14rem,45%)] shrink flex-col overflow-hidden px-2 pb-0.5"
+    class="px-2 pb-0.5"
   >
-    <div class="flex items-center pt-1 pr-1">
+    <div class="flex items-center pt-1">
       <!-- Same header affordance as the Recents mode switcher: the label is a
            TextButton with a tight trailing chevron; clicking it folds the
            whole section. -->
@@ -36,8 +39,7 @@
 
     <div
       v-if="!sectionCollapsed"
-      ref="foldersScrollEl"
-      class="sidebar-scroll min-h-0 flex-1 overflow-y-auto pr-1 pt-0.5"
+      class="pt-0.5"
     >
       <template
         v-for="folder in liveFolders"
@@ -101,7 +103,6 @@
         <FolderSessionsList
           v-if="isExpanded(folder.id ?? '')"
           :workdir-id="folder.id ?? ''"
-          :scroll-el="foldersScrollEl"
           @select="handleSelect"
           @open-new-tab="handleOpenNewTab"
           @rename="sessionDialogs?.openRename($event)"
@@ -195,7 +196,6 @@ import { resolveApiErrorMessage } from '@/utils/api-error'
 import SessionDialogs from './session-dialogs.vue'
 import FolderSessionsList from './folder-sessions-list.vue'
 import FolderCreateDialog from './folder-create-dialog.vue'
-import '@/styles/sidebar-scroll.css'
 
 const { t } = useI18n()
 const chatStore = useChatStore()
@@ -217,7 +217,6 @@ const sectionTrailingClass = 'flex shrink-0 items-center pr-[11px]' /* ui-allow-
 const folderRowClass = 'group/folder relative flex w-full min-h-[2.125rem] cursor-pointer select-none items-center rounded-[9px] px-[11px] text-left transition-colors hover:bg-[color:var(--sidebar-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' /* ui-allow-px: matches session-item.vue's 11px sidebar row gutter */ /* ui-allow-style: sidebar rows are a deliberately local row system (see ui-owners) — same hover token as session-item.vue */
 
 const sessionDialogs = ref<InstanceType<typeof SessionDialogs> | null>(null)
-const foldersScrollEl = ref<HTMLElement | null>(null)
 
 watch(currentBotId, (botId) => {
   if (botId) void workdirsStore.ensureWorkdirs(botId)

--- a/apps/web/src/components/sidebar/panel-sessions.vue
+++ b/apps/web/src/components/sidebar/panel-sessions.vue
@@ -72,18 +72,27 @@
     -->
 
     <!-- Folders is a SIBLING section of Recents: folders of workdir-bound
-         chats above, the ungrouped timeline below. The wrapper owns the
-         remaining height so neither section can spill into the sidebar footer. -->
-    <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+         chats above, the ungrouped timeline below — and both live in ONE
+         scrollport owned here. Each section used to scroll itself, which
+         capped Folders at ~14rem and buried long folder lists in a second
+         inner scrollbar; now overflow is handled once, for the whole list, so
+         a folder is a peer of Recents rather than an item inside a box.
+         Per-folder growth is bounded by its Show more page instead
+         (folder-sessions-list.vue). pr-1 keeps the scrollbar clear of the
+         rows' hover chips — the sections themselves keep their px-2. -->
+    <div
+      ref="listScrollEl"
+      class="sidebar-scroll min-h-0 flex-1 overflow-y-auto pr-1"
+    >
       <FoldersSection />
 
-      <Recents class="min-h-0 flex-1 overflow-hidden" />
+      <Recents :scroll-el="listScrollEl" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
@@ -94,8 +103,13 @@ import SidebarPanelHeader from './panel-header.vue'
 import SidebarNavButton from './nav-button.vue'
 import FoldersSection from './folders-section.vue'
 import Recents from './recents.vue'
+import '@/styles/sidebar-scroll.css'
 
 const { t } = useI18n()
+
+// The one scrollport for Folders + Recents. Recents needs the element itself
+// for its load-more sentinel root, so it is passed down rather than provided.
+const listScrollEl = ref<HTMLElement | null>(null)
 const router = useRouter()
 const chatStore = useChatStore()
 const workspaceTabs = useWorkspaceTabsStore()

--- a/apps/web/src/components/sidebar/recents.vue
+++ b/apps/web/src/components/sidebar/recents.vue
@@ -1,8 +1,11 @@
 <template>
-  <div class="flex min-h-0 flex-1 flex-col min-w-0 overflow-hidden">
+  <div class="flex min-w-0 flex-col">
     <!-- Unified Recents: one timeline for chats, ACP chats, and schedule
          runs (each row carries its own type mark — see session-item.vue).
-         The header folds the section, mirroring the Folders header above. -->
+         The header folds the section, mirroring the Folders header above.
+         Recents does not own a scrollport: it is the tail of the sessions
+         panel's single scroll container (passed in as `scrollEl`), so the
+         folders above it and this timeline scroll as one list. -->
     <div class="shrink-0 px-2 pb-0.5 pt-1">
       <TextButton
         :class="sectionHeaderClass"
@@ -16,76 +19,69 @@
       </TextButton>
     </div>
 
+    <!-- Cursor-paginated rows render as a plain list; load-more still uses a
+         bottom sentinel, now observed against the shared scrollport. -->
     <div
       v-show="!sectionCollapsed"
-      class="flex-1 relative min-h-0"
+      class="px-2"
     >
-      <!-- Native overflow scroll (not Reka ScrollArea): cursor-paginated rows
-           render as a plain list; load-more uses a bottom sentinel. -->
       <div
-        ref="scrollEl"
-        class="absolute inset-0 overflow-y-auto sidebar-scroll"
+        v-for="session in visibleSessions"
+        :key="session.id"
+        class="pb-[2px]"
       >
-        <div class="px-2 pr-3">
-          <div
-            v-for="session in visibleSessions"
-            :key="session.id"
-            class="pb-[2px]"
-          >
-            <SessionItem
-              :session="session"
-              :is-active="sessionId === session.id"
-              :streaming="chatStore.isSessionStreaming(currentBotId, session.id)"
-              @select="handleSelect"
-              @open-new-tab="handleOpenNewTab"
-              @rename="sessionDialogs?.openRename($event)"
-              @delete="sessionDialogs?.openDelete($event, { fallbackMode: 'recent' })"
+        <SessionItem
+          :session="session"
+          :is-active="sessionId === session.id"
+          :streaming="chatStore.isSessionStreaming(currentBotId, session.id)"
+          @select="handleSelect"
+          @open-new-tab="handleOpenNewTab"
+          @rename="sessionDialogs?.openRename($event)"
+          @delete="sessionDialogs?.openDelete($event, { fallbackMode: 'recent' })"
+        />
+      </div>
+
+      <div
+        v-if="showSentinel"
+        ref="loadMoreSentinel"
+        data-testid="load-more-sentinel"
+        class="h-px w-full"
+      />
+
+      <template v-if="loadingMoreSessions">
+        <div
+          v-for="(widthClass, index) in loadMoreSkeletonRows"
+          :key="`load-more-${index}`"
+          class="pb-[2px]"
+        >
+          <div class="flex min-h-[2.125rem] items-center rounded-[9px] px-3">
+            <Skeleton
+              :class="[sessionSkeletonBarClass, widthClass]"
             />
           </div>
-
-          <div
-            v-if="showSentinel"
-            ref="loadMoreSentinel"
-            data-testid="load-more-sentinel"
-            class="h-px w-full"
-          />
-
-          <template v-if="loadingMoreSessions">
-            <div
-              v-for="(widthClass, index) in loadMoreSkeletonRows"
-              :key="`load-more-${index}`"
-              class="pb-[2px]"
-            >
-              <div class="flex min-h-[2.125rem] items-center rounded-[9px] px-3">
-                <Skeleton
-                  :class="[sessionSkeletonBarClass, widthClass]"
-                />
-              </div>
-            </div>
-          </template>
-
-          <div
-            v-if="currentBotId && !loadingChats && visibleSessions.length === 0"
-            class="px-3 py-6 text-center text-xs text-muted-foreground"
-          >
-            {{ t('chat.noSessions') }}
-          </div>
-
-          <template v-if="loadingChats && visibleSessions.length === 0">
-            <div
-              v-for="(widthClass, index) in initialSkeletonRows"
-              :key="`initial-${index}`"
-              class="pb-[2px]"
-            >
-              <div class="flex min-h-[2.125rem] items-center rounded-[9px] px-3">
-                <Skeleton
-                  :class="[sessionSkeletonBarClass, widthClass]"
-                />
-              </div>
-            </div>
-          </template>
         </div>
+      </template>
+
+      <div
+        v-if="currentBotId && !loadingChats && visibleSessions.length === 0"
+        class="px-3 py-6 text-center text-xs text-muted-foreground"
+      >
+        {{ t('chat.noSessions') }}
       </div>
+
+      <template v-if="loadingChats && visibleSessions.length === 0">
+        <div
+          v-for="(widthClass, index) in initialSkeletonRows"
+          :key="`initial-${index}`"
+          class="pb-[2px]"
+        >
+          <div class="flex min-h-[2.125rem] items-center rounded-[9px] px-3">
+            <Skeleton
+              :class="[sessionSkeletonBarClass, widthClass]"
+            />
+          </div>
+        </div>
+      </template>
     </div>
 
     <SessionDialogs ref="sessionDialogs" />
@@ -93,7 +89,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, watch } from 'vue'
+import { ref, computed, nextTick, toRef, watch } from 'vue'
 import { ChevronDown } from 'lucide-vue-next'
 import { useLocalStorage } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
@@ -107,7 +103,12 @@ import { useSidebarInfiniteScroll } from './use-sidebar-infinite-scroll'
 import { TextButton, Skeleton } from '@felinic/ui'
 import SessionItem from './session-item.vue'
 import SessionDialogs from './session-dialogs.vue'
-import '@/styles/sidebar-scroll.css'
+
+// The sessions panel owns the scrollport shared with Folders; Recents pages
+// against it (sentinel root + reset-to-top) instead of nesting its own.
+const props = defineProps<{
+  scrollEl: HTMLElement | null
+}>()
 
 const { t } = useI18n()
 const chatStore = useChatStore()
@@ -175,7 +176,7 @@ const visibleSessions = computed(() => {
   return sortByRecency(unbound)
 })
 
-const scrollEl = ref<HTMLElement | null>(null)
+const scrollEl = toRef(props, 'scrollEl')
 const {
   loadMoreSentinel,
   showSentinel,

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -942,6 +942,7 @@
     "untitledSession": "Untitled Session",
     "noSessions": "No sessions yet",
     "sessionsLoadFailed": "Failed to load conversations",
+    "showMoreSessions": "Show more",
     "recents": "Recents",
     "quickActions": "Quick Actions",
     "scheduledJobs": "Scheduled Jobs",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -913,6 +913,7 @@
     "untitledSession": "無題のセッション",
     "noSessions": "セッションはまだありません",
     "sessionsLoadFailed": "会話一覧の読み込みに失敗しました",
+    "showMoreSessions": "もっと見る",
     "recents": "最近",
     "quickActions": "クイックアクション",
     "scheduledJobs": "スケジュールされたジョブ",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -942,6 +942,7 @@
     "untitledSession": "未命名会话",
     "noSessions": "暂无会话",
     "sessionsLoadFailed": "会话列表加载失败",
+    "showMoreSessions": "显示更多",
     "recents": "最近",
     "quickActions": "快捷操作",
     "scheduledJobs": "定时任务",

--- a/apps/web/src/styles/sidebar-scroll.css
+++ b/apps/web/src/styles/sidebar-scroll.css
@@ -1,12 +1,12 @@
 /* Sidebar-specific native scroll bar: narrow so it doesn't dominate the tight
  * list panes. The 2px transparent border + padding-box clip insets the thumb
  * to a ~4px sliver — visible on hover/scroll but not a constant presence.
- * Callers keep extra right padding (e.g. recents' pr-3) so hover chips stay
- * off the bar.
+ * Callers keep extra right padding (e.g. panel-sessions' pr-1) so hover chips
+ * stay off the bar.
  *
  * Deliberately a shared stylesheet, NOT a `<style scoped>` block: the class is
- * used by BOTH sidebar/recents.vue and sidebar/panel-schedule.vue. It first
- * lived in recents' scoped style, which silently did nothing for
+ * used by BOTH sidebar/panel-sessions.vue and sidebar/panel-schedule.vue. It
+ * first lived in recents' scoped style, which silently did nothing for
  * panel-schedule (scoped selectors only match the defining component's DOM).
  * Import this file from every component that puts `sidebar-scroll` on a
  * scroll container.


### PR DESCRIPTION
## Problem

The Folders section owned its own scrollport with a `max-h-[min(14rem,45%)]` cap. With more than a couple of folders — or a single expanded one — everything past that cap collapsed into a short inner scroll strip nested inside the sidebar's own scroll. Folders read as items inside a box instead of peers of Recents, and reaching a chat meant driving two scrollbars.

## Change

**One scrollport.** `panel-sessions.vue` now owns a single `overflow-y-auto` container holding both Folders and Recents; both sections render as plain flow inside it. Overflow is handled once, for the whole list, so every folder sits at the same level as Recents on one continuous timeline.

**Recents stops nesting a scrollport.** It takes the shared element as a `scrollEl` prop and observes its load-more sentinel (and reset-to-top on bot switch) against it, so cursor pagination is unchanged.

**8 rows per folder, then Show more.** Without the height cap, a folder with a long history would push every folder below it — and Recents — out of reach, and the old sentinel-based prefetch made that worse by growing whenever the tail neared the viewport. Each expanded folder now renders 8 rows plus a `Show more` that reveals another 8. A fetched page is 50 rows, so this is usually a local reveal; the network is only touched once the revealed window runs past what has been fetched.

## Alignment

The scrollbar moves to the shared container (`pr-1`) while each section keeps its `px-2`, so the row hover fill still ends at 12px and row text still starts at 8px + the 11px gutter — identical to before. `Show more` / `Retry` use a 5px inset that, with the text button's own 6px padding, lands their labels on the session titles' x.

## Drive-by

`folder-sessions-list.vue` called `t('chat.retry')`, a key that has never existed — the retry row rendered the raw key. Now `chat.actions.retry`.

## Verification

`vue-tsc`, ESLint, `scripts/check-ui-contract.mjs`, and the sidebar + i18n Vitest suites all pass. (The `packages/ui` `#/` alias errors and the pre-existing `recents.vue` TS6133 are unchanged — confirmed by running typecheck against the file at `HEAD`.)

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
