### PR TITLE
fix(connectors): make the connect dialog cancellable during OAuth

### DIFF
--- a/apps/web/src/composables/useConnectorOAuth.test.ts
+++ b/apps/web/src/composables/useConnectorOAuth.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getConnector: vi.fn(),
+}))
+
+vi.mock('@memohai/sdk', () => ({
+  getBotsByBotIdConnectorsByConnectionId: mocks.getConnector,
+}))
+
+import { isConnectorOAuthCancelled, waitForConnectorOAuth } from './useConnectorOAuth'
+
+describe('waitForConnectorOAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getConnector.mockResolvedValue({ data: { status: 'pending' } })
+  })
+
+  it('resolves once the connection turns active', async () => {
+    mocks.getConnector.mockResolvedValue({ data: { status: 'active' } })
+    await expect(waitForConnectorOAuth('bot', 'conn', null)).resolves.toBeUndefined()
+  })
+
+  it('rejects as cancelled when the caller aborts mid-wait', async () => {
+    const controller = new AbortController()
+    const popup = { closed: false, close: vi.fn() } as unknown as Window
+
+    const wait = waitForConnectorOAuth('bot', 'conn', popup, controller.signal)
+    // Let the first poll run and settle on `pending` before cancelling, so the
+    // abort has to interrupt a wait that would otherwise keep polling.
+    await vi.waitFor(() => expect(mocks.getConnector).toHaveBeenCalled())
+    controller.abort()
+
+    await expect(wait).rejects.toSatisfy(isConnectorOAuthCancelled)
+    expect(popup.close).toHaveBeenCalled()
+  })
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    await expect(
+      waitForConnectorOAuth('bot', 'conn', null, AbortSignal.abort()),
+    ).rejects.toSatisfy(isConnectorOAuthCancelled)
+    expect(mocks.getConnector).not.toHaveBeenCalled()
+  })
+
+  it('does not treat a real failure as a cancellation', async () => {
+    mocks.getConnector.mockResolvedValue({ data: { status: 'authorization_failed' } })
+    await expect(waitForConnectorOAuth('bot', 'conn', null)).rejects.toSatisfy(
+      error => !isConnectorOAuthCancelled(error),
+    )
+  })
+})

--- a/apps/web/src/composables/useConnectorOAuth.ts
+++ b/apps/web/src/composables/useConnectorOAuth.ts
@@ -2,6 +2,8 @@ import { getBotsByBotIdConnectorsByConnectionId } from '@memohai/sdk'
 
 const oauthTimeoutMs = 120_000
 
+const oauthCancelledCode = 'oauth_cancelled'
+
 // The OAuth helpers below throw bare internal codes; map them to i18n keys at
 // the toast site so Error.message is never surfaced verbatim to the user.
 export function connectorOAuthErrorKey(error: unknown): string | null {
@@ -9,6 +11,12 @@ export function connectorOAuthErrorKey(error: unknown): string | null {
   if (error.message === 'oauth_popup_blocked') return 'connectors.oauthPopupBlocked'
   if (error.message === 'oauth_failed') return 'connectors.oauthFailed'
   return null
+}
+
+// A caller-initiated abort is not a failure: the caller swallows it instead of
+// toasting, so it needs to be distinguishable from a real 'oauth_failed'.
+export function isConnectorOAuthCancelled(error: unknown): boolean {
+  return error instanceof Error && error.message === oauthCancelledCode
 }
 
 export function prepareConnectorOAuthPopup(loadingMessage: string): Window | null {
@@ -50,6 +58,10 @@ export function waitForConnectorOAuth(
   botId: string,
   connectionId: string,
   popup: Window | null,
+  // Without a signal the wait can only end by success, by the popup closing,
+  // or by the 2-minute timeout — none of which the user can trigger from the
+  // page they came back to. The signal is how Cancel/Esc/overlay-click end it.
+  signal?: AbortSignal,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     let completed = false
@@ -60,9 +72,15 @@ export function waitForConnectorOAuth(
       if (completed) return
       completed = true
       if (pollTimer) clearTimeout(pollTimer)
+      signal?.removeEventListener('abort', onAbort)
       popup?.close()
       if (error) reject(new Error(error))
       else resolve()
+    }
+
+    // Hoisted so finish() above can unsubscribe it.
+    function onAbort() {
+      finish(oauthCancelledCode)
     }
 
     const poll = async () => {
@@ -94,6 +112,11 @@ export function waitForConnectorOAuth(
       pollTimer = setTimeout(() => void poll(), 2000)
     }
 
+    if (signal?.aborted) {
+      finish(oauthCancelledCode)
+      return
+    }
+    signal?.addEventListener('abort', onAbort)
     void poll()
   })
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -3283,6 +3283,7 @@
     "browse": "Browse connectors",
     "connect": "Connect",
     "connectTitle": "Connect {name}",
+    "awaitingAuthorization": "Waiting for authorization…",
     "unavailable": "Unavailable",
     "unknown": "Unknown connector",
     "emptyTitle": "No connectors yet",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -3268,6 +3268,7 @@
     "browse": "コネクターを見る",
     "connect": "接続",
     "connectTitle": "{name} に接続",
+    "awaitingAuthorization": "認証を待っています…",
     "unavailable": "利用不可",
     "unknown": "不明なコネクター",
     "emptyTitle": "コネクターはまだありません",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -3283,6 +3283,7 @@
     "browse": "浏览连接器",
     "connect": "连接",
     "connectTitle": "连接 {name}",
+    "awaitingAuthorization": "等待授权…",
     "unavailable": "暂不可用",
     "unknown": "未知连接器",
     "emptyTitle": "还没有连接器",

--- a/apps/web/src/pages/supermarket/components/connect-connector-dialog.vue
+++ b/apps/web/src/pages/supermarket/components/connect-connector-dialog.vue
@@ -107,7 +107,7 @@
         <DialogClose as-child>
           <Button
             variant="outline"
-            :disabled="connecting"
+            :disabled="phase === 'submitting'"
           >
             {{ t('common.cancel') }}
           </Button>
@@ -115,9 +115,9 @@
         <Button
           form="connector-connect-form"
           type="submit"
-          :loading="connecting"
+          :loading="phase !== 'idle'"
         >
-          {{ t('connectors.connect') }}
+          {{ phase === 'awaiting-oauth' ? t('connectors.awaitingAuthorization') : t('connectors.connect') }}
         </Button>
       </DialogFooter>
     </DialogPanel>
@@ -154,6 +154,8 @@ import {
   toast,
 } from '@felinic/ui'
 import {
+  deleteBotsByBotIdConnectorsByConnectionId,
+  getBotsByBotIdConnectorsByConnectionId,
   postBotsByBotIdConnectorsApiKey,
   postBotsByBotIdConnectorsOauth,
   type ConnectitAuthMethod,
@@ -162,6 +164,7 @@ import {
 import BotSelect from '@/components/bot-select/index.vue'
 import {
   connectorOAuthErrorKey,
+  isConnectorOAuthCancelled,
   openConnectorOAuthURL,
   prepareConnectorOAuthPopup,
   waitForConnectorOAuth,
@@ -276,15 +279,47 @@ const createCredentialMutation = useMutation({
   },
 })
 
-const connecting = ref(false)
+// 'submitting' is an un-undoable write in flight (a few hundred ms), so the
+// dialog stays locked for it. 'awaiting-oauth' waits on the user finishing the
+// flow in another window — up to the 2-minute poll timeout — and must stay
+// dismissable, or coming back to this page leaves a dialog nothing can close.
+const phase = ref<'idle' | 'submitting' | 'awaiting-oauth'>('idle')
+// Non-null while an attempt is in flight; aborting it is how a dismiss ends
+// the OAuth wait and keeps the resolved attempt from toasting afterwards.
+let attempt: AbortController | null = null
 
 function updateOpen(open: boolean) {
-  if (!open && connecting.value) return
+  if (!open) {
+    if (phase.value === 'submitting') return
+    attempt?.abort()
+  }
   emit('update:open', open)
 }
 
+// BeginOAuth creates the connection upstream before the user authorizes, so a
+// cancelled flow would otherwise leave a `pending` connector on the bot. Best
+// effort only: the user already walked away, and the connector page can still
+// disconnect a leftover row.
+async function discardPendingConnection(botId: string, connectionId: string) {
+  try {
+    const { data } = await getBotsByBotIdConnectorsByConnectionId({
+      path: { bot_id: botId, connection_id: connectionId },
+      throwOnError: true,
+    })
+    // The callback can land in the instant between the abort and this check;
+    // don't delete a connection that ended up working.
+    if (data?.status === 'active') return
+    await deleteBotsByBotIdConnectorsByConnectionId({
+      path: { bot_id: botId, connection_id: connectionId },
+      throwOnError: true,
+    })
+  } catch {
+    // Cleanup failures are not worth a toast on a dialog the user just closed.
+  }
+}
+
 async function connect() {
-  if (connecting.value) return
+  if (phase.value !== 'idle') return
   const method = selectedMethod.value
   const connectorType = props.connector?.type
   const oauthPopup = method?.type === 'oauth2'
@@ -297,7 +332,9 @@ async function connect() {
     toast.error(t('connectors.oauthPopupBlocked'))
     return
   }
-  connecting.value = true
+  const flow = new AbortController()
+  attempt = flow
+  phase.value = 'submitting'
   try {
     const validation = await form.validate()
     if (!validation.valid || !connectorType || !method?.key) {
@@ -336,8 +373,20 @@ async function connect() {
       })
       const connectionId = result.connection_id
       if (!result.authorization_url || !connectionId) throw new Error('oauth_failed')
+      if (flow.signal.aborted) {
+        // Dismissed while the create POST was still in flight.
+        void discardPendingConnection(botId, connectionId)
+        return
+      }
+      phase.value = 'awaiting-oauth'
       await openConnectorOAuthURL(result.authorization_url, oauthPopup)
-      await waitForConnectorOAuth(botId, connectionId, oauthPopup)
+      try {
+        await waitForConnectorOAuth(botId, connectionId, oauthPopup, flow.signal)
+      } catch (error) {
+        if (!isConnectorOAuthCancelled(error)) throw error
+        void discardPendingConnection(botId, connectionId)
+        return
+      }
     } else {
       await createCredentialMutation.mutateAsync({
         botId,
@@ -353,10 +402,17 @@ async function connect() {
     emit('connected', botId)
   } catch (error) {
     oauthPopup?.close()
+    if (flow.signal.aborted) return
     const oauthKey = connectorOAuthErrorKey(error)
     toast.error(oauthKey ? t(oauthKey) : resolveApiErrorMessage(error, t('connectors.connectFailed')))
   } finally {
-    connecting.value = false
+    if (flow.signal.aborted) oauthPopup?.close()
+    // Only the current attempt owns the phase — a reopened dialog may already
+    // have started a new one by the time a cancelled attempt unwinds.
+    if (attempt === flow) {
+      attempt = null
+      phase.value = 'idle'
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Problem

Installing a connector onto a bot, going through the authorization flow, then coming back to the page leaves the connect dialog pinned open: **Cancel is disabled, and Esc / overlay click / the corner close all do nothing.**

`connect()` used one `connecting` flag for the whole attempt, including the OAuth phase, where `waitForConnectorOAuth` polls the connection status for up to 2 minutes. During that window:

- `:disabled="connecting"` disabled the Cancel button, and
- `updateOpen` had `if (!open && connecting.value) return`, swallowing every dismiss path.

The poll's only user-reachable early exit is `popup.closed`, which does not help here:

- **Desktop** opens the URL via `openExternalUrl`, so `popup` is `null` and the check never fires — the dialog locks for the full 120s.
- **Web**, if the user leaves the auth popup open and switches back to the main window, keeps polling for the same reason.

## Fix

- **`useConnectorOAuth.ts`** — `waitForConnectorOAuth` takes an optional `AbortSignal`; aborting stops the poll, closes the auth popup and rejects with a distinct `oauth_cancelled` code. New `isConnectorOAuthCancelled()` so a dismiss is never toasted as `connectors.oauthFailed`.
- **`connect-connector-dialog.vue`** — `connecting` becomes `phase: 'idle' | 'submitting' | 'awaiting-oauth'`:
  - `submitting` (the short, un-undoable POST) still locks the dialog — unchanged semantics, now scoped to where it is actually justified.
  - `awaiting-oauth` keeps Cancel enabled and Esc / overlay / close working; dismissing aborts the attempt. The primary button reads “Waiting for authorization…” while it waits.
- **Cancel actually cancels.** `BeginOAuth` creates the connection upstream *before* the user authorizes, so an abandoned flow left a `pending` connector row on the bot. The dialog now deletes it best-effort — after re-reading its status, so a callback that landed in the same instant keeps its now-`active` connection instead of being deleted.
- New `connectors.awaitingAuthorization` string in `en` / `zh` / `ja`.

## Testing

- `vue-tsc --noEmit` clean; ESLint clean; `scripts/check-ui-contract.mjs` passes.
- New `apps/web/src/composables/useConnectorOAuth.test.ts` (4 tests): resolves on `active`, rejects as cancelled when aborted mid-wait (and closes the popup), rejects immediately on an already-aborted signal, and does not classify a real `authorization_failed` as a cancellation.

Not covered by automated tests: the real install → authorize → return-to-page path, which is what this PR is about.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
