### PR TITLE
chore(deps): bump Connect-It to v0.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Default host ports are shifted away from the production compose stack: Web `1808
 ### Connect-It
 
 The dev Compose files pull the pinned multi-architecture image
-`ghcr.io/memohai/connect-it:0.1.1`; no Connect-It source checkout is required.
+`ghcr.io/memohai/connect-it:0.2.0`; no Connect-It source checkout is required.
 The image serves the API, MCP endpoint, and admin UI from one container.
 Connect-It uses the same `memoh` PostgreSQL database as Memoh, with
 its independently migrated tables isolated in the `connect_it` schema. The

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -92,7 +92,7 @@ services:
   # Connect-It owns the connect_it schema and creates it on startup; it only
   # needs postgres, never Memoh's migrations.
   connect-it:
-    image: "${MEMOH_DEV_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.1.1}"
+    image: "${MEMOH_DEV_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.2.0}"
     container_name: memoh-dev-connect-it
     environment:
       DATABASE_URL: "postgres://memoh:memoh123@postgres:5432/memoh?sslmode=disable&search_path=connect_it"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
   # Connect-It at startup and presented by the Memoh server as its bearer
   # token — the install script generates and persists all of these values.
   connect-it:
-    image: "${MEMOH_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.1.1}"
+    image: "${MEMOH_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.2.0}"
     container_name: memoh-connect-it
     profiles: [connectors]
     environment:


### PR DESCRIPTION
## Summary

- pin the development and production Compose defaults to Connect-It `0.2.0`
- update the contributor documentation to match the deployed image version

Release: https://github.com/memohai/connect-it/releases/tag/v0.2.0

## Validation

- `docker compose -f devenv/docker-compose.yml config --quiet`
- `MEMOH_INTERNAL_RPC_SHARED_SECRET=validation-only docker compose --profile connectors -f docker-compose.yml config --quiet`
- verified both rendered configurations resolve to `ghcr.io/memohai/connect-it:0.2.0`
- `git diff --check`

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
