### PR TITLE
fix(runtime): preserve context values and restore ACP tool discovery

### DIFF
--- a/internal/agent/application/runtime_decision.go
+++ b/internal/agent/application/runtime_decision.go
@@ -208,11 +208,13 @@ func implicitDecisionControlID(commandType, decisionID string) string {
 // handleRuntimeDecisionCommand commits on the routed-command deadline, then
 // continues independently on the owning run. The command result therefore
 // means "the decision was durably accepted", not "the model finished".
+//
+//nolint:contextcheck // the continuation is rooted in the owning run, not the acknowledgement request.
 func (s *Service) handleRuntimeDecisionCommand(ctx context.Context, command sessionruntime.Command) error {
 	if s == nil || s.decisionRuntime == nil {
 		return errors.New("runtime decision handler is not configured")
 	}
-	runCtx, runCancel, err := s.decisionRuntime.DecisionContinuationContext(ctx, command)
+	runCtx, runCancel, err := s.decisionRuntime.DecisionContinuationContext(command)
 	if err != nil {
 		return err
 	}

--- a/internal/agent/runtime/acp/client/client_test.go
+++ b/internal/agent/runtime/acp/client/client_test.go
@@ -322,12 +322,15 @@ func TestSessionCloseRequiresAdvertisedCapability(t *testing.T) {
 }
 
 func TestSessionCloseUsesAdvertisedCapability(t *testing.T) {
+	type contextKey struct{}
+
 	runner, agentPath := newSessionResumeTestRunner(t)
 	capturePath := filepath.Join(t.TempDir(), "close")
 	t.Setenv("MEMOH_ACP_FAKE_AGENT_CLOSE", "1")
 	t.Setenv("MEMOH_ACP_FAKE_AGENT_CAPTURE_CLOSE_FILE", capturePath)
 
-	sess, err := runner.StartSession(context.Background(), StartRequest{
+	startCtx := context.WithValue(context.Background(), contextKey{}, "session-scope")
+	sess, err := runner.StartSession(startCtx, StartRequest{
 		AgentID:     acpprofile.AgentCodexID,
 		BotID:       "bot-1",
 		ProjectPath: "/data/project",
@@ -336,6 +339,9 @@ func TestSessionCloseUsesAdvertisedCapability(t *testing.T) {
 	}, nil)
 	if err != nil {
 		t.Fatalf("StartSession() error = %v", err)
+	}
+	if got := sess.lifecycleCtx.Value(contextKey{}); got != "session-scope" {
+		t.Fatalf("session lifecycle context value = %v, want session-scope", got)
 	}
 	if err := sess.Close(); err != nil {
 		t.Fatalf("Close() error = %v", err)

--- a/internal/agent/runtime/acp/client/process.go
+++ b/internal/agent/runtime/acp/client/process.go
@@ -72,16 +72,17 @@ type processOptions struct {
 }
 
 type bridgeProcess struct {
-	stream   *bridge.ExecStream
-	stdin    *io.PipeWriter
-	stdout   *io.PipeReader
-	tail     *stderrTail
-	done     chan struct{}
-	env      []string
-	toolEnv  []string
-	unsetEnv []string
-	lease    *runtimeLease
-	logger   *slog.Logger
+	stream       *bridge.ExecStream
+	stdin        *io.PipeWriter
+	stdout       *io.PipeReader
+	tail         *stderrTail
+	done         chan struct{}
+	lifecycleCtx context.Context
+	env          []string
+	toolEnv      []string
+	unsetEnv     []string
+	lease        *runtimeLease
+	logger       *slog.Logger
 
 	stateMu      sync.Mutex
 	activated    bool
@@ -158,6 +159,7 @@ func startBridgeProcess(ctx context.Context, client *bridge.Client, command stri
 		stdout:       stdoutR,
 		tail:         &stderrTail{},
 		done:         make(chan struct{}),
+		lifecycleCtx: ctx,
 		env:          append([]string(nil), env...),
 		toolEnv:      append([]string(nil), lease.toolEnv...),
 		unsetEnv:     append([]string(nil), lease.unsetEnv...),
@@ -416,23 +418,28 @@ func (p *bridgeProcess) Activate() {
 	p.stateMu.Lock()
 	if !p.activated {
 		p.activated = true
-		go p.syncLoop()
+		go p.syncLoop(runtimeSyncInterval)
 	}
 	p.stateMu.Unlock()
 }
 
-func (p *bridgeProcess) syncLoop() {
-	if p == nil || p.lease == nil {
+func (p *bridgeProcess) syncLoop(interval time.Duration) {
+	if p == nil || p.lease == nil || p.lifecycleCtx == nil {
 		return
 	}
-	ticker := time.NewTicker(runtimeSyncInterval)
+	if interval <= 0 {
+		interval = runtimeSyncInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-p.done:
 			return
+		case <-p.lifecycleCtx.Done():
+			return
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(p.lifecycleCtx, 10*time.Second)
 			err := p.lease.syncLiveState(ctx)
 			cancel()
 			if errors.Is(err, ErrRuntimeSyncGenerationStale) {

--- a/internal/agent/runtime/acp/client/process_test.go
+++ b/internal/agent/runtime/acp/client/process_test.go
@@ -477,6 +477,45 @@ func TestStartBridgeProcessCanRunWithoutBridgeHardTimeout(t *testing.T) {
 	assertEnvHas(t, processRecord.Env, "CODEX_HOME="+path.Join(proc.lease.root, "state"))
 }
 
+func TestSyncLoopKeepsContext(t *testing.T) {
+	type contextKey struct{}
+
+	lifeCtx, cancel := context.WithCancel(
+		context.WithValue(context.Background(), contextKey{}, "runtime-scope"),
+	)
+	observed := make(chan context.Context, 1)
+	var observeOnce sync.Once
+	proc := &bridgeProcess{
+		done:         make(chan struct{}),
+		lifecycleCtx: lifeCtx,
+		lease: &runtimeLease{runtimeSyncGuard: func(ctx context.Context, sync func(context.Context) error) error {
+			observeOnce.Do(func() { observed <- ctx })
+			return sync(ctx)
+		}},
+	}
+	loopDone := make(chan struct{})
+	go func() {
+		proc.syncLoop(time.Millisecond)
+		close(loopDone)
+	}()
+
+	select {
+	case ctx := <-observed:
+		if got := ctx.Value(contextKey{}); got != "runtime-scope" {
+			t.Fatalf("periodic sync context value = %v, want runtime-scope", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("periodic sync did not run")
+	}
+
+	cancel()
+	select {
+	case <-loopDone:
+	case <-time.After(time.Second):
+		t.Fatal("periodic sync did not stop with the process lifecycle")
+	}
+}
+
 func TestStartBridgeProcessUsesContainerToolkitFallback(t *testing.T) {
 	client, server := newRecordingBridgeClient(t)
 	server.setExitCode("command -v codex-acp >/dev/null 2>&1", 127)

--- a/internal/agent/runtime/acp/client/session.go
+++ b/internal/agent/runtime/acp/client/session.go
@@ -142,6 +142,7 @@ type Session struct {
 	imagePromptSupported      bool
 	closeSessionSupported     bool
 	defaultSink               EventSink
+	lifecycleCtx              context.Context
 	cancel                    context.CancelFunc
 	reverseHTTPStop           func()
 
@@ -403,6 +404,7 @@ func (r *Runner) StartSession(ctx context.Context, req StartRequest, sink EventS
 		imagePromptSupported:      initResp.AgentCapabilities.PromptCapabilities.Image,
 		closeSessionSupported:     initResp.AgentCapabilities.SessionCapabilities.Close != nil,
 		defaultSink:               sink,
+		lifecycleCtx:              lifecycleCtx,
 		cancel:                    cancel,
 		reverseHTTPStop:           toolHTTPStop,
 	}
@@ -1096,6 +1098,7 @@ func (s *Session) close(force bool) error {
 	cancel := s.cancel
 	reverseHTTPStop := s.reverseHTTPStop
 	closeSessionSupported := s.closeSessionSupported
+	lifecycleCtx := s.lifecycleCtx
 	promptCancel := s.promptCancel
 	promptDone := s.promptDone
 	s.mu.Unlock()
@@ -1135,7 +1138,10 @@ func (s *Session) close(force bool) error {
 		return closeErr
 	}
 	if closeSessionSupported && conn != nil && sessionID != "" {
-		ctx, cancelClose := context.WithTimeout(context.Background(), 2*time.Second)
+		if lifecycleCtx == nil {
+			lifecycleCtx = context.Background()
+		}
+		ctx, cancelClose := context.WithTimeout(context.WithoutCancel(lifecycleCtx), 2*time.Second)
 		_, _ = conn.CloseSession(ctx, acp.CloseSessionRequest{SessionId: sessionID})
 		cancelClose()
 	}

--- a/internal/agent/runtime/acp/session_pool.go
+++ b/internal/agent/runtime/acp/session_pool.go
@@ -2161,6 +2161,9 @@ func (p *SessionPool) closeHandle(h *runtimeHandle) error {
 	if sessionID == "" {
 		sessionID = activeSession
 	}
+	if cleanupParent == nil && sessionID != "" {
+		cleanupParent = p.decisionCleanupRoot(h.botID, sessionID)
+	}
 	p.cancelHandlePendingDecisions(cleanupParent, h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
 	h.op.Lock()
 	closeErr := p.teardown(h)
@@ -2249,6 +2252,9 @@ func (p *SessionPool) teardown(h *runtimeHandle) error {
 	if sessionID == "" {
 		sessionID = activeSession
 	}
+	if cleanupParent == nil && sessionID != "" {
+		cleanupParent = p.decisionCleanupRoot(h.botID, sessionID)
+	}
 	p.cancelHandlePendingDecisions(cleanupParent, h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
 
 	if cancel != nil {
@@ -2277,6 +2283,15 @@ const (
 	decisionCleanupPre decisionCleanupPhase = iota
 	decisionCleanupFinal
 )
+
+// decisionCleanupRoot is the single fail-open boundary for a malformed handle
+// that has pending decisions but no owner context. The cleanup loses values,
+// but skipping it would leave approvals or questions stranded in the UI.
+func (p *SessionPool) decisionCleanupRoot(botID, sessionID string) context.Context {
+	p.logger.Error("pending ACP decision cleanup without runtime context",
+		slog.String("bot_id", botID), slog.String("session_id", sessionID))
+	return context.Background()
+}
 
 func (p *SessionPool) cancelHandlePendingDecisions(parent context.Context, h *runtimeHandle, sessionID string, fence runtimefence.Fence, phase decisionCleanupPhase, reason string) {
 	if p == nil || h == nil {
@@ -2308,7 +2323,7 @@ func (p *SessionPool) cancelHandlePendingDecisions(parent context.Context, h *ru
 		return
 	}
 	if parent == nil {
-		p.logger.Error("skip pending ACP decision cleanup without runtime context",
+		p.logger.Error("skip pending ACP decision cleanup without normalized context",
 			slog.String("bot_id", h.botID), slog.String("session_id", sessionID))
 		return
 	}
@@ -2329,7 +2344,7 @@ func (p *SessionPool) cancelPendingDecisions(parent context.Context, botID, sess
 		return
 	}
 	if parent == nil {
-		p.logger.Error("skip pending ACP decision cleanup without parent context",
+		p.logger.Error("skip pending ACP decision cleanup without normalized parent context",
 			slog.String("bot_id", botID), slog.String("session_id", sessionID))
 		return
 	}

--- a/internal/agent/runtime/acp/session_pool.go
+++ b/internal/agent/runtime/acp/session_pool.go
@@ -197,9 +197,12 @@ type runtimeHandle struct {
 	hadPrompt                bool
 	decisionPreCleanupOnce   sync.Once
 	decisionFinalCleanupOnce sync.Once
-	closeStarted             bool
-	closeDone                chan struct{}
-	closeErr                 error
+	// decisionFallbackOnce keeps the malformed-handle report to one log line
+	// even though closeHandle and teardown both reach the cleanup path.
+	decisionFallbackOnce sync.Once
+	closeStarted         bool
+	closeDone            chan struct{}
+	closeErr             error
 	// nativeHead names the publication head this process's native conversation
 	// corresponds to. It advances locally the moment a turn's state is staged
 	// (checkpoint) or a snapshot-incapable turn completes (reset). The database
@@ -2162,7 +2165,7 @@ func (p *SessionPool) closeHandle(h *runtimeHandle) error {
 		sessionID = activeSession
 	}
 	if cleanupParent == nil && sessionID != "" {
-		cleanupParent = p.decisionCleanupRoot(h.botID, sessionID)
+		cleanupParent = p.fallbackDecisionCleanupRoot(h, sessionID)
 	}
 	p.cancelHandlePendingDecisions(cleanupParent, h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
 	h.op.Lock()
@@ -2253,7 +2256,7 @@ func (p *SessionPool) teardown(h *runtimeHandle) error {
 		sessionID = activeSession
 	}
 	if cleanupParent == nil && sessionID != "" {
-		cleanupParent = p.decisionCleanupRoot(h.botID, sessionID)
+		cleanupParent = p.fallbackDecisionCleanupRoot(h, sessionID)
 	}
 	p.cancelHandlePendingDecisions(cleanupParent, h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
 
@@ -2284,12 +2287,15 @@ const (
 	decisionCleanupFinal
 )
 
-// decisionCleanupRoot is the single fail-open boundary for a malformed handle
-// that has pending decisions but no owner context. The cleanup loses values,
-// but skipping it would leave approvals or questions stranded in the UI.
-func (p *SessionPool) decisionCleanupRoot(botID, sessionID string) context.Context {
-	p.logger.Error("pending ACP decision cleanup without runtime context",
-		slog.String("bot_id", botID), slog.String("session_id", sessionID))
+// fallbackDecisionCleanupRoot is the single fail-open boundary for a malformed
+// handle that has pending decisions but no owner context. The cleanup loses
+// values, but skipping it would leave approvals or questions stranded in the
+// UI. The report is logged once per handle.
+func (p *SessionPool) fallbackDecisionCleanupRoot(h *runtimeHandle, sessionID string) context.Context {
+	h.decisionFallbackOnce.Do(func() {
+		p.logger.Error("pending ACP decision cleanup without runtime context",
+			slog.String("bot_id", h.botID), slog.String("session_id", sessionID))
+	})
 	return context.Background()
 }
 

--- a/internal/agent/runtime/acp/session_pool.go
+++ b/internal/agent/runtime/acp/session_pool.go
@@ -174,6 +174,9 @@ type runtimeHandle struct {
 	sessionStateLocator   acpprofile.RuntimeSessionLocator
 	sessionStateCursor    client.SessionStateCursor
 	runtimeConfigEpoch    RuntimeConfigEpoch
+	// ownerCtx is a value-only context retained for detached runtime cleanup.
+	// Its cancellation and deadline do not describe request liveness.
+	ownerCtx context.Context
 
 	// op serializes operations (start, prompt, runtime config, bind, close).
 	op sync.Mutex
@@ -415,7 +418,7 @@ func (p *SessionPool) CreateRuntime(ctx context.Context, input CreateRuntimeInpu
 		return RuntimeStatus{}, runtimeOwnerMissingError()
 	}
 
-	p.reapIdle(time.Now()) //nolint:contextcheck // reaper close uses its own background ctx.
+	p.reapIdle(time.Now()) //nolint:contextcheck // reaper uses each handle's owner context.
 
 	h := &runtimeHandle{
 		id:                    newRuntimeID(),
@@ -424,6 +427,7 @@ func (p *SessionPool) CreateRuntime(ctx context.Context, input CreateRuntimeInpu
 		agentID:               agentID,
 		projectPath:           projectPath,
 		runtimeOwnerAccountID: runtimeOwnerAccountID,
+		ownerCtx:              context.WithoutCancel(ctx),
 		status:                stateStarting,
 		lastActive:            time.Now(),
 	}
@@ -458,7 +462,7 @@ func (p *SessionPool) CreateRuntime(ctx context.Context, input CreateRuntimeInpu
 	for _, victim := range victims {
 		p.logger.Info("evicting oldest unbound ACP runtime",
 			slog.String("runtime_id", victim.id), slog.String("bot_id", botID))
-		p.tryCloseIdle(victim, 0) //nolint:contextcheck // lifecycle close uses background ctx.
+		p.tryCloseIdle(victim, 0) //nolint:contextcheck // lifecycle close uses the handle owner context.
 	}
 
 	h.op.Lock()
@@ -515,7 +519,10 @@ func (p *SessionPool) unboundBudgetLocked(botID string) ([]*runtimeHandle, error
 // session's prompts reuse the warm process. Returns ErrRuntimeBindRejected
 // when the runtime cannot serve this session; callers fall back to a cold
 // start and must not treat that as fatal.
-func (p *SessionPool) BindRuntime(botID, runtimeID, sessionID, agentID, projectPath, runtimeOwnerAccountID string) error {
+func (p *SessionPool) BindRuntime(ctx context.Context, botID, runtimeID, sessionID, agentID, projectPath, runtimeOwnerAccountID string) error {
+	if ctx == nil {
+		return errors.New("runtime bind context is required")
+	}
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
 		return errors.New("session_id is required")
@@ -524,10 +531,13 @@ func (p *SessionPool) BindRuntime(botID, runtimeID, sessionID, agentID, projectP
 	if bindTimeout <= 0 {
 		bindTimeout = 30 * time.Second
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), bindTimeout)
+	// Binding is part of the synchronous create-session request: cancellation
+	// should stop reset/config waits. The stored owner context below detaches
+	// cancellation separately so later runtime cleanup can retain its values.
+	opCtx, cancel := context.WithTimeout(ctx, bindTimeout)
 	defer cancel()
 	if p.sessionRuntime != nil {
-		if err := p.sessionRuntime.WaitForHistoryReset(ctx, botID, sessionID); err != nil {
+		if err := p.sessionRuntime.WaitForHistoryReset(opCtx, botID, sessionID); err != nil {
 			return err
 		}
 	}
@@ -548,7 +558,7 @@ func (p *SessionPool) BindRuntime(botID, runtimeID, sessionID, agentID, projectP
 	// Waits out an in-flight model change on the runtime.
 	h.op.Lock()
 	defer h.op.Unlock()
-	actualEpoch, err := p.loadRuntimeConfigEpoch(ctx, h.botID, sessionID)
+	actualEpoch, err := p.loadRuntimeConfigEpoch(opCtx, h.botID, sessionID)
 	if err != nil {
 		return err
 	}
@@ -566,6 +576,7 @@ func (p *SessionPool) BindRuntime(botID, runtimeID, sessionID, agentID, projectP
 		// half-bound handle.
 		h.boundSession = sessionID
 		h.runtimeConfigEpoch = actualEpoch
+		h.ownerCtx = context.WithoutCancel(ctx)
 		h.lastActive = time.Now()
 	}
 	h.state.Unlock()
@@ -736,7 +747,7 @@ func (p *SessionPool) updateConfigOnHandle(
 	// accepted the value even though Memoh never received its new config
 	// snapshot. The cached state is no longer trustworthy, so rebuild rather
 	// than allowing the per-turn equality check to skip a required setter.
-	_ = p.teardown(h) //nolint:contextcheck // lifecycle close uses background ctx.
+	_ = p.teardown(h) //nolint:contextcheck // lifecycle close uses the handle owner context.
 	return RuntimeStatus{}, fmt.Errorf("%w: %w", ErrRuntimeConfigUpdateFailed, err)
 }
 
@@ -753,7 +764,7 @@ func (p *SessionPool) CloseRuntime(botID, runtimeID string) error {
 	if err != nil {
 		return err
 	}
-	return p.closeHandle(h) //nolint:contextcheck // lifecycle close uses background ctx.
+	return p.closeHandle(h) //nolint:contextcheck // lifecycle close uses the handle owner context.
 }
 
 // ResolveRuntimeToolContext resolves the trusted MCP tool context for a
@@ -801,7 +812,7 @@ func (p *SessionPool) prepareInput(ctx context.Context, input PromptInput) (Prom
 // Prompt sends a prompt to the runtime bound to input.SessionID, cold
 // starting (and binding) one when the session has no live runtime.
 //
-//nolint:contextcheck // lifecycle close intentionally uses background ctx.
+//nolint:contextcheck // lifecycle close uses the handle owner context.
 func (p *SessionPool) Prompt(ctx context.Context, input PromptInput) (client.PromptResult, error) {
 	input, err := p.prepareInput(ctx, input)
 	if err != nil {
@@ -818,7 +829,7 @@ func (p *SessionPool) Prompt(ctx context.Context, input PromptInput) (client.Pro
 
 	p.reapIdle(time.Now())
 	if input.ForceFreshRuntime {
-		_ = p.CloseSession(input.SessionID) //nolint:contextcheck // lifecycle close uses background ctx.
+		_ = p.CloseSession(input.SessionID) //nolint:contextcheck // lifecycle close uses the handle owner context.
 		// Discuss turns inject a complete bounded context into a fresh process.
 		// Resuming or checkpointing that temporary native session would duplicate
 		// context and could replace a normal chat checkpoint. Note the full
@@ -878,6 +889,7 @@ func (p *SessionPool) promptOnHandle(ctx context.Context, h *runtimeHandle, inpu
 	h.lastActive = time.Now()
 	toolCtx := toolSessionContext(ctx, input, h)
 	h.active = &toolCtx
+	h.ownerCtx = context.WithoutCancel(ctx)
 	h.hadPrompt = true
 	if toolCtx.RuntimeFence.Valid() {
 		h.persistenceFence = toolCtx.RuntimeFence
@@ -901,7 +913,7 @@ func (p *SessionPool) promptOnHandle(ctx context.Context, h *runtimeHandle, inpu
 		// A transport/protocol failure while mutating session config leaves the
 		// agent's effective state unknown. Drop the runtime so the next turn
 		// starts from a clean session.
-		_ = p.teardown(h) //nolint:contextcheck // lifecycle close uses background ctx.
+		_ = p.teardown(h) //nolint:contextcheck // lifecycle close uses the handle owner context.
 		return client.PromptResult{}, false, fmt.Errorf("%w: %w", ErrRuntimeConfigUpdateFailed, err)
 	}
 
@@ -981,14 +993,14 @@ func (p *SessionPool) promptOnHandle(ctx context.Context, h *runtimeHandle, inpu
 				// graceful teardown would otherwise block trying session/close behind
 				// that same writer and never reach the process close.
 				_ = sess.ForceClose() //nolint:contextcheck // forced lifecycle teardown must outlive the cancelled turn.
-				_ = p.teardown(h)     //nolint:contextcheck // lifecycle close uses background ctx.
+				_ = p.teardown(h)     //nolint:contextcheck // lifecycle close uses the handle owner context.
 			}
 			return result, false, err
 		}
 		// Prompt failures usually indicate the ACP process is in a bad state
 		// (transport hang, agent crash); drop the runtime so the next call
 		// starts fresh.
-		_ = p.teardown(h) //nolint:contextcheck // lifecycle close uses background ctx.
+		_ = p.teardown(h) //nolint:contextcheck // lifecycle close uses the handle owner context.
 		return result, false, err
 	}
 	staged, persistErr := p.persistSessionState(ctx, h, sess, input.RunID, toolCtx.RuntimeFence, result.StateReceipt)
@@ -1294,7 +1306,7 @@ func isPromptConfigSelectionError(err error) bool {
 
 // Ensure starts (or reuses) the runtime for a session without prompting it.
 //
-//nolint:contextcheck // lifecycle close intentionally uses background ctx.
+//nolint:contextcheck // lifecycle close uses the handle owner context.
 func (p *SessionPool) Ensure(ctx context.Context, input PromptInput) (RuntimeStatus, error) {
 	input, err := p.prepareInput(ctx, input)
 	if err != nil {
@@ -1311,7 +1323,7 @@ func (p *SessionPool) Ensure(ctx context.Context, input PromptInput) (RuntimeSta
 // SetModel switches the model of the runtime bound to a session, cold
 // starting one when needed.
 //
-//nolint:contextcheck // lifecycle close intentionally uses background ctx.
+//nolint:contextcheck // lifecycle close uses the handle owner context.
 func (p *SessionPool) SetModel(ctx context.Context, input PromptInput, modelID string) (RuntimeStatus, error) {
 	if strings.TrimSpace(modelID) == "" {
 		return RuntimeStatus{}, client.ErrModelIDRequired
@@ -1331,7 +1343,7 @@ func (p *SessionPool) SetModel(ctx context.Context, input PromptInput, modelID s
 // SetReasoning switches the reasoning effort of the runtime bound to a
 // session, cold starting one when needed.
 //
-//nolint:contextcheck // lifecycle close intentionally uses background ctx.
+//nolint:contextcheck // lifecycle close uses the handle owner context.
 func (p *SessionPool) SetReasoning(ctx context.Context, input PromptInput, effort string) (RuntimeStatus, error) {
 	if strings.TrimSpace(effort) == "" {
 		return RuntimeStatus{}, client.ErrReasoningEffortRequired
@@ -1351,7 +1363,7 @@ func (p *SessionPool) SetReasoning(ctx context.Context, input PromptInput, effor
 // SetMode switches the agent-declared mode of the runtime bound to a session,
 // cold starting one when needed. The mode remains process/session local.
 //
-//nolint:contextcheck // lifecycle close intentionally uses background ctx.
+//nolint:contextcheck // lifecycle close uses the handle owner context.
 func (p *SessionPool) SetMode(ctx context.Context, input PromptInput, modeID string) (RuntimeStatus, error) {
 	if strings.TrimSpace(modeID) == "" {
 		return RuntimeStatus{}, client.ErrModeIDRequired
@@ -1453,6 +1465,7 @@ func (p *SessionPool) runtimeForSession(ctx context.Context, input PromptInput) 
 				agentID:               agentID,
 				projectPath:           projectPath,
 				runtimeOwnerAccountID: runtimeOwnerAccountID,
+				ownerCtx:              context.WithoutCancel(ctx),
 				disableSessionState:   input.disableSessionState,
 				status:                stateStarting,
 				lastActive:            time.Now(),
@@ -1514,7 +1527,7 @@ func (p *SessionPool) runtimeForSession(ctx context.Context, input PromptInput) 
 			return h, nil
 		}
 		// Agent or project changed for this session: replace the runtime.
-		_ = p.closeHandle(h) //nolint:contextcheck // lifecycle close uses background ctx.
+		_ = p.closeHandle(h) //nolint:contextcheck // lifecycle close uses the handle owner context.
 		attempt++
 	}
 	return nil, errors.New("ACP runtime is restarting, retry the request")
@@ -1529,11 +1542,14 @@ type startOptions struct {
 // called with h.op held. On failure the handle is fully torn down (process,
 // maps, context) before returning.
 //
-//nolint:contextcheck // startup failure cleanup intentionally uses background ctx.
+//nolint:contextcheck // startup failure cleanup uses the handle owner context.
 func (p *SessionPool) startRuntime(ctx context.Context, h *runtimeHandle, opts startOptions) error {
 	startCtx, cancelStart := context.WithCancel(ctx)
 	defer cancelStart()
 	h.state.Lock()
+	if h.ownerCtx == nil {
+		h.ownerCtx = context.WithoutCancel(ctx)
+	}
 	if h.closed {
 		h.state.Unlock()
 		return errors.New("ACP runtime was closed during startup")
@@ -1908,7 +1924,7 @@ func (p *SessionPool) StartReaper(ctx context.Context) {
 		for {
 			select {
 			case <-ticker.C:
-				p.reapIdle(time.Now()) //nolint:contextcheck // reaper close uses its own background ctx.
+				p.reapIdle(time.Now()) //nolint:contextcheck // reaper uses each handle's owner context.
 			case <-ctx.Done():
 				return
 			}
@@ -1920,7 +1936,7 @@ func (p *SessionPool) StartReaper(ctx context.Context) {
 // session is deleted or its agent changes). Session IDs reaching this path
 // are database-validated by the caller.
 //
-//nolint:contextcheck // lifecycle close intentionally uses background ctx so cleanup runs after caller cancels.
+//nolint:contextcheck // lifecycle cleanup uses owner values after the caller cancels.
 func (p *SessionPool) CloseSession(sessionID string) error {
 	if p == nil {
 		return nil
@@ -2106,8 +2122,12 @@ func (p *SessionPool) closeHandle(h *runtimeHandle) error {
 	bound := h.boundSession
 	activeSession := ""
 	fence := h.persistenceFence
+	cleanupParent := h.ownerCtx
 	if h.active != nil {
 		activeSession = strings.TrimSpace(h.active.SessionID)
+		if h.active.RunContext != nil {
+			cleanupParent = h.active.RunContext
+		}
 		if h.active.RuntimeFence.Valid() {
 			fence = h.active.RuntimeFence
 		}
@@ -2141,7 +2161,7 @@ func (p *SessionPool) closeHandle(h *runtimeHandle) error {
 	if sessionID == "" {
 		sessionID = activeSession
 	}
-	p.cancelHandlePendingDecisions(h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
+	p.cancelHandlePendingDecisions(cleanupParent, h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
 	h.op.Lock()
 	closeErr := p.teardown(h)
 	h.op.Unlock()
@@ -2206,8 +2226,12 @@ func (p *SessionPool) teardown(h *runtimeHandle) error {
 	bound := h.boundSession
 	activeSession := ""
 	fence := h.persistenceFence
+	cleanupParent := h.ownerCtx
 	if h.active != nil {
 		activeSession = strings.TrimSpace(h.active.SessionID)
+		if h.active.RunContext != nil {
+			cleanupParent = h.active.RunContext
+		}
 		if h.active.RuntimeFence.Valid() {
 			fence = h.active.RuntimeFence
 		}
@@ -2225,7 +2249,7 @@ func (p *SessionPool) teardown(h *runtimeHandle) error {
 	if sessionID == "" {
 		sessionID = activeSession
 	}
-	p.cancelHandlePendingDecisions(h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
+	p.cancelHandlePendingDecisions(cleanupParent, h, sessionID, fence, decisionCleanupPre, "decision cancelled: ACP runtime closed before a response arrived")
 
 	if cancel != nil {
 		cancel()
@@ -2234,7 +2258,7 @@ func (p *SessionPool) teardown(h *runtimeHandle) error {
 	if sess != nil {
 		closeErr = sess.Close()
 	}
-	p.cancelHandlePendingDecisions(h, sessionID, fence, decisionCleanupFinal, "decision cancelled: ACP runtime closed before a response arrived")
+	p.cancelHandlePendingDecisions(cleanupParent, h, sessionID, fence, decisionCleanupFinal, "decision cancelled: ACP runtime closed before a response arrived")
 
 	if !closing {
 		p.mu.Lock()
@@ -2254,7 +2278,7 @@ const (
 	decisionCleanupFinal
 )
 
-func (p *SessionPool) cancelHandlePendingDecisions(h *runtimeHandle, sessionID string, fence runtimefence.Fence, phase decisionCleanupPhase, reason string) {
+func (p *SessionPool) cancelHandlePendingDecisions(parent context.Context, h *runtimeHandle, sessionID string, fence runtimefence.Fence, phase decisionCleanupPhase, reason string) {
 	if p == nil || h == nil {
 		return
 	}
@@ -2283,7 +2307,12 @@ func (p *SessionPool) cancelHandlePendingDecisions(h *runtimeHandle, sessionID s
 	default:
 		return
 	}
-	cleanupCtx := context.Background()
+	if parent == nil {
+		p.logger.Error("skip pending ACP decision cleanup without runtime context",
+			slog.String("bot_id", h.botID), slog.String("session_id", sessionID))
+		return
+	}
+	cleanupCtx := context.WithoutCancel(parent)
 	if fence.Valid() {
 		cleanupCtx = runtimefence.WithContext(cleanupCtx, fence)
 	}
@@ -2300,7 +2329,9 @@ func (p *SessionPool) cancelPendingDecisions(parent context.Context, botID, sess
 		return
 	}
 	if parent == nil {
-		parent = context.Background()
+		p.logger.Error("skip pending ACP decision cleanup without parent context",
+			slog.String("bot_id", botID), slog.String("session_id", sessionID))
+		return
 	}
 	var cleanup sync.WaitGroup
 	if approval, ok := p.approval.(interface {

--- a/internal/agent/runtime/acp/sessionpool_test.go
+++ b/internal/agent/runtime/acp/sessionpool_test.go
@@ -41,6 +41,9 @@ import (
 // injectRuntime registers a hand-built handle for tests that exercise
 // internal state without booting a real agent process.
 func injectRuntime(p *SessionPool, h *runtimeHandle) {
+	if h.ownerCtx == nil {
+		h.ownerCtx = context.Background()
+	}
 	p.mu.Lock()
 	p.runtimes[h.id] = h
 	if h.boundSession != "" {
@@ -570,6 +573,8 @@ func TestSessionPoolCreateRuntimeGeneratesIDAndReportsModels(t *testing.T) {
 }
 
 func TestSessionPoolBindRuntimeAttachesWarmProcessToSession(t *testing.T) {
+	type contextKey struct{}
+
 	t.Setenv("MEMOH_ACP_SESSION_POOL_FAKE_AGENT_MODELS", "1")
 	pool := newFakeScriptPool(t)
 
@@ -586,12 +591,29 @@ func TestSessionPoolBindRuntimeAttachesWarmProcessToSession(t *testing.T) {
 		t.Fatalf("SetRuntimeModel() error = %v", err)
 	}
 
-	if err := pool.BindRuntime("bot-1", created.RuntimeID, "session-1", acpprofile.AgentCodexID, "/data/project", "user-1"); err != nil {
+	bindCtx, cancelBind := context.WithCancel(
+		context.WithValue(context.Background(), contextKey{}, "bind-scope"),
+	)
+	defer cancelBind()
+	if err := pool.BindRuntime(bindCtx, "bot-1", created.RuntimeID, "session-1", acpprofile.AgentCodexID, "/data/project", "user-1"); err != nil {
 		t.Fatalf("BindRuntime() error = %v", err)
 	}
+	cancelBind()
 	h := pool.sessionHandle("session-1")
 	if h == nil || h.id != created.RuntimeID {
 		t.Fatalf("session index does not point at the bound runtime")
+	}
+	h.state.Lock()
+	ownerCtx := h.ownerCtx
+	h.state.Unlock()
+	if ownerCtx == nil {
+		t.Fatal("bound runtime owner context is nil")
+	}
+	if got := ownerCtx.Value(contextKey{}); got != "bind-scope" {
+		t.Fatalf("bound runtime owner context value = %v, want bind-scope", got)
+	}
+	if err := ownerCtx.Err(); err != nil {
+		t.Fatalf("bound runtime owner context error = %v, want request cancellation detached", err)
 	}
 
 	// The bound session reuses the warm process - including its model.
@@ -616,7 +638,7 @@ func TestSessionPoolBindRuntimeAttachesWarmProcessToSession(t *testing.T) {
 	}
 
 	// A bound runtime cannot be bound again.
-	if err := pool.BindRuntime("bot-1", created.RuntimeID, "session-2", acpprofile.AgentCodexID, "/data/project", "user-1"); !errors.Is(err, ErrRuntimeBindRejected) {
+	if err := pool.BindRuntime(context.Background(), "bot-1", created.RuntimeID, "session-2", acpprofile.AgentCodexID, "/data/project", "user-1"); !errors.Is(err, ErrRuntimeBindRejected) {
 		t.Fatalf("second BindRuntime() error = %v, want ErrRuntimeBindRejected", err)
 	}
 }
@@ -698,30 +720,30 @@ func TestSessionPoolBindRuntimeRejectsMismatches(t *testing.T) {
 		{"wrong project", "bot-2", "real", acpprofile.AgentCodexID, "/other", ErrRuntimeBindRejected},
 	}
 	for _, tc := range cases {
-		if err := pool.BindRuntime(tc.botID, pending.id, tc.sessionID, tc.agent, tc.path, "user-1"); !errors.Is(err, tc.wantErr) {
+		if err := pool.BindRuntime(context.Background(), tc.botID, pending.id, tc.sessionID, tc.agent, tc.path, "user-1"); !errors.Is(err, tc.wantErr) {
 			t.Fatalf("%s: BindRuntime() error = %v, want %v", tc.name, err, tc.wantErr)
 		}
 	}
-	if err := pool.BindRuntime("bot-2", "rt_missing", "real", acpprofile.AgentCodexID, "/data", "user-1"); !errors.Is(err, ErrRuntimeNotFound) {
+	if err := pool.BindRuntime(context.Background(), "bot-2", "rt_missing", "real", acpprofile.AgentCodexID, "/data", "user-1"); !errors.Is(err, ErrRuntimeNotFound) {
 		t.Fatalf("missing runtime: BindRuntime() error = %v, want ErrRuntimeNotFound", err)
 	}
 
 	// Session already served by another runtime.
 	other := &runtimeHandle{id: newRuntimeID(), botID: "bot-2", boundSession: "real", status: stateIdle}
 	injectRuntime(pool, other)
-	if err := pool.BindRuntime("bot-2", pending.id, "real", acpprofile.AgentCodexID, "/data", "user-1"); !errors.Is(err, ErrRuntimeBindRejected) {
+	if err := pool.BindRuntime(context.Background(), "bot-2", pending.id, "real", acpprofile.AgentCodexID, "/data", "user-1"); !errors.Is(err, ErrRuntimeBindRejected) {
 		t.Fatalf("occupied session: BindRuntime() error = %v, want ErrRuntimeBindRejected", err)
 	}
 
 	// A still-starting runtime (no live process yet) is not bindable.
 	starting := &runtimeHandle{id: newRuntimeID(), botID: "bot-2", agentID: acpprofile.AgentCodexID, projectPath: "/data", status: stateStarting}
 	injectRuntime(pool, starting)
-	if err := pool.BindRuntime("bot-2", starting.id, "real-2", acpprofile.AgentCodexID, "/data", "user-1"); !errors.Is(err, ErrRuntimeBindRejected) {
+	if err := pool.BindRuntime(context.Background(), "bot-2", starting.id, "real-2", acpprofile.AgentCodexID, "/data", "user-1"); !errors.Is(err, ErrRuntimeBindRejected) {
 		t.Fatalf("starting runtime: BindRuntime() error = %v, want ErrRuntimeBindRejected", err)
 	}
 
 	// Everything matching succeeds.
-	if err := pool.BindRuntime("bot-2", pending.id, "real-2", acpprofile.AgentCodexID, "/data", "user-1"); err != nil {
+	if err := pool.BindRuntime(context.Background(), "bot-2", pending.id, "real-2", acpprofile.AgentCodexID, "/data", "user-1"); err != nil {
 		t.Fatalf("matching BindRuntime() error = %v", err)
 	}
 	if pool.sessionHandle("real-2") != pending {
@@ -752,7 +774,7 @@ func TestSessionPoolOwnedGateHasZeroSideEffectsAcrossBots(t *testing.T) {
 	if err := pool.CloseRuntime("bot-1", foreign.id); !errors.Is(err, ErrRuntimeNotFound) {
 		t.Fatalf("CloseRuntime(cross bot) error = %v, want ErrRuntimeNotFound", err)
 	}
-	if err := pool.BindRuntime("bot-1", foreign.id, "my-session", acpprofile.AgentCodexID, "/data", "user-1"); !errors.Is(err, ErrRuntimeNotFound) {
+	if err := pool.BindRuntime(context.Background(), "bot-1", foreign.id, "my-session", acpprofile.AgentCodexID, "/data", "user-1"); !errors.Is(err, ErrRuntimeNotFound) {
 		t.Fatalf("BindRuntime(cross bot) error = %v, want ErrRuntimeNotFound", err)
 	}
 	if _, ok := pool.ResolveRuntimeToolContext("bot-1", foreign.id, "runtime-token-1"); ok {
@@ -2237,6 +2259,7 @@ func TestSessionPoolReapIdlePolicies(t *testing.T) {
 
 func TestCloseSessionCancelsPendingDecisions(t *testing.T) {
 	t.Parallel()
+	type contextKey struct{}
 
 	approval := &fakeToolApprovalService{}
 	userInput := &fakeUserInputCanceller{}
@@ -2250,6 +2273,7 @@ func TestCloseSessionCancelsPendingDecisions(t *testing.T) {
 		boundSession: "session-1",
 		lastActive:   time.Now(),
 		hadPrompt:    true,
+		ownerCtx:     context.WithValue(context.Background(), contextKey{}, "runtime-scope"),
 	})
 
 	if err := pool.CloseSession("session-1"); err != nil {
@@ -2263,6 +2287,12 @@ func TestCloseSessionCancelsPendingDecisions(t *testing.T) {
 	}
 	if approval.cancelCount != 2 || userInput.cancelCount != 2 {
 		t.Fatalf("decision cleanup count = approval:%d user_input:%d, want pre and final cleanup", approval.cancelCount, userInput.cancelCount)
+	}
+	if got := approval.cancelCtx.Value(contextKey{}); got != "runtime-scope" {
+		t.Fatalf("approval cleanup context value = %v, want runtime-scope", got)
+	}
+	if got := userInput.cancelCtx.Value(contextKey{}); got != "runtime-scope" {
+		t.Fatalf("user input cleanup context value = %v, want runtime-scope", got)
 	}
 }
 
@@ -2509,6 +2539,7 @@ func (s *recordingSessionStateStore) setHead(head SessionPublicationHead, found 
 }
 
 type fakeToolApprovalService struct {
+	cancelCtx       context.Context
 	cancelBotID     string
 	cancelSessionID string
 	cancelReason    string
@@ -2549,6 +2580,7 @@ func (f *fakeToolApprovalService) CancelPendingForSession(ctx context.Context, b
 	if f.cancelRelease != nil {
 		<-f.cancelRelease
 	}
+	f.cancelCtx = ctx
 	f.cancelBotID = botID
 	f.cancelSessionID = sessionID
 	f.cancelReason = reason
@@ -2558,6 +2590,7 @@ func (f *fakeToolApprovalService) CancelPendingForSession(ctx context.Context, b
 }
 
 type fakeUserInputCanceller struct {
+	cancelCtx       context.Context
 	cancelBotID     string
 	cancelSessionID string
 	cancelReason    string
@@ -2586,6 +2619,7 @@ func (f *fakeUserInputCanceller) CancelPendingForSession(ctx context.Context, bo
 	if f.cancelStarted != nil {
 		f.cancelStarted <- struct{}{}
 	}
+	f.cancelCtx = ctx
 	f.cancelBotID = botID
 	f.cancelSessionID = sessionID
 	f.cancelReason = reason

--- a/internal/agent/runtime/acp/sessionpool_test.go
+++ b/internal/agent/runtime/acp/sessionpool_test.go
@@ -2317,6 +2317,34 @@ func TestCloseSessionWithoutPromptDoesNotCancelPendingDecisions(t *testing.T) {
 	}
 }
 
+// A handle built without an owner context still has pending approvals and
+// questions to release. Cleanup degrades to a value-less context rather than
+// skipping, which would strand those decisions in the UI.
+func TestCloseSessionCancelsPendingDecisionsWithoutOwnerContext(t *testing.T) {
+	t.Parallel()
+
+	approval := &fakeToolApprovalService{}
+	userInput := &fakeUserInputCanceller{}
+	pool := newSessionPool(nil, nil, fakeBotGetter{})
+	pool.SetToolApprovalService(approval)
+	pool.SetUserInputService(userInput)
+	h := &runtimeHandle{
+		id: "rt-no-owner-ctx", botID: "bot-1", status: stateIdle,
+		boundSession: "session-1", lastActive: time.Now(), hadPrompt: true,
+	}
+	pool.mu.Lock()
+	pool.runtimes[h.id] = h
+	pool.bySession[h.boundSession] = h.id
+	pool.mu.Unlock()
+
+	if err := pool.CloseSession("session-1"); err != nil {
+		t.Fatalf("CloseSession() error = %v", err)
+	}
+	if approval.cancelCount != 2 || userInput.cancelCount != 2 {
+		t.Fatalf("decision cleanup count = approval:%d user_input:%d, want pre and final cleanup", approval.cancelCount, userInput.cancelCount)
+	}
+}
+
 func TestPendingDecisionCleanupRunsServicesIndependently(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/runtime/acp/sessionpool_test.go
+++ b/internal/agent/runtime/acp/sessionpool_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -2325,7 +2326,8 @@ func TestCloseSessionCancelsPendingDecisionsWithoutOwnerContext(t *testing.T) {
 
 	approval := &fakeToolApprovalService{}
 	userInput := &fakeUserInputCanceller{}
-	pool := newSessionPool(nil, nil, fakeBotGetter{})
+	logs := &countingLogHandler{}
+	pool := newSessionPool(slog.New(logs), nil, fakeBotGetter{})
 	pool.SetToolApprovalService(approval)
 	pool.SetUserInputService(userInput)
 	h := &runtimeHandle{
@@ -2343,6 +2345,43 @@ func TestCloseSessionCancelsPendingDecisionsWithoutOwnerContext(t *testing.T) {
 	if approval.cancelCount != 2 || userInput.cancelCount != 2 {
 		t.Fatalf("decision cleanup count = approval:%d user_input:%d, want pre and final cleanup", approval.cancelCount, userInput.cancelCount)
 	}
+	// closeHandle and teardown both reach the cleanup path; the malformed
+	// handle is still reported once.
+	if got := logs.count(slog.LevelError); got != 1 {
+		t.Fatalf("fallback error logs = %d, want 1", got)
+	}
+}
+
+// countingLogHandler records log levels so tests can assert how often a
+// condition is reported.
+type countingLogHandler struct {
+	mu     sync.Mutex
+	levels []slog.Level
+}
+
+func (*countingLogHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *countingLogHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.levels = append(h.levels, r.Level)
+	return nil
+}
+
+func (h *countingLogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *countingLogHandler) WithGroup(string) slog.Handler { return h }
+
+func (h *countingLogHandler) count(level slog.Level) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, l := range h.levels {
+		if l == level {
+			n++
+		}
+	}
+	return n
 }
 
 func TestPendingDecisionCleanupRunsServicesIndependently(t *testing.T) {

--- a/internal/agent/runtime/session/commands.go
+++ b/internal/agent/runtime/session/commands.go
@@ -48,12 +48,14 @@ func runHandleForCommand(cmd Command) RunHandle {
 // DecisionContinuationContext detaches the model continuation from the short
 // command acknowledgement deadline while keeping it tied to the run owner's
 // lifecycle and persistence fence.
-func (m *Manager) DecisionContinuationContext(parent context.Context, cmd Command) (context.Context, context.CancelFunc, error) {
+func (m *Manager) DecisionContinuationContext(cmd Command) (context.Context, context.CancelFunc, error) {
 	ctrl := m.localControlForScope(cmd.BotID, cmd.SessionID, cmd.RunID)
 	if ctrl == nil || ctrl.generation != strings.TrimSpace(cmd.Generation) || !ctrl.commandsActive() {
 		return nil, func() {}, ErrCommandTargetNotActive
 	}
-	ctx, cancel := ctrl.commandContext(context.WithoutCancel(parent))
+	// The acknowledgement request ends before the continuation. Only the run
+	// lifecycle owns this context, so no transport cancellation is attached.
+	ctx, cancel := ctrl.commandContext(context.Background())
 	if err := m.ValidateRunOwnership(ctx, runHandleForCommand(cmd)); err != nil {
 		cancel()
 		return nil, func() {}, err

--- a/internal/agent/runtime/session/control.go
+++ b/internal/agent/runtime/session/control.go
@@ -193,8 +193,29 @@ func (c *runControl) commandContext(parent context.Context) (context.Context, co
 
 	// The run owns context values; the command transport only contributes its
 	// cancellation. Detach both here so ownership loss can retain its cause.
-	ctx, cancelCause := context.WithCancelCause(context.WithoutCancel(c.lifecycleCtx))
-	cancelParent := func() { cancelCause(context.Cause(parent)) }
+	base, cancelCause := context.WithCancelCause(context.WithoutCancel(c.lifecycleCtx))
+	ctx := base
+	stopDeadline := func() {}
+	// A command deadline must stay a deadline: callers distinguish an expired
+	// command from a cancelled one by ctx.Err(), which a cancel-only relay
+	// would always report as context.Canceled.
+	deadline, hasDeadline := parent.Deadline()
+	if hasDeadline {
+		var cancelDeadline context.CancelFunc
+		ctx, cancelDeadline = context.WithDeadline(base, deadline)
+		stopDeadline = cancelDeadline
+	}
+	cancelParent := func() {
+		cause := context.Cause(parent)
+		// The deadline layer expires on its own at the same instant and is the
+		// only path that can report ctx.Err() as context.DeadlineExceeded. Check
+		// Err rather than Cause: a parent cancelled early may carry a
+		// DeadlineExceeded cause while its cancellation mode is still Canceled.
+		if hasDeadline && errors.Is(parent.Err(), context.DeadlineExceeded) {
+			return
+		}
+		cancelCause(cause)
+	}
 	cancelOwner := func() {
 		if c.ownershipWasLost() {
 			cancelCause(ErrRunOwnershipLost)
@@ -215,6 +236,7 @@ func (c *runControl) commandContext(parent context.Context) (context.Context, co
 	return ctx, func() {
 		stopParent()
 		stopOwner()
+		stopDeadline()
 		cancelCause(context.Canceled)
 	}
 }

--- a/internal/agent/runtime/session/control.go
+++ b/internal/agent/runtime/session/control.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/memohai/memoh/internal/agent/turn"
-	"github.com/memohai/memoh/internal/runtimefence"
 )
 
 func (m *Manager) localControl(runID string) *runControl {
@@ -150,7 +149,9 @@ func (m *Manager) releaseAllLocalRuns(ctx context.Context) error {
 
 	var releaseErr error
 	for _, ctrl := range controls {
-		_, err := m.finishRunState(ctx, ctrl.handle(), RunStatusLost, runtimeOwnerShutdownError)
+		runCtx, cancel := ctrl.cleanupContext(ctx)
+		_, err := m.finishRunState(runCtx, ctrl.handle(), RunStatusLost, runtimeOwnerShutdownError)
+		cancel()
 		if err == nil || errors.Is(err, ErrRunOwnershipLost) {
 			continue
 		}
@@ -162,30 +163,59 @@ func (m *Manager) releaseAllLocalRuns(ctx context.Context) error {
 	return releaseErr
 }
 
+func (c *runControl) cleanupContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	if c == nil || c.lifecycleCtx == nil {
+		return context.WithCancel(parent)
+	}
+	ctx, cancel := context.WithCancel(context.WithoutCancel(c.lifecycleCtx))
+	stop := context.AfterFunc(parent, cancel)
+	if parent.Err() != nil {
+		cancel()
+	}
+	return ctx, func() {
+		stop()
+		cancel()
+	}
+}
+
 func (c *runControl) commandContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		parent = context.Background()
 	}
-	if c != nil {
-		if fence, ok := runtimefence.FromContext(c.lifecycleCtx); ok {
-			parent = runtimefence.WithContext(parent, fence)
-		}
-	}
-	ctx, cancelCause := context.WithCancelCause(parent)
-	cancel := func() { cancelCause(context.Canceled) }
 	if c == nil || c.lifecycleCtx == nil {
+		ctx, cancelCause := context.WithCancelCause(parent)
+		cancel := func() { cancelCause(context.Canceled) }
 		return ctx, cancel
 	}
-	stop := context.AfterFunc(c.lifecycleCtx, func() {
+
+	// The run owns context values; the command transport only contributes its
+	// cancellation. Detach both here so ownership loss can retain its cause.
+	ctx, cancelCause := context.WithCancelCause(context.WithoutCancel(c.lifecycleCtx))
+	cancelParent := func() { cancelCause(context.Cause(parent)) }
+	cancelOwner := func() {
 		if c.ownershipWasLost() {
 			cancelCause(ErrRunOwnershipLost)
 			return
 		}
 		cancelCause(context.Canceled)
-	})
+	}
+	stopParent := context.AfterFunc(parent, cancelParent)
+	stopOwner := context.AfterFunc(c.lifecycleCtx, cancelOwner)
+	// AfterFunc callbacks run asynchronously. Apply cancellation synchronously
+	// when either source is already done because callers inspect ctx.Err next.
+	if parent.Err() != nil {
+		cancelParent()
+	}
+	if c.lifecycleCtx.Err() != nil {
+		cancelOwner()
+	}
 	return ctx, func() {
-		stop()
-		cancel()
+		stopParent()
+		stopOwner()
+		cancelCause(context.Canceled)
 	}
 }
 
@@ -433,10 +463,6 @@ func (c *runControl) revokeOwnership(cause error) {
 // answer distinguishes "the run ended" from "the run was taken away".
 func (c *runControl) ownershipWasLost() bool {
 	return c != nil && c.ownershipLost.Load()
-}
-
-func (m *Manager) stopLeaseRenewal(ctrl *runControl) {
-	_ = m.stopLeaseRenewalContext(context.Background(), ctrl)
 }
 
 func (*Manager) stopLeaseRenewalContext(ctx context.Context, ctrl *runControl) error {

--- a/internal/agent/runtime/session/decision_route_test.go
+++ b/internal/agent/runtime/session/decision_route_test.go
@@ -37,6 +37,74 @@ func TestRunControlCommandContextPreservesOwnershipLossCause(t *testing.T) {
 	}
 }
 
+// A command carries the acknowledgement deadline of the request that routed
+// it. Relaying only cancellation would report every expiry as context.Canceled
+// and hide expired commands from callers that branch on DeadlineExceeded.
+func TestRunControlCommandContextKeepsParentDeadline(t *testing.T) {
+	type contextKey struct{}
+	lifecycleCtx, lifecycleCancel := context.WithCancel(
+		context.WithValue(context.Background(), contextKey{}, "run-scope"),
+	)
+	defer lifecycleCancel()
+	ctrl := &runControl{
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
+	}
+
+	parent, cancelParent := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelParent()
+	ctx, cancel := ctrl.commandContext(parent)
+	defer cancel()
+	if _, ok := ctx.Deadline(); !ok {
+		t.Fatal("command context has no deadline")
+	}
+	if got := ctx.Value(contextKey{}); got != "run-scope" {
+		t.Fatalf("command context value = %v, want run-scope", got)
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("command context did not expire with its parent")
+	}
+	if err := ctx.Err(); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("command context error = %v, want context deadline exceeded", err)
+	}
+	if cause := context.Cause(ctx); !errors.Is(cause, context.DeadlineExceeded) {
+		t.Fatalf("command context cause = %v, want context deadline exceeded", cause)
+	}
+}
+
+func TestRunControlCommandContextPropagatesCancellationCauseBeforeDeadline(t *testing.T) {
+	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
+	defer lifecycleCancel()
+	ctrl := &runControl{
+		lifecycleCtx:    lifecycleCtx,
+		lifecycleCancel: lifecycleCancel,
+	}
+
+	sourceCtx, cancelSource := context.WithCancelCause(context.Background())
+	parent, cancelDeadline := context.WithDeadline(sourceCtx, time.Now().Add(time.Minute))
+	defer cancelDeadline()
+	ctx, cancel := ctrl.commandContext(parent)
+	defer cancel()
+
+	// A DeadlineExceeded cause does not mean the deadline itself fired. This
+	// cancellation must propagate immediately and retain Canceled as ctx.Err().
+	cancelSource(context.DeadlineExceeded)
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("command context did not propagate parent cancellation")
+	}
+	if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("command context error = %v, want context canceled", err)
+	}
+	if cause := context.Cause(ctx); !errors.Is(cause, context.DeadlineExceeded) {
+		t.Fatalf("command context cause = %v, want context deadline exceeded", cause)
+	}
+}
+
 type fakeDecisionStore struct {
 	mu     sync.Mutex
 	target DecisionTarget

--- a/internal/agent/runtime/session/decision_route_test.go
+++ b/internal/agent/runtime/session/decision_route_test.go
@@ -14,13 +14,19 @@ import (
 )
 
 func TestRunControlCommandContextPreservesOwnershipLossCause(t *testing.T) {
-	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
+	type contextKey struct{}
+	lifecycleCtx, lifecycleCancel := context.WithCancel(
+		context.WithValue(context.Background(), contextKey{}, "run-scope"),
+	)
 	ctrl := &runControl{
 		lifecycleCtx:    lifecycleCtx,
 		lifecycleCancel: lifecycleCancel,
 	}
 	ctx, cancel := ctrl.commandContext(context.Background())
 	defer cancel()
+	if got := ctx.Value(contextKey{}); got != "run-scope" {
+		t.Fatalf("command context value = %v, want run-scope", got)
+	}
 
 	ctrl.revokeOwnership(ErrRunOwnershipLost)
 	ctrl.stopCommands()

--- a/internal/agent/runtime/session/manager_test.go
+++ b/internal/agent/runtime/session/manager_test.go
@@ -1052,7 +1052,7 @@ func runManagerDoesNotRetryFinishAfterOwnershipLoss(t *testing.T, suite distribu
 	if err := manager.StartRun(context.Background(), testBotID, testSessionID, "stream-expired-finish", make(chan struct{}, 1), func() {}, make(chan turn.InjectMessage, 1)); err != nil {
 		t.Fatalf("start run: %v", err)
 	}
-	manager.stopLeaseRenewal(manager.localControl("stream-expired-finish"))
+	_ = manager.stopLeaseRenewalContext(context.Background(), manager.localControl("stream-expired-finish"))
 	time.Sleep(leaseTTL + leaseTTL/2)
 	if err := manager.FinishRun(context.Background(), requireRunHandle(t, manager, testBotID, testSessionID, "stream-expired-finish"), RunStatusCompleted, ""); !errors.Is(err, ErrRunOwnershipLost) {
 		t.Fatalf("finish expired run error = %v, want ErrRunOwnershipLost", err)
@@ -1957,7 +1957,7 @@ func runRuntimeManagerExpiredCleanupScopesLocalControlToGeneration(t *testing.T,
 		t.Fatalf("start old generation: %v", err)
 	}
 	backend.targetGeneration = oldHandle.Generation
-	manager.stopLeaseRenewal(manager.localControlForHandle(oldHandle))
+	_ = manager.stopLeaseRenewalContext(context.Background(), manager.localControlForHandle(oldHandle))
 	time.Sleep(leaseTTL + 30*time.Millisecond)
 
 	snapshotDone := make(chan error, 1)
@@ -2023,7 +2023,7 @@ func runRuntimeManagerRejectsValidationAfterLocalLeaseDeadline(t *testing.T, sui
 	if err != nil {
 		t.Fatalf("start run: %v", err)
 	}
-	manager.stopLeaseRenewal(manager.localControlForHandle(handle))
+	_ = manager.stopLeaseRenewalContext(context.Background(), manager.localControlForHandle(handle))
 
 	result := make(chan error, 1)
 	go func() {
@@ -2162,7 +2162,7 @@ func runRuntimeManagerRejectsExpiredLeaseRevivalContract(t *testing.T, suite dis
 	if ctrl == nil {
 		t.Fatal("local run control is missing")
 	}
-	manager.stopLeaseRenewal(ctrl)
+	_ = manager.stopLeaseRenewalContext(context.Background(), ctrl)
 
 	initial, ok, err := backend.Load(context.Background(), Key{BotID: testBotID, SessionID: testSessionID})
 	if err != nil || !ok || initial.CurrentRunView == nil {
@@ -3452,7 +3452,7 @@ func runRuntimeManagerFencesStaleOwnerEventsContract(t *testing.T, suite distrib
 		t.Fatalf("start stale owner run: %v", err)
 	}
 	staleControl := oldOwner.localControl("stream-stale")
-	oldOwner.stopLeaseRenewal(staleControl)
+	_ = oldOwner.stopLeaseRenewalContext(context.Background(), staleControl)
 	time.Sleep(80 * time.Millisecond)
 
 	lost, err := newOwner.Snapshot(context.Background(), testBotID, testSessionID)
@@ -3567,7 +3567,7 @@ func runRuntimeManagerNotifiesLeaseLostContract(t *testing.T, suite distributedR
 	if err := owner.StartRun(context.Background(), testBotID, testSessionID, testRunID, make(chan struct{}, 1), func() {}, make(chan turn.InjectMessage, 1)); err != nil {
 		t.Fatalf("start run: %v", err)
 	}
-	owner.stopLeaseRenewal(owner.localControl(testRunID))
+	_ = owner.stopLeaseRenewalContext(context.Background(), owner.localControl(testRunID))
 
 	deadline := time.After(5 * time.Second)
 	for {

--- a/internal/agent/runtime/session/recovery.go
+++ b/internal/agent/runtime/session/recovery.go
@@ -131,7 +131,7 @@ func (m *Manager) reserveRecoveredWaitingDecision(ctx context.Context, run ledge
 		BotID: run.BotID, SessionID: run.SessionID, RunID: run.RunID,
 		TurnID: run.TurnID, Generation: generation, FencingToken: run.FencingToken,
 	}.normalized()
-	lifecycleBase := runtimefence.WithContext(context.Background(), runtimefence.Fence{
+	lifecycleBase := runtimefence.WithContext(context.WithoutCancel(ctx), runtimefence.Fence{
 		BotID: handle.BotID, SessionID: handle.SessionID, Token: handle.FencingToken,
 	})
 	lifecycleCtx, lifecycleCancel := context.WithCancel(lifecycleBase)

--- a/internal/agent/runtime/session/recovery_test.go
+++ b/internal/agent/runtime/session/recovery_test.go
@@ -187,6 +187,7 @@ func (f *waitingDecisionRecoveryFence) recordedReclaims() [][2]int64 {
 }
 
 func TestWaitingDecisionRecoveryRetriesAfterFenceCommitWhenLiveReservationFails(t *testing.T) {
+	type contextKey struct{}
 	const (
 		runID      = "run-waiting-recovery"
 		sessionID  = "session-waiting-recovery"
@@ -221,8 +222,9 @@ func TestWaitingDecisionRecoveryRetriesAfterFenceCommitWhenLiveReservationFails(
 	manager.SetDecisionStore(decisions)
 	reaper := newTestReaperWithLiveness(t, runs, backend, "generation-new")
 	reaper.SetWaitingDecisionRecoverer(manager.recoverWaitingDecision)
+	reaperCtx := context.WithValue(context.Background(), contextKey{}, "reaper-scope")
 
-	reaper.tick(context.Background())
+	reaper.tick(reaperCtx)
 
 	firstRun, err := runs.Get(context.Background(), runID)
 	if err != nil {
@@ -242,7 +244,7 @@ func TestWaitingDecisionRecoveryRetriesAfterFenceCommitWhenLiveReservationFails(
 		t.Fatalf("retry pointer changed after reservation failure: indexed=%+v release_calls=%d applied=%d", indexed, releaseCalls, releaseApplied)
 	}
 
-	reaper.tick(context.Background())
+	reaper.tick(reaperCtx)
 
 	secondRun, err := runs.Get(context.Background(), runID)
 	if err != nil {
@@ -257,6 +259,10 @@ func TestWaitingDecisionRecoveryRetriesAfterFenceCommitWhenLiveReservationFails(
 	}
 	if startCalls != 2 || ref.FencingToken != 7 || manager.localControlForScope(testBotID, sessionID, runID) == nil {
 		t.Fatalf("retried live reservation = starts:%d ref:%+v", startCalls, ref)
+	}
+	ctrl := manager.localControlForScope(testBotID, sessionID, runID)
+	if got := ctrl.lifecycleCtx.Value(contextKey{}); got != "reaper-scope" {
+		t.Fatalf("recovered run context value = %v, want reaper-scope", got)
 	}
 	if indexed.FencingToken != 7 || releaseCalls != 1 || releaseApplied != 0 {
 		t.Fatalf("stale release changed successor lease: indexed=%+v release_calls=%d applied=%d", indexed, releaseCalls, releaseApplied)

--- a/internal/agent/runtime/session/reset.go
+++ b/internal/agent/runtime/session/reset.go
@@ -123,7 +123,7 @@ func (m *Manager) beginHistoryReset(ctx context.Context, scope ResetScope) (cont
 			close(stopRenew)
 			<-renewDone
 			cancelReset(context.Canceled)
-			releaseCtx, cancel := context.WithTimeout(context.Background(), ttl/3)
+			releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(resetCtx), ttl/3)
 			defer cancel()
 			if liveHeld {
 				if resetBackend, hasLive := m.backend.(HistoryResetBackend); hasLive {

--- a/internal/agent/runtime/session/reset_manager_test.go
+++ b/internal/agent/runtime/session/reset_manager_test.go
@@ -25,6 +25,7 @@ type fakeResetLedger struct {
 	renewResults    []fakeRenewResult
 	renews          int
 	released        []ledger.ResetLease
+	releaseCtx      context.Context
 	// activeRunsByBot is consumed one call at a time; when exhausted the bot
 	// has no active runs left.
 	activeRunsByBot [][]ledger.Run
@@ -72,9 +73,10 @@ func (f *fakeResetLedger) RenewReset(_ context.Context, lease ledger.ResetLease,
 	return lease, true, nil
 }
 
-func (f *fakeResetLedger) ReleaseReset(_ context.Context, lease ledger.ResetLease) (bool, error) {
+func (f *fakeResetLedger) ReleaseReset(ctx context.Context, lease ledger.ResetLease) (bool, error) {
 	f.resetMu.Lock()
 	defer f.resetMu.Unlock()
+	f.releaseCtx = ctx
 	f.released = append(f.released, lease)
 	return true, nil
 }
@@ -128,10 +130,12 @@ func newResetTestManager(t *testing.T, runs ledger.Store) (*Manager, *MemoryBack
 
 func TestBeginSessionHistoryResetAcquiresFencesAndReleases(t *testing.T) {
 	t.Parallel()
+	type contextKey struct{}
 	runs := newFakeResetLedger()
 	manager, backend := newResetTestManager(t, runs)
 
-	resetCtx, release, err := manager.BeginSessionHistoryReset(context.Background(), "bot-1", "session-1")
+	ctx := context.WithValue(context.Background(), contextKey{}, "reset-scope")
+	resetCtx, release, err := manager.BeginSessionHistoryReset(ctx, "bot-1", "session-1")
 	if err != nil {
 		t.Fatalf("BeginSessionHistoryReset() error = %v", err)
 	}
@@ -151,6 +155,12 @@ func TestBeginSessionHistoryResetAcquiresFencesAndReleases(t *testing.T) {
 	released := runs.releasedLeases()
 	if len(released) != 1 || released[0].Token != fence.Token || released[0].Scope != ledger.ResetScopeSession {
 		t.Fatalf("durable release = %#v, want the acquired token", released)
+	}
+	runs.resetMu.Lock()
+	releaseCtx := runs.releaseCtx
+	runs.resetMu.Unlock()
+	if got := releaseCtx.Value(contextKey{}); got != "reset-scope" {
+		t.Fatalf("release context value = %v, want reset-scope", got)
 	}
 	if _, blocked, err := backend.EffectiveHistoryReset(context.Background(), ResetScope{BotID: "bot-1", SessionID: "session-1"}); err != nil || blocked {
 		t.Fatalf("live mirror after release = (%v, %v)", blocked, err)

--- a/internal/handlers/mcp_tools_test.go
+++ b/internal/handlers/mcp_tools_test.go
@@ -142,6 +142,12 @@ func TestHandleMCPToolsWithGatewayAcceptCompatibility(t *testing.T) {
 		t.Fatalf("decode list payload failed: %v", err)
 	}
 	result, _ := listPayload["result"].(map[string]any)
+	if cacheScope, _ := result["cacheScope"].(string); cacheScope != "private" {
+		t.Fatalf("tools/list cacheScope = %#v, want private", result["cacheScope"])
+	}
+	if ttlMs, ok := result["ttlMs"].(float64); !ok || ttlMs != 0 {
+		t.Fatalf("tools/list ttlMs = %#v, want 0", result["ttlMs"])
+	}
 	tools, _ := result["tools"].([]any)
 	if len(tools) != 1 {
 		t.Fatalf("expected one tool, got: %#v", result["tools"])

--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -43,7 +43,7 @@ type sessionWorkdirService interface {
 // warm agent process and binding a session to a runtime.
 type acpSessionRuntimeService interface {
 	CloseSession(sessionID string) error
-	BindRuntime(botID, runtimeID, sessionID, agentID, projectPath, runtimeOwnerAccountID string) error
+	BindRuntime(ctx context.Context, botID, runtimeID, sessionID, agentID, projectPath, runtimeOwnerAccountID string) error
 }
 
 // sessionResetService is the runtime-agnostic history reset boundary. It is a
@@ -209,6 +209,7 @@ func (h *SessionHandler) CreateSession(c echo.Context) error {
 	// session — the first prompt simply cold starts a runtime.
 	if runtimeID := strings.TrimSpace(req.ACPRuntimeID); runtimeID != "" && session.IsACPRuntime(sess) && h.acpRuntimes != nil {
 		if bindErr := h.acpRuntimes.BindRuntime(
+			c.Request().Context(),
 			bot.ID,
 			runtimeID,
 			sess.ID,

--- a/internal/handlers/session_create_test.go
+++ b/internal/handlers/session_create_test.go
@@ -242,6 +242,7 @@ func TestCreateSessionDefaultsACPProjectPath(t *testing.T) {
 }
 
 type recordingRuntimeBinder struct {
+	bindCtx  context.Context
 	bindArgs []string
 	bindErr  error
 }
@@ -252,12 +253,15 @@ func (*recordingRuntimeBinder) BeginSessionHistoryReset(ctx context.Context, _, 
 	return ctx, func() {}, nil
 }
 
-func (b *recordingRuntimeBinder) BindRuntime(botID, runtimeID, sessionID, agentID, projectPath, runtimeOwnerAccountID string) error {
+func (b *recordingRuntimeBinder) BindRuntime(ctx context.Context, botID, runtimeID, sessionID, agentID, projectPath, runtimeOwnerAccountID string) error {
+	b.bindCtx = ctx
 	b.bindArgs = []string{botID, runtimeID, sessionID, agentID, projectPath, runtimeOwnerAccountID}
 	return b.bindErr
 }
 
 func TestCreateSessionBindsWarmACPRuntime(t *testing.T) {
+	type contextKey struct{}
+
 	botID := "11111111-1111-1111-1111-111111111111"
 	queries := &sessionCreateQueries{
 		bot: testBotRow(botID, map[string]any{
@@ -278,12 +282,20 @@ func TestCreateSessionBindsWarmACPRuntime(t *testing.T) {
 	)
 
 	body := `{"type":"acp_agent","title":"Codex","metadata":{"acp_agent_id":"codex"},"acp_runtime_id":"rt_warm"}`
-	if err := callCreateSession(handler, botID, body); err != nil {
+	requestCtx := context.WithValue(context.Background(), contextKey{}, "create-session-scope")
+	req := httptest.NewRequestWithContext(requestCtx, http.MethodPost, "/bots/"+botID+"/sessions", bytes.NewBufferString(body))
+	if err := callCreateSessionRequest(handler, botID, req); err != nil {
 		t.Fatalf("CreateSession() error = %v", err)
 	}
 	want := []string{botID, "rt_warm", "22222222-2222-2222-2222-222222222222", "codex", session.DefaultACPProjectPath, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}
 	if len(binder.bindArgs) != len(want) {
 		t.Fatalf("bind args = %#v, want %#v", binder.bindArgs, want)
+	}
+	if binder.bindCtx == nil {
+		t.Fatal("BindRuntime context is nil")
+	}
+	if got := binder.bindCtx.Value(contextKey{}); got != "create-session-scope" {
+		t.Fatalf("BindRuntime context value = %v, want create-session-scope", got)
 	}
 	for i := range want {
 		if binder.bindArgs[i] != want[i] {
@@ -324,8 +336,12 @@ func TestCreateSessionToleratesFailedRuntimeBind(t *testing.T) {
 }
 
 func callCreateSession(handler *SessionHandler, botID string, body string) error {
-	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/bots/"+botID+"/sessions", bytes.NewBufferString(body))
+	return callCreateSessionRequest(handler, botID, req)
+}
+
+func callCreateSessionRequest(handler *SessionHandler, botID string, req *http.Request) error {
+	e := echo.New()
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	ctx := testAuthContext(e, req, rec, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")

--- a/internal/handlers/session_delete_test.go
+++ b/internal/handlers/session_delete_test.go
@@ -81,7 +81,7 @@ func (c *recordingACPSessionCloser) BeginSessionHistoryReset(ctx context.Context
 	return context.WithValue(ctx, sessionDeleteResetCtxKey{}, true), release, nil
 }
 
-func (*recordingACPSessionCloser) BindRuntime(_, _, _, _, _, _ string) error {
+func (*recordingACPSessionCloser) BindRuntime(context.Context, string, string, string, string, string, string) error {
 	return nil
 }
 

--- a/internal/mcp/http_tools.go
+++ b/internal/mcp/http_tools.go
@@ -155,6 +155,13 @@ func ToolGatewayMiddleware(gateway *ToolGatewayService, contexts *ToolSessionCon
 					return nil, err
 				}
 				return &sdkmcp.ListToolsResult{
+					// Tool availability is scoped by the authenticated bot/session/runtime.
+					// Set the v1.7 cache metadata explicitly because this middleware bypasses
+					// the SDK's built-in tools/list handler and its default initialization.
+					Cacheable: sdkmcp.Cacheable{
+						TTLMs:      0,
+						CacheScope: "private",
+					},
 					Tools: ConvertGatewayToolsToSDK(tools),
 				}, nil
 			case "tools/call":


### PR DESCRIPTION
## 改了什么

- 脱离请求生命周期运行的 runtime 工作会保留所属请求或 run 中的 context value，同时由自己的生命周期控制取消。覆盖 ACP 进程同步、warm runtime 绑定与清理、decision continuation、run 恢复、history reset 释放，以及 ACP session 的正常关闭。
- 命令 context 会保留 run 级 values 和请求的 deadline 语义。真正超时时，`ctx.Err()` 是 `context.DeadlineExceeded`；请求提前取消时仍是 `context.Canceled`，并保留原始 cause。
- ACP teardown 遇到缺少 owner context 的异常 handle 时仍会清理 pending approval 和 `ask_user`，同时只记录一次错误日志。
- MCP `tools/list` 会明确返回 `cacheScope: "private"` 和 `ttlMs: 0`。工具列表按认证身份、Bot、session 和 runtime 隔离，不会在这些边界之间共享缓存。

## 为什么要改

直接使用请求 context 会让客户端断开提前终止仍需完成的清理；改用 `context.Background()` 又会丢失 runtime fence 等 values。现在 detached work 保留原有 values，取消由对应的 run 或 runtime 生命周期管理。

自定义 `tools/list` handler 绕过了 Go SDK 的默认值处理，之前会返回空的 `cacheScope`。Codex 0.147 会拒绝该响应，导致 Memoh 自带工具无法暴露给 ACP。

## 测试

- `go test -race ./internal/agent/runtime/acp/...`
- `go test ./...`
- `golangci-lint run ./...`
- 人工 QA：新建 Codex ACP session 后成功调用 `list_schedule`，返回了预期的空定时计划列表。
