### PR TITLE
feat(agent): 让 schedule 触发的 run 在运行中全程可见

### DIFF
--- a/internal/agent/application/service_messages.go
+++ b/internal/agent/application/service_messages.go
@@ -70,13 +70,6 @@ func modelMessageToSDKMessage(mm ModelMessage) sdk.Message {
 	return messageconv.ModelMessageToSDKMessage(mm)
 }
 
-// prependUserMessage prepends the user query as a ModelMessage to the output
-// messages from the agent. The SDK only returns output messages (assistant + tool);
-// user messages must be added back at the resolver boundary for persistence.
-func prependUserMessage(query string, output []ModelMessage) []ModelMessage {
-	return messageconv.PrependUserMessage(query, output)
-}
-
 func prependTurnUserMessage(req ChatRequest, output []ModelMessage) []ModelMessage {
 	if strings.TrimSpace(req.Query) == "" && req.UserMessageKind != UserMessageKindSkillActivation {
 		return output

--- a/internal/agent/application/service_trigger.go
+++ b/internal/agent/application/service_trigger.go
@@ -260,10 +260,11 @@ func (s *Service) triggerScheduleACP(ctx context.Context, botID string, payload 
 // watch the run live; persistence follows the same discipline as the WS loop
 // (streamChatWSResultWithHooks): steps persist as they complete via the step
 // committer, with one terminal-snapshot write as the fallback when step
-// persistence is unavailable. What a trigger deliberately does NOT have is
-// the WS client plumbing — no push channel, no abort channel, no idle
-// timeout — because there is no client; the runtime lease and routed abort
-// already bound execution.
+// persistence is unavailable, and an abort terminal is reported as an error
+// outcome while its partial transcript still persists. What a trigger
+// deliberately does NOT have is the WS client plumbing — no push channel, no
+// abort channel, no idle timeout — because there is no client; the runtime
+// lease and routed abort already bound execution.
 //
 // The events channel is a parameter (rather than this function calling
 // agent.Stream itself) so tests can drive the loop directly; the caller owns
@@ -277,6 +278,7 @@ func (s *Service) consumeTriggeredStream(ctx context.Context, events <-chan nati
 		hasSnapshot      bool
 		hasVisibleOutput bool
 		stored           bool
+		terminalAborted  bool
 		streamErr        error
 	)
 	for event := range events {
@@ -288,6 +290,18 @@ func (s *Service) consumeTriggeredStream(ctx context.Context, events <-chan nati
 			)
 			if streamErr == nil {
 				streamErr = eventErr
+			}
+		}
+		if event.IsTerminal() && event.Type == native.EventAgentAbort && strings.TrimSpace(event.ApprovalID) == "" {
+			// A stopped run is not a success: mirror the WS loop, which maps
+			// an abort terminal to agentAbortCause (a deferred approval is a
+			// pending pause, not an abort, so it is excluded). The partial
+			// transcript still persists below; only the reported outcome
+			// changes — without this the schedule log would mark a stopped
+			// run "ok", a regression from the Generate era, which errored.
+			terminalAborted = true
+			if streamErr == nil {
+				streamErr = agentAbortCause(ctx)
 			}
 		}
 		if hasVisibleAgentStreamOutput(event) {
@@ -361,6 +375,10 @@ func (s *Service) consumeTriggeredStream(ctx context.Context, events <-chan nati
 		// The reaper names this run's outcome; a superseded owner must not
 		// report a result for it (SR-DUR-002).
 		return schedule.TriggerResult{}, sessionruntime.ErrRunOwnershipLost
+	case terminalAborted:
+		// The transcript already persisted above; report the abort as the
+		// outcome so the schedule log records the stop, not a success.
+		return schedule.TriggerResult{}, streamErr
 	case streamErr != nil && !hasSnapshot:
 		return schedule.TriggerResult{}, streamErr
 	case !hasSnapshot:

--- a/internal/agent/application/service_trigger.go
+++ b/internal/agent/application/service_trigger.go
@@ -7,13 +7,16 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	"github.com/memohai/memoh/internal/agent/event"
 	acpagent "github.com/memohai/memoh/internal/agent/runtime/acp"
 	acpclient "github.com/memohai/memoh/internal/agent/runtime/acp/client"
 	"github.com/memohai/memoh/internal/agent/runtime/native"
+	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	"github.com/memohai/memoh/internal/agent/sessionmode"
+	chatview "github.com/memohai/memoh/internal/agent/view"
 	"github.com/memohai/memoh/internal/schedule"
 )
 
@@ -41,7 +44,23 @@ func (s *Service) TriggerSchedule(ctx context.Context, botID string, payload sch
 	if err != nil {
 		return schedule.TriggerResult{}, err
 	}
-	runCtx, admission, finish, err := s.admitTriggeredRun(ctx, botID, payload.SessionID, scheduleInvocationID(payload), submission)
+	// Project the command as the run's request user turn so subscribers (an
+	// open web session, any future thread subscriber) see what fired this run
+	// while it is still executing — not only after it finishes. Text must equal
+	// the persisted user message (prependTurnUserMessage uses req.Query =
+	// payload.Command), otherwise the bubble's content would visibly change
+	// when the runtime projection hands over to the database at run end.
+	viewFn := func(handle sessionruntime.RunHandle) *sessionruntime.RunAdmissionView {
+		return &sessionruntime.RunAdmissionView{
+			RequestUserTurn: &chatview.UITurn{
+				TurnID:    handle.TurnID,
+				Role:      "user",
+				Text:      payload.Command,
+				Timestamp: time.Now(),
+			},
+		}
+	}
+	runCtx, admission, finish, err := s.admitTriggeredRun(ctx, botID, payload.SessionID, scheduleInvocationID(payload), submission, viewFn)
 	if err != nil {
 		// Including a busy answer: a fire that cannot take the thread's slot has
 		// no value once the next one is due, so it is reported and dropped rather
@@ -78,6 +97,10 @@ func (s *Service) TriggerSchedule(ctx context.Context, botID string, payload sch
 		return schedule.TriggerResult{}, err
 	}
 	req.RunID = rc.runConfig.RunID
+	// The step committer refuses to arm without the durable turn identity
+	// (step_commit.go), and that identity only exists after admission.
+	req.TurnID = admission.TurnID
+	req.TurnPosition = &admission.TurnPosition
 
 	cfg := rc.runConfig
 	cfg.SessionType = sessionmode.Schedule
@@ -98,28 +121,24 @@ func (s *Service) TriggerSchedule(ctx context.Context, botID string, payload sch
 	var lifecycleCause error
 	defer func() { terminal(lifecycleCause) }()
 
-	result, err := s.agent.Generate(ctx, cfg)
-	lifecycleCause = err
-	if err != nil {
-		return schedule.TriggerResult{}, err
+	// Wire the trigger run like an interactive turn: steps persist as they
+	// complete, and every stream event is projected to the session runtime so
+	// the run is visible while it executes. The previous Generate-based path
+	// emitted nothing until storeRound wrote the whole round at the end.
+	stepCommitter := s.newAgentStepCommitter(ctx, req, rc)
+	if stepCommitter != nil {
+		cfg.OnStepCommitted = stepCommitter.commit
+		cfg.OnStepInterrupted = stepCommitter.interrupt
 	}
 
-	outputMessages := sdkMessagesToModelMessages(result.Messages)
-	roundMessages := prependUserMessage(req.Query, outputMessages)
-	storeErr := s.storeRoundWithOptions(ctx, req, roundMessages, rc.model.ID, storeRoundOptions{
-		ContextLifecycle: cfg.ContextLifecycle,
-	})
-	if storeErr != nil {
-		lifecycleCause = storeErr
-	}
-
-	totalUsageJSON, _ := json.Marshal(result.Usage)
-	return schedule.TriggerResult{
-		Status:     "ok",
-		Text:       strings.TrimSpace(result.Text),
-		UsageBytes: totalUsageJSON,
-		ModelID:    rc.model.ID,
-	}, storeErr
+	// cancelStream is the consumption brake: if the consumer stops early
+	// (projection refused, terminal handled), cancelling unwinds the Stream
+	// goroutine instead of leaving it blocked on an unread channel.
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+	result, streamErr := s.consumeTriggeredStream(streamCtx, s.agent.Stream(streamCtx, cfg), req, rc, admission.Handle, stepCommitter)
+	lifecycleCause = streamErr
+	return result, streamErr
 }
 
 // triggerScheduleACP runs one schedule fire through the ACP session pool.
@@ -233,6 +252,135 @@ func (s *Service) triggerScheduleACP(ctx context.Context, botID string, payload 
 		Status:     "ok",
 		Text:       strings.TrimSpace(result.Text),
 		UsageBytes: usageJSON,
+	}, nil
+}
+
+// consumeTriggeredStream drains a triggered (non-interactive) run's event
+// stream. Every event is published to the session runtime so subscribers
+// watch the run live; persistence follows the same discipline as the WS loop
+// (streamChatWSResultWithHooks): steps persist as they complete via the step
+// committer, with one terminal-snapshot write as the fallback when step
+// persistence is unavailable. What a trigger deliberately does NOT have is
+// the WS client plumbing — no push channel, no abort channel, no idle
+// timeout — because there is no client; the runtime lease and routed abort
+// already bound execution.
+//
+// The events channel is a parameter (rather than this function calling
+// agent.Stream itself) so tests can drive the loop directly; the caller owns
+// the stream context and must cancel it to unwind a still-running Stream
+// goroutine when this returns early.
+func (s *Service) consumeTriggeredStream(ctx context.Context, events <-chan native.StreamEvent, req ChatRequest, rc resolvedContext, handle sessionruntime.RunHandle, stepCommitter *agentStepCommitter) (schedule.TriggerResult, error) {
+	publishEvent := s.turnAgentEventPublisher(handle)
+
+	var (
+		lastSnapshot     terminalSnapshot
+		hasSnapshot      bool
+		hasVisibleOutput bool
+		stored           bool
+		streamErr        error
+	)
+	for event := range events {
+		if eventErr := agentStreamEventError(event); eventErr != nil {
+			s.logger.Error("triggered run stream error",
+				slog.String("bot_id", req.BotID),
+				slog.String("session_id", req.ThreadID),
+				slog.Any("error", eventErr),
+			)
+			if streamErr == nil {
+				streamErr = eventErr
+			}
+		}
+		if hasVisibleAgentStreamOutput(event) {
+			hasVisibleOutput = true
+		}
+		if publishEvent != nil {
+			if publishErr := publishEvent(ctx, event); publishErr != nil {
+				// A refused projection write (fence rejection, ownership
+				// handoff) means this process may no longer own the run, and
+				// continuing would persist history the runtime no longer
+				// attributes to it — the same stop policy as the channel
+				// pump (turn_service.go). Stop consuming; the caller's
+				// stream-context cancel unwinds the producer goroutine.
+				if streamErr == nil {
+					streamErr = publishErr
+				}
+				break
+			}
+		}
+		if event.IsTerminal() && len(event.Messages) > 0 {
+			data, marshalErr := json.Marshal(event)
+			if marshalErr != nil {
+				continue
+			}
+			snap, ok := extractTerminalSnapshot(data)
+			if !ok {
+				continue
+			}
+			snap.visibleOutput = hasVisibleOutput
+			lastSnapshot = snap
+			hasSnapshot = true
+			if !stored && !runOwnershipLost(ctx) {
+				if stepCommitter != nil {
+					if storeErr := stepCommitter.finish(ctx, extractInputTokensFromUsage(snap.usage)); storeErr != nil {
+						if streamErr == nil {
+							streamErr = storeErr
+						}
+						s.logger.Error("triggered run step finalization failed", slog.Any("error", storeErr))
+					} else {
+						stored = true
+					}
+				} else {
+					if storeErr := s.persistTerminalSnapshot(context.WithoutCancel(ctx), req, rc, snap); storeErr != nil {
+						if streamErr == nil {
+							streamErr = storeErr
+						}
+						s.logger.Error("triggered run terminal persist failed", slog.Any("error", storeErr))
+					} else {
+						stored = true
+					}
+				}
+			}
+		}
+	}
+
+	// Mid-run abort/error: finalize whatever the step committer already landed
+	// so the partial transcript survives for audit. This is a deliberate
+	// behavior change from the Generate era, which persisted nothing on
+	// failure — the partial record is the more honest one.
+	if !stored && stepCommitter != nil && !runOwnershipLost(ctx) {
+		if storeErr := stepCommitter.finish(ctx, rc.estimatedTokens); storeErr != nil {
+			if streamErr == nil {
+				streamErr = storeErr
+			}
+			s.logger.Error("triggered run step finalization failed", slog.Any("error", storeErr))
+		}
+	}
+
+	switch {
+	case runOwnershipLost(ctx):
+		// The reaper names this run's outcome; a superseded owner must not
+		// report a result for it (SR-DUR-002).
+		return schedule.TriggerResult{}, sessionruntime.ErrRunOwnershipLost
+	case streamErr != nil && !hasSnapshot:
+		return schedule.TriggerResult{}, streamErr
+	case !hasSnapshot:
+		return schedule.TriggerResult{}, errors.New("schedule run ended without a terminal event")
+	}
+
+	// A terminal snapshot settles the run even if a non-fatal stream error was
+	// seen earlier (already logged); the trigger result mirrors the Generate
+	// era's contract: final assistant text plus usage for the schedule log.
+	text := ""
+	if modelMsgs := sdkMessagesToModelMessages(lastSnapshot.sdkMessages); len(modelMsgs) > 0 {
+		if idx := lastAssistantMessageIndex(modelMsgs); idx >= 0 {
+			text = strings.TrimSpace(modelMsgs[idx].TextContent())
+		}
+	}
+	return schedule.TriggerResult{
+		Status:     "ok",
+		Text:       text,
+		UsageBytes: lastSnapshot.usage,
+		ModelID:    rc.model.ID,
 	}, nil
 }
 

--- a/internal/agent/application/service_trigger_test.go
+++ b/internal/agent/application/service_trigger_test.go
@@ -195,6 +195,61 @@ func TestConsumeTriggeredStreamSkipsPersistenceOnOwnershipLoss(t *testing.T) {
 	}
 }
 
+func TestConsumeTriggeredStreamReportsAbortWithPartialTranscript(t *testing.T) {
+	t.Parallel()
+
+	messages := &recordingMessageService{}
+	svc := newTriggerStreamService(messages, &recordingTurnEventPublisher{})
+
+	// A routed abort (web stop, runtime revoke) cancels the run context with
+	// a cause; the terminal event still carries the partial transcript.
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(context.Canceled)
+
+	messagesJSON, err := json.Marshal([]sdk.Message{sdk.AssistantMessage("partial answer")})
+	if err != nil {
+		t.Fatalf("marshal abort messages: %v", err)
+	}
+	events := make(chan native.StreamEvent, 2)
+	events <- native.StreamEvent{Type: native.EventTextDelta, Delta: "working"}
+	events <- native.StreamEvent{Type: native.EventAgentAbort, Messages: messagesJSON}
+	close(events)
+
+	_, err = svc.consumeTriggeredStream(ctx, events, triggerStreamRequest(), resolvedContext{}, sessionruntime.RunHandle{RunID: "run-1", TurnID: "turn-1"}, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("consumeTriggeredStream() error = %v, want the abort cause, not a success", err)
+	}
+	// The abort changes the reported outcome, not the history discipline: the
+	// partial transcript persists for audit exactly like a clean terminal.
+	if len(messages.persisted) != 2 {
+		t.Fatalf("persisted %d messages, want user + partial assistant", len(messages.persisted))
+	}
+}
+
+func TestConsumeTriggeredStreamDeferredApprovalIsNotAnAbort(t *testing.T) {
+	t.Parallel()
+
+	svc := newTriggerStreamService(&recordingMessageService{}, &recordingTurnEventPublisher{})
+
+	messagesJSON, err := json.Marshal([]sdk.Message{sdk.AssistantMessage("needs approval")})
+	if err != nil {
+		t.Fatalf("marshal deferred messages: %v", err)
+	}
+	events := make(chan native.StreamEvent, 1)
+	// A deferred approval pauses the run for a decision; it is not a stopped
+	// run, so the outcome stays ok (mirrors the WS loop's deferred guard).
+	events <- native.StreamEvent{Type: native.EventAgentAbort, ApprovalID: "appr-1", Messages: messagesJSON}
+	close(events)
+
+	result, err := svc.consumeTriggeredStream(context.Background(), events, triggerStreamRequest(), resolvedContext{}, sessionruntime.RunHandle{RunID: "run-1", TurnID: "turn-1"}, nil)
+	if err != nil {
+		t.Fatalf("consumeTriggeredStream() error = %v, want nil for a deferred approval", err)
+	}
+	if result.Status != "ok" {
+		t.Fatalf("result.Status = %q, want ok", result.Status)
+	}
+}
+
 func TestConsumeTriggeredStreamWithStepCommitterDoesNotDoublePersist(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/application/service_trigger_test.go
+++ b/internal/agent/application/service_trigger_test.go
@@ -1,0 +1,308 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	"github.com/memohai/memoh/internal/agent/runtime/native"
+	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	chatview "github.com/memohai/memoh/internal/agent/view"
+)
+
+// recordingTurnEventPublisher stands in for the session-runtime projection
+// sink: it records every published event and can be armed to refuse the Nth
+// publish, which is how fence rejections surface to the consumer.
+type recordingTurnEventPublisher struct {
+	mu     sync.Mutex
+	events []native.StreamEvent
+	calls  int
+	errAt  int // 1-based call index to fail; 0 means never fail
+	err    error
+}
+
+func (p *recordingTurnEventPublisher) publish(_ context.Context, _ sessionruntime.RunHandle, event native.StreamEvent) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if p.errAt > 0 && p.calls == p.errAt {
+		return p.err
+	}
+	p.events = append(p.events, event)
+	return nil
+}
+
+func (p *recordingTurnEventPublisher) published() []native.StreamEvent {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]native.StreamEvent(nil), p.events...)
+}
+
+func newTriggerStreamService(messages *recordingMessageService, pub *recordingTurnEventPublisher) *Service {
+	svc := &Service{
+		logger:         slog.New(slog.DiscardHandler),
+		messageService: messages,
+	}
+	if pub != nil {
+		svc.publishTurnEvent = pub.publish
+	}
+	return svc
+}
+
+func scheduleTerminalEvent(t *testing.T, assistantText string) native.StreamEvent {
+	t.Helper()
+	messagesJSON, err := json.Marshal([]sdk.Message{sdk.AssistantMessage(assistantText)})
+	if err != nil {
+		t.Fatalf("marshal terminal messages: %v", err)
+	}
+	usageJSON, err := json.Marshal(sdk.Usage{InputTokens: 12, OutputTokens: 3})
+	if err != nil {
+		t.Fatalf("marshal usage: %v", err)
+	}
+	return native.StreamEvent{Type: native.EventAgentEnd, Messages: messagesJSON, Usage: usageJSON}
+}
+
+func triggerStreamRequest() ChatRequest {
+	return ChatRequest{BotID: "bot-1", ChatID: "bot-1", ThreadID: "session-1", Query: "run scheduled task"}
+}
+
+func TestConsumeTriggeredStreamProjectsEventsAndBuildsResult(t *testing.T) {
+	t.Parallel()
+
+	messages := &recordingMessageService{}
+	pub := &recordingTurnEventPublisher{}
+	svc := newTriggerStreamService(messages, pub)
+
+	events := make(chan native.StreamEvent, 2)
+	events <- native.StreamEvent{Type: native.EventTextDelta, Delta: "working"}
+	events <- scheduleTerminalEvent(t, "对账完成。")
+	close(events)
+
+	result, err := svc.consumeTriggeredStream(context.Background(), events, triggerStreamRequest(), resolvedContext{}, sessionruntime.RunHandle{RunID: "run-1", TurnID: "turn-1"}, nil)
+	if err != nil {
+		t.Fatalf("consumeTriggeredStream() error = %v", err)
+	}
+	if result.Status != "ok" {
+		t.Fatalf("result.Status = %q, want ok", result.Status)
+	}
+	if result.Text != "对账完成。" {
+		t.Fatalf("result.Text = %q, want the terminal assistant text", result.Text)
+	}
+	if len(result.UsageBytes) == 0 {
+		t.Fatal("result.UsageBytes is empty, want the terminal usage payload")
+	}
+
+	published := pub.published()
+	if len(published) != 2 {
+		t.Fatalf("published %d events, want both stream events projected", len(published))
+	}
+	if published[0].Type != native.EventTextDelta || published[1].Type != native.EventAgentEnd {
+		t.Fatalf("published event types = %q, %q; want text delta then agent end", published[0].Type, published[1].Type)
+	}
+
+	// No step committer: the terminal snapshot fallback persists the round
+	// (user query prepended + assistant output), exactly like the WS fallback.
+	if len(messages.persisted) != 2 {
+		t.Fatalf("persisted %d messages, want user + assistant via terminal snapshot", len(messages.persisted))
+	}
+	if messages.persisted[0].Role != "user" || messages.persisted[1].Role != "assistant" {
+		t.Fatalf("persisted roles = %q, %q; want user then assistant", messages.persisted[0].Role, messages.persisted[1].Role)
+	}
+}
+
+func TestConsumeTriggeredStreamStopsWhenProjectionRefused(t *testing.T) {
+	t.Parallel()
+
+	messages := &recordingMessageService{}
+	pub := &recordingTurnEventPublisher{errAt: 2, err: errors.New("projection refused")}
+	svc := newTriggerStreamService(messages, pub)
+
+	events := make(chan native.StreamEvent, 3)
+	events <- native.StreamEvent{Type: native.EventTextDelta, Delta: "a"}
+	events <- native.StreamEvent{Type: native.EventTextDelta, Delta: "b"}
+	events <- scheduleTerminalEvent(t, "done")
+	close(events)
+
+	_, err := svc.consumeTriggeredStream(context.Background(), events, triggerStreamRequest(), resolvedContext{}, sessionruntime.RunHandle{RunID: "run-1", TurnID: "turn-1"}, nil)
+	if err == nil {
+		t.Fatal("consumeTriggeredStream() error = nil, want the projection failure")
+	}
+	if pub.calls != 2 {
+		t.Fatalf("publish calls = %d, want exactly the refused call before stopping", pub.calls)
+	}
+	// The terminal event was never consumed, so nothing may be persisted.
+	if len(messages.persisted) != 0 {
+		t.Fatalf("persisted %d messages, want none after a refused projection", len(messages.persisted))
+	}
+}
+
+func TestConsumeTriggeredStreamFailsWithoutTerminalEvent(t *testing.T) {
+	t.Parallel()
+
+	svc := newTriggerStreamService(&recordingMessageService{}, &recordingTurnEventPublisher{})
+
+	events := make(chan native.StreamEvent, 1)
+	events <- native.StreamEvent{Type: native.EventTextDelta, Delta: "working"}
+	close(events)
+
+	_, err := svc.consumeTriggeredStream(context.Background(), events, triggerStreamRequest(), resolvedContext{}, sessionruntime.RunHandle{RunID: "run-1", TurnID: "turn-1"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "terminal event") {
+		t.Fatalf("consumeTriggeredStream() error = %v, want the missing-terminal failure", err)
+	}
+}
+
+func TestConsumeTriggeredStreamSurfacesStreamErrorWithoutTerminal(t *testing.T) {
+	t.Parallel()
+
+	svc := newTriggerStreamService(&recordingMessageService{}, &recordingTurnEventPublisher{})
+
+	events := make(chan native.StreamEvent, 1)
+	events <- native.StreamEvent{Type: native.EventError, Error: "provider boom"}
+	close(events)
+
+	_, err := svc.consumeTriggeredStream(context.Background(), events, triggerStreamRequest(), resolvedContext{}, sessionruntime.RunHandle{RunID: "run-1", TurnID: "turn-1"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "provider boom") {
+		t.Fatalf("consumeTriggeredStream() error = %v, want the provider error", err)
+	}
+}
+
+func TestConsumeTriggeredStreamSkipsPersistenceOnOwnershipLoss(t *testing.T) {
+	t.Parallel()
+
+	messages := &recordingMessageService{}
+	svc := newTriggerStreamService(messages, &recordingTurnEventPublisher{})
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(sessionruntime.ErrRunOwnershipLost)
+
+	events := make(chan native.StreamEvent, 1)
+	events <- scheduleTerminalEvent(t, "done")
+	close(events)
+
+	_, err := svc.consumeTriggeredStream(ctx, events, triggerStreamRequest(), resolvedContext{}, sessionruntime.RunHandle{RunID: "run-1", TurnID: "turn-1"}, nil)
+	if !errors.Is(err, sessionruntime.ErrRunOwnershipLost) {
+		t.Fatalf("consumeTriggeredStream() error = %v, want ErrRunOwnershipLost", err)
+	}
+	if len(messages.persisted) != 0 {
+		t.Fatalf("persisted %d messages, want none: a superseded owner must not write history", len(messages.persisted))
+	}
+}
+
+func TestConsumeTriggeredStreamWithStepCommitterDoesNotDoublePersist(t *testing.T) {
+	t.Parallel()
+
+	messages := &recordingMessageService{}
+	svc := newTriggerStreamService(messages, &recordingTurnEventPublisher{})
+
+	// A step committer with nothing committed finalizes into a no-op, but its
+	// presence must switch the terminal path away from the snapshot fallback —
+	// otherwise every step would be written twice.
+	committer := &agentStepCommitter{service: svc, req: triggerStreamRequest()}
+
+	events := make(chan native.StreamEvent, 1)
+	events <- scheduleTerminalEvent(t, "done")
+	close(events)
+
+	result, err := svc.consumeTriggeredStream(context.Background(), events, triggerStreamRequest(), resolvedContext{}, sessionruntime.RunHandle{RunID: "run-1", TurnID: "turn-1"}, committer)
+	if err != nil {
+		t.Fatalf("consumeTriggeredStream() error = %v", err)
+	}
+	if result.Status != "ok" || result.Text != "done" {
+		t.Fatalf("result = %#v, want completed output", result)
+	}
+	if len(messages.persisted) != 0 {
+		t.Fatalf("persisted %d messages via the fallback, want none: step committer owns persistence", len(messages.persisted))
+	}
+}
+
+// fakeTriggeredAdmitter captures the Admit input so tests can drive the
+// admission hook exactly the way the runtime manager would at activation.
+type fakeTriggeredAdmitter struct {
+	admitInput sessionruntime.AdmitInput
+}
+
+func (f *fakeTriggeredAdmitter) Admit(_ context.Context, input sessionruntime.AdmitInput) (sessionruntime.Admission, error) {
+	f.admitInput = input
+	return sessionruntime.Admission{
+		Started:      true,
+		RunID:        "run-1",
+		TurnID:       "turn-1",
+		TurnPosition: 1,
+		Handle: sessionruntime.RunHandle{
+			BotID:        input.BotID,
+			SessionID:    input.SessionID,
+			RunID:        "run-1",
+			TurnID:       "turn-1",
+			FencingToken: 1,
+		},
+	}, nil
+}
+
+func (*fakeTriggeredAdmitter) FinishRun(context.Context, sessionruntime.RunHandle, string, string) error {
+	return nil
+}
+
+func TestAdmitTriggeredRunInjectsAdmissionView(t *testing.T) {
+	t.Parallel()
+
+	admitter := &fakeTriggeredAdmitter{}
+	svc := &Service{logger: slog.New(slog.DiscardHandler), sessionRuntime: admitter}
+
+	viewFn := func(handle sessionruntime.RunHandle) *sessionruntime.RunAdmissionView {
+		return &sessionruntime.RunAdmissionView{
+			RequestUserTurn: &chatview.UITurn{
+				TurnID:    handle.TurnID,
+				Role:      "user",
+				Text:      "run scheduled task",
+				Timestamp: time.Now(),
+			},
+		}
+	}
+
+	ctx, admission, _, err := svc.admitTriggeredRun(context.Background(), "bot-1", "session-1", "inv-1", []byte(`{}`), viewFn)
+	if err != nil {
+		t.Fatalf("admitTriggeredRun() error = %v", err)
+	}
+	if admitter.admitInput.Execution.Admission == nil {
+		t.Fatal("runtime admission hook is nil")
+	}
+	view, err := admitter.admitInput.Execution.Admission(ctx, admission.Handle)
+	if err != nil {
+		t.Fatalf("admission hook error = %v", err)
+	}
+	if view.RequestUserTurn == nil {
+		t.Fatal("request user turn is nil, want the injected projection")
+	}
+	if view.RequestUserTurn.Text != "run scheduled task" {
+		t.Fatalf("request user turn text = %q, want the schedule command", view.RequestUserTurn.Text)
+	}
+	if view.RequestUserTurn.TurnID != admission.TurnID {
+		t.Fatalf("request user turn turn id = %q, want the admitted turn %q", view.RequestUserTurn.TurnID, admission.TurnID)
+	}
+}
+
+func TestAdmitTriggeredRunWithoutViewKeepsEmptyProjection(t *testing.T) {
+	t.Parallel()
+
+	admitter := &fakeTriggeredAdmitter{}
+	svc := &Service{logger: slog.New(slog.DiscardHandler), sessionRuntime: admitter}
+
+	ctx, admission, _, err := svc.admitTriggeredRun(context.Background(), "bot-1", "session-1", "inv-1", []byte(`{}`), nil)
+	if err != nil {
+		t.Fatalf("admitTriggeredRun() error = %v", err)
+	}
+	view, err := admitter.admitInput.Execution.Admission(ctx, admission.Handle)
+	if err != nil {
+		t.Fatalf("admission hook error = %v", err)
+	}
+	if view.RequestUserTurn != nil {
+		t.Fatalf("request user turn = %#v, want nil without a view factory", view.RequestUserTurn)
+	}
+}

--- a/internal/agent/application/turn_admission.go
+++ b/internal/agent/application/turn_admission.go
@@ -216,6 +216,10 @@ func runOwnershipLost(ctx context.Context) bool {
 // stop a long schedule run, and so a lost owner lease revokes execution instead
 // of letting a superseded owner keep writing.
 //
+// viewFn optionally supplies the subscriber-facing admission view (the request
+// user turn projection); nil keeps the run contentless in the projection, the
+// historical default for triggers and subagents alike.
+//
 // The finish function is always returned non-nil when the error is nil, so a
 // caller can defer it unconditionally.
 type triggeredRunTerminal struct {
@@ -223,7 +227,14 @@ type triggeredRunTerminal struct {
 	cause  error
 }
 
-func (s *Service) admitTriggeredRun(ctx context.Context, botID, threadID, invocationID string, submission []byte) (context.Context, sessionruntime.Admission, func(triggeredRunTerminal), error) {
+// triggeredAdmissionView lets a triggered caller inject the subscriber-facing
+// projection for its run. The hook fires at activation, when the handle already
+// carries the allocated turn identity — which is why the view is a factory
+// rather than a value: the turn id only exists by then.
+// Nil means the run projects no request user turn (the historical default).
+type triggeredAdmissionView func(handle sessionruntime.RunHandle) *sessionruntime.RunAdmissionView
+
+func (s *Service) admitTriggeredRun(ctx context.Context, botID, threadID, invocationID string, submission []byte, viewFn triggeredAdmissionView) (context.Context, sessionruntime.Admission, func(triggeredRunTerminal), error) {
 	if s.sessionRuntime == nil {
 		return nil, sessionruntime.Admission{}, nil, errors.New("session runtime is not configured")
 	}
@@ -234,7 +245,13 @@ func (s *Service) admitTriggeredRun(ctx context.Context, botID, threadID, invoca
 		InvocationID: invocationID,
 		Payload:      submission,
 		Execution: sessionruntime.Execution{
-			Admission: func(context.Context, sessionruntime.RunHandle) (sessionruntime.RunAdmissionView, error) {
+			Admission: func(_ context.Context, handle sessionruntime.RunHandle) (sessionruntime.RunAdmissionView, error) {
+				if viewFn == nil {
+					return sessionruntime.RunAdmissionView{}, nil
+				}
+				if view := viewFn(handle); view != nil {
+					return *view, nil
+				}
 				return sessionruntime.RunAdmissionView{}, nil
 			},
 			Cancel:          func() { cancelCause(context.Canceled) },
@@ -311,7 +328,7 @@ func (s *Service) AdmitSubagentRun(
 	botID, threadID, invocationID string,
 	submission []byte,
 ) (context.Context, tools.SubagentAdmission, func(tools.SubagentTerminal), error) {
-	runCtx, admission, finish, err := s.admitTriggeredRun(ctx, botID, threadID, invocationID, submission)
+	runCtx, admission, finish, err := s.admitTriggeredRun(ctx, botID, threadID, invocationID, submission, nil)
 	switch {
 	case errors.Is(err, sessionruntime.ErrSessionBusy):
 		return nil, tools.SubagentAdmission{}, nil, fmt.Errorf("%w: thread %s", turn.ErrSessionBusy, threadID)


### PR DESCRIPTION
## 问题

bot 定时任务（schedule）触发后，运行全程在 web 端不可见：没有 prompt 气泡、没有流式过程、没有 tool 进展，只有一个无内容的 "Mulling this over…" 占位；整轮消息（prompt + assistant + tool）在 run 结束后瞬间一起出现。

## 根因

turn 的「存在」层已被 durable runtime 统一（所有入口走同一个 `Admit`：Redis lease、thread slot、`FinishRun`），但「内容」层的接线是逐入口手工进行的，schedule 是什么都没接的入口：

- 执行用 `agent.Generate`（非流式），全程不产生事件；
- `RequestUserTurn` 无人填充——admission hook 写死返回空 view，prompt 气泡要等落库才存在；
- 没有 stepCommitter——整轮消息跑完才由 `storeRound` 一次写入；
- 没有事件投影——订阅者看到的 run 状态里 messages 永远为空。

渠道/WS/subagent 的 turn 这些线都有（fence、`publishChunk`、`agentStepCommitter`），schedule 是最后一个黑盒。本 PR 是 `turn_admission.go` 注释里"thread subscriptions replace per-run event forwarding"方向的收尾。

## 改动

- `admitTriggeredRun` 新增可选的 admission view 工厂；`TriggerSchedule` 把 command 投影为 run 的 `RequestUserTurn`——**该机制的第一个真实使用方**。投影文本与落库 user 消息一致（`req.Query = payload.Command`），run 结束投影切回数据库时气泡内容不跳变。
- run 改走 `agent.Stream`；新增 `consumeTriggeredStream`：每个事件经与渠道 pump 相同的 publisher 灌进 session runtime 投影，terminal 事件提取快照构造 `TriggerResult`，并收尾 stepCommitter。
- 用 admission 的 turn 身份装配 stepCommitter → step 完成即落库（`PersistAgentStep`，带 fence）；step 落库不可用时回退终态快照。
- 投影写被拒时中断执行（与渠道 pump 同策）；ownership lost 时跳过终态写并返回 `ErrRunOwnershipLost`。
- 中止语义与 WS 循环对齐：abort 终端事件（停止/路由 abort，非 deferred approval）映射为 `agentAbortCause` 返回 error——review 发现初版抹掉了 `EventAgentEnd`/`EventAgentAbort` 的区别，会把被停止的 run 在 schedule 日志里记成 ok（Generate 时代是 error），已修（commit `de6e6605f`）。
- 删除死代码 `prependUserMessage`（切换后零调用）。

## 行为变化（review/QA 必知）

1. **运行中逐步落库**：每个 step 落库后发 `message_created`，侧边栏实时刷新——这是目的本身，但属于新增流量。
2. **失败留下部分过程消息**（以前是什么都不留）——审计上的改进，但是语义变化。
3. **ownership lost 不落终态**（防脑裂纪律延伸到本路径）。
4. **prompt 在第一个 step 完成时落库**（而非 admit 时）——admit 到首个 step 的窗口由 `RequestUserTurn` 投影衔接。
5. **被中止的 run 在 schedule 日志记 error**（与 Generate 时代一致），中止前的部分过程消息保留——与第 2 条同源。
6. **schedule 轮次开始计入 auto-compaction 评估**（逐步落库链路自带；旧 `storeRound` 路径不过 compaction）。仅在 bot 开启 compaction 且超阈值时才真正压缩；`existing_session` 的长 schedule 会话从此能压缩。

## 测试

- 新增 10 个单测：事件投影转发、publish 失败中断、无 terminal、stream 错误、ownership lost 跳过落库、stepCommitter 在场不双写、admission view 注入/缺省、abort 报错且部分过程照落、deferred approval 不算 abort。
- `go build ./...`、`go vet`、`go test ./internal/agent/... ./internal/schedule/...` 全绿（`-race` 亦过）。
- `golangci-lint` 仅剩 `service_run_lifecycle.go:359` 一项——已在干净 origin/main 复现，main 既有，与本 PR 无关。
- 另注：`internal/agent/runtime/native` 的 `TestRunMidStreamRetrySuppressesRawErrorAfterStepBudgetCancellation` 在干净 origin/main 上同样失败（疑似 #1064 引入，本地 macOS 可复现、CI Linux 绿），与本 PR 无关。

## 人工 QA

第一轮（作者 session，Playwright 打真实本地栈）：onboarding 配真实 DeepSeek provider → 建 bot → 建每分钟 schedule → 实看触发。运行中：prompt 气泡 + 逐步文本 + tool 块 + 后台任务等待块全部实时渲染；结束后：整轮完整、无重复、投影切库时气泡无跳变。

第二轮（08-24 人工实机，同一第二栈，含 abort 修复 commit）：运行中可见性复核通过；**数据库硬证据**——进行中的 session 已逐步落库（user/assistant/tool 消息在 run 未完成时即在库），且 prompt 恰好 1 条（投影↔落库无双写）；已完结 run transcript 完整、`schedule_logs` 记 ok；普通交互聊天回归正常。DeepSeek 余额耗尽期间的 1598 次失败 fire 全部正确记 error（失败路径顺带验证）。**未覆盖**：web 端手动停止 schedule run（abort 路径仅单测覆盖，web 是否暴露停止入口未确认）。

## 范围外（已知遗留，刻意不动）

- **ACP 分支的 schedule**（`triggerScheduleACP`）事件 Sink 仍显式丢弃——ACP 事件类型不同，需独立接线 PR；但 `RequestUserTurn` 投影对它已生效。
- email 入口连 durable admission 都还没走（busy 语义是产品决策，先决策后动手）。
- 渠道 turn 的 `RequestUserTurn`（TG 用户消息运行中在云端不可见）——独立痛点，独立 PR。
