### PR TITLE
fix(context): generation envelope authority across estimator, output allowance, and dispatch

### DIFF
--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -796,6 +796,7 @@ func (s *Service) buildBaseRunConfig(ctx context.Context, p baseRunConfigParams)
 		ReasoningDefaultOn:    chatModel.Config.ReasoningDefaultOn,
 		ThinkingBudgetMin:     chatModel.Config.ThinkingBudgetMin,
 		ThinkingBudgetMax:     chatModel.Config.ThinkingBudgetMax,
+		ContextWindow:         contextBudgetFromChatModel(chatModel),
 	})
 
 	var agentSkills []native.SkillEntry

--- a/internal/agent/context/fragment/mutation.go
+++ b/internal/agent/context/fragment/mutation.go
@@ -241,13 +241,13 @@ func (l *MutationLedger) LoopSelectionMode() string {
 
 // ProviderInputHash hashes the assembled provider payload deterministically.
 func ProviderInputHash(system string, messages any) string {
-	hash, _ := ProviderPayloadHashAndBytes(system, messages, nil)
-	return hash
+	return ProviderPayloadHash(system, messages, nil)
 }
 
-// ProviderPayloadHashAndBytes includes tool definitions when supplied while
-// preserving the legacy hash shape when tools are empty.
-func ProviderPayloadHashAndBytes(system string, messages any, tools any) (string, int) {
+// ProviderPayloadHash includes tool definitions when supplied while preserving
+// the legacy hash shape when tools are empty. It is a content fingerprint only;
+// envelope decisions price payloads through ProviderEnvelopeTokens.
+func ProviderPayloadHash(system string, messages any, tools any) string {
 	tools = nilIfEmptyValue(tools)
 	raw, err := json.Marshal(struct {
 		System   string `json:"system"`
@@ -255,10 +255,10 @@ func ProviderPayloadHashAndBytes(system string, messages any, tools any) (string
 		Tools    any    `json:"tools,omitempty"`
 	}{System: system, Messages: messages, Tools: tools})
 	if err != nil {
-		return "", 0
+		return ""
 	}
 	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:]), len(raw)
+	return hex.EncodeToString(sum[:])
 }
 
 func nilIfEmptyValue(value any) any {

--- a/internal/agent/context/fragment/mutation_test.go
+++ b/internal/agent/context/fragment/mutation_test.go
@@ -53,15 +53,17 @@ func TestProviderInputHashDeterministic(t *testing.T) {
 func TestProviderPayloadHashTracksTools(t *testing.T) {
 	t.Parallel()
 
-	withoutTools, withoutToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, nil)
-	withEmptyTools, withEmptyToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, []string(nil))
-	withAllocatedEmptyTools, withAllocatedEmptyToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, []string{})
-	withTools, withToolsBytes := ProviderPayloadHashAndBytes("system", []string{"a"}, []string{"tool"})
-	if withoutTools != withEmptyTools || withoutToolsBytes != withEmptyToolsBytes ||
-		withoutTools != withAllocatedEmptyTools || withoutToolsBytes != withAllocatedEmptyToolsBytes {
+	withoutTools := ProviderPayloadHash("system", []string{"a"}, nil)
+	withEmptyTools := ProviderPayloadHash("system", []string{"a"}, []string(nil))
+	withAllocatedEmptyTools := ProviderPayloadHash("system", []string{"a"}, []string{})
+	withTools := ProviderPayloadHash("system", []string{"a"}, []string{"tool"})
+	if withoutTools != withEmptyTools || withoutTools != withAllocatedEmptyTools {
 		t.Fatal("empty tools must preserve the legacy payload identity")
 	}
-	if withTools == withoutTools || withToolsBytes <= withoutToolsBytes {
+	if withoutTools != ProviderInputHash("system", []string{"a"}) {
+		t.Fatal("ProviderInputHash must stay the tool-less payload identity")
+	}
+	if withTools == withoutTools {
 		t.Fatal("tool definitions must participate in provider payload identity")
 	}
 }

--- a/internal/agent/context/fragment/tokens.go
+++ b/internal/agent/context/fragment/tokens.go
@@ -123,9 +123,9 @@ func ResolveProviderBudgetFragTokens(frag ContextFrag) int {
 }
 
 // ProviderEnvelopeTokens prices one provider payload for envelope decisions
-// with the estimator that selection applies per fragment, so a message costs
-// the same whether it is being selected or has already been frozen into a
-// prefix.
+// with the estimator that selection applies per fragment, so a single-message
+// fragment costs the same whether it is being selected or has already been
+// frozen into a prefix.
 func ProviderEnvelopeTokens(system string, messages []sdk.Message, tools []sdk.Tool) int {
 	total := ProviderBudgetTokensFromBytes(len(system))
 	for _, message := range messages {

--- a/internal/agent/context/fragment/tokens.go
+++ b/internal/agent/context/fragment/tokens.go
@@ -35,9 +35,9 @@ func TokensFromBytes(n int) int {
 	return n / EstimateBytesPerToken
 }
 
-// ProviderBudgetTokensFromBytes converts bytes for provider-envelope decisions
-// only. Selection, compaction, cache metrics, and other ledger consumers keep
-// the legacy floor-based TokensFromBytes contract.
+// ProviderBudgetTokensFromBytes converts bytes for provider-envelope decisions,
+// including selection under a provider budget. Compaction, cache metrics, and
+// other ledger consumers keep the legacy floor-based TokensFromBytes contract.
 func ProviderBudgetTokensFromBytes(n int) int {
 	if n <= 0 {
 		return 0
@@ -123,8 +123,9 @@ func ResolveProviderBudgetFragTokens(frag ContextFrag) int {
 }
 
 // ProviderEnvelopeTokens prices one provider payload for envelope decisions
-// with the estimator selection applies per fragment, so a message costs the
-// same whether it is being selected or has already been frozen into a prefix.
+// with the estimator that selection applies per fragment, so a message costs
+// the same whether it is being selected or has already been frozen into a
+// prefix.
 func ProviderEnvelopeTokens(system string, messages []sdk.Message, tools []sdk.Tool) int {
 	total := ProviderBudgetTokensFromBytes(len(system))
 	for _, message := range messages {

--- a/internal/agent/context/fragment/tokens.go
+++ b/internal/agent/context/fragment/tokens.go
@@ -122,6 +122,26 @@ func ResolveProviderBudgetFragTokens(frag ContextFrag) int {
 	return estimated
 }
 
+// ProviderEnvelopeTokens prices one provider payload for envelope decisions
+// with the estimator selection applies per fragment, so a message costs the
+// same whether it is being selected or has already been frozen into a prefix.
+func ProviderEnvelopeTokens(system string, messages []sdk.Message, tools []sdk.Tool) int {
+	total := ProviderBudgetTokensFromBytes(len(system))
+	for _, message := range messages {
+		bytes, images := sdkMessageEstimate(message)
+		total += ProviderBudgetTokensFromBytes(bytes) + images*EstimateImageTokens
+	}
+	for _, tool := range tools {
+		total += ProviderToolDefTokens(ToolDefAccountingFor("", tool))
+	}
+	return total
+}
+
+// ProviderToolDefTokens prices one tool definition for envelope decisions.
+func ProviderToolDefTokens(def ToolDefAccounting) int {
+	return max(def.TokenEstimate, ProviderBudgetTokensFromBytes(def.Bytes))
+}
+
 // ToolDefAccountingFor measures one tool definition as the provider will
 // receive it (name, description, parameter schema). A definition that fails
 // to serialize falls back to its visible prose size.

--- a/internal/agent/context/fragment/tokens_test.go
+++ b/internal/agent/context/fragment/tokens_test.go
@@ -257,3 +257,49 @@ func TestResolveFragTokensPrefersPresetEstimate(t *testing.T) {
 		t.Fatalf("ResolveFragTokens = %d, want 2 (fallback to computed)", got)
 	}
 }
+
+func TestProviderEnvelopeTokensPricesInlineImagesFlat(t *testing.T) {
+	t.Parallel()
+
+	photo := sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{
+		sdk.TextPart{Text: "what is in this photo?"},
+		sdk.ImagePart{Image: "data:image/jpeg;base64," + strings.Repeat("A", 400_000), MediaType: "image/jpeg"},
+	}}
+	got := ProviderEnvelopeTokens("", []sdk.Message{photo}, nil)
+	want := ResolveProviderBudgetFragTokens(MessageFrag(MessageFragInput{Message: photo}))
+	if got != want {
+		t.Fatalf("ProviderEnvelopeTokens(photo) = %d, want selection estimate %d", got, want)
+	}
+	if got > 2*EstimateImageTokens {
+		t.Fatalf("ProviderEnvelopeTokens(photo) = %d, want flat image pricing near %d", got, EstimateImageTokens)
+	}
+}
+
+func TestProviderEnvelopeTokensSumsSystemMessagesAndTools(t *testing.T) {
+	t.Parallel()
+
+	system := strings.Repeat("s", 400)
+	messages := []sdk.Message{
+		sdk.UserMessage(strings.Repeat("u", 800)),
+		{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{sdk.ToolResultPart{
+			ToolCallID: "call-1", ToolName: "exec", Result: strings.Repeat("r", 1200),
+		}}},
+	}
+	tools := []sdk.Tool{{
+		Name:        "exec",
+		Description: "Execute a bounded command.",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{"command": map[string]any{"type": "string"}}},
+	}}
+
+	if got := ProviderEnvelopeTokens(system, messages[:1], nil); got != 125+250 {
+		t.Fatalf("ProviderEnvelopeTokens(system+user) = %d, want 375 (400 and 800 bytes at ceil/4 x 1.25)", got)
+	}
+	want := 375 + ResolveProviderBudgetFragTokens(MessageFrag(MessageFragInput{Message: messages[1]})) +
+		ProviderToolDefTokens(ToolDefAccountingFor("native", tools[0]))
+	if got := ProviderEnvelopeTokens(system, messages, tools); got != want {
+		t.Fatalf("ProviderEnvelopeTokens = %d, want %d", got, want)
+	}
+	if got := ProviderEnvelopeTokens("", nil, nil); got != 0 {
+		t.Fatalf("ProviderEnvelopeTokens(empty) = %d, want 0", got)
+	}
+}

--- a/internal/agent/context/fragment/types.go
+++ b/internal/agent/context/fragment/types.go
@@ -430,6 +430,7 @@ type ContextBudgetPlan struct {
 	EstimatorSafetyFactorPercent int    `json:"estimator_safety_factor_percent"`
 	Window                       int    `json:"window"`
 	OutputReserve                int    `json:"output_reserve"`
+	OutputReserveResolution      string `json:"output_reserve_resolution,omitempty"`
 	ToolDefsCost                 int    `json:"tool_defs_cost"`
 	CurrentRequestCost           int    `json:"current_request_cost"`
 	SystemBudget                 int    `json:"system_budget"`

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -1225,62 +1225,59 @@ func prepareProviderAttempt(
 	if mode == LoopReselectOff {
 		reselector = nil
 	}
-	if reselector == nil || prefixCount >= len(params.Messages) {
-		stagePreparedProviderAttempt(ctx, handoff, snapshot, systemPrepended, "", provenance)
-		return params
-	}
-
-	beforeMessages := append([]sdk.Message(nil), params.Messages...)
 	inputAllowance := stepReselectionAllowance(cfg)
-	selection := reselector(ctx, ContextStepSelectionInput{
-		Scope: cfg.ContextScope, InitialMessageCount: prefixCount, Messages: params.Messages,
-		BudgetMaxTokens:              remainingStepBudget(inputAllowance, params, prefixCount),
-		ProviderSystem:               params.System,
-		ProviderTools:                params.Tools,
-		ProviderInputAllowanceTokens: inputAllowance,
-		RecentProtectTokens:          cfg.ContextRecentProtectTokens, KeepRecentToolResults: stepReselectKeepRecentToolResults,
-		MinMessages: stepReselectMinMessages,
-	})
-	if mode == LoopReselectShadow {
-		snapshot.Dropped = selection.Dropped
-		snapshot.Truncated = selection.Truncated
-		snapshot.DropReasons = copyDropReasons(selection.DropReasons)
+	reselectionDetail := ""
+	if reselector != nil && prefixCount < len(params.Messages) {
+		beforeMessages := append([]sdk.Message(nil), params.Messages...)
+		selection := reselector(ctx, ContextStepSelectionInput{
+			Scope: cfg.ContextScope, InitialMessageCount: prefixCount, Messages: params.Messages,
+			BudgetMaxTokens:              remainingStepBudget(inputAllowance, params, prefixCount),
+			ProviderSystem:               params.System,
+			ProviderTools:                params.Tools,
+			ProviderInputAllowanceTokens: inputAllowance,
+			RecentProtectTokens:          cfg.ContextRecentProtectTokens, KeepRecentToolResults: stepReselectKeepRecentToolResults,
+			MinMessages: stepReselectMinMessages,
+		})
 		switch {
+		case mode == LoopReselectShadow:
+			snapshot.Dropped = selection.Dropped
+			snapshot.Truncated = selection.Truncated
+			snapshot.DropReasons = copyDropReasons(selection.DropReasons)
+			switch {
+			case selection.FatalError != nil:
+				snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeWouldFail
+			case selection.Messages != nil || selection.Dropped > 0 || selection.Truncated > 0:
+				snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeWouldApply
+			default:
+				snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeUnchanged
+			}
 		case selection.FatalError != nil:
-			snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeWouldFail
-		case selection.Messages != nil || selection.Dropped > 0 || selection.Truncated > 0:
-			snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeWouldApply
+			return failPreparedProviderAttempt(cfg, handoff, params, snapshot, prefixCount, provenance, selection.FatalError)
+		case selection.Messages != nil && stepSelectionPreservesPrefix(beforeMessages, selection.Messages, prefixCount):
+			sourceIndexes, valid := selectionMessageSourceIndexes(beforeMessages, selection.Messages, prefixCount, selection)
+			if !valid {
+				return failPreparedProviderAttempt(cfg, handoff, params, snapshot, prefixCount, provenance, fmt.Errorf(
+					"%w: invalid provider step message provenance",
+					contextfrag.ErrBudgetUnsatisfied,
+				))
+			}
+			composed, composedOK := composePreparedMessageProvenance(provenance, len(beforeMessages), sourceIndexes)
+			if !composedOK {
+				composed = failClosedPreparedMessageProvenance(provenance, len(selection.Messages), prefixCount)
+			}
+			params.Messages = selection.Messages
+			provenance = composed
+			snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeApplied
+			snapshot.ReselectionApplied = true
+			snapshot.Dropped = selection.Dropped
+			snapshot.Truncated = selection.Truncated
+			snapshot.DropReasons = copyDropReasons(selection.DropReasons)
+			if selection.Dropped > 0 || selection.Truncated > 0 {
+				reselectionDetail = contextStepSelectionDetail(selection)
+			}
 		default:
 			snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeUnchanged
 		}
-		stagePreparedProviderAttempt(ctx, handoff, snapshot, systemPrepended, "", provenance)
-		return params
-	}
-
-	switch {
-	case selection.FatalError != nil:
-		return failPreparedProviderAttempt(cfg, handoff, params, snapshot, prefixCount, provenance, selection.FatalError)
-	case selection.Messages != nil && stepSelectionPreservesPrefix(beforeMessages, selection.Messages, prefixCount):
-		sourceIndexes, valid := selectionMessageSourceIndexes(beforeMessages, selection.Messages, prefixCount, selection)
-		if !valid {
-			return failPreparedProviderAttempt(cfg, handoff, params, snapshot, prefixCount, provenance, fmt.Errorf(
-				"%w: invalid provider step message provenance",
-				contextfrag.ErrBudgetUnsatisfied,
-			))
-		}
-		composed, composedOK := composePreparedMessageProvenance(provenance, len(beforeMessages), sourceIndexes)
-		if !composedOK {
-			composed = failClosedPreparedMessageProvenance(provenance, len(selection.Messages), prefixCount)
-		}
-		params.Messages = selection.Messages
-		provenance = composed
-		snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeApplied
-		snapshot.ReselectionApplied = true
-		snapshot.Dropped = selection.Dropped
-		snapshot.Truncated = selection.Truncated
-		snapshot.DropReasons = copyDropReasons(selection.DropReasons)
-	default:
-		snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeUnchanged
 	}
 	if overflow := providerAttemptEnvelopeOverflow(params, inputAllowance); overflow > 0 {
 		return failPreparedProviderAttempt(cfg, handoff, params, snapshot, prefixCount, provenance, fmt.Errorf(
@@ -1289,10 +1286,6 @@ func prepareProviderAttempt(
 			overflow,
 			inputAllowance,
 		))
-	}
-	reselectionDetail := ""
-	if snapshot.ReselectionApplied && (selection.Dropped > 0 || selection.Truncated > 0) {
-		reselectionDetail = contextStepSelectionDetail(selection)
 	}
 	stagePreparedProviderAttempt(ctx, handoff, snapshot, systemPrepended, reselectionDetail, provenance)
 	return params
@@ -1351,18 +1344,18 @@ func copyDropReasons(reasons map[string]int) map[string]int {
 	return out
 }
 
+// stepReselectionAllowance is the input allowance every provider dispatch is
+// checked against: the window minus the output reserve, whether the plan
+// recorded it or the run assembled its context without a plan.
 func stepReselectionAllowance(cfg RunConfig) int {
+	window, reserve := cfg.ContextBudgetMaxTokens, cfg.GenerationLimits().MaxOutputTokens
 	if plan := cfg.ContextManifest.BudgetPlan; plan != nil {
-		if plan.Window <= 0 {
-			return 0
-		}
-		allowance := plan.Window - plan.OutputReserve
-		if allowance < 1 {
-			return 1
-		}
-		return allowance
+		window, reserve = plan.Window, plan.OutputReserve
 	}
-	return cfg.EffectiveHistoryBudgetTokens()
+	if window <= 0 {
+		return 0
+	}
+	return max(window-reserve, 1)
 }
 
 func remainingStepBudget(maxTokens int, params *sdk.GenerateParams, prefixCount int) int {

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -1322,7 +1322,11 @@ func failPreparedProviderAttempt(
 	provenance preparedMessageProvenance,
 	err error,
 ) *sdk.GenerateParams {
-	snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeFailed
+	switch snapshot.ReselectionOutcome {
+	case contextfrag.ReselectionOutcomeWouldApply, contextfrag.ReselectionOutcomeWouldFail:
+	default:
+		snapshot.ReselectionOutcome = contextfrag.ReselectionOutcomeFailed
+	}
 	snapshot.ReselectionApplied = false
 	params.Messages = append([]sdk.Message(nil), params.Messages[:prefixCount]...)
 	handoff.reject(provenance)
@@ -1348,9 +1352,11 @@ func copyDropReasons(reasons map[string]int) map[string]int {
 // checked against: the window minus the output reserve, whether the plan
 // recorded it or the run assembled its context without a plan.
 func stepReselectionAllowance(cfg RunConfig) int {
-	window, reserve := cfg.ContextBudgetMaxTokens, cfg.GenerationLimits().MaxOutputTokens
+	window, reserve := cfg.ContextBudgetMaxTokens, 0
 	if plan := cfg.ContextManifest.BudgetPlan; plan != nil {
 		window, reserve = plan.Window, plan.OutputReserve
+	} else if window > 0 {
+		reserve = cfg.GenerationLimits().MaxOutputTokens
 	}
 	if window <= 0 {
 		return 0

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -1155,6 +1155,9 @@ func (a *Agent) buildGenerateOptions(ctx context.Context, cfg RunConfig, tools [
 		sdk.WithSystem(system),
 		sdk.WithMaxSteps(-1),
 	}
+	if limits := cfg.GenerationLimits(); limits.Enforced {
+		opts = append(opts, sdk.WithMaxTokens(limits.MaxOutputTokens))
+	}
 	if len(providerTools) > 0 {
 		opts = append(opts, sdk.WithTools(providerTools))
 	}

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -1281,7 +1281,7 @@ func prepareProviderAttempt(
 	}
 	if overflow := providerAttemptEnvelopeOverflow(params, inputAllowance); overflow > 0 {
 		return failPreparedProviderAttempt(cfg, handoff, params, snapshot, prefixCount, provenance, fmt.Errorf(
-			"%w: serialized_input_overflow=%d allowance=%d",
+			"%w: input_overflow=%d allowance=%d",
 			contextfrag.ErrBudgetUnsatisfied,
 			overflow,
 			inputAllowance,
@@ -1314,8 +1314,7 @@ func providerAttemptEnvelopeOverflow(params *sdk.GenerateParams, allowance int) 
 	if params == nil || allowance <= 0 {
 		return 0
 	}
-	_, payloadBytes := contextfrag.ProviderPayloadHashAndBytes(params.System, params.Messages, params.Tools)
-	return contextfrag.ProviderBudgetTokensFromBytes(payloadBytes) - allowance
+	return contextfrag.ProviderEnvelopeTokens(params.System, params.Messages, params.Tools) - allowance
 }
 
 func failPreparedProviderAttempt(
@@ -1368,9 +1367,7 @@ func remainingStepBudget(maxTokens int, params *sdk.GenerateParams, prefixCount 
 		return 0
 	}
 	prefixCount = clampStableMessageCount(prefixCount, len(params.Messages))
-	prefixMessages := append([]sdk.Message(nil), params.Messages[:prefixCount]...)
-	_, bytes := contextfrag.ProviderPayloadHashAndBytes(params.System, prefixMessages, params.Tools)
-	remaining := maxTokens - contextfrag.ProviderBudgetTokensFromBytes(bytes)
+	remaining := maxTokens - contextfrag.ProviderEnvelopeTokens(params.System, params.Messages[:prefixCount], params.Tools)
 	if remaining < 1 {
 		return 1
 	}

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -1155,7 +1155,7 @@ func (a *Agent) buildGenerateOptions(ctx context.Context, cfg RunConfig, tools [
 		sdk.WithSystem(system),
 		sdk.WithMaxSteps(-1),
 	}
-	if limits := cfg.GenerationLimits(); limits.Enforced {
+	if limits := cfg.GenerationLimits(); limits.Requested {
 		opts = append(opts, sdk.WithMaxTokens(limits.MaxOutputTokens))
 	}
 	if len(providerTools) > 0 {

--- a/internal/agent/runtime/native/context_frag.go
+++ b/internal/agent/runtime/native/context_frag.go
@@ -21,6 +21,18 @@ func (cfg RunConfig) EffectiveHistoryBudgetTokens() int {
 	return budget
 }
 
+// GenerationLimits resolves the turn's output allowance from the model the
+// run dispatches to and the thinking decision it was constructed with. The
+// context budget plan reserves exactly this value and, when enforced, the
+// provider request carries it as max_tokens.
+func (cfg RunConfig) GenerationLimits() models.GenerationLimits {
+	return models.ResolveGenerationLimits(
+		models.ClientType(models.ResolveClientType(cfg.Model)),
+		cfg.ReasoningConfig,
+		cfg.ContextBudgetMaxTokens,
+	)
+}
+
 // RefreshContextFrag rebuilds the typed context frag view from the legacy
 // RunConfig fields. The SDK-facing fields remain the source of truth in phase 1.
 func (cfg RunConfig) RefreshContextFrag() RunConfig {

--- a/internal/agent/runtime/native/context_frag.go
+++ b/internal/agent/runtime/native/context_frag.go
@@ -23,7 +23,7 @@ func (cfg RunConfig) EffectiveHistoryBudgetTokens() int {
 
 // GenerationLimits resolves the turn's output allowance from the model the
 // run dispatches to and the thinking decision it was constructed with. The
-// context budget plan reserves exactly this value and, when enforced, the
+// context budget plan reserves exactly this value and, when requested, the
 // provider request carries it as max_tokens.
 func (cfg RunConfig) GenerationLimits() models.GenerationLimits {
 	return models.ResolveGenerationLimits(

--- a/internal/agent/runtime/native/context_frag.go
+++ b/internal/agent/runtime/native/context_frag.go
@@ -5,22 +5,6 @@ import (
 	"github.com/memohai/memoh/internal/models"
 )
 
-// EffectiveHistoryBudgetTokens is the droppable-history budget after fixed
-// tool-definition overhead. Zero retains its unlimited-budget meaning.
-func (cfg RunConfig) EffectiveHistoryBudgetTokens() int {
-	budget := cfg.ContextBudgetMaxTokens
-	if budget <= 0 {
-		return budget
-	}
-	for _, def := range cfg.ContextToolDefs {
-		budget -= def.TokenEstimate
-	}
-	if budget < 1 {
-		return 1
-	}
-	return budget
-}
-
 // GenerationLimits resolves the turn's output allowance from the model the
 // run dispatches to and the thinking decision it was constructed with. The
 // context budget plan reserves exactly this value and, when requested, the

--- a/internal/agent/runtime/native/context_view_applier_test.go
+++ b/internal/agent/runtime/native/context_view_applier_test.go
@@ -56,7 +56,7 @@ func TestGenerateAppliesContextViewBeforeProviderOptions(t *testing.T) {
 	if params.System != "compiled system" || !reflect.DeepEqual(params.Messages, []sdk.Message{sdk.UserMessage("compiled message")}) {
 		t.Fatalf("provider payload = system %q messages %#v", params.System, params.Messages)
 	}
-	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(params.System, params.Messages, params.Tools)
+	wantHash := contextfrag.ProviderPayloadHash(params.System, params.Messages, params.Tools)
 	if ledger.FinalInputHash() != wantHash {
 		t.Fatalf("final input hash = %q, want %q", ledger.FinalInputHash(), wantHash)
 	}
@@ -93,7 +93,7 @@ func TestGenerateFinalInputHashTracksLastProviderStep(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Generate error: %v", err)
 	}
-	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(lastParams.System, lastParams.Messages, lastParams.Tools)
+	wantHash := contextfrag.ProviderPayloadHash(lastParams.System, lastParams.Messages, lastParams.Tools)
 	if ledger.FinalInputHash() != wantHash {
 		t.Fatalf("final input hash = %q, want last provider step %q", ledger.FinalInputHash(), wantHash)
 	}

--- a/internal/agent/runtime/native/generation_limits_test.go
+++ b/internal/agent/runtime/native/generation_limits_test.go
@@ -18,19 +18,19 @@ func TestRunConfigGenerationLimitsFollowModelAndReasoning(t *testing.T) {
 		ReasoningConfig:        &models.ReasoningConfig{Active: true, Adaptive: true, Effort: models.ReasoningEffortHigh},
 		ContextBudgetMaxTokens: 200_000,
 	}
-	if got := anthropic.GenerationLimits(); got.MaxOutputTokens != 32_000 || !got.Enforced || got.Resolution != models.GenerationLimitsProviderDefault {
-		t.Fatalf("anthropic adaptive limits = %+v, want enforced 32000 provider_default", got)
+	if got := anthropic.GenerationLimits(); got.MaxOutputTokens != 32_000 || !got.Requested || got.Resolution != models.GenerationLimitsProviderDefault {
+		t.Fatalf("anthropic adaptive limits = %+v, want requested 32000 provider_default", got)
 	}
 	generic := RunConfig{Model: &sdk.Model{ID: "mock", Provider: &atomicMockProvider{}}, ContextBudgetMaxTokens: 128_000}
-	if got := generic.GenerationLimits(); got.MaxOutputTokens != models.DefaultOutputReserveTokens || got.Enforced {
-		t.Fatalf("generic limits = %+v, want unenforced %d", got, models.DefaultOutputReserveTokens)
+	if got := generic.GenerationLimits(); got.MaxOutputTokens != models.DefaultOutputReserveTokens || got.Requested {
+		t.Fatalf("generic limits = %+v, want unrequested %d", got, models.DefaultOutputReserveTokens)
 	}
-	if got := (RunConfig{}).GenerationLimits(); got.MaxOutputTokens != models.DefaultOutputReserveTokens || got.Enforced {
-		t.Fatalf("model-less limits = %+v, want unenforced default", got)
+	if got := (RunConfig{}).GenerationLimits(); got.MaxOutputTokens != models.DefaultOutputReserveTokens || got.Requested {
+		t.Fatalf("model-less limits = %+v, want unrequested default", got)
 	}
 }
 
-func TestAgentGenerateSendsMaxTokensOnlyWhenLimitsAreEnforced(t *testing.T) {
+func TestAgentGenerateSendsMaxTokensOnlyWhenLimitsAreRequested(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -38,7 +38,7 @@ func TestAgentGenerateSendsMaxTokensOnlyWhenLimitsAreEnforced(t *testing.T) {
 		provider sdk.Provider
 		want     *int
 	}{
-		{name: "anthropic enforces the mirrored default", provider: anthropicNameMockProvider{&atomicMockProvider{}}, want: intPtr(4096)},
+		{name: "anthropic requests the mirrored default", provider: anthropicNameMockProvider{&atomicMockProvider{}}, want: intPtr(4096)},
 		{name: "generic completions keeps the provider default", provider: &atomicMockProvider{}, want: nil},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/agent/runtime/native/generation_limits_test.go
+++ b/internal/agent/runtime/native/generation_limits_test.go
@@ -1,0 +1,84 @@
+package native
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	"github.com/memohai/memoh/internal/models"
+)
+
+func TestRunConfigGenerationLimitsFollowModelAndReasoning(t *testing.T) {
+	t.Parallel()
+
+	anthropic := RunConfig{
+		Model:                  &sdk.Model{ID: "claude", Provider: anthropicNameMockProvider{&atomicMockProvider{}}},
+		ReasoningConfig:        &models.ReasoningConfig{Active: true, Adaptive: true, Effort: models.ReasoningEffortHigh},
+		ContextBudgetMaxTokens: 200_000,
+	}
+	if got := anthropic.GenerationLimits(); got.MaxOutputTokens != 32_000 || !got.Enforced || got.Resolution != models.GenerationLimitsProviderDefault {
+		t.Fatalf("anthropic adaptive limits = %+v, want enforced 32000 provider_default", got)
+	}
+	generic := RunConfig{Model: &sdk.Model{ID: "mock", Provider: &atomicMockProvider{}}, ContextBudgetMaxTokens: 128_000}
+	if got := generic.GenerationLimits(); got.MaxOutputTokens != models.DefaultOutputReserveTokens || got.Enforced {
+		t.Fatalf("generic limits = %+v, want unenforced %d", got, models.DefaultOutputReserveTokens)
+	}
+	if got := (RunConfig{}).GenerationLimits(); got.MaxOutputTokens != models.DefaultOutputReserveTokens || got.Enforced {
+		t.Fatalf("model-less limits = %+v, want unenforced default", got)
+	}
+}
+
+func TestAgentGenerateSendsMaxTokensOnlyWhenLimitsAreEnforced(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		provider sdk.Provider
+		want     *int
+	}{
+		{name: "anthropic enforces the mirrored default", provider: anthropicNameMockProvider{&atomicMockProvider{}}, want: intPtr(4096)},
+		{name: "generic completions keeps the provider default", provider: &atomicMockProvider{}, want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var seen sdk.GenerateParams
+			handler := func(_ int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+				seen = cloneGenerateParams(params)
+				return &sdk.GenerateResult{Text: "ok", FinishReason: sdk.FinishReasonStop}, nil
+			}
+			switch p := tc.provider.(type) {
+			case anthropicNameMockProvider:
+				p.handler = handler
+			case *atomicMockProvider:
+				p.handler = handler
+			}
+			a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
+				return cfg, nil
+			}})
+			plan := contextfrag.ContextBudgetPlan{Window: 200_000, OutputReserve: 4096}
+			_, err := a.Generate(context.Background(), RunConfig{
+				Model:                  &sdk.Model{ID: "model", Provider: tc.provider},
+				System:                 "system",
+				Messages:               []sdk.Message{sdk.UserMessage("task")},
+				Identity:               SessionContext{BotID: "bot-1"},
+				ContextMutations:       contextfrag.NewMutationLedger(),
+				ContextBudgetMaxTokens: 200_000,
+				ContextManifest:        contextfrag.Manifest{BudgetPlan: &plan},
+			})
+			if err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			switch {
+			case tc.want == nil && seen.MaxTokens != nil:
+				t.Fatalf("MaxTokens = %d, want the provider default to stand", *seen.MaxTokens)
+			case tc.want != nil && (seen.MaxTokens == nil || *seen.MaxTokens != *tc.want):
+				t.Fatalf("MaxTokens = %v, want %d", seen.MaxTokens, *tc.want)
+			}
+		})
+	}
+}
+
+func intPtr(v int) *int { return &v }

--- a/internal/agent/runtime/native/provider_attempt_final_envelope_test.go
+++ b/internal/agent/runtime/native/provider_attempt_final_envelope_test.go
@@ -98,9 +98,10 @@ func TestAgentGenerateShadowModeStillFailsClosedOnEnvelopeOverflow(t *testing.T)
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name       string
-		reselector ContextStepReselector
-		want       string
+		name        string
+		reselector  ContextStepReselector
+		want        string
+		wantDropped bool
 	}{
 		{
 			name: "would apply",
@@ -110,7 +111,8 @@ func TestAgentGenerateShadowModeStillFailsClosedOnEnvelopeOverflow(t *testing.T)
 					Dropped:  len(input.Messages) - input.InitialMessageCount,
 				}
 			},
-			want: contextfrag.ReselectionOutcomeWouldApply,
+			want:        contextfrag.ReselectionOutcomeWouldApply,
+			wantDropped: true,
 		},
 		{
 			name: "would fail",
@@ -175,7 +177,7 @@ func TestAgentGenerateShadowModeStillFailsClosedOnEnvelopeOverflow(t *testing.T)
 			if len(steps) != 2 {
 				t.Fatalf("step snapshots = %#v, want the dispatched step and the rejected shadow step", steps)
 			}
-			if rejected := steps[1]; rejected.ReselectionOutcome != tc.want || rejected.ReselectionApplied {
+			if rejected := steps[1]; rejected.ReselectionOutcome != tc.want || rejected.ReselectionApplied || (rejected.Dropped > 0) != tc.wantDropped {
 				t.Fatalf("shadow step snapshot = %#v, want the observed %s verdict kept on the rejected step", rejected, tc.want)
 			}
 		})

--- a/internal/agent/runtime/native/provider_attempt_final_envelope_test.go
+++ b/internal/agent/runtime/native/provider_attempt_final_envelope_test.go
@@ -97,65 +97,88 @@ func TestAgentGenerateChecksFullPrefixInitialEnvelopeWithReselector(t *testing.T
 func TestAgentGenerateShadowModeStillFailsClosedOnEnvelopeOverflow(t *testing.T) {
 	t.Parallel()
 
-	lookupTool := sdk.Tool{
-		Name:       "lookup",
-		Parameters: &jsonschema.Schema{Type: "object"},
-		Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
-			return strings.Repeat("large-result ", 1_000), nil
+	for _, tc := range []struct {
+		name       string
+		reselector ContextStepReselector
+		want       string
+	}{
+		{
+			name: "would apply",
+			reselector: func(_ context.Context, input ContextStepSelectionInput) ContextStepSelectionResult {
+				return ContextStepSelectionResult{
+					Messages: append([]sdk.Message(nil), input.Messages[:input.InitialMessageCount]...),
+					Dropped:  len(input.Messages) - input.InitialMessageCount,
+				}
+			},
+			want: contextfrag.ReselectionOutcomeWouldApply,
 		},
-	}
-	modelProvider := &atomicMockProvider{handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
-		if call != 1 {
-			return nil, fmt.Errorf("unexpected provider call %d after envelope overflow", call)
-		}
-		return &sdk.GenerateResult{
-			FinishReason: sdk.FinishReasonToolCalls,
-			ToolCalls: []sdk.ToolCall{{
-				ToolCallID: "call-shadow", ToolName: "lookup", Input: map[string]any{"q": "one"},
-			}},
-		}, nil
-	}}
-	a := New(Deps{
-		LoopReselectMode: LoopReselectShadow,
-		ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
-			return cfg, nil
+		{
+			name: "would fail",
+			reselector: func(context.Context, ContextStepSelectionInput) ContextStepSelectionResult {
+				return ContextStepSelectionResult{FatalError: contextfrag.ErrProtectedContextOverflow}
+			},
+			want: contextfrag.ReselectionOutcomeWouldFail,
 		},
-	})
-	a.SetToolProviders([]agenttools.ToolProvider{staticToolProvider{tools: []sdk.Tool{lookupTool}}})
-	plan := contextfrag.ContextBudgetPlan{Window: 2_000, OutputReserve: 100}
-	ledger := contextfrag.NewMutationLedger()
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err := a.Generate(context.Background(), RunConfig{
-		Model:                  &sdk.Model{ID: "mock-model", Provider: modelProvider},
-		System:                 "system",
-		Messages:               []sdk.Message{sdk.UserMessage("task")},
-		SupportsToolCall:       true,
-		Identity:               SessionContext{BotID: "bot-1"},
-		ContextMutations:       ledger,
-		ContextBudgetMaxTokens: plan.Window,
-		ContextManifest:        contextfrag.Manifest{BudgetPlan: &plan},
-		ContextStepReselector: func(_ context.Context, input ContextStepSelectionInput) ContextStepSelectionResult {
-			return ContextStepSelectionResult{
-				Messages: append([]sdk.Message(nil), input.Messages[:input.InitialMessageCount]...),
-				Dropped:  len(input.Messages) - input.InitialMessageCount,
+			lookupTool := sdk.Tool{
+				Name:       "lookup",
+				Parameters: &jsonschema.Schema{Type: "object"},
+				Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
+					return strings.Repeat("large-result ", 1_000), nil
+				},
 			}
-		},
-	})
-	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
-		t.Fatalf("Generate() error = %v, want %v", err, contextfrag.ErrBudgetUnsatisfied)
-	}
-	if got := modelProvider.calls.Load(); got != 1 {
-		t.Fatalf("provider calls = %d, want the initial call only", got)
-	}
-	if mode := ledger.LoopSelectionMode(); mode != contextfrag.LoopSelectionSuffixOnlyShadow {
-		t.Fatalf("loop selection mode = %q, want shadow", mode)
-	}
-	steps := ledger.StepSnapshots()
-	if len(steps) != 2 {
-		t.Fatalf("step snapshots = %#v, want the dispatched step and the rejected shadow step", steps)
-	}
-	if rejected := steps[1]; rejected.ReselectionOutcome != contextfrag.ReselectionOutcomeWouldApply || rejected.ReselectionApplied || rejected.Dropped == 0 {
-		t.Fatalf("shadow step snapshot = %#v, want the observed would_apply verdict kept on the rejected step", rejected)
+			modelProvider := &atomicMockProvider{handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+				if call != 1 {
+					return nil, fmt.Errorf("unexpected provider call %d after envelope overflow", call)
+				}
+				return &sdk.GenerateResult{
+					FinishReason: sdk.FinishReasonToolCalls,
+					ToolCalls: []sdk.ToolCall{{
+						ToolCallID: "call-shadow", ToolName: "lookup", Input: map[string]any{"q": "one"},
+					}},
+				}, nil
+			}}
+			a := New(Deps{
+				LoopReselectMode: LoopReselectShadow,
+				ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
+					return cfg, nil
+				},
+			})
+			a.SetToolProviders([]agenttools.ToolProvider{staticToolProvider{tools: []sdk.Tool{lookupTool}}})
+			plan := contextfrag.ContextBudgetPlan{Window: 2_000, OutputReserve: 100}
+			ledger := contextfrag.NewMutationLedger()
+
+			_, err := a.Generate(context.Background(), RunConfig{
+				Model:                  &sdk.Model{ID: "mock-model", Provider: modelProvider},
+				System:                 "system",
+				Messages:               []sdk.Message{sdk.UserMessage("task")},
+				SupportsToolCall:       true,
+				Identity:               SessionContext{BotID: "bot-1"},
+				ContextMutations:       ledger,
+				ContextBudgetMaxTokens: plan.Window,
+				ContextManifest:        contextfrag.Manifest{BudgetPlan: &plan},
+				ContextStepReselector:  tc.reselector,
+			})
+			if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+				t.Fatalf("Generate() error = %v, want %v", err, contextfrag.ErrBudgetUnsatisfied)
+			}
+			if got := modelProvider.calls.Load(); got != 1 {
+				t.Fatalf("provider calls = %d, want the initial call only", got)
+			}
+			if mode := ledger.LoopSelectionMode(); mode != contextfrag.LoopSelectionSuffixOnlyShadow {
+				t.Fatalf("loop selection mode = %q, want shadow", mode)
+			}
+			steps := ledger.StepSnapshots()
+			if len(steps) != 2 {
+				t.Fatalf("step snapshots = %#v, want the dispatched step and the rejected shadow step", steps)
+			}
+			if rejected := steps[1]; rejected.ReselectionOutcome != tc.want || rejected.ReselectionApplied {
+				t.Fatalf("shadow step snapshot = %#v, want the observed %s verdict kept on the rejected step", rejected, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/agent/runtime/native/provider_attempt_final_envelope_test.go
+++ b/internal/agent/runtime/native/provider_attempt_final_envelope_test.go
@@ -50,6 +50,18 @@ func TestAgentGenerateChecksInitialEnvelopeWithoutReselector(t *testing.T) {
 	if len(records) != 1 || records[0].Kind != contextfrag.MutationContextBudgetFailure {
 		t.Fatalf("mutations = %#v, want one context budget failure", records)
 	}
+	assertRejectedInitialStep(t, cfg.ContextMutations)
+}
+
+func assertRejectedInitialStep(t *testing.T, ledger *contextfrag.MutationLedger) {
+	t.Helper()
+	steps := ledger.StepSnapshots()
+	if len(steps) != 1 {
+		t.Fatalf("step snapshots = %#v, want exactly the rejected initial step", steps)
+	}
+	if steps[0].StepIndex != 0 || steps[0].ReselectionApplied || steps[0].ReselectionOutcome != contextfrag.ReselectionOutcomeFailed {
+		t.Fatalf("initial step snapshot = %#v, want step 0 failed without reselection", steps[0])
+	}
 }
 
 func TestAgentGenerateChecksFullPrefixInitialEnvelopeWithReselector(t *testing.T) {
@@ -79,6 +91,7 @@ func TestAgentGenerateChecksFullPrefixInitialEnvelopeWithReselector(t *testing.T
 	if reselectorCalls != 0 {
 		t.Fatalf("reselector calls = %d, want none for a prefix-only initial dispatch", reselectorCalls)
 	}
+	assertRejectedInitialStep(t, cfg.ContextMutations)
 }
 
 func TestAgentGenerateShadowModeStillFailsClosedOnEnvelopeOverflow(t *testing.T) {
@@ -121,8 +134,11 @@ func TestAgentGenerateShadowModeStillFailsClosedOnEnvelopeOverflow(t *testing.T)
 		ContextMutations:       ledger,
 		ContextBudgetMaxTokens: plan.Window,
 		ContextManifest:        contextfrag.Manifest{BudgetPlan: &plan},
-		ContextStepReselector: func(context.Context, ContextStepSelectionInput) ContextStepSelectionResult {
-			return ContextStepSelectionResult{}
+		ContextStepReselector: func(_ context.Context, input ContextStepSelectionInput) ContextStepSelectionResult {
+			return ContextStepSelectionResult{
+				Messages: append([]sdk.Message(nil), input.Messages[:input.InitialMessageCount]...),
+				Dropped:  len(input.Messages) - input.InitialMessageCount,
+			}
 		},
 	})
 	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
@@ -133,6 +149,13 @@ func TestAgentGenerateShadowModeStillFailsClosedOnEnvelopeOverflow(t *testing.T)
 	}
 	if mode := ledger.LoopSelectionMode(); mode != contextfrag.LoopSelectionSuffixOnlyShadow {
 		t.Fatalf("loop selection mode = %q, want shadow", mode)
+	}
+	steps := ledger.StepSnapshots()
+	if len(steps) != 2 {
+		t.Fatalf("step snapshots = %#v, want the dispatched step and the rejected shadow step", steps)
+	}
+	if rejected := steps[1]; rejected.ReselectionOutcome != contextfrag.ReselectionOutcomeWouldApply || rejected.ReselectionApplied || rejected.Dropped == 0 {
+		t.Fatalf("shadow step snapshot = %#v, want the observed would_apply verdict kept on the rejected step", rejected)
 	}
 }
 

--- a/internal/agent/runtime/native/provider_attempt_final_envelope_test.go
+++ b/internal/agent/runtime/native/provider_attempt_final_envelope_test.go
@@ -1,0 +1,154 @@
+package native
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agenttools "github.com/memohai/memoh/internal/agent/tool"
+	"github.com/memohai/memoh/internal/models"
+)
+
+func oversizedPrefixRunConfig(provider sdk.Provider, plan *contextfrag.ContextBudgetPlan) RunConfig {
+	return RunConfig{
+		Model:                  &sdk.Model{ID: "mock-model", Provider: provider},
+		System:                 "system",
+		Messages:               []sdk.Message{sdk.UserMessage(strings.Repeat("oversized ", 2_000))},
+		Identity:               SessionContext{BotID: "bot-1"},
+		ContextMutations:       contextfrag.NewMutationLedger(),
+		ContextBudgetMaxTokens: plan.Window,
+		ContextManifest:        contextfrag.Manifest{BudgetPlan: plan},
+	}
+}
+
+func TestAgentGenerateChecksInitialEnvelopeWithoutReselector(t *testing.T) {
+	t.Parallel()
+
+	modelProvider := &atomicMockProvider{handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		return nil, fmt.Errorf("provider must not be called for an oversized prefix (call %d)", call)
+	}}
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
+		return cfg, nil
+	}})
+	plan := contextfrag.ContextBudgetPlan{Window: 2_000, OutputReserve: 500}
+	cfg := oversizedPrefixRunConfig(modelProvider, &plan)
+
+	_, err := a.Generate(context.Background(), cfg)
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("Generate() error = %v, want %v", err, contextfrag.ErrBudgetUnsatisfied)
+	}
+	if got := modelProvider.calls.Load(); got != 0 {
+		t.Fatalf("provider calls = %d, want 0", got)
+	}
+	records := cfg.ContextMutations.Records()
+	if len(records) != 1 || records[0].Kind != contextfrag.MutationContextBudgetFailure {
+		t.Fatalf("mutations = %#v, want one context budget failure", records)
+	}
+}
+
+func TestAgentGenerateChecksFullPrefixInitialEnvelopeWithReselector(t *testing.T) {
+	t.Parallel()
+
+	modelProvider := &atomicMockProvider{handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		return nil, fmt.Errorf("provider must not be called for an oversized prefix (call %d)", call)
+	}}
+	a := New(Deps{ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
+		return cfg, nil
+	}})
+	plan := contextfrag.ContextBudgetPlan{Window: 2_000, OutputReserve: 500}
+	cfg := oversizedPrefixRunConfig(modelProvider, &plan)
+	reselectorCalls := 0
+	cfg.ContextStepReselector = func(context.Context, ContextStepSelectionInput) ContextStepSelectionResult {
+		reselectorCalls++
+		return ContextStepSelectionResult{}
+	}
+
+	_, err := a.Generate(context.Background(), cfg)
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("Generate() error = %v, want %v", err, contextfrag.ErrBudgetUnsatisfied)
+	}
+	if got := modelProvider.calls.Load(); got != 0 {
+		t.Fatalf("provider calls = %d, want 0", got)
+	}
+	if reselectorCalls != 0 {
+		t.Fatalf("reselector calls = %d, want none for a prefix-only initial dispatch", reselectorCalls)
+	}
+}
+
+func TestAgentGenerateShadowModeStillFailsClosedOnEnvelopeOverflow(t *testing.T) {
+	t.Parallel()
+
+	lookupTool := sdk.Tool{
+		Name:       "lookup",
+		Parameters: &jsonschema.Schema{Type: "object"},
+		Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
+			return strings.Repeat("large-result ", 1_000), nil
+		},
+	}
+	modelProvider := &atomicMockProvider{handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		if call != 1 {
+			return nil, fmt.Errorf("unexpected provider call %d after envelope overflow", call)
+		}
+		return &sdk.GenerateResult{
+			FinishReason: sdk.FinishReasonToolCalls,
+			ToolCalls: []sdk.ToolCall{{
+				ToolCallID: "call-shadow", ToolName: "lookup", Input: map[string]any{"q": "one"},
+			}},
+		}, nil
+	}}
+	a := New(Deps{
+		LoopReselectMode: LoopReselectShadow,
+		ContextViewApplier: func(_ context.Context, cfg RunConfig) (RunConfig, error) {
+			return cfg, nil
+		},
+	})
+	a.SetToolProviders([]agenttools.ToolProvider{staticToolProvider{tools: []sdk.Tool{lookupTool}}})
+	plan := contextfrag.ContextBudgetPlan{Window: 2_000, OutputReserve: 100}
+	ledger := contextfrag.NewMutationLedger()
+
+	_, err := a.Generate(context.Background(), RunConfig{
+		Model:                  &sdk.Model{ID: "mock-model", Provider: modelProvider},
+		System:                 "system",
+		Messages:               []sdk.Message{sdk.UserMessage("task")},
+		SupportsToolCall:       true,
+		Identity:               SessionContext{BotID: "bot-1"},
+		ContextMutations:       ledger,
+		ContextBudgetMaxTokens: plan.Window,
+		ContextManifest:        contextfrag.Manifest{BudgetPlan: &plan},
+		ContextStepReselector: func(context.Context, ContextStepSelectionInput) ContextStepSelectionResult {
+			return ContextStepSelectionResult{}
+		},
+	})
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("Generate() error = %v, want %v", err, contextfrag.ErrBudgetUnsatisfied)
+	}
+	if got := modelProvider.calls.Load(); got != 1 {
+		t.Fatalf("provider calls = %d, want the initial call only", got)
+	}
+	if mode := ledger.LoopSelectionMode(); mode != contextfrag.LoopSelectionSuffixOnlyShadow {
+		t.Fatalf("loop selection mode = %q, want shadow", mode)
+	}
+}
+
+func TestStepReselectionAllowanceWithoutPlanReservesResolvedOutput(t *testing.T) {
+	t.Parallel()
+
+	cfg := RunConfig{
+		Model:                  &sdk.Model{ID: "claude", Provider: anthropicNameMockProvider{&atomicMockProvider{}}},
+		ReasoningConfig:        &models.ReasoningConfig{Active: true, Adaptive: true, Effort: models.ReasoningEffortHigh},
+		ContextBudgetMaxTokens: 200_000,
+		ContextToolDefs:        []contextfrag.ToolDefAccounting{{Name: "lookup", TokenEstimate: 900}},
+	}
+	if got := stepReselectionAllowance(cfg); got != 200_000-32_000 {
+		t.Fatalf("allowance without a plan = %d, want window minus the resolved output reserve", got)
+	}
+	if got := stepReselectionAllowance(RunConfig{}); got != 0 {
+		t.Fatalf("allowance without a window = %d, want budgeting disabled", got)
+	}
+}

--- a/internal/agent/runtime/native/provider_attempt_handoff.go
+++ b/internal/agent/runtime/native/provider_attempt_handoff.go
@@ -97,7 +97,7 @@ func (h *providerAttemptHandoff) publish(params sdk.GenerateParams) error {
 	}
 
 	h.cfg.preparedStepMessages.reconcile(params.Messages, pending.provenance)
-	hash, _ := contextfrag.ProviderPayloadHashAndBytes(params.System, params.Messages, params.Tools)
+	hash := contextfrag.ProviderPayloadHash(params.System, params.Messages, params.Tools)
 	h.cfg.providerAttemptState.store(&params, pending.snapshot.StepIndex, pending.systemPrepended, pending.provenance)
 	h.cfg.ContextMutations.SetFinalInputHash(hash)
 	pending.snapshot.PostPrepareInputHash = hash

--- a/internal/agent/runtime/native/provider_attempt_handoff_test.go
+++ b/internal/agent/runtime/native/provider_attempt_handoff_test.go
@@ -26,7 +26,7 @@ func TestProviderAttemptHandoffRejectsCanceledDispatch(t *testing.T) {
 			t.Parallel()
 
 			oldParams := sdk.GenerateParams{Messages: []sdk.Message{sdk.UserMessage("last dispatched")}}
-			oldHash, _ := contextfrag.ProviderPayloadHashAndBytes(oldParams.System, oldParams.Messages, oldParams.Tools)
+			oldHash := contextfrag.ProviderPayloadHash(oldParams.System, oldParams.Messages, oldParams.Tools)
 			ledger := contextfrag.NewMutationLedger()
 			ledger.SetFinalInputHash(oldHash)
 			ledger.AppendStepSnapshot(contextfrag.StepSnapshot{StepIndex: 0, PostPrepareInputHash: oldHash})
@@ -138,7 +138,7 @@ func TestProviderAttemptHandoffPublishesBeforeProviderEntry(t *testing.T) {
 				Tools:    []sdk.Tool{{Name: "lookup"}},
 			}
 			params = *prepare(&params)
-			wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(params.System, params.Messages, params.Tools)
+			wantHash := contextfrag.ProviderPayloadHash(params.System, params.Messages, params.Tools)
 			ledger := contextfrag.NewMutationLedger()
 			fork := agenttools.NewMessageSnapshot(nil)
 			attemptState := &providerAttemptState{}

--- a/internal/agent/runtime/native/provider_attempt_preflight_test.go
+++ b/internal/agent/runtime/native/provider_attempt_preflight_test.go
@@ -198,7 +198,7 @@ func TestAgentGenerateInitialHookProviderAttemptModes(t *testing.T) {
 				return
 			}
 
-			wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(providerParams.System, providerParams.Messages, providerParams.Tools)
+			wantHash := contextfrag.ProviderPayloadHash(providerParams.System, providerParams.Messages, providerParams.Tools)
 			if steps[0].PostPrepareInputHash != wantHash {
 				t.Fatalf("step hash = %q, want actual provider hash %q", steps[0].PostPrepareInputHash, wantHash)
 			}
@@ -324,7 +324,7 @@ func TestPrepareProviderAttemptStepZeroWindowZeroAppliesSuffixHygiene(t *testing
 		steps[0].Truncated != 6 {
 		t.Fatalf("step snapshots = %#v", steps)
 	}
-	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(params.System, params.Messages, params.Tools)
+	wantHash := contextfrag.ProviderPayloadHash(params.System, params.Messages, params.Tools)
 	if steps[0].PostPrepareInputHash != wantHash || ledger.FinalInputHash() != wantHash {
 		t.Fatalf("step/final hashes = %q/%q, want %q", steps[0].PostPrepareInputHash, ledger.FinalInputHash(), wantHash)
 	}
@@ -377,7 +377,7 @@ func TestAgentGenerateSnapshotHashesResolvedMapToolSchema(t *testing.T) {
 	if len(steps) != 1 {
 		t.Fatalf("step snapshots = %#v, want one", steps)
 	}
-	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(
+	wantHash := contextfrag.ProviderPayloadHash(
 		providerParams.System,
 		providerParams.Messages,
 		providerParams.Tools,
@@ -472,7 +472,7 @@ func TestAgentGenerateHookStaysGovernedAcrossAnthropicProviderSteps(t *testing.T
 			step.ReselectionOutcome != contextfrag.ReselectionOutcomeUnchanged {
 			t.Fatalf("steps[%d] = %#v", i, step)
 		}
-		wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(
+		wantHash := contextfrag.ProviderPayloadHash(
 			callParams[i].System, callParams[i].Messages, callParams[i].Tools,
 		)
 		if step.PostPrepareInputHash != wantHash {

--- a/internal/agent/runtime/native/provider_attempt_reconciliation_test.go
+++ b/internal/agent/runtime/native/provider_attempt_reconciliation_test.go
@@ -149,7 +149,7 @@ func TestAgentGenerateFailedPreflightKeepsLastDispatchedHashAndFork(t *testing.T
 	if !errors.Is(err, contextfrag.ErrProtectedContextOverflow) {
 		t.Fatalf("Generate() error = %v, want %v", err, contextfrag.ErrProtectedContextOverflow)
 	}
-	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(
+	wantHash := contextfrag.ProviderPayloadHash(
 		firstProviderInput.System,
 		firstProviderInput.Messages,
 		firstProviderInput.Tools,
@@ -522,7 +522,7 @@ func TestAgentGenerateCanceledPreflightKeepsLastDispatchedHashAndFork(t *testing
 	if modelProvider.calls.Load() != 1 {
 		t.Fatalf("provider calls = %d, want 1", modelProvider.calls.Load())
 	}
-	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(
+	wantHash := contextfrag.ProviderPayloadHash(
 		firstProviderInput.System,
 		firstProviderInput.Messages,
 		firstProviderInput.Tools,

--- a/internal/agent/runtime/native/provider_attempt_retry_test.go
+++ b/internal/agent/runtime/native/provider_attempt_retry_test.go
@@ -194,7 +194,7 @@ func TestRunMidStreamRetryWindowZeroAppliesAccumulatedSuffixHygiene(t *testing.T
 		retryStep.Truncated != 6 {
 		t.Fatalf("retry step = %#v", retryStep)
 	}
-	wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(retryParams.System, retryParams.Messages, retryParams.Tools)
+	wantHash := contextfrag.ProviderPayloadHash(retryParams.System, retryParams.Messages, retryParams.Tools)
 	if retryStep.PostPrepareInputHash != wantHash || ledger.FinalInputHash() != wantHash {
 		t.Fatalf("retry/final hashes = %q/%q, want %q", retryStep.PostPrepareInputHash, ledger.FinalInputHash(), wantHash)
 	}

--- a/internal/agent/runtime/native/provider_budget_test.go
+++ b/internal/agent/runtime/native/provider_budget_test.go
@@ -16,15 +16,37 @@ func TestRemainingStepBudgetUsesConservativeProviderEstimator(t *testing.T) {
 		System:   strings.Repeat("s", 101),
 		Messages: []sdk.Message{sdk.UserMessage(strings.Repeat("m", 103))},
 	}
-	_, payloadBytes := contextfrag.ProviderPayloadHashAndBytes(params.System, params.Messages, params.Tools)
-	legacy := contextfrag.TokensFromBytes(payloadBytes)
-	conservative := contextfrag.ProviderBudgetTokensFromBytes(payloadBytes)
-	if conservative <= legacy {
-		t.Fatalf("fixture estimates = legacy %d conservative %d, want conservative to be greater", legacy, conservative)
+	legacy := contextfrag.TokensFromBytes(len(params.System)) + contextfrag.EstimateSDKMessageTokens(params.Messages[0])
+	if legacy != 50 {
+		t.Fatalf("legacy estimate = %d, want 50", legacy)
 	}
 
 	const allowance = 1000
-	if got, want := remainingStepBudget(allowance, params, len(params.Messages)), allowance-conservative; got != want {
-		t.Fatalf("remainingStepBudget() = %d, want provider allowance %d", got, want)
+	if got := remainingStepBudget(allowance, params, len(params.Messages)); got != 936 {
+		t.Fatalf("remainingStepBudget() = %d, want 936 (ceil(101/4)*1.25 + ceil(103/4)*1.25 = 64 reserved)", got)
+	}
+}
+
+func TestStepEnvelopeEstimatesPriceFrozenPrefixImagesFlat(t *testing.T) {
+	t.Parallel()
+
+	photo := sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{
+		sdk.TextPart{Text: "what is in this photo?"},
+		sdk.ImagePart{Image: "data:image/jpeg;base64," + strings.Repeat("A", 400_000), MediaType: "image/jpeg"},
+	}}
+	params := &sdk.GenerateParams{
+		System:   "system",
+		Messages: []sdk.Message{photo, sdk.AssistantMessage("looking")},
+	}
+	const allowance = 128_000 - 8_192
+	prefixCost := contextfrag.ProviderEnvelopeTokens(params.System, params.Messages[:1], nil)
+	if prefixCost != 1_509 {
+		t.Fatalf("photo prefix cost = %d, want 1509 (flat image + 9 text tokens)", prefixCost)
+	}
+	if got, want := remainingStepBudget(allowance, params, 1), allowance-prefixCost; got != want {
+		t.Fatalf("remainingStepBudget() = %d, want %d", got, want)
+	}
+	if overflow := providerAttemptEnvelopeOverflow(params, allowance); overflow >= 0 {
+		t.Fatalf("providerAttemptEnvelopeOverflow() = %d, want a photo turn to stay inside the allowance", overflow)
 	}
 }

--- a/internal/agent/runtime/native/step_snapshot_test.go
+++ b/internal/agent/runtime/native/step_snapshot_test.go
@@ -329,7 +329,7 @@ func TestAgentGenerateRecordsOneStepSnapshotPerModelStepWithDistinctHashes(t *te
 		if step.PostPrepareInputHash == "" {
 			t.Fatalf("steps[%d].PostPrepareInputHash empty", i)
 		}
-		wantHash, _ := contextfrag.ProviderPayloadHashAndBytes(callParams[i].System, callParams[i].Messages, callParams[i].Tools)
+		wantHash := contextfrag.ProviderPayloadHash(callParams[i].System, callParams[i].Messages, callParams[i].Tools)
 		if step.PostPrepareInputHash != wantHash {
 			t.Fatalf("steps[%d].PostPrepareInputHash = %q, want hash of call %d's actual input %q", i, step.PostPrepareInputHash, i, wantHash)
 		}

--- a/internal/agent/tool/subagent.go
+++ b/internal/agent/tool/subagent.go
@@ -1839,6 +1839,10 @@ func (p *SpawnProvider) resolveModel(
 	if err != nil {
 		return resolvedSubagentModel{}, fmt.Errorf("resolve subagent reasoning: %w", err)
 	}
+	contextWindow := modelInfo.Config.ContextBudgetMaxTokens()
+	if contextWindow <= 0 {
+		contextWindow = session.ContextBudgetMaxTokens
+	}
 
 	sdkModel := models.NewSDKChatModel(models.SDKModelConfig{
 		ModelID:               modelInfo.ModelID,
@@ -1853,6 +1857,7 @@ func (p *SpawnProvider) resolveModel(
 		ReasoningDefaultOn:    modelInfo.Config.ReasoningDefaultOn,
 		ThinkingBudgetMin:     modelInfo.Config.ThinkingBudgetMin,
 		ThinkingBudgetMax:     modelInfo.Config.ThinkingBudgetMax,
+		ContextWindow:         contextWindow,
 	})
 	return resolvedSubagentModel{
 		Model:                  sdkModel,
@@ -1864,7 +1869,7 @@ func (p *SpawnProvider) resolveModel(
 		ChatCompletionsCompat:  chatCompletionsCompat,
 		SupportsImageInput:     modelInfo.HasCompatibility(models.CompatVision),
 		SupportsToolCall:       modelInfo.HasCompatibility(models.CompatToolCall),
-		ContextBudgetMaxTokens: modelInfo.Config.ContextBudgetMaxTokens(),
+		ContextBudgetMaxTokens: contextWindow,
 	}, nil
 }
 

--- a/internal/contextview/provider_budget_plan_test.go
+++ b/internal/contextview/provider_budget_plan_test.go
@@ -13,6 +13,7 @@ import (
 
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/models"
 )
 
 func contextWindowForDefaultOutputReserve(inputBudget int) int {
@@ -21,7 +22,7 @@ func contextWindowForDefaultOutputReserve(inputBudget int) int {
 	}
 	window := inputBudget
 	for {
-		resolved := inputBudget + min(DefaultOutputReserveTokens, window/4)
+		resolved := inputBudget + min(models.DefaultOutputReserveTokens, window/4)
 		if resolved == window {
 			return window
 		}

--- a/internal/contextview/provider_envelope_budget.go
+++ b/internal/contextview/provider_envelope_budget.go
@@ -9,10 +9,7 @@ import (
 func providerToolDefsCost(definitions []contextfrag.ToolDefAccounting) int {
 	total := 0
 	for _, definition := range definitions {
-		total += max(
-			definition.TokenEstimate,
-			contextfrag.ProviderBudgetTokensFromBytes(definition.Bytes),
-		)
+		total += contextfrag.ProviderToolDefTokens(definition)
 	}
 	return total
 }
@@ -24,12 +21,7 @@ func providerRenderedEnvelopeTokens(
 	if payload == nil {
 		return 0
 	}
-	total := contextfrag.ProviderBudgetTokensFromBytes(len(payload.System))
-	for _, message := range payload.Messages {
-		frag := contextfrag.MessageFrag(contextfrag.MessageFragInput{Message: message})
-		total += contextfrag.ResolveProviderBudgetFragTokens(frag)
-	}
-	return total + providerToolDefsCost(toolDefs)
+	return contextfrag.ProviderEnvelopeTokens(payload.System, payload.Messages, nil) + providerToolDefsCost(toolDefs)
 }
 
 func validateProviderRenderedEnvelope(

--- a/internal/contextview/provider_envelope_budget_regression_test.go
+++ b/internal/contextview/provider_envelope_budget_regression_test.go
@@ -86,7 +86,7 @@ func TestProviderSelectorReservesConservativeHistoryTrimNotice(t *testing.T) {
 	}
 }
 
-func TestApplyProviderRunConfigFailsClosedOnRenderedEnvelopeOverflow(t *testing.T) {
+func TestApplyProviderRunConfigTrimsUnderchargedHistoryBeforeDispatch(t *testing.T) {
 	t.Parallel()
 
 	history := testBudgetMessageFrag(
@@ -104,17 +104,42 @@ func TestApplyProviderRunConfigFailsClosedOnRenderedEnvelopeOverflow(t *testing.
 		ContextSourceFrags:     []contextfrag.ContextFrag{history, current},
 		ContextBudgetMaxTokens: 1_000,
 	})
+	if err != nil {
+		t.Fatalf("preflight error = %v, want undercharged history trimmed by envelope pricing", err)
+	}
+	for _, message := range out.Messages {
+		if strings.Contains(messageText(t, message), "xxxx") {
+			t.Fatal("undercharged history reached the provider payload")
+		}
+	}
+	plan := out.ContextManifest.BudgetPlan
+	if plan == nil {
+		t.Fatal("budget plan missing from manifest")
+	}
+	if rendered := contextfrag.ProviderEnvelopeTokens(out.System, out.Messages, nil); rendered+plan.OutputReserve > plan.Window {
+		t.Fatalf("rendered envelope = %d + reserve %d exceeds window %d", rendered, plan.OutputReserve, plan.Window)
+	}
+	for _, record := range out.ContextMutations.Records() {
+		if record.Kind == contextfrag.MutationContextBudgetFailure {
+			t.Fatalf("trimmable history recorded %#v", record)
+		}
+	}
+}
+
+func TestValidateProviderRenderedEnvelopeFailsClosedOnOverflow(t *testing.T) {
+	t.Parallel()
+
+	payload := &SDKRenderedPayload{System: "system", Messages: []sdk.Message{sdk.UserMessage(strings.Repeat("x", 4_000))}}
+	plan := &contextfrag.ContextBudgetPlan{Window: 1_000, OutputReserve: 250}
+	err := validateProviderRenderedEnvelope(payload, nil, plan)
 	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
-		t.Fatalf("preflight error = %v, want rendered-envelope ErrBudgetUnsatisfied", err)
+		t.Fatalf("validateProviderRenderedEnvelope() = %v, want ErrBudgetUnsatisfied", err)
 	}
-	if out.ContextMutations == nil {
-		t.Fatal("rendered-envelope failure lost mutation audit")
+	if want := "rendered_input=1252 output_reserve=250 window=1000"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("validateProviderRenderedEnvelope() = %v, want detail %q", err, want)
 	}
-	records := out.ContextMutations.Records()
-	if len(records) != 1 || records[0] != (contextfrag.MutationRecord{
-		Kind: contextfrag.MutationContextBudgetFailure, Detail: "budget_unsatisfied",
-	}) {
-		t.Fatalf("rendered-envelope mutations = %#v, want one budget_unsatisfied record", records)
+	if err := validateProviderRenderedEnvelope(payload, nil, &contextfrag.ContextBudgetPlan{Window: 1_502, OutputReserve: 250}); err != nil {
+		t.Fatalf("exact fit rejected: %v", err)
 	}
 }
 

--- a/internal/contextview/provider_envelope_budget_regression_test.go
+++ b/internal/contextview/provider_envelope_budget_regression_test.go
@@ -45,7 +45,10 @@ func TestApplyProviderRunConfigContextbench16KRenderedEnvelope(t *testing.T) {
 	}
 
 	inputTokens := testRenderedProviderEnvelopeTokens(out.System, out.Messages, out.ContextToolDefs)
-	reserve := min(DefaultOutputReserveTokens, out.ContextBudgetMaxTokens/4)
+	if out.ContextManifest.BudgetPlan == nil {
+		t.Fatal("budget plan missing from manifest")
+	}
+	reserve := out.ContextManifest.BudgetPlan.OutputReserve
 	if envelope := inputTokens + reserve; envelope > out.ContextBudgetMaxTokens {
 		t.Fatalf("provider call allowed with rendered envelope %d > window %d (input=%d reserve=%d)",
 			envelope, out.ContextBudgetMaxTokens, inputTokens, reserve)

--- a/internal/contextview/provider_envelope_matrix_test.go
+++ b/internal/contextview/provider_envelope_matrix_test.go
@@ -24,7 +24,9 @@ func (p namedEnvelopeProbeProvider) Name() string { return p.name }
 // client types, thinking decisions, and assembly paths: the plan reserves the
 // resolved output allowance, the request carries it only where the adapter
 // would have resolved the same value, a fitting payload dispatches, and a
-// payload over the allowance never reaches the provider.
+// payload that fits the window but not the allowance never reaches the
+// provider. Fragment-first assembly rejects it while planning the budget;
+// the fallback assembles the legacy payload and relies on the dispatch check.
 func TestProviderEnvelopeAuthorityMatrix(t *testing.T) {
 	t.Parallel()
 
@@ -42,6 +44,7 @@ func TestProviderEnvelopeAuthorityMatrix(t *testing.T) {
 		{name: "responses", provider: "openai-responses-mock", clientType: models.ClientTypeOpenAIResponses},
 		{name: "codex", provider: "openai-codex-mock", clientType: models.ClientTypeOpenAICodex},
 		{name: "google", provider: "google-mock", clientType: models.ClientTypeGoogleGenerativeAI},
+		{name: "copilot", provider: "github-copilot-mock", clientType: models.ClientTypeGitHubCopilot},
 	}
 	paths := []struct {
 		name   string
@@ -60,7 +63,6 @@ func TestProviderEnvelopeAuthorityMatrix(t *testing.T) {
 	}
 	const window = 200_000
 	fitting := []sdk.Message{sdk.UserMessage("hello")}
-	oversized := []sdk.Message{sdk.UserMessage(strings.Repeat("oversized ", 80_000))}
 
 	for _, client := range clients {
 		for _, path := range paths {
@@ -68,6 +70,13 @@ func TestProviderEnvelopeAuthorityMatrix(t *testing.T) {
 				t.Parallel()
 
 				limits := models.ResolveGenerationLimits(client.clientType, client.reasoning, window)
+				// Inside the window, outside the allowance: only the output reserve
+				// can reject it, so an allowance that forgot the reserve would dispatch.
+				overAllowanceTokens := window - limits.MaxOutputTokens + 1_000
+				oversized := []sdk.Message{sdk.UserMessage(strings.Repeat("o", overAllowanceTokens*4*100/contextfrag.ProviderBudgetSafetyFactorPercent))}
+				if cost := contextfrag.ProviderEnvelopeTokens("", oversized, nil); cost <= window-limits.MaxOutputTokens || cost >= window {
+					t.Fatalf("oversized fixture costs %d tokens, want strictly between allowance %d and window %d", cost, window-limits.MaxOutputTokens, window)
+				}
 				var seen sdk.GenerateParams
 				probe := &envelopeProbeProvider{handler: func(_ int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
 					seen = params

--- a/internal/contextview/provider_envelope_matrix_test.go
+++ b/internal/contextview/provider_envelope_matrix_test.go
@@ -1,0 +1,166 @@
+package contextview
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/models"
+)
+
+type namedEnvelopeProbeProvider struct {
+	*envelopeProbeProvider
+	name string
+}
+
+func (p namedEnvelopeProbeProvider) Name() string { return p.name }
+
+// TestProviderEnvelopeAuthorityMatrix pins the cross-boundary contract across
+// client types, thinking decisions, and assembly paths: the plan reserves the
+// resolved output allowance, the request carries it only where the adapter
+// would have resolved the same value, a fitting payload dispatches, and a
+// payload over the allowance never reaches the provider.
+func TestProviderEnvelopeAuthorityMatrix(t *testing.T) {
+	t.Parallel()
+
+	clients := []struct {
+		name       string
+		provider   string
+		clientType models.ClientType
+		reasoning  *models.ReasoningConfig
+	}{
+		{name: "anthropic", provider: "anthropic-mock", clientType: models.ClientTypeAnthropicMessages},
+		{name: "anthropic adaptive", provider: "anthropic-mock", clientType: models.ClientTypeAnthropicMessages, reasoning: &models.ReasoningConfig{Active: true, Adaptive: true, Effort: models.ReasoningEffortHigh}},
+		{name: "anthropic legacy high", provider: "anthropic-mock", clientType: models.ClientTypeAnthropicMessages, reasoning: &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortHigh}},
+		{name: "completions", provider: "mock", clientType: models.ClientTypeOpenAICompletions},
+		{name: "completions reasoning", provider: "mock", clientType: models.ClientTypeOpenAICompletions, reasoning: &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortHigh}},
+		{name: "responses", provider: "openai-responses-mock", clientType: models.ClientTypeOpenAIResponses},
+		{name: "codex", provider: "openai-codex-mock", clientType: models.ClientTypeOpenAICodex},
+		{name: "google", provider: "google-mock", clientType: models.ClientTypeGoogleGenerativeAI},
+	}
+	paths := []struct {
+		name   string
+		config func(messages []sdk.Message, window int) agentpkg.RunConfig
+	}{
+		{name: "fragment-first", config: func(messages []sdk.Message, window int) agentpkg.RunConfig {
+			currentIndex := len(messages) - 1
+			return agentpkg.RunConfig{
+				System:                         "you are helpful",
+				Messages:                       messages,
+				ContextCurrentUserMessageIndex: &currentIndex,
+				ContextBudgetMaxTokens:         window,
+			}
+		}},
+		{name: "fallback", config: buildErrorFragsFirstConfig},
+	}
+	const window = 200_000
+	fitting := []sdk.Message{sdk.UserMessage("hello")}
+	oversized := []sdk.Message{sdk.UserMessage(strings.Repeat("oversized ", 80_000))}
+
+	for _, client := range clients {
+		for _, path := range paths {
+			t.Run(client.name+"/"+path.name, func(t *testing.T) {
+				t.Parallel()
+
+				limits := models.ResolveGenerationLimits(client.clientType, client.reasoning, window)
+				var seen sdk.GenerateParams
+				probe := &envelopeProbeProvider{handler: func(_ int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+					seen = params
+					return &sdk.GenerateResult{Text: "ok", FinishReason: sdk.FinishReasonStop}, nil
+				}}
+				provider := namedEnvelopeProbeProvider{envelopeProbeProvider: probe, name: client.provider}
+				run := func(messages []sdk.Message) (*contextfrag.LifecycleSnapshot, []contextfrag.MutationRecord, error) {
+					cfg := path.config(messages, window)
+					cfg.Model = &sdk.Model{ID: "model", Provider: provider, Type: sdk.ModelTypeChat}
+					cfg.ReasoningConfig = client.reasoning
+					cfg.Identity = agentpkg.SessionContext{BotID: "bot-1"}
+					cfg.ContextMutations = contextfrag.NewMutationLedger()
+					cfg.ContextLifecycle = contextfrag.NewLifecycleHolder()
+					agent := agentpkg.New(agentpkg.Deps{ContextViewApplier: ProviderRunConfigApplier(nil)})
+					_, err := agent.Generate(context.Background(), cfg)
+					snapshot, _ := cfg.ContextLifecycle.Snapshot()
+					return &snapshot, cfg.ContextMutations.Records(), err
+				}
+
+				snapshot, _, err := run(fitting)
+				if err != nil {
+					t.Fatalf("fitting payload failed: %v", err)
+				}
+				if probe.calls.Load() != 1 {
+					t.Fatalf("provider calls = %d, want one dispatch for a fitting payload", probe.calls.Load())
+				}
+				if snapshot.BudgetPlan == nil || snapshot.BudgetPlan.OutputReserve != limits.MaxOutputTokens || snapshot.BudgetPlan.OutputReserveResolution != limits.Resolution {
+					t.Fatalf("budget plan = %+v, want reserve %d (%s)", snapshot.BudgetPlan, limits.MaxOutputTokens, limits.Resolution)
+				}
+				switch {
+				case limits.Requested && (seen.MaxTokens == nil || *seen.MaxTokens != limits.MaxOutputTokens):
+					t.Fatalf("MaxTokens = %v, want the reserved %d on the request", seen.MaxTokens, limits.MaxOutputTokens)
+				case !limits.Requested && seen.MaxTokens != nil:
+					t.Fatalf("MaxTokens = %d, want the provider default to stand", *seen.MaxTokens)
+				}
+
+				probe.calls.Store(0)
+				_, records, err := run(oversized)
+				if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) && !errors.Is(err, contextfrag.ErrProtectedContextOverflow) {
+					t.Fatalf("oversized payload error = %v, want a typed budget failure", err)
+				}
+				if probe.calls.Load() != 0 {
+					t.Fatalf("provider calls = %d, want zero dispatches over the allowance", probe.calls.Load())
+				}
+				if !hasMutation(records, contextfrag.MutationContextBudgetFailure) {
+					t.Fatalf("mutations = %+v, want a context budget failure", records)
+				}
+				if path.name == "fallback" && !hasMutation(records, contextfrag.MutationContextViewFallback) {
+					t.Fatalf("mutations = %+v, want the fallback recorded alongside the failure", records)
+				}
+			})
+		}
+	}
+}
+
+func hasMutation(records []contextfrag.MutationRecord, kind contextfrag.MutationKind) bool {
+	for _, record := range records {
+		if record.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProviderEnvelopeEstimatorParity keeps the envelope estimator and the
+// selection estimator identical for every message shape production emits.
+func TestProviderEnvelopeEstimatorParity(t *testing.T) {
+	t.Parallel()
+
+	messages := map[string]sdk.Message{
+		"text":         sdk.UserMessage(strings.Repeat("hello world ", 300)),
+		"unicode":      sdk.AssistantMessage(strings.Repeat("上下文预算", 200)),
+		"tool call":    assistantToolCallMessage("call-1", "lookup", "let me check"),
+		"tool result":  toolResultMessage("call-1", "lookup", strings.Repeat("r", 5_000)),
+		"image":        imageUserMessage(500_000, sdk.TextPart{Text: "what is this?"}),
+		"reasoning":    {Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{sdk.ReasoningPart{Text: strings.Repeat("think ", 400)}, sdk.TextPart{Text: "answer"}}},
+		"file":         fileUserMessage(2_000),
+		"multi images": imageUserMessage(100_000, sdk.ImagePart{Image: "data:image/png;base64," + strings.Repeat("B", 100_000), MediaType: "image/png"}),
+	}
+	for name, message := range messages {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			envelope := contextfrag.ProviderEnvelopeTokens("", []sdk.Message{message}, nil)
+			selection := contextfrag.ResolveProviderBudgetFragTokens(contextfrag.MessageFrag(contextfrag.MessageFragInput{Message: message}))
+			if envelope != selection {
+				t.Fatalf("envelope estimate %d != selection estimate %d", envelope, selection)
+			}
+			if envelope <= 0 {
+				t.Fatal("estimate must be positive")
+			}
+		})
+	}
+	if images := contextfrag.ProviderEnvelopeTokens("", []sdk.Message{messages["multi images"]}, nil); images != 2*contextfrag.EstimateImageTokens {
+		t.Fatalf("two images priced at %d, want %d", images, 2*contextfrag.EstimateImageTokens)
+	}
+}

--- a/internal/contextview/provider_fallback_envelope_test.go
+++ b/internal/contextview/provider_fallback_envelope_test.go
@@ -42,6 +42,9 @@ func TestApplyProviderRunConfigFallbackCarriesBudgetPlanAndStepReselector(t *tes
 	if plan.Window != 100_000 || plan.OutputReserve != limits.MaxOutputTokens || plan.OutputReserveResolution != limits.Resolution {
 		t.Fatalf("fallback plan = %+v, want window 100000 reserving %d (%s)", plan, limits.MaxOutputTokens, limits.Resolution)
 	}
+	if plan.ActualSystemCost != 0 || plan.HistoryBudget != 0 {
+		t.Fatalf("fallback plan = %+v, want the failed build's system and history figures cleared", plan)
+	}
 	if out.ContextStepReselector == nil {
 		t.Fatal("fallback assembly must keep step reselection; it is an assembly path, not a budget-disabled path")
 	}
@@ -61,7 +64,9 @@ func TestFallbackDispatchFailsClosedWhenLegacyPayloadExceedsAllowance(t *testing
 		return nil, fmt.Errorf("provider must not be called for an oversized fallback payload (call %d)", call)
 	}}
 	agent := agentpkg.New(agentpkg.Deps{ContextViewApplier: ProviderRunConfigApplier(nil)})
-	cfg := buildErrorFragsFirstConfig([]sdk.Message{sdk.UserMessage(strings.Repeat("oversized ", 2_000))}, 2_000)
+	// 1,598 tokens with the legacy system: inside the 2,000 window, outside the
+	// 1,500 allowance, so only the output reserve can reject it.
+	cfg := buildErrorFragsFirstConfig([]sdk.Message{sdk.UserMessage(strings.Repeat("o", 5_100))}, 2_000)
 	cfg.Model = &sdk.Model{ID: "model", Provider: provider, Type: sdk.ModelTypeChat}
 	cfg.Identity = agentpkg.SessionContext{BotID: "bot-1"}
 	cfg.ContextMutations = contextfrag.NewMutationLedger()
@@ -74,16 +79,8 @@ func TestFallbackDispatchFailsClosedWhenLegacyPayloadExceedsAllowance(t *testing
 	if calls := provider.calls.Load(); calls != 0 {
 		t.Fatalf("provider calls = %d, want 0", calls)
 	}
-	var sawFallback, sawBudgetFailure bool
-	for _, record := range cfg.ContextMutations.Records() {
-		switch record.Kind {
-		case contextfrag.MutationContextViewFallback:
-			sawFallback = true
-		case contextfrag.MutationContextBudgetFailure:
-			sawBudgetFailure = true
-		}
-	}
-	if !sawFallback || !sawBudgetFailure {
-		t.Fatalf("mutations = %+v, want both the fallback and the budget failure recorded", cfg.ContextMutations.Records())
+	records := cfg.ContextMutations.Records()
+	if !hasMutation(records, contextfrag.MutationContextViewFallback) || !hasMutation(records, contextfrag.MutationContextBudgetFailure) {
+		t.Fatalf("mutations = %+v, want both the fallback and the budget failure recorded", records)
 	}
 }

--- a/internal/contextview/provider_fallback_envelope_test.go
+++ b/internal/contextview/provider_fallback_envelope_test.go
@@ -1,0 +1,89 @@
+package contextview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/models"
+)
+
+// buildErrorFragsFirstConfig reproduces an internal build error (duplicate
+// fragment IDs) so the applier takes the legacy fallback path.
+func buildErrorFragsFirstConfig(messages []sdk.Message, window int) agentpkg.RunConfig {
+	first := attentionMessageFrag("duplicate", sdk.UserMessage("first"), 10)
+	second := attentionMessageFrag("duplicate", sdk.AssistantMessage("second"), 10)
+	return agentpkg.RunConfig{
+		System:                 "legacy system",
+		Messages:               messages,
+		ContextSourceFrags:     []contextfrag.ContextFrag{first, second},
+		ContextBudgetMaxTokens: window,
+	}
+}
+
+func TestApplyProviderRunConfigFallbackCarriesBudgetPlanAndStepReselector(t *testing.T) {
+	t.Parallel()
+
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), buildErrorFragsFirstConfig([]sdk.Message{sdk.UserMessage("legacy message")}, 100_000))
+	if err != nil {
+		t.Fatalf("ApplyProviderRunConfig() error = %v, want ordinary build fallback", err)
+	}
+	plan := out.ContextManifest.BudgetPlan
+	if plan == nil {
+		t.Fatal("fallback manifest lost the budget plan")
+	}
+	limits := models.ResolveGenerationLimits(models.ClientTypeOpenAICompletions, nil, 100_000)
+	if plan.Window != 100_000 || plan.OutputReserve != limits.MaxOutputTokens || plan.OutputReserveResolution != limits.Resolution {
+		t.Fatalf("fallback plan = %+v, want window 100000 reserving %d (%s)", plan, limits.MaxOutputTokens, limits.Resolution)
+	}
+	if out.ContextStepReselector == nil {
+		t.Fatal("fallback assembly must keep step reselection; it is an assembly path, not a budget-disabled path")
+	}
+	if out.ContextMutations == nil {
+		t.Fatal("fallback lost the mutation ledger")
+	}
+	records := out.ContextMutations.Records()
+	if len(records) != 1 || records[0].Kind != contextfrag.MutationContextViewFallback || records[0].Detail != "build_error" {
+		t.Fatalf("fallback records = %#v, want one build_error context fallback", records)
+	}
+}
+
+func TestFallbackDispatchFailsClosedWhenLegacyPayloadExceedsAllowance(t *testing.T) {
+	t.Parallel()
+
+	provider := &envelopeProbeProvider{handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		return nil, fmt.Errorf("provider must not be called for an oversized fallback payload (call %d)", call)
+	}}
+	agent := agentpkg.New(agentpkg.Deps{ContextViewApplier: ProviderRunConfigApplier(nil)})
+	cfg := buildErrorFragsFirstConfig([]sdk.Message{sdk.UserMessage(strings.Repeat("oversized ", 2_000))}, 2_000)
+	cfg.Model = &sdk.Model{ID: "model", Provider: provider, Type: sdk.ModelTypeChat}
+	cfg.Identity = agentpkg.SessionContext{BotID: "bot-1"}
+	cfg.ContextMutations = contextfrag.NewMutationLedger()
+	cfg.ContextLifecycle = contextfrag.NewLifecycleHolder()
+
+	_, err := agent.Generate(context.Background(), cfg)
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("Generate() error = %v, want %v", err, contextfrag.ErrBudgetUnsatisfied)
+	}
+	if calls := provider.calls.Load(); calls != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls)
+	}
+	var sawFallback, sawBudgetFailure bool
+	for _, record := range cfg.ContextMutations.Records() {
+		switch record.Kind {
+		case contextfrag.MutationContextViewFallback:
+			sawFallback = true
+		case contextfrag.MutationContextBudgetFailure:
+			sawBudgetFailure = true
+		}
+	}
+	if !sawFallback || !sawBudgetFailure {
+		t.Fatalf("mutations = %+v, want both the fallback and the budget failure recorded", cfg.ContextMutations.Records())
+	}
+}

--- a/internal/contextview/provider_fallback_envelope_test.go
+++ b/internal/contextview/provider_fallback_envelope_test.go
@@ -17,12 +17,13 @@ import (
 // buildErrorFragsFirstConfig reproduces an internal build error (duplicate
 // fragment IDs) so the applier takes the legacy fallback path.
 func buildErrorFragsFirstConfig(messages []sdk.Message, window int) agentpkg.RunConfig {
+	system := systemTextFrag("system.prompt", "fragment system", contextfrag.KindSystemPrompt, 100)
 	first := attentionMessageFrag("duplicate", sdk.UserMessage("first"), 10)
 	second := attentionMessageFrag("duplicate", sdk.AssistantMessage("second"), 10)
 	return agentpkg.RunConfig{
 		System:                 "legacy system",
 		Messages:               messages,
-		ContextSourceFrags:     []contextfrag.ContextFrag{first, second},
+		ContextSourceFrags:     []contextfrag.ContextFrag{system, first, second},
 		ContextBudgetMaxTokens: window,
 	}
 }
@@ -64,9 +65,12 @@ func TestFallbackDispatchFailsClosedWhenLegacyPayloadExceedsAllowance(t *testing
 		return nil, fmt.Errorf("provider must not be called for an oversized fallback payload (call %d)", call)
 	}}
 	agent := agentpkg.New(agentpkg.Deps{ContextViewApplier: ProviderRunConfigApplier(nil)})
-	// 1,598 tokens with the legacy system: inside the 2,000 window, outside the
-	// 1,500 allowance, so only the output reserve can reject it.
-	cfg := buildErrorFragsFirstConfig([]sdk.Message{sdk.UserMessage(strings.Repeat("o", 5_100))}, 2_000)
+	const window = 2_000
+	limits := models.ResolveGenerationLimits(models.ClientTypeOpenAICompletions, nil, window)
+	cfg := buildErrorFragsFirstConfig([]sdk.Message{sdk.UserMessage(strings.Repeat("o", 5_100))}, window)
+	if cost := contextfrag.ProviderEnvelopeTokens(cfg.System, cfg.Messages, nil); cost <= window-limits.MaxOutputTokens || cost >= window {
+		t.Fatalf("legacy payload costs %d tokens, want strictly between allowance %d and window %d", cost, window-limits.MaxOutputTokens, window)
+	}
 	cfg.Model = &sdk.Model{ID: "model", Provider: provider, Type: sdk.ModelTypeChat}
 	cfg.Identity = agentpkg.SessionContext{BotID: "bot-1"}
 	cfg.ContextMutations = contextfrag.NewMutationLedger()

--- a/internal/contextview/provider_fallback_test.go
+++ b/internal/contextview/provider_fallback_test.go
@@ -121,7 +121,7 @@ func TestProviderViewFallbackPlacesHookAfterDynamicContextBeforeCurrent(t *testi
 			ContextMemoryMessageIndex:      &memoryIndex,
 			ContextQueryMaterialized:       true,
 			ContextHookText:                "workspace hook guidance",
-		}, contextfrag.NewMutationLedger(), "build_error", "fallback", nil)
+		}, contextfrag.NewMutationLedger(), nil, "build_error", "fallback", nil)
 
 		assertMessagesEqual(t, out.Messages, []sdk.Message{
 			sdk.UserMessage("memory recall"),
@@ -155,7 +155,7 @@ func TestProviderViewFallbackPlacesHookAfterDynamicContextBeforeCurrent(t *testi
 			},
 			ContextSourceFrags: []contextfrag.ContextFrag{current},
 			ContextHookText:    "discuss hook guidance",
-		}, contextfrag.NewMutationLedger(), "build_error", "fallback", nil)
+		}, contextfrag.NewMutationLedger(), nil, "build_error", "fallback", nil)
 
 		assertMessagesEqual(t, out.Messages, []sdk.Message{
 			sdk.AssistantMessage("previous answer"),

--- a/internal/contextview/provider_generation_limits_test.go
+++ b/internal/contextview/provider_generation_limits_test.go
@@ -1,0 +1,111 @@
+package contextview
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	"github.com/memohai/memoh/internal/models"
+)
+
+type anthropicEnvelopeProbeProvider struct{ *envelopeProbeProvider }
+
+func (anthropicEnvelopeProbeProvider) Name() string { return "anthropic-mock" }
+
+func TestProviderContextBudgetPlanReservesResolvedGenerationLimits(t *testing.T) {
+	t.Parallel()
+
+	reasoning := &models.ReasoningConfig{Active: true, Adaptive: true, Effort: models.ReasoningEffortHigh}
+	plan, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{
+		Model:                  &sdk.Model{ID: "claude", Provider: anthropicEnvelopeProbeProvider{&envelopeProbeProvider{}}},
+		ReasoningConfig:        reasoning,
+		ContextBudgetMaxTokens: 200_000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.OutputReserve != 32_000 || plan.OutputReserveResolution != models.GenerationLimitsProviderDefault {
+		t.Fatalf("plan = %+v, want the Anthropic adaptive default reserved as provider_default", plan)
+	}
+
+	legacy, err := providerContextBudgetPlan(context.Background(), agentpkg.RunConfig{ContextBudgetMaxTokens: 200_000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.OutputReserve != models.DefaultOutputReserveTokens || legacy.OutputReserveResolution != models.GenerationLimitsEstimated {
+		t.Fatalf("model-less plan = %+v, want an estimated default reserve", legacy)
+	}
+}
+
+func TestGenerateReservesExactlyTheMaxTokensItSends(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		provider  func(*envelopeProbeProvider) sdk.Provider
+		reasoning *models.ReasoningConfig
+		wantSent  bool
+	}{
+		{
+			name:      "anthropic adaptive",
+			provider:  func(p *envelopeProbeProvider) sdk.Provider { return anthropicEnvelopeProbeProvider{p} },
+			reasoning: &models.ReasoningConfig{Active: true, Adaptive: true, Effort: models.ReasoningEffortHigh},
+			wantSent:  true,
+		},
+		{
+			name:      "anthropic legacy thinking",
+			provider:  func(p *envelopeProbeProvider) sdk.Provider { return anthropicEnvelopeProbeProvider{p} },
+			reasoning: &models.ReasoningConfig{Active: true, Effort: models.ReasoningEffortHigh},
+			wantSent:  true,
+		},
+		{
+			name:     "generic completions",
+			provider: func(p *envelopeProbeProvider) sdk.Provider { return p },
+			wantSent: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var seen sdk.GenerateParams
+			probe := &envelopeProbeProvider{handler: func(_ int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+				seen = params
+				return &sdk.GenerateResult{Text: "ok", FinishReason: sdk.FinishReasonStop}, nil
+			}}
+			agent := agentpkg.New(agentpkg.Deps{ContextViewApplier: ProviderRunConfigApplier(nil)})
+			currentIndex := 0
+			lifecycle := contextfrag.NewLifecycleHolder()
+			_, err := agent.Generate(context.Background(), agentpkg.RunConfig{
+				Model:                          &sdk.Model{ID: "model", Provider: tc.provider(probe), Type: sdk.ModelTypeChat},
+				ReasoningConfig:                tc.reasoning,
+				System:                         "you are helpful",
+				Messages:                       []sdk.Message{sdk.UserMessage("hello")},
+				ContextCurrentUserMessageIndex: &currentIndex,
+				ContextBudgetMaxTokens:         200_000,
+				Identity:                       agentpkg.SessionContext{BotID: "bot-1"},
+				ContextMutations:               contextfrag.NewMutationLedger(),
+				ContextLifecycle:               lifecycle,
+			})
+			if err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			snapshot, ok := lifecycle.Snapshot()
+			if !ok || snapshot.BudgetPlan == nil {
+				t.Fatal("lifecycle snapshot lost the budget plan")
+			}
+			limits := models.ResolveGenerationLimits(models.ClientType(models.ResolveClientType(&sdk.Model{Provider: tc.provider(probe)})), tc.reasoning, 200_000)
+			if snapshot.BudgetPlan.OutputReserve != limits.MaxOutputTokens {
+				t.Fatalf("OutputReserve = %d, want resolved %d", snapshot.BudgetPlan.OutputReserve, limits.MaxOutputTokens)
+			}
+			switch {
+			case !tc.wantSent && seen.MaxTokens != nil:
+				t.Fatalf("MaxTokens = %d, want the provider default to stand", *seen.MaxTokens)
+			case tc.wantSent && (seen.MaxTokens == nil || *seen.MaxTokens != snapshot.BudgetPlan.OutputReserve):
+				t.Fatalf("MaxTokens = %v, want exactly the reserved %d", seen.MaxTokens, snapshot.BudgetPlan.OutputReserve)
+			}
+		})
+	}
+}

--- a/internal/contextview/provider_initial_envelope_test.go
+++ b/internal/contextview/provider_initial_envelope_test.go
@@ -1,0 +1,67 @@
+package contextview
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+)
+
+// floorPricedHistory mirrors the application's history estimates, which are
+// the legacy bytes/4 floor rather than the provider envelope estimate.
+func floorPricedHistory(count, bytesEach int) []contextfrag.ContextFrag {
+	frags := make([]contextfrag.ContextFrag, 0, count)
+	for i := range count {
+		text := strings.Repeat(string(rune('a'+i%26)), bytesEach)
+		msg := sdk.UserMessage(text)
+		if i%2 == 1 {
+			msg = sdk.AssistantMessage(text)
+		}
+		frag := historyMessageFrag(fmt.Sprintf("h%02d", i), msg)
+		frag.TokenEstimate = contextfrag.TokensFromBytes(bytesEach)
+		frags = append(frags, frag)
+	}
+	return frags
+}
+
+func TestApplyProviderRunConfigTrimsFloorPricedHistoryToTheRenderedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	frags := append(
+		[]contextfrag.ContextFrag{systemTextFrag("system", strings.Repeat("s", 400), contextfrag.KindSystemPrompt, 100)},
+		floorPricedHistory(60, 1_000)...,
+	)
+	frags = append(frags, currentMessageFrag("current", "latest question"))
+	zero := 0
+	cfg := agentpkg.RunConfig{
+		ContextSourceFrags:         frags,
+		ContextBudgetMaxTokens:     16_000,
+		ContextRecentProtectTokens: &zero,
+	}
+
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("ApplyProviderRunConfig() error = %v, want history trimmed until the rendered envelope fits", err)
+	}
+	plan := out.ContextManifest.BudgetPlan
+	if plan == nil {
+		t.Fatal("budget plan missing from manifest")
+	}
+	rendered := contextfrag.ProviderEnvelopeTokens(out.System, out.Messages, nil)
+	if rendered+plan.OutputReserve > plan.Window {
+		t.Fatalf("rendered envelope = %d + reserve %d exceeds window %d", rendered, plan.OutputReserve, plan.Window)
+	}
+	if len(out.Messages) < 2 || len(out.Messages) >= 61 {
+		t.Fatalf("messages = %d, want a trimmed history that still keeps recent turns", len(out.Messages))
+	}
+	for _, record := range out.ContextMutations.Records() {
+		if record.Kind == contextfrag.MutationContextBudgetFailure || record.Kind == contextfrag.MutationContextViewFallback {
+			t.Fatalf("trimmable history recorded %+v", record)
+		}
+	}
+}

--- a/internal/contextview/provider_initial_envelope_test.go
+++ b/internal/contextview/provider_initial_envelope_test.go
@@ -2,6 +2,7 @@ package contextview
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -59,9 +60,47 @@ func TestApplyProviderRunConfigTrimsFloorPricedHistoryToTheRenderedEnvelope(t *t
 	if len(out.Messages) < 2 || len(out.Messages) >= 61 {
 		t.Fatalf("messages = %d, want a trimmed history that still keeps recent turns", len(out.Messages))
 	}
+	if slack, next := plan.Window-plan.OutputReserve-rendered, contextfrag.ProviderEnvelopeTokens("", []sdk.Message{sdk.UserMessage(strings.Repeat("a", 1_000))}, nil); slack >= next {
+		t.Fatalf("slack = %d tokens, want less than the next trimmed message (%d) so trimming stays tight", slack, next)
+	}
 	for _, record := range out.ContextMutations.Records() {
 		if record.Kind == contextfrag.MutationContextBudgetFailure || record.Kind == contextfrag.MutationContextViewFallback {
 			t.Fatalf("trimmable history recorded %+v", record)
 		}
+	}
+}
+
+// TestApplyProviderRunConfigFailsClosedWhenRenderingOutgrowsSelection keeps
+// the rendered-envelope check as the last line of defense: a fragment that
+// renders as many tiny messages is charged once by selection but per message
+// by the rendered check, and that drift must still fail closed.
+func TestApplyProviderRunConfigFailsClosedWhenRenderingOutgrowsSelection(t *testing.T) {
+	t.Parallel()
+
+	tiny := sdk.UserMessage("x")
+	burst := historyMessageFrag("burst", tiny)
+	for range 39 {
+		burst.Parts = append(burst.Parts, contextfrag.Part{Type: contextfrag.PartSDKMessage, SDKMessage: &tiny})
+	}
+	frags := []contextfrag.ContextFrag{
+		systemTextFrag("system", strings.Repeat("s", 2_784), contextfrag.KindSystemPrompt, 100),
+		burst,
+		currentMessageFrag("current", "current"),
+	}
+	out, err := ProviderRunConfigApplier(nil)(context.Background(), agentpkg.RunConfig{
+		ContextSourceFrags:     frags,
+		ContextBudgetMaxTokens: 1_200,
+	})
+	if !errors.Is(err, contextfrag.ErrBudgetUnsatisfied) {
+		t.Fatalf("preflight error = %v, want rendered-envelope ErrBudgetUnsatisfied", err)
+	}
+	if !strings.Contains(err.Error(), "rendered_input=") {
+		t.Fatalf("preflight error = %v, want the rendered-envelope detail", err)
+	}
+	records := out.ContextMutations.Records()
+	if len(records) != 1 || records[0] != (contextfrag.MutationRecord{
+		Kind: contextfrag.MutationContextBudgetFailure, Detail: "budget_unsatisfied",
+	}) {
+		t.Fatalf("rendered-envelope mutations = %#v, want one budget_unsatisfied record", records)
 	}
 }

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -243,12 +243,17 @@ func providerContextBudgetPlan(ctx context.Context, cfg agentpkg.RunConfig) (*co
 	if err != nil {
 		return nil, err
 	}
-	return ComputeContextBudgetPlan(
+	limits := cfg.GenerationLimits()
+	plan, err := ComputeContextBudgetPlan(
 		cfg.ContextBudgetMaxTokens,
-		min(DefaultOutputReserveTokens, cfg.ContextBudgetMaxTokens/4),
+		limits.MaxOutputTokens,
 		providerToolDefsCost(cfg.ContextToolDefs),
 		currentRequestCost,
 	)
+	if plan != nil {
+		plan.OutputReserveResolution = limits.Resolution
+	}
+	return plan, err
 }
 
 func providerCurrentRequestCost(ctx context.Context, cfg agentpkg.RunConfig) (int, error) {

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -338,7 +338,7 @@ func applyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 	} else {
 		frags = CollectProviderSourceFrags(ctx, cfg)
 		if frags == nil {
-			return providerViewFallback(logger, cfg, ledger, "collect_error", "context view collection failed", nil), nil
+			return providerViewFallback(logger, cfg, ledger, nil, "collect_error", "context view collection failed", nil), nil
 		}
 		cfg = materializeLegacyQuery(cfg, false)
 	}
@@ -360,7 +360,7 @@ func applyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 		selector = gate
 	}
 	if budgetErr != nil && !isContextBudgetError(budgetErr) {
-		return providerViewFallback(logger, fallbackCfg, ledger, "budget_plan_error", "context budget plan failed", budgetErr), nil
+		return providerViewFallback(logger, fallbackCfg, ledger, budgetPlan, "budget_plan_error", "context budget plan failed", budgetErr), nil
 	}
 
 	registry := NewMapCollectorRegistry(StaticCollector{CollectorName: sourceFragsCollectorName, Frags: frags})
@@ -386,11 +386,11 @@ func applyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 			recordContextBudgetFailure(ledger, err)
 			return providerBudgetAuditConfig(cfg, view, ledger, budgetPlan), err
 		}
-		return providerViewFallback(logger, fallbackCfg, ledger, "build_error", "context view build failed", err), nil
+		return providerViewFallback(logger, fallbackCfg, ledger, budgetPlan, "build_error", "context view build failed", err), nil
 	}
 	payload, ok := view.Rendered[contextfrag.RenderSDKMessages].Data.(*SDKRenderedPayload)
 	if !ok {
-		return providerViewFallback(logger, fallbackCfg, ledger, "unexpected_payload", "context view rendered unexpected payload", nil), nil
+		return providerViewFallback(logger, fallbackCfg, ledger, budgetPlan, "unexpected_payload", "context view rendered unexpected payload", nil), nil
 	}
 	if err := validateProviderRenderedEnvelope(payload, cfg.ContextToolDefs, budgetPlan); err != nil {
 		recordContextBudgetFailure(ledger, err)
@@ -410,7 +410,7 @@ func applyProviderRunConfig(ctx context.Context, logger *slog.Logger, cfg agentp
 	cfg.Messages = payload.Messages
 	ordered, err := orderedSelectedFrags(view.Selected, view.Placement)
 	if err != nil {
-		return providerViewFallback(logger, fallbackCfg, ledger, "placement_error", "context view placement invalid after render", err), nil
+		return providerViewFallback(logger, fallbackCfg, ledger, budgetPlan, "placement_error", "context view placement invalid after render", err), nil
 	}
 	currentIndex, memoryIndex := renderedSpecialMessageIndexes(ordered)
 	cfg.ContextMemoryMessageIndex = memoryIndex
@@ -499,7 +499,18 @@ func providerBudgetAuditConfig(
 	return cfg
 }
 
-func providerViewFallback(logger *slog.Logger, cfg agentpkg.RunConfig, ledger *contextfrag.MutationLedger, reason, message string, err error) agentpkg.RunConfig {
+// providerViewFallback assembles the legacy payload when the context view
+// cannot. It is an assembly path, not a budget-disabled path: the budget plan
+// and step reselection stay in force so every dispatch still meets the final
+// envelope check.
+func providerViewFallback(
+	logger *slog.Logger,
+	cfg agentpkg.RunConfig,
+	ledger *contextfrag.MutationLedger,
+	budgetPlan *contextfrag.ContextBudgetPlan,
+	reason, message string,
+	err error,
+) agentpkg.RunConfig {
 	warnProviderContextView(logger, cfg, message, err)
 	priorManifest := cfg.ContextManifest
 	cfg = legacyMaterializeQuery(cfg)
@@ -511,12 +522,17 @@ func providerViewFallback(logger *slog.Logger, cfg agentpkg.RunConfig, ledger *c
 	plan := contextfrag.CachePlan{}
 	manifest := cfg.ContextManifest
 	manifest.CachePlan = &plan
+	if budgetPlan != nil {
+		fallbackPlan := *budgetPlan
+		manifest.BudgetPlan = &fallbackPlan
+	}
 	manifest.Mutations = ledger
 	manifest.ToolDefs = append([]contextfrag.ToolDefAccounting(nil), cfg.ContextToolDefs...)
 	appendContextSourceWarnings(&manifest, cfg.ContextSourceWarnings)
 	cfg.ContextManifest = manifest
 	cfg.ContextCachePlan = plan
 	cfg.ContextMutations = ledger
+	cfg.ContextStepReselector = SelectProviderStepMessages
 	if cfg.ContextLifecycle != nil {
 		cfg.ContextLifecycle.SetManifest(manifest)
 	}

--- a/internal/contextview/provider_run_config.go
+++ b/internal/contextview/provider_run_config.go
@@ -524,6 +524,8 @@ func providerViewFallback(
 	manifest.CachePlan = &plan
 	if budgetPlan != nil {
 		fallbackPlan := *budgetPlan
+		fallbackPlan.ActualSystemCost = 0
+		fallbackPlan.HistoryBudget = 0
 		manifest.BudgetPlan = &fallbackPlan
 	}
 	manifest.Mutations = ledger

--- a/internal/contextview/provider_run_config_test.go
+++ b/internal/contextview/provider_run_config_test.go
@@ -183,7 +183,7 @@ func TestProviderRunConfigApplierUsesInjectedLoggerShape(t *testing.T) {
 	}
 }
 
-func TestProviderRunConfigApplierInstallsStepReselectorOnlyOnSuccess(t *testing.T) {
+func TestProviderRunConfigApplierInstallsStepReselectorOnAssembledPayloads(t *testing.T) {
 	t.Parallel()
 
 	t.Run("success", func(t *testing.T) {
@@ -233,8 +233,8 @@ func TestProviderRunConfigApplierInstallsStepReselectorOnlyOnSuccess(t *testing.
 		if err != nil {
 			t.Fatalf("fallback error = %v", err)
 		}
-		if out.ContextStepReselector != nil {
-			t.Fatal("legacy fallback installed the step reselector")
+		if out.ContextStepReselector == nil {
+			t.Fatal("legacy fallback is an assembly path and must keep step reselection")
 		}
 	})
 

--- a/internal/contextview/provider_run_config_test.go
+++ b/internal/contextview/provider_run_config_test.go
@@ -68,7 +68,7 @@ func TestProviderStepReselectorPreservesPrefixAndDropsLoopSpan(t *testing.T) {
 		Messages:            messages,
 		// Leave room for the newest protected tool closure and the required
 		// trim notice while forcing the bulky older closure out.
-		BudgetMaxTokens: 100,
+		BudgetMaxTokens: 200,
 	})
 
 	if result.Dropped != 2 {
@@ -211,7 +211,7 @@ func TestProviderRunConfigApplierInstallsStepReselectorOnlyOnSuccess(t *testing.
 			}),
 		)
 		result := out.ContextStepReselector(context.Background(), agentpkg.ContextStepSelectionInput{
-			InitialMessageCount: len(prefix), Messages: messages, BudgetMaxTokens: 100,
+			InitialMessageCount: len(prefix), Messages: messages, BudgetMaxTokens: 200,
 		})
 		if result.Dropped != 2 || len(result.Messages) != 4 {
 			t.Fatalf("step result = %#v, want the bulky old tool closure dropped", result)

--- a/internal/contextview/provider_run_config_view_test.go
+++ b/internal/contextview/provider_run_config_view_test.go
@@ -53,6 +53,9 @@ func activateHistoryBudget(cfg *agentpkg.RunConfig, legacyBudget int) {
 		frags = CollectNonSystemProviderSourceFrags(context.Background(), *cfg)
 	}
 	tagged := tagFragments(frags, (&FragmentSelector{}).ProfileFor(contextfrag.IntentRunConfigPreProvider))
+	for i := range tagged {
+		tagged[i].Tokens = contextfrag.ResolveProviderBudgetFragTokens(tagged[i].Frag)
+	}
 	inputBudget += protectedHistoryTokenCost(tagged)
 	currentRequestCost, err := providerCurrentRequestCost(context.Background(), *cfg)
 	if err != nil {
@@ -74,6 +77,6 @@ func activeHistoryInputBudget(legacyBudget int) (inputBudget, scale int) {
 	if scaled := legacyBudget * scale; scaled < MinimumSystemBudgetTokens {
 		scale = (MinimumSystemBudgetTokens + legacyBudget - 1) / legacyBudget
 	}
-	noticeCost := contextfrag.ResolveFragTokens(TrimNoticeFrag(contextfrag.Scope{}))
+	noticeCost := contextfrag.ResolveProviderBudgetFragTokens(TrimNoticeFrag(contextfrag.Scope{}))
 	return legacyBudget*scale + noticeCost, scale
 }

--- a/internal/contextview/provider_step_envelope_test.go
+++ b/internal/contextview/provider_step_envelope_test.go
@@ -13,7 +13,7 @@ import (
 	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
 )
 
-func TestProviderStepReselectionFailsClosedForSerializedS3HugeResult(t *testing.T) {
+func TestProviderStepReselectionFailsClosedForEnvelopeS3HugeResult(t *testing.T) {
 	t.Parallel()
 	const (
 		inputAllowance = 24_000
@@ -35,12 +35,10 @@ func TestProviderStepReselectionFailsClosedForSerializedS3HugeResult(t *testing.
 		Name: "exec", Description: "Execute a bounded command.",
 		Parameters: map[string]any{"type": "object", "properties": map[string]any{"command": map[string]any{"type": "string"}}},
 	}}
-	_, fixedBytes := contextfrag.ProviderPayloadHashAndBytes(system, prefix, tools)
-	_, candidateBytes := contextfrag.ProviderPayloadHashAndBytes(system, messages, tools)
-	if candidateTokens := contextfrag.ProviderBudgetTokensFromBytes(candidateBytes); candidateTokens <= inputAllowance {
+	if candidateTokens := contextfrag.ProviderEnvelopeTokens(system, messages, tools); candidateTokens <= inputAllowance {
 		t.Fatalf("literal S3 candidate = %d tokens, want over allowance %d", candidateTokens, inputAllowance)
 	}
-	suffixBudget := inputAllowance - contextfrag.ProviderBudgetTokensFromBytes(fixedBytes)
+	suffixBudget := inputAllowance - contextfrag.ProviderEnvelopeTokens(system, prefix, tools)
 
 	result := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
 		Scope:                        contextfrag.Scope{BotID: "contextbench"},
@@ -55,11 +53,11 @@ func TestProviderStepReselectionFailsClosedForSerializedS3HugeResult(t *testing.
 		t.Fatalf("step reselection error = %v, want protected overflow for the newest tool closure", result.FatalError)
 	}
 	if result.Messages != nil {
-		t.Fatalf("fatal serialized overflow returned provider messages: %#v", result.Messages)
+		t.Fatalf("fatal envelope overflow returned provider messages: %#v", result.Messages)
 	}
 }
 
-func TestProviderStepReselectionTightensSerializedS3HugeResultWhenDroppable(t *testing.T) {
+func TestProviderStepReselectionTightensEnvelopeS3HugeResultWhenDroppable(t *testing.T) {
 	t.Parallel()
 	const (
 		inputAllowance = 24_000
@@ -79,9 +77,7 @@ func TestProviderStepReselectionTightensSerializedS3HugeResultWhenDroppable(t *t
 		Name: "exec", Description: "Execute a bounded command.",
 		Parameters: map[string]any{"type": "object", "properties": map[string]any{"command": map[string]any{"type": "string"}}},
 	}}
-	_, fixedBytes := contextfrag.ProviderPayloadHashAndBytes(system, prefix, tools)
-	_, candidateBytes := contextfrag.ProviderPayloadHashAndBytes(system, messages, tools)
-	if candidateTokens := contextfrag.ProviderBudgetTokensFromBytes(candidateBytes); candidateTokens <= inputAllowance {
+	if candidateTokens := contextfrag.ProviderEnvelopeTokens(system, messages, tools); candidateTokens <= inputAllowance {
 		t.Fatalf("literal S3 candidate = %d tokens, want over allowance %d", candidateTokens, inputAllowance)
 	}
 
@@ -89,7 +85,7 @@ func TestProviderStepReselectionTightensSerializedS3HugeResultWhenDroppable(t *t
 		Scope:                        contextfrag.Scope{BotID: "contextbench"},
 		InitialMessageCount:          len(prefix),
 		Messages:                     messages,
-		BudgetMaxTokens:              inputAllowance - contextfrag.ProviderBudgetTokensFromBytes(fixedBytes),
+		BudgetMaxTokens:              inputAllowance - contextfrag.ProviderEnvelopeTokens(system, prefix, tools),
 		ProviderSystem:               system,
 		ProviderTools:                tools,
 		ProviderInputAllowanceTokens: inputAllowance,
@@ -98,18 +94,17 @@ func TestProviderStepReselectionTightensSerializedS3HugeResultWhenDroppable(t *t
 		t.Fatalf("step reselection failed instead of tightening droppable history: %v", result.FatalError)
 	}
 	if result.Messages == nil || result.Dropped == 0 {
-		t.Fatalf("serialized overflow was not tightened: %+v", result)
+		t.Fatalf("envelope overflow was not tightened: %+v", result)
 	}
 	if !reflect.DeepEqual(result.Messages[:len(prefix)], prefix) {
 		t.Fatalf("immutable prefix changed: %#v", result.Messages[:len(prefix)])
 	}
-	_, selectedBytes := contextfrag.ProviderPayloadHashAndBytes(system, result.Messages, tools)
-	if got := contextfrag.ProviderBudgetTokensFromBytes(selectedBytes); got > inputAllowance {
+	if got := contextfrag.ProviderEnvelopeTokens(system, result.Messages, tools); got > inputAllowance {
 		t.Fatalf("nonfatal provider payload = %d tokens, want <= allowance %d", got, inputAllowance)
 	}
 }
 
-func TestProviderStepReselectionAllowsExactlyFittingProtectedSerializedSuffix(t *testing.T) {
+func TestProviderStepReselectionAllowsExactlyFittingProtectedEnvelopeSuffix(t *testing.T) {
 	t.Parallel()
 
 	prefix := []sdk.Message{sdk.UserMessage(strings.Repeat("prefix", 137))}
@@ -120,19 +115,10 @@ func TestProviderStepReselectionAllowsExactlyFittingProtectedSerializedSuffix(t 
 	messages := append(append([]sdk.Message(nil), prefix...), loop...)
 	system := strings.Repeat("system", 83)
 	tools := []sdk.Tool{{Name: "exec", Description: "Execute a bounded command."}}
-	_, fixedBytes := contextfrag.ProviderPayloadHashAndBytes(system, prefix, tools)
-	_, candidateBytes := contextfrag.ProviderPayloadHashAndBytes(system, messages, tools)
-	fixedTokens := contextfrag.ProviderBudgetTokensFromBytes(fixedBytes)
-	allowance := contextfrag.ProviderBudgetTokensFromBytes(candidateBytes)
-	suffixBudget := allowance - fixedTokens
-
-	singletonCost := 0
-	for _, message := range loop {
-		_, messageBytes := contextfrag.ProviderPayloadHashAndBytes("", []sdk.Message{message}, nil)
-		singletonCost += contextfrag.ProviderBudgetTokensFromBytes(messageBytes)
-	}
-	if singletonCost <= suffixBudget {
-		t.Fatalf("fixture singleton cost = %d, want greater than exact additive suffix %d", singletonCost, suffixBudget)
+	allowance := contextfrag.ProviderEnvelopeTokens(system, messages, tools)
+	suffixBudget := allowance - contextfrag.ProviderEnvelopeTokens(system, prefix, tools)
+	if selectionCost := contextfrag.ProviderEnvelopeTokens("", loop, nil); selectionCost != suffixBudget {
+		t.Fatalf("fixture suffix cost = %d, want exact additive suffix budget %d", selectionCost, suffixBudget)
 	}
 
 	result := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
@@ -149,5 +135,16 @@ func TestProviderStepReselectionAllowsExactlyFittingProtectedSerializedSuffix(t 
 	}
 	if result.Messages != nil || result.Dropped != 0 || result.Truncated != 0 {
 		t.Fatalf("exact-fit protected suffix changed: %+v", result)
+	}
+	if result := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
+		Scope:                        contextfrag.Scope{BotID: "contextbench"},
+		InitialMessageCount:          len(prefix),
+		Messages:                     messages,
+		BudgetMaxTokens:              suffixBudget - 1,
+		ProviderSystem:               system,
+		ProviderTools:                tools,
+		ProviderInputAllowanceTokens: allowance - 1,
+	}); !errors.Is(result.FatalError, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("one token short of the protected suffix must fail closed, got %v", result.FatalError)
 	}
 }

--- a/internal/contextview/provider_step_image_prefix_test.go
+++ b/internal/contextview/provider_step_image_prefix_test.go
@@ -12,6 +12,7 @@ import (
 	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
 	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
 	agenttools "github.com/memohai/memoh/internal/agent/tool"
+	"github.com/memohai/memoh/internal/models"
 )
 
 // photoPrefix is a vision turn whose user message carries a JPEG of the given
@@ -36,7 +37,7 @@ func TestProviderStepReselectionKeepsPhotoInFrozenPrefixWithinEnvelope(t *testin
 	system := strings.Repeat("s", 8_000)
 	tools := []sdk.Tool{{Name: "lookup", Description: "Look something up.", Parameters: map[string]any{"type": "object"}}}
 
-	plan, err := ComputeContextBudgetPlan(128_000, min(DefaultOutputReserveTokens, 128_000/4), 0, 0)
+	plan, err := ComputeContextBudgetPlan(128_000, models.DefaultOutputReserveTokens, 0, 0)
 	if err != nil {
 		t.Fatalf("ComputeContextBudgetPlan: %v", err)
 	}

--- a/internal/contextview/provider_step_image_prefix_test.go
+++ b/internal/contextview/provider_step_image_prefix_test.go
@@ -1,0 +1,162 @@
+package contextview
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	sdk "github.com/memohai/twilight-ai/sdk"
+
+	contextfrag "github.com/memohai/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/memohai/memoh/internal/agent/runtime/native"
+	agenttools "github.com/memohai/memoh/internal/agent/tool"
+)
+
+// photoPrefix is a vision turn whose user message carries a JPEG of the given
+// base64 length as an inline data URL, the shape every channel adapter
+// produces for attachments.
+func photoPrefix(base64Length int) []sdk.Message {
+	return []sdk.Message{{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{
+		sdk.TextPart{Text: "what's in this photo, and what's the weather there?"},
+		sdk.ImagePart{Image: "data:image/jpeg;base64," + strings.Repeat("A", base64Length), MediaType: "image/jpeg"},
+	}}}
+}
+
+func TestProviderStepReselectionKeepsPhotoInFrozenPrefixWithinEnvelope(t *testing.T) {
+	t.Parallel()
+
+	prefix := photoPrefix(400_000)
+	messages := append([]sdk.Message(nil), prefix...)
+	messages = append(messages,
+		assistantToolCallMessage("call-weather", "lookup", ""),
+		toolResultMessage("call-weather", "lookup", "sunny, 25C"),
+	)
+	system := strings.Repeat("s", 8_000)
+	tools := []sdk.Tool{{Name: "lookup", Description: "Look something up.", Parameters: map[string]any{"type": "object"}}}
+
+	plan, err := ComputeContextBudgetPlan(128_000, min(DefaultOutputReserveTokens, 128_000/4), 0, 0)
+	if err != nil {
+		t.Fatalf("ComputeContextBudgetPlan: %v", err)
+	}
+	allowance := plan.Window - plan.OutputReserve
+	prefixCost := contextfrag.ProviderEnvelopeTokens(system, prefix, tools)
+	if prefixCost > allowance/4 {
+		t.Fatalf("photo prefix priced at %d tokens, want a flat media estimate well inside allowance %d", prefixCost, allowance)
+	}
+
+	protect := DefaultRecentProtectTokens
+	result := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
+		Scope:                        contextfrag.Scope{BotID: "bot-1"},
+		InitialMessageCount:          len(prefix),
+		Messages:                     messages,
+		BudgetMaxTokens:              allowance - prefixCost,
+		ProviderSystem:               system,
+		ProviderTools:                tools,
+		ProviderInputAllowanceTokens: allowance,
+		RecentProtectTokens:          &protect,
+		KeepRecentToolResults:        2,
+		MinMessages:                  4,
+	})
+	if result.FatalError != nil {
+		t.Fatalf("step reselection failed for a photo prefix that fits the window: %v", result.FatalError)
+	}
+	if result.Messages != nil || result.Dropped != 0 || result.Truncated != 0 {
+		t.Fatalf("step reselection changed a fitting tool loop: %+v", result)
+	}
+}
+
+type envelopeProbeToolProvider struct{ tools []sdk.Tool }
+
+func (p envelopeProbeToolProvider) Tools(context.Context, agenttools.SessionContext) ([]sdk.Tool, error) {
+	return p.tools, nil
+}
+
+type envelopeProbeProvider struct {
+	calls   atomic.Int32
+	handler func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error)
+}
+
+func (*envelopeProbeProvider) Name() string { return "mock" }
+
+func (*envelopeProbeProvider) ListModels(context.Context) ([]sdk.Model, error) { return nil, nil }
+
+func (*envelopeProbeProvider) Test(context.Context) *sdk.ProviderTestResult {
+	return &sdk.ProviderTestResult{Status: sdk.ProviderStatusOK}
+}
+
+func (*envelopeProbeProvider) TestModel(context.Context, string) (*sdk.ModelTestResult, error) {
+	return &sdk.ModelTestResult{Supported: true}, nil
+}
+
+func (p *envelopeProbeProvider) DoGenerate(_ context.Context, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+	return p.handler(int(p.calls.Add(1)), params)
+}
+
+func (*envelopeProbeProvider) DoStream(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {
+	return nil, nil
+}
+
+func TestAgentToolLoopSurvivesPhotoInFrozenPrefix(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		window int
+	}{
+		{name: "128k window", window: 128_000},
+		{name: "200k window", window: 200_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &envelopeProbeProvider{handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+				if call == 1 {
+					return &sdk.GenerateResult{FinishReason: sdk.FinishReasonToolCalls, ToolCalls: []sdk.ToolCall{{
+						ToolCallID: "call-weather", ToolName: "lookup", Input: map[string]any{"q": "weather"},
+					}}}, nil
+				}
+				return &sdk.GenerateResult{Text: "sunny", FinishReason: sdk.FinishReasonStop}, nil
+			}}
+			agent := agentpkg.New(agentpkg.Deps{ContextViewApplier: ProviderRunConfigApplier(nil)})
+			agent.SetToolProviders([]agenttools.ToolProvider{envelopeProbeToolProvider{tools: []sdk.Tool{{
+				Name:       "lookup",
+				Parameters: &jsonschema.Schema{Type: "object"},
+				Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
+					return map[string]any{"weather": "sunny"}, nil
+				},
+			}}}})
+			currentIndex := 0
+			ledger := contextfrag.NewMutationLedger()
+			lifecycle := contextfrag.NewLifecycleHolder()
+			_, genErr := agent.Generate(context.Background(), agentpkg.RunConfig{
+				Model:                          &sdk.Model{ID: "vision-model", Provider: provider, Type: sdk.ModelTypeChat},
+				System:                         "you are helpful",
+				Messages:                       photoPrefix(1_000_000),
+				ContextCurrentUserMessageIndex: &currentIndex,
+				ContextBudgetMaxTokens:         tc.window,
+				SupportsToolCall:               true,
+				SupportsImageInput:             true,
+				Identity:                       agentpkg.SessionContext{BotID: "bot-1"},
+				ContextMutations:               ledger,
+				ContextLifecycle:               lifecycle,
+			})
+			if genErr != nil {
+				t.Fatalf("Generate() error = %v, mutations = %+v", genErr, ledger.Records())
+			}
+			if calls := provider.calls.Load(); calls != 2 {
+				t.Fatalf("provider calls = %d, want the tool step to dispatch after the photo turn", calls)
+			}
+			for _, record := range ledger.Records() {
+				if record.Kind == contextfrag.MutationContextBudgetFailure || record.Kind == contextfrag.MutationContextViewFallback {
+					t.Fatalf("photo prefix left the fragment-first path: %+v", record)
+				}
+			}
+			snapshot, ok := lifecycle.Snapshot()
+			if !ok || snapshot.BudgetPlan == nil || snapshot.BudgetPlan.Window != tc.window {
+				t.Fatalf("lifecycle snapshot = %+v, want the active budget plan for window %d", snapshot.BudgetPlan, tc.window)
+			}
+		})
+	}
+}

--- a/internal/contextview/provider_step_injection_test.go
+++ b/internal/contextview/provider_step_injection_test.go
@@ -237,7 +237,7 @@ func TestStepReselectionDropsBulkyImagePayloadsUnderBudgetPressure(t *testing.T)
 	}
 	loopEstimate := 0
 	for _, msg := range selection.Messages[len(prefix):] {
-		loopEstimate += fragTokenEstimate(contextfrag.ContextFrag{
+		loopEstimate += contextfrag.ResolveProviderBudgetFragTokens(contextfrag.ContextFrag{
 			Parts: []contextfrag.Part{{Type: contextfrag.PartSDKMessage, SDKMessage: &msg}},
 		})
 	}

--- a/internal/contextview/provider_step_reselection.go
+++ b/internal/contextview/provider_step_reselection.go
@@ -45,7 +45,7 @@ func SelectProviderStepMessages(ctx context.Context, input agentpkg.ContextStepS
 	}
 	frags = markInjectedLoopUserFrags(frags)
 	if input.ProviderInputAllowanceTokens > 0 {
-		frags = applyProviderStepSerializedCosts(frags, input)
+		frags = applyProviderStepEnvelopeCosts(frags)
 	}
 
 	selector := &FragmentSelector{}
@@ -102,43 +102,21 @@ func SelectProviderStepMessages(ctx context.Context, input agentpkg.ContextStepS
 		budget = nextBudget
 	}
 	return agentpkg.ContextStepSelectionResult{FatalError: fmt.Errorf(
-		"%w: serialized provider step exceeds input allowance %d",
+		"%w: provider step exceeds input allowance %d",
 		contextfrag.ErrBudgetUnsatisfied,
 		input.ProviderInputAllowanceTokens,
 	)}
 }
 
-func applyProviderStepSerializedCosts(
-	frags []contextfrag.ContextFrag,
-	input agentpkg.ContextStepSelectionInput,
-) []contextfrag.ContextFrag {
-	prefix := append([]sdk.Message(nil), input.Messages[:input.InitialMessageCount]...)
-	_, runningBytes := contextfrag.ProviderPayloadHashAndBytes(input.ProviderSystem, prefix, input.ProviderTools)
-	runningTokens := contextfrag.ProviderBudgetTokensFromBytes(runningBytes)
-	_, emptyEnvelopeBytes := contextfrag.ProviderPayloadHashAndBytes("", []sdk.Message{}, nil)
-	messageCount := len(prefix)
+// applyProviderStepEnvelopeCosts lifts each loop fragment to the provider
+// envelope estimate so the selector's budget arithmetic and the envelope check
+// price the same message identically.
+func applyProviderStepEnvelopeCosts(frags []contextfrag.ContextFrag) []contextfrag.ContextFrag {
 	for i := range frags {
-		msg := providerStepFragMessage(frags[i])
-		if msg == nil {
+		if providerStepFragMessage(frags[i]) == nil {
 			continue
 		}
-		_, singletonBytes := contextfrag.ProviderPayloadHashAndBytes("", []sdk.Message{*msg}, nil)
-		messageBytes := singletonBytes - emptyEnvelopeBytes
-		if messageCount == 0 {
-			// The fixed-envelope measurement serializes an empty cloned prefix as
-			// null. The first message replaces those four bytes with [<message>].
-			messageBytes -= 2
-		} else {
-			messageBytes++ // comma before an appended array element
-		}
-		runningBytes += messageBytes
-		nextTokens := contextfrag.ProviderBudgetTokensFromBytes(runningBytes)
-		serializedTokens := nextTokens - runningTokens
-		if serializedTokens > frags[i].TokenEstimate {
-			frags[i].TokenEstimate = serializedTokens
-		}
-		runningTokens = nextTokens
-		messageCount++
+		frags[i].TokenEstimate = contextfrag.ResolveProviderBudgetFragTokens(frags[i])
 	}
 	return frags
 }
@@ -147,16 +125,14 @@ func providerStepEnvelopeOverflow(input agentpkg.ContextStepSelectionInput, mess
 	if input.ProviderInputAllowanceTokens <= 0 {
 		return 0
 	}
-	_, payloadBytes := contextfrag.ProviderPayloadHashAndBytes(input.ProviderSystem, messages, input.ProviderTools)
-	return contextfrag.ProviderBudgetTokensFromBytes(payloadBytes) - input.ProviderInputAllowanceTokens
+	return contextfrag.ProviderEnvelopeTokens(input.ProviderSystem, messages, input.ProviderTools) - input.ProviderInputAllowanceTokens
 }
 
 // markInjectedLoopUserFrags types user-role messages appended during the tool
 // loop. Text-only carriers (InjectCh text, background summaries) hold content
 // the run deliberately inserted mid-stream, so step budget pressure must never
-// drop them. Image-bearing payloads (read_media injections) stay droppable:
-// their sources live at workspace paths the model can re-read, and their
-// base64 bodies can exceed the whole step budget on their own.
+// drop them. Media-bearing payloads (read_media injections) stay droppable:
+// their sources live at workspace paths the model can re-read.
 func markInjectedLoopUserFrags(frags []contextfrag.ContextFrag) []contextfrag.ContextFrag {
 	for i := range frags {
 		msg := providerStepFragMessage(frags[i])

--- a/internal/contextview/provider_step_reselection.go
+++ b/internal/contextview/provider_step_reselection.go
@@ -44,9 +44,6 @@ func SelectProviderStepMessages(ctx context.Context, input agentpkg.ContextStepS
 		return agentpkg.ContextStepSelectionResult{}
 	}
 	frags = markInjectedLoopUserFrags(frags)
-	if input.ProviderInputAllowanceTokens > 0 {
-		frags = applyProviderStepEnvelopeCosts(frags)
-	}
 
 	selector := &FragmentSelector{}
 	budget := input.BudgetMaxTokens
@@ -106,19 +103,6 @@ func SelectProviderStepMessages(ctx context.Context, input agentpkg.ContextStepS
 		contextfrag.ErrBudgetUnsatisfied,
 		input.ProviderInputAllowanceTokens,
 	)}
-}
-
-// applyProviderStepEnvelopeCosts lifts each loop fragment to the provider
-// envelope estimate so the selector's budget arithmetic and the envelope check
-// price the same message identically.
-func applyProviderStepEnvelopeCosts(frags []contextfrag.ContextFrag) []contextfrag.ContextFrag {
-	for i := range frags {
-		if providerStepFragMessage(frags[i]) == nil {
-			continue
-		}
-		frags[i].TokenEstimate = contextfrag.ResolveProviderBudgetFragTokens(frags[i])
-	}
-	return frags
 }
 
 func providerStepEnvelopeOverflow(input agentpkg.ContextStepSelectionInput, messages []sdk.Message) int {

--- a/internal/contextview/selection_tag.go
+++ b/internal/contextview/selection_tag.go
@@ -21,6 +21,11 @@ const (
 type TaggedFrag struct {
 	Frag contextfrag.ContextFrag
 	Tags []SelectionTag
+	// Tokens is the cost budget arithmetic charges for Frag. A hard provider
+	// budget prices it with the envelope estimator so selection and the
+	// rendered-envelope check agree; the fragment's own estimate is left
+	// untouched so selection decisions do not read as trims.
+	Tokens int
 }
 
 func (t TaggedFrag) HasTag(tag SelectionTag) bool {
@@ -30,7 +35,7 @@ func (t TaggedFrag) HasTag(tag SelectionTag) bool {
 func tagFragments(frags []contextfrag.ContextFrag, profile IntentProfile) []TaggedFrag {
 	tagged := make([]TaggedFrag, 0, len(frags))
 	for _, frag := range frags {
-		next := TaggedFrag{Frag: frag}
+		next := TaggedFrag{Frag: frag, Tokens: contextfrag.ResolveFragTokens(frag)}
 		if isMustKeepFrag(frag, profile) {
 			next.Tags = appendSelectionTag(next.Tags, TagMustKeep)
 		}

--- a/internal/contextview/selector.go
+++ b/internal/contextview/selector.go
@@ -64,6 +64,9 @@ func (*FragmentSelector) Select(frags []contextfrag.ContextFrag, profile IntentP
 	trimDrops := budgetTrimDrops
 	hardBudget := budget.Plan != nil || budget.EnforceProtectedBudget
 	if hardBudget {
+		for i := range tagged {
+			tagged[i].Tokens = contextfrag.ResolveProviderBudgetFragTokens(tagged[i].Frag)
+		}
 		protectedCost := protectedHistoryTokenCost(tagged)
 		if protectedCost > historyBudget {
 			result := selectionResultFromTaggedReasons(tagged, allSelectedIndexes(tagged), nil)

--- a/internal/contextview/selector_budget.go
+++ b/internal/contextview/selector_budget.go
@@ -173,7 +173,7 @@ func mergeBudgetUnits(units []budgetUnit, dest, src int, open map[string]int) {
 
 func addFragToBudgetUnit(unit *budgetUnit, index int, frag contextfrag.ContextFrag, taggedFrag TaggedFrag, hasCall, hasResult bool) {
 	unit.indexes = append(unit.indexes, index)
-	unit.tokens += fragTokenEstimate(frag)
+	unit.tokens += taggedFrag.Tokens
 	if !taggedFrag.HasTag(TagCanDrop) {
 		unit.droppable = false
 	}
@@ -350,7 +350,7 @@ func protectedHistoryTokenCost(tagged []TaggedFrag) int {
 				frag.Kind == contextfrag.KindCurrentUserMessage {
 				continue
 			}
-			total += fragTokenEstimate(frag)
+			total += tagged[idx].Tokens
 		}
 	}
 	return total
@@ -367,10 +367,6 @@ func hasSpatialBudgetDrop(reasons map[int]string) bool {
 		}
 	}
 	return false
-}
-
-func fragTokenEstimate(frag contextfrag.ContextFrag) int {
-	return contextfrag.ResolveFragTokens(frag)
 }
 
 // TrimNoticeFrag is the synthetic fragment the builder splices in when budget

--- a/internal/contextview/selector_tokens_test.go
+++ b/internal/contextview/selector_tokens_test.go
@@ -23,18 +23,19 @@ func toolCallMessageFrag(text string) contextfrag.ContextFrag {
 	})
 }
 
-func TestFragTokenEstimateAddsToolPayloadToText(t *testing.T) {
+func TestTagFragmentsPricesWithSharedEstimator(t *testing.T) {
 	t.Parallel()
 
 	text := "Running the search now."
 	frag := toolCallMessageFrag(text)
 
-	got := fragTokenEstimate(frag)
+	tagged := tagFragments([]contextfrag.ContextFrag{frag}, IntentProfile{Intent: contextfrag.IntentRunConfigPreProvider})
+	got := tagged[0].Tokens
 	if want := contextfrag.ResolveFragTokens(frag); got != want {
-		t.Fatalf("fragTokenEstimate = %d, want shared estimator value %d", got, want)
+		t.Fatalf("tagged tokens = %d, want shared estimator value %d", got, want)
 	}
 	if textOnly := len(text) / 4; got <= textOnly {
-		t.Fatalf("fragTokenEstimate = %d, must exceed text-only estimate %d", got, textOnly)
+		t.Fatalf("tagged tokens = %d, must exceed text-only estimate %d", got, textOnly)
 	}
 }
 

--- a/internal/contextview/system_budget.go
+++ b/internal/contextview/system_budget.go
@@ -167,10 +167,7 @@ func systemBudgetPlanActive(profile IntentProfile, plan *contextfrag.ContextBudg
 
 func finishSystemBudgetPlan(plan *contextfrag.ContextBudgetPlan, actual int) {
 	plan.ActualSystemCost = actual
-	plan.HistoryBudget = plan.SystemBudget - actual
-	if plan.HistoryBudget < 1 {
-		plan.HistoryBudget = 1
-	}
+	plan.HistoryBudget = max(plan.SystemBudget-actual, 0)
 }
 
 func systemFragCost(frags []contextfrag.ContextFrag) int {

--- a/internal/contextview/system_budget.go
+++ b/internal/contextview/system_budget.go
@@ -13,11 +13,6 @@ import (
 )
 
 const (
-	// DefaultOutputReserveTokens is the conservative large-window completion
-	// allowance ceiling used until model configuration exposes an explicit
-	// maximum output size. Default plans reserve the smaller of this ceiling
-	// and one quarter of the model context window.
-	DefaultOutputReserveTokens = 8192
 	// MinimumSystemBudgetTokens prevents an active plan from treating a tiny
 	// positive remainder as a usable system envelope.
 	MinimumSystemBudgetTokens = 256
@@ -30,8 +25,8 @@ const (
 )
 
 // ComputeContextBudgetPlan allocates the fixed reserves named by the provider
-// envelope contract. Passing outputReserve explicitly leaves the source seam
-// ready for a future model-level maximum without inventing one on RunConfig.
+// envelope contract. outputReserve is the resolved generation limit, so the
+// plan reserves exactly what the provider request may emit.
 func ComputeContextBudgetPlan(window, outputReserve, toolDefsCost, currentRequestCost int) (*contextfrag.ContextBudgetPlan, error) {
 	if window == 0 {
 		return nil, nil

--- a/internal/contextview/system_budget_test.go
+++ b/internal/contextview/system_budget_test.go
@@ -120,8 +120,8 @@ func TestSystemBudgetDropsOptionalBeforePreferredInDeterministicOrder(t *testing
 	if plan.ActualSystemCost != plan.SystemBudget {
 		t.Fatalf("actual system cost = %d, want budget-accounted %d", plan.ActualSystemCost, plan.SystemBudget)
 	}
-	if plan.HistoryBudget != 1 {
-		t.Fatalf("history budget = %d, want floor 1", plan.HistoryBudget)
+	if plan.HistoryBudget != 0 {
+		t.Fatalf("history budget = %d, want nothing left for history", plan.HistoryBudget)
 	}
 }
 

--- a/internal/contextview/types.go
+++ b/internal/contextview/types.go
@@ -22,8 +22,7 @@ type BudgetEnvelope struct {
 	// Plan activates unified provider-envelope budgeting. Nil preserves the
 	// legacy unbudgeted provider selection path. Either Plan or
 	// EnforceProtectedBudget makes the budget a provider allowance, which
-	// charges fragments with the provider envelope estimator instead of their
-	// legacy estimates.
+	// charges fragments at least the provider envelope estimate.
 	Plan *contextfrag.ContextBudgetPlan
 	// EnforceProtectedBudget makes MaxTokens a hard allowance that includes
 	// must-keep fragments without reactivating the turn-start system pass.

--- a/internal/contextview/types.go
+++ b/internal/contextview/types.go
@@ -20,7 +20,10 @@ type SourceSpec struct {
 type BudgetEnvelope struct {
 	MaxTokens int
 	// Plan activates unified provider-envelope budgeting. Nil preserves the
-	// legacy unbudgeted provider selection path.
+	// legacy unbudgeted provider selection path. Either Plan or
+	// EnforceProtectedBudget makes the budget a provider allowance, which
+	// charges fragments with the provider envelope estimator instead of their
+	// legacy estimates.
 	Plan *contextfrag.ContextBudgetPlan
 	// EnforceProtectedBudget makes MaxTokens a hard allowance that includes
 	// must-keep fragments without reactivating the turn-start system pass.
@@ -28,7 +31,7 @@ type BudgetEnvelope struct {
 	// context cannot fit the remaining provider envelope.
 	EnforceProtectedBudget bool
 	// RecentProtectTokens bands the newest droppable history within this many
-	// estimated tokens to drop last. Zero disables the window.
+	// charged tokens to drop last. Zero disables the window.
 	RecentProtectTokens int
 	ToolExchange        *contextfrag.ToolExchangePolicy
 }

--- a/internal/models/generation_limits.go
+++ b/internal/models/generation_limits.go
@@ -43,12 +43,12 @@ func ResolveGenerationLimits(clientType ClientType, reasoning *ReasoningConfig, 
 	if reasoning != nil && reasoning.Active {
 		limits.MaxOutputTokens = DefaultReasoningOutputReserveTokens
 	}
-	if !EnforcesMaxOutputTokens(clientType) {
-		limits.Resolution = GenerationLimitsProviderIgnores
-	}
 	if contextWindow > 0 && limits.MaxOutputTokens > contextWindow/4 {
 		limits.MaxOutputTokens = contextWindow / 4
 		limits.Resolution = GenerationLimitsWindowClamped
+	}
+	if !EnforcesMaxOutputTokens(clientType) {
+		limits.Resolution = GenerationLimitsProviderIgnores
 	}
 	return limits
 }
@@ -56,7 +56,8 @@ func ResolveGenerationLimits(clientType ClientType, reasoning *ReasoningConfig, 
 // anthropicGenerationLimits reproduces the adapter's max_tokens resolution:
 // the answer allowance, the reasoning-aware default for adaptive thinking, or
 // the answer allowance plus the legacy thinking budget. Thinking may use at
-// most half of a configured window.
+// most half of a configured window, down to the minimum budget the API
+// accepts.
 func anthropicGenerationLimits(reasoning *ReasoningConfig, contextWindow int) GenerationLimits {
 	limits := GenerationLimits{
 		MaxOutputTokens: anthropicDefaultMaxTokens,
@@ -84,8 +85,9 @@ func anthropicGenerationLimits(reasoning *ReasoningConfig, contextWindow int) Ge
 
 // AnthropicThinkingBudget is the legacy budget_tokens sent for an effort,
 // fitted so the answer allowance plus the budget stays within half of the
-// configured window; the model construction and the budget plan share it so
-// budget_tokens always stays below the requested max_tokens.
+// configured window but never below the minimum the API accepts; the model
+// construction and the budget plan share it so budget_tokens always stays
+// below the requested max_tokens.
 func AnthropicThinkingBudget(effort string, contextWindow int) int {
 	budget := legacyAnthropicBudgetFor(effort)
 	if contextWindow > 0 {

--- a/internal/models/generation_limits.go
+++ b/internal/models/generation_limits.go
@@ -10,62 +10,86 @@ const (
 
 	anthropicDefaultMaxTokens          = 4096
 	anthropicDefaultReasoningMaxTokens = 32000
+	anthropicMinThinkingBudgetTokens   = 1024
 )
 
 const (
 	GenerationLimitsProviderDefault = "provider_default"
-	GenerationLimitsPolicyCap       = "policy_cap"
 	GenerationLimitsEstimated       = "estimated"
 	GenerationLimitsProviderIgnores = "provider_ignores"
 	GenerationLimitsWindowClamped   = "window_clamped"
 )
 
 // GenerationLimits is the single authority for one turn's output allowance:
-// the same MaxOutputTokens reserves window space in the context budget plan
-// and, when Enforced, is sent to the provider as max_tokens. Unenforced
-// limits are Memoh's reserve only; the provider keeps its own default because
-// the model's real cap is unknown and an explicit value could be rejected.
+// the context budget plan reserves MaxOutputTokens and, when Requested, the
+// provider request carries the same value as max_tokens. Unrequested limits
+// are Memoh's reserve only; the provider keeps its own default because the
+// model's real cap is unknown and an explicit value could be rejected.
 type GenerationLimits struct {
 	MaxOutputTokens int
-	Enforced        bool
+	Requested       bool
 	Resolution      string
 }
 
-// ResolveGenerationLimits derives the output allowance from the client type
-// and the resolved thinking decision. Anthropic mirrors the SDK's own
-// defaults exactly (answer allowance, plus the thinking budget for legacy
-// models, or the reasoning-aware default for adaptive thinking), so the
-// reserved and requested values cannot diverge; OpenAI Responses models all
-// accept the policy caps; other clients are estimated without enforcement.
+// ResolveGenerationLimits derives the output allowance from the client type,
+// the resolved thinking decision, and the configured context window.
+// Anthropic mirrors the SDK's own defaults, so the reserved and requested
+// values cannot diverge; every other client is estimated without a request.
 func ResolveGenerationLimits(clientType ClientType, reasoning *ReasoningConfig, contextWindow int) GenerationLimits {
-	active := reasoning != nil && reasoning.Active
+	if clientType == ClientTypeAnthropicMessages {
+		return anthropicGenerationLimits(reasoning, contextWindow)
+	}
 	limits := GenerationLimits{MaxOutputTokens: DefaultOutputReserveTokens, Resolution: GenerationLimitsEstimated}
-	if active {
+	if reasoning != nil && reasoning.Active {
 		limits.MaxOutputTokens = DefaultReasoningOutputReserveTokens
 	}
-	legacyThinking := false
-	switch clientType {
-	case ClientTypeAnthropicMessages:
-		limits.Enforced = true
-		limits.Resolution = GenerationLimitsProviderDefault
-		switch {
-		case active && reasoning.Adaptive:
-			limits.MaxOutputTokens = anthropicDefaultReasoningMaxTokens
-		case active:
-			legacyThinking = true
-			limits.MaxOutputTokens = anthropicDefaultMaxTokens + legacyAnthropicBudgetFor(reasoning.Effort)
-		default:
-			limits.MaxOutputTokens = anthropicDefaultMaxTokens
-		}
-	case ClientTypeOpenAIResponses:
-		limits.Enforced = true
-		limits.Resolution = GenerationLimitsPolicyCap
-	case ClientTypeOpenAICodex:
+	if !EnforcesMaxOutputTokens(clientType) {
 		limits.Resolution = GenerationLimitsProviderIgnores
 	}
-	if contextWindow > 0 && !legacyThinking && limits.MaxOutputTokens > contextWindow/4 {
+	if contextWindow > 0 && limits.MaxOutputTokens > contextWindow/4 {
 		limits.MaxOutputTokens = contextWindow / 4
 		limits.Resolution = GenerationLimitsWindowClamped
 	}
 	return limits
+}
+
+// anthropicGenerationLimits reproduces the adapter's max_tokens resolution:
+// the answer allowance, the reasoning-aware default for adaptive thinking, or
+// the answer allowance plus the legacy thinking budget. Thinking may use at
+// most half of a configured window.
+func anthropicGenerationLimits(reasoning *ReasoningConfig, contextWindow int) GenerationLimits {
+	limits := GenerationLimits{
+		MaxOutputTokens: anthropicDefaultMaxTokens,
+		Requested:       true,
+		Resolution:      GenerationLimitsProviderDefault,
+	}
+	switch {
+	case reasoning == nil || !reasoning.Active:
+		return limits
+	case reasoning.Adaptive:
+		limits.MaxOutputTokens = anthropicDefaultReasoningMaxTokens
+		if contextWindow > 0 && limits.MaxOutputTokens > contextWindow/2 {
+			limits.MaxOutputTokens = contextWindow / 2
+			limits.Resolution = GenerationLimitsWindowClamped
+		}
+	default:
+		budget := AnthropicThinkingBudget(reasoning.Effort, contextWindow)
+		limits.MaxOutputTokens = anthropicDefaultMaxTokens + budget
+		if budget < legacyAnthropicBudgetFor(reasoning.Effort) {
+			limits.Resolution = GenerationLimitsWindowClamped
+		}
+	}
+	return limits
+}
+
+// AnthropicThinkingBudget is the legacy budget_tokens sent for an effort,
+// fitted so the answer allowance plus the budget stays within half of the
+// configured window; the model construction and the budget plan share it so
+// budget_tokens always stays below the requested max_tokens.
+func AnthropicThinkingBudget(effort string, contextWindow int) int {
+	budget := legacyAnthropicBudgetFor(effort)
+	if contextWindow > 0 {
+		budget = min(budget, max(anthropicMinThinkingBudgetTokens, contextWindow/2-anthropicDefaultMaxTokens))
+	}
+	return budget
 }

--- a/internal/models/generation_limits.go
+++ b/internal/models/generation_limits.go
@@ -1,0 +1,71 @@
+package models
+
+const (
+	// DefaultOutputReserveTokens is the completion allowance reserved for a
+	// turn when the provider's own cap is not mirrored exactly.
+	DefaultOutputReserveTokens = 8192
+	// DefaultReasoningOutputReserveTokens is the allowance when thinking is
+	// active; reasoning output shares the completion cap on every provider.
+	DefaultReasoningOutputReserveTokens = 32000
+
+	anthropicDefaultMaxTokens          = 4096
+	anthropicDefaultReasoningMaxTokens = 32000
+)
+
+const (
+	GenerationLimitsProviderDefault = "provider_default"
+	GenerationLimitsPolicyCap       = "policy_cap"
+	GenerationLimitsEstimated       = "estimated"
+	GenerationLimitsProviderIgnores = "provider_ignores"
+	GenerationLimitsWindowClamped   = "window_clamped"
+)
+
+// GenerationLimits is the single authority for one turn's output allowance:
+// the same MaxOutputTokens reserves window space in the context budget plan
+// and, when Enforced, is sent to the provider as max_tokens. Unenforced
+// limits are Memoh's reserve only; the provider keeps its own default because
+// the model's real cap is unknown and an explicit value could be rejected.
+type GenerationLimits struct {
+	MaxOutputTokens int
+	Enforced        bool
+	Resolution      string
+}
+
+// ResolveGenerationLimits derives the output allowance from the client type
+// and the resolved thinking decision. Anthropic mirrors the SDK's own
+// defaults exactly (answer allowance, plus the thinking budget for legacy
+// models, or the reasoning-aware default for adaptive thinking), so the
+// reserved and requested values cannot diverge; OpenAI Responses models all
+// accept the policy caps; other clients are estimated without enforcement.
+func ResolveGenerationLimits(clientType ClientType, reasoning *ReasoningConfig, contextWindow int) GenerationLimits {
+	active := reasoning != nil && reasoning.Active
+	limits := GenerationLimits{MaxOutputTokens: DefaultOutputReserveTokens, Resolution: GenerationLimitsEstimated}
+	if active {
+		limits.MaxOutputTokens = DefaultReasoningOutputReserveTokens
+	}
+	legacyThinking := false
+	switch clientType {
+	case ClientTypeAnthropicMessages:
+		limits.Enforced = true
+		limits.Resolution = GenerationLimitsProviderDefault
+		switch {
+		case active && reasoning.Adaptive:
+			limits.MaxOutputTokens = anthropicDefaultReasoningMaxTokens
+		case active:
+			legacyThinking = true
+			limits.MaxOutputTokens = anthropicDefaultMaxTokens + legacyAnthropicBudgetFor(reasoning.Effort)
+		default:
+			limits.MaxOutputTokens = anthropicDefaultMaxTokens
+		}
+	case ClientTypeOpenAIResponses:
+		limits.Enforced = true
+		limits.Resolution = GenerationLimitsPolicyCap
+	case ClientTypeOpenAICodex:
+		limits.Resolution = GenerationLimitsProviderIgnores
+	}
+	if contextWindow > 0 && !legacyThinking && limits.MaxOutputTokens > contextWindow/4 {
+		limits.MaxOutputTokens = contextWindow / 4
+		limits.Resolution = GenerationLimitsWindowClamped
+	}
+	return limits
+}

--- a/internal/models/generation_limits_test.go
+++ b/internal/models/generation_limits_test.go
@@ -24,7 +24,7 @@ func TestResolveGenerationLimitsMirrorsAnthropicProviderDefaults(t *testing.T) {
 			if got.MaxOutputTokens != tc.want {
 				t.Fatalf("MaxOutputTokens = %d, want %d", got.MaxOutputTokens, tc.want)
 			}
-			if !got.Enforced {
+			if !got.Requested {
 				t.Fatal("Anthropic limits must be sent as max_tokens so the plan and the request share one value")
 			}
 			if got.Resolution != GenerationLimitsProviderDefault {
@@ -34,64 +34,70 @@ func TestResolveGenerationLimitsMirrorsAnthropicProviderDefaults(t *testing.T) {
 	}
 }
 
-func TestResolveGenerationLimitsCapsOpenAIResponses(t *testing.T) {
+func TestResolveGenerationLimitsFitsAnthropicThinkingIntoHalfTheWindow(t *testing.T) {
 	t.Parallel()
 
-	plain := ResolveGenerationLimits(ClientTypeOpenAIResponses, nil, 400_000)
-	if plain.MaxOutputTokens != DefaultOutputReserveTokens || !plain.Enforced || plain.Resolution != GenerationLimitsPolicyCap {
-		t.Fatalf("plain responses limits = %+v, want enforced policy cap %d", plain, DefaultOutputReserveTokens)
+	legacy := ResolveGenerationLimits(ClientTypeAnthropicMessages, &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, 64_000)
+	if legacy.MaxOutputTokens != 32_000 || !legacy.Requested || legacy.Resolution != GenerationLimitsWindowClamped {
+		t.Fatalf("legacy high on 64k = %+v, want 4096 + a 27904 budget fitted to half the window", legacy)
 	}
-	reasoning := ResolveGenerationLimits(ClientTypeOpenAIResponses, &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, 400_000)
-	if reasoning.MaxOutputTokens != DefaultReasoningOutputReserveTokens || !reasoning.Enforced {
-		t.Fatalf("reasoning responses limits = %+v, want enforced policy cap %d", reasoning, DefaultReasoningOutputReserveTokens)
+	if budget := AnthropicThinkingBudget(ReasoningEffortHigh, 64_000); budget != 27_904 {
+		t.Fatalf("fitted budget = %d, want 27904 so budget_tokens stays below max_tokens", budget)
+	}
+	if budget := AnthropicThinkingBudget(ReasoningEffortHigh, 200_000); budget != 50_000 {
+		t.Fatalf("budget on 200k = %d, want the full 50000", budget)
+	}
+	if budget := AnthropicThinkingBudget(ReasoningEffortHigh, 8_000); budget != 1_024 {
+		t.Fatalf("budget on 8k = %d, want the Anthropic minimum", budget)
+	}
+	adaptive := ResolveGenerationLimits(ClientTypeAnthropicMessages, &ReasoningConfig{Active: true, Adaptive: true}, 100_000)
+	if adaptive.MaxOutputTokens != 32_000 || adaptive.Resolution != GenerationLimitsProviderDefault {
+		t.Fatalf("adaptive on 100k = %+v, want the untouched 32000 default", adaptive)
+	}
+	small := ResolveGenerationLimits(ClientTypeAnthropicMessages, &ReasoningConfig{Active: true, Adaptive: true}, 60_000)
+	if small.MaxOutputTokens != 30_000 || !small.Requested || small.Resolution != GenerationLimitsWindowClamped {
+		t.Fatalf("adaptive on 60k = %+v, want 30000 window_clamped", small)
 	}
 }
 
-func TestResolveGenerationLimitsEstimatesWithoutEnforcingForUnknownCatalogs(t *testing.T) {
+func TestResolveGenerationLimitsEstimatesWithoutRequestingForOtherClients(t *testing.T) {
 	t.Parallel()
 
-	for _, clientType := range []ClientType{ClientTypeOpenAICompletions, ClientTypeGoogleGenerativeAI, ClientTypeGitHubCopilot} {
+	for _, clientType := range []ClientType{ClientTypeOpenAIResponses, ClientTypeOpenAICompletions, ClientTypeGoogleGenerativeAI, ClientTypeGitHubCopilot} {
 		t.Run(string(clientType), func(t *testing.T) {
 			t.Parallel()
 			plain := ResolveGenerationLimits(clientType, nil, 128_000)
-			if plain.MaxOutputTokens != DefaultOutputReserveTokens || plain.Enforced || plain.Resolution != GenerationLimitsEstimated {
-				t.Fatalf("plain limits = %+v, want unenforced estimate %d", plain, DefaultOutputReserveTokens)
+			if plain.MaxOutputTokens != DefaultOutputReserveTokens || plain.Requested || plain.Resolution != GenerationLimitsEstimated {
+				t.Fatalf("plain limits = %+v, want unrequested estimate %d", plain, DefaultOutputReserveTokens)
 			}
 			reasoning := ResolveGenerationLimits(clientType, &ReasoningConfig{Active: true}, 128_000)
-			if reasoning.MaxOutputTokens != DefaultReasoningOutputReserveTokens || reasoning.Enforced {
-				t.Fatalf("reasoning limits = %+v, want unenforced estimate %d", reasoning, DefaultReasoningOutputReserveTokens)
+			if reasoning.MaxOutputTokens != DefaultReasoningOutputReserveTokens || reasoning.Requested {
+				t.Fatalf("reasoning limits = %+v, want unrequested estimate %d", reasoning, DefaultReasoningOutputReserveTokens)
 			}
 		})
 	}
 }
 
-func TestResolveGenerationLimitsNeverEnforcesOnCodex(t *testing.T) {
+func TestResolveGenerationLimitsMarksCodexAsIgnoringTheCap(t *testing.T) {
 	t.Parallel()
 
 	got := ResolveGenerationLimits(ClientTypeOpenAICodex, &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, 400_000)
-	if got.Enforced || got.Resolution != GenerationLimitsProviderIgnores || got.MaxOutputTokens != DefaultReasoningOutputReserveTokens {
-		t.Fatalf("codex limits = %+v, want unenforced reserve %d with provider_ignores", got, DefaultReasoningOutputReserveTokens)
+	if got.Requested || got.Resolution != GenerationLimitsProviderIgnores || got.MaxOutputTokens != DefaultReasoningOutputReserveTokens {
+		t.Fatalf("codex limits = %+v, want unrequested reserve %d with provider_ignores", got, DefaultReasoningOutputReserveTokens)
 	}
 }
 
-func TestResolveGenerationLimitsClampsToAQuarterOfTheWindow(t *testing.T) {
+func TestResolveGenerationLimitsClampsEstimatesToAQuarterOfTheWindow(t *testing.T) {
 	t.Parallel()
 
 	got := ResolveGenerationLimits(ClientTypeOpenAICompletions, nil, 8_192)
-	if got.MaxOutputTokens != 2_048 || got.Resolution != GenerationLimitsWindowClamped || got.Enforced {
+	if got.MaxOutputTokens != 2_048 || got.Resolution != GenerationLimitsWindowClamped || got.Requested {
 		t.Fatalf("small-window limits = %+v, want 2048 window_clamped", got)
 	}
 	if got := ResolveGenerationLimits(ClientTypeOpenAICompletions, nil, 32_767); got.MaxOutputTokens != 8_191 {
 		t.Fatalf("quarter-window clamp = %+v, want 8191", got)
 	}
-	if got := ResolveGenerationLimits(ClientTypeOpenAIResponses, &ReasoningConfig{Active: true}, 64_000); got.MaxOutputTokens != 16_000 || !got.Enforced {
-		t.Fatalf("clamped enforced limits = %+v, want 16000 still enforced", got)
-	}
 	if got := ResolveGenerationLimits(ClientTypeOpenAICompletions, nil, 0); got.MaxOutputTokens != DefaultOutputReserveTokens {
 		t.Fatalf("unknown window must not clamp: %+v", got)
-	}
-	legacy := ResolveGenerationLimits(ClientTypeAnthropicMessages, &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, 64_000)
-	if legacy.MaxOutputTokens != 4096+50000 {
-		t.Fatalf("legacy thinking floor must survive the clamp (budget_tokens must stay below max_tokens): %+v", legacy)
 	}
 }

--- a/internal/models/generation_limits_test.go
+++ b/internal/models/generation_limits_test.go
@@ -1,0 +1,97 @@
+package models
+
+import "testing"
+
+func TestResolveGenerationLimitsMirrorsAnthropicProviderDefaults(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		reasoning *ReasoningConfig
+		want      int
+	}{
+		{name: "no reasoning config", reasoning: nil, want: 4096},
+		{name: "explicitly disabled", reasoning: &ReasoningConfig{Disabled: true}, want: 4096},
+		{name: "adaptive", reasoning: &ReasoningConfig{Active: true, Adaptive: true, Effort: ReasoningEffortHigh}, want: 32000},
+		{name: "legacy low", reasoning: &ReasoningConfig{Active: true, Effort: ReasoningEffortLow}, want: 4096 + 5000},
+		{name: "legacy medium", reasoning: &ReasoningConfig{Active: true, Effort: ReasoningEffortMedium}, want: 4096 + 16000},
+		{name: "legacy high", reasoning: &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, want: 4096 + 50000},
+		{name: "legacy unknown effort defaults to medium", reasoning: &ReasoningConfig{Active: true}, want: 4096 + 16000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveGenerationLimits(ClientTypeAnthropicMessages, tc.reasoning, 200_000)
+			if got.MaxOutputTokens != tc.want {
+				t.Fatalf("MaxOutputTokens = %d, want %d", got.MaxOutputTokens, tc.want)
+			}
+			if !got.Enforced {
+				t.Fatal("Anthropic limits must be sent as max_tokens so the plan and the request share one value")
+			}
+			if got.Resolution != GenerationLimitsProviderDefault {
+				t.Fatalf("Resolution = %q, want %q", got.Resolution, GenerationLimitsProviderDefault)
+			}
+		})
+	}
+}
+
+func TestResolveGenerationLimitsCapsOpenAIResponses(t *testing.T) {
+	t.Parallel()
+
+	plain := ResolveGenerationLimits(ClientTypeOpenAIResponses, nil, 400_000)
+	if plain.MaxOutputTokens != DefaultOutputReserveTokens || !plain.Enforced || plain.Resolution != GenerationLimitsPolicyCap {
+		t.Fatalf("plain responses limits = %+v, want enforced policy cap %d", plain, DefaultOutputReserveTokens)
+	}
+	reasoning := ResolveGenerationLimits(ClientTypeOpenAIResponses, &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, 400_000)
+	if reasoning.MaxOutputTokens != DefaultReasoningOutputReserveTokens || !reasoning.Enforced {
+		t.Fatalf("reasoning responses limits = %+v, want enforced policy cap %d", reasoning, DefaultReasoningOutputReserveTokens)
+	}
+}
+
+func TestResolveGenerationLimitsEstimatesWithoutEnforcingForUnknownCatalogs(t *testing.T) {
+	t.Parallel()
+
+	for _, clientType := range []ClientType{ClientTypeOpenAICompletions, ClientTypeGoogleGenerativeAI, ClientTypeGitHubCopilot} {
+		t.Run(string(clientType), func(t *testing.T) {
+			t.Parallel()
+			plain := ResolveGenerationLimits(clientType, nil, 128_000)
+			if plain.MaxOutputTokens != DefaultOutputReserveTokens || plain.Enforced || plain.Resolution != GenerationLimitsEstimated {
+				t.Fatalf("plain limits = %+v, want unenforced estimate %d", plain, DefaultOutputReserveTokens)
+			}
+			reasoning := ResolveGenerationLimits(clientType, &ReasoningConfig{Active: true}, 128_000)
+			if reasoning.MaxOutputTokens != DefaultReasoningOutputReserveTokens || reasoning.Enforced {
+				t.Fatalf("reasoning limits = %+v, want unenforced estimate %d", reasoning, DefaultReasoningOutputReserveTokens)
+			}
+		})
+	}
+}
+
+func TestResolveGenerationLimitsNeverEnforcesOnCodex(t *testing.T) {
+	t.Parallel()
+
+	got := ResolveGenerationLimits(ClientTypeOpenAICodex, &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, 400_000)
+	if got.Enforced || got.Resolution != GenerationLimitsProviderIgnores || got.MaxOutputTokens != DefaultReasoningOutputReserveTokens {
+		t.Fatalf("codex limits = %+v, want unenforced reserve %d with provider_ignores", got, DefaultReasoningOutputReserveTokens)
+	}
+}
+
+func TestResolveGenerationLimitsClampsToAQuarterOfTheWindow(t *testing.T) {
+	t.Parallel()
+
+	got := ResolveGenerationLimits(ClientTypeOpenAICompletions, nil, 8_192)
+	if got.MaxOutputTokens != 2_048 || got.Resolution != GenerationLimitsWindowClamped || got.Enforced {
+		t.Fatalf("small-window limits = %+v, want 2048 window_clamped", got)
+	}
+	if got := ResolveGenerationLimits(ClientTypeOpenAICompletions, nil, 32_767); got.MaxOutputTokens != 8_191 {
+		t.Fatalf("quarter-window clamp = %+v, want 8191", got)
+	}
+	if got := ResolveGenerationLimits(ClientTypeOpenAIResponses, &ReasoningConfig{Active: true}, 64_000); got.MaxOutputTokens != 16_000 || !got.Enforced {
+		t.Fatalf("clamped enforced limits = %+v, want 16000 still enforced", got)
+	}
+	if got := ResolveGenerationLimits(ClientTypeOpenAICompletions, nil, 0); got.MaxOutputTokens != DefaultOutputReserveTokens {
+		t.Fatalf("unknown window must not clamp: %+v", got)
+	}
+	legacy := ResolveGenerationLimits(ClientTypeAnthropicMessages, &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, 64_000)
+	if legacy.MaxOutputTokens != 4096+50000 {
+		t.Fatalf("legacy thinking floor must survive the clamp (budget_tokens must stay below max_tokens): %+v", legacy)
+	}
+}

--- a/internal/models/generation_limits_wire_test.go
+++ b/internal/models/generation_limits_wire_test.go
@@ -1,0 +1,84 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// TestAnthropicGenerationLimitsMatchTheAdapterDefaults binds the mirrored
+// constants to the SDK's real wire: with no explicit MaxTokens, the adapter
+// must resolve exactly what ResolveGenerationLimits reserves, and the thinking
+// budget it sends must stay below that cap.
+func TestAnthropicGenerationLimitsMatchTheAdapterDefaults(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		reasoning *ReasoningConfig
+		window    int
+	}{
+		{name: "no reasoning", window: 200_000},
+		{name: "disabled", reasoning: &ReasoningConfig{Disabled: true}, window: 200_000},
+		{name: "adaptive", reasoning: &ReasoningConfig{Active: true, Adaptive: true, Effort: ReasoningEffortHigh}, window: 200_000},
+		{name: "legacy low", reasoning: &ReasoningConfig{Active: true, Effort: ReasoningEffortLow}, window: 200_000},
+		{name: "legacy medium", reasoning: &ReasoningConfig{Active: true, Effort: ReasoningEffortMedium}, window: 200_000},
+		{name: "legacy high", reasoning: &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, window: 200_000},
+		{name: "legacy high fitted to a 64k window", reasoning: &ReasoningConfig{Active: true, Effort: ReasoningEffortHigh}, window: 64_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var body struct {
+				MaxTokens int `json:"max_tokens"`
+				Thinking  *struct {
+					Type         string `json:"type"`
+					BudgetTokens int    `json:"budget_tokens"`
+				} `json:"thinking"`
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id": "msg_anthropic", "type": "message", "model": "claude-test", "role": "assistant",
+					"content":     []map[string]any{{"type": "text", "text": "ok"}},
+					"stop_reason": "end_turn",
+					"usage":       map[string]any{"input_tokens": 1, "output_tokens": 1},
+				})
+			}))
+			defer srv.Close()
+
+			cfg := SDKModelConfig{
+				ModelID:         "claude-test",
+				ClientType:      string(ClientTypeAnthropicMessages),
+				BaseURL:         srv.URL,
+				APIKey:          "test-key",
+				ReasoningConfig: tc.reasoning,
+				ContextWindow:   tc.window,
+			}
+			opts := append([]sdk.GenerateOption{
+				sdk.WithModel(NewSDKChatModel(cfg)),
+				sdk.WithMessages([]sdk.Message{sdk.UserMessage("hi")}),
+			}, BuildReasoningOptions(cfg)...)
+			if _, err := sdk.GenerateTextResult(context.Background(), opts...); err != nil {
+				t.Fatalf("generate text: %v", err)
+			}
+
+			limits := ResolveGenerationLimits(ClientTypeAnthropicMessages, tc.reasoning, tc.window)
+			if body.MaxTokens != limits.MaxOutputTokens {
+				t.Fatalf("adapter max_tokens = %d, resolver reserves %d", body.MaxTokens, limits.MaxOutputTokens)
+			}
+			if body.Thinking != nil && body.Thinking.Type == "enabled" {
+				if body.Thinking.BudgetTokens != limits.MaxOutputTokens-anthropicDefaultMaxTokens {
+					t.Fatalf("budget_tokens = %d, want %d below max_tokens", body.Thinking.BudgetTokens, limits.MaxOutputTokens-anthropicDefaultMaxTokens)
+				}
+			}
+		})
+	}
+}

--- a/internal/models/sdk.go
+++ b/internal/models/sdk.go
@@ -40,6 +40,9 @@ type SDKModelConfig struct {
 	// ReasoningDefaultOn reports whether omitting the thinking field leaves the
 	// model thinking. nil means unknown.
 	ReasoningDefaultOn *bool
+	// ContextWindow is the configured context window the turn budgets against;
+	// legacy Anthropic thinking budgets are fitted to it. Zero means unknown.
+	ContextWindow int
 }
 
 // ReasoningConfig is the resolved extended-thinking decision for one call,
@@ -127,7 +130,7 @@ func NewSDKChatModel(cfg SDKModelConfig) *sdk.Model {
 			case rc.Active:
 				opts = append(opts, anthropicmessages.WithThinking(anthropicmessages.ThinkingConfig{
 					Type:         "enabled",
-					BudgetTokens: legacyAnthropicBudgetFor(rc.Effort),
+					BudgetTokens: AnthropicThinkingBudget(rc.Effort, cfg.ContextWindow),
 				}))
 			case rc.Disabled && anthropicNeedsExplicitOff(cfg.ReasoningOffSupport, cfg.ReasoningDefaultOn):
 				opts = append(opts, anthropicmessages.WithThinking(anthropicmessages.ThinkingConfig{


### PR DESCRIPTION
## What changes

The provider envelope gets a single authority on both of its sides.

**One estimator for every envelope decision.** `contextfrag.ProviderEnvelopeTokens` prices a payload the way selection prices a fragment (conservative bytes for text and tool payloads, the flat per-image estimate for media). The initial rendered check, `remainingStepBudget`, step reselection, and the attempt overflow guard all use it; `ProviderPayloadHash` is hash-only. The step-level checks previously serialized the SDK payload and priced inline images by base64 length, so a 300KB photo in the user message failed the first tool step closed on a 128k window (`protected context exceeds its budget`) while the initial check had priced it at 1.5k tokens. Selection under a provider budget now charges history through `TaggedFrag.Tokens` with the same estimator, so a nearly full window trims a few more messages instead of failing closed at the rendered check, and a system slot that fills its budget leaves no phantom history token.

**One value for the output allowance.** `models.ResolveGenerationLimits` derives the turn's output allowance from the client type, the thinking decision, and the configured window; `RunConfig.GenerationLimits()` is the single derivation behind both the budget plan's `OutputReserve` (now recorded with `output_reserve_resolution`) and the request. Anthropic mirrors the SDK adapter's own default exactly (4096, 32000 adaptive, 4096 plus the legacy thinking budget) and sends it as `max_tokens`; a wire test binds the mirrored values to the adapter so an SDK change cannot silently turn the mirror into an override. Legacy thinking budgets are fitted to half of the configured window through `AnthropicThinkingBudget`, shared by model construction and the plan, so a user-lowered window no longer fails every turn and `budget_tokens` stays below `max_tokens`. Every other client keeps an unrequested estimate (8192, 32000 with thinking active, clamped to a quarter of the window) because its model cap is unknown and an explicit value could be rejected; Codex is recorded as ignoring the field.

**The final envelope check on every dispatch.** `prepareProviderAttempt` ran the check only after a reselection, so the initial full-prefix dispatch, runs without a reselector, shadow mode, and the legacy fallback reached the provider unchecked. The check is now the unconditional post-condition of every prepared attempt, the plan-less allowance reserves the resolved output, and the fallback keeps both the budget plan and step reselection: it is an assembly path, not a budget-disabled path. Shadow mode keeps its observed verdict on a rejected step.

**The acceptance matrix.** Client types × thinking decisions × assembly paths pin the contract end to end through the real applier and a captured provider request: the plan reserves the resolved allowance, the request carries it only where the adapter would resolve the same value, a fitting payload dispatches once, and a payload inside the window but outside the allowance never reaches the provider.

## Scope

Correctness only: no schema, API handler, or web changes. The additive `output_reserve_resolution` field on the lifecycle budget plan is `omitempty`; the OpenAPI/SDK artifacts are not regenerated here because they already lag upstream by unrelated drift that the PR8 regen commit absorbs.

Tracked follow-ups, not in this PR: `sdk.FilePart` is still byte-priced on both sides (a 300KB PDF prices at ~125k tokens); catalog `max_output_tokens` (LiteLLM carries it) would let the long tail request its cap and would cure the pre-existing Opus 4/4.1 legacy-high 54096 > 32000 rejection; mid-stream retries re-reserve the full output allowance on top of already-produced partial output.

This is part 6 of the landing work motivated by #890, on top of #959, #968, #1012 (via #1039), #960, #969, #1041, and #1058, rebased onto main after #1058 merged. It does not close #890.

## Verification

The following checks passed on final head `2e42131bf`:

- `go build ./...`
- `go test -count=1 ./...` (zero failures)
- `go test -race -count=1 ./internal/contextview ./internal/agent/runtime/native`
- `golangci-lint run` over `internal/models`, `internal/contextview`, `internal/agent/runtime/native`, `internal/agent/context/fragment`, `internal/agent/tool`, `internal/agent/application`
- `git diff --check`; merge-base equals the upstream main head `773dfa564`, 15 commits, zero merge commits, each commit verified green independently (build plus the six touched packages)
- Every work item was reviewed by an independent reviewer given only the diff and requirements, fixed, and re-reviewed until no Critical or Important findings remained

## Landing stack

| PR | Scope |
| --- | --- |
| PR1 (merged #959) | Fragments-first authoritative compiler with byte-equivalent provider output |
| PR2 (merged #968) | System-section retention, drop policy, grouped rendering, and capability gating |
| PR3 (merged #1012 via #1039) | Unified `ContextBudgetPlan` and budget-aware behavior for all modes |
| PR4 (merged #1041) | Hook authority split and provider-attempt preflight |
| PR5 (merged #960) | Runtime decision correctness and fencing for #865 |
| PR6 (merged #969) | Run-keyed lifecycle persistence and read ownership |
| PR7 (merged #1058) | Prompt shrink, baselines, and golden equivalence gates |
| PR7.1 (this PR) | Generation envelope authority: one estimator, one output allowance, one final check |
| PR8 | Cross-stack lifecycle, budget, fallback, and tool-roster integration seams |

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
