### PR TITLE
feat(web): sidebar 滚动条 hover 渐入渐隐(reka ScrollArea)

### DIFF
--- a/apps/web/src/components/sidebar/panel-schedule.vue
+++ b/apps/web/src/components/sidebar/panel-schedule.vue
@@ -16,10 +16,11 @@
       <Spinner class="size-3" />
     </div>
 
-    <!-- Grouped list -->
-    <div
+    <!-- Grouped list (scroller = @felinic/ui ScrollArea, see sidebar-scroll.css) -->
+    <ScrollArea
       v-else
-      class="flex-1 min-h-0 overflow-y-auto sidebar-scroll"
+      class="sidebar-scroll flex-1 min-h-0"
+      :scroll-hide-delay="300"
     >
       <!-- Empty -->
       <div
@@ -84,7 +85,7 @@
           </div>
         </div>
       </template>
-    </div>
+    </ScrollArea>
 
     <!-- Delete confirmation -->
     <ConfirmDeleteDialog
@@ -107,7 +108,7 @@ import { storeToRefs } from 'pinia'
 import { Plus } from 'lucide-vue-next'
 import { ConfirmDeleteDialog, toast } from '@felinic/ui'
 import {
-  Button, Spinner,
+  Button, ScrollArea, Spinner,
 } from '@felinic/ui'
 import { getBotsByBotIdSchedule, deleteBotsByBotIdScheduleById, putBotsByBotIdScheduleById } from '@memohai/sdk'
 import type { ScheduleSchedule } from '@memohai/sdk'
@@ -117,9 +118,10 @@ import { resolveApiErrorMessage } from '@/utils/api-error'
 import { describeCron, nextRuns } from '@/utils/cron-pattern'
 import ScheduleItem from './schedule-item.vue'
 import SidebarPanelHeader from './panel-header.vue'
-// The narrow native scrollbar this template's `sidebar-scroll` class relies on.
-// Without this import the class was silently inert (it used to be defined only
-// inside recents.vue's scoped style, which never reaches this component).
+// The shared sidebar scroll treatment (fade, thumb ink, skeleton tuning) lives
+// in this stylesheet — NOT a scoped style, because it is used by both
+// panel-sessions.vue and this component (scoped selectors only match the
+// defining component's DOM).
 import '@/styles/sidebar-scroll.css'
 
 const { t, locale } = useI18n()

--- a/apps/web/src/components/sidebar/panel-sessions.vue
+++ b/apps/web/src/components/sidebar/panel-sessions.vue
@@ -78,25 +78,28 @@
          inner scrollbar; now overflow is handled once, for the whole list, so
          a folder is a peer of Recents rather than an item inside a box.
          Per-folder growth is bounded by its Show more page instead
-         (folder-sessions-list.vue). pr-1 keeps the scrollbar clear of the
-         rows' hover chips — the sections themselves keep their px-2. -->
-    <div
-      ref="listScrollEl"
-      class="sidebar-scroll min-h-0 flex-1 overflow-y-auto pr-1"
+         (folder-sessions-list.vue). The scroller is @felinic/ui's ScrollArea
+         (reka): its self-drawn bar fades in/out on hover — native scrollbar
+         pseudos can't transition, so a native bar could only snap. -->
+    <ScrollArea
+      ref="scrollAreaRef"
+      class="sidebar-scroll min-h-0 flex-1"
+      :scroll-hide-delay="300"
     >
       <FoldersSection />
 
       <Recents :scroll-el="listScrollEl" />
-    </div>
+    </ScrollArea>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { SquarePen, Settings2 } from 'lucide-vue-next'
+import { ScrollArea } from '@felinic/ui'
 import { useChatStore } from '@/store/chat-list'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import SidebarPanelHeader from './panel-header.vue'
@@ -107,9 +110,17 @@ import '@/styles/sidebar-scroll.css'
 
 const { t } = useI18n()
 
-// The one scrollport for Folders + Recents. Recents needs the element itself
-// for its load-more sentinel root, so it is passed down rather than provided.
+// The one scrollport for Folders + Recents. Recents needs the scrolling
+// element itself for its load-more sentinel root, so it is passed down rather
+// than provided. With ScrollArea the scroller is the inner viewport node, not
+// the component root — grab it by its data-slot (the library's stable marker).
+// Assigned in onMounted: Recents reads it reactively through toRef(props).
+const scrollAreaRef = ref<InstanceType<typeof ScrollArea> | null>(null)
 const listScrollEl = ref<HTMLElement | null>(null)
+onMounted(() => {
+  const rootEl = (scrollAreaRef.value as unknown as { $el?: HTMLElement } | null)?.$el
+  listScrollEl.value = rootEl?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]') ?? null
+})
 const router = useRouter()
 const chatStore = useChatStore()
 const workspaceTabs = useWorkspaceTabsStore()

--- a/apps/web/src/styles/sidebar-scroll.css
+++ b/apps/web/src/styles/sidebar-scroll.css
@@ -1,36 +1,52 @@
-/* Sidebar-specific native scroll bar: narrow so it doesn't dominate the tight
- * list panes. The 2px transparent border + padding-box clip insets the thumb
- * to a ~4px sliver — visible on hover/scroll but not a constant presence.
- * Callers keep extra right padding (e.g. panel-sessions' pr-1) so hover chips
- * stay off the bar.
+/* Sidebar scroll treatment, on top of @felinic/ui's ScrollArea (reka-ui).
  *
- * Deliberately a shared stylesheet, NOT a `<style scoped>` block: the class is
- * used by BOTH sidebar/panel-sessions.vue and sidebar/panel-schedule.vue. It
- * first lived in recents' scoped style, which silently did nothing for
- * panel-schedule (scoped selectors only match the defining component's DOM).
- * Import this file from every component that puts `sidebar-scroll` on a
- * scroll container.
+ * The visible bar is reka's self-drawn scrollbar, NOT the native one — the
+ * viewport's native bar is hidden by the component's own injected style
+ * (scrollbar-width:none + ::-webkit-scrollbar{display:none}). We went
+ * self-drawn for one reason: the fade. Native scrollbar pseudos don't
+ * participate in CSS transitions and `scrollbar-color` is not animatable, so
+ * a native bar can only appear instantly; reka's thumb is a real element, and
+ * its data-state flips (visible/hidden) drive keyframe fades. Presence keeps
+ * the node mounted until the exit animation ends.
  *
- * overflow-anchor is OFF here on purpose. Chat panes keep the browser default
- * so history prepend stays visually pinned; sidebar lists grow downward from
- * a short first paint (load-more append), and anchoring would walk scrollTop
- * down with that growth — Recents opening mid-list. */
-.sidebar-scroll {
+ * Ink levels reuse the exact percentages the ui-contract alpha baseline
+ * already knows (10% container-hover, 16% thumb-hover) — do not invent new
+ * ones without burning down the baseline first.
+ *
+ * overflow-anchor is OFF on the viewport on purpose. Chat panes keep the
+ * browser default so history prepend stays visually pinned; sidebar lists
+ * grow downward from a short first paint (load-more append), and anchoring
+ * would walk scrollTop down with that growth — Recents opening mid-list. */
+.sidebar-scroll [data-slot="scroll-area-viewport"] {
   overflow-anchor: none;
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in oklab, var(--foreground) 18%, transparent) transparent;
+  /* Keeps the rows' hover chips clear of the 8px overlay bar (the bar is
+   * absolutely positioned over the viewport's right edge). */
+  padding-right: 0.25rem;
 }
-.sidebar-scroll::-webkit-scrollbar {
-  width: 8px;
+
+.sidebar-scroll [data-slot="scroll-area-scrollbar"][data-state="visible"] {
+  animation: sidebar-scroll-in 0.1s ease-out both;
 }
-.sidebar-scroll::-webkit-scrollbar-track {
-  background: transparent;
+.sidebar-scroll [data-slot="scroll-area-scrollbar"][data-state="hidden"] {
+  animation: sidebar-scroll-out 0.16s ease-in both;
 }
-.sidebar-scroll::-webkit-scrollbar-thumb {
-  background-color: color-mix(in oklab, var(--foreground) 18%, transparent);
-  background-clip: padding-box;
-  border: 2px solid transparent;
-  border-radius: 9999px;
+@keyframes sidebar-scroll-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes sidebar-scroll-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+/* Quieter than the library default (muted-foreground/35): the sidebar is a
+ * tight, dark-adjacent surface where 35% read as a smudge. Specificity must
+ * beat the wrapper's tailwind classes (bg-muted-foreground/35 + hover:/55). */
+.sidebar-scroll [data-slot="scroll-area-thumb"] {
+  background-color: color-mix(in oklab, var(--foreground) 10%, transparent);
+}
+.sidebar-scroll [data-slot="scroll-area-thumb"]:hover {
+  background-color: color-mix(in oklab, var(--foreground) 16%, transparent);
 }
 
 /* Session title skeletons are short (~40–70% of ~240px). The global tile is 640px


### PR DESCRIPTION
## 背景

生产(app.memoh.net)sidebar 列表的滚动条常显,用户期望 hover 才显示、且带渐入渐隐。排查发现:7 月的 hover 版改动(f123e0c96)曾搁浅在被 #1005 取代的废弃分支上从未合入;且原生方案存在平台天花板 —— `::-webkit-scrollbar` 伪元素不参与 transition、`scrollbar-color` 规范上不可动画,自定义原生滚动条**只能瞬切,做不出 fade**。

## 方案

两个 sidebar 滚动容器(panel-sessions / panel-schedule)从原生 div + 自定义 webkit 样式,换成 **@felinic/ui 的 `ScrollArea`**(reka-ui):

- 自绘 thumb 是真实元素,`data-state` 翻转驱动 keyframe 渐入渐隐(**入 0.1s / 出 0.16s**),reka Presence 等渐隐播完再卸载节点;
- hover 移出后 **300ms** 开始渐隐(`scrollHideDelay` 600→300);
- thumb 墨色复用 ui-contract alpha baseline 的 **10% / 16%** 档,零新增违规;
- viewport 保留 `overflow-anchor: none` + 4px 右 padding,行内 hover chips 不被压;
- Recents 无限滚动哨兵接线迁移:`onMounted` 按 `data-slot` 取 viewport 元素下传,时序由 `toRef(props)` 响应式兜住;
- 自绘条**全平台行为一致**(Windows/Linux 同样有 fade),不依赖 macOS overlay 特性。

## 依赖

零新增。`reka-ui` 是 @felinic/ui 的既有地基依赖(151 文件、40+ 组件族);`ScrollArea` 产品内已有 5 处使用,本 PR 是第 6、7 处。ui submodule 零改动。

## 验证

- UI contract guard 绿(alpha baseline 零新增);
- typecheck 报错均为预存基线(`#/lib/utils`、bot_id 等),本 PR 零新增;
- 行为冒烟(浏览器驱动实测):hover 淡入连拍、移出渐隐抓到 opacity 0.75 中间态、渐隐后节点卸载;thumb 命中 10% foreground token;
- 净 diff:3 文件,+73/-44。

## Test plan

- [x] 人工 QA:hover 淡入 / 移出渐隐机制确认可用(2026-08-24,0.2s 参数版)
- [ ] 复看 0.1s 淡入 / 300ms 隐藏延迟的最终手感
- [ ] Schedule 面板同样生效
- [ ] 长列表 load-more 哨兵分页正常
- [ ] 深色模式下 thumb 墨色观感