### PR TITLE
fix(web): 首次打开 websocket 启动失败改为无限退避恢复

### DIFF
--- a/apps/web/src/pages/home/index.vue
+++ b/apps/web/src/pages/home/index.vue
@@ -115,7 +115,7 @@ async function syncStoreFromUrl(rawName: string) {
   const urlName = rawName.trim()
   if (!urlName) {
     if (!currentBotId.value) {
-      await chatStore.initialize()
+      await chatStore.initializeWithRecovery()
     }
     await maybeStartACPSession()
     return

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -34,6 +34,7 @@ import {
 import { fetchSessions } from '@/composables/api/useChat'
 import {
   bindBotIdInitializeWatch,
+  createInitializeRecovery,
   createSessionListSnapshot,
 } from './chat/session-list-init-recovery'
 
@@ -251,7 +252,7 @@ export const useChatStore = defineStore('chat', () => {
   const {
     startWebSocket,
     stopWebSocket,
-    ensureWebSocketConnected,
+    ensureWebSocket,
     sendWebSocketMessage,
     startSessionRuntime,
     stopSessionRuntime,
@@ -491,6 +492,11 @@ export const useChatStore = defineStore('chat', () => {
   bindBotIdInitializeWatch({
     currentBotId, initialize, resetUserScopedState,
   })
+  // First-open recovery for the no-bot-selected entry (bare home route); the
+  // watch above only fires once a bot id exists.
+  const { initializeWithRecovery } = createInitializeRecovery({
+    currentBotId, initialize,
+  })
 
   const stopAuthSessionListener = onAuthSessionCleared(() => {
     resetUserScopedState({ clearSelection: true })
@@ -554,7 +560,7 @@ export const useChatStore = defineStore('chat', () => {
         seq: ++userSendSeq,
       }
     },
-    ensureWebSocketConnected,
+    ensureWebSocket,
     trackAssistantStream,
     sendWebSocketMessage,
     createdSessionIdForInvocation,
@@ -596,7 +602,7 @@ export const useChatStore = defineStore('chat', () => {
     startupSendFailure, startupSendFailureFor,
     commandEvent, commandEventForScope, rememberCommandEvent, showCommandError,
     fsChangedAt, markFsChanged, affectsPath, fsEventForPath,
-    initialize, refreshBots, selectBot, selectSession, createNewSession,
+    initialize, initializeWithRecovery, refreshBots, selectBot, selectSession, createNewSession,
     selectDraft, userSentInSession, draftViewRequested, applyDraftViewRequest,
     forkedSessionRequested, guiToolUseRequested, deletedSession,
     stageACPSession, stageDefaultACPSession, cacheDefaultACPSession,

--- a/apps/web/src/store/chat/bots.test.ts
+++ b/apps/web/src/store/chat/bots.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createChatBots } from './bots'
+import { fetchBots } from '@/composables/api/useChat'
+import type { Bot } from '@/composables/api/useChat'
+
+vi.mock('@/composables/api/useChat', () => ({
+  fetchBots: vi.fn(),
+}))
+
+const fetchBotsMock = vi.mocked(fetchBots)
+
+function bot(id: string): Bot {
+  return { id, status: 'ready' } as Bot
+}
+
+function makeBots(initialBotId: string | null = null) {
+  const currentBotId = ref<string | null>(initialBotId)
+  let generation = 0
+  const store = createChatBots({
+    currentBotId,
+    userScopeGeneration: () => generation,
+  })
+  return {
+    currentBotId,
+    bumpGeneration: () => { generation += 1 },
+    ...store,
+  }
+}
+
+describe('chat bots ensureBot', () => {
+  afterEach(() => {
+    fetchBotsMock.mockReset()
+  })
+
+  it('rethrows live fetch failures so bootstrap recovery can retry (#1070)', async () => {
+    fetchBotsMock.mockRejectedValue(new Error('server booting'))
+    const { ensureBot, currentBotId } = makeBots('bot-1')
+
+    await expect(ensureBot()).rejects.toThrow('server booting')
+    // A failed fetch must not rewrite the current selection either.
+    expect(currentBotId.value).toBe('bot-1')
+  })
+
+  it('returns null quietly when the user scope changed mid-flight', async () => {
+    let rejectFetch!: (error: Error) => void
+    fetchBotsMock.mockImplementation(() => new Promise<Bot[]>((_, reject) => {
+      rejectFetch = reject
+    }))
+    const { ensureBot, bumpGeneration } = makeBots('bot-1')
+
+    const pending = ensureBot()
+    bumpGeneration()
+    rejectFetch(new Error('down'))
+
+    await expect(pending).resolves.toBeNull()
+  })
+
+  it('keeps the current bot when it is still present and ready', async () => {
+    fetchBotsMock.mockResolvedValue([bot('bot-1'), bot('bot-2')])
+    const { ensureBot, currentBotId } = makeBots('bot-2')
+
+    await expect(ensureBot()).resolves.toBe('bot-2')
+    expect(currentBotId.value).toBe('bot-2')
+  })
+
+  it('returns null for a genuinely empty bot list', async () => {
+    fetchBotsMock.mockResolvedValue([])
+    const { ensureBot, currentBotId } = makeBots('bot-1')
+
+    await expect(ensureBot()).resolves.toBeNull()
+    expect(currentBotId.value).toBeNull()
+  })
+})

--- a/apps/web/src/store/chat/bots.ts
+++ b/apps/web/src/store/chat/bots.ts
@@ -26,9 +26,13 @@ export function createChatBots(deps: {
       deps.currentBotId.value = (ready?.id ?? list[0]?.id ?? '').trim() || null
       return deps.currentBotId.value
     } catch (error) {
+      // Stale run (user scope changed mid-flight): resolve quietly. A live
+      // failure must surface so bootstrap recovery retries it — swallowing it
+      // here used to read as "account has no bots", letting initialize()
+      // complete "successfully" with no WebSocket and no recovery (#1070).
       if (generation !== deps.userScopeGeneration()) return null
       console.error('Failed to fetch bots:', error)
-      return deps.currentBotId.value
+      throw error
     }
   }
 

--- a/apps/web/src/store/chat/commands.ts
+++ b/apps/web/src/store/chat/commands.ts
@@ -107,7 +107,9 @@ export function createChatCommands(deps: ChatCommandDeps) {
     const command = deps.beginDraftCommand(target)
     try {
       const targetBotId = target.botId === '__unbound__' ? '' : target.botId
-      const botId = targetBotId || await deps.ensureBot()
+      // ensureBot now rethrows fetch failures (so bootstrap recovery can retry
+      // them); this interactive path keeps its original "not ready" reply.
+      const botId = targetBotId || await deps.ensureBot().catch(() => null)
       if (!botId) return { kind: 'error', message: 'Bot not ready' }
       const defaults = await deps.defaultACPSettingsForAgent(botId, agentId)
       if (

--- a/apps/web/src/store/chat/decisions.test.ts
+++ b/apps/web/src/store/chat/decisions.test.ts
@@ -51,7 +51,7 @@ function setup(
     },
     transcriptForTarget: () => transcript,
     currentRun: () => currentRun,
-    ensureConnected: () => options.connected ?? true,
+    ensureWebSocket: () => options.connected ?? true,
     send: (_botId, message) => {
       if (options.sendError) throw options.sendError
       sent.push(message)

--- a/apps/web/src/store/chat/decisions.ts
+++ b/apps/web/src/store/chat/decisions.ts
@@ -34,7 +34,9 @@ export interface ChatDecisionDeps {
   normalizeTarget: (target?: ChatViewTarget) => ChatViewTarget
   transcriptForTarget: (target?: ChatViewTarget) => Transcript
   currentRun: (sessionId: string) => RuntimeCurrentRunView | null
-  ensureConnected: (botId: string) => boolean
+  // True when a socket handle exists for the bot; messages queue until open,
+  // so this is not limited to fully-connected sockets.
+  ensureWebSocket: (botId: string) => boolean
   send: (botId: string, message: WSClientMessage) => boolean
   createControlId: () => string
   connectionLostMessage: () => string
@@ -164,7 +166,7 @@ export function createChatDecisions(deps: ChatDecisionDeps) {
     const run = deps.currentRun(sessionId)
     if (!botId || !sessionId || !decisionId || !run) return false
     if (approval.status !== 'pending' || approval.can_approve === false) return false
-    if (!deps.ensureConnected(botId)) {
+    if (!deps.ensureWebSocket(botId)) {
       deps.showError(deps.connectionLostMessage())
       return false
     }
@@ -221,7 +223,7 @@ export function createChatDecisions(deps: ChatDecisionDeps) {
     const run = deps.currentRun(sessionId)
     if (!botId || !sessionId || !decisionId || !run) return
     if (userInput.status !== 'pending' || userInput.can_respond === false) return
-    if (!deps.ensureConnected(botId)) {
+    if (!deps.ensureWebSocket(botId)) {
       deps.showError(deps.connectionLostMessage())
       return
     }

--- a/apps/web/src/store/chat/realtime.test.ts
+++ b/apps/web/src/store/chat/realtime.test.ts
@@ -47,7 +47,7 @@ function createSocket(connected = true): ChatWebSocket & {
   }
 }
 
-function makeController() {
+function makeController(options: { socketConnected?: boolean } = {}) {
   const sockets: Array<{
     botId: string
     handler: (event: UIStreamEvent) => void
@@ -65,7 +65,7 @@ function makeController() {
   }
   const transport: ChatRealtimeTransport = {
     connectWebSocket: vi.fn((botId, handler) => {
-      const socket = createSocket()
+      const socket = createSocket(options.socketConnected ?? true)
       sockets.push({ botId, handler, socket })
       return socket
     }),
@@ -136,6 +136,21 @@ describe('chat realtime controller', () => {
     expect(controller.sendWebSocketMessage('bot-2', message)).toBe(true)
     expect(sockets[0]!.socket.close).toHaveBeenCalledOnce()
     expect(sockets[1]!.socket.send).toHaveBeenCalledWith(message)
+  })
+
+  it('queues sends through a still-connecting socket instead of refusing them (#1070)', () => {
+    const { controller, sockets } = makeController({ socketConnected: false })
+    const message: WSClientMessage = {
+      type: 'message',
+      invocation_id: 'invocation-1',
+      text: 'hello',
+    }
+
+    // The socket exists but has not finished its first-open handshake; the ws
+    // layer queues the payload and flushes it on open, so the send must pass
+    // through rather than fail with "WebSocket is not connected".
+    expect(controller.sendWebSocketMessage('bot-1', message)).toBe(true)
+    expect(sockets[0]!.socket.send).toHaveBeenCalledWith(message)
   })
 
   it('aborts only a connected websocket for the matching bot', () => {

--- a/apps/web/src/store/chat/realtime.ts
+++ b/apps/web/src/store/chat/realtime.ts
@@ -131,15 +131,20 @@ export function createChatRealtimeController(
     }
   }
 
-  function ensureWebSocketConnected(botId: string): boolean {
+  // A live socket handle is enough, even mid-handshake or between reconnect
+  // attempts: the ws layer queues messages and flushes them on open, so a send
+  // only fails when no socket exists for the bot at all. Failing fast while
+  // the first-open handshake was still in flight used to sacrifice the user's
+  // first message with "WebSocket is not connected" (#1070).
+  function ensureWebSocket(botId: string): boolean {
     const bid = botId.trim()
     if (!bid) return false
     if (!activeWebSocket || activeWebSocketBotId !== bid) startWebSocket(bid)
-    return activeWebSocket?.connected === true
+    return activeWebSocket !== null
   }
 
   function sendWebSocketMessage(botId: string, message: WSClientMessage): boolean {
-    if (!ensureWebSocketConnected(botId)) return false
+    if (!ensureWebSocket(botId)) return false
     activeWebSocket!.send(message)
     return true
   }
@@ -258,7 +263,7 @@ export function createChatRealtimeController(
   return {
     startWebSocket,
     stopWebSocket,
-    ensureWebSocketConnected,
+    ensureWebSocket,
     sendWebSocketMessage,
     abortWebSocketRun,
     startSessionRuntime,

--- a/apps/web/src/store/chat/runtime-layer.ts
+++ b/apps/web/src/store/chat/runtime-layer.ts
@@ -50,7 +50,7 @@ export function createChatRuntimeLayer(deps: ChatRuntimeLayerDeps) {
     transcriptForTarget: deps.transcriptForTarget,
     currentRun: sessionId =>
       realtime.runtimeProjection(sessionId)?.currentRunView ?? null,
-    ensureConnected: realtime.ensureWebSocketConnected,
+    ensureWebSocket: realtime.ensureWebSocket,
     send: realtime.sendWebSocketMessage,
     createControlId: deps.createControlId,
     connectionLostMessage: deps.connectionLostMessage,

--- a/apps/web/src/store/chat/send.ts
+++ b/apps/web/src/store/chat/send.ts
@@ -114,7 +114,9 @@ export interface ChatSendDeps {
   ) => Promise<ChatViewTarget>
   startSessionRuntime: (botId: string, sessionId: string) => void
   recordUserSent: (target: ChatViewTarget, sessionId: string, wasDraft: boolean) => void
-  ensureWebSocketConnected: (botId: string) => boolean
+  // True when a socket handle exists for the bot; the ws layer queues until
+  // open, so sends are not refused during the first-open handshake.
+  ensureWebSocket: (botId: string) => boolean
   trackAssistantStream: (input: TrackStreamInput) => Promise<void>
   sendWebSocketMessage: (botId: string, message: WSClientMessage) => boolean
   createdSessionIdForInvocation: (invocationId: string) => string
@@ -306,7 +308,7 @@ export function createChatSend(deps: ChatSendDeps) {
         transcript.appendToView(userTurn, assistantTurn)
       }
 
-      if (!deps.ensureWebSocketConnected(botId)) {
+      if (!deps.ensureWebSocket(botId)) {
         throw new StreamFailureError('WebSocket is not connected', 'startup')
       }
       const completion = deps.trackAssistantStream({
@@ -468,7 +470,7 @@ export function createChatSend(deps: ChatSendDeps) {
     )
     const replacedTurns = transcript.replaceTailFromTurn(target, [assistantTurn])
     try {
-      if (!deps.ensureWebSocketConnected(botId)) {
+      if (!deps.ensureWebSocket(botId)) {
         throw new StreamFailureError('WebSocket is not connected', 'startup')
       }
       const completion = deps.trackAssistantStream({
@@ -555,7 +557,7 @@ export function createChatSend(deps: ChatSendDeps) {
     )
     const replacedTurns = transcript.replaceTailFromTurn(target, [userTurn, assistantTurn])
     try {
-      if (!deps.ensureWebSocketConnected(botId)) {
+      if (!deps.ensureWebSocket(botId)) {
         throw new StreamFailureError('WebSocket is not connected', 'startup')
       }
       const completion = deps.trackAssistantStream({

--- a/apps/web/src/store/chat/session-list-init-recovery.test.ts
+++ b/apps/web/src/store/chat/session-list-init-recovery.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { toast } from '@felinic/ui'
+import { createInitializeRecovery } from './session-list-init-recovery'
+
+vi.mock('@felinic/ui', () => ({
+  toast: { error: vi.fn() },
+}))
+vi.mock('@/i18n', () => ({
+  default: { global: { t: (key: string) => key } },
+}))
+
+const toastError = vi.mocked(toast.error)
+
+describe('chat initialize recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    toastError.mockClear()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('retries with backoff until initialize succeeds, toasting once (#1070)', async () => {
+    const currentBotId = ref<string | null>('bot-1')
+    const initialize = vi.fn()
+      .mockRejectedValueOnce(new Error('down'))
+      .mockRejectedValueOnce(new Error('down'))
+      .mockRejectedValueOnce(new Error('down'))
+      .mockResolvedValueOnce(undefined)
+    const { initializeWithRecovery } = createInitializeRecovery({ currentBotId, initialize })
+
+    const done = initializeWithRecovery()
+    // First attempt runs synchronously before any backoff sleep.
+    expect(initialize).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(initialize).toHaveBeenCalledTimes(2)
+    expect(toastError).toHaveBeenCalledTimes(1)
+
+    // Third failure must not re-toast; backoff keeps doubling (2s, then 4s).
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(initialize).toHaveBeenCalledTimes(3)
+    expect(toastError).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(4000)
+    await expect(done).resolves.toBeUndefined()
+    expect(initialize).toHaveBeenCalledTimes(4)
+    expect(toastError).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying when the bot scope changes mid-outage', async () => {
+    const currentBotId = ref<string | null>('bot-1')
+    const initialize = vi.fn().mockRejectedValue(new Error('down'))
+    const { initializeWithRecovery } = createInitializeRecovery({ currentBotId, initialize })
+
+    const done = initializeWithRecovery()
+    expect(initialize).toHaveBeenCalledTimes(1)
+
+    // A bot switch (or sign-out) owns its own initialize; the old loop exits.
+    currentBotId.value = 'bot-2'
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    await expect(done).resolves.toBeUndefined()
+    expect(initialize).toHaveBeenCalledTimes(1)
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('hands recovery off once a bot gets selected (first-open, no bot id)', async () => {
+    const currentBotId = ref<string | null>(null)
+    const initialize = vi.fn().mockRejectedValue(new Error('down'))
+    const { initializeWithRecovery } = createInitializeRecovery({ currentBotId, initialize })
+
+    const done = initializeWithRecovery()
+    expect(initialize).toHaveBeenCalledTimes(1)
+
+    // ensureBot inside a later attempt would set the id; simulate the watcher
+    // taking over by setting it here — the ''-scoped loop must stop.
+    currentBotId.value = 'bot-1'
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    await expect(done).resolves.toBeUndefined()
+    expect(initialize).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves immediately when initialize succeeds first try', async () => {
+    const currentBotId = ref<string | null>('bot-1')
+    const initialize = vi.fn().mockResolvedValue(undefined)
+    const { initializeWithRecovery } = createInitializeRecovery({ currentBotId, initialize })
+
+    await expect(initializeWithRecovery()).resolves.toBeUndefined()
+    expect(initialize).toHaveBeenCalledTimes(1)
+    expect(toastError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/store/chat/session-list-init-recovery.ts
+++ b/apps/web/src/store/chat/session-list-init-recovery.ts
@@ -29,34 +29,65 @@ export function bindBotIdInitializeWatch(deps: {
   }, { immediate: true })
 }
 
+// Entry for the first-open path where no bot is selected yet (bare home
+// route). Captures the current bot id (possibly '') so a later bot selection
+// cleanly hands recovery off to the watcher's own retry loop instead of
+// running a second one.
+export function createInitializeRecovery(deps: {
+  currentBotId: Ref<string | null>
+  initialize: () => Promise<void>
+}) {
+  return {
+    initializeWithRecovery: () =>
+      initializeWithRetry(deps, (deps.currentBotId.value ?? '').trim()),
+  }
+}
+
+const INITIALIZE_RETRY_INITIAL_DELAY_MS = 1000
+const INITIALIZE_RETRY_MAX_DELAY_MS = 30000
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
 // Recovery must rerun the FULL bootstrap, not hand-patch the sessions list:
 // initialize() stops the WebSocket / activity streams before its first request
 // and restarts them (plus session selection and the session runtime) only on
 // the success path — a list-only retry would look recovered while realtime
-// stays dead. The bootstrap's reentrancy guard resets before its promise
-// rejects, so the second call below is a clean, idempotent rerun.
+// stays dead. First-open failures are usually transient (server still booting
+// behind an already-serving proxy, a brief network blip), so retry with
+// exponential backoff until the bootstrap succeeds. Giving up after a single
+// retry used to leave the page with no WebSocket and no automatic recovery
+// until a manual refresh (#1070).
 async function initializeWithRetry(
   deps: { currentBotId: Ref<string | null>; initialize: () => Promise<void> },
   botId: string,
 ) {
-  if (!botId) return
-  try {
-    await deps.initialize()
-    return
-  } catch (error) {
-    console.error('Chat initialize failed; retrying once:', error)
-  }
-  // A bot switch during the failed run owns its own initialize — never retry
-  // for a bot the user has already left.
-  if ((deps.currentBotId.value ?? '').trim() !== botId) return
-  try {
-    await deps.initialize()
-  } catch (retryError) {
+  let delay = INITIALIZE_RETRY_INITIAL_DELAY_MS
+  let failures = 0
+  for (;;) {
+    // A scope change (bot switch, sign-out) owns its own initialize — never
+    // keep retrying for a scope the user has already left.
     if ((deps.currentBotId.value ?? '').trim() !== botId) return
-    console.error('Chat initialize retry failed:', retryError)
-    toast.error(resolveApiErrorMessage(
-      retryError,
-      i18n.global.t('chat.sessionsLoadFailed'),
-    ))
+    try {
+      await deps.initialize()
+      return
+    } catch (error) {
+      if ((deps.currentBotId.value ?? '').trim() !== botId) return
+      failures += 1
+      if (failures === 1) {
+        console.error('Chat initialize failed; retrying with backoff:', error)
+      }
+      // Surface the outage once (on the second consecutive failure, matching
+      // the previous single-retry UX) and keep retrying silently afterwards.
+      if (failures === 2) {
+        toast.error(resolveApiErrorMessage(
+          error,
+          i18n.global.t('chat.sessionsLoadFailed'),
+        ))
+      }
+      await sleep(delay)
+      delay = Math.min(delay * 2, INITIALIZE_RETRY_MAX_DELAY_MS)
+    }
   }
 }


### PR DESCRIPTION
## 问题

#1070：首次打开有概率连不上 websocket，且连接失败后不会自动重试。

## 根因（代码反查）

ws 封装层（`useChat.ws.ts`）本身有无限退避重连，没问题。缺口在它"包外"：

1. **bootstrap 恢复层只重试 1 次**（`session-list-init-recovery.ts`）。首次打开时 initialize 要先跑完 fetchBots/fetchSessions 等 REST 才创建 WebSocket（`bootstrap.ts:173`）；REST 一旦瞬时失败（典型：compose 刚 `up`，nginx 已服务而 server 还在启动），两次尝试间隔 <1s 全部落空后，**WebSocket 从未被创建**，重连机制无从谈起，页面死到手动刷新。
2. **`ensureBot` 吞错**：fetchBots 失败被吞成 `null`，被当成"账户没有 bot"假成功，连那一次重试都不触发。
3. **发送在握手窗口 fail-fast**：首次打开 CONNECTING 的几百毫秒内发第一条消息必报 "WebSocket is not connected"（ws 层明明有队列）。

## 改动

- **启动恢复无限退避**：`initializeWithRetry` 重试 1 次 → 退避循环（1s×2 封顶 30s），守卫 = 切 bot / 登出即停；第 2 次失败弹一次 toast（保留原 UX）后静默。新增 `createInitializeRecovery` 覆盖无 botId 的首次打开入口（home 路由直调）。
- **`ensureBot` 失败上抛**：让恢复循环接住；`/new` 斜杠命令用 `.catch` 保留原 "Bot not ready" 回复。
- **发送/审批握手窗口改排队**：`ensureWebSocketConnected` → `ensureWebSocket`，socket 句柄存在即放行，由 ws 层队列等 open 补发。审批 / ask_user 回复同样受益。

## 界限（什么没变）

- ws 层重连/队列、runtime 重订阅、SSE、Go 服务端、终端面板均未触碰
- socket 已连接的主路径（发送/重试/编辑/审批/abort）行为逐字不变
- 真零 bot 账户的空状态页不变

## 已知边界（QA 实证发现）

- **发送排队的 UI 可达性比设计窄**：断连期间 composer 发送按钮会被一道预存的、本 PR 未触碰的门禁用（`composerConfigPending`，chat-pane.vue，ACP 配置未就绪即禁用），键盘 Enter 同挡。排队实际 reachable 的窗口是"配置已就绪但 socket 未 OPEN"的瞬间（bot 切换/重连）+ retry/edit/审批路径。
- **排队期间 abort 的幽灵 run 边**：消息已排队、run 未 accept 时用户 abort，`trackAbort` 需要 runId 覆盖不到该窗口，本地流拆了但消息恢复后仍会发出（reliable-replay 预存同款边，本 PR 把窗口略拓宽）。留 follow-up。

## 测试

- 新增 9 个单测：恢复循环×4（退避至成功/换 bot 停/无 botId 交接/一次成功）、ensureBot×4、CONNECTING 排队×1
- 相关 5 个测试文件 36/36 绿；store+home 全量 536/536 绿（基于 origin/main）
- ESLint 零告警；desktop renderer typecheck 通过

## QA 结果（2026-08-25，人类确认）

- [x] 正常路径回归：聊天/界面无 break（人类确认 + 基线浏览复核）
- [x] 停 server → 首次打开：恰好一次 toast，页面降级不崩（浏览器实证）
- [x] 启 server：页面**无需刷新自己恢复**，会话/历史自动回填（两轮实证）
- [-] 断连期间发消息：该场景被 `composerConfigPending` 门挡住，UI 不可达（见"已知边界"）；排队行为由单测锁定
- [-] 断连期间切 bot / 登出守卫：单测锁定，未做端到端

## 遗留（另行 follow-up，不在本 PR）

- chat-only 权限成员 WS 升级 403 → 无限静默重试（服务端 `canOpenLocalWebSocket` 要求 WorkspaceExec || Manage）
- 终端面板 WS 无自动重连
- 重连复用首次的 token URL；nginx `proxy_read_timeout 300s` 每 5 分钟杀空闲连接
- 排队期间 abort 的幽灵 run（见"已知边界"）

Fixes #1070