### PR TITLE
chore(deps): upgrade Connect-It to v0.3.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Default host ports are shifted away from the production compose stack: Web `1808
 ### Connect-It
 
 The dev Compose files pull the pinned multi-architecture image
-`ghcr.io/memohai/connect-it:0.2.0`; no Connect-It source checkout is required.
+`ghcr.io/memohai/connect-it:0.3.0`; no Connect-It source checkout is required.
 The image serves the API, MCP endpoint, and admin UI from one container.
 Connect-It uses the same `memoh` PostgreSQL database as Memoh, with
 its independently migrated tables isolated in the `connect_it` schema. The

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -92,7 +92,7 @@ services:
   # Connect-It owns the connect_it schema and creates it on startup; it only
   # needs postgres, never Memoh's migrations.
   connect-it:
-    image: "${MEMOH_DEV_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.2.0}"
+    image: "${MEMOH_DEV_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.3.0}"
     container_name: memoh-dev-connect-it
     environment:
       DATABASE_URL: "postgres://memoh:memoh123@postgres:5432/memoh?sslmode=disable&search_path=connect_it"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
   # Connect-It at startup and presented by the Memoh server as its bearer
   # token — the install script generates and persists all of these values.
   connect-it:
-    image: "${MEMOH_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.2.0}"
+    image: "${MEMOH_CONNECT_IT_IMAGE:-ghcr.io/memohai/connect-it:0.3.0}"
     container_name: memoh-connect-it
     profiles: [connectors]
     environment:

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/line/line-bot-sdk-go/v8 v8.20.1
 	github.com/mailgun/mailgun-go/v5 v5.14.0
 	github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7
-	github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6
+	github.com/memohai/connect-it/sdk/go v0.1.1-0.20260823104951-478f43caffb2
 	github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978
 	github.com/memohai/twilight-ai v0.5.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,8 @@ github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRC
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7 h1:beehwOQperqGWj4m4EhcPhnSZKtDiuHK/7ZMoTPaQjw=
 github.com/memohai/acgo v0.0.0-20260221232113-babac0d6acd7/go.mod h1:OvmxM7JmnXBmwJWWVqtreL3HSHSKuzPbtbhlg5MvBg0=
-github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6 h1:izUUiax2VaFHdOynSuDGpqVcTuzbO9azDiuR+OW90co=
-github.com/memohai/connect-it/sdk/go v0.1.1-0.20260801041115-19a755fb92f6/go.mod h1:8n7yDCRRNju4+wB8JrKOd29xwbKq9luyihK4eBONBVY=
+github.com/memohai/connect-it/sdk/go v0.1.1-0.20260823104951-478f43caffb2 h1:0VxBDk0lJbkwKpg4+TH40cC8gytKntuHN8BGtHZoje4=
+github.com/memohai/connect-it/sdk/go v0.1.1-0.20260823104951-478f43caffb2/go.mod h1:0XfT9WNZF/cKDaJYoQrXzRRkvMn2f77gBRscF9U3YvY=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978 h1:6gD8DvZkimGmU0e3PjlusJPyw55SyeoE12CZQoYUa8g=
 github.com/memohai/dingtalk-stream-sdk-go v0.0.0-20260405113102-87e23096b978/go.mod h1:2LMgK5QYFlTSvrGY+sI/j+jK2WK+YGHv4IMuiW+iPSc=
 github.com/memohai/twilight-ai v0.5.0 h1:zkQkmUhasQooHP8/6aZM/+Ogv5a12zlCFfxQ4XJ+uRU=


### PR DESCRIPTION
## Summary

- pin the production and development Compose stacks to `ghcr.io/memohai/connect-it:0.3.0`
- update the Connect-It Go SDK to the `v0.3.0` release commit
- keep the contributor documentation aligned with the development image

## Validation

- `go mod verify`
- `go test ./internal/connectors ./internal/handlers`
- `docker compose -f docker-compose.yml config --no-interpolate --quiet`
- `docker compose -f devenv/docker-compose.yml config --no-interpolate --quiet`

Release: https://github.com/memohai/connect-it/releases/tag/v0.3.0

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
