### PR TITLE
fix(agent): 在 runtime 投影中呈现 channel 触发的用户消息 (#1044)

### DIFF
--- a/internal/agent/application/turn_admission.go
+++ b/internal/agent/application/turn_admission.go
@@ -16,6 +16,7 @@ import (
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	tools "github.com/memohai/memoh/internal/agent/tool"
 	"github.com/memohai/memoh/internal/agent/turn"
+	chatview "github.com/memohai/memoh/internal/agent/view"
 	"github.com/memohai/memoh/internal/apperror"
 	"github.com/memohai/memoh/internal/runtimefence"
 )
@@ -85,11 +86,16 @@ func (s *Service) admitTurnRun(
 		InvocationID: invocationID,
 		Payload:      payload,
 		Execution: sessionruntime.Execution{
-			// The subscriber-facing view stays empty until thread subscriptions
-			// replace per-run event forwarding: a channel turn's only reader is
-			// the adapter consuming this handle's events.
-			Admission: func(context.Context, sessionruntime.RunHandle) (sessionruntime.RunAdmissionView, error) {
-				return sessionruntime.RunAdmissionView{}, nil
+			// Project the inbound user message so subscribers (an open web
+			// session on the thread) see what fired the run while it still
+			// executes — the same contract the ws and schedule admissions
+			// already honor. NewRequestUserTurn returns nil for commands that
+			// persist no user message (discuss-shaped, attachment-only), and
+			// those runs stay contentless in the projection.
+			Admission: func(_ context.Context, handle sessionruntime.RunHandle) (sessionruntime.RunAdmissionView, error) {
+				return sessionruntime.RunAdmissionView{
+					RequestUserTurn: chatview.NewRequestUserTurn(cmd, handle.TurnID),
+				}, nil
 			},
 			Cancel: cancel,
 			// Nil for discuss, which has no reader for steering messages.

--- a/internal/agent/application/turn_admission_integration_test.go
+++ b/internal/agent/application/turn_admission_integration_test.go
@@ -1,0 +1,168 @@
+package application
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	"github.com/memohai/memoh/internal/agent/runtime/session/ledger"
+	"github.com/memohai/memoh/internal/agent/turn"
+	dbpkg "github.com/memohai/memoh/internal/db"
+	"github.com/memohai/memoh/internal/db/dbtest"
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
+	"github.com/memohai/memoh/internal/runtimefence"
+)
+
+// This integration test pins the #1044 chain end to end at the backend: a
+// channel-shaped StartTurnCommand admitted through admitTurnRun must surface
+// its user message in the runtime snapshot a subscriber receives — the same
+// snapshot the web frontend renders the live bubble from. It uses the real
+// Manager and the real PostgreSQL ledger, so a break anywhere between wiring,
+// activation, and snapshot delivery fails here rather than in production.
+
+var (
+	turnAdmissionMigrationOnce sync.Once
+	turnAdmissionMigrationErr  error
+)
+
+func TestAdmitTurnRunRequestUserTurnReachesSubscriber(t *testing.T) {
+	ctx := context.Background()
+	pool := openTurnAdmissionPostgres(t, ctx)
+	botID, sessionID := createTurnAdmissionFixture(t, ctx, pool)
+
+	manager := sessionruntime.NewManager(sessionruntime.NewMemoryBackend(), sessionruntime.Options{
+		OwnerID:       "owner-turn-admission-test",
+		StateTTL:      time.Minute,
+		OwnerLeaseTTL: time.Second,
+		Ledger:        ledger.NewPostgres(dbsqlc.New(pool), pool),
+		// The durable ledger refuses admission without the fence that orders
+		// its writes; wire the same pair the composition root wires.
+		Fence: runtimefence.NewActivator(postgresstore.NewQueriesWithPool(pool, dbsqlc.New(pool))),
+	})
+	t.Cleanup(func() { _ = manager.Close() })
+
+	svc := &Service{logger: slog.New(slog.DiscardHandler), sessionRuntime: manager}
+	cmd := turn.StartTurnCommand{
+		TeamID:                  "team-1",
+		Mode:                    turn.ModeChat,
+		BotID:                   botID,
+		ThreadID:                sessionID,
+		Query:                   "hello from telegram",
+		ExternalMessageID:       "ext-1",
+		CurrentChannel:          "telegram",
+		DisplayName:             "Alice",
+		SourceChannelIdentityID: "ci-1",
+	}
+	admission, err := svc.admitTurnRun(ctx, cmd, func() {}, nil, nil)
+	if err != nil {
+		t.Fatalf("admitTurnRun() error = %v", err)
+	}
+	t.Cleanup(func() {
+		// Close the run's record so the fixture leaves no active row behind;
+		// the fixture rows themselves cascade away with the bot.
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), 10*time.Second)
+		defer cancel()
+		_ = manager.FinishRun(ctx, admission.Handle, sessionruntime.RunStatusCompleted, "")
+	})
+
+	sub, err := manager.Subscribe(ctx, botID, sessionID)
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	t.Cleanup(sub.Close)
+
+	select {
+	case event := <-sub.C:
+		if event.Type != sessionruntime.EventRuntimeSnapshot {
+			t.Fatalf("first event = %q, want %q", event.Type, sessionruntime.EventRuntimeSnapshot)
+		}
+		if event.Snapshot == nil || event.Snapshot.CurrentRunView == nil {
+			t.Fatal("snapshot has no current run, want the admitted run")
+		}
+		request := event.Snapshot.CurrentRunView.RequestUserTurn
+		if request == nil {
+			t.Fatal("snapshot request_user_turn is nil — the #1044 regression shape")
+		}
+		if request.Text != "hello from telegram" {
+			t.Fatalf("request_user_turn text = %q, want the channel message", request.Text)
+		}
+		if request.TurnID != admission.TurnID {
+			t.Fatalf("request_user_turn turn id = %q, want the admitted turn %q", request.TurnID, admission.TurnID)
+		}
+		if request.Platform != "telegram" || request.SenderDisplayName != "Alice" {
+			t.Fatalf("platform/sender = (%q, %q), want telegram/Alice", request.Platform, request.SenderDisplayName)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the subscription baseline snapshot")
+	}
+}
+
+func openTurnAdmissionPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	dsn := strings.TrimSpace(os.Getenv("TEST_POSTGRES_DSN"))
+	if dsn == "" {
+		t.Skip("set TEST_POSTGRES_DSN to run the turn admission PostgreSQL integration")
+	}
+	pool, err := dbpkg.OpenPostgresDSN(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open PostgreSQL pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if os.Getenv("TEST_POSTGRES_BOOTSTRAP_SCHEMA") == "1" {
+		turnAdmissionMigrationOnce.Do(func() {
+			turnAdmissionMigrationErr = dbtest.MigratePostgresUp(dsn)
+		})
+		if turnAdmissionMigrationErr != nil {
+			t.Fatalf("migrate PostgreSQL test database: %v", turnAdmissionMigrationErr)
+		}
+	}
+	return pool
+}
+
+// createTurnAdmissionFixture mirrors the ledger integration fixtures: random
+// identities relying on the default team, cleaned up by deleting the bot
+// (session_runs and bot_sessions cascade) and the user.
+func createTurnAdmissionFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (string, string) {
+	t.Helper()
+	userID := uuid.New()
+	botID := uuid.New()
+	sessionID := uuid.New()
+	name := "turn-admission-" + uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		WITH created_user AS (
+			INSERT INTO users (id, username, is_active)
+			VALUES ($1, $2, true)
+			RETURNING id
+		)
+		INSERT INTO team_members (user_id, role)
+		SELECT id, 'admin' FROM created_user
+	`, userID, name); err != nil {
+		t.Fatalf("create user fixture: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO bots (id, owner_user_id, name) VALUES ($1, $2, $3)
+	`, botID, userID, name); err != nil {
+		t.Fatalf("create bot fixture: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO bot_sessions (id, bot_id, channel_type, runtime_type)
+		VALUES ($1, $2, 'telegram', 'model')
+	`, sessionID, botID); err != nil {
+		t.Fatalf("create session fixture: %v", err)
+	}
+	cleanupCtx := context.WithoutCancel(ctx)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(cleanupCtx, "DELETE FROM bots WHERE id = $1", botID)
+		_, _ = pool.Exec(cleanupCtx, "DELETE FROM users WHERE id = $1", userID)
+	})
+	return botID.String(), sessionID.String()
+}

--- a/internal/agent/application/turn_admission_test.go
+++ b/internal/agent/application/turn_admission_test.go
@@ -1,0 +1,110 @@
+package application
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
+	"github.com/memohai/memoh/internal/agent/turn"
+)
+
+// fakeTurnAdmitter captures the Admit input so tests can drive the admission
+// hook exactly the way the runtime manager would at activation. Mirrors
+// fakeTriggeredAdmitter in service_trigger_test.go.
+type fakeTurnAdmitter struct {
+	admitInput sessionruntime.AdmitInput
+}
+
+func (f *fakeTurnAdmitter) Admit(_ context.Context, input sessionruntime.AdmitInput) (sessionruntime.Admission, error) {
+	f.admitInput = input
+	return sessionruntime.Admission{
+		Started:      true,
+		RunID:        "run-1",
+		TurnID:       "turn-1",
+		TurnPosition: 1,
+		Handle: sessionruntime.RunHandle{
+			BotID:        input.BotID,
+			SessionID:    input.SessionID,
+			RunID:        "run-1",
+			TurnID:       "turn-1",
+			FencingToken: 1,
+		},
+	}, nil
+}
+
+func (*fakeTurnAdmitter) FinishRun(context.Context, sessionruntime.RunHandle, string, string) error {
+	return nil
+}
+
+func TestAdmitTurnRunProjectsRequestUserTurn(t *testing.T) {
+	t.Parallel()
+
+	admitter := &fakeTurnAdmitter{}
+	svc := &Service{logger: slog.New(slog.DiscardHandler), sessionRuntime: admitter}
+
+	cmd := turn.StartTurnCommand{
+		TeamID:                  "team-1",
+		Mode:                    turn.ModeChat,
+		BotID:                   "bot-1",
+		ThreadID:                "thread-1",
+		Query:                   "hello from telegram",
+		ExternalMessageID:       "ext-1",
+		CurrentChannel:          "telegram",
+		DisplayName:             "Alice",
+		SourceChannelIdentityID: "ci-1",
+	}
+	admission, err := svc.admitTurnRun(context.Background(), cmd, func() {}, nil, nil)
+	if err != nil {
+		t.Fatalf("admitTurnRun() error = %v", err)
+	}
+	if admitter.admitInput.Execution.Admission == nil {
+		t.Fatal("runtime admission hook is nil")
+	}
+	view, err := admitter.admitInput.Execution.Admission(context.Background(), admission.Handle)
+	if err != nil {
+		t.Fatalf("admission hook error = %v", err)
+	}
+	request := view.RequestUserTurn
+	if request == nil {
+		t.Fatal("request user turn is nil, want the inbound message projection")
+	}
+	if request.Text != "hello from telegram" {
+		t.Fatalf("request user turn text = %q, want the inbound text", request.Text)
+	}
+	if request.TurnID != admission.TurnID {
+		t.Fatalf("request user turn turn id = %q, want the admitted turn %q", request.TurnID, admission.TurnID)
+	}
+	if request.Platform != "telegram" || request.SenderDisplayName != "Alice" || request.SenderUserID != "ci-1" {
+		t.Fatalf("platform/sender = (%q, %q, %q), want telegram/Alice/ci-1",
+			request.Platform, request.SenderDisplayName, request.SenderUserID)
+	}
+}
+
+func TestAdmitTurnRunDiscussShapeStaysContentless(t *testing.T) {
+	t.Parallel()
+
+	admitter := &fakeTurnAdmitter{}
+	svc := &Service{logger: slog.New(slog.DiscardHandler), sessionRuntime: admitter}
+
+	// Discuss-shaped commands carry composed context and persist no user
+	// message, so the projection must stay empty — otherwise a bubble would
+	// render during the run and vanish at the database handover.
+	cmd := turn.StartTurnCommand{
+		TeamID:   "team-1",
+		Mode:     turn.ModeDiscuss,
+		BotID:    "bot-1",
+		ThreadID: "thread-1",
+	}
+	admission, err := svc.admitTurnRun(context.Background(), cmd, func() {}, nil, nil)
+	if err != nil {
+		t.Fatalf("admitTurnRun() error = %v", err)
+	}
+	view, err := admitter.admitInput.Execution.Admission(context.Background(), admission.Handle)
+	if err != nil {
+		t.Fatalf("admission hook error = %v", err)
+	}
+	if view.RequestUserTurn != nil {
+		t.Fatalf("request user turn = %#v, want nil for a discuss-shaped command", view.RequestUserTurn)
+	}
+}

--- a/internal/agent/view/uimessage_request_turn.go
+++ b/internal/agent/view/uimessage_request_turn.go
@@ -1,0 +1,125 @@
+package view
+
+import (
+	"strings"
+	"time"
+
+	"github.com/memohai/memoh/internal/agent/turn"
+	attachmentpkg "github.com/memohai/memoh/internal/attachment"
+)
+
+// UIAttachmentsFromTurnAttachments converts turn attachments into the
+// normalized UI shape for live runtime projections. Runtime state carries
+// media references, not the uploaded bytes: Base64 is deliberately not
+// copied, which would duplicate every attachment into the live backend.
+func UIAttachmentsFromTurnAttachments(botID string, attachments []turn.Attachment) []UIAttachment {
+	uiAttachments := make([]UIAttachment, 0, len(attachments))
+	for _, attachment := range attachments {
+		contentHash := strings.TrimSpace(attachment.ContentHash)
+		uiAttachments = append(uiAttachments, UIAttachment{
+			ID:          contentHash,
+			Type:        normalizeUIAttachmentType(attachment.Type, attachment.Mime),
+			Path:        strings.TrimSpace(attachment.Path),
+			URL:         strings.TrimSpace(attachment.URL),
+			Name:        strings.TrimSpace(attachment.Name),
+			ContentHash: contentHash,
+			BotID:       strings.TrimSpace(botID),
+			Mime:        strings.TrimSpace(attachment.Mime),
+			Size:        attachment.Size,
+			StorageKey:  attachmentpkg.MetadataString(attachment.Metadata, attachmentpkg.MetadataKeyStorageKey),
+		})
+	}
+	return uiAttachments
+}
+
+// NewRequestUserTurn builds the subscriber-facing projection of the user
+// message that fired a run, so subscribers watching a thread see the
+// triggering message while the run is still executing — not only after the
+// step committer lands it in history.
+//
+// Two invariants keep the live bubble seamless with the settled one:
+//
+//  1. The result is nil exactly when the turn will not persist a user
+//     message (mirrors prependTurnUserMessage in internal/agent/application):
+//     an attachment-only or discuss-shaped command produces no history turn,
+//     so projecting one would make a bubble vanish at the database handover.
+//  2. The text is the same display text the persistence layer stores
+//     (mirrors the displayText switch in service_store.go): UserVisibleText
+//     when present, else the envelope-unwrapped Query. Anything else would
+//     visibly change the bubble's content when the runtime projection hands
+//     over to the database at run end.
+//
+// Reply, forward, sender, and platform fields come straight from the command,
+// which is also the source buildInteractionMetadata persists from.
+func NewRequestUserTurn(cmd turn.StartTurnCommand, turnID string) *UITurn {
+	if strings.TrimSpace(cmd.Query) == "" && strings.TrimSpace(cmd.UserMessageKind) != turn.UserMessageKindSkillActivation {
+		return nil
+	}
+	platform := strings.ToLower(strings.TrimSpace(cmd.CurrentChannel))
+	if platform == "local" {
+		// Mirrors resolveUIPersistencePlatform: local turns render without a
+		// platform badge, and sender fields only ride along with a platform.
+		platform = ""
+	}
+	request := &UITurn{
+		TurnID:            turnID,
+		Role:              "user",
+		Text:              requestUserTurnText(cmd),
+		UserMessageKind:   strings.TrimSpace(cmd.UserMessageKind),
+		SkillActivation:   cmd.SkillActivation,
+		Attachments:       UIAttachmentsFromTurnAttachments(cmd.BotID, cmd.Attachments),
+		Reply:             uiReplyFromCommand(cmd),
+		Forward:           uiForwardFromCommand(cmd),
+		Timestamp:         time.Now().UTC(),
+		Platform:          platform,
+		ExternalMessageID: strings.TrimSpace(cmd.ExternalMessageID),
+	}
+	if platform != "" {
+		request.SenderDisplayName = strings.TrimSpace(cmd.DisplayName)
+		request.SenderUserID = strings.TrimSpace(cmd.SourceChannelIdentityID)
+	}
+	return request
+}
+
+// requestUserTurnText mirrors the displayText selection the persistence layer
+// applies to the turn-leading user message (service_store.go): the visible
+// text wins when present, otherwise the query with any transport envelope
+// stripped. cmd.Query is not yet envelope-wrapped at admission time, but the
+// unwrap keeps the two equal even if a caller ever admits a wrapped query.
+func requestUserTurnText(cmd turn.StartTurnCommand) string {
+	if trimmed := strings.TrimSpace(cmd.UserVisibleText); trimmed != "" ||
+		strings.TrimSpace(cmd.UserMessageKind) == turn.UserMessageKindSkillActivation {
+		return trimmed
+	}
+	return strings.TrimSpace(turn.UnwrapUserMessageEnvelope(cmd.Query))
+}
+
+// uiReplyFromCommand mirrors uiReplyFromMessage: the same fields the
+// persistence layer writes into the reply metadata, in the same UI shape.
+func uiReplyFromCommand(cmd turn.StartTurnCommand) *UIReplyRef {
+	reply := UIReplyRef{
+		MessageID:   strings.TrimSpace(cmd.SourceReplyToMessageID),
+		Sender:      strings.TrimSpace(cmd.ReplySender),
+		Preview:     truncateUIReplyPreview(cmd.ReplyPreview),
+		Attachments: UIAttachmentsFromTurnAttachments(cmd.BotID, cmd.ReplyAttachments),
+	}
+	if reply.MessageID == "" && reply.Sender == "" && reply.Preview == "" && len(reply.Attachments) == 0 {
+		return nil
+	}
+	return &reply
+}
+
+// uiForwardFromCommand mirrors uiForwardFromMessage for the live projection.
+func uiForwardFromCommand(cmd turn.StartTurnCommand) *UIForwardRef {
+	forward := UIForwardRef{
+		MessageID:          strings.TrimSpace(cmd.ForwardMessageID),
+		FromUserID:         strings.TrimSpace(cmd.ForwardFromUserID),
+		FromConversationID: strings.TrimSpace(cmd.ForwardFromConversationID),
+		Sender:             strings.TrimSpace(cmd.ForwardSender),
+		Date:               cmd.ForwardDate,
+	}
+	if forward.MessageID == "" && forward.FromUserID == "" && forward.FromConversationID == "" && forward.Sender == "" && forward.Date == 0 {
+		return nil
+	}
+	return &forward
+}

--- a/internal/agent/view/uimessage_request_turn_test.go
+++ b/internal/agent/view/uimessage_request_turn_test.go
@@ -1,0 +1,235 @@
+package view
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/memohai/memoh/internal/agent/turn"
+)
+
+func TestNewRequestUserTurnNilWithoutPersistedUserMessage(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]turn.StartTurnCommand{
+		// Discuss-shaped commands carry composed context, not a user message.
+		"empty command": {},
+		// An attachment-only message persists no user turn
+		// (prependTurnUserMessage), so nothing may project either.
+		"attachment only": {
+			Attachments: []turn.Attachment{{Type: "image", ContentHash: "hash-1"}},
+		},
+		// Whitespace is not a message.
+		"blank query": {Query: "  \n "},
+	}
+	for name, cmd := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := NewRequestUserTurn(cmd, "turn-1"); got != nil {
+				t.Fatalf("NewRequestUserTurn() = %#v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestNewRequestUserTurnTextMessage(t *testing.T) {
+	t.Parallel()
+
+	got := NewRequestUserTurn(turn.StartTurnCommand{
+		BotID:                   "bot-1",
+		Query:                   "  hello bot  ",
+		ExternalMessageID:       "ext-1",
+		CurrentChannel:          "Telegram",
+		DisplayName:             "  Alice  ",
+		SourceChannelIdentityID: "ci-1",
+	}, "turn-1")
+	if got == nil {
+		t.Fatal("NewRequestUserTurn() = nil, want a projection")
+	}
+	if got.TurnID != "turn-1" || got.Role != "user" {
+		t.Fatalf("identity = (%q, %q), want (turn-1, user)", got.TurnID, got.Role)
+	}
+	if got.Text != "hello bot" {
+		t.Fatalf("Text = %q, want the trimmed query", got.Text)
+	}
+	if got.Platform != "telegram" {
+		t.Fatalf("Platform = %q, want lowercased telegram", got.Platform)
+	}
+	if got.SenderDisplayName != "Alice" || got.SenderUserID != "ci-1" {
+		t.Fatalf("sender = (%q, %q), want (Alice, ci-1)", got.SenderDisplayName, got.SenderUserID)
+	}
+	if got.ExternalMessageID != "ext-1" {
+		t.Fatalf("ExternalMessageID = %q, want ext-1", got.ExternalMessageID)
+	}
+	if got.Timestamp.IsZero() {
+		t.Fatal("Timestamp is zero, want admission time")
+	}
+}
+
+func TestNewRequestUserTurnDisplayTextMirrorsPersistence(t *testing.T) {
+	t.Parallel()
+
+	// The projected text must equal the display text the persistence layer
+	// stores (service_store.go), or the bubble visibly changes at handover.
+	wrapped := turn.FormatUserHeaderFromMeta(turn.UserMessageMeta{DisplayName: "Alice"}, "real text")
+	cases := map[string]struct {
+		cmd  turn.StartTurnCommand
+		want string
+	}{
+		"visible text wins": {
+			cmd:  turn.StartTurnCommand{Query: "model facing", UserVisibleText: "user facing"},
+			want: "user facing",
+		},
+		"envelope unwrapped": {
+			cmd:  turn.StartTurnCommand{Query: wrapped},
+			want: "real text",
+		},
+		"skill activation keeps visible text": {
+			cmd: turn.StartTurnCommand{
+				Query:           "summarize this",
+				UserVisibleText: "summarize this",
+				UserMessageKind: turn.UserMessageKindSkillActivation,
+			},
+			want: "summarize this",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := NewRequestUserTurn(tc.cmd, "turn-1")
+			if got == nil {
+				t.Fatal("NewRequestUserTurn() = nil, want a projection")
+			}
+			if got.Text != tc.want {
+				t.Fatalf("Text = %q, want %q", got.Text, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewRequestUserTurnBareSkillActivation(t *testing.T) {
+	t.Parallel()
+
+	got := NewRequestUserTurn(turn.StartTurnCommand{
+		UserMessageKind: turn.UserMessageKindSkillActivation,
+		SkillActivation: &turn.SkillActivation{Prompt: "run it"},
+	}, "turn-1")
+	if got == nil {
+		t.Fatal("NewRequestUserTurn() = nil, want a projection for a bare activation")
+	}
+	if got.Text != "" {
+		t.Fatalf("Text = %q, want empty for a bare activation", got.Text)
+	}
+	if got.SkillActivation == nil || got.SkillActivation.Prompt != "run it" {
+		t.Fatalf("SkillActivation = %#v, want the carried activation", got.SkillActivation)
+	}
+	if got.UserMessageKind != turn.UserMessageKindSkillActivation {
+		t.Fatalf("UserMessageKind = %q, want %q", got.UserMessageKind, turn.UserMessageKindSkillActivation)
+	}
+}
+
+func TestNewRequestUserTurnLocalPlatformHasNoSender(t *testing.T) {
+	t.Parallel()
+
+	got := NewRequestUserTurn(turn.StartTurnCommand{
+		Query:          "hi",
+		CurrentChannel: "local",
+		DisplayName:    "Alice",
+	}, "turn-1")
+	if got == nil {
+		t.Fatal("NewRequestUserTurn() = nil, want a projection")
+	}
+	if got.Platform != "" {
+		t.Fatalf("Platform = %q, want empty for local", got.Platform)
+	}
+	if got.SenderDisplayName != "" || got.SenderUserID != "" {
+		t.Fatalf("sender = (%q, %q), want empty without a platform", got.SenderDisplayName, got.SenderUserID)
+	}
+}
+
+func TestNewRequestUserTurnReplyAndForward(t *testing.T) {
+	t.Parallel()
+
+	longPreview := strings.Repeat("长", uiReplyPreviewMaxRunes+10)
+	got := NewRequestUserTurn(turn.StartTurnCommand{
+		Query:                  "replying",
+		SourceReplyToMessageID: "msg-9",
+		ReplySender:            "Bob",
+		ReplyPreview:           longPreview,
+		ReplyAttachments:       []turn.Attachment{{Type: "image", ContentHash: "rh-1", Mime: "image/png"}},
+		ForwardMessageID:       "fwd-1",
+		ForwardFromUserID:      "user-2",
+		ForwardSender:          "Carol",
+		ForwardDate:            123,
+	}, "turn-1")
+	if got == nil {
+		t.Fatal("NewRequestUserTurn() = nil, want a projection")
+	}
+	if got.Reply == nil {
+		t.Fatal("Reply = nil, want the reply ref")
+	}
+	if got.Reply.MessageID != "msg-9" || got.Reply.Sender != "Bob" {
+		t.Fatalf("Reply = %#v, want msg-9 from Bob", got.Reply)
+	}
+	if len([]rune(got.Reply.Preview)) > uiReplyPreviewMaxRunes {
+		t.Fatalf("Reply.Preview = %d runes, want at most %d", len([]rune(got.Reply.Preview)), uiReplyPreviewMaxRunes)
+	}
+	if len(got.Reply.Attachments) != 1 || got.Reply.Attachments[0].ContentHash != "rh-1" {
+		t.Fatalf("Reply.Attachments = %#v, want the single reply attachment", got.Reply.Attachments)
+	}
+	if got.Forward == nil {
+		t.Fatal("Forward = nil, want the forward ref")
+	}
+	if got.Forward.MessageID != "fwd-1" || got.Forward.FromUserID != "user-2" || got.Forward.Sender != "Carol" || got.Forward.Date != 123 {
+		t.Fatalf("Forward = %#v, want the carried forward fields", got.Forward)
+	}
+}
+
+func TestUIAttachmentsFromTurnAttachments(t *testing.T) {
+	t.Parallel()
+
+	got := UIAttachmentsFromTurnAttachments("bot-1", []turn.Attachment{
+		{
+			Type:        "",
+			Mime:        "image/png",
+			ContentHash: "hash-1",
+			Name:        "photo.png",
+			Size:        42,
+			Base64:      "AAAA",
+			Metadata:    map[string]any{"storage_key": "key-1"},
+		},
+		{Type: "FILE", ContentHash: "hash-2"},
+	})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	first := got[0]
+	if first.Type != "image" {
+		t.Fatalf("Type = %q, want inferred image", first.Type)
+	}
+	if first.ID != "hash-1" || first.ContentHash != "hash-1" || first.BotID != "bot-1" {
+		t.Fatalf("identity = (%q, %q, %q), want hash-1/hash-1/bot-1", first.ID, first.ContentHash, first.BotID)
+	}
+	if first.Base64 != "" {
+		t.Fatal("Base64 copied into runtime state, want references only")
+	}
+	if first.StorageKey != "key-1" {
+		t.Fatalf("StorageKey = %q, want key-1 from metadata", first.StorageKey)
+	}
+	if got[1].Type != "file" {
+		t.Fatalf("second Type = %q, want lowercased file", got[1].Type)
+	}
+}
+
+func TestNewRequestUserTurnTimestampRecent(t *testing.T) {
+	t.Parallel()
+
+	before := time.Now().UTC()
+	got := NewRequestUserTurn(turn.StartTurnCommand{Query: "hi"}, "turn-1")
+	if got == nil {
+		t.Fatal("NewRequestUserTurn() = nil, want a projection")
+	}
+	if got.Timestamp.Before(before) || time.Since(got.Timestamp) > time.Minute {
+		t.Fatalf("Timestamp = %v, want admission time", got.Timestamp)
+	}
+}

--- a/internal/handlers/runtime_ws.go
+++ b/internal/handlers/runtime_ws.go
@@ -11,7 +11,6 @@ import (
 	sessionruntime "github.com/memohai/memoh/internal/agent/runtime/session"
 	"github.com/memohai/memoh/internal/agent/turn"
 	chatview "github.com/memohai/memoh/internal/agent/view"
-	attachmentpkg "github.com/memohai/memoh/internal/attachment"
 )
 
 // Each half is reached by asserting the one injected session runtime, and a
@@ -119,7 +118,7 @@ func (a *wsMessageAdmission) build(ctx context.Context, handle sessionruntime.Ru
 	}
 	request := a.request
 	request.TurnID = handle.TurnID
-	request.Attachments = wsRuntimeUIAttachments(a.botID, a.attachments)
+	request.Attachments = chatview.UIAttachmentsFromTurnAttachments(a.botID, a.attachments)
 	return sessionruntime.RunAdmissionView{RequestUserTurn: &request}, nil
 }
 
@@ -159,7 +158,7 @@ func (a *wsReplacementAdmission) build(ctx context.Context, handle sessionruntim
 		}
 		replacement := *a.replacementUserTurn
 		replacement.TurnID = handle.TurnID
-		replacement.Attachments = wsRuntimeUIAttachments(a.botID, a.attachments)
+		replacement.Attachments = chatview.UIAttachmentsFromTurnAttachments(a.botID, a.attachments)
 		operation.ReplacementUserTurn = &replacement
 	}
 	return sessionruntime.RunAdmissionView{Operation: operation}, nil
@@ -167,41 +166,6 @@ func (a *wsReplacementAdmission) build(ctx context.Context, handle sessionruntim
 
 func (a *wsReplacementAdmission) preparedAttachments() []turn.Attachment {
 	return a.attachments
-}
-
-func wsRuntimeUIAttachments(botID string, attachments []turn.Attachment) []chatview.UIAttachment {
-	uiAttachments := make([]chatview.UIAttachment, 0, len(attachments))
-	for _, attachment := range attachments {
-		kind := strings.ToLower(strings.TrimSpace(attachment.Type))
-		if kind == "" {
-			switch mime := strings.ToLower(strings.TrimSpace(attachment.Mime)); {
-			case strings.HasPrefix(mime, "image/"):
-				kind = "image"
-			case strings.HasPrefix(mime, "audio/"):
-				kind = "audio"
-			case strings.HasPrefix(mime, "video/"):
-				kind = "video"
-			default:
-				kind = "file"
-			}
-		}
-		contentHash := strings.TrimSpace(attachment.ContentHash)
-		// Runtime state carries media references, not the uploaded bytes. Copying
-		// Base64 here would duplicate every attachment into the live backend.
-		uiAttachments = append(uiAttachments, chatview.UIAttachment{
-			ID:          contentHash,
-			Type:        kind,
-			Path:        strings.TrimSpace(attachment.Path),
-			URL:         strings.TrimSpace(attachment.URL),
-			Name:        strings.TrimSpace(attachment.Name),
-			ContentHash: contentHash,
-			BotID:       strings.TrimSpace(botID),
-			Mime:        strings.TrimSpace(attachment.Mime),
-			Size:        attachment.Size,
-			StorageKey:  attachmentpkg.MetadataString(attachment.Metadata, attachmentpkg.MetadataKeyStorageKey),
-		})
-	}
-	return uiAttachments
 }
 
 // runtimeSubscribeAuthorizer re-checks this connection's read access to one


### PR DESCRIPTION
# 修复 #1044:channel 触发消息在运行中对 Web 订阅者不可见

## 现象

在 Telegram 群(或其他 channel)发消息触发 bot 时,Web 侧打开着这个 session 的用户**在运行过程中看不到触发本轮的那条 channel 消息**——只能看到 run 状态(如 "The bidding is over")和 bot 的流式输出,两条 bot 消息粘连;要等落库后的历史刷新(或手动刷新页面)那条消息才补上。

## 根因

runtime 投影(`RunAdmissionView.RequestUserTurn`)是 run 运行中向订阅者呈现"是什么触发了这一轮"的正式机制。三个 turn 入口里有两个早已接入,唯独 channel 入口没有:

| 入口 | Admission view | 出处 |
|---|---|---|
| Web WS 发消息 | ✅ 投影完整用户消息 | `internal/handlers/runtime_ws.go` `wsMessageAdmission.build` |
| schedule 触发 | ✅ 投影 `payload.Command` | `internal/agent/application/service_trigger.go`(#1068) |
| **channel(StartTurn)** | ❌ **硬编码空 view** | `internal/agent/application/turn_admission.go` `admitTurnRun` |

空 view 处原注释写着"等 thread subscription 取代 per-run 转发"——这个迁移在 ws 和 schedule 入口已经发生了,channel 是最后一个没迁的入口。`broadcastInboundMessage`(RouteHub 广播)走的是另一条通道,进不了前端的 turn 结构,所以运行中消息不可见。

**前端无需改动**:`request_user_turn` 的渲染路径(runtime-projection.ts)由 #1068 验证过,是既有能力。

## 修法

`admitTurnRun` 的 `Execution.Admission` 改为从 `StartTurnCommand` 构建 `chatview.NewRequestUserTurn(cmd, handle.TurnID)` 投影——与 #1068 同一机制,不同入口。

### 关键不变量(评审重点)

投影必须与 run 结束后落库的历史 turn **逐字段一致**,否则交接瞬间气泡跳变:

1. **谓词镜像 `prependTurnUserMessage`**(service_messages.go):`Query == "" && kind != skill_activation` 时不投影——discuss 形态的 command、纯附件无文字消息在落库时本来就不产生 user message,投影了反而会在交接时气泡消失。
2. **文本镜像 `service_store.go` 的 displayText 分支**:`UserVisibleText` 非空(或 skill activation kind)用它,否则 `UnwrapUserMessageEnvelope(Query)`(admission 时 Query 尚未包 envelope,unwrap 是防御性恒等)。
3. **Reply/Forward/附件/平台/发送人**与 `buildInteractionMetadata` 落库内容同源,全部取自 cmd 字段;reply preview 截断复用 `truncateUIReplyPreview`(120 runes),平台走 `local → ""` 的同一归一化。
4. **TurnID 用 admission 分配的 id**,stepCommitter 落库用同一个 id,前端按它合并,不会双气泡。

### 顺带的收编

`wsRuntimeUIAttachments`(handlers 私有)迁移为 `chatview.UIAttachmentsFromTurnAttachments`,ws 两处调用点切换;kind 推断逻辑逐字等价于既有的 `normalizeUIAttachmentType`,行为不变。

## 改动清单

- `internal/agent/view/uimessage_request_turn.go`(新):投影构造器 + 附件转换器
- `internal/agent/application/turn_admission.go`:接线(+8/-5,含注释更新)
- `internal/handlers/runtime_ws.go`:收编(-37 净)
- 测试:view 表驱动 8 组、application 接线 2 组、全链路集成测试 1 组

## 验证

- ✅ `go test -race`:view / application / handlers / arch / runtime/session 全绿
- ✅ `golangci-lint` 干净
- ✅ **全链路集成测试** `turn_admission_integration_test.go`:`TEST_POSTGRES_DSN` 门控(无 DSN 自动 skip,CI 无负担)。真 `Manager` + 真 PG ledger + 真 `Subscribe`,断言订阅者 baseline snapshot 的 `request_user_turn` 携带 channel 消息文本、TurnID、platform、sender
- ✅ **变异检查**:将 `admitTurnRun` 回退为空 view,该集成测试以 "snapshot request_user_turn is nil"(即 #1044 形态)失败;恢复后通过。证明测试确实在守这个回归

## 验证边界(未验证项,给评审与 QA)

- ❌ **未做 UI 层人工 QA**。本地开发栈没有任何 channel 配置,无法走真实 Telegram 链路。集成测试覆盖到"订阅者收到 snapshot"为止;snapshot → 前端气泡的渲染路径是 #1068 已在生产验证的既有路径,本 PR 未触碰。
- 建议 QA:Web 打开 channel session,从 Telegram 发消息触发 bot,运行中应看到该消息气泡;落库后气泡不跳变、不双份。

## 披露的相邻既有缺口(不在本 PR 范围)

**纯附件无文字的 channel 消息(如无 caption 的照片)在落库时根本不产生 user turn**,Web 历史里整条不可见——这是 `prependTurnUserMessage` 的既有行为,不是本 PR 引入或修复的。投影谓词刻意与之保持一致(此类消息同样不投影),避免 live/settled 不一致。如需修,应独立 issue 讨论落库策略。

## 给评审 AI 的独立验证指引

1. 根因核对:`git show origin/main:internal/agent/application/turn_admission.go` 看 `admitTurnRun` 的 Admission 闭包(本 PR 前为空 view);对比 `service_trigger.go` 的 viewFn(#1068)与 `runtime_ws.go` 的 `wsMessageAdmission.build`。
2. 不变量核对:对照 `service_messages.go` `prependTurnUserMessage`、`service_store.go` displayText switch、`uimessage_convert.go` `ConvertMessagesToUITurns` 的 user 分支,逐字段比对新构造器。
3. 复现集成测试:需要一个本地 PG;`TEST_POSTGRES_DSN=... TEST_POSTGRES_BOOTSTRAP_SCHEMA=1 go test ./internal/agent/application/ -run TestAdmitTurnRunRequestUserTurnReachesSubscriber -v`。
4. 变异检查复现:`git stash` 掉 `turn_admission.go` 的改动再跑上面的测试,应失败。

## Test plan

- [ ] 人工 QA:Telegram 触发 → Web 运行中可见 channel 消息气泡
- [ ] 人工 QA:落库交接无跳变、无双气泡
- [ ] 人工 QA(回归面):skill activation 触发、reply 引用块显示
- [ ] 生产验证(app.memoh.net 或同等环境)

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
