### PR TITLE
fix: provider 连接测试移除假模型二次探测,消除 Invalid API key 误报

### DIFF
--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -278,7 +278,12 @@ const (
 )
 
 // Test probes the provider using the Twilight AI SDK to check
-// reachability and authentication.
+// reachability and authentication. A successful models-list response is
+// conclusive; no follow-up generation probe is made. An earlier fake-model
+// probe was removed (#1042): some OpenAI-compatible gateways validate the
+// model before auth and answer 401 for an unknown model, which the probe
+// misclassified as "Invalid API key" even after the key had authenticated.
+// Per-model availability is covered by models.Service.Test instead.
 func (s *Service) Test(ctx context.Context, id string) (TestResponse, error) {
 	providerID, err := db.ParseUUID(id)
 	if err != nil {
@@ -325,16 +330,6 @@ func (s *Service) Test(ctx context.Context, id string) (TestResponse, error) {
 			Message:   message,
 		}, nil
 	default:
-		if _, probeErr := sdkProvider.TestModel(ctx, "__ping__"); probeErr != nil {
-			if strings.Contains(probeErr.Error(), "authentication failed") {
-				return TestResponse{
-					Status:    TestStatusAuthError,
-					Reachable: true,
-					LatencyMs: time.Since(start).Milliseconds(),
-					Message:   probeErr.Error(),
-				}, nil
-			}
-		}
 		return TestResponse{
 			Status:    TestStatusOK,
 			Reachable: true,

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -12,7 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/models"
 )
 
@@ -949,4 +952,55 @@ func TestFetchRemoteModelsViaSDK(t *testing.T) {
 			t.Fatalf("expected Name to fall back to ID when DisplayName is empty, got %q", remoteModels[0].Name)
 		}
 	})
+}
+
+// providerTestQueries stubs dbstore.Queries with the single row Test needs;
+// every other method nil-panics, which keeps this test honest about how
+// little the probe path is allowed to touch the database.
+type providerTestQueries struct {
+	dbstore.Queries
+	provider sqlc.Provider
+}
+
+func (s providerTestQueries) GetProviderByID(context.Context, pgtype.UUID) (sqlc.Provider, error) {
+	return s.provider, nil
+}
+
+// Regression for #1042: a successful models list is conclusive for
+// reachability + auth. The fake-model generation probe that used to run
+// afterwards turned into an "Invalid API key" false positive on gateways
+// that answer 401 for an unknown model. This test fails if any request
+// beyond the models list is attempted.
+func TestTestSkipsModelProbeAfterSuccessfulModelsList(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/models" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": []map[string]any{{"id": "real-model"}},
+			})
+			return
+		}
+		t.Errorf("unexpected probe request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	providerID := pgtype.UUID{Bytes: [16]byte{0x10, 0x42}, Valid: true}
+	service := &Service{queries: providerTestQueries{provider: sqlc.Provider{
+		ID:         providerID,
+		ClientType: string(models.ClientTypeOpenAICompletions),
+		Config:     []byte(`{"api_key":"sk-test","base_url":"` + server.URL + `"}`),
+	}}}
+
+	resp, err := service.Test(context.Background(), providerID.String())
+	if err != nil {
+		t.Fatalf("Test() error = %v", err)
+	}
+	if resp.Status != TestStatusOK {
+		t.Fatalf("status = %q, want %q (message: %s)", resp.Status, TestStatusOK, resp.Message)
+	}
+	if !resp.Reachable {
+		t.Fatal("reachable = false, want true")
+	}
 }


### PR DESCRIPTION
## 问题

Provider 的「Test Connection」在 key 实际有效的情况下误报 `Invalid API key`(#1042)。

根因:`internal/providers/service.go` 的 `Test` 在 `GET /models?limit=1` 已经验证「端点可达 + 鉴权通过」之后,还会拿假模型 `__ping__` 追加一次 chat completion 探测。部分 OpenAI 兼容网关对未知模型返回 **401**(响应体是模型错误,而非认证错误),该 401 被错误分类器映射为 `authentication failed`,最终报成 `auth_error`。

## 修法

删除第二阶段探测,provider Test 以 models 列表请求为唯一判据。该探测原本就只在一种情况下影响结果(把 OK 翻转为 `auth_error`),其余输出一律被丢弃——即它只会制造假阳性,从不提供正面信号。

模型可用性由模型级测试(模型列表每行的测试按钮,使用真实 model ID)覆盖,那条路径不受影响。

**有意接受的代价**:key 有 models 读取权限但无推理权限(分路径鉴权的网关)这一罕见场景,provider 测试不再识别;该场景由模型级测试承接。

另注:没有 `/models` 端点的 provider 在改动前后都会在第一步失败(现状,非本次引入),如需覆盖应做「models 缺失时才兜底 chat 探测」的条件触发,留作后续。

## 测试计划

- [x] 新增回归测试 `TestTestSkipsModelProbeAfterSuccessfulModelsList`:models 列表成功后,断言不再发出任何模型级探测请求(旧代码会触发并翻转为 auth_error)
- [x] `go test ./internal/providers/` 全绿,`go vet` / `go build` 通过
- [ ] 人工 QA:onboarding 和 providers 页对一个正常 provider 点 Test Connection 显示成功;对一个错 key 的 provider 仍报 Invalid API key

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

Fixes #1042
