### PR TITLE
feat: provider 连接测试增加「无法确认」中间态,不再对无 models 端点误判失败

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1300,6 +1300,7 @@
     "reachable": "Reachable",
     "unreachable": "Unreachable",
     "testFailed": "Test failed",
+    "testUnverifiedHint": "Connected, but the model list could not confirm availability — this provider may not support it. Test a specific model instead.",
     "autoImport": "Auto Import Models",
     "autoImportHint": "Automatically fetch and import models from the provider after creation",
     "configurationTitle": "Configuration",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1259,6 +1259,7 @@
     "reachable": "到達可能",
     "unreachable": "到達不能",
     "testFailed": "テストが失敗しました",
+    "testUnverifiedHint": "接続できましたが、モデル一覧では動作を確認できませんでした。このプロバイダーが一覧に対応していない可能性があります。個別のモデルでテストしてください。",
     "autoImport": "モデルを自動インポート",
     "autoImportHint": "作成後にプロバイダーからモデルを自動的に取得してインポートします。",
     "configurationTitle": "構成",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1300,6 +1300,7 @@
     "reachable": "可连接",
     "unreachable": "不可连接",
     "testFailed": "测试失败",
+    "testUnverifiedHint": "已连通，但无法通过模型列表确认可用——该服务商可能不支持此接口。可改为测试具体模型。",
     "autoImport": "自动导入模型",
     "autoImportHint": "创建后自动从服务商获取并导入模型",
     "configurationTitle": "配置",

--- a/apps/web/src/pages/providers/components/provider-form-test-connection.test.ts
+++ b/apps/web/src/pages/providers/components/provider-form-test-connection.test.ts
@@ -90,9 +90,9 @@ describe('provider test connection states', () => {
     document.body.innerHTML = ''
   })
 
-  async function mountAndRunTest(status: string) {
+  async function mountAndRunTest(status: string, message = 'service error (404): not found') {
     mocks.postTest.mockResolvedValue({
-      data: { status, reachable: true, latency_ms: 12, message: 'service error (404): not found' },
+      data: { status, reachable: true, latency_ms: 12, message },
     })
     const providerForm = (await import('./provider-form.vue')).default
     const root = document.createElement('div')
@@ -134,6 +134,20 @@ describe('provider test connection states', () => {
   it('does not show the unverified hint on a plain error', async () => {
     const { app, root } = await mountAndRunTest('error')
     expect(root.textContent).not.toContain('provider.testUnverifiedHint')
+    app.unmount()
+    root.remove()
+  })
+
+  // Base URL 指向网页时,上游把整个 HTML 页面塞在错误体里;页面散文
+  // (含剥了链接的死文字)不是有用的 API 错误,必须整条丢掉,只留状态头。
+  it('drops HTML page prose from the upstream error body', async () => {
+    const { app, root } = await mountAndRunTest(
+      'unverified',
+      'api error 404: 404 Not Found [body: <!doctype html><html><body><h1>Example Domain</h1><a href="https://iana.org">Learn more</a></body></html>]',
+    )
+    expect(root.textContent).toContain('api error 404')
+    expect(root.textContent).not.toContain('Learn more')
+    expect(root.textContent).not.toContain('Example Domain')
     app.unmount()
     root.remove()
   })

--- a/apps/web/src/pages/providers/components/provider-form-test-connection.test.ts
+++ b/apps/web/src/pages/providers/components/provider-form-test-connection.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+// 独立文件而非并入 provider-form.test.ts:那边的 SettingsSection mock 只渲染
+// default slot(测试按钮在 #footer 里,渲染不出来),而渲染全部 slot 会改变
+// 既有用例的按钮 DOM 顺序。这里自建一套渲染全 slot 的 mock,互不干扰。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import type { Slots } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  postTest: vi.fn(),
+}))
+
+function translate(key: string) {
+  return key
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: translate }),
+}))
+
+vi.mock('@memohai/sdk', () => ({
+  deleteProvidersByIdOauthToken: vi.fn(),
+  getProvidersByIdOauthAuthorize: vi.fn(),
+  getProvidersByIdOauthStatus: vi.fn(),
+  postProvidersByIdOauthPoll: vi.fn(),
+  postProvidersByIdTest: mocks.postTest,
+}))
+
+vi.mock('@/composables/useProviderModelCatalog', () => ({
+  useProviderModelCatalog: () => ({ syncProviderModelCatalog: vi.fn() }),
+}))
+
+vi.mock('lucide-vue-next', () => ({
+  AlertCircle: () => h('span'),
+  KeyRound: () => h('span'),
+  RefreshCw: () => h('span'),
+}))
+
+vi.mock('@/components/check-draw-icon/index.vue', () => ({ default: { template: '<span />' } }))
+vi.mock('@/components/loading-button/index.vue', () => ({ default: { template: '<div><slot /></div>' } }))
+
+vi.mock('@felinic/ui', async () => {
+  const { h } = await import('vue')
+  const Passthrough = (_props: Record<string, unknown>, { slots }: { slots: Slots }) =>
+    h('div', Object.values(slots).map(slot => slot?.()))
+  const FormField = (_props: Record<string, unknown>, { slots }: { slots: Slots }) => h('div', slots.default?.({
+    componentField: {},
+    errorMessage: '',
+  }))
+  const Button = (_props: Record<string, unknown>, { attrs, slots }: { attrs: Record<string, unknown>, slots: Slots }) => h('button', attrs, slots.default?.())
+  return {
+    AutoHeight: Passthrough,
+    Button,
+    ConfirmPopover: Passthrough,
+    DeviceCodePanel: Passthrough,
+    SettingsRow: Passthrough,
+    SettingsSection: Passthrough,
+    FormControl: Passthrough,
+    FormField,
+    FormItem: Passthrough,
+    FormMessage: Passthrough,
+    HoverCard: Passthrough,
+    HoverCardContent: Passthrough,
+    HoverCardTrigger: Passthrough,
+    Input: Passthrough,
+    LabelSwap: Passthrough,
+    Select: Passthrough,
+    SelectContent: Passthrough,
+    SelectItem: Passthrough,
+    SelectTrigger: Passthrough,
+    SelectValue: Passthrough,
+    Spinner: Passthrough,
+    toast: { success: vi.fn(), error: vi.fn() },
+  }
+})
+
+describe('provider test connection states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  async function mountAndRunTest(status: string) {
+    mocks.postTest.mockResolvedValue({
+      data: { status, reachable: true, latency_ms: 12, message: 'service error (404): not found' },
+    })
+    const providerForm = (await import('./provider-form.vue')).default
+    const root = document.createElement('div')
+    document.body.append(root)
+     
+    const app = createApp(providerForm, {
+      provider: {
+        id: 'provider-id',
+        name: 'Custom',
+        client_type: 'openai-completions',
+        enable: true,
+        config: {},
+      },
+      editLoading: false,
+      ensureProvider: vi.fn(),
+      saveProvider: vi.fn(),
+    })
+    app.config.globalProperties.$t = translate
+    app.mount(root)
+    await flushPromises()
+
+    const testButton = [...root.querySelectorAll('button')].find(b =>
+      b.textContent?.includes('provider.testConnection'),
+    ) as HTMLButtonElement
+    expect(testButton, 'test connection button should render').toBeTruthy()
+    testButton.click()
+    await flushPromises()
+    return { app, root }
+  }
+
+  // #1087: unverified 是"无法确认"而非失败,必须给指引文案,不能落进错误态。
+  it('shows the unverified hint when the provider cannot be confirmed', async () => {
+    const { app, root } = await mountAndRunTest('unverified')
+    expect(root.textContent).toContain('provider.testUnverifiedHint')
+    app.unmount()
+    root.remove()
+  })
+
+  it('does not show the unverified hint on a plain error', async () => {
+    const { app, root } = await mountAndRunTest('error')
+    expect(root.textContent).not.toContain('provider.testUnverifiedHint')
+    app.unmount()
+    root.remove()
+  })
+})

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -433,22 +433,19 @@ function truncateError(text: string): string {
 }
 
 // The probe detail can embed the raw upstream response inside `[body: …]`. When
-// a Base URL points at a website instead of an API the body is a full HTML
-// page, so strip the markup down to its visible text (often near-empty) and
-// keep only a short, actionable hint instead of dumping the document.
+// a Base URL points at a website instead of an API the body is a full HTML page;
+// its visible text is page prose ("Example Domain … Learn more"), never an
+// actionable API error — and stripping tags leaves dead, unclickable text. Drop
+// HTML bodies entirely and keep only the status head; non-HTML bodies (real
+// JSON API errors) are still shown.
 function formatTestError(raw: string | undefined): string {
   const text = (raw ?? '').trim()
   if (!text) return t('provider.unreachable')
   const bodyStart = text.indexOf('[body:')
   if (bodyStart === -1) return truncateError(text)
   const head = text.slice(0, bodyStart).trim()
-  let body = text.slice(bodyStart + '[body:'.length).replace(/\]\s*$/, '').trim()
-  if (/<!doctype|<\/?[a-z][^>]*>/i.test(body)) {
-    body = body
-      .replace(/<(script|style)[^>]*>[\s\S]*?(<\/\1>|$)/gi, ' ')
-      .replace(/<[^>]*>/g, ' ')
-  }
-  body = body.replace(/\s+/g, ' ').trim()
+  const body = text.slice(bodyStart + '[body:'.length).replace(/\]\s*$/, '').trim()
+  if (/<!doctype|<\/?[a-z][^>]*>/i.test(body)) return truncateError(head)
   return truncateError(body ? `${head} · ${body}` : head)
 }
 

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -182,14 +182,19 @@
           <HoverCardContent
             v-if="testError"
             class="w-80 text-xs whitespace-pre-wrap break-words"
-            :class="testStatus === 'unverified' ? 'text-muted-foreground' : 'text-destructive'"
+            :class="testStatus === 'unverified' ? '' : 'text-destructive'"
           >
-            <!-- unverified 不是失败:端点已连通,只是 models 列表无法证实可用,
-                 先给指引文案再附上游细节,不涂成 destructive。 -->
+            <!-- unverified 不是失败:引导文案为主信息(正文色),上游细节
+                 降为次要点色自成一行,不和文案挤在一句里。 -->
             <template v-if="testStatus === 'unverified'">
-              {{ $t('provider.testUnverifiedHint') }} ·
+              <p>{{ $t('provider.testUnverifiedHint') }}</p>
+              <p class="mt-1.5 text-muted-foreground">
+                {{ testError }}
+              </p>
             </template>
-            {{ testError }}
+            <template v-else>
+              {{ testError }}
+            </template>
           </HoverCardContent>
         </HoverCard>
 

--- a/apps/web/src/pages/providers/components/provider-form.vue
+++ b/apps/web/src/pages/providers/components/provider-form.vue
@@ -165,6 +165,10 @@
                 class="size-4 text-success"
               />
               <AlertCircle
+                v-else-if="testStatus === 'unverified'"
+                class="size-4 text-warning"
+              />
+              <AlertCircle
                 v-else-if="testStatus === 'error'"
                 class="size-4 text-destructive"
               />
@@ -177,8 +181,14 @@
           </HoverCardTrigger>
           <HoverCardContent
             v-if="testError"
-            class="w-80 text-xs text-destructive whitespace-pre-wrap break-words"
+            class="w-80 text-xs whitespace-pre-wrap break-words"
+            :class="testStatus === 'unverified' ? 'text-muted-foreground' : 'text-destructive'"
           >
+            <!-- unverified 不是失败:端点已连通,只是 models 列表无法证实可用,
+                 先给指引文案再附上游细节,不涂成 destructive。 -->
+            <template v-if="testStatus === 'unverified'">
+              {{ $t('provider.testUnverifiedHint') }} ·
+            </template>
             {{ testError }}
           </HoverCardContent>
         </HoverCard>
@@ -404,6 +414,8 @@ let oauthStatusLoadGeneration = 0
 
 const testStatus = computed(() => {
   if (testResult.value?.status === 'ok') return 'ok'
+  // unverified(#1087)必须先于 error 判断:它不是失败,是"无法确认"。
+  if (testResult.value?.status === 'unverified') return 'unverified'
   if (testError.value) return 'error'
   // Any non-ok probe result is an error state (the ok case returned above).
   if (testResult.value) return 'error'

--- a/internal/models/probe.go
+++ b/internal/models/probe.go
@@ -67,12 +67,19 @@ func (s *Service) Test(ctx context.Context, id string) (TestResponse, error) {
 			Message:   providerResult.Message,
 		}, nil
 	case sdk.ProviderStatusUnhealthy:
-		return TestResponse{
-			Status:    TestStatusAuthError,
-			Reachable: true,
-			LatencyMs: time.Since(start).Milliseconds(),
-			Message:   providerResult.Message,
-		}, nil
+		// Only an auth failure justifies an early verdict. Any other
+		// unhealthy result (e.g. 404 because the provider does not implement
+		// the models list at all) must not be reported as "Invalid API key" —
+		// fall through to the real-model generation probe, which is the only
+		// check that can give a definitive answer for such providers (#1087).
+		if strings.Contains(providerResult.Message, "authentication failed") {
+			return TestResponse{
+				Status:    TestStatusAuthError,
+				Reachable: true,
+				LatencyMs: time.Since(start).Milliseconds(),
+				Message:   providerResult.Message,
+			}, nil
+		}
 	}
 
 	modelResult, err := sdkProvider.TestModel(ctx, model.ModelID)

--- a/internal/models/probe_test.go
+++ b/internal/models/probe_test.go
@@ -1,0 +1,103 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+)
+
+// probeTestQueries stubs the two rows Test needs; every other method
+// nil-panics, keeping the probe path honest about its database footprint.
+type probeTestQueries struct {
+	dbstore.Queries
+	model    sqlc.Model
+	provider sqlc.Provider
+}
+
+func (q probeTestQueries) GetModelByID(context.Context, pgtype.UUID) (sqlc.Model, error) {
+	return q.model, nil
+}
+
+func (q probeTestQueries) GetProviderByID(context.Context, pgtype.UUID) (sqlc.Provider, error) {
+	return q.provider, nil
+}
+
+func newProbeTestService(server *httptest.Server) (*Service, pgtype.UUID) {
+	modelID := pgtype.UUID{Bytes: [16]byte{0x10, 0x87}, Valid: true}
+	providerID := pgtype.UUID{Bytes: [16]byte{0x10, 0x87, 0x02}, Valid: true}
+	return &Service{queries: probeTestQueries{
+		model: sqlc.Model{
+			ID:         modelID,
+			ProviderID: providerID,
+			ModelID:    "real-model",
+			Type:       string(ModelTypeChat),
+		},
+		provider: sqlc.Provider{
+			ID:         providerID,
+			ClientType: string(ClientTypeOpenAICompletions),
+			Config:     []byte(`{"api_key":"sk-test","base_url":"` + server.URL + `"}`),
+		},
+	}}, modelID
+}
+
+// #1087: when the provider does not implement the models list (404), the
+// model test must fall through to the real-model generation probe instead
+// of reporting "Invalid API key" — that probe is the only check able to
+// settle such providers.
+func TestTestFallsThroughToModelProbeWhenModelsListMissing(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/models", "/models/real-model":
+			w.WriteHeader(http.StatusNotFound)
+		case "/chat/completions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{{"message": map[string]string{"role": "assistant", "content": "hi"}}},
+			})
+		default:
+			t.Errorf("unexpected probe request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	service, modelID := newProbeTestService(server)
+	resp, err := service.Test(context.Background(), modelID.String())
+	if err != nil {
+		t.Fatalf("Test() error = %v", err)
+	}
+	if resp.Status != TestStatusOK {
+		t.Fatalf("status = %q, want %q (message: %s)", resp.Status, TestStatusOK, resp.Message)
+	}
+}
+
+// An auth failure on the models list is still reported as auth_error and
+// must short-circuit before any generation request is attempted.
+func TestTestModelsListAuthFailureStaysAuthError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Errorf("unexpected probe request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	service, modelID := newProbeTestService(server)
+	resp, err := service.Test(context.Background(), modelID.String())
+	if err != nil {
+		t.Fatalf("Test() error = %v", err)
+	}
+	if resp.Status != TestStatusAuthError {
+		t.Fatalf("status = %q, want %q (message: %s)", resp.Status, TestStatusAuthError, resp.Message)
+	}
+}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -284,6 +284,14 @@ const (
 // model before auth and answer 401 for an unknown model, which the probe
 // misclassified as "Invalid API key" even after the key had authenticated.
 // Per-model availability is covered by models.Service.Test instead.
+//
+// Outcome semantics (#1087) — the models list is only a partial falsifier:
+//   - reachable + 200: verified (ok);
+//   - reachable + 401/403: auth failed (auth_error) — the request carries no
+//     model parameter, so this cannot be confused with "model not found";
+//   - reachable + anything else (404/5xx): unverified, NOT a failure — the
+//     base URL may be wrong, or the provider may not implement model listing;
+//   - unreachable (DNS/TCP): error, the only hard failure kept at this layer.
 func (s *Service) Test(ctx context.Context, id string) (TestResponse, error) {
 	providerID, err := db.ParseUUID(id)
 	if err != nil {
@@ -319,12 +327,16 @@ func (s *Service) Test(ctx context.Context, id string) (TestResponse, error) {
 			Message:   message,
 		}, nil
 	case sdk.ProviderStatusUnhealthy:
-		status := TestStatusError
 		if strings.Contains(result.Message, "authentication failed") {
-			status = TestStatusAuthError
+			return TestResponse{
+				Status:    TestStatusAuthError,
+				Reachable: true,
+				LatencyMs: time.Since(start).Milliseconds(),
+				Message:   message,
+			}, nil
 		}
 		return TestResponse{
-			Status:    status,
+			Status:    TestStatusUnverified,
 			Reachable: true,
 			LatencyMs: time.Since(start).Milliseconds(),
 			Message:   message,

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -1004,3 +1004,74 @@ func TestTestSkipsModelProbeAfterSuccessfulModelsList(t *testing.T) {
 		t.Fatal("reachable = false, want true")
 	}
 }
+
+// Locks the #1087 outcome mapping: only an auth failure on the models list
+// is an auth_error; any other HTTP response is unverified (not a failure);
+// a transport-level failure stays a hard error.
+func TestTestModelsListOutcomeMapping(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		modelsStatus int
+		wantStatus   TestStatus
+	}{
+		{"auth failure stays auth_error", http.StatusUnauthorized, TestStatusAuthError},
+		{"missing models endpoint is unverified", http.StatusNotFound, TestStatusUnverified},
+		{"upstream 5xx is unverified", http.StatusInternalServerError, TestStatusUnverified},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/models" {
+					t.Errorf("unexpected probe request: %s %s", r.Method, r.URL.Path)
+				}
+				w.WriteHeader(tc.modelsStatus)
+			}))
+			defer server.Close()
+
+			providerID := pgtype.UUID{Bytes: [16]byte{0x10, 0x87}, Valid: true}
+			service := &Service{queries: providerTestQueries{provider: sqlc.Provider{
+				ID:         providerID,
+				ClientType: string(models.ClientTypeOpenAICompletions),
+				Config:     []byte(`{"api_key":"sk-test","base_url":"` + server.URL + `"}`),
+			}}}
+
+			resp, err := service.Test(context.Background(), providerID.String())
+			if err != nil {
+				t.Fatalf("Test() error = %v", err)
+			}
+			if resp.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q (message: %s)", resp.Status, tc.wantStatus, resp.Message)
+			}
+			if !resp.Reachable {
+				t.Fatal("reachable = false, want true")
+			}
+		})
+	}
+}
+
+func TestTestUnreachableStaysHardError(t *testing.T) {
+	t.Parallel()
+
+	// Port 1 is reserved and refuses connections deterministically.
+	providerID := pgtype.UUID{Bytes: [16]byte{0x10, 0x87, 0x01}, Valid: true}
+	service := &Service{queries: providerTestQueries{provider: sqlc.Provider{
+		ID:         providerID,
+		ClientType: string(models.ClientTypeOpenAICompletions),
+		Config:     []byte(`{"api_key":"sk-test","base_url":"http://127.0.0.1:1"}`),
+	}}}
+
+	resp, err := service.Test(context.Background(), providerID.String())
+	if err != nil {
+		t.Fatalf("Test() error = %v", err)
+	}
+	if resp.Status != TestStatusError {
+		t.Fatalf("status = %q, want %q", resp.Status, TestStatusError)
+	}
+	if resp.Reachable {
+		t.Fatal("reachable = true, want false")
+	}
+}

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -65,6 +65,11 @@ const (
 	TestStatusOK        TestStatus = "ok"
 	TestStatusAuthError TestStatus = "auth_error"
 	TestStatusError     TestStatus = "error"
+	// TestStatusUnverified means the endpoint answered but the models list
+	// could not confirm it works (e.g. the provider does not implement model
+	// listing). It is deliberately not a failure: only a real generation
+	// against a concrete model can settle that (see models.Service.Test).
+	TestStatusUnverified TestStatus = "unverified"
 )
 
 // TestResponse is returned by POST /providers/:id/test.

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -1151,6 +1151,7 @@ export type ContextfragContextBudgetPlan = {
     estimator_safety_factor_percent?: number;
     history_budget?: number;
     output_reserve?: number;
+    output_reserve_resolution?: string;
     system_budget?: number;
     tool_defs_cost?: number;
     window?: number;
@@ -2932,7 +2933,7 @@ export type ProvidersTestResponse = {
     status?: ProvidersTestStatus;
 };
 
-export type ProvidersTestStatus = 'ok' | 'auth_error' | 'error';
+export type ProvidersTestStatus = 'ok' | 'auth_error' | 'error' | 'unverified';
 
 export type ProvidersUpdateRequest = {
     client_type?: string;

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -18020,6 +18020,9 @@ const docTemplate = `{
                 "output_reserve": {
                     "type": "integer"
                 },
+                "output_reserve_resolution": {
+                    "type": "string"
+                },
                 "system_budget": {
                     "type": "integer"
                 },
@@ -22636,12 +22639,14 @@ const docTemplate = `{
             "enum": [
                 "ok",
                 "auth_error",
-                "error"
+                "error",
+                "unverified"
             ],
             "x-enum-varnames": [
                 "TestStatusOK",
                 "TestStatusAuthError",
-                "TestStatusError"
+                "TestStatusError",
+                "TestStatusUnverified"
             ]
         },
         "providers.UpdateRequest": {

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -18011,6 +18011,9 @@
                 "output_reserve": {
                     "type": "integer"
                 },
+                "output_reserve_resolution": {
+                    "type": "string"
+                },
                 "system_budget": {
                     "type": "integer"
                 },
@@ -22627,12 +22630,14 @@
             "enum": [
                 "ok",
                 "auth_error",
-                "error"
+                "error",
+                "unverified"
             ],
             "x-enum-varnames": [
                 "TestStatusOK",
                 "TestStatusAuthError",
-                "TestStatusError"
+                "TestStatusError",
+                "TestStatusUnverified"
             ]
         },
         "providers.UpdateRequest": {

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -1977,6 +1977,8 @@ definitions:
         type: integer
       output_reserve:
         type: integer
+      output_reserve_resolution:
+        type: string
       system_budget:
         type: integer
       tool_defs_cost:
@@ -5102,11 +5104,13 @@ definitions:
     - ok
     - auth_error
     - error
+    - unverified
     type: string
     x-enum-varnames:
     - TestStatusOK
     - TestStatusAuthError
     - TestStatusError
+    - TestStatusUnverified
   providers.UpdateRequest:
     properties:
       client_type:


### PR DESCRIPTION
## 问题

Provider Test Connection 的 `GET /models` 探测此前被当作**完整证伪器**:`/models` 返回 404/5xx 时一律判 `error`。但 404 既可能是 base URL 填错,也可能是 provider 根本没实现模型列表接口(极简网关等)——两种解释都成立,判死就意味着这类 provider 永远无法通过测试,onboarding 也被硬挡(#1087)。

## 语义:`/models` 只是部分证伪器

| 结果 | 含义 | 判定 |
|---|---|---|
| 200 | 端点可达 + key 有效 | `ok`(不变) |
| 401/403 | key 无效。该请求不带模型参数,不会与「模型不存在」混淆,是最干净的鉴权信号 | `auth_error`(不变) |
| 404/5xx 等 | base URL 错,**或** provider 未实现 models 列表 | **`unverified`(新)** |
| 连不上(DNS/TCP) | 真失败 | `error`(不变) |

「无法确认」不是失败:完整证伪只能由真实生成完成,而那条路径我们本来就有——模型级测试。

## 改动

- **`internal/providers`**:新增 `TestStatusUnverified`;非鉴权类 unhealthy 从 `error` 改为 `unverified`。
- **`internal/models` 配套修正(超出 issue 字面但为其必需)**:模型级测试此前把**任何** unhealthy(含 404)提前判成 `auth_error`——无 `/models` 的 provider 连模型测试都会误报 "Invalid API key",#1087 承诺的「保存后去测模型」出口是断的。现在仅鉴权失败才提前判 `auth_error`,其余落到真实 model ID 的生成探针(该探针自带 GET 404 → POST 兜底,天然兼容无列表接口的 provider)。
- **前端 provider-form**:unverified 显示 warning 图标,HoverCard 给引导文案(已连通但无法通过模型列表确认,可改为测试具体模型)+ 上游细节,不复用 destructive 样式。三语言(en/zh/ja)。
- **onboarding 无需改动**:unverified 不匹配既有的 `auth_error`/`error` 分支,自然流入模型导入;导入失败仍落在已有的人工添加/跳过路径。行为变化:此前被 `error` 硬挡的无 `/models` provider 现在能走到手动加模型。
- **顺带修复(评审中发现)**:测试详情里的 HTML 错误体(如 Base URL 指向普通网站)此前剥标签留可见文本,会把网页正文连同死链接文字(如 "Learn more")显示在浮层;现在 HTML 体整条丢弃只留状态头,JSON 错误体照旧。
- swagger / SDK 已重新生成(`ProvidersTestStatus` 增加 `'unverified'`)。

## 测试计划

- [x] 后端新增:`/models` 401→`auth_error`、404/5xx→`unverified`、连不上→`error` 映射全锁(providers);`/models` 404 落到真实生成探针得 `ok`、401 仍 `auth_error` 且不再发出任何生成请求(models)
- [x] 前端新增:unverified 出现引导文案、普通 error 不出现
- [x] `go test ./internal/models/ ./internal/providers/` 全绿、pre-commit(全仓 go test + staticcheck + eslint)通过
- [x] web typecheck 基线红(443 错,全部位于未触碰文件),本次改动文件零错误
- [ ] 人工 QA:providers 页对一个无 `/models` 端点的自定义 provider 点 Test Connection 显示「无法确认」样式与文案;正常 provider 与错 key 行为不变

Fixes #1087


