### PR TITLE
fix(web): move tree loading into the chevron slot to stop expand jitter

### DIFF
--- a/apps/web/src/components/file-manager/directory-picker-node.vue
+++ b/apps/web/src/components/file-manager/directory-picker-node.vue
@@ -12,6 +12,7 @@ import {
   treeRowIdleClass,
   treeRowSelectedClass,
 } from './tree-row'
+import { useTreeDisclosure } from './tree-disclosure'
 
 // One directory row in the folder picker. Mirrors file-tree-node's shape and
 // disclosure behaviour, minus everything the Explorer needs and a picker does
@@ -38,42 +39,28 @@ const emit = defineEmits<{ select: [path: string] }>()
 
 const { t } = useI18n()
 
-const expanded = ref(false)
-const loaded = ref(false)
-const loading = ref(false)
 const failed = ref(false)
 const children = ref<string[]>([])
 
 const selected = computed(() => props.selectedPath === props.path)
 
-async function loadChildren() {
-  loading.value = true
-  failed.value = false
+const { expanded, loaded, spinnerVisible, expand, toggle, reload } = useTreeDisclosure(async () => {
   try {
     children.value = await props.listDirectory(props.path)
-    loaded.value = true
+    failed.value = false
+    return true
   } catch {
     // The message is on the retry line below the row; a toast per node would
-    // stack one per expanded folder.
+    // stack one per expanded folder. `failed` clears only on success so the
+    // line holds its place during a retry instead of flickering out and back.
     failed.value = true
-  } finally {
-    loading.value = false
+    return false
   }
-}
-
-async function expand() {
-  expanded.value = true
-  if (!loaded.value) await loadChildren()
-}
+})
 
 function onRowClick() {
   emit('select', props.path)
   if (!expanded.value) void expand()
-}
-
-function onChevronClick() {
-  if (expanded.value) expanded.value = false
-  else void expand()
 }
 
 onMounted(() => {
@@ -97,12 +84,17 @@ onMounted(() => {
     />
     <span
       :class="treeGlyphSlotClass"
-      @click.stop="onChevronClick"
+      @click.stop="toggle"
     >
+      <Spinner
+        v-if="spinnerVisible"
+        class="text-muted-foreground"
+      />
       <ChevronRight
+        v-else
         :stroke-width="1.53"
-        class="size-4 text-muted-foreground transition-transform"
-        :class="{ 'rotate-90': expanded }"
+        class="size-4 text-muted-foreground transition-[rotate]"
+        :class="{ 'rotate-90': expanded && (loaded || failed) }"
       />
     </span>
     <span class="ml-1 min-w-0 flex-1 truncate">{{ name }}</span>
@@ -110,21 +102,7 @@ onMounted(() => {
 
   <template v-if="expanded">
     <div
-      v-if="loading"
-      :class="treeAsideClass"
-    >
-      <span
-        v-for="g in depth + 1"
-        :key="g"
-        :class="treeIndentClass"
-      />
-      <span :class="treeGlyphSlotClass">
-        <Spinner class="size-3.5" />
-      </span>
-    </div>
-
-    <div
-      v-else-if="failed"
+      v-if="failed"
       :class="treeAsideClass"
     >
       <span
@@ -135,7 +113,7 @@ onMounted(() => {
       <span class="ml-1 min-w-0 flex-1 truncate">{{ t('bots.folders.form.browseFailed') }}</span>
       <TextButton
         class="ml-2 shrink-0"
-        @click.stop="loadChildren"
+        @click.stop="reload"
       >
         {{ t('bots.folders.form.browseRetry') }}
       </TextButton>

--- a/apps/web/src/components/file-manager/file-tree-node.vue
+++ b/apps/web/src/components/file-manager/file-tree-node.vue
@@ -27,13 +27,13 @@ import { isArchiveFile, sortDirsFirst } from './utils'
 import { resolveFileIcon } from './file-icon'
 import { FileTreeKey } from './file-tree-context'
 import {
-  treeAsideClass,
   treeGlyphSlotClass,
   treeIndentClass,
   treeRowClass,
   treeRowIdleClass,
   treeRowSelectedClass,
 } from './tree-row'
+import { useTreeDisclosure } from './tree-disclosure'
 
 const props = defineProps<{
   entry: HandlersFsFileInfo
@@ -46,9 +46,6 @@ if (!ctx) throw new Error('FileTreeNode must be used within a FileTree provider'
 const tree = ctx
 const isDark = useDark()
 
-const expanded = ref(false)
-const loaded = ref(false)
-const loading = ref(false)
 const children = ref<HandlersFsFileInfo[]>([])
 const rowEl = ref<HTMLElement | null>(null)
 
@@ -63,38 +60,24 @@ const isArchive = computed(() => isArchiveFile(props.entry.name))
 // Seti type glyph by name/extension (color tracks the active theme).
 const fileIcon = computed(() => resolveFileIcon(props.entry.name ?? '', isDark.value))
 
-async function loadChildren() {
-  if (!props.entry.isDir || !path.value) return
-  loading.value = true
-  try {
-    children.value = sortDirsFirst(await tree.listDirectory(path.value))
-    loaded.value = true
-  } finally {
-    loading.value = false
-  }
-}
-
-async function expand() {
-  expanded.value = true
-  if (!loaded.value) await loadChildren()
-}
+const { expanded, loaded, spinnerVisible, expand, toggle, reload } = useTreeDisclosure(async () => {
+  if (!props.entry.isDir || !path.value) return false
+  children.value = sortDirsFirst(await tree.listDirectory(path.value))
+  return true
+})
 
 function onRowClick() {
   if (selectionMode.value && path.value) {
     tree.toggleSelect(props.entry, !selected.value)
     return
   }
-  if (props.entry.isDir) {
-    if (expanded.value) expanded.value = false
-    else void expand()
-  } else {
-    tree.openFile(props.entry)
-  }
+  if (props.entry.isDir) toggle()
+  else tree.openFile(props.entry)
 }
 
 // Re-fetch an expanded folder's children when the workspace changes.
 watch(() => tree.refreshKey.value, () => {
-  if (expanded.value) void loadChildren()
+  if (expanded.value) void reload()
 })
 
 // Reveal (deep-link): expand the chain of ancestor folders leading to the
@@ -143,11 +126,15 @@ function onCheckbox(checked: boolean | 'indeterminate') {
         />
 
         <span :class="treeGlyphSlotClass">
+          <Spinner
+            v-if="entry.isDir && spinnerVisible"
+            class="text-muted-foreground"
+          />
           <ChevronRight
-            v-if="entry.isDir"
+            v-else-if="entry.isDir"
             :stroke-width="1.53"
-            class="size-4 text-muted-foreground"
-            :class="{ 'rotate-90': expanded }"
+            class="size-4 text-muted-foreground transition-[rotate]"
+            :class="{ 'rotate-90': expanded && loaded }"
           />
           <span
             v-else
@@ -213,22 +200,6 @@ function onCheckbox(checked: boolean | 'indeterminate') {
       </ContextMenuItem>
     </ContextMenuContent>
   </ContextMenu>
-
-  <!-- Loading spinner: kept outside the display:contents wrapper so the
-       browser can composite the animation layer correctly. -->
-  <div
-    v-if="entry.isDir && expanded && loading && children.length === 0"
-    :class="treeAsideClass"
-  >
-    <span
-      v-for="g in depth + 1"
-      :key="g"
-      :class="treeIndentClass"
-    />
-    <span :class="treeGlyphSlotClass">
-      <Spinner class="size-3.5" />
-    </span>
-  </div>
 
   <!-- Children: kept mounted after first load to avoid re-mount cost on
        close/reopen. display:contents when expanded (no layout impact),

--- a/apps/web/src/components/file-manager/tree-disclosure.test.ts
+++ b/apps/web/src/components/file-manager/tree-disclosure.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { treeSpinnerDelayMs, useTreeDisclosure } from './tree-disclosure'
+
+function deferred() {
+  let resolve!: (ok: boolean) => void
+  const promise = new Promise<boolean>((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+describe('useTreeDisclosure', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('expands, loads once, and reuses the loaded children on re-expand', async () => {
+    const load = vi.fn(async () => true)
+    const d = useTreeDisclosure(load)
+
+    await d.expand()
+    expect(d.expanded.value).toBe(true)
+    expect(d.loaded.value).toBe(true)
+    expect(load).toHaveBeenCalledTimes(1)
+
+    d.toggle()
+    expect(d.expanded.value).toBe(false)
+    d.toggle()
+    expect(d.expanded.value).toBe(true)
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it('never shows the spinner when the load settles before the delay', async () => {
+    const d = useTreeDisclosure(async () => true)
+
+    await d.expand()
+    expect(d.spinnerVisible.value).toBe(false)
+    await vi.advanceTimersByTimeAsync(treeSpinnerDelayMs * 2)
+    expect(d.spinnerVisible.value).toBe(false)
+  })
+
+  it('shows the spinner only after the delay, and clears it when the load settles', async () => {
+    const gate = deferred()
+    const d = useTreeDisclosure(() => gate.promise)
+
+    const expanding = d.expand()
+    expect(d.spinnerVisible.value).toBe(false)
+    await vi.advanceTimersByTimeAsync(treeSpinnerDelayMs - 1)
+    expect(d.spinnerVisible.value).toBe(false)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(d.spinnerVisible.value).toBe(true)
+
+    gate.resolve(true)
+    await expanding
+    expect(d.spinnerVisible.value).toBe(false)
+    expect(d.loaded.value).toBe(true)
+  })
+
+  it('hides the spinner when the node is collapsed mid-load', async () => {
+    const gate = deferred()
+    const d = useTreeDisclosure(() => gate.promise)
+
+    const expanding = d.expand()
+    await vi.advanceTimersByTimeAsync(treeSpinnerDelayMs)
+    expect(d.spinnerVisible.value).toBe(true)
+
+    d.toggle()
+    expect(d.spinnerVisible.value).toBe(false)
+
+    gate.resolve(true)
+    await expanding
+    expect(d.expanded.value).toBe(false)
+    expect(d.loaded.value).toBe(true)
+  })
+
+  it('stays unloaded when the load reports failure, so expand retries', async () => {
+    const load = vi.fn(async () => false)
+    const d = useTreeDisclosure(load)
+
+    await d.expand()
+    expect(d.loaded.value).toBe(false)
+    expect(d.spinnerVisible.value).toBe(false)
+
+    await d.expand()
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('reload refreshes in place: loaded stays true and the spinner overlays after the delay', async () => {
+    let gate: ReturnType<typeof deferred> | null = null
+    const load = vi.fn(() => gate ? gate.promise : Promise.resolve(true))
+    const d = useTreeDisclosure(load)
+
+    await d.expand()
+    expect(d.loaded.value).toBe(true)
+
+    gate = deferred()
+    const reloading = d.reload()
+    await vi.advanceTimersByTimeAsync(treeSpinnerDelayMs)
+    expect(d.spinnerVisible.value).toBe(true)
+    expect(d.loaded.value).toBe(true)
+    expect(d.expanded.value).toBe(true)
+
+    gate.resolve(true)
+    await reloading
+    expect(d.spinnerVisible.value).toBe(false)
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/src/components/file-manager/tree-disclosure.ts
+++ b/apps/web/src/components/file-manager/tree-disclosure.ts
@@ -1,0 +1,44 @@
+import { computed, ref } from 'vue'
+import { useTimeoutFn } from '@vueuse/core'
+
+// Only a slow load gets a spinner: fast expands go straight ▸ → ▾ with no
+// intermediate frame, so the glyph never flashes on a local listing.
+export const treeSpinnerDelayMs = 200
+
+// The disclosure state machine shared by every tree-row surface (Explorer
+// node, folder-picker node — see ./tree-row for the same single-home rule on
+// the row shape). Loading state lives in the chevron slot via spinnerVisible;
+// no surface may insert a transient child row for it (a placeholder row that
+// collapses again is exactly the empty-folder height jolt this replaces).
+// `load` reports success and must not reject; on failure the node stays
+// unloaded so the next expand retries.
+export function useTreeDisclosure(load: () => Promise<boolean>) {
+  const expanded = ref(false)
+  const loaded = ref(false)
+  const slow = ref(false)
+  const spinnerVisible = computed(() => expanded.value && slow.value)
+
+  const spinnerDelay = useTimeoutFn(() => { slow.value = true }, treeSpinnerDelayMs, { immediate: false })
+
+  async function reload() {
+    spinnerDelay.start()
+    try {
+      if (await load()) loaded.value = true
+    } finally {
+      spinnerDelay.stop()
+      slow.value = false
+    }
+  }
+
+  async function expand() {
+    expanded.value = true
+    if (!loaded.value) await reload()
+  }
+
+  function toggle() {
+    if (expanded.value) expanded.value = false
+    else void expand()
+  }
+
+  return { expanded, loaded, spinnerVisible, expand, toggle, reload }
+}

--- a/apps/web/src/components/file-manager/tree-row.ts
+++ b/apps/web/src/components/file-manager/tree-row.ts
@@ -35,5 +35,5 @@ export const treeIndentClass = 'h-full w-2 shrink-0 self-stretch'
 /** The fixed 24px column that holds a row's chevron or type glyph. */
 export const treeGlyphSlotClass = 'flex size-6 shrink-0 items-center justify-center'
 
-/** A non-row line rendered inside the tree (a child-loading or error line). */
+/** A non-row line rendered inside the tree (the picker's load-failed retry line). */
 export const treeAsideClass = 'flex min-h-[1.6875rem] items-center mx-1 mb-px pl-1 pr-1 text-[0.84375rem] tracking-normal font-[350] text-muted-foreground [-webkit-font-smoothing:auto]' /* ui-allow-px: same Explorer row density as treeRowClass */


### PR DESCRIPTION
## Problem

Expanding a not-yet-loaded folder in the Explorer inserts a one-row-high placeholder line holding a spinner. When the folder turns out empty, that line collapses again, so the tree height jumps back — a visible jitter on every empty-folder expand. `directory-picker-node.vue` (the New-folder dialog's picker) copied the same pattern and had the same problem.

## Fix

Loading feedback moves into the chevron slot; no transient row is ever inserted.

- Fast loads (< 200ms, the common local case): `▸` flips straight to `▾` with the children appearing in the same frame — no spinner at all, so nothing flashes.
- Slow loads: after 200ms the chevron swaps to a spinner inside the same fixed 24px glyph slot (zero layout impact); on settle, `▾` and the children land together.
- Empty folder end state: `▾` with nothing beneath (VS Code semantics). The tree's height never bounces back.

The disclosure state machine was duplicated across the two tree surfaces (the drift `tree-row.ts`'s header warns about); it now lives once in `useTreeDisclosure` (`tree-disclosure.ts`), DOM-free and unit-tested with fake timers: delayed spinner appearance, zero-flash fast path, collapse mid-load, failure retry, in-place reload.

Also fixed on the way:

- An expanded empty folder re-showed the placeholder row on every workspace refresh — same jitter; reloads now overlay the spinner on the chevron while loaded children stay in place.
- The picker chevron's `transition-transform` was dead (Tailwind v4 maps `rotate-90` to the standalone `rotate` property — the gotcha documented in `packages/ui/AGENTS.md`); both surfaces now animate the flip with `transition-[rotate]` (default 150ms, within the motion palette).
- The picker's load-failed retry line holds its place during a retry (`failed` now clears only on success) instead of flickering out and back.

## Verification

- New `tree-disclosure.test.ts` written first (red → green), 6/6 passing.
- Full web vitest project: 1136 tests pass; the 2 pre-existing collection failures (`useMediaGallery.test.ts`, `panel-preview.test.ts`, environment issues present on main too) are unchanged.
- ESLint, `check-ui-contract.mjs`, and the pre-commit hook (Go lint + full Go tests) all pass; `vue-tsc` reports no errors in the touched files.