### PR TITLE
chore: 补齐 Go 构建产物二进制的 gitignore 覆盖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,17 @@ tmp/
 /memoh
 /agent
 /bridge
+/channel
+/gen-bridge-mtls
+/synccaps
+# `go build` run inside a cmd/<name>/ package drops the binary next to the
+# sources; the 65MB cmd/agent/agent blob still in history (#583) was
+# accidentally committed that way.
+/cmd/agent/agent
+/cmd/bridge/bridge
+/cmd/channel/channel
+/cmd/gen-bridge-mtls/gen-bridge-mtls
+/cmd/synccaps/synccaps
 
 # Rust build artifacts (Cargo workspace at the repo root)
 /target/


### PR DESCRIPTION
## 背景

#583 的 65MB 二进制(`cmd/agent/agent`)能进仓库,直接原因是当时的 `/agent` 只匹配仓库根目录,挡不住在 `cmd/agent/` 里跑 `go build` 产出的 `cmd/agent/agent`。`git check-ignore` 实测该路径不命中。

## 改动

按当前 `cmd/` 下全部 5 个 main 包(agent / bridge / channel / gen-bridge-mtls / synccaps)补齐两种 `go build` 输出位置的 ignore:

- 仓库根目录(`go build ./cmd/<name>` 的输出,其中 `/agent`、`/bridge` 已有,补 3 个)
- 包目录内(`cd cmd/<name> && go build` 的输出,即 #583 的事故路径)

只改 `.gitignore`,11 行新增。

## 验证

`git check-ignore -v` 实测:

- ✅ 5 个包内二进制路径 + 3 个根目录二进制名全部命中
- ✅ `cmd/agent/new_file.go`、`internal/agent/new_file.go`、`cmd/internal/core/foo.go` 均不受影响(没有误伤源码目录)

## 关联

- 对应 #583 的防复发部分;是否 rewrite 历史的决策在该 issue 里另述,本 PR 不涉及。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.