### PR TITLE
fix: 会话标题 prompt 去除「新对话」占位名特例,输入改为完整首条消息

### DIFF
--- a/internal/agent/application/service_title.go
+++ b/internal/agent/application/service_title.go
@@ -22,8 +22,7 @@ import (
 )
 
 const (
-	titlePromptMaxInputChars = 500
-	titleGenerateTimeout     = 60 * time.Second
+	titleGenerateTimeout = 60 * time.Second
 	// titleGenerateMaxTokens caps the title completion. Reasoning models burn
 	// budget on hidden thinking before answering, so the cap must clear their
 	// thinking plus a short title (provider defaults can be far smaller, which
@@ -41,6 +40,13 @@ const (
 // trailing question mark, while worked examples carry the target style.
 // Keep the "rules + examples" shape when editing, and keep example inputs
 // disjoint from real traffic so the model generalizes instead of copying.
+//
+// Deliberately no special case for meaningless input (a number, a sticker):
+// the model still returns *something* topic-ish for it, and an empty result
+// already falls back to the prompt-derived title — whereas a fixed
+// placeholder string (the previous rule returned "新对话") collides with the
+// UI's own untitled-session label and makes every such session
+// indistinguishable in the sidebar.
 const titleGenerationPrompt = `Generate a short title for this conversation, in the same language as the user's message.
 
 Rules:
@@ -52,7 +58,6 @@ Rules:
 - For two-entity topics in Chinese, use the "X与Y" form; in English, use "X and Y".
 - For Chinese titles, allowed suffixes when one is needed: 分析/解析/介绍/建议/疑问/困惑/误解/修复/控制/设计/差异 — pick by topic nature, or use no suffix. English titles use plain noun phrases.
 - No ending punctuation, no quotes.
-- If the message is meaningless (a number, a sticker, a single character), return exactly: 新对话
 - Return ONLY the title text.
 
 Examples of the rules (do not copy their content):
@@ -202,7 +207,11 @@ func shouldGenerateSessionTitle(sess session.Thread) bool {
 }
 
 func (s *Service) generateTitle(ctx context.Context, userID string, model models.GetResponse, provider sqlc.Provider, userQuery string) string {
-	userSnippet := truncate(strings.TrimSpace(userQuery), titlePromptMaxInputChars)
+	// The full first user message goes in untruncated: truncating it (the old
+	// 500-char cap) cut the actual topic off long first messages — a pasted
+	// log or document often states its subject well past the opening — and
+	// left the model with only the greeting half to summarize.
+	userSnippet := strings.TrimSpace(userQuery)
 	if userSnippet == "" {
 		return ""
 	}

--- a/internal/agent/application/service_title.go
+++ b/internal/agent/application/service_title.go
@@ -206,12 +206,60 @@ func shouldGenerateSessionTitle(sess session.Thread) bool {
 	return false
 }
 
+const (
+	// titlePromptOverheadTokens reserves budget for the fixed prompt text plus
+	// protocol framing when sizing the user message against the title model's
+	// context window. The prompt is ~400 tokens; the slack covers tokenizer
+	// variance.
+	titlePromptOverheadTokens = 512
+	// titleInputFallbackWindow bounds the user message when the model's
+	// context window is unknown (config absent). 8k is below virtually every
+	// chat model's real window, so the request stays accepted; without any
+	// bound a huge pasted message could overflow an unknown-but-small window
+	// and the provider would reject the whole title call, silently leaving
+	// the first-line fallback title in place.
+	titleInputFallbackWindow = 8192
+	// titleInputFloorRunes is the minimum sample kept even when the window
+	// cannot cover it (a window smaller than the output reservation). Sending
+	// something risks a rejection there, but sending nothing guarantees the
+	// fallback title wins.
+	titleInputFloorRunes = 1000
+)
+
+// boundTitleInput sizes the first user message against the title model's
+// context window so prompt + input + the titleGenerateMaxTokens reservation
+// always fits. Small-context title models exist (provider templates catalog
+// 4096/4097-token ones), and an oversized request is rejected outright —
+// which would leave the fallback title in place, defeating long-message
+// support exactly on the long messages it exists for.
+//
+// Messages within budget pass through whole (the common case). Over-budget
+// messages keep a head/tail sample — 2/3 head, 1/3 tail — because a pasted
+// log or document may state its subject at either end; a pure head cut was
+// the old 500-char bug. The rune budget assumes the worst case of ~1 token
+// per rune (CJK-heavy text); English over-reserves, which errs safe.
+func boundTitleInput(msg string, contextWindowTokens int) string {
+	if msg == "" {
+		return ""
+	}
+	if contextWindowTokens <= 0 {
+		contextWindowTokens = titleInputFallbackWindow
+	}
+	budget := contextWindowTokens - titleGenerateMaxTokens - titlePromptOverheadTokens
+	if budget < titleInputFloorRunes {
+		budget = titleInputFloorRunes
+	}
+	runes := []rune(msg)
+	if len(runes) <= budget {
+		return msg
+	}
+	head := budget * 2 / 3
+	tail := budget - head
+	return string(runes[:head]) + "\n…\n" + string(runes[len(runes)-tail:])
+}
+
 func (s *Service) generateTitle(ctx context.Context, userID string, model models.GetResponse, provider sqlc.Provider, userQuery string) string {
-	// The full first user message goes in untruncated: truncating it (the old
-	// 500-char cap) cut the actual topic off long first messages — a pasted
-	// log or document often states its subject well past the opening — and
-	// left the model with only the greeting half to summarize.
-	userSnippet := strings.TrimSpace(userQuery)
+	userSnippet := boundTitleInput(strings.TrimSpace(userQuery), model.Config.ContextBudgetMaxTokens())
 	if userSnippet == "" {
 		return ""
 	}

--- a/internal/agent/application/service_title_test.go
+++ b/internal/agent/application/service_title_test.go
@@ -124,3 +124,90 @@ func TestResolveTitleModelUsesBotOwnerProfile(t *testing.T) {
 		t.Fatalf("resolveTitleModel() = (%q, %q), want (%q, %q)", gotModelID, gotOwnerID, modelID, ownerID.String())
 	}
 }
+
+func TestBoundTitleInput(t *testing.T) {
+	longASCII := strings.Repeat("a", 20000)
+	longCJK := strings.Repeat("对", 20000)
+
+	tests := []struct {
+		name          string
+		msg           string
+		contextWindow int
+		check         func(t *testing.T, got, msg string)
+	}{
+		{
+			name:          "empty stays empty",
+			msg:           "",
+			contextWindow: 8192,
+			check: func(t *testing.T, got, _ string) {
+				if got != "" {
+					t.Fatalf("expected empty, got %q", got)
+				}
+			},
+		},
+		{
+			name:          "within budget passes through whole",
+			msg:           "为什么 Kubernetes 的滚动更新这么慢",
+			contextWindow: 8192,
+			check: func(t *testing.T, got, msg string) {
+				if got != msg {
+					t.Fatalf("expected passthrough, got %q", got)
+				}
+			},
+		},
+		{
+			name:          "unknown window still passes small messages whole",
+			msg:           "hello world",
+			contextWindow: 0,
+			check: func(t *testing.T, got, msg string) {
+				if got != msg {
+					t.Fatalf("expected passthrough, got %q", got)
+				}
+			},
+		},
+		{
+			name:          "over budget keeps head and tail with elision",
+			msg:           longASCII,
+			contextWindow: 8192, // budget = 8192-2048-512 = 5632 runes
+			check: func(t *testing.T, got, msg string) {
+				runes := []rune(msg)
+				head := string(runes[:5632*2/3])
+				tail := string(runes[len(runes)-5632/3:])
+				if !strings.HasPrefix(got, head) || !strings.HasSuffix(got, tail) {
+					t.Fatal("expected head and tail of the original message to be kept")
+				}
+				if !strings.Contains(got, "\n…\n") {
+					t.Fatal("expected elision marker between head and tail")
+				}
+			},
+		},
+		{
+			name:          "budget counts runes not bytes",
+			msg:           longCJK,
+			contextWindow: 8192,
+			check: func(t *testing.T, got, _ string) {
+				if !strings.Contains(got, "\n…\n") {
+					t.Fatal("expected CJK message of 20000 runes to be sampled")
+				}
+			},
+		},
+		{
+			name:          "window smaller than output reservation keeps the floor sample",
+			msg:           longASCII,
+			contextWindow: 1024,
+			check: func(t *testing.T, got, msg string) {
+				runes := []rune(msg)
+				head := string(runes[:titleInputFloorRunes*2/3])
+				if !strings.HasPrefix(got, head) {
+					t.Fatal("expected the floor-sized head sample")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t, boundTitleInput(tt.msg, tt.contextWindow), tt.msg)
+		})
+	}
+}


### PR DESCRIPTION
## 问题

首条消息是无意义内容(纯数字、表情)时,title prompt 里的特例规则让模型返回固定字符串「新对话」——这恰好是 UI 的空会话占位名。于是 sidebar 出现一排都叫「新对话」的会话,无法区分,看起来像列表坏了。

另外输入只给首条消息的前 500 字符,长消息(粘贴的日志、文档)的真正主题常被切掉,模型只能拿开头客套话起标题。

## 改动

对照 lobe-chat(`packages/prompts/src/chains/summaryTitle.ts`,纯通用规则无特例)与 cherry-studio(一句话 prompt)后,只动有问题的点,结构不变:

- **删除特例规则**「If the message is meaningless..., return exactly: 新对话」。空输出本就回落到 prompt 派生的 fallback 标题(`generateTitle` 返回空时不覆盖),特例是给输入缺陷打的多余补丁;模型对无意义输入自行产出的标题再差也可区分。
- **输入不再截 500 字符,改为按 title model 的 context window 动态定界**(`boundTitleInput`):
  - 预算 = 窗口 − 2048 输出预留 − 512 固定 prompt 开销,按最坏情况 1 rune ≈ 1 token(CJK)折算;
  - 预算内整条通过 —— 常见 case 就是全量首条消息;
  - 超预算取 2/3 头 + 1/3 尾采样(主题可能在文末,纯头部截断正是旧的 500 字符问题);
  - 窗口未知按 8192 兜底,窗口小于输出预留时保留 1000 rune 下限。
  - 全量无界输入曾在 4096/4097 token 的小窗 title model 上直接超窗被拒 → 静默落回 fallback,长消息支持恰好在长消息上失效(本 PR review 指出,已修)。
- rules + examples 结构、「same language as user's message」、中文后缀白名单等风格规则**均保留**。

## 已知边界(不在本 PR 范围)

- 存量已被写成「新对话」的 session 不会自愈:`shouldGenerateSessionTitle` 只在标题为空时重跑(no-retry 遗留缺陷),需手动改名或另开 PR 做 fallback 打标重试。
- 纯附件首条消息的 `Untitled Session` 路径是独立缺口,未触碰。

## Test plan

- [ ] 配置 title model 后,发一条无意义首条消息(如 `111111`),确认 sidebar 标题不再是「新对话」
- [ ] 发一条长首条消息(主题在 500 字符之后),确认标题覆盖真正主题;小窗 title model 下确认 title 调用不再因超窗被拒
- [ ] 正常中文/英文首条消息标题风格无回归(6-10 字名词短语)

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.