### PR TITLE
fix(desktop): keep the workspace browser panel from popping out to the OS browser

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,7 +29,7 @@
     "typecheck:node": "pnpm run prepare:runtime && tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "vue-tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
-    "test:release": "vitest run src/shared/updates.test.ts && node --test scripts/build-env.test.mjs",
+    "test:release": "vitest run src/shared/updates.test.ts src/main/external-links.test.ts && node --test scripts/build-env.test.mjs",
     "icons": "node scripts/build-icons.mjs"
   },
   "dependencies": {

--- a/apps/desktop/src/main/external-links.test.ts
+++ b/apps/desktop/src/main/external-links.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeExternalUrl, resolveNavigationGuardAction } from './external-links'
+
+const trusted = 'file:///Applications/Memoh.app/Contents/renderer/index.html'
+
+describe('normalizeExternalUrl', () => {
+  it('accepts web and mail protocols', () => {
+    expect(normalizeExternalUrl(' https://memoh.ai/docs ')).toEqual({
+      url: 'https://memoh.ai/docs',
+      protocol: 'https:',
+      supported: true,
+    })
+    expect(normalizeExternalUrl('mailto:hi@memoh.ai').supported).toBe(true)
+  })
+
+  it('rejects anything else', () => {
+    expect(normalizeExternalUrl('file:///etc/passwd').supported).toBe(false)
+    expect(normalizeExternalUrl('not a url').supported).toBe(false)
+    expect(normalizeExternalUrl(null).supported).toBe(false)
+  })
+})
+
+describe('resolveNavigationGuardAction', () => {
+  it('lets the trusted renderer entry navigate', () => {
+    expect(resolveNavigationGuardAction({
+      url: trusted,
+      isMainFrame: true,
+      isTrustedRenderer: true,
+    })).toEqual({ kind: 'allow' })
+  })
+
+  it('sends untrusted main-frame navigation to the OS browser', () => {
+    expect(resolveNavigationGuardAction({
+      url: 'https://memoh.ai/docs',
+      isMainFrame: true,
+      isTrustedRenderer: false,
+    })).toEqual({ kind: 'external', url: 'https://memoh.ai/docs' })
+  })
+
+  it('blocks untrusted main-frame navigation on unsupported protocols', () => {
+    expect(resolveNavigationGuardAction({
+      url: 'chrome://settings',
+      isMainFrame: true,
+      isTrustedRenderer: false,
+    })).toEqual({ kind: 'block', url: 'chrome://settings' })
+  })
+
+  // Regression: the workspace browser panel renders the proxied workspace site in
+  // an <iframe>. `will-redirect` fires for EVERY frame (unlike `will-navigate`,
+  // which is main-frame only), so a plain 3xx from the proxied site used to be
+  // treated as an untrusted top-level navigation: the iframe load was cancelled
+  // and the page was handed to the OS browser instead.
+  it('leaves subframe navigation alone so the workspace browser stays embedded', () => {
+    expect(resolveNavigationGuardAction({
+      url: 'http://abc123.browser.memoh.example.com:8080/login',
+      isMainFrame: false,
+      isTrustedRenderer: false,
+    })).toEqual({ kind: 'allow' })
+  })
+
+  it('leaves subframe navigation alone even on unsupported protocols', () => {
+    expect(resolveNavigationGuardAction({
+      url: 'about:blank',
+      isMainFrame: false,
+      isTrustedRenderer: false,
+    })).toEqual({ kind: 'allow' })
+  })
+})

--- a/apps/desktop/src/main/external-links.ts
+++ b/apps/desktop/src/main/external-links.ts
@@ -1,0 +1,46 @@
+// Decides what the main process does with a navigation the renderer tries to
+// start. Kept free of Electron imports so the policy itself is unit-testable.
+
+const EXTERNAL_PROTOCOLS = ['http:', 'https:', 'mailto:']
+
+export interface NormalizedExternalUrl {
+  url: string
+  protocol: string
+  supported: boolean
+}
+
+export function normalizeExternalUrl(rawURL: unknown): NormalizedExternalUrl {
+  const url = typeof rawURL === 'string' ? rawURL.trim() : ''
+  let protocol = ''
+  try {
+    protocol = new URL(url).protocol
+  } catch {
+    protocol = ''
+  }
+  return { url, protocol, supported: EXTERNAL_PROTOCOLS.includes(protocol) }
+}
+
+export type NavigationGuardAction =
+  | { kind: 'allow' }
+  | { kind: 'external', url: string }
+  | { kind: 'block', url: string }
+
+export interface NavigationGuardInput {
+  url: string
+  isMainFrame: boolean
+  isTrustedRenderer: boolean
+}
+
+export function resolveNavigationGuardAction(input: NavigationGuardInput): NavigationGuardAction {
+  // Subframes are content, not the app shell. The workspace browser panel renders
+  // the proxied workspace site in an <iframe>, and `will-redirect` — unlike
+  // `will-navigate` — is emitted for every frame, so guarding subframes here would
+  // cancel the iframe load and hand the page to the OS browser on any 3xx.
+  // Framing rules stay where they belong: the iframe's own `sandbox` attribute.
+  if (!input.isMainFrame) return { kind: 'allow' }
+  if (input.isTrustedRenderer) return { kind: 'allow' }
+
+  const external = normalizeExternalUrl(input.url)
+  if (!external.supported) return { kind: 'block', url: external.url || input.url }
+  return { kind: 'external', url: external.url }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -26,6 +26,7 @@ import { macWindowChromeOptions } from './window-chrome'
 import { maybeSelfInstallMacOS } from './self-install'
 import { DesktopRemoteRuntimeManager } from './remote-runtime'
 import { isTrustedRendererUrl } from './renderer-trust'
+import { normalizeExternalUrl, resolveNavigationGuardAction } from './external-links'
 import { registerDesktopUpdates } from './updates'
 import {
   normalizeBaseUrl,
@@ -270,21 +271,6 @@ function assertTrustedRenderer(event: IpcMainInvokeEvent): void {
   }
 }
 
-function normalizeExternalUrl(rawURL: unknown): { url: string, protocol: string, supported: boolean } {
-  const url = typeof rawURL === 'string' ? rawURL.trim() : ''
-  let protocol = ''
-  try {
-    protocol = new URL(url).protocol
-  } catch {
-    protocol = ''
-  }
-  return {
-    url,
-    protocol,
-    supported: ['http:', 'https:', 'mailto:'].includes(protocol),
-  }
-}
-
 function attachExternalLinkGuards(webContents: Electron.WebContents): void {
   if (guardedExternalLinkWebContents.has(webContents)) return
   guardedExternalLinkWebContents.add(webContents)
@@ -301,16 +287,27 @@ function attachExternalLinkGuards(webContents: Electron.WebContents): void {
     return { action: 'deny' }
   })
 
-  const guardNavigation = (event: Electron.Event, url: string): void => {
-    if (isTrustedRendererNavigation(url)) return
-    event.preventDefault()
-    const external = normalizeExternalUrl(url)
-    if (!external.supported) {
-      console.warn('blocked untrusted navigation URL', external.url || url)
+  // `will-navigate` only ever fires for the main frame, but `will-redirect` fires
+  // for every frame — so this handler must check `isMainFrame` itself. Without it,
+  // a 3xx from a page embedded in the workspace browser panel's <iframe> is read as
+  // an untrusted top-level navigation, and the panel pops out into the OS browser.
+  const guardNavigation = (
+    details: Electron.Event & { url?: string, isMainFrame?: boolean },
+    url: string,
+  ): void => {
+    const action = resolveNavigationGuardAction({
+      url: details.url ?? url,
+      isMainFrame: details.isMainFrame ?? true,
+      isTrustedRenderer: isTrustedRendererNavigation(details.url ?? url),
+    })
+    if (action.kind === 'allow') return
+    details.preventDefault()
+    if (action.kind === 'block') {
+      console.warn('blocked untrusted navigation URL', action.url)
       return
     }
-    void shell.openExternal(external.url).catch((error) => {
-      console.error('failed to open external navigation URL', external.url, error)
+    void shell.openExternal(action.url).catch((error) => {
+      console.error('failed to open external navigation URL', action.url, error)
     })
   }
   webContents.on('will-navigate', guardNavigation)


### PR DESCRIPTION
## Problem

在桌面端打开工作区「浏览器」面板（或在面板里点 **Go**）时，页面不会渲染在面板里，而是弹到系统浏览器。Web 端没有这个问题。

## Root cause

`apps/desktop/src/main/index.ts` 的导航守卫把同一个 handler 挂在了两个作用域不同的事件上：

```js
webContents.on('will-navigate', guardNavigation)
webContents.on('will-redirect', guardNavigation)
```

按 `electron@42.5.0` 的 typings：

- `will-navigate` — *"navigation on the **main frame**"*，只有主框架触发（`will-frame-navigate` 存在的原因正是它覆盖不到子框架）
- `will-redirect` — 文档没有主框架限制，**任意 frame（含 iframe）** 都会触发，所以它的 event params 才带 `isMainFrame`

而工作区浏览器面板 (`apps/web/src/pages/home/components/browser-pane.vue`) 用 `<iframe>` 渲染，src 指向服务端反向代理 (`internal/handlers/containerd_browser.go`)，该代理原样透传上游 3xx。

于是：iframe 内被代理的站点返回一次重定向 → `will-redirect` 在**顶层 webContents** 上触发 → URL 不等于渲染进程入口 (`file://.../renderer/index.html`) → 守卫执行 `event.preventDefault()`（掐掉 iframe 加载）+ `shell.openExternal(url)` → 面板弹到系统浏览器。

「点 Go」和「正常打开」都会复现，因为两者的共同点就是给 iframe 设新 src。

## Fix

把守卫策略抽到新的 `apps/desktop/src/main/external-links.ts`（不依赖 Electron，可单测），并让它按 frame 判断：子框架导航一律放行 —— 页面能否被嵌套是 iframe 自身 `sandbox` 属性的职责，不是导航守卫的。主框架的非信任导航行为保持不变。

## Test

新增 `external-links.test.ts`，7 个用例，其中 2 个专门覆盖本次回归（子框架导航必须放行）。先写测试跑失败，再实现，最后通过。

- `npx vitest run --project desktop` → 45 passed / 7 failed；这 7 个失败在未改动的干净树上同样存在（`server-connection.test.ts`、`remote-runtime.test.ts`），与本 PR 无关
- `pnpm run typecheck:node` 通过
- 改动文件 eslint 无告警

## Out of scope

`setWindowOpenHandler` 同样对子框架生效，所以在工作区浏览器里点 `target="_blank"` 链接仍会跳到系统浏览器。这是否算 bug 取决于产品预期（也可能是想要的行为），本 PR 未改动。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)