### PR TITLE
fix(chat): name turns, not stored messages, for retry/edit/fork

### DIFF
--- a/apps/web/src/composables/api/useChat.chat-api.ts
+++ b/apps/web/src/composables/api/useChat.chat-api.ts
@@ -130,18 +130,18 @@ export interface ForkSessionOptions {
   title?: string
 }
 
-export async function forkSessionFromMessage(botId: string, sessionId: string, messageId: string, options?: ForkSessionOptions): Promise<SessionSummary> {
+export async function forkSessionFromTurn(botId: string, sessionId: string, turnId: string, options?: ForkSessionOptions): Promise<SessionSummary> {
   const bid = botId.trim()
   const sid = sessionId.trim()
-  const mid = messageId.trim()
+  const tid = turnId.trim()
   const title = options?.title?.trim() ?? ''
   if (!bid) throw new Error('bot id is required')
   if (!sid) throw new Error('session id is required')
-  if (!mid) throw new Error('message id is required')
+  if (!tid) throw new Error('turn id is required')
   const { data } = await postBotsByBotIdSessionsBySessionIdFork({
     path: { bot_id: bid, session_id: sid },
     body: {
-      message_id: mid,
+      turn_id: tid,
       ...(title ? { title } : {}),
     },
     throwOnError: true,

--- a/apps/web/src/composables/api/useChat.ws.ts
+++ b/apps/web/src/composables/api/useChat.ws.ts
@@ -35,13 +35,17 @@ export type WSClientMessage =
       type: 'retry_message'
       invocation_id: string
       session_id: string
-      message_id: string
+      /** The turn being replaced. A client holds it from admission onward,
+       *  unlike a stored message id, which only exists once the round has
+       *  been persisted and fetched back. */
+      turn_id: string
     } & WSTurnOptions)
   | ({
       type: 'edit_message'
       invocation_id: string
       session_id: string
-      message_id: string
+      /** See retry_message. */
+      turn_id: string
       text?: string
       attachments?: ChatAttachment[]
     } & WSTurnOptions)

--- a/apps/web/src/pages/home/components/chat-fork-dialog.vue
+++ b/apps/web/src/pages/home/components/chat-fork-dialog.vue
@@ -49,7 +49,7 @@ import { useChatViewTarget } from '../composables/useChatViewContext'
 // back to this panel even if another split gains focus while it is being made.
 const props = defineProps<{
   open: boolean
-  messageId: string
+  turnId: string
 }>()
 
 const emit = defineEmits<{
@@ -76,12 +76,12 @@ watch(() => props.open, (open) => {
 })
 
 async function handleCreateFork() {
-  const messageId = props.messageId.trim()
+  const turnId = props.turnId.trim()
   const title = forkSessionTitle.value.trim()
-  if (!messageId || !title || forkSubmitting.value) return
+  if (!turnId || !title || forkSubmitting.value) return
   forkSubmitting.value = true
   try {
-    const ok = await chatStore.forkMessage(messageId, { title, target: chatViewTarget.value })
+    const ok = await chatStore.forkTurn(turnId, { title, target: chatViewTarget.value })
     if (ok) emit('update:open', false)
   } finally {
     forkSubmitting.value = false

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -109,8 +109,8 @@
                       :on-open-media="galleryOpenBySrc"
                       :on-reply-click="handleReplyJump"
                       :on-retry-message="handleRetryMessage"
-                      :can-retry-latest-assistant="latestRetryableAssistantId === ((msg.serverId ?? msg.id).trim())"
-                      :can-edit-latest-user="latestEditableUserId === ((msg.serverId ?? msg.id).trim())"
+                      :can-retry-latest-assistant="isRetryableTurn(msg)"
+                      :can-edit-latest-user="isEditableTurn(msg)"
                       :can-fork-assistant="canForkAssistant"
                       :is-scrolling="isScrolling"
                       :is-last-message="msg.id === lastMessageId"
@@ -164,7 +164,7 @@
 
       <ChatForkDialog
         v-model:open="forkDialogOpen"
-        :message-id="pendingForkMessageId"
+        :turn-id="pendingForkTurnId"
       />
 
       <!-- The composer is a single instance reused in both layouts: pinned to
@@ -978,7 +978,7 @@ const {
 
 const composerError = ref('')
 const forkDialogOpen = ref(false)
-const pendingForkMessageId = ref('')
+const pendingForkTurnId = ref('')
 const modelPopoverOpen = ref(false)
 const agentPopoverOpen = ref(false)
 const agentChanging = ref(false)
@@ -1102,29 +1102,44 @@ const activeSupportsTurnReplacement = computed(() =>
   !activeChatTarget.value.isACP && !activeChatTarget.value.isPendingACP,
 )
 
-const latestRetryableAssistantId = computed(() => {
+// The turn id, not a message id: a turn carries it from admission, so the
+// affordance is live the moment the round exists rather than after the
+// database twin of that round has been fetched back.
+const latestRetryableAssistantTurnId = computed(() => {
   if (streaming.value || loadingMessages.value || activeChatReadOnly.value) return ''
   if (!activeSupportsTurnReplacement.value) return ''
   for (let i = messages.value.length - 1; i >= 0; i--) {
     const message = messages.value[i]
     if (message?.role === 'assistant' && !message.streaming && !message.__optimistic) {
-      return (message.serverId ?? message.id).trim()
+      return message.turnId?.trim() ?? ''
     }
   }
   return ''
 })
 
-const latestEditableUserId = computed(() => {
+const latestEditableUserTurnId = computed(() => {
   if (streaming.value || loadingMessages.value || activeChatReadOnly.value) return ''
   if (!activeSupportsTurnReplacement.value) return ''
   for (let i = messages.value.length - 1; i >= 0; i--) {
     const message = messages.value[i]
     if (message?.role === 'user' && !message.streaming && !message.__optimistic) {
-      return (message.serverId ?? message.id).trim()
+      return message.turnId?.trim() ?? ''
     }
   }
   return ''
 })
+
+// Both halves of a round share one turn id, so the role decides which
+// affordance a message gets: retry belongs to the reply, edit to the request.
+function isRetryableTurn(message: ChatMessage): boolean {
+  const turnId = latestRetryableAssistantTurnId.value
+  return message.role === 'assistant' && turnId !== '' && turnId === (message.turnId?.trim() ?? '')
+}
+
+function isEditableTurn(message: ChatMessage): boolean {
+  const turnId = latestEditableUserTurnId.value
+  return message.role === 'user' && turnId !== '' && turnId === (message.turnId?.trim() ?? '')
+}
 
 const { data: modelData } = useQuery({
   key: ['models'],
@@ -2999,11 +3014,11 @@ async function handleForkSourceClick() {
   }
 }
 
-function handleForkMessage(messageId: string) {
+function handleForkMessage(turnId: string) {
   composerError.value = ''
-  const id = messageId.trim()
+  const id = turnId.trim()
   if (!id) return
-  pendingForkMessageId.value = id
+  pendingForkTurnId.value = id
   forkDialogOpen.value = true
 }
 
@@ -3060,10 +3075,10 @@ function handleComposerKeydown(e: KeyboardEvent) {
   handleSend()
 }
 
-async function handleRetryMessage(messageId: string) {
+async function handleRetryMessage(turnId: string) {
   if (composerConfigPending.value) return
   composerError.value = ''
-  const result = await chatStore.retryLatestAssistant(messageId, {
+  const result = await chatStore.retryLatestAssistant(turnId, {
     target: paneTarget.value,
     modelId: overrideModelId.value,
     reasoningEffort: overrideReasoningEffort.value,
@@ -3075,14 +3090,14 @@ async function handleRetryMessage(messageId: string) {
   }
 }
 
-async function handleEditMessage(messageId: string, text: string, done?: (started: boolean) => void) {
+async function handleEditMessage(turnId: string, text: string, done?: (started: boolean) => void) {
   if (composerConfigPending.value) {
     done?.(false)
     return
   }
   composerError.value = ''
   try {
-    const result = await chatStore.editLatestUser(messageId, text, {
+    const result = await chatStore.editLatestUser(turnId, text, {
       target: paneTarget.value,
       modelId: overrideModelId.value,
       reasoningEffort: overrideReasoningEffort.value,

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -406,7 +406,7 @@ const messageEl = useTemplateRef('messageItem')
 const emit = defineEmits<{
   active: [isActive: boolean, { id: string, top: number,  }]
   editMessage: [messageId: string, text: string, done: (started: boolean) => void]
-  forkMessage: [messageId: string]
+  forkMessage: [turnId: string]
 }>()
 
 const props = defineProps<{
@@ -452,14 +452,17 @@ const isEditingUserMessage = ref(false)
 const editDraft = ref('')
 const editSubmitting = ref(false)
 
+// Retry, edit and fork all address a round, and a round is named by its turn
+// id — an identity the turn carries from admission onward. The message id is a
+// render identity here and would not survive the trip to the server.
+const turnId = computed(() => props.message.turnId?.trim() ?? '')
+
 function handleRetry() {
-  const messageId = (props.message.serverId ?? props.message.id).trim()
-  if (messageId) props.onRetryMessage?.(messageId)
+  if (turnId.value) props.onRetryMessage?.(turnId.value)
 }
 
 function handleFork() {
-  const messageId = (props.message.serverId ?? props.message.id).trim()
-  if (messageId) emit('forkMessage', messageId)
+  if (turnId.value) emit('forkMessage', turnId.value)
 }
 
 // The pre-stream "running" line picks one phrase and holds it for the turn:
@@ -587,13 +590,15 @@ const canEditUserMessage = computed(() =>
   && props.canEditLatestUser === true
   && props.message.attachments.length === 0
   && cleanCurrentUserText.value.length > 0
-  && bubbleSelf.value,
+  && bubbleSelf.value
+  && turnId.value !== '',
 )
 
 const canForkAssistantMessage = computed(() =>
   props.message.role === 'assistant'
   && !props.message.streaming
-  && props.message.__optimistic !== true,
+  && props.message.__optimistic !== true
+  && turnId.value !== '',
 )
 
 const canSubmitEdit = computed(() =>
@@ -626,10 +631,9 @@ function cancelEdit() {
 }
 
 async function submitEdit() {
-  if (!canSubmitEdit.value || props.message.role !== 'user') return
+  if (!canSubmitEdit.value || props.message.role !== 'user' || !turnId.value) return
   editSubmitting.value = true
-  const messageId = (props.message.serverId ?? props.message.id).trim()
-  emit('editMessage', messageId, editDraft.value.trim(), (started) => {
+  emit('editMessage', turnId.value, editDraft.value.trim(), (started) => {
     editSubmitting.value = false
     if (started) {
       isEditingUserMessage.value = false

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -19,7 +19,7 @@ import { useChatStore } from './chat-list'
 const api = vi.hoisted(() => ({
   createSession: vi.fn(),
   deleteSession: vi.fn(),
-  forkSessionFromMessage: vi.fn(),
+  forkSessionFromTurn: vi.fn(),
   fetchSession: vi.fn(),
   fetchSessions: vi.fn(),
   fetchBots: vi.fn(),
@@ -2305,6 +2305,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-0-1',
           role: 'user',
           text: 'hello',
           attachments: [],
@@ -2312,6 +2313,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-old',
+          turn_id: 'turn-fx-0-1',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'old answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2322,13 +2324,13 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const retry = store.retryLatestAssistant('assistant-old', { workspaceTargetId: 'computer-b' })
+      const retry = store.retryLatestAssistant('turn-fx-0-1', { workspaceTargetId: 'computer-b' })
       await flushPromises()
 
       expect(h.sentWSMessages.at(-1)).toMatchObject({
         type: 'retry_message',
         session_id: 'session-1',
-        message_id: 'assistant-old',
+        turn_id: 'turn-fx-0-1',
         workspace_target_id: 'computer-b',
       })
       expect(store.messages.map(message => message.id)).not.toContain('assistant-old')
@@ -2342,6 +2344,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-0-2',
           role: 'user',
           text: 'hello',
           attachments: [],
@@ -2349,6 +2352,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-new',
+          turn_id: 'turn-fx-0-2',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'new answer' }],
           timestamp: '2026-05-17T08:00:02.000Z',
@@ -2385,6 +2389,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-1-1',
           role: 'user',
           text: 'first',
           attachments: [],
@@ -2392,6 +2397,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-prev',
+          turn_id: 'turn-fx-1-1',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'previous answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2399,6 +2405,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'user-2',
+          turn_id: 'turn-fx-1-2',
           role: 'user',
           text: 'second',
           attachments: [],
@@ -2406,6 +2413,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-old',
+          turn_id: 'turn-fx-1-2',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'old answer' }],
           timestamp: '2026-05-17T08:00:03.000Z',
@@ -2416,7 +2424,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const retry = store.retryLatestAssistant('assistant-old')
+      const retry = store.retryLatestAssistant('turn-fx-1-2')
       await flushPromises()
 
       expect(store.activeChatTarget.metadata.forked_from).toMatchObject({
@@ -2426,6 +2434,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-1-3',
           role: 'user',
           text: 'first',
           attachments: [],
@@ -2433,6 +2442,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-prev',
+          turn_id: 'turn-fx-1-3',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'previous answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2440,6 +2450,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'user-2',
+          turn_id: 'turn-fx-1-4',
           role: 'user',
           text: 'second',
           attachments: [],
@@ -2447,6 +2458,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-new',
+          turn_id: 'turn-fx-1-4',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'new answer' }],
           timestamp: '2026-05-17T08:00:06.000Z',
@@ -2485,6 +2497,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-2-1',
           role: 'user',
           text: 'hello',
           attachments: [],
@@ -2492,6 +2505,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-old',
+          turn_id: 'turn-fx-2-1',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'old answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2502,7 +2516,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const retry = store.retryLatestAssistant('assistant-old')
+      const retry = store.retryLatestAssistant('turn-fx-2-1')
       await flushPromises()
 
       expect(store.activeChatTarget.metadata.forked_from).toMatchObject({
@@ -2514,6 +2528,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-2-2',
           role: 'user',
           text: 'hello',
           attachments: [],
@@ -2521,6 +2536,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-new',
+          turn_id: 'turn-fx-2-2',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'new answer' }],
           timestamp: '2026-05-17T08:00:06.000Z',
@@ -2557,6 +2573,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-3-1',
           role: 'user',
           text: 'first',
           attachments: [],
@@ -2564,6 +2581,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-prev',
+          turn_id: 'turn-fx-3-1',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'previous answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2571,6 +2589,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'user-2',
+          turn_id: 'turn-fx-3-2',
           role: 'user',
           text: 'second',
           attachments: [],
@@ -2578,6 +2597,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-old',
+          turn_id: 'turn-fx-3-2',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'old answer' }],
           timestamp: '2026-05-17T08:00:03.000Z',
@@ -2588,7 +2608,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const edit = store.editLatestUser('user-2', 'edited second')
+      const edit = store.editLatestUser('turn-fx-3-2', 'edited second')
       await flushPromises()
 
       expect(store.activeChatTarget.metadata.forked_from).toMatchObject({
@@ -2598,6 +2618,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-3-3',
           role: 'user',
           text: 'first',
           attachments: [],
@@ -2605,6 +2626,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-prev',
+          turn_id: 'turn-fx-3-3',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'previous answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2612,6 +2634,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'user-new',
+          turn_id: 'turn-fx-3-4',
           role: 'user',
           text: 'edited second',
           attachments: [],
@@ -2619,6 +2642,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-new',
+          turn_id: 'turn-fx-3-4',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'new answer' }],
           timestamp: '2026-05-17T08:00:07.000Z',
@@ -2643,6 +2667,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-4-1',
           role: 'user',
           text: 'hello',
           attachments: [],
@@ -2650,6 +2675,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-old',
+          turn_id: 'turn-fx-4-1',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'old answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2660,7 +2686,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const result = await store.retryLatestAssistant('assistant-old')
+      const result = await store.retryLatestAssistant('turn-fx-4-1')
 
       expect(result).toMatchObject({ ok: false, stage: 'startup', error: 'model failed' })
       expect(store.messages.map(message => message.id)).toEqual(['user-1', 'assistant-old'])
@@ -2680,6 +2706,7 @@ describe('chat-list store', () => {
           return Promise.resolve([
             {
               id: 'user-a',
+              turn_id: 'turn-fx-5-1',
               role: 'user',
               text: 'hello',
               attachments: [],
@@ -2687,6 +2714,7 @@ describe('chat-list store', () => {
             },
             {
               id: 'assistant-old',
+              turn_id: 'turn-fx-5-1',
               role: 'assistant',
               messages: [{ id: 1, type: 'text', content: 'old answer' }],
               timestamp: '2026-05-17T08:00:01.000Z',
@@ -2698,6 +2726,7 @@ describe('chat-list store', () => {
           return Promise.resolve([
             {
               id: 'user-b',
+              turn_id: 'turn-fx-5-2',
               role: 'user',
               text: 'other chat',
               attachments: [],
@@ -2711,7 +2740,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const retry = store.retryLatestAssistant('assistant-old')
+      const retry = store.retryLatestAssistant('turn-fx-5-1')
       await flushPromises()
       expect(store.messages.map(message => message.id)).toEqual(['user-a', expect.any(String)])
       const retryRunId = h.lastRunId
@@ -2743,6 +2772,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-6-1',
           role: 'user',
           text: 'old prompt',
           attachments: [],
@@ -2750,6 +2780,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-old',
+          turn_id: 'turn-fx-6-1',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'old answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2760,13 +2791,13 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const edit = store.editLatestUser('user-1', 'new prompt', { workspaceTargetId: 'computer-a' })
+      const edit = store.editLatestUser('turn-fx-6-1', 'new prompt', { workspaceTargetId: 'computer-a' })
       await flushPromises()
 
       expect(h.sentWSMessages.at(-1)).toMatchObject({
         type: 'edit_message',
         session_id: 'session-1',
-        message_id: 'user-1',
+        turn_id: 'turn-fx-6-1',
         text: 'new prompt',
         workspace_target_id: 'computer-a',
       })
@@ -2787,6 +2818,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-new',
+          turn_id: 'turn-fx-6-2',
           role: 'user',
           text: 'new prompt',
           attachments: [],
@@ -2794,6 +2826,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-new',
+          turn_id: 'turn-fx-6-2',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'new answer' }],
           timestamp: '2026-05-17T08:00:03.000Z',
@@ -2816,6 +2849,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-7-1',
           role: 'user',
           text: 'old prompt',
           attachments: [],
@@ -2823,6 +2857,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-old',
+          turn_id: 'turn-fx-7-1',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'old answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2833,7 +2868,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const result = await store.editLatestUser('user-1', 'new prompt')
+      const result = await store.editLatestUser('turn-fx-7-1', 'new prompt')
 
       expect(result).toMatchObject({
         ok: false,
@@ -2858,6 +2893,7 @@ describe('chat-list store', () => {
           return Promise.resolve([
             {
               id: 'user-a',
+              turn_id: 'turn-fx-8-1',
               role: 'user',
               text: 'old prompt',
               attachments: [],
@@ -2865,6 +2901,7 @@ describe('chat-list store', () => {
             },
             {
               id: 'assistant-a',
+              turn_id: 'turn-fx-8-1',
               role: 'assistant',
               messages: [{ id: 1, type: 'text', content: 'old answer' }],
               timestamp: '2026-05-17T08:00:01.000Z',
@@ -2876,6 +2913,7 @@ describe('chat-list store', () => {
           return Promise.resolve([
             {
               id: 'user-b',
+              turn_id: 'turn-fx-8-2',
               role: 'user',
               text: 'other chat',
               attachments: [],
@@ -2889,7 +2927,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const edit = store.editLatestUser('user-a', 'new prompt')
+      const edit = store.editLatestUser('turn-fx-8-1', 'new prompt')
       await flushPromises()
       expect(store.messages.map(message => message.role)).toEqual(['user', 'assistant'])
       expect(store.messages[0]).toMatchObject({ role: 'user', text: 'new prompt' })
@@ -2927,6 +2965,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'user-1',
+          turn_id: 'turn-fx-8-3',
           role: 'user',
           text: 'old prompt',
           attachments: [{
@@ -2942,6 +2981,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'assistant-old',
+          turn_id: 'turn-fx-8-3',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'old answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2952,7 +2992,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const result = await store.editLatestUser('user-1', 'new prompt')
+      const result = await store.editLatestUser('turn-fx-8-3', 'new prompt')
 
       expect(result).toMatchObject({ ok: false, stage: 'startup' })
       expect(h.sentWSMessages).toHaveLength(0)
@@ -2971,6 +3011,7 @@ describe('chat-list store', () => {
       const sourceTurns = [
         {
           id: 'source-user',
+          turn_id: 'turn-fx-9-1',
           role: 'user' as const,
           text: 'hello',
           attachments: [],
@@ -2978,6 +3019,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'source-assistant',
+          turn_id: 'turn-fx-9-1',
           role: 'assistant' as const,
           messages: [{ id: 1, type: 'text' as const, content: 'answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -2987,6 +3029,7 @@ describe('chat-list store', () => {
       const forkTurns = [
         {
           id: 'fork-user',
+          turn_id: 'turn-fx-9-2',
           role: 'user' as const,
           text: 'hello',
           attachments: [],
@@ -2994,6 +3037,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'fork-assistant',
+          turn_id: 'turn-fx-9-2',
           role: 'assistant' as const,
           messages: [{ id: 1, type: 'text' as const, content: 'answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -3005,7 +3049,7 @@ describe('chat-list store', () => {
         if (sessionId === 'fork-session') return Promise.resolve(forkTurns)
         return Promise.resolve([])
       })
-      api.forkSessionFromMessage.mockResolvedValueOnce({
+      api.forkSessionFromTurn.mockResolvedValueOnce({
         id: 'fork-session',
         bot_id: 'bot-1',
         title: 'Source fork',
@@ -3040,12 +3084,12 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const ok = await store.forkMessage('source-assistant', { title: 'Custom fork name' })
+      const ok = await store.forkTurn('turn-fx-9-1', { title: 'Custom fork name' })
       await applyLatestForkRequest(store)
       await flushPromises()
 
       expect(ok).toBe(true)
-      expect(api.forkSessionFromMessage).toHaveBeenCalledWith('bot-1', 'source-session', 'source-assistant', { title: 'Custom fork name' })
+      expect(api.forkSessionFromTurn).toHaveBeenCalledWith('bot-1', 'source-session', 'turn-fx-9-1', { title: 'Custom fork name' })
       expect(store.sessionId).toBe('fork-session')
       expect(store.messages.map(message => message.id)).toEqual(['fork-user', 'fork-assistant'])
       expect(store.activeChatTarget.metadata.forked_from).toMatchObject({
@@ -3063,6 +3107,7 @@ describe('chat-list store', () => {
       const sourceTurns = [
         {
           id: 'source-user',
+          turn_id: 'turn-fx-10-1',
           role: 'user' as const,
           text: 'hello',
           attachments: [],
@@ -3070,6 +3115,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'source-assistant',
+          turn_id: 'turn-fx-10-1',
           role: 'assistant' as const,
           messages: [{ id: 1, type: 'text' as const, content: 'answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -3079,6 +3125,7 @@ describe('chat-list store', () => {
       const forkTurns = [
         {
           id: 'fork-user',
+          turn_id: 'turn-fx-10-2',
           role: 'user' as const,
           text: 'hello',
           attachments: [],
@@ -3086,6 +3133,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'fork-assistant',
+          turn_id: 'turn-fx-10-2',
           role: 'assistant' as const,
           messages: [{ id: 1, type: 'text' as const, content: 'answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -3097,7 +3145,7 @@ describe('chat-list store', () => {
         if (sessionId === 'fork-session') return Promise.resolve(forkTurns)
         return Promise.resolve([])
       })
-      api.forkSessionFromMessage.mockResolvedValueOnce({
+      api.forkSessionFromTurn.mockResolvedValueOnce({
         id: 'fork-session',
         bot_id: 'bot-1',
         title: 'Source fork',
@@ -3119,7 +3167,7 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const ok = await store.forkMessage('source-assistant')
+      const ok = await store.forkTurn('turn-fx-10-1')
       await applyLatestForkRequest(store)
       await flushPromises()
 
@@ -3148,6 +3196,7 @@ describe('chat-list store', () => {
           return Promise.resolve([
             {
               id: 'source-assistant',
+              turn_id: 'turn-fx-11-1',
               role: 'assistant' as const,
               messages: [{ id: 1, type: 'text' as const, content: 'answer' }],
               timestamp: '2026-05-17T08:00:01.000Z',
@@ -3159,6 +3208,7 @@ describe('chat-list store', () => {
           return Promise.resolve([
             {
               id: 'other-user',
+              turn_id: 'turn-fx-11-2',
               role: 'user' as const,
               text: 'other',
               attachments: [],
@@ -3169,7 +3219,7 @@ describe('chat-list store', () => {
         return Promise.resolve([])
       })
       let resolveFork!: (session: unknown) => void
-      api.forkSessionFromMessage.mockReturnValueOnce(new Promise(resolve => {
+      api.forkSessionFromTurn.mockReturnValueOnce(new Promise(resolve => {
         resolveFork = resolve
       }))
       const store = useChatStore()
@@ -3180,7 +3230,7 @@ describe('chat-list store', () => {
       const targetB = { botId: 'bot-1', sessionId: 'other-session', viewId: 'chat:b' }
       store.bindChatView(targetA.viewId, targetA, true)
       store.focusChatView(targetA.viewId)
-      const fork = store.forkMessage('source-assistant', { target: targetA })
+      const fork = store.forkTurn('turn-fx-11-1', { target: targetA })
       await flushPromises()
       store.bindChatView(targetB.viewId, targetB, true)
       store.focusChatView(targetB.viewId)
@@ -3225,6 +3275,7 @@ describe('chat-list store', () => {
       })
       api.fetchMessagesUI.mockResolvedValueOnce([{
         id: 'source-assistant',
+        turn_id: 'turn-fx-12-1',
         role: 'assistant',
         messages: [{ id: 1, type: 'text', content: 'answer' }],
         timestamp: '2026-07-11T00:00:00Z',
@@ -3236,12 +3287,12 @@ describe('chat-list store', () => {
         title: string
         type: string
       }>()
-      api.forkSessionFromMessage.mockReturnValueOnce(response.promise)
+      api.forkSessionFromTurn.mockReturnValueOnce(response.promise)
       const store = useChatStore()
       await store.selectBot('bot-1')
       await flushPromises()
 
-      const fork = store.forkMessage('source-assistant')
+      const fork = store.forkTurn('turn-fx-12-1')
       windowTarget.dispatchEvent(new CustomEvent(AUTH_SESSION_CLEARED_EVENT, {
         detail: { reason: 'logout' },
       }))
@@ -3261,6 +3312,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'assistant-1',
+          turn_id: 'turn-fx-13-1',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'answer' }],
           timestamp: '2026-05-17T08:00:01.000Z',
@@ -3271,10 +3323,10 @@ describe('chat-list store', () => {
 
       await store.selectBot('bot-1')
       await flushPromises()
-      const ok = await store.forkMessage('assistant-1')
+      const ok = await store.forkTurn('turn-fx-13-1')
 
       expect(ok).toBe(false)
-      expect(api.forkSessionFromMessage).not.toHaveBeenCalled()
+      expect(api.forkSessionFromTurn).not.toHaveBeenCalled()
     })
 
   it('sends disable as an explicit reasoning effort override', async () => {
@@ -4271,6 +4323,7 @@ describe('chat-list store', () => {
       ], nextCursor: null })
       api.fetchMessagesUI.mockResolvedValueOnce([{
         id: 'visible-message',
+        turn_id: 'turn-fx-14-1',
         role: 'user',
         text: 'visible',
         attachments: [],
@@ -4435,6 +4488,7 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'server-user',
+          turn_id: 'turn-fx-14-2',
           role: 'user',
           text: 'hi',
           attachments: [],
@@ -4442,6 +4496,7 @@ describe('chat-list store', () => {
         },
         {
           id: 'server-assistant',
+          turn_id: 'turn-fx-14-2',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'hello', running: false }],
           timestamp: past,
@@ -4536,6 +4591,10 @@ describe('chat-list store', () => {
       // older fetch then returns empty to simulate end-of-history.
       const initialPage = Array.from({ length: 30 }, (_, idx) => ({
         id: `msg-${idx}`,
+        turn_id: `turn-${idx}`,
+        // A settled page always carries turn positions; the older-page cursor
+        // is taken from the oldest turn that has one.
+        turn_position: idx + 1,
         role: 'user' as const,
         text: 'hi',
         attachments: [],
@@ -4690,12 +4749,14 @@ describe('chat-list store', () => {
       api.fetchMessagesUI.mockResolvedValueOnce([
         {
           id: 'bot-2-user',
+          turn_id: 'turn-fx-14-3',
           role: 'user',
           text: 'bot two prompt',
           timestamp: '2026-06-20T00:00:00.000Z',
         },
         {
           id: 'bot-2-assistant',
+          turn_id: 'turn-fx-14-3',
           role: 'assistant',
           messages: [{ id: 1, type: 'text', content: 'bot two reply' }],
           timestamp: '2026-06-20T00:00:01.000Z',

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -450,7 +450,7 @@ export const useChatStore = defineStore('chat', () => {
     cleanupFailedDeferredSession,
     removeSession,
     renameSession,
-    forkMessage,
+    forkTurn,
     reset: resetSessionActions,
   } = createSessionActions({
     currentBotId,
@@ -612,7 +612,7 @@ export const useChatStore = defineStore('chat', () => {
     setPendingACPModel, setPendingACPMode, setPendingACPReasoning, clearPendingACPSession,
     createACPSession, updateCurrentSessionAgent, updateCurrentSessionToMemoh,
     acpRuntimeKey, ensureACPRuntime, setACPRuntimeMode, setACPRuntimeModel, setACPRuntimeReasoning,
-    removeSession, renameSession, forkMessage,
+    removeSession, renameSession, forkTurn,
     sendMessage, retryLatestAssistant, editLatestUser,
     respondToolApproval, respondUserInput,
     loadOlderMessages, findMessageIdByExternalId, locateMessageByExternalId,

--- a/apps/web/src/store/chat/send.ts
+++ b/apps/web/src/store/chat/send.ts
@@ -435,7 +435,7 @@ export function createChatSend(deps: ChatSendDeps) {
   }
 
   async function retryLatestAssistant(
-    messageId: string,
+    turnId: string,
     options: {
       target?: ChatViewTarget
       modelId?: string
@@ -447,16 +447,16 @@ export function createChatSend(deps: ChatSendDeps) {
     const botId = viewTarget.botId
     const targetSessionId = viewTarget.sessionId ?? ''
     const transcript = deps.transcriptForTarget(viewTarget)
-    const targetId = messageId.trim()
+    const targetTurnId = turnId.trim()
     if (
       !botId
       || !targetSessionId
-      || !targetId
+      || !targetTurnId
       || deps.chatReadOnlyFor(viewTarget)
       || deps.isChatViewStreaming(viewTarget)
       || transcript.loadingMessages.value
     ) return { ok: false, stage: 'startup' }
-    const target = transcript.findTurnByServerId(targetId)
+    const target = transcript.findTurnByTurnId(targetTurnId, 'assistant')
     if (!target || !transcript.isLatestVisibleAssistantTurn(target)) {
       return { ok: false, stage: 'startup' }
     }
@@ -483,7 +483,7 @@ export function createChatSend(deps: ChatSendDeps) {
         type: 'retry_message',
         invocation_id: invocationId,
         session_id: targetSessionId,
-        message_id: targetId,
+        turn_id: targetTurnId,
         model_id: options.modelId?.trim() || deps.overrideModelId.value || undefined,
         reasoning_effort: options.reasoningEffort?.trim()
           || deps.overrideReasoningEffort.value
@@ -518,7 +518,7 @@ export function createChatSend(deps: ChatSendDeps) {
   }
 
   async function editLatestUser(
-    messageId: string,
+    turnId: string,
     text: string,
     options: {
       target?: ChatViewTarget
@@ -532,17 +532,17 @@ export function createChatSend(deps: ChatSendDeps) {
     const botId = viewTarget.botId
     const targetSessionId = viewTarget.sessionId ?? ''
     const transcript = deps.transcriptForTarget(viewTarget)
-    const targetId = messageId.trim()
+    const targetTurnId = turnId.trim()
     if (
       !botId
       || !targetSessionId
-      || !targetId
+      || !targetTurnId
       || !trimmed
       || deps.chatReadOnlyFor(viewTarget)
       || deps.isChatViewStreaming(viewTarget)
       || transcript.loadingMessages.value
     ) return { ok: false, stage: 'startup' }
-    const target = transcript.findTurnByServerId(targetId)
+    const target = transcript.findTurnByTurnId(targetTurnId, 'user')
     if (!target || !transcript.isLatestVisibleUserTurn(target) || hasUserAttachments(target)) {
       return { ok: false, stage: 'startup' }
     }
@@ -570,7 +570,7 @@ export function createChatSend(deps: ChatSendDeps) {
         type: 'edit_message',
         invocation_id: invocationId,
         session_id: targetSessionId,
-        message_id: targetId,
+        turn_id: targetTurnId,
         text: trimmed,
         model_id: options.modelId?.trim() || deps.overrideModelId.value || undefined,
         reasoning_effort: options.reasoningEffort?.trim()

--- a/apps/web/src/store/chat/session-actions.ts
+++ b/apps/web/src/store/chat/session-actions.ts
@@ -3,7 +3,7 @@ import { toast } from '@felinic/ui'
 import { resolveApiErrorMessage } from '@/utils/api-error'
 import {
   deleteSession,
-  forkSessionFromMessage,
+  forkSessionFromTurn,
   updateSessionTitle,
   type SessionSummary,
   type UITurn,
@@ -60,7 +60,7 @@ export function createSessionActions(deps: {
     activate: boolean
     seq: number
   } | null>(null)
-  const forkingMessages = new Set<string>()
+  const forkingTurns = new Set<string>()
   let deletedSessionSeq = 0
   let forkedSessionRequestSeq = 0
 
@@ -152,14 +152,14 @@ export function createSessionActions(deps: {
     return updated
   }
 
-  async function forkMessage(
-    messageId: string,
+  async function forkTurn(
+    turnId: string,
     options: { title?: string; target?: ChatViewTarget } = {},
   ) {
     const target = deps.normalizeTarget(options.target)
     const botId = target.botId
     const sessionId = target.sessionId ?? ''
-    const id = messageId.trim()
+    const id = turnId.trim()
     const view = deps.chatView(target)
     const generation = deps.userScopeGeneration()
     const activate = deps.isFocusedTarget(target)
@@ -172,10 +172,10 @@ export function createSessionActions(deps: {
     ) return false
 
     const key = `${botId}:${sessionId}:${id}`
-    if (forkingMessages.has(key)) return false
-    forkingMessages.add(key)
+    if (forkingTurns.has(key)) return false
+    forkingTurns.add(key)
     try {
-      const forked = await forkSessionFromMessage(
+      const forked = await forkSessionFromTurn(
         botId,
         sessionId,
         id,
@@ -211,7 +211,7 @@ export function createSessionActions(deps: {
       toast.error(resolveApiErrorMessage(error, deps.forkFailedMessage()))
       return false
     } finally {
-      forkingMessages.delete(key)
+      forkingTurns.delete(key)
     }
   }
 
@@ -221,11 +221,11 @@ export function createSessionActions(deps: {
     cleanupFailedDeferredSession,
     removeSession,
     renameSession,
-    forkMessage,
+    forkTurn,
     reset: () => {
       deletedSession.value = null
       forkedSessionRequested.value = null
-      forkingMessages.clear()
+      forkingTurns.clear()
     },
   }
 }

--- a/apps/web/src/store/chat/transcript-queries.ts
+++ b/apps/web/src/store/chat/transcript-queries.ts
@@ -10,10 +10,18 @@ export function createTranscriptQueries(messages: ChatMessage[]) {
     return ''
   }
 
-  function findTurnByServerId(messageId: string): ChatMessage | null {
-    const id = messageId.trim()
+  // A turn id names a round, and a round has two halves on screen: retry
+  // addresses its assistant half, edit its user half. The role is part of the
+  // lookup rather than an afterthought.
+  function findTurnByTurnId(turnId: string, role: 'user'): ChatUserTurn | null
+  function findTurnByTurnId(turnId: string, role: 'assistant'): ChatAssistantTurn | null
+  function findTurnByTurnId(turnId: string, role: 'user' | 'assistant'): ChatUserTurn | ChatAssistantTurn | null {
+    const id = turnId.trim()
     if (!id) return null
-    return messages.find(turn => serverMessageId(turn) === id) ?? null
+    for (const turn of messages) {
+      if (turn.role === role && turn.turnId?.trim() === id) return turn
+    }
+    return null
   }
 
   function latestVisibleTurn(role: 'user'): ChatUserTurn | null
@@ -41,7 +49,7 @@ export function createTranscriptQueries(messages: ChatMessage[]) {
   return {
     latestOptimisticUserText,
     hasTurn: (turn: ChatMessage) => messages.includes(turn),
-    findTurnByServerId,
+    findTurnByTurnId,
     isLatestVisibleUserTurn,
     isLatestVisibleAssistantTurn,
   }

--- a/apps/web/src/store/chat/transcript.test.ts
+++ b/apps/web/src/store/chat/transcript.test.ts
@@ -81,7 +81,7 @@ describe('chat transcript controller', () => {
     expect(toRaw(transcript.messages[0])).toBe(turn)
   })
 
-  it('owns server-id lookup and latest visible turn queries', () => {
+  it('owns turn lookup and latest visible turn queries', () => {
     const { transcript } = makeTranscript()
     transcript.replaceMessages([
       rawUser('user-1'),
@@ -89,8 +89,8 @@ describe('chat transcript controller', () => {
       rawUser('user-2'),
       rawAssistant('assistant-2'),
     ], 'session-1')
-    const latestUser = transcript.findTurnByServerId('user-2')!
-    const latestAssistant = transcript.findTurnByServerId('assistant-2')!
+    const latestUser = transcript.findTurnByTurnId('turn-user-2', 'user')!
+    const latestAssistant = transcript.findTurnByTurnId('turn-assistant-2', 'assistant')!
     const optimisticUser: ChatUserTurn = {
       id: 'optimistic-user',
       role: 'user',
@@ -104,11 +104,60 @@ describe('chat transcript controller', () => {
     transcript.appendToView(optimisticUser)
 
     expect(transcript.hasTurn(optimisticUser)).toBe(true)
-    expect(transcript.findTurnByServerId('missing')).toBeNull()
+    expect(transcript.findTurnByTurnId('missing', 'user')).toBeNull()
     expect(transcript.isLatestVisibleUserTurn(latestUser)).toBe(true)
     expect(transcript.isLatestVisibleAssistantTurn(latestAssistant)).toBe(true)
     expect(transcript.isLatestVisibleUserTurn(optimisticUser)).toBe(false)
-    expect(transcript.isLatestVisibleUserTurn(transcript.findTurnByServerId('user-1')!)).toBe(false)
+    expect(transcript.isLatestVisibleUserTurn(transcript.findTurnByTurnId('turn-user-1', 'user')!)).toBe(false)
+  })
+
+  // Both halves of a round share one turn id, so the role is what separates
+  // what a retry addresses from what an edit addresses.
+  it('resolves the two halves of one turn by role', () => {
+    const { transcript } = makeTranscript()
+    transcript.replaceMessages([
+      { id: 'user-1', turn_id: 'turn-1', role: 'user', text: 'hello', timestamp: '2026-01-01T00:00:00.000Z' },
+      { id: 'assistant-1', turn_id: 'turn-1', role: 'assistant', messages: [], timestamp: '2026-01-01T00:00:01.000Z' },
+    ], 'session-1')
+
+    expect(transcript.findTurnByTurnId('turn-1', 'user')?.id).toBe('user-1')
+    expect(transcript.findTurnByTurnId('turn-1', 'assistant')?.id).toBe('assistant-1')
+  })
+
+  // A live turn is on screen before the database has numbered it. Paging from
+  // it would hand the server a render identity it cannot resolve.
+  it('never pages from a turn the database has not numbered', async () => {
+    const { transcript, fetchMessages } = makeTranscript()
+    transcript.replaceHistoryView([], 'session-1')
+    transcript.appendToView({
+      id: 'runtime:turn-1:user',
+      role: 'user',
+      text: 'hi',
+      attachments: [],
+      timestamp: '2026-01-01T00:00:00.000Z',
+      streaming: false,
+      isSelf: true,
+      turnId: 'turn-1',
+    })
+
+    expect(await transcript.loadOlderMessages()).toBe(0)
+    expect(fetchMessages).not.toHaveBeenCalled()
+
+    transcript.replaceHistoryView([{
+      id: '018f47f2-8bc1-7a3d-91b2-b73a7b925b1e',
+      turn_id: 'turn-1',
+      turn_position: 7,
+      role: 'user',
+      text: 'hi',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    }], 'session-1')
+    fetchMessages.mockResolvedValueOnce([])
+
+    expect(await transcript.loadOlderMessages()).toBe(0)
+    expect(fetchMessages).toHaveBeenCalledWith('bot-1', 'session-1', {
+      limit: 30,
+      beforeMessageId: '018f47f2-8bc1-7a3d-91b2-b73a7b925b1e',
+    })
   })
 
   it('does not guess optimistic identity from matching text and timestamps', () => {

--- a/apps/web/src/store/chat/transcript.ts
+++ b/apps/web/src/store/chat/transcript.ts
@@ -230,11 +230,20 @@ export function createTranscriptController({
     return fetchMessages(botId, targetSessionId, { limit: PAGE_SIZE })
   }
 
+  // The oldest turn the database has actually numbered. turnPosition is that
+  // signal exactly: the visible-history view cannot return a row without one,
+  // and a live turn carries none until its settled twin arrives. Paging from
+  // messages[0] instead would hand the server a render identity whenever a
+  // live turn sits at the head of an otherwise unsettled transcript.
+  function oldestSettledTurn(): ChatMessage | undefined {
+    return messages.find(turn => turn.turnPosition !== undefined)
+  }
+
   async function loadOlderMessages(): Promise<number> {
     const bid = (currentBotId.value ?? '').trim()
     const sid = (sessionId.value ?? '').trim()
     if (!bid || !sid || loadingOlder.value || !hasMoreOlder.value) return 0
-    const first = messages[0]
+    const first = oldestSettledTurn()
     if (!first) return 0
     const firstId = serverMessageId(first)
     if (!firstId) return 0
@@ -496,7 +505,8 @@ export function createTranscriptController({
       if (!next) return current ? [current] : []
       if (!current) return [next]
       const renderId = current.id
-      Object.assign(current, next, { id: renderId })
+      const settledPosition = current.turnPosition ?? next.turnPosition
+      Object.assign(current, next, { id: renderId, turnPosition: settledPosition })
       return [current]
     })
 

--- a/db/postgres/queries/sessions.sql
+++ b/db/postgres/queries/sessions.sql
@@ -20,7 +20,7 @@ VALUES (
 )
 RETURNING *;
 
--- name: ForkSessionFromAssistantMessage :one
+-- name: ForkSessionFromAssistantTurn :one
 WITH source_session AS (
   SELECT s.*
   FROM bot_sessions s
@@ -38,10 +38,9 @@ target_turn AS (
   FROM source_session s
   JOIN bot_visible_history_messages vm ON vm.team_id = public.memoh_current_team_id()
     AND vm.session_id = s.id
-    AND vm.id = sqlc.arg(message_id)
+    AND vm.turn_id = sqlc.arg(turn_id)
     AND vm.role = 'assistant'
-    AND vm.turn_id IS NOT NULL
-    AND vm.turn_position IS NOT NULL
+  ORDER BY vm.turn_message_seq ASC, vm.created_at ASC, vm.id ASC
   LIMIT 1
 ),
 copy_messages AS (
@@ -102,9 +101,11 @@ fork_plan AS (
   SELECT
     s.*,
     fam.new_message_id AS fork_message_id,
+    tt.message_id AS source_message_id,
     ntp.value AS next_turn_position_value
   FROM source_session s
   JOIN fork_anchor_message fam ON true
+  JOIN target_turn tt ON true
   CROSS JOIN next_turn_position ntp
   WHERE EXISTS (SELECT 1 FROM copy_turns)
 ),
@@ -138,7 +139,10 @@ created_session AS (
     jsonb_set(
       pm.value,
       '{forked_from}',
-      COALESCE(pm.value->'forked_from', '{}'::jsonb) || jsonb_build_object('fork_message_id', fp.fork_message_id::text),
+      COALESCE(pm.value->'forked_from', '{}'::jsonb) || jsonb_build_object(
+        'message_id', fp.source_message_id::text,
+        'fork_message_id', fp.fork_message_id::text
+      ),
       true
     ),
     fp.next_turn_position_value,

--- a/internal/agent/application/service_retry_edit.go
+++ b/internal/agent/application/service_retry_edit.go
@@ -15,12 +15,14 @@ import (
 )
 
 type RetryLatestMessageInput struct {
-	BotID                  string
-	SessionID              string
-	RunID                  string
-	TurnID                 string
-	TurnPosition           *int64
-	MessageID              string
+	BotID        string
+	SessionID    string
+	RunID        string
+	TurnID       string
+	TurnPosition *int64
+	// TargetTurnID names the round being replaced. It is distinct from TurnID,
+	// which names the new turn this operation admits.
+	TargetTurnID           string
 	ActorChannelIdentityID string
 	ActorUserID            string
 	ChatToken              string
@@ -31,12 +33,13 @@ type RetryLatestMessageInput struct {
 }
 
 type EditLatestMessageInput struct {
-	BotID                  string
-	SessionID              string
-	RunID                  string
-	TurnID                 string
-	TurnPosition           *int64
-	MessageID              string
+	BotID        string
+	SessionID    string
+	RunID        string
+	TurnID       string
+	TurnPosition *int64
+	// TargetTurnID names the round being replaced. See RetryLatestMessageInput.
+	TargetTurnID           string
 	Text                   string
 	Attachments            []ChatAttachment
 	ActorChannelIdentityID string
@@ -50,8 +53,7 @@ type EditLatestMessageInput struct {
 
 func (s *Service) RetryLatestMessageWS(ctx context.Context, input RetryLatestMessageInput, eventCh chan<- WSStreamEvent, abortCh <-chan struct{}) error {
 	sessionID := strings.TrimSpace(input.SessionID)
-	messageID := strings.TrimSpace(input.MessageID)
-	turn, _, cutoffMessageID, err := s.prepareRetryLatestMessageOperation(ctx, sessionID, messageID)
+	turn, cutoffMessageID, err := s.prepareRetryLatestTurnOperation(ctx, sessionID, strings.TrimSpace(input.TargetTurnID))
 	if err != nil {
 		return err
 	}
@@ -96,13 +98,12 @@ func (s *Service) RetryLatestMessageWS(ctx context.Context, input RetryLatestMes
 
 func (s *Service) EditLatestMessageWS(ctx context.Context, input EditLatestMessageInput, eventCh chan<- WSStreamEvent, abortCh <-chan struct{}) error {
 	sessionID := strings.TrimSpace(input.SessionID)
-	messageID := strings.TrimSpace(input.MessageID)
 	text := strings.TrimSpace(input.Text)
 	if text == "" && len(input.Attachments) == 0 {
 		return errors.New("message text or attachments required")
 	}
 
-	turn, target, err := s.prepareEditLatestMessageOperation(ctx, sessionID, messageID)
+	turn, err := s.prepareEditLatestTurnOperation(ctx, sessionID, strings.TrimSpace(input.TargetTurnID))
 	if err != nil {
 		return err
 	}
@@ -130,111 +131,97 @@ func (s *Service) EditLatestMessageWS(ctx context.Context, input EditLatestMessa
 		WorkspaceTargetID:            strings.TrimSpace(input.WorkspaceTargetID),
 		ToolHTTPURL:                  strings.TrimSpace(input.ToolHTTPURL),
 		SkipHistoryTurn:              true,
-		HistoryCutoffBeforeMessageID: target.ID,
+		HistoryCutoffBeforeMessageID: strings.TrimSpace(turn.RequestMessageID),
 	}
 	return s.streamReplacementWS(ctx, req, turn.ID, "", "edit", eventCh, abortCh)
 }
 
-// PrepareRetryLatestMessageOperation validates the replacement target before
+// PrepareRetryLatestTurnOperation validates the replacement target before
 // Session Runtime publishes it to subscribers and returns the exact persisted
 // message where the old assistant tail begins.
-func (s *Service) PrepareRetryLatestMessageOperation(ctx context.Context, sessionID, messageID string) (string, error) {
-	_, _, replaceFromMessageID, err := s.prepareRetryLatestMessageOperation(ctx, strings.TrimSpace(sessionID), strings.TrimSpace(messageID))
+func (s *Service) PrepareRetryLatestTurnOperation(ctx context.Context, sessionID, turnID string) (string, error) {
+	_, replaceFromMessageID, err := s.prepareRetryLatestTurnOperation(ctx, strings.TrimSpace(sessionID), strings.TrimSpace(turnID))
 	return replaceFromMessageID, err
 }
 
-func (s *Service) prepareRetryLatestMessageOperation(ctx context.Context, sessionID, messageID string) (messagepkg.HistoryTurn, messagepkg.Message, string, error) {
-	if s == nil || s.messageService == nil {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, "", errors.New("message service not configured")
-	}
-	if sessionID == "" {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, "", errors.New("session id is required")
-	}
-	if messageID == "" {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, "", errors.New("message id is required")
-	}
-	turn, target, err := s.latestVisibleTurnAndMessage(ctx, sessionID, messageID)
+func (s *Service) prepareRetryLatestTurnOperation(ctx context.Context, sessionID, turnID string) (messagepkg.HistoryTurn, string, error) {
+	turn, err := s.resolveLatestVisibleTurn(ctx, sessionID, turnID, "only the latest assistant message can be retried")
 	if err != nil {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, "", err
+		return messagepkg.HistoryTurn{}, "", err
 	}
-	if !strings.EqualFold(target.Role, "assistant") {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, "", errors.New("only latest assistant messages can be retried")
+	if strings.TrimSpace(turn.RequestMessageID) == "" {
+		return messagepkg.HistoryTurn{}, "", errors.New("retry target has no request message")
 	}
-	if err := s.ensureLatestVisibleTurn(ctx, sessionID, turn.ID); err != nil {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, "", errors.New("only the latest assistant message can be retried")
-	}
-	requestMessageID := strings.TrimSpace(turn.RequestMessageID)
-	if requestMessageID == "" {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, "", errors.New("retry target has no request message")
-	}
+	// The turn's own assistant anchor, not a message the client named: a turn
+	// that reached the client without one is a history the server cannot cut.
 	replaceFromMessageID := strings.TrimSpace(turn.AssistantMessageID)
 	if replaceFromMessageID == "" {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, "", apperror.New(
+		return messagepkg.HistoryTurn{}, "", apperror.New(
 			apperror.CodeSessionHistoryInconsistent,
 			nil,
 		)
 	}
-	return turn, target, replaceFromMessageID, nil
+	return turn, replaceFromMessageID, nil
 }
 
-// PrepareEditLatestMessageOperation validates the replacement target before
+// PrepareEditLatestTurnOperation validates the replacement target before
 // Session Runtime publishes it to subscribers and returns the exact persisted
 // user message where the old turn begins.
-func (s *Service) PrepareEditLatestMessageOperation(ctx context.Context, sessionID, messageID string) (string, error) {
-	_, target, err := s.prepareEditLatestMessageOperation(ctx, strings.TrimSpace(sessionID), strings.TrimSpace(messageID))
+func (s *Service) PrepareEditLatestTurnOperation(ctx context.Context, sessionID, turnID string) (string, error) {
+	turn, err := s.prepareEditLatestTurnOperation(ctx, strings.TrimSpace(sessionID), strings.TrimSpace(turnID))
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(target.ID), nil
+	return strings.TrimSpace(turn.RequestMessageID), nil
 }
 
-func (s *Service) prepareEditLatestMessageOperation(ctx context.Context, sessionID, messageID string) (messagepkg.HistoryTurn, messagepkg.Message, error) {
+func (s *Service) prepareEditLatestTurnOperation(ctx context.Context, sessionID, turnID string) (messagepkg.HistoryTurn, error) {
+	turn, err := s.resolveLatestVisibleTurn(ctx, sessionID, turnID, "only the latest user message can be edited")
+	if err != nil {
+		return messagepkg.HistoryTurn{}, err
+	}
+	// The turn's request message is by construction its leading user message,
+	// so naming the turn already names what an edit replaces.
+	if strings.TrimSpace(turn.RequestMessageID) == "" {
+		return messagepkg.HistoryTurn{}, errors.New("edit target has no request message")
+	}
+	return turn, nil
+}
+
+// resolveLatestVisibleTurn answers which round the client named, from the turn
+// alone. Retry and edit can only ever address the moving tail, so "is this the
+// latest visible turn" is the entire validation; the turn then carries its own
+// canonical request/assistant message ids, which is why no message lookup is
+// needed to find the round.
+//
+// The turn is also the only identity both sides hold at the same time. A turn
+// id is minted at admission and reaches the client while the run is still
+// streaming, whereas a database message id exists only once the round is
+// persisted — keying on the turn is what lets a live round be retried or
+// edited without first waiting for its stored twin to arrive.
+func (s *Service) resolveLatestVisibleTurn(ctx context.Context, sessionID, turnID, notLatest string) (messagepkg.HistoryTurn, error) {
 	if s == nil || s.messageService == nil {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, errors.New("message service not configured")
+		return messagepkg.HistoryTurn{}, errors.New("message service not configured")
 	}
 	if sessionID == "" {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, errors.New("session id is required")
+		return messagepkg.HistoryTurn{}, errors.New("session id is required")
 	}
-	if messageID == "" {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, errors.New("message id is required")
+	if turnID == "" {
+		return messagepkg.HistoryTurn{}, errors.New("turn id is required")
 	}
-	turn, target, err := s.latestVisibleTurnAndMessage(ctx, sessionID, messageID)
+	latest, err := s.messageService.GetLatestVisibleTurnBySession(ctx, sessionID)
 	if err != nil {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, err
+		return messagepkg.HistoryTurn{}, fmt.Errorf("load latest visible turn: %w", err)
 	}
-	if !strings.EqualFold(target.Role, "user") {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, errors.New("only latest user messages can be edited")
+	if strings.TrimSpace(latest.ID) != turnID {
+		return messagepkg.HistoryTurn{}, errors.New(notLatest)
 	}
-	if strings.TrimSpace(turn.RequestMessageID) != target.ID {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, errors.New("edit target is not the request for its turn")
-	}
-	if err := s.ensureLatestVisibleTurn(ctx, sessionID, turn.ID); err != nil {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, errors.New("only the latest user message can be edited")
-	}
-	return turn, target, nil
-}
-
-func (s *Service) latestVisibleTurnAndMessage(ctx context.Context, sessionID, messageID string) (messagepkg.HistoryTurn, messagepkg.Message, error) {
-	target, err := s.messageService.GetByIDBySession(ctx, sessionID, messageID)
-	if err != nil {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, fmt.Errorf("load message: %w", err)
-	}
-	turn, err := s.messageService.GetVisibleTurnByMessage(ctx, sessionID, messageID)
-	if err != nil {
-		return messagepkg.HistoryTurn{}, messagepkg.Message{}, fmt.Errorf("load visible turn: %w", err)
-	}
-	return turn, target, nil
+	return latest, nil
 }
 
 func (s *Service) ensureLatestVisibleTurn(ctx context.Context, sessionID, turnID string) error {
-	latest, err := s.messageService.GetLatestVisibleTurnBySession(ctx, sessionID)
-	if err != nil {
-		return fmt.Errorf("load latest visible turn: %w", err)
-	}
-	if strings.TrimSpace(latest.ID) != strings.TrimSpace(turnID) {
-		return errors.New("turn is not latest")
-	}
-	return nil
+	_, err := s.resolveLatestVisibleTurn(ctx, sessionID, strings.TrimSpace(turnID), "turn is not latest")
+	return err
 }
 
 func (s *Service) streamReplacementWS(

--- a/internal/agent/application/service_retry_edit_test.go
+++ b/internal/agent/application/service_retry_edit_test.go
@@ -21,17 +21,7 @@ type forkAnchorMessageService struct {
 
 type replacementOperationMessageService struct {
 	recordingMessageService
-	target messagepkg.Message
-	turn   messagepkg.HistoryTurn
 	latest messagepkg.HistoryTurn
-}
-
-func (s *replacementOperationMessageService) GetByIDBySession(context.Context, string, string) (messagepkg.Message, error) {
-	return s.target, nil
-}
-
-func (s *replacementOperationMessageService) GetVisibleTurnByMessage(context.Context, string, string) (messagepkg.HistoryTurn, error) {
-	return s.turn, nil
 }
 
 func (s *replacementOperationMessageService) GetLatestVisibleTurnBySession(context.Context, string) (messagepkg.HistoryTurn, error) {
@@ -39,19 +29,17 @@ func (s *replacementOperationMessageService) GetLatestVisibleTurnBySession(conte
 }
 
 func TestPrepareReplacementOperationUsesPersistedTurnBoundary(t *testing.T) {
-	t.Run("retry begins at first assistant message", func(t *testing.T) {
+	t.Run("retry begins at the turn's own assistant anchor", func(t *testing.T) {
 		messages := &replacementOperationMessageService{
-			target: messagepkg.Message{ID: "assistant-result", Role: "assistant"},
-			turn: messagepkg.HistoryTurn{
+			latest: messagepkg.HistoryTurn{
 				ID:                 "turn-old",
 				RequestMessageID:   "user-request",
 				AssistantMessageID: "assistant-first",
 			},
-			latest: messagepkg.HistoryTurn{ID: "turn-old"},
 		}
 		service := &Service{messageService: messages}
 
-		got, err := service.PrepareRetryLatestMessageOperation(context.Background(), "session-1", "assistant-result")
+		got, err := service.PrepareRetryLatestTurnOperation(context.Background(), "session-1", "turn-old")
 		if err != nil {
 			t.Fatalf("prepare retry operation: %v", err)
 		}
@@ -62,16 +50,14 @@ func TestPrepareReplacementOperationUsesPersistedTurnBoundary(t *testing.T) {
 
 	t.Run("edit begins at persisted request message", func(t *testing.T) {
 		messages := &replacementOperationMessageService{
-			target: messagepkg.Message{ID: "user-request", Role: "user"},
-			turn: messagepkg.HistoryTurn{
+			latest: messagepkg.HistoryTurn{
 				ID:               "turn-old",
 				RequestMessageID: "user-request",
 			},
-			latest: messagepkg.HistoryTurn{ID: "turn-old"},
 		}
 		service := &Service{messageService: messages}
 
-		got, err := service.PrepareEditLatestMessageOperation(context.Background(), "session-1", "user-request")
+		got, err := service.PrepareEditLatestTurnOperation(context.Background(), "session-1", "turn-old")
 		if err != nil {
 			t.Fatalf("prepare edit operation: %v", err)
 		}
@@ -80,18 +66,44 @@ func TestPrepareReplacementOperationUsesPersistedTurnBoundary(t *testing.T) {
 		}
 	})
 
-	t.Run("retry rejects a turn without its canonical assistant anchor", func(t *testing.T) {
+	// The turn id is the whole validation: a client that names an older round
+	// is refused without ever naming a stored message.
+	t.Run("a turn that is no longer the latest is refused", func(t *testing.T) {
 		messages := &replacementOperationMessageService{
-			target: messagepkg.Message{ID: "assistant-result", Role: "assistant"},
-			turn: messagepkg.HistoryTurn{
-				ID:               "turn-old",
-				RequestMessageID: "user-request",
+			latest: messagepkg.HistoryTurn{
+				ID:                 "turn-new",
+				RequestMessageID:   "user-request",
+				AssistantMessageID: "assistant-first",
 			},
-			latest: messagepkg.HistoryTurn{ID: "turn-old"},
 		}
 		service := &Service{messageService: messages}
 
-		_, err := service.PrepareRetryLatestMessageOperation(context.Background(), "session-1", "assistant-result")
+		if _, err := service.PrepareRetryLatestTurnOperation(context.Background(), "session-1", "turn-old"); err == nil {
+			t.Fatal("prepare retry operation on a superseded turn: want error")
+		}
+		if _, err := service.PrepareEditLatestTurnOperation(context.Background(), "session-1", "turn-old"); err == nil {
+			t.Fatal("prepare edit operation on a superseded turn: want error")
+		}
+	})
+
+	t.Run("an unnamed turn is refused before any lookup", func(t *testing.T) {
+		service := &Service{messageService: &replacementOperationMessageService{}}
+
+		if _, err := service.PrepareRetryLatestTurnOperation(context.Background(), "session-1", "  "); err == nil {
+			t.Fatal("prepare retry operation without a turn id: want error")
+		}
+	})
+
+	t.Run("retry rejects a turn without its canonical assistant anchor", func(t *testing.T) {
+		messages := &replacementOperationMessageService{
+			latest: messagepkg.HistoryTurn{
+				ID:               "turn-old",
+				RequestMessageID: "user-request",
+			},
+		}
+		service := &Service{messageService: messages}
+
+		_, err := service.PrepareRetryLatestTurnOperation(context.Background(), "session-1", "turn-old")
 		if got := apperror.CodeOf(err); got != apperror.CodeSessionHistoryInconsistent {
 			t.Fatalf("error code = %q, want %q", got, apperror.CodeSessionHistoryInconsistent)
 		}

--- a/internal/chat/thread/service.go
+++ b/internal/chat/thread/service.go
@@ -234,7 +234,7 @@ type Queries interface {
 	CreateSession(context.Context, sqlc.CreateSessionParams) (sqlc.BotSession, error)
 	CreateSubagentConfig(context.Context, sqlc.CreateSubagentConfigParams) (sqlc.SubagentConfig, error)
 	CreateSubagentForkContext(context.Context, sqlc.CreateSubagentForkContextParams) (sqlc.CreateSubagentForkContextRow, error)
-	ForkSessionFromAssistantMessage(context.Context, sqlc.ForkSessionFromAssistantMessageParams) (sqlc.ForkSessionFromAssistantMessageRow, error)
+	ForkSessionFromAssistantTurn(context.Context, sqlc.ForkSessionFromAssistantTurnParams) (sqlc.ForkSessionFromAssistantTurnRow, error)
 	GetBotByID(context.Context, pgtype.UUID) (sqlc.GetBotByIDRow, error)
 	GetSessionByID(context.Context, pgtype.UUID) (sqlc.BotSession, error)
 	GetSubagentConfig(context.Context, pgtype.UUID) (sqlc.SubagentConfig, error)
@@ -255,9 +255,12 @@ type Queries interface {
 // ForkFromAssistantInput creates a new chat thread from the source thread's
 // visible history through the assistant message's turn.
 type ForkFromAssistantInput struct {
-	BotID           string
-	ThreadID        string
-	MessageID       string
+	BotID    string
+	ThreadID string
+	// TurnID names the round the fork inherits through. A turn is the identity
+	// a client holds while the round is still live, and the cut is turn-level
+	// anyway, so the fork point is named by turn rather than by stored message.
+	TurnID          string
 	Title           string
 	CreatedByUserID string
 }
@@ -598,7 +601,7 @@ func (s *Service) ListSubagentForkContext(ctx context.Context, sessionID string)
 
 // ForkFromAssistantMessage creates a new chat thread containing the source
 // thread's visible linear history through the selected assistant turn.
-func (s *Service) ForkFromAssistantMessage(ctx context.Context, input ForkFromAssistantInput) (Thread, error) {
+func (s *Service) ForkFromAssistantTurn(ctx context.Context, input ForkFromAssistantInput) (Thread, error) {
 	pgBotID, err := dbpkg.ParseUUID(input.BotID)
 	if err != nil {
 		return Thread{}, fmt.Errorf("invalid bot id: %w", err)
@@ -607,9 +610,9 @@ func (s *Service) ForkFromAssistantMessage(ctx context.Context, input ForkFromAs
 	if err != nil {
 		return Thread{}, fmt.Errorf("invalid session id: %w", err)
 	}
-	pgMessageID, err := dbpkg.ParseUUID(input.MessageID)
+	pgTurnID, err := dbpkg.ParseUUID(input.TurnID)
 	if err != nil {
-		return Thread{}, fmt.Errorf("invalid message id: %w", err)
+		return Thread{}, fmt.Errorf("invalid turn id: %w", err)
 	}
 	pgCreatedByUserID, err := parseOptionalUUID(input.CreatedByUserID)
 	if err != nil {
@@ -648,17 +651,16 @@ func (s *Service) ForkFromAssistantMessage(ctx context.Context, input ForkFromAs
 	meta["forked_from"] = map[string]any{
 		"session_id": source.ID,
 		"title":      title,
-		"message_id": pgMessageID.String(),
 	}
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
 		return Thread{}, fmt.Errorf("marshal metadata: %w", err)
 	}
 
-	row, err := s.queries.ForkSessionFromAssistantMessage(ctx, sqlc.ForkSessionFromAssistantMessageParams{
+	row, err := s.queries.ForkSessionFromAssistantTurn(ctx, sqlc.ForkSessionFromAssistantTurnParams{
 		SessionID:       pgSessionID,
 		BotID:           pgBotID,
-		MessageID:       pgMessageID,
+		TurnID:          pgTurnID,
 		Title:           forkTitle,
 		Metadata:        metaBytes,
 		CreatedByUserID: pgCreatedByUserID,
@@ -1413,7 +1415,7 @@ func toSubagentConfig(row sqlc.SubagentConfig) SubagentConfig {
 	}
 }
 
-func toThreadFromForkRow(row sqlc.ForkSessionFromAssistantMessageRow) Thread {
+func toThreadFromForkRow(row sqlc.ForkSessionFromAssistantTurnRow) Thread {
 	return toThread(sqlc.BotSession(row))
 }
 

--- a/internal/chat/thread/service_postgres_integration_test.go
+++ b/internal/chat/thread/service_postgres_integration_test.go
@@ -16,21 +16,21 @@ import (
 	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
 )
 
-func TestPostgresForkFromAssistantMessageCopiesVisibleTurns(t *testing.T) {
+func TestPostgresForkFromAssistantTurnCopiesVisibleTurns(t *testing.T) {
 	ctx := context.Background()
 	tx := beginPostgresSessionTestTx(t, ctx)
 	setupPostgresSessionForkFixtures(t, ctx, tx)
 
 	svc := NewService(nil, postgresstore.NewQueries(dbsqlc.New(tx)), nil)
-	fork, err := svc.ForkFromAssistantMessage(ctx, ForkFromAssistantInput{
+	fork, err := svc.ForkFromAssistantTurn(ctx, ForkFromAssistantInput{
 		BotID:           postgresSessionTestBotID,
 		ThreadID:        postgresSessionTestSessionID,
-		MessageID:       postgresSessionTestAssistant2ID,
+		TurnID:          postgresSessionTestTurn2ID,
 		Title:           "Forked",
 		CreatedByUserID: postgresSessionTestUserID,
 	})
 	if err != nil {
-		t.Fatalf("fork assistant message: %v", err)
+		t.Fatalf("fork assistant turn: %v", err)
 	}
 
 	forkedFrom, ok := fork.Metadata["forked_from"].(map[string]any)
@@ -313,7 +313,7 @@ func TestPostgresCreateSubagentStoresForkContextAsHiddenHistory(t *testing.T) {
 	}
 }
 
-func TestPostgresForkFromAssistantMessageRejectsInvalidTargetWithoutSideEffects(t *testing.T) {
+func TestPostgresForkFromAssistantTurnRejectsInvalidTargetWithoutSideEffects(t *testing.T) {
 	ctx := context.Background()
 	tx := beginPostgresSessionTestTx(t, ctx)
 	setupPostgresSessionForkFixtures(t, ctx, tx)
@@ -322,15 +322,15 @@ func TestPostgresForkFromAssistantMessageRejectsInvalidTargetWithoutSideEffects(
 	beforeSessions := countPostgresSessionTestRows(t, ctx, tx, "bot_sessions")
 	beforeMessages := countPostgresSessionTestRows(t, ctx, tx, "bot_history_messages")
 
-	for _, messageID := range []string{postgresSessionTestUser1ID, postgresSessionTestHiddenAssistantID} {
-		_, err := svc.ForkFromAssistantMessage(ctx, ForkFromAssistantInput{
-			BotID:     postgresSessionTestBotID,
-			ThreadID:  postgresSessionTestSessionID,
-			MessageID: messageID,
-			Title:     "Should Not Exist",
+	for _, turnID := range []string{postgresSessionTestHiddenTurnID, postgresSessionTestUnknownTurnID} {
+		_, err := svc.ForkFromAssistantTurn(ctx, ForkFromAssistantInput{
+			BotID:    postgresSessionTestBotID,
+			ThreadID: postgresSessionTestSessionID,
+			TurnID:   turnID,
+			Title:    "Should Not Exist",
 		})
 		if !errors.Is(err, ErrForkSourceNotReply) {
-			t.Fatalf("fork invalid message %s error = %v, want ErrForkSourceNotReply", messageID, err)
+			t.Fatalf("fork invalid turn %s error = %v, want ErrForkSourceNotReply", turnID, err)
 		}
 
 		if got := countPostgresSessionTestRows(t, ctx, tx, "bot_sessions"); got != beforeSessions {
@@ -785,6 +785,9 @@ const (
 	postgresSessionTestUser2ID           = "00000000-0000-0000-0000-000000075113"
 	postgresSessionTestAssistant2ID      = "00000000-0000-0000-0000-000000075114"
 	postgresSessionTestHiddenAssistantID = "00000000-0000-0000-0000-000000075115"
+	postgresSessionTestTurn2ID           = "00000000-0000-0000-0000-000000075202"
+	postgresSessionTestHiddenTurnID      = "00000000-0000-0000-0000-000000075203"
+	postgresSessionTestUnknownTurnID     = "00000000-0000-0000-0000-000000075299"
 )
 
 func beginPostgresSessionTestTx(t *testing.T, ctx context.Context) pgx.Tx {

--- a/internal/db/postgres/sqlc/sessions.sql.go
+++ b/internal/db/postgres/sqlc/sessions.sql.go
@@ -139,7 +139,7 @@ func (q *Queries) DeleteSessionDiscussCursorsByBot(ctx context.Context, botID pg
 	return err
 }
 
-const forkSessionFromAssistantMessage = `-- name: ForkSessionFromAssistantMessage :one
+const forkSessionFromAssistantTurn = `-- name: ForkSessionFromAssistantTurn :one
 WITH source_session AS (
   SELECT s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.visibility, s.title, s.metadata, s.next_turn_position, s.compaction_epoch, s.runtime_fencing_token, s.runtime_reset_token, s.runtime_reset_expires_at, s.runtime_config_epoch, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at, s.team_id, s.workdir_id, s.bot_agent_id
   FROM bot_sessions s
@@ -157,10 +157,9 @@ target_turn AS (
   FROM source_session s
   JOIN bot_visible_history_messages vm ON vm.team_id = public.memoh_current_team_id()
     AND vm.session_id = s.id
-    AND vm.id = $3
+    AND vm.turn_id = $3
     AND vm.role = 'assistant'
-    AND vm.turn_id IS NOT NULL
-    AND vm.turn_position IS NOT NULL
+  ORDER BY vm.turn_message_seq ASC, vm.created_at ASC, vm.id ASC
   LIMIT 1
 ),
 copy_messages AS (
@@ -221,9 +220,11 @@ fork_plan AS (
   SELECT
     s.id, s.bot_id, s.route_id, s.channel_type, s.type, s.session_mode, s.runtime_type, s.runtime_metadata, s.visibility, s.title, s.metadata, s.next_turn_position, s.compaction_epoch, s.runtime_fencing_token, s.runtime_reset_token, s.runtime_reset_expires_at, s.runtime_config_epoch, s.parent_session_id, s.created_by_user_id, s.created_at, s.updated_at, s.deleted_at, s.team_id, s.workdir_id, s.bot_agent_id,
     fam.new_message_id AS fork_message_id,
+    tt.message_id AS source_message_id,
     ntp.value AS next_turn_position_value
   FROM source_session s
   JOIN fork_anchor_message fam ON true
+  JOIN target_turn tt ON true
   CROSS JOIN next_turn_position ntp
   WHERE EXISTS (SELECT 1 FROM copy_turns)
 ),
@@ -257,7 +258,10 @@ created_session AS (
     jsonb_set(
       pm.value,
       '{forked_from}',
-      COALESCE(pm.value->'forked_from', '{}'::jsonb) || jsonb_build_object('fork_message_id', fp.fork_message_id::text),
+      COALESCE(pm.value->'forked_from', '{}'::jsonb) || jsonb_build_object(
+        'message_id', fp.source_message_id::text,
+        'fork_message_id', fp.fork_message_id::text
+      ),
       true
     ),
     fp.next_turn_position_value,
@@ -351,16 +355,16 @@ FROM created_session cs
 CROSS JOIN (SELECT count(*) AS copied_asset_count FROM copied_assets) copied_asset_counts
 `
 
-type ForkSessionFromAssistantMessageParams struct {
+type ForkSessionFromAssistantTurnParams struct {
 	SessionID       pgtype.UUID `json:"session_id"`
 	BotID           pgtype.UUID `json:"bot_id"`
-	MessageID       pgtype.UUID `json:"message_id"`
+	TurnID          pgtype.UUID `json:"turn_id"`
 	Metadata        []byte      `json:"metadata"`
 	Title           string      `json:"title"`
 	CreatedByUserID pgtype.UUID `json:"created_by_user_id"`
 }
 
-type ForkSessionFromAssistantMessageRow struct {
+type ForkSessionFromAssistantTurnRow struct {
 	ID                    pgtype.UUID        `json:"id"`
 	BotID                 pgtype.UUID        `json:"bot_id"`
 	RouteID               pgtype.UUID        `json:"route_id"`
@@ -388,16 +392,16 @@ type ForkSessionFromAssistantMessageRow struct {
 	BotAgentID            pgtype.UUID        `json:"bot_agent_id"`
 }
 
-func (q *Queries) ForkSessionFromAssistantMessage(ctx context.Context, arg ForkSessionFromAssistantMessageParams) (ForkSessionFromAssistantMessageRow, error) {
-	row := q.db.QueryRow(ctx, forkSessionFromAssistantMessage,
+func (q *Queries) ForkSessionFromAssistantTurn(ctx context.Context, arg ForkSessionFromAssistantTurnParams) (ForkSessionFromAssistantTurnRow, error) {
+	row := q.db.QueryRow(ctx, forkSessionFromAssistantTurn,
 		arg.SessionID,
 		arg.BotID,
-		arg.MessageID,
+		arg.TurnID,
 		arg.Metadata,
 		arg.Title,
 		arg.CreatedByUserID,
 	)
-	var i ForkSessionFromAssistantMessageRow
+	var i ForkSessionFromAssistantTurnRow
 	err := row.Scan(
 		&i.ID,
 		&i.BotID,

--- a/internal/db/store/queries.go
+++ b/internal/db/store/queries.go
@@ -104,7 +104,7 @@ type Queries interface {
 	CreateScheduleLog(ctx context.Context, arg dbsqlc.CreateScheduleLogParams) (dbsqlc.CreateScheduleLogRow, error)
 	CreateSearchProvider(ctx context.Context, arg dbsqlc.CreateSearchProviderParams) (dbsqlc.SearchProvider, error)
 	CreateSession(ctx context.Context, arg dbsqlc.CreateSessionParams) (dbsqlc.BotSession, error)
-	ForkSessionFromAssistantMessage(ctx context.Context, arg dbsqlc.ForkSessionFromAssistantMessageParams) (dbsqlc.ForkSessionFromAssistantMessageRow, error)
+	ForkSessionFromAssistantTurn(ctx context.Context, arg dbsqlc.ForkSessionFromAssistantTurnParams) (dbsqlc.ForkSessionFromAssistantTurnRow, error)
 	CreateSessionEvent(ctx context.Context, arg dbsqlc.CreateSessionEventParams) (pgtype.UUID, error)
 	CreateStorageProvider(ctx context.Context, arg dbsqlc.CreateStorageProviderParams) (dbsqlc.StorageProvider, error)
 	CreateSubagentConfig(ctx context.Context, arg dbsqlc.CreateSubagentConfigParams) (dbsqlc.SubagentConfig, error)

--- a/internal/handlers/local_channel.go
+++ b/internal/handlers/local_channel.go
@@ -882,13 +882,17 @@ var wsUpgrader = websocket.Upgrader{
 // that already exists, which is why abort and decision responses carry it. A
 // client can never name a run it has not been told about.
 type wsClientMessage struct {
-	Type              string                     `json:"type"`
-	RunID             string                     `json:"run_id,omitempty"`
-	Text              string                     `json:"text,omitempty"`
-	SessionID         string                     `json:"session_id,omitempty"`
-	InvocationID      string                     `json:"invocation_id,omitempty"`
-	ComposerScope     string                     `json:"composer_scope,omitempty"`
-	MessageID         string                     `json:"message_id,omitempty"`
+	Type          string `json:"type"`
+	RunID         string `json:"run_id,omitempty"`
+	Text          string `json:"text,omitempty"`
+	SessionID     string `json:"session_id,omitempty"`
+	InvocationID  string `json:"invocation_id,omitempty"`
+	ComposerScope string `json:"composer_scope,omitempty"`
+	// TurnID names an existing turn the client wants replaced (retry, edit).
+	// It is a turn rather than a message because the client holds a turn id
+	// from admission onward, while a stored message id only exists once the
+	// round has been persisted.
+	TurnID            string                     `json:"turn_id,omitempty"`
 	Attachments       []json.RawMessage          `json:"attachments,omitempty"`
 	RequestedSkills   []webRequestedSkill        `json:"requested_skills,omitempty"`
 	ModelID           string                     `json:"model_id,omitempty"`
@@ -1395,7 +1399,7 @@ type wsSubmission struct {
 	Kind      string `json:"kind"`
 	SessionID string `json:"session_id"`
 	Text      string `json:"text,omitempty"`
-	MessageID string `json:"message_id,omitempty"`
+	TurnID    string `json:"turn_id,omitempty"`
 	// Attachments is a digest rather than the files themselves. Two submissions
 	// differ if their attachments differ, which is all the fingerprint needs,
 	// and the durable row does not carry inlined uploads to learn it.
@@ -1423,7 +1427,7 @@ func digestWSAttachments(attachments []json.RawMessage) string {
 func (s wsSubmission) encode() []byte {
 	payload, err := json.Marshal(s)
 	if err != nil {
-		return []byte(s.Kind + "\x00" + s.SessionID + "\x00" + s.Text + "\x00" + s.MessageID)
+		return []byte(s.Kind + "\x00" + s.SessionID + "\x00" + s.Text + "\x00" + s.TurnID)
 	}
 	return payload
 }
@@ -2288,7 +2292,7 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 		case "retry_message":
 			sessionID := strings.TrimSpace(msg.SessionID)
 			ref := wsTurn(msg.InvocationID, sessionID)
-			messageID := strings.TrimSpace(msg.MessageID)
+			targetTurnID := strings.TrimSpace(msg.TurnID)
 			workspaceTargetID := strings.TrimSpace(msg.WorkspaceTargetID)
 			if ref.InvocationID == "" {
 				sendWSError(writer, ref, "invocation_id is required")
@@ -2298,8 +2302,8 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 				sendWSError(writer, ref, "session_id is required")
 				continue
 			}
-			if messageID == "" {
-				sendWSError(writer, ref, "message_id is required")
+			if targetTurnID == "" {
+				sendWSError(writer, ref, "turn_id is required")
 				continue
 			}
 			if err := h.authorizeWSSession(c.Request().Context(), channelIdentityID, botID, sessionID); err != nil {
@@ -2320,12 +2324,12 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 			retrySubmission := wsSubmission{
 				Kind:      "retry_message",
 				SessionID: sessionID,
-				MessageID: messageID,
+				TurnID:    targetTurnID,
 			}.encode()
 			retryInput := application.RetryLatestMessageInput{
 				BotID:                  botID,
 				SessionID:              sessionID,
-				MessageID:              messageID,
+				TargetTurnID:           targetTurnID,
 				ActorChannelIdentityID: channelIdentityID,
 				ActorUserID:            channelIdentityID,
 				ChatToken:              bearerToken,
@@ -2337,7 +2341,7 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 			retryAdmission := &wsReplacementAdmission{
 				kind: sessionruntime.RunOperationRetry,
 				prepareAnchor: func(ctx context.Context) (string, error) {
-					return h.agentService.PrepareRetryLatestMessageOperation(ctx, sessionID, messageID)
+					return h.agentService.PrepareRetryLatestTurnOperation(ctx, sessionID, targetTurnID)
 				},
 			}
 			h.startWSStream(streamBaseCtx, connCtx, writer, botID, ref, "ws retry stream error", retrySubmission, retryAdmission.build, nil,
@@ -2354,7 +2358,7 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 			text := strings.TrimSpace(msg.Text)
 			sessionID := strings.TrimSpace(msg.SessionID)
 			ref := wsTurn(msg.InvocationID, sessionID)
-			messageID := strings.TrimSpace(msg.MessageID)
+			targetTurnID := strings.TrimSpace(msg.TurnID)
 			workspaceTargetID := strings.TrimSpace(msg.WorkspaceTargetID)
 			if ref.InvocationID == "" {
 				sendWSError(writer, ref, "invocation_id is required")
@@ -2364,8 +2368,8 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 				sendWSError(writer, ref, "session_id is required")
 				continue
 			}
-			if messageID == "" {
-				sendWSError(writer, ref, "message_id is required")
+			if targetTurnID == "" {
+				sendWSError(writer, ref, "turn_id is required")
 				continue
 			}
 			chatAttachments, attachmentErr := parseWSClientAttachments(msg.Attachments)
@@ -2400,13 +2404,13 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 				Kind:        "edit_message",
 				SessionID:   sessionID,
 				Text:        text,
-				MessageID:   messageID,
+				TurnID:      targetTurnID,
 				Attachments: digestWSAttachments(msg.Attachments),
 			}.encode()
 			editInput := application.EditLatestMessageInput{
 				BotID:                  botID,
 				SessionID:              sessionID,
-				MessageID:              messageID,
+				TargetTurnID:           targetTurnID,
 				Text:                   text,
 				ActorChannelIdentityID: channelIdentityID,
 				ActorUserID:            channelIdentityID,
@@ -2421,7 +2425,7 @@ func (h *LocalChannelHandler) HandleWebSocket(c echo.Context) error {
 				botID:   botID,
 				kind:    sessionruntime.RunOperationEdit,
 				prepareAnchor: func(ctx context.Context) (string, error) {
-					return h.agentService.PrepareEditLatestMessageOperation(ctx, sessionID, messageID)
+					return h.agentService.PrepareEditLatestTurnOperation(ctx, sessionID, targetTurnID)
 				},
 				replacementUserTurn: &chatview.UITurn{
 					Role:         "user",

--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -137,8 +137,8 @@ type updateSessionRequest struct {
 }
 
 type forkSessionRequest struct {
-	MessageID string `json:"message_id" validate:"required"`
-	Title     string `json:"title,omitempty"`
+	TurnID string `json:"turn_id" validate:"required" format:"uuid"`
+	Title  string `json:"title,omitempty"`
 }
 
 // CreateSession godoc
@@ -282,7 +282,7 @@ func (h *SessionHandler) CreateSession(c echo.Context) error {
 // @Tags sessions
 // @Param bot_id path string true "Bot ID"
 // @Param session_id path string true "Source session ID"
-// @Param body body forkSessionRequest true "Fork source message"
+// @Param body body forkSessionRequest true "Fork source turn"
 // @Success 201 {object} session.Thread
 // @Failure 400 {object} ErrorResponse
 // @Failure 403 {object} ErrorResponse
@@ -314,18 +314,18 @@ func (h *SessionHandler) ForkSession(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	messageID := strings.TrimSpace(req.MessageID)
-	if messageID == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "message_id is required")
+	turnID := strings.TrimSpace(req.TurnID)
+	if turnID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "turn_id is required")
 	}
-	if _, err := uuid.Parse(messageID); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid message_id")
+	if _, err := uuid.Parse(turnID); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid turn_id")
 	}
 
-	forked, err := h.sessionService.ForkFromAssistantMessage(c.Request().Context(), session.ForkFromAssistantInput{
+	forked, err := h.sessionService.ForkFromAssistantTurn(c.Request().Context(), session.ForkFromAssistantInput{
 		BotID:           bot.ID,
 		ThreadID:        source.ID,
-		MessageID:       messageID,
+		TurnID:          turnID,
 		Title:           strings.TrimSpace(req.Title),
 		CreatedByUserID: channelIdentityID,
 	})

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -2476,8 +2476,8 @@ export type HandlersEmailOAuthStatusResponse = {
 };
 
 export type HandlersForkSessionRequest = {
-    message_id: string;
     title?: string;
+    turn_id: string;
 };
 
 export type HandlersFsOpResponse = {
@@ -9815,7 +9815,7 @@ export type GetBotsByBotIdSessionsBySessionIdContextLifecycleResponse = GetBotsB
 
 export type PostBotsByBotIdSessionsBySessionIdForkData = {
     /**
-     * Fork source message
+     * Fork source turn
      */
     body: HandlersForkSessionRequest;
     path: {

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -7743,7 +7743,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Fork source message",
+                        "description": "Fork source turn",
                         "name": "body",
                         "in": "body",
                         "required": true,
@@ -21549,14 +21549,15 @@ const docTemplate = `{
         "handlers.forkSessionRequest": {
             "type": "object",
             "required": [
-                "message_id"
+                "turn_id"
             ],
             "properties": {
-                "message_id": {
-                    "type": "string"
-                },
                 "title": {
                     "type": "string"
+                },
+                "turn_id": {
+                    "type": "string",
+                    "format": "uuid"
                 }
             }
         },

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -7734,7 +7734,7 @@
                         "required": true
                     },
                     {
-                        "description": "Fork source message",
+                        "description": "Fork source turn",
                         "name": "body",
                         "in": "body",
                         "required": true,
@@ -21540,14 +21540,15 @@
         "handlers.forkSessionRequest": {
             "type": "object",
             "required": [
-                "message_id"
+                "turn_id"
             ],
             "properties": {
-                "message_id": {
-                    "type": "string"
-                },
                 "title": {
                     "type": "string"
+                },
+                "turn_id": {
+                    "type": "string",
+                    "format": "uuid"
                 }
             }
         },

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -4357,12 +4357,13 @@ definitions:
     type: object
   handlers.forkSessionRequest:
     properties:
-      message_id:
-        type: string
       title:
         type: string
+      turn_id:
+        format: uuid
+        type: string
     required:
-    - message_id
+    - turn_id
     type: object
   handlers.fsOpResponse:
     properties:
@@ -11183,7 +11184,7 @@ paths:
         name: session_id
         required: true
         type: string
-      - description: Fork source message
+      - description: Fork source turn
         in: body
         name: body
         required: true


### PR DESCRIPTION
## Summary

Retry, edit and fork asked the client for a **database message id**. A client only holds one after the round has been persisted *and* fetched back — so between a turn ending and its REST twin arriving, the on-screen turn carries only a render identity (`1787820846874-502`, `runtime:<turn-id>:user`). Sending that across a persistence boundary produced `load message: invalid UUID` on retry/edit and HTTP 400 on the older-history cursor.

This names the **turn** instead. A turn id is minted at admission and reaches the client while the run is still streaming — exactly the window the old contract could not express.

## Root cause

The message id was never what these operations needed. All three are turn-scoped at the storage layer and convert the message id into a turn immediately, then discard it:

| Operation | What it did with `message_id` | What it actually used |
|---|---|---|
| retry (`service_retry_edit.go`) | load message → get its turn → assert turn is the session's latest visible | `turn.RequestMessageID` / `turn.AssistantMessageID` |
| edit | same, plus "the message you named must be this turn's request" | the same turn |
| fork (`sessions.sql`) | `message_id` → `target_turn` | cut by `turn_position <= target` — a turn-level boundary |

So the client was made to produce an identity it does not have, to name something the server resolves to a turn anyway.

## What changed

**Backend**
- `retry_message` / `edit_message` take `turn_id`. `RetryLatestMessageInput` / `EditLatestMessageInput` gain `TargetTurnID`, deliberately distinct from `TurnID` (the *new* turn the operation admits).
- `resolveLatestVisibleTurn` replaces the message-lookup pair. Retry saves a `GetVisibleTurnByMessage` round trip; edit no longer loads the message at all.
- Edit's `"edit target is not the request for its turn"` check is **gone** — it existed only to confirm a client-named message really was its turn's request. Naming the turn makes it unrepresentable.
- `POST /bots/{bot_id}/sessions/{session_id}/fork` takes `turn_id`. `ForkSessionFromAssistantTurn` resolves the turn's leading assistant message inside the query, so `forked_from` keeps its stored shape (`message_id` + `fork_message_id`) and neither the fork-divider logic nor botbackup's id remapping changes.

**Frontend**
- Retry/edit/fork key on `turnId`. `findTurnByTurnId(turnId, role)` replaces `findTurnByServerId`: both halves of a round share one turn id, so the role is part of the lookup.
- The older-history cursor comes from the oldest turn the database has actually numbered, not blindly from `messages[0]`. `turn_position` is that signal — `bot_visible_history_messages` cannot return a row without one, and a live turn carries none until its settled twin arrives.
- Fixed a latent bug this surfaced: a runtime frame merging over a settled turn wiped `turnPosition`, because `Object.assign` copies the explicitly-present `undefined` key. The field had no readers before, so it never showed.

**Net effect:** the client no longer has to choose between two kinds of id, and the affordances are live as soon as the round exists rather than after its stored twin is fetched.

## Relationship to #1092

#1092 fixes the same bug by *hiding* retry/edit/fork until a canonical UUID is available, gating on a UUID-shaped regex. That is a correct stopgap and its `serverMessageId` → `messageIdentityId` rename is good hygiene, but it leaves the broken contract in place and couples the frontend to "persisted ids are UUIDs".

**These two are alternatives, not a stack.** If #1092 lands first this branch should be rebased onto it and `persistedMessageId` / `isPersistedMessageId` / the UUID regex deleted — turn-scoping makes them dead code. Happy to do that rebase either way; whichever order you prefer.

## ⚠️ Breaking change

`POST /bots/{bot_id}/sessions/{session_id}/fork` now requires `turn_id` instead of `message_id`. The WebSocket `retry_message` / `edit_message` frames likewise carry `turn_id`.

Clean cut rather than a deprecated alias: keeping `message_id` alive would keep the "name a stored row" path alive, which is the thing being removed. The spec and SDK are regenerated in this PR, and the only in-repo caller is the bundled web app. Say the word if you want a fallback for external SDK consumers.

## Validation

- `go build ./...` and `go test ./internal/...` — pass
- **Fork SQL exercised against a real Postgres.** The integration tests skip silently without `TEST_POSTGRES_DSN`, so they had not been covering the query. Ran them against a throwaway container migrated with the project's own `migrate up` (141 migrations): both fork tests pass — copying the visible turns through the target, and rejecting a hidden turn and an unknown turn with no side effects. Container removed afterwards; no dev database was touched.
- `pnpm exec vitest run --project web` — 1171 passed
- `pnpm lint` (golangci-lint + ESLint + UI contract guard) — clean
- `pnpm --filter @memohai/web typecheck` — output byte-identical to the base commit (the repo has 184 pre-existing errors; this PR adds none)
- Baseline check: `useMediaGallery`, `panel-preview` and one `internal/schedule` integration test fail with identical errors on the base commit

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
