### PR TITLE
fix(bot-agents): serialize default assignment with disable

### DIFF
--- a/db/postgres/queries/bot_agents.sql
+++ b/db/postgres/queries/bot_agents.sql
@@ -25,6 +25,13 @@ WHERE team_id = public.memoh_current_team_id()
   AND enabled
   AND deleted_at IS NULL;
 
+-- name: LockBotForAgentMutation :one
+SELECT id
+FROM bots
+WHERE team_id = public.memoh_current_team_id()
+  AND id = sqlc.arg(bot_id)
+FOR NO KEY UPDATE;
+
 -- name: ListBotAgents :many
 SELECT *
 FROM bot_agents

--- a/internal/botagents/service.go
+++ b/internal/botagents/service.go
@@ -15,6 +15,7 @@ import (
 	acpprofile "github.com/memohai/memoh/internal/agent/runtime/acp/profile"
 	"github.com/memohai/memoh/internal/db"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
 )
 
 var (
@@ -45,6 +46,11 @@ type queries interface {
 	ListBotAgents(context.Context, pgtype.UUID) ([]sqlc.BotAgent, error)
 	SoftDeleteBotAgent(context.Context, sqlc.SoftDeleteBotAgentParams) (sqlc.BotAgent, error)
 	UpdateBotAgent(context.Context, sqlc.UpdateBotAgentParams) (sqlc.BotAgent, error)
+}
+
+type transactionalQueries interface {
+	SupportsTransactions() bool
+	InTx(context.Context, func(dbstore.Queries) error) error
 }
 
 type Service struct {
@@ -186,24 +192,29 @@ func (s *Service) Update(ctx context.Context, botID, id string, req UpdateReques
 		enabled = *req.Enabled
 	}
 	pgBotID, pgID, _ := parseIDs(botID, id)
-	row, err := s.queries.UpdateBotAgent(ctx, sqlc.UpdateBotAgentParams{
-		Name:    name,
-		Enabled: enabled,
-		BotID:   pgBotID,
-		ID:      pgID,
-	})
-	if errors.Is(err, pgx.ErrNoRows) {
+	var row sqlc.BotAgent
+	err = s.withBotMutationLock(ctx, pgBotID, func(q queries) error {
+		var updateErr error
+		row, updateErr = q.UpdateBotAgent(ctx, sqlc.UpdateBotAgentParams{
+			Name:    name,
+			Enabled: enabled,
+			BotID:   pgBotID,
+			ID:      pgID,
+		})
+		if !errors.Is(updateErr, pgx.ErrNoRows) {
+			return updateErr
+		}
 		if !enabled {
-			isDefault, checkErr := s.queries.BotAgentIsDefault(ctx, sqlc.BotAgentIsDefaultParams{BotID: pgBotID, ID: pgID})
+			isDefault, checkErr := q.BotAgentIsDefault(ctx, sqlc.BotAgentIsDefaultParams{BotID: pgBotID, ID: pgID})
 			if checkErr != nil {
-				return BotAgent{}, checkErr
+				return checkErr
 			}
 			if isDefault {
-				return BotAgent{}, ErrDefaultInUse
+				return ErrDefaultInUse
 			}
 		}
-		return BotAgent{}, ErrNotFound
-	}
+		return ErrNotFound
+	})
 	if err != nil {
 		if db.IsUniqueViolation(err) {
 			return BotAgent{}, ErrNameTaken
@@ -218,9 +229,12 @@ func (s *Service) Delete(ctx context.Context, botID, id string) error {
 	if err != nil {
 		return ErrNotFound
 	}
-	_, err = s.queries.SoftDeleteBotAgent(ctx, sqlc.SoftDeleteBotAgentParams{BotID: pgBotID, ID: pgID})
-	if errors.Is(err, pgx.ErrNoRows) {
-		isDefault, checkErr := s.queries.BotAgentIsDefault(ctx, sqlc.BotAgentIsDefaultParams{BotID: pgBotID, ID: pgID})
+	return s.withBotMutationLock(ctx, pgBotID, func(q queries) error {
+		_, deleteErr := q.SoftDeleteBotAgent(ctx, sqlc.SoftDeleteBotAgentParams{BotID: pgBotID, ID: pgID})
+		if !errors.Is(deleteErr, pgx.ErrNoRows) {
+			return deleteErr
+		}
+		isDefault, checkErr := q.BotAgentIsDefault(ctx, sqlc.BotAgentIsDefaultParams{BotID: pgBotID, ID: pgID})
 		if checkErr != nil {
 			return checkErr
 		}
@@ -228,8 +242,24 @@ func (s *Service) Delete(ctx context.Context, botID, id string) error {
 			return ErrDefaultInUse
 		}
 		return ErrNotFound
+	})
+}
+
+// withBotMutationLock serializes Agent availability changes with default-Agent
+// assignment. Both paths lock the parent bot before reading or writing the
+// child Agent, so they share one lock order and cannot publish a disabled
+// default. Query-only test doubles retain the historical direct path.
+func (s *Service) withBotMutationLock(ctx context.Context, botID pgtype.UUID, fn func(queries) error) error {
+	txer, ok := s.queries.(transactionalQueries)
+	if !ok || !txer.SupportsTransactions() {
+		return fn(s.queries)
 	}
-	return err
+	return txer.InTx(ctx, func(q dbstore.Queries) error {
+		if _, err := q.LockBotForAgentMutation(ctx, botID); err != nil {
+			return err
+		}
+		return fn(q)
+	})
 }
 
 func DescriptorFor(agent BotAgent) (Descriptor, error) {

--- a/internal/botagents/service_test.go
+++ b/internal/botagents/service_test.go
@@ -40,7 +40,7 @@ type fakeQueries struct {
 
 func (f *fakeQueries) SupportsTransactions() bool { return f.transactions }
 
-func (f *fakeQueries) InTx(ctx context.Context, fn func(dbstore.Queries) error) error {
+func (f *fakeQueries) InTx(_ context.Context, fn func(dbstore.Queries) error) error {
 	f.events = append(f.events, "transaction")
 	return fn(f)
 }

--- a/internal/botagents/service_test.go
+++ b/internal/botagents/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
+	dbstore "github.com/memohai/memoh/internal/db/store"
 )
 
 const (
@@ -21,6 +22,7 @@ const (
 )
 
 type fakeQueries struct {
+	dbstore.Queries
 	createParams sqlc.CreateBotAgentParams
 	createRow    sqlc.BotAgent
 	createErr    error
@@ -31,6 +33,21 @@ type fakeQueries struct {
 	updateErr    error
 	deleteErr    error
 	isDefault    bool
+	transactions bool
+	lockErr      error
+	events       []string
+}
+
+func (f *fakeQueries) SupportsTransactions() bool { return f.transactions }
+
+func (f *fakeQueries) InTx(ctx context.Context, fn func(dbstore.Queries) error) error {
+	f.events = append(f.events, "transaction")
+	return fn(f)
+}
+
+func (f *fakeQueries) LockBotForAgentMutation(context.Context, pgtype.UUID) (pgtype.UUID, error) {
+	f.events = append(f.events, "lock-bot")
+	return testUUID(testBotID), f.lockErr
 }
 
 func (f *fakeQueries) BotAgentIsDefault(context.Context, sqlc.BotAgentIsDefaultParams) (bool, error) {
@@ -55,10 +72,12 @@ func (*fakeQueries) ListBotAgents(context.Context, pgtype.UUID) ([]sqlc.BotAgent
 }
 
 func (f *fakeQueries) SoftDeleteBotAgent(context.Context, sqlc.SoftDeleteBotAgentParams) (sqlc.BotAgent, error) {
+	f.events = append(f.events, "delete-agent")
 	return sqlc.BotAgent{}, f.deleteErr
 }
 
 func (f *fakeQueries) UpdateBotAgent(_ context.Context, params sqlc.UpdateBotAgentParams) (sqlc.BotAgent, error) {
+	f.events = append(f.events, "update-agent")
 	f.updateParams = params
 	return f.updateRow, f.updateErr
 }
@@ -140,6 +159,39 @@ func TestUpdateAndDeleteProtectDefaultAgent(t *testing.T) {
 	}
 	if err := service.Delete(context.Background(), testBotID, testAgentID); !errors.Is(err, ErrDefaultInUse) {
 		t.Fatalf("Delete() error = %v, want %v", err, ErrDefaultInUse)
+	}
+}
+
+func TestUpdateAndDeleteLockBotBeforeAgentMutation(t *testing.T) {
+	falseValue := false
+	updateFake := &fakeQueries{
+		getRow:       testRow(true),
+		updateRow:    testRow(false),
+		transactions: true,
+	}
+	if _, err := NewService(slog.Default(), updateFake).Update(
+		context.Background(), testBotID, testAgentID, UpdateRequest{Enabled: &falseValue},
+	); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	assertEvents(t, updateFake.events, []string{"transaction", "lock-bot", "update-agent"})
+
+	deleteFake := &fakeQueries{transactions: true}
+	if err := NewService(slog.Default(), deleteFake).Delete(context.Background(), testBotID, testAgentID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	assertEvents(t, deleteFake.events, []string{"transaction", "lock-bot", "delete-agent"})
+}
+
+func assertEvents(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("events = %v, want %v", got, want)
+		}
 	}
 }
 

--- a/internal/db/postgres/sqlc/bot_agents.sql.go
+++ b/internal/db/postgres/sqlc/bot_agents.sql.go
@@ -218,6 +218,21 @@ func (q *Queries) ListBotAgents(ctx context.Context, botID pgtype.UUID) ([]BotAg
 	return items, nil
 }
 
+const lockBotForAgentMutation = `-- name: LockBotForAgentMutation :one
+SELECT id
+FROM bots
+WHERE team_id = public.memoh_current_team_id()
+  AND id = $1
+FOR NO KEY UPDATE
+`
+
+func (q *Queries) LockBotForAgentMutation(ctx context.Context, botID pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, lockBotForAgentMutation, botID)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const softDeleteBotAgent = `-- name: SoftDeleteBotAgent :one
 UPDATE bot_agents
 SET enabled = false,

--- a/internal/db/store/queries.go
+++ b/internal/db/store/queries.go
@@ -172,6 +172,7 @@ type Queries interface {
 	GetBotAgentByID(ctx context.Context, arg dbsqlc.GetBotAgentByIDParams) (dbsqlc.BotAgent, error)
 	FindActiveBotAgentByRuntimeProvider(ctx context.Context, arg dbsqlc.FindActiveBotAgentByRuntimeProviderParams) (dbsqlc.BotAgent, error)
 	ListBotAgents(ctx context.Context, botID pgtype.UUID) ([]dbsqlc.BotAgent, error)
+	LockBotForAgentMutation(ctx context.Context, botID pgtype.UUID) (pgtype.UUID, error)
 	UpdateBotAgent(ctx context.Context, arg dbsqlc.UpdateBotAgentParams) (dbsqlc.BotAgent, error)
 	SoftDeleteBotAgent(ctx context.Context, arg dbsqlc.SoftDeleteBotAgentParams) (dbsqlc.BotAgent, error)
 	BotAgentIsDefault(ctx context.Context, arg dbsqlc.BotAgentIsDefaultParams) (bool, error)

--- a/internal/settings/default_agent_concurrency_postgres_integration_test.go
+++ b/internal/settings/default_agent_concurrency_postgres_integration_test.go
@@ -1,0 +1,269 @@
+//go:build integration
+
+package settings
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/memohai/memoh/internal/botagents"
+	dbpkg "github.com/memohai/memoh/internal/db"
+	"github.com/memohai/memoh/internal/db/dbtest"
+	dbsqlc "github.com/memohai/memoh/internal/db/postgres/sqlc"
+	postgresstore "github.com/memohai/memoh/internal/db/postgres/store"
+	dbstore "github.com/memohai/memoh/internal/db/store"
+	"github.com/memohai/memoh/internal/team"
+)
+
+var (
+	defaultAgentMigrationOnce sync.Once
+	defaultAgentMigrationErr  error
+)
+
+func TestDefaultAgentAssignmentSerializesWithDisableAndDelete(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	pool := openDefaultAgentPostgres(t, ctx)
+
+	for _, mutation := range []string{"disable", "delete"} {
+		mutation := mutation
+		t.Run(mutation+" wins the lock", func(t *testing.T) {
+			botID, agentID := createDefaultAgentFixture(t, ctx, pool)
+			mutationLocked := make(chan struct{})
+			releaseMutation := make(chan struct{})
+			setterEnteredTx := make(chan struct{})
+
+			mutationStore := newHookedAgentStore(pool, nil, mutationLocked, releaseMutation)
+			setterStore := newHookedAgentStore(pool, setterEnteredTx, nil, nil)
+			mutationService := botagents.NewService(slog.Default(), mutationStore)
+			setterService := newDefaultAgentSettingsService(setterStore)
+
+			mutationResult := make(chan error, 1)
+			go func() { mutationResult <- mutateAgent(ctx, mutationService, mutation, botID, agentID) }()
+			waitForAgentSignal(t, mutationLocked, "mutation to lock bot")
+
+			setterResult := make(chan error, 1)
+			go func() { setterResult <- setDefaultAgent(ctx, setterService, botID, agentID) }()
+			waitForAgentSignal(t, setterEnteredTx, "setter to finish its optimistic precheck")
+			close(releaseMutation)
+
+			if err := waitForAgentResult(t, mutationResult, "mutation"); err != nil {
+				t.Fatalf("%s error = %v", mutation, err)
+			}
+			if err := waitForAgentResult(t, setterResult, "setter"); !errors.Is(err, botagents.ErrUnavailable) {
+				t.Fatalf("setter error = %v, want %v", err, botagents.ErrUnavailable)
+			}
+			assertDefaultAgentState(t, ctx, pool, botID, agentID, false, false, mutation == "delete")
+		})
+
+		t.Run("assignment wins before "+mutation, func(t *testing.T) {
+			botID, agentID := createDefaultAgentFixture(t, ctx, pool)
+			setterLocked := make(chan struct{})
+			releaseSetter := make(chan struct{})
+			mutationEnteredTx := make(chan struct{})
+
+			setterStore := newHookedAgentStore(pool, nil, setterLocked, releaseSetter)
+			mutationStore := newHookedAgentStore(pool, mutationEnteredTx, nil, nil)
+			setterService := newDefaultAgentSettingsService(setterStore)
+			mutationService := botagents.NewService(slog.Default(), mutationStore)
+
+			setterResult := make(chan error, 1)
+			go func() { setterResult <- setDefaultAgent(ctx, setterService, botID, agentID) }()
+			waitForAgentSignal(t, setterLocked, "setter to lock bot")
+
+			mutationResult := make(chan error, 1)
+			go func() { mutationResult <- mutateAgent(ctx, mutationService, mutation, botID, agentID) }()
+			waitForAgentSignal(t, mutationEnteredTx, "mutation to finish its optimistic read")
+			close(releaseSetter)
+
+			if err := waitForAgentResult(t, setterResult, "setter"); err != nil {
+				t.Fatalf("setter error = %v", err)
+			}
+			if err := waitForAgentResult(t, mutationResult, "mutation"); !errors.Is(err, botagents.ErrDefaultInUse) {
+				t.Fatalf("%s error = %v, want %v", mutation, err, botagents.ErrDefaultInUse)
+			}
+			assertDefaultAgentState(t, ctx, pool, botID, agentID, true, true, false)
+		})
+	}
+}
+
+type hookedAgentStore struct {
+	dbstore.Queries
+	base        *postgresstore.Queries
+	enteredTx   chan struct{}
+	locked      chan struct{}
+	releaseLock <-chan struct{}
+	enteredOnce sync.Once
+	lockedOnce  sync.Once
+}
+
+func newHookedAgentStore(pool *pgxpool.Pool, enteredTx, locked chan struct{}, releaseLock <-chan struct{}) *hookedAgentStore {
+	base := postgresstore.NewQueriesWithPool(pool, dbsqlc.New(pool))
+	return &hookedAgentStore{
+		Queries:     base,
+		base:        base,
+		enteredTx:   enteredTx,
+		locked:      locked,
+		releaseLock: releaseLock,
+	}
+}
+
+func (*hookedAgentStore) SupportsTransactions() bool { return true }
+
+func (s *hookedAgentStore) InTx(ctx context.Context, fn func(dbstore.Queries) error) error {
+	return s.base.InTx(ctx, func(q dbstore.Queries) error {
+		if s.enteredTx != nil {
+			s.enteredOnce.Do(func() { close(s.enteredTx) })
+		}
+		return fn(&hookedAgentTxQueries{Queries: q, owner: s})
+	})
+}
+
+type hookedAgentTxQueries struct {
+	dbstore.Queries
+	owner *hookedAgentStore
+}
+
+func (q *hookedAgentTxQueries) LockBotForAgentMutation(ctx context.Context, botID pgtype.UUID) (pgtype.UUID, error) {
+	lockedID, err := q.Queries.LockBotForAgentMutation(ctx, botID)
+	if err != nil {
+		return pgtype.UUID{}, err
+	}
+	if q.owner.locked != nil {
+		q.owner.lockedOnce.Do(func() { close(q.owner.locked) })
+	}
+	if q.owner.releaseLock != nil {
+		select {
+		case <-q.owner.releaseLock:
+		case <-ctx.Done():
+			return pgtype.UUID{}, ctx.Err()
+		}
+	}
+	return lockedID, nil
+}
+
+func newDefaultAgentSettingsService(store dbstore.Queries) *Service {
+	agents := botagents.NewService(slog.Default(), store)
+	service := NewService(slog.Default(), store, nil, nil)
+	service.SetBotAgents(agents)
+	return service
+}
+
+func setDefaultAgent(ctx context.Context, service *Service, botID, agentID string) error {
+	_, err := service.UpsertBot(ctx, botID, UpsertRequest{DefaultBotAgentID: &agentID})
+	return err
+}
+
+func mutateAgent(ctx context.Context, service *botagents.Service, mutation, botID, agentID string) error {
+	if mutation == "delete" {
+		return service.Delete(ctx, botID, agentID)
+	}
+	enabled := false
+	_, err := service.Update(ctx, botID, agentID, botagents.UpdateRequest{Enabled: &enabled})
+	return err
+}
+
+func createDefaultAgentFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (string, string) {
+	t.Helper()
+	userID := uuid.New()
+	botID := uuid.New()
+	agentID := uuid.New()
+	name := "default-agent-race-" + uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		WITH created_user AS (
+			INSERT INTO users (id, username, is_active, metadata)
+			VALUES ($1, $2, true, '{}'::jsonb)
+			RETURNING id
+		), created_member AS (
+			INSERT INTO team_members (team_id, user_id, role)
+			SELECT $3, id, 'admin' FROM created_user
+			RETURNING user_id
+		), created_bot AS (
+			INSERT INTO bots (id, team_id, owner_user_id, name, status, metadata)
+			SELECT $4, $3, user_id, $2, 'ready',
+				'{"acp":{"agents":{"codex":{"enabled":true,"setup_mode":"self"}}}}'::jsonb
+			FROM created_member
+			RETURNING id
+		)
+		INSERT INTO bot_agents (id, team_id, bot_id, name, runtime, enabled, metadata)
+		SELECT $5, $3, id, 'Codex', 'acp', true, '{"provider":"codex"}'::jsonb
+		FROM created_bot`,
+		userID, name, team.DefaultTeamID, botID, agentID,
+	); err != nil {
+		t.Fatalf("create default Agent fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM bots WHERE id = $1", botID)
+		_, _ = pool.Exec(context.Background(), "DELETE FROM users WHERE id = $1", userID)
+	})
+	return botID.String(), agentID.String()
+}
+
+func assertDefaultAgentState(t *testing.T, ctx context.Context, pool *pgxpool.Pool, botID, agentID string, pointsToAgent, enabled, deleted bool) {
+	t.Helper()
+	var gotPointsToAgent, gotEnabled, gotDeleted bool
+	if err := pool.QueryRow(ctx, `
+		SELECT COALESCE(b.default_bot_agent_id = a.id, false), a.enabled, a.deleted_at IS NOT NULL
+		FROM bots b
+		JOIN bot_agents a ON a.bot_id = b.id
+		WHERE b.id = $1 AND a.id = $2`, botID, agentID,
+	).Scan(&gotPointsToAgent, &gotEnabled, &gotDeleted); err != nil {
+		t.Fatalf("read default Agent state: %v", err)
+	}
+	if gotPointsToAgent != pointsToAgent || gotEnabled != enabled || gotDeleted != deleted {
+		t.Fatalf("state = (default=%t enabled=%t deleted=%t), want (%t %t %t)",
+			gotPointsToAgent, gotEnabled, gotDeleted, pointsToAgent, enabled, deleted)
+	}
+}
+
+func waitForAgentSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func waitForAgentResult(t *testing.T, result <-chan error, description string) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+		return nil
+	}
+}
+
+func openDefaultAgentPostgres(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("TEST_POSTGRES_DSN is not set")
+	}
+	if os.Getenv("TEST_POSTGRES_BOOTSTRAP_SCHEMA") == "1" {
+		defaultAgentMigrationOnce.Do(func() { defaultAgentMigrationErr = dbtest.MigratePostgresUp(dsn) })
+		if defaultAgentMigrationErr != nil {
+			t.Fatalf("migrate PostgreSQL test database: %v", defaultAgentMigrationErr)
+		}
+	}
+	pool, err := dbpkg.OpenPostgresDSN(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open PostgreSQL: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("ping PostgreSQL: %v", err)
+	}
+	return pool
+}

--- a/internal/settings/service.go
+++ b/internal/settings/service.go
@@ -37,6 +37,11 @@ type Service struct {
 	logger            *slog.Logger
 }
 
+type defaultAgentTransactionalQueries interface {
+	SupportsTransactions() bool
+	InTx(context.Context, func(dbstore.Queries) error) error
+}
+
 var (
 	ErrModelIDAmbiguous            = errors.New("model_id is ambiguous across providers")
 	ErrInvalidModelRef             = errors.New("invalid model reference")
@@ -425,7 +430,7 @@ func (s *Service) UpsertBot(ctx context.Context, botID string, req UpsertRequest
 	if err != nil {
 		return Settings{}, rollbackNetworkChange(fmt.Errorf("marshal network config: %w", err))
 	}
-	updated, err := s.queries.UpsertBotSettings(ctx, sqlc.UpsertBotSettingsParams{
+	upsertParams := sqlc.UpsertBotSettingsParams{
 		ID:                         pgID,
 		Timezone:                   timezoneValue,
 		Language:                   current.Language,
@@ -466,7 +471,8 @@ func (s *Service) UpsertBot(ctx context.Context, botID string, req UpsertRequest
 		OverlayProvider:            normalizedNetwork.OverlayProvider,
 		OverlayEnabled:             normalizedNetwork.OverlayEnabled,
 		OverlayConfig:              overlayConfigJSON,
-	})
+	}
+	updated, err := s.upsertBotSettings(ctx, upsertParams)
 	if err != nil {
 		return Settings{}, rollbackNetworkChange(err)
 	}
@@ -481,6 +487,47 @@ func (s *Service) UpsertBot(ctx context.Context, botID string, req UpsertRequest
 	settings := normalizeBotSettingsWriteRow(updated)
 	settings.AclDefaultEffect = current.AclDefaultEffect
 	return settings, nil
+}
+
+// upsertBotSettings serializes default-Agent changes with Agent availability
+// changes. The active recheck intentionally runs after the parent bot lock in
+// a separate statement, so READ COMMITTED observes a disable/delete that won
+// the lock before this assignment. Query-only test doubles retain the direct
+// path used by existing unit tests.
+func (s *Service) upsertBotSettings(ctx context.Context, params sqlc.UpsertBotSettingsParams) (sqlc.UpsertBotSettingsRow, error) {
+	if !params.DefaultBotAgentIDSet {
+		return s.queries.UpsertBotSettings(ctx, params)
+	}
+	txer, ok := s.queries.(defaultAgentTransactionalQueries)
+	if !ok || !txer.SupportsTransactions() {
+		return s.queries.UpsertBotSettings(ctx, params)
+	}
+
+	var updated sqlc.UpsertBotSettingsRow
+	err := txer.InTx(ctx, func(q dbstore.Queries) error {
+		if _, err := q.LockBotForAgentMutation(ctx, params.ID); err != nil {
+			return err
+		}
+		if params.DefaultBotAgentID.Valid {
+			agent, err := q.GetBotAgentByID(ctx, sqlc.GetBotAgentByIDParams{
+				BotID: params.ID,
+				ID:    params.DefaultBotAgentID,
+			})
+			if errors.Is(err, pgx.ErrNoRows) {
+				return botagents.ErrUnavailable
+			}
+			if err != nil {
+				return err
+			}
+			if !agent.Enabled || agent.DeletedAt.Valid {
+				return botagents.ErrUnavailable
+			}
+		}
+		var err error
+		updated, err = q.UpsertBotSettings(ctx, params)
+		return err
+	})
+	return updated, err
 }
 
 func (s *Service) Delete(ctx context.Context, botID string) error {

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	acpfeedback "github.com/memohai/memoh/internal/agent/decision/feedback"
+	"github.com/memohai/memoh/internal/botagents"
 	"github.com/memohai/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/memohai/memoh/internal/db/store"
 	"github.com/memohai/memoh/internal/reasoning"
@@ -172,6 +173,26 @@ type reasoningPolicyQueries struct {
 	storedEffort   string
 	upsertCalls    int
 	lastUpsert     sqlc.UpsertBotSettingsParams
+	transactions   bool
+	botAgent       sqlc.BotAgent
+	events         []string
+}
+
+func (q *reasoningPolicyQueries) SupportsTransactions() bool { return q.transactions }
+
+func (q *reasoningPolicyQueries) InTx(ctx context.Context, fn func(dbstore.Queries) error) error {
+	q.events = append(q.events, "transaction")
+	return fn(q)
+}
+
+func (q *reasoningPolicyQueries) LockBotForAgentMutation(context.Context, pgtype.UUID) (pgtype.UUID, error) {
+	q.events = append(q.events, "lock-bot")
+	return q.botID, nil
+}
+
+func (q *reasoningPolicyQueries) GetBotAgentByID(context.Context, sqlc.GetBotAgentByIDParams) (sqlc.BotAgent, error) {
+	q.events = append(q.events, "get-agent")
+	return q.botAgent, nil
 }
 
 func (q *reasoningPolicyQueries) GetBotByID(context.Context, pgtype.UUID) (sqlc.GetBotByIDRow, error) {
@@ -210,6 +231,7 @@ func (*reasoningPolicyQueries) GetModelByID(_ context.Context, id pgtype.UUID) (
 }
 
 func (q *reasoningPolicyQueries) UpsertBotSettings(_ context.Context, arg sqlc.UpsertBotSettingsParams) (sqlc.UpsertBotSettingsRow, error) {
+	q.events = append(q.events, "upsert-settings")
 	q.upsertCalls++
 	q.lastUpsert = arg
 	modelID := q.currentModelID
@@ -236,6 +258,54 @@ func (q *reasoningPolicyQueries) UpsertBotSettings(_ context.Context, arg sqlc.U
 		ToolApprovalConfig:  arg.ToolApprovalConfig,
 		OverlayConfig:       arg.OverlayConfig,
 	}, nil
+}
+
+func TestUpsertBotSettingsRechecksDefaultAgentAfterBotLock(t *testing.T) {
+	botID := pgtype.UUID{Bytes: uuid.MustParse("00000000-0000-0000-0000-000000000740"), Valid: true}
+	agentID := pgtype.UUID{Bytes: uuid.MustParse("00000000-0000-0000-0000-000000000741"), Valid: true}
+	params := sqlc.UpsertBotSettingsParams{
+		ID:                   botID,
+		DefaultBotAgentID:    agentID,
+		DefaultBotAgentIDSet: true,
+	}
+
+	t.Run("active agent is assigned", func(t *testing.T) {
+		queries := &reasoningPolicyQueries{
+			botID:        botID,
+			transactions: true,
+			botAgent:     sqlc.BotAgent{ID: agentID, BotID: botID, Enabled: true},
+		}
+		service := &Service{queries: queries}
+		if _, err := service.upsertBotSettings(context.Background(), params); err != nil {
+			t.Fatalf("upsertBotSettings() error = %v", err)
+		}
+		assertSettingsEvents(t, queries.events, []string{"transaction", "lock-bot", "get-agent", "upsert-settings"})
+	})
+
+	t.Run("agent disabled before lock release is rejected", func(t *testing.T) {
+		queries := &reasoningPolicyQueries{
+			botID:        botID,
+			transactions: true,
+			botAgent:     sqlc.BotAgent{ID: agentID, BotID: botID, Enabled: false},
+		}
+		service := &Service{queries: queries}
+		if _, err := service.upsertBotSettings(context.Background(), params); !errors.Is(err, botagents.ErrUnavailable) {
+			t.Fatalf("upsertBotSettings() error = %v, want %v", err, botagents.ErrUnavailable)
+		}
+		assertSettingsEvents(t, queries.events, []string{"transaction", "lock-bot", "get-agent"})
+	})
+}
+
+func assertSettingsEvents(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("events = %v, want %v", got, want)
+		}
+	}
 }
 
 func TestUpsertBotLegacyNativeRuntimeClearsDefaultAgent(t *testing.T) {

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -180,7 +180,7 @@ type reasoningPolicyQueries struct {
 
 func (q *reasoningPolicyQueries) SupportsTransactions() bool { return q.transactions }
 
-func (q *reasoningPolicyQueries) InTx(ctx context.Context, fn func(dbstore.Queries) error) error {
+func (q *reasoningPolicyQueries) InTx(_ context.Context, fn func(dbstore.Queries) error) error {
 	q.events = append(q.events, "transaction")
 	return fn(q)
 }


### PR DESCRIPTION
## Summary

- serialize default Agent assignment and Agent disable/soft-delete on the parent bots row
- recheck Agent availability after acquiring the parent lock so READ COMMITTED cannot reuse a stale pre-lock decision
- preserve a single bots -> bot_agents lock order and use FOR NO KEY UPDATE to avoid unnecessary FK contention
- add unit lock-order coverage and deterministic PostgreSQL concurrency regressions for both winner orderings of set-default vs disable/delete

## Tests

- go test ./internal/botagents ./internal/settings ./internal/db/postgres/store
- go test -tags=integration ./internal/settings -run TestDefaultAgentAssignmentSerializesWithDisableAndDelete -count=1 -v (PostgreSQL 15; all four interleavings passed)

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.