### PR TITLE
fix(context): keep frozen system history rows in the stable prefix

### DIFF
--- a/internal/agent/context/fragment/compile.go
+++ b/internal/agent/context/fragment/compile.go
@@ -435,9 +435,12 @@ func PriorityForMessage(msg sdk.Message) int {
 
 func cacheForMessage(msg sdk.Message) CacheClass {
 	switch msg.Role {
-	case sdk.MessageRoleSystem:
-		return CacheDynamic
-	case sdk.MessageRoleUser, sdk.MessageRoleAssistant, sdk.MessageRoleTool:
+	case sdk.MessageRoleSystem, sdk.MessageRoleUser, sdk.MessageRoleAssistant, sdk.MessageRoleTool:
+		// History messages render from the append-only timeline and are frozen
+		// at persistence; a system event row (session_created and friends) is
+		// as byte-stable within the session as a user row. Classifying it
+		// dynamic truncated the stable prefix at history position 0, which
+		// kept Anthropic message breakpoints off the conversation entirely.
 		return CacheStable
 	default:
 		return CacheNever

--- a/internal/agent/context/fragment/compile_test.go
+++ b/internal/agent/context/fragment/compile_test.go
@@ -110,13 +110,15 @@ func manifestHasKind(manifest Manifest, kind Kind) bool {
 	return false
 }
 
-// TestCacheForMessageMatchesHistoryCollectorMapping is the P5 RED test.
-// cacheForMessage backs the legacy/fallback compile path (contextfrag.Compile,
-// used by agent.RefreshContextFrag); contextview's history collector
-// (cacheForSDKMessage in internal/contextview/collector_history.go) backs the
-// newer contextview path. Both classify the same message roles, so they must
-// agree: history messages (user/assistant/tool) are CacheStable, matching
-// the view-side rule, instead of the legacy path's CacheNever.
+// TestCacheForMessageMatchesHistoryCollectorMapping pins the shared mapping
+// between the legacy/fallback compile path (contextfrag.Compile, used by
+// agent.RefreshContextFrag) and contextview's history collector
+// (cacheForSDKMessage in internal/contextview/collector_history.go). History
+// messages of every role are CacheStable: they render from the append-only
+// timeline and are frozen at persistence, so a system event row (for example
+// session_created) is as byte-stable within the session as a user row —
+// classifying it dynamic truncated the stable prefix at history position 0
+// and kept Anthropic message breakpoints off the conversation entirely.
 func TestCacheForMessageMatchesHistoryCollectorMapping(t *testing.T) {
 	t.Parallel()
 
@@ -124,7 +126,7 @@ func TestCacheForMessageMatchesHistoryCollectorMapping(t *testing.T) {
 		role sdk.MessageRole
 		want CacheClass
 	}{
-		{sdk.MessageRoleSystem, CacheDynamic},
+		{sdk.MessageRoleSystem, CacheStable},
 		{sdk.MessageRoleUser, CacheStable},
 		{sdk.MessageRoleAssistant, CacheStable},
 		{sdk.MessageRoleTool, CacheStable},

--- a/internal/contextview/collector_history.go
+++ b/internal/contextview/collector_history.go
@@ -176,11 +176,11 @@ func kindForSDKMessage(msg sdk.Message) contextfrag.Kind {
 }
 
 func cacheForSDKMessage(msg sdk.Message) contextfrag.CacheClass {
-	if msg.Role == sdk.MessageRoleSystem {
-		return contextfrag.CacheDynamic
-	}
 	switch msg.Role {
-	case sdk.MessageRoleUser, sdk.MessageRoleAssistant, sdk.MessageRoleTool:
+	case sdk.MessageRoleSystem, sdk.MessageRoleUser, sdk.MessageRoleAssistant, sdk.MessageRoleTool:
+		// Mirrors contextfrag.cacheForMessage: history rows are frozen at
+		// persistence, system event rows included, so they belong to the
+		// stable prefix the cache plan hands to providers.
 		return contextfrag.CacheStable
 	default:
 		return contextfrag.CacheNever

--- a/internal/contextview/placement_test.go
+++ b/internal/contextview/placement_test.go
@@ -63,3 +63,27 @@ func TestStablePrefixPlacerHashIgnoresVolatileSuffix(t *testing.T) {
 		t.Fatalf("StablePrefixHash did not change after stable prefix edit: %q", first.StablePrefixHash)
 	}
 }
+
+func TestStablePrefixPlacerKeepsSystemHistoryMessagesStable(t *testing.T) {
+	t.Parallel()
+
+	sessionEvent := messageFrag("event", sdk.Message{
+		Role:    sdk.MessageRoleSystem,
+		Content: []sdk.MessagePart{sdk.TextPart{Text: `<event type="session_created" t="2026-08-26T21:14:40Z"/>`}},
+	})
+	sessionEvent.CacheClass = cacheForSDKMessage(sdk.Message{Role: sdk.MessageRoleSystem})
+	current := messageFrag("current", sdk.UserMessage("latest"))
+	current.CacheClass = contextfrag.CacheNever
+	frags := contextfrag.NormalizeContextRefs([]contextfrag.ContextFrag{
+		textFrag("system", contextfrag.SlotSystem, contextfrag.KindSystemPrompt, sdk.MessageRoleSystem, "system"),
+		sessionEvent,
+		messageFrag("turn1", sdk.UserMessage("hello")),
+		current,
+	})
+
+	plan := StablePrefixPlacer{}.Place(frags, contextfrag.IntentRunConfigPreProvider)
+
+	if plan.FirstVolatileIndex != 3 {
+		t.Fatalf("FirstVolatileIndex = %d, want 3 (session event and history stay in the stable prefix)", plan.FirstVolatileIndex)
+	}
+}


### PR DESCRIPTION
## What changes

History-slot messages of every role are now `CacheStable`, in both role→cache mappings (`contextfrag.cacheForMessage` and contextview's `cacheForSDKMessage`). History renders from the append-only timeline and is frozen at persistence, so a system event row (`session_created` and friends) is as byte-stable within the session as a user row.

Before this fix, the leading system event row was classified `CacheDynamic`, which cut `firstVolatile` at history position 0: `StableMessageCount` stayed 0 forever, so `applyAnthropicPromptCache` never placed a message-level cache breakpoint on the conversation — the entire history was re-billed at full input price every turn on Anthropic models. On OpenAI-family models the damage was observability-only (the stable-prefix hash and token estimate never covered history), but that in turn blinded the lifecycle snapshots to real history dynamics.

## Verification

- `TestStablePrefixPlacerKeepsSystemHistoryMessagesStable` pins that a leading session-event row stays inside the stable prefix (red before the fix).
- `TestCacheForMessageMatchesHistoryCollectorMapping` updated: both mappings agree system-role history rows are stable.
- `go build ./...`; `go test -count=1 ./internal/agent/... ./internal/contextview/ ./internal/models/` zero failures; `golangci-lint run` clean over the touched packages.
- Live trial on a real server (memoh-bench context-lifecycle trial, grok-4.6 via openai-responses, 15-turn tool loop): `stable_message_count` now populates (1→27 across turns) and the stable-prefix hash covers history. The run also surfaced — correctly, as a one-time bounded cost — the tool-strip rewrite at the >10-message threshold crossing (`smc` 9→7 for one turn, then monotonic again).

## Stack

Stacked on #1085: the base branch `land/pr8-integration` mirrors its head (6aa22075c) inside this repository, because a cross-repository PR head cannot serve as a stack base. After #1085 merges, retarget this PR to `main` and delete the mirror branch. #1100 (`land/pr10-openai-cache-key`) sits on top.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
