### PR TITLE
feat(models): route OpenAI-family prompt cache by session key

### DIFF
--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -1223,6 +1223,9 @@ func (a *Agent) buildGenerateOptions(ctx context.Context, cfg RunConfig, tools [
 	}
 	opts = append(opts, sdk.WithPrepareStep(stepPrepare))
 
+	if key := models.PromptCacheKey(cfg.Model, cfg.PromptCacheTTL, cfg.Identity.SessionID); key != "" {
+		opts = append(opts, sdk.WithPromptCacheKey(key))
+	}
 	opts = append(opts, models.BuildReasoningOptions(models.SDKModelConfig{
 		ClientType:            models.ResolveClientType(cfg.Model),
 		ChatCompletionsCompat: cfg.ChatCompletionsCompat,

--- a/internal/models/prompt_cache.go
+++ b/internal/models/prompt_cache.go
@@ -98,14 +98,30 @@ func ApplyPromptCacheWithPlan(
 		return system, messages, tools, false, plan.StableMessageCount
 	}
 	// OpenAI-family vendors identify cache-warm backends via a
-	// prompt_cache_key on the request rather than explicit breakpoints;
-	// wiring that through needs upstream support in the twilight-ai SDK,
-	// which isn't available yet, so the default branch below is a no-op.
+	// prompt_cache_key on the request rather than explicit breakpoints; that
+	// key comes from PromptCacheKey and rides the request options, so the
+	// payload itself stays untouched in the default branch below.
 	switch ResolveClientType(model) {
 	case string(ClientTypeAnthropicMessages):
 		return applyAnthropicPromptCache(normalized, plan, system, messages, tools)
 	default:
 		return system, messages, tools, false, plan.StableMessageCount
+	}
+}
+
+// PromptCacheKey returns the per-session cache-routing key for OpenAI-family
+// clients. prompt_cache_key groups requests that share a prefix lineage onto
+// cache-warm backends, and the session is exactly that lineage; providers that
+// cache via explicit breakpoints get no key.
+func PromptCacheKey(model *sdk.Model, ttl, sessionID string) string {
+	if model == nil || sessionID == "" || NormalizePromptCacheTTL(ttl) == PromptCacheTTLOff {
+		return ""
+	}
+	switch ResolveClientType(model) {
+	case string(ClientTypeOpenAIResponses), string(ClientTypeOpenAICompletions):
+		return "memoh-session-" + sessionID
+	default:
+		return ""
 	}
 }
 

--- a/internal/models/prompt_cache_test.go
+++ b/internal/models/prompt_cache_test.go
@@ -170,3 +170,22 @@ func TestApplyPromptCache_AnthropicDoesNotMutateInput(t *testing.T) {
 		t.Errorf("source tool slice was mutated: %+v", tools[1].CacheControl)
 	}
 }
+
+func TestPromptCacheKeyOpenAIFamilyOnly(t *testing.T) {
+	openai := newOpenAITestModel(t)
+	if got := PromptCacheKey(openai, "5m", "sess-1"); got != "memoh-session-sess-1" {
+		t.Errorf("openai completions key = %q, want memoh-session-sess-1", got)
+	}
+	if got := PromptCacheKey(openai, "off", "sess-1"); got != "" {
+		t.Errorf("ttl off key = %q, want empty", got)
+	}
+	if got := PromptCacheKey(openai, "5m", ""); got != "" {
+		t.Errorf("empty session key = %q, want empty", got)
+	}
+	if got := PromptCacheKey(newAnthropicTestModel(t), "5m", "sess-1"); got != "" {
+		t.Errorf("anthropic key = %q, want empty (breakpoints, not routing keys)", got)
+	}
+	if got := PromptCacheKey(nil, "5m", "sess-1"); got != "" {
+		t.Errorf("nil model key = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## What changes

OpenAI-family requests (openai-responses and openai-completions) now carry `prompt_cache_key=memoh-session-<id>`. `models.PromptCacheKey` returns the per-session key when the prompt-cache TTL is not `off`; breakpoint providers (Anthropic) and other client types get no key. The stale "needs upstream support in the twilight-ai SDK" comment is replaced — twilight-ai v0.5.0 ships `WithPromptCacheKey` and both OpenAI providers pass it through.

`prompt_cache_key` is OpenAI's cache-routing hint: requests sharing a key are routed to cache-warm backends, and a session is exactly one prefix lineage. On multi-backend OpenAI deployments this lifts prefix-cache hit rates; providers that ignore the parameter are unaffected (verified against an openai-responses gateway fronting xAI: the parameter is accepted and behavior is unchanged).

## Verification

- `TestPromptCacheKeyOpenAIFamilyOnly` pins the key shape, the ttl=off/empty-session guards, and that Anthropic gets no key.
- `go build ./...`; `go test -count=1 ./internal/models/ ./internal/agent/runtime/native/` zero failures; `golangci-lint run` clean over the touched packages.
- Live A/B on a grok-4.6 gateway (memoh-bench lifecycle trial, 15 turns each): no regression; deltas within run-to-run noise, as expected for a backend that does not key its cache on the parameter.

## Stack

Stacked on #1099 (`land/pr9-stable-history-prefix`), which sits behind #1085.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
