### PR TITLE
fix(install): align workspace images with server releases

### DIFF
--- a/.github/workflows/install-ci.yml
+++ b/.github/workflows/install-ci.yml
@@ -1,0 +1,39 @@
+name: Installer CI
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "conf/app.docker.toml"
+      - "docker-compose.yml"
+      - "scripts/install.sh"
+      - "scripts/test-install-*.sh"
+      - ".github/workflows/install-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "conf/app.docker.toml"
+      - "docker-compose.yml"
+      - "scripts/install.sh"
+      - "scripts/test-install-*.sh"
+      - ".github/workflows/install-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Root execution guard
+        run: scripts/test-install-root-guard.sh
+      - name: Workspace image release alignment
+        run: scripts/test-install-workspace-image.sh

--- a/conf/app.apple.toml
+++ b/conf/app.apple.toml
@@ -44,7 +44,7 @@ driver = "postgres"
 # Apple backend uses socktainer and the Apple Containerization framework.
 # It is local-macOS oriented and does not support provider sidecar overlays.
 backend = "apple"
-default_image = "memohai/workspace:debian"
+default_image = "memohai/workspace:debian-latest"
 image_pull_policy = "if_not_present"
 # Workspace state and bridge sockets.
 data_root = "data"

--- a/conf/app.docker.toml
+++ b/conf/app.docker.toml
@@ -52,7 +52,7 @@ driver = "postgres"
 # runtime bind mounts and Docker socket access.
 backend = "containerd"
 # registry = "memoh.cn"  # Uncomment for China mainland mirror
-default_image = "memohai/workspace:debian"
+default_image = "memohai/workspace:debian-latest"
 image_pull_policy = "if_not_present"
 # containerd snapshotter and CNI settings for bot workspace containers.
 snapshotter = "overlayfs"

--- a/conf/app.example.toml
+++ b/conf/app.example.toml
@@ -117,7 +117,7 @@ driver = "postgres"
 # - apple: macOS Apple Container backend via socktainer.
 backend = "docker"
 # registry = "memoh.cn"  # Uncomment for China mainland mirror
-default_image = "memohai/workspace:debian"
+default_image = "memohai/workspace:debian-latest"
 # Workspace image pull policy: if_not_present, always, or never.
 # The selected container backend applies it before creating the workspace.
 image_pull_policy = "if_not_present"

--- a/conf/app.windows.toml
+++ b/conf/app.windows.toml
@@ -45,7 +45,7 @@ driver = "postgres"
 # available for custom deployments, but its runtime paths must match the host.
 backend = "containerd"
 # registry = "memoh.cn"  # Uncomment for China mainland mirror
-default_image = "memohai/workspace:debian"
+default_image = "memohai/workspace:debian-latest"
 image_pull_policy = "if_not_present"
 # containerd snapshotter used by workspace containers.
 snapshotter = "overlayfs"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,9 +44,9 @@ const (
 	DefaultPGVectorSSLMode       = "disable"
 	DefaultRuntimeDir            = "/opt/memoh/runtime"
 	DefaultBridgePath            = DefaultRuntimeDir + "/bridge"
-	DefaultWorkspaceImage        = "memohai/workspace:debian"
+	DefaultWorkspaceImage        = "memohai/workspace:debian-latest"
 	DefaultBaseImage             = DefaultWorkspaceImage
-	DefaultWorkspaceMirrorImage  = "memoh.cn/memohai/workspace:debian"
+	DefaultWorkspaceMirrorImage  = "memoh.cn/memohai/workspace:debian-latest"
 	DefaultTimezone              = "UTC"
 	DefaultAgentToolOutputBytes  = 64 * 1024
 	DefaultAgentToolOutputLines  = 2000

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -599,15 +599,15 @@ func TestWorkspaceImagePullPolicyDefaultsAndNormalizes(t *testing.T) {
 
 func TestWorkspaceImageRefDefaultsToPackagedWorkspace(t *testing.T) {
 	got := (WorkspaceConfig{}).ImageRef()
-	want := "docker.io/memohai/workspace:debian"
+	want := "docker.io/memohai/workspace:debian-latest"
 	if got != want {
 		t.Fatalf("default image ref = %q, want %q", got, want)
 	}
 }
 
 func TestWorkspaceImagePullCandidatesAddsWorkspaceMirror(t *testing.T) {
-	got := WorkspaceImagePullCandidates("memohai/workspace:debian")
-	want := []string{"docker.io/memohai/workspace:debian", "memoh.cn/memohai/workspace:debian"}
+	got := WorkspaceImagePullCandidates("memohai/workspace:debian-latest")
+	want := []string{"docker.io/memohai/workspace:debian-latest", "memoh.cn/memohai/workspace:debian-latest"}
 	if len(got) != len(want) {
 		t.Fatalf("candidate count = %d, want %d (%v)", len(got), len(want), got)
 	}

--- a/internal/workspace/image_pull_test.go
+++ b/internal/workspace/image_pull_test.go
@@ -96,8 +96,8 @@ func TestPrepareImageForCreateDelegatesWhenImageServiceUnsupported(t *testing.T)
 }
 
 func TestPrepareImageForCreateFallsBackToWorkspaceMirror(t *testing.T) {
-	primary := "docker.io/memohai/workspace:debian"
-	fallback := "memoh.cn/memohai/workspace:debian"
+	primary := "docker.io/memohai/workspace:debian-latest"
+	fallback := "memoh.cn/memohai/workspace:debian-latest"
 	svc := &legacyRouteTestService{
 		getImageErr: ctr.ErrNotFound,
 		pullErrs: map[string]error{
@@ -108,7 +108,7 @@ func TestPrepareImageForCreateFallsBackToWorkspaceMirror(t *testing.T) {
 		ImagePullPolicy: config.ImagePullPolicyIfNotPresent,
 	})
 
-	result, err := m.PrepareImageForCreate(context.Background(), "memohai/workspace:debian", nil)
+	result, err := m.PrepareImageForCreate(context.Background(), "memohai/workspace:debian-latest", nil)
 	if err != nil {
 		t.Fatalf("PrepareImageForCreate returned error: %v", err)
 	}
@@ -124,8 +124,8 @@ func TestPrepareImageForCreateFallsBackToWorkspaceMirror(t *testing.T) {
 }
 
 func TestPrepareImageForCreateSkipsExistingWorkspaceMirror(t *testing.T) {
-	primary := "docker.io/memohai/workspace:debian"
-	fallback := "memoh.cn/memohai/workspace:debian"
+	primary := "docker.io/memohai/workspace:debian-latest"
+	fallback := "memoh.cn/memohai/workspace:debian-latest"
 	svc := &legacyRouteTestService{
 		getImageErrs: map[string]error{
 			primary: ctr.ErrNotFound,
@@ -135,7 +135,7 @@ func TestPrepareImageForCreateSkipsExistingWorkspaceMirror(t *testing.T) {
 		ImagePullPolicy: config.ImagePullPolicyIfNotPresent,
 	})
 
-	result, err := m.PrepareImageForCreate(context.Background(), "memohai/workspace:debian", nil)
+	result, err := m.PrepareImageForCreate(context.Background(), "memohai/workspace:debian-latest", nil)
 	if err != nil {
 		t.Fatalf("PrepareImageForCreate returned error: %v", err)
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -74,8 +74,10 @@ EXISTING_DOCKER_NETWORK=false
 EXISTING_WORKSPACE_FILES=false
 EXISTING_REPO_DIR=false
 EXISTING_WORKSPACE_IMAGE=""
+EXISTING_WORKSPACE_IMAGE_SECTION="container"
 EXISTING_INSTALLER_WORKSPACE_IMAGE=""
 WORKSPACE_IMAGE=""
+WORKSPACE_IMAGE_SECTION="container"
 WORKSPACE_IMAGE_MANAGED=false
 
 # Parse flags
@@ -183,6 +185,12 @@ read_toml_value() {
     return 1
   fi
   printf '%s' "$value" | sed 's/\\"/"/g; s/\\\\/\\/g'
+}
+
+toml_section_exists() {
+  file="$1"
+  section="$2"
+  [ -f "$file" ] && grep -q "^[[:space:]]*\[$section\][[:space:]]*$" "$file"
 }
 
 normalize_database_driver() {
@@ -339,6 +347,7 @@ detect_existing_installation() {
   EXISTING_WORKSPACE_FILES=false
   EXISTING_REPO_DIR=false
   EXISTING_WORKSPACE_IMAGE=""
+  EXISTING_WORKSPACE_IMAGE_SECTION="container"
   EXISTING_INSTALLER_WORKSPACE_IMAGE=""
 
   if [ -d "$WORKSPACE/$DIR" ]; then
@@ -396,7 +405,13 @@ detect_existing_installation() {
 load_existing_settings() {
   if [ -n "$EXISTING_CONFIG_SOURCE" ]; then
     value=$(read_toml_value "$EXISTING_CONFIG_SOURCE" "container" "default_image" || true)
-    [ -n "$value" ] && EXISTING_WORKSPACE_IMAGE="$value"
+    if [ -n "$value" ]; then
+      EXISTING_WORKSPACE_IMAGE="$value"
+    elif toml_section_exists "$EXISTING_CONFIG_SOURCE" "workspace"; then
+      EXISTING_WORKSPACE_IMAGE_SECTION="workspace"
+      value=$(read_toml_value "$EXISTING_CONFIG_SOURCE" "workspace" "default_image" || true)
+      [ -n "$value" ] && EXISTING_WORKSPACE_IMAGE="$value"
+    fi
 
     value=$(read_toml_value "$EXISTING_CONFIG_SOURCE" "admin" "username" || true)
     [ -n "$value" ] && ADMIN_USER="$value"
@@ -508,10 +523,12 @@ select_workspace_image() {
   fi
 
   WORKSPACE_IMAGE="$release_workspace_image"
+  WORKSPACE_IMAGE_SECTION="container"
   WORKSPACE_IMAGE_MANAGED=true
   if [ "$INSTALL_MODE" != "upgrade" ]; then
     return
   fi
+  WORKSPACE_IMAGE_SECTION="$EXISTING_WORKSPACE_IMAGE_SECTION"
 
   case "$EXISTING_WORKSPACE_IMAGE" in
     ""|memohai/workspace:debian|docker.io/memohai/workspace:debian|memohai/workspace:debian-latest|docker.io/memohai/workspace:debian-latest)
@@ -937,10 +954,10 @@ else
   rm -f config.toml.bak
 fi
 
-set_toml_string_value config.toml "container" "default_image" "$WORKSPACE_IMAGE"
-configured_workspace_image=$(read_toml_value config.toml "container" "default_image" || true)
+set_toml_string_value config.toml "$WORKSPACE_IMAGE_SECTION" "default_image" "$WORKSPACE_IMAGE"
+configured_workspace_image=$(read_toml_value config.toml "$WORKSPACE_IMAGE_SECTION" "default_image" || true)
 if [ "$configured_workspace_image" != "$WORKSPACE_IMAGE" ]; then
-  echo "${RED}Error: failed to configure [container].default_image in config.toml.${NC}"
+  echo "${RED}Error: failed to configure [${WORKSPACE_IMAGE_SECTION}].default_image in config.toml.${NC}"
   exit 1
 fi
 if [ "$WORKSPACE_IMAGE_MANAGED" = true ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -165,8 +165,11 @@ read_toml_value() {
     return 1
   fi
   value=$(awk -v target_section="[$section]" -v target_key="$key" '
-    /^\[[^]]+\]/ {
-      in_section = ($0 == target_section)
+    /^[[:space:]]*\[[^]]+\]/ {
+      section_header = $0
+      sub(/^[[:space:]]*/, "", section_header)
+      sub(/[[:space:]]*$/, "", section_header)
+      in_section = (section_header == target_section)
       next
     }
     in_section && $0 ~ "^[[:space:]]*" target_key "[[:space:]]*=" {
@@ -257,12 +260,15 @@ set_toml_string_value() {
     BEGIN {
       target_value = ENVIRON["TOML_VALUE"]
     }
-    /^\[[^]]+\]/ {
+    /^[[:space:]]*\[[^]]+\]/ {
       if (in_section && !value_written) {
         print target_key " = \"" target_value "\""
         value_written = 1
       }
-      in_section = ($0 == target_section)
+      section_header = $0
+      sub(/^[[:space:]]*/, "", section_header)
+      sub(/[[:space:]]*$/, "", section_header)
+      in_section = (section_header == target_section)
       if (in_section) {
         section_found = 1
       }
@@ -301,8 +307,11 @@ set_toml_bool_value() {
     BEGIN {
       target_value = ENVIRON["TOML_VALUE"]
     }
-    /^\[[^]]+\]/ {
-      in_section = ($0 == target_section)
+    /^[[:space:]]*\[[^]]+\]/ {
+      section_header = $0
+      sub(/^[[:space:]]*/, "", section_header)
+      sub(/[[:space:]]*$/, "", section_header)
+      in_section = (section_header == target_section)
     }
     in_section && $0 ~ "^[[:space:]]*" target_key "[[:space:]]*=" {
       indent = $0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,6 +73,10 @@ EXISTING_DOCKER_CONTAINERS=false
 EXISTING_DOCKER_NETWORK=false
 EXISTING_WORKSPACE_FILES=false
 EXISTING_REPO_DIR=false
+EXISTING_WORKSPACE_IMAGE=""
+EXISTING_INSTALLER_WORKSPACE_IMAGE=""
+WORKSPACE_IMAGE=""
+WORKSPACE_IMAGE_MANAGED=false
 
 # Parse flags
 while [ $# -gt 0 ]; do
@@ -246,15 +250,31 @@ set_toml_string_value() {
       target_value = ENVIRON["TOML_VALUE"]
     }
     /^\[[^]]+\]/ {
+      if (in_section && !value_written) {
+        print target_key " = \"" target_value "\""
+        value_written = 1
+      }
       in_section = ($0 == target_section)
+      if (in_section) {
+        section_found = 1
+      }
     }
     in_section && $0 ~ "^[[:space:]]*" target_key "[[:space:]]*=" {
       indent = $0
       sub(/[^[:space:]].*/, "", indent)
       print indent target_key " = \"" target_value "\""
+      value_written = 1
       next
     }
     { print }
+    END {
+      if (in_section && !value_written) {
+        print target_key " = \"" target_value "\""
+      }
+      if (!section_found) {
+        exit 2
+      }
+    }
   ' "$file" > "$tmp"; then
     mv "$tmp" "$file"
   else
@@ -318,6 +338,8 @@ detect_existing_installation() {
   EXISTING_DOCKER_NETWORK=false
   EXISTING_WORKSPACE_FILES=false
   EXISTING_REPO_DIR=false
+  EXISTING_WORKSPACE_IMAGE=""
+  EXISTING_INSTALLER_WORKSPACE_IMAGE=""
 
   if [ -d "$WORKSPACE/$DIR" ]; then
     EXISTING_REPO_DIR=true
@@ -373,6 +395,9 @@ detect_existing_installation() {
 
 load_existing_settings() {
   if [ -n "$EXISTING_CONFIG_SOURCE" ]; then
+    value=$(read_toml_value "$EXISTING_CONFIG_SOURCE" "container" "default_image" || true)
+    [ -n "$value" ] && EXISTING_WORKSPACE_IMAGE="$value"
+
     value=$(read_toml_value "$EXISTING_CONFIG_SOURCE" "admin" "username" || true)
     [ -n "$value" ] && ADMIN_USER="$value"
 
@@ -412,6 +437,9 @@ load_existing_settings() {
   fi
 
   if [ -n "$EXISTING_ENV_SOURCE" ]; then
+    value=$(read_env_file_value "$EXISTING_ENV_SOURCE" "MEMOH_INSTALLER_WORKSPACE_IMAGE" || true)
+    [ -n "$value" ] && EXISTING_INSTALLER_WORKSPACE_IMAGE="$value"
+
     value=$(read_env_file_value "$EXISTING_ENV_SOURCE" "POSTGRES_PASSWORD" || true)
     [ -n "$value" ] && PG_PASS="$value"
 
@@ -468,6 +496,35 @@ load_existing_settings() {
     value=$(read_env_file_value "$EXISTING_ENV_SOURCE" "MEMOH_CONNECT_IT_IMAGE" || true)
     [ -n "$value" ] && MEMOH_CONNECT_IT_IMAGE="${MEMOH_CONNECT_IT_IMAGE:-$value}"
   fi
+
+  return 0
+}
+
+select_workspace_image() {
+  if [ "$MEMOH_DOCKER_VERSION" = "latest" ]; then
+    release_workspace_image="memohai/workspace:debian-latest"
+  else
+    release_workspace_image="memohai/workspace:${MEMOH_DOCKER_VERSION}-debian"
+  fi
+
+  WORKSPACE_IMAGE="$release_workspace_image"
+  WORKSPACE_IMAGE_MANAGED=true
+  if [ "$INSTALL_MODE" != "upgrade" ]; then
+    return
+  fi
+
+  case "$EXISTING_WORKSPACE_IMAGE" in
+    ""|memohai/workspace:debian|docker.io/memohai/workspace:debian|memohai/workspace:debian-latest|docker.io/memohai/workspace:debian-latest)
+      return
+      ;;
+  esac
+
+  if [ -n "$EXISTING_INSTALLER_WORKSPACE_IMAGE" ] && [ "$EXISTING_WORKSPACE_IMAGE" = "$EXISTING_INSTALLER_WORKSPACE_IMAGE" ]; then
+    return
+  fi
+
+  WORKSPACE_IMAGE="$EXISTING_WORKSPACE_IMAGE"
+  WORKSPACE_IMAGE_MANAGED=false
 }
 
 prompt_install_mode() {
@@ -749,6 +806,7 @@ if [ "$INSTALL_MODE" = "fresh" ] && [ "$EXISTING_DOCKER_STATE" = true ]; then
   exit 1
 fi
 enforce_compose_container_backend
+select_workspace_image
 
 if [ "$SILENT" = false ] && [ "$INSTALL_MODE" != "upgrade" ]; then
   printf "  Data directory (reserved for future bind-mount support) [%s]: " "$MEMOH_DATA_DIR" > /dev/tty
@@ -879,6 +937,18 @@ else
   rm -f config.toml.bak
 fi
 
+set_toml_string_value config.toml "container" "default_image" "$WORKSPACE_IMAGE"
+configured_workspace_image=$(read_toml_value config.toml "container" "default_image" || true)
+if [ "$configured_workspace_image" != "$WORKSPACE_IMAGE" ]; then
+  echo "${RED}Error: failed to configure [container].default_image in config.toml.${NC}"
+  exit 1
+fi
+if [ "$WORKSPACE_IMAGE_MANAGED" = true ]; then
+  echo "${GREEN}✓ Workspace image pinned to ${WORKSPACE_IMAGE}${NC}"
+else
+  echo "${GREEN}✓ Preserving custom workspace image ${WORKSPACE_IMAGE}${NC}"
+fi
+
 INSTALL_DIR="$(pwd)"
 mkdir -p "$MEMOH_DATA_DIR"
 MEMOH_DATA_DIR=$(cd "$MEMOH_DATA_DIR" && pwd)
@@ -981,6 +1051,9 @@ write_env_value "MEMOH_CONFIG" "./config.toml"
 write_env_value "MEMOH_DATA_DIR" "$MEMOH_DATA_DIR"
 write_env_value "MEMOH_DATABASE_DRIVER" "$DATABASE_DRIVER"
 write_env_value "MEMOH_CONTAINER_BACKEND" "$CONTAINER_BACKEND"
+if [ "$WORKSPACE_IMAGE_MANAGED" = true ]; then
+  write_env_value "MEMOH_INSTALLER_WORKSPACE_IMAGE" "$WORKSPACE_IMAGE"
+fi
 write_env_value "MEMOH_WEBHOOK_PUBLIC_BASE_URL" "${MEMOH_WEBHOOK_PUBLIC_BASE_URL:-}"
 write_env_value "MEMOH_WEBHOOK_TUNNEL_MODE" "$WEBHOOK_TUNNEL_MODE"
 write_env_value "MEMOH_WEBHOOK_TUNNEL_LISTEN_ADDR" "$MEMOH_WEBHOOK_TUNNEL_LISTEN_ADDR"

--- a/scripts/test-install-workspace-image.sh
+++ b/scripts/test-install-workspace-image.sh
@@ -54,10 +54,10 @@ EOF
 chmod +x "$FAKEBIN/id" "$FAKEBIN/docker" "$FAKEBIN/git" "$FAKEBIN/curl"
 
 read_workspace_image() {
-  awk '
-    /^\[container\]$/ { in_container = 1; next }
-    /^\[/ { in_container = 0 }
-    in_container && /^[[:space:]]*default_image[[:space:]]*=/ {
+  section=$2
+  awk -v target_section="[$section]" '
+    /^\[[^]]+\]$/ { in_section = ($0 == target_section); next }
+    in_section && /^[[:space:]]*default_image[[:space:]]*=/ {
       value = substr($0, index($0, "=") + 1)
       gsub(/^[[:space:]\"]+|[[:space:]\"]+$/, "", value)
       print value
@@ -93,9 +93,42 @@ prepare_upgrade() {
   rm -f "$home/memoh/config.toml.bak"
 }
 
+prepare_legacy_upgrade() {
+  home=$1
+  image=$2
+  mkdir -p "$home/memoh"
+  cat > "$home/memoh/config.toml" <<EOF
+[admin]
+username = "admin"
+password = "admin123"
+
+[auth]
+jwt_secret = "test-secret"
+
+[database]
+driver = "postgres"
+
+[container]
+backend = "containerd"
+
+[workspace]
+default_image = "$image"
+image_pull_policy = "if_not_present"
+snapshotter = "overlayfs"
+data_root = "/opt/memoh/data"
+bridge_path = "/opt/memoh/runtime/bridge"
+
+[postgres]
+password = "memoh123"
+
+[pgvector]
+password = "memoh123"
+EOF
+}
+
 FRESH_HOME="$TMPDIR/fresh"
 MEMOH_INSTALL_MODE=fresh run_installer "$FRESH_HOME" v0.19.0 "$TMPDIR/fresh.out"
-fresh_image=$(read_workspace_image "$FRESH_HOME/memoh/config.toml")
+fresh_image=$(read_workspace_image "$FRESH_HOME/memoh/config.toml" container)
 [ "$fresh_image" = "memohai/workspace:0.19.0-debian" ] || {
   echo "fresh install workspace image = $fresh_image" >&2
   cat "$TMPDIR/fresh.out" >&2
@@ -106,7 +139,7 @@ grep -q "MEMOH_INSTALLER_WORKSPACE_IMAGE='memohai/workspace:0.19.0-debian'" "$FR
 
 FALLBACK_HOME="$TMPDIR/fallback"
 MEMOH_INSTALL_MODE=fresh run_installer "$FALLBACK_HOME" "" "$TMPDIR/fallback.out"
-fallback_image=$(read_workspace_image "$FALLBACK_HOME/memoh/config.toml")
+fallback_image=$(read_workspace_image "$FALLBACK_HOME/memoh/config.toml" container)
 [ "$fallback_image" = "memohai/workspace:debian-latest" ] || {
   echo "fallback workspace image = $fallback_image" >&2
   cat "$TMPDIR/fallback.out" >&2
@@ -118,7 +151,7 @@ MANAGED_HOME="$TMPDIR/managed"
 prepare_upgrade "$MANAGED_HOME" "memohai/workspace:debian"
 MEMOH_INSTALL_MODE=upgrade run_installer "$MANAGED_HOME" v0.19.0 "$TMPDIR/managed-19.out"
 MEMOH_INSTALL_MODE=upgrade run_installer "$MANAGED_HOME" v0.20.0 "$TMPDIR/managed-20.out"
-managed_image=$(read_workspace_image "$MANAGED_HOME/memoh/config.toml")
+managed_image=$(read_workspace_image "$MANAGED_HOME/memoh/config.toml" container)
 [ "$managed_image" = "memohai/workspace:0.20.0-debian" ] || {
   echo "managed upgrade workspace image = $managed_image" >&2
   cat "$TMPDIR/managed-20.out" >&2
@@ -131,18 +164,33 @@ prepare_upgrade "$MISSING_HOME" "memohai/workspace:debian"
 sed -i.bak '/^[[:space:]]*default_image[[:space:]]*=/d' "$MISSING_HOME/memoh/config.toml"
 rm "$MISSING_HOME/memoh/config.toml.bak"
 MEMOH_INSTALL_MODE=upgrade run_installer "$MISSING_HOME" v0.20.0 "$TMPDIR/missing.out"
-missing_image=$(read_workspace_image "$MISSING_HOME/memoh/config.toml")
+missing_image=$(read_workspace_image "$MISSING_HOME/memoh/config.toml" container)
 [ "$missing_image" = "memohai/workspace:0.20.0-debian" ] || {
   echo "missing default workspace image = $missing_image" >&2
   cat "$TMPDIR/missing.out" >&2
   exit 1
 }
 
+LEGACY_HOME="$TMPDIR/legacy"
+prepare_legacy_upgrade "$LEGACY_HOME" "memohai/workspace:debian"
+MEMOH_INSTALL_MODE=upgrade run_installer "$LEGACY_HOME" v0.20.0 "$TMPDIR/legacy.out"
+legacy_image=$(read_workspace_image "$LEGACY_HOME/memoh/config.toml" workspace)
+[ "$legacy_image" = "memohai/workspace:0.20.0-debian" ] || {
+  echo "legacy workspace image = $legacy_image" >&2
+  cat "$TMPDIR/legacy.out" >&2
+  exit 1
+}
+if [ -n "$(read_workspace_image "$LEGACY_HOME/memoh/config.toml" container)" ]; then
+  echo "legacy workspace image was duplicated into [container]" >&2
+  cat "$LEGACY_HOME/memoh/config.toml" >&2
+  exit 1
+fi
+
 CUSTOM_HOME="$TMPDIR/custom"
 prepare_upgrade "$CUSTOM_HOME" "registry.example/workspace:gold"
 printf "MEMOH_INSTALLER_WORKSPACE_IMAGE='memohai/workspace:0.19.0-debian'\n" > "$CUSTOM_HOME/memoh/.env"
 MEMOH_INSTALL_MODE=upgrade run_installer "$CUSTOM_HOME" v0.20.0 "$TMPDIR/custom.out"
-custom_image=$(read_workspace_image "$CUSTOM_HOME/memoh/config.toml")
+custom_image=$(read_workspace_image "$CUSTOM_HOME/memoh/config.toml" container)
 [ "$custom_image" = "registry.example/workspace:gold" ] || {
   echo "custom upgrade workspace image = $custom_image" >&2
   cat "$TMPDIR/custom.out" >&2

--- a/scripts/test-install-workspace-image.sh
+++ b/scripts/test-install-workspace-image.sh
@@ -56,7 +56,13 @@ chmod +x "$FAKEBIN/id" "$FAKEBIN/docker" "$FAKEBIN/git" "$FAKEBIN/curl"
 read_workspace_image() {
   section=$2
   awk -v target_section="[$section]" '
-    /^\[[^]]+\]$/ { in_section = ($0 == target_section); next }
+    /^[[:space:]]*\[[^]]+\]/ {
+      section_header = $0
+      sub(/^[[:space:]]*/, "", section_header)
+      sub(/[[:space:]]*$/, "", section_header)
+      in_section = (section_header == target_section)
+      next
+    }
     in_section && /^[[:space:]]*default_image[[:space:]]*=/ {
       value = substr($0, index($0, "=") + 1)
       gsub(/^[[:space:]\"]+|[[:space:]\"]+$/, "", value)
@@ -124,6 +130,8 @@ password = "memoh123"
 [pgvector]
 password = "memoh123"
 EOF
+  sed -i.bak 's/^\[workspace\]$/[workspace]  /' "$home/memoh/config.toml"
+  rm -f "$home/memoh/config.toml.bak"
 }
 
 FRESH_HOME="$TMPDIR/fresh"

--- a/scripts/test-install-workspace-image.sh
+++ b/scripts/test-install-workspace-image.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd "$(dirname "$0")/.." && pwd)
+TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/test-install-workspace-image.XXXXXX" 2>/dev/null || mktemp -d -t test-install-workspace-image)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+FAKEBIN="$TMPDIR/bin"
+mkdir -p "$FAKEBIN"
+
+cat > "$FAKEBIN/id" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-u" ]; then
+  printf '1000\n'
+  exit 0
+fi
+exit 1
+EOF
+
+cat > "$FAKEBIN/docker" <<'EOF'
+#!/bin/sh
+case "$1 ${2:-}" in
+  "info "|"compose version") exit 0 ;;
+  "volume inspect"|"container inspect"|"network inspect") exit 1 ;;
+  "compose "*) exit 0 ;;
+esac
+exit 0
+EOF
+
+cat > "$FAKEBIN/git" <<'EOF'
+#!/bin/sh
+command=$1
+shift
+case "$command" in
+  clone)
+    for argument do
+      destination=$argument
+    done
+    mkdir -p "$destination/conf"
+    cp "$TEST_SOURCE_ROOT/docker-compose.yml" "$destination/docker-compose.yml"
+    cp "$TEST_SOURCE_ROOT/conf/app.docker.toml" "$destination/conf/app.docker.toml"
+    cp -R "$TEST_SOURCE_ROOT/conf/providers" "$destination/conf/providers"
+    ;;
+  fetch|checkout|reset|submodule) ;;
+  *) echo "unexpected git command: $command" >&2; exit 1 ;;
+esac
+EOF
+
+cat > "$FAKEBIN/curl" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+
+chmod +x "$FAKEBIN/id" "$FAKEBIN/docker" "$FAKEBIN/git" "$FAKEBIN/curl"
+
+read_workspace_image() {
+  awk '
+    /^\[container\]$/ { in_container = 1; next }
+    /^\[/ { in_container = 0 }
+    in_container && /^[[:space:]]*default_image[[:space:]]*=/ {
+      value = substr($0, index($0, "=") + 1)
+      gsub(/^[[:space:]\"]+|[[:space:]\"]+$/, "", value)
+      print value
+      exit
+    }
+  ' "$1"
+}
+
+run_installer() {
+  home=$1
+  version=$2
+  output=$3
+  mkdir -p "$home"
+  if ! PATH="$FAKEBIN:/usr/bin:/bin" \
+    HOME="$home" \
+    TEST_SOURCE_ROOT="$ROOT" \
+    MEMOH_VERSION="$version" \
+    MEMOH_INSTALL_MODE="${MEMOH_INSTALL_MODE:-fresh}" \
+    MEMOH_CONNECT_IT_MODE=disabled \
+    MEMOH_WEBHOOK_TUNNEL_MODE=disabled \
+    sh "$ROOT/scripts/install.sh" --yes >"$output" 2>&1; then
+    cat "$output" >&2
+    return 1
+  fi
+}
+
+prepare_upgrade() {
+  home=$1
+  image=$2
+  mkdir -p "$home/memoh"
+  cp "$ROOT/conf/app.docker.toml" "$home/memoh/config.toml"
+  sed -i.bak "s|default_image = .*|default_image = \"$image\"|" "$home/memoh/config.toml"
+  rm -f "$home/memoh/config.toml.bak"
+}
+
+FRESH_HOME="$TMPDIR/fresh"
+MEMOH_INSTALL_MODE=fresh run_installer "$FRESH_HOME" v0.19.0 "$TMPDIR/fresh.out"
+fresh_image=$(read_workspace_image "$FRESH_HOME/memoh/config.toml")
+[ "$fresh_image" = "memohai/workspace:0.19.0-debian" ] || {
+  echo "fresh install workspace image = $fresh_image" >&2
+  cat "$TMPDIR/fresh.out" >&2
+  exit 1
+}
+grep -q "memohai/server:0.19.0" "$FRESH_HOME/memoh/docker-compose.yml"
+grep -q "MEMOH_INSTALLER_WORKSPACE_IMAGE='memohai/workspace:0.19.0-debian'" "$FRESH_HOME/memoh/.env"
+
+FALLBACK_HOME="$TMPDIR/fallback"
+MEMOH_INSTALL_MODE=fresh run_installer "$FALLBACK_HOME" "" "$TMPDIR/fallback.out"
+fallback_image=$(read_workspace_image "$FALLBACK_HOME/memoh/config.toml")
+[ "$fallback_image" = "memohai/workspace:debian-latest" ] || {
+  echo "fallback workspace image = $fallback_image" >&2
+  cat "$TMPDIR/fallback.out" >&2
+  exit 1
+}
+grep -q "memohai/server:latest" "$FALLBACK_HOME/memoh/docker-compose.yml"
+
+MANAGED_HOME="$TMPDIR/managed"
+prepare_upgrade "$MANAGED_HOME" "memohai/workspace:debian"
+MEMOH_INSTALL_MODE=upgrade run_installer "$MANAGED_HOME" v0.19.0 "$TMPDIR/managed-19.out"
+MEMOH_INSTALL_MODE=upgrade run_installer "$MANAGED_HOME" v0.20.0 "$TMPDIR/managed-20.out"
+managed_image=$(read_workspace_image "$MANAGED_HOME/memoh/config.toml")
+[ "$managed_image" = "memohai/workspace:0.20.0-debian" ] || {
+  echo "managed upgrade workspace image = $managed_image" >&2
+  cat "$TMPDIR/managed-20.out" >&2
+  exit 1
+}
+grep -q "MEMOH_INSTALLER_WORKSPACE_IMAGE='memohai/workspace:0.20.0-debian'" "$MANAGED_HOME/memoh/.env"
+
+MISSING_HOME="$TMPDIR/missing"
+prepare_upgrade "$MISSING_HOME" "memohai/workspace:debian"
+sed -i.bak '/^[[:space:]]*default_image[[:space:]]*=/d' "$MISSING_HOME/memoh/config.toml"
+rm "$MISSING_HOME/memoh/config.toml.bak"
+MEMOH_INSTALL_MODE=upgrade run_installer "$MISSING_HOME" v0.20.0 "$TMPDIR/missing.out"
+missing_image=$(read_workspace_image "$MISSING_HOME/memoh/config.toml")
+[ "$missing_image" = "memohai/workspace:0.20.0-debian" ] || {
+  echo "missing default workspace image = $missing_image" >&2
+  cat "$TMPDIR/missing.out" >&2
+  exit 1
+}
+
+CUSTOM_HOME="$TMPDIR/custom"
+prepare_upgrade "$CUSTOM_HOME" "registry.example/workspace:gold"
+printf "MEMOH_INSTALLER_WORKSPACE_IMAGE='memohai/workspace:0.19.0-debian'\n" > "$CUSTOM_HOME/memoh/.env"
+MEMOH_INSTALL_MODE=upgrade run_installer "$CUSTOM_HOME" v0.20.0 "$TMPDIR/custom.out"
+custom_image=$(read_workspace_image "$CUSTOM_HOME/memoh/config.toml")
+[ "$custom_image" = "registry.example/workspace:gold" ] || {
+  echo "custom upgrade workspace image = $custom_image" >&2
+  cat "$TMPDIR/custom.out" >&2
+  exit 1
+}
+if grep -q '^MEMOH_INSTALLER_WORKSPACE_IMAGE=' "$CUSTOM_HOME/memoh/.env"; then
+  echo "custom workspace image was marked as installer-managed" >&2
+  cat "$CUSTOM_HOME/memoh/.env" >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #1036.

## What changed

- use `debian-latest` for packaged defaults, matching the server `latest` release channel
- pin fresh one-click installs to `workspace:${MEMOH_DOCKER_VERSION}-debian`
- advance installer-managed images during upgrades and preserve user-owned references
- update the section that owns `default_image`, including supported legacy `[workspace]` configs
- cover fresh installs, release lookup fallback, repeated upgrades, legacy section ownership, missing config keys, and custom images in Installer CI

## Why

The Docker workflow publishes `workspace:debian` from `main`. Release builds publish `workspace:debian-latest` and versioned `workspace:<version>-debian`. The prior default combined a release server with a main-branch workspace, allowing their workspace contracts to diverge.

The installer now gives server, web, and workspace images one release identity. `MEMOH_INSTALLER_WORKSPACE_IMAGE` records ownership in `.env`; an edited `default_image` remains user-owned.

## Validation

- `scripts/test-install-root-guard.sh`
- `scripts/test-install-workspace-image.sh`
- `/bin/dash scripts/test-install-workspace-image.sh`
- `mise exec -- go test ./...`
- `shellcheck -s sh scripts/test-install-workspace-image.sh`
- `actionlint .github/workflows/install-ci.yml`
- OCI manifest resolution for `server:0.19.0`, `workspace:0.19.0-debian`, and `workspace:debian-latest`