### PR TITLE
fix(compaction): tolerate slow summarizers and show live chat activity

### DIFF
--- a/apps/web/src/composables/api/useChat.types.ts
+++ b/apps/web/src/composables/api/useChat.types.ts
@@ -55,12 +55,19 @@ export interface BotSessionActivityPingEvent {
   type: 'ping'
 }
 
+export interface SessionCompactionEvent {
+  type: 'session_compaction'
+  /** Complete, permission-filtered set of sessions currently compacting. */
+  session_ids: string[]
+}
+
 export type BotSessionActivityEvent =
   | SessionTouchedEvent
   | SessionTitleChangedEvent
   | SessionCreatedEvent
   | BotSessionActivityDroppedEvent
   | BotSessionActivityPingEvent
+  | SessionCompactionEvent
 
 export interface FetchMessagesOptions {
   limit?: number

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1093,6 +1093,7 @@
     "infoNoData": "No data available",
     "compactNow": "Compact Now",
     "compactSuccess": "Context compaction completed",
+    "compactingContext": "Compacting context…",
     "compactFailed": "Context compaction failed",
     "sessionStreaming": "Generating",
     "slash": {

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1061,6 +1061,7 @@
     "infoNoData": "利用可能なデータがありません",
     "compactNow": "今すぐコンパクトに",
     "compactSuccess": "コンテキストの圧縮が完了しました",
+    "compactingContext": "コンテキストを圧縮中…",
     "compactFailed": "コンテキストの圧縮に失敗しました",
     "sessionStreaming": "生成中",
     "slash": {

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1093,6 +1093,7 @@
     "infoNoData": "暂无数据",
     "compactNow": "立即压缩",
     "compactSuccess": "上下文压缩完成",
+    "compactingContext": "正在压缩上下文…",
     "compactFailed": "上下文压缩失败",
     "sessionStreaming": "生成中",
     "slash": {

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -379,6 +379,7 @@
               :command-panel="composerCommandPanel"
               :error-message="composerError"
               :pending-user-input="pendingUserInput"
+              :compacting="isCompactingSession"
               @select-command-item="selectCommandResultItem"
               @dismiss-command="clearCurrentCommandEvent"
               @reveal-composer="handleDockRevealComposer"

--- a/apps/web/src/pages/home/components/composer-dock.vue
+++ b/apps/web/src/pages/home/components/composer-dock.vue
@@ -14,6 +14,7 @@
         :approvals="approvals"
         :command-panel="commandPanel"
         :error-message="errorMessage"
+        :compacting="compacting"
         class="mb-2"
         @select-command-item="emit('selectCommandItem', $event)"
         @dismiss-command="emit('dismissCommand')"
@@ -85,6 +86,7 @@ const props = defineProps<{
   commandPanel: CommandPanelData | null
   errorMessage: string
   pendingUserInput: UIUserInput | null
+  compacting?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -94,7 +96,7 @@ const emit = defineEmits<{
 }>()
 
 const stackVisible = computed(() => Boolean(
-  props.errorMessage || props.commandPanel || props.approvals.length,
+  props.errorMessage || props.commandPanel || props.approvals.length || props.compacting,
 ))
 
 // Box-tier mutex: while an ask_user request is pending the capsule owns the

--- a/apps/web/src/pages/home/components/composer-panel-compaction.vue
+++ b/apps/web/src/pages/home/components/composer-panel-compaction.vue
@@ -1,0 +1,9 @@
+<template>
+  <div
+    role="status"
+    aria-live="polite"
+    class="px-1.5 py-1 text-body"
+  >
+    <span class="tool-shimmer-text">{{ $t('chat.compactingContext') }}</span>
+  </div>
+</template>

--- a/apps/web/src/pages/home/components/composer-panel.vue
+++ b/apps/web/src/pages/home/components/composer-panel.vue
@@ -20,6 +20,7 @@
           @select="emit('selectCommandItem', $event)"
           @dismiss="emit('dismissCommand')"
         />
+        <ComposerPanelCompaction v-else-if="section.kind === 'compaction'" />
         <Transition
           v-else
           mode="out-in"
@@ -78,6 +79,7 @@ import ComposerCapsule from './composer-capsule.vue'
 import ComposerPanelApproval from './composer-panel-approval.vue'
 import ComposerPanelCommand from './composer-panel-command.vue'
 import ComposerPanelError from './composer-panel-error.vue'
+import ComposerPanelCompaction from './composer-panel-compaction.vue'
 import type { PendingApprovalItem } from '../composables/usePendingApprovals'
 import type { CommandActionListItem } from '@/composables/api/useChat'
 
@@ -94,11 +96,13 @@ type PanelSection =
   | { kind: 'error', message: string }
   | { kind: 'command', panel: CommandPanelData }
   | { kind: 'approval' }
+  | { kind: 'compaction' }
 
 const props = defineProps<{
   approvals: PendingApprovalItem[]
   commandPanel: CommandPanelData | null
   errorMessage: string
+  compacting?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -112,6 +116,7 @@ const sections = computed<PanelSection[]>(() => {
   const list: PanelSection[] = []
   if (props.errorMessage) list.push({ kind: 'error', message: props.errorMessage })
   if (props.commandPanel) list.push({ kind: 'command', panel: props.commandPanel })
+  if (props.compacting) list.push({ kind: 'compaction' })
   if (approvalHead.value) list.push({ kind: 'approval' })
   return list
 })

--- a/apps/web/src/pages/home/composables/useSessionInfo.ts
+++ b/apps/web/src/pages/home/composables/useSessionInfo.ts
@@ -73,14 +73,17 @@ export function useSessionInfo(options: UseSessionInfoOptions = {}) {
   // invalidation of this composable's own query.
   const { t } = useI18n()
   const queryCache = useQueryCache()
-  const isCompacting = ref(false)
+  const isCompacting = computed(() => chatStore.isSessionCompacting(
+    currentBotId.value ?? '', sessionId.value ?? '',
+  ))
 
   async function triggerCompact() {
     const botId = currentBotId.value
     const sid = sessionId.value
-    if (!botId || !sid || isCompacting.value) return
+    if (!botId || !sid) return
+    const finish = chatStore.beginSessionCompaction(botId, sid)
+    if (!finish) return
 
-    isCompacting.value = true
     try {
       await postBotsByBotIdSessionsBySessionIdCompact({
         path: { bot_id: botId, session_id: sid },
@@ -93,7 +96,7 @@ export function useSessionInfo(options: UseSessionInfoOptions = {}) {
       toast.error(resolveApiErrorMessage(error, t('chat.compactFailed')))
     }
     finally {
-      isCompacting.value = false
+      finish()
     }
   }
 

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -152,6 +152,7 @@ export const useChatStore = defineStore('chat', () => {
   const {
     ensureSessionSummary, ensureVisibleSessionSummary, loadMoreSessions,
     handleActivity: handleBotSessionsActivityEvent,
+    isSessionCompacting, beginSessionCompaction,
     reset: resetSessionActivity,
   } = createSessionActivity({
     currentBotId,
@@ -585,6 +586,7 @@ export const useChatStore = defineStore('chat', () => {
     initializeWorkspaceTargetSelection, resetWorkspaceTargetSelection,
     chatReadOnlyFor, chatCanForkFor, isChatViewStreaming,
     isChatViewCreatingSession, streaming, streamingSessionId,
+    isSessionCompacting, beginSessionCompaction,
     sessions, sessionsCursor, hasMoreSessions, loadingMoreSessions,
     loadMoreSessions, activeSession, knownSessions, knownSessionSummary,
     workdirSessionsFor, workdirSessionsState,

--- a/apps/web/src/store/chat/realtime.test.ts
+++ b/apps/web/src/store/chat/realtime.test.ts
@@ -331,10 +331,20 @@ describe('chat realtime controller', () => {
     controller.startBotSessionsActivityStream('bot-1')
     await retryingStreams[0]!.attempt!(new AbortController().signal)
     const staleHandler = activityHandlers[0]!
+    vi.mocked(callbacks.onBotSessionsActivityEvent).mockClear()
 
     controller.stopStreams()
     staleHandler({ type: 'ping' })
 
     expect(callbacks.onBotSessionsActivityEvent).not.toHaveBeenCalled()
+  })
+
+  it('clears compaction activity when the activity stream ends', async () => {
+    const { controller, callbacks, retryingStreams } = makeController()
+    controller.startBotSessionsActivityStream('bot-1')
+    await retryingStreams[0]!.attempt!(new AbortController().signal)
+    expect(callbacks.onBotSessionsActivityEvent).toHaveBeenLastCalledWith('bot-1', {
+      type: 'session_compaction', session_ids: [],
+    })
   })
 })

--- a/apps/web/src/store/chat/realtime.ts
+++ b/apps/web/src/store/chat/realtime.ts
@@ -59,7 +59,7 @@ function isRuntimeEvent(event: UIStreamEvent): event is UIRuntimeEvent {
 }
 
 // Owns chat transport lifecycles. The WebSocket carries both turn commands and
-// session runtime subscriptions; the bot-wide SSE remains sidebar metadata only.
+// session runtime subscriptions; the bot-wide SSE carries lightweight activity.
 export function createChatRealtimeController(
   callbacks: ChatRealtimeCallbacks,
   transport: ChatRealtimeTransport = defaultTransport,
@@ -247,10 +247,18 @@ export function createChatRealtimeController(
     const generation = botSessionsActivityGeneration
     botSessionsActivityStream.start(async (signal) => {
       if (generation !== botSessionsActivityGeneration || signal.aborted) return
-      await transport.streamBotSessionsActivityEvents(bid, signal, (event) => {
-        if (generation !== botSessionsActivityGeneration) return
-        callbacks.onBotSessionsActivityEvent(bid, event)
-      })
+      try {
+        await transport.streamBotSessionsActivityEvents(bid, signal, (event) => {
+          if (generation !== botSessionsActivityGeneration) return
+          callbacks.onBotSessionsActivityEvent(bid, event)
+        })
+      } finally {
+        // A disconnected stream cannot vouch for a still-running compaction.
+        // The server sends a fresh snapshot when this stream reconnects.
+        if (generation === botSessionsActivityGeneration) {
+          callbacks.onBotSessionsActivityEvent(bid, { type: 'session_compaction', session_ids: [] })
+        }
+      }
     })
   }
 

--- a/apps/web/src/store/chat/session-activity.test.ts
+++ b/apps/web/src/store/chat/session-activity.test.ts
@@ -1,0 +1,55 @@
+import { ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { createSessionActivity } from './session-activity'
+
+vi.mock('@/composables/api/useChat', () => ({ fetchSession: vi.fn(), fetchSessions: vi.fn() }))
+
+function activity() {
+  return createSessionActivity({
+    currentBotId: ref('bot-1'), sessionId: ref('session-1'),
+    userScopeGeneration: () => 0, currentSessionListRevision: () => 0, currentSelectRequest: () => 0,
+    knownSession: () => null, rememberSession: vi.fn(), sessionsCursor: ref(null),
+    hasMoreSessions: ref(false), loadingMoreSessions: ref(false), appendSessions: vi.fn(),
+    hasListedSession: () => false, touchKnownSession: () => ({ source: 'listed' }),
+    updateKnownSessionTitle: vi.fn(), refreshSessionsList: vi.fn(async () => {}),
+  })
+}
+
+describe('session compaction activity', () => {
+  it('replaces the snapshot on completion/reconnect and scopes it to its bot and session', () => {
+    const state = activity()
+    state.handleActivity('bot-1', { type: 'session_compaction', session_ids: ['session-1', 'session-2'] })
+    expect(state.isSessionCompacting('bot-1', 'session-1')).toBe(true)
+    expect(state.isSessionCompacting('bot-2', 'session-1')).toBe(false)
+    expect(state.isSessionCompacting('bot-1', 'session-3')).toBe(false)
+    state.handleActivity('bot-1', { type: 'session_compaction', session_ids: ['session-2'] })
+    expect(state.isSessionCompacting('bot-1', 'session-1')).toBe(false)
+    expect(state.isSessionCompacting('bot-1', 'session-2')).toBe(true)
+    state.handleActivity('bot-1', { type: 'session_compaction', session_ids: [] })
+    expect(state.isSessionCompacting('bot-1', 'session-2')).toBe(false)
+  })
+
+  it('shows manual requests immediately, deduplicates them, and waits for both owners to settle', () => {
+    const state = activity()
+    const done = state.beginSessionCompaction('bot-1', 'session-1')!
+    expect(state.isSessionCompacting('bot-1', 'session-1')).toBe(true)
+    expect(state.beginSessionCompaction('bot-1', 'session-1')).toBeNull()
+    state.handleActivity('bot-1', { type: 'session_compaction', session_ids: ['session-1'] })
+    done()
+    expect(state.isSessionCompacting('bot-1', 'session-1')).toBe(true)
+    state.handleActivity('bot-1', { type: 'session_compaction', session_ids: [] })
+    expect(state.isSessionCompacting('bot-1', 'session-1')).toBe(false)
+  })
+
+  it('does not let an old request completion clear a new request after reset', () => {
+    const state = activity()
+    const oldDone = state.beginSessionCompaction('bot-1', 'session-1')!
+    state.reset()
+    expect(state.isSessionCompacting('bot-1', 'session-1')).toBe(false)
+    const done = state.beginSessionCompaction('bot-1', 'session-1')!
+    oldDone()
+    expect(state.isSessionCompacting('bot-1', 'session-1')).toBe(true)
+    done()
+    expect(state.isSessionCompacting('bot-1', 'session-1')).toBe(false)
+  })
+})

--- a/apps/web/src/store/chat/session-activity.ts
+++ b/apps/web/src/store/chat/session-activity.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import { ref, type Ref } from 'vue'
 import {
   fetchSession,
   fetchSessions,
@@ -27,7 +27,24 @@ export function createSessionActivity(deps: {
   refreshSessionsList: (botId: string) => Promise<void>
 }) {
   const visibleSummaryRequests = new Map<string, Promise<SessionSummary | null>>()
+  const compactingSessions = ref<Record<string, string[]>>({})
+  const manualCompactions = ref(new Map<string, symbol>())
   let loadMoreRequestVersion = 0
+
+  function isSessionCompacting(botId: string, sessionId: string): boolean {
+    return manualCompactions.value.has(`${botId}\u0000${sessionId}`)
+      || (compactingSessions.value[botId]?.includes(sessionId) ?? false)
+  }
+
+  function beginSessionCompaction(botId: string, sessionId: string): (() => void) | null {
+    if (!botId || !sessionId || isSessionCompacting(botId, sessionId)) return null
+    const key = `${botId}\u0000${sessionId}`
+    const request = Symbol()
+    manualCompactions.value.set(key, request)
+    return () => {
+      if (manualCompactions.value.get(key) === request) manualCompactions.value.delete(key)
+    }
+  }
 
   async function ensureSessionSummary(
     botId: string,
@@ -123,6 +140,10 @@ export function createSessionActivity(deps: {
   }
 
   function handleActivity(botId: string, event: BotSessionActivityEvent) {
+    if (event.type === 'session_compaction') {
+      compactingSessions.value[botId] = event.session_ids
+      return
+    }
     if (event.type === 'ping') return
     if (event.type === 'dropped') {
       void deps.refreshSessionsList(botId)
@@ -157,7 +178,11 @@ export function createSessionActivity(deps: {
     ensureVisibleSessionSummary,
     loadMoreSessions,
     handleActivity,
+    isSessionCompacting,
+    beginSessionCompaction,
     reset: () => {
+      compactingSessions.value = {}
+      manualCompactions.value.clear()
       visibleSummaryRequests.clear()
       loadMoreRequestVersion += 1
       deps.loadingMoreSessions.value = false

--- a/cmd/agent/http_providers.go
+++ b/cmd/agent/http_providers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/felinics/memoh/internal/accounts"
 	"github.com/felinics/memoh/internal/agent/application"
 	"github.com/felinics/memoh/internal/agent/background"
+	"github.com/felinics/memoh/internal/agent/context/compaction"
 	toolapproval "github.com/felinics/memoh/internal/agent/decision/approval"
 	userinput "github.com/felinics/memoh/internal/agent/decision/input"
 	acpagent "github.com/felinics/memoh/internal/agent/runtime/acp"
@@ -72,7 +73,7 @@ func provideAuthHandler(log *slog.Logger, accountService *accounts.Service, rc *
 	return handlers.NewAuthHandler(log, accountService, rc.JwtSecret, rc.JwtExpiresIn)
 }
 
-func provideMessageHandler(log *slog.Logger, msgService *message.DBService, sessionService *sessionpkg.Service, mediaService *media.Service, botService *bots.Service, accountService *accounts.Service, hub *event.Hub, toolApproval *toolapproval.Service, userInput *userinput.Service, bgManager *background.Manager, acpPool *acpagent.SessionPool, pipeline *timeline.Pipeline) *handlers.MessageHandler {
+func provideMessageHandler(log *slog.Logger, msgService *message.DBService, sessionService *sessionpkg.Service, mediaService *media.Service, botService *bots.Service, accountService *accounts.Service, hub *event.Hub, toolApproval *toolapproval.Service, userInput *userinput.Service, bgManager *background.Manager, acpPool *acpagent.SessionPool, pipeline *timeline.Pipeline, compactionService *compaction.Service) *handlers.MessageHandler {
 	h := handlers.NewMessageHandler(log, msgService, sessionService, botService, accountService, hub)
 	h.SetMediaService(mediaService)
 	h.SetToolApprovalService(toolApproval)
@@ -80,6 +81,7 @@ func provideMessageHandler(log *slog.Logger, msgService *message.DBService, sess
 	h.SetBackgroundManager(bgManager)
 	h.SetRuntimeResetService(acpPool)
 	h.SetProjectionCache(pipeline)
+	h.SetCompactionActivity(compactionService)
 	return h
 }
 

--- a/cmd/internal/core/providers.go
+++ b/cmd/internal/core/providers.go
@@ -638,6 +638,7 @@ func provideAgentService(log *slog.Logger, a *native.Agent, modelsService *model
 	}
 	if compactionService != nil {
 		compactionService.SetHookService(hookService)
+		compactionService.SetEventPublisher(eventHub)
 	}
 	if workspaceManager != nil {
 		workspaceManager.SetHookService(hookService)

--- a/internal/agent/application/service.go
+++ b/internal/agent/application/service.go
@@ -125,6 +125,7 @@ type Service struct {
 	pipeline                *timeline.Pipeline
 	streamHTTPClient        *http.Client
 	nonStreamingHTTPClient  *http.Client
+	compactionHTTPClient    *http.Client
 	streamIdleTimeout       time.Duration
 	streamIdleTimeoutMax    time.Duration
 	bgManager               *background.Manager
@@ -198,6 +199,15 @@ func NewService(
 		Transport: nonStreamingTransport,
 		Timeout:   10 * time.Minute,
 	}
+	// The summarizer sends one large cold prompt whose first byte routinely
+	// takes 60-93s upstream; the interactive 30s header deadline would kill
+	// every automatic pass while manual /compact (SDK default client) works.
+	compactionTransport := streamTransport.Clone()
+	compactionTransport.ResponseHeaderTimeout = 3 * time.Minute
+	compactionHTTPClient := &http.Client{
+		Transport: compactionTransport,
+		Timeout:   10 * time.Minute,
+	}
 
 	return &Service{
 		agent:                  a,
@@ -209,6 +219,7 @@ func NewService(
 		accountService:         accountService,
 		streamHTTPClient:       streamHTTPClient,
 		nonStreamingHTTPClient: nonStreamingHTTPClient,
+		compactionHTTPClient:   compactionHTTPClient,
 		timeout:                timeout,
 		memorySearchTimeout:    defaultMemorySearchTimeout,
 		clockLocation:          clockLocation,

--- a/internal/agent/application/service_compaction.go
+++ b/internal/agent/application/service_compaction.go
@@ -263,6 +263,6 @@ func (s *Service) buildCompactionConfig(ctx context.Context, req ChatRequest, bo
 	cfg.BotID = req.BotID
 	cfg.SessionID = req.ThreadID
 	cfg.TotalInputTokens = inputTokens
-	cfg.HTTPClient = s.nonStreamingHTTPClient
+	cfg.HTTPClient = s.compactionHTTPClient
 	return cfg, nil
 }

--- a/internal/agent/application/service_compaction_client_test.go
+++ b/internal/agent/application/service_compaction_client_test.go
@@ -1,0 +1,36 @@
+package application
+
+import (
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestCompactionClientOutlivesColdSummarizerTTFB(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(slog.New(slog.DiscardHandler), nil, nil, nil, nil, nil, nil, nil, 0)
+
+	if svc.compactionHTTPClient == nil {
+		t.Fatal("compaction HTTP client not wired")
+	}
+	transport, ok := svc.compactionHTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("compaction client transport = %T, want *http.Transport", svc.compactionHTTPClient.Transport)
+	}
+	if transport.ResponseHeaderTimeout < 2*time.Minute {
+		t.Fatalf("compaction ResponseHeaderTimeout = %v, want >= 2m (cold summarizer TTFB measured 60-93s)", transport.ResponseHeaderTimeout)
+	}
+
+	nonStreaming, ok := svc.nonStreamingHTTPClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("non-streaming transport = %T, want *http.Transport", svc.nonStreamingHTTPClient.Transport)
+	}
+	if nonStreaming.ResponseHeaderTimeout != 30*time.Second {
+		t.Fatalf("non-streaming ResponseHeaderTimeout = %v, want unchanged 30s", nonStreaming.ResponseHeaderTimeout)
+	}
+	if svc.compactionHTTPClient == svc.nonStreamingHTTPClient {
+		t.Fatal("compaction must not share the interactive non-streaming client")
+	}
+}

--- a/internal/agent/context/compaction/service.go
+++ b/internal/agent/context/compaction/service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	messageevent "github.com/felinics/memoh/internal/chat/event"
 	"github.com/felinics/memoh/internal/db"
 	"github.com/felinics/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/felinics/memoh/internal/db/store"
@@ -56,6 +58,7 @@ const compactionFailureCooldown = 5 * time.Minute
 // done closes after res/err are set, so concurrent sync callers can wait for
 // the owner and reuse its outcome instead of skipping or double-running.
 type inflightRun struct {
+	botID   string
 	done    chan struct{}
 	waiters atomic.Int32
 	res     Result
@@ -68,6 +71,7 @@ type Service struct {
 	hookService *hooks.Service
 	logger      *slog.Logger
 	nowFn       func() time.Time
+	events      messageevent.Publisher
 
 	inflightMu sync.Mutex
 	inflight   map[string]*inflightRun
@@ -139,6 +143,34 @@ func (s *Service) clearCompactionFailure(sessionID string) {
 
 func (s *Service) SetHookService(h *hooks.Service) {
 	s.hookService = h
+}
+
+// SetEventPublisher wires lightweight activity notifications at startup.
+func (s *Service) SetEventPublisher(p messageevent.Publisher) {
+	s.events = p
+}
+
+// ActiveSessions is a process-local activity snapshot, not an admission gate.
+func (s *Service) ActiveSessions(botID string) []string {
+	s.inflightMu.Lock()
+	defer s.inflightMu.Unlock()
+	ids := make([]string, 0)
+	for id, run := range s.inflight {
+		if run.botID == botID {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (s *Service) publishActivity(botID string) {
+	if s.events != nil {
+		s.events.Publish(messageevent.Event{
+			Type: messageevent.EventTypeCompactionChanged, BotID: botID,
+			Data: json.RawMessage(`{}`),
+		})
+	}
 }
 
 // ShouldCompact returns true if inputTokens exceeds the threshold.
@@ -214,6 +246,9 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 	var compactErr error
 	defer func() {
 		s.endSessionCompaction(cfg.SessionID, run, compactRes, compactErr)
+		if run.botID != "" {
+			s.publishActivity(cfg.BotID)
+		}
 	}()
 
 	// Manual (user-initiated) compaction bypasses the cooldown: the user may
@@ -227,6 +262,11 @@ func (s *Service) runCompaction(ctx context.Context, cfg TriggerConfig) (Result,
 		compactRes = Result{Status: StatusNoop}
 		return compactRes, nil, nil
 	}
+
+	s.inflightMu.Lock()
+	run.botID = cfg.BotID
+	s.inflightMu.Unlock()
+	s.publishActivity(cfg.BotID)
 
 	preHookRan := false
 	defer func() {

--- a/internal/agent/context/compaction/service_activity_test.go
+++ b/internal/agent/context/compaction/service_activity_test.go
@@ -1,0 +1,83 @@
+package compaction
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	messageevent "github.com/felinics/memoh/internal/chat/event"
+)
+
+func TestCompactionActivityLifecycle(t *testing.T) {
+	t.Parallel()
+	for _, manual := range []bool{false, true} {
+		t.Run(map[bool]string{false: "automatic", true: "manual"}[manual], func(t *testing.T) {
+			started, release := make(chan struct{}), make(chan struct{})
+			svc := NewService(slog.New(slog.DiscardHandler), &fakeQueries{listStarted: started, listRelease: release})
+			hub := messageevent.NewHub()
+			svc.SetEventPublisher(hub)
+			cfg := TriggerConfig{BotID: "00000000-0000-0000-0000-00000000b715", SessionID: "00000000-0000-0000-0000-00000000e715", Manual: manual}
+			sub, cancel := hub.Subscribe(cfg.BotID, 8)
+			defer cancel()
+			done := make(chan error, 1)
+			go func() {
+				_, err := svc.RunCompactionSync(context.Background(), cfg)
+				done <- err
+			}()
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				close(release)
+				t.Fatal("compaction did not start")
+			}
+			ids := svc.ActiveSessions(cfg.BotID)
+			other := svc.ActiveSessions("other-bot")
+			close(release)
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			if len(ids) != 1 || ids[0] != cfg.SessionID || len(other) != 0 {
+				t.Fatalf("incorrect active sessions: %v, other bot: %v", ids, other)
+			}
+			if ids := svc.ActiveSessions(cfg.BotID); len(ids) != 0 {
+				t.Fatalf("finished compaction still active: %v", ids)
+			}
+			for range 2 {
+				select {
+				case ev := <-sub.Events:
+					if ev.Type != messageevent.EventTypeCompactionChanged {
+						t.Fatalf("unexpected event: %v", ev)
+					}
+				default:
+					t.Fatal("missing start/end notification")
+				}
+			}
+		})
+	}
+}
+
+func TestCompactionActivityClearsAfterPanicAndSkipsCooldown(t *testing.T) {
+	t.Parallel()
+	svc := NewService(slog.New(slog.DiscardHandler), &fakeQueries{listPanic: true, listStarted: make(chan struct{})})
+	hub := messageevent.NewHub()
+	svc.SetEventPublisher(hub)
+	cfg := TriggerConfig{BotID: "00000000-0000-0000-0000-00000000b715", SessionID: "00000000-0000-0000-0000-00000000e715"}
+	sub, cancel := hub.Subscribe(cfg.BotID, 8)
+	defer cancel()
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected injected panic")
+			}
+		}()
+		_, _ = svc.RunCompactionSync(context.Background(), cfg)
+	}()
+	if len(svc.ActiveSessions(cfg.BotID)) != 0 || len(sub.Events) != 2 {
+		t.Fatal("panic must clear activity and notify subscribers")
+	}
+	_, _ = svc.RunCompactionSync(context.Background(), cfg)
+	if len(sub.Events) != 2 {
+		t.Fatal("cooldown skips must not announce compaction")
+	}
+}

--- a/internal/chat/event/hub.go
+++ b/internal/chat/event/hub.go
@@ -30,6 +30,8 @@ const (
 	EventTypeSessionTitleUpdated EventType = "session_title_updated"
 	// EventTypeBackgroundTask is emitted for live background task updates.
 	EventTypeBackgroundTask EventType = "background_task"
+	// EventTypeCompactionChanged invalidates the bot's live compaction snapshot.
+	EventTypeCompactionChanged EventType = "compaction_changed"
 )
 
 // Event is the normalized payload emitted by the in-process message event hub.

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -31,18 +31,19 @@ import (
 
 // MessageHandler handles bot-scoped messaging endpoints.
 type MessageHandler struct {
-	messageService  messagepkg.Service
-	sessionService  *session.Service
-	runtimeResets   messageRuntimeResetService
-	messageEvents   messageevent.Subscriber
-	mediaService    *media.Service
-	botService      *bots.Service
-	accountService  *accounts.Service
-	toolApproval    *toolapproval.Service
-	userInput       *userinput.Service
-	bgManager       *background.Manager
-	projectionCache messageProjectionCache
-	logger          *slog.Logger
+	messageService     messagepkg.Service
+	sessionService     *session.Service
+	runtimeResets      messageRuntimeResetService
+	messageEvents      messageevent.Subscriber
+	mediaService       *media.Service
+	botService         *bots.Service
+	accountService     *accounts.Service
+	toolApproval       *toolapproval.Service
+	userInput          *userinput.Service
+	bgManager          *background.Manager
+	projectionCache    messageProjectionCache
+	compactionActivity interface{ ActiveSessions(string) []string }
+	logger             *slog.Logger
 }
 
 type messageProjectionCache interface {
@@ -94,6 +95,10 @@ func (h *MessageHandler) SetMediaService(svc *media.Service) {
 
 func (h *MessageHandler) SetProjectionCache(cache messageProjectionCache) {
 	h.projectionCache = cache
+}
+
+func (h *MessageHandler) SetCompactionActivity(activity interface{ ActiveSessions(string) []string }) {
+	h.compactionActivity = activity
 }
 
 func (h *MessageHandler) SetToolApprovalService(svc *toolapproval.Service) {

--- a/internal/handlers/message_stream.go
+++ b/internal/handlers/message_stream.go
@@ -73,6 +73,23 @@ func (h *MessageHandler) StreamSessionsActivityEvents(c echo.Context) error {
 	defer cancel()
 
 	cache := newSessionCache(h.logger, h.sessionService)
+	// Subscribe before sampling: changes racing the snapshot remain queued.
+	// Re-sample on notification instead of replaying potentially stale payloads.
+	writeCompaction := func() error {
+		if h.compactionActivity == nil {
+			return nil
+		}
+		ids := h.visibleCompactingSessions(c.Request().Context(), channelIdentityID, botID, perms, cache)
+		return writeSSEJSON(writer, flusher, map[string]any{
+			"type": "session_compaction", "session_ids": ids,
+			// Older clients fall through to session_created for unknown types
+			// and trim session_id unconditionally. An empty id makes them ignore it.
+			"session_id": "",
+		})
+	}
+	if err := writeCompaction(); err != nil {
+		return nil
+	}
 
 	heartbeat := time.NewTicker(sseHeartbeatInterval)
 	defer heartbeat.Stop()
@@ -82,6 +99,10 @@ func (h *MessageHandler) StreamSessionsActivityEvents(c echo.Context) error {
 		case <-c.Request().Context().Done():
 			return nil
 		case <-heartbeat.C:
+			// Also repairs missed notifications when a subscriber buffer overflowed.
+			if err := writeCompaction(); err != nil {
+				return nil
+			}
 			if err := writeSSEJSON(writer, flusher, map[string]any{"type": "ping"}); err != nil {
 				return nil
 			}
@@ -106,6 +127,10 @@ func (h *MessageHandler) StreamSessionsActivityEvents(c echo.Context) error {
 			}
 
 			switch event.Type {
+			case messageevent.EventTypeCompactionChanged:
+				if err := writeCompaction(); err != nil {
+					return nil
+				}
 			case messageevent.EventTypeMessageCreated:
 				var message messagepkg.Message
 				if err := json.Unmarshal(event.Data, &message); err != nil {
@@ -185,6 +210,18 @@ func (h *MessageHandler) StreamSessionsActivityEvents(c echo.Context) error {
 			}
 		}
 	}
+}
+
+func (h *MessageHandler) visibleCompactingSessions(ctx context.Context, userID, botID string, perms []string, cache *sessionCache) []string {
+	ids := make([]string, 0)
+	if h.compactionActivity != nil {
+		for _, id := range h.compactionActivity.ActiveSessions(botID) {
+			if canDeliverSessionActivity(ctx, userID, botID, perms, cache, id) {
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids
 }
 
 // canDeliverSessionActivity returns true when the subscriber may see an

--- a/internal/handlers/message_stream_test.go
+++ b/internal/handlers/message_stream_test.go
@@ -8,11 +8,32 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/felinics/memoh/internal/bots"
 	messageevent "github.com/felinics/memoh/internal/chat/event"
 	session "github.com/felinics/memoh/internal/chat/thread"
 	"github.com/felinics/memoh/internal/db/postgres/sqlc"
 	dbstore "github.com/felinics/memoh/internal/db/store"
 )
+
+type compactionActivityStub []string
+
+func (s compactionActivityStub) ActiveSessions(string) []string { return s }
+
+func TestCompactionActivityFiltersUnreadableSessions(t *testing.T) {
+	t.Parallel()
+	cache := newSessionCache(nil, nil)
+	cache.rows["mine"] = session.Thread{ID: "mine", BotID: "bot", Type: session.TypeChat, CreatedByUserID: "me"}
+	cache.rows["private"] = session.Thread{ID: "private", BotID: "bot", Type: session.TypeChat, CreatedByUserID: "other"}
+	cache.rows["internal"] = session.Thread{ID: "internal", BotID: "bot", Type: session.TypeSubagent, CreatedByUserID: "me"}
+	h := &MessageHandler{compactionActivity: compactionActivityStub{"mine", "private", "internal", "missing"}}
+	ids := h.visibleCompactingSessions(context.Background(), "me", "bot", []string{bots.PermissionChat}, cache)
+	if len(ids) != 1 || ids[0] != "mine" {
+		t.Fatalf("unexpected visible compactions: %v", ids)
+	}
+	if ids := h.visibleCompactingSessions(context.Background(), "me", "bot", nil, cache); len(ids) != 0 {
+		t.Fatalf("no permission must expose no compactions: %v", ids)
+	}
+}
 
 // sessionCreateRecorder is a minimal sqlc-shaped fake that records the row a
 // CreateSession call returns so we can assert what the service publishes.


### PR DESCRIPTION
Automatic context compaction used the interactive HTTP client's 30-second response-header timeout, which could abort a healthy summarizer before its first response. Compaction now uses a dedicated client with a 3-minute header timeout and a 10-minute overall cap; interactive chat retains its existing timeout.

Long compactions also left chat users without visible feedback. The composer now shows a localized “Compacting context…” shimmer while manual or automatic compaction runs, and removes it when the work ends. It reuses the existing composer panel and reduced-motion styling.

The existing bot activity stream carries permission-filtered compaction snapshots on connection, on state changes, and with its heartbeat. Manual requests show feedback immediately and are deduplicated by bot/session. Reconnection replaces stale activity, and older frontends safely ignore the new event. Activity reflects the connected server process, consistent with the existing in-process event hub.

Validation:

- 133 related frontend tests passed, covering chat state, activity snapshots, request deduplication, and stream cleanup.
- `go test -race ./internal/agent/context/compaction ./internal/handlers ./cmd/agent ./cmd/internal/core` passed.
- The commit hook also passed full `go test ./...` and Go lint.
- Web production build and full `mise run lint` passed.
- Browser component checks passed for light/dark themes, narrow layouts, English/Chinese/Japanese, reduced motion, completion cleanup, and continued typing.
- Full Web typecheck still fails with 447 diagnostics; the untouched base also reports 447. This change does not resolve the existing type/path-configuration debt.
- The timeout fix was previously validated with a live summarizer on the earlier head. The new activity UI has component/transport tests, but has not been exercised end-to-end against a real summarizer.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
