### PR TITLE
fix(contextview): never trim a compaction summary before newer raw rows

### DIFF
--- a/internal/contextview/selection_tag.go
+++ b/internal/contextview/selection_tag.go
@@ -86,6 +86,11 @@ func isMustKeepFrag(frag contextfrag.ContextFrag, profile IntentProfile) bool {
 	if frag.Budget.Overflow == contextfrag.OverflowKeep {
 		return true
 	}
+	// A compaction summary is the sole survivor of everything already evicted;
+	// trimming it before newer raw rows silently re-loses the compacted span.
+	if frag.Kind == contextfrag.KindConversationSummary {
+		return true
+	}
 	if profile.MustKeepFrag != nil && profile.MustKeepFrag(frag) {
 		return true
 	}

--- a/internal/contextview/selector.go
+++ b/internal/contextview/selector.go
@@ -76,6 +76,20 @@ func (*FragmentSelector) Select(frags []contextfrag.ContextFrag, profile IntentP
 			tagged[i].Tokens = contextfrag.ResolveProviderBudgetFragTokens(tagged[i].Frag)
 		}
 		protectedCost := protectedHistoryTokenCost(tagged)
+		// Protected content must leave room for the trim notice exactly when
+		// trimming will happen: droppable rows that cannot all fit force
+		// spatial drops, and the notice they require is charged against the
+		// summary's ceiling instead of failing the selection afterwards.
+		summaryCeiling := historyBudget
+		if droppable := droppableHistoryTokenCost(tagged); droppable > 0 && droppable > historyBudget-protectedCost {
+			summaryCeiling -= contextfrag.ResolveProviderBudgetFragTokens(TrimNoticeFrag(contextfrag.Scope{}))
+		}
+		if protectedCost > summaryCeiling {
+			if edits := shrinkOversizedProtectedSummaries(tagged, protectedCost, summaryCeiling); len(edits) > 0 {
+				fragBudgetEdits = append(fragBudgetEdits, edits...)
+				protectedCost = protectedHistoryTokenCost(tagged)
+			}
+		}
 		if protectedCost > historyBudget {
 			result := selectionResultFromTaggedReasons(tagged, allSelectedIndexes(tagged), nil)
 			result.FatalError = contextfrag.ErrProtectedContextOverflow

--- a/internal/contextview/selector_budget.go
+++ b/internal/contextview/selector_budget.go
@@ -356,6 +356,19 @@ func protectedHistoryTokenCost(tagged []TaggedFrag) int {
 	return total
 }
 
+// droppableHistoryTokenCost totals the units budget trimming may drop, so
+// the caller can tell whether trimming (and its notice) is even possible.
+func droppableHistoryTokenCost(tagged []TaggedFrag) int {
+	units := buildBudgetUnits(tagged)
+	total := 0
+	for i := range units {
+		if units[i].droppable {
+			total += units[i].tokens
+		}
+	}
+	return total
+}
+
 // hasSpatialBudgetDrop reports whether any drop reason came from budget
 // pressure rather than the unconditional orphan cut, so the trim notice
 // (which promises the model earlier or intervening messages were trimmed to

--- a/internal/contextview/selector_summary_accounting_test.go
+++ b/internal/contextview/selector_summary_accounting_test.go
@@ -1,9 +1,11 @@
 package contextview
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	sdk "github.com/felinics/twilight/sdk"
 
@@ -44,5 +46,271 @@ func TestConversationSummarySurvivesHistoryBudgetTrim(t *testing.T) {
 	}
 	if !containsFragID(result.Dropped, "raw-0") {
 		t.Fatalf("oldest raw row must fund the trim: dropped=%v", fragIDs(result.Dropped))
+	}
+}
+
+func selectedFragText(frags []contextfrag.ContextFrag, id string) string {
+	for _, frag := range frags {
+		if frag.ID != id {
+			continue
+		}
+		for _, part := range frag.Parts {
+			if part.Type == contextfrag.PartText {
+				return part.Text
+			}
+			if msg := sdkMessagePart(part); msg != nil {
+				for _, mp := range msg.Content {
+					if text, ok := mp.(sdk.TextPart); ok {
+						return text.Text
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func TestOversizedConversationSummaryTruncatesInsteadOfFailingClosed(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	frags := []contextfrag.ContextFrag{contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "summary", Kind: contextfrag.KindConversationSummary, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotHistory, Text: strings.Repeat("s", 40_000),
+		Trust: contextfrag.TrustExternal,
+	})}
+	for i := range 5 {
+		frags = append(frags, contextfrag.TextFrag(contextfrag.TextFragInput{
+			ID: fmt.Sprintf("raw-%d", i), Kind: contextfrag.KindConversationEvent,
+			Role: sdk.MessageRoleUser, Slot: contextfrag.SlotHistory,
+			Text: strings.Repeat("r", 2_000), Trust: contextfrag.TrustExternal,
+		}))
+	}
+
+	result := selector.Select(frags, profile, BudgetEnvelope{
+		Plan: &contextfrag.ContextBudgetPlan{SystemBudget: 6_000},
+	})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() fatal = %v, want the summary truncated instead", result.FatalError)
+	}
+	if !containsFragID(result.Selected, "summary") {
+		t.Fatalf("summary missing after truncation: selected=%v", fragIDs(result.Selected))
+	}
+	text := selectedFragText(result.Selected, "summary")
+	if len(text) >= 40_000 || !strings.Contains(text, "truncated to fit") {
+		t.Fatalf("summary text len=%d, want a shortened body carrying the truncation notice", len(text))
+	}
+	if !strings.HasPrefix(text, strings.Repeat("s", 100)) {
+		t.Fatalf("truncation must preserve the summary head, got %.40q", text)
+	}
+}
+
+func TestOversizedSummaryStillFailsClosedBelowMinimumBudget(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	frags := []contextfrag.ContextFrag{contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "summary", Kind: contextfrag.KindConversationSummary, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotHistory, Text: strings.Repeat("s", 40_000),
+		Trust: contextfrag.TrustExternal,
+	})}
+
+	result := selector.Select(frags, profile, BudgetEnvelope{
+		Plan: &contextfrag.ContextBudgetPlan{SystemBudget: 40},
+	})
+
+	if !errors.Is(result.FatalError, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("Select() fatal = %v, want fail-closed below the minimum viable summary", result.FatalError)
+	}
+}
+
+func TestSummaryOnlySelectionSkipsTheNoticeReserve(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	frags := []contextfrag.ContextFrag{contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "summary", Kind: contextfrag.KindConversationSummary, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotHistory, Text: strings.Repeat("s", 40_000),
+		Trust: contextfrag.TrustExternal,
+	})}
+
+	result := selector.Select(frags, profile, BudgetEnvelope{
+		Plan: &contextfrag.ContextBudgetPlan{SystemBudget: 100},
+	})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() fatal = %v; nothing can drop, so no trim notice is ever emitted and the full budget belongs to the summary", result.FatalError)
+	}
+	text := selectedFragText(result.Selected, "summary")
+	if !strings.Contains(text, "truncated to fit") {
+		t.Fatalf("summary must be truncated into the budget, got len=%d", len(text))
+	}
+}
+
+func TestSummaryShrinkRedistributesUnusedShares(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	frags := []contextfrag.ContextFrag{
+		contextfrag.TextFrag(contextfrag.TextFragInput{
+			ID: "summary-small", Kind: contextfrag.KindConversationSummary, Role: sdk.MessageRoleUser,
+			Slot: contextfrag.SlotHistory, Text: strings.Repeat("s", 32),
+			Trust: contextfrag.TrustExternal,
+		}),
+		contextfrag.TextFrag(contextfrag.TextFragInput{
+			ID: "summary-big", Kind: contextfrag.KindConversationSummary, Role: sdk.MessageRoleUser,
+			Slot: contextfrag.SlotHistory, Text: strings.Repeat("s", 40_000),
+			Trust: contextfrag.TrustExternal,
+		}),
+	}
+
+	result := selector.Select(frags, profile, BudgetEnvelope{
+		Plan: &contextfrag.ContextBudgetPlan{SystemBudget: 150},
+	})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() fatal = %v; the small summary's unused share must fund the big one", result.FatalError)
+	}
+	if small := selectedFragText(result.Selected, "summary-small"); small != strings.Repeat("s", 32) {
+		t.Fatalf("under-target summary must stay untouched, got %q", small)
+	}
+	if big := selectedFragText(result.Selected, "summary-big"); !strings.Contains(big, "truncated to fit") {
+		t.Fatalf("oversized summary must be truncated, got len=%d", len(big))
+	}
+}
+
+func TestSummaryYieldsSpaceForTheTrimNotice(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	frags := []contextfrag.ContextFrag{contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "summary", Kind: contextfrag.KindConversationSummary, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotHistory, Text: strings.Repeat("s", 2_720),
+		Trust: contextfrag.TrustExternal,
+	})}
+	for i := range 2 {
+		frags = append(frags, contextfrag.TextFrag(contextfrag.TextFragInput{
+			ID: fmt.Sprintf("raw-%d", i), Kind: contextfrag.KindConversationEvent,
+			Role: sdk.MessageRoleUser, Slot: contextfrag.SlotHistory,
+			Text: strings.Repeat("r", 400), Trust: contextfrag.TrustExternal,
+		}))
+	}
+
+	result := selector.Select(frags, profile, BudgetEnvelope{
+		Plan: &contextfrag.ContextBudgetPlan{SystemBudget: 1_000},
+	})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() fatal = %v; the summary must yield enough space to fund the trim notice", result.FatalError)
+	}
+	if !strings.Contains(selectedFragText(result.Selected, "summary"), "truncated to fit") {
+		t.Fatal("summary must be shaved to make room for the trim notice")
+	}
+	if !containsFragID(result.Selected, "raw-1") || !containsFragID(result.Dropped, "raw-0") {
+		t.Fatalf("newest raw row must survive and the oldest fund the trim: selected=%v dropped=%v", fragIDs(result.Selected), fragIDs(result.Dropped))
+	}
+}
+
+func TestSummaryTruncateNoticeStaysUnderTheFloor(t *testing.T) {
+	t.Parallel()
+
+	longest := summaryTruncateNotice + "\n</summary>"
+	if utf8.RuneCountInString(longest) >= minSummaryKeepRunes {
+		t.Fatalf("notice (%d runes) must stay below the %d-rune floor or TruncateRunesWithSuffix silently drops it",
+			utf8.RuneCountInString(longest), minSummaryKeepRunes)
+	}
+}
+
+func TestSummaryShrinkProbesTheFloorBeforeFailing(t *testing.T) {
+	t.Parallel()
+
+	frag := contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "summary", Kind: contextfrag.KindConversationSummary, Role: sdk.MessageRoleUser,
+		Slot:  contextfrag.SlotHistory,
+		Text:  strings.Repeat("夏", 5_000) + strings.Repeat("a", 25_000),
+		Trust: contextfrag.TrustExternal,
+	})
+
+	shrunk, tokens, ok := shrinkSummaryFragToTokens(frag, 150)
+	if !ok {
+		t.Fatal("a floor-sized summary fits the target, shrink must not fail closed")
+	}
+	if tokens > 150 {
+		t.Fatalf("shrunk tokens = %d, want <= 150", tokens)
+	}
+	text := selectedFragText([]contextfrag.ContextFrag{shrunk}, "summary")
+	if !strings.HasPrefix(text, "夏夏夏") || !strings.Contains(text, "truncated to fit") {
+		t.Fatalf("floor probe must keep the head and carry the notice, got %.60q", text)
+	}
+}
+
+func TestSummaryTruncationClosesTheSummaryTag(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	frags := []contextfrag.ContextFrag{contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: "summary", Kind: contextfrag.KindConversationSummary,
+		Slot: contextfrag.SlotHistory, Trust: contextfrag.TrustExternal,
+		Message: sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{
+			sdk.TextPart{Text: "<summary>\n" + strings.Repeat("s", 40_000) + "\n</summary>"},
+		}},
+	})}
+
+	result := selector.Select(frags, profile, BudgetEnvelope{
+		Plan: &contextfrag.ContextBudgetPlan{SystemBudget: 2_000},
+	})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() fatal = %v", result.FatalError)
+	}
+	text := selectedFragText(result.Selected, "summary")
+	if !strings.Contains(text, "truncated to fit") {
+		t.Fatalf("summary must carry the truncation notice, got %.60q", text)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(text), "</summary>") {
+		t.Fatalf("truncation must re-close the summary tag, got tail %.80q", text[max(0, len(text)-80):])
+	}
+}
+
+func TestOversizedMessageShapedSummaryTruncates(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	frags := []contextfrag.ContextFrag{contextfrag.MessageFrag(contextfrag.MessageFragInput{
+		ID: "summary", Kind: contextfrag.KindConversationSummary,
+		Slot: contextfrag.SlotHistory, Trust: contextfrag.TrustExternal,
+		Message: sdk.Message{Role: sdk.MessageRoleUser, Content: []sdk.MessagePart{
+			sdk.TextPart{Text: strings.Repeat("s", 40_000)},
+		}},
+	})}
+
+	result := selector.Select(frags, profile, BudgetEnvelope{
+		Plan: &contextfrag.ContextBudgetPlan{SystemBudget: 2_000},
+	})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() fatal = %v, want the message-shaped summary truncated", result.FatalError)
+	}
+	text := selectedFragText(result.Selected, "summary")
+	if len(text) >= 40_000 || !strings.Contains(text, "truncated to fit") {
+		t.Fatalf("summary text len=%d, want a shortened body carrying the truncation notice", len(text))
+	}
+	if !strings.HasPrefix(text, strings.Repeat("s", 100)) {
+		t.Fatalf("truncation must preserve the summary head, got %.40q", text)
 	}
 }

--- a/internal/contextview/selector_summary_accounting_test.go
+++ b/internal/contextview/selector_summary_accounting_test.go
@@ -1,0 +1,48 @@
+package contextview
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	sdk "github.com/felinics/twilight/sdk"
+
+	contextfrag "github.com/felinics/memoh/internal/agent/context/fragment"
+)
+
+func TestConversationSummarySurvivesHistoryBudgetTrim(t *testing.T) {
+	t.Parallel()
+
+	selector := &FragmentSelector{}
+	profile := selector.ProfileFor(contextfrag.IntentRunConfigPreProvider)
+
+	frags := []contextfrag.ContextFrag{contextfrag.TextFrag(contextfrag.TextFragInput{
+		ID: "summary", Kind: contextfrag.KindConversationSummary, Role: sdk.MessageRoleUser,
+		Slot: contextfrag.SlotHistory, Text: strings.Repeat("s", 2_000),
+		Trust: contextfrag.TrustExternal,
+	})}
+	for i := range 20 {
+		frags = append(frags, contextfrag.TextFrag(contextfrag.TextFragInput{
+			ID: fmt.Sprintf("raw-%d", i), Kind: contextfrag.KindConversationEvent,
+			Role: sdk.MessageRoleUser, Slot: contextfrag.SlotHistory,
+			Text: strings.Repeat("r", 2_000), Trust: contextfrag.TrustExternal,
+		}))
+	}
+
+	result := selector.Select(frags, profile, BudgetEnvelope{
+		Plan: &contextfrag.ContextBudgetPlan{SystemBudget: 6_000},
+	})
+
+	if result.FatalError != nil {
+		t.Fatalf("Select() fatal = %v", result.FatalError)
+	}
+	if !containsFragID(result.Selected, "summary") {
+		t.Fatalf("summary evicted under history-budget pressure: dropped=%v", fragIDs(result.Dropped))
+	}
+	if !containsFragID(result.Selected, "raw-19") {
+		t.Fatalf("newest raw row missing: selected=%v", fragIDs(result.Selected))
+	}
+	if !containsFragID(result.Dropped, "raw-0") {
+		t.Fatalf("oldest raw row must fund the trim: dropped=%v", fragIDs(result.Dropped))
+	}
+}

--- a/internal/contextview/selector_summary_shrink.go
+++ b/internal/contextview/selector_summary_shrink.go
@@ -1,0 +1,162 @@
+package contextview
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	sdk "github.com/felinics/twilight/sdk"
+
+	contextfrag "github.com/felinics/memoh/internal/agent/context/fragment"
+	"github.com/felinics/memoh/internal/textutil"
+)
+
+// summaryTruncateNotice is appended to a summary shortened under protected
+// budget pressure. The text is model-visible; change it only deliberately.
+const summaryTruncateNotice = "\n\n[The rest of this summary was truncated to fit the context window.]"
+
+// minSummaryKeepRunes is the smallest truncated summary worth keeping,
+// notice included: below this a truncated summary carries no recall value,
+// so selection fails closed instead of shipping a stub.
+const minSummaryKeepRunes = 200
+
+const summaryBudgetEditReason = "summary_budget_truncate"
+
+// shrinkOversizedProtectedSummaries shortens must-keep conversation summaries
+// in place until the protected set fits ceiling, so a summary larger than the
+// history slot degrades to a truncated summary instead of failing the whole
+// selection. Under-target summaries settle at their actual cost and their
+// unused share funds the oversized ones. It reports the applied edits; an
+// empty result means nothing could be shrunk.
+func shrinkOversizedProtectedSummaries(tagged []TaggedFrag, protectedCost, ceiling int) []fragBudgetEdit {
+	var summaries []int
+	summaryCost := 0
+	for i := range tagged {
+		if tagged[i].Frag.Kind == contextfrag.KindConversationSummary && tagged[i].HasTag(TagMustKeep) {
+			summaries = append(summaries, i)
+			summaryCost += tagged[i].Tokens
+		}
+	}
+	if len(summaries) == 0 {
+		return nil
+	}
+	available := ceiling - (protectedCost - summaryCost)
+	if available <= 0 {
+		return nil
+	}
+	pending := summaries
+	target := available / len(pending)
+	for range summaries {
+		settledSome := false
+		var oversized []int
+		for _, idx := range pending {
+			if tagged[idx].Tokens <= target {
+				available -= tagged[idx].Tokens
+				settledSome = true
+			} else {
+				oversized = append(oversized, idx)
+			}
+		}
+		pending = oversized
+		if len(pending) == 0 || available <= 0 {
+			return nil
+		}
+		target = available / len(pending)
+		if !settledSome {
+			break
+		}
+	}
+
+	var edits []fragBudgetEdit
+	for _, idx := range pending {
+		entry := &tagged[idx]
+		next, tokens, ok := shrinkSummaryFragToTokens(entry.Frag, target)
+		if !ok {
+			continue
+		}
+		entry.Frag = next
+		entry.Tokens = tokens
+		edits = append(edits, fragBudgetEdit{
+			trace: contextfrag.ContextEditTrace{
+				EditID: "summary.budget_truncate." + next.ID,
+				Op:     contextfrag.EditReplace,
+				Slot:   next.Slot,
+				Refs:   []contextfrag.ContextRef{next.Ref},
+			},
+			fragID: next.ID,
+			reason: summaryBudgetEditReason,
+		})
+	}
+	return edits
+}
+
+func shrinkSummaryFragToTokens(frag contextfrag.ContextFrag, target int) (contextfrag.ContextFrag, int, bool) {
+	text, rebuild, ok := summaryFragText(frag)
+	if !ok || target <= 0 {
+		return frag, 0, false
+	}
+	current := contextfrag.ResolveProviderBudgetFragTokens(frag)
+	if current <= 0 {
+		return frag, 0, false
+	}
+	suffix := summaryTruncateNotice
+	if strings.HasSuffix(strings.TrimRight(text, " \t\n"), "</summary>") {
+		suffix += "\n</summary>"
+	}
+	keepRunes := utf8.RuneCountInString(text) * target / current
+	for attempt := 0; attempt < 8 && keepRunes >= minSummaryKeepRunes; attempt++ {
+		next := rebuild(textutil.TruncateRunesWithSuffix(text, keepRunes, suffix))
+		tokens := contextfrag.ResolveProviderBudgetFragTokens(next)
+		if tokens <= target {
+			return next, tokens, true
+		}
+		keepRunes = keepRunes * 4 / 5
+	}
+	// The geometric descent can overshoot straight past the floor on
+	// mixed-density text, so probe exactly the floor before failing closed:
+	// cost is monotonic in kept runes, which makes this probe decisive.
+	next := rebuild(textutil.TruncateRunesWithSuffix(text, minSummaryKeepRunes, suffix))
+	if tokens := contextfrag.ResolveProviderBudgetFragTokens(next); tokens <= target {
+		return next, tokens, true
+	}
+	return frag, 0, false
+}
+
+// summaryFragText extracts the single text body of a summary fragment and a
+// rebuild closure that re-normalizes refs and estimates around a replacement
+// body. Fragments with any other part shape are not shrinkable.
+func summaryFragText(frag contextfrag.ContextFrag) (string, func(string) contextfrag.ContextFrag, bool) {
+	if len(frag.Parts) != 1 {
+		return "", nil, false
+	}
+	part := frag.Parts[0]
+	if part.Type == contextfrag.PartText {
+		return part.Text, func(text string) contextfrag.ContextFrag {
+			next := frag
+			nextPart := part
+			nextPart.Text = text
+			next.Parts = []contextfrag.Part{nextPart}
+			conflictKey := next.ConflictKey
+			next.TokenEstimate = 0
+			next.Ref.HashAlgo = ""
+			next.Ref.HashScope = ""
+			next.Ref.ContentHash = ""
+			next = contextfrag.WithContextRef(next, next.Ref)
+			next.ConflictKey = conflictKey
+			return next
+		}, true
+	}
+	msg := sdkMessagePart(part)
+	if msg == nil || len(msg.Content) != 1 {
+		return "", nil, false
+	}
+	textPart, ok := msg.Content[0].(sdk.TextPart)
+	if !ok {
+		return "", nil, false
+	}
+	return textPart.Text, func(text string) contextfrag.ContextFrag {
+		return rebuildMessageFrag(frag, sdk.Message{
+			Role:    msg.Role,
+			Content: []sdk.MessagePart{sdk.TextPart{Text: text}},
+		})
+	}, true
+}


### PR DESCRIPTION
## Problem

Selection treats a compaction summary as ordinary droppable history. The summary sits at the oldest anchor position, so under history-budget pressure it is the **first fragment evicted** — a successful compaction pass renders zero value at exactly the moment the budget needs it, and the compacted span is silently re-lost.

Live evidence (500-turn LongMemEval haystack, window 32000, budget plan `history_budget≈6.9k`): after a successful automatic pass (438 rows covered, 12k-char summary), every subsequent turn's `selection_decisions` showed the summary fragment as `decision=dropped, retention_tier=None` while newer raw rows survived; the rendered breakdown was byte-identical to a no-compaction run. ~90s and ~125k summarizer tokens spent for zero rendered value.

## Fix

`KindConversationSummary` fragments are must-keep in selection. Trimming funds itself from raw rows; the compacted span stays represented. The new test reproduces the production shape (summary dropped first among 12 drops) and pins the fixed behavior (summary kept, oldest raw rows fund the trim, newest raw row kept).

Trade-off, disclosed: where the history budget cannot hold even the summary, selection now fails closed (protected overflow) instead of silently re-losing the compacted span; that regime previously produced an unusable context either way.

## Verification

- `go test` over contextview, application, agent/context/…, native: green; `go test -race` contextview + application: green; `golangci-lint run` (2.10.1): clean.
- Live harness validation on this branch (same seeded protocol as the reproduction): post-compaction turns now render `conversation_summary` (est 1,577) alongside the trimmed raw tail on every turn, and the cross-turn prompt-cache classification stays hit/stable across the compacted render.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
