### PR TITLE
fix(discuss): stop consuming trigger messages on failed native turns

### DIFF
--- a/internal/channel/discuss/driver_test.go
+++ b/internal/channel/discuss/driver_test.go
@@ -255,6 +255,51 @@ func TestHandleReplyWithTurn_ACPDoesNotAdvanceCursorOnRuntimeError(t *testing.T)
 	}
 }
 
+func TestHandleReplyWithTurn_NativeDoesNotAdvanceCursorOnFailedTurn(t *testing.T) {
+	rc := timeline.RenderedContext{
+		{
+			ReceivedAtMs: 200,
+			MentionsMe:   true,
+			Content:      []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="1">please inspect the app</message>`}},
+		},
+	}
+	svc := &fakeTurnService{streamErr: errors.New("context.protected_overflow")}
+	driver := NewDiscussDriver(DiscussDriverDeps{})
+	sess := &discussSession{
+		config: DiscussSessionConfig{BotID: "bot-1", ThreadID: "sess-1"},
+	}
+
+	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
+
+	if svc.calls != 1 {
+		t.Fatalf("StartTurn calls = %d, want 1", svc.calls)
+	}
+	if sess.lastProcessed != (timeline.DiscussCursorPosition{}) {
+		t.Fatalf("lastProcessed = %+v, want zero when the native turn fails", sess.lastProcessed)
+	}
+}
+
+func TestHandleReplyWithTurn_NativeAdvancesCursorAfterRecoveredRetry(t *testing.T) {
+	rc := timeline.RenderedContext{
+		{
+			ReceivedAtMs: 200,
+			MentionsMe:   true,
+			Content:      []timeline.RenderedContentPiece{{Type: "text", Text: `<message id="1">please inspect the app</message>`}},
+		},
+	}
+	svc := &fakeTurnService{midStreamError: true}
+	driver := NewDiscussDriver(DiscussDriverDeps{})
+	sess := &discussSession{
+		config: DiscussSessionConfig{BotID: "bot-1", ThreadID: "sess-1"},
+	}
+
+	driver.handleReplyWithTurn(context.Background(), sess, rc, driver.logger, svc)
+
+	if sess.lastProcessed.SourceCursor != 200 {
+		t.Fatalf("lastProcessed = %+v, want the recovered turn to commit its cursor", sess.lastProcessed)
+	}
+}
+
 func TestHandleReplyWithTurn_ACPSkipsRuntimeForPassiveMessage(t *testing.T) {
 	// Passive group chatter that does not address the bot must NOT spin up the
 	// external ACP runtime, but the consumed cursor must still advance so the
@@ -481,12 +526,13 @@ func TestAgentEventToChannelEventMapsACPDecisionRequests(t *testing.T) {
 // a run-resolved event first, then either a skip marker (ACP participation
 // gate) or a terminal agent event stream.
 type fakeTurnService struct {
-	runtimeType string // empty means the native model runtime
-	startErr    error
-	streamErr   error
-	onStart     func(turn.StartTurnCommand)
-	calls       int
-	lastCmd     turn.StartTurnCommand
+	runtimeType    string // empty means the native model runtime
+	startErr       error
+	streamErr      error
+	midStreamError bool // emit a recovered Error event before the clean AgentEnd
+	onStart        func(turn.StartTurnCommand)
+	calls          int
+	lastCmd        turn.StartTurnCommand
 }
 
 func (f *fakeTurnService) StartTurn(_ context.Context, cmd turn.StartTurnCommand) (turn.RunHandle, error) {
@@ -520,6 +566,10 @@ func (f *fakeTurnService) StartTurn(_ context.Context, cmd turn.StartTurnCommand
 		if f.streamErr != nil {
 			h.errs <- f.streamErr
 			return
+		}
+		if f.midStreamError {
+			retryable, _ := json.Marshal(agentevent.StreamEvent{Type: agentevent.Error, Error: "upstream 429"})
+			emit(string(agentevent.Error), retryable)
 		}
 		end, _ := json.Marshal(agentevent.StreamEvent{Type: agentevent.AgentEnd})
 		emit(string(agentevent.AgentEnd), end)

--- a/internal/channel/discuss/runner.go
+++ b/internal/channel/discuss/runner.go
@@ -21,8 +21,12 @@ type discussRunOutcome struct {
 	streamed    bool
 	terminal    bool
 	failed      bool
-	skipped     bool
-	cancelled   bool
+	// endedClean marks a run the runtime closed with AgentEnd. A recovered
+	// mid-stream retry emits an Error event first and still replies, so a
+	// clean end outranks the sticky failed flag for cursor commits.
+	endedClean bool
+	skipped    bool
+	cancelled  bool
 }
 
 // Run starts one Agent turn and reduces its ordered event stream to the
@@ -65,6 +69,9 @@ func (r discussTurnRunner) Run(ctx context.Context, service turn.Service, comman
 				}
 				if streamEvent.Type == agentevent.AgentEnd || streamEvent.Type == agentevent.AgentAbort {
 					outcome.terminal = true
+				}
+				if streamEvent.Type == agentevent.AgentEnd {
+					outcome.endedClean = true
 				}
 				r.projector.Broadcast(command.BotID, streamEvent)
 			}

--- a/internal/channel/discuss/worker.go
+++ b/internal/channel/discuss/worker.go
@@ -148,5 +148,7 @@ func (d *DiscussDriver) handleReplyWithTurn(ctx context.Context, sess *discussSe
 		}
 		return
 	}
-	d.cursor.Advance(ctx, sess, cfg, plan.consumed, log)
+	if outcome.endedClean || !outcome.failed {
+		d.cursor.Advance(ctx, sess, cfg, plan.consumed, log)
+	}
 }


### PR DESCRIPTION
## What this is

The discuss worker's native branch advanced the consumed cursor unconditionally after a started turn, so a turn that started and then failed — a `context.protected_overflow` budget rejection inside the turn, a provider error — still consumed the triggering message: no reply was produced and the message was never retried. The ACP branch already gates its advance on a clean terminal.

## How it works

- `handleReplyWithTurn` now skips the native cursor advance when the turn failed, so a later compaction (or a fixed model) gets a retry instead of a silent gap. Retry cost stays bounded: a new attempt fires only on the next inbound event, the same per-message cadence as before this change.
- A recovered mid-stream retry emits an `Error` stream event, then finishes with a clean `AgentEnd` and a delivered reply. The runner records that clean end (`endedClean`) and it outranks the sticky failed flag — otherwise a transient 429/5xx blip would leave the cursor uncommitted on a turn that answered, and the next trigger would reprocess already-answered messages. Verified against the native runtime's terminal paths: every genuine failure either ends in `AgentAbort` or withholds the terminal event (the discuss pump emits `AgentEnd` only after successful persist/publish), so a clean end is a safe commit signal.

## Verification

- `go test ./internal/channel/discuss/ -count=1` — new tests: a failed native turn keeps the cursor; a recovered retry commits it
- `go test -race ./internal/channel/discuss/`; full `go test ./...` + lint via pre-commit
- Two independent adversarial review passes; the recovered-retry counterexample was found in review and is pinned by a dedicated test

Note for #1078: its worker recompose loop touches the same lines; whichever lands second needs a trivial rebase carrying this guard into the loop body.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
