### PR TITLE
fix(contextview): prune in-flight tool results before failing a protected overflow

### DIFF
--- a/internal/agent/context/limit/step_truncate.go
+++ b/internal/agent/context/limit/step_truncate.go
@@ -11,35 +11,36 @@ import (
 // step-level / mid-task pruning.
 const StepToolResultTruncateBytes = 512
 
-// TruncateStepToolResult replaces every sdk.ToolResultPart in msg with a
-// "[tool result pruned: N bytes]" summary when their combined encoded size
-// exceeds thresholdBytes (falling back to StepToolResultTruncateBytes when
-// thresholdBytes <= 0), preserving ToolCallID/ToolName. ok reports whether
-// msg was changed.
+// TruncateStepToolResult replaces each sdk.ToolResultPart in msg whose own
+// encoded size exceeds thresholdBytes (falling back to
+// StepToolResultTruncateBytes when thresholdBytes <= 0) with a
+// "[tool result pruned: N bytes]" summary. Parallel-call batches share one
+// tool message, so sizing is per part: small siblings survive verbatim, and
+// every other field of the part — IsError above all — is preserved so a
+// failed result never reads as success. ok reports whether msg was changed.
 func TruncateStepToolResult(msg sdk.Message, thresholdBytes int) (out sdk.Message, ok bool) {
 	if thresholdBytes <= 0 {
 		thresholdBytes = StepToolResultTruncateBytes
 	}
-	contentSize := 0
-	for _, part := range msg.Content {
-		if tr, isResult := part.(sdk.ToolResultPart); isResult {
-			contentSize += len(fmt.Sprintf("%v", tr.Result))
-		}
-	}
-	if contentSize <= thresholdBytes {
-		return msg, false
-	}
+	changed := false
 	parts := make([]sdk.MessagePart, 0, len(msg.Content))
 	for _, part := range msg.Content {
-		if tr, isResult := part.(sdk.ToolResultPart); isResult {
-			parts = append(parts, sdk.ToolResultPart{
-				ToolCallID: tr.ToolCallID,
-				ToolName:   tr.ToolName,
-				Result:     fmt.Sprintf("[tool result pruned: %d bytes]", contentSize),
-			})
+		tr, isResult := part.(sdk.ToolResultPart)
+		if !isResult {
+			parts = append(parts, part)
 			continue
 		}
-		parts = append(parts, part)
+		size := len(fmt.Sprintf("%v", tr.Result))
+		if size <= thresholdBytes {
+			parts = append(parts, tr)
+			continue
+		}
+		tr.Result = fmt.Sprintf("[tool result pruned: %d bytes]", size)
+		parts = append(parts, tr)
+		changed = true
+	}
+	if !changed {
+		return msg, false
 	}
 	return sdk.Message{Role: msg.Role, Content: parts}, true
 }

--- a/internal/agent/context/limit/step_truncate_test.go
+++ b/internal/agent/context/limit/step_truncate_test.go
@@ -1,0 +1,64 @@
+package contextlimit
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/felinics/twilight/sdk"
+)
+
+func TestTruncateStepToolResultStubsEachOversizedPartIndependently(t *testing.T) {
+	t.Parallel()
+
+	msg := sdk.Message{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{
+		sdk.ToolResultPart{ToolCallID: "call-big", ToolName: "exec", Result: strings.Repeat("x", 1_000)},
+		sdk.ToolResultPart{ToolCallID: "call-small", ToolName: "exec", Result: "ok: created id-42"},
+	}}
+
+	out, changed := TruncateStepToolResult(msg, 512)
+	if !changed {
+		t.Fatal("oversized part must be stubbed")
+	}
+	big, small := out.Content[0].(sdk.ToolResultPart), out.Content[1].(sdk.ToolResultPart)
+	if text, _ := big.Result.(string); !strings.Contains(text, "pruned") {
+		t.Fatalf("oversized part must carry the stub, got %v", big.Result)
+	}
+	if small.Result != "ok: created id-42" {
+		t.Fatalf("small sibling must survive verbatim, got %v", small.Result)
+	}
+}
+
+func TestTruncateStepToolResultPreservesErrorAndCacheMetadata(t *testing.T) {
+	t.Parallel()
+
+	cache := &sdk.CacheControl{}
+	msg := sdk.Message{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{
+		sdk.ToolResultPart{
+			ToolCallID: "call-fail", ToolName: "exec",
+			Result: strings.Repeat("stderr ", 200), IsError: true, CacheControl: cache,
+		},
+	}}
+
+	out, changed := TruncateStepToolResult(msg, 512)
+	if !changed {
+		t.Fatal("oversized part must be stubbed")
+	}
+	stubbed := out.Content[0].(sdk.ToolResultPart)
+	if !stubbed.IsError {
+		t.Fatal("a failed result must not read as success after pruning")
+	}
+	if stubbed.CacheControl != cache {
+		t.Fatal("cache control must survive pruning")
+	}
+}
+
+func TestTruncateStepToolResultLeavesSmallPartsUntouched(t *testing.T) {
+	t.Parallel()
+
+	msg := sdk.Message{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{
+		sdk.ToolResultPart{ToolCallID: "call-1", ToolName: "exec", Result: "small"},
+	}}
+	if _, changed := TruncateStepToolResult(msg, 512); changed {
+		t.Fatal("under-threshold results must pass through unchanged")
+	}
+}

--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -1267,6 +1267,7 @@ func prepareProviderAttempt(
 	}
 	inputAllowance := stepReselectionAllowance(cfg)
 	reselectionDetail := ""
+	protectedPruned := 0
 	if reselector != nil && prefixCount < len(params.Messages) {
 		beforeMessages := append([]sdk.Message(nil), params.Messages...)
 		selection := reselector(ctx, ContextStepSelectionInput{
@@ -1312,6 +1313,7 @@ func prepareProviderAttempt(
 			snapshot.Dropped = selection.Dropped
 			snapshot.Truncated = selection.Truncated
 			snapshot.DropReasons = copyDropReasons(selection.DropReasons)
+			protectedPruned = selection.ProtectedPruned
 			if selection.Dropped > 0 || selection.Truncated > 0 {
 				reselectionDetail = contextStepSelectionDetail(selection)
 			}
@@ -1327,7 +1329,7 @@ func prepareProviderAttempt(
 			inputAllowance,
 		))
 	}
-	stagePreparedProviderAttempt(ctx, handoff, snapshot, systemPrepended, reselectionDetail, provenance)
+	stagePreparedProviderAttempt(ctx, handoff, snapshot, systemPrepended, reselectionDetail, protectedPruned, provenance)
 	return params
 }
 
@@ -1337,13 +1339,14 @@ func stagePreparedProviderAttempt(
 	snapshot contextfrag.StepSnapshot,
 	systemPrepended bool,
 	reselectionDetail string,
+	protectedPruned int,
 	provenance preparedMessageProvenance,
 ) {
 	if !providerAttemptDispatchAllowed(ctx) {
 		handoff.reject(provenance)
 		return
 	}
-	handoff.stage(snapshot, systemPrepended, reselectionDetail, provenance)
+	handoff.stage(snapshot, systemPrepended, reselectionDetail, protectedPruned, provenance)
 }
 
 func providerAttemptEnvelopeOverflow(params *sdk.GenerateParams, allowance int) int {

--- a/internal/agent/runtime/native/generate_loop_test.go
+++ b/internal/agent/runtime/native/generate_loop_test.go
@@ -258,6 +258,67 @@ func TestAgentGenerateRunsStepReselectorBeforeNextProviderCall(t *testing.T) {
 	}
 }
 
+func TestAgentGenerateRecordsMidTaskPruneForProtectedRescue(t *testing.T) {
+	t.Parallel()
+
+	ledger := contextfrag.NewMutationLedger()
+	modelProvider := &atomicMockProvider{
+		handler: func(call int, _ sdk.GenerateParams) (*sdk.GenerateResult, error) {
+			if call == 1 {
+				return &sdk.GenerateResult{
+					FinishReason: sdk.FinishReasonToolCalls,
+					ToolCalls: []sdk.ToolCall{{
+						ToolCallID: "call-1",
+						ToolName:   "lookup",
+						Input:      map[string]any{"q": "one"},
+					}},
+				}, nil
+			}
+			return &sdk.GenerateResult{Text: "ok", FinishReason: sdk.FinishReasonStop}, nil
+		},
+	}
+
+	a := New(Deps{})
+	a.SetToolProviders([]agenttools.ToolProvider{
+		staticToolProvider{
+			tools: []sdk.Tool{{
+				Name:       "lookup",
+				Parameters: &jsonschema.Schema{Type: "object"},
+				Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
+					return map[string]any{"answer": strings.Repeat("tool-result ", 64)}, nil
+				},
+			}},
+		},
+	})
+
+	_, err := a.Generate(context.Background(), RunConfig{
+		Model:            &sdk.Model{ID: "mock-model", Provider: modelProvider},
+		Messages:         []sdk.Message{sdk.UserMessage("start")},
+		SupportsToolCall: true,
+		Identity:         SessionContext{BotID: "bot-1"},
+		ContextMutations: ledger,
+		ContextStepReselector: func(_ context.Context, input ContextStepSelectionInput) ContextStepSelectionResult {
+			return ContextStepSelectionResult{
+				Messages:        append([]sdk.Message(nil), input.Messages...),
+				Truncated:       1,
+				ProtectedPruned: 1,
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	var pruneDetail string
+	for _, record := range ledger.Records() {
+		if record.Kind == contextfrag.MutationMidTaskPrune {
+			pruneDetail = record.Detail
+		}
+	}
+	if pruneDetail != "truncated=1" {
+		t.Fatalf("mutation records = %#v, want mid_task_prune with truncated=1", ledger.Records())
+	}
+}
+
 func TestAgentGeneratePassesRemainingBudgetToStepReselector(t *testing.T) {
 	t.Parallel()
 	const budget = 1_000

--- a/internal/agent/runtime/native/provider_attempt_handoff.go
+++ b/internal/agent/runtime/native/provider_attempt_handoff.go
@@ -2,6 +2,7 @@ package native
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	sdk "github.com/felinics/twilight/sdk"
@@ -15,6 +16,7 @@ type preparedProviderAttempt struct {
 	snapshot          contextfrag.StepSnapshot
 	systemPrepended   bool
 	reselectionDetail string
+	protectedPruned   int
 	provenance        preparedMessageProvenance
 }
 
@@ -36,6 +38,7 @@ func (h *providerAttemptHandoff) stage(
 	snapshot contextfrag.StepSnapshot,
 	systemPrepended bool,
 	reselectionDetail string,
+	protectedPruned int,
 	provenanceValues ...preparedMessageProvenance,
 ) {
 	if h == nil {
@@ -50,6 +53,7 @@ func (h *providerAttemptHandoff) stage(
 		snapshot:          snapshot,
 		systemPrepended:   systemPrepended,
 		reselectionDetail: reselectionDetail,
+		protectedPruned:   protectedPruned,
 		provenance:        clonePreparedMessageProvenance(provenance),
 	}
 	h.mu.Unlock()
@@ -104,6 +108,12 @@ func (h *providerAttemptHandoff) publish(params sdk.GenerateParams) error {
 	h.cfg.ContextMutations.AppendStepSnapshot(pending.snapshot)
 	if pending.reselectionDetail != "" {
 		h.cfg.ContextMutations.Record(contextfrag.MutationLoopStepReselection, pending.reselectionDetail)
+	}
+	if pending.protectedPruned > 0 {
+		h.cfg.ContextMutations.Record(
+			contextfrag.MutationMidTaskPrune,
+			fmt.Sprintf("truncated=%d", pending.protectedPruned),
+		)
 	}
 	h.pending = nil
 	return nil

--- a/internal/agent/runtime/native/provider_attempt_handoff_test.go
+++ b/internal/agent/runtime/native/provider_attempt_handoff_test.go
@@ -55,6 +55,7 @@ func TestProviderAttemptHandoffRejectsCanceledDispatch(t *testing.T) {
 				contextfrag.StepSnapshot{StepIndex: 1},
 				false,
 				"dropped=1",
+				0,
 				capture.latestProvenance(newParams.Messages),
 			)
 
@@ -153,6 +154,7 @@ func TestProviderAttemptHandoffPublishesBeforeProviderEntry(t *testing.T) {
 				contextfrag.StepSnapshot{StepIndex: 1},
 				false,
 				"dropped=1",
+				0,
 				capture.latestProvenance(params.Messages),
 			)
 

--- a/internal/agent/runtime/native/types.go
+++ b/internal/agent/runtime/native/types.go
@@ -104,8 +104,11 @@ type ContextStepSelectionResult struct {
 	MessageSourceIndexesKnown bool
 	Dropped                   int
 	Truncated                 int
-	DropReasons               map[string]int
-	FatalError                error
+	// ProtectedPruned counts the subset of Truncated stubbed to resolve a
+	// protected-budget overflow that would otherwise fail the run.
+	ProtectedPruned int
+	DropReasons     map[string]int
+	FatalError      error
 }
 
 type ContextStepReselector func(context.Context, ContextStepSelectionInput) ContextStepSelectionResult

--- a/internal/contextview/provider_step_envelope_test.go
+++ b/internal/contextview/provider_step_envelope_test.go
@@ -2,7 +2,6 @@ package contextview
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -13,7 +12,7 @@ import (
 	agentpkg "github.com/felinics/memoh/internal/agent/runtime/native"
 )
 
-func TestProviderStepReselectionFailsClosedForEnvelopeS3HugeResult(t *testing.T) {
+func TestProviderStepReselectionRescuesEnvelopeS3HugeResult(t *testing.T) {
 	t.Parallel()
 	const (
 		inputAllowance = 24_000
@@ -49,11 +48,17 @@ func TestProviderStepReselectionFailsClosedForEnvelopeS3HugeResult(t *testing.T)
 		ProviderTools:                tools,
 		ProviderInputAllowanceTokens: inputAllowance,
 	})
-	if !errors.Is(result.FatalError, contextfrag.ErrProtectedContextOverflow) {
-		t.Fatalf("step reselection error = %v, want protected overflow for the newest tool closure", result.FatalError)
+	if result.FatalError != nil {
+		t.Fatalf("step reselection error = %v, want the newest tool closure pruned instead of a failed run", result.FatalError)
 	}
-	if result.Messages != nil {
-		t.Fatalf("fatal envelope overflow returned provider messages: %#v", result.Messages)
+	if result.Messages == nil || result.ProtectedPruned != 1 {
+		t.Fatalf("huge protected result was not pruned: %+v", result)
+	}
+	if !reflect.DeepEqual(result.Messages[:len(prefix)], prefix) {
+		t.Fatalf("immutable prefix changed: %#v", result.Messages[:len(prefix)])
+	}
+	if got := contextfrag.ProviderEnvelopeTokens(system, result.Messages, tools); got > inputAllowance {
+		t.Fatalf("rescued provider payload = %d tokens, want <= allowance %d", got, inputAllowance)
 	}
 }
 
@@ -144,7 +149,7 @@ func TestProviderStepReselectionAllowsExactlyFittingProtectedEnvelopeSuffix(t *t
 		ProviderSystem:               system,
 		ProviderTools:                tools,
 		ProviderInputAllowanceTokens: allowance - 1,
-	}); !errors.Is(result.FatalError, contextfrag.ErrProtectedContextOverflow) {
-		t.Fatalf("one token short of the protected suffix must fail closed, got %v", result.FatalError)
+	}); result.FatalError != nil || result.ProtectedPruned != 1 {
+		t.Fatalf("one token short of the protected suffix must prune the result, got %+v", result)
 	}
 }

--- a/internal/contextview/provider_step_rescue_test.go
+++ b/internal/contextview/provider_step_rescue_test.go
@@ -1,0 +1,218 @@
+package contextview
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	sdk "github.com/felinics/twilight/sdk"
+
+	contextfrag "github.com/felinics/memoh/internal/agent/context/fragment"
+	agentpkg "github.com/felinics/memoh/internal/agent/runtime/native"
+)
+
+func collectToolResults(messages []sdk.Message) []sdk.ToolResultPart {
+	var results []sdk.ToolResultPart
+	for _, msg := range messages {
+		if msg.Role != sdk.MessageRoleTool {
+			continue
+		}
+		for _, part := range msg.Content {
+			if result, ok := part.(sdk.ToolResultPart); ok {
+				results = append(results, result)
+			}
+		}
+	}
+	return results
+}
+
+func TestStepReselectionRescuesProtectedOverflowByPruningInFlightResults(t *testing.T) {
+	t.Parallel()
+
+	prefix := []sdk.Message{sdk.UserMessage("task")}
+	messages := loopSpanWithToolCycles(prefix, 1, 8_000)
+
+	selection := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
+		Scope:                 contextfrag.Scope{BotID: "bot-1"},
+		InitialMessageCount:   len(prefix),
+		Messages:              messages,
+		BudgetMaxTokens:       300,
+		KeepRecentToolResults: 4,
+		MinMessages:           20,
+	})
+
+	if selection.FatalError != nil {
+		t.Fatalf("FatalError = %v, want in-flight results pruned instead of a failed run", selection.FatalError)
+	}
+	if selection.Messages == nil {
+		t.Fatal("rescue must produce a message override")
+	}
+	if selection.ProtectedPruned < 1 || selection.Truncated < 1 {
+		t.Fatalf("pruned = %d truncated = %d, want the protected result stubbed", selection.ProtectedPruned, selection.Truncated)
+	}
+	results := collectToolResults(selection.Messages)
+	if len(results) != 1 {
+		t.Fatalf("tool results = %d, want the exchange preserved as parts", len(results))
+	}
+	text, _ := results[0].Result.(string)
+	if !strings.Contains(text, "pruned") {
+		t.Fatalf("protected result must carry the pruned stub, got %q", text)
+	}
+}
+
+func TestStepReselectionRescueEscalatesToNewestResultAsLastResort(t *testing.T) {
+	t.Parallel()
+
+	prefix := []sdk.Message{sdk.UserMessage("task")}
+	messages := loopSpanWithToolCycles(prefix, 5, 4_000)
+
+	selection := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
+		Scope:                 contextfrag.Scope{BotID: "bot-1"},
+		InitialMessageCount:   len(prefix),
+		Messages:              messages,
+		BudgetMaxTokens:       600,
+		KeepRecentToolResults: 4,
+		MinMessages:           20,
+	})
+
+	if selection.FatalError != nil {
+		t.Fatalf("FatalError = %v, want escalating prune instead of a failed run", selection.FatalError)
+	}
+	results := collectToolResults(selection.Messages)
+	if len(results) == 0 {
+		t.Fatal("expected surviving tool results")
+	}
+	newest, _ := results[len(results)-1].Result.(string)
+	if !strings.Contains(newest, "pruned") {
+		t.Fatalf("newest result must be stubbed once older prunes cannot fit the budget, got %q", newest)
+	}
+}
+
+func TestStepReselectionRescueKeepsNewestResultWhenOlderPruneSuffices(t *testing.T) {
+	t.Parallel()
+
+	prefix := []sdk.Message{sdk.UserMessage("task")}
+	newestBody := strings.Repeat("keep", 200)
+	messages := append(append([]sdk.Message(nil), prefix...),
+		sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			sdk.ToolCallPart{ToolCallID: "call-old", ToolName: "lookup", Input: map[string]any{}},
+			sdk.ToolCallPart{ToolCallID: "call-new", ToolName: "lookup", Input: map[string]any{}},
+		}},
+		toolResultMessage("call-old", "lookup", strings.Repeat("x", 8_000)),
+		toolResultMessage("call-new", "lookup", newestBody),
+	)
+
+	selection := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
+		Scope:                 contextfrag.Scope{BotID: "bot-1"},
+		InitialMessageCount:   len(prefix),
+		Messages:              messages,
+		BudgetMaxTokens:       400,
+		KeepRecentToolResults: 4,
+		MinMessages:           20,
+	})
+
+	if selection.FatalError != nil {
+		t.Fatalf("FatalError = %v, want the older protected result pruned instead", selection.FatalError)
+	}
+	if selection.ProtectedPruned != 1 {
+		t.Fatalf("ProtectedPruned = %d, want exactly the older result stubbed", selection.ProtectedPruned)
+	}
+	results := collectToolResults(selection.Messages)
+	if len(results) != 2 {
+		t.Fatalf("tool results = %d, want both preserved as parts", len(results))
+	}
+	older, _ := results[0].Result.(string)
+	newest, _ := results[1].Result.(string)
+	if !strings.Contains(older, "pruned") {
+		t.Fatalf("older result must be stubbed, got %q", older)
+	}
+	if newest != newestBody {
+		t.Fatalf("newest result must survive intact when pruning older ones suffices, got %q", newest)
+	}
+}
+
+func TestStepReselectionRescuePreservesSiblingsInParallelBatch(t *testing.T) {
+	t.Parallel()
+
+	prefix := []sdk.Message{sdk.UserMessage("task")}
+	messages := append(append([]sdk.Message(nil), prefix...),
+		sdk.Message{Role: sdk.MessageRoleAssistant, Content: []sdk.MessagePart{
+			sdk.ToolCallPart{ToolCallID: "call-big", ToolName: "exec", Input: map[string]any{}},
+			sdk.ToolCallPart{ToolCallID: "call-small", ToolName: "exec", Input: map[string]any{}},
+		}},
+		sdk.Message{Role: sdk.MessageRoleTool, Content: []sdk.MessagePart{
+			sdk.ToolResultPart{ToolCallID: "call-big", ToolName: "exec", Result: strings.Repeat("x", 8_000), IsError: true},
+			sdk.ToolResultPart{ToolCallID: "call-small", ToolName: "exec", Result: "ok: created id-42"},
+		}},
+	)
+
+	selection := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
+		Scope:                 contextfrag.Scope{BotID: "bot-1"},
+		InitialMessageCount:   len(prefix),
+		Messages:              messages,
+		BudgetMaxTokens:       400,
+		KeepRecentToolResults: 4,
+		MinMessages:           20,
+	})
+
+	if selection.FatalError != nil {
+		t.Fatalf("FatalError = %v, want the batched exchange pruned instead", selection.FatalError)
+	}
+	results := collectToolResults(selection.Messages)
+	if len(results) != 2 {
+		t.Fatalf("tool results = %d, want both parts preserved", len(results))
+	}
+	big, small := results[0], results[1]
+	if text, _ := big.Result.(string); !strings.Contains(text, "pruned") {
+		t.Fatalf("oversized part must be stubbed, got %v", big.Result)
+	}
+	if !big.IsError {
+		t.Fatal("a failed result must not read as success after the rescue")
+	}
+	if small.Result != "ok: created id-42" {
+		t.Fatalf("small sibling must survive verbatim, got %v", small.Result)
+	}
+}
+
+func TestStepReselectionFailsClosedWhenEvenStubbedExchangeOverflows(t *testing.T) {
+	t.Parallel()
+
+	prefix := []sdk.Message{sdk.UserMessage("task")}
+	messages := loopSpanWithToolCycles(prefix, 1, 8_000)
+
+	selection := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
+		Scope:                 contextfrag.Scope{BotID: "bot-1"},
+		InitialMessageCount:   len(prefix),
+		Messages:              messages,
+		BudgetMaxTokens:       1,
+		KeepRecentToolResults: 4,
+		MinMessages:           20,
+	})
+
+	if !errors.Is(selection.FatalError, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("FatalError = %v, want fail-closed when the stubbed exchange still overflows", selection.FatalError)
+	}
+}
+
+func TestStepReselectionProtectedOverflowFailsClosedWhenNothingPrunable(t *testing.T) {
+	t.Parallel()
+
+	prefix := []sdk.Message{sdk.UserMessage("task")}
+	messages := append(append([]sdk.Message(nil), prefix...),
+		sdk.UserMessage(strings.Repeat("injected carrier ", 500)),
+	)
+
+	selection := SelectProviderStepMessages(context.Background(), agentpkg.ContextStepSelectionInput{
+		Scope:                 contextfrag.Scope{BotID: "bot-1"},
+		InitialMessageCount:   len(prefix),
+		Messages:              messages,
+		BudgetMaxTokens:       300,
+		KeepRecentToolResults: 4,
+		MinMessages:           20,
+	})
+
+	if !errors.Is(selection.FatalError, contextfrag.ErrProtectedContextOverflow) {
+		t.Fatalf("FatalError = %v, want protected overflow to stay fail-closed", selection.FatalError)
+	}
+}

--- a/internal/contextview/provider_step_reselection.go
+++ b/internal/contextview/provider_step_reselection.go
@@ -2,6 +2,7 @@ package contextview
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -47,7 +48,10 @@ func SelectProviderStepMessages(ctx context.Context, input agentpkg.ContextStepS
 
 	selector := &FragmentSelector{}
 	budget := input.BudgetMaxTokens
-	for attempt := 0; attempt <= len(frags)+1; attempt++ {
+	rescueLevels := protectedRescueLevels(input.KeepRecentToolResults)
+	protectedPruned := 0
+	maxAttempts := len(frags) + 1 + len(rescueLevels)
+	for attempt := 0; attempt <= maxAttempts; attempt++ {
 		attemptInput := input
 		attemptInput.BudgetMaxTokens = budget
 		selection := selector.Select(
@@ -56,13 +60,28 @@ func SelectProviderStepMessages(ctx context.Context, input agentpkg.ContextStepS
 			providerStepBudgetEnvelope(attemptInput),
 		)
 		if selection.FatalError != nil {
+			// A protected overflow would fail the whole run, so before failing
+			// closed the in-flight tool-result bodies are stubbed, newest last.
+			if errors.Is(selection.FatalError, contextfrag.ErrProtectedContextOverflow) {
+				pruned := 0
+				for pruned == 0 && len(rescueLevels) > 0 {
+					frags, pruned = truncateToolResultFragsKeeping(frags, rescueLevels[0])
+					rescueLevels = rescueLevels[1:]
+				}
+				if pruned > 0 {
+					protectedPruned += pruned
+					continue
+				}
+			}
 			return agentpkg.ContextStepSelectionResult{FatalError: selection.FatalError}
 		}
 
 		selected := selectedProviderStepFrags(selection, input.Scope)
-		truncated := 0
+		truncated := protectedPruned
 		if len(input.Messages) >= input.MinMessages {
-			selected, truncated = truncateOldToolResultFrags(selected, input.KeepRecentToolResults)
+			var cosmetic int
+			selected, cosmetic = truncateOldToolResultFrags(selected, input.KeepRecentToolResults)
+			truncated += cosmetic
 		}
 		changed := len(selection.Dropped) > 0 || truncated > 0
 		messages := input.Messages
@@ -85,6 +104,7 @@ func SelectProviderStepMessages(ctx context.Context, input agentpkg.ContextStepS
 				MessageSourceIndexesKnown: true,
 				Dropped:                   len(selection.Dropped),
 				Truncated:                 truncated,
+				ProtectedPruned:           protectedPruned,
 				DropReasons:               dropReasonHistogram(selection.Summary.DropReasons),
 			}
 		}
@@ -147,6 +167,15 @@ func messageHasNativeMediaPart(msg sdk.Message) bool {
 	return false
 }
 
+// protectedRescueLevels orders the keep-recent widths a protected-overflow
+// rescue walks through: the configured width first, then one cycle, then none.
+func protectedRescueLevels(keepRecent int) []int {
+	if keepRecent > 1 {
+		return []int{keepRecent, 1, 0}
+	}
+	return []int{1, 0}
+}
+
 // truncateOldToolResultFrags keeps the most recent keepRecent complete tool
 // cycles intact and replaces older bulky tool results with a size summary,
 // preserving the ToolResultPart shape so provider serializers stay happy.
@@ -155,6 +184,12 @@ func truncateOldToolResultFrags(frags []contextfrag.ContextFrag, keepRecent int)
 	if keepRecent <= 0 {
 		return frags, 0
 	}
+	return truncateToolResultFragsKeeping(frags, keepRecent)
+}
+
+// truncateToolResultFragsKeeping stubs every bulky tool result outside the
+// newest keep cycles; keep == 0 stubs them all.
+func truncateToolResultFragsKeeping(frags []contextfrag.ContextFrag, keep int) ([]contextfrag.ContextFrag, int) {
 	recentCycles := 0
 	cutoff := -1
 	for i := len(frags) - 1; i >= 0; i-- {
@@ -163,7 +198,7 @@ func truncateOldToolResultFrags(frags []contextfrag.ContextFrag, keepRecent int)
 			continue
 		}
 		recentCycles++
-		if recentCycles > keepRecent {
+		if recentCycles > keep {
 			cutoff = i
 			break
 		}


### PR DESCRIPTION
## What this is

On small context windows, a tool-driven turn died deterministically mid-loop: step reselection returned a fatal `context.protected_overflow` (HTTP 422) the moment the protected in-flight tool exchanges exceeded the remaining step budget — reading one large file was enough, and the whole turn failed with no recovery (observed live as 4/4 rounds failing on a 32k window). The existing mid-task truncation helper ran only after a successful selection, so it never fired on the one path that needed it.

## How it works

- On a protected overflow, `SelectProviderStepMessages` now walks a keep-recent ladder (configured width → one cycle → none), stubbing bulky in-flight tool-result bodies to `[tool result pruned: N bytes]` and re-selecting. The tool-call/result closure shape providers require stays intact, and the model can re-read the source with an offset. Fail-closed remains as the last resort, only when even the fully stubbed exchange cannot fit.
- The rescue never touches the immutable message prefix (it operates on the loop span only; the runtime's prefix-preservation gate stays in force), and provenance/source-index handling follows the existing truncation path.
- `TruncateStepToolResult` now sizes and stubs each result part independently instead of gating on the batch's combined size: parallel tool calls share one tool message, so the old shape let one oversized result erase small siblings, and the rebuild dropped `IsError` — a failed call could read as success after pruning. Every other part field (`IsError`, `CacheControl`) survives the stub. This also strengthens the pre-existing cosmetic truncation path.
- Applied rescues surface as `ProtectedPruned` (folded into `Truncated`) and as a `mid_task_prune` mutation recorded at provider-attempt publish, next to the existing `loop_step_reselection` record.
- Two prior acceptance tests pinned the fail-closed behavior for this exact scenario (the S3 huge-result fixture; the one-token-short suffix); they now pin the rescue outcome instead, and new fail-closed tests keep the last-resort contract pinned.

## Known accepted trade-offs (from three review rounds, including a second-model adversarial pass)

- Stubbing the newest protected exchange loses result content the model never saw (non-replayable tools lose their receipt); the fail-closed alternative loses the same content plus the whole turn, so the rescue strictly dominates. A per-tool replayability classification or an external result store would refine this and is out of scope here.
- Per-part sizing means a batch of several medium results (each under the 512B threshold) is no longer reclaimable at keep=0, slightly raising the fail-closed floor in deeply degenerate budgets (a few hundred tokens) — accepted for metadata honesty and sibling preservation; a future honest hardening rung could lower the per-part threshold before failing closed.
- The ladder's intermediate levels can stub droppable results that don't relieve protected cost (wasted retries, outcome still correct); `Truncated` can double-report against `Dropped` in telemetry when a stubbed droppable frag is later dropped; shadow-mode snapshots fold the rescue count into `Truncated`.

## Verification

- `go test ./internal/contextview/ ./internal/agent/runtime/native/ ./internal/agent/context/limit/ -count=1` — new tests: rescue on a single big exchange; escalation to the newest result; gradualism (the newest result survives when stubbing an older protected result suffices — mutation-verified against a prune-everything ladder); parallel-batch sibling/IsError preservation; fail-closed when nothing is prunable or even the stub overflows
- `go test -race` on the touched packages; full `go test ./...` + lint via pre-commit
- Three independent adversarial review rounds over termination, escalation order, prefix immutability, provenance, shadow purity, publish-gated mutation records, and the per-part semantics

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
