### PR TITLE
feat(web): sidebar 会话标题悬停跑马灯,行强调统一键在 hover/menu-open

### DIFF
--- a/apps/web/src/components/sidebar/marquee-motion.test.ts
+++ b/apps/web/src/components/sidebar/marquee-motion.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { computeMarqueeMotion, MARQUEE_OVERSHOOT_PX, MARQUEE_SPEED_PX_PER_S } from './marquee-motion'
+
+describe('computeMarqueeMotion', () => {
+  it('treats fitting and sub-pixel overflow as not truncated', () => {
+    for (const overflow of [0, -5, 1]) {
+      expect(computeMarqueeMotion(overflow)).toEqual({ truncated: false, travelPx: 0, durationMs: 0 })
+    }
+  })
+
+  it('travels exactly the overflow so the tail rests flush at the right edge', () => {
+    const motion = computeMarqueeMotion(120)
+    expect(motion.truncated).toBe(true)
+    expect(motion.travelPx).toBe(120)
+  })
+
+  it('keeps the scroll speed constant: one cycle covers the span twice', () => {
+    for (const overflow of [30, 120, 400]) {
+      const span = overflow + 2 * MARQUEE_OVERSHOOT_PX
+      expect(computeMarqueeMotion(overflow).durationMs).toBe(Math.round((span * 2000) / MARQUEE_SPEED_PX_PER_S))
+    }
+  })
+
+  it('holds a constant dwell at each end regardless of title length', () => {
+    // The dwell is the clamped overshoot at each end of BOTH legs: the offset
+    // travels 2·Overshoot within it at the constant speed, so every title —
+    // 30px or 400px — waits the same (2·Overshoot)/speed before its first
+    // pixel moves. A percentage-based dwell broke this (long titles waited
+    // proportionally longer), which is why the clamp exists.
+    const dwellMs = (2 * MARQUEE_OVERSHOOT_PX * 1000) / MARQUEE_SPEED_PX_PER_S
+    expect(dwellMs).toBe(400)
+  })
+})

--- a/apps/web/src/components/sidebar/marquee-motion.ts
+++ b/apps/web/src/components/sidebar/marquee-motion.ts
@@ -1,0 +1,41 @@
+// Motion math for marquee-text.vue, kept pure so it is testable without a
+// DOM. The component turns the result into the CSS vars the stylesheet reads;
+// everything else (transform, fades) is a pure CSS function of the single
+// animated variable --marquee-pos, so nothing here can drift out of sync
+// with what is painted.
+
+// Reading pace for the scroll leg. Slow enough to read CJK comfortably,
+// fast enough that a sidebar-width title completes in a few seconds.
+export const MARQUEE_SPEED_PX_PER_S = 30
+// The keyframe x values run from -Overshoot to +travel+Overshoot (the two
+// out-of-window offsets that clamp to a constant hold at each end — see the
+// component stylesheet). Both keyframe ends and this constant must change
+// together, or the hold silently changes length.
+export const MARQUEE_OVERSHOOT_PX = 6
+
+export interface MarqueeMotion {
+  truncated: boolean
+  // Distance the text must travel left for the tail to rest flush at the
+  // viewport's right edge — exactly the overflow, never more: scrolling
+  // further would leave a dead gap between the tail and the actions slot.
+  travelPx: number
+  // ONE full cycle: forward leg (travel + 2·Overshoot at constant speed —
+  // the overshoot portions clamp to the hold dwells), then the same distance
+  // back. Time-based, not a fraction of the cycle: a percentage-based hold
+  // made long titles dwell proportionally longer (a 400px title sat ~1.9s
+  // before moving, a 30px one only 143ms — the "hover forever before it
+  // scrolls" bug), because stretching the duration to keep speed constant
+  // stretched the dwell with it.
+  durationMs: number
+}
+
+// Sub-pixel jitter (<2px) is not truncation: a nearly-fitting label keeps
+// its crisp tail rather than gaining a fade and a scroll.
+export function computeMarqueeMotion(overflowPx: number): MarqueeMotion {
+  if (overflowPx <= 1) {
+    return { truncated: false, travelPx: 0, durationMs: 0 }
+  }
+  const span = overflowPx + 2 * MARQUEE_OVERSHOOT_PX
+  const durationMs = Math.round((span * 2000) / MARQUEE_SPEED_PX_PER_S)
+  return { truncated: true, travelPx: overflowPx, durationMs }
+}

--- a/apps/web/src/components/sidebar/marquee-text.vue
+++ b/apps/web/src/components/sidebar/marquee-text.vue
@@ -1,0 +1,161 @@
+<template>
+  <!-- Truncating one-line label with hover marquee. -->
+  <span
+    ref="viewport"
+    class="marquee-viewport"
+    :class="{ 'is-truncated': motion.truncated }"
+    :style="motionStyle"
+  >
+    <!-- Only --marquee-pos is ANIMATED (on the viewport; it inherits down).
+         The content's transform and the viewport's mask are pure functions of
+         it, so the scroll and both fades stay in lockstep by construction:
+           left fade  = min(pos, 12px)          — grows as the head scrolls off
+           right fade = min(travel - pos, 28px) — shrinks as the tail arrives
+         Resting at home: right fade only (the ellipsis replacement). Resting
+         at the tail: left fade only, tail crisp at the right edge with no
+         dead gap before the actions slot. -->
+    <span
+      ref="content"
+      class="marquee-content"
+    >
+      <slot />
+    </span>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computeMarqueeMotion, MARQUEE_OVERSHOOT_PX } from './marquee-motion'
+
+const viewport = ref<HTMLElement>()
+const content = ref<HTMLElement>()
+const overflowPx = ref(0)
+
+let observer: ResizeObserver | undefined
+
+function measure() {
+  const box = viewport.value
+  const inner = content.value
+  if (!box || !inner) return
+  overflowPx.value = inner.scrollWidth - box.clientWidth
+}
+
+const motion = computed(() => computeMarqueeMotion(overflowPx.value))
+
+const motionStyle = computed(() => {
+  if (!motion.value.truncated) return {}
+  return {
+    '--marquee-travel': `${motion.value.travelPx}px`,
+    '--marquee-overshoot': `${MARQUEE_OVERSHOOT_PX}px`,
+    '--marquee-duration': `${motion.value.durationMs}ms`,
+  }
+})
+
+onMounted(() => {
+  measure()
+  // Sidebar width changes (drag), font loading, and title edits all resize
+  // one of the two boxes — the observer catches every path, so nothing else
+  // needs to trigger re-measurement.
+  observer = new ResizeObserver(measure)
+  if (viewport.value) observer.observe(viewport.value)
+  if (content.value) observer.observe(content.value)
+})
+
+onBeforeUnmount(() => observer?.disconnect())
+</script>
+
+<!-- Unscoped by design: the hover trigger lives on the row (`.group`), an
+     ancestor this component does not own — scoped + :global() collapses the
+     compound selector down to the global part alone (verified: it compiled
+     to a bare `.group:hover` rule and the scroll never fired). The marquee-*
+     class names are unique to this component, so a plain block is exact. -->
+<style>
+/* Only --marquee-pos is animated (registered below so keyframes can
+   interpolate it); the transform and mask are pure functions of it. */
+
+.marquee-viewport {
+  display: block;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.marquee-content {
+  display: inline-block;
+  white-space: nowrap;
+  /* The clamp turns the animated offset into the painted position and pins
+     BOTH ends, so each overshoot is a true hold rather than a bounce. pos
+     runs -Overshoot → travel+Overshoot; painted x = -pos while
+     0 ≤ pos ≤ travel (the scroll). Outside that range the clamp snaps x to
+     0 (home overshoot) or -travel (far overshoot) — WITHOUT the far clamp
+     the tail slides Overshoot past its flush point and a gap flashes at the
+     right edge. The pinned intervals ARE the dwells at each end. */
+  transform: translateX(
+    clamp(
+      calc(-1 * var(--marquee-travel, 0px)),
+      calc(-1 * var(--marquee-pos)),
+      0px
+    )
+  );
+}
+
+/* The mask MUST live on the viewport, not the content: gradient percentages
+   resolve against the masked element's own box. The content box is the full
+   text width, so `100%` there points off-screen past the visible window and
+   the right fade never appears — that exact bug shipped once. On the viewport
+   `100%` is the visible window, and both fades are continuous functions of
+   --marquee-pos, so they widen/narrow smoothly AS the text moves. */
+.marquee-viewport.is-truncated {
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 min(var(--marquee-pos), 12px),
+    #000 calc(100% - min(var(--marquee-travel) - var(--marquee-pos), 28px)),
+    transparent
+  );
+}
+
+/* Scrolling keys off the row's emphasis state — :hover OR data-menu-open
+   (class `group` on the row root). When the dropdown is open the cursor sits
+   over the portaled menu, so :hover alone is gone from the row and the scroll
+   would freeze mid-read; data-menu-open (set by the row while its dropdown is
+   open) keeps the row emphasized until the menu closes. Pointing at the
+   trailing actions keeps the text reachable for the same reason.
+   The 0.2s delay is hover-intent gating — long enough that a passing cursor
+   doesn't twitch every row, short enough to feel immediate. During the delay
+   --marquee-pos is still 0, so the title shows the idle right-fade state with
+   no special-case rule. */
+@media (prefers-reduced-motion: no-preference) {
+  .group:hover .marquee-viewport.is-truncated,
+  .group[data-menu-open='true'] .marquee-viewport.is-truncated {
+    animation: marquee-pingpong var(--marquee-duration, 4s) linear 0.2s infinite;
+  }
+}
+
+/* The hold at each end is a CLAMP, not a timed stop: --marquee-pos is
+   animated from -Overshoot to travel+Overshoot (a raw transform would give
+   the same motion but couldn't feed the mask), so during the overshoots the
+   clamped transform above pins the paint at the edge — that pinned interval
+   IS the dwell, a constant 2·Overshoot/speed at each end (400ms at the current constants).
+   Why clamp instead of percentage stops: the duration must grow with travel
+   to keep the reading speed constant, and percentage dwells grow with it —
+   a 400px title sat ~1.9s before its first pixel moved while a 30px one
+   started in 143ms (the "hover forever before it scrolls" bug). A clamped
+   overshoot is a fixed duration no matter how long the title is. */
+@property --marquee-pos {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0px;
+}
+
+@keyframes marquee-pingpong {
+  0% {
+    --marquee-pos: calc(-1 * var(--marquee-overshoot, 6px));
+  }
+  50% {
+    --marquee-pos: calc(var(--marquee-travel, 0px) + var(--marquee-overshoot, 6px));
+  }
+  100% {
+    --marquee-pos: calc(-1 * var(--marquee-overshoot, 6px));
+  }
+}
+</style>

--- a/apps/web/src/components/sidebar/session-item.vue
+++ b/apps/web/src/components/sidebar/session-item.vue
@@ -3,14 +3,24 @@
     <ContextMenuTrigger as-child>
       <!-- active: mirrors the hover fill so a touch press (incl. the hold that
            opens the context menu) gives visible feedback — touch has no hover,
-           and without this the long-press felt dead until the menu appeared. -->
+           and without this the long-press felt dead until the menu appeared.
+
+           data-menu-open is the ROW-EMPHASIZED contract: while the dropdown is
+           open the cursor is over the portaled menu, so :hover is gone from
+           the row — everything that keyed off hover (row fill, actions slot,
+           marquee scroll) must also key off this attribute, or the row
+           visually collapses the moment the pointer moves onto the menu. -->
       <div
+        ref="rowEl"
         role="button"
         tabindex="0"
         class="group relative flex items-center min-h-[2.125rem] w-full rounded-[9px] px-[11px] text-left transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        :class="isActive ? '' : rowInteractionClass"
+        :class="rowClass"
         :data-ui-selected="isActive ? '' : undefined"
+        :data-menu-open="menuOpen || undefined"
         :title="hoverTitle"
+        @mouseenter="syncHovered"
+        @mouseleave="syncHovered"
         @click="$emit('select', session)"
         @keydown.enter.prevent="$emit('select', session)"
         @keydown.space.prevent="$emit('select', session)"
@@ -47,20 +57,37 @@
              per-script treatment as the chat body (.sidebar-cjk / .sidebar-latin reuse
              the --chat-*-body weight + Latin size/tracking). The only thing dropped vs
              the body is streaming — a title is a static one-line label. -->
-        <span class="flex-1 min-w-0 truncate text-control text-foreground dark:text-[color:oklch(0.92_0_0)]"><span
-          v-for="(run, i) in titleRuns"
-          :key="i"
-          :class="run.script === 'cjk' ? 'sidebar-cjk' : 'sidebar-latin'"
-        >{{ run.text }}</span></span>
+        <MarqueeText class="flex-1 min-w-0 text-control text-foreground dark:text-[color:oklch(0.92_0_0)]">
+          <span
+            v-for="(run, i) in titleRuns"
+            :key="i"
+            :class="run.script === 'cjk' ? 'sidebar-cjk' : 'sidebar-latin'"
+          >{{ run.text }}</span>
+        </MarqueeText>
 
         <!-- Trailing slot: spinner and the actions button share one 24px right
              slot so they sit at the same center and never both show at once. The
-             spinner reserves the slot in flow (keeps the title tail clear while
-             streaming and stops the title from jumping on hover); the actions
-             button is the same size-6 box anchored to the same right edge, and on
-             row hover or while the menu is open it fades in as the spinner fades
-             out — streaming + hover no longer stacks the two icons. -->
-        <div class="relative ml-1.5 flex h-6 shrink-0 items-center justify-end">
+             slot reserves its width IN FLOW whenever anything can be visible in
+             it — streaming or row emphasis (hover, or the dropdown being open —
+             keyed off data-menu-open on the row so the slot stays reserved while
+             the cursor is over the portaled menu) — so the title's display area
+             always ends before the icon zone instead of letting the icon float
+             over the text. Keyboard focus alone does NOT widen it (deliberate):
+             closing the dropdown refocuses its trigger inside the row, and a
+             focus-keyed rule would pin the slot open after an Esc close,
+             over-truncating the title. Idle rows keep w-0 (no dead gutter); the
+             width transition lets the title re-truncate smoothly as the slot
+             grows, and the actions button fades in over the same beat as the
+             spinner fades out. The button is ABSOLUTELY anchored to the slot's
+             right edge, never an in-flow flex child: a shrink-0 button beside
+             the 24px spinner out-competes it for flex width inside the fixed
+             w-6 slot and crushes the spinner's box to zero, off-centering the
+             loader. Sole in-flow child while streaming, the spinner keeps its
+             full box and center. -->
+        <div
+          class="relative ml-1.5 flex h-6 shrink-0 items-center justify-end transition-[width] duration-150"
+          :class="streaming || menuOpen ? 'w-6' : 'w-0 group-hover:w-6 group-data-[menu-open=true]:w-6'"
+        >
           <div
             v-if="streaming"
             class="flex h-6 w-6 items-center justify-center transition-opacity duration-150 group-hover:opacity-0"
@@ -82,7 +109,7 @@
               <button
                 type="button"
                 class="absolute inset-y-0 right-0 my-auto inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground outline-none transition-[opacity,background-color,color] duration-150 hover:bg-[color-mix(in_oklab,var(--foreground)_12%,transparent)] hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-[color-mix(in_oklab,var(--foreground)_12%,transparent)] data-[state=open]:text-foreground"
-                :class="menuOpen ? 'opacity-100' : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto'"
+                :class="menuOpen ? 'opacity-100' : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-data-[menu-open=true]:opacity-100 group-data-[menu-open=true]:pointer-events-auto'"
                 :aria-label="t('chat.sessionActions')"
                 @click.stop
                 @keydown.enter.stop
@@ -160,6 +187,7 @@ import {
 import { acpAgentDisplayName, acpAgentIcon, normalizeACPAgentID } from '@/utils/acp'
 import { splitScriptRuns } from '@/utils/script-runs'
 import { normalizedRuntimeType, normalizedSessionMode } from '@/store/chat-list.utils'
+import MarqueeText from './marquee-text.vue'
 
 const props = defineProps<{
   session: SessionSummary
@@ -177,12 +205,41 @@ defineEmits<{
 const { t } = useI18n()
 
 const menuOpen = ref(false)
+const rowEl = ref<HTMLElement>()
+// Pure-CSS :hover re-read as state, so the rowEmphasized computed can consume
+// it (a computed can't match selectors directly). Note the dual channel: only
+// the row FILL flows through this JS predicate; the slot width, actions button
+// and marquee trigger key straight off CSS .group:hover. The channels diverge
+// transiently when the row slides under a STATIONARY cursor (list reorder,
+// folder expand/collapse): no mouseenter fires, so the fill lags one cursor
+// move while the CSS effects apply immediately — cosmetic, self-heals.
+const hovered = ref(false)
+const syncHovered = () => { hovered.value = rowEl.value?.matches(':hover') ?? false }
 
-// Row interaction fill: hover for real pointers, the same fill on :active so a
-// touch press (incl. the long-press that opens the context menu) reads as
-// feedback. --sidebar-hover is the sidebar family's pinned row fill; waiver
-// pattern follows nav-button.vue (component-owned chrome, no global token).
-const rowInteractionClass = 'hover:bg-[color:var(--sidebar-hover)] active:bg-[color:var(--sidebar-hover)]' /* ui-allow-style */
+// Row emphasis = hover OR open dropdown, as ONE predicate feeding the row fill
+// class, the data-menu-open attribute, and (via it) the trailing slot width and
+// the marquee's scroll trigger. One source of truth means the fill, the 24px
+// slot, and the scrolling can never disagree about which state the row is in —
+// previously three independent CSS :hover rules did, and each disagreement was
+// a separate bug report ("slot didn't restore"; "row collapsed while the menu
+// was open" — with the dropdown open the cursor sits over the PORTALED menu,
+// so :hover is gone from the row and hover-keyed effects snapped off mid-read).
+// Active rows are excluded: they already carry the stronger selected fill, and
+// layering hover gray on it reads as a flicker.
+const rowEmphasized = computed(() => !props.isActive && (hovered.value || menuOpen.value))
+
+const rowClass = computed(() => {
+  if (props.isActive) return ''
+  // :active fill is a SEPARATE contract from rowEmphasized, kept from the
+  // pre-marquee hover:/active: pair: it gives touch users press feedback
+  // (incl. the long-press that opens the context menu) where :hover never
+  // fires. It must not widen the slot or start the marquee — pressing is
+  // not emphasis — so it stays out of the predicate on purpose.
+  return [
+    'active:bg-[color:var(--sidebar-hover)]',
+    rowEmphasized.value ? 'bg-[color:var(--sidebar-hover)]' : '',
+  ]
+})
 
 const titleRuns = computed(() =>
   splitScriptRuns((props.session.title ?? '').trim() || t('chat.untitledSession')),


### PR DESCRIPTION
## 概述

sidebar 会话标题超长时被截断,本 PR 让标题在行强调态(悬停,或三点菜单打开时)横向滚动显示全文,滚动两端带渐隐。4 个文件,+296/-20。

## 改动分层

**新增 `marquee-motion.ts`** — 纯函数运动学,4 个单测锁定:截断阈值(溢出 ≤1px 不滚动)、行程(= 溢出量,尾部刚好贴右缘)、时长(常速 30px/s,时长随行程线性缩放,任意长度标题阅读速度一致)。

**新增 `marquee-text.vue`** — 渲染组件。整个动画只动一个注册变量 `--marquee-pos`,文字位移和两端渐隐都是它的纯函数:

- 渐隐(mask)坐在 viewport 上而不是 content 上——渐变百分比相对于被遮罩元素自身盒,content 盒是全文宽度,`100%` 会指向屏幕外,右渐隐永远不出现(这个 bug 真上过线)
- 两端停留是 clamp 过冲(常数 6px),不是百分比停帧——时长随行程缩放时,百分比停帧让长标题起步前多等 ~1.9s、短标题只等 143ms;clamp 过冲让停留恒为 2×过冲÷速度 = 400ms,与标题长度无关。transform 由 clamp 两端夹死:远端过冲时尾部钉在右缘停住,而不是滑出 6px 弹回

**改 `session-item.vue`** — 行强调统一键在 hover 与 menu-open 两个状态上:

- 行填充由 `rowClass`(`!isActive && (hovered || menuOpen)`)给出;尾部 24px 槽宽、action 按钮显隐、跑马灯触发由 `group-hover` + `data-menu-open` 属性给出。三点菜单是 portal 渲染的,光标移到菜单上行内 `:hover` 即消失;之前填充/槽宽/按钮各挂一条独立的 `:hover` 规则,每条失步就是一个 bug("菜单悬停时行坍缩""槽位概率不恢复")
- 不用 `focus-within` 当状态键:Reka 关闭菜单时会把 focus 还给 trigger,focus 键会把槽位钉住不恢复(键盘用户由按钮自身 `focus-visible` 覆盖)
- 触屏 `:active` 按压填充保留为独立契约,不进强调谓词(按压 ≠ 强调,不应触发槽宽/滚动)
- 按钮 absolute 锚定槽右缘,不为 flex 子元素:`shrink-0` 按钮 + 24px spinner 会挤压固定 w-6 槽内的 flex 宽度,spinner 被压成 0 宽、loader 偏出中心(本 PR 内审查发现并修正)

## 设计不变量(每条对应开发中真实踩过的坑)

1. 滚动与渐隐必须共享同一个动画变量——两份真相必脱节
2. mask 必须坐在 viewport 上——百分比解析盒是被遮罩元素自身
3. 停留必须 clamp 计时——百分比停帧 × 时长缩放 = 长度相关的起步延迟
4. 行强调必须单一谓词——portaled 菜单会吃掉行内 `:hover`
5. 不用 `focus-within` 当 UI 状态键——Reka 关菜单时的 trigger refocus 会钉住状态

## 测试与验证

- `vitest` marquee-motion 4/4 绿;eslint 四文件干净;pre-commit 全量 Go 套件绿(其间 `TestMemoryRuntimeManagerContract` 在全量负载下 flaky 失败一次,单独重跑即绿,与本 PR 无关);CI 全绿
- **人工 QA**(Cloud dev 27000,2026-09-01):超长标题往返滚动、rename、三点菜单悬停保持与关闭恢复、streaming 态 spinner 居中——全部通过,最终走查无 breaking
- **Codex review** 两条 P2(远端过冲缺 clamp、按钮挤压 streaming spinner)已修复,修复经几何推演与独立复审双重验证
- **独立复审**(4 文件全文通读 + streaming × menuOpen × hover × isActive 全组合推演):无 P1/P2,仅 1 个 P3(见已知限制)
- 注:QA 栈模型定价问题(`model_not_priced` 403)导致无法新建会话,人工 QA 基于栈内既有会话进行

## 已知限制

- 行填充走 JS hover 通道(mouseenter/mouseleave),槽宽/按钮/滚动走 CSS `:hover`;当行滑动到**静止光标**下方(列表重排、文件夹折叠展开)时填充滞后一次光标移动,cosmetic、自愈
- `transform` 需 `clamp()` 与 `@property` 支持(Chromium 132 / Electron 34 全支持)

## Test plan

- [x] 悬停超长标题:两端渐隐出现,滚动开始(起步延迟与短标题一致),速度适中
- [x] 打开三点菜单、光标移到菜单上:行填充保持,标题继续滚动,尾部槽位保持;Rename 可点
- [x] 关闭菜单:槽位与按钮恢复隐藏,行宽恢复
- [x] streaming 会话行:spinner 在 24px 槽居中,悬停时切换为三点按钮
- [ ] 触屏/触控板按住行有按压填充(未实测;代码层与 base 的 `:active` 契约一致)
- [ ] 无溢出的短标题任何态不滚动、无渐隐(未显式验证;逻辑上溢出 ≤1px 不进入截断态)

> Human QA 已由 @qqqqqf-q 在 Cloud dev(27000)完成(2026-09-01):上述前四项通过,最终走查无 breaking。
