### PR TITLE
fix(web): 空标题 channel 会话显示群名/对方名，不再堆 Untitled Session

### DIFF
--- a/apps/web/src/components/session-select/options.ts
+++ b/apps/web/src/components/session-select/options.ts
@@ -3,7 +3,7 @@ import type { SearchableSelectOption } from '@/components/searchable-select-popo
 import type { BotWorkdir } from '@/composables/api/useWorkdirs'
 import type { SessionKind } from './session-kind-icon.vue'
 import { acpAgentDisplayName, normalizeACPAgentID } from '@/utils/acp'
-import { normalizedRuntimeType, normalizedSessionMode } from '@/store/chat-list.utils'
+import { normalizedRuntimeType, normalizedSessionMode, routeConversationLabel } from '@/store/chat-list.utils'
 
 // The per-row mark the picker paints beside a session title.
 export interface SessionMark {
@@ -25,7 +25,7 @@ export interface SessionSelectLabels {
 export const NO_MARK: SessionMark = { kind: 'chat', agentId: '', label: '' }
 
 export function sessionTitle(session: SessionSession, labels: SessionSelectLabels): string {
-  return (session.title ?? '').trim() || labels.untitled
+  return (session.title ?? '').trim() || routeConversationLabel(session) || labels.untitled
 }
 
 export function sessionMark(session: SessionSession, labels: SessionSelectLabels): SessionMark {

--- a/apps/web/src/components/sidebar/folders-section.vue
+++ b/apps/web/src/components/sidebar/folders-section.vue
@@ -277,16 +277,18 @@ watch(
 )
 
 function handleSelect(session: SessionSummary) {
+  // Same contract as recents.vue: pass the raw title, let the tab store
+  // derive the fallback (incl. channel conversation name).
   workspaceTabs.openSessionChat({
     sessionId: session.id,
-    title: (session.title ?? '').trim() || t('chat.untitledSession'),
+    title: (session.title ?? '').trim(),
   })
 }
 
 function handleOpenNewTab(session: SessionSummary) {
   workspaceTabs.openSessionChatPinned({
     sessionId: session.id,
-    title: (session.title ?? '').trim() || t('chat.untitledSession'),
+    title: (session.title ?? '').trim(),
   })
 }
 

--- a/apps/web/src/components/sidebar/recents.vue
+++ b/apps/web/src/components/sidebar/recents.vue
@@ -197,9 +197,12 @@ watch(currentBotId, () => {
 })
 
 function handleSelect(session: SessionSummary) {
+  // Pass the raw title (possibly empty): openSessionChat's fallback derives
+  // the tab title, including the channel conversation name for untitled
+  // channel sessions — never bake the literal "Untitled" text in here.
   workspaceTabs.openSessionChat({
     sessionId: session.id,
-    title: (session.title ?? '').trim() || t('chat.untitledSession'),
+    title: (session.title ?? '').trim(),
   })
   workspaceTabs.closeMobileNav()
 }
@@ -207,7 +210,7 @@ function handleSelect(session: SessionSummary) {
 function handleOpenNewTab(session: SessionSummary) {
   workspaceTabs.openSessionChatPinned({
     sessionId: session.id,
-    title: (session.title ?? '').trim() || t('chat.untitledSession'),
+    title: (session.title ?? '').trim(),
   })
   workspaceTabs.closeMobileNav()
 }

--- a/apps/web/src/components/sidebar/session-item.vue
+++ b/apps/web/src/components/sidebar/session-item.vue
@@ -159,7 +159,7 @@ import {
 } from '@felinic/ui'
 import { acpAgentDisplayName, acpAgentIcon, normalizeACPAgentID } from '@/utils/acp'
 import { splitScriptRuns } from '@/utils/script-runs'
-import { normalizedRuntimeType, normalizedSessionMode } from '@/store/chat-list.utils'
+import { normalizedRuntimeType, normalizedSessionMode, routeConversationLabel } from '@/store/chat-list.utils'
 
 const props = defineProps<{
   session: SessionSummary
@@ -184,8 +184,18 @@ const menuOpen = ref(false)
 // pattern follows nav-button.vue (component-owned chrome, no global token).
 const rowInteractionClass = 'hover:bg-[color:var(--sidebar-hover)] active:bg-[color:var(--sidebar-hover)]' /* ui-allow-style */
 
+function routeMeta(): Record<string, unknown> {
+  return props.session.route_metadata ?? {}
+}
+
+// Group title for group sessions, peer name for DMs — the default visible
+// label for untitled channel sessions, and the IM handle for the hover
+// tooltip. Empty title is expected: only the chat turn path generates titles
+// server-side; discuss (group) sessions never get one (issue #1043).
+const displayLabel = computed(() => routeConversationLabel(props.session))
+
 const titleRuns = computed(() =>
-  splitScriptRuns((props.session.title ?? '').trim() || t('chat.untitledSession')),
+  splitScriptRuns((props.session.title ?? '').trim() || displayLabel.value || t('chat.untitledSession')),
 )
 
 const WEB_CHANNELS = new Set(['local', ''])
@@ -202,22 +212,10 @@ const isACPSession = computed(() => normalizedRuntimeType(props.session) === 'ac
 const isScheduleSession = computed(() => normalizedSessionMode(props.session) === 'schedule')
 const acpAgentLabel = computed(() => acpAgentDisplayName(acpAgentId.value, t('chat.sessionTypeACPAgent')))
 
-function routeMeta(): Record<string, unknown> {
-  return props.session.route_metadata ?? {}
-}
-
-const displayLabel = computed(() => {
-  const meta = routeMeta()
-  return (meta.conversation_name as string ?? '').trim()
-    || (meta.sender_display_name as string ?? '').trim()
-    || (meta.sender_username as string ?? '').trim()
-    || ''
-})
-
 // The old two-line subLabel is folded into the native tooltip: channel handle
 // for IM sessions, agent name for ACP sessions.
 const hoverTitle = computed(() => {
-  const title = props.session.title || t('chat.untitledSession')
+  const title = (props.session.title ?? '').trim() || displayLabel.value || t('chat.untitledSession')
   if (isACPSession.value) {
     return `${title} — ${acpAgentLabel.value}`
   }

--- a/apps/web/src/components/sidebar/session-search-dialog.vue
+++ b/apps/web/src/components/sidebar/session-search-dialog.vue
@@ -46,7 +46,7 @@
               class="size-3.5 shrink-0 text-muted-foreground"
             />
             <span class="min-w-0 flex-1 truncate text-xs text-foreground">
-              {{ session.title || t('chat.untitledSession') }}
+              {{ displayTitle(session) }}
             </span>
           </button>
 
@@ -79,7 +79,7 @@ import {
 } from '@felinic/ui'
 import { useChatStore } from '@/store/chat-list'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
-import { sortByRecency } from '@/store/chat-list.utils'
+import { sortByRecency, routeConversationLabel } from '@/store/chat-list.utils'
 import type { SessionSummary } from '@/composables/api/useChat'
 
 const props = defineProps<{
@@ -103,11 +103,18 @@ const results = computed<SessionSummary[]>(() => {
   const list = q
     ? sessions.value.filter(session =>
       (session.title ?? '').toLowerCase().includes(q)
-      || (session.id ?? '').toLowerCase().includes(q),
+      || (session.id ?? '').toLowerCase().includes(q)
+      // Untitled channel sessions show as their conversation name — make that
+      // the searchable form of their identity too.
+      || routeConversationLabel(session).toLowerCase().includes(q),
     )
     : sessions.value
   return sortByRecency(list).slice(0, 50)
 })
+
+function displayTitle(session: SessionSummary): string {
+  return (session.title ?? '').trim() || routeConversationLabel(session) || t('chat.untitledSession')
+}
 
 function iconOf(session: SessionSummary): Component {
   switch (session.type) {
@@ -119,7 +126,9 @@ function iconOf(session: SessionSummary): Component {
 }
 
 function handleSelect(session: SessionSummary) {
-  const title = (session.title ?? '').trim() || t('chat.untitledSession')
+  // Raw title only — the tab store derives its own fallback (channel
+  // conversation name) from the session summary.
+  const title = (session.title ?? '').trim()
   // Subagent sessions live in the region right of the conversation (the same
   // split the live Desktop uses); everything else opens as a regular chat tab.
   if (session.type === 'subagent') {

--- a/apps/web/src/pages/main-section/components/mobile-top-bar.vue
+++ b/apps/web/src/pages/main-section/components/mobile-top-bar.vue
@@ -95,6 +95,7 @@ import MobileBar from '@/components/mobile-bar/index.vue'
 import MobileBarIconButton from '@/components/mobile-bar/icon-button.vue'
 import { mobileBarIconButtonClass } from '@/components/mobile-bar/icon-button-class'
 import { useChatStore } from '@/store/chat-list'
+import { routeConversationLabel } from '@/store/chat-list.utils'
 import { useChatSelectionStore } from '@/store/chat-selection'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { hasBotPermission } from '@/utils/bot-permissions'
@@ -152,7 +153,7 @@ onBeforeUnmount(() => titleSub?.dispose())
 const title = computed(() => {
   if (!activePanelIsChat.value) return activePanelTitle.value || botLabel.value
   if (selectionStore.sessionId) {
-    return chatStore.activeSession?.title?.trim() || t('chat.untitledSession')
+    return chatStore.activeSession?.title?.trim() || routeConversationLabel(chatStore.activeSession) || t('chat.untitledSession')
   }
   return botLabel.value
 })

--- a/apps/web/src/store/chat-list.utils.ts
+++ b/apps/web/src/store/chat-list.utils.ts
@@ -73,8 +73,23 @@ export function normalizedRuntimeType(session: SessionDescriptorShape): string {
   return (session.type ?? '').trim() === 'acp_agent' ? 'acp_agent' : 'model'
 }
 
-export function isSessionVisibleInSidebarMode(session: SessionDescriptorShape, mode: SidebarSessionMode): boolean {
-  switch (mode) {
+// Default visible label for a channel-bound session that has no title: a group
+// shows its conversation (group) name, a DM the peer's display name. Discuss
+// sessions never get a title generated server-side (only the chat turn path
+// runs maybeGenerateSessionTitle), so without this fallback they would pile up
+// in Recents as indistinguishable "Untitled Session" rows. The name comes from
+// the channel route metadata that EnrichThreads projects onto session list
+// responses; every render surface (sidebar row, workspace tab, session picker)
+// funnels through here so the fallback chain stays identical.
+export function routeConversationLabel(session: { route_metadata?: Record<string, unknown> | null } | null | undefined): string {
+  const meta = session?.route_metadata ?? {}
+  return (meta.conversation_name as string ?? '').trim()
+    || (meta.sender_display_name as string ?? '').trim()
+    || (meta.sender_username as string ?? '').trim()
+    || ''
+}
+
+export function isSessionVisibleInSidebarMode(session: SessionDescriptorShape, mode: SidebarSessionMode): boolean {  switch (mode) {
     case 'recent': {
       const sessionMode = normalizedSessionMode(session)
       return sessionMode === 'chat' || sessionMode === 'discuss'

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -1398,8 +1398,15 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
       const sid = panelSessionId(panel)
       if (!sid) continue
       const session = chatStore.knownSessionSummary(sid)
-      const title = (session?.title ?? '').trim()
-      if (title && panel.api.title !== title) panel.api.setTitle(title)
+      // Unknown session (not yet in the loaded list): leave the tab alone —
+      // deriving from nothing would overwrite a correct title with a fallback.
+      if (!session) continue
+      // Untitled sessions (channel/discuss ones) derive their tab title from the
+      // fallback chain (conversation name → untitled): this refreshes a persisted
+      // "Untitled Session" placeholder after upgrade and follows a group rename —
+      // repairEmptyPanelTitles skips non-empty titles, so without this both stay stale.
+      const next = (session.title ?? '').trim() || chatTitleFallbackFor(sid)
+      if (panel.api.title !== next) panel.api.setTitle(next)
     }
   }
 
@@ -2494,9 +2501,10 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   )
 
   // Server renames flow into each open chat tab's title. Keyed by a sorted
-  // id:title digest so it fires on title changes, not on every sidebar reorder.
+  // id:title:conversation-name digest so it fires on title changes AND on
+  // channel route (group/peer name) changes, not on every sidebar reorder.
   watch(
-    () => chatStore.knownSessions.map(s => `${s.id}:${s.title ?? ''}`).sort().join('|'),
+    () => chatStore.knownSessions.map(s => `${s.id}:${s.title ?? ''}:${(s.route_metadata?.conversation_name as string) ?? ''}`).sort().join('|'),
     () => syncChatTitles(),
   )
 

--- a/apps/web/src/store/workspace-tabs.ts
+++ b/apps/web/src/store/workspace-tabs.ts
@@ -5,6 +5,7 @@ import { useTabScopedStorage } from '@/utils/tab-scoped-storage'
 import { useIsMobile } from '@/composables/useIsMobile'
 import type { DockviewApi, DockviewGroupPanel, SerializedDockview } from 'dockview-vue'
 import { useChatStore } from '@/store/chat-list'
+import { routeConversationLabel } from '@/store/chat-list.utils'
 import { useChatSelectionStore } from '@/store/chat-selection'
 import { onAuthSessionCleared } from '@/lib/auth-session'
 import { hasBotPermission, type BotPermission } from '@/utils/bot-permissions'
@@ -351,7 +352,7 @@ export const useWorkspaceTabsStore = defineStore('workspace-tabs', () => {
   function chatTitleFallbackFor(sid: string | null): string {
     if (!sid) return DEFAULT_CHAT_TITLE
     const session = chatStore.knownSessionSummary(sid)
-    return (session?.title ?? '').trim() || i18n.global.t('chat.untitledSession')
+    return (session?.title ?? '').trim() || routeConversationLabel(session) || i18n.global.t('chat.untitledSession')
   }
 
   function panelTitleFallback(panel: { id: string, params?: Record<string, unknown> }): string {


### PR DESCRIPTION
## 问题

由外部 channel（如 Telegram 群）触发、同步到 Web 侧的 session 永远不生成标题：只有 chat turn 路径会走 `maybeGenerateSessionTitle`，群消息默认走 discuss 路径（`turn_discuss.go`），其中没有任何标题生成逻辑。Web 侧 Recents 里这些会话全部堆成 "Untitled Session"，多条并排无法区分。

Fixes #1043

## 方案

不为 discuss 路径补标题生成（起名本身难，且群消息首行质量差，@bot/命令居多）。群聊 session 的身份就是"那个群的会话"，空标题时直接显示**渠道会话名**：

- 新增 `routeConversationLabel()`（chat-list.utils）：空标题 fallback 链 = 群名（conversation_name）→ 对方显示名 → 对方用户名。数据来自 `EnrichThreads` 已下发的 `route_metadata`（此前只用于 hover tooltip），**零后端改动**。
- 接入渲染点：侧边栏行、hover tooltip、workspace tab 标题、session 选择器。

语义：
- 用户 rename 仍写 `title` 字段，覆盖默认显示；
- 群改名自动跟随（route metadata 回填）；
- **同群多个 session 接受同名**，靠 Recents 排序区分 —— 产品取舍，已与 issue 讨论确认。

## 第二批（1e9c02e69，回应 Codex review 前两条 P2）

Codex 两条评论经核实**均属实**：

1. **tab 标题被调用方绕过**：recents / folders / 搜索对话框把 `"Untitled Session"` 字面量当 `opts.title` 传给 `openSessionChat`（对非空 title 优先使用），fallback 链从不执行。→ 5 个调用点改为只传原始 title，fallback 统一收敛到 tab store 派生。
2. **搜索对话框未接入**：结果渲染死 fallback、关键词只搜 title+id。→ 渲染与搜索关键词接入 `routeConversationLabel`，**群名可搜**。

另发现并补上同类遗漏：**移动端顶栏**（mobile-top-bar.vue）接入同一链。

## 第三批（ec53f5747，回应 Codex review 第三条 P2 + 解 main 冲突）

Codex 第三条评论经核实**属实**（陈旧级）：
- `repairEmptyPanelTitles` 跳过一切非空标题 → 升级前持久化为 "Untitled Session" 的 tab 恢复后永不翻新；
- `syncChatTitles` 只在 `session.title` 非空时写入，watcher digest 不含 route_metadata → 群改名后已打开 tab 不跟随。

修法：`syncChatTitles` 对已知 session 且 title 为空时 derive fallback 写入（session 未加载进列表时保持原样，沿用原保护语义；draft panel 无 sessionId 不受影响）;watcher digest 加入 `conversation_name`。

同时 merge main 解了 `session-item.vue` 冲突（main 的 #1125 标题跑马灯/行强调改动与本文正交，双方保留）。

穷尽检查：全仓 `untitledSession` 残留引用均为链末端兜底（title → route label → untitled），无第六个遗漏点。

## 测试

- [x] 本地 OSS 槽实测：Recents 中 4 条空标题 discuss session 全部显示群名（Arkloop），DM/chat 路径标题不受影响，hover tooltip 与 tab 标题同步
- [x] `pnpm vitest run apps/web/src`:1201 通过；2 个失败文件（useMediaGallery / panel-preview mock 与超时）为测试基建既有问题，与本改动无关
- [x] `pnpm --filter @memohai/web typecheck`：仓库既有失败（ui submodule `#/` 别名、dockview 等），stash 前后对照本次改动**零新增**
- [x] pre-commit 全量门禁：eslint + `go test ./...` 全绿（三批均过）
- [ ] 合并发版后在 app.memoh.net 线上确认（该 issue 的原始复现环境）