### PR TITLE
fix(docker): make workspace bridge reachable from containerized servers

### DIFF
--- a/cmd/internal/core/providers.go
+++ b/cmd/internal/core/providers.go
@@ -104,7 +104,9 @@ func provideLogger(cfg config.Config) *slog.Logger {
 }
 
 func provideContainerService(lc fx.Lifecycle, log *slog.Logger, cfg config.Config, rc *boot.RuntimeConfig) (ctr.Service, error) {
-	svc, cleanup, err := containerprovider.ProvideService(context.Background(), log, cfg, rc.ContainerBackend)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	svc, cleanup, err := containerprovider.ProvideService(ctx, log, cfg, rc.ContainerBackend)
 	if err != nil {
 		return nil, err
 	}

--- a/conf/app.docker.toml
+++ b/conf/app.docker.toml
@@ -69,6 +69,9 @@ namespace = "default"
 # Used only when [container].backend = "docker"; the official Compose stack
 # uses containerd above.
 host = ""
+# Dedicated user-defined network shared by a custom containerized
+# Docker-backend server and its workspace containers.
+network = ""
 
 ## Postgres configuration.
 [postgres]

--- a/conf/app.docker.toml
+++ b/conf/app.docker.toml
@@ -73,6 +73,9 @@ host = ""
 # Docker-backend server and its workspace containers. Requires
 # [bridge_tls].mode = "strict".
 network = ""
+# Container ID or unique name of this Memoh server on the configured Docker
+# daemon. Required together with network.
+server_container = ""
 
 ## Postgres configuration.
 [postgres]

--- a/conf/app.docker.toml
+++ b/conf/app.docker.toml
@@ -70,7 +70,8 @@ namespace = "default"
 # uses containerd above.
 host = ""
 # Dedicated user-defined network shared by a custom containerized
-# Docker-backend server and its workspace containers.
+# Docker-backend server and its workspace containers. Requires
+# [bridge_tls].mode = "strict".
 network = ""
 
 ## Postgres configuration.

--- a/conf/app.example.toml
+++ b/conf/app.example.toml
@@ -142,6 +142,9 @@ namespace = "default"
 # Leave empty to use Docker's standard environment discovery (DOCKER_HOST,
 # DOCKER_TLS_VERIFY, DOCKER_CERT_PATH, or the platform default socket).
 host = ""
+# Dedicated user-defined network shared by a containerized server and its
+# workspace containers. Host deployments keep this empty.
+network = ""
 
 [bridge_tls]
 # disabled: default for local/open-source deployments.

--- a/conf/app.example.toml
+++ b/conf/app.example.toml
@@ -146,6 +146,9 @@ host = ""
 # workspace containers. Host deployments keep this empty. Network routing
 # requires [bridge_tls].mode = "strict".
 network = ""
+# Container ID or unique name of this Memoh server on the configured Docker
+# daemon. Required together with network.
+server_container = ""
 
 [bridge_tls]
 # disabled: default for local/open-source deployments.

--- a/conf/app.example.toml
+++ b/conf/app.example.toml
@@ -143,7 +143,8 @@ namespace = "default"
 # DOCKER_TLS_VERIFY, DOCKER_CERT_PATH, or the platform default socket).
 host = ""
 # Dedicated user-defined network shared by a containerized server and its
-# workspace containers. Host deployments keep this empty.
+# workspace containers. Host deployments keep this empty. Network routing
+# requires [bridge_tls].mode = "strict".
 network = ""
 
 [bridge_tls]

--- a/devenv/app.dev.toml
+++ b/devenv/app.dev.toml
@@ -60,6 +60,9 @@ host = ""
 # Docker-backend server and its workspace containers. Requires
 # [bridge_tls].mode = "strict".
 network = ""
+# Container ID or unique name of this Memoh server on the configured Docker
+# daemon. Required together with network.
+server_container = ""
 
 [postgres]
 host = "postgres"

--- a/devenv/app.dev.toml
+++ b/devenv/app.dev.toml
@@ -57,7 +57,8 @@ namespace = "default"
 # Used only when [container].backend = "docker"; the dev Compose stack uses containerd.
 host = ""
 # Dedicated user-defined network shared by a custom containerized
-# Docker-backend server and its workspace containers.
+# Docker-backend server and its workspace containers. Requires
+# [bridge_tls].mode = "strict".
 network = ""
 
 [postgres]

--- a/devenv/app.dev.toml
+++ b/devenv/app.dev.toml
@@ -56,6 +56,9 @@ namespace = "default"
 [docker]
 # Used only when [container].backend = "docker"; the dev Compose stack uses containerd.
 host = ""
+# Dedicated user-defined network shared by a custom containerized
+# Docker-backend server and its workspace containers.
+network = ""
 
 [postgres]
 host = "postgres"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -444,8 +444,9 @@ type ContainerdConfig struct {
 }
 
 type DockerConfig struct {
-	Host    string `toml:"host"`
-	Network string `toml:"network"`
+	Host            string `toml:"host"`
+	Network         string `toml:"network"`
+	ServerContainer string `toml:"server_container"`
 }
 
 type AppleConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -444,7 +444,8 @@ type ContainerdConfig struct {
 }
 
 type DockerConfig struct {
-	Host string `toml:"host"`
+	Host    string `toml:"host"`
+	Network string `toml:"network"`
 }
 
 type AppleConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -134,6 +134,7 @@ namespace = "memoh-test"
 [docker]
 host = "unix:///var/run/docker.sock"
 network = "memoh-workspace"
+server_container = "memoh-server"
 
 [apple]
 socket_path = "/tmp/socktainer.sock"
@@ -152,6 +153,9 @@ binary_path = "/opt/homebrew/bin/socktainer"
 	}
 	if cfg.Containerd.Namespace != "memoh-test" {
 		t.Fatalf("containerd namespace = %q", cfg.Containerd.Namespace)
+	}
+	if cfg.Docker.ServerContainer != "memoh-server" {
+		t.Fatalf("docker server container = %q", cfg.Docker.ServerContainer)
 	}
 	if cfg.Docker.Host != "unix:///var/run/docker.sock" {
 		t.Fatalf("docker host = %q", cfg.Docker.Host)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,6 +133,7 @@ namespace = "memoh-test"
 
 [docker]
 host = "unix:///var/run/docker.sock"
+network = "memoh-workspace"
 
 [apple]
 socket_path = "/tmp/socktainer.sock"
@@ -154,6 +155,9 @@ binary_path = "/opt/homebrew/bin/socktainer"
 	}
 	if cfg.Docker.Host != "unix:///var/run/docker.sock" {
 		t.Fatalf("docker host = %q", cfg.Docker.Host)
+	}
+	if cfg.Docker.Network != "memoh-workspace" {
+		t.Fatalf("docker network = %q", cfg.Docker.Network)
 	}
 	if cfg.Apple.SocketPath != "/tmp/socktainer.sock" {
 		t.Fatalf("apple socket path = %q", cfg.Apple.SocketPath)

--- a/internal/container/docker/service.go
+++ b/internal/container/docker/service.go
@@ -313,7 +313,7 @@ func validateServerNetworkMembership(ctx context.Context, cli *client.Client, se
 		mappedErr := mapDockerErr(err)
 		if containerapi.IsNotFound(mappedErr) {
 			return fmt.Errorf(
-				"%w: Memoh server container %q does not exist on Docker daemon %q: %v",
+				"%w: Memoh server container %q does not exist on Docker daemon %q: %w",
 				containerapi.ErrInvalidArgument,
 				serverContainer,
 				cli.DaemonHost(),

--- a/internal/container/docker/service.go
+++ b/internal/container/docker/service.go
@@ -43,12 +43,13 @@ type Service struct {
 	workspaceNetwork string
 }
 
-func NewService(log *slog.Logger, cfg config.Config) (*Service, error) {
+func NewService(ctx context.Context, log *slog.Logger, cfg config.Config) (*Service, error) {
 	if log == nil {
 		log = slog.Default()
 	}
 	workspaceNetwork := strings.TrimSpace(cfg.Docker.Network)
-	if err := validateWorkspaceNetwork(workspaceNetwork, runningInContainer(), cfg.BridgeTLS.Strict()); err != nil {
+	serverContainer := strings.TrimSpace(cfg.Docker.ServerContainer)
+	if err := validateWorkspaceNetwork(workspaceNetwork, serverContainer, runningInContainer(), cfg.BridgeTLS.Strict()); err != nil {
 		return nil, err
 	}
 	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
@@ -58,6 +59,13 @@ func NewService(log *slog.Logger, cfg config.Config) (*Service, error) {
 	cli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create docker client: %w", err)
+	}
+	if workspaceNetwork != "" {
+		err = validateServerNetworkMembership(ctx, cli, serverContainer, workspaceNetwork)
+		if err != nil {
+			_ = cli.Close()
+			return nil, err
+		}
 	}
 	return &Service{
 		client:           cli,
@@ -280,7 +288,7 @@ func isUserDefinedDockerNetwork(name string) bool {
 	}
 }
 
-func validateWorkspaceNetwork(name string, serverInContainer, bridgeTLSStrict bool) error {
+func validateWorkspaceNetwork(name, serverContainer string, serverInContainer, bridgeTLSStrict bool) error {
 	if name == "" {
 		return nil
 	}
@@ -293,7 +301,37 @@ func validateWorkspaceNetwork(name string, serverInContainer, bridgeTLSStrict bo
 	if !bridgeTLSStrict {
 		return fmt.Errorf("docker network %q requires [bridge_tls].mode = %q to isolate workspace bridge access", name, config.BridgeTLSModeStrict)
 	}
+	if strings.TrimSpace(serverContainer) == "" {
+		return fmt.Errorf("docker network %q requires [docker].server_container to identify this Memoh server on the configured Docker daemon", name)
+	}
 	return nil
+}
+
+func validateServerNetworkMembership(ctx context.Context, cli *client.Client, serverContainer, networkName string) error {
+	info, err := cli.ContainerInspect(ctx, serverContainer)
+	if err != nil {
+		mappedErr := mapDockerErr(err)
+		if containerapi.IsNotFound(mappedErr) {
+			return fmt.Errorf(
+				"%w: Memoh server container %q does not exist on Docker daemon %q: %v",
+				containerapi.ErrInvalidArgument,
+				serverContainer,
+				cli.DaemonHost(),
+				err,
+			)
+		}
+		return fmt.Errorf("inspect Memoh server container %q on Docker daemon %q: %w", serverContainer, cli.DaemonHost(), mappedErr)
+	}
+	if containerNetworkEndpoint(info, networkName) != nil {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: Memoh server container %q is not attached to Docker network %q on Docker daemon %q",
+		containerapi.ErrInvalidArgument,
+		serverContainer,
+		networkName,
+		cli.DaemonHost(),
+	)
 }
 
 func containerNetworkIP(info container.InspectResponse, networkName string) string {

--- a/internal/container/docker/service.go
+++ b/internal/container/docker/service.go
@@ -48,11 +48,8 @@ func NewService(log *slog.Logger, cfg config.Config) (*Service, error) {
 		log = slog.Default()
 	}
 	workspaceNetwork := strings.TrimSpace(cfg.Docker.Network)
-	if isDefaultDockerNetwork(workspaceNetwork) {
-		return nil, fmt.Errorf("docker network %q does not provide container-name DNS; configure a user-defined network", workspaceNetwork)
-	}
-	if workspaceNetwork != "" && !runningInContainer() {
-		return nil, fmt.Errorf("docker network %q requires the Memoh server to run in a container; host deployments use the loopback workspace bridge", workspaceNetwork)
+	if err := validateWorkspaceNetwork(workspaceNetwork, runningInContainer(), cfg.BridgeTLS.Strict()); err != nil {
+		return nil, err
 	}
 	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
 	if host := strings.TrimSpace(cfg.Docker.Host); host != "" {
@@ -270,20 +267,37 @@ func runningInContainer() bool {
 	return false
 }
 
-func isDefaultDockerNetwork(name string) bool {
-	switch strings.TrimSpace(name) {
-	case "bridge", "default", "host", "none":
-		return true
-	default:
+func isUserDefinedDockerNetwork(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
 		return false
+	}
+	switch name {
+	case "bridge", "default", "host", "nat", "none":
+		return false
+	default:
+		return !container.NetworkMode(name).IsContainer()
 	}
 }
 
-func containerNetworkIP(info container.InspectResponse, networkName string) string {
-	if info.NetworkSettings == nil {
-		return ""
+func validateWorkspaceNetwork(name string, serverInContainer, bridgeTLSStrict bool) error {
+	if name == "" {
+		return nil
 	}
-	endpoint := info.NetworkSettings.Networks[strings.TrimSpace(networkName)]
+	if !isUserDefinedDockerNetwork(name) {
+		return fmt.Errorf("docker network %q does not provide container-name DNS; configure a user-defined network", name)
+	}
+	if !serverInContainer {
+		return fmt.Errorf("docker network %q requires the Memoh server to run in a container; host deployments use the loopback workspace bridge", name)
+	}
+	if !bridgeTLSStrict {
+		return fmt.Errorf("docker network %q requires [bridge_tls].mode = %q to isolate workspace bridge access", name, config.BridgeTLSModeStrict)
+	}
+	return nil
+}
+
+func containerNetworkIP(info container.InspectResponse, networkName string) string {
+	endpoint := containerNetworkEndpoint(info, networkName)
 	if endpoint == nil {
 		return ""
 	}
@@ -291,6 +305,13 @@ func containerNetworkIP(info container.InspectResponse, networkName string) stri
 		return ip
 	}
 	return strings.TrimSpace(endpoint.GlobalIPv6Address)
+}
+
+func containerNetworkEndpoint(info container.InspectResponse, networkName string) *network.EndpointSettings {
+	if info.NetworkSettings == nil {
+		return nil
+	}
+	return info.NetworkSettings.Networks[strings.TrimSpace(networkName)]
 }
 
 func (s *Service) GetContainer(ctx context.Context, id string) (containerapi.ContainerInfo, error) {
@@ -449,7 +470,7 @@ func (s *Service) SetupNetwork(ctx context.Context, req containerapi.NetworkRequ
 		return containerapi.NetworkResult{}, mapDockerErr(err)
 	}
 	if workspaceNetwork != "" {
-		if containerNetworkIP(info, workspaceNetwork) == "" {
+		if containerNetworkEndpoint(info, workspaceNetwork) == nil {
 			connectErr := s.client.NetworkConnect(ctx, workspaceNetwork, req.ContainerID, nil)
 			info, err = s.client.ContainerInspect(ctx, req.ContainerID)
 			if err != nil {
@@ -467,9 +488,26 @@ func (s *Service) SetupNetwork(ctx context.Context, req containerapi.NetworkRequ
 	return containerapi.NetworkResult{IP: firstContainerIP(info)}, nil
 }
 
-func (*Service) RemoveNetwork(_ context.Context, req containerapi.NetworkRequest) error {
+func (s *Service) RemoveNetwork(ctx context.Context, req containerapi.NetworkRequest) error {
 	if strings.TrimSpace(req.ContainerID) == "" {
 		return containerapi.ErrInvalidArgument
+	}
+	workspaceNetwork, err := s.resolveWorkspaceNetwork(ctx)
+	if err != nil {
+		return err
+	}
+	if workspaceNetwork == "" {
+		return nil
+	}
+	info, err := s.client.ContainerInspect(ctx, req.ContainerID)
+	if err != nil {
+		return mapDockerErr(err)
+	}
+	if containerNetworkEndpoint(info, workspaceNetwork) == nil {
+		return nil
+	}
+	if err := s.client.NetworkDisconnect(ctx, workspaceNetwork, req.ContainerID, false); err != nil {
+		return fmt.Errorf("disconnect container %q from Docker network %q: %w", req.ContainerID, workspaceNetwork, mapDockerErr(err))
 	}
 	return nil
 }

--- a/internal/container/docker/service.go
+++ b/internal/container/docker/service.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"syscall"
@@ -19,6 +20,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	dockermount "github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 
@@ -36,8 +38,9 @@ const (
 var invalidSnapshotTagChars = regexp.MustCompile(`[^A-Za-z0-9_.-]+`)
 
 type Service struct {
-	client *client.Client
-	logger *slog.Logger
+	client           *client.Client
+	logger           *slog.Logger
+	workspaceNetwork string
 }
 
 func NewService(log *slog.Logger, cfg config.Config) (*Service, error) {
@@ -52,9 +55,15 @@ func NewService(log *slog.Logger, cfg config.Config) (*Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create docker client: %w", err)
 	}
+	workspaceNetwork := strings.TrimSpace(cfg.Docker.Network)
+	if isDefaultDockerNetwork(workspaceNetwork) {
+		_ = cli.Close()
+		return nil, fmt.Errorf("docker network %q does not provide container-name DNS; configure a user-defined network", workspaceNetwork)
+	}
 	return &Service{
-		client: cli,
-		logger: log.With(slog.String("service", "docker")),
+		client:           cli,
+		logger:           log.With(slog.String("service", "docker")),
+		workspaceNetwork: workspaceNetwork,
 	}, nil
 }
 
@@ -132,6 +141,10 @@ func (s *Service) CreateContainer(ctx context.Context, req containerapi.CreateCo
 	if req.StorageRef.Key != "" {
 		labels[containerapi.StorageKeyLabel] = req.StorageRef.Key
 	}
+	workspaceNetwork, err := s.resolveWorkspaceNetwork(ctx)
+	if err != nil {
+		return containerapi.ContainerInfo{}, err
+	}
 	hostCfg := &container.HostConfig{
 		Mounts: toDockerMounts(req.Spec.Mounts),
 		DNS:    req.Spec.DNS,
@@ -139,6 +152,7 @@ func (s *Service) CreateContainer(ctx context.Context, req containerapi.CreateCo
 			nat.Port(bridgeTCPPort + "/tcp"): []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: ""}},
 		},
 	}
+	var networkingCfg *network.NetworkingConfig
 	if req.ResourceLimits.MemoryBytes > 0 {
 		hostCfg.Memory = req.ResourceLimits.MemoryBytes
 	}
@@ -147,6 +161,14 @@ func (s *Service) CreateContainer(ctx context.Context, req containerapi.CreateCo
 	}
 	if req.Spec.NetworkJoinTarget.Value != "" {
 		hostCfg.NetworkMode = container.NetworkMode("none")
+	} else if workspaceNetwork != "" {
+		hostCfg.NetworkMode = container.NetworkMode(workspaceNetwork)
+		hostCfg.PortBindings = nil
+		networkingCfg = &network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				workspaceNetwork: {},
+			},
+		}
 	}
 	cfg := &container.Config{
 		Image:      req.ImageRef,
@@ -160,7 +182,7 @@ func (s *Service) CreateContainer(ctx context.Context, req containerapi.CreateCo
 			nat.Port(bridgeTCPPort + "/tcp"): struct{}{},
 		},
 	}
-	resp, err := s.client.ContainerCreate(ctx, cfg, hostCfg, nil, nil, req.ID)
+	resp, err := s.client.ContainerCreate(ctx, cfg, hostCfg, networkingCfg, nil, req.ID)
 	if err != nil {
 		return containerapi.ContainerInfo{}, mapDockerErr(err)
 	}
@@ -173,9 +195,20 @@ func (s *Service) BridgeTarget(botID string) string {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+	workspaceNetwork, err := s.resolveWorkspaceNetwork(ctx)
+	if err != nil {
+		s.logger.Warn("resolve Docker workspace network", slog.Any("error", err))
+		return ""
+	}
 	info, err := s.client.ContainerInspect(ctx, workspaceContainerPref+strings.TrimSpace(botID))
 	if err != nil {
 		return ""
+	}
+	if workspaceNetwork != "" {
+		if containerNetworkIP(info, workspaceNetwork) == "" {
+			return ""
+		}
+		return net.JoinHostPort(workspaceContainerPref+strings.TrimSpace(botID), bridgeTCPPort)
 	}
 	if host := firstHostPort(info, bridgeTCPPort); host != "" {
 		return host
@@ -203,6 +236,59 @@ func firstHostPort(info container.InspectResponse, port string) string {
 		return net.JoinHostPort(hostIP, hostPort)
 	}
 	return ""
+}
+
+func (s *Service) resolveWorkspaceNetwork(ctx context.Context) (string, error) {
+	if s.workspaceNetwork != "" {
+		return s.workspaceNetwork, nil
+	}
+	if !runningInContainer() {
+		return "", nil
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("%w: read server container hostname: %w", containerapi.ErrInvalidArgument, err)
+	}
+	info, err := s.client.ContainerInspect(ctx, hostname)
+	if err != nil {
+		return "", fmt.Errorf("%w: inspect server container %q: %w; set [docker].network explicitly", containerapi.ErrInvalidArgument, hostname, err)
+	}
+	if info.HostConfig != nil && info.HostConfig.NetworkMode.IsHost() {
+		return "", nil
+	}
+	return "", fmt.Errorf("%w: Docker backend inside a container requires [docker].network to name a dedicated user-defined network shared with workspace containers", containerapi.ErrInvalidArgument)
+}
+
+func runningInContainer() bool {
+	for _, marker := range []string{"/.dockerenv", "/run/.containerenv"} {
+		if _, err := os.Stat(marker); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func isDefaultDockerNetwork(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "bridge", "default", "host", "none":
+		return true
+	default:
+		return false
+	}
+}
+
+func containerNetworkIP(info container.InspectResponse, networkName string) string {
+	if info.NetworkSettings == nil {
+		return ""
+	}
+	endpoint := info.NetworkSettings.Networks[strings.TrimSpace(networkName)]
+	if endpoint == nil {
+		return ""
+	}
+	if ip := strings.TrimSpace(endpoint.IPAddress); ip != "" {
+		return ip
+	}
+	return strings.TrimSpace(endpoint.GlobalIPv6Address)
 }
 
 func (s *Service) GetContainer(ctx context.Context, id string) (containerapi.ContainerInfo, error) {
@@ -349,9 +435,29 @@ func (s *Service) ListTasks(ctx context.Context, _ *containerapi.ListTasksOption
 }
 
 func (s *Service) SetupNetwork(ctx context.Context, req containerapi.NetworkRequest) (containerapi.NetworkResult, error) {
+	workspaceNetwork, err := s.resolveWorkspaceNetwork(ctx)
+	if err != nil {
+		return containerapi.NetworkResult{}, err
+	}
 	info, err := s.client.ContainerInspect(ctx, req.ContainerID)
 	if err != nil {
 		return containerapi.NetworkResult{}, mapDockerErr(err)
+	}
+	if workspaceNetwork != "" {
+		if containerNetworkIP(info, workspaceNetwork) == "" {
+			connectErr := s.client.NetworkConnect(ctx, workspaceNetwork, req.ContainerID, nil)
+			info, err = s.client.ContainerInspect(ctx, req.ContainerID)
+			if err != nil {
+				return containerapi.NetworkResult{}, mapDockerErr(err)
+			}
+			if containerNetworkIP(info, workspaceNetwork) == "" {
+				if connectErr != nil {
+					return containerapi.NetworkResult{}, fmt.Errorf("connect container %q to Docker network %q: %w", req.ContainerID, workspaceNetwork, mapDockerErr(connectErr))
+				}
+				return containerapi.NetworkResult{}, errors.Join(containerapi.ErrRuntime, fmt.Errorf("container %q joined Docker network %q without an IP address", req.ContainerID, workspaceNetwork))
+			}
+		}
+		return containerapi.NetworkResult{IP: containerNetworkIP(info, workspaceNetwork)}, nil
 	}
 	return containerapi.NetworkResult{IP: firstContainerIP(info)}, nil
 }
@@ -361,8 +467,18 @@ func (*Service) RemoveNetwork(context.Context, containerapi.NetworkRequest) erro
 }
 
 func (s *Service) CheckNetwork(ctx context.Context, req containerapi.NetworkRequest) error {
-	_, err := s.client.ContainerInspect(ctx, req.ContainerID)
-	return mapDockerErr(err)
+	workspaceNetwork, err := s.resolveWorkspaceNetwork(ctx)
+	if err != nil {
+		return err
+	}
+	info, err := s.client.ContainerInspect(ctx, req.ContainerID)
+	if err != nil {
+		return mapDockerErr(err)
+	}
+	if workspaceNetwork != "" && containerNetworkIP(info, workspaceNetwork) == "" {
+		return errors.Join(containerapi.ErrRuntime, fmt.Errorf("container %q is detached from Docker network %q", req.ContainerID, workspaceNetwork))
+	}
+	return nil
 }
 
 func (s *Service) CommitSnapshot(ctx context.Context, req containerapi.CommitSnapshotRequest) error {

--- a/internal/container/docker/service.go
+++ b/internal/container/docker/service.go
@@ -47,6 +47,13 @@ func NewService(log *slog.Logger, cfg config.Config) (*Service, error) {
 	if log == nil {
 		log = slog.Default()
 	}
+	workspaceNetwork := strings.TrimSpace(cfg.Docker.Network)
+	if isDefaultDockerNetwork(workspaceNetwork) {
+		return nil, fmt.Errorf("docker network %q does not provide container-name DNS; configure a user-defined network", workspaceNetwork)
+	}
+	if workspaceNetwork != "" && !runningInContainer() {
+		return nil, fmt.Errorf("docker network %q requires the Memoh server to run in a container; host deployments use the loopback workspace bridge", workspaceNetwork)
+	}
 	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
 	if host := strings.TrimSpace(cfg.Docker.Host); host != "" {
 		opts = append(opts, client.WithHost(host))
@@ -54,11 +61,6 @@ func NewService(log *slog.Logger, cfg config.Config) (*Service, error) {
 	cli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create docker client: %w", err)
-	}
-	workspaceNetwork := strings.TrimSpace(cfg.Docker.Network)
-	if isDefaultDockerNetwork(workspaceNetwork) {
-		_ = cli.Close()
-		return nil, fmt.Errorf("docker network %q does not provide container-name DNS; configure a user-defined network", workspaceNetwork)
 	}
 	return &Service{
 		client:           cli,

--- a/internal/container/docker/service.go
+++ b/internal/container/docker/service.go
@@ -437,6 +437,9 @@ func (s *Service) ListTasks(ctx context.Context, _ *containerapi.ListTasksOption
 }
 
 func (s *Service) SetupNetwork(ctx context.Context, req containerapi.NetworkRequest) (containerapi.NetworkResult, error) {
+	if strings.TrimSpace(req.ContainerID) == "" {
+		return containerapi.NetworkResult{}, containerapi.ErrInvalidArgument
+	}
 	workspaceNetwork, err := s.resolveWorkspaceNetwork(ctx)
 	if err != nil {
 		return containerapi.NetworkResult{}, err
@@ -464,11 +467,17 @@ func (s *Service) SetupNetwork(ctx context.Context, req containerapi.NetworkRequ
 	return containerapi.NetworkResult{IP: firstContainerIP(info)}, nil
 }
 
-func (*Service) RemoveNetwork(context.Context, containerapi.NetworkRequest) error {
+func (*Service) RemoveNetwork(_ context.Context, req containerapi.NetworkRequest) error {
+	if strings.TrimSpace(req.ContainerID) == "" {
+		return containerapi.ErrInvalidArgument
+	}
 	return nil
 }
 
 func (s *Service) CheckNetwork(ctx context.Context, req containerapi.NetworkRequest) error {
+	if strings.TrimSpace(req.ContainerID) == "" {
+		return containerapi.ErrInvalidArgument
+	}
 	workspaceNetwork, err := s.resolveWorkspaceNetwork(ctx)
 	if err != nil {
 		return err

--- a/internal/container/docker/service_test.go
+++ b/internal/container/docker/service_test.go
@@ -296,6 +296,29 @@ func TestSetupNetworkAttachesExistingWorkspace(t *testing.T) {
 	}
 }
 
+func TestDockerNetworkOperationsRejectEmptyContainerID(t *testing.T) {
+	svc := &Service{}
+	tests := map[string]func() error{
+		"setup": func() error {
+			_, err := svc.SetupNetwork(context.Background(), containerapi.NetworkRequest{})
+			return err
+		},
+		"remove": func() error {
+			return svc.RemoveNetwork(context.Background(), containerapi.NetworkRequest{})
+		},
+		"check": func() error {
+			return svc.CheckNetwork(context.Background(), containerapi.NetworkRequest{})
+		},
+	}
+	for name, operation := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := operation(); !errors.Is(err, containerapi.ErrInvalidArgument) {
+				t.Fatalf("network operation error = %v, want ErrInvalidArgument", err)
+			}
+		})
+	}
+}
+
 func newTestService(t *testing.T, workspaceNetwork string, handler http.HandlerFunc) *Service {
 	t.Helper()
 	server := httptest.NewServer(handler)

--- a/internal/container/docker/service_test.go
+++ b/internal/container/docker/service_test.go
@@ -286,7 +286,7 @@ func TestValidateServerNetworkMembership(t *testing.T) {
 }
 
 func TestValidateServerNetworkMembershipPreservesCancellation(t *testing.T) {
-	svc := newTestService(t, "memoh-workspace", func(w http.ResponseWriter, r *http.Request) {
+	svc := newTestService(t, "memoh-workspace", func(_ http.ResponseWriter, r *http.Request) {
 		t.Errorf("unexpected Docker API request after cancellation: %s %s", r.Method, r.URL.Path)
 	})
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/container/docker/service_test.go
+++ b/internal/container/docker/service_test.go
@@ -162,8 +162,8 @@ func TestBridgeTargetPrefersPublishedHostPort(t *testing.T) {
 	}
 }
 
-func TestNewServiceRejectsDefaultDockerNetwork(t *testing.T) {
-	for _, networkName := range []string{"bridge", "default", "host", "none"} {
+func TestNewServiceRejectsNonUserDefinedDockerNetwork(t *testing.T) {
+	for _, networkName := range []string{"bridge", "default", "host", "nat", "none", "container:server"} {
 		t.Run(networkName, func(t *testing.T) {
 			_, err := NewService(slog.New(slog.DiscardHandler), config.Config{
 				Docker: config.DockerConfig{Network: networkName},
@@ -190,6 +190,16 @@ func TestNewServiceRejectsWorkspaceNetworkForHostServer(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "host deployments use the loopback workspace bridge") {
 		t.Fatalf("NewService() error = %q, want host loopback guidance", err)
+	}
+}
+
+func TestValidateWorkspaceNetworkRequiresStrictBridgeTLS(t *testing.T) {
+	const networkName = "memoh-workspace"
+	if err := validateWorkspaceNetwork(networkName, true, false); err == nil || !strings.Contains(err.Error(), `[bridge_tls].mode = "strict"`) {
+		t.Fatalf("validateWorkspaceNetwork() error = %v, want strict bridge TLS guidance", err)
+	}
+	if err := validateWorkspaceNetwork(networkName, true, true); err != nil {
+		t.Fatalf("validateWorkspaceNetwork() with strict bridge TLS error = %v", err)
 	}
 }
 
@@ -293,6 +303,54 @@ func TestSetupNetworkAttachesExistingWorkspace(t *testing.T) {
 	}
 	if result.IP != "172.20.0.4" {
 		t.Fatalf("SetupNetwork() IP = %q, want 172.20.0.4", result.IP)
+	}
+}
+
+func TestRemoveNetworkDetachesWorkspaceIdempotently(t *testing.T) {
+	connected := true
+	disconnects := 0
+	svc := newTestService(t, "memoh-workspace", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/containers/workspace-bot-1/json"):
+			networks := map[string]*dockernetwork.EndpointSettings{}
+			if connected {
+				networks["memoh-workspace"] = &dockernetwork.EndpointSettings{}
+			}
+			writeDockerJSON(t, w, dockercontainer.InspectResponse{
+				NetworkSettings: &dockercontainer.NetworkSettings{Networks: networks},
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/networks/memoh-workspace/disconnect"):
+			var request struct {
+				Container string `json:"Container"`
+				Force     bool   `json:"Force"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode network disconnect request: %v", err)
+			}
+			if request.Container != "workspace-bot-1" {
+				t.Errorf("network disconnect container = %q, want workspace-bot-1", request.Container)
+			}
+			if request.Force {
+				t.Error("network disconnect unexpectedly forced detachment")
+			}
+			disconnects++
+			connected = false
+			writeDockerJSON(t, w, struct{}{})
+		default:
+			t.Errorf("unexpected Docker API request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	})
+
+	request := containerapi.NetworkRequest{ContainerID: "workspace-bot-1"}
+	if err := svc.RemoveNetwork(context.Background(), request); err != nil {
+		t.Fatalf("RemoveNetwork() error = %v", err)
+	}
+	if err := svc.RemoveNetwork(context.Background(), request); err != nil {
+		t.Fatalf("second RemoveNetwork() error = %v", err)
+	}
+	if disconnects != 1 {
+		t.Fatalf("network disconnect calls = %d, want 1", disconnects)
 	}
 }
 

--- a/internal/container/docker/service_test.go
+++ b/internal/container/docker/service_test.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockerimage "github.com/docker/docker/api/types/image"
+	dockernetwork "github.com/docker/docker/api/types/network"
+	dockerclient "github.com/docker/docker/client"
 
+	"github.com/felinics/memoh/internal/config"
 	containerapi "github.com/felinics/memoh/internal/container"
 )
 
@@ -154,5 +159,151 @@ func TestBridgeTargetPrefersPublishedHostPort(t *testing.T) {
 	}
 	if got, want := firstHostPort(info, bridgeTCPPort), "127.0.0.1:49153"; got != want {
 		t.Fatalf("firstHostPort = %q, want %q", got, want)
+	}
+}
+
+func TestNewServiceRejectsDefaultDockerNetwork(t *testing.T) {
+	for _, networkName := range []string{"bridge", "default", "host", "none"} {
+		t.Run(networkName, func(t *testing.T) {
+			_, err := NewService(slog.New(slog.DiscardHandler), config.Config{
+				Docker: config.DockerConfig{Network: networkName},
+			})
+			if err == nil {
+				t.Fatalf("NewService() accepted Docker network %q", networkName)
+			}
+			if !strings.Contains(err.Error(), "user-defined network") {
+				t.Fatalf("NewService() error = %q, want user-defined network guidance", err)
+			}
+		})
+	}
+}
+
+func TestCreateContainerUsesWorkspaceNetworkWithoutPublishingBridge(t *testing.T) {
+	var createRequest dockercontainer.CreateRequest
+	svc := newTestService(t, "memoh-workspace", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/containers/create"):
+			if err := json.NewDecoder(r.Body).Decode(&createRequest); err != nil {
+				t.Errorf("decode create request: %v", err)
+			}
+			writeDockerJSON(t, w, dockercontainer.CreateResponse{ID: "container-id"})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/containers/container-id/json"):
+			writeDockerJSON(t, w, dockercontainer.InspectResponse{
+				ContainerJSONBase: &dockercontainer.ContainerJSONBase{ID: "container-id", Name: "/workspace-bot-1"},
+				Config:            &dockercontainer.Config{Image: "debian:bookworm-slim"},
+			})
+		default:
+			t.Errorf("unexpected Docker API request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	})
+
+	_, err := svc.CreateContainer(context.Background(), containerapi.CreateContainerRequest{
+		ID:       "workspace-bot-1",
+		ImageRef: "debian:bookworm-slim",
+	})
+	if err != nil {
+		t.Fatalf("CreateContainer() error = %v", err)
+	}
+	if got := string(createRequest.HostConfig.NetworkMode); got != "memoh-workspace" {
+		t.Fatalf("NetworkMode = %q, want memoh-workspace", got)
+	}
+	if len(createRequest.HostConfig.PortBindings) != 0 {
+		t.Fatalf("PortBindings = %#v, want no host bridge publication", createRequest.HostConfig.PortBindings)
+	}
+	if createRequest.NetworkingConfig == nil || createRequest.NetworkingConfig.EndpointsConfig["memoh-workspace"] == nil {
+		t.Fatalf("NetworkingConfig = %#v, want memoh-workspace endpoint", createRequest.NetworkingConfig)
+	}
+}
+
+func TestBridgeTargetUsesWorkspaceContainerDNS(t *testing.T) {
+	svc := newTestService(t, "memoh-workspace", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/containers/workspace-bot-1/json") {
+			t.Errorf("unexpected Docker API request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		writeDockerJSON(t, w, dockercontainer.InspectResponse{
+			NetworkSettings: &dockercontainer.NetworkSettings{
+				Networks: map[string]*dockernetwork.EndpointSettings{
+					"memoh-workspace": {IPAddress: "172.20.0.3"},
+				},
+			},
+		})
+	})
+
+	if got, want := svc.BridgeTarget("bot-1"), "workspace-bot-1:9090"; got != want {
+		t.Fatalf("BridgeTarget() = %q, want %q", got, want)
+	}
+}
+
+func TestSetupNetworkAttachesExistingWorkspace(t *testing.T) {
+	connected := false
+	svc := newTestService(t, "memoh-workspace", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/containers/workspace-bot-1/json"):
+			networks := map[string]*dockernetwork.EndpointSettings{
+				"bridge": {IPAddress: "172.17.0.2"},
+			}
+			if connected {
+				networks["memoh-workspace"] = &dockernetwork.EndpointSettings{IPAddress: "172.20.0.4"}
+			}
+			writeDockerJSON(t, w, dockercontainer.InspectResponse{
+				NetworkSettings: &dockercontainer.NetworkSettings{Networks: networks},
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/networks/memoh-workspace/connect"):
+			var request struct {
+				Container string `json:"Container"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode network connect request: %v", err)
+			}
+			if request.Container != "workspace-bot-1" {
+				t.Errorf("network connect container = %q, want workspace-bot-1", request.Container)
+			}
+			connected = true
+			writeDockerJSON(t, w, struct{}{})
+		default:
+			t.Errorf("unexpected Docker API request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := svc.SetupNetwork(context.Background(), containerapi.NetworkRequest{ContainerID: "workspace-bot-1"})
+	if err != nil {
+		t.Fatalf("SetupNetwork() error = %v", err)
+	}
+	if !connected {
+		t.Fatal("SetupNetwork() did not connect the existing workspace")
+	}
+	if result.IP != "172.20.0.4" {
+		t.Fatalf("SetupNetwork() IP = %q, want 172.20.0.4", result.IP)
+	}
+}
+
+func newTestService(t *testing.T, workspaceNetwork string, handler http.HandlerFunc) *Service {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	cli, err := dockerclient.NewClientWithOpts(
+		dockerclient.WithHost(server.URL),
+		dockerclient.WithVersion("1.49"),
+	)
+	if err != nil {
+		t.Fatalf("create Docker test client: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Close() })
+	return &Service{
+		client:           cli,
+		logger:           slog.New(slog.DiscardHandler),
+		workspaceNetwork: workspaceNetwork,
+	}
+}
+
+func writeDockerJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Errorf("encode Docker API response: %v", err)
 	}
 }

--- a/internal/container/docker/service_test.go
+++ b/internal/container/docker/service_test.go
@@ -178,6 +178,21 @@ func TestNewServiceRejectsDefaultDockerNetwork(t *testing.T) {
 	}
 }
 
+func TestNewServiceRejectsWorkspaceNetworkForHostServer(t *testing.T) {
+	if runningInContainer() {
+		t.Skip("test requires a host process")
+	}
+	_, err := NewService(slog.New(slog.DiscardHandler), config.Config{
+		Docker: config.DockerConfig{Network: "memoh-workspace"},
+	})
+	if err == nil {
+		t.Fatal("NewService() accepted Docker workspace networking from a host process")
+	}
+	if !strings.Contains(err.Error(), "host deployments use the loopback workspace bridge") {
+		t.Fatalf("NewService() error = %q, want host loopback guidance", err)
+	}
+}
+
 func TestCreateContainerUsesWorkspaceNetworkWithoutPublishingBridge(t *testing.T) {
 	var createRequest dockercontainer.CreateRequest
 	svc := newTestService(t, "memoh-workspace", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/container/docker/service_test.go
+++ b/internal/container/docker/service_test.go
@@ -165,7 +165,7 @@ func TestBridgeTargetPrefersPublishedHostPort(t *testing.T) {
 func TestNewServiceRejectsNonUserDefinedDockerNetwork(t *testing.T) {
 	for _, networkName := range []string{"bridge", "default", "host", "nat", "none", "container:server"} {
 		t.Run(networkName, func(t *testing.T) {
-			_, err := NewService(slog.New(slog.DiscardHandler), config.Config{
+			_, err := NewService(context.Background(), slog.New(slog.DiscardHandler), config.Config{
 				Docker: config.DockerConfig{Network: networkName},
 			})
 			if err == nil {
@@ -182,7 +182,7 @@ func TestNewServiceRejectsWorkspaceNetworkForHostServer(t *testing.T) {
 	if runningInContainer() {
 		t.Skip("test requires a host process")
 	}
-	_, err := NewService(slog.New(slog.DiscardHandler), config.Config{
+	_, err := NewService(context.Background(), slog.New(slog.DiscardHandler), config.Config{
 		Docker: config.DockerConfig{Network: "memoh-workspace"},
 	})
 	if err == nil {
@@ -195,11 +195,105 @@ func TestNewServiceRejectsWorkspaceNetworkForHostServer(t *testing.T) {
 
 func TestValidateWorkspaceNetworkRequiresStrictBridgeTLS(t *testing.T) {
 	const networkName = "memoh-workspace"
-	if err := validateWorkspaceNetwork(networkName, true, false); err == nil || !strings.Contains(err.Error(), `[bridge_tls].mode = "strict"`) {
+	if err := validateWorkspaceNetwork(networkName, "server-id", true, false); err == nil || !strings.Contains(err.Error(), `[bridge_tls].mode = "strict"`) {
 		t.Fatalf("validateWorkspaceNetwork() error = %v, want strict bridge TLS guidance", err)
 	}
-	if err := validateWorkspaceNetwork(networkName, true, true); err != nil {
+	if err := validateWorkspaceNetwork(networkName, "server-id", true, true); err != nil {
 		t.Fatalf("validateWorkspaceNetwork() with strict bridge TLS error = %v", err)
+	}
+}
+
+func TestValidateWorkspaceNetworkRequiresServerContainer(t *testing.T) {
+	err := validateWorkspaceNetwork("memoh-workspace", "", true, true)
+	if err == nil || !strings.Contains(err.Error(), "[docker].server_container") {
+		t.Fatalf("validateWorkspaceNetwork() error = %v, want server container guidance", err)
+	}
+}
+
+func TestValidateServerNetworkMembership(t *testing.T) {
+	const networkName = "memoh-workspace"
+	tests := []struct {
+		name        string
+		containerID string
+		networks    map[string]*dockernetwork.EndpointSettings
+		status      int
+		wantError   string
+		wantRuntime bool
+	}{
+		{
+			name:        "attached with explicit identity",
+			containerID: "server-id",
+			networks:    map[string]*dockernetwork.EndpointSettings{networkName: {}},
+			status:      http.StatusOK,
+		},
+		{
+			name:        "configured container is detached",
+			containerID: "server-id",
+			networks:    map[string]*dockernetwork.EndpointSettings{"bridge": {}},
+			status:      http.StatusOK,
+			wantError:   `server container "server-id" is not attached to Docker network "memoh-workspace"`,
+		},
+		{
+			name:        "configured container does not exist",
+			containerID: "missing-server-id",
+			status:      http.StatusNotFound,
+			wantError:   `server container "missing-server-id" does not exist on Docker daemon`,
+		},
+		{
+			name:        "daemon error",
+			containerID: "server-id",
+			status:      http.StatusInternalServerError,
+			wantError:   `inspect Memoh server container "server-id" on Docker daemon`,
+			wantRuntime: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc := newTestService(t, networkName, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/containers/"+test.containerID+"/json") {
+					t.Errorf("unexpected Docker API request: %s %s", r.Method, r.URL.Path)
+					http.NotFound(w, r)
+					return
+				}
+				if test.status != http.StatusOK {
+					http.Error(w, http.StatusText(test.status), test.status)
+					return
+				}
+				writeDockerJSON(t, w, dockercontainer.InspectResponse{
+					NetworkSettings: &dockercontainer.NetworkSettings{Networks: test.networks},
+				})
+			})
+
+			err := validateServerNetworkMembership(context.Background(), svc.client, test.containerID, networkName)
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateServerNetworkMembership() error = %v", err)
+				}
+				return
+			}
+			if !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("validateServerNetworkMembership() error = %v, want error containing %q", err, test.wantError)
+			}
+			if test.wantRuntime {
+				if !errors.Is(err, containerapi.ErrRuntime) {
+					t.Fatalf("validateServerNetworkMembership() error = %v, want ErrRuntime", err)
+				}
+			} else if !errors.Is(err, containerapi.ErrInvalidArgument) {
+				t.Fatalf("validateServerNetworkMembership() error = %v, want ErrInvalidArgument", err)
+			}
+		})
+	}
+}
+
+func TestValidateServerNetworkMembershipPreservesCancellation(t *testing.T) {
+	svc := newTestService(t, "memoh-workspace", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected Docker API request after cancellation: %s %s", r.Method, r.URL.Path)
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := validateServerNetworkMembership(ctx, svc.client, "server-id", "memoh-workspace")
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, containerapi.ErrRuntime) {
+		t.Fatalf("validateServerNetworkMembership() error = %v, want context.Canceled and ErrRuntime", err)
 	}
 }
 

--- a/internal/container/provider/provider.go
+++ b/internal/container/provider/provider.go
@@ -26,7 +26,7 @@ func ProvideService(ctx context.Context, log *slog.Logger, cfg config.Config, ba
 		cleanup := func() { _ = svc.Close() }
 		return svc, cleanup, nil
 	case containerapi.BackendDocker:
-		svc, err := dockeradapter.NewService(log, cfg)
+		svc, err := dockeradapter.NewService(ctx, log, cfg)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -51,6 +51,8 @@ export interface ContainerdConfig {
 
 export interface DockerConfig {
   host?: string;
+  network?: string;
+  server_container?: string;
 }
 
 export interface AppleConfig {


### PR DESCRIPTION
## Summary

- add `[docker].network` for a dedicated user-defined network shared by a containerized server and its workspace containers
- create new workspaces on that network, keep the bridge port internal, and dial the bridge through Docker DNS
- require strict bridge mTLS for shared-network routing so each workspace accepts its own authenticated bridge client
- identify the server with `[docker].server_container` and verify its network endpoint during bounded startup
- attach existing workspaces during network setup, detach them during network removal, and track endpoint membership independently from runtime IP readiness
- preserve loopback publication for host and host-network deployments

Closes #907

## Validation

- `go test ./internal/config ./internal/container/docker ./internal/container/provider ./cmd/internal/core`
- `go test -race ./internal/container/docker`
- `go vet ./internal/config ./internal/container/docker ./internal/container/provider ./cmd/internal/core`
- `mise exec -- go test -race -count=1 ./internal/config ./internal/container/docker ./internal/container/provider ./internal/network ./internal/workspace ./internal/workspace/bridge ./cmd/bridge`
- `mise exec -- go test ./...`
- `mise exec -- golangci-lint run ./internal/container/docker`
- `GOOS=windows GOARCH=amd64 mise exec -- go test -c ./internal/container/docker`
- live Docker adapter check: reject shared-network routing without strict bridge TLS; create a workspace on a user-defined network with empty host `PortBindings`; resolve `workspace-*:9090` through Docker DNS; detach, repeat removal idempotently, reattach, and reconnect

