### PR TITLE
fix(codex): honor custom provider base URLs

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -1049,6 +1049,9 @@ const overrideReasoningEffort = ref('')
 // Set once the user picks a model in this pane, so late-arriving defaults
 // (a subagent's pinned model, bot settings) never overwrite their choice.
 const userPickedModel = ref(false)
+// Session creation briefly changes several pieces of the direct-runtime
+// identity. That is one draft being promoted, not a switch to another chat.
+let directDraftPromotionPending = false
 const paneComposerScope = computed(() => {
   const botId = paneTarget.value.botId
   return botId ? `${botId}:${paneTarget.value.viewId}` : 'chat'
@@ -2258,11 +2261,13 @@ watch(currentBotId, () => {
 // a user picked belongs to the session they picked it in — clear the flag so the
 // next session's pinned model can still seed the composer.
 watch(() => paneTarget.value.sessionId, () => {
+  if (directDraftPromotionPending) return
   userPickedModel.value = false
 })
 
 watch(activeUsesExternalAgentComposer, (usesExternalAgent, previouslyUsedExternalAgent) => {
   if (usesExternalAgent === previouslyUsedExternalAgent) return
+  if (directDraftPromotionPending) return
   overrideModelId.value = ''
   overrideReasoningEffort.value = ''
   userPickedModel.value = false
@@ -2282,7 +2287,7 @@ const directSessionIdentity = computed(() => JSON.stringify([
   activeDirectRuntime.value,
 ]))
 watch(directSessionIdentity, (identity, previousIdentity) => {
-  if (!activeUsesDirectRuntime.value || identity === previousIdentity) return
+  if (!activeUsesDirectRuntime.value || identity === previousIdentity || directDraftPromotionPending) return
   overrideModelId.value = ''
   overrideReasoningEffort.value = ''
   userPickedModel.value = false
@@ -3255,6 +3260,7 @@ async function handleSend() {
   const sentModelId = overrideModelId.value
   const sentReasoningEffort = overrideReasoningEffort.value
   const sentWorkspaceTargetId = sendWorkspaceTargetId.value
+  const preserveDirectDraftSelection = activeUsesDirectRuntime.value && !sentContext.target.sessionId
   composerError.value = ''
   inputText.value = ''
   saveInputDraft(sentDraftKey, '')
@@ -3283,6 +3289,7 @@ async function handleSend() {
   // setup and is about to start a real turn. Command-only sends therefore do
   // not leave a latent pin behind; startup failures roll the arm back.
   let rollbackPin: (() => void) | null = null
+  directDraftPromotionPending = preserveDirectDraftSelection
   const result = await chatStore.sendMessage(text, attachments, {
     target: sentContext.target,
     modelId: sentModelId,
@@ -3291,6 +3298,9 @@ async function handleSend() {
     requestedSkills: skills,
     composerScope: sentContext.composerScope,
     onBeforeTurnAppend: () => {
+      if (preserveDirectDraftSelection) {
+        void nextTick(() => { directDraftPromotionPending = false })
+      }
       if (!matchesChatPaneSendContext(
         sentContext,
         paneTarget.value,
@@ -3302,6 +3312,8 @@ async function handleSend() {
       rollbackPin?.()
       rollbackPin = null
     },
+  }).finally(() => {
+    directDraftPromotionPending = false
   })
   rollbackPin = null
   await refreshACPComposerConfigAfterSelectionError(result)

--- a/internal/agent/runtime/codex/driver.go
+++ b/internal/agent/runtime/codex/driver.go
@@ -120,13 +120,16 @@ func (d *Driver) resolveAgentConfig(ctx context.Context, botID, botAgentID strin
 	return cfg, credential, nil
 }
 
-// ModelCatalog returns the live model vocabulary advertised by the bot's
-// pinned codex app-server. Authentication is checked first because ChatGPT
-// plans and API-key accounts may expose different catalogs.
+// ModelCatalog returns the models available to this Agent. API-key Agents with
+// an explicit Base URL use that provider's OpenAI-compatible /models endpoint;
+// ChatGPT and default-OpenAI Agents retain Codex's richer native catalog.
 func (d *Driver) ModelCatalog(ctx context.Context, botID, botAgentID string) (external.ModelCatalog, error) {
 	cfg, _, err := d.resolveAgentConfig(ctx, botID, botAgentID, true)
 	if err != nil {
 		return external.ModelCatalog{}, err
+	}
+	if cfg.Auth == AuthAPIKey && strings.TrimSpace(cfg.BaseURL) != "" {
+		return customBaseURLModelCatalog(ctx, cfg, nil)
 	}
 	srv, releaseServer, err := d.acquireServer(ctx, botID, botAgentID)
 	if err != nil {

--- a/internal/agent/runtime/codex/materialize.go
+++ b/internal/agent/runtime/codex/materialize.go
@@ -1,0 +1,51 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+const codexManagedConfigHeader = "# Managed by Memoh. Changes are overwritten when this Agent starts.\n"
+
+type codexConfigWriter interface {
+	WriteFile(ctx context.Context, path string, content []byte) error
+}
+
+type codexManagedConfig struct {
+	OpenAIBaseURL string `toml:"openai_base_url,omitempty"`
+}
+
+// materializeCodexConfig projects the database-owned Bot Agent configuration
+// into the user-level file Codex reads from CODEX_HOME. It always rewrites the
+// managed file, including an empty configuration, so clearing a Base URL or
+// switching to ChatGPT auth cannot leave a stale relay active.
+func materializeCodexConfig(ctx context.Context, writer codexConfigWriter, home string, cfg Config) error {
+	payload, err := renderCodexConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("render codex config: %w", err)
+	}
+	configPath := path.Join(home, "config.toml")
+	if err := writer.WriteFile(ctx, configPath, payload); err != nil {
+		return fmt.Errorf("write codex config %s: %w", configPath, err)
+	}
+	return nil
+}
+
+func renderCodexConfig(cfg Config) ([]byte, error) {
+	managed := codexManagedConfig{}
+	if cfg.Auth == AuthAPIKey {
+		managed.OpenAIBaseURL = strings.TrimSpace(cfg.BaseURL)
+	}
+
+	var payload bytes.Buffer
+	payload.WriteString(codexManagedConfigHeader)
+	if err := toml.NewEncoder(&payload).Encode(managed); err != nil {
+		return nil, err
+	}
+	return payload.Bytes(), nil
+}

--- a/internal/agent/runtime/codex/materialize_test.go
+++ b/internal/agent/runtime/codex/materialize_test.go
@@ -1,0 +1,71 @@
+package codex
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+type recordingCodexConfigWriter struct {
+	writes map[string][]byte
+}
+
+func (w *recordingCodexConfigWriter) WriteFile(_ context.Context, target string, content []byte) error {
+	if w.writes == nil {
+		w.writes = map[string][]byte{}
+	}
+	w.writes[target] = append([]byte(nil), content...)
+	return nil
+}
+
+func TestMaterializeCodexConfig(t *testing.T) {
+	t.Parallel()
+
+	writer := &recordingCodexConfigWriter{}
+	home := codexHome("agent")
+	baseURL := "https://relay.example/v1"
+	secret := "credential-must-not-be-materialized" //nolint:gosec // Test-only sentinel proves the value is excluded.
+	if err := materializeCodexConfig(context.Background(), writer, home, Config{
+		Auth:    AuthAPIKey,
+		APIKey:  secret,
+		BaseURL: baseURL,
+		Model:   "model-must-not-be-materialized",
+	}); err != nil {
+		t.Fatalf("materializeCodexConfig(): %v", err)
+	}
+
+	payload := writer.writes[home+"/config.toml"]
+	assertManagedCodexConfig(t, payload, baseURL)
+	if strings.Contains(string(payload), secret) || strings.Contains(string(payload), "model-must-not-be-materialized") {
+		t.Fatalf("managed config contains a credential or protocol-owned model: %q", payload)
+	}
+	if err := materializeCodexConfig(context.Background(), writer, home, Config{Auth: AuthChatGPT, BaseURL: "https://stale.example/v1"}); err != nil {
+		t.Fatalf("clear materialized config: %v", err)
+	}
+	assertManagedCodexConfig(t, writer.writes[home+"/config.toml"], "")
+
+	for _, entry := range codexAppServerEnv(home) {
+		if strings.HasPrefix(entry, "OPENAI_BASE_URL=") || strings.HasPrefix(entry, "OPENAI_API_KEY=") || strings.HasPrefix(entry, "MEMOH_CODEX_API_KEY=") {
+			t.Fatalf("Codex app-server environment leaks provider configuration or credentials: %q", entry)
+		}
+	}
+}
+
+func assertManagedCodexConfig(t *testing.T, payload []byte, wantBaseURL string) {
+	t.Helper()
+	if !strings.HasPrefix(string(payload), codexManagedConfigHeader) {
+		t.Fatalf("managed config header missing: %q", payload)
+	}
+	var decoded codexManagedConfig
+	if _, err := toml.Decode(string(payload), &decoded); err != nil {
+		t.Fatalf("decode managed config: %v", err)
+	}
+	if decoded.OpenAIBaseURL != wantBaseURL {
+		t.Fatalf("openai_base_url = %q, want %q", decoded.OpenAIBaseURL, wantBaseURL)
+	}
+	if wantBaseURL == "" && strings.Contains(string(payload), "openai_base_url") {
+		t.Fatalf("cleared managed config retained openai_base_url: %q", payload)
+	}
+}

--- a/internal/agent/runtime/codex/model_catalog.go
+++ b/internal/agent/runtime/codex/model_catalog.go
@@ -1,0 +1,59 @@
+package codex
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	openairesponses "github.com/felinics/twilight/provider/openai/responses"
+
+	"github.com/felinics/memoh/internal/agent/runtime/external"
+	modelspkg "github.com/felinics/memoh/internal/models"
+)
+
+// customBaseURLModelCatalog asks the configured OpenAI-compatible endpoint for
+// its actual model IDs. Codex's native model/list catalog describes OpenAI and
+// ChatGPT availability; it cannot represent a relay with a different catalog.
+func customBaseURLModelCatalog(ctx context.Context, cfg Config, httpClient *http.Client) (external.ModelCatalog, error) {
+	if httpClient == nil {
+		httpClient = modelspkg.NewProviderHTTPClient(modelspkg.DefaultProviderProbeTimeout)
+	}
+	provider := openairesponses.New(
+		openairesponses.WithAPIKey(cfg.APIKey),
+		openairesponses.WithBaseURL(strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")),
+		openairesponses.WithHTTPClient(httpClient),
+	)
+	available, err := provider.ListModels(ctx)
+	if err != nil {
+		return external.ModelCatalog{}, fmt.Errorf("list Codex models from custom Base URL: %w", err)
+	}
+
+	models := make([]external.ModelOption, 0, len(available))
+	seen := make(map[string]struct{}, len(available))
+	for _, model := range available {
+		id := strings.TrimSpace(model.ID)
+		if id == "" {
+			continue
+		}
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+		name := strings.TrimSpace(model.DisplayName)
+		if name == "" {
+			name = id
+		}
+		models = append(models, external.ModelOption{
+			ID:               id,
+			Name:             name,
+			ReasoningEfforts: []external.ReasoningEffortOption{},
+		})
+	}
+
+	return external.ModelCatalog{
+		Models:                    models,
+		ConfiguredModelID:         cfg.Model,
+		ConfiguredReasoningEffort: cfg.ReasoningEffort,
+	}, nil
+}

--- a/internal/agent/runtime/codex/model_catalog_test.go
+++ b/internal/agent/runtime/codex/model_catalog_test.go
@@ -1,0 +1,51 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCustomBaseURLModelCatalogUsesConfiguredEndpointAndCredential(t *testing.T) {
+	t.Parallel()
+
+	const credential = "credential-for-model-catalog-test" //nolint:gosec // Test server credential, never used externally.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Errorf("models request = %s %s, want GET /v1/models", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+credential {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"id": "deepseek-v4-flash", "object": "model"},
+				{"id": "deepseek-v4-pro", "object": "model"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	catalog, err := customBaseURLModelCatalog(context.Background(), Config{
+		Auth:            AuthAPIKey,
+		APIKey:          credential,
+		BaseURL:         server.URL + "/v1/",
+		Model:           "deepseek-v4-pro",
+		ReasoningEffort: "high",
+	}, server.Client())
+	if err != nil {
+		t.Fatalf("customBaseURLModelCatalog(): %v", err)
+	}
+	if catalog.ConfiguredModelID != "deepseek-v4-pro" || catalog.ConfiguredReasoningEffort != "high" {
+		t.Fatalf("configured catalog values = (%q, %q)", catalog.ConfiguredModelID, catalog.ConfiguredReasoningEffort)
+	}
+	if len(catalog.Models) != 2 || catalog.Models[0].ID != "deepseek-v4-flash" || catalog.Models[1].ID != "deepseek-v4-pro" {
+		t.Fatalf("models = %#v", catalog.Models)
+	}
+	if catalog.Models[0].Name != "deepseek-v4-flash" || catalog.Models[0].ReasoningEfforts == nil {
+		t.Fatalf("normalized model = %#v", catalog.Models[0])
+	}
+}

--- a/internal/agent/runtime/codex/process.go
+++ b/internal/agent/runtime/codex/process.go
@@ -21,13 +21,16 @@ func startAppServer(ctx context.Context, client *bridge.Client, workDir, home st
 	if err := client.Mkdir(ctx, home); err != nil {
 		return nil, fmt.Errorf("create codex home %s: %w", home, err)
 	}
-	env := []string{
+	if err := materializeCodexConfig(ctx, client, home, cfg); err != nil {
+		return nil, err
+	}
+	return agentprocess.Start(ctx, client, launcherPath+" app-server", workDir, codexAppServerEnv(home))
+}
+
+func codexAppServerEnv(home string) []string {
+	return []string{
 		"CODEX_HOME=" + home,
 		"PATH=" + containerPath,
 		"RUST_LOG=error",
 	}
-	if cfg.Auth == AuthAPIKey && cfg.BaseURL != "" {
-		env = append(env, "OPENAI_BASE_URL="+cfg.BaseURL)
-	}
-	return agentprocess.Start(ctx, client, launcherPath+" app-server", workDir, env)
 }


### PR DESCRIPTION
## 问题

Direct Codex Agent 使用 API Key 和自定义 Base URL 时，原来的实现只把地址放进 `OPENAI_BASE_URL` 环境变量。当前 Codex app-server 不会在这条路径上读取它，因此实际请求仍然发往 `api.openai.com`。

## 修改

- 启动 Codex app-server 前，把数据库中的 Base URL 写入该 Agent 独立的 `CODEX_HOME/config.toml`，使用 Codex 支持的顶层 `openai_base_url` 配置。
- API Key 继续由加密凭证库和 `auth.json` 管理；生成的 TOML 和进程环境不包含密钥或模型。
- API Key Agent 配置了自定义 Base URL 时，通过带认证的 `GET {base_url}/models` 获取实际可用模型；ChatGPT 和默认 OpenAI 仍使用 app-server 的 `model/list`。
- draft session 创建为正式 session 时保留用户选择的模型，避免第一条消息发送后模型选择回到 `Default`。

## 边界

- 没有新增 Memoh API、数据库迁移或 OpenAPI/SDK 变更。
- 对话、线程和工具调用仍然经过 Codex app-server；只有自定义 Provider 的模型发现直接调用 `/models`。
- 自定义 Provider 需要兼容 Responses API；只有实现 `/models` 时才能自动加载模型列表。
- ChatGPT 认证流程和默认 OpenAI 配置不受影响。

Fixes #1129

## 验证

- `go test ./...`
- `golangci-lint run ./internal/agent/runtime/codex/...`
- `pnpm exec eslint apps/web/src/pages/home/components/chat-pane.vue`
- `node scripts/check-ui-contract.mjs`
- 人工 QA：使用 DeepSeek 自定义 Base URL 获取模型列表，从列表选择模型后完成 Codex 对话；draft session 创建完成后，所选模型保持不变。