### PR TITLE
fix: 去掉 exec 工具行悬停时的整段命令 tooltip

### DIFF
--- a/apps/web/src/pages/home/components/composer-panel-approval.vue
+++ b/apps/web/src/pages/home/components/composer-panel-approval.vue
@@ -9,7 +9,7 @@
         <span
           v-if="displayTarget"
           class="min-w-0 truncate font-normal"
-          :title="display.fullTarget || display.target"
+          :title="display.fullTarget || undefined"
         >{{ displayTarget }}</span>
       </p>
 

--- a/apps/web/src/pages/home/components/tool-call-inline.vue
+++ b/apps/web/src/pages/home/components/tool-call-inline.vue
@@ -23,7 +23,7 @@
         v-if="display.target && canOpenInFiles"
         class="truncate min-w-0 hover:underline cursor-pointer"
         :class="targetClass"
-        :title="display.fullTarget || display.target"
+        :title="display.fullTarget || undefined"
         @click.stop="handleOpenInFiles"
       >
         {{ display.target }}
@@ -32,7 +32,7 @@
         v-else-if="display.target"
         class="truncate min-w-0"
         :class="targetClass"
-        :title="display.fullTarget || display.target"
+        :title="display.fullTarget || undefined"
       >{{ display.target }}</span>
       <span
         v-if="executionLocationLabel"
@@ -83,7 +83,7 @@
         v-if="display.target && canOpenInFiles"
         class="truncate min-w-0 hover:underline cursor-pointer"
         :class="targetClass"
-        :title="display.fullTarget || display.target"
+        :title="display.fullTarget || undefined"
         @click="handleOpenInFiles"
       >
         {{ display.target }}
@@ -92,7 +92,7 @@
         v-else-if="display.target"
         class="truncate min-w-0"
         :class="targetClass"
-        :title="display.fullTarget || display.target"
+        :title="display.fullTarget || undefined"
       >{{ display.target }}</span>
       <span
         v-if="executionLocationLabel"

--- a/apps/web/src/pages/home/components/tool-call-registry.ts
+++ b/apps/web/src/pages/home/components/tool-call-registry.ts
@@ -102,6 +102,11 @@ export interface ToolDisplay {
   actionKey: string
   actionParams?: Record<string, unknown>
   target: string
+  // Native `title` tooltip completing a truncated `target` — only for short,
+  // single-line values (full path, URL, query). Never a long or multi-line blob
+  // (a whole exec command, a message body): a native tooltip can't scroll or be
+  // copied, so such content renders as an unreadable wall; the expandable detail
+  // is the channel for full content. Consumers bind `title` only when this is set.
   fullTarget?: string
   detail?: Component
   isError?: boolean
@@ -726,8 +731,8 @@ function resolveToolDisplay(block: ToolCallBlock): ToolDisplay {
       return {
         icon: SquareTerminal,
         actionKey: background ? 'exec_background' : 'exec',
+        // No fullTarget: the full command lives in the exec detail, not a tooltip.
         target: firstLine(cmd, 80),
-        fullTarget: cmd,
         detail: ToolCallDetailExec,
       }
     }


### PR DESCRIPTION
## 问题

鼠标悬停在 exec 工具行（如「运行 N 条命令」里的单条命令）上约 1 秒，浏览器原生 `title` tooltip 会把**整条原始命令**原样弹出——多行 heredoc 脚本就是一堵不可滚动、不可复制、鼠标一动就消失的文本墙，盖住半个对话。

## 根因

`fullTarget` 机制本是为**文件路径**设计的：行内只显示 basename，悬停补全绝对路径——短、单行、且是不展开就看不到的信息。exec 复用了同一通道，把整条命令塞进去，而原生 tooltip 这个通道根本承载不了长文本。完整命令本来就有更好的出口：exec 展开详情（等宽、可滚动）和审批卡的 CodeBlock(bash 高亮）都已原样展示。

## 改动

- `tool-call-registry.ts`:exec 不再设置 `fullTarget`；并在字段定义处写明契约——只放短的单行补全（路径 / URL / query)，长文 / 多行内容一律走展开详情
- `tool-call-inline.vue` / `composer-panel-approval.vue`（共 5 处）:`title` 只在 `fullTarget` 存在时挂载，不再回退到行内已显示的 `target`（否则 exec 删掉 fullTarget 后，tooltip 会退化成把看得见的截断文本再弹一遍，纯噪音）

**保持不变**：文件路径、URL、搜索词等短文本的悬停补全照旧——那是该机制的设计场景。

## 明确没动

- send / message / prompt / task 等工具的 `fullTarget` 装的是用户长文本，属同一问题的轻症版，本次不动，是否一并去掉留待后续决定
- 路径本身不去掉：它是「命令在哪跑的」的真实信息，展开视图里命令必须保持原样可核对、可复制

## 验证

- eslint（三个改动文件）：通过
- `tool-call-registry` + `tool-call-group` 单测：12/12 通过
- pre-commit 钩子（golangci-lint + go test + lint-staged)：通过
- `vue-tsc` 全仓基线即为红（本 worktree 447 个错误、主仓 469 个，均在未触及的文件），我改的三个文件 0 错误——非本 PR 引入
- ❗ 渲染效果**未经实机验证**，按 web skill 约定留人工 QA

## Test plan

- [ ] 悬停 exec 行：不再出现整段命令 tooltip
- [ ] 悬停 read / write / list 行：仍显示完整路径
- [ ] exec 展开详情：仍显示完整命令
- [ ] exec 审批卡：CodeBlock 完整命令显示不受影响