### PR TITLE
fix(web): composer 弱网下 mic/send 按钮叠加——显隐状态移交 wrapper

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -783,92 +783,114 @@
                          The context-pressure ring itself is only shelved for
                          now, not deleted — its useSessionInfo data source
                          stays wired below (untouched) because the /compact
-                         quick action's live percentage still reads off it. -->
-                    <Button
-                      type="button"
-                      variant="primary"
-                      shape="circle"
-                      :disabled="voiceInputDisabled"
-                      :title="voiceInputLabel"
-                      :aria-label="voiceInputLabel"
-                      class="absolute inset-0 size-8 max-md:size-11 rounded-full transition-[opacity,scale] duration-200 ease-out motion-reduce:transition-none"
+                         quick action's live percentage still reads off it.
+
+                         Visibility (opacity / scale / pointer-events) lives on
+                         WRAPPER divs around each Button, never on the Button
+                         itself: the design system's disabled dimming is
+                         element-level opacity-40 (packages/ui AGENTS.md
+                         § Disabled), which outranks opacity-0/100 state classes
+                         in the cascade — so a disabled "hidden" button still
+                         painted at 0.4 and bled through its sibling (the mic
+                         ghost showed under the semi-transparent send while
+                         loadingMessages). Split onto two elements, the two
+                         opacity systems compound instead of fight: hidden
+                         stays hidden, while a VISIBLE disabled button still
+                         dims as designed. -->
+                    <div
+                      class="absolute inset-0 transition-[opacity,scale] duration-200 ease-out motion-reduce:transition-none"
                       :class="micVisible ? 'scale-100 opacity-100' : 'pointer-events-none scale-75 opacity-0'"
-                      @click="handleVoiceInput"
                     >
-                      <Spinner
-                        v-if="voiceInputState === 'transcribing'"
-                        class="size-4 max-md:size-5"
-                      />
-                      <svg
-                        v-else
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2.5"
-                        stroke-linecap="round"
-                        class="size-4.5 max-md:size-5"
-                        :class="voiceInputState === 'recording' ? 'motion-safe:animate-pulse' : undefined"
-                        aria-hidden="true"
+                      <Button
+                        type="button"
+                        variant="primary"
+                        shape="circle"
+                        :disabled="voiceInputDisabled"
+                        :title="voiceInputLabel"
+                        :aria-label="voiceInputLabel"
+                        class="size-full"
+                        @click="handleVoiceInput"
                       >
-                        <!-- Relaxed envelope: the center bar spans only 14 of
-                             the 24 viewBox units — the full-18 spike made the
-                             glyph read tense. Ends are vertical ovals
-                             (2.5 × 3.5 — a hair taller than pure circles), mids
-                             hold half the max (7). The 4.5-unit gaps are
-                             untouched: denser spacing smudges at this size. -->
-                        <path d="M3 11.5v1" />
-                        <path d="M7.5 8.5v7" />
-                        <path d="M12 5v14" />
-                        <path d="M16.5 8.5v7" />
-                        <path d="M21 11.5v1" />
-                      </svg>
-                    </Button>
+                        <Spinner
+                          v-if="voiceInputState === 'transcribing'"
+                          class="size-4 max-md:size-5"
+                        />
+                        <svg
+                          v-else
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2.5"
+                          stroke-linecap="round"
+                          class="size-4.5 max-md:size-5"
+                          :class="voiceInputState === 'recording' ? 'motion-safe:animate-pulse' : undefined"
+                          aria-hidden="true"
+                        >
+                          <!-- Relaxed envelope: the center bar spans only 14 of
+                               the 24 viewBox units — the full-18 spike made the
+                               glyph read tense. Ends are vertical ovals
+                               (2.5 × 3.5 — a hair taller than pure circles), mids
+                               hold half the max (7). The 4.5-unit gaps are
+                               untouched: denser spacing smudges at this size. -->
+                          <path d="M3 11.5v1" />
+                          <path d="M7.5 8.5v7" />
+                          <path d="M12 5v14" />
+                          <path d="M16.5 8.5v7" />
+                          <path d="M21 11.5v1" />
+                        </svg>
+                      </Button>
+                    </div>
                     <!-- Send and stop are one brand circle: the surface never
                          changes between the two states, only the glyph cross-fades
                          (arrow ⇄ stop square), so the button can't blink color or
                          shape mid-turn. While streaming it stays clickable to abort. -->
-                    <Button
-                      type="button"
-                      variant="brand"
-                      :disabled="streaming ? false : (!showSend || !currentBotId || activeChatReadOnly || loadingMessages || composerConfigPending || composerHasNoModel)"
-                      :aria-label="streaming ? 'Stop generating response' : 'Send message'"
-                      class="absolute inset-0 size-8 max-md:size-11 rounded-full transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none"
+                    <div
+                      class="absolute inset-0 transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.34,1.56,0.64,1)] motion-reduce:transition-none"
                       :class="sendButtonVisible ? 'scale-100 opacity-100' : 'pointer-events-none scale-0 opacity-0'"
-                      @click="streaming ? chatStore.abort(paneTarget) : handleSend()"
                     >
-                      <span
-                        class="grid size-[18px] max-md:size-5 shrink-0 place-items-center"
-                        aria-hidden="true"
+                      <Button
+                        type="button"
+                        variant="brand"
+                        shape="circle"
+                        :disabled="streaming ? false : (!showSend || !currentBotId || activeChatReadOnly || loadingMessages || composerConfigPending || composerHasNoModel)"
+                        :aria-label="streaming ? 'Stop generating response' : 'Send message'"
+                        class="size-full"
+                        @click="streaming ? chatStore.abort(paneTarget) : handleSend()"
                       >
-                        <svg
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2.75"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          class="col-start-1 row-start-1 size-[18px] max-md:size-5 transition-opacity duration-200 ease-out motion-reduce:transition-none"
-                          :class="streaming ? 'opacity-0' : 'opacity-100'"
+                        <span
+                          class="grid size-[18px] max-md:size-5 shrink-0 place-items-center"
+                          aria-hidden="true"
                         >
-                          <path d="M12 19.5 V5" />
-                          <path d="M6 10.5 L12 4.5 L18 10.5" />
-                        </svg>
-                        <svg
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                          class="col-start-1 row-start-1 size-4 max-md:size-4.5 transition-opacity duration-200 ease-out motion-reduce:transition-none"
-                          :class="streaming ? 'opacity-100' : 'opacity-0'"
-                        >
-                          <rect
-                            x="4"
-                            y="4"
-                            width="16"
-                            height="16"
-                            rx="3"
-                          />
-                        </svg>
-                      </span>
-                    </Button>
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2.75"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            class="col-start-1 row-start-1 size-[18px] max-md:size-5 transition-opacity duration-200 ease-out motion-reduce:transition-none"
+                            :class="streaming ? 'opacity-0' : 'opacity-100'"
+                          >
+                            <path d="M12 19.5 V5" />
+                            <path d="M6 10.5 L12 4.5 L18 10.5" />
+                          </svg>
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="currentColor"
+                            class="col-start-1 row-start-1 size-4 max-md:size-4.5 transition-opacity duration-200 ease-out motion-reduce:transition-none"
+                            :class="streaming ? 'opacity-100' : 'opacity-0'"
+                          >
+                            <rect
+                              x="4"
+                              y="4"
+                              width="16"
+                              height="16"
+                              rx="3"
+                            />
+                          </svg>
+                        </span>
+                      </Button>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## 问题

弱网（3G）下在 Welcome 页发出首条消息后、消息还没出现的窗口内，底部 composer 右下角会**同时看到 mic 与 send 两个圆形控件叠在一起**：send 按钮呈半透明，其下透出 75% 大小的近黑色 mic 圆（含波形 glyph）。streaming 开始（消息出现）后自行恢复。主题无关（黄/紫主题均复现）。

生产环境 app.memoh.net 实机复现确认，DOM computed style 采样证据见「验证」节。

## 根因

mic/send 共享 composer 右端同一个槽位，靠一对互斥显隐类交叉淡入：`micVisible = !sendButtonVisible`，隐藏方拿 `opacity-0`（mic 另带 `scale-75`，send 带 `scale-0`）。

但 `@felinic/ui` Button 基础类带 `disabled:opacity-40`（packages/ui AGENTS.md § Disabled 的明文契约：disabled 态一律 40% 透明度）与 `data-[loading]:opacity-100`。`:disabled` 伪类变体的级联优先级（0,2,0）**高于**显隐用的 `opacity-0`/`opacity-100`（0,1,0）——**按钮一旦 disabled，显隐类失效，透明度被钉在 0.4**。

弱网窗口内两个按钮恰好同时 disabled：

- **send**：输入框有被恢复的字符（见「为什么难复现」条件 2）→ 可见；`loadingMessages`（进 session 后的 history GET，弱网下秒级）→ disabled → 渲染成半透明 0.4；
- **mic**：本应是隐藏态（`opacity-0`），但 `voiceInputDisabled` 同样含 loadingMessages/streaming → disabled → 被钉在 0.4；且 mic 隐藏态是 `scale-75`（非零尺寸），于是从半透明 send 下面透出来。（send 隐藏态是 `scale-0` 零尺寸，反向情况因此侥幸不可见。）

DOM 顺序 mic 在前、send 在后（同槽 `absolute inset-0`，无 z-index，按文档序绘制）→ mic 垫在 send 下方。

## 为什么难复现

四个条件缺一不可：

1. **弱网**：`loadingMessages`（history GET）窗口要拉长到秒级；好网下只有几十毫秒，叠加态一闪而过；
2. **窗口内输入框有内容**：第二条消息在 session 创建 REST 进行中按 Enter，会被 `send.ts` 的 startup 守卫吞掉并**恢复输入**（该守卫返回 `{ok:false, stage:'startup'}` 无 error 字段，调用方当失败处理恢复输入，还会误弹「Message failed to send」——这是另一个独立 bug，不在本 PR 修）。有内容，send 才处于「可见 + disabled」；
3. mic 与 send **同时** disabled（loadingMessages / streaming 等状态重叠）；
4. **时机**：必须在 `run_accepted` 到达之前观察——streaming 一开始 send 恢复不透明，盖住 mic，叠加消失。

### 复现步骤

1. DevTools → Network → 3G 限速（建议自定义拉到 ~2000ms RTT，窗口更稳）；
2. 任意 bot → New Chat（Welcome 页）；
3. 输入一段文字（附图片更佳——上传进一步拉大窗口）→ Enter；
4. 立刻再输入任意字符 → 再 Enter（这次会被吞、输入被恢复、误弹失败条）；
5. 盯右下角：离开 Welcome 后、消息出现前的窗口内，send 半透明、mic 幽灵从其下透出。

## 修复

把显隐状态（opacity / scale / pointer-events / 交叉淡入 transition）从 Button 本体移到**外层 wrapper div**：显隐由页面侧 wrapper 持有，disabled 调光由设计系统在 Button 本体持有，两个 opacity 系统不再共享同一个元素——冲突在构造上消除，而不是用 `!important` 打赢它。`packages/ui` 零改动；「disabled = opacity-40」契约对**可见**按钮照常生效。

- 非 bug 态视觉零变化（四种组合逐一核对：可见+启用不变；可见+disabled 仍按设计 0.4；隐藏+启用不变；隐藏+disabled 现在真正不可见）；
- 顺带的显式化：send 的圆角原先只由被移除的 class 承载（mic 的圆角走 `shape="circle"` prop），改为 prop 表达，行为不变。

## 验证

- [x] 生产环境（app.memoh.net）ego-browser + CDP 限速实机复现，DOM computed style 采样：窗口内 mic（带 `opacity-0` 类）与 send（带 `opacity-100` 类）computed opacity 双双被钉在 0.4，稳定数秒
- [x] 修复版本地 dev 同流程复测：窗口内 mic wrapper opacity=0（彻底隐身）、send 单独 0.4 半透明；streaming 后恢复正常
- [x] 四个状态组合渲染核对（欢迎页空输入 / 输入中 / loadingMessages / streaming）
- [x] eslint 过
- [x] 人工 QA：本地 dev 3G 复现 → 叠加消失（@qqqqqf-q）
- [ ] CI

## 不在本 PR 范围（同一窗口发现的独立问题，待立项）

- **「Message failed to send」误报**：session 创建 REST 进行中的第二次 Enter 被守卫吞掉，但守卫返回无 error 字段，UI 误报发送失败并恢复输入（`send.ts:244-249` → `chat-pane.vue` startup 失败分支）；
- **双击双发窗口**：`creatingSession` 复位到 `run_accepted` 投影之间守卫全穿，此时 Enter 会真发出第二条消息；
- **设计系统层收口**：任何「条件 opacity 显隐类 + 可能 disabled / data-loading」的 Button 都会踩同一个级联陷阱（本 PR 只覆盖 composer 槽位；根治需把 disabled 调光挪下元素 opacity，例如 ::before 填充层或 filter，属设计系统决策）。
