### PR TITLE
fix(agent): mid-stream 重试循环化——重调再失败时继续退避重试

### DIFF
--- a/internal/agent/runtime/native/agent.go
+++ b/internal/agent/runtime/native/agent.go
@@ -1871,6 +1871,12 @@ func wrapPrepareStepWithForkSnapshot(
 // mid-stream error. It re-invokes StreamText with the accumulated messages
 // and drains the new stream into the same output channel.
 //
+// The retry loop keeps going while a re-invoked stream fails with another
+// retryable error: the SDK poisons an errored step without committing it, so
+// every attempt regenerates that step from the same committed boundary, and
+// stopping after the first retry would waste the progress later attempts could
+// still make (overloaded upstreams recover within seconds).
+//
 // sendCtx is used for sendEvent so consumer disconnect (parent ctx) still
 // controls channel back-pressure; streamCtx is passed to the SDK for the same
 // cancellation semantics as the main stream (including loop-detect cancel).
@@ -1904,10 +1910,29 @@ func (a *Agent) runMidStreamRetry(
 	// committed boundary, so it must not survive as a checkpoint. Retried
 	// steps are numbered from the offset the commit barrier already uses.
 	interruptedStep.rebase(stepOffset)
-	retryInput := retryProviderAttemptMessages(cfg, prevResult)
+	// lastAttempt stays the latest failed attempt's own (unmerged) result:
+	// providerAttemptState.retryInput indexes Steps by the call-local step
+	// index, so handing it a merged result would append the wrong step's tail.
+	lastAttempt := prevResult
+	retryInput := retryProviderAttemptMessages(cfg, lastAttempt)
 	accumulatedCount := len(prevResult.Messages)
+	// folded* accumulates the durable output of every attempt that failed
+	// retryably, so whichever way the loop exits (success, terminal error,
+	// budget exhaustion) the returned result preserves the full history.
+	foldedMessages := append([]sdk.Message(nil), prevResult.Messages...)
+	foldedSteps := append([]sdk.StepResult(nil), prevResult.Steps...)
+	// failResult returns the original result carrying everything committed so
+	// far; its drained stream is what the caller expects on an abort path.
+	failResult := func() *sdk.StreamResult {
+		prevResult.Messages = foldedMessages
+		prevResult.Steps = foldedSteps
+		return prevResult
+	}
 
-	retryCfg := DefaultRetryConfig()
+	retryCfg := cfg.Retry
+	if retryCfg.MaxAttempts <= 0 {
+		retryCfg = DefaultRetryConfig()
+	}
 	for attempt := 0; attempt < retryCfg.MaxAttempts; attempt++ {
 		a.logger.Warn("mid-stream error, retrying",
 			slog.Int("step", stepNumber),
@@ -1921,13 +1946,13 @@ func (a *Agent) runMidStreamRetry(
 			MaxAttempt: retryCfg.MaxAttempts,
 			RetryError: errMsg,
 		}) {
-			return prevResult, true
+			return failResult(), true
 		}
 
 		delay := retryDelay(attempt, retryCfg)
 		if delay > 0 {
 			if err := sleepWithContext(streamCtx, delay); err != nil {
-				return prevResult, true // aborted
+				return failResult(), true // aborted
 			}
 		}
 
@@ -1951,7 +1976,7 @@ func (a *Agent) runMidStreamRetry(
 			}))
 		}
 		if contextStepBudgetError(streamCtx) != nil {
-			return prevResult, true
+			return failResult(), true
 		}
 
 		retryResult, retryErr := a.client.StreamText(streamCtx, retryOpts...)
@@ -1967,6 +1992,7 @@ func (a *Agent) runMidStreamRetry(
 
 		// Drain the retry stream into the main event loop
 		aborted := false
+		retryableFailure := false
 		for retryPart := range retryResult.Stream {
 			if streamCtx.Err() != nil {
 				aborted = true
@@ -2065,53 +2091,84 @@ func (a *Agent) runMidStreamRetry(
 					aborted = true
 					break
 				}
-				errMsg := rp.Error.Error()
-				if isAskUserArgumentParseError(errMsg) {
+				partErrMsg := rp.Error.Error()
+				if isAskUserArgumentParseError(partErrMsg) {
 					continue
 				}
-				sendEvent(sendCtx, ch, StreamEvent{Type: EventError, Error: errMsg})
-				aborted = true
+				sendEvent(sendCtx, ch, StreamEvent{Type: EventError, Error: partErrMsg})
+				if isRetryableStreamError(rp.Error) {
+					// A retryable failure inside a retry must not end the run:
+					// fold what this attempt committed and take the next loop
+					// iteration instead of giving up after a single re-call.
+					errMsg = partErrMsg
+					retryableFailure = true
+				} else {
+					aborted = true
+				}
 			case *sdk.AbortPart:
 				aborted = true
 			case *sdk.FinishPart:
 				// handled after loop
 			}
-			if aborted {
+			if aborted || retryableFailure {
 				break
 			}
 		}
-		if aborted {
+		if aborted || retryableFailure {
 			for retryPart := range retryResult.Stream {
 				interruptedStep.observe(retryPart)
 			}
 		}
-		// Merge prev messages into retryResult so the caller sees the full
-		// accumulated history (initial run + retry continuation). The SDK's
+		if retryableFailure && !aborted {
+			// Fold this attempt's durable output and go again. The errored step
+			// was poisoned by the SDK without committing, so folded output never
+			// contains the partial tail the next attempt will regenerate.
+			foldedMessages = append(foldedMessages, retryResult.Messages...)
+			foldedSteps = append(foldedSteps, retryResult.Steps...)
+			stepOffset += len(retryResult.Steps)
+			accumulatedCount += len(retryResult.Messages)
+			lastAttempt = retryResult
+			interruptedStep.rebase(stepOffset)
+			if input, ok := cfg.providerAttemptState.retryInput(lastAttempt); ok {
+				retryInput = input
+			} else {
+				// Without a stored provider attempt (tests, defensive paths),
+				// rebuild from the folded history so earlier attempts' committed
+				// work still reaches the next call.
+				retryInput = retryProviderAttemptMessages(cfg, &sdk.StreamResult{
+					Messages: foldedMessages,
+					Steps:    foldedSteps,
+				})
+			}
+			continue
+		}
+		// Merge the folded history into retryResult so the caller sees the full
+		// accumulated history (initial run + every retry continuation). The SDK's
 		// StreamResult.Messages only contains messages produced within that
 		// StreamText call, so without this merge the original steps before
 		// the mid-stream error would be lost when the retry result becomes
 		// the new streamResult.
-		if len(prevResult.Messages) > 0 {
-			merged := make([]sdk.Message, 0, len(prevResult.Messages)+len(retryResult.Messages))
-			merged = append(merged, prevResult.Messages...)
+		if len(foldedMessages) > 0 {
+			merged := make([]sdk.Message, 0, len(foldedMessages)+len(retryResult.Messages))
+			merged = append(merged, foldedMessages...)
 			merged = append(merged, retryResult.Messages...)
 			retryResult.Messages = merged
 		}
-		if len(prevResult.Steps) > 0 {
-			retryResult.Steps = append(append([]sdk.StepResult(nil), prevResult.Steps...), retryResult.Steps...)
+		if len(foldedSteps) > 0 {
+			retryResult.Steps = append(append([]sdk.StepResult(nil), foldedSteps...), retryResult.Steps...)
 		}
 		return retryResult, aborted || detectGenerateLoopAbort(streamCtx, streamCtx.Err()) != nil
 	}
-	// All retry attempts failed to even start a new stream — return the
-	// previous (already drained) result so its accumulated messages are
-	// preserved as the final partial state. Publish the giving-up error: every
-	// EventRetry retracts the failure it retried, so without this last event a
-	// consumer would see the run end with nothing to explain why it stopped.
+	// All retry attempts failed — return the original result carrying every
+	// attempt's committed output so its accumulated messages are preserved as
+	// the final partial state. Publish the giving-up error: every EventRetry
+	// retracts the failure it retried, so without this last event a consumer
+	// would see the run end with nothing to explain why it stopped.
 	sendEvent(sendCtx, ch, StreamEvent{
 		Type:  EventError,
 		Error: fmt.Sprintf("mid-stream retry: all %d attempts failed (last: %s)", retryCfg.MaxAttempts, errMsg),
 	})
-	return prevResult, true
+	return failResult(), true
 }
 
 func prepareMidStreamRetryConfig(cfg RunConfig, accumulated []sdk.Message, errMsg string) RunConfig {

--- a/internal/agent/runtime/native/mid_stream_retry_loop_test.go
+++ b/internal/agent/runtime/native/mid_stream_retry_loop_test.go
@@ -1,0 +1,451 @@
+package native
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdk "github.com/felinics/twilight/sdk"
+	"github.com/google/jsonschema-go/jsonschema"
+
+	contextfrag "github.com/felinics/memoh/internal/agent/context/fragment"
+)
+
+// streamScript builds a DoStream implementation that plays back one scripted
+// stream per provider invocation; invocations beyond the script replay the
+// last entry (useful for "fails forever" scenarios).
+func streamScript(invocations *atomic.Int32, scripts ...func(chan<- sdk.StreamPart)) func(context.Context, sdk.GenerateParams) (*sdk.StreamResult, error) {
+	return func(_ context.Context, _ sdk.GenerateParams) (*sdk.StreamResult, error) {
+		idx := int(invocations.Add(1)) - 1
+		ch := make(chan sdk.StreamPart, 16)
+		go func() {
+			defer close(ch)
+			script := scripts[len(scripts)-1]
+			if idx < len(scripts) {
+				script = scripts[idx]
+			}
+			script(ch)
+		}()
+		return &sdk.StreamResult{Stream: ch}, nil
+	}
+}
+
+func scriptText(text string) func(chan<- sdk.StreamPart) {
+	return func(ch chan<- sdk.StreamPart) {
+		ch <- &sdk.StartPart{}
+		ch <- &sdk.StartStepPart{}
+		ch <- &sdk.TextStartPart{ID: "mock"}
+		ch <- &sdk.TextDeltaPart{ID: "mock", Text: text}
+		ch <- &sdk.TextEndPart{ID: "mock"}
+		ch <- &sdk.FinishStepPart{FinishReason: sdk.FinishReasonStop}
+		ch <- &sdk.FinishPart{FinishReason: sdk.FinishReasonStop}
+	}
+}
+
+// scriptStreamError fails the step mid-stream: any partial text is poisoned by
+// the SDK (never committed), mirroring how a real provider 429 surfaces.
+func scriptStreamError(partialText, errMsg string) func(chan<- sdk.StreamPart) {
+	return func(ch chan<- sdk.StreamPart) {
+		ch <- &sdk.StartPart{}
+		ch <- &sdk.StartStepPart{}
+		if partialText != "" {
+			ch <- &sdk.TextStartPart{ID: "mock"}
+			ch <- &sdk.TextDeltaPart{ID: "mock", Text: partialText}
+		}
+		ch <- &sdk.ErrorPart{Error: errors.New(errMsg)}
+	}
+}
+
+func scriptToolCall(callID, toolName string) func(chan<- sdk.StreamPart) {
+	return func(ch chan<- sdk.StreamPart) {
+		ch <- &sdk.StartPart{}
+		ch <- &sdk.StartStepPart{}
+		ch <- &sdk.StreamToolCallPart{ToolCallID: callID, ToolName: toolName, Input: map[string]any{"q": "fold"}}
+		ch <- &sdk.FinishStepPart{FinishReason: sdk.FinishReasonToolCalls}
+		ch <- &sdk.FinishPart{FinishReason: sdk.FinishReasonToolCalls}
+	}
+}
+
+func drainStreamEvents(ch <-chan StreamEvent) []StreamEvent {
+	var events []StreamEvent
+	for {
+		select {
+		case ev := <-ch:
+			events = append(events, ev)
+		default:
+			return events
+		}
+	}
+}
+
+func countEventType(events []StreamEvent, eventType StreamEventType) int {
+	count := 0
+	for _, ev := range events {
+		if ev.Type == eventType {
+			count++
+		}
+	}
+	return count
+}
+
+// countToolResultText counts tool-result parts whose payload mentions text:
+// results live in ToolResultPart.Result (any), not in TextPart, so text
+// counters miss them. Counting parts (not substring occurrences) keeps the
+// assertion about duplication, not payload size.
+func countToolResultText(messages []sdk.Message, text string) int {
+	count := 0
+	for _, msg := range messages {
+		if msg.Role != sdk.MessageRoleTool {
+			continue
+		}
+		for _, part := range msg.Content {
+			result, ok := part.(sdk.ToolResultPart)
+			if !ok {
+				continue
+			}
+			if value, ok := result.Result.(string); ok && strings.Contains(value, text) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func retryLoopTestConfig(provider *atomicMockProvider, retry RetryConfig) RunConfig {
+	return captureProviderAttemptPrefix(RunConfig{
+		Model:            &sdk.Model{ID: "mock-model", Provider: provider},
+		Messages:         []sdk.Message{sdk.UserMessage("original task")},
+		Identity:         SessionContext{BotID: "bot-1"},
+		ContextMutations: contextfrag.NewMutationLedger(),
+		Retry:            retry,
+	})
+}
+
+// fastRetry keeps tests instant: every attempt fires with no backoff delay.
+var fastRetry = RetryConfig{MaxAttempts: 5, FastAttempts: 5, BaseDelay: time.Millisecond, MaxDelay: time.Millisecond}
+
+// TestRunMidStreamRetryLoopsOnRetryableStreamError is the regression test for
+// the single-attempt cap: a retryable in-stream error during the retry itself
+// must fold and take the next attempt instead of aborting the run.
+func TestRunMidStreamRetryLoopsOnRetryableStreamError(t *testing.T) {
+	t.Parallel()
+
+	var invocations atomic.Int32
+	var captured []sdk.GenerateParams
+	provider := &atomicMockProvider{}
+	provider.stream = func(ctx context.Context, params sdk.GenerateParams) (*sdk.StreamResult, error) {
+		captured = append(captured, cloneGenerateParams(params))
+		return streamScript(&invocations,
+			scriptStreamError("partial-", "api error 429: engine overloaded"),
+			scriptText("recovered"),
+		)(ctx, params)
+	}
+	cfg := retryLoopTestConfig(provider, fastRetry)
+	streamCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	installContextStepFailureHandler(&cfg, cancel)
+
+	ch := make(chan StreamEvent, 256)
+	result, aborted := New(Deps{}).runMidStreamRetry(
+		context.Background(), streamCtx, cancel, newToolAbortRegistry(), ch,
+		cfg, nil, nil, nil,
+		&sdk.StreamResult{}, &stepMessageCapture{}, nil,
+		&interruptedStepCapture{}, 0, "api error 429: initial failure",
+		&strings.Builder{}, nil,
+	)
+	events := drainStreamEvents(ch)
+
+	if aborted {
+		t.Fatal("runMidStreamRetry() aborted, want recovery on the second attempt")
+	}
+	if got := int(invocations.Load()); got != 2 {
+		t.Fatalf("provider invocations = %d, want 2 (failed attempt plus recovery)", got)
+	}
+	if got := countEventType(events, EventRetry); got != 2 {
+		t.Fatalf("EventRetry count = %d, want 2", got)
+	}
+	if got := countEventType(events, EventError); got != 1 {
+		t.Fatalf("EventError count = %d, want the retry stream's single 429", got)
+	}
+	if len(captured) != 2 {
+		t.Fatalf("captured provider params = %d, want 2", len(captured))
+	}
+	// The poisoned partial text must not leak into the next attempt's input.
+	if countRound8MessageText(captured[1].Messages, "partial-") != 0 {
+		t.Fatalf("second attempt input contains poisoned partial output: %#v", captured[1].Messages)
+	}
+	if len(captured[1].Messages) != len(captured[0].Messages) {
+		t.Fatalf("second attempt input length = %d, want same committed boundary as first (%d)",
+			len(captured[1].Messages), len(captured[0].Messages))
+	}
+	if result == nil || countRound8MessageText(result.Messages, "recovered") != 1 {
+		t.Fatalf("final result = %#v, want the recovered assistant message", result)
+	}
+}
+
+// TestRunMidStreamRetryExhaustsAttemptsOnPersistent429 pins the terminal
+// behavior: the loop must stop at MaxAttempts, publish the giving-up error,
+// and preserve everything committed along the way.
+func TestRunMidStreamRetryExhaustsAttemptsOnPersistent429(t *testing.T) {
+	t.Parallel()
+
+	var invocations atomic.Int32
+	provider := &atomicMockProvider{}
+	provider.stream = streamScript(&invocations,
+		scriptStreamError("", "api error 429: engine overloaded"),
+	)
+	cfg := retryLoopTestConfig(provider, RetryConfig{MaxAttempts: 3, FastAttempts: 3, BaseDelay: time.Millisecond, MaxDelay: time.Millisecond})
+	streamCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	installContextStepFailureHandler(&cfg, cancel)
+
+	prevResult := &sdk.StreamResult{Messages: []sdk.Message{sdk.AssistantMessage("committed before the failure")}}
+	ch := make(chan StreamEvent, 256)
+	result, aborted := New(Deps{}).runMidStreamRetry(
+		context.Background(), streamCtx, cancel, newToolAbortRegistry(), ch,
+		cfg, nil, nil, nil,
+		prevResult, &stepMessageCapture{}, nil,
+		&interruptedStepCapture{}, 0, "api error 429: initial failure",
+		&strings.Builder{}, nil,
+	)
+	events := drainStreamEvents(ch)
+
+	if !aborted {
+		t.Fatal("runMidStreamRetry() did not abort after exhausting attempts")
+	}
+	if got := int(invocations.Load()); got != 3 {
+		t.Fatalf("provider invocations = %d, want MaxAttempts 3", got)
+	}
+	if got := countEventType(events, EventRetry); got != 3 {
+		t.Fatalf("EventRetry count = %d, want 3", got)
+	}
+	last := events[len(events)-1]
+	if last.Type != EventError || !strings.Contains(last.Error, "all 3 attempts failed") {
+		t.Fatalf("terminal event = %#v, want the giving-up error", last)
+	}
+	if result == nil || countRound8MessageText(result.Messages, "committed before the failure") != 1 {
+		t.Fatalf("final result = %#v, want previously committed messages preserved", result)
+	}
+}
+
+// TestRunMidStreamRetryStopsOnNonRetryableStreamError pins that a non-retryable
+// error inside the retry stream stays terminal: no extra attempts, no loop.
+func TestRunMidStreamRetryStopsOnNonRetryableStreamError(t *testing.T) {
+	t.Parallel()
+
+	var invocations atomic.Int32
+	provider := &atomicMockProvider{}
+	provider.stream = streamScript(&invocations,
+		scriptStreamError("", "api error 400: bad request"),
+	)
+	cfg := retryLoopTestConfig(provider, fastRetry)
+	streamCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	installContextStepFailureHandler(&cfg, cancel)
+
+	ch := make(chan StreamEvent, 256)
+	_, aborted := New(Deps{}).runMidStreamRetry(
+		context.Background(), streamCtx, cancel, newToolAbortRegistry(), ch,
+		cfg, nil, nil, nil,
+		&sdk.StreamResult{}, &stepMessageCapture{}, nil,
+		&interruptedStepCapture{}, 0, "api error 429: initial failure",
+		&strings.Builder{}, nil,
+	)
+	events := drainStreamEvents(ch)
+
+	if !aborted {
+		t.Fatal("runMidStreamRetry() did not abort on a non-retryable error")
+	}
+	if got := int(invocations.Load()); got != 1 {
+		t.Fatalf("provider invocations = %d, want exactly 1 (no looping on 400)", got)
+	}
+	if got := countEventType(events, EventRetry); got != 1 {
+		t.Fatalf("EventRetry count = %d, want 1 (only the attempt that ran)", got)
+	}
+}
+
+// TestRunMidStreamRetryFoldsCommittedStepIntoNextAttempt drives the deepest
+// invariant: attempt one commits a tool step and then fails retryably, so
+// attempt two must resume from a boundary that includes that committed step,
+// must commit at the next global index, and must not see the poisoned partial.
+func TestRunMidStreamRetryFoldsCommittedStepIntoNextAttempt(t *testing.T) {
+	t.Parallel()
+
+	var invocations atomic.Int32
+	provider := &atomicMockProvider{}
+	provider.stream = streamScript(&invocations,
+		scriptToolCall("fold-call-1", "lookup"),
+		scriptStreamError("fold-partial", "api error 429: engine overloaded"),
+		scriptText("recovered"),
+	)
+	cfg := retryLoopTestConfig(provider, fastRetry)
+	cfg.SupportsToolCall = true
+	streamCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	installContextStepFailureHandler(&cfg, cancel)
+
+	tools := []sdk.Tool{{
+		Name:       "lookup",
+		Parameters: &jsonschema.Schema{Type: "object"},
+		Execute: func(_ *sdk.ToolExecContext, _ any) (any, error) {
+			return "fold-tool-result", nil
+		},
+	}}
+	var committed []int
+	onStepCommitted := func(_ context.Context, stepIndex int, _ *sdk.StepResult) error {
+		committed = append(committed, stepIndex)
+		return nil
+	}
+
+	ch := make(chan StreamEvent, 256)
+	result, aborted := New(Deps{}).runMidStreamRetry(
+		context.Background(), streamCtx, cancel, newToolAbortRegistry(), ch,
+		cfg, tools, nil, nil,
+		&sdk.StreamResult{}, &stepMessageCapture{}, onStepCommitted,
+		&interruptedStepCapture{}, 0, "api error 429: initial failure",
+		&strings.Builder{}, nil,
+	)
+	events := drainStreamEvents(ch)
+
+	if aborted {
+		t.Fatal("runMidStreamRetry() aborted, want recovery after folding the committed step")
+	}
+	if got := int(invocations.Load()); got != 3 {
+		t.Fatalf("provider invocations = %d, want 3 (tool step, failed step, recovery)", got)
+	}
+	if len(committed) != 2 || committed[0] != 0 || committed[1] != 1 {
+		t.Fatalf("committed step indices = %#v, want [0 1] (folded offset, no collision)", committed)
+	}
+	if result == nil {
+		t.Fatal("runMidStreamRetry() result is nil")
+	}
+	if got := countToolResultText(result.Messages, "fold-tool-result"); got != 1 {
+		t.Fatalf("tool result occurrences in final messages = %d, want exactly 1 (folded, not duplicated)", got)
+	}
+	if got := countRound8MessageText(result.Messages, "fold-partial"); got != 0 {
+		t.Fatalf("poisoned partial output leaked into final messages %d times", got)
+	}
+	if got := countRound8MessageText(result.Messages, "recovered"); got != 1 {
+		t.Fatalf("recovered text occurrences in final messages = %d, want 1", got)
+	}
+	if got := countEventType(events, EventRetry); got != 2 {
+		t.Fatalf("EventRetry count = %d, want 2", got)
+	}
+}
+
+// TestRunMidStreamRetryBackoffHonorsContextCancel pins that the backoff sleep
+// between attempts stays interruptible instead of pinning the run.
+func TestRunMidStreamRetryBackoffHonorsContextCancel(t *testing.T) {
+	t.Parallel()
+
+	var invocations atomic.Int32
+	provider := &atomicMockProvider{}
+	provider.stream = streamScript(&invocations,
+		scriptStreamError("", "api error 429: engine overloaded"),
+	)
+	cfg := retryLoopTestConfig(provider, RetryConfig{MaxAttempts: 5, FastAttempts: 1, BaseDelay: time.Hour, MaxDelay: time.Hour})
+	streamCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+	installContextStepFailureHandler(&cfg, cancel)
+
+	type outcome struct{ aborted bool }
+	done := make(chan outcome, 1)
+	go func() {
+		ch := make(chan StreamEvent, 256)
+		_, aborted := New(Deps{}).runMidStreamRetry(
+			context.Background(), streamCtx, cancel, newToolAbortRegistry(), ch,
+			cfg, nil, nil, nil,
+			&sdk.StreamResult{}, &stepMessageCapture{}, nil,
+			&interruptedStepCapture{}, 0, "api error 429: initial failure",
+			&strings.Builder{}, nil,
+		)
+		done <- outcome{aborted: aborted}
+	}()
+
+	for invocations.Load() < 1 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel(context.Canceled)
+
+	select {
+	case got := <-done:
+		if !got.aborted {
+			t.Fatal("runMidStreamRetry() did not abort after cancel during backoff")
+		}
+		if got := int(invocations.Load()); got != 1 {
+			t.Fatalf("provider invocations = %d, want 1 (cancelled before the second attempt)", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runMidStreamRetry() stuck in backoff after context cancel")
+	}
+}
+
+// TestAgentStreamMidStreamRetryChainRecovers drives the full Stream path:
+// initial step commits a tool call, the next provider call 429s, the first
+// retry 429s again, and only the second retry succeeds — a run the old
+// single-attempt loop would have aborted.
+func TestAgentStreamMidStreamRetryChainRecovers(t *testing.T) {
+	t.Parallel()
+
+	var callParams []sdk.GenerateParams
+	provider := &atomicMockProvider{
+		handler: func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+			callParams = append(callParams, cloneGenerateParams(params))
+			switch call {
+			case 1:
+				return &sdk.GenerateResult{
+					FinishReason: sdk.FinishReasonToolCalls,
+					ToolCalls: []sdk.ToolCall{{
+						ToolCallID: "chain-call-1",
+						ToolName:   "lookup",
+						Input:      map[string]any{"query": "one"},
+					}},
+				}, nil
+			case 2, 3:
+				return nil, errors.New("api error 429: engine overloaded")
+			default:
+				return &sdk.GenerateResult{Text: "ok", FinishReason: sdk.FinishReasonStop}, nil
+			}
+		},
+	}
+	a := New(Deps{})
+	a.SetToolProviders(mockToolLoopTools())
+
+	var events []StreamEvent
+	for ev := range a.Stream(context.Background(), RunConfig{
+		Model:            &sdk.Model{ID: "mock-model", Provider: provider},
+		Messages:         []sdk.Message{sdk.UserMessage("task")},
+		SupportsToolCall: true,
+		Identity:         SessionContext{BotID: "bot-1"},
+		ContextMutations: contextfrag.NewMutationLedger(),
+		Retry:            fastRetry,
+	}) {
+		events = append(events, ev)
+	}
+
+	if got := int(provider.calls.Load()); got != 4 {
+		t.Fatalf("provider calls = %d, want 4 (tool step, two 429s, recovery)", got)
+	}
+	if got := countEventType(events, EventRetry); got != 2 {
+		t.Fatalf("EventRetry count = %d, want 2", got)
+	}
+	if got := countEventType(events, EventAgentAbort); got != 0 {
+		t.Fatalf("run aborted with %d abort events, want a clean EventAgentEnd", got)
+	}
+	if got := countEventType(events, EventAgentEnd); got != 1 {
+		t.Fatalf("EventAgentEnd count = %d, want 1", got)
+	}
+	if len(callParams) != 4 {
+		t.Fatalf("captured provider params = %d, want 4", len(callParams))
+	}
+	// Both retry attempts resume from the boundary that already contains the
+	// committed tool step, exactly once (no duplication, no partial leak).
+	for _, idx := range []int{2, 3} {
+		if got := countToolResultText(callParams[idx].Messages, "large tool result"); got != 1 {
+			t.Fatalf("provider call %d tool result occurrences = %d, want 1", idx+1, got)
+		}
+	}
+}

--- a/internal/agent/runtime/native/retry.go
+++ b/internal/agent/runtime/native/retry.go
@@ -89,8 +89,15 @@ func retryDelay(attempt int, cfg RetryConfig) time.Duration {
 	}
 	delay := cfg.BaseDelay * time.Duration(1<<backoffIdx)
 	delay = min(delay, cfg.MaxDelay)
-	// Add jitter: random value in [0, delay/2), so final delay is in [delay/2, delay).
+	// Int64N panics on a non-positive argument, so a config that leaves the
+	// delay fields at (near-)zero values must never reach it. "No delay
+	// configured" means the same as a fast attempt: fire immediately.
+	half := delay / 2
+	if half <= 0 {
+		return 0
+	}
+	// Add jitter: random value in [0, half), so final delay is in [half, delay).
 	// math/rand is intentional here — cryptographic randomness is not needed for backoff jitter.
-	jitter := time.Duration(rand.Int64N(int64(delay / 2))) //nolint:gosec // G404: jitter does not need crypto/rand
-	return delay/2 + jitter
+	jitter := time.Duration(rand.Int64N(int64(half))) //nolint:gosec // G404: jitter does not need crypto/rand
+	return half + jitter
 }

--- a/internal/agent/runtime/native/retry.go
+++ b/internal/agent/runtime/native/retry.go
@@ -28,14 +28,17 @@ var errEOFPattern = regexp.MustCompile(`(?i)connection (reset|refused)|EOF$`)
 // serverErrPattern matches "api error 5XX" where XX is any two digits.
 var serverErrPattern = regexp.MustCompile(`api error 5\d{2}`)
 
-// DefaultRetryConfig returns the default retry strategy: 10 attempts total,
-// first 5 fast (no delay), last 5 with exponential backoff.
+// DefaultRetryConfig returns the default retry strategy: 5 attempts total.
+// Only the first retry fires immediately — it absorbs network blips and
+// instant upstream rejections. Later attempts back off 1s→8s with jitter, so
+// a sustained overload window (typically tens of seconds) is ridden out
+// without hammering the upstream with a burst of immediate retries.
 func DefaultRetryConfig() RetryConfig {
 	return RetryConfig{
-		MaxAttempts:  10,
-		FastAttempts: 5,
+		MaxAttempts:  5,
+		FastAttempts: 1,
 		BaseDelay:    1 * time.Second,
-		MaxDelay:     30 * time.Second,
+		MaxDelay:     8 * time.Second,
 	}
 }
 

--- a/internal/agent/runtime/native/retry_test.go
+++ b/internal/agent/runtime/native/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestRetryableStreamErrorSeparatesProviderStatusFromApplicationTimeout(t *testing.T) {
@@ -28,5 +29,21 @@ func TestRetryableStreamErrorSeparatesProviderStatusFromApplicationTimeout(t *te
 				t.Fatalf("isRetryableStreamError(%q) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestRetryDelayToleratesUnsetDelayFields pins the misconfiguration guard:
+// callers may set only MaxAttempts (leaving the delay fields at their zero
+// values), and retryDelay must fire immediately instead of panicking inside
+// rand.Int64N on a non-positive argument.
+func TestRetryDelayToleratesUnsetDelayFields(t *testing.T) {
+	t.Parallel()
+
+	if got := retryDelay(2, RetryConfig{MaxAttempts: 3}); got != 0 {
+		t.Fatalf("retryDelay(2, delays unset) = %v, want 0", got)
+	}
+	nano := RetryConfig{MaxAttempts: 3, BaseDelay: time.Nanosecond, MaxDelay: time.Nanosecond}
+	if got := retryDelay(2, nano); got != 0 {
+		t.Fatalf("retryDelay(2, 1ns delays) = %v, want 0 (delay/2 == 0 must not reach Int64N)", got)
 	}
 }


### PR DESCRIPTION
## 问题

线上日志对账（某用户一下午多次「模型响应意外中断」）发现：agent 的 mid-stream 重试机制存在，但**每次事故实际只重调一次**。

- 平台 4 天保留期内所有 `mid-stream error, retrying` 日志永远是 `attempt=1`，从未出现第二次尝试；
- `stream start failed, retrying` 同期 0 次——SDK（twilight）的 `DoStream` 总是立即返回流对象、在后台 goroutine 里发上游请求，传输错误/429/5xx 一律以流内 `ErrorPart` 投递，`StreamText` 从不同步报错，stream-start 重试循环生产不可达；
- 结果是：过载窗口（实测几十秒级）里，唯一的立即重调打在同一个饱和上游的同一秒，约半数概率双败，用户直接看到回合失败红条。

## 根因

`runMidStreamRetry` 的循环只有一个能进入下一轮的分支：重调**连流都开不起来**（`continue`)。而重调流内再出错（生产上唯一发生的失败形态）走的是「标记中止 + return」——配置的 10 次退避因此不可达。

## 改动（两个 commit，可分开取舍）

**commit 1：循环修复（`agent.go`)**
- 重调流内收到可重试错误（429/5xx/网络错误/EOF）时：折入本轮已提交的进度、推进全局步序号偏移、从最新已提交边界重建输入，进入下一轮；
- 不可重试错误（400/鉴权类）保持立即终态，不会被循环误放大；
- 不变量：被上游毒化的半截步骤不提交、不进下一轮输入、不在最终结果里重复（SDK 对出错步骤不落 envelope，测试已钉死）;
- 顺带把 `cfg.Retry` 接进 mid-stream 路径——此前该路径无视配置恒用 `DefaultRetryConfig()`，与 stream-start 循环行为不一致；现在两者一致（无配置时仍回落默认值）。

**commit 2：节奏调整（`retry.go`)**
- 原默认「前 5 次全部无延迟」在上游过载时等于同一瞬间放大 5 倍压力，循环修复后会变成真实的瞬时连打；
- 新默认：第 1 次立即（吸收网络抖动/瞬拒），之后 1s/2s/4s/8s 退避带抖动，总窗口约 20 秒；`MaxAttempts` 10→5。平台不做客户端式的极长退避，但帮用户扛过几十秒级的过载窗口是必要的。

## 为什么不动 SDK 和 relay

- SDK 的 eager 开流是统一消费模型的合理设计；且即使 SDK 改成同步报错，流中途失败仍会以流内错误到达，mid-stream 路径无论如何都要修——修这里一处即覆盖全部场景；
- relay 的 failover 式重试对单渠道模型无效，其「同渠道退避重发」是独立的后续工作（连同 relay 成功路径不落 stop_reason 等可观测性缺口），不在本 PR。

## 测试

新增 `mid_stream_retry_loop_test.go`，直接驱动 `runMidStreamRetry` + 一个 `a.Stream` 端到端：

- 重调第 1 轮流内 429 → 第 2 轮成功恢复（旧代码在此场景必死）;
- 持续 429 → 恰好在 MaxAttempts 次后终态，发「all N attempts failed"，已提交内容保留；
- 流内 400 → 立即终态，不多试；
- 第 1 轮先提交一个工具步骤再失败 → 第 2 轮输入包含该步骤、不含毒化半截，提交序号无碰撞（[0,1])，最终消息无重复；
- 退避期间取消 → 立即中止；
- 端到端：工具步骤 → 429 → 429 → 恢复，验证两次重试的输入都从已提交边界重建。

自检：`go build ./...`、`go vet`、`gofmt`、`golangci-lint run internal/agent/runtime/native/`、`go test ./internal/agent/...` 全绿。

## 遗留事项

- 云上部署走 Memoh-Cloud 的 `packages/memoh` submodule pin，合并后需要单独升级 pin;
- 后续候选（本次未做，待单独评估）:429 按上游 body type 细分（engine_overloaded 重试 / quota 不重试）、relay 同渠道退避重发、流截断（`ended before finish-step`）纳入可重试分类。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.