### PR TITLE
fix(desktop): 隐藏 Windows 单按 Alt 唤出的菜单栏

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -497,7 +497,8 @@ function createChatWindow(): BrowserWindow {
     ...rememberedWindowOptions('chat', CHAT_DEFAULTS),
     ...macWindowChromeOptions(process.platform, 'memoh-chat'),
     show: false,
-    autoHideMenuBar: true,
+    // Electron's auto-hide mode lets a single Alt press reveal the menu.
+    autoHideMenuBar: process.platform !== 'win32',
     title: DESKTOP_PRODUCT_NAME,
     icon: iconPng,
     webPreferences: {
@@ -507,6 +508,7 @@ function createChatWindow(): BrowserWindow {
       nodeIntegration: false,
     },
   })
+  if (process.platform === 'win32') window.setMenuBarVisibility(false)
   attachWindowStatePersistence(window, 'chat', CHAT_DEFAULTS)
 
   window.once('ready-to-show', () => {
@@ -618,6 +620,13 @@ async function rebuildAppMenu(): Promise<void> {
   )
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+  // Keep native accelerators registered while hiding the Windows menu bar,
+  // including after renderer shortcut changes rebuild the application menu.
+  if (process.platform === 'win32') {
+    for (const window of BrowserWindow.getAllWindows()) {
+      window.setMenuBarVisibility(false)
+    }
+  }
 }
 
 app.whenReady().then(async () => {


### PR DESCRIPTION
Windows Desktop 使用 `autoHideMenuBar: true`，单按 Alt 会唤出 Edit / View / Window 菜单栏。此次修复关闭 Windows 的菜单自动显隐，并在窗口创建和应用菜单重建后隐藏菜单栏，使单按 Alt 时界面保持原样。

保留原生菜单及其快捷键注册，覆盖用户修改快捷键后重建菜单的路径；macOS 和 Linux 保持原有行为。

验证：
- 相关 Desktop 单元测试：3 个文件、6 项通过，覆盖窗口配置与快捷键分发。
- Desktop 主进程 TypeScript 检查、修改文件 ESLint、`git diff --check` 通过。
- 本机为 macOS，未执行 Windows 构建或实机按键验证。以上检查不能替代 Windows 验收；待验证单按 Alt、复制/粘贴/关闭标签页快捷键、修改快捷键后及从托盘恢复后的菜单隐藏状态。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
