### PR TITLE
fix(channel): 修复问答与审批续跑后的输出丢失

### DIFF
--- a/internal/agent/application/decision_output_test.go
+++ b/internal/agent/application/decision_output_test.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/felinics/memoh/internal/agent/runtime/native"
@@ -72,5 +73,35 @@ func TestContinuationPublishesTextAndNextQuestionToChannel(t *testing.T) {
 				t.Fatal("channel stream did not close")
 			}
 		})
+	}
+}
+
+type failedEndCheckpointBackend struct{ sessionruntime.Backend }
+
+func (b failedEndCheckpointBackend) Update(ctx context.Context, key sessionruntime.Key, update sessionruntime.SnapshotUpdate) (sessionruntime.Snapshot, bool, error) {
+	return b.Backend.Update(ctx, key, func(s sessionruntime.Snapshot, exists bool) (sessionruntime.Snapshot, bool, error) {
+		next, changed, err := update(s, exists)
+		if err == nil && next.DecisionOutput != nil && next.DecisionOutput.Done {
+			return s, false, errors.New("checkpoint write unavailable")
+		}
+		return next, changed, err
+	})
+}
+
+func TestContinuationClosesRunWhenEndCheckpointCannotPersist(t *testing.T) {
+	backend := failedEndCheckpointBackend{sessionruntime.NewMemoryBackend()}
+	manager, handle := newWaitingDecisionRuntime(t, backend)
+	service := &Service{decisionRuntime: manager}
+	service.continueRuntimeDecision(context.Background(), sessionruntime.Command{ID: "answer", BotID: handle.BotID, SessionID: handle.SessionID, RunID: handle.RunID, Generation: handle.Generation}, func(_ context.Context, _ *continuationLifecycleResult, ch chan<- WSStreamEvent) error {
+		ch <- runtimeDecisionEvent(t, native.StreamEvent{Type: native.EventUserInputRequest, UserInputID: "next", Status: "pending"})
+		ch <- runtimeDecisionEvent(t, native.StreamEvent{Type: native.EventAgentEnd, UserInputID: "next", Status: "pending"})
+		return nil
+	})
+	snapshot, err := manager.Snapshot(context.Background(), handle.BotID, handle.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.CurrentRunView != nil && snapshot.CurrentRunView.Status != sessionruntime.RunStatusErrored {
+		t.Fatalf("failed end write left run parked: %+v", snapshot.CurrentRunView)
 	}
 }

--- a/internal/agent/application/decision_output_test.go
+++ b/internal/agent/application/decision_output_test.go
@@ -1,0 +1,61 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/felinics/memoh/internal/agent/runtime/native"
+	sessionruntime "github.com/felinics/memoh/internal/agent/runtime/session"
+)
+
+type decisionOutputBackend struct {
+	sessionruntime.Backend
+	output []sessionruntime.Event
+}
+
+func (b *decisionOutputBackend) Publish(ctx context.Context, event sessionruntime.Event) error {
+	if len(event.Output) > 0 || event.Type == "decision_output_end" {
+		b.output = append(b.output, event)
+	}
+	return b.Backend.Publish(ctx, event)
+}
+
+func TestContinuationPublishesTextAndNextQuestionToChannel(t *testing.T) {
+	for _, nextQuestion := range []bool{false, true} {
+		t.Run(map[bool]string{false: "ordinary reply", true: "second question"}[nextQuestion], func(t *testing.T) {
+			backend := &decisionOutputBackend{Backend: sessionruntime.NewMemoryBackend()}
+			manager, handle := newWaitingDecisionRuntime(t, backend)
+			service := &Service{decisionRuntime: manager}
+			events := []native.StreamEvent{{Type: native.EventAgentStart}, {Type: native.EventTextDelta, Delta: "收到你的答案"}}
+			terminal := native.StreamEvent{Type: native.EventAgentEnd}
+			if nextQuestion {
+				events = append(events, native.StreamEvent{Type: native.EventUserInputRequest, UserInputID: "next-question", Status: "pending"})
+				terminal.UserInputID = "next-question"
+				terminal.Status = "pending"
+			}
+			events = append(events, terminal)
+			service.continueRuntimeDecision(context.Background(), sessionruntime.Command{ID: "answer-command", BotID: handle.BotID, SessionID: handle.SessionID, RunID: handle.RunID, Generation: handle.Generation}, func(_ context.Context, _ *continuationLifecycleResult, ch chan<- WSStreamEvent) error {
+				for _, event := range events {
+					ch <- runtimeDecisionEvent(t, event)
+				}
+				return nil
+			})
+			if len(backend.output) != len(events)+1 {
+				t.Fatalf("channel output count=%d, want %d", len(backend.output), len(events)+1)
+			}
+			for i, want := range events {
+				var got native.StreamEvent
+				if err := json.Unmarshal(backend.output[i].Output, &got); err != nil {
+					t.Fatal(err)
+				}
+				if got.Type != want.Type || got.Delta != want.Delta || got.UserInputID != want.UserInputID {
+					t.Fatalf("event %d=%+v want %+v", i, got, want)
+				}
+			}
+			if backend.output[len(events)].Type != "decision_output_end" {
+				t.Fatal("channel stream did not close")
+			}
+		})
+	}
+}

--- a/internal/agent/application/decision_output_test.go
+++ b/internal/agent/application/decision_output_test.go
@@ -11,12 +11,27 @@ import (
 
 type decisionOutputBackend struct {
 	sessionruntime.Backend
-	output []sessionruntime.Event
+	output []struct {
+		Type   string
+		Output json.RawMessage
+	}
 }
 
 func (b *decisionOutputBackend) Publish(ctx context.Context, event sessionruntime.Event) error {
-	if len(event.Output) > 0 || event.Type == "decision_output_end" {
-		b.output = append(b.output, event)
+	if event.Delta != nil && event.Delta.DecisionOutput != nil {
+		checkpoint := event.Delta.DecisionOutput
+		for _, raw := range checkpoint.Events {
+			b.output = append(b.output, struct {
+				Type   string
+				Output json.RawMessage
+			}{Output: raw})
+		}
+		if checkpoint.Done {
+			b.output = append(b.output, struct {
+				Type   string
+				Output json.RawMessage
+			}{Type: "decision_output_end"})
+		}
 	}
 	return b.Backend.Publish(ctx, event)
 }

--- a/internal/agent/application/decision_output_test.go
+++ b/internal/agent/application/decision_output_test.go
@@ -18,23 +18,19 @@ type decisionOutputBackend struct {
 	}
 }
 
-func (b *decisionOutputBackend) Publish(ctx context.Context, event sessionruntime.Event) error {
-	if event.Delta != nil && event.Delta.DecisionOutput != nil {
-		checkpoint := event.Delta.DecisionOutput
-		for _, raw := range checkpoint.Events {
-			b.output = append(b.output, struct {
-				Type   string
-				Output json.RawMessage
-			}{Output: raw})
+func (b *decisionOutputBackend) AppendDecisionOutput(ctx context.Context, ref sessionruntime.DecisionOutputRef, seq int64, payload json.RawMessage, limits sessionruntime.DecisionOutputLimits) (sessionruntime.DecisionOutputState, error) {
+	state, err := b.Backend.AppendDecisionOutput(ctx, ref, seq, payload, limits)
+	if err == nil && state.Applied {
+		entry := struct {
+			Type   string
+			Output json.RawMessage
+		}{Output: payload}
+		if payload == nil {
+			entry.Type = "decision_output_end"
 		}
-		if checkpoint.Done {
-			b.output = append(b.output, struct {
-				Type   string
-				Output json.RawMessage
-			}{Type: "decision_output_end"})
-		}
+		b.output = append(b.output, entry)
 	}
-	return b.Backend.Publish(ctx, event)
+	return state, err
 }
 
 func TestContinuationPublishesTextAndNextQuestionToChannel(t *testing.T) {
@@ -78,14 +74,11 @@ func TestContinuationPublishesTextAndNextQuestionToChannel(t *testing.T) {
 
 type failedEndCheckpointBackend struct{ sessionruntime.Backend }
 
-func (b failedEndCheckpointBackend) Update(ctx context.Context, key sessionruntime.Key, update sessionruntime.SnapshotUpdate) (sessionruntime.Snapshot, bool, error) {
-	return b.Backend.Update(ctx, key, func(s sessionruntime.Snapshot, exists bool) (sessionruntime.Snapshot, bool, error) {
-		next, changed, err := update(s, exists)
-		if err == nil && next.DecisionOutput != nil && next.DecisionOutput.Done {
-			return s, false, errors.New("checkpoint write unavailable")
-		}
-		return next, changed, err
-	})
+func (b failedEndCheckpointBackend) AppendDecisionOutput(ctx context.Context, ref sessionruntime.DecisionOutputRef, seq int64, payload json.RawMessage, limits sessionruntime.DecisionOutputLimits) (sessionruntime.DecisionOutputState, error) {
+	if payload == nil {
+		return sessionruntime.DecisionOutputState{}, errors.New("checkpoint write unavailable")
+	}
+	return b.Backend.AppendDecisionOutput(ctx, ref, seq, payload, limits)
 }
 
 func TestContinuationClosesRunWhenEndCheckpointCannotPersist(t *testing.T) {

--- a/internal/agent/application/decision_output_test.go
+++ b/internal/agent/application/decision_output_test.go
@@ -51,7 +51,7 @@ func TestContinuationPublishesTextAndNextQuestionToChannel(t *testing.T) {
 				terminal.Status = "pending"
 			}
 			events = append(events, terminal)
-			service.continueRuntimeDecision(context.Background(), sessionruntime.Command{ID: "answer-command", BotID: handle.BotID, SessionID: handle.SessionID, RunID: handle.RunID, Generation: handle.Generation}, func(_ context.Context, _ *continuationLifecycleResult, ch chan<- WSStreamEvent) error {
+			service.continueRuntimeDecision(context.Background(), sessionruntime.Command{StreamOutput: true, ID: "answer-command", BotID: handle.BotID, SessionID: handle.SessionID, RunID: handle.RunID, Generation: handle.Generation}, func(_ context.Context, _ *continuationLifecycleResult, ch chan<- WSStreamEvent) error {
 				for _, event := range events {
 					ch <- runtimeDecisionEvent(t, event)
 				}
@@ -92,7 +92,7 @@ func TestContinuationClosesRunWhenEndCheckpointCannotPersist(t *testing.T) {
 	backend := failedEndCheckpointBackend{sessionruntime.NewMemoryBackend()}
 	manager, handle := newWaitingDecisionRuntime(t, backend)
 	service := &Service{decisionRuntime: manager}
-	service.continueRuntimeDecision(context.Background(), sessionruntime.Command{ID: "answer", BotID: handle.BotID, SessionID: handle.SessionID, RunID: handle.RunID, Generation: handle.Generation}, func(_ context.Context, _ *continuationLifecycleResult, ch chan<- WSStreamEvent) error {
+	service.continueRuntimeDecision(context.Background(), sessionruntime.Command{StreamOutput: true, ID: "answer", BotID: handle.BotID, SessionID: handle.SessionID, RunID: handle.RunID, Generation: handle.Generation}, func(_ context.Context, _ *continuationLifecycleResult, ch chan<- WSStreamEvent) error {
 		ch <- runtimeDecisionEvent(t, native.StreamEvent{Type: native.EventUserInputRequest, UserInputID: "next", Status: "pending"})
 		ch <- runtimeDecisionEvent(t, native.StreamEvent{Type: native.EventAgentEnd, UserInputID: "next", Status: "pending"})
 		return nil

--- a/internal/agent/application/decision_output_web_test.go
+++ b/internal/agent/application/decision_output_web_test.go
@@ -1,0 +1,34 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/felinics/memoh/internal/agent/runtime/native"
+	sessionruntime "github.com/felinics/memoh/internal/agent/runtime/session"
+)
+
+func TestWebContinuationDoesNotCreateChannelCheckpoint(t *testing.T) {
+	backend := sessionruntime.NewMemoryBackend()
+	manager, handle := newWaitingDecisionRuntime(t, backend)
+	service := &Service{decisionRuntime: manager}
+	cmd := sessionruntime.Command{ID: "web-answer", BotID: handle.BotID, SessionID: handle.SessionID, RunID: handle.RunID, Generation: handle.Generation}
+	// Web calls RouteDecisionResponse directly; it never opens StreamDecisionResponse.
+	service.continueRuntimeDecision(context.Background(), cmd, func(_ context.Context, _ *continuationLifecycleResult, ch chan<- WSStreamEvent) error {
+		for _, e := range []native.StreamEvent{{Type: native.EventAgentStart}, {Type: native.EventTextDelta, Delta: "web reply"}, {Type: native.EventAgentEnd}} {
+			ch <- runtimeDecisionEvent(t, e)
+		}
+		return nil
+	})
+	s, exists, err := backend.Load(context.Background(), sessionruntime.Key{BotID: handle.BotID, SessionID: "decision-output/" + cmd.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, err := manager.Snapshot(context.Background(), handle.BotID, handle.SessionID)
+	if err != nil || live.CurrentRunView == nil || live.CurrentRunView.Status != sessionruntime.RunStatusCompleted {
+		t.Fatalf("web continuation did not finish: %+v, %v", live.CurrentRunView, err)
+	}
+	if exists && s.DecisionOutput != nil {
+		t.Fatalf("Web-only continuation retained %d channel events without a channel subscription", len(s.DecisionOutput.Events))
+	}
+}

--- a/internal/agent/application/decision_output_web_test.go
+++ b/internal/agent/application/decision_output_web_test.go
@@ -20,7 +20,7 @@ func TestWebContinuationDoesNotCreateChannelCheckpoint(t *testing.T) {
 		}
 		return nil
 	})
-	s, exists, err := backend.Load(context.Background(), sessionruntime.Key{BotID: handle.BotID, SessionID: "decision-output/" + cmd.ID})
+	page, err := backend.ReadDecisionOutput(context.Background(), sessionruntime.DecisionOutputRef{BotID: handle.BotID, CommandID: cmd.ID}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestWebContinuationDoesNotCreateChannelCheckpoint(t *testing.T) {
 	if err != nil || live.CurrentRunView == nil || live.CurrentRunView.Status != sessionruntime.RunStatusCompleted {
 		t.Fatalf("web continuation did not finish: %+v, %v", live.CurrentRunView, err)
 	}
-	if exists && s.DecisionOutput != nil {
-		t.Fatalf("Web-only continuation retained %d channel events without a channel subscription", len(s.DecisionOutput.Events))
+	if page.Exists {
+		t.Fatalf("Web-only continuation retained %d channel events without a channel subscription", page.Length)
 	}
 }

--- a/internal/agent/application/runtime_decision.go
+++ b/internal/agent/application/runtime_decision.go
@@ -373,6 +373,12 @@ func (s *Service) continueRuntimeDecision(
 	command sessionruntime.Command,
 	continueRun func(context.Context, *continuationLifecycleResult, chan<- WSStreamEvent) error,
 ) {
+	handle := sessionruntime.RunHandle{
+		BotID:      command.BotID,
+		SessionID:  command.SessionID,
+		RunID:      command.RunID,
+		Generation: command.Generation,
+	}
 	var outputSeq int64
 	var outputCause error
 	defer func() {
@@ -381,16 +387,16 @@ func (s *Service) continueRuntimeDecision(
 			outputSeq++
 			_ = s.decisionRuntime.PublishDecisionOutput(context.WithoutCancel(ctx), command, outputSeq, raw)
 		}
-		if err := s.decisionRuntime.PublishDecisionOutput(context.WithoutCancel(ctx), command, outputSeq+1, nil); err != nil && s.logger != nil {
-			s.logger.Warn("close decision output failed", slog.Any("error", err))
+		if err := s.decisionRuntime.PublishDecisionOutput(context.WithoutCancel(ctx), command, outputSeq+1, nil); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("close decision output failed", slog.Any("error", err))
+			}
+			// A failed checkpoint write must not leave a parked run owning an output
+			// subscription that can never finish. Use the normal run failure lifecycle.
+			s.finishRuntimeDecision(context.WithoutCancel(ctx), handle, err)
 		}
 	}()
-	handle := sessionruntime.RunHandle{
-		BotID:      command.BotID,
-		SessionID:  command.SessionID,
-		RunID:      command.RunID,
-		Generation: command.Generation,
-	}
+
 	if err := s.decisionRuntime.WaitDecisionContinuationReady(ctx, command); err != nil {
 		outputCause = err
 		s.recoverContextLifecycleFromAssistantMetadata(ctx, command.RunID, command.BotID, command.SessionID, err)
@@ -413,6 +419,11 @@ func (s *Service) continueRuntimeDecision(
 		lifecycleDeferred bool
 	)
 	for raw := range eventCh {
+		// Cancellation may leave already-buffered events. Drain them so the runner
+		// can return and finish through the same lifecycle as other stream failures.
+		if publishErr != nil {
+			continue
+		}
 		var event native.StreamEvent
 		if err := json.Unmarshal(raw, &event); err != nil {
 			continue
@@ -436,11 +447,12 @@ func (s *Service) continueRuntimeDecision(
 		if _, err := s.decisionRuntime.HandleAgentEvent(runCtx, handle, event); err != nil {
 			publishErr = err
 			cancel()
-			break
+			continue
 		}
 		outputSeq++
-		if err := s.decisionRuntime.PublishDecisionOutput(runCtx, command, outputSeq, raw); err != nil && s.logger != nil {
-			s.logger.Warn("publish decision output failed", slog.Any("error", err))
+		if err := s.decisionRuntime.PublishDecisionOutput(runCtx, command, outputSeq, raw); err != nil {
+			publishErr = err
+			cancel()
 		}
 	}
 	runErr := <-runDone

--- a/internal/agent/application/runtime_decision.go
+++ b/internal/agent/application/runtime_decision.go
@@ -166,6 +166,18 @@ func (s *Service) routeToolApprovalResponse(ctx context.Context, input ToolAppro
 		return false, nil
 	}
 	if err != nil {
+		if result.Applied && eventCh != nil {
+			if s.logger != nil {
+				s.logger.Warn("accepted decision output interrupted", slog.Any("error", err))
+			}
+			raw, _ := json.Marshal(agentFailureStreamEvent(err))
+			select {
+			case eventCh <- raw:
+				return true, nil
+			case <-ctx.Done():
+				return true, ctx.Err()
+			}
+		}
 		return true, err
 	}
 	if !result.Handled {
@@ -197,6 +209,18 @@ func (s *Service) routeUserInputResponse(ctx context.Context, input UserInputRes
 		return false, nil
 	}
 	if err != nil {
+		if result.Applied && eventCh != nil {
+			if s.logger != nil {
+				s.logger.Warn("accepted decision output interrupted", slog.Any("error", err))
+			}
+			raw, _ := json.Marshal(agentFailureStreamEvent(err))
+			select {
+			case eventCh <- raw:
+				return true, nil
+			case <-ctx.Done():
+				return true, ctx.Err()
+			}
+		}
 		return true, err
 	}
 	if !result.Handled {

--- a/internal/agent/application/runtime_decision.go
+++ b/internal/agent/application/runtime_decision.go
@@ -146,7 +146,7 @@ func pgText(value pgtype.Text) string {
 	return value.String
 }
 
-func (s *Service) routeToolApprovalResponse(ctx context.Context, input ToolApprovalResponseInput) (bool, error) {
+func (s *Service) routeToolApprovalResponse(ctx context.Context, input ToolApprovalResponseInput, eventCh chan<- WSStreamEvent) (bool, error) {
 	if s == nil || s.decisionRuntime == nil {
 		return false, nil
 	}
@@ -157,11 +157,11 @@ func (s *Service) routeToolApprovalResponse(ctx context.Context, input ToolAppro
 	if err != nil {
 		return true, err
 	}
-	result, err := s.decisionRuntime.RouteDecisionResponse(ctx, sessionruntime.DecisionResponse{
+	result, err := s.decisionRuntime.StreamDecisionResponse(ctx, sessionruntime.DecisionResponse{
 		ControlID: input.ControlID, Type: sessionruntime.CommandToolApprovalResponse,
 		DecisionID: firstNonEmpty(input.ExplicitID, input.ApprovalID),
 		BotID:      input.BotID, SessionID: input.ThreadID, Payload: payload,
-	})
+	}, eventCh)
 	if errors.Is(err, sessionruntime.ErrDecisionNotFound) {
 		return false, nil
 	}
@@ -177,7 +177,7 @@ func (s *Service) routeToolApprovalResponse(ctx context.Context, input ToolAppro
 	return true, nil
 }
 
-func (s *Service) routeUserInputResponse(ctx context.Context, input UserInputResponseInput) (bool, error) {
+func (s *Service) routeUserInputResponse(ctx context.Context, input UserInputResponseInput, eventCh chan<- WSStreamEvent) (bool, error) {
 	if s == nil || s.decisionRuntime == nil {
 		return false, nil
 	}
@@ -188,11 +188,11 @@ func (s *Service) routeUserInputResponse(ctx context.Context, input UserInputRes
 	if err != nil {
 		return true, err
 	}
-	result, err := s.decisionRuntime.RouteDecisionResponse(ctx, sessionruntime.DecisionResponse{
+	result, err := s.decisionRuntime.StreamDecisionResponse(ctx, sessionruntime.DecisionResponse{
 		ControlID: input.ControlID, Type: sessionruntime.CommandUserInputResponse,
 		DecisionID: firstNonEmpty(input.ExplicitID, input.UserInputID),
 		BotID:      input.BotID, SessionID: input.ThreadID, Payload: payload,
-	})
+	}, eventCh)
 	if errors.Is(err, sessionruntime.ErrDecisionNotFound) {
 		return false, nil
 	}
@@ -349,6 +349,18 @@ func (s *Service) continueRuntimeDecision(
 	command sessionruntime.Command,
 	continueRun func(context.Context, *continuationLifecycleResult, chan<- WSStreamEvent) error,
 ) {
+	var outputSeq int64
+	var outputCause error
+	defer func() {
+		if outputCause != nil {
+			raw, _ := json.Marshal(agentFailureStreamEvent(outputCause))
+			outputSeq++
+			_ = s.decisionRuntime.PublishDecisionOutput(context.WithoutCancel(ctx), command, outputSeq, raw)
+		}
+		if err := s.decisionRuntime.PublishDecisionOutput(context.WithoutCancel(ctx), command, outputSeq+1, nil); err != nil && s.logger != nil {
+			s.logger.Warn("close decision output failed", slog.Any("error", err))
+		}
+	}()
 	handle := sessionruntime.RunHandle{
 		BotID:      command.BotID,
 		SessionID:  command.SessionID,
@@ -356,6 +368,7 @@ func (s *Service) continueRuntimeDecision(
 		Generation: command.Generation,
 	}
 	if err := s.decisionRuntime.WaitDecisionContinuationReady(ctx, command); err != nil {
+		outputCause = err
 		s.recoverContextLifecycleFromAssistantMetadata(ctx, command.RunID, command.BotID, command.SessionID, err)
 		s.finishRuntimeDecision(ctx, handle, err)
 		return
@@ -401,6 +414,10 @@ func (s *Service) continueRuntimeDecision(
 			cancel()
 			break
 		}
+		outputSeq++
+		if err := s.decisionRuntime.PublishDecisionOutput(runCtx, command, outputSeq, raw); err != nil && s.logger != nil {
+			s.logger.Warn("publish decision output failed", slog.Any("error", err))
+		}
 	}
 	runErr := <-runDone
 	lifecycleDeferred = lifecycleDeferred || lifecycle.deferred
@@ -411,6 +428,7 @@ func (s *Service) continueRuntimeDecision(
 		lifecycleDeferred = false
 	}
 	if runErr != nil {
+		outputCause = runErr
 		s.persistRuntimeDecisionLifecycle(ctx, command, lifecycle, lifecycleCause)
 		s.finishRuntimeDecision(ctx, handle, runErr)
 		return

--- a/internal/agent/application/runtime_decision_test.go
+++ b/internal/agent/application/runtime_decision_test.go
@@ -15,9 +15,13 @@ import (
 	"github.com/felinics/memoh/internal/apperror"
 )
 
-func newWaitingDecisionRuntime(t *testing.T) (*sessionruntime.Manager, sessionruntime.RunHandle) {
+func newWaitingDecisionRuntime(t *testing.T, backends ...sessionruntime.Backend) (*sessionruntime.Manager, sessionruntime.RunHandle) {
 	t.Helper()
-	manager := sessionruntime.NewManager(sessionruntime.NewMemoryBackend(), sessionruntime.Options{
+	var backend sessionruntime.Backend = sessionruntime.NewMemoryBackend()
+	if len(backends) > 0 {
+		backend = backends[0]
+	}
+	manager := sessionruntime.NewManager(backend, sessionruntime.Options{
 		OwnerID:       "runtime-lifecycle-owner",
 		StateTTL:      time.Minute,
 		OwnerLeaseTTL: time.Second,

--- a/internal/agent/application/turn_service.go
+++ b/internal/agent/application/turn_service.go
@@ -272,7 +272,7 @@ func (h *runHandle) publishChunk(chunk StreamChunk) error {
 // RespondToolApproval resumes a turn deferred on tool approval.
 func (s *Service) RespondToolApproval(ctx context.Context, input turn.ToolApprovalResponse, eventCh chan<- json.RawMessage) error {
 	converted := toolApprovalInputFromResponse(input)
-	if handled, err := s.routeToolApprovalResponse(ctx, converted); handled || err != nil {
+	if handled, err := s.routeToolApprovalResponse(ctx, converted, eventCh); handled || err != nil {
 		return err
 	}
 	return s.respondToolApproval(ctx, converted, eventCh)
@@ -281,7 +281,7 @@ func (s *Service) RespondToolApproval(ctx context.Context, input turn.ToolApprov
 // RespondUserInput resumes a turn deferred on ask_user.
 func (s *Service) RespondUserInput(ctx context.Context, input turn.UserInputResponse, eventCh chan<- json.RawMessage) error {
 	converted := userInputInputFromResponse(input)
-	if handled, err := s.routeUserInputResponse(ctx, converted); handled || err != nil {
+	if handled, err := s.routeUserInputResponse(ctx, converted, eventCh); handled || err != nil {
 		return err
 	}
 	return s.respondUserInput(ctx, converted, eventCh)

--- a/internal/agent/runtime/session/commands.go
+++ b/internal/agent/runtime/session/commands.go
@@ -510,7 +510,7 @@ func (m *Manager) RouteDecisionResponse(ctx context.Context, response DecisionRe
 		return DecisionResponseResult{Handled: true}, err
 	} else if ok {
 		err := commandResultErrorFor(Command{PayloadHash: requestHash}, stored)
-		return DecisionResponseResult{Handled: true, Applied: err == nil}, err
+		return DecisionResponseResult{Handled: true, Applied: err == nil, Replayed: true}, err
 	}
 
 	m.mu.Lock()
@@ -540,7 +540,7 @@ func (m *Manager) RouteDecisionResponse(ctx context.Context, response DecisionRe
 			if target.PayloadHash != requestHash {
 				return result, ErrCommandPayloadConflict
 			}
-			return DecisionResponseResult{Handled: true, Applied: true}, nil
+			return DecisionResponseResult{Handled: true, Applied: true, Replayed: true}, nil
 		}
 		return result, nil
 	}

--- a/internal/agent/runtime/session/commands.go
+++ b/internal/agent/runtime/session/commands.go
@@ -528,7 +528,7 @@ func (m *Manager) RouteDecisionResponse(ctx context.Context, response DecisionRe
 		// ACP/MCP and other unfenced decisions retain their waiter-backed path.
 		return DecisionResponseResult{}, nil
 	}
-	result := DecisionResponseResult{Handled: true}
+	result := DecisionResponseResult{Handled: true, RunID: target.RunID}
 	if target.Type != response.Type ||
 		target.BotID != response.BotID ||
 		response.SessionID != "" && target.SessionID != response.SessionID ||

--- a/internal/agent/runtime/session/commands.go
+++ b/internal/agent/runtime/session/commands.go
@@ -528,7 +528,7 @@ func (m *Manager) RouteDecisionResponse(ctx context.Context, response DecisionRe
 		// ACP/MCP and other unfenced decisions retain their waiter-backed path.
 		return DecisionResponseResult{}, nil
 	}
-	result := DecisionResponseResult{Handled: true, RunID: target.RunID}
+	result := DecisionResponseResult{Handled: true, RunID: target.RunID, SessionID: target.SessionID}
 	if target.Type != response.Type ||
 		target.BotID != response.BotID ||
 		response.SessionID != "" && target.SessionID != response.SessionID ||
@@ -572,6 +572,7 @@ func (m *Manager) RouteDecisionResponse(ctx context.Context, response DecisionRe
 	if !ok || strings.TrimSpace(ref.OwnerID) == "" && m.distributed != nil {
 		return result, ErrCommandOwnerUnavailable
 	}
+	result.Generation = ref.Generation
 	createdAt, err := m.backend.Now(ctx)
 	if err != nil {
 		return result, fmt.Errorf("load runtime command time: %w", err)

--- a/internal/agent/runtime/session/commands.go
+++ b/internal/agent/runtime/session/commands.go
@@ -581,7 +581,7 @@ func (m *Manager) RouteDecisionResponse(ctx context.Context, response DecisionRe
 		Type: response.Type, ID: commandID,
 		BotID: target.BotID, SessionID: target.SessionID, RunID: target.RunID,
 		Generation: ref.Generation, FencingToken: target.FencingToken,
-		TargetID: target.ID, DecisionResolved: true,
+		TargetID: target.ID, DecisionResolved: true, StreamOutput: response.streamOutput,
 		Payload: append([]byte(nil), response.Payload...), PayloadHash: requestHash,
 		CreatedAt: createdAt, ExpiresAt: createdAt.Add(m.commandTimeout()),
 	}

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -113,17 +113,6 @@ func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionRespo
 				return err
 			}
 		case <-ticker.C:
-			// The end checkpoint is authoritative even if its notification is lost.
-			snapshot, exists, err := m.backend.Load(ctx, key)
-			if err != nil {
-				return err
-			}
-			if !exists {
-				return io.ErrUnexpectedEOF
-			}
-			if done, err := consume(snapshot.DecisionOutput); done || err != nil {
-				return err
-			}
 			// An owner crash does not close another process's Redis subscription.
 			// Reuse the run snapshot's existing ledger/lease reconciliation instead.
 			if runID != "" {

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -6,26 +6,43 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"time"
 )
 
-// Decision output has a separate backend topic because UI deltas cannot preserve
-// channel events such as attachments, reactions and interactive tool requests.
-// The command ID isolates successive answers in the same run. Both memory and
-// Redis backends support this, including responses routed to a different owner.
+// Each answer uses an independent checkpoint: a run can park again without
+// ending, and its next question must not reuse the previous answer's cursor.
 func decisionOutputKey(botID, commandID string) Key {
 	return Key{BotID: botID, SessionID: "decision-output/" + commandID}
 }
 
-// StreamDecisionResponse subscribes before admission so even a continuation that
-// finishes before the command acknowledgement cannot outrun its channel reader.
-// Cancelling the reader releases only its subscription, not the owning run.
+// Bound retained raw payloads, not the notification buffer. Overflow is an
+// explicit interrupted continuation; it must never silently discard output.
+const (
+	decisionOutputMaxBytes  = 8 << 20
+	decisionOutputMaxEvents = 32768
+)
+
 func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionResponse, output chan<- json.RawMessage) (DecisionResponseResult, error) {
 	if m == nil || m.backend == nil || output == nil {
 		return m.RouteDecisionResponse(ctx, response)
 	}
 	response.BotID = strings.TrimSpace(response.BotID)
 	commandID := decisionControlCommandID(response.Type, response.BotID, response.DecisionID, response.ControlID)
-	sub, err := m.backend.Subscribe(ctx, decisionOutputKey(response.BotID, commandID))
+	key := decisionOutputKey(response.BotID, commandID)
+	if _, _, err := m.backend.Update(ctx, key, func(s Snapshot, exists bool) (Snapshot, bool, error) {
+		if exists && s.DecisionOutput != nil {
+			return s, false, nil
+		}
+		s = EmptySnapshot(key.BotID, key.SessionID)
+		s.Epoch = m.newEpoch()
+		s.DecisionOutput = &DecisionOutputCheckpoint{}
+		return s, true, nil
+	}); err != nil {
+		return DecisionResponseResult{}, err
+	}
+	// Use the web subscription, including snapshot hydration, sequence-gap
+	// repair and periodic reconciliation. Pub/Sub is only a wakeup mechanism.
+	sub, err := m.Subscribe(ctx, key.BotID, key.SessionID)
 	if err != nil {
 		return DecisionResponseResult{}, err
 	}
@@ -34,38 +51,170 @@ func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionR
 	if err != nil || !result.Handled || !result.Applied || result.Replayed {
 		return result, err
 	}
-	var seq int64
+	accepted, _ := json.Marshal(map[string]string{"type": "decision_accepted", "decision_id": response.DecisionID})
+	select {
+	case output <- accepted:
+	case <-ctx.Done():
+		return result, ctx.Err()
+	}
+	return result, m.readDecisionOutput(ctx, response, result.RunID, key, sub, output)
+}
+
+func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionResponse, runID string, key Key, sub Subscription, output chan<- json.RawMessage) error {
+	cursor := 0
+	epoch := ""
+	terminalObserved := false
+	ticker := time.NewTicker(runtimeReconcileInterval(m.ownerLeaseTTL))
+	defer ticker.Stop()
+	consume := func(checkpoint *DecisionOutputCheckpoint) (bool, error) {
+		if checkpoint == nil {
+			return false, nil
+		}
+		if checkpoint.Offset > cursor {
+			return false, io.ErrUnexpectedEOF
+		}
+		for cursor < checkpoint.Offset+len(checkpoint.Events) {
+			select {
+			case output <- checkpoint.Events[cursor-checkpoint.Offset]:
+				cursor++
+			case <-ctx.Done():
+				return false, ctx.Err()
+			}
+		}
+		if checkpoint.Failed {
+			return false, io.ErrUnexpectedEOF
+		}
+		return checkpoint.Done, nil
+	}
 	for {
 		select {
 		case <-ctx.Done():
-			return result, ctx.Err()
+			return ctx.Err()
 		case event, ok := <-sub.C:
-			if !ok {
-				return result, io.ErrUnexpectedEOF
+			if !ok || event.Type == EventRuntimeDropped {
+				return io.ErrUnexpectedEOF
 			}
-			if event.Type == EventRuntimeDropped || event.Seq != seq+1 {
-				return result, errors.New("decision output stream interrupted")
+			if epoch != "" && event.Epoch != epoch {
+				return io.ErrUnexpectedEOF
 			}
-			seq = event.Seq
-			if event.Type == "decision_output_end" {
-				return result, nil
+			epoch = event.Epoch
+			var checkpoint *DecisionOutputCheckpoint
+			if event.Snapshot != nil {
+				checkpoint = event.Snapshot.DecisionOutput
+				if checkpoint == nil {
+					return io.ErrUnexpectedEOF
+				}
 			}
-			select {
-			case output <- event.Output:
-			case <-ctx.Done():
-				return result, ctx.Err()
+			if event.Delta != nil {
+				checkpoint = event.Delta.DecisionOutput
+			}
+			if done, err := consume(checkpoint); done || err != nil {
+				return err
+			}
+		case <-ticker.C:
+			// The end checkpoint is authoritative even if its notification is lost.
+			snapshot, exists, err := m.backend.Load(ctx, key)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return io.ErrUnexpectedEOF
+			}
+			if done, err := consume(snapshot.DecisionOutput); done || err != nil {
+				return err
+			}
+			// An owner crash does not close another process's Redis subscription.
+			// Reuse the run snapshot's existing ledger/lease reconciliation instead.
+			if runID != "" {
+				live, err := m.Snapshot(ctx, response.BotID, response.SessionID)
+				if err != nil {
+					return err
+				}
+				ended := live.CurrentRunView == nil || live.CurrentRunView.RunID != runID || !isActiveRunStatus(live.CurrentRunView.Status)
+				if !ended && live.CurrentRunView.Status == RunStatusWaitingDecision {
+					m.mu.Lock()
+					decisions := m.decisionStore
+					m.mu.Unlock()
+					if decisions != nil {
+						pending, err := decisions.PendingRuntimeDecisions(ctx, runID)
+						if err != nil {
+							return err
+						}
+						for _, target := range pending {
+							if target.RunID == runID && target.ID != response.DecisionID {
+								ended = true
+								break
+							}
+						}
+					}
+				}
+				if ended {
+					// Drain a final checkpoint committed concurrently with the run terminal.
+					latest, _, err := m.backend.Load(ctx, key)
+					if err != nil {
+						return err
+					}
+					if done, err := consume(latest.DecisionOutput); done || err != nil {
+						return err
+					}
+					if terminalObserved {
+						return io.ErrUnexpectedEOF
+					}
+					// FinishRun can precede the continuation's deferred checkpoint write.
+					// Give that writer one reconciliation interval, rather than guessing
+					// that a terminal run proves its output was delivered.
+					terminalObserved = true
+				} else {
+					terminalObserved = false
+				}
 			}
 		}
 	}
 }
 
-// PublishDecisionOutput runs only after the owner has accepted the corresponding
-// agent event. A nil payload closes this continuation, including a new question.
+// Commit state before notifying, exactly as runtime UI deltas do. A nil payload
+// closes this continuation, including when the agent parks on a new question.
 func (m *Manager) PublishDecisionOutput(ctx context.Context, command Command, seq int64, payload json.RawMessage) error {
 	key := decisionOutputKey(command.BotID, command.ID)
-	kind := "decision_output"
-	if payload == nil {
-		kind = "decision_output_end"
+	exceeded := false
+	_, _, err := m.updateAndPublish(ctx, key, command.RunID, func(s Snapshot, exists bool) (Snapshot, bool, error) {
+		if !exists {
+			s = EmptySnapshot(key.BotID, key.SessionID)
+			s.Epoch = m.newEpoch()
+		}
+		if s.DecisionOutput == nil {
+			s.DecisionOutput = &DecisionOutputCheckpoint{}
+		}
+		c := s.DecisionOutput
+		if c.Done || c.Failed {
+			return s, false, nil
+		}
+		if seq != int64(len(c.Events)+1) {
+			return s, false, errors.New("decision output sequence mismatch")
+		}
+		if payload == nil {
+			c.Done = true
+		} else if c.Bytes+len(payload) > decisionOutputMaxBytes || len(c.Events) >= decisionOutputMaxEvents {
+			c.Failed = true
+			exceeded = true
+		} else {
+			c.Events = append(c.Events, append(json.RawMessage(nil), payload...))
+			c.Bytes += len(payload)
+		}
+		s.Seq++
+		s.UpdatedAt = time.Now().UTC()
+		return s, true, nil
+	}, func(s Snapshot) RuntimeDelta {
+		c := s.DecisionOutput
+		delta := &DecisionOutputCheckpoint{Offset: len(c.Events), Done: c.Done, Failed: c.Failed}
+		if payload != nil && !c.Failed {
+			delta.Offset--
+			delta.Events = c.Events[len(c.Events)-1:]
+		}
+		return RuntimeDelta{DecisionOutput: delta}
+	})
+	if err == nil && exceeded {
+		return errors.New("decision output checkpoint limit exceeded")
 	}
-	return m.backend.Publish(ctx, Event{Type: kind, BotID: key.BotID, SessionID: key.SessionID, RunID: command.RunID, Seq: seq, Output: payload})
+	return err
 }

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -57,10 +57,11 @@ func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionR
 	case <-ctx.Done():
 		return result, ctx.Err()
 	}
-	return result, m.readDecisionOutput(ctx, response, result.RunID, key, sub, output)
+	response.SessionID = result.SessionID
+	return result, m.readDecisionOutput(ctx, response, result.RunID, key, sub, output, result.Generation)
 }
 
-func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionResponse, runID string, key Key, sub Subscription, output chan<- json.RawMessage) error {
+func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionResponse, runID string, key Key, sub Subscription, output chan<- json.RawMessage, generation ...string) error {
 	cursor := 0
 	epoch := ""
 	terminalObserved := false
@@ -131,22 +132,8 @@ func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionRespo
 					return err
 				}
 				ended := live.CurrentRunView == nil || live.CurrentRunView.RunID != runID || !isActiveRunStatus(live.CurrentRunView.Status)
-				if !ended && live.CurrentRunView.Status == RunStatusWaitingDecision {
-					m.mu.Lock()
-					decisions := m.decisionStore
-					m.mu.Unlock()
-					if decisions != nil {
-						pending, err := decisions.PendingRuntimeDecisions(ctx, runID)
-						if err != nil {
-							return err
-						}
-						for _, target := range pending {
-							if target.RunID == runID && target.ID != response.DecisionID {
-								ended = true
-								break
-							}
-						}
-					}
+				if !ended && len(generation) > 0 && generation[0] != "" && live.CurrentRunView.Generation != generation[0] {
+					ended = true
 				}
 				if ended {
 					// Drain a final checkpoint committed concurrently with the run terminal.

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -1,0 +1,71 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+)
+
+// Decision output has a separate backend topic because UI deltas cannot preserve
+// channel events such as attachments, reactions and interactive tool requests.
+// The command ID isolates successive answers in the same run. Both memory and
+// Redis backends support this, including responses routed to a different owner.
+func decisionOutputKey(botID, commandID string) Key {
+	return Key{BotID: botID, SessionID: "decision-output/" + commandID}
+}
+
+// StreamDecisionResponse subscribes before admission so even a continuation that
+// finishes before the command acknowledgement cannot outrun its channel reader.
+// Cancelling the reader releases only its subscription, not the owning run.
+func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionResponse, output chan<- json.RawMessage) (DecisionResponseResult, error) {
+	if m == nil || m.backend == nil || output == nil {
+		return m.RouteDecisionResponse(ctx, response)
+	}
+	response.BotID = strings.TrimSpace(response.BotID)
+	commandID := decisionControlCommandID(response.Type, response.BotID, response.DecisionID, response.ControlID)
+	sub, err := m.backend.Subscribe(ctx, decisionOutputKey(response.BotID, commandID))
+	if err != nil {
+		return DecisionResponseResult{}, err
+	}
+	defer sub.Close()
+	result, err := m.RouteDecisionResponse(ctx, response)
+	if err != nil || !result.Handled || !result.Applied || result.Replayed {
+		return result, err
+	}
+	var seq int64
+	for {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case event, ok := <-sub.C:
+			if !ok {
+				return result, io.ErrUnexpectedEOF
+			}
+			if event.Type == EventRuntimeDropped || event.Seq != seq+1 {
+				return result, errors.New("decision output stream interrupted")
+			}
+			seq = event.Seq
+			if event.Type == "decision_output_end" {
+				return result, nil
+			}
+			select {
+			case output <- event.Output:
+			case <-ctx.Done():
+				return result, ctx.Err()
+			}
+		}
+	}
+}
+
+// PublishDecisionOutput runs only after the owner has accepted the corresponding
+// agent event. A nil payload closes this continuation, including a new question.
+func (m *Manager) PublishDecisionOutput(ctx context.Context, command Command, seq int64, payload json.RawMessage) error {
+	key := decisionOutputKey(command.BotID, command.ID)
+	kind := "decision_output"
+	if payload == nil {
+		kind = "decision_output_end"
+	}
+	return m.backend.Publish(ctx, Event{Type: kind, BotID: key.BotID, SessionID: key.SessionID, RunID: command.RunID, Seq: seq, Output: payload})
+}

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -192,12 +192,13 @@ func (m *Manager) PublishDecisionOutput(ctx context.Context, command Command, se
 		if seq != int64(len(c.Events)+1) {
 			return s, false, errors.New("decision output sequence mismatch")
 		}
-		if payload == nil {
+		switch {
+		case payload == nil:
 			c.Done = true
-		} else if c.Bytes+len(payload) > decisionOutputMaxBytes || len(c.Events) >= decisionOutputMaxEvents {
+		case c.Bytes+len(payload) > decisionOutputMaxBytes || len(c.Events) >= decisionOutputMaxEvents:
 			c.Failed = true
 			exceeded = true
-		} else {
+		default:
 			c.Events = append(c.Events, append(json.RawMessage(nil), payload...))
 			c.Bytes += len(payload)
 		}

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -5,27 +5,30 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"strings"
 	"time"
 )
 
-// Channel output reuses the session runtime snapshot and subscription recovery
-// introduced in #800 (47fd904d4), including sequence-gap repair and periodic
-// reconciliation. Backend.Update retains its existing full-snapshot write and
-// TTL semantics; this adapter does not implement another recovery protocol.
-// Raw events preserve channel actions and attachments that the UI projection
-// cannot reproduce. Each answer needs its own checkpoint because one run can
-// park again without ending; successive answers must not share a cursor.
-func decisionOutputKey(botID, commandID string) Key {
-	return Key{BotID: botID, SessionID: "decision-output/" + commandID}
+// Channel continuations forward the raw agent events the run owner emits after
+// an accepted answer. Web reads the session's projected snapshot instead, so a
+// channel reader cannot share that state: it needs the raw stream (cards,
+// attachments, reactions) and it must survive the owner parking again or a
+// notification being lost.
+//
+// The owner appends each event to a per-command log (DecisionOutputStore); the
+// reader keeps a cursor and re-reads from it on every wakeup or tick. Pub/Sub is
+// only a wakeup. Run-terminal reconciliation reuses the session snapshot from
+// #865/#1107 to notice an owner that died without closing the log.
+func decisionOutputRef(botID, commandID string) DecisionOutputRef {
+	return DecisionOutputRef{BotID: strings.TrimSpace(botID), CommandID: strings.TrimSpace(commandID)}
 }
 
-// Bound retained raw payloads, not the notification buffer. Overflow is an
-// explicit interrupted continuation; it must never silently discard output.
-const (
-	decisionOutputMaxBytes  = 8 << 20
-	decisionOutputMaxEvents = 32768
-)
+// Bound retained payloads per command. Overflow is an explicit interrupted
+// continuation; it must never silently discard output.
+var decisionOutputLimits = DecisionOutputLimits{MaxBytes: 8 << 20, MaxEvents: 32768}
+
+var errDecisionOutputLimitExceeded = errors.New("decision output checkpoint limit exceeded")
 
 func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionResponse, output chan<- json.RawMessage) (DecisionResponseResult, error) {
 	if m == nil || m.backend == nil || output == nil {
@@ -33,21 +36,11 @@ func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionR
 	}
 	response.BotID = strings.TrimSpace(response.BotID)
 	commandID := decisionControlCommandID(response.Type, response.BotID, response.DecisionID, response.ControlID)
-	key := decisionOutputKey(response.BotID, commandID)
-	if _, _, err := m.backend.Update(ctx, key, func(s Snapshot, exists bool) (Snapshot, bool, error) {
-		if exists && s.DecisionOutput != nil {
-			return s, false, nil
-		}
-		s = EmptySnapshot(key.BotID, key.SessionID)
-		s.Epoch = m.newEpoch()
-		s.DecisionOutput = &DecisionOutputCheckpoint{}
-		return s, true, nil
-	}); err != nil {
-		return DecisionResponseResult{}, err
-	}
-	// Use the web subscription, including snapshot hydration, sequence-gap
-	// repair and periodic reconciliation. Pub/Sub is only a wakeup mechanism.
-	sub, err := m.Subscribe(ctx, key.BotID, key.SessionID)
+	ref := decisionOutputRef(response.BotID, commandID)
+	// Subscribe before routing: an append committed between acceptance and the
+	// first read is still found by that read, but its wakeup would be missed and
+	// delivery would wait for the next tick.
+	sub, err := m.backend.Subscribe(ctx, ref.topic())
 	if err != nil {
 		return DecisionResponseResult{}, err
 	}
@@ -57,7 +50,10 @@ func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionR
 	if err != nil || !result.Handled || !result.Applied || result.Replayed {
 		return result, err
 	}
-	claimed, err := m.claimDecisionOutput(ctx, key)
+	// Execution deduplication can return success to concurrent callers that both
+	// passed routing's replay check. Shared backend arbitration gives only one of
+	// those callers permission to forward, including across server instances.
+	claimed, err := m.backend.ClaimDecisionOutput(ctx, ref)
 	if err != nil {
 		return result, err
 	}
@@ -72,160 +68,112 @@ func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionR
 		return result, ctx.Err()
 	}
 	response.SessionID = result.SessionID
-	return result, m.readDecisionOutput(ctx, response, result.RunID, key, sub, output, result.Generation)
+	return result, m.readDecisionOutput(ctx, response, result.RunID, result.Generation, ref, sub, output)
 }
 
-// Execution deduplication can return success to concurrent callers that both
-// passed routing's replay check. Shared backend arbitration gives only one of
-// those callers permission to forward, including across server instances.
-func (m *Manager) claimDecisionOutput(ctx context.Context, key Key) (bool, error) {
-	_, claimed, err := m.backend.Update(ctx, key, func(s Snapshot, exists bool) (Snapshot, bool, error) {
-		if !exists || s.DecisionOutput == nil {
-			return s, false, io.ErrUnexpectedEOF
-		}
-		if s.DecisionOutput.Claimed {
-			return s, false, nil
-		}
-		s.DecisionOutput.Claimed = true
-		return s, true, nil
-	})
-	return claimed, err
-}
-
-func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionResponse, runID string, key Key, sub Subscription, output chan<- json.RawMessage, generation ...string) error {
+func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionResponse, runID, generation string, ref DecisionOutputRef, sub Subscription, output chan<- json.RawMessage) error {
 	cursor := 0
-	epoch := ""
 	terminalObserved := false
 	ticker := time.NewTicker(runtimeReconcileInterval(m.ownerLeaseTTL))
 	defer ticker.Stop()
-	consume := func(checkpoint *DecisionOutputCheckpoint) (bool, error) {
-		if checkpoint == nil {
-			return false, nil
+	// drain forwards everything committed past the cursor. It is the only source
+	// of truth; wakeups and ticks just decide when to call it.
+	drain := func() (bool, error) {
+		page, err := m.backend.ReadDecisionOutput(ctx, ref, cursor)
+		if err != nil {
+			return false, err
 		}
-		if checkpoint.Offset > cursor {
-			return false, io.ErrUnexpectedEOF
-		}
-		for cursor < checkpoint.Offset+len(checkpoint.Events) {
+		for _, raw := range page.Events {
 			select {
-			case output <- checkpoint.Events[cursor-checkpoint.Offset]:
+			case output <- raw:
 				cursor++
 			case <-ctx.Done():
 				return false, ctx.Err()
 			}
 		}
-		if checkpoint.Failed {
+		if page.Failed {
 			return false, io.ErrUnexpectedEOF
 		}
-		return checkpoint.Done, nil
+		return page.Done, nil
+	}
+	finish := func(done bool, err error) (bool, error) {
+		if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) || !done && err == nil {
+			return done, err
+		}
+		// Done or Failed: the log has no further readers. Reclaim the entries now
+		// instead of waiting for the state TTL; the claim marker stays.
+		if releaseErr := m.backend.ReleaseDecisionOutput(context.WithoutCancel(ctx), ref); releaseErr != nil {
+			m.logger.Warn("release decision output log failed", slog.Any("error", releaseErr))
+		}
+		return true, err
 	}
 	for {
+		if stop, err := finish(drain()); stop {
+			return err
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case event, ok := <-sub.C:
-			if !ok || event.Type == EventRuntimeDropped {
+		case _, ok := <-sub.C:
+			if !ok {
 				return io.ErrUnexpectedEOF
 			}
-			if epoch != "" && event.Epoch != epoch {
-				return io.ErrUnexpectedEOF
-			}
-			epoch = event.Epoch
-			var checkpoint *DecisionOutputCheckpoint
-			if event.Snapshot != nil {
-				checkpoint = event.Snapshot.DecisionOutput
-				if checkpoint == nil {
-					return io.ErrUnexpectedEOF
-				}
-			}
-			if event.Delta != nil {
-				checkpoint = event.Delta.DecisionOutput
-			}
-			if done, err := consume(checkpoint); done || err != nil {
-				return err
-			}
+			// Any event, including a dropped-notification marker, is a wakeup.
 		case <-ticker.C:
+			if runID == "" {
+				continue
+			}
 			// An owner crash does not close another process's Redis subscription.
 			// Reuse the run snapshot's existing ledger/lease reconciliation instead.
-			if runID != "" {
-				live, err := m.Snapshot(ctx, response.BotID, response.SessionID)
-				if err != nil {
-					return err
-				}
-				ended := live.CurrentRunView == nil || live.CurrentRunView.RunID != runID || !isActiveRunStatus(live.CurrentRunView.Status)
-				if !ended && len(generation) > 0 && generation[0] != "" && live.CurrentRunView.Generation != generation[0] {
-					ended = true
-				}
-				if ended {
-					// Drain a final checkpoint committed concurrently with the run terminal.
-					latest, _, err := m.backend.Load(ctx, key)
-					if err != nil {
-						return err
-					}
-					if done, err := consume(latest.DecisionOutput); done || err != nil {
-						return err
-					}
-					if terminalObserved {
-						return io.ErrUnexpectedEOF
-					}
-					// FinishRun can precede the continuation's deferred checkpoint write.
-					// Give that writer one reconciliation interval, rather than guessing
-					// that a terminal run proves its output was delivered.
-					terminalObserved = true
-				} else {
-					terminalObserved = false
-				}
+			live, err := m.Snapshot(ctx, response.BotID, response.SessionID)
+			if err != nil {
+				return err
 			}
+			ended := live.CurrentRunView == nil || live.CurrentRunView.RunID != runID || !isActiveRunStatus(live.CurrentRunView.Status)
+			if !ended && generation != "" && live.CurrentRunView.Generation != generation {
+				ended = true
+			}
+			if !ended {
+				terminalObserved = false
+				continue
+			}
+			if stop, err := finish(drain()); stop {
+				return err
+			}
+			if terminalObserved {
+				return io.ErrUnexpectedEOF
+			}
+			// FinishRun can precede the continuation's deferred close. Give that
+			// writer one reconciliation interval, rather than guessing that a
+			// terminal run proves its output was delivered.
+			terminalObserved = true
 		}
 	}
 }
 
-// Commit state before notifying, exactly as runtime UI deltas do. A nil payload
-// closes this continuation, including when the agent parks on a new question.
+// PublishDecisionOutput appends one raw event (or closes the log with a nil
+// payload) and then wakes readers. Commit before notify, exactly as runtime UI
+// deltas do; a lost wakeup costs latency, never data.
 func (m *Manager) PublishDecisionOutput(ctx context.Context, command Command, seq int64, payload json.RawMessage) error {
 	if !command.StreamOutput {
 		return nil
 	}
-	key := decisionOutputKey(command.BotID, command.ID)
-	exceeded := false
-	_, _, err := m.updateAndPublish(ctx, key, command.RunID, func(s Snapshot, exists bool) (Snapshot, bool, error) {
-		if !exists {
-			s = EmptySnapshot(key.BotID, key.SessionID)
-			s.Epoch = m.newEpoch()
-		}
-		if s.DecisionOutput == nil {
-			s.DecisionOutput = &DecisionOutputCheckpoint{}
-		}
-		c := s.DecisionOutput
-		if c.Done || c.Failed {
-			return s, false, nil
-		}
-		if seq != int64(len(c.Events)+1) {
-			return s, false, errors.New("decision output sequence mismatch")
-		}
-		switch {
-		case payload == nil:
-			c.Done = true
-		case c.Bytes+len(payload) > decisionOutputMaxBytes || len(c.Events) >= decisionOutputMaxEvents:
-			c.Failed = true
-			exceeded = true
-		default:
-			c.Events = append(c.Events, append(json.RawMessage(nil), payload...))
-			c.Bytes += len(payload)
-		}
-		s.Seq++
-		s.UpdatedAt = time.Now().UTC()
-		return s, true, nil
-	}, func(s Snapshot) RuntimeDelta {
-		c := s.DecisionOutput
-		delta := &DecisionOutputCheckpoint{Offset: len(c.Events), Done: c.Done, Failed: c.Failed}
-		if payload != nil && !c.Failed {
-			delta.Offset--
-			delta.Events = c.Events[len(c.Events)-1:]
-		}
-		return RuntimeDelta{DecisionOutput: delta}
-	})
-	if err == nil && exceeded {
-		return errors.New("decision output checkpoint limit exceeded")
+	ref := decisionOutputRef(command.BotID, command.ID)
+	state, err := m.backend.AppendDecisionOutput(ctx, ref, seq, payload, decisionOutputLimits)
+	if err != nil {
+		return err
 	}
-	return err
+	if state.Applied {
+		topic := ref.topic()
+		if err := m.backend.Publish(ctx, Event{
+			Type: EventDecisionOutput, BotID: topic.BotID, SessionID: topic.SessionID,
+			RunID: command.RunID, Seq: int64(state.Length),
+		}); err != nil {
+			m.logger.Warn("publish decision output wakeup failed; reader will reconcile from log", slog.Any("error", err))
+		}
+	}
+	if state.Exceeded {
+		return errDecisionOutputLimitExceeded
+	}
+	return nil
 }

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -52,6 +52,7 @@ func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionR
 		return DecisionResponseResult{}, err
 	}
 	defer sub.Close()
+	response.streamOutput = true
 	result, err := m.RouteDecisionResponse(ctx, response)
 	if err != nil || !result.Handled || !result.Applied || result.Replayed {
 		return result, err
@@ -156,6 +157,9 @@ func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionRespo
 // Commit state before notifying, exactly as runtime UI deltas do. A nil payload
 // closes this continuation, including when the agent parks on a new question.
 func (m *Manager) PublishDecisionOutput(ctx context.Context, command Command, seq int64, payload json.RawMessage) error {
+	if !command.StreamOutput {
+		return nil
+	}
 	key := decisionOutputKey(command.BotID, command.ID)
 	exceeded := false
 	_, _, err := m.updateAndPublish(ctx, key, command.RunID, func(s Snapshot, exists bool) (Snapshot, bool, error) {

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -9,8 +9,13 @@ import (
 	"time"
 )
 
-// Each answer uses an independent checkpoint: a run can park again without
-// ending, and its next question must not reuse the previous answer's cursor.
+// Channel output reuses the session runtime snapshot and subscription recovery
+// introduced in #800 (47fd904d4), including sequence-gap repair and periodic
+// reconciliation. Backend.Update retains its existing full-snapshot write and
+// TTL semantics; this adapter does not implement another recovery protocol.
+// Raw events preserve channel actions and attachments that the UI projection
+// cannot reproduce. Each answer needs its own checkpoint because one run can
+// park again without ending; successive answers must not share a cursor.
 func decisionOutputKey(botID, commandID string) Key {
 	return Key{BotID: botID, SessionID: "decision-output/" + commandID}
 }

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -57,6 +57,14 @@ func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionR
 	if err != nil || !result.Handled || !result.Applied || result.Replayed {
 		return result, err
 	}
+	claimed, err := m.claimDecisionOutput(ctx, key)
+	if err != nil {
+		return result, err
+	}
+	if !claimed {
+		result.Replayed = true
+		return result, nil
+	}
 	accepted, _ := json.Marshal(map[string]string{"type": "decision_accepted", "decision_id": response.DecisionID})
 	select {
 	case output <- accepted:
@@ -65,6 +73,23 @@ func (m *Manager) StreamDecisionResponse(ctx context.Context, response DecisionR
 	}
 	response.SessionID = result.SessionID
 	return result, m.readDecisionOutput(ctx, response, result.RunID, key, sub, output, result.Generation)
+}
+
+// Execution deduplication can return success to concurrent callers that both
+// passed routing's replay check. Shared backend arbitration gives only one of
+// those callers permission to forward, including across server instances.
+func (m *Manager) claimDecisionOutput(ctx context.Context, key Key) (bool, error) {
+	_, claimed, err := m.backend.Update(ctx, key, func(s Snapshot, exists bool) (Snapshot, bool, error) {
+		if !exists || s.DecisionOutput == nil {
+			return s, false, io.ErrUnexpectedEOF
+		}
+		if s.DecisionOutput.Claimed {
+			return s, false, nil
+		}
+		s.DecisionOutput.Claimed = true
+		return s, true, nil
+	})
+	return claimed, err
 }
 
 func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionResponse, runID string, key Key, sub Subscription, output chan<- json.RawMessage, generation ...string) error {

--- a/internal/agent/runtime/session/decision_output.go
+++ b/internal/agent/runtime/session/decision_output.go
@@ -96,14 +96,19 @@ func (m *Manager) readDecisionOutput(ctx context.Context, response DecisionRespo
 		}
 		return page.Done, nil
 	}
+	// finish decides whether the reader stops. Every error stops it, including a
+	// backend read failure: waiting on would hide an interrupted delivery until
+	// the request context expires.
 	finish := func(done bool, err error) (bool, error) {
-		if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) || !done && err == nil {
-			return done, err
+		if err == nil && !done {
+			return false, nil
 		}
-		// Done or Failed: the log has no further readers. Reclaim the entries now
-		// instead of waiting for the state TTL; the claim marker stays.
-		if releaseErr := m.backend.ReleaseDecisionOutput(context.WithoutCancel(ctx), ref); releaseErr != nil {
-			m.logger.Warn("release decision output log failed", slog.Any("error", releaseErr))
+		if done || errors.Is(err, io.ErrUnexpectedEOF) {
+			// Done or Failed: the log has no further readers. Reclaim the entries
+			// now instead of waiting for the state TTL; the claim marker stays.
+			if releaseErr := m.backend.ReleaseDecisionOutput(context.WithoutCancel(ctx), ref); releaseErr != nil {
+				m.logger.Warn("release decision output log failed", slog.Any("error", releaseErr))
+			}
 		}
 		return true, err
 	}

--- a/internal/agent/runtime/session/decision_output_test.go
+++ b/internal/agent/runtime/session/decision_output_test.go
@@ -187,7 +187,7 @@ func TestDecisionOutputRecoversWithoutEndNotification(t *testing.T) {
 }
 
 func TestDecisionOutputStopsAfterOwnerRunTerminates(t *testing.T) {
-	for _, status := range []string{RunStatusLost, RunStatusWaitingDecision} {
+	for _, status := range []string{RunStatusLost} {
 		t.Run(status, func(t *testing.T) {
 			backend := NewMemoryBackend()
 			manager := NewManager(backend, Options{OwnerLeaseTTL: time.Second})

--- a/internal/agent/runtime/session/decision_output_test.go
+++ b/internal/agent/runtime/session/decision_output_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -70,6 +73,11 @@ func TestDecisionOutputSurvivesEarlyAcknowledgement(t *testing.T) {
 				json.RawMessage(`{"type":"user_input_request","userInputId":"next","status":"pending"}`),
 				json.RawMessage(`{"type":"agent_end","userInputId":"next","status":"pending"}`),
 			}
+			// Publish a burst larger than the notification buffer before the reader
+			// can consume any payload. Recovery must use the checkpoint.
+			for i := 0; i < 130; i++ {
+				expected = append(expected, json.RawMessage(`{"type":"text_delta","delta":"burst"}`))
+			}
 			manager.SetCommandHandler(func(ctx context.Context, command Command) error {
 				executions.Add(1)
 				// Publish before acknowledgement: subscribing afterwards would lose all of it.
@@ -80,13 +88,17 @@ func TestDecisionOutputSurvivesEarlyAcknowledgement(t *testing.T) {
 				}
 				return manager.PublishDecisionOutput(ctx, command, int64(len(expected)+1), nil)
 			})
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			response := DecisionResponse{ControlID: "control", Type: commandType, DecisionID: decisionID, BotID: testBotID, SessionID: sessionID, Payload: json.RawMessage(`{}`)}
-			output := make(chan json.RawMessage, 8)
+			output := make(chan json.RawMessage, len(expected)+1)
 			result, err := manager.StreamDecisionResponse(ctx, response, output)
 			if err != nil || !result.Applied {
 				t.Fatalf("result=%+v error=%v", result, err)
+			}
+			var accepted map[string]string
+			if err := json.Unmarshal(<-output, &accepted); err != nil || accepted["type"] != "decision_accepted" {
+				t.Fatalf("acceptance event: %v %v", accepted, err)
 			}
 			for _, want := range expected {
 				select {
@@ -137,5 +149,141 @@ func TestDecisionOutputCanceledSubscription(t *testing.T) {
 	_, err := manager.StreamDecisionResponse(ctx, DecisionResponse{BotID: "bot"}, make(chan json.RawMessage))
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("error=%v", err)
+	}
+}
+
+// A successful write with every notification lost must still recover via the
+// same periodic snapshot reconciliation used by web subscribers.
+type silentDecisionBackend struct{ Backend }
+
+func (b silentDecisionBackend) Publish(context.Context, Event) error { return nil }
+
+func TestDecisionOutputRecoversWithoutEndNotification(t *testing.T) {
+	backend := silentDecisionBackend{NewMemoryBackend()}
+	manager := NewManager(backend, Options{})
+	defer func() { _ = manager.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	command := Command{BotID: "bot", ID: "silent"}
+	key := decisionOutputKey(command.BotID, command.ID)
+	if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"one"}`)); err != nil {
+		t.Fatal(err)
+	}
+	sub, err := manager.Subscribe(ctx, key.BotID, key.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Close()
+	if err := manager.PublishDecisionOutput(ctx, command, 2, nil); err != nil {
+		t.Fatal(err)
+	}
+	output := make(chan json.RawMessage, 2)
+	if err := manager.readDecisionOutput(ctx, DecisionResponse{}, "", key, sub, output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output) != 1 {
+		t.Fatalf("recovered %d events", len(output))
+	}
+}
+
+func TestDecisionOutputStopsAfterOwnerRunTerminates(t *testing.T) {
+	for _, status := range []string{RunStatusLost, RunStatusWaitingDecision} {
+		t.Run(status, func(t *testing.T) {
+			backend := NewMemoryBackend()
+			manager := NewManager(backend, Options{OwnerLeaseTTL: time.Second})
+			defer func() { _ = manager.Close() }()
+			manager.SetDecisionStore(&fakeDecisionStore{target: DecisionTarget{ID: "next-question", RunID: "run", Status: "pending"}})
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			command := Command{BotID: "bot", ID: "orphan", RunID: "run"}
+			key := decisionOutputKey(command.BotID, command.ID)
+			if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"partial"}`)); err != nil {
+				t.Fatal(err)
+			}
+			_, _, err := backend.Update(ctx, Key{BotID: "bot", SessionID: "session"}, func(s Snapshot, _ bool) (Snapshot, bool, error) {
+				s = EmptySnapshot("bot", "session")
+				s.Epoch = "epoch"
+				s.CurrentRunView = &CurrentRunView{RunID: "run", Status: status}
+				return s, true, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			sub, err := manager.Subscribe(ctx, key.BotID, key.SessionID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer sub.Close()
+			err = manager.readDecisionOutput(ctx, DecisionResponse{BotID: "bot", SessionID: "session", DecisionID: "old-question"}, "run", key, sub, make(chan json.RawMessage, 2))
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("owner loss should release reader: %v", err)
+			}
+		})
+	}
+}
+
+func TestDecisionOutputRedisRecoveryOptional(t *testing.T) {
+	url := os.Getenv("MEMOH_TEST_REDIS_URL")
+	if url == "" {
+		t.Skip("set MEMOH_TEST_REDIS_URL for two-client Redis recovery")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	opts := RedisOptions{URL: url, KeyPrefix: uniqueRuntimeBackendPrefix("decision-output-recovery"), StateTTL: time.Minute}
+	writer, err := NewRedisBackend(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := NewRedisBackend(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	producer := NewManager(silentDecisionBackend{writer}, Options{})
+	consumer := NewManager(reader, Options{})
+	defer func() { _ = producer.Close(); _ = consumer.Close() }()
+	command := Command{BotID: testBotID, ID: "answer"}
+	key := decisionOutputKey(command.BotID, command.ID)
+	if err := producer.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"first"}`)); err != nil {
+		t.Fatal(err)
+	}
+	sub, err := consumer.Subscribe(ctx, key.BotID, key.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Close()
+	for i := 2; i <= 133; i++ {
+		if err := producer.PublishDecisionOutput(ctx, command, int64(i), json.RawMessage(`{"type":"text_delta","delta":"burst"}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := producer.PublishDecisionOutput(ctx, command, 134, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The publisher is gone. The reader still has its own Redis connection and
+	// must finish from shared state without a single notification, including end.
+	if err := producer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out := make(chan json.RawMessage, 133)
+	if err := consumer.readDecisionOutput(ctx, DecisionResponse{}, "", key, sub, out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 133 {
+		t.Fatalf("recovered %d events", len(out))
+	}
+}
+
+func TestDecisionOutputRetentionLimitIsExplicit(t *testing.T) {
+	b := NewMemoryBackend()
+	m := NewManager(b, Options{})
+	defer func() { _ = m.Close() }()
+	command := Command{BotID: "bot", ID: "limit"}
+	payload, _ := json.Marshal(strings.Repeat("x", decisionOutputMaxBytes))
+	if err := m.PublishDecisionOutput(context.Background(), command, 1, payload); err == nil {
+		t.Fatal("oversized checkpoint accepted")
+	}
+	s, ok, err := b.Load(context.Background(), decisionOutputKey(command.BotID, command.ID))
+	if err != nil || !ok || s.DecisionOutput == nil || !s.DecisionOutput.Failed || len(s.DecisionOutput.Events) != 0 {
+		t.Fatalf("limit did not leave recoverable failure: %+v %v", s, err)
 	}
 }

--- a/internal/agent/runtime/session/decision_output_test.go
+++ b/internal/agent/runtime/session/decision_output_test.go
@@ -156,7 +156,7 @@ func TestDecisionOutputCanceledSubscription(t *testing.T) {
 // same periodic snapshot reconciliation used by web subscribers.
 type silentDecisionBackend struct{ Backend }
 
-func (b silentDecisionBackend) Publish(context.Context, Event) error { return nil }
+func (silentDecisionBackend) Publish(context.Context, Event) error { return nil }
 
 func TestDecisionOutputRecoversWithoutEndNotification(t *testing.T) {
 	backend := silentDecisionBackend{NewMemoryBackend()}

--- a/internal/agent/runtime/session/decision_output_test.go
+++ b/internal/agent/runtime/session/decision_output_test.go
@@ -1,0 +1,141 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	chatview "github.com/felinics/memoh/internal/agent/view"
+)
+
+func TestDecisionOutputSurvivesEarlyAcknowledgement(t *testing.T) {
+	for _, commandType := range []string{CommandUserInputResponse, CommandToolApprovalResponse} {
+		t.Run(commandType, func(t *testing.T) {
+			const (
+				sessionID  = "session-decision-route"
+				runID      = "run-decision-route"
+				turnID     = "run-decision-route-turn"
+				decisionID = "decision-route"
+				generation = "generation-decision-route"
+				token      = int64(7)
+			)
+			runs := newFakeLedger()
+			runs.insertClaimed(runID, sessionID, token, "live-generation")
+			if _, applied, err := runs.SetWaitingDecision(context.Background(), runID, token); err != nil || !applied {
+				t.Fatalf("park fake ledger run: applied=%v err=%v", applied, err)
+			}
+			backend := NewMemoryBackend()
+			manager := NewManager(backend, Options{Ledger: runs})
+			store := &fakeDecisionStore{target: DecisionTarget{
+				Type: commandType, ID: decisionID,
+				BotID: testBotID, SessionID: sessionID, RunID: runID, TurnID: turnID,
+				Status: "pending", FencingToken: token,
+			}}
+			manager.SetDecisionStore(store)
+
+			lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
+			defer lifecycleCancel()
+			ctrl := &runControl{
+				botID: testBotID, sessionID: sessionID, runID: runID,
+				generation: generation, fencingToken: token,
+				lifecycleCtx: lifecycleCtx, lifecycleCancel: lifecycleCancel,
+				converter: chatview.NewUIMessageStreamConverter(),
+				ready:     make(chan struct{}),
+			}
+			ctrl.markReady()
+			manager.controls[ctrl.key()] = ctrl
+			now := time.Now().UTC()
+			if _, changed, err := backend.Update(context.Background(), Key{BotID: testBotID, SessionID: sessionID}, func(snapshot Snapshot, _ bool) (Snapshot, bool, error) {
+				snapshot = EmptySnapshot(testBotID, sessionID)
+				snapshot.Epoch = "epoch-decision-route"
+				snapshot.CurrentRunView = &CurrentRunView{
+					RunID: runID, TurnID: turnID, Generation: generation,
+					Status: RunStatusWaitingDecision, StartedAt: now, UpdatedAt: now,
+					// Deliberately empty: decision routing must not depend on the live
+					// subscriber projection containing the pending request.
+					Messages: []chatview.UIMessage{},
+				}
+				return snapshot, true, nil
+			}); err != nil || !changed {
+				t.Fatalf("seed live run: changed=%v err=%v", changed, err)
+			}
+
+			t.Cleanup(func() { _ = manager.Close() })
+			var executions atomic.Int32
+			expected := []json.RawMessage{
+				json.RawMessage(`{"type":"text_delta","delta":"收到答案"}`),
+				json.RawMessage(`{"type":"user_input_request","userInputId":"next","status":"pending"}`),
+				json.RawMessage(`{"type":"agent_end","userInputId":"next","status":"pending"}`),
+			}
+			manager.SetCommandHandler(func(ctx context.Context, command Command) error {
+				executions.Add(1)
+				// Publish before acknowledgement: subscribing afterwards would lose all of it.
+				for i, raw := range expected {
+					if err := manager.PublishDecisionOutput(ctx, command, int64(i+1), raw); err != nil {
+						return err
+					}
+				}
+				return manager.PublishDecisionOutput(ctx, command, int64(len(expected)+1), nil)
+			})
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			response := DecisionResponse{ControlID: "control", Type: commandType, DecisionID: decisionID, BotID: testBotID, SessionID: sessionID, Payload: json.RawMessage(`{}`)}
+			output := make(chan json.RawMessage, 8)
+			result, err := manager.StreamDecisionResponse(ctx, response, output)
+			if err != nil || !result.Applied {
+				t.Fatalf("result=%+v error=%v", result, err)
+			}
+			for _, want := range expected {
+				select {
+				case got := <-output:
+					if string(got) != string(want) {
+						t.Fatalf("got %s want %s", got, want)
+					}
+				default:
+					t.Fatal("missing continuation event")
+				}
+			}
+			replay, err := manager.StreamDecisionResponse(ctx, response, output)
+			if err != nil || !replay.Replayed || executions.Load() != 1 || len(output) != 0 {
+				t.Fatalf("replay=%+v executions=%d error=%v", replay, executions.Load(), err)
+			}
+		})
+	}
+}
+
+func TestDecisionOutputTopicIsolation(t *testing.T) {
+	backend := NewMemoryBackend()
+	manager := NewManager(backend, Options{})
+	defer func() { _ = manager.Close() }()
+	ctx := context.Background()
+	key := decisionOutputKey("bot", "answer-a")
+	sub, err := backend.Subscribe(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Close()
+	for _, command := range []Command{{BotID: "other-bot", ID: "answer-a"}, {BotID: "bot", ID: "answer-b"}} {
+		if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	select {
+	case <-sub.C:
+		t.Fatal("unrelated answer leaked into subscription")
+	default:
+	}
+}
+
+func TestDecisionOutputCanceledSubscription(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	manager := NewManager(NewMemoryBackend(), Options{})
+	defer func() { _ = manager.Close() }()
+	_, err := manager.StreamDecisionResponse(ctx, DecisionResponse{BotID: "bot"}, make(chan json.RawMessage))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/internal/agent/runtime/session/decision_output_test.go
+++ b/internal/agent/runtime/session/decision_output_test.go
@@ -410,6 +410,52 @@ func TestDecisionOutputLogAppendContract(t *testing.T) {
 	}
 }
 
+// A backend read failure must surface immediately, not wait for the caller's
+// context: the channel needs to report the interruption while it still can.
+type failingReadDecisionBackend struct {
+	Backend
+	fail atomic.Bool
+}
+
+func (b *failingReadDecisionBackend) ReadDecisionOutput(ctx context.Context, ref DecisionOutputRef, from int) (DecisionOutputPage, error) {
+	if b.fail.Load() {
+		return DecisionOutputPage{}, errors.New("log unavailable")
+	}
+	return b.Backend.ReadDecisionOutput(ctx, ref, from)
+}
+
+func TestDecisionOutputReadFailureStopsReader(t *testing.T) {
+	backend := &failingReadDecisionBackend{Backend: NewMemoryBackend()}
+	manager := NewManager(backend, Options{})
+	defer func() { _ = manager.Close() }()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	command := Command{StreamOutput: true, BotID: "bot", ID: "unreadable"}
+	ref := decisionOutputRef(command.BotID, command.ID)
+	sub, err := backend.Subscribe(ctx, ref.topic())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sub.Close()
+	readDone := make(chan error, 1)
+	go func() {
+		readDone <- manager.readDecisionOutput(ctx, DecisionResponse{}, "", "", ref, sub, make(chan json.RawMessage, 1))
+	}()
+	time.Sleep(50 * time.Millisecond)
+	backend.fail.Store(true)
+	if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-readDone:
+		if err == nil || errors.Is(err, context.DeadlineExceeded) || err.Error() != "log unavailable" {
+			t.Fatalf("reader must return the read error, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("reader kept waiting after a failed log read")
+	}
+}
+
 // Both requests must pass the initial command-result lookup before either can
 // execute. Sequential retries would only exercise the existing replay shortcut.
 type concurrentDecisionStore struct {

--- a/internal/agent/runtime/session/decision_output_test.go
+++ b/internal/agent/runtime/session/decision_output_test.go
@@ -117,7 +117,7 @@ func TestDecisionOutputConcurrentRetriesAndEarlyAcknowledgement(t *testing.T) {
 			}
 			first, second := <-done, <-done
 			if first.err != nil || second.err != nil || !first.result.Applied || !second.result.Applied {
-				t.Fatalf("concurrent results: %+v %+v", first, second)
+				t.Fatalf("concurrent results: %+v %+v errs=%T/%v %T/%v", first, second, first.err, first.err, second.err, second.err)
 			}
 			if first.result.Replayed == second.result.Replayed || executions.Load() != 1 || len(output) != len(expected)+1 {
 				t.Fatalf("replayed=%v/%v executions=%d events=%d, want one consumer and %d events",
@@ -150,8 +150,7 @@ func TestDecisionOutputTopicIsolation(t *testing.T) {
 	manager := NewManager(backend, Options{})
 	defer func() { _ = manager.Close() }()
 	ctx := context.Background()
-	key := decisionOutputKey("bot", "answer-a")
-	sub, err := backend.Subscribe(ctx, key)
+	sub, err := backend.Subscribe(ctx, decisionOutputRef("bot", "answer-a").topic())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,8 +178,8 @@ func TestDecisionOutputCanceledSubscription(t *testing.T) {
 	}
 }
 
-// A successful write with every notification lost must still recover via the
-// same periodic snapshot reconciliation used by web subscribers.
+// A successful append with every wakeup lost must still be delivered: the
+// reader re-reads the log from its cursor on every reconciliation tick.
 type silentDecisionBackend struct{ Backend }
 
 func (silentDecisionBackend) Publish(context.Context, Event) error { return nil }
@@ -192,24 +191,31 @@ func TestDecisionOutputRecoversWithoutEndNotification(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
 	command := Command{StreamOutput: true, BotID: "bot", ID: "silent"}
-	key := decisionOutputKey(command.BotID, command.ID)
+	ref := decisionOutputRef(command.BotID, command.ID)
 	if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"one"}`)); err != nil {
 		t.Fatal(err)
 	}
-	sub, err := manager.Subscribe(ctx, key.BotID, key.SessionID)
+	sub, err := backend.Subscribe(ctx, ref.topic())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer sub.Close()
+	output := make(chan json.RawMessage, 2)
+	readDone := make(chan error, 1)
+	go func() { readDone <- manager.readDecisionOutput(ctx, DecisionResponse{}, "", "", ref, sub, output) }()
+	// The reader is already blocked on a wakeup that will never arrive.
+	time.Sleep(100 * time.Millisecond)
 	if err := manager.PublishDecisionOutput(ctx, command, 2, nil); err != nil {
 		t.Fatal(err)
 	}
-	output := make(chan json.RawMessage, 2)
-	if err := manager.readDecisionOutput(ctx, DecisionResponse{}, "", key, sub, output); err != nil {
+	if err := <-readDone; err != nil {
 		t.Fatal(err)
 	}
 	if len(output) != 1 {
 		t.Fatalf("recovered %d events", len(output))
+	}
+	if page, err := backend.ReadDecisionOutput(ctx, ref, 0); err != nil || !page.Done || page.Length != 0 {
+		t.Fatalf("finished log was not reclaimed: %+v err=%v", page.DecisionOutputState, err)
 	}
 }
 
@@ -223,7 +229,7 @@ func TestDecisionOutputStopsAfterOwnerRunTerminates(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			command := Command{StreamOutput: true, BotID: "bot", ID: "orphan", RunID: "run"}
-			key := decisionOutputKey(command.BotID, command.ID)
+			ref := decisionOutputRef(command.BotID, command.ID)
 			if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"partial"}`)); err != nil {
 				t.Fatal(err)
 			}
@@ -236,14 +242,18 @@ func TestDecisionOutputStopsAfterOwnerRunTerminates(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			sub, err := manager.Subscribe(ctx, key.BotID, key.SessionID)
+			sub, err := backend.Subscribe(ctx, ref.topic())
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer sub.Close()
-			err = manager.readDecisionOutput(ctx, DecisionResponse{BotID: "bot", SessionID: "session", DecisionID: "old-question"}, "run", key, sub, make(chan json.RawMessage, 2))
+			out := make(chan json.RawMessage, 2)
+			err = manager.readDecisionOutput(ctx, DecisionResponse{BotID: "bot", SessionID: "session", DecisionID: "old-question"}, "run", "", ref, sub, out)
 			if !errors.Is(err, io.ErrUnexpectedEOF) {
 				t.Fatalf("owner loss should release reader: %v", err)
+			}
+			if len(out) != 1 {
+				t.Fatalf("partial output before owner loss was not forwarded: %d", len(out))
 			}
 		})
 	}
@@ -269,7 +279,7 @@ func TestDecisionOutputRedisRecoveryAndClaimOptional(t *testing.T) {
 	consumer := NewManager(reader, Options{})
 	defer func() { _ = producer.Close(); _ = consumer.Close() }()
 	command := Command{StreamOutput: true, BotID: testBotID, ID: "answer"}
-	key := decisionOutputKey(command.BotID, command.ID)
+	ref := decisionOutputRef(command.BotID, command.ID)
 	if err := producer.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"first"}`)); err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +293,7 @@ func TestDecisionOutputRedisRecoveryAndClaimOptional(t *testing.T) {
 	for _, manager := range []*Manager{producer, consumer} {
 		go func() {
 			<-start
-			claimed, err := manager.claimDecisionOutput(ctx, key)
+			claimed, err := manager.backend.ClaimDecisionOutput(ctx, ref)
 			claims <- claimResult{claimed, err}
 		}()
 	}
@@ -292,7 +302,7 @@ func TestDecisionOutputRedisRecoveryAndClaimOptional(t *testing.T) {
 	if first.err != nil || second.err != nil || first.claimed == second.claimed {
 		t.Fatalf("expected exactly one Redis output consumer: %+v %+v", first, second)
 	}
-	sub, err := consumer.Subscribe(ctx, key.BotID, key.SessionID)
+	sub, err := reader.Subscribe(ctx, ref.topic())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,15 +320,18 @@ func TestDecisionOutputRedisRecoveryAndClaimOptional(t *testing.T) {
 	if err := producer.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if claimed, err := consumer.claimDecisionOutput(ctx, key); err != nil || claimed {
+	if claimed, err := reader.ClaimDecisionOutput(ctx, ref); err != nil || claimed {
 		t.Fatalf("output updates or publisher close lost the claim: claimed=%v err=%v", claimed, err)
 	}
 	out := make(chan json.RawMessage, 133)
-	if err := consumer.readDecisionOutput(ctx, DecisionResponse{}, "", key, sub, out); err != nil {
+	if err := consumer.readDecisionOutput(ctx, DecisionResponse{}, "", "", ref, sub, out); err != nil {
 		t.Fatal(err)
 	}
 	if len(out) != 133 {
 		t.Fatalf("recovered %d events", len(out))
+	}
+	if page, err := reader.ReadDecisionOutput(ctx, ref, 0); err != nil || !page.Done || !page.Claimed || page.Length != 0 {
+		t.Fatalf("finished Redis log was not reclaimed with its markers kept: %+v err=%v", page.DecisionOutputState, err)
 	}
 }
 
@@ -327,13 +340,73 @@ func TestDecisionOutputRetentionLimitIsExplicit(t *testing.T) {
 	m := NewManager(b, Options{})
 	defer func() { _ = m.Close() }()
 	command := Command{StreamOutput: true, BotID: "bot", ID: "limit"}
-	payload, _ := json.Marshal(strings.Repeat("x", decisionOutputMaxBytes))
+	payload, _ := json.Marshal(strings.Repeat("x", decisionOutputLimits.MaxBytes))
 	if err := m.PublishDecisionOutput(context.Background(), command, 1, payload); err == nil {
 		t.Fatal("oversized checkpoint accepted")
 	}
-	s, ok, err := b.Load(context.Background(), decisionOutputKey(command.BotID, command.ID))
-	if err != nil || !ok || s.DecisionOutput == nil || !s.DecisionOutput.Failed || len(s.DecisionOutput.Events) != 0 {
-		t.Fatalf("limit did not leave recoverable failure: %+v %v", s, err)
+	page, err := b.ReadDecisionOutput(context.Background(), decisionOutputRef(command.BotID, command.ID), 0)
+	if err != nil || !page.Exists || !page.Failed || page.Length != 0 {
+		t.Fatalf("limit did not leave recoverable failure: %+v %v", page.DecisionOutputState, err)
+	}
+	// A failed log refuses further appends instead of resuming silently.
+	if err := m.PublishDecisionOutput(context.Background(), command, 1, json.RawMessage(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+	if page, err := b.ReadDecisionOutput(context.Background(), decisionOutputRef(command.BotID, command.ID), 0); err != nil || page.Length != 0 {
+		t.Fatalf("failed log accepted an append: %+v %v", page.DecisionOutputState, err)
+	}
+}
+
+// Append is the only write; its idempotency and gap detection are what let the
+// producer retry a seq and let the reader trust Length as a cursor bound.
+func TestDecisionOutputLogAppendContract(t *testing.T) {
+	ctx := context.Background()
+	b := NewMemoryBackend()
+	ref := decisionOutputRef("bot", "contract")
+	limits := DecisionOutputLimits{MaxBytes: 1 << 10, MaxEvents: 3}
+	if page, err := b.ReadDecisionOutput(ctx, ref, 0); err != nil || page.Exists {
+		t.Fatalf("empty ref: %+v %v", page.DecisionOutputState, err)
+	}
+	if _, err := b.AppendDecisionOutput(ctx, ref, 2, json.RawMessage(`{}`), limits); !errors.Is(err, ErrDecisionOutputSequenceGap) {
+		t.Fatalf("gap accepted: %v", err)
+	}
+	first, err := b.AppendDecisionOutput(ctx, ref, 1, json.RawMessage(`{"n":1}`), limits)
+	if err != nil || !first.Applied || first.Length != 1 {
+		t.Fatalf("first append: %+v %v", first, err)
+	}
+	replay, err := b.AppendDecisionOutput(ctx, ref, 1, json.RawMessage(`{"n":"other"}`), limits)
+	if err != nil || replay.Applied || replay.Length != 1 {
+		t.Fatalf("replayed seq must be a no-op: %+v %v", replay, err)
+	}
+	if _, err := b.AppendDecisionOutput(ctx, ref, 2, json.RawMessage(`{"n":2}`), limits); err != nil {
+		t.Fatal(err)
+	}
+	page, err := b.ReadDecisionOutput(ctx, ref, 1)
+	if err != nil || len(page.Events) != 1 || string(page.Events[0]) != `{"n":2}` || page.Length != 2 {
+		t.Fatalf("read from cursor: %+v %v", page, err)
+	}
+	if claimed, err := b.ClaimDecisionOutput(ctx, ref); err != nil || !claimed {
+		t.Fatalf("first claim: %v %v", claimed, err)
+	}
+	if claimed, err := b.ClaimDecisionOutput(ctx, ref); err != nil || claimed {
+		t.Fatalf("second claim must lose: %v %v", claimed, err)
+	}
+	closed, err := b.AppendDecisionOutput(ctx, ref, 3, nil, limits)
+	if err != nil || !closed.Applied || !closed.Done || !closed.Claimed {
+		t.Fatalf("close: %+v %v", closed, err)
+	}
+	if after, err := b.AppendDecisionOutput(ctx, ref, 4, json.RawMessage(`{}`), limits); err != nil || after.Applied {
+		t.Fatalf("append after close must be ignored: %+v %v", after, err)
+	}
+	if err := b.ReleaseDecisionOutput(ctx, ref); err != nil {
+		t.Fatal(err)
+	}
+	// Entries are gone; the markers that guard against a second forwarder stay.
+	if page, err := b.ReadDecisionOutput(ctx, ref, 0); err != nil || page.Length != 0 || len(page.Events) != 0 || !page.Done || !page.Claimed {
+		t.Fatalf("released log: %+v %v", page.DecisionOutputState, err)
+	}
+	if claimed, err := b.ClaimDecisionOutput(ctx, ref); err != nil || claimed {
+		t.Fatalf("release must not reopen the claim: %v %v", claimed, err)
 	}
 }
 

--- a/internal/agent/runtime/session/decision_output_test.go
+++ b/internal/agent/runtime/session/decision_output_test.go
@@ -14,7 +14,7 @@ import (
 	chatview "github.com/felinics/memoh/internal/agent/view"
 )
 
-func TestDecisionOutputSurvivesEarlyAcknowledgement(t *testing.T) {
+func TestDecisionOutputConcurrentRetriesAndEarlyAcknowledgement(t *testing.T) {
 	for _, commandType := range []string{CommandUserInputResponse, CommandToolApprovalResponse} {
 		t.Run(commandType, func(t *testing.T) {
 			const (
@@ -37,7 +37,7 @@ func TestDecisionOutputSurvivesEarlyAcknowledgement(t *testing.T) {
 				BotID: testBotID, SessionID: sessionID, RunID: runID, TurnID: turnID,
 				Status: "pending", FencingToken: token,
 			}}
-			manager.SetDecisionStore(store)
+			manager.SetDecisionStore(&concurrentDecisionStore{fakeDecisionStore: store, ready: make(chan struct{})})
 
 			lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 			defer lifecycleCancel()
@@ -103,10 +103,25 @@ func TestDecisionOutputSurvivesEarlyAcknowledgement(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			response := DecisionResponse{ControlID: "control", Type: commandType, DecisionID: decisionID, BotID: testBotID, SessionID: sessionID, Payload: json.RawMessage(`{}`)}
-			output := make(chan json.RawMessage, len(expected)+1)
-			result, err := manager.StreamDecisionResponse(ctx, response, output)
-			if err != nil || !result.Applied {
-				t.Fatalf("result=%+v error=%v", result, err)
+			output := make(chan json.RawMessage, 2*(len(expected)+1))
+			type outcome struct {
+				result DecisionResponseResult
+				err    error
+			}
+			done := make(chan outcome, 2)
+			for i := 0; i < 2; i++ {
+				go func() {
+					result, err := manager.StreamDecisionResponse(ctx, response, output)
+					done <- outcome{result, err}
+				}()
+			}
+			first, second := <-done, <-done
+			if first.err != nil || second.err != nil || !first.result.Applied || !second.result.Applied {
+				t.Fatalf("concurrent results: %+v %+v", first, second)
+			}
+			if first.result.Replayed == second.result.Replayed || executions.Load() != 1 || len(output) != len(expected)+1 {
+				t.Fatalf("replayed=%v/%v executions=%d events=%d, want one consumer and %d events",
+					first.result.Replayed, second.result.Replayed, executions.Load(), len(output), len(expected)+1)
 			}
 			var accepted map[string]string
 			if err := json.Unmarshal(<-output, &accepted); err != nil || accepted["type"] != "decision_accepted" {
@@ -234,7 +249,7 @@ func TestDecisionOutputStopsAfterOwnerRunTerminates(t *testing.T) {
 	}
 }
 
-func TestDecisionOutputRedisRecoveryOptional(t *testing.T) {
+func TestDecisionOutputRedisRecoveryAndClaimOptional(t *testing.T) {
 	url := os.Getenv("MEMOH_TEST_REDIS_URL")
 	if url == "" {
 		t.Skip("set MEMOH_TEST_REDIS_URL for two-client Redis recovery")
@@ -258,6 +273,25 @@ func TestDecisionOutputRedisRecoveryOptional(t *testing.T) {
 	if err := producer.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"first"}`)); err != nil {
 		t.Fatal(err)
 	}
+	// Independent clients must arbitrate through Redis, not a manager-local lock.
+	type claimResult struct {
+		claimed bool
+		err     error
+	}
+	claims := make(chan claimResult, 2)
+	start := make(chan struct{})
+	for _, manager := range []*Manager{producer, consumer} {
+		go func() {
+			<-start
+			claimed, err := manager.claimDecisionOutput(ctx, key)
+			claims <- claimResult{claimed, err}
+		}()
+	}
+	close(start)
+	first, second := <-claims, <-claims
+	if first.err != nil || second.err != nil || first.claimed == second.claimed {
+		t.Fatalf("expected exactly one Redis output consumer: %+v %+v", first, second)
+	}
 	sub, err := consumer.Subscribe(ctx, key.BotID, key.SessionID)
 	if err != nil {
 		t.Fatal(err)
@@ -275,6 +309,9 @@ func TestDecisionOutputRedisRecoveryOptional(t *testing.T) {
 	// must finish from shared state without a single notification, including end.
 	if err := producer.Close(); err != nil {
 		t.Fatal(err)
+	}
+	if claimed, err := consumer.claimDecisionOutput(ctx, key); err != nil || claimed {
+		t.Fatalf("output updates or publisher close lost the claim: claimed=%v err=%v", claimed, err)
 	}
 	out := make(chan json.RawMessage, 133)
 	if err := consumer.readDecisionOutput(ctx, DecisionResponse{}, "", key, sub, out); err != nil {
@@ -298,4 +335,24 @@ func TestDecisionOutputRetentionLimitIsExplicit(t *testing.T) {
 	if err != nil || !ok || s.DecisionOutput == nil || !s.DecisionOutput.Failed || len(s.DecisionOutput.Events) != 0 {
 		t.Fatalf("limit did not leave recoverable failure: %+v %v", s, err)
 	}
+}
+
+// Both requests must pass the initial command-result lookup before either can
+// execute. Sequential retries would only exercise the existing replay shortcut.
+type concurrentDecisionStore struct {
+	*fakeDecisionStore
+	arrivals atomic.Int32
+	ready    chan struct{}
+}
+
+func (s *concurrentDecisionStore) ResolveRuntimeDecision(ctx context.Context, kind, id string) (DecisionTarget, error) {
+	if s.arrivals.Add(1) == 2 {
+		close(s.ready)
+	}
+	select {
+	case <-s.ready:
+	case <-ctx.Done():
+		return DecisionTarget{}, ctx.Err()
+	}
+	return s.fakeDecisionStore.ResolveRuntimeDecision(ctx, kind, id)
 }

--- a/internal/agent/runtime/session/decision_output_test.go
+++ b/internal/agent/runtime/session/decision_output_test.go
@@ -80,6 +80,18 @@ func TestDecisionOutputSurvivesEarlyAcknowledgement(t *testing.T) {
 			}
 			manager.SetCommandHandler(func(ctx context.Context, command Command) error {
 				executions.Add(1)
+				if !command.StreamOutput {
+					t.Fatal("streaming admission did not enable output on the owner command")
+				}
+				rawCommand, err := json.Marshal(command)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var routed Command
+				if err := json.Unmarshal(rawCommand, &routed); err != nil || !routed.StreamOutput {
+					t.Fatalf("routed output flag lost: %v", err)
+				}
+
 				// Publish before acknowledgement: subscribing afterwards would lose all of it.
 				for i, raw := range expected {
 					if err := manager.PublishDecisionOutput(ctx, command, int64(i+1), raw); err != nil {
@@ -129,7 +141,7 @@ func TestDecisionOutputTopicIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer sub.Close()
-	for _, command := range []Command{{BotID: "other-bot", ID: "answer-a"}, {BotID: "bot", ID: "answer-b"}} {
+	for _, command := range []Command{{StreamOutput: true, BotID: "other-bot", ID: "answer-a"}, {StreamOutput: true, BotID: "bot", ID: "answer-b"}} {
 		if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{}`)); err != nil {
 			t.Fatal(err)
 		}
@@ -164,7 +176,7 @@ func TestDecisionOutputRecoversWithoutEndNotification(t *testing.T) {
 	defer func() { _ = manager.Close() }()
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
-	command := Command{BotID: "bot", ID: "silent"}
+	command := Command{StreamOutput: true, BotID: "bot", ID: "silent"}
 	key := decisionOutputKey(command.BotID, command.ID)
 	if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"one"}`)); err != nil {
 		t.Fatal(err)
@@ -195,7 +207,7 @@ func TestDecisionOutputStopsAfterOwnerRunTerminates(t *testing.T) {
 			manager.SetDecisionStore(&fakeDecisionStore{target: DecisionTarget{ID: "next-question", RunID: "run", Status: "pending"}})
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			command := Command{BotID: "bot", ID: "orphan", RunID: "run"}
+			command := Command{StreamOutput: true, BotID: "bot", ID: "orphan", RunID: "run"}
 			key := decisionOutputKey(command.BotID, command.ID)
 			if err := manager.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"partial"}`)); err != nil {
 				t.Fatal(err)
@@ -241,7 +253,7 @@ func TestDecisionOutputRedisRecoveryOptional(t *testing.T) {
 	producer := NewManager(silentDecisionBackend{writer}, Options{})
 	consumer := NewManager(reader, Options{})
 	defer func() { _ = producer.Close(); _ = consumer.Close() }()
-	command := Command{BotID: testBotID, ID: "answer"}
+	command := Command{StreamOutput: true, BotID: testBotID, ID: "answer"}
 	key := decisionOutputKey(command.BotID, command.ID)
 	if err := producer.PublishDecisionOutput(ctx, command, 1, json.RawMessage(`{"type":"text_delta","delta":"first"}`)); err != nil {
 		t.Fatal(err)
@@ -277,7 +289,7 @@ func TestDecisionOutputRetentionLimitIsExplicit(t *testing.T) {
 	b := NewMemoryBackend()
 	m := NewManager(b, Options{})
 	defer func() { _ = m.Close() }()
-	command := Command{BotID: "bot", ID: "limit"}
+	command := Command{StreamOutput: true, BotID: "bot", ID: "limit"}
 	payload, _ := json.Marshal(strings.Repeat("x", decisionOutputMaxBytes))
 	if err := m.PublishDecisionOutput(context.Background(), command, 1, payload); err == nil {
 		t.Fatal("oversized checkpoint accepted")

--- a/internal/agent/runtime/session/manager.go
+++ b/internal/agent/runtime/session/manager.go
@@ -1975,7 +1975,7 @@ func (m *Manager) liveSnapshot(ctx context.Context, botID, sessionID string) (Sn
 // it would put a run back into the structure other reads treat as live — the
 // snapshot would stop being a report and start being a claim.
 func (m *Manager) hydrateSnapshotFromLedger(ctx context.Context, snapshot Snapshot) Snapshot {
-	if m.runs == nil || snapshot.CurrentRunView != nil {
+	if m.runs == nil || snapshot.CurrentRunView != nil || snapshot.DecisionOutput != nil {
 		return snapshot
 	}
 	sessionID := strings.TrimSpace(snapshot.SessionID)

--- a/internal/agent/runtime/session/manager.go
+++ b/internal/agent/runtime/session/manager.go
@@ -1975,7 +1975,7 @@ func (m *Manager) liveSnapshot(ctx context.Context, botID, sessionID string) (Sn
 // it would put a run back into the structure other reads treat as live — the
 // snapshot would stop being a report and start being a claim.
 func (m *Manager) hydrateSnapshotFromLedger(ctx context.Context, snapshot Snapshot) Snapshot {
-	if m.runs == nil || snapshot.CurrentRunView != nil || snapshot.DecisionOutput != nil {
+	if m.runs == nil || snapshot.CurrentRunView != nil {
 		return snapshot
 	}
 	sessionID := strings.TrimSpace(snapshot.SessionID)

--- a/internal/agent/runtime/session/memory.go
+++ b/internal/agent/runtime/session/memory.go
@@ -82,9 +82,13 @@ type MemoryBackend struct {
 	nextCleanup       time.Time
 	snapshots         map[string]Snapshot
 	snapshotExpiresAt map[string]time.Time
-	historyResets     map[string]ResetLease
-	subscribers       *subscriberSet[Event]
-	closed            bool
+	// decisionOutputs share the snapshot TTL but never the snapshot map: they
+	// are per-command event logs, not session state.
+	decisionOutputs         map[string]*memoryDecisionOutput
+	decisionOutputExpiresAt map[string]time.Time
+	historyResets           map[string]ResetLease
+	subscribers             *subscriberSet[Event]
+	closed                  bool
 	// generation is this process's liveness incarnation. It is minted once and
 	// never changes, so it dies with the heap that holds the live state.
 	generation string
@@ -99,12 +103,14 @@ func NewMemoryBackendWithTTL(stateTTL time.Duration) *MemoryBackend {
 		stateTTL = 24 * time.Hour
 	}
 	return &MemoryBackend{
-		stateTTL:          stateTTL,
-		snapshots:         make(map[string]Snapshot),
-		snapshotExpiresAt: make(map[string]time.Time),
-		historyResets:     make(map[string]ResetLease),
-		subscribers:       newSubscriberSet[Event](),
-		generation:        uuid.NewString(),
+		stateTTL:                stateTTL,
+		snapshots:               make(map[string]Snapshot),
+		snapshotExpiresAt:       make(map[string]time.Time),
+		decisionOutputs:         make(map[string]*memoryDecisionOutput),
+		decisionOutputExpiresAt: make(map[string]time.Time),
+		historyResets:           make(map[string]ResetLease),
+		subscribers:             newSubscriberSet[Event](),
+		generation:              uuid.NewString(),
 	}
 }
 
@@ -492,6 +498,14 @@ func (b *MemoryBackend) purgeExpiredLocked(now time.Time) {
 		return
 	}
 	nextCleanup := time.Time{}
+	for key, expiresAt := range b.decisionOutputExpiresAt {
+		if !now.Before(expiresAt) {
+			delete(b.decisionOutputs, key)
+			delete(b.decisionOutputExpiresAt, key)
+		} else if nextCleanup.IsZero() || expiresAt.Before(nextCleanup) {
+			nextCleanup = expiresAt
+		}
+	}
 	for key, expiresAt := range b.snapshotExpiresAt {
 		if !now.Before(expiresAt) {
 			if snapshot, ok := b.snapshots[key]; ok && snapshot.CurrentRunView != nil && isActiveRunStatus(snapshot.CurrentRunView.Status) {

--- a/internal/agent/runtime/session/memory_decision_output.go
+++ b/internal/agent/runtime/session/memory_decision_output.go
@@ -1,0 +1,127 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// memoryDecisionOutput is one command's append-only raw output log. Entries are
+// stored as the exact bytes the producer committed; readers receive copies.
+type memoryDecisionOutput struct {
+	events  []json.RawMessage
+	bytes   int
+	done    bool
+	failed  bool
+	claimed bool
+}
+
+func (l *memoryDecisionOutput) state() DecisionOutputState {
+	return DecisionOutputState{
+		Exists: true, Length: len(l.events), Bytes: l.bytes,
+		Done: l.done, Failed: l.failed, Claimed: l.claimed,
+	}
+}
+
+func (r DecisionOutputRef) String() string {
+	return r.topic().String()
+}
+
+func (b *MemoryBackend) decisionOutputLocked(ref DecisionOutputRef, now time.Time) *memoryDecisionOutput {
+	k := ref.String()
+	log, ok := b.decisionOutputs[k]
+	if !ok {
+		log = &memoryDecisionOutput{}
+		b.decisionOutputs[k] = log
+	}
+	b.decisionOutputExpiresAt[k] = now.Add(b.stateTTL)
+	b.scheduleCleanupLocked(b.decisionOutputExpiresAt[k])
+	return log
+}
+
+func (b *MemoryBackend) AppendDecisionOutput(ctx context.Context, ref DecisionOutputRef, seq int64, payload json.RawMessage, limits DecisionOutputLimits) (DecisionOutputState, error) {
+	if err := contextError(ctx); err != nil {
+		return DecisionOutputState{}, err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := time.Now()
+	b.purgeExpiredLocked(now)
+	log := b.decisionOutputLocked(ref, now)
+	state := log.state()
+	switch {
+	case log.done || log.failed:
+		return state, nil
+	case seq <= int64(len(log.events)):
+		return state, nil
+	case seq != int64(len(log.events))+1:
+		return state, ErrDecisionOutputSequenceGap
+	case payload == nil:
+		log.done = true
+	case exceedsDecisionOutputLimits(log.bytes, len(log.events), len(payload), limits):
+		log.failed = true
+		state = log.state()
+		state.Applied, state.Exceeded = true, true
+		return state, nil
+	default:
+		log.events = append(log.events, append(json.RawMessage(nil), payload...))
+		log.bytes += len(payload)
+	}
+	state = log.state()
+	state.Applied = true
+	return state, nil
+}
+
+func (b *MemoryBackend) ReadDecisionOutput(ctx context.Context, ref DecisionOutputRef, from int) (DecisionOutputPage, error) {
+	if err := contextError(ctx); err != nil {
+		return DecisionOutputPage{}, err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.purgeExpiredLocked(time.Now())
+	log, ok := b.decisionOutputs[ref.String()]
+	if !ok {
+		return DecisionOutputPage{}, nil
+	}
+	page := DecisionOutputPage{DecisionOutputState: log.state()}
+	if from < 0 {
+		from = 0
+	}
+	for _, raw := range log.events[min(from, len(log.events)):] {
+		page.Events = append(page.Events, append(json.RawMessage(nil), raw...))
+	}
+	return page, nil
+}
+
+func (b *MemoryBackend) ClaimDecisionOutput(ctx context.Context, ref DecisionOutputRef) (bool, error) {
+	if err := contextError(ctx); err != nil {
+		return false, err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := time.Now()
+	b.purgeExpiredLocked(now)
+	log := b.decisionOutputLocked(ref, now)
+	if log.claimed {
+		return false, nil
+	}
+	log.claimed = true
+	return true, nil
+}
+
+func (b *MemoryBackend) ReleaseDecisionOutput(ctx context.Context, ref DecisionOutputRef) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if log, ok := b.decisionOutputs[ref.String()]; ok {
+		log.events, log.bytes = nil, 0
+	}
+	return nil
+}
+
+func exceedsDecisionOutputLimits(bytes, events, next int, limits DecisionOutputLimits) bool {
+	return limits.MaxBytes > 0 && bytes+next > limits.MaxBytes ||
+		limits.MaxEvents > 0 && events >= limits.MaxEvents
+}

--- a/internal/agent/runtime/session/redis_decision_output.go
+++ b/internal/agent/runtime/session/redis_decision_output.go
@@ -1,0 +1,145 @@
+package sessionruntime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// The log is a Redis list plus a small hash of markers. One append is one RPUSH
+// and two HSETs evaluated atomically; the list is never rewritten. Both keys
+// carry the live-state TTL so an abandoned log expires with the run state.
+//
+// Result codes: 0 applied, 1 already terminal, 2 replayed seq, 3 sequence gap,
+// 4 limit exceeded (log marked failed).
+var appendRedisDecisionOutputScript = redis.NewScript(`
+local len = redis.call('LLEN', KEYS[1])
+local done = redis.call('HGET', KEYS[2], 'done') == '1'
+local failed = redis.call('HGET', KEYS[2], 'failed') == '1'
+local bytes = tonumber(redis.call('HGET', KEYS[2], 'bytes') or '0')
+local seq = tonumber(ARGV[1])
+local max_bytes = tonumber(ARGV[4])
+local max_events = tonumber(ARGV[5])
+local code
+if done or failed then
+  code = 1
+elseif seq <= len then
+  code = 2
+elseif seq ~= len + 1 then
+  code = 3
+elseif ARGV[3] == '1' then
+  redis.call('HSET', KEYS[2], 'done', '1')
+  done = true
+  code = 0
+elseif (max_bytes > 0 and bytes + #ARGV[2] > max_bytes) or (max_events > 0 and len >= max_events) then
+  redis.call('HSET', KEYS[2], 'failed', '1')
+  failed = true
+  code = 4
+else
+  redis.call('RPUSH', KEYS[1], ARGV[2])
+  len = len + 1
+  bytes = bytes + #ARGV[2]
+  redis.call('HSET', KEYS[2], 'bytes', bytes)
+  code = 0
+end
+redis.call('PEXPIRE', KEYS[1], ARGV[6])
+redis.call('PEXPIRE', KEYS[2], ARGV[6])
+local claimed = redis.call('HGET', KEYS[2], 'claimed') == '1'
+return {code, len, bytes, done and 1 or 0, failed and 1 or 0, claimed and 1 or 0}
+`)
+
+func (b *RedisBackend) decisionOutputListKey(ref DecisionOutputRef) string {
+	return b.keyPrefix + "decision_output:" + ref.String()
+}
+
+func (b *RedisBackend) decisionOutputMetaKey(ref DecisionOutputRef) string {
+	return b.keyPrefix + "decision_output_meta:" + ref.String()
+}
+
+func (b *RedisBackend) AppendDecisionOutput(ctx context.Context, ref DecisionOutputRef, seq int64, payload json.RawMessage, limits DecisionOutputLimits) (DecisionOutputState, error) {
+	closing := "0"
+	if payload == nil {
+		closing = "1"
+	}
+	raw, err := appendRedisDecisionOutputScript.Run(ctx, b.client,
+		[]string{b.decisionOutputListKey(ref), b.decisionOutputMetaKey(ref)},
+		seq, string(payload), closing, limits.MaxBytes, limits.MaxEvents, b.stateTTL.Milliseconds(),
+	).Int64Slice()
+	if err != nil {
+		return DecisionOutputState{}, err
+	}
+	if len(raw) != 6 {
+		return DecisionOutputState{}, fmt.Errorf("decision output append returned %d fields", len(raw))
+	}
+	state := DecisionOutputState{
+		Exists: true, Length: int(raw[1]), Bytes: int(raw[2]),
+		Done: raw[3] == 1, Failed: raw[4] == 1, Claimed: raw[5] == 1,
+	}
+	switch raw[0] {
+	case 0:
+		state.Applied = true
+	case 3:
+		return state, ErrDecisionOutputSequenceGap
+	case 4:
+		state.Applied, state.Exceeded = true, true
+	}
+	return state, nil
+}
+
+func (b *RedisBackend) ReadDecisionOutput(ctx context.Context, ref DecisionOutputRef, from int) (DecisionOutputPage, error) {
+	if from < 0 {
+		from = 0
+	}
+	listKey, metaKey := b.decisionOutputListKey(ref), b.decisionOutputMetaKey(ref)
+	var (
+		length *redis.IntCmd
+		meta   *redis.MapStringStringCmd
+		events *redis.StringSliceCmd
+	)
+	// MULTI/EXEC keeps length, markers and the tail consistent with each other;
+	// a reader must never see a Done marker without the entries before it.
+	if _, err := b.client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		length = pipe.LLen(ctx, listKey)
+		meta = pipe.HGetAll(ctx, metaKey)
+		events = pipe.LRange(ctx, listKey, int64(from), -1)
+		return nil
+	}); err != nil {
+		return DecisionOutputPage{}, err
+	}
+	fields := meta.Val()
+	page := DecisionOutputPage{DecisionOutputState: DecisionOutputState{
+		Exists:  length.Val() > 0 || len(fields) > 0,
+		Length:  int(length.Val()),
+		Done:    fields["done"] == "1",
+		Failed:  fields["failed"] == "1",
+		Claimed: fields["claimed"] == "1",
+	}}
+	if bytes, err := strconv.Atoi(fields["bytes"]); err == nil {
+		page.Bytes = bytes
+	}
+	for _, raw := range events.Val() {
+		page.Events = append(page.Events, json.RawMessage(raw))
+	}
+	return page, nil
+}
+
+func (b *RedisBackend) ClaimDecisionOutput(ctx context.Context, ref DecisionOutputRef) (bool, error) {
+	metaKey := b.decisionOutputMetaKey(ref)
+	var claimed *redis.BoolCmd
+	if _, err := b.client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		claimed = pipe.HSetNX(ctx, metaKey, "claimed", "1")
+		pipe.PExpire(ctx, metaKey, b.stateTTL)
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	return claimed.Val(), nil
+}
+
+func (b *RedisBackend) ReleaseDecisionOutput(ctx context.Context, ref DecisionOutputRef) error {
+	// The meta hash keeps its own TTL; only the entries are reclaimed.
+	return b.client.Del(ctx, b.decisionOutputListKey(ref)).Err()
+}

--- a/internal/agent/runtime/session/types.go
+++ b/internal/agent/runtime/session/types.go
@@ -314,6 +314,9 @@ type Event struct {
 	Snapshot  *Snapshot     `json:"snapshot,omitempty"`
 	Delta     *RuntimeDelta `json:"delta,omitempty"`
 	Message   string        `json:"message,omitempty"`
+
+	// Output is used only on the internal decision-output topic, never the UI topic.
+	Output json.RawMessage `json:"output,omitempty"`
 }
 
 // RuntimeDelta carries only the state changed by one committed runtime
@@ -441,6 +444,9 @@ type DecisionResponse struct {
 type DecisionResponseResult struct {
 	Handled bool
 	Applied bool
+
+	// Replayed acknowledges an earlier submission without rerunning its output.
+	Replayed bool
 }
 
 type Subscription struct {

--- a/internal/agent/runtime/session/types.go
+++ b/internal/agent/runtime/session/types.go
@@ -452,9 +452,11 @@ type DecisionResponse struct {
 // answer changed it". A resolved terminal decision is handled but not applied;
 // an unfenced ACP/MCP request is not handled and follows its existing path.
 type DecisionResponseResult struct {
-	RunID   string
-	Handled bool
-	Applied bool
+	SessionID  string
+	Generation string
+	RunID      string
+	Handled    bool
+	Applied    bool
 
 	// Replayed acknowledges an earlier submission without rerunning its output.
 	Replayed bool

--- a/internal/agent/runtime/session/types.go
+++ b/internal/agent/runtime/session/types.go
@@ -211,16 +211,28 @@ func (h RunHandle) key() Key {
 	return Key{BotID: h.BotID, SessionID: h.SessionID}
 }
 
+// DecisionOutputCheckpoint retains channel payloads using the same live-state
+// storage and gap recovery as web subscriptions. It expires with the backend
+// snapshot; it is not an external delivery receipt or a durable outbox.
+type DecisionOutputCheckpoint struct {
+	Offset int               `json:"offset,omitempty"`
+	Events []json.RawMessage `json:"events,omitempty"`
+	Done   bool              `json:"done,omitempty"`
+	Failed bool              `json:"failed,omitempty"`
+	Bytes  int               `json:"bytes,omitempty"`
+}
+
 // Snapshot is the authoritative live view of one session. It holds at most one
 // run: admission answers busy rather than queueing, so there is no pending list
 // to project and a subscriber never has to reason about work it cannot see yet.
 type Snapshot struct {
-	BotID          string          `json:"bot_id"`
-	SessionID      string          `json:"session_id"`
-	Epoch          string          `json:"epoch"`
-	Seq            int64           `json:"seq"`
-	CurrentRunView *CurrentRunView `json:"current_run_view,omitempty"`
-	UpdatedAt      time.Time       `json:"updated_at"`
+	DecisionOutput *DecisionOutputCheckpoint `json:"decision_output,omitempty" swaggerignore:"true"`
+	BotID          string                    `json:"bot_id"`
+	SessionID      string                    `json:"session_id"`
+	Epoch          string                    `json:"epoch"`
+	Seq            int64                     `json:"seq"`
+	CurrentRunView *CurrentRunView           `json:"current_run_view,omitempty"`
+	UpdatedAt      time.Time                 `json:"updated_at"`
 }
 
 // EmptySnapshot returns the canonical empty runtime snapshot for a session.
@@ -314,20 +326,18 @@ type Event struct {
 	Snapshot  *Snapshot     `json:"snapshot,omitempty"`
 	Delta     *RuntimeDelta `json:"delta,omitempty"`
 	Message   string        `json:"message,omitempty"`
-
-	// Output is used only on the internal decision-output topic, never the UI topic.
-	Output json.RawMessage `json:"output,omitempty"`
 }
 
 // RuntimeDelta carries only the state changed by one committed runtime
 // transition. Full snapshots are reserved for hydration and gap recovery.
 type RuntimeDelta struct {
-	CurrentRunView  *CurrentRunView         `json:"current_run_view,omitempty"`
-	Run             *CurrentRunPatch        `json:"run,omitempty"`
-	MessageAppends  []RuntimeMessageAppend  `json:"message_appends,omitempty"`
-	ProgressAppends []RuntimeProgressAppend `json:"progress_appends,omitempty"`
-	MessageUpserts  []chatview.UIMessage    `json:"message_upserts,omitempty"`
-	ResetMessages   bool                    `json:"reset_messages,omitempty"`
+	DecisionOutput  *DecisionOutputCheckpoint `json:"decision_output,omitempty" swaggerignore:"true"`
+	CurrentRunView  *CurrentRunView           `json:"current_run_view,omitempty"`
+	Run             *CurrentRunPatch          `json:"run,omitempty"`
+	MessageAppends  []RuntimeMessageAppend    `json:"message_appends,omitempty"`
+	ProgressAppends []RuntimeProgressAppend   `json:"progress_appends,omitempty"`
+	MessageUpserts  []chatview.UIMessage      `json:"message_upserts,omitempty"`
+	ResetMessages   bool                      `json:"reset_messages,omitempty"`
 }
 
 type CurrentRunPatch struct {
@@ -442,6 +452,7 @@ type DecisionResponse struct {
 // answer changed it". A resolved terminal decision is handled but not applied;
 // an unfenced ACP/MCP request is not handled and follows its existing path.
 type DecisionResponseResult struct {
+	RunID   string
 	Handled bool
 	Applied bool
 

--- a/internal/agent/runtime/session/types.go
+++ b/internal/agent/runtime/session/types.go
@@ -220,6 +220,10 @@ type DecisionOutputCheckpoint struct {
 	Done   bool              `json:"done,omitempty"`
 	Failed bool              `json:"failed,omitempty"`
 	Bytes  int               `json:"bytes,omitempty"`
+
+	// One accepted request owns forwarding for this command across all callers.
+	// Retain the claim until expiry; retries must not resend external messages.
+	Claimed bool `json:"claimed,omitempty"`
 }
 
 // Snapshot is the authoritative live view of one session. It holds at most one

--- a/internal/agent/runtime/session/types.go
+++ b/internal/agent/runtime/session/types.go
@@ -15,6 +15,9 @@ const (
 	EventRuntimeSnapshot = "runtime_snapshot"
 	EventRuntimeDelta    = "runtime_delta"
 	EventRuntimeDropped  = "runtime_dropped"
+	// EventDecisionOutput wakes a channel continuation reader. It carries no
+	// payload: the reader always resumes from its cursor in the output log.
+	EventDecisionOutput = "decision_output"
 
 	RunStatusRunning   = "running"
 	RunStatusAdmitting = "admitting"
@@ -211,32 +214,16 @@ func (h RunHandle) key() Key {
 	return Key{BotID: h.BotID, SessionID: h.SessionID}
 }
 
-// DecisionOutputCheckpoint retains channel payloads using the same live-state
-// storage and gap recovery as web subscriptions. It expires with the backend
-// snapshot; it is not an external delivery receipt or a durable outbox.
-type DecisionOutputCheckpoint struct {
-	Offset int               `json:"offset,omitempty"`
-	Events []json.RawMessage `json:"events,omitempty"`
-	Done   bool              `json:"done,omitempty"`
-	Failed bool              `json:"failed,omitempty"`
-	Bytes  int               `json:"bytes,omitempty"`
-
-	// One accepted request owns forwarding for this command across all callers.
-	// Retain the claim until expiry; retries must not resend external messages.
-	Claimed bool `json:"claimed,omitempty"`
-}
-
 // Snapshot is the authoritative live view of one session. It holds at most one
 // run: admission answers busy rather than queueing, so there is no pending list
 // to project and a subscriber never has to reason about work it cannot see yet.
 type Snapshot struct {
-	DecisionOutput *DecisionOutputCheckpoint `json:"decision_output,omitempty" swaggerignore:"true"`
-	BotID          string                    `json:"bot_id"`
-	SessionID      string                    `json:"session_id"`
-	Epoch          string                    `json:"epoch"`
-	Seq            int64                     `json:"seq"`
-	CurrentRunView *CurrentRunView           `json:"current_run_view,omitempty"`
-	UpdatedAt      time.Time                 `json:"updated_at"`
+	BotID          string          `json:"bot_id"`
+	SessionID      string          `json:"session_id"`
+	Epoch          string          `json:"epoch"`
+	Seq            int64           `json:"seq"`
+	CurrentRunView *CurrentRunView `json:"current_run_view,omitempty"`
+	UpdatedAt      time.Time       `json:"updated_at"`
 }
 
 // EmptySnapshot returns the canonical empty runtime snapshot for a session.
@@ -335,13 +322,12 @@ type Event struct {
 // RuntimeDelta carries only the state changed by one committed runtime
 // transition. Full snapshots are reserved for hydration and gap recovery.
 type RuntimeDelta struct {
-	DecisionOutput  *DecisionOutputCheckpoint `json:"decision_output,omitempty" swaggerignore:"true"`
-	CurrentRunView  *CurrentRunView           `json:"current_run_view,omitempty"`
-	Run             *CurrentRunPatch          `json:"run,omitempty"`
-	MessageAppends  []RuntimeMessageAppend    `json:"message_appends,omitempty"`
-	ProgressAppends []RuntimeProgressAppend   `json:"progress_appends,omitempty"`
-	MessageUpserts  []chatview.UIMessage      `json:"message_upserts,omitempty"`
-	ResetMessages   bool                      `json:"reset_messages,omitempty"`
+	CurrentRunView  *CurrentRunView         `json:"current_run_view,omitempty"`
+	Run             *CurrentRunPatch        `json:"run,omitempty"`
+	MessageAppends  []RuntimeMessageAppend  `json:"message_appends,omitempty"`
+	ProgressAppends []RuntimeProgressAppend `json:"progress_appends,omitempty"`
+	MessageUpserts  []chatview.UIMessage    `json:"message_upserts,omitempty"`
+	ResetMessages   bool                    `json:"reset_messages,omitempty"`
 }
 
 type CurrentRunPatch struct {
@@ -490,8 +476,75 @@ type Backend interface {
 	Update(ctx context.Context, key Key, update SnapshotUpdate) (Snapshot, bool, error)
 	Publish(ctx context.Context, event Event) error
 	Subscribe(ctx context.Context, key Key) (Subscription, error)
+	DecisionOutputStore
 	Close() error
 }
+
+// DecisionOutputRef identifies the raw output log of one accepted decision
+// command. Logs are keyed per command, not per session: one run can park on a
+// second question without ending, and successive answers must not share a
+// cursor.
+type DecisionOutputRef struct {
+	BotID     string
+	CommandID string
+}
+
+// topic is the pub/sub wakeup channel for one log. Nothing is stored under this
+// key; Manager.Subscribe must not be used with it because there is no snapshot
+// to reconcile against.
+func (r DecisionOutputRef) topic() Key {
+	return Key{BotID: r.BotID, SessionID: "decision-output/" + r.CommandID}
+}
+
+// DecisionOutputLimits bounds one log. Exceeding them marks the log failed
+// rather than silently truncating it; the producer reports the overflow.
+type DecisionOutputLimits struct {
+	MaxBytes  int
+	MaxEvents int
+}
+
+// DecisionOutputState is the log's committed position after an append or read.
+type DecisionOutputState struct {
+	Exists  bool
+	Length  int
+	Bytes   int
+	Done    bool
+	Failed  bool
+	Claimed bool
+	// Applied reports whether this append changed the log. Replays of an
+	// already-committed seq and writes after a terminal marker are no-ops.
+	Applied bool
+	// Exceeded reports that this append tripped the limits and failed the log.
+	Exceeded bool
+}
+
+// DecisionOutputPage is a read from a cursor to the current end of the log.
+type DecisionOutputPage struct {
+	DecisionOutputState
+	Events []json.RawMessage
+}
+
+// DecisionOutputStore is an append-only raw event log with the same
+// lifetime/TTL as live state. It is separate from Snapshot so session state
+// keeps one meaning and each append writes one entry, not the whole log.
+//
+// Append is idempotent by seq: seq must be Length+1 to apply; seq <= Length is
+// a replay and returns the current state; a larger seq is a gap and an error.
+// A nil payload closes the log (Done). Claim hands exclusive forwarding rights
+// to one caller across processes. Release drops the stored entries once they
+// are delivered but keeps the Done/Failed/Claimed markers until the TTL: a
+// retry that arrives after delivery must still lose the claim, never replay
+// the run's output to the channel a second time.
+type DecisionOutputStore interface {
+	AppendDecisionOutput(ctx context.Context, ref DecisionOutputRef, seq int64, payload json.RawMessage, limits DecisionOutputLimits) (DecisionOutputState, error)
+	ReadDecisionOutput(ctx context.Context, ref DecisionOutputRef, from int) (DecisionOutputPage, error)
+	ClaimDecisionOutput(ctx context.Context, ref DecisionOutputRef) (bool, error)
+	ReleaseDecisionOutput(ctx context.Context, ref DecisionOutputRef) error
+}
+
+// ErrDecisionOutputSequenceGap reports an append whose seq skips uncommitted
+// entries. The producer treats it as a failed checkpoint write.
+var ErrDecisionOutputSequenceGap = errors.New("decision output sequence gap")
 
 // DistributedBackend adds cross-process run ownership and command routing.
 // MemoryBackend intentionally does not implement this interface.

--- a/internal/agent/runtime/session/types.go
+++ b/internal/agent/runtime/session/types.go
@@ -384,6 +384,10 @@ type Command struct {
 	Error            string          `json:"error,omitempty"`
 	CreatedAt        time.Time       `json:"created_at"`
 	ExpiresAt        time.Time       `json:"expires_at,omitempty"`
+
+	// StreamOutput is fixed at admission and travels to the owner with the command.
+	// It must not depend on subscriber liveness: disconnecting cannot change a run.
+	StreamOutput bool `json:"stream_output,omitempty"`
 }
 
 // DecisionTarget is the durable identity of one approval or user-input
@@ -446,6 +450,9 @@ type DecisionResponse struct {
 	SessionID  string
 	RunID      string
 	Payload    json.RawMessage
+
+	// Only StreamDecisionResponse enables channel output capture.
+	streamOutput bool
 }
 
 // DecisionResponseResult separates "this is a runtime decision" from "the

--- a/internal/channel/inbound/channel.go
+++ b/internal/channel/inbound/channel.go
@@ -22,6 +22,7 @@ import (
 	agentfeedback "github.com/felinics/memoh/internal/agent/decision/feedback"
 	userinput "github.com/felinics/memoh/internal/agent/decision/input"
 	"github.com/felinics/memoh/internal/agent/turn"
+	"github.com/felinics/memoh/internal/apperror"
 	"github.com/felinics/memoh/internal/attachment"
 	"github.com/felinics/memoh/internal/auth"
 	"github.com/felinics/memoh/internal/bots"
@@ -424,6 +425,7 @@ func (p *ChannelInboundProcessor) HandleInbound(ctx context.Context, cfg channel
 	if sender == nil {
 		return errors.New("reply sender not configured")
 	}
+	sender = p.withDecisionReceipts(sender, cfg)
 	text := strings.TrimSpace(msg.Message.PlainText())
 	if p.logger != nil {
 		p.logger.Debug("inbound handle start",
@@ -3800,6 +3802,8 @@ func (p *ChannelInboundProcessor) streamUserInputResponseCommand(ctx context.Con
 type streamContinuationFunc func(context.Context, chan<- json.RawMessage) error
 
 func (p *ChannelInboundProcessor) streamContinuationCommand(ctx context.Context, msg channel.InboundMessage, sender channel.StreamReplySender, identity InboundIdentity, routeID string, run streamContinuationFunc) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	target := strings.TrimSpace(msg.ReplyTarget)
 	if target == "" {
 		return errors.New("reply target missing")
@@ -3850,11 +3854,24 @@ func (p *ChannelInboundProcessor) streamContinuationCommand(ctx context.Context,
 	}()
 
 	var finalMessages []turn.ModelMessage
+	var continuationErr error
+	accepted := false
 	for eventCh != nil || errCh != nil {
 		select {
 		case chunk, ok := <-eventCh:
 			if !ok {
 				eventCh = nil
+				continue
+			}
+			var receipt struct {
+				Type       string `json:"type"`
+				DecisionID string `json:"decision_id"`
+			}
+			if json.Unmarshal(chunk, &receipt) == nil && receipt.Type == "decision_accepted" {
+				accepted = true
+				if receiver, ok := sender.(interface{ AcceptDecision(context.Context, string) }); ok {
+					receiver.AcceptDecision(ctx, receipt.DecisionID)
+				}
 				continue
 			}
 			events, messages, parseErr := mapStreamChunkToChannelEvents(chunk)
@@ -3892,12 +3909,25 @@ func (p *ChannelInboundProcessor) streamContinuationCommand(ctx context.Context,
 				continue
 			}
 			if runErr != nil {
-				_ = stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventError, Error: runErr.Error()})
-				return runErr
+				continuationErr = runErr
 			}
 		}
 	}
 
+	if continuationErr != nil {
+		if !accepted {
+			_ = stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventError, Error: continuationErr.Error()})
+			return continuationErr
+		}
+		if p.logger != nil {
+			p.logger.Warn("accepted decision delivery interrupted", slog.Any("error", continuationErr))
+		}
+		public, _ := apperror.PublicFrom(apperror.Wrap(apperror.CodeAgentResponseInterrupted, continuationErr, nil), "")
+		if err := stream.Push(ctx, channel.StreamEvent{Type: channel.StreamEventError, Error: public.Detail}); err != nil {
+			return err
+		}
+		return closeStream()
+	}
 	sentTexts, suppressReplies := collectMessageToolContext(p.registry, finalMessages, msg.Channel, target)
 	if !suppressReplies {
 		outputs := turn.ExtractAssistantOutputs(finalMessages)

--- a/internal/channel/inbound/continuation_output_test.go
+++ b/internal/channel/inbound/continuation_output_test.go
@@ -1,0 +1,37 @@
+package inbound
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/felinics/memoh/internal/channel"
+)
+
+func TestContinuationForwardsReplyAndInteractiveFollowUp(t *testing.T) {
+	processor := NewChannelInboundProcessor(slog.Default(), nil, nil, nil, nil, nil, nil, "", 0)
+	sender := &fakeReplySender{}
+	msg := channel.InboundMessage{Channel: channel.ChannelType("telegram"), ReplyTarget: "test-chat", Message: channel.Message{ID: "answer"}}
+	err := processor.streamContinuationCommand(context.Background(), msg, sender, InboundIdentity{BotID: "bot"}, "", func(_ context.Context, ch chan<- json.RawMessage) error {
+		ch <- json.RawMessage(`{"type":"text_delta","delta":"收到你的答案"}`)
+		ch <- json.RawMessage(`{"type":"user_input_request","toolName":"ask_user","toolCallId":"second-call","userInputId":"second-question","status":"pending","metadata":{"ui_payload":{"version":2,"questions":[{"id":"q1","kind":"text","text":"接下来做什么？"}]}}}`)
+		ch <- json.RawMessage(`{"type":"agent_end","userInputId":"second-question","status":"pending"}`)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var text, question bool
+	for _, event := range sender.events {
+		if event.Type == channel.StreamEventDelta {
+			text = true
+		}
+		if isUserInputEvent(&event) && event.ToolCall.CallID == "second-call" {
+			question = true
+		}
+	}
+	if !text || !question {
+		t.Fatalf("reply=%v follow-up=%v events=%+v", text, question, sender.events)
+	}
+}

--- a/internal/channel/inbound/continuation_output_test.go
+++ b/internal/channel/inbound/continuation_output_test.go
@@ -3,7 +3,9 @@ package inbound
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/felinics/memoh/internal/channel"
@@ -33,5 +35,32 @@ func TestContinuationForwardsReplyAndInteractiveFollowUp(t *testing.T) {
 	}
 	if !text || !question {
 		t.Fatalf("reply=%v follow-up=%v events=%+v", text, question, sender.events)
+	}
+}
+
+func TestAcceptanceReceiptPrecedesFailedContinuation(t *testing.T) {
+	p := NewChannelInboundProcessor(slog.Default(), nil, nil, nil, nil, nil, nil, "", 0)
+	sink := &fakeReplySender{}
+	accepted := false
+	sender := decisionReplySender{StreamReplySender: sink, accepted: func(context.Context, string) { accepted = true }}
+	msg := channel.InboundMessage{Channel: channel.ChannelType("telegram"), ReplyTarget: "chat"}
+	err := p.streamContinuationCommand(context.Background(), msg, sender, InboundIdentity{BotID: "bot"}, "", func(_ context.Context, ch chan<- json.RawMessage) error {
+		ch <- json.RawMessage(`{"type":"decision_accepted","decision_id":"question"}`)
+		return errors.New("SECRET transport failure after acceptance")
+	})
+	if err != nil || !accepted {
+		t.Fatalf("accepted=%v err=%v", accepted, err)
+	}
+	found := false
+	for _, event := range sink.events {
+		if event.Type == channel.StreamEventError {
+			found = true
+			if strings.Contains(event.Error, "SECRET") {
+				t.Fatal("private cause leaked")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("missing output failure feedback")
 	}
 }

--- a/internal/channel/inbound/decision_receipt.go
+++ b/internal/channel/inbound/decision_receipt.go
@@ -1,0 +1,39 @@
+package inbound
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/felinics/memoh/internal/channel"
+	"github.com/felinics/memoh/internal/i18n"
+)
+
+// Acceptance is a control receipt, not model output. Keep the configuration at
+// ingress so the stream can refresh the original card before a slow continuation.
+type decisionReplySender struct {
+	channel.StreamReplySender
+	accepted func(context.Context, string)
+}
+
+func (s decisionReplySender) AcceptDecision(ctx context.Context, id string) { s.accepted(ctx, id) }
+
+func (p *ChannelInboundProcessor) withDecisionReceipts(sender channel.StreamReplySender, cfg channel.ChannelConfig) channel.StreamReplySender {
+	return decisionReplySender{StreamReplySender: sender, accepted: func(ctx context.Context, id string) {
+		if p.registry == nil {
+			return
+		}
+		adapter, ok := p.registry.Get(cfg.ChannelType)
+		if !ok {
+			return
+		}
+		updater, ok := adapter.(interface {
+			UpdateUserInputCard(context.Context, channel.ChannelConfig, string, *i18n.Localizer) (bool, error)
+		})
+		if !ok {
+			return
+		}
+		if _, err := updater.UpdateUserInputCard(ctx, cfg, id, p.localizer(ctx, cfg.BotID)); err != nil && p.logger != nil {
+			p.logger.Warn("refresh accepted decision card failed", slog.Any("error", err))
+		}
+	}}
+}


### PR DESCRIPTION
修复 ask_user / 工具审批接受后，后台继续运行但渠道收不到后续回复的问题。答案接受后立即回执并同步问题卡片，随后转发续跑文本、附件及下一张问题卡片；接受后的输出错误与答案提交失败分开反馈。

### 实现

- 按命令隔离原始输出追加日志：Memory 保存独立事件列表，Redis 使用 list + 元数据 hash，追加时不重写完整日志。仅渠道续跑启用，Web 保持原有消息投影路径。
- 订阅通知只负责唤醒；读取者按游标从日志恢复，定期读取补偿丢失通知。共享存储的独占消费权避免并发重复命令重复转发。
- 日志完成或显式失败后释放事件，保留消费权及终态标记至 TTL。读取失败立即退出并反馈中断。
- 运行归属及终态检查继续复用 Session Runtime。运行归属/fence 来源为 #865（207844099），finishing/finish retry 来源为 #1107（a23d24a1f）；Backend 及通知设施来源为 #800（47fd904d4）。本 PR 新增的追加日志和游标读取不属于原有 Snapshot 恢复算法。
- 不新增 PostgreSQL migration、SQL 查询、生成数据库代码或依赖。

### 与 #1156 及部署的关系

#1156 已先合入 main（29ddb19d8），负责答案接收、按钮 fence 和停止清理。本 PR head 968bc2888 已同步该 main。渠道错误处理冲突沿用已验证组合版本：提交前失败显示本地化提交错误，接受后失败显示输出中断。

Server / Channel 应协调更新；不要假定任意新旧混跑兼容。新 Channel 调用旧 Server 的 StopTurn 会返回 Unimplemented；旧 runtime owner 不支持渠道追加日志。上线及回滚均应暂停入口、处理在途输出并协调切换全部相关实例。回滚不撤销已提交答案或已取消问题。

### 成本和边界

每个命令最多保留 8 MiB、32768 条原始事件，超限显式中断，遗留日志沿用 Backend TTL。此日志不是持久化渠道 outbox，不承诺外部消息 exactly-once，也不承诺断线或进程重启后完整补发。Memory 进程丢失、Redis 状态丢失仍是恢复边界。

### 代码量自审

远端 base 29ddb19d8，head 968bc2888，按 base...head 统计：

| 分类 | 新增 | 删除 | 净变化 |
|---|---:|---:|---:|
| 全部 | 1386 | 31 | +1355 |
| 测试，含注释和空行 | 683 | 2 | +681 |
| 生产文件 | 703 | 29 | +674 |
| 生产代码，排除纯注释和空行 | 575 | 29 | +546 |
| 自动生成内容 | 0 | 0 | 0 |

没有独立批量机械变更；局部字段对齐仍计入生产行。新增生产代码主要用于两种 Backend 的追加/读取/消费权/释放、渠道日志读取、接受回执和中断处理。测试覆盖并发重试、输出突发、通知丢失、终态退出、存储失败、日志上限与释放、Web 隔离。少量问答/审批错误处理仍有重复，不为压行数扩大抽象。

自审修复：纯 Web 不再写渠道日志；并发重复提交只允许一个转发者；日志读取失败不再等待至请求超时。当前未发现新的已复现代码阻塞项。重点行为为渠道续跑、重复提交、停止等待及协调升级边界。

### 验证与真人 QA

组合源码 tree d1269ab 的全仓 go test ./... 通过；独立 PostgreSQL 的 fenced 问答持久化测试及既有 finishing migration 往返测试通过；独立 Redis 的通知丢失恢复、跨客户端消费权及释放测试通过。混合版本 RPC 测试确认旧 Run 兼容、新 Stop 对旧服务不兼容。本次同步 main 后，internal、cmd、db、go.mod、go.sum 与上述组合源码逐文件一致，保持这些验证的代码范围。

2026-09-06，用户在 @Memoh_test_bot 对组合版本明确确认真人 happy path 通过并提供截图：自由文字“0 点”提交后原样回复、原问题显示答案、再次提问后的选项答案与续跑回复送达。部署来源为 #1156 ec274d9f7 + #1159 1150071ca，版本 qa-1156-1159-latest。此次 main 同步保留已验证后端行为。

真人确认不覆盖 Other、多题、/stop、工具审批、群聊权限或跨实例故障恢复的完整人工验证；自动检查不替代这些人工项目。PR 最新 CI 由本次同步 main 后的检查结果单独确认。
