### PR TITLE
fix(web): 接住聊天输入框失焦时的文本输入

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -968,6 +968,7 @@ import { EFFORT_LABELS, REASONING_EFFORT_DISABLE, reconcileStoredEffort } from '
 import { useMediaGallery } from '../composables/useMediaGallery'
 import { ATTACHMENT_ANIM_MS, attachmentToFile, fileToAttachment, useComposerAttachments } from '../composables/useComposerAttachments'
 import { useComposerDrafts } from '../composables/useComposerDrafts'
+import { useUnfocusedComposerInput } from '../composables/useUnfocusedComposerInput'
 import { useComposerPair } from '../composables/useComposerPair'
 import { COMPOSER_MASK_BELOW_PX, useComposerLayout } from '../composables/useComposerLayout'
 import { provideChatViewTarget } from '../composables/useChatViewContext'
@@ -2654,6 +2655,12 @@ const {
 } = useComposerLayout({
   continueOnVisible: showComputersMenu,
   continueOnExpanded,
+})
+
+useUnfocusedComposerInput({
+  textarea: textareaEl,
+  enabled: () => isActive.value && isVisible.value,
+  onPaste: handlePaste,
 })
 
 const showSend = computed(() => Boolean(inputText.value.trim()) || pendingFiles.value.length > 0 || requestedSkills.value.length > 0)

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -2659,7 +2659,9 @@ const {
 
 useUnfocusedComposerInput({
   textarea: textareaEl,
-  enabled: () => isActive.value && isVisible.value,
+  // Settings keeps the dock mounted underneath its full-screen layer.
+  enabled: () => (router.currentRoute.value.name === 'home' || router.currentRoute.value.name === 'bot')
+    && isActive.value && isVisible.value,
   onPaste: handlePaste,
 })
 

--- a/apps/web/src/pages/home/composables/useUnfocusedComposerInput.test.ts
+++ b/apps/web/src/pages/home/composables/useUnfocusedComposerInput.test.ts
@@ -4,13 +4,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useUnfocusedComposerInput } from './useUnfocusedComposerInput'
 
 let cleanup: (() => void) | undefined
-function setup(enabled = true, onPaste = vi.fn()) {
+function setup(enabled: boolean | (() => boolean) = true, onPaste = vi.fn()) {
   const host = document.createElement('div')
   document.body.append(host)
   const app = createApp(defineComponent({
     setup() {
       const textarea = ref<HTMLTextAreaElement | null>(null)
-      useUnfocusedComposerInput({ textarea, enabled: () => enabled, onPaste })
+      useUnfocusedComposerInput({ textarea, enabled: () => typeof enabled === 'function' ? enabled() : enabled, onPaste })
       return () => h('textarea', { ref: textarea })
     },
   }))
@@ -106,6 +106,34 @@ describe('unfocused composer input', () => {
     document.body.dispatchEvent(event)
     expect(textarea.value).toBe('你好')
     expect(event.defaultPrevented).toBe(true)
+  })
+  it('stops capture when the application hides a still-mounted chat pane', () => {
+    let chatRoute = true
+    const textarea = setup(() => chatRoute)
+    chatRoute = false
+    expect(paste(document.body).defaultPrevented).toBe(false)
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }))
+    expect(document.activeElement).not.toBe(textarea)
+    expect(textarea.value).toBe('')
+    chatRoute = true
+    paste(document.body)
+    expect(textarea.value).toBe('Typeless')
+  })
+  it('allows AltGr text without treating Ctrl+Alt shortcuts as text', () => {
+    const textarea = setup()
+    const shortcut = new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, altKey: true, bubbles: true })
+    document.body.dispatchEvent(shortcut)
+    expect(document.activeElement).not.toBe(textarea)
+    const text = new KeyboardEvent('keydown', { key: '@', ctrlKey: true, altKey: true, bubbles: true })
+    vi.spyOn(text, 'getModifierState').mockImplementation(key => key === 'AltGraph')
+    document.body.dispatchEvent(text)
+    expect(document.activeElement).toBe(textarea)
+  })
+  it.each(['€', 'Dead'])('allows macOS Option-produced %s', (key) => {
+    vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel')
+    const textarea = setup()
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key, altKey: true, bubbles: true }))
+    expect(document.activeElement).toBe(textarea)
   })
   it('removes listeners on unmount', () => {
     const textarea = setup()

--- a/apps/web/src/pages/home/composables/useUnfocusedComposerInput.test.ts
+++ b/apps/web/src/pages/home/composables/useUnfocusedComposerInput.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { createApp, defineComponent, h, ref } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useUnfocusedComposerInput } from './useUnfocusedComposerInput'
+
+let cleanup: (() => void) | undefined
+function setup(enabled = true, onPaste = vi.fn()) {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const app = createApp(defineComponent({
+    setup() {
+      const textarea = ref<HTMLTextAreaElement | null>(null)
+      useUnfocusedComposerInput({ textarea, enabled: () => enabled, onPaste })
+      return () => h('textarea', { ref: textarea })
+    },
+  }))
+  app.mount(host)
+  const textarea = host.querySelector('textarea')!
+  vi.spyOn(textarea, 'getClientRects').mockReturnValue([{}] as unknown as DOMRectList)
+  cleanup = () => { app.unmount(); host.remove() }
+  return textarea
+}
+function paste(target: Element, text = 'Typeless') {
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', { value: { getData: () => text } })
+  target.dispatchEvent(event)
+  return event
+}
+afterEach(() => { cleanup?.(); document.body.replaceChildren(); vi.restoreAllMocks() })
+
+describe('unfocused composer input', () => {
+  it('focuses for printable typing without canceling native insertion', () => {
+    const textarea = setup()
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true })
+    document.body.dispatchEvent(event)
+    expect(document.activeElement).toBe(textarea)
+    expect(event.defaultPrevented).toBe(false)
+  })
+  it('inserts pasted text at the saved selection and notifies v-model', () => {
+    const textarea = setup()
+    textarea.value = 'hello world'
+    textarea.setSelectionRange(6, 11)
+    const input = vi.fn()
+    textarea.addEventListener('input', input)
+    expect(paste(document.body).defaultPrevented).toBe(true)
+    expect(textarea.value).toBe('hello Typeless')
+    expect(input).toHaveBeenCalledOnce()
+  })
+  it('preserves existing large-paste handling', () => {
+    const textarea = setup(true, vi.fn((event: Event) => event.preventDefault()))
+    paste(document.body)
+    expect(textarea.value).toBe('')
+  })
+  it.each(['input', 'textarea', '[contenteditable]', '[role="textbox"]', '.xterm'])('does not steal from %s', (selector) => {
+    const textarea = setup()
+    const owner = document.createElement(selector === 'input' || selector === 'textarea' ? selector : 'div')
+    if (selector === '[contenteditable]') owner.setAttribute('contenteditable', 'true')
+    if (selector === '[role="textbox"]') owner.setAttribute('role', 'textbox')
+    if (selector === '.xterm') owner.className = 'xterm'
+    document.body.append(owner)
+    expect(paste(owner).defaultPrevented).toBe(false)
+    expect(textarea.value).toBe('')
+  })
+  it('preserves the focused editor even when injected events target the body', () => {
+    const textarea = setup()
+    const input = document.createElement('input')
+    document.body.append(input)
+    input.focus()
+    expect(paste(document.body).defaultPrevented).toBe(false)
+    expect(textarea.value).toBe('')
+  })
+  it('ignores shortcuts and button activation', () => {
+    const textarea = setup()
+    const button = document.createElement('button')
+    document.body.append(button)
+    button.focus()
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, bubbles: true }))
+    expect(document.activeElement).toBe(button)
+    expect(textarea.value).toBe('')
+  })
+  it('does not capture behind an open overlay', () => {
+    const textarea = setup()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    document.body.append(dialog)
+    vi.spyOn(dialog, 'getClientRects').mockReturnValue([{}] as unknown as DOMRectList)
+    expect(paste(document.body).defaultPrevented).toBe(false)
+    expect(textarea.value).toBe('')
+  })
+  it('ignores inactive, disabled and hidden composers', () => {
+    const textarea = setup(false)
+    expect(paste(document.body).defaultPrevented).toBe(false)
+    expect(textarea.value).toBe('')
+    cleanup?.()
+    const active = setup()
+    active.disabled = true
+    expect(paste(document.body).defaultPrevented).toBe(false)
+    active.disabled = false
+    vi.mocked(active.getClientRects).mockReturnValue([] as unknown as DOMRectList)
+    expect(paste(document.body).defaultPrevented).toBe(false)
+  })
+  it('handles direct text insertion events once', () => {
+    const textarea = setup()
+    const event = new InputEvent('beforeinput', { inputType: 'insertText', data: '你好', bubbles: true, cancelable: true })
+    document.body.dispatchEvent(event)
+    expect(textarea.value).toBe('你好')
+    expect(event.defaultPrevented).toBe(true)
+  })
+  it('removes listeners on unmount', () => {
+    const textarea = setup()
+    cleanup?.()
+    cleanup = undefined
+    expect(paste(document.body).defaultPrevented).toBe(false)
+    expect(textarea.value).toBe('')
+  })
+})

--- a/apps/web/src/pages/home/composables/useUnfocusedComposerInput.ts
+++ b/apps/web/src/pages/home/composables/useUnfocusedComposerInput.ts
@@ -1,0 +1,74 @@
+import { onBeforeUnmount, onMounted, type Ref } from 'vue'
+
+const INPUT_OWNER = 'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="textbox"], [role="combobox"], [role="listbox"], [role="menu"], [role="tree"], [role="grid"], [role="slider"], [role="spinbutton"], .monaco-editor, .cm-editor, .xterm'
+const OPEN_OVERLAY = '[role="dialog"], [role="alertdialog"], [role="menu"], [role="listbox"]'
+
+/** Only the active chat pane may recover text that otherwise has no input owner. */
+export function useUnfocusedComposerInput(options: {
+  textarea: Ref<HTMLTextAreaElement | null>
+  enabled: () => boolean
+  onPaste: (event: ClipboardEvent) => void
+}) {
+  function destination(event: Event) {
+    const textarea = options.textarea.value
+    if (event.defaultPrevented || !options.enabled() || !textarea?.isConnected
+      || textarea.disabled || textarea.readOnly || !textarea.getClientRects().length) return null
+    if (document.activeElement?.closest(INPUT_OWNER)) return null
+    const path = event.composedPath()
+    if (path.some(node => node instanceof Element && node.closest(INPUT_OWNER))) return null
+    // Portalled overlays can own keyboard interaction even while focus is on a trigger.
+    if (Array.from(document.querySelectorAll<HTMLElement>(OPEN_OVERLAY))
+      .some(node => node.getClientRects().length && getComputedStyle(node).visibility !== 'hidden')) return null
+    return textarea
+  }
+
+  function insert(textarea: HTMLTextAreaElement, text: string) {
+    textarea.focus({ preventScroll: true })
+    textarea.setRangeText(text, textarea.selectionStart, textarea.selectionEnd, 'end')
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.ctrlKey || event.metaKey || event.altKey || event.isComposing) return
+    if (event.key.length !== 1 && event.key !== 'Process' && event.key !== 'Dead') return
+    // Space on a focused control belongs to that control, not the composer.
+    if (event.key === ' ' && event.composedPath().some(node => node instanceof Element
+      && node.closest('button, a, [role="button"], [role="checkbox"], [role="switch"]'))) return
+    const textarea = destination(event)
+    if (!textarea) return
+    // Keep the native default action: the browser inserts into the newly focused
+    // textarea, preserving IME/dead-key processing and the native undo stack.
+    textarea.focus({ preventScroll: true })
+  }
+
+  function onPaste(event: ClipboardEvent) {
+    const textarea = destination(event)
+    const text = event.clipboardData?.getData('text/plain')
+    if (!textarea || !text || !event.cancelable) return
+    textarea.focus({ preventScroll: true })
+    // Reuse attachment/large-paste policy before handling plain text ourselves.
+    options.onPaste(event)
+    if (event.defaultPrevented) return
+    event.preventDefault()
+    insert(textarea, text)
+  }
+
+  function onBeforeInput(event: InputEvent) {
+    if (event.isComposing || event.inputType !== 'insertText' || !event.data || !event.cancelable) return
+    const textarea = destination(event)
+    if (!textarea) return
+    event.preventDefault()
+    insert(textarea, event.data)
+  }
+
+  onMounted(() => {
+    document.addEventListener('keydown', onKeydown)
+    document.addEventListener('paste', onPaste)
+    document.addEventListener('beforeinput', onBeforeInput)
+  })
+  onBeforeUnmount(() => {
+    document.removeEventListener('keydown', onKeydown)
+    document.removeEventListener('paste', onPaste)
+    document.removeEventListener('beforeinput', onBeforeInput)
+  })
+}

--- a/apps/web/src/pages/home/composables/useUnfocusedComposerInput.ts
+++ b/apps/web/src/pages/home/composables/useUnfocusedComposerInput.ts
@@ -1,4 +1,5 @@
 import { onBeforeUnmount, onMounted, type Ref } from 'vue'
+import { detectPlatform } from '@/lib/keyboard-bindings'
 
 const INPUT_OWNER = 'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="textbox"], [role="combobox"], [role="listbox"], [role="menu"], [role="tree"], [role="grid"], [role="slider"], [role="spinbutton"], .monaco-editor, .cm-editor, .xterm'
 const OPEN_OVERLAY = '[role="dialog"], [role="alertdialog"], [role="menu"], [role="listbox"]'
@@ -29,7 +30,11 @@ export function useUnfocusedComposerInput(options: {
   }
 
   function onKeydown(event: KeyboardEvent) {
-    if (event.ctrlKey || event.metaKey || event.altKey || event.isComposing) return
+    if (event.metaKey || event.isComposing) return
+    // AltGr and macOS Option produce text; ordinary Ctrl/Alt shortcuts do not.
+    const altGraph = event.getModifierState('AltGraph')
+    const optionText = detectPlatform() === 'mac' && event.altKey && !event.ctrlKey
+    if ((event.ctrlKey || event.altKey) && !altGraph && !optionText) return
     if (event.key.length !== 1 && event.key !== 'Process' && event.key !== 'Dead') return
     // Space on a focused control belongs to that control, not the composer.
     if (event.key === ' ' && event.composedPath().some(node => node instanceof Element


### PR DESCRIPTION
## 问题与改动

聊天页焦点落在非输入区域时，直接打字或通过输入工具粘贴文本可能被丢弃。现在只有当前可见、激活且可编辑的聊天输入框会接收这类文本；不自动发送。

普通按键先恢复输入焦点并保留浏览器原生输入行为；页面收到的纯文本 paste / 可取消 insertText 事件写入草稿，粘贴复用现有大段文本与附件处理。其他输入框、编辑器、菜单、弹窗、快捷键和按钮空格激活不被接管，卸载时移除监听。

仅包含聊天输入逻辑与测试，不包含组件库、图标或样式改动。没有浏览器输入事件的操作系统注入无法由网页兜底；用户已在 18084 确认初版正常。随后补充设置页与特殊键盘字符的边界修复。

## 边界修复

- 仅在 home / bot 聊天路由启用捕获，避免设置页背后的常驻聊天区接收文本。
- 允许 AltGraph 与 macOS Option 产生字符，同时保留普通 Ctrl / Alt 快捷键。

## 验证

- 18 项针对性 Vitest 测试通过；相关 ESLint 和 diff 检查通过。
- AI 浏览器自检：真实按键首字符保留；失焦后的文本注入、页面纯文本粘贴进入输入框。未发送消息。
- AI 浏览器回归：设置页按键、粘贴不修改聊天草稿；返回聊天后 Option 字符 € 正常进入输入框。AltGr 由单元测试覆盖。
- 真人 QA：用户确认初版 bc01d4ccb 正常；新增边界修复尚未由真人复核。
- 整站 typecheck 未通过，存在当前基线的 UI `#` 路径别名及其他错误；未通过修改无关代码消除。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.

