### PR TITLE
feat(web): 支持用户消息 Markdown 渲染

### DIFF
--- a/apps/web/src/pages/home/components/collapsible-user-text.vue
+++ b/apps/web/src/pages/home/components/collapsible-user-text.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useResizeObserver } from '@vueuse/core'
-import { splitScriptRuns } from '@/utils/script-runs'
 
 // A long user prompt collapses to ~11 lines with a quiet text toggle in the
 // 12th line's place; expanded it shows everything plus "show less". The toggle
@@ -11,14 +10,10 @@ import { splitScriptRuns } from '@/utils/script-runs'
 const props = defineProps<{ text: string }>()
 const { t } = useI18n()
 
-// Per-script runs so CJK and Latin in the same prompt each take their own weight
-// (see .chat-cjk / .chat-latin in style.css). Joining the runs reproduces the
-// text verbatim, so white-space: pre-wrap still preserves newlines and spacing.
-const runs = computed(() => splitScriptRuns(props.text))
-
 const expanded = ref(false)
 const overflowing = ref(false)
 const textEl = useTemplateRef<HTMLElement>('textEl')
+const contentEl = useTemplateRef<HTMLElement>('contentEl')
 
 // Whether the full text exceeds the collapsed height is a property of the text
 // at the current width, so it is only meaningful while clamped — when expanded
@@ -33,31 +28,28 @@ function measure() {
 onMounted(() => nextTick(measure))
 watch(() => props.text, () => { expanded.value = false; nextTick(measure) })
 watch(expanded, (open) => { if (!open) nextTick(measure) })
-useResizeObserver(textEl, () => measure())
+// Markdown images, diagrams and highlighted code can finish after mount.
+// Observe the unclamped content too: the outer height stops changing at the cap.
+useResizeObserver([textEl, contentEl], () => measure())
 </script>
 
 <template>
   <div>
-    <!-- Collapsed clamp is a literal class so Tailwind's JIT actually emits it
-         (line-clamp-[11] = 11 visible lines; the toggle takes the 12th). Runs
-         are emitted with no whitespace between the <span> tags, so the pre-wrap
-         content stays free of injected whitespace. -->
-    <!-- eslint-disable vue/multiline-html-element-content-newline -- no breaks
-         between the tags and runs: under white-space: pre-wrap a source newline
-         would render as a literal blank line in the prompt. -->
+    <!-- A height cap also bounds block content such as tables and code fences,
+         which CSS line-clamp cannot reliably count as prose lines. -->
     <div
       ref="textEl"
-      class="whitespace-pre-wrap break-words"
-      :class="expanded ? '' : 'line-clamp-[11]'"
-    ><span
-      v-for="(run, i) in runs"
-      :key="i"
-      :class="run.script === 'cjk' ? 'chat-cjk' : 'chat-latin'"
-    >{{ run.text }}</span></div>
-    <!-- eslint-enable vue/multiline-html-element-content-newline -->
+      class="overflow-hidden break-words"
+      :class="expanded ? '' : 'max-h-[11lh]'"
+    >
+      <div ref="contentEl">
+        <slot />
+      </div>
+    </div>
     <button
       v-if="overflowing || expanded"
       type="button"
+      :aria-expanded="expanded"
       class="mt-0.5 cursor-pointer select-none text-[0.85em] text-muted-foreground transition-colors hover:text-foreground"
       @click="expanded = !expanded"
     >

--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -109,7 +109,7 @@
         <div
           v-else-if="isSkillActivationMessage || userBubbleText || message.forward || message.reply"
           :lang="contentLang(userBubbleText || skillActivationNames || skillActivationTitle)"
-          class="chat-user-bubble w-fit max-w-full bg-chat-user-bubble px-4 py-3 text-chat-user-bubble-fg whitespace-pre-wrap break-words"
+          class="chat-user-bubble w-fit max-w-full bg-chat-user-bubble px-4 py-3 text-chat-user-bubble-fg break-words"
           :class="userBubbleRadiusClass"
         >
           <div
@@ -182,7 +182,24 @@
             v-if="userBubbleText"
             :class="isSkillActivationMessage ? 'mt-2' : ''"
             :text="userBubbleText"
-          />
+          >
+            <MarkdownRender
+              :content="userBubbleText"
+              :is-dark="isDark"
+              mode="chat"
+              :final="true"
+              :smooth-streaming="false"
+              :typewriter="false"
+              :fade="false"
+              :batch-rendering="false"
+              :show-tooltips="false"
+              :mermaid-props="{ showTooltips: false }"
+              :code-block-dark-theme="codeBlockTheme.dark"
+              :code-block-light-theme="codeBlockTheme.light"
+              custom-id="chat-msg"
+              class="max-w-full whitespace-normal text-chat-user-bubble-fg! [&_.blockquote]:text-inherit! [&_.link-node]:text-inherit! [&_.link-node]:decoration-current! [&_p]:my-0! [&_p+p]:mt-2! [&>div:first-child>*:first-child]:mt-0! [&>div:last-child>*:last-child]:mb-0!"
+            />
+          </CollapsibleUserText>
         </div>
         <MessageActions
           v-if="!isEditingUserMessage"

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -708,6 +708,13 @@
   --inline-code-bg: oklch(0.24 0 0);
 }
 
+/* Inline code in a user bubble overlays that bubble's themed surface instead
+ * of introducing the neutral page surface used by assistant Markdown. */
+.chat-user-bubble .markstream-vue {
+  --inline-code-bg: var(--ui-hover);
+  --inline-code-fg: var(--chat-user-bubble-fg);
+}
+
 /* Full grid (Excel feel): both vertical + horizontal cell lines, but a finer/
  * lighter hairline than the outer frame so the grid is calm, not heavy. */
 .markstream-vue .table-node th,


### PR DESCRIPTION
用户发送的 Markdown 此前在聊天气泡中按纯文本显示，例如 `**重点**` 会直接显示星号。现在用户消息复用现有聊天 Markdown 渲染器，支持标题、强调、列表、引用、代码块、表格和链接，并沿用中英文混排组件。复制与编辑仍使用 Markdown 原文。

长消息保留展开/收起入口，折叠改用约 11 行的高度上限，以覆盖代码块和表格；同时观察内容高度变化，支持异步渲染后重新判断是否溢出。用户气泡内的引用和链接沿用气泡文字色，保证深色背景下可读。用户气泡内的行内代码使用现有半透明叠色 token 和气泡文字色，避免固定灰底与主题脱节。本次涉及两个前端组件及其颜色适配；正文排版优化留待后续 PR。

验证：
- `mise run lint` 通过（UI contract、全量 ESLint、Go lint）；最终颜色适配后重新通过相关 ESLint 与 UI contract。
- 提交钩子的 `go test ./...` 通过。
- Playwright 使用真实 MessageItem 的本地样例验证 Markdown 结构、中文/英文混排、深色 390px 窄屏、展开/收起、复制与编辑原文，以及切回短消息后的折叠状态。未向 Bot 发送测试消息，未验证完整发送/重载链路。
- 追加颜色验证：浅色/深色 × Memoh/Ocean/Forest 六种组合中，行内代码背景为主题叠色，文字色与气泡一致。
- `vue-tsc` 未通过：基线与本次改动均为相同的 446 条类型错误（比较时忽略行号变化），无新增错误。
- 独立前端 `http://127.0.0.1:8093`，代理现有 OSS 后端 `http://localhost:18080`；首页与 `/api/ping` 可达。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
