### PR TITLE
fix(web): 工具执行失败不再染红过程标题

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -972,6 +972,7 @@
         "apply_patch": "Applying patch"
       },
       "detail": {
+        "failed": "Tool execution failed.",
         "openInFiles": "Open in files",
         "input": "Input",
         "result": "Result",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -953,6 +953,7 @@
         "apply_patch": "パッチを適用中"
       },
       "detail": {
+        "failed": "ツールの実行に失敗しました。",
         "openInFiles": "ファイルで開く",
         "input": "入力",
         "result": "結果",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -972,6 +972,7 @@
         "apply_patch": "正在应用补丁"
       },
       "detail": {
+        "failed": "工具执行失败。",
         "openInFiles": "在文件中打开",
         "input": "输入",
         "result": "结果",

--- a/apps/web/src/pages/home/components/tool-call-detail-exec.vue
+++ b/apps/web/src/pages/home/components/tool-call-detail-exec.vue
@@ -7,6 +7,12 @@
       $ {{ command }}
     </div>
     <div
+      v-if="exitLabel"
+      class="text-muted-foreground"
+    >
+      {{ exitLabel }}
+    </div>
+    <div
       v-if="backgroundMeta.length"
       class="flex flex-wrap gap-x-2 gap-y-0.5 text-caption text-muted-foreground"
     >
@@ -67,6 +73,15 @@ function resolveResult(): Record<string, unknown> | null {
   const sc = result.structuredContent as Record<string, unknown> | undefined
   return sc ?? result
 }
+
+// 退出码属于按需查看的执行诊断，不应出现在工具标题中。
+const exitLabel = computed(() => {
+  if (!props.block.done) return ''
+  const result = resolveResult()
+  const code = result?.exit_code ?? result?.exitCode
+  return typeof code === 'number' && code !== 0
+    ? t('chat.tools.exitCode', { code }) : ''
+})
 
 const stdout = computed(() => {
   const r = resolveResult()

--- a/apps/web/src/pages/home/components/tool-call-detail-generic.vue
+++ b/apps/web/src/pages/home/components/tool-call-detail-generic.vue
@@ -31,6 +31,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ToolCallBlock } from '@/store/chat-list'
 import EmptyRow from './tool-detail/empty-row.vue'
+import { hasToolResultError, toolResultErrorText } from './tool-result-error'
 
 const props = defineProps<{ block: ToolCallBlock }>()
 const { t } = useI18n()
@@ -55,10 +56,7 @@ const inputEntries = computed(() => {
     .map(([k, v]) => ({ k, v: stringify(v) }))
 })
 
-const isError = computed(() => {
-  const r = props.block.result as Record<string, unknown> | null
-  return Boolean(r && r.isError === true)
-})
+const isError = computed(() => hasToolResultError(props.block))
 
 function extractText(): string {
   const r = props.block.result
@@ -77,6 +75,8 @@ function extractText(): string {
   return sc ? stringify(sc) : ''
 }
 
-const errorText = computed(() => (isError.value ? extractText() : ''))
+const errorText = computed(() => isError.value
+  ? toolResultErrorText(props.block.result) || t('chat.tools.detail.failed')
+  : '')
 const resultText = computed(() => (isError.value ? '' : extractText()))
 </script>

--- a/apps/web/src/pages/home/components/tool-call-inline.test.ts
+++ b/apps/web/src/pages/home/components/tool-call-inline.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { createApp, h, nextTick, reactive } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ToolCallBlock } from '@/store/chat-list'
+import en from '@/i18n/locales/en.json'
+import zh from '@/i18n/locales/zh.json'
+import ja from '@/i18n/locales/ja.json'
+
+vi.mock('@/i18n', () => ({
+  default: { global: { t: (key: string) => key } },
+  i18nRef: (key: string) => ({ value: key }),
+}))
+import ToolCallInline from './tool-call-inline.vue'
+
+const mounted: ReturnType<typeof createApp>[] = []
+afterEach(() => { for (const app of mounted.splice(0)) app.unmount() })
+let sequence = 0
+function mountTool(name: string, input: Record<string, unknown>, result: unknown, inGroup = false, locale = 'en') {
+  const id = ++sequence
+  const block = reactive<ToolCallBlock>({
+    id, type: 'tool', name, toolName: name, tool_call_id: `call-${id}`,
+    toolCallId: `call-${id}`, input, result, running: false, done: true,
+  })
+  const root = document.createElement('div')
+  const app = createApp({ render: () => h(ToolCallInline, { block, inGroup, messageId: `message-${id}` }) })
+  app.use(createI18n({ legacy: false, locale, messages: { en, zh, ja } }))
+  app.mount(root)
+  mounted.push(app)
+  return { root, block }
+}
+async function open(root: HTMLElement) {
+  const header = root.querySelector<HTMLElement>('.tool-header-row')
+  expect(header).not.toBeNull()
+  header!.click()
+  await nextTick()
+  expect(header!.getAttribute('aria-expanded')).toBe('true')
+  return header!
+}
+
+const failures = [
+  { isError: true, content: [{ type: 'text', text: 'Delivery unavailable' }] },
+  { structuredContent: { isError: true, content: [{ type: 'text', text: 'Delivery unavailable' }] } },
+  { structuredContent: { isError: true, message: 'Delivery unavailable' } },
+]
+describe.each([false, true])('tool failure detail (inGroup=%s)', (inGroup) => {
+  it.each(failures)('shows the search failure instead of an empty result: %j', async (result) => {
+    const { root } = mountTool('web_search', { query: 'review' }, result, inGroup)
+    expect(root.textContent).not.toContain('Delivery unavailable')
+    const header = await open(root)
+    expect(header.classList.contains('text-destructive')).toBe(false)
+    expect(header.textContent).not.toContain('Delivery unavailable')
+    expect(root.textContent).toContain('Delivery unavailable')
+    expect(root.textContent).not.toContain('No results')
+    expect(root.querySelector('.text-destructive')?.textContent).toContain('Delivery unavailable')
+  })
+  it('shows send failure together with the attempted input', async () => {
+    const { root } = mountTool('send', { text: 'attempted message' }, failures[0], inGroup)
+    await open(root)
+    expect(root.textContent).toContain('attempted message')
+    expect(root.textContent).toContain('Delivery unavailable')
+  })
+  it('lets an empty-content write expand when it failed', async () => {
+    const { root } = mountTool('write', { path: '/data/empty.txt', content: '' }, failures[0], inGroup)
+    await open(root)
+    expect(root.textContent).toContain('Delivery unavailable')
+  })
+})
+
+it.each([['en', 'Tool execution failed.'], ['zh', '工具执行失败。'], ['ja', 'ツールの実行に失敗しました。']])('localizes a failure without diagnostics (%s)', async (locale, text) => {
+  const { root } = mountTool('web_search', { query: 'review' }, { isError: true }, false, locale)
+  await open(root)
+  expect(root.textContent).toContain(text)
+})
+it('switches an open specialized detail when the streamed result completes', async () => {
+  const { root, block } = mountTool('web_search', { query: 'review' }, null)
+  block.running = true; block.done = false
+  await nextTick()
+  await open(root)
+  expect(root.textContent).toContain('No results')
+  block.result = failures[0]; block.running = false; block.done = true
+  await nextTick()
+  expect(root.textContent).toContain('Delivery unavailable')
+  expect(root.textContent).not.toContain('No results')
+})
+it('preserves successful search rendering even when its content mentions errors', async () => {
+  const { root } = mountTool('web_search', { query: 'errors' }, { isError: false, results: [{ title: 'Error handling guide', url: 'https://example.com/guide' }] })
+  await open(root)
+  expect(root.querySelector('a')?.textContent).toContain('Error handling guide')
+  expect(root.querySelector('.text-destructive')).toBeNull()
+})
+it.each([1, -1, 127])('keeps native exec exit %s and stderr in the exec detail', async (code) => {
+  const { root } = mountTool('exec', { command: 'false' }, { exit_code: code, stdout: 'output', stderr: 'diagnostic' })
+  const header = await open(root)
+  expect(header.textContent).not.toContain('exit')
+  expect(root.textContent).toContain(`exit ${code}`)
+  expect(root.textContent).toContain('output')
+  expect(root.querySelector('.text-destructive')?.textContent).toContain('diagnostic')
+})
+it('retains structured diagnostics alongside MCP error text', async () => {
+  const { root } = mountTool('exec', { command: 'false' }, { isError: true, content: [{ type: 'text', text: 'Command failed' }], structuredContent: { exit_code: 1, stderr: 'diagnostic' } })
+  await open(root)
+  expect(root.textContent).toContain('Command failed')
+  expect(root.textContent).toContain('"exit_code":1')
+  expect(root.textContent).toContain('diagnostic')
+})

--- a/apps/web/src/pages/home/components/tool-call-inline.vue
+++ b/apps/web/src/pages/home/components/tool-call-inline.vue
@@ -125,8 +125,8 @@
         class="mt-1.5 rounded-sm bg-card px-2.5 py-2 font-[400]"
       >
         <component
-          :is="display.detail"
-          v-if="display.detail"
+          :is="detailComponent"
+          v-if="detailComponent"
           :block="block"
         />
         <ToolCallDetailGeneric
@@ -140,8 +140,8 @@
         class="mt-1.5 font-[400]"
       >
         <component
-          :is="display.detail"
-          v-if="display.detail"
+          :is="detailComponent"
+          v-if="detailComponent"
           :block="block"
         />
         <ToolCallDetailGeneric
@@ -166,6 +166,7 @@ import {
 } from './tool-call-registry'
 import ConnectorLogo from './tool-detail/connector-logo.vue'
 import ToolCallDetailGeneric from './tool-call-detail-generic.vue'
+import { hasToolResultError } from './tool-result-error'
 import ToolCallDetailWrite from './tool-call-detail-write.vue'
 import CollapseSection from './collapse-section.vue'
 import { getCollapseOpen, setCollapseOpen, toolCollapseKey } from './process-collapse'
@@ -180,6 +181,10 @@ const openInFileManager = inject(openInFileManagerKey, undefined)
 
 const title = computed(() => getToolTitle(props.block, t))
 const display = computed(() => title.value.display)
+// Specialized panels describe successful results or attempted inputs. Failed
+// results use the shared diagnostic detail, without changing the neutral title.
+const resultFailed = computed(() => hasToolResultError(props.block))
+const detailComponent = computed(() => resultFailed.value ? ToolCallDetailGeneric : display.value.detail)
 
 // A Connect-It tool carries its binding's alias in the tool name; when that
 // alias resolves to one of the bot's connectors the row leads with its logo.
@@ -202,6 +207,7 @@ watch(collapseKey, (key) => {
 
 const expandable = computed(() => {
   if (isPending.value) return false
+  if (resultFailed.value) return true
   if (display.value.detail === ToolCallDetailWrite) {
     const input = props.block.input as Record<string, unknown> | undefined
     return (typeof input?.content === 'string' && input.content.length > 0)

--- a/apps/web/src/pages/home/components/tool-call-inline.vue
+++ b/apps/web/src/pages/home/components/tool-call-inline.vue
@@ -7,7 +7,6 @@
       v-if="expandable"
       :open="open"
       nested
-      :tone="display.isError ? 'error' : 'cop'"
       @toggle="toggleOpen"
     >
       <ConnectorLogo
@@ -47,10 +46,6 @@
         v-if="display.diffRemove"
         class="font-mono shrink-0 text-destructive"
       >-{{ display.diffRemove }}</span>
-      <span
-        v-if="exitLabel"
-        class="font-mono shrink-0"
-      >{{ exitLabel }}</span>
       <span
         v-if="approvalLabel"
         class="font-mono shrink-0 text-xs text-warning-foreground"
@@ -107,10 +102,6 @@
         v-if="display.diffRemove"
         class="font-mono shrink-0 text-destructive"
       >-{{ display.diffRemove }}</span>
-      <span
-        v-if="exitLabel"
-        class="font-mono shrink-0"
-      >{{ exitLabel }}</span>
       <span
         v-if="approvalLabel"
         class="font-mono shrink-0 text-xs text-warning-foreground"
@@ -219,25 +210,16 @@ const expandable = computed(() => {
   return Boolean(display.value.detail) || display.value.expandable === true
 })
 
-// A failed command carries its exit status on the collapsed row; every other
-// failure detail stays in the expanded output.
-const exitLabel = computed(() => (
-  display.value.exitCode ? t('chat.tools.exitCode', { code: display.value.exitCode }) : ''
-))
-
 const isPending = computed(() => title.value.pending)
 const showPendingLabel = computed(() => title.value.pending)
 const showActionLabel = computed(() => title.value.showAction)
 const renderedActionLabel = computed(() => title.value.action)
 
-// Every row is gray at rest and animates to near-black (foreground) on hover:
-// one neutral material, with color expressing interaction. Rest ink matches the
-// process/thinking headers (--cop-title) so a lone tool row and a collapsed
-// group read at the same weight.
-const rowClass = computed(() => {
-  if (display.value.isError) return 'text-destructive transition-colors duration-75'
-  return 'text-cop-title hover:text-foreground transition-colors duration-75'
-})
+// 工具标题是执行过程摘要。Agent 在虚拟机中试错、检查并修复命令是正常的
+// 长任务行为；非零退出码（包括 -1）或工具 isError 不等于用户任务失败。
+// 标题保持中性色，不附加退出码或错误染色；诊断留在展开详情中，真正的
+// 任务失败由回合级错误反馈表达，不能从某一次工具调用推导。
+const rowClass = 'text-cop-title hover:text-foreground transition-colors duration-75'
 
 // Brief tools (e.g. send/memory) finish in <100ms. Showing the running
 // shimmer for them flickers, so we only display it after a short delay.
@@ -272,7 +254,6 @@ onBeforeUnmount(clearRunningTimer)
 
 const targetClass = computed(() => {
   if (showRunning.value) return 'tool-shimmer-text'
-  if (display.value.isError) return 'text-destructive'
   return '' // inherit the row's gray→black hover color
 })
 

--- a/apps/web/src/pages/home/components/tool-call-registry.test.ts
+++ b/apps/web/src/pages/home/components/tool-call-registry.test.ts
@@ -148,14 +148,22 @@ describe('tool call registry', () => {
       .toBe('browserAction.scroll')
   })
 
-  it('marks failed calls, including a non-zero exec exit', () => {
-    expect(getToolDisplay(toolBlock('exec', { command: 'false' })).isError).toBeUndefined()
+  it.each([
+    { exit_code: -1 },
+    { exit_code: 1 },
+    { structuredContent: { exitCode: 127 } },
+    { isError: true },
+    { structuredContent: { isError: true, exit_code: -1 } },
+  ])('keeps recoverable execution failures out of the title: %j', (result) => {
+    const block = toolBlock('exec', { command: 'false', description: 'Check environment' })
+    const failed = { ...block, result } as ToolCallBlock
+    expect(getToolDisplay(failed)).toEqual(getToolDisplay(block))
+    expect(failed.result).toBe(result)
+  })
 
-    const failedExec = { ...toolBlock('exec', { command: 'false' }), result: { exit_code: 1 } } as ToolCallBlock
-    expect(getToolDisplay(failedExec).isError).toBe(true)
-    expect(getToolDisplay(failedExec).exitCode).toBe(1)
-
-    const failedTool = { ...toolBlock('web_search', { query: 'x' }), result: { isError: true } } as ToolCallBlock
-    expect(getToolDisplay(failedTool).isError).toBe(true)
+  it('keeps other tool failures in their details', () => {
+    const block = toolBlock('web_search', { query: 'x' })
+    expect(getToolDisplay({ ...block, result: { isError: true } } as ToolCallBlock))
+      .toEqual(getToolDisplay(block))
   })
 })

--- a/apps/web/src/pages/home/components/tool-call-registry.ts
+++ b/apps/web/src/pages/home/components/tool-call-registry.ts
@@ -109,9 +109,6 @@ export interface ToolDisplay {
   // is the channel for full content. Consumers bind `title` only when this is set.
   fullTarget?: string
   detail?: Component
-  isError?: boolean
-  // Non-zero exit of a finished exec; the row renders it through i18n.
-  exitCode?: number
   expandable?: boolean
   defaultOpen?: boolean
   diffAdd?: number
@@ -615,30 +612,9 @@ function guiActionVariant(action: string, input: Record<string, unknown>): strin
   return ''
 }
 
-// A result the runtime marked as failed. Kept separate from the per-tool
-// display so every tool — including ones with no dedicated case — renders its
-// failures in destructive ink instead of looking like a clean call.
-function isErrorResult(block: ToolCallBlock): boolean {
-  const result = asObject(block.result)
-  if (result.isError === true) return true
-  return asObject(result.structuredContent).isError === true
-}
-
-// A non-zero exit is the one machine-readable failure detail worth carrying on
-// the collapsed row; everything else stays in the expanded output.
-function execExitCode(block: ToolCallBlock): number {
-  return pickNumber(resultObject(block), 'exit_code', 'exitCode')
-}
-
+// 工具结果中的错误供 Agent 自行检查和恢复，不代表用户任务失败。
+// 不把 isError / 非零退出码提升成标题状态；原始结果仍交给详情组件展示。
 export function getToolDisplay(block: ToolCallBlock): ToolDisplay {
-  const display = resolveToolDisplay(block)
-  if (!block.done) return display
-  const exitCode = block.toolName === 'exec' ? execExitCode(block) : 0
-  if (!exitCode && !isErrorResult(block)) return display
-  return { ...display, isError: true, exitCode: exitCode || undefined }
-}
-
-function resolveToolDisplay(block: ToolCallBlock): ToolDisplay {
   const input = asObject(block.input)
 
   switch (block.toolName) {

--- a/apps/web/src/pages/home/components/tool-detail/header-row.vue
+++ b/apps/web/src/pages/home/components/tool-detail/header-row.vue
@@ -8,10 +8,9 @@
     to the majority: py-px, duration-75, unnamed `group`), so the hover chrome
     lives in the component instead of being injected onto it from a caller.
     Each caller keeps its own open/toggle state and slot content, and only
-    picks its rest-ink `tone` — the three tones map exactly to what each site
-    already used (cluster = muted-foreground rest; group/inline's non-error
-    rows = the shared --cop-title ink; inline's error row = destructive, which
-    never had a hover color-swap in the original).
+    picks its neutral rest-ink `tone`. Tool execution failures are recoverable
+    steps in an Agent turn, so process headers do not offer an error tone;
+    diagnostics belong in the expanded tool detail.
 
     `nested` picks the root tag: tool-call-inline's expandable row contains a
     real nested <button> (the "open in files" action), so ITS root can't also
@@ -39,7 +38,7 @@ import { computed } from 'vue'
 const props = withDefaults(defineProps<{
   open?: boolean
   nested?: boolean
-  tone?: 'muted' | 'cop' | 'error'
+  tone?: 'muted' | 'cop'
 }>(), {
   open: false,
   nested: false,
@@ -49,11 +48,9 @@ const emit = defineEmits<{ toggle: [] }>()
 
 // Hover is the component's own chrome, not a page injection — enumerated in
 // full per tone (never string-concatenated) so Tailwind's literal-text scan
-// picks up every combination. 'error' never had a hover swap in the original
-// three sites, so it stays a flat destructive ink.
+// picks up every combination.
 const toneClass = computed(() => {
   if (props.tone === 'muted') return 'text-muted-foreground hover:text-foreground' /* ui-allow-style */
-  if (props.tone === 'error') return 'text-destructive'
   return 'text-cop-title hover:text-foreground' /* ui-allow-style */
 })
 

--- a/apps/web/src/pages/home/components/tool-result-error.ts
+++ b/apps/web/src/pages/home/components/tool-result-error.ts
@@ -1,0 +1,37 @@
+import type { ToolCallBlock } from '@/store/chat-list'
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown> : {}
+}
+
+// This is the tool-result protocol flag, not a turn-level failure. Plain text
+// can also be a successful result; never infer failure from its wording.
+export function hasToolResultError(block: Pick<ToolCallBlock, 'done' | 'result'>): boolean {
+  if (!block.done) return false
+  const result = asObject(block.result)
+  return result.isError === true || asObject(result.structuredContent).isError === true
+}
+
+export function toolResultErrorText(result: unknown): string {
+  const outer = asObject(result)
+  const structured = asObject(outer.structuredContent)
+  const texts: string[] = []
+  for (const value of [outer.content, structured.content]) {
+    if (typeof value === 'string' && value.trim()) texts.push(value)
+    if (Array.isArray(value)) {
+      for (const part of value) {
+        const item = asObject(part)
+        if (item.type === 'text' && typeof item.text === 'string' && item.text.trim()) texts.push(item.text)
+      }
+    }
+  }
+  // Some tools return only structured diagnostics (error/message, exit status,
+  // stdout/stderr, etc.). Preserve those fields instead of showing an empty panel.
+  for (const value of [structured, outer]) {
+    const fields = Object.fromEntries(Object.entries(value)
+      .filter(([key]) => !['isError', 'content', 'structuredContent'].includes(key)))
+    if (Object.keys(fields).length) texts.push(JSON.stringify(fields))
+  }
+  return [...new Set(texts)].join('\n')
+}


### PR DESCRIPTION
Agent 在虚拟机里执行命令返回 `exit -1` 等非零退出码时，原实现会把整条工具标题染红，并把退出码附在标题后；其他工具的 `isError` 也会触发红色标题。单次调用失败是长任务中正常的检查、重试和修复过程，不能据此表示用户任务失败。

本次让独立工具行和组内工具行保持中性色，退出码移到展开的执行详情；保留原始结果及详情诊断，不改变工具执行、恢复或回合级错误反馈。删除共享标题组件的 error tone，并在标题和显示解析处写明设计理由，避免后续重新引入错误染色。多工具汇总标题原本就没有该染色逻辑。

验证：
- 相关文件 ESLint、`git diff --check` 通过。
- UI contract guard 通过；3 条既有警告位于本次未修改的文件。
- 更新 registry 测试，覆盖 `-1`、`1`、嵌套 `exitCode: 127`、顶层及嵌套 `isError`。本地测试未能执行：复用依赖指向另一 worktree 的 UI 版本，最终在 `#/lib/useScrollFade` 导入处失败；不声明测试通过。
- 未做浏览器视觉验证或人类 QA。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
