### PR TITLE
feat(web): onboarding 机器人名随机猫名预设 + 摇骰子重抽

### DIFF
--- a/apps/web/src/constants/bot-name-presets.ts
+++ b/apps/web/src/constants/bot-name-presets.ts
@@ -1,0 +1,19 @@
+// Preset bot names for users who don't want to invent one. Every entry is a
+// classic cat name (or the word/sound for "cat") in one of the product's
+// locales, so the list works untranslated across en/zh/ja.
+export const CAT_NAME_PRESETS = [
+  'Neko',
+  'Tama',
+  'Nyanko',
+  'Mimi',
+  'Miao',
+  'Kitty',
+] as const
+
+// Returns a random preset, never repeating `current` when it is one of the
+// presets, so re-rolling always produces a visible change.
+export function randomCatName(current?: string): string {
+  const trimmed = current?.trim()
+  const pool = CAT_NAME_PRESETS.filter(name => name !== trimmed)
+  return pool[Math.floor(Math.random() * pool.length)] ?? CAT_NAME_PRESETS[0]
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -3568,6 +3568,7 @@
       "title": "Create Your First Bot",
       "placeholder": "Bot creation coming soon.",
       "preparingEnvironment": "Preparing environment...",
+      "randomName": "Pick a random name",
       "model": {
         "selectPlaceholder": "Select a model",
         "hint": "Pick the model your bot replies with. Recommended, but you can change it anytime in settings.",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -3563,6 +3563,7 @@
       "title": "最初のBotを作成する",
       "placeholder": "Botの作成は近日開始予定です。",
       "preparingEnvironment": "環境を準備しています...",
+      "randomName": "ランダムに名前をつける",
       "model": {
         "selectPlaceholder": "モデルを選択してください",
         "hint": "Bot が応答に使用するモデルを選択します。推奨項目ですが、設定でいつでも変更できます。",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -3568,6 +3568,7 @@
       "title": "创建你的第一个 Bot",
       "placeholder": "Bot 创建即将推出。",
       "preparingEnvironment": "正在准备环境...",
+      "randomName": "随机取个名字",
       "model": {
         "selectPlaceholder": "选择模型",
         "hint": "选择 Bot 回复时使用的模型。建议现在选择，之后也可随时在设置中更改。",

--- a/apps/web/src/pages/onboarding/steps/Step4Bot.vue
+++ b/apps/web/src/pages/onboarding/steps/Step4Bot.vue
@@ -4,7 +4,10 @@ import {
   AvatarImage,
   AvatarFallback,
   Button,
-  Input,
+  InputGroup,
+  InputGroupInput,
+  InputGroupAddon,
+  InputGroupButton,
   Label,
   Separator,
   Spinner,
@@ -13,7 +16,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@felinic/ui'
-import { SquarePen, CircleHelp, Bot } from 'lucide-vue-next'
+import { SquarePen, CircleHelp, Bot, Dices } from 'lucide-vue-next'
 import { ref, reactive, computed, watch } from 'vue'
 import { FieldStack, InlineLoadingRow, toast } from '@felinic/ui'
 import { useI18n } from 'vue-i18n'
@@ -24,6 +27,7 @@ import { storeToRefs } from 'pinia'
 import { useOnboarding } from '@/composables/useOnboarding'
 import { useAvatarInitials } from '@/composables/useAvatarInitials'
 import { defaultAclPreset } from '@/constants/acl-presets'
+import { randomCatName } from '@/constants/bot-name-presets'
 import { acpAgentDisplayName, normalizeACPAgentID, withACPMetadata, type ACPForm } from '@/utils/acp'
 import { BOT_AGENT_RUNTIME_CLAUDE_CODE, BOT_AGENT_RUNTIME_CODEX, directBotAgentMetadata } from '@/utils/bot-agent'
 import { useBotCreateProgressStore } from '@/store/bot-create-progress'
@@ -81,7 +85,9 @@ const selectedAcpProfile = computed<AcpprofilePublicProfile | null>(() => {
 const onboardingProviderId = readOnboardingProviderId()
 
 const form = reactive({
-  display_name: '',
+  // Prefill with a random cat-name preset so naming isn't a blocker; the dice
+  // button re-rolls. Runs once per mount — a user-cleared field stays empty.
+  display_name: randomCatName(),
   avatar_url: '',
   chat_model_id: '',
   memory_provider_id: '',
@@ -89,6 +95,10 @@ const form = reactive({
 
 const avatarDialogOpen = ref(false)
 const avatarFallback = useAvatarInitials(() => form.display_name || '')
+
+function rollRandomName() {
+  form.display_name = randomCatName(form.display_name)
+}
 
 const { data: memoryProviderData } = useQuery({
   key: ['memory-providers'],
@@ -361,11 +371,25 @@ async function handleSubmit() {
                         >*</span>
                       </Label>
                     </template>
-                    <Input
-                      v-model="form.display_name"
-                      type="text"
-                      :placeholder="$t('bots.displayNamePlaceholder')"
-                    />
+                    <InputGroup class="overflow-hidden">
+                      <InputGroupInput
+                        v-model="form.display_name"
+                        type="text"
+                        :placeholder="$t('bots.displayNamePlaceholder')"
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          variant="quiet"
+                          type="button"
+                          :aria-label="$t('onboarding.bot.randomName')"
+                          :title="$t('onboarding.bot.randomName')"
+                          @click="rollRandomName"
+                        >
+                          <Dices />
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
                   </FieldStack>
                 </div>
               </div>

--- a/internal/bots/service.go
+++ b/internal/bots/service.go
@@ -289,10 +289,14 @@ func (s *Service) nameTaken(ctx context.Context, normalized, excludeBotID string
 }
 
 // resolveName validates and (when empty) derives a bot name from displayName,
-// then ensures it is unique. excludeBotID is ignored during uniqueness checks.
+// then ensures it is unique. A derived name that collides gets a numeric
+// suffix (neko-2, neko-3, ...) instead of failing: the caller never picked a
+// slug, so a slug collision is not theirs to fix. An explicitly requested
+// name still fails with ErrBotNameTaken when taken.
 func (s *Service) resolveName(ctx context.Context, rawName, displayName, excludeBotID string) (string, error) {
 	normalized := normalizeName(rawName)
-	if normalized == "" {
+	derived := normalized == ""
+	if derived {
 		normalized = slugify(displayName)
 	}
 	switch validateNameFormat(normalized) {
@@ -305,10 +309,24 @@ func (s *Service) resolveName(ctx context.Context, rawName, displayName, exclude
 	if err != nil {
 		return "", err
 	}
-	if taken {
+	if !taken {
+		return normalized, nil
+	}
+	if !derived {
 		return "", ErrBotNameTaken
 	}
-	return normalized, nil
+	// slugify clamps to 48 chars, so any suffix keeps the candidate within
+	// the 63-char format limit.
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", normalized, i)
+		taken, err := s.nameTaken(ctx, candidate, excludeBotID)
+		if err != nil {
+			return "", err
+		}
+		if !taken {
+			return candidate, nil
+		}
+	}
 }
 
 // ListByOwner returns bots owned by the given user.

--- a/internal/bots/service_test.go
+++ b/internal/bots/service_test.go
@@ -543,3 +543,45 @@ func decodePersistedMetadata(t *testing.T, payload []byte) map[string]any {
 	}
 	return metadata
 }
+
+func TestResolveNameSuffixesDerivedNameCollisions(t *testing.T) {
+	taken := map[string]bool{"neko": true, "neko-2": true}
+	ownerUUID := mustParseUUID("00000000-0000-0000-0000-000000000001")
+
+	dbtx := &fakeDBTX{
+		queryRowFunc: func(_ context.Context, sql string, args ...any) pgx.Row {
+			if strings.Contains(sql, "FROM bots") && strings.Contains(sql, "name = $1") {
+				name, _ := args[0].(string)
+				if taken[name] {
+					return makeBotRow(mustParseUUID("00000000-0000-0000-0000-0000000000aa"), ownerUUID)
+				}
+			}
+			return &fakeRow{scanFunc: func(_ ...any) error { return pgx.ErrNoRows }}
+		},
+	}
+
+	svc := NewService(nil, postgresstore.NewQueries(sqlc.New(dbtx)))
+
+	// Derived names walk suffixes until free.
+	got, err := svc.resolveName(context.Background(), "", "Neko", "")
+	if err != nil {
+		t.Fatalf("resolveName derived: %v", err)
+	}
+	if got != "neko-3" {
+		t.Fatalf("expected neko-3, got %q", got)
+	}
+
+	// Free derived names stay unsuffixed.
+	got, err = svc.resolveName(context.Background(), "", "Mimi", "")
+	if err != nil {
+		t.Fatalf("resolveName free derived: %v", err)
+	}
+	if got != "mimi" {
+		t.Fatalf("expected mimi, got %q", got)
+	}
+
+	// Explicitly requested names still fail when taken.
+	if _, err := svc.resolveName(context.Background(), "neko", "", ""); !errors.Is(err, ErrBotNameTaken) {
+		t.Fatalf("expected ErrBotNameTaken, got %v", err)
+	}
+}


### PR DESCRIPTION
## 背景

Onboarding 的 Bot 名字是必填项,起名困难的用户会卡在这一步甚至流失。与其让用户的第一个决策是"想一个名字",不如直接给一个。

## 改动

- 新增 `apps/web/src/constants/bot-name-presets.ts`:6 个猫名预设(Neko / Tama / Nyanko / Mimi / Miao / Kitty)——每个都是产品三语言(en/zh/ja)里最经典的猫名或"猫"的叫法,所以名单无需翻译、全 locale 通用。`randomCatName()` 重抽时排除当前值,保证每次重摇都有可见变化。
- `Step4Bot.vue`:进入步骤即预填一个随机名字(挂载时跑一次,不覆盖用户输入;手动清空后保持空,必填校验不变);输入框右侧内嵌骰子(`Dices`)按钮可重抽,复用 `InputGroup`/`InputGroupButton` 既有模式(同 password-input),无新增样式。
- en / zh / ja 三个 locale 各加 `onboarding.bot.randomName`。

## 验证

- eslint 过、三个 locale JSON 合法、vite 代理自检通过
- 本地 dev 栈(18080)走 onboarding 实测:预填出现、骰子重抽不重复、清空后必填星标照常显示

## 后续:派生 slug 撞车修复(Codex review P1)

review 发现:bot `name`(slug)从 `display_name` 派生且 team 级唯一,预填猫名会让第二个撞名的团队成员创建失败(`ErrBotNameTaken`),预设占满后默认路径 100% 失败。

修复(`internal/bots/service.go` `resolveName`):**行为变化** —— 创建/更新时不传 `name`(即 slug 为派生)且被撞时,不再报错,自动追加数字后缀(`neko-2` / `neko-3` …);显式传入 `name` 撞车仍返回 `ErrBotNameTaken`。理由:用户没选择过 slug,slug 撞车不应由用户承担。新增 `TestResolveNameSuffixesDerivedNameCollisions` 覆盖派生加后缀 / 空闲不加后缀 / 显式撞名仍报错三条路径,`internal/bots` 包测试全绿。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
