### PR TITLE
fix(web): #1179 后续修复——mic 曲线、scrollend 兜底、composer 导航门与消息骨架屏

### DIFF
--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -1258,7 +1258,15 @@ const isWelcome = computed(() =>
 // from the first frame, so this gate never engages on session routes.
 const composerPlacementPending = computed(() => loadingChats.value && !hasRenderedSession.value)
 const composerPlacementEl = useTemplateRef<HTMLElement>('composerPlacementEl')
-useComposerPlacementMotion(composerPlacementEl, isWelcome)
+// Armed by handleSend when the send leaves from welcome; consumed on the
+// welcome→chat flip. Without an armed send the flip is navigation, and the
+// composer just lands docked with the rest of the pane.
+const welcomeSendMotionArmed = ref(false)
+useComposerPlacementMotion(composerPlacementEl, isWelcome, () => {
+  const armed = welcomeSendMotionArmed.value
+  welcomeSendMotionArmed.value = false
+  return armed
+})
 
 // Rotate the greeting per fresh chat so the entry point feels alive rather than
 // a fixed banner; the pick stays stable while a single welcome screen is shown
@@ -3590,6 +3598,7 @@ async function handleSend() {
   const sentReasoningEffort = pairSend.pair.reasoningEffort
   const sentWorkspaceTargetId = sendWorkspaceTargetId.value
   const preserveDirectDraftSelection = activeUsesDirectRuntime.value && !sentContext.target.sessionId
+  welcomeSendMotionArmed.value = isWelcome.value
   composerError.value = ''
   inputText.value = ''
   saveInputDraft(sentDraftKey, '')
@@ -3650,6 +3659,11 @@ async function handleSend() {
     pairSend.releaseReads()
   })
   rollbackPin = null
+  // A send that never promoted the draft (command-only, or failed before the
+  // turn) leaves the motion armed; disarm so a later navigation can't inherit it.
+  void nextTick(() => {
+    if (isWelcome.value) welcomeSendMotionArmed.value = false
+  })
   pairSend.finish(result.messageSent === true || result.stage === 'stream')
   await refreshACPComposerConfigAfterSelectionError(result)
   if (!result.ok && result.stage === 'startup') {

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -64,6 +64,35 @@
                 </p>
               </div>
 
+              <!-- Cold-open placeholder while a session's first page is on the
+                   wire — Arkloop's ChatSkeleton shape, re-derived on Memoh
+                   geometry: chat text is 16px at --chat-leading 1.48 ≈ 24px
+                   line pitch, so a real one-line user bubble is py-3 + 24px =
+                   48px tall and ~10 CJK chars + px-4 ≈ 192px wide; each reply
+                   bar (12px + 12px gap) occupies one text line's 24px pitch.
+                   Bars use element opacity (not color alpha) so the parent's
+                   animate-pulse compounds with the per-bar fade. -->
+              <div
+                v-if="messages.length === 0 && loadingMessages"
+                class="animate-pulse flex flex-col gap-6"
+                aria-hidden="true"
+              >
+                <div class="flex justify-end">
+                  <div
+                    class="h-12 w-48 rounded-2xl bg-foreground"
+                    style="opacity: 0.08"
+                  />
+                </div>
+                <div class="flex flex-col gap-3">
+                  <div
+                    v-for="(w, i) in CHAT_SKELETON_BAR_WIDTHS"
+                    :key="i"
+                    class="h-3 rounded bg-foreground"
+                    :style="{ width: w, opacity: 0.15 - i * 0.013 }"
+                  />
+                </div>
+              </div>
+
               <!-- One persistent container per turn, keyed by the turn's
                    opening message id — a send APPENDS a container; previous
                    turns' DOM is never re-parented (see messageTurns for why
@@ -1276,6 +1305,11 @@ const WELCOME_GREETING_KEYS = [
   'chat.welcome.g5', 'chat.welcome.g6', 'chat.welcome.g7', 'chat.welcome.g8',
   'chat.welcome.g9', 'chat.welcome.g10', 'chat.welcome.g11', 'chat.welcome.g12',
 ] as const
+
+// Arkloop ChatSkeleton's width sequence, verbatim — percentages of the column,
+// so they scale with Memoh's layout; heights/pitches above are derived from
+// Memoh's own chat metrics, not copied.
+const CHAT_SKELETON_BAR_WIDTHS = ['85%', '65%', '90%', '55%', '75%', '60%', '80%', '50%', '70%', '40%'] as const
 function pickWelcomeGreetingIndex() {
   return Math.floor(Math.random() * WELCOME_GREETING_KEYS.length)
 }

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -913,7 +913,7 @@
                          stays hidden, while a VISIBLE disabled button still
                          dims as designed. -->
                     <div
-                      class="absolute inset-0 transition-[opacity,scale] duration-[188ms] ease motion-reduce:transition-none"
+                      class="absolute inset-0 transition-[opacity,scale] duration-[188ms] ease-[ease] motion-reduce:transition-none"
                       :class="micVisible ? 'scale-100 opacity-100' : 'pointer-events-none scale-70 opacity-0'"
                     >
                       <Button

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -70,25 +70,23 @@
                    line pitch, so a real one-line user bubble is py-3 + 24px =
                    48px tall and ~10 CJK chars + px-4 ≈ 192px wide; each reply
                    bar (12px + 12px gap) occupies one text line's 24px pitch.
-                   Bars use element opacity (not color alpha) so the parent's
-                   animate-pulse compounds with the per-bar fade. -->
+                   The shared Skeleton primitive owns the loading motion and
+                   base tone; only the width stagger is kept from the old
+                   hand-rolled version. -->
               <div
                 v-if="messages.length === 0 && loadingMessages"
-                class="animate-pulse flex flex-col gap-6"
+                class="flex flex-col gap-6"
                 aria-hidden="true"
               >
                 <div class="flex justify-end">
-                  <div
-                    class="h-12 w-48 rounded-2xl bg-foreground"
-                    style="opacity: 0.08"
-                  />
+                  <Skeleton class="h-12 w-48 rounded-2xl" />
                 </div>
                 <div class="flex flex-col gap-3">
-                  <div
-                    v-for="(w, i) in CHAT_SKELETON_BAR_WIDTHS"
-                    :key="i"
-                    class="h-3 rounded bg-foreground"
-                    :style="{ width: w, opacity: 0.15 - i * 0.013 }"
+                  <Skeleton
+                    v-for="w in CHAT_SKELETON_BAR_WIDTHS"
+                    :key="w"
+                    class="h-3 rounded"
+                    :style="{ width: w }"
                   />
                 </div>
               </div>
@@ -1077,7 +1075,7 @@ import {
   SquarePen,
   ShieldCheck,
 } from 'lucide-vue-next'
-import { Button, Command, CommandGroup, CommandItem, CommandKeyBridge, CommandList, CommandSeparator, Dialog, DialogContent, DialogHeader, DialogTitle, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger, InlineLoadingRow, PanePlaceholder, Popover, PopoverContent, PopoverTrigger, ScrollArea, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Spinner, menuChromeClass, toast } from '@felinic/ui'
+import { Button, Command, CommandGroup, CommandItem, CommandKeyBridge, CommandList, CommandSeparator, Dialog, DialogContent, DialogHeader, DialogTitle, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger, InlineLoadingRow, PanePlaceholder, Popover, PopoverContent, PopoverTrigger, ScrollArea, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Skeleton, Spinner, menuChromeClass, toast } from '@felinic/ui'
 import { useChatStore, type ExternalAgentSessionInput, type ChatMessage, type ChatWorkspaceTargetSnapshot, type SendMessageResult } from '@/store/chat-list'
 import { useWorkdirsStore } from '@/store/workdirs'
 import type { BotWorkdir } from '@/composables/api/useWorkdirs'
@@ -3632,7 +3630,6 @@ async function handleSend() {
   const sentReasoningEffort = pairSend.pair.reasoningEffort
   const sentWorkspaceTargetId = sendWorkspaceTargetId.value
   const preserveDirectDraftSelection = activeUsesDirectRuntime.value && !sentContext.target.sessionId
-  welcomeSendMotionArmed.value = isWelcome.value
   composerError.value = ''
   inputText.value = ''
   saveInputDraft(sentDraftKey, '')
@@ -3658,6 +3655,10 @@ async function handleSend() {
     return
   }
 
+  // Arm the placement FLIP only after attachment conversion has succeeded and
+  // the send is really going out: arming earlier lets a navigation during the
+  // async read (or a failed conversion) consume/inherit the flag.
+  welcomeSendMotionArmed.value = isWelcome.value
   // Arm the pin only once the store has passed command handling and session
   // setup and is about to start a real turn. Command-only sends therefore do
   // not leave a latent pin behind; startup failures roll the arm back.

--- a/apps/web/src/pages/home/composables/native-scroll.test.ts
+++ b/apps/web/src/pages/home/composables/native-scroll.test.ts
@@ -64,6 +64,34 @@ describe('native scrolling', () => {
 })
 
 describe('live destinations', () => {
+  it('releases via the backstop when scrollend never arrives', () => {
+    vi.useFakeTimers()
+    const root = viewport()
+    const finish = vi.fn()
+    nativeScrollTo(root, () => 500, finish)
+    vi.advanceTimersByTime(1_999)
+    expect(finish).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(finish).toHaveBeenCalledOnce()
+    // After the backstop fires, a late scrollend is ignored.
+    root.dispatchEvent(new Event('scrollend'))
+    expect(finish).toHaveBeenCalledOnce()
+  })
+
+  it('re-arms the backstop across a live-destination leg', () => {
+    vi.useFakeTimers()
+    const root = viewport()
+    let target = 400
+    const finish = vi.fn()
+    nativeScrollTo(root, () => target, finish)
+    target = 600
+    root.scrollTop = 400
+    root.dispatchEvent(new Event('scrollend'))
+    expect(root.scrollTo).toHaveBeenLastCalledWith({ top: 600, behavior: 'smooth' })
+    vi.advanceTimersByTime(2_000)
+    expect(finish).toHaveBeenCalledOnce()
+  })
+
   it.each([620, 180])('settles at a moved destination (%i) before finishing', (next) => {
     const root = viewport()
     let target = 400

--- a/apps/web/src/pages/home/composables/native-scroll.test.ts
+++ b/apps/web/src/pages/home/composables/native-scroll.test.ts
@@ -92,6 +92,24 @@ describe('live destinations', () => {
     expect(finish).toHaveBeenCalledOnce()
   })
 
+  it('corrects a moved destination when the backstop fires, then releases', () => {
+    vi.useFakeTimers()
+    const root = viewport()
+    let target = 400
+    const finish = vi.fn()
+    nativeScrollTo(root, () => target, finish)
+    // The destination moves mid-flight and scrollend never arrives: the
+    // backstop must retarget rather than release at the original offset.
+    target = 600
+    vi.advanceTimersByTime(2_000)
+    expect(finish).not.toHaveBeenCalled()
+    expect(root.scrollTo).toHaveBeenLastCalledWith({ top: 600, behavior: 'smooth' })
+    // Position frozen (no real scrolling): the next tick detects no progress
+    // and finishes instead of re-arming forever.
+    vi.advanceTimersByTime(2_000)
+    expect(finish).toHaveBeenCalledOnce()
+  })
+
   it.each([620, 180])('settles at a moved destination (%i) before finishing', (next) => {
     const root = viewport()
     let target = 400

--- a/apps/web/src/pages/home/composables/native-scroll.ts
+++ b/apps/web/src/pages/home/composables/native-scroll.ts
@@ -44,9 +44,25 @@ export function nativeScrollTo(
   // "smooth scroll in flight" latch would stick. Well past any browser smooth-
   // scroll duration, so a false finish means the flight was already lost —
   // releasing is the right recovery either way.
+  let armedTarget = 0
+  let armedScrollTop = 0
+  const onBackstop = () => {
+    // Revalidate through settle() rather than releasing blindly: the live
+    // destination may have moved during the flight, and these callers disable
+    // bottom-following, so nothing downstream corrects the landing. If neither
+    // the destination nor the position moved since the last arm, no flight is
+    // making progress — finish instead of re-arming forever.
+    if (root.scrollTop === armedScrollTop && resolveTarget() === armedTarget) {
+      finish()
+      return
+    }
+    settle()
+  }
   const armBackstop = () => {
     clearTimeout(backstop)
-    backstop = setTimeout(finish, 2000)
+    armedTarget = target
+    armedScrollTop = root.scrollTop
+    backstop = setTimeout(onBackstop, 2000)
   }
   const stationary = Math.abs(root.scrollTop - target) < 1
   root.addEventListener('scrollend', settle)

--- a/apps/web/src/pages/home/composables/native-scroll.ts
+++ b/apps/web/src/pages/home/composables/native-scroll.ts
@@ -6,10 +6,12 @@ export function nativeScrollTo(
 ): () => void {
   let finished = false
   let idleTimer: ReturnType<typeof setTimeout> | undefined
+  let backstop: ReturnType<typeof setTimeout> | undefined
   const finish = () => {
     if (finished) return
     finished = true
     clearTimeout(idleTimer)
+    clearTimeout(backstop)
     root.removeEventListener('scrollend', settle)
     root.removeEventListener('scroll', onScroll)
     onFinish()
@@ -27,6 +29,7 @@ export function nativeScrollTo(
       target = nextTarget
       root.scrollTo({ top: target, behavior: 'smooth' })
       if (!Reflect.has(root, 'onscrollend')) onScroll()
+      else armBackstop()
       return
     }
     finish()
@@ -36,11 +39,22 @@ export function nativeScrollTo(
     clearTimeout(idleTimer)
     idleTimer = setTimeout(settle, 150)
   }
+  // scrollend is expected on every terminal path, but nothing guarantees it:
+  // if the engine swallows the event, finish would never fire and the caller's
+  // "smooth scroll in flight" latch would stick. Well past any browser smooth-
+  // scroll duration, so a false finish means the flight was already lost —
+  // releasing is the right recovery either way.
+  const armBackstop = () => {
+    clearTimeout(backstop)
+    backstop = setTimeout(finish, 2000)
+  }
   const stationary = Math.abs(root.scrollTop - target) < 1
   root.addEventListener('scrollend', settle)
   if (!Reflect.has(root, 'onscrollend')) {
     root.addEventListener('scroll', onScroll, { passive: true })
     onScroll()
+  } else {
+    armBackstop()
   }
   root.scrollTo({ top: target, behavior: reduced ? 'instant' : 'smooth' })
   // No movement means no scrollend event, including reduced-motion jumps.

--- a/apps/web/src/pages/home/composables/useComposerPlacementMotion.test.ts
+++ b/apps/web/src/pages/home/composables/useComposerPlacementMotion.test.ts
@@ -38,3 +38,19 @@ describe('motion accessibility', () => {
     scope.stop()
   })
 })
+
+describe('navigation gate', () => {
+  it('lands without animating when the flip is not send-initiated', async () => {
+    const el = document.createElement('div')
+    const welcome = ref(true)
+    el.getBoundingClientRect = () => ({ left: 0, top: 300 }) as DOMRect
+    const scope = effectScope()
+    scope.run(() => useComposerPlacementMotion(ref(el), welcome, () => false))
+    welcome.value = false
+    await nextTick()
+    await nextTick()
+    expect(animate).not.toHaveBeenCalled()
+    expect(el.style.transform).toBe('')
+    scope.stop()
+  })
+})

--- a/apps/web/src/pages/home/composables/useComposerPlacementMotion.ts
+++ b/apps/web/src/pages/home/composables/useComposerPlacementMotion.ts
@@ -5,6 +5,11 @@ import { CHAT_SEND_MOTION } from './turn-entrance'
 export function useComposerPlacementMotion(
   element: Ref<HTMLElement | null>,
   isWelcome: Ref<boolean>,
+  // The FLIP is only honest on the send path, where the pane's layout is
+  // otherwise stable. Navigation (welcome → sidebar session) swaps the whole
+  // pane in the same flush; gliding the composer over the already-arrived
+  // content reads as a stray ghost, so callers gate those flips out.
+  allow: () => boolean = () => true,
 ) {
   let cancel: (() => void) | undefined
   let revision = 0
@@ -16,7 +21,7 @@ export function useComposerPlacementMotion(
   watch(isWelcome, async (welcome, wasWelcome) => {
     reset()
     const el = element.value
-    if (welcome || !wasWelcome || !el
+    if (welcome || !wasWelcome || !el || !allow()
       || window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return
     const attempt = revision
     // Measure before Vue changes the welcome layout, then invert the movement.


### PR DESCRIPTION
#1179 合并后的独立 review 与实机走查发现的四个细节修复。welcome 首发的 pin 门问题（draft→session 晋升时 `matchesChatPaneSendContext` 恒不匹配）经定性为**产品形态选择**而非 bug——线上行为与 #1179 前一致、无回归——本 PR 刻意不包含它，单独决定后另行处理。

## 修复

- **mic 按钮过渡曲线**:`ease` 在 Tailwind v4 里不是有效 utility（项目 theme 无对应 token)，不生成任何 CSS,mic 退出实际跑的是默认过渡曲线而非设计意图；改 `ease-[ease]` 才对齐参考参数（Arkloop composer)。
- **composer 位置动效加导航门**：从 welcome 点侧栏会话时 `isWelcome` 同样翻转，FLIP 让 composer 在整个面板已换完内容后从居中位滑行 400ms，读作残影。改为仅在 `handleSend` 从 welcome 发出时武装；发送未晋升 draft（纯命令/失败）在落定后清扫，避免残留武装污染下一次导航。导航时 composer 直接随面板落位。
- **原生平滑滚动 scrollend 兜底**:scrollend 分支完全依赖事件，若引擎在某条中断路径吞掉它,`finish` 永不触发、`smoothScrollActive` 门闩卡死，流式跟随静默失效。加 2s backstop（合并版 live-destination 续段时重新武装），远超任何浏览器 smooth 滚动时长；#1179 之前的手写 tween 有等价的沉降定时器，重写时遗失。
- **消息冷加载骨架屏**：冷打开未加载过的会话原先消息区纯白到首屏到达（查史证实：消息区从未有过加载占位，非回归）。骨架形状借 Arkloop `ChatSkeleton`，但高度/宽度/节奏按 Memoh 真实几何重算——16px 正文 × `--chat-leading: 1.48` ≈ 24px 行距，气泡占位 48×192 与真气泡同形（`rounded-2xl`)，条形 12+12 卡进文本行节奏；宽度百分比序列沿用 Arkloop。条形用元素 opacity 而非颜色 alpha，不推进 alpha 基线。

## 验证

- 4 个相关测试文件 38 项测试全过（新增 3 项：导航门、backstop 及其续段重武装）;ESLint、UI contract 通过（alpha 基线 155 未变）。
- 各次提交正常执行 hook(Go tests、Go lint、暂存文件 ESLint)。
- 真人 QA:mic 曲线与骨架屏已在本地 dev 栈（vite 指向 OSS 槽位）实机过目；导航门与 backstop 仅自动测试与代码审查覆盖（backstop 可用控制台屏蔽 `scrollend` 注册复现：跟随在滚动结束后不再恢复）。


## 范围与代码量

base `31c8a0132`(origin/main),head `513322dcb`,4 个 commit,5 文件，+116/-3。其中生产代码（含注释）+77/-3：骨架模板与常量、导航门（含武装/消费/清扫)、backstop 与注释；测试 +39：三个新用例。无后端、API、数据库或依赖改动。

