### PR TITLE
docs: 约定主工作语言为中文（含 issue 与 PR）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Working Language
+
+The primary working language for this repository is **Chinese (中文)**, including issue and PR titles and bodies, review comments, and commit/PR discussion. Other languages (e.g. English) are not rejected — quoted code, error logs, and upstream English material stay as-is — but default to Chinese whenever you author new content.
+
 ## Project Overview
 
 Memoh is a multi-member, structured long-memory AI agent platform with isolated workspace runtimes. Users can create AI bots and chat with them via Telegram, Discord, Lark (Feishu), DingTalk, WeChat, Matrix, Email, and more. Each bot can use an independent container workspace to edit files, execute commands, run tools, and build itself while keeping runtime ownership explicit.


### PR DESCRIPTION
在根 AGENTS.md 顶部新增 **Working Language** 约定：

- 本仓库主工作语言为**中文**，包括 issue 与 PR 的标题和正文、review 评论及提交讨论。
- 不拒绝其他语言（如英文）；引用的代码、错误日志、上游英文资料保持原文，撰写新内容时默认使用中文。

纯文档改动，无代码影响。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.