### PR TITLE
fix(workspace): 修复依赖卸载与操作确认流程

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -2424,7 +2424,7 @@
         "updateTitle": "Update {name}",
         "updateDescription": "Currently {from}. The new version installs first and switches over only on success; the current one stays untouched on failure, and you can roll back afterwards.",
         "installDescription": "Downloads and installs {name} into the workspace.",
-        "reinstallDescription": "Removes the current copy of {name} and installs it again. Agents that depend on it can't start until it finishes.",
+        "reinstallDescription": "Downloads and reinstalls {name} in the workspace.",
         "dependency": "Dependency",
         "installPath": "Install location",
         "version": "Version",
@@ -2461,8 +2461,7 @@
       },
       "remove": {
         "title": "Remove {name}?",
-        "description": "Deletes every version under {path}. Agents that depend on it can't start until it is reinstalled.",
-        "overlayDescription": "Removes {installed}; the workspace goes back to {image_version}."
+        "description": "Removes {name} and its installed versions from this workspace. Programs that depend on it may stop working."
       },
       "rollback": {
         "title": "Roll back {name}",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -2423,7 +2423,7 @@
         "updateTitle": "{name} を更新",
         "updateDescription": "現在は {from} です。新しいバージョンを先にインストールし、成功した場合のみ切り替えます。失敗しても現在のバージョンには影響せず、後からロールバックできます。",
         "installDescription": "Workspace に {name} をダウンロードしてインストールします。",
-        "reinstallDescription": "現在の {name} を削除して再インストールします。完了するまで、これに依存する Agent は起動できません。",
+        "reinstallDescription": "Workspace に {name} を再ダウンロードしてインストールします。",
         "dependency": "依存関係",
         "installPath": "インストール先",
         "version": "バージョン",
@@ -2460,8 +2460,7 @@
       },
       "remove": {
         "title": "{name} を削除しますか？",
-        "description": "{path} 以下のすべてのバージョンを削除します。これに依存する Agent は再インストールまで起動できません。",
-        "overlayDescription": "{installed} を削除し、Workspace は {image_version} に戻ります。"
+        "description": "この Workspace から {name} とインストール済みの各バージョンを削除します。この依存関係を必要とするプログラムが動作しなくなる場合があります。"
       },
       "rollback": {
         "title": "{name} をロールバック",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -2424,7 +2424,7 @@
         "updateTitle": "更新 {name}",
         "updateDescription": "当前 {from}。新版本安装完成后才切换；失败不影响当前版本，成功后可回滚。",
         "installDescription": "将在工作区中下载并安装 {name}。",
-        "reinstallDescription": "将删除当前安装并重新安装 {name}。完成前依赖它的 Agent 无法启动。",
+        "reinstallDescription": "在工作区中重新下载并安装 {name}。",
         "dependency": "依赖",
         "installPath": "安装位置",
         "version": "版本",
@@ -2461,8 +2461,7 @@
       },
       "remove": {
         "title": "卸载 {name}？",
-        "description": "将删除 {path} 下的全部版本。依赖它的 Agent 在重新安装前无法启动。",
-        "overlayDescription": "将移除 {installed}，工作区回到 {image_version}。"
+        "description": "从工作区中移除 {name} 及其已安装版本。依赖它的程序可能无法运行。"
       },
       "rollback": {
         "title": "回滚 {name}",

--- a/apps/web/src/pages/bots/components/bot-dependencies.vue
+++ b/apps/web/src/pages/bots/components/bot-dependencies.vue
@@ -207,11 +207,8 @@
       :item="confirm.item"
       :target-kind="targetKind"
       :target-name="targetName"
-      :loading="script.forConfirmation && script.loading"
-      :script-ready="script.forConfirmation && !!script.data?.definition_revision && !script.error"
       @update:open="(value) => { confirm.open = value }"
       @confirm="onConfirmed"
-      @view-script="openScriptFromConfirm"
     />
 
     <DependencyProgressDialog
@@ -240,7 +237,7 @@
     />
 
     <ConfirmDeleteDialog
-      :open="!!removeTarget && !script.open && !script.loading && !!script.data?.definition_revision && script.item?.id === removeTarget.id && script.action === 'remove'"
+      :open="!!removeTarget"
       :title="t('bots.dependencies.remove.title', { name: removeTarget ? dependencyName(removeTarget) : '' })"
       :description="removeDescription"
       :cancel-label="t('common.cancel')"
@@ -486,7 +483,6 @@ function openConfirm(item: DependencyItem, mode: DependencyConfirmMode, operatio
   scriptSequence++
   script.open = false
   script.loading = false
-  script.forConfirmation = false
   script.data = null
   confirm.mode = mode
   confirm.operation = operation
@@ -528,19 +524,11 @@ const removeTarget = ref<DependencyItem | null>(null)
 const rollbackTarget = ref<DependencyItem | null>(null)
 const rollingBack = ref(false)
 
-// Removing an overlay uncovers the image copy; removing anything else leaves
-// nothing behind. The dialog states the result and nothing more.
+// Removal clears the dependency from this workspace, including image copies.
 const removeDescription = computed(() => {
   const item = removeTarget.value
   if (!item) return ''
-  const imageVersion = formatDependencyVersion(item.image_version)
-  if (item.overlay && imageVersion) {
-    return t('bots.dependencies.remove.overlayDescription', {
-      installed: formatDependencyVersion(item.installed_version),
-      image_version: imageVersion,
-    })
-  }
-  return t('bots.dependencies.remove.description', { path: item.install_path ?? '' })
+  return t('bots.dependencies.remove.description', { name: dependencyName(item) })
 })
 
 function onMenu(item: DependencyItem, action: DependencyMenuAction) {
@@ -549,14 +537,13 @@ function onMenu(item: DependencyItem, action: DependencyMenuAction) {
       openConfirm(item, 'install', 'install')
       return
     case 'reinstall':
-      openConfirm(item, 'reinstall', 'reinstall')
+      openConfirm(item, 'reinstall', action.operation ?? 'reinstall')
       return
     case 'rollback':
       rollbackTarget.value = item
       return
     case 'remove':
       removeTarget.value = item
-      void openScript(item, 'remove')
       return
     default:
       void openScript(item, defaultScriptAction(item))
@@ -565,10 +552,9 @@ function onMenu(item: DependencyItem, action: DependencyMenuAction) {
 
 function onRemoveConfirmed() {
   const item = removeTarget.value
-  const revision = script.data?.definition_revision
-  if (!item || script.item?.id !== item.id || script.action !== 'remove' || !revision) return
+  if (!item) return
   removeTarget.value = null
-  start(item, 'remove', { definitionRevision: revision })
+  start(item, 'remove', { definitionRevision: item.definition_revision })
 }
 
 async function onRollbackConfirmed() {
@@ -595,7 +581,6 @@ async function onRollbackConfirmed() {
 
 const script = reactive<{
   definitionRevision: string
-  forConfirmation: boolean
   open: boolean
   item: DependencyItem | null
   action: ScriptAction
@@ -603,11 +588,12 @@ const script = reactive<{
   data: ScriptResponse | null
   loading: boolean
   error: string
-}>({ open: false, item: null, action: 'install', actions: [], data: null, loading: false, error: '', definitionRevision: '', forConfirmation: false })
+}>({ open: false, item: null, action: 'install', actions: [], data: null, loading: false, error: '', definitionRevision: '' })
 let scriptSequence = 0
 watch([botIdRef, selectedTargetId], () => {
   confirm.open = false
   confirm.definitionRevision = ''
+  removeTarget.value = null
   script.open = false
   scriptSequence++
 })
@@ -625,13 +611,10 @@ function defaultScriptAction(item: DependencyItem): ScriptAction {
   return dependencyAllows(item, 'update') ? 'update' : 'install'
 }
 
-async function openScript(item: DependencyItem, action: ScriptAction, forConfirmation = false) {
-  script.forConfirmation = forConfirmation
-  script.definitionRevision = forConfirmation ? confirm.definitionRevision : ''
+async function openScript(item: DependencyItem, action: ScriptAction) {
+  script.definitionRevision = item.definition_revision ?? ''
   script.item = item
-  script.actions = (forConfirmation || (action === 'remove' && removeTarget.value?.id === item.id))
-    ? [action]
-    : scriptActionsFor(item)
+  script.actions = scriptActionsFor(item)
   script.open = true
   await loadScript(action)
 }
@@ -649,7 +632,6 @@ async function loadScript(action: ScriptAction) {
     if (sequence === scriptSequence) {
       script.data = response
       script.definitionRevision = response.definition_revision ?? ''
-      if (script.forConfirmation && confirm.open && confirm.item?.id === item.id) confirm.definitionRevision = script.definitionRevision
     }
   } catch (err) {
     if (sequence === scriptSequence) script.error = resolveApiErrorMessage(err, t('common.loadFailed'))
@@ -660,15 +642,6 @@ async function loadScript(action: ScriptAction) {
 
 function switchScriptAction(action: ScriptAction) {
   void loadScript(action)
-}
-
-// The confirm dialog's "View script" shows the script the confirmed button
-// would run; a reinstall reads as the install script since nothing else is
-// left to inspect once the current copy is gone.
-function openScriptFromConfirm() {
-  const item = confirm.item
-  if (!item) return
-  void openScript(item, confirm.operation, true)
 }
 
 // ---- Manual refresh, workspace start & navigation ---------------------------

--- a/apps/web/src/pages/bots/components/dependency-confirm-dialog.vue
+++ b/apps/web/src/pages/bots/components/dependency-confirm-dialog.vue
@@ -24,7 +24,6 @@ import {
   FormField,
   FormControl,
   Input,
-  TextButton,
 } from '@felinic/ui'
 import type { DependencyItem } from '@/composables/api/useWorkspaceDependencies'
 import {
@@ -33,7 +32,6 @@ import {
   type DependencyConfirmMode,
 } from '@/utils/workspace-dependency'
 import { useWorkspaceDependencyText } from '@/composables/useWorkspaceDependencyText'
-import DependencyKvList, { type DependencyKvRow } from './dependency-kv-list.vue'
 
 const props = withDefaults(defineProps<{
   open: boolean
@@ -43,14 +41,11 @@ const props = withDefaults(defineProps<{
   /** Display name identifying the computer where the script will run. */
   targetName?: string
   loading?: boolean
-  /** The exact script revision has been loaded for review before confirmation. */
-  scriptReady?: boolean
   /** Overrides the confirm label (the enable flow says "Install and enable"). */
   confirmLabel?: string
 }>(), {
   targetName: '',
   loading: false,
-  scriptReady: false,
   confirmLabel: '',
 })
 
@@ -58,7 +53,6 @@ const emit = defineEmits<{
   'update:open': [value: boolean]
   /** The trimmed version the user typed; empty means the latest. */
   confirm: [version: string]
-  viewScript: []
 }>()
 
 const { t } = useI18n()
@@ -102,11 +96,6 @@ const description = computed(() => {
   }
 })
 
-const rows = computed<DependencyKvRow[]>(() => [
-  { label: t('bots.dependencies.confirm.dependency'), value: props.item?.id, mono: true },
-  { label: t('bots.dependencies.confirm.installPath'), value: props.item?.install_path, mono: true },
-])
-
 const confirmText = computed(() => {
   if (props.confirmLabel) return props.confirmLabel
   switch (props.mode) {
@@ -127,8 +116,7 @@ function onOpenChange(value: boolean) {
 
 const submit = form.handleSubmit(({ version }) => {
   if (props.loading) return
-  if (!props.scriptReady) emit('viewScript')
-  else emit('confirm', version)
+  emit('confirm', version)
 })
 </script>
 
@@ -177,8 +165,6 @@ const submit = form.handleSubmit(({ version }) => {
           </FormField>
         </form>
 
-        <DependencyKvList :rows="rows" />
-
         <CalloutBanner
           v-if="targetKind === 'remote'"
           tone="warning"
@@ -187,30 +173,21 @@ const submit = form.handleSubmit(({ version }) => {
         />
       </DialogBody>
 
-      <DialogFooter class="min-w-0 items-center gap-2 sm:justify-between">
-        <TextButton
-          v-if="scriptReady"
+      <DialogFooter class="min-w-0 items-center gap-2">
+        <Button
+          variant="outline"
           :disabled="loading"
-          @click="emit('viewScript')"
+          @click="emit('update:open', false)"
         >
-          {{ t('bots.dependencies.action.viewScript') }}
-        </TextButton>
-        <div class="flex items-center gap-2">
-          <Button
-            variant="outline"
-            :disabled="loading"
-            @click="emit('update:open', false)"
-          >
-            {{ t('common.cancel') }}
-          </Button>
-          <Button
-            form="dependency-confirm-form"
-            type="submit"
-            :loading="loading"
-          >
-            {{ scriptReady ? confirmText : t('bots.dependencies.action.viewScript') }}
-          </Button>
-        </div>
+          {{ t('common.cancel') }}
+        </Button>
+        <Button
+          form="dependency-confirm-form"
+          type="submit"
+          :loading="loading"
+        >
+          {{ confirmText }}
+        </Button>
       </DialogFooter>
     </DialogPanel>
   </Dialog>

--- a/apps/web/src/pages/bots/components/dependency-enable-flow.vue
+++ b/apps/web/src/pages/bots/components/dependency-enable-flow.vue
@@ -24,11 +24,8 @@ import {
 } from '@felinic/ui'
 import { postBotsByBotIdContainerStart, type BotagentsBotAgent } from '@memohai/sdk'
 import {
-  fetchDependencyScript,
   preflightDependencies,
   type DependencyItem,
-  type ScriptAction,
-  type ScriptResponse,
 } from '@/composables/api/useWorkspaceDependencies'
 import { useDependencyOperationsStore, type DependencyOperation } from '@/store/dependency-operations'
 import { resolveApiErrorMessage } from '@/utils/api-error'
@@ -36,7 +33,6 @@ import { dependencyDisplayName } from '@/utils/workspace-dependency'
 import DependencyConfirmDialog from './dependency-confirm-dialog.vue'
 import DependencyKvList, { type DependencyKvRow } from './dependency-kv-list.vue'
 import DependencyProgressDialog from './dependency-progress-dialog.vue'
-import DependencyScriptDialog from './dependency-script-dialog.vue'
 import {
   agentDependencyRequirement,
   dependencyItemFromPreflight,
@@ -75,12 +71,6 @@ const progressOpen = ref(false)
 // after the store dropped the record.
 const displayed = shallowRef<DependencyOperation | null>(null)
 
-const scriptOpen = ref(false)
-const scriptLoading = ref(false)
-const scriptError = ref('')
-const script = ref<ScriptResponse | null>(null)
-let scriptSequence = 0
-
 const workspaceRows = computed<DependencyKvRow[]>(() => [
   { label: t('bots.dependencies.confirm.dependency'), value: item.value?.id, mono: true },
 ])
@@ -103,9 +93,6 @@ function finish(ok: boolean) {
   workspaceOpen.value = false
   confirmOpen.value = false
   hideProgress()
-  scriptOpen.value = false
-  script.value = null
-  scriptSequence++
   resolve?.(ok)
 }
 
@@ -197,7 +184,6 @@ function onConfirmed(version: string) {
     item: current,
     action: OPERATION,
     version,
-    definitionRevision: script.value?.definition_revision,
     onBackgroundDone: onBackgroundDone,
   })
   switch (result.kind) {
@@ -240,25 +226,6 @@ function retryOperation() {
 function onProgressOpenChange(value: boolean) {
   if (value) return
   finish(displayed.value?.status === 'done')
-}
-
-async function openScript() {
-  const depId = item.value?.id ?? ''
-  const action: ScriptAction = OPERATION
-  const sequence = ++scriptSequence
-  scriptOpen.value = true
-  scriptLoading.value = true
-  scriptError.value = ''
-  const revision = script.value?.definition_revision
-  script.value = null
-  try {
-    const result = await fetchDependencyScript(props.botId, '', depId, action, revision)
-    if (sequence === scriptSequence) script.value = result
-  } catch (error) {
-    if (sequence === scriptSequence) scriptError.value = resolveApiErrorMessage(error, t('common.loadFailed'))
-  } finally {
-    if (sequence === scriptSequence) scriptLoading.value = false
-  }
 }
 
 onBeforeUnmount(hideProgress)
@@ -322,20 +289,8 @@ defineExpose({ run, checking })
     :item="item"
     target-kind="native"
     :confirm-label="t('bots.dependencies.confirm.installAndEnable')"
-    :loading="scriptLoading"
-    :script-ready="!!script?.definition_revision && !scriptError"
     @update:open="onConfirmOpenChange"
     @confirm="onConfirmed"
-    @view-script="openScript"
-  />
-
-  <DependencyScriptDialog
-    v-model:open="scriptOpen"
-    :script="script"
-    :loading="scriptLoading"
-    :error="scriptError"
-    :dependency-name="name"
-    :action="OPERATION"
   />
 
   <DependencyProgressDialog

--- a/apps/web/src/pages/supermarket/components/install-dependency-dialog.vue
+++ b/apps/web/src/pages/supermarket/components/install-dependency-dialog.vue
@@ -89,28 +89,19 @@
         </form>
       </DialogBody>
 
-      <DialogFooter class="min-w-0 items-center gap-2 sm:justify-between">
-        <TextButton
-          v-if="script?.definition_revision"
-          :disabled="!botId || resumable"
-          @click="openScript"
-        >
-          {{ t('bots.dependencies.action.viewScript') }}
-        </TextButton>
-        <div class="flex items-center gap-2">
-          <DialogClose as-child>
-            <Button variant="outline">
-              {{ t('common.cancel') }}
-            </Button>
-          </DialogClose>
-          <Button
-            form="install-dependency-form"
-            type="submit"
-            :disabled="!botId || scriptLoading"
-          >
-            {{ resumable ? t('bots.dependencies.action.viewProgress') : script?.definition_revision ? t('supermarket.install') : t('bots.dependencies.action.viewScript') }}
+      <DialogFooter class="min-w-0 items-center gap-2">
+        <DialogClose as-child>
+          <Button variant="outline">
+            {{ t('common.cancel') }}
           </Button>
-        </div>
+        </DialogClose>
+        <Button
+          form="install-dependency-form"
+          type="submit"
+          :disabled="!botId"
+        >
+          {{ resumable ? t('bots.dependencies.action.viewProgress') : t('supermarket.install') }}
+        </Button>
       </DialogFooter>
     </DialogPanel>
   </Dialog>
@@ -130,14 +121,6 @@
     @update:open="onProgressOpenChange"
     @retry="retry"
     @done="onDone"
-  />
-  <DependencyScriptDialog
-    v-model:open="scriptOpen"
-    :script="script"
-    :loading="scriptLoading"
-    :error="scriptError"
-    :dependency-name="name"
-    action="install"
   />
 </template>
 
@@ -168,7 +151,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  TextButton,
   toast,
 } from '@felinic/ui'
 import {
@@ -177,12 +159,9 @@ import {
   type WorkspaceWorkspaceTarget,
 } from '@memohai/sdk'
 import { validDependencyVersion } from '@/utils/workspace-dependency'
-import { resolveApiErrorMessage } from '@/utils/api-error'
-import { fetchDependencyScript, type ScriptResponse } from '@/composables/api/useWorkspaceDependencies'
 import BotSelect from '@/components/bot-select/index.vue'
 import { useWorkspaceDependencyText } from '@/composables/useWorkspaceDependencyText'
 import DependencyProgressDialog from '@/pages/bots/components/dependency-progress-dialog.vue'
-import DependencyScriptDialog from '@/pages/bots/components/dependency-script-dialog.vue'
 import { useDependencyOperationsStore, type DependencyOperation } from '@/store/dependency-operations'
 import {
   workspaceTargetAvailable,
@@ -225,38 +204,6 @@ const form = useForm({
 // '' means the bot's current target: the Server resolves it, the same way the
 // bot's Dependencies tab does when nothing is picked.
 const selectedTargetId = ref('')
-const scriptOpen = ref(false)
-const scriptLoading = ref(false)
-const scriptError = ref('')
-const script = shallowRef<ScriptResponse | null>(null)
-let scriptSequence = 0
-
-watch([botId, selectedTargetId, () => props.item, () => props.open], () => {
-  scriptSequence++
-  script.value = null
-  scriptOpen.value = false
-  scriptLoading.value = false
-})
-
-async function openScript() {
-  if (!botId.value || !depId.value) return
-  const sequence = ++scriptSequence
-  scriptOpen.value = true
-  scriptLoading.value = true
-  scriptError.value = ''
-  try {
-    const response = await fetchDependencyScript(
-      botId.value, selectedTargetId.value, depId.value, 'install',
-      script.value?.definition_revision || props.item?.definition_revision,
-    )
-    if (sequence === scriptSequence) script.value = response
-  } catch (error) {
-    if (sequence === scriptSequence) scriptError.value = resolveApiErrorMessage(error, t('common.loadFailed'))
-  } finally {
-    if (sequence === scriptSequence) scriptLoading.value = false
-  }
-}
-
 const { data: targetsResponse } = useQuery({
   key: () => ['bot-workspace-targets', botId.value],
   query: async () => {
@@ -320,20 +267,16 @@ function show(operation: DependencyOperation) {
   store.view(operation.key, VIEWER_ID)
 }
 
-const startInstall = form.handleSubmit(async ({ version }) => {
+const startInstall = form.handleSubmit(({ version }) => {
   const item = props.item
-  if (!item || !botId.value || !depId.value || scriptLoading.value) return
-  if (!resumable.value && !script.value?.definition_revision) {
-    await openScript()
-    return
-  }
+  if (!item || !botId.value || !depId.value) return
   const result = store.start({
     botId: botId.value,
     targetId: selectedTargetId.value,
     item,
     action: 'install',
     version,
-    definitionRevision: script.value?.definition_revision || item.definition_revision,
+    definitionRevision: item.definition_revision,
   })
   switch (result.kind) {
     case 'started':

--- a/apps/web/src/utils/workspace-dependency.test.ts
+++ b/apps/web/src/utils/workspace-dependency.test.ts
@@ -38,7 +38,7 @@ function imageCopy(overrides: Partial<DependencyItem> = {}): DependencyItem {
     status: 'installed',
     installed_version: '24.14.0',
     image_version: '24.14.0',
-    actions: ['install', 'check_update'],
+    actions: ['install', 'remove', 'check_update'],
     ...overrides,
   })
 }
@@ -198,12 +198,33 @@ describe('dependencyMenuActions', () => {
     expect(actions[3]).toMatchObject({ destructive: true, disabled: false })
   })
 
-  it('offers install and script for an up-to-date image copy the Server lets you lay a version over', () => {
+  it('reinstalls a preinstalled copy through install, including when an update is available', () => {
     const actions = dependencyMenuActions(imageCopy(), 'running')
-    expect(actions.map(action => action.kind)).toEqual(['install', 'viewScript'])
-    expect(actions[0]).toMatchObject({ labelKey: 'bots.dependencies.action.install', disabled: false })
-    // Once install doubles as the row's Update button, the menu does not repeat it.
-    expect(dependencyMenuActions(imageCopy({ latest_version: '24.15.0' }), 'running').map(action => action.kind)).toEqual(['viewScript'])
+    expect(actions.map(action => action.kind)).toEqual(['reinstall', 'viewScript', 'remove'])
+    expect(actions[0]).toMatchObject({ labelKey: 'bots.dependencies.action.reinstall', operation: 'install', disabled: false })
+    expect(dependencyMenuActions(imageCopy({ latest_version: '24.15.0' }), 'running')).toEqual(actions)
+  })
+
+  it('keeps reinstall and remove beside Update for a managed dependency', () => {
+    const updatable = item({ status: 'installed', latest_version: '2', installed_version: '1', actions: ['update', 'reinstall', 'remove'] })
+    expect(dependencyPrimaryAction(updatable, 'running')).toMatchObject({ kind: 'update', operation: 'update' })
+    expect(dependencyMenuActions(updatable, 'running')).toEqual([
+      expect.objectContaining({ kind: 'reinstall', operation: 'reinstall' }),
+      expect.objectContaining({ kind: 'viewScript' }),
+      expect.objectContaining({ kind: 'remove', labelKey: 'bots.dependencies.action.remove' }),
+    ])
+  })
+
+  it('removes an image copy and an overlay with the same menu action', () => {
+    const overlay = imageCopy({ source: 'managed', overlay: true, actions: ['update', 'reinstall', 'remove'] })
+    expect(dependencyMenuActions(overlay, 'running').at(-1)).toMatchObject({
+      kind: 'remove', labelKey: 'bots.dependencies.action.remove',
+    })
+    expect(dependencyMenuActions(imageCopy({ latest_version: '24.15.0' }), 'running').at(-1)).toMatchObject({
+      kind: 'remove', labelKey: 'bots.dependencies.action.remove', disabled: false,
+    })
+    // After removal no copy or record remains, so the installed list drops it.
+    expect(dependencyIsInstalled(item({ actions: ['install'] }))).toBe(false)
   })
 
   it('keeps only the script preview clickable while the workspace is read-only', () => {

--- a/apps/web/src/utils/workspace-dependency.ts
+++ b/apps/web/src/utils/workspace-dependency.ts
@@ -40,6 +40,8 @@ export type DependencyMenuActionKind = 'install' | 'reinstall' | 'rollback' | 'v
 
 export interface DependencyMenuAction {
   kind: DependencyMenuActionKind
+  /** The server operation; reinstalling a preinstalled copy uses install. */
+  operation?: DependencyOperationAction
   /** Full i18n key of the item label. */
   labelKey: string
   args?: Record<string, string>
@@ -275,21 +277,15 @@ export function dependencyMenuActions(
 
   const readonly = workspaceState !== 'running' || dependencyInProgress(item)
   const items: DependencyMenuAction[] = []
-  // Install on an installed row lays a chosen version over the copy in effect.
-  // It moves to the primary button when it doubles as the row's update.
-  const installIsPrimary = dependencyUpdateAvailable(item) && dependencyUpdateOperation(item) === 'install'
-  if (item.status === 'installed' && dependencyAllows(item, 'install') && !installIsPrimary) {
-    items.push({
-      kind: 'install',
-      labelKey: `${ACTION_KEY}.install`,
-      destructive: false,
-      disabled: readonly,
-      separatorBefore: false,
-    })
-  }
-  if (dependencyAllows(item, 'reinstall')) {
+  // The copy already exists even when it came from the image. Reinstall
+  // stays available beside Update; the server still decides which script runs.
+  const reinstallOperation = dependencyAllows(item, 'reinstall')
+    ? 'reinstall'
+    : item.status === 'installed' && dependencyAllows(item, 'install') ? 'install' : undefined
+  if (reinstallOperation) {
     items.push({
       kind: 'reinstall',
+      operation: reinstallOperation,
       labelKey: `${ACTION_KEY}.reinstall`,
       destructive: false,
       disabled: readonly,

--- a/docs/design/workspace-dependencies.md
+++ b/docs/design/workspace-dependencies.md
@@ -59,11 +59,12 @@ install, update, reinstall, remove, manual update checks and background update
 checks. A software version request is independent of that choice. In particular,
 requesting an older CLI version still uses the current installation recipe.
 
-Preparation freezes one revision for the operation. Script preview returns
-`definition_revision`; the corresponding operation request carries that revision.
-A refresh or publication between preview and execution cannot swap the script.
-A new operation or an explicit retry resolves latest again unless the user is
-confirming that prepared preview. Reinstall keeps the prior installation available
+Preparation freezes one revision for the operation. After the user confirms an
+action, the Server resolves and pins its definition; viewing the script is optional.
+Requests may carry `definition_revision` from catalog metadata or the script viewer.
+A refresh or publication between preparation and execution cannot swap the script.
+A new operation resolves latest when no revision is supplied, while retries retain
+the prepared revision reported by the started event. Reinstall keeps the prior installation available
 while the replacement is staged. If the definition has no dedicated reinstall
 script, Memoh reruns install without removing the existing versions first.
 
@@ -104,7 +105,7 @@ operations remain available in the persistent cache.
   empty. Existing managed, image-provided and PATH copies do not require registry
   access. A missing CLI produces actionable feedback; chat messages and device-code
   login never authorize a script execution. Installation requires Manage permission
-  and confirmation of a revision-bound script preview.
+  and confirmation of the operation; the Server fixes its revision before execution.
 - Script caching is not binary caching. Reinstalling software may still require npm,
   GitHub or the relevant upstream download service.
 
@@ -119,8 +120,14 @@ targets supply their own data root. The direct Codex and Claude Code runtimes cu
 require a native workspace and reject remote targets before launcher resolution.
 
 The image keeps Node.js, Python, uv, display tools and the bridge contract paths.
-Node.js/Python/uv installations add managed overlays; removal restores the image
-baseline. Codex and Claude Code are downloaded per workspace and are absent from the
+Node.js/Python/uv installations add managed copies. Removing a dependency from a
+native workspace deletes both the managed copy and the toolkit commands and runtime
+files in that container. The Debian image's additional system Python is removed
+through its package manager, including packages that require the interpreter; unrelated
+packages are not autoremoved. A removed dependency is no longer discovered or listed
+as installed. Recreating the container from an image restores that image's contents.
+Remote targets continue to use their reviewed removal recipes. Codex and Claude Code
+are downloaded per workspace and are absent from the
 image. The old workspace-contract JSON gate is removed. Server and image upgrades
 must follow the [upgrade and rollback procedure](../workspace-dependencies-upgrade.md);
 an old Server cannot initialize this new image.

--- a/docs/workspace-dependencies-upgrade.md
+++ b/docs/workspace-dependencies-upgrade.md
@@ -5,7 +5,7 @@ runtime scripts. Codex and Claude Code are managed per workspace under
 `/data/.memoh/deps`; they are no longer installed in the image. The new Server
 discovers an existing supported CLI before requiring a managed installation.
 A chat message or a device-code login attempt does not authorize installation:
-a user with the Bot's Manage permission must preview and confirm it in workspace
+a user with the Bot's Manage permission must confirm installation in workspace
 dependency settings.
 
 ## Server and image compatibility
@@ -44,9 +44,8 @@ uses this image-level check; it validates a dependency at its point of use.
    An installed CLI outside the supported version range must be updated before
    the Agent can run.
 4. While the old image is still available, have a Manage-capable user open each
-   relevant workspace target's dependency settings, review the manifest and
-   installation script, and confirm installation of the required Codex or Claude
-   Code version. Wait for successful installation, verify the managed executable
+   relevant workspace target's dependency settings and confirm installation of
+   the required Codex or Claude Code version. Wait for successful installation, verify the managed executable
    and its version, and start a fresh Agent session. Dependencies are stored per
    workspace target; installation for one Bot or target does not prepare others.
 5. Only after those checks, select the new baseline image by immutable digest

--- a/internal/handlers/workspace_dependencies.go
+++ b/internal/handlers/workspace_dependencies.go
@@ -95,9 +95,8 @@ type WorkspaceDependencyItem struct {
 	// runtime launches and the one first on PATH (managed, then image, then
 	// PATH).
 	InstalledVersion string `json:"installed_version,omitempty"`
-	// ImageVersion is the version of the copy the workspace image ships,
-	// omitted when the image has none. It is the baseline a managed overlay
-	// sits on and what remove returns to.
+	// ImageVersion is the version of the workspace's toolkit copy, omitted
+	// when no toolkit copy remains. Native removal clears it as well.
 	ImageVersion string `json:"image_version,omitempty"`
 	// Overlay is set when the copy in effect is a managed one installed over
 	// an image copy.
@@ -702,7 +701,7 @@ func (h *ContainerdHandler) streamWorkspaceDependencyOperation(c echo.Context, a
 		return apperror.New(apperror.CodeWorkspaceDependencyRequestInvalid, nil)
 	}
 	// A browser disconnect must not cancel a download already admitted by Manage
-	// authorization and pinned to the reviewed definition revision.
+	// authorization and pinned to the prepared definition revision.
 	ctx = context.WithoutCancel(ctx)
 	version := request.Version
 	writer, flusher, err := beginSSEResponse(c)
@@ -900,7 +899,9 @@ func workspaceDependencyOperationRequest(c echo.Context, action catalog.Action) 
 	req.Version = strings.TrimSpace(req.Version)
 	req.SessionID = strings.TrimSpace(req.SessionID)
 	req.DefinitionRevision = strings.TrimSpace(req.DefinitionRevision)
-	if !catalog.ValidRevision(req.DefinitionRevision) {
+	// A normal confirmation need not open the script viewer. The handler
+	// prepares and pins the current definition before it admits the operation.
+	if req.DefinitionRevision != "" && !catalog.ValidRevision(req.DefinitionRevision) {
 		return req, apperror.New(apperror.CodeWorkspaceDependencyRequestInvalid, nil)
 	}
 	if action == catalog.ActionRemove {

--- a/internal/handlers/workspace_dependencies_test.go
+++ b/internal/handlers/workspace_dependencies_test.go
@@ -224,13 +224,13 @@ type depsCall struct {
 	depID          string
 	body           any
 	userID         string
-	unreviewed     bool
+	omitRevision   bool
 	requestContext context.Context
 }
 
 func (call depsCall) invoke(t *testing.T, fn func(echo.Context) error) (*httptest.ResponseRecorder, error) {
 	t.Helper()
-	if !call.unreviewed && call.depID != "" && (call.method == http.MethodPost || call.method == http.MethodDelete) && !strings.Contains(call.target, "/rollback") {
+	if !call.omitRevision && call.depID != "" && (call.method == http.MethodPost || call.method == http.MethodDelete) && !strings.Contains(call.target, "/rollback") {
 		switch body := call.body.(type) {
 		case nil:
 			call.body = WorkspaceDependencyInstallRequest{DefinitionRevision: strings.Repeat("a", 64)}
@@ -1049,13 +1049,49 @@ func TestWorkspaceDependencyErrorMapping(t *testing.T) {
 	}
 }
 
-func TestWorkspaceDependencyMutationRequiresReviewedRevision(t *testing.T) {
+func TestWorkspaceDependencyMutationPreparesRevisionWithoutClientPreview(t *testing.T) {
+	for _, action := range []string{"install", "update", "reinstall", "remove"} {
+		t.Run(action, func(t *testing.T) {
+			revision := strings.Repeat("b", 64)
+			svc := &fakeWorkspaceDependencyService{
+				deps:      depsTestCatalog(),
+				preview:   workspacedeps.ScriptPreview{Revision: revision},
+				operation: workspacedeps.OperationResult{DefinitionRevision: revision},
+			}
+			h := newDepsTestHandler("admin", svc)
+			handlers := map[string]func(echo.Context) error{
+				"install":   h.InstallWorkspaceDependency,
+				"update":    h.UpdateWorkspaceDependency,
+				"reinstall": h.ReinstallWorkspaceDependency,
+				"remove":    h.RemoveWorkspaceDependency,
+			}
+			rec, err := (depsCall{method: http.MethodPost, target: "/bots/x/dependencies/codex/" + action, depID: "codex", omitRevision: true}).invoke(t, handlers[action])
+			if err != nil {
+				t.Fatal(err)
+			}
+			frames := sseFrames(t, rec.Body.String())
+			if len(frames) != 2 || frames[0]["type"] != "started" || frames[1]["type"] != "done" {
+				t.Fatalf("operation did not run: %v", frames)
+			}
+			for _, frame := range frames {
+				if frame["definition_revision"] != revision {
+					t.Fatalf("revision was not pinned: %v", frames)
+				}
+			}
+			if len(svc.calls) != 2 || svc.calls[0] != "script" || svc.calls[1] != action {
+				t.Fatalf("expected server preparation followed by operation: %v", svc.calls)
+			}
+		})
+	}
+}
+
+func TestWorkspaceDependencyMutationRejectsMalformedRevision(t *testing.T) {
 	svc := &fakeWorkspaceDependencyService{deps: depsTestCatalog()}
 	h := newDepsTestHandler("admin", svc)
-	rec, err := (depsCall{method: http.MethodPost, target: "/bots/x/dependencies/codex/install", depID: "codex", unreviewed: true}).invoke(t, h.InstallWorkspaceDependency)
+	_, err := (depsCall{method: http.MethodPost, target: "/bots/x/dependencies/codex/install", depID: "codex", body: WorkspaceDependencyInstallRequest{DefinitionRevision: "invalid"}}).invoke(t, h.InstallWorkspaceDependency)
 	requireAppErrorCode(t, err, apperror.CodeWorkspaceDependencyRequestInvalid)
-	if strings.HasPrefix(rec.Header().Get(echo.HeaderContentType), "text/event-stream") || len(svc.calls) != 0 {
-		t.Fatal("unreviewed mutation reached operation")
+	if len(svc.calls) != 0 {
+		t.Fatal("malformed revision reached operation")
 	}
 }
 

--- a/internal/workspacedeps/catalog_context.go
+++ b/internal/workspacedeps/catalog_context.go
@@ -12,8 +12,9 @@ type (
 )
 
 // WithDefinitionRevision binds a user's prepared operation to the immutable
-// revision returned by its script preview. Empty means resolve latest when
-// the operation begins; it never changes halfway through a running script.
+// revision returned by catalog metadata or an optional script preview. Empty
+// means resolve latest when the operation begins; it never changes halfway
+// through a running script.
 func WithDefinitionRevision(ctx context.Context, revision string) context.Context {
 	return context.WithValue(ctx, revisionContextKey{}, revision)
 }

--- a/internal/workspacedeps/deps_docker_test.go
+++ b/internal/workspacedeps/deps_docker_test.go
@@ -74,6 +74,49 @@ func TestDockerCatalogScripts(t *testing.T) {
 	}
 }
 
+// Uses disposable containers and no network: removal must clear the actual
+// image binaries, not just make the database row disappear.
+func TestDockerRemoveImageDependencies(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not installed")
+	}
+	image := os.Getenv("MEMOH_DEPS_TEST_IMAGE")
+	if image == "" {
+		image = dockerTestDefaultImage
+	}
+	for _, dep := range []catalog.Dependency{
+		{ID: "node", Provides: []string{"node", "npm", "npx"}},
+		{ID: "python", Provides: []string{"python3", "python", "pip", "pip3"}},
+		{ID: "uv", Provides: []string{"uv", "uvx"}},
+	} {
+		t.Run(dep.ID, func(t *testing.T) {
+			home := Home("/data", dep.ID)
+			script := "set -eu\nexport MEMOH_DEP_OS=linux\nexport MEMOH_DEP_WORKSPACE_TARGET=native\nexport MEMOH_DEP_HOME=" + shellQuote(home) + "\nexport MEMOH_DEP_BIN=" + shellQuote(ShimDir("/data")) + "\n"
+			script += "command -v " + shellQuote(dep.Provides[0]) + " >/dev/null\n"
+			script += "mkdir -p \"$MEMOH_DEP_HOME\"\nprintf '{}' > \"$MEMOH_DEP_HOME/state.json\"\n"
+			script += "(\n" + WrapScript(actionScript(dep, catalog.ActionRemove, "exit 0")) + ")\nhash -r\n"
+			for _, command := range dep.Provides {
+				script += "if command -v " + shellQuote(command) + "; then exit 1; fi\n"
+			}
+			script += "[ ! -e \"$MEMOH_DEP_HOME\" ]\n"
+			script += buildDiscoveryScript("/data", []catalog.Dependency{dep})
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "docker", "run", "--rm", "-i", "--network", "none", "--entrypoint", "sh", image, "-s")
+			cmd.Stdin = strings.NewReader(script)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("remove from image: %v\n%s", err, out)
+			}
+			probes, complete := parseDiscoveryOutput(string(out))
+			probe := probes[dep.ID]
+			if !complete || probe == nil || probe.hasState || len(probe.toolkit) != 0 || len(probe.path) != 0 {
+				t.Fatalf("removed dependency was rediscovered: %s", out)
+			}
+		})
+	}
+}
+
 const (
 	dockerTestDefaultImage = "memohai/workspace:debian"
 	// dockerTestDepsRoot is where the per-dependency volume is mounted inside

--- a/internal/workspacedeps/preview.go
+++ b/internal/workspacedeps/preview.go
@@ -100,14 +100,15 @@ func (s *Service) ScriptPreviewDetails(ctx context.Context, botID, targetID, dep
 	timeout := previewTimeout(dep, action)
 
 	spec := RunSpec{
-		DepID:          dep.ID,
-		Action:         action,
-		Home:           Home(dataRoot, dep.ID),
-		ShimDir:        ShimDir(dataRoot),
-		Version:        previewVersion(dep, action),
-		CurrentVersion: previewCurrentVersion(action),
-		Platform:       platform,
-		Timeout:        timeout,
+		DepID:             dep.ID,
+		Action:            action,
+		WorkspaceTargetID: targetID,
+		Home:              Home(dataRoot, dep.ID),
+		ShimDir:           ShimDir(dataRoot),
+		Version:           previewVersion(dep, action),
+		CurrentVersion:    previewCurrentVersion(action),
+		Platform:          platform,
+		Timeout:           timeout,
 	}
 	if s.scriptEnv != nil {
 		spec.ExtraEnv = s.scriptEnv(ctx)

--- a/internal/workspacedeps/remove.go
+++ b/internal/workspacedeps/remove.go
@@ -1,0 +1,77 @@
+package workspacedeps
+
+import (
+	"fmt"
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/felinics/memoh/internal/workspacedeps/catalog"
+)
+
+// removalScript includes workspace-owned copies in the prepared script, so
+// removing an updated tool cannot silently expose the image's older copy.
+// Keep cleanup inside the runner's lock and completion receipt. A catalog
+// script's exit/return must not skip cleanup, and failure must stop it.
+func removalScript(dep catalog.Dependency, script, toolkitRoot string) string {
+	var b strings.Builder
+	b.WriteString("(\n" + script + "\n)\n")
+	b.WriteString("rm -rf -- \"$MEMOH_DEP_HOME\"\n")
+	// Remote targets own their software layout through the reviewed recipe.
+	// Only a native workspace has an isolated, writable image filesystem.
+	fmt.Fprintf(&b, "if [ \"${MEMOH_DEP_WORKSPACE_TARGET:-}\" = %s ]; then\n", shellQuote(TargetNative))
+	// Never follow a replaced ancestor into a different tree. rm removes
+	// individual symlinks themselves, not their targets.
+	fmt.Fprintf(&b, "  [ ! -L %s ] && [ ! -L %s ] || exit 1\n", shellQuote(toolkitRoot), shellQuote(path.Join(toolkitRoot, "bin")))
+	commands := slices.Clone(dep.Provides)
+	var trees []string
+	// These paths belong to the canonical image assembly in docker/toolkit.
+	// Do not infer recursive deletion paths from catalog names or PATH.
+	switch dep.ID {
+	case "node":
+		commands = append(commands, "node", "npm", "npx")
+		trees = []string{"node-glibc", "node-musl"}
+	case "python":
+		commands = append(commands, "python", "python3", "pip", "pip3")
+		trees = []string{"python-gnu", "python-musl", "python-gnu-x86_64", "python-gnu-aarch64", "python-musl-x86_64", "python-musl-aarch64"}
+	case "uv":
+		commands = append(commands, "uv", "uvx")
+		trees = []string{"uv"}
+	}
+	slices.Sort(commands)
+	for _, command := range slices.Compact(commands) {
+		if isPlainFileName(command) {
+			fmt.Fprintf(&b, "  rm -f -- %s\n", shellQuote(path.Join(toolkitRoot, "bin", command)))
+		}
+	}
+	for _, tree := range trees {
+		fmt.Fprintf(&b, "  rm -rf -- %s\n", shellQuote(path.Join(toolkitRoot, tree)))
+	}
+	if dep.ID == "python" && toolkitRoot == path.Dir(toolkitBinDir) {
+		b.WriteString(removeSystemPython)
+	}
+	b.WriteString("fi\n")
+	return b.String()
+}
+
+// The Debian desktop image also includes distro Python. Let its package
+// manager remove the interpreter and resolve dependents instead of unlinking
+// package-owned files behind its back. Never autoremove unrelated packages.
+// This runs only inside the native workspace branch above, and is included
+// in the script available through the optional script viewer.
+const removeSystemPython = `  if [ "${MEMOH_DEP_OS:-}" = linux ] && command -v dpkg-query >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+    memoh_python_packages=$(dpkg-query -W -f='${binary:Package}\t${Status}\n' 'python3*' 2>/dev/null | awk '$2 == "install" && $3 == "ok" && $4 == "installed" && $1 ~ /^python3([.][0-9]+)?(-minimal)?(:[a-z0-9]+)?$/ { print $1 }')
+    if [ -n "$memoh_python_packages" ]; then
+      # Package names are restricted to interpreter packages by the pattern.
+      # shellcheck disable=SC2086
+      apt-get remove -y --no-auto-remove $memoh_python_packages
+    fi
+  fi
+`
+
+func actionScript(dep catalog.Dependency, action catalog.Action, script string) string {
+	if action == catalog.ActionRemove {
+		return removalScript(dep, script, path.Dir(toolkitBinDir))
+	}
+	return script
+}

--- a/internal/workspacedeps/remove_test.go
+++ b/internal/workspacedeps/remove_test.go
@@ -1,0 +1,134 @@
+package workspacedeps
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/felinics/memoh/internal/workspacedeps/catalog"
+)
+
+func TestRemovalScriptDeletesWorkspaceCopies(t *testing.T) {
+	for _, tc := range []struct {
+		id       string
+		commands []string
+		trees    []string
+	}{
+		{"node", []string{"node", "npm", "npx"}, []string{"node-glibc", "node-musl"}},
+		{"python", []string{"python", "python3", "pip", "pip3"}, []string{"python-gnu", "python-musl", "python-gnu-x86_64", "python-gnu-aarch64", "python-musl-x86_64", "python-musl-aarch64"}},
+		{"uv", []string{"uv", "uvx"}, []string{"uv"}},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			root := t.TempDir()
+			toolkit := filepath.Join(root, "toolkit with spaces")
+			home := filepath.Join(root, "managed", tc.id)
+			writeRemovalFixture(t, filepath.Join(home, "state.json"))
+			for _, command := range tc.commands {
+				writeRemovalFixture(t, filepath.Join(toolkit, "bin", command))
+			}
+			for _, tree := range tc.trees {
+				name := filepath.Join(toolkit, tree)
+				if tc.id != "uv" {
+					name = filepath.Join(name, "bin", "runtime")
+				}
+				writeRemovalFixture(t, name)
+			}
+			unrelated := filepath.Join(toolkit, "display", "bin", "a11y-cli")
+			writeRemovalFixture(t, unrelated)
+			dep := catalog.Dependency{ID: tc.id, Provides: tc.commands}
+			// Recipes commonly exit explicitly; cleanup must still run.
+			body := removalScript(dep, "exit 0", toolkit)
+			if out, err := runRemovalFixture(t, body, home, TargetNative); err != nil {
+				t.Fatalf("remove: %v: %s", err, out)
+			}
+			for _, name := range append(append([]string{home}, removalFixturePaths(toolkit, "bin", tc.commands)...), removalFixturePaths(toolkit, "", tc.trees)...) {
+				if _, err := os.Lstat(name); !os.IsNotExist(err) {
+					t.Errorf("dependency file remains: %s (%v)", name, err)
+				}
+			}
+			if _, err := os.Stat(unrelated); err != nil {
+				t.Fatalf("unrelated toolkit file removed: %v", err)
+			}
+			// Repeated removal is safe, including when no managed copy existed.
+			if out, err := runRemovalFixture(t, body, home, TargetNative); err != nil {
+				t.Fatalf("repeat remove: %v: %s", err, out)
+			}
+		})
+	}
+}
+
+func TestRemovalScriptFailureAndRemoteScope(t *testing.T) {
+	for _, tc := range []struct {
+		name, target, script string
+		failed               bool
+	}{
+		{"failed recipe", TargetNative, "exit 42", true},
+		{"remote target", "remote-test", "exit 0", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			home := filepath.Join(root, "managed")
+			toolkit := filepath.Join(root, "toolkit")
+			state := filepath.Join(home, "state.json")
+			command := filepath.Join(toolkit, "bin", "uv")
+			writeRemovalFixture(t, state)
+			writeRemovalFixture(t, command)
+			body := removalScript(catalog.Dependency{ID: "uv", Provides: []string{"uv"}}, tc.script, toolkit)
+			if out, err := runRemovalFixture(t, body, home, tc.target); (err != nil) != tc.failed {
+				t.Fatalf("remove: %v: %s", err, out)
+			}
+			if _, err := os.Stat(command); err != nil {
+				t.Fatalf("toolkit must remain untouched: %v", err)
+			}
+			if tc.failed {
+				if _, err := os.Stat(state); err != nil {
+					t.Fatalf("cleanup ran after a failed recipe: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRemovalScriptDoesNotFollowToolkitSymlinks(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(root, "unrelated")
+	writeRemovalFixture(t, filepath.Join(outside, "keep"))
+	toolkit := filepath.Join(root, "toolkit")
+	if err := os.Symlink(outside, toolkit); err != nil {
+		t.Fatal(err)
+	}
+	body := removalScript(catalog.Dependency{ID: "uv", Provides: []string{"../keep", "uv"}}, ":", toolkit)
+	if out, err := runRemovalFixture(t, body, filepath.Join(root, "managed"), TargetNative); err == nil {
+		t.Fatalf("symlink ancestor must fail: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "keep")); err != nil {
+		t.Fatal("followed toolkit symlink")
+	}
+}
+
+func writeRemovalFixture(t *testing.T, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(name), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(name, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runRemovalFixture(t *testing.T, body, home, target string) ([]byte, error) {
+	cmd := exec.CommandContext(t.Context(), "sh", "-s")
+	cmd.Stdin = strings.NewReader("set -eu\n" + body)
+	cmd.Env = append(os.Environ(), "MEMOH_DEP_HOME="+home, "MEMOH_DEP_WORKSPACE_TARGET="+target)
+	return cmd.CombinedOutput()
+}
+
+func removalFixturePaths(root, dir string, names []string) []string {
+	paths := make([]string, 0, len(names))
+	for _, name := range names {
+		paths = append(paths, filepath.Join(root, dir, name))
+	}
+	return paths
+}

--- a/internal/workspacedeps/runner.go
+++ b/internal/workspacedeps/runner.go
@@ -49,6 +49,8 @@ type RunSpec struct {
 	Script  string
 	Home    string
 	ShimDir string
+	// WorkspaceTargetID scopes image cleanup to isolated native workspaces.
+	WorkspaceTargetID string
 	// Version is exported as MEMOH_DEP_VERSION: the version to install (the
 	// one requested, else the manifest pin) and empty for "latest".
 	Version string
@@ -273,6 +275,7 @@ func buildEnv(spec RunSpec, resultPath string, timeout time.Duration) []string {
 	env := []string{
 		"MEMOH_DEP_ID=" + spec.DepID,
 		"MEMOH_DEP_ACTION=" + string(spec.Action),
+		"MEMOH_DEP_WORKSPACE_TARGET=" + spec.WorkspaceTargetID,
 		"MEMOH_DEP_HOME=" + spec.Home,
 		"MEMOH_DEP_BIN=" + spec.ShimDir,
 		"MEMOH_DEP_VERSION=" + spec.Version,

--- a/internal/workspacedeps/service.go
+++ b/internal/workspacedeps/service.go
@@ -189,11 +189,10 @@ type Entry struct {
 	// PATH (managed, then toolkit, then PATH).
 	InstalledVersion string
 	// ImageVersion is the version of the copy the workspace image ships in
-	// its toolkit, empty when the image has none. It is the baseline a
-	// managed overlay sits on and what remove returns to.
+	// its toolkit, empty when the workspace has no toolkit copy.
 	ImageVersion string
 	// Overlay is set when the copy in effect is a managed one installed over
-	// an image copy: removing it uncovers the ImageVersion copy.
+	// an image copy. Native removal clears both copies.
 	Overlay bool
 	// LatestVersion is the last check_update result recorded for the
 	// dependency, empty until a check ran.
@@ -695,8 +694,8 @@ func SupportedActions(dep catalog.Dependency) []catalog.Action {
 }
 
 // availableActions lists the actions the current state allows. A managed
-// copy is what install produces and what update, reinstall, remove, and
-// rollback operate on; an image copy underneath it is only ever a baseline.
+// copy is what install produces and what update, reinstall, and rollback
+// operate on. Remove also clears commands supplied by the workspace image.
 // Update checks follow the script and the pin, not the category: an agent
 // CLI is checked upstream like any other tool.
 func availableActions(dep catalog.Dependency, rec *Installation, obs Observed) []catalog.Action {
@@ -713,10 +712,10 @@ func availableActions(dep catalog.Dependency, rec *Installation, obs Observed) [
 		} else if rec != nil {
 			actions = append(actions, catalog.ActionReinstall)
 		}
-		if rec != nil && !obs.Present {
-			// A missing or failed record can be dropped without a workspace
-			// copy to delete; remove runs the script (a no-op then) and
-			// deletes the intent.
+		imageCopy := rec != nil && rec.WorkspaceTargetID == TargetNative && (imageCandidate(obs).Path != "" || obs.Source == SourceToolkit)
+		if ActionSupported(dep, catalog.ActionRemove) && ((rec != nil && !obs.Present) || imageCopy) {
+			// Remove clears native image copies as well as missing/failed
+			// installation records; remote software stays recipe-owned.
 			actions = append(actions, catalog.ActionRemove)
 		}
 	default:
@@ -836,9 +835,8 @@ func (s *Service) Reinstall(ctx context.Context, botID, targetID, depID, version
 }
 
 // Remove runs the remove script, deletes the shims, and drops the record.
-// For a dependency the image ships this removes the managed overlay only:
-// the next discovery finds the image copy again and adopts it as installed
-// from the image.
+// Native workspaces also remove the image's copy so discovery cannot adopt
+// the same dependency again immediately after a successful removal.
 func (s *Service) Remove(ctx context.Context, botID, targetID, depID string, sink LogSink) (OperationResult, error) {
 	ctx, cancelOperation := context.WithCancel(ctx)
 	defer cancelOperation()
@@ -992,7 +990,7 @@ func (s *Service) ScriptPreview(ctx context.Context, depID string, action catalo
 		return WrapScript(rollbackScript), nil
 	}
 	if script, ok := s.catalogFor(ctx).Script(dep.ID, action); ok {
-		return WrapScript(script), nil
+		return WrapScript(actionScript(dep, action, script)), nil
 	}
 	switch action {
 	case catalog.ActionUpdate:
@@ -1306,15 +1304,16 @@ func (s *Service) runScript(ctx context.Context, op *operation, action catalog.A
 		timeout = op.dep.Timeouts.Duration(action)
 	}
 	spec := RunSpec{
-		DepID:          op.dep.ID,
-		Action:         action,
-		Script:         script,
-		Home:           op.home,
-		ShimDir:        op.shimDir,
-		Version:        version,
-		CurrentVersion: currentVersion,
-		Platform:       op.platform,
-		Timeout:        timeout,
+		DepID:             op.dep.ID,
+		Action:            action,
+		Script:            actionScript(op.dep, action, script),
+		WorkspaceTargetID: op.key.WorkspaceTargetID,
+		Home:              op.home,
+		ShimDir:           op.shimDir,
+		Version:           version,
+		CurrentVersion:    currentVersion,
+		Platform:          op.platform,
+		Timeout:           timeout,
 	}
 	if s.scriptEnv != nil {
 		spec.ExtraEnv = s.scriptEnv(ctx)

--- a/internal/workspacedeps/service_test.go
+++ b/internal/workspacedeps/service_test.go
@@ -773,7 +773,7 @@ func TestListLeavesInProgressAndFailedRecordsAlone(t *testing.T) {
 // TestListImageBaselineAndOverlay covers the two shapes an installable
 // dependency the image also ships can take: image copy only (a baseline the
 // panel offers to install over) and a managed overlay on top of it (what
-// remove returns to the baseline).
+// remove clears along with the managed copy).
 func TestListImageBaselineAndOverlay(t *testing.T) {
 	f := newServiceFixture(t)
 	f.present("agent-x", SourceToolkit, "1.9.0", nil)
@@ -790,8 +790,8 @@ func TestListImageBaselineAndOverlay(t *testing.T) {
 	if agent.InstalledVersion != "1.9.0" || agent.ImageVersion != "1.9.0" || agent.Overlay || agent.Installation.Source != InstallationSourceImage {
 		t.Errorf("agent-x entry = %+v, want the image copy as baseline", agent)
 	}
-	if got := actionsOf(agent); got != "install" {
-		t.Errorf("agent-x actions = %s, want install of an overlay only", got)
+	if got := actionsOf(agent); got != "install,remove" {
+		t.Errorf("agent-x actions = %s, want install and remove", got)
 	}
 	tool := f.entry(t, result, "tool-y")
 	if !tool.Overlay || tool.InstalledVersion != "1.0.0" || tool.ImageVersion != "0.9.0" || tool.Installation.Source != InstallationSourceManaged {
@@ -804,22 +804,22 @@ func TestListImageBaselineAndOverlay(t *testing.T) {
 		t.Errorf("tool-y actions = %s", got)
 	}
 
-	// Removing the overlay uncovers the image copy, which the next discovery
-	// adopts as installed from the image.
+	// Removing the dependency clears both copies; discovery has nothing left
+	// to adopt and the installed list must drop the row.
 	f.writeState(t, "tool-y", State{Version: "1.0.0", Entrypoints: map[string]string{"tool-y": managedTool.Path}})
 	if _, err := f.svc.Remove(f.ctx(), testBot, testTarget, "tool-y", nil); err != nil {
 		t.Fatalf("Remove: %v", err)
 	}
-	f.presentCandidates("tool-y", nil, imageTool)
+	f.absent("tool-y")
 	result, err = f.svc.List(f.ctx(), testBot, testTarget)
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 	tool = f.entry(t, result, "tool-y")
-	if tool.Status != StatusInstalled || tool.Overlay || tool.InstalledVersion != "0.9.0" || tool.ImageVersion != "0.9.0" || tool.Installation.Source != InstallationSourceImage {
-		t.Errorf("tool-y entry after remove = %+v, want the image baseline adopted", tool)
+	if tool.Status != "" || tool.InstalledVersion != "" || tool.Installation != nil || tool.Observed.Present {
+		t.Errorf("tool-y entry after remove = %+v, want an absent dependency", tool)
 	}
-	if got := actionsOf(tool); got != "install,check_update" {
+	if got := actionsOf(tool); got != "install" {
 		t.Errorf("tool-y actions after remove = %s", got)
 	}
 }
@@ -1574,6 +1574,13 @@ func TestRemoveDeletesShimsAndRecord(t *testing.T) {
 	}
 	if spec := f.runSpecs()[0]; spec.Action != catalog.ActionRemove || spec.Timeout != time.Duration(catalog.DefaultRemoveTimeout)*time.Second {
 		t.Errorf("spec = %+v", spec)
+	}
+	preview, err := f.svc.ScriptPreviewDetails(f.ctx(), testBot, testTarget, "tool-y", catalog.ActionRemove)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec := f.runSpecs()[0]; preview.Script != WrapScript(spec.Script) || previewEnv(t, preview, "MEMOH_DEP_WORKSPACE_TARGET").Value != spec.WorkspaceTargetID {
+		t.Fatal("remove preview differs from execution")
 	}
 	if got := f.store.statuses(f.key("tool-y")); !statusesEqual(got, StatusRemoving) {
 		t.Errorf("status history = %v", got)

--- a/packages/sdk/src/types.gen.ts
+++ b/packages/sdk/src/types.gen.ts
@@ -2611,9 +2611,8 @@ export type HandlersWorkspaceDependencyItem = {
     icon_url?: string;
     id?: string;
     /**
-     * ImageVersion is the version of the copy the workspace image ships,
-     * omitted when the image has none. It is the baseline a managed overlay
-     * sits on and what remove returns to.
+     * ImageVersion is the version of the workspace's toolkit copy, omitted
+     * when no toolkit copy remains. Native removal clears it as well.
      */
     image_version?: string;
     /**

--- a/spec/docs.go
+++ b/spec/docs.go
@@ -23379,7 +23379,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "image_version": {
-                    "description": "ImageVersion is the version of the copy the workspace image ships,\nomitted when the image has none. It is the baseline a managed overlay\nsits on and what remove returns to.",
+                    "description": "ImageVersion is the version of the workspace's toolkit copy, omitted\nwhen no toolkit copy remains. Native removal clears it as well.",
                     "type": "string"
                 },
                 "install_path": {

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -23370,7 +23370,7 @@
                     "type": "string"
                 },
                 "image_version": {
-                    "description": "ImageVersion is the version of the copy the workspace image ships,\nomitted when the image has none. It is the baseline a managed overlay\nsits on and what remove returns to.",
+                    "description": "ImageVersion is the version of the workspace's toolkit copy, omitted\nwhen no toolkit copy remains. Native removal clears it as well.",
                     "type": "string"
                 },
                 "install_path": {

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -4632,9 +4632,8 @@ definitions:
         type: string
       image_version:
         description: |-
-          ImageVersion is the version of the copy the workspace image ships,
-          omitted when the image has none. It is the baseline a managed overlay
-          sits on and what remove returns to.
+          ImageVersion is the version of the workspace's toolkit copy, omitted
+          when no toolkit copy remains. Native removal clears it as well.
         type: string
       install_path:
         description: |-


### PR DESCRIPTION
修复工作区依赖已安装却显示 Install、出现更新后重装入口消失，以及删除后又被扫描回列表的问题。安装、更新、重装和删除现在都可直接确认，脚本查看仅保留在依赖行的“更多”菜单中；Supermarket 和 Agent 启用流程同步简化。

- 已安装依赖统一提供重装入口，并按后端支持的操作执行；更新状态保留重装、删除。
- Native Workspace 删除依赖时清理受管理版本、镜像中的命令入口和运行时文件，清理步骤纳入执行锁、完成记录和可选脚本预览。
- 接口允许省略 `definition_revision`，由 Server 在执行前解析并固定版本；显式传入的非法修订号仍拒绝，Manage 权限检查保持生效。
- 同步中英日文提示、升级说明、OpenAPI 和生成的 SDK。

删除 Python 会通过 Debian 包管理器卸载系统解释器及依赖它的组件（当前镜像包括 `xfce4-helpers`），不会执行 autoremove。此行为仅作用于当前 Native Workspace；从镜像重建容器会恢复镜像内容。

验证：

- `go test ./...` 全量通过，提交钩子的全量 Go lint 通过。
- 在 `memohai/workspace:deps-pr1144` 的临时、无网络容器中验证 Node.js、Python、uv 删除后命令消失且扫描不再发现。
- 前端相关测试 123 项通过，Web 生产构建通过。
- UI contract、修改文件 ESLint、排除本地未跟踪工作副本后的全量 ESLint 通过。
- OpenAPI / SDK 重新生成，SDK 类型检查通过。

完整 `mise run lint` 最初因 ESLint 扫描本地未跟踪工作副本而达到 Node 内存上限；随后排除 `.claude`、`.cache`、`.superpowers` 重跑 ESLint 通过。Web 全量类型检查仍有其他页面和共享 UI 的类型错误。

与 #1189 在脚本预览流程上有交叉；本 PR 同时包含实际卸载和后端缺省修订号处理。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
