### PR TITLE
feat(audio): add Alibaba Cloud Qwen ASR transcription

### DIFF
--- a/conf/providers/alibabacloud-transcription.yaml
+++ b/conf/providers/alibabacloud-transcription.yaml
@@ -1,0 +1,9 @@
+name: Alibaba Cloud Transcription
+client_type: alibabacloud-transcription
+icon: bailian-color
+base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+
+models:
+  - model_id: qwen3-asr-flash
+    name: Qwen3 ASR Flash
+    type: transcription

--- a/db/postgres/migrations/0001_init.up.sql
+++ b/db/postgres/migrations/0001_init.up.sql
@@ -149,6 +149,7 @@ CREATE TABLE IF NOT EXISTS providers (
     'minimax-speech',
     'volcengine-speech',
     'alibabacloud-speech',
+    'alibabacloud-transcription',
     'microsoft-speech',
     'google-speech',
     'google-transcription',

--- a/db/postgres/migrations/0149_alibaba_transcription.down.sql
+++ b/db/postgres/migrations/0149_alibaba_transcription.down.sql
@@ -1,0 +1,30 @@
+-- 0149_alibaba_transcription
+-- Restore the previous provider types. Remove Alibaba ASR providers before rollback.
+
+ALTER TABLE public.providers DROP CONSTRAINT IF EXISTS providers_client_type_check;
+ALTER TABLE public.providers ADD CONSTRAINT providers_client_type_check CHECK (client_type IN (
+    'openai-responses',
+    'openai-completions',
+    'anthropic-messages',
+    'google-generative-ai',
+    'openai-codex',
+    'github-copilot',
+    'edge-speech',
+    'openai-speech',
+    'openai-transcription',
+    'openrouter-speech',
+    'openrouter-transcription',
+    'elevenlabs-speech',
+    'elevenlabs-transcription',
+    'deepgram-speech',
+    'deepgram-transcription',
+    'minimax-speech',
+    'volcengine-speech',
+    'alibabacloud-speech',
+    'microsoft-speech',
+    'google-speech',
+    'google-transcription',
+    'openrouter-video',
+    'modelark-video',
+    'volcengine-video'
+  ));

--- a/db/postgres/migrations/0149_alibaba_transcription.up.sql
+++ b/db/postgres/migrations/0149_alibaba_transcription.up.sql
@@ -1,0 +1,31 @@
+-- 0149_alibaba_transcription
+-- Allow Alibaba Cloud Qwen ASR providers.
+
+ALTER TABLE public.providers DROP CONSTRAINT IF EXISTS providers_client_type_check;
+ALTER TABLE public.providers ADD CONSTRAINT providers_client_type_check CHECK (client_type IN (
+    'openai-responses',
+    'openai-completions',
+    'anthropic-messages',
+    'google-generative-ai',
+    'openai-codex',
+    'github-copilot',
+    'edge-speech',
+    'openai-speech',
+    'openai-transcription',
+    'openrouter-speech',
+    'openrouter-transcription',
+    'elevenlabs-speech',
+    'elevenlabs-transcription',
+    'deepgram-speech',
+    'deepgram-transcription',
+    'minimax-speech',
+    'volcengine-speech',
+    'alibabacloud-speech',
+    'alibabacloud-transcription',
+    'microsoft-speech',
+    'google-speech',
+    'google-transcription',
+    'openrouter-video',
+    'modelark-video',
+    'volcengine-video'
+  ));

--- a/db/postgres/queries/models.sql
+++ b/db/postgres/queries/models.sql
@@ -47,6 +47,7 @@ WHERE team_id = public.memoh_current_team_id() AND client_type NOT IN (
   'minimax-speech',
   'volcengine-speech',
   'alibabacloud-speech',
+  'alibabacloud-transcription',
   'microsoft-speech',
   'google-speech',
   'google-transcription',
@@ -88,6 +89,7 @@ WHERE team_id = public.memoh_current_team_id() AND client_type NOT IN (
   'minimax-speech',
   'volcengine-speech',
   'alibabacloud-speech',
+  'alibabacloud-transcription',
   'microsoft-speech',
   'google-speech',
   'google-transcription',
@@ -282,6 +284,7 @@ WHERE team_id = public.memoh_current_team_id() AND client_type IN (
   'openrouter-transcription',
   'elevenlabs-transcription',
   'deepgram-transcription',
+  'alibabacloud-transcription',
   'google-transcription'
 )
 ORDER BY created_at DESC;

--- a/internal/audio/adapter/alibabacloud/transcription.go
+++ b/internal/audio/adapter/alibabacloud/transcription.go
@@ -1,0 +1,248 @@
+// Package alibabacloud implements DashScope's OpenAI-compatible Qwen ASR API.
+package alibabacloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	sdk "github.com/felinics/twilight/sdk"
+)
+
+const (
+	DefaultBaseURL    = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+	DefaultModel      = "qwen3-asr-flash"
+	maxAudioDataBytes = 10_000_000
+	maxResponseBytes  = 8 * 1024 * 1024
+)
+
+type asrRequest struct {
+	Model    string       `json:"model"`
+	Messages []asrMessage `json:"messages"`
+	Stream   bool         `json:"stream"`
+	Options  asrOptions   `json:"asr_options"`
+}
+
+type asrMessage struct {
+	Role string `json:"role"`
+	// Qwen expects a string for context and an audio-content array for the user.
+	Content any `json:"content"`
+}
+
+type asrAudioContent struct {
+	Type       string        `json:"type"`
+	InputAudio asrInputAudio `json:"input_audio"`
+}
+
+type asrInputAudio struct {
+	Data string `json:"data"`
+}
+
+type asrOptions struct {
+	Language  string `json:"language,omitempty"`
+	EnableITN *bool  `json:"enable_itn,omitempty"`
+}
+
+type Provider struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+var _ sdk.TranscriptionProvider = (*Provider)(nil)
+
+// Keep transport diagnostics private even when a legacy handler uses Error().
+type requestError struct{ cause error }
+
+func (*requestError) Error() string   { return "alibaba cloud ASR request failed" }
+func (e *requestError) Unwrap() error { return e.cause }
+
+func New(apiKey, baseURL string) (*Provider, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, errors.New("alibaba cloud ASR requires an API key")
+	}
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return nil, errors.New("alibaba cloud ASR base URL must be an HTTP(S) API base URL")
+	}
+	return &Provider{apiKey: apiKey, baseURL: baseURL, client: &http.Client{
+		Timeout:       90 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}}, nil
+}
+
+// ListModels returns the supported preset catalog; DashScope has no ASR-only model list.
+func (p *Provider) ListModels(ctx context.Context) ([]*sdk.TranscriptionModel, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return []*sdk.TranscriptionModel{{ID: DefaultModel, Provider: p}}, nil
+}
+
+func (p *Provider) DoTranscribe(ctx context.Context, params sdk.TranscriptionParams) (*sdk.TranscriptionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(params.Audio) == 0 {
+		return nil, errors.New("alibaba cloud ASR requires a non-empty audio file")
+	}
+	// Keep the entire data URL within DashScope's 10 MB encoded input limit.
+	audioPrefix := "data:" + audioContentType(params) + ";base64,"
+	maxAudioBytes := (maxAudioDataBytes - len(audioPrefix)) / 4 * 3
+	if len(params.Audio) > maxAudioBytes {
+		return nil, errors.New("audio file must fit within 10 MB after Base64 encoding")
+	}
+	modelID := DefaultModel
+	if params.Model != nil && strings.TrimSpace(params.Model.ID) != "" {
+		modelID = strings.TrimSpace(params.Model.ID)
+	}
+	language, err := optionalString(params.Config, "language")
+	if err != nil {
+		return nil, err
+	}
+	contextText, err := optionalString(params.Config, "context")
+	if err != nil {
+		return nil, err
+	}
+	prompt, err := optionalString(params.Config, "prompt")
+	if err != nil {
+		return nil, err
+	}
+	// The Agent tool's per-call prompt takes precedence over saved Qwen context.
+	if prompt != "" {
+		contextText = prompt
+	}
+	options := asrOptions{Language: language}
+	if v, ok := params.Config["enable_itn"]; ok && v != nil {
+		flag, valid := v.(bool)
+		if !valid {
+			return nil, errors.New("enable_itn must be a boolean")
+		}
+		options.EnableITN = &flag
+	}
+	messages := make([]asrMessage, 0, 2)
+	if contextText != "" {
+		messages = append(messages, asrMessage{Role: "system", Content: contextText})
+	}
+	messages = append(messages, asrMessage{Role: "user", Content: []asrAudioContent{{
+		Type:       "input_audio",
+		InputAudio: asrInputAudio{Data: audioPrefix + base64.StdEncoding.EncodeToString(params.Audio)},
+	}}})
+	body, err := json.Marshal(asrRequest{Model: modelID, Messages: messages, Options: options})
+	if err != nil {
+		return nil, &requestError{cause: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, &requestError{cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	// #nosec G704 -- The endpoint is administrator-configured; redirects are disabled.
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, &requestError{cause: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Upstream error bodies can echo submitted audio or credentials. Do not expose them.
+		return nil, fmt.Errorf("alibaba cloud ASR returned HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return nil, &requestError{cause: err}
+	}
+	if len(data) > maxResponseBytes {
+		return nil, errors.New("alibaba cloud ASR response exceeds size limit")
+	}
+	var result struct {
+		ID      string `json:"id"`
+		Model   string `json:"model"`
+		Choices []struct {
+			Message struct {
+				Content     *string `json:"content"`
+				Annotations []struct {
+					Type     string `json:"type"`
+					Language string `json:"language"`
+				} `json:"annotations"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			Seconds float64 `json:"seconds"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, errors.New("invalid Alibaba Cloud ASR response JSON")
+	}
+	if len(result.Choices) == 0 {
+		return nil, errors.New("alibaba cloud ASR response has no transcription choice")
+	}
+	message := result.Choices[0].Message
+	if message.Content == nil {
+		return nil, errors.New("alibaba cloud ASR response has no transcription content")
+	}
+	out := &sdk.TranscriptionResult{
+		Text: *message.Content, DurationSeconds: result.Usage.Seconds,
+		ProviderMetadata: map[string]any{"id": result.ID, "model": result.Model},
+	}
+	for _, annotation := range message.Annotations {
+		if annotation.Type == "audio_info" {
+			out.Language = annotation.Language
+			break
+		}
+	}
+	return out, nil
+}
+
+func optionalString(config map[string]any, key string) (string, error) {
+	value, ok := config[key]
+	if !ok || value == nil {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string", key)
+	}
+	return strings.TrimSpace(text), nil
+}
+
+func audioContentType(params sdk.TranscriptionParams) string {
+	contentType, _, _ := mime.ParseMediaType(params.ContentType)
+	if strings.HasPrefix(contentType, "audio/") || strings.HasPrefix(contentType, "video/") {
+		return contentType
+	}
+	// The PC test uploader can send application/octet-stream. Infer its media type.
+	switch strings.ToLower(filepath.Ext(params.Filename)) {
+	case ".wav":
+		return "audio/wav"
+	case ".mp3":
+		return "audio/mpeg"
+	case ".m4a", ".mp4":
+		return "audio/mp4"
+	case ".aac":
+		return "audio/aac"
+	case ".flac":
+		return "audio/flac"
+	case ".ogg", ".opus":
+		return "audio/ogg"
+	case ".webm":
+		return "audio/webm"
+	default:
+		return http.DetectContentType(params.Audio)
+	}
+}

--- a/internal/audio/registry.go
+++ b/internal/audio/registry.go
@@ -22,6 +22,7 @@ import (
 	volcenginespeech "github.com/felinics/twilight/provider/volcengine/speech"
 	sdk "github.com/felinics/twilight/sdk"
 
+	"github.com/felinics/memoh/internal/audio/adapter/alibabacloud"
 	"github.com/felinics/memoh/internal/models"
 )
 
@@ -60,6 +61,7 @@ func isTranscriptionClientType(clientType models.ClientType) bool {
 		models.ClientTypeOpenRouterTranscription,
 		models.ClientTypeElevenLabsTranscription,
 		models.ClientTypeDeepgramTranscription,
+		models.ClientTypeAlibabaTranscription,
 		models.ClientTypeGoogleTranscription:
 		return true
 	default:
@@ -221,7 +223,35 @@ func (r *Registry) ListTranscriptionMeta() []ProviderMetaResponse {
 }
 
 func transcriptionProviderDefinitions(base []ProviderDefinition) []ProviderDefinition {
-	out := make([]ProviderDefinition, 0, len(base))
+	schema := ConfigSchema{Fields: []FieldSchema{
+		stringField("language", "Language", "Optional language code (zh, en, yue, etc.); leave empty for automatic detection or mixed languages", false, "", 10),
+		boolField("enable_itn", "Normalize numbers", "Convert spoken Chinese and English numbers into digits", false, 20),
+		advancedStringField("context", "Context", "Optional background text and vocabulary to aid recognition", false, "", 30),
+	}}
+	modelList := []ModelInfo{{
+		ID:           alibabacloud.DefaultModel,
+		Name:         "Qwen3 ASR Flash",
+		Description:  "Short audio transcription with automatic language detection",
+		ConfigSchema: schema,
+		Capabilities: ModelCapabilities{ConfigSchema: schema},
+	}}
+	out := []ProviderDefinition{{
+		ClientType:  models.ClientTypeAlibabaTranscription,
+		DisplayName: "Alibaba Cloud Transcription",
+		Icon:        "bailian-color",
+		Description: "DashScope Qwen ASR (Alibaba Cloud Bailian)",
+		ConfigSchema: ConfigSchema{Fields: []FieldSchema{
+			secretField("api_key", "API Key", "DashScope API key for the selected region", true, 10),
+			stringField("base_url", "Base URL", "OpenAI-compatible HTTP base URL; defaults to Beijing", false, alibabacloud.DefaultBaseURL, 20),
+		}},
+		DefaultTranscriptionModel: alibabacloud.DefaultModel,
+		SupportsTranscriptionList: true,
+		TranscriptionModels:       modelList,
+		TranscriptionFactory: func(config map[string]any) (sdk.TranscriptionProvider, error) {
+			return alibabacloud.New(configString(config, "api_key"), configString(config, "base_url"))
+		},
+		Order: 81,
+	}}
 	for _, def := range base {
 		clientType := speechToTranscriptionClientType(def.ClientType)
 		if clientType == "" || def.TranscriptionFactory == nil {

--- a/internal/db/postgres/sqlc/models.sql.go
+++ b/internal/db/postgres/sqlc/models.sql.go
@@ -50,6 +50,7 @@ WHERE team_id = public.memoh_current_team_id() AND client_type NOT IN (
   'minimax-speech',
   'volcengine-speech',
   'alibabacloud-speech',
+  'alibabacloud-transcription',
   'microsoft-speech',
   'google-speech',
   'google-transcription',
@@ -988,6 +989,7 @@ WHERE team_id = public.memoh_current_team_id() AND client_type NOT IN (
   'minimax-speech',
   'volcengine-speech',
   'alibabacloud-speech',
+  'alibabacloud-transcription',
   'microsoft-speech',
   'google-speech',
   'google-transcription',
@@ -1275,6 +1277,7 @@ WHERE team_id = public.memoh_current_team_id() AND client_type IN (
   'openrouter-transcription',
   'elevenlabs-transcription',
   'deepgram-transcription',
+  'alibabacloud-transcription',
   'google-transcription'
 )
 ORDER BY created_at DESC

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -526,6 +526,7 @@ func IsValidClientType(clientType ClientType) bool {
 		ClientTypeMiniMaxSpeech,
 		ClientTypeVolcengineSpeech,
 		ClientTypeAlibabaSpeech,
+		ClientTypeAlibabaTranscription,
 		ClientTypeMicrosoftSpeech,
 		ClientTypeGoogleSpeech,
 		ClientTypeGoogleTranscription,

--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -40,6 +40,7 @@ const (
 	ClientTypeMiniMaxSpeech           ClientType = "minimax-speech"
 	ClientTypeVolcengineSpeech        ClientType = "volcengine-speech"
 	ClientTypeAlibabaSpeech           ClientType = "alibabacloud-speech"
+	ClientTypeAlibabaTranscription    ClientType = "alibabacloud-transcription"
 	ClientTypeMicrosoftSpeech         ClientType = "microsoft-speech"
 	ClientTypeGoogleSpeech            ClientType = "google-speech"
 	ClientTypeGoogleTranscription     ClientType = "google-transcription"


### PR DESCRIPTION
Closes #1191.

Adds Alibaba Cloud Qwen ASR as a transcription provider. Users can configure a DashScope API key and `qwen3-asr-flash` in the existing PC transcription settings, upload a short audio file to test transcription, and select the model for a bot's voice input. Model options support language hints, context, and number normalization.

The change contains 10 files (+358/-1): the DashScope adapter and provider preset, transcription registry and client-type registration, PostgreSQL migration 0149 with its rollback and canonical schema update, and SQL queries with generated sqlc output. It reuses the existing UI, HTTP handlers, and SDK/API contracts.

The adapter calls DashScope's `chat/completions` audio-input endpoint, bounds Base64-encoded input and response sizes, preserves cancellation, disables redirects, and keeps upstream response bodies and transport diagnostics out of returned error text.

Validation:

- Human QA of the ASR happy path was explicitly confirmed by the contributor.
- [Go CI passed all six jobs](https://github.com/kilockok/Memoh/actions/runs/34440131001): lint, full Linux tests with the race detector, Pgvector bootstrap, and Redis/Valkey/PostgreSQL session runtime checks. This PR's source tree matches the verified commit `40c24501`.
- `go test ./internal/audio/... ./internal/models/... ./internal/providers/... ./internal/registry/... ./internal/providertemplates/...` passes.
- Go formatting, diff whitespace, and file-size checks pass.
