### PR TITLE
fix(web): 恢复 Codex Connect 按钮等待态

### DIFF
--- a/apps/web/src/pages/bots/components/settings-direct-agent-detail.vue
+++ b/apps/web/src/pages/bots/components/settings-direct-agent-detail.vue
@@ -116,13 +116,19 @@
             loading-mode="manual"
             @click="deviceLogin ? cancelDeviceLogin() : startDeviceLogin()"
           >
-            <template v-if="deviceLogin">
-              {{ $t('common.cancel') }}
-            </template>
-            <template v-else>
-              <KeyRound />
-              {{ credentialConnected ? $t('bots.agent.reconnect') : $t('provider.oauth.connect') }}
-            </template>
+            <LabelSwap :active="authorizing ? 'connecting' : deviceLogin ? 'cancel' : 'connect'">
+              <template #connect>
+                <KeyRound />
+                {{ credentialConnected ? $t('bots.agent.reconnect') : $t('provider.oauth.connect') }}
+              </template>
+              <template #connecting>
+                <Spinner />
+                {{ $t('provider.oauth.connecting') }}
+              </template>
+              <template #cancel>
+                {{ $t('common.cancel') }}
+              </template>
+            </LabelSwap>
           </Button>
           <ConfirmPopover
             v-if="credentialConnected"
@@ -177,6 +183,7 @@ import {
   ConfirmPopover,
   DeviceCodePanel,
   Input,
+  LabelSwap,
   Select,
   SelectContent,
   SelectItem,
@@ -184,6 +191,7 @@ import {
   SelectValue,
   SettingsRow,
   SettingsSection,
+  Spinner,
   toast,
 } from '@felinic/ui'
 import { KeyRound } from 'lucide-vue-next'


### PR DESCRIPTION
Codex Agent 使用 ChatGPT 账号授权时，点击 Connect 后按钮只会禁用，没有显示 spinner 和 Connecting，容易被误认为没有响应。原因是使用了 `loading-mode="manual"`，但插槽只渲染 Connect / Cancel 两态。

复用 Provider 页现有的 `LabelSwap` 与 `Spinner`，恢复 `Connect → spinner + Connecting → Cancel` 三态和宽度过渡。保留已连接时的 Reconnect 文案、授权请求、轮询、取消及错误处理。

范围：仅 `apps/web/src/pages/bots/components/settings-direct-agent-detail.vue`，新增 15 行、删除 7 行；无后端、共享组件、翻译或生成文件变更。本地模拟对比页不纳入 PR。

验证：
- 提交钩子的 `go test ./...`、`golangci-lint run ./...` 通过。
- 单文件 ESLint、`git diff --check` 和 UI contract 检查通过（UI contract 有 3 项其他文件的警告）。
- AI 浏览器自检：加载实际 OSS 组件，使用延迟 8 秒的模拟 SDK 响应，确认请求期间 active label 为 Connecting、spinner 具有 spin 动画且按钮 busy；响应后变成 Cancel 并显示演示验证码；取消后恢复 Connect。
- 全量 typecheck 未通过：共享 UI 的 `#/lib/utils` 等类型路径解析错误仍存在；未修改配置来绕过检查。
- 尚未验证真实 OAuth 授权完整流程；本改动仅恢复等待反馈，不处理后端响应延迟。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
