### PR TITLE
fix(web): 在文件中打开不再给绝对路径加 /data 前缀

### DIFF
--- a/apps/web/src/pages/home/components/chat-workspace.test.ts
+++ b/apps/web/src/pages/home/components/chat-workspace.test.ts
@@ -33,7 +33,10 @@ vi.mock('dockview-vue', () => ({
     setup(_, { emit }) {
       const openFile = inject(openInFileManagerKey)!
       onMounted(() => emit('ready', { api: dock }))
-      return () => h('button', { onClick: () => openFile('/data/a.md') }, 'Open file')
+      return () => [
+        h('button', { class: 'open-workspace-file', onClick: () => openFile('/data/a.md') }, 'Open file'),
+        h('button', { class: 'open-outside-file', onClick: () => openFile('/home/user/project/package.json') }, 'Open outside file'),
+      ]
     },
   }),
 }))
@@ -88,6 +91,7 @@ describe('chat workspace initialization', () => {
     workspaceStore.openSessionChat.mockClear()
     workspaceStore.openDraftChat.mockClear()
     workspaceStore.releaseApi.mockClear()
+    workspaceStore.openFilePinned.mockClear()
     dock.layout.mockClear()
     api.value = null
     root?.remove()
@@ -113,8 +117,13 @@ describe('chat workspace initialization', () => {
     expect(workspaceStore.openSessionChat).not.toHaveBeenCalled()
     expect(workspaceStore.openDraftChat).not.toHaveBeenCalled()
 
-    root.querySelector('button')!.click()
+    root.querySelector<HTMLButtonElement>('.open-workspace-file')!.click()
     expect(workspaceStore.openFilePinned).toHaveBeenCalledWith('/data/a.md')
+
+    // An absolute path outside the workspace mount must reach the store as-is;
+    // the workspace root used to be prefixed onto it.
+    root.querySelector<HTMLButtonElement>('.open-outside-file')!.click()
+    expect(workspaceStore.openFilePinned).toHaveBeenCalledWith('/home/user/project/package.json')
 
     app.unmount()
   })

--- a/apps/web/src/pages/home/components/chat-workspace.vue
+++ b/apps/web/src/pages/home/components/chat-workspace.vue
@@ -41,6 +41,7 @@ import 'dockview-vue/dist/styles/dockview.css'
 import '@/styles/dockview-theme.css'
 import { useWorkspaceTabsStore } from '@/store/workspace-tabs'
 import { openInFileManagerKey, openAssetPreviewKey } from '../composables/useFileManagerProvider'
+import { normalizeFileManagerPath } from './file-manager-path'
 import { DesktopShellKey } from '@/lib/desktop-shell'
 import PanelChat from './dockview/panel-chat.vue'
 import PanelFile from './dockview/panel-file.vue'
@@ -179,21 +180,6 @@ function onReady(event: DockviewReadyEvent) {
   // workspace by opening New Session into its ephemeral slot.
   store.registerApi(event.api)
   applyLayout()
-}
-
-const FILE_MANAGER_ROOT = '/data'
-
-function normalizeFileManagerPath(path: string): string {
-  const trimmedPath = path.trim()
-  if (!trimmedPath) return FILE_MANAGER_ROOT
-  if (trimmedPath === FILE_MANAGER_ROOT || trimmedPath.startsWith(`${FILE_MANAGER_ROOT}/`)) {
-    return trimmedPath
-  }
-  if (trimmedPath === '/') return FILE_MANAGER_ROOT
-  if (trimmedPath.startsWith('/')) {
-    return `${FILE_MANAGER_ROOT}${trimmedPath}`
-  }
-  return `${FILE_MANAGER_ROOT}/${trimmedPath}`
 }
 
 // dockview-vue renders panel/tab/header-action components by mounting fresh

--- a/apps/web/src/pages/home/components/file-manager-path.test.ts
+++ b/apps/web/src/pages/home/components/file-manager-path.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { FILE_MANAGER_ROOT, normalizeFileManagerPath } from './file-manager-path'
+
+describe('normalizeFileManagerPath', () => {
+  it('keeps paths already under the workspace root', () => {
+    expect(normalizeFileManagerPath('/data/a.md')).toBe('/data/a.md')
+    expect(normalizeFileManagerPath('/data/one/wechat-bot/package.json')).toBe('/data/one/wechat-bot/package.json')
+    expect(normalizeFileManagerPath(FILE_MANAGER_ROOT)).toBe(FILE_MANAGER_ROOT)
+  })
+
+  it('returns absolute paths outside the workspace root untouched', () => {
+    // Regression: the workspace root used to be concatenated onto every
+    // absolute path, so a tool call on a container-local file opened
+    // '/data/home/user/...' and the read failed with "does not exist".
+    expect(normalizeFileManagerPath('/home/user/project/package.json')).toBe('/home/user/project/package.json')
+    expect(normalizeFileManagerPath('/opt/memoh/toolkit/bin/node')).toBe('/opt/memoh/toolkit/bin/node')
+    expect(normalizeFileManagerPath('/datastore/a.md')).toBe('/datastore/a.md')
+  })
+
+  it('anchors relative paths at the workspace root', () => {
+    expect(normalizeFileManagerPath('src/main.ts')).toBe('/data/src/main.ts')
+    expect(normalizeFileManagerPath('./src/main.ts')).toBe('/data/src/main.ts')
+  })
+
+  it('resolves the filesystem root and empty input to the workspace root', () => {
+    expect(normalizeFileManagerPath('/')).toBe(FILE_MANAGER_ROOT)
+    expect(normalizeFileManagerPath('')).toBe(FILE_MANAGER_ROOT)
+    expect(normalizeFileManagerPath('   ')).toBe(FILE_MANAGER_ROOT)
+    expect(normalizeFileManagerPath('/..')).toBe(FILE_MANAGER_ROOT)
+  })
+
+  it('collapses redundant segments so one file yields one tab identity', () => {
+    expect(normalizeFileManagerPath('  /data/./a.md  ')).toBe('/data/a.md')
+    expect(normalizeFileManagerPath('/data//nested///a.md')).toBe('/data/nested/a.md')
+    expect(normalizeFileManagerPath('/data/nested/../a.md')).toBe('/data/a.md')
+    expect(normalizeFileManagerPath('/data/nested/')).toBe('/data/nested')
+  })
+})

--- a/apps/web/src/pages/home/components/file-manager-path.ts
+++ b/apps/web/src/pages/home/components/file-manager-path.ts
@@ -1,0 +1,49 @@
+// Workspace mount inside the bot container. The bridge resolves relative paths
+// against this directory (bridgesvc.DefaultWorkDir) and the sidebar file tree is
+// rooted here.
+export const FILE_MANAGER_ROOT = '/data'
+
+// POSIX-style cleanup: collapse empty/'.' segments and resolve '..'. Tab
+// identity and the file tree's active-row match are both plain string
+// comparisons on the path, so '/data/./a.md' and '/data/a.md' must not diverge
+// into two tabs for one file.
+function cleanPosixPath(path: string): string {
+  const absolute = path.startsWith('/')
+  const segments: string[] = []
+  for (const segment of path.split('/')) {
+    if (!segment || segment === '.') continue
+    if (segment === '..') {
+      const last = segments[segments.length - 1]
+      if (last !== undefined && last !== '..') {
+        segments.pop()
+        continue
+      }
+      // '/..' is '/'; a relative path keeps the '..' it cannot resolve.
+      if (absolute) continue
+    }
+    segments.push(segment)
+  }
+  const joined = segments.join('/')
+  return absolute ? `/${joined}` : joined
+}
+
+// Resolve a tool-call path into the path the file manager should open.
+//
+// Absolute paths are returned as they are: the bridge forwards host absolute
+// paths untouched (bridgesvc.resolvePath with AllowHostAbsolute), so prefixing
+// the workspace root would fabricate a path that does not exist — '/data' +
+// '/home/user/x' — and the read would fail with "does not exist".
+//
+// Relative paths are anchored at the workspace root, matching how the bridge
+// resolves them against its default work dir.
+export function normalizeFileManagerPath(path: string): string {
+  const trimmedPath = path.trim()
+  if (!trimmedPath) return FILE_MANAGER_ROOT
+  const joinedPath = trimmedPath.startsWith('/')
+    ? trimmedPath
+    : `${FILE_MANAGER_ROOT}/${trimmedPath}`
+  const cleanedPath = cleanPosixPath(joinedPath)
+  // The tree is rooted at the workspace mount and cannot render the filesystem
+  // root, so '/' resolves to that mount.
+  return cleanedPath === '/' ? FILE_MANAGER_ROOT : cleanedPath
+}


### PR DESCRIPTION
Fixes #1203.

## 问题

工具调用（`read` / `write` / `edit` / `list`）的 `path` 是 `/data` 之外的绝对路径时，点击「在文件中打开」会用 `/data` + 原路径打开，例如 `/home/user/project/package.json` 变成 `/data/home/user/project/package.json`，文件面板报 `path '...' does not exist`。

路径污染发生在 Web 客户端，请求发出前。`apps/web/src/pages/home/components/chat-workspace.vue` 里的 `normalizeFileManagerPath` 对所有不在 `/data` 下的绝对路径做字符串拼接，把工作区根目录接在一个已经是绝对的路径前面。

## 修复

- 绝对路径原样返回。bridge 的 `bridgesvc.resolvePath` 在 `AllowHostAbsolute`（`cmd/bridge/main.go` 中为 `true`）下原样透传绝对路径，因此不需要任何前缀；加前缀构造出的是一条不存在的路径。
- 相对路径仍锚定到工作区根目录，与 bridge 用 `DefaultWorkDir`（`/data`）解析相对路径的行为一致。
- `/` 和空输入仍解析为 `/data`：侧边栏文件树以工作区挂载点为根，无法呈现文件系统根目录。
- 顺带做路径规范化，折叠 `.`、`..` 和重复斜杠。tab 标识和文件树高亮都是路径字符串比较，`/data/./a.md` 与 `/data/a.md` 原先会产生两个 tab。

## 测试

- 函数从 SFC 抽到 `apps/web/src/pages/home/components/file-manager-path.ts`，新增 `file-manager-path.test.ts` 覆盖原先无测试的那条分支（`/data` 之外的绝对路径），以及 issue 中列出的全部对照用例。
- `chat-workspace.test.ts` 增加一次 `/data` 之外绝对路径的点击，断言到达 store 的路径未被改写。
- `npx vitest run --project web`：152 个文件中 144 通过；8 个失败与本改动无关，在同一环境下对基线提交复现出完全相同的失败集合（本地 worktree 缺少部分包依赖导致 `markstream-vue` 等解析失败）。

## 未包含

`list` 一个 `/data` 之外的目录时，「在文件中打开」仍不会定位到该目录——文件树以 `/data` 为根，无法展开范围外的路径（修复前后一致，加 `/data` 前缀时同样定位失败）。issue 中提到的「超出工作区范围」提示属于产品行为变更，未在此 PR 内处理。
