### PR TITLE
fix(web): allow resubmitting an unchanged message edit

### DIFF
--- a/apps/web/src/pages/home/components/message-item.vue
+++ b/apps/web/src/pages/home/components/message-item.vue
@@ -625,11 +625,13 @@ const canForkAssistantMessage = computed(() =>
   && turnId.value !== '',
 )
 
+// Resubmitting the same text is a valid edit: the server replaces the turn and
+// reruns it either way, so an unchanged draft is the way to re-roll a turn
+// without rewording it. Only an empty draft has nothing to submit.
 const canSubmitEdit = computed(() =>
   props.message.role === 'user'
   && props.canEditLatestUser === true
   && editDraft.value.trim().length > 0
-  && editDraft.value.trim() !== cleanCurrentUserText.value.trim()
   && !editSubmitting.value,
 )
 


### PR DESCRIPTION
## 问题

编辑最新一条用户消息时，如果草稿文本与原文完全相同，发送按钮处于 disabled 状态，快捷键提交也被同一判断拦截，无法在不改动文字的情况下重跑该 turn。

限制只存在于前端：`apps/web/src/pages/home/components/message-item.vue` 的 `canSubmitEdit` 带有 `editDraft.trim() !== cleanCurrentUserText.trim()` 条件。store 层 `apps/web/src/store/chat/send.ts` 的 `editLatestUser` 没有此类判断。

## 后端确认

相同文本会被正常接受：

- `internal/handlers/local_channel.go` 的 `edit_message` 分支只校验 `invocation_id`、`session_id` 非空，以及 text 或附件至少有一项非空。
- `internal/agent/application/service_retry_edit.go` 的 `EditLatestMessageWS` 只校验文本非空，再经 `prepareEditLatestTurnOperation` 确认目标是最新可见 user turn，不与原消息内容比较。
- 去重指纹 `wsSubmission` 按 invocation 作用域判定是否为同一次提交的重投，每次编辑使用新的 `invocation_id`，相同文本不会被判为重复提交。

## 修改

删除该相等性条件，`canSubmitEdit` 只保留"草稿非空"与"未在提交中"两个条件，并补充注释说明相同文本重新提交等价于重跑该 turn。

## 验证

- ESLint 通过。
- `apps/web/src/store/chat-list.test.ts`：121 passed，包含全部 `editLatestUser` 用例。
- 全量 `vitest run`：1574 个用例中 1569 passed、5 failed。失败集中在 4 个文件（desktop 的 `server-connection`、`remote-runtime`，web 的 `useMediaGallery`、`dockview/panel-preview`）。已将 `message-item.vue` 还原到基线再单独运行这 4 个文件，失败完全相同，与本次修改无关；原因为测试环境问题（`localStorage.getItem is not a function`、`vue-i18n` mock 缺少 `createI18n` 导出）。
- pre-commit 钩子的 Go 与前端全量检查通过。