### PR TITLE
fix(web): 等待电脑连接时主动轮询状态

### DIFF
--- a/apps/web/src/components/computer/connect-computer-dialog.test.ts
+++ b/apps/web/src/components/computer/connect-computer-dialog.test.ts
@@ -36,7 +36,8 @@ const credential = { id: 'runtime-1', key: 'test-key' }
 let items = ref<UserruntimeRuntime[]>([])
 
 async function flush() {
-  for (let i = 0; i < 12; i++) await nextTick()
+  await vi.advanceTimersByTimeAsync(0)
+  await nextTick()
 }
 
 async function mount(open = true) {
@@ -121,10 +122,10 @@ describe('connect computer polling', () => {
     expect(api.list).toHaveBeenCalledOnce()
   })
 
-  it('does not advance or duplicate grants while authorization is still pending', async () => {
+  it('serializes grants and resumes a new connection after the previous grant finishes', async () => {
     let finishGrant!: (value: { data: object }) => void
     api.grant.mockImplementationOnce(() => new Promise(resolve => { finishGrant = resolve }))
-    await mount()
+    const props = await mount()
     items.value = [{ ...credential, online: true }]
     await vi.advanceTimersByTimeAsync(1000)
     await flush()
@@ -135,8 +136,17 @@ describe('connect computer polling', () => {
     await flush()
     expect(api.grant).toHaveBeenCalledOnce()
     expect(root.textContent).not.toContain('access-list')
+    props.open = false
+    await flush()
+    props.credential = { id: 'runtime-2', key: 'second-key' }
+    items.value = [{ ...props.credential, online: true }]
+    props.open = true
+    await flush()
+    expect(api.grant).toHaveBeenCalledOnce()
     finishGrant({ data: {} })
     await flush()
+    expect(api.grant).toHaveBeenCalledTimes(2)
+    expect(api.grant.mock.lastCall?.[0].path.runtime_id).toBe('runtime-2')
     expect(root.textContent).toContain('access-list')
   })
 

--- a/apps/web/src/components/computer/connect-computer-dialog.test.ts
+++ b/apps/web/src/components/computer/connect-computer-dialog.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, reactive, ref, type App, type Slots } from 'vue'
+import { createPinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+import type { UserruntimeRuntime } from '@memohai/sdk'
+import ConnectComputerDialog from './connect-computer-dialog.vue'
+
+const api = vi.hoisted(() => ({ list: vi.fn(), remove: vi.fn(), grant: vi.fn() }))
+vi.mock('@memohai/sdk', () => ({
+  getUsersMeRuntimes: api.list,
+  deleteUsersMeRuntimesById: api.remove,
+  putBotsByBotIdWorkspaceTargetsRemotesByRuntimeId: api.grant,
+}))
+vi.mock('@memohai/sdk/colada', () => ({
+  getBotsQuery: () => ({ key: ['bots'], query: async () => ({ items: [{ id: 'bot-1' }] }) }),
+}))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('@/lib/api-client', () => ({ sdkApiBaseUrl: () => '/api' }))
+vi.mock('@/pages/runtimes/command', () => ({ buildRuntimeConnectCommand: () => 'runtime command' }))
+vi.mock('./computer-access-list.vue', () => ({ default: () => h('div', 'access-list') }))
+vi.mock('@felinic/ui', () => {
+  const Wrapper = (_props: unknown, { slots }: { slots: Slots }) => h('div', slots.default?.())
+  return {
+    Button: (_props: unknown, { slots }: { slots: Slots }) => h('button', slots.default?.()),
+    Dialog: Wrapper, DialogContent: Wrapper, DialogDescription: Wrapper,
+    DialogFooter: Wrapper, DialogHeader: Wrapper, DialogTitle: Wrapper,
+    toast: { success: vi.fn(), error: vi.fn() },
+    useClipboard: () => ({ copyText: vi.fn() }),
+  }
+})
+
+let app: App | undefined
+let root: HTMLDivElement
+const credential = { id: 'runtime-1', key: 'test-key' }
+let items = ref<UserruntimeRuntime[]>([])
+
+async function flush() {
+  for (let i = 0; i < 12; i++) await nextTick()
+}
+
+async function mount(open = true) {
+  const props = reactive({ open, credential })
+  root = document.createElement('div')
+  app = createApp(() => h(ConnectComputerDialog, {
+    ...props, 'onUpdate:open': (value: boolean) => { props.open = value },
+  }))
+  app.use(createPinia()).use(PiniaColada)
+  app.mount(root)
+  await flush()
+  return props
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  items = ref([])
+  api.list.mockImplementation(async () => ({ data: items.value }))
+  api.grant.mockResolvedValue({ data: {} })
+  api.remove.mockResolvedValue({})
+})
+afterEach(() => {
+  app?.unmount()
+  app = undefined
+  vi.useRealTimers()
+})
+
+describe('connect computer polling', () => {
+  it('detects a connection without visibility events and stops after success', async () => {
+    await mount()
+    expect(root.textContent).toContain('computerConnect.waiting')
+    items.value = [{ ...credential, online: true, name: 'Computer' }]
+    await vi.advanceTimersByTimeAsync(1000)
+    await flush()
+    expect(root.textContent).toContain('access-list')
+    expect(api.grant).toHaveBeenCalledOnce()
+    const calls = api.list.mock.calls.length
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(api.list).toHaveBeenCalledTimes(calls)
+  })
+
+  it('does not overlap slow requests and recovers after a failed query', async () => {
+    let reject!: (reason: Error) => void
+    api.list.mockImplementationOnce(() => new Promise((_resolve, rejectRequest) => { reject = rejectRequest }))
+    await mount()
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(api.list).toHaveBeenCalledOnce()
+    reject(new Error('temporary outage'))
+    await flush()
+    items.value = [{ ...credential, online: true }]
+    await vi.advanceTimersByTimeAsync(1000)
+    await flush()
+    expect(root.textContent).toContain('access-list')
+  })
+
+  it('does not poll while closed and starts immediately when opened', async () => {
+    const props = await mount(false)
+    const calls = api.list.mock.calls.length
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(api.list).toHaveBeenCalledTimes(calls)
+    props.open = true
+    await flush()
+    expect(api.list).toHaveBeenCalledTimes(calls + 1)
+    props.open = false
+    await flush()
+    const afterClose = api.list.mock.calls.length
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(api.list).toHaveBeenCalledTimes(afterClose)
+  })
+
+  it('does not grant access or restart polling when a request resolves after close', async () => {
+    let resolve!: (value: { data: UserruntimeRuntime[] }) => void
+    api.list.mockImplementationOnce(() => new Promise(resolveRequest => { resolve = resolveRequest }))
+    const props = await mount()
+    props.open = false
+    await flush()
+    resolve({ data: [{ ...credential, online: true }] })
+    await flush()
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(api.grant).not.toHaveBeenCalled()
+    expect(api.list).toHaveBeenCalledOnce()
+  })
+
+  it('does not advance or duplicate grants while authorization is still pending', async () => {
+    let finishGrant!: (value: { data: object }) => void
+    api.grant.mockImplementationOnce(() => new Promise(resolve => { finishGrant = resolve }))
+    await mount()
+    items.value = [{ ...credential, online: true }]
+    await vi.advanceTimersByTimeAsync(1000)
+    await flush()
+    expect(api.grant).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(6000)
+    items.value = [{ ...credential, online: true }]
+    document.dispatchEvent(new Event('visibilitychange'))
+    await flush()
+    expect(api.grant).toHaveBeenCalledOnce()
+    expect(root.textContent).not.toContain('access-list')
+    finishGrant({ data: {} })
+    await flush()
+    expect(root.textContent).toContain('access-list')
+  })
+
+  it('stops polling on unmount', async () => {
+    await mount()
+    app?.unmount()
+    app = undefined
+    const calls = api.list.mock.calls.length
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(api.list).toHaveBeenCalledTimes(calls)
+  })
+})

--- a/apps/web/src/components/computer/connect-computer-dialog.vue
+++ b/apps/web/src/components/computer/connect-computer-dialog.vue
@@ -147,18 +147,23 @@ watch([open, runtimeId, step, () => !!connectedRuntime.value], ([isOpen, id, cur
 }, { immediate: true })
 
 const granting = ref(false)
-watch(connectedRuntime, async (runtime) => {
+// A newly opened connection may become online while the previous grant is
+// still running. Re-check it when that grant releases the shared busy state.
+watch([connectedRuntime, granting, open], async ([runtime]) => {
   if (!open.value || !runtime || step.value !== 'command' || granting.value) return
   adoptedName.value = runtime.name || runtime.hostname || runtimeId.value
   toast.success(t('runtimes.computerOnline', { name: adoptedName.value }))
   const connectedId = runtimeId.value
-  await grantAllBots(connectedId)
-  if (open.value && runtimeId.value === connectedId) step.value = 'access'
+  granting.value = true
+  try {
+    await grantAllBots(connectedId)
+    if (open.value && runtimeId.value === connectedId) step.value = 'access'
+  } finally {
+    granting.value = false
+  }
 })
 
 async function grantAllBots(connectedId: string): Promise<void> {
-  if (granting.value) return
-  granting.value = true
   let failed = 0
   for (const bot of botsData.value?.items ?? []) {
     if (!bot.id) continue
@@ -168,7 +173,6 @@ async function grantAllBots(connectedId: string): Promise<void> {
       failed += 1
     }
   }
-  granting.value = false
   if (failed > 0) {
     toast.error(t('computerAccess.updateFailed'))
   }

--- a/apps/web/src/components/computer/connect-computer-dialog.vue
+++ b/apps/web/src/components/computer/connect-computer-dialog.vue
@@ -128,23 +128,42 @@ const adoptedName = ref('')
 const connectedRuntime = computed(() => (
   (runtimes.value ?? []).find(runtime => runtime.id === runtimeId.value && runtime.online)
 ))
-watch(connectedRuntime, async (runtime) => {
-  if (!runtime || step.value !== 'command') return
-  adoptedName.value = runtime.name || runtime.hostname || runtimeId.value
-  toast.success(t('runtimes.computerOnline', { name: adoptedName.value }))
-  await grantAllBots()
-  step.value = 'access'
-})
+// Own connection refresh here rather than relying on polling in the caller.
+// Refetch resolves with Colada's error state on failure, so the next tick can
+// recover without overlapping requests or depending on browser focus events.
+watch([open, runtimeId, step, () => !!connectedRuntime.value], ([isOpen, id, currentStep, online], _previous, onCleanup) => {
+  if (!isOpen || !id || currentStep !== 'command' || online) return
+  let stopped = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  onCleanup(() => {
+    stopped = true
+    clearTimeout(timer)
+  })
+  async function poll(): Promise<void> {
+    await refetchRuntimes()
+    if (!stopped) timer = setTimeout(() => { void poll() }, 1000)
+  }
+  void poll()
+}, { immediate: true })
 
 const granting = ref(false)
-async function grantAllBots(): Promise<void> {
+watch(connectedRuntime, async (runtime) => {
+  if (!open.value || !runtime || step.value !== 'command' || granting.value) return
+  adoptedName.value = runtime.name || runtime.hostname || runtimeId.value
+  toast.success(t('runtimes.computerOnline', { name: adoptedName.value }))
+  const connectedId = runtimeId.value
+  await grantAllBots(connectedId)
+  if (open.value && runtimeId.value === connectedId) step.value = 'access'
+})
+
+async function grantAllBots(connectedId: string): Promise<void> {
   if (granting.value) return
   granting.value = true
   let failed = 0
   for (const bot of botsData.value?.items ?? []) {
     if (!bot.id) continue
     try {
-      await grantAccess({ botId: bot.id, runtimeId: runtimeId.value })
+      await grantAccess({ botId: bot.id, runtimeId: connectedId })
     } catch {
       failed += 1
     }


### PR DESCRIPTION
Connect computer 弹窗原来依赖调用方刷新状态：OSS 管理页每 5 秒查询一次，聊天内弹窗预览分支则没有主动查询周期。现在弹窗打开后立即查询，等待期间在每次请求结束 1 秒后再查；连接成功、关闭或卸载后停止。

同时修复 Codex 指出的 P2：旧电脑还在授权时关闭弹窗并连接第二台，第二台可能永久停在 Waiting。现在旧授权结束会重新检查当前连接，并按顺序完成授权。

### 验证

- **真人 QA 已通过原轮询修复**：用户在 `18089` 手动完成连接 happy path，并确认 `956f09eb8` 通过。之后补充的 P2 修复已有自动化回归，尚未真人复测。
- AI 实际连接验证（原轮询修复）：管理页 1.08 秒、聊天内弹窗 1.20 秒自动切页，无手动刷新；取消后停止查询、凭据撤销通过。
- 6 项组件测试通过，使用真实 Vue / Pinia Colada、模拟 API，覆盖连接发现、慢请求和错误恢复、关闭/卸载清理、迟到响应以及连续连接的串行授权。P2 用例修复前失败、修复后通过。
- ESLint、差异检查及提交钩子通过。全量 Web typecheck 原基线与首版修复均有相同的 448 条错误，不声明全量类型检查通过。

### OSS / Cloud

Cloud Runtime CLI 复用 Memoh 子模块中的 OSS Runtime 源码，Cloud 弹窗另有发布包名替换。此次仅修改共享前端，应由 OSS 同步到 Cloud，无需重新发布 Runtime 包；Cloud 尚未同步或做端到端验证。

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
