### PR TITLE
fix(agent): 模型服务失败按具体原因报错，重试失败不再外泄 pgx 原文

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -142,7 +142,11 @@
     },
     "agent": {
       "response_timeout": "The model did not respond in time. Please try again.",
-      "response_interrupted": "The model response was interrupted. Please try again."
+      "response_interrupted": "The model response was interrupted. Please try again.",
+      "provider_overloaded": "The model provider is overloaded right now. Please try again in a moment.",
+      "provider_rate_limited": "The model provider rate limit was reached. Please wait a moment before sending again.",
+      "provider_quota_exhausted": "The model provider account has no remaining balance or quota.",
+      "provider_auth_failed": "The model provider rejected the credentials. Check the provider API key."
     },
     "queue_request_invalid": "Enter text after /steer or /queue in an existing conversation.",
     "queue_no_active_run": "The current response has ended. Send this as a new message.",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -139,7 +139,11 @@
     },
     "agent": {
       "response_timeout": "モデルから時間内に応答がありませんでした。もう一度お試しください。",
-      "response_interrupted": "モデルの応答が中断されました。もう一度お試しください。"
+      "response_interrupted": "モデルの応答が中断されました。もう一度お試しください。",
+      "provider_overloaded": "モデルプロバイダーが混雑しています。しばらくしてからお試しください。",
+      "provider_rate_limited": "モデルプロバイダーのレート制限に達しました。少し待ってから送信してください。",
+      "provider_quota_exhausted": "モデルプロバイダーのアカウントに残高またはクォータが残っていません。",
+      "provider_auth_failed": "モデルプロバイダーが認証情報を拒否しました。プロバイダーの API キーを確認してください。"
     },
     "queue_request_invalid": "既存の会話で /steer または /queue の後に内容を入力してください。",
     "queue_no_active_run": "現在の応答は終了しています。内容を新しいメッセージとして送信してください。",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -142,7 +142,11 @@
     },
     "agent": {
       "response_timeout": "模型未能及时响应，请重试。",
-      "response_interrupted": "模型响应意外中断，请重试。"
+      "response_interrupted": "模型响应意外中断，请重试。",
+      "provider_overloaded": "模型服务当前过载，请稍后重试。",
+      "provider_rate_limited": "已达到模型服务的速率上限，请稍后再发送。",
+      "provider_quota_exhausted": "模型服务账户的余额或配额已用尽。",
+      "provider_auth_failed": "模型服务拒绝了当前凭据，请检查该服务商的 API Key。"
     },
     "queue_request_invalid": "请在已有会话中使用 /steer 或 /queue，并在命令后输入内容。",
     "queue_no_active_run": "当前回复已结束，请将内容作为新消息发送。",

--- a/apps/web/src/utils/api-error.test.ts
+++ b/apps/web/src/utils/api-error.test.ts
@@ -199,6 +199,14 @@ describe('resolveApiErrorMessage', () => {
     ['agent.response_interrupted', 'en', 'The model response was interrupted. Please try again.'],
     ['agent.response_interrupted', 'zh', '模型响应意外中断，请重试。'],
     ['agent.response_interrupted', 'ja', 'モデルの応答が中断されました。もう一度お試しください。'],
+    ['agent.provider_overloaded', 'en', 'The model provider is overloaded right now. Please try again in a moment.'],
+    ['agent.provider_overloaded', 'zh', '模型服务当前过载，请稍后重试。'],
+    ['agent.provider_overloaded', 'ja', 'モデルプロバイダーが混雑しています。しばらくしてからお試しください。'],
+    ['agent.provider_rate_limited', 'zh', '已达到模型服务的速率上限，请稍后再发送。'],
+    ['agent.provider_quota_exhausted', 'en', 'The model provider account has no remaining balance or quota.'],
+    ['agent.provider_quota_exhausted', 'zh', '模型服务账户的余额或配额已用尽。'],
+    ['agent.provider_auth_failed', 'en', 'The model provider rejected the credentials. Check the provider API key.'],
+    ['agent.provider_auth_failed', 'zh', '模型服务拒绝了当前凭据，请检查该服务商的 API Key。'],
   ])('localizes structural stream failure %s for %s', (code, language, expected) => {
     locale = language
 

--- a/internal/agent/application/provider_failure.go
+++ b/internal/agent/application/provider_failure.go
@@ -1,0 +1,52 @@
+package application
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/felinics/memoh/internal/apperror"
+)
+
+// Provider stream failures reach the application layer as the provider's own
+// text: the runtime forwards `StreamEvent.Error`, and the native runtime's
+// retry decision already reads the same text (`internal/agent/runtime/native/
+// retry.go`). The patterns below name the four conditions a user can act on.
+// Everything else keeps the generic interrupted response.
+var (
+	providerAuthPattern = regexp.MustCompile(
+		`(?i)api error 40[13]\b|invalid[ _-]api[ _-]key|invalid_request_error: incorrect api key|authentication_error|unauthorized|permission_denied`,
+	)
+	providerQuotaPattern = regexp.MustCompile(
+		`(?i)api error 402\b|insufficient[ _-](balance|quota|credit|funds)|exceeded your current quota|billing_(hard_limit|not_active)|payment required`,
+	)
+	providerRateLimitPattern = regexp.MustCompile(
+		`(?i)(^|[^0-9])429($|[^0-9])|rate[ _-]?limit|too many requests|usage limit reached`,
+	)
+	providerOverloadPattern = regexp.MustCompile(
+		`(?i)server_is_overloaded|overloaded_error|\boverloaded\b|api error 50[0234]\b|service unavailable|temporarily unavailable`,
+	)
+)
+
+// providerFailureCode names the provider condition a failure text describes, or
+// returns an empty code when the text does not identify one. Order resolves the
+// overlaps in provider wording: an exhausted quota is often reported alongside
+// a rate limit ("exceeded your current quota" arrives as a 429), and a rejected
+// key is reported alongside both, so the more specific cause is matched first.
+func providerFailureCode(detail string) apperror.Code {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return ""
+	}
+	switch {
+	case providerAuthPattern.MatchString(detail):
+		return apperror.CodeAgentProviderAuthFailed
+	case providerQuotaPattern.MatchString(detail):
+		return apperror.CodeAgentProviderQuotaExhausted
+	case providerRateLimitPattern.MatchString(detail):
+		return apperror.CodeAgentProviderRateLimited
+	case providerOverloadPattern.MatchString(detail):
+		return apperror.CodeAgentProviderOverloaded
+	default:
+		return ""
+	}
+}

--- a/internal/agent/application/provider_failure_test.go
+++ b/internal/agent/application/provider_failure_test.go
@@ -1,0 +1,100 @@
+package application
+
+import (
+	"testing"
+
+	"github.com/felinics/memoh/internal/agent/runtime/native"
+	"github.com/felinics/memoh/internal/apperror"
+)
+
+func TestProviderFailureCode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		detail string
+		want   apperror.Code
+	}{
+		{
+			name:   "codex overload",
+			detail: "openai-codex: server_is_overloaded: Our servers are currently overloaded. Please try again later.",
+			want:   apperror.CodeAgentProviderOverloaded,
+		},
+		{
+			name:   "anthropic overload",
+			detail: "anthropic: api error 529: {\"type\":\"overloaded_error\"}",
+			want:   apperror.CodeAgentProviderOverloaded,
+		},
+		{
+			name:   "upstream 503",
+			detail: "openai: stream failed: api error 503: Service Unavailable",
+			want:   apperror.CodeAgentProviderOverloaded,
+		},
+		{
+			name:   "insufficient balance",
+			detail: "openai: stream failed: api error 402: Insufficient Balance [body: {\"error\":{}}]",
+			want:   apperror.CodeAgentProviderQuotaExhausted,
+		},
+		{
+			name:   "exhausted quota reported as a rate limit",
+			detail: "openai: api error 429: You exceeded your current quota, please check your plan and billing details.",
+			want:   apperror.CodeAgentProviderQuotaExhausted,
+		},
+		{
+			name:   "rate limit",
+			detail: "anthropic: api error 429: rate_limit_error: number of request tokens has exceeded your per-minute rate limit",
+			want:   apperror.CodeAgentProviderRateLimited,
+		},
+		{
+			name:   "rejected key",
+			detail: "openai: stream start: api error 401: Incorrect API key provided",
+			want:   apperror.CodeAgentProviderAuthFailed,
+		},
+		{
+			name:   "a failure the provider does not name",
+			detail: "stream start: unexpected EOF",
+		},
+		{
+			name:   "no detail",
+			detail: "   ",
+		},
+		{
+			name:   "a request id that merely contains the digits",
+			detail: "openai: stream failed: request req_4291 ended early",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := providerFailureCode(tc.detail); got != tc.want {
+				t.Fatalf("providerFailureCode(%q) = %q, want %q", tc.detail, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAgentStreamLifecycleErrorReportsTheProviderCondition(t *testing.T) {
+	t.Parallel()
+
+	overloaded := agentStreamLifecycleError(native.StreamEvent{
+		Type:  native.EventError,
+		Error: "openai-codex: server_is_overloaded: Our servers are currently overloaded.",
+	})
+	if got := apperror.CodeOf(overloaded); got != apperror.CodeAgentProviderOverloaded {
+		t.Fatalf("code = %q, want %q", got, apperror.CodeAgentProviderOverloaded)
+	}
+
+	generic := agentStreamLifecycleError(native.StreamEvent{
+		Type:  native.EventError,
+		Error: "agent stream failed",
+	})
+	if got := apperror.CodeOf(generic); got != apperror.CodeAgentResponseInterrupted {
+		t.Fatalf("code = %q, want %q", got, apperror.CodeAgentResponseInterrupted)
+	}
+
+	public := agentFailureStreamEvent(overloaded)
+	if public.Code != string(apperror.CodeAgentProviderOverloaded) || public.Error == "" {
+		t.Fatalf("public event = %+v, want the overloaded code with a detail", public)
+	}
+}

--- a/internal/agent/application/service_retry_edit.go
+++ b/internal/agent/application/service_retry_edit.go
@@ -264,10 +264,17 @@ func (s *Service) resolveLatestVisibleTurn(ctx context.Context, sessionID, turnI
 	}
 	latest, err := s.messageService.GetLatestVisibleTurnBySession(ctx, sessionID)
 	if err != nil {
+		// A session with no visible turn at all and a session whose latest turn
+		// is a different one are the same answer to the client: the round it
+		// named is not the one the server can replace, so it has to reload.
+		// Both are reported with that code instead of the store's own wording.
+		if errors.Is(err, messagepkg.ErrNoVisibleTurn) {
+			return messagepkg.HistoryTurn{}, apperror.Wrap(apperror.CodeSessionHistoryInconsistent, err, nil)
+		}
 		return messagepkg.HistoryTurn{}, fmt.Errorf("load latest visible turn: %w", err)
 	}
 	if strings.TrimSpace(latest.ID) != turnID {
-		return messagepkg.HistoryTurn{}, errors.New(notLatest)
+		return messagepkg.HistoryTurn{}, apperror.Wrap(apperror.CodeSessionHistoryInconsistent, errors.New(notLatest), nil)
 	}
 	return latest, nil
 }

--- a/internal/agent/application/service_retry_edit_test.go
+++ b/internal/agent/application/service_retry_edit_test.go
@@ -22,11 +22,15 @@ type forkAnchorMessageService struct {
 type replacementOperationMessageService struct {
 	recordingMessageService
 	latest      messagepkg.HistoryTurn
+	latestErr   error
 	turnByMsg   messagepkg.HistoryTurn
 	turnByMsgID string
 }
 
 func (s *replacementOperationMessageService) GetLatestVisibleTurnBySession(context.Context, string) (messagepkg.HistoryTurn, error) {
+	if s.latestErr != nil {
+		return messagepkg.HistoryTurn{}, s.latestErr
+	}
 	return s.latest, nil
 }
 
@@ -140,6 +144,17 @@ func TestPrepareReplacementOperationUsesPersistedTurnBoundary(t *testing.T) {
 				RequestMessageID: "user-request",
 			},
 		}
+		service := &Service{messageService: messages}
+
+		_, err := service.PrepareRetryLatestTurnOperation(context.Background(), "session-1", "turn-old")
+		if got := apperror.CodeOf(err); got != apperror.CodeSessionHistoryInconsistent {
+			t.Fatalf("error code = %q, want %q", got, apperror.CodeSessionHistoryInconsistent)
+		}
+	})
+
+	// The store's own no-rows wording used to reach the composer verbatim.
+	t.Run("a session with no visible turn reports the history code", func(t *testing.T) {
+		messages := &replacementOperationMessageService{latestErr: messagepkg.ErrNoVisibleTurn}
 		service := &Service{messageService: messages}
 
 		_, err := service.PrepareRetryLatestTurnOperation(context.Background(), "session-1", "turn-old")

--- a/internal/agent/application/service_stream.go
+++ b/internal/agent/application/service_stream.go
@@ -37,7 +37,12 @@ func snapshotFailureCode(idleFired bool, cause error) apperror.Code {
 		return apperror.CodeAgentResponseTimeout
 	}
 	switch code := apperror.CodeOf(cause); code {
-	case apperror.CodeAgentResponseTimeout, apperror.CodeAgentResponseInterrupted:
+	case apperror.CodeAgentResponseTimeout,
+		apperror.CodeAgentResponseInterrupted,
+		apperror.CodeAgentProviderOverloaded,
+		apperror.CodeAgentProviderRateLimited,
+		apperror.CodeAgentProviderQuotaExhausted,
+		apperror.CodeAgentProviderAuthFailed:
 		return code
 	default:
 		return ""
@@ -92,6 +97,13 @@ func agentStreamLifecycleError(event native.StreamEvent) error {
 	err := agentStreamEventError(event)
 	if err == nil || apperror.CodeOf(err) != "" {
 		return err
+	}
+	// A provider that names why it refused the request is reported with that
+	// reason: an exhausted balance and a rejected key both need the user to go
+	// change something, and "the model response was interrupted, please try
+	// again" sends them back into a call that cannot succeed.
+	if code := providerFailureCode(event.Error); code != "" {
+		return apperror.Wrap(code, err, nil)
 	}
 	return apperror.Wrap(apperror.CodeAgentResponseInterrupted, err, nil)
 }

--- a/internal/apperror/error.go
+++ b/internal/apperror/error.go
@@ -103,6 +103,10 @@ const (
 	CodeSessionHistoryInconsistent               Code = "session_runtime.history_inconsistent"
 	CodeAgentResponseTimeout                     Code = "agent.response_timeout"
 	CodeAgentResponseInterrupted                 Code = "agent.response_interrupted"
+	CodeAgentProviderOverloaded                  Code = "agent.provider_overloaded"
+	CodeAgentProviderRateLimited                 Code = "agent.provider_rate_limited"
+	CodeAgentProviderQuotaExhausted              Code = "agent.provider_quota_exhausted"
+	CodeAgentProviderAuthFailed                  Code = "agent.provider_auth_failed"
 	CodeQueueNoActiveRun                         Code = "queue_no_active_run"
 	CodeQueueAdmissionOverloaded                 Code = "queue_admission_overloaded"
 	CodeQueueAdmissionUnavailable                Code = "queue_admission_unavailable"
@@ -542,6 +546,22 @@ var catalog = map[Code]Definition{
 	CodeAgentResponseInterrupted: {
 		HTTPStatus: http.StatusBadGateway,
 		Detail:     "The model response was interrupted. Please try again.",
+	},
+	CodeAgentProviderOverloaded: {
+		HTTPStatus: http.StatusServiceUnavailable,
+		Detail:     "The model provider is overloaded right now. Please try again in a moment.",
+	},
+	CodeAgentProviderRateLimited: {
+		HTTPStatus: http.StatusTooManyRequests,
+		Detail:     "The model provider rate limit was reached. Please wait a moment before sending again.",
+	},
+	CodeAgentProviderQuotaExhausted: {
+		HTTPStatus: http.StatusPaymentRequired,
+		Detail:     "The model provider account has no remaining balance or quota.",
+	},
+	CodeAgentProviderAuthFailed: {
+		HTTPStatus: http.StatusUnauthorized,
+		Detail:     "The model provider rejected the credentials. Check the provider API key.",
 	},
 	CodeQueueSteerUnsupported: {
 		HTTPStatus: http.StatusConflict,

--- a/internal/chat/message/service.go
+++ b/internal/chat/message/service.go
@@ -1358,6 +1358,11 @@ func (s *DBService) GetVisibleTurnByMessage(ctx context.Context, sessionID strin
 	return toHistoryTurn(row), nil
 }
 
+// ErrNoVisibleTurn reports that a session holds no visible turn at all. It is
+// a sentinel rather than the driver's own no-rows error so callers can map it
+// onto a user-facing code instead of surfacing the driver's wording.
+var ErrNoVisibleTurn = errors.New("session has no visible turn")
+
 func (s *DBService) GetLatestVisibleTurnBySession(ctx context.Context, sessionID string) (HistoryTurn, error) {
 	pgSessionID, err := dbpkg.ParseUUID(sessionID)
 	if err != nil {
@@ -1365,6 +1370,9 @@ func (s *DBService) GetLatestVisibleTurnBySession(ctx context.Context, sessionID
 	}
 	row, err := s.queries.GetLatestVisibleHistoryTurnBySession(ctx, pgSessionID)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return HistoryTurn{}, ErrNoVisibleTurn
+		}
 		return HistoryTurn{}, err
 	}
 	return toHistoryTurn(row), nil


### PR DESCRIPTION
## 问题

### 1. 模型服务的失败原因被统一成"回复被中断"

流式轮次在产生任何可见输出之前终止时，`streamErrorToAppError` 把失败一律包装成 `agent.response_interrupted`，界面显示"模型回复被中断，请重试"。余额耗尽和 API Key 被拒这两类情况需要用户去改配置，该提示会把用户送回一个不可能成功的调用。

### 2. `pgx` 的原始文本外泄到界面

会话内没有任何可见轮次时，`GetLatestVisibleTurnBySession` 返回 `pgx.ErrNoRows`，`resolveLatestVisibleTurn` 用 `fmt.Errorf` 包装后没有携带任何 apperror code，界面上直接出现 `load latest visible turn: no rows in result set`。

## 改动

新增 `providerFailureCode`（`internal/agent/application/provider_failure.go`）按错误文本识别四类模型服务失败，并补齐对应的 apperror code 与 en/zh/ja 文案：

| code | HTTP | 场景 |
|---|---|---|
| `agent.provider_auth_failed` | 401 | 凭据被拒 |
| `agent.provider_quota_exhausted` | 402 | 余额或配额耗尽 |
| `agent.provider_rate_limited` | 429 | 触及速率上限 |
| `agent.provider_overloaded` | 503 | 服务过载 |

四个正则按具体程度从高到低匹配（auth → quota → rate limit → overload），因为各服务商的错误文本存在重叠。识别失败时仍回落到 `agent.response_interrupted`，已携带 code 的错误不被覆盖。

`GetLatestVisibleTurnBySession` 把 `pgx.ErrNoRows` 映射为 sentinel `message.ErrNoVisibleTurn`，`resolveLatestVisibleTurn` 将其与已有的 "not latest" 分支统一映射为 `apperror.CodeSessionHistoryInconsistent`，该 code 三语文案此前已存在。

## 不在本次范围

停止生成后重试仍然无法执行。原因是一个轮次的存在被记录在两个存储里：`session_runs` 在准入时就铸出 `turn_id`，`bot_history_messages` 只在第一次 step commit 时才写行；在出现可见输出之前终止的轮次没有任何历史行，重试找不到可取代的轮次。本次只修正了该情况下显示的错误文案，前端提示从 `no rows in result set` 变为 `session_runtime.history_inconsistent` 的文案。

## 验证

- `go build ./...`、`go vet ./...`
- `go test ./internal/agent/application/... ./internal/chat/message/... ./internal/apperror/...`
- `mise run lint:go`
- `pnpm vitest run apps/web/src/utils/api-error.test.ts`（59 passed）

新增测试：`TestProviderFailureCode` 覆盖 10 个用例，含否定用例 `request req_4291`（不应匹配 429）；`TestAgentStreamLifecycleErrorReportsTheProviderCondition`；`service_retry_edit_test.go` 新增无可见轮次时返回 `history_inconsistent` 的子测试。

