### PR TITLE
feat(apps): authorize connectors during installation

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -3675,15 +3675,15 @@
     "unnamedSkill": "Unnamed skill",
     "dependenciesHint": "Installed into the bot's workspace and shared with other Apps that need them.",
     "dependencyPending": "Loading…",
-    "connectorsHint": "Each connector needs your authorization after the App is installed.",
+    "connectorsHint": "Authorize connectors during installation.",
     "connectorsUnavailableHint": "Connect-It is not configured on this server; these connectors will stay unauthorized.",
-    "connectorAuthHint": "Authorize after installing.",
+    "connectorAuthHint": "Authorize during installation.",
     "license": "License",
     "repository": "Repository",
     "revision": "Revision",
     "installPreview": "Installing will",
     "installPreviewDependency": "install into the workspace if missing",
-    "installPreviewConnector": "need your authorization",
+    "installPreviewConnector": "authorize during installation",
     "installPreviewConnectorOptional": "can be authorized later (optional)",
     "viewAll": "View all"
   },
@@ -3916,7 +3916,11 @@
       "noLog": "No script output.",
       "log": "Operation log",
       "runInBackground": "Run in background",
-      "reconnecting": "Connection to the server was lost; checking the result…"
+      "reconnecting": "Connection to the server was lost; checking the result…",
+      "preparingAuthorization": "Preparing authorization…",
+      "awaitingAuthorization": "Complete authorization in the opened window.",
+      "authorize": "Connect {name} to finish installation.",
+      "authorizationLoadFailed": "Could not load authorization. Try again."
     },
     "steps": {
       "skills": "Skills",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -3669,15 +3669,15 @@
     "unnamedSkill": "名前のないスキル",
     "dependenciesHint": "Bot のワークスペースにインストールされ、必要とする他のアプリと共有されます。",
     "dependencyPending": "読み込み中…",
-    "connectorsHint": "アプリをインストールした後、各コネクターの認証が必要です。",
+    "connectorsHint": "インストール中にコネクターを認証できます。",
     "connectorsUnavailableHint": "このサーバーでは Connect-It が設定されていないため、これらのコネクターは未認証のままになります。",
-    "connectorAuthHint": "インストール後に認証します。",
+    "connectorAuthHint": "インストール中に認証します。",
     "license": "ライセンス",
     "repository": "リポジトリ",
     "revision": "リビジョン",
     "installPreview": "インストールすると",
     "installPreviewDependency": "未インストールならワークスペースにインストールします",
-    "installPreviewConnector": "認証が必要です",
+    "installPreviewConnector": "インストール中に認証",
     "installPreviewConnectorOptional": "後で認証できます（任意）",
     "viewAll": "すべて表示"
   },
@@ -3910,7 +3910,11 @@
       "noLog": "スクリプトの出力はありません。",
       "log": "操作ログ",
       "runInBackground": "バックグラウンドで実行",
-      "reconnecting": "サーバーとの接続が切れました。結果を確認しています…"
+      "reconnecting": "サーバーとの接続が切れました。結果を確認しています…",
+      "preparingAuthorization": "認証を準備しています…",
+      "awaitingAuthorization": "開いたウィンドウで認証を完了してください。",
+      "authorize": "{name} に接続してインストールを完了します。",
+      "authorizationLoadFailed": "認証情報を読み込めませんでした。もう一度お試しください。"
     },
     "steps": {
       "skills": "スキル",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -3675,15 +3675,15 @@
     "unnamedSkill": "未命名 Skill",
     "dependenciesHint": "安装到 Bot 的工作区，并与需要它们的其他应用共享。",
     "dependencyPending": "加载中…",
-    "connectorsHint": "安装应用后，每个连接器都需要你授权。",
+    "connectorsHint": "安装时即可完成连接器授权。",
     "connectorsUnavailableHint": "服务器未配置 Connect-It，这些连接器将保持未授权状态。",
-    "connectorAuthHint": "安装后授权。",
+    "connectorAuthHint": "安装时授权。",
     "license": "许可证",
     "repository": "仓库",
     "revision": "版本修订",
     "installPreview": "安装将会",
     "installPreviewDependency": "缺失时安装到工作区",
-    "installPreviewConnector": "需要你授权",
+    "installPreviewConnector": "安装时授权",
     "installPreviewConnectorOptional": "可稍后授权（可选）",
     "viewAll": "查看全部"
   },
@@ -3916,7 +3916,11 @@
       "noLog": "没有脚本输出。",
       "log": "操作日志",
       "runInBackground": "后台运行",
-      "reconnecting": "与服务器的连接中断，正在确认结果…"
+      "reconnecting": "与服务器的连接中断，正在确认结果…",
+      "preparingAuthorization": "正在准备授权…",
+      "awaitingAuthorization": "请在打开的窗口中完成授权。",
+      "authorize": "连接 {name} 以完成安装。",
+      "authorizationLoadFailed": "无法加载授权信息，请重试。"
     },
     "steps": {
       "skills": "Skills",

--- a/apps/web/src/pages/bots/components/app-connector-auth-dialog.vue
+++ b/apps/web/src/pages/bots/components/app-connector-auth-dialog.vue
@@ -1,3 +1,40 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  Alert, AlertDescription, AlertTitle, Button, Dialog, DialogBody,
+  DialogDescription, DialogFooter, DialogHeader, DialogPanel, DialogTitle, toast,
+} from '@felinic/ui'
+import type { ConnectitConnector } from '@memohai/sdk'
+import type { AppConnectorItem } from '@/composables/api/useApps'
+import AppConnectorAuthForm from './app-connector-auth-form.vue'
+
+const props = defineProps<{
+  open: boolean
+  botId: string
+  installationId: string
+  appName: string
+  connector: AppConnectorItem | null
+  catalog: ConnectitConnector | undefined
+}>()
+const emit = defineEmits<{
+  'update:open': [open: boolean]
+  authorized: []
+}>()
+const { t } = useI18n()
+const authForm = ref<InstanceType<typeof AppConnectorAuthForm> | null>(null)
+function updateOpen(open: boolean) {
+  if (!open && authForm.value?.phase === 'submitting') return
+  if (!open) authForm.value?.cancel()
+  emit('update:open', open)
+}
+function authorized() {
+  toast.success(t('connectors.connectedSuccess', { name: props.catalog?.name || props.connector?.type }))
+  emit('update:open', false)
+  emit('authorized')
+}
+</script>
+
 <template>
   <Dialog
     :open="open"
@@ -8,304 +45,40 @@
       footer
     >
       <DialogHeader>
-        <DialogTitle>
-          {{ t('connectors.connectTitle', { name: catalog?.name || connector?.type || t('connectors.unknown') }) }}
-        </DialogTitle>
-        <DialogDescription>
-          {{ catalog?.description || t('apps.connector.authDescription', { name: appName }) }}
-        </DialogDescription>
+        <DialogTitle>{{ t('connectors.connectTitle', { name: catalog?.name || connector?.type || t('connectors.unknown') }) }}</DialogTitle>
+        <DialogDescription>{{ catalog?.description || t('apps.connector.authDescription', { name: appName }) }}</DialogDescription>
       </DialogHeader>
-
       <DialogBody>
-        <Alert
-          v-if="!catalog"
-          variant="default"
-        >
+        <AppConnectorAuthForm
+          v-if="open && catalog"
+          ref="authForm"
+          :bot-id="botId"
+          :installation-id="installationId"
+          :connector="connector"
+          :catalog="catalog"
+          @authorized="authorized"
+        />
+        <Alert v-else>
           <AlertTitle>{{ t('apps.connector.unavailableTitle') }}</AlertTitle>
           <AlertDescription>{{ t('apps.connector.unavailableDescription') }}</AlertDescription>
         </Alert>
-        <form
-          v-else
-          id="app-connector-auth-form"
-          @submit.prevent="connect"
-        >
-          <FormStack>
-            <FormField
-              v-if="authMethods.length > 1"
-              v-slot="{ componentField }"
-              name="auth_method"
-            >
-              <FieldStack :label="t('connectors.authMethod')">
-                <FormControl>
-                  <Select v-bind="componentField">
-                    <SelectTrigger class="w-full">
-                      <SelectValue :placeholder="t('connectors.selectAuthMethod')" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem
-                        v-for="method in authMethods"
-                        :key="method.key"
-                        :value="method.key!"
-                      >
-                        {{ method.label || method.key }}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </FormControl>
-              </FieldStack>
-            </FormField>
-
-            <FormField
-              v-for="field in credentialFields"
-              :key="field.key"
-              v-slot="{ componentField }"
-              :name="`fields.${field.key}`"
-            >
-              <FieldStack
-                :label="field.label || field.key"
-                :help="field.description"
-              >
-                <FormControl>
-                  <Select
-                    v-if="field.input_type === 'select'"
-                    v-bind="componentField"
-                  >
-                    <SelectTrigger class="w-full">
-                      <SelectValue :placeholder="field.label || field.key" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem
-                        v-for="option in field.options ?? []"
-                        :key="option"
-                        :value="option"
-                      >
-                        {{ option }}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    v-else
-                    v-bind="componentField"
-                    :type="field.secret ? 'password' : 'text'"
-                    :placeholder="t('connectors.credentialPlaceholder', { field: field.label || field.key })"
-                  />
-                </FormControl>
-              </FieldStack>
-            </FormField>
-          </FormStack>
-        </form>
       </DialogBody>
-
       <DialogFooter>
-        <DialogClose as-child>
-          <Button
-            variant="outline"
-            :disabled="phase === 'submitting'"
-          >
-            {{ t('common.cancel') }}
-          </Button>
-        </DialogClose>
+        <Button
+          variant="outline"
+          :disabled="authForm?.phase === 'submitting'"
+          @click="updateOpen(false)"
+        >
+          {{ t('common.cancel') }}
+        </Button>
         <Button
           v-if="catalog"
-          form="app-connector-auth-form"
-          type="submit"
-          :loading="phase !== 'idle'"
+          :loading="!!authForm && authForm.phase !== 'idle'"
+          @click="authForm?.connect()"
         >
-          {{ phase === 'awaiting-oauth' ? t('connectors.awaitingAuthorization') : t('connectors.connect') }}
+          {{ authForm?.phase === 'awaiting-oauth' ? t('connectors.awaitingAuthorization') : t('connectors.connect') }}
         </Button>
       </DialogFooter>
     </DialogPanel>
   </Dialog>
 </template>
-
-<script setup lang="ts">
-// Authorizes one connector an App references. The connection is created
-// through the App endpoints so the Server links it to the installation;
-// the OAuth popup handling is the same as before.
-import { computed, ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { useForm } from 'vee-validate'
-import { toTypedSchema } from '@vee-validate/zod'
-import z from 'zod'
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-  Button,
-  Dialog,
-  DialogBody,
-  DialogClose,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogPanel,
-  DialogTitle,
-  FieldStack,
-  FormControl,
-  FormField,
-  FormStack,
-  Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  toast,
-} from '@felinic/ui'
-import type { ConnectitAuthMethod, ConnectitConnector } from '@memohai/sdk'
-import {
-  beginAppConnectorOAuth,
-  createAppConnectorCredential,
-  type AppConnectorItem,
-} from '@/composables/api/useApps'
-import {
-  connectorOAuthErrorKey,
-  isConnectorOAuthCancelled,
-  openConnectorOAuthURL,
-  prepareConnectorOAuthPopup,
-  waitForConnectorOAuth,
-} from '@/composables/useConnectorOAuth'
-import { resolveApiErrorMessage } from '@/utils/api-error'
-
-const props = defineProps<{
-  open: boolean
-  botId: string
-  installationId: string
-  appName: string
-  connector: AppConnectorItem | null
-  /** Catalog entry for the connector type, undefined when Connect-It lacks it. */
-  catalog: ConnectitConnector | undefined
-}>()
-
-const emit = defineEmits<{
-  'update:open': [open: boolean]
-  authorized: []
-}>()
-
-const { t } = useI18n()
-const schema = toTypedSchema(z.object({
-  auth_method: z.string().min(1, t('connectors.validation.authMethodRequired')),
-  fields: z.record(z.string(), z.string().optional()),
-}))
-const form = useForm({
-  validationSchema: schema,
-  initialValues: { auth_method: '', fields: {} },
-})
-
-const authMethods = computed(() => (props.catalog?.auth_methods ?? []).filter(method => method.key))
-const selectedMethod = computed<ConnectitAuthMethod | undefined>(() =>
-  authMethods.value.find(method => method.key === form.values.auth_method),
-)
-function methodCredentialFields(method: ConnectitAuthMethod | undefined) {
-  if (method?.type === 'oauth2') return []
-  return (method?.credential_fields ?? []).filter(field => field.key)
-}
-function credentialDefaults(method: ConnectitAuthMethod | undefined): Record<string, string> {
-  return Object.fromEntries(methodCredentialFields(method).map(field => [field.key!, field.default_value ?? '']))
-}
-const credentialFields = computed(() => methodCredentialFields(selectedMethod.value))
-
-watch(
-  () => [props.open, props.connector, props.catalog] as const,
-  ([open]) => {
-    if (!open) return
-    const method = authMethods.value[0]
-    form.resetForm({ values: { auth_method: method?.key || '', fields: credentialDefaults(method) } })
-  },
-  { immediate: true },
-)
-
-watch(
-  () => form.values.auth_method,
-  (methodKey, previous) => {
-    if (!props.open || !previous || methodKey === previous) return
-    form.setFieldValue('fields', credentialDefaults(authMethods.value.find(item => item.key === methodKey)))
-  },
-)
-
-const phase = ref<'idle' | 'submitting' | 'awaiting-oauth'>('idle')
-let attempt: AbortController | null = null
-
-function updateOpen(open: boolean) {
-  if (!open) {
-    if (phase.value === 'submitting') return
-    attempt?.abort()
-  }
-  emit('update:open', open)
-}
-
-async function connect() {
-  if (phase.value !== 'idle') return
-  const method = selectedMethod.value
-  const connectorType = props.connector?.type
-  const oauthPopup = method?.type === 'oauth2' ? prepareConnectorOAuthPopup(t('common.loading')) : null
-  if (method?.type === 'oauth2' && !oauthPopup && !window.api?.desktop?.openExternalUrl) {
-    toast.error(t('connectors.oauthPopupBlocked'))
-    return
-  }
-  const flow = new AbortController()
-  attempt = flow
-  phase.value = 'submitting'
-  try {
-    const validation = await form.validate()
-    if (!validation.valid || !connectorType || !method?.key) {
-      oauthPopup?.close()
-      return
-    }
-    let credentialValid = true
-    for (const field of credentialFields.value) {
-      if (!field.key) continue
-      const value = String(form.values.fields?.[field.key] ?? '').trim()
-      if (field.required && !value) {
-        form.setFieldError(`fields.${field.key}`, t('connectors.validation.fieldRequired', { field: field.label || field.key }))
-        credentialValid = false
-      }
-      if (value && field.pattern && !new RegExp(field.pattern).test(value)) {
-        form.setFieldError(`fields.${field.key}`, t('connectors.validation.fieldInvalid', { field: field.label || field.key }))
-        credentialValid = false
-      }
-    }
-    if (!credentialValid) {
-      oauthPopup?.close()
-      return
-    }
-
-    if (method.type === 'oauth2') {
-      const result = await beginAppConnectorOAuth(props.botId, props.installationId, connectorType, method.key)
-      const connectionId = result.connection_id
-      if (!result.authorization_url || !connectionId) throw new Error('oauth_failed')
-      if (flow.signal.aborted) return
-      phase.value = 'awaiting-oauth'
-      await openConnectorOAuthURL(result.authorization_url, oauthPopup)
-      try {
-        await waitForConnectorOAuth(props.botId, connectionId, oauthPopup, flow.signal)
-      } catch (error) {
-        if (!isConnectorOAuthCancelled(error)) throw error
-        return
-      }
-    } else {
-      await createAppConnectorCredential(
-        props.botId,
-        props.installationId,
-        connectorType,
-        method.key,
-        Object.fromEntries(Object.entries(form.values.fields ?? {}).map(([key, value]) => [key, String(value ?? '').trim()])),
-      )
-    }
-    toast.success(t('connectors.connectedSuccess', { name: props.catalog?.name || connectorType }))
-    emit('update:open', false)
-    emit('authorized')
-  } catch (error) {
-    oauthPopup?.close()
-    if (flow.signal.aborted) return
-    const oauthKey = connectorOAuthErrorKey(error)
-    toast.error(oauthKey ? t(oauthKey) : resolveApiErrorMessage(error, t('connectors.connectFailed')))
-  } finally {
-    if (flow.signal.aborted) oauthPopup?.close()
-    if (attempt === flow) {
-      attempt = null
-      phase.value = 'idle'
-    }
-  }
-}
-</script>

--- a/apps/web/src/pages/bots/components/app-connector-auth-form.test.ts
+++ b/apps/web/src/pages/bots/components/app-connector-auth-form.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import AppConnectorAuthForm from './app-connector-auth-form.vue'
+
+const mocks = vi.hoisted(() => ({ begin: vi.fn(), credential: vi.fn(), prepare: vi.fn(), open: vi.fn(), wait: vi.fn() }))
+vi.mock('@/composables/api/useApps', () => ({ beginAppConnectorOAuth: mocks.begin, createAppConnectorCredential: mocks.credential }))
+vi.mock('@/composables/useConnectorOAuth', () => ({
+  prepareConnectorOAuthPopup: mocks.prepare, openConnectorOAuthURL: mocks.open, waitForConnectorOAuth: mocks.wait,
+  connectorOAuthErrorKey: () => null,
+  isConnectorOAuthCancelled: (error: Error) => error.message === 'cancelled',
+}))
+vi.mock('@/utils/api-error', () => ({ resolveApiErrorMessage: (_: unknown, fallback: string) => fallback }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+vi.mock('@felinic/ui', async () => {
+  const { Field } = await import('vee-validate')
+  const slot = { template: '<div><slot /></div>' }
+  return {
+    Alert: slot, AlertTitle: slot, AlertDescription: slot, FormStack: slot, FormControl: slot,
+    FormField: { components: { Field }, props: ['name'], template: '<Field :name="name" v-slot="{ componentField, errors }"><slot :componentField="componentField" /><span>{{ errors[0] }}</span></Field>' },
+    FieldStack: { props: ['label'], template: '<div><label>{{ label }}</label><slot /></div>' },
+    Input: { props: ['modelValue'], emits: ['update:modelValue'], template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />' },
+    Select: { props: ['modelValue'], emits: ['update:modelValue'], template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>' },
+    SelectContent: { template: '<slot />' }, SelectItem: { props: ['value'], template: '<option :value="value"><slot /></option>' },
+    SelectTrigger: { template: '<span />' }, SelectValue: slot,
+  }
+})
+
+let app: App | undefined
+let root: HTMLDivElement
+const flush = async () => { for (let i = 0; i < 8; i++) { await Promise.resolve(); await nextTick() } }
+function setup(methods: unknown[], extra: Record<string, unknown> = {}) {
+  const authorized = vi.fn()
+  const phase = vi.fn()
+  root = document.createElement('div')
+  document.body.append(root)
+  let form!: InstanceType<typeof AppConnectorAuthForm>
+  app = createApp({ render: () => h(AppConnectorAuthForm, {
+    ref: (instance: unknown) => { form = instance as typeof form }, botId: 'bot', installationId: 'installation',
+    connector: { type: 'example' }, catalog: { type: 'example', auth_methods: methods },
+    onAuthorized: authorized, onPhase: phase, ...extra,
+  } as never) })
+  app.mount(root)
+  return { get form() { return form }, authorized, phase }
+}
+const oauth = [{ key: 'oauth', type: 'oauth2' }]
+beforeEach(() => {
+  mocks.begin.mockResolvedValue({ connection_id: 'connection', authorization_url: 'https://example.com/authorize' })
+  mocks.open.mockResolvedValue(undefined)
+})
+afterEach(() => { app?.unmount(); root?.remove(); vi.resetAllMocks() })
+
+describe('App connector authorization form', () => {
+  it('automatically uses the window reserved by Install and waits for active authorization', async () => {
+    let complete!: () => void
+    mocks.wait.mockReturnValue(new Promise<void>(resolve => { complete = resolve }))
+    const popup = { close: vi.fn() }
+    const flow = setup(oauth, { autoStart: true, oauthPopup: popup })
+    await vi.waitFor(() => expect(mocks.begin).toHaveBeenCalled())
+    await flush()
+    expect(mocks.prepare).not.toHaveBeenCalled()
+    expect(mocks.begin).toHaveBeenCalledWith('bot', 'installation', 'example', 'oauth')
+    expect(mocks.open).toHaveBeenCalledWith('https://example.com/authorize', popup)
+    expect(flow.authorized).not.toHaveBeenCalled()
+    expect(flow.form.phase).toBe('awaiting-oauth')
+    complete()
+    await flush()
+    expect(flow.authorized).toHaveBeenCalledOnce()
+  })
+
+  it('offers an explicit Connect action when no popup was reserved', async () => {
+    const flow = setup(oauth, { autoStart: true })
+    await flush()
+    expect(mocks.begin).not.toHaveBeenCalled()
+    mocks.prepare.mockReturnValue(null)
+    await flow.form.connect()
+    expect(root.textContent).toContain('connectors.oauthPopupBlocked')
+    expect(mocks.begin).not.toHaveBeenCalled()
+  })
+
+  it('cancels pending OAuth and can retry without re-installing', async () => {
+    mocks.wait.mockImplementation((_bot, _connection, _popup, signal: AbortSignal) => new Promise((_, reject) => {
+      signal.addEventListener('abort', () => reject(new Error('cancelled')))
+    }))
+    mocks.prepare.mockReturnValue({ close: vi.fn() })
+    const flow = setup(oauth)
+    const attempt = flow.form.connect()
+    await vi.waitFor(() => expect(flow.form.phase).toBe('awaiting-oauth'))
+    flow.form.cancel()
+    await attempt
+    expect(flow.form.phase).toBe('idle')
+    expect(flow.authorized).not.toHaveBeenCalled()
+    mocks.wait.mockResolvedValueOnce(undefined)
+    await flow.form.connect()
+    expect(flow.authorized).toHaveBeenCalledOnce()
+  })
+
+  it('validates required credential fields before sending API keys', async () => {
+    const flow = setup([{ key: 'token', type: 'api_key', credential_fields: [
+      { key: 'token', label: 'API key', required: true, secret: true },
+    ] }], { autoStart: true })
+    await flush()
+    expect(mocks.credential).not.toHaveBeenCalled()
+    await flow.form.connect()
+    expect(mocks.credential).not.toHaveBeenCalled()
+    expect(root.textContent).toContain('connectors.validation.fieldRequired')
+    const input = root.querySelector('input')!
+    expect(input.type).toBe('password')
+    input.value = 'test-only-placeholder'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+    await flow.form.connect()
+    expect(mocks.credential).toHaveBeenCalledWith('bot', 'installation', 'example', 'token', { token: 'test-only-placeholder' })
+    expect(flow.authorized).toHaveBeenCalledOnce()
+  })
+
+  it('does not report authorization after the form is unmounted', async () => {
+    let finish!: (result: unknown) => void
+    mocks.credential.mockReturnValue(new Promise(resolve => { finish = resolve }))
+    const flow = setup([{ key: 'token', type: 'api_key', credential_fields: [] }])
+    const attempt = flow.form.connect()
+    await vi.waitFor(() => expect(mocks.credential).toHaveBeenCalled())
+    app?.unmount(); app = undefined
+    finish({})
+    await attempt
+    expect(flow.authorized).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/pages/bots/components/app-connector-auth-form.vue
+++ b/apps/web/src/pages/bots/components/app-connector-auth-form.vue
@@ -1,0 +1,277 @@
+<template>
+  <div class="space-y-4">
+    <form
+      :id="formId"
+      ref="formElement"
+      @submit.prevent="connect"
+    >
+      <FormStack>
+        <FormField
+          v-if="authMethods.length > 1"
+          v-slot="{ componentField }"
+          name="auth_method"
+        >
+          <FieldStack :label="t('connectors.authMethod')">
+            <FormControl>
+              <Select
+                v-bind="componentField"
+                :disabled="phase !== 'idle'"
+              >
+                <SelectTrigger class="w-full">
+                  <SelectValue :placeholder="t('connectors.selectAuthMethod')" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem
+                    v-for="method in authMethods"
+                    :key="method.key"
+                    :value="method.key!"
+                  >
+                    {{ method.label || method.key }}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </FormControl>
+          </FieldStack>
+        </FormField>
+
+        <FormField
+          v-for="field in credentialFields"
+          :key="field.key"
+          v-slot="{ componentField }"
+          :name="`fields.${field.key}`"
+        >
+          <FieldStack
+            :label="field.label || field.key"
+            :help="field.description"
+          >
+            <FormControl>
+              <Select
+                v-if="field.input_type === 'select'"
+                :disabled="phase !== 'idle'"
+                v-bind="componentField"
+              >
+                <SelectTrigger class="w-full">
+                  <SelectValue :placeholder="field.label || field.key" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem
+                    v-for="option in field.options ?? []"
+                    :key="option"
+                    :value="option"
+                  >
+                    {{ option }}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <Input
+                v-else
+                :disabled="phase !== 'idle'"
+                v-bind="componentField"
+                :type="field.secret ? 'password' : 'text'"
+                :placeholder="t('connectors.credentialPlaceholder', { field: field.label || field.key })"
+              />
+            </FormControl>
+          </FieldStack>
+        </FormField>
+      </FormStack>
+    </form>
+    <Alert
+      v-if="errorMessage"
+      variant="destructive"
+    >
+      <AlertTitle>{{ t('connectors.connectFailed') }}</AlertTitle>
+      <AlertDescription>{{ errorMessage }}</AlertDescription>
+    </Alert>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Both installation progress and the Apps tab use this authorization form.
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import z from 'zod'
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  FieldStack,
+  FormControl,
+  FormField,
+  FormStack,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@felinic/ui'
+import type { ConnectitAuthMethod, ConnectitConnector } from '@memohai/sdk'
+import {
+  beginAppConnectorOAuth,
+  createAppConnectorCredential,
+  type AppConnectorItem,
+} from '@/composables/api/useApps'
+import {
+  connectorOAuthErrorKey,
+  isConnectorOAuthCancelled,
+  openConnectorOAuthURL,
+  prepareConnectorOAuthPopup,
+  waitForConnectorOAuth,
+} from '@/composables/useConnectorOAuth'
+import { resolveApiErrorMessage } from '@/utils/api-error'
+
+const props = defineProps<{
+  autoStart?: boolean
+  oauthPopup?: Window | null
+  botId: string
+  installationId: string
+  connector: AppConnectorItem | null
+  /** Catalog entry for the connector type, undefined when Connect-It lacks it. */
+  catalog: ConnectitConnector | undefined
+}>()
+
+const emit = defineEmits<{
+  phase: [phase: 'idle' | 'submitting' | 'awaiting-oauth']
+  authorized: []
+}>()
+
+const { t } = useI18n()
+const schema = toTypedSchema(z.object({
+  auth_method: z.string().min(1, t('connectors.validation.authMethodRequired')),
+  fields: z.record(z.string(), z.string().optional()),
+}))
+const form = useForm({
+  validationSchema: schema,
+  initialValues: { auth_method: '', fields: {} },
+})
+
+const authMethods = computed(() => (props.catalog?.auth_methods ?? []).filter(method => method.key))
+const selectedMethod = computed<ConnectitAuthMethod | undefined>(() =>
+  authMethods.value.find(method => method.key === form.values.auth_method),
+)
+function methodCredentialFields(method: ConnectitAuthMethod | undefined) {
+  if (method?.type === 'oauth2') return []
+  return (method?.credential_fields ?? []).filter(field => field.key)
+}
+function credentialDefaults(method: ConnectitAuthMethod | undefined): Record<string, string> {
+  return Object.fromEntries(methodCredentialFields(method).map(field => [field.key!, field.default_value ?? '']))
+}
+const credentialFields = computed(() => methodCredentialFields(selectedMethod.value))
+
+watch(() => [props.connector?.type, props.installationId], () => {
+  const method = authMethods.value[0]
+  form.resetForm({ values: { auth_method: method?.key || '', fields: credentialDefaults(method) } })
+}, { immediate: true })
+
+watch(
+  () => form.values.auth_method,
+  (methodKey, previous) => {
+    if (!previous || methodKey === previous) return
+    form.setFieldValue('fields', credentialDefaults(authMethods.value.find(item => item.key === methodKey)))
+  },
+)
+
+const phase = ref<'idle' | 'submitting' | 'awaiting-oauth'>('idle')
+let attempt: AbortController | null = null
+
+const errorMessage = ref('')
+const formId = useId()
+const formElement = ref<HTMLFormElement | null>(null)
+let reservedPopup = props.oauthPopup
+watch(phase, value => emit('phase', value), { flush: 'sync' })
+
+function cancel() {
+  attempt?.abort()
+}
+onBeforeUnmount(() => {
+  cancel()
+  reservedPopup?.close()
+})
+onMounted(async () => {
+  await nextTick()
+  if (!formElement.value) return
+  formElement.value.querySelector<HTMLElement>('input, select')?.focus()
+  // A popup must be reserved by the Install click, before the streamed install.
+  // Later connectors without a reserved window use the visible Connect button.
+  if (props.autoStart && selectedMethod.value?.type === 'oauth2'
+    && (reservedPopup || window.api?.desktop?.openExternalUrl)) void connect()
+})
+defineExpose({ connect, cancel, phase, formId })
+
+async function connect() {
+  if (phase.value !== 'idle') return
+  const method = selectedMethod.value
+  const connectorType = props.connector?.type
+  errorMessage.value = ''
+  const oauthPopup = method?.type === 'oauth2' ? (reservedPopup ?? prepareConnectorOAuthPopup(t('common.loading'))) : null
+  reservedPopup = null
+  if (method?.type === 'oauth2' && !oauthPopup && !window.api?.desktop?.openExternalUrl) {
+    errorMessage.value = t('connectors.oauthPopupBlocked')
+    return
+  }
+  const flow = new AbortController()
+  attempt = flow
+  phase.value = 'submitting'
+  try {
+    const validation = await form.validate()
+    if (!validation.valid || !connectorType || !method?.key) {
+      oauthPopup?.close()
+      return
+    }
+    let credentialValid = true
+    for (const field of credentialFields.value) {
+      if (!field.key) continue
+      const value = String(form.values.fields?.[field.key] ?? '').trim()
+      if (field.required && !value) {
+        form.setFieldError(`fields.${field.key}`, t('connectors.validation.fieldRequired', { field: field.label || field.key }))
+        credentialValid = false
+      }
+      if (value && field.pattern && !new RegExp(field.pattern).test(value)) {
+        form.setFieldError(`fields.${field.key}`, t('connectors.validation.fieldInvalid', { field: field.label || field.key }))
+        credentialValid = false
+      }
+    }
+    if (!credentialValid) {
+      oauthPopup?.close()
+      return
+    }
+
+    if (method.type === 'oauth2') {
+      const result = await beginAppConnectorOAuth(props.botId, props.installationId, connectorType, method.key)
+      const connectionId = result.connection_id
+      if (!result.authorization_url || !connectionId) throw new Error('oauth_failed')
+      if (flow.signal.aborted) return
+      phase.value = 'awaiting-oauth'
+      await openConnectorOAuthURL(result.authorization_url, oauthPopup)
+      try {
+        await waitForConnectorOAuth(props.botId, connectionId, oauthPopup, flow.signal)
+      } catch (error) {
+        if (!isConnectorOAuthCancelled(error)) throw error
+        return
+      }
+    } else {
+      await createAppConnectorCredential(
+        props.botId,
+        props.installationId,
+        connectorType,
+        method.key,
+        Object.fromEntries(Object.entries(form.values.fields ?? {}).map(([key, value]) => [key, String(value ?? '').trim()])),
+      )
+    }
+    if (!flow.signal.aborted) emit('authorized')
+  } catch (error) {
+    oauthPopup?.close()
+    if (flow.signal.aborted) return
+    const oauthKey = connectorOAuthErrorKey(error)
+    errorMessage.value = oauthKey ? t(oauthKey) : resolveApiErrorMessage(error, t('connectors.connectFailed'))
+  } finally {
+    if (flow.signal.aborted) oauthPopup?.close()
+    if (attempt === flow) {
+      attempt = null
+      phase.value = 'idle'
+    }
+  }
+}
+</script>

--- a/apps/web/src/pages/bots/components/app-progress-dialog.vue
+++ b/apps/web/src/pages/bots/components/app-progress-dialog.vue
@@ -3,13 +3,14 @@
 // Server walks through (dependencies, Skills, connectors) above the raw script
 // log. Closing while running means "run in background"; the store keeps the
 // stream and the verdict lands as a toast.
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, toRef, watch } from 'vue'
+import { useQuery } from '@pinia/colada'
+import { getConnectorsCatalog } from '@memohai/sdk'
 import { useI18n } from 'vue-i18n'
 import {
   Alert,
   AlertDescription,
   AlertTitle,
-  Badge,
   Button,
   Dialog,
   DialogBody,
@@ -18,6 +19,7 @@ import {
   DialogHeader,
   DialogPanel,
   DialogTitle,
+  InlineLoadingRow,
   Spinner,
   TextButton,
   toast,
@@ -25,11 +27,16 @@ import {
 } from '@felinic/ui'
 import { AlertTriangle, Check, CircleDashed, Link2, KeyRound } from 'lucide-vue-next'
 import type { AppOperationAction } from '@/composables/api/useAppStream'
-import type { AppOperationStep } from '@/store/app-operations'
+import AppConnectorAuthForm from './app-connector-auth-form.vue'
+import { useAppInstallAuthorization } from '../composables/useAppInstallAuthorization'
+import type { AppOperation, AppOperationStep } from '@/store/app-operations'
 import type { DependencyLogLine, DependencyProgressStatus } from '@/utils/workspace-dependency'
 
 const props = withDefaults(defineProps<{
   open: boolean
+  operation?: AppOperation | null
+  oauthPopup?: Window | null
+  hasSkills?: boolean
   name: string
   action?: AppOperationAction
   steps: AppOperationStep[]
@@ -42,6 +49,9 @@ const props = withDefaults(defineProps<{
   doneLabel?: string
 }>(), {
   action: 'install',
+  operation: null,
+  oauthPopup: null,
+  hasSkills: true,
   result: '',
   error: '',
   canRetry: true,
@@ -59,7 +69,42 @@ const { copyText } = useClipboard()
 
 const running = computed(() => props.status === 'running')
 
+const operation = computed(() => props.operation ?? null)
+const authorization = useAppInstallAuthorization(operation, toRef(props, 'open'))
+const { installation, loading: authorizationLoading, error: authorizationError, current: connector, needsSetup } = authorization
+const authForm = ref<InstanceType<typeof AppConnectorAuthForm> | null>(null)
+const authPhase = ref<'idle' | 'submitting' | 'awaiting-oauth'>('idle')
+const catalogQuery = useQuery({
+  key: () => ['connectors-catalog'],
+  query: async () => (await getConnectorsCatalog({ throwOnError: true })).data,
+  enabled: () => props.open && !!props.operation && props.steps.some(step => step.kind === 'connector'),
+})
+const catalog = computed(() => catalogQuery.data.value?.find(item => item.type === connector.value?.type))
+const visibleSteps = computed(() => props.steps.filter(step => step.kind !== 'skills' || props.hasSkills))
+const catalogLoading = computed(() => !catalog.value && catalogQuery.asyncStatus.value === 'loading')
+const setupLoading = computed(() => authorizationLoading.value || catalogLoading.value)
+const showAuthForm = computed(() => props.open && needsSetup.value && !setupLoading.value
+  && !authorizationError.value && !!connector.value && !!catalog.value)
+watch(showAuthForm, shown => { if (!shown) authPhase.value = 'idle' })
+watch([() => props.status, needsSetup, authorizationLoading, () => props.open], () => {
+  if (!props.open || props.status === 'error' || props.status === 'unknown'
+    || (props.status === 'done' && !needsSetup.value && !authorizationLoading.value)) props.oauthPopup?.close()
+})
+function updateOpen(open: boolean) {
+  if (!open && authPhase.value === 'submitting') return
+  if (!open) authForm.value?.cancel()
+  emit('update:open', open)
+}
+async function retryAuthorization() {
+  await Promise.all([authorization.refresh(), catalogQuery.refetch()])
+}
+
 const subtitle = computed(() => {
+  if (needsSetup.value) {
+    if (setupLoading.value) return t('apps.progress.preparingAuthorization')
+    if (authPhase.value === 'awaiting-oauth') return t('apps.progress.awaitingAuthorization')
+    return t('apps.progress.authorize', { name: catalog.value?.name || connector.value?.type || props.name })
+  }
   if (props.status === 'done') {
     return props.result === 'partial' ? t('apps.progress.partialTitle') : t('apps.progress.doneTitle')
   }
@@ -83,7 +128,7 @@ function stepLabel(step: AppOperationStep): string {
     case 'skills':
       return t('apps.steps.skills')
     case 'connector':
-      return t('apps.steps.connector', { name: step.id })
+      return catalogQuery.data.value?.find(item => item.type === step.id)?.name || step.id
     case 'dependency':
       return t('apps.steps.dependency', { name: step.id })
     default:
@@ -97,25 +142,8 @@ function stepStatusLabel(step: AppOperationStep): string {
   return text === key ? step.status : text
 }
 
-function stepVariant(step: AppOperationStep): 'secondary' | 'success' | 'warning' | 'destructive' | 'outline' {
-  switch (step.status) {
-    case 'running':
-      return 'secondary'
-    case 'failed':
-      return 'destructive'
-    case 'needs_auth':
-      return 'warning'
-    case 'installed':
-    case 'linked':
-    case 'removed':
-    case 'disconnected':
-      return 'success'
-    default:
-      return 'outline'
-  }
-}
-
 function stepIcon(step: AppOperationStep) {
+  if (step.kind === 'connector' && step.id === connector.value?.type && authPhase.value !== 'idle') return Spinner
   switch (step.status) {
     case 'running':
       return Spinner
@@ -164,10 +192,10 @@ function finish() {
 <template>
   <Dialog
     :open="open"
-    @update:open="(value) => emit('update:open', value)"
+    @update:open="updateOpen"
   >
     <DialogPanel
-      width="2xl"
+      width="lg"
       footer
     >
       <DialogHeader class="min-w-0">
@@ -186,11 +214,11 @@ function finish() {
 
       <DialogBody class="min-w-0 space-y-4">
         <ul
-          v-if="steps.length"
+          v-if="visibleSteps.length"
           class="space-y-1.5"
         >
           <li
-            v-for="step in steps"
+            v-for="step in visibleSteps"
             :key="`${step.kind}/${step.id}`"
             class="flex min-w-0 items-center gap-2 text-body"
           >
@@ -203,28 +231,20 @@ function finish() {
               v-if="step.version && step.kind !== 'skills'"
               class="font-mono text-caption text-muted-foreground"
             >{{ step.version }}</span>
-            <Badge
-              :variant="stepVariant(step)"
-              size="sm"
-            >
+            <span :class="['installed', 'linked', 'needs_auth'].includes(step.status) ? 'sr-only' : 'text-caption text-muted-foreground'">
               {{ stepStatusLabel(step) }}
-            </Badge>
+            </span>
           </li>
         </ul>
 
         <div
+          v-if="lines.length"
           ref="scroller"
           role="region"
           :aria-label="t('apps.progress.log')"
           tabindex="0"
           class="max-h-60 min-w-0 overflow-auto rounded-lg border border-border bg-muted-soft p-3 font-mono text-caption leading-relaxed text-foreground"
         >
-          <p
-            v-if="lines.length === 0"
-            class="text-muted-foreground"
-          >
-            {{ running ? t('apps.progress.preparing') : t('apps.progress.noLog') }}
-          </p>
           <div
             v-for="(line, index) in lines"
             :key="line.id ?? index"
@@ -234,6 +254,30 @@ function finish() {
             {{ line.data }}
           </div>
         </div>
+
+        <InlineLoadingRow v-if="needsSetup && setupLoading">
+          {{ t('apps.progress.preparingAuthorization') }}
+        </InlineLoadingRow>
+        <AppConnectorAuthForm
+          v-else-if="showAuthForm && operation && installation"
+          :key="`${installation.installation_id}/${connector?.type}`"
+          ref="authForm"
+          :bot-id="operation.botId"
+          :installation-id="installation.installation_id!"
+          :connector="connector ?? null"
+          :catalog="catalog"
+          :oauth-popup="oauthPopup?.closed ? null : oauthPopup"
+          auto-start
+          @phase="authPhase = $event"
+          @authorized="authorization.authorized"
+        />
+        <Alert
+          v-else-if="needsSetup"
+          variant="destructive"
+        >
+          <AlertTitle>{{ t('apps.progress.authorizationLoadFailed') }}</AlertTitle>
+          <AlertDescription>{{ authorizationError || t('apps.connector.unavailableDescription') }}</AlertDescription>
+        </Alert>
 
         <Alert
           v-if="status === 'error' || status === 'unknown'"
@@ -247,7 +291,7 @@ function finish() {
         </Alert>
 
         <Alert
-          v-else-if="status === 'done' && result === 'partial'"
+          v-else-if="status === 'done' && result === 'partial' && !needsSetup"
           variant="default"
           class="min-w-0"
         >
@@ -258,14 +302,42 @@ function finish() {
 
       <DialogFooter class="min-w-0 items-center gap-2 sm:justify-between">
         <TextButton
-          :disabled="lines.length === 0"
+          v-if="lines.length"
           @click="copyLog"
         >
           {{ t('common.copy') }}
         </TextButton>
-        <div class="flex items-center gap-2">
+        <div class="ml-auto flex items-center gap-2">
+          <template v-if="needsSetup">
+            <Button
+              variant="outline"
+              :disabled="authPhase === 'submitting'"
+              @click="updateOpen(false)"
+            >
+              {{ t('bots.dependencies.close') }}
+            </Button>
+            <Button
+              v-if="showAuthForm && authPhase === 'awaiting-oauth'"
+              @click="authForm?.cancel()"
+            >
+              {{ t('common.cancel') }}
+            </Button>
+            <Button
+              v-else-if="showAuthForm"
+              :loading="authPhase === 'submitting'"
+              @click="authForm?.connect()"
+            >
+              {{ t('connectors.connect') }}
+            </Button>
+            <Button
+              v-else-if="!setupLoading"
+              @click="retryAuthorization"
+            >
+              {{ t('common.retry') }}
+            </Button>
+          </template>
           <Button
-            v-if="running"
+            v-else-if="running"
             variant="outline"
             @click="emit('update:open', false)"
           >

--- a/apps/web/src/pages/bots/composables/useAppInstallAuthorization.test.ts
+++ b/apps/web/src/pages/bots/composables/useAppInstallAuthorization.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, ref, type App } from 'vue'
+import type { AppOperation } from '@/store/app-operations'
+import { useAppInstallAuthorization } from './useAppInstallAuthorization'
+
+const mocks = vi.hoisted(() => ({ list: vi.fn(), invalidate: vi.fn() }))
+vi.mock('@memohai/sdk', () => ({ getBotsByBotIdApps: mocks.list }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('@pinia/colada', () => ({ useQueryCache: () => ({ invalidateQueries: mocks.invalidate }) }))
+vi.mock('@/composables/api/useApps', () => ({ invalidateBotApps: mocks.invalidate }))
+vi.mock('@/utils/api-error', () => ({ resolveApiErrorMessage: (_: unknown, fallback: string) => fallback }))
+
+let app: App | undefined
+const flush = async () => { await Promise.resolve(); await nextTick(); await Promise.resolve(); await nextTick() }
+const connector = (type: string, status = 'needs_auth', connectionStatus?: string) => ({
+  type, required: true, status, connector: connectionStatus ? { status: connectionStatus } : undefined,
+})
+const item = (connectors: unknown[], status = 'partial') => ({
+  installation_id: 'installation', registry_id: 'memoh', app_id: 'example', status, connectors,
+})
+function setup(status = 'running', action = 'install') {
+  const operation = ref({
+    key: 'bot/memoh/example', botId: 'bot', targetId: 'remote-target', registryId: 'memoh',
+    appId: 'example', status, action, result: 'partial',
+    steps: [{ kind: 'connector', id: 'notion', status: 'needs_auth' }],
+  } as AppOperation)
+  const open = ref(true)
+  let flow!: ReturnType<typeof useAppInstallAuthorization>
+  app = createApp({ setup() { flow = useAppInstallAuthorization(operation, open); return () => h('div') } })
+  app.mount(document.createElement('div'))
+  return { flow, operation, open }
+}
+afterEach(() => { app?.unmount(); vi.resetAllMocks() })
+
+describe('installation authorization', () => {
+  it('waits for installation and resolves the exact App and workspace target', async () => {
+    mocks.list.mockResolvedValue({ data: { items: [item([connector('notion')])] } })
+    const { flow, operation } = setup()
+    expect(mocks.list).not.toHaveBeenCalled()
+    operation.value.status = 'done'
+    await flush()
+    expect(mocks.list).toHaveBeenCalledWith(expect.objectContaining({ path: { bot_id: 'bot' }, query: { workspace_target_id: 'remote-target' } }))
+    expect(flow.current.value?.type).toBe('notion')
+    expect(flow.needsSetup.value).toBe(true)
+    expect(operation.value.installationId).toBe('installation')
+  })
+
+  it('does not treat a linked pending OAuth connection as successful', async () => {
+    mocks.list.mockResolvedValue({ data: { items: [item([connector('notion', 'linked', 'pending')], 'installed')] } })
+    const { flow, operation } = setup('done')
+    await flush()
+    expect(flow.needsSetup.value).toBe(true)
+    expect(operation.value.result).toBe('partial')
+    expect(operation.value.steps[0]?.status).toBe('needs_auth')
+  })
+
+  it('advances through connectors and refreshes the installed result after authorization', async () => {
+    mocks.list.mockResolvedValueOnce({ data: { items: [item([connector('notion'), connector('github')])] } })
+    const { flow, operation } = setup('done')
+    await flush()
+    mocks.list.mockResolvedValueOnce({ data: { items: [item([connector('notion', 'linked', 'active'), connector('github')])] } })
+    await flow.authorized()
+    expect(flow.current.value?.type).toBe('github')
+    expect(operation.value.steps[0]?.status).toBe('linked')
+    mocks.list.mockResolvedValueOnce({ data: { items: [item([connector('notion', 'linked', 'active'), connector('github', 'linked', 'active')], 'installed')] } })
+    await flow.authorized()
+    expect(flow.needsSetup.value).toBe(false)
+    expect(operation.value.result).toBe('installed')
+    expect(mocks.invalidate).toHaveBeenCalled()
+  })
+
+  it('preserves a partial result caused by another component after authorization', async () => {
+    mocks.list.mockResolvedValue({ data: { items: [item([connector('notion', 'linked', 'active')])] } })
+    const { flow, operation } = setup('done')
+    await flush()
+    expect(flow.needsSetup.value).toBe(false)
+    expect(operation.value.result).toBe('partial')
+  })
+
+  it('keeps failed discovery retryable and ignores a late response after closing', async () => {
+    mocks.list.mockRejectedValueOnce(new Error('offline'))
+    const { flow, open, operation } = setup('done')
+    await flush()
+    expect(flow.error.value).toBeTruthy()
+    expect(flow.needsSetup.value).toBe(true)
+    let resolve!: (value: unknown) => void
+    mocks.list.mockReturnValueOnce(new Promise(done => { resolve = done }))
+    const retry = flow.refresh()
+    open.value = false
+    await nextTick()
+    resolve({ data: { items: [item([connector('notion', 'linked', 'active')], 'installed')] } })
+    await retry
+    expect(flow.installation.value).toBeNull()
+    expect(operation.value.result).toBe('partial')
+  })
+
+  it('never starts authorization for removal', async () => {
+    const { flow } = setup('done', 'remove')
+    await flush()
+    expect(mocks.list).not.toHaveBeenCalled()
+    expect(flow.needsSetup.value).toBe(false)
+  })
+})

--- a/apps/web/src/pages/bots/composables/useAppInstallAuthorization.ts
+++ b/apps/web/src/pages/bots/composables/useAppInstallAuthorization.ts
@@ -1,0 +1,85 @@
+import { computed, onBeforeUnmount, ref, watch, type Ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useQueryCache } from '@pinia/colada'
+import { getBotsByBotIdApps } from '@memohai/sdk'
+import { invalidateBotApps, type AppItem } from '@/composables/api/useApps'
+import type { AppOperation } from '@/store/app-operations'
+import { resolveApiErrorMessage } from '@/utils/api-error'
+
+/** Resolves the installation created by the stream and keeps authorization in that flow. */
+export function useAppInstallAuthorization(operation: Ref<AppOperation | null>, open: Ref<boolean>) {
+  const { t } = useI18n()
+  const queryCache = useQueryCache()
+  const installation = ref<AppItem | null>(null)
+  const loading = ref(false)
+  const error = ref('')
+  let request: AbortController | undefined
+
+  const pending = computed(() => (installation.value?.connectors ?? []).filter(connector =>
+    connector.status === 'needs_auth' || connector.connector?.status !== 'active',
+  ))
+  const current = computed(() => pending.value[0])
+  const hasConnectors = computed(() => operation.value?.action !== 'remove'
+    && !!operation.value?.steps.some(step => step.kind === 'connector'))
+  const needsSetup = computed(() => hasConnectors.value && operation.value?.status === 'done'
+    && (loading.value || !!error.value || pending.value.length > 0))
+
+  async function refresh() {
+    const active = operation.value
+    if (!open.value || !active || active.status !== 'done' || !hasConnectors.value) return
+    request?.abort()
+    const controller = new AbortController()
+    request = controller
+    loading.value = true
+    error.value = ''
+    try {
+      const { data } = await getBotsByBotIdApps({
+        path: { bot_id: active.botId },
+        query: { workspace_target_id: active.targetId || undefined },
+        signal: controller.signal,
+        throwOnError: true,
+      })
+      if (controller.signal.aborted) return
+      const item = data.items?.find(item => item.registry_id === active.registryId && item.app_id === active.appId)
+      if (!item?.installation_id) {
+        error.value = t('apps.progress.authorizationLoadFailed')
+        return
+      }
+      installation.value = item
+      active.installationId = item.installation_id
+      for (const step of active.steps) {
+        if (step.kind !== 'connector') continue
+        const connector = item.connectors?.find(connector => connector.type === step.id)
+        if (connector) step.status = connector.connector?.status === 'active' ? 'linked' : 'needs_auth'
+      }
+      // OAuth start links a connection before it is active. Only report success
+      // after the authorization form has observed an active connection.
+      active.result = pending.value.some(connector => connector.required) ? 'partial' : (item.status ?? active.result)
+    } catch (cause) {
+      if (!controller.signal.aborted) error.value = resolveApiErrorMessage(cause, t('apps.progress.authorizationLoadFailed'))
+    } finally {
+      if (request === controller) loading.value = false
+    }
+  }
+
+  watch([open, () => operation.value, () => operation.value?.status], () => {
+    request?.abort()
+    installation.value = null
+    error.value = ''
+    loading.value = false
+    void refresh()
+  }, { immediate: true })
+  onBeforeUnmount(() => request?.abort())
+
+  async function authorized() {
+    await refresh()
+    const botId = operation.value?.botId
+    if (!botId) return
+    await Promise.all([
+      invalidateBotApps(queryCache, botId),
+      queryCache.invalidateQueries({ key: ['bot-connectors', botId] }),
+    ])
+  }
+
+  return { installation, loading, error, current, needsSetup, refresh, authorized }
+}

--- a/apps/web/src/pages/supermarket/components/install-app-dialog.vue
+++ b/apps/web/src/pages/supermarket/components/install-app-dialog.vue
@@ -101,6 +101,9 @@
 
   <AppProgressDialog
     :open="progressOpen"
+    :operation="active"
+    :oauth-popup="oauthPopup"
+    :has-skills="!!pkg?.skills.length"
     :name="active?.name ?? ''"
     :action="active?.action ?? 'install'"
     :steps="active?.steps ?? []"
@@ -116,7 +119,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useQuery } from '@pinia/colada'
@@ -139,12 +142,14 @@ import {
 } from '@felinic/ui'
 import {
   getBotsByBotIdWorkspaceTargets,
+  getConnectorsCatalog,
   type HandlersSupermarketAppDescriptor,
   type WorkspaceWorkspaceTarget,
 } from '@memohai/sdk'
 import BotSelect from '@/components/bot-select/index.vue'
 import AppProgressDialog from '@/pages/bots/components/app-progress-dialog.vue'
 import { useAppOperation } from '@/pages/bots/composables/useAppOperation'
+import { prepareConnectorOAuthPopup } from '@/composables/useConnectorOAuth'
 import { appDisplayName } from '@/composables/api/useApps'
 import { workspaceTargetAvailable, workspaceTargetName } from '@/utils/workspace-target'
 
@@ -197,9 +202,26 @@ watch(selectedBotId, () => {
 
 const { active, progressOpen, start, retry, setProgressOpen } = useAppOperation(selectedBotId, 'supermarket-install')
 
+const oauthPopup = shallowRef<Window | null>(null)
+const catalogQuery = useQuery({
+  key: () => ['connectors-catalog'],
+  query: async () => (await getConnectorsCatalog({ throwOnError: true })).data,
+  enabled: () => props.open && !!props.pkg?.connectors.length,
+})
+function closePopup() {
+  oauthPopup.value?.close()
+  oauthPopup.value = null
+}
+watch(progressOpen, open => { if (!open) closePopup() })
+onBeforeUnmount(closePopup)
+
 function handleInstall() {
   const pkg = props.pkg
   if (!selectedBotId.value || !pkg?.registry_id || !pkg.app_id || !pkg.revision) return
+  closePopup()
+  const firstConnector = pkg.connectors[0]
+  const method = catalogQuery.data.value?.find(item => item.type === firstConnector?.type)?.auth_methods?.[0]
+  if (method?.type === 'oauth2') oauthPopup.value = prepareConnectorOAuthPopup(t('common.loading'))
   const started = start({
     targetId: selectedTargetId.value,
     registryId: pkg.registry_id,
@@ -214,6 +236,7 @@ function handleInstall() {
     },
   })
   if (started) emit('update:open', false)
+  else closePopup()
 }
 
 function openBotApps() {


### PR DESCRIPTION
Installing an App with connectors currently stops at “Needs authorization” and sends users to the bot's Apps tab to finish setup. Keep authorization in the installation progress dialog so users can finish connecting the App where they started.

- Reserve the OAuth window on the Install click and start authorization automatically once installation is ready. Show API key fields inline, with cancellation, retry, and sequential connector setup.
- Refresh the installed App for the selected workspace target and report a connector as connected only after its connection is active.
- Reuse the authorization form in the existing Apps tab dialog. Remove the Installed / Needs authorization badges, empty script output, and the Skills row for Apps without skills; update English, Chinese, and Japanese copy.

Validation: 15 focused authorization tests passed; Web typecheck, production build, `mise run lint` (frontend ESLint, UI contract, and Go lint), and `go test ./...` passed. Agent browser checks on the local development server covered Notion OAuth initiation/cancel/retry, Buildium credential validation, dark mode, and a 390px viewport. Real third-party consent and authenticated connector operations have not been verified end to end.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.
