### PR TITLE
feat(web): 会话重访精准乐观展示——缓存未变更时秒开 (#1212)

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -505,7 +505,11 @@ Live conversation turns are read over the **WebSocket**. SSE carries identifiers
 
 #### Sessions activity SSE
 - **Endpoint**: `GET /bots/{bot_id}/sessions/events` — bot-wide lightweight activity stream; `session_touched` / `session_title_changed` / `session_created` for sidebar live-sort. Never carries message bodies.
+- **First frame**: `activity_ready {cache_invalidation}` — sent right after subscription so events racing connection setup are queued behind it. `cache_invalidation: true` declares the server emits `session_invalidated` for every runtime admission and history deletion; `false` (or a missing ready frame on older servers) means no coverage and every revisit must reload under the mask.
+- `session_invalidated {session_id}` — a session's visible projection changed while another tab/client could have been holding a cached copy; empty `session_id` invalidates all sessions of the bot. Marks the transcript stale so the next revisit reloads instead of trusting its cache.
+- `dropped` — emitted when the server's per-subscriber buffer overflowed; the client conservatively marks all sessions stale because it cannot know which events were lost.
 - `session_touched` with `reason: background_task` also refreshes persisted messages for an already loaded session. Notifications can arrive without a live turn; use the transcript merge path so active output survives. Coalesce pending notifications and perform a trailing refresh for the final outcome.
+- **Optimistic revisit contract**: a hidden session's cached transcript may render immediately on revisit only while coverage holds (ready frame declared `cache_invalidation`, stream still connected, no `dropped`, no pending `session_invalidated`). Any disconnect or capability gap revokes coverage until the next ready frame — there is no client-side grace window.
 - **Parsing**: handled by the generated SDK (`@memohai/sdk` `sse.get`); wrappers live in `composables/api/useChat.message-api.ts`.
 - **Retry**: `useRetryingStream` composable drives reconnection with exponential backoff.
 - There is no per-session SSE. A session's messages and run state come from the session runtime over the WebSocket, so that every subscriber of a session — this tab, another tab, another device — is reading the same projection instead of each building its own.

--- a/apps/web/src/composables/api/useChat.types.ts
+++ b/apps/web/src/composables/api/useChat.types.ts
@@ -69,6 +69,8 @@ export interface SessionCompactionEvent {
 }
 
 export type BotSessionActivityEvent =
+  | { type: 'activity_ready', cache_invalidation: boolean }
+  | { type: 'session_invalidated', session_id: string }
   | SessionTouchedEvent
   | SessionTitleChangedEvent
   | SessionCreatedEvent

--- a/apps/web/src/pages/home/components/chat-pane.vue
+++ b/apps/web/src/pages/home/components/chat-pane.vue
@@ -74,7 +74,7 @@
                    base tone; only the width stagger is kept from the old
                    hand-rolled version. -->
               <div
-                v-if="messages.length === 0 && loadingMessages"
+                v-if="skeletonVisible"
                 class="flex flex-col gap-6"
                 aria-hidden="true"
               >
@@ -1212,6 +1212,18 @@ provideConnectorLogos(paneTarget)
 const paneView = computed(() => chatStore.chatView(paneTarget.value))
 const messages = computed(() => paneView.value.transcript.visibleMessages.value)
 const loadingMessages = computed(() => paneView.value.transcript.loadingMessages.value)
+// Delayed skeleton reveal: local/fast loads finish within a few frames, and
+// flashing the placeholder for a frame or two reads as a glitch. Mount it
+// only when loading actually outlives the delay.
+const skeletonVisible = ref(false)
+watch(() => messages.value.length === 0 && loadingMessages.value, (pending, _prev, onCleanup) => {
+  if (!pending) {
+    skeletonVisible.value = false
+    return
+  }
+  const timer = setTimeout(() => { skeletonVisible.value = true }, CHAT_SKELETON_REVEAL_DELAY_MS)
+  onCleanup(() => clearTimeout(timer))
+}, { immediate: true })
 const loadingOlder = computed(() => paneView.value.transcript.loadingOlder.value)
 const hasMoreOlder = computed(() => paneView.value.transcript.hasMoreOlder.value)
 const streaming = computed(() => chatStore.isChatViewStreaming(paneTarget.value))
@@ -1312,6 +1324,8 @@ const WELCOME_GREETING_KEYS = [
 // so they scale with Memoh's layout; heights/pitches above are derived from
 // Memoh's own chat metrics, not copied.
 const CHAT_SKELETON_BAR_WIDTHS = ['85%', '65%', '90%', '55%', '75%', '60%', '80%', '50%', '70%', '40%'] as const
+// Loading shorter than this never shows the placeholder at all.
+const CHAT_SKELETON_REVEAL_DELAY_MS = 200
 function pickWelcomeGreetingIndex() {
   return Math.floor(Math.random() * WELCOME_GREETING_KEYS.length)
 }

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -3906,7 +3906,7 @@ describe('chat-list store', () => {
       await sending
     })
 
-  it('does not expose a cached Session transcript while it rehydrates', async () => {
+  it('keeps a fresh cached Session transcript visible while it rehydrates', async () => {
       api.fetchSessions.mockResolvedValueOnce({ items: [
         { id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' },
         { id: 'session-b', bot_id: 'bot-1', title: 'B', type: 'chat' },
@@ -3931,11 +3931,62 @@ describe('chat-list store', () => {
       await flushPromises()
       await store.selectSession('session-a')
 
+      // Untouched while hidden: the cache stays on screen (optimistic
+      // revisit) and the revalidation commits through the same atomic path.
       expect(store.chatView({
         botId: 'bot-1',
         sessionId: 'session-a',
         viewId: 'chat',
       }).transcript.messages.map(turn => turn.id)).toEqual(['cached-a'])
+      expect(store.loadingMessages).toBe(false)
+      expect(store.messages.map(turn => turn.id)).toEqual(['cached-a'])
+
+      freshSessionA.resolve([{
+        id: 'fresh-a',
+        turn_id: 'fresh-a',
+        role: 'user',
+        text: 'fresh',
+        attachments: [],
+        timestamp: '2026-01-02T00:00:00.000Z',
+      }])
+      await flushPromises()
+
+      expect(store.messages.map(turn => turn.id)).toEqual(['fresh-a'])
+    })
+
+  it('masks a stale-marked cached Session transcript while it rehydrates', async () => {
+      api.fetchSessions.mockResolvedValueOnce({ items: [
+        { id: 'session-a', bot_id: 'bot-1', title: 'A', type: 'chat' },
+        { id: 'session-b', bot_id: 'bot-1', title: 'B', type: 'chat' },
+      ], nextCursor: null })
+      const freshSessionA = deferred<UITurn[]>()
+      api.fetchMessagesUI
+        .mockResolvedValueOnce([{
+          id: 'cached-a',
+          turn_id: 'cached-a',
+          role: 'user',
+          text: 'cached',
+          attachments: [],
+          timestamp: '2026-01-01T00:00:00.000Z',
+        }])
+        .mockResolvedValueOnce([])
+        .mockReturnValueOnce(freshSessionA.promise)
+      const store = useChatStore()
+
+      await store.selectBot('bot-1')
+      await flushPromises()
+      await store.selectSession('session-b')
+      await flushPromises()
+
+      // A touch arrived while session-a was hidden: the cache can no longer
+      // be trusted, so the revisit masks until fresh history commits (#933).
+      store.chatView({
+        botId: 'bot-1',
+        sessionId: 'session-a',
+        viewId: 'chat',
+      }).staleWhileHidden = true
+      await store.selectSession('session-a')
+
       expect(store.loadingMessages).toBe(true)
       expect(store.messages).toEqual([])
 

--- a/apps/web/src/store/chat-list.test.ts
+++ b/apps/web/src/store/chat-list.test.ts
@@ -402,6 +402,7 @@ beforeEach(() => {
     sdk.getBotsByBotIdSettings.mockResolvedValue({ data: { chat_runtime: 'model' } })
     api.streamBotSessionsActivityEvents.mockImplementation((_botId: string, signal: AbortSignal, onEvent: (event: BotSessionActivityEvent) => void) => new Promise<void>((resolve) => {
       h.sessionsActivityHandler = onEvent
+      onEvent({ type: 'activity_ready', cache_invalidation: true })
       signal.addEventListener('abort', () => resolve(), { once: true })
     }))
     api.connectWebSocket.mockImplementation((_botId: string, onStreamEvent: UIStreamEventHandler) => {

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -255,7 +255,7 @@ export const useChatStore = defineStore('chat', () => {
     resolveErrorMessage: resolveApiErrorMessage,
     showError: message => toast.error(message),
     onBotSessionsActivityEvent: handleBotSessionsActivityEvent,
-    onActivityStreamInterrupted: chatViews.markAllSessionsStale,
+    onActivityStreamCoverageChanged: chatViews.setActivityStreamCoverage,
   })
   const {
     startWebSocket,

--- a/apps/web/src/store/chat-list.ts
+++ b/apps/web/src/store/chat-list.ts
@@ -176,6 +176,8 @@ export const useChatStore = defineStore('chat', () => {
         await refreshCurrentSession(botId, targetSessionId)
       }
     },
+    markSessionViewStale: chatViews.markSessionStale,
+    markAllSessionViewsStale: chatViews.markAllSessionsStale,
   })
   // `loadingChats` covers the bot-level boot path (sessions list fetch), so
   // the sidebar can show its skeleton + suppress its empty-state placeholder
@@ -253,6 +255,7 @@ export const useChatStore = defineStore('chat', () => {
     resolveErrorMessage: resolveApiErrorMessage,
     showError: message => toast.error(message),
     onBotSessionsActivityEvent: handleBotSessionsActivityEvent,
+    onActivityStreamInterrupted: chatViews.markAllSessionsStale,
   })
   const {
     startWebSocket,

--- a/apps/web/src/store/chat/cache-revisit.test.ts
+++ b/apps/web/src/store/chat/cache-revisit.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createSessionActivity } from './session-activity'
+import type { BotSessionActivityEvent, ChatWebSocket, UIStreamEvent, UITurn, UIUserTurn } from '@/composables/api/useChat'
+import { createChatViews } from './views'
+import { createChatRealtimeController, type ChatRealtimeTransport } from './realtime'
+
+const api = vi.hoisted(() => ({ fetchMessagesUI: vi.fn(), locateMessageUI: vi.fn(), connectWebSocket: vi.fn(), streamBotSessionsActivityEvents: vi.fn() }))
+vi.mock('@/composables/api/useChat', () => api)
+
+async function flush() { for (let i = 0; i < 15; i++) await Promise.resolve() }
+const rawUser = (id: string, text: string): UIUserTurn => ({
+  role: 'user', id, turn_id: id, text, attachments: [], timestamp: '2026-09-12T00:00:00.000Z',
+})
+
+function harness() {
+  api.fetchMessagesUI.mockReset().mockImplementation(async (_bot: string, sid: string) => [rawUser(`${sid}-old`, 'old')])
+  const views = createChatViews({
+    currentBotId: ref('bot'), sessionId: ref('a'), rememberBackgroundTask: task => task,
+    applyPendingBackgroundEventsToTool: () => {}, bumpFsChangedAtIfFsMutation: () => {},
+  })
+  let attempt!: (signal: AbortSignal) => Promise<void>
+  let activity!: (event: BotSessionActivityEvent) => void
+  let closeAttempt!: () => void
+  let socketEvent!: (event: UIStreamEvent) => void
+  let holdSnapshots = false
+  const snapshot = (sid: string) => socketEvent({
+    type: 'runtime_snapshot', session_id: sid, epoch: `epoch-${sid}`, seq: 1,
+    snapshot: { bot_id: 'bot', session_id: sid, epoch: `epoch-${sid}`, seq: 1, updated_at: '2026-09-12T00:00:00.000Z' },
+  })
+  const activityState = createSessionActivity({
+    currentBotId: ref('bot'), sessionId: ref('a'), userScopeGeneration: () => 0,
+    currentSessionListRevision: () => 0, currentSelectRequest: () => 0,
+    knownSession: () => null, rememberSession: vi.fn(), sessionsCursor: ref(null),
+    hasMoreSessions: ref(false), loadingMoreSessions: ref(false), appendSessions: vi.fn(),
+    hasListedSession: () => true, touchKnownSession: () => ({ source: 'listed' }),
+    updateKnownSessionTitle: vi.fn(), refreshSessionsList: vi.fn(async () => {}),
+    refreshSessionMessages: views.refreshCurrentSession,
+    markSessionViewStale: views.chatViews.markSessionStale,
+    markAllSessionViewsStale: views.chatViews.markAllSessionsStale,
+  })
+  const transport: ChatRealtimeTransport = {
+    createRetryingStream: () => ({ start: run => { attempt = run }, stop: () => {} }),
+    streamBotSessionsActivityEvents: (_bot, _signal, handler) => {
+      activity = handler
+      return new Promise<void>(resolve => { closeAttempt = resolve })
+    },
+    connectWebSocket: (_bot, handler) => {
+      socketEvent = handler
+      return {
+        connected: true, onOpen: null, onClose: null, close: () => {}, abort: () => {},
+        send: message => {
+          if (message.type !== 'runtime_subscribe') return
+          if (!holdSnapshots) snapshot(message.session_id)
+        },
+      } as ChatWebSocket
+    },
+  }
+  const realtime = createChatRealtimeController({
+    prepareSessionRuntime: views.loadInitialMessages,
+    onRuntimeProjection: (bid, sid, change) => { views.sessionTranscript(bid, sid).applyRuntimeTranscript(change.current.transcript) },
+    onWebSocketEvent: () => {},
+    onBotSessionsActivityEvent: activityState.handleActivity,
+    onActivityStreamCoverageChanged: views.chatViews.setActivityStreamCoverage,
+  }, transport)
+  views.configure({
+    runtimeProjection: realtime.runtimeProjection,
+    startSessionRuntime: realtime.startSessionRuntime,
+    stopSessionRuntime: realtime.stopSessionRuntime,
+    discardDraft: () => {}, invalidateDraftCommand: () => {}, saveDraftExternalAgent: () => {},
+    activateDraftExternalAgent: () => {}, refreshAppliedHook: () => {}, ensureVisibleSummary: () => {},
+  })
+  realtime.startWebSocket('bot')
+  realtime.startBotSessionsActivityStream('bot')
+  const openActivity = () => attempt(new AbortController().signal)
+  const select = (sid: string) => views.bindChatView('panel', { botId: 'bot', sessionId: sid, viewId: 'panel' }, true)
+  return {
+    views, realtime, select, openActivity,
+    activity: (event: BotSessionActivityEvent) => activity(event),
+    closeActivity: () => closeAttempt(),
+    holdSnapshots: () => { holdSnapshots = true },
+    socketEvent: (event: UIStreamEvent) => socketEvent(event),
+  }
+}
+
+afterEach(() => vi.useRealTimers())
+
+describe('cached revisit activity coverage', () => {
+  it('shows untouched cache immediately while covered, then atomically revalidates it', async () => {
+    const h = harness()
+    const active = h.openActivity()
+    h.activity({ type: 'activity_ready', cache_invalidation: true })
+    const a = h.select('a')
+    await flush()
+    h.select('b')
+    await flush()
+    h.holdSnapshots()
+    let resolveHistory!: (turns: UITurn[]) => void
+    api.fetchMessagesUI.mockImplementationOnce(() => new Promise<UITurn[]>(resolve => { resolveHistory = resolve }))
+    h.select('a')
+    expect(a.transcript.loadingMessages.value).toBe(false)
+    expect(a.transcript.visibleMessages.value.map(turn => turn.id)).toEqual(['a-old'])
+    resolveHistory([rawUser('a-new', 'new')])
+    await flush()
+    expect(a.transcript.visibleMessages.value.map(turn => turn.id)).toEqual(['a-old'])
+    h.socketEvent({ type: 'runtime_snapshot', session_id: 'a', epoch: 'epoch-a', seq: 2,
+      snapshot: { bot_id: 'bot', session_id: 'a', epoch: 'epoch-a', seq: 2, updated_at: '2026-09-12T00:01:00Z' },
+    })
+    await flush()
+    expect(a.transcript.visibleMessages.value.map(turn => turn.id)).toEqual(['a-new'])
+    h.closeActivity()
+    await active
+    h.realtime.stopStreams()
+  })
+
+  it('keeps a refreshed cache conservative throughout an activity outage and its recovery', async () => {
+    const h = harness()
+    const active = h.openActivity()
+    h.activity({ type: 'activity_ready', cache_invalidation: true })
+    const a = h.select('a')
+    await flush()
+    h.select('b')
+    await flush()
+    h.closeActivity()
+    await active
+    const reconnect = h.openActivity()
+    expect(a.staleWhileHidden).toBe(true)
+    h.select('a')
+    expect(a.transcript.loadingMessages.value).toBe(true)
+    await flush()
+    expect(a.staleWhileHidden).toBe(false)
+    h.select('b')
+    await flush()
+    let resolveHistory!: (turns: UITurn[]) => void
+    api.fetchMessagesUI.mockImplementationOnce(() => new Promise<UITurn[]>(resolve => { resolveHistory = resolve }))
+    h.select('a')
+    expect(a.transcript.visibleMessages.value).toEqual([])
+    resolveHistory([rawUser('a-edited', 'edited')])
+    await flush()
+    expect(a.staleWhileHidden).toBe(false)
+    h.select('b')
+    await flush()
+    // Ready cannot certify writes missed after the successful REST fetch.
+    h.activity({ type: 'activity_ready', cache_invalidation: true })
+    expect(a.staleWhileHidden).toBe(true)
+    h.select('a')
+    expect(a.transcript.visibleMessages.value).toEqual([])
+    await flush()
+    expect(a.staleWhileHidden).toBe(false)
+    h.select('b')
+    await flush()
+    h.select('a')
+    expect(a.transcript.loadingMessages.value).toBe(false)
+    await flush()
+    h.closeActivity()
+    await reconnect
+    h.realtime.stopStreams()
+  })
+
+  it.each(['no-frame', 'legacy', 'unsupported'] as const)('does not trust cached views with %s activity coverage', async (mode) => {
+    vi.useFakeTimers({ now: Date.parse('2026-09-12T00:00:00Z') })
+    const h = harness()
+    const active = h.openActivity()
+    if (mode === 'legacy') h.activity({ type: 'ping' })
+    if (mode === 'unsupported') h.activity({ type: 'activity_ready', cache_invalidation: false })
+    const a = h.select('a')
+    await flush()
+    h.select('b')
+    await flush()
+    await vi.advanceTimersByTimeAsync(60_000)
+    h.holdSnapshots()
+    h.select('a')
+    expect(a.transcript.visibleMessages.value).toEqual([])
+    h.closeActivity()
+    await active
+    h.realtime.stopStreams()
+    await flush()
+  })
+
+  it.each([true, false])('masks an active cross-client edit (invalidation support: %s)', async (supported) => {
+    const h = harness()
+    const active = h.openActivity()
+    if (supported) h.activity({ type: 'activity_ready', cache_invalidation: true })
+    else h.activity({ type: 'ping' })
+    const a = h.select('a')
+    await flush()
+    h.select('b')
+    await flush()
+    // The server's admission observer now emits this before edit/retry
+    // generation. Legacy servers have no such signal and remain masked.
+    if (supported) h.activity({ type: 'session_invalidated', session_id: 'a' })
+    h.holdSnapshots()
+    h.select('a')
+    await flush()
+    expect(a.transcript.visibleMessages.value).toEqual([])
+    h.socketEvent({
+      type: 'runtime_snapshot', session_id: 'a', epoch: 'epoch-a', seq: 2,
+      snapshot: {
+        bot_id: 'bot', session_id: 'a', epoch: 'epoch-a', seq: 2, updated_at: '2026-09-12T00:01:00Z',
+        current_run_view: {
+          run_id: 'edit-run', turn_id: 'edit-turn', generation: 'generation-a', status: 'running',
+          operation: { kind: 'edit', replace_from_message_id: 'a-old', replacement_user_turn: rawUser('edit-turn', 'edited') },
+          messages: [], started_at: '2026-09-12T00:01:00Z', updated_at: '2026-09-12T00:01:00Z',
+        },
+      },
+    })
+    await flush()
+    expect(a.transcript.visibleMessages.value.map(turn => turn.id)).not.toContain('a-old')
+    expect(a.transcript.visibleMessages.value[0]).toMatchObject({ role: 'user', text: 'edited' })
+    h.closeActivity()
+    await active
+    h.realtime.stopStreams()
+  })
+})

--- a/apps/web/src/store/chat/realtime.test.ts
+++ b/apps/web/src/store/chat/realtime.test.ts
@@ -385,4 +385,36 @@ describe('activity stream interruption', () => {
       vi.useRealTimers()
     }
   })
+
+  it('accumulates instant-close cycles into one outage instead of forgiving each', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(2_000_000)
+      const { controller, callbacks, retryingStreams } = makeController()
+      controller.startBotSessionsActivityStream('bot-1')
+
+      // A proxy accepting then instantly closing the SSE: every attempt ends
+      // immediately and the next starts ~300ms later. Each individual gap is
+      // sub-grace, but there is never any real coverage.
+      for (let cycle = 0; cycle < 9; cycle++) {
+        await retryingStreams[0]!.attempt!(new AbortController().signal)
+        vi.setSystemTime(2_000_000 + (cycle + 1) * 300)
+      }
+      expect(callbacks.onActivityStreamInterrupted).not.toHaveBeenCalled()
+
+      // The outage clock has been running since the first close: once the
+      // cumulative outage passes the grace, the interruption trips.
+      vi.setSystemTime(2_000_000 + 3_300)
+      await retryingStreams[0]!.attempt!(new AbortController().signal)
+      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledWith('bot-1')
+      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
+
+      // It does not re-fire while the same outage continues.
+      vi.setSystemTime(2_000_000 + 4_500)
+      await retryingStreams[0]!.attempt!(new AbortController().signal)
+      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/apps/web/src/store/chat/realtime.test.ts
+++ b/apps/web/src/store/chat/realtime.test.ts
@@ -62,6 +62,7 @@ function makeController(options: { socketConnected?: boolean } = {}) {
     }),
     onRuntimeProjection: vi.fn(),
     onBotSessionsActivityEvent: vi.fn(),
+    onActivityStreamInterrupted: vi.fn(),
   }
   const transport: ChatRealtimeTransport = {
     connectWebSocket: vi.fn((botId, handler) => {
@@ -346,5 +347,42 @@ describe('chat realtime controller', () => {
     expect(callbacks.onBotSessionsActivityEvent).toHaveBeenLastCalledWith('bot-1', {
       type: 'session_compaction', session_ids: [],
     })
+  })
+})
+
+describe('activity stream interruption', () => {
+  it('interrupts the bot when its activity stream is explicitly stopped', async () => {
+    const { controller, callbacks, retryingStreams } = makeController()
+    controller.startBotSessionsActivityStream('bot-1')
+    await retryingStreams[0]!.attempt!(new AbortController().signal)
+
+    controller.stopStreams()
+
+    expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledWith('bot-1')
+  })
+
+  it('absorbs sub-grace reconnects and interrupts only after the grace window', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(1_000_000)
+      const { controller, callbacks, retryingStreams } = makeController()
+      controller.startBotSessionsActivityStream('bot-1')
+
+      // First attempt ends → gap starts.
+      await retryingStreams[0]!.attempt!(new AbortController().signal)
+      // Reconnect 1s later: inside the 3s grace → no interruption.
+      vi.setSystemTime(1_001_000)
+      await retryingStreams[0]!.attempt!(new AbortController().signal)
+      expect(callbacks.onActivityStreamInterrupted).not.toHaveBeenCalled()
+
+      // That attempt ends too; the gap continues from the original start.
+      // Next attempt begins 4s after the gap began → interrupted.
+      vi.setSystemTime(1_004_001)
+      await retryingStreams[0]!.attempt!(new AbortController().signal)
+      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledWith('bot-1')
+      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/web/src/store/chat/realtime.test.ts
+++ b/apps/web/src/store/chat/realtime.test.ts
@@ -62,7 +62,7 @@ function makeController(options: { socketConnected?: boolean } = {}) {
     }),
     onRuntimeProjection: vi.fn(),
     onBotSessionsActivityEvent: vi.fn(),
-    onActivityStreamInterrupted: vi.fn(),
+    onActivityStreamCoverageChanged: vi.fn(),
   }
   const transport: ChatRealtimeTransport = {
     connectWebSocket: vi.fn((botId, handler) => {
@@ -350,76 +350,48 @@ describe('chat realtime controller', () => {
   })
 })
 
-describe('activity stream interruption', () => {
-  it('interrupts the bot when its activity stream is explicitly stopped', async () => {
-    const { controller, callbacks, retryingStreams } = makeController()
+describe('activity stream coverage', () => {
+  it('stays uncovered before a supported ready frame and after an explicit stop', async () => {
+    let onEvent!: (event: BotSessionActivityEvent) => void
+    let close!: () => void
+    const stream = createFakeRetryingStream()
+    const coverage = vi.fn()
+    const controller = createChatRealtimeController({
+      onWebSocketEvent: vi.fn(), prepareSessionRuntime: vi.fn(), onRuntimeProjection: vi.fn(),
+      onBotSessionsActivityEvent: vi.fn(), onActivityStreamCoverageChanged: coverage,
+    }, {
+      connectWebSocket: vi.fn(), createRetryingStream: () => stream,
+      streamBotSessionsActivityEvents: (_bot, _signal, handler) => {
+        onEvent = handler
+        return new Promise<void>(resolve => { close = resolve })
+      },
+    })
+    controller.startBotSessionsActivityStream('bot-1')
+    const attempt = stream.attempt!(new AbortController().signal)
+    expect(coverage).toHaveBeenLastCalledWith('bot-1', false)
+    onEvent({ type: 'ping' })
+    expect(coverage).toHaveBeenCalledTimes(1)
+    onEvent({ type: 'activity_ready', cache_invalidation: false })
+    expect(coverage).toHaveBeenLastCalledWith('bot-1', false)
+    onEvent({ type: 'activity_ready', cache_invalidation: true })
+    expect(coverage).toHaveBeenLastCalledWith('bot-1', true)
+    controller.stopStreams()
+    expect(coverage).toHaveBeenLastCalledWith('bot-1', false)
+    const count = coverage.mock.calls.length
+    onEvent({ type: 'activity_ready', cache_invalidation: true })
+    close()
+    await attempt
+    expect(coverage).toHaveBeenCalledTimes(count)
+  })
+
+  it('invalidates even a short gap and ignores frames from a completed attempt', async () => {
+    const { controller, callbacks, retryingStreams, activityHandlers } = makeController()
     controller.startBotSessionsActivityStream('bot-1')
     await retryingStreams[0]!.attempt!(new AbortController().signal)
-
+    expect(callbacks.onActivityStreamCoverageChanged).toHaveBeenLastCalledWith('bot-1', false)
+    vi.mocked(callbacks.onActivityStreamCoverageChanged!).mockClear()
+    activityHandlers[0]!({ type: 'activity_ready', cache_invalidation: true })
+    expect(callbacks.onActivityStreamCoverageChanged).not.toHaveBeenCalled()
     controller.stopStreams()
-
-    expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledWith('bot-1')
-  })
-
-  it('absorbs sub-grace reconnects and interrupts only after the grace window', async () => {
-    vi.useFakeTimers()
-    try {
-      const { controller, callbacks, retryingStreams, activityHandlers } = makeController()
-      controller.startBotSessionsActivityStream('bot-1')
-
-      // First attempt ends → the gap and its grace timer start.
-      await retryingStreams[0]!.attempt!(new AbortController().signal)
-      // 1s in, a new attempt delivers a frame: coverage provably restored
-      // inside the grace window, so the pending invalidation is cancelled.
-      await vi.advanceTimersByTimeAsync(1_000)
-      await retryingStreams[0]!.attempt!(new AbortController().signal)
-      activityHandlers[1]!({ type: 'ping' })
-
-      // That attempt ends too → a FRESH gap starts now. The old grace timer
-      // must be gone: another 2.9s of outage stays sub-grace.
-      await vi.advanceTimersByTimeAsync(2_900)
-      await retryingStreams[0]!.attempt!(new AbortController().signal)
-      expect(callbacks.onActivityStreamInterrupted).not.toHaveBeenCalled()
-
-      // The new gap crosses the grace at its own 3s mark — fired by the
-      // timer, with no further attempt needed.
-      await vi.advanceTimersByTimeAsync(3_001)
-      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledWith('bot-1')
-      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('accumulates instant-close cycles into one outage instead of forgiving each', async () => {
-    vi.useFakeTimers()
-    try {
-      const { controller, callbacks, retryingStreams } = makeController()
-      controller.startBotSessionsActivityStream('bot-1')
-
-      // A proxy accepting then instantly closing the SSE: every attempt ends
-      // immediately and the next starts ~300ms later. Each individual gap is
-      // sub-grace, but there is never any real coverage.
-      for (let cycle = 0; cycle < 9; cycle++) {
-        await retryingStreams[0]!.attempt!(new AbortController().signal)
-        await vi.advanceTimersByTimeAsync(300)
-      }
-      // 9 × 300ms = 2.7s of cumulative outage — still sub-grace.
-      expect(callbacks.onActivityStreamInterrupted).not.toHaveBeenCalled()
-
-      // The outage clock has been running since the first close: crossing the
-      // grace trips the interruption even while the current attempt hangs and
-      // no new attempt starts.
-      await vi.advanceTimersByTimeAsync(400)
-      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledWith('bot-1')
-      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
-
-      // It does not re-fire while the same outage continues.
-      await retryingStreams[0]!.attempt!(new AbortController().signal)
-      await vi.advanceTimersByTimeAsync(1_000)
-      expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
-    } finally {
-      vi.useRealTimers()
-    }
   })
 })

--- a/apps/web/src/store/chat/realtime.test.ts
+++ b/apps/web/src/store/chat/realtime.test.ts
@@ -364,21 +364,26 @@ describe('activity stream interruption', () => {
   it('absorbs sub-grace reconnects and interrupts only after the grace window', async () => {
     vi.useFakeTimers()
     try {
-      vi.setSystemTime(1_000_000)
-      const { controller, callbacks, retryingStreams } = makeController()
+      const { controller, callbacks, retryingStreams, activityHandlers } = makeController()
       controller.startBotSessionsActivityStream('bot-1')
 
-      // First attempt ends → gap starts.
+      // First attempt ends → the gap and its grace timer start.
       await retryingStreams[0]!.attempt!(new AbortController().signal)
-      // Reconnect 1s later: inside the 3s grace → no interruption.
-      vi.setSystemTime(1_001_000)
+      // 1s in, a new attempt delivers a frame: coverage provably restored
+      // inside the grace window, so the pending invalidation is cancelled.
+      await vi.advanceTimersByTimeAsync(1_000)
+      await retryingStreams[0]!.attempt!(new AbortController().signal)
+      activityHandlers[1]!({ type: 'ping' })
+
+      // That attempt ends too → a FRESH gap starts now. The old grace timer
+      // must be gone: another 2.9s of outage stays sub-grace.
+      await vi.advanceTimersByTimeAsync(2_900)
       await retryingStreams[0]!.attempt!(new AbortController().signal)
       expect(callbacks.onActivityStreamInterrupted).not.toHaveBeenCalled()
 
-      // That attempt ends too; the gap continues from the original start.
-      // Next attempt begins 4s after the gap began → interrupted.
-      vi.setSystemTime(1_004_001)
-      await retryingStreams[0]!.attempt!(new AbortController().signal)
+      // The new gap crosses the grace at its own 3s mark — fired by the
+      // timer, with no further attempt needed.
+      await vi.advanceTimersByTimeAsync(3_001)
       expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledWith('bot-1')
       expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
     } finally {
@@ -389,7 +394,6 @@ describe('activity stream interruption', () => {
   it('accumulates instant-close cycles into one outage instead of forgiving each', async () => {
     vi.useFakeTimers()
     try {
-      vi.setSystemTime(2_000_000)
       const { controller, callbacks, retryingStreams } = makeController()
       controller.startBotSessionsActivityStream('bot-1')
 
@@ -398,20 +402,21 @@ describe('activity stream interruption', () => {
       // sub-grace, but there is never any real coverage.
       for (let cycle = 0; cycle < 9; cycle++) {
         await retryingStreams[0]!.attempt!(new AbortController().signal)
-        vi.setSystemTime(2_000_000 + (cycle + 1) * 300)
+        await vi.advanceTimersByTimeAsync(300)
       }
+      // 9 × 300ms = 2.7s of cumulative outage — still sub-grace.
       expect(callbacks.onActivityStreamInterrupted).not.toHaveBeenCalled()
 
-      // The outage clock has been running since the first close: once the
-      // cumulative outage passes the grace, the interruption trips.
-      vi.setSystemTime(2_000_000 + 3_300)
-      await retryingStreams[0]!.attempt!(new AbortController().signal)
+      // The outage clock has been running since the first close: crossing the
+      // grace trips the interruption even while the current attempt hangs and
+      // no new attempt starts.
+      await vi.advanceTimersByTimeAsync(400)
       expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledWith('bot-1')
       expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
 
       // It does not re-fire while the same outage continues.
-      vi.setSystemTime(2_000_000 + 4_500)
       await retryingStreams[0]!.attempt!(new AbortController().signal)
+      await vi.advanceTimersByTimeAsync(1_000)
       expect(callbacks.onActivityStreamInterrupted).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()

--- a/apps/web/src/store/chat/realtime.ts
+++ b/apps/web/src/store/chat/realtime.ts
@@ -83,6 +83,7 @@ export function createChatRealtimeController(
   let activityStreamBotId = ''
   let activityGapStartedAt = 0
   let activityOutageMarked = false
+  let activityOutageTimer: ReturnType<typeof setTimeout> | null = null
   const sessionRuntimeConnections = new Map<string, SessionRuntimeConnection>()
   const botSessionsActivityStream = transport.createRetryingStream()
   const runtimeClient = createRuntimeClient({
@@ -249,17 +250,41 @@ export function createChatRealtimeController(
       })
   }
 
+  function clearActivityOutage() {
+    activityGapStartedAt = 0
+    activityOutageMarked = false
+    if (activityOutageTimer) {
+      clearTimeout(activityOutageTimer)
+      activityOutageTimer = null
+    }
+  }
+
+  function markActivityOutage(botId: string) {
+    if (activityOutageMarked) return
+    activityOutageMarked = true
+    callbacks.onActivityStreamInterrupted?.(botId)
+  }
+
+  function beginActivityGap(botId: string) {
+    if (activityGapStartedAt) return
+    activityGapStartedAt = Date.now()
+    // Fire the invalidation at the end of the grace window even if no new
+    // attempt starts — a hung connect must not postpone it indefinitely.
+    activityOutageTimer = setTimeout(() => {
+      activityOutageTimer = null
+      if (activityGapStartedAt) markActivityOutage(botId)
+    }, ACTIVITY_GAP_GRACE_MS)
+  }
+
   function stopBotSessionsActivityStream() {
     botSessionsActivityGeneration += 1
     botSessionsActivityStream.stop()
+    const bid = activityStreamBotId
+    activityStreamBotId = ''
+    clearActivityOutage()
     // An explicit stop (bot switch, teardown) ends coverage with no quick
     // reconnect coming; the bot's hidden views can no longer be trusted fresh.
-    if (activityStreamBotId) {
-      callbacks.onActivityStreamInterrupted?.(activityStreamBotId)
-      activityStreamBotId = ''
-    }
-    activityGapStartedAt = 0
-    activityOutageMarked = false
+    if (bid) callbacks.onActivityStreamInterrupted?.(bid)
   }
 
   function startBotSessionsActivityStream(botId: string) {
@@ -272,30 +297,26 @@ export function createChatRealtimeController(
     botSessionsActivityStream.start(async (signal) => {
       if (generation !== botSessionsActivityGeneration || signal.aborted) return
       // An attempt STARTING proves nothing — a proxy can accept the SSE and
-      // close it immediately, cycling forever with sub-grace gaps between
-      // attempts. So the outage clock is only cleared by an attempt that
-      // actually STAYS connected past the grace window. Instant-close cycles
-      // keep the clock running and trip the interruption once the cumulative
-      // outage exceeds the grace, exactly like one long outage.
+      // close it immediately, or hold the connect pending for minutes. The
+      // outage clock is only cleared by the first real frame of an attempt;
+      // sub-grace cycles keep it running and trip the interruption once the
+      // cumulative outage exceeds the grace, exactly like one long outage.
       if (activityGapStartedAt
-        && Date.now() - activityGapStartedAt > ACTIVITY_GAP_GRACE_MS
-        && !activityOutageMarked) {
-        activityOutageMarked = true
-        callbacks.onActivityStreamInterrupted?.(bid)
+        && Date.now() - activityGapStartedAt > ACTIVITY_GAP_GRACE_MS) {
+        markActivityOutage(bid)
       }
-      const coverageRestored = setTimeout(() => {
-        activityGapStartedAt = 0
-        activityOutageMarked = false
-      }, ACTIVITY_GAP_GRACE_MS)
       try {
         await transport.streamBotSessionsActivityEvents(bid, signal, (event) => {
           if (generation !== botSessionsActivityGeneration) return
+          // The first frame of an attempt is the only proof that coverage
+          // actually resumed — no timer can tell a live subscription from a
+          // hung connect.
+          clearActivityOutage()
           callbacks.onBotSessionsActivityEvent(bid, event)
         })
       } finally {
-        clearTimeout(coverageRestored)
         if (generation === botSessionsActivityGeneration) {
-          if (!activityGapStartedAt) activityGapStartedAt = Date.now()
+          beginActivityGap(bid)
           // A disconnected stream cannot vouch for a still-running compaction.
           // The server sends a fresh snapshot when this stream reconnects.
           callbacks.onBotSessionsActivityEvent(bid, { type: 'session_compaction', session_ids: [] })

--- a/apps/web/src/store/chat/realtime.ts
+++ b/apps/web/src/store/chat/realtime.ts
@@ -38,6 +38,12 @@ export interface ChatRealtimeCallbacks {
     change: RuntimeProjectionChange,
   ) => void
   onBotSessionsActivityEvent: (botId: string, event: BotSessionActivityEvent) => void
+  // Fired when the activity stream stops covering a bot for long enough that
+  // touches were probably missed (bot switch, explicit stop, or an outage
+  // beyond the grace window): cached views of the bot can no longer be
+  // trusted as fresh. Sub-grace reconnects do not fire — see
+  // ACTIVITY_GAP_GRACE_MS for the tradeoff.
+  onActivityStreamInterrupted?: (botId: string) => void
 }
 
 export interface ChatRealtimeTransport {
@@ -58,6 +64,12 @@ function isRuntimeEvent(event: UIStreamEvent): event is UIRuntimeEvent {
     || event.type === 'runtime_dropped'
 }
 
+// How long the activity stream may be down before its bot's hidden views are
+// distrusted. RetryingStream reconnects routine drops in ~0.3–5s; a grace of
+// a few seconds absorbs those without masking every cached view, while still
+// catching real outages (bot switch excepted — that interrupts immediately).
+const ACTIVITY_GAP_GRACE_MS = 3_000
+
 // Owns chat transport lifecycles. The WebSocket carries both turn commands and
 // session runtime subscriptions; the bot-wide SSE carries lightweight activity.
 export function createChatRealtimeController(
@@ -68,6 +80,8 @@ export function createChatRealtimeController(
   let activeWebSocketBotId = ''
   let webSocketGeneration = 0
   let botSessionsActivityGeneration = 0
+  let activityStreamBotId = ''
+  let activityGapStartedAt = 0
   const sessionRuntimeConnections = new Map<string, SessionRuntimeConnection>()
   const botSessionsActivityStream = transport.createRetryingStream()
   const runtimeClient = createRuntimeClient({
@@ -237,25 +251,43 @@ export function createChatRealtimeController(
   function stopBotSessionsActivityStream() {
     botSessionsActivityGeneration += 1
     botSessionsActivityStream.stop()
+    // An explicit stop (bot switch, teardown) ends coverage with no quick
+    // reconnect coming; the bot's hidden views can no longer be trusted fresh.
+    if (activityStreamBotId) {
+      callbacks.onActivityStreamInterrupted?.(activityStreamBotId)
+      activityStreamBotId = ''
+    }
+    activityGapStartedAt = 0
   }
 
   function startBotSessionsActivityStream(botId: string) {
     stopBotSessionsActivityStream()
     const bid = botId.trim()
     if (!bid) return
+    activityStreamBotId = bid
 
     const generation = botSessionsActivityGeneration
     botSessionsActivityStream.start(async (signal) => {
       if (generation !== botSessionsActivityGeneration || signal.aborted) return
+      // A previous attempt ended and this one is only now starting: the gap
+      // between them had no coverage. Below the grace window the miss risk is
+      // a touch landing inside a routine reconnect (rare, self-correcting —
+      // the revisit revalidation replaces atomically); beyond it a touch was
+      // probably missed, so the bot's hidden views must be distrusted.
+      if (activityGapStartedAt && Date.now() - activityGapStartedAt > ACTIVITY_GAP_GRACE_MS) {
+        callbacks.onActivityStreamInterrupted?.(bid)
+      }
+      activityGapStartedAt = 0
       try {
         await transport.streamBotSessionsActivityEvents(bid, signal, (event) => {
           if (generation !== botSessionsActivityGeneration) return
           callbacks.onBotSessionsActivityEvent(bid, event)
         })
       } finally {
-        // A disconnected stream cannot vouch for a still-running compaction.
-        // The server sends a fresh snapshot when this stream reconnects.
         if (generation === botSessionsActivityGeneration) {
+          if (!activityGapStartedAt) activityGapStartedAt = Date.now()
+          // A disconnected stream cannot vouch for a still-running compaction.
+          // The server sends a fresh snapshot when this stream reconnects.
           callbacks.onBotSessionsActivityEvent(bid, { type: 'session_compaction', session_ids: [] })
         }
       }

--- a/apps/web/src/store/chat/realtime.ts
+++ b/apps/web/src/store/chat/realtime.ts
@@ -82,6 +82,7 @@ export function createChatRealtimeController(
   let botSessionsActivityGeneration = 0
   let activityStreamBotId = ''
   let activityGapStartedAt = 0
+  let activityOutageMarked = false
   const sessionRuntimeConnections = new Map<string, SessionRuntimeConnection>()
   const botSessionsActivityStream = transport.createRetryingStream()
   const runtimeClient = createRuntimeClient({
@@ -258,6 +259,7 @@ export function createChatRealtimeController(
       activityStreamBotId = ''
     }
     activityGapStartedAt = 0
+    activityOutageMarked = false
   }
 
   function startBotSessionsActivityStream(botId: string) {
@@ -269,21 +271,29 @@ export function createChatRealtimeController(
     const generation = botSessionsActivityGeneration
     botSessionsActivityStream.start(async (signal) => {
       if (generation !== botSessionsActivityGeneration || signal.aborted) return
-      // A previous attempt ended and this one is only now starting: the gap
-      // between them had no coverage. Below the grace window the miss risk is
-      // a touch landing inside a routine reconnect (rare, self-correcting —
-      // the revisit revalidation replaces atomically); beyond it a touch was
-      // probably missed, so the bot's hidden views must be distrusted.
-      if (activityGapStartedAt && Date.now() - activityGapStartedAt > ACTIVITY_GAP_GRACE_MS) {
+      // An attempt STARTING proves nothing — a proxy can accept the SSE and
+      // close it immediately, cycling forever with sub-grace gaps between
+      // attempts. So the outage clock is only cleared by an attempt that
+      // actually STAYS connected past the grace window. Instant-close cycles
+      // keep the clock running and trip the interruption once the cumulative
+      // outage exceeds the grace, exactly like one long outage.
+      if (activityGapStartedAt
+        && Date.now() - activityGapStartedAt > ACTIVITY_GAP_GRACE_MS
+        && !activityOutageMarked) {
+        activityOutageMarked = true
         callbacks.onActivityStreamInterrupted?.(bid)
       }
-      activityGapStartedAt = 0
+      const coverageRestored = setTimeout(() => {
+        activityGapStartedAt = 0
+        activityOutageMarked = false
+      }, ACTIVITY_GAP_GRACE_MS)
       try {
         await transport.streamBotSessionsActivityEvents(bid, signal, (event) => {
           if (generation !== botSessionsActivityGeneration) return
           callbacks.onBotSessionsActivityEvent(bid, event)
         })
       } finally {
+        clearTimeout(coverageRestored)
         if (generation === botSessionsActivityGeneration) {
           if (!activityGapStartedAt) activityGapStartedAt = Date.now()
           // A disconnected stream cannot vouch for a still-running compaction.

--- a/apps/web/src/store/chat/realtime.ts
+++ b/apps/web/src/store/chat/realtime.ts
@@ -38,12 +38,10 @@ export interface ChatRealtimeCallbacks {
     change: RuntimeProjectionChange,
   ) => void
   onBotSessionsActivityEvent: (botId: string, event: BotSessionActivityEvent) => void
-  // Fired when the activity stream stops covering a bot for long enough that
-  // touches were probably missed (bot switch, explicit stop, or an outage
-  // beyond the grace window): cached views of the bot can no longer be
-  // trusted as fresh. Sub-grace reconnects do not fire — see
-  // ACTIVITY_GAP_GRACE_MS for the tradeoff.
-  onActivityStreamInterrupted?: (botId: string) => void
+  // Coverage requires the server's ready frame, including runtime admission
+  // invalidation support. Legacy servers and disconnected streams stay
+  // conservative even when REST history requests continue to succeed.
+  onActivityStreamCoverageChanged?: (botId: string, covered: boolean) => void
 }
 
 export interface ChatRealtimeTransport {
@@ -64,12 +62,6 @@ function isRuntimeEvent(event: UIStreamEvent): event is UIRuntimeEvent {
     || event.type === 'runtime_dropped'
 }
 
-// How long the activity stream may be down before its bot's hidden views are
-// distrusted. RetryingStream reconnects routine drops in ~0.3–5s; a grace of
-// a few seconds absorbs those without masking every cached view, while still
-// catching real outages (bot switch excepted — that interrupts immediately).
-const ACTIVITY_GAP_GRACE_MS = 3_000
-
 // Owns chat transport lifecycles. The WebSocket carries both turn commands and
 // session runtime subscriptions; the bot-wide SSE carries lightweight activity.
 export function createChatRealtimeController(
@@ -81,9 +73,6 @@ export function createChatRealtimeController(
   let webSocketGeneration = 0
   let botSessionsActivityGeneration = 0
   let activityStreamBotId = ''
-  let activityGapStartedAt = 0
-  let activityOutageMarked = false
-  let activityOutageTimer: ReturnType<typeof setTimeout> | null = null
   const sessionRuntimeConnections = new Map<string, SessionRuntimeConnection>()
   const botSessionsActivityStream = transport.createRetryingStream()
   const runtimeClient = createRuntimeClient({
@@ -250,41 +239,12 @@ export function createChatRealtimeController(
       })
   }
 
-  function clearActivityOutage() {
-    activityGapStartedAt = 0
-    activityOutageMarked = false
-    if (activityOutageTimer) {
-      clearTimeout(activityOutageTimer)
-      activityOutageTimer = null
-    }
-  }
-
-  function markActivityOutage(botId: string) {
-    if (activityOutageMarked) return
-    activityOutageMarked = true
-    callbacks.onActivityStreamInterrupted?.(botId)
-  }
-
-  function beginActivityGap(botId: string) {
-    if (activityGapStartedAt) return
-    activityGapStartedAt = Date.now()
-    // Fire the invalidation at the end of the grace window even if no new
-    // attempt starts — a hung connect must not postpone it indefinitely.
-    activityOutageTimer = setTimeout(() => {
-      activityOutageTimer = null
-      if (activityGapStartedAt) markActivityOutage(botId)
-    }, ACTIVITY_GAP_GRACE_MS)
-  }
-
   function stopBotSessionsActivityStream() {
     botSessionsActivityGeneration += 1
     botSessionsActivityStream.stop()
     const bid = activityStreamBotId
     activityStreamBotId = ''
-    clearActivityOutage()
-    // An explicit stop (bot switch, teardown) ends coverage with no quick
-    // reconnect coming; the bot's hidden views can no longer be trusted fresh.
-    if (bid) callbacks.onActivityStreamInterrupted?.(bid)
+    if (bid) callbacks.onActivityStreamCoverageChanged?.(bid, false)
   }
 
   function startBotSessionsActivityStream(botId: string) {
@@ -292,33 +252,26 @@ export function createChatRealtimeController(
     const bid = botId.trim()
     if (!bid) return
     activityStreamBotId = bid
+    callbacks.onActivityStreamCoverageChanged?.(bid, false)
 
     const generation = botSessionsActivityGeneration
     botSessionsActivityStream.start(async (signal) => {
       if (generation !== botSessionsActivityGeneration || signal.aborted) return
-      // An attempt STARTING proves nothing — a proxy can accept the SSE and
-      // close it immediately, or hold the connect pending for minutes. The
-      // outage clock is only cleared by the first real frame of an attempt;
-      // sub-grace cycles keep it running and trip the interruption once the
-      // cumulative outage exceeds the grace, exactly like one long outage.
-      if (activityGapStartedAt
-        && Date.now() - activityGapStartedAt > ACTIVITY_GAP_GRACE_MS) {
-        markActivityOutage(bid)
-      }
+      let attemptActive = true
       try {
         await transport.streamBotSessionsActivityEvents(bid, signal, (event) => {
-          if (generation !== botSessionsActivityGeneration) return
-          // The first frame of an attempt is the only proof that coverage
-          // actually resumed — no timer can tell a live subscription from a
-          // hung connect.
-          clearActivityOutage()
+          if (!attemptActive || signal.aborted || generation !== botSessionsActivityGeneration) return
+          if (event.type === 'activity_ready') {
+            callbacks.onActivityStreamCoverageChanged?.(bid, event.cache_invalidation === true)
+          }
           callbacks.onBotSessionsActivityEvent(bid, event)
         })
       } finally {
+        attemptActive = false
         if (generation === botSessionsActivityGeneration) {
-          beginActivityGap(bid)
-          // A disconnected stream cannot vouch for a still-running compaction.
-          // The server sends a fresh snapshot when this stream reconnects.
+          // Even a short gap can lose an edit notification. Coverage stays
+          // false until a new subscription explicitly confirms it is ready.
+          callbacks.onActivityStreamCoverageChanged?.(bid, false)
           callbacks.onBotSessionsActivityEvent(bid, { type: 'session_compaction', session_ids: [] })
         }
       }

--- a/apps/web/src/store/chat/runtime-layer.ts
+++ b/apps/web/src/store/chat/runtime-layer.ts
@@ -21,7 +21,7 @@ export interface ChatRuntimeLayerDeps
   showError: ChatDecisionDeps['showError']
   createControlId: ChatDecisionDeps['createControlId']
   onBotSessionsActivityEvent: ChatRealtimeCallbacks['onBotSessionsActivityEvent']
-  onActivityStreamInterrupted?: ChatRealtimeCallbacks['onActivityStreamInterrupted']
+  onActivityStreamCoverageChanged?: ChatRealtimeCallbacks['onActivityStreamCoverageChanged']
 }
 
 export function createChatRuntimeLayer(deps: ChatRuntimeLayerDeps) {
@@ -45,7 +45,7 @@ export function createChatRuntimeLayer(deps: ChatRuntimeLayerDeps) {
     onRuntimeProjection: (botId, sessionId, change) =>
       forwardRuntimeProjection(botId, sessionId, change),
     onBotSessionsActivityEvent: deps.onBotSessionsActivityEvent,
-    onActivityStreamInterrupted: deps.onActivityStreamInterrupted,
+    onActivityStreamCoverageChanged: deps.onActivityStreamCoverageChanged,
   })
   const decisions = createChatDecisions({
     normalizeTarget: target => deps.normalizeTarget(target),

--- a/apps/web/src/store/chat/runtime-layer.ts
+++ b/apps/web/src/store/chat/runtime-layer.ts
@@ -21,6 +21,7 @@ export interface ChatRuntimeLayerDeps
   showError: ChatDecisionDeps['showError']
   createControlId: ChatDecisionDeps['createControlId']
   onBotSessionsActivityEvent: ChatRealtimeCallbacks['onBotSessionsActivityEvent']
+  onActivityStreamInterrupted?: ChatRealtimeCallbacks['onActivityStreamInterrupted']
 }
 
 export function createChatRuntimeLayer(deps: ChatRuntimeLayerDeps) {
@@ -44,6 +45,7 @@ export function createChatRuntimeLayer(deps: ChatRuntimeLayerDeps) {
     onRuntimeProjection: (botId, sessionId, change) =>
       forwardRuntimeProjection(botId, sessionId, change),
     onBotSessionsActivityEvent: deps.onBotSessionsActivityEvent,
+    onActivityStreamInterrupted: deps.onActivityStreamInterrupted,
   })
   const decisions = createChatDecisions({
     normalizeTarget: target => deps.normalizeTarget(target),

--- a/apps/web/src/store/chat/session-activity.test.ts
+++ b/apps/web/src/store/chat/session-activity.test.ts
@@ -81,3 +81,33 @@ describe('persisted background notifications', () => {
     expect(displayed).toEqual(['Installing', 'Installed'])
   })
 })
+
+describe('session view staleness signals', () => {
+  function activityWithStaleDeps() {
+    const markSessionViewStale = vi.fn()
+    const markAllSessionViewsStale = vi.fn()
+    const state = createSessionActivity({
+      currentBotId: ref('bot-1'), sessionId: ref('session-1'),
+      userScopeGeneration: () => 0, currentSessionListRevision: () => 0, currentSelectRequest: () => 0,
+      knownSession: () => null, rememberSession: vi.fn(), sessionsCursor: ref(null),
+      hasMoreSessions: ref(false), loadingMoreSessions: ref(false), appendSessions: vi.fn(),
+      hasListedSession: () => true, touchKnownSession: () => ({ source: 'listed' }),
+      updateKnownSessionTitle: vi.fn(), refreshSessionsList: vi.fn(async () => {}),
+      refreshSessionMessages: vi.fn(async () => {}),
+      markSessionViewStale, markAllSessionViewsStale,
+    })
+    return { state, markSessionViewStale, markAllSessionViewsStale }
+  }
+
+  it('marks the touched session view stale', () => {
+    const { state, markSessionViewStale } = activityWithStaleDeps()
+    state.handleActivity('bot-1', { type: 'session_touched', session_id: 'session-9' })
+    expect(markSessionViewStale).toHaveBeenCalledWith('bot-1', 'session-9')
+  })
+
+  it('marks every hidden view stale when events were dropped', () => {
+    const { state, markAllSessionViewsStale } = activityWithStaleDeps()
+    state.handleActivity('bot-1', { type: 'dropped', count: 3 })
+    expect(markAllSessionViewsStale).toHaveBeenCalledWith('bot-1')
+  })
+})

--- a/apps/web/src/store/chat/session-activity.test.ts
+++ b/apps/web/src/store/chat/session-activity.test.ts
@@ -105,6 +105,16 @@ describe('session view staleness signals', () => {
     expect(markSessionViewStale).toHaveBeenCalledWith('bot-1', 'session-9')
   })
 
+  it('invalidates runtime replacements before persisted message activity arrives', () => {
+    const { state, markSessionViewStale, markAllSessionViewsStale } = activityWithStaleDeps()
+    state.handleActivity('bot-1', { type: 'session_invalidated', session_id: 'session-9' })
+    expect(markSessionViewStale).toHaveBeenCalledWith('bot-1', 'session-9')
+    expect(markAllSessionViewsStale).not.toHaveBeenCalled()
+
+    state.handleActivity('bot-1', { type: 'session_invalidated', session_id: '' })
+    expect(markAllSessionViewsStale).toHaveBeenCalledWith('bot-1')
+  })
+
   it('marks every hidden view stale when events were dropped', () => {
     const { state, markAllSessionViewsStale } = activityWithStaleDeps()
     state.handleActivity('bot-1', { type: 'dropped', count: 3 })

--- a/apps/web/src/store/chat/session-activity.ts
+++ b/apps/web/src/store/chat/session-activity.ts
@@ -169,6 +169,13 @@ export function createSessionActivity(deps: {
   }
 
   function handleActivity(botId: string, event: BotSessionActivityEvent) {
+    if (event.type === 'activity_ready') return
+    if (event.type === 'session_invalidated') {
+      const sessionId = event.session_id.trim()
+      if (sessionId) deps.markSessionViewStale?.(botId, sessionId)
+      else deps.markAllSessionViewsStale?.(botId)
+      return
+    }
     if (event.type === 'session_compaction') {
       compactingSessions.value[botId] = event.session_ids
       return

--- a/apps/web/src/store/chat/session-activity.ts
+++ b/apps/web/src/store/chat/session-activity.ts
@@ -26,6 +26,11 @@ export function createSessionActivity(deps: {
   updateKnownSessionTitle: (sessionId: string, title: string) => void
   refreshSessionsList: (botId: string) => Promise<void>
   refreshSessionMessages: (botId: string, sessionId: string) => Promise<void>
+  // Staleness signals for cached session views (see view-registry): a touch
+  // marks one view, a dropped frame means events were lost and every hidden
+  // view of the bot becomes unknowable.
+  markSessionViewStale?: (botId: string, sessionId: string) => void
+  markAllSessionViewsStale?: (botId: string) => void
 }) {
   const visibleSummaryRequests = new Map<string, Promise<SessionSummary | null>>()
   const compactingSessions = ref<Record<string, string[]>>({})
@@ -170,6 +175,7 @@ export function createSessionActivity(deps: {
     }
     if (event.type === 'ping') return
     if (event.type === 'dropped') {
+      deps.markAllSessionViewsStale?.(botId)
       void deps.refreshSessionsList(botId)
       return
     }
@@ -177,6 +183,7 @@ export function createSessionActivity(deps: {
       const sessionId = event.session_id.trim()
       if (!sessionId) return
       if (event.reason === 'background_task') refreshNotification(botId, sessionId)
+      deps.markSessionViewStale?.(botId, sessionId)
       const touched = deps.touchKnownSession(sessionId, event.updated_at)
       if (touched.source === 'listed') return
       if (touched.source === 'remembered') {

--- a/apps/web/src/store/chat/transcript.test.ts
+++ b/apps/web/src/store/chat/transcript.test.ts
@@ -876,7 +876,7 @@ describe('chat transcript controller', () => {
 
     expect(transcript.loadingMessages.value).toBe(false)
     expect(transcript.hasMoreOlder.value).toBe(true)
-    expect(onRefreshApplied).toHaveBeenCalledWith('session-1', '2026-01-01T00:00:02.000Z')
+    expect(onRefreshApplied).toHaveBeenCalledWith('session-1', '2026-01-01T00:00:02.000Z', undefined)
   })
 
   it('drops an older-page response that resolves after the active session changes', async () => {

--- a/apps/web/src/store/chat/transcript.test.ts
+++ b/apps/web/src/store/chat/transcript.test.ts
@@ -504,6 +504,31 @@ describe('chat transcript controller', () => {
     expect(transcript.visibleMessages.value.map(turn => turn.id)).toEqual(['fresh-user'])
   })
 
+  it('keeps a trusted cached transcript visible while revalidating unmasked', async () => {
+    const { transcript, fetchMessages } = makeTranscript()
+    transcript.replaceMessages([rawUser('cached-user', 'cached')], 'session-1')
+    const pending = deferred<UITurn[]>()
+    fetchMessages.mockReturnValueOnce(pending.promise)
+
+    const hydration = transcript.loadInitialMessages(
+      'bot-1',
+      'session-1',
+      async applyHistory => applyHistory(),
+      { mask: false },
+    )
+
+    // No mask: the cache stays on screen and loadingMessages is untouched
+    // while the same atomic commit path applies the fresh history.
+    expect(transcript.loadingMessages.value).toBe(false)
+    expect(transcript.visibleMessages.value.map(turn => turn.id)).toEqual(['cached-user'])
+
+    pending.resolve([rawUser('fresh-user', 'fresh')])
+    await hydration
+
+    expect(transcript.loadingMessages.value).toBe(false)
+    expect(transcript.visibleMessages.value.map(turn => turn.id)).toEqual(['fresh-user'])
+  })
+
   it('replaces staged database history with an active edit projection', async () => {
     const { transcript, fetchMessages } = makeTranscript()
     fetchMessages.mockResolvedValueOnce([

--- a/apps/web/src/store/chat/transcript.ts
+++ b/apps/web/src/store/chat/transcript.ts
@@ -211,12 +211,21 @@ export function createTranscriptController({
     botId: string,
     targetSessionId: string,
     commitInitialHistory: CommitInitialHistory,
+    // mask=true (default) hides the cached transcript behind loadingMessages
+    // until fresh history commits. mask=false keeps a trusted cache visible
+    // and revalidates in the open; the fetched history still commits through
+    // the same atomic path, so a superseded turn never paints either way.
+    options: { mask?: boolean } = {},
   ) {
     const bid = botId.trim()
     const sid = targetSessionId.trim()
     if (!bid || !sid) return
-    loadingMessages.value = true
-    const version = ++loadingMessagesVersion
+    const mask = options.mask !== false
+    if (mask) loadingMessages.value = true
+    // Only a masked load owns the loadingMessages lifecycle: bumping the
+    // version here (or clearing in finally) when unmasked could strand a
+    // concurrent masked load's flag.
+    const version = mask ? ++loadingMessagesVersion : loadingMessagesVersion
     const generation = historyGeneration
     try {
       const turns = await fetchMessages(bid, sid, { limit: PAGE_SIZE })
@@ -225,7 +234,7 @@ export function createTranscriptController({
         applyFetchedHistory(bid, sid, generation, turns)
       })
     } finally {
-      if (version === loadingMessagesVersion) loadingMessages.value = false
+      if (mask && version === loadingMessagesVersion) loadingMessages.value = false
     }
   }
 

--- a/apps/web/src/store/chat/transcript.ts
+++ b/apps/web/src/store/chat/transcript.ts
@@ -221,8 +221,8 @@ export function createTranscriptController({
     commitInitialHistory: CommitInitialHistory,
     // mask=true (default) hides the cached transcript behind loadingMessages
     // until fresh history commits. mask=false keeps a trusted cache visible
-    // and revalidates in the open; the fetched history still commits through
-    // the same atomic path, so a superseded turn never paints either way.
+    // and revalidates in the open. Both paths commit fetched history and its
+    // runtime projection together, without a database-only intermediate frame.
     options: { mask?: boolean } = {},
   ) {
     const bid = botId.trim()

--- a/apps/web/src/store/chat/transcript.ts
+++ b/apps/web/src/store/chat/transcript.ts
@@ -38,9 +38,13 @@ export interface TranscriptDeps {
   // this turn? Settled reconciliation uses it to tell an in-flight boundary
   // turn (retain) from a vanished one (drop).
   isTurnLive?: (sessionId: string, turnId: string) => boolean
+  // The view registry's stale-mark version: captured when a history fetch
+  // starts and handed back through the refresh hook, so a stale mark that
+  // landed mid-refresh is not mistaken for covered by the fetched history.
+  historyRefreshToken?: () => number
 }
 
-type RefreshAppliedHook = (targetSessionId: string, latestTimestamp?: string) => void
+type RefreshAppliedHook = (targetSessionId: string, latestTimestamp?: string, refreshToken?: number) => void
 type CommitInitialHistory = (applyHistory: () => void) => Promise<void>
 type AfterHistoryCommit = () => void
 
@@ -62,6 +66,7 @@ export function createTranscriptController({
   fetchMessages,
   locateMessage,
   isTurnLive: isTurnLiveDep,
+  historyRefreshToken,
 }: TranscriptDeps) {
   const messages = reactive<ChatMessage[]>([])
   const loadingMessages = ref(false)
@@ -158,7 +163,9 @@ export function createTranscriptController({
     loadingOlder.value = false
   }
 
-  function applyFetchedHistory(botId: string, targetSessionId: string, generation: number, turns: UITurn[]) {
+  function applyFetchedHistory(
+    botId: string, targetSessionId: string, generation: number, turns: UITurn[], refreshToken?: number,
+  ) {
     if (!isCurrentHistoryContext(botId, targetSessionId, generation)) return
     if (hasLoadedOlder.value) {
       mergeMessages(turns, targetSessionId)
@@ -168,7 +175,7 @@ export function createTranscriptController({
       // page is not proof that history ended. Only pagination can settle it.
       hasMoreOlder.value = true
     }
-    onRefreshApplied(targetSessionId, messages[messages.length - 1]?.timestamp)
+    onRefreshApplied(targetSessionId, messages[messages.length - 1]?.timestamp, refreshToken)
   }
 
   async function refreshCurrentSession(
@@ -193,10 +200,11 @@ export function createTranscriptController({
 
     const afterHistoryCallbacks = new Set<AfterHistoryCommit>()
     if (afterHistory) afterHistoryCallbacks.add(afterHistory)
+    const refreshToken = historyRefreshToken?.()
     const promise = (async () => {
       const turns = await fetchMessages(bid, sid, { limit: PAGE_SIZE })
       if (!isCurrentHistoryContext(bid, sid, generation)) return
-      applyFetchedHistory(bid, sid, generation, turns)
+      applyFetchedHistory(bid, sid, generation, turns, refreshToken)
       // Keep a replacement Runtime projection in the same synchronous commit
       // as the refreshed anchor so Vue cannot paint the database-only state.
       for (const apply of afterHistoryCallbacks) apply()
@@ -227,11 +235,14 @@ export function createTranscriptController({
     // concurrent masked load's flag.
     const version = mask ? ++loadingMessagesVersion : loadingMessagesVersion
     const generation = historyGeneration
+    // Captured before the fetch: marks already present are covered by this
+    // read; only later marks must survive the refresh-applied hook.
+    const refreshToken = historyRefreshToken?.()
     try {
       const turns = await fetchMessages(bid, sid, { limit: PAGE_SIZE })
       if (!isCurrentHistoryContext(bid, sid, generation)) return
       await commitInitialHistory(() => {
-        applyFetchedHistory(bid, sid, generation, turns)
+        applyFetchedHistory(bid, sid, generation, turns, refreshToken)
       })
     } finally {
       if (mask && version === loadingMessagesVersion) loadingMessages.value = false

--- a/apps/web/src/store/chat/view-registry.test.ts
+++ b/apps/web/src/store/chat/view-registry.test.ts
@@ -275,13 +275,16 @@ describe('stale-while-hidden marks', () => {
     expect(view.staleWhileHidden).toBe(false)
   })
 
-  it('does not mark a view that is still visible', () => {
+  it('marks a visible view too: coverage can end before it hides (bot switch)', () => {
     const { registry } = makeRegistry()
     const view = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' })
     registry.bindPanel('chat:1', { botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' }, true)
 
-    registry.markSessionStale('bot-1', 'session-1')
-    expect(view.staleWhileHidden).toBe(false)
+    // The mark is inert while the view stays visible, but it must follow the
+    // view into hiding — otherwise a bot switch would let a stale cache
+    // through the optimistic path on revisit.
+    registry.markAllSessionsStale('bot-1')
+    expect(view.staleWhileHidden).toBe(true)
   })
 
   it('marks every hidden view of the interrupted bot and leaves other bots alone', () => {

--- a/apps/web/src/store/chat/view-registry.test.ts
+++ b/apps/web/src/store/chat/view-registry.test.ts
@@ -262,3 +262,46 @@ describe('chat view registry', () => {
     expect(onEvict).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'oldest' }))
   })
 })
+
+describe('stale-while-hidden marks', () => {
+  it('marks a hidden session view stale and clears it after a refresh', async () => {
+    const { registry } = makeRegistry()
+    const view = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' })
+
+    registry.markSessionStale('bot-1', 'session-1')
+    expect(view.staleWhileHidden).toBe(true)
+
+    await view.transcript.loadInitialMessages('bot-1', 'session-1', async applyHistory => applyHistory())
+    expect(view.staleWhileHidden).toBe(false)
+  })
+
+  it('does not mark a view that is still visible', () => {
+    const { registry } = makeRegistry()
+    const view = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' })
+    registry.bindPanel('chat:1', { botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' }, true)
+
+    registry.markSessionStale('bot-1', 'session-1')
+    expect(view.staleWhileHidden).toBe(false)
+  })
+
+  it('marks every hidden view of the interrupted bot and leaves other bots alone', () => {
+    const { registry } = makeRegistry()
+    const own = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' })
+    const other = registry.getOrCreate({ botId: 'bot-2', sessionId: 'session-2', viewId: 'chat:2' })
+
+    registry.markAllSessionsStale('bot-1')
+
+    expect(own.staleWhileHidden).toBe(true)
+    expect(other.staleWhileHidden).toBe(false)
+  })
+
+  it('marks a view that was hidden after being visible', () => {
+    const { registry } = makeRegistry()
+    const view = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' })
+    registry.bindPanel('chat:1', { botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' }, true)
+    registry.setPanelVisible('chat:1', false)
+
+    registry.markSessionStale('bot-1', 'session-1')
+    expect(view.staleWhileHidden).toBe(true)
+  })
+})

--- a/apps/web/src/store/chat/view-registry.test.ts
+++ b/apps/web/src/store/chat/view-registry.test.ts
@@ -73,12 +73,13 @@ function pendingUserInputTurn(id: string): ChatAssistantTurn {
 
 function makeRegistry(options: { cacheLimit?: number, streaming?: Set<string> } = {}) {
   const onEvict = vi.fn()
+  const fetchMessages = vi.fn().mockResolvedValue([])
   const registry = createChatViewRegistry({
     cacheLimit: options.cacheLimit,
     rememberBackgroundTask: task => task,
     applyPendingBackgroundEventsToTool: () => {},
     bumpFsChangedAtIfFsMutation: () => {},
-    fetchMessages: vi.fn().mockResolvedValue([]),
+    fetchMessages,
       locateMessage: vi.fn().mockResolvedValue({
         items: [],
         target_id: '',
@@ -87,7 +88,7 @@ function makeRegistry(options: { cacheLimit?: number, streaming?: Set<string> } 
     isSessionStreaming: (botId, sessionId) => options.streaming?.has(`${botId}:${sessionId}`) === true,
     onEvict,
   })
-  return { registry, onEvict }
+  return { registry, onEvict, fetchMessages }
 }
 
 describe('chat view registry', () => {
@@ -306,5 +307,29 @@ describe('stale-while-hidden marks', () => {
 
     registry.markSessionStale('bot-1', 'session-1')
     expect(view.staleWhileHidden).toBe(true)
+  })
+
+  it('keeps a stale mark that landed while the refresh was still in flight', async () => {
+    const { registry, fetchMessages } = makeRegistry()
+    const view = registry.getOrCreate({ botId: 'bot-1', sessionId: 'session-1', viewId: 'chat:1' })
+    let release!: (turns: []) => void
+    fetchMessages.mockImplementationOnce(() => new Promise<[]>((resolve) => { release = resolve }))
+
+    // A revisit starts revalidating; before the fetched history commits, a
+    // touch marks the view stale. That mark postdates the fetch's snapshot —
+    // the history being committed may not include the write — so the refresh
+    // must not clear it.
+    const loading = view.transcript.loadInitialMessages('bot-1', 'session-1', async applyHistory => applyHistory())
+    await Promise.resolve()
+    registry.markSessionStale('bot-1', 'session-1')
+    release([])
+    await loading
+
+    expect(view.staleWhileHidden).toBe(true)
+
+    // A refresh started after the mark covers it and clears the flag.
+    fetchMessages.mockResolvedValueOnce([])
+    await view.transcript.loadInitialMessages('bot-1', 'session-1', async applyHistory => applyHistory())
+    expect(view.staleWhileHidden).toBe(false)
   })
 })

--- a/apps/web/src/store/chat/view-registry.ts
+++ b/apps/web/src/store/chat/view-registry.ts
@@ -39,6 +39,12 @@ export interface ChatViewEntry {
   pairEffort: Ref<string>
   pairSource: Ref<ChatWorkspaceTargetSelectionSource>
   lastAccess: number
+  // Set when the session may have changed while this view was hidden (a
+  // session_touched activity event, or a coverage gap in the activity stream).
+  // Revisit revalidation masks the cached transcript while this is set; a
+  // successful refresh clears it. Events cannot arrive for a view that does
+  // not exist yet, so entries start unmarked.
+  staleWhileHidden: boolean
 }
 
 interface ChatViewRegistryDeps extends Omit<TranscriptDeps, 'currentBotId' | 'sessionId'> {
@@ -143,9 +149,11 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
       pairEffort: ref(''),
       pairSource: ref('unset'),
       lastAccess: 0,
+      staleWhileHidden: false,
     }
     transcript.setRefreshAppliedHook((targetSessionId, latestTimestamp) => {
       view.initialized = true
+      view.staleWhileHidden = false
       deps.onRefreshApplied?.(view, targetSessionId, latestTimestamp)
     })
     views.set(view.key, view)
@@ -279,6 +287,25 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
     return deactivated
   }
 
+  // Staleness only needs flagging while the view is hidden: a visible view
+  // receives its updates live, and a refresh clears the flag on commit.
+  function markSessionStale(botId: string, sessionId: string) {
+    const view = views.get(chatSessionViewKey(botId, sessionId))
+    if (view && view.visiblePanelIds.size === 0) view.staleWhileHidden = true
+  }
+
+  // The activity stream is the only staleness signal; any gap in it (buffer
+  // drop, reconnect, bot switch) makes every hidden view of that bot
+  // unknowable, so they all become conservative.
+  function markAllSessionsStale(botId: string) {
+    const prefix = `session:${normalize(botId)}:`
+    for (const view of views.values()) {
+      if (view.key.startsWith(prefix) && view.visiblePanelIds.size === 0) {
+        view.staleWhileHidden = true
+      }
+    }
+  }
+
   function promoteDraft(botId: string, viewId: string, sessionId: string): ChatViewEntry {
     const bid = normalize(botId)
     const vid = normalize(viewId)
@@ -383,6 +410,8 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
     unbindPanel,
     promoteDraft,
     removeSession,
+    markSessionStale,
+    markAllSessionsStale,
     prune,
     resetBot,
     resetAll,

--- a/apps/web/src/store/chat/view-registry.ts
+++ b/apps/web/src/store/chat/view-registry.ts
@@ -45,6 +45,11 @@ export interface ChatViewEntry {
   // successful refresh clears it. Events cannot arrive for a view that does
   // not exist yet, so entries start unmarked.
   staleWhileHidden: boolean
+  // Bumped on every stale mark. A refresh clears the flag only when no mark
+  // arrived after that refresh began: its fetched history may predate a
+  // mid-refresh touch (the commit can wait on the runtime snapshot while
+  // another client writes) and cannot vouch for it.
+  staleMarkVersion: number
 }
 
 interface ChatViewRegistryDeps extends Omit<TranscriptDeps, 'currentBotId' | 'sessionId'> {
@@ -130,6 +135,7 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
       fetchMessages: deps.fetchMessages,
       locateMessage: deps.locateMessage,
       isTurnLive: deps.isTurnLive,
+      historyRefreshToken: () => view.staleMarkVersion,
     })
     const view: ChatViewEntry = {
       key: chatViewKey({ botId, sessionId, viewId }),
@@ -150,10 +156,15 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
       pairSource: ref('unset'),
       lastAccess: 0,
       staleWhileHidden: false,
+      staleMarkVersion: 0,
     }
-    transcript.setRefreshAppliedHook((targetSessionId, latestTimestamp) => {
+    transcript.setRefreshAppliedHook((targetSessionId, latestTimestamp, refreshToken) => {
       view.initialized = true
-      view.staleWhileHidden = false
+      // A mark that landed mid-refresh is not covered by the history this
+      // refresh fetched — keep the flag so the next revisit still masks.
+      if (refreshToken === undefined || refreshToken === view.staleMarkVersion) {
+        view.staleWhileHidden = false
+      }
       deps.onRefreshApplied?.(view, targetSessionId, latestTimestamp)
     })
     views.set(view.key, view)
@@ -293,7 +304,10 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
   // which it hides and would otherwise revisit with an untrusted cache.
   function markSessionStale(botId: string, sessionId: string) {
     const view = views.get(chatSessionViewKey(botId, sessionId))
-    if (view) view.staleWhileHidden = true
+    if (view) {
+      view.staleWhileHidden = true
+      view.staleMarkVersion += 1
+    }
   }
 
   // The activity stream is the only staleness signal; any gap in it (buffer
@@ -302,7 +316,10 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
   function markAllSessionsStale(botId: string) {
     const prefix = `session:${normalize(botId)}:`
     for (const view of views.values()) {
-      if (view.key.startsWith(prefix)) view.staleWhileHidden = true
+      if (view.key.startsWith(prefix)) {
+        view.staleWhileHidden = true
+        view.staleMarkVersion += 1
+      }
     }
   }
 

--- a/apps/web/src/store/chat/view-registry.ts
+++ b/apps/web/src/store/chat/view-registry.ts
@@ -110,6 +110,7 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
   const cacheLimit = Math.max(0, deps.cacheLimit ?? CHAT_SESSION_VIEW_CACHE_LIMIT)
   const views = new Map<string, ChatViewEntry>()
   const panelKeys = new Map<string, string>()
+  const coveredBots = new Set<string>()
   let accessClock = 0
 
   function touch(view: ChatViewEntry) {
@@ -323,6 +324,21 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
     }
   }
 
+  function isActivityStreamCovered(botId: string): boolean {
+    return coveredBots.has(normalize(botId))
+  }
+
+  function setActivityStreamCoverage(botId: string, covered: boolean) {
+    const bid = normalize(botId)
+    if (!bid || covered === coveredBots.has(bid)) return
+    if (covered) coveredBots.add(bid)
+    else coveredBots.delete(bid)
+    // Mark both edges. History refreshed during an outage may already be
+    // outdated when coverage returns; the ready frame does not replay the
+    // changes that were missed before this subscription was established.
+    markAllSessionsStale(bid)
+  }
+
   function promoteDraft(botId: string, viewId: string, sessionId: string): ChatViewEntry {
     const bid = normalize(botId)
     const vid = normalize(viewId)
@@ -402,6 +418,7 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
 
   function resetBot(botId: string) {
     const bid = normalize(botId)
+    coveredBots.delete(bid)
     for (const view of [...views.values()]) {
       if (view.botId === bid) evict(view)
     }
@@ -410,6 +427,7 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
   function resetAll() {
     for (const view of [...views.values()]) evict(view)
     panelKeys.clear()
+    coveredBots.clear()
   }
 
   function entries(): ChatViewEntry[] {
@@ -429,6 +447,8 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
     removeSession,
     markSessionStale,
     markAllSessionsStale,
+    isActivityStreamCovered,
+    setActivityStreamCoverage,
     prune,
     resetBot,
     resetAll,

--- a/apps/web/src/store/chat/view-registry.ts
+++ b/apps/web/src/store/chat/view-registry.ts
@@ -287,22 +287,22 @@ export function createChatViewRegistry(deps: ChatViewRegistryDeps) {
     return deactivated
   }
 
-  // Staleness only needs flagging while the view is hidden: a visible view
-  // receives its updates live, and a refresh clears the flag on commit.
+  // The flag is only consulted at activation, so marking a visible view is
+  // inert — but it must still be marked: coverage can end while it is
+  // visible (e.g. the bot's activity stream stops on a bot switch), after
+  // which it hides and would otherwise revisit with an untrusted cache.
   function markSessionStale(botId: string, sessionId: string) {
     const view = views.get(chatSessionViewKey(botId, sessionId))
-    if (view && view.visiblePanelIds.size === 0) view.staleWhileHidden = true
+    if (view) view.staleWhileHidden = true
   }
 
   // The activity stream is the only staleness signal; any gap in it (buffer
-  // drop, reconnect, bot switch) makes every hidden view of that bot
-  // unknowable, so they all become conservative.
+  // drop, reconnect, bot switch) makes every view of that bot unknowable,
+  // so they all become conservative.
   function markAllSessionsStale(botId: string) {
     const prefix = `session:${normalize(botId)}:`
     for (const view of views.values()) {
-      if (view.key.startsWith(prefix) && view.visiblePanelIds.size === 0) {
-        view.staleWhileHidden = true
-      }
+      if (view.key.startsWith(prefix)) view.staleWhileHidden = true
     }
   }
 

--- a/apps/web/src/store/chat/views.ts
+++ b/apps/web/src/store/chat/views.ts
@@ -166,7 +166,11 @@ export function createChatViews(deps: ChatViewsDeps) {
       sessionId,
       viewId: focusedViewId.value,
     })
-    await view.transcript.loadInitialMessages(botId, sessionId, commitInitialHistory)
+    // Revisit of a view whose cache is present and untouched-while-hidden:
+    // show the cache and revalidate in the open. An empty or stale cache
+    // keeps the #933 behavior — mask until fresh history commits atomically.
+    const mask = view.transcript.messages.length === 0 || view.staleWhileHidden
+    await view.transcript.loadInitialMessages(botId, sessionId, commitInitialHistory, { mask })
     view.initialized = true
   }
   const fetchSessionWindow = (botId: string, sessionId: string) =>

--- a/apps/web/src/store/chat/views.ts
+++ b/apps/web/src/store/chat/views.ts
@@ -166,10 +166,12 @@ export function createChatViews(deps: ChatViewsDeps) {
       sessionId,
       viewId: focusedViewId.value,
     })
-    // Revisit of a view whose cache is present and untouched-while-hidden:
-    // show the cache and revalidate in the open. An empty or stale cache
-    // keeps the #933 behavior — mask until fresh history commits atomically.
-    const mask = view.transcript.messages.length === 0 || view.staleWhileHidden
+    // A populated, untouched cache can render immediately only while the bot's
+    // activity stream covers changes. Otherwise keep the #933 behavior: mask
+    // until fresh history and the initial runtime snapshot commit together.
+    const mask = view.transcript.messages.length === 0
+      || view.staleWhileHidden
+      || !chatViews.isActivityStreamCovered(botId)
     await view.transcript.loadInitialMessages(botId, sessionId, commitInitialHistory, { mask })
     view.initialized = true
   }

--- a/cmd/agent/http_providers.go
+++ b/cmd/agent/http_providers.go
@@ -77,7 +77,7 @@ func provideSessionQueueHandler(queries dbstore.Queries, agentService *applicati
 	return handlers.NewSessionQueueHandler(queries, agentService, botService, accountService)
 }
 
-func provideMessageHandler(log *slog.Logger, msgService *message.DBService, sessionService *sessionpkg.Service, mediaService *media.Service, botService *bots.Service, accountService *accounts.Service, hub *event.Hub, toolApproval *toolapproval.Service, userInput *userinput.Service, bgManager *background.Manager, acpPool *acpagent.SessionPool, pipeline *timeline.Pipeline, compactionService *compaction.Service) *handlers.MessageHandler {
+func provideMessageHandler(log *slog.Logger, msgService *message.DBService, sessionService *sessionpkg.Service, mediaService *media.Service, botService *bots.Service, accountService *accounts.Service, hub *event.Hub, toolApproval *toolapproval.Service, userInput *userinput.Service, bgManager *background.Manager, acpPool *acpagent.SessionPool, pipeline *timeline.Pipeline, compactionService *compaction.Service, cfg config.Config) *handlers.MessageHandler {
 	h := handlers.NewMessageHandler(log, msgService, sessionService, botService, accountService, hub)
 	h.SetMediaService(mediaService)
 	h.SetToolApprovalService(toolApproval)
@@ -86,6 +86,9 @@ func provideMessageHandler(log *slog.Logger, msgService *message.DBService, sess
 	h.SetRuntimeResetService(acpPool)
 	h.SetProjectionCache(pipeline)
 	h.SetCompactionActivity(compactionService)
+	// This hub is process-local. A cluster cannot promise it observes runtime
+	// admissions and persisted writes performed by another instance.
+	h.SetSessionActivityInvalidationSupported(!cfg.SessionRuntime.Cluster)
 	return h
 }
 

--- a/cmd/internal/core/session_runtime.go
+++ b/cmd/internal/core/session_runtime.go
@@ -9,6 +9,7 @@ import (
 
 	sessionruntime "github.com/felinics/memoh/internal/agent/runtime/session"
 	"github.com/felinics/memoh/internal/agent/runtime/session/ledger"
+	"github.com/felinics/memoh/internal/chat/event"
 	"github.com/felinics/memoh/internal/config"
 	postgresstore "github.com/felinics/memoh/internal/db/postgres/store"
 	dbstore "github.com/felinics/memoh/internal/db/store"
@@ -40,11 +41,14 @@ func provideRuntimeFenceActivator(queries dbstore.Queries) sessionruntime.FenceA
 // elects the reaper leader, and begins the fail-closed generation sweep — for a
 // single OSS instance that sweep is what turns the previous process's runs into
 // `lost` instead of leaving them active forever.
-func provideSessionRuntimeManager(lc fx.Lifecycle, log *slog.Logger, cfg config.Config, runs ledger.Store, fence sessionruntime.FenceActivator) (*sessionruntime.Manager, error) {
+func provideSessionRuntimeManager(lc fx.Lifecycle, log *slog.Logger, cfg config.Config, runs ledger.Store, fence sessionruntime.FenceActivator, hub *event.Hub) (*sessionruntime.Manager, error) {
 	manager, err := sessionruntime.NewManagerFromConfig(log, cfg.SessionRuntime, runs, fence)
 	if err != nil {
 		return nil, err
 	}
+	manager.SetAdmissionObserver(func(botID, sessionID string) {
+		event.InvalidateSession(hub, botID, sessionID)
+	})
 	lc.Append(fx.Hook{
 		OnStart: manager.Start,
 		OnStop: func(ctx context.Context) error {

--- a/internal/agent/runtime/session/activity.go
+++ b/internal/agent/runtime/session/activity.go
@@ -1,0 +1,19 @@
+package sessionruntime
+
+// SetAdmissionObserver installs the lightweight activity invalidation sink.
+// The composition root owns its transport; Runtime does not depend on the
+// bot activity hub or carry conversation contents through that channel.
+func (m *Manager) SetAdmissionObserver(observer func(botID, sessionID string)) {
+	m.mu.Lock()
+	m.admissionObserver = observer
+	m.mu.Unlock()
+}
+
+func (m *Manager) observeAdmission(botID, sessionID string) {
+	m.mu.Lock()
+	observer := m.admissionObserver
+	m.mu.Unlock()
+	if observer != nil {
+		observer(botID, sessionID)
+	}
+}

--- a/internal/agent/runtime/session/activity_test.go
+++ b/internal/agent/runtime/session/activity_test.go
@@ -1,0 +1,60 @@
+package sessionruntime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	chatview "github.com/felinics/memoh/internal/agent/view"
+)
+
+func TestAdmissionInvalidatesTranscriptBeforeReturning(t *testing.T) {
+	for _, kind := range []string{RunOperationEdit, RunOperationRetry} {
+		t.Run(kind, func(t *testing.T) {
+			f := newAdmitFixture(t)
+			called := false
+			var notifiedBot, notifiedSession string
+			f.manager.SetAdmissionObserver(func(botID, sessionID string) {
+				called = true
+				notifiedBot, notifiedSession = botID, sessionID
+				snapshot, err := f.manager.Snapshot(context.Background(), botID, sessionID)
+				if err != nil || snapshot.CurrentRunView == nil || snapshot.CurrentRunView.Operation == nil {
+					t.Errorf("admission observer ran without a readable replacement snapshot: %v", err)
+				}
+			})
+			input := f.input("inv-replace", kind)
+			input.Execution.Admission = func(context.Context, RunHandle) (RunAdmissionView, error) {
+				return RunAdmissionView{Operation: &RunOperationView{
+					Kind: kind, ReplaceFromMessageID: "old-message",
+					ReplacementUserTurn: &chatview.UITurn{Role: "user", Text: "edited"},
+				}}, nil
+			}
+			if _, err := f.manager.Admit(context.Background(), input); err != nil {
+				t.Fatal(err)
+			}
+			// No model output or message persistence has occurred. Observers
+			// must already have been told when admission returns; the
+			// composition root turns this callback into a hub publication.
+			if !called || notifiedBot != testBotID || notifiedSession != testSessionID {
+				t.Fatalf("accepted replacement did not notify observer: called=%v bot=%q session=%q",
+					called, notifiedBot, notifiedSession)
+			}
+		})
+	}
+}
+
+func TestFailedAdmissionDoesNotNotifyTranscriptObserver(t *testing.T) {
+	f := newAdmitFixture(t)
+	called := false
+	f.manager.SetAdmissionObserver(func(string, string) { called = true })
+	input := f.input("inv-invalid", "edit")
+	input.Execution.Admission = func(context.Context, RunHandle) (RunAdmissionView, error) {
+		return RunAdmissionView{}, errors.New("invalid replacement")
+	}
+	if _, err := f.manager.Admit(context.Background(), input); err == nil {
+		t.Fatal("expected admission rejection")
+	}
+	if called {
+		t.Fatal("rejected admission notified transcript observer")
+	}
+}

--- a/internal/agent/runtime/session/manager.go
+++ b/internal/agent/runtime/session/manager.go
@@ -55,6 +55,7 @@ type Manager struct {
 	commandHandler         func(context.Context, Command) error
 	decisionStore          DecisionStore
 	terminalObserver       func(context.Context, TerminalRun)
+	admissionObserver      func(botID, sessionID string)
 	decisionFinalizer      func(context.Context, RunHandle) error
 	terminalReconciler     func(context.Context) error
 	cancelLostRunDecisions func(context.Context, string, string, string, int64, string) error
@@ -1242,6 +1243,10 @@ func (m *Manager) startRun(ctx context.Context, start runStart) (RunHandle, Curs
 	if !ctrl.completeAdmissionForAbort() {
 		return RunHandle{}, Cursor{}, context.Canceled
 	}
+	// Runtime edits/retries replace visible content before their messages are
+	// persisted. Notify cached-view observers before the admitted run returns
+	// to its caller and starts generating output.
+	m.observeAdmission(botID, sessionID)
 	ctrl.markReady()
 	return handle, activated.cursor(), nil
 }

--- a/internal/agent/runtime/session/manager.go
+++ b/internal/agent/runtime/session/manager.go
@@ -1243,9 +1243,10 @@ func (m *Manager) startRun(ctx context.Context, start runStart) (RunHandle, Curs
 	if !ctrl.completeAdmissionForAbort() {
 		return RunHandle{}, Cursor{}, context.Canceled
 	}
-	// Runtime edits/retries replace visible content before their messages are
-	// persisted. Notify cached-view observers before the admitted run returns
-	// to its caller and starts generating output.
+	// Every admitted run — not only edits/retries — changes the visible
+	// projection before its messages are persisted (a plain user turn already
+	// commits visible content at admission). Notify cached-view observers
+	// before the admitted run returns to its caller and starts generating.
 	m.observeAdmission(botID, sessionID)
 	ctrl.markReady()
 	return handle, activated.cursor(), nil

--- a/internal/chat/event/hub.go
+++ b/internal/chat/event/hub.go
@@ -32,7 +32,24 @@ const (
 	EventTypeBackgroundTask EventType = "background_task"
 	// EventTypeCompactionChanged invalidates the bot's live compaction snapshot.
 	EventTypeCompactionChanged EventType = "compaction_changed"
+	// EventTypeSessionInvalidated marks cached transcripts stale when runtime
+	// admission changes them, or after history is cleared without a new message.
+	EventTypeSessionInvalidated EventType = "session_invalidated"
 )
+
+// SessionInvalidation contains only an address. An empty SessionID invalidates
+// all cached sessions of the bot, without exposing any private session ids.
+type SessionInvalidation struct {
+	SessionID string `json:"session_id"`
+}
+
+func InvalidateSession(publisher Publisher, botID, sessionID string) {
+	if publisher == nil {
+		return
+	}
+	payload, _ := json.Marshal(SessionInvalidation{SessionID: strings.TrimSpace(sessionID)})
+	publisher.Publish(Event{Type: EventTypeSessionInvalidated, BotID: strings.TrimSpace(botID), Data: payload})
+}
 
 // Event is the normalized payload emitted by the in-process message event hub.
 type Event struct {

--- a/internal/handlers/message.go
+++ b/internal/handlers/message.go
@@ -31,19 +31,21 @@ import (
 
 // MessageHandler handles bot-scoped messaging endpoints.
 type MessageHandler struct {
-	messageService     messagepkg.Service
-	sessionService     *session.Service
-	runtimeResets      messageRuntimeResetService
-	messageEvents      messageevent.Subscriber
-	mediaService       *media.Service
-	botService         *bots.Service
-	accountService     *accounts.Service
-	toolApproval       *toolapproval.Service
-	userInput          *userinput.Service
-	bgManager          *background.Manager
-	projectionCache    messageProjectionCache
-	compactionActivity interface{ ActiveSessions(string) []string }
-	logger             *slog.Logger
+	messageService                messagepkg.Service
+	sessionService                *session.Service
+	runtimeResets                 messageRuntimeResetService
+	messageEvents                 messageevent.Subscriber
+	messagePublisher              messageevent.Publisher
+	activityInvalidationSupported bool
+	mediaService                  *media.Service
+	botService                    *bots.Service
+	accountService                *accounts.Service
+	toolApproval                  *toolapproval.Service
+	userInput                     *userinput.Service
+	bgManager                     *background.Manager
+	projectionCache               messageProjectionCache
+	compactionActivity            interface{ ActiveSessions(string) []string }
+	logger                        *slog.Logger
 }
 
 type messageProjectionCache interface {
@@ -78,13 +80,15 @@ func NewMessageHandler(log *slog.Logger, messageService messagepkg.Service, sess
 	if len(eventSubscribers) > 0 {
 		messageEvents = eventSubscribers[0]
 	}
+	messagePublisher, _ := messageEvents.(messageevent.Publisher)
 	return &MessageHandler{
-		messageService: messageService,
-		sessionService: sessionService,
-		messageEvents:  messageEvents,
-		botService:     botService,
-		accountService: accountService,
-		logger:         log.With(slog.String("handler", "conversation")),
+		messageService:   messageService,
+		sessionService:   sessionService,
+		messageEvents:    messageEvents,
+		messagePublisher: messagePublisher,
+		botService:       botService,
+		accountService:   accountService,
+		logger:           log.With(slog.String("handler", "conversation")),
 	}
 }
 
@@ -99,6 +103,10 @@ func (h *MessageHandler) SetProjectionCache(cache messageProjectionCache) {
 
 func (h *MessageHandler) SetCompactionActivity(activity interface{ ActiveSessions(string) []string }) {
 	h.compactionActivity = activity
+}
+
+func (h *MessageHandler) SetSessionActivityInvalidationSupported(supported bool) {
+	h.activityInvalidationSupported = supported
 }
 
 func (h *MessageHandler) SetToolApprovalService(svc *toolapproval.Service) {
@@ -737,6 +745,7 @@ func (h *MessageHandler) DeleteMessages(c echo.Context) error {
 			h.projectionCache.DropAll()
 		}
 	}
+	messageevent.InvalidateSession(h.messagePublisher, botID, sessionID)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/handlers/message_activity_test.go
+++ b/internal/handlers/message_activity_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/felinics/memoh/internal/bots"
+	messageevent "github.com/felinics/memoh/internal/chat/event"
+	messagepkg "github.com/felinics/memoh/internal/chat/message"
+	session "github.com/felinics/memoh/internal/chat/thread"
+	"github.com/felinics/memoh/internal/db/postgres/sqlc"
+)
+
+const (
+	activityTestBotID     = "11111111-1111-1111-1111-111111111111"
+	activityTestSessionID = "22222222-2222-2222-2222-222222222222"
+)
+
+func activityTestHandler() (*MessageHandler, *messageevent.Hub) {
+	hub := messageevent.NewHub()
+	queries := &sessionDeleteQueries{
+		bot: testBotRow(activityTestBotID, nil),
+		session: sqlc.BotSession{
+			ID: testUUID(activityTestSessionID), BotID: testUUID(activityTestBotID), Type: session.TypeChat,
+		},
+	}
+	return NewMessageHandler(slog.Default(), nil, session.NewService(nil, queries, hub),
+		bots.NewService(nil, queries), newTestAdminAccountService("admin"), hub), hub
+}
+
+// Queue an admission racing connection setup, after Subscribe but before the
+// handler sends its ready frame. It must still reach the client afterward.
+type admissionOnSubscribe struct{ hub *messageevent.Hub }
+
+func (s admissionOnSubscribe) Subscribe(botID string, buffer int) (*messageevent.Subscription, func()) {
+	sub, cancel := s.hub.Subscribe(botID, buffer)
+	messageevent.InvalidateSession(s.hub, botID, activityTestSessionID)
+	return sub, cancel
+}
+
+type activityResponseRecorder struct {
+	*httptest.ResponseRecorder
+	flushes int
+	cancel  context.CancelFunc
+}
+
+func (r *activityResponseRecorder) Flush() {
+	r.ResponseRecorder.Flush()
+	r.flushes++
+	if r.flushes == 2 {
+		r.cancel()
+	}
+}
+
+func TestSessionActivitySendsReadyThenQueuedInvalidation(t *testing.T) {
+	for _, supported := range []bool{false, true} {
+		h, hub := activityTestHandler()
+		h.SetSessionActivityInvalidationSupported(supported)
+		h.messageEvents = admissionOnSubscribe{hub}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		rec := &activityResponseRecorder{ResponseRecorder: httptest.NewRecorder(), cancel: cancel}
+		req := httptest.NewRequest(http.MethodGet, "/bots/"+activityTestBotID+"/sessions/events", nil).WithContext(ctx)
+		c := testAuthContext(echo.New(), req, rec, "user-1")
+		c.SetParamNames("bot_id")
+		c.SetParamValues(activityTestBotID)
+		if err := h.StreamSessionsActivityEvents(c); err != nil {
+			t.Fatal(err)
+		}
+		frames := strings.Split(strings.TrimSpace(rec.Body.String()), "\n\n")
+		if len(frames) != 2 {
+			t.Fatalf("expected ready and invalidation, got %q", rec.Body.String())
+		}
+		for i, frame := range frames {
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(frame, "data: ")), &payload); err != nil {
+				t.Fatal(err)
+			}
+			if i == 0 {
+				if payload["type"] != "activity_ready" || payload["cache_invalidation"] != supported || payload["session_id"] != "" {
+					t.Fatalf("unexpected ready frame: %+v", payload)
+				}
+			} else if payload["type"] != "session_invalidated" || payload["session_id"] != activityTestSessionID {
+				t.Fatalf("queued admission invalidation missing: %+v", payload)
+			}
+		}
+	}
+}
+
+type activityHistoryStore struct {
+	messagepkg.Service
+	deleteErr error
+}
+
+func (s activityHistoryStore) DeleteBySession(context.Context, string) error { return s.deleteErr }
+func (s activityHistoryStore) DeleteByBot(context.Context, string) error     { return s.deleteErr }
+
+type activityHistoryReset struct{ recordingACPSessionCloser }
+
+func (r *activityHistoryReset) BeginBotHistoryReset(ctx context.Context, botID string) (context.Context, func(), error) {
+	return r.BeginSessionHistoryReset(ctx, botID, "")
+}
+
+func TestDeleteMessagesInvalidatesOnlyCommittedHistory(t *testing.T) {
+	for _, sessionID := range []string{activityTestSessionID, ""} {
+		for _, failure := range []bool{false, true} {
+			h, hub := activityTestHandler()
+			sub, cancel := hub.Subscribe(activityTestBotID, 4)
+			defer cancel()
+			store := activityHistoryStore{}
+			if failure {
+				store.deleteErr = errors.New("delete failed")
+			}
+			h.messageService = store
+			h.SetRuntimeResetService(&activityHistoryReset{})
+			req := httptest.NewRequest(http.MethodDelete, "/bots/"+activityTestBotID+"/messages?session_id="+sessionID, nil)
+			rec := httptest.NewRecorder()
+			c := testAuthContext(echo.New(), req, rec, "user-1")
+			c.SetParamNames("bot_id")
+			c.SetParamValues(activityTestBotID)
+			err := h.DeleteMessages(c)
+			if (err != nil) != failure {
+				t.Fatalf("unexpected delete outcome: %v", err)
+			}
+			if !failure && rec.Code != http.StatusNoContent {
+				t.Fatalf("delete status = %d", rec.Code)
+			}
+			select {
+			case ev := <-sub.Events:
+				var payload messageevent.SessionInvalidation
+				if err := json.Unmarshal(ev.Data, &payload); err != nil {
+					t.Fatal(err)
+				}
+				if failure || ev.Type != messageevent.EventTypeSessionInvalidated || payload.SessionID != sessionID {
+					t.Fatalf("unexpected invalidation after delete: %+v", ev)
+				}
+			default:
+				if !failure {
+					t.Fatal("cleared history emitted no invalidation")
+				}
+			}
+		}
+	}
+}

--- a/internal/handlers/message_stream.go
+++ b/internal/handlers/message_stream.go
@@ -71,8 +71,12 @@ func (h *MessageHandler) StreamSessionsActivityEvents(c echo.Context) error {
 	// propagate within one reconnect window.
 	sub, cancel := h.messageEvents.Subscribe(botID, sessionMessageStreamBuffer)
 	defer cancel()
+	// Declare coverage only when this handler can actually emit every
+	// invalidation source: admission events flow through the runtime observer,
+	// delete-history events flow through messagePublisher. A Subscriber that
+	// lacks Publish must not leave clients trusting deletions they never hear.
 	if err := writeSSEJSON(writer, flusher, map[string]any{
-		"type": "activity_ready", "cache_invalidation": h.activityInvalidationSupported,
+		"type": "activity_ready", "cache_invalidation": h.activityInvalidationSupported && h.messagePublisher != nil,
 		// Older clients treat unknown types as session_created and read this id.
 		"session_id": "",
 	}); err != nil {

--- a/internal/handlers/message_stream.go
+++ b/internal/handlers/message_stream.go
@@ -71,6 +71,13 @@ func (h *MessageHandler) StreamSessionsActivityEvents(c echo.Context) error {
 	// propagate within one reconnect window.
 	sub, cancel := h.messageEvents.Subscribe(botID, sessionMessageStreamBuffer)
 	defer cancel()
+	if err := writeSSEJSON(writer, flusher, map[string]any{
+		"type": "activity_ready", "cache_invalidation": h.activityInvalidationSupported,
+		// Older clients treat unknown types as session_created and read this id.
+		"session_id": "",
+	}); err != nil {
+		return nil
+	}
 
 	cache := newSessionCache(h.logger, h.sessionService)
 	// Subscribe before sampling: changes racing the snapshot remain queued.
@@ -127,6 +134,13 @@ func (h *MessageHandler) StreamSessionsActivityEvents(c echo.Context) error {
 			}
 
 			switch event.Type {
+			case messageevent.EventTypeSessionInvalidated:
+				activity := sessionInvalidationActivity(c.Request().Context(), channelIdentityID, botID, perms, cache, event.Data)
+				if activity != nil {
+					if err := writeSSEJSON(writer, flusher, activity); err != nil {
+						return nil
+					}
+				}
 			case messageevent.EventTypeCompactionChanged:
 				if err := writeCompaction(); err != nil {
 					return nil
@@ -221,6 +235,18 @@ func messageSessionActivity(message messagepkg.Message) map[string]any {
 		activity["reason"] = "background_task"
 	}
 	return activity
+}
+
+func sessionInvalidationActivity(ctx context.Context, userID, botID string, perms []string, cache *sessionCache, data json.RawMessage) map[string]any {
+	var invalidation messageevent.SessionInvalidation
+	if err := json.Unmarshal(data, &invalidation); err != nil {
+		return nil
+	}
+	sessionID := strings.TrimSpace(invalidation.SessionID)
+	if sessionID != "" && !canDeliverSessionActivity(ctx, userID, botID, perms, cache, sessionID) {
+		return nil
+	}
+	return map[string]any{"type": "session_invalidated", "session_id": sessionID}
 }
 
 func (h *MessageHandler) visibleCompactingSessions(ctx context.Context, userID, botID string, perms []string, cache *sessionCache) []string {

--- a/internal/handlers/message_stream_test.go
+++ b/internal/handlers/message_stream_test.go
@@ -35,6 +35,30 @@ func TestCompactionActivityFiltersUnreadableSessions(t *testing.T) {
 	}
 }
 
+func TestSessionInvalidationActivityFiltersUnreadableSessions(t *testing.T) {
+	t.Parallel()
+	cache := newSessionCache(nil, nil)
+	cache.rows["mine"] = session.Thread{ID: "mine", BotID: "bot", Type: session.TypeChat, CreatedByUserID: "me"}
+	cache.rows["private"] = session.Thread{ID: "private", BotID: "bot", Type: session.TypeChat, CreatedByUserID: "other"}
+	cache.rows["internal"] = session.Thread{ID: "internal", BotID: "bot", Type: session.TypeSubagent, CreatedByUserID: "me"}
+	for _, sid := range []string{"mine", "private", "internal", ""} {
+		data, err := json.Marshal(messageevent.SessionInvalidation{SessionID: sid})
+		if err != nil {
+			t.Fatal(err)
+		}
+		activity := sessionInvalidationActivity(context.Background(), "me", "bot", []string{bots.PermissionChat}, cache, data)
+		if sid == "private" || sid == "internal" {
+			if activity != nil {
+				t.Fatalf("invalidation leaked unreadable session %q", sid)
+			}
+			continue
+		}
+		if len(activity) != 2 || activity["type"] != "session_invalidated" || activity["session_id"] != sid {
+			t.Fatalf("unexpected invalidation for %q: %+v", sid, activity)
+		}
+	}
+}
+
 // sessionCreateRecorder is a minimal sqlc-shaped fake that records the row a
 // CreateSession call returns so we can assert what the service publishes.
 type sessionCreateRecorder struct {


### PR DESCRIPTION
## 概要

会话切换重访时,缓存非空且服务端失效覆盖在线 → **直接展示缓存,后台原子重新验证**,替代 #933 的全局遮罩。慢网络下同 bot 来回切换从"白等一个往返"变为秒开。

**缓存可信不由客户端猜测,由服务端宣告**:活动 SSE 连接建立后首帧下发 `activity_ready {cache_invalidation}`,声明本实例能对"渲染可见变更"发全失效信号;客户端只在覆盖在线期间信任隐藏会话的缓存。

## 信号层(服务端)

- `activity_ready`:订阅建立后立刻下发(先于采样),竞连接建立的事件排队后送达,不会漏在 ready 之前。`cache_invalidation` 与发布能力实际可用性绑定——集群模式、无 Publisher 的事件源如实报 `false`。
- `session_invalidated {session_id}`:每次 runtime 准入(普通 send / edit / retry 都会改变可见投影)经 event hub 广播;历史删除同样广播;空 id 失效该 bot 全部缓存。hub 按 bot 作用域 + 会话权限过滤,内部/subagent 会话不可见。
- `dropped`:订阅缓冲溢出时下发,客户端全量置 stale(无法知道丢了哪些事件)。

## 行为层(前端)

- `ChatViewEntry` 增 `staleWhileHidden` + `staleMarkVersion`;重访三分流——缓存为空 → 全量加载(现状);非空但 stale/无覆盖 → 遮罩重新验证(#933 现状);非空且覆盖在线且无标记 → **乐观展示 + 后台原子校验**。
- 覆盖撤销即保守:断流、丢帧、旧服务端(无 ready 帧)、声明不支持的部署,一律回退遮罩行为。**无客户端宽限**——断流期间一律不信任,重连后由新 ready 帧恢复覆盖。
- `staleMarkVersion` 防 refresh 中途到达的失效标记被刷新误清。

## 不变量(#931 约束,保持)

- 被 edit/supersede 的 turn 永远不画出:乐观路径的重新验证仍走 `commitInitialHistory`(等 Runtime 快照就绪后 DB 历史 + 投影**同帧提交**),只是不遮罩。
- `visibleMessages` 遮罩机制本身零改动。

## 兼容与残余缝隙

- 双向兼容:新客户端 + 旧服务端 = 永远遮罩(无 ready 帧);旧客户端 + 新服务端 = 未知事件类型按 `session_id:""` 空转。
- 已知残余缝隙(下限 = 现状):在恰好漏掉信号时该次重访短暂显示旧内容,随后原子重新验证同帧纠正,不会出现 #931 的双帧分裂。
- 弃用方案:时间戳比较(`sessions.updated_at` 被标题/compaction 顶更新)、客户端 3s 宽限(最终版改由服务端宣告,断流即失效)。

## 测试

- 新增:registry 标记生命周期、mid-refresh 标记保留、transcript 免遮罩重验证、session-activity 置位/权限过滤、realtime 中断与覆盖恢复、handler 侧 ready 帧与准入/删除失效。
- 全量 store 套件 567 通过;Go 侧 handlers/session/event 通过;ESLint 通过。
- **行为变化**(按约定报备):缓存重访默认从"遮罩白屏"变为"覆盖在线时直接显示";旧 #933 测试 `does not expose a cached Session transcript while it rehydrates` 按新契约为两条分流测试所替代。

## 人工 QA

已在本地 dev 环境(`memoh-dev` OSS 槽 + 宿主机 Vite)由作者走通 happy path:

- 同 bot 会话来回切换——缓存命中时直接展示,无白屏遮罩 ✅
- 另一客户端发消息后切回——遮罩重新加载 ✅
- 隐藏期间经另一客户端 edit 后切回——遮罩加载,无旧内容闪出 ✅
